### PR TITLE
fix(#13621): story-gate console/a11y baseline is a pure allowlist, not an on/off switch

### DIFF
--- a/packages/ui/test/story-gate/run-story-gate.mjs
+++ b/packages/ui/test/story-gate/run-story-gate.mjs
@@ -267,6 +267,86 @@ function normalizeConsole(text) {
   return normalized;
 }
 
+/**
+ * Classify per-story render results against the console / a11y / broken
+ * allowlist baselines and produce the failure list + regenerated baselines.
+ *
+ * Doctrine (matches the `broken-baseline` ratchet): each baseline is a pure
+ * ALLOWLIST of pre-existing violations, never an on/off switch. A violation
+ * whose key is NOT in the allowlist reds the run. An empty or absent baseline
+ * therefore means fail-on-ANY violation (zero tolerance). This is the corrected
+ * behaviour after the inverted `Object.keys(baseline).length > 0` gate (which
+ * silently disabled the check whenever a baseline was emptied/reset).
+ *
+ * Pure + deterministic so it is unit-testable without a browser (see
+ * story-gate-classify.test.mjs). `main()` calls it with the live run results.
+ *
+ * @param {object} params
+ * @param {Array<object>} params.results per-story render results
+ * @param {Record<string, string[]>} params.consoleBaseline allowlisted console keys per story id
+ * @param {Record<string, string[]>} params.a11yBaseline allowlisted a11y rule ids per story id
+ * @param {Record<string, unknown>} params.brokenBaseline allowlisted known-broken story ids
+ * @param {boolean} [params.updateBaseline] when true, skip console/a11y failures (regeneration mode)
+ */
+export function classifyStoryGateFailures({
+  results,
+  consoleBaseline,
+  a11yBaseline,
+  brokenBaseline,
+  updateBaseline = false,
+}) {
+  const newConsoleBaseline = {};
+  const newA11yBaseline = {};
+  const newBrokenBaseline = {};
+  const failures = [];
+
+  for (const r of results) {
+    if (r.verdict === "broken") {
+      newBrokenBaseline[r.id] = (r.issues ?? []).join(" | ").slice(0, 200);
+    }
+    // console errors -> baseline keys
+    const consoleKeys = (r.consoleErrors ?? [])
+      .map(normalizeConsole)
+      .filter(Boolean);
+    if (consoleKeys.length)
+      newConsoleBaseline[r.id] = [...new Set(consoleKeys)];
+    const allowedConsole = new Set(consoleBaseline[r.id] || []);
+    const newConsole = consoleKeys.filter((k) => !allowedConsole.has(k));
+
+    // a11y -> baseline keys (rule id)
+    const a11yKeys = [...new Set((r.a11y ?? []).map((v) => v.id))];
+    if (a11yKeys.length) newA11yBaseline[r.id] = a11yKeys;
+    const allowedA11y = new Set(a11yBaseline[r.id] || []);
+    const newA11y = a11yKeys.filter((k) => !allowedA11y.has(k));
+
+    if (r.verdict === "broken" && !(r.id in brokenBaseline)) {
+      failures.push({
+        id: r.id,
+        kind: "broken",
+        detail: (r.issues ?? []).join(" | "),
+      });
+    }
+    // Console + a11y gating is ALWAYS on (baseline is a pure allowlist); a key
+    // absent from the allowlist reds regardless of how many rows it holds.
+    if (!updateBaseline && newConsole.length) {
+      failures.push({
+        id: r.id,
+        kind: "new-console-error",
+        detail: newConsole.join(" | "),
+      });
+    }
+    if (!updateBaseline && newA11y.length) {
+      failures.push({
+        id: r.id,
+        kind: "new-a11y-violation",
+        detail: newA11y.join(", "),
+      });
+    }
+  }
+
+  return { failures, newConsoleBaseline, newA11yBaseline, newBrokenBaseline };
+}
+
 // ---------------------------------------------------------------------------
 // per-story render + assert
 // ---------------------------------------------------------------------------
@@ -535,12 +615,15 @@ async function main() {
   // "no NEW broken stories" from day one while the existing set is fixed. Shape:
   // { "<story-id>": "<reason>" }. Regenerate via `--update-baseline`.
   const brokenBaseline = await loadBaseline("broken-baseline.json");
-  // Console + a11y gating is opt-in: it only enforces once a non-empty baseline
-  // has been committed (the team has captured the existing backlog). Until then
-  // the gate still HARD-fails on NEW broken/blank/threw stories — so it is
-  // useful and CI-safe from day one, then tightens as the baselines populate.
-  const enforceConsole = Object.keys(consoleBaseline).length > 0;
-  const enforceA11y = Object.keys(a11yBaseline).length > 0;
+  // Console + a11y gating is ALWAYS on, exactly like the broken-baseline ratchet
+  // above: each baseline is a pure ALLOWLIST of pre-existing violations, never a
+  // switch. An empty or absent baseline therefore means fail-on-ANY violation
+  // (zero tolerance) — the same shape as `broken-baseline.json = {}`.
+  //
+  // The old `Object.keys(baseline).length > 0` gate INVERTED this: emptying or
+  // resetting a baseline silently DISABLED the check (the opposite of a burn-down
+  // ratchet), so green-washing was one `echo '{}' > a11y-baseline.json` away.
+  // Enforcement now lives in classifyStoryGateFailures() and is unconditional.
 
   rmRecursive(outDir);
   await mkdir(outDir, { recursive: true });
@@ -584,46 +667,14 @@ async function main() {
   // -------------------------------------------------------------------------
   // classify against baselines
   // -------------------------------------------------------------------------
-  const newConsoleBaseline = {};
-  const newA11yBaseline = {};
-  const newBrokenBaseline = {};
-  const failures = [];
-
-  for (const r of results) {
-    if (r.verdict === "broken") {
-      newBrokenBaseline[r.id] = r.issues.join(" | ").slice(0, 200);
-    }
-    // console errors -> baseline keys
-    const consoleKeys = r.consoleErrors.map(normalizeConsole).filter(Boolean);
-    if (consoleKeys.length)
-      newConsoleBaseline[r.id] = [...new Set(consoleKeys)];
-    const allowedConsole = new Set(consoleBaseline[r.id] || []);
-    const newConsole = consoleKeys.filter((k) => !allowedConsole.has(k));
-
-    // a11y -> baseline keys (rule id)
-    const a11yKeys = [...new Set(r.a11y.map((v) => v.id))];
-    if (a11yKeys.length) newA11yBaseline[r.id] = a11yKeys;
-    const allowedA11y = new Set(a11yBaseline[r.id] || []);
-    const newA11y = a11yKeys.filter((k) => !allowedA11y.has(k));
-
-    if (r.verdict === "broken" && !(r.id in brokenBaseline)) {
-      failures.push({ id: r.id, kind: "broken", detail: r.issues.join(" | ") });
-    }
-    if (!args.updateBaseline && enforceConsole && newConsole.length) {
-      failures.push({
-        id: r.id,
-        kind: "new-console-error",
-        detail: newConsole.join(" | "),
-      });
-    }
-    if (!args.updateBaseline && enforceA11y && newA11y.length) {
-      failures.push({
-        id: r.id,
-        kind: "new-a11y-violation",
-        detail: newA11y.join(", "),
-      });
-    }
-  }
+  const { failures, newConsoleBaseline, newA11yBaseline, newBrokenBaseline } =
+    classifyStoryGateFailures({
+      results,
+      consoleBaseline,
+      a11yBaseline,
+      brokenBaseline,
+      updateBaseline: args.updateBaseline,
+    });
 
   // -------------------------------------------------------------------------
   // write artifacts
@@ -849,7 +900,11 @@ async function writeManualReview(dir, results, failures) {
   await writeFile(join(dir, "manual-review.md"), md);
 }
 
-main().catch((err) => {
-  console.error("story-gate: fatal", err);
-  process.exit(1);
-});
+// Only auto-run as a CLI; importing this module (e.g. from the classifier unit
+// test) must NOT launch a browser run.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error("story-gate: fatal", err);
+    process.exit(1);
+  });
+}

