### PR TITLE
fix(#13602): contain mobile analytics and connector overflow

### DIFF
--- a/.github/issue-evidence/13602-mobile-overflow.md
+++ b/.github/issue-evidence/13602-mobile-overflow.md
@@ -1,0 +1,38 @@
+# Issue #13602 — Mobile 390px Analytics + Connectors Overflow
+
+## Fix
+
+- Hardened the shared cloud `ConnectionCard` shell so connector cards cannot
+  push the dashboard pane wider than the viewport:
+  - card root now uses `min-w-0 overflow-hidden`;
+  - header stacks on narrow screens and only becomes row layout at `sm`;
+  - connector names and descriptions wrap instead of forcing horizontal scroll;
+  - status badges are isolated in a non-growing wrapper.
+- Hardened `/dashboard/analytics` narrow layouts:
+  - page/header/filter containers now propagate `min-w-0`;
+  - range/granularity chips wrap long text;
+  - the model breakdown table scrolls inside its card with an explicit inner
+    minimum width, instead of widening the whole page.
+
+## Verification
+
+Commands run in a clean `fix/13602-mobile-overflow` worktree:
+
+```bash
+bun install --frozen-lockfile --ignore-scripts
+bun run --cwd packages/ui test src/cloud-ui/components/connection-card.layout.test.tsx
+bunx biome check packages/ui/src/cloud-ui/components/connection-card.tsx packages/ui/src/cloud-ui/components/connection-card.layout.test.tsx packages/ui/src/cloud/analytics/_components/analytics-page-client.tsx packages/ui/src/cloud/analytics/_components/filters.tsx packages/ui/src/cloud/analytics/_components/model-breakdown.tsx
+```
+
+Results:
+
+- Vitest: 1 file passed, 1 test passed.
+- Biome: 5 files checked, no fixes required.
+
+## Evidence Matrix
+
+- Unit/component regression: attached in
+  `packages/ui/src/cloud-ui/components/connection-card.layout.test.tsx`.
+- Browser screenshot/video: pending full app audit capture on the PR branch.
+- Backend logs: N/A — CSS/layout-only UI containment change.
+- Real LLM trajectory: N/A — no agent/action/model/prompt behavior changed.

--- a/packages/ui/src/cloud-ui/components/connection-card.layout.test.tsx
+++ b/packages/ui/src/cloud-ui/components/connection-card.layout.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ConnectionCard, ConnectionConnectedBadge } from "./connection-card";
+
+describe("ConnectionCard mobile layout", () => {
+  it("keeps long connector titles and status badges inside the card surface", () => {
+    const { container } = render(
+      <ConnectionCard
+        name="Extremely Long Enterprise Messaging Connector Name That Must Wrap"
+        icon={<span aria-hidden="true">C</span>}
+        description="A connector description that should wrap instead of forcing the dashboard pane wider than a phone viewport."
+        status="connected"
+        statusBadge={
+          <ConnectionConnectedBadge label="Connected with a very long label" />
+        }
+        connectedContent={<p>Connected</p>}
+      />,
+    );
+
+    const card = container.querySelector("[data-slot='connection-card']");
+    expect(card?.classList.contains("min-w-0")).toBe(true);
+    expect(card?.classList.contains("overflow-hidden")).toBe(true);
+    expect(
+      screen.getByText(/Extremely Long/).classList.contains("break-words"),
+    ).toBe(true);
+    expect(
+      screen
+        .getByText(/connector description/)
+        .classList.contains("break-words"),
+    ).toBe(true);
+  });
+});

--- a/packages/ui/src/cloud-ui/components/connection-card.tsx
+++ b/packages/ui/src/cloud-ui/components/connection-card.tsx
@@ -77,7 +77,7 @@ function ConnectionLoadingCard({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "rounded-sm border bg-card text-card-foreground ",
+        "min-w-0 overflow-hidden rounded-sm border bg-card text-card-foreground",
         className,
       )}
     >
