### PR TITLE
fix(shared): stabilize brand env sync alias precedence

### DIFF
--- a/packages/shared/src/config/brand-env-aliases.ts
+++ b/packages/shared/src/config/brand-env-aliases.ts
@@ -96,12 +96,12 @@ export const BRAND_ENV_ALIAS_DEFINITIONS = [
   },
   { brandSuffix: "DISABLE_EDGE_TTS", elizaKey: "ELIZA_DISABLE_EDGE_TTS" },
   // Ports
+  { brandSuffix: "UI_PORT", elizaKey: "ELIZA_UI_PORT" },
   {
     brandSuffix: "PORT",
     elizaKey: "ELIZA_PORT",
     syncElizaKey: "ELIZA_UI_PORT",
   },
-  { brandSuffix: "UI_PORT", elizaKey: "ELIZA_UI_PORT" },
   { brandSuffix: "API_PORT", elizaKey: "ELIZA_API_PORT" },
   { brandSuffix: "HOME_PORT", elizaKey: "ELIZA_HOME_PORT" },
   { brandSuffix: "GATEWAY_PORT", elizaKey: "ELIZA_GATEWAY_PORT" },
@@ -140,6 +140,10 @@ export function buildBrandEnvSyncAliases(prefix: string): BrandEnvAliasPair[] {
       "vite" in definition && definition.vite
         ? `VITE_${normalizedPrefix}_${definition.brandSuffix}`
         : `${normalizedPrefix}_${definition.brandSuffix}`;
-    return [brandKey, definition.syncElizaKey ?? definition.elizaKey] as const;
+    const elizaKey =
+      "syncElizaKey" in definition
+        ? definition.syncElizaKey
+        : definition.elizaKey;
+    return [brandKey, elizaKey] as const;
   });
 }

--- a/packages/shared/src/utils/env.test.ts
+++ b/packages/shared/src/utils/env.test.ts
@@ -243,16 +243,14 @@ describe("syncElizaEnvAliases", () => {
     );
 
     try {
-      for (const key of tracked) {
-        delete process.env[key];
-      }
-      for (const [from] of aliases) {
-        process.env[from] = `${from}-value`;
-      }
-
-      syncElizaEnvAliases({ brandedPrefix: "BRAND" });
-
       for (const [from, to] of aliases) {
+        for (const key of tracked) {
+          delete process.env[key];
+        }
+        process.env[from] = `${from}-value`;
+
+        syncElizaEnvAliases({ brandedPrefix: "BRAND" });
+
         expect(process.env[to]).toBe(`${from}-value`);
       }
     } finally {
@@ -286,6 +284,34 @@ describe("syncElizaEnvAliases", () => {
       syncElizaEnvAliases({ brandedPrefix: "BRAND" });
 
       expect(process.env.ELIZA_UI_PORT).toBe("4100");
+      expect(process.env.ELIZA_PORT).toBeUndefined();
+    } finally {
+      for (const [key, value] of previous) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+  });
+
+  it("prefers explicit BRAND_UI_PORT over the legacy BRAND_PORT sync fallback", () => {
+    const keys = ["BRAND_PORT", "BRAND_UI_PORT", "ELIZA_PORT", "ELIZA_UI_PORT"];
+    const previous = new Map(
+      keys.map((key) => [key, process.env[key]] as const),
+    );
+
+    try {
+      for (const key of keys) {
+        delete process.env[key];
+      }
+      process.env.BRAND_PORT = "4100";
+      process.env.BRAND_UI_PORT = "4101";
+
+      syncElizaEnvAliases({ brandedPrefix: "BRAND" });
+
+      expect(process.env.ELIZA_UI_PORT).toBe("4101");
       expect(process.env.ELIZA_PORT).toBeUndefined();
     } finally {
       for (const [key, value] of previous) {


### PR DESCRIPTION
## Summary
- fix the merged #13632 shared typecheck error by guarding the optional syncElizaKey property on the narrowed alias-definition union
- make explicit BRAND_UI_PORT win over the legacy BRAND_PORT -> ELIZA_UI_PORT sync fallback when both are set
- update the full-table sync materialization guard so duplicate sync targets are tested independently instead of clobbering each other in one process.env setup

Follow-up to #13632 / #13528.

## Verification
- bun run --cwd packages/shared test src/utils/env.test.ts
- bun run --cwd packages/shared typecheck
- bunx @biomejs/biome check packages/shared/src/config/brand-env-aliases.ts packages/shared/src/utils/env.test.ts --no-errors-on-unmatched
- git diff --check
- bun run --cwd packages/app test src/brand-env.test.ts