### PR TITLE
fix(#13614): inject cloud team account pool

### DIFF
--- a/.github/issue-evidence/13614-cloud-shared-app-core-cycle.md
+++ b/.github/issue-evidence/13614-cloud-shared-app-core-cycle.md
@@ -1,0 +1,82 @@
+# Issue #13614 — cloud-shared/app-core cycle break
+
+## What changed
+
+- Removed the production `@elizaos/cloud-shared -> @elizaos/app-core` dependency edge.
+- Replaced cloud-shared's lazy import of `@elizaos/app-core/account-pool` with an injected `TeamAccountPoolFactory`.
+- Registered the concrete app-core `AccountPool` implementation from the cloud API chat completions route, which is the production caller of team pooled credentials.
+- Kept the real team-pool tests on app-core's `AccountPool` by injecting the factory explicitly in the test registry.
+
+## Verification
+
+Commands run from `/Users/shawwalters/.codex/wt-project12-13614`.
+
+```bash
+jq -e '.dependencies["@elizaos/app-core"] == null' packages/cloud/shared/package.json
+```
+
+Result: passed and printed `cloud-shared has no app-core dependency`.
+
+```bash
+rg -n '@elizaos/app-core' \
+  packages/cloud/shared/package.json \
+  packages/cloud/shared/src/lib/services/team-credential-pool \
+  -g '!**/__tests__/**'
+```
+
+Result: no production references found.
+
+```bash
+bunx biome check \
+  packages/cloud/shared/src/lib/services/team-credential-pool/registry.ts \
+  packages/cloud/shared/src/lib/services/team-credential-pool/pool-deps.ts \
+  packages/cloud/shared/src/lib/services/team-credential-pool/index.ts \
+  packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts \
+  packages/cloud/api/v1/chat/completions/route.ts \
+  packages/cloud/api/package.json \
+  packages/cloud/shared/package.json
+```
+
+Result: passed, `Checked 7 files ... No fixes applied.`
+
+```bash
+node <workspace dependency-closure check>
+```
+
+Result: `OK: @elizaos/cloud-shared dependency closure does not reach @elizaos/app-core across 14 workspace packages.`
+
+```bash
+bun run --cwd packages/cloud/shared typecheck
+```
+
+Patch-specific result: no `team-credential-pool` errors after the fix.
+
+Remaining pre-existing failures in this local worktree:
+
+- `../../core/src/i18n/action-search-keywords.ts`: missing generated `validation-keyword-data`.
+- `../../core/src/i18n/validation-keywords.ts`: missing generated `validation-keyword-data`.
+- `../../shared/src/config/brand-env-aliases.ts`: existing `syncElizaKey` type error.
+- `../../shared/src/i18n/keyword-matching.ts`: missing generated `validation-keyword-data`.
+
+```bash
+bun run --cwd packages/cloud/api typecheck
+```
+
+Patch-specific result: no `team-credential-pool` or chat route errors after the fix.
+
+Remaining pre-existing/local-install failures:
+
+- app-core source import cannot resolve `@elizaos/auth/*` subpaths in this throwaway worktree's node_modules layout.
+- the same generated i18n and `brand-env-aliases.ts` failures listed above.
+
+```bash
+bun test packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts
+```
+
+Result: blocked before exercising the team-pool code because the test setup cannot import `@elizaos/cloud-routing` from `packages/core/src/cloud-routing.ts` in this isolated worktree. The downstream test failures are all from undefined setup imports after that initial import failure.
+
+```bash
+bunx turbo run build --dry-run=json --filter=@elizaos/cloud-shared
+```
+
+Result: abandoned after 90 seconds with no output; the process did not respond to interrupt and was killed before continuing with deterministic package.json graph checks.

--- a/packages/cloud/api/package.json
+++ b/packages/cloud/api/package.json
@@ -28,8 +28,10 @@
     "@ai-sdk/openai": "^3.0.54",
     "@cloudflare/workers-types": "^4.20260429.1",
     "@elevenlabs/elevenlabs-js": "^2.45.0",
+    "@elizaos/app-core": "workspace:*",
     "@elizaos/cloud-shared": "workspace:*",
     "@elizaos/security": "workspace:*",
+    "@elizaos/shared": "workspace:*",
     "@fal-ai/client": "^1.10.1",
     "@fal-ai/server-proxy": "^1.2.1",
     "@upstash/redis": "^1.37.0",
@@ -44,8 +46,7 @@
     "uuid": "^14.0.0",
     "viem": "^2.48.8",
     "wrangler": "^4.0.0",
-    "zod": "^4.4.3",
-    "@elizaos/shared": "workspace:*"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.2",

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -13,6 +13,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * IMPORTANT: Do NOT call provider APIs directly. Always use AI SDK.
  */
 
+import { AccountPool } from "@elizaos/app-core/account-pool";
 import {
   APICallError,
   generateText,
@@ -95,6 +96,7 @@ import {
 import { getCachedGatewayModelById } from "@/lib/services/model-catalog";
 import {
   getTeamPoolRegistry,
+  registerTeamAccountPoolFactory,
   type SelectedPooledCredential,
 } from "@/lib/services/team-credential-pool";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
@@ -103,6 +105,8 @@ import { getRouteTimeoutMs } from "@/lib/utils/request-timeout";
 import { settleOffResponsePath } from "@/lib/utils/settle-off-response-path";
 
 const ROUTE_MAX_DURATION = 800;
+
+registerTeamAccountPoolFactory((deps) => new AccountPool(deps));
 
 // Minimum tokens to reserve for actual response generation when CoT is active
 const MIN_RESPONSE_TOKENS = 4096;

--- a/packages/cloud/shared/package.json
+++ b/packages/cloud/shared/package.json
@@ -51,7 +51,6 @@
     "@electric-sql/pglite": "^0.4.5",
     "@electric-sql/pglite-socket": "0.1.6",
     "@elevenlabs/elevenlabs-js": "^2.45.0",
-    "@elizaos/app-core": "workspace:*",
     "@elizaos/cloud-sdk": "workspace:*",
     "@elizaos/contracts": "workspace:*",
     "@elizaos/core": "workspace:*",

--- a/packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts
@@ -1,11 +1,11 @@
 /**
  * Team credential pool — REAL AccountPool brain + REAL PGlite DB (#11332).
  *
- * These cases run the actual `AccountPool` class (lazy-loaded from
- * @elizaos/app-core/account-pool through `TeamPoolRegistry`) against real
- * `pooled_credentials` rows, real envelope-encrypted `secrets` rows, and a
- * real HTTP provider stub for the live contribution probe (the probe honors
- * ANTHROPIC_BASE_URL, so no fetch mocking — real request, real 200/401).
+ * These cases run the actual `AccountPool` class (injected from the host-layer
+ * package into `TeamPoolRegistry`) against real `pooled_credentials` rows, real
+ * envelope-encrypted `secrets` rows, and a real HTTP provider stub for the live
+ * contribution probe (the probe honors ANTHROPIC_BASE_URL, so no fetch mocking
+ * — real request, real 200/401).
  *
  * Proven here, against the DB:
  *  - contribution probe-gates keys (bad key → rejected, no row, no secret)
@@ -49,6 +49,7 @@ let dbWrite: typeof import("../../../db/client").dbWrite;
 let repo: typeof import("../../../db/repositories/pooled-credentials").pooledCredentialsRepository;
 let svc: typeof import("../team-credential-pool/service");
 let registryMod: typeof import("../team-credential-pool/registry");
+let AccountPoolClass: typeof import("@elizaos/app-core/account-pool").AccountPool;
 
 const ORG_A = "11111111-1111-4111-8111-111111111111";
 const ORG_B = "22222222-2222-4222-8222-222222222222";
@@ -61,6 +62,12 @@ const AUDIT = {
   actorId: OWNER_A,
   source: "team-credential-pool.test",
 };
+
+function createRegistry(): InstanceType<typeof registryMod.TeamPoolRegistry> {
+  return new registryMod.TeamPoolRegistry({
+    accountPoolFactory: (deps) => new AccountPoolClass(deps),
+  });
+}
 
 beforeAll(async () => {
   try {
@@ -85,6 +92,7 @@ beforeAll(async () => {
     ));
     svc = await import("../team-credential-pool/service");
     registryMod = await import("../team-credential-pool/registry");
+    ({ AccountPool: AccountPoolClass } = await import("@elizaos/app-core/account-pool"));
 
     const { organizations } = await import("../../../db/schemas/organizations");
     const { users } = await import("../../../db/schemas/users");
@@ -256,7 +264,7 @@ describe("selection — real AccountPool rotation + health", () => {
     credAlpha = all.find((r) => r.label === "alpha")?.id ?? "";
     expect(credAlpha).not.toBe("");
 
-    const registry = new registryMod.TeamPoolRegistry();
+    const registry = createRegistry();
     const picked: string[] = [];
     const keys = new Set<string>();
     for (let i = 0; i < 6; i++) {
@@ -287,7 +295,7 @@ describe("selection — real AccountPool rotation + health", () => {
   });
 
   test("a rate-limited key is skipped, then re-admitted after `until` passes", async () => {
-    const registry = new registryMod.TeamPoolRegistry();
+    const registry = createRegistry();
     const entry = await registry.getOrgPool(ORG_A);
     if (!entry) throw new Error("no pool for ORG_A");
     // 429 recorded against beta with a 60s cool-off — through the REAL pool
@@ -331,7 +339,7 @@ describe("selection — real AccountPool rotation + health", () => {
   });
 
   test("Worker provider outcome writeback marks 429 and 401 credentials unhealthy", async () => {
-    const registry = new registryMod.TeamPoolRegistry();
+    const registry = createRegistry();
 
     await registry.recordProviderFailure({
       organizationId: ORG_A,
@@ -373,7 +381,7 @@ describe("selection — real AccountPool rotation + health", () => {
     if (!before) throw new Error("gamma missing");
     const cipherBefore = (await secretRow(before.secret_id))?.encrypted_value;
 
-    const registry = new registryMod.TeamPoolRegistry();
+    const registry = createRegistry();
     const entry = await registry.getOrgPool(ORG_A);
     if (!entry) throw new Error("no pool for ORG_A");
     await entry.pool.markNeedsReauth(credGamma, "401 from provider", {
@@ -388,7 +396,7 @@ describe("selection — real AccountPool rotation + health", () => {
   });
 
   test("a stale-snapshot health write cannot revert a concurrent admin disable", async () => {
-    const registry = new registryMod.TeamPoolRegistry();
+    const registry = createRegistry();
     // Load the snapshot while alpha is still enabled.
     const entry = await registry.getOrgPool(ORG_A);
     if (!entry) throw new Error("no pool for ORG_A");
@@ -429,7 +437,7 @@ describe("selection — real AccountPool rotation + health", () => {
     // alpha's key gets revoked at the provider console.
     GOOD_KEYS.delete("sk-ant-pool-key-alpha-0001");
 
-    const registry = new registryMod.TeamPoolRegistry();
+    const registry = createRegistry();
     const entry = await registry.getOrgPool(ORG_A);
     if (!entry) throw new Error("no pool for ORG_A");
     await registry.sweepActivePools();
@@ -453,7 +461,7 @@ describe("selection — real AccountPool rotation + health", () => {
   });
 
   test("per-member daily rollup upserts (credential, user, day) and sums per org-day", async () => {
-    const registry = new registryMod.TeamPoolRegistry();
+    const registry = createRegistry();
     await registry.recordUse({
       organizationId: ORG_A,
       credentialId: credAlpha,

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/index.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/index.ts
@@ -13,6 +13,10 @@ export {
 } from "./provider-map";
 export {
   getTeamPoolRegistry,
+  registerTeamAccountPoolFactory,
   type SelectedPooledCredential,
+  type TeamAccountPoolFactory,
+  type TeamAccountPoolLike,
+  type TeamAccountPoolStrategy,
   TeamPoolRegistry,
 } from "./registry";

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/pool-deps.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/pool-deps.ts
@@ -1,10 +1,9 @@
 /**
  * Drizzle-backed AccountPoolDeps (#11332).
  *
- * The self-host AccountPool brain (@elizaos/app-core/account-pool) is
- * dependency-injected: give it `readAccounts` / `writeAccount` /
- * `deleteAccount` and every selection strategy, health rule, and affinity
- * behavior works unchanged. This implements those deps against the
+ * The account-selection brain is dependency-injected: give it `readAccounts` /
+ * `writeAccount` / `deleteAccount` and every selection strategy, health rule,
+ * and affinity behavior works unchanged. This implements those deps against the
  * `pooled_credentials` table for ONE organization:
  *
  * - `readAccounts` is synchronous by contract (the self-host impl reads a
@@ -23,8 +22,10 @@
  * metadata records; callers resolve ciphertext via SecretsService at use time.
  */
 
-import type { AccountPoolDeps, PoolProviderId } from "@elizaos/app-core/account-pool";
-import type { LinkedAccountConfig, LinkedAccountHealth } from "@elizaos/contracts";
+import type {
+  LinkedAccountConfig,
+  LinkedAccountHealth,
+} from "@elizaos/shared/contracts/service-routing";
 import {
   type PooledCredential,
   pooledCredentialsRepository,
@@ -52,6 +53,17 @@ function rowToLinkedAccount(row: PooledCredential): LinkedAccountConfig {
     organizationId: row.organization_id,
     ...(row.contributed_by ? { userId: row.contributed_by } : {}),
   };
+}
+
+export type PoolProviderId = LinkedAccountConfig["providerId"];
+
+export interface AccountPoolDeps {
+  /** Read the current account metadata snapshot. */
+  readAccounts: () => Record<string, LinkedAccountConfig>;
+  /** Persist the account fields mutated by the selection brain. */
+  writeAccount: (account: LinkedAccountConfig) => Promise<void>;
+  /** Remove metadata for an account. */
+  deleteAccount?: (providerId: PoolProviderId, accountId: string) => Promise<void>;
 }
 
 export class DrizzleAccountPoolDeps implements AccountPoolDeps {

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/registry.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/registry.ts
@@ -3,14 +3,15 @@
  *
  * The self-host AccountPool assumes ONE pool per process (wired through
  * globalThis bridges). Cloud is multi-tenant: this registry holds one
- * `AccountPool` + `DrizzleAccountPoolDeps` per organization in an LRU-evicted
- * map, and NEVER touches the globalThis bridges (those are single-tenant
- * self-host plumbing).
+ * account-selection pool + `DrizzleAccountPoolDeps` per organization in an
+ * LRU-evicted map, and NEVER touches the globalThis bridges (those are
+ * single-tenant self-host plumbing).
  *
- * The AccountPool class is loaded lazily from @elizaos/app-core/account-pool
- * and every public method is strict-fallback: any failure (module load, DB,
- * decrypt) returns null / no-ops so callers keep today's platform-env
- * behavior. Pooled keys are an additive layer, never a new failure mode.
+ * The account-selection pool is supplied by the host layer through
+ * `registerTeamAccountPoolFactory()`. Every public method is strict-fallback:
+ * any failure (missing registration, DB, decrypt) returns null / no-ops so
+ * callers keep today's platform-env behavior. Pooled keys are an additive
+ * layer, never a new failure mode.
  *
  * Keep-alive: a low-frequency sweep over ACTIVE orgs (orgs currently in the
  * registry) that (a) re-probes flagged credentials whose cool-off has passed
@@ -23,11 +24,11 @@
  * rate-limits at selection time and every acquire refreshes from the DB.
  */
 
-import type { AccountPool, Strategy } from "@elizaos/app-core/account-pool";
+import type { LinkedAccountConfig } from "@elizaos/shared/contracts/service-routing";
 import { pooledCredentialsRepository } from "../../../db/repositories/pooled-credentials";
 import { logger } from "../../utils/logger";
 import { secretsService } from "../secrets/secrets";
-import { DrizzleAccountPoolDeps } from "./pool-deps";
+import { type AccountPoolDeps, DrizzleAccountPoolDeps, type PoolProviderId } from "./pool-deps";
 import { probePooledApiKey } from "./probe";
 import {
   isPooledDirectProvider,
@@ -42,8 +43,42 @@ const KEEP_ALIVE_PROBES_PER_SWEEP = 8;
 /** Healthy credentials get re-verified when older than this. */
 const STALE_OK_REPROBE_MS = 6 * 60 * 60_000;
 
+export type TeamAccountPoolStrategy = "priority" | "round-robin" | "least-used" | "quota-aware";
+
+export interface TeamAccountPoolLike {
+  get(accountId: string, providerId?: PoolProviderId): LinkedAccountConfig | null;
+  list(providerId?: PoolProviderId): LinkedAccountConfig[];
+  select(input: {
+    providerId: PoolProviderId;
+    sessionKey?: string;
+    strategy?: TeamAccountPoolStrategy;
+    accountIds?: string[];
+    exclude?: string[];
+  }): Promise<LinkedAccountConfig | null>;
+  reprobeFlagged(): Promise<string[]>;
+  markRateLimited(
+    accountId: string,
+    untilMs: number,
+    detail?: string,
+    options?: { providerId?: PoolProviderId },
+  ): Promise<void>;
+  markNeedsReauth(
+    accountId: string,
+    detail?: string,
+    options?: { providerId?: PoolProviderId },
+  ): Promise<void>;
+}
+
+export type TeamAccountPoolFactory = (deps: AccountPoolDeps) => TeamAccountPoolLike;
+
+let defaultAccountPoolFactory: TeamAccountPoolFactory | null = null;
+
+export function registerTeamAccountPoolFactory(factory: TeamAccountPoolFactory | null): void {
+  defaultAccountPoolFactory = factory;
+}
+
 interface OrgPoolEntry {
-  pool: AccountPool;
+  pool: TeamAccountPoolLike;
   deps: DrizzleAccountPoolDeps;
   lastAccessAt: number;
 }
@@ -53,7 +88,7 @@ export interface SelectPooledCredentialParams {
   providerId: PooledDirectProvider;
   /** Stable affinity key (e.g. agent sandbox id). */
   sessionKey?: string;
-  strategy?: Strategy;
+  strategy?: TeamAccountPoolStrategy;
 }
 
 export interface SelectedPooledCredential {
@@ -67,10 +102,15 @@ export interface SelectedPooledCredential {
 export class TeamPoolRegistry {
   private readonly pools = new Map<string, OrgPoolEntry>();
   private readonly maxOrgPools: number;
+  private readonly accountPoolFactory: TeamAccountPoolFactory | null;
   private keepAlive: ReturnType<typeof setInterval> | null = null;
 
-  constructor(options?: { maxOrgPools?: number }) {
+  constructor(options?: {
+    maxOrgPools?: number;
+    accountPoolFactory?: TeamAccountPoolFactory | null;
+  }) {
     this.maxOrgPools = options?.maxOrgPools ?? DEFAULT_MAX_ORG_POOLS;
+    this.accountPoolFactory = options?.accountPoolFactory ?? null;
   }
 
   /** Orgs with a live pool instance (keep-alive scope). */
@@ -92,10 +132,16 @@ export class TeamPoolRegistry {
     try {
       let entry = this.pools.get(organizationId);
       if (!entry) {
-        const { AccountPool: AccountPoolClass } = await import("@elizaos/app-core/account-pool");
+        const accountPoolFactory = this.accountPoolFactory ?? defaultAccountPoolFactory;
+        if (!accountPoolFactory) {
+          logger.warn("[TeamPoolRegistry] account pool factory is not registered", {
+            organizationId,
+          });
+          return null;
+        }
         const deps = new DrizzleAccountPoolDeps(organizationId);
         entry = {
-          pool: new AccountPoolClass(deps),
+          pool: accountPoolFactory(deps),
           deps,
           lastAccessAt: Date.now(),
         };


### PR DESCRIPTION
## Summary

- remove the production `@elizaos/cloud-shared -> @elizaos/app-core` dependency edge from the team credential pool
- replace cloud-shared's lazy app-core import with an injected `TeamAccountPoolFactory`
- register the concrete app-core `AccountPool` from the cloud API chat completions host route
- keep the real team-pool tests wired to app-core by injecting the factory explicitly

Refs #13614.

## Evidence

- `.github/issue-evidence/13614-cloud-shared-app-core-cycle.md`

## Verification

- `jq -e '.dependencies["@elizaos/app-core"] == null' packages/cloud/shared/package.json`\n- `rg -n '@elizaos/app-core' packages/cloud/shared/package.json packages/cloud/shared/src/lib/services/team-credential-pool -g '!**/__tests__/**'` returned no production references\n- `bunx biome check ...` on all touched code/package files passed\n- lightweight workspace dependency-closure check: `@elizaos/cloud-shared` no longer reaches `@elizaos/app-core`\n- `bun run --cwd packages/cloud/shared typecheck` has no patch-specific `team-credential-pool` errors; remaining failures are existing generated i18n/brand-env issues documented in evidence\n- `bun run --cwd packages/cloud/api typecheck` has no patch-specific team-pool/chat route errors; remaining failures are app-core auth subpath resolution in this throwaway worktree plus the same existing generated i18n/brand-env issues\n- `bun test packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts` is blocked before exercising this code by missing `@elizaos/cloud-routing` from core in the isolated worktree; documented in evidence\n