### PR TITLE
fix: return 402 insufficient_credits from shared-agent chat instead of retryable 503

### DIFF
--- a/packages/cloud/api/__tests__/shared-agent-messages-route.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-route.test.ts
@@ -1,6 +1,7 @@
 // Exercises cloud API tests shared agent messages route.test behavior with deterministic Worker route fixtures.
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { InsufficientCreditsError } from "@/lib/api/errors";
 import * as realResolveSharedAgent from "@/lib/services/shared-runtime/resolve-shared-agent";
 import * as realSharedRestAdapter from "@/lib/services/shared-runtime/shared-rest-adapter";
 import * as realLogger from "@/lib/utils/logger";
@@ -129,5 +130,29 @@ describe("shared agent messages route", () => {
     const res = await postMessage({ text: "  " });
     expect(res.status).toBe(400);
     expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  // The bug this pins: insufficient credits is a PERMANENT add-credits
+  // condition (welcome-bonus-withheld signups, drained orgs), and the blanket
+  // 503 above disguised it as a transient outage — "try again" forever. The
+  // route must return the canonical 402 so the app can route to top-up.
+  test("insufficient credits returns a non-retryable 402, not the retryable 503", async () => {
+    sharedRestMessageSend.mockRejectedValue(
+      new InsufficientCreditsError(
+        "Insufficient credits. Required: $0.0500, Available: $0.0000",
+      ),
+    );
+
+    const res = await postMessage({ text: "hello" }, APP_ORIGIN);
+
+    expect(res.status).toBe(402);
+    expect(res.headers.get("access-control-allow-origin")).toBe(APP_ORIGIN);
+    expect(res.headers.get("access-control-allow-credentials")).toBe("true");
+    await expect(res.json()).resolves.toEqual({
+      success: false,
+      error: "Insufficient credits. Required: $0.0500, Available: $0.0000",
+      code: "insufficient_credits",
+      retryable: false,
+    });
   });
 });

--- a/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
@@ -21,6 +21,7 @@
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { InsufficientCreditsError } from "@/lib/api/errors";
 // Keep the real modules so afterAll can restore them — bun's `mock.module` is
 // process-global, so a blanket `mock.restore()` here would strand sibling test
 // files that import the full eliza-sandbox / resolve-shared-agent surface.
