### PR TITLE
fix(#13419): fail closed on failed cloud-connector status probes

### DIFF
--- a/.github/issue-evidence/13419-cloud-ui-three-state.md
+++ b/.github/issue-evidence/13419-cloud-ui-three-state.md
@@ -1,0 +1,96 @@
+# #13419 evidence — cloud-connector status three-state slice
+
+Successor slice to #12784 for `packages/ui/src/cloud/**`. Non-visual scope: the
+shared cloud-connector status **probe hook** + the shared `ConnectionCard`
+render contract that every token-credential connector (Twilio / WhatsApp /
+Blooio / Telegram) renders through. Focused unit/component tests per the
+accepted #13227 / #13434 / #13444 / #13463 precedent (no screenshot-gated .tsx
+page surfaces changed in a way that alters a visual page's happy path).
+
+## Path / pattern / verdict
+
+| path | pattern | verdict |
+| --- | --- | --- |
+| `cloud/connectors/use-connection-status.ts` | failed status probe collapsed into `status=null` + a transient toast; no durable error signal | **FIX** — added `isError`/`errorMessage` three-state; `// error-policy:J4` on the probe-failure branch |
+| `cloud-ui/components/connection-card.tsx` | only `loading` / `not-configured` / `connected` / `disconnected` states — no error surface | **FIX** — added `"error"` status + `role="alert"` block + optional `onRetry` |
+| `cloud/connectors/twilio-connection.tsx` | `status={status?.connected ? "connected" : "disconnected"}` rendered the setup form on a FAILED probe | **FIX** — prefer `"error"`, wire `errorMessage`/`onRetry` |
+| `cloud/connectors/whatsapp-connection.tsx` | same | **FIX** — same |
+| `cloud/connectors/blooio-connection.tsx` | same | **FIX** — same |
+| `cloud/connectors/telegram-connection.tsx` | same | **FIX** — same |
+| `cloud/lib/api-client.ts` | transport/parse layer | audited-clean — already throws structured `ApiError`, 401→refresh nudge, `readPayload` fails closed |
+| `cloud/admin/data/use-admin-gate.ts` | admin authorization gate | audited-clean — `isAdmin ?? false` fail-closed + exposes `isError` |
+| `cloud/lib/use-session-auth.ts`, `jwt.ts` | auth resolution | audited-clean — `null` = signed-out is the correct fail-closed designed state |
+
+## The fabrication (root cause)
+
+`useConnectionStatus` (shared by all four token-credential connectors) caught a
+failed status fetch, showed a transient `toast.error`, and left `status` at
+`null` with `isLoading=false`. Consumers render
+`status={status?.connected ? "connected" : "disconnected"}`, so a
+transport / 5xx / parse / auth failure of `GET /api/v1/<connector>/status`
+rendered the **"disconnected" setup form** — byte-identical to a genuinely
+unconfigured connector, even though the backend was unreachable. The only signal
+was a toast that vanishes. Classic #12784 three-state collapse: `error` folded
+into `designed-empty`.
+
+## The fix
+
+- **Hook**: `isError: boolean` + `errorMessage: string | null`. A failed probe
+  sets them (`// error-policy:J4`, toast retained for immediacy); a successful
+  probe clears them so the surface leaves the error state. A healthy
+  `connected:false` stays a real status (NOT an error) — the setup form still
+  shows for a genuinely-disconnected connector.
+- **ConnectionCard**: new `"error"` status renders a distinguishable
+  `role="alert"` block (`errorMessage` + optional `Retry` button via `onRetry`),
+  never the setup form.
+- **Consumers**: render `"error"` when `isError`, pass the connector-specific
+  fetch-failed i18n string, and wire `onRetry` → `refetch`. Reused existing
+  `cloud.<connector>.statusFetchFailed` i18n keys → zero locale churn.
+
+## Tests (focused, green)
+
+```
+packages/ui $ bunx vitest run \
+  src/cloud/connectors/use-connection-status.test.ts \
+  src/cloud-ui/components/connection-card.error.test.tsx
+
+ ✓ src/cloud/connectors/use-connection-status.test.ts (4 tests)
+ ✓ src/cloud-ui/components/connection-card.error.test.tsx (3 tests)
+
+ Test Files  2 passed (2)
+      Tests  7 passed (7)
+```
+
+- `use-connection-status.test.ts`: success → readable status, no error; failure →
+  `isError`/`errorMessage`/toast (regression guard: a failed probe never reads as
+  a healthy "not connected"); non-ApiError falls back to the default message;
+  successful retry clears the error and a `connected:false` result is treated as a
+  real status.
+- `connection-card.error.test.tsx`: `status="error"` renders the alert and NOT
+  the setup/connected content; `status="disconnected"` still renders the setup
+  form with no alert; `onRetry` fires on the retry button.
+
+## Gates
+
+- `tsgo --noEmit -p packages/ui/tsconfig.json` → **0 errors** (whole package clean).
+- `bunx @biomejs/biome check <8 touched files>` → clean.
+- `bun run audit:error-policy-ratchet` → `no new fallback-slop in touched files`.
+- `git diff --check` → clean; only the 8 intended files staged, no forbidden
+  files (vite.config / index.html / client-base.ts / bun.lock / dist).
+
+## N/A rows
+
+- Model trajectories / audio — N/A (no changed cloud view invokes those flows).
+- before/after page screenshots — the changed surface is the shared status
+  **hook + card contract**, verified at the component/state level; the four
+  connector pages' happy paths (loading / connected / disconnected) are
+  unchanged, only the previously-invisible error path is now rendered.
+
+## Scope note
+
+`packages/ui/src/cloud/**` is large (per the issue inventory ~100+ files across
+instances / applications / billing / organization / …). This slice takes the
+shared connector-status contract — the highest-leverage single fabrication in
+the connectors area. Issue stays open for the remaining cloud UI surfaces.
+
+— [sol-orch]

--- a/packages/ui/src/cloud-ui/components/connection-card.error.test.tsx
+++ b/packages/ui/src/cloud-ui/components/connection-card.error.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+/**
+ * ConnectionCard three-state error surface (#12784/#13419).
+ *
+ * A failed connector status probe now renders `status="error"` — a
+ * distinguishable state with an alert + retry — instead of collapsing into the
+ * "disconnected" setup form. These tests pin that the error branch renders its
+ * own content (not the setup form), and that the retry affordance is wired.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ConnectionCard } from "./connection-card";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ConnectionCard — error state (#12784/#13419)", () => {
+  it("renders a distinguishable alert (not the setup form) when status is error", () => {
+    render(
+      <ConnectionCard
+        name="Twilio"
+        icon={<span>icon</span>}
+        description="desc"
+        status="error"
+        errorMessage="We couldn't load Twilio status."
+        setupContent={<div>SETUP FORM</div>}
+        connectedContent={<div>CONNECTED PANEL</div>}
+      />,
+    );
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "We couldn't load Twilio status.",
+    );
+    // The regression this guards: an errored probe must NOT show the setup form
+    // (which would read as a healthy "not connected" connector).
+    expect(screen.queryByText("SETUP FORM")).toBeNull();
+    expect(screen.queryByText("CONNECTED PANEL")).toBeNull();
+  });
+
+  it("still renders the setup form for a genuine disconnected status", () => {
+    render(
+      <ConnectionCard
+        name="Twilio"
+        icon={<span>icon</span>}
+        description="desc"
+        status="disconnected"
+        setupContent={<div>SETUP FORM</div>}
+      />,
+    );
+
+    expect(screen.getByText("SETUP FORM")).not.toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("invokes onRetry when the retry button is pressed", async () => {
+    const onRetry = vi.fn();
+    render(
+      <ConnectionCard
+        name="Twilio"
+        icon={<span>icon</span>}
+        description="desc"
+        status="error"
+        errorMessage="boom"
+        onRetry={onRetry}
+        retryLabel="Try again"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/cloud-ui/components/connection-card.tsx
+++ b/packages/ui/src/cloud-ui/components/connection-card.tsx
@@ -4,7 +4,14 @@
  */
 "use client";
 
-import { CheckCircle, ChevronDown, Copy, Loader2, XCircle } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle,
+  ChevronDown,
+  Copy,
+  Loader2,
+  XCircle,
+} from "lucide-react";
 import type * as React from "react";
 import {
   AlertDialog,
@@ -31,7 +38,11 @@ type ConnectionCardStatus =
   | "loading"
   | "not-configured"
   | "connected"
-  | "disconnected";
+  | "disconnected"
+  // The status probe FAILED (transport / 5xx / parse / auth). Distinct from
+  // "disconnected" (a healthy "not connected yet") so a broken/unreachable
+  // backend never renders as the setup form (#12784/#13419 three-state).
+  | "error";
 
 interface ConnectionCardProps {
   /** Integration name (e.g. "Discord Bot") */
@@ -50,6 +61,12 @@ interface ConnectionCardProps {
   setupContent?: React.ReactNode;
   /** Content shown when not configured */
   notConfiguredMessage?: string;
+  /** Message shown when the status probe failed (status === "error"). */
+  errorMessage?: string;
+  /** Optional retry affordance rendered in the error state. */
+  onRetry?: () => void;
+  /** Label for the retry button in the error state. */
+  retryLabel?: string;
   /** Status badge shown in the header when connected */
   statusBadge?: React.ReactNode;
   /** Additional CSS classes */
@@ -348,6 +365,9 @@ function ConnectionCard({
   connectedContent,
   setupContent,
   notConfiguredMessage = "This integration is not configured. Please contact your administrator.",
+  errorMessage = "We couldn't load this connection's status. Please try again.",
+  onRetry,
+  retryLabel = "Retry",
   statusBadge,
   className,
 }: ConnectionCardProps) {
@@ -374,7 +394,9 @@ function ConnectionCard({
             <p className="text-sm text-muted-foreground mt-1.5">
               {status === "not-configured"
                 ? `${name} integration is not configured`
-                : description}
+                : status === "error"
+                  ? `Couldn't load ${name} status`
+                  : description}
             </p>
           </div>
           {status === "connected" && statusBadge}
@@ -388,6 +410,24 @@ function ConnectionCard({
             <p className="text-sm text-muted-foreground">
               {notConfiguredMessage}
             </p>
+          </div>
+        )}
+        {status === "error" && (
+          <div
+            role="alert"
+            className="flex flex-col gap-3 p-4 bg-destructive/10 border border-destructive/30 rounded-sm"
+          >
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-destructive" />
+              <p className="text-sm text-destructive">{errorMessage}</p>
+            </div>
+            {onRetry && (
+              <div>
+                <Button variant="outline" size="sm" onClick={onRetry}>
+                  {retryLabel}
+                </Button>
+              </div>
+            )}
           </div>
         )}
         {status === "connected" && connectedContent}

--- a/packages/ui/src/cloud/connectors/blooio-connection.tsx
+++ b/packages/ui/src/cloud/connectors/blooio-connection.tsx
@@ -54,6 +54,8 @@ export function BlooioConnection() {
   const {
     status,
     isLoading,
+    isError: isStatusError,
+    errorMessage: statusErrorMessage,
     refetch: fetchStatus,
   } = useConnectionStatus<BlooioStatus>(
     "/api/v1/blooio/status",
@@ -232,7 +234,20 @@ export function BlooioConnection() {
       description={t("cloud.blooio.cardDescription", {
         defaultValue: "Connect iMessage for AI-powered text conversations",
       })}
-      status={status?.connected ? "connected" : "disconnected"}
+      status={
+        isStatusError
+          ? "error"
+          : status?.connected
+            ? "connected"
+            : "disconnected"
+      }
+      errorMessage={
+        statusErrorMessage ??
+        t("cloud.blooio.statusFetchFailed", {
+          defaultValue: "Failed to fetch Blooio status",
+        })
+      }
+      onRetry={() => void fetchStatus()}
       statusBadge={<ConnectionConnectedBadge />}
       connectedContent={
         <div className="space-y-4">

--- a/packages/ui/src/cloud/connectors/telegram-connection.tsx
+++ b/packages/ui/src/cloud/connectors/telegram-connection.tsx
@@ -58,6 +58,8 @@ export function TelegramConnection() {
   const {
     status,
     isLoading,
+    isError: isStatusError,
+    errorMessage: statusErrorMessage,
     refetch: fetchStatus,
   } = useConnectionStatus<TelegramStatus>(
     "/api/v1/telegram/status",
@@ -170,7 +172,20 @@ export function TelegramConnection() {
       description={t("cloud.telegram.cardDescription", {
         defaultValue: "Connect your Telegram bot for AI-powered automation",
       })}
-      status={status?.connected ? "connected" : "disconnected"}
+      status={
+        isStatusError
+          ? "error"
+          : status?.connected
+            ? "connected"
+            : "disconnected"
+      }
+      errorMessage={
+        statusErrorMessage ??
+        t("cloud.telegram.statusFetchFailed", {
+          defaultValue: "Failed to fetch Telegram status",
+        })
+      }
+      onRetry={() => void fetchStatus()}
       statusBadge={<ConnectionConnectedBadge />}
       connectedContent={
         <div className="space-y-4">

--- a/packages/ui/src/cloud/connectors/twilio-connection.tsx
+++ b/packages/ui/src/cloud/connectors/twilio-connection.tsx
@@ -52,6 +52,8 @@ export function TwilioConnection() {
   const {
     status,
     isLoading,
+    isError: isStatusError,
+    errorMessage: statusErrorMessage,
     refetch: fetchStatus,
   } = useConnectionStatus<TwilioStatus>(
     "/api/v1/twilio/status",
@@ -186,7 +188,20 @@ export function TwilioConnection() {
       description={t("cloud.twilio.cardDescription", {
         defaultValue: "Connect Twilio for SMS, MMS, and voice call automation",
       })}
-      status={status?.connected ? "connected" : "disconnected"}
+      status={
+        isStatusError
+          ? "error"
+          : status?.connected
+            ? "connected"
+            : "disconnected"
+      }
+      errorMessage={
+        statusErrorMessage ??
+        t("cloud.twilio.statusFetchFailed", {
+          defaultValue: "Failed to fetch Twilio status",
+        })
+      }
+      onRetry={() => void fetchStatus()}
       statusBadge={<ConnectionConnectedBadge />}
       connectedContent={
         <div className="space-y-4">

--- a/packages/ui/src/cloud/connectors/use-connection-status.test.ts
+++ b/packages/ui/src/cloud/connectors/use-connection-status.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Three-state contract for the shared cloud-connector status probe
+ * (#12784/#13419).
+ *
+ * Before this fix a FAILED status fetch (transport / 5xx / parse / auth) left
+ * `status` at `null` with only a transient toast, so every connector surface
+ * rendered its "disconnected" setup form — visually identical to a genuinely
+ * unconfigured connector even though the backend was unreachable. These tests
+ * pin that a probe failure is now a DISTINGUISHABLE error state (`isError` +
+ * `errorMessage`) that a healthy "not connected" response can never be mistaken
+ * for, and that a later successful retry clears it.
+ */
+
+// The hook throws `ApiError` from the shared client on non-2xx; give the mock a
+// real subclass so the `instanceof ApiError` branch (which reads `.message`) is
+// exercised, not just the generic `Error` fallback. Built via `vi.hoisted` so
+// the class + spies exist before the hoisted `vi.mock` factories run.
+const { MockApiError, apiMock, toastErrorMock } = vi.hoisted(() => {
+  class MockApiError extends Error {
+    constructor(
+      public readonly status: number,
+      public readonly code: string,
+      message: string,
+    ) {
+      super(message);
+      this.name = "ApiError";
+    }
+  }
+  return { MockApiError, apiMock: vi.fn(), toastErrorMock: vi.fn() };
+});
+
+vi.mock("../lib/api-client", () => ({
+  api: (...args: unknown[]) => apiMock(...args),
+  ApiError: MockApiError,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}));
+
+import { useConnectionStatus } from "./use-connection-status";
+
+interface FakeStatus {
+  connected: boolean;
+}
+
+beforeEach(() => {
+  apiMock.mockReset();
+  toastErrorMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useConnectionStatus — three-state probe (#12784/#13419)", () => {
+  it("resolves a successful probe into a readable status with NO error state", async () => {
+    apiMock.mockResolvedValueOnce({ connected: true });
+
+    const { result } = renderHook(() =>
+      useConnectionStatus<FakeStatus>("/api/v1/twilio/status"),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.status).toEqual({ connected: true });
+    expect(result.current.isError).toBe(false);
+    expect(result.current.errorMessage).toBeNull();
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a distinguishable ERROR state (not a fabricated disconnected) when the probe fails", async () => {
+    apiMock.mockRejectedValueOnce(
+      new MockApiError(503, "HTTP_503", "Service Unavailable"),
+    );
+
+    const { result } = renderHook(() =>
+      useConnectionStatus<FakeStatus>("/api/v1/twilio/status"),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // The regression this guards: a failed probe MUST NOT leave the caller
+    // reading `status === null` as a healthy "not connected".
+    expect(result.current.isError).toBe(true);
+    expect(result.current.errorMessage).toBe("Service Unavailable");
+    expect(result.current.status).toBeNull();
+    expect(toastErrorMock).toHaveBeenCalledWith("Service Unavailable");
+  });
+
+  it("falls back to the provided default message for a non-ApiError failure", async () => {
+    apiMock.mockRejectedValueOnce(new Error(""));
+
+    const { result } = renderHook(() =>
+      useConnectionStatus<FakeStatus>(
+        "/api/v1/whatsapp/status",
+        "Failed to fetch WhatsApp status",
+      ),
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.errorMessage).toBe("Failed to fetch WhatsApp status");
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "Failed to fetch WhatsApp status",
+    );
+  });
+
+  it("clears the error state after a successful retry", async () => {
+    apiMock.mockRejectedValueOnce(new MockApiError(500, "HTTP_500", "boom"));
+
+    const { result } = renderHook(() =>
+      useConnectionStatus<FakeStatus>("/api/v1/twilio/status"),
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    apiMock.mockResolvedValueOnce({ connected: false });
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    // A healthy "not connected" (connected:false) is a real status, NOT an
+    // error — the surface leaves the error state and renders the setup form.
+    expect(result.current.isError).toBe(false);
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.status).toEqual({ connected: false });
+  });
+});

--- a/packages/ui/src/cloud/connectors/use-connection-status.ts
+++ b/packages/ui/src/cloud/connectors/use-connection-status.ts
@@ -1,6 +1,20 @@
 /**
  * Generic GET-status hook for token-credential cloud connectors (Twilio,
  * Blooio, WhatsApp, Telegram).
+ *
+ * Three-state contract (#12784/#13419): a status fetch resolves into exactly
+ * one of
+ *   - loading      — the probe is in flight and no status is known yet;
+ *   - a status      — the server answered (connected / not-connected are then
+ *     read off the returned payload by the caller);
+ *   - error         — the probe FAILED (transport / 5xx / parse / auth). This
+ *     is deliberately distinguishable from a healthy "not connected" status:
+ *     previously a failed fetch left `status` at `null` with only a transient
+ *     toast, so the connector surface rendered the "disconnected" setup form —
+ *     indistinguishable from a genuinely unconfigured connector even though the
+ *     backend was unreachable. `isError`/`errorMessage` now expose that failure
+ *     so callers can render a real error state instead of a fabricated
+ *     "not connected".
  */
 
 "use client";
@@ -9,12 +23,29 @@ import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ApiError, api } from "../lib/api-client";
 
+export interface ConnectionStatusResult<TStatus> {
+  /** Last successfully fetched status payload, or `null` before the first
+   *  successful fetch. Only meaningful when `isError` is false. */
+  status: TStatus | null;
+  /** The probe is in flight. */
+  isLoading: boolean;
+  /** The most recent probe FAILED (transport / 5xx / parse / auth). When true,
+   *  `status` is stale/absent and must NOT be read as a healthy state. */
+  isError: boolean;
+  /** Human-readable failure reason for the error surface, or `null` when the
+   *  last probe succeeded. */
+  errorMessage: string | null;
+  /** Re-run the status probe (used by both mount and an error-state retry). */
+  refetch: (signal?: AbortSignal) => Promise<void>;
+}
+
 export function useConnectionStatus<TStatus>(
   endpoint: string,
   errorMessage = "Failed to fetch connection status",
-) {
+): ConnectionStatusResult<TStatus> {
   const [status, setStatus] = useState<TStatus | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const refetch = useCallback(
     async (signal?: AbortSignal) => {
@@ -23,15 +54,24 @@ export function useConnectionStatus<TStatus>(
         const data = await api<TStatus>(endpoint, { signal });
         if (signal?.aborted) return;
         setStatus(data);
-      } catch (error) {
+        // A successful probe clears any prior failure so the surface leaves the
+        // error state instead of leaving a stale error banner up.
+        setError(null);
+      } catch (err) {
         if (!signal?.aborted) {
           const message =
-            error instanceof ApiError
-              ? error.message
-              : error instanceof Error
-                ? error.message
+            err instanceof ApiError
+              ? err.message
+              : err instanceof Error
+                ? err.message
                 : errorMessage;
-          toast.error(message || errorMessage);
+          const resolved = message || errorMessage;
+          // error-policy:J4 status probe failed — surface a distinguishable
+          // error state (not a fabricated "disconnected"). The toast stays for
+          // immediacy; `isError` is the durable signal the connector card reads
+          // so a broken/unreachable backend never renders as "not connected".
+          setError(resolved);
+          toast.error(resolved);
         }
       } finally {
         if (!signal?.aborted) {
@@ -48,5 +88,11 @@ export function useConnectionStatus<TStatus>(
     return () => controller.abort();
   }, [refetch]);
 
-  return { status, isLoading, refetch };
+  return {
+    status,
+    isLoading,
+    isError: error !== null,
+    errorMessage: error,
+    refetch,
+  };
 }

--- a/packages/ui/src/cloud/connectors/whatsapp-connection.tsx
+++ b/packages/ui/src/cloud/connectors/whatsapp-connection.tsx
@@ -54,6 +54,8 @@ export function WhatsAppConnection() {
   const {
     status,
     isLoading,
+    isError: isStatusError,
+    errorMessage: statusErrorMessage,
     refetch: fetchStatus,
   } = useConnectionStatus<WhatsAppStatus>(
     "/api/v1/whatsapp/status",
@@ -200,7 +202,20 @@ export function WhatsAppConnection() {
       description={t("cloud.whatsapp.cardDescription", {
         defaultValue: "Connect WhatsApp Business for AI-powered automation",
       })}
-      status={status?.connected ? "connected" : "disconnected"}
+      status={
+        isStatusError
+          ? "error"
+          : status?.connected
+            ? "connected"
+            : "disconnected"
+      }
+      errorMessage={
+        statusErrorMessage ??
+        t("cloud.whatsapp.statusFetchFailed", {
+          defaultValue: "Failed to fetch WhatsApp status",
+        })
+      }
+      onRetry={() => void fetchStatus()}
       statusBadge={<ConnectionConnectedBadge />}
       connectedContent={
         <div className="space-y-4">


### PR DESCRIPTION
## Problem

Successor slice to #12784 for `packages/ui/src/cloud/**`. The shared cloud-connector status-probe hook `useConnectionStatus` (used by the Twilio, WhatsApp, Blooio, and Telegram connectors) **swallowed a failed status fetch** into `status = null` with only a transient `toast.error`, then returned `isLoading = false` and NO durable error signal.

Consumers render:

```tsx
status={status?.connected ? "connected" : "disconnected"}
```

So a transport / 5xx / parse / auth failure of `GET /api/v1/<connector>/status` rendered the **"disconnected" setup form** — byte-identical to a genuinely unconfigured connector, even though the backend was unreachable. The toast vanishes; the surface then reads as a healthy "not connected". This is the exact #12784 three-state collapse (error folded into designed-empty).

## Fix

- **`use-connection-status.ts`**: added `isError` / `errorMessage` to the hook contract (`// error-policy:J4` on the probe-failure branch, toast retained for immediacy). A successful probe clears them; a healthy `connected:false` stays a real status (NOT an error), so the setup form still renders for a genuinely-disconnected connector.
- **`connection-card.tsx`**: added a distinguishable `"error"` status → `role="alert"` block with the message and an optional `Retry` button (`onRetry`). A failed probe never renders the setup/connected content.
- **Four connectors** (twilio/whatsapp/blooio/telegram): render `"error"` when `isError`, pass the connector-specific `cloud.<connector>.statusFetchFailed` i18n string (existing keys → zero locale churn), and wire `onRetry` → `refetch`.

## Tests

```
packages/ui $ bunx vitest run \
  src/cloud/connectors/use-connection-status.test.ts \
  src/cloud-ui/components/connection-card.error.test.tsx

 ✓ src/cloud/connectors/use-connection-status.test.ts (4 tests)
 ✓ src/cloud-ui/components/connection-card.error.test.tsx (3 tests)
 Test Files  2 passed (2)
      Tests  7 passed (7)
```

- **hook**: success → readable status + no error; failure → `isError`/`errorMessage`/toast (regression guard: a failed probe never reads as healthy "not connected"); non-`ApiError` → default message; successful retry clears the error and treats `connected:false` as a real status.
- **card**: `status="error"` renders the alert and NOT the setup/connected content; `status="disconnected"` still renders the setup form with no alert; `onRetry` fires on the retry button.

## Gates

- `tsgo --noEmit -p packages/ui/tsconfig.json` → **0 errors** (whole package).
- `bunx @biomejs/biome check` (8 touched files) → clean.
- `bun run audit:error-policy-ratchet` → `no new fallback-slop in touched files`.
- `git diff --check` → clean; only the 8 intended files changed, no forbidden files.

Evidence: `.github/issue-evidence/13419-cloud-ui-three-state.md` (path/pattern/verdict table + audited-clean rows for api-client / admin-gate / session-auth). Non-visual slice per the accepted #13227 / #13434 / #13444 / #13463 precedent; the four connector pages' happy paths are unchanged, only the previously-invisible error path is now rendered. Issue stays open for the remaining cloud UI surfaces.

Closes part of #13419.

— [sol-orch]
