### PR TITLE
fix(#13492): keep stock Android first-run cloud-first

### DIFF
--- a/.github/issue-evidence/13492-android-low-ram-cloud-first-autostart.md
+++ b/.github/issue-evidence/13492-android-low-ram-cloud-first-autostart.md
@@ -1,0 +1,30 @@
+# Issue #13492 Evidence
+
+## Change
+
+Stock Android fresh installs no longer auto-start the bundled Bun/PGlite agent
+before onboarding records a local runtime choice. The foreground service still
+auto-starts on branded device images, and stock Android starts it only for the
+persisted `local` mobile runtime mode.
+
+## Manual Review
+
+- Reviewed the native boot path in `MainActivity` and `ElizaBootReceiver`: both
+  delegate to `ElizaAgentService.shouldAutoStart`.
+- Reviewed the renderer runtime-mode vocabulary in
+  `packages/ui/src/first-run/mobile-runtime-mode.ts`: `cloud`,
+  `cloud-hybrid`, `remote-mac`, and `tunnel-to-mobile` do not require the
+  bundled local service at first paint.
+- Confirmed the issue's frozen boot trace is consistent with the previous fresh
+  install behavior: `readRuntimeMode(context) == null` caused service startup,
+  which reached PGlite initialization before the user could reach cloud sign-in.
+
+## Verification
+
+- Added JVM coverage in
+  `packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java`
+  for branded, fresh stock, cloud, cloud-hybrid, remote, tunnel, and local
+  modes.
+- Local Gradle execution is blocked in this worktree because the host Java is
+  11 while this Android project targets Java 21. CI's Android lane should run
+  the added unit test with the configured Java toolchain.

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -3359,22 +3359,18 @@ public class ElizaAgentService extends Service {
      * - On AOSP / ElizaOS-branded devices (`ro.elizaos.product` set or any
      *   white-label fork's `ro.<brand>os.product`), the device IS the
      *   agent: always start.
-     * - On stock Android, only start when the user has explicitly picked
-     *   the Local runtime in the onboarding picker (mobile-runtime-mode
-     *   == "local"). Cloud and Remote modes do not need this service.
+     * - On stock Android, only start when the user has explicitly picked the
+     *   Local runtime in the onboarding picker (mobile-runtime-mode ==
+     *   "local"). Cloud, hybrid cloud, remote, tunnel, and not-yet-chosen
+     *   modes do not need this service.
      */
     public static boolean shouldAutoStart(Context context) {
-        if (isBrandedDevice()) {
-            return true;
-        }
-        // This APK is the on-device local-agent sideload build (the cloud
-        // thin-client is a separate build). Autostart the agent unless the
-        // user has explicitly chosen a cloud runtime mode. A fresh install
-        // has no persisted mode yet (the renderer writes it only after the
-        // WebView boots), so default to autostart instead of stranding the
-        // dashboard with no agent to connect to.
-        String mode = readRuntimeMode(context);
-        return !"cloud".equals(mode);
+        return shouldAutoStartForRuntimeMode(isBrandedDevice(), readRuntimeMode(context));
+    }
+
+    static boolean shouldAutoStartForRuntimeMode(boolean brandedDevice, String mode) {
+        if (brandedDevice) return true;
+        return "local".equals(mode == null ? null : mode.trim());
     }
 
     /**
@@ -3383,12 +3379,9 @@ public class ElizaAgentService extends Service {
      * runtime mode has been explicitly persisted by the onboarding picker.
      *
      * Distinct from {@link #shouldAutoStart}: a fresh stock install has no
-     * persisted mode yet, so the agent still auto-starts (so the dashboard has
-     * something to talk to) but the user has chosen nothing. We use this to
-     * avoid cold-asking for notification consent during first-run onboarding —
-     * iOS-style, we ask only after there is a committed reason (the foreground
-     * service still runs without the grant; its notification is just
-     * suppressed until later granted).
+     * persisted mode yet, so the user has chosen nothing. We use this to avoid
+     * cold-asking for notification consent during first-run onboarding —
+     * iOS-style, we ask only after there is a committed reason.
      */
     public static boolean hasCommittedRuntimeChoice(Context context) {
         return isBrandedDevice() || readRuntimeMode(context) != null;

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
@@ -130,13 +130,9 @@ public class MainActivity extends BridgeActivity {
             ElizaAgentService.start(this);
             // Ask for notification consent only once the user (or the device
             // image) has actually committed to running the on-device agent.
-            // A fresh stock install auto-starts the service so the dashboard
-            // has something to talk to, but the user has chosen nothing yet —
-            // cold-asking there is the first-run nag we want to avoid
-            // (iOS-style: ask only when there is a reason). The foreground
-            // service still runs without the grant; its notification is just
-            // suppressed until later granted in settings or on a later launch
-            // once a runtime mode is persisted.
+            // Fresh stock installs stay cloud-first until onboarding records a
+            // local runtime choice, so there is no foreground service reason to
+            // cold-ask on first paint.
             if (ElizaAgentService.hasCommittedRuntimeChoice(this)) {
                 requestPostNotificationsIfNeeded();
             }

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
@@ -1,0 +1,50 @@
+/**
+ * Host-side coverage for the Android service boot gate that decides whether a
+ * stock phone should spawn the bundled local agent before the renderer starts.
+ */
+package ai.elizaos.app;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * JVM unit tests for the stock-Android local-agent autostart policy. The
+ * service must stay out of the first-run cloud path on low-RAM phones unless a
+ * device image or an explicit local runtime choice needs the bundled agent.
+ */
+public class ElizaAgentAutostartPolicyTest {
+
+    @Test
+    public void brandedDevicesAlwaysStartTheBundledAgent() {
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "cloud"));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "remote-mac"));
+    }
+
+    @Test
+    public void stockFreshInstallDoesNotStartTheBundledAgent() {
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, ""));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "   "));
+    }
+
+    @Test
+    public void stockCloudModesStayCloudFirst() {
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud"));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud-hybrid"));
+    }
+
+    @Test
+    public void stockExternalModesDoNotStartTheBundledAgent() {
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "remote-mac"));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "tunnel-to-mobile"));
+    }
+
+    @Test
+    public void stockLocalModeStartsTheBundledAgent() {
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local"));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local "));
+    }
+}


### PR DESCRIPTION
## Summary
- keep fresh stock Android installs from auto-starting the bundled Bun/PGlite agent before onboarding records a local runtime choice
- preserve branded-device auto-start and stock local-mode auto-start behavior
- add JVM coverage for branded, fresh stock, cloud, cloud-hybrid, remote, tunnel, and local runtime modes

Fixes #13492.

## Evidence
- Evidence note: `.github/issue-evidence/13492-android-low-ram-cloud-first-autostart.md`
- `git diff --check -- packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java .github/issue-evidence/13492-android-low-ram-cloud-first-autostart.md`
- `bun run audit:error-policy-ratchet`
- `java -version` confirms this host is Java 11; Android Gradle unit execution is blocked locally because the project targets Java 21

## N/A
- UI screenshots/video: N/A - native service autostart policy only; no renderer UI changed
- Real-LLM trajectories: N/A - no agent/action/provider/prompt/model behavior changed