### PR TITLE
feat(#13377): gate local and remote onboarding choices

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3290,6 +3290,7 @@
       "version": "2.0.3-beta.7",
       "dependencies": {
         "@elizaos/core": "workspace:*",
+        "@elizaos/shared": "workspace:*",
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.2",

--- a/packages/ui/src/config/cloud-only.test.ts
+++ b/packages/ui/src/config/cloud-only.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Product-mode policy for the cloud-first app shell.
+ */
+import { describe, expect, it } from "vitest";
+import { canOfferLocalRemoteOnboarding } from "./cloud-only";
+
+describe("canOfferLocalRemoteOnboarding", () => {
+  it("keeps local and remote onboarding available outside production", () => {
+    expect(canOfferLocalRemoteOnboarding({ PROD: false })).toBe(true);
+  });
+
+  it("hides local and remote onboarding by default in production", () => {
+    expect(canOfferLocalRemoteOnboarding({ PROD: true })).toBe(false);
+  });
+
+  it("allows explicit production opt-in for testing local and remote paths", () => {
+    expect(
+      canOfferLocalRemoteOnboarding({
+        PROD: true,
+        VITE_ELIZA_ENABLE_LOCAL_REMOTE_ONBOARDING: "1",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows explicit opt-out in dev and test builds", () => {
+    expect(
+      canOfferLocalRemoteOnboarding({
+        PROD: false,
+        VITE_ELIZA_ENABLE_LOCAL_REMOTE_ONBOARDING: "0",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/ui/src/config/cloud-only.ts
+++ b/packages/ui/src/config/cloud-only.ts
@@ -1,4 +1,42 @@
 /**
- * Re-exports the shared cloud-only-branding predicate.
+ * Cloud-first product policy shared by the app shell and first-run setup.
  */
 export { shouldUseCloudOnlyBranding } from "@elizaos/shared";
+
+type EnvValue = string | boolean | undefined;
+
+export interface LocalRemoteOnboardingEnv {
+  PROD?: EnvValue;
+  VITE_ELIZA_ENABLE_LOCAL_REMOTE_ONBOARDING?: EnvValue;
+}
+
+function isTruthyEnv(value: EnvValue): boolean {
+  return value === true || String(value ?? "").trim() === "1";
+}
+
+function isExplicitlyDisabled(value: EnvValue): boolean {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  return normalized === "0" || normalized === "false" || normalized === "off";
+}
+
+function viteEnv(): LocalRemoteOnboardingEnv {
+  return (
+    (import.meta as ImportMeta & { env?: LocalRemoteOnboardingEnv }).env ?? {}
+  );
+}
+
+/**
+ * Local and remote first-run paths stay available for development and explicit
+ * test builds, while production defaults to the cloud-only onboarding product.
+ */
+export function canOfferLocalRemoteOnboarding(
+  env: LocalRemoteOnboardingEnv = viteEnv(),
+): boolean {
+  if (isExplicitlyDisabled(env.VITE_ELIZA_ENABLE_LOCAL_REMOTE_ONBOARDING)) {
+    return false;
+  }
+  if (isTruthyEnv(env.VITE_ELIZA_ENABLE_LOCAL_REMOTE_ONBOARDING)) return true;
+  return !isTruthyEnv(env.PROD);
+}

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -44,6 +44,7 @@ const mocks = vi.hoisted(() => ({
     }),
   },
   autoDownloadRecommendedLocalModelInBackground: vi.fn(async () => undefined),
+  canOfferLocalRemoteOnboarding: vi.fn(() => true),
 }));
 
 vi.mock("../api/client", async (importOriginal) => {
@@ -55,6 +56,14 @@ vi.mock("./auto-download-recommended", () => ({
   autoDownloadRecommendedLocalModelInBackground:
     mocks.autoDownloadRecommendedLocalModelInBackground,
 }));
+
+vi.mock("../config/cloud-only", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/cloud-only")>();
+  return {
+    ...actual,
+    canOfferLocalRemoteOnboarding: mocks.canOfferLocalRemoteOnboarding,
+  };
+});
 
 import type { ConversationMessage, LocalAgentBackupMetadata } from "../api";
 import { __setAppValueForTests } from "../state/app-store";
@@ -212,6 +221,7 @@ beforeEach(() => {
     success: true,
     data: [],
   });
+  mocks.canOfferLocalRemoteOnboarding.mockReturnValue(true);
   localStorage.setItem("steward_session_token", "cloud-token");
 });
 
@@ -387,6 +397,27 @@ describe("useFirstRunConductor", () => {
     expect(transcript.current.some((m) => m.id === "first-run:provider")).toBe(
       false,
     );
+    unmount();
+  });
+
+  it("cloud-only onboarding offers only Eliza Cloud and consumes stale local/remote picks as no-ops", async () => {
+    mocks.canOfferLocalRemoteOnboarding.mockReturnValue(false);
+    seedAppStore();
+    const { turn, transcript, unmount } = renderConductor();
+    const greeting = await waitForTurn(turn, "first-run:greeting");
+
+    expect(greeting.text).toContain("__first_run__:runtime:cloud=");
+    expect(greeting.text).not.toContain("__first_run__:runtime:local=");
+    expect(greeting.text).not.toContain("__first_run__:runtime:remote=");
+
+    expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
+    expect(tryHandleFirstRunAction("__first_run__:runtime:remote")).toBe(true);
+    expect(transcript.current.some((m) => m.id === "first-run:provider")).toBe(
+      false,
+    );
+    expect(
+      transcript.current.some((m) => m.id === "first-run:remote-connect"),
+    ).toBe(false);
     unmount();
   });
 

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -44,6 +44,7 @@ import { client } from "../api";
 import { getCloudAuthToken } from "../api/client-cloud";
 import { startTutorial } from "../components/pages/tutorial/tutorial-controller";
 import { getBootConfig } from "../config/boot-config";
+import { canOfferLocalRemoteOnboarding } from "../config/cloud-only";
 import { ACCENT_PRESETS, useAppSelectorShallow } from "../state";
 import { useConversationMessages } from "../state/ConversationMessagesContext.hooks";
 import { preOpenWindow } from "../utils";
@@ -138,13 +139,18 @@ function newestLocalBackup(
 // runtime with `configure-later` and hands off provider setup to Settings via
 // the finish path's banner. Remote picks an already-running agent by URL +
 // token; it owns its own provider, so it skips the provider sub-step.
-const RUNTIME_CHOICE = [
-  "[CHOICE:first-run id=runtime]",
-  `${FIRST_RUN_ACTION_PREFIX}runtime:cloud=Eliza Cloud (managed)`,
-  `${FIRST_RUN_ACTION_PREFIX}runtime:local=On this device`,
-  `${FIRST_RUN_ACTION_PREFIX}runtime:remote=Connect to a remote agent`,
-  "[/CHOICE]",
-].join("\n");
+function runtimeChoice(): string {
+  const choices = [
+    `${FIRST_RUN_ACTION_PREFIX}runtime:cloud=Eliza Cloud (managed)`,
+  ];
+  if (canOfferLocalRemoteOnboarding()) {
+    choices.push(
+      `${FIRST_RUN_ACTION_PREFIX}runtime:local=On this device`,
+      `${FIRST_RUN_ACTION_PREFIX}runtime:remote=Connect to a remote agent`,
+    );
+  }
+  return ["[CHOICE:first-run id=runtime]", ...choices, "[/CHOICE]"].join("\n");
+}
 
 const BACKUP_RESTORE_CHOICE = [
   "[CHOICE:first-run id=backup-restore]",
@@ -284,7 +290,7 @@ export function surfaceCloudLoginRetryTurn(writer: FirstRunTurnWriter): void {
   // runtime widget locked itself on first tap).
   const connectTurn = makeTurn(
     "first-run:cloud-oauth",
-    `Connect your Eliza Cloud account to continue — I'll pick up where we left off. You can also pick how to run your agent again.\n\n${RUNTIME_CHOICE}`,
+    `Connect your Eliza Cloud account to continue — I'll pick up where we left off. You can also pick how to run your agent again.\n\n${runtimeChoice()}`,
     { secretRequest: cloudOAuthSecretRequest("failed") },
   );
   writer.seedTurn(connectTurn);
@@ -408,7 +414,7 @@ export function useFirstRunConductor(): void {
 
   const seedRuntimeChoice = React.useCallback(() => {
     seedTurn(
-      makeTurn("first-run:greeting", `${GREETING}\n\n${RUNTIME_CHOICE}`),
+      makeTurn("first-run:greeting", `${GREETING}\n\n${runtimeChoice()}`),
     );
   }, [seedTurn]);
 
@@ -678,6 +684,7 @@ export function useFirstRunConductor(): void {
 
       if (group === "runtime") {
         if (id !== "cloud" && id !== "local" && id !== "remote") return true;
+        if (id !== "cloud" && !canOfferLocalRemoteOnboarding()) return true;
         if (id === "cloud") {
           draftRef.current = {
             ...draftRef.current,
@@ -859,7 +866,7 @@ export function useFirstRunConductor(): void {
           // runtime widget locked itself on its first pick).
           seedFreshChoiceTurn(
             "first-run:greeting",
-            `${GREETING}\n\n${RUNTIME_CHOICE}`,
+            `${GREETING}\n\n${runtimeChoice()}`,
           );
           return true;
         }
@@ -937,7 +944,8 @@ export function useFirstRunConductor(): void {
           : erroredRef.current
             ? FIRST_RUN_TEXT_REPLY.error
             : FIRST_RUN_TEXT_REPLY.choosing;
-      const seq = (textTurnSeqRef.current += 1);
+      textTurnSeqRef.current += 1;
+      const seq = textTurnSeqRef.current;
       seedTurn({
         id: `first-run:user:${seq}`,
         role: "user",

--- a/packages/ui/src/platform/init.ts
+++ b/packages/ui/src/platform/init.ts
@@ -3,6 +3,7 @@
 import { Capacitor } from "@capacitor/core";
 import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
 import { getBootConfig, setBootConfig } from "../config/boot-config";
+import { canOfferLocalRemoteOnboarding } from "../config/cloud-only";
 import { userAgentHasElizaOSMarker } from "./aosp-user-agent";
 
 export { userAgentHasElizaOSMarker } from "./aosp-user-agent";
@@ -67,6 +68,7 @@ export function canRunLocal(): boolean {
  * a bundled local agent, so they only see Cloud + Remote.
  */
 export function canSelectLocalRuntime(): boolean {
+  if (!canOfferLocalRemoteOnboarding()) return false;
   return canRunLocal() || isElizaOS();
 }
 


### PR DESCRIPTION
## Summary

First incremental slice for #13377. Adds a cloud-first onboarding policy so production builds default to Cloud-only runtime choice while local/remote first-run paths remain in-tree for dev and explicit test builds.

- adds `canOfferLocalRemoteOnboarding()` with production default-off and explicit `VITE_ELIZA_ENABLE_LOCAL_REMOTE_ONBOARDING=1` opt-in
- hides Local/Remote choices in the in-chat first-run conductor when policy disables them
- consumes stale Local/Remote first-run actions as no-ops when hidden, so old transcript widgets cannot start hidden flows
- makes `canSelectLocalRuntime()` respect the same policy

## Verification

- `bun run install:light`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/cloud/routing build`
- `bun run --cwd packages/ui test -- src/config/cloud-only.test.ts src/first-run/use-first-run-conductor.test.ts` — 34 passed
- `bunx @biomejs/biome check packages/ui/src/config/cloud-only.ts packages/ui/src/config/cloud-only.test.ts packages/ui/src/platform/init.ts packages/ui/src/first-run/use-first-run-conductor.ts packages/ui/src/first-run/use-first-run-conductor.test.ts`

## Known Remaining Work

This does not close #13377. Remaining workstreams include real cloud OAuth verification across platforms, cloud-hosted session injection, chat-native TutorialService, and Help→default knowledge migration.

`bun run --cwd packages/ui typecheck` is currently blocked by unrelated repo issues: missing/built `@elizaos/contracts`, existing account type mismatches, duplicate fixture exports, and a wallet implicit-any.

## Evidence

N/A for screenshots/video in this slice: this is a policy/helper + first-run transcript choice guard. The focused conductor test proves the rendered in-chat choice text and stale-action behavior.