### PR TITLE
fix(#13618): make live and deploy gates fail honestly

### DIFF
--- a/.github/issue-evidence/13618-live-deploy-gates.md
+++ b/.github/issue-evidence/13618-live-deploy-gates.md
@@ -1,0 +1,29 @@
+# Issue #13618 — Honest Live/Deploy Gates
+
+## Fix
+
+- Cloud live E2E now fails in strict contexts (push, merge_group, workflow_dispatch, schedule) when the Eliza Cloud API key is missing instead of producing a green skip.
+- Scheduled/dispatch remote capability cloud smoke now fails when the capability flag is not enabled, so report-producing runs cannot silently skip.
+- Provider live E2E now fails in strict contexts when all provider endpoints or required provider endpoints are missing.
+- Cloud CF deploy jobs now have job-level timeouts for API, console, and app deploys.
+- Worker e2e is a hard deploy gate again; `continue-on-error` was removed.
+- Voice live e2e no longer soft-passes an unprovisioned runner; missing fused ASR/model assets emit an error and exit 1.
+
+## Verification
+
+Static validation on the patched workflow payload:
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file("/tmp/eliza-13618/.github/workflows/test.yml"); YAML.load_file("/tmp/eliza-13618/.github/workflows/cloud-cf-deploy.yml"); YAML.load_file("/tmp/eliza-13618/.github/workflows/voice-live-e2e.yml"); puts "workflow yaml ok"'
+rg "continue-on-error: true|Skipping to a neutral" /tmp/eliza-13618/.github/workflows/cloud-cf-deploy.yml /tmp/eliza-13618/.github/workflows/voice-live-e2e.yml /tmp/eliza-13618/.github/workflows/test.yml
+```
+
+Full CI and deploy workflow evidence must be captured on the PR branch / dispatch runs.
+
+## Evidence Matrix
+
+- Missing-secret strict run: pending GitHub workflow run after PR creation.
+- Worker e2e seeded failure: pending deploy workflow verification.
+- Killed/stalled runner timeout: pending deploy workflow verification.
+- UI screenshots/video: N/A - workflow-only change.
+- Real LLM trajectories: N/A - no agent/action/prompt/model behavior changed.

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -200,6 +200,7 @@ jobs:
     # array such as ["self-hosted","Linux","X64","hetzner-robot"] to use the
     # Hetzner fleet; otherwise default to GitHub-hosted Ubuntu.
     runs-on: ${{ fromJSON(vars.CLOUD_CF_DEPLOY_RUNNER_JSON || '["ubuntu-latest"]') }}
+    timeout-minutes: 75
     # Schema gate (#11208): the Worker talks to the database, so it only
     # deploys after migrate-db succeeded for this same commit. A failed or
     # cancelled migrate-db skips this job — fail-closed.
@@ -370,11 +371,8 @@ jobs:
         run: bun run --cwd packages/cloud/api typecheck
 
       - name: Run Worker e2e
-        # Non-blocking: the avatar-upload e2e flakes intermittently against the
-        # self-hosted wrangler-dev box and was the ORIGINAL gate that stalled the
-        # release. Build + typecheck stay the hard gates; don't block deploy on a
-        # flaky test. (Mirrors the main hotfix #10398 that unwedged prod.)
-        continue-on-error: true
+        # Hard deploy gate (#13618): Worker behavior regressions must fail the
+        # deploy instead of shipping behind a green soft-failed e2e step.
         working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun run --cwd packages/cloud/api test:e2e
         env:
@@ -538,6 +536,7 @@ jobs:
     # previews always use GitHub-hosted runners because the shared deploy robot
     # can fail before any cleanup step while staging downloaded setup actions.
     runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || vars.CLOUD_CF_DEPLOY_RUNNER_JSON || '["ubuntu-latest"]') }}
+    timeout-minutes: 75
     # Schema gate (#11208): real (non-PR) deploys only run after migrate-db
     # succeeded, so the frontend never goes live ahead of the schema its API
     # features expect. PR previews are the ONE allowed skip: migrate-db is
@@ -899,6 +898,7 @@ jobs:
     # previews always use GitHub-hosted runners because the shared deploy robot
     # can fail before any cleanup step while staging downloaded setup actions.
     runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || vars.CLOUD_CF_DEPLOY_RUNNER_JSON || '["ubuntu-latest"]') }}
+    timeout-minutes: 75
     # Schema gate (#11208): same contract as deploy-console — non-PR deploys
     # require a successful migrate-db; PR previews (migrate-db skipped) still
     # run; failed/cancelled migrate-db skips this job (fail-closed).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -945,8 +945,18 @@ jobs:
           ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY != '' && secrets.ELIZAOS_CLOUD_API_KEY || secrets.ELIZACLOUD_API_KEY }}
           ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED: ${{ vars.ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED != '' && vars.ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED || secrets.ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED }}
         run: |
+          strict_context=false
+          case "${EVENT_NAME}" in
+            push|merge_group|workflow_dispatch|schedule) strict_context=true ;;
+          esac
+
           if [ -z "${ELIZAOS_CLOUD_API_KEY}" ]; then
-            echo "::warning::No Eliza Cloud API key configured - skipping optional cloud live E2E for ${EVENT_NAME}."
+            message="No Eliza Cloud API key configured"
+            if [ "${strict_context}" = "true" ]; then
+              echo "::error::${message}; strict ${EVENT_NAME} live lanes must fail instead of greening by skip."
+              exit 1
+            fi
+            echo "::warning::${message} - skipping optional cloud live E2E for ${EVENT_NAME}."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "capability_skip=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -957,6 +967,10 @@ jobs:
           if [ "${ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED}" = "1" ]; then
             echo "capability_skip=false" >> "$GITHUB_OUTPUT"
           else
+            if [ "${EVENT_NAME}" = "workflow_dispatch" ] || [ "${EVENT_NAME}" = "schedule" ]; then
+              echo "::error::Remote capability cloud sandbox live smoke is required for ${EVENT_NAME}; set ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED=1 instead of producing a green skip."
+              exit 1
+            fi
             echo "::notice::Remote capability cloud sandbox live smoke skipped because ELIZA_REMOTE_CAPABILITY_CLOUD_LIVE_ENABLED is not configured."
             echo "capability_skip=true" >> "$GITHUB_OUTPUT"
           fi
@@ -1075,8 +1089,18 @@ jobs:
           MOBILE_URL: ${{ secrets.ELIZA_REMOTE_CAPABILITY_MOBILE_COMPANION_URL }}
           DESKTOP_URL: ${{ secrets.ELIZA_REMOTE_CAPABILITY_DESKTOP_COMPANION_URL }}
         run: |
+          strict_context=false
+          case "${EVENT_NAME}" in
+            push|merge_group|workflow_dispatch|schedule) strict_context=true ;;
+          esac
+
           if [ -z "${E2B_URL}${HOME_URL}${MOBILE_URL}${DESKTOP_URL}" ]; then
-            echo "::warning::No remote capability provider endpoints configured - skipping optional provider live E2E."
+            message="No remote capability provider endpoints configured"
+            if [ "${strict_context}" = "true" ]; then
+              echo "::error::${message}; strict ${EVENT_NAME} live lanes must fail instead of greening by skip."
+              exit 1
+            fi
+            echo "::warning::${message} - skipping optional provider live E2E."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -1094,6 +1118,10 @@ jobs:
 
           if [ "${#missing_required[@]}" -gt 0 ]; then
             message="Missing required remote capability provider endpoint secrets: ${missing_required[*]}"
+            if [ "${strict_context}" = "true" ]; then
+              echo "::error::${message}; strict ${EVENT_NAME} live lanes must fail instead of greening by skip."
+              exit 1
+            fi
             echo "::warning::${message}. Skipping optional provider live E2E for ${EVENT_NAME}."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -109,8 +109,7 @@ jobs:
     env:
       ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
       CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
-    # Non-blocking: a missing GPU/model environment must not red-X the branch.
-    continue-on-error: true
+    # Hard live lane: a missing GPU/model environment must be visible as a failure.
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -306,7 +305,8 @@ jobs:
               echo "bundle), then re-dispatch:"
               echo "  gh workflow run voice-live-e2e.yml --ref develop"
             } | tee "$VOICE_REAL_MATRIX_OUT/SKIPPED.md"
-            echo "::warning title=Voice acoustic matrix skipped (runner not provisioned)::Missing fused libelizainference.so and/or the eliza-1-2b ASR bundle on this self-hosted runner. This lane needs the GPU runner staged per #9454 (.github/issue-evidence/9454-gpu-runner-provisioning.md). Skipping to a neutral result instead of a mid-run hard fail."
+            echo "::error title=Voice acoustic matrix runner not provisioned::Missing fused libelizainference.so and/or the eliza-1-2b ASR bundle on this self-hosted runner. This lane needs the GPU runner staged per #9454 (.github/issue-evidence/9454-gpu-runner-provisioning.md)."
+            exit 1
           fi
 
       - name: Setup Node.js


### PR DESCRIPTION
## Summary

Fixes #13618.

- fail cloud live E2E in strict contexts when the Eliza Cloud API key is missing instead of greening by skip
- fail scheduled/dispatch remote capability cloud smoke when the capability flag is disabled, so report-producing runs cannot silently skip
- fail provider live E2E in strict contexts when all provider endpoints or required endpoints are missing
- add job-level timeouts to Cloud CF API, console, and app deploy jobs
- make Worker e2e a hard deploy gate again by removing `continue-on-error`
- make voice live E2E fail when the self-hosted runner lacks the required fused ASR/model assets

## Verification

```bash
ruby -e 'require "yaml"; YAML.load_file("/tmp/eliza-13618/.github/workflows/test.yml"); YAML.load_file("/tmp/eliza-13618/.github/workflows/cloud-cf-deploy.yml"); YAML.load_file("/tmp/eliza-13618/.github/workflows/voice-live-e2e.yml"); puts "workflow yaml ok"'
rg "strict_context|greening by skip|capability cloud sandbox live smoke is required|Run Worker e2e|timeout-minutes: 75|continue-on-error: true|Skipping to a neutral|Voice acoustic matrix runner not provisioned" /tmp/eliza-13618/.github/workflows/test.yml /tmp/eliza-13618/.github/workflows/cloud-cf-deploy.yml /tmp/eliza-13618/.github/workflows/voice-live-e2e.yml
```

Evidence note: `.github/issue-evidence/13618-live-deploy-gates.md`

## Evidence matrix

- Missing-secret strict run: pending GitHub workflow run on branch/dispatch
- Worker e2e seeded failure: pending deploy workflow verification
- Killed/stalled runner timeout: pending deploy workflow verification
- UI screenshots/video: N/A - workflow-only change
- Real LLM trajectories: N/A - no agent/action/prompt/model behavior changed
