### PR TITLE
fix(#13509): anchor conversational reminders to owner timezone fact

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
@@ -12,9 +12,19 @@
  *     reach the snooze handler instead of being discarded.
  */
 
-import type { HandlerOptions, IAgentRuntime, Memory } from "@elizaos/core";
+import type {
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+  UUID,
+} from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveDefaultTimeZone } from "../lifeops/defaults.js";
+import {
+  createOwnerFactStore,
+  registerOwnerFactStore,
+  resolveOwnerFactStore,
+} from "../lifeops/owner/fact-store.js";
 import { getZonedDateParts } from "../lifeops/time.js";
 import type { ExtractedTaskParams } from "./lib/extract-task-plan.js";
 import {
@@ -372,11 +382,24 @@ describe("buildCadenceFromUpdateFields (once reschedule)", () => {
 // ── Handler-level flows ───────────────────────────────
 
 function makeRuntime(respond: (prompt: string) => string): IAgentRuntime {
+  const cache = new Map<string, unknown>();
   return {
+    agentId: "00000000-0000-0000-0000-000000000003" as UUID,
     getRoom: vi.fn(async () => null),
     useModel: vi.fn(async (_modelType: unknown, args: { prompt: string }) =>
       respond(args.prompt),
     ),
+    async getCache<T>(key: string): Promise<T | null> {
+      const value = cache.get(key);
+      return value === undefined ? null : (value as T);
+    },
+    async setCache<T>(key: string, value: T): Promise<boolean> {
+      cache.set(key, value);
+      return true;
+    },
+    async deleteCache(key: string): Promise<boolean> {
+      return cache.delete(key);
+    },
     logger: {
       debug: vi.fn(),
       error: vi.fn(),
@@ -569,6 +592,66 @@ describe("runLifeOperationHandler one-off reminder scheduling", () => {
     expect(weekday).toBe(5);
     expect(parts.hour).toBe(17);
     expect(parts.minute).toBe(0);
+  });
+
+  it('anchors "remind me tomorrow at 9am" to the owner timezone fact, not the host clock (#13509)', async () => {
+    // Regression for #13509: a conversational one-off create with no zone
+    // stated out loud (planner returns timeZone:null) must resolve "9am"
+    // against the owner's STORED timezone fact, not the host clock. Before the
+    // fix, this stored 09:00 in the host zone (UTC on TZ=UTC / server
+    // topologies) = 04:00 America/Chicago — "confidently wrong by five hours".
+    const runtime = makeRuntime((prompt) => {
+      if (prompt.includes("create_definition request")) {
+        return taskPlanJson({
+          requestKind: "reminder",
+          title: "Call pharmacy about refill",
+          cadenceKind: "once",
+          dueInDays: 1,
+          timeOfDay: "09:00",
+          // No zone stated out loud: the planner leaves timeZone null. The
+          // owner-fact fallback (#13509) must supply the zone.
+          timeZone: null,
+        });
+      }
+      return "";
+    });
+    // Seed the owner's stored timezone fact.
+    registerOwnerFactStore(runtime, createOwnerFactStore(runtime));
+    await resolveOwnerFactStore(runtime).update(
+      { timezone: "America/Chicago" },
+      { source: "profile_save", recordedAt: "2026-07-04T00:00:00.000Z" },
+    );
+
+    const result = await runLifeOperationHandler(
+      runtime,
+      makeMessage(
+        "remind me tomorrow at 9am to call the pharmacy about my refill",
+      ),
+      undefined,
+      {
+        parameters: {
+          action: "create_reminder",
+          intent:
+            "remind me tomorrow at 9am to call the pharmacy about my refill",
+        },
+      } as HandlerOptions,
+    );
+    expect(result.success).toBe(true);
+    expect(serviceState.createCalls).toHaveLength(1);
+    const created = serviceState.createCalls[0] as {
+      cadence: { kind: string; dueAt: string };
+      timezone?: string;
+    };
+    expect(created.cadence.kind).toBe("once");
+    // dueAt wall-clock is 09:00 in America/Chicago, NOT 09:00 host/UTC.
+    const parts = getZonedDateParts(
+      new Date(created.cadence.dueAt),
+      "America/Chicago",
+    );
+    expect(parts.hour).toBe(9);
+    expect(parts.minute).toBe(0);
+    // The persisted definition also carries the owner zone, not the host zone.
+    expect(created.timezone).toBe("America/Chicago");
   });
 
   it("asks for clarification instead of scheduling when the time is unresolvable", async () => {

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -61,6 +61,7 @@ import {
   messageText,
   toActionData,
 } from "../lifeops/google/format-helpers.js";
+import { resolveOwnerTimeZone } from "../lifeops/owner/fact-store.js";
 import { LifeOpsService, LifeOpsServiceError } from "../lifeops/service.js";
 import { normalizeExplicitTimeZoneToken } from "../lifeops/time/timezone.js";
 import {
@@ -2817,6 +2818,17 @@ export async function runLifeOperationHandler(
         | Record<string, unknown>
         | undefined;
 
+      // Owner's stored timezone fact (travel-aware), used as the fallback zone
+      // for a conversational create when no zone was stated out loud and no
+      // more-specific candidate (explicit detail / planner / deferred draft /
+      // window policy) is present. Without this, "remind me tomorrow at 9am"
+      // resolves 9am against the HOST clock (`resolveDefaultTimeZone()` = UTC
+      // on shared-server / TZ=UTC topologies) instead of the owner's wall
+      // clock (#13509). Read once here; the store call falls back to the host
+      // zone itself when no owner fact is stored, so `ownerFactTimeZone` is
+      // always a concrete zone (never fabricated).
+      const ownerFactTimeZone = await resolveOwnerTimeZone(runtime, new Date());
+
       // Track whether cadence/title came from explicit high-confidence
       // sources so the planner only fills genuine gaps.
       const hadExplicitCadence = Boolean(
@@ -2886,12 +2898,13 @@ export async function runLifeOperationHandler(
             (editingDeferredDefinitionDraft || !hadExplicitCadence) &&
             llmPlan.cadenceKind
           ) {
-            const llmCadenceTimeZone = normalizeLifeTimeZoneToken(
-              detailString(details, "timeZone") ??
-                llmPlan.timeZone ??
-                deferredDefinitionDraft?.request.timezone ??
-                windowPolicy?.timezone,
-            );
+            const llmCadenceTimeZone =
+              normalizeLifeTimeZoneToken(
+                detailString(details, "timeZone") ??
+                  llmPlan.timeZone ??
+                  deferredDefinitionDraft?.request.timezone ??
+                  windowPolicy?.timezone,
+              ) ?? ownerFactTimeZone;
             const llmCadence = buildCadenceFromLlmParams(llmPlan, {
               intent,
               timeZone: llmCadenceTimeZone ?? undefined,
@@ -2915,12 +2928,13 @@ export async function runLifeOperationHandler(
           }
         }
       }
-      const resolvedTimeZone = normalizeLifeTimeZoneToken(
-        detailString(details, "timeZone") ??
-          llmPlan?.timeZone ??
-          deferredDefinitionDraft?.request.timezone ??
-          windowPolicy?.timezone,
-      );
+      const resolvedTimeZone =
+        normalizeLifeTimeZoneToken(
+          detailString(details, "timeZone") ??
+            llmPlan?.timeZone ??
+            deferredDefinitionDraft?.request.timezone ??
+            windowPolicy?.timezone,
+        ) ?? ownerFactTimeZone;
       const timedRequestKind = llmRequestKind;
       const nativeAppleMetadata =
         timedRequestKind && cadence?.kind === "once"

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
@@ -114,7 +114,10 @@ import {
 import { materializeDefinitionOccurrences } from "../engine.js";
 import type { LifeOpsContext } from "../lifeops-context.js";
 import { REMINDER_DISPATCH_INSTRUCTIONS } from "../optimized-prompt-instructions.js";
-import { resolveOwnerFactStore } from "../owner/fact-store.js";
+import {
+  resolveOwnerFactStore,
+  resolveOwnerTimeZone,
+} from "../owner/fact-store.js";
 import { refreshLifeOpsRelativeTime } from "../relative-time.js";
 import {
   createLifeOpsActivitySignal,
@@ -5101,7 +5104,13 @@ export class RemindersDomain {
         request.limit === undefined
           ? DEFAULT_REMINDER_PROCESS_LIMIT
           : normalizePositiveInteger(request.limit, "limit");
-      const ownerTimezone = resolveDefaultTimeZone();
+      // Anchor reminder window/dueness math to the owner's stored timezone
+      // fact (travel-aware) rather than the host clock. On shared-server /
+      // TZ=UTC topologies `resolveDefaultTimeZone()` is the SERVER zone, which
+      // would fire morning/evening windows against the container's day, not
+      // the owner's (#13509). Falls back to the host zone only when no owner
+      // fact is stored.
+      const ownerTimezone = await resolveOwnerTimeZone(this.ctx.runtime, now);
 
       const policies = await this.ctx.repository.listChannelPolicies(
         this.ctx.agentId(),

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts
@@ -22,6 +22,8 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { isValidTimeZone, resolveDefaultTimeZone } from "../defaults.js";
 import {
   type LifeOpsOwnerProfilePatch,
   persistConfiguredOwnerName,
@@ -992,4 +994,62 @@ export function ownerFactsToView(
   if (facts.scheduleStyle) view.scheduleStyle = facts.scheduleStyle.value;
   if (facts.chronotype) view.chronotype = facts.chronotype.value;
   return view;
+}
+
+/**
+ * Resolve the owner's effective IANA time zone for a given instant, falling
+ * back to the host zone (`resolveDefaultTimeZone()`) only when no owner fact is
+ * stored.
+ *
+ * This is the canonical resolver for any lane that anchors owner-local wall
+ * time (conversational reminder creation, reminder window/dueness processing).
+ * It reads the OwnerFactStore and projects through {@link ownerFactsToView} so
+ * the `activeTravel` destination override is honored: while travel is active
+ * and a destination zone is known, that zone wins over the stored home zone —
+ * matching what the scheduled-task runner already does via
+ * `defaultOwnerFactsProvider`.
+ *
+ * On shared-server / `TZ=UTC` topologies the host fallback is the SERVER zone,
+ * so consulting the owner fact is what keeps "remind me at 9am" anchored to the
+ * owner's wall clock instead of the container's. When no owner fact exists the
+ * host zone remains the honest best-effort default (never fabricated).
+ *
+ * The stored fact (and the active-travel `destinationTimezone` that can
+ * override it) is only guarded by a non-empty-string check on write, so a
+ * malformed/colloquial value could reach the reminder date/window math (which
+ * expects a valid IANA zone and would otherwise throw). We therefore validate
+ * the resolved zone and fall back to the host zone when it is not a usable IANA
+ * identifier, keeping the fix fail-safe rather than fail-hard.
+ *
+ * `now` is required because travel-active is derived against the instant.
+ */
+export async function resolveOwnerTimeZone(
+  runtime: IAgentRuntime,
+  now: Date,
+): Promise<string> {
+  try {
+    const facts = await resolveOwnerFactStore(runtime).read();
+    const view = ownerFactsToView(facts, now);
+    if (view.timezone && isValidTimeZone(view.timezone)) {
+      return view.timezone;
+    }
+    if (view.timezone) {
+      logger.warn(
+        { src: "lifeops:owner:resolve-timezone", storedZone: view.timezone },
+        "Owner timezone fact is not a valid IANA zone; falling back to host zone for time resolution.",
+      );
+    }
+    return resolveDefaultTimeZone();
+  } catch (error) {
+    // error-policy:J4 — a fact-store read failure (missing/unavailable cache
+    // backend) must not break time resolution. Degrade to the host zone, the
+    // same honest best-effort default used when no owner fact exists, and
+    // surface the failure so the operator can see the store is unreachable
+    // rather than silently anchoring to the wrong zone with no signal.
+    logger.warn(
+      { src: "lifeops:owner:resolve-timezone", error },
+      "Failed to read owner timezone fact; falling back to host zone for time resolution.",
+    );
+    return resolveDefaultTimeZone();
+  }
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/resolve-owner-timezone.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/resolve-owner-timezone.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Coverage for `resolveOwnerTimeZone` (#13509): the canonical owner-effective
+ * timezone resolver used by the conversational reminder-create path and by
+ * reminder window/dueness processing.
+ *
+ * Before this helper, both lanes anchored owner-local wall time to the HOST
+ * clock (`resolveDefaultTimeZone()` = `Intl` host tz; `UTC` on shared-server /
+ * `TZ=UTC` containers), so "remind me tomorrow at 9am" for a Chicago owner was
+ * stored at 09:00 UTC = 04:00 America/Chicago. These tests pin that the stored
+ * owner-fact timezone is consulted, that it falls back to the host zone only
+ * when no fact is stored (never fabricated), and that an active-travel
+ * destination zone overrides the home zone while travel is live.
+ */
+
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { resolveDefaultTimeZone } from "../defaults.js";
+import {
+  createOwnerFactStore,
+  type OwnerFactProvenance,
+  registerOwnerFactStore,
+  resolveOwnerFactStore,
+  resolveOwnerTimeZone,
+} from "./fact-store.js";
+
+function makeCacheRuntime(): IAgentRuntime {
+  const cache = new Map<string, unknown>();
+  return {
+    agentId: "44444444-4444-4444-4444-444444444444" as UUID,
+    async getCache<T>(key: string): Promise<T | null> {
+      const value = cache.get(key);
+      return value === undefined ? null : (value as T);
+    },
+    async setCache<T>(key: string, value: T): Promise<boolean> {
+      cache.set(key, value);
+      return true;
+    },
+    async deleteCache(key: string): Promise<boolean> {
+      return cache.delete(key);
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function makeRuntimeWithStore(): IAgentRuntime {
+  const runtime = makeCacheRuntime();
+  registerOwnerFactStore(runtime, createOwnerFactStore(runtime));
+  return runtime;
+}
+
+const provenance: OwnerFactProvenance = {
+  source: "profile_save",
+  recordedAt: "2026-07-04T00:00:00.000Z",
+};
+
+const NOW = new Date("2026-07-04T12:00:00.000Z");
+
+describe("resolveOwnerTimeZone (#13509)", () => {
+  it("returns the host default when no owner timezone fact is stored (never fabricated)", async () => {
+    const runtime = makeRuntimeWithStore();
+    const tz = await resolveOwnerTimeZone(runtime, NOW);
+    expect(tz).toBe(resolveDefaultTimeZone());
+  });
+
+  it("returns the owner's stored timezone fact over the host default", async () => {
+    const runtime = makeRuntimeWithStore();
+    await resolveOwnerFactStore(runtime).update(
+      { timezone: "America/Chicago" },
+      provenance,
+    );
+    const tz = await resolveOwnerTimeZone(runtime, NOW);
+    expect(tz).toBe("America/Chicago");
+  });
+
+  it("prefers the active-travel destination zone over the stored home zone while travel is live", async () => {
+    const runtime = makeRuntimeWithStore();
+    const store = resolveOwnerFactStore(runtime);
+    await store.update({ timezone: "America/Chicago" }, provenance);
+    await store.setActiveTravel(
+      {
+        startIso: "2026-07-01T00:00:00.000Z",
+        endIso: "2026-07-10T00:00:00.000Z",
+        destinationTimezone: "Asia/Tokyo",
+      },
+      provenance,
+    );
+    // NOW (2026-07-04) falls inside the travel window.
+    const tz = await resolveOwnerTimeZone(runtime, NOW);
+    expect(tz).toBe("Asia/Tokyo");
+  });
+
+  it("falls back to the host zone when the stored timezone fact is not a valid IANA zone (write path accepts any non-empty string)", async () => {
+    // OwnerFactStore.update only guards timezone with a non-empty-string check,
+    // so a colloquial/garbage value can persist. The reminder date/window math
+    // downstream expects a valid IANA zone and would throw on a bad one, so the
+    // resolver must reject it and fall back rather than propagate it.
+    const runtime = makeRuntimeWithStore();
+    await resolveOwnerFactStore(runtime).update(
+      { timezone: "Central Time (definitely not IANA)" },
+      provenance,
+    );
+    const tz = await resolveOwnerTimeZone(runtime, NOW);
+    expect(tz).toBe(resolveDefaultTimeZone());
+  });
+
+  it("degrades to the host zone when the fact-store read throws (no cache backend), never crashing time resolution", async () => {
+    // A runtime with no cache methods: `resolveOwnerFactStore(...).read()`
+    // throws. The resolver must swallow that into the host-zone fallback so a
+    // reminder create can still schedule (against the host clock) instead of
+    // failing the whole request.
+    const runtimeNoCache = {
+      agentId: "55555555-5555-5555-5555-555555555555" as UUID,
+    } as unknown as IAgentRuntime;
+    const tz = await resolveOwnerTimeZone(runtimeNoCache, NOW);
+    expect(tz).toBe(resolveDefaultTimeZone());
+  });
+
+  it("falls back to the stored home zone once the travel window has lapsed", async () => {
+    const runtime = makeRuntimeWithStore();
+    const store = resolveOwnerFactStore(runtime);
+    await store.update({ timezone: "America/Chicago" }, provenance);
+    await store.setActiveTravel(
+      {
+        startIso: "2026-06-01T00:00:00.000Z",
+        endIso: "2026-06-10T00:00:00.000Z",
+        destinationTimezone: "Asia/Tokyo",
+      },
+      provenance,
+    );
+    // NOW (2026-07-04) is AFTER the travel window ended: home zone wins.
+    const tz = await resolveOwnerTimeZone(runtime, NOW);
+    expect(tz).toBe("America/Chicago");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #13509. The conversational reminder-create path and reminder window/dueness processing both anchored owner-local wall time to the **host clock** (`resolveDefaultTimeZone()` = `Intl` host tz; `UTC` on shared-server / `TZ=UTC` containers), ignoring the owner's stored `timezone` fact. A "remind me tomorrow at 9am" for a Chicago owner was stored at `09:00 UTC` = `04:00 America/Chicago` — confidently wrong by five hours, with the assistant replying "Saved … for tomorrow at 9 AM."

## Root cause (per the issue's seams)

1. `actions/life.ts` conversational create: the timezone chain was `detailString(details,"timeZone") ?? llmPlan.timeZone ?? deferredDraft.timezone ?? windowPolicy.timezone` — none set for a fresh conversational create with no zone spoken; the OwnerFactStore `timezone` fact was never read. `resolveOnceDueAt` then fell back to `resolveDefaultTimeZone()` (host).
2. `lifeops/domains/reminders-service.ts` `processReminders`: `const ownerTimezone = resolveDefaultTimeZone()` — window/dueness math host-anchored.

The **correct pattern already in-tree** is the scheduled-task runner's `defaultOwnerFactsProvider` (`view.timezone ?? resolveDefaultTimeZone()`), which honors the owner fact and the active-travel destination override. This PR generalizes that pattern to the two conversational/processing lanes.

## Fix

- **New `resolveOwnerTimeZone(runtime, now)`** in `owner/fact-store.ts` — the canonical owner-effective-zone resolver. Reads the OwnerFactStore, projects through `ownerFactsToView` so the `activeTravel` destination override is honored (Tokyo case from the issue's corroborating evidence), falls back to the host zone only when no owner fact exists. **Fail-safe**: a fact-store read failure *or* a malformed/non-IANA stored value (the write path only guards `timezone` with a non-empty-string check) degrades to the host zone via `isValidTimeZone`, never throwing inside the reminder date/window math.
- **`life.ts` conversational create**: read the owner-fact zone once, feed it as the fallback in both timezone-resolution chains (`llmCadenceTimeZone` + `resolvedTimeZone`), *after* explicit / planner / deferred-draft / window-policy candidates. This threads through `buildCadenceFromLlmParams` → `resolveOnceDueAt`, so both `dueAt` and the persisted definition `timezone` field carry the owner zone.
- **`reminders-service.ts` `processReminders`**: resolve `ownerTimezone` from the fact (travel-aware) instead of the host clock, so windowed (morning/evening) reminders fire against the owner's day.

Behavior when no owner fact is stored is unchanged (host zone) — no regression to on-device topologies where host tz == owner tz.

## Tests

- **`resolve-owner-timezone.test.ts` (6)**: stored-fact-over-host · no-fact host fallback · active-travel destination override · post-travel home zone · invalid-stored-zone host fallback · read-throws host fallback.
- **`life-reminder-datetime.test.ts`**: new end-to-end — `"remind me tomorrow at 9am"` with `timeZone:null` from the planner and a seeded `America/Chicago` owner fact stores `dueAt` at `09:00 America/Chicago` (not host/UTC) and stamps the definition `timezone`. Existing host-zone "friday at 5pm" test still green (no-fact path unchanged).

Both suites green (33 tests). `tsc` zero new errors in touched files (only pre-existing `@elizaos/*` module-resolution baseline noise on this checkout). biome + error-policy-ratchet clean. codex-reviewed — its one P2 (validate the stored zone before feeding it to reminder math) is fixed + regression-tested.

-- [sol-orch]