### PR TITLE
fix(#13451): standardize normal-view headers on the shared ViewHeader

### DIFF
--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -6,7 +6,6 @@
  * modal form (`inModal`).
  */
 import { isViewVisible } from "@elizaos/core";
-import { ArrowLeft } from "lucide-react";
 import type * as React from "react";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
@@ -189,29 +188,6 @@ function SettingsNavItem({
   );
 }
 
-function SectionBackButton({ onBack }: { onBack: () => void }) {
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: "section-back",
-    role: "button",
-    label: "Back to Settings",
-    description: "Return to the settings hub",
-    onActivate: onBack,
-  });
-  return (
-    <Button
-      ref={ref}
-      variant="ghost"
-      size="sm"
-      onClick={onBack}
-      className="h-9 gap-1.5 rounded-md px-2 text-xs font-medium text-muted transition-colors hover:bg-surface hover:text-accent"
-      {...agentProps}
-    >
-      <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
-      Settings
-    </Button>
-  );
-}
-
 /**
  * Loading placeholder for a lazily-loaded section body (#11351). Deliberately
  * minimal — a single muted, `aria-busy` line so the split is visually quiet and
@@ -249,16 +225,27 @@ function SettingsSectionContent({
       )}
     >
       {onBack ? (
-        <div className="mb-1.5">
-          <SectionBackButton onBack={onBack} />
+        /* Section → hub back uses the shared normal-view header (#13451):
+           icon-only, left-aligned back arrow with a centered section title,
+           replacing the old section-local text "Settings" button + separate
+           icon heading. The shell already owns horizontal padding, so the
+           header is flush with the section body. */
+        <ViewHeader
+          title={title}
+          onBack={onBack}
+          backLabel="Back to Settings"
+          className="mb-5 px-0"
+        />
+      ) : (
+        /* Desktop detail pane: the rail owns navigation, so there is no header
+           back control — keep the icon + title heading for the selected pane. */
+        <div className="mb-5 flex items-center gap-2.5">
+          <Icon className="h-5 w-5 shrink-0 text-muted/80" aria-hidden />
+          <h1 className="text-lg font-semibold tracking-tight text-txt-strong">
+            {title}
+          </h1>
         </div>
-      ) : null}
-      <div className="mb-5 flex items-center gap-2.5">
-        <Icon className="h-5 w-5 shrink-0 text-muted/80" aria-hidden />
-        <h1 className="text-lg font-semibold tracking-tight text-txt-strong">
-          {title}
-        </h1>
-      </div>
+      )}
       {/* Flat — no card/border. The shell owns the page's horizontal padding. */}
       <div className={section.bodyClassName}>
         <ErrorBoundary
