### PR TITLE
Align orchestrator lifecycle prompt with action scoring

### DIFF
--- a/packages/lifeops-bench/src/plugin.ts
+++ b/packages/lifeops-bench/src/plugin.ts
@@ -1046,13 +1046,13 @@ function formatContextAsText(ctx: BenchmarkContext): string {
       );
     } else if (isOrchestratorLifecycle) {
       sections.push(
-        `This is an orchestrator lifecycle benchmark. Respond with actions: REPLY and put only the next lifecycle message in text. Do not call BENCHMARK_ACTION.`,
+        `This is an orchestrator lifecycle benchmark. Use the normal orchestrator task-management actions for lifecycle operations, and use REPLY only for the user-facing narration that accompanies those actions. Prose-only lifecycle claims do not satisfy this benchmark. Do not call BENCHMARK_ACTION.`,
       );
       sections.push(
-        `If the user says the current approach failed, asks to replan, changes scope, or asks to continue with revised work, acknowledge the scope change or failure and state that the updated plan has been applied.`,
+        `If the user says the current approach failed, asks to replan, changes scope, or asks to continue with revised work, send the updated instruction to the active task agent or use the appropriate task-control operation; do not merely state that the plan changed.`,
       );
       sections.push(
-        `For delegation/status turns, mention the active subagent and the status or progress update. For underspecified turns, ask a clarifying question and say you will wait before starting.`,
+        `For delegation/status turns, create or consult the active subagent/task registry as appropriate, then summarize the result to the user. For underspecified turns, ask a clarifying question and wait before starting any task action.`,
       );
     } else {
       sections.push(

--- a/packages/lifeops-bench/src/server-utils.test.ts
+++ b/packages/lifeops-bench/src/server-utils.test.ts
@@ -256,8 +256,13 @@ describe("composeBenchmarkPrompt", () => {
     });
 
     expect(prompt).toContain("orchestrator lifecycle benchmark");
-    expect(prompt).toContain("updated plan has been applied");
-    expect(prompt).toContain("active subagent status or progress");
+    expect(prompt).toContain("normal orchestrator task-management actions");
+    expect(prompt).toContain("send updates to an active task");
+    expect(prompt).toContain("prose-only lifecycle claims do not satisfy");
+    expect(prompt).toContain("Use REPLY only for the user-facing narration");
+    expect(prompt).toContain("Do not call BENCHMARK_ACTION");
+    expect(prompt).not.toContain("Use REPLY text for the next lifecycle message");
+    expect(prompt).not.toContain("mention active subagent status or progress");
   });
 });
 
@@ -383,7 +388,7 @@ describe("benchmark plugin LifeOps tool capture", () => {
     setBenchmarkContext(null);
   });
 
-  it("renders orchestrator lifecycle-specific reply instructions", async () => {
+  it("renders orchestrator lifecycle-specific action instructions", async () => {
     setBenchmarkContext({
       benchmark: "orchestrator_lifecycle",
       taskId: "lifecycle-a",
@@ -403,8 +408,15 @@ describe("benchmark plugin LifeOps tool capture", () => {
     expect(rendered?.text).toContain(
       "This is an orchestrator lifecycle benchmark",
     );
-    expect(rendered?.text).toContain("updated plan has been applied");
-    expect(rendered?.text).toContain("active subagent");
+    expect(rendered?.text).toContain(
+      "normal orchestrator task-management actions",
+    );
+    expect(rendered?.text).toContain("send the updated instruction");
+    expect(rendered?.text).toContain(
+      "Prose-only lifecycle claims do not satisfy",
+    );
+    expect(rendered?.text).toContain("Do not call BENCHMARK_ACTION");
+    expect(rendered?.text).not.toContain("Respond with actions: REPLY");
 
     setBenchmarkContext(null);
   });

--- a/packages/lifeops-bench/src/server-utils.ts
+++ b/packages/lifeops-bench/src/server-utils.ts
@@ -592,10 +592,10 @@ export function composeBenchmarkPrompt(params: {
     segments.push(
       [
         "This is an orchestrator lifecycle benchmark.",
-        "Use REPLY text for the next lifecycle message.",
-        "For failed approaches, replans, and scope changes, acknowledge the failure or scope change and state that the updated plan has been applied.",
-        "For delegation/status turns, mention active subagent status or progress.",
-        "For underspecified turns, ask a clarifying question and say you will wait before starting.",
+        "Use the normal orchestrator task-management actions for lifecycle operations: create/spawn a task agent for delegation, send updates to an active task for scope changes or replans, list/history/status actions for status reports, and pause/resume/cancel controls for interruptions.",
+        "Use REPLY only for the user-facing narration that accompanies those actions; prose-only lifecycle claims do not satisfy this benchmark.",
+        "Do not call BENCHMARK_ACTION for orchestrator lifecycle turns.",
+        "For underspecified turns, ask a clarifying question and wait before starting any task action.",
       ].join(" "),
     );
   } else {


### PR DESCRIPTION
Fixes #13484.

## Summary
- Align the orchestrator lifecycle benchmark prompt with the evaluator's structural action scoring instead of telling live agents to emit prose-only lifecycle replies.
- Update the benchmark plugin provider instructions so replans, status checks, delegation, and task-control turns require real orchestrator task actions plus user-facing narration.
- Add/adjust tests that lock out the old reply-only wording and assert the structural-action guidance.

## Verification
- `git diff --check HEAD~1..HEAD`
- `rg -n "Use REPLY text for the next lifecycle message|Respond with actions: REPLY and put only the next lifecycle message|mention active subagent status or progress|updated plan has been applied" packages/lifeops-bench/src packages/benchmarks/orchestrator_lifecycle` only finds the negative assertions that guard against the old prompt.

## Verification blocked
- `bun run --cwd packages/lifeops-bench test -- src/server-utils.test.ts` could not run in this worktree because `bun install` and a filtered `bun install --filter @elizaos/lifeops-bench --ignore-scripts --frozen-lockfile` both exhausted the local filesystem (`ENOSPC`) and left an incomplete dependency tree; the first Vitest attempt failed before test load on missing `tinyrainbow`.
