### PR TITLE
Fix cloud console loading states and account DTO types

### DIFF
--- a/.github/issue-evidence/13447-console-visual-loading-states.md
+++ b/.github/issue-evidence/13447-console-visual-loading-states.md
@@ -1,0 +1,50 @@
+# #13447 console visual loading-state evidence
+
+Date: 2026-07-04
+
+## Changes verified
+
+- `/dashboard/apps` renders loading stat skeletons before app data resolves, so the page no longer shows success-shaped zero stats or a blank light rectangle during load/error transitions.
+- `/dashboard/agents` no longer renders the pricing/empty banner while the agents table query is still loading, and renders a real error state when the query fails.
+- Billing disabled buy-credit states use explicit dark styling instead of inherited blank/gray button states; invoice fetch failures render an error row rather than silently looking empty.
+- Account UI consumes the shared linked-account DTO exported by `@elizaos/shared`, and `useWalletState` has an explicit `WalletEntry` callback annotation so the console typecheck remains clean.
+
+## Commands
+
+```bash
+bunx @biomejs/biome check --write packages/ui/src/api/client-agent.ts packages/ui/src/hooks/useAccounts.ts packages/ui/src/components/accounts/AddAccountDialog.tsx packages/ui/src/state/useWalletState.ts packages/ui/src/cloud/applications/ApplicationsPage.tsx packages/ui/src/cloud/instances/AgentsPage.tsx packages/ui/src/cloud/billing/components/billing-tab.tsx
+```
+
+Result: passed.
+
+```bash
+bun run --cwd packages/contracts build
+bun run --cwd packages/cloud/routing build
+bun run --cwd packages/shared build:i18n
+bun run --cwd packages/ui typecheck
+```
+
+Result: passed. This first reproduced the linked-account and wallet type errors in a fresh worktree; after the fix, `packages/ui` typecheck exits cleanly.
+
+```bash
+bun run --cwd packages/app audit:app
+```
+
+Result: passed, `373 passed (13.5m)`. Summary: `broken=0`, `needs-work=0`, `needs-eyeball=25`, `good=347`, `minimalism-budget-failures=0`.
+
+```bash
+bun run --cwd packages/app audit:cloud
+```
+
+Result: passed, `69 passed (3.2m)`. Summary: `broken=0`, `needs-work=0`, `needs-eyeball=68`.
+
+## Manual review targets
+
+Generated cloud-audit artifacts were written under `packages/app/aesthetic-audit-output-cloud/`.
+
+- `desktop/dashboard-agents.png`, `mobile/dashboard-agents.png`, plus hover captures: no console errors, no blue-color hits, no hover violations, no screenshot quality issues.
+- `desktop/dashboard-apps.png`, `mobile/dashboard-apps.png`, plus hover captures: no console errors, no blue-color hits, no hover violations, no screenshot quality issues.
+- `desktop/dashboard-billing-success.png`, `mobile/dashboard-billing-success.png`: no console errors, no blue-color hits, no hover violations, no screenshot quality issues.
+- `desktop/dashboard-invoice-detail.png`, `mobile/dashboard-invoice-detail.png`, plus hover captures: no console errors, no blue-color hits, no hover violations, no screenshot quality issues.
+
+The full cloud report is `packages/app/aesthetic-audit-output-cloud/report.json`; the contact sheet is `packages/app/aesthetic-audit-output-cloud/contact-sheet.html`.

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -305,6 +305,15 @@ export type BootstrapExchangeResult =
 
 export type AccountStrategy = ServiceRouteAccountStrategy;
 
+export type {
+  LinkedAccountAccountSource,
+  LinkedAccountConfig,
+  LinkedAccountHealth,
+  LinkedAccountHealthDetail,
+  LinkedAccountProviderId,
+  LinkedAccountUsage,
+} from "@elizaos/shared";
+
 export interface AccountWithCredentialFlag extends LinkedAccountConfig {
   hasCredential: boolean;
 }

