### PR TITLE
fix(#13415): fail closed on corrupt agent-monetization NUMERIC reads

### DIFF
--- a/.github/issue-evidence/13415-agent-monetization-numeric-fallback.md
+++ b/.github/issue-evidence/13415-agent-monetization-numeric-fallback.md
@@ -1,0 +1,76 @@
+# #13415 — cloud-shared service-layer fallback slop: `agent-monetization.ts` NUMERIC fail-closed
+
+Slice of the `packages/cloud/shared/src/lib/services/**` fallback-slop sweep.
+Distinct file from every prior/live #13415 slice (auto-top-up, agent-billing-gate,
+token-redemption-secure, payout-processor, oxapay, agent-budgets, credits,
+redeemable-earnings, payout-status, x402).
+
+## Vulnerability (money-out fail-open)
+
+`AgentMonetizationService.getAgentMonetization` read two Postgres `NUMERIC`
+columns via a bare `Number(...)`:
+
+```ts
+markupPercentage: Number(agent.inference_markup_percentage || 0),
+totalEarnings:    Number(agent.total_creator_earnings),
+```
+
+Postgres accepts `'NaN'::numeric` as a **valid** stored value, so a poisoned row
+reads back as the driver string `"NaN"` and `Number("NaN")` is `NaN`. That NaN
+then poisoned downstream consumers **silently** (no throw ever fires because every
+ordering / threshold comparison against `NaN` is `false`):
+
+- the service's own creator-markup math — `estimateCost` /
+  `processUsage`: `baseCost * (markupPercentage / 100)` → `NaN` → a fabricated /
+  garbage creator markup;
+- `getEarningsSummary`: `sum + Number(a.total_creator_earnings)` → `NaN` total, and
+  the `.sort((a,b) => Number(...) - Number(...))` ranking becomes arbitrary;
+- the display route `api/v1/agents/[agentId]/monetization/route.ts`:
+  `info?.totalEarnings || 0` collapsed the NaN into a **fabricated healthy `$0`**
+  over a corrupt earnings ledger (`NaN || 0 === 0`).
+
+## Fix (fail closed)
+
+New colocated, exported, pure `parseAgentMonetizationNumber(value, field)` +
+`CorruptAgentMonetizationNumberError`:
+
+- throws on `null` / `undefined` / blank / non-finite (`NaN`, `Infinity`) / non-numeric;
+- preserves an explicit domain zero (`"0"`, `"0.00"`) and negative domain values.
+
+Wired into both NUMERIC read sites:
+
+- `getAgentMonetization`: `markupPercentage` (null-safe default 0 preserved for the
+  NOT-NULL-with-`"0.00"`-default column; a **corrupt** value throws) + `totalEarnings`
+  (throws on corrupt).
+- `getEarningsSummary`: each monetized agent's `total_creator_earnings` is read once
+  through the boundary before summing / ranking; a corrupt row throws instead of
+  poisoning the summary.
+
+The display route already wraps the call in `try/catch → failureResponse`, so a
+corrupt row now surfaces an observable error instead of a fabricated `$0`.
+
+Mirrors the merged NUMERIC fail-closed slices #13454 / #13474 / #13482 / #13486 /
+#13503 / #13504 / #13507.
+
+## Path / verdict table
+
+| path | line(s) | before | after |
+| --- | --- | --- | --- |
+| `agent-monetization.ts` `getAgentMonetization` | markup + earnings reads | `Number(row.<numeric>)` → NaN on corrupt | `parseAgentMonetizationNumber(...)` throws (markup null-safe default 0) |
+| `agent-monetization.ts` `getEarningsSummary` | sum + sort + map | `Number(row.total_creator_earnings)` ×N → NaN | single boundary read per row, throws on corrupt |
+| `agent-monetization.ts` `recordCreatorEarnings` | `earnings <= 0` guard + `new Decimal(earnings)` | already fail-loud (Decimal(NaN) throws) | unchanged |
+| `agent-monetization.ts` `estimateCost` / `processUsage` | `markupPercentage` param | consumer-supplied; would inherit a corrupt read via `getAgentMonetization` | protected upstream by the read boundary |
+
+## Verification
+
+- Focused tests: `packages/cloud/shared/src/lib/services/__tests__/agent-monetization-numeric-fail-closed.test.ts` — **11/11 pass** (parser boundary exhaustive incl `'NaN'`/`Infinity`/blank fail-open regressions; `getAgentMonetization` healthy/corrupt-markup/corrupt-earnings/null-default/missing-agent; `getEarningsSummary` healthy sum+rank / single-corrupt-row-fails-closed).
+- `bunx @biomejs/biome check <touched files>` — clean.
+- `bun run audit:error-policy-ratchet` — `no new fallback-slop in touched files` (EXIT 0).
+- `bun run --cwd packages/cloud/shared typecheck` — 17 pre-existing baseline errors in unrelated files (`app-core/account-pool.ts`, `app-core/coding-account-bridge.ts`, `node-redis-adapter.ts`, `plugin-mcp/utils/json.ts`, `anthropic-web-search.ts`), **zero in `agent-monetization.ts`** — identical baseline to the merged sibling cloud-shared slices.
+- `git diff --check` — clean.
+
+## N/A rows
+
+- UI screenshots: N/A — service unit boundary only.
+- Model trajectories / audio: N/A — no such surface touched.
+- Runtime logs: N/A — service unit boundary; the fix converts a silent NaN into a thrown `CorruptAgentMonetizationNumberError` surfaced by the route's existing `failureResponse`.