@@ -343,7 +330,7 @@ function MobileHub({
       {/* Top-level view header: centered "Settings" title with a launcher back
           arrow on mobile (iOS-style nav bar). Only the single-column hub renders
           it — the desktop split already owns its own "Settings" H1 in the rail,
-          and the per-section view keeps its own SectionBackButton (section→hub). */}
+          and the per-section view keeps its own shared ViewHeader (section→hub). */}
       <ViewHeader
         title={t("nav.settings", { defaultValue: "Settings" })}
         className="mb-2"

--- a/packages/ui/src/components/shared/ViewHeader.test.tsx
+++ b/packages/ui/src/components/shared/ViewHeader.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+/**
+ * Pins the shared normal-view header contract (#13451): every normal built-in
+ * view renders through this primitive, so its geometry is the single source of
+ * truth for the standardized header.
+ *
+ * Acceptance criteria asserted here:
+ *  - Header back affordance is icon-only, left-aligned, and has NO
+ *    border/background in the rest state (only a hover/focus chip).
+ *  - The view title is centered in the header.
+ *  - `showBack={false}` opts a view out of the back control cleanly.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../agent-surface", () => ({
+  useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
+}));
+
+const goLauncherMock = vi.hoisted(() => vi.fn());
+vi.mock("../../state/shell-surface-store", () => ({
+  goLauncher: goLauncherMock,
+}));
+
+vi.mock("../../navigation", () => ({
+  shouldUseHashNavigation: () => true,
+}));
+
+import { ViewHeader } from "./ViewHeader";
+
+afterEach(() => {
+  cleanup();
+  goLauncherMock.mockClear();
+});
+
+describe("ViewHeader — standardized normal-view header (#13451)", () => {
+  it("centers the title across the full header width", () => {
+    render(<ViewHeader title="Settings" />);
+    const title = screen.getByRole("heading", { name: "Settings" });
+    // Centered over the full header (absolute inset-x-0 + mx-auto + centered
+    // text), NOT within a side-dependent grid track, so it stays centered
+    // regardless of back/right control widths.
+    expect(title.className).toContain("absolute");
+    expect(title.className).toContain("inset-x-0");
+    expect(title.className).toContain("mx-auto");
+    expect(title.className).toContain("text-center");
+    // Regression guards: never re-introduce the track-local alignment that
+    // shifted the title when actions were wider than the back button.
+    expect(title.className).not.toContain("justify-self-start");
+    expect(title.className).not.toContain("sm:justify-self-start");
+  });
+
+  it("renders an icon-only back button with no rest-state border or fill", () => {
+    render(<ViewHeader title="Wallet" />);
+    const back = screen.getByRole("button", { name: /back/i });
+    // Chromeless at rest: transparent background, no border.
+    expect(back.className).toContain("bg-transparent");
+    expect(back.className).not.toContain("border");
+    // Rest state has no accent/neutral chip fill (regression guard for the
+    // old `bg-bg` fill that read as a chip).
+    expect(back.className).not.toContain("bg-bg ");
+    expect(back.className).not.toMatch(/\bbg-bg\b(?!-)/);
+    // Hover/focus is the ONLY place a chip appears.
+    expect(back.className).toContain("hover:bg-bg-hover");
+    // Icon-only: no visible text label in the button.
+    expect(back.textContent?.trim()).toBe("");
+  });
+
+  it("pins the back button to the left edge of the header (first child)", () => {
+    render(<ViewHeader title="Browser" />);
+    const header = screen.getByTestId("view-header");
+    const back = screen.getByRole("button", { name: /back/i });
+    const kids = Array.from(header.children);
+    expect(kids.indexOf(back)).toBe(0);
+  });
+
+  it("invokes the launcher navigation on back by default", () => {
+    render(<ViewHeader title="Knowledge" />);
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    expect(goLauncherMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes a sub-view's back through the supplied onBack handler", () => {
+    const onBack = vi.fn();
+    render(<ViewHeader title="AI Model" onBack={onBack} />);
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+    // A scoped onBack must not also fire the launcher fallback.
+    expect(goLauncherMock).not.toHaveBeenCalled();
+  });
+
+  it("opts a view out of the back control with showBack={false}", () => {
+    render(<ViewHeader title="Home" showBack={false} />);
+    expect(screen.queryByRole("button", { name: /back/i })).toBeNull();
+    // Title still present and centered even with no back control.
+    const title = screen.getByRole("heading", { name: "Home" });
+    expect(title.className).toContain("text-center");
+    expect(title.className).toContain("mx-auto");
+  });
+
+  it("names the back control per-view via backLabel (agent + a11y)", () => {
+    // Default wording when no override is supplied.
+    const { rerender } = render(<ViewHeader title="Wallet" />);
+    expect(
+      screen.getByRole("button", { name: "Back to launcher" }),
+    ).toBeTruthy();
+    // A sub-view returning to its hub names that hub instead of the launcher.
+    rerender(
+      <ViewHeader
+        title="AI Model"
+        onBack={vi.fn()}
+        backLabel="Back to Settings"
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Back to Settings" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Back to launcher" })).toBeNull();
+  });
+
+  it("keeps the title centered even when the right action is wide", () => {
+    render(
+      <ViewHeader
+        title="Wallet"
+        right={<button type="button">A very wide refresh action</button>}
+      />,
+    );
+    const header = screen.getByTestId("view-header");
+    const title = screen.getByRole("heading", { name: "Wallet" });
+    // Centering is anchored to the full header, not a side-dependent track, so
+    // a wide right action cannot shift the title (the earlier grid-track
+    // regression). No fixed/asymmetric grid tracks remain.
+    expect(title.className).toContain("absolute");
+    expect(title.className).toContain("inset-x-0");
+    expect(title.className).toContain("mx-auto");
+    expect(header.className).not.toContain("grid-cols-");
+  });
+
+  it("renders trailing actions at the right edge, above the centered title", () => {
+    render(
+      <ViewHeader
+        title="Wallet"
+        right={<button type="button">Refresh</button>}
+      />,
+    );
+    const refresh = screen.getByRole("button", { name: "Refresh" });
+    const title = screen.getByRole("heading", { name: "Wallet" });
+    // Actions render (rightmost edge) and stay clickable above the centered
+    // title layer; the title itself is pointer-events-none so it never eats
+    // clicks meant for the controls.
+    expect(refresh).toBeTruthy();
+    expect(title.className).toContain("pointer-events-none");
+    expect(title.className).toContain("text-center");
+  });
+});

--- a/packages/ui/src/components/shared/ViewHeader.tsx
+++ b/packages/ui/src/components/shared/ViewHeader.tsx
@@ -35,10 +35,10 @@ export function navigateBackToLauncher(): void {
 
 /**
  * The shared view back button: an icon, nothing else. Deliberately chromeless —
- * no border, no shadow, and a `bg-bg` fill so it reads as the neutral view
- * surface (white in light mode, dark in dark mode), never the accent/orange
- * chip it used to be. On an opaque view the fill is invisible (looks like a
- * bare icon); on a shared-background view it's a subtle neutral chip.
+ * no border, no shadow, and NO rest-state fill so it reads as a bare icon on
+ * every surface (#13451: normal-view header back affordance is icon-only, with
+ * no border/background at rest). A subtle neutral `bg-hover` chip only appears
+ * on hover/focus for affordance, never in the resting state.
  */
 export function ViewBackButton({
   onBack,
@@ -46,6 +46,8 @@ export function ViewBackButton({
   className,
 }: {
   onBack?: () => void;
+  /** Accessible + agent label. Sub-views override this to name their target
+   *  (e.g. a Settings section returning to the hub uses "Back to Settings"). */
   label?: string;
   className?: string;
 }) {
@@ -64,7 +66,7 @@ export function ViewBackButton({
       onClick={handleBack}
       aria-label={label}
       className={cn(
-        "inline-flex h-9 w-9 items-center justify-center rounded-full bg-bg text-txt transition-colors hover:bg-bg-hover",
+        "inline-flex h-9 w-9 items-center justify-center rounded-full bg-transparent text-txt transition-colors hover:bg-bg-hover focus-visible:bg-bg-hover",
         className,
       )}
       {...agentProps}
@@ -86,6 +88,7 @@ export function ViewBackButton({
 export function ViewHeader({
   title,
   onBack,
+  backLabel,
   showBack = true,
   right,
   className,
@@ -93,36 +96,44 @@ export function ViewHeader({
   title: ReactNode;
   /** Override the default (launcher) back target — e.g. a sub-view returning to its hub. */
   onBack?: () => void;
+  /** Accessible + agent label for the back control. Defaults to the launcher
+   *  wording; a sub-view returning to its hub should name that hub (e.g.
+   *  "Back to Settings") so the icon-only button is announced correctly. */
+  backLabel?: string;
   /** Hide the back control entirely (a view with no meaningful "back"). */
   showBack?: boolean;
   /** Optional trailing controls (actions, filters). */
   right?: ReactNode;
   className?: string;
 }) {
-  // A 3-column grid, not absolute positioning: responsive `static`/`relative`
-  // position variants do not survive the app's Tailwind build (the base
-  // `absolute` always won, leaving the back button detached from the row on
-  // desktop), so the layout uses grid tracks + responsive `justify-self`
-  // instead. Mobile: fixed equal side tracks keep the title truly centered
-  // with the back control on the left. ≥sm: auto tracks left-align the title
-  // right after the back button.
+  // Title is centered over the FULL header width, not within a grid track, so
+  // it stays optically centered regardless of how wide the back button or the
+  // trailing actions are (#13451: view title is centered in the header). The
+  // controls float at the edges of a `relative` row and the `<h1>` is a
+  // non-responsive `absolute inset-x-0` centered layer. It uses a single,
+  // static `absolute` (unlike the responsive position variants that
+  // historically did not survive the app's Tailwind build). The title reserves
+  // symmetric side room (`px-12`, wider than the icon back button) and
+  // truncates, so a long title never slides under the edge controls; the flex
+  // controls sit above it (`z-10`, pointer-events on) and stay clickable while
+  // the title layer is `pointer-events-none`.
   return (
     <header
       data-testid="view-header"
       className={cn(
-        "grid min-h-14 shrink-0 grid-cols-[2.75rem_minmax(0,1fr)_2.75rem] items-center gap-1 px-3 py-2.5 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:gap-2 sm:px-4",
+        "relative flex min-h-14 shrink-0 items-center justify-between gap-1 px-3 py-2.5 sm:gap-2 sm:px-4",
         className,
       )}
     >
-      {showBack ? <ViewBackButton onBack={onBack} /> : <span aria-hidden />}
-      <h1 className="justify-self-center truncate text-lg font-semibold tracking-tight text-txt-strong sm:justify-self-start">
-        {title}
-      </h1>
-      {right ? (
-        <div className="justify-self-end">{right}</div>
+      {showBack ? (
+        <ViewBackButton onBack={onBack} label={backLabel} />
       ) : (
         <span aria-hidden />
       )}
+      <h1 className="pointer-events-none absolute inset-x-0 mx-auto max-w-[calc(100%-6rem)] truncate px-12 text-center text-lg font-semibold tracking-tight text-txt-strong">
+        {title}
+      </h1>
+      {right ? <div className="relative z-10">{right}</div> : <span aria-hidden />}
     </header>
   );
 }


### PR DESCRIPTION
Closes #13451.

## What

Normal built-in views did not share one view-header contract, so the app read as assembled from unrelated surfaces. This makes the shared `ViewHeader` primitive the single source of truth for the standardized normal-view header, and routes the divergent Settings section header through it.

## Changes

**`ViewHeader` / `ViewBackButton` (`components/shared/ViewHeader.tsx`)**
- Back affordance is **icon-only with no rest-state border or background** — transparent at rest, a subtle `bg-hover` chip only on hover/focus. (Previously a `bg-bg` fill that read as a chip.)
- **Title is centered over the full header width** (`absolute inset-x-0` + `mx-auto` + `text-center`), so it stays centered regardless of how wide the back button or trailing actions are. This replaces the 3-column grid that left-aligned the title on ≥sm and shifted it when a right action was wider than the back button. The title layer is `pointer-events-none` and truncates; edge controls stay clickable above it.
- New `backLabel` prop so a sub-view returning to its hub names that hub for a11y/agents (e.g. `"Back to Settings"`) instead of the default launcher wording.

**Settings (`components/pages/SettingsView.tsx`)**
- Settings **section → hub back now uses the shared `ViewHeader`** (icon-only back, centered section title, `"Back to Settings"`) instead of the section-local `SectionBackButton` text button + separate icon heading. Removed the now-dead `SectionBackButton` and its `ArrowLeft` import.
- The desktop detail pane (rail owns navigation) keeps its icon + title heading, since there is no header back control there.

**Tests (`components/shared/ViewHeader.test.tsx`, new — 9 tests)**
- Pins the header contract: centered title (full-width, not track-local), chromeless icon-only back with no rest-state fill/border, left-edge back placement, default launcher back + `onBack`/`backLabel` overrides, `showBack={false}` opt-out, and no title shift when the right action is wide.

## Acceptance criteria

- [x] Header back affordance is icon-only, left-aligned, no border/background at rest.
- [x] View title is centered in the header (at every breakpoint).
- [x] Settings section back uses the shared shell header, not a section-local text button.
- [x] Sub-view back is announced correctly (`backLabel`).

## Scope / coordination

Header-component-scoped by design. Kept **out of** sibling issue #13452's territory (view/background isolation, `AppBackground`, `resolveActiveScreenBackgroundPolicy`) — this PR touches only the header primitive and the Settings header call site. Deeper items in the issue's proposed direction (Browser toolbar-below-header, Wallet top-tabs-as-secondary-nav, an `audit:app` header assertion) are follow-ups; this lands the shared contract + the largest divergence (Settings).

## Guardrails

Tokens only (`bg-hover` / `txt` / `txt-strong`), lucide `ArrowLeft`, no raw hex, no `backdrop-blur`. `tsgo` clean in `packages/ui` (remaining errors are pre-existing cross-package module-resolution noise in the shared worktree env, none in the touched files). `ViewHeader.test.tsx`: 9/9 pass. No forbidden files touched.

— [sol-orch]