### PR TITLE
fix(#13415): fail closed on unreadable payout-network on-chain balance

### DIFF
--- a/.github/issue-evidence/13415-payout-status-balance-fallback.md
+++ b/.github/issue-evidence/13415-payout-status-balance-fallback.md
@@ -37,7 +37,8 @@ confirms "operational" is a real availability gate, not cosmetic).
 
 New pure, exported `classifyPayoutNetworkBalance(rawAmount, decimals)` computes
 `balance` and returns the balance-derived `{ balance, hasBalance, status,
-message }` subset. Fail-closed boundary: **`!Number.isFinite(balance)` →
+message }` subset. Fail-closed boundary: **`!Number.isFinite(balance) ||
+balance < 0` →
 `status: "not_configured"`, `hasBalance: false`, `balance: 0`** with an
 explicit "Unable to verify payout wallet balance (unreadable on-chain value)"
 message and an observable `logger.warn` at the call site — never `operational`.
@@ -49,11 +50,12 @@ existing fail-closed `not_configured` returns.
 
 ## Tests
 
-`payout-status-balance.test.ts` — 8/8 green (`bun test`, 28 expect calls):
+`payout-status-balance.test.ts` — 9/9 green (`bun test`, 31 expect calls):
 
 - **fail-closed:** NaN raw balance → `not_configured` (regression: asserts the
   old fabricated `operational`/`low_balance` verdict + `NaN` message are gone),
-  `Infinity` → `not_configured`, unparseable string → `not_configured`.
+  `Infinity` → `not_configured`, unparseable string → `not_configured`,
+  impossible negative amount → `not_configured`.
 - **preserved:** `0n` → `no_balance`; 50 tokens → `low_balance`; exactly 100
   (threshold) → `operational` (>= boundary); 12,345 tokens → `operational` with
   token count; a `bigint` on-chain amount (viem/spl-token read shape) classifies
@@ -64,7 +66,7 @@ the per-network degrade-on-throw contract).
 
 ## Verification
 
-- `bun test src/lib/services/payout-status-balance.test.ts` → 8 pass / 0 fail.
+- `bun test src/lib/services/payout-status-balance.test.ts` → 9 pass / 0 fail.
 - `bun test src/lib/services/__tests__/payout-status-resilience.test.ts` → 4 pass / 0 fail.
 - `bunx @biomejs/biome check <touched files>` → clean, no fixes applied.
 - `bun run audit:error-policy-ratchet` → "no new fallback-slop in touched files".

--- a/.github/issue-evidence/13415-payout-status-balance-fallback.md
+++ b/.github/issue-evidence/13415-payout-status-balance-fallback.md
@@ -1,0 +1,77 @@
+# #13415 slice — payout-status.ts on-chain-balance NaN fail-open
+
+`packages/cloud/shared/src/lib/services/payout-status.ts`
+(fallback-slop successor to #12788; distinct file from prior #13415 slices:
+auto-top-up #13507, agent-billing-gate #13522, token-redemption-secure #13518,
+payout-processor #13508, oxapay #13527, plus live agent-budgets / x402 /
+redeemable-earnings / credits sibling lanes.)
+
+## Fallback census (before → after)
+
+| path:line | pattern | verdict | fix |
+| --- | --- | --- | --- |
+| `payout-status.ts` EVM `checkEvmNetwork` | `balance = Number(rawBalance) / 10 ** decimals` with no finite guard, then `balance === 0` / `balance < LOW_BALANCE_THRESHOLD` classification | **FAIL-OPEN** money-availability gate | routed through fail-closed `classifyPayoutNetworkBalance` |
+| `payout-status.ts` Solana `checkSolanaNetwork` | `balance = Number(account.amount) / 10 ** ELIZA_DECIMALS.solana` with no finite guard, same classification | **FAIL-OPEN** money-availability gate | routed through fail-closed `classifyPayoutNetworkBalance` |
+
+## The bug (fail-OPEN)
+
+Both per-network checks computed the token balance as
+`Number(rawAmount) / 10 ** decimals` and then classified it with
+`balance === 0` and `balance < LOW_BALANCE_THRESHOLD`. A corrupt / unparseable
+on-chain read that **did not throw** (so `resolveNetworkStatus`'s outer
+try/catch never caught it — `Number()` does not throw, it returns `NaN`) yields
+`balance = NaN`:
+
+- `NaN === 0` → `false`
+- `NaN < LOW_BALANCE_THRESHOLD` → `false`
+
+…so control fell through to the terminal
+`status: "operational", hasBalance: true, message: "Operational with NaN tokens
+available"`. That made `operationalNetworks.length > 0`, reported the whole
+payout system `operational: true`, and **enabled token redemption against a
+payout wallet whose balance was never verified** — a fail-open money gate (the
+`PAYOUT_STATUS_ASSUME_OPERATIONAL` production guard elsewhere in the file
+confirms "operational" is a real availability gate, not cosmetic).
+
+## The fix (fail-CLOSED)
+
+New pure, exported `classifyPayoutNetworkBalance(rawAmount, decimals)` computes
+`balance` and returns the balance-derived `{ balance, hasBalance, status,
+message }` subset. Fail-closed boundary: **`!Number.isFinite(balance)` →
+`status: "not_configured"`, `hasBalance: false`, `balance: 0`** with an
+explicit "Unable to verify payout wallet balance (unreadable on-chain value)"
+message and an observable `logger.warn` at the call site — never `operational`.
+For finite values the classification (`no_balance` / `low_balance` /
+`operational`, exact messages + `>= threshold` boundary) is **behavior-preserving**.
+Both `checkEvmNetwork` and `checkSolanaNetwork` now spread the classifier
+result. `error`-flag (RPC read rejected) and setup-throw paths keep their
+existing fail-closed `not_configured` returns.
+
+## Tests
+
+`payout-status-balance.test.ts` — 8/8 green (`bun test`, 28 expect calls):
+
+- **fail-closed:** NaN raw balance → `not_configured` (regression: asserts the
+  old fabricated `operational`/`low_balance` verdict + `NaN` message are gone),
+  `Infinity` → `not_configured`, unparseable string → `not_configured`.
+- **preserved:** `0n` → `no_balance`; 50 tokens → `low_balance`; exactly 100
+  (threshold) → `operational` (>= boundary); 12,345 tokens → `operational` with
+  token count; a `bigint` on-chain amount (viem/spl-token read shape) classifies
+  without throwing.
+
+Existing `__tests__/payout-status-resilience.test.ts` 4/4 green (no regression to
+the per-network degrade-on-throw contract).
+
+## Verification
+
+- `bun test src/lib/services/payout-status-balance.test.ts` → 8 pass / 0 fail.
+- `bun test src/lib/services/__tests__/payout-status-resilience.test.ts` → 4 pass / 0 fail.
+- `bunx @biomejs/biome check <touched files>` → clean, no fixes applied.
+- `bun run audit:error-policy-ratchet` → "no new fallback-slop in touched files".
+- `bun run --cwd packages/cloud/shared typecheck` → 13 pre-existing baseline
+  errors, ALL in unrelated `packages/app-core/src/services/{account-pool,
+  coding-account-bridge}.ts` (`@elizaos/auth` symlink-resolution drift documented
+  in prior merged cloud-shared slices); **ZERO errors in the two touched files**.
+- N/A rows: UI screenshots, model trajectories, audio — this is a service unit
+  boundary that performs on-chain RPC reads only; no touched UI/model/audio
+  surface.

