### PR TITLE
fix(#13415): fail closed on corrupt redemption_limits NUMERIC daily-gate reads

### DIFF
--- a/packages/cloud/shared/src/lib/services/token-redemption-secure.daily-limit.test.ts
+++ b/packages/cloud/shared/src/lib/services/token-redemption-secure.daily-limit.test.ts
@@ -1,0 +1,137 @@
+// Fail-closed daily-limit gate for the secure token-redemption money-out path.
+//
+// Regression coverage for #13415: `checkDailyLimitsUTC` read the
+// `redemption_limits.daily_usd_total` (numeric(12,2)) and `redemption_count`
+// (numeric(5,0)) columns via bare `Number(...)`. The Postgres driver returns
+// NUMERIC as strings and `'NaN'::numeric` is a valid stored value that reads
+// back as the string "NaN": `Number("NaN") === NaN`, and every `NaN`
+// comparison is `false`, so a corrupt limits row made BOTH anti-sybil gates
+// (`count >= MAX`, `total + usd > DAILY_LIMIT_USD`) fail OPEN — authorizing
+// unbounded redemptions. The fix parses through a fail-closed boundary and
+// DENIES on a corrupt row.
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// db/client mock — control the single redemptionLimits.findFirst read that
+// checkDailyLimitsUTC performs. Nothing else in this method touches the DB.
+// ---------------------------------------------------------------------------
+let nextLimitsRow: Record<string, unknown> | undefined;
+
+mock.module("../../db/client", () => ({
+  dbRead: {
+    query: {
+      redemptionLimits: {
+        findFirst: async () => nextLimitsRow,
+      },
+    },
+  },
+  dbWrite: {},
+}));
+
+const { SecureTokenRedemptionService, parseRedemptionLimitNumber, CorruptRedemptionLimitError } =
+  await import("./token-redemption-secure");
+
+// checkDailyLimitsUTC is private in TS but present at runtime; exercise the seam
+// directly with a controlled limits row.
+type DailyLimitCheck = (
+  userId: string,
+  pointsAmount: number,
+) => Promise<{ valid: boolean; error?: string }>;
+
+function callCheckDailyLimits(pointsAmount: number): Promise<{ valid: boolean; error?: string }> {
+  const service = new SecureTokenRedemptionService() as unknown as {
+    checkDailyLimitsUTC: DailyLimitCheck;
+  };
+  return service.checkDailyLimitsUTC("user-1", pointsAmount);
+}
+
+beforeEach(() => {
+  nextLimitsRow = undefined;
+});
+
+describe("parseRedemptionLimitNumber (fail-closed boundary)", () => {
+  test("parses a well-formed NUMERIC driver string", () => {
+    expect(parseRedemptionLimitNumber("1234.56", "daily_usd_total")).toBe(1234.56);
+    expect(parseRedemptionLimitNumber("7", "redemption_count")).toBe(7);
+  });
+
+  test("allows an explicit domain zero (fresh/zeroed row is legitimate)", () => {
+    expect(parseRedemptionLimitNumber("0", "daily_usd_total")).toBe(0);
+    expect(parseRedemptionLimitNumber("0.00", "daily_usd_total")).toBe(0);
+    expect(parseRedemptionLimitNumber(0, "redemption_count")).toBe(0);
+  });
+
+  test("accepts a plain finite number", () => {
+    expect(parseRedemptionLimitNumber(42.5, "daily_usd_total")).toBe(42.5);
+  });
+
+  test.each([
+    ["NaN"], // <- the exact fail-open value ('NaN'::numeric reads back as "NaN")
+    [""],
+    ["   "],
+    ["not-a-number"],
+    ["Infinity"],
+    [Number.NaN],
+    [Number.POSITIVE_INFINITY],
+    [null],
+    [undefined],
+  ])("throws CorruptRedemptionLimitError on non-finite/absent value %p", (bad) => {
+    expect(() => parseRedemptionLimitNumber(bad as unknown, "daily_usd_total")).toThrow(
+      CorruptRedemptionLimitError,
+    );
+  });
+});
+
+describe("checkDailyLimitsUTC (money-out anti-sybil gate)", () => {
+  test("healthy row under limits authorizes", async () => {
+    nextLimitsRow = { daily_usd_total: "10.00", redemption_count: "2" };
+    const result = await callCheckDailyLimits(500); // $5
+    expect(result.valid).toBe(true);
+  });
+
+  test("no limits row today authorizes (nothing spent yet)", async () => {
+    nextLimitsRow = undefined;
+    const result = await callCheckDailyLimits(500);
+    expect(result.valid).toBe(true);
+  });
+
+  test("healthy row over the USD daily limit denies", async () => {
+    // DAILY_LIMIT_USD = 5000; already spent 4999.99, +$5 pushes over.
+    nextLimitsRow = { daily_usd_total: "4999.99", redemption_count: "1" };
+    const result = await callCheckDailyLimits(500);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Daily limit exceeded");
+  });
+
+  test("healthy row at the redemption-count cap denies", async () => {
+    // MAX_DAILY_REDEMPTIONS = 10
+    nextLimitsRow = { daily_usd_total: "50.00", redemption_count: "10" };
+    const result = await callCheckDailyLimits(500);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Daily limit reached");
+  });
+
+  test("REGRESSION: corrupt daily_usd_total ('NaN') DENIES instead of failing open", async () => {
+    // Old behavior: Number("NaN") + 5 > 5000 === false -> gate authorized.
+    nextLimitsRow = { daily_usd_total: "NaN", redemption_count: "1" };
+    const result = await callCheckDailyLimits(500);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Unable to verify your daily redemption limit");
+  });
+
+  test("REGRESSION: corrupt redemption_count ('NaN') DENIES instead of failing open", async () => {
+    // Old behavior: NaN >= 10 === false -> count cap bypassed.
+    nextLimitsRow = { daily_usd_total: "10.00", redemption_count: "NaN" };
+    const result = await callCheckDailyLimits(500);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Unable to verify your daily redemption limit");
+  });
+
+  test("REGRESSION: empty-string NUMERIC read DENIES", async () => {
+    nextLimitsRow = { daily_usd_total: "", redemption_count: "1" };
+    const result = await callCheckDailyLimits(500);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Unable to verify your daily redemption limit");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/token-redemption-secure.ts
+++ b/packages/cloud/shared/src/lib/services/token-redemption-secure.ts
@@ -188,6 +188,63 @@ function maskAddress(address: string): string {
 }
 
 // ============================================================================
+// HELPER: Fail-closed NUMERIC parsing for money-out limit gates (Fix #6 hardening)
+// ============================================================================
+
+/**
+ * A stored `redemption_limits` row NUMERIC value could not be parsed into a
+ * finite number. The Postgres driver returns NUMERIC columns as strings, and
+ * `'NaN'::numeric` is a *valid* Postgres NUMERIC that reads back as the string
+ * `"NaN"`. `Number("NaN") === NaN`, and every `NaN` comparison is `false`, so a
+ * corrupt `daily_usd_total` / `redemption_count` would silently make the daily
+ * anti-sybil money-out gates fail OPEN (unbounded redemptions). We throw here so
+ * the caller can fail CLOSED (deny) instead of authorizing over a corrupt row.
+ */
+export class CorruptRedemptionLimitError extends Error {
+  constructor(field: string, rawValue: unknown) {
+    super(
+      `redemption_limits.${field} is not a finite number (got ${JSON.stringify(
+        String(rawValue),
+      )}); refusing to evaluate the daily limit gate on a corrupt row`,
+    );
+    this.name = "CorruptRedemptionLimitError";
+  }
+}
+
+/**
+ * Fail-closed boundary for a `redemption_limits` NUMERIC column read.
+ *
+ * - Rejects null/undefined/empty/whitespace and any value that does not parse to
+ *   a finite number (NaN, Infinity, `"NaN"`, `""`, garbage) -> throws.
+ * - Allows an explicit domain zero (a fresh/zeroed limit row is legitimate).
+ *
+ * error-policy:J4 (fail-closed: a corrupt money-out limit value must DENY, not
+ * silently authorize an unbounded redemption).
+ *
+ * Exported for unit testing of the fail-closed boundary.
+ */
+export function parseRedemptionLimitNumber(value: unknown, field: string): number {
+  if (value === null || value === undefined) {
+    throw new CorruptRedemptionLimitError(field, value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new CorruptRedemptionLimitError(field, value);
+    }
+    return value;
+  }
+  const raw = String(value).trim();
+  if (raw === "") {
+    throw new CorruptRedemptionLimitError(field, value);
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    throw new CorruptRedemptionLimitError(field, value);
+  }
+  return parsed;
+}
+
+// ============================================================================
 // HELPER: Decimal math (Fix #11)
 // ============================================================================
 
@@ -780,8 +837,26 @@ export class SecureTokenRedemptionService {
     const usdValue = pointsAmount / 100;
 
     if (limits) {
-      const currentTotal = Number(limits.daily_usd_total);
-      const currentCount = Number(limits.redemption_count);
+      // Fail-closed: the daily limit gates are money-out anti-sybil controls. A
+      // corrupt NUMERIC row ('NaN'::numeric reads back as "NaN") would make
+      // `NaN >= MAX` and `NaN + usd > LIMIT` both false -> the gate would fail
+      // OPEN and authorize unbounded redemptions. Refuse instead of authorize.
+      // error-policy:J4
+      let currentTotal: number;
+      let currentCount: number;
+      try {
+        currentTotal = parseRedemptionLimitNumber(limits.daily_usd_total, "daily_usd_total");
+        currentCount = parseRedemptionLimitNumber(limits.redemption_count, "redemption_count");
+      } catch (error) {
+        logger.error("[SecureRedemption] Corrupt daily-limit row; denying redemption", {
+          userId: sanitizeForLog(userId),
+          reason: error instanceof Error ? error.message : String(error),
+        });
+        return {
+          valid: false,
+          error: "Unable to verify your daily redemption limit right now. Please try again later.",
+        };
+      }
 
       if (currentCount >= SECURE_CONFIG.MAX_DAILY_REDEMPTIONS) {
         return {


### PR DESCRIPTION
## Problem

`checkDailyLimitsUTC` in the **secure token-redemption** service (`packages/cloud/shared/src/lib/services/token-redemption-secure.ts`) is a money-out anti-sybil gate. It read the `redemption_limits` row's NUMERIC columns via bare `Number(...)`:

```ts
const currentTotal = Number(limits.daily_usd_total);   // numeric(12,2)
const currentCount = Number(limits.redemption_count);  // numeric(5,0)
```

The Postgres driver returns NUMERIC columns as **strings**, and `'NaN'::numeric` is a *valid* stored Postgres NUMERIC that reads back as the string `"NaN"`. `Number("NaN") === NaN`, and **every `NaN` comparison is `false`**, so a corrupt limits row made **both daily gates fail OPEN**:

- `currentCount >= MAX_DAILY_REDEMPTIONS` → `NaN >= 10` === `false` → **redemption-count cap bypassed**
- `currentTotal + usdValue > DAILY_LIMIT_USD` → `NaN + 5 > 5000` === `false` → **daily-USD spend cap bypassed**

→ unbounded redemptions authorized over a single corrupt row, silently.

## Fix

New colocated fail-closed boundary `parseRedemptionLimitNumber` + `CorruptRedemptionLimitError`:
- throws on `null`/`undefined`/empty/whitespace and any value that doesn't parse to a **finite** number (`NaN`, `Infinity`, `"NaN"`, `""`, garbage);
- allows an explicit domain **zero** (a fresh/zeroed limit row is legitimate).

`checkDailyLimitsUTC` now catches a corrupt read, logs `logger.error` (observable), and **DENIES** the redemption (`"Unable to verify your daily redemption limit right now."`) instead of silently authorizing. `error-policy:J4`.

Mirrors the merged cloud-shared NUMERIC fail-closed pattern (#13454 / #13474 / #13482 / #13486 / #13503 / #13504).

## Tests

`token-redemption-secure.daily-limit.test.ts` — **19/19 green** under `bun test --isolate`:
- exhaustive parser boundary (incl the exact `"NaN"` / `""` fail-open values, `Infinity`, `null`, `undefined`);
- `checkDailyLimitsUTC` seam via a mocked `db/client`: healthy-under-limit authorizes, no-row authorizes, over-USD-limit denies, at-count-cap denies;
- **3 REGRESSION tests** proving corrupt `daily_usd_total` / corrupt `redemption_count` / empty-string all **DENY** instead of failing open.

## Gates

- `bun test --isolate` → 19 pass / 0 fail
- `tsgo --noEmit` → **0 errors in touched files** (17 pre-existing baseline errors, stash-verified **identical** on pristine `origin/develop`)
- `biome check` → clean
- `error-policy-ratchet` → no new fallback-slop

## Scope / collision

Distinct file from the concurrent #13415 sibling lanes (`agent-budgets.ts`) and my prior #13415 slices `auto-top-up.ts` (#13507) + `payout-processor.ts` (#13508). No open PR touched `token-redemption-secure.ts` at claim or push; no `lalalune`/`NubsCarson`/`roninjin10` redemption PR in the last day. Issue stays open for remaining service-layer inventory.

-- [sol-orch]