@@ -186,6 +187,32 @@ describe("shared agent messages/stream", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/event-stream");
     await expect(res.text()).resolves.toContain("event: error");
+  });
+
+  // Insufficient credits is rejected before any SSE bytes exist (bridgeStream's
+  // shared branch throws the typed 402), so the route answers with the same
+  // canonical 402 JSON as the non-stream send — not an error frame buried in a
+  // 200 stream the app would read as a transient turn failure.
+  test("insufficient credits → non-retryable 402 JSON, not an SSE frame", async () => {
+    bridgeStream.mockRejectedValue(
+      new InsufficientCreditsError(
+        "Insufficient credits. Required: $0.0500, Available: $0.0000",
+      ),
+    );
+
+    const res = await postStream({ text: "hi" }, "https://localhost");
+
+    expect(res.status).toBe(402);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "https://localhost",
+    );
+    await expect(res.json()).resolves.toEqual({
+      success: false,
+      error: "Insufficient credits. Required: $0.0500, Available: $0.0000",
+      code: "insufficient_credits",
+      retryable: false,
+    });
   });
 
   test("auth/tier failure surfaces the resolver error status", async () => {

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
@@ -79,6 +79,7 @@ app.post("/", async (c) => {
       r.agentName,
     );
   } catch (error) {
+    // error-policy:J1 route boundary translates bridge/billing failures to HTTP responses.
     // Insufficient credits is a PERMANENT condition until the org tops up —
     // hiding it behind the generic retryable 503 below reads as "try again"
     // forever to every welcome-bonus-withheld signup and drained org. Return

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
@@ -1,5 +1,6 @@
 // Handles v1 cloud API v1 eliza agents agentid api conversations conversationid messages route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import { InsufficientCreditsError } from "@/lib/api/errors";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { resolveSharedAgent } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import {
@@ -78,6 +79,33 @@ app.post("/", async (c) => {
       r.agentName,
     );
   } catch (error) {
+    // Insufficient credits is a PERMANENT condition until the org tops up —
+    // hiding it behind the generic retryable 503 below reads as "try again"
+    // forever to every welcome-bonus-withheld signup and drained org. Return
+    // the canonical 402 the agent-create path uses so the app can route to
+    // add-credits instead. The message is our own billing copy (required vs
+    // available), safe to show.
+    if (error instanceof InsufficientCreditsError) {
+      logger.warn(
+        "[shared-runtime REST] message.send rejected: insufficient credits",
+        {
+          agentId: r.agentId,
+        },
+      );
+      return applyCorsHeaders(
+        Response.json(
+          {
+            success: false,
+            error: error.message,
+            code: "insufficient_credits",
+            retryable: false,
+          },
+          { status: 402 },
+        ),
+        CORS_METHODS,
+        origin,
+      );
+    }
     // A shared-bridge / inference failure (transient: cold sandbox, provider
     // 429/5xx, timeout) would otherwise surface as a bare 500 on the
     // launch-critical first chat turn. Return a structured, retryable error so

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -1,9 +1,11 @@
 // Handles v1 cloud API v1 eliza agents agentid api conversations conversationid messages stream route traffic with route-local auth expectations.
 import { Hono } from "hono";
+import { InsufficientCreditsError } from "@/lib/api/errors";
 import type { BridgeRequest } from "@/lib/services/eliza-sandbox";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { resolveSharedAgent } from "@/lib/services/shared-runtime/resolve-shared-agent";
+import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 /**
@@ -84,11 +86,35 @@ app.post("/", async (c) => {
     params: { text, roomId: conversationId },
   };
 
-  const upstream = await elizaSandboxService.bridgeStream(
-    r.agentId,
-    r.orgId,
-    rpc,
-  );
+  let upstream: Response | null;
+  try {
+    upstream = await elizaSandboxService.bridgeStream(r.agentId, r.orgId, rpc);
+  } catch (error) {
+    // Insufficient credits is rejected before any SSE bytes exist, so answer
+    // with the same canonical 402 as the non-stream send — not an SSE error
+    // frame inside a 200 stream, which the app cannot distinguish from a
+    // transient turn failure. Permanent until the org adds credits.
+    if (error instanceof InsufficientCreditsError) {
+      logger.warn(
+        "[shared-runtime REST] stream send rejected: insufficient credits",
+        { agentId: r.agentId },
+      );
+      return applyCorsHeaders(
+        Response.json(
+          {
+            success: false,
+            error: error.message,
+            code: "insufficient_credits",
+            retryable: false,
+          },
+          { status: 402 },
+        ),
+        CORS_METHODS,
+        origin,
+      );
+    }
+    throw error;
+  }
   if (!upstream?.body) {
     // No reply produced (or the turn errored without an SSE body): emit an SSE
     // error frame the client's stream reader understands, instead of a 404 that

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -90,6 +90,7 @@ app.post("/", async (c) => {
   try {
     upstream = await elizaSandboxService.bridgeStream(r.agentId, r.orgId, rpc);
   } catch (error) {
+    // error-policy:J1 route boundary translates pre-stream bridge failures to HTTP responses.
     // Insufficient credits is rejected before any SSE bytes exist, so answer
     // with the same canonical 402 as the non-stream send — not an SSE error
     // frame inside a 200 stream, which the app cannot distinguish from a

--- a/packages/cloud/services/container-control-plane/src/index.ts
+++ b/packages/cloud/services/container-control-plane/src/index.ts
@@ -9,6 +9,7 @@ import {
   errorEnvelope,
   toCompatOpResult,
 } from "@elizaos/cloud-shared/lib/api/compat-envelope";
+import { ApiError } from "@elizaos/cloud-shared/lib/api/errors";
 import { containersEnv } from "@elizaos/cloud-shared/lib/config/containers-env";
 import { runWithCloudBindingsAsync } from "@elizaos/cloud-shared/lib/runtime/cloud-bindings";
 import { WarmPoolManager } from "@elizaos/cloud-shared/lib/services/containers/agent-warm-pool";
@@ -52,6 +53,12 @@ export const app = new Hono();
 const client = getHetznerContainersClient();
 
 function errorStatus(error: unknown): number {
+  // Typed API errors (e.g. the 402 insufficient-credits throw from
+  // bridgeStream's shared branch) carry their own status — pass it through
+  // instead of flattening to 500.
+  if (error instanceof ApiError) {
+    return error.status;
+  }
   if (error instanceof HetznerClientError) {
     switch (error.code) {
       case "container_not_found":
@@ -71,6 +78,9 @@ function errorStatus(error: unknown): number {
 }
 
 function errorBody(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.toJSON();
+  }
   return {
     success: false,
     code:

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
@@ -265,4 +265,67 @@ describe("ElizaSandboxService shared runtime billing", () => {
       historyUpsertSpy.mockRestore();
     }
   });
+
+  // The credit-gate contract for a drained org / welcome-bonus-withheld signup:
+  // the JSON-RPC bridge keeps the -32002 wire error (the /bridge route serves
+  // raw JSON-RPC), while bridgeStream — whose callers are HTTP boundaries —
+  // throws the typed 402 ApiError so routes translate it to a non-retryable
+  // insufficient_credits response instead of a disguised transient failure.
+  test("credit-reserve rejection: bridge returns -32002, bridgeStream throws the typed 402", async () => {
+    const { ElizaSandboxService, BRIDGE_INSUFFICIENT_CREDITS_CODE } = await import(
+      "./eliza-sandbox.ts?actual"
+    );
+    const { InsufficientCreditsError: InsufficientCreditsApiError } = await import(
+      "../api/errors"
+    );
+    const sandbox = sharedSandbox();
+    const findRunningSandboxSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockResolvedValue(sandbox);
+    const historyGetSpy = spyOn(sharedRuntimeHistoryRepository, "get").mockResolvedValue([]);
+    reserveCredits.mockImplementation(async () => {
+      throw new MockInsufficientCreditsError(0.05, 0);
+    });
+
+    try {
+      const rpc = {
+        jsonrpc: "2.0" as const,
+        id: "shared-turn",
+        method: "message.send",
+        params: { text: "hello" },
+      };
+      const service = new ElizaSandboxService();
+
+      const response = await runWithCloudBindings({ CEREBRAS_API_KEY: "test-key" }, () =>
+        service.bridge(sandbox.id, sandbox.organization_id, rpc),
+      );
+      expect(response).toEqual({
+        jsonrpc: "2.0",
+        id: "shared-turn",
+        error: {
+          code: BRIDGE_INSUFFICIENT_CREDITS_CODE,
+          message: "Insufficient credits. Required: $0.0500, Available: $0.0000",
+        },
+      });
+      expect(runSharedAgentTurn).not.toHaveBeenCalled();
+
+      const streamRejection = runWithCloudBindings({ CEREBRAS_API_KEY: "test-key" }, () =>
+        service.bridgeStream(sandbox.id, sandbox.organization_id, rpc),
+      );
+      await expect(streamRejection).rejects.toBeInstanceOf(InsufficientCreditsApiError);
+      await expect(streamRejection).rejects.toMatchObject({
+        code: "insufficient_credits",
+        status: 402,
+      });
+    } finally {
+      reserveCredits.mockImplementation(async () => ({
+        reservedAmount: 0.002,
+        reservationTransactionId: "reservation-1",
+        reconcile: reconcileReservation,
+      }));
+      findRunningSandboxSpy.mockRestore();
+      historyGetSpy.mockRestore();
+    }
+  });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
@@ -275,9 +275,7 @@ describe("ElizaSandboxService shared runtime billing", () => {
     const { ElizaSandboxService, BRIDGE_INSUFFICIENT_CREDITS_CODE } = await import(
       "./eliza-sandbox.ts?actual"
     );
-    const { InsufficientCreditsError: InsufficientCreditsApiError } = await import(
-      "../api/errors"
-    );
+    const { InsufficientCreditsError: InsufficientCreditsApiError } = await import("../api/errors");
     const sandbox = sharedSandbox();
     const findRunningSandboxSpy = spyOn(
       agentSandboxesRepository,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -29,6 +29,7 @@ import {
   type NewAgentSandboxBackup,
 } from "../../db/schemas/agent-sandboxes";
 import { jobs } from "../../db/schemas/jobs";
+import { InsufficientCreditsError as InsufficientCreditsApiError } from "../api/errors";
 import { containersEnv } from "../config/containers-env";
 import { getElizaAgentPublicWebUiUrl } from "../eliza-agent-web-ui";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
@@ -229,6 +230,16 @@ export interface BridgeRequest {
   method: string;
   params?: Record<string, unknown>;
 }
+
+/**
+ * JSON-RPC error code for a shared-runtime turn rejected by the credit
+ * reserve. REST callers (shared-rest-adapter, the messages/stream route)
+ * match on this code to translate the failure into the canonical 402
+ * insufficient-credits response instead of a generic retryable failure —
+ * an empty balance is permanent until the org tops up, not a transient
+ * outage.
+ */
+export const BRIDGE_INSUFFICIENT_CREDITS_CODE = -32002;
 
 export interface BridgeResponse {
   jsonrpc: "2.0";
@@ -2016,7 +2027,7 @@ export class ElizaSandboxService {
             jsonrpc: "2.0",
             id: rpc.id,
             error: {
-              code: -32002,
+              code: BRIDGE_INSUFFICIENT_CREDITS_CODE,
               message: `Insufficient credits. Required: $${error.required.toFixed(4)}, Available: $${error.available.toFixed(4)}`,
             },
           };
@@ -3475,6 +3486,15 @@ export class ElizaSandboxService {
         return this.createBridgeSseTextResponse(text);
       }
       if (sharedResponse.error) {
+        // A credit-reserve rejection is not a stream failure — no SSE bytes
+        // exist yet, so throw the canonical typed 402 for the route boundary
+        // to translate (messages/stream → 402 JSON; agent stream routes'
+        // errorToResponse / control-plane errorBody map ApiError natively).
+        // Wrapping it in an SSE error frame here would bury a permanent
+        // add-credits condition inside a 200 stream.
+        if (sharedResponse.error.code === BRIDGE_INSUFFICIENT_CREDITS_CODE) {
+          throw new InsufficientCreditsApiError(sharedResponse.error.message);
+        }
         return this.createBridgeSseErrorResponse(sharedResponse.error.message);
       }
       return fallbackText ? this.createBridgeSseTextResponse(fallbackText) : null;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -18,6 +18,7 @@
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { InsufficientCreditsError } from "../../api/errors";
 import * as realElizaSandbox from "../eliza-sandbox";
 
 const bridge = mock();
@@ -240,5 +241,23 @@ describe("shared-rest-adapter — messages", () => {
     await expect(sharedRestMessageSend(AGENT, ORG, AGENT, "hi", "Eliza")).rejects.toThrow(
       "Sandbox is not running",
     );
+  });
+
+  test("POST surfaces a bridge credit rejection as the TYPED 402 error, not a plain Error", async () => {
+    bridge.mockResolvedValue({
+      jsonrpc: "2.0",
+      id: "x",
+      error: {
+        code: realElizaSandbox.BRIDGE_INSUFFICIENT_CREDITS_CODE,
+        message: "Insufficient credits. Required: $0.0500, Available: $0.0000",
+      },
+    });
+    const rejection = sharedRestMessageSend(AGENT, ORG, AGENT, "hi", "Eliza");
+    await expect(rejection).rejects.toBeInstanceOf(InsufficientCreditsError);
+    await expect(rejection).rejects.toMatchObject({
+      code: "insufficient_credits",
+      status: 402,
+      message: "Insufficient credits. Required: $0.0500, Available: $0.0000",
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -17,6 +17,7 @@
  * bridge already writes.
  */
 
+import { InsufficientCreditsError } from "../../api/errors";
 import type { BridgeRequest } from "../eliza-sandbox";
 // Namespace import (resolved at call-time, not captured at module-eval) so the
 // adapter always reads the *current* eliza-sandbox export. Under bun's
@@ -353,6 +354,12 @@ export async function sharedRestMessageSend(
   };
   const response = await elizaSandbox.elizaSandboxService.bridge(agentId, orgId, rpc);
   if (response.error) {
+    // A credit-reserve rejection is a permanent add-credits condition, not a
+    // transient bridge failure — surface it typed so the route boundary can
+    // return the canonical 402 instead of the generic retryable 503.
+    if (response.error.code === elizaSandbox.BRIDGE_INSUFFICIENT_CREDITS_CODE) {
+      throw new InsufficientCreditsError(response.error.message);
+    }
     throw new Error(response.error.message || "shared message.send failed");
   }
   const result = (response.result ?? {}) as { text?: unknown };


### PR DESCRIPTION
# fix: return 402 insufficient_credits from shared-agent chat instead of retryable 503

## Problem

A fresh cloud user whose welcome bonus was WITHHELD (IP-capped anti-sybil grant — shared NAT/office/university IPs, `steward-sync.ts` grant guard), or any org that has drained its balance, gets this on their **first chat turn**:

```
503 { "error": "The agent is temporarily unavailable. Please try again.",
      "code": "inference_unavailable", "retryable": true }
```

…forever. A **permanent** add-credits condition is disguised as a transient outage, so the app shows a "try again" affordance instead of routing to top-up.

Chain: `reserveCredits` throws `InsufficientCreditsError` → `bridgeSharedMessageSend` maps it to JSON-RPC `-32002` (`eliza-sandbox.ts`) → `sharedRestMessageSend` rethrew it as a **plain `Error`** (`shared-rest-adapter.ts:355-357`) → the messages route's blanket catch (`.../conversations/[conversationId]/messages/route.ts`) flattened it to the generic retryable 503. The `/messages/stream` sibling buried the same failure as an SSE `error` frame inside a 200 stream.

## Fix (structural — type the failure through the bridge)

- `eliza-sandbox.ts` — name the wire code (`BRIDGE_INSUFFICIENT_CREDITS_CODE = -32002`); `bridgeStream`'s shared branch throws the canonical `InsufficientCreditsError` (402 `ApiError`, `lib/api/errors.ts`) instead of wrapping the permanent condition in an SSE error frame. The `/bridge` JSON-RPC surface keeps the `-32002` wire shape (raw JSON-RPC clients still get a JSON-RPC error).
- `shared-rest-adapter.ts` — `sharedRestMessageSend` translates `-32002` into the same typed 402 instead of a plain `Error`.
- `messages/route.ts` + `messages/stream/route.ts` — map the typed error to `402 { code: "insufficient_credits", retryable: false }` (mirrors the `insufficientCredits402` agent-create contract) so the app can route to top-up. All other failures keep the existing retryable-503 / SSE behavior.
- `container-control-plane/src/index.ts` — its `handle` boundary now passes typed `ApiError` status/body through (was flattening everything non-Hetzner to 500). The `v1/eliza/agents/[agentId]/stream` route needed **no change**: its `errorToResponse` boundary already maps `ApiError` natively.

## Verify-first — reproduced on unpatched develop (212af0cee3)

Stashed the 5 product files, kept the tests, re-ran:

```
cloud-shared: 21 pass, 2 fail   (typed-402 adapter test + bridge/bridgeStream contract test)
cloud-api:    10 pass, 2 fail   (messages 402 test + stream 402 test — both got 503/SSE instead)
```

Restored the fix: **all 4 fail→pass**.

## Tests (fail on the bug, pass with the fix)

- `eliza-sandbox-shared-billing.test.ts` — real `ElizaSandboxService` with `reserveCredits` rejecting: `bridge()` keeps the `-32002` JSON-RPC error (wire-contract pin), `bridgeStream()` rejects with the typed 402 (`code: "insufficient_credits", status: 402`), and no turn runs.
- `shared-rest-adapter.test.ts` — `-32002` from the bridge → typed `InsufficientCreditsError`, not a plain `Error`.
- `shared-agent-messages-route.test.ts` — insufficient credits → `402 {code:"insufficient_credits", retryable:false}` with CORS, not the retryable 503.
- `shared-agent-messages-stream.test.ts` — insufficient credits → 402 JSON (not an SSE frame in a 200 stream), with CORS.

## Verification (real counts)

- `packages/cloud/shared`: blast-radius set (shared-runtime/ + eliza-sandbox billing + dedicated-bootstrap + billing-gate-402) — **44 pass / 0 fail** (6 files).
- `packages/cloud/api`: full `bun run test` — **133/136 files pass**; the 3 failing files (`compat-agent-credit-gate`, `eliza-agents-create-idempotency`, `messages-iac-fast-path`) fail **identically on unpatched develop** (pre-existing missing-export errors: `AgentImageNotAllowedError`, `modelUsesReasoningTokens`) — verified by stash A/B, zero delta from this PR.
- Typecheck: `cloud/api` `tsgo --noEmit` clean; `cloud/services/container-control-plane` `tsgo --noEmit` clean; `cloud/shared` `tsc` — zero diagnostics on touched files.
- `bun run audit:error-policy-ratchet` — `no new fallback-slop in touched files` (the new route catches are J1 boundary translations that return a typed failure).

## Client impact

The app's send path can now distinguish "add credits" (402, `retryable:false`, same `insufficient_credits` code the agent-create path already emits) from "try again later" (503, `retryable:true`). No change to the happy path, the JSON-RPC `/bridge` wire contract, or dedicated-agent streaming.

Findings signed [core-brain].

🤖 Generated with [Claude Code](https://claude.com/claude-code)
