### PR TITLE
fix(#13420): fail closed on desktop runtime permission check errors

### DIFF
--- a/packages/ui/src/platform/desktop-permissions-client.test.ts
+++ b/packages/ui/src/platform/desktop-permissions-client.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit coverage for the desktop permission client's runtime-permission merge.
+ *
+ * Focus: the security-relevant `website-blocking` control must NOT keep an
+ * optimistic bridged snapshot when its authoritative runtime check fails.
+ * A failed check has to fail closed to an explicit unverified state so the
+ * permissions UI cannot advertise a blocking control as enforced when the
+ * runtime could not confirm it.
+ */
+import type { AllPermissionsState, PermissionState } from "@elizaos/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mergeRuntimePermissions } from "./desktop-permissions-client";
+
+const warnSpy = vi.fn();
+vi.mock("@elizaos/logger", () => ({
+  logger: {
+    warn: (...args: unknown[]) => warnSpy(...args),
+    error: () => {},
+    info: () => {},
+    debug: () => {},
+  },
+}));
+
+function permissionState(
+  overrides: Partial<PermissionState> = {},
+): PermissionState {
+  return {
+    id: "website-blocking",
+    status: "granted",
+    canRequest: false,
+    lastChecked: 0,
+    platform: "darwin",
+    ...overrides,
+  } as PermissionState;
+}
+
+function baseSnapshot(websiteBlocking: PermissionState): AllPermissionsState {
+  // Only the runtime permission id is exercised here; other ids are carried
+  // through untouched by mergeRuntimePermissions.
+  return {
+    "website-blocking": websiteBlocking,
+  } as unknown as AllPermissionsState;
+}
+
+afterEach(() => {
+  warnSpy.mockClear();
+});
+
+describe("mergeRuntimePermissions", () => {
+  it("uses the authoritative runtime check when it succeeds", async () => {
+    const snapshot = baseSnapshot(
+      permissionState({ status: "granted", canRequest: false }),
+    );
+    const getPermission = vi.fn().mockResolvedValue(
+      permissionState({
+        status: "denied",
+        canRequest: true,
+        lastChecked: 123,
+      }),
+    );
+
+    const merged = await mergeRuntimePermissions(
+      snapshot,
+      getPermission as never,
+    );
+
+    expect(merged["website-blocking"].status).toBe("denied");
+    expect(merged["website-blocking"].canRequest).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("fails closed to an unverified state when the runtime check throws (does not keep an optimistic granted snapshot)", async () => {
+    const snapshot = baseSnapshot(
+      // The bridged desktop-shell snapshot optimistically reports the blocking
+      // control as enforced.
+      permissionState({ status: "granted", canRequest: false }),
+    );
+    const getPermission = vi
+      .fn()
+      .mockRejectedValue(new Error("runtime route unreachable"));
+
+    const merged = await mergeRuntimePermissions(
+      snapshot,
+      getPermission as never,
+    );
+
+    const result = merged["website-blocking"];
+    // Must NOT continue advertising the unconfirmable control as granted.
+    expect(result.status).not.toBe("granted");
+    expect(result.status).toBe("not-determined");
+    expect(result.canRequest).toBe(true);
+    expect(typeof result.reason).toBe("string");
+    expect(result.reason).toMatch(/unverified|unavailable/i);
+    expect(result.id).toBe("website-blocking");
+  });
+
+  it("logs an observable warning when the runtime check throws", async () => {
+    const snapshot = baseSnapshot(permissionState({ status: "granted" }));
+    const getPermission = vi.fn().mockRejectedValue(new Error("boom"));
+
+    await mergeRuntimePermissions(snapshot, getPermission as never);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [context, message] = warnSpy.mock.calls[0];
+    expect(context).toMatchObject({ permissionId: "website-blocking" });
+    expect(String(message)).toContain("[desktop-permissions]");
+  });
+
+  it("preserves the resolved platform of the previous snapshot on failure", async () => {
+    const snapshot = baseSnapshot(
+      permissionState({ status: "granted", platform: "win32" }),
+    );
+    const getPermission = vi.fn().mockRejectedValue(new Error("nope"));
+
+    const merged = await mergeRuntimePermissions(
+      snapshot,
+      getPermission as never,
+    );
+
+    expect(merged["website-blocking"].platform).toBe("win32");
+    expect(merged["website-blocking"].status).toBe("not-determined");
+  });
+});

--- a/packages/ui/src/platform/desktop-permissions-client.ts
+++ b/packages/ui/src/platform/desktop-permissions-client.ts
@@ -2,6 +2,7 @@
  * Desktop permission client: queries/requests OS permissions through the
  * Electrobun bridge, conforming to the shared permissions-client shape.
  */
+import { logger } from "@elizaos/logger";
 import type { client as appClient } from "../api/client";
 import { invokeDesktopBridgeRequest } from "../bridge/electrobun-rpc";
 import type {
@@ -177,7 +178,33 @@ async function reconcileRendererPermissions(
   return changed ? nextPermissions : permissions;
 }
 
-async function mergeRuntimePermissions(
+/**
+ * Build the explicit "authoritative runtime check failed" state for a runtime
+ * permission (`website-blocking`). The desktop shell's bridged
+ * `permissionsGetAll` snapshot can carry an optimistic `granted` for a
+ * security-relevant blocking control; when the authoritative runtime check
+ * throws we must NOT keep advertising it as granted, or the permissions UI
+ * tells the user a blocking control is enforced when its true state is
+ * unverified. `not-determined` is the fail-closed representation: the UI
+ * renders it as "Request Approval" (unconfirmed/actionable), never as active.
+ */
+function unverifiedRuntimePermissionState(
+  id: SystemPermissionId,
+  previous: PermissionState | undefined,
+): PermissionState {
+  return {
+    ...(previous ?? {}),
+    id,
+    status: "not-determined",
+    canRequest: true,
+    reason:
+      "Runtime permission check is temporarily unavailable; status is unverified.",
+    lastChecked: Date.now(),
+    platform: previous?.platform ?? currentRendererPlatform(),
+  } as PermissionState;
+}
+
+export async function mergeRuntimePermissions(
   permissions: AllPermissionsState,
   getPermission: (id: SystemPermissionId) => Promise<PermissionState>,
 ): Promise<AllPermissionsState> {
@@ -187,9 +214,21 @@ async function mergeRuntimePermissions(
     RUNTIME_PERMISSION_IDS.map(async (id) => {
       try {
         nextPermissions[id] = await getPermission(id);
-      } catch {
-        // Leave the bridged snapshot untouched when the runtime-side permission
-        // route is temporarily unavailable.
+      } catch (error) {
+        // error-policy:J4 the authoritative runtime check for a
+        // security-relevant permission (website-blocking) failed. Do NOT
+        // silently retain the possibly-optimistic bridged snapshot, which
+        // fabricates a "granted"/enforced state the runtime can't confirm.
+        // Fail closed to an explicit unverified state and surface the error
+        // so the permissions UI shows "unconfirmed" instead of "protected".
+        logger.warn(
+          { error, permissionId: id },
+          "[desktop-permissions] runtime permission check failed; marking unverified",
+        );
+        nextPermissions[id] = unverifiedRuntimePermissionState(
+          id,
+          nextPermissions[id],
+        );
       }
     }),
   );


### PR DESCRIPTION
Closes a fallback-policy gap under #13420 (packages/ui non-visual helper sweep, successor to #12784) in the desktop permissions client.

## Problem

`mergeRuntimePermissions` in `packages/ui/src/platform/desktop-permissions-client.ts` overlays the **authoritative runtime check** for the runtime permission id `website-blocking` onto the desktop shell's bridged `permissionsGetAll` snapshot. `website-blocking` is a security-relevant OS content-blocking control (screen-time / focus enforcement via the native website-blocker plugin's `checkPermissions`).

When that authoritative check threw, the catch **silently left the bridged snapshot untouched**:

```ts
try {
  nextPermissions[id] = await getPermission(id);
} catch {
  // Leave the bridged snapshot untouched when the runtime-side permission
  // route is temporarily unavailable.
}
```

The bridged snapshot can carry an optimistic `granted`/enforced value. So a temporarily-unreachable runtime kept advertising the blocking control as **active**, with no log signal. That collapses a provider error into a fabricated healthy state: the permissions UI tells the user a blocking control is enforced when its true status is unverified — the exact three-state violation this sweep targets (transport/provider failure must render error/unverified, not healthy).

## Fix

Fail closed. On a runtime-check failure:
- mark the permission `not-determined` (the settings UI renders this as **"Request Approval" / unconfirmed**, never as active — verified in `components/settings/permission-types.ts`), with an explicit `reason` naming the unverified status,
- preserve the previously-resolved `platform`,
- surface the failure via `logger.warn({ error, permissionId }, ...)` (existing `@elizaos/logger` pattern used elsewhere in `bridge/`) instead of swallowing silently.

`not-determined` is the fail-closed representation given the shared `PermissionStatus` union (`granted | denied | not-determined | restricted | not-applicable`) — it surfaces "unverified/actionable" without fabricating protection.

Annotated `// error-policy:J4` per the repo convention.

## Tests

New `packages/ui/src/platform/desktop-permissions-client.test.ts` (previously untested module):
- successful authoritative check wins over the bridged snapshot;
- a **thrown** check fails closed to `not-determined` and does **not** keep an optimistic `granted`;
- the failure is logged observably (`[desktop-permissions]` warn with `permissionId`);
- the resolved `platform` from the prior snapshot is preserved on failure.

## Evidence

- new suite: **4/4 green**
- `src/platform/` + `components/settings/permission*` suites: **48/48 green** (no regressions)
- `tsgo --noEmit -p tsconfig.json`: **0 errors**
- `biome check` (touched files): **clean**
- `audit:error-policy-ratchet`: **no new fallback-slop in touched files**
- `git diff --check`: clean

Forbidden files untouched (no vite.config/index.html/client-base/bun.lock/dist). Only `desktop-permissions-client.ts` (+43/-4) and its new test.

Note: `codex review --uncommitted` did not converge to a verdict on this box (stuck in repo-wide exploration, killed after >8min); the change is small, contained, and validated by the deterministic gates above.

-- [sol-orch]