### PR TITLE
feat(bench): add ZoomGroupStats and VCAPurdue meeting datasets

### DIFF
--- a/.github/issue-evidence/13359-qmsum-meetingbank-adapter-contract.md
+++ b/.github/issue-evidence/13359-qmsum-meetingbank-adapter-contract.md
@@ -1,0 +1,37 @@
+# Issue 13359 - QMSum / MeetingBank Adapter Contract
+
+## Scope
+
+Added a metadata-only adapter contract for QMSum and MeetingBank under
+`packages/benchmarks/meeting-transcription-proof`. The contract records source
+URLs, license/access notes, selected splits, row-selection policy, required
+hashes, `elizaos.meeting_artifact.v1` output schema, scenario-runner metadata,
+score JSON metrics, and eval-only separation without committing raw external
+dataset rows.
+
+## Source Review
+
+- QMSum GitHub checked on 2026-07-04.
+  - Repository license: MIT.
+  - Public README describes 1,808 query-summary pairs over 232 meetings across
+    Academic, Product, and Committee domains.
+  - Data is available under `data/ALL` and domain folders with train/val/test
+    splits.
+- MeetingBank project page checked on 2026-07-04.
+  - Describes 1,366 city-council meetings, more than 3,579 hours of video,
+    transcripts, minutes, agenda, metadata, and 6,892 segment-level
+    summarization instances.
+  - Usage points to Hugging Face, Zenodo, and archive.org resources.
+
+## Validation
+
+- `pytest packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py -q`
+- `python -m compileall packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py`
+- `git diff --check`
+
+## Evidence Boundary
+
+This PR does not claim publishable benchmark scores. #13359 still requires a
+real provider/model run over downloaded rows, source revision and content hashes,
+`elizaos.meeting_artifact.v1` outputs, score JSON, and manually reviewed
+success/failure artifacts.

--- a/.github/issue-evidence/13359-zoomgroupstats-vcapurdue-datasets.md
+++ b/.github/issue-evidence/13359-zoomgroupstats-vcapurdue-datasets.md
@@ -1,0 +1,72 @@
+# Meeting datasets: zoomGroupStats + VCAPurdue (adapters + baselines)
+
+Issue: #13359 (parent #13352). Extends the #13378 meeting dataset adapter contract.
+
+## What was added
+
+Two video-conferencing datasets, each honestly typed to its real modality.
+
+### 1. zoomGroupStats — transcription + diarization (fits the meeting-artifact contract)
+
+- Source: https://github.com/andrewpknight/zoomGroupStats (https://zoomgroupstats.org), **MIT**.
+- New adapter `zoomgroupstats_p0_smoke` appended to
+  `elizaos_meeting_transcription_proof/dataset_adapters.py`
+  (`output_schema = elizaos.meeting_artifact.v1`, `raw_rows_committed = False`).
+- New **executable** importer `zoom_vtt.py`: parses a Zoom `transcript.vtt` (both the
+  classic `Speaker: text` inline form and the newer `<v Speaker>text</v>` voice-tag form)
+  into canonical `eliza.meeting_artifact.v1` transcript spans (ms offsets) + a diarized
+  speaker roster with stable `speaker-<slug>` foreign keys. Unlabeled cues map to
+  `UNIDENTIFIED` (mirrors zoomGroupStats' `userName` NA handling).
+- Because zoomGroupStats' native signal is transcript + **diarization**, the adapter
+  declares the 5 contract-required (reference-free / judge-scored) metrics **plus** its
+  primary gate: `diarization_error_rate`, `transcript_word_error_rate`,
+  `speaker_attribution_accuracy`.
+
+### 2. VCAPurdue — network / QoE (different modality, separate contract)
+
+- Source: https://www.cs.purdue.edu/homes/fahmy/datasets/VCAPurdue/ (Cherian, Prasad,
+  Fahmy, PAM 2026). ~2.6 GB, direct download, **no stated license** (academic-use assumed;
+  cite the paper).
+- **Honest finding:** VCAPurdue has NO audio/speech/speaker labels/transcripts — packet
+  traces + BESS buffer logs + frame-derived QoE (SSIM/PSNR/VIF) for Webex/Meet/Teams/Zoom.
+  It **cannot** benchmark ASR or diarization. Forcing it into the meeting-artifact contract
+  would be dishonest, so it gets a sibling contract `elizaos.vc_network_qoe.v1` in
+  `network_qoe_adapters.py` (adapter `vca_purdue_qoe`, `transcription_usable = False`) for
+  the network-side VC benchmark axis (congestion control, bandwidth adaptation, QoE).
+
+## Baselines (compare.py-style: a reference system, not a fixed number)
+
+- **zoomGroupStats diarization** → DER vs the `pyannote.audio speaker-diarization-3.1`
+  reference used in `packages/benchmarks/voice-speaker-validation` (test DER ≤ 0.45,
+  production target 0.25).
+- **zoomGroupStats transcript** → WER vs a Whisper reference (large-v3 / Groq Whisper
+  cascade), matching `voicebench`.
+- **VCAPurdue** → delta of an elizaOS RTP/capture path vs the dataset's measured per-app
+  behavior under a matched network scenario.
+
+## Data discipline
+
+- **No raw dataset rows committed.** Both adapters are `downloaded-eval`; the only fixture
+  is a **synthetic, self-authored** `fixtures/zoom_transcript_sample.vtt` (not real
+  participant data) that drives the deterministic parser test.
+- Both adapters are `eval_only = True`, `training_allowed = False`.
+
+## Verification
+
+```
+uv run --with pytest python -m pytest packages/benchmarks/meeting-transcription-proof/tests/ -q
+# 46 passed
+```
+
+Covers: contract validity for all three transcript adapters (QMSum/MeetingBank/zoomGroupStats),
+the zoomGroupStats DER/WER baseline, the VTT parser (ordered turns, ms timing, voice-tag form,
+UNIDENTIFIED fallback, canonical segment/foreign-key emission, clamped negative-duration), and
+the VCAPurdue QoE contract (network-QoE modality, data-free, eval-only, reference baseline).
+
+## Follow-ups flagged
+
+- Schema-id mismatch: the TS canonical is `eliza.meeting_artifact.v1`
+  (`packages/shared/src/meeting-artifacts.ts`) but the Python contract uses
+  `elizaos.meeting_artifact.v1`. Reconcile in a follow-up so producers/validators agree.
+- Publishable runs still require a real provider + judge model (per the contract); this PR
+  is the data-free adapter + importer layer, not the live scored run.

--- a/packages/benchmarks/meeting-transcription-proof/README.md
+++ b/packages/benchmarks/meeting-transcription-proof/README.md
@@ -40,6 +40,41 @@ must download the selected rows at runtime, record source revisions and hashes,
 produce meeting artifacts and score JSON, and attach real provider/model outputs
 with manually reviewed representative successes and failures.
 
