### PR TITLE
fix(#13408): resolve mobile bundle workspace packages

### DIFF
--- a/.github/issue-evidence/13408-ios-local-sim-workspace-resolution.md
+++ b/.github/issue-evidence/13408-ios-local-sim-workspace-resolution.md
@@ -1,0 +1,106 @@
+# Issue #13408: iOS local simulator workspace resolution
+
+## Reproduction
+
+Fresh worktree from `origin/develop`:
+
+```bash
+git worktree add /tmp/eliza-13408 -b fix/13408-ios-local-sim-workspace-resolution origin/develop
+bun install --ignore-scripts
+bun run --cwd packages/app build:ios:local:sim
+```
+
+Result: failed during `packages/agent` mobile bundle generation with unresolved
+workspace imports including:
+
+- `@elizaos/plugin-birdclaw`
+- `@elizaos/plugin-commands`
+- `@elizaos/plugin-vision`
+- `@elizaos/plugin-background-runner`
+- `@elizaos/plugin-wallet/diagnostic`
+- `@elizaos/cloud-routing`
+- `@elizaos/cloud-sdk`
+
+## Change
+
+- Added `packages/agent/scripts/lib/workspace-packages.mjs`.
+- The mobile bundle workspace fallback now resolves `@elizaos/*` package roots
+  from the monorepo workspace package manifests when the package is not linked
+  from the relevant `node_modules` tree.
+- The fallback preserves the existing `node_modules` preference, then falls back
+  to local `packages/**` and `plugins/**` workspace package roots.
+
+## Verification
+
+```bash
+node --test packages/agent/scripts/lib/workspace-packages.test.mjs
+```
+
+Result: 3 passed.
+
+```bash
+bun run --cwd packages/agent build:ios-bun
+```
+
+Result: passed. The previously failing `Bun.build` phase completed and wrote:
+
+- `packages/agent/dist-mobile-ios/agent-bundle.js` — 30,949.6 KB
+- `packages/agent/dist-mobile-ios/pglite.wasm` — 9,646.9 KB
+- `packages/agent/dist-mobile-ios/initdb.wasm` — 384.7 KB
+- `packages/agent/dist-mobile-ios/pglite.data` — 6,086.1 KB
+- `packages/agent/dist-mobile-ios/vector.tar.gz` — 43.8 KB
+- `packages/agent/dist-mobile-ios/fuzzystrmatch.tar.gz` — 11.1 KB
+- `packages/agent/dist-mobile-ios/plugins-manifest.json` — 2.9 KB
+
+```bash
+bunx @biomejs/biome check \
+  packages/agent/scripts/build-mobile-bundle.mjs \
+  packages/agent/scripts/lib/workspace-packages.mjs \
+  packages/agent/scripts/lib/workspace-packages.test.mjs \
+  --no-errors-on-unmatched
+```
+
+Result: passed.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Install / verify status
+
+After rebasing on `origin/develop`, `bun install` was attempted. It reached
+postinstall artifact sync, but the 971 MiB artifact bundle was downloading at
+roughly 0.4-0.5 MiB/s with a 30+ minute ETA and was interrupted at about 27 MiB
+downloaded.
+
+The root `bun run verify` was not rerun for this PR. The same current-tree Turbo
+cycle shown below blocks the build/typecheck/lint pipeline before this resolver
+change is exercised.
+
+## Full simulator build status
+
+After this fix, `bun run --cwd packages/app build:ios:local:sim` no longer fails
+in the `packages/agent` mobile bundle resolver. It successfully builds the iOS
+agent bundle and then reaches renderer preparation.
+
+The full simulator build is still blocked on separate current-tree build issues:
+
+1. The script's root `dev:prepare` call fails before tasks run because Turbo
+   detects the existing build cycle:
+
+```text
+@elizaos/plugin-local-inference#build, @elizaos/agent#build
+```
+
+2. Manual probing after building `@elizaos/cloud-routing`, `@elizaos/core`, and
+   `@elizaos/shared` let `packages/app build:web` start, but the exploratory
+   Vite build was interrupted after several minutes in transform. It had moved
+   past the earlier missing-dist config errors and emitted dependency warnings
+   from `@pixiv/three-vrm` / `three`.
+
+This PR fixes the workspace-resolution failure described in #13408. The
+remaining full-simulator build blockers are outside the mobile agent bundle
+resolver and overlap the repository-wide Turbo cycle also observed by
+`bun run verify`.

--- a/packages/agent/scripts/build-mobile-bundle.mjs
+++ b/packages/agent/scripts/build-mobile-bundle.mjs
@@ -46,6 +46,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createWorkspacePackageResolver } from "./lib/workspace-packages.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const agentRoot = path.resolve(here, "..");
@@ -61,6 +62,13 @@ const rmRecursiveScript = path.join(
   "scripts",
   "rm-path-recursive.mjs",
 );
