### PR TITLE
fix(cloud): agent restore/bridge/stream 500s on caller-shaped bodies + restore backup-id oracle (#13406)

### DIFF
--- a/.github/issue-evidence/13406-agent-mgmt-backend-500-audit.md
+++ b/.github/issue-evidence/13406-agent-mgmt-backend-500-audit.md
@@ -1,0 +1,79 @@
+# Agent-management backend 500-class audit (#13406)
+
+Lane: [cloud-security] · Branch: `fix/agent-mgmt-backend-500s` · Date: 2026-07-04
+
+Scope: the backend endpoints the console `/dashboard/agents` + agent-detail
+pages (packages/ui/src/cloud/instances) fire on load and on action, under
+`packages/cloud/api/v1/eliza/agents/`. Hunted the NON-stub 500 class
+(unguarded throw mapped to 500 on a normal/empty/not-provisioned input);
+stub-drift is already closed + mirror-guarded (#13557) and was not re-audited.
+Money/credit assertions (gates, billing) were left to the money lane.
+
+## Endpoints audited (handler + the cloud-shared repos/services it calls)
+
+| Endpoint | Fired by | Verdict |
+| --- | --- | --- |
+| GET `/api/v1/eliza/agents` (list) | agents table, status poll | CLEAN — `listByOrganization` returns `[]`; char join `findByIdsInOrganization([])` short-circuits; `toIsoStringOrNull` guards nullable `last_backup_at`/`last_heartbeat_at`; `resolvePublicWebUiUrl` returns null for shared/unset domains |
+| GET `/api/v1/eliza/agents/:agentId` (detail) | detail page, status poll | CLEAN — 404 on missing row; steward wallet lookup wrapped (J-annotated warn); `db.query.agentServerWallets` registered via `schemas/index.ts` barrel; admin slice null for non-admins; all nullable timestamps guarded |
+| GET `/api/v1/eliza/agents/:agentId/backups` | backups panel | CLEAN — missing agent/no backups → `[]` (metadata select, no R2 hydration on the list path) |
+| POST `/api/v1/eliza/agents/:agentId/pairing-token` | Open Web UI | CLEAN — starting/stopped/never-provisioned → typed 202 + Retry-After; error-state agent → explicit 500 by design; enqueue failure → typed 503 |
+| POST `/api/v1/eliza/agents/:agentId/provision` | create dialog, table action | CLEAN — 404/402/409 typed; warm-pool claim wrapped; enqueue throw mapped |
+| POST `/api/v1/eliza/agents/:agentId/resume` | actions | CLEAN — same shape as provision |
+| POST `/api/v1/eliza/agents/:agentId/sleep` | actions | CLEAN — no body parse, all status branches typed |
+| POST `/api/v1/eliza/agents/:agentId/wake` | actions | CLEAN — same shape as sleep + gates |
+| POST `/api/v1/eliza/agents/:agentId/snapshot` | backups panel | CLEAN — no body parse; not-running → 409 |
+| PATCH/DELETE `/api/v1/eliza/agents/:agentId` | actions | CLEAN — `c.req.json().catch(() => null)` guard; provisioning → 409 |
+| POST `/api/v1/eliza/agents` (create) | create dialog | CLEAN — `json().catch(() => { throw ValidationError })` guard already present |
+| POST `/api/v1/eliza/agents/:agentId/restore` | backups panel | **BUG (fixed)** |
+| POST `/api/v1/eliza/agents/:agentId/bridge` | agent chat surfaces | **BUG (fixed)** |
+| POST `/api/v1/eliza/agents/:agentId/stream` | agent chat surfaces | **BUG (fixed)** |
+
+Cost badge / pricing banner compute from the list DTO (no extra GET); wallet
+`/:agentId/api/wallet/*` is the money lane and was not touched.
+
+## Bugs (the non-stub 500 class)
+
+1. **restore: unguarded `await request.json()`** — every field of
+   `restoreSchema` is optional, so a bodyless POST is the canonical
+   "restore the latest backup" call (SDK/curl); it threw a SyntaxError that
+   `errorToResponse` maps to **500**. Fix: empty body ⇒ `{}` (restore-latest
+   semantics), malformed non-empty JSON ⇒ typed 400 `ValidationError`
+   (`error-policy:J3`).
+2. **restore: cross-agent backupId → 500 + existence oracle** — the service's
+   "Backup does not belong to this agent" ownership result fell through the
+   status map to **500** with a distinct message, so a signed-in caller could
+   distinguish "backup id exists on someone else's agent" from "does not
+   exist". Fix: mapped to the same 404 "No backup found" (gated ≠ owned;
+   org-scoping unchanged — the check itself already prevented the restore).
+3. **bridge + stream: unguarded `await request.json()`** — an empty or
+   malformed body (client abort, curl without body) → SyntaxError → **500**
+   instead of the typed 400 the zod schema path returns for every other bad
+   body. Fix: `json().catch(() => { throw ValidationError("Invalid JSON body") })`
+   (`error-policy:J3`), identical to the create route's existing guard.
+
+## Proof
+
+Unit test `packages/cloud/api/__tests__/eliza-agents-restore-body-guard.test.ts`
+— real route modules + real repositories on in-process PGlite
+(`pglite://memory`), real `agent_sandboxes` + `agent_sandbox_backups` rows
+across TWO orgs; the only mocked seam is `requireAuthOrApiKeyWithOrg`
+(same harness as `org-credentials-routes.test.ts` /
+`my-agents-characters-search-bio-guard.test.ts`).
+
+- RED without the fix (routes stashed): **6 fail / 3 pass** — bodyless
+  restore, malformed restore body, foreign-backupId restore, bodyless bridge,
+  malformed bridge, bodyless stream all returned 500.
+- GREEN with the fix: **9 pass / 0 fail** (`Ran 9 tests across 1 file`).
+- Mutation checks: console `{}` body ≡ no body (404 "No backup found");
+  parsed `backupId` still drives the real service path (409
+  "Stopped agents can only restore the latest backup" for a non-latest
+  backup on a stopped agent); valid-JSON invalid-schema bridge body still
+  hits the zod 400 (guard is parse-only).
+- `bun run --cwd packages/cloud/api typecheck` clean; `lint` (biome) clean;
+  `bun run audit:error-policy-ratchet` → "no new fallback-slop in touched
+  files"; neighbor suites green (`agent-bridge-runtime-routing.test.ts` 2/2,
+  `pairing-token/route.test.ts` 9/9).
+
+N/A — screenshots/video: backend-only status-code change, no rendered UI
+delta (console already sends `{}` and never hit the bodyless path).
+N/A — model trajectories: no agent/model behavior touched.

