### PR TITLE
fix(#13550): serve Android local-agent auth core routes

### DIFF
--- a/.github/issue-evidence/13550-android-local-agent-core-auth-routes.md
+++ b/.github/issue-evidence/13550-android-local-agent-core-auth-routes.md
@@ -1,0 +1,31 @@
+# Issue #13550 Evidence: Android local-agent core auth routes
+
+## Scope
+
+- `GET /api/auth/status` now answers in the Android in-process core route shim before falling through to the plugin-route kernel.
+- `GET /api/auth/me` now mirrors the trusted local machine-session response used by app-core/iOS local transports.
+- Existing `/api/first-run/status` and `/api/first-run` behavior is unchanged.
+
+## Verification
+
+```bash
+bun test plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
+```
+
+Result: 18 tests passed.
+
+```bash
+bunx @biomejs/biome check \
+  plugins/plugin-capacitor-bridge/src/android/dispatch.ts \
+  plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
+```
+
+Result: passed, no fixes applied.
+
+```bash
+bun run --cwd plugins/plugin-capacitor-bridge typecheck
+```
+
+Result: failed before this plugin due existing unresolved workspace references
+from `packages/agent` / sibling packages, including `@elizaos/auth`,
+`@elizaos/plugin-streaming`, and `@elizaos/plugin-sql`.

--- a/.github/issue-evidence/13550-android-local-agent-core-auth-routes.md
+++ b/.github/issue-evidence/13550-android-local-agent-core-auth-routes.md
@@ -4,6 +4,9 @@
 
 - `GET /api/auth/status` now answers in the Android in-process core route shim before falling through to the plugin-route kernel.
 - `GET /api/auth/me` now mirrors the trusted local machine-session response used by app-core/iOS local transports.
+- The Android local machine response includes `access.role: "OWNER"`, matching
+  the canonical agent auth route's trusted-local boundary role instead of
+  relying on UI fallback role derivation.
 - Existing `/api/first-run/status` and `/api/first-run` behavior is unchanged.
 
 ## Verification

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
@@ -285,6 +285,7 @@ describe("android core routes (first-run)", () => {
 				mode: "local",
 				passwordConfigured: false,
 				ownerConfigured: false,
+				role: "OWNER",
 			},
 		});
 		expect(calls).toHaveLength(0);

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
@@ -241,6 +241,55 @@ describe("android core routes (first-run)", () => {
 		expect(calls).toHaveLength(0);
 	});
 
