### PR TITLE
fix: register room-less durable-task app builds before the origin gate

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/built-apps-registry.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/built-apps-registry.test.ts
@@ -290,28 +290,13 @@ describe("task_complete → registry record (real router path)", () => {
     );
   });
 
-  it("a successful app-deploy completion writes the live URL to the registry", async () => {
-    const liveUrl = `${baseUrl}/apps/snake-game/`;
+  function routerHarness(session: { id: string } & Record<string, unknown>): {
+    cache: Map<string, unknown>;
+    runtime: IAgentRuntime;
+  } {
     const cache = new Map<string, unknown>();
-    const session = {
-      id: "sess-app",
-      agentType: "codex",
-      name: "Ada",
-      workdir: "/tmp/built-apps-registry-test",
-      status: "ready",
-      createdAt: new Date(0),
-      lastActivityAt: new Date(0),
-      metadata: {
-        roomId: ROOM,
-        taskRoomId: ROOM,
-        messageId: MSG,
-        source: "discord",
-        label: "build snake game",
-        initialTask: "build a snake game web app and deploy it live",
-      },
-    };
     const sessions = new Map<string, Record<string, unknown>>([
-      ["sess-app", session],
+      [session.id, session],
     ]);
     const acp = {
       onSessionEvent: () => () => {},
@@ -342,17 +327,51 @@ describe("task_complete → registry record (real router path)", () => {
       emitEvent: vi.fn(async () => undefined),
       useModel: vi.fn(async () => "{}"),
     } as unknown as IAgentRuntime;
+    return { cache, runtime };
+  }
 
+  async function driveTaskComplete(
+    runtime: IAgentRuntime,
+    sessionId: string,
+    response: string,
+  ): Promise<void> {
     const router = new SubAgentRouter(runtime);
     await router.start();
     const internals = router as unknown as {
       handleEvent(id: string, event: string, data: unknown): Promise<void>;
     };
-    await internals.handleEvent("sess-app", "task_complete", {
-      response: `The snake game is built and live at ${liveUrl}`,
+    await internals.handleEvent(sessionId, "task_complete", {
+      response,
       stopReason: "end_turn",
     });
     await router.stop();
+  }
+
+  it("a successful app-deploy completion writes the live URL to the registry", async () => {
+    const liveUrl = `${baseUrl}/apps/snake-game/`;
+    const { cache, runtime } = routerHarness({
+      id: "sess-app",
+      agentType: "codex",
+      name: "Ada",
+      workdir: "/tmp/built-apps-registry-test",
+      status: "ready",
+      createdAt: new Date(0),
+      lastActivityAt: new Date(0),
+      metadata: {
+        roomId: ROOM,
+        taskRoomId: ROOM,
+        messageId: MSG,
+        source: "discord",
+        label: "build snake game",
+        initialTask: "build a snake game web app and deploy it live",
+      },
+    });
+
+    await driveTaskComplete(
+      runtime,
+      "sess-app",
+      `The snake game is built and live at ${liveUrl}`,
+    );
 
     const apps = cache.get(BUILT_APPS_CACHE_KEY) as BuiltAppRecord[];
     expect(apps).toHaveLength(1);
@@ -365,5 +384,49 @@ describe("task_complete → registry record (real router path)", () => {
       label: "build snake game",
     });
     expect(apps[0].registeredAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("a room-less durable task's deploy still registers (cockpit new-session / bare API create)", async () => {
+    const liveUrl = `${baseUrl}/apps/workout-tracker/`;
+    // Exactly what spawnAgentForTask stamps for a task created WITHOUT a chat
+    // room (cockpit "new session", bare POST /api/orchestrator/tasks): no room
+    // UUID anywhere, the bare `goal` (not `initialTask`), source
+    // "orchestrator". readOrigin() yields null for this session, so the router
+    // has no room to post to — the registry write must not depend on one.
+    const { cache, runtime } = routerHarness({
+      id: "sess-roomless",
+      agentType: "codex",
+      name: "Ada",
+      workdir: "/tmp/built-apps-registry-test",
+      status: "ready",
+      createdAt: new Date(0),
+      lastActivityAt: new Date(0),
+      metadata: {
+        taskId: "task-1",
+        roomId: undefined,
+        label: "Ada",
+        source: "orchestrator",
+        goal: "build a workout tracker web app and deploy it live",
+        keepAliveAfterComplete: true,
+        nestingDepth: 0,
+      },
+    });
+
+    await driveTaskComplete(
+      runtime,
+      "sess-roomless",
+      `Deployed. The workout tracker is live at ${liveUrl}`,
+    );
+
+    const apps = cache.get(BUILT_APPS_CACHE_KEY) as BuiltAppRecord[];
+    expect(apps).toHaveLength(1);
+    expect(apps[0]).toMatchObject({
+      slug: "workout-tracker",
+      name: "Workout Tracker",
+      url: liveUrl,
+      target: "custom",
+      sessionId: "sess-roomless",
+      label: "Ada",
+    });
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -815,6 +815,16 @@ export class SubAgentRouter extends Service {
 
     const origin = readOrigin(session);
     if (!origin) {
+      // No origin room means there is nothing to post — but a durable task
+      // created WITHOUT a chat room (cockpit "new session", bare POST
+      // /api/orchestrator/tasks) spawns exactly such a session:
+      // spawnAgentForTask stamps roomId from the task's optional room, which
+      // is undefined. Its completed app build must still land in the durable
+      // built-apps registry (#12036) — registration needs only the session
+      // and its verified URLs, never a room.
+      if (event === "task_complete") {
+        await this.registerRoomlessBuiltApps(session, data);
+      }
       this.log(
         "debug",
         "session has no origin metadata; skipping router post",
@@ -1578,6 +1588,56 @@ export class SubAgentRouter extends Service {
       });
       return delivered ? [delivered] : [];
     };
+  }
+
+  /**
+   * Built-app registration for a completion whose session has NO origin room
+   * (a durable task created without a chat room: cockpit "new session", bare
+   * POST /api/orchestrator/tasks). The normal registration sits after the
+   * readOrigin gate on the narration path, so these sessions never reached it
+   * and their deploys were fire-and-forget. Mirrors that path's verification:
+   * probe the URLs the completion claims and register only the live ones. The
+   * reference text falls back from `initialTask` to the bare `goal` —
+   * spawnAgentForTask stamps only the latter. Never throws: the registry is a
+   * side-record and must not break event handling.
+   */
+  private async registerRoomlessBuiltApps(
+    session: SessionInfo,
+    data: unknown,
+  ): Promise<void> {
+    try {
+      const response = pickPayloadString(data, "response");
+      if (!response) return;
+      const meta = session.metadata as Record<string, unknown> | undefined;
+      const referenceText =
+        typeof meta?.initialTask === "string"
+          ? meta.initialTask
+          : typeof meta?.goal === "string"
+            ? meta.goal
+            : undefined;
+      const verified = await annotateUnverifiedUrls(
+        normalizeUrlsInText(response),
+        (m) => this.log("debug", m),
+        referenceText,
+        pickStringSet(meta?.cachedStaleMissUrls),
+        this.runtime,
+        routeVerificationForSession(session),
+      );
+      if (verified.verifiedUrls.length === 0) return;
+      await registerBuiltAppsForCompletion(
+        this.runtime,
+        session,
+        verified.verifiedUrls,
+        (level, message, ctx) => this.log(level, message, ctx),
+      );
+    } catch (err) {
+      // error-policy:J7 side-record on the event path; a registration failure
+      // warns and must not break handling of the completion event.
+      this.log("warn", "room-less built-app registration failed", {
+        sessionId: session.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Bug ([core-brain] launch-QA, #13406 surface: app-management)

Durable-task built-app registration is dead for **room-less** tasks — cockpit "new session" and bare `POST /api/orchestrator/tasks` creates.

- The cockpit create sends `{title, goal, providerPolicy}` with no `roomId` (`packages/ui/src/components/cockpit/cockpit-modes.ts`), and the route leaves `roomId`/`taskRoomId` optional (`orchestrator-routes.ts`).
- `spawnAgentForTask` stamps `metadata.roomId = doc.task.taskRoomId ?? doc.task.roomId` → `undefined`.
- `readOrigin` requires a strict UUID (`pickUuid`), returns `null`, and `handleEvent` bails at the "session has no origin metadata; skipping router post" guard — **before** the `registerBuiltAppsForCompletion` call further down the narration path.
- Net effect: an app built through a room-less durable task deploys fine but never appears in the built-apps management surface (`GET /api/orchestrator/built-apps`). Chat-spawned tasks are unaffected (they carry a room).

The existing #13268 test masked this: it stamped `roomId: ROOM` on the session and/or called `registerBuiltAppsForCompletion` directly instead of driving the router.

## Fix (structural)

Register at the no-origin guard itself: for a `task_complete` with no origin, probe the completion's claimed URLs through the same verification path the narration flow uses (`annotateUnverifiedUrls`, with `goal` as the reference-text fallback — `spawnAgentForTask` stamps only the bare `goal`, not `initialTask`) and persist the registry record. Registration needs only the session and its verified URLs, never a room. Room-full sessions keep the existing registration on the narration path — no double-register.

## Test

New router-driven test with a **room-less orchestrator-source** session (exact `spawnAgentForTask` metadata shape: `taskId` + `goal` + `source: "orchestrator"`, `roomId: undefined`) against a real local HTTP server. Fails on develop (registry empty), passes with the fix. The existing room-full router test is unchanged in behavior (harness factored out).

## Verification

- `vitest run src/__tests__/built-apps-registry.test.ts`: 9 pass + new test **fails** on unmodified develop → **10/10 pass** with the fix.
- All 16 test files touching `sub-agent-router`: 235/235 pass.
- `bun run typecheck` (plugin): clean. `biome check` on both changed files: clean.
- Pre-existing failures in `__tests__/unit/` (task-control/history/provision-workspace, 26 tests) reproduce identically on pristine develop with the change stashed — not from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)