### PR TITLE
fix(type-safety): reduce ratchet drift

### DIFF
--- a/packages/app/src/web-ws-base-fix.ts
+++ b/packages/app/src/web-ws-base-fix.ts
@@ -54,6 +54,14 @@ import { Capacitor } from "@capacitor/core";
 import { setElizaApiBase } from "@elizaos/shared";
 import { isElectrobunRuntime } from "@elizaos/ui/bridge";
 
+declare global {
+  interface Window {
+    __ELIZA_WS_BASE__?: unknown;
+    __ELIZAOS_WS_BASE__?: unknown;
+    [key: `__${string}_WS_BASE__`]: unknown;
+  }
+}
+
 const LOOPBACK_HOSTNAMES = new Set([
   "localhost",
   "127.0.0.1",
@@ -66,10 +74,9 @@ function isLoopbackHostname(hostname: string): boolean {
   return LOOPBACK_HOSTNAMES.has(hostname.toLowerCase());
 }
 
-function setInjectedGlobal(key: string, value: string): void {
+function setInjectedGlobal(key: `__${string}_WS_BASE__`, value: string): void {
   try {
-    const w = window as unknown as Record<string, unknown>;
-    w[key] = value;
+    window[key] = value;
   } catch {
     // best-effort — never block boot
   }
@@ -141,13 +148,9 @@ function injectedWsBaseIsForeignLoopback(value: unknown): boolean {
  */
 export function repairWebSameOriginWsBase(): void {
   if (!isPlainWebSameOriginContext()) return;
-  const w = window as unknown as {
-    __ELIZA_WS_BASE__?: unknown;
-    __ELIZAOS_WS_BASE__?: unknown;
-  };
   const anyForeign =
-    injectedWsBaseIsForeignLoopback(w.__ELIZA_WS_BASE__) ||
-    injectedWsBaseIsForeignLoopback(w.__ELIZAOS_WS_BASE__);
+    injectedWsBaseIsForeignLoopback(window.__ELIZA_WS_BASE__) ||
+    injectedWsBaseIsForeignLoopback(window.__ELIZAOS_WS_BASE__);
   if (!anyForeign) return;
 
   // 1) WS base → same-origin wss://<host>.
@@ -155,13 +158,12 @@ export function repairWebSameOriginWsBase(): void {
   setInjectedGlobal("__ELIZA_WS_BASE__", wsTarget);
   setInjectedGlobal("__ELIZAOS_WS_BASE__", wsTarget);
   try {
-    const wRecord = window as unknown as Record<string, unknown>;
-    for (const key of Object.keys(wRecord)) {
+    for (const key of Object.keys(window)) {
       if (
         /^__[A-Z0-9]+_WS_BASE__$/.test(key) &&
-        injectedWsBaseIsForeignLoopback(wRecord[key])
+        injectedWsBaseIsForeignLoopback(window[key as `__${string}_WS_BASE__`])
       ) {
-        setInjectedGlobal(key, wsTarget);
+        setInjectedGlobal(key as `__${string}_WS_BASE__`, wsTarget);
       }
     }
   } catch {

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -117,7 +117,10 @@ function resolveEnvEntry(
 	const direct = presentEnvValue(env[key]);
 	if (direct !== undefined) return { key, value: direct };
 
-	for (const [brandKey, elizaKey] of getBootConfigEnvAliases() ?? []) {
+	const aliases = getBootConfigEnvAliases();
+	if (!aliases) return null;
+
+	for (const [brandKey, elizaKey] of aliases) {
 		const partner =
 			key === brandKey ? elizaKey : key === elizaKey ? brandKey : null;
 		if (!partner) continue;


### PR DESCRIPTION
## Summary
- remove the `as unknown as` double-casts from `web-ws-base-fix.ts` by declaring the injected WS globals on `Window`
- replace the scoped `getBootConfigEnvAliases() ?? []` empty fallback with an explicit no-alias branch
- restore `audit:type-safety-ratchet` without changing the baseline

Fixes #13658.

## Verification
- `bun run audit:type-safety-ratchet`
  - `as unknown as`: 72 / 73
  - `?? []` (core/agent/app-core): 581 / 581
- `bunx @biomejs/biome check packages/app/src/web-ws-base-fix.ts packages/core/src/runtime-env.ts --no-errors-on-unmatched`
- `bun run --cwd packages/app test -- src/web-ws-base-fix.test.ts`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/core typecheck`
- `git diff --check`
