### PR TITLE
fix(#13416): fail closed on corrupt container-billing NUMERIC reads

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/container-billing-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/container-billing-numeric.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Fail-closed NUMERIC boundary for the container daily-billing transaction
+ * (#13416, cloud-shared DB-repository fallback-slop sweep).
+ *
+ * Postgres NUMERIC arrives as a string. Before this slice
+ * `recordSuccessfulDailyBilling` read `containers.total_billed` and
+ * `organizations.credit_balance` through a bare `Number(...)`, so a corrupt
+ * value became `NaN` and poisoned the billing write path:
+ *
+ *   - `total_billed`  → `String(Number(total_billed) + dailyCost)` = `"NaN"`,
+ *                       written back into the NUMERIC column. That either
+ *                       rolls back the whole billing transaction with a cryptic
+ *                       driver cast error (container never billed, cron retries
+ *                       forever = silent free hosting) or persists a corrupt
+ *                       running total.
+ *   - `credit_balance` → the returned `newBalance` becomes `NaN` and is shown
+ *                        verbatim: the low-balance email renders `$NaN`, and
+ *                        `lowerOrgBalanceHint`/logs record a garbage figure.
+ *
+ * A real corrupt NUMERIC cannot be stored in PGlite/Postgres (they reject it),
+ * so the healthy-path regression coverage lives in the PGlite-backed
+ * container-billing-idempotency suite (it asserts a finite `newBalance` and a
+ * correctly-accumulated `total_billed`). These tests pin the PARSER boundary
+ * exhaustively and prove each wired read site delegates to it — which is the
+ * exact seam a read-time driver quirk / migration artifact would hit.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import * as numericModule from "../container-billing-numeric";
+import { parseContainerBillingNumber } from "../container-billing-numeric";
+
+describe("parseContainerBillingNumber", () => {
+  test("parses a well-formed NUMERIC string", () => {
+    expect(parseContainerBillingNumber("50.00", "total_billed")).toBe(50);
+    expect(parseContainerBillingNumber("1234.567890", "credit_balance")).toBe(1234.56789);
+  });
+
+  test("parses a numeric literal", () => {
+    expect(parseContainerBillingNumber(0, "credit_balance")).toBe(0);
+    expect(parseContainerBillingNumber(42, "total_billed")).toBe(42);
+  });
+
+  test("allows an explicit domain zero (a brand-new container / zeroed balance)", () => {
+    expect(parseContainerBillingNumber("0", "total_billed")).toBe(0);
+    expect(parseContainerBillingNumber("0.00", "total_billed")).toBe(0);
+    expect(parseContainerBillingNumber("0.000000", "credit_balance")).toBe(0);
+  });
+
+  test("throws on null / undefined instead of fabricating 0", () => {
+    expect(() => parseContainerBillingNumber(null, "total_billed")).toThrow(/total_billed/);
+    expect(() => parseContainerBillingNumber(undefined, "credit_balance")).toThrow(
+      /credit_balance/,
+    );
+    expect(() => parseContainerBillingNumber(null, "total_billed")).toThrow(/empty or missing/);
+  });
+
+  test("throws on empty / whitespace-only instead of fabricating 0", () => {
+    expect(() => parseContainerBillingNumber("", "total_billed")).toThrow(/empty or missing/);
+    expect(() => parseContainerBillingNumber("   ", "credit_balance")).toThrow(/empty or missing/);
+  });
+
+  test("REGRESSION: a corrupt value throws instead of becoming NaN (fail-open guard)", () => {
+    // The exact class the write path used to swallow: Number("corrupt") is NaN,
+    // NaN + dailyCost is NaN, and String(NaN) = "NaN" poisons the NUMERIC write.
+    expect(Number("corrupt")).toBeNaN();
+    expect(() => parseContainerBillingNumber("corrupt", "total_billed")).toThrow(
+      /not a finite number/,
+    );
+    expect(() => parseContainerBillingNumber("12.3.4", "total_billed")).toThrow(
+      /not a finite number/,
+    );
+    expect(() => parseContainerBillingNumber("NaN", "credit_balance")).toThrow(
+      /not a finite number/,
+    );
+    expect(() => parseContainerBillingNumber("Infinity", "credit_balance")).toThrow(
+      /not a finite number/,
+    );
+    expect(() => parseContainerBillingNumber("-Infinity", "total_billed")).toThrow(
+      /not a finite number/,
+    );
+  });
+
+  test("error names the field so a corrupt column is diagnosable", () => {
+    expect(() => parseContainerBillingNumber("corrupt", "total_billed")).toThrow(
+      /container billing total_billed/,
+    );
+    expect(() => parseContainerBillingNumber("corrupt", "credit_balance")).toThrow(
+      /container billing credit_balance/,
+    );
+  });
+});
+
+describe("recordSuccessfulDailyBilling wires every NUMERIC read through the fail-closed parser", () => {
+  test("source pins all three read sites to parseContainerBillingNumber (no bare Number(...) survives)", () => {
+    // Grep-guard against a regression that reintroduces a bare `Number(<row
+    // field>)` read on the billing write path. Reads the actual source (not a
+    // transpiled Function.toString(), which can rename/reorder).
+    const repoPath = fileURLToPath(new URL("../container-billing.ts", import.meta.url));
+    const src = readFileSync(repoPath, "utf8");
+    expect(src).toContain("parseContainerBillingNumber(input.currentTotalBilled");
+    expect(src).toContain('parseContainerBillingNumber(org.credit_balance, "credit_balance")');
+    expect(src).toContain(
+      'parseContainerBillingNumber(updatedOrg.credit_balance, "credit_balance")',
+    );
+    // No bare Number(...) read of a corrupt-prone NUMERIC row field survives.
+    // `\bNumber\(` anchors on the global Number constructor, NOT the tail of
+    // the helper name `parseContainerBillingNumber(` (which contains "Number(").
+    expect(src).not.toMatch(/\bNumber\(\s*input\.currentTotalBilled/);
+    expect(src).not.toMatch(/\bNumber\(\s*org\.credit_balance/);
+    expect(src).not.toMatch(/\bNumber\(\s*updatedOrg\.credit_balance/);
+    // exported parser is the module's fail-closed boundary
+    expect(typeof numericModule.parseContainerBillingNumber).toBe("function");
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/container-billing-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/container-billing-numeric.ts
@@ -1,0 +1,41 @@
+/**
+ * Numeric parsing boundary for container-billing rows.
+ *
+ * Postgres NUMERIC columns (`containers.total_billed`,
+ * `organizations.credit_balance`) arrive as strings. Before this slice the
+ * daily-billing transaction read them through a bare `Number(...)`, so a
+ * corrupt value (driver quirk, migration artifact, or manual DB edit) silently
+ * became `NaN` and poisoned the billing write path:
+ *
+ *   - `total_billed`  → `String(Number(total_billed) + dailyCost)` becomes
+ *                       `"NaN"`. Writing `"NaN"` back into the NUMERIC column
+ *                       either throws a cryptic driver cast error that rolls
+ *                       back the ENTIRE billing transaction (the container is
+ *                       then never billed and the cron retries it forever =
+ *                       silent free hosting), or, on a lenient driver, persists
+ *                       a corrupt running total. Either way the failure is
+ *                       undiagnosable at the point it matters.
+ *   - `credit_balance` → the returned `newBalance` becomes `NaN` and is
+ *                        surfaced verbatim to the caller: the low-balance email
+ *                        renders `$NaN`, `lowerOrgBalanceHint`/logs record a
+ *                        garbage balance — a fabricated (nonsense) money figure
+ *                        shown to the user instead of a fail-closed error.
+ *
+ * Failing closed here surfaces the corruption with a field-named error BEFORE
+ * a corrupt total is written or a NaN balance is reported, so the per-container
+ * billing loop can isolate and report it instead of silently mis-billing.
+ */
+
+export function parseContainerBillingNumber(
+  value: string | number | null | undefined,
+  fieldName: string,
+): number {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    throw new Error(`Unable to read container billing ${fieldName}: value is empty or missing`);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Unable to read container billing ${fieldName}: value is not a finite number`);
+  }
+  return parsed;
+}

--- a/packages/cloud/shared/src/db/repositories/container-billing.ts
+++ b/packages/cloud/shared/src/db/repositories/container-billing.ts
@@ -5,6 +5,7 @@ import { containerBillingRecords, containers } from "../schemas/containers";
 import { creditTransactions } from "../schemas/credit-transactions";
 import { organizationBilling } from "../schemas/organization-billing";
 import { organizations } from "../schemas/organizations";
+import { parseContainerBillingNumber } from "./container-billing-numeric";
 
 export type ContainerBillingStatus = "active" | "warning" | "suspended" | "shutdown_pending";
 
@@ -187,7 +188,12 @@ export class ContainerBillingRepository {
           .from(organizations)
           .where(eq(organizations.id, input.organizationId));
         return {
-          newBalance: org ? Number(org.credit_balance) : input.newBalance,
+          // Row present but the NUMERIC read is corrupt → fail closed with a
+          // field-named error instead of returning a NaN balance. Row absent
+          // (org concurrently deleted) keeps the caller-computed fallback.
+          newBalance: org
+            ? parseContainerBillingNumber(org.credit_balance, "credit_balance")
+            : input.newBalance,
           transactionId: null,
           alreadyBilled: true,
         };
@@ -246,7 +252,12 @@ export class ContainerBillingRepository {
           billing_status: "active" as ContainerBillingStatus,
           shutdown_warning_sent_at: null,
           scheduled_shutdown_at: null,
-          total_billed: String(Number(input.currentTotalBilled) + input.dailyCost),
+          // Fail closed on a corrupt running total instead of writing "NaN"
+          // back into the NUMERIC column (which would poison every future
+          // billing run for this container via a rolled-back cast error).
+          total_billed: String(
+            parseContainerBillingNumber(input.currentTotalBilled, "total_billed") + input.dailyCost,
+          ),
           updated_at: input.now,
         })
         .where(eq(containers.id, input.containerId));
@@ -263,7 +274,12 @@ export class ContainerBillingRepository {
       });
 
       return {
-        newBalance: updatedOrg ? Number(updatedOrg.credit_balance) : input.newBalance,
+        // Fail closed on a corrupt post-decrement balance read rather than
+        // returning NaN (which the low-balance email would render as `$NaN`).
+        // Row absent keeps the caller-computed fallback.
+        newBalance: updatedOrg
+          ? parseContainerBillingNumber(updatedOrg.credit_balance, "credit_balance")
+          : input.newBalance,
         transactionId: creditTx.id,
         alreadyBilled: false,
       };


### PR DESCRIPTION
## What

Fail-closed slice of the #13416 cloud-shared DB-repository fallback-slop sweep, targeting **`packages/cloud/shared/src/db/repositories/container-billing.ts`** (distinct from the merged usage-quota #13454 / app-earnings #13474 slices and the concurrent sibling agent-billing #13482 / conversations #13483 slices — zero file overlap).

## The bug

`recordSuccessfulDailyBilling` read `containers.total_billed` and `organizations.credit_balance` (both Postgres NUMERIC → arrive as strings) through a bare `Number(...)`. A corrupt value (driver quirk, migration artifact, or manual DB edit) silently became `NaN` and poisoned the billing write path:

- **`total_billed`** → `String(Number(currentTotalBilled) + dailyCost)` = `"NaN"`, written back into the NUMERIC column. That either **rolls back the entire billing transaction** with a cryptic driver cast error (the container is then *never billed* and the cron retries it forever = silent free hosting), or, on a lenient driver, **persists a corrupt running total**.
- **`credit_balance`** (both the already-billed read and the post-decrement read) → the returned `newBalance` became `NaN` and was surfaced verbatim: the low-balance email renders `$NaN`, and `lowerOrgBalanceHint`/logs record a garbage figure.

## The fix

New co-located `parseContainerBillingNumber()` fail-closed boundary — throws a **field-named** error on null / empty / whitespace / non-finite, allows an explicit domain `0` — wired into all three reads. Row-absent branches keep the existing caller-computed fallback (`input.newBalance`); only a corrupt *value* fails closed. Mirrors the accepted `#13474` `app-earnings-numeric` slice pattern.

## Tests / evidence

- **`container-billing-numeric.test.ts` — 8/8 green:** parser exhaustive (well-formed string / numeric literal / explicit zero / null+undefined / empty+whitespace / **corrupt → throws not NaN** regression / field-named error) + a source **grep-guard** proving no bare `Number(<row field>)` read survives on the write path (`\bNumber\(` anchors on the constructor, not the helper's `...BillingNumber(` tail).
- **Healthy-path regression coverage** lives in the PGlite-backed `container-billing-idempotency` suite (asserts a *finite* `newBalance` and a correctly-accumulated `total_billed` across the gate + row-lock + concurrent-decrement paths). A real corrupt NUMERIC can't be stored in PGlite/Postgres, so the read-time corruption is guarded at the parser seam.
- **tsc (tsgo):** 0 new errors — 17 baseline errors are pre-existing (`@elizaos/auth/*` symlink-resolution + node-redis/plugin-mcp/anthropic drift), **stash-verified identical on pristine `origin/develop`**, none in touched files.
- **biome:** clean. **error-policy-ratchet:** clean (no new fallback-slop).

**N/A evidence:** no HTTP/DB-migration/auth/agent-trajectory surface — this is a pure DB-repository NUMERIC-read boundary. 2 pre-existing failures in the idempotency suite (the test's hand-written `credit_transactions` DDL is missing `settled_at`) are stash-verified identical on `origin/develop` — a harness DDL drift, orthogonal to this change.

Issue stays open for the remaining ~47-file DB-repository inventory.

— [sol-orch]