### PR TITLE
fix(ui): disable missing account security calls

### DIFF
--- a/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
@@ -1,16 +1,12 @@
 /**
- * Active sessions panel: lists signed-in devices and revokes them.
- *   GET    /api/v1/sessions
- *   DELETE /api/v1/sessions/:id
- *
- * Renders the backend's explicit unavailable state until revocable session
- * inventory exists.
+ * Active sessions panel. The Worker does not currently expose session
+ * enumeration/revocation, so keep this panel in the explicit unavailable state
+ * instead of issuing dead account-session calls on every Security page load.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { BrandButton, BrandCard, CornerBrackets } from "../../../cloud-ui";
-import { api, apiFetch } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import { emitAuditEvent } from "../data/audit-client";
 
@@ -23,12 +19,6 @@ interface SessionRow {
   current?: boolean;
 }
 
-interface SessionsResponse {
-  available?: boolean;
-  reason?: string;
-  sessions: SessionRow[];
-}
-
 type SessionsState =
   | { kind: "loading" }
   | { kind: "missing" }
@@ -37,39 +27,12 @@ type SessionsState =
 
 export function ActiveSessionsPanel() {
   const t = useCloudT();
-  const [state, setState] = useState<SessionsState>({ kind: "loading" });
+  const [state] = useState<SessionsState>({ kind: "missing" });
   const [revoking, setRevoking] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    setState({ kind: "loading" });
-    try {
-      const data = await api<SessionsResponse>("/api/v1/sessions");
-      if (data.available === false) {
-        setState({ kind: "missing" });
-        return;
-      }
-      if (!Array.isArray(data.sessions)) {
-        throw new Error("Malformed sessions response");
-      }
-      setState({ kind: "ready", sessions: data.sessions });
-    } catch (err) {
-      setState({
-        kind: "error",
-        message: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }, []);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
 
   const revoke = async (id: string) => {
     setRevoking(id);
     try {
-      await apiFetch(`/api/v1/sessions/${encodeURIComponent(id)}`, {
-        method: "DELETE",
-      });
       await emitAuditEvent({
         action: "auth.session.revoke",
         result: "allow",
@@ -78,7 +41,6 @@ export function ActiveSessionsPanel() {
       toast.success(
         t("cloud.activeSessions.revoked", { defaultValue: "Session revoked" }),
       );
-      await load();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       toast.error(

--- a/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
@@ -1,6 +1,7 @@
 /**
- * Two-factor authentication status panel. Reads GET /api/v1/me/mfa and renders
- * the backend's explicit unavailable state until enrollment support exists.
+ * Two-factor authentication status panel. The Worker does not currently expose
+ * an MFA status route, so keep the panel in the explicit unavailable state
+ * instead of firing a dead request on Security page load.
  *
  * NOTE: the "Enroll a second factor" button is not wired — there is no MFA
  * enrollment endpoint yet (only the read route). The CTA renders so the surface
@@ -8,17 +9,9 @@
  */
 
 import { Lock } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { BrandButton, BrandCard, CornerBrackets } from "../../../cloud-ui";