@@ -379,19 +379,19 @@ function ConnectionCard({
     <div
       data-slot="connection-card"
       className={cn(
-        "rounded-sm border bg-card text-card-foreground ",
+        "min-w-0 overflow-hidden rounded-sm border bg-card text-card-foreground",
         className,
       )}
     >
       {/* Header */}
-      <div className="flex flex-col space-y-1.5 p-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <h3 className="flex items-center gap-2 text-2xl font-semibold leading-none tracking-tight">
-              <span className="[&>svg]:h-5 [&>svg]:w-5">{icon}</span>
-              {name}
+      <div className="flex min-w-0 flex-col space-y-1.5 p-4 sm:p-6">
+        <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <h3 className="flex min-w-0 items-center gap-2 text-xl font-semibold leading-tight tracking-tight sm:text-2xl">
+              <span className="shrink-0 [&>svg]:h-5 [&>svg]:w-5">{icon}</span>
+              <span className="min-w-0 break-words">{name}</span>
             </h3>
-            <p className="text-sm text-muted-foreground mt-1.5">
+            <p className="mt-1.5 break-words text-sm text-muted-foreground">
               {status === "not-configured"
                 ? `${name} integration is not configured`
                 : status === "error"
@@ -399,12 +399,14 @@ function ConnectionCard({
                   : description}
             </p>
           </div>
-          {status === "connected" && statusBadge}
+          {status === "connected" && statusBadge ? (
+            <div className="shrink-0 self-start">{statusBadge}</div>
+          ) : null}
         </div>
       </div>
 
       {/* Content */}
-      <div className="p-6 pt-0">
+      <div className="min-w-0 p-4 pt-0 sm:p-6 sm:pt-0">
         {status === "not-configured" && (
           <div className="p-4 bg-muted rounded-sm">
             <p className="text-sm text-muted-foreground">

--- a/packages/ui/src/cloud/analytics/_components/analytics-page-client.tsx
+++ b/packages/ui/src/cloud/analytics/_components/analytics-page-client.tsx
@@ -202,21 +202,21 @@ export function AnalyticsPageClient({
   ];
 
   return (
-    <DashboardPageContainer className="space-y-10 lg:space-y-14">
-      <section className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between lg:gap-10 pb-2">
-        <div className="space-y-5 lg:max-w-3xl">
+    <DashboardPageContainer className="min-w-0 space-y-10 overflow-hidden lg:space-y-14">
+      <section className="flex min-w-0 flex-col gap-6 pb-2 lg:flex-row lg:items-start lg:justify-between lg:gap-10">
+        <div className="min-w-0 space-y-5 lg:max-w-3xl">
           <div className="flex flex-wrap items-center gap-2 gap-y-3 text-xs font-medium text-white/60">
-            <span className="flex items-center gap-1 rounded-sm border border-white/20 bg-white/10 px-3 py-1">
-              <CalendarRange className="h-3.5 w-3.5 text-[var(--accent)]" />
-              {rangeLabel}
+            <span className="flex min-w-0 max-w-full items-center gap-1 rounded-sm border border-white/20 bg-white/10 px-3 py-1">
+              <CalendarRange className="h-3.5 w-3.5 shrink-0 text-[var(--accent)]" />
+              <span className="min-w-0 break-words">{rangeLabel}</span>
             </span>
-            <span className="rounded-sm border border-white/20 bg-white/10 px-3 py-1">
+            <span className="max-w-full break-words rounded-sm border border-white/20 bg-white/10 px-3 py-1">
               {t("cloud.analytics.granularityLabel", {
                 defaultValue: "Granularity",
               })}
               : {granularityLabel}
             </span>
-            <span className="rounded-sm border border-white/20 bg-white/10 px-3 py-1">
+            <span className="max-w-full break-words rounded-sm border border-white/20 bg-white/10 px-3 py-1">
               {t("cloud.analytics.dataPointsCount", {
                 defaultValue: "{{n}} data points",
                 n: data.timeSeriesData.length.toLocaleString(),
@@ -246,8 +246,8 @@ export function AnalyticsPageClient({
           <KeyMetricsGrid metrics={metrics} />
         </section>
 
-        <section className="grid gap-8 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] lg:gap-10">
-          <BrandCard className="relative">
+        <section className="grid min-w-0 gap-8 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] lg:gap-10">
+          <BrandCard className="relative min-w-0 overflow-hidden">
             <CornerBrackets size="sm" className="opacity-50" />
             <div className="relative z-10 space-y-4">
               <h3 className="text-base font-semibold text-white">
@@ -277,7 +277,7 @@ export function AnalyticsPageClient({
               value="breakdown"
               className="space-y-8 lg:space-y-10 mb-4"
             >
-              <div className="grid gap-8 lg:grid-cols-2 lg:gap-10">
+              <div className="grid min-w-0 gap-8 lg:grid-cols-2 lg:gap-10">
                 <ProviderBreakdown providers={data.providerBreakdown} />
                 <ModelBreakdown models={data.modelBreakdown} />
               </div>

--- a/packages/ui/src/cloud/analytics/_components/filters.tsx
+++ b/packages/ui/src/cloud/analytics/_components/filters.tsx
@@ -103,9 +103,9 @@ export function AnalyticsFilters() {
   };
 
   return (
-    <div className="flex flex-col gap-5 md:gap-6 lg:flex-row lg:items-center lg:justify-between">
-      <div className="flex flex-wrap items-center gap-4 md:gap-5">
-        <div className="space-y-2">
+    <div className="flex min-w-0 flex-col gap-5 md:gap-6 lg:flex-row lg:items-center lg:justify-between">
+      <div className="flex min-w-0 flex-wrap items-center gap-4 md:gap-5">
+        <div className="min-w-0 space-y-2">
           <p className="text-xs uppercase tracking-wide text-white/50">
             {t("cloud.analytics.filters.aggregation", {
               defaultValue: "Aggregation",
@@ -115,7 +115,7 @@ export function AnalyticsFilters() {
             value={timeRange}
             onValueChange={(value) => updateFilters({ timeRange: value })}
           >
-            <SelectTrigger className="w-[160px] rounded-sm border-white/10 bg-black/40 text-white  ">
+            <SelectTrigger className="w-full min-w-0 max-w-[160px] rounded-sm border-white/10 bg-black/40 text-white sm:w-[160px]">
               <SelectValue>{rangeLabels[timeRange]}</SelectValue>
             </SelectTrigger>
             <SelectContent className="rounded-sm border-white/10 bg-black/90">
@@ -133,16 +133,18 @@ export function AnalyticsFilters() {
         </div>
 
         {activeRange === "custom" ? (
-          <span className="flex items-center gap-1 rounded-sm border border-white/20 bg-white/10 px-3 py-1 text-xs">
-            <Sparkles className="h-3.5 w-3.5 text-[var(--accent)]" />
-            {t("cloud.analytics.filters.customRange", {
-              defaultValue: "Custom range detected",
-            })}
+          <span className="flex min-w-0 max-w-full items-center gap-1 rounded-sm border border-white/20 bg-white/10 px-3 py-1 text-xs">
+            <Sparkles className="h-3.5 w-3.5 shrink-0 text-[var(--accent)]" />
+            <span className="min-w-0 break-words">
+              {t("cloud.analytics.filters.customRange", {
+                defaultValue: "Custom range detected",
+              })}
+            </span>
           </span>
         ) : null}
       </div>
 
-      <div className="flex flex-wrap gap-3 md:gap-4">
+      <div className="flex min-w-0 flex-wrap gap-3 md:gap-4">
         {presets.map((preset) => {
           const isActive = activeRange === preset.value;
 

--- a/packages/ui/src/cloud/analytics/_components/model-breakdown.tsx
+++ b/packages/ui/src/cloud/analytics/_components/model-breakdown.tsx
@@ -93,10 +93,10 @@ export function ModelBreakdown({ models }: ModelBreakdownProps) {
           })}
         </p>
       </CardHeader>
-      <CardContent className="border-t border-border/60 p-6">
-        <div className="space-y-4">
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+      <CardContent className="min-w-0 border-t border-border/60 p-4 sm:p-6">
+        <div className="min-w-0 space-y-4">
+          <div className="max-w-full overflow-x-auto">
+            <table className="min-w-[640px] w-full text-sm">
               <thead>
                 <tr className="border-b border-border/50">
                   <th className="pb-3 text-left font-medium text-muted-foreground">


### PR DESCRIPTION
## Summary

Fixes #13602.

- constrains the shared cloud `ConnectionCard` surface with `min-w-0`/`overflow-hidden`, narrow-screen header stacking, wrapped names/descriptions, and isolated status badges
- hardens `/dashboard/analytics` header/filter/container layout so chips and controls wrap at 390px instead of widening the pane
- keeps the model breakdown table scrollable inside its card with an explicit inner table width
- adds a component regression covering long connector names/descriptions/status labels

## Verification

```bash
bun install --frozen-lockfile --ignore-scripts
bun run --cwd packages/ui test src/cloud-ui/components/connection-card.layout.test.tsx
bunx biome check packages/ui/src/cloud-ui/components/connection-card.tsx packages/ui/src/cloud-ui/components/connection-card.layout.test.tsx packages/ui/src/cloud/analytics/_components/analytics-page-client.tsx packages/ui/src/cloud/analytics/_components/filters.tsx packages/ui/src/cloud/analytics/_components/model-breakdown.tsx
```

Evidence note: `.github/issue-evidence/13602-mobile-overflow.md`

## Evidence matrix

- Unit/component regression: included
- Browser screenshot/video: pending full app audit capture on PR branch
- Backend logs: N/A - CSS/layout-only UI containment change
- Real LLM trajectory: N/A - no agent/action/model/prompt behavior changed
