### PR TITLE
fix(#13417): fail closed on response json parsing

### DIFF
--- a/.github/issue-evidence/13417-cloud-shared-lib-helper-fallback.md
+++ b/.github/issue-evidence/13417-cloud-shared-lib-helper-fallback.md
@@ -1,0 +1,95 @@
+# #13417 Cloud-Shared Lib Helper Fallback Evidence
+
+## Scope
+
+Targeted first slice for `packages/cloud/shared/src/lib/utils/json-parsing.ts` and its known cloud service callers. This does not claim to close the full #13417 inventory; it removes one helper-level success-shaped fallback and documents the remaining intentional diagnostic fallback.
+
+## Fallback Census
+
+Before command:
+
+```bash
+rg -l --glob '!**/*.test.ts' --glob '!**/*.test.tsx' --glob '!**/__tests__/**' --glob '*.ts' --glob '*.tsx' "catch\s*\(|\.catch\s*\(|\?\?\s*(0|\[\]|\{\}|''|\"\")|\|\|\s*(0|\[\]|\{\}|''|\"\")|console\." packages/cloud/shared/src/lib | sed 's#^packages/cloud/shared/src/lib/##' | cut -d/ -f1 | sort | uniq -c | sort -nr | head -30
+```
+
+Before top buckets:
+
+```text
+ 320 services
+  47 eliza
+  18 utils
+  16 providers
+  11 cache
+   8 auth
+   5 api
+   4 mcp
+   4 debug
+```
+
+After top buckets:
+
+```text
+ 320 services
+  47 eliza
+  18 utils
+  16 providers
+  11 cache
+   8 auth
+   5 api
+   4 mcp
+   4 debug
+```
+
+The bucket count is unchanged because this is a broad package inventory and `utils` still has other candidates. The targeted helper changed from an unannotated `safeJsonParse()` that returned `{}` for empty or malformed response bodies to:
+
+- `parseJsonResponse()` for success payloads, which throws on empty/malformed JSON.
+- `parseJsonErrorBody()` for provider error payload diagnostics, annotated `error-policy:J3`.
+
+## Changed Fallback Verdicts
+
+| Path | Verdict |
+| --- | --- |
+| `packages/cloud/shared/src/lib/utils/json-parsing.ts` | Removed success-shaped `{}` fallback from response parsing. Kept one J3 diagnostic fallback for third-party error bodies where HTTP status remains the failure signal. |
+| `packages/cloud/shared/src/lib/services/twitter-automation/oauth2-client.ts` | Twitter OAuth2 success token parsing now uses strict `parseJsonResponse()`; non-OK error body parsing uses `parseJsonErrorBody()` and still throws on HTTP status. |
+| `packages/cloud/shared/src/lib/services/social-media/token-refresh.ts` | Meta/LinkedIn/TikTok non-OK error body parsing uses explicit diagnostic parser; callers still throw provider refresh errors. |
+| `packages/cloud/shared/src/lib/services/social-media/providers/reddit.ts` | Reddit non-OK error body parsing uses explicit diagnostic parser; caller still throws provider API error. |
+
+## Focused Test Output
+
+```text
+bun test packages/cloud/shared/src/lib/utils/json-parsing.test.ts
+6 pass
+0 fail
+```
+
+## Verification
+
+```text
+bunx @biomejs/biome check packages/cloud/shared/src/lib/utils/json-parsing.ts packages/cloud/shared/src/lib/utils/json-parsing.test.ts packages/cloud/shared/src/lib/services/twitter-automation/oauth2-client.ts packages/cloud/shared/src/lib/services/social-media/token-refresh.ts packages/cloud/shared/src/lib/services/social-media/providers/reddit.ts
+Checked 5 files. No fixes applied.
+
+bun run audit:error-policy-ratchet
+[error-policy-ratchet] no new fallback-slop in touched files
+
+bun run --cwd packages/cloud/shared typecheck 2>&1 | rg 'json-parsing|twitter-automation/oauth2-client|social-media/token-refresh|social-media/providers/reddit'
+no touched-file typecheck diagnostics
+
+git diff --check origin/develop...HEAD && git diff --check
+passed
+```
+
+## Runtime Logs
+
+N/A - service helper unit boundary only. The changed paths parse `Response` bodies and preserve existing thrown provider errors; no live provider credentials were used.
+
+## UI Screenshots
+
+N/A - no UI, CSS, route, or rendered component changed.
+
+## Model Trajectories
+
+N/A - no agent, prompt, action, provider model invocation, or trajectory path changed.
+
+## Audio
+
+N/A - no voice, ASR, TTS, or audio path changed.

--- a/packages/cloud/shared/src/lib/services/social-media/providers/reddit.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/reddit.ts
@@ -12,7 +12,7 @@ import type {
   SocialMediaProvider,
 } from "../../../types/social-media";
 import { extractErrorMessage } from "../../../utils/error-handling";
-import { safeJsonParse } from "../../../utils/json-parsing";
+import { parseJsonErrorBody } from "../../../utils/json-parsing";
 import { logger } from "../../../utils/logger";
 import { withRetry } from "../rate-limit";
 
@@ -133,7 +133,7 @@ async function _redditApiRequestLegacy<T>(
   });
 
   if (!response.ok) {
-    const error = await safeJsonParse<{ message?: string }>(response);
+    const error = await parseJsonErrorBody<{ message?: string }>(response);
     throw new Error(error.message || `Reddit API error: ${response.status}`);
   }
 

