### PR TITLE
fix(#13422): migrate ELIZA_PLATFORM raw reads to the alias-aware shared reader

### DIFF
--- a/packages/agent/src/api/misc-routes.ts
+++ b/packages/agent/src/api/misc-routes.ts
@@ -20,6 +20,7 @@ import {
 } from "@elizaos/core";
 import type { ReadJsonBodyOptions } from "@elizaos/shared";
 import {
+  isAndroidMobile,
   PostAgentEventRequestSchema,
   PostCustomActionGenerateRequestSchema,
   PostCustomActionRequestSchema,
@@ -73,7 +74,7 @@ function resolveTerminalShellCommand(): {
     command:
       process.env.CODING_TOOLS_SHELL ||
       process.env.SHELL ||
-      (process.env.ELIZA_PLATFORM === "android" ? "/system/bin/sh" : "/bin/sh"),
+      (isAndroidMobile() ? "/system/bin/sh" : "/bin/sh"),
     argsFor: (command) => ["-c", command],
   };
 }

--- a/packages/agent/src/services/app-package-modules.ts
+++ b/packages/agent/src/services/app-package-modules.ts
@@ -22,6 +22,7 @@ import {
   type AppSessionState,
   type AppViewerAuthMessage,
   hasAppInterface,
+  isMobilePlatform,
   packageNameToAppRouteSlug,
 } from "@elizaos/shared";
 import { isLegacyAppsWorkspaceDiscoveryEnabled } from "../config/feature-flags.ts";
@@ -395,9 +396,7 @@ function bridgeExportToSpecifier(
 function isMobileBundleRuntime(): boolean {
   return (
     (globalThis as { __ELIZA_MOBILE_BUNDLE__?: boolean })
-      .__ELIZA_MOBILE_BUNDLE__ === true ||
-    process.env.ELIZA_PLATFORM === "android" ||
-    process.env.ELIZA_PLATFORM === "ios"
+      .__ELIZA_MOBILE_BUNDLE__ === true || isMobilePlatform()
   );
 }
 

--- a/packages/agent/src/services/shell-execution-router.ts
+++ b/packages/agent/src/services/shell-execution-router.ts
@@ -22,6 +22,7 @@ import path from "node:path";
 import process from "node:process";
 import { sanitizeSpawnEnv } from "@elizaos/core";
 import {
+  isIosMobile,
   type RuntimeExecutionMode,
   resolveRuntimeExecutionMode,
 } from "@elizaos/shared";
@@ -465,5 +466,5 @@ function isInsideOrEqual(root: string, target: string): boolean {
 }
 
 function isIosPlatform(): boolean {
-  return process.env.ELIZA_PLATFORM?.trim().toLowerCase() === "ios";
+  return isIosMobile();
 }

--- a/packages/shared/src/config/runtime-mode.ts
+++ b/packages/shared/src/config/runtime-mode.ts
@@ -5,6 +5,7 @@
  */
 import type { DeploymentTargetConfig } from "../contracts/service-routing.js";
 import { normalizeDeploymentTargetConfig } from "../contracts/service-routing.js";
+import { isIosMobile } from "../runtime-env.js";
 import { isPlainObject } from "../type-guards.js";
 
 export const RUNTIME_EXECUTION_MODES = [
@@ -140,10 +141,7 @@ export function resolveRuntimeExecutionMode(
   const clampForPlatform = (
     mode: RuntimeExecutionMode,
   ): RuntimeExecutionMode =>
-    process.env.ELIZA_PLATFORM?.trim().toLowerCase() === "ios" &&
-    mode === "local-yolo"
-      ? "local-safe"
-      : mode;
+    isIosMobile() && mode === "local-yolo" ? "local-safe" : mode;
 
   for (const key of RUNTIME_EXECUTION_MODE_SETTING_KEYS) {
     const fromSetting = normalizeRuntimeExecutionMode(

--- a/packages/shared/src/runtime-env.test.ts
+++ b/packages/shared/src/runtime-env.test.ts
@@ -9,12 +9,14 @@ import { getBootConfig, setBootConfig } from "./config/boot-config";
 import {
   firstWinningEnvString,
   isAndroidMobile,
+  isIosMobile,
   isLoopbackBindHost,
   isMobilePlatform,
   isWildcardBindHost,
   resolveApiExposePort,
   resolveApiSecurityConfig,
   resolveDesktopApiPortPreference,
+  resolvePlatform,
   resolveRuntimePorts,
   stripOptionalHostPort,
 } from "./runtime-env";
@@ -178,6 +180,54 @@ describe("runtime env alias resolution", () => {
 
     expect(isMobilePlatform(env)).toBe(true);
     expect(isAndroidMobile(env)).toBe(true);
+    expect(isIosMobile(env)).toBe(false);
+    expect(resolvePlatform(env)).toBe("android");
     expect(env).not.toHaveProperty("ELIZA_PLATFORM");
+  });
+
+  it("resolves iOS platform checks from a branded alias without materializing the mirror", () => {
+    const env = {
+      // upper-case + padding proves the resolver trims + lowercases the value
+      ACME_PLATFORM: "  IOS  ",
+    };
+
+    expect(isIosMobile(env)).toBe(true);
+    expect(isMobilePlatform(env)).toBe(true);
+    expect(isAndroidMobile(env)).toBe(false);
+    expect(resolvePlatform(env)).toBe("ios");
+    expect(env).not.toHaveProperty("ELIZA_PLATFORM");
+  });
+
+  it("resolvePlatform returns undefined when neither the canonical key nor a branded alias is set", () => {
+    expect(resolvePlatform({})).toBeUndefined();
+    expect(isMobilePlatform({})).toBe(false);
+    expect(isAndroidMobile({})).toBe(false);
+    expect(isIosMobile({})).toBe(false);
+  });
+
+  it("keeps an explicit ELIZA_PLATFORM ahead of the branded alias", () => {
+    const env = {
+      ACME_PLATFORM: "android",
+      ELIZA_PLATFORM: "ios",
+    };
+
+    // canonical key wins; the branded alias never suppresses a present
+    // ELIZA_ value (matches the direct-key precedence contract used for
+    // ports / API security above).
+    expect(resolvePlatform(env)).toBe("ios");
+    expect(isIosMobile(env)).toBe(true);
+    expect(isAndroidMobile(env)).toBe(false);
+  });
+
+  it("a blank ELIZA_PLATFORM does not shadow a present branded alias", () => {
+    const env = {
+      ELIZA_PLATFORM: "   ",
+      ACME_PLATFORM: "android",
+    };
+
+    // empty-is-unset: the blank canonical value must fall through to the
+    // branded alias rather than resolving as "no platform".
+    expect(resolvePlatform(env)).toBe("android");
+    expect(isAndroidMobile(env)).toBe(true);
   });
 });

--- a/packages/shared/src/runtime-env.ts
+++ b/packages/shared/src/runtime-env.ts
@@ -431,15 +431,31 @@ export function syncResolvedApiPort(
 const MOBILE_PLATFORM_VALUES = new Set(["android", "ios"]);
 
 export function isMobilePlatform(env: RuntimeEnvRecord = process.env): boolean {
-  const raw = resolveEnvValue(env, "ELIZA_PLATFORM")?.trim().toLowerCase();
+  const raw = resolvePlatform(env);
   if (!raw) return false;
   return MOBILE_PLATFORM_VALUES.has(raw);
 }
 
 export function isAndroidMobile(env: RuntimeEnvRecord = process.env): boolean {
-  return (
-    resolveEnvValue(env, "ELIZA_PLATFORM")?.trim().toLowerCase() === "android"
-  );
+  return resolvePlatform(env) === "android";
+}
+
+export function isIosMobile(env: RuntimeEnvRecord = process.env): boolean {
+  return resolvePlatform(env) === "ios";
+}
+
+/**
+ * The normalized `ELIZA_PLATFORM` value (trimmed + lowercased), resolved through
+ * the brand<->eliza alias table so a rebranded `<PREFIX>_PLATFORM` is honoured
+ * WITHOUT depending on the `syncBrandEnvToEliza` mirror mutation (arch-audit
+ * #12251). Returns `undefined` when neither the canonical key nor a branded
+ * alias is set — callers that only care about the mobile embeddings should
+ * prefer {@link isMobilePlatform} / {@link isAndroidMobile} / {@link isIosMobile}.
+ */
+export function resolvePlatform(
+  env: RuntimeEnvRecord = process.env,
+): string | undefined {
+  return resolveEnvValue(env, "ELIZA_PLATFORM")?.trim().toLowerCase();
 }
 
 export function resolveElizaRuntimeEnv(

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -24,6 +24,7 @@ import {
 } from "@elizaos/core";
 import {
 	buildHuggingFaceResolveUrl,
+	isMobilePlatform,
 	resolveHubAuthHeaders,
 	MODEL_CATALOG as SHARED_MODEL_CATALOG,
 	type CatalogModel as SharedCatalogModel,
@@ -341,8 +342,7 @@ function huggingFaceResolveUrl(model: CatalogModel): string {
 }
 
 function shouldUseMobileDns(): boolean {
-	const platform = process.env.ELIZA_PLATFORM?.toLowerCase();
-	return platform === "android" || platform === "ios";
+	return isMobilePlatform();
 }
 
 const mobileLookup: http.RequestOptions["lookup"] = (

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
@@ -27,6 +27,7 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { logger, resolveStateDir } from "@elizaos/core";
+import { resolvePlatform } from "@elizaos/shared";
 import { StreamingEchoDelayCalibrator } from "@elizaos/shared/voice/aec";
 import {
 	type AttributedTurn,
@@ -273,10 +274,11 @@ function resolveEchoDelaySamples(): number {
 		// `linux`. Using the resolved id makes the iOS (25 ms) / AOSP-Android
 		// (45 ms) seeds in the #9653 table reachable on device instead of
 		// collapsing to the host's darwin (20 ms) / linux (30 ms) seed.
+		const resolvedPlatform = resolvePlatform();
 		const platformId =
-			process.env.ELIZA_PLATFORM === "ios"
+			resolvedPlatform === "ios"
 				? "ios"
-				: process.env.ELIZA_PLATFORM === "android"
+				: resolvedPlatform === "android"
 					? "android"
 					: process.platform;
 		return platformPlaybackDelaySamples(platformId, AUDIO_FRAME_SAMPLE_RATE);


### PR DESCRIPTION
Closes part of #13422 (the `ELIZA_PLATFORM` slice of the #12251 brand<->ELIZA process-env alias-sync cleanup).

## Why

Raw `process.env.ELIZA_PLATFORM` reads only resolve a branded `<PREFIX>_PLATFORM` because the `syncBrandEnvToEliza` mirror mutation copies the branded value onto the canonical `ELIZA_*` key at boot. Every such raw read is a dependency on that mutation. To make the final sync-layer deletion (#13423) safe, these reads must resolve through the alias-aware, **non-mutating** reader instead — so a non-ELIZA brand still works once the mirror is gone.

`@elizaos/shared` already ships alias-aware platform helpers (`isMobilePlatform` / `isAndroidMobile`, resolved via `resolveEnvValue` → the BootConfig alias table). This PR extends that pattern and migrates the remaining shared-importing `ELIZA_PLATFORM` read sites onto it.

## Changes

**shared/runtime-env.ts** — add two alias-aware helpers, symmetric with the existing ones:
- `resolvePlatform(env?)` → trimmed+lowercased `ELIZA_PLATFORM` resolved through the alias table, or `undefined`.
- `isIosMobile(env?)` → `resolvePlatform() === "ios"`.
- `isMobilePlatform` / `isAndroidMobile` now delegate to `resolvePlatform()` so all four share one resolution path.

**Migrated raw-read sites (all already import `@elizaos/shared`):**

| File | Before | After |
|---|---|---|
| `shared/config/runtime-mode.ts` | `process.env.ELIZA_PLATFORM…=== "ios"` | `isIosMobile()` |
| `agent/api/misc-routes.ts` | `=== "android" ? /system/bin/sh …` | `isAndroidMobile()` |
| `agent/services/app-package-modules.ts` | `=== "android" \|\| === "ios"` | `isMobilePlatform()` |
| `agent/services/shell-execution-router.ts` | `?.trim().toLowerCase() === "ios"` | `isIosMobile()` |
| `plugin-local-inference/local-inference-routes.ts` | `?.toLowerCase(); android\|\|ios` | `isMobilePlatform()` |
| `plugin-local-inference/…/live-diarization-session.ts` | `=== "ios" ? … : === "android" …` | `resolvePlatform()` |

**Deliberately NOT migrated (documented):**
- `packages/agent/src/bin.ts` — runs at the earliest boot phase, **before** the runtime/BootConfig (and thus the alias table) is populated; its raw reads are the intended early-boot mechanism, and one is a diagnostic log of the literal env value. Importing shared here to resolve aliases would be both premature and heavy.
- Mobile bridges (`plugin-capacitor-bridge/{android,ios}/bridge.ts`) that self-`||=`/assign `ELIZA_PLATFORM` are **writes**, not reads.
- The `ELIZA_PLATFORM` **writers/deleters** in `agent/runtime/eliza.ts` are the canonical writer path (out of scope; keep the mirror fallback per the issue).

## Tests

Extends the existing non-ELIZA (`ACME_`) brand fixture in `runtime-env.test.ts` (which already proved `isMobilePlatform`/`isAndroidMobile` resolve from a branded alias) with:
- iOS resolution + trim/lowercase normalization (`"  IOS  "` → `"ios"`),
- `resolvePlatform` returns `undefined` when neither the canonical key nor an alias is set,
- explicit `ELIZA_PLATFORM` takes precedence over the branded alias,
- a **blank** `ELIZA_PLATFORM` does not shadow a present branded alias (empty-is-unset fall-through),
- and asserts the `ELIZA_*` mirror key is **never materialized** on the env record.

## Verification

- `runtime-env.test.ts` → **24 pass**; `config/__tests__/runtime-mode.test.ts` → **4 pass**.
- `tsgo --noEmit` clean on every touched file. (The remaining tsgo output is pre-existing environmental noise: unbuilt `i18n/generated/*` data + `file-type`/`fast-redact` resolution against the shared bun store — present on develop, unrelated to this diff.)
- Codex review (`codex review --uncommitted`): *"routes platform checks through the shared runtime-env helpers and adds coverage for branded platform aliases. I did not identify a discrete regression."*

No secrets. No changes to vite/index.html/client-base/bun.lock/workflows.

— [sol-orch]

Author: Sol <sol@shad0w.xyz>
Co-authored-by: wakesync <shadow@shad0w.xyz>