--- a/packages/cloud/shared/src/lib/services/__tests__/agent-monetization-numeric-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/agent-monetization-numeric-fail-closed.test.ts
@@ -1,0 +1,186 @@
+/**
+ * #13415 — agent-monetization NUMERIC money-out fail-closed boundary.
+ *
+ * `getAgentMonetization` read `inference_markup_percentage` +
+ * `total_creator_earnings` (Postgres NUMERIC → driver string) via a bare
+ * `Number(...)`. Postgres accepts `'NaN'::numeric` as a valid value, so a
+ * poisoned row reads back as the string `"NaN"` and `Number("NaN")` is `NaN`.
+ * That NaN then poisoned every downstream consumer SILENTLY:
+ *   - the service's own creator-markup math (`baseCost * (markup / 100)`) is
+ *     `NaN` with no throw → a fabricated / garbage charge;
+ *   - `getEarningsSummary` summed + sorted `NaN`, producing a garbage summary
+ *     (every `NaN` comparison is `false`, so ranking is arbitrary);
+ *   - the display route's `info?.totalEarnings || 0` collapsed the NaN into a
+ *     fabricated healthy `$0` over a corrupt earnings ledger.
+ *
+ * The fix reads both NUMERIC values through `parseAgentMonetizationNumber`,
+ * which THROWS on a corrupt/non-finite value (fail closed) while preserving an
+ * explicit domain zero. These tests drive the parser directly (exhaustive
+ * boundary + fail-open regressions) and the two real read sites via a stubbed
+ * `dbRead`, proving a corrupt row now throws instead of returning NaN.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+// Stub the DB client's read query so the read sites resolve deterministic rows
+// with no real Postgres. Only `dbRead.query.userCharacters.{findFirst,findMany}`
+// is used by the two methods under test. The rest of the client's exports
+// (`getDbConnectionInfo`, `dbWrite`, etc.) are spread from the real module so
+// modules that import them at load still resolve.
+import * as realDbClient from "../../../db/client";
+
+let findFirstRow: Record<string, unknown> | null = null;
+let findManyRows: Array<Record<string, unknown>> = [];
+
+const findFirst = mock(async () => findFirstRow);
+const findMany = mock(async () => findManyRows);
+
+mock.module("../../../db/client", () => ({
+  ...realDbClient,
+  dbRead: {
+    query: {
+      userCharacters: { findFirst, findMany },
+    },
+  },
+}));
+
+// Not exercised on the read paths under test, but imported at module load.
+mock.module("../credits", () => ({ creditsService: {} }));
+mock.module("../redeemable-earnings", () => ({ redeemableEarningsService: {} }));
+mock.module("../pricing", () => ({
+  calculateCost: mock(async () => ({ totalCost: 0 })),
+  estimateRequestCost: mock(async () => 0),
+  getProviderFromModel: mock(() => "openai"),
+}));
+
+const {
+  agentMonetizationService,
+  parseAgentMonetizationNumber,
+  CorruptAgentMonetizationNumberError,
+} = await import("../agent-monetization");
+
+const baseAgentRow = (overrides: Record<string, unknown> = {}) => ({
+  id: "agent-1",
+  name: "Test Agent",
+  user_id: "00000000-0000-4000-8000-00000000user",
+  organization_id: "00000000-0000-4000-8000-0000000000org",
+  monetization_enabled: true,
+  inference_markup_percentage: "50.00",
+  total_creator_earnings: "12.3400",
+  total_inference_requests: 7,
+  ...overrides,
+});
+
+beforeEach(() => {
+  findFirstRow = null;
+  findManyRows = [];
+  findFirst.mockClear();
+  findMany.mockClear();
+});
+
+describe("parseAgentMonetizationNumber (fail-closed boundary)", () => {
+  test("parses valid NUMERIC strings and numbers", () => {
+    expect(parseAgentMonetizationNumber("50.00", "inference_markup_percentage")).toBe(50);
+    expect(parseAgentMonetizationNumber("12.3400", "total_creator_earnings")).toBeCloseTo(12.34, 6);
+    expect(parseAgentMonetizationNumber(0, "x")).toBe(0);
+    expect(parseAgentMonetizationNumber("0.00", "x")).toBe(0);
+    expect(parseAgentMonetizationNumber(-5, "x")).toBe(-5); // domain values pass through unchanged
+  });
+
+  test("THROWS on the corrupt 'NaN'::numeric read (the fail-open regression)", () => {
+    expect(() => parseAgentMonetizationNumber("NaN", "inference_markup_percentage")).toThrow(
+      CorruptAgentMonetizationNumberError,
+    );
+    expect(() => parseAgentMonetizationNumber(Number.NaN, "x")).toThrow(
+      CorruptAgentMonetizationNumberError,
+    );
+    // Proof of the pre-fix vulnerability: a bare Number("NaN") silently yields NaN.
+    expect(Number("NaN")).toBeNaN();
+  });
+
+  test("THROWS on null/undefined/blank/non-finite/garbage", () => {
+    for (const bad of [null, undefined, "", "   ", "abc", Number.POSITIVE_INFINITY, {}, []]) {
+      expect(() => parseAgentMonetizationNumber(bad, "field")).toThrow(
+        CorruptAgentMonetizationNumberError,
+      );
+    }
+  });
+
+  test("error names the field and raw value", () => {
+    try {
+      parseAgentMonetizationNumber("NaN", "total_creator_earnings");
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CorruptAgentMonetizationNumberError);
+      const err = e as InstanceType<typeof CorruptAgentMonetizationNumberError>;
+      expect(err.field).toBe("total_creator_earnings");
+      expect(err.rawValue).toBe("NaN");
+    }
+  });
+});
+
+describe("getAgentMonetization (read-site wiring)", () => {
+  test("healthy row parses markup + earnings through the boundary", async () => {
+    findFirstRow = baseAgentRow();
+    const info = await agentMonetizationService.getAgentMonetization("agent-1");
+    expect(info).not.toBeNull();
+    expect(info?.markupPercentage).toBe(50);
+    expect(info?.totalEarnings).toBeCloseTo(12.34, 6);
+    // Never NaN on a healthy read.
+    expect(Number.isFinite(info?.markupPercentage ?? Number.NaN)).toBe(true);
+    expect(Number.isFinite(info?.totalEarnings ?? Number.NaN)).toBe(true);
+  });
+
+  test("corrupt inference_markup_percentage THROWS instead of returning NaN markup", async () => {
+    findFirstRow = baseAgentRow({ inference_markup_percentage: "NaN" });
+    await expect(agentMonetizationService.getAgentMonetization("agent-1")).rejects.toBeInstanceOf(
+      CorruptAgentMonetizationNumberError,
+    );
+  });
+
+  test("corrupt total_creator_earnings THROWS instead of returning NaN earnings", async () => {
+    findFirstRow = baseAgentRow({ total_creator_earnings: "NaN" });
+    await expect(agentMonetizationService.getAgentMonetization("agent-1")).rejects.toBeInstanceOf(
+      CorruptAgentMonetizationNumberError,
+    );
+  });
+
+  test("null markup (defensive) defaults to domain 0, does not throw", async () => {
+    findFirstRow = baseAgentRow({ inference_markup_percentage: null });
+    const info = await agentMonetizationService.getAgentMonetization("agent-1");
+    expect(info?.markupPercentage).toBe(0);
+  });
+
+  test("missing agent returns null (unchanged)", async () => {
+    findFirstRow = null;
+    expect(await agentMonetizationService.getAgentMonetization("missing")).toBeNull();
+  });
+});
+
+describe("getEarningsSummary (read-site wiring)", () => {
+  test("healthy rows sum + rank without NaN poisoning", async () => {
+    findManyRows = [
+      baseAgentRow({ id: "a", total_creator_earnings: "10.0000" }),
+      baseAgentRow({ id: "b", total_creator_earnings: "30.0000" }),
+      baseAgentRow({ id: "c", total_creator_earnings: "20.0000", monetization_enabled: false }),
+    ];
+    const summary = await agentMonetizationService.getEarningsSummary("user-1");
+    // c is not monetized → excluded.
+    expect(summary.agentCount).toBe(2);
+    expect(summary.totalAgentEarnings).toBeCloseTo(40, 6);
+    // ranked descending by earnings — b (30) before a (10).
+    expect(summary.topAgents.map((t) => t.id)).toEqual(["b", "a"]);
+  });
+
+  test("a single corrupt monetized row FAILS the summary closed (no NaN total)", async () => {
+    findManyRows = [
+      baseAgentRow({ id: "a", total_creator_earnings: "10.0000" }),
+      baseAgentRow({ id: "poison", total_creator_earnings: "NaN" }),
+    ];
+    await expect(agentMonetizationService.getEarningsSummary("user-1")).rejects.toBeInstanceOf(
+      CorruptAgentMonetizationNumberError,
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-monetization.ts
+++ b/packages/cloud/shared/src/lib/services/agent-monetization.ts
@@ -26,6 +26,59 @@ import { creditsService } from "./credits";
 import { redeemableEarningsService } from "./redeemable-earnings";
 
 // ============================================================================
+// FAIL-CLOSED NUMERIC BOUNDARY (#13415)
+// ============================================================================
+
+/**
+ * A corrupt monetization NUMERIC read (`inference_markup_percentage`,
+ * `total_creator_earnings`) surfaces to JS as a driver string. Postgres accepts
+ * `'NaN'::numeric` as a valid value, so a poisoned row reads back as the string
+ * `"NaN"` and a bare `Number(...)` yields `NaN` — which then poisons the creator
+ * markup math silently: `baseCost * (NaN / 100)` is `NaN`, and every ordering /
+ * threshold comparison against `NaN` is `false`, so no throw ever fires and a
+ * fabricated / garbage charge (or a NaN-poisoned earnings display) sails through.
+ *
+ * This is the money-out fail-open the #13415 sweep hardens: parse at the read
+ * boundary and THROW on a corrupt/non-finite value instead of returning `NaN`.
+ * An explicit domain zero (`"0"`, `"0.00"`) is a legitimate value and is
+ * preserved. Mirrors the merged NUMERIC fail-closed slices
+ * (#13454 / #13474 / #13482 / #13486 / #13503 / #13504 / #13507).
+ */
+export class CorruptAgentMonetizationNumberError extends Error {
+  constructor(
+    readonly field: string,
+    readonly rawValue: unknown,
+  ) {
+    super(`agent-monetization: corrupt NUMERIC value for "${field}": ${JSON.stringify(rawValue)}`);
+    this.name = "CorruptAgentMonetizationNumberError";
+  }
+}
+
+export function parseAgentMonetizationNumber(value: unknown, field: string): number {
+  if (value === null || value === undefined) {
+    throw new CorruptAgentMonetizationNumberError(field, value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new CorruptAgentMonetizationNumberError(field, value);
+    }
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") {
+      throw new CorruptAgentMonetizationNumberError(field, value);
+    }
+    const parsed = Number(trimmed);
+    if (!Number.isFinite(parsed)) {
+      throw new CorruptAgentMonetizationNumberError(field, value);
+    }
+    return parsed;
+  }
+  throw new CorruptAgentMonetizationNumberError(field, value);
+}
+
+// ============================================================================
 // TYPES
 // ============================================================================
 
