### PR TITLE
fix(ci): tighten app aesthetic audit trigger

### DIFF
--- a/.github/workflows/app-aesthetic-audit.yml
+++ b/.github/workflows/app-aesthetic-audit.yml
@@ -8,10 +8,8 @@ name: App Aesthetic Audit
 # This is the agent app's equivalent of cloud-frontend's `audit:cloud`. Until
 # this workflow existed the audit ran in NO CI lane (honor-system per the PR
 # template, #9304). It hard-fails on any uncaught page error (a real crash) and
-# uploads all artifacts. To additionally gate on `broken` verdicts (console
-# errors / blank renders / empty views), capture the current set into
-# AESTHETIC_VERDICT_DEBT (in all-views-aesthetic-audit.spec.ts) from this
-# workflow's first clean run, then set ELIZA_AUDIT_APP_STRICT=1 below.
+# uploads all artifacts. It also gates computed `broken` and `needs-work`
+# verdicts against AESTHETIC_VERDICT_DEBT (in all-views-aesthetic-audit.spec.ts).
 
 on:
   pull_request:
@@ -19,13 +17,10 @@ on:
     paths:
       - "packages/app/**"
       - "packages/ui/**"
+      - "packages/shared/**"
+      - "plugins/**"
       - ".github/workflows/app-aesthetic-audit.yml"
   workflow_dispatch:
-    inputs:
-      strict:
-        description: "Fail on non-exempt broken verdicts (ELIZA_AUDIT_APP_STRICT)"
-        type: boolean
-        default: false
 
 concurrency:
   group: app-aesthetic-audit-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -45,7 +40,6 @@ jobs:
     env:
       # Keyless: the ui-smoke stub is forced when CI=true (shouldForceStubStack).
       ELIZA_UI_SMOKE_FORCE_STUB: "1"
