### PR TITLE
Fail orchestrator lifecycle bridge runs on reset errors

### DIFF
--- a/packages/benchmarks/orchestrator_lifecycle/runner.py
+++ b/packages/benchmarks/orchestrator_lifecycle/runner.py
@@ -174,11 +174,10 @@ class LifecycleRunner:
                 benchmark="orchestrator_lifecycle",
             )
         except Exception as exc:
-            logger.debug(
-                "[orchestrator_lifecycle] reset failed for %s: %s",
-                scenario_id,
-                exc,
-            )
+            raise RuntimeError(
+                "orchestrator_lifecycle: reset failed for "
+                f"scenario {scenario_id} task {task_id}"
+            ) from exc
 
     def _reply(
         self, *, turn: ScenarioTurn, task_id: str, scenario_id: str

--- a/packages/benchmarks/orchestrator_lifecycle/tests/test_runner_smoke.py
+++ b/packages/benchmarks/orchestrator_lifecycle/tests/test_runner_smoke.py
@@ -21,6 +21,7 @@ from benchmarks.orchestrator_lifecycle.runner import (
 )
 from benchmarks.orchestrator_lifecycle.types import (
     LifecycleConfig,
+    Scenario,
     ScenarioTurn,
     TurnRecord,
 )
@@ -236,3 +237,38 @@ def test_bridge_reply_retries_generic_failure_response() -> None:
     assert record.events == ["send"]
     assert len(client.calls) == 2
     assert client.calls[1]["retry_empty_response"] is True
+
+
+def test_bridge_reset_failure_aborts_before_turn_dispatch(tmp_path: Path) -> None:
+    class FakeClient:
+        def reset(self, *, task_id: str, benchmark: str) -> dict[str, object]:
+            raise RuntimeError("reset endpoint unavailable")
+
+        def send_message(
+            self, text: str, context: dict[str, object] | None = None
+        ) -> MessageResponse:
+            raise AssertionError("run must abort before dispatching turns")
+
+    class OneScenarioDataset:
+        def load(self) -> list[Scenario]:
+            return [
+                Scenario(
+                    scenario_id="reset_failure_case",
+                    title="reset failure",
+                    category="status",
+                    turns=[
+                        ScenarioTurn(
+                            actor="user",
+                            message="How is it going?",
+                            expected_behaviors=["report_active_subagent_status"],
+                        )
+                    ],
+                )
+            ]
+
+    runner = _bridge_runner(FakeClient())
+    runner.config = LifecycleConfig(output_dir=str(tmp_path), mode="bridge")
+    runner.dataset = OneScenarioDataset()
+
+    with pytest.raises(RuntimeError, match="reset failed for scenario reset_failure_case"):
+        runner.run()


### PR DESCRIPTION
Fixes #13499.

## Summary
- Make orchestrator lifecycle bridge-mode reset failures fail loudly instead of logging and continuing with potentially stale session state.
- Preserve simulate-mode reset as a no-op.
- Add a regression test that a reset exception aborts before any turn dispatch/scoring.

## Verification
- `pytest packages/benchmarks/orchestrator_lifecycle/tests/ -v`
- `python -m compileall -q packages/benchmarks/orchestrator_lifecycle`
- `python -m benchmarks.orchestrator_lifecycle.cli --mode simulate --max-scenarios 3 --output /tmp/olc-reset-failfast-smoke` from `packages/`
- `git diff --check HEAD~1..HEAD`

## Notes
- Node/Bun package verification remains blocked in this worktree by local disk constraints encountered while working on #13498; this PR is Python-only and the relevant Python harness checks passed.
