### PR TITLE
refactor(#12251): read sensitive request cloud env aliases

### DIFF
--- a/.github/issue-evidence/12251-sensitive-request-alias-env.md
+++ b/.github/issue-evidence/12251-sensitive-request-alias-env.md
@@ -1,0 +1,51 @@
+# #12251 sensitive-request cloud env alias migration
+
+## Scope
+
+This slice migrates the sensitive-request cloud link adapters off raw
+`process.env.ELIZAOS_CLOUD_*` reads and onto the alias-aware, non-mutating
+`readAliasedEnv` helper introduced by PR #13356.
+
+Changed paths:
+
+- `packages/app-core/src/services/sensitive-requests/cloud-link-adapter.ts`
+- `packages/app-core/src/services/sensitive-requests/public-link-adapter.ts`
+- `packages/app-core/src/services/sensitive-requests/cloud-link-adapter.test.ts`
+- `packages/app-core/src/services/sensitive-requests/public-link-adapter.test.ts`
+
+## Manual Review
+
+Reviewed the two adapter diffs and confirmed runtime settings still take
+precedence over env fallback. The fallback now resolves configured
+brand<->canonical aliases without writing `ELIZAOS_CLOUD_API_KEY` or
+`ELIZAOS_CLOUD_BASE_URL` into `process.env`.
+
+This PR is stacked on #13356 because it depends on the new `readAliasedEnv`
+export and non-mutating alias reader.
+
+## Verification
+
+```bash
+bun run --cwd packages/app-core test src/services/sensitive-requests/cloud-link-adapter.test.ts src/services/sensitive-requests/public-link-adapter.test.ts
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       18 passed (18)
+```
+
+```bash
+bunx @biomejs/biome check packages/app-core/src/services/sensitive-requests/cloud-link-adapter.ts packages/app-core/src/services/sensitive-requests/public-link-adapter.ts packages/app-core/src/services/sensitive-requests/cloud-link-adapter.test.ts packages/app-core/src/services/sensitive-requests/public-link-adapter.test.ts
+```
+
+Result:
+
+```text
+Checked 4 files in 107ms. No fixes applied.
+```
+
+Raw `bun test` for the same two files executed all 18 assertions successfully
+but exited nonzero after dumping repository-wide coverage, so the package-local
+Vitest runner above is the recorded verification.

--- a/packages/app-core/src/services/sensitive-requests/cloud-link-adapter.test.ts
+++ b/packages/app-core/src/services/sensitive-requests/cloud-link-adapter.test.ts
@@ -12,11 +12,18 @@ import type {
   SensitiveRequestKind,
   SensitiveRequestTarget,
 } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
+import { getBootConfig, setBootConfig } from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createCloudLinkSensitiveRequestAdapter } from "./cloud-link-adapter";
 
 const EXPIRES_AT = "2099-01-01T00:00:00.000Z";
 const CREATED_AT = "2024-01-01T00:00:00.000Z";
