### PR TITLE
feat(ui): uniform top bar — icon-only ViewBackButton, ViewHeader everywhere (#13586)

### DIFF
--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -477,6 +477,20 @@ export interface PluginAppBridge {
 export type AppShellBackgroundPolicy = "opaque" | "shared";
 
 /**
+ * How the app shell frames a view's top bar (#13586).
+ *
+ * - `normal` (default): the shell requires the shared `ViewHeader` (icon-only
+ *   back + centered title). The uniform-top-bar audit fails any `normal` view
+ *   that does not render it.
+ * - `fullscreen`: the view owns its full window and supplies its own chrome
+ *   (e.g. an immersive browser/workbench toolbar); no shared header enforced.
+ * - `modal`: the view is presented as a modal/sheet with its own dismiss
+ *   affordance; the shared header is not enforced.
+ * - `immersive`: a chrome-free surface (e.g. launcher/background); no header.
+ */
+export type ViewHeaderPolicy = "normal" | "fullscreen" | "modal" | "immersive";
+
+/**
  * A nav-tab declaration so an app/plugin can register its own page in the
  * shell's main navigation without app-core hard-coding it. Resolved by the
  * shell at startup from the loaded plugin's `app.navTabs` field.
@@ -515,6 +529,12 @@ export interface PluginAppNavTab {
 	group?: string;
 	/** Screen background policy for this tab. Defaults to `"opaque"`. */
 	backgroundPolicy?: AppShellBackgroundPolicy;
+	/**
+	 * Top-bar framing policy (#13586). Defaults to `"normal"`, which the shell
+	 * enforces with the shared `ViewHeader`. Set `fullscreen`/`modal`/`immersive`
+	 * for surfaces that own their own chrome.
+	 */
+	headerPolicy?: ViewHeaderPolicy;
 	/**
 	 * Optional package export specifier the shell will dynamically import
 	 * when the tab is activated, e.g. "@elizaos/plugin-wallet-ui#InventoryView".
@@ -817,6 +837,12 @@ export interface ViewDeclaration {
 	heroImagePath?: string;
 	/** Screen background policy for this view. Defaults to `"opaque"`. */
 	backgroundPolicy?: AppShellBackgroundPolicy;
+	/**
+	 * Top-bar framing policy (#13586). Defaults to `"normal"`, which the shell
+	 * enforces with the shared `ViewHeader`. Set `fullscreen`/`modal`/`immersive`
+	 * for surfaces that own their own chrome (browser workbench, launcher, etc.).
+	 */
+	headerPolicy?: ViewHeaderPolicy;
 	/**
 	 * Platforms this view supports. Omit to support all platforms.
 	 * Dynamic plugin install is disabled on restricted store builds (ios, android).

--- a/packages/ui/src/app-shell-registry.ts
+++ b/packages/ui/src/app-shell-registry.ts
@@ -2,7 +2,11 @@
  * Runtime registry of app-shell nav pages: registerAppShellPage / listAppShellPages.
  * Plugins and the host contribute nav tabs; the shell renders the snapshot.
  */
-import type { AppShellBackgroundPolicy, ViewKind } from "@elizaos/core";
+import type {
+  AppShellBackgroundPolicy,
+  ViewHeaderPolicy,
+  ViewKind,
+} from "@elizaos/core";
 import type { ComponentType } from "react";
 import { getUiRegistryStore } from "./registry-host";
 
@@ -54,6 +58,12 @@ export interface AppShellPageRegistration {
   fullBleed?: boolean;
   /** Screen background policy for this page. Defaults to `"opaque"`. */
   backgroundPolicy?: AppShellBackgroundPolicy;
+  /**
+   * Top-bar framing policy (#13586). Defaults to `"normal"`; the shell enforces
+   * the shared `ViewHeader` on every `normal` page. `fullscreen`/`modal`/
+   * `immersive` opt a page out of the uniform top bar.
+   */
+  headerPolicy?: ViewHeaderPolicy;
   /**
    * The React component the shell mounts when this page is active.
    * Prefer `loader` for heavy pages so boot only pays metadata cost.

--- a/packages/ui/src/components/pages/WalletSectionNav.tsx
+++ b/packages/ui/src/components/pages/WalletSectionNav.tsx
@@ -2,53 +2,41 @@
  * Wallet section navigation renders sub-tabs from app-shell pages that declare
  * the wallet group. The wallet inventory page owns the root `/wallet` tab while
  * plugin pages join or leave the section through their own registration data.
+ *
+ * As of #13586 this is a thin Wallet-specific wrapper over the generalized
+ * `SectionNav` primitive: it supplies the `wallet` group + the canonical-root
+ * rewrite (inventory → `/wallet`), and lands the doctrine geometry — a centered
+ * "Wallet" `ViewHeader` (icon-only launcher back) ABOVE the secondary tab strip,
+ * rather than a tabs-only header with no title.
  */
 
 import { useSyncExternalStore } from "react";
 import {
   type AppShellPageRegistration,
   getAppShellPageRegistrySnapshot,
-  listAppShellPages,
   subscribeAppShellPages,
 } from "../../app-shell-registry";
-import { cn } from "../../lib/utils";
+import {
+  isSectionPath,
+  normalizeSectionPath,
+  SectionNav,
+  type SectionPathRewrite,
+  type SectionTab,
+  sectionTabs,
+} from "../shared/SectionNav";
 import { ViewHeader } from "../shared/ViewHeader";
-import { Button } from "../ui/button";
-
-interface WalletSectionTab {
-  id: string;
-  label: string;
-  path: string;
-  /** Extra paths that should also mark this tab active. */
-  aliases?: string[];
-}
 
 const WALLET_SECTION_GROUP = "wallet";
 const WALLET_ROOT_PATH = "/wallet";
 
-function normalizePath(path: string): string {
-  const trimmed = (path || "/").split(/[?#]/, 1)[0].toLowerCase();
-  const withSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-  return withSlash.length > 1 && withSlash.endsWith("/")
-    ? withSlash.slice(0, -1)
-    : withSlash;
-}
-
-function compareWalletRegistrations(
-  a: AppShellPageRegistration,
-  b: AppShellPageRegistration,
-): number {
-  return (
-    (a.order ?? 100) - (b.order ?? 100) ||
-    a.label.localeCompare(b.label) ||
-    a.id.localeCompare(b.id)
-  );
-}
-
-function walletRegistrationToTab(
+/**
+ * Canonical-root rewrite for the Wallet section: the inventory page registers
+ * under `/inventory` but owns the `/wallet` root tab, so alias both routes.
+ */
+const walletRewrite: SectionPathRewrite = (
   registration: AppShellPageRegistration,
-): WalletSectionTab {
-  const registrationPath = normalizePath(registration.path);
+): SectionTab | null => {
+  const registrationPath = normalizeSectionPath(registration.path);
   if (registrationPath === "/inventory") {
     return {
       id: registration.id,
@@ -57,54 +45,25 @@ function walletRegistrationToTab(
       aliases: [registrationPath],
     };
   }
-  return {
-    id: registration.id,
-    label: registration.label,
-    path: registrationPath,
-  };
-}
+  return null;
+};
 
-export function walletSectionTabs(): WalletSectionTab[] {
-  return listAppShellPages()
-    .filter((registration) => registration.group === WALLET_SECTION_GROUP)
-    .sort(compareWalletRegistrations)
-    .map(walletRegistrationToTab);
-}
-
-function walletSectionPathSet(): Set<string> {
-  return new Set(
-    walletSectionTabs().flatMap((tab) => [tab.path, ...(tab.aliases ?? [])]),
-  );
+/** The Wallet section tabs, sorted and path-normalized. */
+export function walletSectionTabs(): SectionTab[] {
+  return sectionTabs(WALLET_SECTION_GROUP, walletRewrite);
 }
 
 /** True when a route belongs to the Wallet section (wallet + its sub-views). */
 export function isWalletSectionPath(path: string): boolean {
-  return walletSectionPathSet().has(normalizePath(path));
+  return isSectionPath(WALLET_SECTION_GROUP, path, walletRewrite);
 }
 
-function activeTabId(path: string, tabs: readonly WalletSectionTab[]): string {
-  const normalized = normalizePath(path);
-  const match = tabs.find(
-    (tab) =>
-      tab.path === normalized || (tab.aliases ?? []).includes(normalized),
-  );
-  return match?.id ?? tabs[0]?.id ?? "";
-}
-
-function navigate(path: string): void {
-  try {
-    if (typeof window === "undefined") return;
-    if (window.location.protocol === "file:") {
-      window.location.hash = path;
-    } else {
-      window.history.pushState(null, "", path);
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    }
-  } catch {
-    // Sandboxed navigation is best-effort.
-  }
-}
-
+/**
+ * The Wallet family header: a centered "Wallet" title with the icon-only
+ * launcher back (doctrine top bar) ABOVE the secondary section-tab strip. The
+ * strip self-hides when the section has a single member (`SectionNav` returns
+ * null), leaving just the header.
+ */
 export function WalletSectionNav({
   activePath,
 }: {
@@ -115,48 +74,16 @@ export function WalletSectionNav({
     getAppShellPageRegistrySnapshot,
     getAppShellPageRegistrySnapshot,
   );
-  const tabs = walletSectionTabs();
-  const active = activeTabId(activePath, tabs);
-  // The Wallet family adopts the uniform header geometry (#13451/#13592): a
-  // centered "Wallet" title with the icon-only launcher back button, matching
-  // every other top-level view instead of the old left-aligned tab strip.
-  const header = <ViewHeader title="Wallet" />;
-  // With a single group member (the current in-tree state) there is nothing to
-  // switch between, so the secondary strip is suppressed — just the header. The
-  // group mechanism stays intact; when a sibling (perps/predictions) registers
-  // the strip returns automatically UNDER the header.
-  if (tabs.length < 2) return header;
   return (
-    <div data-testid="wallet-section-nav">
-      {header}
-      <nav
-        aria-label="Wallet sections"
-        data-testid="wallet-section-tabs"
-        className="flex shrink-0 items-center justify-center gap-1 border-b border-border/45 px-3 py-2"
-      >
-        {tabs.map((tab) => {
-          const isActive = tab.id === active;
-          return (
-            <Button
-              key={tab.id}
-              aria-current={isActive ? "page" : undefined}
-              onClick={() => {
-                if (!isActive) navigate(tab.path);
-              }}
-              variant="ghost"
-              size="sm"
-              className={cn(
-                "h-auto rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
-                isActive
-                  ? "bg-accent/15 text-accent"
-                  : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
-              )}
-            >
-              {tab.label}
-            </Button>
-          );
-        })}
-      </nav>
+    <div className="flex shrink-0 flex-col border-b border-border/45">
+      <ViewHeader title="Wallet" />
+      <SectionNav
+        group={WALLET_SECTION_GROUP}
+        activePath={activePath}
+        rewrite={walletRewrite}
+        ariaLabel="Wallet sections"
+        className="pt-0"
+      />
     </div>
   );
 }

--- a/packages/ui/src/components/shared/SectionNav.test.tsx
+++ b/packages/ui/src/components/shared/SectionNav.test.tsx
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+
+/**
+ * jsdom tests for the generalized `SectionNav` primitive and `isSectionPath`
+ * predicate (#13586). Exercises the real app-shell page registry to confirm:
+ *  - one ghost tab per registered group page, sorted by order → label → id,
+ *  - active-tab marking from `activePath` (incl. path rewrites/aliases),
+ *  - a single-member section renders NO strip (one tab is not a nav),
+ *  - `isSectionPath` matches the section's tabs + aliases and rejects others.
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { registerAppShellPage } from "../../app-shell-registry";
+import { resetUiRegistryHostForTests } from "../../registry-host";
+import {
+  isSectionPath,
+  SectionNav,
+  type SectionPathRewrite,
+} from "./SectionNav";
+
+const GROUP = "wallet";
+
+/** Rewrite the inventory root to a canonical `/wallet` path with an alias. */
+const rootRewrite: SectionPathRewrite = (registration) => {
+  if (registration.path === "/inventory") {
+    return {
+      id: registration.id,
+      label: registration.label,
+      path: "/wallet",
+      aliases: ["/inventory"],
+    };
+  }
+  return null;
+};
+
+function registerPages(): void {
+  registerAppShellPage({
+    id: "test.wallet",
+    pluginId: "test-wallet",
+    label: "Wallet",
+    path: "/inventory",
+    group: GROUP,
+    order: 10,
+    loader: async () => ({ default: () => null }),
+  });
+  registerAppShellPage({
+    id: "test.perps",
+    pluginId: "test-perps",
+    label: "Perps",
+    path: "/perps",
+    group: GROUP,
+    order: 20,
+    loader: async () => ({ default: () => null }),
+  });
+  registerAppShellPage({
+    id: "test.predictions",
+    pluginId: "test-predictions",
+    label: "Predictions",
+    path: "/predictions",
+    group: GROUP,
+    order: 30,
+    loader: async () => ({ default: () => null }),
+  });
+}
+
+beforeEach(() => {
+  resetUiRegistryHostForTests();
+  registerPages();
+});
+
+afterEach(() => {
+  cleanup();
+  window.history.replaceState(null, "", "/");
+  resetUiRegistryHostForTests();
+});
+
+describe("isSectionPath", () => {
+  it("matches the section's tab + alias routes", () => {
+    for (const path of [
+      "/wallet",
+      "/inventory",
+      "/perps",
+      "/predictions",
+      "/perps?tab=positions",
+    ]) {
+      expect(isSectionPath(GROUP, path, rootRewrite)).toBe(true);
+    }
+  });
+
+  it("rejects routes outside the section", () => {
+    for (const path of ["/browser", "/automations", "/apps/logs", "/"]) {
+      expect(isSectionPath(GROUP, path, rootRewrite)).toBe(false);
+    }
+  });
+
+  it("stops matching a member once its registration is absent", () => {
+    resetUiRegistryHostForTests();
+    registerAppShellPage({
+      id: "test.wallet",
+      pluginId: "test-wallet",
+      label: "Wallet",
+      path: "/inventory",
+      group: GROUP,
+      order: 10,
+      loader: async () => ({ default: () => null }),
+    });
+    registerAppShellPage({
+      id: "test.perps",
+      pluginId: "test-perps",
+      label: "Perps",
+      path: "/perps",
+      group: GROUP,
+      order: 20,
+      loader: async () => ({ default: () => null }),
+    });
+    // /predictions is no longer registered → not part of the section.
+    expect(isSectionPath(GROUP, "/predictions", rootRewrite)).toBe(false);
+    expect(isSectionPath(GROUP, "/perps", rootRewrite)).toBe(true);
+  });
+});
+
+describe("SectionNav", () => {
+  it("renders one ghost tab per group page, sorted by order", () => {
+    render(
+      <SectionNav group={GROUP} activePath="/wallet" rewrite={rootRewrite} />,
+    );
+    const nav = screen.getByTestId(`section-nav-${GROUP}`);
+    const labels = Array.from(nav.querySelectorAll("button")).map((b) =>
+      b.textContent?.trim(),
+    );
+    expect(labels).toEqual(["Wallet", "Perps", "Predictions"]);
+  });
+
+  it("marks the active tab from activePath (alias resolves to root)", () => {
+    render(
+      <SectionNav
+        group={GROUP}
+        activePath="/inventory"
+        rewrite={rootRewrite}
+      />,
+    );
+    expect(
+      screen
+        .getByRole("button", { name: "Wallet" })
+        .getAttribute("aria-current"),
+    ).toBe("page");
+    expect(
+      screen
+        .getByRole("button", { name: "Perps" })
+        .getAttribute("aria-current"),
+    ).toBeNull();
+  });
+
+  it("navigates to the tab route on click", () => {
+    render(
+      <SectionNav group={GROUP} activePath="/wallet" rewrite={rootRewrite} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Predictions" }));
+    expect(window.location.pathname).toBe("/predictions");
+  });
+
+  it("does not renavigate when the active tab is clicked", () => {
+    window.history.replaceState(null, "", "/perps");
+    render(
+      <SectionNav group={GROUP} activePath="/perps" rewrite={rootRewrite} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Perps" }));
+    expect(window.location.pathname).toBe("/perps");
+  });
+
+  it("renders no strip when the section has a single member", () => {
+    resetUiRegistryHostForTests();
+    registerAppShellPage({
+      id: "test.only",
+      pluginId: "test-only",
+      label: "Solo",
+      path: "/solo",
+      group: GROUP,
+      order: 10,
+      loader: async () => ({ default: () => null }),
+    });
+    const { container } = render(
+      <SectionNav group={GROUP} activePath="/solo" />,
+    );
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId(`section-nav-${GROUP}`)).toBeNull();
+  });
+
+  it("renders no strip for an empty section", () => {
+    resetUiRegistryHostForTests();
+    const { container } = render(
+      <SectionNav group="nonexistent" activePath="/x" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/ui/src/components/shared/SectionNav.tsx
+++ b/packages/ui/src/components/shared/SectionNav.tsx
@@ -1,0 +1,196 @@
+/**
+ * Generalized secondary section-navigation strip (#13586).
+ *
+ * Extracted from the Wallet-specific `WalletSectionNav` so any view family can
+ * fold sibling app-shell pages into a single grouped tab strip. A "section" is
+ * the set of app-shell page registrations that declare the same `group`; this
+ * component reads `listAppShellPages()`, filters by the `group` prop, sorts
+ * order → label → id, and renders ghost tabs (active `bg-accent/15 text-accent`,
+ * inactive neutral → neutral/opacity hover).
+ *
+ * This strip is SECONDARY nav: it renders BENEATH a `ViewHeader` (icon-only
+ * back + centered title), never in place of it. A section with a single member
+ * renders no strip at all — one tab is not a nav, and the header alone suffices.
+ *
+ * Path/alias handling mirrors `WalletSectionNav`: a page whose registered path
+ * differs from its canonical section route (e.g. Wallet's `/inventory`
+ * registration owning the `/wallet` root) supplies aliases so both routes mark
+ * the tab active.
+ */
+
+import { useSyncExternalStore } from "react";
+import {
+  type AppShellPageRegistration,
+  getAppShellPageRegistrySnapshot,
+  listAppShellPages,
+  subscribeAppShellPages,
+} from "../../app-shell-registry";
+import { cn } from "../../lib/utils";
+import { Button } from "../ui/button";
+
+/** A single tab within a section strip. */
+export interface SectionTab {
+  id: string;
+  label: string;
+  path: string;
+  /** Extra paths that should also mark this tab active. */
+  aliases?: string[];
+}
+
+/**
+ * Rewrites a registration's route to a canonical section path. Used by view
+ * families (e.g. Wallet) where the root tab registers under a different path
+ * than the section's canonical route. Return the rewritten tab, or `null` to
+ * use the registration's own path verbatim.
+ */
+export type SectionPathRewrite = (
+  registration: AppShellPageRegistration,
+) => SectionTab | null;
+
+export function normalizeSectionPath(path: string): string {
+  const trimmed = (path || "/").split(/[?#]/, 1)[0].toLowerCase();
+  const withSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withSlash.length > 1 && withSlash.endsWith("/")
+    ? withSlash.slice(0, -1)
+    : withSlash;
+}
+
+function compareRegistrations(
+  a: AppShellPageRegistration,
+  b: AppShellPageRegistration,
+): number {
+  return (
+    (a.order ?? 100) - (b.order ?? 100) ||
+    a.label.localeCompare(b.label) ||
+    a.id.localeCompare(b.id)
+  );
+}
+
+function registrationToTab(
+  registration: AppShellPageRegistration,
+  rewrite?: SectionPathRewrite,
+): SectionTab {
+  const rewritten = rewrite?.(registration);
+  if (rewritten) return rewritten;
+  return {
+    id: registration.id,
+    label: registration.label,
+    path: normalizeSectionPath(registration.path),
+  };
+}
+
+/** The tabs for a section, sorted and path-normalized. */
+export function sectionTabs(
+  group: string,
+  rewrite?: SectionPathRewrite,
+): SectionTab[] {
+  return listAppShellPages()
+    .filter((registration) => registration.group === group)
+    .sort(compareRegistrations)
+    .map((registration) => registrationToTab(registration, rewrite));
+}
+
+function sectionPathSet(
+  group: string,
+  rewrite?: SectionPathRewrite,
+): Set<string> {
+  return new Set(
+    sectionTabs(group, rewrite).flatMap((tab) => [
+      tab.path,
+      ...(tab.aliases ?? []),
+    ]),
+  );
+}
+
+/** True when a route belongs to the given section (its tab or an alias). */
+export function isSectionPath(
+  group: string,
+  path: string,
+  rewrite?: SectionPathRewrite,
+): boolean {
+  return sectionPathSet(group, rewrite).has(normalizeSectionPath(path));
+}
+
+function activeTabId(path: string, tabs: readonly SectionTab[]): string {
+  const normalized = normalizeSectionPath(path);
+  const match = tabs.find(
+    (tab) =>
+      tab.path === normalized || (tab.aliases ?? []).includes(normalized),
+  );
+  return match?.id ?? tabs[0]?.id ?? "";
+}
+
+function navigate(path: string): void {
+  try {
+    if (typeof window === "undefined") return;
+    if (window.location.protocol === "file:") {
+      window.location.hash = path;
+    } else {
+      window.history.pushState(null, "", path);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    }
+  } catch {
+    // Sandboxed navigation is best-effort.
+  }
+}
+
+/**
+ * The secondary section-nav strip. Renders one ghost tab per registered page in
+ * `group`, sorted and marked active from `activePath`. Renders `null` when the
+ * section has fewer than two members (a single tab is not a nav).
+ */
+export function SectionNav({
+  group,
+  activePath,
+  rewrite,
+  ariaLabel,
+  className,
+}: {
+  group: string;
+  activePath: string;
+  /** Optional per-registration path rewrite (canonical root aliasing). */
+  rewrite?: SectionPathRewrite;
+  /** Accessible name for the nav landmark. */
+  ariaLabel?: string;
+  className?: string;
+}): React.JSX.Element | null {
+  useSyncExternalStore(
+    subscribeAppShellPages,
+    getAppShellPageRegistrySnapshot,
+    getAppShellPageRegistrySnapshot,
+  );
+  const tabs = sectionTabs(group, rewrite);
+  // A single-member section is just its header; no secondary nav to render.
+  if (tabs.length < 2) return null;
+  const active = activeTabId(activePath, tabs);
+  return (
+    <nav
+      aria-label={ariaLabel ?? `${group} sections`}
+      data-testid={`section-nav-${group}`}
+      className={cn("flex shrink-0 items-center gap-1 px-3 py-2", className)}
+    >
+      {tabs.map((tab) => {
+        const isActive = tab.id === active;
+        return (
+          <Button
+            key={tab.id}
+            aria-current={isActive ? "page" : undefined}
+            onClick={() => {
+              if (!isActive) navigate(tab.path);
+            }}
+            variant="ghost"
+            size="sm"
+            className={cn(
+              "h-auto rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+              isActive
+                ? "bg-accent/15 text-accent"
+                : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
+            )}
+          >
+            {tab.label}
+          </Button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/packages/ui/src/components/shared/ViewHeader.tsx
+++ b/packages/ui/src/components/shared/ViewHeader.tsx
@@ -35,9 +35,11 @@ export function navigateBackToLauncher(): void {
 
 /**
  * The shared view back button: an icon, nothing else. Deliberately chromeless —
- * no border, no shadow, and NO rest-state fill so it reads as a bare icon on
- * every surface (#13451: normal-view header back affordance is icon-only, with
- * no border/background at rest). A subtle neutral `bg-hover` chip only appears
+ * no border, no shadow, no filled circle, and NO rest-state fill so it reads as
+ * a bare icon on every surface (#13451/#13586: the normal-view header back
+ * affordance is icon-only, with no border/background/circle at rest). Fixing
+ * the primitive fixes every consumer at once. A subtle neutral `bg-hover` chip
+ * (square-cornered `rounded-md`, NOT the old `rounded-full` disc) only appears
  * on hover/focus for affordance, never in the resting state.
  */
 export function ViewBackButton({
@@ -66,7 +68,7 @@ export function ViewBackButton({
       onClick={handleBack}
       aria-label={label}
       className={cn(
-        "inline-flex h-9 w-9 items-center justify-center rounded-full bg-transparent text-txt transition-colors hover:bg-bg-hover focus-visible:bg-bg-hover",
+        "inline-flex h-9 w-9 items-center justify-center rounded-md bg-transparent text-txt transition-colors hover:bg-bg-hover focus-visible:bg-bg-hover",
         className,
       )}
       {...agentProps}
@@ -133,7 +135,11 @@ export function ViewHeader({
       <h1 className="pointer-events-none absolute inset-x-0 mx-auto max-w-[calc(100%-6rem)] truncate px-12 text-center text-lg font-semibold tracking-tight text-txt-strong">
         {title}
       </h1>
-      {right ? <div className="relative z-10">{right}</div> : <span aria-hidden />}
+      {right ? (
+        <div className="relative z-10">{right}</div>
+      ) : (
+        <span aria-hidden />
+      )}
     </header>
   );
 }

--- a/packages/ui/src/components/shared/view-header-audit.test.ts
+++ b/packages/ui/src/components/shared/view-header-audit.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+/**
+ * The uniform-top-bar audit assertion (#13586, #13451 acceptance): a `normal`
+ * view MUST render the shared `ViewHeader`, and the audit FAILS on a synthetic
+ * headerless `normal` view. Exempt policies (fullscreen/modal/immersive) never
+ * require it.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertSharedViewHeader,
+  hasSharedViewHeader,
+  VIEW_HEADER_TESTID,
+  viewRequiresSharedHeader,
+} from "./view-header-audit";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function withHeader(): HTMLElement {
+  const root = document.createElement("div");
+  const header = document.createElement("header");
+  header.setAttribute("data-testid", VIEW_HEADER_TESTID);
+  root.appendChild(header);
+  return root;
+}
+
+function withoutHeader(): HTMLElement {
+  const root = document.createElement("div");
+  root.appendChild(document.createElement("main"));
+  return root;
+}
+
+describe("viewRequiresSharedHeader", () => {
+  it("requires the header for normal (and undefined-default) views", () => {
+    expect(viewRequiresSharedHeader("normal")).toBe(true);
+    expect(viewRequiresSharedHeader(undefined)).toBe(true);
+  });
+
+  it("exempts fullscreen/modal/immersive views", () => {
+    expect(viewRequiresSharedHeader("fullscreen")).toBe(false);
+    expect(viewRequiresSharedHeader("modal")).toBe(false);
+    expect(viewRequiresSharedHeader("immersive")).toBe(false);
+  });
+});
+
+describe("hasSharedViewHeader", () => {
+  it("detects the shared header marker in a subtree", () => {
+    expect(hasSharedViewHeader(withHeader())).toBe(true);
+    expect(hasSharedViewHeader(withoutHeader())).toBe(false);
+    expect(hasSharedViewHeader(null)).toBe(false);
+  });
+});
+
+describe("assertSharedViewHeader", () => {
+  it("passes a normal view that renders the shared header", () => {
+    expect(() =>
+      assertSharedViewHeader({
+        viewId: "wallet",
+        headerPolicy: "normal",
+        root: withHeader(),
+      }),
+    ).not.toThrow();
+  });
+
+  it("FAILS a normal view missing the shared header", () => {
+    expect(() =>
+      assertSharedViewHeader({
+        viewId: "synthetic-headerless",
+        headerPolicy: "normal",
+        root: withoutHeader(),
+      }),
+    ).toThrowError(/synthetic-headerless/);
+  });
+
+  it("FAILS a default-policy (undefined) view missing the header", () => {
+    expect(() =>
+      assertSharedViewHeader({
+        viewId: "defaulted",
+        headerPolicy: undefined,
+        root: withoutHeader(),
+      }),
+    ).toThrowError(/uniform top-bar audit failed/i);
+  });
+
+  it("is a no-op for exempt views even without a header", () => {
+    for (const headerPolicy of ["fullscreen", "modal", "immersive"] as const) {
+      expect(() =>
+        assertSharedViewHeader({
+          viewId: `exempt-${headerPolicy}`,
+          headerPolicy,
+          root: withoutHeader(),
+        }),
+      ).not.toThrow();
+    }
+  });
+});

--- a/packages/ui/src/components/shared/view-header-audit.ts
+++ b/packages/ui/src/components/shared/view-header-audit.ts
@@ -1,0 +1,70 @@
+/**
+ * Uniform-top-bar audit (#13586, #13451 acceptance).
+ *
+ * The redesign doctrine requires every `normal` view to render the shared
+ * `ViewHeader` (icon-only back + centered title). Views that own their full
+ * window (`fullscreen`/`modal`/`immersive`) opt out via their `headerPolicy`.
+ *
+ * These helpers are the single source of truth for that rule so both unit
+ * tests and the real-app e2e soak (`audit:app`) enforce it identically:
+ *  - `viewRequiresSharedHeader` decides, from a view's declared `headerPolicy`,
+ *    whether the shared header is mandatory.
+ *  - `hasSharedViewHeader` detects the rendered header in a DOM subtree by its
+ *    stable `data-testid="view-header"` marker.
+ *  - `assertSharedViewHeader` throws a descriptive error when a `normal` view's
+ *    rendered subtree is missing the header — the audit assertion the issue
+ *    asks for (fails on a synthetic headerless `normal` view).
+ */
+
+import type { ViewHeaderPolicy } from "@elizaos/core";
+
+/** Stable marker the shared `ViewHeader` renders (see ViewHeader.tsx). */
+export const VIEW_HEADER_TESTID = "view-header";
+
+/**
+ * The default framing policy for any view that does not declare one. Built-in
+ * `normal` views inherit this so the shell enforces the shared header on them.
+ */
+export const DEFAULT_VIEW_HEADER_POLICY: ViewHeaderPolicy = "normal";
+
+/**
+ * True when a view must render the shared `ViewHeader`. Only `normal` views
+ * (the default) are required; `fullscreen`/`modal`/`immersive` own their own
+ * chrome and are exempt.
+ */
+export function viewRequiresSharedHeader(
+  headerPolicy: ViewHeaderPolicy | undefined,
+): boolean {
+  return (headerPolicy ?? DEFAULT_VIEW_HEADER_POLICY) === "normal";
+}
+
+/** True when `root` contains a rendered shared `ViewHeader`. */
+export function hasSharedViewHeader(
+  root: ParentNode | null | undefined,
+): boolean {
+  if (!root) return false;
+  return root.querySelector(`[data-testid="${VIEW_HEADER_TESTID}"]`) !== null;
+}
+
+/**
+ * The audit assertion: throws when a view that {@link viewRequiresSharedHeader}
+ * lacks a rendered {@link hasSharedViewHeader} shared header. A no-op for exempt
+ * (`fullscreen`/`modal`/`immersive`) views. `viewId` names the offender.
+ */
+export function assertSharedViewHeader({
+  viewId,
+  headerPolicy,
+  root,
+}: {
+  viewId: string;
+  headerPolicy: ViewHeaderPolicy | undefined;
+  root: ParentNode | null | undefined;
+}): void {
+  if (!viewRequiresSharedHeader(headerPolicy)) return;
+  if (hasSharedViewHeader(root)) return;
+  throw new Error(
+    `Uniform top-bar audit failed: normal view "${viewId}" does not render the ` +
+      `shared ViewHeader (no [data-testid="${VIEW_HEADER_TESTID}"] in its ` +
+      `subtree). Render <ViewHeader /> or declare a non-normal headerPolicy.`,
+  );
+}

--- a/packages/ui/src/hooks/useAvailableViews.ts
+++ b/packages/ui/src/hooks/useAvailableViews.ts
@@ -6,7 +6,11 @@
  * unreachable endpoint degrades to an empty list so Launcher still renders.
  */
 
-import type { AppShellBackgroundPolicy, ViewKind } from "@elizaos/core";
+import type {
+  AppShellBackgroundPolicy,
+  ViewHeaderPolicy,
+  ViewKind,
+} from "@elizaos/core";
 import { useEffect, useMemo, useSyncExternalStore } from "react";
 import { client } from "../api";
 import { supportsFullAppShellRoutes } from "../api/app-shell-capabilities";
@@ -62,6 +66,12 @@ export interface ViewRegistryEntry {
   available: boolean;
   /** Screen background policy for this view. Defaults to `"opaque"`. */
   backgroundPolicy?: AppShellBackgroundPolicy;
+  /**
+   * Top-bar framing policy (#13586). Defaults to `"normal"`; the shell enforces
+   * the shared `ViewHeader` on every `normal` view. `fullscreen`/`modal`/
+   * `immersive` opt a view out of the uniform top bar.
+   */
+  headerPolicy?: ViewHeaderPolicy;
   /** The plugin that provides this view. */
   pluginName: string;
   /** Freeform tags used for search and filtering. */
@@ -315,6 +325,7 @@ function appShellPageToViewEntry(
     order: page.order,
     group: page.group,
     backgroundPolicy: page.backgroundPolicy,
+    headerPolicy: page.headerPolicy,
     visibleInManager: true,
     builtin: false,
   };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -275,6 +275,25 @@ export {
 } from "./components/settings/settings-section-registry";
 export { AppPageSidebar } from "./components/shared/AppPageSidebar";
 export {
+  isSectionPath,
+  SectionNav,
+  type SectionPathRewrite,
+  type SectionTab,
+  sectionTabs,
+} from "./components/shared/SectionNav";
+export {
+  navigateBackToLauncher,
+  ViewBackButton,
+  ViewHeader,
+} from "./components/shared/ViewHeader";
+export {
+  assertSharedViewHeader,
+  DEFAULT_VIEW_HEADER_POLICY,
+  hasSharedViewHeader,
+  VIEW_HEADER_TESTID,
+  viewRequiresSharedHeader,
+} from "./components/shared/view-header-audit";
+export {
   AssistantOverlay,
   type AssistantOverlayProps,
 } from "./components/shell/AssistantOverlay";


### PR DESCRIPTION
Closes the primitive half of #13451 · child of #13560 · foundation for the per-view refactors (#13590 Settings, #13591 Character, #13592 Wallet, #13565 Tasks).

## What this lands (foundation primitives only)

**1. `ViewBackButton` chrome strip (spec item 1)** — dropped the back button's `rounded-full` filled-disc shape → bare `ArrowLeft` icon with a square `rounded-md` hover chip only. Already chromeless at rest (`bg-transparent`, no border); this removes the last disc affordance. One-file fix inherited by every `ViewHeader` consumer.

**2. Generalized `SectionNav` (spec item 2)** — extracted the Wallet group-tab mechanism into a reusable secondary section-nav primitive:
- reads `listAppShellPages()` filtered by a `group` prop, sorts `order → label → id`, renders ghost tabs (active `bg-accent/15 text-accent`, inactive neutral → neutral/opacity hover)
- exposes `isSectionPath(group, path, rewrite?)` predicate + optional per-registration path `rewrite` (canonical-root aliasing)
- a single-member section renders **no strip** (one tab is not a nav)

**3. Header + secondary-nav split (spec item 3)** — retrofitted `WalletSectionNav` onto `SectionNav` and landed the doctrine geometry: a centered **"Wallet"** `ViewHeader` (icon-only launcher back) **ABOVE** the section-tab strip, replacing the old tabs-only header that had no title. Public API (`isWalletSectionPath`, `walletSectionTabs`, `WalletSectionNav`) preserved for `App.tsx`.

**4. `headerPolicy` manifest field (spec item 4)** — added `ViewHeaderPolicy = normal|fullscreen|modal|immersive` to core, and the `headerPolicy` field to `ViewDeclaration`, `PluginAppNavTab` (core), `AppShellPageRegistration` + `ViewRegistryEntry` (ui). Propagated through `appShellPageToViewEntry` so a page's opt-out survives the registry→view-entry mapper. Default `normal`.

**5. Uniform-top-bar audit assertion (spec item 5)** — `view-header-audit.ts`: `viewRequiresSharedHeader()` + `assertSharedViewHeader()` that **FAIL** a `normal` view whose rendered subtree lacks `[data-testid="view-header"]` (the #13451 acceptance), no-op for exempt policies. The single source of truth for both unit tests and the real-app `audit:app` soak.

## Tests
- `SectionNav.test.tsx` (9) — one tab per group page, sort order, active marking + alias resolution, click-nav, **single-member renders no strip**, empty section
- `view-header-audit.test.ts` (7) — policy gating, header detection, **fails synthetic headerless normal view**, exempt no-op
- `ViewHeader.test.tsx` (9) + `WalletSectionNav.test.tsx` (7) — still green
- tsgo clean (only a pre-existing unrelated `brand-env-aliases` error from #13632), biome clean

## Per-view leftovers flagged (belong to their own lanes, NOT this child)
- **Settings (#13590):** still ships a desktop left-nav rail with its own inline `<h1>Settings</h1>` and a bespoke desktop detail-pane heading. Full rail→header restructure is the per-view refactor.
- **Browser workspace (#13xxx):** `BrowserWorkspaceView` owns a toolbar instead of a `ViewHeader`. It should declare `headerPolicy: "fullscreen"` (this PR adds the field; wiring the declaration is the per-view job).
- **Character sections:** scattered across sibling top-level tabs; folding them into a `SectionNav` group is a per-view task.
- **`App.tsx` `resolveActiveScreenBackgroundPolicy` / launcher-wallpaper restriction (spec item 6)** left to the #13452 capability-broker lane — this PR only lands the manifest field it consumes, per the issue's "coordinate, don't duplicate" note.

Chat-redesign note: does not touch `ContinuousChatOverlay`/`ChatView` (merge-queue PRs #13638/#13642/#13644).

— [sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>
