### PR TITLE
fix(#13623): scenario-runner reports real LLM spend, stops fabricating flaky-pass count

### DIFF
--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -375,6 +375,9 @@ async function main(): Promise<number> {
     startedAtIso,
     completedAtIso,
     effectiveRunId,
+    // Sum real per-trajectory spend from <runDir>/trajectories/ so
+    // matrix.json's totalCostUsd reflects the run instead of a hardcoded 0.
+    effectiveRunDir,
   );
 
   if (parsed.exportNativePath && effectiveRunDir) {

--- a/packages/scenario-runner/src/reporter.test.ts
+++ b/packages/scenario-runner/src/reporter.test.ts
@@ -14,6 +14,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildAggregate,
   printStdoutSummary,
+  sumTrajectoryCostUsd,
   writeReportBundle,
   writeScenarioRunViewer,
 } from "./reporter.ts";
@@ -69,7 +70,6 @@ function aggregateReport(): AggregateReport {
       passed: 1,
       failed: 0,
       skipped: 0,
-      flakyPassed: 0,
       costUsd: 0,
       finalChecksSkipped: 0,
     },
@@ -77,7 +77,6 @@ function aggregateReport(): AggregateReport {
     passedCount: 1,
     failedCount: 0,
     skippedCount: 0,
-    flakyPassedCount: 0,
     totalCostUsd: 0,
   };
 }
@@ -229,11 +228,19 @@ describe("scenario report aggregation", () => {
         passed: 1,
         failed: 1,
         skipped: 1,
-        flakyPassed: 0,
         costUsd: 0,
         finalChecksSkipped: 0,
       },
     });
+    // A run with no trajectories (no runDir) reports honest $0 spend and no
+    // longer carries the fabricated flaky-pass count.
+    expect(report.totalCostUsd).toBe(0);
+    expect(
+      (report as unknown as Record<string, unknown>).flakyPassedCount,
+    ).toBeUndefined();
+    expect(
+      (report.totals as unknown as Record<string, unknown>).flakyPassed,
+    ).toBeUndefined();
   });
 
   it("counts skipped finalChecks loudly in totals and the stdout summary", () => {
@@ -326,5 +333,91 @@ describe("scenario report aggregation", () => {
     expect(output).toContain("| todos.create-basic | failed | 1000ms |");
     expect(output).toContain("bad \\| value second line");
     expect(output).not.toContain("bad | value\nsecond line");
+  });
+});
+
+function writeTrajectory(
+  runDir: string,
+  relPath: string,
+  payload: unknown,
+): void {
+  const full = path.join(runDir, "trajectories", relPath);
+  mkdirSync(path.dirname(full), { recursive: true });
+  writeFileSync(full, JSON.stringify(payload), "utf-8");
+}
+
+describe("trajectory cost aggregation", () => {
+  it("returns 0 when there is no run dir or no trajectories", () => {
+    expect(sumTrajectoryCostUsd(undefined)).toBe(0);
+    const emptyDir = makeTempDir("scenario-cost-empty-");
+    expect(sumTrajectoryCostUsd(emptyDir)).toBe(0);
+  });
+
+  it("sums real per-trajectory metrics.totalCostUsd across the run", () => {
+    const runDir = makeTempDir("scenario-cost-");
+    writeTrajectory(runDir, "agent-1/traj-1.json", {
+      trajectoryId: "traj-1",
+      metrics: { totalCostUsd: 0.0125 },
+      stages: [{ model: { costUsd: 999 } }], // ignored: rolled metric wins
+    });
+    writeTrajectory(runDir, "agent-2/traj-2.json", {
+      trajectoryId: "traj-2",
+      metrics: { totalCostUsd: 0.005 },
+      stages: [],
+    });
+
+    expect(sumTrajectoryCostUsd(runDir)).toBeCloseTo(0.0175, 10);
+  });
+
+  it("falls back to stage-level model.costUsd when no rolled metric exists", () => {
+    const runDir = makeTempDir("scenario-cost-fallback-");
+    writeTrajectory(runDir, "traj-3.json", {
+      trajectoryId: "traj-3",
+      stages: [
+        { model: { costUsd: 0.002 } },
+        { model: { costUsd: 0.003 } },
+        { kind: "tool" }, // no model stage contributes 0
+      ],
+    });
+
+    expect(sumTrajectoryCostUsd(runDir)).toBeCloseTo(0.005, 10);
+  });
+
+  it("ignores corrupt/NaN/negative costs instead of poisoning the total", () => {
+    const runDir = makeTempDir("scenario-cost-corrupt-");
+    writeTrajectory(runDir, "good.json", {
+      metrics: { totalCostUsd: 0.01 },
+    });
+    // Unparseable JSON file — must not throw or NaN the total.
+    const corruptPath = path.join(runDir, "trajectories", "corrupt.json");
+    writeFileSync(corruptPath, "{ not json", "utf-8");
+    // Non-numeric / negative rolled metric falls back and stays finite.
+    writeTrajectory(runDir, "weird.json", {
+      metrics: { totalCostUsd: "NaN" },
+      stages: [{ model: { costUsd: -5 } }, { model: { costUsd: 0.004 } }],
+    });
+
+    const total = sumTrajectoryCostUsd(runDir);
+    expect(Number.isFinite(total)).toBe(true);
+    expect(total).toBeCloseTo(0.014, 10);
+  });
+
+  it("threads the summed cost into buildAggregate.totalCostUsd (> 0 on a costed run)", () => {
+    const runDir = makeTempDir("scenario-cost-aggregate-");
+    writeTrajectory(runDir, "traj.json", {
+      metrics: { totalCostUsd: 0.0421 },
+    });
+
+    const report = buildAggregate(
+      [{ ...aggregateReport().scenarios[0] }],
+      "anthropic-claude",
+      "2026-05-23T00:00:00.000Z",
+      "2026-05-23T00:01:00.000Z",
+      "run-cost",
+      runDir,
+    );
+
+    expect(report.totalCostUsd).toBeCloseTo(0.0421, 10);
+    expect(report.totals.costUsd).toBeCloseTo(0.0421, 10);
   });
 });

