### PR TITLE
fix(agent-orchestrator): serialize built-app registry mutations

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/built-apps-registry.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/built-apps-registry.test.ts
@@ -179,6 +179,55 @@ describe("registry round-trip", () => {
     expect(await listBuiltApps(runtime)).toHaveLength(1);
   });
 
+  it("concurrent registrations from different sessions all land", async () => {
+    // Two sub-agent sessions can complete at the same time, so two
+    // registerBuiltApp calls interleave on the get/set-only cache. Without
+    // serialization both read the same snapshot and the last write clobbers
+    // the other's record. A latency-injected cache widens the interleaving
+    // window the way a real DB-backed cache does.
+    const store = new Map<string, unknown>();
+    const runtime = {
+      getCache: async (key: string) => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return store.get(key);
+      },
+      setCache: async (key: string, value: unknown) => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        store.set(key, value);
+        return true;
+      },
+    } as unknown as IAgentRuntime;
+
+    const slugs = ["snake-game", "todo", "workouts", "chess", "notes"];
+    await Promise.all(
+      slugs.map((slug, i) =>
+        registerBuiltApp(
+          runtime,
+          record({
+            slug,
+            name: slug,
+            url: `https://example.org/apps/${slug}/`,
+            sessionId: `sess-${i}`,
+          }),
+        ),
+      ),
+    );
+    const apps = await listBuiltApps(runtime);
+    expect(apps.map((app) => app.slug).sort()).toEqual([...slugs].sort());
+  });
+
+  it("a concurrent delete cannot resurrect or drop unrelated records", async () => {
+    const { runtime } = cacheRuntime();
+    await registerBuiltApp(runtime, record());
+    // Register of a second app races the delete of the first: both must
+    // observe each other's write regardless of interleaving order.
+    await Promise.all([
+      registerBuiltApp(runtime, record({ slug: "todo", name: "Todo" })),
+      deleteBuiltApp(runtime, "custom", "snake-game"),
+    ]);
+    expect(await listBuiltApps(runtime)).toMatchObject([{ slug: "todo" }]);
+  });
+
   it("degrades gracefully when the runtime has no cache", async () => {
     const bare = {} as IAgentRuntime;
     expect(await registerBuiltApp(bare, record())).toBe(false);

--- a/plugins/plugin-agent-orchestrator/src/services/built-apps-registry.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/built-apps-registry.ts
@@ -145,6 +145,31 @@ function asRecordList(value: unknown): BuiltAppRecord[] {
   );
 }
 
+// The cache API is get/set only (no compare-and-swap), so every registry
+// mutation is a read-modify-write. Completions are serial per session but NOT
+// across sessions — two sub-agents finishing together (or a register racing an
+// HTTP DELETE) would read the same snapshot and last-write-wins would drop a
+// record. A per-runtime promise chain serializes mutations, the same
+// promise-chain mutex AcpService uses for session-slot reservation. Keyed
+// weakly on the runtime object so distinct runtimes (tests, multi-agent hosts)
+// never contend and the chain dies with the runtime.
+const mutationChains = new WeakMap<CacheRuntime, Promise<unknown>>();
+
+function withRegistryLock<T>(
+  runtime: CacheRuntime,
+  mutate: () => Promise<T>,
+): Promise<T> {
+  const tail = mutationChains.get(runtime) ?? Promise.resolve();
+  const run = tail.then(mutate);
+  // The stored tail only sequences the next mutation; its rejection is
+  // observed by this mutation's caller via `run`.
+  mutationChains.set(
+    runtime,
+    run.catch(() => undefined),
+  );
+  return run;
+}
+
 /** Read the built-apps registry, newest first. Empty when never written. */
 export async function listBuiltApps(
   runtime: unknown,
@@ -154,31 +179,34 @@ export async function listBuiltApps(
 }
 
 /**
- * Insert (or refresh, keyed on target+slug) one record. Read-modify-write on
- * the runtime cache — completions are handled serially per session in a
- * single process, so no cross-process lock is needed here.
+ * Insert (or refresh, keyed on target+slug) one record. Serialized against
+ * other registry mutations so concurrent completions all persist.
  */
 export async function registerBuiltApp(
   runtime: unknown,
   record: BuiltAppRecord,
 ): Promise<boolean> {
   if (!hasCache(runtime)) return false;
-  const existing = await listBuiltApps(runtime);
-  const rest = existing.filter(
-    (entry) => !(entry.target === record.target && entry.slug === record.slug),
-  );
-  await runtime.setCache(
-    BUILT_APPS_CACHE_KEY,
-    [record, ...rest].slice(0, MAX_BUILT_APPS),
-  );
-  return true;
+  return withRegistryLock(runtime, async () => {
+    const existing = asRecordList(await runtime.getCache(BUILT_APPS_CACHE_KEY));
+    const rest = existing.filter(
+      (entry) =>
+        !(entry.target === record.target && entry.slug === record.slug),
+    );
+    await runtime.setCache(
+      BUILT_APPS_CACHE_KEY,
+      [record, ...rest].slice(0, MAX_BUILT_APPS),
+    );
+    return true;
+  });
 }
 
 /**
- * Remove one record by its registry key (target+slug). Returns false when no
- * such record exists — or the runtime has no cache, in which case the registry
- * is structurally empty — so the route can answer 404 without a separate
- * existence check.
+ * Remove one record by its registry key (target+slug). Serialized against
+ * other registry mutations so a delete racing a register cannot clobber the
+ * other's write. Returns false when no such record exists — or the runtime has
+ * no cache, in which case the registry is structurally empty — so the route
+ * can answer 404 without a separate existence check.
  */
 export async function deleteBuiltApp(
   runtime: unknown,
@@ -186,13 +214,15 @@ export async function deleteBuiltApp(
   slug: string,
 ): Promise<boolean> {
   if (!hasCache(runtime)) return false;
-  const existing = await listBuiltApps(runtime);
-  const rest = existing.filter(
-    (entry) => !(entry.target === target && entry.slug === slug),
-  );
-  if (rest.length === existing.length) return false;
-  await runtime.setCache(BUILT_APPS_CACHE_KEY, rest);
-  return true;
+  return withRegistryLock(runtime, async () => {
+    const existing = asRecordList(await runtime.getCache(BUILT_APPS_CACHE_KEY));
+    const rest = existing.filter(
+      (entry) => !(entry.target === target && entry.slug === slug),
+    );
+    if (rest.length === existing.length) return false;
+    await runtime.setCache(BUILT_APPS_CACHE_KEY, rest);
+    return true;
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- serialize built-app registry read-modify-write mutations per runtime
- prevent concurrent sub-agent completions from clobbering each other in the get/set-only cache
- add regression coverage for concurrent register/register and register/delete races

## What

`registerBuiltApp` / `deleteBuiltApp` in `plugins/plugin-agent-orchestrator/src/services/built-apps-registry.ts` performed an unserialized read-modify-write on the runtime cache (`getCache` → filter → `setCache`). The cache API is get/set only — no compare-and-swap — so two interleaved mutations read the same snapshot and the last write clobbers the other. Completions ARE serial per session, but NOT across sessions: two sub-agents finishing at the same time each call `registerBuiltAppsForCompletion` (`sub-agent-router.ts` `task_complete`), and one built app silently vanishes from the registry. A register racing the HTTP `DELETE /api/orchestrator/built-apps/:target/:slug` leg has the same clobber shape. The old code even carried a comment asserting per-session serialization made this safe — it doesn't hold across sessions.

## Fix (structural)

Serialize all registry mutations through a per-runtime promise-chain mutex — the same primitive `acp-service.ts` already uses for session-slot reservation (reuse the store's existing atomic pattern; the cache exposes no upsert/CAS). Keyed in a `WeakMap` on the runtime object so distinct runtimes (tests, multi-agent hosts) never contend and the chain dies with the runtime. Reads (`listBuiltApps`) stay lock-free. Public API and return semantics unchanged — both consumers (`sub-agent-router.ts`, `orchestrator-routes.ts`) already `await` the calls.

## Proof the bug is real on develop

Both new tests were run against the **unmodified develop implementation at the current tip `8bb78f6b7c`** (develop's `built-apps-registry.ts` swapped in, new tests kept):

```
× concurrent registrations from different sessions all land
  → only a subset of 5 concurrently-registered apps survive (last-write-wins drop)
× a concurrent delete cannot resurrect or drop unrelated records
  → the racing delete's stale snapshot erased the concurrently-registered record
Tests  2 failed | 13 passed (15)
```

With the fix restored: `Tests  15 passed (15)`.

## Verification (real counts)

- `vitest run src/__tests__/built-apps-registry.test.ts` — **15 passed (15)** (13 pre-existing + 2 new; the 2 new fail on develop, pass with the fix — transcript above)
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` (`tsgo --noEmit`) — clean
- Full plugin suite (`vitest run`): **1614 passed | 26 failed | 8 skipped (1648)**. All 26 failures are `TypeError: runtime.reportError is not a function` from fixture runtimes in 6 pre-existing test files exercising `task-policy.ts` — a file this diff does not touch. The branch is merge-base + this single 2-file commit, so those failures reproduce identically on clean develop; none of the failing tests import the registry.
- Branch merges cleanly onto current develop; the two touched files are unchanged upstream since the merge-base (`git diff merge-base..origin/develop -- <files>` is empty)

## Evidence

- The concurrency test uses a latency-injected async cache (the interleaving window a real DB-backed cache has) plus the plain async-Map harness — both reproduce the drop on unfixed code deterministically.
- N/A - UI screenshots/video: no UI surface changes; this is a pure persistence race in a registry helper.
- N/A - LLM trajectories: no agent/action/prompt/model behavior change; the fix is below the model layer and is covered by deterministic concurrency tests that fail on the unfixed code.
