### PR TITLE
fix(dev): repair observability probes

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "dev:ui": "ELIZA_DEV_SOURCE=1 bun --conditions=eliza-source packages/app-core/scripts/dev-ui.mjs --name=eliza --app=app --ui-only",
     "dev:desktop": "ELIZA_DEV_SOURCE=1 ELIZA_NAMESPACE=eliza bun --conditions=eliza-source packages/app-core/scripts/dev-platform.mjs",
     "dev:desktop:watch": "ELIZA_DEV_SOURCE=1 ELIZA_NAMESPACE=eliza ELIZA_DESKTOP_VITE_WATCH=1 bun --conditions=eliza-source packages/app-core/scripts/dev-platform.mjs",
+    "desktop:stack-status": "bun --conditions=eliza-source packages/app-core/scripts/desktop-stack-status.mjs",
     "dev:harness": "bun packages/scripts/dev-harness.mjs",
     "dev:all": "node packages/scripts/dev-all.mjs",
     "voice:matrix": "node packages/scripts/voice-matrix.mjs",

--- a/packages/agent/src/runtime/boot-telemetry.test.ts
+++ b/packages/agent/src/runtime/boot-telemetry.test.ts
@@ -14,6 +14,9 @@ import type { BootSummary } from "./boot-timer.ts";
 
 const ENV_KEYS = [
   "ELIZA_DISABLE_TELEMETRY",
+  "ELIZA_DESKTOP_API_WATCH",
+  "ELIZA_DEV_NO_WATCH",
+  "ELIZA_DEV_SOURCE_WATCH",
   "ELIZA_STARTUP_TRACE_ID",
   "ELIZA_STATE_DIR",
   "NODE_ENV",
@@ -79,5 +82,32 @@ describe("boot telemetry startup trace id", () => {
 
     expect(bootLatest.traceId).toBe("android-trace-123");
     expect(restartEvents.at(-1)?.traceId).toBe("android-trace-123");
+  });
+
+  it("records the real dev watch state into restart telemetry", async () => {
+    process.env.ELIZA_DEV_NO_WATCH = "0";
+    await recordBootEvent("[test-no-watch]");
+
+    process.env.ELIZA_DESKTOP_API_WATCH = "1";
+    await recordBootEvent("[test-watch]");
+
+    if (!stateDir) {
+      throw new Error("stateDir was not initialized");
+    }
+    const restartEvents = JSON.parse(
+      await readFile(
+        path.join(stateDir, "telemetry", "restart", "events.json"),
+        "utf8",
+      ),
+    ) as Array<{ label: string; watch: boolean }>;
+
+    expect(restartEvents.at(-2)).toMatchObject({
+      label: "[test-no-watch]",
+      watch: false,
+    });
+    expect(restartEvents.at(-1)).toMatchObject({
+      label: "[test-watch]",
+      watch: true,
+    });
   });
 });

--- a/packages/agent/src/runtime/boot-telemetry.ts
+++ b/packages/agent/src/runtime/boot-telemetry.ts
@@ -16,6 +16,7 @@ import path from "node:path";
 import process from "node:process";
 
 import { logger } from "@elizaos/core";
+import { isDevApiWatchEnabled } from "@elizaos/shared/runtime-env";
 
 import { resolveStateDir } from "../config/paths.ts";
 import type { BootSummary } from "./boot-timer.ts";