--- a/packages/scenario-runner/src/reporter.ts
+++ b/packages/scenario-runner/src/reporter.ts
@@ -16,18 +16,55 @@ import path from "node:path";
 import { logger } from "@elizaos/core";
 import type { AggregateReport, ScenarioReport } from "./types.ts";
 
+/**
+ * Walk `<runDir>/trajectories/**\/*.json` and sum the real per-trajectory LLM
+ * spend so the aggregate report's `totalCostUsd` reflects what the run actually
+ * cost instead of a hardcoded `0`.
+ *
+ * Each persisted trajectory carries a top-level `metrics.totalCostUsd` (summed
+ * by the recorder from every model stage); we prefer that and fall back to
+ * summing `stages[].model.costUsd` directly when a trajectory predates the
+ * rolled-up metric. Only finite, non-negative values are counted — a corrupt
+ * or unreadable trajectory contributes `0` rather than poisoning the total with
+ * `NaN`. Returns `0` when no run dir / no trajectories exist (honest absence,
+ * not a fabricated spend of `0` on a real live run — callers pass a runDir only
+ * when trajectories were actually recorded).
+ */
+export function sumTrajectoryCostUsd(runDir: string | undefined): number {
+  if (!runDir) return 0;
+  const trajectoriesDir = path.join(runDir, "trajectories");
+  if (!existsSync(trajectoriesDir)) return 0;
+  let total = 0;
+  for (const file of collectFiles(trajectoriesDir)) {
+    if (!file.endsWith(".json")) continue;
+    const payload = asRecord(readJsonFile(file));
+    const rolled = asNumber(asRecord(payload.metrics).totalCostUsd);
+    if (rolled !== null && rolled >= 0) {
+      total += rolled;
+      continue;
+    }
+    // Fallback: sum stage-level costs for trajectories without a rolled metric.
+    const stages = Array.isArray(payload.stages) ? payload.stages : [];
+    for (const stage of stages) {
+      const stageCost = asNumber(asRecord(asRecord(stage).model).costUsd);
+      if (stageCost !== null && stageCost >= 0) total += stageCost;
+    }
+  }
+  return total;
+}
+
 export function buildAggregate(
   scenarios: ScenarioReport[],
   providerName: string | null,
   startedAtIso: string,
   completedAtIso: string,
   runId: string,
+  runDir?: string,
 ): AggregateReport {
   const totals = {
     passed: 0,
     failed: 0,
     skipped: 0,
-    flakyPassed: 0,
     costUsd: 0,
     finalChecksSkipped: 0,
   };
@@ -39,6 +76,7 @@ export function buildAggregate(
       if (check.status === "skipped") totals.finalChecksSkipped += 1;
     }
   }
+  totals.costUsd = sumTrajectoryCostUsd(runDir);
   return {
     runId,
     startedAtIso,
@@ -50,7 +88,6 @@ export function buildAggregate(
     passedCount: totals.passed,
     failedCount: totals.failed,
     skippedCount: totals.skipped,
-    flakyPassedCount: totals.flakyPassed,
     totalCostUsd: totals.costUsd,
   };
 }

