### PR TITLE
Fix orchestrator lifecycle metric categories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3290,6 +3290,7 @@
       "version": "2.0.3-beta.7",
       "dependencies": {
         "@elizaos/core": "workspace:*",
+        "@elizaos/shared": "workspace:*",
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.2",

--- a/packages/benchmarks/orchestrator_lifecycle/evaluator.py
+++ b/packages/benchmarks/orchestrator_lifecycle/evaluator.py
@@ -125,6 +125,7 @@ class LifecycleEvaluator:
         return ScenarioResult(
             scenario_id=scenario.scenario_id,
             title=scenario.title,
+            category=scenario.category,
             passed=passed,
             score=score,
             checks_passed=checks_passed,
@@ -138,23 +139,19 @@ class LifecycleEvaluator:
         passed = sum(1 for r in results if r.passed)
         overall = (sum(r.score for r in results) / total) if total > 0 else 0.0
 
-        def _rate(tag: str) -> float:
-            tagged = [r for r in results if tag in r.scenario_id]
+        def _rate(*categories: str) -> float:
+            expected = set(categories)
+            tagged = [r for r in results if r.category in expected]
             if not tagged:
                 return 0.0
             return sum(r.score for r in tagged) / len(tagged)
 
         clarification = _rate("clarification")
         status = _rate("status")
-        interruption = (
-            _rate("pause")
-            + _rate("resume")
-            + _rate("cancel")
-            + _rate("interrupt")
-        ) / 4
+        interruption = _rate("interrupt")
         # No inflation fallback: a category with no scenarios (or all-failing
         # scenarios) reports its real rate, never the overall score.
-        summary = _rate("summary")
+        summary = _rate("completion_summary")
         return LifecycleMetrics(
             overall_score=overall,
             scenario_pass_rate=(passed / total) if total > 0 else 0.0,

--- a/packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py
+++ b/packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py
@@ -301,6 +301,36 @@ def test_summary_metric_reports_real_rate_never_overall_fallback() -> None:
     assert metrics.completion_summary_quality == 0.0
 
 
+def test_category_metrics_use_scenario_metadata_not_id_substrings() -> None:
+    """`check_in_while_running` is a status scenario even though its ID lacks
+    the word "status"; category metrics must follow the scenario metadata."""
+    evaluator = LifecycleEvaluator()
+    scenario = Scenario(
+        scenario_id="check_in_while_running",
+        title="Check In While Running",
+        category="status",
+        turns=[
+            ScenarioTurn(
+                actor="user",
+                message="How is it going? Give me a status update.",
+                expected_behaviors=["report_active_subagent_status"],
+            )
+        ],
+    )
+    result = evaluator.evaluate_scenario(
+        scenario,
+        [
+            TurnRecord(
+                reply_text="Collection finished, analysis underway.",
+                events=["status_query"],
+            )
+        ],
+    )
+    metrics = evaluator.compute_metrics([result])
+    assert result.category == "status"
+    assert metrics.status_accuracy_rate == 1.0
+
+
 def test_compute_metrics_aggregates_pass_rate() -> None:
     evaluator = LifecycleEvaluator()
     scenario = _scenario(

--- a/packages/benchmarks/orchestrator_lifecycle/tests/test_runner_smoke.py
+++ b/packages/benchmarks/orchestrator_lifecycle/tests/test_runner_smoke.py
@@ -85,6 +85,7 @@ def test_bridge_report_is_scored(tmp_path: Path) -> None:
     )
     report = json.loads(Path(report_path).read_text())
     assert report["scored"] is True
+    assert report["scenarios"][0]["category"] == "test"
     extraction = _score_from_orchestrator_lifecycle_json(report)
     assert extraction.score == 1.0
 

--- a/packages/benchmarks/orchestrator_lifecycle/types.py
+++ b/packages/benchmarks/orchestrator_lifecycle/types.py
@@ -57,6 +57,7 @@ class TurnRecord:
 class ScenarioResult:
     scenario_id: str
     title: str
+    category: str
     passed: bool
     score: float
     checks_passed: int


### PR DESCRIPTION
## Summary
- Fix orchestrator lifecycle benchmark category rollups to use explicit scenario metadata instead of scenario-id substring matching.
- Persist `ScenarioResult.category` into JSON reports so downstream scoring/auditing can inspect the source category.
- Add regression coverage for `check_in_while_running`, whose ID does not contain `status`, plus a smoke assertion for bridge report category output.

Fixes #13395

## Evidence
- `pytest packages/benchmarks/orchestrator_lifecycle/tests/ -v` -> 27 passed.
- `python -m compileall -q packages/benchmarks/orchestrator_lifecycle` -> passed.
- `python -m benchmarks.orchestrator_lifecycle.cli --mode simulate --max-scenarios 3 --output /tmp/olc-codex-13395` -> passed; manually inspected report categories for `cancel_task`, `cancel_then_undo_resume`, and `check_in_while_running`.
- Full base-scenario ideal-events metrics probe -> all lifecycle category metrics 1.0 across 12 scenarios.
- `bun run --cwd packages/scenario-runner test:orchestrator:pr:e2e` -> 7/7 deterministic orchestrator scenarios passed; report bundle written under `reports/scenarios/pr-deterministic-orchestrator`.
- Focused plugin unit slice: `bunx vitest run --config vitest.config.ts __tests__/unit/orchestrator-correctness.test.ts __tests__/unit/orchestrator-task-service.test.ts __tests__/unit/smithers-task-runner.test.ts` from `plugins/plugin-agent-orchestrator` -> 74 tests passed.
- `bun run --cwd packages/auth build && bun run --cwd packages/cloud/shared typecheck` -> passed after the first root verify exposed missing built auth declarations.
- `bun run verify` -> failed in unrelated `@elizaos/cloud-ui#lint` import ordering under `packages/cloud-ui/src/approvals/*` and `packages/cloud-ui/src/index.ts`; no orchestrator lifecycle failures observed before Turbo stopped.

## Notes
- `bun run install:light` repaired the existing missing `@elizaos/shared` lock entry for `plugins/plugin-agent-orchestrator/package.json`.
- No UI changes; app visual audit is N/A.