### PR TITLE
fix(app): harden iOS simulator hygiene and renderer freshness (#13570, #13575)

### DIFF
--- a/.github/issue-evidence/13570-13575-ios-sim-hygiene-stamp.md
+++ b/.github/issue-evidence/13570-13575-ios-sim-hygiene-stamp.md
@@ -1,0 +1,19 @@
+# #13570 / #13575 - iOS simulator lane hygiene and renderer freshness
+
+## Change
+
+- Added shared iOS simulator defaults hygiene for smoke/auth/runtime keys. It enumerates the simulator defaults domain, deletes both `CapacitorStorage.*` and raw key variants, and flushes `cfprefsd`.
+- Added shared renderer stamp verification for iOS `.app` bundles and installed simulator containers. Candidate apps now must match the expected bundle id and the freshly built `dist/eliza-renderer-build.json` before install.
+- Wired the helpers into `ios-onboarding-smoke.mjs`, `mobile-local-chat-smoke.mjs`, and `ios-e2e.mjs`, including cleanup in failure paths.
+- Added host-side tests for defaults key selection and renderer build-id comparison.
+
+## Verification
+
+- `node --check` on the two new helpers and all three touched scripts passed.
+- Pure helper runtime check passed: stale renderer build IDs throw, matching IDs pass, stale smoke keys are selected.
+
+## Evidence notes
+
+- Screenshots/video: N/A - harness integrity change, no rendered UI changed.
+- Live model trajectory: N/A - no prompt/model behavior changed.
+- Native capture: required for the broader iOS evidence umbrella; this PR specifically makes stale simulator state and stale app installs fail before captures can be trusted.

--- a/packages/app/scripts/ios-e2e.mjs
+++ b/packages/app/scripts/ios-e2e.mjs
@@ -13,8 +13,10 @@
 // Flags: --device <name|udid>  --skip-build  --skip-local-chat  --skip-auth
 //        --cloud
 import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { clearIosSmokeDefaults } from "./lib/ios-sim-defaults-hygiene.mjs";
 
 const appDir = path.resolve(fileURLToPath(import.meta.url), "..", "..");
 const has = (f) => process.argv.includes(f);
@@ -23,6 +25,12 @@ const val = (f, fb) => {
   return i >= 0 ? process.argv[i + 1] : fb;
 };
 const log = (m) => console.log(`[ios-e2e] ${m}`);
+
+function readAppId() {
+  const configPath = path.join(appDir, "app.config.ts");
+  const src = fs.readFileSync(configPath, "utf8");
+  return src.match(/appId:\s*["']([^"']+)["']/)?.[1] ?? "ai.elizaos.app";
+}
 
 function run(cmd, args, env = {}) {
   const res = spawnSync(cmd, args, {
@@ -77,47 +85,51 @@ function ensureSimulatorBooted(deviceName) {
 }
 
 async function main() {
+  const appId = readAppId();
   const udid = ensureSimulatorBooted(val("--device"));
   log(`simulator udid=${udid}`);
+  clearIosSmokeDefaults({ udid, bundleId: appId, log });
+  try {
+    if (has("--skip-build")) {
+      log("skipping build (--skip-build)");
+    } else {
+      log("building + installing the iOS Simulator app…");
+      run("bun", ["run", "build:ios:local:sim"]);
+    }
 
-  if (has("--skip-build")) {
-    log("skipping build (--skip-build)");
-  } else {
-    log("building + installing the iOS Simulator app…");
-    run("bun", ["run", "build:ios:local:sim"]);
+    if (!has("--skip-auth")) {
+      log("auth route: deep-link / callback registration + drive…");
+      run("node", [
+        "../../packages/app-core/scripts/mobile-auth-simulator-smoke.mjs",
+        "--platform",
+        "ios",
+        "--device",
+        udid,
+      ]);
+    }
+
+    if (!has("--skip-local-chat")) {
+      log("local route: on-device agent + smallest model + real chat…");
+      run("node", [
+        "scripts/mobile-local-chat-smoke.mjs",
+        "--platform",
+        "ios",
+        "--require-installed",
+        "--ios-select-local",
+        "--ios-full-bun-smoke",
+      ]);
+    }
+
+    if (has("--cloud")) {
+      log("cloud route: real provisioning probe…");
+      run("node", ["scripts/cloud-provisioning-e2e.mjs"]);
+    }
+
+    log("ALL iOS E2E PASSED ✅");
+  } finally {
+    clearIosSmokeDefaults({ udid, bundleId: appId, log });
   }
-
-  if (!has("--skip-auth")) {
-    log("auth route: deep-link / callback registration + drive…");
-    run("node", [
-      "../../packages/app-core/scripts/mobile-auth-simulator-smoke.mjs",
-      "--platform",
-      "ios",
-      "--device",
-      udid,
-    ]);
-  }
-
-  if (!has("--skip-local-chat")) {
-    log("local route: on-device agent + smallest model + real chat…");
-    run("node", [
-      "scripts/mobile-local-chat-smoke.mjs",
-      "--platform",
-      "ios",
-      "--require-installed",
-      "--ios-select-local",
-      "--ios-full-bun-smoke",
-    ]);
-  }
-
-  if (has("--cloud")) {
-    log("cloud route: real provisioning probe…");
-    run("node", ["scripts/cloud-provisioning-e2e.mjs"]);
-  }
-
-  log("ALL iOS E2E PASSED ✅");
 }
-
 main().catch((error) => {
   console.error(`[ios-e2e] FAILED: ${error?.message ?? error}`);
   process.exit(1);

--- a/packages/app/scripts/ios-onboarding-smoke.mjs
+++ b/packages/app/scripts/ios-onboarding-smoke.mjs
@@ -14,6 +14,11 @@ import {
   captureIosSimulatorScreenshot,
   startIosSimulatorVideo,
 } from "./lib/ios-simulator-capture.mjs";
+import { clearIosSmokeDefaults } from "./lib/ios-sim-defaults-hygiene.mjs";
+import {
+  assertCandidateIosAppRendererFresh,
+  assertInstalledIosAppRendererFresh,
+} from "./lib/ios-renderer-stamp.mjs";
 
 const appDir = path.resolve(fileURLToPath(import.meta.url), "..", "..");
 const repoRoot = path.resolve(appDir, "..", "..");
@@ -175,13 +180,27 @@ function latestBuiltApp() {
 }
 
 function installLatestApp(udid, appId) {
-  if (has("--skip-install")) return;
+  if (has("--skip-install")) {
+    assertInstalledIosAppRendererFresh({
+      udid,
+      bundleId: appId,
+      repoRoot,
+      log,
+    });
+    return;
+  }
   const appPath = val("--app-path") ?? latestBuiltApp();
   if (!appPath) {
     throw new Error(
       "Could not find a Debug-iphonesimulator App.app. Build the iOS simulator app first or pass --app-path.",
     );
   }
+  assertCandidateIosAppRendererFresh({
+    appPath,
+    bundleId: appId,
+    repoRoot,
+    log,
+  });
   tryRun("xcrun", ["simctl", "terminate", udid, appId]);
   tryRun("xcrun", ["simctl", "uninstall", udid, appId]);
   log(`installing ${appPath}`);
@@ -196,6 +215,12 @@ function installLatestApp(udid, appId) {
   if (!installed) {
     throw new Error(`${appId} was not installed after simctl install.`);
   }
+  assertInstalledIosAppRendererFresh({
+    udid,
+    bundleId: appId,
+    repoRoot,
+    log,
+  });
 }
 
 function prefsDomainPath(udid, appId) {
@@ -485,11 +510,20 @@ async function main() {
   removePathRecursive(resultDir);
   fs.mkdirSync(resultDir, { recursive: true });
 
-  deleteSimulatorPreferenceDomainKeys(udid, appId, FIRST_RUN_STATE_KEYS);
-  flushPreferences(udid);
+  clearIosSmokeDefaults({
+    udid,
+    bundleId: appId,
+    extraKeys: FIRST_RUN_STATE_KEYS,
+    log,
+  });
   installLatestApp(udid, appId);
   tryRun("xcrun", ["simctl", "terminate", udid, appId]);
-  clearFirstRunState(udid, appId);
+  clearIosSmokeDefaults({
+    udid,
+    bundleId: appId,
+    extraKeys: FIRST_RUN_STATE_KEYS,
+    log,
+  });
   defaultsWriteString(udid, appId, REQUEST_KEY, JSON.stringify({ apiBase }));
   defaultsWriteString(
     udid,
@@ -628,6 +662,12 @@ async function main() {
         `iOS relaunch smoke did not prove onboarding was hidden: ${JSON.stringify(relaunchResult)}`,
       );
     }
+    clearIosSmokeDefaults({
+      udid,
+      bundleId: appId,
+      extraKeys: FIRST_RUN_STATE_KEYS,
+      log,
+    });
     fs.writeFileSync(
       path.join(resultDir, "result.json"),
       `${JSON.stringify(
@@ -649,6 +689,12 @@ async function main() {
   } catch (error) {
     const screenshot = takeScreenshot(udid, "failure");
     await stopVideo(recording);
+    clearIosSmokeDefaults({
+      udid,
+      bundleId: appId,
+      extraKeys: FIRST_RUN_STATE_KEYS,
+      log,
+    });
     throw new Error(
       `${error instanceof Error ? error.message : String(error)}${screenshot ? ` (screenshot: ${screenshot})` : ""}`,
     );

--- a/packages/app/scripts/ios-onboarding-smoke.mjs
+++ b/packages/app/scripts/ios-onboarding-smoke.mjs
@@ -11,14 +11,14 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  captureIosSimulatorScreenshot,
-  startIosSimulatorVideo,
-} from "./lib/ios-simulator-capture.mjs";
-import { clearIosSmokeDefaults } from "./lib/ios-sim-defaults-hygiene.mjs";
-import {
   assertCandidateIosAppRendererFresh,
   assertInstalledIosAppRendererFresh,
 } from "./lib/ios-renderer-stamp.mjs";
+import { clearIosSmokeDefaults } from "./lib/ios-sim-defaults-hygiene.mjs";
+import {
+  captureIosSimulatorScreenshot,
+  startIosSimulatorVideo,
+} from "./lib/ios-simulator-capture.mjs";
 
 const appDir = path.resolve(fileURLToPath(import.meta.url), "..", "..");
 const repoRoot = path.resolve(appDir, "..", "..");
@@ -239,44 +239,6 @@ function preferenceNativeKeys(key) {
   return [`CapacitorStorage.${key}`, key];
 }
 
-function defaultsDelete(udid, appId, key) {
-  const nativeKeys = preferenceNativeKeys(key);
-  for (const nativeKey of nativeKeys) {
-    tryRun("xcrun", [
-      "simctl",
-      "spawn",
-      udid,
-      "defaults",
-      "delete",
-      appId,
-      nativeKey,
-    ]);
-  }
-
-  const domainPath = prefsDomainPath(udid, appId);
-  if (domainPath) {
-    for (const nativeKey of nativeKeys) {
-      tryRun("defaults", ["delete", domainPath, nativeKey]);
-    }
-  }
-}
-
-function deleteSimulatorPreferenceDomainKeys(udid, appId, keys) {
-  for (const key of keys) {
-    for (const nativeKey of preferenceNativeKeys(key)) {
-      tryRun("xcrun", [
-        "simctl",
-        "spawn",
-        udid,
-        "defaults",
-        "delete",
-        appId,
-        nativeKey,
-      ]);
-    }
-  }
-}
-
 function defaultsWriteString(udid, appId, key, value) {
   const nativeKeys = preferenceNativeKeys(key);
   // Write through the simulator defaults domain. Host-path `defaults write`
@@ -362,12 +324,6 @@ const FIRST_RUN_STATE_KEYS = [
   "eliza.background.config",
   "elizaos:first-run:force-fresh",
 ];
-
-function clearFirstRunState(udid, appId) {
-  for (const key of FIRST_RUN_STATE_KEYS) {
-    defaultsDelete(udid, appId, key);
-  }
-}
 
 function takeScreenshot(udid, label) {
   try {

--- a/packages/app/scripts/lib/ios-renderer-stamp.mjs
+++ b/packages/app/scripts/lib/ios-renderer-stamp.mjs
@@ -23,7 +23,9 @@ export function rendererManifestPathFromAppPath(appPath) {
 
 export function freshRendererManifestPath({ repoRoot, rendererDist }) {
   return path.join(
-    rendererDist ? path.resolve(rendererDist) : path.join(repoRoot, "packages", "app", "dist"),
+    rendererDist
+      ? path.resolve(rendererDist)
+      : path.join(repoRoot, "packages", "app", "dist"),
     RENDERER_MANIFEST,
   );
 }
@@ -34,12 +36,18 @@ export function readRendererManifest(manifestPath, label) {
   }
   const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
   if (typeof parsed.buildId !== "string" || parsed.buildId.length === 0) {
-    throw new Error(`${label} renderer manifest has no buildId: ${manifestPath}`);
+    throw new Error(
+      `${label} renderer manifest has no buildId: ${manifestPath}`,
+    );
   }
   return parsed;
 }
 
-export function compareRendererBuildIds({ fresh, installed, label = "iOS app" }) {
+export function compareRendererBuildIds({
+  fresh,
+  installed,
+  label = "iOS app",
+}) {
   if (installed.buildId !== fresh.buildId) {
     throw new Error(
       `${label} renderer buildId ${installed.buildId} != freshly built ${fresh.buildId} - stale UI install.`,
@@ -56,9 +64,13 @@ export function readIosBundleIdFromAppPath(appPath) {
   if (!fs.existsSync(plist)) {
     throw new Error(`iOS app bundle is missing Info.plist: ${plist}`);
   }
-  const bundleId = execText("plutil", ["-extract", "CFBundleIdentifier", "raw", plist], {
-    optional: true,
-  });
+  const bundleId = execText(
+    "plutil",
+    ["-extract", "CFBundleIdentifier", "raw", plist],
+    {
+      optional: true,
+    },
+  );
   if (!bundleId) {
     throw new Error(`Could not read CFBundleIdentifier from ${plist}`);
   }
@@ -68,7 +80,9 @@ export function readIosBundleIdFromAppPath(appPath) {
 export function assertIosAppPathMatchesBundleId({ appPath, bundleId }) {
   const actual = readIosBundleIdFromAppPath(appPath);
   if (actual !== bundleId) {
-    throw new Error(`iOS app bundle id ${actual} did not match expected ${bundleId}: ${appPath}`);
+    throw new Error(
+      `iOS app bundle id ${actual} did not match expected ${bundleId}: ${appPath}`,
+    );
   }
   return actual;
 }
@@ -91,7 +105,12 @@ export function assertIosAppRendererFresh({
   return result;
 }
 
-export function assertCandidateIosAppRendererFresh({ appPath, bundleId, repoRoot, log }) {
+export function assertCandidateIosAppRendererFresh({
+  appPath,
+  bundleId,
+  repoRoot,
+  log,
+}) {
   assertIosAppPathMatchesBundleId({ appPath, bundleId });
   return assertIosAppRendererFresh({
     appPath,
@@ -113,7 +132,9 @@ export function assertInstalledIosAppRendererFresh({
     { optional: true },
   );
   if (!appPath) {
-    throw new Error(`Cannot verify renderer stamp: ${bundleId} is not installed in simulator ${udid}.`);
+    throw new Error(
+      `Cannot verify renderer stamp: ${bundleId} is not installed in simulator ${udid}.`,
+    );
   }
   return assertIosAppRendererFresh({
     appPath,

--- a/packages/app/scripts/lib/ios-renderer-stamp.mjs
+++ b/packages/app/scripts/lib/ios-renderer-stamp.mjs
@@ -1,0 +1,124 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const RENDERER_MANIFEST = "eliza-renderer-build.json";
+
+function execText(command, args, options = {}) {
+  try {
+    return execFileSync(command, args, {
+      cwd: options.cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    if (options.optional) return null;
+    throw error;
+  }
+}
+
+export function rendererManifestPathFromAppPath(appPath) {
+  return path.join(appPath, "public", RENDERER_MANIFEST);
+}
+
+export function freshRendererManifestPath({ repoRoot, rendererDist }) {
+  return path.join(
+    rendererDist ? path.resolve(rendererDist) : path.join(repoRoot, "packages", "app", "dist"),
+    RENDERER_MANIFEST,
+  );
+}
+
+export function readRendererManifest(manifestPath, label) {
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`${label} renderer manifest is missing: ${manifestPath}`);
+  }
+  const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (typeof parsed.buildId !== "string" || parsed.buildId.length === 0) {
+    throw new Error(`${label} renderer manifest has no buildId: ${manifestPath}`);
+  }
+  return parsed;
+}
+
+export function compareRendererBuildIds({ fresh, installed, label = "iOS app" }) {
+  if (installed.buildId !== fresh.buildId) {
+    throw new Error(
+      `${label} renderer buildId ${installed.buildId} != freshly built ${fresh.buildId} - stale UI install.`,
+    );
+  }
+  return {
+    buildId: fresh.buildId,
+    builtAt: fresh.builtAt ?? null,
+  };
+}
+
+export function readIosBundleIdFromAppPath(appPath) {
+  const plist = path.join(appPath, "Info.plist");
+  if (!fs.existsSync(plist)) {
+    throw new Error(`iOS app bundle is missing Info.plist: ${plist}`);
+  }
+  const bundleId = execText("plutil", ["-extract", "CFBundleIdentifier", "raw", plist], {
+    optional: true,
+  });
+  if (!bundleId) {
+    throw new Error(`Could not read CFBundleIdentifier from ${plist}`);
+  }
+  return bundleId;
+}
+
+export function assertIosAppPathMatchesBundleId({ appPath, bundleId }) {
+  const actual = readIosBundleIdFromAppPath(appPath);
+  if (actual !== bundleId) {
+    throw new Error(`iOS app bundle id ${actual} did not match expected ${bundleId}: ${appPath}`);
+  }
+  return actual;
+}
+
+export function assertIosAppRendererFresh({
+  appPath,
+  repoRoot,
+  rendererDist = process.env.ELIZA_SMOKE_RENDERER_DIST,
+  label = "iOS app",
+  log = () => {},
+}) {
+  const freshManifest = freshRendererManifestPath({ repoRoot, rendererDist });
+  const installedManifest = rendererManifestPathFromAppPath(appPath);
+  const fresh = readRendererManifest(freshManifest, "freshly built");
+  const installed = readRendererManifest(installedManifest, label);
+  const result = compareRendererBuildIds({ fresh, installed, label });
+  log(
+    `renderer build stamp OK for ${label}: ${String(result.buildId).slice(0, 12)}${result.builtAt ? ` built ${result.builtAt}` : ""}`,
+  );
+  return result;
+}
+
+export function assertCandidateIosAppRendererFresh({ appPath, bundleId, repoRoot, log }) {
+  assertIosAppPathMatchesBundleId({ appPath, bundleId });
+  return assertIosAppRendererFresh({
+    appPath,
+    repoRoot,
+    label: `candidate ${bundleId}`,
+    log,
+  });
+}
+
+export function assertInstalledIosAppRendererFresh({
+  udid,
+  bundleId,
+  repoRoot,
+  log,
+}) {
+  const appPath = execText(
+    "xcrun",
+    ["simctl", "get_app_container", udid, bundleId, "app"],
+    { optional: true },
+  );
+  if (!appPath) {
+    throw new Error(`Cannot verify renderer stamp: ${bundleId} is not installed in simulator ${udid}.`);
+  }
+  return assertIosAppRendererFresh({
+    appPath,
+    repoRoot,
+    label: `installed ${bundleId}`,
+    log,
+  });
+}

--- a/packages/app/scripts/lib/ios-sim-defaults-hygiene.mjs
+++ b/packages/app/scripts/lib/ios-sim-defaults-hygiene.mjs
@@ -157,16 +157,17 @@ export function clearIosSmokeDefaults({
   log = () => {},
 }) {
   const domainKeys = readIosDefaultsDomain({ udid, bundleId });
-  const selected = selectIosSmokePreferenceKeys(
-    [...domainKeys, ...extraKeys],
-    { includeAppState },
-  );
+  const selected = selectIosSmokePreferenceKeys([...domainKeys, ...extraKeys], {
+    includeAppState,
+  });
   for (const key of selected) {
     deleteIosDefaultsKey({ udid, bundleId, key });
   }
   flushIosPreferencesCache(udid);
   if (selected.length > 0) {
-    log(`cleared ${selected.length} iOS simulator smoke/default key(s): ${selected.join(", ")}`);
+    log(
+      `cleared ${selected.length} iOS simulator smoke/default key(s): ${selected.join(", ")}`,
+    );
   }
   return selected;
 }

--- a/packages/app/scripts/lib/ios-sim-defaults-hygiene.mjs
+++ b/packages/app/scripts/lib/ios-sim-defaults-hygiene.mjs
@@ -1,0 +1,172 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const EXACT_SMOKE_KEYS = new Set([
+  "elizaos:active-server",
+  "eliza:first-run-complete",
+  "eliza:setup:step",
+  "eliza:onboarding-complete",
+  "eliza:mobile-runtime-mode",
+  "eliza.background.config",
+  "elizaos:first-run:force-fresh",
+]);
+
+const SMOKE_KEY_PATTERNS = [
+  /^eliza:.*smoke(?::|$)/,
+  /^elizaos:.*smoke(?::|$)/,
+  /^eliza:auth-callback-smoke(?::|$)/,
+  /^eliza:ios-.*(?:smoke|harness)(?::|$)/,
+  /^eliza:ios-full-bun-(?:smoke|prewarm)(?::|$)/,
+  /^eliza:ios-background(?::|$)/,
+];
+
+function stripCapacitorPrefix(key) {
+  return key.startsWith("CapacitorStorage.")
+    ? key.slice("CapacitorStorage.".length)
+    : key;
+}
+
+export function preferenceNativeKeys(key) {
+  return [`CapacitorStorage.${key}`, key];
+}
+
+export function shouldClearIosSmokePreferenceKey(key, options = {}) {
+  const normalized = stripCapacitorPrefix(String(key));
+  if (EXACT_SMOKE_KEYS.has(normalized)) return true;
+  if (SMOKE_KEY_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return true;
+  }
+  if (options.includeAppState === true) {
+    return (
+      normalized.startsWith("eliza:first-run") ||
+      normalized.startsWith("eliza:onboarding") ||
+      normalized.startsWith("eliza:mobile-runtime") ||
+      normalized.startsWith("elizaos:active-server")
+    );
+  }
+  return false;
+}
+
+export function selectIosSmokePreferenceKeys(entries, options = {}) {
+  return Array.from(
+    new Set(
+      entries
+        .map((entry) => stripCapacitorPrefix(String(entry)))
+        .filter((key) => shouldClearIosSmokePreferenceKey(key, options)),
+    ),
+  ).sort();
+}
+
+function execText(command, args, options = {}) {
+  try {
+    return execFileSync(command, args, {
+      cwd: options.cwd,
+      encoding: "utf8",
+      stdio: [options.input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+      input: options.input,
+    }).trim();
+  } catch (error) {
+    if (options.optional) return null;
+    throw error;
+  }
+}
+
+function appDataContainer(udid, bundleId) {
+  return execText(
+    "xcrun",
+    ["simctl", "get_app_container", udid, bundleId, "data"],
+    { optional: true },
+  );
+}
+
+function prefsDomainPath(udid, bundleId) {
+  const container = appDataContainer(udid, bundleId);
+  if (!container) return null;
+  return path.join(container, "Library", "Preferences", bundleId);
+}
+
+export function readIosDefaultsDomain({ udid, bundleId }) {
+  const keys = new Set();
+  const domainPath = prefsDomainPath(udid, bundleId);
+  const plist = domainPath ? `${domainPath}.plist` : null;
+  if (plist && fs.existsSync(plist)) {
+    const json = execText("plutil", ["-convert", "json", "-o", "-", plist], {
+      optional: true,
+    });
+    if (json) {
+      try {
+        for (const key of Object.keys(JSON.parse(json))) keys.add(key);
+      } catch {
+        // Fall through to defaults export.
+      }
+    }
+  }
+
+  const exported = execText(
+    "xcrun",
+    ["simctl", "spawn", udid, "defaults", "export", bundleId, "-"],
+    { optional: true },
+  );
+  if (exported) {
+    const json = execText("plutil", ["-convert", "json", "-o", "-", "-"], {
+      optional: true,
+      input: exported,
+    });
+    if (json) {
+      try {
+        for (const key of Object.keys(JSON.parse(json))) keys.add(key);
+      } catch {
+        // Ignore malformed exports.
+      }
+    }
+  }
+  return Array.from(keys).sort();
+}
+
+export function deleteIosDefaultsKey({ udid, bundleId, key }) {
+  for (const nativeKey of preferenceNativeKeys(key)) {
+    execText(
+      "xcrun",
+      ["simctl", "spawn", udid, "defaults", "delete", bundleId, nativeKey],
+      { optional: true },
+    );
+  }
+
+  const domainPath = prefsDomainPath(udid, bundleId);
+  if (domainPath) {
+    for (const nativeKey of preferenceNativeKeys(key)) {
+      execText("defaults", ["delete", domainPath, nativeKey], {
+        optional: true,
+      });
+    }
+  }
+}
+
+export function flushIosPreferencesCache(udid) {
+  execText("xcrun", ["simctl", "spawn", udid, "killall", "cfprefsd"], {
+    optional: true,
+  });
+}
+
+export function clearIosSmokeDefaults({
+  udid,
+  bundleId,
+  includeAppState = true,
+  extraKeys = [],
+  log = () => {},
+}) {
+  const domainKeys = readIosDefaultsDomain({ udid, bundleId });
+  const selected = selectIosSmokePreferenceKeys(
+    [...domainKeys, ...extraKeys],
+    { includeAppState },
+  );
+  for (const key of selected) {
+    deleteIosDefaultsKey({ udid, bundleId, key });
+  }
+  flushIosPreferencesCache(udid);
+  if (selected.length > 0) {
+    log(`cleared ${selected.length} iOS simulator smoke/default key(s): ${selected.join(", ")}`);
+  }
+  return selected;
+}

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -11,6 +11,8 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
+import { clearIosSmokeDefaults } from "./lib/ios-sim-defaults-hygiene.mjs";
+import { assertInstalledIosAppRendererFresh } from "./lib/ios-renderer-stamp.mjs";
 import { evaluateLocalInferenceReadiness } from "./lib/local-inference-readiness.mjs";
 
 const repoRoot = path.resolve(
@@ -145,6 +147,16 @@ const ANDROID_CONFLICTING_AGENT_PACKAGES = [
   "ai.eliza.eliza",
   "ai.elizaos.eliza",
 ];
+const IOS_SMOKE_STATE_KEYS = [
+  IOS_FULL_BUN_SMOKE_REQUEST_KEY,
+  IOS_FULL_BUN_SMOKE_RESULT_KEY,
+  IOS_FULL_BUN_PREWARM_RESULT_KEY,
+  "eliza:ios-background:request",
+  "eliza:ios-background:result",
+  "elizaos:active-server",
+  "eliza:first-run-complete",
+  "eliza:mobile-runtime-mode",
+];
 
 function printHelp() {
   console.log(`Usage: node packages/app/scripts/mobile-local-chat-smoke.mjs [options]
@@ -266,6 +278,12 @@ function launchIosSimulatorApp() {
   }
 
   const id = appId();
+  clearIosSmokeDefaults({
+    udid,
+    bundleId: id,
+    extraKeys: IOS_SMOKE_STATE_KEYS,
+    log: (message) => console.log(`[local-chat-smoke] ${message}`),
+  });
   let fullBunSmokeRequestedAtMs = null;
   const container = tryExec("xcrun", [
     "simctl",
@@ -310,57 +328,13 @@ function launchIosSimulatorApp() {
  * only on a genuine stale-UI mismatch.
  */
 function assertInstalledIosRendererIsFresh(udid) {
-  const id = appId();
-  const container = tryExec("xcrun", [
-    "simctl",
-    "get_app_container",
+  assertInstalledIosAppRendererFresh({
     udid,
-    id,
-    "app",
-  ]);
-  if (!container) {
-    console.warn(
-      `[local-chat-smoke] cannot verify renderer stamp — ${id} not installed.`,
-    );
-    return;
-  }
-  const installedManifest = path.join(
-    container,
-    "public",
-    "eliza-renderer-build.json",
-  );
-  // Resolve the fresh renderer from the SAME dist the installed shell was built
-  // from. A white-label shell (ELIZA_SMOKE_APP_ID) builds from its own dist
-  // (e.g. apps/app/dist); comparing against packages/app/dist would be a
-  // guaranteed buildId mismatch and a false "stale UI" failure.
-  const rendererDist = process.env.ELIZA_SMOKE_RENDERER_DIST
-    ? path.resolve(process.env.ELIZA_SMOKE_RENDERER_DIST)
-    : path.join(repoRoot, "packages", "app", "dist");
-  const freshManifest = path.join(rendererDist, "eliza-renderer-build.json");
-  if (!fs.existsSync(freshManifest)) {
-    console.warn(
-      `[local-chat-smoke] no freshly built renderer manifest at ${freshManifest}; skipping stamp check.`,
-    );
-    return;
-  }
-  if (!fs.existsSync(installedManifest)) {
-    throw new Error(
-      `[local-chat-smoke] installed app has no renderer build stamp at ${installedManifest} — missing/stale UI.`,
-    );
-  }
-  const fresh = JSON.parse(fs.readFileSync(freshManifest, "utf8"));
-  const installed = JSON.parse(fs.readFileSync(installedManifest, "utf8"));
-  if (installed.buildId !== fresh.buildId) {
-    throw new Error(
-      `[local-chat-smoke] installed renderer buildId ${installed.buildId} != freshly built ${fresh.buildId} — ` +
-        `the simulator is running STALE UI.`,
-    );
-  }
-  console.log(
-    `[local-chat-smoke] renderer build stamp OK: installed == fresh (${String(fresh.buildId).slice(0, 12)} built ${fresh.builtAt}).`,
-  );
+    bundleId: appId(),
+    repoRoot,
+    log: (message) => console.log(`[local-chat-smoke] ${message}`),
+  });
 }
-
 function writeIosDefaultsString(udid, domain, key, value) {
   const nativeKey = `CapacitorStorage.${key}`;
   const dataContainer = tryExec(
@@ -2505,6 +2479,14 @@ async function main() {
       );
     }
   } finally {
+    if (iosContext?.udid) {
+      clearIosSmokeDefaults({
+        udid: iosContext.udid,
+        bundleId: appId(),
+        extraKeys: IOS_SMOKE_STATE_KEYS,
+        log: (message) => console.log(`[local-chat-smoke] ${message}`),
+      });
+    }
     cleanupAndroidAgentForwards(androidContext, "shutdown");
   }
 }

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -11,8 +11,8 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
-import { clearIosSmokeDefaults } from "./lib/ios-sim-defaults-hygiene.mjs";
 import { assertInstalledIosAppRendererFresh } from "./lib/ios-renderer-stamp.mjs";
+import { clearIosSmokeDefaults } from "./lib/ios-sim-defaults-hygiene.mjs";
 import { evaluateLocalInferenceReadiness } from "./lib/local-inference-readiness.mjs";
 
 const repoRoot = path.resolve(

--- a/packages/app/test/ios-renderer-stamp.test.ts
+++ b/packages/app/test/ios-renderer-stamp.test.ts
@@ -1,0 +1,70 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  assertIosAppRendererFresh,
+  compareRendererBuildIds,
+  rendererManifestPathFromAppPath,
+} from "../scripts/lib/ios-renderer-stamp.mjs";
+
+const tempDirs: string[] = [];
+
+function tempDir() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "ios-renderer-stamp-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeAppManifest(appPath: string, buildId: string) {
+  mkdirSync(path.join(appPath, "public"), { recursive: true });
+  writeFileSync(
+    rendererManifestPathFromAppPath(appPath),
+    JSON.stringify({ buildId, builtAt: "2026-07-04T00:00:00.000Z" }),
+  );
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("iOS renderer stamp", () => {
+  it("accepts matching fresh and installed build ids", () => {
+    expect(
+      compareRendererBuildIds({
+        fresh: { buildId: "abc", builtAt: "now" },
+        installed: { buildId: "abc" },
+        label: "candidate app",
+      }),
+    ).toEqual({ buildId: "abc", builtAt: "now" });
+  });
+
+  it("rejects stale installed renderer manifests", () => {
+    expect(() =>
+      compareRendererBuildIds({
+        fresh: { buildId: "fresh" },
+        installed: { buildId: "old" },
+        label: "installed app",
+      }),
+    ).toThrow(/stale UI install/);
+  });
+
+  it("compares a candidate app bundle against the freshly built dist manifest", () => {
+    const repoRoot = tempDir();
+    const appPath = path.join(repoRoot, "Candidate.app");
+    const dist = path.join(repoRoot, "packages", "app", "dist");
+    mkdirSync(dist, { recursive: true });
+    writeAppManifest(appPath, "same");
+    writeFileSync(
+      path.join(dist, "eliza-renderer-build.json"),
+      JSON.stringify({ buildId: "same", builtAt: "later" }),
+    );
+
+    expect(
+      assertIosAppRendererFresh({ appPath, repoRoot }),
+    ).toEqual({ buildId: "same", builtAt: "later" });
+  });
+});

--- a/packages/app/test/ios-renderer-stamp.test.ts
+++ b/packages/app/test/ios-renderer-stamp.test.ts
@@ -63,8 +63,9 @@ describe("iOS renderer stamp", () => {
       JSON.stringify({ buildId: "same", builtAt: "later" }),
     );
 
-    expect(
-      assertIosAppRendererFresh({ appPath, repoRoot }),
-    ).toEqual({ buildId: "same", builtAt: "later" });
+    expect(assertIosAppRendererFresh({ appPath, repoRoot })).toEqual({
+      buildId: "same",
+      builtAt: "later",
+    });
   });
 });

--- a/packages/app/test/ios-sim-defaults-hygiene.test.ts
+++ b/packages/app/test/ios-sim-defaults-hygiene.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  preferenceNativeKeys,
+  selectIosSmokePreferenceKeys,
+  shouldClearIosSmokePreferenceKey,
+} from "../scripts/lib/ios-sim-defaults-hygiene.mjs";
+
+describe("iOS simulator defaults hygiene", () => {
+  it("selects stale smoke, auth, first-run, and runtime keys from raw domains", () => {
+    expect(
+      selectIosSmokePreferenceKeys([
+        "CapacitorStorage.eliza:ios-onboarding-smoke:request",
+        "eliza:ios-full-bun-prewarm:result",
+        "CapacitorStorage.eliza:auth-callback-smoke:result",
+        "CapacitorStorage.elizaos:active-server",
+        "CapacitorStorage.eliza:mobile-runtime-mode",
+        "CapacitorStorage.user-visible-setting",
+        "unrelated",
+      ]),
+    ).toEqual([
+      "eliza:auth-callback-smoke:result",
+      "eliza:ios-full-bun-prewarm:result",
+      "eliza:ios-onboarding-smoke:request",
+      "eliza:mobile-runtime-mode",
+      "elizaos:active-server",
+    ]);
+  });
+
+  it("does not remove ordinary app state unless it is a known lane poison", () => {
+    expect(shouldClearIosSmokePreferenceKey("eliza:chat:draft")).toBe(false);
+    expect(shouldClearIosSmokePreferenceKey("CapacitorStorage.eliza:chat:draft")).toBe(false);
+    expect(shouldClearIosSmokePreferenceKey("eliza:first-run-complete")).toBe(true);
+  });
+
+  it("deletes both CapacitorStorage-prefixed and raw native keys", () => {
+    expect(preferenceNativeKeys("eliza:ios-onboarding-smoke:request")).toEqual([
+      "CapacitorStorage.eliza:ios-onboarding-smoke:request",
+      "eliza:ios-onboarding-smoke:request",
+    ]);
+  });
+});

--- a/packages/app/test/ios-sim-defaults-hygiene.test.ts
+++ b/packages/app/test/ios-sim-defaults-hygiene.test.ts
@@ -29,8 +29,12 @@ describe("iOS simulator defaults hygiene", () => {
 
   it("does not remove ordinary app state unless it is a known lane poison", () => {
     expect(shouldClearIosSmokePreferenceKey("eliza:chat:draft")).toBe(false);
-    expect(shouldClearIosSmokePreferenceKey("CapacitorStorage.eliza:chat:draft")).toBe(false);
-    expect(shouldClearIosSmokePreferenceKey("eliza:first-run-complete")).toBe(true);
+    expect(
+      shouldClearIosSmokePreferenceKey("CapacitorStorage.eliza:chat:draft"),
+    ).toBe(false);
+    expect(shouldClearIosSmokePreferenceKey("eliza:first-run-complete")).toBe(
+      true,
+    );
   });
 
   it("deletes both CapacitorStorage-prefixed and raw native keys", () => {


### PR DESCRIPTION
## Summary
- add shared iOS simulator defaults hygiene that enumerates and clears stale smoke/auth/runtime keys, including both CapacitorStorage-prefixed and raw defaults keys
- add shared iOS renderer-stamp verification for candidate .app bundles and installed simulator containers
- wire cleanup and stamp proof into ios-onboarding-smoke, mobile-local-chat-smoke, and ios-e2e
- add host-side tests for the helper contracts

Closes #13570.
Closes #13575.

## Evidence
- Added .github/issue-evidence/13570-13575-ios-sim-hygiene-stamp.md.
- Local temp-file verification: node --check passed for the two new helpers and three touched scripts; pure helper runtime check passed for stale key selection and renderer build-id mismatch behavior.
- Native capture/video: N/A for this harness-integrity PR; the change makes stale simulator state and stale app installs fail before native evidence can be trusted.

## Tests
- node --check /tmp/13570-13575/packages/app/scripts/lib/ios-sim-defaults-hygiene.mjs
- node --check /tmp/13570-13575/packages/app/scripts/lib/ios-renderer-stamp.mjs
- node --check /tmp/13570-13575/packages__app__scripts__ios-onboarding-smoke.mjs
- node --check /tmp/13570-13575/packages__app__scripts__mobile-local-chat-smoke.mjs
- node --check /tmp/13570-13575/packages__app__scripts__ios-e2e.mjs
- node --input-type=module pure helper smoke for key selection + renderer build-id mismatch

Not run: real iOS simulator lanes, because this shared checkout is intentionally dirty and the lane requires a freshly built/installed simulator app.