### PR TITLE
fix(#13416): fail closed on corrupt organizations.credit_balance mutation reads

### DIFF
--- a/packages/cloud/shared/src/db/repositories/organizations-credit-balance-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/organizations-credit-balance-numeric.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Fail-closed coverage for `organizations.credit_balance` mutation reads (#13416).
+ *
+ * Guards the two balance-mutation paths in OrganizationsRepository
+ * (updateCreditBalance negative-balance guard, deductCreditsWithTransaction
+ * insufficient-balance spend gate) against a corrupt NUMERIC read silently
+ * failing OPEN via a bare `Number(...)`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { parseOrganizationCreditBalance } from "./organizations-credit-balance-numeric";
+
+describe("parseOrganizationCreditBalance", () => {
+  test("parses a well-formed NUMERIC string", () => {
+    expect(parseOrganizationCreditBalance("10.50", "credit_balance")).toBe(10.5);
+  });
+
+  test("parses a NUMERIC string with surrounding whitespace", () => {
+    expect(parseOrganizationCreditBalance(" 10.50 ", "credit_balance")).toBe(10.5);
+  });
+
+  test("parses a numeric value", () => {
+    expect(parseOrganizationCreditBalance(42, "credit_balance")).toBe(42);
+  });
+
+  test("parses an explicit domain zero (a genuinely $0 balance is allowed)", () => {
+    expect(parseOrganizationCreditBalance("0.00", "credit_balance")).toBe(0);
+    expect(parseOrganizationCreditBalance(0, "credit_balance")).toBe(0);
+  });
+
+  test("parses a negative balance (an overdrawn balance is a real value)", () => {
+    expect(parseOrganizationCreditBalance("-5.00", "credit_balance")).toBe(-5);
+  });
+
+  test("throws on a non-numeric corrupt string instead of returning NaN", () => {
+    expect(() => parseOrganizationCreditBalance("corrupt", "credit_balance")).toThrow(
+      /Unable to read organization credit_balance/,
+    );
+  });
+
+  test("throws on the literal string 'NaN' (a valid Postgres NUMERIC value)", () => {
+    expect(() => parseOrganizationCreditBalance("NaN", "credit_balance")).toThrow(/credit_balance/);
+  });
+
+  test("throws on a partially numeric corrupt string", () => {
+    expect(() => parseOrganizationCreditBalance("12.5oops", "credit_balance")).toThrow(
+      /credit_balance/,
+    );
+  });
+
+  test("throws on JS-only numeric strings Number() would otherwise coerce", () => {
+    expect(() => parseOrganizationCreditBalance("1e3", "credit_balance")).toThrow(/credit_balance/);
+    expect(() => parseOrganizationCreditBalance("0x10", "credit_balance")).toThrow(
+      /credit_balance/,
+    );
+    expect(() => parseOrganizationCreditBalance("Infinity", "credit_balance")).toThrow(
+      /credit_balance/,
+    );
+  });
+
+  test("throws on NaN / Infinity numeric input rather than fabricating a value", () => {
+    expect(() => parseOrganizationCreditBalance(Number.NaN, "credit_balance")).toThrow(
+      /not a finite number/,
+    );
+    expect(() =>
+      parseOrganizationCreditBalance(Number.POSITIVE_INFINITY, "credit_balance"),
+    ).toThrow(/not a finite number/);
+  });
+
+  test("throws on null / undefined / empty / whitespace (missing value)", () => {
+    expect(() => parseOrganizationCreditBalance(null, "credit_balance")).toThrow(
+      /empty or missing/,
+    );
+    expect(() => parseOrganizationCreditBalance(undefined, "credit_balance")).toThrow(
+      /empty or missing/,
+    );
+    expect(() => parseOrganizationCreditBalance("", "credit_balance")).toThrow(/empty or missing/);
+    expect(() => parseOrganizationCreditBalance("   ", "credit_balance")).toThrow(
+      /empty or missing/,
+    );
+  });
+
+  test("names the field in the error so a corrupt column is identifiable", () => {
+    expect(() => parseOrganizationCreditBalance("x", "credit_balance")).toThrow(/credit_balance/);
+  });
+});
+
+describe("spend-gate / negative-guard fail-open regression (corrupt credit_balance)", () => {
+  test("bare Number(...) makes both money gates silently fail OPEN on a corrupt balance", () => {
+    // Reproduces the pre-fix behavior at both mutation sites.
+    const corruptBalance = Number("corrupt"); // NaN
+    const amount = 100;
+
+    // updateCreditBalance negative-balance guard: NaN + amount = NaN, NaN < 0 is false.
+    const newBalance = corruptBalance + amount;
+    expect(Number.isNaN(newBalance)).toBe(true);
+    expect(newBalance < 0).toBe(false); // guard bypassed -> "NaN" written back
+
+    // deductCreditsWithTransaction spend gate: NaN < amount is false.
+    expect(corruptBalance < amount).toBe(false); // debit authorized against corrupt balance
+  });
+
+  test("the fail-closed reader throws on that same corrupt balance instead", () => {
+    expect(() => parseOrganizationCreditBalance("corrupt", "credit_balance")).toThrow();
+  });
+});
+
+describe("OrganizationsRepository wires both balance-mutation reads through the parser", () => {
+  // A real corrupt NUMERIC cannot be stored in Postgres/PGlite (they reject it),
+  // so healthy-path behavior is covered by the existing credit-balance service
+  // suites. These grep-guards pin the two mutation read sites to the fail-closed
+  // parser and prove no bare Number(<row field>) survives on the write path.
+  const repoPath = fileURLToPath(new URL("./organizations.ts", import.meta.url));
+  const src = readFileSync(repoPath, "utf8");
+
+  test("updateCreditBalance + deductCreditsWithTransaction both delegate to parseOrganizationCreditBalance", () => {
+    const wiredReads =
+      src.match(/parseOrganizationCreditBalance\(org\.credit_balance, "credit_balance"\)/g) ?? [];
+    // Exactly the two balance-mutation sites route through the parser.
+    expect(wiredReads.length).toBe(2);
+  });
+
+  test("no bare Number(<row field>) read of credit_balance survives on the write path", () => {
+    // \bNumber\( anchors on the global Number constructor, not a helper tail.
+    expect(/\bNumber\(\s*org\.credit_balance/.test(src)).toBe(false);
+    expect(src).not.toContain("Number(org.credit_balance)");
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/organizations-credit-balance-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/organizations-credit-balance-numeric.ts
@@ -1,0 +1,46 @@
+/**
+ * Fail-closed numeric boundary for `organizations.credit_balance` mutation reads
+ * (#13416, cloud-shared DB-repositories fallback-slop sweep).
+ *
+ * `organizations.credit_balance` is a Postgres NUMERIC column, so the driver
+ * hands it back as a string. Before this slice the two balance-mutation paths in
+ * `OrganizationsRepository` read it through a bare `Number(...)`, which fails
+ * OPEN on a corrupt value (`'NaN'::numeric` is a valid Postgres NUMERIC, a
+ * migration artifact, or a manual DB edit can all produce a non-parseable
+ * string):
+ *
+ *   - `updateCreditBalance`: `newBalance = Number(credit_balance) + amount`
+ *     becomes `NaN`, and the negative-balance guard `newBalance < 0` is FALSE for
+ *     `NaN`, so the guard is bypassed and `String(NaN)` = `"NaN"` is written back
+ *     — permanently poisoning the balance column.
+ *   - `deductCreditsWithTransaction`: the insufficient-balance spend gate
+ *     `Number(credit_balance) < amount` is FALSE for `NaN`, so the debit is
+ *     AUTHORIZED against a corrupt balance, `"NaN"` is written back, and a
+ *     phantom debit credit-transaction row is inserted. A money-out gate failing
+ *     open is the worst class of this bug.
+ *
+ * Failing closed here surfaces the corruption with a field-named error INSIDE
+ * the mutation transaction — before the guard is bypassed or a corrupt total is
+ * written — so the debit rolls back atomically and the corruption is reported
+ * instead of silently mis-charged.
+ *
+ * The regex only accepts a plain signed decimal (the exact shape Postgres NUMERIC
+ * emits) so JS-only coercions (`"1e3"`, `"0x10"`, `"NaN"`, `"Infinity"`) that
+ * `Number(...)` would otherwise accept or turn into `NaN` are rejected too.
+ */
+export function parseOrganizationCreditBalance(
+  value: string | number | null | undefined,
+  fieldName: string,
+): number {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    throw new Error(`Unable to read organization ${fieldName}: value is empty or missing`);
+  }
+  if (typeof value === "string" && !/^[+-]?(?:\d+|\d*\.\d+)$/.test(value.trim())) {
+    throw new Error(`Unable to read organization ${fieldName}: value is not a valid NUMERIC`);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Unable to read organization ${fieldName}: value is not a finite number`);
+  }
+  return parsed;
+}

--- a/packages/cloud/shared/src/db/repositories/organizations.ts
+++ b/packages/cloud/shared/src/db/repositories/organizations.ts
@@ -5,6 +5,7 @@ import type { CreditTransaction } from "../schemas/credit-transactions";
 import { creditTransactions } from "../schemas/credit-transactions";
 import { organizationBilling } from "../schemas/organization-billing";
 import { type NewOrganization, type Organization, organizations } from "../schemas/organizations";
+import { parseOrganizationCreditBalance } from "./organizations-credit-balance-numeric";
 
 export type { NewOrganization, Organization };
 
@@ -140,7 +141,10 @@ export class OrganizationsRepository {
         throw new Error("Organization not found");
       }
 
-      const currentBalance = Number(org.credit_balance);
+      // Fail closed on a corrupt NUMERIC read: a bare Number(...) would yield
+      // NaN, and `NaN < 0` is false, so the negative-balance guard below would
+      // be bypassed and String(NaN) = "NaN" written back, poisoning the column.
+      const currentBalance = parseOrganizationCreditBalance(org.credit_balance, "credit_balance");
       const newBalance = currentBalance + amount;
 
       if (newBalance < 0) {
@@ -194,7 +198,11 @@ export class OrganizationsRepository {
         throw new Error("Organization not found");
       }
 
-      const currentBalance = Number(org.credit_balance);
+      // Fail closed on a corrupt NUMERIC read: a bare Number(...) would yield
+      // NaN, and `NaN < amount` is false, so the insufficient-balance SPEND GATE
+      // below would be bypassed, authorizing a debit against a corrupt balance,
+      // writing "NaN" back, and inserting a phantom debit transaction.
+      const currentBalance = parseOrganizationCreditBalance(org.credit_balance, "credit_balance");
 
       if (currentBalance < amount) {
         throw new Error(


### PR DESCRIPTION
## What & why (#13416 cloud-shared DB-repository fallback-slop sweep)

`OrganizationsRepository` read `organizations.credit_balance` (Postgres NUMERIC → string at read) through a bare `Number(...)` in **both** balance-mutation paths, which fails **OPEN** on a corrupt value (`'NaN'::numeric` is a valid Postgres NUMERIC; a migration artifact or manual DB edit produces the same non-parseable string):

- **`updateCreditBalance`** (`organizations.ts:142`): `newBalance = Number(credit_balance) + amount` becomes `NaN`, and the negative-balance guard `newBalance < 0` is **false** for `NaN`, so the guard is bypassed and `String(NaN)` = `"NaN"` is written back — permanently poisoning the balance column.
- **`deductCreditsWithTransaction`** (`organizations.ts:196`): the insufficient-balance **spend gate** `Number(credit_balance) < amount` is **false** for `NaN`, so a debit is authorized against a corrupt balance, `"NaN"` is written back, and a phantom debit `credit_transactions` row is inserted. A money-out gate failing open is the worst class of this bug.

## Fix

Adds a colocated fail-closed `parseOrganizationCreditBalance()` boundary, mirroring the merged #13416 slices (usage-quotas #13454, app-earnings #13474, agent-billing #13482, conversations #13483, container-billing #13486). A regex accepts only a plain signed decimal (the exact shape Postgres NUMERIC emits), rejecting JS-only coercions (`"1e3"`, `"0x10"`, `"NaN"`, `"Infinity"`); an explicit domain `0` and a negative (overdrawn) balance are allowed. Both reads now throw **inside the mutation transaction**, so a corrupt row rolls the debit back atomically instead of bypassing the guard and mis-charging.

Behavior-preserving on healthy rows. Read-only display aggregations elsewhere in the repo are left as-is (not money-out gates).

## Tests & gates

- **16/16 green** (`packages/cloud/shared`): exhaustive parser boundary + fail-open regression proving both bare-`Number` gates would silently authorize on a corrupt balance + source grep-guard proving both mutation read sites delegate to the parser and no bare `Number(org.credit_balance)` survives on the write path. Parser 100% line/func coverage.
- **tsgo**: 0 new errors in touched files (17 pre-existing baseline in unrelated `app-core`/`redis`/`plugin-mcp`/`anthropic` files, identical on `develop`).
- **biome** clean, **error-policy-ratchet** clean.
- **codex**: "did not find any introduced correctness issues in the modified or new files."

Distinct file from all prior #13416 slices. Issue stays open for the remaining ~47-file DB-repo inventory.

— [sol-orch]