### PR TITLE
[codex] fix(#13120): ignore cloud CHARACTER env override

### DIFF
--- a/packages/cloud/services/agent-server/__tests__/unit/config.test.ts
+++ b/packages/cloud/services/agent-server/__tests__/unit/config.test.ts
@@ -4,6 +4,7 @@ import {
   ensureServerName,
   getAdvertisedServerUrl,
   normalizeServerName,
+  validateStartupEnv,
 } from "../../src/config";
 
 describe("normalizeServerName", () => {
@@ -41,6 +42,58 @@ describe("ensureServerName", () => {
 
     expect(ensureServerName(env)).toBe("8baf830a-2dc3-465d-b7ed-725fae3eaa56");
     expect(env.SERVER_NAME).toBe("8baf830a-2dc3-465d-b7ed-725fae3eaa56");
+  });
+});
+
+describe("validateStartupEnv", () => {
+  const baseEnv = {
+    SERVER_NAME: "shared-eliza",
+    REDIS_URL: "redis://localhost:6379",
+    DATABASE_URL: "postgres://user:pass@localhost:5432/eliza",
+    CAPACITY: "2",
+    TIER: "standard",
+    AGENT_SERVER_SHARED_SECRET: "secret",
+  };
+
+  test("requires the cloud pod startup variables", () => {
+    expect(() =>
+      validateStartupEnv({
+        ...baseEnv,
+        DATABASE_URL: "",
+      }),
+    ).toThrow("Missing required env var: DATABASE_URL");
+  });
+
+  test("returns explicit auto-start config from AGENT_ID and CHARACTER_REF", () => {
+    expect(
+      validateStartupEnv({
+        ...baseEnv,
+        AGENT_ID: "agent-123",
+        CHARACTER_REF: "casey",
+      }),
+    ).toEqual({
+      agentId: "agent-123",
+      characterRef: "casey",
+    });
+  });
+
+  test("does not treat CHARACTER as a cloud character override", () => {
+    expect(() =>
+      validateStartupEnv({
+        ...baseEnv,
+        AGENT_ID: "agent-123",
+        CHARACTER: "casey",
+      }),
+    ).toThrow("CHARACTER_REF is required when AGENT_ID is set");
+  });
+
+  test("ignores CHARACTER when no explicit auto-start agent is configured", () => {
+    expect(
+      validateStartupEnv({
+        ...baseEnv,
+        CHARACTER: "casey",
+      }),
+    ).toEqual({});
   });
 });
 

--- a/packages/cloud/services/agent-server/src/config.ts
+++ b/packages/cloud/services/agent-server/src/config.ts
@@ -1,5 +1,26 @@
-// Runs the hosted agent-server config boundary for cloud runtime containers.
+/**
+ * Runtime configuration helpers for hosted agent-server containers.
+ *
+ * The startup contract is intentionally explicit: cloud pods may auto-start an
+ * agent only from AGENT_ID plus CHARACTER_REF. The legacy process-wide
+ * CHARACTER override is not a cloud runtime API and must not satisfy auto-start
+ * validation.
+ */
 type Env = Record<string, string | undefined>;
+
+export const REQUIRED_STARTUP_ENV = [
+  "SERVER_NAME",
+  "REDIS_URL",
+  "DATABASE_URL",
+  "CAPACITY",
+  "TIER",
+  "AGENT_SERVER_SHARED_SECRET",
+] as const;
+
+export interface StartupConfig {
+  agentId?: string;
+  characterRef?: string;
+}
 
 export function normalizeServerName(
   value: string | undefined,
@@ -40,6 +61,24 @@ export function getRequiredEnv(name: string, env: Env = process.env): string {
     throw new Error(`Missing required env var: ${name}`);
   }
   return value;
+}
+
+export function validateStartupEnv(env: Env = process.env): StartupConfig {
+  for (const key of REQUIRED_STARTUP_ENV) {
+    getRequiredEnv(key, env);
+  }
+
+  const agentId = env.AGENT_ID?.trim();
+  const characterRef = env.CHARACTER_REF?.trim();
+
+  if (agentId && !characterRef) {
+    throw new Error("CHARACTER_REF is required when AGENT_ID is set");
+  }
+
+  return {
+    ...(agentId ? { agentId } : {}),
+    ...(agentId && characterRef ? { characterRef } : {}),
+  };
 }
 
 function withoutTrailingSlash(value: string): string {

--- a/packages/cloud/services/agent-server/src/index.ts
+++ b/packages/cloud/services/agent-server/src/index.ts
@@ -1,7 +1,18 @@
-// Runs the hosted agent-server index boundary for cloud runtime containers.
+/**
+ * Process entrypoint for hosted agent-server containers.
+ *
+ * It validates pod configuration before accepting traffic, starts the runtime
+ * manager, optionally auto-starts one explicit character reference, and drains
+ * in-flight agent work on SIGTERM.
+ */
 import { Elysia } from "elysia";
 import { AgentManager } from "./agent-manager";
-import { ensureServerName, getRequiredEnv } from "./config";
+import {
+  ensureServerName,
+  getRequiredEnv,
+  type StartupConfig,
+  validateStartupEnv,
+} from "./config";
 import { logger } from "./logger";
 import { getRedis } from "./redis";
 import { createRoutes } from "./routes";
@@ -13,25 +24,15 @@ if (process.env.DATABASE_URL && !process.env.POSTGRES_URL) {
 
 ensureServerName();
 
-const required = [
-  "SERVER_NAME",
-  "REDIS_URL",
-  "DATABASE_URL",
-  "CAPACITY",
-  "TIER",
-  "AGENT_SERVER_SHARED_SECRET",
-];
-for (const key of required) {
-  try {
-    getRequiredEnv(key);
-  } catch {
-    logger.error("Missing required env var", { key });
-    process.exit(1);
-  }
-}
-
-if (process.env.AGENT_ID && !process.env.CHARACTER_REF) {
-  logger.error("CHARACTER_REF is required when AGENT_ID is set");
+let startupConfig: StartupConfig;
+try {
+  startupConfig = validateStartupEnv();
+} catch (err) {
+  // error-policy:J1 process startup boundary translates invalid pod config into
+  // a fail-fast exit before the HTTP server accepts traffic.
+  logger.error("Invalid startup environment", {
+    error: err instanceof Error ? err.message : String(err),
+  });
   process.exit(1);
 }
 
@@ -42,8 +43,7 @@ const manager = new AgentManager();
 // Initialize manager before accepting connections
 await manager.initialize();
 
-const agentId = process.env.AGENT_ID;
-const characterRef = process.env.CHARACTER_REF;
+const { agentId, characterRef } = startupConfig;
 if (agentId && characterRef) {
   await manager.startAgent(agentId, characterRef);
   logger.info("Auto-started agent", {


### PR DESCRIPTION
## Summary

Closes #13120 by making the cloud agent-server startup contract explicit: hosted pods may auto-start an agent only from `AGENT_ID` plus `CHARACTER_REF`. The legacy process-wide `CHARACTER` env var is ignored and cannot satisfy auto-start validation.

## What changed

- Added `validateStartupEnv()` in `packages/cloud/services/agent-server/src/config.ts`.
- Routed `src/index.ts` through the shared validator before accepting traffic.
- Added unit coverage proving:
  - required pod env vars still fail fast when missing,
  - `AGENT_ID + CHARACTER_REF` is the valid explicit auto-start path,
  - `AGENT_ID + CHARACTER` fails instead of acting as a cloud character override,
  - `CHARACTER` alone is ignored.

## Validation

- `bun test packages/cloud/services/agent-server/__tests__/unit/config.test.ts` ✅
- `bun run --cwd packages/cloud/services/agent-server lint:check` ✅
- `git diff --check` ✅

## Not run / blocked

- `bun run --cwd packages/cloud/services/agent-server test:unit` is blocked in this checkout by missing workspace/runtime deps (`@elizaos/cloud-services-common`, `@elizaos/core`, `ioredis`) before unrelated tests run. The new config test itself passes.
- `bun run --cwd packages/cloud/services/agent-server typecheck` is blocked because `tsgo` is not installed in the current environment.

## Evidence notes

This is a startup config guard change, not a model-backed runtime behavior change. No live LLM trajectory applies. The regression proof is the focused unit test that demonstrates `CHARACTER` is unsupported in the cloud startup path.
