### PR TITLE
fix(#13416): fail closed on corrupt org credit_balance in agent-billing

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-numeric.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Fail-closed NUMERIC boundary for agent-billing organization `credit_balance`
+ * reads (#13416, cloud-shared DB-repository fallback-slop sweep).
+ *
+ * Postgres NUMERIC arrives as a string. Before this slice the balance was read
+ * through a bare `Number(...)`, so a corrupt value became `NaN` and downstream
+ * consumers FAILED OPEN:
+ *
+ *   - `getOrganizationCreditBalance` returned `NaN` (not `null`) as an
+ *     authoritative balance. The hourly-billing cron does
+ *     `liveBalance = (await getOrgBalance(org)) ?? currentBalance` — `??` does
+ *     NOT catch `NaN` — then gates on `liveBalance >= hourlyCost` and renders
+ *     the value into the low-credit warning email/webhook as `$NaN`.
+ *   - `recordHourlyBilling` derived the post-debit warning status from
+ *     `newBalance < lowCreditWarningAmount ? "warning" : "active"`; a `NaN`
+ *     balance makes that comparison always false, silently SUPPRESSING the
+ *     low-credit "warning" status so the org keeps billing as "active" past its
+ *     threshold with no signal.
+ *
+ * The parser suite pins the boundary exhaustively (deterministic, no DB). The
+ * PGlite wiring test proves `getOrganizationCreditBalance` routes a real read
+ * through the parser (healthy path) and returns `null` — not a fabricated 0 —
+ * for a genuinely-missing org. A corrupt NUMERIC cannot be *stored* in
+ * Postgres/PGlite, so the corrupt-read fail-closed behavior is proven at the
+ * parser boundary the method calls (see the NaN-regression case below), which
+ * is exactly the read-time driver-quirk / migration-artifact failure mode this
+ * guards.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+// PGlite isolation harness (mirrors agent-billing-reactivation.test.ts): the
+// wiring suite self-skips LOUDLY against a shared non-PGlite Postgres.
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
+import { organizations } from "../../schemas/organizations";
+import { agentBillingRepository } from "../agent-billing";
+import { parseOrgCreditBalance } from "../agent-billing-numeric";
+
+describe("parseOrgCreditBalance", () => {
+  test("parses a well-formed NUMERIC string", () => {
+    expect(parseOrgCreditBalance("25.00")).toBe(25);
+    expect(parseOrgCreditBalance("100.500000")).toBe(100.5);
+  });
+
+  test("parses a numeric literal", () => {
+    expect(parseOrgCreditBalance(0)).toBe(0);
+    expect(parseOrgCreditBalance(42)).toBe(42);
+  });
+
+  test("allows an explicit domain zero (a legitimately depleted org)", () => {
+    expect(parseOrgCreditBalance("0")).toBe(0);
+    expect(parseOrgCreditBalance("0.000000")).toBe(0);
+  });
+
+  test("allows a negative balance (orgs can go negative between billing cycles)", () => {
+    expect(parseOrgCreditBalance("-5.00")).toBe(-5);
+  });
+
+  test("throws on null / undefined instead of fabricating 0", () => {
+    expect(() => parseOrgCreditBalance(null)).toThrow(/credit_balance/);
+    expect(() => parseOrgCreditBalance(undefined)).toThrow(/empty or missing/);
+  });
+
+  test("throws on empty / whitespace-only instead of fabricating 0", () => {
+    expect(() => parseOrgCreditBalance("")).toThrow(/empty or missing/);
+    expect(() => parseOrgCreditBalance("   ")).toThrow(/empty or missing/);
+  });
+
+  test("REGRESSION: a corrupt value throws instead of becoming NaN (fail-open guard)", () => {
+    // This is the exact class the billing paths used to swallow: `Number("corrupt")`
+    // is NaN, `NaN >= hourlyCost` and `NaN < warningAmount` are both false — a
+    // silently-open billing gate + suppressed low-credit warning.
+    expect(Number("corrupt")).toBeNaN();
+    expect(() => parseOrgCreditBalance("corrupt")).toThrow(/not a finite number/);
+    expect(() => parseOrgCreditBalance("12.3.4")).toThrow(/not a finite number/);
+    expect(() => parseOrgCreditBalance("Infinity")).toThrow(/not a finite number/);
+    expect(() => parseOrgCreditBalance("NaN")).toThrow(/not a finite number/);
+  });
+
+  test("honors a caller-supplied field name in the error", () => {
+    expect(() => parseOrgCreditBalance(null, "new_balance")).toThrow(/new_balance/);
+  });
+});
+
+describe("AgentBillingRepository.getOrganizationCreditBalance fail-closed wiring", () => {
+  const PGLITE_TIMEOUT = 60_000;
+  let pgliteReady = true;
+
+  let seq = 0;
+  const uniq = (prefix: string): string => {
+    seq += 1;
+    return `${prefix}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+  };
+
+  beforeAll(async () => {
+    if (!CAN_USE_ISOLATED_PGLITE) {
+      pgliteReady = false;
+      console.warn(
+        "[agent-billing-numeric.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite wiring suite self-skips — pushSchema against a shared connection crashes the bun runner and would mutate the shared schema. Parser suite above still runs.",
+      );
+      return;
+    }
+    try {
+      const schema = { organizations };
+      const { apply } = await pushSchema(schema as never, dbWrite as never);
+      await apply();
+    } catch (error) {
+      pgliteReady = false;
+      console.error(
+        "[agent-billing-numeric.test] PGlite/pushSchema unavailable — cannot drive AgentBillingRepository against a real DB. Skipping wiring cases.",
+        error,
+      );
+    }
+  }, PGLITE_TIMEOUT);
+
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    await dbWrite.delete(organizations);
+  });
+
+  afterAll(async () => {
+    await closeDatabaseConnectionsForTests();
+  });
+
+  test("a real credit_balance read routes through the parser (healthy path)", async () => {
+    if (!pgliteReady) return;
+    const [org] = await dbWrite
+      .insert(organizations)
+      .values({ name: "Billing Org", slug: uniq("org"), credit_balance: "123.450000" })
+      .returning();
+
+    const balance = await agentBillingRepository.getOrganizationCreditBalance(org.id);
+    expect(balance).toBe(123.45);
+    expect(Number.isFinite(balance as number)).toBe(true);
+  });
+
+  test("a genuinely-missing org returns null — NOT a fabricated 0", async () => {
+    if (!pgliteReady) return;
+    const balance = await agentBillingRepository.getOrganizationCreditBalance(
+      "00000000-0000-0000-0000-000000000000",
+    );
+    expect(balance).toBeNull();
+  });
+
+  test("an explicit zero balance reads as 0, distinguishable from a missing org's null", async () => {
+    if (!pgliteReady) return;
+    const [org] = await dbWrite
+      .insert(organizations)
+      .values({ name: "Depleted Org", slug: uniq("org"), credit_balance: "0" })
+      .returning();
+
+    const balance = await agentBillingRepository.getOrganizationCreditBalance(org.id);
+    expect(balance).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/agent-billing-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-billing-numeric.ts
@@ -1,0 +1,37 @@
+/**
+ * Numeric parsing boundary for agent-billing rows that read an organization's
+ * `credit_balance` and expose it as an authoritative money figure.
+ *
+ * Postgres NUMERIC fields arrive as strings. A corrupt value (driver quirk,
+ * migration artifact, or manual DB edit) must throw instead of silently
+ * becoming `NaN`, because the balance flows into decisions that FAIL OPEN on
+ * `NaN`:
+ *
+ *   - The hourly-billing cron treats the returned number as the live balance
+ *     and gates a shutdown-warning skip on `liveBalance >= hourlyCost`. A `NaN`
+ *     balance is not `null`, so the `?? currentBalance` fallback does not catch
+ *     it, and it is also rendered into the low-credit warning email / webhook
+ *     as `$NaN` (fabricated user-facing data).
+ *   - `recordHourlyBilling` derives the post-debit warning status from
+ *     `newBalance < lowCreditWarningAmount ? "warning" : "active"`. With a `NaN`
+ *     balance that comparison is always false, so the low-credit **warning**
+ *     status is silently suppressed and the org keeps billing as "active" past
+ *     its warning threshold with no signal.
+ *
+ * Failing closed here surfaces the corruption instead of propagating a `NaN`
+ * that masquerades as a real balance.
+ */
+
+export function parseOrgCreditBalance(
+  value: string | number | null | undefined,
+  fieldName = "credit_balance",
+): number {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    throw new Error(`Unable to read organization ${fieldName}: value is empty or missing`);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Unable to read organization ${fieldName}: value is not a finite number`);
+  }
+  return parsed;
+}

--- a/packages/cloud/shared/src/db/repositories/agent-billing.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-billing.ts
@@ -9,6 +9,7 @@ import {
 import { creditTransactions } from "../schemas/credit-transactions";
 import { organizationBilling } from "../schemas/organization-billing";
 import { organizations } from "../schemas/organizations";
+import { parseOrgCreditBalance } from "./agent-billing-numeric";
 
 export interface AgentBillingSandbox {
   id: string;
@@ -58,7 +59,12 @@ export class AgentBillingRepository {
       .from(organizations)
       .where(eq(organizations.id, organizationId));
 
-    return org ? Number(org.credit_balance) : null;
+    // Fail closed on a corrupt NUMERIC read: returning `Number(...) = NaN` here
+    // would masquerade as a real balance and flow into the cron billing gate
+    // (`liveBalance >= hourlyCost`, where `NaN` is not caught by `?? fallback`)
+    // and into user-facing warning emails/webhooks as `$NaN`. A genuinely
+    // missing org still returns `null` (caller treats it as unknown).
+    return org ? parseOrgCreditBalance(org.credit_balance) : null;
   }
 
   async listBillableSandboxes(
@@ -228,7 +234,12 @@ export class AgentBillingRepository {
         return { status: "insufficient_credits" as const };
       }
 
-      const newBalance = Number(updatedOrg.credit_balance);
+      // Fail closed on a corrupt post-debit balance: a `NaN` here would make
+      // `newBalance < lowCreditWarningAmount` always false and silently suppress
+      // the low-credit "warning" status, letting the org keep billing as
+      // "active" past its threshold. The debit already committed, so surfacing
+      // the corruption is the safe outcome (the transaction rolls back on throw).
+      const newBalance = parseOrgCreditBalance(updatedOrg.credit_balance);
       const [creditTx] = await tx
         .insert(creditTransactions)
         .values({


### PR DESCRIPTION
## Problem

Part of the #13416 cloud-shared DB-repository fallback-slop sweep.

`AgentBillingRepository` read an organization's `credit_balance` (Postgres `NUMERIC`, arrives as a **string**) through a bare `Number(...)`, so a corrupt value (driver quirk / migration artifact / manual DB edit surfacing at read time) became `NaN` and the billing paths **failed open**:

- **`getOrganizationCreditBalance`** returned `NaN` — not `null` — as an authoritative balance. The hourly-billing cron does `liveBalance = (await getOrgBalance(org)) ?? currentBalance`; `??` does **not** catch `NaN`. It then gates a shutdown-warning skip on `liveBalance >= hourlyCost` and renders the value into the low-credit warning **email/webhook** as `$NaN` (fabricated user-facing data).
- **`recordHourlyBilling`** derived the post-debit warning status from `newBalance < lowCreditWarningAmount ? "warning" : "active"`. With `NaN` that comparison is always false, so the low-credit **"warning"** status is silently **suppressed** and the org keeps billing as `"active"` past its threshold with no signal.

## Fix

New `parseOrgCreditBalance` fail-closed boundary (`agent-billing-numeric.ts`) — throws on missing/empty/non-finite, allows explicit domain zero and negative balances — wired into both reads.

In `recordHourlyBilling` the throw happens **inside** `dbWrite.transaction`, so the just-committed debit **rolls back** (no phantom charge) and the corruption surfaces loudly. A genuinely-missing org still returns `null` (caller treats it as unknown).

Only the repository (DB-repo) boundary is touched; the route-level `Number(org.credit_balance)` in `packages/cloud/api/cron/agent-billing/route.ts` belongs to the cloud-api boundary sweep and is out of scope here.

## Tests

`agent-billing-numeric.test.ts` — **11/11 green**:
- 8 parser cases: well-formed / numeric literal / domain-zero / negative / null+undefined / empty+whitespace / **NaN-regression** (`corrupt`/`12.3.4`/`Infinity`/`NaN` throw) / caller field-name.
- 3 PGlite wiring cases: a real read routes through the parser (healthy path), a missing org returns `null` **not** a fabricated 0, an explicit zero reads as 0.

Also verified:
- Sibling `agent-billing-reactivation.test.ts` **2/2 green** (no regression).
- `tsgo --noEmit`: **0 new errors** in touched files (17 pre-existing baseline errors elsewhere, identical on `develop`).
- biome clean; `audit:error-policy-ratchet` — **no new fallback-slop in touched files**.
- codex over-explored the repo without converging (documented behavior); validated via the deterministic gates above.

Distinct from #13454 (usage-quotas), #13474 (app-earnings), #13137 (credit_balance), and the concurrent `container-billing` slice.

— [sol-orch]
