### PR TITLE
fix(ui): clarify cloud console loading states

### DIFF
--- a/.github/issue-evidence/13447-console-visual-loading-states.md
+++ b/.github/issue-evidence/13447-console-visual-loading-states.md
@@ -1,50 +1,65 @@
-# #13447 console visual loading-state evidence
+# #13447 console visual/loading-state evidence
 
 Date: 2026-07-04
 
-## Changes verified
+## Scope retained after syncing with develop
 
-- `/dashboard/apps` renders loading stat skeletons before app data resolves, so the page no longer shows success-shaped zero stats or a blank light rectangle during load/error transitions.
-- `/dashboard/agents` no longer renders the pricing/empty banner while the agents table query is still loading, and renders a real error state when the query fails.
-- Billing disabled buy-credit states use explicit dark styling instead of inherited blank/gray button states; invoice fetch failures render an error row rather than silently looking empty.
-- Account UI consumes the shared linked-account DTO exported by `@elizaos/shared`, and `useWalletState` has an explicit `WalletEntry` callback annotation so the console typecheck remains clean.
+This PR was reduced to the still-unmerged #13447 UI-state fixes. Already-merged
+or superseded work was intentionally dropped:
 
-## Commands
+- Billing selected-state and disabled button styling: covered by #13437.
+- Apps/Create App white-on-white CTA styling: covered by #13546.
+- Console title/sidebar changes: covered by #13552.
+- Account DTO and wallet callback type cleanup: covered by #13450.
+
+## Changes verified in this branch
+
+- `/dashboard/apps` renders stat-card skeletons while the session/app query is
+  loading, instead of success-shaped zero stats.
+- `/dashboard/apps` suppresses success stats when the apps query fails and shows
+  the existing dashboard error state.
+- `/dashboard/agents` renders the table skeleton before the pricing banner, so
+  loading does not look like an empty/no-agent state.
+- `/dashboard/agents` renders an explicit error state when the agents query
+  fails, instead of collapsing to an empty table.
+
+## Local checks
 
 ```bash
-bunx @biomejs/biome check --write packages/ui/src/api/client-agent.ts packages/ui/src/hooks/useAccounts.ts packages/ui/src/components/accounts/AddAccountDialog.tsx packages/ui/src/state/useWalletState.ts packages/ui/src/cloud/applications/ApplicationsPage.tsx packages/ui/src/cloud/instances/AgentsPage.tsx packages/ui/src/cloud/billing/components/billing-tab.tsx
+bunx @biomejs/biome check packages/ui/src/cloud/instances/AgentsPage.tsx packages/ui/src/cloud/instances/AgentsPage.test.tsx packages/ui/src/cloud/applications/ApplicationsPage.tsx packages/ui/src/cloud/applications/ApplicationsPage.test.tsx
 ```
 
 Result: passed.
 
 ```bash
-bun run --cwd packages/contracts build
-bun run --cwd packages/cloud/routing build
-bun run --cwd packages/shared build:i18n
-bun run --cwd packages/ui typecheck
+git diff --check
 ```
 
-Result: passed. This first reproduced the linked-account and wallet type errors in a fresh worktree; after the fix, `packages/ui` typecheck exits cleanly.
+Result: passed.
+
+## Focused tests
+
+Added component regression tests:
+
+- `packages/ui/src/cloud/instances/AgentsPage.test.tsx`
+- `packages/ui/src/cloud/applications/ApplicationsPage.test.tsx`
+
+Attempted command:
+
+```bash
+bun run --cwd packages/ui test -- src/cloud/instances/AgentsPage.test.tsx src/cloud/applications/ApplicationsPage.test.tsx
+```
+
+Result: blocked before test execution in the sparse checkout because the local
+workspace install does not expose `react/package.json`. A fresh `bun install`
+was not run because this machine was at the disk limit during the cleanup wave.
+
+## Visual audit
+
+Not rerun in this sparse checkout for the same disk/install reason. Required
+before final merge if CI does not provide equivalent coverage:
 
 ```bash
 bun run --cwd packages/app audit:app
-```
-
-Result: passed, `373 passed (13.5m)`. Summary: `broken=0`, `needs-work=0`, `needs-eyeball=25`, `good=347`, `minimalism-budget-failures=0`.
-
-```bash
 bun run --cwd packages/app audit:cloud
 ```
