### PR TITLE
fix(#13478,#13484): align orchestrator lifecycle scoring

### DIFF
--- a/.github/issue-evidence/13478-13484-orchestrator-lifecycle-benchmark.md
+++ b/.github/issue-evidence/13478-13484-orchestrator-lifecycle-benchmark.md
@@ -1,0 +1,19 @@
+# Issues #13478 / #13484 orchestrator lifecycle benchmark
+
+## Change
+
+- `report_active_subagent_status` now requires a `status_query` lifecycle event; `spawn` and `share` no longer satisfy status reporting.
+- The TypeScript benchmark bridge/provider prompts now tell the agent to use normal task-management/orchestrator actions for lifecycle operations and to use REPLY only for user-facing narration.
+- Regression coverage pins both the stricter Python evaluator contract and the updated benchmark prompt language.
+
+## Verification
+
+- `pytest packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py -q` passed: 12 tests.
+- `bunx vitest run --config packages/lifeops-bench/vitest.config.ts packages/lifeops-bench/src/server-utils.test.ts` passed: 16 tests.
+- `python -m packages.benchmarks.orchestrator_lifecycle.cli --mode simulate --max-scenarios 3 --output /tmp/olc-smoke-13478-13484` passed with 100% harness self-check.
+- `git diff --check` passed for the touched files.
+
+## Notes
+
+- `bun test packages/lifeops-bench/src/server-utils.test.ts` reached all 16 passing assertions but hung while printing coverage output; it was interrupted and replaced with the Vitest command above for a clean exit code.
+- A real bridge/model run is still required for publishable benchmark evidence; this patch verifies evaluator and prompt contracts plus deterministic smoke only.

--- a/packages/lifeops-bench/src/plugin.ts
+++ b/packages/lifeops-bench/src/plugin.ts
@@ -1046,13 +1046,13 @@ function formatContextAsText(ctx: BenchmarkContext): string {
       );
     } else if (isOrchestratorLifecycle) {
       sections.push(
-        `This is an orchestrator lifecycle benchmark. Respond with actions: REPLY and put only the next lifecycle message in text. Do not call BENCHMARK_ACTION.`,
+        `This is an orchestrator lifecycle benchmark. Use the normal task-management and orchestrator actions for lifecycle operations; use REPLY only for user-facing narration around those actions. Do not use BENCHMARK_ACTION.`,
       );
       sections.push(
-        `If the user says the current approach failed, asks to replan, changes scope, or asks to continue with revised work, acknowledge the scope change or failure and state that the updated plan has been applied.`,
+        `If the user says the current approach failed, asks to replan, changes scope, or asks to continue with revised work, apply the update through the running task and then acknowledge it.`,
       );
       sections.push(
-        `For delegation/status turns, mention the active subagent and the status or progress update. For underspecified turns, ask a clarifying question and say you will wait before starting.`,
+        `For status turns, query the active task or subagent registry before reporting progress; prose-only status claims do not satisfy the benchmark. For underspecified turns, ask a clarifying question and wait before starting.`,
       );
     } else {
       sections.push(

--- a/packages/lifeops-bench/src/server-utils.test.ts
+++ b/packages/lifeops-bench/src/server-utils.test.ts
@@ -256,8 +256,10 @@ describe("composeBenchmarkPrompt", () => {
     });
 
     expect(prompt).toContain("orchestrator lifecycle benchmark");
-    expect(prompt).toContain("updated plan has been applied");
-    expect(prompt).toContain("active subagent status or progress");
+    expect(prompt).toContain("normal task-management and orchestrator actions");
+    expect(prompt).toContain("prose-only lifecycle claims do not satisfy");
+    expect(prompt).toContain("query the active task or subagent registry");
+    expect(prompt).not.toContain("Use REPLY text for the next lifecycle message");
   });
 });
 
@@ -403,8 +405,14 @@ describe("benchmark plugin LifeOps tool capture", () => {
     expect(rendered?.text).toContain(
       "This is an orchestrator lifecycle benchmark",
     );
-    expect(rendered?.text).toContain("updated plan has been applied");
-    expect(rendered?.text).toContain("active subagent");
+    expect(rendered?.text).toContain(
+      "normal task-management and orchestrator actions",
+    );
+    expect(rendered?.text).toContain(
+      "query the active task or subagent registry",
+    );
+    expect(rendered?.text).toContain("prose-only status claims do not satisfy");
+    expect(rendered?.text).not.toContain("Respond with actions: REPLY");
 
     setBenchmarkContext(null);
   });

--- a/packages/lifeops-bench/src/server-utils.ts
+++ b/packages/lifeops-bench/src/server-utils.ts
@@ -592,10 +592,11 @@ export function composeBenchmarkPrompt(params: {
     segments.push(
       [
         "This is an orchestrator lifecycle benchmark.",
-        "Use REPLY text for the next lifecycle message.",
-        "For failed approaches, replans, and scope changes, acknowledge the failure or scope change and state that the updated plan has been applied.",
-        "For delegation/status turns, mention active subagent status or progress.",
-        "For underspecified turns, ask a clarifying question and say you will wait before starting.",
+        "Use your normal task-management and orchestrator actions for lifecycle operations: delegation, task updates, status checks, pause, resume, cancel, and sharing results.",
+        "Use REPLY for user-facing narration only; prose-only lifecycle claims do not satisfy this benchmark.",
+        "For failed approaches, replans, and scope changes, apply the update through the running task and then acknowledge it.",
+        "For status turns, query the active task or subagent registry before reporting progress.",
+        "For underspecified turns, ask a clarifying question and wait before starting work.",
       ].join(" "),
     );
   } else {


### PR DESCRIPTION
## Summary

Fixes #13478. Fixes #13484.

- require a real `status_query` lifecycle event for `report_active_subagent_status`; `spawn` and `share` no longer satisfy status reporting
- align the TypeScript benchmark prompt/provider guidance with structural lifecycle action scoring instead of prose-only REPLY coaching
- add regression tests for spawn/share status failures and for the updated prompt language

## Verification

- `pytest packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py -q`
- `bunx vitest run --config packages/lifeops-bench/vitest.config.ts packages/lifeops-bench/src/server-utils.test.ts`
- `python -m packages.benchmarks.orchestrator_lifecycle.cli --mode simulate --max-scenarios 3 --output /tmp/olc-smoke-13478-13484`
- `git diff --check` for touched files

## Notes

- `bun test packages/lifeops-bench/src/server-utils.test.ts` reached all 16 passing assertions but hung while printing coverage output; I interrupted it and used the Vitest command above for a clean exit code.
- Real bridge/model benchmark evidence is still required before treating this as a publishable benchmark result; simulate mode is only harness/evaluator smoke.

Evidence note: `.github/issue-evidence/13478-13484-orchestrator-lifecycle-benchmark.md`.