### PR TITLE
fix(cloud): make the white-on-white primary CTAs visible (Create App + siblings)

### DIFF
--- a/packages/ui/src/cloud/api-explorer/ApiExplorerPage.tsx
+++ b/packages/ui/src/cloud/api-explorer/ApiExplorerPage.tsx
@@ -474,7 +474,7 @@ export function ApiExplorerSurface() {
                 variant="ghost"
                 type="button"
                 onClick={handleCopyJson}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-[var(--accent)] text-white rounded-sm hover:bg-[#e54f00] transition-colors"
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-[#FF5800] text-black rounded-sm hover:bg-[#e54f00] transition-colors"
               >
                 {copied === "json" ? (
                   <Check className="h-3.5 w-3.5" />

--- a/packages/ui/src/cloud/applications/components/BuyDomainCard.tsx
+++ b/packages/ui/src/cloud/applications/components/BuyDomainCard.tsx
@@ -208,7 +208,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
           type="submit"
           size="sm"
           disabled={!isValid || checking}
-          className="bg-[var(--accent)] hover:bg-[#e54f00] text-white rounded-sm shrink-0"
+          className="bg-[#FF5800] hover:bg-[#e54f00] text-black rounded-sm shrink-0"
         >
           {checking ? (
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -264,7 +264,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
               <Button
                 size="sm"
                 disabled={buying}
-                className="bg-[var(--accent)] hover:bg-[#e54f00] text-white rounded-sm shrink-0"
+                className="bg-[#FF5800] hover:bg-[#e54f00] text-black rounded-sm shrink-0"
               >
                 {buying ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -304,7 +304,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
                 </AlertDialogCancel>
                 <AlertDialogAction
                   onClick={() => void handleBuy()}
-                  className="bg-[var(--accent)] hover:bg-[#e54f00] text-white"
+                  className="bg-[#FF5800] hover:bg-[#e54f00] text-black"
                 >
                   {t("cloud.appDomains.buyConfirmAction", {
                     defaultValue: "Buy domain",

--- a/packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx
+++ b/packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx
@@ -248,7 +248,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
                 onClick={() => {
                   navigate(`/dashboard/apps/${appId}?tab=monetization`);
                 }}
-                className="bg-[var(--accent)] hover:bg-[#e54f00] text-white"
+                className="bg-[#FF5800] hover:bg-[#e54f00] text-black"
               >
                 Enable Monetization
               </Button>

--- a/packages/ui/src/cloud/applications/components/app-promote.tsx
+++ b/packages/ui/src/cloud/applications/components/app-promote.tsx
@@ -146,7 +146,7 @@ export function AppPromote({ app }: AppPromoteProps) {
           <Button
             onClick={() => setShowPromoteDialog(true)}
             size="sm"
-            className="bg-[var(--accent)] hover:bg-[#e54f00] text-white rounded-sm"
+            className="bg-[#FF5800] hover:bg-[#e54f00] text-black rounded-sm"
           >
             <Megaphone className="h-4 w-4 mr-1.5" />
             {t("cloud.appPromote.launch", { defaultValue: "Launch Promotion" })}

--- a/packages/ui/src/cloud/applications/components/create-app-button.tsx
+++ b/packages/ui/src/cloud/applications/components/create-app-button.tsx
@@ -16,7 +16,7 @@ export function CreateAppButton() {
     <>
       <Button
         onClick={() => setIsOpen(true)}
-        className="bg-[var(--accent)] hover:bg-[#e54f00] text-white"
+        className="bg-[#FF5800] hover:bg-[#e54f00] text-black"
         data-onboarding="apps-create"
       >
         <Plus className="h-4 w-4 mr-2" />

--- a/packages/ui/src/cloud/billing/components/auto-top-up-card.tsx
+++ b/packages/ui/src/cloud/billing/components/auto-top-up-card.tsx
@@ -259,7 +259,7 @@ export function AutoTopUpCard() {
             type="button"
             onClick={handleSave}
             disabled={saving || !!validationError || !!noPaymentMethod}
-            className="bg-[var(--accent)] hover:bg-[#e54f00] text-white font-mono"
+            className="bg-[#FF5800] hover:bg-[#e54f00] text-black font-mono"
           >
             {saving ? (
               <>

--- a/packages/ui/src/cloud/join/JoinPage.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.tsx
@@ -156,7 +156,7 @@ export default function JoinPage(): React.JSX.Element {
               variant="ghost"
               type="button"
               onClick={handleRetry}
-              className="bg-[var(--accent)] px-6 py-2.5 font-semibold text-white transition-colors hover:bg-[#e54f00]"
+              className="bg-[#FF5800] px-6 py-2.5 font-semibold text-black transition-colors hover:bg-[#e54f00]"
             >
               {t("cloud.join.retry", { defaultValue: "Try again" })}
             </Button>


### PR DESCRIPTION
Launch-QA card: **prod dashboard/apps — broken white rectangle above stats tiles**.

## Root cause (verified live on prod + staging)

The "broken white rectangle" is the **Create App** button rendering as a solid white box with an invisible white-on-white label. Live DOM inspection on `elizacloud.ai/dashboard/apps`:
- button classes: `bg-[var(--accent)] hover:bg-[#e54f00] text-white`
- under `.theme-cloud`, `--accent` resolves to `var(--brand-white)` (`#fff`)
- → `bg-[var(--accent)]` = white, `text-white` = white ⇒ computed `background: rgb(255,255,255)`, `color: rgb(255,255,255)`.

The card guessed "image/logo failing" — it is not; it is this button. It only looked fine on dark themes where `--accent` is orange.

Same copy-pasted broken CTA appears in **7 places / 5 files** (Create App, BuyDomainCard ×3, app-promote, app-earnings, auto-top-up) — fixing one and leaving the rest would be a silent partial fix, so all 7 are aligned here.

## Fix

Align to the established primary-CTA pattern already used across the console (chat-redirect, agents-section, mcps-section, dashboard tiles): `bg-[#FF5800] text-black hover:bg-[#e54f00]` — orange resting, **black** label (readable), darker-orange hover (per the palette rule: orange→darker-orange, never orange→black). className-only, no logic change.

## Evidence

- **Before:** two invisible white boxes on `dashboard/apps` (top bar + empty state) — reproduce live now.
- **After:** injected the fixed classes into the live staging DOM → computed `background: rgb(255,88,0)` + `color: rgb(0,0,0)` = visible orange button with a black label + black `+` icon. Screenshot captured.

Card → Needs-human-verify.