### PR TITLE
fix(#13395): compute lifecycle metrics by category

### DIFF
--- a/.github/issue-evidence/13395-orchestrator-lifecycle-category-metrics.md
+++ b/.github/issue-evidence/13395-orchestrator-lifecycle-category-metrics.md
@@ -1,0 +1,100 @@
+# Issue #13395: Orchestrator lifecycle category metrics
+
+## Change
+
+- `ScenarioResult` now carries the explicit scenario `category`.
+- `LifecycleEvaluator.compute_metrics()` derives the surfaced category metrics from `ScenarioResult.category` instead of substring matches against `scenario_id`.
+- Completion summary uses the existing dataset category value `completion_summary`; interruption uses the existing dataset category value `interrupt`.
+- Added regression coverage for IDs that omit their category name and IDs that contain misleading category substrings.
+
+## Verification
+
+```bash
+PYTHONPATH=packages pytest packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py -v
+```
+
+Result: 15 passed.
+
+```bash
+PYTHONPATH=packages pytest packages/benchmarks/orchestrator_lifecycle/tests/ -v
+```
+
+Result: 29 passed.
+
+```bash
+PYTHONPATH=packages python -m compileall packages/benchmarks/orchestrator_lifecycle
+```
+
+Result: compiled successfully.
+
+```bash
+PYTHONPATH=packages python -m benchmarks.orchestrator_lifecycle.cli --mode simulate --max-scenarios 3 --output /tmp/olc-smoke-13395
+```
+
+Result:
+
+- Mode: simulate
+- Scenarios: 3
+- Harness self-check pass rate: 100.0%
+- Report: `/tmp/olc-smoke-13395/orchestrator-lifecycle-20260704_141144.json`
+
+Smoke report guard and shape:
+
+```json
+{
+  "mode": "simulate",
+  "scored": false,
+  "metrics": {
+    "overall_score": null,
+    "scenario_pass_rate": 1.0,
+    "total_scenarios": 3,
+    "passed_scenarios": 3,
+    "clarification_success_rate": 0.0,
+    "status_accuracy_rate": 1.0,
+    "interruption_handling_rate": 1.0,
+    "completion_summary_quality": 0.0
+  },
+  "scenarios": [
+    { "scenario_id": "cancel_task", "category": "interrupt", "score": 1.0, "passed": true },
+    { "scenario_id": "cancel_then_undo_resume", "category": "interrupt", "score": 1.0, "passed": true },
+    { "scenario_id": "check_in_while_running", "category": "status", "score": 1.0, "passed": true }
+  ]
+}
+```
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Repository verify
+
+After syncing with `origin/develop`, the required install step completed:
+
+```bash
+bun install
+```
+
+Result: passed.
+
+The full repository verify was attempted:
+
+```bash
+bun run verify
+```
+
+Result: failed before package typecheck/lint because Turbo reported an existing
+workspace build cycle:
+
+```text
+Cyclic dependency detected:
+  @elizaos/plugin-local-inference#build, @elizaos/agent#build
+
+The cycle can be broken by removing any of these sets of dependencies:
+  @elizaos/agent#build -> @elizaos/plugin-local-inference#build
+  @elizaos/plugin-local-inference#build -> @elizaos/agent#build
+```
+
+This PR only touches `packages/benchmarks/orchestrator_lifecycle` and the
+evidence file above.

--- a/packages/benchmarks/orchestrator_lifecycle/evaluator.py
+++ b/packages/benchmarks/orchestrator_lifecycle/evaluator.py
@@ -125,6 +125,7 @@ class LifecycleEvaluator:
         return ScenarioResult(
             scenario_id=scenario.scenario_id,
             title=scenario.title,
+            category=scenario.category,
             passed=passed,
             score=score,
             checks_passed=checks_passed,
@@ -138,23 +139,18 @@ class LifecycleEvaluator:
         passed = sum(1 for r in results if r.passed)
         overall = (sum(r.score for r in results) / total) if total > 0 else 0.0
 
-        def _rate(tag: str) -> float:
-            tagged = [r for r in results if tag in r.scenario_id]
+        def _category_rate(category: str) -> float:
+            tagged = [r for r in results if r.category == category]
             if not tagged:
                 return 0.0
             return sum(r.score for r in tagged) / len(tagged)
 
-        clarification = _rate("clarification")
-        status = _rate("status")
-        interruption = (
-            _rate("pause")
-            + _rate("resume")
-            + _rate("cancel")
-            + _rate("interrupt")
-        ) / 4
+        clarification = _category_rate("clarification")
+        status = _category_rate("status")
+        interruption = _category_rate("interrupt")
         # No inflation fallback: a category with no scenarios (or all-failing
         # scenarios) reports its real rate, never the overall score.
-        summary = _rate("summary")
+        summary = _category_rate("completion_summary")
         return LifecycleMetrics(
             overall_score=overall,
             scenario_pass_rate=(passed / total) if total > 0 else 0.0,

--- a/packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py
+++ b/packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py
@@ -12,15 +12,41 @@ pass.
 from __future__ import annotations
 
 from benchmarks.orchestrator_lifecycle.evaluator import LifecycleEvaluator
-from benchmarks.orchestrator_lifecycle.types import Scenario, ScenarioTurn, TurnRecord
+from benchmarks.orchestrator_lifecycle.types import (
+    Scenario,
+    ScenarioResult,
+    ScenarioTurn,
+    TurnRecord,
+)
 
 
-def _scenario(turns: list[ScenarioTurn], scenario_id: str = "case") -> Scenario:
+def _scenario(
+    turns: list[ScenarioTurn],
+    scenario_id: str = "case",
+    category: str = "test",
+) -> Scenario:
     return Scenario(
         scenario_id=scenario_id,
         title=scenario_id,
-        category="test",
+        category=category,
         turns=turns,
+    )
+
+
+def _result(
+    scenario_id: str,
+    category: str,
+    score: float,
+    passed: bool = True,
+) -> ScenarioResult:
+    return ScenarioResult(
+        scenario_id=scenario_id,
+        title=scenario_id,
+        category=category,
+        passed=passed,
+        score=score,
+        checks_passed=1 if passed else 0,
+        checks_total=1,
     )
 
 
@@ -47,6 +73,54 @@ def test_typed_cancel_event_passes_cancel_checks() -> None:
     )
     assert result.passed
     assert result.score == 1.0
+
+
+def test_scenario_result_carries_category() -> None:
+    evaluator = LifecycleEvaluator()
+    scenario = _scenario(
+        [
+            ScenarioTurn(
+                actor="user",
+                message="How is it going?",
+                expected_behaviors=["report_active_subagent_status"],
+            )
+        ],
+        scenario_id="check_in_while_running",
+        category="status",
+    )
+    result = evaluator.evaluate_scenario(
+        scenario,
+        [TurnRecord(reply_text="Still working.", events=["status_query"])],
+    )
+    assert result.category == "status"
+
+
+def test_category_metrics_do_not_depend_on_scenario_id_spelling() -> None:
+    evaluator = LifecycleEvaluator()
+    results = [
+        _result("ambiguous_first_turn", "clarification", 0.25),
+        _result("check_in_while_running", "status", 0.5),
+        _result("cancel_task", "interrupt", 0.75),
+        _result("final_stakeholder_summary", "completion_summary", 1.0),
+    ]
+    metrics = evaluator.compute_metrics(results)
+    assert metrics.clarification_success_rate == 0.25
+    assert metrics.status_accuracy_rate == 0.5
+    assert metrics.interruption_handling_rate == 0.75
+    assert metrics.completion_summary_quality == 1.0
+
+
+def test_category_metrics_ignore_misleading_id_substrings() -> None:
+    evaluator = LifecycleEvaluator()
+    results = [
+        _result("status_in_name_but_summary_category", "completion_summary", 0.2),
+        _result("summary_in_name_but_status_category", "status", 0.8),
+        _result("pause_in_name_but_scope_category", "scope", 1.0),
+    ]
+    metrics = evaluator.compute_metrics(results)
+    assert metrics.status_accuracy_rate == 0.8
+    assert metrics.completion_summary_quality == 0.2
+    assert metrics.interruption_handling_rate == 0.0
 
 
 def test_coached_keyword_reply_without_events_fails() -> None:

--- a/packages/benchmarks/orchestrator_lifecycle/types.py
+++ b/packages/benchmarks/orchestrator_lifecycle/types.py
@@ -57,6 +57,7 @@ class TurnRecord:
 class ScenarioResult:
     scenario_id: str
     title: str
+    category: str
     passed: bool
     score: float
     checks_passed: int


### PR DESCRIPTION
## Summary
- carry explicit scenario category into orchestrator lifecycle scenario results
- compute clarification/status/interrupt/completion-summary metrics from category values instead of scenario-id substrings
- add regression coverage for category IDs that omit or misleadingly include metric names

## Evidence
- Evidence note: .github/issue-evidence/13395-orchestrator-lifecycle-category-metrics.md
- `PYTHONPATH=packages pytest packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py -v` (15 passed)
- `PYTHONPATH=packages pytest packages/benchmarks/orchestrator_lifecycle/tests/ -v` (29 passed)
- `PYTHONPATH=packages python -m compileall packages/benchmarks/orchestrator_lifecycle` (passed)
- `PYTHONPATH=packages python -m benchmarks.orchestrator_lifecycle.cli --mode simulate --max-scenarios 3 --output /tmp/olc-smoke-13395` (3 scenarios, harness self-check pass rate 100%; simulate report remains unscored with metrics.overall_score null)
- `git diff --check` (passed)
- `bun install` after rebasing onto origin/develop (passed)

## Verify note
- `bun run verify` was attempted after sync and failed before package typecheck/lint because Turbo detected the existing workspace build cycle between `@elizaos/plugin-local-inference#build` and `@elizaos/agent#build`. Exact output is captured in the evidence note.

Closes #13395