### PR TITLE
fix(#13415): fail-closed auto-top-up money-gate NUMERIC reads

### DIFF
--- a/.github/issue-evidence/13415-auto-top-up-fallback.md
+++ b/.github/issue-evidence/13415-auto-top-up-fallback.md
@@ -1,0 +1,68 @@
+# #13415 evidence — cloud-shared service-layer fallback slop: `auto-top-up.ts` money-gate NUMERIC reads
+
+Slice of the `agent-ready: fallback slop sweep for cloud-shared service layer` sweep.
+File: `packages/cloud/shared/src/lib/services/auto-top-up.ts`. Distinct from the sibling
+fleet-13415 lane (which owns `agent-budgets.ts`) and from the credit-balance slices
+`#13137`/`#13256`/`#13261`/PR `#13355`.
+
+## Fallback census (before → after)
+
+| path:line | read | verdict | fix |
+| --- | --- | --- | --- |
+| `auto-top-up.ts` `executeAutoTopUp` (was line ~151) | `const amount = Number(org.auto_top_up_amount \|\| 0)` then `if (amount <= 0 \|\| amount > MAX)` | **FAIL-OPEN money gate** — a corrupt `auto_top_up_amount` (`'NaN'::numeric` is a valid Postgres store, reads back as the string `"NaN"`; `"NaN" \|\| 0` = `"NaN"`, truthy → `Number("NaN")` = `NaN`). `NaN <= 0` and `NaN > MAX` are **both false**, so a corrupt amount slips **past** the invalid-amount guard into `paymentIntents.create({ amount: Math.round(NaN * 100) })` = charge with `amount: NaN`. | Read via new `parseAutoTopUpNumber("auto_top_up_amount", ...)` fail-closed boundary; a corrupt amount hits the **existing** invalid-amount path (`disableAutoTopUp` + `success:false`) instead of charging. |
+| `auto-top-up.ts` affiliate block (was line ~185) | `const affiliatePercent = Number(referrer.markup_percent)` → `affiliateFeeAmount = amount * (affiliatePercent / 100)` → `totalAmount = amount + affiliateFeeAmount + platformFeeAmount` | **FAIL-OPEN money gate** — a corrupt `markup_percent` NaN poisons `affiliateFeeAmount` → `totalAmount` = `NaN` → `Math.round(NaN * 100)` = `NaN` charged amount. | Read via `parseAutoTopUpNumber("markup_percent", ...)`; on corruption the **best-effort surcharge is dropped** (affiliate attribution + fees reset to 0, base amount still charged) with an observable `logger.error`. Customer's top-up is not denied over a corrupt affiliate record, and no `NaN` total is ever charged. |
+| `auto-top-up.ts` `previousBalance = Number(org.credit_balance)` | display-only value passed to the success email | **intentional keep** — not a money gate / decision input | left as-is |
+| `auto-top-up.ts` `Number(org.auto_top_up_amount \|\| 0)` / `Number(org.auto_top_up_threshold \|\| 0)` in `getSettings`/`updateSettings` | read-back for display + `validateSettings` (which already `throw`s on non-finite via `Number.isFinite` guard) | **intentional keep** — `validateSettings` already fails closed on non-finite | left as-is |
+
+## Root cause
+
+Postgres `NUMERIC` values arrive as strings at the driver, and `'NaN'::numeric` is a legal
+stored value that reads back as `"NaN"`. Every comparison against `NaN` is `false`, so a
+bare `Number(...)` read on a money field silently defeats a `<= 0` / `> MAX` range gate and
+propagates `NaN` into a Stripe charge. Mirrors the merged fail-closed NUMERIC-boundary
+pattern from `#13454` (usage-quotas), `#13474` (app-earnings), `#13482`/`#13486` (agent/
+container billing).
+
+## Fix
+
+New colocated `parseAutoTopUpNumber(field, raw)` fail-closed boundary + typed
+`CorruptAutoTopUpNumberError`. Throws on `null`/`undefined`/blank/non-finite; allows an
+explicit domain `0`. Wired into the two money-computation reads:
+- `auto_top_up_amount` → corrupt = same `disableAutoTopUp` + `success:false` path as an
+  out-of-range amount (never charges).
+- affiliate `markup_percent` → corrupt = drop the surcharge, charge the base amount
+  (best-effort surcharge fail-safe), never a `NaN` total.
+
+## Tests (focused error-path)
+
+`packages/cloud/shared/src/lib/services/__tests__/auto-top-up.test.ts` (+8 tests):
+- `parseAutoTopUpNumber` unit: parses finite strings/numbers/explicit-0; throws on the
+  `"NaN"` read-back (regression guard asserting `Number("NaN")` is `NaN`), on
+  null/undefined/blank/non-numeric/Infinity.
+- `executeAutoTopUp`: corrupt `auto_top_up_amount` disables + fails, `createPaymentIntent`
+  and `addCredits` **never called**; corrupt `markup_percent` charges base `1000` cents
+  (not `Math.round(NaN*100)`) with no affiliate metadata and `total_charged: "10.00"`,
+  top-up still succeeds; valid markup still applies the `$13.00` surcharge (no behavior
+  change).
+
+```
+bun test packages/cloud/shared/src/lib/services/__tests__/auto-top-up.test.ts
+12 pass / 0 fail / 39 expect() calls
+```
+
+## Verification
+
+- `bunx @biomejs/biome check <touched files>` → clean (2 files, no fixes).
+- `bun run --cwd packages/cloud/shared typecheck` → **0 errors in `auto-top-up.ts`**; 21
+  pre-existing baseline errors in unrelated files (fresh-worktree i18n generated keyword
+  data + symlinked-node_modules drift: `core/src/i18n/*`, `shared/src/i18n/*`, `app-core/*`,
+  `lib/cache/adapters/node-redis-adapter.ts`, `plugin-mcp/utils/json.ts`,
+  `providers/anthropic-web-search.ts`) — none in touched files.
+- `node packages/scripts/error-policy-ratchet.mjs` → `no new fallback-slop in touched files`.
+
+## N/A rows
+
+- UI screenshots: N/A — service unit boundary only.
+- Model trajectories: N/A.
+- Audio: N/A.
+- Runtime logs: N/A — service unit boundary only (Stripe/DB not exercised live).

--- a/packages/cloud/shared/src/lib/services/__tests__/auto-top-up.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/auto-top-up.test.ts
@@ -14,11 +14,13 @@ mock.module("../../../db/client", () => ({
 }));
 
 const updateOrganization = mock();
+const findOrganizationById = mock();
 const listByOrganization = mock();
 
 mock.module("../../../db/repositories", () => ({
   organizationsRepository: {
     update: updateOrganization,
+    findById: findOrganizationById,
   },
   usersRepository: {
     listByOrganization,
@@ -75,7 +77,9 @@ mock.module("../../utils/logger", () => ({
   },
 }));
 
-const { AutoTopUpService } = await import("../auto-top-up");
+const { AutoTopUpService, parseAutoTopUpNumber, CorruptAutoTopUpNumberError } = await import(
+  "../auto-top-up"
+);
 
 type AutoTopUpOrganization = Parameters<AutoTopUpService["executeAutoTopUp"]>[0];
 
@@ -96,7 +100,9 @@ function makeOrganization(overrides: Partial<AutoTopUpOrganization> = {}): AutoT
 
 beforeEach(() => {
   updateOrganization.mockReset();
+  findOrganizationById.mockReset();
   listByOrganization.mockReset();
+  findOrganizationById.mockResolvedValue(makeOrganization());
   createPaymentIntent.mockReset();
   retrievePaymentMethod.mockReset();
   requireStripe.mockClear();
@@ -153,6 +159,110 @@ describe("AutoTopUpService.executeAutoTopUp", () => {
       amount: 10,
       newBalance: 42.25,
     });
+  });
+});
+
+describe("parseAutoTopUpNumber (fail-closed NUMERIC boundary)", () => {
+  test("parses finite numeric strings and numbers", () => {
+    expect(parseAutoTopUpNumber("auto_top_up_amount", "10.00")).toBe(10);
+    expect(parseAutoTopUpNumber("markup_percent", 5)).toBe(5);
+    expect(parseAutoTopUpNumber("markup_percent", "0")).toBe(0);
+    expect(parseAutoTopUpNumber("markup_percent", 0)).toBe(0);
+  });
+
+  test("throws on the corrupt 'NaN'::numeric read-back that slips past bare Number()", () => {
+    // Regression guard: bare Number("NaN") is NaN and NaN <= 0 / NaN > MAX are
+    // both false, so this exact value used to flow into a Stripe NaN charge.
+    expect(() => parseAutoTopUpNumber("auto_top_up_amount", "NaN")).toThrow(
+      CorruptAutoTopUpNumberError,
+    );
+    expect(Number("NaN")).toBeNaN();
+  });
+
+  test("throws on null/undefined/blank/non-numeric values", () => {
+    expect(() => parseAutoTopUpNumber("auto_top_up_amount", null)).toThrow(
+      CorruptAutoTopUpNumberError,
+    );
+    expect(() => parseAutoTopUpNumber("auto_top_up_amount", undefined)).toThrow(
+      CorruptAutoTopUpNumberError,
+    );
+    expect(() => parseAutoTopUpNumber("auto_top_up_amount", "   ")).toThrow(
+      CorruptAutoTopUpNumberError,
+    );
+    expect(() => parseAutoTopUpNumber("auto_top_up_amount", "abc")).toThrow(
+      CorruptAutoTopUpNumberError,
+    );
+    expect(() => parseAutoTopUpNumber("markup_percent", Number.POSITIVE_INFINITY)).toThrow(
+      CorruptAutoTopUpNumberError,
+    );
+  });
+});
+
+describe("AutoTopUpService.executeAutoTopUp fail-closed money gates", () => {
+  test("corrupt auto_top_up_amount ('NaN') disables + fails instead of charging NaN", async () => {
+    const org = makeOrganization({ auto_top_up_amount: "NaN" });
+
+    const result = await new AutoTopUpService().executeAutoTopUp(org);
+
+    // The corrupt amount must NEVER reach Stripe as Math.round(NaN * 100).
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+    expect(addCredits).not.toHaveBeenCalled();
+    // Same fail-closed path as an out-of-range invalid amount: disable + fail.
+    expect(updateOrganization).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ auto_top_up_enabled: false }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        organizationId: "org-1",
+        success: false,
+        error: "Invalid top-up amount",
+      }),
+    );
+  });
+
+  test("corrupt affiliate markup_percent charges the base amount (no NaN total), no surcharge", async () => {
+    getReferrer.mockResolvedValue({
+      user_id: "affiliate-owner",
+      id: "code-1",
+      markup_percent: "NaN",
+    });
+
+    const result = await new AutoTopUpService().executeAutoTopUp(makeOrganization());
+
+    expect(createPaymentIntent).toHaveBeenCalledTimes(1);
+    const chargedAmount = createPaymentIntent.mock.calls[0][0].amount;
+    // Base $10.00 charged as 1000 cents, NOT Math.round(NaN * 100) = NaN.
+    expect(chargedAmount).toBe(1000);
+    expect(Number.isNaN(chargedAmount)).toBe(false);
+    // Surcharge dropped: no affiliate fee metadata on a corrupt markup.
+    const metadata = createPaymentIntent.mock.calls[0][0].metadata;
+    expect(metadata.affiliate_fee_amount).toBeUndefined();
+    expect(metadata.affiliate_owner_id).toBeUndefined();
+    expect(metadata.total_charged).toBe("10.00");
+    // Customer's top-up still succeeds (best-effort surcharge, fail-safe).
+    expect(addCredits).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(
+      expect.objectContaining({ organizationId: "org-1", success: true, amount: 10 }),
+    );
+  });
+
+  test("valid affiliate markup still applies the surcharge (no behavior change)", async () => {
+    getReferrer.mockResolvedValue({
+      user_id: "affiliate-owner",
+      id: "code-1",
+      markup_percent: "10",
+    });
+
+    await new AutoTopUpService().executeAutoTopUp(makeOrganization());
+
+    expect(createPaymentIntent).toHaveBeenCalledTimes(1);
+    // $10 base + 10% affiliate ($1) + 20% platform ($2) = $13.00 -> 1300 cents.
+    expect(createPaymentIntent.mock.calls[0][0].amount).toBe(1300);
+    const metadata = createPaymentIntent.mock.calls[0][0].metadata;
+    expect(metadata.affiliate_fee_amount).toBe("1.00");
+    expect(metadata.affiliate_owner_id).toBe("affiliate-owner");
+    expect(metadata.total_charged).toBe("13.00");
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/auto-top-up.ts
+++ b/packages/cloud/shared/src/lib/services/auto-top-up.ts
@@ -15,6 +15,49 @@ export const AUTO_TOP_UP_LIMITS = {
   MAX_THRESHOLD: 1000,
 } as const;
 
+/**
+ * Thrown when an auto-top-up money-gate field read from a NUMERIC column
+ * cannot be coerced to a finite number. A corrupt persisted value must fail
+ * closed (no charge, no fabricated success) rather than flow a `NaN` into the
+ * charged Stripe amount or the affiliate/total markup math.
+ */
+export class CorruptAutoTopUpNumberError extends Error {
+  constructor(
+    readonly field: string,
+    readonly rawValue: unknown,
+  ) {
+    super(`Auto top-up ${field} is not a finite number: ${String(rawValue)}`);
+    this.name = "CorruptAutoTopUpNumberError";
+  }
+}
+
+/**
+ * Fail-closed boundary for auto-top-up NUMERIC reads. Postgres NUMERIC values
+ * arrive as strings at the driver, and `'NaN'::numeric` is a VALID stored value
+ * that reads back as the string `"NaN"` — `Number("NaN")` is `NaN`, and every
+ * `NaN <= 0` / `NaN > MAX` comparison is `false`, so a bare `Number(...)` read
+ * silently slips a corrupt amount PAST the invalid-amount guard and into a
+ * Stripe `paymentIntents.create({ amount: Math.round(NaN * 100) })` charge (or
+ * a `NaN` total via corrupt affiliate `markup_percent`).
+ *
+ * Throws {@link CorruptAutoTopUpNumberError} on a missing/blank/non-finite
+ * value so the caller aborts before charging. An explicit domain value of `0`
+ * is allowed (a legitimately zero markup/threshold is not corruption).
+ */
+export function parseAutoTopUpNumber(field: string, raw: unknown): number {
+  if (raw === null || raw === undefined) {
+    throw new CorruptAutoTopUpNumberError(field, raw);
+  }
+  if (typeof raw === "string" && raw.trim() === "") {
+    throw new CorruptAutoTopUpNumberError(field, raw);
+  }
+  const value = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new CorruptAutoTopUpNumberError(field, raw);
+  }
+  return value;
+}
+
 export interface AutoTopUpResult {
   organizationId: string;
   success: boolean;
@@ -148,7 +191,26 @@ export class AutoTopUpService {
       };
     }
 
-    const amount = Number(org.auto_top_up_amount || 0);
+    // Fail-closed read: a corrupt/non-finite persisted auto_top_up_amount (e.g.
+    // 'NaN'::numeric) would coerce to NaN and PASS both `<= 0` and `> MAX`
+    // guards below, then flow into Stripe as amount: Math.round(NaN * 100).
+    // Treat a corrupt amount exactly like an invalid amount: disable + fail,
+    // never charge.
+    let amount: number;
+    try {
+      amount = parseAutoTopUpNumber("auto_top_up_amount", org.auto_top_up_amount ?? 0);
+    } catch (parseError) {
+      logger.error(
+        `[AutoTopUp] Org ${organizationId} has a corrupt top-up amount`,
+        parseError instanceof Error ? { error: parseError.message } : { error: String(parseError) },
+      );
+      await this.disableAutoTopUp(organizationId, "Invalid top-up amount");
+      return {
+        organizationId,
+        success: false,
+        error: "Invalid top-up amount",
+      };
+    }
     if (amount <= 0 || amount > AUTO_TOP_UP_LIMITS.MAX_AMOUNT) {
       logger.error(`[AutoTopUp] Org ${organizationId} has invalid top-up amount: ${amount}`);
       await this.disableAutoTopUp(organizationId, "Invalid top-up amount");
@@ -180,17 +242,44 @@ export class AutoTopUpService {
       if (checkUserId) {
         const referrer = await affiliatesService.getReferrer(checkUserId);
         if (referrer) {
-          affiliateOwnerId = referrer.user_id;
-          affiliateCodeId = referrer.id;
-          const affiliatePercent = Number(referrer.markup_percent);
-          const platformPercent = 20.0;
+          // Fail-closed read: a corrupt markup_percent ('NaN'::numeric) would
+          // make affiliateFeeAmount = amount * (NaN / 100) = NaN, poisoning
+          // totalAmount into Math.round(NaN * 100) = NaN. Never charge NaN.
+          let affiliatePercent: number;
+          try {
+            affiliatePercent = parseAutoTopUpNumber("markup_percent", referrer.markup_percent);
+          } catch (markupError) {
+            // A corrupt affiliate surcharge must NOT deny the customer's top-up
+            // and must NOT fabricate a NaN charge: drop the affiliate
+            // attribution + surcharge and proceed to bill the base amount.
+            logger.error(
+              `[AutoTopUp] Corrupt affiliate markup_percent for org ${organizationId}; charging base amount without surcharge`,
+              markupError instanceof Error
+                ? { error: markupError.message }
+                : { error: String(markupError) },
+            );
+            affiliateOwnerId = null;
+            affiliateCodeId = null;
+            affiliateFeeAmount = 0;
+            platformFeeAmount = 0;
+            affiliatePercent = Number.NaN; // sentinel: skip surcharge below
+          }
 
-          affiliateFeeAmount = amount * (affiliatePercent / 100);
-          platformFeeAmount = amount * (platformPercent / 100);
-          logger.info("Affiliate metadata applied", referrer);
+          if (Number.isFinite(affiliatePercent)) {
+            affiliateOwnerId = referrer.user_id;
+            affiliateCodeId = referrer.id;
+            const platformPercent = 20.0;
+
+            affiliateFeeAmount = amount * (affiliatePercent / 100);
+            platformFeeAmount = amount * (platformPercent / 100);
+            logger.info("Affiliate metadata applied", referrer);
+          }
         }
       }
     } catch (e) {
+      // Affiliate lookup/markup is a best-effort surcharge; on any failure we
+      // charge the base amount (surcharge fields reset to 0 above) rather than
+      // abort the top-up or bill a fabricated total.
       logger.error(`[AutoTopUp] Failed to lookup affiliate for org ${organizationId}`, e);
     }
 


### PR DESCRIPTION
## Problem

`AutoTopUpService.executeAutoTopUp` read two money-gate NUMERIC columns via bare `Number(...)`:

1. `const amount = Number(org.auto_top_up_amount || 0)` then `if (amount <= 0 || amount > MAX)`.
2. `const affiliatePercent = Number(referrer.markup_percent)` → `affiliateFeeAmount = amount * (affiliatePercent / 100)` → `totalAmount = amount + affiliateFeeAmount + platformFeeAmount`.

Postgres `NUMERIC` values arrive as strings at the driver, and `'NaN'::numeric` is a **valid stored value** that reads back as the string `"NaN"` (`"NaN" || 0` = `"NaN"`, truthy → `Number("NaN")` = `NaN`). Every comparison against `NaN` is `false`, so:

- A corrupt `auto_top_up_amount` slips **past** the invalid-amount guard (`NaN <= 0` and `NaN > MAX` both false) straight into `paymentIntents.create({ amount: Math.round(NaN * 100) })` — a Stripe charge with `amount: NaN`.
- A corrupt affiliate `markup_percent` poisons `totalAmount` into `NaN`, again charging `Math.round(NaN * 100)`.

This is the same NUMERIC-fail-open class the merged slices `#13454` (usage-quotas), `#13474` (app-earnings), and `#13482`/`#13486` (agent/container billing) closed on other columns.

## Fix

New colocated `parseAutoTopUpNumber(field, raw)` fail-closed boundary + typed `CorruptAutoTopUpNumberError` (throws on `null`/`undefined`/blank/non-finite; allows explicit domain `0`). Wired into both reads:

- `auto_top_up_amount` → a corrupt value now takes the **existing** `disableAutoTopUp` + `success:false` path (identical to an out-of-range amount) instead of charging `NaN`.
- affiliate `markup_percent` → a corrupt value **drops the best-effort surcharge** (affiliate attribution + fees reset to 0, base amount still charged) with an observable `logger.error`. The customer's top-up is not denied over a corrupt affiliate record, and no `NaN` total is ever charged.

Display-only `previousBalance = Number(org.credit_balance)` and the `getSettings`/`updateSettings` reads (already guarded by `validateSettings`' `Number.isFinite` throw) are intentional keeps.

## Tests

`packages/cloud/shared/src/lib/services/__tests__/auto-top-up.test.ts` (+8):
- `parseAutoTopUpNumber` unit — parses finite strings/numbers/explicit-`0`; throws on the `"NaN"` read-back (regression guard asserting `Number("NaN")` is `NaN`), null/undefined/blank/non-numeric/Infinity.
- `executeAutoTopUp` — corrupt `auto_top_up_amount` disables + fails with `createPaymentIntent`/`addCredits` **never called**; corrupt `markup_percent` charges base `1000` cents (not `Math.round(NaN*100)`) with no affiliate metadata + `total_charged: "10.00"`, top-up still succeeds; valid markup still applies the `$13.00` surcharge (no behavior change).

```
bun test packages/cloud/shared/src/lib/services/__tests__/auto-top-up.test.ts
12 pass / 0 fail / 39 expect() calls
```

- `bunx @biomejs/biome check <touched files>` → clean.
- `node packages/scripts/error-policy-ratchet.mjs` → `no new fallback-slop in touched files` (`auto-top-up.ts` emptyCatch 0→0, serverConsole 0→0).
- `bun run --cwd packages/cloud/shared typecheck` → **0 errors in `auto-top-up.ts`** (21 pre-existing baseline errors in unrelated files: fresh-worktree i18n generated keyword data + symlinked-node_modules drift; none in touched files).
- `git diff --check` clean.

## Scope

Slice of #13415 (cloud-shared service-layer fallback sweep). Distinct file from sibling lanes (`agent-budgets.ts`, `payout-processor.ts`) and from the credit-balance slices #13137/#13256/#13261/#13355. Issue stays open for the remaining service-layer inventory. Evidence: `.github/issue-evidence/13415-auto-top-up-fallback.md`.

-- [sol-orch]
