### PR TITLE
fix(#13452): keep settings on opaque background

### DIFF
--- a/.github/issue-evidence/13452-settings-opaque-background.md
+++ b/.github/issue-evidence/13452-settings-opaque-background.md
@@ -1,0 +1,64 @@
+# #13452 Settings opaque background slice
+
+## Scope
+
+Changed the builtin tab background policy so Settings no longer opts into the
+shared launcher wallpaper. This is a narrow slice of #13452 that prevents the
+documented Settings view leak while leaving the broader view-isolation manifest
+work open.
+
+## Local verification
+
+Command:
+
+```bash
+bunx @biomejs/biome check --write packages/ui/src/builtin-tab-registry.ts packages/ui/src/builtin-tab-registry.test.ts packages/ui/src/App.screen-background-fuzz.test.tsx
+```
+
+Result: passed; Biome formatted the touched files.
+
+Command:
+
+```bash
+bunx @biomejs/biome check packages/ui/src/builtin-tab-registry.ts packages/ui/src/builtin-tab-registry.test.ts packages/ui/src/App.screen-background-fuzz.test.tsx
+```
+
+Result: passed.
+
+Command:
+
+```bash
+bun -e 'import { resolveBuiltinBackgroundPolicy } from "./packages/ui/src/builtin-tab-registry.ts"; console.log(JSON.stringify({ chat: resolveBuiltinBackgroundPolicy("chat", "/chat"), settings: resolveBuiltinBackgroundPolicy("settings", "/settings"), views: resolveBuiltinBackgroundPolicy("views", "/views") }));'
+```
+
+Result:
+
+```json
+{"chat":"shared","settings":null,"views":"shared"}
+```
+
+## Blocked verification
+
+Command:
+
+```bash
+bun run --cwd packages/ui test src/builtin-tab-registry.test.ts src/App.screen-background-fuzz.test.tsx
+```
+
+Result: blocked before test execution because the temp worktree dependency tree
+cannot resolve `react/package.json` while loading `packages/ui/vitest.config.ts`.
+
+The local host also only has CommandLineTools selected and lacks an available
+iOS simulator SDK, so iOS simulator screenshots, screen recording, and
+installed-app capture could not be produced locally for this slice.
+
+## Evidence not applicable for this slice
+
+Real-LLM trajectories: N/A - this changes shell background routing only; no
+agent/action/provider/prompt/model behavior changed.
+
+Backend logs: N/A - no backend code path changed.
+
+Domain artifacts: N/A - no persisted memories, scheduled tasks, database rows,
+files, or on-chain/device artifacts are produced by this background policy
+change.

--- a/packages/ui/src/App.screen-background-fuzz.test.tsx
+++ b/packages/ui/src/App.screen-background-fuzz.test.tsx
@@ -23,9 +23,11 @@
  *      the screen color is always defined; never blank, never two conflicting layers.
  *   B. When the wallpaper shows, its color === the seeded persisted color —
  *      switching views never mutates the user's background color.
- *   C. The known-shared surfaces (chat, background, settings, /views,
- *      /apps) always show the wallpaper — never the opaque underlay.
- *   D. Returning to the launcher (`/views`) always restores the wallpaper,
+ *   C. The known-shared surfaces (chat, background, /views, /apps) always
+ *      show the wallpaper — never the opaque underlay.
+ *   D. Settings always uses the opaque app surface — never the shared launcher
+ *      wallpaper.
+ *   E. Returning to the launcher (`/views`) always restores the wallpaper,
  *      regardless of which (possibly opaque) view preceded it.
  *
  * Runs the whole fuzz under shader, image, and programmable GLSL configs so
@@ -453,10 +455,12 @@ const LAUNCHER = { tab: "views" as BuiltinTab, path: "/views" };
 const ALWAYS_SHARED = new Set([
   "chat@/chat",
   "background@/background",
-  "settings@/settings",
   "views@/views",
   "apps@/apps",
 ]);
+
+// Routes that must be isolated from the launcher wallpaper/global background.
+const MUST_BE_OPAQUE = new Set(["settings@/settings"]);
 
 // Deterministic PRNG (mulberry32) so the fuzz is reproducible — no Math.random.
 function makeRng(seed: number): () => number {
@@ -677,6 +681,13 @@ describe("App screen-background fuzz — color invariant across view switching",
           `${label} ${key}: known-shared route shows wallpaper`,
         ).toBe(expectedWallpaperKind());
       }
+      if (MUST_BE_OPAQUE.has(key)) {
+        // Invariant D: isolated app surfaces must not leak the launcher wallpaper.
+        expect(
+          layer.kind,
+          `${label} ${key}: route uses opaque app surface`,
+        ).toBe("opaque");
+      }
       // Invariant B everywhere a wallpaper shows: color is preserved.
       if (layer.kind === "shader" || layer.kind === "glsl") {
         expect(
@@ -685,7 +696,7 @@ describe("App screen-background fuzz — color invariant across view switching",
         ).toBe(expectedRgb(bgState.config.color));
       }
 
-      // Invariant D: bounce back to the launcher — wallpaper always restored.
+      // Invariant E: bounce back to the launcher — wallpaper always restored.
       await navigate(rerender, LAUNCHER.tab, LAUNCHER.path);
       assertWallpaper(`after ${entry.tab} → launcher`);
     }

--- a/packages/ui/src/builtin-tab-registry.test.ts
+++ b/packages/ui/src/builtin-tab-registry.test.ts
@@ -61,9 +61,8 @@ describe("resolveBuiltinTabId: alias resolution", () => {
 });
 
 describe("resolveBuiltinBackgroundPolicy: legacy parity", () => {
-  // Golden table mirroring the pre-refactor builtinRouteBackgroundPolicy chain:
+  // Golden table covering the builtinRouteBackgroundPolicy table:
   //   chat / background       -> "shared"
-  //   settings                -> "shared"
   //   views  && path==/views  -> "shared"
   //   apps   && path==/apps   -> "shared"
   //   otherwise               -> null (fall through to downstream resolution)
@@ -71,7 +70,6 @@ describe("resolveBuiltinBackgroundPolicy: legacy parity", () => {
     ["chat", "/chat", "shared"],
     ["chat", "/anything", "shared"],
     ["background", "/background", "shared"],
-    ["settings", "/settings", "shared"],
   ] as const)("%s @ %s -> %s (unconditional shared)", (tab, path, expected) => {
     expect(resolveBuiltinBackgroundPolicy(tab, path)).toBe(expected);
   });
@@ -88,6 +86,7 @@ describe("resolveBuiltinBackgroundPolicy: legacy parity", () => {
 
   it.each([
     ["voice", "/voice"],
+    ["settings", "/settings"],
     ["files", "/apps/files"],
     ["memories", "/apps/memories"],
     ["some-plugin-tab", "/plugin"],

--- a/packages/ui/src/builtin-tab-registry.ts
+++ b/packages/ui/src/builtin-tab-registry.ts
@@ -75,7 +75,6 @@ export const BUILTIN_TAB_METADATA: readonly BuiltinTabMetadata[] = [
   // ── Background policy: unconditionally "shared" (wallpaper shows through) ──
   { id: "chat", backgroundPolicy: "shared" },
   { id: "background", backgroundPolicy: "shared" },
-  { id: "settings", backgroundPolicy: "shared" },
   // ── Background policy: "shared" only at the tab's launcher root ──
   {
     id: "views",


### PR DESCRIPTION
## Summary
- remove Settings from the builtin shared-wallpaper route table so it falls through to the opaque app surface
- update the registry unit expectations so `settings@/settings` has no builtin shared policy
- tighten the mounted App screen-background fuzz test with a `MUST_BE_OPAQUE` guard for Settings
- add issue evidence documenting local verification and capture blockers

Advances #13452. This is intentionally a narrow Settings leak slice, not the full view-isolation manifest architecture.

## Verification
- `bunx @biomejs/biome check --write packages/ui/src/builtin-tab-registry.ts packages/ui/src/builtin-tab-registry.test.ts packages/ui/src/App.screen-background-fuzz.test.tsx`
- `bunx @biomejs/biome check packages/ui/src/builtin-tab-registry.ts packages/ui/src/builtin-tab-registry.test.ts packages/ui/src/App.screen-background-fuzz.test.tsx`
- `bun -e 'import { resolveBuiltinBackgroundPolicy } from "./packages/ui/src/builtin-tab-registry.ts"; console.log(JSON.stringify({ chat: resolveBuiltinBackgroundPolicy("chat", "/chat"), settings: resolveBuiltinBackgroundPolicy("settings", "/settings"), views: resolveBuiltinBackgroundPolicy("views", "/views") }));'` -> `{"chat":"shared","settings":null,"views":"shared"}`\n\n## Blocked locally\n- `bun run --cwd packages/ui test src/builtin-tab-registry.test.ts src/App.screen-background-fuzz.test.tsx` cannot start in this temp worktree because Vitest cannot resolve `react/package.json` while loading `packages/ui/vitest.config.ts`.\n- iOS simulator screenshots/screen recording/installed-app capture are blocked on this host because only CommandLineTools are selected and no iOS simulator SDK is available.\n\n## Evidence\n- `.github/issue-evidence/13452-settings-opaque-background.md`\n\n## PR evidence checklist\n- Real-LLM trajectories: N/A - shell background routing only; no agent/action/provider/prompt/model behavior changed.\n- Backend logs: N/A - no backend code path changed.\n- Frontend screenshots/video: blocked locally as noted above; draft PR remains open for reviewer/CI-host visual capture.\n- Domain artifacts: N/A - no persisted/domain artifacts are produced by this policy change.