### PR TITLE
fix(#12784): three-state rendering for the full-page custom actions view

### DIFF
--- a/packages/ui/src/components/custom-actions/CustomActionsView.error.test.tsx
+++ b/packages/ui/src/components/custom-actions/CustomActionsView.error.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
-//
-// Three-state guard for the full-page custom actions view (#12784): a failed
-// listCustomActions load must render an explicit error state with a retry
-// path — never the designed "create your first action" empty state. A 404
-// (the custom-actions surface isn't hosted on this runtime) IS the designed
-// empty state. Toggle/delete failures must surface a visible error banner
-// instead of failing silently.
+
+/**
+ * Three-state coverage for full-page custom action loading and row mutations.
+ *
+ * Transport failures render an explicit retry state, a runtime-level 404 stays
+ * the designed empty state, and per-row write failures surface an alert while
+ * keeping the server-confirmed row state visible.
+ */
 
 import {
   cleanup,
@@ -89,7 +90,6 @@ describe("CustomActionsView three-state rendering", () => {
     expect(
       screen.getByTestId("custom-actions-load-error").textContent,
     ).toContain("Couldn't load custom actions.");
-    // The designed empty state must NOT render on a broken endpoint.
     expect(screen.queryByText("customactionsview.EmptyTitle")).toBeNull();
   });
 
@@ -168,7 +168,6 @@ describe("CustomActionsView three-state rendering", () => {
     expect(
       screen.getByTestId("custom-actions-action-error").textContent,
     ).toContain("Couldn't update this action.");
-    // The failed toggle must not lie about the server state.
     expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
       "true",
     );

--- a/packages/ui/src/components/custom-actions/CustomActionsView.error.test.tsx
+++ b/packages/ui/src/components/custom-actions/CustomActionsView.error.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+//
+// Three-state guard for the full-page custom actions view (#12784): a failed
+// listCustomActions load must render an explicit error state with a retry
+// path — never the designed "create your first action" empty state. A 404
+// (the custom-actions surface isn't hosted on this runtime) IS the designed
+// empty state. Toggle/delete failures must surface a visible error banner
+// instead of failing silently.
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../../api/client-types-core";
+
+const clientMock = vi.hoisted(() => ({
+  listCustomActions: vi.fn(),
+  createCustomAction: vi.fn(),
+  updateCustomAction: vi.fn(),
+  deleteCustomAction: vi.fn(),
+}));
+
+vi.mock("../../api/client", () => ({ client: clientMock }));
+
+vi.mock("../../state", () => ({
+  useAppSelector: (
+    selector: (s: {
+      t: (
+        key: string,
+        options?: { defaultValue?: string; [key: string]: unknown },
+      ) => string;
+    }) => unknown,
+  ) =>
+    selector({
+      t: (key, options) => options?.defaultValue ?? key,
+    }),
+}));
+
+const confirmDesktopActionMock = vi.hoisted(() => vi.fn());
+vi.mock("../../utils/desktop-dialogs", () => ({
+  confirmDesktopAction: confirmDesktopActionMock,
+  alertDesktopMessage: vi.fn(),
+}));
+
+vi.mock("./CustomActionEditor", () => ({
+  CustomActionEditor: () => null,
+}));
+
+import { CustomActionsView } from "./CustomActionsView";
+
+const sampleAction = {
+  id: "action-1",
+  name: "Ping service",
+  description: "Pings the service",
+  enabled: true,
+  handler: { type: "http" },
+  parameters: [],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  clientMock.listCustomActions.mockReset();
+  clientMock.updateCustomAction.mockReset();
+  clientMock.deleteCustomAction.mockReset();
+  confirmDesktopActionMock.mockReset();
+});
+
+describe("CustomActionsView three-state rendering", () => {
+  it("renders the error state (not the designed empty state) when the load 500s", async () => {
+    clientMock.listCustomActions.mockRejectedValue(
+      new ApiError({
+        kind: "http",
+        path: "/api/custom-actions",
+        message: "Internal Server Error",
+        status: 500,
+      }),
+    );
+
+    render(<CustomActionsView />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("custom-actions-load-error")).not.toBeNull(),
+    );
+    expect(
+      screen.getByTestId("custom-actions-load-error").textContent,
+    ).toContain("Couldn't load custom actions.");
+    // The designed empty state must NOT render on a broken endpoint.
+    expect(screen.queryByText("customactionsview.EmptyTitle")).toBeNull();
+  });
+
+  it("renders the error state on a transport failure", async () => {
+    clientMock.listCustomActions.mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+
+    render(<CustomActionsView />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("custom-actions-load-error")).not.toBeNull(),
+    );
+    expect(screen.queryByText("customactionsview.EmptyTitle")).toBeNull();
+  });
+
+  it("recovers to the list when retry succeeds", async () => {
+    clientMock.listCustomActions
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce([sampleAction]);
+
+    render(<CustomActionsView />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("custom-actions-load-error")).not.toBeNull(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Ping service")).not.toBeNull(),
+    );
+    expect(screen.queryByTestId("custom-actions-load-error")).toBeNull();
+  });
+
+  it("renders the designed empty state (not an error) when the surface 404s", async () => {
+    clientMock.listCustomActions.mockRejectedValue(
+      new ApiError({
+        kind: "http",
+        path: "/api/custom-actions",
+        message: "Not Found",
+        status: 404,
+      }),
+    );
+
+    render(<CustomActionsView />);
+
+    await waitFor(() =>
+      expect(screen.getByText("customactionsview.EmptyTitle")).not.toBeNull(),
+    );
+    expect(screen.queryByTestId("custom-actions-load-error")).toBeNull();
+  });
+
+  it("surfaces a visible error when the enable toggle fails", async () => {
+    clientMock.listCustomActions.mockResolvedValue([sampleAction]);
+    clientMock.updateCustomAction.mockRejectedValue(
+      new ApiError({
+        kind: "http",
+        path: "/api/custom-actions/action-1",
+        message: "Internal Server Error",
+        status: 500,
+      }),
+    );
+
+    render(<CustomActionsView />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Ping service")).not.toBeNull(),
+    );
+
+    fireEvent.click(screen.getByRole("switch"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("custom-actions-action-error")).not.toBeNull(),
+    );
+    expect(
+      screen.getByTestId("custom-actions-action-error").textContent,
+    ).toContain("Couldn't update this action.");
+    // The failed toggle must not lie about the server state.
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+      "true",
+    );
+  });
+
+  it("surfaces a visible error when delete fails and keeps the item listed", async () => {
+    clientMock.listCustomActions.mockResolvedValue([sampleAction]);
+    confirmDesktopActionMock.mockResolvedValue(true);
+    clientMock.deleteCustomAction.mockRejectedValue(
+      new ApiError({
+        kind: "http",
+        path: "/api/custom-actions/action-1",
+        message: "Internal Server Error",
+        status: 500,
+      }),
+    );
+
+    render(<CustomActionsView />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Ping service")).not.toBeNull(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "common.delete" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("custom-actions-action-error")).not.toBeNull(),
+    );
+    expect(
+      screen.getByTestId("custom-actions-action-error").textContent,
+    ).toContain("Couldn't delete this action.");
+    expect(screen.getByText("Ping service")).not.toBeNull();
+  });
+});