+const resolveWorkspacePackageDir = createWorkspacePackageResolver({
+  repoRoot,
+  nodeModulesRoots: [
+    path.join(agentRoot, "node_modules"),
+    path.join(repoRoot, "node_modules"),
+  ],
+});
 
 function rmRecursive(targetPath) {
   const result = spawnSync(process.execPath, [rmRecursiveScript, targetPath], {
@@ -1139,18 +1147,6 @@ const stripStaleJsArtifactsPlugin = {
 const workspaceSrcFallbackPlugin = {
   name: "eliza-mobile-workspace-src-fallback",
   setup(build) {
-    const cache = new Map();
-    const resolvePackageDir = (pkgName) => {
-      if (cache.has(pkgName)) return cache.get(pkgName);
-      const pkgPath = path.resolve(
-        repoRoot,
-        "node_modules",
-        ...pkgName.split("/"),
-      );
-      const result = existsSync(pkgPath) ? pkgPath : null;
-      cache.set(pkgName, result);
-      return result;
-    };
     build.onResolve({ filter: /^@elizaos\// }, (args) => {
       // Don't override packages already handled by the dedupe / capacitor
       // plugins. Order matters: those plugins run earlier in the array.
@@ -1161,7 +1157,7 @@ const workspaceSrcFallbackPlugin = {
       // `@elizaos/foo` => 2 segments; `@elizaos/foo/bar` => 3+
       const pkgName = `${segments[0]}/${segments[1]}`;
       const subpath = segments.slice(2).join("/");
-      const pkgDir = resolvePackageDir(pkgName);
+      const pkgDir = resolveWorkspacePackageDir(pkgName);
       if (!pkgDir) return undefined;
 
       // Identity-pinned packages (see dedupePlugin) must resolve their

--- a/packages/agent/scripts/lib/workspace-packages.mjs
+++ b/packages/agent/scripts/lib/workspace-packages.mjs
@@ -1,0 +1,103 @@
+import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
+import path from "node:path";
+
+const SKIPPED_DIRS = new Set([
+  ".git",
+  ".turbo",
+  "android",
+  "build",
+  "dist",
+  "dist-mobile",
+  "dist-mobile-ios",
+  "dist-mobile-ios-jsc",
+  "ios",
+  "node_modules",
+]);
+
+function readPackageName(packageJsonPath) {
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    return typeof parsed.name === "string" ? parsed.name : null;
+  } catch {
+    return null;
+  }
+}
+
+function realpathIfPossible(value) {
+  try {
+    return realpathSync(value);
+  } catch {
+    return value;
+  }
+}
+
+function collectWorkspacePackages(root, packagesByName) {
+  if (!existsSync(root)) return;
+  const entries = readdirSync(root, { withFileTypes: true });
+  if (
+    entries.some((entry) => entry.isFile() && entry.name === "package.json")
+  ) {
+    const packageJsonPath = path.join(root, "package.json");
+    const packageName = readPackageName(packageJsonPath);
+    if (packageName?.startsWith("@elizaos/")) {
+      packagesByName.set(packageName, realpathIfPossible(root));
+    }
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || SKIPPED_DIRS.has(entry.name)) continue;
+    collectWorkspacePackages(path.join(root, entry.name), packagesByName);
+  }
+}
+
+export function createWorkspacePackageResolver({
+  repoRoot,
+  nodeModulesRoots = [path.join(repoRoot, "node_modules")],
+  workspaceRoots = [
+    path.join(repoRoot, "packages"),
+    path.join(repoRoot, "plugins"),
+  ],
+} = {}) {
+  if (!repoRoot) {
+    throw new Error("repoRoot is required");
+  }
+
+  const nodeModuleCache = new Map();
+  const workspaceCache = new Map();
+  let workspacePackages = null;
+
+  function resolveFromNodeModules(packageName) {
+    if (nodeModuleCache.has(packageName))
+      return nodeModuleCache.get(packageName);
+    for (const root of nodeModulesRoots) {
+      const candidate = path.join(root, ...packageName.split("/"));
+      if (existsSync(candidate)) {
+        const resolved = realpathIfPossible(candidate);
+        nodeModuleCache.set(packageName, resolved);
+        return resolved;
+      }
+    }
+    nodeModuleCache.set(packageName, null);
+    return null;
+  }
+
+  function resolveFromWorkspace(packageName) {
+    if (workspaceCache.has(packageName)) return workspaceCache.get(packageName);
+    if (!workspacePackages) {
+      workspacePackages = new Map();
+      for (const root of workspaceRoots) {
+        collectWorkspacePackages(root, workspacePackages);
+      }
+    }
+    const resolved = workspacePackages.get(packageName) ?? null;
+    workspaceCache.set(packageName, resolved);
+    return resolved;
+  }
+
+  return function resolvePackageDir(packageName) {
+    return (
+      resolveFromNodeModules(packageName) ?? resolveFromWorkspace(packageName)
+    );
+  };
+}

--- a/packages/agent/scripts/lib/workspace-packages.test.mjs
+++ b/packages/agent/scripts/lib/workspace-packages.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { createWorkspacePackageResolver } from "./workspace-packages.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../../..");
+
+test("workspace resolver finds plugin packages not linked at root node_modules", () => {
+  const resolvePackageDir = createWorkspacePackageResolver({
+    repoRoot,
+    nodeModulesRoots: [path.join(repoRoot, ".missing-node-modules")],
+  });
+
+  assert.equal(
+    resolvePackageDir("@elizaos/plugin-vision"),
+    path.join(repoRoot, "plugins", "plugin-vision"),
+  );
+  assert.equal(
+    resolvePackageDir("@elizaos/plugin-birdclaw"),
+    path.join(repoRoot, "plugins", "plugin-birdclaw"),
+  );
+});
+
+test("workspace resolver finds nested cloud packages", () => {
+  const resolvePackageDir = createWorkspacePackageResolver({
+    repoRoot,
+    nodeModulesRoots: [path.join(repoRoot, ".missing-node-modules")],
+  });
+
+  assert.equal(
+    resolvePackageDir("@elizaos/cloud-routing"),
+    path.join(repoRoot, "packages", "cloud", "routing"),
+  );
+  assert.equal(
+    resolvePackageDir("@elizaos/cloud-sdk"),
+    path.join(repoRoot, "packages", "cloud", "sdk"),
+  );
+});
+
+test("workspace resolver returns package roots used for subpath fallbacks", () => {
+  const resolvePackageDir = createWorkspacePackageResolver({
+    repoRoot,
+    nodeModulesRoots: [path.join(repoRoot, ".missing-node-modules")],
+  });
+
+  assert.equal(
+    resolvePackageDir("@elizaos/plugin-wallet"),
+    path.join(repoRoot, "plugins", "plugin-wallet"),
+  );
+});


### PR DESCRIPTION
## Summary
- add a mobile-bundle workspace package resolver that falls back from node_modules links to local packages/** and plugins/** package manifests
- use it in the @elizaos/agent mobile bundle workspace source fallback
- add a node:test contract for plugin packages, nested cloud packages, and subpath package roots that are missing from root node_modules in light/ignore-scripts installs

## Evidence
- Evidence note: .github/issue-evidence/13408-ios-local-sim-workspace-resolution.md
- Reproduced the original failure in a fresh worktree after `bun install --ignore-scripts`; `packages/app build:ios:local:sim` failed during `packages/agent` mobile bundle generation on unresolved `@elizaos/plugin-birdclaw`, `@elizaos/plugin-commands`, `@elizaos/plugin-vision`, `@elizaos/plugin-background-runner`, `@elizaos/plugin-wallet/diagnostic`, `@elizaos/cloud-routing`, and `@elizaos/cloud-sdk`.
- `node --test packages/agent/scripts/lib/workspace-packages.test.mjs` (3 passed)
- `bun run --cwd packages/agent build:ios-bun` (passed; wrote `dist-mobile-ios/agent-bundle.js` and runtime assets)
- `bunx @biomejs/biome check packages/agent/scripts/build-mobile-bundle.mjs packages/agent/scripts/lib/workspace-packages.mjs packages/agent/scripts/lib/workspace-packages.test.mjs --no-errors-on-unmatched` (passed)
- `git diff --check` (passed)

## Remaining blockers for #13408
This PR fixes the workspace-resolution failure in the iOS agent bundle phase, but does not close #13408. A full `bun run --cwd packages/app build:ios:local:sim` still hits separate current-tree build blockers after the agent bundle succeeds:
- root `dev:prepare` fails before tasks run on the existing Turbo cycle between `@elizaos/plugin-local-inference#build` and `@elizaos/agent#build`
- manual probing of `packages/app build:web` after minimal package builds moved past missing-dist config errors but was interrupted after several minutes in Vite transform

## Install / verify note
- `bun install` after rebase was attempted, but postinstall artifact sync was downloading the 971 MiB bundle at ~0.4-0.5 MiB/s with a 30+ minute ETA and was interrupted at ~27 MiB.
- Root `bun run verify` was not rerun because the same Turbo cycle blocks the workspace pipeline before this resolver change is exercised.

Refs #13408