### PR TITLE
fix(#13515): import from package barrels instead of sibling src trees

### DIFF
--- a/.github/issue-evidence/13515-cross-package-src-imports.md
+++ b/.github/issue-evidence/13515-cross-package-src-imports.md
@@ -1,0 +1,83 @@
+# #13515 — cross-package src relative imports → package barrels + guard
+
+Scope: the three static cross-package src imports in packages/agent production
+sources, plus a vitest guard that keeps them out. The residual
+plugin-app-manager tsconfig path mapping and the app/app-core escapes are left
+for a follow-up, as the issue suggests.
+
+## Changes
+
+| file | before | after |
+| --- | --- | --- |
+| `packages/agent/src/api/inbox-routes.ts` | `import { resolveEffectiveMuteState, setRoomMuteUntil, setWorldMuteState } from "../../../core/src/services/message/mute-state.ts"` | `from "@elizaos/core"` (barrel re-exports at `services/message.ts:1526-1534`, surfaced via `index.node.ts:299 export * from "./services/message"`) |
+| `packages/agent/src/services/relationships-graph.ts` | value+type re-export block `from "../../../core/src/services/relationships-graph-builder.ts"` | `from "@elizaos/core"` (`index.node.ts:312 export * from "./services/relationships-graph-builder"`) |
+| `packages/agent/src/config/zod-schema.agent-runtime.ts` | `import { parseDurationMs } from "../../../shared/src/cli/parse-duration.ts"` | `from "@elizaos/shared"` (`shared/src/index.ts:26 export * from "./cli/parse-duration.js"`) |
+
+New guard: `packages/agent/src/__tests__/no-cross-package-src-imports.test.ts`
+— walks all production agent sources (tests/`__tests__`/`.d.ts` excluded,
+they never reach dist) and fails on any static import/export-from specifier
+that resolves outside `packages/agent`. Dynamic-import fallback path strings
+(e.g. the plugin-sql source-checkout fallback in `runtime/eliza.ts:294`,
+which is a `path.resolve` argument, not an import specifier) are intentionally
+not matched.
+
+## Litter proof (the actual bug)
+
+On this branch, from `packages/agent`:
+
+```
+$ find ../core/src ../shared/src -name "*.js" ! -path "*node_modules*" | wc -l
+0                                    # before build
+$ bunx tsc --noCheck -p tsconfig.build.json ; echo EXIT:$?
+EXIT:0
+$ find ../core/src ../shared/src -name "*.js" ! -path "*node_modules*" | wc -l
+0                                    # after build — was 112+ on develop
+```
+
+`git status` after the build: only the three edited sources + the new test.
+No gitignored .js litter emitted into `packages/core/src` or
+`packages/shared/src`.
+
+Dist now references the barrels, not sibling src:
+
+```
+dist/api/inbox-routes.js:36
+  import { resolveEffectiveMuteState, setRoomMuteUntil, setWorldMuteState, } from "@elizaos/core";
+dist/config/zod-schema.agent-runtime.js:11
+  import { parseDurationMs } from "@elizaos/shared";
+```
+
+`grep -rn "core/src\|shared/src" dist/api/inbox-routes.js
+dist/services/relationships-graph.js dist/config/zod-schema.agent-runtime.js`
+→ no matches.
+
+## Guard test output
+
+```
+✓ src/__tests__/no-cross-package-src-imports.test.ts (1 test) 46ms
+Test Files  1 passed (1)
+     Tests  1 passed (1)
+EXIT:0
+```
+
+(Guard passes = zero offenders across ALL agent production sources, so the
+other two known imports are confirmed gone and no additional ones exist.)
+
+## Checks
+
+- `bunx @biomejs/biome check --write` on the four touched files: clean.
+- `tsgo --noEmit -p tsconfig.json` (packages/agent): zero diagnostics in any
+  touched file; remaining 12 lines are pre-existing optional-plugin and
+  out-of-package noise (`@elizaos/plugin-streaming`, `@elizaos/plugin-vision`,
+  generated `validation-keyword-data.js`, `@elizaos/plugin-meetings`),
+  identical on base.
+- `bunx tsc --noCheck -p tsconfig.build.json` (the dist build the issue is
+  about): EXIT:0, zero litter (above).
+
+## N/A rows
+
+- UI screenshots: N/A — build-graph/import hygiene only, no UI change.
+- Model trajectories: N/A.
+- Audio: N/A.
+- Runtime logs: N/A — behavior of the running agent is unchanged; the same
+  symbols come from the same modules via their sanctioned barrels.

--- a/packages/agent/src/__tests__/no-cross-package-src-imports.test.ts
+++ b/packages/agent/src/__tests__/no-cross-package-src-imports.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Guard against cross-package src relative imports (#13515).
+ *
+ * A production source in packages/agent that statically imports a sibling
+ * package's src via a relative path (e.g. `../../../core/src/...`) compiles
+ * "successfully" under `tsc --noCheck`, but because the pulled-in sources sit
+ * outside the agent program's rootDir, tsc emits the sibling package's
+ * compiled .js files NEXT TO their .ts sources — gitignored .js litter inside
+ * packages/core/src and packages/shared/src — and the emitted dist then
+ * depends on that litter existing at runtime. This is the known ".js litter
+ * shadows .ts" failure signature that has previously broken live deployments.
+ *
+ * All such symbols are exported from the package barrels (`@elizaos/core`,
+ * `@elizaos/shared`), so a deep relative import is never needed. This test
+ * fails on ANY static import/export-from specifier in production agent
+ * sources that resolves outside packages/agent. Tests are excluded (they are
+ * never compiled into dist) and dynamic-import fallback path strings (e.g.
+ * the plugin-sql source-checkout fallback in runtime/eliza.ts) are not import
+ * specifiers and are unaffected.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(here, "../..");
+const srcRoot = path.join(packageRoot, "src");
+
+function isProductionSource(filePath: string): boolean {
+  if (!filePath.endsWith(".ts") && !filePath.endsWith(".tsx")) return false;
+  if (filePath.endsWith(".test.ts") || filePath.endsWith(".test.tsx"))
+    return false;
+  if (filePath.endsWith(".d.ts")) return false;
+  const rel = path.relative(srcRoot, filePath);
+  if (rel.split(path.sep).includes("__tests__")) return false;
+  return true;
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (entry === "node_modules" || entry === "dist") continue;
+      walk(full, out);
+    } else if (isProductionSource(full)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Static import/export-from specifiers only. Dynamic import(...) of computed
+// strings and bare path.resolve(...) arguments are intentionally not matched.
+const SPECIFIER_RE =
+  /(?:^|\n)\s*(?:import|export)\s[^;]*?from\s*["'](\.\.?\/[^"']+)["']|(?:^|\n)\s*import\s*["'](\.\.?\/[^"']+)["']/g;
+
+describe("packages/agent production sources", () => {
+  test("no static relative import escapes the package root", () => {
+    const offenders: string[] = [];
+
+    for (const file of walk(srcRoot)) {
+      const content = readFileSync(file, "utf8");
+      for (const match of content.matchAll(SPECIFIER_RE)) {
+        const specifier = match[1] ?? match[2];
+        if (!specifier) continue;
+        const resolved = path.resolve(path.dirname(file), specifier);
+        const relToPackage = path.relative(packageRoot, resolved);
+        if (relToPackage.startsWith("..")) {
+          offenders.push(
+            `${path.relative(packageRoot, file)} -> ${specifier} (resolves outside packages/agent)`,
+          );
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      `Cross-package src relative imports found. Import from the package barrel ` +
+        `(@elizaos/core, @elizaos/shared, ...) instead — deep relative imports make ` +
+        `tsc emit .js litter into the sibling package's src tree and produce dist ` +
+        `output that depends on that litter at runtime (#13515):\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/agent/src/api/inbox-routes.ts
+++ b/packages/agent/src/api/inbox-routes.ts
@@ -43,6 +43,11 @@ import type {
   UUID,
   World,
 } from "@elizaos/core";
+import {
+  resolveEffectiveMuteState,
+  setRoomMuteUntil,
+  setWorldMuteState,
+} from "@elizaos/core";
 import type { DiscordService as IDiscordService } from "@elizaos/plugin-discord/service";
 import {
   expandConnectorSourceFilter,
@@ -50,11 +55,6 @@ import {
   PostInboxMessageRequestSchema,
 } from "@elizaos/shared";
 import { z } from "zod";
-import {
-  resolveEffectiveMuteState,
-  setRoomMuteUntil,
-  setWorldMuteState,
-} from "../../../core/src/services/message/mute-state.ts";
 
 let discordModulePromise: Promise<{
   cacheDiscordAvatarUrl: (

--- a/packages/agent/src/config/zod-schema.agent-runtime.ts
+++ b/packages/agent/src/config/zod-schema.agent-runtime.ts
@@ -8,8 +8,9 @@
  * (one configured agent) and `AgentDefaultsSchema` (fallbacks applied to every
  * agent). `.strict()` throughout, so unknown keys surface as validation errors.
  */
+
+import { parseDurationMs } from "@elizaos/shared";
 import * as zod from "zod";
-import { parseDurationMs } from "../../../shared/src/cli/parse-duration.ts";
 import {
   BlockStreamingChunkSchema,
   BlockStreamingCoalesceSchema,

--- a/packages/agent/src/services/relationships-graph.ts
+++ b/packages/agent/src/services/relationships-graph.ts
@@ -37,7 +37,7 @@ export {
   type RelationshipsServiceLike,
   type RelationshipsUserPersonalityPreference,
   searchMemoriesForCluster,
-} from "../../../core/src/services/relationships-graph-builder.ts";
+} from "@elizaos/core";
 
 type RelationshipsFeatureRuntime = IAgentRuntime & {
   enableRelationships?: () => Promise<void>;


### PR DESCRIPTION
## Fixes the .js-litter build hazard from #13515

### Problem

Three production agent sources statically imported sibling packages' **src** via relative paths:

- `src/api/inbox-routes.ts` → `../../../core/src/services/message/mute-state.ts`
- `src/services/relationships-graph.ts` → `../../../core/src/services/relationships-graph-builder.ts`
- `src/config/zod-schema.agent-runtime.ts` → `../../../shared/src/cli/parse-duration.ts`

Because those sources sit outside the agent tsc program's rootDir, `build:dist` exits 0 but emits **112+ gitignored .js files next to the sibling .ts sources** (packages/core/src, packages/shared/src), and the emitted dist imports that litter via `../../../core/src/...` paths that only resolve while the litter AND core's src tree exist at runtime — the known ".js litter shadows .ts" signature that has previously broken live deployments.

### Fix

All three symbols were already exported from the `@elizaos/core` / `@elizaos/shared` barrels (receipts in the evidence doc), so the deep imports were never needed — switched to the barrels. Verified on this branch:

- `bunx tsc --noCheck -p tsconfig.build.json` → EXIT:0, **zero** .js files emitted into core/src or shared/src (was 112+).
- `dist/api/inbox-routes.js` now imports `@elizaos/core`; `dist/config/zod-schema.agent-runtime.js` imports `@elizaos/shared`; no `core/src`/`shared/src` strings anywhere in the touched dist output.

### Guard

New `src/__tests__/no-cross-package-src-imports.test.ts`: walks all agent production sources and fails on ANY static import/export-from specifier resolving outside packages/agent (tests/`.d.ts` excluded — never compiled to dist; dynamic-import fallback path strings like the plugin-sql source-checkout fallback are path.resolve args, not import specifiers, and are unaffected). Passing = the whole package is clean, not just these three files.

### Checks

- biome clean on all four touched files.
- tsgo: zero diagnostics in touched files; remaining lines are pre-existing optional-plugin noise identical on base.
- Evidence: `.github/issue-evidence/13515-cross-package-src-imports.md`.

Residual left for follow-up per the issue: plugin-app-manager tsconfig path mapping (bare-specifier dist, benign) and the app/app-core escapes.

— [sol-orch]