--- a/packages/cloud/api/__tests__/eliza-agents-restore-body-guard.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-restore-body-guard.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Agent-management POST routes must not 500 on caller-shaped input (#13406).
+ *
+ * /restore ran an unguarded `await request.json()`, so the canonical
+ * bodyless "restore the latest backup" call (every field is optional) threw a
+ * SyntaxError that errorToResponse maps to 500 — same for /bridge and
+ * /stream on an empty or malformed body. /restore also surfaced the
+ * service's "Backup does not belong to this agent" ownership check as a 500
+ * with a distinct message, making backup ids a cross-agent/cross-org
+ * existence oracle. Real route modules + real repositories against
+ * in-process PGlite; the only mocked seam is `requireAuthOrApiKeyWithOrg`
+ * (same pattern as org-credentials-routes / my-agents-characters-search).
+ */
+
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { Hono } from "hono";
+import * as realAuth from "@/lib/auth";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const ORG_A = "11111111-1111-4111-8111-111111111111";
+const ORG_B = "22222222-2222-4222-8222-222222222222";
+const USER_A = "aaaaaaaa-1111-4111-8111-111111111111";
+const USER_B = "bbbbbbbb-1111-4111-8111-111111111111";
+const AGENT_A = "cccccccc-1111-4111-8111-111111111111";
+const AGENT_B = "cccccccc-2222-4222-8222-222222222222";
+const BACKUP_B = "dddddddd-1111-4111-8111-111111111111";
+const BACKUP_A_OLD = "dddddddd-2222-4222-8222-222222222222";
+const BACKUP_A_NEW = "dddddddd-3333-4333-8333-333333333333";
+
+// Caller is always org A's user; agent B + backup B live in org B so the
+// cross-org backupId probe exercises the ownership check for real.
+mock.module("@/lib/auth", () => ({
+  ...realAuth,
+  requireAuthOrApiKeyWithOrg: mock(async () => ({
+    user: {
+      id: USER_A,
+      email: "owner@test.test",
+      organization_id: ORG_A,
+      organization: { id: ORG_A, name: "Org A", is_active: true },
+      is_active: true,
+      role: "owner",
+    },
+  })),
+}));
+
+const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+
+let pgliteReady = true;
+let closeDb: (() => Promise<void>) | undefined;
+let app: Hono<AppEnv>;
+
+beforeAll(async () => {
+  try {
+    const { closeDatabaseConnectionsForTests, dbWrite } = await import(
+      "@/db/client"
+    );
+    closeDb = closeDatabaseConnectionsForTests;
+
+    const { organizations } = await import("@/db/schemas/organizations");
+    const { users } = await import("@/db/schemas/users");
+    const { userCharacters } = await import("@/db/schemas/user-characters");
+    const { agentSandboxes, agentSandboxBackups } = await import(
+      "@/db/schemas/agent-sandboxes"
+    );
+    const { pushSchema } = await import("@/db/push-schema-for-tests");
+    const { apply } = await pushSchema(
+      {
+        organizations,
+        users,
+        userCharacters,
+        agentSandboxes,
+        agentSandboxBackups,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+
+    await dbWrite.insert(organizations).values([
+      { id: ORG_A, name: "Org A", slug: "org-a" },
+      { id: ORG_B, name: "Org B", slug: "org-b" },
+    ]);
+    await dbWrite.insert(users).values([
+      {
+        id: USER_A,
+        email: "owner@test.test",
+        organization_id: ORG_A,
+        role: "owner",
+        steward_user_id: `steward-${USER_A}`,
+      },
+      {
+        id: USER_B,
+        email: "other@test.test",
+        organization_id: ORG_B,
+        role: "owner",
+        steward_user_id: `steward-${USER_B}`,
+      },
+    ]);
+
+    // Agent A: dedicated, never provisioned (status "stopped", no bridge) —
+    // the fresh/suspended console state the restore panel acts on.
+    await dbWrite.insert(agentSandboxes).values([
+      {
+        id: AGENT_A,
+        organization_id: ORG_A,
+        user_id: USER_A,
+        agent_name: "Agent A",
+        execution_tier: "dedicated-lazy",
+        status: "stopped",
+      },
+      {
+        id: AGENT_B,
+        organization_id: ORG_B,
+        user_id: USER_B,
+        agent_name: "Agent B",
+        execution_tier: "dedicated-lazy",
+        status: "stopped",
+      },
+    ]);
+
+    // Backups: one for org B's agent (the foreign backupId probe target) —
+    // agent A starts with NONE (the empty first-time state).
+    await dbWrite.insert(agentSandboxBackups).values([
+      {
+        id: BACKUP_B,
+        sandbox_record_id: AGENT_B,
+        snapshot_type: "manual",
+        state_data: { memories: [], config: {}, workspaceFiles: {} },
+        size_bytes: 16,
+      },
+    ]);
+
+    const restoreRoute = (
+      await import("../v1/eliza/agents/[agentId]/restore/route")
+    ).default;
+    const bridgeRoute = (
+      await import("../v1/eliza/agents/[agentId]/bridge/route")
+    ).default;
+    const streamRoute = (
+      await import("../v1/eliza/agents/[agentId]/stream/route")
+    ).default;
+    app = new Hono<AppEnv>();
+    app.route("/api/v1/eliza/agents/:agentId/restore", restoreRoute);
+    app.route("/api/v1/eliza/agents/:agentId/bridge", bridgeRoute);
+    app.route("/api/v1/eliza/agents/:agentId/stream", streamRoute);
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[eliza-agents-restore-body-guard.test] setup failed — failing.",
+      error,
+    );
+  }
+}, 120_000);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+  mock.restore();
+});
+
+function post(path: string, body?: BodyInit, contentType = "application/json") {
+  return app.request(
+    path,
+    {
+      method: "POST",
+      headers: body === undefined ? {} : { "Content-Type": contentType },
+      ...(body === undefined ? {} : { body }),
+    },
+    ENV,
+  );
+}
+
+describe("POST /api/v1/eliza/agents/:agentId/restore — body + ownership guards", () => {
+  test("bodyless restore-latest with no backups is a typed 404, not a 500", async () => {
+    expect(pgliteReady).toBe(true);
+
+    const res = await post(`/api/v1/eliza/agents/${AGENT_A}/restore`);
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("No backup found");
+  });
+
+  test("console `{}` body behaves identically to no body", async () => {
+    expect(pgliteReady).toBe(true);
+
+    const res = await post(
+      `/api/v1/eliza/agents/${AGENT_A}/restore`,
+      JSON.stringify({}),
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("No backup found");
+  });
+
+  test("malformed JSON body is a typed 400, not a 500", async () => {
+    expect(pgliteReady).toBe(true);
+
+    const res = await post(`/api/v1/eliza/agents/${AGENT_A}/restore`, "{nope");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Invalid JSON body");
+  });
+
+  test("another org's backupId is indistinguishable from a nonexistent one (404, no oracle)", async () => {
+    expect(pgliteReady).toBe(true);
+
+    const foreign = await post(
+      `/api/v1/eliza/agents/${AGENT_A}/restore`,
+      JSON.stringify({ backupId: BACKUP_B }),
+    );
+    expect(foreign.status).toBe(404);
+    const foreignBody = (await foreign.json()) as { error: string };
+    expect(foreignBody.error).toBe("No backup found");
+
+    const missing = await post(
+      `/api/v1/eliza/agents/${AGENT_A}/restore`,
+      JSON.stringify({ backupId: "eeeeeeee-1111-4111-8111-111111111111" }),
+    );
+    expect(missing.status).toBe(404);
+    const missingBody = (await missing.json()) as { error: string };
+    expect(missingBody.error).toBe("No backup found");
+  });
+
+  test("parsed backupId still drives the real service path (409 on non-latest for a stopped agent)", async () => {
+    expect(pgliteReady).toBe(true);
+
+    const { dbWrite } = await import("@/db/client");
+    const { agentSandboxBackups } = await import(
+      "@/db/schemas/agent-sandboxes"
+    );
+    await dbWrite.insert(agentSandboxBackups).values([
+      {
+        id: BACKUP_A_OLD,
+        sandbox_record_id: AGENT_A,
+        snapshot_type: "manual",
+        state_data: { memories: [], config: {}, workspaceFiles: {} },
+        size_bytes: 16,
+        created_at: new Date("2026-07-01T00:00:00.000Z"),
+      },
+      {
+        id: BACKUP_A_NEW,
+        sandbox_record_id: AGENT_A,
+        snapshot_type: "manual",
+        state_data: { memories: [], config: {}, workspaceFiles: {} },
+        size_bytes: 16,
+        created_at: new Date("2026-07-02T00:00:00.000Z"),
+      },
+    ]);
+
+    const res = await post(
+      `/api/v1/eliza/agents/${AGENT_A}/restore`,
+      JSON.stringify({ backupId: BACKUP_A_OLD }),
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe(
+      "Stopped agents can only restore the latest backup",
+    );
+  });
+});
+
+describe("POST /bridge and /stream — malformed body guards", () => {
+  test("bodyless bridge call is a typed 400, not a 500", async () => {
+    expect(pgliteReady).toBe(true);
+
+    const res = await post(`/api/v1/eliza/agents/${AGENT_A}/bridge`);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Invalid JSON body");
+  });
+
+  test("malformed bridge body is a typed 400", async () => {
+    expect(pgliteReady).toBe(true);
+
+    const res = await post(`/api/v1/eliza/agents/${AGENT_A}/bridge`, "{nope");
+    expect(res.status).toBe(400);
+  });
+
+  test("bodyless stream call is a typed 400, not a 500", async () => {
+    expect(pgliteReady).toBe(true);
+
+    const res = await post(`/api/v1/eliza/agents/${AGENT_A}/stream`);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid JSON body");
+  });
+
+  test("valid-JSON invalid-schema bridge body still returns the zod 400 (guard is parse-only)", async () => {
+    expect(pgliteReady).toBe(true);
+
+    const res = await post(
+      `/api/v1/eliza/agents/${AGENT_A}/bridge`,
+      JSON.stringify({ method: "message.send" }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid JSON-RPC request");
+  });
+});

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 eliza agents agentid bridge route traffic with route-local auth expectations.
 import { Hono } from "hono";
 import { z } from "zod";
-import { errorToResponse } from "@/lib/api/errors";
+import { errorToResponse, ValidationError } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import type { BridgeRequest } from "@/lib/services/eliza-sandbox";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
@@ -34,7 +34,12 @@ async function __hono_POST(
   try {
     const { user } = await requireAuthOrApiKeyWithOrg(request);
     const { agentId } = await params;
-    const body = await request.json();
+    // A missing/malformed JSON body is caller error: a typed 400, not the
+    // unguarded SyntaxError that errorToResponse maps to a 500.
+    const body = await request.json().catch(() => {
+      // error-policy:J3 untrusted request body — malformed JSON becomes a typed 400 "invalid" result
+      throw new ValidationError("Invalid JSON body");
+    });
 
     const parsed = bridgeRequestSchema.safeParse(body);
     if (!parsed.success) {

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/restore/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/restore/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 eliza agents agentid restore route traffic with route-local auth expectations.
 import { Hono } from "hono";
 import { z } from "zod";
-import { errorToResponse } from "@/lib/api/errors";
+import { errorToResponse, ValidationError } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
@@ -27,7 +27,21 @@ async function __hono_POST(
   try {
     const { user } = await requireAuthOrApiKeyWithOrg(request);
     const { agentId } = await params;
-    const body = await request.json();
+
+    // Every field is optional, so a bodyless POST is the canonical
+    // "restore the latest backup" call — treat an empty body as `{}`.
+    // Malformed non-empty JSON is the caller's fault: a typed 400, not the
+    // unguarded SyntaxError that errorToResponse maps to a 500.
+    const rawBody = await request.text();
+    let body: unknown = {};
+    if (rawBody.trim().length > 0) {
+      try {
+        body = JSON.parse(rawBody);
+      } catch {
+        // error-policy:J3 untrusted request body — malformed JSON becomes a typed 400 "invalid" result
+        throw new ValidationError("Invalid JSON body");
+      }
+    }
 
     const parsed = restoreSchema.safeParse(body);
     if (!parsed.success) {
@@ -51,6 +65,21 @@ async function __hono_POST(
     );
 
     if (!result.success) {
+      // A backupId that exists but belongs to a different agent must be
+      // indistinguishable from one that does not exist (same 404 + message):
+      // the service's ownership check is not a server fault (was a 500), and
+      // a distinct response would make backup ids a cross-agent/cross-org
+      // existence oracle (gated ≠ owned).
+      if (result.error === "Backup does not belong to this agent") {
+        return applyCorsHeaders(
+          Response.json(
+            { success: false, error: "No backup found" },
+            { status: 404 },
+          ),
+          CORS_METHODS,
+        );
+      }
+
       const status =
         result.error === "Agent not found"
           ? 404

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.ts
@@ -1,7 +1,7 @@
 // Handles v1 cloud API v1 eliza agents agentid stream route traffic with route-local auth expectations.
 import { Hono } from "hono";
 import { z } from "zod";
-import { errorToResponse } from "@/lib/api/errors";
+import { errorToResponse, ValidationError } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import type { BridgeRequest } from "@/lib/services/eliza-sandbox";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
@@ -104,7 +104,12 @@ async function __hono_POST(
   try {
     const { user } = await requireAuthOrApiKeyWithOrg(request);
     const { agentId } = await params;
-    const body = await request.json();
+    // A missing/malformed JSON body is caller error: a typed 400, not the
+    // unguarded SyntaxError that errorToResponse maps to a 500.
+    const body = await request.json().catch(() => {
+      // error-policy:J3 untrusted request body — malformed JSON becomes a typed 400 "invalid" result
+      throw new ValidationError("Invalid JSON body");
+    });
 
     const parsed = streamRequestSchema.safeParse(body);
     if (!parsed.success) {


### PR DESCRIPTION
## Agent-management backend 500-class audit (#13406)

Same discipline as the my-agents 500 (#13495) and the console page-load sweep (#13637): audited every backend endpoint the console `/dashboard/agents` + agent-detail pages fire (`packages/cloud/api/v1/eliza/agents/**`), hunting the NON-stub class — unguarded throws mapped to 500 on the normal/empty/not-provisioned signed-in load. Stub-drift is closed + mirror-guarded (#13557) and was not re-audited; wallet/credit money paths left to the money lane.

### Bugs fixed (3 handlers, one shared class)

1. **`POST /:agentId/restore` — unguarded `await request.json()` → 500 on the canonical call.** Every `restoreSchema` field is optional, so a bodyless POST is the natural "restore the latest backup" request — it threw a `SyntaxError` that `errorToResponse` maps to **500**. Now: empty body ⇒ `{}` (restore-latest semantics, proper 2xx/typed-4xx path), malformed non-empty JSON ⇒ typed 400 `ValidationError` (`error-policy:J3`).
2. **`POST /:agentId/restore` — cross-agent backupId → 500 + existence oracle.** The service's "Backup does not belong to this agent" ownership result fell through the status map to a **500** with a distinct message, letting any signed-in user distinguish a foreign backup id from a nonexistent one. Now returns the same 404 "No backup found" (gated ≠ owned; the ownership check itself is unchanged).
3. **`POST /:agentId/bridge` + `POST /:agentId/stream` — same unguarded parse.** Empty/malformed body → 500 instead of the typed 400 the zod path returns for every other bad body. Guarded with the identical `json().catch(() => { throw ValidationError })` pattern the create route already uses.

### Clean endpoints (audited handler + the cloud-shared repos/services each calls)

GET list, GET detail, GET backups, POST pairing-token, POST create, provision, resume, sleep, wake, snapshot, PATCH (suspend/edit), DELETE — all handle the freshly-created / never-provisioned / stopped / empty-backups / first-login states with typed 2xx/4xx. Full per-endpoint reasoning table: `.github/issue-evidence/13406-agent-mgmt-backend-500-audit.md`.

### Evidence (PR_EVIDENCE rows)

- **Real E2E-style unit test** — `packages/cloud/api/__tests__/eliza-agents-restore-body-guard.test.ts`: real route modules + real repositories on in-process PGlite, real `agent_sandboxes`/`agent_sandbox_backups` rows across two orgs; only the auth seam mocked (same harness as `org-credentials-routes.test.ts` / `my-agents-characters-search-bio-guard.test.ts`).
- **RED → GREEN**: without the fix 6/9 fail (all 500s: bodyless restore, malformed restore, foreign backupId, bodyless bridge, malformed bridge, bodyless stream); with it 9/9 pass.
- **Mutation checks**: console `{}` body ≡ no body; parsed `backupId` still drives the real service path (409 non-latest on a stopped agent); valid-JSON invalid-schema bridge body still hits the zod 400.
- **Gates**: `typecheck` (tsgo) clean · biome `lint` clean · `audit:error-policy-ratchet` clean · neighbor suites green (`agent-bridge-runtime-routing` 2/2, `pairing-token/route.test` 9/9).
- Screenshots/video: **N/A** — backend status-code fix only; the console always sends `{}` and never hit the bodyless path, so there is no rendered UI delta.
- Model trajectories: **N/A** — no agent/model behavior touched.

Tracker: #13406.

[cloud-agent]

---
**Authored by a Fable-5 agent** (pure — 100% claude-fable-5), committed+pushed. Main-loop re-verification: pure ✓; clean 5-file diff; restore/bridge/stream body-guard test **9/9 pass** (real route modules + real PGlite, 2 orgs); cloud-api typecheck 0 errors; agent's RED→GREEN (6/9 fail → 9/9) + mutation-checked; error-policy-ratchet clean. Also closes a cross-org backup-id existence oracle (restore now returns the same 404 for foreign + nonexistent). 12 other agent-management endpoints statically verified clean (not-provisioned/stopped/empty states → typed 2xx/4xx). — [cloud-agent]