### PR TITLE
fix(#13416): fail closed on corrupt usage-quota NUMERIC reads

### DIFF
--- a/.github/issue-evidence/13416-cloud-shared-db-fallback.md
+++ b/.github/issue-evidence/13416-cloud-shared-db-fallback.md
@@ -1,0 +1,85 @@
+# Evidence — #13416 fallback slop sweep: cloud-shared DB repositories (usage-quotas slice)
+
+Agent-ready successor to #12788 for the DB/repository side of `packages/cloud/shared`.
+This PR ships the **usage-quotas spend-gate slice**: the corrupt-NUMERIC-row → fail-open
+class on the quota enforcement path. Other repositories in the 47-file inventory remain
+open for follow-up slices (this issue stays open).
+
+## Before/after fallback census (this slice)
+
+Inventory re-run on `origin/develop` (base `08b5e87ff0`):
+
+```
+grep -rn -E 'Number\(|parseFloat\(|\?\? 0|\|\| \[\]' packages/cloud/shared/src/db/repositories/**  (non-test)
+```
+150 raw candidate hits across the repository tree. This slice addresses the **highest-severity
+subset**: the `usage_quotas.credits_limit` / `usage_quotas.current_usage` reads that gate metered
+spend. These columns are Postgres `NUMERIC` (surfaced as strings); a present-but-corrupt value
+flows through a bare `Number(...)` as `NaN`, and every comparison against `NaN` is `false`, which
+**silently disables the spend gate** (`newUsage > NaN` → allowed; `usage >= NaN` → not exceeded).
+
+## Path/line/verdict table
+
+| Path | Line(s) (pre-fix) | Field | Verdict | Fix |
+|---|---|---|---|---|
+| `src/db/repositories/usage-quotas.ts` | 77-78 `checkQuotaExceeded` | current_usage, credits_limit | **fail-open bug** — `NaN >= NaN` = false → "not exceeded" over corrupt row | parse via `parseUsageQuotaNumber` (throws on corrupt) |
+| `src/db/repositories/usage-quotas.ts` | 111-116 `getCurrentUsage` | current_usage, credits_limit | fabricated `NaN` in reporting DTO | same fail-closed reader |
+| `src/lib/services/usage-quotas.ts` | 102-103, 130-131 `checkQuota` (model + global) | current_usage, credits_limit | **fail-open bug** — `newUsage > NaN` = false → `{ allowed: true }` (quota bypass, unbounded metered spend) | same fail-closed reader |
+| `src/lib/services/usage-quotas.ts` | 220-221, 229-230 `getCurrentUsage` | current_usage, credits_limit | fabricated `NaN` usage % in reporting DTO | same fail-closed reader |
+
+New boundary: `src/db/repositories/usage-quotas-numeric.ts` — `parseUsageQuotaNumber(value, field)`
+throws on null/undefined/empty/whitespace (missing) and on non-finite (`NaN`/`Infinity`/non-numeric).
+Explicit domain zero (`"0.00"`, `0`) is allowed. Mirrors the fail-closed reader convention from the
+sibling app-credit-balances slice (#12788 family).
+
+Fail-closed rationale: for a spend gate, denying (or surfacing a read error) on a corrupt limit is
+security-correct — better to reject a request than to grant unbounded metered usage over a
+corrupted quota row. "No quota configured" (no rows) remains `allowed` — that is explicit domain
+policy, not a corrupt read, and is preserved + tested.
+
+## Focused test output
+
+`bun test src/db/repositories/usage-quotas-numeric.test.ts src/lib/services/__tests__/usage-quotas-fail-closed.test.ts`
+
+```
+ 17 pass
+ 0 fail
+ 26 expect() calls
+```
+
+Coverage:
+- helper: well-formed / numeric / zero (allowed) / corrupt-string throws / NaN throws / Infinity
+  throws / null|undefined|empty|whitespace throws / field-name in error.
+- regression guard: pins that a bare `Number(...)` comparison fails OPEN on a corrupt limit, and
+  that the fail-closed reader throws on that same value.
+- service seam: `checkQuota` allows with headroom, denies when exceeded, THROWS (fails closed)
+  on a corrupt global limit and a corrupt model limit, allows when no quota configured;
+  `getCurrentUsage` throws on corrupt `current_usage`, returns healthy breakdown for good rows.
+
+## Verification
+
+- `bunx @biomejs/biome check <touched files>` → **clean** (5 files, no fixes applied).
+- `bun run audit:error-policy-ratchet` → **clean** (`no new fallback-slop in touched files`).
+- `bun run --cwd packages/cloud/shared typecheck` → **zero errors in touched `usage-quotas` files**;
+  17 pre-existing baseline errors remain in unrelated files (`app-core/services/account-pool.ts`,
+  `coding-account-bridge.ts`, `plugin-mcp/utils/json.ts`, `anthropic-web-search.ts`,
+  `node-redis-adapter.ts`) — untouched by this PR.
+- `git diff --check origin/develop...HEAD && git diff --check` → clean.
+- Migrations: none touched (append-only respected).
+
+## DB row / domain artifact examples
+
+- Healthy: `credits_limit="100.00"`, `current_usage="10.00"` → `checkQuota(amount=5)` = `{ allowed: true }`.
+- Exceeded: `credits_limit="100.00"`, `current_usage="99.00"` → `checkQuota(amount=5)` = `{ allowed: false, reason: "Weekly quota exceeded..." }`.
+- Corrupt (the bug): `credits_limit="corrupt"` → previously `{ allowed: true }` (bypass); now **throws** `Unable to read extra usage credits_limit`.
+
+## N/A rows
+
+- UI screenshots: N/A (no UI surface touched).
+- Model trajectories: N/A.
+- Audio: N/A.
+
+## Human involvement
+
+None. The "no quota configured → allowed" behavior is existing domain policy (preserved + tested),
+not an engineering default requiring a decision.

--- a/packages/cloud/shared/src/db/repositories/usage-quotas-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/usage-quotas-numeric.test.ts
@@ -1,0 +1,66 @@
+// Exercises the fail-closed numeric boundary for usage-quota rows so a corrupt
+// NUMERIC column cannot silently disable the spend gate.
+import { describe, expect, test } from "bun:test";
+import { parseUsageQuotaNumber } from "./usage-quotas-numeric";
+
+describe("parseUsageQuotaNumber", () => {
+  test("parses a well-formed NUMERIC string", () => {
+    expect(parseUsageQuotaNumber("10.50", "credits_limit")).toBe(10.5);
+  });
+
+  test("parses a numeric value", () => {
+    expect(parseUsageQuotaNumber(42, "current_usage")).toBe(42);
+  });
+
+  test("parses a zero string (explicit domain zero is allowed)", () => {
+    expect(parseUsageQuotaNumber("0.00", "current_usage")).toBe(0);
+    expect(parseUsageQuotaNumber(0, "current_usage")).toBe(0);
+  });
+
+  test("throws on a non-numeric corrupt string instead of returning NaN", () => {
+    expect(() => parseUsageQuotaNumber("corrupt", "credits_limit")).toThrow(
+      /Unable to read extra usage credits_limit/,
+    );
+  });
+
+  test("throws on NaN input rather than fabricating a permissive value", () => {
+    expect(() => parseUsageQuotaNumber(Number.NaN, "credits_limit")).toThrow(/not a finite number/);
+  });
+
+  test("throws on Infinity", () => {
+    expect(() => parseUsageQuotaNumber(Number.POSITIVE_INFINITY, "credits_limit")).toThrow(
+      /not a finite number/,
+    );
+  });
+
+  test("throws on null / undefined / empty / whitespace (missing value)", () => {
+    expect(() => parseUsageQuotaNumber(null, "current_usage")).toThrow(/empty or missing/);
+    expect(() => parseUsageQuotaNumber(undefined, "current_usage")).toThrow(/empty or missing/);
+    expect(() => parseUsageQuotaNumber("", "current_usage")).toThrow(/empty or missing/);
+    expect(() => parseUsageQuotaNumber("   ", "current_usage")).toThrow(/empty or missing/);
+  });
+
+  test("names the field in the error so corrupt columns are identifiable", () => {
+    expect(() => parseUsageQuotaNumber("x", "credits_limit")).toThrow(/credits_limit/);
+    expect(() => parseUsageQuotaNumber("x", "current_usage")).toThrow(/current_usage/);
+  });
+});
+
+// Regression guard proving the spend-gate CANNOT fabricate an "allowed" / "not
+// exceeded" decision over a corrupt limit the way a bare Number(...) comparison does.
+describe("spend-gate fail-open regression (corrupt limit)", () => {
+  // Mirrors the exact comparison shapes used by checkQuotaExceeded (repo) and
+  // checkQuota (service) — proving they now throw instead of returning permissively.
+  test("bare Number(...) comparison would silently fail OPEN on a corrupt limit", () => {
+    const corruptLimit = Number("corrupt"); // NaN
+    const usage = Number("999999");
+    // checkQuotaExceeded: usage >= limit
+    expect(usage >= corruptLimit).toBe(false); // NaN comparison -> "not exceeded"
+    // checkQuota: newUsage > limit
+    expect(usage + 100 > corruptLimit).toBe(false); // NaN comparison -> "allowed"
+  });
+
+  test("the fail-closed reader throws on that same corrupt limit", () => {
+    expect(() => parseUsageQuotaNumber("corrupt", "credits_limit")).toThrow();
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/usage-quotas-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/usage-quotas-numeric.test.ts
@@ -1,5 +1,6 @@
-// Exercises the fail-closed numeric boundary for usage-quota rows so a corrupt
-// NUMERIC column cannot silently disable the spend gate.
+/**
+ * Exercises the fail-closed numeric boundary for usage-quota rows.
+ */
 import { describe, expect, test } from "bun:test";
 import { parseUsageQuotaNumber } from "./usage-quotas-numeric";
 
@@ -46,18 +47,12 @@ describe("parseUsageQuotaNumber", () => {
   });
 });
 
-// Regression guard proving the spend-gate CANNOT fabricate an "allowed" / "not
-// exceeded" decision over a corrupt limit the way a bare Number(...) comparison does.
 describe("spend-gate fail-open regression (corrupt limit)", () => {
-  // Mirrors the exact comparison shapes used by checkQuotaExceeded (repo) and
-  // checkQuota (service) — proving they now throw instead of returning permissively.
   test("bare Number(...) comparison would silently fail OPEN on a corrupt limit", () => {
-    const corruptLimit = Number("corrupt"); // NaN
+    const corruptLimit = Number("corrupt");
     const usage = Number("999999");
-    // checkQuotaExceeded: usage >= limit
-    expect(usage >= corruptLimit).toBe(false); // NaN comparison -> "not exceeded"
-    // checkQuota: newUsage > limit
-    expect(usage + 100 > corruptLimit).toBe(false); // NaN comparison -> "allowed"
+    expect(usage >= corruptLimit).toBe(false);
+    expect(usage + 100 > corruptLimit).toBe(false);
   });
 
   test("the fail-closed reader throws on that same corrupt limit", () => {

--- a/packages/cloud/shared/src/db/repositories/usage-quotas-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/usage-quotas-numeric.ts
@@ -1,16 +1,9 @@
 /**
- * Numeric parsing boundary for usage-quota rows.
+ * Numeric parsing boundary for usage-quota rows that gate metered spend.
  *
- * Quota columns (`current_usage`, `credits_limit`) are Postgres NUMERIC, surfaced by
- * the driver as strings. A present-but-corrupt value (non-numeric, `NaN`, `Infinity`,
- * empty) would otherwise flow through a bare `Number(...)` as `NaN` and silently
- * DISABLE the spend gate: `newUsage > NaN` and `NaN >= NaN` are both `false`, so a
- * corrupt limit reads as "quota not exceeded" and unbounded metered usage is allowed.
- *
- * These readers FAIL CLOSED: a present row whose numeric field cannot be parsed to a
- * finite number throws instead of fabricating a permissive `NaN`. Callers on the
- * spend-gate path (checkQuota / checkQuotaExceeded) then surface the read failure
- * rather than granting quota over a corrupt row.
+ * Postgres NUMERIC fields arrive as strings. Corrupt values must throw instead
+ * of becoming `NaN`, because comparisons against `NaN` fail open on quota
+ * checks.
  */
 
 export function parseUsageQuotaNumber(

--- a/packages/cloud/shared/src/db/repositories/usage-quotas-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/usage-quotas-numeric.ts
@@ -1,0 +1,28 @@
+/**
+ * Numeric parsing boundary for usage-quota rows.
+ *
+ * Quota columns (`current_usage`, `credits_limit`) are Postgres NUMERIC, surfaced by
+ * the driver as strings. A present-but-corrupt value (non-numeric, `NaN`, `Infinity`,
+ * empty) would otherwise flow through a bare `Number(...)` as `NaN` and silently
+ * DISABLE the spend gate: `newUsage > NaN` and `NaN >= NaN` are both `false`, so a
+ * corrupt limit reads as "quota not exceeded" and unbounded metered usage is allowed.
+ *
+ * These readers FAIL CLOSED: a present row whose numeric field cannot be parsed to a
+ * finite number throws instead of fabricating a permissive `NaN`. Callers on the
+ * spend-gate path (checkQuota / checkQuotaExceeded) then surface the read failure
+ * rather than granting quota over a corrupt row.
+ */
+
+export function parseUsageQuotaNumber(
+  value: string | number | null | undefined,
+  fieldName: string,
+): number {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    throw new Error(`Unable to read extra usage ${fieldName}: value is empty or missing`);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Unable to read extra usage ${fieldName}: value is not a finite number`);
+  }
+  return parsed;
+}

--- a/packages/cloud/shared/src/db/repositories/usage-quotas.ts
+++ b/packages/cloud/shared/src/db/repositories/usage-quotas.ts
@@ -75,9 +75,6 @@ export class UsageQuotasRepository {
       return false;
     }
 
-    // Fail closed: a corrupt NUMERIC would make Number(...) NaN, and NaN >= NaN is
-    // false, i.e. a corrupt row would read as "quota not exceeded" and silently open
-    // the spend gate. Throw instead so the caller surfaces the read failure.
     const currentUsage = parseUsageQuotaNumber(quota.current_usage, "current_usage");
     const creditsLimit = parseUsageQuotaNumber(quota.credits_limit, "credits_limit");
 

--- a/packages/cloud/shared/src/db/repositories/usage-quotas.ts
+++ b/packages/cloud/shared/src/db/repositories/usage-quotas.ts
@@ -2,6 +2,7 @@
 import { and, eq, lte, sql } from "drizzle-orm";
 import { dbRead, dbWrite } from "../helpers";
 import { type NewUsageQuota, type UsageQuota, usageQuotas } from "../schemas/usage-quotas";
+import { parseUsageQuotaNumber } from "./usage-quotas-numeric";
 
 export type { NewUsageQuota, UsageQuota };
 
@@ -74,8 +75,11 @@ export class UsageQuotasRepository {
       return false;
     }
 
-    const currentUsage = Number(quota.current_usage);
-    const creditsLimit = Number(quota.credits_limit);
+    // Fail closed: a corrupt NUMERIC would make Number(...) NaN, and NaN >= NaN is
+    // false, i.e. a corrupt row would read as "quota not exceeded" and silently open
+    // the spend gate. Throw instead so the caller surfaces the read failure.
+    const currentUsage = parseUsageQuotaNumber(quota.current_usage, "current_usage");
+    const creditsLimit = parseUsageQuotaNumber(quota.credits_limit, "credits_limit");
 
     return currentUsage >= creditsLimit;
   }
@@ -108,12 +112,12 @@ export class UsageQuotasRepository {
 
     for (const quota of quotas) {
       if (quota.quota_type === "global") {
-        result.global.used = Number(quota.current_usage);
-        result.global.limit = Number(quota.credits_limit);
+        result.global.used = parseUsageQuotaNumber(quota.current_usage, "current_usage");
+        result.global.limit = parseUsageQuotaNumber(quota.credits_limit, "credits_limit");
       } else if (quota.quota_type === "model_specific" && quota.model_name) {
         result.modelSpecific[quota.model_name] = {
-          used: Number(quota.current_usage),
-          limit: Number(quota.credits_limit),
+          used: parseUsageQuotaNumber(quota.current_usage, "current_usage"),
+          limit: parseUsageQuotaNumber(quota.credits_limit, "credits_limit"),
         };
       }
     }

--- a/packages/cloud/shared/src/lib/services/__tests__/usage-quotas-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/usage-quotas-fail-closed.test.ts
@@ -1,0 +1,116 @@
+/**
+ * #13416 — usage-quota spend gate must fail closed on a corrupt NUMERIC row.
+ *
+ * Before the fix, `checkQuota` read `credits_limit` via a bare `Number(...)`. A
+ * present-but-corrupt limit yields `NaN`, and `newUsage > NaN` is `false`, so the
+ * gate returned `{ allowed: true }` and permitted unbounded metered usage over a
+ * corrupt row. These tests pin the fail-closed behavior at the service seam: a
+ * corrupt quota row now throws instead of silently granting quota, while healthy
+ * rows still allow/deny correctly.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const findByOrganizationAndType = mock();
+const findActiveByOrganization = mock();
+
+mock.module("../../../db/repositories", () => ({
+  usageQuotasRepository: {
+    findByOrganizationAndType,
+    findActiveByOrganization,
+  },
+}));
+
+const { usageQuotasService } = await import("../usage-quotas");
+
+function healthyQuota(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    organization_id: "22222222-2222-4222-8222-222222222222",
+    quota_type: "global",
+    model_name: null,
+    period_type: "weekly",
+    credits_limit: "100.00",
+    current_usage: "10.00",
+    period_start: new Date("2026-07-01T00:00:00Z"),
+    period_end: new Date("2026-07-08T00:00:00Z"),
+    is_active: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  findByOrganizationAndType.mockReset();
+  findActiveByOrganization.mockReset();
+});
+
+describe("UsageQuotasService.checkQuota fail-closed", () => {
+  test("allows when a healthy global quota has headroom", async () => {
+    findByOrganizationAndType.mockResolvedValue(healthyQuota());
+    const result = await usageQuotasService.checkQuota("org", 5);
+    expect(result.allowed).toBe(true);
+  });
+
+  test("denies when a healthy global quota is exceeded", async () => {
+    findByOrganizationAndType.mockResolvedValue(
+      healthyQuota({ credits_limit: "100.00", current_usage: "99.00" }),
+    );
+    const result = await usageQuotasService.checkQuota("org", 5);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/quota exceeded/i);
+  });
+
+  test("THROWS (fails closed) instead of allowing when the global limit is corrupt", async () => {
+    findByOrganizationAndType.mockResolvedValue(
+      healthyQuota({ credits_limit: "corrupt", current_usage: "10.00" }),
+    );
+    await expect(usageQuotasService.checkQuota("org", 5)).rejects.toThrow(
+      /Unable to read extra usage credits_limit/,
+    );
+  });
+
+  test("THROWS (fails closed) instead of allowing when the model limit is corrupt", async () => {
+    findByOrganizationAndType.mockImplementation(async (_org: string, quotaType: string) =>
+      quotaType === "model_specific"
+        ? healthyQuota({
+            quota_type: "model_specific",
+            model_name: "gpt",
+            credits_limit: "",
+            current_usage: "10.00",
+          })
+        : undefined,
+    );
+    await expect(usageQuotasService.checkQuota("org", 5, "gpt")).rejects.toThrow(
+      /Unable to read extra usage/,
+    );
+  });
+
+  test("no quota rows -> allowed (no quota configured is not a corrupt read)", async () => {
+    findByOrganizationAndType.mockResolvedValue(undefined);
+    const result = await usageQuotasService.checkQuota("org", 5);
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe("UsageQuotasService.getCurrentUsage fail-closed", () => {
+  test("THROWS on a corrupt current_usage instead of reporting NaN", async () => {
+    findActiveByOrganization.mockResolvedValue([healthyQuota({ current_usage: "corrupt" })]);
+    let caught: unknown;
+    try {
+      await usageQuotasService.getCurrentUsage("org");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("Unable to read extra usage current_usage");
+  });
+
+  test("returns a healthy usage breakdown for well-formed rows", async () => {
+    findActiveByOrganization.mockResolvedValue([
+      healthyQuota({ current_usage: "25.00", credits_limit: "100.00" }),
+    ]);
+    const result = await usageQuotasService.getCurrentUsage("org");
+    expect(result.global.used).toBe(25);
+    expect(result.global.limit).toBe(100);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/usage-quotas-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/usage-quotas-fail-closed.test.ts
@@ -1,12 +1,8 @@
 /**
- * #13416 — usage-quota spend gate must fail closed on a corrupt NUMERIC row.
+ * Service-seam coverage for usage-quota rows that gate metered spend.
  *
- * Before the fix, `checkQuota` read `credits_limit` via a bare `Number(...)`. A
- * present-but-corrupt limit yields `NaN`, and `newUsage > NaN` is `false`, so the
- * gate returned `{ allowed: true }` and permitted unbounded metered usage over a
- * corrupt row. These tests pin the fail-closed behavior at the service seam: a
- * corrupt quota row now throws instead of silently granting quota, while healthy
- * rows still allow/deny correctly.
+ * Corrupt quota values must throw instead of granting quota, while healthy rows
+ * still allow or deny by their configured limits.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";

--- a/packages/cloud/shared/src/lib/services/usage-quotas.ts
+++ b/packages/cloud/shared/src/lib/services/usage-quotas.ts
@@ -3,6 +3,7 @@
  */
 
 import { usageQuotasRepository } from "../../db/repositories";
+import { parseUsageQuotaNumber } from "../../db/repositories/usage-quotas-numeric";
 import type { NewUsageQuota, UsageQuota } from "../../db/schemas/usage-quotas";
 import { logger } from "../utils/logger";
 import { deriveQuotaUsage } from "./analytics-derived";
@@ -101,8 +102,11 @@ class UsageQuotasService {
       );
 
       if (modelQuota) {
-        const currentUsage = Number(modelQuota.current_usage);
-        const limit = Number(modelQuota.credits_limit);
+        // Fail closed: a corrupt NUMERIC would make Number(...) NaN, and newUsage > NaN
+        // is false, so a corrupt limit would fabricate `allowed: true` and bypass the
+        // spend gate. parseUsageQuotaNumber throws on a present-but-unparseable value.
+        const currentUsage = parseUsageQuotaNumber(modelQuota.current_usage, "current_usage");
+        const limit = parseUsageQuotaNumber(modelQuota.credits_limit, "credits_limit");
         const newUsage = currentUsage + amount;
 
         if (newUsage > limit) {
@@ -124,8 +128,8 @@ class UsageQuotasService {
     );
 
     if (globalQuota) {
-      const currentUsage = Number(globalQuota.current_usage);
-      const limit = Number(globalQuota.credits_limit);
+      const currentUsage = parseUsageQuotaNumber(globalQuota.current_usage, "current_usage");
+      const limit = parseUsageQuotaNumber(globalQuota.credits_limit, "credits_limit");
       const newUsage = currentUsage + amount;
 
       if (newUsage > limit) {
@@ -214,8 +218,11 @@ class UsageQuotasService {
 
     for (const quota of quotas) {
       if (quota.quota_type === "global") {
-        const used = Number(quota.current_usage);
-        const limit = Number(quota.credits_limit);
+        // Fail closed on a corrupt row: a bare Number(...) would surface NaN usage/limit
+        // to the reporting DTO (and NaN usedPercent), masking data corruption behind a
+        // plausible-looking zero-ish reading. Throw so the read failure is observable.
+        const used = parseUsageQuotaNumber(quota.current_usage, "current_usage");
+        const limit = parseUsageQuotaNumber(quota.credits_limit, "credits_limit");
         const derived = deriveQuotaUsage(used, limit);
         result.global.used = used;
         result.global.limit = limit;
@@ -223,8 +230,8 @@ class UsageQuotasService {
         result.global.usedPercent = derived.usedPercent;
         result.global.usedPercentClamped = derived.usedPercentClamped;
       } else if (quota.quota_type === "model_specific" && quota.model_name) {
-        const used = Number(quota.current_usage);
-        const limit = Number(quota.credits_limit);
+        const used = parseUsageQuotaNumber(quota.current_usage, "current_usage");
+        const limit = parseUsageQuotaNumber(quota.credits_limit, "credits_limit");
         const derived = deriveQuotaUsage(used, limit);
         result.modelSpecific[quota.model_name] = {
           used,

--- a/packages/cloud/shared/src/lib/services/usage-quotas.ts
+++ b/packages/cloud/shared/src/lib/services/usage-quotas.ts
@@ -102,9 +102,6 @@ class UsageQuotasService {
       );
 
       if (modelQuota) {
-        // Fail closed: a corrupt NUMERIC would make Number(...) NaN, and newUsage > NaN
-        // is false, so a corrupt limit would fabricate `allowed: true` and bypass the
-        // spend gate. parseUsageQuotaNumber throws on a present-but-unparseable value.
         const currentUsage = parseUsageQuotaNumber(modelQuota.current_usage, "current_usage");
         const limit = parseUsageQuotaNumber(modelQuota.credits_limit, "credits_limit");
         const newUsage = currentUsage + amount;
@@ -218,9 +215,6 @@ class UsageQuotasService {
 
     for (const quota of quotas) {
       if (quota.quota_type === "global") {
-        // Fail closed on a corrupt row: a bare Number(...) would surface NaN usage/limit
-        // to the reporting DTO (and NaN usedPercent), masking data corruption behind a
-        // plausible-looking zero-ish reading. Throw so the read failure is observable.
         const used = parseUsageQuotaNumber(quota.current_usage, "current_usage");
         const limit = parseUsageQuotaNumber(quota.credits_limit, "credits_limit");
         const derived = deriveQuotaUsage(used, limit);


### PR DESCRIPTION
## Summary

Agent-ready successor to #12788 for the DB/repository side of `packages/cloud/shared`. This PR ships the **usage-quotas slice**: the corrupt-`NUMERIC`-row → fail-open class on the spend-enforcement path. The issue stays open for the remaining ~47-file repository inventory.

## The bug (fail-open spend gate)

`usage_quotas.credits_limit` / `current_usage` are Postgres `NUMERIC`, surfaced by the driver as strings. The gate read them with a bare `Number(...)`. A present-but-corrupt value yields `NaN`, and **every comparison against `NaN` is `false`**:

| Site | Pre-fix | Effect |
|---|---|---|
| `lib/services/usage-quotas.ts` `checkQuota` (model + global) | `newUsage > NaN` → `false` | returns `{ allowed: true }` → **quota bypass, unbounded metered spend over a corrupt row** |
| `db/repositories/usage-quotas.ts` `checkQuotaExceeded` | `NaN >= NaN` → `false` | reads as "not exceeded" — same fail-open |
| `getCurrentUsage` (repo + service) | `Number("corrupt")` = `NaN` | fabricates `NaN` usage/limit + `NaN` usedPercent in the reporting DTO, masking corruption |

## The fix (fail closed)

New numeric boundary `db/repositories/usage-quotas-numeric.ts` → `parseUsageQuotaNumber(value, field)`:
- throws on `null`/`undefined`/empty/whitespace (missing) and on non-finite (`NaN`/`Infinity`/non-numeric),
- allows explicit domain zero (`"0.00"` / `0`).

Wired into both the repository and service read sites. A corrupt quota row now **surfaces the read failure (deny)** rather than silently granting quota — for a spend gate, denying on a corrupt limit is the security-correct behavior. "No quota configured" (no rows) still allows: that is existing domain policy, preserved and tested. Mirrors the fail-closed reader convention from the sibling app-credit-balances slice.

## Tests (17, all green)

- **`usage-quotas-numeric.test.ts` (10):** parser — well-formed / numeric / zero (allowed) / corrupt-string throws / `NaN` throws / `Infinity` throws / missing throws / field-named error; **plus a regression guard** pinning that a bare `Number(...)` comparison fails OPEN on a corrupt limit while the fail-closed reader throws.
- **`usage-quotas-fail-closed.test.ts` (7):** service seam via mocked repository — `checkQuota` allows with headroom, denies when exceeded, **THROWS on a corrupt global limit and a corrupt model limit**, allows when no quota configured; `getCurrentUsage` throws on corrupt `current_usage`, returns a healthy breakdown for good rows.

```
17 pass / 0 fail
```

## Verification

- `bunx @biomejs/biome check <touched>` → clean
- `bun run audit:error-policy-ratchet` → clean (`no new fallback-slop in touched files`)
- `bun run --cwd packages/cloud/shared typecheck` → **zero errors in touched `usage-quotas` files** (17 pre-existing baseline errors in unrelated files: `app-core/services/account-pool.ts`, `coding-account-bridge.ts`, `plugin-mcp/utils/json.ts`, `anthropic-web-search.ts`, `node-redis-adapter.ts` — untouched here)
- `git diff --check` → clean
- Migrations: none touched (append-only respected)

Evidence: `.github/issue-evidence/13416-cloud-shared-db-fallback.md`

Forbidden files (`vite.config.*`, root `index.html`, `client-base.ts`, `bun.lock`, binaries, `dist/`) untouched.

— [sol-orch]