--- a/packages/cloud/shared/src/lib/services/social-media/token-refresh.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/token-refresh.ts
@@ -1,6 +1,6 @@
 // Coordinates cloud service token refresh behavior behind route handlers.
 import type { SocialCredentials, SocialPlatform } from "../../types/social-media";
-import { safeJsonParse } from "../../utils/json-parsing";
+import { parseJsonErrorBody } from "../../utils/json-parsing";
 import { logger } from "../../utils/logger";
 import { requestTwitterOAuth2Token } from "../twitter-automation/oauth2-client";
 
@@ -70,7 +70,7 @@ async function refreshMetaToken(accessToken: string): Promise<RefreshResult> {
   );
 
   if (!response.ok) {
-    const error = await safeJsonParse<{ error?: { message?: string } }>(response);
+    const error = await parseJsonErrorBody<{ error?: { message?: string } }>(response);
     throw new Error(error.error?.message || `Meta token refresh failed: ${response.status}`);
   }
 
@@ -100,7 +100,7 @@ async function refreshLinkedInToken(refreshToken: string): Promise<RefreshResult
   });
 
   if (!response.ok) {
-    const error = await safeJsonParse<{ error_description?: string }>(response);
+    const error = await parseJsonErrorBody<{ error_description?: string }>(response);
     throw new Error(error.error_description || `LinkedIn token refresh failed: ${response.status}`);
   }
 
@@ -135,7 +135,7 @@ async function refreshTikTokToken(refreshToken: string): Promise<RefreshResult> 
   });
 
   if (!response.ok) {
-    const error = await safeJsonParse<{ error_description?: string }>(response);
+    const error = await parseJsonErrorBody<{ error_description?: string }>(response);
     throw new Error(error.error_description || `TikTok token refresh failed: ${response.status}`);
   }
 

--- a/packages/cloud/shared/src/lib/services/twitter-automation/oauth2-client.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/oauth2-client.ts
@@ -1,5 +1,5 @@
 // Coordinates cloud service oauth2 client behavior behind route handlers.
-import { safeJsonParse } from "../../utils/json-parsing";
+import { parseJsonErrorBody, parseJsonResponse } from "../../utils/json-parsing";
 
 const TWITTER_OAUTH2_TOKEN_URL = "https://api.x.com/2/oauth2/token";
 
