### PR TITLE
fix: agent dist must not depend on gitignored .js litter in sibling src trees

### DIFF
--- a/packages/agent/src/__tests__/no-cross-package-src-imports.test.ts
+++ b/packages/agent/src/__tests__/no-cross-package-src-imports.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Build-boundary guard: no source file that reaches the agent dist may import
+ * another package's `src/` via a relative path. `build:dist` transpiles per
+ * file (tsc `rewriteRelativeImportExtensions`), so a specifier like
+ * `../../../core/src/x.ts` survives into `dist/` as `../../../core/src/x.js`
+ * — a path that only exists as gitignored build litter in the sibling
+ * package's `src/` (core ignores emitted `.js` under `src/`) and never exists
+ * at all in the published layout (core ships `dist` only). A clean checkout +
+ * build then fails at import time. Cross-package symbols must come through
+ * the package's public exports (`@elizaos/core`, ...) instead.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const SRC_DIR = path.resolve(here, "..");
+const PACKAGE_DIR = path.resolve(SRC_DIR, "..");
+
+/**
+ * Pre-existing offenders (baseline debt, must never grow). Each entry needs
+ * its target exported from every core entry (node/browser/edge) before it can
+ * move to `@elizaos/core` — relationships-graph-builder is node-entry-only
+ * today and relationships-graph.ts is reachable from the mobile bundle.
+ */
+const KNOWN_OFFENDERS = new Set(["services/relationships-graph.ts"]);
+
+/** Matches static import/export-from and dynamic import specifiers. */
+const SPECIFIER_RE = /(?:\bfrom\s*|\bimport\s*\(\s*)["']([^"']+)["']/g;
+
+/**
+ * Comments may quote import statements as prose (api/server.ts does); strip
+ * them so only live code is scanned. Naive stripping cannot corrupt a real
+ * specifier: relative import paths never contain `//` or block-comment
+ * delimiters.
+ */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+function walkSources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      out.push(...walkSources(full));
+    } else if (
+      /\.(ts|tsx|mts|cts)$/.test(entry.name) &&
+      !/\.test\.(ts|tsx)$/.test(entry.name) &&
+      !entry.name.endsWith(".d.ts")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function escapingSpecifiers(filePath: string): string[] {
+  const source = stripComments(readFileSync(filePath, "utf8"));
+  const dir = path.dirname(filePath);
+  const escapes: string[] = [];
+  for (const match of source.matchAll(SPECIFIER_RE)) {
+    const specifier = match[1];
+    if (!specifier.startsWith(".")) continue;
+    const resolved = path.resolve(dir, specifier);
+    if (
+      resolved !== PACKAGE_DIR &&
+      !resolved.startsWith(PACKAGE_DIR + path.sep)
+    ) {
+      escapes.push(specifier);
+    }
+  }
+  return escapes;
+}
+
+describe("agent build boundary", () => {
+  it("has no relative imports escaping packages/agent (ratchet)", () => {
+    const offenders: string[] = [];
+    for (const file of walkSources(SRC_DIR)) {
+      const escapes = escapingSpecifiers(file);
+      if (escapes.length === 0) continue;
+      const rel = path.relative(SRC_DIR, file);
+      if (KNOWN_OFFENDERS.has(rel)) continue;
+      offenders.push(`${rel}: ${escapes.join(", ")}`);
+    }
+    expect(offenders, offenders.join("\n")).toEqual([]);
+  });
+
+  it("keeps the known-offender baseline honest", () => {
+    const stale = [...KNOWN_OFFENDERS].filter((rel) => {
+      try {
+        return escapingSpecifiers(path.join(SRC_DIR, rel)).length === 0;
+      } catch {
+        return true; // error-policy:J3 missing file = stale entry, report it
+      }
+    });
+    expect(
+      stale,
+      `remove fixed entries from KNOWN_OFFENDERS: ${stale.join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/agent/src/api/inbox-routes.ts
+++ b/packages/agent/src/api/inbox-routes.ts
@@ -43,6 +43,11 @@ import type {
   UUID,
   World,
 } from "@elizaos/core";
+import {
+  resolveEffectiveMuteState,
+  setRoomMuteUntil,
+  setWorldMuteState,
+} from "@elizaos/core";
 import type { DiscordService as IDiscordService } from "@elizaos/plugin-discord/service";
 import {
   expandConnectorSourceFilter,
@@ -50,11 +55,6 @@ import {
   PostInboxMessageRequestSchema,
 } from "@elizaos/shared";
 import { z } from "zod";
-import {
-  resolveEffectiveMuteState,
-  setRoomMuteUntil,
-  setWorldMuteState,
-} from "../../../core/src/services/message/mute-state.ts";
 
 let discordModulePromise: Promise<{
   cacheDiscordAvatarUrl: (

--- a/packages/agent/src/config/zod-schema.agent-runtime.ts
+++ b/packages/agent/src/config/zod-schema.agent-runtime.ts
@@ -8,8 +8,8 @@
  * (one configured agent) and `AgentDefaultsSchema` (fallbacks applied to every
  * agent). `.strict()` throughout, so unknown keys surface as validation errors.
  */
+import { parseDurationMs } from "@elizaos/shared";
 import * as zod from "zod";
-import { parseDurationMs } from "../../../shared/src/cli/parse-duration.ts";
 import {
   BlockStreamingChunkSchema,
   BlockStreamingCoalesceSchema,


### PR DESCRIPTION
# fix: agent dist must not depend on gitignored .js litter in sibling src trees

## Bug

#13059 added a cross-package relative import in `packages/agent/src/api/inbox-routes.ts`:

```ts
import {
  resolveEffectiveMuteState,
  setRoomMuteUntil,
  setWorldMuteState,
} from "../../../core/src/services/message/mute-state.ts";
```

`packages/agent` builds with per-file `tsc` (`rewriteRelativeImportExtensions`), so the specifier survives into the dist verbatim with `.ts` → `.js`:

```
packages/agent/dist/api/inbox-routes.js:38
import { resolveEffectiveMuteState, setRoomMuteUntil, setWorldMuteState, }
  from "../../../core/src/services/message/mute-state.js";
```

That resolves to `packages/core/src/services/message/mute-state.js`, which:

- is **gitignored build litter** (`packages/core/.gitignore:12` — `src/**/*.js`). The agent build itself emits it: the out-of-rootDir import pulls the file's whole relative-import closure into the tsc program, which lands `.js` next to `.ts` inside `packages/core/src` (the ".js-shadows-.ts" landmine for every later tool that resolves `.js` first).
- **never exists in the published layout** — `@elizaos/core` ships `"files": ["registry-entry.json", "dist"]`; `node_modules/@elizaos/core/src` does not exist, so the installed package's dist import can never resolve (`ERR_MODULE_NOT_FOUND`).

The symbols were already on core's public surface (`services/message.ts` re-exports them; node/browser/edge entries all `export * from "./services/message"`), so the relative import was never needed.

## Fix (structural)

- `packages/agent/src/api/inbox-routes.ts` — import the three mute-state helpers from `@elizaos/core` (the #13059 regression).
- `packages/agent/src/config/zod-schema.agent-runtime.ts` — same class, found by the new guard: imported `../../../shared/src/cli/parse-duration.ts`; `parseDurationMs` is already exported from `@elizaos/shared`. Switched to the package import.
- **New ratchet test** `packages/agent/src/__tests__/no-cross-package-src-imports.test.ts` — scans every source file that reaches the agent dist and fails on any relative import escaping `packages/agent` (comment-stripped, so prose that quotes imports doesn't false-positive). One documented baseline entry: `services/relationships-graph.ts` (present since the v2.0.4 squash; its target `relationships-graph-builder` is exported from core's **node entry only** and the file is reachable from the mobile bundle, so moving it needs browser/edge-entry parity first). A companion test keeps the baseline honest — fixed entries must be removed from the allowlist.

## Proof

- **Ratchet fails on the bug**: on unfixed develop sources it reports both offenders (`api/inbox-routes.ts`, `config/zod-schema.agent-runtime.ts`) and fails; with the fix, 2/2 pass.
- **Rebuilt dist depends on the package surface**: `dist/api/inbox-routes.js` → `from "@elizaos/core"`, `dist/config/zod-schema.agent-runtime.js` → `from "@elizaos/shared"`. Repo-wide dist grep for sibling-`src` specifiers now matches only the baselined `relationships-graph.js`.
- **Litter no longer emitted**: after removing all 1755 gitignored `.js`/`.d.ts` litter files from `packages/core/src` + `packages/shared/src` and rebuilding agent, `mute-state.js` and `parse-duration.js` are **not** recreated (pre-fix they were).
- **Clean-tree runtime probe** (node, from inside `packages/agent/dist/api`):

```json
{
 "packageImport": {
  "resolveEffectiveMuteState": "function",
  "setRoomMuteUntil": "function",
  "setWorldMuteState": "function",
  "resolvedFrom": "file://.../packages/core/dist/node/index.node.js"
 },
 "oldSpecifier": "ERR_MODULE_NOT_FOUND"
}
```

- **Typecheck**: `bun run --cwd packages/agent typecheck` (tsgo) — exit 0, 0 errors, against freshly built core/shared dists on latest develop.
- **Tests (real counts)**: agent filtered vitest (guard + `media-provider` + `mobile-optional-routes` + `lifeops-inbox-fallback-routes`) — 4 files, 27/27 pass; core `mute-state.test.ts` — 15/15 pass (module untouched, for the record). Dep build for verification: turbo 96/96 tasks green.

## Evidence

- Real-LLM trajectories: N/A — build/import-graph fix; no agent/action/provider/prompt/model behavior change.
- Screenshots / video: N/A — no user-facing surface changes.
- Frontend logs: N/A — no client execution path changes; proof is the dist specifiers + resolution probes above.