@@ -92,8 +145,23 @@ class AgentMonetizationService {
       ownerId: agent.user_id,
       organizationId: agent.organization_id,
       monetizationEnabled: agent.monetization_enabled,
-      markupPercentage: Number(agent.inference_markup_percentage || 0),
-      totalEarnings: Number(agent.total_creator_earnings),
+      // Fail closed: a corrupt markup NUMERIC must not read back as NaN and
+      // poison the creator-markup charge math downstream (#13415). A null/blank
+      // read defaults to a legitimate domain 0 (the column is NOT NULL with a
+      // "0.00" default, so this is defensive), but a corrupt "NaN"/garbage value
+      // throws instead of silently disabling the money gate.
+      markupPercentage:
+        agent.inference_markup_percentage === null ||
+        agent.inference_markup_percentage === undefined
+          ? 0
+          : parseAgentMonetizationNumber(
+              agent.inference_markup_percentage,
+              "inference_markup_percentage",
+            ),
+      totalEarnings: parseAgentMonetizationNumber(
+        agent.total_creator_earnings,
+        "total_creator_earnings",
+      ),
       totalRequests: agent.total_inference_requests,
     };
   }
@@ -402,19 +470,26 @@ class AgentMonetizationService {
 
     const monetizedAgents = agents.filter((a) => a.monetization_enabled);
 
-    const totalEarnings = monetizedAgents.reduce(
-      (sum, a) => sum + Number(a.total_creator_earnings),
-      0,
-    );
+    // Fail closed: a corrupt total_creator_earnings row must not silently poison
+    // the summed total (NaN) or the ranking (every NaN comparison is false, so a
+    // corrupt row would sort arbitrarily) — read each earnings value through the
+    // fail-closed boundary once so a poisoned row throws instead of producing a
+    // garbage earnings summary (#13415).
+    const monetizedEarnings = monetizedAgents.map((a) => ({
+      agent: a,
+      earnings: parseAgentMonetizationNumber(a.total_creator_earnings, "total_creator_earnings"),
+    }));
 
-    const topAgents = monetizedAgents
-      .sort((a, b) => Number(b.total_creator_earnings) - Number(a.total_creator_earnings))
+    const totalEarnings = monetizedEarnings.reduce((sum, e) => sum + e.earnings, 0);
+
+    const topAgents = monetizedEarnings
+      .sort((a, b) => b.earnings - a.earnings)
       .slice(0, 5)
-      .map((a) => ({
-        id: a.id,
-        name: a.name,
-        earnings: Number(a.total_creator_earnings),
-        requests: a.total_inference_requests,
+      .map((e) => ({
+        id: e.agent.id,
+        name: e.agent.name,
+        earnings: e.earnings,
+        requests: e.agent.total_inference_requests,
       }));
 
     return {


### PR DESCRIPTION
## #13415 — cloud-shared service-layer fallback-slop sweep: `agent-monetization.ts`

A slice of the `packages/cloud/shared/src/lib/services/**` fallback-slop sweep. Distinct file from every prior/live #13415 slice (auto-top-up #13507, agent-billing-gate #13522, token-redemption-secure #13518, payout-processor #13508, oxapay #13527, agent-budgets, credits, redeemable-earnings, payout-status, x402).

### Vulnerability (money-out fail-open)

`AgentMonetizationService.getAgentMonetization` read two Postgres `NUMERIC` columns via a bare `Number(...)`:

```ts
markupPercentage: Number(agent.inference_markup_percentage || 0),
totalEarnings:    Number(agent.total_creator_earnings),
```

Postgres accepts `'NaN'::numeric` as a **valid** stored value, so a poisoned row reads back as the driver string `"NaN"` and `Number("NaN")` is `NaN`. Because every ordering/threshold comparison against `NaN` is `false`, no throw ever fires and the NaN poisoned downstream consumers **silently**:

- the service's own creator-markup math (`estimateCost` / `processUsage`): `baseCost * (markupPercentage / 100)` → `NaN` → a fabricated/garbage creator markup;
- `getEarningsSummary`: `sum + Number(a.total_creator_earnings)` → `NaN` total, and the `.sort(...)` ranking becomes arbitrary;
- the display route `api/v1/agents/[agentId]/monetization/route.ts`: `info?.totalEarnings || 0` collapsed the NaN into a **fabricated healthy `$0`** over a corrupt earnings ledger (`NaN || 0 === 0`).

### Fix (fail closed)

New colocated, exported, pure `parseAgentMonetizationNumber(value, field)` + `CorruptAgentMonetizationNumberError`:

- throws on `null` / `undefined` / blank / non-finite (`NaN`, `Infinity`) / non-numeric;
- preserves an explicit domain zero (`"0"`, `"0.00"`) and negative domain values.

Wired into both NUMERIC read sites. `markupPercentage` keeps the null-safe default `0` (the column is NOT NULL with a `"0.00"` default) but a **corrupt** value throws; `getEarningsSummary` reads each monetized agent's earnings once through the boundary before summing/ranking. The display route already wraps the call in `try/catch → failureResponse`, so a corrupt row now surfaces an observable error instead of a fabricated `$0`.

Mirrors the merged NUMERIC fail-closed slices #13454 / #13474 / #13482 / #13486 / #13503 / #13504 / #13507.

### Verification

- **Tests: 11/11 green** — `packages/cloud/shared/src/lib/services/__tests__/agent-monetization-numeric-fail-closed.test.ts` (parser boundary exhaustive incl `'NaN'`/`Infinity`/blank fail-open regressions; `getAgentMonetization` healthy/corrupt-markup/corrupt-earnings/null-default/missing-agent; `getEarningsSummary` healthy sum+rank / single-corrupt-row-fails-closed).
- `bunx @biomejs/biome check <touched files>` — clean.
- `bun run audit:error-policy-ratchet` — `no new fallback-slop in touched files` (EXIT 0).
- `bun run --cwd packages/cloud/shared typecheck` — 17 pre-existing baseline errors in unrelated files (`app-core/account-pool.ts`, `app-core/coding-account-bridge.ts`, `node-redis-adapter.ts`, `plugin-mcp/utils/json.ts`, `anthropic-web-search.ts`), **zero in `agent-monetization.ts`** — identical baseline to the merged sibling cloud-shared slices.
- `git diff --check` — clean.

### Collision receipts

No open PR touches `agent-monetization.ts` at claim OR push; no `lalalune`/`NubsCarson`/`roninjin10` PR referencing the file in the last day (#11925/#11828 merged Jul 3 are different files; #11932 = Cloud Apps plugin enablement, different file). No live worktree on the file; unique worktree path, deleted after PR. Forbidden files untouched.

Evidence: `.github/issue-evidence/13415-agent-monetization-numeric-fallback.md`. Issue stays open for remaining service-layer inventory.

— [sol-orch]