### PR TITLE
docs: add contributor governance policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,44 @@
+---
+name: Epic / tracking issue
+about: Track a multi-PR project with acceptance criteria and evidence
+title: "[Epic] "
+labels: "documentation"
+assignees: ""
+---
+
+## Goal
+
+<!-- What user-visible or maintainer-visible state should be true when this epic is done? -->
+
+## Scope
+
+<!-- List the product areas, packages, services, or workflows included. -->
+
+## Non-goals
+
+<!-- Explicitly list related work that is out of scope. -->
+
+## Work Items
+
+- [ ] Item 1
+- [ ] Item 2
+
+## Acceptance Criteria
+
+- [ ] The implemented behavior is verified end to end.
+- [ ] Required tests and CI gates are added or updated.
+- [ ] Evidence artifacts are attached under `.github/issue-evidence/<issue#>-<slug>/`.
+
+## Evidence Plan
+
+<!-- Keep every applicable row visible. Use `N/A - <reason>` only when a row truly does not apply. -->
+
+- [ ] Screenshots or recording:
+- [ ] Logs:
+- [ ] Real-LLM trajectories:
+- [ ] Domain artifacts:
+- [ ] CI runs:
+
+## Dependencies / Sequencing
+
+<!-- Link prerequisite issues or PRs. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 <!-- LINK TO ISSUE OR TICKET -->
 
-Definition of Done: full standard in [`PR_EVIDENCE.md`](PR_EVIDENCE.md).
+Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).
 
 - [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
       with zero conflicts (`git fetch origin && git rebase origin/develop`).

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -1,0 +1,41 @@
+name: Markdown Links
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "**/*.md"
+      - "scripts/check-markdown-links.mjs"
+      - ".github/workflows/markdown-links.yml"
+  push:
+    branches: [main, develop]
+    paths:
+      - "**/*.md"
+      - "scripts/check-markdown-links.mjs"
+      - ".github/workflows/markdown-links.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: markdown-links-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  relative-links:
+    name: Relative Markdown Links
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Check relative Markdown links
+        run: node scripts/check-markdown-links.mjs

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:security@elizaos.ai
+Policy: https://github.com/elizaOS/eliza/security/policy
+Preferred-Languages: en
+Canonical: https://elizaos.ai/.well-known/security.txt
+Expires: 2027-07-04T00:00:00Z

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 Thanks for helping with elizaOS. Open an issue before non-trivial work, branch
 from the latest `develop`, and ship changes through a PR against `develop`.
+All contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md). Report
+security issues privately through the [Security Policy](SECURITY.md), not public
+GitHub issues.
 
 By participating you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
 Security issues go through [SECURITY.md](SECURITY.md), never a public issue.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ video, logs, and any relevant real-LLM trajectories attached under
 
 - [Bug Report](.github/ISSUE_TEMPLATE/bug_report.md)
 - [Feature Request](.github/ISSUE_TEMPLATE/feature_request.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Security Policy](SECURITY.md)
+- [Windows Setup](WINDOWS.md)
 
 All community spaces are covered by our [Code of Conduct](CODE_OF_CONDUCT.md).
 To report a security vulnerability, follow [SECURITY.md](SECURITY.md); do not

--- a/packages/docs/security/README.md
+++ b/packages/docs/security/README.md
@@ -16,5 +16,5 @@ response for the runtime, Cloud, and agent surfaces in this repo.
 
 ## Package-specific security docs
 
-- KMS / secrets package: [`../../packages/security/docs/`](../../packages/security/docs/)
+- KMS / secrets package: [`../../security/docs/`](../../security/docs/)
 - Repo-wide security policy: [`../../../SECURITY.md`](../../../SECURITY.md)

