### PR TITLE
fix(#13448): resolve ui contracts from source

### DIFF
--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -100,6 +100,8 @@
       ],
       "@elizaos/shared": ["../shared/src/index.ts"],
       "@elizaos/shared/*": ["../shared/src/*"],
+      "@elizaos/contracts": ["../contracts/src/index.ts"],
+      "@elizaos/contracts/*": ["../contracts/src/*"],
       "@elizaos/skills": ["../skills/src/index.ts"],
       "@elizaos/skills/*": ["../skills/src/*"],
       "@elizaos/core": ["../core/src/index.ts"],


### PR DESCRIPTION
## Summary

Fixes #13448 by teaching the `packages/ui` TypeScript project to resolve `@elizaos/contracts` from workspace source, matching the source-alias pattern already used for `@elizaos/shared`, `@elizaos/core`, and other workspace packages.

The account and wallet contracts are already correct in `packages/contracts/src`. The fresh-env failure happens when UI typechecking follows the `@elizaos/shared` re-export through `node_modules/@elizaos/contracts` and lands on missing or stale built declarations instead of source. That can make `LinkedAccountConfig` lose `id` / `priority` and make wallet rows untyped.

This PR only changes `packages/ui/tsconfig.json`:

- `@elizaos/contracts` -> `../contracts/src/index.ts`
- `@elizaos/contracts/*` -> `../contracts/src/*`

No casts, DTO weakening, or runtime UI changes.

## Relationship to PR #13450

PR #13450 contains the same UI tsconfig fix plus unrelated turbo/package changes for a broader fresh-clone DX issue. This PR is the isolated #13448 slice so the UI typecheck regression can land independently.

## Evidence

- `bun run --cwd packages/ui typecheck` passed.
- Fresh-env simulation passed: temporarily moved `packages/contracts/dist` out of the tree, ran `bun run --cwd packages/ui typecheck`, and restored `dist` in the same shell.
- `bunx @biomejs/biome check packages/ui/tsconfig.json` passed.
- `git diff --check origin/develop...HEAD && git diff --check` passed.

## Visual Evidence

N/A - tsconfig-only change; no rendered UI behavior, CSS, component, or route changed.
