### PR TITLE
docs: fix root repo map drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,25 +100,25 @@ above is the day-to-day set. Use `bun run` with no args to print them all.
 packages/        framework, shared libraries, and product surfaces
   core/          @elizaos/core — runtime, types, agent loop, memory/state, model layer
   agent/         @elizaos/agent — AgentRuntime, plugin loader, default plugin map
-  app-core/      API + dashboard host; dev/build orchestration (dev-ui.mjs)
+  app-core/      API + dashboard host; dev/build orchestration (scripts/dev-ui.mjs)
   elizaos/       the `elizaos` CLI — create / info / upgrade / version; project + plugin templates
   prompts/       shared prompt scaffolding
   shared/        cross-package utilities + brand assets
   ui/            shared React component library
-  app/           web + desktop dashboard (Vite + React; desktop shell)
+  app/           web + desktop dashboard, desktop shell, and current cloud apex UI
   tui/           terminal UI
   skills/        runtime skills knowledge base (USE_SKILL)
   scenario-runner/ scenario + eval harness
   cloud/api/     managed backend API (Hono on Cloudflare Workers)
-  app/           web + desktop dashboard; also hosts the current cloud apex UI
+  cloud/docs-redirect/ Eliza Cloud docs redirects
   cloud/shared/  shared cloud backend: db (Drizzle), billing, services, types
   cloud/sdk/ cloud/routing/ cloud/infra/  cloud client SDK, model routing, IaC
   contracts/     on-chain contracts + ABIs
-  security/ vault/ soc2-verify/  secrets, key management, compliance tooling
+  security/ security/soc2-verify/ vault/  secrets, key management, compliance tooling
   os/ robot/                     device/OS images, OS landing, robotics
   plugin-remote-manifest/ plugin-worker-runtime/
                  remote plugin manifests, host shims, and worker runtime support
-  homepage/ docs/ docs-elizacloud-redirect/  marketing site, docs site, redirects
+  homepage/ docs/  marketing site and docs site
   examples/      30+ standalone runnable examples (each has its own README)
   benchmarks/    30+ evaluation suites (each has its own README + harness)
 
@@ -128,10 +128,10 @@ plugins/         runtime plugins and app plugins
   plugin-native-*/     native device bridges (camera, contacts, calendar, location, …)
   plugin-local-inference/  on-device llama.cpp (Kokoro TTS folded in) / whisper (git submodules under native/)
   plugin-sql/ plugin-localdb/ plugin-inmemorydb/  storage adapters
-  plugin-documents/ plugin-lifeops/ plugin-health/ …  app plugins
+  plugin-documents/ plugin-personal-assistant/ plugin-health/ …  app plugins
 
 scripts/         repo automation        patches/   dependency patches
-skills/          runtime skill packages turbo.json knip.json  build + dead-code config
+turbo.json knip.json  build + dead-code config
 ```
 
 Every package and plugin carries its own `CLAUDE.md` / `AGENTS.md` (identical)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,25 +100,25 @@ above is the day-to-day set. Use `bun run` with no args to print them all.
 packages/        framework, shared libraries, and product surfaces
   core/          @elizaos/core — runtime, types, agent loop, memory/state, model layer
   agent/         @elizaos/agent — AgentRuntime, plugin loader, default plugin map
-  app-core/      API + dashboard host; dev/build orchestration (dev-ui.mjs)
+  app-core/      API + dashboard host; dev/build orchestration (scripts/dev-ui.mjs)
   elizaos/       the `elizaos` CLI — create / info / upgrade / version; project + plugin templates
   prompts/       shared prompt scaffolding
   shared/        cross-package utilities + brand assets
   ui/            shared React component library
-  app/           web + desktop dashboard (Vite + React; desktop shell)
+  app/           web + desktop dashboard, desktop shell, and current cloud apex UI
   tui/           terminal UI
   skills/        runtime skills knowledge base (USE_SKILL)
   scenario-runner/ scenario + eval harness
   cloud/api/     managed backend API (Hono on Cloudflare Workers)
-  app/           web + desktop dashboard; also hosts the current cloud apex UI
+  cloud/docs-redirect/ Eliza Cloud docs redirects
   cloud/shared/  shared cloud backend: db (Drizzle), billing, services, types
   cloud/sdk/ cloud/routing/ cloud/infra/  cloud client SDK, model routing, IaC
   contracts/     on-chain contracts + ABIs
-  security/ vault/ soc2-verify/  secrets, key management, compliance tooling
+  security/ security/soc2-verify/ vault/  secrets, key management, compliance tooling
   os/ robot/                     device/OS images, OS landing, robotics
   plugin-remote-manifest/ plugin-worker-runtime/
                  remote plugin manifests, host shims, and worker runtime support
-  homepage/ docs/ docs-elizacloud-redirect/  marketing site, docs site, redirects
+  homepage/ docs/  marketing site and docs site
   examples/      30+ standalone runnable examples (each has its own README)
   benchmarks/    30+ evaluation suites (each has its own README + harness)
 
@@ -128,10 +128,10 @@ plugins/         runtime plugins and app plugins
   plugin-native-*/     native device bridges (camera, contacts, calendar, location, …)
   plugin-local-inference/  on-device llama.cpp (Kokoro TTS folded in) / whisper (git submodules under native/)
   plugin-sql/ plugin-localdb/ plugin-inmemorydb/  storage adapters
-  plugin-documents/ plugin-lifeops/ plugin-health/ …  app plugins
+  plugin-documents/ plugin-personal-assistant/ plugin-health/ …  app plugins
 
 scripts/         repo automation        patches/   dependency patches
-skills/          runtime skill packages turbo.json knip.json  build + dead-code config
+turbo.json knip.json  build + dead-code config
 ```
 
 Every package and plugin carries its own `CLAUDE.md` / `AGENTS.md` (identical)


### PR DESCRIPTION
## Summary

- remove the duplicate root repo-map app row and fold the cloud-apex note into the real `packages/app` row
- correct stale entries for `cloud/docs-redirect`, `plugin-personal-assistant`, and `security/soc2-verify`
- remove the bogus top-level `skills/` row and clarify `app-core/scripts/dev-ui.mjs`
- keep root `CLAUDE.md` and `AGENTS.md` byte-identical

Fixes #13627

## Verification

- `cmp -s CLAUDE.md AGENTS.md` -> identical
- `node scripts/assert-agents-claude-identical.mjs` -> `PASS: 299 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.`
- repo-map path verifier checked 40 concrete paths with `missing: []` (placeholder/wildcard examples excluded)
- `git diff --check`
