### PR TITLE
test(ci): red merge queue canary (#13386)

### DIFF
--- a/packages/scripts/__tests__/merge-queue-red-canary.test.ts
+++ b/packages/scripts/__tests__/merge-queue-red-canary.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from "bun:test";
+
+describe("merge queue red canary for #13386", () => {
+  it("intentionally fails to prove required checks block merge", () => {
+    expect("blocked-by-required-checks").toBe("mergeable");
+  });
+});


### PR DESCRIPTION
## Summary

Intentional red canary for #13386. This branch adds a single failing Bun test so required checks should block merge and prove the develop ruleset/queue does not admit a failing aggregate.

## Cleanup

This PR should be closed after the failing-check evidence is captured. It must not be auto-merged.

Refs #13386