### PR TITLE
fix(#13475): fail Android packaging when SIGSYS shim is missing

### DIFF
--- a/.github/issue-evidence/13475-android-seccomp-shim-build-gate.md
+++ b/.github/issue-evidence/13475-android-seccomp-shim-build-gate.md
@@ -1,0 +1,38 @@
+# Issue #13475 Evidence: Android SIGSYS shim build gate
+
+## Scope
+
+- `stageSeccompShimForAbi` now fails the Android staging step when the compiled
+  SIGSYS shim artifacts are missing for the ABI being packaged.
+- This prevents stock Android APKs from shipping the raw Alpine loader, which
+  was confirmed on-device to die with exit 159 / SIGSYS after PGlite init.
+
+## Verification
+
+```bash
+bun test packages/app-core/scripts/stage-android-agent.test.mjs
+```
+
+Result: 7 tests passed. New coverage asserts an `arm64-v8a` stage with no
+cached shim throws instead of continuing with the raw loader.
+
+```bash
+bunx @biomejs/biome check \
+  packages/app-core/scripts/lib/stage-android-agent.mjs \
+  packages/app-core/scripts/stage-android-agent.test.mjs
+```
+
+Result: exit 0. Biome reported one pre-existing warning in the launch-script
+string literal; no fixes were applied.
+
+```bash
+bun run audit:error-policy-ratchet
+```
+
+Result: passed; no new fallback-slop in touched files.
+
+## Not run
+
+- Full `build:android` and on-device Moto/emulator boot proof are not captured
+  in this slice. This PR gates the known-bad packaging path; runtime boot proof
+  still requires a host with Android build prerequisites and device access.

--- a/packages/app-core/scripts/lib/stage-android-agent.mjs
+++ b/packages/app-core/scripts/lib/stage-android-agent.mjs
@@ -865,8 +865,8 @@ function writeIfChanged(target, content) {
  *   - Drop `libsigsys-handler.so` next to it.
  *
  * Returns the number of files changed this call (0 when nothing
- * happened). When no compiled shim exists for the ABI this returns 0 and
- * the Capacitor APK build path keeps the legacy loader.
+ * happened). When no compiled shim exists for an ABI that stock Android
+ * requires, fail the build instead of shipping a known-SIGSYS-dead runtime.
  *
  * Exported for testing.
  */
@@ -881,12 +881,13 @@ export function stageSeccompShimForAbi({
   const cachedWrap = path.join(abiCacheDir, ldName);
   const cachedShim = path.join(abiCacheDir, "libsigsys-handler.so");
   if (!fs.existsSync(cachedWrap) || !fs.existsSync(cachedShim)) {
-    log?.(
-      `No compiled SIGSYS shim for ${androidAbi}; leaving the Alpine ` +
-        `loader at ${ldName} (run \`node packages/app-core/scripts/aosp/compile-shim.mjs\` ` +
-        `for the AOSP path).`,
+    throw new Error(
+      `[stage-android-agent] Missing compiled SIGSYS shim for ${androidAbi}. ` +
+        `Stock Android kills the raw Alpine loader with SIGSYS during Bun's ` +
+        `event loop startup; refusing to build an APK that cannot boot. Run ` +
+        `\`node packages/app-core/scripts/aosp/compile-shim.mjs --abi ${androidAbi}\` ` +
+        `or restore ${path.relative(process.cwd(), abiCacheDir)} before building.`,
     );
-    return 0;
   }
 
   const stagedLoader = path.join(abiAssetsDir, ldName);
@@ -1109,8 +1110,8 @@ export async function stageAndroidAgentRuntime({
     //
     // Idempotent: if the wrapper is already in place we just refresh
     // the .real loader and the shim file (handled by copyIfDifferent's
-    // size+mtime check). If shim artifacts are missing we leave the packaged
-    // musl loader in place so the Capacitor APK build still works.
+    // size+mtime check). If shim artifacts are missing we fail here rather
+    // than shipping a stock Android APK whose local agent dies with SIGSYS.
     const shimChanges = stageSeccompShimForAbi({
       androidAbi,
       ldName,

--- a/packages/app-core/scripts/stage-android-agent.test.mjs
+++ b/packages/app-core/scripts/stage-android-agent.test.mjs
@@ -7,7 +7,10 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { __testables } from "./lib/stage-android-agent.mjs";
+import {
+  __testables,
+  stageSeccompShimForAbi,
+} from "./lib/stage-android-agent.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..", "..", "..");
@@ -87,6 +90,30 @@ test("launch script records the real detached agent child status", () => {
   assert.match(script, /agent_pid=\$!/);
   assert.match(script, /wait "\$agent_pid"/);
   assert.doesNotMatch(script, /LD_LIBRARY_PATH="\$runtime_ld" exec "\$@"/);
+});
+
+test("stock Android staging fails when the required SIGSYS shim is missing", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-seccomp-missing-"));
+  try {
+    const abiAssetsDir = path.join(tmp, "assets", "arm64-v8a");
+    fs.mkdirSync(abiAssetsDir, { recursive: true });
+    const ldName = "ld-musl-aarch64.so.1";
+    fs.writeFileSync(path.join(abiAssetsDir, ldName), Buffer.alloc(256 * 1024));
+
+    assert.throws(
+      () =>
+        stageSeccompShimForAbi({
+          androidAbi: "arm64-v8a",
+          ldName,
+          abiAssetsDir,
+          cacheDir: path.join(tmp, "empty-cache"),
+          log: () => {},
+        }),
+      /Missing compiled SIGSYS shim for arm64-v8a/,
+    );
+  } finally {
+    removePathRecursive(tmp);
+  }
 });
 
 test("runtime provenance records repo-local riscv64 artifacts as relative paths", () => {


### PR DESCRIPTION
## Summary

- make `stageSeccompShimForAbi` throw when the compiled SIGSYS shim is missing instead of staging the raw Alpine loader
- update the staging comments to reflect the stock Android fail-loud policy
- add a focused test proving an `arm64-v8a` stage without a shim fails before producing a known-dead APK

This is a bounded follow-up to #13475. It does not claim full device boot proof; it prevents the confirmed build-host lottery where fresh hosts silently package a runtime that stock Android kills with exit 159 / SIGSYS after PGlite init.

Refs #13475

## Evidence

- Evidence note: `.github/issue-evidence/13475-android-seccomp-shim-build-gate.md`
- `bun test packages/app-core/scripts/stage-android-agent.test.mjs` — 7 passed
- `bunx @biomejs/biome check packages/app-core/scripts/lib/stage-android-agent.mjs packages/app-core/scripts/stage-android-agent.test.mjs` — exit 0; one pre-existing launch-script string warning, no fixes applied
- `bun run audit:error-policy-ratchet` — passed

## Not run

- Full `build:android` and Moto/emulator boot proof. This PR gates the known-bad packaging path; runtime boot proof still requires a host with Android build prerequisites and device access.
