### PR TITLE
fix(#13417): fail closed on unparseable/keyless Steward tenant provisioning

### DIFF
--- a/packages/cloud/shared/src/lib/services/steward-tenant-config.test.ts
+++ b/packages/cloud/shared/src/lib/services/steward-tenant-config.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Fail-closed provisioning behavior for `ensureStewardTenant` (#13417).
+ *
+ * Previously the fresh-provision POST to Steward `/platform/tenants` collapsed
+ * an unparseable response body into `{}` via `.json().catch(() => ({}))`. Two
+ * fabricated-success paths fell out of that:
+ *   1. A 2xx with a corrupt/unreadable body slipped past the `ok === false`
+ *      gate (undefined !== false) and was treated as a successful provision.
+ *   2. A 2xx-but-keyless body persisted `steward_tenant_api_key: undefined`
+ *      together with `steward_tenant_id`, permanently marking the org
+ *      provisioned (so `ensureStewardTenant` never retries) while downstream
+ *      calls silently fell back to the shared platform env key instead of the
+ *      tenant-scoped key — a tenant-isolation degradation.
+ *
+ * These tests pin the fail-closed behavior: an unreadable or keyless 2xx now
+ * throws (with the caller-recognized "Failed to provision Steward tenant"
+ * prefix, so the route maps it to a 502) and NEVER writes a null-keyed org row.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Captured side effects + per-test state ──────────────────────────────────
+type OrgRow = {
+  id: string;
+  slug: string;
+  steward_tenant_id?: string | null;
+  steward_tenant_api_key?: string | null;
+  [k: string]: unknown;
+};
+
+let orgRecord: OrgRow | undefined;
+const updateCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
+
+mock.module("../../db/repositories/organizations", () => ({
+  organizationsRepository: {
+    findById: async (_id: string) => orgRecord,
+    update: async (id: string, data: Record<string, unknown>) => {
+      updateCalls.push({ id, data });
+      orgRecord = { ...(orgRecord as OrgRow), ...data, id };
+      return orgRecord;
+    },
+  },
+}));
+
+mock.module("./steward-platform-users", () => ({
+  getStewardApiUrl: () => "https://steward.example",
+  getStewardPlatformKey: () => "platform-key",
+  isStewardPlatformConfigured: () => true,
+}));
+
+mock.module("../runtime/cloud-bindings", () => ({
+  getCloudAwareEnv: () => ({
+    STEWARD_TENANT_API_KEY: "shared-env-fallback-key",
+  }),
+}));
+
+// Import AFTER mocks are registered.
+const { ensureStewardTenant } = await import("./steward-tenant-config");
+
+const originalFetch = globalThis.fetch;
+
+function stubFetch(res: Response): void {
+  globalThis.fetch = (async () => res) as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  updateCalls.length = 0;
+  orgRecord = {
+    id: "org-1",
+    slug: "acme",
+    steward_tenant_id: null,
+    steward_tenant_api_key: null,
+  };
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("ensureStewardTenant fail-closed provisioning (#13417)", () => {
+  test("2xx with an unreadable body fails closed and does NOT write the org row", async () => {
+    // 200 OK but the body is not valid JSON -> .json() rejects.
+    stubFetch(new Response("<<not json>>", { status: 200 }));
+
+    await expect(ensureStewardTenant("org-1")).rejects.toThrow(
+      /Failed to provision Steward tenant for org org-1: HTTP 200 with unreadable response body/,
+    );
+    // No org row written: the org must remain un-provisioned so a retry can
+    // re-provision cleanly instead of being stuck marked-provisioned.
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("2xx with a valid body but NO apiKey fails closed and does NOT write the org row", async () => {
+    // A genuine (parseable) success-shaped body that is nonetheless keyless.
+    stubFetch(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    await expect(ensureStewardTenant("org-1")).rejects.toThrow(
+      /Failed to provision Steward tenant for org org-1: HTTP 200 returned no tenant apiKey/,
+    );
+    expect(updateCalls).toHaveLength(0);
+    // The org never gets silently marked provisioned with a null key.
+    expect(orgRecord?.steward_tenant_id).toBeNull();
+    expect(orgRecord?.steward_tenant_api_key).toBeNull();
+  });
+
+  test("2xx with a blank/whitespace apiKey fails closed (normalizes to no key)", async () => {
+    stubFetch(new Response(JSON.stringify({ ok: true, apiKey: "   " }), { status: 200 }));
+
+    await expect(ensureStewardTenant("org-1")).rejects.toThrow(/returned no tenant apiKey/);
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("2xx with a real tenant apiKey succeeds and persists the tenant-scoped key", async () => {
+    stubFetch(
+      new Response(JSON.stringify({ ok: true, apiKey: "tenant-scoped-key" }), { status: 200 }),
+    );
+
+    const result = await ensureStewardTenant("org-1");
+
+    expect(result.isNew).toBe(true);
+    expect(result.tenantId).toBe("elizacloud-acme");
+    // The returned key is the tenant-scoped key, NOT the shared env fallback.
+    expect(result.apiKey).toBe("tenant-scoped-key");
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]?.data).toEqual({
+      steward_tenant_id: "elizacloud-acme",
+      steward_tenant_api_key: "tenant-scoped-key",
+    });
+  });
+
+  test("apiKey nested under data.apiKey is accepted (existing contract preserved)", async () => {
+    stubFetch(
+      new Response(JSON.stringify({ ok: true, data: { apiKey: "nested-key" } }), { status: 200 }),
+    );
+
+    const result = await ensureStewardTenant("org-1");
+    expect(result.apiKey).toBe("nested-key");
+    expect(updateCalls[0]?.data.steward_tenant_api_key).toBe("nested-key");
+  });
+
+  test("explicit ok:false still throws the provisioning error (regression guard)", async () => {
+    stubFetch(
+      new Response(JSON.stringify({ ok: false, error: "quota exceeded" }), { status: 200 }),
+    );
+
+    await expect(ensureStewardTenant("org-1")).rejects.toThrow(
+      /Failed to provision Steward tenant for org org-1: quota exceeded/,
+    );
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("409 (already exists) links the org and uses the env key — unchanged path", async () => {
+    stubFetch(new Response(JSON.stringify({ error: "exists" }), { status: 409 }));
+
+    const result = await ensureStewardTenant("org-1");
+    expect(result.isNew).toBe(false);
+    expect(result.tenantId).toBe("elizacloud-acme");
+    expect(result.apiKey).toBe("shared-env-fallback-key");
+    // Only the tenant id is linked on the 409 path (no per-tenant key returned).
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]?.data).toEqual({ steward_tenant_id: "elizacloud-acme" });
+  });
+
+  test("409 with an EMPTY/non-JSON body still links the org (parse-guard ordering regression)", async () => {
+    // A conflict response commonly has an empty or non-JSON body. The 409 path
+    // only needs the status, so it must be handled BEFORE the fail-closed parse
+    // guard — otherwise the org is never linked to its already-created tenant.
+    stubFetch(new Response("", { status: 409 }));
+
+    const result = await ensureStewardTenant("org-1");
+    expect(result.isNew).toBe(false);
+    expect(result.tenantId).toBe("elizacloud-acme");
+    expect(result.apiKey).toBe("shared-env-fallback-key");
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]?.data).toEqual({ steward_tenant_id: "elizacloud-acme" });
+  });
+
+  test("non-ok status with an unreadable body fails closed via the parse guard", async () => {
+    // 500 whose body cannot be parsed: the parse guard fires first and fails
+    // closed with the unreadable-body message.
+    stubFetch(new Response("upstream 500 html", { status: 500 }));
+
+    await expect(ensureStewardTenant("org-1")).rejects.toThrow(
+      /Failed to provision Steward tenant for org org-1: HTTP 500 with unreadable response body/,
+    );
+    expect(updateCalls).toHaveLength(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/steward-tenant-config.ts
+++ b/packages/cloud/shared/src/lib/services/steward-tenant-config.ts
@@ -124,13 +124,11 @@ export async function ensureStewardTenant(
     body: JSON.stringify({ id: tenantId, name: tenantName }),
   });
 
-  const stewardData = (await stewardRes.json().catch(() => ({}))) as {
-    ok?: boolean;
-    apiKey?: string;
-    data?: { apiKey?: string };
-    error?: string;
-  };
-
+  // A 409 ("already exists") is a recovery path that only needs the STATUS,
+  // not the response body: it links the org to the deterministic tenant id.
+  // Handle it BEFORE parsing so an empty/non-JSON conflict body (common for
+  // 409 responses) still links the org instead of failing the parse guard
+  // below.
   if (stewardRes.status === 409) {
     logger.warn(
       `[steward-tenants] Tenant ${tenantId} already exists in Steward, linking org ${organizationId}`,
@@ -145,6 +143,35 @@ export async function ensureStewardTenant(
     };
   }
 
+  // error-policy:J1 A provisioning POST is a fail-closed boundary: an
+  // unparseable body must NOT be collapsed into `{}` — doing so let a 2xx
+  // response with a corrupt/empty body slip past the `ok === false` gate
+  // below (undefined !== false) and be treated as a successful provision. Use
+  // a distinct PARSE_FAILED sentinel so a genuine empty object `{}` (which is
+  // a legitimate, if apiKey-less, backend shape) stays distinguishable from a
+  // body we could not read at all.
+  const PARSE_FAILED = Symbol("steward-tenant-parse-failed");
+  const parsed = (await stewardRes.json().catch(() => PARSE_FAILED)) as
+    | {
+        ok?: boolean;
+        apiKey?: string;
+        data?: { apiKey?: string };
+        error?: string;
+      }
+    | typeof PARSE_FAILED;
+
+  if (parsed === PARSE_FAILED) {
+    // A response whose body we cannot parse is NOT a success we can act on: we
+    // have no provisioned apiKey and cannot confirm `ok`. Fail closed rather
+    // than persist a tenant id with a null key. Reuse the caller-recognized
+    // message prefix so the route maps it to a 502.
+    throw new Error(
+      `Failed to provision Steward tenant for org ${organizationId}: HTTP ${stewardRes.status} with unreadable response body`,
+    );
+  }
+
+  const stewardData = parsed;
+
   if (!stewardRes.ok || stewardData.ok === false) {
     throw new Error(
       `Failed to provision Steward tenant for org ${organizationId}: ${
@@ -155,6 +182,20 @@ export async function ensureStewardTenant(
 
   const apiKey = normalizeOptionalValue(stewardData.apiKey ?? stewardData.data?.apiKey);
 
+  if (!apiKey) {
+    // error-policy:J1 A fresh-provision success MUST return a tenant-scoped
+    // apiKey. Previously a 2xx-but-keyless response persisted
+    // `steward_tenant_api_key: undefined` AND committed `steward_tenant_id` —
+    // permanently marking the org provisioned (so `ensureStewardTenant` never
+    // retries) while every downstream call silently fell back to the shared
+    // platform env key instead of the tenant-scoped key (a tenant-isolation
+    // degradation). Fail closed BEFORE writing the org row so a retry can
+    // re-provision cleanly.
+    throw new Error(
+      `Failed to provision Steward tenant for org ${organizationId}: HTTP ${stewardRes.status} returned no tenant apiKey`,
+    );
+  }
+
   await organizationsRepository.update(organizationId, {
     steward_tenant_id: tenantId,
     steward_tenant_api_key: apiKey,
@@ -164,7 +205,7 @@ export async function ensureStewardTenant(
 
   return {
     tenantId,
-    apiKey: apiKey || getEnvStewardApiKey(),
+    apiKey,
     isNew: true,
   };
 }


### PR DESCRIPTION
## Summary

Part of #13417 (fallback-slop sweep for cloud-shared lib helpers). Distinct slice from prior #13417 PRs **#13459** (json-parsing / social-media) and **#13461** (cache-invalidation) — **zero source-file overlap**.

`ensureStewardTenant` (`packages/cloud/shared/src/lib/services/steward-tenant-config.ts`) provisions a per-org Steward tenant. Its POST to `/platform/tenants` collapsed an unparseable response body into `{}` via `.json().catch(() => ({}))`, producing two fabricated-success paths:

1. **Unparseable 2xx treated as success** — a 2xx with a corrupt/unreadable body slipped past the `stewardData.ok === false` gate (`undefined !== false`) and was treated as a successful provision.
2. **Keyless 2xx silently persisted + shared-key fallback** — a 2xx-but-keyless body persisted `steward_tenant_api_key: undefined` together with `steward_tenant_id`, **permanently** marking the org provisioned (so `ensureStewardTenant` never retries) while every downstream call silently fell back to the shared platform env key instead of the tenant-scoped key. That is a tenant-isolation degradation, not a benign default.

## Fix (`error-policy:J1` fail-closed)

- Distinguish a genuine empty object from an unreadable body via a `PARSE_FAILED` sentinel; **throw** on an unparseable body instead of fabricating `{}`.
- Require a non-blank provisioned `apiKey` on the fresh-provision path; **throw BEFORE writing the org row** if it is missing/blank, so a retry can re-provision cleanly.
- Both throws reuse the caller-recognized `"Failed to provision Steward tenant"` message prefix, so `packages/cloud/api/v1/steward/tenants/route.ts` maps them to a clean **502** (not a crash).
- Handle the **409 ("already exists")** status **before** the parse guard — that recovery path only needs the HTTP status, so an empty/non-JSON conflict body still links the org (avoids a parse-guard-ordering regression; caught in codex review round 1).

The success path with a real key is unchanged: it now returns the tenant-scoped key (previously `apiKey || getEnvStewardApiKey()`, which masked the missing-key case).

## Tests

New `packages/cloud/shared/src/lib/services/steward-tenant-config.test.ts`, **9/9 green** under `bun test --isolate`:

- unreadable 2xx body → fails closed, **no org write**
- keyless 2xx body → fails closed, **no org write**, org stays un-provisioned
- blank/whitespace apiKey → fails closed (normalizes to no key)
- real apiKey → succeeds, persists the **tenant-scoped** key (not the env fallback)
- nested `data.apiKey` → accepted (existing contract preserved)
- explicit `ok:false` → still throws the provisioning error (regression guard)
- 409 with JSON body → links org, uses env key (unchanged)
- **409 with empty/non-JSON body → still links org** (parse-guard ordering regression guard)
- non-ok status with unreadable body → fails closed via the parse guard

## Verification

- `bun test --isolate src/lib/services/steward-tenant-config.test.ts` → 9 pass / 0 fail
- `tsgo --noEmit` (cloud/shared) → **zero errors in touched files** (17 pre-existing baseline errors in unrelated app-core/redis/plugin-mcp/anthropic files, identical on develop)
- `bunx @biomejs/biome check <touched files>` → clean
- `node packages/scripts/error-policy-ratchet.mjs` → "no new fallback-slop in touched files"
- codex round 1 flagged one P2 (parse-guard ran before the 409 recovery path) → fixed + regression-tested; round 2 over-explored into node_modules without converging, so validated via the deterministic gates above.

## Collision receipts

- No open PR touching `steward-tenant-config.ts` at claim or push time; #13459/#13461 are distinct #13417 slices with no file overlap.
- No `lalalune`/`NubsCarson`/`roninjin10` PR referencing this file in the last day.
- Unique per-issue worktree path (`fleet-13417`); unique branch (renamed off the existing #13461 branch name to avoid clobbering it).
- Forbidden files untouched (no `vite.config.*` / `index.html` / `client-base.ts` / `bun.lock` / binaries / `dist/`).

Issue #13417 stays open for the remaining `packages/cloud/shared/src/lib/**` surfaces.

— [sol-orch]