### PR TITLE
fix(#13415): fail-closed anti-sybil count in signup grant guard

### DIFF
--- a/packages/cloud/api/v1/agents/route.test.ts
+++ b/packages/cloud/api/v1/agents/route.test.ts
@@ -19,7 +19,7 @@ type InitialCreditGrantMockResult = {
   initialCreditsGranted: boolean;
   initialFreeCreditsUsd: number;
   welcomeBonusWithheld?: boolean;
-  welcomeBonusWithheldReason?: "ip_daily_cap";
+  welcomeBonusWithheldReason?: "ip_daily_cap" | "count_unavailable";
   welcomeBonusWithheldMessage?: string;
 };
 const grantInitialCreditsToWalletAccount = mock(

--- a/packages/cloud/api/v1/agents/route.ts
+++ b/packages/cloud/api/v1/agents/route.ts
@@ -310,7 +310,11 @@ app.post("/", async (c) => {
     let initialCreditsGranted = false;
     let initialFreeCreditsUsd = 0;
     let welcomeBonusWithheld = false;
-    let welcomeBonusWithheldReason: "ip_daily_cap" | undefined;
+    // Track the grant service's own withheld-reason type so a new reason (e.g.
+    // "count_unavailable") doesn't silently drop here.
+    let welcomeBonusWithheldReason: Awaited<
+      ReturnType<typeof grantInitialCreditsToWalletAccount>
+    >["welcomeBonusWithheldReason"];
     let welcomeBonusWithheldMessage: string | undefined;
     let agent: Awaited<
       ReturnType<typeof elizaSandboxService.createAgent>

--- a/packages/cloud/shared/src/lib/services/signup-grant-guard.test.ts
+++ b/packages/cloud/shared/src/lib/services/signup-grant-guard.test.ts
@@ -15,6 +15,10 @@ type TxResult = boolean | { granted?: boolean };
 
 // Committed grant rows, visible to every new transaction's COUNT.
 let committedGrants: GrantRow[] = [];
+// When set, the COUNT(*) query returns this row shape instead of the real
+// per-IP count. Lets a test inject a malformed/unreadable count to exercise the
+// fail-closed guard. `null` -> a row with no `count` field at all.
+let countRowOverride: { count: unknown } | null | undefined;
 // Per-lock-key queue of waiters, enforcing FIFO mutual exclusion.
 const lockHolders = new Map<string, Promise<void>>();
 // SQL strings each tx.execute saw, for asserting the advisory lock is acquired.
@@ -45,6 +49,13 @@ class FakeTx {
     if (text.includes("COUNT(*)")) {
       // The guard always runs the advisory-lock statement before the COUNT, so
       // `this.ip` is set; count only COMMITTED grant rows for this IP.
+      if (countRowOverride !== undefined) {
+        return {
+          rows: (countRowOverride === null ? [{}] : [countRowOverride]) as Array<{
+            count: string;
+          }>,
+        };
+      }
       const count = committedGrants.filter((g) => g.ip === this.ip).length;
       return { rows: [{ count: String(count) }] };
     }
@@ -130,9 +141,13 @@ mock.module("../utils/logger", () => ({
   logger: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
 }));
 
-const { runWithSignupGrantIpCap, resolveSignupGrantIpLimits, FREE_GRANT_IP_LIMITS } = await import(
-  "./signup-grant-guard"
-);
+const {
+  runWithSignupGrantIpCap,
+  runWithSignupGrantIpCapDetailed,
+  resolveSignupGrantIpLimits,
+  parseGrantCount,
+  FREE_GRANT_IP_LIMITS,
+} = await import("./signup-grant-guard");
 
 const CAP = FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY;
 
@@ -172,6 +187,7 @@ describe("runWithSignupGrantIpCap (anti-sybil free-grant cap)", () => {
     committedGrants = [];
     executedSql = [];
     lockHolders.clear();
+    countRowOverride = undefined;
   });
 
   test("falls open and runs the grant without a transaction when no IP is known", async () => {
@@ -244,5 +260,78 @@ describe("runWithSignupGrantIpCap (anti-sybil free-grant cap)", () => {
       }),
     ).rejects.toThrow("addCredits failed");
     expect(committedGrants.filter((g) => g.ip === "7.7.7.7").length).toBe(0);
+  });
+
+  // Fail-closed regression: an unreadable per-IP COUNT must WITHHOLD the bonus.
+  // The old `Number(count ?? 0)` produced NaN, and `NaN >= cap` === false, so a
+  // corrupt/unexpected count silently GRANTED the free credits — an unbounded
+  // anti-sybil faucet. Each of these malformed shapes must now deny the grant.
+  const malformedCounts: Array<[string, { count: unknown } | null]> = [
+    ["non-numeric string", { count: "NaN" }],
+    ["empty string", { count: "" }],
+    ["fractional string", { count: "1.5" }],
+    ["negative string", { count: "-1" }],
+    ["null count field", { count: null }],
+    ["missing count field", null],
+  ];
+
+  for (const [label, override] of malformedCounts) {
+    test(`withholds the grant (fail-closed) when the COUNT is unreadable: ${label}`, async () => {
+      countRowOverride = override;
+      let granted = false;
+      const decision = await runWithSignupGrantIpCapDetailed("4.4.4.4", async () => {
+        granted = true;
+      });
+      expect(decision.granted).toBe(false);
+      expect(decision.withheldReason).toBe("count_unavailable");
+      // The grant callback must never run on an unverifiable count.
+      expect(granted).toBe(false);
+      expect(committedGrants.filter((g) => g.ip === "4.4.4.4").length).toBe(0);
+    });
+  }
+
+  test("still grants when the COUNT reads a valid below-cap integer string", async () => {
+    // Force a well-formed "0" so the healthy path is exercised via the override.
+    countRowOverride = { count: "0" };
+    let granted = false;
+    const decision = await runWithSignupGrantIpCapDetailed("6.6.6.6", async () => {
+      granted = true;
+    });
+    expect(decision.granted).toBe(true);
+    expect(granted).toBe(true);
+  });
+});
+
+describe("parseGrantCount (fail-closed anti-sybil count boundary)", () => {
+  test("accepts non-negative integer strings and numbers", () => {
+    expect(parseGrantCount("0")).toBe(0);
+    expect(parseGrantCount("3")).toBe(3);
+    expect(parseGrantCount(" 42 ")).toBe(42);
+    expect(parseGrantCount(0)).toBe(0);
+    expect(parseGrantCount(7)).toBe(7);
+    expect(parseGrantCount(5n)).toBe(5);
+  });
+
+  test("throws on any unverifiable/malformed count (never returns NaN)", () => {
+    for (const bad of [
+      "NaN",
+      "",
+      "   ",
+      "1.5",
+      "-1",
+      "1e3",
+      "0x10",
+      "abc",
+      null,
+      undefined,
+      Number.NaN,
+      Infinity,
+      -1,
+      1.5,
+      -3n,
+      {},
+    ]) {
+      expect(() => parseGrantCount(bad)).toThrow();
+    }
   });
 });

--- a/packages/cloud/shared/src/lib/services/signup-grant-guard.ts
+++ b/packages/cloud/shared/src/lib/services/signup-grant-guard.ts
@@ -46,7 +46,7 @@ export function resolveSignupGrantIpLimits(env: SignupGrantIpLimitEnv = process.
 
 export const FREE_GRANT_IP_LIMITS = resolveSignupGrantIpLimits();
 
-export type SignupGrantWithheldReason = "ip_daily_cap";
+export type SignupGrantWithheldReason = "ip_daily_cap" | "count_unavailable";
 
 export interface SignupGrantDecision {
   granted: boolean;
@@ -60,6 +60,56 @@ function readPositiveIntEnv(raw: string | undefined, fallback: number): number {
   if (raw === undefined || raw.trim() === "") return fallback;
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Signals that the per-IP grant COUNT could not be resolved to a finite,
+ * non-negative integer. The anti-sybil cap is a security gate, so an
+ * unreadable count must FAIL CLOSED (withhold the free bonus), never fall
+ * open into an unbounded faucet.
+ */
+export class SignupGrantCountUnavailableError extends Error {
+  readonly rawCount: unknown;
+  constructor(rawCount: unknown) {
+    super(
+      `[SignupGrantGuard] per-IP free-grant count is not a finite integer: ${String(rawCount)}`,
+    );
+    this.name = "SignupGrantCountUnavailableError";
+    this.rawCount = rawCount;
+  }
+}
+
+/**
+ * Fail-closed parse of the per-IP grant COUNT. Postgres `COUNT(*)` returns a
+ * bigint as a decimal string, so the happy path is a plain non-negative
+ * integer string. Anything else (missing row, non-numeric, NaN/Infinity,
+ * fractional, negative) means the anti-sybil count is unverifiable — throw so
+ * the caller withholds the grant instead of granting past an unread cap.
+ *
+ * Rationale: the old `Number(count ?? 0)` returned `NaN` on a malformed read,
+ * and `NaN >= cap` is `false`, which silently GRANTED the bonus — a fail-open
+ * on a sybil gate. This mirrors the fail-closed numeric-read boundaries used by
+ * the redemption/billing money gates in the same service layer.
+ */
+export function parseGrantCount(rawCount: unknown): number {
+  if (typeof rawCount === "number") {
+    if (Number.isInteger(rawCount) && rawCount >= 0) return rawCount;
+    throw new SignupGrantCountUnavailableError(rawCount);
+  }
+  if (typeof rawCount === "bigint") {
+    if (rawCount < 0n) throw new SignupGrantCountUnavailableError(rawCount);
+    return Number(rawCount);
+  }
+  if (typeof rawCount === "string") {
+    const trimmed = rawCount.trim();
+    // Plain non-negative integer only: rejects "", "NaN", "1.5", "1e3", "0x10", "-1".
+    if (/^\d+$/.test(trimmed)) {
+      const parsed = Number(trimmed);
+      if (Number.isSafeInteger(parsed)) return parsed;
+    }
+    throw new SignupGrantCountUnavailableError(rawCount);
+  }
+  throw new SignupGrantCountUnavailableError(rawCount);
 }
 
 function maskIp(ip: string): string {
@@ -121,7 +171,33 @@ export async function runWithSignupGrantIpCapDetailed(
         AND created_at >= ${dayAgo}
     `);
 
-    const granted = Number((result.rows[0] as { count: string } | undefined)?.count ?? 0);
+    const rawCount = (result.rows[0] as { count?: unknown } | undefined)?.count;
+    let granted: number;
+    try {
+      granted = parseGrantCount(rawCount);
+    } catch (error) {
+      // Fail closed: an unreadable anti-sybil count must NOT grant the bonus.
+      // (The old `Number(count ?? 0)` -> NaN, and `NaN >= cap` === false, which
+      // silently granted — an unbounded free-credit faucet on a corrupt read.)
+      logger.warn(
+        "[SignupGrantGuard] Per-IP free-grant count unreadable; withholding welcome bonus (fail-closed)",
+        {
+          ip: maskIp(ip),
+          rawCount,
+          cap,
+          windowHours,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      return {
+        granted: false,
+        withheldReason: "count_unavailable",
+        withheldMessage: "Welcome credit unavailable right now. Add funds to start an agent.",
+        cap,
+        windowHours,
+      };
+    }
+
     if (granted >= cap) {
       logger.warn(
         "[SignupGrantGuard] Per-IP daily free-grant cap reached; withholding welcome bonus",

--- a/packages/shared/src/steward-session-client/index.ts
+++ b/packages/shared/src/steward-session-client/index.ts
@@ -73,7 +73,11 @@ export interface StewardSessionResponse {
   initialCreditsGranted?: boolean;
   initialFreeCreditsUsd?: number;
   welcomeBonusWithheld?: boolean;
-  welcomeBonusWithheldReason?: "ip_daily_cap";
+  // Mirrors `SignupGrantWithheldReason` in
+  // packages/cloud/shared/src/lib/services/signup-grant-guard.ts (the source of
+  // truth). Kept as an inline literal union because `packages/shared` cannot
+  // depend on `packages/cloud/shared`; keep in sync when reasons are added.
+  welcomeBonusWithheldReason?: "ip_daily_cap" | "count_unavailable";
   welcomeBonusWithheldMessage?: string;
 }
 


### PR DESCRIPTION
## Problem (#13415 cloud-shared service-layer fail-closed sweep)

`packages/cloud/shared/src/lib/services/signup-grant-guard.ts` is the anti-sybil gate for free welcome-bonus credits (per-IP daily cap). It read the `COUNT(*)` result via:

```ts
const granted = Number((result.rows[0] as { count: string } | undefined)?.count ?? 0);
if (granted >= cap) { /* withhold */ }
```

A malformed / unexpected count read (unreadable row shape, driver drift, `NaN`) makes `granted = NaN`, and `NaN >= cap` is **`false`** — so the guard **silently GRANTS the free bonus anyway**. That is a **fail-open on a security gate**: the per-IP cap that exists specifically to stop one host from minting unlimited orgs to farm free metered-inference becomes an unbounded faucet the moment the count read is anything other than a clean integer.

Same fail-open numeric-read class the sibling money/anti-sybil gates in this service layer already hardened (`token-redemption-secure.ts`, `usage-quotas.ts`, `app-earnings.ts`, `organizations.ts`, etc.).

> Note: I first scoped this slice to `ai-billing.ts` affiliate `markup_percent`, but on `origin/develop` that read is already consolidated into `resolveBillableAffiliate` with an `isFinite`+`<= 0` guard (STALE-CLONE gotcha). Re-scoped to this genuinely-unguarded gate.

## Fix

- New colocated **fail-closed** `parseGrantCount()` boundary + `SignupGrantCountUnavailableError`: a non-finite / non-integer / negative / unparseable count now **throws**, and the guard **withholds** the grant (new `count_unavailable` withheld reason + observable `logger.warn`) instead of granting past an unread cap. Healthy non-negative integer reads are behavior-preserving.
- Propagated the new withheld reason to the two consumers that hardcoded the narrow `"ip_daily_cap"` literal instead of the source-of-truth type (both were `tsgo` errors caught by codex review):
  - `StewardSessionResponse` (`packages/shared` steward-session-client) widened to `"ip_daily_cap" | "count_unavailable"` (inline literal, since `packages/shared` cannot depend on `cloud/shared`).
  - `v1/agents/route.ts` now derives its local reason type from `grantInitialCreditsToWalletAccount`'s return type so future reasons can't silently drop.

## Tests / evidence

- `signup-grant-guard.test.ts`: **17/17 green** (8 pre-existing + 9 new). New cases cover 6 malformed-count shapes (non-numeric / empty / fractional / negative / null field / missing field) all fail-closed to `count_unavailable`, a healthy below-cap grant still lands, and an exhaustive `parseGrantCount` boundary suite (never returns `NaN`).
- **Reversion-proof**: restoring the old bare-`Number()` read makes the 6 malformed-count regression tests **FAIL** (the guard grants on a corrupt count) — proving the tests catch the fail-open.
- Consumer suites green with the widened reason: `agent-billing-gate-402.test.ts` 4/4; `v1/agents/route.test.ts` 14/14 (incl. "explains insufficient credits after a same-session welcome bonus withhold").
- `tsgo` (cloud/shared + cloud/api + shared): **zero errors in any touched file**; the two `welcomeBonusWithheldReason` type errors codex flagged are resolved. Remaining errors are the pre-existing fresh-worktree i18n / symlinked-node_modules / fal-proxy baseline, identical on `develop`.
- biome clean on all 5 files; `error-policy-ratchet` "no new fallback-slop in touched files".
- codex round-1 caught the consumer type-widening (P1) — fixed; round-2 over-explored the cloud/shared money-invariants docs without converging (documented behavior on this package), validated via the deterministic gates above.

## Collision receipts

No open PR touches `signup-grant-guard.ts` at claim or push; only open PR on #13415 is lalalune's #13645 (agent-budgets.ts — different file). No `lalalune`/`NubsCarson`/`roninjin10` signup-grant PR in the last day (#13343 "surface withheld signup grants" at 16:52 did not add a count fail-closed guard). Unique worktree path, deleted after push. Issue stays open for the remaining service-layer inventory.

-- [sol-orch]