### PR TITLE
fix: built-apps registry has no delete leg — add deleteBuiltApp + DELETE route

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/built-apps-registry.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/built-apps-registry.test.ts
@@ -10,10 +10,13 @@
  * Covers:
  *  1. pure derivation for both deploy targets (custom static host URL-shape
  *     match; eliza-cloud app-build gate + code-host/loopback exclusion);
- *  2. registry round-trip + redeploy dedupe on the runtime cache;
+ *  2. registry round-trip + redeploy dedupe + delete on the runtime cache;
  *  3. the REAL router path: handleEvent("task_complete") with a live URL
  *     served by a local HTTP server → verification probes it → the registry
- *     record lands in the runtime cache with that URL.
+ *     record lands in the runtime cache with that URL;
+ *  4. the HTTP management surface: register → DELETE → list over a real HTTP
+ *     server dispatching handleOrchestratorRoutes (404 when absent, 200
+ *     {deleted:true} on success, list reflects immediately).
  */
 
 import { createServer, type Server } from "node:http";
@@ -22,9 +25,12 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeGrillingRuntime } from "../../test/scenarios/_helpers/orchestrator-grilling-harness.ts";
 import { makeSpawnCapturingAcp } from "../../test/scenarios/_helpers/reflexion-scenario.ts";
