### PR TITLE
fix(#13415): fail closed on corrupt redeemable-earnings NUMERIC balance reads

### DIFF
--- a/packages/cloud/shared/src/lib/services/redeemable-earnings-numeric.test.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings-numeric.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Exercises the fail-closed numeric boundary for redeemable-earnings rows and
+ * pins the money-out fail-open regression it closes.
+ */
+import { describe, expect, test } from "bun:test";
+import Decimal from "decimal.js";
+import {
+  CorruptRedeemableEarningsNumberError,
+  parseRedeemableEarningsNumber,
+} from "./redeemable-earnings-numeric";
+
+describe("parseRedeemableEarningsNumber", () => {
+  test("parses a well-formed NUMERIC string", () => {
+    expect(parseRedeemableEarningsNumber("10.5000", "available_balance")).toBe(10.5);
+  });
+
+  test("parses a numeric value", () => {
+    expect(parseRedeemableEarningsNumber(42, "total_earned")).toBe(42);
+  });
+
+  test("parses a zero string (explicit domain zero is allowed)", () => {
+    expect(parseRedeemableEarningsNumber("0.0000", "available_balance")).toBe(0);
+    expect(parseRedeemableEarningsNumber(0, "available_balance")).toBe(0);
+  });
+
+  test("throws on the 'NaN' string a corrupt Postgres NUMERIC reads back as", () => {
+    // `'NaN'::numeric` is a valid Postgres NUMERIC and the driver returns "NaN".
+    expect(() => parseRedeemableEarningsNumber("NaN", "available_balance")).toThrow(
+      /Unable to read redeemable earnings available_balance/,
+    );
+  });
+
+  test("throws on a non-numeric corrupt string instead of returning NaN", () => {
+    expect(() => parseRedeemableEarningsNumber("corrupt", "available_balance")).toThrow(
+      /available_balance/,
+    );
+  });
+
+  test("throws on NaN input rather than fabricating a permissive value", () => {
+    expect(() => parseRedeemableEarningsNumber(Number.NaN, "available_balance")).toThrow(
+      /not a finite number/,
+    );
+  });
+
+  test("throws on Infinity", () => {
+    expect(() =>
+      parseRedeemableEarningsNumber(Number.POSITIVE_INFINITY, "available_balance"),
+    ).toThrow(/not a finite number/);
+    expect(() =>
+      parseRedeemableEarningsNumber(Number.NEGATIVE_INFINITY, "available_balance"),
+    ).toThrow(/not a finite number/);
+  });
+
+  test("throws on null / undefined / empty / whitespace (missing value)", () => {
+    expect(() => parseRedeemableEarningsNumber(null, "available_balance")).toThrow(
+      /empty or missing/,
+    );
+    expect(() => parseRedeemableEarningsNumber(undefined, "available_balance")).toThrow(
+      /empty or missing/,
+    );
+    expect(() => parseRedeemableEarningsNumber("", "available_balance")).toThrow(
+      /empty or missing/,
+    );
+    expect(() => parseRedeemableEarningsNumber("   ", "available_balance")).toThrow(
+      /empty or missing/,
+    );
+  });
+
+  test("names the field in the error so corrupt columns are identifiable", () => {
+    expect(() => parseRedeemableEarningsNumber("x", "total_redeemed")).toThrow(/total_redeemed/);
+    expect(() => parseRedeemableEarningsNumber("x", "total_pending")).toThrow(/total_pending/);
+  });
+
+  test("throws a typed CorruptRedeemableEarningsNumberError carrying field + raw value", () => {
+    try {
+      parseRedeemableEarningsNumber("NaN", "available_balance");
+      throw new Error("expected parse to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CorruptRedeemableEarningsNumberError);
+      const typed = err as CorruptRedeemableEarningsNumberError;
+      expect(typed.fieldName).toBe("available_balance");
+      expect(typed.rawValue).toBe("NaN");
+    }
+  });
+});
+
+describe("money-out fail-open regression (secure token-redemption insufficient-balance gate)", () => {
+  // Reproduces token-redemption-secure.ts createRedemption():
+  //   const availableBalance = new Decimal(earningsBalance.availableBalance);
+  //   if (availableBalance.lt(deductionAmount)) return { insufficient }
+  // where earningsBalance.availableBalance came from getBalance()'s NUMERIC read.
+  const deductionAmount = 50;
+
+  test("a bare Number('NaN') balance makes the Decimal insufficient-check FAIL OPEN", () => {
+    const fabricatedBalance = Number("NaN"); // what getBalance used to return
+    const availableBalance = new Decimal(fabricatedBalance);
+    // Decimal(NaN).lt(50) === false -> the insufficient-balance branch is skipped
+    // -> the redemption is authorized against a corrupt (unbacked) balance.
+    expect(availableBalance.lt(deductionAmount)).toBe(false);
+  });
+
+  test("the fail-closed reader throws on that same corrupt balance so the gate never fabricates funds", () => {
+    // getBalance now routes available_balance through the reader, so a corrupt
+    // row throws before any Decimal comparison -> the route catch denies (500).
+    expect(() => parseRedeemableEarningsNumber("NaN", "available_balance")).toThrow();
+  });
+
+  test("a healthy balance still parses and the Decimal gate behaves normally", () => {
+    const healthy = parseRedeemableEarningsNumber("10.0000", "available_balance");
+    const availableBalance = new Decimal(healthy);
+    expect(availableBalance.lt(deductionAmount)).toBe(true); // $10 < $50 -> insufficient, correctly denied
+    expect(availableBalance.lt(5)).toBe(false); // $10 >= $5 -> sufficient, correctly allowed
+  });
+});

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings-numeric.test.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings-numeric.test.ts
@@ -111,4 +111,19 @@ describe("money-out fail-open regression (secure token-redemption insufficient-b
     expect(availableBalance.lt(deductionAmount)).toBe(true); // $10 < $50 -> insufficient, correctly denied
     expect(availableBalance.lt(5)).toBe(false); // $10 >= $5 -> sufficient, correctly allowed
   });
+
+  test("the same parser protects the other redeemable-earnings debit gates", () => {
+    const corruptAvailableBalance = Number("NaN");
+
+    // These mirror lockForRedemption(), convertToCredits(), and
+    // reduceEarnings({ requireSufficientBalance: true }) before they parse the
+    // locked available_balance. A bare Decimal(NaN) comparison reports
+    // "not less than", so the insufficient-balance branch would be skipped.
+    expect(new Decimal(corruptAvailableBalance).lt(5)).toBe(false);
+    expect(new Decimal(corruptAvailableBalance).lessThan(5)).toBe(false);
+
+    expect(() => parseRedeemableEarningsNumber("NaN", "available_balance")).toThrow(
+      CorruptRedeemableEarningsNumberError,
+    );
+  });
 });

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings-numeric.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings-numeric.ts
@@ -1,0 +1,53 @@
+/**
+ * Numeric parsing boundary for redeemable-earnings rows.
+ *
+ * Postgres NUMERIC columns arrive as strings on read. A corrupt value
+ * (`'NaN'::numeric` is a valid Postgres NUMERIC and reads back as the string
+ * `"NaN"`) must THROW here rather than becoming a JS `NaN`, because a `NaN`
+ * balance silently fails open on the money-out gate: the secure token
+ * redemption pre-check does
+ *   `new Decimal(balance.availableBalance).lt(deductionAmount)`
+ * and `Decimal(NaN).lt(x)` is `false`, so an insufficient-balance check over a
+ * corrupt row would be BYPASSED and authorize a redemption against garbage.
+ *
+ * Mirrors the fail-closed NUMERIC boundary used by the sibling billing/quota
+ * repositories (usage-quotas, app-earnings, organizations, etc.).
+ */
+
+export class CorruptRedeemableEarningsNumberError extends Error {
+  readonly fieldName: string;
+  readonly rawValue: unknown;
+
+  constructor(fieldName: string, rawValue: unknown, reason: string) {
+    super(`Unable to read redeemable earnings ${fieldName}: ${reason}`);
+    this.name = "CorruptRedeemableEarningsNumberError";
+    this.fieldName = fieldName;
+    this.rawValue = rawValue;
+  }
+}
+
+/**
+ * Parse a redeemable-earnings NUMERIC field fail-closed.
+ *
+ * - Throws on null / undefined / empty-or-whitespace-only strings.
+ * - Throws on any non-finite parse (`NaN`, `Infinity`, `-Infinity`).
+ * - Allows an explicit domain zero and any other finite value (incl. negatives,
+ *   though balances are DB-CHECK non-negative — the parser stays value-neutral).
+ */
+export function parseRedeemableEarningsNumber(
+  value: string | number | null | undefined,
+  fieldName: string,
+): number {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    throw new CorruptRedeemableEarningsNumberError(fieldName, value, "value is empty or missing");
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new CorruptRedeemableEarningsNumberError(
+      fieldName,
+      value,
+      "value is not a finite number",
+    );
+  }
+  return parsed;
+}

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
@@ -23,6 +23,7 @@ import { dbRead, dbWrite } from "../../db/client";
 import { redeemableEarnings, redeemableEarningsLedger } from "../../db/schemas/redeemable-earnings";
 import { normalizeLedgerSourceId } from "../utils/ledger-source-id";
 import { logger } from "../utils/logger";
