### PR TITLE
fix(#13441): avoid cycle-prone mobile web prep

### DIFF
--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -1198,12 +1198,39 @@ async function buildWeb(platform) {
     await run(process.execPath, [packageStylesPatch], { cwd: repoRoot, env });
   }
   if (bun) {
+    const coreEntry = path.join(
+      packagesRoot,
+      "core",
+      "dist",
+      "node",
+      "index.node.js",
+    );
+    if (!fs.existsSync(coreEntry)) {
+      console.log(
+        "[mobile-build] Building @elizaos/core for mobile web bundle.",
+      );
+      await run(
+        bun,
+        ["run", "--cwd", path.join(packagesRoot, "core"), "build"],
+        {
+          cwd: repoRoot,
+          env,
+        },
+      );
+    }
     const sharedEntry = path.join(packagesRoot, "shared", "dist", "index.js");
     if (!fs.existsSync(sharedEntry)) {
       console.log(
-        "[mobile-build] Building workspace dependencies for mobile web bundle.",
+        "[mobile-build] Building @elizaos/shared for mobile web bundle.",
       );
-      await run(bun, ["run", "dev:prepare"], { cwd: repoRoot, env });
+      await run(
+        bun,
+        ["run", "--cwd", path.join(packagesRoot, "shared"), "build"],
+        {
+          cwd: repoRoot,
+          env,
+        },
+      );
     }
     await run(bun, ["run", "build:web"], { cwd: appDir, env });
     return;


### PR DESCRIPTION
## Summary

Fixes #13441, the follow-up blocker discovered after PR #13435 gets the iOS local simulator build past the mobile agent bundle resolver phase.

The iOS local simulator lane only checked for `packages/shared/dist/index.js`, but if it was missing it ran the broad root `dev:prepare` target:

```bash
node packages/scripts/run-turbo.mjs run build --filter=@elizaos/app... --filter=!@elizaos/app
```

That graph currently includes a Turbo cycle between `@elizaos/plugin-local-inference#build` and `@elizaos/agent#build`, blocking the build before the app/native phases.

This PR replaces that broad prep with the concrete artifacts the mobile web build needs before Vite can load config in a fresh tree:

- build `@elizaos/core` when `packages/core/dist/node/index.node.js` is missing
- build `@elizaos/shared` when `packages/shared/dist/index.js` is missing
- then run the existing `packages/app build:web`

## Relationship to #13408 / #13435

PR #13435 is the dedicated workspace package resolver fix for #13408. This PR intentionally does not duplicate that resolver work. It addresses the next phase blocker (#13441) that appears after #13435 succeeds.

## Evidence

- `bunx @biomejs/biome check packages/app-core/scripts/run-mobile-build.mjs` passed.
- `git diff --check origin/develop...HEAD && git diff --check` passed.
- `bun run --cwd packages/core build` passed.
- `ELIZA_WEB_ABSOLUTE_BASE=1 bun run --cwd packages/app build:web` passed, including `verify-chunk-safety`.
- `bun run --cwd packages/app build:ios:local:sim` advanced past:
  - mobile agent bundle generation
  - the former Turbo `dev:prepare` cycle
  - app web build and chunk-safety
  - iOS platform template sync
  - iOS agent payload staging at `packages/app/ios/App/App/public/agent`
  - Capacitor web asset copy

## Remaining host blocker

The local simulator build now fails later because this host only has Command Line Tools and no full Xcode install:

```text
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
```

`/Applications/Xcode*.app` is absent on this machine, so I could not produce the final `.app` artifact locally. The next run on a full Xcode host should continue at `pod install` / `xcodebuild`.