@@ -58,7 +58,7 @@ function getTwitterOAuth2AuthorizationHeader(clientId: string, clientSecret: str
 }
 
 async function readTwitterOAuth2ErrorMessage(response: Response): Promise<string> {
-  const payload = await safeJsonParse<TwitterOAuth2ErrorResponse>(response);
+  const payload = await parseJsonErrorBody<TwitterOAuth2ErrorResponse>(response);
   const details = [payload.error, payload.error_description, payload.detail, payload.title].filter(
     (value, index, all): value is string => {
       return typeof value === "string" && value.trim().length > 0 && all.indexOf(value) === index;
@@ -98,5 +98,5 @@ export async function requestTwitterOAuth2Token(
     throw new Error(await readTwitterOAuth2ErrorMessage(response));
   }
 
-  return safeJsonParse<TwitterOAuth2TokenResponse>(response);
+  return parseJsonResponse<TwitterOAuth2TokenResponse>(response, "Twitter OAuth2 token response");
 }

--- a/packages/cloud/shared/src/lib/utils/json-parsing.test.ts
+++ b/packages/cloud/shared/src/lib/utils/json-parsing.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Response JSON parsing tests for cloud service clients.
+ *
+ * Provider success payloads must fail closed when malformed, while provider
+ * error payloads can degrade to "no parsed detail" because HTTP status remains
+ * the failure signal.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { parseJsonErrorBody, parseJsonResponse } from "./json-parsing";
+
+describe("parseJsonResponse", () => {
+  test("parses non-empty JSON response bodies", async () => {
+    const response = new Response('{"access_token":"token"}');
+
+    await expect(parseJsonResponse(response)).resolves.toEqual({
+      access_token: "token",
+    });
+  });
+
+  test("rejects empty success bodies instead of fabricating an object", async () => {
+    const response = new Response("  ");
+
+    await expect(parseJsonResponse(response, "oauth token")).rejects.toThrow(
+      "Failed to parse JSON (oauth token): empty response body",
+    );
+  });
+
+  test("rejects malformed JSON with context", async () => {
+    const response = new Response("{not json}");
+
+    await expect(parseJsonResponse(response, "provider response")).rejects.toThrow(
+      "Failed to parse JSON (provider response):",
+    );
+  });
+});
+
+describe("parseJsonErrorBody", () => {
+  test("parses valid provider error payloads", async () => {
+    const response = new Response('{"error_description":"expired"}', {
+      status: 400,
+    });
+
+    await expect(parseJsonErrorBody<{ error_description?: string }>(response)).resolves.toEqual({
+      error_description: "expired",
+    });
+  });
+
+  test("returns an explicit empty detail object for empty provider error bodies", async () => {
+    const response = new Response("", { status: 500 });
+
+    await expect(parseJsonErrorBody(response)).resolves.toEqual({});
+  });
+
+  test("returns an explicit empty detail object for malformed provider error bodies", async () => {
+    const response = new Response("<html>nope</html>", { status: 502 });
+
+    await expect(parseJsonErrorBody(response)).resolves.toEqual({});
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/json-parsing.ts
+++ b/packages/cloud/shared/src/lib/utils/json-parsing.ts
@@ -1,25 +1,46 @@
 /**
- * JSON Parsing Utilities
+ * Response JSON helpers for cloud service clients.
  *
- * Shared utilities for safe JSON parsing with consistent error handling.
- * Consolidates duplicate JSON parsing patterns.
+ * Success responses parse strictly so malformed provider payloads surface as
+ * integration failures. Error responses have a separate best-effort parser
+ * because third-party APIs often return empty or non-JSON bodies alongside a
+ * useful HTTP status.
  */
 
 import { extractErrorMessage } from "./error-handling";
 
 /**
- * Safely parse JSON response, returning empty object on failure
- * Use when parsing error responses where JSON might be malformed
+ * Parse a response body as JSON, preserving empty or malformed payloads as
+ * failures for the caller to handle at the service boundary.
  */
-export async function safeJsonParse<T = Record<string, unknown>>(response: Response): Promise<T> {
+export async function parseJsonResponse<T = Record<string, unknown>>(
+  response: Response,
+  context?: string,
+): Promise<T> {
+  const text = await response.text();
+  if (!text.trim()) {
+    const contextMsg = context ? ` (${context})` : "";
+    throw new Error(`Failed to parse JSON${contextMsg}: empty response body`);
+  }
+  return parseJson<T>(text, context);
+}
+
+/**
+ * Best-effort parser for provider error bodies where the HTTP status remains
+ * the failure signal when the body is empty or malformed.
+ */
+export async function parseJsonErrorBody<T extends object>(
+  response: Response,
+): Promise<Partial<T>> {
+  // error-policy:J3 Third-party error bodies are untrusted diagnostics; invalid
+  // JSON becomes an explicit "no parsed details" result while the caller still
+  // throws based on the non-OK HTTP status.
+  const text = await response.text().catch(() => "");
+  if (!text.trim()) return {};
   try {
-    const text = await response.text();
-    if (!text.trim()) {
-      return {} as T;
-    }
-    return JSON.parse(text) as T;
+    return JSON.parse(text) as Partial<T>;
   } catch {
-    return {} as T;
+    return {};
   }
 }
 


### PR DESCRIPTION
## Summary

Partial slice for #13417. This focuses on `packages/cloud/shared/src/lib/utils/json-parsing.ts` and the cloud service callers that used its broad `safeJsonParse()` helper.

The old helper returned `{}` for empty or malformed response bodies in every context. That was acceptable only for provider error-body diagnostics, but unsafe for success payloads such as Twitter OAuth2 token responses because a malformed token response looked like a parsed object.

Changes:

- replace `safeJsonParse()` with strict `parseJsonResponse()` for success response bodies;
- add `parseJsonErrorBody()` for non-OK provider diagnostic bodies, annotated `error-policy:J3`;
- update Twitter OAuth2 success parsing to fail closed on empty/malformed JSON;
- update Meta/LinkedIn/TikTok/Reddit error-body parsing to the explicit diagnostic helper;
- add focused tests for success parsing, empty/malformed success failure, and malformed error-body diagnostic behavior;
- add evidence at `.github/issue-evidence/13417-cloud-shared-lib-helper-fallback.md`.

This does not claim to complete the full #13417 helper sweep; the evidence records the unchanged package-level census and the exact fallback removed in this slice.

## Evidence

- `bun test packages/cloud/shared/src/lib/utils/json-parsing.test.ts` passed: 6 tests.
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/utils/json-parsing.ts packages/cloud/shared/src/lib/utils/json-parsing.test.ts packages/cloud/shared/src/lib/services/twitter-automation/oauth2-client.ts packages/cloud/shared/src/lib/services/social-media/token-refresh.ts packages/cloud/shared/src/lib/services/social-media/providers/reddit.ts` passed.
- `bun run audit:error-policy-ratchet` passed with no new fallback-slop in touched files.
- `bun run --cwd packages/cloud/shared typecheck 2>&1 | rg 'json-parsing|twitter-automation/oauth2-client|social-media/token-refresh|social-media/providers/reddit'` produced no touched-file diagnostics.
- `git diff --check origin/develop...HEAD && git diff --check` passed.

## Runtime / UI / Model Evidence

N/A - service helper unit boundary only. No UI, model trajectory, or audio path changed. Provider errors still throw from the same service boundaries; only response-body parsing behavior changed.
