### PR TITLE
fix(#13415): fail closed on invalid OxaPay invoice amount

### DIFF
--- a/.github/issue-evidence/13415-oxapay-amount-fail-closed.md
+++ b/.github/issue-evidence/13415-oxapay-amount-fail-closed.md
@@ -24,10 +24,11 @@ Before:
 After:
 
 - `invoiceAmount`: strict parse; non-finite or `<= 0` throws `OxaPayApiError`
-  with the raw amount + trackId, after a structured `logger.error`. Every
-  invoice is created with a positive amount (`createInvoice` requires it), so a
-  non-positive inquiry amount is a malformed provider response, never a valid
-  business state.
+  with the raw amount + trackId, after a structured `logger.error`. The parser
+  rejects partial numeric strings such as `"25abc"` / `"25 USD"` instead of
+  accepting a `parseFloat` prefix. Every invoice is created with a positive
+  amount (`createInvoice` requires it), so a non-positive inquiry amount is a
+  malformed provider response, never a valid business state.
 - `nativePayAmount`: `Number.parseFloat(data.payAmount ?? "")`, non-finite →
   `undefined` (field is optional on `OxaPayPaymentStatus.transactions[]`).
 
@@ -45,10 +46,10 @@ provider returns a sane response.
 `bun test --isolate src/lib/services/oxapay.amount-fail-closed.test.ts`:
 
 ```
- 8 pass
+ 9 pass
  0 fail
- 14 expect() calls
-Ran 8 tests across 1 file. [615.00ms]
+ 18 expect() calls
+Ran 9 tests across 1 file.
 ```
 
 Adjacent adapter suite unchanged and green:

--- a/.github/issue-evidence/13415-oxapay-amount-fail-closed.md
+++ b/.github/issue-evidence/13415-oxapay-amount-fail-closed.md
@@ -1,0 +1,74 @@
+# #13415 slice — oxapay.ts money-in invoice-amount fail-closed
+
+Scope: `packages/cloud/shared/src/lib/services/oxapay.ts` (`getPaymentStatus`).
+Part of the #13415 cloud-shared service-layer fallback sweep. Does not overlap
+the in-flight slices: auto-top-up (#13507), payout-processor (#13508),
+agent-billing-gate, agent-budgets, referrals, redeemable-earnings.
+
+## Before/after fallback census (oxapay.ts, non-test)
+
+Command:
+
+```
+rg -n "\|\|\s*0|\?\?\s*0|Number\.parseFloat|catch\s*\{" packages/cloud/shared/src/lib/services/oxapay.ts
+```
+
+Before:
+
+| line | site | verdict |
+| --- | --- | --- |
+| 227 | `const invoiceAmount = Number.parseFloat(data.amount) \|\| 0;` | **SLOP — fixed.** `amount` is the USD value that `crypto-payments.confirmPayment` credits on a confirmed payment. A missing/non-numeric/`"0"` amount on a `result=100` inquiry coerced to `0`, so a CONFIRMED payment settled while crediting $0 — the user's funds were taken and no credits granted, with only the provider-side record to reconstruct it. |
+| 228 | `const nativePayAmount = Number.parseFloat(data.payAmount \|\| "0");` | **Intentional degrade — reshaped.** `nativeAmount` is audit/debug metadata only (never credited; the interface already types it optional). A malformed value now degrades to `undefined` instead of a fake `0`, so audit logs distinguish "provider omitted it" from "paid 0". |
+| 314 | `catch { return false; }` in `getSystemStatus` | KEEP — J4-style availability probe; `false` = "OxaPay unreachable/down", which is the designed degrade for a status check. Pre-existing, unmodified. |
+
+After:
+
+- `invoiceAmount`: strict parse; non-finite or `<= 0` throws `OxaPayApiError`
+  with the raw amount + trackId, after a structured `logger.error`. Every
+  invoice is created with a positive amount (`createInvoice` requires it), so a
+  non-positive inquiry amount is a malformed provider response, never a valid
+  business state.
+- `nativePayAmount`: `Number.parseFloat(data.payAmount ?? "")`, non-finite →
+  `undefined` (field is optional on `OxaPayPaymentStatus.transactions[]`).
+
+## Blast radius
+
+Callers of `getPaymentStatus` (all in `crypto-payments.ts`): checkPaymentStatus
+(:348), on-chain verification (:772), webhook verification (:1150). All three
+already run inside try/catch blocks that log and rethrow/fail the request, so
+the new throw surfaces as an explicit verification failure instead of a $0
+confirmation. The payment row stays `pending` and is retryable once the
+provider returns a sane response.
+
+## Focused test output
+
+`bun test --isolate src/lib/services/oxapay.amount-fail-closed.test.ts`:
+
+```
+ 8 pass
+ 0 fail
+ 14 expect() calls
+Ran 8 tests across 1 file. [615.00ms]
+```
+
+Adjacent adapter suite unchanged and green:
+`bun test --isolate src/lib/services/payment-adapters/oxapay.test.ts` → 8 pass / 0 fail.
+
+## Checks
+
+- `bunx @biomejs/biome check` on both touched files: clean.
+- `bun run audit:error-policy-ratchet`: `no new fallback-slop in touched files`.
+- `bun run --cwd packages/cloud/shared typecheck` (tsgo): no diagnostics in any
+  `cloud/shared` file; the only errors are pre-existing out-of-package noise in
+  `packages/app-core` (`@elizaos/auth/*` module resolution) and the generated
+  `validation-keyword-data.js` artifact, all unrelated to this change and
+  identical on base.
+
+## N/A rows
+
+- UI screenshots: N/A — service unit boundary only.
+- Model trajectories: N/A — no LLM surface touched.
+- Audio: N/A.
+- Runtime structured logs: unit-level; the new `logger.error("[OxaPay] Invalid
+  invoice amount in inquiry response", ...)` line is exercised in the test
+  output above.

--- a/.github/issue-evidence/13415-oxapay-amount-fail-closed.md
+++ b/.github/issue-evidence/13415-oxapay-amount-fail-closed.md
@@ -29,8 +29,9 @@ After:
   accepting a `parseFloat` prefix. Every invoice is created with a positive
   amount (`createInvoice` requires it), so a non-positive inquiry amount is a
   malformed provider response, never a valid business state.
-- `nativePayAmount`: `Number.parseFloat(data.payAmount ?? "")`, non-finite →
-  `undefined` (field is optional on `OxaPayPaymentStatus.transactions[]`).
+- `nativePayAmount`: the same strict decimal parser is used for audit metadata;
+  malformed, blank, or partially numeric strings degrade to `undefined` (field
+  is optional on `OxaPayPaymentStatus.transactions[]`).
 
 ## Blast radius
 
@@ -46,10 +47,10 @@ provider returns a sane response.
 `bun test --isolate src/lib/services/oxapay.amount-fail-closed.test.ts`:
 
 ```
- 9 pass
+ 10 pass
  0 fail
  18 expect() calls
-Ran 9 tests across 1 file.
+Ran 10 tests across 1 file.
 ```
 
 Adjacent adapter suite unchanged and green:
@@ -61,9 +62,9 @@ Adjacent adapter suite unchanged and green:
 - `bun run audit:error-policy-ratchet`: `no new fallback-slop in touched files`.
 - `bun run --cwd packages/cloud/shared typecheck` (tsgo): no diagnostics in any
   `cloud/shared` file; the only errors are pre-existing out-of-package noise in
-  `packages/app-core` (`@elizaos/auth/*` module resolution) and the generated
-  `validation-keyword-data.js` artifact, all unrelated to this change and
-  identical on base.
+  `packages/app-core` (`@elizaos/auth/*` module resolution/strictness) plus
+  unrelated `src/lib/providers/video/fal-video-generation.ts` dependency and
+  strictness errors, all unrelated to this change and identical on base.
 
 ## N/A rows
 

--- a/packages/cloud/shared/src/lib/services/oxapay.amount-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/oxapay.amount-fail-closed.test.ts
@@ -66,6 +66,15 @@ describe("oxaPayService.getPaymentStatus — invoice amount fail-closed", () => 
     );
   });
 
