### PR TITLE
ci: retarget test.yml to self-hosted hetzner fleet (hosted runners billing-frozen)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
     name: Server Tests
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.server == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 60
     env:
       PGLITE_WASM_MODE: node
@@ -235,7 +235,7 @@ jobs:
     name: Client Tests
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.client == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -338,7 +338,7 @@ jobs:
     name: XR harness e2e
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.plugins == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -396,7 +396,7 @@ jobs:
     name: Plugin Tests (${{ matrix.shard }}/4)
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.plugins == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 95
     strategy:
       fail-fast: false
@@ -479,7 +479,7 @@ jobs:
       - changes
       - plugin-tests
     if: ${{ !cancelled() && always() }}
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     steps:
       - name: Check plugin shard results
         shell: bash
@@ -510,7 +510,7 @@ jobs:
     name: Integration Lane (personal-assistant)
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.plugins == 'true' || needs.changes.outputs.server == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 45
     env:
       PGLITE_WASM_MODE: node
@@ -548,7 +548,7 @@ jobs:
     name: Electrobun Desktop Contract
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.desktop == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -578,7 +578,7 @@ jobs:
     name: Zero-Key unit + UI coverage
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 30
     env:
       TEST_LANE: "pr"
@@ -638,7 +638,7 @@ jobs:
     name: Zero-Key app browser
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 35
     env:
       TEST_LANE: "pr"
@@ -713,7 +713,7 @@ jobs:
     name: Zero-Key diagnostics
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 30
     env:
       TEST_LANE: "pr"
@@ -772,7 +772,7 @@ jobs:
     name: Zero-Key scenario runner
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 30
     env:
       TEST_LANE: "pr"
@@ -841,7 +841,7 @@ jobs:
     name: Zero-Key harness E2E
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 15
     env:
       TEST_LANE: "pr"
@@ -897,7 +897,7 @@ jobs:
       - zero-key-scenario-runner
       - zero-key-harness-e2e
     if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true')
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     steps:
       - name: Check zero-key slices
         shell: bash
@@ -927,7 +927,7 @@ jobs:
     name: Cloud Live E2E (Eliza Cloud)
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.cloud == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 60
     outputs:
       skip: ${{ steps.cloud.outputs.skip }}
@@ -1056,7 +1056,7 @@ jobs:
 
   provider-live-e2e:
     name: Remote Capability Provider Live E2E
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 45
     outputs:
       skip: ${{ steps.providers.outputs.skip }}
@@ -1179,7 +1179,7 @@ jobs:
       - cloud-live-e2e
       - provider-live-e2e
     if: always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && (needs.cloud-live-e2e.outputs.capability_skip != 'true' || needs.provider-live-e2e.outputs.skip != 'true')
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1233,7 +1233,7 @@ jobs:
       - cloud-live-e2e
       - provider-live-e2e
       - github-live-artifact-validate
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     steps:
       - name: Check test results
         shell: bash


### PR DESCRIPTION
## Why

The org's GitHub-hosted Actions runners (`ubuntu-24.04`) are **billing-frozen** — every hosted job queues forever. `develop`'s ruleset (`18511845`) requires the `ci-ok` aggregate status from `test.yml`. Today only the `changes` (Classify changed paths) job runs on the self-hosted `[self-hosted, hetzner-robot]` fleet; **every other job in `test.yml` is `runs-on: ubuntu-24.04` → frozen → `ci-ok` never reports**. The merge queue is blocked.

This is a **chicken-and-egg**: this CI-restore PR can't pass frozen CI either. It is verified locally (YAML lint + dedup contract) and will be **admin-merged** (authorized), then validated by re-running a real PR's Tests workflow and watching jobs land on self-hosted runners until `ci-ok` reports.

## What changed

Retarget **only `test.yml`**: all 17 `runs-on: ubuntu-24.04` jobs → `runs-on: [self-hosted, hetzner-robot]` (the `changes` job already runs there). No ruleset, billing, app code, or other workflow touched. `ci-ok`'s `needs:` list and non-vacuous strict-results logic are **unchanged** — the gate still hard-requires typecheck/unit/integration/e2e; nothing is made vacuously green.

