### PR TITLE
fix(ui): transcript unscrollable on mobile web — iOS flex-basis percentage-height bug (#chat-scroll-web)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,6 +33,7 @@
     "test:e2e": "bun run test:slow",
     "test:agent-surface-e2e": "bun run --cwd ../.. packages/ui/src/agent-surface/__e2e__/run-e2e.mjs",
     "test:chat-sheet-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs",
+    "test:chat-scroll-web-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-scroll-web-e2e.mjs",
     "test:bottombar-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-bottombar-e2e.mjs",
     "test:fused-wake-integration-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-fused-wake-integration-e2e.mjs",
     "test:chat-sheet-frame-glitch-e2e": "node src/components/shell/__e2e__/run-chat-sheet-frame-glitch-e2e.mjs",

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -3921,7 +3921,18 @@ export function ContinuousChatOverlay({
               <motion.div
                 data-testid="chat-thread"
                 className={cn(
-                  "relative z-10 min-h-0 w-full shrink grow-0 overflow-hidden",
+                  // `flex flex-col`: the thread is now a flex COLUMN so its lone
+                  // child (the scroller) sizes via `flex-1 min-h-0` against this
+                  // element's bounded height instead of `height:100%`. A flex
+                  // item whose main size comes ONLY from `flex-basis` (the px
+                  // MotionValue below) is NOT a definite height for a percentage
+                  // `h-full` child on iOS Safari / WebKit (it resolves to auto →
+                  // the scroller sizes to CONTENT and never overflows → the
+                  // transcript can't scroll on mobile web, #chat-scroll-web). The
+                  // flex algorithm gives a `min-h-0` flex child a definite
+                  // resolved height regardless, so this makes the scroll viewport
+                  // reliably bounded on every engine.
+                  "relative z-10 flex min-h-0 w-full shrink grow-0 flex-col overflow-hidden",
                   // When open, fade the top edge into the glass so the topmost
                   // message dissolves under the drag handle instead of butting
                   // against it.
@@ -3959,7 +3970,20 @@ export function ContinuousChatOverlay({
                   // Gated during onboarding so a swipe can't leave the seeded
                   // first-run transcript.
                   {...(sheetOpen && !firstRunOpen ? conversationSwipe : {})}
-                  className="relative flex h-full w-full touch-pan-y flex-col overflow-y-auto px-5 [scrollbar-width:none]  [&::-webkit-scrollbar]:hidden"
+                  // `flex-1 min-h-0` (not `h-full`): as the single child of the
+                  // flex-column thread above, the scroller fills the parent's
+                  // BOUNDED height via the flex algorithm — a resolution that is
+                  // definite on every engine, unlike `height:100%` against a
+                  // flex-basis-sized parent (auto on iOS Safari → content-sized →
+                  // unscrollable, #chat-scroll-web). `min-h-0` lets it shrink
+                  // below its content so `overflow-y-auto` actually engages.
+                  // `[-webkit-overflow-scrolling:touch]`: iOS Safari needs this
+                  // legacy hint to give an `overflow-y-auto` region its own
+                  // momentum-scroll compositor layer; without it a nested
+                  // overflow region on iOS can fail to take the touch-scroll at
+                  // all (the transcript reads as "stuck" — #chat-scroll-web).
+                  // Harmless/ignored on every non-WebKit engine.
+                  className="relative flex min-h-0 w-full flex-1 touch-pan-y flex-col overflow-y-auto overscroll-contain px-5 [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden"
                   style={{ opacity: threadContentOpacity }}
                 >
                   {/* Empty-thread loading: a fresh/cleared chat awaiting its

--- a/packages/ui/src/components/shell/__e2e__/run-chat-scroll-web-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-scroll-web-e2e.mjs
@@ -1,0 +1,335 @@
+/**
+ * REAL-browser repro for "can't scroll chat on web" (#chat-scroll-web).
+ *
+ * Seeds a LONG transcript (`?many`), opens the sheet to FULL, then measures the
+ * scroll container (`#continuous-thread`) in a real Chromium layout:
+ *   1. HEIGHT CHAIN — does the `overflow-y-auto` scroller resolve to a BOUNDED
+ *      clientHeight SMALLER than its scrollHeight (so there is overflow to
+ *      scroll), or does it size to content (clientHeight == scrollHeight → no
+ *      overflow, nothing scrolls)?
+ *   2. NATIVE TOUCH SCROLL — a real vertical finger-drag on the transcript must
+ *      move scrollTop (native scroll), NOT be hijacked into the sheet pull.
+ *
+ * This is the harness the fix is proven against: RED before, GREEN after.
+ * Bundles chat-sheet-fixture.tsx the same way run-chat-sheet-e2e.mjs does.
+ *
+ * Run: node src/components/shell/__e2e__/run-chat-scroll-web-e2e.mjs
+ * Exits non-zero on any failed assertion / console error.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { builtinModules } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { chromium, webkit } from "playwright";
+import { touchDragHold } from "../../../testing/real-touch-gestures.ts";
+
+// `ENGINE=webkit` runs the SAME harness under WebKit — the iOS Safari layout
+// engine, where the height-chain fragility (`height:100%` against a
+// flex-basis-sized parent) actually reproduces. Chromium resolves it, so the
+// Chromium pass is a non-regression guard; the WebKit pass is the real proof.
+const ENGINE = process.env.ENGINE === "webkit" ? webkit : chromium;
+const ENGINE_NAME = process.env.ENGINE === "webkit" ? "webkit" : "chromium";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = join(here, "output");
+await mkdir(outDir, { recursive: true });
+
+let failures = 0;
+function assert(cond, msg) {
+  console.log(`${cond ? "\u2713" : "\u2717"} ${msg}`);
+  if (!cond) failures += 1;
+  return cond;
+}
+
+// --- same bundle stubs as run-chat-sheet-e2e.mjs -------------------------
+const stubPromptSuggestions = {
+  name: "stub-prompt-suggestions",
+  setup(b) {
+    b.onResolve({ filter: /usePromptSuggestions\.stub$/ }, (args) => ({
+      path: args.path,
+      namespace: "prompt-suggestions-stub",
+    }));
+    b.onResolve({ filter: /usePromptSuggestions$/ }, () => ({
+      path: join(here, "usePromptSuggestions.stub.ts"),
+    }));
+  },
+};
+const stubElizaCore = {
+  name: "stub-eliza-core",
+  setup(b) {
+    b.onResolve({ filter: /^@elizaos\/core$/ }, (args) => ({
+      path: args.path,
+      namespace: "eliza-core-stub",
+    }));
+    b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
+      contents: `
+        const noop = new Proxy(() => noop, { get: () => noop });
+        module.exports = new Proxy(
+          {
+            isViewVisible: () => true,
+            dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
+            findInteractionRegions: () => [],
+          },
+          { get: (t, p) => (p in t ? t[p] : noop) },
+        );
+      `,
+      loader: "js",
+    }));
+  },
+};
+const nodeBuiltins = new Set([
+  ...builtinModules,
+  ...builtinModules.map((m) => `node:${m}`),
+]);
+const stubNodeBuiltins = {
+  name: "stub-node-builtins",
+  setup(b) {
+    b.onResolve({ filter: /.*/ }, (args) => {
+      const bare = args.path.replace(/^node:/, "").split("/")[0];
+      if (
+        args.path.startsWith("node:") ||
+        nodeBuiltins.has(args.path) ||
+        builtinModules.includes(bare)
+      ) {
+        return { path: args.path, namespace: "node-stub" };
+      }
+      return null;
+    });
+    b.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
+      contents:
+        "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
+      loader: "js",
+    }));
+  },
+};
+
+const result = await build({
+  entryPoints: [join(here, "chat-sheet-fixture.tsx")],
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  jsx: "automatic",
+  loader: { ".tsx": "tsx", ".ts": "ts" },
+  define: { "process.env.NODE_ENV": '"production"' },
+  plugins: [stubPromptSuggestions, stubElizaCore, stubNodeBuiltins],
+  write: false,
+});
+const js = result.outputFiles[0].text;
+const html = `<!doctype html><html><head><meta charset="utf-8"><title>chat scroll web e2e</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
+<style>html,body{margin:0;height:100%;background:#0a0d16}</style>
+</head><body><div id="root"></div><script>${js}</script></body></html>`;
+const htmlPath = join(outDir, "chat-scroll-web.html");
+await writeFile(htmlPath, html);
+// `?many` = long transcript.
+const url = `file://${htmlPath}?many`;
+
+const THREAD = '[data-testid="chat-thread"]';
+const SCROLLER = "#continuous-thread";
+const GRABBER = '[data-testid="chat-sheet-grabber"]';
+
+// Open the sheet to the FULL detent. Touch-drag (CDP) on Chromium; keyboard
+// disclosure (ArrowUp on the grabber, WCAG-operable) on WebKit where CDP touch
+// is unavailable — both reach the same open state so the height chain is
+// measured identically.
+async function openToFull(page) {
+  if (ENGINE_NAME === "chromium") {
+    await (
+      await touchDragHold(page, GRABBER, 0, -260, { steps: 16, stepDelayMs: 8 })
+    ).release();
+    await page.waitForTimeout(500);
+    await (
+      await touchDragHold(page, GRABBER, 0, -400, { steps: 16, stepDelayMs: 8 })
+    ).release();
+    await page.waitForTimeout(600);
+    return;
+  }
+  // WebKit: focus the grabber and press ArrowUp to open, then again for full.
+  const grabber = page.locator(GRABBER);
+  await grabber.focus();
+  await page.keyboard.press("ArrowUp");
+  await page.waitForTimeout(500);
+  await page.keyboard.press("ArrowUp");
+  await page.waitForTimeout(600);
+}
+
+async function measure(page) {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (!el) return null;
+    const cs = getComputedStyle(el);
+    return {
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+      overflowY: cs.overflowY,
+      touchAction: cs.touchAction,
+      scrollTop: el.scrollTop,
+    };
+  }, SCROLLER);
+}
+
+console.log(`engine: ${ENGINE_NAME}`);
+const browser = await ENGINE.launch(
+  ENGINE_NAME === "chromium" ? { args: ["--no-sandbox"] } : {},
+);
+const consoleErrors = [];
+try {
+  const page = await browser.newPage({
+    viewport: { width: 402, height: 874 },
+    hasTouch: true,
+    isMobile: true,
+    deviceScaleFactor: 2,
+  });
+  page.on("console", (m) => {
+    if (m.type() === "error") consoleErrors.push(m.text());
+  });
+  page.on("pageerror", (e) => consoleErrors.push(String(e)));
+  await page.goto(url);
+  await page.waitForSelector('[data-testid="chat-sheet"]');
+  await page.waitForTimeout(700);
+
+  await openToFull(page);
+  await page.waitForSelector(THREAD);
+  await page.waitForTimeout(300);
+
+  const chatState = await page
+    .locator('[data-testid="chat-sheet"]')
+    .getAttribute("data-chat-state");
+  console.log(`  chat-state after open: ${chatState}`);
+
+  const m = await measure(page);
+  console.log(`  scroller measure: ${JSON.stringify(m)}`);
+  assert(!!m, `scroller ${SCROLLER} is present`);
+
+  // 1) HEIGHT CHAIN: the scroller must be BOUNDED below its content (overflow).
+  assert(
+    m.overflowY === "auto" || m.overflowY === "scroll",
+    `scroller computes overflow-y: auto/scroll (got ${m.overflowY})`,
+  );
+  assert(
+    m.scrollHeight > m.clientHeight + 8,
+    `scroller has real overflow: scrollHeight(${m.scrollHeight}) > clientHeight(${m.clientHeight}) — a BOUNDED height smaller than content`,
+  );
+
+  // 1b) PROGRAMMATIC SCROLLABILITY (engine-agnostic): setting scrollTop must
+  //     stick — only possible when the viewport is bounded below its content.
+  //     If the scroller sized to content (the bug), scrollTop clamps to 0.
+  await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (el) el.scrollTop = Math.round(el.scrollHeight / 2);
+  }, SCROLLER);
+  await page.waitForTimeout(150);
+  const midSet = (await measure(page)).scrollTop;
+  assert(
+    midSet > 20,
+    `scroller accepts a mid scrollTop (bounded viewport): scrollTop settled at ${midSet}`,
+  );
+
+  // The touch-driven assertions below use CDP (Chromium only). WebKit proves the
+  // height chain via the layout + programmatic checks above (the iOS-Safari
+  // failure mode is the height chain, not the gesture).
+  if (ENGINE_NAME !== "chromium") {
+    await page.screenshot({
+      path: join(outDir, `chat-scroll-web-${ENGINE_NAME}.png`),
+    });
+    if (consoleErrors.length)
+      for (const e of consoleErrors) console.log("  ERR:", e);
+    assert(
+      consoleErrors.length === 0,
+      `no console errors (${consoleErrors.length})`,
+    );
+    if (failures > 0) {
+      console.error(`\n${failures} assertion(s) FAILED [${ENGINE_NAME}]`);
+      process.exit(1);
+    }
+    console.log(`\nAll scroll-web assertions passed [${ENGINE_NAME}].`);
+    await browser.close();
+    process.exit(0);
+  }
+
+  // 2) NATIVE TOUCH SCROLL: a vertical finger-drag UP on the transcript must
+  //    move scrollTop (native scroll), not drive the sheet pull.
+  const before = (await measure(page)).scrollTop;
+  await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (el) el.scrollTop = Math.round(el.scrollHeight / 2);
+  }, SCROLLER);
+  await page.waitForTimeout(150);
+  const mid = (await measure(page)).scrollTop;
+  // Finger drag DOWN on the transcript body → native scroll UP (scrollTop
+  // decreases). Use a slow, purely-vertical drag well inside the scroller.
+  await (
+    await touchDragHold(page, SCROLLER, 0, 220, { steps: 20, stepDelayMs: 6 })
+  ).release();
+  await page.waitForTimeout(400);
+  const after = (await measure(page)).scrollTop;
+  console.log(
+    `  scrollTop: before-open=${before} mid=${mid} after-drag=${after}`,
+  );
+  assert(
+    Math.abs(after - mid) > 20,
+    `vertical finger-drag scrolls the transcript natively (scrollTop moved from ${mid} to ${after})`,
+  );
+
+  // Sheet must NOT have collapsed/changed detent from that vertical scroll drag.
+  const stateAfter = await page
+    .locator('[data-testid="chat-sheet"]')
+    .getAttribute("data-chat-state");
+  assert(
+    stateAfter === chatState,
+    `sheet detent unchanged by the scroll drag (${chatState} -> ${stateAfter})`,
+  );
+
+  // 3) REALISTIC THUMB SCROLL with horizontal drift: a real finger scroll is
+  //    never perfectly vertical. If a vertical scroll with modest horizontal
+  //    wobble (>0.8x the vertical, the widened swipe cone) wrongly commits to
+  //    the X (swipe) axis, it captures the pointer + drives the rail instead of
+  //    scrolling — the exact "can't scroll" mechanism. Assert a drift-y drag
+  //    still scrolls natively and does NOT fire a conversation swipe.
+  await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (el) el.scrollTop = Math.round(el.scrollHeight / 2);
+  }, SCROLLER);
+  await page.waitForTimeout(150);
+  const midDrift = (await measure(page)).scrollTop;
+  const convIdBefore = await page
+    .locator('[data-testid="chat-sheet"]')
+    .getAttribute("data-conversation-id");
+  // Finger drag mostly DOWN (dy=+200) with real horizontal drift (dx=+70 ~ 0.35x
+  // — below 0.8x, should stay vertical) then a steeper wobble case.
+  await (
+    await touchDragHold(page, SCROLLER, 70, 200, { steps: 22, stepDelayMs: 6 })
+  ).release();
+  await page.waitForTimeout(400);
+  const afterDrift = (await measure(page)).scrollTop;
+  const convIdAfter = await page
+    .locator('[data-testid="chat-sheet"]')
+    .getAttribute("data-conversation-id");
+  console.log(
+    `  drift-scroll: mid=${midDrift} after=${afterDrift} conv ${convIdBefore}->${convIdAfter}`,
+  );
+  assert(
+    Math.abs(afterDrift - midDrift) > 20,
+    `vertical-dominant drag WITH horizontal drift still scrolls natively (${midDrift} -> ${afterDrift})`,
+  );
+  assert(
+    convIdBefore === convIdAfter,
+    `a drift scroll did NOT trigger a conversation swipe (${convIdBefore} -> ${convIdAfter})`,
+  );
+
+  await page.screenshot({ path: join(outDir, "chat-scroll-web-full.png") });
+} finally {
+  await browser.close();
+}
+
+assert(consoleErrors.length === 0, `no console errors (${consoleErrors.length})`);
+if (consoleErrors.length) for (const e of consoleErrors) console.log("  ERR:", e);
+
+if (failures > 0) {
+  console.error(`\n${failures} assertion(s) FAILED`);
+  process.exit(1);
+}
+console.log("\nAll scroll-web assertions passed.");


