### PR TITLE
feat(chat): single infinite thread — remove swipe/reset/maximize, pull-based expand (#13531)

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.fuzz.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.fuzz.test.tsx
@@ -239,6 +239,35 @@ function slowDrag(el: Element, fromY: number, toY: number): void {
 }
 const flickUp = (el: Element) => flick(el, 420, 400);
 const flickDown = (el: Element) => flick(el, 200, 220);
+// A big upward over-pull of the grabber — far past the FULL detent — which the
+// pull-to-maximize path (#13531) commits to edge-to-edge full-bleed. Maximize is
+// a gesture now, not a button.
+function bigPullUp(el: Element): void {
+  const now = vi.spyOn(performance, "now");
+  now.mockReturnValue(0);
+  fireEvent.pointerDown(el, { clientY: 760, pointerId: 1 });
+  now.mockReturnValue(200);
+  fireEvent.pointerMove(el, { clientY: 400, pointerId: 1 });
+  now.mockReturnValue(400);
+  fireEvent.pointerMove(el, { clientY: 40, pointerId: 1 });
+  now.mockReturnValue(800); // slow ⇒ settle/free-rest path (not a flick)
+  fireEvent.pointerMove(el, { clientY: 0, pointerId: 1 });
+  fireEvent.pointerUp(el, { clientY: 0, pointerId: 1 });
+  now.mockRestore();
+}
+// A downward pull that STARTS in the maximized top-20% restore zone — exits
+// full-bleed back to the inset FULL-detent overlay (#13531).
+function pullDownRestoreZone(): void {
+  const zone = screen.getByTestId("chat-maximize-restore-zone");
+  const now = vi.spyOn(performance, "now");
+  now.mockReturnValue(0);
+  fireEvent.pointerDown(zone, { clientY: 20, pointerId: 1 });
+  now.mockReturnValue(200);
+  fireEvent.pointerMove(zone, { clientY: 200, pointerId: 1 });
+  now.mockReturnValue(800);
+  fireEvent.pointerUp(zone, { clientY: 320, pointerId: 1 });
+  now.mockRestore();
+}
 const focusReal = () => act(() => input().focus());
 const blurReal = () => act(() => input().blur());
 
@@ -257,8 +286,8 @@ function gotoFull(): void {
   expect(detentOf()).toBe("full");
 }
 function gotoMaximized(): void {
-  gotoFull();
-  fireEvent.click(screen.getByTestId("chat-full-maximize"));
+  // Maximize is a big upward over-pull now (#13531), not a header button.
+  bigPullUp(grabber() as Element);
   expect(detentOf()).toBe("full");
   expect(sheet().getAttribute("data-maximized")).toBe("true");
 }
@@ -310,7 +339,8 @@ describe("ContinuousChatOverlay — reachable states", () => {
       <ContinuousChatOverlay controller={makeController({ messages: [] })} />,
     );
     tutorial("expand");
-    fireEvent.click(screen.getByTestId("chat-full-maximize"));
+    // Maximize is a big upward over-pull now (#13531), not a header button.
+    bigPullUp(grabber() as Element);
     expect(sheet().getAttribute("data-maximized")).toBe("true");
     assertInvariants("tutorial-maximized");
 
@@ -382,10 +412,23 @@ describe("ContinuousChatOverlay — state × action matrix", () => {
       run: () => fireEvent.pointerDown(document.body),
     },
     {
+      // Maximize is a big upward over-pull of the grabber now (#13531). When the
+      // grabber is absent (already maximized), it's a no-op — the matrix just
+      // proves the state stays valid.
       name: "maximize",
       run: () => {
-        const b = screen.queryByTestId("chat-full-maximize");
-        if (b) fireEvent.click(b);
+        const g = grabber();
+        if (g) bigPullUp(g);
+      },
+    },
+    {
+      // Restore-from-maximized: a downward pull in the top-20% zone (#13531).
+      // No-op when not maximized (the zone is unmounted).
+      name: "restore-zone-pull-down",
+      run: () => {
+        if (screen.queryByTestId("chat-maximize-restore-zone")) {
+          pullDownRestoreZone();
+        }
       },
     },
   ];
@@ -502,14 +545,15 @@ describe("ContinuousChatOverlay — multi-press storms", () => {
     expect(detentOf()).toBe("collapsed");
   });
 
-  it("double-clicking the maximize toggle returns to the inset full detent", () => {
+  it("pull-up-to-maximize then top-20% pull-down returns to the inset full detent (#13531)", () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
-    gotoFull();
-    const max = () => screen.getByTestId("chat-full-maximize");
-    fireEvent.click(max());
+    // Big over-pull maximizes.
+    gotoMaximized();
     expect(sheet().getAttribute("data-maximized")).toBe("true");
     assertInvariants("maximized");
-    fireEvent.click(max());
+    // A downward pull in the top-20% restore zone drops full-bleed but keeps the
+    // sheet open at the FULL detent (not a full collapse).
+    pullDownRestoreZone();
     expect(sheet().getAttribute("data-maximized")).not.toBe("true");
     expect(detentOf()).toBe("full");
     assertInvariants("un-maximized");
@@ -627,9 +671,16 @@ describe("ContinuousChatOverlay — seeded random fuzz", () => {
     () => fireEvent.click(backdrop()),
     () => fireEvent.pointerDown(backdrop()),
     () => fireEvent.pointerDown(document.body),
+    // Maximize is a big upward over-pull now (#13531); restore is a top-20%
+    // pull-down. Both no-op when their surface is absent.
     () => {
-      const b = screen.queryByTestId("chat-full-maximize");
-      if (b) fireEvent.click(b);
+      const g = grabber();
+      if (g) bigPullUp(g);
+    },
+    () => {
+      if (screen.queryByTestId("chat-maximize-restore-zone")) {
+        pullDownRestoreZone();
+      }
     },
   ];
 
@@ -854,13 +905,15 @@ describe("ContinuousChatOverlay — long adversarial random walk", () => {
     () => fireEvent.keyDown(input(), { key: "Escape" }),
     () => fireEvent.click(backdrop()),
     () => fireEvent.pointerDown(document.body),
+    // Maximize/restore are pull gestures now (#13531); no clear/new-chat button.
     () => {
-      const b = screen.queryByTestId("chat-full-maximize");
-      if (b) fireEvent.click(b);
+      const g = grabber();
+      if (g) bigPullUp(g);
     },
     () => {
-      const b = screen.queryByTestId("chat-full-clear");
-      if (b) fireEvent.click(b);
+      if (screen.queryByTestId("chat-maximize-restore-zone")) {
+        pullDownRestoreZone();
+      }
     },
   ];
 

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.slash.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.slash.test.tsx
@@ -89,7 +89,24 @@ const COMMANDS: SlashCommandCatalogItem[] = [
     requiresAuth: false,
     requiresElevated: false,
     surfaces: ["gui", "tui"],
+    // Single infinite thread (#13531): the overlay treats clear-chat as inert.
     target: { kind: "client", clientAction: "clear-chat" },
+    source: "builtin",
+  },
+  {
+    key: "commands",
+    nativeName: "commands",
+    description: "Show commands",
+    textAliases: ["/commands"],
+    scope: "text",
+    acceptsArgs: false,
+    args: [],
+    requiresAuth: false,
+    requiresElevated: false,
+    surfaces: ["gui", "tui"],
+    // A client command the overlay STILL forwards — exercises the generic
+    // client-action dispatch path now that clear-chat is inert (#13531).
+    target: { kind: "client", clientAction: "open-command-palette" },
     source: "builtin",
   },
   {
@@ -193,10 +210,24 @@ describe("ContinuousChatOverlay slash commands", () => {
   it("Enter on a client command runs the client action", () => {
     const slash = makeSlash();
     const { input, controller } = renderOverlay(slash);
+    // `/commands` → open-command-palette, a client action the overlay still
+    // forwards (clear-chat is intentionally inert under one-infinite-thread,
+    // #13531).
+    fireEvent.change(input, { target: { value: "/commands" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(slash.openCommandPalette).toHaveBeenCalled();
+    expect(controller.send).not.toHaveBeenCalled();
+  });
+
+  it("Enter on /clear is inert — no clear, no send (single infinite thread, #13531)", () => {
+    const slash = makeSlash();
+    const { input, controller } = renderOverlay(slash);
     fireEvent.change(input, { target: { value: "/clear" } });
     fireEvent.keyDown(input, { key: "Enter" });
-    expect(slash.clearChat).toHaveBeenCalled();
+    expect(slash.clearChat).not.toHaveBeenCalled();
     expect(controller.send).not.toHaveBeenCalled();
+    // The draft is still consumed (the command resolved), not left in the box.
+    expect(input.value).toBe("");
   });
 
   it("natural navigation stays inert when the feature flag is off", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -2214,14 +2214,14 @@ describe("ContinuousChatOverlay", () => {
 });
 
 /**
- * Swipe-between-conversations integration (#8929). Drives the REAL overlay with
- * the REAL `usePullGesture` binding and a REAL `conversationNav` (built via the
- * production `buildConversationNav` helper) — not the isolated `__e2e__` fixture
- * mock. A committed horizontal swipe on the thread must (a) light the edge hint
- * with the live drag offset and (b) select the adjacent conversation through
- * `handleSelectConversation`, proving the active conversation actually changes.
+ * Single infinite thread (#13531): the chat-to-chat horizontal swipe was
+ * REMOVED. This suite drives the REAL overlay with a REAL `conversationNav`
+ * (built via the production `buildConversationNav` helper) and proves a
+ * committed horizontal drag on the transcript NO LONGER selects an adjacent
+ * conversation and NO swipe edge hint renders. (The collapsed-composer
+ * home↔launcher swipe is a separate binding, covered elsewhere.)
  */
-describe("ContinuousChatOverlay swipe-nav", () => {
+describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
   function conv(id: string): Conversation {
     return {
       id,
@@ -2233,7 +2233,7 @@ describe("ContinuousChatOverlay swipe-nav", () => {
   }
 
   // The list is most-recent-first: [newest "a", "b", oldest "c"]. Active "b" is
-  // in the middle so both directions are navigable.
+  // in the middle so both directions WOULD have been navigable pre-#13531.
   const CONVERSATIONS = [conv("a"), conv("b"), conv("c")];
 
   function makeSwipeController() {
@@ -2258,145 +2258,136 @@ describe("ContinuousChatOverlay swipe-nav", () => {
     return el;
   }
 
-  it("a committed LEFT swipe selects the next (older) conversation", () => {
+  it("a committed LEFT drag does NOT switch to the next conversation", () => {
     const { controller, onSelect } = makeSwipeController();
     render(<ContinuousChatOverlay controller={controller} />);
     openSheet();
 
     const el = thread();
-    // Drag LEFT: clientX decreases. The first move commits the X axis (>8px);
-    // total travel of 120px clears the 64px horizontal distance threshold.
+    // The exact gesture that used to navigate LEFT (→ "c") pre-#13531.
     fireEvent.pointerDown(el, { clientX: 300, clientY: 300, pointerId: 2 });
     fireEvent.pointerMove(el, { clientX: 280, clientY: 302, pointerId: 2 });
     fireEvent.pointerUp(el, { clientX: 180, clientY: 302, pointerId: 2 });
 
-    // "b" → next/older is "c".
-    expect(onSelect).toHaveBeenCalledExactlyOnceWith("c");
+    expect(onSelect).not.toHaveBeenCalled();
   });
 
-  it("a committed RIGHT swipe selects the previous (newer) conversation", () => {
+  it("a committed RIGHT drag does NOT switch to the previous conversation", () => {
     const { controller, onSelect } = makeSwipeController();
     render(<ContinuousChatOverlay controller={controller} />);
     openSheet();
 
     const el = thread();
-    // Drag RIGHT: clientX increases.
+    // The exact gesture that used to navigate RIGHT (→ "a") pre-#13531.
     fireEvent.pointerDown(el, { clientX: 180, clientY: 300, pointerId: 2 });
     fireEvent.pointerMove(el, { clientX: 200, clientY: 302, pointerId: 2 });
     fireEvent.pointerUp(el, { clientX: 300, clientY: 302, pointerId: 2 });
 
-    // "b" → prev/newer is "a".
-    expect(onSelect).toHaveBeenCalledExactlyOnceWith("a");
+    expect(onSelect).not.toHaveBeenCalled();
   });
 
-  it("lights an edge hint with the live drag offset while swiping", async () => {
+  it("never renders a conversation-swipe edge hint mid-drag", () => {
     const { controller } = makeSwipeController();
     render(<ContinuousChatOverlay controller={controller} />);
     openSheet();
 
     const el = thread();
-    // Hold mid-drag (no pointerUp) so swipeDx is live and the hint is mounted.
-    // Dragging LEFT (clientX decreases) drives swipeDx > 0 — the next/older
-    // conversation slides in from the RIGHT edge, so the RIGHT hint lights.
+    // Hold mid-drag (no pointerUp): pre-#13531 this lit the RIGHT edge hint.
     fireEvent.pointerDown(el, { clientX: 300, clientY: 300, pointerId: 3 });
     fireEvent.pointerMove(el, { clientX: 240, clientY: 302, pointerId: 3 });
 
-    const hint = await waitFor(() =>
-      screen.getByTestId("conversation-swipe-hint-right"),
-    );
-    expect(hint).toBeTruthy();
-    // Opacity scales with the drag distance (60px of 96px ≈ 0.625).
-    expect(Number.parseFloat(hint.style.opacity)).toBeGreaterThan(0);
-    // The opposite (left) hint stays inert while dragging left.
+    expect(screen.queryByTestId("conversation-swipe-hint-right")).toBeNull();
     expect(screen.queryByTestId("conversation-swipe-hint-left")).toBeNull();
   });
 
-  it("does NOT switch conversations on a mostly-vertical drag (axis lock)", () => {
-    const { controller, onSelect } = makeSwipeController();
+  it("exposes no maximize / minimize / clear (new-chat) header buttons", () => {
+    const { controller } = makeSwipeController();
     render(<ContinuousChatOverlay controller={controller} />);
     openSheet();
 
-    const el = thread();
-    // Vertical travel dominates → the gesture commits to the Y axis and never
-    // fires a swipe, so the active conversation is unchanged.
-    fireEvent.pointerDown(el, { clientX: 300, clientY: 300, pointerId: 4 });
-    fireEvent.pointerMove(el, { clientX: 290, clientY: 220, pointerId: 4 });
-    fireEvent.pointerUp(el, { clientX: 285, clientY: 140, pointerId: 4 });
-
-    expect(onSelect).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("chat-full-maximize")).toBeNull();
+    expect(screen.queryByTestId("chat-full-clear")).toBeNull();
+    // The launcher (the sole remaining header control) still renders.
+    expect(screen.getByTestId("chat-full-launcher")).toBeTruthy();
   });
 
-  it("does NOT switch conversations when a mouse drag was highlighting bubble text", () => {
-    // The swipe binding lives on the transcript, which contains the selectable
-    // message bubbles. A horizontal MOUSE drag to highlight text would commit as
-    // a swipe and navigate away — destroying the selection. A live (non-
-    // collapsed) selection at release means the gesture was a highlight, so the
-    // swipe is skipped (mirrors the ThreadLine tap-reveal guard).
-    const { controller, onSelect } = makeSwipeController();
+  // Maximize is a PULL now, not a button (#13531). A big upward over-pull of the
+  // grabber — far past the FULL detent — flips the sheet to edge-to-edge
+  // full-bleed (data-maximized="true", data-chat-state="MAXIMIZED").
+  function bigPullUp() {
+    const grabber = screen.getByTestId("chat-sheet-grabber");
+    // Start low, drag all the way to the very top: a deliberate slow over-pull
+    // whose peak raw height clears the maximize threshold.
+    fireEvent.pointerDown(grabber, { clientY: 760, pointerId: 7 });
+    fireEvent.pointerMove(grabber, { clientY: 400, pointerId: 7 });
+    fireEvent.pointerMove(grabber, { clientY: 40, pointerId: 7 });
+    fireEvent.pointerMove(grabber, { clientY: 0, pointerId: 7 });
+    fireEvent.pointerUp(grabber, { clientY: 0, pointerId: 7 });
+  }
+
+  it("a big upward over-pull of the grabber maximizes to full-bleed", () => {
+    const { controller } = makeSwipeController();
     render(<ContinuousChatOverlay controller={controller} />);
+    const sheet = screen.getByTestId("chat-sheet");
+    bigPullUp();
+    expect(sheet.getAttribute("data-maximized")).toBe("true");
+    expect(sheet.getAttribute("data-chat-state")).toBe("MAXIMIZED");
+  });
+
+  it("renders the top-20% pull-down restore zone ONLY while maximized", () => {
+    const { controller } = makeSwipeController();
+    render(<ContinuousChatOverlay controller={controller} />);
+    // Not present at rest / half.
     openSheet();
-
-    const getSelection = vi.spyOn(window, "getSelection").mockReturnValue({
-      toString: () => "selected bubble text",
-    } as unknown as Selection);
-    try {
-      const el = thread();
-      // The exact gesture that DOES navigate in the passing test above — only
-      // the live selection differs.
-      fireEvent.pointerDown(el, { clientX: 300, clientY: 300, pointerId: 6 });
-      fireEvent.pointerMove(el, { clientX: 280, clientY: 302, pointerId: 6 });
-      fireEvent.pointerUp(el, { clientX: 180, clientY: 302, pointerId: 6 });
-
-      expect(onSelect).not.toHaveBeenCalled();
-    } finally {
-      getSelection.mockRestore();
-    }
+    expect(screen.queryByTestId("chat-maximize-restore-zone")).toBeNull();
+    // Appears once maximized.
+    bigPullUp();
+    expect(screen.getByTestId("chat-maximize-restore-zone")).toBeTruthy();
   });
 
-  it("does not bind the swipe gesture while the sheet is collapsed", () => {
-    const { controller, onSelect } = makeSwipeController();
+  it("a downward pull in the top-20% restore zone exits full-bleed back to the overlay (not a full collapse)", () => {
+    const { controller } = makeSwipeController();
     render(<ContinuousChatOverlay controller={controller} />);
+    const sheet = screen.getByTestId("chat-sheet");
+    bigPullUp();
+    expect(sheet.getAttribute("data-maximized")).toBe("true");
 
-    // No openSheet(): the transcript target is not mounted while collapsed, so
-    // there is nothing to bind and no hidden layer can catch a swipe.
-    expect(document.getElementById("continuous-thread")).toBeNull();
-    expect(onSelect).not.toHaveBeenCalled();
+    const zone = screen.getByTestId("chat-maximize-restore-zone");
+    // A committed downward pull starting in the top-20% zone.
+    fireEvent.pointerDown(zone, { clientY: 20, pointerId: 8 });
+    fireEvent.pointerMove(zone, { clientY: 200, pointerId: 8 });
+    fireEvent.pointerUp(zone, { clientY: 320, pointerId: 8 });
+
+    // Back to the inset overlay: no longer maximized, but the sheet stays OPEN
+    // (the thread didn't collapse to the input).
+    expect(sheet.getAttribute("data-maximized")).toBeNull();
+    expect(sheet.getAttribute("data-variant")).toBe("open");
   });
 
-  it("still navigates (no crash) when swiping while the thread is loading/empty", () => {
-    // The exact reported state: after a reset the thread is empty and the
-    // loading spinner is up, and the user "thumbs back and forth". The swipe
-    // must stay bound and select the adjacent conversation instead of throwing.
-    const onSelect = vi.fn<(id: string) => void>();
-    const conversationNav = buildConversationNav(CONVERSATIONS, "b", onSelect);
-    const make = (over: Partial<ShellController>) =>
-      makeController({
-        conversationNav,
-        ...over,
-      } as unknown as Partial<ShellController>);
+  it("keyboard-activates the restore zone (ArrowDown exits full-bleed)", () => {
+    const { controller } = makeSwipeController();
+    render(<ContinuousChatOverlay controller={controller} />);
+    const sheet = screen.getByTestId("chat-sheet");
+    bigPullUp();
+    expect(sheet.getAttribute("data-maximized")).toBe("true");
 
-    const { rerender } = render(
-      <ContinuousChatOverlay controller={make({})} />,
-    );
-    openSheet(); // opens into the (present) default thread
+    fireEvent.keyDown(screen.getByTestId("chat-maximize-restore-zone"), {
+      key: "ArrowDown",
+    });
+    expect(sheet.getAttribute("data-maximized")).toBeNull();
+    expect(sheet.getAttribute("data-variant")).toBe("open");
+  });
 
-    // Conversation cleared, a fresh one loading: empty thread + spinner.
-    rerender(
-      <ContinuousChatOverlay
-        controller={make({
-          messages: [],
-          conversationLoading: true,
-        })}
-      />,
-    );
-    expect(screen.getByTestId("chat-thread-loading")).toBeTruthy();
+  it("Escape from maximized collapses the whole sheet (not just restore)", () => {
+    const { controller } = makeSwipeController();
+    render(<ContinuousChatOverlay controller={controller} />);
+    const sheet = screen.getByTestId("chat-sheet");
+    bigPullUp();
+    expect(sheet.getAttribute("data-maximized")).toBe("true");
 
-    const el = thread();
-    fireEvent.pointerDown(el, { clientX: 300, clientY: 300, pointerId: 6 });
-    fireEvent.pointerMove(el, { clientX: 280, clientY: 302, pointerId: 6 });
-    fireEvent.pointerUp(el, { clientX: 180, clientY: 302, pointerId: 6 });
-
-    expect(onSelect).toHaveBeenCalledExactlyOnceWith("c");
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(sheet.getAttribute("data-maximized")).toBeNull();
+    expect(sheet.getAttribute("data-variant")).toBe("closed");
   });
 });
 

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -8,9 +8,7 @@ import {
   Film,
   LayoutGrid,
   Loader2,
-  Maximize2,
   Mic,
-  Minimize2,
   Music,
   RotateCcw,
   SendHorizontal,
@@ -56,7 +54,6 @@ import {
   sqrtRubberBand,
   useRafCoalescer,
 } from "../../gestures";
-import { useConversationSwipeJank } from "../../hooks/useConversationSwipeJank";
 import {
   LAYOUT_SHIFT_INTENT_ATTR,
   LAYOUT_SHIFT_INTENT_TRANSIENT,
@@ -197,6 +194,20 @@ export type ChatMode = "pill" | "input" | "half" | "full";
 type MotionControls = { stop: () => void };
 
 const SHEET_HALF_VH = 0.46; // fraction of viewport height at the HALF detent
+// Pull-to-maximize threshold (#13531). The FULL detent already rises to just
+// under the status bar (`openH` ≈ 0.9×viewportH, an INSET sheet with side margins
+// and a top gap); "maximize" is the edge-to-edge variant. The product spec is
+// "pull up past 80% of viewport height" — since FULL already exceeds that, the
+// faithful, unambiguous trigger is an OVER-pull whose peak raw (pre-clamp) pull
+// height clears max(0.8×viewportH, FULL) by this margin. In practice a pull that
+// pushes the sheet meaningfully past the FULL detent into the rubber-band zone
+// commits to full-bleed. A plain rest AT full never trips it (the margin gates
+// it above openH).
+const MAXIMIZE_OVERPULL_PX = 56;
+// Restore-from-maximized grab zone (#13531): while full-bleed, a downward pull
+// that STARTS within this fraction of the panel height from the top animates
+// back to the inset overlay. 0.2 = the "top 20%" per the product spec.
+const MAXIMIZE_RESTORE_ZONE_VH = 0.2;
 // The panel's top clearance + max height (which decide where the header buttons
 // land relative to the notch) live in the pure, unit-tested
 // `resolveChatPanelLayout` — see chat-panel-layout.ts.
@@ -367,7 +378,7 @@ function HeaderButton({
   disabled,
   testId,
 }: {
-  icon: typeof Maximize2;
+  icon: typeof LayoutGrid;
   label: string;
   onClick: () => void;
   active?: boolean;
@@ -402,34 +413,6 @@ function HeaderButton({
   );
 }
 
-/** Horizontal travel (px) at which a conversation-swipe edge hint is fully lit. */
-const SWIPE_HINT_FULL = 96;
-
-/**
- * Follow-the-finger conversation rail (#8929 tracking fix). While a horizontal
- * swipe is in progress the transcript content translates with the finger (rather
- * than the old edge-glow-only affordance, which never moved the content and read
- * as "broken" / non-native). The live drag is rubber-band-damped past the edges
- * of what the drag can commit, so the pull always feels attached but resists.
- */
-/** Fraction of raw finger travel the content actually translates by. Slightly
- *  under 1 gives the neighbour a touch of parallax lead (the edge hint sits
- *  ahead of the content), so the rail reads as revealing a neighbour, not just
- *  sliding the current thread. */
-const SWIPE_RAIL_TRACK_RATIO = 0.92;
-/** Extra damping applied to the portion of a drag that heads toward an edge with
- *  no neighbour to commit to (first/last conversation) — the content still gives
- *  a little so the gesture feels alive, but resists to signal the dead end. */
-const SWIPE_RAIL_EDGE_RESISTANCE = 0.32;
-/** Spring used to settle the rail back to rest (or animate the committed side
- *  out) on release. Snappy but not brittle — mirrors the iOS pager feel. */
-const SWIPE_RAIL_SPRING = {
-  type: "spring",
-  stiffness: 520,
-  damping: 44,
-  mass: 1,
-} as const;
-
 /** Inert conversation-nav fallback for minimal mock controllers. */
 const EMPTY_CONVERSATION_NAV: ConversationNav = {
   hasPrev: false,
@@ -439,38 +422,6 @@ const EMPTY_CONVERSATION_NAV: ConversationNav = {
   activeId: null,
   index: -1,
 };
-
-/**
- * A soft glass glow on the sheet edge the next/previous conversation will slide
- * in from during a horizontal swipe (#8929). Brightens with the drag distance;
- * inert and non-interactive.
- */
-function SwipeEdgeHint({
-  side,
-  active,
-  amount,
-}: {
-  side: "left" | "right";
-  active: boolean;
-  amount: number;
-}): React.JSX.Element | null {
-  if (!active) return null;
-  const opacity = Math.min(1, Math.max(0, amount) / SWIPE_HINT_FULL);
-  if (opacity <= 0) return null;
-  return (
-    <div
-      aria-hidden
-      data-testid={`conversation-swipe-hint-${side}`}
-      className={cn(
-        "pointer-events-none absolute inset-y-0 z-20 w-16",
-        side === "left"
-          ? "left-0 bg-gradient-to-r from-border-strong to-transparent"
-          : "right-0 bg-gradient-to-l from-border-strong to-transparent",
-      )}
-      style={{ opacity }}
-    />
-  );
-}
 
 /**
  * The drag handle at the top of the chat sheet — pull UP to open the history,
@@ -787,21 +738,6 @@ function ThreadLineText({ content }: { content: string }): React.ReactNode {
 }
 
 /**
- * True while there's a live (non-collapsed) text selection. The
- * conversation-swipe binding lives on the transcript surface, which contains
- * the selectable message bubbles — so a MOUSE drag to highlight bubble text
- * travels horizontally and otherwise reads as a swipe, navigating away and
- * destroying the selection on release. The swipe handlers consult this to skip
- * navigation when the gesture was really a highlight, mirroring the ThreadLine
- * tap-reveal guard (`window.getSelection()` non-collapsed). Touch drags don't
- * create a selection, so a genuine finger swipe is unaffected.
- */
-function hasLiveTextSelection(): boolean {
-  const sel = typeof window !== "undefined" ? window.getSelection() : null;
-  return !!sel && sel.toString().trim().length > 0;
-}
-
-/**
  * The overlay's message BODY — everything rendered inside the canonical
  * ChatMessage glass row: the no-provider recovery gate, the in-flight breathing
  * dots (TurnStatus), a user turn's slash-bolded text, and a settled assistant
@@ -1000,7 +936,6 @@ export function ContinuousChatOverlay({
     openSettings,
     navigateHome,
     currentTab,
-    clearConversation,
     stop,
     speak,
     stopSpeaking,
@@ -1028,128 +963,6 @@ export function ContinuousChatOverlay({
   // True while a clear/swipe is fetching an uncached thread — gates the empty
   // thread's loading spinner. Defaulted for minimal mock controllers.
   const conversationLoading = controller.conversationLoading ?? false;
-
-  // Horizontal swipe between conversations (#8929). `swipeDx` is the live
-  // horizontal drag (+left toward the next/older chat, -right toward the
-  // newer/previous chat) and drives the edge hint. The gesture defers pointer
-  // capture until a horizontal commit, so vertical thread scrolling is
-  // unaffected; it is only bound while the sheet is open (below).
-  const [swipeDx, setSwipeDx] = React.useState(0);
-  // Frame-budget telemetry scoped to the swipe gesture (#9954): begin sampling
-  // on the first live drag and flush a dropped-frame/p95/fps summary into the
-  // telemetry ring on release, so swipe jank is observable without the dev HUD.
-  const swipeJank = useConversationSwipeJank();
-
-  // Follow-the-finger rail (#8929 tracking fix). `railX` is the live horizontal
-  // translate (px) of the transcript content — driven straight off the gesture's
-  // live drag so the content tracks the pointer instead of only lighting an edge
-  // glow. It's a MotionValue (not React state) so a per-frame drag writes to the
-  // compositor without a re-render; React state (`swipeDx`) is kept in parallel
-  // only for the (cheap, already-existing) edge-hint + jank telemetry.
-  const railX = useMotionValue(0);
-  // Reads used inside the gesture callbacks are funnelled through refs so the
-  // (stable) callback closures never go stale on a conversationNav / reduce
-  // change — `conversationSwipe` is memo-free but the gesture engine holds these
-  // handlers across a drag, so a mid-drag prop change must still be visible.
-  const railReduceRef = React.useRef(false);
-  const railHasNextRef = React.useRef(false);
-  const railHasPrevRef = React.useRef(false);
-  railHasNextRef.current = conversationNav.hasNext;
-  railHasPrevRef.current = conversationNav.hasPrev;
-  // Stop any in-flight settle spring the previous gesture left running before a
-  // fresh drag grabs the rail, so a new touch takes over from where it sits.
-  const railSettleRef = React.useRef<{ stop: () => void } | null>(null);
-  const stopRailSettle = React.useCallback(() => {
-    railSettleRef.current?.stop();
-    railSettleRef.current = null;
-  }, []);
-  // Spring the rail back to rest (0). Under reduced motion it jumps instantly so
-  // the follow-the-finger animation never fights the OS setting — this is the
-  // reduced-motion fallback for the settle (the drag itself already no-ops the
-  // translate when reduced, see the onDragX guard below).
-  const settleRailHome = React.useCallback(() => {
-    stopRailSettle();
-    if (railReduceRef.current) {
-      railX.set(0);
-      return;
-    }
-    railSettleRef.current = animate(railX, 0, SWIPE_RAIL_SPRING);
-  }, [railX, stopRailSettle]);
-
-  const conversationSwipe = usePullGesture({
-    // The transcript is BOTH this horizontal swipe surface and the native
-    // vertical scroller. Bias axis-commit toward vertical so a thumb SCROLL is
-    // never captured as a conversation swipe and blocked from scrolling on real
-    // mobile web (#chat-scroll-web); a deliberate horizontal flick still
-    // navigates via the unchanged release-time recognition.
-    verticalScrollPriority: true,
-    onDragX: (dx) => {
-      // A non-zero offset means the gesture is actively dragging; 0 is the
-      // settle/cancel reset the gesture emits on release. `begin` is idempotent,
-      // so calling it every frame only starts one sampling window per gesture.
-      if (dx !== 0) swipeJank.begin();
-      else swipeJank.end();
-      setSwipeDx(dx);
-      // Follow-the-finger: translate the transcript with the drag. `dx` is
-      // positive dragging LEFT (toward the next/older chat), so the content
-      // moves LEFT (negative translateX) to reveal the right neighbour. Under
-      // reduced motion the content stays put (the edge hint alone signals the
-      // pending nav — the reduced-motion fallback), matching the prior behaviour.
-      if (railReduceRef.current) return;
-      if (dx === 0) {
-        // The gesture's own settle/cancel reset — spring home rather than snap,
-        // unless a commit handler is about to drive the rail itself.
-        settleRailHome();
-        return;
-      }
-      stopRailSettle();
-      // Damp the portion of the drag that has no neighbour to commit to so the
-      // first/last conversation resists instead of sliding into a blank void.
-      const canGo = dx > 0 ? railHasNextRef.current : railHasPrevRef.current;
-      const tracked = canGo
-        ? dx * SWIPE_RAIL_TRACK_RATIO
-        : dx * SWIPE_RAIL_EDGE_RESISTANCE;
-      railX.set(-tracked);
-    },
-    onSwipeLeft: () => {
-      setSwipeDx(0);
-      // A mouse highlight drag inside a bubble finishes here too; never switch
-      // the conversation out from under a live text selection (destroying it).
-      // Mirrors the ThreadLine tap-reveal selection guard.
-      if (hasLiveTextSelection()) {
-        swipeJank.end();
-        settleRailHome();
-        return;
-      }
-      // Tag the flushed window with the committed direction so the ring shows
-      // which way a janky swipe went (left → "next", the older conversation).
-      swipeJank.end("next");
-      // Settle the rail home while the controller swaps in the neighbour's
-      // content underneath (the transcript re-renders with the new thread and
-      // cross-fades in via threadContentOpacity) — a native pager settles the
-      // committed page in; without the neighbour pre-rendered, springing home as
-      // the content swaps reads the same without a blank frame.
-      settleRailHome();
-      conversationNav.goNext();
-    },
-    onSwipeRight: () => {
-      setSwipeDx(0);
-      if (hasLiveTextSelection()) {
-        swipeJank.end();
-        settleRailHome();
-        return;
-      }
-      swipeJank.end("prev");
-      settleRailHome();
-      conversationNav.goPrev();
-    },
-    onCancel: () => {
-      // pointercancel / lost-capture with no committed swipe — bring the rail
-      // back to rest so a half-dragged transcript never sticks off-centre.
-      setSwipeDx(0);
-      settleRailHome();
-    },
-  });
 
   // Copy a message (reveal-row Copy). Stable identity so the memoized row isn't
   // re-rendered every parent tick.
@@ -1256,10 +1069,6 @@ export function ContinuousChatOverlay({
   // Honor the OS "reduce motion" setting: every overlay animation collapses to
   // a near-instant cross-fade with no positional movement when this is true.
   const reduce = useReducedMotion() ?? false;
-  // Keep the follow-the-finger rail's reduced-motion read current for the
-  // gesture callbacks (which capture a ref, not `reduce` directly, so a mid-drag
-  // OS-setting toggle takes effect and the callback identity stays stable).
-  railReduceRef.current = reduce;
 
   // The composer draft + pending attachments are the SHARED ChatComposerContext
   // slot (one draft per active conversation, edited by every surface): under
@@ -1439,6 +1248,13 @@ export function ContinuousChatOverlay({
   // the morph keeps the pill↔input crossfade from stranding both bars visible.
   const settleDragRef = React.useRef<(() => void) | null>(null);
   const draggingRef = React.useRef(false);
+  // Peak RAW (pre-clamp) pull height reached during the current upward drag
+  // (#13531). The visible `threadHeight` is rubber-band-clamped at `openH`, so a
+  // deliberate over-pull past FULL is invisible to a `threadHeight.get()` read on
+  // release. This ref records the true finger height each frame so the release
+  // path can tell an over-pull past the 80%-viewport maximize threshold from a
+  // plain release at FULL. Reset to 0 at the start of every gesture.
+  const maxPullRawRef = React.useRef(0);
   // At rest the collapsed composer should not carry hidden transcript/header
   // DOM. During an upward pull, though, the sheet needs a mounted body so the
   // MotionValue-driven height can follow the finger before the release commits
@@ -2365,17 +2181,13 @@ export function ContinuousChatOverlay({
     [closeSheet, maximized, reduce],
   );
 
-  // Maximize toggle. Maximizing from ANY open detent (half or a free rest) first
-  // rises to the FULL detent, then drops the inset — so the height spring
-  // animates up and the panel goes edge-to-edge in one gesture (previously
-  // full-bleed required `expanded`, so tapping maximize at the half detent did
-  // nothing). Un-maximizing drops back to the inset FULL detent.
-  const toggleMaximize = React.useCallback(() => {
-    if (maximized) {
-      stopThreadAnimation();
-      setMaximized(false);
-      return;
-    }
+  // Maximize via a vertical PULL, not a button (#13531). A pull-up that crosses
+  // the 80%-of-viewport threshold rises to the FULL detent and drops the inset,
+  // so the panel goes edge-to-edge in one continuous gesture. The button-only
+  // `toggleMaximize` is gone; this is the single entry into full-bleed and is
+  // called from the pull-gesture release path (maybeMaximizeOnRelease) once the
+  // peak raw pull clears the maximize threshold (see MAXIMIZE_OVERPULL_PX).
+  const maximizeFromPull = React.useCallback(() => {
     // Snap the morph fully open BEFORE flipping to full-bleed so no in-flight
     // pill-open spring can leak a sub-1 scale into the maximized frame (top gap).
     draggingRef.current = false;
@@ -2385,7 +2197,22 @@ export function ContinuousChatOverlay({
     setFreeH(null);
     setMode("full");
     setMaximized(true);
-  }, [maximized, openProgress, stopThreadAnimation, stopOpenProgressAnimation]);
+    detentHaptic();
+  }, [openProgress, stopThreadAnimation, stopOpenProgressAnimation]);
+
+  // Restore OUT of full-bleed back to the inset FULL-detent overlay (#13531).
+  // Driven by a downward pull that starts in the top 20% of the maximized panel
+  // (the top-20% grab zone below); it drops full-bleed but keeps the thread open
+  // at the FULL detent, so it reads as shrinking the edge-to-edge view back into
+  // the overlay chat rather than collapsing the whole sheet (Escape/back still
+  // collapse to the input).
+  const restoreFromMaximized = React.useCallback(() => {
+    draggingRef.current = false;
+    stopThreadAnimation();
+    setMaximized(false);
+    setMode("full");
+    detentHaptic();
+  }, [stopThreadAnimation]);
 
   // The single detent→detent animator: whenever the settled detent (or viewport)
   // changes and we're not mid finger-drag, spring the history height to it. The
@@ -2913,11 +2740,14 @@ export function ContinuousChatOverlay({
         navigateTab: slash.navigateTab,
         navigateSettings: slash.navigateSettings,
         navigateView: slash.navigateView,
-        clearChat: slash.clearChat,
-        newConversation: () => controller.clearConversation(),
-        // The overlay owns full-screen via the `maximized` detent flag, not a
-        // controller method, so toggle it directly here.
-        toggleFullscreen: toggleMaximize,
+        // One infinite thread (#13531): the overlay no longer resets/switches
+        // conversations (clear-chat / new-conversation) or toggles full-screen
+        // via a command — maximize is a vertical pull now. These slash paths are
+        // inert in the overlay; the shared subsystem plumbing (first-run/wipe/
+        // switch, CommandPalette, TUI) is untouched and handled elsewhere.
+        clearChat: () => {},
+        newConversation: () => {},
+        toggleFullscreen: () => {},
         openCommandPalette: openPaletteCollapsed,
         showCommands: openPaletteCollapsed,
         toggleTranscription: toggleTranscriptionMode,
@@ -2929,15 +2759,7 @@ export function ContinuousChatOverlay({
         inputRef.current?.focus();
       }
     },
-    [
-      slash,
-      controller,
-      submitText,
-      setDraft,
-      toggleMaximize,
-      toggleTranscriptionMode,
-      collapse,
-    ],
+    [slash, submitText, setDraft, toggleTranscriptionMode, collapse],
   );
 
   const submit = React.useCallback(() => {
@@ -3305,6 +3127,8 @@ export function ContinuousChatOverlay({
       if (!draggingRef.current) {
         stopThreadAnimation();
         stopOpenProgressAnimation();
+        // Fresh gesture: reset the peak raw-pull tracker (#13531).
+        maxPullRawRef.current = 0;
       }
       draggingRef.current = true;
       // PILL drag: map the upward travel to the pill→input morph (openProgress).
@@ -3343,6 +3167,13 @@ export function ContinuousChatOverlay({
         : expanded
           ? Math.min(0, offset)
           : offset;
+      // Record the TRUE upward finger travel (pre-clamp AND pre-pin) so the
+      // release path can detect an over-pull past the maximize threshold even
+      // from the FULL detent, where the visible height is pinned (off is clamped
+      // to <=0 above) and the rendered height rubber-bands at openH (#13531). A
+      // pull DOWN (offset<0) never advances the maximize tracker.
+      const rawUpH = baseH + Math.max(0, offset);
+      if (rawUpH > maxPullRawRef.current) maxPullRawRef.current = rawUpH;
       threadHeight.set(clampHeight(baseH + off));
     },
     [
@@ -3360,6 +3191,26 @@ export function ContinuousChatOverlay({
       setDragPreviewMounted,
     ],
   );
+
+  // Pull-to-maximize decision (#13531): a released upward pull whose PEAK raw
+  // upward travel (maxPullRawRef, pre-clamp/pre-pin) cleared the maximize
+  // threshold commits to edge-to-edge full-bleed. The threshold is the greater
+  // of "80% of viewport height" (the product spec) and the FULL detent height
+  // (openH ≈ 0.9×viewportH, already inset-full), plus an over-pull margin — so a
+  // plain release AT full never trips it, only a deliberate over-pull past full
+  // does. Returns true when it took over the release so the caller skips its
+  // normal detent settle. Onboarding never maximizes (the sheet is pinned FULL
+  // and undismissable).
+  const maybeMaximizeOnRelease = React.useCallback((): boolean => {
+    if (firstRunOpen) return false;
+    const threshold = Math.max(viewportH * 0.8, openH) + MAXIMIZE_OVERPULL_PX;
+    if (maxPullRawRef.current >= threshold) {
+      focusThreadRef.current = true;
+      maximizeFromPull();
+      return true;
+    }
+    return false;
+  }, [firstRunOpen, viewportH, openH, maximizeFromPull]);
 
   const pullBinding: PullGestureBinding = usePullGesture({
     onDrag: onDragOffset,
@@ -3399,6 +3250,9 @@ export function ContinuousChatOverlay({
         }
         return;
       }
+      // Over-pull past the 80%-viewport threshold maximizes from ANY open state
+      // (#13531) — this must win before the per-state detent settle below.
+      if (maybeMaximizeOnRelease()) return;
       if (!sheetOpen) {
         if (!hasRevealableThread) return settleDrag();
         const releasedH = Math.max(0, Math.min(threadHeight.get(), panelMaxH));
@@ -3500,6 +3354,10 @@ export function ContinuousChatOverlay({
         }
         return;
       }
+      // A slow over-pull past the 80%-viewport threshold maximizes (#13531),
+      // even though the visible height rubber-banded at FULL — the peak raw pull
+      // (maxPullRawRef) carries the intent. Must win before detent magnetism.
+      if (maybeMaximizeOnRelease()) return;
       const h = Math.max(0, Math.min(threadHeight.get(), panelMaxH));
       // DETENT MAGNETISM — the resting positions are the detents {collapsed:0,
       // half, full}; a release within SHEET_DETENT_MAGNET of one snaps to it
@@ -3526,6 +3384,30 @@ export function ContinuousChatOverlay({
         setMode("half");
         setMaximized(false);
       }
+    },
+  });
+
+  // Top-20% pull-down-to-restore (#13531). While maximized (full-bleed) there is
+  // no SheetGrabber; this binding drives an invisible grab strip over the top
+  // 20% of the panel. A downward pull/flick that STARTS in that zone animates
+  // back to the inset FULL-detent overlay (restoreFromMaximized) rather than
+  // collapsing the whole sheet — Escape / Android-back still fully collapse. A
+  // pull UP or a tap in the zone is a no-op (it stays maximized); only a
+  // committed downward gesture restores. Onboarding pins the sheet, so the zone
+  // is inert there (it is only rendered under `fullBleed`, never during
+  // first-run, but guard anyway for safety).
+  const restoreFromMaximizedGuarded = React.useCallback(() => {
+    if (firstRunOpen) return;
+    restoreFromMaximized();
+  }, [firstRunOpen, restoreFromMaximized]);
+  const maximizeRestoreBinding: PullGestureBinding = usePullGesture({
+    // No horizontal nav on the maximize grab strip.
+    swipeEnabled: false,
+    onPullDown: restoreFromMaximizedGuarded,
+    // A slow drag DOWN released past the tap slop also restores; up/stationary
+    // keeps the maximized view.
+    onSettleFree: (direction) => {
+      if (direction === "down") restoreFromMaximizedGuarded();
     },
   });
 
@@ -3950,22 +3832,6 @@ export function ContinuousChatOverlay({
               }
             }}
           >
-            {/* Conversation-swipe edge hints (#8929): glow the edge the next /
-                previous conversation will slide in from as the user drags. */}
-            {sheetOpen ? (
-              <>
-                <SwipeEdgeHint
-                  side="left"
-                  active={swipeDx < 0 && conversationNav.hasPrev}
-                  amount={-swipeDx}
-                />
-                <SwipeEdgeHint
-                  side="right"
-                  active={swipeDx > 0 && conversationNav.hasNext}
-                  amount={swipeDx}
-                />
-              </>
-            ) : null}
             {/* Specular sheen — a soft light from the top edge, the liquid-glass
             highlight. Subtle + non-interactive. */}
             <div
@@ -3973,12 +3839,42 @@ export function ContinuousChatOverlay({
               className="pointer-events-none absolute inset-x-0 top-0 z-0 h-20 bg-gradient-to-b from-surface to-transparent"
             />
 
+            {/* Top-20% pull-down-to-restore grab zone (#13531). Only mounted
+                while maximized (full-bleed) — where the SheetGrabber isn't
+                rendered — so a downward pull starting in the top 20% animates
+                the edge-to-edge view back into the inset overlay. `z-10` sits
+                UNDER the header (`z-20`) so the launcher button keeps its taps;
+                this strip catches pulls on the surrounding empty header space.
+                Keyboard-operable (Enter/Space/ArrowDown restore) so the
+                gesture-only affordance stays WCAG 2.1.1 operable. */}
+            {fullBleed ? (
+              <button
+                {...maximizeRestoreBinding}
+                type="button"
+                data-testid="chat-maximize-restore-zone"
+                aria-label="drag down to exit full screen"
+                onKeyDown={(e) => {
+                  if (
+                    e.key === "Enter" ||
+                    e.key === " " ||
+                    e.key === "ArrowDown"
+                  ) {
+                    e.preventDefault();
+                    restoreFromMaximizedGuarded();
+                  }
+                }}
+                className="pointer-events-auto absolute inset-x-0 top-0 z-10 touch-none bg-transparent"
+                style={{ height: `${MAXIMIZE_RESTORE_ZONE_VH * 100}%` }}
+              />
+            ) : null}
+
             {/* Sheet header — shown at the HALF detent and up (not just FULL).
-              Left: Maximize (toggle edge-to-edge full-screen) + Clear (reset to
-              a fresh greeted thread, RotateCcw — it resets, it doesn't delete).
+              One infinite thread (#13531): no maximize/minimize (that's a
+              vertical pull now) and no clear/new-chat (the thread never resets).
               Right: one Launcher/Home launcher. Settings lives inside the
               Launcher grid, so the chat header stops acting like a second app
-              nav bar. */}
+              nav bar. The left slot is intentionally empty so the launcher
+              stays anchored right. */}
             {threadPresented ? (
               <motion.div
                 // Mounted while the sheet is open, or while an upward drag is
@@ -4010,24 +3906,9 @@ export function ContinuousChatOverlay({
                   "relative z-20 flex shrink-0 items-center justify-between gap-1.5 overflow-hidden px-3",
                 )}
               >
-                <div className="flex items-center gap-1.5">
-                  <HeaderButton
-                    icon={maximized ? Minimize2 : Maximize2}
-                    label={maximized ? "exit full screen" : "full screen"}
-                    active={maximized}
-                    onClick={toggleMaximize}
-                    testId="chat-full-maximize"
-                  />
-                  <HeaderButton
-                    icon={RotateCcw}
-                    label="clear conversation"
-                    // Clearing mid-onboarding would wipe the seeded first-run
-                    // choices and strand the flow — inert until it completes.
-                    disabled={firstRunOpen}
-                    onClick={() => clearConversation()}
-                    testId="chat-full-clear"
-                  />
-                </div>
+                {/* Empty left slot: keeps the launcher pinned to the right now
+                    that maximize/clear were removed (#13531). */}
+                <div className="flex items-center gap-1.5" />
                 {transcriptionMode ? (
                   <div
                     data-testid="chat-transcribing-badge"
@@ -4103,11 +3984,6 @@ export function ContinuousChatOverlay({
                       collapse();
                     }
                   }}
-                  // Horizontal-swipe navigation between conversations, sheet-open
-                  // only (#8929). Deferred capture keeps vertical scroll native.
-                  // Gated during onboarding so a swipe can't leave the seeded
-                  // first-run transcript.
-                  {...(sheetOpen && !firstRunOpen ? conversationSwipe : {})}
                   // `flex-1 min-h-0` (not `h-full`): as the single child of the
                   // flex-column thread above, the scroller fills the parent's
                   // BOUNDED height via the flex algorithm — a resolution that is
@@ -4151,18 +4027,9 @@ export function ContinuousChatOverlay({
                   until the thread overflows, then it scrolls. The ref measures
                   this content so onboarding can size the sheet to it (grow from
                   the bottom). */}
-                  <motion.div
+                  <div
                     ref={threadContentRef}
                     className="mt-auto flex flex-col pb-3 pt-1"
-                    // Follow-the-finger rail (#8929): the transcript content
-                    // tracks the horizontal swipe live (railX, px) and
-                    // spring-settles home on release. Transform-only (compositor,
-                    // no layout thrash); the scroll container + mask above stay
-                    // put so vertical scroll and the top fade are untouched. Under
-                    // reduced motion railX is never written (stays 0), so this is
-                    // an inert identity transform — the edge hint alone signals the
-                    // pending nav (the reduced-motion fallback).
-                    style={{ x: railX }}
                   >
                     {hasTopics
                       ? // Topic-grouped transcript: each cluster collapses via a
@@ -4224,7 +4091,7 @@ export function ContinuousChatOverlay({
                         />
                       ) : null}
                     </AnimatePresence>
-                  </motion.div>
+                  </div>
                 </motion.div>
               </motion.div>
             ) : null}


### PR DESCRIPTION
## What & why

Makes `ContinuousChatOverlay` match product intent: **one continuous thread**, no chat switching, no reset, pure vertical-pull expand/collapse. Closes the surface gaps called out in #13531 (part of the chat-redesign epic #13539).

## Shipped

**No chat-to-chat horizontal swipe.** Removed `conversationSwipe` (the `usePullGesture` swipe binding on the transcript), the `swipeDx`/`railX` follow-the-finger rail + `useConversationSwipeJank` wiring, `SwipeEdgeHint` + its render sites, `SWIPE_HINT_FULL`/`SWIPE_RAIL_*`, `hasLiveTextSelection`, and the swipe spread on `#continuous-thread`. The collapsed-composer home↔launcher swipe is untouched (separate binding).

**No new-chat / reset.** Removed the RotateCcw "Clear" header button. The overlay's `new-conversation`/`clear-chat` slash executions are now inert (no-op deps into the shared `runSlashExecution`).

**Maximize via gesture, not a button.** Removed the Maximize/Minimize header button and the overlay's `toggle-fullscreen` slash path. Maximize is now a **big upward over-pull**: `maybeMaximizeOnRelease` fires `maximizeFromPull` when the peak raw pull clears `max(0.8×viewportH, FULL) + MAXIMIZE_OVERPULL_PX`. Peak raw (pre-clamp/pre-pin) pull is tracked in `maxPullRawRef` so an over-pull registers even from the FULL detent where the visible height rubber-bands.

**Top-20% pull-down to restore.** New `chat-maximize-restore-zone` grab strip, rendered only while full-bleed (where `SheetGrabber` is unrendered). A downward pull/flick — or ArrowDown/Enter/Space for a11y — starting in the top 20% animates back to the inset FULL overlay via `restoreFromMaximized`. Escape / Android-back still fully collapse to the input.

## Scope / coordination

Per the issue's **Open decision**, this is the P0 overlay button/swipe removal. The multi-conversation subsystem (`handleNewConversation`, `ConversationsSidebar`, `use-conversation-reset`, `useConversationSwipeJank.ts`, conversation-swipe e2e/perf-gate fixtures) is intentionally **left intact** — its deprecation is the explicit follow-up, and the shared `handleNewConversation`/reset plumbing is still used by first-run/wipe/switch. `conversationNav.activeId`/`index` are still surfaced on the sheet DOM (tutorial observes them).

**Cross-scope needs flagged** (siblings on the same file — not touched here):
- Lane 13532 (transcript loading/scroll, perf-gate): the standalone `run-conversation-swipe-e2e.mjs` + `perf-gate` fixtures still drive a conversation swipe that no longer exists in the overlay. They should be retired/retargeted alongside the subsystem follow-up.
- `packages/app-core/.../GestureSemanticsUITests.swift` (iOS): still references the old maximize/swipe semantics; update on the native lane.
- `ContinuousChatOverlay.stories.tsx` keeps a demo `clear-chat` slash entry (inert in the overlay now) — harmless, left for the subsystem follow-up.

## Verification

- `packages/ui` overlay unit suite reworked: swipe removal asserted (no nav, no edge hint), new maximize/restore state-machine tests (pull-up→MAXIMIZED, top-20% pull-down→FULL, ArrowDown restore, Escape full-collapse), no maximize/clear header buttons.
- Slash suite retargeted off `clear-chat` (now asserts `/clear` is inert) onto a still-live client action.
- Gesture **fuzz** matrix drives maximize/restore via pulls (state×action + 150-step random walks) — 125 green.
- `tsgo` clean, `biome` clean, `chat-gesture-coverage` gate green.

Screenshots + video walkthrough + `audit:app` per PR_EVIDENCE.md to follow on the L3/ui-smoke lane.

Refs #13531, epic #13539. — [sol-orch]