### PR TITLE
[codex] fix default device health workflow

### DIFF
--- a/packages/app/test/ui-smoke/automations.spec.ts
+++ b/packages/app/test/ui-smoke/automations.spec.ts
@@ -676,29 +676,7 @@ test("automations overview empty state encourages creating tasks and workflows",
   await expect(page.getByRole("button", { name: "Workflows 0" })).toBeVisible();
   await expect(page.getByText("Nothing scheduled yet")).toBeVisible();
 
-  // "New" no longer opens a task/workflow chooser — it focuses the Automations
-  // chat with a creation prefill (mirrors AutomationsFeed.test.tsx). Capture the
-  // dispatched prefill event as the proof of the new contract.
-  await page.evaluate(() => {
-    (window as unknown as { __prefill?: unknown }).__prefill = null;
-    window.addEventListener(
-      "eliza:chat:prefill",
-      (event) => {
-        (window as unknown as { __prefill?: unknown }).__prefill = (
-          event as CustomEvent
-        ).detail;
-      },
-      { once: true },
-    );
-  });
-  await page.getByRole("button", { name: "New" }).click();
-  await expect
-    .poll(() =>
-      page.evaluate(
-        () => (window as unknown as { __prefill?: unknown }).__prefill,
-      ),
-    )
-    .toEqual({ text: "Create an automation that ", select: false });
+  await expect(page.getByRole("button", { name: "New" })).toHaveCount(0);
   await expect(page.getByTestId("automations-shell")).toBeVisible();
 });
 

--- a/packages/benchmarks/orchestrator/tests/test_adapter_discovery.py
+++ b/packages/benchmarks/orchestrator/tests/test_adapter_discovery.py
@@ -17,6 +17,7 @@ import pytest
 from benchmarks.orchestrator import adapters as orchestrator_adapters
 from benchmarks.bench_cli_types import ModelSpec
 from benchmarks.orchestrator.adapters import (
+    SMITHERS_BENCHMARKS,
     _score_from_app_eval,
     _score_from_eliza_1,
     _score_from_personality_bench,
@@ -1416,6 +1417,74 @@ def test_standard_public_benchmarks_publish_real_harness_rows() -> None:
         assert _is_harness_compatible(adapter, "hermes") is True
         assert _is_harness_compatible(adapter, "openclaw") is True
         assert _is_harness_compatible(adapter, "smithers") is True
+
+
+def test_smithers_benchmark_compatibility_has_real_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        orchestrator_adapters,
+        "_has_swe_bench_docker_backend",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        orchestrator_adapters,
+        "_has_terminal_bench_docker_backend",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        orchestrator_adapters,
+        "_has_osworld_docker_backend",
+        lambda: True,
+    )
+
+    workspace_root = _workspace_root()
+    benchmarks_root = workspace_root / "benchmarks"
+    monkeypatch.setattr(
+        orchestrator_adapters,
+        "_git_visible_dir_names",
+        lambda _root: {p.name for p in benchmarks_root.iterdir() if p.is_dir()},
+    )
+    registry_ids = {item.id for item in get_benchmark_registry(workspace_root)}
+
+    missing_from_registry = sorted(SMITHERS_BENCHMARKS - registry_ids)
+    assert missing_from_registry == []
+
+    report = build_cross_matrix_report(
+        workspace_root.parent,
+        harnesses=("smithers",),
+        provider="cerebras",
+        model="gpt-oss-120b",
+    )
+    cells = {cell.benchmark_id: cell for cell in report.cells}
+    for benchmark_id in sorted(SMITHERS_BENCHMARKS):
+        cell = cells[benchmark_id]
+        assert cell.compatible is True, benchmark_id
+        assert cell.command, benchmark_id
+        assert cell.propagated_env["BENCHMARK_HARNESS"] == "smithers"
+        assert cell.propagated_env["ELIZA_BENCH_HARNESS"] == "smithers"
+        assert "smithers-adapter" in cell.propagated_env["PYTHONPATH"]
+
+
+def test_smithers_adapter_modules_import_for_declared_factories() -> None:
+    adapter_root = _workspace_root().parent / "packages" / "benchmarks" / "smithers-adapter"
+    sys.path.insert(0, str(adapter_root))
+    try:
+        for module_name in (
+            "agentbench",
+            "bfcl",
+            "clawbench",
+            "context_bench",
+            "swe_bench",
+            "tau_bench",
+            "terminal_bench",
+            "woobench",
+        ):
+            module = importlib.import_module(f"smithers_adapter.{module_name}")
+            assert module is not None
+    finally:
+        with contextlib.suppress(ValueError):
+            sys.path.remove(str(adapter_root))
 
 
 def test_framework_publishes_real_harness_rows() -> None:

