### PR TITLE
fix(#13406): repair claim-affiliate Worker SQL stub schema

### DIFF
--- a/.github/issue-evidence/13406-my-agents-claim-affiliate-500.md
+++ b/.github/issue-evidence/13406-my-agents-claim-affiliate-500.md
@@ -1,0 +1,84 @@
+# #13406 — `/dashboard/my-agents` HTTP 500 on `POST /api/my-agents/claim-affiliate-characters`
+
+Repro + fix evidence, captured against the real e2e harness (`wrangler dev` Worker +
+PGlite bridge via `packages/cloud/api/test/e2e/run-e2e-batches.mjs`) — the same stack
+the CI e2e lane runs.
+
+## Root cause
+
+The Worker bundles `packages/cloud/api/src/stubs/elizaos-plugin-sql.ts` in place of
+`@elizaos/plugin-sql` (`wrangler.toml` `alias`). The stub's `rooms` table was stale:
+it still declared `server_id`, but the real plugin-sql schema (which the cloud
+migrations were generated from) renamed that column to `message_server_id` (and added
+`name`). `roomsRepository.findByIds` does `dbRead.select().from(roomTable)`, so inside
+the deployed Worker it emits:
+
+```
+select "id", "agent_id", "source", "type", "server_id", "world_id", "channel_id",
+       "metadata", "created_at" from "rooms" where "rooms"."id" in ($1)
+```
+
+→ Postgres 42703 (`column "server_id" does not exist`) → route catch →
+`failureResponse` classifies the driver error as infrastructure → **500** for every
+signed-in user with ≥1 `participants` row (i.e. anyone who ever chatted), which is
+exactly the `/dashboard/my-agents` page-load claim call.
+
+Same drift class fixed in the stub for `worlds.server_id` / `channels.server_id`
+(→ `message_server_id`) and `channel_participants.user_id` (→ `entity_id`).
+
+## BEFORE (fix reverted / develop) — request → 500
+
+New e2e test (`group-c-agents.test.ts`, session cookie + the exact page-load POST):
+
+```
+(fail) /api/my-agents/claim-affiliate-characters > POST with a session cookie claims
+       an affiliate character the user chatted with [44.74ms]
+error: body: {"success":false,"error":"An unexpected error occurred","code":"internal_error"}
+Expected: 200
+Received: 500
+ 83 pass
+ 1 fail
+```
+
+Worker structured log at the moment of the request:
+
+```
+<-- POST /api/my-agents/claim-affiliate-characters
+✘ [ERROR] [Claim Affiliate Chars] Error: Error: Failed query: select "id", "agent_id",
+  "source", "type", "server_id", "world_id", "channel_id", "metadata", "created_at"
+  from "rooms" where "rooms"."id" in ($1)
+      at async RoomsRepository.findByIds (packages/cloud/shared/src/db/repositories/agents/rooms.ts:91:21)
+--> POST /api/my-agents/claim-affiliate-characters 500 8ms
+```
+
+## AFTER (stub fixed) — request → 200, claim executes
+
+```
+<-- POST /api/my-agents/claim-affiliate-characters
+--> POST /api/my-agents/claim-affiliate-characters 200 5ms    (no rooms → {success:true, claimed:[]})
+<-- POST /api/my-agents/claim-affiliate-characters
+--> POST /api/my-agents/claim-affiliate-characters 200 22ms   (seeded affiliate room → character claimed)
+ 84 pass
+ 0 fail
+```
+
+The seeded test also asserts the domain artifact directly in the DB after the claim:
+`user_characters.user_id` / `organization_id` flipped from the anonymous affiliate
+owner to the claiming user + org (gated ≠ owned, ownership transfer verified on the
+row, not the response).
+
+## Mutation check
+
+Reverting only the stub fix and re-running the suite reds the new test with the exact
+original failure (`83 pass / 1 fail`, same `server_id` failed query + 500); restoring
+the fix goes green (`84 pass / 0 fail`).
+
+## Gates
+
+- `E2E_ONLY=group-c bun run --cwd packages/cloud/api test:e2e` → 84 pass / 0 fail
+- `bun run --cwd packages/cloud/api typecheck` → clean
+- `bun run --cwd packages/cloud/api lint` → clean (850 files, no fixes)
+- `bun run --cwd packages/cloud/api test` → 133/136 files pass; the 3 failing files
+  (`compat-agent-credit-gate`, `eliza-agents-create-idempotency`,
+  `messages-iac-fast-path`) fail identically on clean `origin/develop`
+  (pre-existing missing exports in cloud-shared, unrelated to this change).

--- a/packages/cloud/api/src/stubs/elizaos-plugin-sql.ts
+++ b/packages/cloud/api/src/stubs/elizaos-plugin-sql.ts
@@ -25,13 +25,19 @@ const agents = pgTable("agents", {
   updatedAt: updated(),
 });
 
+// Column names MUST mirror plugins/plugin-sql/src/schema/* (the source the
+// cloud migrations were generated from): repositories in cloud-shared build
+// real SQL from these tables, so a drifted column here (e.g. the old
+// `server_id`, renamed upstream to `message_server_id`) makes every
+// `select().from(...)` fail with 42703 in the deployed Worker (#13406).
 const rooms = pgTable("rooms", {
   id: id(),
   agentId: text("agent_id"),
   source: text("source"),
   type: text("type"),
-  serverId: text("server_id"),
+  messageServerId: text("message_server_id"),
   worldId: text("world_id"),
+  name: text("name"),
   channelId: text("channel_id"),
   metadata: meta(),
   createdAt: created(),
@@ -130,7 +136,7 @@ const worlds = pgTable("worlds", {
   agentId: text("agent_id"),
   name: text("name"),
   metadata: meta(),
-  serverId: text("server_id"),
+  messageServerId: text("message_server_id"),
   createdAt: created(),
 });
 
@@ -174,7 +180,7 @@ const messageServers = pgTable("message_servers", {
 
 const channels = pgTable("channels", {
   id: id(),
-  serverId: text("server_id"),
+  messageServerId: text("message_server_id"),
   name: text("name"),
   type: text("type"),
   sourceType: text("source_type"),
@@ -187,7 +193,7 @@ const channels = pgTable("channels", {
 
 const channelParticipants = pgTable("channel_participants", {
   channelId: text("channel_id"),
-  userId: text("user_id"),
+  entityId: text("entity_id"),
 });
 
 export const schema = {

--- a/packages/cloud/api/test/e2e/group-c-agents.test.ts
+++ b/packages/cloud/api/test/e2e/group-c-agents.test.ts
@@ -29,6 +29,7 @@ import { Client } from "pg";
 import {
   api,
   bearerHeaders,
+  exchangeApiKeyForSession,
   getApiKey,
   getBaseUrl,
   isServerReachable,
@@ -143,12 +144,109 @@ async function seedOwnedCharacter(input: {
   }
 }
 
+/**
+ * Seeds the real "signed-in user chatted with an affiliate character" state
+ * the claim-affiliate-characters route reads: an anonymous affiliate owner
+ * (own org + @anonymous.elizacloud.ai email), a user_characters row it owns,
+ * the eliza runtime rows (agents / entities / rooms) and a participants row
+ * linking the claiming user (entity_id = users.id, rooms.agent_id =
+ * user_characters.id — the route's "new architecture" mapping).
+ */
+async function seedAffiliateInteraction(input: {
+  userId: string;
+}): Promise<{ characterId: string; anonOrgId: string }> {
+  const databaseUrl = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error(
+      "TEST_DATABASE_URL or DATABASE_URL must be set by the e2e harness",
+    );
+  }
+
+  const suffix = crypto.randomUUID().slice(0, 8);
+  const anonOrgId = crypto.randomUUID();
+  const anonUserId = crypto.randomUUID();
+  const characterId = crypto.randomUUID();
+  const roomId = crypto.randomUUID();
+
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    await client.query(
+      `INSERT INTO organizations (id, name, slug) VALUES ($1, $2, $3)`,
+      [anonOrgId, `E2E Anon Org ${suffix}`, `e2e-anon-org-${suffix}`],
+    );
+    await client.query(
+      `INSERT INTO users (id, email, steward_user_id, is_anonymous, organization_id)
+       VALUES ($1, $2, $3, true, $4)`,
+      [
+        anonUserId,
+        `e2e-anon-${suffix}@anonymous.elizacloud.ai`,
+        `e2e-anon-steward-${suffix}`,
+        anonOrgId,
+      ],
+    );
+    await seedOwnedCharacter({
+      id: characterId,
+      organizationId: anonOrgId,
+      userId: anonUserId,
+      name: `E2E Affiliate ${suffix}`,
+    });
+    // The eliza runtime rows the route joins through: rooms.agent_id is the
+    // character id, participants.entity_id is the claiming user's users.id.
+    await client.query(`INSERT INTO agents (id, name) VALUES ($1, $2)`, [
+      characterId,
+      `E2E Affiliate ${suffix}`,
+    ]);
+    await client.query(
+      `INSERT INTO entities (id, agent_id) VALUES ($1, $2)
+       ON CONFLICT (id) DO NOTHING`,
+      [input.userId, characterId],
+    );
+    await client.query(
+      `INSERT INTO rooms (id, agent_id, source, type) VALUES ($1, $2, 'client_chat', 'dm')`,
+      [roomId, characterId],
+    );
+    await client.query(
+      `INSERT INTO participants (entity_id, room_id, agent_id) VALUES ($1, $2, $3)`,
+      [input.userId, roomId, characterId],
+    );
+  } finally {
+    await client.end();
+  }
+
+  return { characterId, anonOrgId };
+}
+
+const seededAnonOrgIds: string[] = [];
+
 afterAll(async () => {
   if (!serverReachable || !hasTestApiKey) return;
   for (const id of createdCharacterIds) {
     await api.delete(`/api/my-agents/characters/${id}`, {
       headers: bearerHeaders(),
     });
+  }
+  // Remove the affiliate-claim seed rows (agents cascades rooms/participants/
+  // entities; organizations cascades the anonymous owner user).
+  if (seededAnonOrgIds.length > 0) {
+    const databaseUrl =
+      process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+    if (databaseUrl) {
+      const client = new Client({ connectionString: databaseUrl });
+      await client.connect();
+      try {
+        for (const id of createdCharacterIds) {
+          await client.query(`DELETE FROM agents WHERE id = $1`, [id]);
+        }
+        for (const orgId of seededAnonOrgIds) {
+          await client.query(`DELETE FROM organizations WHERE id = $1`, [
+            orgId,
+          ]);
+        }
+      } finally {
+        await client.end();
+      }
+    }
   }
 });
 
@@ -894,6 +992,74 @@ describeE2E("/api/my-agents/claim-affiliate-characters", () => {
       },
     );
     expect(res.status).toBe(401);
+  });
+
+  // -----------------------------------------------------------------------
+  // Signed-in page-load path (session cookie). /dashboard/my-agents fires
+  // exactly this request on load; it must never 500 for a normal signed-in
+  // user — regression for tracker #13406 (HTTP 500 on page load).
+  // -----------------------------------------------------------------------
+  test("POST with a session cookie and empty body returns 200 no-op (the /dashboard/my-agents page-load request)", async () => {
+    const sessionCookie = await exchangeApiKeyForSession();
+    const res = await api.post(
+      "/api/my-agents/claim-affiliate-characters",
+      {},
+      { headers: { Cookie: sessionCookie } },
+    );
+    const bodyText = await res.text();
+    expect(res.status, `body: ${bodyText.slice(0, 500)}`).toBe(200);
+    const body = JSON.parse(bodyText) as {
+      success?: boolean;
+      claimed?: unknown[];
+    };
+    expect(body.success).toBe(true);
+    expect(Array.isArray(body.claimed)).toBe(true);
+  });
+
+  test("POST with a session cookie claims an affiliate character the user chatted with", async () => {
+    const userId = process.env.TEST_USER_ID;
+    const organizationId = process.env.TEST_ORGANIZATION_ID;
+    if (!userId || !organizationId) {
+      throw new Error(
+        "TEST_USER_ID and TEST_ORGANIZATION_ID must be set by e2e preload",
+      );
+    }
+
+    const seeded = await seedAffiliateInteraction({ userId });
+    createdCharacterIds.push(seeded.characterId);
+    seededAnonOrgIds.push(seeded.anonOrgId);
+
+    const sessionCookie = await exchangeApiKeyForSession();
+    const res = await api.post(
+      "/api/my-agents/claim-affiliate-characters",
+      {},
+      { headers: { Cookie: sessionCookie } },
+    );
+    const bodyText = await res.text();
+    expect(res.status, `body: ${bodyText.slice(0, 500)}`).toBe(200);
+    const body = JSON.parse(bodyText) as {
+      success?: boolean;
+      claimed?: Array<{ id?: string; name?: string }>;
+    };
+    expect(body.success).toBe(true);
+    expect(body.claimed?.some((c) => c.id === seeded.characterId)).toBe(true);
+
+    // Ownership actually transferred to the claiming user + org (gated ≠ owned).
+    const client = new Client({
+      connectionString:
+        process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL,
+    });
+    await client.connect();
+    try {
+      const row = await client.query(
+        `SELECT user_id, organization_id FROM user_characters WHERE id = $1`,
+        [seeded.characterId],
+      );
+      expect(row.rows[0]?.user_id).toBe(userId);
+      expect(row.rows[0]?.organization_id).toBe(organizationId);
+    } finally {
+      await client.end();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- update the Worker `@elizaos/plugin-sql` stub schema to match current plugin-sql/cloud migration column names
- add an e2e page-load/session-cookie regression for `/api/my-agents/claim-affiliate-characters`
- verify the seeded affiliate interaction transfers the `user_characters` row to the claiming user/org instead of only asserting the response

Fixes #13406.

## Verification
- `E2E_ONLY=group-c bun run --cwd packages/cloud/api test:e2e` - 84 pass / 0 fail
- `bun run --cwd packages/cloud/api typecheck` - clean
- `bun run --cwd packages/cloud/api lint` - clean
- `bun run --cwd packages/cloud/api test` - 133/136 files pass; remaining failures documented as pre-existing on clean `origin/develop`

## Evidence
- `.github/issue-evidence/13406-my-agents-claim-affiliate-500.md`