### PR TITLE
fix(#12784): surface slash-command catalog load failure as a distinct UI state

### DIFF
--- a/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
+++ b/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
@@ -149,6 +149,7 @@ describe("useSlashCommandController — catalog load (#11112)", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.commands).toEqual([]);
+    expect(result.current.error).toBe(false);
     expect(consoleError).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });
@@ -164,6 +165,9 @@ describe("useSlashCommandController — catalog load (#11112)", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.commands).toEqual([]);
+    // #12784 three-state: a failed load must be distinguishable from a genuine
+    // empty catalog — `error` is true, not a silent healthy-empty.
+    expect(result.current.error).toBe(true);
     expect(consoleError).toHaveBeenCalledWith(
       expect.stringContaining("[useSlashCommandController]"),
       failure,
@@ -183,10 +187,41 @@ describe("useSlashCommandController — catalog load (#11112)", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.commands.map((c) => c.key)).toEqual(["settings"]);
+    // Partial/degraded load: server catalog rendered, but the failed
+    // custom-actions fetch still raises the error flag (#12784) so the surface
+    // does not imply a complete catalog.
+    expect(result.current.error).toBe(true);
     expect(consoleError).toHaveBeenCalledWith(
       expect.stringContaining("[useSlashCommandController]"),
       failure,
     );
+    consoleError.mockRestore();
+  });
+
+  it("a fully successful load leaves error false even when the catalog is non-empty", async () => {
+    listCommands.mockResolvedValue([cmd({ key: "settings" })]);
+    listCustomActions.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.commands.map((c) => c.key)).toEqual(["settings"]);
+    // Healthy load must NEVER set the error flag (no false-positive degrade).
+    expect(result.current.error).toBe(false);
+  });
+
+  it("both fetches failing surfaces the error with an empty catalog (not a false healthy-empty)", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    listCommands.mockRejectedValue(new Error("catalog down"));
+    listCustomActions.mockRejectedValue(new Error("custom down"));
+
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.commands).toEqual([]);
+    expect(result.current.error).toBe(true);
     consoleError.mockRestore();
   });
 });

