### PR TITLE
ci(#12338): shard Windows CI command groups

### DIFF
--- a/.github/issue-evidence/12338-windows-ci-shards.md
+++ b/.github/issue-evidence/12338-windows-ci-shards.md
@@ -27,6 +27,7 @@
   - `test-cloud-run`
   - `clean-stray-dts`
 - The workflow paths filter now includes every package/plugin directory directly exercised by the Windows shard commands.
+- `packages/scripts/__tests__/windows-ci-workflow.test.ts` now fails if the shard lane set changes accidentally or if any pre-shard Windows command is dropped or duplicated.
 
 ## Local verification
 
@@ -34,9 +35,10 @@
 ruby -e 'require "yaml"; YAML.load_file(".github/workflows/windows-ci.yml"); puts "yaml ok"'
 actionlint .github/workflows/windows-ci.yml
 rg -n "^\\s*- (node packages/scripts|bun run --cwd)" .github/workflows/windows-ci.yml
+bun test packages/scripts/__tests__/windows-ci-workflow.test.ts
 ```
 
 ## Post-PR evidence still required
 
 - A before/after `gh run view <id> --json jobs` timing comparison from real Windows CI runs.
-- Confirmation that the new 5-shard run preserves the same command coverage and reduces Windows billable minutes by at least 40 percent against the #12337 baseline.
+- Confirmation that the new 5-shard run reduces Windows billable minutes by at least 40 percent against the #12337 baseline.

--- a/.github/issue-evidence/12338-windows-ci-shards.md
+++ b/.github/issue-evidence/12338-windows-ci-shards.md
@@ -1,0 +1,42 @@
+# #12338 Windows CI shard consolidation evidence
+
+## Static change
+
+- `.github/workflows/windows-ci.yml` now runs 5 Windows shards instead of the previous 19 one-command matrix lanes.
+- The existing Windows command coverage is preserved as shard commands:
+  - `typecheck-core`
+  - `test-core`
+  - `test-shared`
+  - `test-app-core`
+  - `test-elizaos-cli`
+  - `test-cloud-shared`
+  - `test-plugin-coding-tools`
+  - `test-scenario-runner`
+  - `test-vault`
+  - `test-security`
+  - `test-plugin-elizacloud`
+  - `test-plugin-discord`
+  - `test-plugin-anthropic`
+  - `test-plugin-openai`
+  - `test-plugin-app-control`
+  - `test-plugin-task-coordinator`
+  - `test-plugin-browser`
+  - `build-agent-cascade`
+  - `verify-riscv64-buildpaths`
+  - `run-python --version`
+  - `test-cloud-run`
+  - `clean-stray-dts`
+- The workflow paths filter now includes every package/plugin directory directly exercised by the Windows shard commands.
+
+## Local verification
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/windows-ci.yml"); puts "yaml ok"'
+actionlint .github/workflows/windows-ci.yml
+rg -n "^\\s*- (node packages/scripts|bun run --cwd)" .github/workflows/windows-ci.yml
+```
+
+## Post-PR evidence still required
+
+- A before/after `gh run view <id> --json jobs` timing comparison from real Windows CI runs.
+- Confirmation that the new 5-shard run preserves the same command coverage and reduces Windows billable minutes by at least 40 percent against the #12337 baseline.

--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -58,6 +58,11 @@ jobs:
           fetch-depth: 0
           submodules: false
 
+      - name: Setup Node.js for path gate
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Determine affected dev smoke surface
         id: filter
         shell: bash

--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -29,6 +29,11 @@ jobs:
           fetch-depth: 0
           submodules: false
 
+      - name: Setup Node.js for path gate
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
       - name: Determine affected Docker smoke surface
         id: filter
         shell: bash

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -32,6 +32,11 @@ jobs:
           fetch-depth: 0
           submodules: false
 
+      - name: Setup Node.js for path gate
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
       - name: Determine affected mobile smoke surface
         id: filter
         shell: bash

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -50,6 +50,11 @@ jobs:
           fetch-depth: 0
           submodules: false
 
+      - name: Setup Node.js for path gate
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Determine affected CI surface
         id: filter
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,11 @@ jobs:
           fetch-depth: 0
           submodules: false
 
+      - name: Setup Node.js for path gate
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Validate CI path gate
         run: node packages/scripts/ci-path-gate.self-test.mjs
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -26,7 +26,21 @@ on:
       - "packages/app-core/**"
       - "packages/agent/**"
       - "packages/ui/**"
+      - "packages/elizaos/**"
+      - "packages/cloud/shared/**"
+      - "packages/scenario-runner/**"
+      - "packages/vault/**"
+      - "packages/security/**"
       - "packages/scripts/**"
+      - "plugins/plugin-coding-tools/**"
+      - "plugins/plugin-elizacloud/**"
+      - "plugins/plugin-discord/**"
+      - "plugins/plugin-anthropic/**"
+      - "plugins/plugin-openai/**"
+      - "plugins/plugin-app-control/**"
+      - "plugins/plugin-task-coordinator/**"
+      - "plugins/plugin-browser/**"
+      - "scripts/verify-riscv64-buildpaths.sh"
       - "WINDOWS.md"
       - ".github/workflows/windows-ci.yml"
   pull_request:
@@ -39,7 +53,21 @@ on:
       - "packages/app-core/**"
       - "packages/agent/**"
       - "packages/ui/**"
+      - "packages/elizaos/**"
+      - "packages/cloud/shared/**"
+      - "packages/scenario-runner/**"
+      - "packages/vault/**"
+      - "packages/security/**"
       - "packages/scripts/**"
+      - "plugins/plugin-coding-tools/**"
+      - "plugins/plugin-elizacloud/**"
+      - "plugins/plugin-discord/**"
+      - "plugins/plugin-anthropic/**"
+      - "plugins/plugin-openai/**"
+      - "plugins/plugin-app-control/**"
+      - "plugins/plugin-task-coordinator/**"
+      - "plugins/plugin-browser/**"
+      - "scripts/verify-riscv64-buildpaths.sh"
       - "WINDOWS.md"
       - ".github/workflows/windows-ci.yml"
   workflow_dispatch:
@@ -54,56 +82,45 @@ permissions:
 jobs:
   windows:
     runs-on: windows-latest
-    timeout-minutes: ${{ matrix.timeout || 45 }}
+    timeout-minutes: ${{ matrix.timeout || 90 }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - lane: typecheck-core
-            command: |
-              node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/cloud-shared --concurrency=4
-          - lane: test-core
-            command: bun run --cwd packages/core test
-          - lane: test-shared
-            command: bun run --cwd packages/shared test
-          - lane: test-app-core
-            command: bun run --cwd packages/app-core test
-          - lane: test-elizaos-cli
-            command: bun run --cwd packages/elizaos test
-          - lane: test-cloud-shared
-            command: bun run --cwd packages/cloud/shared test
-          - lane: test-plugin-coding-tools
-            command: bun run --cwd plugins/plugin-coding-tools test
-          - lane: test-scenario-runner
-            command: bun run --cwd packages/scenario-runner test
-          - lane: test-vault
-            command: bun run --cwd packages/vault test
-          - lane: test-security
-            command: bun run --cwd packages/security test
-          - lane: test-plugin-elizacloud
-            command: bun run --cwd plugins/plugin-elizacloud test
-          - lane: test-plugin-discord
-            command: bun run --cwd plugins/plugin-discord test
-          - lane: test-plugin-anthropic
-            command: bun run --cwd plugins/plugin-anthropic test
-          - lane: test-plugin-openai
-            command: bun run --cwd plugins/plugin-openai test
-          - lane: test-plugin-app-control
-            command: bun run --cwd plugins/plugin-app-control test
-          - lane: test-plugin-task-coordinator
-            command: bun run --cwd plugins/plugin-task-coordinator test
-          - lane: test-plugin-browser
-            command: bun run --cwd plugins/plugin-browser test
-          - lane: build-agent-cascade
+          - lane: core-runtime
             timeout: 75
-            command: |
-              node packages/scripts/run-turbo.mjs run build --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/agent --concurrency=4
-          - lane: helper-smokes
-            command: |
-              node packages/scripts/run-bash-linux-only.mjs scripts/verify-riscv64-buildpaths.sh
-              node packages/scripts/run-python.mjs --version
-              node packages/scripts/test-cloud-run.mjs
-              node packages/scripts/clean-stray-dts.mjs
+            commands:
+              - node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/cloud-shared --concurrency=4
+              - bun run --cwd packages/core test
+              - bun run --cwd packages/shared test
+          - lane: app-and-cli
+            commands:
+              - bun run --cwd packages/app-core test
+              - bun run --cwd packages/elizaos test
+              - bun run --cwd packages/cloud/shared test
+          - lane: framework-packages
+            commands:
+              - bun run --cwd packages/scenario-runner test
+              - bun run --cwd packages/vault test
+              - bun run --cwd packages/security test
+              - bun run --cwd plugins/plugin-coding-tools test
+          - lane: plugins
+            commands:
+              - bun run --cwd plugins/plugin-elizacloud test
+              - bun run --cwd plugins/plugin-discord test
+              - bun run --cwd plugins/plugin-anthropic test
+              - bun run --cwd plugins/plugin-openai test
+              - bun run --cwd plugins/plugin-app-control test
+              - bun run --cwd plugins/plugin-task-coordinator test
+              - bun run --cwd plugins/plugin-browser test
+          - lane: build-and-helper-smokes
+            timeout: 90
+            commands:
+              - node packages/scripts/run-turbo.mjs run build --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/agent --concurrency=4
+              - node packages/scripts/run-bash-linux-only.mjs scripts/verify-riscv64-buildpaths.sh
+              - node packages/scripts/run-python.mjs --version
+              - node packages/scripts/test-cloud-run.mjs
+              - node packages/scripts/clean-stray-dts.mjs
 
     steps:
       - name: Enable long paths
@@ -163,6 +180,18 @@ jobs:
           node packages/scripts/run-turbo.mjs run build --filter=@elizaos/core --filter=@elizaos/shared --concurrency=1
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: Run lane "${{ matrix.lane }}"
+      - name: Run shard "${{ matrix.lane }}"
         shell: pwsh
-        run: ${{ matrix.command }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $commands = '${{ toJson(matrix.commands) }}' | ConvertFrom-Json
+          foreach ($command in $commands) {
+            Write-Host "::group::$command"
+            Invoke-Expression $command
+            $code = $LASTEXITCODE
+            Write-Host "::endgroup::"
+            if ($code -ne 0) {
+              Write-Error "Command failed with exit code $code`: $command"
+              exit $code
+            }
+          }

--- a/.github/workflows/windows-desktop-preload-smoke.yml
+++ b/.github/workflows/windows-desktop-preload-smoke.yml
@@ -26,6 +26,11 @@ jobs:
           fetch-depth: 0
           submodules: false
 
+      - name: Setup Node.js for path gate
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
       - name: Determine affected desktop preload surface
         id: filter
         shell: bash

--- a/.github/workflows/windows-dev-smoke.yml
+++ b/.github/workflows/windows-dev-smoke.yml
@@ -29,6 +29,11 @@ jobs:
           fetch-depth: 0
           submodules: false
 
+      - name: Setup Node.js for path gate
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
       - name: Determine affected Windows dev smoke surface
         id: filter
         shell: bash

--- a/packages/scripts/__tests__/windows-ci-workflow.test.ts
+++ b/packages/scripts/__tests__/windows-ci-workflow.test.ts
@@ -1,0 +1,69 @@
+// Pins the Windows CI sharding contract (#12338): grouped matrix lanes may
+// change names or ordering deliberately, but they must keep every command the
+// Windows compatibility lane is responsible for running.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const workflowText = readFileSync(
+  new URL("../../../.github/workflows/windows-ci.yml", import.meta.url),
+  "utf8",
+);
+
+const EXPECTED_LANES = [
+  "core-runtime",
+  "app-and-cli",
+  "framework-packages",
+  "plugins",
+  "build-and-helper-smokes",
+];
+
+const EXPECTED_COMMANDS = [
+  "node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/cloud-shared --concurrency=4",
+  "bun run --cwd packages/core test",
+  "bun run --cwd packages/shared test",
+  "bun run --cwd packages/app-core test",
+  "bun run --cwd packages/elizaos test",
+  "bun run --cwd packages/cloud/shared test",
+  "bun run --cwd packages/scenario-runner test",
+  "bun run --cwd packages/vault test",
+  "bun run --cwd packages/security test",
+  "bun run --cwd plugins/plugin-coding-tools test",
+  "bun run --cwd plugins/plugin-elizacloud test",
+  "bun run --cwd plugins/plugin-discord test",
+  "bun run --cwd plugins/plugin-anthropic test",
+  "bun run --cwd plugins/plugin-openai test",
+  "bun run --cwd plugins/plugin-app-control test",
+  "bun run --cwd plugins/plugin-task-coordinator test",
+  "bun run --cwd plugins/plugin-browser test",
+  "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/agent --concurrency=4",
+  "node packages/scripts/run-bash-linux-only.mjs scripts/verify-riscv64-buildpaths.sh",
+  "node packages/scripts/run-python.mjs --version",
+  "node packages/scripts/test-cloud-run.mjs",
+  "node packages/scripts/clean-stray-dts.mjs",
+];
+
+function extractMatrixLanes(): string[] {
+  return [...workflowText.matchAll(/^ {10}- lane: (.+)$/gm)].map(
+    (match) => match[1],
+  );
+}
+
+function extractMatrixCommands(): string[] {
+  return [...workflowText.matchAll(/^ {14}- (.+)$/gm)].map(
+    (match) => match[1],
+  );
+}
+
+describe("Windows CI workflow", () => {
+  test("keeps the shard lane set intentional", () => {
+    expect(extractMatrixLanes()).toEqual(EXPECTED_LANES);
+  });
+
+  test("keeps every pre-shard command represented exactly once", () => {
+    const commands = extractMatrixCommands();
+
+    expect(commands).toHaveLength(EXPECTED_COMMANDS.length);
+    expect(commands).toEqual(EXPECTED_COMMANDS);
+    expect(new Set(commands).size).toBe(commands.length);
+  });
+});


### PR DESCRIPTION
## Summary
- collapse Windows CI from 19 one-command matrix lanes into 5 command-group shards
- preserve the existing Windows command coverage while running each shard after one install/generated-build prep
- expand the workflow path filters to include every package/plugin directory exercised by the Windows lanes
- add static issue evidence for the command census and pending live timing proof

Advances #12338.

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/windows-ci.yml"); puts "yaml ok"'
- actionlint .github/workflows/windows-ci.yml
- rg -n "^\\s*- (node packages/scripts|bun run --cwd)" .github/workflows/windows-ci.yml | wc -l

## Evidence
- Static evidence: .github/issue-evidence/12338-windows-ci-shards.md
- Pending before ready-for-review: real Windows CI before/after job timing via gh run view --json jobs, including billable-minute comparison against the #12337 baseline and confirmation of >=40% reduction.