### PR TITLE
fix(#13451): use shared settings section header

### DIFF
--- a/.github/issue-evidence/13451-settings-shared-header.md
+++ b/.github/issue-evidence/13451-settings-shared-header.md
@@ -1,0 +1,62 @@
+# #13451 Settings shared-header slice
+
+## Scope
+
+Changed the mobile/narrow Settings section detail view to use the shared
+`ViewHeader` contract instead of the section-local text back button. Also made
+the shared view back button backgroundless at rest so normal-view headers use an
+icon-only affordance.
+
+This is a narrow Settings slice for #13451. Browser, Wallet, Launcher subviews,
+and the full shell-owned header contract remain broader follow-up work.
+
+## Local verification
+
+Command:
+
+```bash
+bunx @biomejs/biome check --write packages/ui/src/components/shared/ViewHeader.tsx packages/ui/src/components/pages/SettingsView.tsx packages/ui/src/components/pages/SettingsView.test.tsx
+```
+
+Result: passed; Biome formatted the touched files.
+
+Command:
+
+```bash
+bunx @biomejs/biome check packages/ui/src/components/shared/ViewHeader.tsx packages/ui/src/components/pages/SettingsView.tsx packages/ui/src/components/pages/SettingsView.test.tsx
+```
+
+Result: passed.
+
+## Test coverage added
+
+`packages/ui/src/components/pages/SettingsView.test.tsx` now asserts that a
+selected Settings section renders the shared `view-header`, that its title is
+centered under the shared header contract, that the back control is accessible
+as `Back to Settings`, that the button is icon-only, and that its resting class
+uses `bg-transparent` instead of a filled `bg-bg` chip.
+
+## Blocked verification
+
+Command:
+
+```bash
+bun run --cwd packages/ui test src/components/pages/SettingsView.test.tsx
+```
+
+Result: blocked before test execution because the temp worktree dependency tree
+cannot resolve `react/package.json` while loading `packages/ui/vitest.config.ts`.
+
+The local host also only has CommandLineTools selected and lacks an available
+iOS simulator SDK, so iOS simulator screenshots, screen recording, and
+installed-app capture could not be produced locally for this UI slice.
+
+## Evidence not applicable for this slice
+
+Real-LLM trajectories: N/A - this changes UI header rendering only; no
+agent/action/provider/prompt/model behavior changed.
+
+Backend logs: N/A - no backend code path changed.
+
+Domain artifacts: N/A - no persisted memories, scheduled tasks, database rows,
+files, or on-chain/device artifacts are produced by this header change.

--- a/packages/ui/src/components/pages/SettingsView.test.tsx
+++ b/packages/ui/src/components/pages/SettingsView.test.tsx
@@ -12,6 +12,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { Settings } from "lucide-react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -162,10 +163,20 @@ describe("SettingsView", () => {
 
     fireEvent.click(runtimeTile);
 
-    // The section body is now mounted, and a back affordance is present.
+    // The section body is now mounted, and the shared view header owns the
+    // icon-only back affordance back to the settings hub.
     expect(screen.getByTestId("stub-runtime")).toBeTruthy();
     expect(screen.queryByTestId("stub-identity")).toBeNull();
-    expect(screen.getByText("Settings")).toBeTruthy();
+    const header = screen.getByTestId("view-header");
+    expect(
+      within(header).getByRole("heading", { name: "Settings" }),
+    ).toBeTruthy();
+    const back = within(header).getByRole("button", {
+      name: "Back to Settings",
+    });
+    expect(back.textContent).toBe("");
+    expect(back.classList.contains("bg-transparent")).toBe(true);
+    expect(back.classList.contains("bg-bg")).toBe(false);
   });
 
   it("respects an initialSection prop by opening that section directly", () => {
@@ -178,9 +189,8 @@ describe("SettingsView", () => {
   it("back affordance returns to the hub", () => {
     render(<SettingsView initialSection="runtime" />);
 
-    const back = screen.getByText("Settings").closest("button");
-    expect(back).toBeTruthy();
-    fireEvent.click(back as HTMLButtonElement);
+    const back = screen.getByRole("button", { name: "Back to Settings" });
+    fireEvent.click(back);
 
     // Both tiles are visible again and no section body is mounted.
     expect(screen.getByText("Basics")).toBeTruthy();
@@ -200,7 +210,11 @@ describe("SettingsView", () => {
       // per-section fallback renders and the nav back-affordance stays usable.
       expect(screen.getByTestId("settings-section-error")).toBeTruthy();
       expect(screen.queryByTestId("stub-crash")).toBeNull();
-      expect(screen.getByText("Settings")).toBeTruthy();
+      expect(
+        within(screen.getByTestId("view-header")).getByRole("button", {
+          name: "Back to Settings",
+        }),
+      ).toBeTruthy();
     } finally {
       consoleError.mockRestore();
     }

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -6,7 +6,6 @@
  * modal form (`inModal`).
  */
 import { isViewVisible } from "@elizaos/core";
-import { ArrowLeft } from "lucide-react";
 import type * as React from "react";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
@@ -189,29 +188,6 @@ function SettingsNavItem({
   );
 }
 
-function SectionBackButton({ onBack }: { onBack: () => void }) {
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: "section-back",
-    role: "button",
-    label: "Back to Settings",
-    description: "Return to the settings hub",
-    onActivate: onBack,
-  });
-  return (
-    <Button
-      ref={ref}
-      variant="ghost"
-      size="sm"
-      onClick={onBack}
-      className="h-9 gap-1.5 rounded-md px-2 text-xs font-medium text-muted transition-colors hover:bg-surface hover:text-accent"
-      {...agentProps}
-    >
-      <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
-      Settings
-    </Button>
-  );
-}
-
 /**
  * Loading placeholder for a lazily-loaded section body (#11351). Deliberately
  * minimal — a single muted, `aria-busy` line so the split is visually quiet and
@@ -226,7 +202,7 @@ function SettingsSectionLoading() {
   );
 }
 
-/** The active section's body: optional back, header (icon + title), content. */
+/** The active section's body: optional Settings header, section title, content. */
 function SettingsSectionContent({
   section,
   t,
@@ -249,9 +225,12 @@ function SettingsSectionContent({
       )}
     >
       {onBack ? (
-        <div className="mb-1.5">
-          <SectionBackButton onBack={onBack} />
-        </div>
+        <ViewHeader
+          title={t("nav.settings", { defaultValue: "Settings" })}
+          onBack={onBack}
+          backLabel="Back to Settings"
+          className="-mx-3 mb-1.5 sm:-mx-4"
+        />
       ) : null}
       <div className="mb-5 flex items-center gap-2.5">
         <Icon className="h-5 w-5 shrink-0 text-muted/80" aria-hidden />

--- a/packages/ui/src/components/shared/ViewHeader.tsx
+++ b/packages/ui/src/components/shared/ViewHeader.tsx
@@ -35,10 +35,7 @@ export function navigateBackToLauncher(): void {
 
 /**
  * The shared view back button: an icon, nothing else. Deliberately chromeless —
- * no border, no shadow, and a `bg-bg` fill so it reads as the neutral view
- * surface (white in light mode, dark in dark mode), never the accent/orange
- * chip it used to be. On an opaque view the fill is invisible (looks like a
- * bare icon); on a shared-background view it's a subtle neutral chip.
+ * no border, no fill, no shadow, and never the accent/orange chip it used to be.
  */
 export function ViewBackButton({
   onBack,
@@ -64,7 +61,7 @@ export function ViewBackButton({
       onClick={handleBack}
       aria-label={label}
       className={cn(
-        "inline-flex h-9 w-9 items-center justify-center rounded-full bg-bg text-txt transition-colors hover:bg-bg-hover",
+        "inline-flex h-9 w-9 items-center justify-center rounded-full bg-transparent text-txt transition-colors hover:bg-bg-hover",
         className,
       )}
       {...agentProps}
@@ -77,15 +74,15 @@ export function ViewBackButton({
 /**
  * Standard view header: a chromeless back button and a title on one line.
  *
- * Mobile centers the title with the back button overlaid on the left (the
- * iOS-style nav bar the redesign asks for); ≥sm left-aligns the title after the
- * back button. A sub-view renders its OWN `ViewHeader`, which REPLACES this one
- * rather than stacking beneath it — callers swap the header for the active
- * section, they do not nest two.
+ * The title stays centered with the back button in the left slot (the iOS-style
+ * nav bar the redesign asks for). A sub-view renders its OWN `ViewHeader`,
+ * which REPLACES this one rather than stacking beneath it — callers swap the
+ * header for the active section, they do not nest two.
  */
 export function ViewHeader({
   title,
   onBack,
+  backLabel,
   showBack = true,
   right,
   className,
@@ -93,6 +90,8 @@ export function ViewHeader({
   title: ReactNode;
   /** Override the default (launcher) back target — e.g. a sub-view returning to its hub. */
   onBack?: () => void;
+  /** Accessible label for the back control when `onBack` points somewhere custom. */
+  backLabel?: string;
   /** Hide the back control entirely (a view with no meaningful "back"). */
   showBack?: boolean;
   /** Optional trailing controls (actions, filters). */
@@ -110,12 +109,16 @@ export function ViewHeader({
     <header
       data-testid="view-header"
       className={cn(
-        "grid min-h-14 shrink-0 grid-cols-[2.75rem_minmax(0,1fr)_2.75rem] items-center gap-1 px-3 py-2.5 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:gap-2 sm:px-4",
+        "grid min-h-14 shrink-0 grid-cols-[2.75rem_minmax(0,1fr)_2.75rem] items-center gap-1 px-3 py-2.5 sm:gap-2 sm:px-4",
         className,
       )}
     >
-      {showBack ? <ViewBackButton onBack={onBack} /> : <span aria-hidden />}
-      <h1 className="justify-self-center truncate text-lg font-semibold tracking-tight text-txt-strong sm:justify-self-start">
+      {showBack ? (
+        <ViewBackButton label={backLabel} onBack={onBack} />
+      ) : (
+        <span aria-hidden />
+      )}
+      <h1 className="justify-self-center truncate text-lg font-semibold tracking-tight text-txt-strong">
         {title}
       </h1>
       {right ? (


### PR DESCRIPTION
## Summary
- replace the Settings section-local text back button with the shared `ViewHeader`
- add a `backLabel` prop so subviews can keep accessible custom back labels while reusing the shared header
- make the shared view back button backgroundless at rest and keep `ViewHeader` titles centered across breakpoints
- update `SettingsView.test.tsx` to assert the section header uses `view-header`, exposes `Back to Settings`, and renders an icon-only transparent back control
- add issue evidence documenting local verification and blocked capture

Advances #13451. This is a focused Settings subview/header slice; Browser, Wallet, Launcher subviews, and the full shell-owned header contract remain broader follow-up work.

## Verification
- `bunx @biomejs/biome check --write packages/ui/src/components/shared/ViewHeader.tsx packages/ui/src/components/pages/SettingsView.tsx packages/ui/src/components/pages/SettingsView.test.tsx`
- `bunx @biomejs/biome check packages/ui/src/components/shared/ViewHeader.tsx packages/ui/src/components/pages/SettingsView.tsx packages/ui/src/components/pages/SettingsView.test.tsx`

## Blocked locally
- `bun run --cwd packages/ui test src/components/pages/SettingsView.test.tsx` cannot start in this temp worktree because Vitest cannot resolve `react/package.json` while loading `packages/ui/vitest.config.ts`.
- iOS simulator screenshots/screen recording/installed-app capture are blocked on this host because only CommandLineTools are selected and no iOS simulator SDK is available.

## Evidence
- `.github/issue-evidence/13451-settings-shared-header.md`

## PR evidence checklist
- Real-LLM trajectories: N/A - UI header rendering only; no agent/action/provider/prompt/model behavior changed.
- Backend logs: N/A - no backend code path changed.
- Frontend screenshots/video: blocked locally as noted above; draft PR remains open for visual capture on a properly provisioned machine.
- Domain artifacts: N/A - no persisted/domain artifacts are produced by this UI header change.