--- a/packages/ui/src/components/custom-actions/CustomActionsView.tsx
+++ b/packages/ui/src/components/custom-actions/CustomActionsView.tsx
@@ -9,6 +9,7 @@
 import type { CustomActionDef } from "@elizaos/shared";
 import { useCallback, useEffect, useId, useState } from "react";
 import { client } from "../../api/client";
+import { isApiError } from "../../api/client-types-core";
 import { useAppSelector } from "../../state";
 import {
   alertDesktopMessage,
@@ -43,14 +44,23 @@ export function CustomActionsView() {
     null,
   );
   const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const loadActions = useCallback(async () => {
     try {
       setLoading(true);
       const result = await client.listCustomActions();
       setActions(result);
-    } catch {
-      // load failure: list stays empty
+      setLoadFailed(false);
+    } catch (err) {
+      // error-policy:J4 a 404 means the custom-actions surface isn't hosted
+      // on this runtime — the designed empty state is correct there. Anything
+      // else (5xx, transport, parse) must render the explicit error state
+      // below instead of masquerading as the healthy "create your first
+      // action" empty state.
+      setActions([]);
+      setLoadFailed(!(isApiError(err) && err.status === 404));
     } finally {
       setLoading(false);
     }
@@ -83,6 +93,7 @@ export function CustomActionsView() {
 
   const handleToggleEnabled = useCallback(
     async (id: string, enabled: boolean) => {
+      setActionError(null);
       try {
         await client.updateCustomAction(id, { enabled });
         setActions((prev) =>
@@ -91,10 +102,16 @@ export function CustomActionsView() {
           ),
         );
       } catch {
-        // A failed toggle leaves the displayed state to be reconciled by the next load.
+        // The switch is not flipped optimistically, so the displayed state is
+        // still the server's; surface the failure instead of staying silent.
+        setActionError(
+          t("customactionspanel.UpdateFailed", {
+            defaultValue: "Couldn't update this action. Try again.",
+          }),
+        );
       }
     },
-    [],
+    [t],
   );
 
   const handleDelete = useCallback(
@@ -110,11 +127,18 @@ export function CustomActionsView() {
         return;
       }
 
+      setActionError(null);
       try {
         await client.deleteCustomAction(id);
         setActions((prev) => prev.filter((action) => action.id !== id));
       } catch {
-        // A failed delete keeps the item visible for retry.
+        // The item stays visible for retry; tell the user why it's still
+        // there rather than failing silently.
+        setActionError(
+          t("customactionspanel.DeleteFailed", {
+            defaultValue: "Couldn't delete this action. Try again.",
+          }),
+        );
       }
     },
     [t],
@@ -187,6 +211,36 @@ export function CustomActionsView() {
     );
   }
 
+  // Load failure (non-404): an explicit error state with a retry path — never
+  // the designed "create your first action" empty state below.
+  if (loadFailed) {
+    return (
+      <div
+        data-testid="custom-actions-load-error"
+        className={CUSTOM_ACTIONS_SHELL_CLASS}
+      >
+        <div
+          role="alert"
+          className={`${CUSTOM_ACTIONS_PANEL_CLASS} flex flex-1 flex-col items-center justify-center gap-3 px-6 py-16 text-center`}
+        >
+          <p className="text-sm text-danger">
+            {t("customactionspanel.LoadFailed", {
+              defaultValue: "Couldn't load custom actions. Try again.",
+            })}
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void loadActions()}
+            className={`${CUSTOM_ACTIONS_TOOLBAR_BUTTON_CLASS} bg-bg/35 text-muted hover:bg-bg/55`}
+          >
+            {t("common.retry", { defaultValue: "Retry" })}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
   const emptyState = (
     <div
       className={`${CUSTOM_ACTIONS_PANEL_CLASS} flex flex-1 flex-col items-center justify-center px-6 py-14 text-center`}
@@ -251,6 +305,16 @@ export function CustomActionsView() {
           </span>
         </div>
       </div>
+
+      {actionError && (
+        <div
+          data-testid="custom-actions-action-error"
+          role="alert"
+          className="rounded-sm border border-danger/35 bg-danger/10 px-3 py-2 text-sm text-danger"
+        >
+          {actionError}
+        </div>
+      )}
 
       <div className={`${CUSTOM_ACTIONS_PANEL_CLASS} p-3 sm:p-4`}>
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">

--- a/packages/ui/src/components/custom-actions/CustomActionsView.tsx
+++ b/packages/ui/src/components/custom-actions/CustomActionsView.tsx
@@ -54,11 +54,8 @@ export function CustomActionsView() {
       setActions(result);
       setLoadFailed(false);
     } catch (err) {
-      // error-policy:J4 a 404 means the custom-actions surface isn't hosted
-      // on this runtime — the designed empty state is correct there. Anything
-      // else (5xx, transport, parse) must render the explicit error state
-      // below instead of masquerading as the healthy "create your first
-      // action" empty state.
+      // error-policy:J4 a 404 means the custom-actions surface is unavailable
+      // on this runtime; other failures must not collapse into healthy-empty.
       setActions([]);
       setLoadFailed(!(isApiError(err) && err.status === 404));
     } finally {
@@ -102,8 +99,8 @@ export function CustomActionsView() {
           ),
         );
       } catch {
-        // The switch is not flipped optimistically, so the displayed state is
-        // still the server's; surface the failure instead of staying silent.
+        // The switch is not flipped optimistically, so the row still reflects
+        // server-confirmed state.
         setActionError(
           t("customactionspanel.UpdateFailed", {
             defaultValue: "Couldn't update this action. Try again.",
@@ -132,8 +129,7 @@ export function CustomActionsView() {
         await client.deleteCustomAction(id);
         setActions((prev) => prev.filter((action) => action.id !== id));
       } catch {
-        // The item stays visible for retry; tell the user why it's still
-        // there rather than failing silently.
+        // The item stays visible for retry because deletion was not confirmed.
         setActionError(
           t("customactionspanel.DeleteFailed", {
             defaultValue: "Couldn't delete this action. Try again.",
@@ -211,8 +207,7 @@ export function CustomActionsView() {
     );
   }
 
-  // Load failure (non-404): an explicit error state with a retry path — never
-  // the designed "create your first action" empty state below.
+  // Non-404 load failures get a retry path instead of healthy-empty UI.
   if (loadFailed) {
     return (
       <div

--- a/packages/ui/src/components/custom-actions/CustomActionsView.tsx
+++ b/packages/ui/src/components/custom-actions/CustomActionsView.tsx
@@ -99,8 +99,8 @@ export function CustomActionsView() {
           ),
         );
       } catch {
-        // The switch is not flipped optimistically, so the row still reflects
-        // server-confirmed state.
+        // error-policy:J4 explicit row error; the switch is not flipped
+        // optimistically, so the row still reflects server-confirmed state.
         setActionError(
           t("customactionspanel.UpdateFailed", {
             defaultValue: "Couldn't update this action. Try again.",
@@ -129,7 +129,8 @@ export function CustomActionsView() {
         await client.deleteCustomAction(id);
         setActions((prev) => prev.filter((action) => action.id !== id));
       } catch {
-        // The item stays visible for retry because deletion was not confirmed.
+        // error-policy:J4 explicit row error; the item stays visible for retry
+        // because deletion was not confirmed.
         setActionError(
           t("customactionspanel.DeleteFailed", {
             defaultValue: "Couldn't delete this action. Try again.",


### PR DESCRIPTION
## Summary

Fallback-slop slice of #12784 (packages/ui three-state rule) on `CustomActionsView` — the routed full-page custom actions surface. (The slide-out `CustomActionsPanel` already renders errors and is untouched. Distinct files from the merged #13227, the merged #13240 mobile batch, and the open #13434 slash-command slice.)

**Before:**
- A failed `listCustomActions` load rendered the designed "Build reusable actions for power workflows" empty state with a Create CTA over a broken endpoint (`catch { // load failure: list stays empty }`).
- A failed enable/disable toggle was fully silent — the comment claimed the state would be "reconciled by the next load", but nothing told the user the write failed.
- A failed delete was fully silent while the row stayed visible.

**After:**
- 5xx/transport/parse load failures render an explicit error state with a Retry button; a 404 (custom-actions surface not hosted on this runtime) keeps the designed empty state (J4 annotation).
- Toggle and delete failures surface a visible error banner (`role="alert"`). The switch was never flipped optimistically, so the displayed state stays the server's truth.
- Reuses existing i18n keys (`customactionspanel.LoadFailed/UpdateFailed/DeleteFailed`, `common.retry`) — no locale churn.

## Tests

- **New** `CustomActionsView.error.test.tsx` (6 tests, all green):
  - 500 load → error state, designed empty state NOT rendered
  - transport failure → error state
  - Retry recovers to the loaded list
  - 404 → designed empty state, error state NOT rendered
  - toggle failure → visible banner + switch stays server-true
  - delete failure → visible banner + row kept for retry
- `customactions-stories-smoke` suite stays green (8 tests)
- `tsgo --noEmit` clean
- `audit:error-policy-ratchet` clean (0 new slop)
- codex review: "did not find any introduced correctness issues"

-- [sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>
