### PR TITLE
fix(env): unify brand alias table

### DIFF
--- a/packages/app/src/brand-env.test.ts
+++ b/packages/app/src/brand-env.test.ts
@@ -22,9 +22,56 @@ describe("buildBrandEnvAliases", () => {
     expect(aliases.get("ACME_DISABLE_AUTO_API_TOKEN")).toBe(
       "ELIZA_DISABLE_AUTO_API_TOKEN",
     );
+    expect(aliases.get("ACME_WALLET_EXPORT_TOKEN")).toBe(
+      "ELIZA_WALLET_EXPORT_TOKEN",
+    );
+    expect(aliases.get("ACME_TERMINAL_RUN_TOKEN")).toBe(
+      "ELIZA_TERMINAL_RUN_TOKEN",
+    );
     expect(aliases.get("ACME_PORT")).toBe("ELIZA_PORT");
     expect(aliases.get("ACME_UI_PORT")).toBe("ELIZA_UI_PORT");
     expect(aliases.get("ACME_API_PORT")).toBe("ELIZA_API_PORT");
     expect(aliases.get("ACME_PLATFORM")).toBe("ELIZA_PLATFORM");
+  });
+
+  it("covers aliases formerly present only in the sync mutation table", () => {
+    const aliases = new Map(buildBrandEnvAliases("ACME"));
+
+    expect(aliases.get("ACME_OAUTH_DIR")).toBe("ELIZA_OAUTH_DIR");
+    expect(aliases.get("ACME_AGENT_ORCHESTRATOR")).toBe(
+      "ELIZA_AGENT_ORCHESTRATOR",
+    );
+    expect(aliases.get("ACME_CLOUD_PROVISIONED")).toBe(
+      "ELIZA_CLOUD_PROVISIONED",
+    );
+    expect(aliases.get("ACME_CLOUD_MANAGED_AGENTS_API_SEGMENT")).toBe(
+      "ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT",
+    );
+    expect(aliases.get("ACME_CHAT_GENERATION_TIMEOUT_MS")).toBe(
+      "ELIZA_CHAT_GENERATION_TIMEOUT_MS",
+    );
+    expect(aliases.get("ACME_SKIP_LOCAL_PLUGIN_ROLES")).toBe(
+      "ELIZA_SKIP_LOCAL_PLUGIN_ROLES",
+    );
+    expect(aliases.get("ACME_SETTINGS_DEBUG")).toBe("ELIZA_SETTINGS_DEBUG");
+    expect(aliases.get("VITE_ACME_SETTINGS_DEBUG")).toBe(
+      "VITE_ELIZA_SETTINGS_DEBUG",
+    );
+    expect(aliases.get("ACME_GOOGLE_OAUTH_DESKTOP_CLIENT_ID")).toBe(
+      "ELIZA_GOOGLE_OAUTH_DESKTOP_CLIENT_ID",
+    );
+    expect(aliases.get("ACME_API_BASE")).toBe("ELIZA_API_BASE");
+    expect(aliases.get("ACME_API_BASE_URL")).toBe("ELIZA_API_BASE_URL");
+    expect(aliases.get("ACME_DESKTOP_API_BASE")).toBe("ELIZA_DESKTOP_API_BASE");
+    expect(aliases.get("ACME_DESKTOP_TEST_API_BASE")).toBe(
+      "ELIZA_DESKTOP_TEST_API_BASE",
+    );
+    expect(aliases.get("ACME_DESKTOP_SKIP_EMBEDDED_AGENT")).toBe(
+      "ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT",
+    );
+    expect(aliases.get("ACME_RENDERER_URL")).toBe("ELIZA_RENDERER_URL");
+    expect(aliases.get("ACME_APP_ROUTE_PLUGIN_MODULES")).toBe(
+      "ELIZA_APP_ROUTE_PLUGIN_MODULES",
+    );
   });
 });

--- a/packages/app/src/brand-env.ts
+++ b/packages/app/src/brand-env.ts
@@ -6,49 +6,11 @@
  * `APP_ENV_ALIASES` is the concrete table resolved for this app's configured
  * prefix (`APP_ENV_PREFIX`).
  */
+import { buildBrandEnvAliases } from "@elizaos/shared/config/brand-env-aliases";
 import { APP_CONFIG } from "./app-config";
 import { normalizeEnvPrefix } from "./env-prefix.js";
 