--- a/packages/ui/src/chat/useSlashCommandController.ts
+++ b/packages/ui/src/chat/useSlashCommandController.ts
@@ -113,6 +113,16 @@ export interface SlashCommandController {
   /** The merged catalog (server commands + custom actions + saved commands). */
   commands: SlashCommandCatalogItem[];
   loading: boolean;
+  /**
+   * True when the last catalog load failed at the transport/parse layer (the
+   * server command fetch OR the custom-actions fetch threw). Lets the surface
+   * render a distinguishable error state instead of a healthy-empty menu
+   * (#12784 three-state degrade): a network/5xx/parse failure must not
+   * masquerade as a genuinely empty catalog. Locally-derived commands
+   * (saved/custom) still render when only one source failed, so `commands`
+   * may be non-empty while `error` is true (partial/degraded load).
+   */
+  error: boolean;
   /** Whether natural-language navigate/client shortcuts may short-circuit send. */
   naturalShortcutsEnabled: boolean;
   /** Resolve dynamic argument completions for a named source. */
@@ -223,19 +233,26 @@ export function useSlashCommandController(
     SlashCommandCatalogItem[]
   >([]);
   const [loading, setLoading] = React.useState(true);
+  const [loadError, setLoadError] = React.useState(false);
 
   React.useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setLoadError(false);
     void (async () => {
       // Degrade to an empty catalog so the composer keeps working, but SURFACE
       // the failure: a silently-swallowed fetch error is indistinguishable
       // from a genuinely empty catalog (the menu just never mounts), which
-      // made #11112 needlessly hard to diagnose.
+      // made #11112 needlessly hard to diagnose. Beyond the console log we also
+      // raise a user-facing `error` flag (#12784 three-state) so the menu can
+      // show a distinguishable degraded state, not a false healthy-empty.
+      let loadFailed = false;
       const catalog: SlashCommandCatalogItem[] = await client
         .listCommands("gui")
         // error-policy:J4 degrade to an empty catalog with the failure logged
+        // + flagged (not fabricated as a healthy-empty catalog).
         .catch((error: unknown) => {
+          loadFailed = true;
           console.error(
             "[useSlashCommandController] Failed to load the slash-command catalog; slash menu will be empty",
             error,
@@ -244,8 +261,9 @@ export function useSlashCommandController(
         });
       const customActions: CustomActionDef[] = await client
         .listCustomActions()
-        // error-policy:J4 omit custom actions with the failure logged
+        // error-policy:J4 omit custom actions with the failure logged + flagged.
         .catch((error: unknown) => {
+          loadFailed = true;
           console.error(
             "[useSlashCommandController] Failed to load custom actions; omitting them from the slash menu",
             error,
@@ -261,6 +279,7 @@ export function useSlashCommandController(
         .filter((a) => a.enabled)
         .map((a) => customActionToCommand(a.name));
       setCustomCommands([...saved, ...custom]);
+      setLoadError(loadFailed);
       setLoading(false);
     })();
     return () => {
@@ -351,6 +370,7 @@ export function useSlashCommandController(
     () => ({
       commands,
       loading,
+      error: loadError,
       naturalShortcutsEnabled,
       resolveChoices,
       resolveSection: resolveSettingsSectionToken,
@@ -365,6 +385,7 @@ export function useSlashCommandController(
     [
       commands,
       loading,
+      loadError,
       naturalShortcutsEnabled,
       resolveChoices,
       isAuthorized,

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.slash.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.slash.test.tsx
@@ -113,6 +113,7 @@ function makeSlash(
   return {
     commands: COMMANDS,
     loading: false,
+    error: false,
     naturalShortcutsEnabled: false,
     isAuthorized: true,
     isElevated: true,

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.stories.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.stories.tsx
@@ -233,6 +233,7 @@ const SLASH_COMMANDS: SlashCommandCatalogItem[] = [
 const SLASH_CONTROLLER: SlashCommandController = {
   commands: SLASH_COMMANDS,
   loading: false,
+  error: false,
   naturalShortcutsEnabled: false,
   isAuthorized: true,
   isElevated: true,

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -114,6 +114,7 @@ import type { ConversationNav, ShellController } from "./useShellController";
 const EMPTY_SLASH_CONTROLLER: SlashCommandController = {
   commands: [],
   loading: false,
+  error: false,
   naturalShortcutsEnabled: false,
   isAuthorized: false,
   isElevated: false,
@@ -4174,6 +4175,7 @@ export function ContinuousChatOverlay({
                 <SlashCommandMenu
                   state={slashMenu}
                   loading={isSlashDraft && slash.loading}
+                  error={isSlashDraft && slash.error}
                   onPick={pickSlashItem}
                 />
               ) : null}

--- a/packages/ui/src/components/shell/SlashCommandMenu.error-state.test.tsx
+++ b/packages/ui/src/components/shell/SlashCommandMenu.error-state.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+/**
+ * Three-state degrade contract for <SlashCommandMenu> (#12784 split of #12267).
+ *
+ * When the menu is not open, the closed branch must render three DISTINGUISHABLE
+ * states rather than collapsing a failed catalog load into a silent empty menu:
+ *  - loading      -> the "loading commands…" status row
+ *  - error        -> a distinct "couldn't load commands" status row
+ *  - idle/success -> nothing (the menu simply does not mount)
+ *
+ * A failed catalog fetch previously rendered identically to "no commands"
+ * (nothing), so a network/5xx/parse failure was indistinguishable from a
+ * genuinely empty catalog. This pins the visible error affordance.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { SlashCommandMenu, type SlashMenuState } from "./SlashCommandMenu";
+
+function closedState(): SlashMenuState {
+  return {
+    open: false,
+    mode: "none",
+    items: [],
+    activeIndex: 0,
+    headerLabel: "",
+    setActiveIndex: () => {},
+    move: () => {},
+    complete: () => null,
+    resolve: () => null,
+  };
+}
+
+afterEach(() => cleanup());
+
+describe("<SlashCommandMenu> closed-state three-state degrade (#12784)", () => {
+  it("renders nothing when idle (not loading, no error, closed)", () => {
+    const { container } = render(
+      <SlashCommandMenu state={closedState()} onPick={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId("slash-menu-loading")).toBeNull();
+    expect(screen.queryByTestId("slash-menu-error")).toBeNull();
+  });
+
+  it("renders the loading state while the catalog is loading", () => {
+    render(
+      <SlashCommandMenu state={closedState()} onPick={() => {}} loading />,
+    );
+    expect(screen.getByTestId("slash-menu-loading")).toBeTruthy();
+    expect(screen.queryByTestId("slash-menu-error")).toBeNull();
+  });
+
+  it("renders a DISTINCT error state when the catalog load failed", () => {
+    render(<SlashCommandMenu state={closedState()} onPick={() => {}} error />);
+    const err = screen.getByTestId("slash-menu-error");
+    expect(err).toBeTruthy();
+    expect(err.textContent).toContain("couldn't load commands");
+    // Must not be mistaken for loading or an empty/absent menu.
+    expect(screen.queryByTestId("slash-menu-loading")).toBeNull();
+  });
+
+  it("loading takes precedence over error while both are set", () => {
+    render(
+      <SlashCommandMenu
+        state={closedState()}
+        onPick={() => {}}
+        loading
+        error
+      />,
+    );
+    expect(screen.getByTestId("slash-menu-loading")).toBeTruthy();
+    expect(screen.queryByTestId("slash-menu-error")).toBeNull();
+  });
+
+  it("an OPEN menu with a partial load failure surfaces a degraded banner (commands present + error)", () => {
+    const open: SlashMenuState = {
+      ...closedState(),
+      open: true,
+      mode: "command",
+      headerLabel: "Commands",
+      items: [
+        {
+          id: "settings",
+          primary: "/settings",
+          secondary: "Open settings",
+          isCommand: true,
+          hasArgs: false,
+        },
+      ],
+    };
+    render(<SlashCommandMenu state={open} onPick={() => {}} error />);
+    // The closed-only "couldn't load commands" row does not apply, but a
+    // degraded affordance MUST render inside the open list so a partial load
+    // (#12784: commands non-empty while error is true) is distinguishable from
+    // a healthy complete catalog.
+    expect(screen.queryByTestId("slash-menu-error")).toBeNull();
+    expect(screen.getByTestId("slash-command-menu")).toBeTruthy();
+    const partial = screen.getByTestId("slash-menu-partial-error");
+    expect(partial.textContent).toContain("some commands couldn't load");
+  });
+
+  it("an OPEN menu with a healthy load shows NO degraded banner", () => {
+    const open: SlashMenuState = {
+      ...closedState(),
+      open: true,
+      mode: "command",
+      headerLabel: "Commands",
+      items: [
+        {
+          id: "settings",
+          primary: "/settings",
+          secondary: "Open settings",
+          isCommand: true,
+          hasArgs: false,
+        },
+      ],
+    };
+    render(<SlashCommandMenu state={open} onPick={() => {}} />);
+    expect(screen.getByTestId("slash-command-menu")).toBeTruthy();
+    // No false-positive degrade on a healthy catalog.
+    expect(screen.queryByTestId("slash-menu-partial-error")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/shell/SlashCommandMenu.tsx
+++ b/packages/ui/src/components/shell/SlashCommandMenu.tsx
@@ -217,11 +217,18 @@ export function SlashCommandMenu({
   state,
   onPick,
   loading,
+  error,
 }: {
   state: SlashMenuState;
   /** Execute the item at index (Enter/click). */
   onPick: (index: number) => void;
   loading?: boolean;
+  /**
+   * True when the command catalog failed to load (transport/parse). Renders a
+   * distinguishable error state instead of a silent empty menu so a failed
+   * load is not mistaken for "no commands" (#12784 three-state degrade).
+   */
+  error?: boolean;
 }): React.JSX.Element | null {
   const listboxId = "slash-command-listbox";
   if (!state.open) {
@@ -236,6 +243,22 @@ export function SlashCommandMenu({
           data-testid="slash-menu-loading"
         >
           loading commands…
+        </div>
+      );
+    }
+    // Loading takes precedence; once settled, a failed load surfaces here as a
+    // distinct error state rather than an empty/absent menu.
+    if (error) {
+      return (
+        <div
+          className={cn(
+            "absolute bottom-full left-0 right-0 z-10 mb-2 rounded-2xl border border-amber-400/25 bg-black/85 px-4 py-3 text-xs text-amber-200/80",
+            FLOAT_SHADOW,
+          )}
+          role="status"
+          data-testid="slash-menu-error"
+        >
+          couldn't load commands
         </div>
       );
     }
@@ -264,6 +287,22 @@ export function SlashCommandMenu({
       >
         {state.headerLabel}
       </div>
+      {/* #12784 three-state: when the catalog load partially failed but some
+          commands (server/saved) still resolved, the open menu would otherwise
+          look like a complete, healthy list. Surface a degraded affordance so
+          `error === true` is distinguishable even with non-empty `commands`. */}
+      {error ? (
+        <div
+          className={cn(
+            "mx-2 mb-1 rounded-lg border border-amber-400/25 bg-amber-400/5 px-2.5 py-1 text-[10px] text-amber-200/80",
+            FLOAT_SHADOW,
+          )}
+          role="status"
+          data-testid="slash-menu-partial-error"
+        >
+          some commands couldn't load
+        </div>
+      ) : null}
       {state.items.map((item, index) => (
         <Button
           key={item.id}


### PR DESCRIPTION
Split slice of #12784 (fallback-slop UI three-state sweep, from #12267). Non-visual `.ts`/`.tsx` transport slice for the chat composer's slash-command catalog.

## Problem
`useSlashCommandController` loads the slash-command catalog via `client.listCommands()` + `client.listCustomActions()`. A prior sweep annotated the catches (`error-policy:J4`) and added `console.error` logging, but both still degrade a **failed** fetch (network / 5xx / parse) into an empty array, and the controller exposed **no user-facing signal**. Result: a transport failure renders identically to a genuinely empty catalog — the exact #12784 three-state gap (an error state collapsing into a designed-empty state). The `console.error` is developer-only; the UI can't distinguish "no commands" from "couldn't load commands".

## Fix
- Add `error: boolean` to the `SlashCommandController` contract. Each catch now flags the failure (kept `error-policy:J4`) — raised when the server-command fetch **or** the custom-actions fetch throws. Locally-derived saved commands still render on a partial outage, so `commands` may be non-empty while `error` is true (partial/degraded load).
- `SlashCommandMenu` now renders **distinguishable** states:
  - closed + loading → `loading commands…` (unchanged)
  - closed + error → a distinct `couldn't load commands` row (new)
  - **open + error** (commands present) → an inline degraded banner `some commands couldn't load`, so a partial load is not mistaken for a healthy complete catalog. *(Added in response to a codex round-1 P2: the closed-only affordance left the open-menu partial-load case indistinguishable from a healthy list.)*
- Thread `error` from the controller through `ContinuousChatOverlay`; `EMPTY_SLASH_CONTROLLER`, the storybook literal, and the overlay test builder updated to the new contract.

No fabricated success-shaped defaults are introduced; the composer still stays usable on failure (the fix is additive observability of the degraded state).

## Tests (packages/ui)
- `useSlashCommandController.catalog.test.ts` — `error` **false** on empty/healthy loads (no false-positive degrade), **true** on server-fetch failure, custom-actions failure, and both failing (empty catalog + error, not a false healthy-empty).
- `SlashCommandMenu.error-state.test.tsx` (new) — closed idle renders nothing; loading vs error rows are distinct; loading takes precedence; OPEN menu shows the degraded banner only when `error` is true, never on a healthy load.
- 30 targeted tests green (controller 8, menu 7, overlay 15); full slash suite 63/63 green (`slash-menu`, `slash-menu.surface-auth`, `report-shortcut-fired`, `ContinuousChatOverlay.slash`).
- `tsgo --noEmit` clean; biome clean; **codex reviewed** — round-1 P2 (open-menu partial-load affordance) fixed, round-2 clean ("no obvious functional regression").

Forbidden files untouched (vite.config / index.html / client-base / bun.lock / dist). Issue stays open for further #12784 slices.

-- [sol-orch]