### PR TITLE
fix(cloud): my-agents characters search 500 on non-string bio entries — console page-load non-stub 500 sweep (#13406)

### DIFF
--- a/packages/cloud/api/__tests__/my-agents-characters-search-bio-guard.test.ts
+++ b/packages/cloud/api/__tests__/my-agents-characters-search-bio-guard.test.ts
@@ -1,0 +1,179 @@
+/**
+ * GET /api/my-agents/characters?search= must not 500 when a stored
+ * character's bio jsonb array contains non-string entries (#13406).
+ *
+ * The POST handler in the same route file stores the request body verbatim
+ * (no bio validation), so `bio: ["text", null, {…}]` is a state the API
+ * itself can produce. The search filter then ran `b.toLowerCase()` on every
+ * bio entry of every character, so ONE malformed row turned every console
+ * search on the my-agents page into a 500. Real route module + real
+ * repositories against in-process PGlite; the only mocked seam is
+ * `requireUserOrApiKeyWithOrg` (same pattern as org-credentials-routes).
+ */
+
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { Hono } from "hono";
+import * as realAuth from "@/lib/auth/workers-hono-auth";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const ORG = "11111111-1111-4111-8111-111111111111";
+const USER = "aaaaaaaa-1111-4111-8111-111111111111";
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...realAuth,
+  requireUserOrApiKeyWithOrg: mock(async () => ({
+    id: USER,
+    email: "owner@test.test",
+    organization_id: ORG,
+    organization: { id: ORG, name: "Org", is_active: true },
+    is_active: true,
+    role: "owner",
+  })),
+}));
+
+const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+
+let pgliteReady = true;
+let closeDb: (() => Promise<void>) | undefined;
+let app: Hono<AppEnv>;
+
+beforeAll(async () => {
+  try {
+    const { closeDatabaseConnectionsForTests, dbWrite } = await import(
+      "@/db/client"
+    );
+    closeDb = closeDatabaseConnectionsForTests;
+
+    const { organizations } = await import("@/db/schemas/organizations");
+    const { users } = await import("@/db/schemas/users");
+    const { userCharacters } = await import("@/db/schemas/user-characters");
+    const { elizaRoomCharactersTable } = await import(
+      "@/db/schemas/eliza-room-characters"
+    );
+    const { agentTable } = await import("@/db/schemas/eliza");
+    const { pushSchema } = await import("@/db/push-schema-for-tests");
+    const { apply } = await pushSchema(
+      {
+        organizations,
+        users,
+        userCharacters,
+        elizaRoomCharactersTable,
+        agentTable,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+
+    await dbWrite
+      .insert(organizations)
+      .values([{ id: ORG, name: "Org", slug: "org" }]);
+    await dbWrite.insert(users).values([
+      {
+        id: USER,
+        email: "owner@test.test",
+        organization_id: ORG,
+        role: "owner",
+        steward_user_id: `steward-${USER}`,
+      },
+    ]);
+
+    const route = (await import("../my-agents/characters/route")).default;
+    app = new Hono<AppEnv>();
+    app.route("/api/my-agents/characters", route);
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[my-agents-characters-search-bio-guard.test] setup failed — failing.",
+      error,
+    );
+  }
+}, 120_000);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+  mock.restore();
+});
+
+async function createCharacter(
+  body: Record<string, unknown>,
+): Promise<Response> {
+  return app.request(
+    "/api/my-agents/characters",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    ENV,
+  );
+}
+
+describe("GET /api/my-agents/characters?search= — non-string bio entries", () => {
+  test("POST accepts a bio array containing non-string entries (the state the bug needs)", async () => {
+    expect(pgliteReady).toBe(true);
+
+    const good = await createCharacter({
+      name: "Alpha Helper",
+      bio: ["Alpha is a friendly research assistant"],
+    });
+    expect(good.status).toBe(200);
+
+    // The front door itself stores this verbatim — no bio validation.
+    const malformed = await createCharacter({
+      name: "Bravo Bot",
+      bio: ["greets users", null, { note: "structured entry" }],
+    });
+    expect(malformed.status).toBe(200);
+  });
+
+  test("search returns 200 and still matches string bios (was: 500 TypeError on the null entry)", async () => {
+    expect(pgliteReady).toBe(true);
+
+    const res = await app.request(
+      "/api/my-agents/characters?search=alpha",
+      {},
+      ENV,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: { characters: Array<{ name: string }> };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.characters.map((c) => c.name)).toEqual(["Alpha Helper"]);
+  });
+
+  test("search matching a string entry of the malformed bio still finds it", async () => {
+    expect(pgliteReady).toBe(true);
+
+    const res = await app.request(
+      "/api/my-agents/characters?search=greets",
+      {},
+      ENV,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: { characters: Array<{ name: string }> };
+    };
+    expect(body.data.characters.map((c) => c.name)).toEqual(["Bravo Bot"]);
+  });
+
+  test("normal empty-search page load returns both characters", async () => {
+    expect(pgliteReady).toBe(true);
+
+    const res = await app.request("/api/my-agents/characters", {}, ENV);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: { characters: Array<{ name: string }> };
+    };
+    expect(body.data.characters).toHaveLength(2);
+  });
+});

