### PR TITLE
fix(#13422): read shared cloud env aliases non-mutating

### DIFF
--- a/.github/issue-evidence/13422-shared-cloud-env-read-migration.md
+++ b/.github/issue-evidence/13422-shared-cloud-env-read-migration.md
@@ -1,0 +1,18 @@
+# #13422 Shared Cloud Env-Read Migration
+
+## Scope
+
+- Migrated `@elizaos/shared` cloud base URL, cloud reachability, HF proxy,
+  cloud provisioning, and loopback cloud-check reads from raw `process.env`
+  access to the non-mutating boot alias reader.
+- Added focused tests proving branded env aliases work without materializing
+  canonical `ELIZA*` / `ELIZAOS*` mirror keys.
+
+## Verification
+
+- `bun run --cwd packages/shared test -- elizacloud/base-url.test.ts elizacloud/cloud-provisioning.test.ts local-inference/hf-proxy.test.ts loopback-trust.test.ts`
+  - Result: 4 files passed, 84 tests passed.
+
+## UI / Media Evidence
+
+- N/A - shared runtime/env helper change with no rendered UI surface.

--- a/packages/shared/src/elizacloud/base-url.test.ts
+++ b/packages/shared/src/elizacloud/base-url.test.ts
@@ -6,11 +6,16 @@
  * The ELIZAOS_CLOUD_BASE_URL env override takes precedence over the passed URL.
  */
 import { afterEach, describe, expect, it } from "vitest";
+import { getBootConfig, setBootConfig } from "../config/boot-config";
 import { normalizeCloudSiteUrl, resolveCloudApiBaseUrl } from "./base-url";
 
 describe("Eliza Cloud base URL normalization", () => {
+  const savedConfig = getBootConfig();
+
   afterEach(() => {
     delete process.env.ELIZAOS_CLOUD_BASE_URL;
+    delete process.env.ACME_CLOUD_BASE_URL;
+    setBootConfig(savedConfig);
   });
 
   it("normalizes every cloud host alias to the apex origin", () => {
@@ -59,5 +64,17 @@ describe("Eliza Cloud base URL normalization", () => {
     expect(normalizeCloudSiteUrl("https://raw.example.com")).toBe(
       "https://env.example.com",
     );
+  });
+
+  it("resolves branded env aliases without materializing the canonical key", () => {
+    setBootConfig({
+      ...savedConfig,
+      envAliases: [["ACME_CLOUD_BASE_URL", "ELIZAOS_CLOUD_BASE_URL"]],
+    });
+    process.env.ACME_CLOUD_BASE_URL =
+      "http://branded.example.com:8080/api/v1?debug=1";
+
+    expect(resolveCloudApiBaseUrl()).toBe("https://branded.example.com/api/v1");
+    expect(process.env.ELIZAOS_CLOUD_BASE_URL).toBeUndefined();
   });
 });

--- a/packages/shared/src/elizacloud/base-url.ts
+++ b/packages/shared/src/elizacloud/base-url.ts
@@ -2,6 +2,8 @@
  * Pure URL normalizer for Eliza Cloud site/API base URLs. No host-layer deps.
  */
 
+import { readAliasedEnv } from "../utils/env.js";
+
 const DEFAULT_CLOUD_SITE_URL = "https://elizacloud.ai";
 
 const LEGACY_CLOUD_HOST_ALIASES = new Set([
@@ -42,7 +44,7 @@ function normalizeMalformedCandidate(candidate: string): string {
 
 export function normalizeCloudSiteUrl(rawUrl?: string): string {
   // Allow cloud-provisioned containers to override the base URL via env var
-  const envOverride = process.env.ELIZAOS_CLOUD_BASE_URL?.trim();
+  const envOverride = readAliasedEnv("ELIZAOS_CLOUD_BASE_URL");
   const candidate = envOverride || rawUrl?.trim() || DEFAULT_CLOUD_SITE_URL;
 
   try {

--- a/packages/shared/src/elizacloud/cloud-provisioning.test.ts
+++ b/packages/shared/src/elizacloud/cloud-provisioning.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Cloud container provisioning detection. The tests cover both legacy canonical
+ * env names and boot-configured brand aliases, proving the shared detector can
+ * run before alias sync writes have materialized compatibility keys.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getBootConfig, setBootConfig } from "../config/boot-config.js";
+import { isCloudProvisionedContainer } from "./cloud-provisioning.js";
+
+const CLOUD_PROVISIONING_KEYS = [
+  "ACME_API_TOKEN",
+  "ACME_CLOUD_API_KEY",
+  "ACME_CLOUD_ENABLED",
+  "ACME_CLOUD_PROVISIONED",
+  "ELIZA_API_TOKEN",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_ENABLED",
+  "ELIZA_CLOUD_PROVISIONED",
+  "STEWARD_AGENT_TOKEN",
+] as const;
+
+describe("isCloudProvisionedContainer", () => {
+  const savedConfig = getBootConfig();
+  const savedEnv = Object.fromEntries(
+    CLOUD_PROVISIONING_KEYS.map((key) => [key, process.env[key]]),
+  );
+
+  beforeEach(() => {
+    setBootConfig(savedConfig);
+    for (const key of CLOUD_PROVISIONING_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    setBootConfig(savedConfig);
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("requires the cloud flag plus at least one provisioning credential", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    expect(isCloudProvisionedContainer()).toBe(false);
+
+    process.env.STEWARD_AGENT_TOKEN = "steward-token";
+    expect(isCloudProvisionedContainer()).toBe(true);
+  });
+
+  it("accepts a branded API-token alias without materializing ELIZA_API_TOKEN", () => {
+    setBootConfig({
+      ...savedConfig,
+      envAliases: [
+        ["ACME_CLOUD_PROVISIONED", "ELIZA_CLOUD_PROVISIONED"],
+        ["ACME_API_TOKEN", "ELIZA_API_TOKEN"],
+      ],
+    });
+    process.env.ACME_CLOUD_PROVISIONED = "1";
+    process.env.ACME_API_TOKEN = "owner-token";
+
+    expect(isCloudProvisionedContainer()).toBe(true);
+    expect(process.env.ELIZA_CLOUD_PROVISIONED).toBeUndefined();
+    expect(process.env.ELIZA_API_TOKEN).toBeUndefined();
+  });
+
+  it("accepts branded cloud API-key provisioning aliases without env sync", () => {
+    setBootConfig({
+      ...savedConfig,
+      envAliases: [
+        ["ACME_CLOUD_PROVISIONED", "ELIZA_CLOUD_PROVISIONED"],
+        ["ACME_CLOUD_ENABLED", "ELIZAOS_CLOUD_ENABLED"],
+        ["ACME_CLOUD_API_KEY", "ELIZAOS_CLOUD_API_KEY"],
+      ],
+    });
+    process.env.ACME_CLOUD_PROVISIONED = "1";
+    process.env.ACME_CLOUD_ENABLED = "true";
+    process.env.ACME_CLOUD_API_KEY = "cloud-key";
+
+    expect(isCloudProvisionedContainer()).toBe(true);
+    expect(process.env.ELIZA_CLOUD_PROVISIONED).toBeUndefined();
+    expect(process.env.ELIZAOS_CLOUD_ENABLED).toBeUndefined();
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+  });
+});

--- a/packages/shared/src/elizacloud/cloud-provisioning.ts
+++ b/packages/shared/src/elizacloud/cloud-provisioning.ts
@@ -6,23 +6,25 @@
  * during container boot.
  */
 
+import { readAliasedEnv } from "../utils/env.js";
+
 function hasValue(value: string | undefined): boolean {
   return Boolean(value?.trim());
 }
 
 function hasCompatApiToken(): boolean {
-  return hasValue(process.env.ELIZA_API_TOKEN);
+  return hasValue(readAliasedEnv("ELIZA_API_TOKEN"));
 }
 
 function hasCloudApiKeyProvisioning(): boolean {
   return (
-    process.env.ELIZAOS_CLOUD_ENABLED === "true" &&
-    hasValue(process.env.ELIZAOS_CLOUD_API_KEY)
+    readAliasedEnv("ELIZAOS_CLOUD_ENABLED") === "true" &&
+    hasValue(readAliasedEnv("ELIZAOS_CLOUD_API_KEY"))
   );
 }
 
 export function isCloudProvisionedContainer(): boolean {
-  const hasCloudFlag = process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  const hasCloudFlag = readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
 
   return (
     hasCloudFlag &&

--- a/packages/shared/src/elizacloud/is-cloud-reachable.ts
+++ b/packages/shared/src/elizacloud/is-cloud-reachable.ts
@@ -18,7 +18,7 @@ const PROBE_TIMEOUT_MS = 1_000;
 let inFlight: Promise<boolean> | null = null;
 
 async function probeCloud(): Promise<boolean> {
-  const baseUrl = resolveCloudApiBaseUrl(process.env.ELIZAOS_CLOUD_BASE_URL);
+  const baseUrl = resolveCloudApiBaseUrl();
   try {
     const response = await fetch(baseUrl, {
       method: "HEAD",

--- a/packages/shared/src/local-inference/hf-proxy.test.ts
+++ b/packages/shared/src/local-inference/hf-proxy.test.ts
@@ -6,6 +6,7 @@
  * the cloud-secrets cache around each case.
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getBootConfig, setBootConfig } from "../config/boot-config.js";
 import { _resetCloudSecretsForTesting } from "../elizacloud/cloud-secrets.js";
 import { resolveHfDownloadBase, resolveHfDownloadBases } from "./hf-proxy.js";
 
@@ -17,7 +18,9 @@ import { resolveHfDownloadBase, resolveHfDownloadBases } from "./hf-proxy.js";
  *   3. Direct public huggingface.co — no auth.
  */
 describe("resolveHfDownloadBase", () => {
+  const savedConfig = getBootConfig();
   const savedEnv = {
+    ACME_CLOUD_BASE_URL: process.env.ACME_CLOUD_BASE_URL,
     ELIZA_HF_BASE_URL: process.env.ELIZA_HF_BASE_URL,
     ELIZA_HF_BASE_URLS: process.env.ELIZA_HF_BASE_URLS,
     ELIZAOS_CLOUD_API_KEY: process.env.ELIZAOS_CLOUD_API_KEY,
@@ -30,6 +33,8 @@ describe("resolveHfDownloadBase", () => {
     delete process.env.ELIZA_HF_BASE_URLS;
     delete process.env.ELIZAOS_CLOUD_API_KEY;
     delete process.env.ELIZAOS_CLOUD_BASE_URL;
+    delete process.env.ACME_CLOUD_BASE_URL;
+    setBootConfig(savedConfig);
   });
 
   afterEach(() => {
@@ -38,6 +43,7 @@ describe("resolveHfDownloadBase", () => {
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;
     }
+    setBootConfig(savedConfig);
   });
 
   it("routes directly to the public HuggingFace host when nothing is configured", () => {
@@ -58,6 +64,23 @@ describe("resolveHfDownloadBase", () => {
       viaCloud: true,
       label: "cloud",
     });
+  });
+
+  it("uses a branded cloud base URL alias for the cloud proxy without syncing env", () => {
+    setBootConfig({
+      ...savedConfig,
+      envAliases: [["ACME_CLOUD_BASE_URL", "ELIZAOS_CLOUD_BASE_URL"]],
+    });
+    process.env.ELIZAOS_CLOUD_API_KEY = "key-123";
+    process.env.ACME_CLOUD_BASE_URL = "https://acme.example.com/api/v1";
+
+    expect(resolveHfDownloadBase()).toEqual({
+      base: "https://acme.example.com/api/v1/hf-proxy",
+      authHeader: { authorization: "Bearer key-123" },
+      viaCloud: true,
+      label: "cloud",
+    });
+    expect(process.env.ELIZAOS_CLOUD_BASE_URL).toBeUndefined();
   });
 
   it("tries explicit mirrors before the cloud proxy and public host", () => {

--- a/packages/shared/src/local-inference/hf-proxy.ts
+++ b/packages/shared/src/local-inference/hf-proxy.ts
@@ -74,7 +74,7 @@ export function resolveHfDownloadBases(): HfDownloadBase[] {
 
   const apiKey = cloudApiKey();
   if (apiKey) {
-    const cloudApi = resolveCloudApiBaseUrl(process.env.ELIZAOS_CLOUD_BASE_URL);
+    const cloudApi = resolveCloudApiBaseUrl();
     bases.push({
       base: `${trimTrailingSlash(cloudApi)}/hf-proxy`,
       authHeader: { authorization: `Bearer ${apiKey}` },

--- a/packages/shared/src/loopback-trust.test.ts
+++ b/packages/shared/src/loopback-trust.test.ts
@@ -10,6 +10,7 @@
 import http from "node:http";
 import { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getBootConfig, setBootConfig } from "./config/boot-config.js";
 import {
   isLoopbackRemoteAddress,
   isTrustedLocalRequest,
@@ -237,8 +238,14 @@ describe("isTrustedLocalRequest — shared host/origin classification", () => {
 });
 
 describe("isTrustedLocalRequest — app-core policy gates (cloudCheck=env, dev bypass)", () => {
+  const savedConfig = getBootConfig();
+
   beforeEach(clearTrustEnv);
-  afterEach(clearTrustEnv);
+  afterEach(() => {
+    clearTrustEnv();
+    delete process.env.ACME_CLOUD_PROVISIONED;
+    setBootConfig(savedConfig);
+  });
 
   const localReq = () => makeReq({ headers: { host: "localhost:2138" } });
 
@@ -264,6 +271,17 @@ describe("isTrustedLocalRequest — app-core policy gates (cloudCheck=env, dev b
   it("cloudCheck=env: raw ELIZA_CLOUD_PROVISIONED=1 denies trust (no token needed)", () => {
     process.env.ELIZA_CLOUD_PROVISIONED = "1";
     expect(isTrustedLocalRequest(localReq(), APP_CORE_OPTIONS)).toBe(false);
+  });
+
+  it("cloudCheck=env: branded cloud-provisioned alias denies trust without syncing env", () => {
+    setBootConfig({
+      ...savedConfig,
+      envAliases: [["ACME_CLOUD_PROVISIONED", "ELIZA_CLOUD_PROVISIONED"]],
+    });
+    process.env.ACME_CLOUD_PROVISIONED = "1";
+
+    expect(isTrustedLocalRequest(localReq(), APP_CORE_OPTIONS)).toBe(false);
+    expect(process.env.ELIZA_CLOUD_PROVISIONED).toBeUndefined();
   });
 });
 

--- a/packages/shared/src/loopback-trust.ts
+++ b/packages/shared/src/loopback-trust.ts
@@ -12,7 +12,7 @@
  * The two consumers differ ONLY in their policy gates, expressed via
  * {@link LoopbackTrustOptions}:
  *  - app-core: requireLocalAuthEnv + devAuthBypassEnv, cloudCheck "env"
- *    (`ELIZA_CLOUD_PROVISIONED === "1"`).
+ *    (`ELIZA_CLOUD_PROVISIONED === "1"` through the boot alias table).
  *  - agent:    requireLocalAuthEnv (no dev bypass), cloudCheck "container"
  *    (`isCloudProvisionedContainer()` — flag AND a provisioning token).
  *
@@ -30,6 +30,7 @@ import type http from "node:http";
 import { isIP } from "node:net";
 import { isCloudProvisionedContainer } from "./elizacloud/cloud-provisioning.js";
 import { isLoopbackBindHost } from "./runtime-env.js";
+import { readAliasedEnv } from "./utils/env.js";
 
 export interface LoopbackTrustOptions {
   /**
@@ -249,7 +250,7 @@ function isTrustedLocalOrigin(raw: string): boolean {
 
 function cloudBlocksLocalTrust(cloudCheck: "env" | "container"): boolean {
   if (cloudCheck === "container") return isCloudProvisionedContainer();
-  return process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  return readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
 }
 
 function localAuthRequired(options: LoopbackTrustOptions): boolean {


### PR DESCRIPTION
## Summary
- migrate shared cloud base URL, reachability, HF proxy, loopback cloud-check, and provisioning reads to `readAliasedEnv`
- add branded-alias tests proving canonical `ELIZA*` / `ELIZAOS*` keys are not materialized
- rebased after #13356 merged, so this PR now contains only the #13422 shared-env slice

Advances #13422 and #12251.

## Verification
- `bun run --cwd packages/shared test -- elizacloud/base-url.test.ts elizacloud/cloud-provisioning.test.ts local-inference/hf-proxy.test.ts loopback-trust.test.ts` — 4 files / 84 tests passed
- `bunx @biomejs/biome check packages/shared/src/elizacloud/base-url.ts packages/shared/src/elizacloud/base-url.test.ts packages/shared/src/elizacloud/cloud-provisioning.ts packages/shared/src/elizacloud/cloud-provisioning.test.ts packages/shared/src/elizacloud/is-cloud-reachable.ts packages/shared/src/local-inference/hf-proxy.ts packages/shared/src/local-inference/hf-proxy.test.ts packages/shared/src/loopback-trust.ts packages/shared/src/loopback-trust.test.ts` — pass
- `git diff --check origin/develop...HEAD && git diff --check` — pass

## Evidence
- `.github/issue-evidence/13422-shared-cloud-env-read-migration.md`

## UI / Media Evidence
- N/A — shared runtime/env helper change with no rendered UI surface.