-      ELIZA_AUDIT_APP_STRICT: ${{ github.event.inputs.strict == 'true' && '1' || '0' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,25 +100,25 @@ above is the day-to-day set. Use `bun run` with no args to print them all.
 packages/        framework, shared libraries, and product surfaces
   core/          @elizaos/core — runtime, types, agent loop, memory/state, model layer
   agent/         @elizaos/agent — AgentRuntime, plugin loader, default plugin map
-  app-core/      API + dashboard host; dev/build orchestration (dev-ui.mjs)
+  app-core/      API + dashboard host; dev/build orchestration (scripts/dev-ui.mjs)
   elizaos/       the `elizaos` CLI — create / info / upgrade / version; project + plugin templates
   prompts/       shared prompt scaffolding
   shared/        cross-package utilities + brand assets
   ui/            shared React component library
-  app/           web + desktop dashboard (Vite + React; desktop shell)
+  app/           web + desktop dashboard, desktop shell, and current cloud apex UI
   tui/           terminal UI
   skills/        runtime skills knowledge base (USE_SKILL)
   scenario-runner/ scenario + eval harness
   cloud/api/     managed backend API (Hono on Cloudflare Workers)
-  app/           web + desktop dashboard; also hosts the current cloud apex UI
+  cloud/docs-redirect/ Eliza Cloud docs redirects
   cloud/shared/  shared cloud backend: db (Drizzle), billing, services, types
   cloud/sdk/ cloud/routing/ cloud/infra/  cloud client SDK, model routing, IaC
   contracts/     on-chain contracts + ABIs
-  security/ vault/ soc2-verify/  secrets, key management, compliance tooling
+  security/ security/soc2-verify/ vault/  secrets, key management, compliance tooling
   os/ robot/                     device/OS images, OS landing, robotics
   plugin-remote-manifest/ plugin-worker-runtime/
                  remote plugin manifests, host shims, and worker runtime support
-  homepage/ docs/ docs-elizacloud-redirect/  marketing site, docs site, redirects
+  homepage/ docs/  marketing site and docs site
   examples/      30+ standalone runnable examples (each has its own README)
   benchmarks/    30+ evaluation suites (each has its own README + harness)
 
@@ -128,10 +128,10 @@ plugins/         runtime plugins and app plugins
   plugin-native-*/     native device bridges (camera, contacts, calendar, location, …)
   plugin-local-inference/  on-device llama.cpp (Kokoro TTS folded in) / whisper (git submodules under native/)
   plugin-sql/ plugin-localdb/ plugin-inmemorydb/  storage adapters
-  plugin-documents/ plugin-lifeops/ plugin-health/ …  app plugins
+  plugin-documents/ plugin-personal-assistant/ plugin-health/ …  app plugins
 
 scripts/         repo automation        patches/   dependency patches
-skills/          runtime skill packages turbo.json knip.json  build + dead-code config
+turbo.json knip.json  build + dead-code config
 ```
 
 Every package and plugin carries its own `CLAUDE.md` / `AGENTS.md` (identical)
@@ -322,11 +322,13 @@ bun run --cwd packages/app audit:app
 
 This walks the app views (desktop + mobile, rest + hover), captures the
 populated UI, and auto-stubs `aesthetic-audit-output/manual-review/<slug>.md`
-per view. Fill in the verdict (`good` · `needs-work` · `needs-eyeball` ·
-`broken`) for every page you touched or can reach via shared
+per view. Use those Markdown files for human notes and eyeballing; CI enforces
+the computed verdicts in `report.json` / the Playwright run, not edited
+manual-review Markdown. Review every page you touched or can reach via shared
 layout/theme/components.
 
-- No page may stay `needs-work` / `broken` when a UI task is declared done.
+- No computed page verdict may stay `needs-work` / `broken` when a UI task is
+  declared done.
 - Iterate the loop ≥5× for any meaningful redesign.
 - Orange is accent only; no blue anywhere; orange-resting → darker-orange hover
   (never orange→black). Full package rules: `packages/app/AGENTS.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,25 +100,25 @@ above is the day-to-day set. Use `bun run` with no args to print them all.
 packages/        framework, shared libraries, and product surfaces
   core/          @elizaos/core — runtime, types, agent loop, memory/state, model layer
   agent/         @elizaos/agent — AgentRuntime, plugin loader, default plugin map
-  app-core/      API + dashboard host; dev/build orchestration (dev-ui.mjs)
+  app-core/      API + dashboard host; dev/build orchestration (scripts/dev-ui.mjs)
   elizaos/       the `elizaos` CLI — create / info / upgrade / version; project + plugin templates
   prompts/       shared prompt scaffolding
   shared/        cross-package utilities + brand assets
   ui/            shared React component library
-  app/           web + desktop dashboard (Vite + React; desktop shell)
+  app/           web + desktop dashboard, desktop shell, and current cloud apex UI
   tui/           terminal UI
   skills/        runtime skills knowledge base (USE_SKILL)
   scenario-runner/ scenario + eval harness
   cloud/api/     managed backend API (Hono on Cloudflare Workers)
-  app/           web + desktop dashboard; also hosts the current cloud apex UI
+  cloud/docs-redirect/ Eliza Cloud docs redirects
   cloud/shared/  shared cloud backend: db (Drizzle), billing, services, types
   cloud/sdk/ cloud/routing/ cloud/infra/  cloud client SDK, model routing, IaC
   contracts/     on-chain contracts + ABIs
-  security/ vault/ soc2-verify/  secrets, key management, compliance tooling
+  security/ security/soc2-verify/ vault/  secrets, key management, compliance tooling
   os/ robot/                     device/OS images, OS landing, robotics
   plugin-remote-manifest/ plugin-worker-runtime/
                  remote plugin manifests, host shims, and worker runtime support
-  homepage/ docs/ docs-elizacloud-redirect/  marketing site, docs site, redirects
+  homepage/ docs/  marketing site and docs site
   examples/      30+ standalone runnable examples (each has its own README)
   benchmarks/    30+ evaluation suites (each has its own README + harness)
 
@@ -128,10 +128,10 @@ plugins/         runtime plugins and app plugins
   plugin-native-*/     native device bridges (camera, contacts, calendar, location, …)
   plugin-local-inference/  on-device llama.cpp (Kokoro TTS folded in) / whisper (git submodules under native/)
   plugin-sql/ plugin-localdb/ plugin-inmemorydb/  storage adapters
-  plugin-documents/ plugin-lifeops/ plugin-health/ …  app plugins
+  plugin-documents/ plugin-personal-assistant/ plugin-health/ …  app plugins
 
 scripts/         repo automation        patches/   dependency patches
-skills/          runtime skill packages turbo.json knip.json  build + dead-code config
+turbo.json knip.json  build + dead-code config
 ```
 
 Every package and plugin carries its own `CLAUDE.md` / `AGENTS.md` (identical)
@@ -322,11 +322,13 @@ bun run --cwd packages/app audit:app
 
 This walks the app views (desktop + mobile, rest + hover), captures the
 populated UI, and auto-stubs `aesthetic-audit-output/manual-review/<slug>.md`
-per view. Fill in the verdict (`good` · `needs-work` · `needs-eyeball` ·
-`broken`) for every page you touched or can reach via shared
+per view. Use those Markdown files for human notes and eyeballing; CI enforces
+the computed verdicts in `report.json` / the Playwright run, not edited
+manual-review Markdown. Review every page you touched or can reach via shared
 layout/theme/components.
 
-- No page may stay `needs-work` / `broken` when a UI task is declared done.
+- No computed page verdict may stay `needs-work` / `broken` when a UI task is
+  declared done.
 - Iterate the loop ≥5× for any meaningful redesign.
 - Orange is accent only; no blue anywhere; orange-resting → darker-orange hover
   (never orange→black). Full package rules: `packages/app/AGENTS.md`.

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -262,6 +262,6 @@ behavior, **re-capture** evidence; stale proof is worse than none.
 **Capture & manually review for this package — UI surface:**
 - Before/after **full-page** screenshots — desktop **and** mobile, portrait **and** landscape, rest **and** hover (`bun run --cwd packages/app audit:app` where applicable) — not desktop-only-happy-path (see #9950).
 - A **video walkthrough** of the whole view/flow, plus browser console + network logs showing the real request/response and state change.
-- Empty, loading, error, and permission-denied states — and fill the per-view manual-review verdict (`good`/`needs-work`/`needs-eyeball`/`broken`); no page ships `needs-work`/`broken`.
+- Empty, loading, error, and permission-denied states — review the per-view manual-review notes (`good`/`needs-work`/`needs-eyeball`/`broken` guidance); no computed page verdict ships `needs-work`/`broken`.
 - The backend trajectory/logs behind anything the UI triggered.
 <!-- END: evidence-and-e2e-mandate -->

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -262,6 +262,6 @@ behavior, **re-capture** evidence; stale proof is worse than none.
 **Capture & manually review for this package — UI surface:**
 - Before/after **full-page** screenshots — desktop **and** mobile, portrait **and** landscape, rest **and** hover (`bun run --cwd packages/app audit:app` where applicable) — not desktop-only-happy-path (see #9950).
 - A **video walkthrough** of the whole view/flow, plus browser console + network logs showing the real request/response and state change.
-- Empty, loading, error, and permission-denied states — and fill the per-view manual-review verdict (`good`/`needs-work`/`needs-eyeball`/`broken`); no page ships `needs-work`/`broken`.
+- Empty, loading, error, and permission-denied states — review the per-view manual-review notes (`good`/`needs-work`/`needs-eyeball`/`broken` guidance); no computed page verdict ships `needs-work`/`broken`.
 - The backend trajectory/logs behind anything the UI triggered.
 <!-- END: evidence-and-e2e-mandate -->


### PR DESCRIPTION
Fixes #13625.

## Summary
- widen the app aesthetic audit PR trigger to include `packages/shared/**` and `plugins/**`, so shared UI/theme and plugin-view changes run the gate
- remove the dead `workflow_dispatch.strict` input and stale job-level env wiring; the audit step already runs strict + needs-work strict unconditionally
- update root and app AGENTS/CLAUDE docs to state that manual-review Markdown is for human notes, while CI enforces computed `report.json` / Playwright verdicts

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/app-aesthetic-audit.yml"); puts "yaml-ok"'`
- `actionlint .github/workflows/app-aesthetic-audit.yml`
- `node scripts/assert-agents-claude-identical.mjs`
- `cmp -s AGENTS.md CLAUDE.md`
- `cmp -s packages/app/AGENTS.md packages/app/CLAUDE.md`
- `git diff --check`

GitHub-side red/green evidence for the widened path filter will be produced by this PR's workflow matching behavior and required checks.