+	it("GET /api/auth/status reports the sealed Android pipe as local trusted access", async () => {
+		const { route, calls } = fixedRoute(null);
+		const { deps } = coreDeps();
+		const res = await dispatchBufferedRequest(
+			runtime,
+			route,
+			{ method: "GET", path: "/api/auth/status" },
+			deps,
+		);
+		expect(res.status).toBe(200);
+		expect(JSON.parse(res.body)).toEqual({
+			required: false,
+			authenticated: true,
+			loginRequired: false,
+			bootstrapRequired: false,
+			localAccess: true,
+			passwordConfigured: false,
+			pairingEnabled: false,
+			expiresAt: null,
+		});
+		expect(calls).toHaveLength(0);
+	});
+
+	it("GET /api/auth/me returns the local machine identity over the sealed Android pipe", async () => {
+		const { route, calls } = fixedRoute(null);
+		const { deps } = coreDeps();
+		const res = await dispatchBufferedRequest(
+			runtime,
+			route,
+			{ method: "GET", path: "/api/auth/me" },
+			deps,
+		);
+		expect(res.status).toBe(200);
+		expect(JSON.parse(res.body)).toEqual({
+			identity: {
+				id: "local-agent",
+				displayName: "Local Agent",
+				kind: "machine",
+			},
+			session: { id: "local", kind: "local", expiresAt: null },
+			access: {
+				mode: "local",
+				passwordConfigured: false,
+				ownerConfigured: false,
+			},
+		});
+		expect(calls).toHaveLength(0);
+	});
+
 	it("GET /api/first-run/status reports complete from the persisted config", async () => {
 		const { route } = fixedRoute(null);
 		const { deps } = coreDeps({

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
@@ -248,6 +248,7 @@ export function handleAndroidCoreRoute(
 				mode: "local",
 				passwordConfigured: false,
 				ownerConfigured: false,
+				role: "OWNER",
 			},
 		});
 	}

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
@@ -186,18 +186,18 @@ function jsonBuffered(status: number, value: unknown): AndroidBufferedResponse {
 
 // ── Server-level core routes ─────────────────────────────────────────────────
 //
-// /api/first-run/* is served at the HTTP SERVER layer on desktop
-// (handleFirstRunRoutes in @elizaos/agent api/server.ts), not through the
-// plugin-route kernel — so the in-process stdio dispatch never sees it. On
-// Android the WebView talks to the bridge from the very first boot (the local
-// agent is pre-seeded as the active server on sideload builds), which made the
-// startup poll's GET /api/first-run/status 404 and hard-fail a FRESH install
-// with "Startup failed: Backend Unreachable" before onboarding could start.
-// These two routes answer from the SAME durable truth the server uses: the
-// persisted ElizaConfig. Unlike the iOS full-Bun shim (which hardcodes
-// complete:true because iOS only reaches its bridge after a local runtime was
-// chosen), Android must report honestly in both phases or a fresh install
-// would skip onboarding entirely.
+// /api/first-run/* and the auth bootstrap probes are served at the HTTP SERVER
+// layer on desktop (handleFirstRunRoutes / app-core auth routes), not through
+// the plugin-route kernel — so the in-process stdio dispatch never sees them.
+// On Android the WebView talks to the bridge from the very first boot (the
+// local agent is pre-seeded as the active server on sideload builds), which made
+// startup polls 404 and hard-fail a FRESH install with "Startup failed: Backend
+// Unreachable" before onboarding could start. These routes answer from the SAME
+// durable truth the server uses where there is durable state: the persisted
+// ElizaConfig. Unlike the iOS full-Bun shim (which hardcodes complete:true
+// because iOS only reaches its bridge after a local runtime was chosen), Android
+// must report honestly in both phases or a fresh install would skip onboarding
+// entirely.
 
 /** The persisted-config seams the core routes read/write (from @elizaos/agent). */
 export interface AndroidCoreRouteDeps {
@@ -224,6 +224,33 @@ export function handleAndroidCoreRoute(
 	pathname: string,
 	deps: AndroidCoreRouteDeps,
 ): AndroidBufferedResponse | null {
+	if (method === "GET" && pathname === "/api/auth/status") {
+		return jsonBuffered(200, {
+			required: false,
+			authenticated: true,
+			loginRequired: false,
+			bootstrapRequired: false,
+			localAccess: true,
+			passwordConfigured: false,
+			pairingEnabled: false,
+			expiresAt: null,
+		});
+	}
+	if (method === "GET" && pathname === "/api/auth/me") {
+		return jsonBuffered(200, {
+			identity: {
+				id: "local-agent",
+				displayName: "Local Agent",
+				kind: "machine",
+			},
+			session: { id: "local", kind: "local", expiresAt: null },
+			access: {
+				mode: "local",
+				passwordConfigured: false,
+				ownerConfigured: false,
+			},
+		});
+	}
 	if (method === "GET" && pathname === "/api/first-run/status") {
 		let complete = false;
 		try {


### PR DESCRIPTION
## Summary

- add Android in-process core-route handling for `GET /api/auth/status`
- add Android local-machine response for `GET /api/auth/me`
- cover both routes in the existing Android dispatch tests so they do not fall through to the plugin-route kernel and 404 during startup

Refs #13550

## Evidence

- Evidence note: `.github/issue-evidence/13550-android-local-agent-core-auth-routes.md`
- `bun test plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts` — 18 passed
- `bunx @biomejs/biome check plugins/plugin-capacitor-bridge/src/android/dispatch.ts plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts` — passed
- `bun run --cwd plugins/plugin-capacitor-bridge typecheck` — failed before this plugin due existing unresolved workspace references from `packages/agent` / sibling packages (`@elizaos/auth`, `@elizaos/plugin-streaming`, `@elizaos/plugin-sql`, etc.)