--- a/packages/scenario-runner/src/types.ts
+++ b/packages/scenario-runner/src/types.ts
@@ -109,7 +109,11 @@ export interface AggregateReport {
     passed: number;
     failed: number;
     skipped: number;
-    flakyPassed: number;
+    /**
+     * Real summed LLM spend across the run's recorded trajectories
+     * (`metrics.totalCostUsd` per trajectory). `0` only when no trajectories
+     * were recorded (no `--run-dir`), never fabricated on a costed run.
+     */
     costUsd: number;
     /**
      * finalChecks across all scenarios that reported status `skipped`
@@ -124,7 +128,6 @@ export interface AggregateReport {
   passedCount: number;
   failedCount: number;
   skippedCount: number;
-  flakyPassedCount: number;
   totalCostUsd: number;
 }
 


### PR DESCRIPTION
Closes part of #13623 (the **fabricated aggregate metrics** task). Distinct slice from the provider-recording / `evidenceGrade` / native-export-attestation tasks in the same issue.

## Problem

`packages/scenario-runner/src/reporter.ts` `buildAggregate` initialized `totals.costUsd` and `totals.flakyPassed` to `0` and **never incremented** them, yet serialized both as `totalCostUsd` / `flakyPassedCount` into `matrix.json`, `report.json`, and the run viewer. So:

- Every report showed **$0 spend** regardless of real model cost — which *does* exist per-stage at `stage.model.costUsd` and rolled up per-trajectory at `metrics.totalCostUsd`. The downstream `packages/scripts/aggregate-scenario-reports.mjs` then summed a hardcoded `0` into its `- LLM cost: $…` line.
- `flakyPassedCount` was always `0` — a metric the runner never actually measures (there is no flaky-retry mechanism), and `reporter.test.ts` locked in `0` as the "expected" value.

## Fix

- New exported **`sumTrajectoryCostUsd(runDir)`**: walks `<runDir>/trajectories/**/*.json` and sums each trajectory's rolled `metrics.totalCostUsd`, falling back to summing `stages[].model.costUsd` when a trajectory predates the rolled metric. Only **finite, non-negative** values count, so a corrupt/unreadable/`NaN` trajectory contributes `0` instead of poisoning the total. Returns `0` when there's no run dir or no trajectories — honest absence, not a fabricated `$0` on a costed run (callers only pass a runDir when trajectories were recorded).
- `buildAggregate` takes an optional `runDir` and sets `totals.costUsd` from it; `cli.ts` threads `effectiveRunDir`. So `matrix.json.totalCostUsd` now equals the summed trajectory spend (**> 0 on a costed run**).
- **Removed** the fabricated `flakyPassed` / `flakyPassedCount` from the runner's `AggregateReport` (types + reporter + tests). The downstream aggregator already reads `?? 0`, so absence is safe and no longer fabricates a metric that was never measured.

## Acceptance criteria addressed

> A live `--run-dir` run's `matrix.json.totalCostUsd` equals the summed `stage.model.costUsd` (> 0).

Now true: `totalCostUsd` is the summed per-trajectory spend, `> 0` on a costed run, `0` only when no trajectories exist.

(The provider-recording / `evidenceGrade` / `requireLiveProvider` / native-export attestation tasks in #13623 are separate slices — issue stays open.)

## Tests

`packages/scenario-runner/src/reporter.test.ts` — **11/11 green**:
- +4 new cost cases: no-runDir/no-trajectories → 0; sums real `metrics.totalCostUsd` across a run (rolled metric wins over stage cost); stage-level `model.costUsd` fallback; ignores corrupt JSON / `NaN` / negative costs without poisoning the total; `buildAggregate.totalCostUsd` **> 0** on a costed run.
- Updated the aggregation test to assert the fabricated `flakyPassed`/`flakyPassedCount` fields are gone and cost stays honest `0` with no runDir.

Gates:
- `scenario-runner` `tsgo` — **zero new errors** vs pristine `origin/develop` (51 == 51 pre-existing baseline in unrelated `../ui/*`/plugin symlink files, verified by patch-out/re-apply).
- `biome` clean on changed lines (one pre-existing `develop` format drift on an untouched `detail:` string line left as-is, confirmed identical on pristine develop).
- `audit:error-policy-ratchet` — "no new fallback-slop in touched files".

Files: `packages/scenario-runner/src/{reporter.ts,types.ts,cli.ts,reporter.test.ts}`.

— [sol-orch]