@@ -167,7 +168,7 @@ interface BootEvent {
   pid: number;
   /** Supervisor spawn timestamp, when known (restart-correlation key). */
   spawnedAtMs: number | null;
-  /** True when the API runs under `node --watch` (ELIZA_DEV_NO_WATCH=0). */
+  /** True when the API is running under an active dev watcher. */
   watch: boolean;
   /** Short label, e.g. the BootTimer label. */
   label: string;
@@ -196,7 +197,7 @@ export async function recordBootEvent(label: string): Promise<void> {
     pid: process.pid,
     spawnedAtMs:
       Number.isFinite(spawnedAtMs) && spawnedAtMs > 0 ? spawnedAtMs : null,
-    watch: process.env.ELIZA_DEV_NO_WATCH === "0",
+    watch: isDevApiWatchEnabled(),
     label,
   };
 

--- a/packages/app-core/scripts/dev-platform.mjs
+++ b/packages/app-core/scripts/dev-platform.mjs
@@ -873,6 +873,7 @@ async function launch() {
   }
   console.log("");
 
+  const apiWatchEnabled = envFlagEnabled("ELIZA_DESKTOP_API_WATCH");
   const apiEnv = {
     NODE_ENV: "development",
     ELIZA_API_PORT: apiPort,
@@ -888,13 +889,13 @@ async function launch() {
     ELIZA_NAMESPACE: process.env.ELIZA_NAMESPACE ?? defaultElizaNamespace,
     ...(rendererUrlForShell ? { ELIZA_RENDERER_URL: rendererUrlForShell } : {}),
     ELIZA_DESKTOP_API_BASE: `http://127.0.0.1:${apiPort}`,
+    ELIZA_DESKTOP_API_WATCH: apiWatchEnabled ? "1" : "0",
     ...screenshotEnvApi,
     ...(desktopDevLogPath
       ? { ELIZA_DESKTOP_DEV_LOG_PATH: desktopDevLogPath }
       : {}),
     ...apiEmbeddingWarmupPolicy.env,
   };
-  const apiWatchEnabled = envFlagEnabled("ELIZA_DESKTOP_API_WATCH");
   // Runtime startup must never mutate dependencies. Optional plugin imports
   // should fail fast when a package is absent instead of letting Bun auto-install
   // transitive native packages inside the desktop app process.

--- a/packages/app-core/scripts/dev-ui.mjs
+++ b/packages/app-core/scripts/dev-ui.mjs
@@ -1256,6 +1256,7 @@ if (uiOnly) {
       ELIZA_API_PORT: String(API_PORT),
       ELIZA_UI_PORT: String(UI_PORT),
       ELIZA_PORT: String(UI_PORT),
+      ELIZA_DEV_SOURCE_WATCH: skipSourceWatch ? "0" : "1",
       ELIZA_HEADLESS: "1",
       ELIZA_DEV_AUTH_BYPASS: "1",
       // Defer the post-ready boot tail (app-route plugins, training hooks,

--- a/packages/app-core/scripts/lib/desktop-stack-status.mjs
+++ b/packages/app-core/scripts/lib/desktop-stack-status.mjs
@@ -8,9 +8,9 @@
  */
 
 import { createConnection } from "node:net";
+import { resolveDesktopApiPort } from "@elizaos/shared/runtime-env";
 
 const DEFAULT_UI_PORT = 2138;
-const DEFAULT_API_PORT = 2138;
 const CONNECT_TIMEOUT_MS = 800;
 const FETCH_TIMEOUT_MS = 2500;
 
@@ -20,14 +20,6 @@ function parsePositivePort(value) {
   return Number.isInteger(parsed) && parsed > 0 && parsed < 65536
     ? parsed
     : NaN;
-}
-
-function resolveDesktopApiPort(env) {
-  return (
-    parsePositivePort(env.ELIZA_API_PORT) ||
-    parsePositivePort(env.ELIZA_PORT) ||
-    DEFAULT_API_PORT
-  );
 }
 
 /**

--- a/packages/app-core/scripts/lib/desktop-stack-status.test.mjs
+++ b/packages/app-core/scripts/lib/desktop-stack-status.test.mjs
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { gatherDesktopStackStatus } from "./desktop-stack-status.mjs";
+
+function jsonResponse(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("gatherDesktopStackStatus", () => {
+  it("defaults the API probe to the canonical desktop API port", async () => {
+    const checkedPorts = [];
+    const fetchImpl = vi.fn(async (url) => {
+      if (String(url).endsWith("/api/dev/stack")) {
+        return jsonResponse(200, {
+          desktop: { uiPort: 2138, rendererUrl: null },
+        });
+      }
+      return jsonResponse(200, { state: "ready" });
+    });
+
+    const report = await gatherDesktopStackStatus({}, fetchImpl, {
+      isPortOpen: async (port) => {
+        checkedPorts.push(port);
+        return port === 31337;
+      },
+    });
+
+    expect(report.apiPort).toBe(31337);
+    expect(report.apiListening).toBe(true);
+    expect(checkedPorts).toContain(31337);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://127.0.0.1:31337/api/dev/stack",
+      expect.any(Object),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://127.0.0.1:31337/api/health",
+      expect.any(Object),
+    );
+  });
+
+  it("detects an API-only stack when Vite is stopped", async () => {
+    const fetchImpl = vi.fn(async (url) => {
+      if (String(url).endsWith("/api/dev/stack")) {
+        return jsonResponse(200, {
+          desktop: { uiPort: 2138, rendererUrl: null },
+        });
+      }
+      return jsonResponse(200, { state: "ready" });
+    });
+
+    const report = await gatherDesktopStackStatus({}, fetchImpl, {
+      isPortOpen: async (port) => port === 31337,
+    });
+
+    expect(report.apiPort).toBe(31337);
+    expect(report.apiListening).toBe(true);
+    expect(report.uiPort).toBe(2138);
+    expect(report.uiListening).toBe(false);
+    expect(report.apiHealth.ok).toBe(true);
+  });
+});

--- a/packages/app-core/src/api/dev-boot-history.test.ts
+++ b/packages/app-core/src/api/dev-boot-history.test.ts
@@ -62,4 +62,32 @@ describe("buildBootHistoryPayload — failed plugins", () => {
       await rm(stateDir, { recursive: true, force: true });
     }
   });
+
+  it("reports the real dev watch state from active watcher signals", async () => {
+    const stateDir = await mkdtemp(path.join(tmpdir(), "eliza-boot-history-"));
+    try {
+      await expect(
+        buildBootHistoryPayload({
+          ELIZA_STATE_DIR: stateDir,
+          ELIZA_DEV_NO_WATCH: "0",
+        } as NodeJS.ProcessEnv),
+      ).resolves.toMatchObject({ watch: false });
+
+      await expect(
+        buildBootHistoryPayload({
+          ELIZA_STATE_DIR: stateDir,
+          ELIZA_DESKTOP_API_WATCH: "1",
+        } as NodeJS.ProcessEnv),
+      ).resolves.toMatchObject({ watch: true });
+
+      await expect(
+        buildBootHistoryPayload({
+          ELIZA_STATE_DIR: stateDir,
+          ELIZA_DEV_SOURCE_WATCH: "1",
+        } as NodeJS.ProcessEnv),
+      ).resolves.toMatchObject({ watch: true });
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/app-core/src/api/dev-boot-history.ts
+++ b/packages/app-core/src/api/dev-boot-history.ts
@@ -19,6 +19,7 @@ import {
   getLastFailedPluginDetails,
 } from "@elizaos/agent";
 import { resolveStateDir } from "@elizaos/core";
+import { isDevApiWatchEnabled } from "@elizaos/shared/runtime-env";
 
 export const ELIZA_DEV_BOOT_HISTORY_SCHEMA = "elizaos.dev.boot-history/v1";
 
@@ -27,7 +28,7 @@ export interface BootHistoryPayload {
   generatedAtEpochMs: number;
   /** Spawn timestamp of the current API child — restart-correlation key. */
   currentSpawnAtMs: number | null;
-  /** True when the API runs under `node --watch` (ELIZA_DEV_NO_WATCH=0). */
+  /** True when the API is running under an active dev watcher. */
   watch: boolean;
   /** Latest completed boot record, or null if no boot has completed. */
   latestBoot: unknown;
@@ -74,14 +75,14 @@ export async function buildBootHistoryPayload(
     schema: ELIZA_DEV_BOOT_HISTORY_SCHEMA,
     generatedAtEpochMs: Date.now(),
     currentSpawnAtMs: Number.isFinite(spawnAt) && spawnAt > 0 ? spawnAt : null,
-    watch: env.ELIZA_DEV_NO_WATCH === "0",
+    watch: isDevApiWatchEnabled(env),
     latestBoot,
     memory,
     restarts,
     failedPlugins: getLastFailedPluginDetails(),
     hints: [
       "latestBoot===null means the runtime has not completed a boot since this process started (restart storm or hard crash) — check restarts and /api/dev/console-log.",
-      "watch===true means the API runs under node --watch; a concurrent workspace build (tsc/vite) can rewrite watched files and trigger a restart loop.",
+      "watch===true means the API is running under an active dev watcher (ELIZA_DESKTOP_API_WATCH, ELIZA_DEV_SOURCE_WATCH, or --watch); inspect restarts if source edits are bouncing the API.",
     ],
   };
 }

--- a/packages/app-core/src/api/dev-stack.test.ts
+++ b/packages/app-core/src/api/dev-stack.test.ts
@@ -1,0 +1,55 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveDevStackFromEnv } from "./dev-stack";
+
+const ENV_KEYS = ["ELIZA_STATE_DIR"] as const;
+
+let savedEnv: Record<(typeof ENV_KEYS)[number], string | undefined>;
+let stateDir: string | undefined;
+
+beforeEach(async () => {
+  savedEnv = Object.fromEntries(
+    ENV_KEYS.map((key) => [key, process.env[key]]),
+  ) as typeof savedEnv;
+  stateDir = await mkdtemp(path.join(tmpdir(), "eliza-dev-stack-"));
+  process.env.ELIZA_STATE_DIR = stateDir;
+});
+
+afterEach(async () => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  if (stateDir) {
+    await rm(stateDir, { recursive: true, force: true });
+    stateDir = undefined;
+  }
+});
+
+describe("resolveDevStackFromEnv", () => {
+  it("advertises the console-log tail only for allowed desktop dev log paths", () => {
+    if (!stateDir) throw new Error("stateDir was not initialized");
+
+    const allowedPath = path.join(stateDir, "desktop-dev-console.log");
+    expect(
+      resolveDevStackFromEnv({
+        ELIZA_DESKTOP_DEV_LOG_PATH: allowedPath,
+      }).desktopDevLog,
+    ).toEqual({
+      filePath: allowedPath,
+      apiTailPath: "/api/dev/console-log",
+    });
+
+    expect(
+      resolveDevStackFromEnv({
+        ELIZA_DESKTOP_DEV_LOG_PATH: path.join(stateDir, "secrets.log"),
+      }).desktopDevLog,
+    ).toEqual({
+      filePath: path.join(stateDir, "secrets.log"),
+      apiTailPath: null,
+    });
+  });
+});

