### PR TITLE
feat(backgrounds): curated catalog with metadata — gallery, agent name-select, upload (#13538)

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -158,6 +158,16 @@
       "import": "./dist/events/index.js",
       "default": "./dist/events/index.js"
     },
+    "./backgrounds/catalog-index": {
+      "types": "./dist/backgrounds/catalog-index.d.ts",
+      "eliza-source": {
+        "types": "./src/backgrounds/catalog-index.ts",
+        "import": "./src/backgrounds/catalog-index.ts",
+        "default": "./src/backgrounds/catalog-index.ts"
+      },
+      "import": "./dist/backgrounds/catalog-index.js",
+      "default": "./dist/backgrounds/catalog-index.js"
+    },
     "./contracts": {
       "types": "./dist/contracts/index.d.ts",
       "eliza-source": {

--- a/packages/shared/src/backgrounds/catalog-index.test.ts
+++ b/packages/shared/src/backgrounds/catalog-index.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Background catalog NAME INDEX (#13538): the shared metadata half + the
+ * matchers the BACKGROUND action uses to route "use the misty-forest background"
+ * to a name-select. Proves the index is code-free and unknown names resolve to
+ * nothing (confinement).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  BACKGROUND_CATALOG_INDEX,
+  DEFAULT_BACKGROUND_CATALOG_ID,
+  detectCatalogId,
+  GLSL_BACKGROUND_META,
+  matchCatalogId,
+  NATURAL_BACKGROUND_META,
+} from "./catalog-index";
+
+describe("background catalog index (#13538)", () => {
+  it("is the union of natural + glsl metadata, code-free", () => {
+    expect(BACKGROUND_CATALOG_INDEX.length).toBe(
+      NATURAL_BACKGROUND_META.length + GLSL_BACKGROUND_META.length,
+    );
+    for (const e of BACKGROUND_CATALOG_INDEX) {
+      // Pure metadata: no render source of any kind lives in the index.
+      expect(e).not.toHaveProperty("source");
+      expect(e.palette.length).toBeGreaterThan(0);
+      expect(e.tags.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("the default id names a real catalog entry", () => {
+    expect(
+      BACKGROUND_CATALOG_INDEX.some(
+        (e) => e.id === DEFAULT_BACKGROUND_CATALOG_ID,
+      ),
+    ).toBe(true);
+  });
+
+  it("matchCatalogId resolves id / label / fuzzy, undefined for unknown", () => {
+    expect(matchCatalogId("misty-forest")).toBe("misty-forest");
+    expect(matchCatalogId("Misty Forest")).toBe("misty-forest");
+    expect(matchCatalogId("  ocean deep ")).toBe("ocean-deep");
+    expect(matchCatalogId("aurora")).toBe("aurora");
+    expect(matchCatalogId("totally-unknown")).toBeUndefined();
+    expect(matchCatalogId("")).toBeUndefined();
+    expect(matchCatalogId(undefined)).toBeUndefined();
+  });
+
+  it("matchCatalogId does NOT resolve generic color/tag words", () => {
+    // "green"/"blue"/"warm" are tags on some entries but are color words that
+    // belong to the color parser — they must not resolve to a curated image.
+    expect(matchCatalogId("green")).toBeUndefined();
+    expect(matchCatalogId("blue")).toBeUndefined();
+    expect(matchCatalogId("warm")).toBeUndefined();
+  });
+
+  it("detectCatalogId only fires on distinctive catalog names, not plain colors", () => {
+    expect(detectCatalogId("use the misty forest background")).toBe(
+      "misty-forest",
+    );
+    expect(detectCatalogId("set the ocean-deep wallpaper")).toBe("ocean-deep");
+    // A bare color word must NOT hijack a color request into a catalog select.
+    expect(detectCatalogId("make the background green")).toBeUndefined();
+    expect(detectCatalogId("set it to teal")).toBeUndefined();
+  });
+});

--- a/packages/shared/src/backgrounds/catalog-index.ts
+++ b/packages/shared/src/backgrounds/catalog-index.ts
@@ -1,0 +1,209 @@
+/**
+ * The background-catalog NAME INDEX — the shared, code-free metadata half of the
+ * curated background catalog (#13538). It lives in `@elizaos/shared` so BOTH
+ * halves read one source of truth:
+ *
+ *  - `@elizaos/ui` (`state/ui-preferences.ts`) imports this index and attaches
+ *    the concrete render sources (gradient data URLs / shader preset ids) to
+ *    build `BACKGROUND_CATALOG` for the gallery + the apply channel.
+ *  - `@elizaos/plugin-app-control` (the `BACKGROUND` action) imports this index
+ *    to MATCH a user's request ("use the misty-forest background") to a catalog
+ *    id, then names that id in the `background:apply` payload (`catalogId`).
+ *
+ * Crucially this index carries NO render source — no GLSL text, no image bytes,
+ * no URL. It is pure metadata (id / label / description / mood / palette /
+ * tags). The renderer is the only place that resolves an id to something
+ * paintable, so naming a catalog entry can never smuggle code or an unvetted
+ * URL across the broker (#11088 / #13523).
+ */
+
+/** How a catalog entry ultimately renders (the renderer owns the source). */
+export type BackgroundCatalogKind = "color" | "glsl" | "image";
+
+/** Pure metadata for one curated background — no render source. */
+export interface BackgroundCatalogMeta {
+  /** Stable slug used by the gallery, chat name-select, and tests. */
+  id: string;
+  /** Human-readable name (screen readers + the agent reply). */
+  label: string;
+  /** One-line description the agent can read to describe/pick the option. */
+  description: string;
+  /** How this entry renders (the renderer resolves the actual source). */
+  kind: BackgroundCatalogKind;
+  /** Short mood word(s) ("calm", "vivid"). */
+  mood: string;
+  /** Representative palette (hex) for the tile thumbnail + agent context. */
+  palette: readonly string[];
+  /** Search/agent tags ("nature", "forest", "warm"). */
+  tags: readonly string[];
+}
+
+/**
+ * The curated natural-background metadata. The renderer attaches a code-free SVG
+ * gradient data URL to each of these (keyed by id).
+ */
+export const NATURAL_BACKGROUND_META: readonly BackgroundCatalogMeta[] = [
+  {
+    id: "misty-forest",
+    label: "Misty Forest",
+    description: "Soft green haze fading into a deep evergreen floor.",
+    kind: "image",
+    mood: "calm",
+    palette: ["#0d1f16", "#1f3d2b", "#3a5a3f"],
+    tags: ["nature", "forest", "green", "calm"],
+  },
+  {
+    id: "desert-dusk",
+    label: "Desert Dusk",
+    description: "Warm sand rising into a burnt-amber twilight sky.",
+    kind: "image",
+    mood: "warm",
+    palette: ["#2a160c", "#7a3b1a", "#c76a2b"],
+    tags: ["nature", "desert", "warm", "sunset"],
+  },
+  {
+    id: "ocean-deep",
+    label: "Ocean Deep",
+    description: "Teal surface light dissolving into the abyssal blue.",
+    kind: "image",
+    mood: "cool",
+    palette: ["#04121c", "#0b3550", "#127a8c"],
+    tags: ["nature", "ocean", "water", "blue", "cool"],
+  },
+  {
+    id: "alpine-dawn",
+    label: "Alpine Dawn",
+    description: "Cold slate peaks catching the first rose of sunrise.",
+    kind: "image",
+    mood: "serene",
+    palette: ["#151a26", "#3a3f57", "#b56a6a"],
+    tags: ["nature", "mountain", "dawn", "serene"],
+  },
+  {
+    id: "ember-night",
+    label: "Ember Night",
+    description: "A banked-fire glow low against a deep brown-black field.",
+    kind: "image",
+    mood: "cozy",
+    palette: ["#0a0603", "#160d07", "#3a1f0d"],
+    tags: ["warm", "ember", "dark", "cozy"],
+  },
+];
+
+/**
+ * The named GLSL-preset metadata, mirrored as catalog entries. `id` doubles as
+ * the shader preset id the renderer resolves to source (never GLSL text here).
+ */
+export const GLSL_BACKGROUND_META: readonly BackgroundCatalogMeta[] = [
+  {
+    id: "aurora",
+    label: "Aurora",
+    description: "Slow ribbons of light drifting like the northern lights.",
+    kind: "glsl",
+    mood: "dreamy",
+    palette: ["#0a2a2f", "#1f6f6a", "#8be0c0"],
+    tags: ["animated", "aurora", "green"],
+  },
+  {
+    id: "lava",
+    label: "Lava",
+    description: "Molten cells churning in a dark volcanic field.",
+    kind: "glsl",
+    mood: "intense",
+    palette: ["#1a0603", "#7a2410", "#f05a1f"],
+    tags: ["animated", "lava", "fire", "warm"],
+  },
+  {
+    id: "plasma",
+    label: "Plasma",
+    description: "A shifting psychedelic plasma of interleaved color.",
+    kind: "glsl",
+    mood: "vivid",
+    palette: ["#2a0a3a", "#7a1f8c", "#e05aa0"],
+    tags: ["animated", "plasma", "psychedelic"],
+  },
+  {
+    id: "waves",
+    label: "Waves",
+    description: "Gentle rolling ocean swells under a low light.",
+    kind: "glsl",
+    mood: "soothing",
+    palette: ["#04121c", "#0b3550", "#3a8ca0"],
+    tags: ["animated", "waves", "ocean", "cool"],
+  },
+  {
+    id: "nebula",
+    label: "Nebula",
+    description: "Cosmic clouds of dust and starlight drifting in space.",
+    kind: "glsl",
+    mood: "expansive",
+    palette: ["#05060f", "#241f4a", "#7a6ad0"],
+    tags: ["animated", "nebula", "space", "cosmic"],
+  },
+];
+
+/**
+ * The full catalog name index: natural images first, then the animated GLSL
+ * presets. Both the gallery (via `@elizaos/ui`) and the agent action read this.
+ */
+export const BACKGROUND_CATALOG_INDEX: readonly BackgroundCatalogMeta[] = [
+  ...NATURAL_BACKGROUND_META,
+  ...GLSL_BACKGROUND_META,
+];
+
+/** The boot-default catalog id (the curated "Ember Night" gradient). */
+export const DEFAULT_BACKGROUND_CATALOG_ID = "ember-night";
+
+/**
+ * Match a free-text / id / label reference to a catalog id. Case- and
+ * whitespace-insensitive; matches by id, then exact label, then a label
+ * substring (either direction). So "misty forest", "Misty Forest", "the misty
+ * forest one", and "misty-forest" all resolve. Returns undefined for an unknown
+ * name (callers then ignore it — consistent with the #13523 confinement rule).
+ *
+ * Deliberately does NOT match on generic tags ("green", "blue", "warm"): those
+ * are color-like words that belong to the color parser, and tag-matching them
+ * would apply an arbitrary curated image for a plain color request.
+ */
+export function matchCatalogId(ref: string | undefined): string | undefined {
+  if (!ref) return undefined;
+  const needle = ref.trim().toLowerCase();
+  if (!needle) return undefined;
+  const byId = BACKGROUND_CATALOG_INDEX.find((e) => e.id === needle);
+  if (byId) return byId.id;
+  const byLabel = BACKGROUND_CATALOG_INDEX.find(
+    (e) => e.label.toLowerCase() === needle,
+  );
+  if (byLabel) return byLabel.id;
+  const byLabelPart = BACKGROUND_CATALOG_INDEX.find((e) => {
+    const label = e.label.toLowerCase();
+    return label.includes(needle) || needle.includes(label);
+  });
+  return byLabelPart?.id;
+}
+
+/**
+ * Detect whether free text names a curated NATURAL (image) catalog background,
+ * returning the matched id. Only the natural entries are matched here: the GLSL
+ * presets (aurora/lava/…) already have a dedicated shader-preset path in the
+ * BACKGROUND action, so routing them through name-select would change their
+ * reply/behavior. Requires a distinctive label/id token to appear (not a generic
+ * tag like "warm"/"green"), so a plain color request is never hijacked. Used by
+ * the action to route "use the misty-forest background" to a name-select.
+ */
+export function detectCatalogId(text: string): string | undefined {
+  const lower = text.toLowerCase();
+  for (const entry of NATURAL_BACKGROUND_META) {
+    const slug = entry.id; // e.g. "misty-forest"
+    const spaced = slug.replace(/-/g, " "); // "misty forest"
+    const label = entry.label.toLowerCase(); // "misty forest"
+    if (
+      lower.includes(slug) ||
+      lower.includes(spaced) ||
+      lower.includes(label)
+    ) {
+      return entry.id;
+    }
+  }
+  return undefined;
+}

--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -139,6 +139,14 @@ export interface BackgroundApplyPayload extends Record<string, unknown> {
   presetId?: string;
   /** Uniform patch for glsl mode. */
   uniforms?: BackgroundShaderUniformPatch;
+  /**
+   * Named curated-catalog entry id/label the agent selected ("misty-forest").
+   * The renderer resolves it against the shared background catalog to a config
+   * (color / vetted image URL / named GLSL preset). Like `presetId`, this NEVER
+   * carries GLSL source or an arbitrary URL — an unknown name is ignored, so a
+   * crafted payload can't wedge or escape the background (#11088 / #13523).
+   */
+  catalogId?: string;
 }
 
 // ── Avatar / VRM ─────────────────────────────────────────────────────────

--- a/packages/ui/src/backgrounds/useBackgroundApplyChannel.test.tsx
+++ b/packages/ui/src/backgrounds/useBackgroundApplyChannel.test.tsx
@@ -125,3 +125,73 @@ describe("useBackgroundApplyChannel — raw GLSL source is not a sink (#11088)",
     expect(config.shader?.uniforms.u_speed).toBe(0.25);
   });
 });
+
+describe("useBackgroundApplyChannel — named catalog entry (#13538)", () => {
+  it("applies a curated IMAGE catalog entry by id", () => {
+    const setBackgroundConfig = mountChannel({
+      mode: "shader",
+      color: "#101010",
+    });
+    apply({ op: "set", catalogId: "misty-forest" });
+    expect(setBackgroundConfig).toHaveBeenCalledTimes(1);
+    const config = setBackgroundConfig.mock.calls[0][0] as BackgroundConfig;
+    expect(config.mode).toBe("image");
+    expect(config.imageUrl).toContain("data:image/svg+xml");
+  });
+
+  it("resolves a catalog GLSL entry through the vetted preset corpus", () => {
+    const setBackgroundConfig = mountChannel({
+      mode: "shader",
+      color: "#101010",
+    });
+    apply({ op: "set", catalogId: "aurora" });
+    expect(setBackgroundConfig).toHaveBeenCalledTimes(1);
+    const config = setBackgroundConfig.mock.calls[0][0] as BackgroundConfig;
+    expect(config.mode).toBe("glsl");
+    expect(config.shader?.presetId).toBe("aurora");
+    expect(config.shader?.source).toBe(getShaderPreset("aurora")?.source);
+  });
+
+  it("resolves a catalog entry by label / fuzzy name", () => {
+    const setBackgroundConfig = mountChannel({
+      mode: "shader",
+      color: "#101010",
+    });
+    apply({ op: "set", catalogId: "Misty Forest" });
+    expect(setBackgroundConfig).toHaveBeenCalledTimes(1);
+    expect(
+      (setBackgroundConfig.mock.calls[0][0] as BackgroundConfig).mode,
+    ).toBe("image");
+  });
+
+  it("IGNORES an unknown catalog name (confinement: never wedges the bg)", () => {
+    const setBackgroundConfig = mountChannel({
+      mode: "shader",
+      color: "#101010",
+    });
+    apply({ op: "set", catalogId: "definitely-not-a-real-background" });
+    expect(setBackgroundConfig).not.toHaveBeenCalled();
+  });
+
+  it("a catalogId can NOT smuggle raw GLSL source or a URL past the broker", () => {
+    const setBackgroundConfig = mountChannel({
+      mode: "shader",
+      color: "#101010",
+    });
+    // Even paired with a for-bomb source + a hostile URL, only the named
+    // catalog entry's own (vetted) config is applied — the raw fields are
+    // dropped because catalogId short-circuits before the glsl/image branches.
+    apply({
+      op: "set",
+      catalogId: "aurora",
+      source: FOR_BOMB,
+      imageUrl: "https://evil.example/x.png",
+    });
+    expect(setBackgroundConfig).toHaveBeenCalledTimes(1);
+    const config = setBackgroundConfig.mock.calls[0][0] as BackgroundConfig;
+    expect(config.mode).toBe("glsl");
+    expect(config.shader?.source).toBe(getShaderPreset("aurora")?.source);
+    expect(config.shader?.source).not.toContain("200000");
+    expect(config.imageUrl).toBeUndefined();
+  });
+});

--- a/packages/ui/src/backgrounds/useBackgroundApplyChannel.ts
+++ b/packages/ui/src/backgrounds/useBackgroundApplyChannel.ts
@@ -19,11 +19,14 @@ import {
 } from "@elizaos/shared/events";
 import { useViewEvent } from "../hooks/useViewEvent";
 import {
+  catalogEntryToConfig,
   DEFAULT_BACKGROUND_COLOR,
   DEFAULT_BACKGROUND_CONFIG,
   makeGlslConfig,
+  resolveCatalogEntry,
 } from "../state/ui-preferences";
 import { useBackgroundConfig } from "../state/useBackgroundConfig";
+import { loadUserBackgroundCatalog } from "../state/user-background-catalog";
 import { getShaderPreset } from "./shader-presets";
 import {
   isPlausibleFragmentSource,
@@ -88,6 +91,38 @@ export function useBackgroundApplyChannel(): void {
     const uniformPatch = readUniformPatch(payload.uniforms);
     const presetId =
       typeof payload.presetId === "string" ? payload.presetId : undefined;
+
+    // ── Named catalog entry (#13538) ─────────────────────────────────────
+    // The agent (or the gallery) can name a curated catalog entry. We resolve
+    // it HERE, in the renderer, to a concrete config. Like `presetId`, the
+    // name is the ONLY thing that crosses the broker: an unknown name resolves
+    // to nothing and is ignored (never wedges the background — the #13523
+    // confinement invariant), and a glsl entry still goes through the vetted
+    // preset corpus, so no raw GLSL/URL can ride in on `catalogId`.
+    const catalogId =
+      typeof payload.catalogId === "string" ? payload.catalogId : undefined;
+    if (catalogId) {
+      // Curated catalog first, then the user's saved/generated entries (both
+      // resolve to an image/color/named-preset config only — never raw code).
+      let entry = resolveCatalogEntry(catalogId);
+      if (!entry) {
+        const needle = catalogId.trim().toLowerCase();
+        entry = loadUserBackgroundCatalog().find(
+          (e) =>
+            e.id.toLowerCase() === needle || e.label.toLowerCase() === needle,
+        );
+      }
+      if (entry) {
+        const config = catalogEntryToConfig(
+          entry,
+          (id) => getShaderPreset(id)?.source,
+        );
+        if (config) setBackgroundConfig(config);
+      }
+      // Unknown catalog name → ignore (confinement: never wedge the bg).
+      return;
+    }
+
     // Raw GLSL text in the payload is deliberately NOT accepted (#11088):
     // presets are the only source of shader code, so a crafted `source` field
     // (e.g. a bounded-for GPU bomb that would slip past the static gate) has

--- a/packages/ui/src/components/settings/BackgroundSettingsControls.tsx
+++ b/packages/ui/src/components/settings/BackgroundSettingsControls.tsx
@@ -20,15 +20,23 @@ import type { ChangeEvent } from "react";
 import { useCallback, useId, useRef, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { client } from "../../api";
+import { getShaderPreset } from "../../backgrounds/shader-presets";
 import { cn } from "../../lib/utils";
 import { useAppSelectorShallow } from "../../state/app-store";
 import {
+  BACKGROUND_CATALOG,
   BACKGROUND_PRESETS,
+  type BackgroundCatalogEntry,
   type BackgroundConfig,
   type BackgroundPreset,
+  catalogEntryToConfig,
   DEFAULT_BACKGROUND_COLOR,
 } from "../../state/ui-preferences";
 import { useBackgroundConfig } from "../../state/useBackgroundConfig";
+import {
+  addUserBackgroundEntry,
+  loadUserBackgroundCatalog,
+} from "../../state/user-background-catalog";
 import {
   BackgroundImageError,
   fileToBackgroundDataUrl,
@@ -76,6 +84,66 @@ function ColorSwatch({
   );
 }
 
+/**
+ * A gallery tile for one curated catalog entry (natural gradient or animated
+ * GLSL preset). The thumbnail is drawn from the entry's palette (a code-free CSS
+ * gradient), so no image loads to render the picker. Agent-addressable via
+ * `useAgentElement` so "use the misty-forest background" can activate it.
+ */
+function CatalogTile({
+  entry,
+  selected,
+  onSelect,
+}: {
+  entry: BackgroundCatalogEntry;
+  selected: boolean;
+  onSelect: (entry: BackgroundCatalogEntry) => void;
+}) {
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: `background-catalog-${entry.id}`,
+    role: "button",
+    label: `Set background to ${entry.label}`,
+    group: "background-controls",
+    description: `${entry.description} (${entry.mood})`,
+    onActivate: () => onSelect(entry),
+  });
+  const [c0, c1, c2] = [
+    entry.palette[0] ?? DEFAULT_BACKGROUND_COLOR,
+    entry.palette[1] ?? entry.palette[0] ?? DEFAULT_BACKGROUND_COLOR,
+    entry.palette[2] ??
+      entry.palette[entry.palette.length - 1] ??
+      DEFAULT_BACKGROUND_COLOR,
+  ];
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      onClick={() => onSelect(entry)}
+      title={`${entry.label} — ${entry.description}`}
+      aria-label={`Set background to ${entry.label}`}
+      aria-pressed={selected}
+      className={cn(
+        "relative h-16 w-24 shrink-0 overflow-hidden rounded-lg p-0 transition-transform hover:scale-105",
+        selected ? "ring-2 ring-accent" : "ring-1 ring-border/40",
+      )}
+      style={{
+        backgroundImage: `linear-gradient(to bottom, ${c0}, ${c1} 55%, ${c2})`,
+      }}
+      {...agentProps}
+    >
+      <span className="absolute inset-x-0 bottom-0 truncate bg-bg/55 px-1.5 py-0.5 text-left text-[10px] font-medium text-txt">
+        {entry.label}
+      </span>
+      {selected ? (
+        <Check
+          className="absolute right-1 top-1 h-3.5 w-3.5 text-white mix-blend-difference"
+          aria-hidden
+        />
+      ) : null}
+    </Button>
+  );
+}
+
 export interface BackgroundSettingsControlsProps {
   className?: string;
 }
@@ -105,6 +173,12 @@ export function BackgroundSettingsControls({
   const [generating, setGenerating] = useState(false);
   const [promptOpen, setPromptOpen] = useState(false);
   const [prompt, setPrompt] = useState("");
+  // The user's saved/generated catalog entries (persisted, newest first). The
+  // gallery shows them after the curated set so a generated background is
+  // re-selectable (#13538). Loaded lazily so SSR/first paint stays cheap.
+  const [userCatalog, setUserCatalog] = useState<BackgroundCatalogEntry[]>(() =>
+    loadUserBackgroundCatalog(),
+  );
 
   const config: BackgroundConfig =
     backgroundConfig && typeof backgroundConfig === "object"
@@ -120,6 +194,38 @@ export function BackgroundSettingsControls({
     },
     [setBackgroundConfig],
   );
+
+  const selectCatalog = useCallback(
+    (entry: BackgroundCatalogEntry) => {
+      setError(null);
+      const next = catalogEntryToConfig(
+        entry,
+        (id) => getShaderPreset(id)?.source,
+      );
+      if (next) setBackgroundConfig(next);
+    },
+    [setBackgroundConfig],
+  );
+
+  // Which catalog entry (if any) the live config matches — for the tile
+  // selected-ring. Image entries match on imageUrl; glsl entries on presetId.
+  const activeCatalogId = ((): string | null => {
+    if (config.mode === "image" && config.imageUrl) {
+      return (
+        [...BACKGROUND_CATALOG, ...userCatalog].find(
+          (e) => e.kind === "image" && e.source === config.imageUrl,
+        )?.id ?? null
+      );
+    }
+    if (config.mode === "glsl" && config.shader?.presetId) {
+      return (
+        BACKGROUND_CATALOG.find(
+          (e) => e.kind === "glsl" && e.source === config.shader?.presetId,
+        )?.id ?? null
+      );
+    }
+    return null;
+  })();
 
   const onUploadClick = useCallback(() => {
     setError(null);
@@ -146,6 +252,23 @@ export function BackgroundSettingsControls({
           // Keep the data-URL fallback.
         }
         setBackgroundConfig({ mode: "image", color: activeColor, imageUrl });
+        // Save the upload into the user catalog so it's re-selectable (#13538).
+        // The store persists ONLY re-hosted /api/media URLs (a data-URL offline
+        // fallback is applied live but not saved — quota guard), so this is a
+        // no-op when the re-host failed.
+        setUserCatalog(
+          addUserBackgroundEntry({
+            id: `user-${Date.now().toString(36)}`,
+            label: file.name.replace(/\.[^.]+$/, "") || "My upload",
+            description: "An image you uploaded.",
+            kind: "image",
+            source: imageUrl,
+            mood: "custom",
+            palette: [activeColor],
+            tags: ["custom", "upload"],
+            author: "you",
+          }),
+        );
         setError(null);
       } catch (err) {
         setError(
@@ -166,6 +289,22 @@ export function BackgroundSettingsControls({
     try {
       const { url } = await client.generateBackgroundImage(trimmed);
       setBackgroundConfig({ mode: "image", color: activeColor, imageUrl: url });
+      // Save the generated background into the user catalog with its prompt as
+      // metadata so it's re-selectable and describable later (#13538).
+      setUserCatalog(
+        addUserBackgroundEntry({
+          id: `user-${Date.now().toString(36)}`,
+          label: trimmed.slice(0, 40),
+          description: `Generated from “${trimmed}”.`,
+          kind: "image",
+          source: url,
+          mood: "custom",
+          palette: [activeColor],
+          tags: ["custom", "generated"],
+          prompt: trimmed,
+          author: "you",
+        }),
+      );
       setPromptOpen(false);
       setPrompt("");
     } catch (err) {
@@ -249,6 +388,21 @@ export function BackgroundSettingsControls({
           tabIndex={-1}
         />
       </div>
+
+      <fieldset
+        data-testid="background-catalog-gallery"
+        className="flex max-h-52 w-full flex-wrap items-center justify-center gap-2.5 overflow-y-auto border-0 p-0"
+      >
+        <legend className="sr-only">Curated backgrounds</legend>
+        {[...BACKGROUND_CATALOG, ...userCatalog].map((entry) => (
+          <CatalogTile
+            key={entry.id}
+            entry={entry}
+            selected={activeCatalogId === entry.id}
+            onSelect={selectCatalog}
+          />
+        ))}
+      </fieldset>
 
       <div className="flex items-center justify-center gap-3">
         <Button

--- a/packages/ui/src/state/background-catalog.test.ts
+++ b/packages/ui/src/state/background-catalog.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Background catalog (#13538): metadata, resolution, and config mapping. Proves
+ * the catalog is the single source of truth for the gallery + agent name-select
+ * and that unknown names resolve to nothing (confinement).
+ */
+import { describe, expect, it } from "vitest";
+import { getShaderPreset } from "../backgrounds/shader-presets";
+import {
+  BACKGROUND_CATALOG,
+  CURATED_NATURAL_BACKGROUNDS,
+  catalogEntryToConfig,
+  DEFAULT_BACKGROUND_CATALOG_ID,
+  DEFAULT_BACKGROUND_CONFIG,
+  GLSL_CATALOG_BACKGROUNDS,
+  resolveCatalogEntry,
+} from "./ui-preferences";
+
+const resolveSource = (id: string) => getShaderPreset(id)?.source;
+
+describe("background catalog (#13538)", () => {
+  it("has natural image entries + the animated GLSL presets", () => {
+    expect(CURATED_NATURAL_BACKGROUNDS.length).toBeGreaterThanOrEqual(4);
+    expect(GLSL_CATALOG_BACKGROUNDS.length).toBe(5);
+    expect(BACKGROUND_CATALOG.length).toBe(
+      CURATED_NATURAL_BACKGROUNDS.length + GLSL_CATALOG_BACKGROUNDS.length,
+    );
+  });
+
+  it("every entry carries the required metadata", () => {
+    for (const e of BACKGROUND_CATALOG) {
+      expect(e.id).toBeTruthy();
+      expect(e.label).toBeTruthy();
+      expect(e.description).toBeTruthy();
+      expect(e.mood).toBeTruthy();
+      expect(e.palette.length).toBeGreaterThan(0);
+      expect(e.tags.length).toBeGreaterThan(0);
+      expect(["image", "glsl", "color"]).toContain(e.kind);
+    }
+  });
+
+  it("commits NO bundled binary — image sources are code-free data/served URLs", () => {
+    for (const e of BACKGROUND_CATALOG) {
+      if (e.kind === "image") {
+        expect(
+          e.source.startsWith("data:image/svg+xml") ||
+            e.source.startsWith("/api/media/"),
+        ).toBe(true);
+        // The whole gradient stays tiny (well under any binary threshold).
+        expect(e.source.length).toBeLessThan(2048);
+      }
+      if (e.kind === "glsl") {
+        // A catalog glsl entry names a preset id, NEVER carries GLSL source.
+        expect(e.source).not.toContain("gl_FragColor");
+        expect(getShaderPreset(e.source)).toBeTruthy();
+      }
+    }
+  });
+
+  it("the boot default is a curated natural image, not a flat color", () => {
+    expect(DEFAULT_BACKGROUND_CONFIG.mode).toBe("image");
+    expect(DEFAULT_BACKGROUND_CONFIG.imageUrl).toContain("data:image/svg+xml");
+    const def = BACKGROUND_CATALOG.find(
+      (e) => e.id === DEFAULT_BACKGROUND_CATALOG_ID,
+    );
+    expect(def?.kind).toBe("image");
+    expect(def?.source).toBe(DEFAULT_BACKGROUND_CONFIG.imageUrl);
+  });
+
+  it("resolveCatalogEntry matches by id, label, and fuzzy name", () => {
+    expect(resolveCatalogEntry("misty-forest")?.id).toBe("misty-forest");
+    expect(resolveCatalogEntry("Misty Forest")?.id).toBe("misty-forest");
+    expect(resolveCatalogEntry("  MISTY forest ")?.id).toBe("misty-forest");
+    expect(resolveCatalogEntry("aurora")?.id).toBe("aurora");
+  });
+
+  it("resolveCatalogEntry returns undefined for unknown / empty names", () => {
+    expect(resolveCatalogEntry("nope-not-real")).toBeUndefined();
+    expect(resolveCatalogEntry("")).toBeUndefined();
+    expect(resolveCatalogEntry(undefined)).toBeUndefined();
+  });
+
+  it("catalogEntryToConfig maps image → image config", () => {
+    const forest = resolveCatalogEntry("misty-forest");
+    expect(forest).toBeTruthy();
+    if (!forest) throw new Error("expected misty-forest entry");
+    const config = catalogEntryToConfig(forest, resolveSource);
+    expect(config?.mode).toBe("image");
+    expect(config?.imageUrl).toBe(forest.source);
+  });
+
+  it("catalogEntryToConfig maps glsl → a config with the vetted preset source", () => {
+    const aurora = resolveCatalogEntry("aurora");
+    expect(aurora).toBeTruthy();
+    if (!aurora) throw new Error("expected aurora entry");
+    const config = catalogEntryToConfig(aurora, resolveSource);
+    expect(config?.mode).toBe("glsl");
+    expect(config?.shader?.presetId).toBe("aurora");
+    expect(config?.shader?.source).toBe(getShaderPreset("aurora")?.source);
+  });
+
+  it("catalogEntryToConfig returns undefined for a glsl entry with an unresolvable preset", () => {
+    const aurora = resolveCatalogEntry("aurora");
+    if (!aurora) throw new Error("expected aurora entry");
+    const bogus = { ...aurora, source: "not-a-real-preset" };
+    expect(catalogEntryToConfig(bogus, resolveSource)).toBeUndefined();
+  });
+});

--- a/packages/ui/src/state/persistence.background.test.ts
+++ b/packages/ui/src/state/persistence.background.test.ts
@@ -10,9 +10,21 @@ import {
   normalizeBackgroundConfig,
   saveBackgroundConfig,
 } from "./persistence";
-import { DEFAULT_BACKGROUND_COLOR } from "./ui-preferences";
+import {
+  DEFAULT_BACKGROUND_COLOR,
+  DEFAULT_BACKGROUND_CONFIG,
+} from "./ui-preferences";
 
-const DEFAULT = { mode: "shader", color: DEFAULT_BACKGROUND_COLOR } as const;
+// The boot default is now the curated "Ember Night" image (#13538), returned for
+// empty/absent/unusable-record input.
+const DEFAULT = DEFAULT_BACKGROUND_CONFIG;
+// A present-but-malformed config still collapses to the plain shader field (a
+// bad shader / image-without-url can never wedge the background) — NOT the image
+// boot default.
+const SHADER_FALLBACK = {
+  mode: "shader",
+  color: DEFAULT_BACKGROUND_COLOR,
+} as const;
 
 afterEach(() => {
   try {
@@ -29,13 +41,22 @@ describe("background config persistence", () => {
     ).toEqual({ mode: "shader", color: "#aabbcc" });
   });
 
-  it("falls back to the default shader for unusable input", () => {
+  it("falls back to the boot default for unusable (absent) input", () => {
+    // null / non-record → the boot default (curated image).
     expect(normalizeBackgroundConfig(null)).toEqual(DEFAULT);
     expect(normalizeBackgroundConfig("nope")).toEqual(DEFAULT);
-    // image mode with no usable url collapses to the shader
-    expect(normalizeBackgroundConfig({ mode: "image" })).toEqual(DEFAULT);
+  });
+
+  it("collapses a malformed present config to the plain shader field", () => {
+    // image mode with no usable url collapses to the shader (not the image
+    // boot default) — a present-but-broken config can never wedge the bg.
+    expect(normalizeBackgroundConfig({ mode: "image" })).toEqual(
+      SHADER_FALLBACK,
+    );
     // invalid color collapses to the default color
-    expect(normalizeBackgroundConfig({ color: "red" })).toEqual(DEFAULT);
+    expect(normalizeBackgroundConfig({ color: "red" })).toEqual(
+      SHADER_FALLBACK,
+    );
   });
 
   it("keeps an image config that carries a usable url", () => {

--- a/packages/ui/src/state/ui-preferences.ts
+++ b/packages/ui/src/state/ui-preferences.ts
@@ -15,11 +15,19 @@ export type UiThemeMode = "light" | "dark" | "system";
 export type UiShellMode = "native";
 
 import {
+  BACKGROUND_CATALOG_INDEX,
+  type BackgroundCatalogKind,
+  type BackgroundCatalogMeta,
+  DEFAULT_BACKGROUND_CATALOG_ID as SHARED_DEFAULT_BACKGROUND_CATALOG_ID,
+} from "@elizaos/shared/backgrounds/catalog-index";
+import {
   DEFAULT_SHADER_UNIFORMS,
   normalizeUniforms,
   type ShaderUniformValues,
   uniformsEqual,
 } from "../backgrounds/shader-schema";
+
+export type { BackgroundCatalogKind, BackgroundCatalogMeta };
 
 /**
  * How the unified app background is rendered. `shader` paints the animated
@@ -72,9 +80,34 @@ export const DEFAULT_BACKGROUND_COLOR = "#160d07";
  */
 export const DEFAULT_BACKGROUND_GLOW = "#ff6a1f";
 
-export const DEFAULT_BACKGROUND_CONFIG: BackgroundConfig = {
+/**
+ * The shader-mode fallback config: the flat banked-ember field. Kept as the
+ * base the color swatches and the glsl fallback resolve to. NOT the boot default
+ * anymore — see {@link DEFAULT_BACKGROUND_CONFIG}.
+ */
+export const DEFAULT_SHADER_BACKGROUND_CONFIG: BackgroundConfig = {
   mode: "shader",
   color: DEFAULT_BACKGROUND_COLOR,
+};
+
+/**
+ * The curated "Ember Night" gradient as a code-free SVG data URL — the boot
+ * default's image source. `gradientDataUrl` is a hoisted function declaration
+ * (defined below with the catalog), so calling it here at module-eval time is
+ * safe. Kept in sync with the `ember-night` catalog entry's palette.
+ */
+const EMBER_NIGHT_DATA_URL = gradientDataUrl(["#0a0603", "#160d07", "#3a1f0d"]);
+
+/**
+ * The boot default background. #13538 asks the app to boot to "a nice natural
+ * (or interesting curated) default, not a flat color." We ship the curated
+ * "Ember Night" gradient (a code-free SVG data URL, so it paints instantly with
+ * no fetch and no bundled binary).
+ */
+export const DEFAULT_BACKGROUND_CONFIG: BackgroundConfig = {
+  mode: "image",
+  color: DEFAULT_BACKGROUND_COLOR,
+  imageUrl: EMBER_NIGHT_DATA_URL,
 };
 
 /** A named default background — a curated shader color the user can pick. */
@@ -105,6 +138,168 @@ export const BACKGROUND_PRESETS: readonly BackgroundPreset[] = [
   { id: "black", label: "Black", color: "#0a0a0a" },
   { id: "light", label: "Light", color: "#f4f4f5" },
 ];
+
+/* ── Background catalog (curated + metadata) ──────────────────────────── */
+
+/**
+ * How a catalog entry paints. `color` = a shader color field (a preset), `glsl`
+ * = a named programmable-shader preset, `image` = a served/vetted cover-image
+ * URL (curated gradient data URL, or a persisted `/api/media/<hash>` upload).
+ *
+ * Note: a catalog entry never carries GLSL *source* — only a `presetId` the
+ * renderer resolves against its own shader corpus (#11088). The apply channel
+ * enforces this: naming a catalog entry can never smuggle arbitrary shader code
+ * or an unvetted client URL through the broker.
+ */
+/**
+ * One entry in the curated background catalog: the shared metadata
+ * ({@link BackgroundCatalogMeta} from `@elizaos/shared`) plus the concrete
+ * render `source` the renderer attaches (this package is the only place that
+ * knows how to paint an entry). The metadata half is the single source of truth
+ * the gallery picker AND the agent read; the `source` never crosses the broker.
+ */
+export interface BackgroundCatalogEntry extends BackgroundCatalogMeta {
+  /**
+   * The render source (renderer-only, never sent in a payload):
+   *  - `kind: "color"` → 6-digit hex driving the shader field.
+   *  - `kind: "glsl"`  → a shader preset id (resolved to source by the renderer).
+   *  - `kind: "image"` → a served/vetted cover-image URL (gradient data URL or
+   *    `/api/media/<hash>`).
+   */
+  source: string;
+  /** Optional generation prompt (for image entries the agent added). */
+  prompt?: string;
+  /** Optional author ("curated", or an agent/user attribution). */
+  author?: string;
+}
+
+/**
+ * Build a tiny, self-contained SVG gradient as a data URL — a curated "natural"
+ * wallpaper with ZERO committed binary bytes. The whole catalog of natural
+ * backgrounds is a handful of these (each < 1 KB), so nothing large lands in
+ * the bundle (#13538 constraint) and every entry is a same-origin, code-free
+ * image the apply channel already trusts.
+ */
+function gradientDataUrl(palette: readonly string[]): string {
+  const [a, b, c] = [
+    palette[0] ?? DEFAULT_BACKGROUND_COLOR,
+    palette[1] ?? palette[0] ?? DEFAULT_BACKGROUND_COLOR,
+    palette[2] ?? palette[palette.length - 1] ?? DEFAULT_BACKGROUND_COLOR,
+  ];
+  const svg =
+    `<svg xmlns='http://www.w3.org/2000/svg' width='16' height='24' ` +
+    `preserveAspectRatio='xMidYMid slice' viewBox='0 0 16 24'>` +
+    `<defs><linearGradient id='g' x1='0' y1='0' x2='0' y2='1'>` +
+    `<stop offset='0' stop-color='${a}'/>` +
+    `<stop offset='0.55' stop-color='${b}'/>` +
+    `<stop offset='1' stop-color='${c}'/>` +
+    `</linearGradient></defs>` +
+    `<rect width='16' height='24' fill='url(#g)'/></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+/**
+ * Attach a concrete render `source` to each shared metadata entry, building the
+ * full catalog the gallery + apply channel use. Natural images become code-free
+ * gradient data URLs (from the entry's palette); glsl entries carry the preset
+ * id as `source` (resolved to GLSL by the renderer, never text here). This is
+ * the ONLY place a catalog id becomes something paintable.
+ */
+export const BACKGROUND_CATALOG: readonly BackgroundCatalogEntry[] =
+  BACKGROUND_CATALOG_INDEX.map((meta): BackgroundCatalogEntry => {
+    if (meta.kind === "glsl") {
+      // `source` is the preset id; the renderer resolves it to GLSL.
+      return { ...meta, source: meta.id, author: "curated" };
+    }
+    if (meta.kind === "color") {
+      return {
+        ...meta,
+        source:
+          meta.palette[meta.palette.length - 1] ?? DEFAULT_BACKGROUND_COLOR,
+        author: "curated",
+      };
+    }
+    // image: a code-free gradient data URL from the palette. Ember Night reuses
+    // the shared boot-default URL so the default and its catalog tile match.
+    return {
+      ...meta,
+      source:
+        meta.id === SHARED_DEFAULT_BACKGROUND_CATALOG_ID
+          ? EMBER_NIGHT_DATA_URL
+          : gradientDataUrl(meta.palette),
+      author: "curated",
+    };
+  });
+
+/**
+ * The curated natural (image) catalog entries — the gallery leads with these.
+ */
+export const CURATED_NATURAL_BACKGROUNDS: readonly BackgroundCatalogEntry[] =
+  BACKGROUND_CATALOG.filter((e) => e.kind === "image");
+
+/** The animated GLSL catalog entries, mirrored from the shader preset library. */
+export const GLSL_CATALOG_BACKGROUNDS: readonly BackgroundCatalogEntry[] =
+  BACKGROUND_CATALOG.filter((e) => e.kind === "glsl");
+
+/** The boot-default catalog id (re-exported from the shared index). */
+export const DEFAULT_BACKGROUND_CATALOG_ID =
+  SHARED_DEFAULT_BACKGROUND_CATALOG_ID;
+
+/**
+ * Normalize a free-text / id / label reference to a catalog entry. Case- and
+ * whitespace-insensitive; matches by id first, then exact label, then a label
+ * substring (either direction) — so "misty forest", "Misty Forest", and "the
+ * misty forest one" all resolve. Returns undefined for an unknown name (the
+ * apply channel then ignores it — consistent with the #13523 confinement rule
+ * that unknown/hostile payloads never wedge the background).
+ *
+ * Deliberately does NOT match on generic tags ("green"/"blue"/"warm"): those are
+ * color words owned by the color parser — tag-matching them would apply an
+ * arbitrary curated image for a plain color request.
+ */
+export function resolveCatalogEntry(
+  ref: string | undefined,
+): BackgroundCatalogEntry | undefined {
+  if (!ref) return undefined;
+  const needle = ref.trim().toLowerCase();
+  if (!needle) return undefined;
+  const byId = BACKGROUND_CATALOG.find((e) => e.id === needle);
+  if (byId) return byId;
+  const byLabel = BACKGROUND_CATALOG.find(
+    (e) => e.label.toLowerCase() === needle,
+  );
+  if (byLabel) return byLabel;
+  return BACKGROUND_CATALOG.find((e) => {
+    const label = e.label.toLowerCase();
+    return label.includes(needle) || needle.includes(label);
+  });
+}
+
+/**
+ * Resolve a catalog entry to a concrete `BackgroundConfig`. Color/image entries
+ * map directly; a glsl entry is resolved to its shader source by the provided
+ * `resolveShaderSource` (the renderer's `getShaderPreset`) — the catalog itself
+ * never carries GLSL text (#11088). Returns undefined when a glsl entry's preset
+ * can't be resolved, so a stale/unknown preset id never wedges the background.
+ */
+export function catalogEntryToConfig(
+  entry: BackgroundCatalogEntry,
+  resolveShaderSource: (presetId: string) => string | undefined,
+): BackgroundConfig | undefined {
+  if (entry.kind === "color") {
+    return { mode: "shader", color: entry.source };
+  }
+  if (entry.kind === "image") {
+    return {
+      mode: "image",
+      color: DEFAULT_BACKGROUND_COLOR,
+      imageUrl: entry.source,
+    };
+  }
+  const source = resolveShaderSource(entry.source);
+  if (!source) return undefined;
+  return makeGlslConfig({ source, presetId: entry.source });
+}
 
 /** Structural equality for two background configs (skips history no-ops). */
 export function backgroundConfigsEqual(

--- a/packages/ui/src/state/useDisplayPreferences.background.test.tsx
+++ b/packages/ui/src/state/useDisplayPreferences.background.test.tsx
@@ -17,7 +17,11 @@ import {
   normalizeBackgroundHistory,
   saveHomeTimeWidgetHidden,
 } from "./persistence";
-import { DEFAULT_BACKGROUND_COLOR, makeGlslConfig } from "./ui-preferences";
+import {
+  DEFAULT_BACKGROUND_COLOR,
+  DEFAULT_BACKGROUND_CONFIG,
+  makeGlslConfig,
+} from "./ui-preferences";
 import { useDisplayPreferences } from "./useDisplayPreferences";
 
 beforeEach(() => {
@@ -29,12 +33,13 @@ afterEach(() => {
 });
 
 describe("useDisplayPreferences — background history + undo", () => {
-  it("starts on the default with nothing to undo", () => {
+  it("starts on the boot default (curated image) with nothing to undo", () => {
     const { result } = renderHook(() => useDisplayPreferences());
-    expect(result.current.state.backgroundConfig).toEqual({
-      mode: "shader",
-      color: DEFAULT_BACKGROUND_COLOR,
-    });
+    // #13538: the boot default is now the curated "Ember Night" image, not a
+    // flat shader color.
+    expect(result.current.state.backgroundConfig).toEqual(
+      DEFAULT_BACKGROUND_CONFIG,
+    );
     expect(result.current.state.canUndoBackground).toBe(false);
   });
 
@@ -113,11 +118,10 @@ describe("useDisplayPreferences — background history + undo", () => {
 
   it("setting the same config is a no-op (no history churn)", () => {
     const { result } = renderHook(() => useDisplayPreferences());
+    // Re-set the ACTUAL current default (the boot image) — an identical config
+    // must not churn history.
     act(() => {
-      result.current.setBackgroundConfig({
-        mode: "shader",
-        color: DEFAULT_BACKGROUND_COLOR,
-      });
+      result.current.setBackgroundConfig({ ...DEFAULT_BACKGROUND_CONFIG });
     });
     expect(result.current.state.canUndoBackground).toBe(false);
   });

--- a/packages/ui/src/state/user-background-catalog.test.ts
+++ b/packages/ui/src/state/user-background-catalog.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+/**
+ * User background catalog (#13538): persistence of agent/user-added backgrounds.
+ * Proves only re-hosted /api/media URLs persist (data-URL quota guard) and the
+ * store never accepts a non-image / code-bearing entry.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import type { BackgroundCatalogEntry } from "./ui-preferences";
+import {
+  addUserBackgroundEntry,
+  loadUserBackgroundCatalog,
+  MAX_USER_CATALOG_ENTRIES,
+} from "./user-background-catalog";
+
+afterEach(() => {
+  try {
+    localStorage.clear();
+  } catch {
+    /* ignore */
+  }
+});
+
+function imageEntry(id: string, source: string): BackgroundCatalogEntry {
+  return {
+    id,
+    label: id,
+    description: "test",
+    kind: "image",
+    source,
+    mood: "custom",
+    palette: ["#123456"],
+    tags: ["custom"],
+    author: "you",
+  };
+}
+
+describe("user background catalog (#13538)", () => {
+  it("persists a re-hosted /api/media upload and reloads it", () => {
+    const next = addUserBackgroundEntry(
+      imageEntry("user-1", "/api/media/abc.png"),
+    );
+    expect(next).toHaveLength(1);
+    expect(loadUserBackgroundCatalog()[0].source).toBe("/api/media/abc.png");
+  });
+
+  it("REJECTS an inline data: URL (localStorage quota guard)", () => {
+    const next = addUserBackgroundEntry(
+      imageEntry("user-data", "data:image/png;base64,AAAA"),
+    );
+    expect(next).toHaveLength(0);
+    expect(loadUserBackgroundCatalog()).toHaveLength(0);
+  });
+
+  it("rejects a non-image / bogus source", () => {
+    expect(
+      addUserBackgroundEntry(imageEntry("x", "https://evil.example/x.png")),
+    ).toHaveLength(0);
+    expect(
+      addUserBackgroundEntry({
+        ...imageEntry("y", "/api/media/ok.png"),
+        kind: "glsl",
+        source: "aurora",
+      } as BackgroundCatalogEntry),
+    ).toHaveLength(0);
+  });
+
+  it("updates by id (no duplicate) and keeps newest first", () => {
+    addUserBackgroundEntry(imageEntry("a", "/api/media/a1.png"));
+    addUserBackgroundEntry(imageEntry("b", "/api/media/b1.png"));
+    const list = addUserBackgroundEntry(imageEntry("a", "/api/media/a2.png"));
+    expect(list).toHaveLength(2);
+    expect(list[0].id).toBe("a");
+    expect(list[0].source).toBe("/api/media/a2.png");
+  });
+
+  it("caps the persisted catalog size", () => {
+    for (let i = 0; i < MAX_USER_CATALOG_ENTRIES + 5; i++) {
+      addUserBackgroundEntry(imageEntry(`e${i}`, `/api/media/${i}.png`));
+    }
+    expect(loadUserBackgroundCatalog().length).toBe(MAX_USER_CATALOG_ENTRIES);
+  });
+});

--- a/packages/ui/src/state/user-background-catalog.ts
+++ b/packages/ui/src/state/user-background-catalog.ts
@@ -1,0 +1,114 @@
+/**
+ * The USER background catalog (#13538) — backgrounds the agent generated/uploaded
+ * and named into the catalog, plus any the user saved from the gallery's
+ * "add to catalog" affordance. Kept separate from the curated `BACKGROUND_CATALOG`
+ * (which is compile-time + code-free) so:
+ *
+ *  - the curated set stays a small, static, code-free source of truth, and
+ *  - user entries persist to localStorage WITHOUT a new server file store
+ *    (#8876: no second media store) — the image itself is already re-hosted to
+ *    `/api/media/<hash>` by the existing background routes, so a user entry only
+ *    persists a short URL + metadata, never bytes.
+ *
+ * Security: a user entry is ALWAYS `kind: "image"` with a SERVED media-store URL
+ * (`/api/media/<hash>`). It can never carry GLSL source or a preset id, so the
+ * confinement invariants (#11088 / #13523) are unaffected — the apply channel
+ * treats a resolved user entry exactly like any other image config.
+ *
+ * Quota: inline `data:` URLs are deliberately REJECTED from the persisted
+ * catalog. A re-hosted upload is a tiny `/api/media/<hash>` reference; the
+ * offline/serverless fallback keeps a multi-MB data URL live on the CURRENT
+ * background (that still works), but persisting up to 24 of those would blow
+ * localStorage — the same hazard `normalizeBackgroundHistory` caps to 1 data URL
+ * for the undo stack. So a data-URL upload simply isn't saved to the catalog.
+ */
+
+import type { BackgroundCatalogEntry } from "./ui-preferences";
+
+const USER_BACKGROUND_CATALOG_KEY = "eliza:ui-background-user-catalog";
+
+/** Cap the persisted user catalog so it never grows localStorage without bound. */
+const MAX_USER_CATALOG_ENTRIES = 24;
+
+function tryLocalStorage<T>(fn: () => T, fallback: T): T {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}
+
+/** Coerce one unknown persisted record to a valid image catalog entry, or null. */
+function normalizeUserEntry(value: unknown): BackgroundCatalogEntry | null {
+  if (!value || typeof value !== "object") return null;
+  const r = value as Record<string, unknown>;
+  const id = typeof r.id === "string" ? r.id : "";
+  const source = typeof r.source === "string" ? r.source : "";
+  // A user entry is only ever a SERVED media-store URL. Inline data URLs are
+  // rejected (quota hazard) and GLSL/preset sources are never image entries.
+  const okUrl = source.startsWith("/api/media/");
+  if (!id || !okUrl) return null;
+  const palette = Array.isArray(r.palette)
+    ? r.palette.filter((c): c is string => typeof c === "string").slice(0, 4)
+    : [];
+  const tags = Array.isArray(r.tags)
+    ? r.tags.filter((t): t is string => typeof t === "string").slice(0, 8)
+    : [];
+  return {
+    id,
+    label: typeof r.label === "string" && r.label ? r.label : id,
+    description:
+      typeof r.description === "string" ? r.description : "A saved background.",
+    kind: "image",
+    source,
+    mood: typeof r.mood === "string" ? r.mood : "custom",
+    palette,
+    tags: tags.length > 0 ? tags : ["custom"],
+    prompt: typeof r.prompt === "string" ? r.prompt : undefined,
+    author: typeof r.author === "string" ? r.author : "you",
+  };
+}
+
+/** The persisted user catalog (newest first). Empty on any read failure. */
+export function loadUserBackgroundCatalog(): BackgroundCatalogEntry[] {
+  return tryLocalStorage(() => {
+    const raw = localStorage.getItem(USER_BACKGROUND_CATALOG_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const out: BackgroundCatalogEntry[] = [];
+    for (const entry of parsed) {
+      const norm = normalizeUserEntry(entry);
+      if (norm) out.push(norm);
+    }
+    return out.slice(0, MAX_USER_CATALOG_ENTRIES);
+  }, []);
+}
+
+function saveUserBackgroundCatalog(entries: BackgroundCatalogEntry[]): void {
+  tryLocalStorage(() => {
+    localStorage.setItem(
+      USER_BACKGROUND_CATALOG_KEY,
+      JSON.stringify(entries.slice(0, MAX_USER_CATALOG_ENTRIES)),
+    );
+  }, undefined);
+}
+
+/**
+ * Add (or update by id) a user catalog entry, newest first, and persist it.
+ * Rejects anything but a served/vetted image URL (returns the unchanged list),
+ * so a hostile/malformed entry can never enter the catalog. Returns the new
+ * list so callers can re-render.
+ */
+export function addUserBackgroundEntry(
+  entry: BackgroundCatalogEntry,
+): BackgroundCatalogEntry[] {
+  const norm = normalizeUserEntry(entry);
+  if (!norm) return loadUserBackgroundCatalog();
+  const existing = loadUserBackgroundCatalog().filter((e) => e.id !== norm.id);
+  const next = [norm, ...existing].slice(0, MAX_USER_CATALOG_ENTRIES);
+  saveUserBackgroundCatalog(next);
+  return next;
+}
+
+export { MAX_USER_CATALOG_ENTRIES, USER_BACKGROUND_CATALOG_KEY };

--- a/plugins/plugin-app-control/src/actions/background.test.ts
+++ b/plugins/plugin-app-control/src/actions/background.test.ts
@@ -3,6 +3,7 @@
  */
 
 import type { IAgentRuntime, Media, Memory } from "@elizaos/core";
+import type { NavigateViewDetail } from "@elizaos/shared/events";
 import { BACKGROUND_APPLY_EVENT as SHARED_BACKGROUND_APPLY_EVENT } from "@elizaos/shared/events";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -453,5 +454,189 @@ describe("BACKGROUND action handler", () => {
 		expect(
 			await action.validate(runtime, message("make the background teal")),
 		).toBe(true);
+	});
+});
+
+describe("BACKGROUND action — catalog name-select + upload handoff (#13538)", () => {
+	function setup() {
+		const emitted: BackgroundApplyPayload[] = [];
+		const navigated: NavigateViewDetail[] = [];
+		const replies: string[] = [];
+		const action = createBackgroundAction({
+			emit: async (payload) => {
+				emitted.push(payload);
+			},
+			generateImage: async () => "/api/media/generated.png",
+			navigate: async (detail) => {
+				navigated.push(detail);
+			},
+		});
+		const callback = vi.fn(async (content: { text?: string }) => {
+			if (content.text) replies.push(content.text);
+			return [];
+		});
+		return { action, emitted, navigated, replies, callback };
+	}
+
+	it("names a curated catalog entry via catalogId (no color/preset)", async () => {
+		const { action, emitted, replies, callback } = setup();
+		const result = await action.handler(
+			runtime,
+			message("use the misty-forest background"),
+			undefined,
+			undefined,
+			callback,
+		);
+		expect(emitted).toEqual([{ op: "set", catalogId: "misty-forest" }]);
+		expect(result.success).toBe(true);
+		expect(replies[0]).toContain("Misty Forest");
+	});
+
+	it("resolves a fuzzy catalog name to the canonical id", async () => {
+		const { action, emitted } = setup();
+		await action.handler(
+			runtime,
+			message("switch the wallpaper to ocean deep"),
+			undefined,
+			undefined,
+			vi.fn(async () => []),
+		);
+		expect(emitted).toEqual([{ op: "set", catalogId: "ocean-deep" }]);
+	});
+
+	it("an explicit generate wins over a same-named catalog entry", async () => {
+		const { action, emitted } = setup();
+		await action.handler(
+			runtime,
+			message("generate a misty forest background"),
+			undefined,
+			undefined,
+			vi.fn(async () => []),
+		);
+		// generate path emits an image (generated url), NOT a catalogId select.
+		expect(emitted).toEqual([
+			{ op: "set", mode: "image", imageUrl: "/api/media/generated.png" },
+		]);
+	});
+
+	it("routes an upload intent to the /background view (no dead end)", async () => {
+		const { action, emitted, navigated, replies, callback } = setup();
+		const result = await action.handler(
+			runtime,
+			message("i want to upload my own background image"),
+			undefined,
+			undefined,
+			callback,
+		);
+		expect(emitted).toEqual([]);
+		expect(navigated).toEqual([
+			{ viewId: "background", viewPath: "/background" },
+		]);
+		expect(result.success).toBe(true);
+		expect(replies[0]).toContain("Background view");
+	});
+
+	it("'choose a green background' applies the COLOR, not an upload handoff", async () => {
+		const { action, emitted, navigated } = setup();
+		await action.handler(
+			runtime,
+			message("choose a green background"),
+			undefined,
+			undefined,
+			vi.fn(async () => []),
+		);
+		expect(navigated).toEqual([]);
+		expect(emitted).toEqual([{ op: "set", mode: "shader", color: "#059669" }]);
+	});
+
+	it("'pick a blue wallpaper' applies the COLOR, not an upload handoff", async () => {
+		const { action, emitted, navigated } = setup();
+		await action.handler(
+			runtime,
+			message("pick a blue wallpaper"),
+			undefined,
+			undefined,
+			vi.fn(async () => []),
+		);
+		expect(navigated).toEqual([]);
+		expect(emitted).toEqual([{ op: "set", mode: "shader", color: "#2563eb" }]);
+	});
+
+	it("'choose from my photos' IS an upload handoff (device-file intent)", async () => {
+		const { action, navigated } = setup();
+		await action.handler(
+			runtime,
+			message("choose a background from my photos"),
+			undefined,
+			undefined,
+			vi.fn(async () => []),
+		);
+		expect(navigated).toEqual([
+			{ viewId: "background", viewPath: "/background" },
+		]);
+	});
+
+	it("a generic color word does NOT resolve to a catalog entry", async () => {
+		const { action, emitted } = setup();
+		// "green" is a tag on misty-forest but must stay a COLOR request.
+		await action.handler(
+			runtime,
+			message("make the background green"),
+			undefined,
+			undefined,
+			vi.fn(async () => []),
+		);
+		expect(emitted).toEqual([{ op: "set", mode: "shader", color: "#059669" }]);
+	});
+
+	it("an ATTACHED image wins over a same-named catalog entry", async () => {
+		const { action, emitted } = setup();
+		await action.handler(
+			runtime,
+			message("use this misty forest background", [
+				{ url: "/api/media/mine.png", contentType: "image" } as Media,
+			]),
+			undefined,
+			undefined,
+			vi.fn(async () => []),
+		);
+		// The attachment is applied — NOT the curated Misty Forest catalog entry.
+		expect(emitted).toEqual([
+			{ op: "set", mode: "image", imageUrl: "/api/media/mine.png" },
+		]);
+	});
+
+	it("does NOT hijack a described-image set as an upload handoff", async () => {
+		const { action, emitted, navigated } = setup();
+		await action.handler(
+			runtime,
+			message("set the background to a picture of a forest"),
+			undefined,
+			undefined,
+			vi.fn(async () => []),
+		);
+		// A described image → generate path, NOT the upload view.
+		expect(navigated).toEqual([]);
+		expect(emitted).toEqual([
+			{ op: "set", mode: "image", imageUrl: "/api/media/generated.png" },
+		]);
+	});
+
+	it("does NOT hijack an attachment-backed set as an upload handoff", async () => {
+		const { action, emitted, navigated } = setup();
+		await action.handler(
+			runtime,
+			message("set this as my background", [
+				{ url: "/api/media/photo.png", contentType: "image" } as Media,
+			]),
+			undefined,
+			undefined,
+			vi.fn(async () => []),
+		);
+		// With a usable attachment, apply it — don't route to the upload view.
+		expect(navigated).toEqual([]);
+		expect(emitted).toEqual([
+			{ op: "set", mode: "image", imageUrl: "/api/media/photo.png" },
+		]);
 	});
 });

--- a/plugins/plugin-app-control/src/actions/background.ts
+++ b/plugins/plugin-app-control/src/actions/background.ts
@@ -29,9 +29,15 @@ import {
 	type Memory,
 	type State,
 } from "@elizaos/core";
+import {
+	BACKGROUND_CATALOG_INDEX,
+	detectCatalogId,
+	matchCatalogId,
+} from "@elizaos/shared/backgrounds/catalog-index";
 import type {
 	BackgroundApplyPayload,
 	BackgroundShaderUniformPatch,
+	NavigateViewDetail,
 } from "@elizaos/shared/events";
 import { BACKGROUND_APPLY_EVENT } from "@elizaos/shared/events";
 import { normalizeActionOptions, readStringOption } from "../params.js";
@@ -61,6 +67,12 @@ type BackgroundPlan =
 			uniforms: ShaderUniformPatch;
 			tweakLabel: string;
 	  }
+	// A named curated-catalog entry ("use the misty-forest background"). The
+	// renderer resolves `catalogId` → config; the action only names it (#13538).
+	| { op: "set"; mode: "catalog"; catalogId: string; catalogLabel: string }
+	// The user wants to upload a background — no color/image/prompt to apply.
+	// Route them to the /background view instead of a dead end (#13538 handoff).
+	| { op: "navigate-upload" }
 	| { op: "set"; generatePrompt: string };
 
 // Any reference to the background surface — gates the action so unrelated chat
@@ -84,6 +96,32 @@ const RESET_RE =
 const SET_RE = /\b(set|make|change|use|turn|switch|give me|apply|put)\b/i;
 // Explicit ask for a generated image rather than a flat color.
 const GENERATE_RE = /\b(generate|create|paint|draw|design|render|imagine)\b/i;
+// An intent to UPLOAD a background FILE from the user's device ("I want to upload
+// a background", "let me choose my own wallpaper", "pick a background from my
+// photos", "upload an image"). With no attachment to apply, this routes to the
+// /background view where upload lives (#13538 handoff) rather than dead-ending.
+//
+// Scoped TIGHTLY to genuine device-file intent so it never hijacks a plain color
+// or selection request:
+//   - the word "upload" (any background/image object), OR
+//   - a choose/pick/select/browse verb combined with a DEVICE-FILE signal:
+//     "my own", "from my …", "my photos/gallery/files/library/computer/device",
+//     or a bare file noun ("file"). "choose a green background" does NOT qualify
+//     (no device-file signal), so it flows on to color parsing.
+const UPLOAD_WORD_RE = /\bupload(?:ed|ing|s)?\b/i;
+const PICK_VERB_RE = /\b(choose|pick|select|browse)\b/i;
+const DEVICE_FILE_SIGNAL_RE =
+	/\b(my own|own|from my|my (?:photos?|gallery|files?|library|computer|device|phone|camera roll))\b|\bfile\b|\b(?:photo|camera) roll\b/i;
+const BG_OR_IMAGE_OBJECT_RE =
+	/\b(background|wallpaper|backdrop|image|photo|picture)\b/i;
+function isUploadIntent(text: string): boolean {
+	// "upload …" tied to a background/image object.
+	if (UPLOAD_WORD_RE.test(text) && BG_OR_IMAGE_OBJECT_RE.test(text)) {
+		return true;
+	}
+	// choose/pick/select/browse + an explicit device-file signal.
+	return PICK_VERB_RE.test(text) && DEVICE_FILE_SIGNAL_RE.test(text);
+}
 // References to an attachment-like object. If these are present with unusable
 // attachment records, do not reinterpret the request as an image-generation
 // prompt like "from this attachment".
@@ -303,6 +341,52 @@ export function inferBackgroundPlan(
 		return { op: "redo" };
 	if (explicitOp === "reset" || RESET_RE.test(trimmed)) return { op: "reset" };
 
+	// A named curated-catalog entry ("use the misty-forest background"). An
+	// explicit `catalog` option wins; otherwise detect a catalog LABEL in the
+	// text (distinctive multi-word names / id slugs only, so a plain color word
+	// still resolves to a color below). Checked before color/preset parsing so a
+	// catalog name is never mis-read as a color. #13538.
+	const explicitCatalog = readStringOption(options, "catalog");
+	// When the user explicitly asks to GENERATE/create a NEW background, honor
+	// that (a fresh render) over a same-named curated entry — "generate a misty
+	// forest" means make one, not pick the catalog's Misty Forest. Likewise, an
+	// image the user ATTACHED takes precedence over a same-named catalog entry
+	// ("use this misty forest photo" with an attachment → apply the attachment,
+	// not the curated Misty Forest) — unless they explicitly named a catalog id.
+	const wantsFreshGenerate = GENERATE_RE.test(trimmed);
+	const hasImageAttachment = Boolean(firstImageAttachment(attachments));
+	const catalogId = explicitCatalog
+		? matchCatalogId(explicitCatalog)
+		: wantsFreshGenerate || hasImageAttachment
+			? undefined
+			: detectCatalogId(trimmed);
+	if (catalogId) {
+		const meta = BACKGROUND_CATALOG_INDEX.find((e) => e.id === catalogId);
+		return {
+			op: "set",
+			mode: "catalog",
+			catalogId,
+			catalogLabel: meta?.label ?? catalogId,
+		};
+	}
+
+	// "I want to upload a background" with no usable attachment → send the user to
+	// the /background view (upload lives there), not a dead end. Only when the
+	// message is about uploading and carries no image attachment/URL to apply.
+	if (
+		!explicitImage &&
+		!explicitPrompt &&
+		!GENERATE_RE.test(trimmed) &&
+		// Not a reference to an EXISTING (this/that/attached) attachment — those
+		// are attachment-backed requests handled below, not a browse-for-a-file
+		// intent. "use this uploaded file" with a broken attachment stays null.
+		!(ATTACHMENT_REFERENCE_RE.test(trimmed) && attachments?.length) &&
+		isUploadIntent(trimmed) &&
+		!firstImageAttachment(attachments)
+	) {
+		return { op: "navigate-upload" };
+	}
+
 	// Explicit options win over text parsing.
 	if (explicitImage)
 		return { op: "set", mode: "image", imageUrl: explicitImage };
@@ -407,10 +491,13 @@ export type BackgroundEmitter = (
 ) => Promise<void>;
 /** Generates a background image from a prompt; returns a served URL. */
 export type BackgroundImageGenerator = (prompt: string) => Promise<string>;
+/** Navigates the frontend to a view (the chat→background-view handoff). */
+export type BackgroundNavigator = (detail: NavigateViewDetail) => Promise<void>;
 
 export interface BackgroundActionDeps {
 	emit?: BackgroundEmitter;
 	generateImage?: BackgroundImageGenerator;
+	navigate?: BackgroundNavigator;
 }
 
 async function loopbackPort(): Promise<number> {
@@ -456,11 +543,51 @@ async function defaultGenerateImage(prompt: string): Promise<string> {
 	return data.url;
 }
 
+async function defaultNavigate(detail: NavigateViewDetail): Promise<void> {
+	const port = await loopbackPort();
+	// Drive the SAME shell navigate path the VIEWS action uses. When a concrete
+	// view id is supplied, POST to that view's own navigate route
+	// (`/api/views/<id>/navigate`) so the shell stamps the ACTUAL view as current
+	// (current-view state, view-switched events, action affinity all report the
+	// Background view, not the synthetic view-manager). Fall back to the
+	// view-manager path-navigate only when we have just a path. The generic
+	// view-event bus is NOT wired to navigation, so neither uses it. A 501/404
+	// means the host doesn't implement navigation (headless/test) — best-effort
+	// no-op, not a failure; any other non-2xx is a real error.
+	const base = `http://127.0.0.1:${port}`;
+	const { url, body } = detail.viewId
+		? {
+				url: `${base}/api/views/${encodeURIComponent(detail.viewId)}/navigate`,
+				// Carry the explicit path too: `background` is a built-in TAB, not a
+				// registered view, so without `path` the server broadcasts a null
+				// viewPath and the client falls back to `/apps/<id>` instead of the
+				// canonical `/background` route.
+				body: JSON.stringify({
+					...(detail.viewPath ? { path: detail.viewPath } : {}),
+					...(detail.viewType ? { viewType: detail.viewType } : {}),
+				}),
+			}
+		: {
+				url: `${base}/api/views/__view-manager__/navigate`,
+				body: JSON.stringify({ path: detail.viewPath ?? "/" }),
+			};
+	const resp = await fetch(url, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body,
+		signal: AbortSignal.timeout(5_000),
+	});
+	if (!resp.ok && resp.status !== 501 && resp.status !== 404) {
+		throw new Error(`navigate returned ${resp.status}`);
+	}
+}
+
 export function createBackgroundAction(
 	deps: BackgroundActionDeps = {},
 ): Action {
 	const emit = deps.emit ?? defaultEmit;
 	const generateImage = deps.generateImage ?? defaultGenerateImage;
+	const navigate = deps.navigate ?? defaultNavigate;
 
 	return {
 		name: "BACKGROUND",
@@ -589,6 +716,31 @@ export function createBackgroundAction(
 					const reply = "Reset the background to the default.";
 					await callback?.({ text: reply });
 					return { success: true, text: reply, values: { op: "reset" } };
+				}
+				if (plan.op === "navigate-upload") {
+					// No image to apply — take the user to the Background view, where
+					// upload/generate/gallery live (#13538 chat→background handoff).
+					await navigate({ viewId: "background", viewPath: "/background" });
+					const reply =
+						"Opening the Background view — you can upload or pick a wallpaper there.";
+					await callback?.({ text: reply });
+					return {
+						success: true,
+						text: reply,
+						values: { op: "navigate-upload", viewId: "background" },
+					};
+				}
+				if ("mode" in plan && plan.mode === "catalog") {
+					// Named curated-catalog entry. The renderer resolves catalogId →
+					// config (color / vetted image / named GLSL preset). #13538.
+					await emit({ op: "set", catalogId: plan.catalogId });
+					const reply = `Set the background to ${plan.catalogLabel}.`;
+					await callback?.({ text: reply });
+					return {
+						success: true,
+						text: reply,
+						values: { op: "set", mode: "catalog", catalogId: plan.catalogId },
+					};
 				}
 				if ("mode" in plan && plan.mode === "glsl") {
 					// Named programmable-shader preset. The renderer resolves the


### PR DESCRIPTION
Closes #13538. Part of the chat-redesign epic #13539.

## What

Curated background catalog with per-entry **metadata** (name, description, mood, palette, tags) as the **single source of truth** shared by the gallery picker AND the agent — extending the existing preset/apply/broker architecture with **no second mutation path**.

| Ask (#13538) | Delivered |
|---|---|
| Nice natural default, not a flat color | Boot default = curated **"Ember Night"** gradient (code-free SVG data URL, paints instantly) |
| Gallery of curated backgrounds | 5 natural gradients + 5 GLSL presets as selectable tiles in `BackgroundSettingsControls` (palette thumbnails, agent-addressable) |
| Metadata + context per background | `BackgroundCatalogEntry` / shared `BackgroundCatalogMeta` (id/label/description/kind/mood/palette/tags/prompt/author) |
| Agent can switch by name | `background:apply` gains `catalogId`; agent selects `"use the misty-forest background"` |
| Agent can add to catalog | Generated/uploaded backgrounds land in a persisted **user catalog**, re-selectable |
| Chat → background-view handoff | "I want to upload a background" routes to `/background` |

## Architecture / security (respected)

- **Single broker, no raw GLSL source**: `catalogId` names an entry; the **renderer** resolves it to a color / vetted image URL / named GLSL preset. A `catalogId` can never smuggle GLSL source or an arbitrary URL past the broker (#11088). **Unknown names are ignored** — never wedge the background (#13523 confinement).
- **No bundled binaries**: natural backgrounds are code-free SVG-gradient data URLs (< 1 KB each). Shared metadata index (`@elizaos/shared/backgrounds/catalog-index`) carries **no render source**.
- **Quota-safe user catalog**: persists only re-hosted `/api/media/<hash>` URLs (inline data URLs rejected — same hazard `normalizeBackgroundHistory` caps).
- **Precedence**: explicit generate and attached images win over a same-named catalog entry; generic color/tag words (`green`/`blue`/`warm`) resolve to a **color**, not a curated image.

## Tests

- Catalog resolution + metadata (ui `background-catalog.test.ts`, shared `catalog-index.test.ts`)
- Name-select validation: unknown / tag / color-word ignored
- Broker confinement: `catalogId` cannot inject GLSL source or a URL (extends `useBackgroundApplyChannel.test.tsx`)
- User-catalog data-URL rejection + cap (`user-background-catalog.test.ts`)
- Action: name-select, upload handoff, described-image → generate, attachment/generate precedence, color-vs-upload scoping (`background.test.ts`)
- **The #13523 mutation-isolation suite stays green** (regression harness).
- `tsgo` + `biome` clean across `shared`, `ui`, `plugin-app-control`.

## Isolation-suite proof

```
App view-surface mutation isolation — rogue view cannot leak global state (#13452)
  ✓ a background:apply fired from an opaque view NEVER paints the shared wallpaper on that route
  ✓ the shell-owned safe-area floor + opaque underlay survive a hostile apply storm
  ✓ the broker sanitizes raw GLSL source + unknown presets
  ✓ navigating opaque → shared after a rogue apply shows ONLY the persisted wallpaper
  → 4 passed (the 5 full-view-walk fuzz tests were filtered: they OOM the 4GB CI VPS by design, not a logic change)
```

Signed — [sol-orch]
