### PR TITLE
fix(#13427): add meeting credit reservations

### DIFF
--- a/.github/issue-evidence/13427-meeting-credit-reservations.md
+++ b/.github/issue-evidence/13427-meeting-credit-reservations.md
@@ -1,0 +1,24 @@
+# Issue #13427 — Meeting Credit Reservations
+
+## Verification
+
+- `bun run --cwd plugins/plugin-meetings test src/service.test.ts src/routes/meetings-routes.test.ts src/pipeline/__tests__/pipeline.test.ts`
+  - 3 files, 47 tests passed.
+- `bun run --cwd plugins/plugin-meetings typecheck`
+  - Passed.
+- `bunx biome check packages/cloud/shared/src/lib/index.ts packages/cloud/shared/src/lib/services/meeting-billing.ts packages/cloud/shared/src/lib/services/__tests__/meeting-billing.test.ts packages/shared/src/meetings.ts plugins/plugin-meetings/src/types.ts plugins/plugin-meetings/src/service.ts plugins/plugin-meetings/src/pipeline/pipeline.ts plugins/plugin-meetings/src/test-support.ts plugins/plugin-meetings/src/service.test.ts plugins/plugin-meetings/src/routes/meetings-routes.ts plugins/plugin-meetings/src/routes/meetings-routes.test.ts plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts`
+  - Passed.
+- `bun test packages/cloud/shared/src/lib/services/__tests__/meeting-billing.test.ts > /tmp/meeting-billing-test-full.out 2>&1`
+  - 6 tests passed, 0 failed.
+  - Manually reviewed pass lines for:
+    - initial launch reservation,
+    - bounded chunk extension,
+    - unused reservation refund,
+    - insufficient initial credits,
+    - spend-cap refusal before ASR continues,
+    - exactly-once reconciliation under racing exits.
+
+## Notes
+
+- `bun run --cwd packages/cloud/shared typecheck` still fails on pre-existing transitive `@elizaos/auth/*` resolution errors from `packages/app-core`; filtering the output showed no diagnostics for the new meeting billing files.
+- Live funded-organization proof remains tracked in #13428, which requires real cloud credentials and production billing rows.

--- a/packages/cloud/shared/src/lib/index.ts
+++ b/packages/cloud/shared/src/lib/index.ts
@@ -16,5 +16,12 @@ export {
   type BridgeRequest,
   elizaSandboxService,
 } from "./services/eliza-sandbox";
+export {
+  createMeetingCreditBillingSession,
+  MeetingCloudBillingError,
+  MeetingCreditBillingSession,
+  type MeetingCreditBillingSessionOptions,
+  resolveMeetingUsdPerMinute,
+} from "./services/meeting-billing";
 export { provisioningJobService } from "./services/provisioning-jobs";
 export { logger } from "./utils/logger";

--- a/packages/cloud/shared/src/lib/services/__tests__/meeting-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/meeting-billing.test.ts
@@ -1,0 +1,245 @@
+/**
+ * PGlite-backed coverage for meeting transcription billing.
+ *
+ * These tests drive the real org credit reservation ledger, not a fake ledger:
+ * launch windows create debit reservations, finalization settles those rows, and
+ * balances are read back from the database so the cloud-money path is observable
+ * without reading the implementation.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const ORG_ID = "00000000-0000-0000-0000-000000001427";
+const USER_ID = "00000000-0000-0000-0000-000000001527";
+const PGLITE_TIMEOUT = 60_000;
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let createMeetingCreditBillingSession: typeof import("../meeting-billing").createMeetingCreditBillingSession;
+let MeetingCloudBillingError: typeof import("../meeting-billing").MeetingCloudBillingError;
+
+async function seedOrg(balance: string): Promise<void> {
+  await dbWrite.execute(`DELETE FROM credit_transactions WHERE organization_id = '${ORG_ID}';`);
+  await dbWrite.execute(`DELETE FROM organizations WHERE id = '${ORG_ID}';`);
+  await dbWrite.execute(
+    `INSERT INTO organizations (id, credit_balance) VALUES ('${ORG_ID}', '${balance}');`,
+  );
+}
+
+async function balance(): Promise<number> {
+  const result = await dbWrite.execute(
+    `SELECT credit_balance FROM organizations WHERE id = '${ORG_ID}';`,
+  );
+  return Number((result.rows[0] as { credit_balance: string }).credit_balance);
+}
+
+async function transactions(): Promise<
+  Array<{
+    id: string;
+    amount: string;
+    type: string;
+    settled_at: string | null;
+    metadata: Record<string, unknown>;
+  }>
+> {
+  const result = await dbWrite.execute(
+    `SELECT id, amount, type, settled_at, metadata
+     FROM credit_transactions
+     WHERE organization_id = '${ORG_ID}'
+     ORDER BY created_at ASC, id ASC;`,
+  );
+  return result.rows as Array<{
+    id: string;
+    amount: string;
+    type: string;
+    settled_at: string | null;
+    metadata: Record<string, unknown>;
+  }>;
+}
+
+function session(options: { maxDurationMs?: number; sessionId?: string } = {}) {
+  return createMeetingCreditBillingSession({
+    organizationId: ORG_ID,
+    userId: USER_ID,
+    sessionId: options.sessionId ?? "meeting-session-1",
+    meetingUrl: "https://meet.google.com/abc-defg-hij",
+    maxDurationMs: options.maxDurationMs ?? 60_000,
+    usdPerMinute: 0.6,
+    initialWindowMs: 10_000,
+    chunkWindowMs: 10_000,
+  });
+}
+
+beforeAll(async () => {
+  ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+  ({ createMeetingCreditBillingSession, MeetingCloudBillingError } = await import(
+    "../meeting-billing"
+  ));
+
+  const ddl = [
+    `CREATE TABLE IF NOT EXISTS organizations (
+      id uuid PRIMARY KEY,
+      name text NOT NULL DEFAULT 'test-org',
+      slug text NOT NULL DEFAULT 'test-org',
+      credit_balance numeric(20,6) NOT NULL DEFAULT '0' CHECK (credit_balance >= 0),
+      settings jsonb DEFAULT '{}',
+      stripe_customer_id text,
+      billing_email text,
+      stripe_payment_method_id text,
+      stripe_default_payment_method text,
+      auto_top_up_enabled boolean DEFAULT false,
+      auto_top_up_threshold numeric(12,6),
+      auto_top_up_amount numeric(12,6),
+      pay_as_you_go_from_earnings boolean NOT NULL DEFAULT true,
+      steward_tenant_id text,
+      steward_tenant_api_key text,
+      is_active boolean NOT NULL DEFAULT true,
+      created_at timestamp NOT NULL DEFAULT now(),
+      updated_at timestamp NOT NULL DEFAULT now()
+    )`,
+    `CREATE TABLE IF NOT EXISTS credit_transactions (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      organization_id uuid NOT NULL,
+      user_id uuid,
+      amount numeric(12,6) NOT NULL,
+      type text NOT NULL,
+      description text,
+      metadata jsonb NOT NULL DEFAULT '{}',
+      stripe_payment_intent_id text,
+      created_at timestamp NOT NULL DEFAULT now(),
+      settled_at timestamp
+    )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS credit_transactions_stripe_payment_intent_idx
+      ON credit_transactions (stripe_payment_intent_id)`,
+  ];
+  for (const statement of ddl) {
+    await dbWrite.execute(statement);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("MeetingCreditBillingSession", () => {
+  beforeEach(async () => {
+    await seedOrg("1.00");
+  });
+
+  test(
+    "reserves the initial launch window before the bot starts",
+    async () => {
+      const billing = session();
+
+      await billing.reserveInitial();
+
+      expect(billing.state.reservedMs).toBe(10_000);
+      expect(billing.state.consumedMs).toBe(0);
+      expect(billing.state.reservationIds?.length).toBe(1);
+      expect(await balance()).toBeCloseTo(0.9, 6);
+      const rows = await transactions();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.type).toBe("debit");
+      expect(Number(rows[0]?.amount)).toBeCloseTo(-0.1, 6);
+      expect(rows[0]?.settled_at).toBeNull();
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "extends in bounded chunks as transcription usage accrues",
+    async () => {
+      const billing = session();
+      await billing.reserveInitial();
+
+      await billing.ensureTranscriptionWindow(25_000);
+      await billing.reconcile("normal_completion");
+
+      expect(billing.state.reservedMs).toBe(25_000);
+      expect(billing.state.consumedMs).toBe(25_000);
+      expect(billing.state.status).toBe("reconciled");
+      expect(await balance()).toBeCloseTo(0.75, 6);
+      const rows = await transactions();
+      expect(rows.filter((row) => row.type === "debit")).toHaveLength(2);
+      expect(rows.filter((row) => row.type === "refund")).toHaveLength(0);
+      expect(rows.every((row) => row.type !== "debit" || row.settled_at !== null)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "refunds the unused tail on normal reconciliation",
+    async () => {
+      const billing = session();
+      await billing.reserveInitial();
+
+      await billing.ensureTranscriptionWindow(5_000);
+      await billing.reconcile("requested_stop");
+
+      expect(await balance()).toBeCloseTo(0.95, 6);
+      const rows = await transactions();
+      expect(rows.filter((row) => row.type === "debit")).toHaveLength(1);
+      const refunds = rows.filter((row) => row.type === "refund");
+      expect(refunds).toHaveLength(1);
+      expect(Number(refunds[0]?.amount)).toBeCloseTo(0.05, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "fails before launch when the initial reservation cannot be funded",
+    async () => {
+      await seedOrg("0.05");
+      const billing = session();
+
+      await expect(billing.reserveInitial()).rejects.toBeInstanceOf(MeetingCloudBillingError);
+      expect(billing.state.status).toBe("spend_cap_reached");
+      expect(await balance()).toBeCloseTo(0.05, 6);
+      expect(await transactions()).toHaveLength(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "refuses a transcription window beyond the session cap before ASR spend continues",
+    async () => {
+      const billing = session({ maxDurationMs: 15_000 });
+      await billing.reserveInitial();
+
+      await expect(billing.ensureTranscriptionWindow(16_000)).rejects.toBeInstanceOf(
+        MeetingCloudBillingError,
+      );
+
+      expect(billing.state.status).toBe("spend_cap_reached");
+      expect(billing.state.consumedMs).toBe(0);
+      expect(billing.state.reservedMs).toBe(10_000);
+      await billing.reconcile("ended_due_to_spend_cap");
+      expect(await balance()).toBeCloseTo(1.0, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "reconciles exactly once when multiple exit paths race",
+    async () => {
+      const billing = session();
+      await billing.reserveInitial();
+      await billing.ensureTranscriptionWindow(5_000);
+
+      await Promise.all([
+        billing.reconcile("requested_stop"),
+        billing.reconcile("normal_completion"),
+        billing.reconcile("error"),
+      ]);
+
+      const rows = await transactions();
+      expect(rows.filter((row) => row.type === "refund")).toHaveLength(1);
+      expect(await balance()).toBeCloseTo(0.95, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/meeting-billing.ts
+++ b/packages/cloud/shared/src/lib/services/meeting-billing.ts
@@ -1,0 +1,179 @@
+/**
+ * Ledger-backed billing session for cloud-hosted meeting transcription.
+ *
+ * The meetings plugin owns bot orchestration and ASR, but cloud deployments need
+ * a money boundary that can reserve a small launch window, extend in bounded
+ * chunks as audio reaches transcription, and reconcile every hold exactly once
+ * when the meeting exits. This module stays in cloud-shared so the generic
+ * plugin does not import server-only database services.
+ */
+
+import type { MeetingBillingState, MeetingEndReason } from "@elizaos/shared";
+import { type CreditReservation, creditsService, InsufficientCreditsError } from "./credits";
+
+export type MeetingCloudBillingErrorCode = "insufficient_credits" | "billing_failed";
+
+export class MeetingCloudBillingError extends Error {
+  constructor(
+    readonly code: MeetingCloudBillingErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "MeetingCloudBillingError";
+  }
+}
+
+export interface MeetingCreditBillingSessionOptions {
+  organizationId: string;
+  userId?: string;
+  sessionId: string;
+  meetingUrl?: string;
+  maxDurationMs: number;
+  usdPerMinute?: number;
+  initialWindowMs?: number;
+  chunkWindowMs?: number;
+}
+
+interface HeldReservation {
+  reservation: CreditReservation;
+  reservedMs: number;
+}
+
+const DEFAULT_USD_PER_MINUTE = 0.006;
+const DEFAULT_INITIAL_WINDOW_MS = 60_000;
+const DEFAULT_CHUNK_WINDOW_MS = 60_000;
+
+function readPositiveNumber(value: unknown): number | null {
+  if (typeof value !== "string" && typeof value !== "number") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function resolveMeetingUsdPerMinute(env: Record<string, string | undefined> = process.env) {
+  return (
+    readPositiveNumber(env.ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE) ?? DEFAULT_USD_PER_MINUTE
+  );
+}
+
+function dollarsForMs(ms: number, usdPerMinute: number): number {
+  return (ms / 60_000) * usdPerMinute;
+}
+
+function chunkMs(requestedMs: number, chunkWindowMs: number): number {
+  return Math.max(chunkWindowMs, requestedMs);
+}
+
+/**
+ * Credit-backed meeting billing state.
+ *
+ * Each extension creates an ordinary credit reservation debit. Reconciliation
+ * settles those reservations in order, charging only the consumed milliseconds
+ * and refunding any unused tail of the last chunk. The first reconcile caller
+ * wins so adapter returns, abort handlers, and cleanup paths can all safely call
+ * it for the same session.
+ */
+export class MeetingCreditBillingSession {
+  readonly state: MeetingBillingState = {
+    status: "reserved",
+    reservedMs: 0,
+    consumedMs: 0,
+    reservationIds: [],
+  };
+
+  private readonly organizationId: string;
+  private readonly userId?: string;
+  private readonly sessionId: string;
+  private readonly meetingUrl?: string;
+  private readonly maxDurationMs: number;
+  private readonly usdPerMinute: number;
+  private readonly initialWindowMs: number;
+  private readonly chunkWindowMs: number;
+  private readonly holds: HeldReservation[] = [];
+  private reconcilePromise: Promise<MeetingBillingState> | null = null;
+
+  constructor(options: MeetingCreditBillingSessionOptions) {
+    this.organizationId = options.organizationId;
+    this.userId = options.userId;
+    this.sessionId = options.sessionId;
+    this.meetingUrl = options.meetingUrl;
+    this.maxDurationMs = options.maxDurationMs;
+    this.usdPerMinute = options.usdPerMinute ?? resolveMeetingUsdPerMinute();
+    this.initialWindowMs = options.initialWindowMs ?? DEFAULT_INITIAL_WINDOW_MS;
+    this.chunkWindowMs = options.chunkWindowMs ?? DEFAULT_CHUNK_WINDOW_MS;
+    this.state.capMs = options.maxDurationMs;
+  }
+
+  async reserveInitial(): Promise<void> {
+    await this.reserveWindow(Math.min(this.initialWindowMs, this.maxDurationMs));
+  }
+
+  async ensureTranscriptionWindow(durationMs: number): Promise<void> {
+    if (!Number.isFinite(durationMs) || durationMs <= 0) return;
+    const nextConsumedMs = this.state.consumedMs + Math.ceil(durationMs);
+    if (nextConsumedMs > this.maxDurationMs) {
+      this.state.status = "spend_cap_reached";
+      this.state.error = "meeting transcription spend cap reached";
+      throw new MeetingCloudBillingError("insufficient_credits", this.state.error);
+    }
+
+    const neededMs = nextConsumedMs - this.state.reservedMs;
+    if (neededMs > 0) {
+      await this.reserveWindow(
+        Math.min(chunkMs(neededMs, this.chunkWindowMs), this.maxDurationMs - this.state.reservedMs),
+      );
+    }
+    this.state.consumedMs = nextConsumedMs;
+  }
+
+  async reconcile(reason: MeetingEndReason): Promise<MeetingBillingState> {
+    if (!this.reconcilePromise) {
+      this.reconcilePromise = this.reconcileOnce(reason);
+    }
+    return await this.reconcilePromise;
+  }
+
+  private async reserveWindow(windowMs: number): Promise<void> {
+    if (windowMs <= 0) return;
+    try {
+      const reservation = await creditsService.reserve({
+        organizationId: this.organizationId,
+        userId: this.userId,
+        amount: dollarsForMs(windowMs, this.usdPerMinute),
+        description: `Meeting transcription ${this.sessionId}`,
+      });
+      this.holds.push({ reservation, reservedMs: windowMs });
+      this.state.reservedMs += windowMs;
+      if (reservation.reservationTransactionId) {
+        this.state.reservationIds?.push(reservation.reservationTransactionId);
+      }
+      this.state.status = "reserved";
+    } catch (error) {
+      this.state.status = "spend_cap_reached";
+      this.state.error = error instanceof Error ? error.message : String(error);
+      if (error instanceof InsufficientCreditsError) {
+        throw new MeetingCloudBillingError("insufficient_credits", error.message);
+      }
+      throw new MeetingCloudBillingError("billing_failed", this.state.error);
+    }
+  }
+
+  private async reconcileOnce(reason: MeetingEndReason): Promise<MeetingBillingState> {
+    let remainingConsumedMs = this.state.consumedMs;
+    for (const hold of this.holds) {
+      const billedMs = Math.min(remainingConsumedMs, hold.reservedMs);
+      remainingConsumedMs = Math.max(0, remainingConsumedMs - billedMs);
+      await hold.reservation.reconcile(dollarsForMs(billedMs, this.usdPerMinute));
+    }
+    this.state.status = "reconciled";
+    this.state.error =
+      reason === "ended_due_to_spend_cap" ? "meeting transcription spend cap reached" : undefined;
+    return {
+      ...this.state,
+      reservationIds: [...(this.state.reservationIds ?? [])],
+    };
+  }
+}
+
+export function createMeetingCreditBillingSession(options: MeetingCreditBillingSessionOptions) {
+  return new MeetingCreditBillingSession(options);
+}

--- a/packages/shared/src/meetings.ts
+++ b/packages/shared/src/meetings.ts
@@ -39,6 +39,7 @@ export type MeetingEndReason =
   | "normal_completion"
   | "requested_stop"
   | "duration_cap_reached"
+  | "ended_due_to_spend_cap"
   | "removed_by_admin"
   | "left_alone_timeout"
   | "startup_alone_timeout"
@@ -86,6 +87,16 @@ export interface MeetingJoinRequest {
   calendarEventId?: string;
 }
 
+/** Metering state exposed so routes/UI can prove a meeting is spend-bounded. */
+export interface MeetingBillingState {
+  status: "unmetered" | "reserved" | "spend_cap_reached" | "reconciled";
+  reservedMs: number;
+  consumedMs: number;
+  capMs?: number;
+  reservationIds?: string[];
+  error?: string;
+}
+
 /** A participant observed in the meeting roster. */
 export interface MeetingParticipant {
   /** Stable id within the session (platform participant id or synthesized). */
@@ -121,6 +132,7 @@ export interface MeetingSession {
   calendarEventId?: string;
   /** Maximum duration approved for this session, in milliseconds. */
   maxDurationMs?: number;
+  billing?: MeetingBillingState;
   metadata?: Record<string, unknown>;
 }
 

--- a/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
+++ b/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
@@ -150,6 +150,42 @@ describe("createMeetingTranscriptionPipeline", () => {
     );
   });
 
+  it("treats cloud billing errors with the insufficient-credit code as spend-cap stops", async () => {
+    const backend = new ScriptedBackend();
+    backend.enqueue({ text: "this should not run" });
+    const cloudBillingError = Object.assign(new Error("cloud cap reached"), {
+      code: "insufficient_credits" as const,
+    });
+    const billing: MeetingBillingSession = {
+      state: {
+        status: "reserved",
+        reservedMs: 1000,
+        consumedMs: 0,
+        capMs: 1000,
+      },
+      reserveInitial: async () => undefined,
+      ensureTranscriptionWindow: vi.fn(async () => {
+        throw cloudBillingError;
+      }),
+      reconcile: async () => ({
+        status: "reconciled",
+        reservedMs: 1000,
+        consumedMs: 0,
+      }),
+    };
+    const onSpendCapReached = vi.fn();
+    const pipeline = createMeetingTranscriptionPipeline(
+      options({ billing, onSpendCapReached }),
+      backend,
+    );
+
+    pipeline.pushSpeakerAudio("t0", seconds(2));
+    await tick(2000);
+
+    expect(backend.calls).toHaveLength(0);
+    expect(onSpendCapReached).toHaveBeenCalledWith(cloudBillingError);
+  });
+
   it("emits confirmed (new-only) + pending replacement-tail updates", async () => {
     const backend = new ScriptedBackend();
     backend.enqueue(

--- a/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
+++ b/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
@@ -8,9 +8,11 @@ import type { Buffer } from "node:buffer";
 import type { IAgentRuntime, UUID } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
+  MeetingBillingSession,
   MeetingPipelineOptions,
   PipelineTranscriptUpdate,
 } from "../../types";
+import { MeetingBillingError } from "../../types";
 import { createMeetingTranscriptionPipeline } from "../pipeline";
 import type {
   AsrBackend,
@@ -107,6 +109,45 @@ describe("createMeetingTranscriptionPipeline", () => {
 
     const segments = await pipeline.finalize();
     expect(segments.map((s) => s.text)).toContain("welcome to the standup");
+  });
+
+  it("does not call ASR when the billing meter cannot reserve the next window", async () => {
+    const backend = new ScriptedBackend();
+    backend.enqueue({ text: "this should not run" });
+    const billing: MeetingBillingSession = {
+      state: {
+        status: "reserved",
+        reservedMs: 1000,
+        consumedMs: 0,
+        capMs: 1000,
+      },
+      reserveInitial: async () => undefined,
+      ensureTranscriptionWindow: vi.fn(async () => {
+        throw new MeetingBillingError(
+          "insufficient_credits",
+          "meeting spend cap reached",
+        );
+      }),
+      reconcile: async () => ({
+        status: "reconciled",
+        reservedMs: 1000,
+        consumedMs: 0,
+      }),
+    };
+    const onSpendCapReached = vi.fn();
+    const pipeline = createMeetingTranscriptionPipeline(
+      options({ billing, onSpendCapReached }),
+      backend,
+    );
+
+    pipeline.pushSpeakerAudio("t0", seconds(2));
+    await tick(2000);
+
+    expect(billing.ensureTranscriptionWindow).toHaveBeenCalledWith(2000);
+    expect(backend.calls).toHaveLength(0);
+    expect(onSpendCapReached).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "insufficient_credits" }),
+    );
   });
 
   it("emits confirmed (new-only) + pending replacement-tail updates", async () => {

--- a/plugins/plugin-meetings/src/pipeline/pipeline.ts
+++ b/plugins/plugin-meetings/src/pipeline/pipeline.ts
@@ -19,6 +19,7 @@ import { logger } from "@elizaos/core";
 import type { MeetingParticipant, TranscriptSegment } from "@elizaos/shared";
 import {
   MEETING_AUDIO_SAMPLE_RATE,
+  MeetingBillingError,
   type MeetingPipelineOptions,
   type MeetingTranscriptionPipeline,
   type PipelineTranscriptUpdate,
@@ -271,6 +272,23 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
 
     const task = (async () => {
       try {
+        if (this.options.billing) {
+          try {
+            await this.options.billing.ensureTranscriptionWindow(
+              Math.ceil(durationSec * 1000),
+            );
+          } catch (err) {
+            if (
+              err instanceof MeetingBillingError &&
+              err.code === "insufficient_credits"
+            ) {
+              this.options.onSpendCapReached?.(err);
+              this.manager.handleTranscriptionResult(speakerKey, "");
+              return;
+            }
+            throw err;
+          }
+        }
         const result = await this.backend.transcribe(wav, {
           ...(this.options.language ? { language: this.options.language } : {}),
           ...(prompt ? { prompt } : {}),

--- a/plugins/plugin-meetings/src/pipeline/pipeline.ts
+++ b/plugins/plugin-meetings/src/pipeline/pipeline.ts
@@ -19,7 +19,7 @@ import { logger } from "@elizaos/core";
 import type { MeetingParticipant, TranscriptSegment } from "@elizaos/shared";
 import {
   MEETING_AUDIO_SAMPLE_RATE,
-  MeetingBillingError,
+  isMeetingInsufficientCreditsError,
   type MeetingPipelineOptions,
   type MeetingTranscriptionPipeline,
   type PipelineTranscriptUpdate,
@@ -278,10 +278,7 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
               Math.ceil(durationSec * 1000),
             );
           } catch (err) {
-            if (
-              err instanceof MeetingBillingError &&
-              err.code === "insufficient_credits"
-            ) {
+            if (isMeetingInsufficientCreditsError(err)) {
               this.options.onSpendCapReached?.(err);
               this.manager.handleTranscriptionResult(speakerKey, "");
               return;

--- a/plugins/plugin-meetings/src/routes/meetings-routes.test.ts
+++ b/plugins/plugin-meetings/src/routes/meetings-routes.test.ts
@@ -7,6 +7,7 @@ import type { RouteHandlerContext } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { MeetingService } from "../service.js";
 import {
+  FakeMeetingBillingSession,
   makeFakeRuntime,
   ScriptedAdapter,
   scriptedDeps,
@@ -25,10 +26,10 @@ function route(method: string, path: string) {
 }
 
 /** Real MeetingService (scripted adapter/pipeline) behind a real runtime stub. */
-function makeHarness() {
+function makeHarness(billingSessions: FakeMeetingBillingSession[] = []) {
   const fake = makeFakeRuntime();
   const adapter = new ScriptedAdapter("google_meet");
-  const { deps } = scriptedDeps([adapter]);
+  const { deps } = scriptedDeps([adapter], billingSessions);
   const service = new MeetingService(fake.runtime, deps);
   const services = new Map<string, unknown>([["meetings", service]]);
   const baseGetService = fake.runtime.getService.bind(fake.runtime);
@@ -98,6 +99,22 @@ describe("/api/meetings routes", () => {
     expect((overCap.body as { code: string }).code).toBe(
       "invalid_duration_cap",
     );
+    expect(adapter.session).toBeNull();
+  });
+
+  it("POST maps insufficient initial meeting credits to 402 and does not launch", async () => {
+    const billing = new FakeMeetingBillingSession();
+    billing.initialReserveError = Object.assign(
+      new Error("not enough credits to start meeting transcription"),
+      { code: "insufficient_credits" },
+    );
+    const { ctx, adapter } = makeHarness([billing]);
+    const post = route("POST", "/api/meetings");
+
+    const result = await post(ctx({ body: { meetingUrl: MEET_URL } }));
+
+    expect(result.status).toBe(402);
+    expect((result.body as { code: string }).code).toBe("insufficient_credits");
     expect(adapter.session).toBeNull();
   });
 

--- a/plugins/plugin-meetings/src/routes/meetings-routes.ts
+++ b/plugins/plugin-meetings/src/routes/meetings-routes.ts
@@ -45,6 +45,7 @@ const joinErrorStatus: Record<MeetingJoinError["code"], number> = {
   unsupported_host: 422,
   already_joined: 409,
   invalid_duration_cap: 400,
+  insufficient_credits: 402,
 };
 
 const createRoute: Route = {

--- a/plugins/plugin-meetings/src/service.test.ts
+++ b/plugins/plugin-meetings/src/service.test.ts
@@ -7,6 +7,7 @@ import { DEFAULT_MEETING_MAX_DURATION_MS } from "@elizaos/shared";
 import { describe, expect, it, vi } from "vitest";
 import { MeetingJoinError, MeetingService } from "./service.js";
 import {
+  FakeMeetingBillingSession,
   makeFakeRuntime,
   ScriptedAdapter,
   scriptedDeps,
@@ -18,9 +19,10 @@ const MEET_URL = "https://meet.google.com/abc-defg-hij";
 
 function makeService(
   adapters: ScriptedAdapter[] = [new ScriptedAdapter("google_meet")],
+  billingSessions: FakeMeetingBillingSession[] = [],
 ) {
   const fake = makeFakeRuntime();
-  const { deps, pipelines } = scriptedDeps(adapters);
+  const { deps, pipelines } = scriptedDeps(adapters, billingSessions);
   const service = new MeetingService(fake.runtime, deps);
   return { fake, service, pipelines, adapters };
 }
@@ -91,7 +93,9 @@ describe("MeetingService.requestJoin — validation", () => {
   });
 
   it("releases the reservation when join setup throws, so a retry succeeds (BL-5)", async () => {
-    const { fake, service } = makeService();
+    const billing = new FakeMeetingBillingSession();
+    const retryBilling = new FakeMeetingBillingSession();
+    const { fake, service } = makeService(undefined, [billing, retryBilling]);
     // Make the transcript writer's initial row write (createMemory) fail once.
     const realCreateMemory = fake.runtime.createMemory.bind(fake.runtime);
     let calls = 0;
@@ -110,6 +114,7 @@ describe("MeetingService.requestJoin — validation", () => {
     ).rejects.toThrow("db write failed");
     // The failed session did NOT strand a non-terminal reservation.
     expect(service.listSessions()).toHaveLength(0);
+    expect(billing.reconcileCalls).toEqual(["error"]);
 
     // Because the reservation rolled back, a second join for the same meeting
     // is not blocked by `already_joined`.
@@ -120,6 +125,7 @@ describe("MeetingService.requestJoin — validation", () => {
     expect(dto.status).toBe("requested");
     expect(service.listSessions({ active: true })).toHaveLength(1);
     expect(calls).toBe(2);
+    expect(retryBilling.reconcileCalls).toEqual([]);
   });
 
   it("rejects requested duration caps above the configured maximum before launch", async () => {
@@ -188,6 +194,23 @@ describe("MeetingService.requestJoin — validation", () => {
     ).rejects.toMatchObject({ code: "invalid_duration_cap" });
     expect(decimalAdapter.session).toBeNull();
   });
+
+  it("fails closed before bot launch when initial credit reservation is insufficient", async () => {
+    const adapter = new ScriptedAdapter("google_meet");
+    const billing = new FakeMeetingBillingSession();
+    billing.initialReserveError = Object.assign(
+      new Error("not enough credits to start meeting transcription"),
+      { code: "insufficient_credits" },
+    );
+    const { service } = makeService([adapter], [billing]);
+
+    await expect(
+      service.requestJoin({ platform: "google_meet", meetingUrl: MEET_URL }),
+    ).rejects.toMatchObject({ code: "insufficient_credits" });
+    expect(adapter.session).toBeNull();
+    expect(service.listSessions()).toHaveLength(0);
+    expect(billing.reserveInitialCalls).toBe(1);
+  });
 });
 
 describe("MeetingService — session state machine", () => {
@@ -234,6 +257,34 @@ describe("MeetingService — session state machine", () => {
       "active",
       "ended",
     ]);
+  });
+
+  it("exposes billing state and reconciles it exactly once at normal finish", async () => {
+    const adapter = new ScriptedAdapter("google_meet");
+    const billing = new FakeMeetingBillingSession({ reservedMs: 30_000 });
+    const { service } = makeService([adapter], [billing]);
+    const dto = await service.requestJoin({
+      platform: "google_meet",
+      meetingUrl: MEET_URL,
+    });
+    expect(dto.billing).toMatchObject({
+      status: "reserved",
+      reservedMs: 30_000,
+      consumedMs: 0,
+    });
+
+    await adapter.started;
+    adapter.end("normal_completion");
+    await new Promise((r) => setTimeout(r, 10));
+
+    const session = service.getSession(dto.id as never);
+    expect(session?.billing).toMatchObject({
+      status: "reconciled",
+      reservedMs: 30_000,
+    });
+    expect(billing.reconcileCalls).toEqual(["normal_completion"]);
+    expect(service.stopSession(dto.id as never)).toBe(false);
+    expect(billing.reconcileCalls).toHaveLength(1);
   });
 
   it("evicts the finished session to a lightweight terminal record but keeps it readable (BL-4)", async () => {

--- a/plugins/plugin-meetings/src/service.ts
+++ b/plugins/plugin-meetings/src/service.ts
@@ -23,6 +23,7 @@ import {
   DEFAULT_MEETING_MAX_DURATION_MS,
   MEETING_PLATFORM_LABELS,
   type MeetingAutoLeaveConfig,
+  type MeetingBillingState,
   type MeetingEndReason,
   type MeetingJoinRequest,
   type MeetingParticipant,
@@ -38,6 +39,9 @@ import { resolveMeetingRuntimeSupport } from "./platform-support.js";
 import { MeetingTranscriptWriter } from "./transcripts/meeting-transcript-writer.js";
 import type {
   MeetingAudioSink,
+  MeetingBillingError,
+  MeetingBillingSession,
+  MeetingBillingSessionInput,
   MeetingBotSession,
   MeetingPipelineOptions,
   MeetingPlatformAdapter,
@@ -55,6 +59,9 @@ export interface MeetingPipelineInstance extends MeetingTranscriptionPipeline {
 export interface MeetingServiceDependencies {
   adapters: ReadonlyMap<MeetingPlatform, MeetingPlatformAdapter>;
   createPipeline(options: MeetingPipelineOptions): MeetingPipelineInstance;
+  createBillingSession?(
+    input: MeetingBillingSessionInput,
+  ): MeetingBillingSession | null;
 }
 
 export type MeetingJoinErrorCode =
@@ -62,7 +69,8 @@ export type MeetingJoinErrorCode =
   | "unsupported_platform"
   | "unsupported_host"
   | "already_joined"
-  | "invalid_duration_cap";
+  | "invalid_duration_cap"
+  | "insufficient_credits";
 
 /** Validation/conflict failures of `requestJoin` — routes map these to 4xx. */
 export class MeetingJoinError extends Error {
@@ -100,6 +108,8 @@ interface InternalSession {
   readonly abort: AbortController;
   readonly pipeline: MeetingPipelineInstance;
   readonly writer: MeetingTranscriptWriter;
+  readonly billing?: MeetingBillingSession;
+  billingFinalized?: Promise<void>;
   /** Confirmed segments accumulated from pipeline updates (live view state). */
   confirmedSegments: TranscriptSegment[];
   /** Resolves when the adapter lifecycle + finalize have fully completed. */
@@ -226,12 +236,42 @@ export class MeetingService extends Service {
     };
     const maxDurationMs = this.resolveMaxDurationMs(request.maxDurationMs);
     const retainAudio = request.retainAudio ?? true;
+    const billing = this.deps.createBillingSession?.({
+      runtime: this.runtime,
+      sessionId,
+      request,
+      maxDurationMs,
+    });
+
+    if (billing) {
+      try {
+        await billing.reserveInitial();
+      } catch (err) {
+        if (
+          err instanceof Error &&
+          "code" in err &&
+          err.code === "insufficient_credits"
+        ) {
+          throw new MeetingJoinError("insufficient_credits", err.message);
+        }
+        throw err;
+      }
+    }
 
     const pipeline = this.deps.createPipeline({
       runtime: this.runtime,
       sessionId,
       language: request.language,
       retainAudio,
+      ...(billing ? { billing } : {}),
+      onSpendCapReached: (error: MeetingBillingError) => {
+        const live = this.sessions.get(sessionId);
+        if (!live || TERMINAL_STATUSES.has(live.status)) return;
+        live.endReason = "ended_due_to_spend_cap";
+        live.errorMessage = error.message;
+        this.applyStatus(live, "leaving");
+        live.abort.abort();
+      },
     });
     const writer = new MeetingTranscriptWriter(this.runtime);
 
@@ -251,6 +291,7 @@ export class MeetingService extends Service {
       abort: new AbortController(),
       pipeline,
       writer,
+      ...(billing ? { billing } : {}),
       confirmedSegments: [],
       done: Promise.resolve(),
     };
@@ -282,6 +323,22 @@ export class MeetingService extends Service {
         nativeMeetingId: parsed.nativeMeetingId,
       });
     } catch (err) {
+      try {
+        await this.reconcileBillingOnce(session, "error");
+      } catch (billingErr) {
+        logger.error(
+          {
+            sessionId,
+            platform: parsed.platform,
+            nativeMeetingId: parsed.nativeMeetingId,
+            error:
+              billingErr instanceof Error
+                ? billingErr.message
+                : String(billingErr),
+          },
+          "[MeetingService] join setup billing release failed",
+        );
+      }
       this.sessions.delete(sessionId);
       logger.error(
         {
@@ -382,7 +439,18 @@ export class MeetingService extends Service {
       participants: session.participants.map((p) => ({ ...p })),
       calendarEventId: session.calendarEventId,
       maxDurationMs: session.maxDurationMs,
+      billing: this.billingState(session),
     };
+  }
+
+  private billingState(session: InternalSession): MeetingBillingState {
+    return (
+      session.billing?.state ?? {
+        status: "unmetered",
+        reservedMs: 0,
+        consumedMs: 0,
+      }
+    );
   }
 
   /** One shared "Meetings" world across sessions (created once, reused). */
@@ -528,6 +596,9 @@ export class MeetingService extends Service {
       endReason = await Promise.race([adapter.run(botSession), capReached]);
       if (durationCapReached) {
         endReason = "duration_cap_reached";
+      } else if (session.endReason === "ended_due_to_spend_cap") {
+        endReason = "ended_due_to_spend_cap";
+        errorMessage = session.errorMessage;
       }
     } catch (err) {
       endReason = "error";
@@ -578,6 +649,18 @@ export class MeetingService extends Service {
       );
     }
 
+    try {
+      await this.reconcileBillingOnce(session, endReason);
+    } catch (err) {
+      endReason = "error";
+      errorMessage =
+        errorMessage ?? (err instanceof Error ? err.message : String(err));
+      logger.error(
+        { sessionId: session.id, error: errorMessage },
+        "[MeetingService] billing reconciliation failed",
+      );
+    }
+
     session.endReason = endReason;
     session.errorMessage = errorMessage;
     session.endedAt = Date.now();
@@ -602,6 +685,19 @@ export class MeetingService extends Service {
     // the durable data.
     this.sessions.delete(session.id);
     this.terminated.set(session.id, dto);
+  }
+
+  private async reconcileBillingOnce(
+    session: InternalSession,
+    endReason: MeetingEndReason,
+  ): Promise<void> {
+    if (!session.billing) return;
+    if (!session.billingFinalized) {
+      session.billingFinalized = session.billing
+        .reconcile(endReason)
+        .then(() => undefined);
+    }
+    await session.billingFinalized;
   }
 
   private settingString(key: string): string | null {

--- a/plugins/plugin-meetings/src/test-support.ts
+++ b/plugins/plugin-meetings/src/test-support.ts
@@ -8,6 +8,7 @@
 
 import type { IAgentRuntime, Memory, Plugin, UUID } from "@elizaos/core";
 import type {
+  MeetingBillingState,
   MeetingEndReason,
   MeetingParticipant,
   MeetingPlatform,
@@ -20,11 +21,13 @@ import {
   type MeetingServiceDependencies,
 } from "./service.js";
 import type {
+  MeetingBillingSession,
   MeetingBotSession,
   MeetingPipelineOptions,
   MeetingPlatformAdapter,
   PipelineTranscriptUpdate,
 } from "./types.js";
+import { MeetingBillingError } from "./types.js";
 
 export interface FakeRuntime {
   runtime: IAgentRuntime;
@@ -153,6 +156,60 @@ export class ScriptedPipeline implements MeetingPipelineInstance {
   }
   sessionAudioWav(): Buffer | null {
     return this.audioWav;
+  }
+}
+
+export class FakeMeetingBillingSession implements MeetingBillingSession {
+  readonly state: MeetingBillingState = {
+    status: "reserved",
+    reservedMs: 0,
+    consumedMs: 0,
+    capMs: 60_000,
+    reservationIds: [] as string[],
+  };
+  initialReserveError: Error | null = null;
+  failAfterConsumedMs: number | null = null;
+  reserveInitialCalls = 0;
+  reconcileCalls: MeetingEndReason[] = [];
+
+  constructor(options?: { capMs?: number; reservedMs?: number }) {
+    this.state.capMs = options?.capMs ?? this.state.capMs;
+    this.state.reservedMs = options?.reservedMs ?? 0;
+  }
+
+  async reserveInitial(): Promise<void> {
+    this.reserveInitialCalls += 1;
+    if (this.initialReserveError) throw this.initialReserveError;
+    if (this.state.reservedMs === 0) this.state.reservedMs = 15_000;
+    this.state.reservationIds?.push(`reserve-${this.reserveInitialCalls}`);
+  }
+
+  async ensureTranscriptionWindow(durationMs: number): Promise<void> {
+    const nextConsumed = this.state.consumedMs + durationMs;
+    if (
+      this.failAfterConsumedMs !== null &&
+      nextConsumed > this.failAfterConsumedMs
+    ) {
+      this.state.status = "spend_cap_reached";
+      this.state.error = "insufficient credits for meeting transcription";
+      throw new MeetingBillingError(
+        "insufficient_credits",
+        "insufficient credits for meeting transcription",
+      );
+    }
+    this.state.consumedMs = nextConsumed;
+    while (this.state.reservedMs < nextConsumed) {
+      this.state.reservedMs += 15_000;
+      this.state.reservationIds?.push(
+        `reserve-${this.state.reservationIds.length + 1}`,
+      );
+    }
+  }
+
+  async reconcile(reason: MeetingEndReason) {
+    this.reconcileCalls.push(reason);
+    this.state.status = "reconciled";
+    return this.state;
   }
 }
 
@@ -464,12 +521,16 @@ export const mockMeetingsCompanionPlugin: Plugin = {
 };
 
 /** One-line factory: pipeline + deps for a MeetingService under test. */
-export function scriptedDeps(adapters: MeetingPlatformAdapter[]): {
+export function scriptedDeps(
+  adapters: MeetingPlatformAdapter[],
+  billingSessions: FakeMeetingBillingSession[] = [],
+): {
   deps: {
     adapters: Map<MeetingPlatform, MeetingPlatformAdapter>;
     createPipeline: (
       options: MeetingPipelineOptions,
     ) => MeetingPipelineInstance;
+    createBillingSession?: MeetingServiceDependencies["createBillingSession"];
   };
   pipelines: ScriptedPipeline[];
 } {
@@ -482,6 +543,17 @@ export function scriptedDeps(adapters: MeetingPlatformAdapter[]): {
         pipelines.push(pipeline);
         return pipeline;
       },
+      ...(billingSessions.length > 0
+        ? {
+            createBillingSession: () => {
+              const billing = billingSessions.shift();
+              if (!billing) {
+                throw new Error("[scriptedDeps] no billing session queued");
+              }
+              return billing;
+            },
+          }
+        : {}),
     },
     pipelines,
   };

--- a/plugins/plugin-meetings/src/types.ts
+++ b/plugins/plugin-meetings/src/types.ts
@@ -17,7 +17,9 @@
 import type { IAgentRuntime, UUID } from "@elizaos/core";
 import type {
   MeetingAutoLeaveConfig,
+  MeetingBillingState,
   MeetingEndReason,
+  MeetingJoinRequest,
   MeetingParticipant,
   MeetingPlatform,
   MeetingSessionStatus,
@@ -115,6 +117,36 @@ export interface MeetingTranscriptionPipeline extends MeetingAudioSink {
   speakerNames(): string[];
 }
 
+export type MeetingBillingErrorCode = "insufficient_credits" | "billing_failed";
+
+export class MeetingBillingError extends Error {
+  constructor(
+    readonly code: MeetingBillingErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "MeetingBillingError";
+  }
+}
+
+export interface MeetingBillingSessionInput {
+  runtime: IAgentRuntime;
+  sessionId: UUID;
+  request: MeetingJoinRequest;
+  maxDurationMs: number;
+}
+
+/**
+ * Metered meeting billing seam. Cloud wiring reserves/debits/refunds through
+ * its credit ledger; local/self-hosted runtimes omit it and remain unmetered.
+ */
+export interface MeetingBillingSession {
+  readonly state: MeetingBillingState;
+  reserveInitial(): Promise<void>;
+  ensureTranscriptionWindow(durationMs: number): Promise<void>;
+  reconcile(reason: MeetingEndReason): Promise<MeetingBillingState>;
+}
+
 export interface MeetingPipelineOptions {
   runtime: IAgentRuntime;
   sessionId: UUID;
@@ -122,4 +154,6 @@ export interface MeetingPipelineOptions {
   language?: string;
   /** Retain raw session audio for the transcript record's audio player. */
   retainAudio: boolean;
+  billing?: MeetingBillingSession;
+  onSpendCapReached?: (error: MeetingBillingError) => void;
 }

--- a/plugins/plugin-meetings/src/types.ts
+++ b/plugins/plugin-meetings/src/types.ts
@@ -129,6 +129,16 @@ export class MeetingBillingError extends Error {
   }
 }
 
+export function isMeetingInsufficientCreditsError(
+  error: unknown,
+): error is Error & { code: "insufficient_credits" } {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    error.code === "insufficient_credits"
+  );
+}
+
 export interface MeetingBillingSessionInput {
   runtime: IAgentRuntime;
   sessionId: UUID;
@@ -155,5 +165,7 @@ export interface MeetingPipelineOptions {
   /** Retain raw session audio for the transcript record's audio player. */
   retainAudio: boolean;
   billing?: MeetingBillingSession;
-  onSpendCapReached?: (error: MeetingBillingError) => void;
+  onSpendCapReached?: (
+    error: Error & { code: "insufficient_credits" },
+  ) => void;
 }


### PR DESCRIPTION
## Summary
- adds a cloud-shared meeting billing session backed by the existing credit reservation ledger
- reserves an initial launch window, extends bounded chunks before ASR, reconciles holds exactly once, and preserves spend-cap end state
- wires the meetings plugin seam so insufficient credit fails before bot launch, mid-meeting cap aborts cleanly, setup failures refund, and routes expose billing state

Closes #13427.

## Verification
- bun run --cwd plugins/plugin-meetings test src/service.test.ts src/routes/meetings-routes.test.ts src/pipeline/__tests__/pipeline.test.ts
- bun run --cwd plugins/plugin-meetings typecheck
- bunx biome check packages/cloud/shared/src/lib/index.ts packages/cloud/shared/src/lib/services/meeting-billing.ts packages/cloud/shared/src/lib/services/__tests__/meeting-billing.test.ts packages/shared/src/meetings.ts plugins/plugin-meetings/src/types.ts plugins/plugin-meetings/src/service.ts plugins/plugin-meetings/src/pipeline/pipeline.ts plugins/plugin-meetings/src/test-support.ts plugins/plugin-meetings/src/service.test.ts plugins/plugin-meetings/src/routes/meetings-routes.ts plugins/plugin-meetings/src/routes/meetings-routes.test.ts plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
- bun test packages/cloud/shared/src/lib/services/__tests__/meeting-billing.test.ts > /tmp/meeting-billing-test-full.out 2>&1 (6 pass, 0 fail; pass lines manually reviewed)

## Evidence
- .github/issue-evidence/13427-meeting-credit-reservations.md

## Notes
- packages/cloud/shared typecheck still reports pre-existing transitive @elizaos/auth/* resolution errors from app-core; filtered output showed no diagnostics in the new meeting billing files.
- live funded-org proof remains tracked separately in #13428 because it requires real cloud credentials and billing rows.