### PR TITLE
fix(#13519): hold a terminal completing-sign-in state during OAuth callback exchange

### DIFF
--- a/packages/ui/src/cloud/public-pages/lib/steward-session.callback-detect.test.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.callback-detect.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+/**
+ * Non-destructive OAuth/token callback detection for the login surface.
+ *
+ * `hasStewardOAuthCallbackInUrl()` peeks the URL (`?code`, `?token`, `#code`,
+ * `#token`, and a snapshotted `__stewardOAuthHash`) WITHOUT stripping anything,
+ * so the login section can hold a terminal "completing sign-in" state during the
+ * in-flight token exchange instead of re-rendering the provider options (the
+ * flash-back-to-sign-in-options bug, #13519). These tests pin that it detects
+ * every callback form and stays false for a plain /login load, and prove it does
+ * not mutate history the way the destructive `consume*` helpers do.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { hasStewardOAuthCallbackInUrl } from "./steward-session";
+
+const realLocation = window.location;
+
+function setUrl({
+  search = "",
+  hash = "",
+}: {
+  search?: string;
+  hash?: string;
+}): void {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...realLocation, pathname: "/login", search, hash },
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: realLocation,
+  });
+  delete (window as Window & { __stewardOAuthHash?: string })
+    .__stewardOAuthHash;
+  vi.restoreAllMocks();
+});
+
+describe("hasStewardOAuthCallbackInUrl", () => {
+  it("is false on a plain /login load (no callback params)", () => {
+    setUrl({ search: "", hash: "" });
+    expect(hasStewardOAuthCallbackInUrl()).toBe(false);
+  });
+
+  it("is false when only an unrelated query param is present", () => {
+    setUrl({ search: "?returnTo=%2Fdashboard", hash: "" });
+    expect(hasStewardOAuthCallbackInUrl()).toBe(false);
+  });
+
+  it("detects an OAuth nonce code in the query string", () => {
+    setUrl({ search: "?code=abc123", hash: "" });
+    expect(hasStewardOAuthCallbackInUrl()).toBe(true);
+  });
+
+  it("detects a legacy token in the query string", () => {
+    setUrl({ search: "?token=jwt.value.here", hash: "" });
+    expect(hasStewardOAuthCallbackInUrl()).toBe(true);
+  });
+
+  it("detects an OAuth code in the URL hash fragment", () => {
+    setUrl({ search: "", hash: "#code=abc123" });
+    expect(hasStewardOAuthCallbackInUrl()).toBe(true);
+  });
+
+  it("detects a legacy token in the URL hash fragment", () => {
+    setUrl({ search: "", hash: "#token=jwt.value.here&refreshToken=r" });
+    expect(hasStewardOAuthCallbackInUrl()).toBe(true);
+  });
+
+  it("detects a snapshotted __stewardOAuthHash code even when window.location.hash is empty", () => {
+    setUrl({ search: "", hash: "" });
+    (window as Window & { __stewardOAuthHash?: string }).__stewardOAuthHash =
+      "#code=snapshotted";
+    expect(hasStewardOAuthCallbackInUrl()).toBe(true);
+  });
+
+  it("is false for an empty hash fragment ('#')", () => {
+    setUrl({ search: "", hash: "#" });
+    expect(hasStewardOAuthCallbackInUrl()).toBe(false);
+  });
+
+  it("does not mutate history/search when peeking (unlike the consume* helpers)", () => {
+    setUrl({ search: "?code=abc123", hash: "" });
+    const replaceSpy = vi.spyOn(window.history, "replaceState");
+    expect(hasStewardOAuthCallbackInUrl()).toBe(true);
+    // Second call still detects the callback — nothing was consumed/stripped.
+    expect(hasStewardOAuthCallbackInUrl()).toBe(true);
+    expect(window.location.search).toBe("?code=abc123");
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.ts
@@ -78,6 +78,29 @@ export async function syncStewardSessionCookie(
 }
 
 /**
+ * Non-destructively detect whether the current URL is an OAuth/token callback
+ * (`?code=`, `#code=`, `?token=`, or `#token=`, including a snapshotted
+ * `__stewardOAuthHash`). Unlike the `consume*` helpers this does NOT strip
+ * anything from history — it only peeks — so it is safe to call from a render
+ * pass to gate the UI into a "completing sign-in" state while the async
+ * exchange runs. Without this gate the login section renders the full provider
+ * options during the exchange round-trip, which reads as the login flashing
+ * back to the sign-in options after a successful callback.
+ */
+export function hasStewardOAuthCallbackInUrl(): boolean {
+  if (typeof window === "undefined") return false;
+
+  const query = new URLSearchParams(window.location.search);
+  if (query.get("code") || query.get("token")) return true;
+
+  const stewardWindow = window as Window & { __stewardOAuthHash?: string };
+  const hash = stewardWindow.__stewardOAuthHash || window.location.hash;
+  if (!hash || hash.length < 2) return false;
+  const hashParams = new URLSearchParams(hash.replace(/^#/, ""));
+  return Boolean(hashParams.get("code") || hashParams.get("token"));
+}
+
+/**
  * Read the one-time OAuth code from `?code=` or `#code=` (nonce-exchange flow).
  * Strips it from history immediately so it can't leak via history / shared URLs,
  * then returns it. Null when no code is present.

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.callback-state.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.callback-state.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+
+/**
+ * #13519: after a successful OAuth callback the login section must NOT re-render
+ * the provider options while the token exchange is in flight — that re-render is
+ * what read as the login "flashing back to the sign-in options" after success.
+ *
+ * This test renders the section with an OAuth callback present in the URL and a
+ * never-resolving exchange, and asserts it holds a terminal "Completing
+ * sign-in…" state (no email input, no passkey/OAuth buttons). A companion case
+ * asserts a callback FAILURE clears that state and surfaces the error + the
+ * options again, so a real failure is never hidden behind the spinner.
+ */
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const callbackState = vi.hoisted(() => ({
+  hasCallback: true,
+  exchange: (): Promise<{ token?: string }> => new Promise(() => {}),
+}));
+
+vi.mock("../../lib/steward-session", () => ({
+  hasStewardOAuthCallbackInUrl: () => callbackState.hasCallback,
+  consumeStewardCodeFromQuery: () => "callback-code",
+  consumeStewardTokensFromHash: () => null,
+  exchangeStewardCodeViaApi: () => callbackState.exchange(),
+  refreshStewardSessionViaCookie: () => Promise.resolve({ ok: true as const }),
+  syncStewardSessionCookie: () => Promise.resolve(),
+}));
+
+vi.mock("@stwd/sdk", () => ({
+  StewardAuth: class {
+    getSession() {
+      return null;
+    }
+    getProviders() {
+      return Promise.resolve({
+        passkey: true,
+        email: true,
+        siwe: false,
+        siws: false,
+        google: true,
+        discord: true,
+        github: false,
+        twitter: false,
+        oauth: ["google", "discord"],
+      });
+    }
+    refreshSession() {
+      return Promise.resolve(null);
+    }
+  },
+}));
+
+vi.mock("../../../shell/steward-url", () => ({
+  resolveBrowserStewardApiUrl: () => "https://api.example.test",
+}));
+
+vi.mock("../../../shell/steward-config", () => ({
+  configuredStewardTenantId: () => "elizacloud",
+  DEFAULT_STEWARD_TENANT_ID: "elizacloud",
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? _key,
+}));
+
+vi.mock("../../lib/steward-oauth-url", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/steward-oauth-url")
+  >("../../lib/steward-oauth-url");
+  return {
+    ...actual,
+    consumeStewardPkceVerifier: () => undefined,
+    buildStewardOAuthRedirectUri: () => "https://app.example.test/login",
+  };
+});
+
+vi.mock("../../lib/login-return-to", () => ({
+  resolveLoginReturnTo: () => "/dashboard",
+  consumePendingOAuthReturnTo: () => null,
+  storePendingOAuthReturnTo: () => undefined,
+}));
+
+import StewardLoginSection from "./steward-login-section";
+
+function renderSection() {
+  return render(
+    <MemoryRouter initialEntries={["/login?code=callback-code"]}>
+      <StewardLoginSection />
+    </MemoryRouter>,
+  );
+}
+
+describe("StewardLoginSection — OAuth callback completion state (#13519)", () => {
+  beforeEach(() => {
+    callbackState.hasCallback = true;
+    callbackState.exchange = () => new Promise(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows a terminal 'Completing sign-in…' state and NOT the provider options while a callback exchange is in flight", async () => {
+    renderSection();
+
+    await waitFor(() =>
+      expect(screen.getByText("Completing sign-in…")).toBeTruthy(),
+    );
+
+    // The provider options must not be rendered underneath — no flash back.
+    expect(screen.queryByPlaceholderText("you@example.com")).toBeNull();
+    expect(screen.queryByRole("button", { name: /Passkey/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Magic Link/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Google/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Discord/i })).toBeNull();
+  });
+
+  it("clears the completing state and surfaces the error when the callback exchange fails", async () => {
+    callbackState.exchange = () =>
+      Promise.reject(new Error("Could not complete Eliza Cloud sign-in."));
+
+    renderSection();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Could not complete Eliza Cloud sign-in."),
+      ).toBeTruthy(),
+    );
+
+    // Completing spinner is gone; the sign-in options are reachable again.
+    expect(screen.queryByText("Completing sign-in…")).toBeNull();
+    expect(screen.getByPlaceholderText("you@example.com")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -59,6 +59,7 @@ import {
   consumeStewardCodeFromQuery,
   consumeStewardTokensFromHash,
   exchangeStewardCodeViaApi,
+  hasStewardOAuthCallbackInUrl,
   refreshStewardSessionViaCookie,
   syncStewardSessionCookie,
 } from "../../lib/steward-session";
@@ -224,6 +225,15 @@ export default function StewardLoginSection() {
   const [error, setError] = useState<string | null>(null);
   const [callbackError, setCallbackError] = useState<string | null>(null);
   const [redirectTo, setRedirectTo] = useState<string | null>(null);
+  // Detected once, synchronously, BEFORE the callback-consuming effect below
+  // strips `?code`/`#token` from the URL. While this is true the section shows a
+  // terminal "completing sign-in" state instead of re-rendering the provider
+  // options underneath the in-flight token exchange — that re-render is what read
+  // as the login flashing back to the sign-in options after a successful
+  // callback. Cleared only if the exchange fails, so the error + retry surface.
+  const [completingCallback, setCompletingCallback] = useState<boolean>(() =>
+    PLAYWRIGHT_TEST_AUTH_ENABLED ? false : hasStewardOAuthCallbackInUrl(),
+  );
   const [providersLoaded, setProvidersLoaded] = useState(
     PLAYWRIGHT_TEST_AUTH_ENABLED || cachedStewardProviders !== null,
   );
@@ -280,6 +290,7 @@ export default function StewardLoginSection() {
           );
         })
         .catch((sessionError) => {
+          setCompletingCallback(false);
           setCallbackError(
             getErrorMessage(
               sessionError,
@@ -300,6 +311,7 @@ export default function StewardLoginSection() {
     try {
       persistStewardToken(token);
     } catch (sessionError) {
+      setCompletingCallback(false);
       setCallbackError(
         getErrorMessage(
           sessionError,
@@ -316,6 +328,7 @@ export default function StewardLoginSection() {
         );
       })
       .catch((sessionError) => {
+        setCompletingCallback(false);
         setCallbackError(
           getErrorMessage(sessionError, "Could not establish a local session"),
         );
@@ -521,6 +534,24 @@ export default function StewardLoginSection() {
 
   if (redirectTo) {
     return <Navigate to={redirectTo} replace />;
+  }
+
+  // A completed OAuth/token callback is being exchanged. Hold a terminal
+  // "completing sign-in" state (never the provider options) until the exchange
+  // resolves into a redirect or an error — so the callback can't flash back to
+  // the sign-in options. A callback failure clears this and surfaces
+  // `callbackError` below.
+  if (completingCallback && !callbackError) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8" role="status">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-border-strong border-t-accent motion-reduce:animate-none" />
+        <p className="text-sm text-muted">
+          {t("cloud.login.completingSignIn", {
+            defaultValue: "Completing sign-in…",
+          })}
+        </p>
+      </div>
+    );
   }
 
   if (step === "success") {


### PR DESCRIPTION
## Problem

Closes #13519. After a successful login on the steward / Eliza Cloud sign-in page, the page briefly re-rendered the sign-in **provider options** before control returned to the app — there was no terminal "logged in / completing" state, so the flash back to the options read as the login having failed or reset.

## Root cause

`steward-login-section.tsx` consumes the OAuth callback (`?code` / `#token`) synchronously on mount via `consumeStewardCodeFromQuery()` / `consumeStewardTokensFromHash()`, which **strip** the marker from the URL, then runs the token exchange asynchronously. During that round-trip `redirectTo` is still `null` and `step` is `"idle"`, so the component falls through to the main return and renders the full provider options underneath the in-flight exchange. Because the URL marker was already stripped, subsequent renders can't tell they're mid-callback.

## Fix

- New **non-destructive** `hasStewardOAuthCallbackInUrl()` in `steward-session.ts` — peeks `?code`/`?token`/`#code`/`#token` (incl. the snapshotted `__stewardOAuthHash`) without stripping anything, so it's safe to call from render.
- `steward-login-section.tsx` gains a `completingCallback` state initialized **synchronously** (before the consuming effect runs) from that peek, and a terminal "Completing sign-in…" render gate placed above the provider-options paths. The provider options can no longer flash back during the exchange.
- The state is cleared **only on callback failure**, so a genuine failure still surfaces `callbackError` + the sign-in options for retry — never hidden behind the spinner (no success-shaped fallback).

Design-token classes only (`text-muted`, `border-strong`, `bg-accent`), no raw hex, no backdrop-blur; mirrors the existing `step === "success"` spinner markup.

## Tests

- `steward-session.callback-detect.test.ts` — 9 unit cases: every callback form (query/hash code+token, `__stewardOAuthHash` snapshot), plain `/login` false, empty `#`, and a no-mutation assertion (peek doesn't call `history.replaceState`, unlike the `consume*` helpers). **9/9 pass.**
- `steward-login-section.callback-state.test.tsx` — 2 component cases: in-flight callback shows the terminal state and NOT the provider options; failed callback clears the state and surfaces the error + options. **2/2 pass.**

## Gates (run in the qa-build worktree where deps resolve)

- vitest (both new files): **11/11 pass**.
- `packages/ui` `tsgo --noEmit`: **EXIT 0**, 0 errors in touched files.
- `biome check`: clean (formatter auto-fix applied to the new test file).

Scope note: the companion `authorize-content.tsx` consent surface delegates callback consumption to the `@stwd/react` SDK and gates on its `isLoading`, so it does not exhibit this flash; this PR fixes the reproducible login-section path named in the issue.

— [sol-orch]