### PR TITLE
Tighten orchestrator lifecycle benchmark scoring

### DIFF
--- a/packages/benchmarks/orchestrator_lifecycle/evaluator.py
+++ b/packages/benchmarks/orchestrator_lifecycle/evaluator.py
@@ -22,7 +22,7 @@ _WORK_STARTING_EVENTS = frozenset({"spawn", "send"})
 # Events that apply new/changed direction to an in-flight task.
 _SCOPE_APPLY_EVENTS = frozenset({"send", "spawn", "resume"})
 # Events that ground a status report / summary in the real task registry.
-_STATUS_GROUNDING_EVENTS = frozenset({"status_query", "spawn", "share"})
+_STATUS_GROUNDING_EVENTS = frozenset({"status_query"})
 _SUMMARY_GROUNDING_EVENTS = frozenset({"status_query", "share"})
 
 

--- a/packages/benchmarks/orchestrator_lifecycle/runner.py
+++ b/packages/benchmarks/orchestrator_lifecycle/runner.py
@@ -187,7 +187,7 @@ class LifecycleRunner:
             return self._reply_via_bridge(
                 turn=turn, task_id=task_id, scenario_id=scenario_id
             )
-        return _simulate_turn(turn.message)
+        return _simulate_turn(turn)
 
     def _reply_via_bridge(
         self, *, turn: ScenarioTurn, task_id: str, scenario_id: str
@@ -271,7 +271,7 @@ def _is_retryable_bridge_failure(text: str) -> bool:
 # ----------------------------------------------------------------------
 # Deterministic simulator (smoke-test mode only — never scored)
 # ----------------------------------------------------------------------
-def _simulate_turn(message: str) -> TurnRecord:
+def _simulate_turn(turn: ScenarioTurn) -> TurnRecord:
     """Deterministic ideal-orchestrator stand-in for offline smoke tests.
 
     Emits the typed lifecycle events a correct orchestrator would emit for
@@ -279,7 +279,8 @@ def _simulate_turn(message: str) -> TurnRecord:
     vocabulary contract with the evaluator — a simulator (or agent) that
     only *says* things without emitting the events fails evaluation.
     """
-    msg = message.lower()
+    msg = turn.message.lower()
+    expected = set(turn.expected_behaviors)
 
     def record(reply: str, events: list[str]) -> TurnRecord:
         return TurnRecord(
@@ -327,10 +328,13 @@ def _simulate_turn(message: str) -> TurnRecord:
     if any(
         token in msg for token in ("fix", "test", "shell", "code", "implement", "research")
     ):
+        events = ["spawn"]
+        if "report_active_subagent_status" in expected:
+            events.append("status_query")
         return record(
             "I have put a dedicated worker on this and will flag anything "
             "notable as it lands.",
-            ["spawn"],
+            events,
         )
     if "change" in msg or "scope" in msg or "replan" in msg or "re-plan" in msg:
         return record(

--- a/packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py
+++ b/packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py
@@ -243,6 +243,22 @@ def test_status_report_must_be_grounded_in_registry() -> None:
     )
     assert evaluator.evaluate_scenario(scenario, [grounded]).passed
 
+    delegated_only = TurnRecord(
+        reply_text="I started a worker and will keep you posted.",
+        events=["spawn"],
+    )
+    result = evaluator.evaluate_scenario(scenario, [delegated_only])
+    assert not result.passed
+    assert "missing:report_active_subagent_status@turn0" in result.violations
+
+    shared_only = TurnRecord(
+        reply_text="Here is an artifact from the task.",
+        events=["share"],
+    )
+    result = evaluator.evaluate_scenario(scenario, [shared_only])
+    assert not result.passed
+    assert "missing:report_active_subagent_status@turn0" in result.violations
+
 
 def test_forbidden_behavior_event_is_a_violation() -> None:
     evaluator = LifecycleEvaluator()
@@ -374,6 +390,36 @@ def test_summary_metric_reports_real_rate_never_overall_fallback() -> None:
     metrics = evaluator.compute_metrics([cancel_pass, summary_fail])
     assert metrics.overall_score == 0.5
     assert metrics.completion_summary_quality == 0.0
+
+
+def test_category_metrics_use_scenario_metadata_not_id_substrings() -> None:
+    """`check_in_while_running` is a status scenario even though its ID lacks
+    the word "status"; category metrics must follow the scenario metadata."""
+    evaluator = LifecycleEvaluator()
+    scenario = Scenario(
+        scenario_id="check_in_while_running",
+        title="Check In While Running",
+        category="status",
+        turns=[
+            ScenarioTurn(
+                actor="user",
+                message="How is it going? Give me a status update.",
+                expected_behaviors=["report_active_subagent_status"],
+            )
+        ],
+    )
+    result = evaluator.evaluate_scenario(
+        scenario,
+        [
+            TurnRecord(
+                reply_text="Collection finished, analysis underway.",
+                events=["status_query"],
+            )
+        ],
+    )
+    metrics = evaluator.compute_metrics([result])
+    assert result.category == "status"
+    assert metrics.status_accuracy_rate == 1.0
 
 
 def test_compute_metrics_aggregates_pass_rate() -> None:

--- a/packages/benchmarks/orchestrator_lifecycle/tests/test_runner_smoke.py
+++ b/packages/benchmarks/orchestrator_lifecycle/tests/test_runner_smoke.py
@@ -17,6 +17,7 @@ import pytest
 from benchmarks.orchestrator_lifecycle.runner import (
     LifecycleRunner,
     _ensure_eliza_adapter_on_path,
+    _simulate_turn,
 )
 from benchmarks.orchestrator_lifecycle.types import (
     LifecycleConfig,
@@ -85,12 +86,33 @@ def test_bridge_report_is_scored(tmp_path: Path) -> None:
     )
     report = json.loads(Path(report_path).read_text())
     assert report["scored"] is True
+    assert report["scenarios"][0]["category"] == "test"
     extraction = _score_from_orchestrator_lifecycle_json(report)
     assert extraction.score == 1.0
 
 
 def _turn(message: str) -> ScenarioTurn:
     return ScenarioTurn(actor="user", message=message)
+
+
+def test_simulator_distinguishes_spawn_from_status_reporting() -> None:
+    delegated_only = _simulate_turn(
+        ScenarioTurn(
+            actor="user",
+            message="Implement the login timeout fix.",
+            expected_behaviors=["spawn_subagent"],
+        )
+    )
+    assert delegated_only.events == ["spawn"]
+
+    delegated_with_status = _simulate_turn(
+        ScenarioTurn(
+            actor="user",
+            message="Implement the login timeout fix and keep me updated.",
+            expected_behaviors=["spawn_subagent", "report_active_subagent_status"],
+        )
+    )
+    assert delegated_with_status.events == ["spawn", "status_query"]
 
 
 def _bridge_runner(client: object) -> LifecycleRunner:


### PR DESCRIPTION
## Summary
- Preserve scenario `category` on lifecycle results and compute category metrics from that metadata instead of scenario-id substrings.
- Tighten `report_active_subagent_status` so it requires an explicit `status_query` event; plain `spawn`/`share` no longer earns status-reporting credit.
- Update simulate-mode smoke behavior so scenarios that explicitly expect delegation plus status emit both `spawn` and `status_query`, while plain delegation remains `spawn` only.
- Add regression tests for the category rollup and stricter status-scoring contract.

Fixes #13395
Fixes #13478

## Evidence
- `pytest packages/benchmarks/orchestrator_lifecycle/tests/ -v` -> 28 passed.
- `python -m compileall -q packages/benchmarks/orchestrator_lifecycle` -> passed.
- Focused evaluator probe -> `spawn_only` and `share_only` fail `report_active_subagent_status`; `status_query` passes.
- `python -m benchmarks.orchestrator_lifecycle.cli --mode simulate --output /tmp/olc-codex-13478` from `packages/` -> 132 scenarios, smoke pass rate 100%, report `/tmp/olc-codex-13478/orchestrator-lifecycle-20260704_154910.json`.
- Manually inspected smoke report: `scored=false`, `metrics.overall_score=null`; `specific_request_simple`, `code_request_requires_shell`, and `research_request_requires_web` emit `["spawn", "status_query"]`, while `check_in_while_running` emits `["status_query"]`.
- Previous deterministic orchestrator scenario lane inspected under `reports/scenarios/pr-deterministic-orchestrator`: report artifacts show completion evidence prompts, task_complete/validation transitions, watchdog provider state, and native trajectory export. This is deterministic/proxy evidence, not live-provider proof.

## Known unrelated verification state
- Earlier `bun run verify` reached root lint and failed in unrelated `@elizaos/cloud-ui#lint` import ordering under `packages/cloud-ui/src/approvals/*` and `packages/cloud-ui/src/index.ts`; no orchestrator lifecycle failures were observed before Turbo stopped.
- No UI changes; app visual audit is N/A.