+### zoomGroupStats (transcription + diarization)
+
+`dataset_adapters.py` also carries `zoomgroupstats_p0_smoke`
+([zoomGroupStats](https://zoomgroupstats.org), MIT). Unlike QMSum/MeetingBank
+(query-summary corpora), its native signal is transcript accuracy + **diarization**,
+so it declares the 5 required (reference-free, judge-scored) metrics plus
+`diarization_error_rate` / `transcript_word_error_rate` /
+`speaker_attribution_accuracy`. `zoom_vtt.py` is the executable importer: it parses a
+Zoom `transcript.vtt` (inline `Speaker: text` and `<v Speaker>text</v>` forms) into
+canonical `eliza.meeting_artifact.v1` transcript spans + a diarized speaker roster with
+stable foreign keys. **Baseline:** DER vs the `pyannote` reference used in
+`voice-speaker-validation`; WER vs a Whisper reference (as in `voicebench`).
+
+```python
+from elizaos_meeting_transcription_proof import parse_zoom_vtt
+segments = parse_zoom_vtt(open("transcript.vtt").read()).to_meeting_artifact_segments()
+# -> {"transcriptSpans": [...], "diarizedSpeakers": [...]}
+```
+
+### VCAPurdue (network / QoE — a different modality)
+
+`network_qoe_adapters.py` carries `vca_purdue_qoe`
+([VCAPurdue](https://www.cs.purdue.edu/homes/fahmy/datasets/VCAPurdue/)). This dataset
+is **network measurement** (packet traces + BESS buffer logs + SSIM/PSNR/VIF QoE for
+Webex/Meet/Teams/Zoom) with **no audio, speech, speaker labels, or transcripts** — it
+**cannot** benchmark ASR or diarization. Rather than misfit it into the meeting-artifact
+contract, it uses a sibling `elizaos.vc_network_qoe.v1` contract for the network-side VC
+benchmark axis (congestion control, bandwidth adaptation, objective video QoE), with the
+dataset's own measured per-app behavior as the reference baseline. For
+transcript+diarization use zoomGroupStats (above) or AMI/ICSI/VoxConverse/DIHARD.
+
+No raw dataset rows are committed for either adapter (`downloaded-eval`); the only
+checked-in sample is a synthetic, self-authored `fixtures/zoom_transcript_sample.vtt`
+that drives the deterministic parser test.
+
 ## Report Contract
 
 The CLI writes `meeting-transcription-proof-report.json`. The scorer accepts two

--- a/packages/benchmarks/meeting-transcription-proof/README.md
+++ b/packages/benchmarks/meeting-transcription-proof/README.md
@@ -27,6 +27,19 @@ python -m benchmarks.orchestrator run \
   --extra '{"lane":"mocked_plumbing"}'
 ```
 
+## QMSum / MeetingBank Adapter Contract
+
+`elizaos_meeting_transcription_proof.dataset_adapters` defines the P0 adapter
+contract for QMSum and MeetingBank without committing raw external data. The
+contract records source URLs, license/access notes, selected splits, row
+selection policy, required content hashes, `elizaos.meeting_artifact.v1` output
+schema, scenario-runner metadata, score JSON metrics, and eval-only separation.
+
+These contracts are not publishable evidence by themselves. A publishable run
+must download the selected rows at runtime, record source revisions and hashes,
+produce meeting artifacts and score JSON, and attach real provider/model outputs
+with manually reviewed representative successes and failures.
+
 ## Report Contract
 
 The CLI writes `meeting-transcription-proof-report.json`. The scorer accepts two

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/__init__.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/__init__.py
@@ -6,6 +6,12 @@ from .network_qoe_adapters import (
     build_qoe_adapter_contract,
     validate_qoe_adapter_contract,
 )
+from .meeting_scoring import (
+    compare_to_baseline,
+    diarization_error_rate,
+    score_transcript,
+    word_error_rate,
+)
 from .zoom_vtt import parse_zoom_vtt
 
 __all__ = [
@@ -17,4 +23,8 @@ __all__ = [
     "build_qoe_adapter_contract",
     "validate_qoe_adapter_contract",
     "parse_zoom_vtt",
+    "score_transcript",
+    "compare_to_baseline",
+    "word_error_rate",
+    "diarization_error_rate",
 ]

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/__init__.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/__init__.py
@@ -1,5 +1,20 @@
 """Meeting transcription proof benchmark package."""
 
 from .cli import build_report, main, validate_manifest
+from .dataset_adapters import build_adapter_contract, validate_adapter_contract
+from .network_qoe_adapters import (
+    build_qoe_adapter_contract,
+    validate_qoe_adapter_contract,
+)
+from .zoom_vtt import parse_zoom_vtt
 
-__all__ = ["build_report", "main", "validate_manifest"]
+__all__ = [
+    "build_report",
+    "main",
+    "validate_manifest",
+    "build_adapter_contract",
+    "validate_adapter_contract",
+    "build_qoe_adapter_contract",
+    "validate_qoe_adapter_contract",
+    "parse_zoom_vtt",
+]

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+ADAPTER_SCHEMA = "elizaos.meeting_dataset_adapter.v1"
+MEETING_ARTIFACT_SCHEMA = "elizaos.meeting_artifact.v1"
+
+REQUIRED_ADAPTER_FIELDS = {
+    "id",
+    "source_url",
+    "license_access",
+    "selected_split",
+    "row_selection",
+    "required_hashes",
+    "output_schema",
+    "scenario_runner",
+    "score_json",
+    "training_eval_separation",
+}
+
+REQUIRED_SCORE_METRICS = {
+    "query_answer_correctness",
+    "quote_grounding",
+    "action_item_extraction",
+    "agenda_topic_coverage",
+    "summary_faithfulness",
+}
+
+ADAPTERS: tuple[dict[str, Any], ...] = (
+    {
+        "id": "qmsum_p0_smoke",
+        "source_url": "https://github.com/Yale-LILY/QMSum",
+        "license_access": {
+            "repo_license": "MIT",
+            "raw_data_policy": "downloaded-eval",
+            "notes": (
+                "QMSum publishes query-summary meeting data in data/ALL and "
+                "domain folders; adapter must download at run time and record "
+                "the exact source revision before scoring."
+            ),
+        },
+        "selected_split": {
+            "dataset": "QMSum",
+            "split": "data/ALL/test",
+            "source_domains": ["Academic", "Product", "Committee"],
+        },
+        "row_selection": {
+            "strategy": "first_n_after_download",
+            "row_count": 10,
+            "row_id_fields": ["meeting_id", "query_id"],
+            "content_hash_fields": [
+                "meeting_transcripts",
+                "general_query_list",
+                "specific_query_list",
+                "topic_list",
+            ],
+            "raw_rows_committed": False,
+        },
+        "required_hashes": [
+            "source_revision",
+            "row_id",
+            "transcript_sha256",
+            "reference_answer_sha256",
+            "adapter_config_sha256",
+        ],
+        "output_schema": MEETING_ARTIFACT_SCHEMA,
+        "scenario_runner": {
+            "kind": "meeting_artifact_eval",
+            "scenario_id_prefix": "qmsum-p0",
+            "input_fields": ["transcript", "query", "reference_answer", "relevant_text_span"],
+            "expected_artifact_fields": [
+                "summary",
+                "answers",
+                "quotes",
+                "action_items",
+                "topics",
+            ],
+        },
+        "score_json": {
+            "metrics": sorted(REQUIRED_SCORE_METRICS),
+            "requires_judge_model": True,
+            "requires_manual_review": True,
+            "publishable_requires_real_provider": True,
+        },
+        "training_eval_separation": {
+            "eval_only": True,
+            "training_allowed": False,
+            "note": "Benchmark rows must not enter training or fine-tuning without explicit approval.",
+        },
+    },
+    {
+        "id": "meetingbank_p0_smoke",
+        "source_url": "https://meetingbank.github.io/",
+        "license_access": {
+            "repo_license": "dataset-specific",
+            "raw_data_policy": "downloaded-eval",
+            "notes": (
+                "MeetingBank provides city-council transcripts, agenda/minutes, "
+                "audio, and videos through Hugging Face, Zenodo, and archive.org; "
+                "adapter must record source URLs and content hashes per selected row."
+            ),
+        },
+        "selected_split": {
+            "dataset": "MeetingBank",
+            "split": "test",
+            "source_domains": ["city_council"],
+        },
+        "row_selection": {
+            "strategy": "first_n_after_download",
+            "row_count": 5,
+            "row_id_fields": ["meeting_id", "segment_id"],
+            "content_hash_fields": ["transcript", "summary", "agenda", "minutes"],
+            "raw_rows_committed": False,
+        },
+        "required_hashes": [
+            "source_revision",
+            "row_id",
+            "transcript_sha256",
+            "reference_summary_sha256",
+            "agenda_sha256",
+            "adapter_config_sha256",
+        ],
+        "output_schema": MEETING_ARTIFACT_SCHEMA,
+        "scenario_runner": {
+            "kind": "meeting_artifact_eval",
+            "scenario_id_prefix": "meetingbank-p0",
+            "input_fields": ["transcript", "agenda", "reference_minutes", "reference_summary"],
+            "expected_artifact_fields": [
+                "summary",
+                "quotes",
+                "action_items",
+                "topics",
+                "decisions",
+            ],
+        },
+        "score_json": {
+            "metrics": sorted(REQUIRED_SCORE_METRICS),
+            "requires_judge_model": True,
+            "requires_manual_review": True,
+            "publishable_requires_real_provider": True,
+        },
+        "training_eval_separation": {
+            "eval_only": True,
+            "training_allowed": False,
+            "note": "City-council benchmark rows stay eval-only unless product/legal approve training use.",
+        },
+    },
+)
+
+
+def build_adapter_contract() -> dict[str, Any]:
+    return {
+        "schema": ADAPTER_SCHEMA,
+        "adapters": deepcopy(list(ADAPTERS)),
+        "raw_data_committed": False,
+        "publishable_run_required": True,
+    }
+
+
+def validate_adapter_contract(contract: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if contract.get("schema") != ADAPTER_SCHEMA:
+        errors.append(f"schema must be {ADAPTER_SCHEMA}")
+    if contract.get("raw_data_committed") is not False:
+        errors.append("raw_data_committed must be false")
+    if contract.get("publishable_run_required") is not True:
+        errors.append("publishable_run_required must be true")
+
+    adapters = contract.get("adapters")
+    if not isinstance(adapters, list) or not adapters:
+        return [*errors, "adapters must be a non-empty array"]
+
+    seen_ids: set[str] = set()
+    for index, adapter in enumerate(adapters):
+        if not isinstance(adapter, dict):
+            errors.append(f"adapters[{index}] must be an object")
+            continue
+        missing = REQUIRED_ADAPTER_FIELDS - set(adapter)
+        if missing:
+            errors.append(f"adapters[{index}] missing fields: {sorted(missing)}")
+        adapter_id = adapter.get("id")
+        if not isinstance(adapter_id, str) or not adapter_id:
+            errors.append(f"adapters[{index}].id must be non-empty")
+        elif adapter_id in seen_ids:
+            errors.append(f"duplicate adapter id: {adapter_id}")
+        else:
+            seen_ids.add(adapter_id)
+        if adapter.get("output_schema") != MEETING_ARTIFACT_SCHEMA:
+            errors.append(f"adapters[{index}].output_schema must be {MEETING_ARTIFACT_SCHEMA}")
+        if adapter.get("license_access", {}).get("raw_data_policy") != "downloaded-eval":
+            errors.append(f"adapters[{index}].license_access.raw_data_policy must be downloaded-eval")
+        row_selection = adapter.get("row_selection", {})
+        if row_selection.get("raw_rows_committed") is not False:
+            errors.append(f"adapters[{index}].row_selection.raw_rows_committed must be false")
+        row_count = row_selection.get("row_count")
+        if isinstance(row_count, bool) or not isinstance(row_count, int) or row_count <= 0:
+            errors.append(f"adapters[{index}].row_selection.row_count must be positive")
+        required_hashes = adapter.get("required_hashes")
+        if not isinstance(required_hashes, list) or "adapter_config_sha256" not in required_hashes:
+            errors.append(f"adapters[{index}].required_hashes must include adapter_config_sha256")
+        score_json = adapter.get("score_json", {})
+        metrics = set(score_json.get("metrics", []))
+        missing_metrics = REQUIRED_SCORE_METRICS - metrics
+        if missing_metrics:
+            errors.append(f"adapters[{index}].score_json missing metrics: {sorted(missing_metrics)}")
+        if score_json.get("publishable_requires_real_provider") is not True:
+            errors.append(f"adapters[{index}].score_json.publishable_requires_real_provider must be true")
+        separation = adapter.get("training_eval_separation", {})
+        if separation.get("eval_only") is not True or separation.get("training_allowed") is not False:
+            errors.append(f"adapters[{index}].training_eval_separation must be eval-only")
+    return errors

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
@@ -1,3 +1,10 @@
+"""Dataset adapter contracts for meeting artifact benchmark sources.
+
+The module records the publishable-run metadata required to adapt QMSum and
+MeetingBank without committing raw rows, and validates the contract shape that
+real benchmark runs must satisfy.
+"""
+
 from __future__ import annotations
 
 from copy import deepcopy

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
@@ -188,9 +188,16 @@ def validate_adapter_contract(contract: dict[str, Any]) -> list[str]:
             seen_ids.add(adapter_id)
         if adapter.get("output_schema") != MEETING_ARTIFACT_SCHEMA:
             errors.append(f"adapters[{index}].output_schema must be {MEETING_ARTIFACT_SCHEMA}")
-        if adapter.get("license_access", {}).get("raw_data_policy") != "downloaded-eval":
+        license_access = adapter.get("license_access")
+        if not isinstance(license_access, dict):
+            errors.append(f"adapters[{index}].license_access must be an object")
+            license_access = {}
+        if license_access.get("raw_data_policy") != "downloaded-eval":
             errors.append(f"adapters[{index}].license_access.raw_data_policy must be downloaded-eval")
-        row_selection = adapter.get("row_selection", {})
+        row_selection = adapter.get("row_selection")
+        if not isinstance(row_selection, dict):
+            errors.append(f"adapters[{index}].row_selection must be an object")
+            row_selection = {}
         if row_selection.get("raw_rows_committed") is not False:
             errors.append(f"adapters[{index}].row_selection.raw_rows_committed must be false")
         row_count = row_selection.get("row_count")
@@ -199,14 +206,21 @@ def validate_adapter_contract(contract: dict[str, Any]) -> list[str]:
         required_hashes = adapter.get("required_hashes")
         if not isinstance(required_hashes, list) or "adapter_config_sha256" not in required_hashes:
             errors.append(f"adapters[{index}].required_hashes must include adapter_config_sha256")
-        score_json = adapter.get("score_json", {})
-        metrics = set(score_json.get("metrics", []))
+        score_json = adapter.get("score_json")
+        if not isinstance(score_json, dict):
+            errors.append(f"adapters[{index}].score_json must be an object")
+            score_json = {}
+        metrics_raw = score_json.get("metrics")
+        metrics = set(metrics_raw) if isinstance(metrics_raw, list) else set()
         missing_metrics = REQUIRED_SCORE_METRICS - metrics
         if missing_metrics:
             errors.append(f"adapters[{index}].score_json missing metrics: {sorted(missing_metrics)}")
         if score_json.get("publishable_requires_real_provider") is not True:
             errors.append(f"adapters[{index}].score_json.publishable_requires_real_provider must be true")
-        separation = adapter.get("training_eval_separation", {})
+        separation = adapter.get("training_eval_separation")
+        if not isinstance(separation, dict):
+            errors.append(f"adapters[{index}].training_eval_separation must be an object")
+            separation = {}
         if separation.get("eval_only") is not True or separation.get("training_allowed") is not False:
             errors.append(f"adapters[{index}].training_eval_separation must be eval-only")
     return errors

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
@@ -153,6 +153,99 @@ ADAPTERS: tuple[dict[str, Any], ...] = (
             "note": "City-council benchmark rows stay eval-only unless product/legal approve training use.",
         },
     },
+    {
+        # zoomGroupStats (https://zoomgroupstats.org, MIT) turns Zoom cloud-recording
+        # exports into datasets. Its `transcript.vtt` maps 1:1 to canonical speaker
+        # turns, so unlike QMSum/MeetingBank (query-summary corpora) this adapter's
+        # native signal is transcript accuracy + DIARIZATION — the summarization
+        # metrics below are reference-free (judge-scored against the transcript), and
+        # the diarization/WER metrics are the primary gate. See zoom_vtt.py for the
+        # executable .vtt -> meeting-artifact importer.
+        "id": "zoomgroupstats_p0_smoke",
+        "source_url": "https://github.com/andrewpknight/zoomGroupStats",
+        "task_family": "transcription_diarization",
+        "license_access": {
+            "repo_license": "MIT",
+            "raw_data_policy": "downloaded-eval",
+            "notes": (
+                "zoomGroupStats is MIT-licensed and ships sample exports under "
+                "inst/extdata (meeting001-003 transcript.vtt/chat.txt/participants.csv) "
+                "usable with no Zoom account; real rows are a user's own Zoom cloud "
+                "recording (transcript.vtt from Recordings, participants.csv from "
+                "Reports), downloaded at run time. Raw rows are never committed; a "
+                "synthetic MIT-clean .vtt fixture drives the deterministic parser test."
+            ),
+        },
+        "selected_split": {
+            "dataset": "zoomGroupStats",
+            "split": "inst/extdata",
+            "source_domains": ["zoom_cloud_recording"],
+        },
+        "row_selection": {
+            "strategy": "first_n_after_download",
+            "row_count": 3,
+            "row_id_fields": ["meeting_id"],
+            "content_hash_fields": ["transcript_vtt", "participants_csv"],
+            "raw_rows_committed": False,
+        },
+        "required_hashes": [
+            "source_revision",
+            "row_id",
+            "transcript_sha256",
+            "participants_sha256",
+            "adapter_config_sha256",
+        ],
+        "output_schema": MEETING_ARTIFACT_SCHEMA,
+        "scenario_runner": {
+            "kind": "meeting_artifact_eval",
+            "scenario_id_prefix": "zoomgroupstats-p0",
+            "input_fields": ["transcript_vtt", "participants_csv"],
+            "expected_artifact_fields": [
+                "transcriptSpans",
+                "diarizedSpeakers",
+                "summary",
+                "action_items",
+                "topics",
+            ],
+        },
+        "score_json": {
+            # The 5 contract-required (reference-free / judge-scored) metrics ...
+            "metrics": sorted(
+                REQUIRED_SCORE_METRICS
+                # ... plus this adapter's PRIMARY transcription/diarization gate.
+                | {
+                    "diarization_error_rate",
+                    "transcript_word_error_rate",
+                    "speaker_attribution_accuracy",
+                }
+            ),
+            "primary_metrics": [
+                "diarization_error_rate",
+                "speaker_attribution_accuracy",
+                "transcript_word_error_rate",
+            ],
+            "baseline": {
+                # compare.py-style baseline: a reference system, not a fixed number.
+                "diarization_reference": "pyannote.audio speaker-diarization-3.1",
+                "transcript_reference": "whisper (large-v3) / Groq Whisper cascade",
+                "note": (
+                    "Diarization scored as DER vs the pyannote reference used in "
+                    "packages/benchmarks/voice-speaker-validation (test DER<=0.45, "
+                    "production target 0.25); transcript scored as WER vs a Whisper "
+                    "reference like voicebench. Summarization metrics are reference-"
+                    "free judge scores over the produced transcript."
+                ),
+            },
+            "requires_judge_model": True,
+            "requires_manual_review": True,
+            "publishable_requires_real_provider": True,
+        },
+        "training_eval_separation": {
+            "eval_only": True,
+            "training_allowed": False,
+            "note": "Zoom recordings are participant data; eval-only, never training, without explicit consent + approval.",
+        },
+    },
 )
 
 

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/meeting_scoring.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/meeting_scoring.py
@@ -1,0 +1,236 @@
+"""Deterministic meeting transcription/diarization scoring + baseline comparison.
+
+Model-free metric computation for the meeting benchmark: given a *reference*
+speaker-turn set (e.g. a Zoom ``transcript.vtt`` parsed by ``zoom_vtt.py``) and a
+*hypothesis* set (a system-under-test's transcript/diarization output), compute:
+
+  * ``word_error_rate`` — token-level Levenshtein / reference length (the
+    ``voicebench`` definition);
+  * ``diarization_error_rate`` — (missed + false-alarm + confusion) time over
+    total reference speech time, under the speaker label mapping that maximises
+    overlap (the standard DER shape used by ``voice-speaker-validation`` /
+    pyannote; mapping here is greedy, which matches optimal for the
+    non-overlapping meeting-turn case);
+  * ``speaker_attribution_accuracy`` — fraction of reference speech time whose
+    mapped hypothesis speaker is correct.
+
+``compare_to_baseline`` renders a ``compare.py``-style report (candidate vs a
+reference/baseline system, with per-metric deltas and an overall pass), so a
+publishable run compares an elizaOS transcript/diarization path to a Whisper/
+pyannote baseline rather than to a fabricated number.
+
+Everything here is deterministic and needs no model or audio — the scoring is
+exercised against synthetic span sets in the tests. Producing the *hypothesis*
+from real audio (running an ASR/diarizer) is the human-gated publishable step.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+# A scored span is any object exposing start_ms/end_ms/text/speaker; we accept
+# either the zoom_vtt.TranscriptSpan dataclass or a plain dict-like via keys.
+
+
+@dataclass(frozen=True)
+class Span:
+    start_ms: int
+    end_ms: int
+    text: str
+    speaker: str
+
+    @property
+    def duration_ms(self) -> int:
+        return max(0, self.end_ms - self.start_ms)
+
+
+def _coerce(span: object) -> Span:
+    if isinstance(span, Span):
+        return span
+    if isinstance(span, dict):
+        return Span(
+            start_ms=int(span["startMs" if "startMs" in span else "start_ms"]),
+            end_ms=int(span["endMs" if "endMs" in span else "end_ms"]),
+            text=str(span.get("text", "")),
+            speaker=str(
+                span.get("speakerId")
+                or span.get("speaker")
+                or span.get("speaker_label")
+                or "UNIDENTIFIED"
+            ),
+        )
+    # zoom_vtt.TranscriptSpan (has speaker_label, no speaker field)
+    return Span(
+        start_ms=int(getattr(span, "start_ms")),
+        end_ms=int(getattr(span, "end_ms")),
+        text=str(getattr(span, "text", "")),
+        speaker=str(getattr(span, "speaker_label", getattr(span, "speaker", "UNIDENTIFIED"))),
+    )
+
+
+def _spans(seq: Iterable[object]) -> list[Span]:
+    return [_coerce(s) for s in seq]
+
+
+def _tokenize(text: str) -> list[str]:
+    return text.lower().split()
+
+
+def _levenshtein(ref: Sequence[str], hyp: Sequence[str]) -> int:
+    """Edit distance (substitutions + insertions + deletions) over token lists."""
+    prev = list(range(len(hyp) + 1))
+    for i, r in enumerate(ref, start=1):
+        cur = [i]
+        for j, h in enumerate(hyp, start=1):
+            cost = 0 if r == h else 1
+            cur.append(min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost))
+        prev = cur
+    return prev[-1]
+
+
+def word_error_rate(reference_text: str, hypothesis_text: str) -> float:
+    ref = _tokenize(reference_text)
+    hyp = _tokenize(hypothesis_text)
+    if not ref:
+        return 0.0 if not hyp else 1.0
+    return _levenshtein(ref, hyp) / len(ref)
+
+
+def transcript_wer(reference: Iterable[object], hypothesis: Iterable[object]) -> float:
+    """WER over the concatenated span texts (turn order preserved)."""
+    ref_text = " ".join(s.text for s in _spans(reference))
+    hyp_text = " ".join(s.text for s in _spans(hypothesis))
+    return word_error_rate(ref_text, hyp_text)
+
+
+def _overlap_ms(a: Span, b: Span) -> int:
+    return max(0, min(a.end_ms, b.end_ms) - max(a.start_ms, b.start_ms))
+
+
+def _greedy_speaker_mapping(
+    ref: list[Span], hyp: list[Span]
+) -> dict[str, str]:
+    """Map each hyp speaker to the ref speaker it overlaps most (greedy, 1:1)."""
+    overlap: dict[tuple[str, str], int] = {}
+    for h in hyp:
+        for r in ref:
+            ms = _overlap_ms(h, r)
+            if ms:
+                overlap[(h.speaker, r.speaker)] = overlap.get((h.speaker, r.speaker), 0) + ms
+    mapping: dict[str, str] = {}
+    used_ref: set[str] = set()
+    for (h_spk, r_spk), _ms in sorted(overlap.items(), key=lambda kv: -kv[1]):
+        if h_spk in mapping or r_spk in used_ref:
+            continue
+        mapping[h_spk] = r_spk
+        used_ref.add(r_spk)
+    return mapping
+
+
+def diarization_error_rate(reference: Iterable[object], hypothesis: Iterable[object]) -> float:
+    """Standard DER = (missed + false_alarm + confusion) / total reference speech.
+
+    Assumes non-overlapping turns (the meeting-transcript case): at each instant
+    at most one reference and one hypothesis speaker are active.
+    """
+    ref = _spans(reference)
+    hyp = _spans(hypothesis)
+    total_ref = sum(s.duration_ms for s in ref)
+    if total_ref == 0:
+        return 0.0
+    mapping = _greedy_speaker_mapping(ref, hyp)
+
+    missed = 0
+    confusion = 0
+    for r in ref:
+        covered = 0
+        correct = 0
+        for h in hyp:
+            ms = _overlap_ms(r, h)
+            if not ms:
+                continue
+            covered += ms
+            if mapping.get(h.speaker) == r.speaker:
+                correct += ms
+        missed += r.duration_ms - covered  # ref speech with no hyp
+        confusion += covered - correct  # covered but wrong speaker
+    total_hyp = sum(s.duration_ms for s in hyp)
+    # False alarm: hyp speech outside any ref span.
+    fa = 0
+    for h in hyp:
+        overlapped = sum(_overlap_ms(h, r) for r in ref)
+        fa += h.duration_ms - overlapped
+    _ = total_hyp
+    return (missed + fa + confusion) / total_ref
+
+
+def speaker_attribution_accuracy(
+    reference: Iterable[object], hypothesis: Iterable[object]
+) -> float:
+    """Fraction of reference speech time whose mapped hyp speaker is correct."""
+    ref = _spans(reference)
+    hyp = _spans(hypothesis)
+    total_ref = sum(s.duration_ms for s in ref)
+    if total_ref == 0:
+        return 1.0
+    mapping = _greedy_speaker_mapping(ref, hyp)
+    correct = 0
+    for r in ref:
+        for h in hyp:
+            ms = _overlap_ms(r, h)
+            if ms and mapping.get(h.speaker) == r.speaker:
+                correct += ms
+    return correct / total_ref
+
+
+def score_transcript(reference: Iterable[object], hypothesis: Iterable[object]) -> dict:
+    """All three deterministic metrics for one (reference, hypothesis) pair."""
+    ref = list(reference)
+    hyp = list(hypothesis)
+    return {
+        "transcript_word_error_rate": round(transcript_wer(ref, hyp), 6),
+        "diarization_error_rate": round(diarization_error_rate(ref, hyp), 6),
+        "speaker_attribution_accuracy": round(speaker_attribution_accuracy(ref, hyp), 6),
+    }
+
+
+# Lower-is-better metrics (a smaller candidate value is an improvement).
+_LOWER_IS_BETTER = {"transcript_word_error_rate", "diarization_error_rate"}
+
+
+def compare_to_baseline(
+    reference: Iterable[object],
+    candidate_hypothesis: Iterable[object],
+    baseline_hypothesis: Iterable[object],
+    noise_threshold: float = 0.01,
+) -> dict:
+    """compare.py-style report: candidate vs a baseline system on the same reference.
+
+    ``baseline_hypothesis`` is a reference system's output (e.g. Whisper +
+    pyannote), NOT a fabricated number. ``passed`` is True when the candidate is
+    no worse than the baseline beyond ``noise_threshold`` on every metric.
+    """
+    ref = list(reference)
+    cand = score_transcript(ref, list(candidate_hypothesis))
+    base = score_transcript(ref, list(baseline_hypothesis))
+    metrics = {}
+    overall_pass = True
+    for name in cand:
+        c, b = cand[name], base[name]
+        # Normalise so "delta >= -threshold means pass" holds for both directions.
+        improvement = (b - c) if name in _LOWER_IS_BETTER else (c - b)
+        passed = improvement >= -noise_threshold
+        overall_pass = overall_pass and passed
+        metrics[name] = {
+            "candidate": c,
+            "baseline": b,
+            "improvement": round(improvement, 6),
+            "lower_is_better": name in _LOWER_IS_BETTER,
+            "passed": passed,
+        }
+    return {
+        "metrics": metrics,
+        "noise_threshold": noise_threshold,
+        "passed": overall_pass,
+    }

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/network_qoe_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/network_qoe_adapters.py
@@ -1,0 +1,198 @@
+"""Network-QoE video-conferencing dataset adapters (distinct modality).
+
+Some video-conferencing datasets carry no audio/speech/transcript and so cannot
+feed the meeting-artifact transcription/diarization benchmark. VCAPurdue is one:
+it is a network measurement corpus — packet traces, BESS-switch buffer logs, and
+frame-derived video-QoE metrics (SSIM/PSNR/VIF) captured from Cisco Webex, Google
+Meet, Microsoft Teams, and Zoom under controlled network conditions
+(https://www.cs.purdue.edu/homes/fahmy/datasets/VCAPurdue/).
+
+Forcing it into ``elizaos.meeting_dataset_adapter.v1`` (which requires an
+``elizaos.meeting_artifact.v1`` transcript output) would be dishonest — there is
+no transcript to produce. Instead this module defines a sibling contract,
+``elizaos.vc_network_qoe.v1``, for the network/QoE benchmark axis: how well an
+elizaOS-hosted VC/RTP path (or an on-device capture pipeline) behaves for
+congestion control, bandwidth adaptation, and objective video quality under
+adverse networks — measured against the dataset's per-app reference behavior.
+
+Same discipline as the transcript adapters: raw rows are never committed
+(downloaded at run time), metrics are declared, and the baseline is a reference
+system (the dataset's own per-app measured behavior), not a fabricated number.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+VC_QOE_ADAPTER_SCHEMA = "elizaos.vc_network_qoe.v1"
+
+REQUIRED_QOE_ADAPTER_FIELDS = {
+    "id",
+    "source_url",
+    "modality",
+    "license_access",
+    "apps_covered",
+    "scenarios",
+    "row_selection",
+    "required_hashes",
+    "metrics",
+    "baseline",
+    "training_eval_separation",
+}
+
+# Objective network + video-QoE metrics VCAPurdue can gate.
+REQUIRED_QOE_METRICS = {
+    "throughput_kbps",
+    "one_way_latency_ms",
+    "packet_loss_rate",
+    "rebuffer_ratio",
+    "ssim",
+    "psnr_db",
+    "vif",
+}
+
+QOE_ADAPTERS: tuple[dict[str, Any], ...] = (
+    {
+        "id": "vca_purdue_qoe",
+        "source_url": "https://www.cs.purdue.edu/homes/fahmy/datasets/VCAPurdue/",
+        "download_url": "http://www.cs.purdue.edu/homes/fahmy/datasets/VCAPurdue/pam2026.zip",
+        "modality": "network_qoe",
+        "license_access": {
+            "repo_license": "unspecified",
+            "raw_data_policy": "downloaded-eval",
+            "notes": (
+                "No explicit license/terms posted on the dataset page (~2.6 GB zip, "
+                "direct download, no login). Treat as academic-use; cite Cherian, "
+                "Prasad, Fahmy, 'A Microscopic View of Congestion Control Behavior in "
+                "Video Conferencing Applications', PAM 2026. Confirm redistribution "
+                "terms with the authors (prasad67@purdue.edu) before caching. Raw "
+                "traces/logs are never committed to this repo."
+            ),
+        },
+        "apps_covered": ["webex", "google_meet", "microsoft_teams", "zoom"],
+        "scenarios": [
+            "constant_bandwidth",
+            "changing_bandwidth",
+            "tcp_background_traffic",
+            "udp_background_traffic",
+        ],
+        "per_sample_files": {
+            "traffic_csv": 4,  # in/out x before/after buffer; 5-tuple flow + RTP meta
+            "buffer_log": 2,  # BESS switch queue occupancy + packet loss
+            "qoe_csv": 1,  # frame-level latency, SSIM, PSNR, VIF
+        },
+        "row_selection": {
+            "strategy": "per_app_per_scenario_after_download",
+            "row_count": 8,  # 4 apps x 2 representative scenarios for the smoke gate
+            "row_id_fields": ["app", "scenario", "capture_id"],
+            "content_hash_fields": ["traffic_csv", "buffer_log", "qoe_csv"],
+            "raw_rows_committed": False,
+        },
+        "required_hashes": [
+            "source_revision",
+            "row_id",
+            "traffic_csv_sha256",
+            "qoe_csv_sha256",
+            "adapter_config_sha256",
+        ],
+        "metrics": sorted(REQUIRED_QOE_METRICS),
+        "baseline": {
+            # The dataset's own measured per-app behavior is the reference; an
+            # elizaOS VC/RTP path is compared to it under the same scenario, the
+            # compare.py way (delta vs a reference system, not a fixed number).
+            "kind": "reference_system_per_app",
+            "reference": "VCAPurdue measured Webex/Meet/Teams/Zoom behavior",
+            "comparison": "delta of elizaOS RTP path vs dataset app under matched scenario",
+            "note": (
+                "Not a transcription baseline. Gates network-side VC quality: "
+                "congestion-control responsiveness, bandwidth-probe behavior, "
+                "loss/latency under adverse networks, and objective video QoE."
+            ),
+        },
+        "training_eval_separation": {
+            "eval_only": True,
+            "training_allowed": False,
+            "note": "Network measurement corpus; eval-only.",
+        },
+        "transcription_usable": False,
+        "usability_note": (
+            "VCAPurdue has NO audio/speech/speaker labels/transcripts, so it cannot "
+            "benchmark ASR or diarization. For transcript+diarization use "
+            "zoomgroupstats_p0_smoke (this package) or AMI/ICSI/VoxConverse/DIHARD."
+        ),
+    },
+)
+
+
+def build_qoe_adapter_contract() -> dict[str, Any]:
+    return {
+        "schema": VC_QOE_ADAPTER_SCHEMA,
+        "adapters": deepcopy(list(QOE_ADAPTERS)),
+        "raw_data_committed": False,
+        "publishable_run_required": True,
+    }
+
+
+def validate_qoe_adapter_contract(contract: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if contract.get("schema") != VC_QOE_ADAPTER_SCHEMA:
+        errors.append(f"schema must be {VC_QOE_ADAPTER_SCHEMA}")
+    if contract.get("raw_data_committed") is not False:
+        errors.append("raw_data_committed must be false")
+    if contract.get("publishable_run_required") is not True:
+        errors.append("publishable_run_required must be true")
+
+    adapters = contract.get("adapters")
+    if not isinstance(adapters, list) or not adapters:
+        return [*errors, "adapters must be a non-empty array"]
+
+    seen_ids: set[str] = set()
+    for index, adapter in enumerate(adapters):
+        if not isinstance(adapter, dict):
+            errors.append(f"adapters[{index}] must be an object")
+            continue
+        missing = REQUIRED_QOE_ADAPTER_FIELDS - set(adapter)
+        if missing:
+            errors.append(f"adapters[{index}] missing fields: {sorted(missing)}")
+        adapter_id = adapter.get("id")
+        if not isinstance(adapter_id, str) or not adapter_id:
+            errors.append(f"adapters[{index}].id must be non-empty")
+        elif adapter_id in seen_ids:
+            errors.append(f"duplicate adapter id: {adapter_id}")
+        else:
+            seen_ids.add(adapter_id)
+        if adapter.get("modality") != "network_qoe":
+            errors.append(f"adapters[{index}].modality must be network_qoe")
+        license_access = adapter.get("license_access")
+        if not isinstance(license_access, dict):
+            errors.append(f"adapters[{index}].license_access must be an object")
+            license_access = {}
+        if license_access.get("raw_data_policy") != "downloaded-eval":
+            errors.append(f"adapters[{index}].license_access.raw_data_policy must be downloaded-eval")
+        row_selection = adapter.get("row_selection")
+        if not isinstance(row_selection, dict):
+            errors.append(f"adapters[{index}].row_selection must be an object")
+            row_selection = {}
+        if row_selection.get("raw_rows_committed") is not False:
+            errors.append(f"adapters[{index}].row_selection.raw_rows_committed must be false")
+        row_count = row_selection.get("row_count")
+        if isinstance(row_count, bool) or not isinstance(row_count, int) or row_count <= 0:
+            errors.append(f"adapters[{index}].row_selection.row_count must be positive")
+        required_hashes = adapter.get("required_hashes")
+        if not isinstance(required_hashes, list) or "adapter_config_sha256" not in required_hashes:
+            errors.append(f"adapters[{index}].required_hashes must include adapter_config_sha256")
+        metrics = adapter.get("metrics")
+        metric_set = set(metrics) if isinstance(metrics, list) else set()
+        missing_metrics = REQUIRED_QOE_METRICS - metric_set
+        if missing_metrics:
+            errors.append(f"adapters[{index}].metrics missing: {sorted(missing_metrics)}")
+        if not isinstance(adapter.get("baseline"), dict):
+            errors.append(f"adapters[{index}].baseline must be an object")
+        separation = adapter.get("training_eval_separation")
+        if not isinstance(separation, dict):
+            errors.append(f"adapters[{index}].training_eval_separation must be an object")
+            separation = {}
+        if separation.get("eval_only") is not True or separation.get("training_allowed") is not False:
+            errors.append(f"adapters[{index}].training_eval_separation must be eval-only")
+    return errors

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/zoom_vtt.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/zoom_vtt.py
@@ -1,0 +1,175 @@
+"""Zoom / zoomGroupStats WebVTT transcript importer.
+
+Parses a Zoom cloud-recording ``transcript.vtt`` (the same format the MIT-licensed
+zoomGroupStats R package ingests, https://zoomgroupstats.org) into the canonical
+elizaOS meeting-artifact transcript shape: one speaker turn per cue, with
+millisecond offsets and a diarized-speaker roster derived from the cue labels.
+
+Zoom cues come in two flavours, both handled here:
+
+  * inline label  — ``Speaker Name: spoken text`` in the cue body (classic export,
+    what zoomGroupStats' ``processZoomTranscript`` reads);
+  * WebVTT voice tag — ``<v Speaker Name>spoken text</v>`` (newer exports).
+
+A cue with no resolvable label maps to the ``UNIDENTIFIED`` speaker, mirroring
+zoomGroupStats' ``userName`` NA handling, so downstream diarization scoring can
+still count the turn. This module is pure/deterministic and does no network I/O:
+the raw corpus is downloaded at run time or read from a fixture and is never
+committed (per the dataset adapter contract).
+
+Output records are intentionally the transcript-span subset of
+``eliza.meeting_artifact.v1`` (packages/shared/src/meeting-artifacts.ts) that a
+``.vtt`` can support: ``startMs``/``endMs``/``text``/``speakerId``. Fields that a
+raw transcript cannot supply (word-level timing, confidence, overlap, media
+provenance) are left to the emitting product runtime, not fabricated here.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Iterable
+
+# ``HH:MM:SS.mmm`` (Zoom always emits the hours field and 3-digit millis).
+_TIMESTAMP = re.compile(r"^(\d{2}):(\d{2}):(\d{2})\.(\d{3})$")
+_CUE_TIMING = re.compile(
+    r"^\s*(\d{2}:\d{2}:\d{2}\.\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}\.\d{3})"
+)
+_VOICE_TAG = re.compile(r"^<v\s+([^>]+)>(.*?)(?:</v>)?\s*$", re.DOTALL)
+_INLINE_LABEL = re.compile(r"^([^:]{1,80}?):\s+(.*)$", re.DOTALL)
+
+UNIDENTIFIED = "UNIDENTIFIED"
+
+
+@dataclass(frozen=True)
+class TranscriptSpan:
+    """One speaker turn — the canonical meeting-artifact transcript-span subset."""
+
+    start_ms: int
+    end_ms: int
+    text: str
+    speaker_label: str
+
+    def to_artifact_span(self, span_id: str, speaker_id: str) -> dict:
+        """Render as an ``eliza.meeting_artifact.v1`` transcriptSpans[] entry."""
+        return {
+            "id": span_id,
+            "startMs": self.start_ms,
+            "endMs": self.end_ms,
+            "text": self.text,
+            "speakerId": speaker_id,
+        }
+
+
+@dataclass
+class ParsedTranscript:
+    spans: list[TranscriptSpan] = field(default_factory=list)
+
+    @property
+    def speaker_labels(self) -> list[str]:
+        """Distinct speaker labels in first-appearance order (diarization roster)."""
+        seen: dict[str, None] = {}
+        for span in self.spans:
+            seen.setdefault(span.speaker_label, None)
+        return list(seen)
+
+    def to_meeting_artifact_segments(self) -> dict:
+        """Canonical transcriptSpans[] + diarizedSpeakers[] for a MeetingArtifact.
+
+        Speaker ids are stable (``speaker-<slug>``) so repeated runs over the same
+        transcript produce identical foreign keys — required for deterministic
+        diarization scoring.
+        """
+        speaker_ids = {
+            label: f"speaker-{_slug(label)}" for label in self.speaker_labels
+        }
+        diarized = [
+            {
+                "id": speaker_ids[label],
+                "sourceStreamIds": [],
+                "name": {
+                    "displayName": None if label == UNIDENTIFIED else label,
+                    "provenance": "unknown" if label == UNIDENTIFIED else "platform",
+                    "confidence": 0.0 if label == UNIDENTIFIED else 1.0,
+                },
+                "status": "unresolved" if label == UNIDENTIFIED else "resolved",
+            }
+            for label in self.speaker_labels
+        ]
+        spans = [
+            span.to_artifact_span(f"span-{index}", speaker_ids[span.speaker_label])
+            for index, span in enumerate(self.spans)
+        ]
+        return {"transcriptSpans": spans, "diarizedSpeakers": diarized}
+
+
+def _slug(label: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-")
+    return slug or "unidentified"
+
+
+def _timestamp_to_ms(value: str) -> int:
+    match = _TIMESTAMP.match(value)
+    if not match:
+        raise ValueError(f"invalid WebVTT timestamp: {value!r}")
+    hours, minutes, seconds, millis = (int(part) for part in match.groups())
+    return ((hours * 60 + minutes) * 60 + seconds) * 1000 + millis
+
+
+def _split_label(body: str) -> tuple[str, str]:
+    """Return ``(speaker_label, text)`` for a cue body, falling back to UNIDENTIFIED."""
+    voice = _VOICE_TAG.match(body)
+    if voice:
+        label = voice.group(1).strip()
+        return (label or UNIDENTIFIED, voice.group(2).strip())
+    inline = _INLINE_LABEL.match(body)
+    if inline:
+        label = inline.group(1).strip()
+        # Reject a timestamp-looking prefix (rare malformed cue) as a non-label.
+        if label and not _TIMESTAMP.match(label):
+            return (label, inline.group(2).strip())
+    return (UNIDENTIFIED, body.strip())
+
+
+def parse_zoom_vtt(text: str) -> ParsedTranscript:
+    """Parse a Zoom ``transcript.vtt`` string into ordered speaker-turn spans.
+
+    Tolerant of the ``WEBVTT`` header, blank separators, optional numeric cue ids,
+    and multi-line cue bodies. End timestamps are clamped to be >= start so a
+    malformed cue never yields a negative-duration span.
+    """
+    transcript = ParsedTranscript()
+    lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    index = 0
+    total = len(lines)
+    while index < total:
+        line = lines[index].strip()
+        index += 1
+        timing = _CUE_TIMING.match(line)
+        if not timing:
+            continue
+        start_ms = _timestamp_to_ms(timing.group(1))
+        end_ms = max(_timestamp_to_ms(timing.group(2)), start_ms)
+        body_lines: list[str] = []
+        while index < total and lines[index].strip() != "":
+            body_lines.append(lines[index].strip())
+            index += 1
+        if not body_lines:
+            continue
+        speaker_label, spoken = _split_label("\n".join(body_lines))
+        if not spoken:
+            continue
+        transcript.spans.append(
+            TranscriptSpan(
+                start_ms=start_ms,
+                end_ms=end_ms,
+                text=spoken,
+                speaker_label=speaker_label,
+            )
+        )
+    return transcript
+
+
+def iter_speaker_turns(text: str) -> Iterable[TranscriptSpan]:
+    """Convenience generator over parsed speaker turns."""
+    yield from parse_zoom_vtt(text).spans

--- a/packages/benchmarks/meeting-transcription-proof/fixtures/zoom_transcript_sample.vtt
+++ b/packages/benchmarks/meeting-transcription-proof/fixtures/zoom_transcript_sample.vtt
@@ -1,0 +1,25 @@
+WEBVTT
+
+1
+00:00:00.000 --> 00:00:03.500
+Alice Kim: Thanks everyone for joining, let's start with the roadmap.
+
+2
+00:00:03.800 --> 00:00:07.200
+Bob Ng: Sounds good. I'll cover the ingestion changes first.
+
+3
+00:00:07.400 --> 00:00:11.900
+Bob Ng: We cut the p95 latency from 400ms to 120ms after the batching fix.
+
+4
+00:00:12.100 --> 00:00:15.000
+Alice Kim: That's a big win. Can you own the rollout note by Friday?
+
+5
+00:00:15.200 --> 00:00:16.400
+Bob Ng: Yes, I'll write it up.
+
+6
+00:00:16.800 --> 00:00:20.500
+<v Carol Diaz>Quick flag: the mobile build is still failing on the new SDK.

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
@@ -81,3 +81,18 @@ def test_validator_rejects_publishable_mock_or_raw_data_contracts() -> None:
         "adapters[0].score_json.publishable_requires_real_provider must be true",
         "adapters[0].training_eval_separation must be eval-only",
     ]
+
+
+def test_validator_rejects_malformed_nested_sections_without_throwing() -> None:
+    contract = build_adapter_contract()
+    contract["adapters"][0]["license_access"] = "MIT"
+    contract["adapters"][0]["row_selection"] = []
+    contract["adapters"][0]["score_json"] = None
+    contract["adapters"][0]["training_eval_separation"] = "eval-only"
+
+    errors = validate_adapter_contract(contract)
+
+    assert "adapters[0].license_access must be an object" in errors
+    assert "adapters[0].row_selection must be an object" in errors
+    assert "adapters[0].score_json must be an object" in errors
+    assert "adapters[0].training_eval_separation must be an object" in errors

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
@@ -24,6 +24,7 @@ def test_qmsum_and_meetingbank_contract_is_valid() -> None:
     assert {adapter["id"] for adapter in contract["adapters"]} == {
         "qmsum_p0_smoke",
         "meetingbank_p0_smoke",
+        "zoomgroupstats_p0_smoke",
     }
 
 
@@ -61,7 +62,9 @@ def test_adapters_emit_meeting_artifact_and_scenario_runner_metadata() -> None:
         assert adapter["scenario_runner"]["scenario_id_prefix"]
         assert adapter["scenario_runner"]["input_fields"]
         assert adapter["scenario_runner"]["expected_artifact_fields"]
-        assert set(adapter["score_json"]["metrics"]) == REQUIRED_SCORE_METRICS
+        # Every adapter carries at least the 5 contract-required metrics; a
+        # transcription/diarization adapter (zoomgroupstats) adds more (DER/WER).
+        assert REQUIRED_SCORE_METRICS <= set(adapter["score_json"]["metrics"])
         assert adapter["score_json"]["requires_judge_model"] is True
         assert adapter["score_json"]["requires_manual_review"] is True
         assert adapter["score_json"]["publishable_requires_real_provider"] is True
@@ -72,6 +75,27 @@ def test_adapters_are_eval_only_until_explicit_training_approval() -> None:
         assert adapter["training_eval_separation"]["eval_only"] is True
         assert adapter["training_eval_separation"]["training_allowed"] is False
         assert "training" in adapter["training_eval_separation"]["note"].lower()
+
+
+def test_zoomgroupstats_adapter_is_transcription_diarization_with_der_wer_baseline() -> None:
+    adapters = {a["id"]: a for a in build_adapter_contract()["adapters"]}
+    zgs = adapters["zoomgroupstats_p0_smoke"]
+
+    assert zgs["license_access"]["repo_license"] == "MIT"
+    assert zgs["task_family"] == "transcription_diarization"
+    assert zgs["row_selection"]["raw_rows_committed"] is False
+    # Native diarization/transcript metrics on top of the required 5.
+    metrics = set(zgs["score_json"]["metrics"])
+    assert REQUIRED_SCORE_METRICS <= metrics
+    assert {
+        "diarization_error_rate",
+        "transcript_word_error_rate",
+        "speaker_attribution_accuracy",
+    } <= metrics
+    # Baseline is a reference system (pyannote DER / Whisper WER), not a number.
+    baseline = zgs["score_json"]["baseline"]
+    assert "pyannote" in baseline["diarization_reference"].lower()
+    assert "whisper" in baseline["transcript_reference"].lower()
 
 
 def test_validator_rejects_publishable_mock_or_raw_data_contracts() -> None:

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
@@ -1,3 +1,9 @@
+"""Contract tests for meeting dataset adapter metadata.
+
+The tests keep QMSum and MeetingBank adapters eval-only, data-free in git, and
+strict about publishable scoring requirements.
+"""
+
 from __future__ import annotations
 
 from elizaos_meeting_transcription_proof.dataset_adapters import (

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from elizaos_meeting_transcription_proof.dataset_adapters import (
+    MEETING_ARTIFACT_SCHEMA,
+    REQUIRED_SCORE_METRICS,
+    build_adapter_contract,
+    validate_adapter_contract,
+)
+
+
+def test_qmsum_and_meetingbank_contract_is_valid() -> None:
+    contract = build_adapter_contract()
+
+    assert validate_adapter_contract(contract) == []
+    assert contract["schema"] == "elizaos.meeting_dataset_adapter.v1"
+    assert contract["raw_data_committed"] is False
+    assert contract["publishable_run_required"] is True
+    assert {adapter["id"] for adapter in contract["adapters"]} == {
+        "qmsum_p0_smoke",
+        "meetingbank_p0_smoke",
+    }
+
+
+def test_adapters_record_source_split_hash_and_row_selection_metadata() -> None:
+    adapters = {adapter["id"]: adapter for adapter in build_adapter_contract()["adapters"]}
+
+    qmsum = adapters["qmsum_p0_smoke"]
+    assert qmsum["source_url"] == "https://github.com/Yale-LILY/QMSum"
+    assert qmsum["license_access"]["repo_license"] == "MIT"
+    assert qmsum["selected_split"] == {
+        "dataset": "QMSum",
+        "split": "data/ALL/test",
+        "source_domains": ["Academic", "Product", "Committee"],
+    }
+    assert qmsum["row_selection"]["row_count"] == 10
+    assert qmsum["row_selection"]["raw_rows_committed"] is False
+    assert {"source_revision", "transcript_sha256", "adapter_config_sha256"} <= set(
+        qmsum["required_hashes"]
+    )
+
+    meetingbank = adapters["meetingbank_p0_smoke"]
+    assert meetingbank["source_url"] == "https://meetingbank.github.io/"
+    assert meetingbank["selected_split"]["split"] == "test"
+    assert meetingbank["row_selection"]["row_count"] == 5
+    assert meetingbank["row_selection"]["raw_rows_committed"] is False
+    assert {"agenda_sha256", "reference_summary_sha256", "adapter_config_sha256"} <= set(
+        meetingbank["required_hashes"]
+    )
+
+
+def test_adapters_emit_meeting_artifact_and_scenario_runner_metadata() -> None:
+    for adapter in build_adapter_contract()["adapters"]:
+        assert adapter["output_schema"] == MEETING_ARTIFACT_SCHEMA
+        assert adapter["scenario_runner"]["kind"] == "meeting_artifact_eval"
+        assert adapter["scenario_runner"]["scenario_id_prefix"]
+        assert adapter["scenario_runner"]["input_fields"]
+        assert adapter["scenario_runner"]["expected_artifact_fields"]
+        assert set(adapter["score_json"]["metrics"]) == REQUIRED_SCORE_METRICS
+        assert adapter["score_json"]["requires_judge_model"] is True
+        assert adapter["score_json"]["requires_manual_review"] is True
+        assert adapter["score_json"]["publishable_requires_real_provider"] is True
+
+
+def test_adapters_are_eval_only_until_explicit_training_approval() -> None:
+    for adapter in build_adapter_contract()["adapters"]:
+        assert adapter["training_eval_separation"]["eval_only"] is True
+        assert adapter["training_eval_separation"]["training_allowed"] is False
+        assert "training" in adapter["training_eval_separation"]["note"].lower()
+
+
+def test_validator_rejects_publishable_mock_or_raw_data_contracts() -> None:
+    contract = build_adapter_contract()
+    contract["raw_data_committed"] = True
+    contract["adapters"][0]["row_selection"]["raw_rows_committed"] = True
+    contract["adapters"][0]["score_json"]["publishable_requires_real_provider"] = False
+    contract["adapters"][0]["training_eval_separation"]["training_allowed"] = True
+
+    assert validate_adapter_contract(contract) == [
+        "raw_data_committed must be false",
+        "adapters[0].row_selection.raw_rows_committed must be false",
+        "adapters[0].score_json.publishable_requires_real_provider must be true",
+        "adapters[0].training_eval_separation must be eval-only",
+    ]

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_meeting_scoring.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_meeting_scoring.py
@@ -1,0 +1,126 @@
+"""Tests for the deterministic meeting scoring + baseline comparison harness.
+
+Model-free: exercises WER / DER / speaker-attribution and the compare.py-style
+baseline report over synthetic span sets (no audio, no models).
+"""
+
+from __future__ import annotations
+
+from elizaos_meeting_transcription_proof.meeting_scoring import (
+    Span,
+    compare_to_baseline,
+    diarization_error_rate,
+    score_transcript,
+    speaker_attribution_accuracy,
+    transcript_wer,
+    word_error_rate,
+)
+from elizaos_meeting_transcription_proof.zoom_vtt import parse_zoom_vtt
+
+
+def _ref() -> list[Span]:
+    return [
+        Span(0, 1000, "hello everyone", "A"),
+        Span(1000, 2000, "hi there", "B"),
+        Span(2000, 3000, "lets begin", "A"),
+    ]
+
+
+def test_word_error_rate_basic() -> None:
+    assert word_error_rate("the quick brown fox", "the quick brown fox") == 0.0
+    # one substitution over 4 ref tokens
+    assert word_error_rate("the quick brown fox", "the quick red fox") == 0.25
+    assert word_error_rate("", "") == 0.0
+    assert word_error_rate("", "extra") == 1.0
+
+
+def test_perfect_hypothesis_scores_zero_error_full_attribution() -> None:
+    ref = _ref()
+    scores = score_transcript(ref, ref)
+    assert scores["transcript_word_error_rate"] == 0.0
+    assert scores["diarization_error_rate"] == 0.0
+    assert scores["speaker_attribution_accuracy"] == 1.0
+
+
+def test_speaker_label_permutation_is_mapped_not_penalized() -> None:
+    # Same timing/speech, speaker labels renamed (A->X, B->Y): a good diarizer
+    # gets full credit under optimal label mapping.
+    ref = _ref()
+    hyp = [
+        Span(0, 1000, "hello everyone", "X"),
+        Span(1000, 2000, "hi there", "Y"),
+        Span(2000, 3000, "lets begin", "X"),
+    ]
+    assert speaker_attribution_accuracy(ref, hyp) == 1.0
+    assert diarization_error_rate(ref, hyp) == 0.0
+
+
+def test_speaker_confusion_raises_der() -> None:
+    ref = _ref()
+    # Middle turn attributed to the wrong (mapped) speaker: 1000ms confusion / 3000ms.
+    hyp = [
+        Span(0, 1000, "hello everyone", "A"),
+        Span(1000, 2000, "hi there", "A"),  # should be B
+        Span(2000, 3000, "lets begin", "A"),
+    ]
+    der = diarization_error_rate(ref, hyp)
+    assert abs(der - (1000 / 3000)) < 1e-9
+    assert abs(speaker_attribution_accuracy(ref, hyp) - (2000 / 3000)) < 1e-9
+
+
+def test_missed_speech_counts_toward_der() -> None:
+    ref = _ref()
+    hyp = [Span(0, 1000, "hello everyone", "A")]  # last 2000ms missed
+    assert abs(diarization_error_rate(ref, hyp) - (2000 / 3000)) < 1e-9
+
+
+def test_transcript_wer_over_spans() -> None:
+    ref = _ref()
+    hyp = [
+        Span(0, 1000, "hello everyone", "A"),
+        Span(1000, 2000, "hi friend", "B"),  # 'there'->'friend' : 1 sub / 6 ref tokens
+        Span(2000, 3000, "lets begin", "A"),
+    ]
+    assert abs(transcript_wer(ref, hyp) - (1 / 6)) < 1e-9
+
+
+def test_compare_to_baseline_candidate_beats_baseline() -> None:
+    ref = _ref()
+    # Candidate is perfect; baseline confuses the middle speaker.
+    candidate = ref
+    baseline = [
+        Span(0, 1000, "hello everyone", "A"),
+        Span(1000, 2000, "hi there", "A"),
+        Span(2000, 3000, "lets begin", "A"),
+    ]
+    report = compare_to_baseline(ref, candidate, baseline)
+    assert report["passed"] is True
+    der = report["metrics"]["diarization_error_rate"]
+    assert der["candidate"] == 0.0
+    assert der["baseline"] > 0.0
+    assert der["lower_is_better"] is True
+    assert der["improvement"] > 0.0
+
+
+def test_compare_to_baseline_candidate_worse_fails() -> None:
+    ref = _ref()
+    baseline = ref  # perfect baseline
+    candidate = [
+        Span(0, 1000, "hello everyone", "A"),
+        Span(1000, 2000, "hi there", "A"),  # confusion
+        Span(2000, 3000, "lets begin", "A"),
+    ]
+    report = compare_to_baseline(ref, candidate, baseline)
+    assert report["passed"] is False
+
+
+def test_scores_zoom_vtt_parser_output_directly() -> None:
+    # The reference can come straight from the .vtt importer.
+    vtt = (
+        "WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\nAlice: hello\n\n"
+        "2\n00:00:01.000 --> 00:00:02.000\nBob: hi\n"
+    )
+    ref_spans = parse_zoom_vtt(vtt).spans
+    scores = score_transcript(ref_spans, ref_spans)
+    assert scores["diarization_error_rate"] == 0.0
+    assert scores["speaker_attribution_accuracy"] == 1.0

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_network_qoe_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_network_qoe_adapters.py
@@ -1,0 +1,52 @@
+"""Contract tests for the network-QoE video-conferencing adapters (VCAPurdue).
+
+Keeps VCAPurdue honestly typed as a non-transcript modality, data-free in git,
+eval-only, and reference-baseline'd — separate from the meeting-artifact contract.
+"""
+
+from __future__ import annotations
+
+from elizaos_meeting_transcription_proof.network_qoe_adapters import (
+    REQUIRED_QOE_METRICS,
+    VC_QOE_ADAPTER_SCHEMA,
+    build_qoe_adapter_contract,
+    validate_qoe_adapter_contract,
+)
+
+
+def test_vca_purdue_qoe_contract_is_valid_and_data_free() -> None:
+    contract = build_qoe_adapter_contract()
+    assert validate_qoe_adapter_contract(contract) == []
+    assert contract["schema"] == VC_QOE_ADAPTER_SCHEMA
+    assert contract["raw_data_committed"] is False
+    assert {a["id"] for a in contract["adapters"]} == {"vca_purdue_qoe"}
+
+
+def test_vca_purdue_is_network_qoe_not_transcription() -> None:
+    vca = build_qoe_adapter_contract()["adapters"][0]
+    assert vca["modality"] == "network_qoe"
+    assert vca["transcription_usable"] is False
+    assert "no audio" in vca["usability_note"].lower()
+    assert set(vca["apps_covered"]) == {"webex", "google_meet", "microsoft_teams", "zoom"}
+    assert REQUIRED_QOE_METRICS <= set(vca["metrics"])
+    # Baseline is the dataset's measured per-app behavior, not a fixed number.
+    assert vca["baseline"]["kind"] == "reference_system_per_app"
+
+
+def test_vca_purdue_is_eval_only_and_raw_data_uncommitted() -> None:
+    vca = build_qoe_adapter_contract()["adapters"][0]
+    assert vca["row_selection"]["raw_rows_committed"] is False
+    assert vca["training_eval_separation"]["eval_only"] is True
+    assert vca["training_eval_separation"]["training_allowed"] is False
+
+
+def test_qoe_validator_rejects_committed_raw_data_and_wrong_modality() -> None:
+    contract = build_qoe_adapter_contract()
+    contract["raw_data_committed"] = True
+    contract["adapters"][0]["modality"] = "transcript"
+    contract["adapters"][0]["row_selection"]["raw_rows_committed"] = True
+
+    errors = validate_qoe_adapter_contract(contract)
+    assert "raw_data_committed must be false" in errors
+    assert "adapters[0].modality must be network_qoe" in errors
+    assert "adapters[0].row_selection.raw_rows_committed must be false" in errors

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_zoom_vtt.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_zoom_vtt.py
@@ -1,0 +1,81 @@
+"""Tests for the Zoom / zoomGroupStats WebVTT -> meeting-artifact importer.
+
+Deterministic and data-free: drives the parser over a synthetic fixture (no Zoom
+account, no committed corpus rows) and asserts speaker turns, millisecond timing,
+the diarized-speaker roster, and stable canonical foreign keys.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from elizaos_meeting_transcription_proof.zoom_vtt import (
+    UNIDENTIFIED,
+    parse_zoom_vtt,
+)
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "zoom_transcript_sample.vtt"
+
+
+def _load() -> str:
+    return FIXTURE.read_text(encoding="utf-8")
+
+
+def test_parses_every_cue_into_ordered_speaker_turns() -> None:
+    parsed = parse_zoom_vtt(_load())
+    assert len(parsed.spans) == 6
+    # Order preserved; ms offsets correct (00:00:03.800 -> 3800).
+    assert parsed.spans[0].speaker_label == "Alice Kim"
+    assert parsed.spans[0].start_ms == 0
+    assert parsed.spans[0].end_ms == 3500
+    assert parsed.spans[1].speaker_label == "Bob Ng"
+    assert parsed.spans[1].start_ms == 3800
+    assert parsed.spans[1].text.startswith("Sounds good")
+
+
+def test_handles_webvtt_voice_tag_form() -> None:
+    parsed = parse_zoom_vtt(_load())
+    # Cue 6 uses the <v Carol Diaz>...</v> voice-tag form.
+    carol = parsed.spans[-1]
+    assert carol.speaker_label == "Carol Diaz"
+    assert "mobile build" in carol.text
+    assert carol.start_ms == 16800
+
+
+def test_diarization_roster_is_first_appearance_order() -> None:
+    parsed = parse_zoom_vtt(_load())
+    assert parsed.speaker_labels == ["Alice Kim", "Bob Ng", "Carol Diaz"]
+
+
+def test_unlabeled_cue_maps_to_unidentified_speaker() -> None:
+    vtt = "WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\njust some words with no speaker\n"
+    parsed = parse_zoom_vtt(vtt)
+    assert len(parsed.spans) == 1
+    assert parsed.spans[0].speaker_label == UNIDENTIFIED
+    assert parsed.spans[0].text == "just some words with no speaker"
+
+
+def test_emits_canonical_meeting_artifact_segments_with_stable_keys() -> None:
+    segments = parse_zoom_vtt(_load()).to_meeting_artifact_segments()
+    spans = segments["transcriptSpans"]
+    speakers = {s["id"]: s for s in segments["diarizedSpeakers"]}
+
+    # Every span references a real diarized speaker (foreign key integrity).
+    assert len(spans) == 6
+    for span in spans:
+        assert span["speakerId"] in speakers
+        assert span["endMs"] >= span["startMs"]
+        assert set(span) == {"id", "startMs", "endMs", "text", "speakerId"}
+
+    # Stable, slugged speaker ids; named speakers resolved, none fabricated.
+    assert speakers["speaker-alice-kim"]["name"]["displayName"] == "Alice Kim"
+    assert speakers["speaker-alice-kim"]["name"]["provenance"] == "platform"
+    assert speakers["speaker-alice-kim"]["status"] == "resolved"
+
+
+def test_end_timestamp_clamped_not_negative_duration() -> None:
+    # Malformed cue where end < start must not produce a negative-duration span.
+    vtt = "WEBVTT\n\n00:00:05.000 --> 00:00:04.000\nDana: backwards timing\n"
+    span = parse_zoom_vtt(vtt).spans[0]
+    assert span.start_ms == 5000
+    assert span.end_ms == 5000


### PR DESCRIPTION
## Summary
- extends the meeting transcription proof benchmark dataset adapters with ZoomGroupStats transcript/diarization support
- adds VCAPurdue network-QoE adapter support and fixtures
- adds focused tests plus issue evidence for the new datasets

## Validation
- Reviewed branch diff against develop.
- Branch includes focused dataset adapter tests and evidence: .github/issue-evidence/13359-zoomgroupstats-vcapurdue-datasets.md
