### PR TITLE
chore(cloud): deep-import PageHeaderProvider from the layout subpath, not the cloud-ui root barrel

### DIFF
--- a/packages/ui/src/cloud/account-security/AccountPage.tsx
+++ b/packages/ui/src/cloud/account-security/AccountPage.tsx
@@ -8,7 +8,7 @@
  * Default export for `React.lazy` code-splitting from the route registration.
  */
 
-import { PageHeaderProvider } from "../../cloud-ui";
+import { PageHeaderProvider } from "../../cloud-ui/components/layout";
 import { useDocumentTitle } from "../lib/use-document-title";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { AccountSurface } from "./AccountSurface";

--- a/packages/ui/src/cloud/account-security/PermissionsPage.tsx
+++ b/packages/ui/src/cloud/account-security/PermissionsPage.tsx
@@ -8,7 +8,7 @@
  * Default export for `React.lazy` code-splitting from the route registration.
  */
 
-import { PageHeaderProvider } from "../../cloud-ui";
+import { PageHeaderProvider } from "../../cloud-ui/components/layout";
 import { useDocumentTitle } from "../lib/use-document-title";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { PermissionsSurface } from "./PermissionsSurface";

--- a/packages/ui/src/cloud/account-security/SecurityPage.tsx
+++ b/packages/ui/src/cloud/account-security/SecurityPage.tsx
@@ -8,7 +8,7 @@
  * Default export for `React.lazy` code-splitting from the route registration.
  */
 
-import { PageHeaderProvider } from "../../cloud-ui";
+import { PageHeaderProvider } from "../../cloud-ui/components/layout";
 import { useDocumentTitle } from "../lib/use-document-title";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { SecuritySurface } from "./SecuritySurface";

--- a/packages/ui/src/cloud/api-keys/ApiKeysPage.tsx
+++ b/packages/ui/src/cloud/api-keys/ApiKeysPage.tsx
@@ -9,7 +9,7 @@
  * Default export for `React.lazy` code-splitting from the route registration.
  */
 
-import { PageHeaderProvider } from "../../cloud-ui";
+import { PageHeaderProvider } from "../../cloud-ui/components/layout";
 import { useDocumentTitle } from "../lib/use-document-title";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { ApiKeysSurface } from "./ApiKeysSurface";

--- a/packages/ui/src/cloud/mcps/McpsRoute.tsx
+++ b/packages/ui/src/cloud/mcps/McpsRoute.tsx
@@ -9,8 +9,8 @@
  * section gets it from `CloudSettingsSectionShell`.
  */
 
-import { PageHeaderProvider } from "../../cloud-ui/components/layout";
 import { DashboardLoadingState } from "../../cloud-ui/components/dashboard/route-placeholders";
+import { PageHeaderProvider } from "../../cloud-ui/components/layout";
 import { useSessionAuth } from "../lib/use-session-auth";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { McpsView } from "./McpsView";

--- a/packages/ui/src/cloud/mcps/McpsRoute.tsx
+++ b/packages/ui/src/cloud/mcps/McpsRoute.tsx
@@ -9,7 +9,7 @@
  * section gets it from `CloudSettingsSectionShell`.
  */
 
-import { PageHeaderProvider } from "../../cloud-ui";
+import { PageHeaderProvider } from "../../cloud-ui/components/layout";
 import { DashboardLoadingState } from "../../cloud-ui/components/dashboard/route-placeholders";
 import { useSessionAuth } from "../lib/use-session-auth";
 import { useCloudT } from "../shell/CloudI18nProvider";

--- a/packages/ui/src/cloud/settings/CloudSettingsSectionShell.tsx
+++ b/packages/ui/src/cloud/settings/CloudSettingsSectionShell.tsx
@@ -32,7 +32,7 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { MemoryRouter, useInRouterContext } from "react-router-dom";
-import { PageHeaderProvider } from "../../cloud-ui";
+import { PageHeaderProvider } from "../../cloud-ui/components/layout";
 import { queryClient } from "../lib/query-client";
 import {
   CloudI18nProvider,


### PR DESCRIPTION
Launch-QA card: **Slop pass — deep imports for PageHeaderProvider wrappers**.

## What

6 console page chunks imported `PageHeaderProvider` from the **root `../../cloud-ui` barrel**:
`account-security/{AccountPage,PermissionsPage,SecurityPage}`, `api-keys/ApiKeysPage`, `mcps/McpsRoute`, `settings/CloudSettingsSectionShell`. Each lazy page chunk pulling the whole cloud-ui barrel just for the provider is the code-splitting slop the card calls out.

Point them at the real export subpath `../../cloud-ui/components/layout` (verified: `layout/index.ts:44 export { PageHeaderProvider }`), which sibling files (e.g. `dashboard-route-page.tsx`) already use. **Import-path only, zero behavior change.**

## Scope

Scoped to the card headline (PageHeaderProvider, 6 files, one symbol, verified subpath) rather than sprawling one PR across all ~18 console barrel imports. Follow-up (noted on #13406): the broader nubs-5-rules sweep — the group imports (`analytics/Page.tsx`) and other barrel symbols (`DashboardErrorState`/`BrandButton`/`BrandCard`/…) → their subpaths, which need import-splitting.

Verified: `git grep` shows 0 root-barrel `PageHeaderProvider` imports remain; typecheck via CI (fresh worktree has no node_modules locally).