### PR TITLE
fix(#13624): resolve backend-log capture port from orchestrator env

### DIFF
--- a/packages/app/scripts/lib/issue-evidence-backend-log-port.test.mjs
+++ b/packages/app/scripts/lib/issue-evidence-backend-log-port.test.mjs
@@ -1,0 +1,66 @@
+// #13624: the capture layer's `captureBackendLog` hardcoded port 31337 and all
+// six desktop/mobile capture callers pass NO port — so when the dev/capture
+// orchestrator auto-shifts the backend port (parallel agent-worktree stacks
+// advertise the shifted port via ELIZA_API_PORT / ELIZA_PORT), the backend-log
+// pull silently probed 31337, got nothing, returned null, and the capture run
+// still finished GREEN with a MISSING log artifact. `resolveBackendLogPort`
+// honors the orchestrator env so the log is pulled from the RIGHT backend.
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_BACKEND_LOG_PORT,
+  resolveBackendLogPort,
+} from "./issue-evidence.mjs";
+
+describe("resolveBackendLogPort (#13624)", () => {
+  it("falls back to the built-in default when no orchestrator env is set", () => {
+    // REGRESSION GUARD: the old hardcoded `port = 31337` default silently
+    // probed 31337 regardless of a shifted stack. An empty env legitimately
+    // resolves to the default — but a SET env must now win (cases below).
+    expect(resolveBackendLogPort({})).toBe(DEFAULT_BACKEND_LOG_PORT);
+    expect(DEFAULT_BACKEND_LOG_PORT).toBe(31337);
+  });
+
+  it("honors ELIZA_API_PORT (the orchestrator's auto-shifted port)", () => {
+    // The exact fix: a port-shifted parallel stack sets ELIZA_API_PORT; the
+    // old hardcoded 31337 ignored it and shipped no log. Now it wins.
+    expect(resolveBackendLogPort({ ELIZA_API_PORT: "41337" })).toBe(41337);
+  });
+
+  it("honors ELIZA_PORT when ELIZA_API_PORT is unset", () => {
+    expect(resolveBackendLogPort({ ELIZA_PORT: "38080" })).toBe(38080);
+  });
+
+  it("prefers ELIZA_API_PORT over ELIZA_PORT (first-wins precedence)", () => {
+    // Mirrors DESKTOP_API_PORT_KEYS order in packages/shared/src/runtime-env.ts.
+    expect(
+      resolveBackendLogPort({ ELIZA_API_PORT: "41337", ELIZA_PORT: "38080" }),
+    ).toBe(41337);
+  });
+
+  it("skips a blank/whitespace ELIZA_API_PORT and falls through to ELIZA_PORT", () => {
+    expect(
+      resolveBackendLogPort({ ELIZA_API_PORT: "   ", ELIZA_PORT: "38080" }),
+    ).toBe(38080);
+  });
+
+  it("ignores a non-numeric/out-of-range env value rather than coercing it", () => {
+    // A garbage/invalid port must NOT silently become 31337-via-NaN or a
+    // nonsense port; it is ignored so the next key (or default) applies.
+    for (const bad of ["not-a-port", "3000abc", "-1", "0", "1.5", "99999999"]) {
+      expect(resolveBackendLogPort({ ELIZA_API_PORT: bad })).toBe(
+        DEFAULT_BACKEND_LOG_PORT,
+      );
+    }
+    // Invalid ELIZA_API_PORT falls through to a valid ELIZA_PORT.
+    expect(
+      resolveBackendLogPort({ ELIZA_API_PORT: "bogus", ELIZA_PORT: "38080" }),
+    ).toBe(38080);
+  });
+
+  it("accepts the boundary port 65535 and rejects 65536", () => {
+    expect(resolveBackendLogPort({ ELIZA_API_PORT: "65535" })).toBe(65535);
+    expect(resolveBackendLogPort({ ELIZA_API_PORT: "65536" })).toBe(
+      DEFAULT_BACKEND_LOG_PORT,
+    );
+  });
+});

--- a/packages/app/scripts/lib/issue-evidence.mjs
+++ b/packages/app/scripts/lib/issue-evidence.mjs
@@ -84,14 +84,59 @@ export function mirrorToRecordings(suite, srcPath) {
   return dest;
 }
 
