### PR TITLE
test(#13622): mechanically enforce the PR evidence gate (parser + tests)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,7 +7,7 @@ concurrency:
 
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 # Default to least privilege. Override per-job where needed.
 permissions:
@@ -26,7 +26,8 @@ jobs:
       - name: Validate PR evidence rows
         run: |
           jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH" > "$RUNNER_TEMP/pr-body.md"
-          node scripts/check-pr-evidence.mjs --body-file "$RUNNER_TEMP/pr-body.md"
+          PR_LABELS=$(jq -r '.pull_request.labels | map(.name) | join(",")' "$GITHUB_EVENT_PATH")
+          node scripts/check-pr-evidence.mjs --body-file "$RUNNER_TEMP/pr-body.md" --labels "$PR_LABELS"
 
   check-pr-title:
     runs-on: ubuntu-latest

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -1,53 +1,14 @@
 #!/usr/bin/env node
 /**
- * Mechanically enforce the PR Evidence Gate (issue #13622).
- *
- * `PR_EVIDENCE.md` and `.github/pull_request_template.md` define a binding
- * "Definition of Done": every Evidence-Gate row must carry a real artifact
- * (screenshot / video / logs / trajectory / domain artifact) OR an explicit
- * `N/A - <reason>`. That standard was pure honor-system — nothing parsed the PR
- * body, so a PR could leave every evidence row blank (or silently drop the rows)
- * and merge. This script closes that gap: it parses a PR body and fails when any
- * required evidence row is blank (unchecked boilerplate with no artifact and no
- * `N/A - <reason>`) or missing entirely.
- *
- * Robustness: the parser keys on the stable `<!-- evidence-row:<id> -->` HTML
- * comment markers injected into the template ABOVE each Evidence-Gate checkbox,
- * NOT on the human-readable row prose (which is free to be reworded). A marker
- * comment is invisible in the rendered PR, so authors never see it; the parser
- * always finds it.
- *
- * A row is SATISFIED when any of the following hold within the row's text block
- * (the checkbox line plus its indented continuation lines, up to the next marker
- * / heading / blank line):
- *   - the checkbox is ticked (`- [x]`), OR
- *   - it contains an explicit `N/A - <reason>` with a non-empty reason, OR
- *   - it references a real artifact: a markdown link `[text](url)`, a bare
- *     http(s) URL, a GitHub attachment (`user-images.githubusercontent.com`,
- *     `github.com/.../assets/...`), or an `.github/issue-evidence/...` path.
- *
- * A row FAILS when it is still the unedited template boilerplate: an unchecked
- * `- [ ]` with no `N/A - <reason>` and no artifact reference. A required marker
- * that is absent from the body also fails (the template was stripped).
- *
- * Usage:
- *   node scripts/check-pr-evidence.mjs --body-file <path>   # read PR body from a file
- *   echo "$PR_BODY" | node scripts/check-pr-evidence.mjs     # read PR body from stdin
- *   node scripts/check-pr-evidence.mjs --json               # machine-readable findings
- *   node scripts/check-pr-evidence.mjs --self-test          # planted-fixture self-check
- *
- * Exit code 0 = all required evidence rows satisfied; 1 = one or more blank /
- * missing; 2 = usage / input error.
+ * Mechanical PR evidence gate for the evidence rows in the pull request
+ * template. The template keeps stable HTML markers above each required row so
+ * this checker can ignore row prose churn while still failing closed when a row
+ * is blank, checkbox-only, or removed.
  */
 
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
-/**
- * Required Evidence-Gate rows, keyed by the id embedded in the template's
- * `<!-- evidence-row:<id> -->` markers. `label` is only used for human-readable
- * failure messages.
- */
 export const REQUIRED_EVIDENCE_ROWS = [
   { id: "before-screenshots", label: "Before screenshots" },
   { id: "after-screenshots", label: "After screenshots" },
@@ -60,79 +21,63 @@ export const REQUIRED_EVIDENCE_ROWS = [
 
 const MARKER_RE = /<!--\s*evidence-row:([a-z0-9-]+)\s*-->/gi;
 
-/**
- * Return true if `text` marks the row as not-applicable with a concrete reason,
- * i.e. `N/A - <reason>` (or `N/A: <reason>` / `N/A — <reason>`) where the reason
- * is non-empty. A bare `N/A` with no reason does NOT satisfy the gate.
- */
 export function hasNaWithReason(text) {
-  // Accept `-`, `:`, en/em dash as the separator; require >= 3 non-space chars
-  // of reason after it so a bare "N/A" or "N/A -" is rejected.
-  const m = text.match(/\bN\/?A\b\s*[-:\u2013\u2014]\s*(\S[\s\S]*?)(?:$)/im);
-  if (!m) return false;
-  const reason = m[1].trim();
+  const match = text.match(/\bN\/?A\b\s*[-:\u2013\u2014]\s*(\S[\s\S]*?)$/im);
+  if (!match) return false;
+  const reason = match[1].trim();
   if (reason.length < 3) return false;
-  // Reject the unedited template placeholder `<reason>` (and any bare
-  // angle-bracket placeholder) so the boilerplate row does NOT satisfy the gate.
   const stripped = reason.replace(/[`*_]+/g, "").trim();
-  if (/^<[^>]*>[.\s]*$/.test(stripped)) return false;
-  return true;
+  return !/^<[^>]*>[.\s]*$/.test(stripped);
 }
 
-/**
- * Return true if `text` references a real evidence artifact: a markdown link, a
- * bare http(s) URL, a GitHub attachment host, or an `.github/issue-evidence/`
- * path.
- */
 export function hasArtifactReference(text) {
-  // Markdown link [label](target) with a non-empty target.
-  if (/\[[^\]]*\]\(\s*\S+\s*\)/.test(text)) return true;
-  // Bare http(s) URL.
+  if (/\[[^\]]+\]\(\s*\S+\s*\)/.test(text)) return true;
   if (/https?:\/\/\S+/i.test(text)) return true;
-  // GitHub drag-and-drop attachment hosts (covered by the URL check too, but
-  // kept explicit for clarity / future non-URL forms).
   if (
     /user-images\.githubusercontent\.com|github\.com\/[^)\s]+\/assets\//i.test(
       text,
     )
-  )
+  ) {
     return true;
-  // Committed evidence path.
-  if (/\.github\/issue-evidence\/\S+/i.test(text)) return true;
-  return false;
+  }
+  return /\.github\/issue-evidence\/\S+/i.test(text);
 }
 
-/**
- * Return true if the checkbox on the row's first line is ticked (`- [x]`).
- */
 export function isChecked(rowText) {
   return /^\s*[-*]\s*\[\s*[xX]\s*\]/m.test(rowText);
 }
 
-/**
- * A row is satisfied when it is checked, carries an `N/A - <reason>`, or
- * references an artifact.
- */
 export function isRowSatisfied(rowText) {
-  return (
-    isChecked(rowText) ||
-    hasNaWithReason(rowText) ||
-    hasArtifactReference(rowText)
-  );
+  return hasNaWithReason(rowText) || hasArtifactReference(rowText);
 }
 
-/**
- * Split `body` into a map of `markerId -> rowText`. `rowText` for a marker is
- * the checkbox line immediately after the marker plus its indented continuation
- * lines, bounded at the first blank line, heading, next list item, or next
- * evidence marker. Bounding to the checkbox's own block (rather than running to
- * the next marker / EOF) keeps unrelated links/URLs in the sections BELOW the
- * last row from bleeding into that row and falsely satisfying it.
- */
+export function boundRowBlock(block) {
+  const lines = block.split(/\r?\n/);
+  const out = [];
+  let started = false;
+  for (const line of lines) {
+    if (!started) {
+      if (line.trim() === "") continue;
+      started = true;
+      out.push(line);
+      continue;
+    }
+
+    const trimmed = line.trim();
+    if (trimmed === "") break;
+    if (/^#/.test(trimmed)) break;
+    if (/<!--\s*evidence-row:/i.test(trimmed)) break;
+    if (/^[-*]\s/.test(line) && !/^\s/.test(line)) break;
+    out.push(line);
+  }
+  return out.join("\n").trim();
+}
+
 export function extractEvidenceRows(body) {
+  const source = body ?? "";
   const rows = new Map();
   const matches = [];
-  for (const match of (body ?? "").matchAll(MARKER_RE)) {
+  for (const match of source.matchAll(MARKER_RE)) {
     const start = match.index;
     matches.push({
       id: match[1].toLowerCase(),
@@ -140,53 +85,19 @@ export function extractEvidenceRows(body) {
       end: start + match[0].length,
     });
   }
+
   for (let i = 0; i < matches.length; i += 1) {
-    const cur = matches[i];
+    const current = matches[i];
     const next = matches[i + 1];
-    const sliceEnd = next ? next.start : (body ?? "").length;
-    const block = body.slice(cur.end, sliceEnd);
-    const rowText = boundRowBlock(block);
-    if (!rows.has(cur.id) || rowText.length > 0) {
-      rows.set(cur.id, rowText);
+    const sliceEnd = next ? next.start : source.length;
+    const rowText = boundRowBlock(source.slice(current.end, sliceEnd));
+    if (!rows.has(current.id) || rowText.length > 0) {
+      rows.set(current.id, rowText);
     }
   }
   return rows;
 }
 
-/**
- * Given the text between one evidence marker and the next (or EOF), return only
- * the row's own block: the first checkbox line and its indented continuation
- * lines, stopping at the first blank line, heading (`#`), or a subsequent
- * top-level list item / marker comment.
- */
-export function boundRowBlock(block) {
-  const lines = block.split(/\r?\n/);
-  const out = [];
-  let started = false;
-  for (const line of lines) {
-    if (!started) {
-      if (line.trim() === "") continue; // skip leading blanks after the marker
-      started = true;
-      out.push(line);
-      continue;
-    }
-    const trimmed = line.trim();
-    if (trimmed === "") break; // blank line ends the row block
-    if (/^#/.test(trimmed)) break; // heading ends the block
-    if (/<!--\s*evidence-row:/i.test(trimmed)) break; // next marker
-    // A new top-level checkbox / list item ends this row's block; an indented
-    // continuation (leading whitespace) belongs to the current row.
-    if (/^[-*]\s/.test(line) && !/^\s/.test(line)) break;
-    out.push(line);
-  }
-  return out.join("\n").trim();
-}
-
-/**
- * Evaluate a PR body against the required evidence rows.
- * Returns `{ ok, findings }` where each finding is
- * `{ id, label, status: "ok" | "blank" | "missing" }`.
- */
 export function evaluatePrEvidence(
   body,
   requiredRows = REQUIRED_EVIDENCE_ROWS,
@@ -202,8 +113,10 @@ export function evaluatePrEvidence(
       status: isRowSatisfied(rowText) ? "ok" : "blank",
     };
   });
-  const ok = findings.every((f) => f.status === "ok");
-  return { ok, findings };
+  return {
+    ok: findings.every((finding) => finding.status === "ok"),
+    findings,
+  };
 }
 
 function readBody(args) {
@@ -216,7 +129,7 @@ function readBody(args) {
     }
     return readFileSync(file, "utf8");
   }
-  // Fall back to stdin.
+
   try {
     return readFileSync(0, "utf8");
   } catch {
@@ -235,21 +148,16 @@ Options:
 `);
 }
 
-// ---------------------------------------------------------------------------
-// Self-test: planted fixtures (all-filled -> pass, one-blank -> fail,
-// N/A - reason -> pass). Mirrors the unit test but runs without a test harness
-// so CI can invoke it as a standalone guard if desired.
-// ---------------------------------------------------------------------------
-
 function buildFixtureBody(overrides = {}) {
   const defaults = {
     "before-screenshots":
-      "- [ ] Before screenshots ... `N/A - backend-only change, no UI surface`.",
+      "- [ ] Before screenshots `N/A - backend-only change, no UI surface`.",
     "after-screenshots":
-      "- [ ] After screenshots ... `N/A - backend-only change, no UI surface`.",
-    "walkthrough-video": "- [x] A video walkthrough is attached.",
+      "- [ ] After screenshots `N/A - backend-only change, no UI surface`.",
+    "walkthrough-video":
+      "- [x] A video walkthrough: .github/issue-evidence/13676-video.mp4",
     "backend-logs":
-      "- [ ] Backend logs: see .github/issue-evidence/13622-logs.txt",
+      "- [ ] Backend logs: see .github/issue-evidence/13676-backend.txt",
     "frontend-logs": "- [ ] Frontend logs `N/A - no frontend change`.",
     "llm-trajectory":
       "- [ ] Real-LLM trajectory: [report](https://example.com/report.json)",
@@ -265,13 +173,11 @@ function buildFixtureBody(overrides = {}) {
 function runSelfTest() {
   const failures = [];
 
-  // 1. all-filled -> pass
   {
     const { ok } = evaluatePrEvidence(buildFixtureBody());
     if (!ok) failures.push("all-filled fixture should pass");
   }
 
-  // 2. one blank (unchecked boilerplate, no artifact, no N/A) -> fail
   {
     const { ok, findings } = evaluatePrEvidence(
       buildFixtureBody({
@@ -279,48 +185,62 @@ function runSelfTest() {
           "- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.",
       }),
     );
-    const blank = findings.find((f) => f.id === "backend-logs");
-    if (ok) failures.push("one-blank fixture should fail");
-    if (blank?.status !== "blank")
+    const blank = findings.find((finding) => finding.id === "backend-logs");
+    if (ok) failures.push("blank fixture should fail");
+    if (blank?.status !== "blank") {
       failures.push("blank row should be reported blank");
+    }
   }
 
-  // 3. N/A - reason on every row -> pass
   {
-    const naBody = REQUIRED_EVIDENCE_ROWS.map(
+    const { ok, findings } = evaluatePrEvidence(
+      buildFixtureBody({
+        "backend-logs": "- [x] Backend logs attached.",
+      }),
+    );
+    const blank = findings.find((finding) => finding.id === "backend-logs");
+    if (ok) failures.push("checked-without-artifact fixture should fail");
+    if (blank?.status !== "blank") {
+      failures.push("checked-without-artifact row should be reported blank");
+    }
+  }
+
+  {
+    const body = REQUIRED_EVIDENCE_ROWS.map(
       ({ id }) =>
         `<!-- evidence-row:${id} -->\n- [ ] row \`N/A - not applicable to this change\`.`,
     ).join("\n\n");
-    const { ok } = evaluatePrEvidence(naBody);
+    const { ok } = evaluatePrEvidence(body);
     if (!ok) failures.push("all-N/A-with-reason fixture should pass");
   }
 
-  // 4. bare N/A (no reason) -> fail
   {
     const { ok } = evaluatePrEvidence(
       buildFixtureBody({ "backend-logs": "- [ ] Backend logs N/A" }),
     );
-    if (ok) failures.push("bare N/A (no reason) should fail");
+    if (ok) failures.push("bare N/A should fail");
   }
 
-  // 5. missing marker -> fail
   {
-    const partial = REQUIRED_EVIDENCE_ROWS.slice(1)
-      .map(({ id }) => `<!-- evidence-row:${id} -->\n- [x] done`)
+    const body = REQUIRED_EVIDENCE_ROWS.slice(1)
+      .map(({ id }) => `<!-- evidence-row:${id} -->\n- [ ] N/A - covered elsewhere`)
       .join("\n\n");
-    const { ok, findings } = evaluatePrEvidence(partial);
-    const missing = findings.find((f) => f.id === "before-screenshots");
+    const { ok, findings } = evaluatePrEvidence(body);
+    const missing = findings.find(
+      (finding) => finding.id === "before-screenshots",
+    );
     if (ok) failures.push("missing-marker fixture should fail");
-    if (missing?.status !== "missing")
+    if (missing?.status !== "missing") {
       failures.push("absent row should be reported missing");
+    }
   }
 
   if (failures.length > 0) {
     console.error("check-pr-evidence self-test FAILED:");
-    for (const f of failures) console.error(`  - ${f}`);
+    for (const failure of failures) console.error(`  - ${failure}`);
     process.exit(1);
   }
-  console.log("check-pr-evidence self-test passed (5 cases).");
+  console.log("check-pr-evidence self-test passed (6 cases).");
 }
 
 function main() {
@@ -340,18 +260,19 @@ function main() {
   if (args.includes("--json")) {
     console.log(JSON.stringify({ ok, findings }, null, 2));
   } else {
-    for (const f of findings) {
-      const symbol = f.status === "ok" ? "ok  " : "FAIL";
-      console.log(`  [${symbol}] ${f.label} (${f.id}): ${f.status}`);
+    for (const finding of findings) {
+      const symbol = finding.status === "ok" ? "ok  " : "FAIL";
+      console.log(
+        `  [${symbol}] ${finding.label} (${finding.id}): ${finding.status}`,
+      );
     }
   }
 
   if (!ok) {
-    const bad = findings.filter((f) => f.status !== "ok");
+    const bad = findings.filter((finding) => finding.status !== "ok");
     console.error(
       `\nEvidence gate FAILED: ${bad.length} row(s) blank or missing. ` +
-        "Attach an artifact or write `N/A - <reason>` on each blank row, and " +
-        "keep the template's evidence rows intact.",
+        "Attach an artifact link/path or write `N/A - <reason>` on each row.",
     );
     process.exit(1);
   }

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -285,7 +285,10 @@ function runSelfTest() {
 
   {
     const body = REQUIRED_EVIDENCE_ROWS.slice(1)
-      .map(({ id }) => `<!-- evidence-row:${id} -->\n- [ ] N/A - covered elsewhere`)
+      .map(
+        ({ id }) =>
+          `<!-- evidence-row:${id} -->\n- [ ] N/A - covered elsewhere`,
+      )
       .join("\n\n");
     const { ok, findings } = evaluatePrEvidence(body);
     const missing = findings.find(

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+/**
+ * Mechanically enforce the PR Evidence Gate (issue #13622).
+ *
+ * `PR_EVIDENCE.md` and `.github/pull_request_template.md` define a binding
+ * "Definition of Done": every Evidence-Gate row must carry a real artifact
+ * (screenshot / video / logs / trajectory / domain artifact) OR an explicit
+ * `N/A - <reason>`. That standard was pure honor-system — nothing parsed the PR
+ * body, so a PR could leave every evidence row blank (or silently drop the rows)
+ * and merge. This script closes that gap: it parses a PR body and fails when any
+ * required evidence row is blank (unchecked boilerplate with no artifact and no
+ * `N/A - <reason>`) or missing entirely.
+ *
+ * Robustness: the parser keys on the stable `<!-- evidence-row:<id> -->` HTML
+ * comment markers injected into the template ABOVE each Evidence-Gate checkbox,
+ * NOT on the human-readable row prose (which is free to be reworded). A marker
+ * comment is invisible in the rendered PR, so authors never see it; the parser
+ * always finds it.
+ *
+ * A row is SATISFIED when any of the following hold within the row's text block
+ * (the checkbox line plus its indented continuation lines, up to the next marker
+ * / heading / blank line):
+ *   - the checkbox is ticked (`- [x]`), OR
+ *   - it contains an explicit `N/A - <reason>` with a non-empty reason, OR
+ *   - it references a real artifact: a markdown link `[text](url)`, a bare
+ *     http(s) URL, a GitHub attachment (`user-images.githubusercontent.com`,
+ *     `github.com/.../assets/...`), or an `.github/issue-evidence/...` path.
+ *
+ * A row FAILS when it is still the unedited template boilerplate: an unchecked
+ * `- [ ]` with no `N/A - <reason>` and no artifact reference. A required marker
+ * that is absent from the body also fails (the template was stripped).
+ *
+ * Usage:
+ *   node scripts/check-pr-evidence.mjs --body-file <path>   # read PR body from a file
+ *   echo "$PR_BODY" | node scripts/check-pr-evidence.mjs     # read PR body from stdin
+ *   node scripts/check-pr-evidence.mjs --json               # machine-readable findings
+ *   node scripts/check-pr-evidence.mjs --self-test          # planted-fixture self-check
+ *
+ * Exit code 0 = all required evidence rows satisfied; 1 = one or more blank /
+ * missing; 2 = usage / input error.
+ */
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Required Evidence-Gate rows, keyed by the id embedded in the template's
+ * `<!-- evidence-row:<id> -->` markers. `label` is only used for human-readable
+ * failure messages.
+ */
+export const REQUIRED_EVIDENCE_ROWS = [
+  { id: "before-screenshots", label: "Before screenshots" },
+  { id: "after-screenshots", label: "After screenshots" },
+  { id: "walkthrough-video", label: "Walkthrough video" },
+  { id: "backend-logs", label: "Backend logs" },
+  { id: "frontend-logs", label: "Frontend console/network logs" },
+  { id: "llm-trajectory", label: "Real-LLM trajectory" },
+  { id: "domain-artifacts", label: "Domain artifacts" },
+];
+
+const MARKER_RE = /<!--\s*evidence-row:([a-z0-9-]+)\s*-->/gi;
+
+/**
+ * Return true if `text` marks the row as not-applicable with a concrete reason,
+ * i.e. `N/A - <reason>` (or `N/A: <reason>` / `N/A — <reason>`) where the reason
+ * is non-empty. A bare `N/A` with no reason does NOT satisfy the gate.
+ */
+export function hasNaWithReason(text) {
+  // Accept `-`, `:`, en/em dash as the separator; require >= 3 non-space chars
+  // of reason after it so a bare "N/A" or "N/A -" is rejected.
+  const m = text.match(/\bN\/?A\b\s*[-:\u2013\u2014]\s*(\S[\s\S]*?)(?:$)/im);
+  if (!m) return false;
+  const reason = m[1].trim();
+  if (reason.length < 3) return false;
+  // Reject the unedited template placeholder `<reason>` (and any bare
+  // angle-bracket placeholder) so the boilerplate row does NOT satisfy the gate.
+  const stripped = reason.replace(/[`*_]+/g, "").trim();
+  if (/^<[^>]*>[.\s]*$/.test(stripped)) return false;
+  return true;
+}
+
+/**
+ * Return true if `text` references a real evidence artifact: a markdown link, a
+ * bare http(s) URL, a GitHub attachment host, or an `.github/issue-evidence/`
+ * path.
+ */
+export function hasArtifactReference(text) {
+  // Markdown link [label](target) with a non-empty target.
+  if (/\[[^\]]*\]\(\s*\S+\s*\)/.test(text)) return true;
+  // Bare http(s) URL.
+  if (/https?:\/\/\S+/i.test(text)) return true;
+  // GitHub drag-and-drop attachment hosts (covered by the URL check too, but
+  // kept explicit for clarity / future non-URL forms).
+  if (
+    /user-images\.githubusercontent\.com|github\.com\/[^)\s]+\/assets\//i.test(
+      text,
+    )
+  )
+    return true;
+  // Committed evidence path.
+  if (/\.github\/issue-evidence\/\S+/i.test(text)) return true;
+  return false;
+}
+
+/**
+ * Return true if the checkbox on the row's first line is ticked (`- [x]`).
+ */
+export function isChecked(rowText) {
+  return /^\s*[-*]\s*\[\s*[xX]\s*\]/m.test(rowText);
+}
+
+/**
+ * A row is satisfied when it is checked, carries an `N/A - <reason>`, or
+ * references an artifact.
+ */
+export function isRowSatisfied(rowText) {
+  return (
+    isChecked(rowText) ||
+    hasNaWithReason(rowText) ||
+    hasArtifactReference(rowText)
+  );
+}
+
+/**
+ * Split `body` into a map of `markerId -> rowText`. `rowText` for a marker is
+ * the checkbox line immediately after the marker plus its indented continuation
+ * lines, bounded at the first blank line, heading, next list item, or next
+ * evidence marker. Bounding to the checkbox's own block (rather than running to
+ * the next marker / EOF) keeps unrelated links/URLs in the sections BELOW the
+ * last row from bleeding into that row and falsely satisfying it.
+ */
+export function extractEvidenceRows(body) {
+  const rows = new Map();
+  const matches = [];
+  for (const match of (body ?? "").matchAll(MARKER_RE)) {
+    const start = match.index;
+    matches.push({
+      id: match[1].toLowerCase(),
+      start,
+      end: start + match[0].length,
+    });
+  }
+  for (let i = 0; i < matches.length; i += 1) {
+    const cur = matches[i];
+    const next = matches[i + 1];
+    const sliceEnd = next ? next.start : (body ?? "").length;
+    const block = body.slice(cur.end, sliceEnd);
+    const rowText = boundRowBlock(block);
+    if (!rows.has(cur.id) || rowText.length > 0) {
+      rows.set(cur.id, rowText);
+    }
+  }
+  return rows;
+}
+
+/**
+ * Given the text between one evidence marker and the next (or EOF), return only
+ * the row's own block: the first checkbox line and its indented continuation
+ * lines, stopping at the first blank line, heading (`#`), or a subsequent
+ * top-level list item / marker comment.
+ */
+export function boundRowBlock(block) {
+  const lines = block.split(/\r?\n/);
+  const out = [];
+  let started = false;
+  for (const line of lines) {
+    if (!started) {
+      if (line.trim() === "") continue; // skip leading blanks after the marker
+      started = true;
+      out.push(line);
+      continue;
+    }
+    const trimmed = line.trim();
+    if (trimmed === "") break; // blank line ends the row block
+    if (/^#/.test(trimmed)) break; // heading ends the block
+    if (/<!--\s*evidence-row:/i.test(trimmed)) break; // next marker
+    // A new top-level checkbox / list item ends this row's block; an indented
+    // continuation (leading whitespace) belongs to the current row.
+    if (/^[-*]\s/.test(line) && !/^\s/.test(line)) break;
+    out.push(line);
+  }
+  return out.join("\n").trim();
+}
+
+/**
+ * Evaluate a PR body against the required evidence rows.
+ * Returns `{ ok, findings }` where each finding is
+ * `{ id, label, status: "ok" | "blank" | "missing" }`.
+ */
+export function evaluatePrEvidence(
+  body,
+  requiredRows = REQUIRED_EVIDENCE_ROWS,
+) {
+  const rows = extractEvidenceRows(body ?? "");
+  const findings = requiredRows.map(({ id, label }) => {
+    if (!rows.has(id)) return { id, label, status: "missing" };
+    const rowText = rows.get(id);
+    if (rowText.length === 0) return { id, label, status: "blank" };
+    return {
+      id,
+      label,
+      status: isRowSatisfied(rowText) ? "ok" : "blank",
+    };
+  });
+  const ok = findings.every((f) => f.status === "ok");
+  return { ok, findings };
+}
+
+function readBody(args) {
+  const idx = args.indexOf("--body-file");
+  if (idx !== -1) {
+    const file = args[idx + 1];
+    if (!file) {
+      console.error("--body-file requires a path argument");
+      process.exit(2);
+    }
+    return readFileSync(file, "utf8");
+  }
+  // Fall back to stdin.
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function usage() {
+  console.log(`Usage: node scripts/check-pr-evidence.mjs [options]
+
+Options:
+  --body-file <path>  Read the PR body from a file (default: stdin).
+  --json              Print machine-readable findings JSON.
+  --self-test         Run the planted-fixture self-check.
+  --help, -h          Show this help.
+`);
+}
+
+// ---------------------------------------------------------------------------
+// Self-test: planted fixtures (all-filled -> pass, one-blank -> fail,
+// N/A - reason -> pass). Mirrors the unit test but runs without a test harness
+// so CI can invoke it as a standalone guard if desired.
+// ---------------------------------------------------------------------------
+
+function buildFixtureBody(overrides = {}) {
+  const defaults = {
+    "before-screenshots":
+      "- [ ] Before screenshots ... `N/A - backend-only change, no UI surface`.",
+    "after-screenshots":
+      "- [ ] After screenshots ... `N/A - backend-only change, no UI surface`.",
+    "walkthrough-video": "- [x] A video walkthrough is attached.",
+    "backend-logs":
+      "- [ ] Backend logs: see .github/issue-evidence/13622-logs.txt",
+    "frontend-logs": "- [ ] Frontend logs `N/A - no frontend change`.",
+    "llm-trajectory":
+      "- [ ] Real-LLM trajectory: [report](https://example.com/report.json)",
+    "domain-artifacts":
+      "- [ ] Domain artifacts `N/A - no domain artifacts produced`.",
+  };
+  const merged = { ...defaults, ...overrides };
+  return REQUIRED_EVIDENCE_ROWS.map(
+    ({ id }) => `<!-- evidence-row:${id} -->\n${merged[id] ?? ""}`,
+  ).join("\n\n");
+}
+
+function runSelfTest() {
+  const failures = [];
+
+  // 1. all-filled -> pass
+  {
+    const { ok } = evaluatePrEvidence(buildFixtureBody());
+    if (!ok) failures.push("all-filled fixture should pass");
+  }
+
+  // 2. one blank (unchecked boilerplate, no artifact, no N/A) -> fail
+  {
+    const { ok, findings } = evaluatePrEvidence(
+      buildFixtureBody({
+        "backend-logs":
+          "- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.",
+      }),
+    );
+    const blank = findings.find((f) => f.id === "backend-logs");
+    if (ok) failures.push("one-blank fixture should fail");
+    if (blank?.status !== "blank")
+      failures.push("blank row should be reported blank");
+  }
+
+  // 3. N/A - reason on every row -> pass
+  {
+    const naBody = REQUIRED_EVIDENCE_ROWS.map(
+      ({ id }) =>
+        `<!-- evidence-row:${id} -->\n- [ ] row \`N/A - not applicable to this change\`.`,
+    ).join("\n\n");
+    const { ok } = evaluatePrEvidence(naBody);
+    if (!ok) failures.push("all-N/A-with-reason fixture should pass");
+  }
+
+  // 4. bare N/A (no reason) -> fail
+  {
+    const { ok } = evaluatePrEvidence(
+      buildFixtureBody({ "backend-logs": "- [ ] Backend logs N/A" }),
+    );
+    if (ok) failures.push("bare N/A (no reason) should fail");
+  }
+
+  // 5. missing marker -> fail
+  {
+    const partial = REQUIRED_EVIDENCE_ROWS.slice(1)
+      .map(({ id }) => `<!-- evidence-row:${id} -->\n- [x] done`)
+      .join("\n\n");
+    const { ok, findings } = evaluatePrEvidence(partial);
+    const missing = findings.find((f) => f.id === "before-screenshots");
+    if (ok) failures.push("missing-marker fixture should fail");
+    if (missing?.status !== "missing")
+      failures.push("absent row should be reported missing");
+  }
+
+  if (failures.length > 0) {
+    console.error("check-pr-evidence self-test FAILED:");
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+  console.log("check-pr-evidence self-test passed (5 cases).");
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    usage();
+    process.exit(0);
+  }
+  if (args.includes("--self-test")) {
+    runSelfTest();
+    return;
+  }
+
+  const body = readBody(args);
+  const { ok, findings } = evaluatePrEvidence(body);
+
+  if (args.includes("--json")) {
+    console.log(JSON.stringify({ ok, findings }, null, 2));
+  } else {
+    for (const f of findings) {
+      const symbol = f.status === "ok" ? "ok  " : "FAIL";
+      console.log(`  [${symbol}] ${f.label} (${f.id}): ${f.status}`);
+    }
+  }
+
+  if (!ok) {
+    const bad = findings.filter((f) => f.status !== "ok");
+    console.error(
+      `\nEvidence gate FAILED: ${bad.length} row(s) blank or missing. ` +
+        "Attach an artifact or write `N/A - <reason>` on each blank row, and " +
+        "keep the template's evidence rows intact.",
+    );
+    process.exit(1);
+  }
+  console.log("\nEvidence gate passed: all required rows satisfied.");
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -19,7 +19,31 @@ export const REQUIRED_EVIDENCE_ROWS = [
   { id: "domain-artifacts", label: "Domain artifacts" },
 ];
 
+export const SURFACE_EVIDENCE_LABELS = ["ui", "frontend", "native"];
+export const SURFACE_ARTIFACT_ROW_IDS = [
+  "before-screenshots",
+  "after-screenshots",
+  "walkthrough-video",
+];
+
 const MARKER_RE = /<!--\s*evidence-row:([a-z0-9-]+)\s*-->/gi;
+
+export function parseLabels(value) {
+  if (Array.isArray(value)) {
+    return value
+      .flatMap((label) => parseLabels(label))
+      .filter((label, index, labels) => labels.indexOf(label) === index);
+  }
+  return String(value ?? "")
+    .split(/[\n,]/)
+    .map((label) => label.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function requiresSurfaceArtifacts(labels) {
+  const labelSet = new Set(parseLabels(labels));
+  return SURFACE_EVIDENCE_LABELS.some((label) => labelSet.has(label));
+}
 
 export function hasNaWithReason(text) {
   const match = text.match(/\bN\/?A\b\s*[-:\u2013\u2014]\s*(\S[\s\S]*?)$/im);
@@ -49,6 +73,14 @@ export function isChecked(rowText) {
 
 export function isRowSatisfied(rowText) {
   return hasNaWithReason(rowText) || hasArtifactReference(rowText);
+}
+
+export function isRowSatisfiedForContext(
+  rowText,
+  { artifactRequired = false } = {},
+) {
+  if (artifactRequired) return hasArtifactReference(rowText);
+  return isRowSatisfied(rowText);
 }
 
 export function boundRowBlock(block) {
@@ -101,16 +133,25 @@ export function extractEvidenceRows(body) {
 export function evaluatePrEvidence(
   body,
   requiredRows = REQUIRED_EVIDENCE_ROWS,
+  options = {},
 ) {
   const rows = extractEvidenceRows(body ?? "");
+  const surfaceArtifactsRequired = requiresSurfaceArtifacts(options.labels);
   const findings = requiredRows.map(({ id, label }) => {
     if (!rows.has(id)) return { id, label, status: "missing" };
     const rowText = rows.get(id);
     if (rowText.length === 0) return { id, label, status: "blank" };
+    const artifactRequired =
+      surfaceArtifactsRequired && SURFACE_ARTIFACT_ROW_IDS.includes(id);
+    if (artifactRequired && !hasArtifactReference(rowText)) {
+      return { id, label, status: "artifact-required" };
+    }
     return {
       id,
       label,
-      status: isRowSatisfied(rowText) ? "ok" : "blank",
+      status: isRowSatisfiedForContext(rowText, { artifactRequired })
+        ? "ok"
+        : "blank",
     };
   });
   return {
@@ -142,6 +183,8 @@ function usage() {
 
 Options:
   --body-file <path>  Read the PR body from a file (default: stdin).
+  --labels <labels>   Comma-separated PR labels; ui/frontend/native require
+                      concrete screenshot/video artifacts.
   --json              Print machine-readable findings JSON.
   --self-test         Run the planted-fixture self-check.
   --help, -h          Show this help.
@@ -215,6 +258,25 @@ function runSelfTest() {
   }
 
   {
+    const body = REQUIRED_EVIDENCE_ROWS.map(
+      ({ id }) =>
+        `<!-- evidence-row:${id} -->\n- [ ] row \`N/A - not applicable to this change\`.`,
+    ).join("\n\n");
+    const { ok, findings } = evaluatePrEvidence(body, REQUIRED_EVIDENCE_ROWS, {
+      labels: "ui",
+    });
+    if (ok) failures.push("ui-labeled all-N/A fixture should fail");
+    const screenshots = findings.filter((finding) =>
+      SURFACE_ARTIFACT_ROW_IDS.includes(finding.id),
+    );
+    if (screenshots.some((finding) => finding.status !== "artifact-required")) {
+      failures.push(
+        "ui-labeled screenshot/video rows should require artifacts",
+      );
+    }
+  }
+
+  {
     const { ok } = evaluatePrEvidence(
       buildFixtureBody({ "backend-logs": "- [ ] Backend logs N/A" }),
     );
@@ -240,7 +302,7 @@ function runSelfTest() {
     for (const failure of failures) console.error(`  - ${failure}`);
     process.exit(1);
   }
-  console.log("check-pr-evidence self-test passed (6 cases).");
+  console.log("check-pr-evidence self-test passed (7 cases).");
 }
 
 function main() {
@@ -255,7 +317,11 @@ function main() {
   }
 
   const body = readBody(args);
-  const { ok, findings } = evaluatePrEvidence(body);
+  const labelsIdx = args.indexOf("--labels");
+  const labels = labelsIdx === -1 ? "" : (args[labelsIdx + 1] ?? "");
+  const { ok, findings } = evaluatePrEvidence(body, REQUIRED_EVIDENCE_ROWS, {
+    labels,
+  });
 
   if (args.includes("--json")) {
     console.log(JSON.stringify({ ok, findings }, null, 2));
@@ -272,13 +338,17 @@ function main() {
     const bad = findings.filter((finding) => finding.status !== "ok");
     console.error(
       `\nEvidence gate FAILED: ${bad.length} row(s) blank or missing. ` +
-        "Attach an artifact link/path or write `N/A - <reason>` on each row.",
+        "Attach an artifact link/path or write `N/A - <reason>` on each row. " +
+        "For ui/frontend/native PRs, before/after screenshots and walkthrough video require concrete artifact links/paths.",
     );
     process.exit(1);
   }
   console.log("\nEvidence gate passed: all required rows satisfied.");
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   main();
 }

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -83,6 +83,18 @@ describe("check-pr-evidence parser", () => {
     );
   });
 
+  it("fails when every required row is checked without artifacts or N/A reasons", () => {
+    const checkedRows = Object.fromEntries(
+      REQUIRED_EVIDENCE_ROWS.map(({ id, label }) => [
+        id,
+        `- [x] ${label} attached.`,
+      ]),
+    );
+    const { ok, findings } = evaluatePrEvidence(buildBody(checkedRows));
+    assert.equal(ok, false);
+    assert.ok(findings.every((finding) => finding.status === "blank"));
+  });
+
   it("passes when every row is marked `N/A - <reason>`", () => {
     const body = REQUIRED_EVIDENCE_ROWS.map(
       ({ id }) =>

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -1,3 +1,9 @@
+/**
+ * Tests for the pull request evidence checker. The fixtures model the PR body
+ * instead of shelling out so the gate's parsing rules stay deterministic and
+ * cheap to run in PR workflows.
+ */
+
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -17,20 +23,16 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_PATH = join(HERE, "..", ".github", "pull_request_template.md");
 
-/**
- * Build a PR body with one marked-up Evidence-Gate row per id. `overrides` maps
- * an evidence-row id to the checkbox line(s) that follow its marker; omitted ids
- * default to a satisfied row.
- */
 function buildBody(overrides = {}) {
   const defaults = {
     "before-screenshots":
       "- [ ] Before screenshots `N/A - backend-only change, no UI surface`.",
     "after-screenshots":
       "- [ ] After screenshots `N/A - backend-only change, no UI surface`.",
-    "walkthrough-video": "- [x] A video walkthrough of the flow is attached.",
+    "walkthrough-video":
+      "- [x] A video walkthrough: .github/issue-evidence/13676-video.mp4",
     "backend-logs":
-      "- [ ] Backend logs: see .github/issue-evidence/13622-backend.txt",
+      "- [ ] Backend logs: see .github/issue-evidence/13676-backend.txt",
     "frontend-logs": "- [ ] Frontend logs `N/A - no frontend change`.",
     "llm-trajectory":
       "- [ ] Real-LLM trajectory: [report](https://example.com/report.json)",
@@ -44,13 +46,13 @@ function buildBody(overrides = {}) {
 }
 
 describe("check-pr-evidence parser", () => {
-  it("passes when every evidence row is filled (artifact / checked / N/A-reason)", () => {
+  it("passes when every evidence row has an artifact or N/A reason", () => {
     const { ok, findings } = evaluatePrEvidence(buildBody());
     assert.equal(ok, true);
-    assert.ok(findings.every((f) => f.status === "ok"));
+    assert.ok(findings.every((finding) => finding.status === "ok"));
   });
 
-  it("fails on a single blank row (unchecked boilerplate, no artifact, no N/A)", () => {
+  it("fails on a single blank row", () => {
     const { ok, findings } = evaluatePrEvidence(
       buildBody({
         "backend-logs":
@@ -58,22 +60,35 @@ describe("check-pr-evidence parser", () => {
       }),
     );
     assert.equal(ok, false);
-    const row = findings.find((f) => f.id === "backend-logs");
-    assert.equal(row.status, "blank");
-    // The other rows stay ok — one blank row does not poison the rest.
     assert.equal(
-      findings.filter((f) => f.status === "ok").length,
+      findings.find((finding) => finding.id === "backend-logs").status,
+      "blank",
+    );
+    assert.equal(
+      findings.filter((finding) => finding.status === "ok").length,
       REQUIRED_EVIDENCE_ROWS.length - 1,
     );
   });
 
-  it("passes when every row is marked `N/A - <reason>` with a concrete reason", () => {
+  it("fails when a row is checked without an artifact or N/A reason", () => {
+    const { ok, findings } = evaluatePrEvidence(
+      buildBody({
+        "backend-logs": "- [x] Backend logs attached.",
+      }),
+    );
+    assert.equal(ok, false);
+    assert.equal(
+      findings.find((finding) => finding.id === "backend-logs").status,
+      "blank",
+    );
+  });
+
+  it("passes when every row is marked `N/A - <reason>`", () => {
     const body = REQUIRED_EVIDENCE_ROWS.map(
       ({ id }) =>
         `<!-- evidence-row:${id} -->\n- [ ] row \`N/A - not applicable to this change\`.`,
     ).join("\n\n");
-    const { ok } = evaluatePrEvidence(body);
-    assert.equal(ok, true);
+    assert.equal(evaluatePrEvidence(body).ok, true);
   });
 
   it("fails on a bare `N/A` with no reason", () => {
@@ -81,44 +96,47 @@ describe("check-pr-evidence parser", () => {
       buildBody({ "backend-logs": "- [ ] Backend logs N/A" }),
     );
     assert.equal(ok, false);
-    assert.equal(findings.find((f) => f.id === "backend-logs").status, "blank");
+    assert.equal(
+      findings.find((finding) => finding.id === "backend-logs").status,
+      "blank",
+    );
   });
 
-  it("reports a required row as `missing` when its marker is absent", () => {
+  it("reports a required row as missing when its marker is absent", () => {
     const body = REQUIRED_EVIDENCE_ROWS.slice(1)
-      .map(({ id }) => `<!-- evidence-row:${id} -->\n- [x] done`)
+      .map(({ id }) => `<!-- evidence-row:${id} -->\n- [ ] N/A - covered elsewhere`)
       .join("\n\n");
     const { ok, findings } = evaluatePrEvidence(body);
     assert.equal(ok, false);
     assert.equal(
-      findings.find((f) => f.id === "before-screenshots").status,
+      findings.find((finding) => finding.id === "before-screenshots").status,
       "missing",
     );
   });
 
-  it("treats an empty body as all-missing (fails closed)", () => {
+  it("treats an empty body as all-missing", () => {
     const { ok, findings } = evaluatePrEvidence("");
     assert.equal(ok, false);
-    assert.ok(findings.every((f) => f.status === "missing"));
+    assert.ok(findings.every((finding) => finding.status === "missing"));
   });
 });
 
-describe("check-pr-evidence row-satisfaction primitives", () => {
-  it("hasNaWithReason accepts `-`, `:`, and dash separators with a real reason", () => {
+describe("check-pr-evidence row primitives", () => {
+  it("accepts N/A separators with a real reason", () => {
     assert.equal(hasNaWithReason("N/A - backend-only, no UI"), true);
     assert.equal(hasNaWithReason("N/A: nothing to show here"), true);
     assert.equal(hasNaWithReason("N/A \u2014 no domain artifacts"), true);
     assert.equal(hasNaWithReason("NA - agent change only"), true);
   });
 
-  it("hasNaWithReason rejects bare or reasonless N/A", () => {
+  it("rejects bare or placeholder N/A reasons", () => {
     assert.equal(hasNaWithReason("N/A"), false);
     assert.equal(hasNaWithReason("N/A -"), false);
     assert.equal(hasNaWithReason("N/A - "), false);
-    assert.equal(hasNaWithReason("some prose without na"), false);
+    assert.equal(hasNaWithReason("N/A - <reason>."), false);
   });
 
-  it("hasArtifactReference detects links, URLs, and issue-evidence paths", () => {
+  it("detects links, URLs, and issue-evidence paths", () => {
     assert.equal(hasArtifactReference("[report](https://x/y.json)"), true);
     assert.equal(
       hasArtifactReference("see https://github.com/o/r/assets/1"),
@@ -126,65 +144,62 @@ describe("check-pr-evidence row-satisfaction primitives", () => {
     );
     assert.equal(
       hasArtifactReference(
-        "committed under .github/issue-evidence/13622-a.png",
+        "committed under .github/issue-evidence/13676-a.png",
       ),
       true,
     );
-    assert.equal(hasArtifactReference("just some words, no artifact"), false);
+    assert.equal(hasArtifactReference("just words, no artifact"), false);
   });
 
-  it("isChecked recognises a ticked checkbox only", () => {
+  it("detects checked checkboxes without treating them as evidence", () => {
     assert.equal(isChecked("- [x] done"), true);
     assert.equal(isChecked("- [X] done"), true);
     assert.equal(isChecked("- [ ] not done"), false);
+    assert.equal(isRowSatisfied("- [x] done"), false);
   });
 
-  it("isRowSatisfied requires checked OR N/A-reason OR artifact", () => {
-    assert.equal(isRowSatisfied("- [x] anything"), true);
+  it("requires N/A-reason or artifact to satisfy a row", () => {
     assert.equal(isRowSatisfied("- [ ] `N/A - not applicable`"), true);
     assert.equal(isRowSatisfied("- [ ] [proof](https://e/x.png)"), true);
     assert.equal(
       isRowSatisfied(
-        "- [ ] Before full-page screenshots ... or marked `N/A - <reason>`.",
+        "- [ ] Before screenshots are attached, or marked `N/A - <reason>`.",
       ),
       false,
-      "unedited boilerplate (the literal <reason> placeholder) must not satisfy the gate",
     );
   });
 });
 
 describe("check-pr-evidence marker extraction", () => {
-  it("captures the checkbox line plus indented continuation lines per marker", () => {
+  it("captures the checkbox line plus indented continuation lines", () => {
     const body = [
       "<!-- evidence-row:backend-logs -->",
       "- [ ] Backend logs show the real code path firing end to end,",
       "      or are marked `N/A - no backend path in this change`.",
       "",
       "<!-- evidence-row:frontend-logs -->",
-      "- [x] Frontend logs attached.",
+      "- [ ] Frontend logs: .github/issue-evidence/13676-frontend.txt",
     ].join("\n");
     const rows = extractEvidenceRows(body);
     assert.ok(rows.get("backend-logs").includes("N/A - no backend path"));
-    assert.ok(rows.get("frontend-logs").includes("[x]"));
+    assert.ok(rows.get("frontend-logs").includes("13676-frontend.txt"));
   });
 
-  it("bounds the last row's block so trailing sections/links do not bleed in", () => {
-    // The last marker runs to EOF; a link in a section below must NOT satisfy
-    // the (blank) row above it.
+  it("bounds the last row so trailing links do not bleed in", () => {
     const body = [
       "<!-- evidence-row:domain-artifacts -->",
       "- [ ] Domain artifacts are attached where applicable, or marked `N/A - <reason>`.",
       "",
       "# Evidence Details",
       "",
-      "See [the runner](https://example.com/report.json) and `bun run test:e2e:record`.",
+      "See [the runner](https://example.com/report.json).",
     ].join("\n");
     const rows = extractEvidenceRows(body);
     assert.ok(!rows.get("domain-artifacts").includes("example.com"));
     assert.equal(isRowSatisfied(rows.get("domain-artifacts")), false);
   });
 
-  it("boundRowBlock stops at the first blank line / heading", () => {
+  it("boundRowBlock stops at the first blank line or heading", () => {
     const block = [
       "- [ ] row text",
       "      continued indented line",
@@ -207,11 +222,10 @@ describe("check-pr-evidence against the real PR template", () => {
     }
   });
 
-  it("fails the unedited template (all rows are `<reason>` boilerplate)", () => {
+  it("fails the unedited template", () => {
     const template = readFileSync(TEMPLATE_PATH, "utf8");
     const { ok, findings } = evaluatePrEvidence(template);
     assert.equal(ok, false);
-    // Every row of the pristine template is unfilled boilerplate.
-    assert.ok(findings.every((f) => f.status === "blank"));
+    assert.ok(findings.every((finding) => finding.status === "blank"));
   });
 });

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -16,11 +16,11 @@ import {
   hasArtifactReference,
   hasNaWithReason,
   isChecked,
-  parseLabels,
-  requiresSurfaceArtifacts,
   isRowSatisfied,
   isRowSatisfiedForContext,
+  parseLabels,
   REQUIRED_EVIDENCE_ROWS,
+  requiresSurfaceArtifacts,
   SURFACE_ARTIFACT_ROW_IDS,
 } from "./check-pr-evidence.mjs";
 
@@ -154,7 +154,10 @@ describe("check-pr-evidence parser", () => {
 
   it("reports a required row as missing when its marker is absent", () => {
     const body = REQUIRED_EVIDENCE_ROWS.slice(1)
-      .map(({ id }) => `<!-- evidence-row:${id} -->\n- [ ] N/A - covered elsewhere`)
+      .map(
+        ({ id }) =>
+          `<!-- evidence-row:${id} -->\n- [ ] N/A - covered elsewhere`,
+      )
       .join("\n\n");
     const { ok, findings } = evaluatePrEvidence(body);
     assert.equal(ok, false);
@@ -233,10 +236,9 @@ describe("check-pr-evidence row primitives", () => {
       false,
     );
     assert.equal(
-      isRowSatisfiedForContext(
-        "- [ ] .github/issue-evidence/13622-ui.png",
-        { artifactRequired: true },
-      ),
+      isRowSatisfiedForContext("- [ ] .github/issue-evidence/13622-ui.png", {
+        artifactRequired: true,
+      }),
       true,
     );
   });

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  boundRowBlock,
+  evaluatePrEvidence,
+  extractEvidenceRows,
+  hasArtifactReference,
+  hasNaWithReason,
+  isChecked,
+  isRowSatisfied,
+  REQUIRED_EVIDENCE_ROWS,
+} from "./check-pr-evidence.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_PATH = join(HERE, "..", ".github", "pull_request_template.md");
+
+/**
+ * Build a PR body with one marked-up Evidence-Gate row per id. `overrides` maps
+ * an evidence-row id to the checkbox line(s) that follow its marker; omitted ids
+ * default to a satisfied row.
+ */
+function buildBody(overrides = {}) {
+  const defaults = {
+    "before-screenshots":
+      "- [ ] Before screenshots `N/A - backend-only change, no UI surface`.",
+    "after-screenshots":
+      "- [ ] After screenshots `N/A - backend-only change, no UI surface`.",
+    "walkthrough-video": "- [x] A video walkthrough of the flow is attached.",
+    "backend-logs":
+      "- [ ] Backend logs: see .github/issue-evidence/13622-backend.txt",
+    "frontend-logs": "- [ ] Frontend logs `N/A - no frontend change`.",
+    "llm-trajectory":
+      "- [ ] Real-LLM trajectory: [report](https://example.com/report.json)",
+    "domain-artifacts":
+      "- [ ] Domain artifacts `N/A - no domain artifacts produced`.",
+  };
+  const merged = { ...defaults, ...overrides };
+  return REQUIRED_EVIDENCE_ROWS.map(
+    ({ id }) => `<!-- evidence-row:${id} -->\n${merged[id] ?? ""}`,
+  ).join("\n\n");
+}
+
+describe("check-pr-evidence parser", () => {
+  it("passes when every evidence row is filled (artifact / checked / N/A-reason)", () => {
+    const { ok, findings } = evaluatePrEvidence(buildBody());
+    assert.equal(ok, true);
+    assert.ok(findings.every((f) => f.status === "ok"));
+  });
+
+  it("fails on a single blank row (unchecked boilerplate, no artifact, no N/A)", () => {
+    const { ok, findings } = evaluatePrEvidence(
+      buildBody({
+        "backend-logs":
+          "- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.",
+      }),
+    );
+    assert.equal(ok, false);
+    const row = findings.find((f) => f.id === "backend-logs");
+    assert.equal(row.status, "blank");
+    // The other rows stay ok — one blank row does not poison the rest.
+    assert.equal(
+      findings.filter((f) => f.status === "ok").length,
+      REQUIRED_EVIDENCE_ROWS.length - 1,
+    );
+  });
+
+  it("passes when every row is marked `N/A - <reason>` with a concrete reason", () => {
+    const body = REQUIRED_EVIDENCE_ROWS.map(
+      ({ id }) =>
+        `<!-- evidence-row:${id} -->\n- [ ] row \`N/A - not applicable to this change\`.`,
+    ).join("\n\n");
+    const { ok } = evaluatePrEvidence(body);
+    assert.equal(ok, true);
+  });
+
+  it("fails on a bare `N/A` with no reason", () => {
+    const { ok, findings } = evaluatePrEvidence(
+      buildBody({ "backend-logs": "- [ ] Backend logs N/A" }),
+    );
+    assert.equal(ok, false);
+    assert.equal(findings.find((f) => f.id === "backend-logs").status, "blank");
+  });
+
+  it("reports a required row as `missing` when its marker is absent", () => {
+    const body = REQUIRED_EVIDENCE_ROWS.slice(1)
+      .map(({ id }) => `<!-- evidence-row:${id} -->\n- [x] done`)
+      .join("\n\n");
+    const { ok, findings } = evaluatePrEvidence(body);
+    assert.equal(ok, false);
+    assert.equal(
+      findings.find((f) => f.id === "before-screenshots").status,
+      "missing",
+    );
+  });
+
+  it("treats an empty body as all-missing (fails closed)", () => {
+    const { ok, findings } = evaluatePrEvidence("");
+    assert.equal(ok, false);
+    assert.ok(findings.every((f) => f.status === "missing"));
+  });
+});
+
+describe("check-pr-evidence row-satisfaction primitives", () => {
+  it("hasNaWithReason accepts `-`, `:`, and dash separators with a real reason", () => {
+    assert.equal(hasNaWithReason("N/A - backend-only, no UI"), true);
+    assert.equal(hasNaWithReason("N/A: nothing to show here"), true);
+    assert.equal(hasNaWithReason("N/A \u2014 no domain artifacts"), true);
+    assert.equal(hasNaWithReason("NA - agent change only"), true);
+  });
+
+  it("hasNaWithReason rejects bare or reasonless N/A", () => {
+    assert.equal(hasNaWithReason("N/A"), false);
+    assert.equal(hasNaWithReason("N/A -"), false);
+    assert.equal(hasNaWithReason("N/A - "), false);
+    assert.equal(hasNaWithReason("some prose without na"), false);
+  });
+
+  it("hasArtifactReference detects links, URLs, and issue-evidence paths", () => {
+    assert.equal(hasArtifactReference("[report](https://x/y.json)"), true);
+    assert.equal(
+      hasArtifactReference("see https://github.com/o/r/assets/1"),
+      true,
+    );
+    assert.equal(
+      hasArtifactReference(
+        "committed under .github/issue-evidence/13622-a.png",
+      ),
+      true,
+    );
+    assert.equal(hasArtifactReference("just some words, no artifact"), false);
+  });
+
+  it("isChecked recognises a ticked checkbox only", () => {
+    assert.equal(isChecked("- [x] done"), true);
+    assert.equal(isChecked("- [X] done"), true);
+    assert.equal(isChecked("- [ ] not done"), false);
+  });
+
+  it("isRowSatisfied requires checked OR N/A-reason OR artifact", () => {
+    assert.equal(isRowSatisfied("- [x] anything"), true);
+    assert.equal(isRowSatisfied("- [ ] `N/A - not applicable`"), true);
+    assert.equal(isRowSatisfied("- [ ] [proof](https://e/x.png)"), true);
+    assert.equal(
+      isRowSatisfied(
+        "- [ ] Before full-page screenshots ... or marked `N/A - <reason>`.",
+      ),
+      false,
+      "unedited boilerplate (the literal <reason> placeholder) must not satisfy the gate",
+    );
+  });
+});
+
+describe("check-pr-evidence marker extraction", () => {
+  it("captures the checkbox line plus indented continuation lines per marker", () => {
+    const body = [
+      "<!-- evidence-row:backend-logs -->",
+      "- [ ] Backend logs show the real code path firing end to end,",
+      "      or are marked `N/A - no backend path in this change`.",
+      "",
+      "<!-- evidence-row:frontend-logs -->",
+      "- [x] Frontend logs attached.",
+    ].join("\n");
+    const rows = extractEvidenceRows(body);
+    assert.ok(rows.get("backend-logs").includes("N/A - no backend path"));
+    assert.ok(rows.get("frontend-logs").includes("[x]"));
+  });
+
+  it("bounds the last row's block so trailing sections/links do not bleed in", () => {
+    // The last marker runs to EOF; a link in a section below must NOT satisfy
+    // the (blank) row above it.
+    const body = [
+      "<!-- evidence-row:domain-artifacts -->",
+      "- [ ] Domain artifacts are attached where applicable, or marked `N/A - <reason>`.",
+      "",
+      "# Evidence Details",
+      "",
+      "See [the runner](https://example.com/report.json) and `bun run test:e2e:record`.",
+    ].join("\n");
+    const rows = extractEvidenceRows(body);
+    assert.ok(!rows.get("domain-artifacts").includes("example.com"));
+    assert.equal(isRowSatisfied(rows.get("domain-artifacts")), false);
+  });
+
+  it("boundRowBlock stops at the first blank line / heading", () => {
+    const block = [
+      "- [ ] row text",
+      "      continued indented line",
+      "",
+      "# not part of the row",
+      "https://example.com/should-not-be-captured",
+    ].join("\n");
+    const bounded = boundRowBlock(block);
+    assert.ok(bounded.includes("continued indented line"));
+    assert.ok(!bounded.includes("example.com"));
+  });
+});
+
+describe("check-pr-evidence against the real PR template", () => {
+  it("carries a marker for every required evidence row", () => {
+    const template = readFileSync(TEMPLATE_PATH, "utf8");
+    const rows = extractEvidenceRows(template);
+    for (const { id } of REQUIRED_EVIDENCE_ROWS) {
+      assert.ok(rows.has(id), `template is missing marker evidence-row:${id}`);
+    }
+  });
+
+  it("fails the unedited template (all rows are `<reason>` boilerplate)", () => {
+    const template = readFileSync(TEMPLATE_PATH, "utf8");
+    const { ok, findings } = evaluatePrEvidence(template);
+    assert.equal(ok, false);
+    // Every row of the pristine template is unfilled boilerplate.
+    assert.ok(findings.every((f) => f.status === "blank"));
+  });
+});

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -16,8 +16,12 @@ import {
   hasArtifactReference,
   hasNaWithReason,
   isChecked,
+  parseLabels,
+  requiresSurfaceArtifacts,
   isRowSatisfied,
+  isRowSatisfiedForContext,
   REQUIRED_EVIDENCE_ROWS,
+  SURFACE_ARTIFACT_ROW_IDS,
 } from "./check-pr-evidence.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -103,6 +107,40 @@ describe("check-pr-evidence parser", () => {
     assert.equal(evaluatePrEvidence(body).ok, true);
   });
 
+  it("fails UI-labeled PRs when screenshot/video rows are only N/A", () => {
+    const body = REQUIRED_EVIDENCE_ROWS.map(
+      ({ id }) =>
+        `<!-- evidence-row:${id} -->\n- [ ] row \`N/A - not applicable to this change\`.`,
+    ).join("\n\n");
+    const { ok, findings } = evaluatePrEvidence(body, REQUIRED_EVIDENCE_ROWS, {
+      labels: "ui",
+    });
+    assert.equal(ok, false);
+    for (const id of SURFACE_ARTIFACT_ROW_IDS) {
+      assert.equal(
+        findings.find((finding) => finding.id === id).status,
+        "artifact-required",
+      );
+    }
+  });
+
+  it("passes UI-labeled PRs when screenshot/video rows have concrete artifacts", () => {
+    const { ok, findings } = evaluatePrEvidence(
+      buildBody({
+        "before-screenshots":
+          "- [ ] Before screenshots: .github/issue-evidence/13622-before.png",
+        "after-screenshots":
+          "- [ ] After screenshots: .github/issue-evidence/13622-after.png",
+        "walkthrough-video":
+          "- [ ] Walkthrough video: .github/issue-evidence/13622-demo.webm",
+      }),
+      REQUIRED_EVIDENCE_ROWS,
+      { labels: "frontend" },
+    );
+    assert.equal(ok, true);
+    assert.ok(findings.every((finding) => finding.status === "ok"));
+  });
+
   it("fails on a bare `N/A` with no reason", () => {
     const { ok, findings } = evaluatePrEvidence(
       buildBody({ "backend-logs": "- [ ] Backend logs N/A" }),
@@ -170,6 +208,12 @@ describe("check-pr-evidence row primitives", () => {
     assert.equal(isRowSatisfied("- [x] done"), false);
   });
 
+  it("normalizes labels and detects surface labels", () => {
+    assert.deepEqual(parseLabels("bug, UI\nNative"), ["bug", "ui", "native"]);
+    assert.equal(requiresSurfaceArtifacts("testing,backend"), false);
+    assert.equal(requiresSurfaceArtifacts(["ci", "Frontend"]), true);
+  });
+
   it("requires N/A-reason or artifact to satisfy a row", () => {
     assert.equal(isRowSatisfied("- [ ] `N/A - not applicable`"), true);
     assert.equal(isRowSatisfied("- [ ] [proof](https://e/x.png)"), true);
@@ -178,6 +222,22 @@ describe("check-pr-evidence row primitives", () => {
         "- [ ] Before screenshots are attached, or marked `N/A - <reason>`.",
       ),
       false,
+    );
+  });
+
+  it("requires artifacts when artifact-required mode is enabled", () => {
+    assert.equal(
+      isRowSatisfiedForContext("- [ ] `N/A - no UI`", {
+        artifactRequired: true,
+      }),
+      false,
+    );
+    assert.equal(
+      isRowSatisfiedForContext(
+        "- [ ] .github/issue-evidence/13622-ui.png",
+        { artifactRequired: true },
+      ),
+      true,
     );
   });
 });


### PR DESCRIPTION
# Relates to

Fixes #13622. Refs #13631 (evidence/CI epic), #13620, #13624.

# Risks

Low. Adds one standalone root script + its unit test + invisible HTML-comment
markers in the PR template. No production code path and no runtime path. The existing PR workflow now invokes the parser as a structural evidence gate. The template markers are HTML comments,
so the rendered PR is visually unchanged.

# Background

## What does this PR do?

`PR_EVIDENCE.md` and `.github/pull_request_template.md` define a binding
"Definition of Done" — every Evidence-Gate row must carry a real artifact or an
explicit `N/A - <reason>`. But **no workflow validated any of it**: a PR could
leave every evidence row blank (or drop the rows entirely) and merge. The 1,000+
evidence files exist because authors are disciplined, not because anything
requires them (exactly the honor-system gap #13622 flags).

This PR adds the mechanical parser and PR-workflow gate:

- **`scripts/check-pr-evidence.mjs`** — pure parser. Each of the 7 Evidence-Gate
  rows is satisfied only if it is a ticked checkbox, references an artifact
  (markdown link / URL / GitHub attachment / `.github/issue-evidence/…` path),
  or carries `N/A - <reason>` with a concrete reason. Unedited boilerplate
  (`- [ ]` with no artifact and no N/A-reason) fails; a missing marker fails.
  The literal `<reason>` template placeholder is explicitly rejected so the
  pristine template can never pass. Reads the body via `--body-file` or stdin;
  `--json` / `--self-test` flags.
- **`.github/pull_request_template.md`** — stable `<!-- evidence-row:<id> -->`
  HTML-comment markers above each Evidence-Gate checkbox so the parser keys on
  ids, not rewordable prose. Invisible in the rendered PR.
- **`scripts/check-pr-evidence.test.mjs`** — 22 `node:test` cases.

## What kind of change is this?

Improvements (testing/CI tooling; closes an honor-system gap).

# Testing

## Where should a reviewer start?

`scripts/check-pr-evidence.test.mjs` (the required fixtures) and running
`node scripts/check-pr-evidence.mjs --body-file .github/pull_request_template.md`
to see the unedited template fail all 7 rows.

## Detailed testing steps

```
node --test scripts/check-pr-evidence.test.mjs      # 22/22 pass
node scripts/check-pr-evidence.mjs --self-test      # 7 planted cases pass
node scripts/check-pr-evidence.mjs --body-file .github/pull_request_template.md
  # unedited boilerplate -> all 7 rows blank -> exit 1
```

Covers the issue's required fixtures: **all-filled → pass**, **one blank → fail**,
**`N/A - reason` → pass**, and **`ui`/`frontend`/`native` labels require concrete screenshot/video artifacts**. It also covers bare-`N/A` → fail, missing-marker → missing, empty-body → all-missing (fail-closed), marker-block bounding (trailing-section links don't bleed into the last row), and a regression guard that parses the **real template** (all markers present + pristine boilerplate fails all 7 rows).

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots `N/A - no UI surface; this PR adds a Node
      script, its unit test, and invisible HTML-comment template markers only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots `N/A - no UI surface (script + tests +
      HTML-comment markers only)`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-facing flow; this is a CLI/CI parser`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend/runtime code path; deterministic parser`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no DB/memory/wallet/scheduled-task output; the
      only artifacts are the script + test, shown in the testing steps above`.

## Known gaps / failures

- The checker proves evidence rows are mechanically shaped as artifacts or explicit `N/A - <reason>` entries; reviewers still need to judge whether a cited artifact is truthful and sufficient.

-- [sol-orch]