--- a/packages/app-core/src/api/dev-stack.ts
+++ b/packages/app-core/src/api/dev-stack.ts
@@ -13,6 +13,7 @@
  */
 
 import { resolveDesktopApiPort, resolveDesktopUiPort } from "@elizaos/shared";
+import { isAllowedDevConsoleLogPath } from "./dev-console-log";
 
 export const ELIZA_DEV_STACK_SCHEMA = "elizaos.dev.stack/v1" as const;
 
@@ -63,7 +64,10 @@ export function resolveDevStackFromEnv(
   const desktopApiBase = env.ELIZA_DESKTOP_API_BASE?.trim() || null;
   const screenshotUpstream =
     env.ELIZA_ELECTROBUN_SCREENSHOT_URL?.trim() || null;
-  const devLogPath = env.ELIZA_DESKTOP_DEV_LOG_PATH?.trim() || null;
+  const configuredDevLogPath = env.ELIZA_DESKTOP_DEV_LOG_PATH?.trim() || null;
+  const devLogPathAllowed =
+    configuredDevLogPath !== null &&
+    isAllowedDevConsoleLogPath(configuredDevLogPath);
 
   return {
     schema: ELIZA_DEV_STACK_SCHEMA,
@@ -81,8 +85,8 @@ export function resolveDevStackFromEnv(
       path: screenshotUpstream ? "/api/dev/cursor-screenshot" : null,
     },
     desktopDevLog: {
-      filePath: devLogPath,
-      apiTailPath: devLogPath ? "/api/dev/console-log" : null,
+      filePath: configuredDevLogPath,
+      apiTailPath: devLogPathAllowed ? "/api/dev/console-log" : null,
     },
     hints: [
       'Electrobun also binds an ephemeral localhost port for its own RPC (see launcher logs: "Server started at http://localhost:…"). That channel is not this API.',
@@ -90,7 +94,7 @@ export function resolveDevStackFromEnv(
       "Full-screen PNG for agents: with desktop dev (screenshot server on by default), GET /api/dev/cursor-screenshot on the API (loopback). Capture uses OS screen APIs, not webview-only pixels.",
       "Aggregated vite/api/electrobun lines: GET /api/dev/console-log?maxLines=400&maxBytes=256000 (loopback) or read desktopDevLog.filePath.",
       "Voice-loop latency traces + per-stage p50/p90/p99 histograms: GET /api/dev/voice-latency?limit=50 (loopback), or `bun run --cwd packages/app-core voice:latency-report` for a printed table.",
-      "Boot phase timings, memory growth, and the exact error for any plugin that failed to load: GET /api/dev/boot-history (alias /api/dev/health, loopback). latestBoot:null = boot has not completed since process start (restart storm/crash); watch:true = API under node --watch.",
+      "Boot phase timings, memory growth, and the exact error for any plugin that failed to load: GET /api/dev/boot-history (alias /api/dev/health, loopback). latestBoot:null = boot has not completed since process start (restart storm/crash); watch:true = API is running under an active dev watcher.",
     ],
   };
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -110,6 +110,11 @@
     },
     "./runtime-env": {
       "types": "./dist/runtime-env.d.ts",
+      "eliza-source": {
+        "types": "./src/runtime-env.ts",
+        "import": "./src/runtime-env.ts",
+        "default": "./src/runtime-env.ts"
+      },
       "import": "./dist/runtime-env.js",
       "default": "./dist/runtime-env.js"
     },

--- a/packages/shared/src/runtime-env.test.ts
+++ b/packages/shared/src/runtime-env.test.ts
@@ -9,6 +9,7 @@ import { getBootConfig, setBootConfig } from "./config/boot-config";
 import {
   firstWinningEnvString,
   isAndroidMobile,
+  isDevApiWatchEnabled,
   isIosMobile,
   isLoopbackBindHost,
   isMobilePlatform,
@@ -74,6 +75,25 @@ describe("runtime env host security helpers", () => {
       "http://localhost:2138",
     ]);
     expect(config.allowedHosts).toEqual(["app.example", "localhost"]);
+  });
+});
+
+describe("dev API watch detection", () => {
+  it("detects node/bun --watch from exec argv", () => {
+    expect(isDevApiWatchEnabled({}, ["--watch"])).toBe(true);
+  });
+
+  it("detects desktop API watch and dev-ui source watcher env flags", () => {
+    expect(isDevApiWatchEnabled({ ELIZA_DESKTOP_API_WATCH: "1" }, [])).toBe(
+      true,
+    );
+    expect(isDevApiWatchEnabled({ ELIZA_DEV_SOURCE_WATCH: "1" }, [])).toBe(
+      true,
+    );
+  });
+
+  it("does not treat ELIZA_DEV_NO_WATCH=0 as an enabled watcher", () => {
+    expect(isDevApiWatchEnabled({ ELIZA_DEV_NO_WATCH: "0" }, [])).toBe(false);
   });
 });
 