+import { parseRedeemableEarningsNumber } from "./redeemable-earnings-numeric";
 
 // ============================================================================
 // TYPES
@@ -158,15 +159,28 @@ class RedeemableEarningsService {
       return null;
     }
 
+    // Fail-closed NUMERIC boundary: a corrupt row (`'NaN'::numeric`) must throw
+    // rather than surface a `NaN` balance. `availableBalance` gates money-out in
+    // the secure token-redemption pre-check
+    // (`new Decimal(balance.availableBalance).lt(deductionAmount)` — `Decimal(NaN).lt(x)`
+    // is `false`, i.e. the insufficient-balance check would FAIL OPEN over a
+    // corrupt row). Throwing here propagates to the redemption route's catch,
+    // which fails closed (denies) instead of authorizing against garbage.
     return {
-      availableBalance: Number(earnings.available_balance),
-      totalEarned: Number(earnings.total_earned),
-      totalRedeemed: Number(earnings.total_redeemed),
-      totalPending: Number(earnings.total_pending),
+      availableBalance: parseRedeemableEarningsNumber(
+        earnings.available_balance,
+        "available_balance",
+      ),
+      totalEarned: parseRedeemableEarningsNumber(earnings.total_earned, "total_earned"),
+      totalRedeemed: parseRedeemableEarningsNumber(earnings.total_redeemed, "total_redeemed"),
+      totalPending: parseRedeemableEarningsNumber(earnings.total_pending, "total_pending"),
       breakdown: {
-        miniapps: Number(earnings.earned_from_miniapps),
-        agents: Number(earnings.earned_from_agents),
-        mcps: Number(earnings.earned_from_mcps),
+        miniapps: parseRedeemableEarningsNumber(
+          earnings.earned_from_miniapps,
+          "earned_from_miniapps",
+        ),
+        agents: parseRedeemableEarningsNumber(earnings.earned_from_agents, "earned_from_agents"),
+        mcps: parseRedeemableEarningsNumber(earnings.earned_from_mcps, "earned_from_mcps"),
       },
     };
   }

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
@@ -518,15 +518,21 @@ class RedeemableEarningsService {
       // Fail-closed money-out guard (computed under the row lock, on the
       // primary): never floor-and-pass when the caller requires the full
       // amount to be debitable.
-      if (requireSufficientBalance && new Decimal(earnings.available_balance).lessThan(amount)) {
-        return {
-          earnings: null,
-          ledgerEntryId: "",
-          skipped: false,
-          insufficient: true,
-          deduplicated: false,
-          currentBalance: Number(earnings.available_balance),
-        };
+      if (requireSufficientBalance) {
+        const currentBalance = parseRedeemableEarningsNumber(
+          earnings.available_balance,
+          "available_balance",
+        );
+        if (new Decimal(currentBalance).lessThan(amount)) {
+          return {
+            earnings: null,
+            ledgerEntryId: "",
+            skipped: false,
+            insufficient: true,
+            deduplicated: false,
+            currentBalance,
+          };
+        }
       }
 
       // Determine the source column
@@ -673,7 +679,9 @@ class RedeemableEarningsService {
         throw new Error("No earnings record found");
       }
 
-      const available = new Decimal(earnings.available_balance);
+      const available = new Decimal(
+        parseRedeemableEarningsNumber(earnings.available_balance, "available_balance"),
+      );
       const requested = new Decimal(amountDecimal);
 
       // Check sufficient balance
@@ -917,7 +925,9 @@ class RedeemableEarningsService {
         }
       }
 
-      const available = new Decimal(earnings.available_balance);
+      const available = new Decimal(
+        parseRedeemableEarningsNumber(earnings.available_balance, "available_balance"),
+      );
       if (available.lt(amountDecimal)) {
         throw new Error(
           `Insufficient redeemable balance. Available: $${available.toFixed(4)}, Requested: $${amount.toFixed(4)}`,


### PR DESCRIPTION
## Problem

`redeemableEarningsService.getBalance()` read the `redeemable_earnings` NUMERIC columns (`available_balance`, `total_earned`, `total_redeemed`, `total_pending`, `earned_from_*`) via bare `Number(...)`. Postgres NUMERIC arrives as a string on read, and `'NaN'::numeric` is a **valid** Postgres NUMERIC that reads back as the string `"NaN"` → `Number("NaN")` is `NaN`.

That `NaN` DTO **fails open on the money-out gate** in the CRITICAL-SECURITY secure token-redemption path (`token-redemption-secure.ts` `createRedemption`, line ~415):

```ts
const earningsBalance = await redeemableEarningsService.getBalance(userId);
...
const availableBalance = new Decimal(earningsBalance.availableBalance); // Decimal(NaN)
if (availableBalance.lt(deductionAmount)) {                            // Decimal(NaN).lt(x) === false
  return { success: false, error: "Insufficient redeemable earnings..." };
}
```

`Decimal(NaN).lt(x)` returns `false`, so the insufficient-balance pre-check is **BYPASSED** and a redemption is authorized against a corrupt (unbacked) balance. Same fail-open class already closed for the sibling billing/quota NUMERIC reads.

## Fix

- New colocated `redeemable-earnings-numeric.ts`: `parseRedeemableEarningsNumber(value, fieldName)` fail-closed boundary + typed `CorruptRedeemableEarningsNumberError`. Throws on `null`/`undefined`/empty/whitespace and any non-finite parse (`NaN`/`Infinity`/`-Infinity`); allows an explicit domain zero and any other finite value.
- Wired into all of `getBalance`'s NUMERIC reads.
- The `/v1/redemptions` route wraps `createRedemption` in a `try/catch` that maps unknown throws to a 500, so a corrupt row now **DENIES** (fails closed) rather than fabricating spendable funds. No fabricated success anywhere.

Mirrors the merged NUMERIC fail-closed boundaries: usage-quotas, app-earnings, organizations, container-billing, agent-billing, conversations.

## Tests

`bun test packages/cloud/shared/src/lib/services/redeemable-earnings-numeric.test.ts` — **13/13 green**:
- Exhaustive parser boundary: well-formed string/number, explicit `"0.0000"`/`0`, the `"NaN"`-string a corrupt NUMERIC reads back as, arbitrary corrupt string, `NaN`/`±Infinity`, `null`/`undefined`/empty/whitespace, field-named errors, typed error carrying `fieldName` + `rawValue`.
- **Money-out fail-open regression**: proves `new Decimal(Number("NaN")).lt(deductionAmount) === false` (the old bug silently authorizes) while the reader **throws** on that same corrupt value, plus a healthy-path control (`$10 < $50` → correctly insufficient; `$10 >= $5` → correctly sufficient).

## Gates

- `tsgo --noEmit`: **0 errors in touched files**. The 17 remaining are pre-existing baseline noise (`@elizaos/auth` symlink resolution + node-redis / plugin-mcp / anthropic drift), identical on `develop`.
- biome: clean.
- error-policy-ratchet: `emptyCatch 0->0, serverConsole 0->0` on both changed source files — no new fallback-slop.

## Scope

Distinct file from all other open #13415 slices (oxapay, auto-top-up, agent-billing-gate, x402-payment-requests, token-redemption-secure daily-limits, payout-processor). No forbidden files touched. Issue stays open for the remaining service-layer inventory.

— [sol-orch]
