### PR TITLE
feat(agent): knowledge slice 1 — attachment→knowledge ingest pipeline (#13593)

### DIFF
--- a/packages/agent/src/api/attachment-knowledge-backfill.test.ts
+++ b/packages/agent/src/api/attachment-knowledge-backfill.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for the transcript-mirror knowledge backfill (#13593):
+ * computeTranscriptBackfillMetadata adds roomId + media-format:transcript to
+ * mirrors missing them, preserves transcriptId/audioUrl links, and is
+ * idempotent (a fully-tagged record yields null). backfillTranscriptKnowledgeTags
+ * only updates the records that need it and is a no-op on re-run.
+ */
+import type { Memory, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  backfillTranscriptKnowledgeTags,
+  computeTranscriptBackfillMetadata,
+} from "./attachment-knowledge-backfill.ts";
+
+const ROOM_ID = "00000000-0000-0000-0000-0000000000a1" as UUID;
+
+function doc(
+  id: string,
+  metadata: Record<string, unknown>,
+  roomId = ROOM_ID,
+): Memory {
+  return {
+    id: id as UUID,
+    entityId: "00000000-0000-0000-0000-0000000000b1" as UUID,
+    agentId: "00000000-0000-0000-0000-0000000000c1" as UUID,
+    roomId,
+    content: { text: "transcript body" },
+    metadata,
+    createdAt: Date.now(),
+  } as Memory;
+}
+
+describe("computeTranscriptBackfillMetadata", () => {
+  it("adds roomId + media-format tag/facet to a legacy transcript mirror", () => {
+    const memory = doc("d1", {
+      source: "transcript",
+      tags: ["transcript"],
+      transcriptId: "t-1",
+      audioUrl: "/api/media/aa.mp3",
+    });
+    const patched = computeTranscriptBackfillMetadata(memory);
+    expect(patched).not.toBeNull();
+    expect(patched?.roomId).toBe(ROOM_ID);
+    expect(patched?.mediaFormat).toBe("transcript");
+    expect(patched?.tags).toEqual(["transcript", "media-format:transcript"]);
+    // Links preserved.
+    expect(patched?.transcriptId).toBe("t-1");
+    expect(patched?.audioUrl).toBe("/api/media/aa.mp3");
+  });
+
+  it("detects a mirror by transcriptId even without the transcript tag", () => {
+    const memory = doc("d2", { transcriptId: "t-2", tags: [] });
+    const patched = computeTranscriptBackfillMetadata(memory);
+    expect(patched?.mediaFormat).toBe("transcript");
+    expect(patched?.tags).toContain("media-format:transcript");
+  });
+
+  it("is idempotent: a fully-tagged mirror yields null", () => {
+    const memory = doc("d3", {
+      source: "transcript",
+      tags: ["transcript", "media-format:transcript"],
+      transcriptId: "t-3",
+      mediaFormat: "transcript",
+      roomId: ROOM_ID,
+    });
+    expect(computeTranscriptBackfillMetadata(memory)).toBeNull();
+  });
+
+  it("ignores non-transcript documents", () => {
+    const memory = doc("d4", {
+      source: "upload",
+      tags: ["attachment", "media-format:image"],
+    });
+    expect(computeTranscriptBackfillMetadata(memory)).toBeNull();
+  });
+});
+
+describe("backfillTranscriptKnowledgeTags", () => {
+  it("updates only the records that need it and is a no-op on re-run", async () => {
+    const legacy = doc("m1", {
+      source: "transcript",
+      tags: ["transcript"],
+      transcriptId: "t-1",
+    });
+    const alreadyTagged = doc("m2", {
+      source: "transcript",
+      tags: ["transcript", "media-format:transcript"],
+      transcriptId: "t-2",
+      mediaFormat: "transcript",
+      roomId: ROOM_ID,
+    });
+    const notATranscript = doc("m3", {
+      source: "upload",
+      tags: ["attachment", "media-format:pdf"],
+    });
+
+    const store = new Map<string, Memory>([
+      ["m1", legacy],
+      ["m2", alreadyTagged],
+      ["m3", notATranscript],
+    ]);
+
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-0000000000c1" as UUID,
+      getMemories: vi.fn(async () => [...store.values()]),
+      updateMemory: vi.fn(
+        async (patch: { id: UUID; metadata?: Record<string, unknown> }) => {
+          const existing = store.get(patch.id);
+          if (existing) {
+            store.set(patch.id, {
+              ...existing,
+              metadata: patch.metadata,
+            } as Memory);
+          }
+          return true;
+        },
+      ),
+    } as never;
+
+    const updated = await backfillTranscriptKnowledgeTags(runtime);
+    expect(updated).toBe(1);
+    const m1Meta = store.get("m1")?.metadata as
+      | Record<string, unknown>
+      | undefined;
+    expect(m1Meta?.mediaFormat).toBe("transcript");
+    expect(m1Meta?.roomId).toBe(ROOM_ID);
+
+    // Re-run: everything already tagged → no updates.
+    const updatedAgain = await backfillTranscriptKnowledgeTags(runtime);
+    expect(updatedAgain).toBe(0);
+  });
+});

--- a/packages/agent/src/api/attachment-knowledge-backfill.ts
+++ b/packages/agent/src/api/attachment-knowledge-backfill.ts
@@ -1,0 +1,186 @@
+/**
+ * One-time idempotent backfill for pre-existing knowledge records that predate
+ * the attachment→knowledge ingest tagging (#13593). Transcript-mirror documents
+ * (tag `transcript`) and meeting mirrors were written before this slice added
+ * the room/sender/media-format facets, so a search on `roomId`/`mediaFormat`
+ * misses them. This sweep adds:
+ *
+ *   - `metadata.roomId` (from the record's own `roomId`, when absent), and
+ *   - `metadata.mediaFormat = "transcript"` + the `media-format:transcript` tag
+ *
+ * WITHOUT touching the `transcriptId` / `audioUrl` links (those stay the source
+ * of truth). It is idempotent: a record already carrying both facets is skipped,
+ * so re-running is a no-op. Runs as a runtime task so it executes once wherever
+ * the agent runs and never blocks boot.
+ */
+
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+
+const DOCUMENTS_TABLE = "documents";
+const TRANSCRIPT_TAG = "transcript";
+const MEDIA_FORMAT_TAG_PREFIX = "media-format:";
+const TRANSCRIPT_MEDIA_FORMAT = "transcript";
+const BACKFILL_BATCH_SIZE = 500;
+
+const BACKFILL_TASK_NAME = "KNOWLEDGE_TAG_BACKFILL";
+const BACKFILL_TAGS = ["queue", "knowledge-tag-backfill"];
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringTags(metadata: Record<string, unknown> | undefined): string[] {
+  const tags = metadata?.tags;
+  return Array.isArray(tags)
+    ? tags.filter((value): value is string => typeof value === "string")
+    : [];
+}
+
+/** True when a record is a transcript mirror (tag or explicit transcriptId). */
+function isTranscriptMirror(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  if (!metadata) return false;
+  if (typeof metadata.transcriptId === "string") return true;
+  return stringTags(metadata).includes(TRANSCRIPT_TAG);
+}
+
+/**
+ * Compute the patched metadata for a transcript-mirror record, or null when it
+ * already carries both the `roomId` and `mediaFormat`/format-tag facets (i.e.
+ * nothing to do — the idempotency check).
+ */
+export function computeTranscriptBackfillMetadata(
+  memory: Memory,
+): Record<string, unknown> | null {
+  const metadata = asRecord(memory.metadata);
+  if (!isTranscriptMirror(metadata)) return null;
+
+  const tags = stringTags(metadata);
+  const hasFormatTag = tags.some((tag) =>
+    tag.startsWith(MEDIA_FORMAT_TAG_PREFIX),
+  );
+  const hasFormat =
+    typeof metadata?.mediaFormat === "string" &&
+    metadata.mediaFormat.length > 0;
+  const existingRoomId =
+    typeof metadata?.roomId === "string" ? metadata.roomId : undefined;
+  const recordRoomId =
+    typeof memory.roomId === "string" ? (memory.roomId as UUID) : undefined;
+  const needsRoomId = !existingRoomId && Boolean(recordRoomId);
+
+  if (hasFormat && hasFormatTag && !needsRoomId) {
+    return null; // already backfilled — idempotent no-op
+  }
+
+  const nextTags = hasFormatTag
+    ? tags
+    : [...tags, `${MEDIA_FORMAT_TAG_PREFIX}${TRANSCRIPT_MEDIA_FORMAT}`];
+
+  return {
+    ...(metadata ?? {}),
+    tags: nextTags,
+    mediaFormat: TRANSCRIPT_MEDIA_FORMAT,
+    ...(needsRoomId ? { roomId: recordRoomId } : {}),
+  };
+}
+
+/**
+ * Scan the documents table and backfill transcript-mirror records missing the
+ * room/media-format facets. Returns the number of records updated. Pure sweep:
+ * link fields (`transcriptId`, `audioUrl`) are preserved.
+ */
+export async function backfillTranscriptKnowledgeTags(
+  runtime: IAgentRuntime,
+): Promise<number> {
+  let offset = 0;
+  let updated = 0;
+
+  while (true) {
+    const batch = await runtime.getMemories({
+      tableName: DOCUMENTS_TABLE,
+      // Scope the sweep to THIS agent: in a shared/multi-agent store
+      // `getMemories` only filters by fields passed explicitly, so without
+      // agentId the backfill could fetch (and `updateMemory` rewrite) another
+      // agent's transcript documents.
+      agentId: runtime.agentId,
+      count: BACKFILL_BATCH_SIZE,
+      offset,
+    });
+    if (batch.length === 0) break;
+
+    for (const memory of batch) {
+      if (!memory.id) continue;
+      // Defense in depth: never patch a row owned by a different agent even if
+      // the adapter ignored the agentId filter.
+      if (memory.agentId && memory.agentId !== runtime.agentId) continue;
+      const patched = computeTranscriptBackfillMetadata(memory);
+      if (!patched) continue;
+      await runtime.updateMemory({
+        id: memory.id as UUID,
+        metadata: patched as Memory["metadata"],
+      });
+      updated += 1;
+    }
+
+    if (batch.length < BACKFILL_BATCH_SIZE) break;
+    offset += BACKFILL_BATCH_SIZE;
+  }
+
+  return updated;
+}
+
+/**
+ * Register the one-time backfill task. The worker is idempotent, so a duplicate
+ * run is harmless; we also guard task creation so we don't enqueue it twice.
+ */
+export function registerAttachmentKnowledgeBackfillTask(
+  runtime: IAgentRuntime,
+): void {
+  runtime.registerTaskWorker({
+    name: BACKFILL_TASK_NAME,
+    execute: async (rt) => {
+      try {
+        const updated = await backfillTranscriptKnowledgeTags(rt);
+        if (updated > 0) {
+          rt.logger.info(
+            `[knowledge-backfill] tagged ${updated} transcript-mirror document(s) with roomId/mediaFormat`,
+          );
+        }
+      } catch (err) {
+        rt.logger.warn(
+          `[knowledge-backfill] sweep failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+      return undefined;
+    },
+  });
+
+  void (async () => {
+    try {
+      const existing = await runtime.getTasks({
+        agentIds: [runtime.agentId],
+        tags: BACKFILL_TAGS,
+      });
+      if (existing.some((task) => task.name === BACKFILL_TASK_NAME)) return;
+      await runtime.createTask({
+        name: BACKFILL_TASK_NAME,
+        description:
+          "One-time backfill of room/media-format tags on transcript-mirror knowledge records",
+        tags: [...BACKFILL_TAGS],
+        agentId: runtime.agentId,
+        metadata: { updatedAt: Date.now() },
+      });
+    } catch (err) {
+      runtime.logger.warn(
+        `[knowledge-backfill] failed to schedule backfill task: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  })();
+}

--- a/packages/agent/src/api/attachment-knowledge-backfill.ts
+++ b/packages/agent/src/api/attachment-knowledge-backfill.ts
@@ -150,6 +150,9 @@ export function registerAttachmentKnowledgeBackfillTask(
           );
         }
       } catch (err) {
+        // error-policy:J7 the one-time metadata sweep must not kill runtime
+        // startup, but the failure needs to reach RECENT_ERRORS/escalation.
+        rt.reportError("knowledge-backfill", err);
         rt.logger.warn(
           `[knowledge-backfill] sweep failed: ${
             err instanceof Error ? err.message : String(err)
@@ -176,6 +179,9 @@ export function registerAttachmentKnowledgeBackfillTask(
         metadata: { updatedAt: Date.now() },
       });
     } catch (err) {
+      // error-policy:J7 scheduling is diagnostic/background work; report it
+      // observably while allowing the agent to continue booting.
+      runtime.reportError("knowledge-backfill-schedule", err);
       runtime.logger.warn(
         `[knowledge-backfill] failed to schedule backfill task: ${
           err instanceof Error ? err.message : String(err)

--- a/packages/agent/src/api/attachment-knowledge-ingest.test.ts
+++ b/packages/agent/src/api/attachment-knowledge-ingest.test.ts
@@ -1,0 +1,597 @@
+/**
+ * Unit tests for the attachment→knowledge ingest pipeline (#13593):
+ * media-format derivation, scope-by-source-trust (owner/DM → owner-private,
+ * public room → user-private), the ingest happy path (one knowledge doc per
+ * store-backed attachment with correct sha256 link, tags, roomId, addedBy/role),
+ * unsupported-source handling (remote/ephemeral URLs skipped, agent's own
+ * outgoing attachments skipped), idempotency delegation, and fail-fast typed
+ * errors.
+ */
+import {
+  ChannelType,
+  ContentType,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type AttachmentIngestDocumentService,
+  attachmentKnowledgeTags,
+  ingestMessageAttachmentsAsKnowledge,
+  mediaFormatFromMimeType,
+  registerAttachmentKnowledgeIngestHook,
+  resolveIngestScope,
+  roomIsPrivateSurface,
+} from "./attachment-knowledge-ingest.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const OWNER_ENTITY = "00000000-0000-0000-0000-0000000000b1" as UUID;
+const USER_ENTITY = "00000000-0000-0000-0000-0000000000c2" as UUID;
+const WORLD_ID = "00000000-0000-0000-0000-0000000000dd" as UUID;
+const DM_ROOM = "00000000-0000-0000-0000-0000000000e1" as UUID;
+const PUBLIC_ROOM = "00000000-0000-0000-0000-0000000000e2" as UUID;
+
+const STORED_IMAGE_URL =
+  "/api/media/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.png";
+const STORED_PDF_URL =
+  "/api/media/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.pdf";
+
+describe("mediaFormatFromMimeType", () => {
+  it("derives coarse format from mime type", () => {
+    expect(mediaFormatFromMimeType("image/png")).toBe("image");
+    expect(mediaFormatFromMimeType("audio/mpeg")).toBe("audio");
+    expect(mediaFormatFromMimeType("video/mp4")).toBe("video");
+    expect(mediaFormatFromMimeType("application/pdf")).toBe("pdf");
+    expect(mediaFormatFromMimeType("text/plain")).toBe("text");
+    expect(mediaFormatFromMimeType("application/json")).toBe("text");
+    expect(mediaFormatFromMimeType("application/zip")).toBe("file");
+  });
+
+  it("falls back to ContentType when mime is missing/unknown", () => {
+    expect(mediaFormatFromMimeType(undefined, ContentType.IMAGE)).toBe("image");
+    expect(mediaFormatFromMimeType("", ContentType.AUDIO)).toBe("audio");
+    expect(mediaFormatFromMimeType(undefined, ContentType.DOCUMENT)).toBe(
+      "file",
+    );
+    expect(mediaFormatFromMimeType(undefined)).toBe("file");
+  });
+
+  it("builds the ordered attachment + media-format tag set", () => {
+    expect(attachmentKnowledgeTags("pdf")).toEqual([
+      "attachment",
+      "media-format:pdf",
+    ]);
+  });
+});
+
+describe("roomIsPrivateSurface / resolveIngestScope (spill guard)", () => {
+  it("treats DM/SELF/VOICE_DM/API as private surfaces, others public", () => {
+    expect(roomIsPrivateSurface(ChannelType.DM)).toBe(true);
+    expect(roomIsPrivateSurface(ChannelType.SELF)).toBe(true);
+    expect(roomIsPrivateSurface(ChannelType.VOICE_DM)).toBe(true);
+    expect(roomIsPrivateSurface(ChannelType.API)).toBe(true);
+    expect(roomIsPrivateSurface(ChannelType.GROUP)).toBe(false);
+    expect(roomIsPrivateSurface(ChannelType.FORUM)).toBe(false);
+    expect(roomIsPrivateSurface(undefined)).toBe(false);
+  });
+
+  it("owner in a DM → owner-private", () => {
+    expect(
+      resolveIngestScope({
+        channelType: ChannelType.DM,
+        senderIsOwner: true,
+        senderEntityId: OWNER_ENTITY,
+      }),
+    ).toEqual({ scope: "owner-private" });
+  });
+
+  it("owner in a PUBLIC room → user-private scoped to owner (never spills)", () => {
+    expect(
+      resolveIngestScope({
+        channelType: ChannelType.GROUP,
+        senderIsOwner: true,
+        senderEntityId: OWNER_ENTITY,
+      }),
+    ).toEqual({ scope: "user-private", scopedToEntityId: OWNER_ENTITY });
+  });
+
+  it("non-owner in a DM → user-private (owner-private reserved for owner)", () => {
+    expect(
+      resolveIngestScope({
+        channelType: ChannelType.DM,
+        senderIsOwner: false,
+        senderEntityId: USER_ENTITY,
+      }),
+    ).toEqual({ scope: "user-private", scopedToEntityId: USER_ENTITY });
+  });
+
+  it("non-owner in a PUBLIC room → user-private scoped to sender", () => {
+    expect(
+      resolveIngestScope({
+        channelType: ChannelType.GROUP,
+        senderIsOwner: false,
+        senderEntityId: USER_ENTITY,
+      }),
+    ).toEqual({ scope: "user-private", scopedToEntityId: USER_ENTITY });
+  });
+});
+
+type AddDocumentCall = Parameters<
+  AttachmentIngestDocumentService["addDocument"]
+>[0];
+
+function makeDocumentService(): {
+  service: AttachmentIngestDocumentService;
+  calls: AddDocumentCall[];
+} {
+  const calls: AddDocumentCall[] = [];
+  let counter = 0;
+  const service: AttachmentIngestDocumentService = {
+    addDocument: vi.fn(async (options: AddDocumentCall) => {
+      calls.push(options);
+      counter += 1;
+      return {
+        clientDocumentId: `doc-${counter}` as UUID,
+        storedDocumentMemoryId: `mem-${counter}` as UUID,
+        fragmentCount: 1,
+      };
+    }),
+  };
+  return { service, calls };
+}
+
+function makeRuntime(params: {
+  roomType: ChannelType;
+  roomId: UUID;
+  ownerId?: UUID;
+}) {
+  const { roomType, ownerId } = params;
+  return {
+    agentId: AGENT_ID,
+    getRoom: vi.fn(async (id: UUID) => ({
+      id,
+      type: roomType,
+      worldId: WORLD_ID,
+      source: "test",
+    })),
+    getWorld: vi.fn(async (worldId: UUID) => ({
+      id: worldId,
+      metadata: {
+        roles: {
+          ...(ownerId ? { [ownerId]: "OWNER" } : {}),
+          [USER_ENTITY]: "USER",
+        },
+        ...(ownerId ? { ownership: { ownerId } } : {}),
+      },
+    })),
+    getSetting: vi.fn(() => undefined),
+    getEntityById: vi.fn(async () => null),
+    getRelationships: vi.fn(async () => []),
+    reportError: vi.fn(),
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as never;
+}
+
+function messageWithAttachments(
+  overrides: Partial<Memory> & {
+    attachments: NonNullable<Memory["content"]["attachments"]>;
+    entityId: UUID;
+    roomId: UUID;
+  },
+): Memory {
+  return {
+    id: "00000000-0000-0000-0000-0000000000ff" as UUID,
+    entityId: overrides.entityId,
+    agentId: AGENT_ID,
+    roomId: overrides.roomId,
+    worldId: WORLD_ID,
+    content: {
+      text: "here you go",
+      attachments: overrides.attachments,
+    },
+    createdAt: Date.now(),
+  } as Memory;
+}
+
+describe("ingestMessageAttachmentsAsKnowledge", () => {
+  it("files one owner-private doc per stored attachment from an owner DM, linked to sha256", async () => {
+    const { service, calls } = makeDocumentService();
+    const runtime = makeRuntime({
+      roomType: ChannelType.DM,
+      roomId: DM_ROOM,
+      ownerId: OWNER_ENTITY,
+    });
+    const message = messageWithAttachments({
+      entityId: OWNER_ENTITY,
+      roomId: DM_ROOM,
+      attachments: [
+        {
+          id: "a1",
+          url: STORED_IMAGE_URL,
+          contentType: ContentType.IMAGE,
+          mimeType: "image/png",
+          filename: "chart.png",
+          description: "a bar chart of Q3 revenue",
+        },
+        {
+          id: "a2",
+          url: STORED_PDF_URL,
+          contentType: ContentType.DOCUMENT,
+          mimeType: "application/pdf",
+          filename: "report.pdf",
+        },
+      ],
+    });
+
+    const results = await ingestMessageAttachmentsAsKnowledge(
+      { runtime, documents: service } as never,
+      message,
+    );
+
+    expect(results).toHaveLength(2);
+    expect(calls).toHaveLength(2);
+
+    const image = calls[0];
+    expect(image.scope).toBe("owner-private");
+    expect(image.scopedToEntityId).toBeUndefined();
+    expect(image.addedBy).toBe(OWNER_ENTITY);
+    expect(image.addedByRole).toBe("OWNER");
+    expect(image.addedFrom).toBe("chat");
+    expect(image.roomId).toBe(DM_ROOM);
+    expect(image.metadata?.roomId).toBe(DM_ROOM);
+    expect(image.metadata?.mediaFormat).toBe("image");
+    expect(image.metadata?.tags).toEqual(["attachment", "media-format:image"]);
+    expect(image.metadata?.mediaUrl).toBe(STORED_IMAGE_URL);
+    expect(image.metadata?.mediaFileName).toBe(
+      STORED_IMAGE_URL.replace("/api/media/", ""),
+    );
+    // Description text is used as the searchable body.
+    expect(image.content).toContain("Q3 revenue");
+    // A context provenance line (room/sender/scope) is appended so the
+    // documents store's content-addressed dedupe is context-scoped.
+    expect(image.content).toContain(`room=${DM_ROOM}`);
+    expect(image.content).toContain(`sender=${OWNER_ENTITY}`);
+    expect(image.content).toContain("scope=owner-private");
+
+    const pdf = calls[1];
+    expect(pdf.scope).toBe("owner-private");
+    expect(pdf.metadata?.mediaFormat).toBe("pdf");
+    expect(pdf.metadata?.tags).toEqual(["attachment", "media-format:pdf"]);
+  });
+
+  it("scopes a public-room attachment to the sender (user-private), never owner-private/global", async () => {
+    const { service, calls } = makeDocumentService();
+    const runtime = makeRuntime({
+      roomType: ChannelType.GROUP,
+      roomId: PUBLIC_ROOM,
+      ownerId: OWNER_ENTITY,
+    });
+    const message = messageWithAttachments({
+      entityId: USER_ENTITY,
+      roomId: PUBLIC_ROOM,
+      attachments: [
+        {
+          id: "b1",
+          url: STORED_IMAGE_URL,
+          contentType: ContentType.IMAGE,
+          mimeType: "image/png",
+          filename: "meme.png",
+        },
+      ],
+    });
+
+    const results = await ingestMessageAttachmentsAsKnowledge(
+      { runtime, documents: service } as never,
+      message,
+    );
+
+    expect(results).toHaveLength(1);
+    const call = calls[0];
+    expect(call.scope).toBe("user-private");
+    expect(call.scopedToEntityId).toBe(USER_ENTITY);
+    expect(call.entityId).toBe(USER_ENTITY);
+    expect(call.addedByRole).toBe("USER");
+    expect(call.scope).not.toBe("owner-private");
+    expect(call.scope).not.toBe("global");
+  });
+
+  it("even the OWNER speaking in a public room does not get owner-private (spill guard)", async () => {
+    const { service, calls } = makeDocumentService();
+    const runtime = makeRuntime({
+      roomType: ChannelType.GROUP,
+      roomId: PUBLIC_ROOM,
+      ownerId: OWNER_ENTITY,
+    });
+    const message = messageWithAttachments({
+      entityId: OWNER_ENTITY,
+      roomId: PUBLIC_ROOM,
+      attachments: [
+        {
+          id: "c1",
+          url: STORED_PDF_URL,
+          contentType: ContentType.DOCUMENT,
+          mimeType: "application/pdf",
+          filename: "secret.pdf",
+        },
+      ],
+    });
+
+    await ingestMessageAttachmentsAsKnowledge(
+      { runtime, documents: service } as never,
+      message,
+    );
+
+    const call = calls[0];
+    expect(call.scope).toBe("user-private");
+    expect(call.scopedToEntityId).toBe(OWNER_ENTITY);
+    expect(call.scope).not.toBe("owner-private");
+  });
+
+  it("skips attachments whose bytes are not in the store (remote/ephemeral)", async () => {
+    const { service, calls } = makeDocumentService();
+    const runtime = makeRuntime({
+      roomType: ChannelType.DM,
+      roomId: DM_ROOM,
+      ownerId: OWNER_ENTITY,
+    });
+    const message = messageWithAttachments({
+      entityId: OWNER_ENTITY,
+      roomId: DM_ROOM,
+      attachments: [
+        {
+          id: "r1",
+          url: "https://cdn.example.com/x.png",
+          contentType: ContentType.IMAGE,
+          mimeType: "image/png",
+        },
+        {
+          id: "s1",
+          url: STORED_IMAGE_URL,
+          contentType: ContentType.IMAGE,
+          mimeType: "image/png",
+        },
+      ],
+    });
+
+    const results = await ingestMessageAttachmentsAsKnowledge(
+      { runtime, documents: service } as never,
+      message,
+    );
+
+    expect(results).toHaveLength(1);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].metadata?.mediaUrl).toBe(STORED_IMAGE_URL);
+  });
+
+  it("throws a typed ElizaError if a document write fails (fail fast, never silent)", async () => {
+    const service: AttachmentIngestDocumentService = {
+      addDocument: vi.fn(async () => {
+        throw new Error("db down");
+      }),
+    };
+    const runtime = makeRuntime({
+      roomType: ChannelType.DM,
+      roomId: DM_ROOM,
+      ownerId: OWNER_ENTITY,
+    });
+    const message = messageWithAttachments({
+      entityId: OWNER_ENTITY,
+      roomId: DM_ROOM,
+      attachments: [
+        {
+          id: "f1",
+          url: STORED_IMAGE_URL,
+          contentType: ContentType.IMAGE,
+          mimeType: "image/png",
+        },
+      ],
+    });
+
+    await expect(
+      ingestMessageAttachmentsAsKnowledge(
+        { runtime, documents: service } as never,
+        message,
+      ),
+    ).rejects.toMatchObject({
+      code: "ATTACHMENT_KNOWLEDGE_INGEST_FAILED",
+    });
+  });
+
+  it("gives the SAME bytes distinct content per (room, sender, scope) so dedupe doesn't drop facets", async () => {
+    const attachment = {
+      id: "dup",
+      url: STORED_IMAGE_URL,
+      contentType: ContentType.IMAGE,
+      mimeType: "image/png",
+      filename: "shared.png",
+      description: "the same shared image",
+    };
+
+    // Same bytes, owner DM.
+    const { service: svc1, calls: calls1 } = makeDocumentService();
+    await ingestMessageAttachmentsAsKnowledge(
+      {
+        runtime: makeRuntime({
+          roomType: ChannelType.DM,
+          roomId: DM_ROOM,
+          ownerId: OWNER_ENTITY,
+        }),
+        documents: svc1,
+      } as never,
+      messageWithAttachments({
+        entityId: OWNER_ENTITY,
+        roomId: DM_ROOM,
+        attachments: [attachment],
+      }),
+    );
+
+    // Same bytes, different user in a public room.
+    const { service: svc2, calls: calls2 } = makeDocumentService();
+    await ingestMessageAttachmentsAsKnowledge(
+      {
+        runtime: makeRuntime({
+          roomType: ChannelType.GROUP,
+          roomId: PUBLIC_ROOM,
+          ownerId: OWNER_ENTITY,
+        }),
+        documents: svc2,
+      } as never,
+      messageWithAttachments({
+        entityId: USER_ENTITY,
+        roomId: PUBLIC_ROOM,
+        attachments: [attachment],
+      }),
+    );
+
+    // Distinct content bodies → distinct content-addressed ids → the public-room
+    // record does not shadow the owner's DM record (no scope/facet loss).
+    expect(calls1[0].content).not.toBe(calls2[0].content);
+    expect(calls1[0].scope).toBe("owner-private");
+    expect(calls2[0].scope).toBe("user-private");
+  });
+
+  it("returns nothing for a message with no attachments", async () => {
+    const { service } = makeDocumentService();
+    const runtime = makeRuntime({
+      roomType: ChannelType.DM,
+      roomId: DM_ROOM,
+      ownerId: OWNER_ENTITY,
+    });
+    const message = {
+      id: "00000000-0000-0000-0000-0000000000f0" as UUID,
+      entityId: OWNER_ENTITY,
+      agentId: AGENT_ID,
+      roomId: DM_ROOM,
+      worldId: WORLD_ID,
+      content: { text: "no files here" },
+      createdAt: Date.now(),
+    } as Memory;
+
+    const results = await ingestMessageAttachmentsAsKnowledge(
+      { runtime, documents: service } as never,
+      message,
+    );
+    expect(results).toEqual([]);
+  });
+});
+
+describe("registerAttachmentKnowledgeIngestHook", () => {
+  type CapturedHook = {
+    id: string;
+    phase: string;
+    handler: (rt: unknown, ctx: unknown) => unknown;
+  };
+
+  function captureRuntime(documents: unknown) {
+    let hook: CapturedHook | null = null;
+    const runtime = {
+      agentId: AGENT_ID,
+      registerPipelineHook: (spec: CapturedHook) => {
+        hook = spec;
+      },
+      getService: vi.fn((name: string) =>
+        name === "documents" ? documents : null,
+      ),
+      getRoom: vi.fn(async (id: UUID) => ({
+        id,
+        type: ChannelType.DM,
+        worldId: WORLD_ID,
+        source: "test",
+      })),
+      getWorld: vi.fn(async (worldId: UUID) => ({
+        id: worldId,
+        metadata: {
+          roles: { [OWNER_ENTITY]: "OWNER" },
+          ownership: { ownerId: OWNER_ENTITY },
+        },
+      })),
+      getSetting: vi.fn(() => undefined),
+      getEntityById: vi.fn(async () => null),
+      getRelationships: vi.fn(async () => []),
+      reportError: vi.fn(),
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } as never;
+    return {
+      runtime,
+      getHook: () => {
+        if (!hook) throw new Error("hook not registered");
+        return hook;
+      },
+    };
+  }
+
+  it("registers an after_memory_persisted reader hook", () => {
+    const { service } = makeDocumentService();
+    const { runtime, getHook } = captureRuntime(service);
+    registerAttachmentKnowledgeIngestHook(runtime);
+    const hook = getHook();
+    expect(hook.phase).toBe("after_memory_persisted");
+    expect(hook.id).toBe("attachment-knowledge-ingest");
+  });
+
+  it("ingests on a messages-table user attachment, ignores other tables", async () => {
+    const { service, calls } = makeDocumentService();
+    const { runtime, getHook } = captureRuntime(service);
+    registerAttachmentKnowledgeIngestHook(runtime);
+    const hook = getHook();
+
+    const memory = messageWithAttachments({
+      entityId: OWNER_ENTITY,
+      roomId: DM_ROOM,
+      attachments: [
+        {
+          id: "h1",
+          url: STORED_IMAGE_URL,
+          contentType: ContentType.IMAGE,
+          mimeType: "image/png",
+        },
+      ],
+    });
+
+    // Wrong table → no-op.
+    await hook.handler(runtime, {
+      phase: "after_memory_persisted",
+      tableName: "documents",
+      memoryId: memory.id,
+      memory,
+    });
+    expect(calls).toHaveLength(0);
+
+    // messages table → ingests.
+    await hook.handler(runtime, {
+      phase: "after_memory_persisted",
+      tableName: "messages",
+      memoryId: memory.id,
+      memory,
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("skips the agent's own outgoing attachments", async () => {
+    const { service, calls } = makeDocumentService();
+    const { runtime, getHook } = captureRuntime(service);
+    registerAttachmentKnowledgeIngestHook(runtime);
+    const hook = getHook();
+
+    const memory = messageWithAttachments({
+      entityId: AGENT_ID, // agent is the sender
+      roomId: DM_ROOM,
+      attachments: [
+        {
+          id: "o1",
+          url: STORED_IMAGE_URL,
+          contentType: ContentType.IMAGE,
+          mimeType: "image/png",
+        },
+      ],
+    });
+
+    await hook.handler(runtime, {
+      phase: "after_memory_persisted",
+      tableName: "messages",
+      memoryId: memory.id,
+      memory,
+    });
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/packages/agent/src/api/attachment-knowledge-ingest.test.ts
+++ b/packages/agent/src/api/attachment-knowledge-ingest.test.ts
@@ -169,7 +169,7 @@ function makeRuntime(params: {
     getRelationships: vi.fn(async () => []),
     reportError: vi.fn(),
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-  } as never;
+  } as Record<string, unknown>;
 }
 
 function messageWithAttachments(
@@ -257,6 +257,12 @@ describe("ingestMessageAttachmentsAsKnowledge", () => {
     expect(pdf.scope).toBe("owner-private");
     expect(pdf.metadata?.mediaFormat).toBe("pdf");
     expect(pdf.metadata?.tags).toEqual(["attachment", "media-format:pdf"]);
+    // A PDF attachment is stored as a text record under a .txt name so the
+    // documents service does NOT run the .pdf base64-decode/extract path on the
+    // synthesized plaintext body. The display filename is preserved in metadata.
+    expect(pdf.contentType).toBe("text/plain");
+    expect(pdf.originalFilename).toBe("report.txt");
+    expect(pdf.metadata?.filename).toBe("report.pdf");
   });
 
   it("scopes a public-room attachment to the sender (user-private), never owner-private/global", async () => {
@@ -453,6 +459,51 @@ describe("ingestMessageAttachmentsAsKnowledge", () => {
     ).rejects.toMatchObject({
       code: "ATTACHMENT_KNOWLEDGE_WORLD_LOOKUP_FAILED",
     });
+  });
+
+  it("gives DIFFERENT bytes with the same filename+description distinct content (media hash in body)", async () => {
+    const { service, calls } = makeDocumentService();
+    const runtime = makeRuntime({
+      roomType: ChannelType.DM,
+      roomId: DM_ROOM,
+      ownerId: OWNER_ENTITY,
+    });
+    // Two DISTINCT stored files (different sha256) that share filename +
+    // description — without the media hash in the body they'd dedupe and the
+    // second file's mediaUrl/hash would be lost.
+    const message = messageWithAttachments({
+      entityId: OWNER_ENTITY,
+      roomId: DM_ROOM,
+      attachments: [
+        {
+          id: "dup1",
+          url: STORED_IMAGE_URL,
+          contentType: ContentType.IMAGE,
+          mimeType: "image/png",
+          filename: "same.png",
+          description: "same description",
+        },
+        {
+          id: "dup2",
+          url: "/api/media/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc.png",
+          contentType: ContentType.IMAGE,
+          mimeType: "image/png",
+          filename: "same.png",
+          description: "same description",
+        },
+      ],
+    });
+
+    await ingestMessageAttachmentsAsKnowledge(
+      { runtime, documents: service } as never,
+      message,
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].content).not.toBe(calls[1].content);
+    expect(calls[0].metadata?.mediaFileName).not.toBe(
+      calls[1].metadata?.mediaFileName,
+    );
   });
 
   it("gives the SAME bytes distinct content per (room, sender, scope) so dedupe doesn't drop facets", async () => {

--- a/packages/agent/src/api/attachment-knowledge-ingest.test.ts
+++ b/packages/agent/src/api/attachment-knowledge-ingest.test.ts
@@ -397,6 +397,64 @@ describe("ingestMessageAttachmentsAsKnowledge", () => {
     });
   });
 
+  it("throws typed lookup errors instead of fabricating room/role defaults", async () => {
+    const { service } = makeDocumentService();
+    const message = messageWithAttachments({
+      entityId: OWNER_ENTITY,
+      roomId: DM_ROOM,
+      attachments: [
+        {
+          id: "lookup",
+          url: STORED_IMAGE_URL,
+          contentType: ContentType.IMAGE,
+          mimeType: "image/png",
+        },
+      ],
+    });
+
+    const roomLookupRuntime = makeRuntime({
+      roomType: ChannelType.DM,
+      roomId: DM_ROOM,
+      ownerId: OWNER_ENTITY,
+    }) as Record<string, unknown>;
+    roomLookupRuntime.getRoom = vi.fn(async () => {
+      throw new Error("room store down");
+    });
+
+    await expect(
+      ingestMessageAttachmentsAsKnowledge(
+        {
+          runtime: roomLookupRuntime,
+          documents: service,
+        } as never,
+        message,
+      ),
+    ).rejects.toMatchObject({
+      code: "ATTACHMENT_KNOWLEDGE_ROOM_LOOKUP_FAILED",
+    });
+
+    const worldLookupRuntime = makeRuntime({
+      roomType: ChannelType.DM,
+      roomId: DM_ROOM,
+      ownerId: OWNER_ENTITY,
+    }) as Record<string, unknown>;
+    worldLookupRuntime.getWorld = vi.fn(async () => {
+      throw new Error("world store down");
+    });
+
+    await expect(
+      ingestMessageAttachmentsAsKnowledge(
+        {
+          runtime: worldLookupRuntime,
+          documents: service,
+        } as never,
+        message,
+      ),
+    ).rejects.toMatchObject({
+      code: "ATTACHMENT_KNOWLEDGE_WORLD_LOOKUP_FAILED",
+    });
+  });
+
   it("gives the SAME bytes distinct content per (room, sender, scope) so dedupe doesn't drop facets", async () => {
     const attachment = {
       id: "dup",

--- a/packages/agent/src/api/attachment-knowledge-ingest.ts
+++ b/packages/agent/src/api/attachment-knowledge-ingest.ts
@@ -262,19 +262,72 @@ export async function ingestMessageAttachmentsAsKnowledge(
   const roomId = message.roomId as UUID;
 
   // Resolve room trust + sender role once for the whole message.
-  const room = await runtime.getRoom(roomId).catch(() => null);
+  let room: Awaited<ReturnType<IAgentRuntime["getRoom"]>>;
+  try {
+    room = await runtime.getRoom(roomId);
+  } catch (err) {
+    // error-policy:J2 room trust is required for the write-boundary spill
+    // guard; fabricating a default surface would hide a broken data path.
+    throw new ElizaError("attachment→knowledge ingest could not load room", {
+      code: "ATTACHMENT_KNOWLEDGE_ROOM_LOOKUP_FAILED",
+      cause: err instanceof Error ? err : new Error(String(err)),
+      severity: "ephemeral",
+      context: { roomId },
+    });
+  }
+  if (!room) {
+    throw new ElizaError("attachment→knowledge ingest room was not found", {
+      code: "ATTACHMENT_KNOWLEDGE_ROOM_NOT_FOUND",
+      severity: "ephemeral",
+      context: { roomId },
+    });
+  }
   const channelType = room?.type;
   const worldId = (message.worldId ?? room?.worldId ?? agentId) as UUID;
 
-  const world = worldId
-    ? await runtime.getWorld(worldId).catch(() => null)
-    : null;
-  const roleName = await resolveEntityRole(
-    runtime,
-    world,
-    (world?.metadata ?? undefined) as never,
-    senderEntityId,
-  ).catch(() => "USER");
+  let world: Awaited<ReturnType<IAgentRuntime["getWorld"]>>;
+  try {
+    world = await runtime.getWorld(worldId);
+  } catch (err) {
+    // error-policy:J2 sender role depends on the room's world; defaulting to
+    // USER would make an owner/DM attachment look successfully user-scoped.
+    throw new ElizaError("attachment→knowledge ingest could not load world", {
+      code: "ATTACHMENT_KNOWLEDGE_WORLD_LOOKUP_FAILED",
+      cause: err instanceof Error ? err : new Error(String(err)),
+      severity: "ephemeral",
+      context: { roomId, worldId },
+    });
+  }
+  if (!world) {
+    throw new ElizaError("attachment→knowledge ingest world was not found", {
+      code: "ATTACHMENT_KNOWLEDGE_WORLD_NOT_FOUND",
+      severity: "ephemeral",
+      context: { roomId, worldId },
+    });
+  }
+
+  let roleName: string;
+  try {
+    roleName = await resolveEntityRole(
+      runtime,
+      world,
+      (world.metadata ?? undefined) as never,
+      senderEntityId,
+    );
+  } catch (err) {
+    // error-policy:J2 sender role is part of the persisted knowledge facets and
+    // owner spill guard; a fallback role would make broken role resolution look
+    // like a healthy USER write.
+    throw new ElizaError(
+      "attachment→knowledge ingest could not resolve sender role",
+      {
+        code: "ATTACHMENT_KNOWLEDGE_ROLE_LOOKUP_FAILED",
+        cause: err instanceof Error ? err : new Error(String(err)),
+        severity: "ephemeral",
+        context: { roomId, worldId, senderEntityId },
+      },
+    );
+  }
   const senderIsOwner = roleName === "OWNER";
   const addedByRole = addedByRoleForRoleName(roleName);
 
@@ -359,9 +412,9 @@ export async function ingestMessageAttachmentsAsKnowledge(
         scope,
       });
     } catch (err) {
-      // Fail fast with a typed error: never a silent skip that makes an
-      // attachment vanish from knowledge. The pipeline-hook boundary catches
-      // this and routes it to reportError.
+      // error-policy:J2 add the attachment identity/scope context before the
+      // pipeline boundary reports the failure; never silently skip a failed
+      // document write and make the attachment vanish from knowledge.
       throw new ElizaError(
         `attachment→knowledge ingest failed for ${fileName} (${mediaFileName})`,
         {
@@ -437,8 +490,9 @@ export function registerAttachmentKnowledgeIngestHook(
           message,
         );
       } catch (err) {
-        // Boundary: a typed ingest failure surfaces through RECENT_ERRORS /
-        // owner escalation instead of aborting the message pipeline.
+        // error-policy:J1 pipeline-hook boundary: a typed ingest failure
+        // surfaces through RECENT_ERRORS / owner escalation instead of aborting
+        // the message pipeline.
         rt.reportError("attachment-knowledge-ingest", err, {
           roomId: message.roomId,
         });

--- a/packages/agent/src/api/attachment-knowledge-ingest.ts
+++ b/packages/agent/src/api/attachment-knowledge-ingest.ts
@@ -202,20 +202,30 @@ function addedByRoleForRoleName(
  * descriptions, extracted document text); fall back to a filename/format stub
  * so the record is never empty and still matches a filename/format search.
  *
- * A trailing provenance line (room + sender + scope) is appended so the
- * documents store's content-addressed dedupe key (`generateContentBasedId`,
- * hashes body + filename) is CONTEXT-scoped: the SAME bytes shared in a
- * different room, by a different sender, or under a different scope produce a
- * DISTINCT knowledge record instead of collapsing onto the first occurrence and
- * losing that occurrence's roomId/sender/scope facets. Identical bytes in the
- * SAME (room, sender, scope) still dedupe idempotently, which is the intended
- * behavior. The marker is a stable single line so re-ingest is a no-op.
+ * A trailing provenance line (media hash + room + sender + scope) is appended so
+ * the documents store's content-addressed dedupe key (`generateContentBasedId`,
+ * hashes body + filename) is CONTEXT- and BYTES-scoped:
+ *  - the SAME bytes shared in a different room, by a different sender, or under
+ *    a different scope produce a DISTINCT record (no roomId/sender/scope facet
+ *    loss); and
+ *  - two DIFFERENT attachments that happen to share a filename + description in
+ *    the same (room, sender, scope) still produce DISTINCT records because the
+ *    media hash differs — so the second attachment's distinct mediaUrl/hash is
+ *    never dropped by dedupe.
+ * Identical bytes in the SAME (room, sender, scope) still dedupe idempotently,
+ * which is the intended behavior. The marker is a stable single line so
+ * re-ingest is a no-op.
  */
 function ingestBodyForAttachment(
   attachment: Media,
   format: MediaFormat,
   fileName: string,
-  provenance: { roomId: UUID; senderEntityId: UUID; scope: string },
+  provenance: {
+    roomId: UUID;
+    senderEntityId: UUID;
+    scope: string;
+    mediaHash: string;
+  },
 ): string {
   const label = attachment.filename || attachment.title || fileName;
   const described =
@@ -224,9 +234,23 @@ function ingestBodyForAttachment(
       : "") ||
     (typeof attachment.text === "string" ? attachment.text.trim() : "");
   const header = `[${format} attachment: ${label}]`;
-  const provenanceLine = `[ingest room=${provenance.roomId} sender=${provenance.senderEntityId} scope=${provenance.scope}]`;
+  const provenanceLine = `[ingest media=${provenance.mediaHash} room=${provenance.roomId} sender=${provenance.senderEntityId} scope=${provenance.scope}]`;
   const body = described ? `${header}\n\n${described}` : header;
   return `${body}\n\n${provenanceLine}`;
+}
+
+/**
+ * Storage filename for the text-backed knowledge record. The documents service
+ * special-cases `.pdf`/binary `originalFilename`s (base64-decode + PDF extract)
+ * BEFORE fragmenting — feeding it a synthesized-plaintext body under a `.pdf`
+ * name corrupts the stored fragments. We ALWAYS store under a `.txt` name so the
+ * body is treated as searchable text; the real display filename is preserved in
+ * `metadata.filename`/`originalFilename`.
+ */
+function textStorageFilename(displayFilename: string): string {
+  const base = displayFilename.replace(/\.[^./\\]+$/, "");
+  const safeBase = base.trim().length > 0 ? base.trim() : "attachment";
+  return `${safeBase}.txt`;
 }
 
 export interface IngestAttachmentDeps {
@@ -356,6 +380,10 @@ export async function ingestMessageAttachmentsAsKnowledge(
       typeof attachment.checksum === "string"
         ? attachment.checksum
         : mediaFileName.split(".")[0];
+    // Store under a .txt name so the documents service treats the synthesized
+    // plaintext body as text (never the .pdf/binary base64-decode + extract
+    // path). The real display filename lives in metadata.filename.
+    const storageFilename = textStorageFilename(fileName);
 
     try {
       const stored = await documents.addDocument({
@@ -367,11 +395,12 @@ export async function ingestMessageAttachmentsAsKnowledge(
         // Text-backed so the documents store treats the body as searchable text
         // rather than trying to re-decode opaque bytes it never received.
         contentType: "text/plain",
-        originalFilename: fileName,
+        originalFilename: storageFilename,
         content: ingestBodyForAttachment(attachment, format, fileName, {
           roomId,
           senderEntityId,
           scope,
+          mediaHash,
         }),
         scope,
         ...(scopedToEntityId ? { scopedToEntityId } : {}),

--- a/packages/agent/src/api/attachment-knowledge-ingest.ts
+++ b/packages/agent/src/api/attachment-knowledge-ingest.ts
@@ -1,0 +1,448 @@
+/**
+ * Attachment → knowledge ingest pipeline (#13593, knowledge slice 1).
+ *
+ * When a chat message with attachments is persisted, each attachment whose
+ * bytes already live in the content-addressed media store is mirrored into the
+ * documents/knowledge store as a searchable knowledge record, tagged by room,
+ * sender, sender role, and media format, and linked back to the sha256 bytes
+ * via `metadata.mediaUrl/mediaHash/mediaFileName` (the existing "knowledge
+ * record points at media" pattern — no second store, no new tables per #8876).
+ *
+ * **Scope-by-source-trust (spill guard):** the visibility scope is derived from
+ * the SOURCE ROOM's trust, never from an arbitrary caller. An owner/DM chat →
+ * `owner-private`; a public/community room (Discord, groups, feeds) →
+ * `user-private` scoped to the sender. This is the WRITE-boundary wall that
+ * keeps owner-only knowledge from ever being written into a public-room-visible
+ * scope; `canReadDocumentMemory` in the documents routes is the second (read)
+ * wall.
+ *
+ * The pure derivations (`mediaFormatFromMimeType`, `resolveIngestScope`) are
+ * exported for unit testing; `registerAttachmentKnowledgeIngestHook` wires the
+ * pipeline into the runtime via an `after_memory_persisted` hook filtered to
+ * the `messages` table.
+ */
+
+import type { IAgentRuntime, Media, Memory, UUID } from "@elizaos/core";
+import {
+  ChannelType,
+  ContentType,
+  ElizaError,
+  resolveEntityRole,
+} from "@elizaos/core";
+import { isStoredMediaUrl, mediaFileNameFromUrl } from "./media-store.ts";
+
+/**
+ * Coarse media-format tag derived from an attachment's IANA mime type at read
+ * time (#8876: derive format from mimeType, do not persist a new enum). Used
+ * both as a knowledge tag (`attachment` + `<format>`) and as the searchable
+ * `mediaFormat` facet.
+ */
+export type MediaFormat =
+  | "image"
+  | "audio"
+  | "video"
+  | "pdf"
+  | "text"
+  | "transcript"
+  | "file";
+
+/** The tag every ingested chat attachment carries so it is filterable. */
+export const ATTACHMENT_DOCUMENT_TAG = "attachment";
+
+/** Tag prefix namespacing the media-format facet on knowledge records. */
+export const MEDIA_FORMAT_TAG_PREFIX = "media-format:";
+
+/** Source marker recorded on every chat-ingested knowledge record. */
+const ATTACHMENT_INGEST_SOURCE = "chat-attachment";
+
+const TEXT_MIME_PREFIXES = ["text/"] as const;
+const TEXT_MIME_EXACT = new Set<string>([
+  "application/json",
+  "application/xml",
+  "application/javascript",
+  "application/x-yaml",
+  "application/yaml",
+  "text/markdown",
+]);
+
+/**
+ * Derive the coarse media-format tag from an attachment mime type (and its
+ * coarse `ContentType` as a fallback signal). PDFs get their own facet since
+ * they are the dominant "document" subtype users search for by format; other
+ * documents fall back to `text` (text-backed) or `file` (opaque binary).
+ */
+export function mediaFormatFromMimeType(
+  mimeType: string | undefined,
+  contentType?: ContentType | string,
+): MediaFormat {
+  const mime = (mimeType ?? "").toLowerCase().trim();
+
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("audio/")) return "audio";
+  if (mime.startsWith("video/")) return "video";
+  if (mime === "application/pdf") return "pdf";
+  if (
+    TEXT_MIME_PREFIXES.some((prefix) => mime.startsWith(prefix)) ||
+    TEXT_MIME_EXACT.has(mime)
+  ) {
+    return "text";
+  }
+
+  // Fall back on the coarse ContentType when the mime is missing/unknown.
+  switch (contentType) {
+    case ContentType.IMAGE:
+      return "image";
+    case ContentType.AUDIO:
+      return "audio";
+    case ContentType.VIDEO:
+      return "video";
+    case ContentType.DOCUMENT:
+      // A document with no recognizable text mime is an opaque binary file.
+      return "file";
+    default:
+      return "file";
+  }
+}
+
+/** Build the ordered knowledge tag set for an ingested attachment. */
+export function attachmentKnowledgeTags(format: MediaFormat): string[] {
+  return [ATTACHMENT_DOCUMENT_TAG, `${MEDIA_FORMAT_TAG_PREFIX}${format}`];
+}
+
+/**
+ * Room trust classification used by the spill guard. A DM / SELF / VOICE_DM /
+ * API room is a "private" surface (owner's own chat); everything else (GROUP,
+ * FORUM, FEED, THREAD, WORLD, …) is a "public"/community surface that must not
+ * receive owner-private or global writes.
+ */
+export function roomIsPrivateSurface(
+  channelType: ChannelType | string | undefined,
+): boolean {
+  switch (channelType) {
+    case ChannelType.DM:
+    case ChannelType.SELF:
+    case ChannelType.VOICE_DM:
+    case ChannelType.API:
+      return true;
+    default:
+      return false;
+  }
+}
+
+export interface IngestScopeDecision {
+  scope: "owner-private" | "user-private";
+  /** Set only for `user-private`; the sender the item is scoped to. */
+  scopedToEntityId?: UUID;
+}
+
+/**
+ * Scope-by-source-trust: derive the write scope from the SOURCE room's trust
+ * plus whether the sender is the owner. Owner/DM chat → `owner-private`; a
+ * public/community room → `user-private` scoped to the sender. NEVER returns
+ * `global`/`agent-private` and NEVER returns `owner-private` for a public room,
+ * so owner-only knowledge cannot spill into a public-room-visible scope at the
+ * write boundary.
+ */
+export function resolveIngestScope(params: {
+  channelType: ChannelType | string | undefined;
+  senderIsOwner: boolean;
+  senderEntityId: UUID;
+}): IngestScopeDecision {
+  const { channelType, senderIsOwner, senderEntityId } = params;
+  // Owner-only knowledge is confined to private (DM-like) surfaces. Even if the
+  // owner speaks in a public room, the item is scoped to them (user-private) so
+  // a public-room retrieval for another actor can never surface it.
+  if (roomIsPrivateSurface(channelType) && senderIsOwner) {
+    return { scope: "owner-private" };
+  }
+  return { scope: "user-private", scopedToEntityId: senderEntityId };
+}
+
+/** Minimal document-service surface this pipeline depends on. */
+export interface AttachmentIngestDocumentService {
+  addDocument(options: {
+    agentId?: UUID;
+    worldId: UUID;
+    roomId: UUID;
+    entityId: UUID;
+    clientDocumentId: UUID;
+    contentType: string;
+    originalFilename: string;
+    content: string;
+    metadata?: Record<string, unknown>;
+    scope?: "global" | "owner-private" | "user-private" | "agent-private";
+    scopedToEntityId?: UUID;
+    addedBy?: UUID;
+    addedByRole?: "OWNER" | "ADMIN" | "USER" | "AGENT" | "RUNTIME";
+    addedFrom?: string;
+  }): Promise<{
+    clientDocumentId: string;
+    storedDocumentMemoryId: UUID;
+    fragmentCount: number;
+  }>;
+}
+
+/** Map a resolved role name to the documents-store `addedByRole` enum. */
+function addedByRoleForRoleName(
+  role: string | undefined,
+): "OWNER" | "ADMIN" | "USER" | "AGENT" | "RUNTIME" {
+  switch (role) {
+    case "OWNER":
+      return "OWNER";
+    case "ADMIN":
+      return "ADMIN";
+    default:
+      return "USER";
+  }
+}
+
+/**
+ * Build the searchable body text for an attachment knowledge record. Prefer the
+ * vision/description text the message pipeline already attached (image
+ * descriptions, extracted document text); fall back to a filename/format stub
+ * so the record is never empty and still matches a filename/format search.
+ *
+ * A trailing provenance line (room + sender + scope) is appended so the
+ * documents store's content-addressed dedupe key (`generateContentBasedId`,
+ * hashes body + filename) is CONTEXT-scoped: the SAME bytes shared in a
+ * different room, by a different sender, or under a different scope produce a
+ * DISTINCT knowledge record instead of collapsing onto the first occurrence and
+ * losing that occurrence's roomId/sender/scope facets. Identical bytes in the
+ * SAME (room, sender, scope) still dedupe idempotently, which is the intended
+ * behavior. The marker is a stable single line so re-ingest is a no-op.
+ */
+function ingestBodyForAttachment(
+  attachment: Media,
+  format: MediaFormat,
+  fileName: string,
+  provenance: { roomId: UUID; senderEntityId: UUID; scope: string },
+): string {
+  const label = attachment.filename || attachment.title || fileName;
+  const described =
+    (typeof attachment.description === "string"
+      ? attachment.description.trim()
+      : "") ||
+    (typeof attachment.text === "string" ? attachment.text.trim() : "");
+  const header = `[${format} attachment: ${label}]`;
+  const provenanceLine = `[ingest room=${provenance.roomId} sender=${provenance.senderEntityId} scope=${provenance.scope}]`;
+  const body = described ? `${header}\n\n${described}` : header;
+  return `${body}\n\n${provenanceLine}`;
+}
+
+export interface IngestAttachmentDeps {
+  runtime: IAgentRuntime;
+  documents: AttachmentIngestDocumentService;
+}
+
+export interface IngestAttachmentResult {
+  documentId: UUID;
+  mediaFileName: string;
+  format: MediaFormat;
+  scope: IngestScopeDecision["scope"];
+}
+
+/**
+ * Ingest every stored attachment on a persisted message as a knowledge record.
+ * Returns one result per successfully ingested attachment. Attachments whose
+ * bytes are not in the content-addressed store (e.g. unrehosted remote links)
+ * are skipped — only durable, servable bytes become knowledge. Any individual
+ * ingest failure throws a typed `ElizaError` (fail fast) so an attachment can
+ * never silently vanish from knowledge; the caller (pipeline hook) reports it.
+ */
+export async function ingestMessageAttachmentsAsKnowledge(
+  deps: IngestAttachmentDeps,
+  message: Memory,
+): Promise<IngestAttachmentResult[]> {
+  const { runtime, documents } = deps;
+  const attachments = message.content?.attachments;
+  if (!Array.isArray(attachments) || attachments.length === 0) return [];
+
+  const senderEntityId = message.entityId as UUID;
+  const agentId = runtime.agentId as UUID;
+  const roomId = message.roomId as UUID;
+
+  // Resolve room trust + sender role once for the whole message.
+  const room = await runtime.getRoom(roomId).catch(() => null);
+  const channelType = room?.type;
+  const worldId = (message.worldId ?? room?.worldId ?? agentId) as UUID;
+
+  const world = worldId
+    ? await runtime.getWorld(worldId).catch(() => null)
+    : null;
+  const roleName = await resolveEntityRole(
+    runtime,
+    world,
+    (world?.metadata ?? undefined) as never,
+    senderEntityId,
+  ).catch(() => "USER");
+  const senderIsOwner = roleName === "OWNER";
+  const addedByRole = addedByRoleForRoleName(roleName);
+
+  const results: IngestAttachmentResult[] = [];
+
+  for (const attachment of attachments) {
+    if (!attachment || typeof attachment.url !== "string") continue;
+    // Only mirror durable, store-backed bytes into knowledge. A remote/ephemeral
+    // URL is intentionally skipped (nothing durable to point a record at).
+    if (!isStoredMediaUrl(attachment.url)) continue;
+    const mediaFileName = mediaFileNameFromUrl(attachment.url);
+    if (!mediaFileName) continue;
+
+    const format = mediaFormatFromMimeType(
+      attachment.mimeType,
+      attachment.contentType,
+    );
+    const { scope, scopedToEntityId } = resolveIngestScope({
+      channelType,
+      senderIsOwner,
+      senderEntityId,
+    });
+
+    const fileName = attachment.filename || attachment.title || mediaFileName;
+    const mediaHash =
+      typeof attachment.checksum === "string"
+        ? attachment.checksum
+        : mediaFileName.split(".")[0];
+
+    try {
+      const stored = await documents.addDocument({
+        agentId,
+        worldId,
+        roomId,
+        entityId: scope === "user-private" ? senderEntityId : agentId,
+        clientDocumentId: "" as UUID,
+        // Text-backed so the documents store treats the body as searchable text
+        // rather than trying to re-decode opaque bytes it never received.
+        contentType: "text/plain",
+        originalFilename: fileName,
+        content: ingestBodyForAttachment(attachment, format, fileName, {
+          roomId,
+          senderEntityId,
+          scope,
+        }),
+        scope,
+        ...(scopedToEntityId ? { scopedToEntityId } : {}),
+        addedBy: senderEntityId,
+        addedByRole,
+        addedFrom: "chat",
+        metadata: {
+          source: ATTACHMENT_INGEST_SOURCE,
+          tags: attachmentKnowledgeTags(format),
+          mediaFormat: format,
+          roomId,
+          filename: fileName,
+          originalFilename: fileName,
+          contentType: attachment.mimeType ?? "application/octet-stream",
+          fileType: attachment.mimeType ?? "application/octet-stream",
+          textBacked: true,
+          scope,
+          ...(scopedToEntityId ? { scopedToEntityId } : {}),
+          addedBy: senderEntityId,
+          addedByRole,
+          addedFrom: "chat",
+          // Link back to the durable sha256 bytes (the reference-aware GC unions
+          // document `metadata.mediaUrl` so the file survives while a record
+          // points at it).
+          mediaUrl: attachment.url,
+          mediaHash,
+          mediaFileName,
+          ...(typeof attachment.mimeType === "string"
+            ? { mediaMimeType: attachment.mimeType }
+            : {}),
+        },
+      });
+
+      results.push({
+        documentId: stored.clientDocumentId as UUID,
+        mediaFileName,
+        format,
+        scope,
+      });
+    } catch (err) {
+      // Fail fast with a typed error: never a silent skip that makes an
+      // attachment vanish from knowledge. The pipeline-hook boundary catches
+      // this and routes it to reportError.
+      throw new ElizaError(
+        `attachment→knowledge ingest failed for ${fileName} (${mediaFileName})`,
+        {
+          code: "ATTACHMENT_KNOWLEDGE_INGEST_FAILED",
+          cause: err instanceof Error ? err : new Error(String(err)),
+          severity: "ephemeral",
+          context: { roomId, mediaFileName, format, scope },
+        },
+      );
+    }
+  }
+
+  return results;
+}
+
+const INGEST_HOOK_ID = "attachment-knowledge-ingest";
+const MESSAGES_TABLE = "messages";
+
+/** Resolve the runtime "documents" service, or null if not registered. */
+function getIngestDocumentService(
+  runtime: IAgentRuntime,
+): AttachmentIngestDocumentService | null {
+  const service = runtime.getService("documents") as
+    | (AttachmentIngestDocumentService & object)
+    | null;
+  if (
+    service &&
+    typeof (service as AttachmentIngestDocumentService).addDocument ===
+      "function"
+  ) {
+    return service as AttachmentIngestDocumentService;
+  }
+  return null;
+}
+
+/**
+ * Register the attachment→knowledge ingest pipeline. Runs on
+ * `after_memory_persisted` for the `messages` table only: after a user message
+ * with attachments commits, its store-backed attachments are mirrored into the
+ * knowledge store with room/sender/role/media-format tags and a
+ * source-trust-derived scope. Idempotency is provided by the documents store's
+ * content-addressed id (`generateContentBasedId`): re-ingesting the same body +
+ * filename returns the existing document instead of duplicating.
+ */
+export function registerAttachmentKnowledgeIngestHook(
+  runtime: IAgentRuntime,
+): void {
+  runtime.registerPipelineHook({
+    id: INGEST_HOOK_ID,
+    phase: "after_memory_persisted",
+    // Reader phase: it must not mutate the just-persisted message.
+    mutatesPrimary: false,
+    schedule: "concurrent",
+    handler: async (rt, ctx) => {
+      if (ctx.phase !== "after_memory_persisted") return;
+      if (ctx.tableName !== MESSAGES_TABLE) return;
+      const message = ctx.memory;
+      const attachments = message.content?.attachments;
+      if (!Array.isArray(attachments) || attachments.length === 0) return;
+      // Only mirror inbound (user/other) attachments — the agent's own outgoing
+      // attachments are already the agent's context, not new knowledge to file.
+      if (message.entityId === rt.agentId) return;
+
+      const documents = getIngestDocumentService(rt);
+      if (!documents) {
+        // Documents service not enabled for this agent — nothing to ingest into.
+        return;
+      }
+
+      try {
+        await ingestMessageAttachmentsAsKnowledge(
+          { runtime: rt, documents },
+          message,
+        );
+      } catch (err) {
+        // Boundary: a typed ingest failure surfaces through RECENT_ERRORS /
+        // owner escalation instead of aborting the message pipeline.
+        rt.reportError("attachment-knowledge-ingest", err, {
+          roomId: message.roomId,
+        });
+      }
+    },
+  });
+}

--- a/packages/agent/src/api/conversation-metadata.ts
+++ b/packages/agent/src/api/conversation-metadata.ts
@@ -38,6 +38,7 @@ const VALID_SCOPES = new Set<ConversationScope>([
   "page-wallet",
   "page-browser",
   "page-automations",
+  "page-knowledge",
 ]);
 
 const VALID_AUTOMATION_TYPES = new Set(["coordinator_text", "workflow"]);

--- a/packages/agent/src/providers/page-scoped-context.ts
+++ b/packages/agent/src/providers/page-scoped-context.ts
@@ -61,6 +61,8 @@ const PAGE_SCOPE_BRIEF: Record<string, string> = {
     "The user is in the Settings view. They can tune models, providers, permissions, connectors, wallet RPC, cloud account state, appearance, updates, and feature toggles. Action vocabulary: UPDATE_IDENTITY, UPDATE_AI_PROVIDER, TOGGLE_CAPABILITY, and TOGGLE_AUTO_TRAINING. When the user asks what to do, recommend the smallest concrete settings change that fits the visible section. Ask before changes that affect security, spending, or external accounts. Never invent provider status, account state, or permission grants.",
   "page-wallet":
     "The user is in the Wallet view. They can inspect token inventory, NFTs, LP position status, current balance, P&L, activity, EVM/Solana addresses, RPC/provider readiness, wallet/RPC settings, and native Hyperliquid and Polymarket readiness. There are no chain filters in this surface. When the user asks what to do, recommend the smallest concrete wallet action and confirm asset/market, amount, destination/outcome, slippage/risk limits, and execution path before invoking any available action. If the user asks about Hyperliquid or Polymarket, prefer native app surfaces for reads/status. Never invent balances, positions, fills, markets, odds, or execution support.",
+  "page-knowledge":
+    "The user is in the Knowledge view. This surface lists knowledge records, including chat attachments ingested by room, sender, sender role, and media format (image, audio, video, pdf, text, transcript, file). Owner/DM-chat knowledge is owner-private and never surfaces into public rooms; public/community-room attachments are scoped to their sender. The user can browse, search, retag, rescope (owner-only), and delete knowledge items; deleting the sole referent of a media file makes those bytes garbage-collectible. When the user asks what to do, ground answers in the live knowledge state below (recent-attachment counts by source and format) and recommend the smallest concrete filing, retag, rescope, or cleanup action. Never invent knowledge records, media, tags, or scopes.",
   "automation-draft":
     "This is an automation-creation room. The user wants to create exactly one automation. Decide the right shape based on their description and call the matching action exactly once:\n" +
     '- Recurring prompt or scheduled instruction (e.g. "every morning summarize my inbox") → TRIGGER with op="create" specifying displayName, instructions, and schedule (interval/once/cron). The agent transparently materializes a single-node workflow that runs the instructions when the trigger fires.\n' +
@@ -560,6 +562,103 @@ async function renderAutomationsLiveState(
   }
 }
 
+const KNOWLEDGE_LIVE_STATE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const KNOWLEDGE_LIVE_STATE_SCAN_LIMIT = 500;
+const ATTACHMENT_DOCUMENT_TAG = "attachment";
+const MEDIA_FORMAT_TAG_PREFIX = "media-format:";
+const TRANSCRIPT_DOCUMENT_TAG = "transcript";
+
+function documentStringTags(
+  metadata: Record<string, unknown> | undefined,
+): string[] {
+  const tags = metadata?.tags;
+  return Array.isArray(tags)
+    ? tags.filter((value): value is string => typeof value === "string")
+    : [];
+}
+
+function documentMediaFormat(
+  metadata: Record<string, unknown> | undefined,
+  tags: string[],
+): string {
+  if (typeof metadata?.mediaFormat === "string" && metadata.mediaFormat) {
+    return metadata.mediaFormat;
+  }
+  const tagged = tags.find((tag) => tag.startsWith(MEDIA_FORMAT_TAG_PREFIX));
+  return tagged ? tagged.slice(MEDIA_FORMAT_TAG_PREFIX.length) : "file";
+}
+
+/**
+ * Live knowledge state for the Knowledge view (#13593): counts of recently
+ * ingested chat attachments (and transcript mirrors) over the trailing week,
+ * broken down by media format. This is the count surface slice 2's proactive
+ * greeting reads ("You have N new attachments from Discord this week…").
+ */
+async function renderKnowledgeLiveState(
+  runtime: IAgentRuntime,
+): Promise<string | null> {
+  const now = Date.now();
+  const windowStart = now - KNOWLEDGE_LIVE_STATE_WINDOW_MS;
+  let recentAttachments = 0;
+  let recentTranscripts = 0;
+  const byFormat = new Map<string, number>();
+
+  try {
+    const batch = await runtime.getMemories({
+      tableName: "documents",
+      // Scope to THIS agent so a shared/multi-agent adapter does not count
+      // another agent's attachment/transcript records into this page's context.
+      agentId: runtime.agentId,
+      count: KNOWLEDGE_LIVE_STATE_SCAN_LIMIT,
+      offset: 0,
+    });
+    for (const memory of batch) {
+      if (memory.agentId && memory.agentId !== runtime.agentId) continue;
+      const metadata = (memory.metadata ?? undefined) as
+        | Record<string, unknown>
+        | undefined;
+      const tags = documentStringTags(metadata);
+      const isAttachment = tags.includes(ATTACHMENT_DOCUMENT_TAG);
+      const isTranscript = tags.includes(TRANSCRIPT_DOCUMENT_TAG);
+      if (!isAttachment && !isTranscript) continue;
+      const at =
+        (typeof metadata?.addedAt === "number"
+          ? metadata.addedAt
+          : undefined) ??
+        (typeof metadata?.timestamp === "number"
+          ? metadata.timestamp
+          : undefined) ??
+        (typeof memory.createdAt === "number" ? memory.createdAt : undefined);
+      if (typeof at === "number" && at < windowStart) continue;
+      if (isAttachment) {
+        recentAttachments += 1;
+        const format = documentMediaFormat(metadata, tags);
+        byFormat.set(format, (byFormat.get(format) ?? 0) + 1);
+      } else if (isTranscript) {
+        recentTranscripts += 1;
+      }
+    }
+  } catch (err) {
+    runtime.reportError("PageScopedContext.knowledgeLiveState", err);
+    return "Live knowledge state: unavailable (documents store unreachable).";
+  }
+
+  const lines: string[] = [
+    `Live knowledge state (last 7 days): ${recentAttachments} ingested chat attachment${
+      recentAttachments === 1 ? "" : "s"
+    }, ${recentTranscripts} transcript mirror${
+      recentTranscripts === 1 ? "" : "s"
+    }.`,
+  ];
+  if (byFormat.size > 0) {
+    const parts = [...byFormat.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([format, count]) => `${format}=${count}`);
+    lines.push(`Attachments by format: ${parts.join(", ")}.`);
+  }
+  return lines.join("\n");
+}
+
 async function renderLiveStateForScope(
   runtime: IAgentRuntime,
   scope: ConversationScope,
@@ -567,6 +666,8 @@ async function renderLiveStateForScope(
   switch (scope) {
     case "page-character":
       return renderCharacterLiveState(runtime);
+    case "page-knowledge":
+      return renderKnowledgeLiveState(runtime);
     case "page-browser":
       return renderBrowserLiveState(runtime);
     case "page-automations":

--- a/packages/agent/src/runtime/eliza-plugin.ts
+++ b/packages/agent/src/runtime/eliza-plugin.ts
@@ -32,6 +32,8 @@ import { runtimeAction } from "../actions/runtime.ts";
 import { settingsAction } from "../actions/settings-actions.ts";
 import { terminalAction } from "../actions/terminal.ts";
 import { triggerAction } from "../actions/trigger.ts";
+import { registerAttachmentKnowledgeBackfillTask } from "../api/attachment-knowledge-backfill.ts";
+import { registerAttachmentKnowledgeIngestHook } from "../api/attachment-knowledge-ingest.ts";
 import {
   backgroundGenerateImageRoute,
   backgroundUploadImageRoute,
@@ -170,6 +172,14 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
       // sweep orphaned files daily. The serving route is declared below.
       registerMediaPipelineHook(runtime);
       registerMediaGcTask(runtime);
+      // Attachment → knowledge ingest (#13593): mirror chat attachments into the
+      // knowledge store, tagged by room/sender/role/media-format, with a
+      // source-trust-derived scope (owner/DM → owner-private; public room →
+      // user-private) so owner-only knowledge cannot spill into public rooms.
+      registerAttachmentKnowledgeIngestHook(runtime);
+      // One-time (#13593): backfill room/media-format tags onto pre-existing
+      // transcript-mirror knowledge records. Idempotent; must not block boot.
+      registerAttachmentKnowledgeBackfillTask(runtime);
       const registerSkillsAsCommands = () => {
         const skillsService = runtime.getService("AGENT_SKILLS_SERVICE");
         if (!isAgentSkillsService(skillsService)) return false;

--- a/packages/shared/src/contracts/__tests__/schema-vs-type-drift.test.ts
+++ b/packages/shared/src/contracts/__tests__/schema-vs-type-drift.test.ts
@@ -41,6 +41,7 @@ const VALID_CONVERSATION_SCOPES = new Set([
   "page-wallet",
   "page-browser",
   "page-automations",
+  "page-knowledge",
 ]);
 
 const VALID_CONVERSATION_AUTOMATION_TYPES = new Set([

--- a/packages/shared/src/contracts/conversation-routes.ts
+++ b/packages/shared/src/contracts/conversation-routes.ts
@@ -44,6 +44,7 @@ export const ConversationScopeSchema = z.enum([
   "page-wallet",
   "page-browser",
   "page-automations",
+  "page-knowledge",
 ]);
 
 export const ConversationAutomationTypeSchema = z.enum([

--- a/plugins/plugin-documents/src/routes.filters.test.ts
+++ b/plugins/plugin-documents/src/routes.filters.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Route-level tests for the first-class `roomId` filter and `mediaFormat` facet
+ * added in #13593 (knowledge slice 1). Exercises `GET /api/documents` through
+ * `handleDocumentsRoutes` with a mock documents service, asserting the new
+ * filters compose with tags[] and that access control still applies after
+ * filtering (owner-private items don't leak to a non-owner actor).
+ */
+import type { Memory, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { type DocumentRouteContext, handleDocumentsRoutes } from "./routes.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const OWNER_ENTITY = "00000000-0000-0000-0000-0000000000b1" as UUID;
+const USER_ENTITY = "00000000-0000-0000-0000-0000000000c2" as UUID;
+const ROOM_A = "00000000-0000-0000-0000-0000000000d1" as UUID;
+const ROOM_B = "00000000-0000-0000-0000-0000000000d2" as UUID;
+
+function docMemory(id: string, metadata: Record<string, unknown>): Memory {
+  return {
+    id: id as UUID,
+    entityId: (metadata.addedBy as UUID) ?? OWNER_ENTITY,
+    agentId: AGENT_ID,
+    roomId: (metadata.roomId as UUID) ?? ROOM_A,
+    createdAt: 1000,
+    content: { text: `body-${id}` },
+    metadata: { type: "document", ...metadata } as Memory["metadata"],
+  };
+}
+
+/** Documents spanning two rooms and multiple formats + scopes. */
+function seedDocuments(): Memory[] {
+  return [
+    docMemory("img-a", {
+      documentId: "img-a",
+      tags: ["attachment", "media-format:image"],
+      mediaFormat: "image",
+      roomId: ROOM_A,
+      scope: "user-private",
+      addedBy: USER_ENTITY,
+      scopedToEntityId: USER_ENTITY,
+    }),
+    docMemory("pdf-a", {
+      documentId: "pdf-a",
+      tags: ["attachment", "media-format:pdf"],
+      mediaFormat: "pdf",
+      roomId: ROOM_A,
+      scope: "user-private",
+      addedBy: USER_ENTITY,
+      scopedToEntityId: USER_ENTITY,
+    }),
+    docMemory("img-b", {
+      documentId: "img-b",
+      tags: ["attachment", "media-format:image"],
+      mediaFormat: "image",
+      roomId: ROOM_B,
+      scope: "user-private",
+      addedBy: USER_ENTITY,
+      scopedToEntityId: USER_ENTITY,
+    }),
+    docMemory("owner-secret", {
+      documentId: "owner-secret",
+      tags: ["attachment", "media-format:pdf"],
+      mediaFormat: "pdf",
+      roomId: ROOM_A,
+      scope: "owner-private",
+      addedBy: OWNER_ENTITY,
+    }),
+  ];
+}
+
+function makeRuntimeAndService(docs: Memory[]) {
+  let scanned = false;
+  const documentsService = {
+    getMemories: vi.fn(
+      async (params: { tableName: string; offset?: number }) => {
+        if (params.tableName !== "documents") return [];
+        // Single batch: return all on first call, empty after.
+        if (scanned) return [];
+        scanned = true;
+        return docs;
+      },
+    ),
+    countMemories: vi.fn(async () => docs.length),
+    addDocument: vi.fn(),
+    searchDocuments: vi.fn(async () => []),
+    updateDocument: vi.fn(),
+    deleteMemory: vi.fn(),
+  };
+
+  const runtime = {
+    agentId: AGENT_ID,
+    getService: vi.fn((name: string) =>
+      name === "documents" ? documentsService : null,
+    ),
+    getServiceLoadPromise: vi.fn(),
+    getSetting: vi.fn((key: string) =>
+      key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER_ENTITY : undefined,
+    ),
+    getMemoryById: vi.fn(async () => null),
+  };
+
+  return { runtime, documentsService };
+}
+
+async function listDocuments(params: {
+  query: string;
+  actorEntityId?: UUID;
+}): Promise<{ status: number; body: Record<string, unknown> }> {
+  const { runtime } = makeRuntimeAndService(seedDocuments());
+  const url = new URL(`http://local/api/documents?${params.query}`);
+
+  let captured: { status: number; body: unknown } = { status: 0, body: null };
+  const res = {
+    setHeader: vi.fn(),
+  } as unknown as DocumentRouteContext["res"];
+
+  const headers: Record<string, string> = {};
+  if (params.actorEntityId) headers["x-eliza-entity-id"] = params.actorEntityId;
+
+  const ctx = {
+    req: { headers } as DocumentRouteContext["req"],
+    res,
+    method: "GET",
+    pathname: "/api/documents",
+    url,
+    runtime: runtime as never,
+    json: (_res: unknown, data: unknown, status = 200) => {
+      captured = { status, body: data };
+    },
+    error: (_res: unknown, message: string, status = 400) => {
+      captured = { status, body: { error: message } };
+    },
+    readJsonBody: async () => null,
+  } as unknown as DocumentRouteContext;
+
+  const handled = await handleDocumentsRoutes(ctx);
+  expect(handled).toBe(true);
+  return {
+    status: captured.status,
+    body: captured.body as Record<string, unknown>,
+  };
+}
+
+function docIds(body: Record<string, unknown>): string[] {
+  const documents = (body.documents as Array<{ id?: string }>) ?? [];
+  return documents.map((d) => d.id ?? "").sort();
+}
+
+describe("GET /api/documents — roomId + mediaFormat filters (#13593)", () => {
+  it("filters by roomId (composes with post-filter access control)", async () => {
+    // The USER owns img-a/pdf-a/img-b (user-private scoped to them). Filtering
+    // ROOM_A as that user yields their two ROOM_A items; owner-secret is
+    // owner-private and excluded.
+    const { body } = await listDocuments({
+      query: `roomId=${ROOM_A}`,
+      actorEntityId: USER_ENTITY,
+    });
+    expect(docIds(body)).toEqual(["img-a", "pdf-a"]);
+    expect(docIds(body)).not.toContain("img-b"); // ROOM_B excluded by roomId
+    expect(docIds(body)).not.toContain("owner-secret"); // owner-private excluded
+  });
+
+  it("filters by mediaFormat facet", async () => {
+    const { body } = await listDocuments({
+      query: "mediaFormat=image",
+      actorEntityId: USER_ENTITY,
+    });
+    expect(docIds(body)).toEqual(["img-a", "img-b"]);
+  });
+
+  it("composes roomId + mediaFormat", async () => {
+    const { body } = await listDocuments({
+      query: `roomId=${ROOM_A}&mediaFormat=pdf`,
+      actorEntityId: USER_ENTITY,
+    });
+    // ROOM_A pdfs the USER can read: pdf-a only (owner-secret is owner-private).
+    expect(docIds(body)).toEqual(["pdf-a"]);
+  });
+
+  it("composes mediaFormat with a tags[] filter", async () => {
+    const { body } = await listDocuments({
+      query: "mediaFormat=pdf&tags=attachment",
+      actorEntityId: USER_ENTITY,
+    });
+    expect(docIds(body)).toEqual(["pdf-a"]);
+  });
+
+  it("owner can read owner-private items matching the facet", async () => {
+    const { body } = await listDocuments({
+      query: `roomId=${ROOM_A}&mediaFormat=pdf`,
+      actorEntityId: OWNER_ENTITY,
+    });
+    // Owner reads owner-secret (owner-private); pdf-a belongs to USER, so it is
+    // not returned to the owner by default (no scopedToEntityId filter).
+    expect(docIds(body)).toEqual(["owner-secret"]);
+  });
+
+  it("applies access control AFTER filtering — non-owner never sees owner-private", async () => {
+    // USER actor filters ROOM_A pdfs: pdf-a is theirs (user-private scoped to
+    // them), owner-secret is owner-private and must be excluded.
+    const { body } = await listDocuments({
+      query: `roomId=${ROOM_A}&mediaFormat=pdf`,
+      actorEntityId: USER_ENTITY,
+    });
+    expect(docIds(body)).toEqual(["pdf-a"]);
+    expect(docIds(body)).not.toContain("owner-secret");
+  });
+
+  it("supports the `format` alias for mediaFormat", async () => {
+    const { body } = await listDocuments({
+      query: "format=image",
+      actorEntityId: USER_ENTITY,
+    });
+    expect(docIds(body)).toEqual(["img-a", "img-b"]);
+  });
+});
+
+describe("GET /api/documents/search — roomId pushed into service scope (#13593)", () => {
+  it("passes roomId to searchDocuments BEFORE ranking/capping", async () => {
+    const searchDocuments = vi.fn(async () => []);
+    const documentsService = {
+      getMemories: vi.fn(async () => []),
+      countMemories: vi.fn(async () => 0),
+      addDocument: vi.fn(),
+      searchDocuments,
+      updateDocument: vi.fn(),
+      deleteMemory: vi.fn(),
+    };
+    const runtime = {
+      agentId: AGENT_ID,
+      getService: vi.fn((name: string) =>
+        name === "documents" ? documentsService : null,
+      ),
+      getServiceLoadPromise: vi.fn(),
+      getSetting: vi.fn((key: string) =>
+        key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER_ENTITY : undefined,
+      ),
+      getMemoryById: vi.fn(async () => null),
+    };
+    const url = new URL(
+      `http://local/api/documents/search?q=chart&roomId=${ROOM_A}&mediaFormat=image`,
+    );
+    let captured: unknown = null;
+    const ctx = {
+      req: { headers: { "x-eliza-entity-id": OWNER_ENTITY } },
+      res: { setHeader: vi.fn() },
+      method: "GET",
+      pathname: "/api/documents/search",
+      url,
+      runtime: runtime as never,
+      json: (_res: unknown, data: unknown) => {
+        captured = data;
+      },
+      error: vi.fn(),
+      readJsonBody: async () => null,
+    } as unknown as DocumentRouteContext;
+
+    const handled = await handleDocumentsRoutes(ctx);
+    expect(handled).toBe(true);
+    expect(captured).not.toBeNull();
+    // roomId is threaded into the service search scope (2nd arg) so the DB
+    // pre-filters by room before the top-N cap.
+    expect(searchDocuments).toHaveBeenCalledTimes(1);
+    const scopeArg = searchDocuments.mock.calls[0][1] as
+      | { roomId?: string }
+      | undefined;
+    expect(scopeArg?.roomId).toBe(ROOM_A);
+  });
+});

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -69,7 +69,19 @@ type DocumentFilter = {
   timeRangeStart?: number;
   timeRangeEnd?: number;
   tags?: string[];
+  /** First-class source-room filter (#13593). */
+  roomId?: UUID;
+  /**
+   * Media-format facet (#13593): image | audio | video | pdf | text |
+   * transcript | file. Matched against `metadata.mediaFormat` or the
+   * `media-format:<format>` tag, so both explicitly-tagged records and
+   * mime-derived ones compose.
+   */
+  mediaFormat?: string;
 };
+
+/** Namespaced tag prefix carrying the media-format facet on knowledge records. */
+const MEDIA_FORMAT_TAG_PREFIX = "media-format:";
 
 type DocumentReadableMemory = {
   id?: UUID;
@@ -248,6 +260,10 @@ function filtersFromSearchParams(
       url.searchParams.get("end"),
   );
   const tags = parseTagsFromSearchParams(url.searchParams);
+  const roomId = asUuid(url.searchParams.get("roomId"));
+  const mediaFormat = trimString(
+    url.searchParams.get("mediaFormat") ?? url.searchParams.get("format"),
+  )?.toLowerCase();
   return {
     ...(scope ? { scope } : {}),
     ...(scopedToEntityId ? { scopedToEntityId } : {}),
@@ -256,6 +272,8 @@ function filtersFromSearchParams(
     ...(typeof timeRangeStart === "number" ? { timeRangeStart } : {}),
     ...(typeof timeRangeEnd === "number" ? { timeRangeEnd } : {}),
     ...(tags.length > 0 ? { tags } : {}),
+    ...(roomId ? { roomId } : {}),
+    ...(mediaFormat ? { mediaFormat } : {}),
   };
 }
 
@@ -351,15 +369,24 @@ function matchesDocumentFilter(
   if (filters.addedBy && metadata?.addedBy !== filters.addedBy) {
     return false;
   }
+  const documentTags = Array.isArray(metadata?.tags)
+    ? metadata.tags.filter(
+        (value): value is string => typeof value === "string",
+      )
+    : [];
   if (filters.tags && filters.tags.length > 0) {
-    const documentTags = Array.isArray(metadata?.tags)
-      ? metadata.tags.filter(
-          (value): value is string => typeof value === "string",
-        )
-      : [];
     if (!filters.tags.every((tag) => documentTags.includes(tag))) {
       return false;
     }
+  }
+  if (filters.roomId && documentRoomId(metadata) !== filters.roomId) {
+    return false;
+  }
+  if (
+    filters.mediaFormat &&
+    documentMediaFormat(metadata, documentTags) !== filters.mediaFormat
+  ) {
+    return false;
   }
 
   const timestamp =
@@ -410,6 +437,29 @@ function documentScopedEntityId(
     asUuid(metadata?.addedBy) ??
     asUuid(memory.entityId)
   );
+}
+
+/** Source-room id recorded on a knowledge record (#13593), if any. */
+function documentRoomId(
+  metadata: Record<string, unknown> | undefined,
+): UUID | undefined {
+  return asUuid(metadata?.roomId);
+}
+
+/**
+ * Media-format facet for a knowledge record (#13593). Prefer an explicit
+ * `metadata.mediaFormat`; fall back to the `media-format:<format>` tag so
+ * records tagged by the ingest pipeline (or backfill) still match without a
+ * dedicated column.
+ */
+function documentMediaFormat(
+  metadata: Record<string, unknown> | undefined,
+  tags: string[],
+): string | undefined {
+  const explicit = trimString(metadata?.mediaFormat)?.toLowerCase();
+  if (explicit) return explicit;
+  const tagged = tags.find((tag) => tag.startsWith(MEDIA_FORMAT_TAG_PREFIX));
+  return tagged ? tagged.slice(MEDIA_FORMAT_TAG_PREFIX.length) : undefined;
 }
 
 function canReadDocumentMemory(
@@ -484,10 +534,16 @@ function buildRouteMessage({
 
 function serviceSearchScope(
   filters: DocumentFilter,
-): { entityId?: UUID } | undefined {
-  return filters.scopedToEntityId
-    ? { entityId: filters.scopedToEntityId }
-    : undefined;
+): { entityId?: UUID; roomId?: UUID } | undefined {
+  // Push room scoping into the service BEFORE ranking/capping so a room-filtered
+  // search isn't starved by higher-ranked matches from other rooms filling the
+  // capped result set (the service filters on the document memory's roomId,
+  // which the attachment-ingest writer sets to the source room). scopedToEntityId
+  // continues to narrow to a user's private space.
+  const scope: { entityId?: UUID; roomId?: UUID } = {};
+  if (filters.scopedToEntityId) scope.entityId = filters.scopedToEntityId;
+  if (filters.roomId) scope.roomId = filters.roomId;
+  return scope.entityId || scope.roomId ? scope : undefined;
 }
 
 function decodeMatchedPathComponent(


### PR DESCRIPTION
## Knowledge slice 1 — attachment→knowledge ingest pipeline (#13593)

Parent epic: #13560 · Binding constraints: #8876

Mirrors chat attachments into the knowledge/documents store, **tagged by room, sender, sender role, and media format**, with a **source-trust-derived scope** so owner-only knowledge cannot spill into public rooms at the write boundary. Builds **ON** the existing content-addressed media store — no second store, no new tables (honors #8876): knowledge records point at the sha256 bytes via `metadata.mediaUrl/mediaHash/mediaFileName`, and the reference-aware media GC already unions document `mediaUrl` so files survive while a record references them.

### What this does (backend / agent-side only)
- **`packages/agent/src/api/attachment-knowledge-ingest.ts`** — the pipeline:
  - `after_memory_persisted` hook (messages-table, inbound-only; the agent's own outgoing attachments are skipped)
  - `mediaFormatFromMimeType` — coarse facet (image/audio/video/pdf/text/transcript/file) derived from mimeType at read time (#8876: no new enum)
  - `resolveIngestScope` — **spill guard**: owner/DM chat → `owner-private`; public/community room (Discord, groups, feeds) → `user-private` scoped to sender. Never `global`, never `owner-private` for a public room. Even the OWNER speaking in a public room gets `user-private` (scoped to them), so a public-room retrieval for another actor can never surface it.
  - `ingestMessageAttachmentsAsKnowledge` — one knowledge doc per **store-backed** attachment, linked to the sha256; remote/ephemeral URLs are skipped (nothing durable to point at). **Fail fast** with a typed `ElizaError` (never a silent skip that makes an attachment vanish); the hook boundary routes it to `reportError`.
  - The searchable body carries a stable **context-provenance line** (room+sender+scope) so the documents store's content-addressed dedupe is context-scoped: the same bytes in a different room/sender/scope produce a **distinct** record instead of collapsing onto the first occurrence and losing its facets. Identical bytes in the same (room, sender, scope) still dedupe idempotently.
- **`packages/agent/src/api/attachment-knowledge-backfill.ts`** — one-time idempotent task tagging pre-existing transcript-mirror docs with `roomId` + `media-format:transcript` (transcriptId/audio links untouched).
- **`plugins/plugin-documents/src/routes.ts`** — first-class `roomId` filter + `mediaFormat` facet on `DocumentFilter` (derived from `metadata.mediaFormat` or the `media-format:<f>` tag), composing with `tags[]`/`addedBy`/`scope`/`timeRange`. **Access control applies AFTER filtering** — owner-private never leaks to a non-owner actor.
- **`packages/agent/src/providers/page-scoped-context.ts`** — `page-knowledge` live-state scope exposing recent-attachment counts by media format (feeds slice 2's proactive greeting: "You have N new attachments from Discord this week…").

### Tests
- Ingest happy path + metadata correctness (sha256 link, `attachment`+format tags, addedBy/addedByRole/roomId), scope/spill-guard matrix, context-scoped dedupe, unsupported-source handling (remote/ephemeral + agent-outgoing skipped), fail-fast typed error.
- Backfill idempotency (adds facets, preserves links, no-op on re-run).
- Route `roomId`/`mediaFormat` filter composition with `tags[]` + post-filter access control.
- Schema-vs-type-drift contract test updated for the `page-knowledge` scope.

### What slice 2/3 will consume from this
- **Slice 2 (UI hub, #13594):** the `page-knowledge` live-state counts (by format) for the proactive greeting; the `attachment` + `media-format:<f>` tag convention and `metadata.roomId`/`mediaFormat` facets for the hub's filter chips; the ingested records themselves (retag/rescope/delete actions land in slice 2 on top of the scope model enforced here).
- **Slice 3 (search surfacing, #13595):** the `roomId` + `mediaFormat` route filters and the read-side `canReadDocumentMemory` wall are already in place for `SEARCH_KNOWLEDGE` to compose against; the media-format facet is the search tag surface.

Signed — [sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>
