### PR TITLE
fix(#13415): fail closed on corrupt NUMERIC money fields in payout-processor

### DIFF
--- a/.github/issue-evidence/13415-cloud-shared-services-payout-processor-fallback.md
+++ b/.github/issue-evidence/13415-cloud-shared-services-payout-processor-fallback.md
@@ -45,6 +45,10 @@ to manual review (non-retryable, because a corrupt row is not transient):
   same parser (defense-in-depth: a direct call can never build a zero-token
   transfer either).
 - `markCompleted` `usdNumber` uses the parser (already proven finite pre-broadcast).
+- `refundStrandedRedemption` also parses `usd_value` before issuing the automatic
+  failed-redemption refund. If the refund amount itself is corrupt, the row stays
+  `failed`/`requires_review` and the refund is skipped instead of sending
+  `NaN`/empty coercion into refund accounting.
 
 Distinct/not-found/unavailable stays distinct from corruption: "not configured"
 wallet, expired quote, and a genuinely-valid row are all unaffected (positive
@@ -80,7 +84,7 @@ Coverage:
 
 ## Gates
 
-- `bun test --isolate <test>` → **14/14 pass**.
+- `bun --conditions=eliza-source test --isolate <test>` → **14/14 pass**.
 - `bunx @biomejs/biome check <payout-processor.ts + test>` → **clean** (2 files fixed then clean).
 - `bun run audit:error-policy-ratchet` → **`no new fallback-slop in touched files`** (EXIT 0).
 - `bun run --cwd packages/cloud/shared typecheck` → **17 pre-existing baseline errors**

--- a/.github/issue-evidence/13415-cloud-shared-services-payout-processor-fallback.md
+++ b/.github/issue-evidence/13415-cloud-shared-services-payout-processor-fallback.md
@@ -1,0 +1,108 @@
+# #13415 — cloud-shared service-layer fallback-slop sweep: `payout-processor.ts` money-out NUMERIC fail-closed slice
+
+Slice of the `packages/cloud/shared` service-layer sweep. Target file:
+`packages/cloud/shared/src/lib/services/payout-processor.ts` (a file the issue
+flags as a "🚨 CRITICAL SECURITY COMPONENT 🚨" — hot-wallet token payouts).
+
+Distinct from the concurrent sibling `#13415` lane (which owns `agent-budgets.ts`
+only) and from every merged `#13416` DB-repository slice.
+
+## Fallback census (before)
+
+The approved-redemption payout path read three `notNull` Postgres `numeric(...)`
+columns on `token_redemptions` — which the driver returns as **strings** — via
+bare `Number()` / viem `parseUnits()`, with **no fail-closed boundary**:
+
+| path/line | read | corrupt-value behavior (before) | verdict |
+| --- | --- | --- | --- |
+| `processRedemption` price guard | `Number(redemption.eliza_price_usd)` → `validatePrice` | `NaN` → `slippage = |current-NaN|/NaN = NaN` → `NaN > MAX === false` → **guard FAILS OPEN**, payout authorized against an unvalidatable quote | **fail-open (fix)** |
+| `executeSolanaPayout` amount | `BigInt(Math.floor(Number(redemption.eliza_amount) * 10**d))` | `Number('')===0` → `0n` → **zero-token transfer broadcast + confirmed + marked `completed` with a real tx hash** (fabricated success; user gets nothing, pending balance still debited). `Number('NaN')*1e9=NaN` → `BigInt(NaN)` raw `RangeError` | **fabricated-success / raw-throw (fix)** |
+| `executeEvmPayout` amount | `parseUnits(redemption.eliza_amount.toString(), d)` | `parseUnits('', d) === 0n` (verified) → same **zero-token fabricated-success** | **fabricated-success (fix)** |
+| `markCompleted` ledger | `usdValue = usd_value.toString()` into `total_pending - usdValue` / `total_redeemed + usdValue` SQL; `usdNumber = Number(usd_value)` into `$${usdNumber.toFixed(2)}` description | corrupt `usd_value` → `- 'NaN'` poisons ledger balances / `$NaN` in ledger description. Runs only AFTER broadcast, so a post-broadcast throw would half-record | **ledger-corruption (fix, gated pre-broadcast)** |
+
+`viem.parseUnits('', 9) === 0n` and `Number('') === 0` confirmed empirically on the
+pinned toolchain; `'NaN'::numeric` is a legal Postgres store returned as `"NaN"`.
+
+## Fix (fail-closed boundary)
+
+New colocated, exported, pure boundary (mirrors the merged `#13474` app-earnings /
+`#13454` usage-quotas parsers):
+
+- `parseRedemptionAmount(field, raw): number` — throws `CorruptRedemptionAmountError`
+  on `null`/`undefined`/empty/whitespace/non-finite; allows an explicit domain `0`;
+  **never returns `NaN`, never silently substitutes `0`**.
+
+Wired so a corrupt row is refused **before anything is signed or broadcast**, as a
+`{ success: false, retryable: false }` `PayoutResult` → routes through `markFailed`
+to manual review (non-retryable, because a corrupt row is not transient):
+
+- `processRedemption` top: parse `eliza_amount` (+ reject `<= 0` no-op transfers),
+  parse `usd_value` (gated here so `markCompleted` never writes `$NaN`/`- 'NaN'`
+  post-broadcast), and — when `ENFORCE_PRICE_VALIDATION` is on — parse
+  `eliza_price_usd` (+ reject `<= 0`, whose `Infinity` slippage would be an
+  accidental divide-by-zero rejection, not a policy signal).
+- `executeSolanaPayout` / `executeEvmPayout` amount reads re-validate through the
+  same parser (defense-in-depth: a direct call can never build a zero-token
+  transfer either).
+- `markCompleted` `usdNumber` uses the parser (already proven finite pre-broadcast).
+
+Distinct/not-found/unavailable stays distinct from corruption: "not configured"
+wallet, expired quote, and a genuinely-valid row are all unaffected (positive
+control test proves a healthy row passes the numeric guards and only hits the
+wallet boundary).
+
+No `console.*` introduced (structured `logger.error` on every refusal). No
+intentional fail-safe keep needed → no new `// error-policy:J<N>` annotation
+(this converts silent slop into explicit fail-closed control flow, not a keep).
+
+## Tests
+
+`packages/cloud/shared/src/lib/services/payout-processor.numeric-fail-closed.test.ts`
+— `bun test --isolate` (the package's primary runner; its `vitest.config.ts` is a
+single-file integration harness):
+
+```
+ 14 pass
+ 0 fail
+ 30 expect() calls
+Ran 14 tests across 1 file.
+```
+
+Coverage:
+- 9 parser unit tests: normal decimal string, numeric input, explicit `0`,
+  `'NaN'` regression, `''` regression (the `parseUnits('')===0n` case), whitespace,
+  `null`/`undefined`, non-numeric + `Infinity`, error names field+value.
+- 5 seam tests through `PayoutProcessorService.processRedemption` (no wallet/DB):
+  corrupt `eliza_amount` → non-retryable refuse; empty `eliza_amount` regression →
+  refuse (not zero-token success); non-positive amount → refuse; corrupt
+  `usd_value` → refuse; **positive control**: a healthy row is NOT over-rejected by
+  the numeric guards (falls through to the wallet boundary).
+
+## Gates
+
+- `bun test --isolate <test>` → **14/14 pass**.
+- `bunx @biomejs/biome check <payout-processor.ts + test>` → **clean** (2 files fixed then clean).
+- `bun run audit:error-policy-ratchet` → **`no new fallback-slop in touched files`** (EXIT 0).
+- `bun run --cwd packages/cloud/shared typecheck` → **17 pre-existing baseline errors**
+  in unrelated files (`app-core/@elizaos/auth/*` symlink drift, `node-redis-adapter.ts`,
+  `plugin-mcp/utils/json.ts`, `anthropic-web-search.ts`), **0 in the touched files**.
+  Identical baseline documented by prior merged cloud-shared slices.
+
+## Non-applicable evidence
+
+- UI screenshots — N/A (server-only service unit boundary).
+- Model trajectories — N/A.
+- Audio — N/A.
+- Runtime logs — N/A (unit boundary; refusal paths emit structured
+  `logger.error(...)`, shown inline in the test transcript).
+
+## Collision receipts
+
+- No open PR references `#13415` at claim OR push.
+- No open PR touches `payout-processor.ts` at claim OR push.
+- No `lalalune` / `NubsCarson` / `roninjin10` payout-processor PR in the last day.
+- Sibling `fleet-13415` worktree owns `agent-budgets.ts` ONLY (no payout files).
+- Unique worktree path `fleet-13415-payout`; only my intended files staged; diff
+  contains no foreign paths.
+
+— [sol-orch]

--- a/packages/cloud/shared/src/lib/services/payout-processor.numeric-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/payout-processor.numeric-fail-closed.test.ts
@@ -1,0 +1,149 @@
+// Fail-closed regression tests for #13415 (cloud-shared service-layer fallback-slop
+// sweep): the token-redemption money-out path in payout-processor.ts read the
+// notNull NUMERIC columns (eliza_amount, eliza_price_usd, usd_value) — returned by
+// the driver as STRINGS — via bare `Number()` / viem `parseUnits()`. A corrupt or
+// empty value coerced to NaN or 0n and silently:
+//   - authorized a payout against an unvalidatable quote (NaN > MAX === false), or
+//   - broadcast a ZERO-token transfer that was confirmed + marked `completed`
+//     with a real tx hash (fabricated success) while the user got nothing.
+// These tests pin the boundary parser and prove processRedemption refuses a
+// corrupt row (non-retryable) BEFORE any wallet/broadcast/DB interaction.
+import { describe, expect, it } from "vitest";
+import {
+  CorruptRedemptionAmountError,
+  PayoutProcessorService,
+  parseRedemptionAmount,
+} from "./payout-processor";
+
+describe("parseRedemptionAmount (fail-closed NUMERIC boundary)", () => {
+  it("parses a normal decimal string (driver returns NUMERIC as string)", () => {
+    expect(parseRedemptionAmount("eliza_amount", "123.45")).toBe(123.45);
+  });
+
+  it("parses a numeric input", () => {
+    expect(parseRedemptionAmount("eliza_price_usd", 0.0125)).toBe(0.0125);
+  });
+
+  it("allows an explicit domain zero (a legitimate zero-value field)", () => {
+    expect(parseRedemptionAmount("usd_value", "0")).toBe(0);
+    expect(parseRedemptionAmount("usd_value", 0)).toBe(0);
+  });
+
+  it("REGRESSION: 'NaN'::numeric read-back throws instead of returning NaN", () => {
+    // Postgres accepts 'NaN'::numeric; the driver hands it back as the string "NaN".
+    // Bare Number("NaN") === NaN previously flowed straight into the guards.
+    expect(() => parseRedemptionAmount("eliza_price_usd", "NaN")).toThrow(
+      CorruptRedemptionAmountError,
+    );
+  });
+
+  it("REGRESSION: empty string throws instead of coercing to 0 (parseUnits('')===0n)", () => {
+    expect(() => parseRedemptionAmount("eliza_amount", "")).toThrow(CorruptRedemptionAmountError);
+  });
+
+  it("throws on whitespace-only string", () => {
+    expect(() => parseRedemptionAmount("eliza_amount", "   ")).toThrow(
+      CorruptRedemptionAmountError,
+    );
+  });
+
+  it("throws on null / undefined (never returns NaN)", () => {
+    expect(() => parseRedemptionAmount("usd_value", null)).toThrow(CorruptRedemptionAmountError);
+    expect(() => parseRedemptionAmount("usd_value", undefined)).toThrow(
+      CorruptRedemptionAmountError,
+    );
+  });
+
+  it("throws on a non-numeric string and on Infinity", () => {
+    expect(() => parseRedemptionAmount("eliza_amount", "not-a-number")).toThrow(
+      CorruptRedemptionAmountError,
+    );
+    expect(() => parseRedemptionAmount("eliza_amount", Number.POSITIVE_INFINITY)).toThrow(
+      CorruptRedemptionAmountError,
+    );
+  });
+
+  it("names the offending field and value in the error", () => {
+    try {
+      parseRedemptionAmount("eliza_amount", "oops");
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CorruptRedemptionAmountError);
+      const err = e as CorruptRedemptionAmountError;
+      expect(err.field).toBe("eliza_amount");
+      expect(err.rawValue).toBe("oops");
+      expect(err.message).toContain("eliza_amount");
+    }
+  });
+});
+
+describe("PayoutProcessorService.processRedemption fail-closed seam", () => {
+  // No wallet env is set in the test process, so evmPrivateKey/solanaKeypair are
+  // null. That is deliberate: a corrupt row must be REFUSED in processRedemption
+  // BEFORE it ever reaches a network payout method, so these tests must not depend
+  // on a configured wallet or a live DB — a refusal that touched either would be a
+  // regression (the corruption should short-circuit at the top of the method).
+  const service = new PayoutProcessorService();
+  // processRedemption is private; call it through a typed view to test the seam.
+  const processRedemption = (
+    service as unknown as {
+      processRedemption: (redemption: Record<string, unknown>) => Promise<{
+        success: boolean;
+        error?: string;
+        retryable?: boolean;
+      }>;
+    }
+  ).processRedemption.bind(service);
+
+  const baseRedemption = () => ({
+    id: "red_test",
+    network: "base",
+    asset: "usdc",
+    payout_address: "0x0000000000000000000000000000000000000001",
+    eliza_amount: "10.0",
+    eliza_price_usd: "1.00",
+    usd_value: "10.0000",
+    // ENFORCE_PRICE_VALIDATION defaults to false, so no price-quote expiry check runs.
+    price_quote_expires_at: new Date(Date.now() + 60_000),
+  });
+
+  it("refuses (non-retryable) a corrupt eliza_amount before any broadcast", async () => {
+    const result = await processRedemption({ ...baseRedemption(), eliza_amount: "NaN" });
+    expect(result.success).toBe(false);
+    expect(result.retryable).toBe(false);
+    expect(result.error).toMatch(/redemption amount/i);
+  });
+
+  it("REGRESSION: refuses an empty eliza_amount instead of a zero-token success", async () => {
+    // Previously '' -> parseUnits('')===0n / Number('')*1e9===0 -> a zero-token
+    // transfer broadcast + marked completed with a real tx hash.
+    const result = await processRedemption({ ...baseRedemption(), eliza_amount: "" });
+    expect(result.success).toBe(false);
+    expect(result.retryable).toBe(false);
+    expect(result.error).toMatch(/redemption amount/i);
+  });
+
+  it("refuses a non-positive eliza_amount (would be a no-op transfer)", async () => {
+    const result = await processRedemption({ ...baseRedemption(), eliza_amount: "0" });
+    expect(result.success).toBe(false);
+    expect(result.retryable).toBe(false);
+    expect(result.error).toMatch(/non-positive redemption amount/i);
+  });
+
+  it("refuses a corrupt usd_value before broadcast (would poison the ledger)", async () => {
+    const result = await processRedemption({ ...baseRedemption(), usd_value: "NaN" });
+    expect(result.success).toBe(false);
+    expect(result.retryable).toBe(false);
+    expect(result.error).toMatch(/usd value/i);
+  });
+
+  it("does NOT over-reject a healthy row: valid amounts pass the numeric guards", async () => {
+    // With no wallet configured the EVM path returns "not configured"; the point
+    // is that a VALID row is NOT refused by the corrupt/non-positive guards, so
+    // the refusal reason must be the wallet boundary, not the numeric boundary.
+    const result = await processRedemption(baseRedemption());
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not configured/i);
+    expect(result.error).not.toMatch(/corrupt|non-positive/i);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/payout-processor.ts
+++ b/packages/cloud/shared/src/lib/services/payout-processor.ts
@@ -108,6 +108,59 @@ interface PayoutResult {
   retryable?: boolean;
 }
 
+/**
+ * Thrown when a `token_redemptions` NUMERIC money field (eliza_amount,
+ * eliza_price_usd, usd_value) reads back as a non-finite / unparseable value.
+ *
+ * These columns are Postgres `numeric(...)` and are returned by the driver as
+ * STRINGS. A corrupt/malformed value (`'NaN'::numeric` is a legal store, a
+ * truncated write, a bad manual edit) coerces to `NaN` under bare `Number()`,
+ * or to `0n` under `viem.parseUnits('')`. On a hot-wallet payout path that is
+ * catastrophic:
+ *   - `Number(eliza_price_usd)=NaN` makes the price-slippage guard
+ *     `slippage > MAX` evaluate `NaN > x === false` → the guard FAILS OPEN and
+ *     authorizes a payout against an unvalidatable quote.
+ *   - `parseUnits('', decimals)` returns `0n` and `Number('')*1e9 = 0` →
+ *     a ZERO-token transfer is broadcast, confirmed, and marked `completed`
+ *     with a real tx hash → fabricated success while the user receives nothing
+ *     and their pending balance is still debited.
+ *
+ * Parsing these values through {@link parseRedemptionAmount} converts that
+ * silent fail-open into an explicit, non-retryable failure that routes to
+ * manual review before anything is signed or broadcast.
+ */
+export class CorruptRedemptionAmountError extends Error {
+  constructor(
+    public readonly field: string,
+    public readonly rawValue: unknown,
+  ) {
+    super(`token_redemptions.${field} is not a finite number: ${JSON.stringify(rawValue)}`);
+    this.name = "CorruptRedemptionAmountError";
+  }
+}
+
+/**
+ * Fail-closed boundary for a `token_redemptions` NUMERIC money field.
+ *
+ * Accepts an explicit domain value of `0` (a legitimate zero-value field), but
+ * throws {@link CorruptRedemptionAmountError} for `null`/`undefined`, an empty
+ * or whitespace-only string, or anything that does not coerce to a finite
+ * number. NEVER returns `NaN` and NEVER silently substitutes `0`.
+ */
+export function parseRedemptionAmount(field: string, raw: unknown): number {
+  if (raw === null || raw === undefined) {
+    throw new CorruptRedemptionAmountError(field, raw);
+  }
+  if (typeof raw === "string" && raw.trim() === "") {
+    throw new CorruptRedemptionAmountError(field, raw);
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new CorruptRedemptionAmountError(field, raw);
+  }
+  return value;
+}
+
 interface ProcessingStats {
   processed: number;
   succeeded: number;
@@ -501,6 +554,65 @@ export class PayoutProcessorService {
     const config = getPayoutConfig();
     const network = redemption.network as SupportedNetwork;
 
+    // Fail closed on a corrupt NUMERIC payout amount BEFORE anything is signed or
+    // broadcast. A non-finite / empty `eliza_amount` otherwise coerces to a
+    // zero-token transfer (parseUnits('')===0n, Number('')*1e9===0) that is
+    // broadcast and marked `completed` with a real tx hash — fabricated success.
+    // A corrupt row is not transient, so this is non-retryable (→ manual review).
+    let payoutAmount: number;
+    try {
+      payoutAmount = parseRedemptionAmount("eliza_amount", redemption.eliza_amount);
+    } catch (error) {
+      logger.error("[PayoutProcessor] Corrupt eliza_amount; refusing payout", {
+        redemptionId: redemption.id,
+        network,
+        rawElizaAmount: redemption.eliza_amount,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        success: false,
+        error: "Corrupt redemption amount (requires review)",
+        retryable: false,
+      };
+    }
+    if (payoutAmount <= 0) {
+      // A zero/negative payout amount would broadcast a no-op transfer and mark
+      // the redemption completed — same fabricated-success class. Refuse it.
+      logger.error("[PayoutProcessor] Non-positive eliza_amount; refusing payout", {
+        redemptionId: redemption.id,
+        network,
+        elizaAmount: payoutAmount,
+      });
+      return {
+        success: false,
+        error: "Non-positive redemption amount (requires review)",
+        retryable: false,
+      };
+    }
+
+    // Fail closed on a corrupt `usd_value` BEFORE broadcast. markCompleted (which
+    // runs only AFTER a successful on-chain transfer) writes usd_value into the
+    // earnings ledger via `total_pending - usd_value` / `total_redeemed +
+    // usd_value` SQL and a `$${Number(usd_value).toFixed(2)}` description; a
+    // corrupt value would poison the ledger balances (`- 'NaN'`) or log `$NaN`.
+    // Catch it here so a corrupt row is reviewed, never broadcast then
+    // half-recorded post-broadcast (tokens sent, accounting corrupt).
+    try {
+      parseRedemptionAmount("usd_value", redemption.usd_value);
+    } catch (error) {
+      logger.error("[PayoutProcessor] Corrupt usd_value; refusing payout", {
+        redemptionId: redemption.id,
+        network,
+        rawUsdValue: redemption.usd_value,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        success: false,
+        error: "Corrupt redemption USD value (requires review)",
+        retryable: false,
+      };
+    }
+
     if (config.ENFORCE_PRICE_VALIDATION) {
       // Optional compatibility guard for fully automated payout deployments.
       if (new Date() > redemption.price_quote_expires_at) {
@@ -511,7 +623,42 @@ export class PayoutProcessorService {
         };
       }
 
-      const priceValidation = await this.validatePrice(network, Number(redemption.eliza_price_usd));
+      // Fail closed on a corrupt quoted price. A non-finite `eliza_price_usd`
+      // makes the slippage guard `NaN > MAX === false` → fail open, authorizing
+      // a payout against an unvalidatable quote. Refuse (non-retryable) instead.
+      let quotedPriceUsd: number;
+      try {
+        quotedPriceUsd = parseRedemptionAmount("eliza_price_usd", redemption.eliza_price_usd);
+      } catch (error) {
+        logger.error("[PayoutProcessor] Corrupt eliza_price_usd; refusing payout", {
+          redemptionId: redemption.id,
+          network,
+          rawElizaPriceUsd: redemption.eliza_price_usd,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+        return {
+          success: false,
+          error: "Corrupt quoted price (requires review)",
+          retryable: false,
+        };
+      }
+      if (quotedPriceUsd <= 0) {
+        // A zero quoted price makes slippage `|current-0|/0 === Infinity`, an
+        // accidental divide-by-zero-shaped rejection rather than an intentional
+        // policy signal. Refuse explicitly so the reason is a corrupt quote.
+        logger.error("[PayoutProcessor] Non-positive eliza_price_usd; refusing payout", {
+          redemptionId: redemption.id,
+          network,
+          quotedPriceUsd,
+        });
+        return {
+          success: false,
+          error: "Non-positive quoted price (requires review)",
+          retryable: false,
+        };
+      }
+
+      const priceValidation = await this.validatePrice(network, quotedPriceUsd);
       if (!priceValidation.valid) {
         return {
           success: false,
@@ -589,6 +736,12 @@ export class PayoutProcessorService {
     const tokenConfig = getPayoutTokenConfig(network, redemption.asset);
     const tokenAddress = tokenConfig.address as Address;
     const toAddress = redemption.payout_address as Address;
+    // Fail-closed parse: viem `parseUnits('', d) === 0n` would build a zero-token
+    // transfer that broadcasts + marks completed with a real tx hash (fabricated
+    // success). processRedemption already gates this, but re-validate here so a
+    // direct call can never silently pay out nothing; parseUnits then does the
+    // precise decimal-string conversion from the (now known-finite) value.
+    parseRedemptionAmount("eliza_amount", redemption.eliza_amount);
     const amount = parseUnits(redemption.eliza_amount.toString(), tokenConfig.decimals);
 
     const account = privateKeyToAccount(this.evmPrivateKey);
@@ -714,7 +867,15 @@ export class PayoutProcessorService {
     const tokenConfig = getPayoutTokenConfig("solana", redemption.asset);
     const mintAddress = new PublicKey(tokenConfig.address);
     const toAddress = new PublicKey(redemption.payout_address);
-    const amount = BigInt(Math.floor(Number(redemption.eliza_amount) * 10 ** tokenConfig.decimals));
+    // Fail-closed parse: bare Number('') === 0 would build a zero-token transfer
+    // that broadcasts + marks completed with a real signature (fabricated
+    // success). processRedemption already gates this, but re-validate here so a
+    // direct call can never silently pay out nothing.
+    const amount = BigInt(
+      Math.floor(
+        parseRedemptionAmount("eliza_amount", redemption.eliza_amount) * 10 ** tokenConfig.decimals,
+      ),
+    );
 
     // Get source token account (hot wallet's ATA)
     const sourceAta = await getAssociatedTokenAddress(mintAddress, this.solanaKeypair.publicKey);
@@ -850,7 +1011,9 @@ export class PayoutProcessorService {
   ): Promise<void> {
     const completedAt = new Date();
     const usdValue = redemption.usd_value.toString();
-    const usdNumber = Number(redemption.usd_value);
+    // Proven finite pre-broadcast in processRedemption; parse fail-closed here
+    // too so a direct call can never write a $NaN ledger description.
+    const usdNumber = parseRedemptionAmount("usd_value", redemption.usd_value);
 
     await dbWrite.transaction(async (tx) => {
       await tx

--- a/packages/cloud/shared/src/lib/services/payout-processor.ts
+++ b/packages/cloud/shared/src/lib/services/payout-processor.ts
@@ -1219,10 +1219,25 @@ export class PayoutProcessorService {
         .limit(1);
       if (existingRefund) return;
 
+      let refundAmount: number;
+      try {
+        refundAmount = parseRedemptionAmount("usd_value", row.usdValue);
+      } catch (error) {
+        logger.error(
+          "[PayoutProcessor] Corrupt usd_value on failed redemption; skipping automatic refund",
+          {
+            redemptionId,
+            rawUsdValue: row.usdValue,
+            reason: error instanceof Error ? error.message : String(error),
+          },
+        );
+        return;
+      }
+
       await redeemableEarningsService.refundRedemption({
         userId: row.userId,
         redemptionId,
-        amount: Number(row.usdValue),
+        amount: refundAmount,
         reason,
       });
 


### PR DESCRIPTION
## Issue
Slice of #13415 (cloud-shared service-layer fallback-slop sweep). Target file: `packages/cloud/shared/src/lib/services/payout-processor.ts` — flagged in-file as a "🚨 CRITICAL SECURITY COMPONENT 🚨" (hot-wallet token payouts).

Distinct from the concurrent sibling #13415 lane (which owns `agent-budgets.ts` only) and from every merged #13416 DB-repository slice.

## Bug
The approved-redemption payout path read three `notNull` Postgres `numeric(...)` columns on `token_redemptions` — returned by the driver as **strings** — via bare `Number()` / viem `parseUnits()` with **no fail-closed boundary**:

- `Number(eliza_price_usd)=NaN` made the slippage guard `NaN > MAX === false` → the price guard **FAILS OPEN**, authorizing a payout against an unvalidatable quote.
- `parseUnits('', d) === 0n` and `Number('')*1e9 === 0` built a **zero-token transfer** that was broadcast, confirmed, and marked `completed` with a real tx hash → **fabricated success** (user gets nothing, pending balance still debited). `Number('NaN')*1e9` → `BigInt(NaN)` raw `RangeError`.
- A corrupt `usd_value` poisoned the earnings ledger (`total_pending - 'NaN'`) or logged `$NaN`.

`viem.parseUnits('', 9) === 0n` and `Number('') === 0` verified empirically; `'NaN'::numeric` is a legal Postgres store returned as `"NaN"`.

## Fix
New colocated, exported, pure fail-closed boundary `parseRedemptionAmount(field, raw)` (+ `CorruptRedemptionAmountError`) — throws on `null`/`undefined`/empty/whitespace/non-finite, allows an explicit domain `0`, **never returns `NaN` and never silently substitutes `0`** (mirrors merged #13474 / #13454 numeric parsers).

Wired so a corrupt row is refused **before anything is signed or broadcast**, as a non-retryable `{success:false}` `PayoutResult` routed to manual review (a corrupt row is not transient):
- `processRedemption` top: parse `eliza_amount` (+ reject `<= 0` no-op transfers) and `usd_value` (gated pre-broadcast so `markCompleted` never writes `$NaN`/`- 'NaN'` post-broadcast); parse `eliza_price_usd` (+ reject `<= 0`) when `ENFORCE_PRICE_VALIDATION` is on.
- `executeSolanaPayout` / `executeEvmPayout` amount reads re-validate through the same parser (defense-in-depth: a direct call can't build a zero-token transfer either).

Distinct/not-found/unavailable stays distinct from corruption (a positive-control test proves a healthy row passes the numeric guards and only hits the wallet boundary). No `console.*` introduced; structured `logger.error` on every refusal.

## Tests
`payout-processor.numeric-fail-closed.test.ts` — `bun test --isolate` (the package's primary runner): **14/14 pass, 30 expect() calls**.
- 9 parser units: normal decimal string, numeric input, explicit `0`, `'NaN'` regression, `''` regression (`parseUnits('')===0n`), whitespace, `null`/`undefined`, non-numeric + `Infinity`, error names field+value.
- 5 seam tests through `PayoutProcessorService.processRedemption` (no wallet/DB): corrupt `eliza_amount` → non-retryable refuse; empty-amount regression → refuse (not zero-token success); non-positive amount → refuse; corrupt `usd_value` → refuse; **positive control** → healthy row not over-rejected.

## Gates
- `bun test --isolate` → **14/14**.
- `bunx @biomejs/biome check` (touched files) → **clean**.
- `bun run audit:error-policy-ratchet` → **`payout-processor.ts: emptyCatch 0->0, serverConsole 0->0` — no new fallback-slop**.
- `bun run --cwd packages/cloud/shared typecheck` → **17 pre-existing baseline errors** in unrelated files (`app-core/@elizaos/auth/*` symlink drift, `node-redis-adapter.ts`, `plugin-mcp/utils/json.ts`, `anthropic-web-search.ts`), **0 in touched files** (matches prior merged cloud-shared slices).

Forbidden files (`vite.config.*`, root `index.html`, `client-base.ts`, `bun.lock`, binaries, `dist/`) untouched. Issue stays open for the remaining service-layer inventory. Evidence: `.github/issue-evidence/13415-cloud-shared-services-payout-processor-fallback.md`.

— [sol-orch]