### PR TITLE
refactor(plugin-wallet-ui): uniform header, calm empty states, strip CTAs (#13592)

### DIFF
--- a/packages/ui/src/components/pages/WalletSectionNav.test.tsx
+++ b/packages/ui/src/components/pages/WalletSectionNav.test.tsx
@@ -6,7 +6,13 @@
  * resolution to Wallet, and that a sub-view stops matching when its registration
  * is absent.
  */
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { registerAppShellPage } from "../../app-shell-registry";
 import { resetUiRegistryHostForTests } from "../../registry-host";
@@ -94,15 +100,46 @@ describe("isWalletSectionPath", () => {
 });
 
 describe("WalletSectionNav", () => {
+  it("renders a centered Wallet title header with an icon-only back button", () => {
+    render(<WalletSectionNav activePath="/inventory" />);
+    // Uniform ViewHeader geometry (#13451/#13592): centered title + bare back.
+    const header = screen.getByTestId("view-header");
+    expect(
+      within(header).getByRole("heading", { name: "Wallet" }),
+    ).toBeTruthy();
+    expect(
+      within(header).getByRole("button", { name: "Back to launcher" }),
+    ).toBeTruthy();
+  });
+
+  it("suppresses the secondary strip when only one group member is registered", () => {
+    resetUiRegistryHostForTests();
+    registerAppShellPage({
+      id: "test.wallet",
+      pluginId: "test-wallet",
+      label: "Wallet",
+      path: "/inventory",
+      tabAffinity: "inventory",
+      group: "wallet",
+      order: 10,
+      loader: async () => ({ default: () => null }),
+    });
+    render(<WalletSectionNav activePath="/wallet" />);
+    // Header present, but no switchable strip with a single member.
+    expect(screen.getByTestId("view-header")).toBeTruthy();
+    expect(screen.queryByTestId("wallet-section-tabs")).toBeNull();
+  });
+
   it("marks the active sub-view (aliases resolve to Wallet)", () => {
     render(<WalletSectionNav activePath="/inventory" />);
+    const strip = screen.getByTestId("wallet-section-tabs");
     expect(
-      screen
+      within(strip)
         .getByRole("button", { name: "Wallet" })
         .getAttribute("aria-current"),
     ).toBe("page");
     expect(
-      screen
+      within(strip)
         .getByRole("button", { name: "Perps" })
         .getAttribute("aria-current"),
     ).toBeNull();
@@ -110,8 +147,9 @@ describe("WalletSectionNav", () => {
 
   it("marks Perps active on its registered route", () => {
     render(<WalletSectionNav activePath="/perps" />);
+    const strip = screen.getByTestId("wallet-section-tabs");
     expect(
-      screen
+      within(strip)
         .getByRole("button", { name: "Perps" })
         .getAttribute("aria-current"),
     ).toBe("page");
@@ -119,14 +157,16 @@ describe("WalletSectionNav", () => {
 
   it("navigates to the sub-view route on click", () => {
     render(<WalletSectionNav activePath="/wallet" />);
-    fireEvent.click(screen.getByRole("button", { name: "Predictions" }));
+    const strip = screen.getByTestId("wallet-section-tabs");
+    fireEvent.click(within(strip).getByRole("button", { name: "Predictions" }));
     expect(window.location.pathname).toBe("/predictions");
   });
 
   it("does not renavigate when the active tab is clicked", () => {
     window.history.replaceState(null, "", "/wallet");
     render(<WalletSectionNav activePath="/wallet" />);
-    fireEvent.click(screen.getByRole("button", { name: "Wallet" }));
+    const strip = screen.getByTestId("wallet-section-tabs");
+    fireEvent.click(within(strip).getByRole("button", { name: "Wallet" }));
     expect(window.location.pathname).toBe("/wallet");
   });
 });

--- a/packages/ui/src/components/pages/WalletSectionNav.tsx
+++ b/packages/ui/src/components/pages/WalletSectionNav.tsx
@@ -12,7 +12,7 @@ import {
   subscribeAppShellPages,
 } from "../../app-shell-registry";
 import { cn } from "../../lib/utils";
-import { ViewBackButton } from "../shared/ViewHeader";
+import { ViewHeader } from "../shared/ViewHeader";
 import { Button } from "../ui/button";
 
 interface WalletSectionTab {
@@ -117,39 +117,46 @@ export function WalletSectionNav({
   );
   const tabs = walletSectionTabs();
   const active = activeTabId(activePath, tabs);
+  // The Wallet family adopts the uniform header geometry (#13451/#13592): a
+  // centered "Wallet" title with the icon-only launcher back button, matching
+  // every other top-level view instead of the old left-aligned tab strip.
+  const header = <ViewHeader title="Wallet" />;
+  // With a single group member (the current in-tree state) there is nothing to
+  // switch between, so the secondary strip is suppressed — just the header. The
+  // group mechanism stays intact; when a sibling (perps/predictions) registers
+  // the strip returns automatically UNDER the header.
+  if (tabs.length < 2) return header;
   return (
-    <nav
-      aria-label="Wallet sections"
-      data-testid="wallet-section-nav"
-      className="flex shrink-0 items-center gap-1 border-b border-border/45 px-3 py-2"
-    >
-      {/* Back-to-launcher control — the Wallet family (wallet/perps/predictions)
-       *  renders this shared tab strip as its header instead of a ViewHeader, so
-       *  it owns the launcher back button the other top-level views get from
-       *  ViewHeader. Without it there is no way back to the launcher on mobile. */}
-      <ViewBackButton className="mr-1" />
-      {tabs.map((tab) => {
-        const isActive = tab.id === active;
-        return (
-          <Button
-            key={tab.id}
-            aria-current={isActive ? "page" : undefined}
-            onClick={() => {
-              if (!isActive) navigate(tab.path);
-            }}
-            variant="ghost"
-            size="sm"
-            className={cn(
-              "h-auto rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
-              isActive
-                ? "bg-accent/15 text-accent"
-                : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
-            )}
-          >
-            {tab.label}
-          </Button>
-        );
-      })}
-    </nav>
+    <div data-testid="wallet-section-nav">
+      {header}
+      <nav
+        aria-label="Wallet sections"
+        data-testid="wallet-section-tabs"
+        className="flex shrink-0 items-center justify-center gap-1 border-b border-border/45 px-3 py-2"
+      >
+        {tabs.map((tab) => {
+          const isActive = tab.id === active;
+          return (
+            <Button
+              key={tab.id}
+              aria-current={isActive ? "page" : undefined}
+              onClick={() => {
+                if (!isActive) navigate(tab.path);
+              }}
+              variant="ghost"
+              size="sm"
+              className={cn(
+                "h-auto rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-accent/15 text-accent"
+                  : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
+              )}
+            >
+              {tab.label}
+            </Button>
+          );
+        })}
+      </nav>
+    </div>
   );
 }

--- a/plugins/plugin-wallet-ui/src/components/InventoryAppView.gui.test.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventoryAppView.gui.test.tsx
@@ -433,11 +433,13 @@ describe("InventoryView GUI — rail tab switching", () => {
     ).toBeTruthy();
     expect(within(sidebar).queryByText("Agent NFT")).toBeNull();
 
-    // DeFi: no LP-like positions in the fixture -> recommendation empty state.
+    // DeFi: no LP-like positions in the fixture -> calm neutral empty state
+    // (no suggestion chips).
     fireEvent.click(within(sidebar).getByRole("button", { name: "DeFi" }));
+    expect(within(sidebar).getByText("No DeFi positions.")).toBeTruthy();
     expect(
-      within(sidebar).getByText("Where can I stake my tokens?"),
-    ).toBeTruthy();
+      within(sidebar).queryByText("Where can I stake my tokens?"),
+    ).toBeNull();
     expect(
       within(sidebar).queryByText(hasFlatText("100.0000 USDC")),
     ).toBeNull();
@@ -687,14 +689,17 @@ describe("InventoryView GUI — dashboard panels", () => {
 
     // Danger banner.
     expect(screen.getByText("RPC provider unreachable")).toBeTruthy();
-    // Empty panels now recommend a next step instead of showing a dead box.
-    expect(await screen.findByText("How do I provide liquidity?")).toBeTruthy();
-    expect(screen.getByText("What NFT collections are trending?")).toBeTruthy();
+    // Empty panels are calm neutral states now — a plain fact, no chips.
+    expect(await screen.findByText("No liquidity positions.")).toBeTruthy();
+    expect(screen.getByText("No NFTs to preview.")).toBeTruthy();
+    // The removed suggestion chips must not resurface.
+    expect(screen.queryByText("How do I provide liquidity?")).toBeNull();
+    expect(screen.queryByText("What NFT collections are trending?")).toBeNull();
   });
 });
 
-describe("InventoryView GUI — empty wallet / market pulse hero", () => {
-  it("disabled wallet shows the hero, enable button, and market movers", async () => {
+describe("InventoryView GUI — calm empty-wallet hero", () => {
+  it("disabled wallet shows a calm hero + Enable control, no Keys CTA, no market panels", async () => {
     const state = makeAppState({
       walletEnabled: false,
       walletBalances: {
@@ -709,30 +714,32 @@ describe("InventoryView GUI — empty wallet / market pulse hero", () => {
     render(React.createElement(InventoryAppView));
     await screen.findByTestId("wallets-sidebar");
 
-    // WalletEmptyHero unconfigured variant: motif + keys CTA (no title text).
+    // Calm hero: motif + one neutral line, nothing else.
     expect(await screen.findByLabelText("Empty wallet")).toBeTruthy();
-    const configure = screen.getByRole("button", { name: "Keys" });
-    fireEvent.click(configure);
-    expect(state.setTab).toHaveBeenCalledWith("settings");
-    expect(window.location.hash).toBe("#wallet-rpc");
+    expect(screen.getByText("Your wallet is empty.")).toBeTruthy();
+    // The "Keys" marketing CTA is gone.
+    expect(screen.queryByRole("button", { name: "Keys" })).toBeNull();
+    // The empty hero no longer pads itself with a market dashboard.
+    expect(screen.queryByText("Solana")).toBeNull();
+    expect(screen.queryByText("Cap rank #5")).toBeNull();
 
-    // Market movers list rendered with concrete data. Scope to the "Top movers"
-    // section so the chain-cluster "SOL" badge in the sidebar isn't ambiguous.
-    const moverName = screen.getByText("Solana");
-    const moverRow = moverName.closest("div.flex");
-    expect(moverRow).toBeTruthy();
-    expect(within(moverRow as HTMLElement).getByText("SOL")).toBeTruthy();
-    expect(screen.getByText("$150.00")).toBeTruthy();
-    expect(screen.getByText("+7.5%")).toBeTruthy();
-    expect(screen.getByText("Cap rank #5")).toBeTruthy();
-
-    // Enable wallet flips walletEnabled true and reloads.
+    // The one functional setup control (Enable wallet) remains and reloads.
     fireEvent.click(screen.getByRole("button", { name: "Enable wallet" }));
     expect(state.setState).toHaveBeenCalledWith("walletEnabled", true);
     expect(state.loadBalances).toHaveBeenCalled();
   });
 
-  it("shows MarketDataUnavailable when the movers source is unavailable", async () => {
+  it("surfaces MarketDataUnavailable (J4) in the dashboard when the movers feed fails", async () => {
+    // Empty the trading profile so there are no *portfolio* movers, but keep the
+    // fixture token balances so the populated dashboard (not the hero) renders.
+    // Its Movers panel then shows the named unavailable state, not a blank.
+    walletClient.getWalletTradingProfile.mockResolvedValue({
+      ...tradingProfile,
+      summary: { ...tradingProfile.summary, evaluatedTrades: 0 },
+      pnlSeries: [],
+      tokenBreakdown: [],
+      recentSwaps: [],
+    });
     walletClient.getWalletMarketOverview.mockResolvedValue({
       ...marketOverview,
       movers: [],
@@ -746,25 +753,37 @@ describe("InventoryView GUI — empty wallet / market pulse hero", () => {
       },
     });
     appHooks.useApp.mockReturnValue(
-      makeAppState({
-        walletEnabled: false,
-        walletBalances: {
-          evm: { address: EVM_ADDRESS, chains: [] },
-          solana: null,
-        },
-        walletNfts: { evm: [], solana: null },
-        walletAddresses: { evmAddress: null, solanaAddress: null },
-        walletConfig: {
-          ...walletConfig,
-          evmAddress: null,
-          solanaAddress: null,
-        },
-      }),
+      makeAppState({ walletNfts: { evm: [], solana: null } }),
     );
     render(React.createElement(InventoryAppView));
     await screen.findByTestId("wallets-sidebar");
 
     expect(await screen.findByText("Unavailable")).toBeTruthy();
+    expect(screen.getByTitle("Top movers unavailable")).toBeTruthy();
+    expect(screen.getByText("CoinGecko rate limited")).toBeTruthy();
+  });
+
+  it("synthesizes an unavailable overview (J4) when the overview fetch throws", async () => {
+    // A rejected fetch must not silently null the overview: the dashboard's
+    // Movers panel should still render MarketDataUnavailable, not a blank.
+    walletClient.getWalletTradingProfile.mockResolvedValue({
+      ...tradingProfile,
+      summary: { ...tradingProfile.summary, evaluatedTrades: 0 },
+      pnlSeries: [],
+      tokenBreakdown: [],
+      recentSwaps: [],
+    });
+    walletClient.getWalletMarketOverview.mockRejectedValue(
+      new Error("network down"),
+    );
+    appHooks.useApp.mockReturnValue(
+      makeAppState({ walletNfts: { evm: [], solana: null } }),
+    );
+    render(React.createElement(InventoryAppView));
+    await screen.findByTestId("wallets-sidebar");
+
+    // The synthesized unavailable overview surfaces the thrown message.
+    expect(await screen.findByText("network down")).toBeTruthy();
     expect(screen.getByTitle("Top movers unavailable")).toBeTruthy();
   });
 });

--- a/plugins/plugin-wallet-ui/src/components/InventoryAppView.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventoryAppView.tsx
@@ -17,13 +17,9 @@ import type {
   WalletMarketMover,
   WalletMarketOverviewResponse,
   WalletMarketOverviewSource,
-  WalletMarketPriceSnapshot,
   WalletTradingProfileResponse,
   WalletTradingProfileWindow,
 } from "@elizaos/shared";
-// Direct subpath: the app renderer resolves the bare `@elizaos/ui` root to the
-// browser barrel, which doesn't reliably re-export this newer component.
-import { ChatEmptyStateWithRecommendations } from "@elizaos/ui";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { client } from "@elizaos/ui/api";
 import { Button } from "@elizaos/ui/components";
@@ -35,7 +31,6 @@ import {
   Activity,
   AlertTriangle,
   ArrowLeftRight,
-  BarChart3,
   CheckCircle2,
   Copy,
   EyeOff,
@@ -114,6 +109,70 @@ const usdFormatter = new Intl.NumberFormat("en-US", {
 const compactFormatter = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 4,
 });
+
+/**
+ * Calm neutral empty state (#13592): a bare muted glyph over one short line of
+ * plain-fact copy. No suggestion chips, no marketing pitch, no setup CTA — an
+ * empty panel states what is empty and stays quiet. Replaces the ten former
+ * `ChatEmptyStateWithRecommendations` prompt-chip surfaces.
+ */
+function CalmEmptyState({
+  icon: Icon,
+  label,
+  className,
+}: {
+  icon: LucideIcon;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-2 px-4 py-8 text-center",
+        className,
+      )}
+    >
+      <Icon className="h-5 w-5 text-muted" aria-hidden />
+      <p className="text-sm text-muted">{label}</p>
+    </div>
+  );
+}
+
+/**
+ * error-policy:J4 — synthesize a fully-unavailable market overview from a fetch
+ * failure. Every source is marked `available:false` and carries the error, so
+ * the dashboard's market panels render `MarketDataUnavailable` (a named,
+ * distinguishable state) rather than a silent null that reads as "empty".
+ */
+function marketOverviewUnavailable(
+  error: string,
+): WalletMarketOverviewResponse {
+  const source = (
+    providerId: WalletMarketOverviewSource["providerId"],
+    providerName: string,
+    providerUrl: string,
+  ): WalletMarketOverviewSource => ({
+    providerId,
+    providerName,
+    providerUrl,
+    available: false,
+    stale: false,
+    error,
+  });
+  return {
+    generatedAt: new Date().toISOString(),
+    cacheTtlSeconds: 0,
+    stale: false,
+    sources: {
+      prices: source("coingecko", "CoinGecko", "https://www.coingecko.com"),
+      movers: source("coingecko", "CoinGecko", "https://www.coingecko.com"),
+      predictions: source("polymarket", "Polymarket", "https://polymarket.com"),
+    },
+    prices: [],
+    movers: [],
+    predictions: [],
+  };
+}
 
 function readHiddenTokenIds(): Set<string> {
   if (typeof window === "undefined") return new Set();
@@ -685,15 +744,19 @@ function PortfolioMoversPanel({
       );
     }
 
+    // error-policy:J4 — distinguish "feed unavailable" from "genuinely no
+    // movers": a failed overview marks its movers source unavailable, so
+    // surface that named state instead of the calm empty line.
+    const moversSource = marketOverview?.sources.movers;
+    if (moversSource && !moversSource.available) {
+      return <MarketDataUnavailable title="Top movers" source={moversSource} />;
+    }
+
     return (
-      <ChatEmptyStateWithRecommendations
+      <CalmEmptyState
         icon={TrendingUp}
+        label="No portfolio movers yet."
         className="min-h-[8rem]"
-        recommendations={[
-          "What tokens are trending right now?",
-          "Which of my holdings moved most this week?",
-          "Find new tokens to watch on Base",
-        ]}
       />
     );
   }
@@ -741,19 +804,6 @@ function MarketAvatar({
   );
 }
 
-function MarketSourceBadge({ source }: { source: WalletMarketOverviewSource }) {
-  return (
-    <a
-      href={source.providerUrl}
-      target="_blank"
-      rel="noreferrer"
-      className="text-[0.68rem] font-medium text-muted transition-colors hover:text-txt"
-    >
-      {source.providerName}
-    </a>
-  );
-}
-
 function MarketDataUnavailable({
   title,
   source,
@@ -771,72 +821,6 @@ function MarketDataUnavailable({
   );
 }
 
-function MajorPriceCard({ snapshot }: { snapshot: WalletMarketPriceSnapshot }) {
-  const isPositive = snapshot.change24hPct >= 0;
-
-  return (
-    <div className="min-w-0 p-2">
-      <div className="flex items-center gap-3">
-        <MarketAvatar imageUrl={snapshot.imageUrl} label={snapshot.symbol} />
-        <div className="min-w-0">
-          <div className="text-sm font-semibold text-txt">
-            {snapshot.symbol}
-          </div>
-          <div className="truncate text-xs-tight text-muted">
-            {snapshot.name}
-          </div>
-        </div>
-      </div>
-      <div className="mt-4 flex flex-wrap items-end justify-between gap-x-3 gap-y-1">
-        <div className="min-w-0 font-mono text-lg font-semibold text-txt sm:text-xl">
-          {formatMarketUsd(snapshot.priceUsd)}
-        </div>
-        <div
-          className={cn(
-            "shrink-0 text-sm font-semibold",
-            isPositive ? "text-txt" : "text-danger",
-          )}
-        >
-          {formatPercentDelta(snapshot.change24hPct)}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function MarketPriceGrid({
-  prices,
-  source,
-}: {
-  prices: WalletMarketPriceSnapshot[];
-  source: WalletMarketOverviewSource;
-}) {
-  if (!source.available) {
-    return <MarketDataUnavailable title="Spot prices" source={source} />;
-  }
-
-  if (prices.length === 0) {
-    return (
-      <ChatEmptyStateWithRecommendations
-        icon={BarChart3}
-        className="min-h-[8rem]"
-        recommendations={[
-          "What's the price of ETH right now?",
-          "Show me BTC and SOL prices",
-        ]}
-      />
-    );
-  }
-
-  return (
-    <div className="grid grid-cols-[repeat(auto-fit,minmax(min(100%,13.5rem),1fr))] gap-3">
-      {prices.map((snapshot) => (
-        <MajorPriceCard key={snapshot.id} snapshot={snapshot} />
-      ))}
-    </div>
-  );
-}
-
 function MarketMoverList({
   movers,
   source,
@@ -850,13 +834,10 @@ function MarketMoverList({
 
   if (movers.length === 0) {
     return (
-      <ChatEmptyStateWithRecommendations
+      <CalmEmptyState
         icon={TrendingUp}
+        label="No market movers right now."
         className="min-h-[8rem]"
-        recommendations={[
-          "What are today's top gainers?",
-          "Which tokens are moving on Solana?",
-        ]}
       />
     );
   }
@@ -951,76 +932,26 @@ function WalletMotif() {
   );
 }
 
-function WalletEmptyHero({
-  hasKeys,
-  onConfigureKeys,
-}: {
-  hasKeys: boolean;
-  onConfigureKeys: () => void;
-}) {
+// The empty wallet is calm (#13592): just the motif over a neutral line, no
+// "Keys" marketing CTA. The one functional setup control (Enable-wallet) lives
+// in the holdings section; wiring keys/RPC is reachable from RPC settings.
+function WalletEmptyHero() {
   return (
-    <div className="flex flex-col items-center gap-4 px-6 py-10 text-center">
+    <div className="flex flex-col items-center gap-3 px-6 py-10 text-center">
       <WalletMotif />
-      {hasKeys ? null : (
-        <Button
-          type="button"
-          variant="surfaceAccent"
-          size="sm"
-          onClick={onConfigureKeys}
-        >
-          Keys
-        </Button>
-      )}
+      <p className="text-sm text-muted">Your wallet is empty.</p>
     </div>
   );
 }
 
-function MarketPulseHero({
-  overview,
-  loading,
-  hasKeys,
-  onConfigureKeys,
-}: {
-  overview: WalletMarketOverviewResponse | null;
-  loading: boolean;
-  hasKeys: boolean;
-  onConfigureKeys: () => void;
-}) {
+// The empty-wallet surface is a single calm hero (#13592). It no longer pads
+// the empty state with a live spot-price / top-mover market dashboard — an
+// empty wallet is quiet, not a market terminal. Market data still renders in
+// the populated dashboard's Movers panel.
+function MarketPulseHero() {
   return (
-    <section className="space-y-6">
-      <WalletEmptyHero hasKeys={hasKeys} onConfigureKeys={onConfigureKeys} />
-
-      {overview ? (
-        <div className="space-y-6">
-          <div className="space-y-3">
-            <div className="flex items-center justify-between gap-2 text-xs text-muted">
-              <span>Spot prices</span>
-              <MarketSourceBadge source={overview.sources.prices} />
-            </div>
-            <MarketPriceGrid
-              prices={overview.prices}
-              source={overview.sources.prices}
-            />
-          </div>
-
-          <div className="space-y-3">
-            <div className="flex items-center justify-between gap-2 text-xs text-muted">
-              <span>Top movers</span>
-              <MarketSourceBadge source={overview.sources.movers} />
-            </div>
-            <MarketMoverList
-              movers={overview.movers}
-              source={overview.sources.movers}
-            />
-          </div>
-        </div>
-      ) : loading ? (
-        <div className="grid grid-cols-[repeat(auto-fit,minmax(min(100%,13.5rem),1fr))] gap-3">
-          {["btc", "eth", "sol"].map((loadingCardId) => (
-            <div key={loadingCardId} className="h-28 animate-pulse bg-bg/20" />
-          ))}
-        </div>
-      ) : null}
+    <section>
+      <WalletEmptyHero />
     </section>
   );
 }
@@ -1542,13 +1473,10 @@ const TokenRailRow = memo(
 function RailNftList({ nfts }: { nfts: NftItem[] }) {
   if (nfts.length === 0) {
     return (
-      <ChatEmptyStateWithRecommendations
+      <CalmEmptyState
         icon={ImageIcon}
+        label="No NFTs in this wallet."
         className="min-h-[13rem]"
-        recommendations={[
-          "Find NFTs worth collecting",
-          "Show trending mints this week",
-        ]}
       />
     );
   }
@@ -1593,14 +1521,10 @@ function RailPositionList({
 }) {
   if (positions.length === 0) {
     return (
-      <ChatEmptyStateWithRecommendations
+      <CalmEmptyState
         icon={Layers3}
+        label="No DeFi positions."
         className="min-h-[13rem]"
-        recommendations={[
-          "Show me my DeFi positions",
-          "Where can I stake my tokens?",
-          "Find the best yield for my USDC",
-        ]}
       />
     );
   }
@@ -1744,14 +1668,10 @@ function WalletHoldingsSection({
         <div className="space-y-1">
           {activeTab === "tokens" ? (
             visibleRows.length === 0 ? (
-              <ChatEmptyStateWithRecommendations
+              <CalmEmptyState
                 icon={Wallet}
+                label="No tokens in this wallet."
                 className="min-h-[13rem]"
-                recommendations={[
-                  "How do I fund my wallet?",
-                  "Buy ETH with my card",
-                  "Bridge USDC to Base",
-                ]}
               />
             ) : (
               visibleRows.map((row) => (
@@ -1840,14 +1760,10 @@ function ActivityLog({
 
   if (entries.length === 0) {
     return (
-      <ChatEmptyStateWithRecommendations
+      <CalmEmptyState
         icon={Activity}
+        label="No recent activity."
         className="min-h-[8rem]"
-        recommendations={[
-          "Show my recent transactions",
-          "Swap 0.1 ETH for USDC",
-          "What did my agent do today?",
-        ]}
       />
     );
   }
@@ -1913,14 +1829,10 @@ function NftPreview({ nfts }: { nfts: NftItem[] }) {
 
   if (visible.length === 0) {
     return (
-      <ChatEmptyStateWithRecommendations
+      <CalmEmptyState
         icon={ImageIcon}
+        label="No NFTs to preview."
         className="min-h-[8rem]"
-        recommendations={[
-          "What NFT collections are trending?",
-          "Show floor prices for a collection",
-          "Find NFTs on Base",
-        ]}
       />
     );
   }
@@ -1965,14 +1877,10 @@ function LpPositionsPanel({
 }) {
   if (positions.length === 0) {
     return (
-      <ChatEmptyStateWithRecommendations
+      <CalmEmptyState
         icon={Layers3}
+        label="No liquidity positions."
         className="min-h-[8rem]"
-        recommendations={[
-          "How do I provide liquidity?",
-          "Explain impermanent loss",
-          "Show me top liquidity pools",
-        ]}
       />
     );
   }
@@ -2065,7 +1973,6 @@ export function InventoryAppView() {
   );
   const [marketOverview, setMarketOverview] =
     useState<WalletMarketOverviewResponse | null>(null);
-  const [marketOverviewLoading, setMarketOverviewLoading] = useState(false);
   const initialLoadRef = useRef(false);
   const tradingProfileRequestRef = useRef(0);
   const marketOverviewRequestRef = useRef(0);
@@ -2102,23 +2009,24 @@ export function InventoryAppView() {
   const loadMarketOverview = useCallback(async () => {
     const requestId = marketOverviewRequestRef.current + 1;
     marketOverviewRequestRef.current = requestId;
-    setMarketOverviewLoading(true);
 
     try {
       const overview = await client.getWalletMarketOverview();
       if (marketOverviewRequestRef.current === requestId) {
         setMarketOverview(overview);
       }
-    } catch {
-      // Market overview is an optional capability — when the feed is
-      // unavailable the empty-wallet hero simply omits the market panels
-      // rather than surfacing an error.
+    } catch (cause) {
+      // error-policy:J4 — the market feed is an optional capability, but a
+      // failed fetch is a *distinguishable* unavailable state, not a silent
+      // null that reads as "empty". Publish an overview whose sources are all
+      // marked unavailable with the error so the dashboard's market panels
+      // render `MarketDataUnavailable` instead of a blank/absent panel.
+      const message =
+        cause instanceof Error && cause.message.trim().length > 0
+          ? cause.message.trim()
+          : "Market data is currently unavailable.";
       if (marketOverviewRequestRef.current === requestId) {
-        setMarketOverview(null);
-      }
-    } finally {
-      if (marketOverviewRequestRef.current === requestId) {
-        setMarketOverviewLoading(false);
+        setMarketOverview(marketOverviewUnavailable(message));
       }
     }
   }, []);
@@ -2260,16 +2168,7 @@ export function InventoryAppView() {
           onEnableWallet={handleEnableWallet}
         />
 
-        {showMarketPulseHero ? (
-          <MarketPulseHero
-            overview={marketOverview}
-            loading={marketOverviewLoading}
-            hasKeys={
-              addresses.evmAddress !== null || addresses.solanaAddress !== null
-            }
-            onConfigureKeys={handleOpenRpcSettings}
-          />
-        ) : null}
+        {showMarketPulseHero ? <MarketPulseHero /> : null}
 
         {!showMarketPulseHero ? (
           <div className="flex flex-col gap-8">


### PR DESCRIPTION
Closes #13592.

## What

Wallet UI redesign per #13592. **Self-contained to `plugin-wallet-ui` + `WalletSectionNav`** — safe to run parallel to the #13586 uniform-topbar foundation lane; no shared-shell shell components touched (that's 13586's fence).

## Before / after

**Header (`packages/ui/src/components/pages/WalletSectionNav.tsx`)**
- Before: left-aligned tab strip with a filled-circle back button; no centered title, so mobile got a strip instead of the iOS-style centered bar other views have.
- After: a centered **"Wallet"** `ViewHeader` (icon-only launcher back), matching every other top-level view. With a single wallet-group member (current in-tree state) the secondary strip is **suppressed** — just the header. The group mechanism is intact: when a sibling registers (`plugin-hyperliquid` perps / `plugin-polymarket` predictions both use `group:"wallet"`), the strip returns automatically **under** the header.

**Empty states (`InventoryAppView.tsx`)**
- Before: **10** `ChatEmptyStateWithRecommendations` prompt-chip surfaces (movers, price grid, mover list, NFT rail, LP rail, tokens-empty, activity, NFT preview, LP panel), plus a "Keys" marketing CTA and a spot-price/top-mover market dashboard padding the empty hero.
- After: all 10 replaced with a neutral `CalmEmptyState` (bare muted glyph + one plain-fact line, no chips/marketing/emoji). "Keys" CTA dropped; `MarketPulseHero` reduced to the calm hero (empty wallet is calm, not a market terminal). The **one functional Enable-wallet control is kept**.

**Error policy (`loadMarketOverview`, `// error-policy:J4`)**
- Before: a failed fetch was swallowed into a silent `null` → "not loaded" read as "empty".
- After: a failure synthesizes an unavailable overview (sources `available:false` + the error) so the dashboard's Movers panel renders the named `MarketDataUnavailable` state, not a blank.

Also removed now-dead `MarketPriceGrid` / `MajorPriceCard` / `MarketSourceBadge` and unused imports.

## Scope note (out of scope for this lane)

The issue's larger spec (view-scoped fillable trade/swap/transfer actions, `PAGE_SCOPE_BRIEF` proactive-greeting scenario, intent-manifest wiring) depends on the scoped-action + page-scoped-context mechanisms from sibling epic children and the agent package — deliberately **not** included here to keep this lane self-contained and mechanically rebaseable. This PR delivers the UI-doctrine slice (uniform header, calm empty states, strip CTAs, J4 error policy).

## Shared-primitive dependency

Uses the existing `ViewHeader` / `ViewBackButton` primitives on develop. If the **#13586** uniform-topbar lane ships better shared header primitives later, `WalletSectionNav` can be **mechanically rebased** onto them (swap the `ViewHeader` import; the suppress-strip-when-single-member logic is orthogonal).

## Tests

- `plugin-wallet-ui`: full suite green (41 tests / 9 files). New/updated: calm-hero (no Keys CTA, no market panels), J4 `MarketDataUnavailable` in the dashboard, J4 synthesized-unavailable on fetch throw, DeFi/empty panels assert calm copy + assert the removed chips do **not** resurface.
- `packages/ui`: `WalletSectionNav.test.tsx` updated (9 tests) — centered-title header, single-member strip suppression, multi-member strip active-state. `ViewHeader.test.tsx` unaffected (9 tests, green).
- `tsgo` clean on both touched packages; `biome check` clean.

Co-authored-by: wakesync <shadow@shad0w.xyz>