### PR TITLE
fix(ui): reclaim dead bottom bar — anchor composer to gesture inset + paint reclaimed floor

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -3612,17 +3612,41 @@ export function ContinuousChatOverlay({
         // Full-bleed fills the screen edge-to-edge: NO overlay bottom padding,
         // so the glass panel reaches the true bottom (no orange gap). The
         // gesture-zone clearance moves INSIDE the composer row (below) so the
-        // input still sits above the home-gesture bar. Non-full-bleed keeps the
-        // chat lifted off the gesture zone as before.
+        // input still sits above the home-gesture bar. Non-full-bleed anchors the
+        // composer down: it clears the home-gesture inset (max safe-area /
+        // android inset) and nothing more, so it sits low with no dead gap
+        // beneath. The floor layer below paints that inset zone with the home
+        // surface so it reads continuous, not as a black bar.
         paddingBottom: fullBleed
           ? 0
           : keyboardLiftActive
             ? "0.75rem"
-            : "calc(var(--eliza-mobile-nav-offset, 0px) + max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) + 0.25rem)",
+            : "calc(var(--eliza-mobile-nav-offset, 0px) + max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)))",
       }}
       data-testid="continuous-chat-overlay"
       data-open={sheetOpen ? "true" : undefined}
     >
+      {/* RECLAIMED BOTTOM FLOOR: the composer is lifted off the home-gesture
+          inset, so the strip between the composer and the true screen bottom
+          used to be an unpainted, transparent zone that read as a DEAD BLACK
+          BAR under the composer. This layer fills the reclaimed zone (and a
+          hair above, so it seats behind the composer with no seam) with the
+          same warm home-surface tone (--launch-bg). Purely cosmetic
+          (pointer-events-none, aria-hidden), back of the overlay stack, only
+          needed at rest. Soft top fade blends it into the field. */}
+      {!fullBleed && !keyboardLiftActive ? (
+        <div
+          aria-hidden="true"
+          data-testid="continuous-chat-bottom-floor"
+          className="pointer-events-none absolute inset-x-0 bottom-0 z-0"
+          style={{
+            height:
+              "calc(max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) + 1.5rem)",
+            backgroundImage:
+              "linear-gradient(to bottom, transparent 0%, var(--launch-bg) 55%)",
+          }}
+        />
+      ) : null}
       {/* Visual dimming scrim behind the open chat. It fades in WITH the reveal
           but never captures pointer events; outside taps are handled by the
           document-level detector above, and outside drags pass through to the


### PR DESCRIPTION
## Symptom

On devices with a home-indicator safe area (iOS notably, Android gesture nav), the non-full-bleed continuous-chat composer showed a **dead black band** between the composer and the true screen bottom. The overlay is anchored by the `visualViewport`-derived `bottom`, and the composer carried an extra `+ 0.25rem` of rest padding on top of the home-gesture inset clearance, so the strip below it was an unpainted, transparent zone that read as a black bar under the input.

## Fix

Two changes, both **at rest only** (full-bleed and keyboard-lift paths are untouched):

1. **Drop the trailing `+ 0.25rem`** from the composer's non-full-bleed `paddingBottom`, so it anchors flush to the home-gesture inset (`max(safe-area-bottom, android-gesture-inset-bottom)`) and nothing more.
2. **Paint the reclaimed strip** with a `continuous-chat-bottom-floor` layer — a `pointer-events-none`, `aria-hidden` div at the back of the overlay stack that fills the inset zone (plus `1.5rem` so it seats behind the composer with no seam) with the warm home-surface tone (`--launch-bg`), soft top fade blending it into the field.

The zone now reads continuous with the home surface instead of a black band.

## Scope / safety

- Purely cosmetic. No layout, keyboard, or gesture behavior change.
- Full-bleed (maximized) and keyboard-lift branches are guarded out (`!fullBleed && !keyboardLiftActive`), so nothing changes there.

## Verification

- On-device (iOS home-indicator): the black band under the composer is gone; the reclaimed inset reads as the warm launcher floor.
- `ContinuousChatOverlay` suite green (154 tests).

[sol-orch]