--- a/packages/ui/src/components/pages/AutomationsFeed.test.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
 // Renders the real AutomationsFeed against a mocked `../../api` client to cover
-// its status overview, truthful run action, and the new-automation → chat
-// hand-off. jsdom + in-memory client stub; no live backend.
+// its status overview, truthful run action, and the streamlined creation
+// surface. jsdom + in-memory client stub; no live backend.
 
 import {
   cleanup,
@@ -47,7 +47,20 @@ function automationItem(
     hasBackingWorkflow: true,
     updatedAt: "2026-06-20T12:00:00.000Z",
     workflowId: "workflow-1",
-    schedules: [],
+    schedules: [
+      {
+        id: "trigger-1",
+        taskId: "task-trigger-1",
+        displayName: "Scheduled workflow run: Nightly review",
+        instructions: "Run workflow Nightly review",
+        triggerType: "interval",
+        enabled: true,
+        wakeMode: "inject_now",
+        createdBy: "workflow.schedule",
+        intervalMs: 3_600_000,
+        runCount: 0,
+      },
+    ],
     lastExecution: {
       status: "success",
       startedAt: "2026-06-20T12:00:00.000Z",
@@ -128,6 +141,7 @@ describe("AutomationsFeed", () => {
       within(screen.getByTestId("automation-stat-failed")).getByText("1"),
     ).toBeTruthy();
     expect(screen.getByText("Failed: HTTP request failed")).toBeTruthy();
+    expect(screen.getAllByText("Every hour").length).toBeGreaterThan(0);
 
     expect(
       screen.queryByRole("button", { name: /activate workflow/i }),
@@ -153,21 +167,10 @@ describe("AutomationsFeed", () => {
     expect(clientMock.listAutomations).toHaveBeenCalledTimes(2);
   });
 
-  it("routes new automation creation into the Automations chat", async () => {
-    const prefill = vi.fn();
-    window.addEventListener("eliza:chat:prefill", prefill as EventListener);
+  it("keeps the feed header focused on status instead of generic creation", async () => {
     render(<AutomationsFeed />);
 
     await screen.findByText("Nightly review");
-    fireEvent.click(screen.getByRole("button", { name: "New" }));
-
-    expect(prefill).toHaveBeenCalledOnce();
-    const event = prefill.mock.calls[0]?.[0] as CustomEvent;
-    expect(event.detail).toEqual({
-      text: "Create an automation that ",
-      select: false,
-    });
-
-    window.removeEventListener("eliza:chat:prefill", prefill as EventListener);
+    expect(screen.queryByRole("button", { name: "New" })).toBeNull();
   });
 });

--- a/packages/ui/src/components/pages/AutomationsFeed.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.tsx
@@ -142,6 +142,19 @@ interface FeedRow {
   source: AutomationItem;
 }
 
+function formatInterval(intervalMs: number): string {
+  const minutes = Math.round(intervalMs / 60_000);
+  if (minutes < 60) {
+    return minutes === 1 ? "Every minute" : `Every ${minutes} minutes`;
+  }
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) {
+    return hours === 1 ? "Every hour" : `Every ${hours} hours`;
+  }
+  const days = Math.round(hours / 24);
+  return days === 1 ? "Every day" : `Every ${days} days`;
+}
+
 /**
  * Derive a schedule label from an automation item's `schedules`
  * (`TriggerSummary[]` populated by the `/api/automations` builder from
@@ -163,6 +176,7 @@ function schedulesLabel(
             defaultValue: "On {{event}}",
           });
         }
+        if (trigger.intervalMs) return formatInterval(trigger.intervalMs);
         if (trigger.displayName) return trigger.displayName;
         return null;
       })
@@ -220,16 +234,6 @@ export function AutomationsFeed({
   const focusAutomationChat = useCallback(() => {
     dispatchChatPrefill({ text: NEW_AUTOMATION_PROMPT, select: false });
   }, []);
-
-  const newAgent = useAgentElement<HTMLButtonElement>({
-    id: "action-new",
-    role: "button",
-    label: t("automationsfeed.new", { defaultValue: "New" }),
-    group: "automations-actions",
-    description:
-      "Focus Automations chat to create a workflow or prompt automation",
-    onActivate: focusAutomationChat,
-  });
 
   const editor: EditorState = useMemo(() => {
     if (scheduledEditorId)
@@ -475,17 +479,6 @@ export function AutomationsFeed({
               {t("automationsfeed.title", { defaultValue: "Automations" })}
             </h1>
           </div>
-          <Button
-            ref={newAgent.ref}
-            variant="default"
-            size="sm"
-            className="min-h-11"
-            onClick={focusAutomationChat}
-            {...newAgent.agentProps}
-          >
-            <Plus className="mr-1 h-3.5 w-3.5" aria-hidden />
-            {t("automationsfeed.new", { defaultValue: "New" })}
-          </Button>
         </div>
 
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">

--- a/plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts
@@ -34,7 +34,7 @@ async function persistentRuntime(
   const client = new PGlite({ dataDir: join(dir, 'pglite') });
   const db = drizzle(client, { schema: dbSchema });
   return {
-    runtime: runtime(settings, services, db),
+    runtime: runtime({ WORKFLOW_SEED_DEFAULTS: false, ...settings }, services, db),
     async close() {
       await client.close();
       await rm(dir, { recursive: true, force: true });
@@ -81,6 +81,60 @@ describe('EmbeddedWorkflowService', () => {
     await embedded.stop();
     await harness.close();
   }, 60_000);
+
+  test('seeds and runs the no-LLM device health check workflow by default', async () => {
+    const tasks: Array<Record<string, unknown>> = [];
+    const harness = await persistentRuntime({ WORKFLOW_SEED_DEFAULTS: true });
+    const runtimeWithTasks = {
+      ...harness.runtime,
+      agentId: 'agent-test',
+      createTask: async (task: Record<string, unknown>) => {
+        tasks.push({ id: `task-${tasks.length + 1}`, ...task });
+      },
+      getTasks: async () => tasks,
+      deleteTask: async (id: string) => {
+        const index = tasks.findIndex((task) => task.id === id);
+        if (index >= 0) tasks.splice(index, 1);
+      },
+    } as unknown as IAgentRuntime;
+
+    const service = await EmbeddedWorkflowService.start(runtimeWithTasks);
+    try {
+      const workflows = await service.listWorkflows();
+      const healthCheck = workflows.data.find(
+        (workflow) => workflow.id === 'system-device-health-check'
+      );
+      expect(healthCheck?.active).toBe(true);
+      expect(healthCheck?.nodes.map((node) => node.type)).toContain(
+        'workflows-nodes-base.deviceStatus'
+      );
+      expect(tasks).toHaveLength(1);
+      expect((tasks[0].metadata as { workflowId?: string }).workflowId).toBe(
+        'system-device-health-check'
+      );
+
+      const executions = await service.listExecutions({
+        workflowId: 'system-device-health-check',
+        limit: 1,
+      });
+      expect(executions.data).toHaveLength(1);
+      expect(executions.data[0].status).toBe('success');
+      const item =
+        executions.data[0].data?.resultData?.runData?.['Device Status']?.[0]?.data?.main?.[0]?.[0]
+          ?.json;
+      expect(item?.memory).toMatchObject({
+        totalBytes: expect.any(Number),
+        freeBytes: expect.any(Number),
+      });
+      expect(item?.disk).toMatchObject({
+        mount: '/',
+        availableBytes: expect.any(Number),
+      });
+    } finally {
+      await service.stop();
+      await harness.close();
+    }
+  }, 90_000);
 
   test('runs a schedule -> HTTP Request -> Set workflow in a child process', async () => {
     const pluginRoot = join(import.meta.dir, '../..');

--- a/plugins/plugin-workflow/src/data/defaultNodes.json
+++ b/plugins/plugin-workflow/src/data/defaultNodes.json
@@ -1851,6 +1851,22 @@
     ]
   },
   {
+    "name": "workflows-nodes-base.deviceStatus",
+    "displayName": "Device Status",
+    "group": [
+      "input"
+    ],
+    "description": "Reports local RAM, disk, CPU, and runtime status without model calls",
+    "version": 1,
+    "inputs": [
+      "main"
+    ],
+    "outputs": [
+      "main"
+    ],
+    "properties": []
+  },
+  {
     "name": "workflows-nodes-base.filter",
     "displayName": "Filter",
     "group": [

--- a/plugins/plugin-workflow/src/data/schemaIndex.json
+++ b/plugins/plugin-workflow/src/data/schemaIndex.json
@@ -1,1 +1,6 @@
-{}
+{
+  "workflows-nodes-base.deviceStatus": {
+    "version": 1,
+    "properties": []
+  }
+}

--- a/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
+++ b/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
@@ -13,6 +13,8 @@
  * `packages/agent` to avoid a dependency cycle.
  */
 import { createHash, randomUUID } from 'node:crypto';
+import { statfs } from 'node:fs/promises';
+import { arch, cpus, freemem, loadavg, platform, release, totalmem, uptime } from 'node:os';
 import {
   type IAgentRuntime,
   logger,
@@ -173,6 +175,8 @@ interface IncomingConnection {
 
 const EMBEDDED_HOST = 'embedded://local';
 const DEFAULT_SCHEDULE_INTERVAL_MS = 60_000;
+const DEVICE_HEALTH_CHECK_WORKFLOW_ID = 'system-device-health-check';
+const DEVICE_HEALTH_CHECK_RUN_KEY = `${DEVICE_HEALTH_CHECK_WORKFLOW_ID}:initial`;
 
 let loadedQuickJs: Promise<typeof import('quickjs-emscripten')> | null = null;
 
@@ -245,6 +249,96 @@ function readString(value: unknown, fallback: string): string {
 
 function readNumber(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function bytesFromBlocks(blocks: number, blockSize: number): number {
+  return Math.max(0, Math.floor(blocks * blockSize));
+}
+
+async function collectDeviceStatus(): Promise<Record<string, unknown>> {
+  const disk = await statfs('/');
+  const blockSize = Number(disk.bsize);
+  const totalDiskBytes = bytesFromBlocks(Number(disk.blocks), blockSize);
+  const freeDiskBytes = bytesFromBlocks(Number(disk.bfree), blockSize);
+  const availableDiskBytes = bytesFromBlocks(Number(disk.bavail), blockSize);
+  const totalMemoryBytes = totalmem();
+  const freeMemoryBytes = freemem();
+
+  return {
+    checkedAt: nowIso(),
+    runtime: {
+      node: process.version,
+      platform: platform(),
+      arch: arch(),
+      osRelease: release(),
+      pid: process.pid,
+      uptimeSeconds: Math.round(uptime()),
+    },
+    cpu: {
+      cores: cpus().length,
+      loadAverage: loadavg(),
+    },
+    memory: {
+      totalBytes: totalMemoryBytes,
+      freeBytes: freeMemoryBytes,
+      usedBytes: Math.max(0, totalMemoryBytes - freeMemoryBytes),
+      freeRatio: totalMemoryBytes > 0 ? freeMemoryBytes / totalMemoryBytes : null,
+    },
+    disk: {
+      mount: '/',
+      totalBytes: totalDiskBytes,
+      freeBytes: freeDiskBytes,
+      availableBytes: availableDiskBytes,
+      usedBytes: Math.max(0, totalDiskBytes - freeDiskBytes),
+      availableRatio: totalDiskBytes > 0 ? availableDiskBytes / totalDiskBytes : null,
+    },
+  };
+}
+
+function buildDeviceHealthCheckWorkflow(): WorkflowDefinition {
+  return {
+    id: DEVICE_HEALTH_CHECK_WORKFLOW_ID,
+    name: 'Device health check',
+    active: true,
+    nodes: [
+      {
+        id: 'schedule',
+        name: 'Hourly check',
+        type: 'workflows-nodes-base.scheduleTrigger',
+        typeVersion: 1.2,
+        position: [0, 0],
+        parameters: {
+          intervalMs: 3_600_000,
+        },
+      },
+      {
+        id: 'device-status',
+        name: 'Device Status',
+        type: 'workflows-nodes-base.deviceStatus',
+        typeVersion: 1,
+        position: [240, 0],
+        parameters: {},
+      },
+    ],
+    connections: {
+      'Hourly check': {
+        main: [[{ node: 'Device Status', type: 'main', index: 0 }]],
+      },
+    },
+    settings: {
+      executionOrder: 'v1',
+    },
+    meta: {
+      assumptions: [
+        'Runs locally without model calls and records RAM, disk, CPU, and runtime facts.',
+      ],
+    },
+  };
+}
+
+function shouldSeedDefaultWorkflows(runtime: IAgentRuntime): boolean {
+  const raw = runtime.getSetting?.('WORKFLOW_SEED_DEFAULTS');
+  return raw !== false && raw !== 'false';
 }
 
 /**
@@ -1131,6 +1225,32 @@ function createItemListsNode(): INodeType {
   };
 }
 
+function createDeviceStatusNode(): INodeType {
+  return {
+    description: {
+      displayName: 'Device Status',
+      name: 'workflows-nodes-base.deviceStatus',
+      group: ['input'],
+      version: [1],
+      description: 'Reports local RAM, disk, CPU, and runtime status without model calls.',
+      defaults: { name: 'Device Status' },
+      inputs: ['main'] as never,
+      outputs: ['main'] as never,
+      properties: [] as never,
+      capabilities: { requiresFs: true },
+    },
+    async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+      const sourceItems = this.getInputData();
+      const status = await collectDeviceStatus();
+      const json = {
+        ...(sourceItems[0]?.json ?? {}),
+        ...status,
+      } as INodeExecutionData['json'];
+      return [[{ json }]];
+    },
+  };
+}
+
 async function runQuickJsCode(jsCode: string, inputItems: INodeExecutionData[]): Promise<unknown> {
   const { getQuickJS, shouldInterruptAfterDeadline } = await loadQuickJs();
   const QuickJS = await getQuickJS();
@@ -1370,6 +1490,7 @@ class EmbeddedNodeTypes implements INodeTypes {
       createDateTimeNode(),
       createCryptoNode(),
       createItemListsNode(),
+      createDeviceStatusNode(),
       createCodeNode(),
     ]) {
       const canonical = node.description.name;
@@ -1434,6 +1555,9 @@ export class EmbeddedWorkflowService extends Service {
     );
     if (runtime.db) {
       await service.ensureSchema();
+      if (shouldSeedDefaultWorkflows(runtime)) {
+        await service.seedDefaultWorkflows();
+      }
       await service.rehydrateSchedules();
     }
     return service;
@@ -2162,6 +2286,38 @@ export class EmbeddedWorkflowService extends Service {
     for (const row of rows) {
       await this.armSchedules(row.id);
     }
+  }
+
+  private async seedDefaultWorkflows(): Promise<void> {
+    const rows = await this.getDb()
+      .select({ id: embeddedWorkflows.id })
+      .from(embeddedWorkflows)
+      .where(eq(embeddedWorkflows.id, DEVICE_HEALTH_CHECK_WORKFLOW_ID))
+      .limit(1);
+    if (rows.length > 0) return;
+
+    const workflow = buildDeviceHealthCheckWorkflow();
+    this.assertRegisteredNodes(workflow);
+    this.assertHostSupports(workflow);
+    const timestamp = nowIso();
+    const versionId = randomUUID();
+    const stored = normalizeWorkflowPayload(workflow, DEVICE_HEALTH_CHECK_WORKFLOW_ID, true);
+    await this.getDb().insert(embeddedWorkflows).values({
+      id: DEVICE_HEALTH_CHECK_WORKFLOW_ID,
+      name: stored.name,
+      active: true,
+      workflow: stored,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      versionId,
+    });
+    await this.runWorkflow(
+      stored,
+      'manual',
+      { source: 'default-workflow-seed' },
+      DEVICE_HEALTH_CHECK_RUN_KEY,
+      false
+    );
   }
 
   /** Remove legacy `workflow.run` / `workflow.webhook` Tasks left behind


### PR DESCRIPTION
## Summary
- Add a seeded, active `Device health check` Smithers workflow that runs without LLM calls, schedules hourly, runs once at startup, and records local RAM, disk, CPU, and runtime status.
- Add a `workflows-nodes-base.deviceStatus` node plus catalog/schema metadata so the workflow appears through the existing automations/workflow surfaces.
- Remove the always-visible Automations header `New` button and show interval labels such as `Every hour` for scheduled workflows.

## Smithers/workflow coverage review
Existing coverage found:
- `plugins/plugin-workflow/__tests__/unit/smithers-runtime.test.ts` covers child-process Smithers runtime cases for fanout, retry, continue, and fail.
- `plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts` covers PGlite-backed CRUD, schedule -> HTTP -> Set, Code/QuickJS, persisted Smithers step storage, webhooks, and now the default no-LLM device health workflow.
- `plugins/plugin-workflow/__tests__/integration/trigger-dispatch-e2e.test.ts` covers the real TaskService -> TRIGGER_DISPATCH -> WORKFLOW_DISPATCH -> EmbeddedWorkflowService path.
- `packages/test/scenarios/automations/automations-api.e2e.ts` covers API-level automation listing and task/trigger shape.
- `packages/app/test/ui-smoke/automations.spec.ts` and `workflow-editor.spec.ts` cover UI smoke paths with stubbed APIs.

Gaps found:
- App UI smoke tests do not drive a live Smithers backend; they prove rendering, not real graph execution.
- `plugins/plugin-workflow/__tests__/integration/routes-e2e.test.ts` uses a mocked WorkflowService, so route behavior is covered but runtime execution is not.
- Benchmarks contain Smithers harness support for agent benchmarks, but I did not find a benchmark that exercises embedded `plugin-workflow` Smithers DAG/node execution.
- Full proof that the seeded health workflow appears in the real Automations tab needs the app audit/browser flow; local `audit:app` hung after build startup in this worktree.

## Validation
- `bun run install:light` completed.
- `bun run --cwd packages/cloud/routing build` passed.
- `bun run --cwd packages/contracts build && bun run --cwd packages/core build:node` passed.
- `bun run --cwd packages/shared build` passed.
- `bun run --cwd plugins/plugin-workflow typecheck` passed.
- `bunx @biomejs/biome check plugins/plugin-workflow/src/services/embedded-workflow-service.ts plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts packages/ui/src/components/pages/AutomationsFeed.tsx packages/ui/src/components/pages/AutomationsFeed.test.tsx packages/app/test/ui-smoke/automations.spec.ts` passed.
- `bun run --cwd packages/ui test -- AutomationsFeed.test.tsx` passed.
- `bun test plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts -t "seeds and runs the no-LLM device health check workflow by default"` printed the new test as pass and logged successful Smithers execution, then Bun hung during coverage/teardown and had to be stopped.
- `bun test plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts` printed all test cases as pass, then Bun hung during coverage/teardown and had to be stopped.
- `bun run --cwd packages/ui typecheck` failed on pre-existing duplicate `fetchAvailableViews` declarations in `packages/ui/src/components/shell/__e2e__/home-screen-fixture.views-stub.ts`.
- `bun run --cwd packages/app audit:app` hung after the build phase and was stopped.
- `bun run --cwd packages/app test:e2e -- automations.spec.ts` hung after the build phase and was stopped.
