### PR TITLE
fix(app): bounce legacy /cloud-avatars/* to the R2 CDN (Account-page avatar 404)

### DIFF
--- a/packages/app/public/_redirects
+++ b/packages/app/public/_redirects
@@ -9,6 +9,13 @@
 # _redirects, so adding rewrite rules for those prefixes here would be
 # misleading dead config.
 
+# Built-in avatar art lives on the R2 CDN (blob.elizacloud.ai), but legacy user
+# rows persisted RELATIVE avatar URLs (/cloud-avatars/profile-N.webp) from when
+# the old cloud-frontend served them same-origin — on this SPA host they fall
+# through to the catch-all and break as images (the Account-page avatar 404,
+# #13601). Bounce them to the CDN so every legacy reference keeps working.
+/cloud-avatars/*  https://blob.elizacloud.ai/cloud-avatars/:splat  302
+
 # Hashed-asset 404s must NOT fall through to the SPA index.html. When a stale
 # browser HTML references an asset hash that no longer exists, the catch-all
 # below would otherwise return index.html with status 200 for the missing .js,


### PR DESCRIPTION
Half of board card **#13601** (tracker #13406): the Account page's on-load 404.

**Root cause (exact URL from the live QA session):** `GET https://elizacloud.ai/cloud-avatars/profile-16.webp → 404`. Legacy user rows store **relative** avatar URLs from when the old cloud-frontend served `/cloud-avatars/` same-origin. The art exists — `https://blob.elizacloud.ai/cloud-avatars/profile-16.webp` → 200 — the SPA host just has no route for it, so the request falls into the `/* → index.html` catch-all and the browser renders a broken image.

**Fix:** one `_redirects` rule (above the catch-alls; first match wins) bouncing `/cloud-avatars/*` → the CDN. Covers every legacy reference app-wide with no data backfill; new writes already store absolute CDN URLs (`default-user-avatar.ts`).

The **other half of #13601** (Security page's three 404s: `/api/v1/sessions`, `/api/v1/me/mfa`, `/api/v1/me/audit-events` — plus Account's DSR buttons `/api/v1/me/export`, `/api/v1/me/delete-request`) is UI shipped ahead of backend: **no `v1/me` or `v1/sessions` route exists in the worker tree at all.** Filed separately for the backend lane.

[qa-agent]