### PR TITLE
[codex] fix smithers benchmark harness proof

### DIFF
--- a/packages/benchmarks/action-calling/tests/test_action_calling_cli.py
+++ b/packages/benchmarks/action-calling/tests/test_action_calling_cli.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 import importlib
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 
 
 cli = importlib.import_module("benchmarks.action-calling.cli")
@@ -90,3 +95,130 @@ def test_main_count_scenarios_does_not_require_out(monkeypatch, capsys) -> None:
     output = capsys.readouterr().out
     assert '"base": 1' in output
     assert '"edge": 10' in output
+
+
+def test_main_runs_smithers_harness_against_local_server(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    packages_root = Path(__file__).resolve().parents[3]
+    smithers_test_helpers = packages_root / "benchmarks" / "smithers-adapter" / "tests"
+    if str(smithers_test_helpers) not in sys.path:
+        sys.path.insert(0, str(smithers_test_helpers))
+    from live_harness import materialize_live_smithers_install
+
+    install_dir = tmp_path / "smithers-install"
+    materialize_live_smithers_install(install_dir)
+    received: list[dict[str, object]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("content-length", "0"))
+            body = json.loads(self.rfile.read(length).decode("utf-8"))
+            body["_path"] = self.path
+            received.append(body)
+            if self.path.endswith("/responses"):
+                payload = {
+                    "id": "resp-action-calling-smithers",
+                    "object": "response",
+                    "created_at": 1,
+                    "status": "completed",
+                    "model": body.get("model", "local-smithers"),
+                    "output": [
+                        {
+                            "id": "fc-action-calling-smithers",
+                            "type": "function_call",
+                            "status": "completed",
+                            "call_id": "call_action_calling_smithers",
+                            "name": "mail_search",
+                            "arguments": json.dumps({"query": "ACME invoice"}),
+                        }
+                    ],
+                    "usage": {
+                        "input_tokens": 13,
+                        "output_tokens": 4,
+                        "total_tokens": 17,
+                    },
+                }
+            else:
+                payload = {
+                    "id": "chatcmpl-action-calling-smithers",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": body.get("model", "local-smithers"),
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": [
+                                    {
+                                        "id": "call_action_calling_smithers",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "mail_search",
+                                            "arguments": json.dumps({"query": "ACME invoice"}),
+                                        },
+                                    }
+                                ],
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 13,
+                        "completion_tokens": 4,
+                        "total_tokens": 17,
+                    },
+                }
+            encoded = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("BENCHMARK_HARNESS", "smithers")
+    monkeypatch.setenv("BENCHMARK_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "local-key")
+    monkeypatch.setenv("SMITHERS_DIR", str(install_dir))
+    out_dir = tmp_path / "out"
+    try:
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "action-calling",
+                "--provider",
+                "cerebras",
+                "--model",
+                "local-smithers",
+                "--base-url",
+                f"http://127.0.0.1:{server.server_port}/v1",
+                "--test-file",
+                str(cli.SMOKE_TEST),
+                "--max-examples",
+                "1",
+                "--out",
+                str(out_dir),
+            ],
+        )
+        assert cli.main() == 0
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    summary = json.loads((out_dir / "action-calling-results.json").read_text(encoding="utf-8"))
+    assert summary["provider"] == "cerebras"
+    assert summary["generation_source"] == "native_tool_calls"
+    assert summary["metrics"]["score"] == 1.0
+    assert summary["n"] == 1
+    assert received
+    assert received[0]["model"] == "local-smithers"
+    assert received[0]["_path"] in {"/v1/chat/completions", "/v1/responses"}

--- a/packages/benchmarks/bfcl/tests/test_e2e_smoke.py
+++ b/packages/benchmarks/bfcl/tests/test_e2e_smoke.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
@@ -92,6 +95,151 @@ def test_simple_multiple_smoke_full_score(fixture_dir: Path) -> None:
     assert results.metrics.total_tests == 2
     assert results.metrics.ast_accuracy == pytest.approx(1.0, abs=0.001)
     assert all(r.status == TestStatus.PASSED for r in results.results)