--- a/packages/ui/test/story-gate/story-gate-classify.test.mjs
+++ b/packages/ui/test/story-gate/story-gate-classify.test.mjs
@@ -1,0 +1,170 @@
+/**
+ * Regression tests for the story-gate console/a11y baseline ratchet
+ * (`classifyStoryGateFailures` in run-story-gate.mjs), issue #13621 task [2].
+ *
+ * The bug: `enforceConsole`/`enforceA11y` were gated on
+ * `Object.keys(baseline).length > 0`, which INVERTED the ratchet — emptying or
+ * resetting a baseline silently DISABLED the check (the opposite of a burn-down
+ * ratchet and the opposite of the correct `broken-baseline` sibling where
+ * `{}` = zero tolerance). These tests pin the corrected behaviour: the baseline
+ * is a pure ALLOWLIST, so an empty/absent baseline fails on ANY violation.
+ *
+ * Runs in the standard `packages/ui` vitest suite (env: node). Importing the
+ * module does not launch a browser — `main()` is guarded behind import.meta.
+ */
+import { describe, expect, it } from "vitest";
+import { classifyStoryGateFailures } from "./run-story-gate.mjs";
+
+/** Minimal per-story result shape the classifier consumes. */
+function story(overrides = {}) {
+  return {
+    id: "acme--widget",
+    verdict: "good",
+    issues: [],
+    consoleErrors: [],
+    a11y: [],
+    ...overrides,
+  };
+}
+
+describe("classifyStoryGateFailures console/a11y allowlist ratchet", () => {
+  it("REGRESSION: an EMPTY console baseline fails on any console error (was silently disabled)", () => {
+    const { failures } = classifyStoryGateFailures({
+      results: [story({ consoleErrors: ["TypeError: boom in widget"] })],
+      consoleBaseline: {}, // empty allowlist == zero tolerance
+      a11yBaseline: {},
+      brokenBaseline: {},
+    });
+    const consoleFailures = failures.filter(
+      (f) => f.kind === "new-console-error",
+    );
+    expect(consoleFailures).toHaveLength(1);
+    expect(consoleFailures[0].id).toBe("acme--widget");
+  });
+
+  it("REGRESSION: an EMPTY a11y baseline fails on any a11y violation (was silently disabled)", () => {
+    const { failures } = classifyStoryGateFailures({
+      results: [
+        story({ a11y: [{ id: "button-name" }, { id: "color-contrast" }] }),
+      ],
+      consoleBaseline: {},
+      a11yBaseline: {}, // empty allowlist == zero tolerance
+      brokenBaseline: {},
+    });
+    const a11yFailures = failures.filter(
+      (f) => f.kind === "new-a11y-violation",
+    );
+    expect(a11yFailures).toHaveLength(1);
+    expect(a11yFailures[0].detail).toContain("button-name");
+    expect(a11yFailures[0].detail).toContain("color-contrast");
+  });
+
+  it("a violation whose key IS in the allowlist does not fail", () => {
+    const { failures } = classifyStoryGateFailures({
+      results: [
+        story({
+          consoleErrors: ["TypeError: boom in widget"],
+          a11y: [{ id: "color-contrast" }],
+        }),
+      ],
+      // Allowlist the normalized console key + the a11y rule id.
+      consoleBaseline: { "acme--widget": ["TypeError: boom in widget"] },
+      a11yBaseline: { "acme--widget": ["color-contrast"] },
+      brokenBaseline: {},
+    });
+    expect(failures).toHaveLength(0);
+  });
+
+  it("a NEW violation absent from a POPULATED allowlist still reds (per-key ratchet)", () => {
+    const { failures } = classifyStoryGateFailures({
+      results: [
+        story({
+          a11y: [{ id: "color-contrast" }, { id: "button-name" }],
+        }),
+      ],
+      consoleBaseline: { "other--story": ["some old error"] }, // populated but unrelated
+      a11yBaseline: { "acme--widget": ["color-contrast"] }, // only one rule allowlisted
+      brokenBaseline: {},
+    });
+    const a11yFailures = failures.filter(
+      (f) => f.kind === "new-a11y-violation",
+    );
+    expect(a11yFailures).toHaveLength(1);
+    // Only the un-allowlisted rule is reported; the allowlisted one is filtered.
+    expect(a11yFailures[0].detail).toBe("button-name");
+  });
+
+  it("broken verdict: allowlisted id is tolerated, un-allowlisted id reds", () => {
+    const { failures } = classifyStoryGateFailures({
+      results: [
+        story({
+          id: "known--broken",
+          verdict: "broken",
+          issues: ["render threw"],
+        }),
+        story({
+          id: "new--broken",
+          verdict: "broken",
+          issues: ["blank render"],
+        }),
+      ],
+      consoleBaseline: {},
+      a11yBaseline: {},
+      brokenBaseline: { "known--broken": "render threw" },
+    });
+    const brokenFailures = failures.filter((f) => f.kind === "broken");
+    expect(brokenFailures).toHaveLength(1);
+    expect(brokenFailures[0].id).toBe("new--broken");
+  });
+
+  it("updateBaseline mode does not push console/a11y failures (regeneration pass)", () => {
+    const { failures, newConsoleBaseline, newA11yBaseline } =
+      classifyStoryGateFailures({
+        results: [
+          story({
+            consoleErrors: ["TypeError: boom in widget"],
+            a11y: [{ id: "button-name" }],
+          }),
+        ],
+        consoleBaseline: {},
+        a11yBaseline: {},
+        brokenBaseline: {},
+        updateBaseline: true,
+      });
+    expect(failures.filter((f) => f.kind === "new-console-error")).toHaveLength(
+      0,
+    );
+    expect(
+      failures.filter((f) => f.kind === "new-a11y-violation"),
+    ).toHaveLength(0);
+    // But the regenerated baselines still capture what it saw.
+    expect(newConsoleBaseline["acme--widget"]).toEqual([
+      "TypeError: boom in widget",
+    ]);
+    expect(newA11yBaseline["acme--widget"]).toEqual(["button-name"]);
+  });
+
+  it("a clean story with no violations produces no failures", () => {
+    const { failures } = classifyStoryGateFailures({
+      results: [story()],
+      consoleBaseline: {},
+      a11yBaseline: {},
+      brokenBaseline: {},
+    });
+    expect(failures).toHaveLength(0);
+  });
+
+  it("de-duplicates repeated console keys into the regenerated baseline", () => {
+    const { newConsoleBaseline } = classifyStoryGateFailures({
+      results: [
+        story({
+          consoleErrors: ["boom", "boom", "boom"],
+        }),
+      ],
+      consoleBaseline: { "acme--widget": ["boom"] },
+      a11yBaseline: {},
+      brokenBaseline: {},
+    });
+    expect(newConsoleBaseline["acme--widget"]).toEqual(["boom"]);
+  });
+});

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -277,6 +277,9 @@ export default defineConfig({
       "__tests__/**/*.test.ts",
       "src/**/*.test.ts",
       "src/**/*.test.tsx",
+      // Pure-logic unit tests for the story-gate audit scripts (e.g. the
+      // console/a11y baseline-allowlist ratchet) run in the standard suite.
+      "test/**/*.test.mjs",
     ],
     exclude: [
       "dist/**",


### PR DESCRIPTION
## Problem (task [2] of #13621)

The story gate's console + a11y ratchet was gated on `Object.keys(baseline).length > 0` (`packages/ui/test/story-gate/run-story-gate.mjs`), which **inverted** the intended burn-down ratchet: emptying or resetting a baseline **silently disabled** the check. Green-washing was one `echo '{}' > a11y-baseline.json` away — the exact opposite of the correct sibling `broken-baseline` ratchet (`!(r.id in brokenBaseline)`), where `{}` means **zero tolerance**.

## Fix

Enforcement is now **unconditional**. Each baseline is a pure **allowlist** of pre-existing violations:
- a violation key **absent** from the allowlist reds the run, regardless of how many rows the baseline holds;
- an **empty or absent** baseline means **fail-on-any** violation (same shape as `broken-baseline.json = {}`).

Refactor:
- Extracted the inline classification loop into an exported, deterministic `classifyStoryGateFailures()` so the ratchet is unit-testable without a browser.
- Guarded `main()` behind `import.meta.url` so importing the module (for the unit test) does not launch a Storybook/playwright run.
- Added `test/**/*.test.mjs` to the `packages/ui` vitest `include` so the new test runs in the standard suite.

## Tests

`packages/ui/test/story-gate/story-gate-classify.test.mjs` — **8/8 green** in the standard `packages/ui` vitest lane:
- **REGRESSION** empty console baseline fails on any console error
- **REGRESSION** empty a11y baseline fails on any a11y violation
- allowlisted violation does not fail
- a new violation absent from a **populated** allowlist still reds (per-key ratchet)
- broken-verdict allowlist semantics (allowlisted tolerated, un-allowlisted reds)
- `updateBaseline` mode skips console/a11y failures but still regenerates baselines
- clean story produces no failures
- repeated console keys de-dupe into the regenerated baseline

**Reversion-proof:** the two `REGRESSION` cases **fail** when the old `Object.keys(baseline).length > 0` gate is restored, and pass under this fix (verified locally).

Gates: biome clean, `error-policy-ratchet` clean (no new fallback-slop), codex review clean ("did not find a discrete regression in the modified or added files").

## Scope

Task **[2]** only. Task **[1]** (test-realness `mockCallOnlyAssertion` diff-scoped ratchet, `packages/scripts/test-realness-audit.mjs`) and task **[3]** (`ui-story-gate.yml` path-broadening) are separate files, left for follow-up slices; the issue stays open.

Closes part of #13621.

-- [sol-orch]