--- a/packages/cloud/api/my-agents/characters/route.ts
+++ b/packages/cloud/api/my-agents/characters/route.ts
@@ -53,8 +53,14 @@ app.get("/", async (c) => {
           char.name.toLowerCase().includes(query) ||
           (typeof char.bio === "string" &&
             char.bio.toLowerCase().includes(query)) ||
+          // bio is caller-supplied jsonb (the POST below stores the body
+          // verbatim), so array entries are not guaranteed to be strings —
+          // one non-string entry must not 500 every search for the user.
+          // Non-string entries simply can't match a text query.
           (Array.isArray(char.bio) &&
-            char.bio.some((b) => b.toLowerCase().includes(query))),
+            char.bio.some(
+              (b) => typeof b === "string" && b.toLowerCase().includes(query),
+            )),
       );
     }
     if (category) {


### PR DESCRIPTION
Part of the #13406 console page-load 500 burn-down — the NON-stub-schema class (stub drift is closed + mirror-guarded by #13557; not re-audited here).

## What

Statically swept all 10 console page-load route handlers under `packages/cloud/api/` (my-agents/{characters,saved}, organizations/{credentials,members,invites}, v1/api-keys{,/explorer}, v1/apps GET, v1/affiliates, v1/advertising/accounts) plus every cloud-shared service/repo they call, hunting unguarded throws mapped to 500 on the normal/empty signed-in load.

**1 real bug found + fixed:** `GET /api/my-agents/characters?search=` ran `b.toLowerCase()` on every entry of every character's `bio` jsonb array. `bio` is stored verbatim from the unvalidated POST body in the same route file, so a character created with `bio: ["greets users", null, {…}]` (accepted today — proven in the test through the real POST) made **every** search on the console my-agents page throw a TypeError that `failureResponse` maps to a 500. Fix: the search filter matches only string entries — a non-string entry can never match a text query, so this is designed behavior, not error-swallowing; real DB failures still surface as typed failures through the existing J1 route boundary.

**9 routes verified clean** on the empty/no-org/first-login case: all list repos return `[]`, every rendered `.toISOString()` target is a `NOT NULL` timestamp column, the explorer key mint lazily provisions the org DEK (`kms.getOrCreateKey`), invites' left-joined inviter is null-guarded, affiliates returns `{ code: null }`, and `requireUser*WithOrg` throws typed 401/403 (never an unexpected throw) for no-org users.

## Test (RED → GREEN, mutation-checked)

`packages/cloud/api/__tests__/my-agents-characters-search-bio-guard.test.ts` — real route module + real repositories on in-process PGlite (schema via `pushSchema`; the only mocked seam is `requireUserOrApiKeyWithOrg`, same pattern as `org-credentials-routes.test.ts`). Seeds the malformed bio through the real POST front door, then asserts search returns 200 with correct matches and the normal empty load returns 200.

- With guard reverted: **3 pass / 1 fail** — exactly the search-200 assertion fails (route returns 500).
- With fix: **4 pass / 0 fail**.
- `bun run --cwd packages/cloud/api typecheck` ✅ · `lint` ✅ · biome clean ✅

[cloud-agent]

---
**Authored by a Fable-5 agent** (pure — 100% claude-fable-5), committed+pushed. Main-loop re-verification: pure ✓; clean 2-file diff; the `typeof b === "string"` guard is correct; cloud-api typecheck 0 errors; agent's RED→GREEN mutation-check on real PGlite (revert guard → search 500 returns / 3-pass-1-fail; fix → 4-pass-0-fail). 9 other console routes statically verified clean (empty/no-org/first-login all 2xx). Completes the console page-load 500 burn-down alongside the stub-drift guard (#13557). — [cloud-agent]