### PR TITLE
feat(#13358): add VoiceCodeBench exact-token ASR gate

### DIFF
--- a/.github/issue-evidence/13358-voice-code-bench-gate.md
+++ b/.github/issue-evidence/13358-voice-code-bench-gate.md
@@ -1,0 +1,31 @@
+# Issue 13358 - VoiceCodeBench Exact-Token ASR Gate
+
+## Scope
+
+Added `packages/training/scripts/asr/voice_code_bench_gate.py`, a pure-Python
+VoiceCodeBench runtime-download contract and metric helper for exact
+structured-token ASR recovery. Raw audio remains outside git.
+
+## Source Review
+
+Hugging Face `besimple-ai/voice-code-bench` checked on 2026-07-04:
+
+- Task: Automatic Speech Recognition.
+- Modalities: audio, tabular, text.
+- License: MIT.
+- Dataset size: default subset, test split, 300 rows.
+- Observed fields include `audio_id`, `duration`, `domain`, `scenario`,
+  `difficulty`, `transcripts`, `entities`, `entity_types`, and `entity_count`.
+
+## Validation
+
+- `pytest packages/training/scripts/asr/__tests__/test_voice_code_bench_gate.py -q`
+- `python -m compileall packages/training/scripts/asr/voice_code_bench_gate.py`
+- `git diff --check`
+
+## Evidence Boundary
+
+This PR adds the gate contract and deterministic metric math only. #13358 still
+requires a real ASR/Eliza-1 run over downloaded VoiceCodeBench rows with source
+revision, row count, content hashes, provider/model metadata, score JSON, logs,
+and manually reviewed failures before any score is publishable.

--- a/packages/training/scripts/asr/README.md
+++ b/packages/training/scripts/asr/README.md
@@ -17,6 +17,7 @@ retired ASR model.
 | --- | --- |
 | `finetune_asr.py` | End-to-end fine-tune pipeline (real + synthetic-smoke). |
 | `eval_asr.py` | WER + RTF evaluation + baseline comparison + HF-push gating. |
+| `voice_code_bench_gate.py` | VoiceCodeBench runtime-download contract plus exact structured-token metrics (`ctem`, `tsr`, WER, CER). |
 | `configs/base.yaml` | Base hyperparameter config for all ASR fine-tunes. |
 | `configs/asr_same.yaml` | Same-corpus-specific overrides. |
 | `__tests__/test_asr_pipeline.py` | CI tests (synthetic-smoke + config + gate logic). |
@@ -84,6 +85,26 @@ is also blocked on a verified Gemma-compatible ASR checkpoint/projector pair.
 | --- | --- | --- |
 | WER | ≤ 15% | jiwer WER vs gold transcripts on val clips. |
 | RTF | ≥ 2.0× | Inference must be ≥ 2× faster than realtime. |
+
+### VoiceCodeBench exact-token gate
+
+`voice_code_bench_gate.py` defines the non-blocking VoiceCodeBench gate for
+exact structured-token ASR recovery. It records the public dataset source
+(`besimple-ai/voice-code-bench`), MIT license, 300-row test split, required
+source/audio/reference/entity hashes, provider metadata, and eval-only training
+separation. Raw audio must be downloaded or cached outside git.
+
+The gate reports:
+
+- `ctem`: canonical token/entity match rate across structured entities,
+- `tsr`: task success rate, where every entity in a row must be recovered,
+- `wer`: normalized word error rate,
+- `cer`: normalized character error rate.
+
+Synthetic/unit results are never publishable. A publishable report must mark
+`publishable: true` and include a real ASR provider/model, artifact revision,
+sample rate, dataset/hash metadata, score JSON, logs, and manually reviewed
+failures.
 
 Sam-specific config relaxes WER to ≤ 20% (5-clip val set is noisy).
 

--- a/packages/training/scripts/asr/__tests__/test_voice_code_bench_gate.py
+++ b/packages/training/scripts/asr/__tests__/test_voice_code_bench_gate.py
@@ -1,0 +1,191 @@
+"""Contract tests for the VoiceCodeBench ASR gate.
+
+The suite verifies dataset provenance, eval-only policy, exact entity recovery,
+and publishable-report requirements without committing benchmark rows or audio.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ASR_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ASR_DIR))
+
+import voice_code_bench_gate as gate  # noqa: E402
+
+
+def _row(audio_id: str = "contact_routing_001") -> gate.VoiceCodeBenchRow:
+    return gate.VoiceCodeBenchRow(
+        audio_id=audio_id,
+        domain="contact_routing",
+        scenario="callback_instructions",
+        difficulty="light",
+        reference=(
+            "Ask GitHub Support to call back at area code four one five "
+            "dash two zero one dash nine zero zero zero with code B H seven four two one."
+        ),
+        entities=(
+            gate.VoiceCodeBenchEntity(
+                id="e01",
+                type="person_or_team_name",
+                canonical="GitHub Support",
+            ),
+            gate.VoiceCodeBenchEntity(
+                id="e02",
+                type="phone_number",
+                canonical="415-201-9000",
+            ),
+            gate.VoiceCodeBenchEntity(
+                id="e03",
+                type="spelled_sequence",
+                canonical="BH-7421",
+            ),
+        ),
+    )
+
+
+def test_gate_contract_records_public_dataset_and_eval_only_policy() -> None:
+    contract = gate.gate_contract()
+
+    assert contract["source_url"] == "https://huggingface.co/datasets/besimple-ai/voice-code-bench"
+    assert contract["license"] == "mit"
+    assert contract["split"] == "test"
+    assert contract["row_count"] == 300
+    assert contract["raw_audio_committed"] is False
+    assert contract["cache_policy"] == "download_or_cache_outside_git"
+    assert contract["metrics"] == ["ctem", "tsr", "wer", "cer"]
+    assert len(contract["entity_types"]) == 26
+    assert {"cli_flag", "environment_variable", "ip_address", "reference_id"} <= set(
+        contract["entity_types"]
+    )
+    assert contract["publishable_requires_real_asr"] is True
+    assert contract["training_eval_separation"] == {
+        "eval_only": True,
+        "training_allowed": False,
+        "note": "VoiceCodeBench rows must not be used for training without explicit approval.",
+    }
+    assert {"audio_sha256", "entities_sha256", "adapter_config_sha256"} <= set(
+        contract["required_hashes"]
+    )
+
+
+def test_exact_entity_recovery_scores_ctem_and_tsr() -> None:
+    row = _row()
+    report = gate.score_voice_code_bench_rows(
+        [row],
+        {
+            row.audio_id: (
+                "Please have GitHub Support call 415 201 9000 and reference "
+                "BH7421 before routing the ticket."
+            )
+        },
+    )
+
+    assert report["publishable"] is False
+    assert report["row_count"] == 1
+    assert report["metrics"]["ctem"] == 1.0
+    assert report["metrics"]["tsr"] == 1.0
+    assert report["rows"][0]["ctem"] == 1.0
+    assert report["rows"][0]["tsr"] == 1.0
+    assert all(entity["matched"] for entity in report["rows"][0]["entities"])
+
+
+def test_partial_entity_recovery_keeps_task_success_false() -> None:
+    row = _row()
+    report = gate.score_voice_code_bench_rows(
+        [row],
+        {row.audio_id: "GitHub Support should call back, but the code was missing."},
+    )
+
+    assert report["metrics"]["ctem"] == 1 / 3
+    assert report["metrics"]["tsr"] == 0.0
+    assert report["rows"][0]["ctem"] == 1 / 3
+    assert report["rows"][0]["tsr"] == 0.0
+
+
+def test_embedded_structured_tokens_do_not_count_as_exact_recovery() -> None:
+    row = _row()
+    report = gate.score_voice_code_bench_rows(
+        [row],
+        {
+            row.audio_id: (
+                "GitHub Support should call 415 201 9000 but use code "
+                "XBH7421Y instead."
+            )
+        },
+    )
+
+    assert report["metrics"]["ctem"] == 2 / 3
+    assert report["metrics"]["tsr"] == 0.0
+    assert report["rows"][0]["entities"][2]["matched"] is False
+
+
+def test_error_rates_normalize_punctuation_without_hiding_entity_errors() -> None:
+    assert gate.word_error_rate("Hello, world!", "hello world") == 0.0
+    assert gate.character_error_rate("BH-7421", "BH7421") == 0.0
+    assert gate.character_error_rate("BH-7421", "BH7429") > 0.0
+
+
+def test_publishable_report_requires_real_provider_hashes_and_metrics() -> None:
+    bad_report = gate.score_voice_code_bench_rows([_row()], {})
+    assert gate.validate_publishable_report(bad_report) == [
+        "publishable must be true for real score reports",
+        "source_url must match VoiceCodeBench",
+        "split must be test",
+        "row_count must be 300 for full publishable run",
+        "provider_metadata is required",
+        "hashes are required",
+    ]
+
+    contract = gate.gate_contract()
+    good_report = {
+        "publishable": True,
+        "source_url": gate.DATASET_SOURCE_URL,
+        "split": gate.DATASET_SPLIT,
+        "row_count": gate.DATASET_ROWS,
+        "provider_metadata": {
+            "asr_provider": "eliza-local-inference",
+            "asr_model": "eliza-1-asr-q4_k_m",
+            "artifact_revision": "sha256:abc",
+            "sample_rate_hz": 16000,
+            "run_started_at": "2026-07-04T12:00:00Z",
+        },
+        "hashes": {key: f"{key}:hash" for key in contract["required_hashes"]},
+        "metrics": {"ctem": 1.0, "tsr": 1.0, "wer": 0.0, "cer": 0.0},
+    }
+
+    assert gate.validate_publishable_report(good_report) == []
+
+    bad_provider_type = {
+        **good_report,
+        "provider_metadata": {
+            **good_report["provider_metadata"],
+            "asr_provider": 123,
+        },
+    }
+    assert "provider_metadata.asr_provider is required" in gate.validate_publishable_report(
+        bad_provider_type
+    )
+
+    bad_sample_rate_string = {
+        **good_report,
+        "provider_metadata": {
+            **good_report["provider_metadata"],
+            "sample_rate_hz": "16000",
+        },
+    }
+    assert "provider_metadata.sample_rate_hz is required" in gate.validate_publishable_report(
+        bad_sample_rate_string
+    )
+
+    bad_sample_rate_bool = {
+        **good_report,
+        "provider_metadata": {
+            **good_report["provider_metadata"],
+            "sample_rate_hz": True,
+        },
+    }
+    assert "provider_metadata.sample_rate_hz is required" in gate.validate_publishable_report(
+        bad_sample_rate_bool
+    )

--- a/packages/training/scripts/asr/voice_code_bench_gate.py
+++ b/packages/training/scripts/asr/voice_code_bench_gate.py
@@ -1,0 +1,265 @@
+"""VoiceCodeBench exact-token ASR gate contract and metric helpers.
+
+The gate is intentionally pure Python and data-free: it defines the
+runtime-download metadata for the public VoiceCodeBench test split and scores
+provider transcripts against row-level structured entities. Raw audio stays
+outside git; publishable reports must record real provider/model metadata.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+DATASET_SOURCE_URL = "https://huggingface.co/datasets/besimple-ai/voice-code-bench"
+DATASET_LICENSE = "mit"
+DATASET_SPLIT = "test"
+DATASET_ROWS = 300
+
+ENTITY_TYPES = {
+    "account_or_record_number",
+    "acronym_or_initialism",
+    "cli_flag",
+    "code_symbol",
+    "command",
+    "currency_amount",
+    "date",
+    "domain_term",
+    "email_address",
+    "environment_variable",
+    "file_path",
+    "ip_address",
+    "measurement",
+    "percentage",
+    "person_or_team_name",
+    "phone_extension",
+    "phone_number",
+    "plain_number",
+    "port_number",
+    "postal_address",
+    "product_code",
+    "reference_id",
+    "spelled_sequence",
+    "time",
+    "url",
+    "version",
+}
+
+
+@dataclass(frozen=True)
+class VoiceCodeBenchEntity:
+    id: str
+    type: str
+    canonical: str
+
+
+@dataclass(frozen=True)
+class VoiceCodeBenchRow:
+    audio_id: str
+    domain: str
+    scenario: str
+    difficulty: str
+    reference: str
+    entities: tuple[VoiceCodeBenchEntity, ...]
+
+
+def gate_contract() -> dict[str, Any]:
+    return {
+        "schema": "elizaos.voice_code_bench_gate.v1",
+        "source_url": DATASET_SOURCE_URL,
+        "license": DATASET_LICENSE,
+        "split": DATASET_SPLIT,
+        "row_count": DATASET_ROWS,
+        "raw_audio_committed": False,
+        "cache_policy": "download_or_cache_outside_git",
+        "required_hashes": [
+            "dataset_revision",
+            "row_id",
+            "audio_sha256",
+            "reference_sha256",
+            "entities_sha256",
+            "adapter_config_sha256",
+        ],
+        "provider_metadata_required": [
+            "asr_provider",
+            "asr_model",
+            "artifact_revision",
+            "sample_rate_hz",
+            "run_started_at",
+        ],
+        "metrics": ["ctem", "tsr", "wer", "cer"],
+        "entity_types": sorted(ENTITY_TYPES),
+        "training_eval_separation": {
+            "eval_only": True,
+            "training_allowed": False,
+            "note": "VoiceCodeBench rows must not be used for training without explicit approval.",
+        },
+        "publishable_requires_real_asr": True,
+    }
+
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+(?:'[a-z0-9]+)?")
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+
+
+def normalize_for_error_rate(text: str) -> str:
+    return " ".join(_TOKEN_RE.findall(text.lower()))
+
+
+def normalize_entity(text: str) -> str:
+    return _NON_ALNUM_RE.sub("", text.lower())
+
+
+def entity_matches_hypothesis(entity: str, hypothesis: str) -> bool:
+    entity_normalized = normalize_entity(entity)
+    if not entity_normalized:
+        return False
+    hypothesis_tokens = _TOKEN_RE.findall(hypothesis.lower())
+    for start in range(len(hypothesis_tokens)):
+        joined = ""
+        for token in hypothesis_tokens[start:]:
+            joined += token
+            if joined == entity_normalized:
+                return True
+            if len(joined) >= len(entity_normalized):
+                break
+    return False
+
+
+def word_error_rate(reference: str, hypothesis: str) -> float:
+    return _edit_rate(
+        normalize_for_error_rate(reference).split(),
+        normalize_for_error_rate(hypothesis).split(),
+    )
+
+
+def character_error_rate(reference: str, hypothesis: str) -> float:
+    return _edit_rate(
+        list(normalize_entity(reference)),
+        list(normalize_entity(hypothesis)),
+    )
+
+
+def score_voice_code_bench_rows(
+    rows: Iterable[VoiceCodeBenchRow],
+    hypotheses: dict[str, str],
+) -> dict[str, Any]:
+    row_scores: list[dict[str, Any]] = []
+    total_entities = 0
+    matched_entities = 0
+    task_successes = 0
+    row_count = 0
+    wer_sum = 0.0
+    cer_sum = 0.0
+
+    for row in rows:
+        row_count += 1
+        hypothesis = hypotheses.get(row.audio_id, "")
+        entity_results: list[dict[str, Any]] = []
+        row_matched = 0
+        for entity in row.entities:
+            total_entities += 1
+            entity_match = entity_matches_hypothesis(entity.canonical, hypothesis)
+            if entity_match:
+                matched_entities += 1
+                row_matched += 1
+            entity_results.append(
+                {
+                    "id": entity.id,
+                    "type": entity.type,
+                    "canonical": entity.canonical,
+                    "matched": entity_match,
+                }
+            )
+        row_success = row.entities and row_matched == len(row.entities)
+        if row_success:
+            task_successes += 1
+        row_wer = word_error_rate(row.reference, hypothesis)
+        row_cer = character_error_rate(row.reference, hypothesis)
+        wer_sum += row_wer
+        cer_sum += row_cer
+        row_scores.append(
+            {
+                "audio_id": row.audio_id,
+                "domain": row.domain,
+                "scenario": row.scenario,
+                "difficulty": row.difficulty,
+                "ctem": row_matched / len(row.entities) if row.entities else 0.0,
+                "tsr": 1.0 if row_success else 0.0,
+                "wer": row_wer,
+                "cer": row_cer,
+                "entities": entity_results,
+            }
+        )
+
+    return {
+        "publishable": False,
+        "row_count": row_count,
+        "metrics": {
+            "ctem": matched_entities / total_entities if total_entities else 0.0,
+            "tsr": task_successes / row_count if row_count else 0.0,
+            "wer": wer_sum / row_count if row_count else 0.0,
+            "cer": cer_sum / row_count if row_count else 0.0,
+        },
+        "rows": row_scores,
+    }
+
+
+def validate_publishable_report(report: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if report.get("publishable") is not True:
+        errors.append("publishable must be true for real score reports")
+    if report.get("source_url") != DATASET_SOURCE_URL:
+        errors.append("source_url must match VoiceCodeBench")
+    if report.get("split") != DATASET_SPLIT:
+        errors.append("split must be test")
+    if report.get("row_count") != DATASET_ROWS:
+        errors.append("row_count must be 300 for full publishable run")
+    provider = report.get("provider_metadata")
+    if not isinstance(provider, dict):
+        errors.append("provider_metadata is required")
+    else:
+        for key in ("asr_provider", "asr_model", "artifact_revision", "run_started_at"):
+            value = provider.get(key)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"provider_metadata.{key} is required")
+        sample_rate = provider.get("sample_rate_hz")
+        if (
+            isinstance(sample_rate, bool)
+            or not isinstance(sample_rate, int)
+            or sample_rate <= 0
+        ):
+            errors.append("provider_metadata.sample_rate_hz is required")
+    hashes = report.get("hashes")
+    if not isinstance(hashes, dict):
+        errors.append("hashes are required")
+    else:
+        for key in gate_contract()["required_hashes"]:
+            value = hashes.get(key)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"hashes.{key} is required")
+    metrics = report.get("metrics")
+    if not isinstance(metrics, dict):
+        errors.append("metrics are required")
+    else:
+        for key in gate_contract()["metrics"]:
+            value = metrics.get(key)
+            if isinstance(value, bool) or not isinstance(value, int | float):
+                errors.append(f"metrics.{key} must be numeric")
+    return errors
+
+
+def _edit_rate(reference: list[str], hypothesis: list[str]) -> float:
+    if not reference:
+        return 0.0 if not hypothesis else 1.0
+    previous = list(range(len(hypothesis) + 1))
+    for i, ref_item in enumerate(reference, start=1):
+        current = [i]
+        for j, hyp_item in enumerate(hypothesis, start=1):
+            substitution = previous[j - 1] + (0 if ref_item == hyp_item else 1)
+            insertion = current[j - 1] + 1
+            deletion = previous[j] + 1
+            current.append(min(substitution, insertion, deletion))
+        previous = current
+    return previous[-1] / len(reference)


### PR DESCRIPTION
Closes #13358

## What

Re-lands the **VoiceCodeBench exact-token ASR gate** for issue #13358. The gate code was complete and validated in PR #13380, but that PR was **closed-unmerged with its branch deleted**, and the code was verified **absent from develop**. This recovers it from the final validated commit `f6884448496ba453572129e8b89fff3a9a3c3e8d`.

## Files added

- `packages/training/scripts/asr/voice_code_bench_gate.py` (265 lines) — runtime-download contract (`besimple-ai/voice-code-bench`, MIT, 300-row test split, required source/audio/reference/entity hashes), 26 `ENTITY_TYPES`, `ctem`/`tsr`/`wer`/`cer` metrics, and publishable-report validation that rejects synthetic/mock/fixture reports.
- `packages/training/scripts/asr/__tests__/test_voice_code_bench_gate.py` (191 lines) — 6 data-free pytest cases (import only `sys` + `pathlib` + the gate module; no torch, no downloads, no audio).
- `packages/training/scripts/asr/README.md` — VoiceCodeBench section + script-table row.
- `.github/issue-evidence/13358-voice-code-bench-gate.md` — issue evidence.

## Verification

```
$ python3 -m pytest packages/training/scripts/asr/__tests__/test_voice_code_bench_gate.py
6 passed in 0.62s
```

`python3 -m compileall` also passes for the gate module. These are data-free unit tests and run without torch or any downloaded audio.

## Scope note

The **real-ASR-run evidence** (running the gate against a live ASR provider on real VoiceCodeBench audio) is separate needs-human work tracked in #13387 and is not part of this land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)