### PR TITLE
fix(#13415): fail closed on corrupt x402 payment-request amount before settling

### DIFF
--- a/.github/issue-evidence/13415-x402-settle-amount-fail-closed.md
+++ b/.github/issue-evidence/13415-x402-settle-amount-fail-closed.md
@@ -1,0 +1,75 @@
+# #13415 slice — x402-payment-requests settle-path amount fail-closed
+
+Scope: `packages/cloud/shared/src/lib/services/x402-payment-requests.ts`
+(`settle()` + `recordAppScopedPaymentEarnings`). Part of the #13415
+cloud-shared service-layer fallback sweep. No overlap with in-flight slices:
+auto-top-up (#13507), payout-processor (#13508), oxapay (#13527),
+agent-billing-gate, agent-budgets, referrals, redeemable-earnings.
+
+## Before/after fallback census (settle path, non-test)
+
+Command:
+
+```
+rg -n "Number\(metadata|amountUsd <= 0|\?\? 0" packages/cloud/shared/src/lib/services/x402-payment-requests.ts
+```
+
+Before:
+
+| line | site | verdict |
+| --- | --- | --- |
+| 750 | `const amountUsd = Number(metadata.amountUsd ?? payment.credits_to_add);` computed AFTER `x402FacilitatorService.settle` moved funds | **SLOP — fixed.** `Number(undefined)` and `Number("garbage")` are `NaN`. |
+| 442 | `if (amountUsd <= 0) return;` in `recordAppScopedPaymentEarnings` | **SLOP — fixed.** `NaN <= 0` is `false`, so a corrupt amount slipped past the guard into `addPurchaseEarnings(appId, NaN)`, a `purchase_share` transaction with `amount: "NaN"` (`NaN.toFixed(6)`), and a `total_creator_earnings + NaN` SQL update that nulls/poisons the rollup. |
+| 394 | `Number(metadata.amountUsd ?? payment.credits_to_add ?? 0)` in `triggerChannelCallback` | KEEP — display-only chat message copy (`formatUsd`); never credited. Unchanged. |
+| 808 | `Number(metadata.amountUsd ?? payment.credits_to_add ?? 0)` in `toView` | KEEP — read-model view DTO; never credited. Unchanged. |
+
+After:
+
+- `settle()` validates `amountUsd` (finite AND > 0) **before**
+  `decodePaymentPayload`/`x402FacilitatorService.settle` — i.e. before any
+  funds move on-chain. A corrupt stored request now fails with
+  `X402PaymentRequestError(500, "corrupt_amount")` + structured `logger.error`
+  + the existing failure callback, leaving the request un-settled instead of
+  taking the payer's money and crediting earnings from NaN. `create()` already
+  guarantees a finite positive `amountUsd` in metadata (`bad_amount` guard at
+  create-time), so a non-finite/non-positive amount at settle-time is always a
+  corrupt record, never a valid state.
+- `recordAppScopedPaymentEarnings` gained a defense-in-depth
+  `Number.isFinite` check (throws `corrupt_amount`) so no other caller can
+  push NaN into the earnings ledgers; the intentional `<= 0` no-op stays for
+  legitimate zero-value cases.
+
+## Focused test output
+
+`bun test --isolate src/lib/services/__tests__/x402-app-earnings.test.ts`
+(3 existing + 3 new fail-closed tests):
+
+```
+ 6 pass
+ 0 fail
+ 31 expect() calls
+Ran 6 tests across 1 file. [2.16s]
+```
+
+New tests prove: corrupt metadata + corrupt `credits_to_add` → settle throws
+before `x402FacilitatorService.settle` is called (facilitator mock not
+invoked, no confirmation, no earnings); missing both amount sources → same;
+zero amount → same.
+
+## Checks
+
+- `bunx @biomejs/biome check` on both touched files: clean.
+- `bun run audit:error-policy-ratchet`: `no new fallback-slop in touched files`.
+- `bun run --cwd packages/cloud/shared typecheck` (tsgo): zero diagnostics
+  mentioning x402 or any `cloud/shared` file; only pre-existing out-of-package
+  noise (`packages/app-core` `@elizaos/auth/*` resolution + the generated
+  `validation-keyword-data.js` artifact), identical on base.
+
+## N/A rows
+
+- UI screenshots: N/A — service unit boundary only.
+- Model trajectories: N/A — no LLM surface touched.
+- Audio: N/A.
+- Runtime structured logs: unit-level; the new
+  `refusing to settle request with corrupt amount` log lines appear in the
+  test output above.

--- a/packages/cloud/shared/src/lib/services/__tests__/x402-app-earnings.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/x402-app-earnings.test.ts
@@ -235,3 +235,72 @@ test("a non-app x402 request credits the payer's own redeemable balance, not an 
   expect(earnArg.userId).toBe("buyer-1");
   expect(earnArg.source).toBe("creator_revenue_share");
 });
+
+// #13415 fail-closed: a corrupt stored amount must abort BEFORE the facilitator
+// moves funds. Previously `Number(metadata.amountUsd ?? credits_to_add)` was
+// computed after settlement and NaN slipped past the `<= 0` earnings guard
+// (NaN comparisons are false), producing an `amount: "NaN"` transaction row
+// and a `total_creator_earnings + NaN` SQL update.
+test("settle refuses a request whose stored amount is corrupt, before moving funds", async () => {
+  findPaymentById.mockResolvedValue(
+    paymentRecord({
+      credits_to_add: "not-a-number",
+      metadata: {
+        kind: "x402_payment_request",
+        appId: APP_ID,
+        amountUsd: "garbage",
+        description: "Corrupt",
+        requirements: { scheme: "exact", network: "eip155:8453", payTo: "0xpayto" },
+      },
+    }),
+  );
+
+  await expect(x402PaymentRequestsService.settle(PAYMENT_ID, validPayload)).rejects.toThrow(
+    /corrupt amount/i,
+  );
+
+  // Fails closed: no on-chain settlement, no confirmation, no earnings.
+  expect(settle).not.toHaveBeenCalled();
+  expect(markAsConfirmed).not.toHaveBeenCalled();
+  expect(addPurchaseEarnings).not.toHaveBeenCalled();
+  expect(addEarnings).not.toHaveBeenCalled();
+});
+
+test("settle refuses a request missing both amountUsd and credits_to_add", async () => {
+  findPaymentById.mockResolvedValue(
+    paymentRecord({
+      credits_to_add: null,
+      metadata: {
+        kind: "x402_payment_request",
+        appId: APP_ID,
+        description: "Missing amount",
+        requirements: { scheme: "exact", network: "eip155:8453", payTo: "0xpayto" },
+      },
+    }),
+  );
+
+  await expect(x402PaymentRequestsService.settle(PAYMENT_ID, validPayload)).rejects.toThrow(
+    /corrupt amount/i,
+  );
+  expect(settle).not.toHaveBeenCalled();
+  expect(addEarnings).not.toHaveBeenCalled();
+});
+
+test("settle refuses a zero-amount request instead of settling for nothing", async () => {
+  findPaymentById.mockResolvedValue(
+    paymentRecord({
+      metadata: {
+        kind: "x402_payment_request",
+        appId: APP_ID,
+        amountUsd: 0,
+        description: "Zero",
+        requirements: { scheme: "exact", network: "eip155:8453", payTo: "0xpayto" },
+      },
+    }),
+  );
+
+  await expect(x402PaymentRequestsService.settle(PAYMENT_ID, validPayload)).rejects.toThrow(
+    /corrupt amount/i,
+  );
+  expect(settle).not.toHaveBeenCalled();
+});

--- a/packages/cloud/shared/src/lib/services/x402-payment-requests.ts
+++ b/packages/cloud/shared/src/lib/services/x402-payment-requests.ts
@@ -439,6 +439,23 @@ async function recordAppScopedPaymentEarnings(
   settlement: Awaited<ReturnType<typeof x402FacilitatorService.settle>>,
   metadata: Record<string, unknown>,
 ): Promise<void> {
+  // Fail closed on a corrupt amount: NaN <= 0 is false, so without the explicit
+  // finiteness check a corrupt metadata amount would flow into
+  // addPurchaseEarnings, an `amount: "NaN"` transaction row, and a
+  // `total_creator_earnings + NaN` SQL update. settle() validates before money
+  // moves; this guard is defense in depth for any other caller.
+  if (!Number.isFinite(amountUsd)) {
+    logger.error("[x402-payment-requests] refusing to record earnings for non-finite amount", {
+      paymentRequestId: payment.id,
+      appId,
+      amountUsd,
+    });
+    throw new X402PaymentRequestError(
+      `Corrupt amountUsd for payment request ${payment.id}`,
+      500,
+      "corrupt_amount",
+    );
+  }
   if (amountUsd <= 0) return;
 
   const app = await appsRepository.findById(appId);
@@ -693,6 +710,27 @@ class X402PaymentRequestsService {
       throw new X402PaymentRequestError("Payment request is missing requirements", 500);
     }
 
+    // Validate the USD amount BEFORE the facilitator moves funds on-chain.
+    // create() guarantees a finite positive amountUsd in metadata, so a
+    // non-finite or non-positive value here means the stored request is
+    // corrupt; settling it would take the payer's money and then credit
+    // earnings from NaN (Number(undefined) is NaN, and NaN survives the old
+    // `<= 0` guard because NaN comparisons are false).
+    const amountUsd = Number(metadata.amountUsd ?? payment.credits_to_add);
+    if (!Number.isFinite(amountUsd) || amountUsd <= 0) {
+      logger.error("[x402-payment-requests] refusing to settle request with corrupt amount", {
+        paymentRequestId: payment.id,
+        metadataAmountUsd: metadata.amountUsd,
+        creditsToAdd: payment.credits_to_add,
+      });
+      await this.triggerFailureCallback(payment, "corrupt_amount");
+      throw new X402PaymentRequestError(
+        `Payment request ${payment.id} has a corrupt amount and cannot be settled`,
+        500,
+        "corrupt_amount",
+      );
+    }
+
     let paymentPayload: Parameters<typeof x402FacilitatorService.settle>[0];
     try {
       paymentPayload = decodePaymentPayload(paymentPayloadInput);
@@ -747,7 +785,6 @@ class X402PaymentRequestsService {
       })) ??
       confirmed ??
       payment;
-    const amountUsd = Number(metadata.amountUsd ?? payment.credits_to_add);
     const appId = typeof metadata.appId === "string" ? metadata.appId : undefined;
 
     if (appId) {


### PR DESCRIPTION
## Slice of #13415 (cloud-shared services fallback sweep)

**File:** `packages/cloud/shared/src/lib/services/x402-payment-requests.ts` — settle-path money math.

### Problem

Two compounding fallback bugs:

1. `settle()` computed `Number(metadata.amountUsd ?? payment.credits_to_add)` **after** `x402FacilitatorService.settle` moved funds on-chain. `Number(undefined)` / `Number("garbage")` = `NaN`.
2. `recordAppScopedPaymentEarnings`'s `if (amountUsd <= 0) return` guard does NOT catch NaN (NaN comparisons are always false).

Net effect: a corrupt stored request took the payer's money on-chain, then flowed NaN into `addPurchaseEarnings`, wrote a `purchase_share` transaction with `amount: "NaN"` (`NaN.toFixed(6)`), and executed `total_creator_earnings + NaN` in SQL, poisoning the app rollup.

### Fix

- `settle()` now validates the amount (finite AND positive) **before** payload decode / on-chain settlement. Corrupt record → `X402PaymentRequestError(500, "corrupt_amount")` + structured log + existing failure callback; the request stays un-settled and no funds move. `create()` already rejects non-positive amounts (`bad_amount`), so a bad amount at settle-time is always corruption, never a valid state.
- `recordAppScopedPaymentEarnings` gains a defense-in-depth `Number.isFinite` throw so no other caller can push NaN into the earnings ledgers; the intentional `<= 0` no-op stays.
- Display-only coercions (`triggerChannelCallback` message copy, `toView` DTO) unchanged — never credited, documented as keeps in the evidence census.

### Verification

- `x402-app-earnings.test.ts`: 3 existing + **3 new fail-closed tests** = 6 pass / 0 fail. New tests prove the facilitator mock is never invoked for corrupt/missing/zero amounts (no settlement, no confirmation, no earnings).
- biome clean on touched files; `audit:error-policy-ratchet`: no new fallback-slop.
- tsgo: zero in-package diagnostics (pre-existing out-of-package `app-core`/generated-artifact noise only, identical on base).
- Evidence: `.github/issue-evidence/13415-x402-settle-amount-fail-closed.md`.

No overlap with in-flight #13415 slices: #13507 (auto-top-up), #13508 (payout-processor), #13527 (oxapay), agent-billing-gate, agent-budgets, referrals, redeemable-earnings.

— [sol-orch]