### PR TITLE
fix(#13620): stop the no-tests skip from swallowing real test failures

### DIFF
--- a/packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
+++ b/packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
@@ -32,6 +32,21 @@ const TEMP_PACKAGE_DIR = join(
   "packages",
   "__run_all_tests_false_no_test_skip__",
 );
+// A second temp package whose `test` script is a SINGLE `bun test <file>`
+// invocation — i.e. one that canSkipWhenOutputHasNoTests() treats as
+// no-test-skippable. This is the code path #13620 task 4 is about: a skippable
+// runner command whose merged output carries BOTH a no-tests banner AND a
+// genuine failure must NOT be reclassified as SKIP=green.
+const SKIPPABLE_MIXED_PACKAGE_DIR = join(
+  repoRoot,
+  "packages",
+  "__run_all_tests_mixed_no_test_and_fail__",
+);
+const SKIPPABLE_EMPTY_PACKAGE_DIR = join(
+  repoRoot,
+  "packages",
+  "__run_all_tests_genuinely_no_tests__",
+);
 
 // Each case spawns the real runner (workspace discovery over the whole repo),
 // so give bun headroom well past the discovery cost on a cold/contended runner.
@@ -177,6 +192,201 @@ describe("run-all-tests --min-tasks vacuous-green guard", () => {
         );
       } finally {
         rmSync(TEMP_PACKAGE_DIR, { recursive: true, force: true });
+      }
+    },
+    SPAWN_TIMEOUT_MS,
+  );
+});
+
+// #13620 task 4: the no-tests-skip reclassification must be narrowed so a
+// non-zero exit whose output ALSO carries a genuine failure signal is not
+// swallowed as SKIP=green. Distinct from the `--min-tasks` guard (task 3,
+// #12342) pinned above, and from the existing "arbitrary failing script" case
+// whose fixture command is not no-test-skippable (so it never reached the
+// swallow branch). These fixtures use a SINGLE `bun test <file>` command, which
+// canSkipWhenOutputHasNoTests() does treat as skippable, so they exercise the
+// exact branch that used to swallow the failure.
+describe("run-all-tests no-test-skip failure-swallow guard (#13620)", () => {
+  test(
+    "a skippable bun-test lane emitting a no-tests banner AND a real failure fails (not SKIP=green)",
+    () => {
+      rmSync(SKIPPABLE_MIXED_PACKAGE_DIR, { recursive: true, force: true });
+      mkdirSync(SKIPPABLE_MIXED_PACKAGE_DIR, { recursive: true });
+      try {
+        writeFileSync(
+          join(SKIPPABLE_MIXED_PACKAGE_DIR, "package.json"),
+          `${JSON.stringify(
+            {
+              name: "@elizaos/run-all-tests-mixed-no-test-and-fail-fixture",
+              private: true,
+              type: "module",
+              // Single `bun test <file>` command => no-test-skippable.
+              scripts: {
+                test: "bun test mixed.test.ts",
+              },
+            },
+            null,
+            2,
+          )}\n`,
+        );
+        // The test prints the "No test files found" banner (simulating a sibling
+        // project in a multi-project run that collected nothing) AND fails a
+        // real assertion (bun emits `(fail)` / `1 fail` / `error:`), all in one
+        // merged stdout+stderr buffer, exiting non-zero.
+        writeFileSync(
+          join(SKIPPABLE_MIXED_PACKAGE_DIR, "mixed.test.ts"),
+          [
+            'import { test, expect } from "bun:test";',
+            'test("empty sibling banner then a real failure", () => {',
+            '  console.log("No test files found in sibling project");',
+            "  expect(1).toBe(2);",
+            "});",
+            "",
+          ].join("\n"),
+        );
+
+        const result = run([
+          "--only=test",
+          "--no-cloud",
+          "--filter=@elizaos/run-all-tests-mixed-no-test-and-fail-fixture",
+        ]);
+        const output = `${result.stdout}${result.stderr}`;
+
+        expect(result.status).toBe(1);
+        expect(output).toContain(
+          "FAIL @elizaos/run-all-tests-mixed-no-test-and-fail-fixture",
+        );
+        expect(output).not.toContain(
+          "SKIP @elizaos/run-all-tests-mixed-no-test-and-fail-fixture",
+        );
+      } finally {
+        rmSync(SKIPPABLE_MIXED_PACKAGE_DIR, { recursive: true, force: true });
+      }
+    },
+    SPAWN_TIMEOUT_MS,
+  );
+
+  test(
+    "a genuinely-empty skippable lane (no test files, no-tests banner, no failure signal) is still SKIP=green",
+    () => {
+      // Behaviour-preservation: a single `bun test <dir>` over a test-free
+      // directory exits non-zero with the recognised no-tests banner and NO
+      // failure signal, and must still be reclassified as a benign skip
+      // (status 0, not a hard failure). This proves the fix is additive — it
+      // only withholds the skip when the lane has test files on disk or the
+      // output carries a real failure marker.
+      rmSync(SKIPPABLE_EMPTY_PACKAGE_DIR, { recursive: true, force: true });
+      mkdirSync(SKIPPABLE_EMPTY_PACKAGE_DIR, { recursive: true });
+      try {
+        writeFileSync(
+          join(SKIPPABLE_EMPTY_PACKAGE_DIR, "package.json"),
+          `${JSON.stringify(
+            {
+              name: "@elizaos/run-all-tests-genuinely-no-tests-fixture",
+              private: true,
+              type: "module",
+              // Single `bun test <dir>` command => no-test-skippable. The dir
+              // exists but contains NO test files, so the runner's own
+              // authoritative empty-file determination (hasLocalTestFiles) is
+              // false AND bun prints a recognised no-tests banner ("did not
+              // match any test files") on non-zero exit with no failure marker.
+              // The lane runs via `bun run test`, so Bun also appends its
+              // wrapper line `error: script "test" exited with code 1`; the
+              // failure detector must NOT treat that wrapper error as a real
+              // failure, or this benign empty lane would be reported as FAIL
+              // instead of SKIP. This pins that regression closed.
+              scripts: {
+                test: "bun test empty-tests",
+              },
+            },
+            null,
+            2,
+          )}\n`,
+        );
+        // An existing but test-free directory: keeps hasLocalTestFiles(cwd)
+        // false (genuinely no tests) while giving bun a real path to search so
+        // it emits the "did not match any test files" banner rather than a
+        // filter-error.
+        mkdirSync(join(SKIPPABLE_EMPTY_PACKAGE_DIR, "empty-tests"), {
+          recursive: true,
+        });
+
+        const result = run([
+          "--only=test",
+          "--no-cloud",
+          "--filter=@elizaos/run-all-tests-genuinely-no-tests-fixture",
+        ]);
+        const output = `${result.stdout}${result.stderr}`;
+
+        expect(result.status).toBe(0);
+        expect(output).not.toContain(
+          "FAIL @elizaos/run-all-tests-genuinely-no-tests-fixture",
+        );
+      } finally {
+        rmSync(SKIPPABLE_EMPTY_PACKAGE_DIR, { recursive: true, force: true });
+      }
+    },
+    SPAWN_TIMEOUT_MS,
+  );
+
+  test(
+    "a lane WITH test files that reports a no-tests banner on non-zero exit is NOT skipped",
+    () => {
+      // The exact edge the output-scan alone could not close: a skippable lane
+      // that DOES have test files on disk exits non-zero and emits a no-tests
+      // banner (e.g. a runtime filter that matched nothing, or a process that
+      // aborts before printing a normal failure summary). Because the runner's
+      // own empty-file determination (hasLocalTestFiles) is TRUE, this is a
+      // real failure/misconfig and must NOT be reclassified as SKIP=green,
+      // even though no per-test failure marker is present in the output.
+      rmSync(SKIPPABLE_MIXED_PACKAGE_DIR, { recursive: true, force: true });
+      mkdirSync(SKIPPABLE_MIXED_PACKAGE_DIR, { recursive: true });
+      try {
+        writeFileSync(
+          join(SKIPPABLE_MIXED_PACKAGE_DIR, "package.json"),
+          `${JSON.stringify(
+            {
+              name: "@elizaos/run-all-tests-hasfiles-but-notests-banner-fixture",
+              private: true,
+              type: "module",
+              // A real test file EXISTS but the command filters to a path that
+              // matches nothing => bun prints a no-tests banner and exits
+              // non-zero WITHOUT a per-test failure marker.
+              scripts: {
+                test: "bun test __no_matching_filter_zzz__",
+              },
+            },
+            null,
+            2,
+          )}\n`,
+        );
+        writeFileSync(
+          join(SKIPPABLE_MIXED_PACKAGE_DIR, "present.test.ts"),
+          [
+            'import { test, expect } from "bun:test";',
+            'test("present but filtered out", () => {',
+            "  expect(true).toBe(true);",
+            "});",
+            "",
+          ].join("\n"),
+        );
+
+        const result = run([
+          "--only=test",
+          "--no-cloud",
+          "--filter=@elizaos/run-all-tests-hasfiles-but-notests-banner-fixture",
+        ]);
+        const output = `${result.stdout}${result.stderr}`;
+
+        expect(result.status).toBe(1);
+        expect(output).toContain(
+          "FAIL @elizaos/run-all-tests-hasfiles-but-notests-banner-fixture",
+        );
+        expect(output).not.toContain(
+          "SKIP @elizaos/run-all-tests-hasfiles-but-notests-banner-fixture",
+        );
+      } finally {
+        rmSync(SKIPPABLE_MIXED_PACKAGE_DIR, { recursive: true, force: true });
       }
     },
     SPAWN_TIMEOUT_MS,

--- a/packages/scripts/run-all-tests.mjs
+++ b/packages/scripts/run-all-tests.mjs
@@ -367,6 +367,33 @@ const NO_TEST_OUTPUT_PATTERNS = [
   // how vitest's --passWithNoTests packages are handled.
   /did not match any test files/i,
 ];
+// Genuine test/run FAILURE signals. When a non-zero child exit carries any of
+// these, the run really failed even if the SAME buffer also contains a
+// "No test files found" line — e.g. a multi-project vitest / `bun test` run
+// where one project has no files (emits the no-tests banner) while a sibling
+// project has a red test (emits a failure line). Without this guard the
+// no-tests substring scan below would swallow that failure as SKIP=green
+// (#13620 task 4). We only skip-as-no-tests when NO failure signal is present.
+const TEST_FAILURE_OUTPUT_PATTERNS = [
+  // vitest summary lines: `Tests  1 failed | 2 passed`, `Test Files  1 failed`.
+  /\bTests?\s+Files?\b[^\n]*\bfailed\b/i,
+  /\bTests?\b[^\n]*\bfailed\b/i,
+  // vitest per-file / per-test markers: a line beginning with `FAIL ` or the
+  // `× ` / ` ✗ ` fail glyphs it prints for a failing case.
+  /(^|\n)\s*FAIL\s/,
+  /(^|\n)\s*(?:×|✗)\s/,
+  // `N failed` / `N test(s) failed` (vitest & generic runners).
+  /\b\d+\s+(?:tests?\s+)?failed\b/i,
+  // bun test: `N fail` in the summary and the per-assertion `(fail)` marker.
+  /\b\d+\s+fail\b/i,
+  /\(fail\)/i,
+];
+// NOTE: deliberately NOT matching a bare `error:` / `exited with code` line.
+// A benign no-tests lane run through `bun run test` still exits non-zero and
+// Bun appends `error: script "test" exited with code 1` — matching that would
+// wrongly withhold the skip for the exact empty-lane case this must preserve.
+// The specific per-test/per-suite failure markers above are sufficient and do
+// not appear in a graceful "No test files found" run.
 const TEST_FILE_PATTERN = /\.(?:test|spec)\.[cm]?[tj]sx?$/;
 const TEST_FILE_SKIP_DIRS = new Set([
   ".git",
@@ -703,6 +730,19 @@ function outputIndicatesNoTests(output) {
   return NO_TEST_OUTPUT_PATTERNS.some((pattern) => pattern.test(output));
 }
 
+function outputIndicatesTestFailure(output) {
+  return TEST_FAILURE_OUTPUT_PATTERNS.some((pattern) => pattern.test(output));
+}
+
+// A non-zero child exit may be reclassified as a benign "no tests" skip only
+// when the command is a single skippable runner invocation, its output carries
+// a no-tests banner, AND that output shows NO genuine failure signal. The last
+// clause is what stops a multi-project run (one empty project + one failing
+// test in the same merged buffer) from being swallowed as SKIP=green (#13620).
+function shouldSkipAsNoTests(output) {
+  return outputIndicatesNoTests(output) && !outputIndicatesTestFailure(output);
+}
+
 function hasLocalTestFiles(dir) {
   let entries;
   try {
@@ -966,7 +1006,21 @@ function runScript(
       },
     );
     let capturedOutput = "";
-    const canSkipNoTests = canSkipWhenOutputHasNoTests(scriptName, scripts);
+    // A non-zero exit may only be reclassified as a benign "no tests" skip when
+    // BOTH hold:
+    //   1. the command is a single vitest/bun-test invocation, AND
+    //   2. the lane genuinely has no test files on disk (the runner's own
+    //      authoritative empty-file determination).
+    // Anchoring on (2) — not just an output substring — is what #13620 task 4
+    // asks for: if test files DO exist, a non-zero exit is a real failure/
+    // misconfig and must never be swallowed as green, even when the output
+    // happens to contain a "No test files found" banner (e.g. a runtime filter
+    // that matched nothing in one project while a sibling project failed, or a
+    // test/setup process that aborts before printing its normal failure
+    // summary). Benign lanes with no test files still skip.
+    const canSkipNoTests =
+      canSkipWhenOutputHasNoTests(scriptName, scripts) &&
+      !hasLocalTestFiles(cwd);
 
     child.stdout?.on("data", (chunk) => {
       if (stream) {
@@ -993,7 +1047,7 @@ function runScript(
         resolve({ skipped: false });
         return;
       }
-      if (canSkipNoTests && outputIndicatesNoTests(capturedOutput)) {
+      if (canSkipNoTests && shouldSkipAsNoTests(capturedOutput)) {
         resolve({ skipped: true });
         return;
       }


### PR DESCRIPTION
## Problem (#13620 task 4)

`packages/scripts/run-all-tests.mjs` reclassified **any** non-zero child exit of a single vitest/`bun test` lane as a benign `SKIP=green` whenever the merged 16 KB output buffer matched a `No test files found` **substring** (`:996`, pre-fix). This swallows real failures in exactly the multi-project case the issue flags: a run where one project collects no tests (emits the no-tests banner) while a sibling project has a **failing** test (emits a real failure) produces both strings in one buffer, so the whole task went green.

`#13640` armed the `--min-tasks` guard (task 3). This closes task 4 — *"narrow the 'no tests' classification to the runner's own empty-file determination, not a substring scan over merged child output."*

## Fix

Narrow the skip on two axes in `runScript`:

1. **Authoritative empty-file anchor** — a lane is only skippable-as-no-tests when the runner's own `hasLocalTestFiles(cwd)` is false. If test files exist on disk, a non-zero exit is a real failure/misconfig and is **never** reclassified as green, even if the output carries a no-tests banner (runtime filter that matched nothing while a sibling failed, or a process that aborts before printing a normal failure summary). This is the issue's preferred narrowing.
2. **Defense-in-depth failure-marker guard** — `shouldSkipAsNoTests()` additionally withholds the skip when the output shows a genuine per-test/per-suite failure marker (vitest `FAIL` / `Tests N failed` / `×`, bun `(fail)` / `N fail`). It **deliberately does not** match Bun's wrapper `error: script "test" exited with code 1` line — a benign empty lane also emits that under `bun run test`, and matching it would break the legitimate empty-lane skip.

## Tests (`run-all-tests-vacuous-green-guard.test.ts`, real-spawn, reversion-proven)

- a skippable bun-test lane emitting a no-tests banner **AND** a real failure now **FAILs** (verified: exits `SKIP=green` under the pre-fix code)
- a genuinely-empty lane (no test files, banner, no failure marker, plus Bun's wrapper `error:` line) is still **SKIP=green** (verified: FAILs if the wrapper-error pattern is naively matched)
- a lane **WITH** test files that reports a no-tests banner on non-zero exit is **NOT** skipped (verified: goes green if the `hasLocalTestFiles` anchor is removed)

`11/11` green. tsc N/A (bare `.mjs` script + `bun:test` dir, no package tsconfig sweep). `biome` + `error-policy-ratchet` (0 new fallback-slop) + `audit:scripts` + `audit:test-realness` all clean. No `.github/workflows` files touched (that half of #13620 is `needs-human`).

Distinct from #13640 (task 3, merged).

## Evidence

Reversion-proof regression tests above (each fails against the pre-fix / naive variant), full deterministic gate output in the lane log.

-- [sol-orch]
