### PR TITLE
fix(#13408): resolve mobile bundle workspace packages

### DIFF
--- a/.github/issue-evidence/13408-ios-local-sim-workspace-resolution.md
+++ b/.github/issue-evidence/13408-ios-local-sim-workspace-resolution.md
@@ -1,0 +1,56 @@
+# Issue #13408 — iOS local simulator mobile bundle workspace resolution
+
+Date: 2026-07-04
+
+## Change
+
+- `packages/agent/scripts/build-mobile-bundle.mjs` now falls back from
+  `node_modules/@elizaos/*` to the workspace package tree when resolving
+  mobile bundle source imports.
+- The fallback scans workspace package roots under `packages/*`,
+  `packages/cloud/*`, `packages/native/*`, and `plugins/*` by package name,
+  preserving the existing preference for linked `node_modules` packages.
+- The viem CJS resolver now rejects the incomplete local `dist/node_modules`
+  mirror when it lacks the `_cjs/actions/test` files imported by viem's test
+  decorator, and instead selects the complete installed package from
+  `node_modules/.bun`.
+
+## Verification
+
+- `bunx vitest run packages/agent/scripts/lib/mobile-workspace-resolution.test.mjs`
+  - 1 file / 8 tests passed.
+- `node --check packages/agent/scripts/build-mobile-bundle.mjs`
+  - Passed.
+- `node --check packages/agent/scripts/lib/mobile-workspace-resolution.mjs`
+  - Passed.
+- `bunx @biomejs/biome check packages/agent/scripts/build-mobile-bundle.mjs packages/agent/scripts/lib/mobile-workspace-resolution.mjs packages/agent/scripts/lib/mobile-workspace-resolution.test.mjs`
+  - Passed.
+- `git diff --check`
+  - Passed.
+- `bun run --cwd packages/agent build:ios-bun`
+  - Passed.
+  - Produced `packages/agent/dist-mobile-ios/agent-bundle.js` plus PGlite
+    assets and `plugins-manifest.json`.
+  - Bundle output reported `agent-bundle.js` at 32.05 MB.
+
+## Bundle Failure Regression Covered
+
+The new contract test covers workspace lookup for the packages named in the
+original failure report and follow-up local bundle run:
+
+- `@elizaos/plugin-birdclaw`
+- `@elizaos/plugin-background-runner`
+- `@elizaos/plugin-commands`
+- `@elizaos/plugin-vision`
+- `@elizaos/plugin-wallet`
+- `@elizaos/cloud-routing`
+- `@elizaos/cloud-sdk`
+
+## Not Captured
+
+- Full `bun run --cwd packages/app build:ios:local:sim` was not run on this
+  host because it is Linux (`uname: Linux BEAST ... x86_64`) and has no
+  `xcodebuild`/`xcrun` simulator toolchain.
+- No simulator app path, install, screenshot, or video is attached here. This
+  proves the previously failing agent bundle phase on this host; final
+  non-stale simulator evidence still requires an Xcode runner.

--- a/packages/agent/scripts/build-mobile-bundle.mjs
+++ b/packages/agent/scripts/build-mobile-bundle.mjs
@@ -46,6 +46,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveWorkspacePackageRoot } from "./lib/mobile-workspace-resolution.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const agentRoot = path.resolve(here, "..");
@@ -850,8 +851,10 @@ function findViemPackageRoot() {
       candidates.push(path.join(bunDir, entry, "node_modules", "viem"));
     }
   }
-  return candidates.find((candidate) =>
-    existsSync(path.join(candidate, "_cjs", "chains", "index.js")),
+  return candidates.find(
+    (candidate) =>
+      existsSync(path.join(candidate, "_cjs", "chains", "index.js")) &&
+      existsSync(path.join(candidate, "_cjs", "actions", "test", "reset.js")),
   );
 }
 
@@ -1147,7 +1150,9 @@ const workspaceSrcFallbackPlugin = {
         "node_modules",
         ...pkgName.split("/"),
       );
-      const result = existsSync(pkgPath) ? pkgPath : null;
+      const result = existsSync(pkgPath)
+        ? pkgPath
+        : resolveWorkspacePackageRoot(repoRoot, pkgName);
       cache.set(pkgName, result);
       return result;
     };