+// Built-in default API port for the dev backend console-log endpoint. Mirrors
+// `DEFAULT_DESKTOP_API_PORT` in packages/shared/src/runtime-env.ts — kept inline
+// so this leaf capture lib stays dependency-light (node builtins only). If the
+// canonical default changes, update it there and here.
+export const DEFAULT_BACKEND_LOG_PORT = 31337;
+
+// Env keys, in precedence order, the dev/capture orchestrator uses to advertise
+// the (possibly auto-shifted) backend API port. Mirrors `DESKTOP_API_PORT_KEYS`
+// in packages/shared/src/runtime-env.ts (ELIZA_API_PORT wins over ELIZA_PORT).
+const BACKEND_LOG_PORT_ENV_KEYS = ["ELIZA_API_PORT", "ELIZA_PORT"];
+
+/**
+ * Resolve the dev backend API port the capture run should probe, honoring the
+ * orchestrator's auto-shifted port (agent worktrees run parallel stacks and the
+ * orchestrator advertises the shifted port via ELIZA_API_PORT / ELIZA_PORT).
+ * A bare hardcoded default silently probes 31337, gets nothing on a shifted
+ * stack, and the capture still finishes green with NO backend-log artifact
+ * (#13624). First non-empty valid positive integer wins; else the built-in
+ * default. Never throws — an unparseable/out-of-range env value is ignored.
+ *
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {number}
+ */
+export function resolveBackendLogPort(env = process.env) {
+  for (const key of BACKEND_LOG_PORT_ENV_KEYS) {
+    const raw = env?.[key];
+    if (typeof raw !== "string") continue;
+    const trimmed = raw.trim();
+    if (trimmed === "") continue;
+    // Only a bare positive integer is a valid port; reject "3000abc", "-1",
+    // "0", "99999999", "1.5", etc. rather than silently coercing.
+    if (!/^\d+$/.test(trimmed)) continue;
+    const parsed = Number.parseInt(trimmed, 10);
+    if (Number.isInteger(parsed) && parsed > 0 && parsed <= 65535) {
+      return parsed;
+    }
+  }
+  return DEFAULT_BACKEND_LOG_PORT;
+}
+
 /**
  * Best-effort pull of the dev backend console log (the structured `[ClassName]`
  * stream) so a capture run ships logs alongside the screenshot + recording.
  * Never throws — returns the written path or null when the endpoint is absent.
+ *
+ * The port defaults to the orchestrator-resolved backend port (ELIZA_API_PORT /
+ * ELIZA_PORT / built-in) so a capture run on a port-shifted parallel stack pulls
+ * the log from the RIGHT backend instead of silently probing 31337 and shipping
+ * no log (#13624). An explicit `{ port }` still wins for callers that know it.
  */
 export function captureBackendLog(
   baseName,
-  { port = 31337, maxLines = 400 } = {},
+  { port = resolveBackendLogPort(), maxLines = 400 } = {},
 ) {
   const url = `http://127.0.0.1:${port}/api/dev/console-log?maxLines=${maxLines}`;
   const res = spawnSync("curl", ["-fsS", "--max-time", "5", url], {


### PR DESCRIPTION
## Summary

One slice of #13624 (capture layer goes "green with no/stale/wrong-window evidence"): the **hardcoded-ports** defect — *"`captureBackendLog` assumes `31337` … contradicts the 'orchestrator auto-shifts ports' rule."*

`captureBackendLog(baseName, { port = 31337 })` in `packages/app/scripts/lib/issue-evidence.mjs` hardcoded `31337`, and **all six** desktop/mobile capture callers (`capture-{ios-sim,android-emu,linux-desktop,macos-desktop,windows-desktop}.mjs`) call `captureBackendLog(base)` with **no** port. So when the dev/capture orchestrator auto-shifts the backend API port (parallel agent-worktree stacks advertise the shifted port via `ELIZA_API_PORT` / `ELIZA_PORT`), the backend-log pull silently probed `31337`, got nothing, returned `null`, and the capture run **still finished green with a missing log artifact**.

## Fix

- New exported `resolveBackendLogPort(env = process.env)` honors `ELIZA_API_PORT` then `ELIZA_PORT` (first-wins, mirroring `DESKTOP_API_PORT_KEYS` in `packages/shared/src/runtime-env.ts`), **rejecting** non-numeric / out-of-range values rather than coercing them, and falls back to the built-in `DEFAULT_BACKEND_LOG_PORT` (31337).
- `captureBackendLog`'s default port now resolves from it; an explicit `{ port }` override still wins, so callers that know the port are unchanged. Behavior is identical when no orchestrator env is set (default 31337), so no existing capture flow regresses.
- Kept dependency-light (node builtins only) per this leaf lib's design, with a drift-flag comment pointing at the canonical `runtime-env.ts`.

Scoped to the port-resolution defect only. The other #13624 sub-problems (the `audit:cloud` `afterAll`-never-throws reporter + turbo-cache skip, the `skip()→exit(0)` / `SKIP_EXIT_CODE=77` divergence, the orphaned story-gate log-capture helpers, the electrobun whole-desktop screenshot) are distinct Playwright/renderer/device-gated slices left for follow-up; issue stays open.

## Tests

`packages/app/scripts/lib/issue-evidence-backend-log-port.test.mjs` — **7/7 green** (`vitest run`):
- default fallback when no env set (asserts `DEFAULT_BACKEND_LOG_PORT === 31337`)
- `ELIZA_API_PORT` honored (the exact orchestrator-shift case the old hardcode ignored)
- `ELIZA_PORT` honored when `ELIZA_API_PORT` unset
- `ELIZA_API_PORT` wins over `ELIZA_PORT` (first-wins precedence)
- blank/whitespace `ELIZA_API_PORT` falls through to `ELIZA_PORT`
- non-numeric / `-1` / `0` / `1.5` / `99999999` ignored (not coerced), falls through to a valid next key/default
- boundary: accepts `65535`, rejects `65536`

**Reversion-proof:** reverting `resolveBackendLogPort` to the old env-ignoring behavior fails **6/7** of these tests — proving the fix is real and the tests catch the bug.

- `bunx @biomejs/biome check` on both touched files — clean
- `audit:error-policy-ratchet` — no new fallback-slop in touched files
- `node --check` on both `.mjs` files — clean (scripts are not in the tsgo typecheck include)
- `codex review --uncommitted` — clean ("correctly resolves the backend log port from the orchestrator environment while preserving the default and explicit override behavior … did not identify a discrete regression")

The single `audit:scripts` finding (`scripts/check-markdown-links.mjs` plugin-token coupling) is **pre-existing** — that file is byte-identical to `origin/develop`, untouched by this PR.

— [sol-orch]