--- a/packages/cloud/shared/src/lib/services/payout-status-balance.test.ts
+++ b/packages/cloud/shared/src/lib/services/payout-status-balance.test.ts
@@ -47,6 +47,16 @@ describe("classifyPayoutNetworkBalance — fail-closed on unreadable balances", 
     expect(result.status).toBe("not_configured");
     expect(result.hasBalance).toBe(false);
   });
+
+  test("negative raw balance fails closed instead of advertising low-balance availability", () => {
+    // Token account balances are unsigned. A negative value is a corrupt read;
+    // low_balance has hasBalance:true and is considered available by
+    // isNetworkAvailable(), so it must not be used for impossible negatives.
+    const result = classifyPayoutNetworkBalance("-1", DECIMALS);
+    expect(result.status).toBe("not_configured");
+    expect(result.hasBalance).toBe(false);
+    expect(result.balance).toBe(0);
+  });
 });
 
 describe("classifyPayoutNetworkBalance — healthy classifications preserved", () => {

--- a/packages/cloud/shared/src/lib/services/payout-status-balance.test.ts
+++ b/packages/cloud/shared/src/lib/services/payout-status-balance.test.ts
@@ -1,0 +1,96 @@
+// Fail-closed contract for the payout-network on-chain balance classifier.
+//
+// Regression target (#13415): checkEvmNetwork/checkSolanaNetwork computed
+//   balance = Number(rawAmount) / 10 ** decimals
+// with NO finite guard, then classified with `balance === 0` / `balance <
+// LOW_BALANCE_THRESHOLD`. A corrupt/unreadable on-chain read that did NOT throw
+// yielded balance = NaN, both comparisons were false, and the network fell
+// through to status:"operational", hasBalance:true ("Operational with NaN
+// tokens available"). That advertised an unverifiable payout wallet as available
+// and enabled token redemption against it — a fail-OPEN money-availability gate.
+// classifyPayoutNetworkBalance must degrade any non-finite balance to
+// not_configured instead.
+import { describe, expect, test } from "bun:test";
+import { ELIZA_DECIMALS } from "../config/token-constants";
+import { classifyPayoutNetworkBalance } from "./payout-status";
+
+// 9 decimals for the elizaOS token across every supported network.
+const DECIMALS = ELIZA_DECIMALS.solana; // === 9
+const UNIT = 10 ** DECIMALS; // raw units per whole token
+// LOW_BALANCE_THRESHOLD is a private module const (100 tokens); mirror it here.
+const LOW_BALANCE_THRESHOLD = 100;
+
+describe("classifyPayoutNetworkBalance — fail-closed on unreadable balances", () => {
+  test("NaN raw balance does NOT fabricate operational (the fail-open regression)", () => {
+    // Number("not-a-number") -> NaN, previously fell through to operational.
+    const result = classifyPayoutNetworkBalance("not-a-number", DECIMALS);
+    expect(result.status).toBe("not_configured");
+    expect(result.hasBalance).toBe(false);
+    expect(result.balance).toBe(0);
+    // Explicitly assert the OLD fabricated verdict is gone.
+    expect(result.status).not.toBe("operational");
+    expect(result.status).not.toBe("low_balance");
+    expect(result.message).not.toContain("NaN");
+  });
+
+  test("Infinity raw balance fails closed to not_configured", () => {
+    const result = classifyPayoutNetworkBalance(Number.POSITIVE_INFINITY, DECIMALS);
+    expect(result.status).toBe("not_configured");
+    expect(result.hasBalance).toBe(false);
+    expect(result.balance).toBe(0);
+  });
+
+  test("empty-string raw balance would compute NaN and fails closed", () => {
+    // Number("") === 0 would be a false negative; only a genuinely-unparseable
+    // value produces NaN. A whitespace/garbage token account amount does.
+    const result = classifyPayoutNetworkBalance("  x ", DECIMALS);
+    expect(result.status).toBe("not_configured");
+    expect(result.hasBalance).toBe(false);
+  });
+});
+
+describe("classifyPayoutNetworkBalance — healthy classifications preserved", () => {
+  test("zero raw balance -> no_balance (not fabricated operational)", () => {
+    const result = classifyPayoutNetworkBalance(0n, DECIMALS);
+    expect(result.status).toBe("no_balance");
+    expect(result.hasBalance).toBe(false);
+    expect(result.balance).toBe(0);
+    expect(result.message).toBe("Payout wallet has no elizaOS tokens");
+  });
+
+  test("balance below the low-balance threshold -> low_balance", () => {
+    // 50 whole tokens (< 100 threshold).
+    const raw = BigInt(50 * UNIT);
+    const result = classifyPayoutNetworkBalance(raw, DECIMALS);
+    expect(result.status).toBe("low_balance");
+    expect(result.hasBalance).toBe(true);
+    expect(result.balance).toBe(50);
+    expect(result.message).toContain(`threshold: ${LOW_BALANCE_THRESHOLD}`);
+  });
+
+  test("balance exactly at the threshold is operational (>= threshold)", () => {
+    const raw = BigInt(LOW_BALANCE_THRESHOLD * UNIT);
+    const result = classifyPayoutNetworkBalance(raw, DECIMALS);
+    expect(result.status).toBe("operational");
+    expect(result.hasBalance).toBe(true);
+    expect(result.balance).toBe(LOW_BALANCE_THRESHOLD);
+  });
+
+  test("healthy balance above threshold -> operational with token count", () => {
+    // 12,345 whole tokens.
+    const raw = BigInt(12_345 * UNIT);
+    const result = classifyPayoutNetworkBalance(raw, DECIMALS);
+    expect(result.status).toBe("operational");
+    expect(result.hasBalance).toBe(true);
+    expect(result.balance).toBe(12_345);
+    expect(result.message).toContain("12345.00 tokens available");
+  });
+
+  test("a bigint on-chain amount classifies without throwing (EVM/Solana read shape)", () => {
+    // Both viem readContract and spl-token account.amount return bigint.
+    const raw: bigint = BigInt(250 * UNIT);
+    const result = classifyPayoutNetworkBalance(raw, DECIMALS);
+    expect(result.status).toBe("operational");
+    expect(result.balance).toBe(250);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/payout-status.ts
+++ b/packages/cloud/shared/src/lib/services/payout-status.ts
@@ -57,12 +57,13 @@ type PayoutBalanceClassification = Pick<
  * an RPC round-trip.
  *
  * FAIL-CLOSED (money-availability gate): a raw balance that does not resolve to
- * a finite number (`Number(rawAmount) / 10**decimals` yielding NaN/±Infinity —
- * e.g. an unparseable/undefined/corrupt on-chain read that did NOT throw) must
- * NOT be advertised as `operational`. Before this guard, `NaN === 0` is false
- * and `NaN < LOW_BALANCE_THRESHOLD` is false, so a network we could not verify
- * fell through to `status: "operational", hasBalance: true` ("Operational with
- * NaN tokens available"). That made `operationalNetworks > 0`, reported the whole
+ * a finite, non-negative number (`Number(rawAmount) / 10**decimals` yielding
+ * NaN/±Infinity or an impossible negative token balance — e.g. an
+ * unparseable/undefined/corrupt on-chain read that did NOT throw) must NOT be
+ * advertised as `operational`. Before this guard, `NaN === 0` is false and
+ * `NaN < LOW_BALANCE_THRESHOLD` is false, so a network we could not verify fell
+ * through to `status: "operational", hasBalance: true` ("Operational with NaN
+ * tokens available"). That made `operationalNetworks > 0`, reported the whole
  * payout system available, and enabled token redemption against a wallet whose
  * funds were never confirmed. A non-throwing corrupt read now degrades that
  * single network to `not_configured` instead of fabricating availability.
@@ -74,7 +75,7 @@ export function classifyPayoutNetworkBalance(
 ): PayoutBalanceClassification {
   const balance = Number(rawAmount) / 10 ** decimals;
 
-  if (!Number.isFinite(balance)) {
+  if (!Number.isFinite(balance) || balance < 0) {
     return {
       balance: 0,
       hasBalance: false,

--- a/packages/cloud/shared/src/lib/services/payout-status.ts
+++ b/packages/cloud/shared/src/lib/services/payout-status.ts
@@ -44,6 +44,71 @@ export interface PayoutSystemStatus {
 // Thresholds for warnings
 const LOW_BALANCE_THRESHOLD = 100; // Tokens
 
+// The balance-derived subset of a NetworkStatus: everything the on-chain token
+// balance decides. network / configured / walletAddress are owned by the caller.
+type PayoutBalanceClassification = Pick<
+  NetworkStatus,
+  "balance" | "hasBalance" | "status" | "message"
+>;
+
+/**
+ * Classify a payout network's operational state from its raw on-chain token
+ * balance. Pure + exported so the fail-closed contract is unit-testable without
+ * an RPC round-trip.
+ *
+ * FAIL-CLOSED (money-availability gate): a raw balance that does not resolve to
+ * a finite number (`Number(rawAmount) / 10**decimals` yielding NaN/±Infinity —
+ * e.g. an unparseable/undefined/corrupt on-chain read that did NOT throw) must
+ * NOT be advertised as `operational`. Before this guard, `NaN === 0` is false
+ * and `NaN < LOW_BALANCE_THRESHOLD` is false, so a network we could not verify
+ * fell through to `status: "operational", hasBalance: true` ("Operational with
+ * NaN tokens available"). That made `operationalNetworks > 0`, reported the whole
+ * payout system available, and enabled token redemption against a wallet whose
+ * funds were never confirmed. A non-throwing corrupt read now degrades that
+ * single network to `not_configured` instead of fabricating availability.
+ * (error-policy: fail-closed on unverifiable balance for a money-out gate.)
+ */
+export function classifyPayoutNetworkBalance(
+  rawAmount: bigint | number | string,
+  decimals: number,
+): PayoutBalanceClassification {
+  const balance = Number(rawAmount) / 10 ** decimals;
+
+  if (!Number.isFinite(balance)) {
+    return {
+      balance: 0,
+      hasBalance: false,
+      status: "not_configured",
+      message: "Unable to verify payout wallet balance (unreadable on-chain value)",
+    };
+  }
+
+  if (balance === 0) {
+    return {
+      balance,
+      hasBalance: false,
+      status: "no_balance",
+      message: "Payout wallet has no elizaOS tokens",
+    };
+  }
+
+  if (balance < LOW_BALANCE_THRESHOLD) {
+    return {
+      balance,
+      hasBalance: true,
+      status: "low_balance",
+      message: `Low balance: ${balance.toFixed(2)} tokens (threshold: ${LOW_BALANCE_THRESHOLD})`,
+    };
+  }
+
+  return {
+    balance,
+    hasBalance: true,
+    status: "operational",
+    message: `Operational with ${balance.toFixed(2)} tokens available`,
+  };
+}
+
 // ============================================================================
 // SERVICE
 // ============================================================================
@@ -396,7 +461,6 @@ class PayoutStatusService {
 
     const ERC20_ABI = parseAbi(["function balanceOf(address account) view returns (uint256)"]);
 
-    let balance = 0;
     let error: string | null = null;
 
     const rawBalance = await publicClient
@@ -410,8 +474,6 @@ class PayoutStatusService {
         error = err.message;
         return BigInt(0);
       });
-
-    balance = Number(rawBalance) / 10 ** decimals;
 
     if (error) {
       logger.warn(`[PayoutStatus] Failed to check ${network} balance`, {
@@ -428,38 +490,21 @@ class PayoutStatusService {
       };
     }
 
-    if (balance === 0) {
-      return {
-        network,
-        configured: true,
-        walletAddress: this.maskAddress(walletAddress),
-        balance,
-        hasBalance: false,
-        status: "no_balance",
-        message: "Payout wallet has no elizaOS tokens",
-      };
+    // Fail-closed on an unreadable on-chain balance: a corrupt read that did not
+    // throw must degrade this network to not_configured, never fabricate
+    // "operational" (see classifyPayoutNetworkBalance).
+    const classification = classifyPayoutNetworkBalance(rawBalance, decimals);
+    if (classification.status === "not_configured") {
+      logger.warn(`[PayoutStatus] ${network} balance is unreadable; treating as unconfigured`, {
+        rawBalance: String(rawBalance),
+        decimals,
+      });
     }
-
-    if (balance < LOW_BALANCE_THRESHOLD) {
-      return {
-        network,
-        configured: true,
-        walletAddress: this.maskAddress(walletAddress),
-        balance,
-        hasBalance: true,
-        status: "low_balance",
-        message: `Low balance: ${balance.toFixed(2)} tokens (threshold: ${LOW_BALANCE_THRESHOLD})`,
-      };
-    }
-
     return {
       network,
       configured: true,
       walletAddress: this.maskAddress(walletAddress),
-      balance,
-      hasBalance: true,
-      status: "operational",
-      message: `Operational with ${balance.toFixed(2)} tokens available`,
+      ...classification,
     };
   }
 
@@ -488,7 +533,6 @@ class PayoutStatusService {
 
     const ata = await getAssociatedTokenAddress(mintAddress, walletPubkey);
 
-    let balance = 0;
     const account = await getAccount(connection, ata).catch(() => null);
 
     if (!account) {
@@ -503,40 +547,21 @@ class PayoutStatusService {
       };
     }
 
-    balance = Number(account.amount) / 10 ** ELIZA_DECIMALS.solana;
-
-    if (balance === 0) {
-      return {
-        network: "solana",
-        configured: true,
-        walletAddress: this.maskAddress(walletAddress),
-        balance,
-        hasBalance: false,
-        status: "no_balance",
-        message: "Payout wallet has no elizaOS tokens",
-      };
+    // Fail-closed on an unreadable on-chain balance: a corrupt account.amount
+    // that did not throw must degrade Solana to not_configured, never fabricate
+    // "operational" (see classifyPayoutNetworkBalance).
+    const classification = classifyPayoutNetworkBalance(account.amount, ELIZA_DECIMALS.solana);
+    if (classification.status === "not_configured") {
+      logger.warn("[PayoutStatus] solana balance is unreadable; treating as unconfigured", {
+        rawBalance: String(account.amount),
+        decimals: ELIZA_DECIMALS.solana,
+      });
     }
-
-    if (balance < LOW_BALANCE_THRESHOLD) {
-      return {
-        network: "solana",
-        configured: true,
-        walletAddress: this.maskAddress(walletAddress),
-        balance,
-        hasBalance: true,
-        status: "low_balance",
-        message: `Low balance: ${balance.toFixed(2)} tokens (threshold: ${LOW_BALANCE_THRESHOLD})`,
-      };
-    }
-
     return {
       network: "solana",
       configured: true,
       walletAddress: this.maskAddress(walletAddress),
-      balance,
-      hasBalance: true,
-      status: "operational",
-      message: `Operational with ${balance.toFixed(2)} tokens available`,
+      ...classification,
     };
   }
 


### PR DESCRIPTION
## #13415 slice — `payout-status.ts` on-chain-balance NaN fail-open

Fallback-slop successor to #12788 (cloud-shared service layer). Distinct file from prior #13415 slices: auto-top-up #13507, agent-billing-gate #13522, token-redemption-secure #13518, payout-processor #13508, oxapay #13527.

### The bug (fail-OPEN money-availability gate)

`checkEvmNetwork` / `checkSolanaNetwork` computed the token balance as `balance = Number(rawAmount) / 10 ** decimals` **with no finite guard**, then classified it with `balance === 0` and `balance < LOW_BALANCE_THRESHOLD`.

A corrupt / unparseable on-chain read that **did not throw** (`Number()` returns `NaN` rather than throwing, so `resolveNetworkStatus`'s outer try/catch never caught it) produced `balance = NaN`:

- `NaN === 0` → `false`
- `NaN < LOW_BALANCE_THRESHOLD` → `false`

…so control fell through to the terminal `status: "operational", hasBalance: true, message: "Operational with NaN tokens available"`. That made `operationalNetworks.length > 0`, reported the whole payout system `operational: true`, and **enabled token redemption against a payout wallet whose balance was never verified**. (The `PAYOUT_STATUS_ASSUME_OPERATIONAL` production guard elsewhere in the file confirms "operational" is a real availability gate.)

### The fix (fail-CLOSED)

New pure, exported `classifyPayoutNetworkBalance(rawAmount, decimals)` returns the balance-derived `{ balance, hasBalance, status, message }`. Fail-closed boundary: **`!Number.isFinite(balance)` → `not_configured`, `hasBalance: false`, `balance: 0`** with an explicit "unreadable on-chain value" message and an observable `logger.warn` at each call site — never `operational`. Finite-value classification (`no_balance` / `low_balance` / `operational`, exact messages, `>= threshold` boundary) is **behavior-preserving**. Both EVM and Solana checks route through it; the existing `error`-flag and setup-throw paths keep their fail-closed `not_configured` returns.

### Tests

`payout-status-balance.test.ts` — **8/8** (`bun test`, 28 expect calls):
- **fail-closed:** NaN → `not_configured` (regression asserts the old fabricated `operational`/`low_balance` verdict + `NaN` message are gone), `Infinity` → `not_configured`, unparseable string → `not_configured`.
- **preserved:** `0n` → `no_balance`; 50 tokens → `low_balance`; exactly 100 (threshold) → `operational` (>= boundary); 12,345 tokens → `operational`; a `bigint` on-chain amount (viem/spl-token read shape) classifies without throwing.

Existing `__tests__/payout-status-resilience.test.ts` **4/4**, no regression.

### Verification

- `bun test` payout-status-balance → 8 pass / 0 fail; resilience → 4 pass / 0 fail.
- `bunx @biomejs/biome check` (touched files) → clean.
- `bun run audit:error-policy-ratchet` → `payout-status.ts: emptyCatch 0->0, serverConsole 0->0`, no new fallback-slop.
- `bun run --cwd packages/cloud/shared typecheck` → **zero errors in the two touched files** (13 pre-existing baseline errors, all in unrelated `packages/app-core/src/services/{account-pool,coding-account-bridge}.ts` `@elizaos/auth` symlink drift documented in prior merged cloud-shared slices).
- codex review (`--base origin/develop`) → clean: "did not find any introduced correctness issues in the touched code."

Evidence: `.github/issue-evidence/13415-payout-status-balance-fallback.md`. UI/model/audio: N/A (service unit boundary; on-chain RPC reads only).

Issue stays open for the remaining service-layer inventory.

— [sol-orch]