### PR TITLE
fix(#13408,#13441): resolve iOS simulator build blockers

### DIFF
--- a/.github/issue-evidence/13408-ios-local-sim-workspace-resolution.md
+++ b/.github/issue-evidence/13408-ios-local-sim-workspace-resolution.md
@@ -4,6 +4,8 @@
 
 Fixed the mobile Bun bundle resolver so scoped workspace packages used by the iOS local simulator build resolve from the current checkout instead of stale or incomplete `node_modules` workspace links.
 
+This also covers the related #13441 Turbo cycle blocker that appeared after the resolver failure was fixed. The cycle was broken by removing the unused `@elizaos/agent` dependency edge from `@elizaos/plugin-local-inference`, and the PR adds a direct workspace package-cycle self-test to the Turbo build-dependency audit.
+
 The original targeted bundle failure reproduced in this worktree:
 
 ```text
@@ -18,9 +20,13 @@ error: Could not resolve: "@elizaos/plugin-elizacloud". Maybe you need to "bun i
 | `bun run --cwd packages/agent build:ios-bun` before fix | Failed with unresolved `@elizaos/cloud-routing` and `@elizaos/plugin-elizacloud`; transcript: `/tmp/13408-agent-ios-bundle-before.log` |
 | `bun run --cwd packages/agent verify:mobile-workspace-resolution` | Passed: `workspace resolution verified for 7 packages`; transcript: `/tmp/13408-mobile-workspace-resolution-check.log` |
 | `bun run --cwd packages/agent build:ios-bun` after fix | Passed and emitted `agent-bundle.js`; transcript: `/tmp/13408-agent-ios-bundle-after.log` |
+| `node packages/scripts/audit-turbo-build-deps.self-test.mjs` | Passed: direct workspace package-cycle and phantom override fixture coverage |
+| `bun run --cwd plugins/plugin-local-inference typecheck` | Passed after removing the unused `@elizaos/agent` dependency edge |
 | `bun install --ignore-scripts` after replacing stale workspace symlinks | Passed; transcript: `/tmp/13408-bun-install-after-stale-symlinks.log` |
 | `bun run --cwd packages/app build:web` | Passed, including `verify-chunk-safety`; transcript: `/tmp/13408-app-build-web-after-local-install.log` |
 | `bun run --cwd packages/app build:ios:local:sim` | Passed with `** BUILD SUCCEEDED **`; transcript: `/tmp/13408-ios-local-sim-build-final.log` |
+
+The full `node packages/scripts/audit-turbo-build-deps.mjs` repo audit still fails on pre-existing phantom overrides outside this fix. The added self-test exercises the new direct-cycle guard without depending on those existing repository audit blockers.
 
 ## Produced simulator artifact
 

--- a/.github/issue-evidence/13408-ios-local-sim-workspace-resolution.md
+++ b/.github/issue-evidence/13408-ios-local-sim-workspace-resolution.md
@@ -1,0 +1,45 @@
+# Issue 13408: iOS local simulator mobile workspace resolution
+
+## Summary
+
+Fixed the mobile Bun bundle resolver so scoped workspace packages used by the iOS local simulator build resolve from the current checkout instead of stale or incomplete `node_modules` workspace links.
+
+The original targeted bundle failure reproduced in this worktree:
+
+```text
+error: Could not resolve: "@elizaos/cloud-routing". Maybe you need to "bun install"?
+error: Could not resolve: "@elizaos/plugin-elizacloud". Maybe you need to "bun install"?
+```
+
+## Commands and evidence
+
+| Check | Result |
+| --- | --- |
+| `bun run --cwd packages/agent build:ios-bun` before fix | Failed with unresolved `@elizaos/cloud-routing` and `@elizaos/plugin-elizacloud`; transcript: `/tmp/13408-agent-ios-bundle-before.log` |
+| `bun run --cwd packages/agent verify:mobile-workspace-resolution` | Passed: `workspace resolution verified for 7 packages`; transcript: `/tmp/13408-mobile-workspace-resolution-check.log` |
+| `bun run --cwd packages/agent build:ios-bun` after fix | Passed and emitted `agent-bundle.js`; transcript: `/tmp/13408-agent-ios-bundle-after.log` |
+| `bun install --ignore-scripts` after replacing stale workspace symlinks | Passed; transcript: `/tmp/13408-bun-install-after-stale-symlinks.log` |
+| `bun run --cwd packages/app build:web` | Passed, including `verify-chunk-safety`; transcript: `/tmp/13408-app-build-web-after-local-install.log` |
+| `bun run --cwd packages/app build:ios:local:sim` | Passed with `** BUILD SUCCEEDED **`; transcript: `/tmp/13408-ios-local-sim-build-final.log` |
+
+## Produced simulator artifact
+
+```text
+/Users/shawwalters/Library/Developer/Xcode/DerivedData/App-gqhkgffunpcdipeljskkszhyfnbi/Build/Products/Debug-iphonesimulator/App.app
+modified: 2026-07-04 15:10:40 EDT
+size: 202M
+```
+
+The app bundle contains the staged mobile agent payload:
+
+```text
+App.app/public/agent/agent-bundle.js
+App.app/public/agent/plugins-manifest.json
+App.app/public/agent/pglite.wasm
+App.app/public/agent/initdb.wasm
+App.app/public/agent/pglite.data
+```
+
+## UI evidence
+
+Not applicable for this issue. The change is build pipeline/package resolution behavior, and the required proof is a successful local iOS simulator build with the bundled agent payload present in the produced `.app`.

--- a/bun.lock
+++ b/bun.lock
@@ -3966,7 +3966,6 @@
       "name": "@elizaos/plugin-local-inference",
       "version": "2.0.3-beta.7",
       "dependencies": {
-        "@elizaos/agent": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-aosp-local-inference": "workspace:*",
         "@elizaos/plugin-capacitor-bridge": "workspace:*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -37,6 +37,7 @@
     "build:mobile": "bun run scripts/build-mobile-bundle.mjs",
     "build:ios-bun": "bun run scripts/build-mobile-bundle.mjs --target=ios",
     "build:ios-jsc": "bun run scripts/build-mobile-bundle.mjs --target=ios-jsc",
+    "verify:mobile-workspace-resolution": "bun run scripts/build-mobile-bundle.mjs --verify-workspace-resolution",
     "build:docker-dist": "node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/agent && node ../scripts/copy-package-assets.mjs packages/agent assets && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/agent",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "build:dist": "node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/agent && node ../scripts/copy-package-assets.mjs packages/agent assets && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/agent",

--- a/packages/agent/scripts/build-mobile-bundle.mjs
+++ b/packages/agent/scripts/build-mobile-bundle.mjs
@@ -99,10 +99,90 @@ const OUT_DIRS = {
 const outDir = path.join(agentRoot, OUT_DIRS[TARGET]);
 const stubsDir = path.join(here, "mobile-stubs");
 const entry = path.join(agentRoot, "src", "bin.ts");
+let mobileWorkspacePackageDirCache = null;
+
+function collectMobileWorkspacePackageDirs() {
+  if (mobileWorkspacePackageDirCache) return mobileWorkspacePackageDirCache;
+  mobileWorkspacePackageDirCache = new Map();
+  const roots = [
+    path.join(repoRoot, "packages"),
+    path.join(repoRoot, "plugins"),
+    path.join(repoRoot, "packages", "cloud"),
+    path.join(repoRoot, "packages", "cloud", "services"),
+    path.join(repoRoot, "packages", "native", "plugins"),
+    path.join(repoRoot, "packages", "os"),
+    path.join(repoRoot, "packages", "examples"),
+  ];
+  for (const root of roots) {
+    for (const entryName of readdirSyncSafe(root)) {
+      const packageDir = path.join(root, entryName);
+      const packageJsonPath = path.join(packageDir, "package.json");
+      if (!existsSync(packageJsonPath)) continue;
+      try {
+        const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+        if (typeof packageJson.name === "string") {
+          mobileWorkspacePackageDirCache.set(packageJson.name, packageDir);
+        }
+      } catch {
+        // Ignore malformed workspace metadata here; the normal bundler error
+        // still surfaces if that package is actually imported.
+      }
+    }
+  }
+  return mobileWorkspacePackageDirCache;
+}
+
+function resolveMobileWorkspacePackageDir(pkgName) {
+  const workspaceDir = collectMobileWorkspacePackageDirs().get(pkgName) ?? null;
+  const pkgPath = path.resolve(repoRoot, "node_modules", ...pkgName.split("/"));
+  if (!existsSync(pkgPath)) return workspaceDir;
+
+  const linkedDir = realpathSync(pkgPath);
+  if (!workspaceDir) return linkedDir;
+  // Fresh/light installs can leave @elizaos workspace symlinks pointing at an
+  // older temp checkout. The mobile bundle must use the current checkout's
+  // sources so local simulator builds do not depend on stale installed output.
+  if (
+    linkedDir === repoRoot ||
+    linkedDir.startsWith(`${repoRoot}${path.sep}`)
+  ) {
+    return linkedDir;
+  }
+  return workspaceDir;
+}
 
 console.log("[build-mobile] target:", TARGET);
 console.log("[build-mobile] agent root:", agentRoot);
 console.log("[build-mobile] output dir:", outDir);
+
+if (process.argv.includes("--verify-workspace-resolution")) {
+  const requiredPackages = [
+    "@elizaos/plugin-birdclaw",
+    "@elizaos/plugin-commands",
+    "@elizaos/plugin-vision",
+    "@elizaos/plugin-background-runner",
+    "@elizaos/plugin-wallet",
+    "@elizaos/cloud-routing",
+    "@elizaos/cloud-sdk",
+  ];
+  const missing = requiredPackages.filter(
+    (pkgName) => !resolveMobileWorkspacePackageDir(pkgName),
+  );
+  const walletDir = resolveMobileWorkspacePackageDir("@elizaos/plugin-wallet");
+  if (walletDir && !existsSync(path.join(walletDir, "src", "diagnostic.ts"))) {
+    missing.push("@elizaos/plugin-wallet/diagnostic");
+  }
+  if (missing.length > 0) {
+    console.error(
+      `[build-mobile] FATAL: mobile workspace resolution missing ${missing.join(", ")}`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `[build-mobile] workspace resolution verified for ${requiredPackages.length} packages`,
+  );
+  process.exit(0);
+}
 
 rmRecursive(outDir);
 await mkdir(outDir, { recursive: true });
@@ -1142,12 +1222,7 @@ const workspaceSrcFallbackPlugin = {
     const cache = new Map();
     const resolvePackageDir = (pkgName) => {
       if (cache.has(pkgName)) return cache.get(pkgName);
-      const pkgPath = path.resolve(
-        repoRoot,
-        "node_modules",
-        ...pkgName.split("/"),
-      );
-      const result = existsSync(pkgPath) ? pkgPath : null;
+      const result = resolveMobileWorkspacePackageDir(pkgName);
       cache.set(pkgName, result);
       return result;
     };

--- a/packages/scripts/audit-turbo-build-deps.mjs
+++ b/packages/scripts/audit-turbo-build-deps.mjs
@@ -154,6 +154,29 @@ const phantomTaskOverrides = [];
 const phantoms = [];
 const undeclared = [];
 const redundant = [];
+const directWorkspaceCycles = [];
+
+const workspaceDepsByPackage = new Map();
+for (const [name, dir] of WORKSPACE_DIRS.entries()) {
+  let pkg;
+  try {
+    pkg = readJson(path.join(dir, "package.json"));
+  } catch {
+    continue;
+  }
+  workspaceDepsByPackage.set(
+    name,
+    new Set([...declaredDeps(pkg)].filter((dep) => WORKSPACE_DIRS.has(dep))),
+  );
+}
+for (const [name, deps] of workspaceDepsByPackage.entries()) {
+  for (const dep of deps) {
+    if (name >= dep) continue;
+    if (workspaceDepsByPackage.get(dep)?.has(name)) {
+      directWorkspaceCycles.push(`${name} <-> ${dep}`);
+    }
+  }
+}
 
 for (const [taskName, def] of Object.entries(tasks)) {
   const separator = taskName.lastIndexOf("#");
@@ -252,6 +275,16 @@ if (phantoms.length) {
   );
   process.exit(1);
 }
+if (directWorkspaceCycles.length) {
+  console.error(
+    `[audit-turbo-build-deps] ${directWorkspaceCycles.length} direct workspace package cycle(s):\n`,
+  );
+  for (const cycle of directWorkspaceCycles) console.error(`  ✗ ${cycle}`);
+  console.error(
+    "\nA direct package.json cycle makes Turbo build-order inference unstable.\nMove one edge behind a runtime dynamic import or remove it if production source does not import it.",
+  );
+  process.exit(1);
+}
 if (phantomTaskOverrides.length) {
   console.error(
     `[audit-turbo-build-deps] ${phantomTaskOverrides.length} phantom pkg#task override(s):\n`,
@@ -264,3 +297,4 @@ if (phantomTaskOverrides.length) {
 }
 console.log("[audit-turbo-build-deps] ✓ no phantom #build dependency edges");
 console.log("[audit-turbo-build-deps] ✓ no phantom pkg#task overrides");
+console.log("[audit-turbo-build-deps] ✓ no direct workspace package cycles");

--- a/packages/scripts/audit-turbo-build-deps.self-test.mjs
+++ b/packages/scripts/audit-turbo-build-deps.self-test.mjs
@@ -28,6 +28,12 @@ try {
   writeJson(path.join(tempRoot, "packages/foo/package.json"), {
     name: "@fixture/foo",
     scripts: { build: "echo build" },
+    dependencies: { "@fixture/bar": "workspace:*" },
+  });
+  writeJson(path.join(tempRoot, "packages/bar/package.json"), {
+    name: "@fixture/bar",
+    scripts: { build: "echo build" },
+    dependencies: { "@fixture/foo": "workspace:*" },
   });
   writeJson(path.join(tempRoot, "turbo.json"), {
     tasks: {
@@ -44,6 +50,29 @@ try {
   });
   const failOutput = `${failResult.stdout}\n${failResult.stderr}`;
   if (failResult.status === 0) {
+    console.error("expected direct workspace cycle audit to fail");
+    process.exit(1);
+  }
+  if (!failOutput.includes("@fixture/bar <-> @fixture/foo")) {
+    console.error(
+      "missing expected audit output: @fixture/bar <-> @fixture/foo",
+    );
+    console.error(failOutput);
+    process.exit(1);
+  }
+
+  writeJson(path.join(tempRoot, "packages/bar/package.json"), {
+    name: "@fixture/bar",
+    scripts: { build: "echo build" },
+  });
+
+  const phantomResult = spawnSync(process.execPath, [scriptPath], {
+    cwd: tempRoot,
+    env: { ...process.env, AUDIT_TURBO_REPO_ROOT: tempRoot },
+    encoding: "utf8",
+  });
+  const phantomOutput = `${phantomResult.stdout}\n${phantomResult.stderr}`;
+  if (phantomResult.status === 0) {
     console.error("expected phantom override audit to fail");
     process.exit(1);
   }
@@ -51,9 +80,9 @@ try {
     '@fixture/foo#typecheck — owner package does not define script "typecheck"',
     "@fixture/missing#build — owner package is not a workspace member",
   ]) {
-    if (!failOutput.includes(expected)) {
+    if (!phantomOutput.includes(expected)) {
       console.error(`missing expected audit output: ${expected}`);
-      console.error(failOutput);
+      console.error(phantomOutput);
       process.exit(1);
     }
   }
@@ -61,6 +90,11 @@ try {
   writeJson(path.join(tempRoot, "packages/foo/package.json"), {
     name: "@fixture/foo",
     scripts: { build: "echo build", typecheck: "echo typecheck" },
+    dependencies: { "@fixture/bar": "workspace:*" },
+  });
+  writeJson(path.join(tempRoot, "packages/bar/package.json"), {
+    name: "@fixture/bar",
+    scripts: { build: "echo build" },
   });
   writeJson(path.join(tempRoot, "packages/missing/package.json"), {
     name: "@fixture/missing",

--- a/plugins/plugin-local-inference/package.json
+++ b/plugins/plugin-local-inference/package.json
@@ -133,7 +133,6 @@
 		"typecheck": "tsgo --noEmit -p tsconfig.json"
 	},
 	"dependencies": {
-		"@elizaos/agent": "workspace:*",
 		"@elizaos/core": "workspace:*",
 		"@elizaos/plugin-capacitor-bridge": "workspace:*",
 		"@elizaos/plugin-computeruse": "workspace:*",

--- a/turbo.json
+++ b/turbo.json
@@ -499,7 +499,7 @@
       "outputs": []
     },
     "@elizaos/plugin-local-inference#typecheck": {
-      "dependsOn": ["@elizaos/agent#build", "^build"],
+      "dependsOn": ["^build"],
       "outputs": []
     },
     "@elizaos/example-farcaster#build": {


### PR DESCRIPTION
## Summary

Fixes #13408.
Fixes #13441.

- Resolve mobile bundle workspace package fallbacks from the current checkout before trusting `node_modules` workspace links, so fresh/light iOS simulator builds do not follow stale temp-checkout symlinks.
- Add `packages/agent` resolver contract script: `verify:mobile-workspace-resolution`.
- Remove the unused `@elizaos/agent` dependency edge from `@elizaos/plugin-local-inference`, which otherwise creates a Turbo build cycle during `build:ios:local:sim`.
- Add direct workspace package-cycle coverage to `audit-turbo-build-deps.self-test.mjs`.
- Add durable evidence at `.github/issue-evidence/13408-ios-local-sim-workspace-resolution.md`.

## Verification

- `bun run --cwd packages/agent build:ios-bun` before fix reproduced unresolved `@elizaos/cloud-routing` / `@elizaos/plugin-elizacloud`: `/tmp/13408-agent-ios-bundle-before.log`
- `bun run --cwd packages/agent verify:mobile-workspace-resolution`
- `bun run --cwd packages/agent build:ios-bun`: `/tmp/13408-agent-ios-bundle-after.log`
- `node packages/scripts/audit-turbo-build-deps.self-test.mjs`
- `bun run --cwd plugins/plugin-local-inference typecheck`
- `bunx @biomejs/biome check packages/agent/scripts/build-mobile-bundle.mjs packages/agent/package.json plugins/plugin-local-inference/package.json .github/issue-evidence/13408-ios-local-sim-workspace-resolution.md`
- `git diff --check origin/develop...HEAD && git diff --check`
- `bun run --cwd packages/app build:web`: `/tmp/13408-app-build-web-after-local-install.log`
- `bun run --cwd packages/app build:ios:local:sim`: `/tmp/13408-ios-local-sim-build-final.log`

Final simulator product:

```text
/Users/shawwalters/Library/Developer/Xcode/DerivedData/App-gqhkgffunpcdipeljskkszhyfnbi/Build/Products/Debug-iphonesimulator/App.app
modified: 2026-07-04 15:10:40 EDT
size: 202M
```

The final `.app` contains `public/agent/agent-bundle.js`, `plugins-manifest.json`, and PGlite assets.

Note: the repo-wide `node packages/scripts/audit-turbo-build-deps.mjs` command still fails on existing phantom overrides outside this change. The added self-test covers the new direct-cycle guard independently of those existing audit blockers.