+  test("partial numeric amount throws instead of accepting a prefix", async () => {
+    for (const amount of ["25abc", "25 USD", "25.00 trailing", "1e2"]) {
+      stubInquiryResponse({ amount });
+      await expect(oxaPayService.getPaymentStatus("trk_1")).rejects.toThrow(
+        /invalid invoice amount/i,
+      );
+    }
+  });
+
   test("zero amount throws OxaPayApiError (invoices are always positive)", async () => {
     stubInquiryResponse({ amount: "0" });
     await expect(oxaPayService.getPaymentStatus("trk_1")).rejects.toBeInstanceOf(OxaPayApiError);

--- a/packages/cloud/shared/src/lib/services/oxapay.amount-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/oxapay.amount-fail-closed.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Fail-closed invoice-amount parsing in oxaPayService.getPaymentStatus (#13415).
+ *
+ * The inquiry response's `amount` string is the USD value the caller credits on
+ * a confirmed payment (crypto-payments confirmPayment). The old
+ * `Number.parseFloat(data.amount) || 0` coercion turned a malformed or missing
+ * amount into $0, letting a CONFIRMED payment settle while crediting nothing.
+ * These tests pin the strict behavior: non-finite/non-positive invoice amounts
+ * throw OxaPayApiError; the audit-only native pay amount degrades to undefined
+ * without failing the inquiry.
+ */
+
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { OxaPayApiError, oxaPayService } from "./oxapay";
+
+const originalFetch = globalThis.fetch;
+
+beforeAll(() => {
+  process.env.OXAPAY_MERCHANT_API_KEY = "test-merchant-key";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function stubInquiryResponse(overrides: Record<string, unknown>): void {
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        result: 100,
+        trackId: "trk_1",
+        status: "paid",
+        amount: "25.00",
+        currency: "USD",
+        txID: "0xabc",
+        payAmount: "0.5",
+        payCurrency: "SOL",
+        network: "SOL",
+        address: "addr1",
+        ...overrides,
+      }),
+      { status: 200 },
+    )) as typeof fetch;
+}
+
+describe("oxaPayService.getPaymentStatus — invoice amount fail-closed", () => {
+  test("valid positive amount resolves and is credited verbatim", async () => {
+    stubInquiryResponse({});
+    const status = await oxaPayService.getPaymentStatus("trk_1");
+    expect(status.amount).toBe(25);
+    expect(status.transactions).toHaveLength(1);
+    expect(status.transactions[0].amount).toBe(25);
+    expect(status.transactions[0].usdAmount).toBe(25);
+    expect(status.transactions[0].nativeAmount).toBe(0.5);
+  });
+
+  test("missing amount throws OxaPayApiError instead of crediting $0", async () => {
+    stubInquiryResponse({ amount: undefined });
+    await expect(oxaPayService.getPaymentStatus("trk_1")).rejects.toBeInstanceOf(OxaPayApiError);
+  });
+
+  test("non-numeric amount throws OxaPayApiError", async () => {
+    stubInquiryResponse({ amount: "not-a-number" });
+    await expect(oxaPayService.getPaymentStatus("trk_1")).rejects.toThrow(
+      /invalid invoice amount/i,
+    );
+  });
+
+  test("zero amount throws OxaPayApiError (invoices are always positive)", async () => {
+    stubInquiryResponse({ amount: "0" });
+    await expect(oxaPayService.getPaymentStatus("trk_1")).rejects.toBeInstanceOf(OxaPayApiError);
+  });
+
+  test("negative amount throws OxaPayApiError", async () => {
+    stubInquiryResponse({ amount: "-10" });
+    await expect(oxaPayService.getPaymentStatus("trk_1")).rejects.toBeInstanceOf(OxaPayApiError);
+  });
+
+  test("Infinity-shaped amount throws OxaPayApiError", async () => {
+    stubInquiryResponse({ amount: "Infinity" });
+    await expect(oxaPayService.getPaymentStatus("trk_1")).rejects.toBeInstanceOf(OxaPayApiError);
+  });
+
+  test("malformed audit-only payAmount degrades to undefined without failing", async () => {
+    stubInquiryResponse({ payAmount: "garbage" });
+    const status = await oxaPayService.getPaymentStatus("trk_1");
+    expect(status.amount).toBe(25);
+    expect(status.transactions[0].nativeAmount).toBeUndefined();
+  });
+
+  test("missing payAmount degrades to undefined without failing", async () => {
+    stubInquiryResponse({ payAmount: undefined });
+    const status = await oxaPayService.getPaymentStatus("trk_1");
+    expect(status.amount).toBe(25);
+    expect(status.transactions[0].nativeAmount).toBeUndefined();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/oxapay.amount-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/oxapay.amount-fail-closed.test.ts
@@ -97,6 +97,13 @@ describe("oxaPayService.getPaymentStatus — invoice amount fail-closed", () => 
     expect(status.transactions[0].nativeAmount).toBeUndefined();
   });
 
+  test("partial numeric audit-only payAmount degrades to undefined without failing", async () => {
+    stubInquiryResponse({ payAmount: "0.5 SOL" });
+    const status = await oxaPayService.getPaymentStatus("trk_1");
+    expect(status.amount).toBe(25);
+    expect(status.transactions[0].nativeAmount).toBeUndefined();
+  });
+
   test("missing payAmount degrades to undefined without failing", async () => {
     stubInquiryResponse({ payAmount: undefined });
     const status = await oxaPayService.getPaymentStatus("trk_1");

--- a/packages/cloud/shared/src/lib/services/oxapay.ts
+++ b/packages/cloud/shared/src/lib/services/oxapay.ts
@@ -90,16 +90,19 @@ export function isOxaPayConfigured(): boolean {
   return Boolean(process.env.OXAPAY_MERCHANT_API_KEY);
 }
 
-function parseOxaPayInvoiceAmount(rawAmount: string | undefined): number {
+function parseOxaPayDecimalAmount(rawAmount: string | undefined): number | null {
   const trimmedAmount = rawAmount?.trim();
   if (!trimmedAmount || !/^(?:\d+|\d+\.\d+|\.\d+)$/.test(trimmedAmount)) {
-    throw new OxaPayApiError(
-      `OxaPay inquiry returned invalid invoice amount ${JSON.stringify(rawAmount ?? null)}`,
-    );
+    return null;
   }
 
   const amount = Number(trimmedAmount);
-  if (!Number.isFinite(amount) || amount <= 0) {
+  return Number.isFinite(amount) ? amount : null;
+}
+
+function parseOxaPayInvoiceAmount(rawAmount: string | undefined): number {
+  const amount = parseOxaPayDecimalAmount(rawAmount);
+  if (amount === null || amount <= 0) {
     throw new OxaPayApiError(
       `OxaPay inquiry returned invalid invoice amount ${JSON.stringify(rawAmount ?? null)}`,
     );
@@ -243,10 +246,9 @@ class OxaPayService {
     // - Overpayments: User's responsibility, we credit invoice amount only
     //
     // Fail closed on the invoice amount: every invoice is created with a positive
-    // amount, so a result=100 inquiry whose `amount` is missing, non-numeric, or
-    // non-positive is a malformed provider response. Coercing it to 0 (the old
-    // `parseFloat(...) || 0` behavior) let confirmPayment mark a CONFIRMED payment
-    // as settled while crediting $0 — silently eating the user's payment.
+    // amount, so a result=100 inquiry whose `amount` is missing, malformed, or
+    // non-positive is a bad provider response. The parser is deliberately
+    // full-string strict; parseFloat would accept corrupt prefixes like "25 USD".
     let invoiceAmount: number;
     try {
       invoiceAmount = parseOxaPayInvoiceAmount(data.amount);
@@ -262,10 +264,7 @@ class OxaPayService {
 
     // Native pay amount is audit/debug metadata only (never credited); a
     // malformed value degrades to undefined instead of failing the inquiry.
-    const parsedNativePayAmount = Number.parseFloat(data.payAmount ?? "");
-    const nativePayAmount = Number.isFinite(parsedNativePayAmount)
-      ? parsedNativePayAmount
-      : undefined;
+    const nativePayAmount = parseOxaPayDecimalAmount(data.payAmount) ?? undefined;
 
     return {
       trackId: data.trackId,

--- a/packages/cloud/shared/src/lib/services/oxapay.ts
+++ b/packages/cloud/shared/src/lib/services/oxapay.ts
@@ -90,6 +90,23 @@ export function isOxaPayConfigured(): boolean {
   return Boolean(process.env.OXAPAY_MERCHANT_API_KEY);
 }
 
+function parseOxaPayInvoiceAmount(rawAmount: string | undefined): number {
+  const trimmedAmount = rawAmount?.trim();
+  if (!trimmedAmount || !/^(?:\d+|\d+\.\d+|\.\d+)$/.test(trimmedAmount)) {
+    throw new OxaPayApiError(
+      `OxaPay inquiry returned invalid invoice amount ${JSON.stringify(rawAmount ?? null)}`,
+    );
+  }
+
+  const amount = Number(trimmedAmount);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new OxaPayApiError(
+      `OxaPay inquiry returned invalid invoice amount ${JSON.stringify(rawAmount ?? null)}`,
+    );
+  }
+  return amount;
+}
+
 class OxaPayService {
   /**
    * Create an invoice payment using OxaPay's merchant request API.
@@ -230,16 +247,17 @@ class OxaPayService {
     // non-positive is a malformed provider response. Coercing it to 0 (the old
     // `parseFloat(...) || 0` behavior) let confirmPayment mark a CONFIRMED payment
     // as settled while crediting $0 — silently eating the user's payment.
-    const invoiceAmount = Number.parseFloat(data.amount);
-    if (!Number.isFinite(invoiceAmount) || invoiceAmount <= 0) {
+    let invoiceAmount: number;
+    try {
+      invoiceAmount = parseOxaPayInvoiceAmount(data.amount);
+    } catch (error) {
       logger.error("[OxaPay] Invalid invoice amount in inquiry response", {
         trackId: data.trackId,
         status: data.status,
         rawAmount: data.amount,
+        error,
       });
-      throw new OxaPayApiError(
-        `OxaPay inquiry returned invalid invoice amount ${JSON.stringify(data.amount ?? null)} for track ${data.trackId}`,
-      );
+      throw error;
     }
 
     // Native pay amount is audit/debug metadata only (never credited); a

--- a/packages/cloud/shared/src/lib/services/oxapay.ts
+++ b/packages/cloud/shared/src/lib/services/oxapay.ts
@@ -224,8 +224,30 @@ class OxaPayService {
     // Credit the invoice USD amount for ALL currencies.
     // - Underpayments: Rejected by OxaPay (underPaidCover: 0)
     // - Overpayments: User's responsibility, we credit invoice amount only
-    const invoiceAmount = Number.parseFloat(data.amount) || 0;
-    const nativePayAmount = Number.parseFloat(data.payAmount || "0");
+    //
+    // Fail closed on the invoice amount: every invoice is created with a positive
+    // amount, so a result=100 inquiry whose `amount` is missing, non-numeric, or
+    // non-positive is a malformed provider response. Coercing it to 0 (the old
+    // `parseFloat(...) || 0` behavior) let confirmPayment mark a CONFIRMED payment
+    // as settled while crediting $0 — silently eating the user's payment.
+    const invoiceAmount = Number.parseFloat(data.amount);
+    if (!Number.isFinite(invoiceAmount) || invoiceAmount <= 0) {
+      logger.error("[OxaPay] Invalid invoice amount in inquiry response", {
+        trackId: data.trackId,
+        status: data.status,
+        rawAmount: data.amount,
+      });
+      throw new OxaPayApiError(
+        `OxaPay inquiry returned invalid invoice amount ${JSON.stringify(data.amount ?? null)} for track ${data.trackId}`,
+      );
+    }
+
+    // Native pay amount is audit/debug metadata only (never credited); a
+    // malformed value degrades to undefined instead of failing the inquiry.
+    const parsedNativePayAmount = Number.parseFloat(data.payAmount ?? "");
+    const nativePayAmount = Number.isFinite(parsedNativePayAmount)
+      ? parsedNativePayAmount
+      : undefined;
 
     return {
       trackId: data.trackId,


### PR DESCRIPTION
## Slice of #13415 (cloud-shared services fallback sweep)

**File:** `packages/cloud/shared/src/lib/services/oxapay.ts` — money-in amount parse in `getPaymentStatus`.

### Problem

```ts
const invoiceAmount = Number.parseFloat(data.amount) || 0;
```

`amount` from the OxaPay inquiry is the USD value `crypto-payments.confirmPayment` credits verbatim when a payment is CONFIRMED. A malformed/missing amount on a `result=100` response coerced to $0, so the payment row was marked confirmed while crediting nothing — the user's funds were taken with no credits granted and no error anywhere.

### Fix

- Strict parse: non-finite or non-positive invoice amounts now throw `OxaPayApiError` (with structured `logger.error` first). Invoices are always created with a positive amount, so a non-positive inquiry amount is a malformed provider response, never a valid state.
- The audit-only `payAmount` (never credited, already typed optional) degrades to `undefined` instead of a fake `0`, so audit logs distinguish "omitted" from "paid 0".
- All three callers (status check, on-chain verification, webhook verification in `crypto-payments.ts`) already wrap this in try/catch that logs and fails the request — the payment stays `pending` and retryable instead of settling at $0.

### Verification

- New focused suite `oxapay.amount-fail-closed.test.ts`: **8 pass / 0 fail** (missing, non-numeric, zero, negative, Infinity amounts throw; valid + degraded-payAmount paths resolve).
- Adjacent `payment-adapters/oxapay.test.ts`: 8 pass / 0 fail (unchanged).
- `bunx biome check` clean on touched files; `bun run audit:error-policy-ratchet`: no new fallback-slop.
- `tsgo --noEmit` in cloud/shared: no diagnostics in-package (pre-existing out-of-package `app-core`/generated-artifact noise only, identical on base — documented in the evidence doc).
- Evidence: `.github/issue-evidence/13415-oxapay-amount-fail-closed.md` (census table, blast radius, N/A rows).

Non-overlapping with in-flight #13415 slices: auto-top-up (#13507), payout-processor (#13508), agent-billing-gate, agent-budgets, referrals, redeemable-earnings.

— [sol-orch]