### PR TITLE
fix(android): serve local app-core startup routes over UDS (#13550)

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
@@ -6,14 +6,11 @@
  * streaming sink lifecycle without booting a runtime or device.
  */
 
-import { Buffer } from "node:buffer";
 import type { IAgentRuntime, RouteHandlerResult } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import type { StdioBridgeStreamSink } from "../shared/stdio-bridge.ts";
 import {
-	type AndroidCoreRouteDeps,
 	type AndroidDispatchRoute,
-	type AndroidElizaConfigLike,
 	dispatchBufferedRequest,
 	dispatchStreamingRequest,
 } from "./dispatch.ts";
@@ -48,6 +45,48 @@ function collectSink(): {
 }
 
 describe("dispatchBufferedRequest", () => {
+	it("serves Android local startup app-core routes before dispatchRoute", async () => {
+		const { route, calls } = fixedRoute(null);
+		const status = await dispatchBufferedRequest(runtime, route, {
+			method: "GET",
+			path: "/api/first-run/status",
+		});
+		expect(status.status).toBe(200);
+		expect(JSON.parse(status.body)).toEqual({
+			complete: true,
+			cloudProvisioned: false,
+			deploymentTarget: "local",
+		});
+
+		const auth = await dispatchBufferedRequest(runtime, route, {
+			method: "GET",
+			path: "/api/auth/me",
+		});
+		expect(auth.status).toBe(200);
+		expect(JSON.parse(auth.body)).toMatchObject({
+			identity: { id: "local-agent", kind: "machine" },
+			session: { id: "local", kind: "local" },
+			access: { mode: "local" },
+		});
+
+		expect(calls).toHaveLength(0);
+	});
+
+	it("returns a non-404 response for Android local auth-bootstrap exchange", async () => {
+		const { route, calls } = fixedRoute(null);
+		const res = await dispatchBufferedRequest(runtime, route, {
+			method: "POST",
+			path: "/api/auth/bootstrap/exchange",
+			body: { token: "unused-local-token" },
+		});
+		expect(res.status).toBe(503);
+		expect(JSON.parse(res.body)).toEqual({
+			error: "db_unavailable",
+			reason: "db_unavailable",
+		});
+		expect(calls).toHaveLength(0);
+	});
+
 	it("returns the loopback-shaped envelope for a JSON route", async () => {
 		const { route, calls } = fixedRoute({
 			status: 200,
@@ -56,7 +95,7 @@ describe("dispatchBufferedRequest", () => {
 		});
 		const res = await dispatchBufferedRequest(runtime, route, {
 			method: "GET",
-			path: "/api/health",
+			path: "/api/custom-health",
 		});
 		expect(res.status).toBe(200);
 		expect(res.statusText).toBe("OK");
@@ -68,7 +107,7 @@ describe("dispatchBufferedRequest", () => {
 		);
 		// dispatchRoute saw an authorized in-process call on the parsed path.
 		expect(calls[0]?.inProcess).toBe(true);
-		expect(calls[0]?.path).toBe("/api/health");
+		expect(calls[0]?.path).toBe("/api/custom-health");
 	});
 
 	it("splits query params off the path", async () => {
@@ -120,6 +159,26 @@ describe("dispatchBufferedRequest", () => {
 });
 
 describe("dispatchStreamingRequest", () => {
+	it("streams Android direct startup route responses without dispatchRoute", async () => {
+		const { route, calls } = fixedRoute(null);
+		const { sink, events } = collectSink();
+		await dispatchStreamingRequest(
+			runtime,
+			route,
+			{ method: "GET", path: "/api/first-run/status" },
+			sink,
+		);
+		expect(events[0]).toMatchObject({ kind: "response", status: 200 });
+		const body = JSON.parse(
+			Buffer.from(events[1]?.dataBase64 as string, "base64").toString("utf8"),
+		);
+		expect(body).toMatchObject({
+			complete: true,
+			deploymentTarget: "local",
+		});
+		expect(calls).toHaveLength(0);
+	});
+
 	it("emits response head then base64 chunks for a return-shape stream", async () => {
 		async function* frames(): AsyncGenerator<string> {
 			yield "data: hello\n\n";
@@ -201,193 +260,5 @@ describe("dispatchStreamingRequest", () => {
 			sink,
 		);
 		expect(events[0]).toMatchObject({ kind: "response", status: 404 });
-	});
-});
-
-describe("android core routes (first-run)", () => {
-	function coreDeps(overrides: Partial<AndroidCoreRouteDeps> = {}): {
-		deps: AndroidCoreRouteDeps;
-		saved: AndroidElizaConfigLike[];
-	} {
-		const saved: AndroidElizaConfigLike[] = [];
-		const deps: AndroidCoreRouteDeps = {
-			configFileExists: () => true,
-			loadElizaConfig: () => ({}),
-			saveElizaConfig: (config) => {
-				saved.push(config);
-			},
-			hasPersistedFirstRunState: (config) =>
-				(config as AndroidElizaConfigLike).meta?.firstRunComplete === true,
-			...overrides,
-		};
-		return { deps, saved };
-	}
-
-	it("GET /api/first-run/status reports incomplete on a fresh install (no config file)", async () => {
-		const { route, calls } = fixedRoute(null);
-		const { deps } = coreDeps({ configFileExists: () => false });
-		const res = await dispatchBufferedRequest(
-			runtime,
-			route,
-			{ method: "GET", path: "/api/first-run/status" },
-			deps,
-		);
-		expect(res.status).toBe(200);
-		expect(JSON.parse(res.body)).toEqual({
-			complete: false,
-			cloudProvisioned: false,
-		});
-		// The core route answered before the plugin-route kernel ran.
-		expect(calls).toHaveLength(0);
-	});
-
-	it("GET /api/auth/status reports the sealed Android pipe as local trusted access", async () => {
-		const { route, calls } = fixedRoute(null);
-		const { deps } = coreDeps();
-		const res = await dispatchBufferedRequest(
-			runtime,
-			route,
-			{ method: "GET", path: "/api/auth/status" },
-			deps,
-		);
-		expect(res.status).toBe(200);
-		expect(JSON.parse(res.body)).toEqual({
-			required: false,
-			authenticated: true,
-			loginRequired: false,
-			bootstrapRequired: false,
-			localAccess: true,
-			passwordConfigured: false,
-			pairingEnabled: false,
-			expiresAt: null,
-		});
-		expect(calls).toHaveLength(0);
-	});
-
-	it("GET /api/auth/me returns the local machine identity over the sealed Android pipe", async () => {
-		const { route, calls } = fixedRoute(null);
-		const { deps } = coreDeps();
-		const res = await dispatchBufferedRequest(
-			runtime,
-			route,
-			{ method: "GET", path: "/api/auth/me" },
-			deps,
-		);
-		expect(res.status).toBe(200);
-		expect(JSON.parse(res.body)).toEqual({
-			identity: {
-				id: "local-agent",
-				displayName: "Local Agent",
-				kind: "machine",
-			},
-			session: { id: "local", kind: "local", expiresAt: null },
-			access: {
-				mode: "local",
-				passwordConfigured: false,
-				ownerConfigured: false,
-				role: "OWNER",
-			},
-		});
-		expect(calls).toHaveLength(0);
-	});
-
-	it("GET /api/first-run/status reports complete from the persisted config", async () => {
-		const { route } = fixedRoute(null);
-		const { deps } = coreDeps({
-			loadElizaConfig: () => ({ meta: { firstRunComplete: true } }),
-		});
-		const res = await dispatchBufferedRequest(
-			runtime,
-			route,
-			{ method: "GET", path: "/api/first-run/status" },
-			deps,
-		);
-		expect(JSON.parse(res.body)).toEqual({
-			complete: true,
-			cloudProvisioned: false,
-		});
-	});
-
-	it("GET /api/first-run/status fails closed to incomplete on an unreadable config", async () => {
-		const { route } = fixedRoute(null);
-		const { deps } = coreDeps({
-			loadElizaConfig: () => {
-				throw new Error("corrupt config");
-			},
-		});
-		const res = await dispatchBufferedRequest(
-			runtime,
-			route,
-			{ method: "GET", path: "/api/first-run/status" },
-			deps,
-		);
-		expect(JSON.parse(res.body)).toEqual({
-			complete: false,
-			cloudProvisioned: false,
-		});
-	});
-
-	it("POST /api/first-run persists the completion marker so status flips durable", async () => {
-		const { route, calls } = fixedRoute(null);
-		const { deps, saved } = coreDeps({ configFileExists: () => false });
-		const res = await dispatchBufferedRequest(
-			runtime,
-			route,
-			{ method: "POST", path: "/api/first-run" },
-			deps,
-		);
-		expect(res.status).toBe(200);
-		expect(JSON.parse(res.body)).toEqual({ ok: true, complete: true });
-		expect(saved).toHaveLength(1);
-		expect(saved[0]?.meta?.firstRunComplete).toBe(true);
-		expect(calls).toHaveLength(0);
-	});
-
-	it("POST /api/first-run surfaces a persist failure instead of acking", async () => {
-		const { route } = fixedRoute(null);
-		const { deps } = coreDeps({
-			saveElizaConfig: () => {
-				throw new Error("disk full");
-			},
-		});
-		const res = await dispatchBufferedRequest(
-			runtime,
-			route,
-			{ method: "POST", path: "/api/first-run" },
-			deps,
-		);
-		expect(res.status).toBe(500);
-		expect(res.body).toContain("disk full");
-	});
-
-	it("streams the core-route answer over the streaming channel too", async () => {
-		const { route } = fixedRoute(null);
-		const { deps } = coreDeps({ configFileExists: () => false });
-		const { sink, events } = collectSink();
-		await dispatchStreamingRequest(
-			runtime,
-			route,
-			{ method: "GET", path: "/api/first-run/status" },
-			sink,
-			deps,
-		);
-		expect(events[0]).toMatchObject({ kind: "response", status: 200 });
-		const chunk = events[1] as { dataBase64: string };
-		expect(
-			JSON.parse(Buffer.from(chunk.dataBase64, "base64").toString("utf8")),
-		).toEqual({ complete: false, cloudProvisioned: false });
-	});
-
-	it("non-core paths still fall through to the plugin-route kernel", async () => {
-		const { route, calls } = fixedRoute(null);
-		const { deps } = coreDeps();
-		const res = await dispatchBufferedRequest(
-			runtime,
-			route,
-			{ method: "GET", path: "/api/agents" },
-			deps,
-		);
-		expect(res.status).toBe(404);
-		expect(calls).toHaveLength(1);
 	});
 });

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
@@ -10,7 +10,9 @@ import type { IAgentRuntime, RouteHandlerResult } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import type { StdioBridgeStreamSink } from "../shared/stdio-bridge.ts";
 import {
+	type AndroidCoreRouteDeps,
 	type AndroidDispatchRoute,
+	type AndroidElizaConfigLike,
 	dispatchBufferedRequest,
 	dispatchStreamingRequest,
 } from "./dispatch.ts";
@@ -44,13 +46,39 @@ function collectSink(): {
 	return { sink, events };
 }
 
+function coreDeps(overrides: Partial<AndroidCoreRouteDeps> = {}): {
+	deps: AndroidCoreRouteDeps;
+	saved: AndroidElizaConfigLike[];
+} {
+	const saved: AndroidElizaConfigLike[] = [];
+	const deps: AndroidCoreRouteDeps = {
+		configFileExists: () => true,
+		loadElizaConfig: () => ({}),
+		saveElizaConfig: (config) => {
+			saved.push(config);
+		},
+		hasPersistedFirstRunState: (config) =>
+			(config as AndroidElizaConfigLike).meta?.firstRunComplete === true,
+		...overrides,
+	};
+	return { deps, saved };
+}
+
 describe("dispatchBufferedRequest", () => {
 	it("serves Android local startup app-core routes before dispatchRoute", async () => {
 		const { route, calls } = fixedRoute(null);
-		const status = await dispatchBufferedRequest(runtime, route, {
-			method: "GET",
-			path: "/api/first-run/status",
+		const { deps } = coreDeps({
+			loadElizaConfig: () => ({ meta: { firstRunComplete: true } }),
 		});
+		const status = await dispatchBufferedRequest(
+			runtime,
+			route,
+			{
+				method: "GET",
+				path: "/api/first-run/status",
+			},
+			deps,
+		);
 		expect(status.status).toBe(200);
 		expect(JSON.parse(status.body)).toEqual({
 			complete: true,
@@ -70,6 +98,61 @@ describe("dispatchBufferedRequest", () => {
 		});
 
 		expect(calls).toHaveLength(0);
+	});
+
+	it("reports first-run incomplete on a fresh Android install", async () => {
+		const { route, calls } = fixedRoute(null);
+		const { deps } = coreDeps({ configFileExists: () => false });
+		const status = await dispatchBufferedRequest(
+			runtime,
+			route,
+			{
+				method: "GET",
+				path: "/api/first-run/status",
+			},
+			deps,
+		);
+		expect(status.status).toBe(200);
+		expect(JSON.parse(status.body)).toEqual({
+			complete: false,
+			cloudProvisioned: false,
+			deploymentTarget: "local",
+		});
+		expect(calls).toHaveLength(0);
+	});
+
+	it("persists first-run completion and fails closed on write errors", async () => {
+		const { route } = fixedRoute(null);
+		const { deps, saved } = coreDeps({ configFileExists: () => false });
+		const ok = await dispatchBufferedRequest(
+			runtime,
+			route,
+			{
+				method: "POST",
+				path: "/api/first-run",
+			},
+			deps,
+		);
+		expect(ok.status).toBe(200);
+		expect(JSON.parse(ok.body)).toMatchObject({ ok: true, complete: true });
+		expect(saved[0]?.meta?.firstRunComplete).toBe(true);
+
+		const failing = coreDeps({
+			saveElizaConfig: () => {
+				throw new Error("disk full");
+			},
+		}).deps;
+		const failed = await dispatchBufferedRequest(
+			runtime,
+			route,
+			{
+				method: "POST",
+				path: "/api/first-run",
+			},
+			failing,
+		);
+		expect(failed.status).toBe(500);
+		expect(JSON.parse(failed.body).error).toContain("disk full");
 	});
 
 	it("returns a non-404 response for Android local auth-bootstrap exchange", async () => {
@@ -161,19 +244,21 @@ describe("dispatchBufferedRequest", () => {
 describe("dispatchStreamingRequest", () => {
 	it("streams Android direct startup route responses without dispatchRoute", async () => {
 		const { route, calls } = fixedRoute(null);
+		const { deps } = coreDeps({ configFileExists: () => false });
 		const { sink, events } = collectSink();
 		await dispatchStreamingRequest(
 			runtime,
 			route,
 			{ method: "GET", path: "/api/first-run/status" },
 			sink,
+			deps,
 		);
 		expect(events[0]).toMatchObject({ kind: "response", status: 200 });
 		const body = JSON.parse(
 			Buffer.from(events[1]?.dataBase64 as string, "base64").toString("utf8"),
 		);
 		expect(body).toMatchObject({
-			complete: true,
+			complete: false,
 			deploymentTarget: "local",
 		});
 		expect(calls).toHaveLength(0);

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
@@ -151,10 +151,24 @@ function runtimeAgentName(runtime: IAgentRuntime): string {
 		: "Eliza";
 }
 
+/** The persisted-config seams the first-run routes read/write (from @elizaos/agent). */
+export interface AndroidCoreRouteDeps {
+	configFileExists: () => boolean;
+	loadElizaConfig: () => AndroidElizaConfigLike;
+	saveElizaConfig: (config: AndroidElizaConfigLike) => void;
+	hasPersistedFirstRunState: (config: AndroidElizaConfigLike) => boolean;
+}
+
+/** Structural stand-in for ElizaConfig — the bridge only touches `meta`. */
+export type AndroidElizaConfigLike = Record<string, unknown> & {
+	meta?: Record<string, unknown>;
+};
+
 function directAndroidCoreRoute(
 	runtime: IAgentRuntime,
 	method: string,
 	pathname: string,
+	coreRoutes?: AndroidCoreRouteDeps,
 ): AndroidBufferedResponse | null {
 	if (method === "GET" && pathname === "/api/health") {
 		return jsonResponse(200, {
@@ -202,14 +216,43 @@ function directAndroidCoreRoute(
 	}
 
 	if (method === "GET" && pathname === "/api/first-run/status") {
+		let complete = false;
+		try {
+			complete = Boolean(
+				coreRoutes?.configFileExists() &&
+					coreRoutes.hasPersistedFirstRunState(coreRoutes.loadElizaConfig()),
+			);
+		} catch {
+			// An unreadable config cannot prove onboarding completion. Fail closed
+			// to "onboarding required" instead of skipping first-run on Android.
+			complete = false;
+		}
 		return jsonResponse(200, {
-			complete: true,
+			complete,
 			cloudProvisioned: false,
 			deploymentTarget: "local",
 		});
 	}
 
 	if (method === "POST" && pathname === "/api/first-run") {
+		if (!coreRoutes) {
+			return jsonResponse(503, {
+				error: "config_unavailable",
+				reason: "config_unavailable",
+			});
+		}
+		try {
+			const config: AndroidElizaConfigLike = coreRoutes.configFileExists()
+				? coreRoutes.loadElizaConfig()
+				: {};
+			config.meta = { ...(config.meta ?? {}), firstRunComplete: true };
+			coreRoutes.saveElizaConfig(config);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return jsonResponse(500, {
+				error: `Failed to persist first-run completion: ${message}`,
+			});
+		}
 		return jsonResponse(200, {
 			ok: true,
 			complete: true,
@@ -229,6 +272,7 @@ function directAndroidCoreRoute(
 				mode: "local",
 				passwordConfigured: false,
 				ownerConfigured: false,
+				role: "OWNER",
 			},
 		});
 	}
@@ -237,6 +281,10 @@ function directAndroidCoreRoute(
 		return jsonResponse(200, {
 			required: false,
 			authenticated: true,
+			loginRequired: false,
+			bootstrapRequired: false,
+			pairingEnabled: false,
+			expiresAt: null,
 			enabled: false,
 			cloudProvisioned: false,
 			passwordConfigured: false,
@@ -305,6 +353,7 @@ export async function dispatchBufferedRequest(
 	runtime: IAgentRuntime,
 	dispatchRoute: AndroidDispatchRoute,
 	payload: AndroidRequestPayload,
+	coreRoutes?: AndroidCoreRouteDeps,
 ): Promise<AndroidBufferedResponse> {
 	const rawPath = typeof payload.path === "string" ? payload.path.trim() : "";
 	if (!rawPath || !isSafeLocalPath(rawPath)) {
@@ -316,7 +365,7 @@ export async function dispatchBufferedRequest(
 	const headers = normalizeHeaderRecord(payload.headers);
 	const { pathname, query } = splitPathAndQuery(rawPath);
 
-	const direct = directAndroidCoreRoute(runtime, method, pathname);
+	const direct = directAndroidCoreRoute(runtime, method, pathname, coreRoutes);
 	if (direct) return direct;
 
 	const result = await dispatchRoute({
@@ -356,6 +405,7 @@ export async function dispatchStreamingRequest(
 	dispatchRoute: AndroidDispatchRoute,
 	payload: AndroidRequestPayload,
 	sink: StdioBridgeStreamSink,
+	coreRoutes?: AndroidCoreRouteDeps,
 ): Promise<void> {
 	const rawPath = typeof payload.path === "string" ? payload.path.trim() : "";
 	if (!rawPath || !isSafeLocalPath(rawPath)) {
@@ -367,7 +417,7 @@ export async function dispatchStreamingRequest(
 	const headers = normalizeHeaderRecord(payload.headers);
 	const { pathname, query } = splitPathAndQuery(rawPath);
 
-	const direct = directAndroidCoreRoute(runtime, method, pathname);
+	const direct = directAndroidCoreRoute(runtime, method, pathname, coreRoutes);
 	if (direct) {
 		sink.emitResponse({
 			status: direct.status,

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
@@ -132,6 +132,129 @@ function statusText(status: number): string {
 	return STATUS_TEXT[status] ?? "";
 }
 
+function jsonResponse(status: number, body: unknown): AndroidBufferedResponse {
+	const text = JSON.stringify(body);
+	return {
+		status,
+		statusText: statusText(status),
+		headers: { "content-type": "application/json; charset=utf-8" },
+		body: text,
+		bodyBase64: Buffer.from(text, "utf8").toString("base64"),
+		bodyEncoding: "base64",
+	};
+}
+
+function runtimeAgentName(runtime: IAgentRuntime): string {
+	const character = (runtime as { character?: { name?: unknown } }).character;
+	return typeof character?.name === "string" && character.name.trim()
+		? character.name.trim()
+		: "Eliza";
+}
+
+function directAndroidCoreRoute(
+	runtime: IAgentRuntime,
+	method: string,
+	pathname: string,
+): AndroidBufferedResponse | null {
+	if (method === "GET" && pathname === "/api/health") {
+		return jsonResponse(200, {
+			ready: true,
+			runtime: "ok",
+			database: "ok",
+			plugins: {
+				loaded: Array.isArray((runtime as { plugins?: unknown }).plugins)
+					? ((runtime as { plugins?: unknown[] }).plugins?.length ?? 0)
+					: 0,
+				failed: 0,
+			},
+			coordinator: "not_wired",
+			agentState: "running",
+			agentName: runtimeAgentName(runtime),
+			startedAt: null,
+			uptime: 0,
+			androidBridge: "uds",
+		});
+	}
+
+	if (method === "GET" && pathname === "/api/status") {
+		return jsonResponse(200, {
+			state: "running",
+			agentName: runtimeAgentName(runtime),
+			model: null,
+			canRespond: true,
+			startedAt: null,
+			uptime: 0,
+			startup: { phase: "running", runtimePhase: "running" },
+			cloud: {
+				connectionStatus: "disconnected",
+				activeAgentId: null,
+				cloudProvisioned: false,
+				hasApiKey: false,
+			},
+			pendingRestart: false,
+			pendingRestartReasons: [],
+			androidBridge: "uds",
+		});
+	}
+
+	if (method === "GET" && pathname === "/api/apps/runs") {
+		return jsonResponse(200, []);
+	}
+
+	if (method === "GET" && pathname === "/api/first-run/status") {
+		return jsonResponse(200, {
+			complete: true,
+			cloudProvisioned: false,
+			deploymentTarget: "local",
+		});
+	}
+
+	if (method === "POST" && pathname === "/api/first-run") {
+		return jsonResponse(200, {
+			ok: true,
+			complete: true,
+			deploymentTarget: "local",
+		});
+	}
+
+	if (method === "GET" && pathname === "/api/auth/me") {
+		return jsonResponse(200, {
+			identity: {
+				id: "local-agent",
+				displayName: "Local Agent",
+				kind: "machine",
+			},
+			session: { id: "local", kind: "local", expiresAt: null },
+			access: {
+				mode: "local",
+				passwordConfigured: false,
+				ownerConfigured: false,
+			},
+		});
+	}
+
+	if (method === "GET" && pathname === "/api/auth/status") {
+		return jsonResponse(200, {
+			required: false,
+			authenticated: true,
+			enabled: false,
+			cloudProvisioned: false,
+			passwordConfigured: false,
+			localAccess: true,
+			mode: "local",
+		});
+	}
+
+	if (method === "POST" && pathname === "/api/auth/bootstrap/exchange") {
+		return jsonResponse(503, {
+			error: "db_unavailable",
+			reason: "db_unavailable",
+		});
+	}
+
+	return null;
+}
+
 /** Serialize a RouteHandlerResult body to raw bytes, mirroring the HTTP path. */
 function resultBodyBytes(result: RouteHandlerResult): {
 	bytes: Buffer;
@@ -172,118 +295,6 @@ function notFound(method: string, pathname: string): AndroidBufferedResponse {
 	};
 }
 
-function jsonBuffered(status: number, value: unknown): AndroidBufferedResponse {
-	const body = JSON.stringify(value);
-	return {
-		status,
-		statusText: statusText(status),
-		headers: { "content-type": "application/json; charset=utf-8" },
-		body,
-		bodyBase64: Buffer.from(body, "utf8").toString("base64"),
-		bodyEncoding: "base64",
-	};
-}
-
-// ── Server-level core routes ─────────────────────────────────────────────────
-//
-// /api/first-run/* and the auth bootstrap probes are served at the HTTP SERVER
-// layer on desktop (handleFirstRunRoutes / app-core auth routes), not through
-// the plugin-route kernel — so the in-process stdio dispatch never sees them.
-// On Android the WebView talks to the bridge from the very first boot (the
-// local agent is pre-seeded as the active server on sideload builds), which made
-// startup polls 404 and hard-fail a FRESH install with "Startup failed: Backend
-// Unreachable" before onboarding could start. These routes answer from the SAME
-// durable truth the server uses where there is durable state: the persisted
-// ElizaConfig. Unlike the iOS full-Bun shim (which hardcodes complete:true
-// because iOS only reaches its bridge after a local runtime was chosen), Android
-// must report honestly in both phases or a fresh install would skip onboarding
-// entirely.
-
-/** The persisted-config seams the core routes read/write (from @elizaos/agent). */
-export interface AndroidCoreRouteDeps {
-	configFileExists: () => boolean;
-	loadElizaConfig: () => AndroidElizaConfigLike;
-	saveElizaConfig: (config: AndroidElizaConfigLike) => void;
-	hasPersistedFirstRunState: (config: AndroidElizaConfigLike) => boolean;
-}
-
-/** Structural stand-in for ElizaConfig — the bridge only touches `meta`. */
-export type AndroidElizaConfigLike = Record<string, unknown> & {
-	meta?: Record<string, unknown>;
-};
-
-/**
- * Answer a server-level core route, or return null to fall through to the
- * plugin-route kernel. GET status reads completion from the persisted config;
- * POST records the completion marker (the full first-run profile writer lives
- * in the server layer — the marker is what gates the startup poll, and the
- * cloud-only flow persists its profile against the bound cloud agent).
- */
-export function handleAndroidCoreRoute(
-	method: string,
-	pathname: string,
-	deps: AndroidCoreRouteDeps,
-): AndroidBufferedResponse | null {
-	if (method === "GET" && pathname === "/api/auth/status") {
-		return jsonBuffered(200, {
-			required: false,
-			authenticated: true,
-			loginRequired: false,
-			bootstrapRequired: false,
-			localAccess: true,
-			passwordConfigured: false,
-			pairingEnabled: false,
-			expiresAt: null,
-		});
-	}
-	if (method === "GET" && pathname === "/api/auth/me") {
-		return jsonBuffered(200, {
-			identity: {
-				id: "local-agent",
-				displayName: "Local Agent",
-				kind: "machine",
-			},
-			session: { id: "local", kind: "local", expiresAt: null },
-			access: {
-				mode: "local",
-				passwordConfigured: false,
-				ownerConfigured: false,
-				role: "OWNER",
-			},
-		});
-	}
-	if (method === "GET" && pathname === "/api/first-run/status") {
-		let complete = false;
-		try {
-			complete =
-				deps.configFileExists() &&
-				deps.hasPersistedFirstRunState(deps.loadElizaConfig());
-		} catch {
-			// error-policy:J3 an unreadable config cannot prove completion — fail
-			// closed to "onboarding required"; the client's durable completion
-			// flag still protects an already-onboarded install (#11506).
-			complete = false;
-		}
-		return jsonBuffered(200, { complete, cloudProvisioned: false });
-	}
-	if (method === "POST" && pathname === "/api/first-run") {
-		try {
-			const config: AndroidElizaConfigLike = deps.configFileExists()
-				? deps.loadElizaConfig()
-				: {};
-			config.meta = { ...(config.meta ?? {}), firstRunComplete: true };
-			deps.saveElizaConfig(config);
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			return jsonBuffered(500, {
-				error: `Failed to persist first-run completion: ${message}`,
-			});
-		}
-		return jsonBuffered(200, { ok: true, complete: true });
-	}
-	return null;
-}
-
 /**
  * Dispatch one buffered request in-process and return the loopback-shaped
  * envelope. Throws on an invalid path/method (the caller surfaces it as an
@@ -294,7 +305,6 @@ export async function dispatchBufferedRequest(
 	runtime: IAgentRuntime,
 	dispatchRoute: AndroidDispatchRoute,
 	payload: AndroidRequestPayload,
-	coreRoutes?: AndroidCoreRouteDeps,
 ): Promise<AndroidBufferedResponse> {
 	const rawPath = typeof payload.path === "string" ? payload.path.trim() : "";
 	if (!rawPath || !isSafeLocalPath(rawPath)) {
@@ -306,10 +316,8 @@ export async function dispatchBufferedRequest(
 	const headers = normalizeHeaderRecord(payload.headers);
 	const { pathname, query } = splitPathAndQuery(rawPath);
 
-	if (coreRoutes) {
-		const core = handleAndroidCoreRoute(method, pathname, coreRoutes);
-		if (core) return core;
-	}
+	const direct = directAndroidCoreRoute(runtime, method, pathname);
+	if (direct) return direct;
 
 	const result = await dispatchRoute({
 		runtime,
@@ -348,7 +356,6 @@ export async function dispatchStreamingRequest(
 	dispatchRoute: AndroidDispatchRoute,
 	payload: AndroidRequestPayload,
 	sink: StdioBridgeStreamSink,
-	coreRoutes?: AndroidCoreRouteDeps,
 ): Promise<void> {
 	const rawPath = typeof payload.path === "string" ? payload.path.trim() : "";
 	if (!rawPath || !isSafeLocalPath(rawPath)) {
@@ -360,17 +367,15 @@ export async function dispatchStreamingRequest(
 	const headers = normalizeHeaderRecord(payload.headers);
 	const { pathname, query } = splitPathAndQuery(rawPath);
 
-	if (coreRoutes) {
-		const core = handleAndroidCoreRoute(method, pathname, coreRoutes);
-		if (core) {
-			sink.emitResponse({
-				status: core.status,
-				statusText: core.statusText,
-				headers: core.headers,
-			});
-			if (core.bodyBase64) sink.emitChunk(core.bodyBase64);
-			return;
-		}
+	const direct = directAndroidCoreRoute(runtime, method, pathname);
+	if (direct) {
+		sink.emitResponse({
+			status: direct.status,
+			statusText: direct.statusText,
+			headers: direct.headers,
+		});
+		if (direct.bodyBase64) sink.emitChunk(direct.bodyBase64);
+		return;
 	}
 
 	// A legacy SSE handler flushes body fragments through `res.write(...)` before

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
@@ -223,8 +223,8 @@ function directAndroidCoreRoute(
 					coreRoutes.hasPersistedFirstRunState(coreRoutes.loadElizaConfig()),
 			);
 		} catch {
-			// An unreadable config cannot prove onboarding completion. Fail closed
-			// to "onboarding required" instead of skipping first-run on Android.
+			// error-policy:J3 an unreadable config cannot prove onboarding completion.
+			// Fail closed to "onboarding required" instead of skipping first-run on Android.
 			complete = false;
 		}
 		return jsonResponse(200, {


### PR DESCRIPTION
## Summary

Fixes #13550.

Android local-agent mode now answers the startup-critical app-core routes directly over the abstract UDS bridge before falling through to the agent `dispatchRoute` kernel. This mirrors the existing iOS local bridge shims and prevents fresh local Android installs from getting `No local route for GET /api/first-run/status` after the backend is already healthy.

Routes covered:
- `GET /api/health`
- `GET /api/status`
- `GET /api/apps/runs`
- `GET /api/first-run/status`
- `POST /api/first-run`
- `GET /api/auth/me`
- `GET /api/auth/status`
- `POST /api/auth/bootstrap/exchange` (non-404 local unavailable response)

## Tests

- `bun test plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts` — passed, 12 tests
- `bunx @biomejs/biome check plugins/plugin-capacitor-bridge/src/android/dispatch.ts plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts --no-errors-on-unmatched` — passed
- `git diff --check` — passed

Additional check attempted:
- `bun run --cwd plugins/plugin-capacitor-bridge typecheck` — failed on pre-existing workspace/module resolution errors across unrelated agent/core/wallet packages in this isolated worktree; no Android dispatch-specific errors surfaced before the broad dependency failures.
- `bun run --cwd plugins/plugin-capacitor-bridge test` — 102/104 passed; the 2 failures are existing abstract-socket tests (`listen EINVAL` on `\0eliza-test-serving-*`) in this macOS worktree, unrelated to the dispatch shim.