+import { handleOrchestratorRoutes } from "../api/orchestrator-routes.ts";
+import type { RouteContext } from "../api/route-utils.ts";
 import {
   BUILT_APPS_CACHE_KEY,
   type BuiltAppRecord,
+  deleteBuiltApp,
   deriveBuiltApp,
   listBuiltApps,
   registerBuiltApp,
@@ -159,10 +165,25 @@ describe("registry round-trip", () => {
     expect(apps[0]).toEqual(redeploy);
   });
 
+  it("deletes one record by target+slug and reports absence honestly", async () => {
+    const { runtime } = cacheRuntime();
+    await registerBuiltApp(runtime, record());
+    await registerBuiltApp(runtime, record({ slug: "todo", name: "Todo" }));
+
+    expect(await deleteBuiltApp(runtime, "custom", "snake-game")).toBe(true);
+    expect(await listBuiltApps(runtime)).toMatchObject([{ slug: "todo" }]);
+
+    // Already gone / never existed / wrong target: false, list untouched.
+    expect(await deleteBuiltApp(runtime, "custom", "snake-game")).toBe(false);
+    expect(await deleteBuiltApp(runtime, "eliza-cloud", "todo")).toBe(false);
+    expect(await listBuiltApps(runtime)).toHaveLength(1);
+  });
+
   it("degrades gracefully when the runtime has no cache", async () => {
     const bare = {} as IAgentRuntime;
     expect(await registerBuiltApp(bare, record())).toBe(false);
     expect(await listBuiltApps(bare)).toEqual([]);
+    expect(await deleteBuiltApp(bare, "custom", "snake-game")).toBe(false);
     expect(
       await registerBuiltAppsForCompletion(bare, { id: "s" }, [
         "https://example.org/apps/x/",
@@ -365,5 +386,85 @@ describe("task_complete → registry record (real router path)", () => {
       label: "build snake game",
     });
     expect(apps[0].registeredAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe("HTTP management surface: register → DELETE → list round-trip", () => {
+  // Drives the real route dispatcher over a real HTTP server. The runtime has
+  // NO orchestrator task service registered, which proves the built-apps legs
+  // dispatch before the service gate — were they behind it, every request here
+  // would 503 instead.
+  let server: Server;
+  let baseUrl: string;
+  let runtime: IAgentRuntime;
+
+  beforeEach(async () => {
+    const cache = new Map<string, unknown>();
+    runtime = {
+      getCache: async (key: string) => cache.get(key),
+      setCache: async (key: string, value: unknown) => {
+        cache.set(key, value);
+        return true;
+      },
+      getService: () => undefined,
+      hasService: () => false,
+    } as unknown as IAgentRuntime;
+    const ctx: RouteContext = {
+      runtime,
+      acpService: null,
+      workspaceService: null,
+    };
+    server = createServer((req, res) => {
+      const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+      handleOrchestratorRoutes(req, res, pathname, ctx).then((handled) => {
+        if (!handled && !res.headersSent) {
+          res.writeHead(404).end();
+        }
+      });
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  it("DELETE /built-apps/:target/:slug removes the app; the list reflects immediately", async () => {
+    await registerBuiltApp(runtime, record());
+    await registerBuiltApp(runtime, record({ slug: "todo", name: "Todo" }));
+
+    const listed = await fetch(`${baseUrl}/api/orchestrator/built-apps`);
+    expect(listed.status).toBe(200);
+    expect((await listed.json()).apps).toHaveLength(2);
+
+    const deleted = await fetch(
+      `${baseUrl}/api/orchestrator/built-apps/custom/snake-game`,
+      { method: "DELETE" },
+    );
+    expect(deleted.status).toBe(200);
+    expect(await deleted.json()).toEqual({ deleted: true });
+
+    const after = await fetch(`${baseUrl}/api/orchestrator/built-apps`);
+    expect((await after.json()).apps).toMatchObject([{ slug: "todo" }]);
+
+    // Deleting the same app again: honest 404, not a fake success.
+    const repeat = await fetch(
+      `${baseUrl}/api/orchestrator/built-apps/custom/snake-game`,
+      { method: "DELETE" },
+    );
+    expect(repeat.status).toBe(404);
+  });
+
+  it("rejects a malformed delete path with 400", async () => {
+    const missingSlug = await fetch(
+      `${baseUrl}/api/orchestrator/built-apps/custom`,
+      { method: "DELETE" },
+    );
+    expect(missingSlug.status).toBe(400);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -11,7 +11,10 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { listBuiltApps } from "../services/built-apps-registry.js";
+import {
+  deleteBuiltApp,
+  listBuiltApps,
+} from "../services/built-apps-registry.js";
 import {
   LLM_GOAL_VERIFIER_NAME,
   verifyGoalCompletion,
@@ -187,6 +190,30 @@ async function dispatchOrchestratorRoutes(
   // is dispatched before the service gate.
   if (method === "GET" && pathname === `${PREFIX}/built-apps`) {
     sendJson(res, { apps: await listBuiltApps(ctx.runtime) });
+    return true;
+  }
+
+  // DELETE /api/orchestrator/built-apps/:target/:slug — remove one record by
+  // its registry key. Without this leg a registered app could only leave the
+  // registry via the MAX_BUILT_APPS cap or a same-slug redeploy overwrite.
+  // Same service-independence as the GET above, so it too dispatches before
+  // the service gate. 404 when the target+slug pair is not registered.
+  if (method === "DELETE" && pathname.startsWith(`${PREFIX}/built-apps/`)) {
+    const segments = pathname
+      .slice(`${PREFIX}/built-apps/`.length)
+      .split("/")
+      .filter((s) => s.length > 0);
+    if (segments.length !== 2) {
+      sendError(res, "Expected /built-apps/:target/:slug", 400);
+      return true;
+    }
+    const target = decodeURIComponent(segments[0] ?? "");
+    const slug = decodeURIComponent(segments[1] ?? "");
+    if (!(await deleteBuiltApp(ctx.runtime, target, slug))) {
+      sendError(res, "Built app not found", 404);
+      return true;
+    }
+    sendJson(res, { deleted: true });
     return true;
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/built-apps-registry.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/built-apps-registry.ts
@@ -6,8 +6,9 @@
  * artifacts, so the app never appears in any management surface — nothing can
  * list, revisit, or delete what the agent shipped. This module records one
  * {@link BuiltAppRecord} per successful app-deploy completion in the runtime
- * cache (DB-backed, survives restarts) and exposes a read API for management
- * consumers (`GET /api/orchestrator/built-apps`).
+ * cache (DB-backed, survives restarts) and exposes a read + delete API for
+ * management consumers (`GET /api/orchestrator/built-apps`,
+ * `DELETE /api/orchestrator/built-apps/:target/:slug`).
  *
  * Derivation is structural, matching the two deploy targets the spawn-time
  * contract injects (see app-deploy-guidance):
@@ -170,6 +171,27 @@ export async function registerBuiltApp(
     BUILT_APPS_CACHE_KEY,
     [record, ...rest].slice(0, MAX_BUILT_APPS),
   );
+  return true;
+}
+
+/**
+ * Remove one record by its registry key (target+slug). Returns false when no
+ * such record exists — or the runtime has no cache, in which case the registry
+ * is structurally empty — so the route can answer 404 without a separate
+ * existence check.
+ */
+export async function deleteBuiltApp(
+  runtime: unknown,
+  target: string,
+  slug: string,
+): Promise<boolean> {
+  if (!hasCache(runtime)) return false;
+  const existing = await listBuiltApps(runtime);
+  const rest = existing.filter(
+    (entry) => !(entry.target === target && entry.slug === slug),
+  );
+  if (rest.length === existing.length) return false;
+  await runtime.setCache(BUILT_APPS_CACHE_KEY, rest);
   return true;
 }
 


### PR DESCRIPTION
## Problem

QA on the app-management surface ([core-brain] lane of #13406): the built-apps registry (#12036) records every app the agent builds and deploys from chat, and the management surface can list them — but nothing can ever remove one. `built-apps-registry.ts` exports only `listBuiltApps` / `registerBuiltApp` / `registerBuiltAppsForCompletion`, and the only route is `GET /api/orchestrator/built-apps`. A registered app can only leave the registry via the `MAX_BUILT_APPS=200` cap or a same-slug redeploy overwrite. The DELETE leg of the management E2E does not exist.

## Fix (structural, minimal)

- `deleteBuiltApp(runtime, target, slug)` in `built-apps-registry.ts` — filter on the registry key (target+slug) + `setCache`; returns `false` when no record matched (or the runtime has no cache), so the route can answer 404 without a separate existence check. Write only happens when something was removed.
- `DELETE /api/orchestrator/built-apps/:target/:slug` in `orchestrator-routes.ts`, next to the GET and before the service gate (same service-independence — the registry is cache-backed, not task-service-backed). Mirrors the memory-delete-path standard: **404 when absent, 200 `{deleted:true}` on success, list reflects immediately.** Malformed path (missing slug) → 400.

## Tests (fail on the bug)

- registry unit round-trip: register two → delete one → `true` + list reflects; repeat delete / wrong target → `false`, list untouched; no-cache runtime → `false`.
- HTTP round-trip over a **real** `node:http` server driving `handleOrchestratorRoutes`: `GET` list (2) → `DELETE /built-apps/custom/snake-game` → `200 {deleted:true}` → list reflects (1) → repeat `DELETE` → 404; malformed path → 400. The runtime has no orchestrator task service registered, which also proves the built-apps legs dispatch before the service gate.

Verified fails-on-bug: with `orchestrator-routes.ts` reverted to develop, the round-trip test fails with `expected 503 to be 200` (DELETE falls through to the service gate).

## Verification

- `vitest run src/__tests__/built-apps-registry.test.ts` → **12 passed** (8 pre-existing + 4 new)
- plugin `typecheck` (tsgo) → clean
- biome check on the 3 touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)