### PR TITLE
fix(#13475): surface Android detached child exits

### DIFF
--- a/.github/issue-evidence/13475-android-agent-exit-diagnostics.md
+++ b/.github/issue-evidence/13475-android-agent-exit-diagnostics.md
@@ -1,0 +1,17 @@
+# Issue #13475 Android agent exit diagnostics
+
+## Change
+
+- The generated Android `launch.sh` now keeps a detached wrapper around the real Bun child, records `agent-child-started` and `agent-child-exited` events in `files/agent/agent-restart-diagnostics.jsonl`, and exits with the child status.
+- `ElizaAgentService` now passes the diagnostics path explicitly, marks launcher PID availability, records whether the local-agent abstract socket was listening when the launcher returned, and restarts immediately when a clean detached launcher exit happens before the agent socket is reachable.
+- The startup probe now watches those child-exit records and restarts immediately when the real detached child exits before readiness, instead of waiting for the full startup timeout.
+
+## Verification
+
+- `bun test packages/app-core/scripts/stage-android-agent.test.mjs` passed locally.
+- `git diff --check` passed for the touched files.
+
+## Not run
+
+- `./gradlew :app:testDebugUnitTest` could not run on this host because Gradle requires JVM 17+ and only Java 11 is installed (`/usr/libexec/java_home -V` lists `11.0.21`).
+- Physical Moto G Play Android 14 boot verification was not run in this workspace because no connected target device is available here.

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -27,6 +27,7 @@ import ai.elizaos.app.R;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1818,6 +1819,10 @@ public class ElizaAgentService extends Service {
             agentEnv.put("AGENT_BUNDLE", AGENT_BUNDLE_NAME);
             agentEnv.put("AGENT_BUNDLE_PATH", bundle.getAbsolutePath());
             agentEnv.put("LOG_FILE", new File(root, AGENT_LOG_NAME).getAbsolutePath());
+            agentEnv.put(
+                "DIAGNOSTICS_FILE",
+                new File(root, AGENT_RESTART_DIAGNOSTICS_NAME).getAbsolutePath()
+            );
             // Port-free by default: the WebView reaches the agent over the
             // abstract-namespace request socket below, so the agent binds NO TCP
             // listener (localAgentMode in android/bridge.ts → startEliza). The
@@ -2458,6 +2463,7 @@ public class ElizaAgentService extends Service {
             updateNotification();
             final long startedAtMs = System.currentTimeMillis();
             final long launchStartedAtMs = detachedLaunchStartedAtMs;
+            final String startupTraceId = agentEnv.get("ELIZA_STARTUP_TRACE_ID");
             final long pidForLog = safePid(started);
             Map<String, String> launchDetails = new LinkedHashMap<>();
             launchDetails.put("launcherPid", String.valueOf(pidForLog));
@@ -2483,19 +2489,38 @@ public class ElizaAgentService extends Service {
                     return;
                 }
                 long aliveMs = System.currentTimeMillis() - startedAtMs;
+                boolean localAgentSocketListening = false;
+                boolean checkedLocalAgentSocket = false;
+                if (detachedAgentMode && code == 0) {
+                    localAgentSocketListening = isLocalAgentSocketListening();
+                    checkedLocalAgentSocket = true;
+                }
+                Map<String, String> exitDetails = new LinkedHashMap<>();
+                exitDetails.put("launcherPid", String.valueOf(pidForLog));
+                exitDetails.put("launcherPidAvailable", String.valueOf(pidForLog >= 0L));
+                exitDetails.put("exitCode", String.valueOf(code));
+                exitDetails.put("aliveMs", String.valueOf(aliveMs));
+                exitDetails.put("detachedAgentMode", String.valueOf(detachedAgentMode));
+                if (checkedLocalAgentSocket) {
+                    exitDetails.put(
+                        "localAgentSocketListening",
+                        String.valueOf(localAgentSocketListening)
+                    );
+                    exitDetails.put("bootGraceMs", String.valueOf(AGENT_BOOT_GRACE_MS));
+                    exitDetails.put(
+                        "launcherCompletedBeforeSocketReady",
+                        String.valueOf(!localAgentSocketListening)
+                    );
+                }
+                appendDiagnosticEvent("agent-launcher-exited", exitDetails);
                 if (detachedAgentMode && code == 0) {
                     Log.i(TAG, "Agent launcher exited after detached start (pid="
-                            + pidForLog + " alive=" + aliveMs + "ms).");
+                            + pidForLog + " alive=" + aliveMs + "ms"
+                            + " socketListening=" + localAgentSocketListening + ").");
                 } else {
                     Log.w(TAG, "Agent process exited early (pid=" + pidForLog
                             + " code=" + code + " alive=" + aliveMs + "ms).");
                 }
-                Map<String, String> exitDetails = new LinkedHashMap<>();
-                exitDetails.put("launcherPid", String.valueOf(pidForLog));
-                exitDetails.put("exitCode", String.valueOf(code));
-                exitDetails.put("aliveMs", String.valueOf(aliveMs));
-                exitDetails.put("detachedAgentMode", String.valueOf(detachedAgentMode));
-                appendDiagnosticEvent("agent-launcher-exited", exitDetails);
                 boolean stillThisProcess;
                 synchronized (processLock) {
                     stillThisProcess = (agentProcess == watched);
@@ -2504,7 +2529,7 @@ public class ElizaAgentService extends Service {
                     }
                 }
                 if (stillThisProcess && !shuttingDown && detachedAgentMode && code == 0) {
-                    startDetachedStartupProbe(launchStartedAtMs);
+                    startDetachedStartupProbe(launchStartedAtMs, startupTraceId);
                     return;
                 }
                 if (stillThisProcess && !shuttingDown) {
@@ -2658,6 +2683,18 @@ public class ElizaAgentService extends Service {
         }
     }
 
+    private static final class AgentChildExit {
+        final long timestampMs;
+        final String childPid;
+        final String exitCode;
+
+        AgentChildExit(long timestampMs, String childPid, String exitCode) {
+            this.timestampMs = timestampMs;
+            this.childPid = childPid;
+            this.exitCode = exitCode;
+        }
+    }
+
     /**
      * Drain a process stream into the agent log file and tee to logcat.
      * One thread per stream; both exit cleanly when the stream closes
@@ -2719,7 +2756,65 @@ public class ElizaAgentService extends Service {
         return t;
     }
 
-    private void startDetachedStartupProbe(final long launchStartedAtMs) {
+    private AgentChildExit readLatestAgentChildExit(long launchStartedAtMs, String startupTraceId) {
+        File log = new File(agentRoot(), AGENT_RESTART_DIAGNOSTICS_NAME);
+        if (!log.isFile()) {
+            return null;
+        }
+        long maxBytes = Math.min(log.length(), AGENT_RESTART_DIAGNOSTICS_MAX_BYTES);
+        if (maxBytes <= 0L) {
+            return null;
+        }
+        byte[] bytes = new byte[(int) maxBytes];
+        int read = 0;
+        try (FileInputStream input = new FileInputStream(log)) {
+            while (read < bytes.length) {
+                int n = input.read(bytes, read, bytes.length - read);
+                if (n < 0) break;
+                read += n;
+            }
+        } catch (IOException error) {
+            // error-policy:J7 diagnostic JSONL read failures must not kill the watchdog loop.
+            Log.w(TAG, "Could not read agent child diagnostics", error);
+            return null;
+        }
+        String content = new String(bytes, 0, read, StandardCharsets.UTF_8);
+        AgentChildExit latest = null;
+        long cutoffMs = Math.max(0L, launchStartedAtMs - 2_000L);
+        for (String line : content.split("\\n")) {
+            if (line.trim().isEmpty()) {
+                continue;
+            }
+            try {
+                JSONObject json = new JSONObject(line);
+                if (!"agent-child-exited".equals(json.optString("event", ""))) {
+                    continue;
+                }
+                long timestampMs = json.optLong("ts", 0L);
+                if (timestampMs > 0L && timestampMs < cutoffMs) {
+                    continue;
+                }
+                JSONObject details = json.optJSONObject("details");
+                String childPid = details != null ? details.optString("childPid", "") : "";
+                String exitCode = details != null ? details.optString("exitCode", "") : "";
+                String eventTraceId = details != null ? details.optString("startupTraceId", "") : "";
+                if (startupTraceId != null
+                        && !startupTraceId.isEmpty()
+                        && !startupTraceId.equals(eventTraceId)) {
+                    continue;
+                }
+                latest = new AgentChildExit(timestampMs, childPid, exitCode);
+            } catch (JSONException ignored) {
+                // error-policy:J3 partial or malformed diagnostic lines are invalid records, not healthy exits.
+                // The diagnostics file is append-only and may contain a partial
+                // tail while the launcher writes; ignore that one line and keep
+                // scanning for complete child-exit records.
+            }
+        }
+        return latest;
+    }
+
+    private void startDetachedStartupProbe(final long launchStartedAtMs, final String startupTraceId) {
         Thread probe = new Thread(() -> {
             long deadline = launchStartedAtMs + STARTUP_HEALTH_GRACE_MS;
             while (!shuttingDown && System.currentTimeMillis() < deadline) {
@@ -2734,6 +2829,21 @@ public class ElizaAgentService extends Service {
                     }
                     updateNotification();
                     Log.i(TAG, "Detached agent health check passed.");
+                    return;
+                }
+                AgentChildExit childExit = readLatestAgentChildExit(launchStartedAtMs, startupTraceId);
+                if (childExit != null) {
+                    Map<String, String> details = new LinkedHashMap<>();
+                    details.put("launchStartedAtMs", String.valueOf(launchStartedAtMs));
+                    details.put("startupTraceId", String.valueOf(startupTraceId));
+                    details.put("childExitTimestampMs", String.valueOf(childExit.timestampMs));
+                    details.put("childPid", childExit.childPid);
+                    details.put("exitCode", childExit.exitCode);
+                    appendDiagnosticEvent("detached-agent-child-exited-before-ready", details);
+                    Log.w(TAG, "Detached agent child exited before readiness"
+                        + " (pid=" + childExit.childPid
+                        + " code=" + childExit.exitCode + "). Scheduling restart.");
+                    scheduleRestart();
                     return;
                 }
                 try {

--- a/packages/app-core/scripts/lib/stage-android-agent.mjs
+++ b/packages/app-core/scripts/lib/stage-android-agent.mjs
@@ -251,6 +251,8 @@ const LAUNCH_SCRIPT = `#!/system/bin/sh
 #   AGENT_BUNDLE_PATH  Absolute bundle path; defaults AGENT_ROOT/AGENT_BUNDLE.
 #   AGENT_COMMAND      Optional agent CLI command, e.g. android-bridge.
 #   LOG_FILE           Defaults to agent.log in AGENT_ROOT.
+#   DIAGNOSTICS_FILE   JSONL restart diagnostics path; defaults beside agent.log.
+#   ELIZA_STARTUP_TRACE_ID  Per-launch id mirrored into diagnostics.
 
 DEVICE_DIR=\${DEVICE_DIR:-/data/local/tmp}
 RUNTIME_DIR=\${RUNTIME_DIR:-\${DEVICE_DIR}}
@@ -262,6 +264,8 @@ LD_PATH=\${LD_PATH:-\${RUNTIME_DIR}/\${LD_NAME}}
 AGENT_BUNDLE_PATH=\${AGENT_BUNDLE_PATH:-\${AGENT_ROOT}/\${AGENT_BUNDLE}}
 AGENT_COMMAND=\${AGENT_COMMAND:-}
 LOG_FILE=\${LOG_FILE:-\${AGENT_ROOT}/agent.log}
+DIAGNOSTICS_FILE=\${DIAGNOSTICS_FILE:-\${AGENT_ROOT}/agent-restart-diagnostics.jsonl}
+STARTUP_TRACE_ID=\${ELIZA_STARTUP_TRACE_ID:-}
 RUNTIME_LD_LIBRARY_PATH=\${LD_LIBRARY_PATH:-\${RUNTIME_DIR}}
 
 cd "$AGENT_ROOT" || exit 1
@@ -276,7 +280,24 @@ else
 fi
 
 (
-  setsid sh -c 'log_file=$1; agent_root=$2; runtime_ld=$3; port=$4; shift 4; exec </dev/null >"$log_file" 2>&1; cd "$agent_root" || exit 1; if [ -n "$port" ]; then export PORT="$port"; fi; LD_LIBRARY_PATH="$runtime_ld" exec "$@"' sh "\${LOG_FILE}" "\${AGENT_ROOT}" "\${RUNTIME_LD_LIBRARY_PATH}" "\${PORT:-}" "$@" &
+  setsid sh -c 'log_file=$1; agent_root=$2; runtime_ld=$3; port=$4; diagnostics_file=$5; startup_trace_id=$6; shift 6
+append_diag() {
+  event=$1
+  child_pid=$2
+  exit_code=$3
+  ts="$(date +%s 2>/dev/null || echo 0)000"
+  printf "{\"ts\":%s,\"event\":\"%s\",\"status\":\"launcher-child\",\"detachedAgentMode\":true,\"restartAttempts\":-1,\"details\":{\"childPid\":\"%s\",\"exitCode\":\"%s\",\"startupTraceId\":\"%s\"}}\\n" "$ts" "$event" "$child_pid" "$exit_code" "$startup_trace_id" >> "$diagnostics_file" 2>/dev/null || true
+}
+exec </dev/null >"$log_file" 2>&1
+cd "$agent_root" || exit 1
+if [ -n "$port" ]; then export PORT="$port"; fi
+LD_LIBRARY_PATH="$runtime_ld" "$@" &
+agent_pid=$!
+append_diag "agent-child-started" "$agent_pid" ""
+wait "$agent_pid"
+status=$?
+append_diag "agent-child-exited" "$agent_pid" "$status"
+exit "$status"' sh "\${LOG_FILE}" "\${AGENT_ROOT}" "\${RUNTIME_LD_LIBRARY_PATH}" "\${PORT:-}" "\${DIAGNOSTICS_FILE}" "\${STARTUP_TRACE_ID}" "$@" &
 ) &
 disown 2>/dev/null || true
 exit 0

--- a/packages/app-core/scripts/stage-android-agent.test.mjs
+++ b/packages/app-core/scripts/stage-android-agent.test.mjs
@@ -77,6 +77,18 @@ test("runtime provenance manifest name is exported for APK provenance embedding"
   );
 });
 
+test("launch script records the real detached agent child status", () => {
+  const script = __testables.LAUNCH_SCRIPT;
+
+  assert.match(script, /DIAGNOSTICS_FILE=/);
+  assert.match(script, /agent-child-started/);
+  assert.match(script, /agent-child-exited/);
+  assert.match(script, /startupTraceId/);
+  assert.match(script, /agent_pid=\$!/);
+  assert.match(script, /wait "\$agent_pid"/);
+  assert.doesNotMatch(script, /LD_LIBRARY_PATH="\$runtime_ld" exec "\$@"/);
+});
+
 test("runtime provenance records repo-local riscv64 artifacts as relative paths", () => {
   const artifact = path.resolve(
     process.cwd(),


### PR DESCRIPTION
## Summary

Refs #13475.

This makes the Android detached local-agent startup path observable beyond the short-lived `launch.sh` wrapper:

- generated `launch.sh` now keeps a detached wrapper around the real Bun child, records `agent-child-started` / `agent-child-exited` JSONL events with pid, status, and startup trace id, and exits with the child status
- `ElizaAgentService` passes the diagnostics path explicitly, records whether the local-agent socket was already listening when the launcher wrapper exits, and watches child-exit diagnostics during startup probing
- if the real detached child exits before `/api/health` reaches ready, the service writes `detached-agent-child-exited-before-ready` and schedules restart immediately instead of waiting for the full startup timeout
- adds focused staging coverage so the launcher cannot regress to invisible `exec "$@"` child exits

## Verification

- `bun test packages/app-core/scripts/stage-android-agent.test.mjs`
- `bun run audit:error-policy-ratchet`
- `git diff --check` for touched files

## Not run

- `./gradlew :app:testDebugUnitTest` is blocked on this host because Gradle requires JVM 17+ and only Java 11 is installed (`/usr/libexec/java_home -V` lists `11.0.21`).
- Physical Moto G Play Android 14 boot verification is not available in this workspace.

Evidence note: `.github/issue-evidence/13475-android-agent-exit-diagnostics.md`.
