### PR TITLE
fix(#13630): desktop:stack-status probes canonical API port (31337) not Vite UI port (2138)

### DIFF
--- a/packages/app-core/scripts/lib/desktop-stack-status.mjs
+++ b/packages/app-core/scripts/lib/desktop-stack-status.mjs
@@ -8,9 +8,18 @@
  */
 
 import { createConnection } from "node:net";
+import {
+  DEFAULT_DESKTOP_UI_PORT,
+  resolveDesktopApiPort,
+} from "@elizaos/shared";
 
-const DEFAULT_UI_PORT = 2138;
-const DEFAULT_API_PORT = 2138;
+// Dev mode splits the API from the Vite UI: API on 31337, UI on 2138. The
+// canonical `DEFAULT_DESKTOP_API_PORT`/`resolveDesktopApiPort` live in
+// `@elizaos/shared/runtime-env`; do NOT re-declare a default API port here (a
+// second, drifted copy previously hardwired 2138 — the Vite UI port — so an
+// API-only stack with no `ELIZA_API_PORT` in the shell probed the wrong port,
+// reported "Nothing listening", and exited 1 while the API was healthy on
+// 31337). Only the UI-port default is app-local (env → /api/dev/stack → default).
 const CONNECT_TIMEOUT_MS = 800;
 const FETCH_TIMEOUT_MS = 2500;
 
@@ -20,14 +29,6 @@ function parsePositivePort(value) {
   return Number.isInteger(parsed) && parsed > 0 && parsed < 65536
     ? parsed
     : NaN;
-}
-
-function resolveDesktopApiPort(env) {
-  return (
-    parsePositivePort(env.ELIZA_API_PORT) ||
-    parsePositivePort(env.ELIZA_PORT) ||
-    DEFAULT_API_PORT
-  );
 }
 
 /**
@@ -126,7 +127,7 @@ export async function gatherDesktopStackStatus(
   const uiPort =
     (Number.isFinite(uiFromEnv) ? uiFromEnv : NaN) ||
     (Number.isFinite(uiFromApi) ? uiFromApi : NaN) ||
-    DEFAULT_UI_PORT;
+    DEFAULT_DESKTOP_UI_PORT;
 
   const uiListening = await checkPort(uiPort);
 

--- a/packages/app-core/scripts/lib/desktop-stack-status.test.mjs
+++ b/packages/app-core/scripts/lib/desktop-stack-status.test.mjs
@@ -1,0 +1,94 @@
+/**
+ * Pins the desktop dev stack-status API-port resolution to the canonical
+ * `@elizaos/shared/runtime-env` source of truth (#13630 B2).
+ *
+ * Regression guarded: a drifted local `DEFAULT_API_PORT = 2138` (the *Vite UI*
+ * port) previously made a clean-shell probe (no `ELIZA_API_PORT`) check 2138
+ * instead of the real desktop API port 31337 — so an API-only stack reported
+ * "Nothing listening" and exited 1 while the API was healthy on 31337, and a
+ * full stack emitted a contradictory `apiPort: 2138` vs the API's real 31337.
+ */
+
+import {
+  DEFAULT_DESKTOP_API_PORT,
+  DEFAULT_DESKTOP_UI_PORT,
+} from "@elizaos/shared";
+import { describe, expect, it, vi } from "vitest";
+import { gatherDesktopStackStatus } from "./desktop-stack-status.mjs";
+
+/** A fetch that never resolves a real endpoint (all probes report failure). */
+function makeDeadFetch() {
+  return vi.fn(async () => ({
+    ok: false,
+    status: 0,
+    text: async () => "",
+  }));
+}
+
+/** isPortOpen stub: returns true only for ports in `openPorts`. */
+function makePortProbe(openPorts) {
+  const set = new Set(openPorts);
+  return vi.fn(async (port) => set.has(port));
+}
+
+describe("gatherDesktopStackStatus — API port resolution (#13630 B2)", () => {
+  it("resolves the canonical desktop API port (31337) in a clean shell, not the Vite UI port", async () => {
+    const status = await gatherDesktopStackStatus(
+      {}, // clean shell: no ELIZA_API_PORT / ELIZA_PORT
+      makeDeadFetch(),
+      { isPortOpen: makePortProbe([]) },
+    );
+
+    expect(status.apiPort).toBe(DEFAULT_DESKTOP_API_PORT);
+    expect(status.apiPort).toBe(31337);
+    // Regression guard: must NEVER default the API port to the Vite UI port.
+    expect(status.apiPort).not.toBe(DEFAULT_DESKTOP_UI_PORT);
+    expect(status.apiPort).not.toBe(2138);
+  });
+
+  it("detects an API-only stack listening on 31337 with no ELIZA_API_PORT in the shell", async () => {
+    const probe = makePortProbe([DEFAULT_DESKTOP_API_PORT]);
+    const status = await gatherDesktopStackStatus({}, makeDeadFetch(), {
+      isPortOpen: probe,
+    });
+
+    expect(status.apiPort).toBe(31337);
+    expect(status.apiListening).toBe(true);
+    // The probe must have been asked about the real API port (31337). The UI
+    // leg still separately probes 2138 (the Vite UI port) — that's expected and
+    // distinct from the API port, which must never itself default to 2138.
+    expect(probe).toHaveBeenCalledWith(31337);
+    expect(status.uiPort).toBe(2138);
+    expect(status.uiPort).not.toBe(status.apiPort);
+  });
+
+  it("honors an explicit ELIZA_API_PORT override", async () => {
+    const status = await gatherDesktopStackStatus(
+      { ELIZA_API_PORT: "45000" },
+      makeDeadFetch(),
+      { isPortOpen: makePortProbe([45000]) },
+    );
+
+    expect(status.apiPort).toBe(45000);
+    expect(status.apiListening).toBe(true);
+  });
+
+  it("falls back to ELIZA_PORT when ELIZA_API_PORT is unset (first-non-empty wins)", async () => {
+    const status = await gatherDesktopStackStatus(
+      { ELIZA_PORT: "39000" },
+      makeDeadFetch(),
+      { isPortOpen: makePortProbe([]) },
+    );
+
+    expect(status.apiPort).toBe(39000);
+  });
+
+  it("still defaults the UI port to the canonical Vite UI port (2138)", async () => {
+    const status = await gatherDesktopStackStatus({}, makeDeadFetch(), {
+      isPortOpen: makePortProbe([]),
+    });
+
+    expect(status.uiPort).toBe(DEFAULT_DESKTOP_UI_PORT);
+    expect(status.uiPort).toBe(2138);
+  });
+});


### PR DESCRIPTION
## What / Why

Fixes the **B2 (HIGH)** defect in #13630: `desktop:stack-status` hardcodes the wrong default API port.

`packages/app-core/scripts/lib/desktop-stack-status.mjs` hardcoded `DEFAULT_API_PORT = 2138` (the **Vite UI** port) and re-implemented `resolveDesktopApiPort`, instead of the canonical `DEFAULT_DESKTOP_API_PORT = 31337` / `resolveDesktopApiPort` in `packages/shared/src/runtime-env.ts` (`"Dev mode splits the API from the Vite UI: API on 31337, UI on 2138"`).

The probe exists precisely for the shell that lacks `ELIZA_API_PORT` — and in that case it checked 2138, not 31337:
- On an **API-only** stack it printed "Nothing listening" and **exited 1 while the API was healthy on 31337** — a false negative for the exact probe the docs tell agents to run.
- On a full `dev:desktop` stack it "worked" only via the Vite `/api` proxy while emitting a **contradictory** `apiPort: 2138` vs `devStack.api.listenPort: 31337`; an agent trusting `apiPort` targets the wrong port.

This also shipped a second, drifted copy of a default port, violating the "never hardcode ports — the orchestrator auto-shifts and syncs" rule, with no test pinning it.

## Fix

- Import `resolveDesktopApiPort` + `DEFAULT_DESKTOP_UI_PORT` from `@elizaos/shared` (same pattern `dev-ui.mjs` already uses: `import { resolveDesktopApiPort, resolveDesktopUiPort } from "@elizaos/shared"`).
- Delete the local `DEFAULT_API_PORT = 2138` and the local `resolveDesktopApiPort` copy.
- Replace the second hardcoded `DEFAULT_UI_PORT` literal with the canonical `DEFAULT_DESKTOP_UI_PORT` — killing both drifted port copies.

API-port preference order (`ELIZA_API_PORT` → `ELIZA_PORT` → default) is preserved; **only the default changes to the correct 31337**. The UI-leg resolution (env → `/api/dev/stack` → default) is behavior-preserving.

Scoped to **B2 only** — B1 (`watch` flag) and B4/B5 (doc drift) are left for follow-up slices so this stays a clean single-file-pair change.

## Tests

New `packages/app-core/scripts/lib/desktop-stack-status.test.mjs` (5/5 green):
- clean-shell default resolves `31337`, **not** `2138` (explicit regression guard for the drifted default);
- API-only detection: API listening on 31337 with no `ELIZA_API_PORT` in the shell → `apiListening: true`, `apiPort: 31337`, probe asked about 31337;
- explicit `ELIZA_API_PORT` override honored;
- `ELIZA_PORT` fallback (first-non-empty wins) honored;
- UI port still defaults to the canonical Vite UI port `2138`.

```
✓ scripts/lib/desktop-stack-status.test.mjs (5 tests)  Tests 5 passed (5)
```

Gates: vitest 5/5 green, `biome check` clean, `audit:error-policy-ratchet` "no new fallback-slop", `audit:scripts` OK, `node --check` clean on both files, `codex review` — "I did not identify any introduced correctness issues in the diff." (`.mjs` scripts aren't in the package `tsgo` typecheck include, so validated via `node --check` + `audit:scripts`.)

— [sol-orch]