--- a/packages/ui/src/cloud/applications/ApplicationsPage.tsx
+++ b/packages/ui/src/cloud/applications/ApplicationsPage.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Activity, Grid3x3, TrendingUp, Users } from "lucide-react";
-import { DashboardStatCard } from "../../cloud-ui/components/brand";
+import { BrandCard, DashboardStatCard } from "../../cloud-ui/components/brand";
 import {
   AppsEmptyState,
   AppsPageWrapper,
@@ -17,11 +17,35 @@ import {
   DashboardStatGrid,
   DashboardToolbar,
 } from "../../cloud-ui/components/layout";
+import { Skeleton } from "../../components/ui/skeleton";
 import { useRequireAuth } from "../lib/use-session-auth";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { AppsTable } from "./components/apps-table";
 import { CreateAppButton } from "./components/create-app-button";
 import { useApps } from "./lib/apps";
+
+function AppsStatsSkeleton(): React.JSX.Element {
+  return (
+    <DashboardStatGrid data-onboarding="apps-stats">
+      {["total", "active", "users", "requests"].map((id) => (
+        <BrandCard
+          key={id}
+          className="min-h-[108px] justify-between p-4"
+          corners={false}
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 space-y-2">
+              <Skeleton className="h-3 w-24 bg-white/10" />
+              <Skeleton className="h-7 w-16 bg-white/10" />
+            </div>
+            <Skeleton className="size-10 rounded-sm bg-white/10" />
+          </div>
+          <Skeleton className="h-3 w-28 bg-white/10" />
+        </BrandCard>
+      ))}
+    </DashboardStatGrid>
+  );
+}
 
 /** /dashboard/apps */
 export default function ApplicationsPage() {
@@ -33,6 +57,7 @@ export default function ApplicationsPage() {
   const totalUsers = apps.reduce((sum, app) => sum + app.total_users, 0);
   const totalRequests = apps.reduce((sum, app) => sum + app.total_requests, 0);
   const activeCount = apps.filter((a) => a.is_active).length;
+  const showLoading = !session.ready || isLoading;
 
   return (
     <AppsPageWrapper>
@@ -40,37 +65,41 @@ export default function ApplicationsPage() {
         <DashboardToolbar className="justify-end">
           <CreateAppButton />
         </DashboardToolbar>
-        <DashboardStatGrid data-onboarding="apps-stats">
-          <DashboardStatCard
-            label={t("cloud.apps.stat.totalApps", {
-              defaultValue: "Total Apps",
-            })}
-            value={apps.length}
-            icon={<Grid3x3 className="h-5 w-5 text-[var(--accent)]" />}
-          />
-          <DashboardStatCard
-            label={t("cloud.apps.stat.activeApps", {
-              defaultValue: "Active Apps",
-            })}
-            value={activeCount}
-            icon={<Activity className="h-5 w-5 text-green-500" />}
-          />
-          <DashboardStatCard
-            label={t("cloud.apps.stat.totalUsers", {
-              defaultValue: "Total Users",
-            })}
-            value={totalUsers.toLocaleString()}
-            icon={<Users className="h-5 w-5 text-white/70" />}
-          />
-          <DashboardStatCard
-            label={t("cloud.apps.stat.totalRequests", {
-              defaultValue: "Total Requests",
-            })}
-            value={totalRequests.toLocaleString()}
-            icon={<TrendingUp className="h-5 w-5 text-purple-500" />}
-          />
-        </DashboardStatGrid>
-        {!session.ready || isLoading ? (
+        {showLoading ? (
+          <AppsStatsSkeleton />
+        ) : isError ? null : (
+          <DashboardStatGrid data-onboarding="apps-stats">
+            <DashboardStatCard
+              label={t("cloud.apps.stat.totalApps", {
+                defaultValue: "Total Apps",
+              })}
+              value={apps.length}
+              icon={<Grid3x3 className="h-5 w-5 text-[var(--accent)]" />}
+            />
+            <DashboardStatCard
+              label={t("cloud.apps.stat.activeApps", {
+                defaultValue: "Active Apps",
+              })}
+              value={activeCount}
+              icon={<Activity className="h-5 w-5 text-green-500" />}
+            />
+            <DashboardStatCard
+              label={t("cloud.apps.stat.totalUsers", {
+                defaultValue: "Total Users",
+              })}
+              value={totalUsers.toLocaleString()}
+              icon={<Users className="h-5 w-5 text-white/70" />}
+            />
+            <DashboardStatCard
+              label={t("cloud.apps.stat.totalRequests", {
+                defaultValue: "Total Requests",
+              })}
+              value={totalRequests.toLocaleString()}
+              icon={<TrendingUp className="h-5 w-5 text-purple-500" />}
+            />
+          </DashboardStatGrid>
+        )}
+        {showLoading ? (
           <AppsSkeleton />
         ) : isError ? (
           <DashboardErrorState

--- a/packages/ui/src/cloud/billing/components/billing-tab.tsx
+++ b/packages/ui/src/cloud/billing/components/billing-tab.tsx
@@ -66,6 +66,7 @@ export function BillingTab({ user }: BillingTabProps) {
   const navigate = useNavigate();
   const [invoices, setInvoices] = useState<InvoiceDisplay[]>([]);
   const [loadingInvoices, setLoadingInvoices] = useState(true);
+  const [invoicesError, setInvoicesError] = useState<string | null>(null);
   const [purchaseAmount, setPurchaseAmount] = useState("");
   const [isProcessingCheckout, setIsProcessingCheckout] = useState(false);
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("card");
@@ -90,13 +91,18 @@ export function BillingTab({ user }: BillingTabProps) {
 
   const fetchInvoices = useCallback(async () => {
     setLoadingInvoices(true);
+    setInvoicesError(null);
     try {
       const data = await api<{ invoices?: InvoiceDisplay[] }>(
         "/api/invoices/list",
       );
       setInvoices(data.invoices ?? []);
-    } catch {
-      setInvoices([]);
+    } catch (error) {
+      setInvoicesError(
+        error instanceof Error
+          ? error.message
+          : "Invoice history could not be loaded.",
+      );
     } finally {
       setLoadingInvoices(false);
     }
@@ -284,6 +290,7 @@ export function BillingTab({ user }: BillingTabProps) {
                       variant="ghost"
                       type="button"
                       onClick={() => setPaymentMethod("card")}
+                      aria-pressed={paymentMethod === "card"}
                       className={`flex items-center gap-2 px-4 py-2 font-mono text-sm border transition-colors ${
                         paymentMethod === "card"
                           ? "bg-accent border-accent text-accent-foreground"
@@ -297,6 +304,7 @@ export function BillingTab({ user }: BillingTabProps) {
                       variant="ghost"
                       type="button"
                       onClick={() => setPaymentMethod("crypto")}
+                      aria-pressed={paymentMethod === "crypto"}
                       className={`flex items-center gap-2 px-4 py-2 font-mono text-sm border transition-colors ${
                         paymentMethod === "crypto"
                           ? "bg-accent border-accent text-accent-foreground"
@@ -345,7 +353,7 @@ export function BillingTab({ user }: BillingTabProps) {
                       variant="primary"
                       onClick={handleBuyCredits}
                       disabled={!isValidAmount || isProcessingCheckout}
-                      className="h-11 px-6 w-full sm:w-auto flex-shrink-0 font-mono text-base whitespace-nowrap"
+                      className="h-11 px-6 w-full sm:w-auto flex-shrink-0 font-mono text-base whitespace-nowrap disabled:border disabled:border-white/10 disabled:bg-white/[0.06] disabled:text-white/35 disabled:opacity-100"
                     >
                       {isProcessingCheckout ? (
                         <>
@@ -477,6 +485,20 @@ export function BillingTab({ user }: BillingTabProps) {
               {loadingInvoices ? (
                 <div className="flex items-center justify-center p-8 border-l border-r border-b border-brand-surface">
                   <Loader2 className="h-6 w-6 animate-spin text-[var(--accent)]" />
+                </div>
+              ) : invoicesError ? (
+                <div className="flex items-start gap-3 p-8 border-l border-r border-b border-brand-surface bg-red-500/5">
+                  <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
+                  <div className="space-y-1">
+                    <p className="text-xs md:text-sm text-red-300 font-mono">
+                      {t("cloud.billingTab.invoiceLoadFailed", {
+                        defaultValue: "Invoice history could not be loaded",
+                      })}
+                    </p>
+                    <p className="text-xs text-white/45 font-mono">
+                      {invoicesError}
+                    </p>
+                  </div>
                 </div>
               ) : invoices.length === 0 ? (
                 <div className="flex items-center justify-center p-8 border-l border-r border-b border-brand-surface">

--- a/packages/ui/src/cloud/instances/AgentsPage.tsx
+++ b/packages/ui/src/cloud/instances/AgentsPage.tsx
@@ -5,6 +5,7 @@
 import type { AgentListItemDto } from "@elizaos/cloud-shared/lib/types/cloud-api";
 import {
   ContainersSkeleton,
+  DashboardErrorState,
   DashboardLoadingState,
   DashboardPageContainer,
   ElizaAgentsPageWrapper,
@@ -70,6 +71,7 @@ export default function AgentsPage() {
   const creditBalance =
     typeof credits.data?.balance === "number" ? credits.data.balance : null;
   const showSkeleton = enabled && agentsQuery.isLoading;
+  const showAgentsError = enabled && agentsQuery.isError;
 
   return (
     <ElizaAgentsPageWrapper>
@@ -78,16 +80,27 @@ export default function AgentsPage() {
             ElizaAgentsPageWrapper (DashboardRoutePage title="Instances" →
             useSetPageHeader). No inline page-level heading here — a second
             "Instances" title under the top bar read as a double title. */}
-        <ElizaAgentPricingBanner
-          runningCount={runningCount}
-          idleCount={idleCount}
-          creditBalance={creditBalance}
-        />
-
         {showSkeleton ? (
           <ContainersSkeleton />
+        ) : showAgentsError ? (
+          <DashboardErrorState
+            message={
+              agentsQuery.error instanceof Error
+                ? agentsQuery.error.message
+                : t("cloud.agents.loadFailed", {
+                    defaultValue: "Failed to load instances",
+                  })
+            }
+          />
         ) : (
-          <ElizaAgentsTable sandboxes={sandboxes} />
+          <>
+            <ElizaAgentPricingBanner
+              runningCount={runningCount}
+              idleCount={idleCount}
+              creditBalance={creditBalance}
+            />
+            <ElizaAgentsTable sandboxes={sandboxes} />
+          </>
         )}
       </DashboardPageContainer>
     </ElizaAgentsPageWrapper>

--- a/packages/ui/src/state/useWalletState.ts
+++ b/packages/ui/src/state/useWalletState.ts
@@ -262,7 +262,7 @@ export function useWalletState({
       source: WalletSource,
     ) =>
       (config?.wallets ?? []).some(
-        (wallet) =>
+        (wallet: WalletEntry) =>
           wallet.chain === chain &&
           wallet.source === source &&
           typeof wallet.address === "string" &&


### PR DESCRIPTION
## Summary

Fixes #13447

- Adds distinct loading/error/success rendering for the cloud apps stats/table and agents pricing/table states.
- Makes billing disabled checkout and invoice-error states explicit so they do not inherit broken blank/gray visuals.
- Keeps linked-account types sourced from `@elizaos/shared` and re-exported at the client boundary without duplicating DTO interfaces.
- Adds `.github/issue-evidence/13447-console-visual-loading-states.md` with verification notes and audit artifact paths.

## Verification

Current clean-head validation:

- `bunx @biomejs/biome check packages/ui/src/api/client-agent.ts packages/ui/src/state/useWalletState.ts packages/ui/src/cloud/applications/ApplicationsPage.tsx packages/ui/src/cloud/instances/AgentsPage.tsx packages/ui/src/cloud/billing/components/billing-tab.tsx` — passed.
- `git diff --check` — passed.
- Source check for the payment toggle regression called out in review: `bg-accent border-accent text-accent-foreground` appears exactly 2 times and `bg-transparent border-border text-muted hover:border-border-strong` appears exactly 2 times.

Prior audit evidence retained in `.github/issue-evidence/13447-console-visual-loading-states.md`:

- `bun run --cwd packages/ui typecheck` — passed on the original audit checkout.
- `bun run --cwd packages/app audit:app` — 373 passed; `broken=0`, `needs-work=0`.
- `bun run --cwd packages/app audit:cloud` — 69 passed; `broken=0`, `needs-work=0`.

## Local limitation

The focused Vitest file `src/cloud/billing/components/billing-tab.selected-state.test.ts` is blocked in this sparse checkout before test execution because `packages/ui/vitest.config.ts` cannot resolve `react/package.json`; this is the same local dependency-resolution limitation seen on other sparse UI checkouts, not a source-level assertion failure.
