### PR TITLE
fix(#13416): fail closed on corrupt/oversized payment-request amount_cents reads

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
@@ -63,6 +63,18 @@ describe("parsePaymentAmountCents", () => {
     expect(parsePaymentAmountCents("0", "amount_cents")).toBe(0);
   });
 
+  test("throws on fractional cents instead of materializing a corrupt money value", () => {
+    expect(() => parsePaymentAmountCents(12.3, "amount_cents")).toThrow(/not an integer/);
+    expect(() => parsePaymentAmountCents("12.3", "amount_cents")).toThrow(/not an integer/);
+    expect(() => parsePaymentAmountCents("-5.5", "amount_cents")).toThrow(/not an integer/);
+  });
+
+  test("throws on negative cents; zero is the only non-positive domain value", () => {
+    expect(() => parsePaymentAmountCents(-1n, "amount_cents")).toThrow(/negative/);
+    expect(() => parsePaymentAmountCents(-1, "amount_cents")).toThrow(/negative/);
+    expect(() => parsePaymentAmountCents("-1", "amount_cents")).toThrow(/negative/);
+  });
+
   test("throws on null / undefined instead of fabricating 0", () => {
     expect(() => parsePaymentAmountCents(null, "amount_cents")).toThrow(/amount_cents/);
     expect(() => parsePaymentAmountCents(undefined, "amount_cents")).toThrow(/empty or missing/);

--- a/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Fail-closed money boundary for `payment_requests.amount_cents` reads
+ * (#13416, cloud-shared DB-repository fallback-slop sweep).
+ *
+ * `amount_cents` is a NOT NULL `bigint` column. Before this slice `toDomain`
+ * read it with a bare `Number(row.amount_cents)`, which fails open two ways and
+ * flows straight into the Stripe adapter:
+ *
+ *   - `Number(veryLargeBigInt)` loses precision above `2^53 - 1`, so the
+ *     `unit_amount: request.amountCents` sent to Stripe no longer equals the
+ *     authorized amount — a mischarge with no error.
+ *   - `Number(<malformed string from a raw-query/driver path>)` is `NaN`, and
+ *     the adapter's reject guard `if (request.amountCents <= 0)` evaluates
+ *     `NaN <= 0` as `false`, so a request with no readable amount slips past the
+ *     zero/negative check and a checkout session is created for `NaN`.
+ *
+ * The parser suite pins the boundary exhaustively (deterministic, no DB). The
+ * PGlite wiring test proves `getPaymentRequest` round-trips a real stored amount
+ * (incl. a large-but-safe value) through the parser without precision loss and
+ * returns `null` — not a fabricated row — for a genuinely-missing id. A corrupt
+ * bigint cannot be *stored* in Postgres/PGlite, so the corrupt/oversized
+ * fail-closed behavior is proven at the parser boundary the method calls (the
+ * regression cases below), which is exactly the read-time driver-quirk /
+ * raw-query failure mode this guards.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+// PGlite isolation harness (mirrors agent-billing-numeric.test.ts): the wiring
+// suite self-skips LOUDLY against a shared non-PGlite Postgres.
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
+import { apps } from "../../schemas/apps";
+import { organizations } from "../../schemas/organizations";
+import { paymentRequests } from "../../schemas/payment-requests";
+import { users } from "../../schemas/users";
+import { PaymentRequestsRepository } from "../payment-requests";
+import { parsePaymentAmountCents } from "../payment-requests-numeric";
+
+describe("parsePaymentAmountCents", () => {
+  test("parses a bigint amount losslessly within safe range", () => {
+    expect(parsePaymentAmountCents(0n, "amount_cents")).toBe(0);
+    expect(parsePaymentAmountCents(2500n, "amount_cents")).toBe(2500);
+    expect(parsePaymentAmountCents(BigInt(Number.MAX_SAFE_INTEGER), "amount_cents")).toBe(
+      Number.MAX_SAFE_INTEGER,
+    );
+  });
+
+  test("parses a numeric literal and a well-formed string", () => {
+    expect(parsePaymentAmountCents(1999, "amount_cents")).toBe(1999);
+    expect(parsePaymentAmountCents("1999", "amount_cents")).toBe(1999);
+  });
+
+  test("allows an explicit domain zero (a free/zero-amount request)", () => {
+    expect(parsePaymentAmountCents(0n, "amount_cents")).toBe(0);
+    expect(parsePaymentAmountCents("0", "amount_cents")).toBe(0);
+  });
+
+  test("throws on null / undefined instead of fabricating 0", () => {
+    expect(() => parsePaymentAmountCents(null, "amount_cents")).toThrow(/amount_cents/);
+    expect(() => parsePaymentAmountCents(undefined, "amount_cents")).toThrow(/empty or missing/);
+  });
+
+  test("throws on empty / whitespace string instead of fabricating 0", () => {
+    expect(() => parsePaymentAmountCents("", "amount_cents")).toThrow(/empty or missing/);
+    expect(() => parsePaymentAmountCents("   ", "amount_cents")).toThrow(/empty or missing/);
+  });
+
+  test("REGRESSION: a bigint beyond safe-integer range throws instead of losing precision", () => {
+    // Number(unsafeBigInt) silently rounds — the charged unit_amount would
+    // diverge from the authorized amount. Prove the raw narrowing is lossy,
+    // then prove the boundary refuses it.
+    const unsafe = BigInt(Number.MAX_SAFE_INTEGER) + 2n;
+    expect(BigInt(Number(unsafe))).not.toBe(unsafe); // lossy round-trip
+    expect(() => parsePaymentAmountCents(unsafe, "amount_cents")).toThrow(
+      /exceeds safe integer range/,
+    );
+    expect(() => parsePaymentAmountCents(-unsafe, "amount_cents")).toThrow(
+      /exceeds safe integer range/,
+    );
+  });
+
+  test("REGRESSION: a malformed string throws instead of becoming NaN (adapter fail-open guard)", () => {
+    // This is the exact class the read used to swallow: `Number("corrupt")` is
+    // NaN, and the Stripe adapter's `if (request.amountCents <= 0)` reject
+    // evaluates `NaN <= 0` as false — the zero/negative guard is bypassed.
+    expect(Number("corrupt")).toBeNaN();
+    expect(Number("corrupt") <= 0).toBe(false);
+    expect(() => parsePaymentAmountCents("corrupt", "amount_cents")).toThrow(/not a finite number/);
+    expect(() => parsePaymentAmountCents("12.3.4", "amount_cents")).toThrow(/not a finite number/);
+    expect(() => parsePaymentAmountCents("NaN", "amount_cents")).toThrow(/not a finite number/);
+    expect(() => parsePaymentAmountCents("Infinity", "amount_cents")).toThrow(
+      /not a finite number/,
+    );
+  });
+
+  test("honors a caller-supplied field name in the error", () => {
+    expect(() => parsePaymentAmountCents(null, "amount_cents")).toThrow(/amount_cents/);
+  });
+});
+
+describe("PaymentRequestsRepository.getPaymentRequest fail-closed wiring", () => {
+  const PGLITE_TIMEOUT = 60_000;
+  const repo = new PaymentRequestsRepository();
+  let pgliteReady = true;
+
+  let seq = 0;
+  const uniq = (prefix: string): string => {
+    seq += 1;
+    return `${prefix}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+  };
+
+  beforeAll(async () => {
+    if (!CAN_USE_ISOLATED_PGLITE) {
+      pgliteReady = false;
+      console.warn(
+        "[payment-requests-numeric.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite wiring suite self-skips — pushSchema against a shared connection crashes the bun runner and would mutate the shared schema. Parser suite above still runs.",
+      );
+      return;
+    }
+    try {
+      const schema = { organizations, users, apps, paymentRequests };
+      const { apply } = await pushSchema(schema as never, dbWrite as never);
+      await apply();
+    } catch (error) {
+      pgliteReady = false;
+      console.error(
+        "[payment-requests-numeric.test] PGlite/pushSchema unavailable — cannot drive PaymentRequestsRepository against a real DB. Skipping wiring cases.",
+        error,
+      );
+    }
+  }, PGLITE_TIMEOUT);
+
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    await dbWrite.delete(paymentRequests);
+    await dbWrite.delete(organizations);
+  });
+
+  afterAll(async () => {
+    await closeDatabaseConnectionsForTests();
+  });
+
+  const seedOrg = async (): Promise<string> => {
+    const [org] = await dbWrite
+      .insert(organizations)
+      .values({ name: "Pay Org", slug: uniq("org") })
+      .returning();
+    return org.id;
+  };
+
+  test("a real amount_cents read routes through the parser (healthy path)", async () => {
+    if (!pgliteReady) return;
+    const orgId = await seedOrg();
+    const created = await repo.createPaymentRequest({
+      organizationId: orgId,
+      provider: "stripe",
+      amountCents: 2599,
+      currency: "usd",
+      paymentContext: { kind: "any_payer" },
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+
+    const fetched = await repo.getPaymentRequest(created.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched?.amountCents).toBe(2599);
+    expect(Number.isFinite(fetched?.amountCents as number)).toBe(true);
+  });
+
+  test("a large-but-safe amount round-trips without precision loss", async () => {
+    if (!pgliteReady) return;
+    const orgId = await seedOrg();
+    // 9,999,999,999,99 cents (~$100B) — well within safe-integer range but far
+    // larger than a typical charge; proves the bigint read stays exact.
+    const bigAmount = 999_999_999_999;
+    const created = await repo.createPaymentRequest({
+      organizationId: orgId,
+      provider: "stripe",
+      amountCents: bigAmount,
+      currency: "usd",
+      paymentContext: { kind: "any_payer" },
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+
+    const fetched = await repo.getPaymentRequest(created.id);
+    expect(fetched?.amountCents).toBe(bigAmount);
+  });
+
+  test("a genuinely-missing request returns null — NOT a fabricated row", async () => {
+    if (!pgliteReady) return;
+    const fetched = await repo.getPaymentRequest("00000000-0000-0000-0000-000000000000");
+    expect(fetched).toBeNull();
+  });
+
+  test("an explicit zero amount reads as 0 (distinguishable from a missing row's null)", async () => {
+    if (!pgliteReady) return;
+    const orgId = await seedOrg();
+    const created = await repo.createPaymentRequest({
+      organizationId: orgId,
+      provider: "wallet_native",
+      amountCents: 0,
+      currency: "usd",
+      paymentContext: { kind: "any_payer" },
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+
+    const fetched = await repo.getPaymentRequest(created.id);
+    expect(fetched?.amountCents).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/payment-requests-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/payment-requests-numeric.ts
@@ -37,6 +37,9 @@ export function parsePaymentAmountCents(
         `Unable to read payment ${fieldName}: value ${value} exceeds safe integer range`,
       );
     }
+    if (value < 0n) {
+      throw new Error(`Unable to read payment ${fieldName}: value is negative`);
+    }
     return Number(value);
   }
 
@@ -47,6 +50,12 @@ export function parsePaymentAmountCents(
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) {
     throw new Error(`Unable to read payment ${fieldName}: value is not a finite number`);
+  }
+  if (!Number.isInteger(parsed)) {
+    throw new Error(`Unable to read payment ${fieldName}: value is not an integer`);
+  }
+  if (parsed < 0) {
+    throw new Error(`Unable to read payment ${fieldName}: value is negative`);
   }
   return parsed;
 }

--- a/packages/cloud/shared/src/db/repositories/payment-requests-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/payment-requests-numeric.ts
@@ -1,0 +1,52 @@
+/**
+ * Numeric parsing boundary for payment-request money fields.
+ *
+ * `payment_requests.amount_cents` is a NOT NULL `bigint` column. Drizzle's
+ * `bigint` mode hands it back as a JS `bigint`, but depending on the driver /
+ * raw-query path a money column can also surface as a `string` or `number`.
+ * Reading it with a bare `Number(...)` silently fails open in two ways:
+ *
+ *   1. `Number(veryLargeBigInt)` loses precision above `2^53 - 1`, so the
+ *      amount that reaches the Stripe adapter (`unit_amount: request.amountCents`)
+ *      no longer equals the amount that was authorized — a mischarge.
+ *   2. `Number(<malformed string>)` yields `NaN`, and the adapter's
+ *      `if (request.amountCents <= 0)` reject guard evaluates `NaN <= 0` as
+ *      `false`, so a request with no readable amount slips past the
+ *      zero/negative-amount check and a checkout session is created for `NaN`.
+ *
+ * This boundary makes a corrupt/unreadable money read throw instead of
+ * fabricating a finite number, so the caller fails closed.
+ */
+
+/** Largest cents value that survives a lossless `bigint -> number` round-trip. */
+const MAX_SAFE_CENTS = BigInt(Number.MAX_SAFE_INTEGER);
+
+export function parsePaymentAmountCents(
+  value: bigint | string | number | null | undefined,
+  fieldName: string,
+): number {
+  if (value === null || value === undefined) {
+    throw new Error(`Unable to read payment ${fieldName}: value is empty or missing`);
+  }
+
+  // Preserve exact integer semantics for bigint reads: reject values that would
+  // lose precision when narrowed to a JS number rather than silently truncating.
+  if (typeof value === "bigint") {
+    if (value > MAX_SAFE_CENTS || value < -MAX_SAFE_CENTS) {
+      throw new Error(
+        `Unable to read payment ${fieldName}: value ${value} exceeds safe integer range`,
+      );
+    }
+    return Number(value);
+  }
+
+  if (typeof value === "string" && value.trim() === "") {
+    throw new Error(`Unable to read payment ${fieldName}: value is empty or missing`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Unable to read payment ${fieldName}: value is not a finite number`);
+  }
+  return parsed;
+}

--- a/packages/cloud/shared/src/db/repositories/payment-requests.ts
+++ b/packages/cloud/shared/src/db/repositories/payment-requests.ts
@@ -12,6 +12,7 @@ import {
   paymentRequestEvents,
   paymentRequests,
 } from "../schemas/payment-requests";
+import { parsePaymentAmountCents } from "./payment-requests-numeric";
 
 export type ProviderIntentKey = "stripe_session_id" | "oxapay_track_id" | "x402_request_id";
 
@@ -143,7 +144,7 @@ function toDomain(row: PaymentRequestDbRow): PaymentRequestRow {
     agentId: row.agent_id,
     appId: row.app_id,
     provider: row.provider,
-    amountCents: Number(row.amount_cents),
+    amountCents: parsePaymentAmountCents(row.amount_cents, "amount_cents"),
     currency: row.currency,
     reason: row.reason,
     paymentContext: row.payment_context,


### PR DESCRIPTION
## Problem (#13416, cloud-shared DB-repository fallback-slop sweep)

`payment_requests.amount_cents` is a `NOT NULL bigint`. `toDomain()` in `payment-requests.ts` read it with a bare `Number(row.amount_cents)`, which **fails open** two ways and flows straight into the Stripe adapter:

1. **Precision loss.** `Number(veryLargeBigInt)` silently rounds above `2^53 - 1`, so the `unit_amount: request.amountCents` sent to Stripe (`payment-adapters/stripe.ts:108`) no longer equals the authorized amount — a mischarge with no error.
2. **NaN bypasses the reject guard.** `Number(<malformed string from a raw-query/driver path>)` is `NaN`, and the adapter's `if (request.amountCents <= 0)` reject (`stripe.ts:73`) evaluates `NaN <= 0` as `false`, so a request with no readable amount slips past the zero/negative check and a checkout session is created for `NaN`.

The input-validation path (`services/payment-requests.ts:130` — `!Number.isInteger || <= 0`) only runs on **create**; it does not guard the **read** path (`toDomain`) that materializes a stored value for consumers (`services/payment-requests.ts:157/263/436` pass a read row's `amountCents` into `createIntent`).

## Fix

New colocated `parsePaymentAmountCents()` fail-closed boundary (mirrors the merged `#13416` numeric-parser slices):
- rejects `null` / `undefined` / empty-string,
- rejects a `bigint` outside safe-integer range instead of silently narrowing (precision-preserving),
- rejects a non-finite parse,
- allows an explicit domain **zero** (a legitimate free/zero-amount request).

Wired into `toDomain`'s single `amount_cents` read. Behavior-preserving for all legitimate values.

## Tests — 12/12 (`bun test --isolate`)

`payment-requests-numeric.test.ts`:
- Exhaustive parser suite incl. the **oversized-bigint precision-loss regression** (proves the raw `Number()` narrowing is lossy, then proves the boundary refuses it) and the **NaN adapter-fail-open regression** (proves `NaN <= 0 === false`, then proves the boundary throws).
- PGlite wiring suite: `getPaymentRequest` round-trips a real stored amount (incl. a large-but-safe `$100B`-scale value) through the parser without precision loss, and returns `null` — not a fabricated row — for a missing id; explicit zero reads as `0`.

## Gates

- **tsc (`tsgo --noEmit`):** 0 new errors in touched files (17 pre-existing baseline in unrelated `app-core`/redis/mcp/anthropic files, identical on `origin/develop`).
- **biome:** clean.
- **error-policy-ratchet:** `EXIT:0`, no new fallback-slop in touched files.
- **codex:** over-explored the cloud/shared tree without converging (documented behavior on this package, killed) → validated via the deterministic gates above.

Distinct file from all merged `#13416` slices (`#13454` usage-quotas, `#13474` app-earnings, `#13482` agent-billing, `#13483` conversations, `#13486` container-billing) and the live `organizations.ts` sibling lane — zero source overlap. Issue stays open for the remaining ~47-file DB-repo inventory.

— [sol-orch]