### PR TITLE
fix(#13441): break local inference Turbo cycle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3966,7 +3966,6 @@
       "name": "@elizaos/plugin-local-inference",
       "version": "2.0.3-beta.7",
       "dependencies": {
-        "@elizaos/agent": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-aosp-local-inference": "workspace:*",
         "@elizaos/plugin-capacitor-bridge": "workspace:*",

--- a/packages/scripts/audit-turbo-build-deps.mjs
+++ b/packages/scripts/audit-turbo-build-deps.mjs
@@ -154,6 +154,29 @@ const phantomTaskOverrides = [];
 const phantoms = [];
 const undeclared = [];
 const redundant = [];
+const directWorkspaceCycles = [];
+
+const workspaceDepsByPackage = new Map();
+for (const [name, dir] of WORKSPACE_DIRS.entries()) {
+  let pkg;
+  try {
+    pkg = readJson(path.join(dir, "package.json"));
+  } catch {
+    continue;
+  }
+  workspaceDepsByPackage.set(
+    name,
+    new Set([...declaredDeps(pkg)].filter((dep) => WORKSPACE_DIRS.has(dep))),
+  );
+}
+for (const [name, deps] of workspaceDepsByPackage.entries()) {
+  for (const dep of deps) {
+    if (name >= dep) continue;
+    if (workspaceDepsByPackage.get(dep)?.has(name)) {
+      directWorkspaceCycles.push(`${name} <-> ${dep}`);
+    }
+  }
+}
 
 for (const [taskName, def] of Object.entries(tasks)) {
   const separator = taskName.lastIndexOf("#");
@@ -252,6 +275,16 @@ if (phantoms.length) {
   );
   process.exit(1);
 }
+if (directWorkspaceCycles.length) {
+  console.error(
+    `[audit-turbo-build-deps] ${directWorkspaceCycles.length} direct workspace package cycle(s):\n`,
+  );
+  for (const cycle of directWorkspaceCycles) console.error(`  ✗ ${cycle}`);
+  console.error(
+    "\nA direct package.json cycle makes Turbo build-order inference unstable.\nMove one edge behind a runtime dynamic import or remove it if production source does not import it.",
+  );
+  process.exit(1);
+}
 if (phantomTaskOverrides.length) {
   console.error(
     `[audit-turbo-build-deps] ${phantomTaskOverrides.length} phantom pkg#task override(s):\n`,
@@ -264,3 +297,4 @@ if (phantomTaskOverrides.length) {
 }
 console.log("[audit-turbo-build-deps] ✓ no phantom #build dependency edges");
 console.log("[audit-turbo-build-deps] ✓ no phantom pkg#task overrides");
+console.log("[audit-turbo-build-deps] ✓ no direct workspace package cycles");

--- a/packages/scripts/audit-turbo-build-deps.self-test.mjs
+++ b/packages/scripts/audit-turbo-build-deps.self-test.mjs
@@ -28,6 +28,12 @@ try {
   writeJson(path.join(tempRoot, "packages/foo/package.json"), {
     name: "@fixture/foo",
     scripts: { build: "echo build" },
+    dependencies: { "@fixture/bar": "workspace:*" },
+  });
+  writeJson(path.join(tempRoot, "packages/bar/package.json"), {
+    name: "@fixture/bar",
+    scripts: { build: "echo build" },
+    dependencies: { "@fixture/foo": "workspace:*" },
   });
   writeJson(path.join(tempRoot, "turbo.json"), {
     tasks: {
@@ -44,6 +50,29 @@ try {
   });
   const failOutput = `${failResult.stdout}\n${failResult.stderr}`;
   if (failResult.status === 0) {
+    console.error("expected direct workspace cycle audit to fail");
+    process.exit(1);
+  }
+  if (!failOutput.includes("@fixture/bar <-> @fixture/foo")) {
+    console.error(
+      "missing expected audit output: @fixture/bar <-> @fixture/foo",
+    );
+    console.error(failOutput);
+    process.exit(1);
+  }
+
+  writeJson(path.join(tempRoot, "packages/bar/package.json"), {
+    name: "@fixture/bar",
+    scripts: { build: "echo build" },
+  });
+
+  const phantomResult = spawnSync(process.execPath, [scriptPath], {
+    cwd: tempRoot,
+    env: { ...process.env, AUDIT_TURBO_REPO_ROOT: tempRoot },
+    encoding: "utf8",
+  });
+  const phantomOutput = `${phantomResult.stdout}\n${phantomResult.stderr}`;
+  if (phantomResult.status === 0) {
     console.error("expected phantom override audit to fail");
     process.exit(1);
   }
@@ -51,9 +80,9 @@ try {
     '@fixture/foo#typecheck — owner package does not define script "typecheck"',
     "@fixture/missing#build — owner package is not a workspace member",
   ]) {
-    if (!failOutput.includes(expected)) {
+    if (!phantomOutput.includes(expected)) {
       console.error(`missing expected audit output: ${expected}`);
-      console.error(failOutput);
+      console.error(phantomOutput);
       process.exit(1);
     }
   }
@@ -61,6 +90,11 @@ try {
   writeJson(path.join(tempRoot, "packages/foo/package.json"), {
     name: "@fixture/foo",
     scripts: { build: "echo build", typecheck: "echo typecheck" },
+    dependencies: { "@fixture/bar": "workspace:*" },
+  });
+  writeJson(path.join(tempRoot, "packages/bar/package.json"), {
+    name: "@fixture/bar",
+    scripts: { build: "echo build" },
   });
   writeJson(path.join(tempRoot, "packages/missing/package.json"), {
     name: "@fixture/missing",

--- a/plugins/plugin-local-inference/package.json
+++ b/plugins/plugin-local-inference/package.json
@@ -133,7 +133,6 @@
 		"typecheck": "tsgo --noEmit -p tsconfig.json"
 	},
 	"dependencies": {
-		"@elizaos/agent": "workspace:*",
 		"@elizaos/core": "workspace:*",
 		"@elizaos/plugin-capacitor-bridge": "workspace:*",
 		"@elizaos/plugin-computeruse": "workspace:*",

--- a/turbo.json
+++ b/turbo.json
@@ -499,7 +499,7 @@
       "outputs": []
     },
     "@elizaos/plugin-local-inference#typecheck": {
-      "dependsOn": ["@elizaos/agent#build", "^build"],
+      "dependsOn": ["^build"],
       "outputs": []
     },
     "@elizaos/example-farcaster#build": {


### PR DESCRIPTION
## Summary
- remove the unused @elizaos/agent workspace dependency from @elizaos/plugin-local-inference
- remove the stale plugin-local-inference typecheck prerequisite on @elizaos/agent#build
- extend the Turbo build-deps audit to fail on direct workspace package cycles

## Validation
- node packages/scripts/audit-turbo-build-deps.self-test.mjs
- direct workspace graph check via packages/scripts/lib/workspaces.mjs: no direct workspace package cycles
- bunx @biomejs/biome check packages/scripts/audit-turbo-build-deps.mjs packages/scripts/audit-turbo-build-deps.self-test.mjs plugins/plugin-local-inference/package.json turbo.json bun.lock (passes with existing AUDIT_TURBO_REPO_ROOT warning)
- git diff --check origin/develop...HEAD
- node packages/scripts/run-turbo.mjs run build --filter=@elizaos/app... --filter=!@elizaos/app now no longer lists @elizaos/plugin-local-inference in the circular package warning; sparse checkout stops next on missing @elizaos/cloud-sdk turbo task

## Not run
- bun run --cwd packages/app build:ios:local:sim: Linux host has no Xcode/iOS simulator
- bun run --cwd plugins/plugin-local-inference build: sparse checkout is missing @elizaos/capacitor-llama
- bun run --cwd plugins/plugin-local-inference typecheck: blocked by existing adze declaration errors and missing sparse native plugin packages (@elizaos/plugin-capacitor-bridge mobile subpath, @elizaos/plugin-aosp-local-inference)
