### PR TITLE
feat(bench): add zoomGroupStats + VCAPurdue meeting datasets (extends #13378)

### DIFF
--- a/.github/issue-evidence/13359-zoomgroupstats-vcapurdue-datasets.md
+++ b/.github/issue-evidence/13359-zoomgroupstats-vcapurdue-datasets.md
@@ -1,0 +1,72 @@
+# Meeting datasets: zoomGroupStats + VCAPurdue (adapters + baselines)
+
+Issue: #13359 (parent #13352). Extends the #13378 meeting dataset adapter contract.
+
+## What was added
+
+Two video-conferencing datasets, each honestly typed to its real modality.
+
+### 1. zoomGroupStats — transcription + diarization (fits the meeting-artifact contract)
+
+- Source: https://github.com/andrewpknight/zoomGroupStats (https://zoomgroupstats.org), **MIT**.
+- New adapter `zoomgroupstats_p0_smoke` appended to
+  `elizaos_meeting_transcription_proof/dataset_adapters.py`
+  (`output_schema = elizaos.meeting_artifact.v1`, `raw_rows_committed = False`).
+- New **executable** importer `zoom_vtt.py`: parses a Zoom `transcript.vtt` (both the
+  classic `Speaker: text` inline form and the newer `<v Speaker>text</v>` voice-tag form)
+  into canonical `eliza.meeting_artifact.v1` transcript spans (ms offsets) + a diarized
+  speaker roster with stable `speaker-<slug>` foreign keys. Unlabeled cues map to
+  `UNIDENTIFIED` (mirrors zoomGroupStats' `userName` NA handling).
+- Because zoomGroupStats' native signal is transcript + **diarization**, the adapter
+  declares the 5 contract-required (reference-free / judge-scored) metrics **plus** its
+  primary gate: `diarization_error_rate`, `transcript_word_error_rate`,
+  `speaker_attribution_accuracy`.
+
+### 2. VCAPurdue — network / QoE (different modality, separate contract)
+
+- Source: https://www.cs.purdue.edu/homes/fahmy/datasets/VCAPurdue/ (Cherian, Prasad,
+  Fahmy, PAM 2026). ~2.6 GB, direct download, **no stated license** (academic-use assumed;
+  cite the paper).
+- **Honest finding:** VCAPurdue has NO audio/speech/speaker labels/transcripts — packet
+  traces + BESS buffer logs + frame-derived QoE (SSIM/PSNR/VIF) for Webex/Meet/Teams/Zoom.
+  It **cannot** benchmark ASR or diarization. Forcing it into the meeting-artifact contract
+  would be dishonest, so it gets a sibling contract `elizaos.vc_network_qoe.v1` in
+  `network_qoe_adapters.py` (adapter `vca_purdue_qoe`, `transcription_usable = False`) for
+  the network-side VC benchmark axis (congestion control, bandwidth adaptation, QoE).
+
+## Baselines (compare.py-style: a reference system, not a fixed number)
+
+- **zoomGroupStats diarization** → DER vs the `pyannote.audio speaker-diarization-3.1`
+  reference used in `packages/benchmarks/voice-speaker-validation` (test DER ≤ 0.45,
+  production target 0.25).
+- **zoomGroupStats transcript** → WER vs a Whisper reference (large-v3 / Groq Whisper
+  cascade), matching `voicebench`.
+- **VCAPurdue** → delta of an elizaOS RTP/capture path vs the dataset's measured per-app
+  behavior under a matched network scenario.
+
+## Data discipline
+
+- **No raw dataset rows committed.** Both adapters are `downloaded-eval`; the only fixture
+  is a **synthetic, self-authored** `fixtures/zoom_transcript_sample.vtt` (not real
+  participant data) that drives the deterministic parser test.
+- Both adapters are `eval_only = True`, `training_allowed = False`.
+
+## Verification
+
+```
+uv run --with pytest python -m pytest packages/benchmarks/meeting-transcription-proof/tests/ -q
+# 46 passed
+```
+
+Covers: contract validity for all three transcript adapters (QMSum/MeetingBank/zoomGroupStats),
+the zoomGroupStats DER/WER baseline, the VTT parser (ordered turns, ms timing, voice-tag form,
+UNIDENTIFIED fallback, canonical segment/foreign-key emission, clamped negative-duration), and
+the VCAPurdue QoE contract (network-QoE modality, data-free, eval-only, reference baseline).
+
+## Follow-ups flagged
+
+- Schema-id mismatch: the TS canonical is `eliza.meeting_artifact.v1`
+  (`packages/shared/src/meeting-artifacts.ts`) but the Python contract uses
+  `elizaos.meeting_artifact.v1`. Reconcile in a follow-up so producers/validators agree.
+- Publishable runs still require a real provider + judge model (per the contract); this PR
+  is the data-free adapter + importer layer, not the live scored run.

--- a/packages/benchmarks/meeting-transcription-proof/README.md
+++ b/packages/benchmarks/meeting-transcription-proof/README.md
@@ -40,6 +40,41 @@ must download the selected rows at runtime, record source revisions and hashes,
 produce meeting artifacts and score JSON, and attach real provider/model outputs
 with manually reviewed representative successes and failures.
 
+### zoomGroupStats (transcription + diarization)
+
+`dataset_adapters.py` also carries `zoomgroupstats_p0_smoke`
+([zoomGroupStats](https://zoomgroupstats.org), MIT). Unlike QMSum/MeetingBank
+(query-summary corpora), its native signal is transcript accuracy + **diarization**,
+so it declares the 5 required (reference-free, judge-scored) metrics plus
+`diarization_error_rate` / `transcript_word_error_rate` /
+`speaker_attribution_accuracy`. `zoom_vtt.py` is the executable importer: it parses a
+Zoom `transcript.vtt` (inline `Speaker: text` and `<v Speaker>text</v>` forms) into
+canonical `eliza.meeting_artifact.v1` transcript spans + a diarized speaker roster with
+stable foreign keys. **Baseline:** DER vs the `pyannote` reference used in
+`voice-speaker-validation`; WER vs a Whisper reference (as in `voicebench`).
+
+```python
+from elizaos_meeting_transcription_proof import parse_zoom_vtt
+segments = parse_zoom_vtt(open("transcript.vtt").read()).to_meeting_artifact_segments()
+# -> {"transcriptSpans": [...], "diarizedSpeakers": [...]}
+```
+
+### VCAPurdue (network / QoE — a different modality)
+
+`network_qoe_adapters.py` carries `vca_purdue_qoe`
+([VCAPurdue](https://www.cs.purdue.edu/homes/fahmy/datasets/VCAPurdue/)). This dataset
+is **network measurement** (packet traces + BESS buffer logs + SSIM/PSNR/VIF QoE for
+Webex/Meet/Teams/Zoom) with **no audio, speech, speaker labels, or transcripts** — it
+**cannot** benchmark ASR or diarization. Rather than misfit it into the meeting-artifact
+contract, it uses a sibling `elizaos.vc_network_qoe.v1` contract for the network-side VC
+benchmark axis (congestion control, bandwidth adaptation, objective video QoE), with the
+dataset's own measured per-app behavior as the reference baseline. For
+transcript+diarization use zoomGroupStats (above) or AMI/ICSI/VoxConverse/DIHARD.
+
+No raw dataset rows are committed for either adapter (`downloaded-eval`); the only
+checked-in sample is a synthetic, self-authored `fixtures/zoom_transcript_sample.vtt`
+that drives the deterministic parser test.
+
 ## Report Contract
 
 The CLI writes `meeting-transcription-proof-report.json`. The scorer accepts two

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/__init__.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/__init__.py
@@ -1,5 +1,20 @@
 """Meeting transcription proof benchmark package."""
 
 from .cli import build_report, main, validate_manifest
+from .dataset_adapters import build_adapter_contract, validate_adapter_contract
+from .network_qoe_adapters import (
+    build_qoe_adapter_contract,
+    validate_qoe_adapter_contract,
+)
+from .zoom_vtt import parse_zoom_vtt
 
-__all__ = ["build_report", "main", "validate_manifest"]
+__all__ = [
+    "build_report",
+    "main",
+    "validate_manifest",
+    "build_adapter_contract",
+    "validate_adapter_contract",
+    "build_qoe_adapter_contract",
+    "validate_qoe_adapter_contract",
+    "parse_zoom_vtt",
+]

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
@@ -153,6 +153,99 @@ ADAPTERS: tuple[dict[str, Any], ...] = (
             "note": "City-council benchmark rows stay eval-only unless product/legal approve training use.",
         },
     },
+    {
+        # zoomGroupStats (https://zoomgroupstats.org, MIT) turns Zoom cloud-recording
+        # exports into datasets. Its `transcript.vtt` maps 1:1 to canonical speaker
+        # turns, so unlike QMSum/MeetingBank (query-summary corpora) this adapter's
+        # native signal is transcript accuracy + DIARIZATION — the summarization
+        # metrics below are reference-free (judge-scored against the transcript), and
+        # the diarization/WER metrics are the primary gate. See zoom_vtt.py for the
+        # executable .vtt -> meeting-artifact importer.
+        "id": "zoomgroupstats_p0_smoke",
+        "source_url": "https://github.com/andrewpknight/zoomGroupStats",
+        "task_family": "transcription_diarization",
+        "license_access": {
+            "repo_license": "MIT",
+            "raw_data_policy": "downloaded-eval",
+            "notes": (
+                "zoomGroupStats is MIT-licensed and ships sample exports under "
+                "inst/extdata (meeting001-003 transcript.vtt/chat.txt/participants.csv) "
+                "usable with no Zoom account; real rows are a user's own Zoom cloud "
+                "recording (transcript.vtt from Recordings, participants.csv from "
+                "Reports), downloaded at run time. Raw rows are never committed; a "
+                "synthetic MIT-clean .vtt fixture drives the deterministic parser test."
+            ),
+        },
+        "selected_split": {
+            "dataset": "zoomGroupStats",
+            "split": "inst/extdata",
+            "source_domains": ["zoom_cloud_recording"],
+        },
+        "row_selection": {
+            "strategy": "first_n_after_download",
+            "row_count": 3,
+            "row_id_fields": ["meeting_id"],
+            "content_hash_fields": ["transcript_vtt", "participants_csv"],
+            "raw_rows_committed": False,
+        },
+        "required_hashes": [
+            "source_revision",
+            "row_id",
+            "transcript_sha256",
+            "participants_sha256",
+            "adapter_config_sha256",
+        ],
+        "output_schema": MEETING_ARTIFACT_SCHEMA,
+        "scenario_runner": {
+            "kind": "meeting_artifact_eval",
+            "scenario_id_prefix": "zoomgroupstats-p0",
+            "input_fields": ["transcript_vtt", "participants_csv"],
+            "expected_artifact_fields": [
+                "transcriptSpans",
+                "diarizedSpeakers",
+                "summary",
+                "action_items",
+                "topics",
+            ],
+        },
+        "score_json": {
+            # The 5 contract-required (reference-free / judge-scored) metrics ...
+            "metrics": sorted(
+                REQUIRED_SCORE_METRICS
+                # ... plus this adapter's PRIMARY transcription/diarization gate.
+                | {
+                    "diarization_error_rate",
+                    "transcript_word_error_rate",
+                    "speaker_attribution_accuracy",
+                }
+            ),
+            "primary_metrics": [
+                "diarization_error_rate",
+                "speaker_attribution_accuracy",
+                "transcript_word_error_rate",
+            ],
+            "baseline": {
+                # compare.py-style baseline: a reference system, not a fixed number.
+                "diarization_reference": "pyannote.audio speaker-diarization-3.1",
+                "transcript_reference": "whisper (large-v3) / Groq Whisper cascade",
+                "note": (
+                    "Diarization scored as DER vs the pyannote reference used in "
+                    "packages/benchmarks/voice-speaker-validation (test DER<=0.45, "
+                    "production target 0.25); transcript scored as WER vs a Whisper "
+                    "reference like voicebench. Summarization metrics are reference-"
+                    "free judge scores over the produced transcript."
+                ),
+            },
+            "requires_judge_model": True,
+            "requires_manual_review": True,
+            "publishable_requires_real_provider": True,
+        },
+        "training_eval_separation": {
+            "eval_only": True,
+            "training_allowed": False,
+            "note": "Zoom recordings are participant data; eval-only, never training, without explicit consent + approval.",
+        },
+    },
 )
 
 

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/network_qoe_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/network_qoe_adapters.py
@@ -1,0 +1,198 @@
+"""Network-QoE video-conferencing dataset adapters (distinct modality).
+
+Some video-conferencing datasets carry no audio/speech/transcript and so cannot
+feed the meeting-artifact transcription/diarization benchmark. VCAPurdue is one:
+it is a network measurement corpus — packet traces, BESS-switch buffer logs, and
+frame-derived video-QoE metrics (SSIM/PSNR/VIF) captured from Cisco Webex, Google
+Meet, Microsoft Teams, and Zoom under controlled network conditions
+(https://www.cs.purdue.edu/homes/fahmy/datasets/VCAPurdue/).
+
+Forcing it into ``elizaos.meeting_dataset_adapter.v1`` (which requires an
+``elizaos.meeting_artifact.v1`` transcript output) would be dishonest — there is
+no transcript to produce. Instead this module defines a sibling contract,
+``elizaos.vc_network_qoe.v1``, for the network/QoE benchmark axis: how well an
+elizaOS-hosted VC/RTP path (or an on-device capture pipeline) behaves for
+congestion control, bandwidth adaptation, and objective video quality under
+adverse networks — measured against the dataset's per-app reference behavior.
+
+Same discipline as the transcript adapters: raw rows are never committed
+(downloaded at run time), metrics are declared, and the baseline is a reference
+system (the dataset's own per-app measured behavior), not a fabricated number.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+VC_QOE_ADAPTER_SCHEMA = "elizaos.vc_network_qoe.v1"
+
+REQUIRED_QOE_ADAPTER_FIELDS = {
+    "id",
+    "source_url",
+    "modality",
+    "license_access",
+    "apps_covered",
+    "scenarios",
+    "row_selection",
+    "required_hashes",
+    "metrics",
+    "baseline",
+    "training_eval_separation",
+}
+
+# Objective network + video-QoE metrics VCAPurdue can gate.
+REQUIRED_QOE_METRICS = {
+    "throughput_kbps",
+    "one_way_latency_ms",
+    "packet_loss_rate",
+    "rebuffer_ratio",
+    "ssim",
+    "psnr_db",
+    "vif",
+}
+
+QOE_ADAPTERS: tuple[dict[str, Any], ...] = (
+    {
+        "id": "vca_purdue_qoe",
+        "source_url": "https://www.cs.purdue.edu/homes/fahmy/datasets/VCAPurdue/",
+        "download_url": "http://www.cs.purdue.edu/homes/fahmy/datasets/VCAPurdue/pam2026.zip",
+        "modality": "network_qoe",
+        "license_access": {
+            "repo_license": "unspecified",
+            "raw_data_policy": "downloaded-eval",
+            "notes": (
+                "No explicit license/terms posted on the dataset page (~2.6 GB zip, "
+                "direct download, no login). Treat as academic-use; cite Cherian, "
+                "Prasad, Fahmy, 'A Microscopic View of Congestion Control Behavior in "
+                "Video Conferencing Applications', PAM 2026. Confirm redistribution "
+                "terms with the authors (prasad67@purdue.edu) before caching. Raw "
+                "traces/logs are never committed to this repo."
+            ),
+        },
+        "apps_covered": ["webex", "google_meet", "microsoft_teams", "zoom"],
+        "scenarios": [
+            "constant_bandwidth",
+            "changing_bandwidth",
+            "tcp_background_traffic",
+            "udp_background_traffic",
+        ],
+        "per_sample_files": {
+            "traffic_csv": 4,  # in/out x before/after buffer; 5-tuple flow + RTP meta
+            "buffer_log": 2,  # BESS switch queue occupancy + packet loss
+            "qoe_csv": 1,  # frame-level latency, SSIM, PSNR, VIF
+        },
+        "row_selection": {
+            "strategy": "per_app_per_scenario_after_download",
+            "row_count": 8,  # 4 apps x 2 representative scenarios for the smoke gate
+            "row_id_fields": ["app", "scenario", "capture_id"],
+            "content_hash_fields": ["traffic_csv", "buffer_log", "qoe_csv"],
+            "raw_rows_committed": False,
+        },
+        "required_hashes": [
+            "source_revision",
+            "row_id",
+            "traffic_csv_sha256",
+            "qoe_csv_sha256",
+            "adapter_config_sha256",
+        ],
+        "metrics": sorted(REQUIRED_QOE_METRICS),
+        "baseline": {
+            # The dataset's own measured per-app behavior is the reference; an
+            # elizaOS VC/RTP path is compared to it under the same scenario, the
+            # compare.py way (delta vs a reference system, not a fixed number).
+            "kind": "reference_system_per_app",
+            "reference": "VCAPurdue measured Webex/Meet/Teams/Zoom behavior",
+            "comparison": "delta of elizaOS RTP path vs dataset app under matched scenario",
+            "note": (
+                "Not a transcription baseline. Gates network-side VC quality: "
+                "congestion-control responsiveness, bandwidth-probe behavior, "
+                "loss/latency under adverse networks, and objective video QoE."
+            ),
+        },
+        "training_eval_separation": {
+            "eval_only": True,
+            "training_allowed": False,
+            "note": "Network measurement corpus; eval-only.",
+        },
+        "transcription_usable": False,
+        "usability_note": (
+            "VCAPurdue has NO audio/speech/speaker labels/transcripts, so it cannot "
+            "benchmark ASR or diarization. For transcript+diarization use "
+            "zoomgroupstats_p0_smoke (this package) or AMI/ICSI/VoxConverse/DIHARD."
+        ),
+    },
+)
+
+
+def build_qoe_adapter_contract() -> dict[str, Any]:
+    return {
+        "schema": VC_QOE_ADAPTER_SCHEMA,
+        "adapters": deepcopy(list(QOE_ADAPTERS)),
+        "raw_data_committed": False,
+        "publishable_run_required": True,
+    }
+
+
+def validate_qoe_adapter_contract(contract: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if contract.get("schema") != VC_QOE_ADAPTER_SCHEMA:
+        errors.append(f"schema must be {VC_QOE_ADAPTER_SCHEMA}")
+    if contract.get("raw_data_committed") is not False:
+        errors.append("raw_data_committed must be false")
+    if contract.get("publishable_run_required") is not True:
+        errors.append("publishable_run_required must be true")
+
+    adapters = contract.get("adapters")
+    if not isinstance(adapters, list) or not adapters:
+        return [*errors, "adapters must be a non-empty array"]
+
+    seen_ids: set[str] = set()
+    for index, adapter in enumerate(adapters):
+        if not isinstance(adapter, dict):
+            errors.append(f"adapters[{index}] must be an object")
+            continue
+        missing = REQUIRED_QOE_ADAPTER_FIELDS - set(adapter)
+        if missing:
+            errors.append(f"adapters[{index}] missing fields: {sorted(missing)}")
+        adapter_id = adapter.get("id")
+        if not isinstance(adapter_id, str) or not adapter_id:
+            errors.append(f"adapters[{index}].id must be non-empty")
+        elif adapter_id in seen_ids:
+            errors.append(f"duplicate adapter id: {adapter_id}")
+        else:
+            seen_ids.add(adapter_id)
+        if adapter.get("modality") != "network_qoe":
+            errors.append(f"adapters[{index}].modality must be network_qoe")
+        license_access = adapter.get("license_access")
+        if not isinstance(license_access, dict):
+            errors.append(f"adapters[{index}].license_access must be an object")
+            license_access = {}
+        if license_access.get("raw_data_policy") != "downloaded-eval":
+            errors.append(f"adapters[{index}].license_access.raw_data_policy must be downloaded-eval")
+        row_selection = adapter.get("row_selection")
+        if not isinstance(row_selection, dict):
+            errors.append(f"adapters[{index}].row_selection must be an object")
+            row_selection = {}
+        if row_selection.get("raw_rows_committed") is not False:
+            errors.append(f"adapters[{index}].row_selection.raw_rows_committed must be false")
+        row_count = row_selection.get("row_count")
+        if isinstance(row_count, bool) or not isinstance(row_count, int) or row_count <= 0:
+            errors.append(f"adapters[{index}].row_selection.row_count must be positive")
+        required_hashes = adapter.get("required_hashes")
+        if not isinstance(required_hashes, list) or "adapter_config_sha256" not in required_hashes:
+            errors.append(f"adapters[{index}].required_hashes must include adapter_config_sha256")
+        metrics = adapter.get("metrics")
+        metric_set = set(metrics) if isinstance(metrics, list) else set()
+        missing_metrics = REQUIRED_QOE_METRICS - metric_set
+        if missing_metrics:
+            errors.append(f"adapters[{index}].metrics missing: {sorted(missing_metrics)}")
+        if not isinstance(adapter.get("baseline"), dict):
+            errors.append(f"adapters[{index}].baseline must be an object")
+        separation = adapter.get("training_eval_separation")
+        if not isinstance(separation, dict):
+            errors.append(f"adapters[{index}].training_eval_separation must be an object")
+            separation = {}
+        if separation.get("eval_only") is not True or separation.get("training_allowed") is not False:
+            errors.append(f"adapters[{index}].training_eval_separation must be eval-only")
+    return errors

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/zoom_vtt.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/zoom_vtt.py
@@ -1,0 +1,175 @@
+"""Zoom / zoomGroupStats WebVTT transcript importer.
+
+Parses a Zoom cloud-recording ``transcript.vtt`` (the same format the MIT-licensed
+zoomGroupStats R package ingests, https://zoomgroupstats.org) into the canonical
+elizaOS meeting-artifact transcript shape: one speaker turn per cue, with
+millisecond offsets and a diarized-speaker roster derived from the cue labels.
+
+Zoom cues come in two flavours, both handled here:
+
+  * inline label  — ``Speaker Name: spoken text`` in the cue body (classic export,
+    what zoomGroupStats' ``processZoomTranscript`` reads);
+  * WebVTT voice tag — ``<v Speaker Name>spoken text</v>`` (newer exports).
+
+A cue with no resolvable label maps to the ``UNIDENTIFIED`` speaker, mirroring
+zoomGroupStats' ``userName`` NA handling, so downstream diarization scoring can
+still count the turn. This module is pure/deterministic and does no network I/O:
+the raw corpus is downloaded at run time or read from a fixture and is never
+committed (per the dataset adapter contract).
+
+Output records are intentionally the transcript-span subset of
+``eliza.meeting_artifact.v1`` (packages/shared/src/meeting-artifacts.ts) that a
+``.vtt`` can support: ``startMs``/``endMs``/``text``/``speakerId``. Fields that a
+raw transcript cannot supply (word-level timing, confidence, overlap, media
+provenance) are left to the emitting product runtime, not fabricated here.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Iterable
+
+# ``HH:MM:SS.mmm`` (Zoom always emits the hours field and 3-digit millis).
+_TIMESTAMP = re.compile(r"^(\d{2}):(\d{2}):(\d{2})\.(\d{3})$")
+_CUE_TIMING = re.compile(
+    r"^\s*(\d{2}:\d{2}:\d{2}\.\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}\.\d{3})"
+)
+_VOICE_TAG = re.compile(r"^<v\s+([^>]+)>(.*?)(?:</v>)?\s*$", re.DOTALL)
+_INLINE_LABEL = re.compile(r"^([^:]{1,80}?):\s+(.*)$", re.DOTALL)
+
+UNIDENTIFIED = "UNIDENTIFIED"
+
+
+@dataclass(frozen=True)
+class TranscriptSpan:
+    """One speaker turn — the canonical meeting-artifact transcript-span subset."""
+
+    start_ms: int
+    end_ms: int
+    text: str
+    speaker_label: str
+
+    def to_artifact_span(self, span_id: str, speaker_id: str) -> dict:
+        """Render as an ``eliza.meeting_artifact.v1`` transcriptSpans[] entry."""
+        return {
+            "id": span_id,
+            "startMs": self.start_ms,
+            "endMs": self.end_ms,
+            "text": self.text,
+            "speakerId": speaker_id,
+        }
+
+
+@dataclass
+class ParsedTranscript:
+    spans: list[TranscriptSpan] = field(default_factory=list)
+
+    @property
+    def speaker_labels(self) -> list[str]:
+        """Distinct speaker labels in first-appearance order (diarization roster)."""
+        seen: dict[str, None] = {}
+        for span in self.spans:
+            seen.setdefault(span.speaker_label, None)
+        return list(seen)
+
+    def to_meeting_artifact_segments(self) -> dict:
+        """Canonical transcriptSpans[] + diarizedSpeakers[] for a MeetingArtifact.
+
+        Speaker ids are stable (``speaker-<slug>``) so repeated runs over the same
+        transcript produce identical foreign keys — required for deterministic
+        diarization scoring.
+        """
+        speaker_ids = {
+            label: f"speaker-{_slug(label)}" for label in self.speaker_labels
+        }
+        diarized = [
+            {
+                "id": speaker_ids[label],
+                "sourceStreamIds": [],
+                "name": {
+                    "displayName": None if label == UNIDENTIFIED else label,
+                    "provenance": "unknown" if label == UNIDENTIFIED else "platform",
+                    "confidence": 0.0 if label == UNIDENTIFIED else 1.0,
+                },
+                "status": "unresolved" if label == UNIDENTIFIED else "resolved",
+            }
+            for label in self.speaker_labels
+        ]
+        spans = [
+            span.to_artifact_span(f"span-{index}", speaker_ids[span.speaker_label])
+            for index, span in enumerate(self.spans)
+        ]
+        return {"transcriptSpans": spans, "diarizedSpeakers": diarized}
+
+
+def _slug(label: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-")
+    return slug or "unidentified"
+
+
+def _timestamp_to_ms(value: str) -> int:
+    match = _TIMESTAMP.match(value)
+    if not match:
+        raise ValueError(f"invalid WebVTT timestamp: {value!r}")
+    hours, minutes, seconds, millis = (int(part) for part in match.groups())
+    return ((hours * 60 + minutes) * 60 + seconds) * 1000 + millis
+
+
+def _split_label(body: str) -> tuple[str, str]:
+    """Return ``(speaker_label, text)`` for a cue body, falling back to UNIDENTIFIED."""
+    voice = _VOICE_TAG.match(body)
+    if voice:
+        label = voice.group(1).strip()
+        return (label or UNIDENTIFIED, voice.group(2).strip())
+    inline = _INLINE_LABEL.match(body)
+    if inline:
+        label = inline.group(1).strip()
+        # Reject a timestamp-looking prefix (rare malformed cue) as a non-label.
+        if label and not _TIMESTAMP.match(label):
+            return (label, inline.group(2).strip())
+    return (UNIDENTIFIED, body.strip())
+
+
+def parse_zoom_vtt(text: str) -> ParsedTranscript:
+    """Parse a Zoom ``transcript.vtt`` string into ordered speaker-turn spans.
+
+    Tolerant of the ``WEBVTT`` header, blank separators, optional numeric cue ids,
+    and multi-line cue bodies. End timestamps are clamped to be >= start so a
+    malformed cue never yields a negative-duration span.
+    """
+    transcript = ParsedTranscript()
+    lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    index = 0
+    total = len(lines)
+    while index < total:
+        line = lines[index].strip()
+        index += 1
+        timing = _CUE_TIMING.match(line)
+        if not timing:
+            continue
+        start_ms = _timestamp_to_ms(timing.group(1))
+        end_ms = max(_timestamp_to_ms(timing.group(2)), start_ms)
+        body_lines: list[str] = []
+        while index < total and lines[index].strip() != "":
+            body_lines.append(lines[index].strip())
+            index += 1
+        if not body_lines:
+            continue
+        speaker_label, spoken = _split_label("\n".join(body_lines))
+        if not spoken:
+            continue
+        transcript.spans.append(
+            TranscriptSpan(
+                start_ms=start_ms,
+                end_ms=end_ms,
+                text=spoken,
+                speaker_label=speaker_label,
+            )
+        )
+    return transcript
+
+
+def iter_speaker_turns(text: str) -> Iterable[TranscriptSpan]:
+    """Convenience generator over parsed speaker turns."""
+    yield from parse_zoom_vtt(text).spans

--- a/packages/benchmarks/meeting-transcription-proof/fixtures/zoom_transcript_sample.vtt
+++ b/packages/benchmarks/meeting-transcription-proof/fixtures/zoom_transcript_sample.vtt
@@ -1,0 +1,25 @@
+WEBVTT
+
+1
+00:00:00.000 --> 00:00:03.500
+Alice Kim: Thanks everyone for joining, let's start with the roadmap.
+
+2
+00:00:03.800 --> 00:00:07.200
+Bob Ng: Sounds good. I'll cover the ingestion changes first.
+
+3
+00:00:07.400 --> 00:00:11.900
+Bob Ng: We cut the p95 latency from 400ms to 120ms after the batching fix.
+
+4
+00:00:12.100 --> 00:00:15.000
+Alice Kim: That's a big win. Can you own the rollout note by Friday?
+
+5
+00:00:15.200 --> 00:00:16.400
+Bob Ng: Yes, I'll write it up.
+
+6
+00:00:16.800 --> 00:00:20.500
+<v Carol Diaz>Quick flag: the mobile build is still failing on the new SDK.

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
@@ -24,6 +24,7 @@ def test_qmsum_and_meetingbank_contract_is_valid() -> None:
     assert {adapter["id"] for adapter in contract["adapters"]} == {
         "qmsum_p0_smoke",
         "meetingbank_p0_smoke",
+        "zoomgroupstats_p0_smoke",
     }
 
 
@@ -61,7 +62,9 @@ def test_adapters_emit_meeting_artifact_and_scenario_runner_metadata() -> None:
         assert adapter["scenario_runner"]["scenario_id_prefix"]
         assert adapter["scenario_runner"]["input_fields"]
         assert adapter["scenario_runner"]["expected_artifact_fields"]
-        assert set(adapter["score_json"]["metrics"]) == REQUIRED_SCORE_METRICS
+        # Every adapter carries at least the 5 contract-required metrics; a
+        # transcription/diarization adapter (zoomgroupstats) adds more (DER/WER).
+        assert REQUIRED_SCORE_METRICS <= set(adapter["score_json"]["metrics"])
         assert adapter["score_json"]["requires_judge_model"] is True
         assert adapter["score_json"]["requires_manual_review"] is True
         assert adapter["score_json"]["publishable_requires_real_provider"] is True
@@ -72,6 +75,27 @@ def test_adapters_are_eval_only_until_explicit_training_approval() -> None:
         assert adapter["training_eval_separation"]["eval_only"] is True
         assert adapter["training_eval_separation"]["training_allowed"] is False
         assert "training" in adapter["training_eval_separation"]["note"].lower()
+
+
+def test_zoomgroupstats_adapter_is_transcription_diarization_with_der_wer_baseline() -> None:
+    adapters = {a["id"]: a for a in build_adapter_contract()["adapters"]}
+    zgs = adapters["zoomgroupstats_p0_smoke"]
+
+    assert zgs["license_access"]["repo_license"] == "MIT"
+    assert zgs["task_family"] == "transcription_diarization"
+    assert zgs["row_selection"]["raw_rows_committed"] is False
+    # Native diarization/transcript metrics on top of the required 5.
+    metrics = set(zgs["score_json"]["metrics"])
+    assert REQUIRED_SCORE_METRICS <= metrics
+    assert {
+        "diarization_error_rate",
+        "transcript_word_error_rate",
+        "speaker_attribution_accuracy",
+    } <= metrics
+    # Baseline is a reference system (pyannote DER / Whisper WER), not a number.
+    baseline = zgs["score_json"]["baseline"]
+    assert "pyannote" in baseline["diarization_reference"].lower()
+    assert "whisper" in baseline["transcript_reference"].lower()
 
 
 def test_validator_rejects_publishable_mock_or_raw_data_contracts() -> None:

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_network_qoe_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_network_qoe_adapters.py
@@ -1,0 +1,52 @@
+"""Contract tests for the network-QoE video-conferencing adapters (VCAPurdue).
+
+Keeps VCAPurdue honestly typed as a non-transcript modality, data-free in git,
+eval-only, and reference-baseline'd — separate from the meeting-artifact contract.
+"""
+
+from __future__ import annotations
+
+from elizaos_meeting_transcription_proof.network_qoe_adapters import (
+    REQUIRED_QOE_METRICS,
+    VC_QOE_ADAPTER_SCHEMA,
+    build_qoe_adapter_contract,
+    validate_qoe_adapter_contract,
+)
+
+
+def test_vca_purdue_qoe_contract_is_valid_and_data_free() -> None:
+    contract = build_qoe_adapter_contract()
+    assert validate_qoe_adapter_contract(contract) == []
+    assert contract["schema"] == VC_QOE_ADAPTER_SCHEMA
+    assert contract["raw_data_committed"] is False
+    assert {a["id"] for a in contract["adapters"]} == {"vca_purdue_qoe"}
+
+
+def test_vca_purdue_is_network_qoe_not_transcription() -> None:
+    vca = build_qoe_adapter_contract()["adapters"][0]
+    assert vca["modality"] == "network_qoe"
+    assert vca["transcription_usable"] is False
+    assert "no audio" in vca["usability_note"].lower()
+    assert set(vca["apps_covered"]) == {"webex", "google_meet", "microsoft_teams", "zoom"}
+    assert REQUIRED_QOE_METRICS <= set(vca["metrics"])
+    # Baseline is the dataset's measured per-app behavior, not a fixed number.
+    assert vca["baseline"]["kind"] == "reference_system_per_app"
+
+
+def test_vca_purdue_is_eval_only_and_raw_data_uncommitted() -> None:
+    vca = build_qoe_adapter_contract()["adapters"][0]
+    assert vca["row_selection"]["raw_rows_committed"] is False
+    assert vca["training_eval_separation"]["eval_only"] is True
+    assert vca["training_eval_separation"]["training_allowed"] is False
+
+
+def test_qoe_validator_rejects_committed_raw_data_and_wrong_modality() -> None:
+    contract = build_qoe_adapter_contract()
+    contract["raw_data_committed"] = True
+    contract["adapters"][0]["modality"] = "transcript"
+    contract["adapters"][0]["row_selection"]["raw_rows_committed"] = True
+
+    errors = validate_qoe_adapter_contract(contract)
+    assert "raw_data_committed must be false" in errors
+    assert "adapters[0].modality must be network_qoe" in errors
+    assert "adapters[0].row_selection.raw_rows_committed must be false" in errors

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_zoom_vtt.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_zoom_vtt.py
@@ -1,0 +1,81 @@
+"""Tests for the Zoom / zoomGroupStats WebVTT -> meeting-artifact importer.
+
+Deterministic and data-free: drives the parser over a synthetic fixture (no Zoom
+account, no committed corpus rows) and asserts speaker turns, millisecond timing,
+the diarized-speaker roster, and stable canonical foreign keys.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from elizaos_meeting_transcription_proof.zoom_vtt import (
+    UNIDENTIFIED,
+    parse_zoom_vtt,
+)
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "zoom_transcript_sample.vtt"
+
+
+def _load() -> str:
+    return FIXTURE.read_text(encoding="utf-8")
+
+
+def test_parses_every_cue_into_ordered_speaker_turns() -> None:
+    parsed = parse_zoom_vtt(_load())
+    assert len(parsed.spans) == 6
+    # Order preserved; ms offsets correct (00:00:03.800 -> 3800).
+    assert parsed.spans[0].speaker_label == "Alice Kim"
+    assert parsed.spans[0].start_ms == 0
+    assert parsed.spans[0].end_ms == 3500
+    assert parsed.spans[1].speaker_label == "Bob Ng"
+    assert parsed.spans[1].start_ms == 3800
+    assert parsed.spans[1].text.startswith("Sounds good")
+
+
+def test_handles_webvtt_voice_tag_form() -> None:
+    parsed = parse_zoom_vtt(_load())
+    # Cue 6 uses the <v Carol Diaz>...</v> voice-tag form.
+    carol = parsed.spans[-1]
+    assert carol.speaker_label == "Carol Diaz"
+    assert "mobile build" in carol.text
+    assert carol.start_ms == 16800
+
+
+def test_diarization_roster_is_first_appearance_order() -> None:
+    parsed = parse_zoom_vtt(_load())
+    assert parsed.speaker_labels == ["Alice Kim", "Bob Ng", "Carol Diaz"]
+
+
+def test_unlabeled_cue_maps_to_unidentified_speaker() -> None:
+    vtt = "WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\njust some words with no speaker\n"
+    parsed = parse_zoom_vtt(vtt)
+    assert len(parsed.spans) == 1
+    assert parsed.spans[0].speaker_label == UNIDENTIFIED
+    assert parsed.spans[0].text == "just some words with no speaker"
+
+
+def test_emits_canonical_meeting_artifact_segments_with_stable_keys() -> None:
+    segments = parse_zoom_vtt(_load()).to_meeting_artifact_segments()
+    spans = segments["transcriptSpans"]
+    speakers = {s["id"]: s for s in segments["diarizedSpeakers"]}
+
+    # Every span references a real diarized speaker (foreign key integrity).
+    assert len(spans) == 6
+    for span in spans:
+        assert span["speakerId"] in speakers
+        assert span["endMs"] >= span["startMs"]
+        assert set(span) == {"id", "startMs", "endMs", "text", "speakerId"}
+
+    # Stable, slugged speaker ids; named speakers resolved, none fabricated.
+    assert speakers["speaker-alice-kim"]["name"]["displayName"] == "Alice Kim"
+    assert speakers["speaker-alice-kim"]["name"]["provenance"] == "platform"
+    assert speakers["speaker-alice-kim"]["status"] == "resolved"
+
+
+def test_end_timestamp_clamped_not_negative_duration() -> None:
+    # Malformed cue where end < start must not produce a negative-duration span.
+    vtt = "WEBVTT\n\n00:00:05.000 --> 00:00:04.000\nDana: backwards timing\n"
+    span = parse_zoom_vtt(vtt).spans[0]
+    assert span.start_ms == 5000
+    assert span.end_ms == 5000


### PR DESCRIPTION
## What

Adds the two datasets requested for meeting/VC transcription benchmarking, each honestly typed to its real modality. **Stacked on #13378** (the dataset-adapter contract) — base will retarget to `develop` once #13378 lands; the diff here is only my additions.

Part of **#13359** (parent #13352).

### zoomGroupStats — transcription + diarization (fits the meeting-artifact contract)
- MIT (https://zoomgroupstats.org). New `zoomgroupstats_p0_smoke` adapter in `dataset_adapters.py`.
- New **executable** `zoom_vtt.py`: parses a Zoom `transcript.vtt` (inline `Speaker: text` + `<v Speaker>text</v>` forms) → canonical `eliza.meeting_artifact.v1` transcript spans (ms offsets) + diarized speaker roster with stable foreign keys; unlabeled cues → `UNIDENTIFIED`.
- Declares the 5 contract-required (reference-free/judge-scored) metrics **plus** its primary gate: `diarization_error_rate` / `transcript_word_error_rate` / `speaker_attribution_accuracy`.
- **Baseline** (compare.py-style reference system, not a number): DER vs `pyannote` (voice-speaker-validation), WER vs Whisper (voicebench).

### VCAPurdue — network / QoE (DIFFERENT modality, honest)
- Purdue/Fahmy network dataset: packet traces + BESS buffer logs + SSIM/PSNR/VIF QoE for Webex/Meet/Teams/Zoom. **No audio/speech/speaker/transcript — cannot benchmark ASR/diarization.** Rather than misfit it into the meeting-artifact schema, it gets a sibling `elizaos.vc_network_qoe.v1` contract (`network_qoe_adapters.py`, `vca_purdue_qoe`, `transcription_usable=False`) for the network-side VC axis, baselined against the dataset's measured per-app behavior.

## Data discipline
No raw dataset rows committed (both `downloaded-eval`, `eval_only`); the only fixture is a **synthetic, self-authored** `fixtures/zoom_transcript_sample.vtt`.

## Tests — 46 passing
```
uv run --with pytest python -m pytest packages/benchmarks/meeting-transcription-proof/tests/ -q   # 46 passed
```
Contract validity (QMSum/MeetingBank/zoomGroupStats + DER/WER baseline), VTT parser (ordered turns, ms timing, voice-tag, UNIDENTIFIED, clamped duration, canonical foreign keys), VCAPurdue QoE contract.

## Follow-up flagged
Schema-id mismatch: TS `eliza.meeting_artifact.v1` vs Python `elizaos.meeting_artifact.v1` — reconcile so producers/validators agree.

Part of #13359.