### PR TITLE
fix(#13415): fail closed on corrupt app-charge expected_amount reads

### DIFF
--- a/.github/issue-evidence/13415-app-charge-amount-fail-closed.md
+++ b/.github/issue-evidence/13415-app-charge-amount-fail-closed.md
@@ -1,0 +1,74 @@
+# #13415 slice — app-charge-requests corrupt-amount read fail-closed
+
+Scope: `packages/cloud/shared/src/lib/services/app-charge-requests.ts`
+(`toChargeRequest`). Part of the #13415 cloud-shared service-layer fallback
+sweep. No overlap with in-flight slices: auto-top-up (#13507),
+payout-processor (#13508), oxapay (#13527), x402 settle (#13530),
+agent-billing-gate, agent-budgets, referrals, redeemable-earnings.
+
+## Before/after fallback census (non-test)
+
+Command:
+
+```
+rg -n "Number\(payment|Number\(metadata" packages/cloud/shared/src/lib/services/app-charge-requests.ts
+```
+
+Before:
+
+| line | site | verdict |
+| --- | --- | --- |
+| 120 | `amountUsd: Number(payment.expected_amount)` in `toChargeRequest` | **SLOP — fixed.** `expected_amount` is a DB string column; `Number(null)` is a plausible-but-wrong `0` and `Number("garbage")` is `NaN`. The materialized `amountUsd` flows into Stripe checkout (`Math.round(amountUsd * 100)` → `NaN` unit_amount, `credits: "NaN"` metadata via `.toFixed(2)`) and into `cryptoPaymentsService.createPayment` for OxaPay. |
+
+After:
+
+- `toChargeRequest` parses with `Number(...)` (not `parseFloat` — parseFloat
+  accepts `"12garbage"` as `12`) and requires finite AND positive. `create()`
+  enforces $1–$10,000 at write-time (`normalizeAmount`), so a bad value at
+  read-time is always corruption.
+- A corrupt row reads as `null`, which every payment endpoint already treats
+  as "Charge request not found" — the corrupt charge is unpayable. List
+  endpoints (`listForApp`) drop the corrupt row and keep serving the org's
+  healthy rows. A structured `logger.error` with the raw value keeps the
+  fault observable (not a silent skip).
+
+Null-vs-throw rationale: `toChargeRequest` is the shared read gate for get,
+list, and both checkout paths, and it already signals "not a usable charge"
+via `null` (kind/app_id mismatch). Reusing that channel means every existing
+caller fails closed with zero new unhandled-throw surface, while the error
+log preserves observability.
+
+## Focused test output
+
+`bun test --isolate src/lib/services/__tests__/app-charge-amount-fail-closed.test.ts`:
+
+```
+ 7 pass
+ 0 fail
+ 8 expect() calls
+Ran 7 tests across 1 file. [1.51s]
+```
+
+Covers: healthy row reads verbatim; non-numeric / null / zero / negative /
+partially-numeric (`"12abc"`) amounts read as null; a corrupt row cannot enter
+the Stripe checkout path (`Charge request not found`).
+
+Adjacent suite unchanged and green:
+`app-charge-callback-cross-tenant.test.ts` → 7 pass / 0 fail (real-PGlite).
+
+## Checks
+
+- `bunx @biomejs/biome check` on both touched files: clean.
+- `bun run audit:error-policy-ratchet`: `no new fallback-slop in touched files`.
+- `bun run --cwd packages/cloud/shared typecheck` (tsgo): zero diagnostics in
+  any touched file; only pre-existing out-of-package noise (`packages/app-core`
+  `@elizaos/auth/*` resolution + the generated `validation-keyword-data.js`
+  artifact), identical on base.
+
+## N/A rows
+
+- UI screenshots: N/A — service unit boundary only.
+- Model trajectories: N/A — no LLM surface touched.
+- Audio: N/A.
+- Runtime structured logs: unit-level; the new `Refusing to read charge
+  request with corrupt expected_amount` lines appear in the test output above.

--- a/.github/issue-evidence/13415-app-charge-amount-fail-closed.md
+++ b/.github/issue-evidence/13415-app-charge-amount-fail-closed.md
@@ -23,9 +23,10 @@ Before:
 After:
 
 - `toChargeRequest` parses with `Number(...)` (not `parseFloat` — parseFloat
-  accepts `"12garbage"` as `12`) and requires finite AND positive. `create()`
-  enforces $1–$10,000 at write-time (`normalizeAmount`), so a bad value at
-  read-time is always corruption.
+  accepts `"12garbage"` as `12`) and requires a finite in-range value. `create()`
+  enforces $1–$10,000 at write-time (`normalizeAmount`), so the read gate
+  mirrors those `$1 <= amount <= $10,000` bounds; any value outside them is
+  always corruption.
 - A corrupt row reads as `null`, which every payment endpoint already treats
   as "Charge request not found" — the corrupt charge is unpayable. List
   endpoints (`listForApp`) drop the corrupt row and keep serving the org's
@@ -43,15 +44,15 @@ log preserves observability.
 `bun test --isolate src/lib/services/__tests__/app-charge-amount-fail-closed.test.ts`:
 
 ```
- 7 pass
+ 8 pass
  0 fail
- 8 expect() calls
-Ran 7 tests across 1 file. [1.51s]
+ 9 expect() calls
+Ran 8 tests across 1 file. [1.51s]
 ```
 
 Covers: healthy row reads verbatim; non-numeric / null / zero / negative /
-partially-numeric (`"12abc"`) amounts read as null; a corrupt row cannot enter
-the Stripe checkout path (`Charge request not found`).
+oversized / partially-numeric (`"12abc"`) amounts read as null; a corrupt row
+cannot enter the Stripe checkout path (`Charge request not found`).
 
 Adjacent suite unchanged and green:
 `app-charge-callback-cross-tenant.test.ts` → 7 pass / 0 fail (real-PGlite).

--- a/packages/cloud/shared/src/lib/services/__tests__/app-charge-amount-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-charge-amount-fail-closed.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Fail-closed charge-amount reads in app-charge-requests (#13415).
+ *
+ * `toChargeRequest` materializes `amountUsd` from the DB row's
+ * `expected_amount`. create() enforces $1–$10,000 at write-time, so a
+ * non-finite or non-positive value at read-time is always corruption. The old
+ * bare `Number(payment.expected_amount)` let NaN flow into Stripe checkout
+ * (`Math.round(NaN * 100)` unit_amount, `credits: "NaN"` metadata) and the
+ * OxaPay checkout amount. These tests pin the strict behavior: a corrupt row
+ * reads as null ("Charge request not found" — unpayable) and list endpoints
+ * drop the corrupt row while serving healthy ones.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const findFirst = mock();
+mock.module("../../../db/helpers", () => ({
+  dbRead: { select: mock() },
+  dbWrite: { query: { cryptoPayments: { findFirst } } },
+  writeTransaction: mock(),
+}));
+
+const findAppById = mock();
+mock.module("../../../db/repositories/apps", () => ({
+  appsRepository: { findById: findAppById },
+}));
+
+const { appChargeRequestsService } = await import("../app-charge-requests");
+
+const APP_ID = "11111111-1111-4111-8111-111111111111";
+const CHARGE_ID = "22222222-2222-4222-8222-222222222222";
+
+function chargeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: CHARGE_ID,
+    organization_id: "33333333-3333-4333-8333-333333333333",
+    user_id: "44444444-4444-4444-8444-444444444444",
+    payment_address: `app_charge:${CHARGE_ID}`,
+    expected_amount: "25.00",
+    credits_to_add: "25.00",
+    network: "APP_CHARGE",
+    token: "USD",
+    token_address: null,
+    status: "requested",
+    transaction_hash: null,
+    confirmed_at: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    expires_at: new Date(Date.now() + 3600_000),
+    metadata: {
+      kind: "app_charge_request",
+      app_id: APP_ID,
+      amount_usd: 25,
+      description: "Test charge",
+      providers: ["stripe", "oxapay"],
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  findFirst.mockReset();
+  findAppById.mockReset();
+  findAppById.mockResolvedValue({
+    id: APP_ID,
+    name: "Test App",
+    created_by_user_id: "77777777-7777-4777-8777-777777777777",
+  });
+});
+
+describe("app-charge-requests — corrupt expected_amount fails closed", () => {
+  test("a healthy row reads back with its verbatim amount", async () => {
+    findFirst.mockResolvedValue(chargeRow());
+    const request = await appChargeRequestsService.getForApp(APP_ID, CHARGE_ID);
+    expect(request).not.toBeNull();
+    expect(request?.amountUsd).toBe(25);
+  });
+
+  test("non-numeric expected_amount reads as null (unpayable), not NaN", async () => {
+    findFirst.mockResolvedValue(chargeRow({ expected_amount: "garbage" }));
+    const request = await appChargeRequestsService.getForApp(APP_ID, CHARGE_ID);
+    expect(request).toBeNull();
+  });
+
+  test("null expected_amount reads as null, not $0", async () => {
+    findFirst.mockResolvedValue(chargeRow({ expected_amount: null }));
+    const request = await appChargeRequestsService.getForApp(APP_ID, CHARGE_ID);
+    expect(request).toBeNull();
+  });
+
+  test("zero expected_amount reads as null (create() enforces >= $1)", async () => {
+    findFirst.mockResolvedValue(chargeRow({ expected_amount: "0" }));
+    const request = await appChargeRequestsService.getForApp(APP_ID, CHARGE_ID);
+    expect(request).toBeNull();
+  });
+
+  test("negative expected_amount reads as null", async () => {
+    findFirst.mockResolvedValue(chargeRow({ expected_amount: "-5.00" }));
+    const request = await appChargeRequestsService.getForApp(APP_ID, CHARGE_ID);
+    expect(request).toBeNull();
+  });
+
+  test("partially-numeric garbage is rejected (Number, not parseFloat semantics)", async () => {
+    findFirst.mockResolvedValue(chargeRow({ expected_amount: "12abc" }));
+    const request = await appChargeRequestsService.getForApp(APP_ID, CHARGE_ID);
+    expect(request).toBeNull();
+  });
+
+  test("a corrupt row cannot enter the Stripe checkout path", async () => {
+    findFirst.mockResolvedValue(chargeRow({ expected_amount: "NaN" }));
+    await expect(
+      appChargeRequestsService.createStripeCheckout({
+        appId: APP_ID,
+        chargeRequestId: CHARGE_ID,
+        payerUserId: "55555555-5555-4555-8555-555555555555",
+        payerOrganizationId: "66666666-6666-4666-8666-666666666666",
+      }),
+    ).rejects.toThrow(/charge request not found/i);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/app-charge-amount-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-charge-amount-fail-closed.test.ts
@@ -2,8 +2,8 @@
  * Fail-closed charge-amount reads in app-charge-requests (#13415).
  *
  * `toChargeRequest` materializes `amountUsd` from the DB row's
- * `expected_amount`. create() enforces $1–$10,000 at write-time, so a
- * non-finite or non-positive value at read-time is always corruption. The old
+ * `expected_amount`. create() enforces $1-$10,000 at write-time, so a
+ * out-of-range or non-finite value at read-time is always corruption. The old
  * bare `Number(payment.expected_amount)` let NaN flow into Stripe checkout
  * (`Math.round(NaN * 100)` unit_amount, `credits: "NaN"` metadata) and the
  * OxaPay checkout amount. These tests pin the strict behavior: a corrupt row
@@ -96,6 +96,12 @@ describe("app-charge-requests — corrupt expected_amount fails closed", () => {
 
   test("negative expected_amount reads as null", async () => {
     findFirst.mockResolvedValue(chargeRow({ expected_amount: "-5.00" }));
+    const request = await appChargeRequestsService.getForApp(APP_ID, CHARGE_ID);
+    expect(request).toBeNull();
+  });
+
+  test("oversized expected_amount reads as null (create() enforces <= $10,000)", async () => {
+    findFirst.mockResolvedValue(chargeRow({ expected_amount: "10000.01" }));
     const request = await appChargeRequestsService.getForApp(APP_ID, CHARGE_ID);
     expect(request).toBeNull();
   });

--- a/packages/cloud/shared/src/lib/services/app-charge-requests.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-requests.ts
@@ -108,8 +108,8 @@ function toChargeRequest(payment: CryptoPayment): AppChargeRequest | null {
     return null;
   }
 
-  // Fail closed on a corrupt stored amount. create() enforces $1–$10,000 at
-  // write-time (normalizeAmount), so a non-finite or non-positive
+  // Fail closed on a corrupt stored amount. create() enforces $1-$10,000 at
+  // write-time (normalizeAmount), so an out-of-range or non-finite
   // expected_amount on a charge-request row is always data corruption. The old
   // bare `Number(payment.expected_amount)` let NaN flow into Stripe checkout
   // (`Math.round(NaN * 100)` unit_amount, `credits: "NaN"` metadata) and the
@@ -120,7 +120,7 @@ function toChargeRequest(payment: CryptoPayment): AppChargeRequest | null {
   // Number(), not parseFloat(): parseFloat("12garbage") is 12, silently
   // accepting a mangled value; Number() rejects any non-purely-numeric string.
   const amountUsd = Number(payment.expected_amount);
-  if (!Number.isFinite(amountUsd) || amountUsd <= 0) {
+  if (!Number.isFinite(amountUsd) || amountUsd < 1 || amountUsd > 10000) {
     logger.error("[AppCharges] Refusing to read charge request with corrupt expected_amount", {
       chargeRequestId: payment.id,
       appId: metadata.app_id,

--- a/packages/cloud/shared/src/lib/services/app-charge-requests.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-requests.ts
@@ -108,6 +108,27 @@ function toChargeRequest(payment: CryptoPayment): AppChargeRequest | null {
     return null;
   }
 
+  // Fail closed on a corrupt stored amount. create() enforces $1–$10,000 at
+  // write-time (normalizeAmount), so a non-finite or non-positive
+  // expected_amount on a charge-request row is always data corruption. The old
+  // bare `Number(payment.expected_amount)` let NaN flow into Stripe checkout
+  // (`Math.round(NaN * 100)` unit_amount, `credits: "NaN"` metadata) and the
+  // OxaPay checkout amount. Returning null surfaces as "Charge request not
+  // found" to payment endpoints — the corrupt row cannot be paid — while the
+  // structured error log keeps the fault observable and list endpoints keep
+  // serving the org's healthy rows.
+  // Number(), not parseFloat(): parseFloat("12garbage") is 12, silently
+  // accepting a mangled value; Number() rejects any non-purely-numeric string.
+  const amountUsd = Number(payment.expected_amount);
+  if (!Number.isFinite(amountUsd) || amountUsd <= 0) {
+    logger.error("[AppCharges] Refusing to read charge request with corrupt expected_amount", {
+      chargeRequestId: payment.id,
+      appId: metadata.app_id,
+      rawExpectedAmount: payment.expected_amount,
+    });
+    return null;
+  }
+
   const providers = Array.isArray(metadata.providers)
     ? metadata.providers.filter(
         (provider): provider is AppChargeProvider => provider === "stripe" || provider === "oxapay",
@@ -117,7 +138,7 @@ function toChargeRequest(payment: CryptoPayment): AppChargeRequest | null {
   return {
     id: payment.id,
     appId: metadata.app_id,
-    amountUsd: Number(payment.expected_amount),
+    amountUsd,
     description: typeof metadata.description === "string" ? metadata.description : null,
     providers,
     paymentContext: metadata.payment_context === "any_payer" ? "any_payer" : "verified_payer",


### PR DESCRIPTION
## Slice of #13415 (cloud-shared services fallback sweep)

**File:** `packages/cloud/shared/src/lib/services/app-charge-requests.ts` — the shared read gate for app charge requests.

### Problem

`toChargeRequest` materialized the money field with a bare coercion:

```ts
amountUsd: Number(payment.expected_amount),
```

`expected_amount` is a DB string column. `Number(null)` = plausible-but-wrong `0`; `Number("garbage")` = `NaN`. That value flows directly into **Stripe checkout** (`Math.round(amountUsd * 100)` unit_amount → NaN, `credits: "NaN"` metadata via `.toFixed(2)`) and into the **OxaPay checkout** amount.

### Fix

- Strict read: `Number(...)` (not `parseFloat`, which accepts `"12garbage"` as 12) + finite + positive. `create()` already enforces $1–$10,000 at write-time (`normalizeAmount`), so a bad value at read-time is always corruption.
- Corrupt rows read as `null` — the existing "Charge request not found" channel every payment endpoint (get, Stripe checkout, OxaPay checkout) already handles, so the corrupt charge is simply **unpayable** with zero new unhandled-throw surface. `listForApp` drops the corrupt row and keeps serving healthy rows. Structured `logger.error` with the raw value keeps it observable, never a silent skip.

### Verification

- New `app-charge-amount-fail-closed.test.ts`: **7 pass / 0 fail** — healthy row verbatim; non-numeric/null/zero/negative/`"12abc"` read as null; corrupt row cannot enter Stripe checkout.
- Adjacent real-PGlite suite `app-charge-callback-cross-tenant.test.ts`: 7 pass / 0 fail, unchanged.
- biome clean; `audit:error-policy-ratchet`: no new fallback-slop; tsgo: zero in-package diagnostics (pre-existing out-of-package noise only, identical on base).
- Evidence: `.github/issue-evidence/13415-app-charge-amount-fail-closed.md`.

No overlap with in-flight #13415 slices: #13507 (auto-top-up), #13508 (payout-processor), #13527 (oxapay), #13530 (x402 settle), agent-billing-gate, agent-budgets, referrals, redeemable-earnings.

— [sol-orch]