### PR TITLE
fix(#13416): fail closed on corrupt payout/withdrawal NUMERIC reads

### DIFF
--- a/.github/issue-evidence/13416-cloud-shared-db-app-earnings-payout-fail-closed.md
+++ b/.github/issue-evidence/13416-cloud-shared-db-app-earnings-payout-fail-closed.md
@@ -1,0 +1,71 @@
+# #13416 evidence — app-earnings payout/withdrawal NUMERIC fail-closed slice
+
+Successor slice under the cloud-shared DB-repository fallback-slop sweep (#13416).
+Distinct from my prior usage-quota slice (PR #13454).
+
+## Path / pattern / verdict
+
+| Path | Pattern | Verdict |
+| --- | --- | --- |
+| `packages/cloud/shared/src/db/repositories/app-earnings.ts` `processWithdrawal` | `Number(earnings.payout_threshold)` / `Number(earnings.withdrawable_balance)` on a money-out gate | FAIL-OPEN — corrupt NUMERIC → `NaN`; `amount < NaN` and `NaN < amount` both false → minimum-payout gate + insufficient-balance pre-check bypassed. Fixed. |
+| `app-earnings.ts` `processIdempotentWithdrawal` | `Number(earnings.payout_threshold)` inside the txn threshold gate | FAIL-OPEN — same NaN bypass of the minimum-payout floor. Runs before the idempotency-key insert, so a corrupt row now aborts with no phantom claim. Fixed. |
+| `app-earnings.ts` `!updated` recovery reads (both paths) | `Number(current?.withdrawable_balance ?? 0)` | Would surface `"NaN"` in the user-facing message on a corrupt row. Now `undefined` → domain 0, present-but-corrupt → throws. Fixed. |
+| `app-earnings.ts` `getEarningsSummary` / `getDailyEarnings` (lines 190/243) | `Number(row.total)` on `COALESCE(SUM(...), 0)` | AUDITED — read-only display aggregation, never null, NOT a money-out gate. Left as-is (out of scope for this fail-closed slice). |
+
+## The bug (fail-open money-out gate)
+
+`payout_threshold` and `withdrawable_balance` are `notNull` Postgres NUMERIC
+columns that arrive as strings. A corrupt value (driver quirk / migration
+artifact / manual DB edit) read through a bare `Number(...)` becomes `NaN`.
+Because every `< NaN` comparison is false:
+
+- `amount < threshold` → a sub-threshold payout passes the minimum-payout floor.
+  This gate has **NO DB-level backstop** (unlike the balance debit, which the
+  `gte(withdrawable_balance, amount)` predicate protects race-safely).
+- `withdrawable < amount` → the insufficient-balance pre-check is bypassed.
+
+## The fix (fail closed)
+
+New `app-earnings-numeric.ts` boundary `parseEarningsNumber(value, fieldName)`:
+throws on null/undefined/empty/whitespace and on any non-finite parse, allows an
+explicit domain zero. Wired into all four withdrawal-gate reads (two
+`processWithdrawal`, two `processIdempotentWithdrawal`). In the idempotent path
+the throw happens before the idempotency-key insert, so a corrupt row rolls the
+transaction back with no phantom claim; the plain-Error throw propagates past the
+`WithdrawalRollback`-only catch, so it fails loud rather than fabricating success.
+Mirrors the established `parseUsageQuotaNumber` pattern from PR #13454.
+
+## Tests — `__tests__/app-earnings-numeric.test.ts` (9/9 green)
+
+```
+bun test src/db/repositories/__tests__/app-earnings-numeric.test.ts
+ 9 pass / 0 fail / 19 expect() calls
+```
+
+- parser: well-formed string, numeric literal, explicit zero, null/undefined,
+  empty/whitespace, REGRESSION (corrupt → throws not NaN, incl. Infinity/NaN/`12.3.4`).
+- gate wiring (stubbed `findByAppId`, no DB needed — Postgres/PGlite won't store a
+  corrupt NUMERIC): healthy sub-threshold rejection still holds; corrupt
+  `payout_threshold` **throws** instead of allowing a $10 payout under the $25
+  floor; corrupt `withdrawable_balance` **throws** instead of bypassing the
+  balance pre-check.
+
+## Other gates
+
+- `bunx @biomejs/biome check <touched>` — clean (import-order autofix applied).
+- `bun run audit:error-policy-ratchet` — "no new fallback-slop in touched files".
+- `bun run typecheck` (tsgo) — 0 errors in touched files; the 17 remaining are
+  pre-existing baseline noise (`@elizaos/auth` symlink resolution in app-core,
+  node-redis-adapter, plugin-mcp/json, anthropic-web-search) identical on
+  `origin/develop`.
+- `codex review --uncommitted` — clean: "I did not identify any introduced
+  correctness, security, or maintainability issues that warrant an inline finding."
+
+## N/A
+
+- Model trajectories / audio: N/A — no changed view invokes those flows.
+- Screenshots: N/A — non-visual DB-repository change.
+
+Issue stays open for the remaining ~47-file repo inventory.
+
+— [sol-orch]

--- a/packages/cloud/shared/src/db/repositories/__tests__/app-earnings-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/app-earnings-numeric.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Fail-closed NUMERIC boundary for app-earnings money-out (payout / withdrawal)
+ * gates (#13416, cloud-shared DB-repository fallback-slop sweep).
+ *
+ * Postgres NUMERIC arrives as a string. Before this slice the withdrawal gates
+ * read `withdrawable_balance` / `payout_threshold` through a bare `Number(...)`,
+ * so a corrupt value became `NaN` and the guards FAILED OPEN:
+ *
+ *   - `amount < threshold`    → `amount < NaN` is always false → the minimum
+ *                               payout gate was bypassed (sub-threshold payout).
+ *                               This gate has NO DB-level backstop.
+ *   - `withdrawable < amount` → `NaN < amount` is always false → the
+ *                               insufficient-balance pre-check was bypassed.
+ *
+ * These tests pin the parser boundary AND the gate wiring (via a stubbed read)
+ * without needing a real corrupt NUMERIC in the DB — Postgres/PGlite would
+ * reject storing one, but a driver quirk / migration artifact can still surface
+ * one at read time, which is exactly the failure mode this guards.
+ */
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { AppEarningsRepository } from "../app-earnings";
+import { parseEarningsNumber } from "../app-earnings-numeric";
+
+describe("parseEarningsNumber", () => {
+  test("parses a well-formed NUMERIC string", () => {
+    expect(parseEarningsNumber("25.00", "payout_threshold")).toBe(25);
+    expect(parseEarningsNumber("100.500000", "withdrawable_balance")).toBe(100.5);
+  });
+
+  test("parses a numeric literal", () => {
+    expect(parseEarningsNumber(0, "withdrawable_balance")).toBe(0);
+    expect(parseEarningsNumber(42, "withdrawable_balance")).toBe(42);
+  });
+
+  test("allows an explicit domain zero", () => {
+    expect(parseEarningsNumber("0", "withdrawable_balance")).toBe(0);
+    expect(parseEarningsNumber("0.000000", "withdrawable_balance")).toBe(0);
+  });
+
+  test("throws on null / undefined instead of fabricating 0", () => {
+    expect(() => parseEarningsNumber(null, "payout_threshold")).toThrow(/payout_threshold/);
+    expect(() => parseEarningsNumber(undefined, "withdrawable_balance")).toThrow(
+      /withdrawable_balance/,
+    );
+  });
+
+  test("throws on empty / whitespace-only instead of fabricating 0", () => {
+    expect(() => parseEarningsNumber("", "payout_threshold")).toThrow(/empty or missing/);
+    expect(() => parseEarningsNumber("   ", "withdrawable_balance")).toThrow(/empty or missing/);
+  });
+
+  test("REGRESSION: a corrupt value throws instead of becoming NaN (fail-open guard)", () => {
+    // This is the exact class the gates used to swallow: `Number("corrupt")` is
+    // NaN, and every `< NaN` comparison is false — a silently-open payout gate.
+    expect(Number("corrupt")).toBeNaN();
+    expect(() => parseEarningsNumber("corrupt", "payout_threshold")).toThrow(/not a finite number/);
+    expect(() => parseEarningsNumber("12.3.4", "withdrawable_balance")).toThrow(
+      /not a finite number/,
+    );
+    expect(() => parseEarningsNumber("Infinity", "payout_threshold")).toThrow(
+      /not a finite number/,
+    );
+    expect(() => parseEarningsNumber("NaN", "withdrawable_balance")).toThrow(/not a finite number/);
+  });
+});
+
+describe("AppEarningsRepository.processWithdrawal fail-closed gate wiring", () => {
+  const repo = new AppEarningsRepository();
+
+  afterEach(() => {
+    // bun:test restores spies via mock.restore between files; explicit for safety.
+  });
+
+  function stubEarnings(overrides: Record<string, unknown>) {
+    return {
+      id: "e1",
+      app_id: "app-1",
+      total_lifetime_earnings: "500.000000",
+      total_inference_earnings: "0.000000",
+      total_purchase_earnings: "500.000000",
+      pending_balance: "0.000000",
+      withdrawable_balance: "500.000000",
+      total_withdrawn: "0.000000",
+      last_withdrawal_at: null,
+      payout_threshold: "25.00",
+      created_at: new Date(),
+      updated_at: new Date(),
+      ...overrides,
+    } as never;
+  }
+
+  test("healthy row: sub-threshold amount is rejected (gate holds)", async () => {
+    const spy = spyOn(repo, "findByAppId").mockResolvedValue(stubEarnings({}));
+    const result = await repo.processWithdrawal("app-1", 10); // below 25.00 threshold
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/at least \$25\.00/);
+    spy.mockRestore();
+  });
+
+  test("corrupt payout_threshold FAILS CLOSED (throws) instead of allowing a sub-threshold payout", async () => {
+    const spy = spyOn(repo, "findByAppId").mockResolvedValue(
+      stubEarnings({ payout_threshold: "corrupt" }),
+    );
+    // Before the fix: Number("corrupt") = NaN, `10 < NaN` false, the minimum
+    // payout gate is bypassed and a $10 payout below the $25 floor proceeds to
+    // the DB write. Now it must throw at the read boundary.
+    await expect(repo.processWithdrawal("app-1", 10)).rejects.toThrow(/payout_threshold/);
+    spy.mockRestore();
+  });
+
+  test("corrupt withdrawable_balance FAILS CLOSED (throws) instead of bypassing the balance pre-check", async () => {
+    const spy = spyOn(repo, "findByAppId").mockResolvedValue(
+      stubEarnings({ withdrawable_balance: "corrupt", payout_threshold: "0.00" }),
+    );
+    // Before the fix: Number("corrupt") = NaN, `NaN < amount` false, the
+    // insufficient-balance pre-check is bypassed. Now it throws first.
+    await expect(repo.processWithdrawal("app-1", 1000)).rejects.toThrow(/withdrawable_balance/);
+    spy.mockRestore();
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/app-earnings-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/app-earnings-numeric.ts
@@ -1,0 +1,32 @@
+/**
+ * Numeric parsing boundary for app-earnings rows that gate money-out (payout /
+ * withdrawal) decisions.
+ *
+ * Postgres NUMERIC fields arrive as strings. A corrupt value (driver quirk,
+ * migration artifact, or manual DB edit) must throw instead of silently
+ * becoming `NaN`, because the withdrawal gates compare against these values:
+ *
+ *   - `amount < threshold`      → `amount < NaN` is always false → the minimum
+ *                                 payout gate is BYPASSED (a sub-threshold
+ *                                 payout is allowed). This gate has NO
+ *                                 DB-level backstop.
+ *   - `withdrawable < amount`   → `NaN < amount` is always false → the
+ *                                 insufficient-balance pre-check is BYPASSED.
+ *
+ * Failing closed here surfaces the corruption before an unbacked or
+ * sub-threshold payout is authorized.
+ */
+
+export function parseEarningsNumber(
+  value: string | number | null | undefined,
+  fieldName: string,
+): number {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    throw new Error(`Unable to read app earnings ${fieldName}: value is empty or missing`);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Unable to read app earnings ${fieldName}: value is not a finite number`);
+  }
+  return parsed;
+}

--- a/packages/cloud/shared/src/db/repositories/app-earnings.ts
+++ b/packages/cloud/shared/src/db/repositories/app-earnings.ts
@@ -9,6 +9,7 @@ import {
   type NewAppEarnings,
   type NewAppEarningsTransaction,
 } from "../schemas/app-earnings";
+import { parseEarningsNumber } from "./app-earnings-numeric";
 
 export type { AppEarnings, AppEarningsTransaction, NewAppEarnings, NewAppEarningsTransaction };
 
@@ -351,8 +352,10 @@ export class AppEarningsRepository {
       };
     }
 
-    const withdrawable = Number(earnings.withdrawable_balance);
-    const threshold = Number(earnings.payout_threshold);
+    // error-policy:J1 corrupt NUMERIC must throw, not become NaN — `amount < NaN`
+    // and `NaN < amount` are both false, which would fail the payout gates OPEN.
+    const withdrawable = parseEarningsNumber(earnings.withdrawable_balance, "withdrawable_balance");
+    const threshold = parseEarningsNumber(earnings.payout_threshold, "payout_threshold");
 
     if (amount < threshold) {
       return {
@@ -388,7 +391,12 @@ export class AppEarningsRepository {
 
     if (!updated) {
       const current = await this.findByAppId(appId);
-      const currentWithdrawable = Number(current?.withdrawable_balance ?? 0);
+      // error-policy:J1 the DB predicate already denied the debit; report the
+      // live balance but never let a corrupt NUMERIC surface as "NaN".
+      const currentWithdrawable =
+        current === undefined
+          ? 0
+          : parseEarningsNumber(current.withdrawable_balance, "withdrawable_balance");
       return {
         success: false,
         earnings: current ?? earnings,
@@ -428,7 +436,11 @@ export class AppEarningsRepository {
           });
         }
 
-        const threshold = Number(earnings.payout_threshold);
+        // error-policy:J1 corrupt NUMERIC threshold must throw, not become NaN
+        // (`amount < NaN` is false → the minimum-payout gate fails OPEN). This
+        // runs before the idempotency-key insert, so a corrupt row aborts the
+        // transaction with no phantom claim.
+        const threshold = parseEarningsNumber(earnings.payout_threshold, "payout_threshold");
         if (amount < threshold) {
           throw new WithdrawalRollback({
             success: false,
@@ -462,7 +474,12 @@ export class AppEarningsRepository {
           const current = await tx.query.appEarnings.findFirst({
             where: eq(appEarnings.app_id, appId),
           });
-          const currentWithdrawable = Number(current?.withdrawable_balance ?? 0);
+          // error-policy:J1 DB predicate already denied the debit; report the
+          // live balance but never surface a corrupt NUMERIC as "NaN".
+          const currentWithdrawable =
+            current === undefined
+              ? 0
+              : parseEarningsNumber(current.withdrawable_balance, "withdrawable_balance");
           throw new WithdrawalRollback({
             success: false,
             earnings: current ?? earnings,


### PR DESCRIPTION
Successor slice under the cloud-shared DB-repository fallback-slop sweep (#13416). Distinct file/scope from my prior usage-quota slice (#13454).

## Bug: fail-open money-out gate

`app-earnings.ts` withdrawal gates read `payout_threshold` and `withdrawable_balance` (both `notNull` Postgres NUMERIC, arriving as strings) through a bare `Number(...)`. A corrupt value (driver quirk / migration artifact / manual DB edit) becomes `NaN`, and every `< NaN` comparison is false, so the gates **failed OPEN**:

- `amount < threshold` → a sub-threshold payout passes the minimum-payout floor. This gate has **no DB-level backstop** (unlike the balance debit, which the `gte(withdrawable_balance, amount)` predicate protects race-safely).
- `withdrawable < amount` → the insufficient-balance pre-check is bypassed.

## Fix (fail closed)

New `app-earnings-numeric.ts` boundary `parseEarningsNumber(value, fieldName)` — throws on null/undefined/empty/whitespace and on any non-finite parse, allows an explicit domain zero. Wired into all four withdrawal-gate reads across `processWithdrawal` and `processIdempotentWithdrawal`.

In the idempotent path the throw happens **before** the idempotency-key insert, so a corrupt row rolls the transaction back with no phantom claim; the plain-`Error` throw propagates past the `WithdrawalRollback`-only catch and fails loud rather than fabricating a successful payout. Mirrors the established `parseUsageQuotaNumber` pattern from #13454.

Read-only display aggregations (`getEarningsSummary` / `getDailyEarnings`, `Number(row.total)` on `COALESCE(SUM(...), 0)`) are left as-is — never null, not money-out gates, out of scope for this fail-closed slice.

## Tests — `__tests__/app-earnings-numeric.test.ts` (9/9)

- Parser: well-formed string, numeric literal, explicit zero, null/undefined, empty/whitespace, and a **regression** proving corrupt values (`"corrupt"`, `"12.3.4"`, `"Infinity"`, `"NaN"`) throw instead of becoming `NaN`.
- Gate wiring (stubbed `findByAppId`, no DB needed — Postgres/PGlite won't store a corrupt NUMERIC): healthy sub-threshold rejection still holds; corrupt `payout_threshold` **throws** instead of allowing a $10 payout under the $25 floor; corrupt `withdrawable_balance` **throws** instead of bypassing the balance pre-check.

## Gates

- `bun run typecheck` (tsgo): 0 errors in touched files (17 remaining are pre-existing baseline noise — `@elizaos/auth` symlink resolution, node-redis-adapter, plugin-mcp/json, anthropic-web-search — identical on `origin/develop`).
- `bunx @biomejs/biome check <touched>`: clean.
- `bun run audit:error-policy-ratchet`: no new fallback-slop in touched files.
- `codex review --uncommitted`: clean — "I did not identify any introduced correctness, security, or maintainability issues that warrant an inline finding."

Evidence: `.github/issue-evidence/13416-cloud-shared-db-app-earnings-payout-fail-closed.md`. Issue stays open for the remaining ~47-file repo inventory.

— [sol-orch]