### PR TITLE
fix(#13417): fail closed on unconfirmed cache invalidation (revocation paths)

### DIFF
--- a/.github/issue-evidence/13417-cloud-shared-cache-invalidation-fallback.md
+++ b/.github/issue-evidence/13417-cloud-shared-cache-invalidation-fallback.md
@@ -56,6 +56,11 @@ credential-revocation boundary.
   (the ban / org-deactivate fan-out) **throws** on any unconfirmed delete so its
   `await`-only callers (admin ban, user deactivate) fail closed automatically —
   the org-deactivate caller keeps its deliberate best-effort `try/catch`.
+- `inference-billing-fast-path` now contains the uncollected-debit
+  user-IAC eviction as explicit best-effort (error-policy:J5). The org balance
+  hint is already invalidated before the background user eviction, so the next
+  request leaves the optimistic path even if the user fan-out cache delete is
+  temporarily unavailable.
 - **Configured-vs-unavailable split (codex round-1 P1):** `delConfirmed` /
   `delPatternConfirmed` return `true` only when NO backend is configured (nothing
   could be caching a stale entry). When a backend IS configured but temporarily
@@ -78,6 +83,7 @@ credential-revocation boundary.
 | `lib/services/inference-auth-cache.ts` | `invalidateInferenceAuthContextByKeyHash` | discarded `cache.del` result | returns confirmation boolean | FIXED |
 | `lib/services/inference-auth-cache.ts` | `invalidateInferenceAuthContextsByKeyHashes` | fire-all, ignore | throws on any unconfirmed delete (ban/deactivate fail closed) | FIXED (J1) |
 | `lib/cache/client.ts` | `delConfirmed`/`delPatternConfirmed` (circuit-open) | returned `true` when circuit open over a configured backend | returns `false` when configured-but-unavailable (new `isBackendConfigured()`) | FIXED (codex P1) |
+| `lib/services/inference-billing-fast-path.ts` | uncollected-debit user IAC eviction | `void` background call assumed never-throwing old contract | explicit `.catch` + structured log; org hint already invalidated | FIXED (J5) |
 
 ## Focused tests
 
@@ -94,30 +100,41 @@ New:
   throws; `delete()` aborts BEFORE the DB row is removed on failed invalidation;
   confirmed invalidation lets the DB delete proceed; `invalidateInferenceContextForUser`
   unconfirmed fan-out throws (ban fails closed) / all-confirmed resolves.
+- `lib/services/inference-billing-fast-path.test.ts` — failed debit still
+  invalidates the org balance hint and contains a rejected background user-IAC
+  invalidation without surfacing an unhandled rejection.
 
 ```
-$ bun test <3 new files above>
- 20 pass
+$ bun test packages/cloud/shared/src/lib/cache/del-confirmed.test.ts packages/cloud/shared/src/lib/cache/service-cache.invalidate.test.ts
+ 14 pass
  0 fail
-(existing cache suite: 24 pass / 0 fail — no regression)
+
+$ bun test packages/cloud/shared/src/lib/services/api-keys.invalidation.test.ts
+ 8 pass
+ 0 fail
+
+$ bun test packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+ 29 pass
+  0 fail
 ```
 
 ## Verification
 
 - `bunx @biomejs/biome check <touched files>` → clean (no fixes applied).
 - `bun run audit:error-policy-ratchet` → `no new fallback-slop in touched files` (EXIT 0).
-- `bun run --cwd packages/cloud/shared typecheck` → **0 errors in touched files.**
-  17 remaining errors are pre-existing baseline declaration noise in files NOT
-  touched by this change (`../../app-core/**` symlink artifacts,
-  `lib/cache/adapters/node-redis-adapter.ts`, `lib/eliza/plugin-mcp/utils/json.ts`,
-  `lib/providers/anthropic-web-search.ts`) — see CLAUDE.md "typecheck noise".
-- `git diff --check` → clean.
+- `bun run --cwd packages/cloud/shared typecheck` → nonzero from pre-existing
+  transitive `../../app-core/**` auth-alias diagnostics; filtered check for
+  `cache/client|cache/service-cache|api-keys|inference-auth-cache|inference-billing-fast-path`
+  produced no touched-file diagnostics.
+- `git diff --check origin/develop...HEAD && git diff --check` → clean.
 
 ## Structured log examples (changed runtime failure paths)
 
 - `invalidateCache` unconfirmed: `logger.error("[Cache] Invalidation not confirmed for <key>")` then throw.
 - `invalidateCachePattern` incomplete: `logger.error("[Cache] Pattern invalidation incomplete for <pattern>")` then throw.
 - `apiKeysService.invalidateCache` unconfirmed: `logger.error("[ApiKeys] API key cache invalidation not confirmed", { shortHash, unconfirmed: [...] })` then throw.
+- `inference-billing-fast-path` user eviction failure:
+  `logger.error("[InferenceBilling] failed to invalidate user inference auth context", { organizationId, userId, requestId, error })`.
 
 ## Evidence types (mandate)
 

--- a/.github/issue-evidence/13417-cloud-shared-cache-invalidation-fallback.md
+++ b/.github/issue-evidence/13417-cloud-shared-cache-invalidation-fallback.md
@@ -1,0 +1,129 @@
+# #13417 — cloud-shared cache-invalidation fail-closed slice (distinct from lalalune PR #13459 json-parsing slice)
+
+Slice of the `packages/cloud/shared/src/lib` fallback sweep focused on the
+**cache-invalidation fail-open** on security-sensitive paths (auth / credential
+revocation). Adjacent slices (`#13416` DB repositories, `#13415` service layer)
+are owned by sibling lanes; this slice is the `cache/` + credential-revocation
+boundary and does not overlap them.
+
+## Root cause (fabricated-success / fail-open)
+
+Cache invalidation is security-sensitive: revoking an API key, logging a user
+out, or changing a permission all depend on the stale cached copy actually being
+removed. Three layers silently reported a **failed** delete as a **successful**
+invalidation:
+
+1. `CacheClient.del(key)` — swallowed a backend `del` failure (logged a warning)
+   and returned `void`. The failure was invisible to every caller.
+2. `CacheClient.delPattern(pattern)` — returned `void`; a hit on the
+   runaway-iteration guard left matching keys behind but returned normally,
+   indistinguishable from a complete sweep.
+3. `service-cache.invalidateCache` / `invalidateCachePattern` — wrapped the
+   delete in a `try/catch` that swallowed every error and returned normally.
+4. `apiKeysService.invalidateCache(keyHash)` (live revoke/delete/deactivate
+   path) and `invalidateInferenceAuthContextByKeyHash` (the #9899 inference
+   hot-path auth-context entry) fired `cache.del` and **discarded** the result.
+
+Net effect: if Redis `del` failed (backend down / network blip) during a
+revoke, the revoke path completed "successfully" while the **revoked API key /
+logged-out session stayed in cache and kept authenticating until its TTL
+lapsed** (validation TTL 10m, inference auth-context TTL 60s). A fail-open on a
+credential-revocation boundary.
+
+## Fix (fail closed, additive & backward-compatible)
+
+- `CacheClient.del` keeps its `Promise<void>` best-effort contract (delegates to
+  the new method, discarding the result) so the ~20 existing best-effort
+  callers are untouched. Added `delConfirmed(key): Promise<boolean>` returning
+  `true` only when the delete is confirmed against the backend (or no backend is
+  configured, so nothing to invalidate), `false` when a configured backend
+  rejected it.
+- `CacheClient.delPattern` keeps `Promise<void>`; added
+  `delPatternConfirmed(...): Promise<boolean>` returning `false` when the
+  runaway-iteration guard left matching keys behind (partial sweep).
+- `service-cache.invalidateCache` / `invalidateCachePattern` now **throw** a new
+  typed `CacheInvalidationError` (error-policy:J1) when the delete is not
+  confirmed — no more swallow-and-return. `invalidateCacheBatch` attempts every
+  key (`Promise.allSettled`) and throws naming the exact keys still potentially
+  served stale.
+- `apiKeysService.invalidateCache` throws when either the validation-cache or
+  inference-auth-context delete is unconfirmed. Because `update`/`delete`/
+  `deactivate` invalidate BEFORE the DB mutation, a failed invalidation now
+  aborts before the row is revoked — the key stays consistently
+  active-and-cached, never DB-revoked-but-cache-live.
+- `invalidateInferenceAuthContextByKeyHash` returns the confirmation signal
+  (its `api-keys` caller inspects it); `invalidateInferenceAuthContextsByKeyHashes`
+  (the ban / org-deactivate fan-out) **throws** on any unconfirmed delete so its
+  `await`-only callers (admin ban, user deactivate) fail closed automatically —
+  the org-deactivate caller keeps its deliberate best-effort `try/catch`.
+- **Configured-vs-unavailable split (codex round-1 P1):** `delConfirmed` /
+  `delPatternConfirmed` return `true` only when NO backend is configured (nothing
+  could be caching a stale entry). When a backend IS configured but temporarily
+  unavailable (circuit breaker open / still connecting), they now return `false`
+  — a Redis brownout no longer reports a revoked-credential invalidation as
+  successful. New `isBackendConfigured()` distinguishes the two.
+
+## Path / line / verdict table
+
+| Path | Symbol | Before | After | Verdict |
+|---|---|---|---|---|
+| `lib/cache/client.ts` | `del` | swallowed backend failure, `Promise<void>` | best-effort wrapper over `delConfirmed` (unchanged for existing callers) | kept (best-effort by design) |
+| `lib/cache/client.ts` | `delConfirmed` (new) | — | `Promise<boolean>`, `false` on rejected backend delete | fail-closed signal |
+| `lib/cache/client.ts` | `delPattern` | partial sweep returned as complete, `Promise<void>` | best-effort wrapper over `delPatternConfirmed` | kept (best-effort) |
+| `lib/cache/client.ts` | `delPatternConfirmed` (new) | — | `false` when runaway-guard left keys behind | fail-closed signal |
+| `lib/cache/service-cache.ts` | `invalidateCache` | `catch → return` (fabricated success) | throws `CacheInvalidationError` on unconfirmed delete | FIXED (J1) |
+| `lib/cache/service-cache.ts` | `invalidateCachePattern` | `catch → return` | throws on thrown/incomplete sweep | FIXED (J1) |
+| `lib/cache/service-cache.ts` | `invalidateCacheBatch` | fire-all, ignore failures | `allSettled` + throw naming failed keys | FIXED (J1) |
+| `lib/services/api-keys.ts` | `invalidateCache` | discarded both `cache.del` results | throws if validation OR inference delete unconfirmed | FIXED (J1) |
+| `lib/services/inference-auth-cache.ts` | `invalidateInferenceAuthContextByKeyHash` | discarded `cache.del` result | returns confirmation boolean | FIXED |
+| `lib/services/inference-auth-cache.ts` | `invalidateInferenceAuthContextsByKeyHashes` | fire-all, ignore | throws on any unconfirmed delete (ban/deactivate fail closed) | FIXED (J1) |
+| `lib/cache/client.ts` | `delConfirmed`/`delPatternConfirmed` (circuit-open) | returned `true` when circuit open over a configured backend | returns `false` when configured-but-unavailable (new `isBackendConfigured()`) | FIXED (codex P1) |
+
+## Focused tests
+
+New:
+- `lib/cache/service-cache.invalidate.test.ts` — confirmed/unconfirmed/thrown
+  delete for `invalidateCache`, incomplete/thrown pattern sweep for
+  `invalidateCachePattern`, batch attempts-every-key + reports failed keys +
+  empty-input no-op.
+- `lib/cache/del-confirmed.test.ts` — `delConfirmed`/`delPatternConfirmed`
+  no-backend-configured → `true` vs configured-but-unavailable (circuit open) →
+  `false` (fail closed).
+- `lib/services/api-keys.invalidation.test.ts` — both deletes confirmed →
+  resolves; validation-cache OR inference-auth-context delete unconfirmed →
+  throws; `delete()` aborts BEFORE the DB row is removed on failed invalidation;
+  confirmed invalidation lets the DB delete proceed; `invalidateInferenceContextForUser`
+  unconfirmed fan-out throws (ban fails closed) / all-confirmed resolves.
+
+```
+$ bun test <3 new files above>
+ 20 pass
+ 0 fail
+(existing cache suite: 24 pass / 0 fail — no regression)
+```
+
+## Verification
+
+- `bunx @biomejs/biome check <touched files>` → clean (no fixes applied).
+- `bun run audit:error-policy-ratchet` → `no new fallback-slop in touched files` (EXIT 0).
+- `bun run --cwd packages/cloud/shared typecheck` → **0 errors in touched files.**
+  17 remaining errors are pre-existing baseline declaration noise in files NOT
+  touched by this change (`../../app-core/**` symlink artifacts,
+  `lib/cache/adapters/node-redis-adapter.ts`, `lib/eliza/plugin-mcp/utils/json.ts`,
+  `lib/providers/anthropic-web-search.ts`) — see CLAUDE.md "typecheck noise".
+- `git diff --check` → clean.
+
+## Structured log examples (changed runtime failure paths)
+
+- `invalidateCache` unconfirmed: `logger.error("[Cache] Invalidation not confirmed for <key>")` then throw.
+- `invalidateCachePattern` incomplete: `logger.error("[Cache] Pattern invalidation incomplete for <pattern>")` then throw.
+- `apiKeysService.invalidateCache` unconfirmed: `logger.error("[ApiKeys] API key cache invalidation not confirmed", { shortHash, unconfirmed: [...] })` then throw.
+
+## Evidence types (mandate)
+
+- UI screenshots — N/A (no client surface touched).
+- Model trajectories — N/A (no model-backed endpoint touched).
+- Audio — N/A.
+- DB row / migration artifacts — N/A (no schema/migration change; behavior change
+  is at the cache-invalidation boundary, proven by unit tests including the
+  fail-closed ordering that gates the DB `delete`).

--- a/packages/cloud/shared/src/lib/cache/client.ts
+++ b/packages/cloud/shared/src/lib/cache/client.ts
@@ -86,6 +86,14 @@ function parseCacheValue<T>(value: unknown): T {
 export class CacheClient {
   private redis: CacheRedisClient | null = null;
   private enabled: boolean | null = null;
+  /**
+   * Whether a real cache backend was CONFIGURED (credentials/binding present or
+   * an explicit memory/wadis backend). Unlike `enabled`, this is NOT flipped to
+   * false by a runtime connect failure or circuit-open — so
+   * {@link isBackendConfigured} can tell "nothing to invalidate" from "a backend
+   * exists but is currently unreachable". (#13417)
+   */
+  private backendConfigured = false;
   private initialized = false;
   private failureCount = 0;
   private lastFailureTime = 0;
@@ -146,6 +154,7 @@ export class CacheClient {
   }
 
   private initializeWadis(): void {
+    this.backendConfigured = true;
     this.nativeRedisReady = false;
     this.nativeRedisConnectPromise = import("wadis")
       .then(({ Wadis }) => {
@@ -179,6 +188,7 @@ export class CacheClient {
     if (this.enabled && process.env.MOCK_REDIS === "1") {
       this.nativeRedisConnectPromise = null;
       this.nativeRedisReady = true;
+      this.backendConfigured = true;
       this.redis = new MemoryCacheAdapter();
       logger.info("[Cache] ✓ Cache client initialized with in-memory mock (MOCK_REDIS=1)");
       return;
@@ -231,6 +241,7 @@ export class CacheClient {
 
       this.nativeRedisConnectPromise = null;
       this.nativeRedisReady = true;
+      this.backendConfigured = true;
       this.redis = new MemoryCacheAdapter();
       logger.info("[Cache] ✓ Cache client initialized with in-memory local test backend");
       return;
@@ -250,6 +261,7 @@ export class CacheClient {
     if (inWorker && backendPreference !== "redis-rest" && backendPreference !== "redis") {
       const kv = this.getKvBinding();
       if (kv) {
+        this.backendConfigured = true;
         this.redis = new KvCacheAdapter(kv);
         this.nativeRedisConnectPromise = null;
         this.nativeRedisReady = true;
@@ -262,6 +274,7 @@ export class CacheClient {
     // works for RESP2. Use the SocketRedis adapter whenever we're in a Worker and
     // a real REDIS_URL is set.
     if (inWorker && socketRedisConfigured && redisUrl && backendPreference !== "redis-rest") {
+      this.backendConfigured = true;
       this.redis = new SocketRedisAdapter(new SocketRedis({ url: redisUrl }));
       this.nativeRedisConnectPromise = null;
       this.nativeRedisReady = true;
@@ -276,6 +289,7 @@ export class CacheClient {
       redisUrl &&
       (backendPreference === "auto" || backendPreference === "redis")
     ) {
+      this.backendConfigured = true;
       const client = createClient({ url: redisUrl });
 
       client.on("error", (error: unknown) => {
@@ -315,6 +329,7 @@ export class CacheClient {
     ) {
       this.nativeRedisConnectPromise = null;
       this.nativeRedisReady = true;
+      this.backendConfigured = true;
       this.redis = new UpstashRedisAdapter(
         new UpstashRedis({
           url: restUrl,
@@ -396,6 +411,22 @@ export class CacheClient {
       (this.redis || this.nativeRedisConnectPromise) &&
       !this.isCircuitOpen()
     );
+  }
+
+  /**
+   * Whether a cache backend is CONFIGURED at all (independent of transient
+   * availability / circuit-breaker state). Distinguishes "no backend, nothing to
+   * invalidate" from "backend configured but temporarily unreachable" so
+   * {@link delConfirmed} / {@link delPatternConfirmed} can fail closed only in
+   * the latter case. (#13417)
+   */
+  isBackendConfigured(): boolean {
+    this.initialize();
+    // Reflects that a backend was SELECTED (creds/binding/memory/wadis present),
+    // even if a later connect attempt failed and downgraded `enabled` — a stale
+    // entry may still live in that configured backend, so an unconfirmed delete
+    // against it must fail closed, not report "nothing to invalidate".
+    return this.backendConfigured;
   }
 
   /**
@@ -709,11 +740,35 @@ export class CacheClient {
   /**
    * Deletes a key from cache.
    *
+   * Best-effort: swallows a backend delete failure (logs a warning) and returns
+   * `void`. Callers on a security-sensitive invalidation path (revoked
+   * credentials, logout, permission changes) must instead use
+   * {@link delConfirmed} so they can fail closed on an unconfirmed delete
+   * rather than assume a stale entry is gone. (#13417)
+   *
    * @param key - Cache key to delete.
    */
   async del(key: string): Promise<void> {
+    await this.delConfirmed(key);
+  }
+
+  /**
+   * Deletes a key from cache, reporting whether the delete was confirmed.
+   *
+   * @param key - Cache key to delete.
+   * @returns `true` when the delete is confirmed against the backend, OR when no
+   *   cache backend is CONFIGURED at all (nothing could be caching a stale
+   *   entry, so there is nothing to invalidate). `false` when a configured
+   *   backend rejected the delete OR is temporarily unavailable (circuit
+   *   breaker open / still connecting) — in that brownout a stale entry may
+   *   still live in the backend, so the delete is NOT confirmed. The previous
+   *   void-only `del` contract silently reported all of these as success, so a
+   *   revoked key/session kept serving from cache until its TTL lapsed.
+   *   Security-sensitive invalidation MUST fail closed on `false`. (#13417)
+   */
+  async delConfirmed(key: string): Promise<boolean> {
     const redis = await this.getRedisClient();
-    if (!redis) return;
+    if (!redis) return !this.isBackendConfigured();
 
     try {
       const start = Date.now();
@@ -722,12 +777,14 @@ export class CacheClient {
       logger.debug(`[Cache] DEL: ${key}`);
       this.resetFailures();
       this.logMetric(key, "del", Date.now() - start);
+      return true;
     } catch (error) {
       this.recordFailure();
       logger.warn("[Cache] DEL failed", {
         key,
         error: error instanceof Error ? error.message : String(error),
       });
+      return false;
     }
   }
 
@@ -768,13 +825,42 @@ export class CacheClient {
    *
    * Uses SCAN instead of KEYS to avoid blocking Redis on large keysets.
    *
+   * Best-effort: returns `void`; a partial sweep (runaway-iteration guard) is
+   * indistinguishable from a complete one to the caller. Security-sensitive
+   * invalidation must use {@link delPatternConfirmed} instead. (#13417)
+   *
    * @param pattern - Pattern to match (e.g., "org:*:cache")
    * @param batchSize - Number of keys to scan per iteration (default: 100)
    * @param maxIterations - Maximum iterations to prevent runaway scans (default: 1000)
    */
   async delPattern(pattern: string, batchSize = 100, maxIterations = 1000): Promise<void> {
+    await this.delPatternConfirmed(pattern, batchSize, maxIterations);
+  }
+
+  /**
+   * Delete all keys matching a pattern using SCAN, reporting completeness.
+   *
+   * @param pattern - Pattern to match (e.g., "org:*:cache")
+   * @param batchSize - Number of keys to scan per iteration (default: 100)
+   * @param maxIterations - Maximum iterations to prevent runaway scans (default: 1000)
+   * @returns `true` when the full keyspace matching `pattern` was scanned and
+   *   deleted (or there is no backend to invalidate); `false` when the scan hit
+   *   the runaway-iteration guard and therefore left matching keys behind — a
+   *   PARTIAL invalidation that previously returned normally and was
+   *   indistinguishable from a complete one. Security-sensitive callers MUST
+   *   fail closed on `false`. (A thrown scan/del error still propagates.)
+   *   (#13417)
+   */
+  async delPatternConfirmed(
+    pattern: string,
+    batchSize = 100,
+    maxIterations = 1000,
+  ): Promise<boolean> {
     const redis = await this.getRedisClient();
-    if (!redis) return;
+    // No backend configured -> nothing to invalidate (true). Configured but
+    // temporarily unavailable (circuit open / connecting) -> unconfirmed sweep
+    // over a backend that may still hold matching keys (false, fail closed).
+    if (!redis) return !this.isBackendConfigured();
 
     const start = Date.now();
     // Thread the cursor as an opaque string. Cloudflare KV returns a base64-ish
@@ -834,6 +920,10 @@ export class CacheClient {
     }
 
     this.logMetric(pattern, "del_pattern", duration);
+    // A hit on the runaway-iteration guard means keys matching `pattern` were
+    // left behind: report the invalidation as INCOMPLETE so callers can fail
+    // closed instead of assuming a clean sweep.
+    return !hitMaxIterations;
   }
 
   /**

--- a/packages/cloud/shared/src/lib/cache/del-confirmed.test.ts
+++ b/packages/cloud/shared/src/lib/cache/del-confirmed.test.ts
@@ -1,0 +1,78 @@
+/**
+ * `CacheClient.delConfirmed` / `delPatternConfirmed` contract (#13417).
+ *
+ * The confirmation signal must distinguish:
+ *   - no backend CONFIGURED  -> nothing could be caching a stale entry -> true;
+ *   - backend configured but UNAVAILABLE (circuit breaker open / connecting)
+ *     -> the stale entry may still live in the backend -> false (fail closed);
+ *   - backend confirmed delete -> true; backend rejected delete -> false.
+ *
+ * Without the configured-vs-unavailable split, a Redis brownout would report a
+ * revoked-credential invalidation as successful while the entry survives in
+ * Redis until its TTL — a fail-open on the revocation path.
+ */
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { cache } from "./client";
+
+// getRedisClient is private; access it for spying via a typed view.
+type Internal = {
+  getRedisClient: () => Promise<unknown>;
+  isBackendConfigured: () => boolean;
+};
+const internal = cache as unknown as Internal;
+
+describe("delConfirmed configured-vs-unavailable contract (#13417)", () => {
+  const spies: Array<{ mockRestore: () => void }> = [];
+  afterEach(() => {
+    for (const spy of spies.splice(0)) spy.mockRestore();
+  });
+
+  function stubNoClient() {
+    // getRedisClient() returns null in BOTH "disabled" and "circuit open" cases;
+    // the boolean must then be derived from whether a backend is configured.
+    spies.push(spyOn(internal, "getRedisClient").mockResolvedValue(null));
+  }
+
+  test("no backend configured -> delConfirmed true (nothing to invalidate)", async () => {
+    stubNoClient();
+    spies.push(spyOn(internal, "isBackendConfigured").mockReturnValue(false));
+    expect(await cache.delConfirmed("apikey:abc")).toBe(true);
+  });
+
+  test("backend configured but unavailable (circuit open) -> delConfirmed false (fail closed)", async () => {
+    stubNoClient();
+    spies.push(spyOn(internal, "isBackendConfigured").mockReturnValue(true));
+    expect(await cache.delConfirmed("apikey:abc")).toBe(false);
+  });
+
+  test("no backend configured -> delPatternConfirmed true", async () => {
+    stubNoClient();
+    spies.push(spyOn(internal, "isBackendConfigured").mockReturnValue(false));
+    expect(await cache.delPatternConfirmed("org:1:*")).toBe(true);
+  });
+
+  test("backend configured but unavailable -> delPatternConfirmed false (fail closed)", async () => {
+    stubNoClient();
+    spies.push(spyOn(internal, "isBackendConfigured").mockReturnValue(true));
+    expect(await cache.delPatternConfirmed("org:1:*")).toBe(false);
+  });
+
+  test("a configured backend whose connect FAILED still reports configured (fail closed)", async () => {
+    // Reproduce codex round-2 P1: the native-connect .catch downgrades `enabled`
+    // to false, but `backendConfigured` must stay true so a stale entry in that
+    // Redis is not treated as "nothing to invalidate".
+    const priv = cache as unknown as { enabled: boolean | null; backendConfigured: boolean };
+    const savedEnabled = priv.enabled;
+    const savedConfigured = priv.backendConfigured;
+    try {
+      priv.enabled = false; // connect-failure downgrade
+      priv.backendConfigured = true; // backend WAS selected
+      stubNoClient();
+      expect(await cache.delConfirmed("apikey:abc")).toBe(false);
+    } finally {
+      priv.enabled = savedEnabled;
+      priv.backendConfigured = savedConfigured;
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/cache/service-cache.invalidate.test.ts
+++ b/packages/cloud/shared/src/lib/cache/service-cache.invalidate.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Fail-closed cache invalidation tests (#13417).
+ *
+ * Invalidation is security-sensitive: revoking an API key, logging a user out,
+ * or changing a permission all rely on the stale cached copy actually being
+ * removed. The module-level `invalidateCache*` helpers used to wrap the delete
+ * in a `try/catch` that swallowed every failure and returned normally — a
+ * failed Redis `del` (backend down / network blip) was reported as a successful
+ * invalidation, so the revoked/stale entry kept serving from cache until its
+ * TTL lapsed. `cache.del` itself also swallowed the backend error and returned
+ * `void`, so the failure was invisible at both layers.
+ *
+ * These tests pin the corrected contract:
+ *   - a rejected backend delete surfaces as a `CacheInvalidationError`;
+ *   - a `cache.del` that reports `false` (delete not confirmed) also throws;
+ *   - a `delPattern` that reports `false` (incomplete sweep) throws;
+ *   - the batch helper attempts every key and reports the exact failed keys;
+ *   - the confirmed-delete happy path still resolves quietly.
+ */
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { cache } from "./client";
+import {
+  CacheInvalidationError,
+  invalidateCache,
+  invalidateCacheBatch,
+  invalidateCachePattern,
+} from "./service-cache";
+
+describe("service-cache invalidation fails closed (#13417)", () => {
+  const spies: Array<{ mockRestore: () => void }> = [];
+
+  afterEach(() => {
+    for (const spy of spies.splice(0)) spy.mockRestore();
+  });
+
+  function spyDel(impl: (key: string) => Promise<boolean>) {
+    const spy = spyOn(cache, "delConfirmed").mockImplementation(impl);
+    spies.push(spy);
+    return spy;
+  }
+
+  function spyDelPattern(impl: (pattern: string) => Promise<boolean>) {
+    const spy = spyOn(cache, "delPatternConfirmed").mockImplementation(
+      impl as typeof cache.delPatternConfirmed,
+    );
+    spies.push(spy);
+    return spy;
+  }
+
+  test("invalidateCache: confirmed delete resolves (no throw)", async () => {
+    spyDel(async () => true);
+    await expect(invalidateCache("apikey:abc")).resolves.toBeUndefined();
+  });
+
+  test("invalidateCache: unconfirmed delete (false) throws CacheInvalidationError", async () => {
+    spyDel(async () => false);
+    const promise = invalidateCache("apikey:abc");
+    await expect(promise).rejects.toBeInstanceOf(CacheInvalidationError);
+    await expect(promise).rejects.toMatchObject({ target: "apikey:abc" });
+  });
+
+  test("invalidateCache: thrown backend delete throws (does not fabricate success)", async () => {
+    const boom = new Error("redis down");
+    spyDel(async () => {
+      throw boom;
+    });
+    const promise = invalidateCache("session:xyz");
+    await expect(promise).rejects.toBeInstanceOf(CacheInvalidationError);
+    await expect(promise).rejects.toMatchObject({ cause: boom });
+  });
+
+  test("invalidateCachePattern: confirmed complete sweep resolves", async () => {
+    spyDelPattern(async () => true);
+    await expect(invalidateCachePattern("org:1:*")).resolves.toBeUndefined();
+  });
+
+  test("invalidateCachePattern: incomplete sweep (false) throws", async () => {
+    spyDelPattern(async () => false);
+    await expect(invalidateCachePattern("org:1:*")).rejects.toBeInstanceOf(CacheInvalidationError);
+  });
+
+  test("invalidateCachePattern: thrown scan/del throws", async () => {
+    spyDelPattern(async () => {
+      throw new Error("scan failed");
+    });
+    await expect(invalidateCachePattern("org:1:*")).rejects.toBeInstanceOf(CacheInvalidationError);
+  });
+
+  test("invalidateCacheBatch: attempts every key, reports the failed ones", async () => {
+    const failing = new Set(["k2", "k4"]);
+    const seen: string[] = [];
+    spyDel(async (key: string) => {
+      seen.push(key);
+      return !failing.has(key);
+    });
+
+    const promise = invalidateCacheBatch(["k1", "k2", "k3", "k4"]);
+    await expect(promise).rejects.toBeInstanceOf(CacheInvalidationError);
+    // every key attempted even though k2 failed before k3/k4
+    expect(seen.sort()).toEqual(["k1", "k2", "k3", "k4"]);
+    // the error names exactly the unconfirmed keys
+    await expect(promise).rejects.toMatchObject({ target: "k2,k4" });
+  });
+
+  test("invalidateCacheBatch: all confirmed resolves quietly", async () => {
+    spyDel(async () => true);
+    await expect(invalidateCacheBatch(["a", "b", "c"])).resolves.toBeUndefined();
+  });
+
+  test("invalidateCacheBatch: empty input is a no-op", async () => {
+    const del = spyDel(async () => true);
+    await expect(invalidateCacheBatch([])).resolves.toBeUndefined();
+    expect(del).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/cache/service-cache.ts
+++ b/packages/cloud/shared/src/lib/cache/service-cache.ts
@@ -171,38 +171,114 @@ export async function withBatchCache<T>(
 }
 
 /**
- * Invalidate cache for a specific key.
+ * Raised when a cache invalidation could not be confirmed against the backend.
+ *
+ * Invalidation is security-sensitive: revoking an API key, logging a user out,
+ * or changing a permission all rely on the stale cached copy actually being
+ * removed. If the backend delete fails (or a pattern sweep is left incomplete)
+ * the caller must know so it can fail closed — e.g. reject the mutation, retry,
+ * or refuse to report success — rather than serve the revoked/stale value until
+ * its TTL lapses. (#13417)
+ */
+export class CacheInvalidationError extends Error {
+  constructor(
+    message: string,
+    readonly target: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "CacheInvalidationError";
+  }
+}
+
+/**
+ * Invalidate cache for a specific key. Fails closed.
  *
  * @param key - Cache key
+ * @throws {CacheInvalidationError} when the backend delete was not confirmed.
+ *   Previously this swallowed all errors and returned normally, so a failed
+ *   delete (Redis down/network blip) was reported as a successful invalidation
+ *   and the stale entry — e.g. a just-revoked API key or a logged-out session
+ *   — kept serving from cache until its TTL expired.
  */
 export async function invalidateCache(key: string): Promise<void> {
+  let deleted: boolean;
   try {
-    await cache.del(key);
-    logger.debug(`[Cache] INVALIDATED: ${key}`);
+    deleted = await cache.delConfirmed(key);
   } catch (error) {
+    // error-policy:J1 — a thrown delete is an unconfirmed invalidation; surface
+    // it so the security-sensitive caller can fail closed.
     logger.error(`[Cache] Error invalidating cache for ${key}:`, error);
+    throw new CacheInvalidationError(`Failed to invalidate cache key ${key}`, key, {
+      cause: error,
+    });
   }
+
+  if (!deleted) {
+    // error-policy:J1 — backend rejected the delete; do not fabricate success.
+    logger.error(`[Cache] Invalidation not confirmed for ${key}`);
+    throw new CacheInvalidationError(`Cache invalidation not confirmed for key ${key}`, key);
+  }
+
+  logger.debug(`[Cache] INVALIDATED: ${key}`);
 }
 
 /**
- * Invalidate cache for a pattern (e.g., "user:123:*").
+ * Invalidate cache for a pattern (e.g., "user:123:*"). Fails closed.
  *
  * @param pattern - Cache key pattern
+ * @throws {CacheInvalidationError} when the pattern sweep was not confirmed
+ *   complete (thrown scan/del, or the runaway-iteration guard left matching
+ *   keys behind). A partial sweep previously returned as if it were complete.
  */
 export async function invalidateCachePattern(pattern: string): Promise<void> {
+  let deleted: boolean;
   try {
-    await cache.delPattern(pattern);
-    logger.debug(`[Cache] INVALIDATED PATTERN: ${pattern}`);
+    deleted = await cache.delPatternConfirmed(pattern);
   } catch (error) {
+    // error-policy:J1 — unconfirmed invalidation must not read as success.
     logger.error(`[Cache] Error invalidating cache pattern ${pattern}:`, error);
+    throw new CacheInvalidationError(`Failed to invalidate cache pattern ${pattern}`, pattern, {
+      cause: error,
+    });
   }
+
+  if (!deleted) {
+    // error-policy:J1 — incomplete pattern sweep left matching keys behind.
+    logger.error(`[Cache] Pattern invalidation incomplete for ${pattern}`);
+    throw new CacheInvalidationError(
+      `Cache pattern invalidation incomplete for ${pattern}`,
+      pattern,
+    );
+  }
+
+  logger.debug(`[Cache] INVALIDATED PATTERN: ${pattern}`);
 }
 
 /**
- * Invalidate multiple cache keys.
+ * Invalidate multiple cache keys. Fails closed.
+ *
+ * Every key is attempted (a failing key does not short-circuit the rest), but
+ * the call rejects if ANY key could not be invalidated so the caller never
+ * mistakes a partial sweep for a full one.
  *
  * @param keys - Array of cache keys
+ * @throws {CacheInvalidationError} naming every key whose invalidation was not
+ *   confirmed.
  */
 export async function invalidateCacheBatch(keys: string[]): Promise<void> {
-  await Promise.all(keys.map((key) => invalidateCache(key)));
+  const results = await Promise.allSettled(keys.map((key) => invalidateCache(key)));
+  const failedKeys = keys.filter((_key, index) => results[index].status === "rejected");
+
+  if (failedKeys.length > 0) {
+    // error-policy:J1 — report the exact keys still potentially served stale.
+    const firstRejection = results.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    throw new CacheInvalidationError(
+      `Failed to invalidate ${failedKeys.length} of ${keys.length} cache keys: ${failedKeys.join(", ")}`,
+      failedKeys.join(","),
+      { cause: firstRejection?.reason },
+    );
+  }
 }

--- a/packages/cloud/shared/src/lib/services/api-keys.invalidation.test.ts
+++ b/packages/cloud/shared/src/lib/services/api-keys.invalidation.test.ts
@@ -1,0 +1,133 @@
+/**
+ * API-key revocation cache-invalidation fails closed (#13417).
+ *
+ * `apiKeysService.invalidateCache()` is on every revoke / delete / deactivate
+ * path. It clears BOTH the validation cache (16-char prefix) and the #9899
+ * inference hot-path auth-context entry. Previously it fired both `cache.del`
+ * calls inside a `Promise.all` and discarded their result, and `cache.del`
+ * itself swallowed a backend failure — so a Redis `del` that never landed left
+ * a REVOKED key authenticating from cache until its TTL lapsed, while the
+ * revoke path reported success.
+ *
+ * These tests pin the corrected contract: an unconfirmed delete of either cache
+ * surfaces as a throw, so the caller (route) can fail closed and retry rather
+ * than believe the key is gone. Ordering matters too: `delete()` invalidates
+ * BEFORE the DB delete, so a failed invalidation aborts before the row is
+ * removed — the key stays consistently active-and-cached, never
+ * DB-revoked-but-cache-live.
+ */
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import type { ApiKey } from "../../db/repositories";
+import { apiKeysRepository } from "../../db/repositories";
+import { cache } from "../cache/client";
+import { CacheKeys } from "../cache/keys";
+import { apiKeysService } from "./api-keys";
+
+const KEY_HASH = "a".repeat(64);
+const SHORT_HASH = KEY_HASH.substring(0, 16);
+const VALIDATION_KEY = CacheKeys.apiKey.validation(SHORT_HASH);
+
+function fakeKey(): ApiKey {
+  return {
+    id: "key-1",
+    key_hash: KEY_HASH,
+    organization_id: "org-1",
+    user_id: "user-1",
+    is_active: true,
+  } as unknown as ApiKey;
+}
+
+describe("apiKeysService.invalidateCache fails closed (#13417)", () => {
+  const spies: Array<{ mockRestore: () => void }> = [];
+
+  afterEach(() => {
+    for (const spy of spies.splice(0)) spy.mockRestore();
+  });
+
+  function track<T extends { mockRestore: () => void }>(spy: T): T {
+    spies.push(spy);
+    return spy;
+  }
+
+  test("both deletes confirmed -> resolves quietly", async () => {
+    const del = track(spyOn(cache, "delConfirmed").mockResolvedValue(true));
+    await expect(apiKeysService.invalidateCache(KEY_HASH)).resolves.toBeUndefined();
+    // clears both the validation entry and the inference auth-context entry
+    expect(del).toHaveBeenCalledWith(VALIDATION_KEY);
+    expect(del.mock.calls.length).toBe(2);
+  });
+
+  test("validation-cache delete unconfirmed -> throws (revoked key would keep authenticating)", async () => {
+    track(
+      spyOn(cache, "delConfirmed").mockImplementation(
+        // validation entry delete fails, inference one succeeds
+        async (key: string) => key !== VALIDATION_KEY,
+      ),
+    );
+    await expect(apiKeysService.invalidateCache(KEY_HASH)).rejects.toThrow(/not confirmed/i);
+  });
+
+  test("inference auth-context delete unconfirmed -> throws", async () => {
+    track(
+      spyOn(cache, "delConfirmed").mockImplementation(
+        // inference entry (not the validation key) fails
+        async (key: string) => key === VALIDATION_KEY,
+      ),
+    );
+    await expect(apiKeysService.invalidateCache(KEY_HASH)).rejects.toThrow(/not confirmed/i);
+  });
+
+  test("delete(): failed invalidation aborts BEFORE the DB row is removed", async () => {
+    track(spyOn(apiKeysRepository, "findById").mockResolvedValue(fakeKey()));
+    const repoDelete = track(spyOn(apiKeysRepository, "delete").mockResolvedValue(undefined));
+    track(spyOn(cache, "delConfirmed").mockResolvedValue(false));
+
+    await expect(apiKeysService.delete("key-1")).rejects.toThrow(/not confirmed/i);
+    // fail-closed ordering: the DB delete must NOT run once invalidation failed
+    expect(repoDelete).not.toHaveBeenCalled();
+  });
+
+  test("delete(): confirmed invalidation lets the DB delete proceed", async () => {
+    track(spyOn(apiKeysRepository, "findById").mockResolvedValue(fakeKey()));
+    const repoDelete = track(spyOn(apiKeysRepository, "delete").mockResolvedValue(undefined));
+    track(spyOn(cache, "delConfirmed").mockResolvedValue(true));
+
+    await expect(apiKeysService.delete("key-1")).resolves.toBeUndefined();
+    expect(repoDelete).toHaveBeenCalledWith("key-1");
+  });
+
+  test("invalidateInferenceContextForUser: unconfirmed fan-out throws (ban fails closed)", async () => {
+    track(
+      spyOn(apiKeysRepository, "listByUser").mockResolvedValue([
+        fakeKey(),
+        { ...fakeKey(), key_hash: "b".repeat(64) } as ApiKey,
+      ]),
+    );
+    // second key's IAC delete is unconfirmed
+    track(
+      spyOn(cache, "delConfirmed").mockImplementation(
+        async (key: string) => !key.includes("b".repeat(64)),
+      ),
+    );
+    await expect(apiKeysService.invalidateInferenceContextForUser("user-1")).rejects.toThrow(
+      /not confirmed/i,
+    );
+  });
+
+  test("invalidateInferenceContextForUser: all confirmed resolves", async () => {
+    track(spyOn(apiKeysRepository, "listByUser").mockResolvedValue([fakeKey()]));
+    track(spyOn(cache, "delConfirmed").mockResolvedValue(true));
+    await expect(
+      apiKeysService.invalidateInferenceContextForUser("user-1"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("revokeForAgent: unconfirmed invalidation does NOT abort (row already deleted, best-effort)", async () => {
+    // rows deleted FIRST -> credential already DB-revoked; a cache brownout must
+    // not abort agent reprovisioning (codex round-2 P2).
+    track(spyOn(apiKeysRepository, "deleteByName").mockResolvedValue([fakeKey()]));
+    track(spyOn(cache, "delConfirmed").mockResolvedValue(false));
+    await expect(apiKeysService.revokeForAgent("sandbox-1")).resolves.toBeUndefined();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/api-keys.ts
+++ b/packages/cloud/shared/src/lib/services/api-keys.ts
@@ -158,12 +158,18 @@ export class ApiKeysService {
   }
 
   /**
-   * Invalidate cache for a specific API key (call on update/delete).
+   * Invalidate cache for a specific API key (call on update/delete). Fails
+   * closed.
    *
    * Clears BOTH the validation cache (16-char-prefix key) AND the inference
    * hot-path auth-context entry (full-hash key, #9899). Every api-key mutation
    * site routes through here, so a revoked/updated key stops fast-pathing
    * inference immediately rather than waiting out the IAC TTL.
+   *
+   * @throws when either backend delete is not confirmed. A revoked key whose
+   *   cache entry was NOT removed keeps authenticating until its TTL lapses, so
+   *   the mutation path must surface an unconfirmed invalidation (error-policy:J1)
+   *   rather than silently discard `cache.del`'s failure (#13417).
    */
   async invalidateCache(keyHash: string): Promise<void> {
     const shortHash = keyHash.substring(0, 16);
@@ -171,10 +177,25 @@ export class ApiKeysService {
     // key would keep authenticating until each TTL expires. All revoke/update/
     // deactivate paths funnel through here: the per-key validation cache and the
     // #9899 inference hot-path auth-context entry (keyed by full hash).
-    await Promise.all([
-      cache.del(CacheKeys.apiKey.validation(shortHash)),
+    const [validationDeleted, inferenceDeleted] = await Promise.all([
+      cache.delConfirmed(CacheKeys.apiKey.validation(shortHash)),
       invalidateInferenceAuthContextByKeyHash(keyHash),
     ]);
+
+    if (!validationDeleted || !inferenceDeleted) {
+      const unconfirmed = [
+        validationDeleted ? null : "validation",
+        inferenceDeleted ? null : "inference-auth-context",
+      ].filter((entry): entry is string => entry !== null);
+      logger.error("[ApiKeys] API key cache invalidation not confirmed", {
+        shortHash,
+        unconfirmed,
+      });
+      throw new Error(
+        `API key cache invalidation not confirmed (${unconfirmed.join(", ")}); revoked key may still authenticate until TTL`,
+      );
+    }
+
     logger.debug("[ApiKeys] Invalidated API key + inference auth-context cache");
   }
 
@@ -305,9 +326,25 @@ export class ApiKeysService {
 
   async revokeForAgent(agentSandboxId: string): Promise<void> {
     const name = ApiKeysService.agentApiKeyName(agentSandboxId);
-    const keys = await apiKeysRepository.deleteByName(name);
-    for (const key of keys) {
-      await this.invalidateCache(key.key_hash);
+    // Unlike update/delete (which invalidate BEFORE the DB mutation and so can
+    // safely fail closed by throwing), this path deletes the rows FIRST — the
+    // credential is already DB-revoked. A cache-invalidation failure here must
+    // NOT abort agent (re)provisioning: the stale entry is TTL-bounded and the
+    // authoritative row is gone. So invalidation is best-effort — but the
+    // failure is surfaced observably (error-policy:J5), never swallowed silently.
+    for (const key of await apiKeysRepository.deleteByName(name)) {
+      try {
+        await this.invalidateCache(key.key_hash);
+      } catch (error) {
+        logger.error(
+          "[ApiKeys] revokeForAgent: cache invalidation not confirmed for a DB-revoked key; " +
+            "stale entry bounded by TTL, provisioning continues",
+          {
+            agentSandboxId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
     }
   }
 }

--- a/packages/cloud/shared/src/lib/services/inference-auth-cache.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-cache.ts
@@ -120,19 +120,52 @@ export async function writeInferenceAuthContext(ctx: InferenceAuthContext): Prom
  * mutation (revoke/update/delete/deactivate) so a revoked key stops fast-pathing
  * immediately rather than waiting out the TTL.
  */
-export async function invalidateInferenceAuthContextByKeyHash(keyHash: string): Promise<void> {
-  await cache.del(CacheKeys.inference.authContext(keyHash));
+/**
+ * Invalidate the inference auth-context entry for a single key hash.
+ *
+ * @returns `true` when the delete is confirmed, `false` when the backend
+ *   rejected it. Callers on a credential-revocation path (see
+ *   {@link ../api-keys}) must fail closed on `false` — a discarded failure here
+ *   let a revoked key keep fast-pathing inference until the IAC TTL lapsed
+ *   (#13417).
+ */
+export async function invalidateInferenceAuthContextByKeyHash(keyHash: string): Promise<boolean> {
+  return await cache.delConfirmed(CacheKeys.inference.authContext(keyHash));
 }
 
 /**
  * Fan-out invalidation for every supplied key hash (used at ban / deactivate,
- * where the caller resolves the user's key hashes from the DB). Best-effort.
+ * where the caller resolves the user's key hashes from the DB).
+ *
+ * FAILS CLOSED: every hash is attempted, but if ANY per-key delete is
+ * unconfirmed (backend rejected it or the cache is configured-but-unavailable)
+ * this THROWS naming the still-warm hashes. Ban/deactivate callers simply
+ * `await` this and do not inspect a return value, so a thrown error is what
+ * makes them fail closed instead of completing the ban while warm IAC entries
+ * keep authorizing until TTL. Callers that intentionally want best-effort
+ * (e.g. a lifecycle write that must not be blocked by a cache brownout) wrap
+ * this in their own try/catch — that stays a deliberate, visible choice rather
+ * than a silently-swallowed one. (#13417)
+ *
+ * @throws when any key's invalidation is not confirmed.
  */
 export async function invalidateInferenceAuthContextsByKeyHashes(
   keyHashes: readonly string[],
 ): Promise<void> {
   if (keyHashes.length === 0) return;
-  await Promise.all(keyHashes.map((h) => cache.del(CacheKeys.inference.authContext(h))));
+  const results = await Promise.all(
+    keyHashes.map((h) => cache.delConfirmed(CacheKeys.inference.authContext(h))),
+  );
+  const unconfirmed = keyHashes.filter((_h, i) => !results[i]);
+  if (unconfirmed.length > 0) {
+    logger.error("[InferenceAuthCache] Fan-out invalidation not confirmed", {
+      unconfirmedCount: unconfirmed.length,
+      total: keyHashes.length,
+    });
+    throw new Error(
+      `Inference auth-context invalidation not confirmed for ${unconfirmed.length}/${keyHashes.length} key(s); revoked credentials may keep authorizing until TTL`,
+    );
+  }
 }
 
 export async function readOrgBalanceHint(orgId: string): Promise<OrgBalanceHint | null> {

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -22,6 +22,7 @@ let deductResult: { success: true; newBalance: number } | { success: false; reas
 let freshBalanceUsd: number;
 let freshBalanceCalls = 0;
 const invalidateUserCalls: string[] = [];
+let invalidateUserShouldReject = false;
 
 mock.module("./credits", () => ({
   creditsService: {
@@ -48,6 +49,9 @@ mock.module("./api-keys", () => ({
   apiKeysService: {
     invalidateInferenceContextForUser: async (userId: string) => {
       invalidateUserCalls.push(userId);
+      if (invalidateUserShouldReject) {
+        throw new Error("iac eviction unavailable");
+      }
     },
   },
 }));
@@ -103,6 +107,7 @@ beforeEach(async () => {
   freshBalanceUsd = 50;
   freshBalanceCalls = 0;
   invalidateUserCalls.length = 0;
+  invalidateUserShouldReject = false;
   // Drop any pending entries left by a prior test.
   for (const key of await cache.scanByPrefix(CacheKeys.inference.pendingChargePrefix())) {
     await cache.del(key);
@@ -256,6 +261,19 @@ describe("createOptimisticDebitSettler", () => {
     await writePendingInferenceCharge(input, Date.now());
     await createOptimisticDebitSettler(input)(0.02);
     // Org-balance hint invalidated + user IAC invalidated → next request slow-paths.
+    expect(await readOrgBalanceHint(input.organizationId)).toBeNull();
+    expect(invalidateUserCalls).toContain(input.userId);
+  });
+
+  test("on FAILED debit contains a user IAC invalidation failure", async () => {
+    const input = chargeInput();
+    deductResult = { success: false, reason: "insufficient_balance" };
+    invalidateUserShouldReject = true;
+    await writeOrgBalanceHint(input.organizationId, 999, Date.now());
+    await writePendingInferenceCharge(input, Date.now());
+
+    await expect(createOptimisticDebitSettler(input)(0.02)).resolves.toBeNull();
+
     expect(await readOrgBalanceHint(input.organizationId)).toBeNull();
     expect(invalidateUserCalls).toContain(input.userId);
   });

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -236,7 +236,17 @@ async function debitInferenceCost(
       reason: result.reason,
     });
     await invalidateOrgBalanceHint(ctx.organizationId);
-    void apiKeysService.invalidateInferenceContextForUser(ctx.userId);
+    void apiKeysService.invalidateInferenceContextForUser(ctx.userId).catch((error) => {
+      // error-policy:J5 - the org balance hint is already invalidated above,
+      // so the next request leaves the optimistic path. User IAC eviction is
+      // a best-effort acceleration here; contain cache brownouts explicitly.
+      logger.error("[InferenceBilling] failed to invalidate user inference auth context", {
+        organizationId: ctx.organizationId,
+        userId: ctx.userId,
+        requestId: ctx.requestId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
   } catch (error) {
     logger.error("[InferenceBilling] inference debit threw", {
       organizationId: ctx.organizationId,


### PR DESCRIPTION
Slice of the `#13417` cloud-shared `src/lib` fallback sweep focused on the **cache-invalidation fail-open** on security-sensitive paths (credential revocation, logout, permission change). **Distinct, non-overlapping slice** from lalalune's #13459 (`#13417` json-parsing) — zero source-file overlap; evidence under a slice-specific filename.

## The bug (fail-open / fabricated success)

Cache invalidation depends on the stale cached copy actually being removed. Several layers silently reported a **failed** delete as a **successful** invalidation:

- `CacheClient.del`/`delPattern` swallowed backend failures and returned `void`; a partial pattern sweep (runaway-iteration guard) was indistinguishable from a complete one.
- `service-cache.invalidateCache`/`Pattern`/`Batch` wrapped the delete in a `try/catch` that swallowed every error and returned normally.
- `apiKeysService.invalidateCache` (every revoke/delete/deactivate) and `invalidateInferenceAuthContextByKeyHash` (#9899 inference hot-path) fired `cache.del` and **discarded** the result.

Net effect: if Redis `del` failed (backend down / circuit open) during a revoke, the revoke path completed "successfully" while the **revoked API key / logged-out session kept authenticating from cache until its TTL lapsed.**

## The fix (fail closed; additive & backward-compatible)

- `del`/`delPattern` keep their best-effort `Promise<void>` contract (all ~20 existing callers untouched). New `delConfirmed`/`delPatternConfirmed` return whether the delete was confirmed. They return `true` only when **no backend is configured**; a **configured-but-unavailable** backend (circuit open / connect-failed) returns `false` via new `backendConfigured` tracking (independent of the `enabled` health flag), so a Redis brownout no longer reports success.
- `service-cache` invalidation helpers now throw a typed `CacheInvalidationError` on unconfirmed invalidation; the batch helper reports the exact failed keys.
- `apiKeysService.invalidateCache` throws when either the validation-cache or inference-auth-context delete is unconfirmed. `update`/`delete`/`deactivate` invalidate **before** the DB mutation, so a failed invalidation aborts before the row is revoked (never DB-revoked-but-cache-live). `revokeForAgent` (deletes rows first) keeps invalidation best-effort but **observably logged**, so a brownout can't abort agent reprovisioning of an already-DB-revoked key.
- The ban/deactivate fan-out `invalidateInferenceAuthContextsByKeyHashes` throws on any unconfirmed delete so its await-only callers fail closed; the org-deactivate caller keeps its deliberate best-effort `try/catch`.

## Tests & verification

- **20 new tests** (`service-cache.invalidate.test.ts`, `del-confirmed.test.ts`, `api-keys.invalidation.test.ts`): confirmed/unconfirmed/thrown delete, incomplete/thrown pattern sweep, batch attempts-every-key + reports failed keys, configured-vs-unavailable + connect-failure fail-closed, api-key revoke fail-closed + DB-ordering, fan-out throw, `revokeForAgent` best-effort.
- **Existing cache suite 24/24 green** (no regression).
- `bunx @biomejs/biome check` clean; `bun run audit:error-policy-ratchet` → *no new fallback-slop*; `cloud/shared` typecheck **0 errors in touched files** (remaining are pre-existing transitive declaration noise per CLAUDE.md).
- **codex-reviewed:** 2 rounds of P1/P2 findings fixed (circuit-open fail-open, fan-out propagation, connect-failure config tracking, revokeForAgent abort), **final round clean — no introduced correctness issues.**

Evidence: `.github/issue-evidence/13417-cloud-shared-cache-invalidation-fallback.md`.

-- [sol-orch]