### PR TITLE
fix(#13415): fail closed on corrupt credit_balance in agent-billing-gate spend gate

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/agent-billing-gate.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/agent-billing-gate.test.ts
@@ -1,0 +1,144 @@
+// Exercises the agent-billing-gate pre-provisioning spend gate with deterministic
+// repository fixtures. Regression focus: a corrupt organizations.credit_balance
+// NUMERIC read ('NaN'::numeric is valid Postgres NUMERIC, read back as "NaN")
+// previously slipped past `Number(...)` + `NaN <= MINIMUM_DEPOSIT` (false) and
+// FAILED OPEN with { allowed: true, balance: NaN }.
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const findById = mock();
+
+mock.module("../../../db/repositories", () => ({
+  organizationsRepository: {
+    findById,
+  },
+}));
+
+const loggerError = mock();
+
+mock.module("../../utils/logger", () => ({
+  logger: {
+    error: loggerError,
+    warn: mock(),
+    info: mock(),
+    debug: mock(),
+  },
+}));
+
+const { checkAgentCreditGate, parseGateCreditBalance, CorruptCreditBalanceError } = await import(
+  "../agent-billing-gate"
+);
+
+beforeEach(() => {
+  findById.mockReset();
+  loggerError.mockReset();
+});
+
+describe("parseGateCreditBalance", () => {
+  test("accepts plain decimal strings (driver NUMERIC shape)", () => {
+    expect(parseGateCreditBalance("12.34")).toBe(12.34);
+    expect(parseGateCreditBalance("0")).toBe(0);
+    expect(parseGateCreditBalance("0.00")).toBe(0);
+    expect(parseGateCreditBalance("-3.5")).toBe(-3.5);
+    expect(parseGateCreditBalance(".25")).toBe(0.25);
+  });
+
+  test("accepts finite numbers", () => {
+    expect(parseGateCreditBalance(7.5)).toBe(7.5);
+    expect(parseGateCreditBalance(0)).toBe(0);
+  });
+
+  test("throws on corrupt values instead of producing NaN", () => {
+    for (const raw of ["NaN", "Infinity", "-Infinity", "", "   ", "1e3", "0x10", "12,34", "abc"]) {
+      expect(() => parseGateCreditBalance(raw)).toThrow(CorruptCreditBalanceError);
+    }
+    expect(() => parseGateCreditBalance(Number.NaN)).toThrow(CorruptCreditBalanceError);
+    expect(() => parseGateCreditBalance(Number.POSITIVE_INFINITY)).toThrow(
+      CorruptCreditBalanceError,
+    );
+    expect(() => parseGateCreditBalance(null)).toThrow(CorruptCreditBalanceError);
+    expect(() => parseGateCreditBalance(undefined)).toThrow(CorruptCreditBalanceError);
+    expect(() => parseGateCreditBalance({})).toThrow(CorruptCreditBalanceError);
+  });
+});
+
+describe("checkAgentCreditGate", () => {
+  test("allows an org with a healthy balance above the minimum deposit", async () => {
+    findById.mockResolvedValue({ credit_balance: "25.00" });
+
+    const result = await checkAgentCreditGate("org-healthy");
+
+    expect(result.allowed).toBe(true);
+    expect(result.balance).toBe(25);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("denies an org at or below the minimum deposit with a funding message", async () => {
+    findById.mockResolvedValue({ credit_balance: "0.05" });
+
+    const result = await checkAgentCreditGate("org-broke");
+
+    expect(result.allowed).toBe(false);
+    expect(result.balance).toBe(0.05);
+    expect(result.error).toContain("Insufficient credits");
+  });
+
+  test("explicit zero balance is a legit domain value and denies (not corrupt)", async () => {
+    findById.mockResolvedValue({ credit_balance: "0.00" });
+
+    const result = await checkAgentCreditGate("org-zero");
+
+    expect(result.allowed).toBe(false);
+    expect(result.balance).toBe(0);
+    expect(result.error).toContain("Insufficient credits");
+    expect(loggerError).not.toHaveBeenCalled();
+  });
+
+  test("REGRESSION: corrupt 'NaN' balance FAILS CLOSED, never { allowed: true, balance: NaN }", async () => {
+    findById.mockResolvedValue({ credit_balance: "NaN" });
+
+    const result = await checkAgentCreditGate("org-corrupt");
+
+    expect(result.allowed).toBe(false);
+    expect(Number.isNaN(result.balance)).toBe(false);
+    expect(result.error).toContain("Unable to verify credit balance");
+    // Observable, distinct corrupt-value log naming the org
+    expect(loggerError).toHaveBeenCalledTimes(1);
+    const [message, context] = loggerError.mock.calls[0] as [string, Record<string, unknown>];
+    expect(message).toContain("Corrupt credit_balance");
+    expect(context.organizationId).toBe("org-corrupt");
+    expect(context.rawValue).toBe("NaN");
+  });
+
+  test("corrupt empty-string balance also fails closed", async () => {
+    findById.mockResolvedValue({ credit_balance: "" });
+
+    const result = await checkAgentCreditGate("org-empty");
+
+    expect(result.allowed).toBe(false);
+    expect(result.error).toContain("Unable to verify credit balance");
+  });
+
+  test("missing org denies without a corrupt-value log", async () => {
+    findById.mockResolvedValue(null);
+
+    const result = await checkAgentCreditGate("org-missing");
+
+    expect(result.allowed).toBe(false);
+    expect(result.balance).toBe(0);
+    expect(result.error).toBe("Organization not found");
+    expect(loggerError).not.toHaveBeenCalled();
+  });
+
+  test("repository failure still fails closed (pre-existing behavior preserved)", async () => {
+    findById.mockRejectedValue(new Error("db down"));
+
+    const result = await checkAgentCreditGate("org-db-down");
+
+    expect(result.allowed).toBe(false);
+    expect(result.balance).toBe(0);
+    expect(result.error).toContain("Unable to verify credit balance");
+    expect(loggerError).toHaveBeenCalledTimes(1);
+    const [message] = loggerError.mock.calls[0] as [string];
+    expect(message).toContain("Failed to check credits");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-billing-gate.ts
+++ b/packages/cloud/shared/src/lib/services/agent-billing-gate.ts
@@ -2,8 +2,7 @@
  * Agent billing gate — pre-provisioning credit check.
  *
  * Ensures an organization has more than the minimum running balance before
- * allowing agent creation, provisioning, or resume. Routes serialize denials
- * with the canonical 402 body from ./agent-billing-gate-402.ts.
+ * allowing agent creation, provisioning, or resume.
  */
 
 import { organizationsRepository } from "../../db/repositories";
@@ -17,10 +16,69 @@ export interface CreditGateResult {
 }
 
 /**
+ * Thrown when an organization's stored credit_balance cannot be parsed into a
+ * finite number. `'NaN'::numeric` is a valid Postgres NUMERIC value, so a
+ * corrupt row reads back as the string "NaN"; without a fail-closed boundary
+ * that read poisons the spend gate below (see parseGateCreditBalance).
+ */
+export class CorruptCreditBalanceError extends Error {
+  readonly rawValue: string;
+
+  constructor(rawValue: unknown) {
+    const printable =
+      rawValue === null ? "null" : rawValue === undefined ? "undefined" : String(rawValue);
+    super(`Corrupt organizations.credit_balance read: ${JSON.stringify(printable)}`);
+    this.name = "CorruptCreditBalanceError";
+    this.rawValue = printable;
+  }
+}
+
+/** Plain signed decimal only — rejects "1e3", "0x10", "NaN", "Infinity", "". */
+const PLAIN_DECIMAL_RE = /^-?(?:\d+\.?\d*|\.\d+)$/;
+
+/**
+ * Fail-closed boundary for the organizations.credit_balance NUMERIC read.
+ *
+ * The previous bare `Number(org.credit_balance)` FAILED OPEN on a corrupt
+ * row: `Number("NaN") === NaN`, and `NaN <= MINIMUM_DEPOSIT` is `false`, so
+ * the gate returned `{ allowed: true, balance: NaN }` — authorizing agent
+ * creation/provisioning/resume against an unverifiable balance, despite the
+ * catch-path comment claiming this gate fails closed.
+ *
+ * Accepts a finite number or a plain signed decimal string (the shape the
+ * Postgres driver returns for NUMERIC). Explicit zero and negative
+ * (overdrawn) balances are legitimate domain values. Everything else throws.
+ * error-policy:J1
+ */
+export function parseGateCreditBalance(raw: unknown): number {
+  if (typeof raw === "number") {
+    if (!Number.isFinite(raw)) {
+      throw new CorruptCreditBalanceError(raw);
+    }
+    return raw;
+  }
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (trimmed !== "" && PLAIN_DECIMAL_RE.test(trimmed)) {
+      const parsed = Number(trimmed);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+    throw new CorruptCreditBalanceError(raw);
+  }
+  throw new CorruptCreditBalanceError(raw);
+}
+
+/**
  * Check whether an organization has sufficient credits for Eliza agent operations.
  *
  * Returns `{ allowed: true }` if `credit_balance > MINIMUM_DEPOSIT`,
  * otherwise returns a user-facing error message directing them to add funds.
+ *
+ * Fails CLOSED on a corrupt stored balance (distinct observable log) and on
+ * any repository/transport failure — never authorizes provisioning against a
+ * balance it could not verify.
  */
 export async function checkAgentCreditGate(organizationId: string): Promise<CreditGateResult> {
   try {
@@ -33,7 +91,7 @@ export async function checkAgentCreditGate(organizationId: string): Promise<Cred
       };
     }
 
-    const balance = Number(org.credit_balance);
+    const balance = parseGateCreditBalance(org.credit_balance);
 
     if (balance <= AGENT_PRICING.MINIMUM_DEPOSIT) {
       const deficit = Math.max(AGENT_PRICING.MINIMUM_DEPOSIT - balance, 0.01);
@@ -46,6 +104,19 @@ export async function checkAgentCreditGate(organizationId: string): Promise<Cred
 
     return { allowed: true, balance };
   } catch (error) {
+    if (error instanceof CorruptCreditBalanceError) {
+      // error-policy:J1 — corrupt stored money value: deny, surface for repair.
+      logger.error("[agent-billing-gate] Corrupt credit_balance — failing closed", {
+        organizationId,
+        rawValue: error.rawValue,
+      });
+      return {
+        allowed: false,
+        balance: 0,
+        error:
+          "Unable to verify credit balance for this organization. Please contact support before creating or resuming agents.",
+      };
+    }
     logger.error("[agent-billing-gate] Failed to check credits", {
       organizationId,
       error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary

`checkAgentCreditGate` (the pre-provisioning spend gate consumed by 5 route call sites: agent create, provision, restart, and both resume routes) read `organizations.credit_balance` (Postgres NUMERIC, string at read) via bare `Number(...)`.

`'NaN'::numeric` is a valid stored Postgres NUMERIC value, so a corrupt row reads back as the string `"NaN"` → `Number("NaN") === NaN` → the gate check `NaN <= MINIMUM_DEPOSIT` evaluates **false** → the gate returned `{ allowed: true, balance: NaN }`, **authorizing agent creation/provisioning/restart/resume against an unverifiable balance**. The catch-path comment claimed this gate fails closed; the happy-path parse failed open.

Same fail-open class as the merged cloud-shared NUMERIC hardening slices (#13454 usage-quotas, #13474 app-earnings, #13482 agent-billing, #13486 container-billing, #13503 organizations mutation reads) — this one is the *service-layer* provisioning gate for #13415.

## Fix

- New `parseGateCreditBalance()` fail-closed boundary: plain signed decimal string (driver NUMERIC shape) or finite number only; rejects `NaN`/`Infinity`/empty/exponent/hex/garbage. Explicit zero and negative (overdrawn) balances remain legitimate domain values that flow into the existing deny-with-funding-message path.
- New `CorruptCreditBalanceError` handled distinctly in the gate: **deny** + observable `logger.error` naming the org and raw value + user-facing contact-support message (`error-policy:J1`).
- Repository/transport failures keep the pre-existing fail-closed catch path unchanged.

## Tests

`packages/cloud/shared/src/lib/services/__tests__/agent-billing-gate.test.ts` — 10/10 green (`bun test --isolate`):

- parser boundary: plain decimals/finite numbers accepted; `NaN`/`Infinity`/`-Infinity`/empty/whitespace/`1e3`/`0x10`/`12,34`/non-string-non-number all throw
- **regression:** corrupt `"NaN"` row FAILS CLOSED — never `{ allowed: true, balance: NaN }` — with a distinct observable corrupt-value log naming the org
- corrupt empty-string fails closed
- healthy balance allows; sub-minimum denies with funding message
- explicit `"0.00"` denies via the normal insufficient-credits path with **no** corrupt-value log (domain zero not over-rejected)
- missing org and repository failure keep their pre-existing fail-closed behavior

## Verification

- `tsgo --noEmit` (packages/cloud/shared): zero new errors in touched files — 17 pre-existing baseline errors in app-core/plugin-mcp/anthropic-web-search/node-redis-adapter, identical on pristine develop
- biome clean on both files
- `error-policy-ratchet`: no new fallback-slop in touched files
- codex review: **CLEAN** ("Corrupt credit_balance reads like 'NaN' now fail closed ... Healthy plain decimal NUMERIC values remain unchanged"), independently re-ran the suite 10/10

## Collision receipts

- No open PR touching `agent-billing-gate.ts` at claim or push (searched `13415` + `agent-billing-gate`)
- Distinct file from sibling #13415 lanes: #13507 auto-top-up, #13508 payout-processor, #13518 token-redemption-secure, live agent-budgets worktree — zero source overlap
- No lalalune/NubsCarson/roninjin10 PR referencing this file in the last day
- Unique worktree path `fleet-13415-gate`

Issue stays open for remaining service-layer inventory.

— [sol-orch]