--- a/packages/agent/scripts/lib/mobile-workspace-resolution.mjs
+++ b/packages/agent/scripts/lib/mobile-workspace-resolution.mjs
@@ -1,0 +1,47 @@
+/**
+ * Workspace package resolution helpers for the mobile agent bundle.
+ *
+ * Bun.build may run in a fresh or sparse install where a workspace package is
+ * present in the checkout but not linked under node_modules. The mobile bundle
+ * still needs to resolve those package sources without requiring every
+ * workspace package to be built first.
+ */
+import { readdirSync, readFileSync, realpathSync } from "node:fs";
+import path from "node:path";
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function packageMatches(dir, packageName) {
+  const packageJson = readJson(path.join(dir, "package.json"));
+  return packageJson?.name === packageName;
+}
+
+function childDirs(parent) {
+  try {
+    return readdirSync(parent, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(parent, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+export function resolveWorkspacePackageRoot(repoRoot, packageName) {
+  const candidates = [
+    ...childDirs(path.join(repoRoot, "packages")),
+    ...childDirs(path.join(repoRoot, "packages", "cloud")),
+    ...childDirs(path.join(repoRoot, "packages", "native")),
+    ...childDirs(path.join(repoRoot, "plugins")),
+  ];
+
+  const found = candidates.find((candidate) =>
+    packageMatches(candidate, packageName),
+  );
+  return found ? realpathSync(found) : null;
+}

--- a/packages/agent/scripts/lib/mobile-workspace-resolution.test.mjs
+++ b/packages/agent/scripts/lib/mobile-workspace-resolution.test.mjs
@@ -1,0 +1,41 @@
+/**
+ * Contract tests for mobile bundle workspace source fallback resolution.
+ *
+ * These cases mirror the packages that blocked fresh iOS simulator builds in
+ * #13408 when the package existed in the checkout but Bun.build did not resolve
+ * it through the isolated node_modules layout.
+ */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { resolveWorkspacePackageRoot } from "./mobile-workspace-resolution.mjs";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "..",
+);
+
+describe("mobile workspace package resolution", () => {
+  it.each([
+    ["@elizaos/plugin-birdclaw", "plugins/plugin-birdclaw"],
+    ["@elizaos/plugin-background-runner", "plugins/plugin-background-runner"],
+    ["@elizaos/plugin-commands", "plugins/plugin-commands"],
+    ["@elizaos/plugin-vision", "plugins/plugin-vision"],
+    ["@elizaos/plugin-wallet", "plugins/plugin-wallet"],
+    ["@elizaos/cloud-routing", "packages/cloud/routing"],
+    ["@elizaos/cloud-sdk", "packages/cloud/sdk"],
+  ])("finds %s in the workspace tree", (packageName, relativePath) => {
+    expect(resolveWorkspacePackageRoot(repoRoot, packageName)).toBe(
+      path.join(repoRoot, relativePath),
+    );
+  });
+
+  it("returns null for packages outside the workspace", () => {
+    expect(
+      resolveWorkspacePackageRoot(repoRoot, "@elizaos/not-a-package"),
+    ).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary
- add workspace package lookup for the mobile bundle source fallback when @elizaos packages are present in the checkout but not linked under node_modules
- reject the incomplete viem dist/node_modules mirror unless the CJS test action files are present
- add focused contract coverage for the package names from the failing iOS-local simulator bundle path

Refs #13408

## Verification
- bunx vitest run packages/agent/scripts/lib/mobile-workspace-resolution.test.mjs
- node --check packages/agent/scripts/build-mobile-bundle.mjs && node --check packages/agent/scripts/lib/mobile-workspace-resolution.mjs && node --check packages/agent/scripts/lib/mobile-workspace-resolution.test.mjs
- bunx @biomejs/biome check packages/agent/scripts/build-mobile-bundle.mjs packages/agent/scripts/lib/mobile-workspace-resolution.mjs packages/agent/scripts/lib/mobile-workspace-resolution.test.mjs
- git diff --check
- bun run --cwd packages/agent build:ios-bun

## Evidence
- .github/issue-evidence/13408-ios-local-sim-workspace-resolution.md

## Not captured
- Full bun run --cwd packages/app build:ios:local:sim was not run because this host is Linux and has no xcodebuild/xcrun simulator toolchain.
- No simulator install, screenshot, or video is attached. This PR proves the previously failing agent bundle phase; final non-stale simulator proof still needs an Xcode runner.