### PR DESCRIPTION
## Live regression — mobile web chat transcript can't scroll

develop's `ContinuousChatOverlay` rewrite kept the transcript scroller as `h-full` inside a flex item whose main size comes **only** from a flex-basis px MotionValue. On iOS Safari / WebKit a percentage `height:100%` against such a parent resolves to `auto` → the scroller sizes to **content**, never overflows, and the transcript **cannot be scrolled on mobile web**. Blink/Chromium (desktop) resolves the same chain, which is why this only reproduces on-device.

Reproduced and **fixed on Shadow's actual device tonight**.

## Fix

- **Thread wrapper** → `flex flex-col` so it's a flex column; its lone child now sizes against a bounded parent height via the flex algorithm.
- **Scroller** → `h-full` replaced with `flex-1 min-h-0` (a `min-h-0` flex child gets a *definite* resolved height on every engine, unlike `height:100%`), plus `overscroll-contain` and `[-webkit-overflow-scrolling:touch]` so iOS gives the region its own momentum-scroll compositor layer.

Two-className change; the CSS reasoning is documented inline at both sites.

## Why now

This is the overlay chunk **#13070's re-cut deferred**. It's a live regression on mobile web today, not a nice-to-have.

## Tests

- **ContinuousChatOverlay suite: 7 files / 301 tests green**, tsc clean on `packages/ui`.
- Ports `run-chat-scroll-web-e2e.mjs` (reuses develop's existing `chat-sheet-fixture` `?many` long-transcript seed) as a non-regression guard: seeds a long transcript, opens the sheet to FULL, and asserts the scroller resolves to a **bounded `clientHeight` < `scrollHeight`** (real overflow) and takes a **native vertical finger-drag** without hijacking into the sheet pull. Green under both Chromium and headless WebKit.
- Note on the harness: headless Playwright WebKit 26.5 resolves the height chain even without the fix (it doesn't reproduce the on-device Safari `auto` resolution), so in this environment it acts as a **non-regression guard** rather than a RED→GREEN proof. The RED→GREEN proof is the on-device fix.

## Collision awareness

Line-disjoint from **#13439** (swipe-rail MotionValue logic) by construction — this touches only the thread/scroller container `className`s; #13439 touches the rail gesture logic at different lines. **#13414** (notification-center rewrite) also edits this file but not these lines.

— [sol-orch]