--- a/packages/docs/security/ai-pr-review-policy.md
+++ b/packages/docs/security/ai-pr-review-policy.md
@@ -40,7 +40,7 @@ weaken CI to "fix" failures are rejected.
 ### 5. No silent secret rotation
 Agents do not rotate, generate, or commit secrets. If an agent encounters an
 exposed secret it must surface the finding to a human (preferably via the
-security mailbox `security@elizalabs.ai`). See `SECURITY.md`.
+security mailbox `security@elizaos.ai`). See `SECURITY.md`.
 
 ## Reviewer checklist
 

--- a/packages/ui/src/cloud/account-security/components/incident-report-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/incident-report-panel.tsx
@@ -14,7 +14,7 @@ import {
 import { ApiError, apiFetch } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 
-const SECURITY_EMAIL = "security@elizalabs.ai";
+const SECURITY_EMAIL = "security@elizaos.ai";
 
 export function IncidentReportPanel() {
   const t = useCloudT();

--- a/scripts/check-markdown-links.mjs
+++ b/scripts/check-markdown-links.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+
+// Historical evidence, fixture, vendored, and prototype documentation contains
+// intentionally stale sample paths. Keep the first gate on maintained
+// contributor-facing docs; shrink this list as those trees are cleaned up.
+const EXCLUDED_PREFIXES = [
+  ".github/issue-evidence/",
+  "docs/",
+  "packages/app-core/",
+  "packages/benchmarks/",
+  "packages/cloud/",
+  "packages/docs/apps/",
+  "packages/docs/build-and-release.md",
+  "packages/docs/connectors/",
+  "packages/docs/dashboard/",
+  "packages/docs/electrobun-startup.md",
+  "packages/docs/plugin-resolution-and-node-path.md",
+  "packages/docs/plugins/",
+  "packages/docs/runtime/",
+  "packages/elizaos/src/commands/",
+  "packages/examples/",
+  "packages/feed/",
+  "packages/research/",
+  "packages/security/docs/",
+  "packages/skills/",
+  "packages/training/",
+  "packages/ui/src/services/local-inference/",
+  "packages/app-core/test/",
+  "plugins/plugin-agent-orchestrator/docs/",
+  "plugins/plugin-computeruse/",
+  "plugins/plugin-local-inference/",
+  "plugins/plugin-wallet/src/chains/solana/",
+  "plugins/plugin-xai/",
+];
+
+const EXCLUDED_NAMES = new Set(["CHANGELOG.md"]);
+
+function trackedMarkdownFiles() {
+  return execFileSync("git", ["ls-files", "*.md"], {
+    cwd: ROOT,
+    encoding: "utf8",
+  })
+    .split("\n")
+    .filter(Boolean)
+    .filter((file) => !EXCLUDED_NAMES.has(path.basename(file)))
+    .filter(
+      (file) => !EXCLUDED_PREFIXES.some((prefix) => file.startsWith(prefix)),
+    );
+}
+
+function stripAnchor(href) {
+  const hashIndex = href.indexOf("#");
+  return hashIndex === -1 ? href : href.slice(0, hashIndex);
+}
+
+function candidateTargets(sourceFile, href) {
+  const withoutQuery = href.split("?")[0];
+  if (withoutQuery.startsWith("/")) {
+    const docsTarget = path.join(
+      ROOT,
+      "packages/docs",
+      withoutQuery.replace(/^\/+/, ""),
+    );
+    return [
+      path.join(ROOT, withoutQuery),
+      docsTarget,
+      `${docsTarget}.md`,
+      `${docsTarget}.mdx`,
+      path.join(docsTarget, "README.md"),
+      path.join(docsTarget, "index.md"),
+      path.join(docsTarget, "index.mdx"),
+    ];
+  }
+
+  const target = path.resolve(ROOT, path.dirname(sourceFile), withoutQuery);
+  return [
+    target,
+    `${target}.md`,
+    `${target}.mdx`,
+    path.join(target, "README.md"),
+    path.join(target, "index.md"),
+    path.join(target, "index.mdx"),
+  ];
+}
+
+function isRelativeLink(href) {
+  return (
+    href &&
+    !href.startsWith("#") &&
+    !href.startsWith("mailto:") &&
+    !href.startsWith("tel:") &&
+    !href.startsWith("http://") &&
+    !href.startsWith("https://") &&
+    !href.startsWith("ftp://") &&
+    !href.startsWith("file://") &&
+    !href.startsWith("data:")
+  );
+}
+
+function decodeHref(href) {
+  try {
+    return decodeURIComponent(href);
+  } catch {
+    return href;
+  }
+}
+
+function targetExists(sourceFile, rawHref) {
+  const href = decodeHref(stripAnchor(rawHref).trim());
+  if (!isRelativeLink(href)) return true;
+
+  for (const target of candidateTargets(sourceFile, href)) {
+    if (!target.startsWith(ROOT)) continue;
+    if (!existsSync(target)) continue;
+    if (statSync(target).isDirectory()) {
+      if (
+        existsSync(path.join(target, "README.md")) ||
+        existsSync(path.join(target, "index.md")) ||
+        existsSync(path.join(target, "index.mdx"))
+      ) {
+        return true;
+      }
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+function stripCode(markdown) {
+  return markdown
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/~~~[\s\S]*?~~~/g, "")
+    .replace(/`[^`\n]+`/g, "");
+}
+
+function markdownLinks(markdown) {
+  const links = [];
+  const searchable = stripCode(markdown);
+  const inlinePattern = /!?\[[^\]\n]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+  const referencePattern = /^\s*\[[^\]\n]+]:\s*(\S+)/gm;
+  for (const match of searchable.matchAll(inlinePattern)) {
+    links.push(match[1]);
+  }
+  for (const match of searchable.matchAll(referencePattern)) {
+    links.push(match[1]);
+  }
+  return links;
+}
+
+const failures = [];
+for (const file of trackedMarkdownFiles()) {
+  const markdown = readFileSync(path.join(ROOT, file), "utf8");
+  for (const href of markdownLinks(markdown)) {
+    if (!targetExists(file, href)) {
+      failures.push(`${file}: missing relative link target ${href}`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(
+    `[check-markdown-links] ${failures.length} missing relative link target(s):`,
+  );
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("[check-markdown-links] PASS: relative Markdown links resolve.");


### PR DESCRIPTION
Fixes #13626.

## Summary
- add `CODE_OF_CONDUCT.md` and link it from README/CONTRIBUTING
- disable blank issues, add contact links, and add an epic/tracking issue template
- clean `SECURITY.md` by removing public unprovisioned-GPG/SOC2 checklist text, standardizing the contact to `security@elizaos.ai`, and adding `.well-known/security.txt`
- link security + Windows setup from README and fix the PR template's broken `PR_EVIDENCE.md` relative link
- add a local `scripts/check-markdown-links.mjs` relative-link checker plus `markdown-links.yml` CI workflow
- align remaining security-contact references in docs and the account-security incident panel

## Verification
- `node scripts/check-markdown-links.mjs`
- `bunx @biomejs/biome check scripts/check-markdown-links.mjs packages/ui/src/cloud/account-security/components/incident-report-panel.tsx --no-errors-on-unmatched`
- `ruby -e 'require "yaml"; YAML.load_file(".github/ISSUE_TEMPLATE/config.yml"); YAML.load_file(".github/workflows/markdown-links.yml"); puts "yaml-ok"'`
- `actionlint .github/workflows/markdown-links.yml`
- `git diff --check`
- `rg -n "elizalabs\.ai|security@elizalabs|not available until|Human-in-loop checklist|\[ \].*SOC2" SECURITY.md README.md CONTRIBUTING.md CODE_OF_CONDUCT.md .github/ISSUE_TEMPLATE packages/docs/security packages/ui/src/cloud/account-security -S` returned no matches

Known unrelated local blocker:
- `bun run --cwd packages/ui typecheck` currently fails before reaching this change because `src/spatial/__e2e__/immersive-fixture.ts` cannot resolve `iwer`.

GitHub UI screenshots for Community Standards and the issue chooser can be captured once this PR is merged to the default branch.