### PR TITLE
fix(#13406): cloud console visual findings — apps header asset, card-brand fallback, buy-credits disabled state

### DIFF
--- a/packages/ui/src/cloud-ui/components/brand/brand-button.test.tsx
+++ b/packages/ui/src/cloud-ui/components/brand/brand-button.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+/**
+ * BrandButton disabled-state regression (#13406, finding 3).
+ *
+ * The "Buy credits" button (BrandButton variant="primary") read as a broken
+ * gray when disabled: under `.theme-cloud`, `--accent` is white, so
+ * `bg-accent` at `disabled:opacity-50` ghosted the white pill into an
+ * accidental muddy gray. The disabled state must be an INTENTIONAL muted
+ * surface (muted token bg + muted text + reduced opacity), not a ghosted
+ * accent fill.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { BrandButton } from "./brand-button";
+
+afterEach(cleanup);
+
+describe("BrandButton primary disabled state (#13406 finding 3)", () => {
+  it("renders disabled primary with muted token surface, not a ghosted accent fill", () => {
+    render(
+      <BrandButton variant="primary" disabled>
+        Buy credits
+      </BrandButton>,
+    );
+    const btn = screen.getByRole("button", { name: "Buy credits" });
+    const cls = btn.className;
+
+    // Intentional disabled surface: muted bg + muted text (theme-aware tokens).
+    expect(cls).toContain("disabled:bg-bg-muted");
+    expect(cls).toContain("disabled:text-muted");
+
+    // Must NOT rely on a raw-white or accent fill for the disabled look.
+    expect(cls).not.toContain("disabled:bg-white");
+    expect(cls).not.toContain("disabled:bg-accent");
+  });
+
+  it("keeps the branded accent fill for the enabled primary button", () => {
+    render(<BrandButton variant="primary">Buy credits</BrandButton>);
+    const btn = screen.getByRole("button", { name: "Buy credits" });
+    expect(btn.className).toContain("bg-accent");
+    expect(btn.className).toContain("text-accent-foreground");
+  });
+});

--- a/packages/ui/src/cloud-ui/components/brand/brand-button.tsx
+++ b/packages/ui/src/cloud-ui/components/brand/brand-button.tsx
@@ -15,7 +15,7 @@ const brandButtonVariants = cva(
     variants: {
       variant: {
         primary:
-          "bg-accent text-accent-foreground hover:bg-background hover:text-foreground active:bg-background/90",
+          "bg-accent text-accent-foreground hover:bg-background hover:text-foreground active:bg-background/90 disabled:bg-bg-muted disabled:text-muted",
         ghost: "bg-transparent text-txt/70 hover:bg-surface hover:text-txt",
         outline:
           "bg-bg-elevated text-txt hover:bg-foreground hover:text-background",

--- a/packages/ui/src/cloud/billing/components/billing-tab.selected-state.test.ts
+++ b/packages/ui/src/cloud/billing/components/billing-tab.selected-state.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Billing payment-method selected-state regression (#13406, finding 2).
+ *
+ * The token sweep #13073 (a6de6d6afc52) converted the selected payment-method
+ * toggle from `bg-[#FF5800] ... text-white` to `bg-[var(--accent)] ... text-white`.
+ * That regressed on the cloud dashboard because the dashboard shell wraps
+ * everything in `.theme-cloud`, where `--accent` resolves to `--brand-white`.
+ * The result was `bg:white + text-white` — a blank white box (invisible label).
+ *
+ * The fix pairs the accent fill with `text-accent-foreground` (black under
+ * `.theme-cloud`) so the selected label stays readable in every theme scope,
+ * and drops the raw white-opacity ladder for theme-aware border/muted tokens.
+ *
+ * This is a source-contract test (the full BillingTab needs api/router/i18n/
+ * wallet providers to render); it guards the exact className regression.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, "billing-tab.tsx"), "utf8");
+
+describe("billing payment-method selected state (#13406 finding 2)", () => {
+  it("never pairs an accent/white fill with white text (the blank-white-box bug)", () => {
+    // The exact regressed signature from the #13073 sweep must be gone.
+    expect(source).not.toContain(
+      "bg-[var(--accent)] border-[var(--accent)] text-white",
+    );
+    expect(source).not.toContain("bg-accent border-accent text-white");
+  });
+
+  it("uses accent-foreground for the selected label so it is readable on the accent fill", () => {
+    const selectedMatches = source.match(
+      /bg-accent border-accent text-accent-foreground/g,
+    );
+    // Two toggles: Card + Crypto.
+    expect(selectedMatches?.length).toBe(2);
+  });
+
+  it("uses theme-aware tokens for the unselected toggle (no raw white-opacity ladder)", () => {
+    const unselectedMatches = source.match(
+      /bg-transparent border-border text-muted hover:border-border-strong/g,
+    );
+    expect(unselectedMatches?.length).toBe(2);
+    // The old raw-rgba white border/muted ladder is gone from the toggles.
+    expect(source).not.toContain(
+      "bg-transparent border-[rgba(255,255,255,0.2)] text-white/60",
+    );
+  });
+});

--- a/packages/ui/src/cloud/billing/components/billing-tab.tsx
+++ b/packages/ui/src/cloud/billing/components/billing-tab.tsx
@@ -286,8 +286,8 @@ export function BillingTab({ user }: BillingTabProps) {
                       onClick={() => setPaymentMethod("card")}
                       className={`flex items-center gap-2 px-4 py-2 font-mono text-sm border transition-colors ${
                         paymentMethod === "card"
-                          ? "bg-[var(--accent)] border-[var(--accent)] text-white"
-                          : "bg-transparent border-[rgba(255,255,255,0.2)] text-white/60 hover:border-[rgba(255,255,255,0.4)]"
+                          ? "bg-accent border-accent text-accent-foreground"
+                          : "bg-transparent border-border text-muted hover:border-border-strong"
                       }`}
                     >
                       <CreditCard className="h-4 w-4" />
@@ -299,8 +299,8 @@ export function BillingTab({ user }: BillingTabProps) {
                       onClick={() => setPaymentMethod("crypto")}
                       className={`flex items-center gap-2 px-4 py-2 font-mono text-sm border transition-colors ${
                         paymentMethod === "crypto"
-                          ? "bg-[var(--accent)] border-[var(--accent)] text-white"
-                          : "bg-transparent border-[rgba(255,255,255,0.2)] text-white/60 hover:border-[rgba(255,255,255,0.4)]"
+                          ? "bg-accent border-accent text-accent-foreground"
+                          : "bg-transparent border-border text-muted hover:border-border-strong"
                       }`}
                     >
                       <Wallet className="h-4 w-4" />


### PR DESCRIPTION
## What

Fixes 2 of the 3 visual findings in the QA tracker #13406 findings ledger, and root-causes the third with pixel evidence.

Screenshot evidence: `finding-apps-white-box.png` (#13406 first comment). Prod verification routes through **[qa-agent]**'s signed-in session per the tracker protocol — this PR ships the code fix + unit coverage + code-level before/after reasoning.

## Finding 2 — billing selected payment-method renders as a blank white box → **OWNED (our regression)**

**Root cause: yes, the #13073 token sweep caused it.** Commit `a6de6d6afc52` converted the selected toggle:

```diff
- paymentMethod === "card" ? "bg-[#FF5800] border-[#FF5800] text-white" : ...
+ paymentMethod === "card" ? "bg-[var(--accent)] border-[var(--accent)] text-white" : ...
```

`#FF5800` rendered orange **unconditionally**. `var(--accent)` inherits the theme scope — and the cloud dashboard shell wraps everything in `.theme-cloud` (`cloud-ui/components/layout/dashboard-shell.tsx:20`), where `base.css` sets `--accent: var(--brand-white)`. So the selected button became **`bg:white + text-white`** = an invisible label on a white fill = the blank white box in the screenshot.

**Fix:** pair the accent fill with `text-accent-foreground` (black under `.theme-cloud`) so the label is readable in every theme scope; swap the unselected raw white-opacity ladder (`border-[rgba(255,255,255,0.2)] text-white/60`) for theme-aware `border-border text-muted hover:border-border-strong`.

## Finding 3 — "Buy credits" disabled state reads as broken gray

`BrandButton variant="primary"` is `bg-accent` (white under `.theme-cloud`); the generic `disabled:opacity-50` ghosted that white pill into an accidental muddy gray. Made the disabled state **intentional** per the design system: `disabled:bg-bg-muted disabled:text-muted` + the existing reduced opacity — mirroring the already-correct `icon-primary` disabled pattern. Fixes every `BrandButton` primary call site, not just billing.

## Finding 1 — dashboard/apps white rectangle → **root-caused, NOT a standalone cloud-ui bug; left to #13410**

The develop apps render path (`ApplicationsPage` → `DashboardStatGrid` → `DashboardStatCard`) has **no `<img>` and no white-block element** — traced the full tree. Pixel analysis of the prod evidence shows a flat **pure-`#ffffff` 289×79 rectangle, zero variance, flanked by pure `#000`** (not the warm `#140c07` brand black) — i.e. the **agent-app-boot artifact** from the apex post-signin bug that **[qa-agent]** already root-caused in #13410 (agent app boots on the apex host with no same-origin backend → assets 404 / shell chrome mis-renders). Likely the same `.theme-cloud` white-accent mechanism as Finding 2 surfacing during the broken boot. Not touching routing (#13410's scope).

## Evidence

- `tsc` (tsgo) clean on touched files — only pre-existing `core/`+`shared/` codegen-artifact errors (`generated/validation-keyword-data`) in a fresh worktree, none in changed files.
- All 4 anti-slop gates unaffected. (The `no-backdrop-blur-gate` failure on develop tip is a **pre-existing** regression in `ChatSurface.tsx:167`, untouched by this PR.)
- biome check clean.
- 5 new unit tests (BrandButton disabled tokens + billing selected-state contrast contract) — all pass.
- codex-reviewed: *"consistently replace the problematic white/accent foreground combinations with theme-aware foreground and muted tokens … did not find a discrete correctness issue introduced by this patch."*

Token-compliant per `DESIGN-SYSTEM.md` (tokens only, no raw hex, lucide icons untouched).

— [sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>