+
+
+def test_smithers_harness_runs_real_bfcl_runner_against_local_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packages_root = Path(__file__).resolve().parents[3]
+    smithers_test_helpers = packages_root / "benchmarks" / "smithers-adapter" / "tests"
+    if str(smithers_test_helpers) not in sys.path:
+        sys.path.insert(0, str(smithers_test_helpers))
+    from live_harness import materialize_live_smithers_install
+
+    data_dir = tmp_path / "data"
+    _write_ndjson(
+        data_dir / "BFCL_v3_irrelevance.json",
+        [
+            {
+                "id": "irrelevance_smithers_0",
+                "question": [[{"role": "user", "content": "Tell me a short greeting."}]],
+                "function": [
+                    {
+                        "name": "get_weather",
+                        "description": "get weather",
+                        "parameters": {
+                            "type": "dict",
+                            "required": ["location"],
+                            "properties": {
+                                "location": {"type": "string", "description": "city"}
+                            },
+                        },
+                    }
+                ],
+            }
+        ],
+    )
+    _write_ndjson(
+        data_dir / "possible_answer" / "BFCL_v3_irrelevance.json",
+        [{"id": "irrelevance_smithers_0", "ground_truth": []}],
+    )
+
+    install_dir = tmp_path / "smithers-install"
+    materialize_live_smithers_install(install_dir)
+
+    received: list[dict[str, object]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("content-length", "0"))
+            body = json.loads(self.rfile.read(length).decode("utf-8"))
+            body["_path"] = self.path
+            received.append(body)
+            if self.path.endswith("/responses"):
+                payload = {
+                    "id": "resp-bfcl-smithers-local",
+                    "object": "response",
+                    "created_at": 1,
+                    "status": "completed",
+                    "model": body.get("model", "local-smithers"),
+                    "output": [
+                        {
+                            "id": "msg-bfcl-smithers-local",
+                            "type": "message",
+                            "status": "completed",
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": "hello from local smithers",
+                                    "annotations": [],
+                                }
+                            ],
+                        }
+                    ],
+                    "usage": {
+                        "input_tokens": 11,
+                        "output_tokens": 4,
+                        "total_tokens": 15,
+                    },
+                }
+            else:
+                payload = {
+                    "id": "chatcmpl-bfcl-smithers-local",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": body.get("model", "local-smithers"),
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "hello from local smithers",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 11,
+                        "completion_tokens": 4,
+                        "total_tokens": 15,
+                    },
+                }
+            encoded = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("BENCHMARK_HARNESS", "smithers")
+    monkeypatch.setenv("BENCHMARK_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_BASE_URL", f"http://127.0.0.1:{server.server_port}/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "local-key")
+    monkeypatch.setenv("SMITHERS_DIR", str(install_dir))
+    try:
+        config = BFCLConfig(
+            data_path=str(data_dir),
+            output_dir=str(tmp_path / "out"),
+            use_huggingface=False,
+            categories=[BFCLCategory.IRRELEVANCE],
+            generate_report=False,
+            save_raw_responses=True,
+            save_detailed_logs=True,
+        )
+        runner = BFCLRunner(config, provider="eliza", model="local-smithers")
+        results = asyncio.run(runner.run())
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert runner.agent.__class__.__name__ == "SmithersBFCLAgent"
+    assert results.provider == "smithers"
+    assert results.metrics.total_tests == 1
+    assert results.metrics.overall_score == pytest.approx(1.0)
+    assert results.results[0].status == TestStatus.PASSED
+    assert received
+    assert received[0]["model"] == "local-smithers"
+    assert received[0]["_path"] in {"/v1/chat/completions", "/v1/responses"}
+    trajectory_files = list((tmp_path / "out" / "trajectories").glob("bfcl_compact_*.jsonl"))
+    assert len(trajectory_files) == 1
 
 
 def test_edge_expansion_adds_ten_variants_per_selected_case(fixture_dir: Path) -> None:

--- a/packages/benchmarks/smithers-adapter/smithers_adapter/client.py
+++ b/packages/benchmarks/smithers-adapter/smithers_adapter/client.py
@@ -28,7 +28,9 @@ from typing import Any, Mapping, Sequence
 logger = logging.getLogger(__name__)
 
 _HARNESS_SCRIPT_NAME = "smithers_turn.mjs"
+_OPTIMIZATION_SCRIPT_NAME = "optimization.mjs"
 _CANONICAL_SCRIPT = Path(__file__).resolve().parent / _HARNESS_SCRIPT_NAME
+_CANONICAL_OPTIMIZATION_SCRIPT = Path(__file__).resolve().parent / _OPTIMIZATION_SCRIPT_NAME
 
 _OPENAI_COMPAT_DEFAULT_BASE_URLS = {
     "cerebras": "https://api.cerebras.ai/v1",
@@ -310,16 +312,21 @@ class SmithersClient:
         return resolve_bun_binary(self._bun_bin_explicit)
 
     def materialize_script(self) -> Path:
-        """Copy the canonical harness into the install dir (beside node_modules).
+        """Copy the canonical harness files into the install dir.
 
         Bun resolves an entry file's bare imports from the file's own directory
         tree, so the script must live next to Smithers' ``node_modules``.
         """
+        self.install_dir.mkdir(parents=True, exist_ok=True)
         target = self.install_dir / _HARNESS_SCRIPT_NAME
-        src_text = _CANONICAL_SCRIPT.read_text(encoding="utf-8")
-        if not target.exists() or target.read_text(encoding="utf-8") != src_text:
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(src_text, encoding="utf-8")
+        optimization_target = self.install_dir / _OPTIMIZATION_SCRIPT_NAME
+        for src, dst in (
+            (_CANONICAL_SCRIPT, target),
+            (_CANONICAL_OPTIMIZATION_SCRIPT, optimization_target),
+        ):
+            src_text = src.read_text(encoding="utf-8")
+            if not dst.exists() or dst.read_text(encoding="utf-8") != src_text:
+                dst.write_text(src_text, encoding="utf-8")
         self._script_path = target
         return target
 

--- a/packages/benchmarks/smithers-adapter/smithers_adapter/smithers_turn.mjs
+++ b/packages/benchmarks/smithers-adapter/smithers_adapter/smithers_turn.mjs
@@ -11,12 +11,10 @@
 // of looping and executing them — exactly what single-turn benchmarks (BFCL,
 // action-calling, ...) need.
 //
-// Provider model is forced onto the chat-completions endpoint via
-// `provider.chat(model)` because OpenAI-compatible backends such as Cerebras do
-// not implement the newer `/responses` endpoint that `@ai-sdk/openai` defaults
-// to for bare model ids.
+// Smithers' OpenAIAgent accepts the OpenAI-compatible `baseURL`/`apiKey` pair
+// directly with a string model and resolves the SDK provider internally. That
+// keeps this adapter aligned with the Smithers package's own AI SDK version.
 
-import { createOpenAI } from "@ai-sdk/openai";
 import { jsonSchema } from "ai";
 import { OpenAIAgent } from "smithers-orchestrator";
 import {
@@ -279,10 +277,10 @@ async function main() {
   let reasoningEffort = payload.reasoning_effort ?? ctx.reasoning_effort;
   if (!reasoningEffort && isGptOss(modelName)) reasoningEffort = "low";
 
-  const sdkProvider = createOpenAI({ baseURL, apiKey });
-
   const agentOpts = {
-    model: sdkProvider.chat(modelName),
+    model: modelName,
+    baseURL,
+    apiKey,
     // ToolLoopAgent passthrough:
     ...(tools ? { tools } : {}),
     ...(toolChoice ? { toolChoice } : {}),

--- a/packages/benchmarks/smithers-adapter/tests/live_harness.py
+++ b/packages/benchmarks/smithers-adapter/tests/live_harness.py
@@ -1,0 +1,92 @@
+"""Helpers for tests that run the real Smithers Bun harness locally."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_HARNESS_DEPS = (
+    ("smithers-orchestrator", ("smithers-orchestrator@*", "smithers-orchestrator")),
+    ("@ai-sdk/openai", ("@ai-sdk+openai@*", "@ai-sdk/openai")),
+    ("ai", ("ai@*", "ai")),
+    ("zod", ("zod@*", "zod")),
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _dep_exists(node_modules: Path, dep: str) -> bool:
+    return (node_modules / dep).exists()
+
+
+def _has_harness_deps(node_modules: Path) -> bool:
+    return all(_dep_exists(node_modules, dep) for dep, _ in _HARNESS_DEPS)
+
+
+def _find_bun_store_dep(repo_root: Path, pattern: str, package_path: str) -> Path | None:
+    bun_root = repo_root / "node_modules" / ".bun"
+    matches = sorted(bun_root.glob(f"{pattern}/node_modules/{package_path}"))
+    return matches[-1] if matches else None
+
+
+def _symlink_dep(node_modules: Path, dep: str, source: Path) -> None:
+    target = node_modules / dep
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        return
+    target.symlink_to(source, target_is_directory=True)
+
+
+def materialize_live_smithers_install(install_dir: Path) -> None:
+    """Create a Smithers install usable by ``SmithersClient`` tests.
+
+    The preferred path uses the repository's Bun store so tests do not mutate
+    the checkout or download packages. Setting ``SMITHERS_LIVE_SUBPROCESS_PROOF=1``
+    allows a temporary ``bun add`` fallback for machines without the store.
+    """
+    repo_root = _repo_root()
+    install_dir.mkdir(parents=True, exist_ok=True)
+
+    for candidate in (
+        repo_root / "node_modules",
+        repo_root / "plugins" / "plugin-workflow" / "node_modules",
+    ):
+        if _has_harness_deps(candidate):
+            (install_dir / "node_modules").symlink_to(candidate, target_is_directory=True)
+            return
+
+    node_modules = install_dir / "node_modules"
+    for dep, (pattern, package_path) in _HARNESS_DEPS:
+        source = _find_bun_store_dep(repo_root, pattern, package_path)
+        if source is None:
+            break
+        _symlink_dep(node_modules, dep, source)
+    else:
+        return
+
+    if os.environ.get("SMITHERS_LIVE_SUBPROCESS_PROOF") != "1":
+        pytest.skip(
+            "set SMITHERS_LIVE_SUBPROCESS_PROOF=1 to provision JS deps and run the live Smithers proof"
+        )
+
+    (install_dir / "package.json").write_text('{"type":"module"}\n', encoding="utf-8")
+    subprocess.run(
+        [
+            os.environ.get("BUN_BIN", "bun"),
+            "add",
+            "smithers-orchestrator@0.26.1",
+            "@ai-sdk/openai",
+            "ai",
+            "zod",
+        ],
+        cwd=install_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )

--- a/packages/benchmarks/smithers-adapter/tests/test_client.py
+++ b/packages/benchmarks/smithers-adapter/tests/test_client.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import json
-import os
-import subprocess
+import sys
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
-import pytest
+_TEST_DIR = Path(__file__).resolve().parent
+if str(_TEST_DIR) not in sys.path:
+    sys.path.insert(0, str(_TEST_DIR))
 
+from live_harness import materialize_live_smithers_install
 from smithers_adapter.client import (
     MessageResponse,
     SmithersClient,
@@ -102,46 +104,8 @@ def test_build_command_shape(tmp_path: Path) -> None:
 def test_send_message_runs_real_smithers_harness_against_local_chat_server(
     tmp_path: Path,
 ) -> None:
-    packages_root = Path(__file__).resolve().parents[3]
-    repo_root = packages_root.parent
-    node_modules = repo_root / "node_modules"
-    has_harness_deps = all(
-        (node_modules / dep).exists()
-        for dep in ("smithers-orchestrator", "@ai-sdk/openai", "ai", "zod")
-    )
-    if not has_harness_deps:
-        node_modules = repo_root / "plugins" / "plugin-workflow" / "node_modules"
-        has_harness_deps = all(
-            (node_modules / dep).exists()
-            for dep in ("smithers-orchestrator", "@ai-sdk/openai", "ai", "zod")
-        )
-    should_provision = os.environ.get("SMITHERS_LIVE_SUBPROCESS_PROOF") == "1"
-    if not has_harness_deps and not should_provision:
-        pytest.skip(
-            "set SMITHERS_LIVE_SUBPROCESS_PROOF=1 to provision JS deps and run the live Smithers subprocess proof"
-        )
-
     install_dir = tmp_path / "smithers-install"
-    install_dir.mkdir()
-    if has_harness_deps:
-        (install_dir / "node_modules").symlink_to(node_modules, target_is_directory=True)
-    else:
-        (install_dir / "package.json").write_text('{"type":"module"}\n', encoding="utf-8")
-        subprocess.run(
-            [
-                os.environ.get("BUN_BIN", "bun"),
-                "add",
-                "smithers-orchestrator@0.26.1",
-                "@ai-sdk/openai",
-                "ai",
-                "zod",
-            ],
-            cwd=install_dir,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
+    materialize_live_smithers_install(install_dir)
     received: list[dict[str, object]] = []
 
     class Handler(BaseHTTPRequestHandler):

--- a/packages/benchmarks/smithers-adapter/tests/test_client.py
+++ b/packages/benchmarks/smithers-adapter/tests/test_client.py
@@ -3,7 +3,13 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+
+import pytest
 
 from smithers_adapter.client import (
     MessageResponse,
@@ -79,6 +85,7 @@ def test_materialize_script_writes_harness(tmp_path: Path) -> None:
     assert target.name == "smithers_turn.mjs"
     assert target.exists()
     assert "OpenAIAgent" in target.read_text(encoding="utf-8")
+    assert (tmp_path / "optimization.mjs").exists()
 
 
 def test_build_command_shape(tmp_path: Path) -> None:
@@ -90,3 +97,147 @@ def test_build_command_shape(tmp_path: Path) -> None:
         return
     assert cmd[1] == "run"
     assert cmd[-1].endswith("smithers_turn.mjs")
+
+
+def test_send_message_runs_real_smithers_harness_against_local_chat_server(
+    tmp_path: Path,
+) -> None:
+    packages_root = Path(__file__).resolve().parents[3]
+    repo_root = packages_root.parent
+    node_modules = repo_root / "node_modules"
+    has_harness_deps = all(
+        (node_modules / dep).exists()
+        for dep in ("smithers-orchestrator", "@ai-sdk/openai", "ai", "zod")
+    )
+    if not has_harness_deps:
+        node_modules = repo_root / "plugins" / "plugin-workflow" / "node_modules"
+        has_harness_deps = all(
+            (node_modules / dep).exists()
+            for dep in ("smithers-orchestrator", "@ai-sdk/openai", "ai", "zod")
+        )
+    should_provision = os.environ.get("SMITHERS_LIVE_SUBPROCESS_PROOF") == "1"
+    if not has_harness_deps and not should_provision:
+        pytest.skip(
+            "set SMITHERS_LIVE_SUBPROCESS_PROOF=1 to provision JS deps and run the live Smithers subprocess proof"
+        )
+
+    install_dir = tmp_path / "smithers-install"
+    install_dir.mkdir()
+    if has_harness_deps:
+        (install_dir / "node_modules").symlink_to(node_modules, target_is_directory=True)
+    else:
+        (install_dir / "package.json").write_text('{"type":"module"}\n', encoding="utf-8")
+        subprocess.run(
+            [
+                os.environ.get("BUN_BIN", "bun"),
+                "add",
+                "smithers-orchestrator@0.26.1",
+                "@ai-sdk/openai",
+                "ai",
+                "zod",
+            ],
+            cwd=install_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+    received: list[dict[str, object]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("content-length", "0"))
+            body = json.loads(self.rfile.read(length).decode("utf-8"))
+            body["_path"] = self.path
+            received.append(body)
+            if self.path.endswith("/responses"):
+                payload = {
+                    "id": "resp-smithers-local",
+                    "object": "response",
+                    "created_at": 1,
+                    "status": "completed",
+                    "model": body.get("model", "local-smithers"),
+                    "output": [
+                        {
+                            "id": "msg-smithers-local",
+                            "type": "message",
+                            "status": "completed",
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": "local smithers benchmark proof",
+                                    "annotations": [],
+                                }
+                            ],
+                        }
+                    ],
+                    "usage": {
+                        "input_tokens": 7,
+                        "output_tokens": 5,
+                        "total_tokens": 12,
+                    },
+                }
+            else:
+                payload = {
+                    "id": "chatcmpl-smithers-local",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": body.get("model", "local-smithers"),
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "local smithers benchmark proof",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 7,
+                        "completion_tokens": 5,
+                        "total_tokens": 12,
+                    },
+                }
+            data = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        client = SmithersClient(
+            install_dir=install_dir,
+            provider="openai",
+            model="local-smithers",
+            api_key="local-key",
+            base_url=f"http://127.0.0.1:{server.server_port}/v1",
+            timeout_s=60,
+        )
+        response = client.send_message(
+            "run the Smithers benchmark harness",
+            {"benchmark": "smithers-adapter-live-proof"},
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert response.text == "local smithers benchmark proof"
+    assert response.params["usage"] == {
+        "prompt_tokens": 7,
+        "completion_tokens": 5,
+        "total_tokens": 12,
+        "cached_tokens": 0,
+        "reasoning_tokens": 0,
+    }
+    assert received
+    assert received[0]["model"] == "local-smithers"
+    assert received[0]["_path"] in {"/v1/chat/completions", "/v1/responses"}


### PR DESCRIPTION
## Summary
- Fix the Smithers benchmark adapter materialization so `optimization.mjs` is copied beside `smithers_turn.mjs` into fresh Smithers installs.
- Switch `smithers_turn.mjs` to Smithers `OpenAIAgent` string-model configuration (`model`, `baseURL`, `apiKey`) so the harness uses the Smithers package's own AI SDK provider resolution instead of mixing provider objects from a separate SDK instance.
- Add an opt-in live subprocess proof that provisions a temporary Smithers install, starts a local OpenAI-compatible server, and drives `SmithersClient.send_message()` through the real Bun/Smithers harness.

## Why
The benchmark adapter tests previously proved payload parsing and Python glue, but not that a fresh materialized Smithers harness could actually run. The opt-in proof exposed two real issues: `optimization.mjs` was not materialized, and the prebuilt provider path could mismatch Smithers' bundled AI SDK expectations.

## Validation
- `python -m pytest packages/benchmarks/smithers-adapter/tests -q` passed: 24 passed, 1 skipped.
- `PYTHONPATH=/Users/shawwalters/.codex/worktrees/c65b/eliza/packages python -m pytest packages/benchmarks/orchestrator/tests/test_adapter_discovery.py -k 'smithers' -q` passed: 2 passed.
- `SMITHERS_LIVE_SUBPROCESS_PROOF=1 python -m pytest packages/benchmarks/smithers-adapter/tests/test_client.py -k 'real_smithers_harness' -q` passed: 1 passed.

## Remaining gap
This proves the real Smithers/Bun benchmark harness runs against an OpenAI-compatible local server. It is still not a live external-provider benchmark run with model credentials and trajectory artifacts; that requires provider credentials in the environment.