-const ENV_ALIAS_SUFFIXES = [
-  // API & auth
-  ["API_TOKEN", "API_TOKEN"],
-  ["API_BIND", "API_BIND"],
-  ["API_EXPOSE_PORT", "API_EXPOSE_PORT"],
-  ["PAIRING_DISABLED", "PAIRING_DISABLED"],
-  ["ALLOWED_ORIGINS", "ALLOWED_ORIGINS"],
-  ["ALLOWED_HOSTS", "ALLOWED_HOSTS"],
-  ["ALLOW_NULL_ORIGIN", "ALLOW_NULL_ORIGIN"],
-  ["ALLOW_WS_QUERY_TOKEN", "ALLOW_WS_QUERY_TOKEN"],
-  ["DISABLE_AUTO_API_TOKEN", "DISABLE_AUTO_API_TOKEN"],
-  ["WALLET_EXPORT_TOKEN", "WALLET_EXPORT_TOKEN"],
-  ["TERMINAL_RUN_TOKEN", "TERMINAL_RUN_TOKEN"],
-  ["NAMESPACE", "NAMESPACE"],
-  ["STATE_DIR", "STATE_DIR"],
-  ["CONFIG_PATH", "CONFIG_PATH"],
-  ["PLATFORM", "PLATFORM"],
-  // Cloud services
-  ["CLOUD_TTS_DISABLED", "CLOUD_TTS_DISABLED"],
-  ["CLOUD_MEDIA_DISABLED", "CLOUD_MEDIA_DISABLED"],
-  ["CLOUD_EMBEDDINGS_DISABLED", "CLOUD_EMBEDDINGS_DISABLED"],
-  ["CLOUD_RPC_DISABLED", "CLOUD_RPC_DISABLED"],
-  ["DISABLE_LOCAL_EMBEDDINGS", "DISABLE_LOCAL_EMBEDDINGS"],
-  ["DISABLE_EDGE_TTS", "DISABLE_EDGE_TTS"],
-  // Ports
-  ["PORT", "PORT"],
-  ["UI_PORT", "UI_PORT"],
-  ["API_PORT", "API_PORT"],
-  ["HOME_PORT", "HOME_PORT"],
-  ["GATEWAY_PORT", "GATEWAY_PORT"],
-  ["BRIDGE_PORT", "BRIDGE_PORT"],
-] as const;
-
-export function buildBrandEnvAliases(prefix: string) {
-  const normalizedPrefix = normalizeEnvPrefix(prefix);
-  return ENV_ALIAS_SUFFIXES.map(
-    ([brandSuffix, elizaSuffix]) =>
-      [`${normalizedPrefix}_${brandSuffix}`, `ELIZA_${elizaSuffix}`] as const,
-  );
-}
+export { buildBrandEnvAliases };
 
 export const APP_ENV_PREFIX = normalizeEnvPrefix(
   APP_CONFIG.envPrefix ?? APP_CONFIG.cliName,

--- a/packages/elizaos/src/__tests__/project-template-brand-env.test.ts
+++ b/packages/elizaos/src/__tests__/project-template-brand-env.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The generated project app must consume the same canonical brand env alias
+ * helper as packages/app. A local suffix table here will drift from runtime
+ * aliases and silently omit security or port keys in newly scaffolded apps.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+
+describe("project template brand env aliases", () => {
+  it("delegates to the shared canonical alias helper", () => {
+    const brandEnv = readFileSync(
+      resolve(here, "../../templates/project/apps/app/src/brand-env.ts"),
+      "utf8",
+    );
+
+    expect(brandEnv).toContain('from "@elizaos/shared"');
+    expect(brandEnv).toContain("buildBrandEnvAliases");
+    expect(brandEnv).toContain("normalizeBrandEnvPrefix");
+    expect(brandEnv).not.toContain("ENV_ALIAS_SUFFIXES");
+  });
+});

--- a/packages/elizaos/templates/project/apps/app/src/brand-env.ts
+++ b/packages/elizaos/templates/project/apps/app/src/brand-env.ts
@@ -9,62 +9,12 @@
  * `MYAPP_API_TOKEN ↔ ELIZA_API_TOKEN`, etc. The prefix is sourced from
  * `APP_CONFIG.envPrefix` (or `cliName` as fallback).
  */
+import { buildBrandEnvAliases, normalizeBrandEnvPrefix } from "@elizaos/shared";
 import { APP_CONFIG } from "./app-config";
 
-const ENV_ALIAS_SUFFIXES = [
-  // API & auth
-  ["API_TOKEN", "API_TOKEN"],
-  ["API_BIND", "API_BIND"],
-  ["API_EXPOSE_PORT", "API_EXPOSE_PORT"],
-  ["PAIRING_DISABLED", "PAIRING_DISABLED"],
-  ["ALLOWED_ORIGINS", "ALLOWED_ORIGINS"],
-  ["ALLOWED_HOSTS", "ALLOWED_HOSTS"],
-  ["ALLOW_NULL_ORIGIN", "ALLOW_NULL_ORIGIN"],
-  ["ALLOW_WS_QUERY_TOKEN", "ALLOW_WS_QUERY_TOKEN"],
-  ["DISABLE_AUTO_API_TOKEN", "DISABLE_AUTO_API_TOKEN"],
-  ["WALLET_EXPORT_TOKEN", "WALLET_EXPORT_TOKEN"],
-  ["TERMINAL_RUN_TOKEN", "TERMINAL_RUN_TOKEN"],
-  ["NAMESPACE", "NAMESPACE"],
-  ["STATE_DIR", "STATE_DIR"],
-  ["CONFIG_PATH", "CONFIG_PATH"],
-  ["PLATFORM", "PLATFORM"],
-  // Cloud services
-  ["CLOUD_TTS_DISABLED", "CLOUD_TTS_DISABLED"],
-  ["CLOUD_MEDIA_DISABLED", "CLOUD_MEDIA_DISABLED"],
-  ["CLOUD_EMBEDDINGS_DISABLED", "CLOUD_EMBEDDINGS_DISABLED"],
-  ["CLOUD_RPC_DISABLED", "CLOUD_RPC_DISABLED"],
-  ["DISABLE_LOCAL_EMBEDDINGS", "DISABLE_LOCAL_EMBEDDINGS"],
-  ["DISABLE_EDGE_TTS", "DISABLE_EDGE_TTS"],
-  // Ports
-  ["PORT", "PORT"],
-  ["UI_PORT", "UI_PORT"],
-  ["API_PORT", "API_PORT"],
-  ["HOME_PORT", "HOME_PORT"],
-  ["GATEWAY_PORT", "GATEWAY_PORT"],
-  ["BRIDGE_PORT", "BRIDGE_PORT"],
-] as const;
+export { buildBrandEnvAliases };
 
-function normalizeEnvPrefix(value: string): string {
-  const normalized = value
-    .trim()
-    .replace(/[^A-Za-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "")
-    .toUpperCase();
-  if (!normalized) {
-    throw new Error("App envPrefix must resolve to a non-empty identifier");
-  }
-  return normalized;
-}
-
-export function buildBrandEnvAliases(prefix: string) {
-  const normalizedPrefix = normalizeEnvPrefix(prefix);
-  return ENV_ALIAS_SUFFIXES.map(
-    ([brandSuffix, elizaSuffix]) =>
-      [`${normalizedPrefix}_${brandSuffix}`, `ELIZA_${elizaSuffix}`] as const,
-  );
-}
-
-export const APP_ENV_PREFIX = normalizeEnvPrefix(
+export const APP_ENV_PREFIX = normalizeBrandEnvPrefix(
   APP_CONFIG.envPrefix ?? APP_CONFIG.cliName,
 );
 

--- a/packages/elizaos/templates/project/apps/app/src/type-stubs/shared/index.d.ts
+++ b/packages/elizaos/templates/project/apps/app/src/type-stubs/shared/index.d.ts
@@ -14,6 +14,10 @@ export interface DevSettingsRow {
   detail?: string;
 }
 
+export type BrandEnvAliasPair = readonly [brandKey: string, elizaKey: string];
+
+export function buildBrandEnvAliases(prefix: string): BrandEnvAliasPair[];
+export function normalizeBrandEnvPrefix(prefix: string | undefined): string;
 export function colorizeDevSettingsStartupBanner(text: string): string;
 export function formatDevSettingsTable(
   title: string,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -73,6 +73,16 @@
       "import": "./dist/config/allowed-hosts.js",
       "default": "./dist/config/allowed-hosts.js"
     },
+    "./config/brand-env-aliases": {
+      "types": "./dist/config/brand-env-aliases.d.ts",
+      "eliza-source": {
+        "types": "./src/config/brand-env-aliases.ts",
+        "import": "./src/config/brand-env-aliases.ts",
+        "default": "./src/config/brand-env-aliases.ts"
+      },
+      "import": "./dist/config/brand-env-aliases.js",
+      "default": "./dist/config/brand-env-aliases.js"
+    },
     "./dev-settings-banner-style": {
       "types": "./dist/dev-settings-banner-style.d.ts",
       "import": "./dist/dev-settings-banner-style.js",

--- a/packages/shared/src/config/brand-env-aliases.ts
+++ b/packages/shared/src/config/brand-env-aliases.ts
@@ -1,0 +1,129 @@
+export type BrandEnvAliasPair = readonly [brandKey: string, elizaKey: string];
+
+interface BrandEnvAliasDefinition {
+  readonly brandSuffix: string;
+  readonly elizaKey: string;
+  readonly vite?: boolean;
+}
+
+export const BRAND_ENV_ALIAS_DEFINITIONS = [
+  // Identity, state, and app boot
+  { brandSuffix: "NAMESPACE", elizaKey: "ELIZA_NAMESPACE" },
+  { brandSuffix: "STATE_DIR", elizaKey: "ELIZA_STATE_DIR" },
+  { brandSuffix: "CONFIG_PATH", elizaKey: "ELIZA_CONFIG_PATH" },
+  { brandSuffix: "OAUTH_DIR", elizaKey: "ELIZA_OAUTH_DIR" },
+  { brandSuffix: "PLATFORM", elizaKey: "ELIZA_PLATFORM" },
+  { brandSuffix: "AGENT_ORCHESTRATOR", elizaKey: "ELIZA_AGENT_ORCHESTRATOR" },
+  { brandSuffix: "CLOUD_PROVISIONED", elizaKey: "ELIZA_CLOUD_PROVISIONED" },
+  {
+    brandSuffix: "CLOUD_MANAGED_AGENTS_API_SEGMENT",
+    elizaKey: "ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT",
+  },
+  {
+    brandSuffix: "CHAT_GENERATION_TIMEOUT_MS",
+    elizaKey: "ELIZA_CHAT_GENERATION_TIMEOUT_MS",
+  },
+  {
+    brandSuffix: "SKIP_LOCAL_PLUGIN_ROLES",
+    elizaKey: "ELIZA_SKIP_LOCAL_PLUGIN_ROLES",
+  },
+  { brandSuffix: "SETTINGS_DEBUG", elizaKey: "ELIZA_SETTINGS_DEBUG" },
+  {
+    brandSuffix: "SETTINGS_DEBUG",
+    elizaKey: "VITE_ELIZA_SETTINGS_DEBUG",
+    vite: true,
+  },
+  {
+    brandSuffix: "GOOGLE_OAUTH_DESKTOP_CLIENT_ID",
+    elizaKey: "ELIZA_GOOGLE_OAUTH_DESKTOP_CLIENT_ID",
+  },
+  {
+    brandSuffix: "APP_ROUTE_PLUGIN_MODULES",
+    elizaKey: "ELIZA_APP_ROUTE_PLUGIN_MODULES",
+  },
+  // API and auth
+  { brandSuffix: "API_TOKEN", elizaKey: "ELIZA_API_TOKEN" },
+  { brandSuffix: "API_BIND", elizaKey: "ELIZA_API_BIND" },
+  { brandSuffix: "API_EXPOSE_PORT", elizaKey: "ELIZA_API_EXPOSE_PORT" },
+  { brandSuffix: "PAIRING_DISABLED", elizaKey: "ELIZA_PAIRING_DISABLED" },
+  { brandSuffix: "ALLOWED_ORIGINS", elizaKey: "ELIZA_ALLOWED_ORIGINS" },
+  { brandSuffix: "ALLOWED_HOSTS", elizaKey: "ELIZA_ALLOWED_HOSTS" },
+  { brandSuffix: "ALLOW_NULL_ORIGIN", elizaKey: "ELIZA_ALLOW_NULL_ORIGIN" },
+  {
+    brandSuffix: "ALLOW_WS_QUERY_TOKEN",
+    elizaKey: "ELIZA_ALLOW_WS_QUERY_TOKEN",
+  },
+  {
+    brandSuffix: "DISABLE_AUTO_API_TOKEN",
+    elizaKey: "ELIZA_DISABLE_AUTO_API_TOKEN",
+  },
+  {
+    brandSuffix: "WALLET_EXPORT_TOKEN",
+    elizaKey: "ELIZA_WALLET_EXPORT_TOKEN",
+  },
+  {
+    brandSuffix: "TERMINAL_RUN_TOKEN",
+    elizaKey: "ELIZA_TERMINAL_RUN_TOKEN",
+  },
+  // API base and desktop shell routing
+  { brandSuffix: "API_BASE", elizaKey: "ELIZA_API_BASE" },
+  { brandSuffix: "API_BASE_URL", elizaKey: "ELIZA_API_BASE_URL" },
+  { brandSuffix: "DESKTOP_API_BASE", elizaKey: "ELIZA_DESKTOP_API_BASE" },
+  {
+    brandSuffix: "DESKTOP_TEST_API_BASE",
+    elizaKey: "ELIZA_DESKTOP_TEST_API_BASE",
+  },
+  {
+    brandSuffix: "DESKTOP_SKIP_EMBEDDED_AGENT",
+    elizaKey: "ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT",
+  },
+  { brandSuffix: "RENDERER_URL", elizaKey: "ELIZA_RENDERER_URL" },
+  // Cloud service toggles
+  { brandSuffix: "CLOUD_TTS_DISABLED", elizaKey: "ELIZA_CLOUD_TTS_DISABLED" },
+  {
+    brandSuffix: "CLOUD_MEDIA_DISABLED",
+    elizaKey: "ELIZA_CLOUD_MEDIA_DISABLED",
+  },
+  {
+    brandSuffix: "CLOUD_EMBEDDINGS_DISABLED",
+    elizaKey: "ELIZA_CLOUD_EMBEDDINGS_DISABLED",
+  },
+  { brandSuffix: "CLOUD_RPC_DISABLED", elizaKey: "ELIZA_CLOUD_RPC_DISABLED" },
+  {
+    brandSuffix: "DISABLE_LOCAL_EMBEDDINGS",
+    elizaKey: "ELIZA_DISABLE_LOCAL_EMBEDDINGS",
+  },
+  { brandSuffix: "DISABLE_EDGE_TTS", elizaKey: "ELIZA_DISABLE_EDGE_TTS" },
+  // Ports
+  { brandSuffix: "PORT", elizaKey: "ELIZA_PORT" },
+  { brandSuffix: "UI_PORT", elizaKey: "ELIZA_UI_PORT" },
+  { brandSuffix: "API_PORT", elizaKey: "ELIZA_API_PORT" },
+  { brandSuffix: "HOME_PORT", elizaKey: "ELIZA_HOME_PORT" },
+  { brandSuffix: "GATEWAY_PORT", elizaKey: "ELIZA_GATEWAY_PORT" },
+  { brandSuffix: "BRIDGE_PORT", elizaKey: "ELIZA_BRIDGE_PORT" },
+] as const satisfies readonly BrandEnvAliasDefinition[];
+
+export function normalizeBrandEnvPrefix(prefix: string | undefined): string {
+  const normalized = String(prefix ?? "ELIZA")
+    .trim()
+    .replace(/[^A-Za-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase();
+
+  if (!normalized) {
+    throw new Error("Brand env prefix must resolve to a non-empty identifier");
+  }
+
+  return normalized;
+}
+
+export function buildBrandEnvAliases(prefix: string): BrandEnvAliasPair[] {
+  const normalizedPrefix = normalizeBrandEnvPrefix(prefix);
+  return BRAND_ENV_ALIAS_DEFINITIONS.map((definition) => {
+    const brandKey =
+      "vite" in definition && definition.vite
+        ? `VITE_${normalizedPrefix}_${definition.brandSuffix}`
+        : `${normalizedPrefix}_${definition.brandSuffix}`;
+    return [brandKey, definition.elizaKey] as const;
+  });
+}

--- a/packages/shared/src/config/brand-env-aliases.ts
+++ b/packages/shared/src/config/brand-env-aliases.ts
@@ -3,6 +3,7 @@ export type BrandEnvAliasPair = readonly [brandKey: string, elizaKey: string];
 interface BrandEnvAliasDefinition {
   readonly brandSuffix: string;
   readonly elizaKey: string;
+  readonly syncElizaKey?: string;
   readonly vite?: boolean;
 }
 
@@ -95,7 +96,11 @@ export const BRAND_ENV_ALIAS_DEFINITIONS = [
   },
   { brandSuffix: "DISABLE_EDGE_TTS", elizaKey: "ELIZA_DISABLE_EDGE_TTS" },
   // Ports
-  { brandSuffix: "PORT", elizaKey: "ELIZA_PORT" },
+  {
+    brandSuffix: "PORT",
+    elizaKey: "ELIZA_PORT",
+    syncElizaKey: "ELIZA_UI_PORT",
+  },
   { brandSuffix: "UI_PORT", elizaKey: "ELIZA_UI_PORT" },
   { brandSuffix: "API_PORT", elizaKey: "ELIZA_API_PORT" },
   { brandSuffix: "HOME_PORT", elizaKey: "ELIZA_HOME_PORT" },
@@ -125,5 +130,16 @@ export function buildBrandEnvAliases(prefix: string): BrandEnvAliasPair[] {
         ? `VITE_${normalizedPrefix}_${definition.brandSuffix}`
         : `${normalizedPrefix}_${definition.brandSuffix}`;
     return [brandKey, definition.elizaKey] as const;
+  });
+}
+
+export function buildBrandEnvSyncAliases(prefix: string): BrandEnvAliasPair[] {
+  const normalizedPrefix = normalizeBrandEnvPrefix(prefix);
+  return BRAND_ENV_ALIAS_DEFINITIONS.map((definition) => {
+    const brandKey =
+      "vite" in definition && definition.vite
+        ? `VITE_${normalizedPrefix}_${definition.brandSuffix}`
+        : `${normalizedPrefix}_${definition.brandSuffix}`;
+    return [brandKey, definition.syncElizaKey ?? definition.elizaKey] as const;
   });
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -33,6 +33,7 @@ export * from "./config/boot-config.js";
 // from the package root because they pull in React at module load time.
 // This keeps node-side benchmark / agent boot paths React-free.
 export * from "./config/boot-config-store.js";
+export * from "./config/brand-env-aliases.js";
 export * from "./config/branding.js";
 export * from "./config/cloud-only.js";
 export * from "./config/config.js";

--- a/packages/shared/src/utils/env.test.ts
+++ b/packages/shared/src/utils/env.test.ts
@@ -5,7 +5,10 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBootConfig, setBootConfig } from "../config/boot-config.js";
-import { buildBrandEnvAliases } from "../config/brand-env-aliases.js";
+import {
+  buildBrandEnvAliases,
+  buildBrandEnvSyncAliases,
+} from "../config/brand-env-aliases.js";
 import {
   DEFAULT_APP_ROUTE_PLUGIN_MODULES,
   isEnvDisabled,
@@ -228,8 +231,8 @@ describe("syncElizaEnvAliases", () => {
     }
   });
 
-  it("materializes every canonical brand alias target from the shared table", () => {
-    const aliases = buildBrandEnvAliases("BRAND");
+  it("materializes every sync brand alias target from the shared table", () => {
+    const aliases = buildBrandEnvSyncAliases("BRAND");
     const defaultedKeys = [
       "ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT",
       "ELIZA_APP_ROUTE_PLUGIN_MODULES",
@@ -252,6 +255,38 @@ describe("syncElizaEnvAliases", () => {
       for (const [from, to] of aliases) {
         expect(process.env[to]).toBe(`${from}-value`);
       }
+    } finally {
+      for (const [key, value] of previous) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+  });
+
+  it("keeps legacy BRAND_PORT sync pointed at the UI port", () => {
+    const runtimeAliases = new Map(buildBrandEnvAliases("BRAND"));
+    const syncAliases = new Map(buildBrandEnvSyncAliases("BRAND"));
+    expect(runtimeAliases.get("BRAND_PORT")).toBe("ELIZA_PORT");
+    expect(syncAliases.get("BRAND_PORT")).toBe("ELIZA_UI_PORT");
+
+    const keys = ["BRAND_PORT", "ELIZA_PORT", "ELIZA_UI_PORT"];
+    const previous = new Map(
+      keys.map((key) => [key, process.env[key]] as const),
+    );
+
+    try {
+      for (const key of keys) {
+        delete process.env[key];
+      }
+      process.env.BRAND_PORT = "4100";
+
+      syncElizaEnvAliases({ brandedPrefix: "BRAND" });
+
+      expect(process.env.ELIZA_UI_PORT).toBe("4100");
+      expect(process.env.ELIZA_PORT).toBeUndefined();
     } finally {
       for (const [key, value] of previous) {
         if (value === undefined) {

--- a/packages/shared/src/utils/env.test.ts
+++ b/packages/shared/src/utils/env.test.ts
@@ -5,6 +5,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBootConfig, setBootConfig } from "../config/boot-config.js";
+import { buildBrandEnvAliases } from "../config/brand-env-aliases.js";
 import {
   DEFAULT_APP_ROUTE_PLUGIN_MODULES,
   isEnvDisabled,
@@ -53,6 +54,12 @@ describe("readAliasedEnv (non-ELIZA brand, zero-mutation resolution)", () => {
     [`${BRAND}_HOME_PORT`, "ELIZA_HOME_PORT"],
     [`${BRAND}_GATEWAY_PORT`, "ELIZA_GATEWAY_PORT"],
     [`${BRAND}_ALLOWED_ORIGINS`, "ELIZA_ALLOWED_ORIGINS"],
+    [`${BRAND}_ALLOWED_HOSTS`, "ELIZA_ALLOWED_HOSTS"],
+    [`${BRAND}_DISABLE_AUTO_API_TOKEN`, "ELIZA_DISABLE_AUTO_API_TOKEN"],
+    [`${BRAND}_ALLOW_WS_QUERY_TOKEN`, "ELIZA_ALLOW_WS_QUERY_TOKEN"],
+    [`${BRAND}_PAIRING_DISABLED`, "ELIZA_PAIRING_DISABLED"],
+    [`${BRAND}_WALLET_EXPORT_TOKEN`, "ELIZA_WALLET_EXPORT_TOKEN"],
+    [`${BRAND}_TERMINAL_RUN_TOKEN`, "ELIZA_TERMINAL_RUN_TOKEN"],
   ];
   const tracked = pairs.flat();
   const savedEnv: Record<string, string | undefined> = {};
@@ -92,6 +99,22 @@ describe("readAliasedEnv (non-ELIZA brand, zero-mutation resolution)", () => {
     expect(readAliasedEnv("ELIZA_ALLOWED_ORIGINS")).toBe(
       "https://acme.example",
     );
+  });
+
+  it("resolves previously-divergent security aliases from branded keys", () => {
+    process.env[`${BRAND}_ALLOWED_HOSTS`] = "acme.example";
+    process.env[`${BRAND}_DISABLE_AUTO_API_TOKEN`] = "1";
+    process.env[`${BRAND}_ALLOW_WS_QUERY_TOKEN`] = "1";
+    process.env[`${BRAND}_PAIRING_DISABLED`] = "1";
+    process.env[`${BRAND}_WALLET_EXPORT_TOKEN`] = "wallet-token";
+    process.env[`${BRAND}_TERMINAL_RUN_TOKEN`] = "terminal-token";
+
+    expect(readAliasedEnv("ELIZA_ALLOWED_HOSTS")).toBe("acme.example");
+    expect(readAliasedEnv("ELIZA_DISABLE_AUTO_API_TOKEN")).toBe("1");
+    expect(readAliasedEnv("ELIZA_ALLOW_WS_QUERY_TOKEN")).toBe("1");
+    expect(readAliasedEnv("ELIZA_PAIRING_DISABLED")).toBe("1");
+    expect(readAliasedEnv("ELIZA_WALLET_EXPORT_TOKEN")).toBe("wallet-token");
+    expect(readAliasedEnv("ELIZA_TERMINAL_RUN_TOKEN")).toBe("terminal-token");
   });
 
   it("performs zero alias writes to process.env while resolving", () => {
@@ -194,6 +217,41 @@ describe("syncElizaEnvAliases", () => {
       expect(process.env.ELIZA_APP_ROUTE_PLUGIN_MODULES).toBe(
         DEFAULT_APP_ROUTE_PLUGIN_MODULES.join(","),
       );
+    } finally {
+      for (const [key, value] of previous) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+  });
+
+  it("materializes every canonical brand alias target from the shared table", () => {
+    const aliases = buildBrandEnvAliases("BRAND");
+    const defaultedKeys = [
+      "ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT",
+      "ELIZA_APP_ROUTE_PLUGIN_MODULES",
+    ];
+    const tracked = Array.from(new Set([...aliases.flat(), ...defaultedKeys]));
+    const previous = new Map(
+      tracked.map((key) => [key, process.env[key]] as const),
+    );
+
+    try {
+      for (const key of tracked) {
+        delete process.env[key];
+      }
+      for (const [from] of aliases) {
+        process.env[from] = `${from}-value`;
+      }
+
+      syncElizaEnvAliases({ brandedPrefix: "BRAND" });
+
+      for (const [from, to] of aliases) {
+        expect(process.env[to]).toBe(`${from}-value`);
+      }
     } finally {
       for (const [key, value] of previous) {
         if (value === undefined) {

--- a/packages/shared/src/utils/env.ts
+++ b/packages/shared/src/utils/env.ts
@@ -48,6 +48,10 @@ import {
   syncBrandEnvToEliza,
   syncElizaEnvToBrand,
 } from "../config/boot-config.js";
+import {
+  buildBrandEnvAliases,
+  normalizeBrandEnvPrefix,
+} from "../config/brand-env-aliases.js";
 
 const DEFAULT_BRANDED_PREFIX = "ELIZA";
 export const DEFAULT_APP_ROUTE_PLUGIN_MODULES = [
@@ -65,65 +69,10 @@ export interface SyncElizaEnvAliasOptions {
   appRoutePluginModules?: readonly string[];
 }
 
-function normalizeBrandedPrefix(prefix: string | undefined): string {
-  const normalized = String(prefix ?? DEFAULT_BRANDED_PREFIX)
-    .trim()
-    .replace(/[^A-Za-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "")
-    .toUpperCase();
-
-  if (!normalized) {
-    throw new Error(
-      "Branded env prefix must resolve to a non-empty identifier",
-    );
-  }
-
-  return normalized;
-}
-
 function buildEnvPairs(
   brandedPrefix: string,
 ): Array<readonly [string, string]> {
-  const prefixed = (suffix: string) => `${brandedPrefix}_${suffix}`;
-  return [
-    [prefixed("NAMESPACE"), "ELIZA_NAMESPACE"],
-    [prefixed("STATE_DIR"), "ELIZA_STATE_DIR"],
-    [prefixed("CONFIG_PATH"), "ELIZA_CONFIG_PATH"],
-    [prefixed("OAUTH_DIR"), "ELIZA_OAUTH_DIR"],
-    [prefixed("AGENT_ORCHESTRATOR"), "ELIZA_AGENT_ORCHESTRATOR"],
-    [prefixed("CLOUD_PROVISIONED"), "ELIZA_CLOUD_PROVISIONED"],
-    [
-      prefixed("CHAT_GENERATION_TIMEOUT_MS"),
-      "ELIZA_CHAT_GENERATION_TIMEOUT_MS",
-    ],
-    [prefixed("SKIP_LOCAL_PLUGIN_ROLES"), "ELIZA_SKIP_LOCAL_PLUGIN_ROLES"],
-    [prefixed("SETTINGS_DEBUG"), "ELIZA_SETTINGS_DEBUG"],
-    [`VITE_${prefixed("SETTINGS_DEBUG")}`, "VITE_ELIZA_SETTINGS_DEBUG"],
-    [
-      prefixed("GOOGLE_OAUTH_DESKTOP_CLIENT_ID"),
-      "ELIZA_GOOGLE_OAUTH_DESKTOP_CLIENT_ID",
-    ],
-    [prefixed("API_PORT"), "ELIZA_API_PORT"],
-    [prefixed("API_BIND"), "ELIZA_API_BIND"],
-    [prefixed("API_TOKEN"), "ELIZA_API_TOKEN"],
-    [prefixed("ALLOWED_ORIGINS"), "ELIZA_ALLOWED_ORIGINS"],
-    [prefixed("ALLOWED_HOSTS"), "ELIZA_ALLOWED_HOSTS"],
-    [prefixed("ALLOW_NULL_ORIGIN"), "ELIZA_ALLOW_NULL_ORIGIN"],
-    [prefixed("DISABLE_AUTO_API_TOKEN"), "ELIZA_DISABLE_AUTO_API_TOKEN"],
-    [prefixed("HOME_PORT"), "ELIZA_HOME_PORT"],
-    [prefixed("GATEWAY_PORT"), "ELIZA_GATEWAY_PORT"],
-    [prefixed("API_BASE"), "ELIZA_API_BASE"],
-    [prefixed("API_BASE_URL"), "ELIZA_API_BASE_URL"],
-    [prefixed("DESKTOP_API_BASE"), "ELIZA_DESKTOP_API_BASE"],
-    [prefixed("DESKTOP_TEST_API_BASE"), "ELIZA_DESKTOP_TEST_API_BASE"],
-    [
-      prefixed("DESKTOP_SKIP_EMBEDDED_AGENT"),
-      "ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT",
-    ],
-    [prefixed("RENDERER_URL"), "ELIZA_RENDERER_URL"],
-    [prefixed("APP_ROUTE_PLUGIN_MODULES"), "ELIZA_APP_ROUTE_PLUGIN_MODULES"],
-    [prefixed("PORT"), "ELIZA_UI_PORT"],
-  ];
+  return buildBrandEnvAliases(brandedPrefix);
 }
 
 /**
@@ -155,7 +104,9 @@ export function syncElizaEnvAliases(options?: SyncElizaEnvAliasOptions): void {
     ).process?.env;
     if (!env) return;
 
-    const brandedPrefix = normalizeBrandedPrefix(options.brandedPrefix);
+    const brandedPrefix = normalizeBrandEnvPrefix(
+      options.brandedPrefix ?? DEFAULT_BRANDED_PREFIX,
+    );
     for (const [from, to] of buildEnvPairs(brandedPrefix)) {
       if (env[to] === undefined && env[from] !== undefined) {
         env[to] = env[from];

--- a/packages/shared/src/utils/env.ts
+++ b/packages/shared/src/utils/env.ts
@@ -49,7 +49,7 @@ import {
   syncElizaEnvToBrand,
 } from "../config/boot-config.js";
 import {
-  buildBrandEnvAliases,
+  buildBrandEnvSyncAliases,
   normalizeBrandEnvPrefix,
 } from "../config/brand-env-aliases.js";
 
@@ -72,7 +72,7 @@ export interface SyncElizaEnvAliasOptions {
 function buildEnvPairs(
   brandedPrefix: string,
 ): Array<readonly [string, string]> {
-  return buildBrandEnvAliases(brandedPrefix);
+  return buildBrandEnvSyncAliases(brandedPrefix);
 }
 
 /**


### PR DESCRIPTION
## Summary

- move the brand env alias definitions into one shared canonical table
- derive both app BootConfig aliases and shared sync-mutation aliases from that table
- add guards for the former runtime-only and sync-only aliases, including security-sensitive keys

Fixes #13528

## Verification

- `bunx @biomejs/biome check packages/shared/src/config/brand-env-aliases.ts packages/shared/src/utils/env.ts packages/shared/src/utils/env.test.ts packages/app/src/brand-env.ts packages/app/src/brand-env.test.ts packages/shared/src/index.ts packages/shared/package.json --no-errors-on-unmatched`
- `bun run --cwd packages/app test src/brand-env.test.ts`
- `bun run --cwd packages/shared test src/utils/env.test.ts`
- `bun run --cwd packages/shared typecheck`
- `bun run --cwd packages/app typecheck`

Note: package typechecks needed the repo keyword generator first because this isolated worktree did not have ignored `packages/*/src/i18n/generated/validation-keyword-data.*` files present. Ran `node packages/shared/scripts/generate-keywords.mjs --target ts`; generated files are ignored and not part of this PR.