-import { api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
-
-interface MfaStatusResponse {
-  available?: boolean;
-  enrolled: boolean;
-  method?: "totp" | "webauthn" | null;
-  reason?: string;
-}
 
 type MfaState =
   | { kind: "loading" }
@@ -28,38 +21,7 @@ type MfaState =
 
 export function MfaPanel() {
   const t = useCloudT();
-  const [state, setState] = useState<MfaState>({ kind: "loading" });
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const data = await api<MfaStatusResponse>("/api/v1/me/mfa");
-        if (cancelled) return;
-        if (data.available === false) {
-          setState({ kind: "missing" });
-          return;
-        }
-        if (typeof data.enrolled !== "boolean") {
-          throw new Error("Malformed MFA status response");
-        }
-        setState({
-          kind: "ready",
-          enrolled: data.enrolled,
-          method: data.method ?? null,
-        });
-      } catch (err) {
-        if (cancelled) return;
-        setState({
-          kind: "error",
-          message: err instanceof Error ? err.message : String(err),
-        });
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const [state] = useState<MfaState>({ kind: "missing" });
 
   return (
     <BrandCard className="relative">

--- a/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
@@ -2,31 +2,20 @@
  * Privacy controls + data-subject rights:
  *   - vision / screen-capture consent toggle (local consent store)
  *   - trajectory logging toggle (local consent store)
- *   - data export   GET  /api/v1/me/export        (DSR right-to-export)
- *   - delete account POST /api/v1/me/delete-request (DSR right-to-erasure)
  *
- * Keeps the 404-graceful "coming soon" pattern for the DSR endpoints.
+ * DSR export/deletion jobs are not exposed by the Worker yet. Keep those
+ * controls visible but disabled so the launch surface does not issue dead
+ * `/api/v1/me/*` calls or imply a request was scheduled.
  */
 
 import { Camera, Download, ScrollText, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { toast } from "sonner";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
   BrandButton,
   BrandCard,
   CornerBrackets,
-  Input,
   Switch,
 } from "../../../cloud-ui";
-import { ApiError, apiFetch } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import { emitAuditEvent } from "../data/audit-client";
 import {
@@ -35,8 +24,6 @@ import {
   setTrajectoryLoggingEnabled,
   setVisionEnabled,
 } from "../data/consent-store";
-
-const DELETE_CONFIRM_PHRASE = "delete my account";
 
 export function PrivacyPanel() {
   const t = useCloudT();
@@ -60,102 +47,6 @@ export function PrivacyPanel() {
   const onTrajectoryChange = (next: boolean) => {
     setTrajectoryLoggingEnabled(next);
     setTrajectory(next);
-  };
-
-  const exportData = async () => {
-    try {
-      const res = await apiFetch("/api/v1/me/export", { method: "GET" });
-      const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `eliza-data-export-${new Date()
-        .toISOString()
-        .replace(/[:.]/g, "-")}.zip`;
-      a.click();
-      URL.revokeObjectURL(url);
-      void emitAuditEvent({
-        action: "data.export",
-        result: "allow",
-        metadata: { scope: "all" },
-      });
-      toast.success(
-        t("cloud.privacyPanel.exportReady", {
-          defaultValue:
-            "Export ready — your download should start automatically.",
-        }),
-      );
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 404) {
-        toast.info(
-          t("cloud.privacyPanel.exportComingSoon", {
-            defaultValue:
-              "Data export is coming soon — not yet available on this server.",
-          }),
-        );
-        return;
-      }
-      const message = err instanceof Error ? err.message : String(err);
-      toast.error(
-        t("cloud.privacyPanel.exportFailed", {
-          message,
-          defaultValue: "Export failed: {{message}}",
-        }),
-      );
-    }
-  };
-
-  const [deleteOpen, setDeleteOpen] = useState(false);
-  const [deleteConfirmText, setDeleteConfirmText] = useState("");
-  const [deleteSubmitting, setDeleteSubmitting] = useState(false);
-
-  const deleteAccount = async () => {
-    if (deleteConfirmText.trim().toLowerCase() !== DELETE_CONFIRM_PHRASE) {
-      toast.error(
-        t("cloud.privacyPanel.confirmPhrasePrompt", {
-          phrase: DELETE_CONFIRM_PHRASE,
-          defaultValue: 'Please type "{{phrase}}" to confirm.',
-        }),
-      );
-      return;
-    }
-    setDeleteSubmitting(true);
-    try {
-      await apiFetch("/api/v1/me/delete-request", { method: "POST" });
-      void emitAuditEvent({
-        action: "data.delete_request",
-        result: "allow",
-        metadata: { scope: "account" },
-      });
-      toast.success(
-        t("cloud.privacyPanel.deletionScheduled", {
-          defaultValue:
-            "Deletion scheduled. You have 30 days to recover before purge.",
-        }),
-      );
-      setDeleteOpen(false);
-      setDeleteConfirmText("");
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 404) {
-        toast.info(
-          t("cloud.privacyPanel.deletionComingSoon", {
-            defaultValue:
-              "Account deletion is coming soon — not yet available on this server.",
-          }),
-        );
-        setDeleteOpen(false);
-        return;
-      }
-      const message = err instanceof Error ? err.message : String(err);
-      toast.error(
-        t("cloud.privacyPanel.deleteRequestFailed", {
-          message,
-          defaultValue: "Delete request failed: {{message}}",
-        }),
-      );
-    } finally {
-      setDeleteSubmitting(false);
-    }
   };
 
   return (
@@ -251,9 +142,15 @@ export function PrivacyPanel() {
           <BrandButton
             size="sm"
             variant="outline"
-            onClick={() => void exportData()}
+            disabled
+            title={t("cloud.privacyPanel.exportComingSoon", {
+              defaultValue:
+                "Data export is coming soon — not yet available on this server.",
+            })}
           >
-            {t("cloud.privacyPanel.export", { defaultValue: "Export" })}
+            {t("cloud.privacyPanel.exportUnavailable", {
+              defaultValue: "Export unavailable",
+            })}
           </BrandButton>
         </div>
 
@@ -281,73 +178,19 @@ export function PrivacyPanel() {
             size="sm"
             variant="outline"
             className="border-red-500/40 text-red-300"
-            onClick={() => setDeleteOpen(true)}
+            disabled
+            title={t("cloud.privacyPanel.deletionComingSoon", {
+              defaultValue:
+                "Account deletion is coming soon — not yet available on this server.",
+            })}
             data-testid="delete-account-trigger"
           >
-            {t("cloud.privacyPanel.deleteAccount", {
-              defaultValue: "Delete account…",
+            {t("cloud.privacyPanel.deleteUnavailable", {
+              defaultValue: "Deletion unavailable",
             })}
           </BrandButton>
         </div>
       </div>
-
-      <AlertDialog
-        open={deleteOpen}
-        onOpenChange={(next) => {
-          if (!next) setDeleteConfirmText("");
-          setDeleteOpen(next);
-        }}
-      >
-        <AlertDialogContent data-testid="delete-account-dialog">
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t("cloud.privacyPanel.dialogTitle", {
-                defaultValue: "Delete your account?",
-              })}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {t("cloud.privacyPanel.dialogIntro", {
-                defaultValue:
-                  "We'll keep your data for 30 days in case you change your mind. To confirm, type",
-              })}{" "}
-              <code>{DELETE_CONFIRM_PHRASE}</code>{" "}
-              {t("cloud.privacyPanel.dialogBelow", {
-                defaultValue: "below.",
-              })}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <Input
-            value={deleteConfirmText}
-            onChange={(e) => setDeleteConfirmText(e.target.value)}
-            placeholder={DELETE_CONFIRM_PHRASE}
-            data-testid="delete-account-confirm-input"
-          />
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteSubmitting}>
-              {t("cloud.privacyPanel.cancel", { defaultValue: "Cancel" })}
-            </AlertDialogCancel>
-            <AlertDialogAction
-              disabled={
-                deleteSubmitting ||
-                deleteConfirmText.trim().toLowerCase() !== DELETE_CONFIRM_PHRASE
-              }
-              onClick={(e) => {
-                e.preventDefault();
-                void deleteAccount();
-              }}
-              data-testid="delete-account-confirm"
-            >
-              {deleteSubmitting
-                ? t("cloud.privacyPanel.submitting", {
-                    defaultValue: "Submitting…",
-                  })
-                : t("cloud.privacyPanel.scheduleDeletion", {
-                    defaultValue: "Schedule deletion",
-                  })}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </BrandCard>
   );
 }

--- a/packages/ui/src/cloud/account-security/components/recent-audit-events.tsx
+++ b/packages/ui/src/cloud/account-security/components/recent-audit-events.tsx
@@ -1,17 +1,13 @@
 /**
- * Recent security events: GET /api/v1/me/audit-events?limit=50.
- * Keeps the 404-graceful "not exposed yet on this server" pattern.
+ * Recent security events. The Worker currently exposes POST-only audit
+ * ingestion, not a user-readable audit-event list, so render the explicit
+ * unavailable state without issuing a dead account-audit request.
  */
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { BrandCard, CornerBrackets } from "../../../cloud-ui";
-import { ApiError, api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import { AuditEventList, type AuditEventRow } from "./AuditEventList";
-
-interface AuditEventsResponse {
-  events: AuditEventRow[];
-}
 
 type AuditState =
   | { kind: "loading" }
@@ -21,33 +17,7 @@ type AuditState =
 
 export function RecentAuditEvents() {
   const t = useCloudT();
-  const [state, setState] = useState<AuditState>({ kind: "loading" });
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const data = await api<AuditEventsResponse>(
-          "/api/v1/me/audit-events?limit=50",
-        );
-        if (cancelled) return;
-        setState({ kind: "ready", events: data.events ?? [] });
-      } catch (err) {
-        if (cancelled) return;
-        if (err instanceof ApiError && err.status === 404) {
-          setState({ kind: "missing" });
-          return;
-        }
-        setState({
-          kind: "error",
-          message: err instanceof Error ? err.message : String(err),
-        });
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const [state] = useState<AuditState>({ kind: "missing" });
 
   return (
     <BrandCard className="relative">


### PR DESCRIPTION
## Summary
- stop the Security surface from fetching missing account-security endpoints for sessions, MFA, and audit events
- keep those panels in their explicit unavailable states until real Worker read routes exist
- disable Account/Privacy DSR export and deletion controls instead of firing missing `/api/v1/me/export` and `/api/v1/me/delete-request` requests

This takes the short-term degrade-by-design path requested in #13662 rather than adding fake backend routes for DSR/session data that do not exist yet.

Fixes #13662.

## Verification
- `bunx @biomejs/biome check packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx packages/ui/src/cloud/account-security/components/mfa-panel.tsx packages/ui/src/cloud/account-security/components/recent-audit-events.tsx packages/ui/src/cloud/account-security/components/privacy-panel.tsx --no-errors-on-unmatched`
- source scan for exact missing endpoint strings in `packages/ui/src/cloud/account-security/components` returned no matches for executable string literals:
  - `/api/v1/sessions`
  - `/api/v1/me/mfa`
  - `/api/v1/me/audit-events`
  - `/api/v1/me/export`
  - `/api/v1/me/delete-request`
- `git diff --check`

## Known unrelated blocker
- `bun run --cwd packages/ui typecheck` still fails before reaching these files on the existing missing fixture dependency: `src/spatial/__e2e__/immersive-fixture.ts(30,38): error TS2307: Cannot find module 'iwer' or its corresponding type declarations.`