## Job-by-job inventory (job → runner change → env risk on shared fleet)

All 26 runners share **one physical box** (`eliza-staging-robot-1`), system `node 24` / `bash` / `git`, working dir `/opt/actions-runners/runner-N/_work`. `install-native-deps` is already `false` on every test job; the protoc/apt steps in `setup-bun-workspace` self-check `command -v protoc` first (no-op if preinstalled).

| Job | Change | Env risk on self-hosted |
|---|---|---|
| `changes` | already self-hosted | none (node-only) |
| `server-tests` | → self-hosted | **docker** step (`test:remote-capabilities:docker`) needs a reachable daemon; TUI mock server uses ephemeral port 0 (safe) |
| `client-tests` | → self-hosted | `playwright install --with-deps chromium` runs `sudo apt` for browser libs — **fails without passwordless sudo / preinstalled libs** |
| `xr-harness-e2e` | → self-hosted | same playwright `--with-deps` risk |
| `plugin-tests` (4 shards) | → self-hosted | rust + **protoc**; `CARGO_TARGET_DIR` is workspace-local (per-runner, no cross-job collision); 4 shards concurrent = heaviest load |
| `plugin-tests-status` | → self-hosted | trivial aggregator |
| `integration-tests` | → self-hosted | pglite (node WASM), turbo build; no third-party services |
| `desktop-contract` | → self-hosted | electrobun contract; `build:core` |
| `zero-key-unit-coverage` | → self-hosted | keyless vitest; no browser/services |
| `zero-key-browser` | → self-hosted | `playwright install --with-deps chromium webkit` — **highest sudo-apt risk** (2 engines) |
| `zero-key-diagnostics` | → self-hosted | keyless vitest; no browser |
| `zero-key-scenario-runner` | → self-hosted | keyless deterministic e2e (LLM proxy), turbo build |
| `zero-key-harness-e2e` | → self-hosted | mock-LLM fixtures; no services |
| `zero-key-e2e` | → self-hosted | trivial aggregator over the 5 zero-key slices |
| `cloud-live-e2e` | → self-hosted | short-circuits `skip=true` on PRs w/o `ELIZAOS_CLOUD_API_KEY` before any heavy step |
| `provider-live-e2e` | → self-hosted | short-circuits `skip=true` on PRs w/o provider endpoint secrets |
| `github-live-artifact-validate` | → self-hosted | only observed on `workflow_dispatch`/`schedule`; skip allowed on PR by `ci-ok` |
| `ci-ok` | → self-hosted | aggregate gate (unchanged logic) |

## Shared-box hazards (called out honestly)

- **One physical machine** hosts all 26 runners. A single PR now spawns ~12–15 self-hosted jobs (vs. 1 today). Expect deep queueing under load; jobs **queue**, they don't fail. Run-level `concurrency` already cancels superseded PR runs.
- Shared `HOME` caches (`~/.bun/install/cache`, `~/.cargo`) across concurrent jobs on the box — pre-existing to the fleet's setup (the `changes` job already shares HOME).
- **Most likely failure points on first real run:** `playwright install --with-deps` (sudo-apt) in `client-tests` / `zero-key-browser` / `xr-harness-e2e`, and the docker smoke in `server-tests`. If the fleet lacks passwordless sudo or a docker daemon, follow-up commits (admin, `test.yml`-only) will drop `--with-deps` where libs are preinstalled or narrow those steps, keeping typecheck + unit + integration as hard `ci-ok` requirements.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses.
- `node packages/scripts/ci-workflow-dedup-contract.mjs` — **passed** (branches, `ci-ok` name, merge_group bypass all intact).
- Post-merge: re-run a real PR's Tests workflow, confirm jobs pick up on `[self-hosted, hetzner-robot]` and `ci-ok` reports.

— [sol-orch]
