### PR TITLE
fix(feed): dedupe experience contradictions

### DIFF
--- a/packages/feed/packages/agents/src/plugins/plugin-experience/src/utils/experienceRelationships.test.ts
+++ b/packages/feed/packages/agents/src/plugins/plugin-experience/src/utils/experienceRelationships.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import type { UUID } from "@elizaos/core";
+import { type Experience, ExperienceType, OutcomeType } from "../types";
+import { ExperienceRelationshipManager } from "./experienceRelationships";
+
+function makeExperience(
+  id: string,
+  overrides: Partial<Experience> = {},
+): Experience {
+  return {
+    id: id as UUID,
+    agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+    type: ExperienceType.SUCCESS,
+    outcome: OutcomeType.POSITIVE,
+    context: "deploying a service",
+    action: "deploy",
+    result: "deployment completed",
+    learning: "deployment signal",
+    tags: [],
+    domain: "shell",
+    confidence: 0.9,
+    importance: 0.5,
+    createdAt: 1,
+    updatedAt: 1,
+    accessCount: 0,
+    ...overrides,
+  };
+}
+
+describe("ExperienceRelationshipManager.findContradictions", () => {
+  test("returns a matching experience once when both detection paths match", () => {
+    const manager = new ExperienceRelationshipManager();
+    const source = makeExperience("source");
+    const target = makeExperience("target", {
+      outcome: OutcomeType.NEGATIVE,
+      result: "deployment failed",
+    });
+
+    manager.addRelationship({
+      fromId: source.id,
+      toId: target.id,
+      type: "contradicts",
+      strength: 1,
+    });
+
+    expect(manager.findContradictions(source, [source, target])).toEqual([
+      target,
+    ]);
+  });
+
+  test("keeps action/outcome and explicit relationship detection independently", () => {
+    const manager = new ExperienceRelationshipManager();
+    const source = makeExperience("source");
+    const outcomeMatch = makeExperience("outcome-match", {
+      outcome: OutcomeType.NEGATIVE,
+    });
+    const explicitMatch = makeExperience("explicit-match", {
+      action: "inspect",
+      outcome: OutcomeType.POSITIVE,
+    });
+
+    manager.addRelationship({
+      fromId: source.id,
+      toId: explicitMatch.id,
+      type: "contradicts",
+      strength: 0.7,
+    });
+
+    expect(
+      manager.findContradictions(source, [source, outcomeMatch, explicitMatch]),
+    ).toEqual([outcomeMatch, explicitMatch]);
+  });
+});

--- a/packages/feed/packages/agents/src/plugins/plugin-experience/src/utils/experienceRelationships.ts
+++ b/packages/feed/packages/agents/src/plugins/plugin-experience/src/utils/experienceRelationships.ts
@@ -158,22 +158,19 @@ export class ExperienceRelationshipManager {
     allExperiences: Experience[],
   ): Experience[] {
     const contradictions: Experience[] = [];
+    const explicitContradictionIds = new Set(
+      this.findRelationships(experience.id, "contradicts").map((r) => r.toId),
+    );
 
     for (const other of allExperiences) {
       if (other.id === experience.id) continue;
 
-      // Same action, different outcome
-      if (
+      const contradictsByOutcome =
         other.action === experience.action &&
         other.outcome !== experience.outcome &&
-        other.domain === experience.domain
-      ) {
-        contradictions.push(other);
-      }
-
-      // Explicit contradiction relationship
-      const rels = this.findRelationships(experience.id, "contradicts");
-      if (rels.some((r) => r.toId === other.id)) {
+        other.domain === experience.domain;
+      const contradictsByRelationship = explicitContradictionIds.has(other.id);
+      if (contradictsByOutcome || contradictsByRelationship) {
         contradictions.push(other);
       }
     }


### PR DESCRIPTION
Fixes #13646.

## Summary
- compute explicit `contradicts` relationship targets once per `findContradictions` call
- return each contradictory experience at most once, even when both action/outcome/domain and explicit-edge signals match
- add regression coverage for the duplicate path and for both detection paths remaining independent

## Verification
- `bun test packages/agents/src/plugins/plugin-experience/src/utils/experienceRelationships.test.ts` (from `packages/feed`)
- `bunx @biomejs/biome check --config-path ../../biome.json --files-ignore-unknown=true --no-errors-on-unmatched packages/agents/src/plugins/plugin-experience/src/utils/experienceRelationships.ts packages/agents/src/plugins/plugin-experience/src/utils/experienceRelationships.test.ts` (from `packages/feed`)
- `git diff --check`