+const SAVED_ENV_KEYS = [
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZA_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_BASE_URL",
+] as const;
 function makeRequest(
   kind: SensitiveRequestKind,
   overrides: {
@@ -80,6 +87,24 @@ function makeRequest(
 }
 
 describe("cloudLinkSensitiveRequestAdapter", () => {
+  const savedConfig = getBootConfig();
+  let savedEnv: Record<(typeof SAVED_ENV_KEYS)[number], string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = Object.fromEntries(
+      SAVED_ENV_KEYS.map((key) => [key, process.env[key]]),
+    ) as Record<(typeof SAVED_ENV_KEYS)[number], string | undefined>;
+  });
+
+  afterEach(() => {
+    setBootConfig(savedConfig);
+    for (const key of SAVED_ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
   it("declares the cloud_authenticated_link target", () => {
     const adapter = createCloudLinkSensitiveRequestAdapter();
     expect(adapter.target).toBe("cloud_authenticated_link");
@@ -200,5 +225,33 @@ describe("cloudLinkSensitiveRequestAdapter", () => {
     expect(result.url).toBe(
       "https://www.elizacloud.ai/sensitive-requests/req%20with%20spaces",
     );
+  });
+
+  it("resolves cloud pairing from aliased env values without mutating canonical keys", async () => {
+    setBootConfig({
+      ...savedConfig,
+      envAliases: [
+        ["ELIZA_CLOUD_API_KEY", "ELIZAOS_CLOUD_API_KEY"],
+        ["ELIZA_CLOUD_BASE_URL", "ELIZAOS_CLOUD_BASE_URL"],
+      ],
+    });
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+    process.env.ELIZA_CLOUD_API_KEY = "legacy-key";
+    process.env.ELIZA_CLOUD_BASE_URL = "https://legacy.example.com/api/v1/";
+
+    const adapter = createCloudLinkSensitiveRequestAdapter();
+    const result = await adapter.deliver({
+      request: makeRequest("secret", { id: "req-legacy" }),
+      runtime: null,
+    });
+
+    expect(result.delivered).toBe(true);
+    if (!result.delivered) throw new Error("expected success");
+    expect(result.url).toBe(
+      "https://legacy.example.com/sensitive-requests/req-legacy",
+    );
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+    expect(process.env.ELIZAOS_CLOUD_BASE_URL).toBeUndefined();
   });
 });

--- a/packages/app-core/src/services/sensitive-requests/cloud-link-adapter.ts
+++ b/packages/app-core/src/services/sensitive-requests/cloud-link-adapter.ts
@@ -14,7 +14,7 @@ import type {
   DispatchSensitiveRequest as SensitiveRequest,
   SensitiveRequestDeliveryAdapter,
 } from "@elizaos/core";
-import { normalizeCloudSiteUrl } from "@elizaos/shared";
+import { normalizeCloudSiteUrl, readAliasedEnv } from "@elizaos/shared";
 
 export interface CloudLinkAdapterDeps {
   /**
@@ -44,12 +44,12 @@ function readSetting(runtime: unknown, key: string): string | undefined {
 function defaultResolveCloudBase(runtime: unknown): string | null {
   const apiKey =
     readSetting(runtime, "ELIZAOS_CLOUD_API_KEY") ??
-    (process.env.ELIZAOS_CLOUD_API_KEY?.trim() || undefined);
+    readAliasedEnv("ELIZAOS_CLOUD_API_KEY");
   if (!apiKey) return null;
 
   const rawBase =
     readSetting(runtime, "ELIZAOS_CLOUD_BASE_URL") ??
-    (process.env.ELIZAOS_CLOUD_BASE_URL?.trim() || undefined);
+    readAliasedEnv("ELIZAOS_CLOUD_BASE_URL");
   const normalized = normalizeCloudSiteUrl(rawBase);
   return normalized || null;
 }

--- a/packages/app-core/src/services/sensitive-requests/public-link-adapter.test.ts
+++ b/packages/app-core/src/services/sensitive-requests/public-link-adapter.test.ts
@@ -8,8 +8,14 @@ import type {
   SensitiveRequest,
   SensitiveRequestWithPaymentContext,
 } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
+import { getBootConfig, setBootConfig } from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { publicLinkSensitiveRequestAdapter } from "./public-link-adapter";
+
+const SAVED_ENV_KEYS = [
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_BASE_URL",
+] as const;
 
 function buildRequest(
   overrides: Partial<SensitiveRequestWithPaymentContext> = {},
@@ -76,6 +82,24 @@ function runtimeWithSetting(value: string | undefined) {
 }
 
 describe("publicLinkSensitiveRequestAdapter", () => {
+  const savedConfig = getBootConfig();
+  let savedEnv: Record<(typeof SAVED_ENV_KEYS)[number], string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = Object.fromEntries(
+      SAVED_ENV_KEYS.map((key) => [key, process.env[key]]),
+    ) as Record<(typeof SAVED_ENV_KEYS)[number], string | undefined>;
+  });
+
+  afterEach(() => {
+    setBootConfig(savedConfig);
+    for (const key of SAVED_ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
   it("declares the public_link target", () => {
     expect(publicLinkSensitiveRequestAdapter.target).toBe("public_link");
   });
@@ -96,21 +120,17 @@ describe("publicLinkSensitiveRequestAdapter", () => {
   });
 
   it("falls back to the default cloud base when no setting or env is provided", async () => {
-    const previous = process.env.ELIZAOS_CLOUD_BASE_URL;
     delete process.env.ELIZAOS_CLOUD_BASE_URL;
-    try {
-      const result = await publicLinkSensitiveRequestAdapter.deliver({
-        request: buildRequest(),
-        runtime: runtimeWithSetting(undefined),
-      });
-      expect(result.delivered).toBe(true);
-      if (!result.delivered) throw new Error("expected success");
-      expect(result.url).toBe(
-        "https://elizacloud.ai/api/v1/payment/app-charge/app_demo/req_pay_1/public",
-      );
-    } finally {
-      if (previous !== undefined) process.env.ELIZAOS_CLOUD_BASE_URL = previous;
-    }
+    delete process.env.ELIZA_CLOUD_BASE_URL;
+    const result = await publicLinkSensitiveRequestAdapter.deliver({
+      request: buildRequest(),
+      runtime: runtimeWithSetting(undefined),
+    });
+    expect(result.delivered).toBe(true);
+    if (!result.delivered) throw new Error("expected success");
+    expect(result.url).toBe(
+      "https://elizacloud.ai/api/v1/payment/app-charge/app_demo/req_pay_1/public",
+    );
   });
 
   it("refuses kind=secret with a structured error", async () => {
@@ -189,5 +209,26 @@ describe("publicLinkSensitiveRequestAdapter", () => {
     expect(result.url).toBe(
       "https://cloud.example.com/payment/app-charge/app%2Fwith%2Fslash/req%20with%20space/public",
     );
+  });
+
+  it("resolves the public cloud base from an aliased env key without mutating canonical env", async () => {
+    setBootConfig({
+      ...savedConfig,
+      envAliases: [["ELIZA_CLOUD_BASE_URL", "ELIZAOS_CLOUD_BASE_URL"]],
+    });
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+    process.env.ELIZA_CLOUD_BASE_URL = "https://legacy.example.com/api/v1/";
+
+    const result = await publicLinkSensitiveRequestAdapter.deliver({
+      request: buildRequest(),
+      runtime: runtimeWithSetting(undefined),
+    });
+
+    expect(result.delivered).toBe(true);
+    if (!result.delivered) throw new Error("expected success");
+    expect(result.url).toBe(
+      "https://legacy.example.com/api/v1/payment/app-charge/app_demo/req_pay_1/public",
+    );
+    expect(process.env.ELIZAOS_CLOUD_BASE_URL).toBeUndefined();
   });
 });

--- a/packages/app-core/src/services/sensitive-requests/public-link-adapter.ts
+++ b/packages/app-core/src/services/sensitive-requests/public-link-adapter.ts
@@ -16,6 +16,7 @@ import {
   type SensitiveRequestWithPaymentContext,
   toRuntimeSettings,
 } from "@elizaos/core";
+import { readAliasedEnv } from "@elizaos/shared";
 
 const CLOUD_BASE_FALLBACK = "https://elizacloud.ai/api/v1";
 
@@ -54,7 +55,7 @@ function resolveCloudBaseUrl(runtime: unknown): string {
       return stripTrailingSlashes(fromSetting.trim());
     }
   }
-  const fromEnv = nonEmpty(process.env.ELIZAOS_CLOUD_BASE_URL);
+  const fromEnv = nonEmpty(readAliasedEnv("ELIZAOS_CLOUD_BASE_URL"));
   if (fromEnv) return stripTrailingSlashes(fromEnv);
   return stripTrailingSlashes(CLOUD_BASE_FALLBACK);
 }


### PR DESCRIPTION
## Summary
- migrate sensitive-request cloud env fallbacks to the non-mutating alias-aware read helper from #13356
- add tests proving legacy cloud env aliases resolve without materializing canonical ELIZAOS_CLOUD_* keys
- record focused verification in .github/issue-evidence/12251-sensitive-request-alias-env.md

## Stack
- Stacked on #13356; this PR should merge after that branch lands or be rebased onto develop once #13356 is merged.

## Verification
- bun run --cwd packages/app-core test src/services/sensitive-requests/cloud-link-adapter.test.ts src/services/sensitive-requests/public-link-adapter.test.ts
- bunx @biomejs/biome check packages/app-core/src/services/sensitive-requests/cloud-link-adapter.ts packages/app-core/src/services/sensitive-requests/public-link-adapter.ts packages/app-core/src/services/sensitive-requests/cloud-link-adapter.test.ts packages/app-core/src/services/sensitive-requests/public-link-adapter.test.ts

Refs #12251