--- a/packages/shared/src/runtime-env.ts
+++ b/packages/shared/src/runtime-env.ts
@@ -332,6 +332,17 @@ export function resolveApiToken(
   return resolveApiSecurityConfig(env).token;
 }
 
+export function isDevApiWatchEnabled(
+  env: RuntimeEnvRecord = process.env,
+  execArgv: readonly string[] = process.execArgv,
+): boolean {
+  return (
+    execArgv.includes("--watch") ||
+    env.ELIZA_DESKTOP_API_WATCH === "1" ||
+    env.ELIZA_DEV_SOURCE_WATCH === "1"
+  );
+}
+
 export function resolveConfiguredApiToken(
   env: RuntimeEnvRecord = process.env,
 ): string | undefined {

--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -73,7 +73,7 @@ All under the elizaOS runtime HTTP server:
 | `/api/orchestrator/*` | `handleOrchestratorRoutes` | Durable task CRUD, lifecycle, event log, usage rollup |
 | `/api/coding-agents/*` | `handleAgentRoutes` | ACP session CRUD: list, spawn, get, send, stop, output |
 | `/api/coding-agents/:id/credentials/*` | `handleBridgeRoutes` | Credential bridge (request + long-poll redemption) for spawned sub-agents |
-| `/api/coding-agents/:id/context` | `handleParentContextRoutes` | Read-only parent-context bridge: memory, workspace state |
+| `/api/coding-agents/:id/{parent-context,memory,active-workspaces}` | `handleParentContextRoutes` | Read-only parent-context bridge: memory, workspace state |
 | `/api/workspace/*` | `handleWorkspaceRoutes` | Git workspace: provision, status, commit, push, PR, delete |
 | `/api/issues/*` | `handleIssueRoutes` | GitHub issue CRUD (separate from manage_issues action) |
 | `/api/task-agents/*` | (aliased to `/api/coding-agents/*`) | Legacy path alias |
@@ -215,7 +215,7 @@ plugins/plugin-agent-orchestrator/
       agent-routes.ts            /api/coding-agents/* handlers
       orchestrator-routes.ts     /api/orchestrator/* handlers
       bridge-routes.ts           /api/coding-agents/:id/credentials/* handlers
-      parent-context-routes.ts   /api/coding-agents/:id/context handlers
+      parent-context-routes.ts   /api/coding-agents/:id/{parent-context,memory,active-workspaces} handlers
       workspace-routes.ts        /api/workspace/* handlers
       issue-routes.ts            /api/issues/* handlers (GitHub issue CRUD)
       route-utils.ts             parseBody, sendJson, sendError, RouteContext

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -73,7 +73,7 @@ All under the elizaOS runtime HTTP server:
 | `/api/orchestrator/*` | `handleOrchestratorRoutes` | Durable task CRUD, lifecycle, event log, usage rollup |
 | `/api/coding-agents/*` | `handleAgentRoutes` | ACP session CRUD: list, spawn, get, send, stop, output |
 | `/api/coding-agents/:id/credentials/*` | `handleBridgeRoutes` | Credential bridge (request + long-poll redemption) for spawned sub-agents |
-| `/api/coding-agents/:id/context` | `handleParentContextRoutes` | Read-only parent-context bridge: memory, workspace state |
+| `/api/coding-agents/:id/{parent-context,memory,active-workspaces}` | `handleParentContextRoutes` | Read-only parent-context bridge: memory, workspace state |
 | `/api/workspace/*` | `handleWorkspaceRoutes` | Git workspace: provision, status, commit, push, PR, delete |
 | `/api/issues/*` | `handleIssueRoutes` | GitHub issue CRUD (separate from manage_issues action) |
 | `/api/task-agents/*` | (aliased to `/api/coding-agents/*`) | Legacy path alias |
@@ -215,7 +215,7 @@ plugins/plugin-agent-orchestrator/
       agent-routes.ts            /api/coding-agents/* handlers
       orchestrator-routes.ts     /api/orchestrator/* handlers
       bridge-routes.ts           /api/coding-agents/:id/credentials/* handlers
-      parent-context-routes.ts   /api/coding-agents/:id/context handlers
+      parent-context-routes.ts   /api/coding-agents/:id/{parent-context,memory,active-workspaces} handlers
       workspace-routes.ts        /api/workspace/* handlers
       issue-routes.ts            /api/issues/* handlers (GitHub issue CRUD)
       route-utils.ts             parseBody, sendJson, sendError, RouteContext


### PR DESCRIPTION
Fixes #13630.

## Summary
- use canonical dev watcher detection for boot-history and restart telemetry instead of treating ELIZA_DEV_NO_WATCH=0 as watch=true
- make desktop:stack-status resolve the canonical desktop API port (31337) via shared runtime env helpers and add API-only/default-port coverage
- gate /api/dev/stack console-log tail advertisement through the same allowed-path check as the tail route
- correct plugin-agent-orchestrator docs for the parent-context/memory/active-workspaces routes

## Verification
- bun run --cwd packages/shared test src/runtime-env.test.ts
- bun run --cwd packages/app-core test src/api/dev-boot-history.test.ts src/api/dev-stack.test.ts scripts/lib/desktop-stack-status.test.mjs
- bun run --cwd packages/agent test src/runtime/boot-telemetry.test.ts
- bunx @biomejs/biome check packages/shared/src/runtime-env.ts packages/shared/src/runtime-env.test.ts packages/app-core/src/api/dev-boot-history.ts packages/app-core/src/api/dev-boot-history.test.ts packages/app-core/src/api/dev-stack.ts packages/app-core/src/api/dev-stack.test.ts packages/app-core/scripts/lib/desktop-stack-status.mjs packages/app-core/scripts/lib/desktop-stack-status.test.mjs packages/app-core/scripts/dev-ui.mjs packages/app-core/scripts/dev-platform.mjs packages/agent/src/runtime/boot-telemetry.ts packages/agent/src/runtime/boot-telemetry.test.ts package.json packages/shared/package.json plugins/plugin-agent-orchestrator/AGENTS.md plugins/plugin-agent-orchestrator/CLAUDE.md --no-errors-on-unmatched
- node scripts/assert-agents-claude-identical.mjs
- cmp -s plugins/plugin-agent-orchestrator/CLAUDE.md plugins/plugin-agent-orchestrator/AGENTS.md
- git diff --check
- bun run desktop:stack-status --json (expected exit 1 with no API listening; JSON reports apiPort 31337)