-
-Result: passed, `69 passed (3.2m)`. Summary: `broken=0`, `needs-work=0`, `needs-eyeball=68`.
-
-## Manual review targets
-
-Generated cloud-audit artifacts were written under `packages/app/aesthetic-audit-output-cloud/`.
-
-- `desktop/dashboard-agents.png`, `mobile/dashboard-agents.png`, plus hover captures: no console errors, no blue-color hits, no hover violations, no screenshot quality issues.
-- `desktop/dashboard-apps.png`, `mobile/dashboard-apps.png`, plus hover captures: no console errors, no blue-color hits, no hover violations, no screenshot quality issues.
-- `desktop/dashboard-billing-success.png`, `mobile/dashboard-billing-success.png`: no console errors, no blue-color hits, no hover violations, no screenshot quality issues.
-- `desktop/dashboard-invoice-detail.png`, `mobile/dashboard-invoice-detail.png`, plus hover captures: no console errors, no blue-color hits, no hover violations, no screenshot quality issues.
-
-The full cloud report is `packages/app/aesthetic-audit-output-cloud/report.json`; the contact sheet is `packages/app/aesthetic-audit-output-cloud/contact-sheet.html`.

--- a/packages/ui/src/cloud/applications/ApplicationsPage.test.tsx
+++ b/packages/ui/src/cloud/applications/ApplicationsPage.test.tsx
@@ -1,0 +1,169 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ApplicationsPage from "./ApplicationsPage";
+
+const appsState = vi.hoisted(() => ({
+  query: {
+    data: undefined as unknown,
+    error: null as unknown,
+    isError: false,
+    isLoading: false,
+  },
+  session: {
+    authenticated: true,
+    ready: true,
+  },
+}));
+
+vi.mock("../../cloud-ui/components/brand", () => ({
+  BrandCard: ({ children }: { children: ReactNode }) => (
+    <article>{children}</article>
+  ),
+  DashboardStatCard: ({
+    label,
+    value,
+  }: {
+    label: string;
+    value: ReactNode;
+  }) => (
+    <div>
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  ),
+}));
+
+vi.mock(
+  "../../cloud-ui/components/dashboard/cloud-dashboard-components",
+  () => ({
+    AppsEmptyState: ({ action }: { action?: ReactNode }) => (
+      <div data-testid="apps-empty">empty {action}</div>
+    ),
+    AppsPageWrapper: ({ children }: { children: ReactNode }) => (
+      <section>{children}</section>
+    ),
+    AppsSkeleton: () => <div data-testid="apps-skeleton" />,
+  }),
+);
+
+vi.mock("../../cloud-ui/components/dashboard/route-placeholders", () => ({
+  DashboardErrorState: ({ message }: { message: string }) => (
+    <div role="alert">{message}</div>
+  ),
+}));
+
+vi.mock("../../cloud-ui/components/layout", () => ({
+  DashboardPageContainer: ({ children }: { children: ReactNode }) => (
+    <main>{children}</main>
+  ),
+  DashboardStatGrid: ({ children, ...props }: { children: ReactNode }) => (
+    <div {...props}>{children}</div>
+  ),
+  DashboardToolbar: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("../../components/ui/skeleton", () => ({
+  Skeleton: () => <span data-testid="stat-skeleton" />,
+}));
+
+vi.mock("../lib/use-session-auth", () => ({
+  useRequireAuth: () => appsState.session,
+}));
+
+vi.mock("../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? "",
+}));
+
+vi.mock("./components/apps-table", () => ({
+  AppsTable: ({ apps }: { apps: unknown[] }) => (
+    <div data-testid="apps-table">{apps.length} apps</div>
+  ),
+}));
+
+vi.mock("./components/create-app-button", () => ({
+  CreateAppButton: () => <button type="button">Create App</button>,
+}));
+
+vi.mock("./lib/apps", () => ({
+  useApps: () => appsState.query,
+}));
+
+afterEach(() => {
+  cleanup();
+  appsState.query = {
+    data: undefined,
+    error: null,
+    isError: false,
+    isLoading: false,
+  };
+  appsState.session = {
+    authenticated: true,
+    ready: true,
+  };
+});
+
+describe("ApplicationsPage", () => {
+  it("renders stat skeletons instead of zero-valued success stats while loading", () => {
+    appsState.query = {
+      data: undefined,
+      error: null,
+      isError: false,
+      isLoading: true,
+    };
+
+    render(<ApplicationsPage />);
+
+    expect(screen.getByTestId("apps-skeleton")).toBeInTheDocument();
+    expect(screen.getAllByTestId("stat-skeleton")).toHaveLength(12);
+    expect(screen.queryByText("Total Apps")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("apps-empty")).not.toBeInTheDocument();
+  });
+
+  it("renders an explicit error without success stats or empty state", () => {
+    appsState.query = {
+      data: undefined,
+      error: new Error("apps unavailable"),
+      isError: true,
+      isLoading: false,
+    };
+
+    render(<ApplicationsPage />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("apps unavailable");
+    expect(screen.queryByText("Total Apps")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("apps-empty")).not.toBeInTheDocument();
+  });
+
+  it("renders stats and table after apps resolve", () => {
+    appsState.query = {
+      data: [
+        {
+          app_id: "app-1",
+          app_url: "https://app.example",
+          client_id: "client-1",
+          created_at: "2026-07-04T00:00:00Z",
+          description: null,
+          id: "app-1",
+          is_active: true,
+          name: "Launch App",
+          total_requests: 17,
+          total_users: 3,
+          updated_at: "2026-07-04T00:00:00Z",
+        },
+      ],
+      error: null,
+      isError: false,
+      isLoading: false,
+    };
+
+    render(<ApplicationsPage />);
+
+    expect(screen.getByText("Total Apps")).toBeInTheDocument();
+    expect(screen.getByText("Total Users")).toBeInTheDocument();
+    expect(screen.getByTestId("apps-table")).toHaveTextContent("1 apps");
+  });
+});

--- a/packages/ui/src/cloud/instances/AgentsPage.test.tsx
+++ b/packages/ui/src/cloud/instances/AgentsPage.test.tsx
@@ -1,0 +1,144 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import AgentsPage from "./AgentsPage";
+
+const agentsState = vi.hoisted(() => ({
+  query: {
+    data: undefined as unknown,
+    error: null as unknown,
+    isError: false,
+    isLoading: false,
+  },
+  credits: {
+    data: { balance: 12.5 },
+  },
+}));
+
+vi.mock("@elizaos/ui/cloud-ui", () => ({
+  ContainersSkeleton: () => <div data-testid="agents-skeleton" />,
+  DashboardErrorState: ({ message }: { message: string }) => (
+    <div role="alert">{message}</div>
+  ),
+  DashboardLoadingState: ({ label }: { label: string }) => <div>{label}</div>,
+  DashboardPageContainer: ({ children }: { children: ReactNode }) => (
+    <main>{children}</main>
+  ),
+  ElizaAgentsPageWrapper: ({ children }: { children: ReactNode }) => (
+    <section>{children}</section>
+  ),
+}));
+
+vi.mock("../lib/use-document-title", () => ({
+  useDocumentTitle: () => {},
+}));
+
+vi.mock("../lib/use-session-auth", () => ({
+  useRequireAuth: () => ({ authenticated: true, ready: true }),
+}));
+
+vi.mock("./components/eliza-agent-pricing-banner", () => ({
+  ElizaAgentPricingBanner: ({
+    runningCount,
+    idleCount,
+  }: {
+    runningCount: number;
+    idleCount: number;
+  }) => (
+    <div data-testid="pricing-banner">
+      running {runningCount} idle {idleCount}
+    </div>
+  ),
+}));
+
+vi.mock("./components/eliza-agents-table", () => ({
+  ElizaAgentsTable: ({ sandboxes }: { sandboxes: unknown[] }) => (
+    <div data-testid="agents-table">{sandboxes.length} rows</div>
+  ),
+}));
+
+vi.mock("./lib/data/credits", () => ({
+  useCreditsBalance: () => agentsState.credits,
+}));
+
+vi.mock("./lib/data/eliza-agents", () => ({
+  useAgents: () => agentsState.query,
+}));
+
+vi.mock("./lib/i18n", () => ({
+  useT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? "",
+}));
+
+afterEach(() => {
+  cleanup();
+  agentsState.query = {
+    data: undefined,
+    error: null,
+    isError: false,
+    isLoading: false,
+  };
+});
+
+describe("AgentsPage", () => {
+  it("does not render pricing or empty table semantics while agents are loading", () => {
+    agentsState.query = {
+      data: undefined,
+      error: null,
+      isError: false,
+      isLoading: true,
+    };
+
+    render(<AgentsPage />);
+
+    expect(screen.getByTestId("agents-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("pricing-banner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("agents-table")).not.toBeInTheDocument();
+  });
+
+  it("renders an explicit error state instead of an empty table on query failure", () => {
+    agentsState.query = {
+      data: undefined,
+      error: new Error("instances unavailable"),
+      isError: true,
+      isLoading: false,
+    };
+
+    render(<AgentsPage />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "instances unavailable",
+    );
+    expect(screen.queryByTestId("pricing-banner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("agents-table")).not.toBeInTheDocument();
+  });
+
+  it("renders pricing and table after agents resolve", () => {
+    agentsState.query = {
+      data: [
+        {
+          agentName: "Launch Agent",
+          createdAt: "2026-07-04T00:00:00Z",
+          dockerImage: "eliza:test",
+          errorMessage: null,
+          executionTier: "shared",
+          id: "agent-1",
+          lastHeartbeatAt: null,
+          status: "running",
+          updatedAt: "2026-07-04T00:00:00Z",
+          webUiUrl: "https://example.test",
+        },
+      ],
+      error: null,
+      isError: false,
+      isLoading: false,
+    };
+
+    render(<AgentsPage />);
+
+    expect(screen.getByTestId("pricing-banner")).toHaveTextContent(
+      "running 1 idle 0",
+    );
+    expect(screen.getByTestId("agents-table")).toHaveTextContent("1 rows");
+  });
+});


### PR DESCRIPTION
Supersedes stale/conflicting PR #13493 with a current develop-based branch that keeps only the remaining #13447 UI-state fixes.\n\nSummary:\n- /dashboard/apps shows stat skeletons while app/session data is loading instead of success-shaped zero stats.\n- /dashboard/apps suppresses success stats on query failure and shows the dashboard error state.\n- /dashboard/agents withholds the pricing banner until the agents query resolves, avoiding loading-as-empty semantics.\n- /dashboard/agents shows an explicit error state when the agents query fails.\n- Adds focused component tests for loading/error/resolved states on both pages.\n\nVerification:\n- bunx @biomejs/biome check packages/ui/src/cloud/instances/AgentsPage.tsx packages/ui/src/cloud/instances/AgentsPage.test.tsx packages/ui/src/cloud/applications/ApplicationsPage.tsx packages/ui/src/cloud/applications/ApplicationsPage.test.tsx: passed.\n- git diff --check: passed.\n- Focused Vitest command attempted but blocked before execution because the sparse checkout and existing local install do not expose react/package.json; see .github/issue-evidence/13447-console-visual-loading-states.md.\n\nRequired before ready:\n- bun run --cwd packages/ui test -- src/cloud/instances/AgentsPage.test.tsx src/cloud/applications/ApplicationsPage.test.tsx\n- bun run --cwd packages/app audit:app\n- bun run --cwd packages/app audit:cloud\n\nFixes #13447.