### PR TITLE
fix(#13566): retry-in-isolation for XCUITest flake cascades + --skip-build stale-runner guard

### DIFF
--- a/packages/app/scripts/ios-device-capture.mjs
+++ b/packages/app/scripts/ios-device-capture.mjs
@@ -39,9 +39,12 @@ import { fileURLToPath } from "node:url";
 import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
 import {
   buildPlistXml,
+  classifyIsolatedReruns,
+  evaluateRunnerStaleness,
   extractXctestrunAppPaths,
   findDeviceRecord,
   parseCliArgs,
+  parseFailedTestIdentifiers,
   parsePlist,
   resolveDeviceId,
   resolveXctestrunTestRoot,
@@ -160,13 +163,42 @@ function newestXctestrun(productsDir) {
   return candidates[0]?.full ?? null;
 }
 
+// Committed XCUITest Swift sources the runner is compiled from. A --skip-build
+// runner older than any of these executes stale tests (#13566).
+const APPUITESTS_SOURCE_DIR = path.resolve(
+  scriptDir,
+  "..",
+  "..",
+  "app-core",
+  "platforms",
+  "ios",
+  "App",
+  "AppUITests",
+);
+
+function collectAppUITestsSources(sourceDir = APPUITESTS_SOURCE_DIR) {
+  if (!fs.existsSync(sourceDir)) return [];
+  return fs
+    .readdirSync(sourceDir)
+    .filter((name) => name.endsWith(".swift"))
+    .map((name) => {
+      const full = path.join(sourceDir, name);
+      return { path: full, mtimeMs: fs.statSync(full).mtimeMs };
+    });
+}
+
 async function main() {
   const args = parseCliArgs(process.argv.slice(2), {
-    booleans: ["skip-build", "help"],
+    booleans: [
+      "skip-build",
+      "allow-stale-runner",
+      "no-retry-isolation",
+      "help",
+    ],
   });
   if (args.help) {
     console.log(
-      "Usage: node scripts/ios-device-capture.mjs --platform sim|device [--device <udid>] [--skip-build] [--output <dir>] [--app-path <App.app>] [--boot-timeout <sec>] [--interval <sec>] [--agent-ready-timeout <sec>] [--derived-data <dir>] [--only-testing <id>]",
+      "Usage: node scripts/ios-device-capture.mjs --platform sim|device [--device <udid>] [--skip-build] [--allow-stale-runner] [--no-retry-isolation] [--output <dir>] [--app-path <App.app>] [--boot-timeout <sec>] [--interval <sec>] [--agent-ready-timeout <sec>] [--derived-data <dir>] [--only-testing <id>]",
     );
     return;
   }
@@ -271,6 +303,43 @@ async function main() {
   }
   log(`xctestrun: ${xctestrunPath}`);
 
+  // --skip-build stale-runner guard (#13566): a reused runner older than any
+  // AppUITests Swift source runs day-old tests and can false-green a change to
+  // the very suite under test. Fail-fast with the rebuild command unless the
+  // operator passes --allow-stale-runner (which proceeds, logging the delta).
+  if (args["skip-build"]) {
+    const runnerStat = fs.existsSync(xctestrunPath)
+      ? fs.statSync(xctestrunPath)
+      : null;
+    const staleness = evaluateRunnerStaleness({
+      runnerMtimeMs: runnerStat ? runnerStat.mtimeMs : null,
+      sources: collectAppUITestsSources(),
+      allowStale: Boolean(args["allow-stale-runner"]),
+    });
+    if (staleness.stale) {
+      const newest = staleness.newestSource;
+      const detail = newest
+        ? `${path.basename(newest.path)} was modified ${Math.round(
+            staleness.deltaMs / 1000,
+          )}s after the runner was built (${newest.path})`
+        : "the reused runner could not be dated";
+      const rebuildCmd =
+        "rebuild the runner: drop --skip-build (xcodebuild build-for-testing " +
+        "-scheme AppUITests), or re-run the mobile build lane you are capturing.";
+      if (staleness.overridden) {
+        log(
+          `WARNING --allow-stale-runner: proceeding with a STALE runner — ${detail}. ` +
+            `Results may not reflect the current AppUITests sources. ${rebuildCmd}`,
+        );
+      } else {
+        fail(
+          `--skip-build runner is STALE: ${detail}. ${rebuildCmd} ` +
+            "Or pass --allow-stale-runner to proceed anyway (logging the delta).",
+        );
+      }
+    }
+  }
+
   // 3. Normalize a working copy of the xctestrun to XML (xcodebuild sometimes
   //    emits binary plists) and parse it — both lanes need the parsed form.
   //    Because the working copy lives in outputDir (not Build/Products),
@@ -332,8 +401,9 @@ async function main() {
   }
   log(`destination: ${destination}`);
 
+  // runHarness clears each result bundle before writing (so the main run and
+  // every isolated re-run start from a clean .xcresult).
   const resultBundle = path.join(outputDir, "BootCapture.xcresult");
-  fs.rmSync(resultBundle, { recursive: true, force: true });
 
   // 5. Run the harness. TEST_RUNNER_-prefixed env vars are forwarded by
   //    xcodebuild into the test-runner process (how the Swift side reads
@@ -342,14 +412,41 @@ async function main() {
   //    boot-capture suite AND the WKWebView gesture-semantics suite (#11353);
   //    narrow with --only-testing AppUITests/<Class>[/<test>].
   const onlyTesting = args["only-testing"] || "AppUITests";
-  // Record the whole run on the simulator (walkthrough evidence for the
-  // gesture-loop lane; no-op on a physical device). Started just before the
-  // harness so it captures every gesture, stopped in `finally` so a failing run
-  // still yields its video.
-  const simVideo = startSimVideo({ udid: simUdid, outputDir });
-  let testResult;
-  try {
-    testResult = spawnSync(
+  const harnessEnv = {
+    ...process.env,
+    TEST_RUNNER_ELIZA_BOOT_TIMEOUT_SECONDS:
+      args["boot-timeout"] ?? process.env.ELIZA_BOOT_TIMEOUT_SECONDS ?? "180",
+    TEST_RUNNER_ELIZA_BOOT_SCREENSHOT_INTERVAL_SECONDS:
+      args.interval ??
+      process.env.ELIZA_BOOT_SCREENSHOT_INTERVAL_SECONDS ??
+      "15",
+    // How long the gesture suite waits for the local model to come online
+    // before sending chat turns (0 = don't wait; the suite then exercises
+    // its warm-up/evicted-thread semantics instead).
+    TEST_RUNNER_ELIZA_AGENT_READY_TIMEOUT_SECONDS:
+      args["agent-ready-timeout"] ??
+      process.env.ELIZA_AGENT_READY_TIMEOUT_SECONDS ??
+      "240",
+    // Local onboarding only: how long to hold the app foregrounded after
+    // finish so the fire-and-forget recommended-model download completes
+    // (0 = skip, the default — a multi-GB pull should not slow normal runs).
+    TEST_RUNNER_ELIZA_LOCAL_MODEL_DOWNLOAD_WAIT_SECONDS:
+      args["local-download-wait"] ??
+      process.env.ELIZA_LOCAL_MODEL_DOWNLOAD_WAIT_SECONDS ??
+      "0",
+    // Seeded launcher gesture-loop (LauncherGestureLoopUITests): forward
+    // the reproduction seed + action count so a run replays exactly.
+    ...(process.env.ELIZA_LOOP_SEED
+      ? { TEST_RUNNER_ELIZA_LOOP_SEED: process.env.ELIZA_LOOP_SEED }
+      : {}),
+    ...(process.env.ELIZA_LOOP_ACTIONS
+      ? { TEST_RUNNER_ELIZA_LOOP_ACTIONS: process.env.ELIZA_LOOP_ACTIONS }
+      : {}),
+  };
+
+  const runHarness = (testing, bundlePath) => {
+    fs.rmSync(bundlePath, { recursive: true, force: true });
+    return spawnSync(
       "xcodebuild",
       [
         "test-without-building",
@@ -358,48 +455,48 @@ async function main() {
         "-destination",
         destination,
         "-resultBundlePath",
-        resultBundle,
+        bundlePath,
         "-only-testing",
-        onlyTesting,
+        testing,
       ],
-      {
-        cwd: iosProjectDir,
-        stdio: "inherit",
-        env: {
-          ...process.env,
-          TEST_RUNNER_ELIZA_BOOT_TIMEOUT_SECONDS:
-            args["boot-timeout"] ??
-            process.env.ELIZA_BOOT_TIMEOUT_SECONDS ??
-            "180",
-          TEST_RUNNER_ELIZA_BOOT_SCREENSHOT_INTERVAL_SECONDS:
-            args.interval ??
-            process.env.ELIZA_BOOT_SCREENSHOT_INTERVAL_SECONDS ??
-            "15",
-          // How long the gesture suite waits for the local model to come online
-          // before sending chat turns (0 = don't wait; the suite then exercises
-          // its warm-up/evicted-thread semantics instead).
-          TEST_RUNNER_ELIZA_AGENT_READY_TIMEOUT_SECONDS:
-            args["agent-ready-timeout"] ??
-            process.env.ELIZA_AGENT_READY_TIMEOUT_SECONDS ??
-            "240",
-          // Local onboarding only: how long to hold the app foregrounded after
-          // finish so the fire-and-forget recommended-model download completes
-          // (0 = skip, the default — a multi-GB pull should not slow normal runs).
-          TEST_RUNNER_ELIZA_LOCAL_MODEL_DOWNLOAD_WAIT_SECONDS:
-            args["local-download-wait"] ??
-            process.env.ELIZA_LOCAL_MODEL_DOWNLOAD_WAIT_SECONDS ??
-            "0",
-          // Seeded launcher gesture-loop (LauncherGestureLoopUITests): forward
-          // the reproduction seed + action count so a run replays exactly.
-          ...(process.env.ELIZA_LOOP_SEED
-            ? { TEST_RUNNER_ELIZA_LOOP_SEED: process.env.ELIZA_LOOP_SEED }
-            : {}),
-          ...(process.env.ELIZA_LOOP_ACTIONS
-            ? { TEST_RUNNER_ELIZA_LOOP_ACTIONS: process.env.ELIZA_LOOP_ACTIONS }
-            : {}),
-        },
-      },
+      { cwd: iosProjectDir, stdio: "inherit", env: harnessEnv },
     );
+  };
+
+  // Read the failed-test identifiers out of a produced .xcresult so the
+  // retry-in-isolation pass can re-run each one alone. Returns [] on any
+  // missing bundle / non-zero summary / unparseable output (fail-closed: no
+  // isolable failures found means the suite verdict stands).
+  const readFailedTestIdentifiers = (bundlePath) => {
+    if (!fs.existsSync(bundlePath)) return [];
+    const summary = spawnSync(
+      "xcrun",
+      [
+        "xcresulttool",
+        "get",
+        "test-results",
+        "summary",
+        "--path",
+        bundlePath,
+        "--format",
+        "json",
+      ],
+      { encoding: "utf8" },
+    );
+    if (summary.status !== 0) return [];
+    return parseFailedTestIdentifiers(summary.stdout, {
+      fallbackTarget: onlyTesting.split("/")[0] || "AppUITests",
+    });
+  };
+
+  // Record the whole run on the simulator (walkthrough evidence for the
+  // gesture-loop lane; no-op on a physical device). Started just before the
+  // harness so it captures every gesture, stopped in `finally` so a failing run
+  // still yields its video.
+  const simVideo = startSimVideo({ udid: simUdid, outputDir });
+  let testResult;
+  try {
+    testResult = runHarness(onlyTesting, resultBundle);
   } finally {
     const videoPath = await simVideo.stop();
     if (videoPath) log(`simulator video: ${videoPath}`);
@@ -450,14 +547,93 @@ async function main() {
   log(`attachments: ${exported.length} file(s) in ${attachmentsDir}`);
   log(`result bundle: ${resultBundle}`);
 
-  if (testResult.status !== 0) {
+  if (testResult.status === 0) {
+    log("boot capture PASSED (home or startup-failure card reached).");
+    return;
+  }
+
+  // 7. Retry-in-isolation (#13566): device XCUITest terminate/relaunch cycles
+  //    flake through devicectl, and a single flaky termination can poison
+  //    subsequent tests in the same monolithic invocation. Re-run EACH failed
+  //    test alone; a test that passes isolated is a `flake` (exit 0 stands),
+  //    one that fails both is a real `fail` (exit nonzero). Skipped with
+  //    --no-retry-isolation, which keeps the legacy hard-fail-on-any behavior.
+  const suiteFailures = readFailedTestIdentifiers(resultBundle);
+  if (args["no-retry-isolation"] || suiteFailures.length === 0) {
+    const why = args["no-retry-isolation"]
+      ? "--no-retry-isolation set"
+      : "no isolable failed-test identifiers parsed from the .xcresult";
+    writeFlakeSummary(outputDir, { skipped: true, reason: why });
     fail(
-      `harness run failed (xcodebuild exit ${testResult.status}). ` +
+      `harness run failed (xcodebuild exit ${testResult.status}); ${why}. ` +
         "Exit 65 means a test assertion failed — e.g. the boot never reached home " +
         `or the startup-failure card. Review the screenshots in ${attachmentsDir}.`,
     );
   }
-  log("boot capture PASSED (home or startup-failure card reached).");
+
+  log(
+    `retry-in-isolation: re-running ${suiteFailures.length} failed test(s) alone — ` +
+      suiteFailures.map((f) => f.identifier).join(", "),
+  );
+  const isolatedResults = [];
+  const isolationDir = path.join(outputDir, "isolation");
+  fs.mkdirSync(isolationDir, { recursive: true });
+  for (const failure of suiteFailures) {
+    const safeName = failure.identifier.replace(/[^A-Za-z0-9._-]/g, "_");
+    const isoBundle = path.join(isolationDir, `${safeName}.xcresult`);
+    log(`  isolated re-run: ${failure.identifier}`);
+    const isoResult = runHarness(failure.identifier, isoBundle);
+    isolatedResults.push({
+      identifier: failure.identifier,
+      isolatedPassed: isoResult.status === 0,
+    });
+  }
+
+  const classification = classifyIsolatedReruns(suiteFailures, isolatedResults);
+  writeFlakeSummary(outputDir, {
+    skipped: false,
+    verdicts: classification.verdicts,
+    flakes: classification.flakes,
+    realFailures: classification.realFailures,
+  });
+  for (const v of classification.verdicts) {
+    log(`  ${v.verdict.toUpperCase()}: ${v.identifier}`);
+  }
+
+  if (classification.exitNonZero) {
+    fail(
+      `harness run failed: ${classification.realFailures.length} test(s) failed ` +
+        `both in-suite AND isolated (${classification.realFailures.join(", ")}). ` +
+        (classification.flakes.length > 0
+          ? `${classification.flakes.length} flake(s) recorded. `
+          : "") +
+        `Review the screenshots in ${attachmentsDir}.`,
+    );
+  }
+  log(
+    `boot capture PASSED after isolation: all ${classification.flakes.length} ` +
+      "suite failure(s) were flakes (passed on isolated re-run).",
+  );
+}
+
+// Persist the flake classification into the run's test-summary output so trend
+// data exists across runs (#13566).
+function writeFlakeSummary(outputDir, payload) {
+  try {
+    fs.writeFileSync(
+      path.join(outputDir, "flake-classification.json"),
+      `${JSON.stringify(payload, null, 2)}\n`,
+    );
+  } catch (error) {
+    // error-policy:J5 — trend-data side-output is non-authoritative; a write
+    // failure must NOT mask or alter the real pass/fail verdict, but is logged
+    // observably (not silently swallowed) so a broken output dir is visible.
+    log(
+      `warning: could not write flake-classification.json (${
+        error?.message ?? error
+      }); the run verdict is unaffected.`,
+    );
+  }
 }
 
 const isDirectRun =

--- a/packages/app/scripts/ios-device-lib.mjs
+++ b/packages/app/scripts/ios-device-lib.mjs
@@ -675,6 +675,241 @@ export function parseCliArgs(argv, { booleans = [] } = {}) {
   return args;
 }
 
+// ── XCUITest failed-test parsing + retry-in-isolation (#13566) ──────────
+
+/**
+ * Parse the failed-test identifiers out of a captured
+ * `xcrun xcresulttool get test-results summary --format json` payload.
+ *
+ * Xcode 16's summary emits a `testFailures` array whose rows carry a
+ * `testIdentifierString` ("Class/testMethod()" form) plus `testName` and
+ * `targetName`. Older/alternate captures nest the same data under
+ * `topInsights` or a bare `failures` array; we accept any of them and dedupe.
+ * The `-only-testing` argument xcodebuild wants is `Target/Class/method` —
+ * `testIdentifierString` omits the target and keeps the `()` suffix on the
+ * method, so we normalize: drop a trailing `()`, and prefix the target
+ * (from the row's `targetName`, else the caller-supplied `fallbackTarget`).
+ *
+ * Pure — the caller reads the file and passes the parsed object (or the raw
+ * JSON string). A non-object / unparseable input yields an empty list rather
+ * than throwing, so a malformed summary degrades to "no isolable failures"
+ * and the harness keeps its normal nonzero-exit verdict (fail-closed: we
+ * never fabricate a pass, we just can't offer retry-in-isolation).
+ *
+ * @param {unknown} summary parsed summary object OR raw JSON string
+ * @param {{ fallbackTarget?: string }} [options]
+ * @returns {Array<{ identifier: string, testName: string, targetName: string | null }>}
+ */
+export function parseFailedTestIdentifiers(
+  summary,
+  { fallbackTarget = "AppUITests" } = {},
+) {
+  let root = summary;
+  if (typeof summary === "string") {
+    try {
+      root = JSON.parse(summary);
+    } catch {
+      return [];
+    }
+  }
+  if (!root || typeof root !== "object") return [];
+
+  const rows = [];
+  const pushRows = (value) => {
+    if (Array.isArray(value)) {
+      for (const row of value) {
+        if (row && typeof row === "object") rows.push(row);
+      }
+    }
+  };
+  pushRows(root.testFailures);
+  pushRows(root.failures);
+  // topInsights on some captures nests { impact, category, testFailures: [...] }
+  if (Array.isArray(root.topInsights)) {
+    for (const insight of root.topInsights) {
+      if (insight && typeof insight === "object")
+        pushRows(insight.testFailures);
+    }
+  }
+
+  const seen = new Set();
+  const failures = [];
+  for (const row of rows) {
+    const targetName =
+      typeof row.targetName === "string" && row.targetName.trim()
+        ? row.targetName.trim()
+        : null;
+    const rawId =
+      typeof row.testIdentifierString === "string" &&
+      row.testIdentifierString.trim()
+        ? row.testIdentifierString.trim()
+        : typeof row.testIdentifier === "string" && row.testIdentifier.trim()
+          ? row.testIdentifier.trim()
+          : typeof row.testName === "string" && row.testName.trim()
+            ? row.testName.trim()
+            : null;
+    if (!rawId) continue;
+    const identifier = buildOnlyTestingIdentifier(rawId, {
+      targetName: targetName ?? fallbackTarget,
+    });
+    if (!identifier || seen.has(identifier)) continue;
+    seen.add(identifier);
+    failures.push({
+      identifier,
+      testName:
+        typeof row.testName === "string" && row.testName.trim()
+          ? row.testName.trim()
+          : rawId,
+      targetName,
+    });
+  }
+  return failures;
+}
+
+/**
+ * Normalize an xcresult test identifier into the `Target/Class/method` form
+ * that `xcodebuild -only-testing:` accepts. Handles:
+ *   - trailing `()` on the method ("Class/testFoo()" → "Class/testFoo")
+ *   - an already-target-prefixed id (kept as-is once the `()` is stripped)
+ *   - a bare "Class/testFoo" (prefixed with `targetName`)
+ *   - a bare "Class" (a whole-class failure — prefixed, no method)
+ *
+ * @param {string} rawId
+ * @param {{ targetName: string }} options
+ * @returns {string | null}
+ */
+export function buildOnlyTestingIdentifier(rawId, { targetName }) {
+  if (typeof rawId !== "string") return null;
+  const trimmed = rawId.trim().replace(/\(\)$/, "");
+  if (!trimmed) return null;
+  const segments = trimmed.split("/").filter((s) => s.length > 0);
+  if (segments.length === 0) return null;
+  // Already target-prefixed? A 3-segment id, or a 2-segment id whose head
+  // equals the target, is taken verbatim; otherwise prefix the target.
+  if (segments.length >= 3) return segments.join("/");
+  if (segments[0] === targetName) return segments.join("/");
+  return [targetName, ...segments].join("/");
+}
+
+/**
+ * Fold per-test isolated-rerun outcomes into a three-way verdict list and an
+ * overall exit decision, per #13566:
+ *   - a test that FAILED in the full suite but PASSED in isolation → `flake`
+ *   - a test that FAILED both → `fail`
+ * (Tests that passed in the suite never enter this pass.) The run should exit
+ * NONZERO iff at least one real `fail` remains; a run whose only failures were
+ * flakes exits 0 with those tests recorded as `flake` for trend data.
+ *
+ * Pure — the caller runs each isolated `xcodebuild test-without-building` and
+ * passes `{ identifier, isolatedPassed }`. An identifier missing from the
+ * results map is treated conservatively as still-failing (`fail`) so a
+ * skipped/crashed isolated rerun can never green-wash the suite.
+ *
+ * @param {Array<{ identifier: string, testName?: string }>} suiteFailures
+ * @param {Array<{ identifier: string, isolatedPassed: boolean }>} isolatedResults
+ * @returns {{
+ *   verdicts: Array<{ identifier: string, testName: string, verdict: 'flake' | 'fail' }>,
+ *   flakes: string[],
+ *   realFailures: string[],
+ *   exitNonZero: boolean,
+ * }}
+ */
+export function classifyIsolatedReruns(suiteFailures, isolatedResults) {
+  const isolatedById = new Map();
+  for (const result of isolatedResults ?? []) {
+    if (result && typeof result.identifier === "string") {
+      isolatedById.set(result.identifier, result.isolatedPassed === true);
+    }
+  }
+  const verdicts = [];
+  const flakes = [];
+  const realFailures = [];
+  for (const failure of suiteFailures ?? []) {
+    if (!failure || typeof failure.identifier !== "string") continue;
+    const passedIsolated = isolatedById.get(failure.identifier) === true;
+    const verdict = passedIsolated ? "flake" : "fail";
+    verdicts.push({
+      identifier: failure.identifier,
+      testName: failure.testName ?? failure.identifier,
+      verdict,
+    });
+    if (verdict === "flake") flakes.push(failure.identifier);
+    else realFailures.push(failure.identifier);
+  }
+  return {
+    verdicts,
+    flakes,
+    realFailures,
+    exitNonZero: realFailures.length > 0,
+  };
+}
+
+// ── --skip-build stale-runner guard (#13566) ────────────────────────────
+
+/**
+ * Decide whether a reused test runner (--skip-build) is stale relative to the
+ * XCUITest Swift sources it was compiled from. A runner built BEFORE any
+ * AppUITests source was last modified executes day-old tests and can
+ * false-green a change to the very suite under test (#13566).
+ *
+ * Pure — the caller stats the `.xctestrun` and the AppUITests/*.swift sources
+ * and passes their mtimes (ms). Returns a decision the script turns into a
+ * fail-fast (naming the newest stale source + the rebuild command) unless the
+ * operator passes an explicit override.
+ *
+ * Fail-closed: if the runner mtime is unknown (null) we report `stale` — a
+ * skip-build run we cannot date is not trusted to be fresh. An empty source
+ * list (no sources found) is NOT stale (nothing to be stale against), so a
+ * repo layout change can't wedge the guard shut.
+ *
+ * @param {{
+ *   runnerMtimeMs: number | null,
+ *   sources: Array<{ path: string, mtimeMs: number }>,
+ *   allowStale?: boolean,
+ * }} params
+ * @returns {{
+ *   stale: boolean,
+ *   overridden: boolean,
+ *   newestSource: { path: string, mtimeMs: number } | null,
+ *   deltaMs: number,
+ * }}
+ */
+export function evaluateRunnerStaleness({
+  runnerMtimeMs,
+  sources,
+  allowStale = false,
+}) {
+  const validSources = (sources ?? []).filter(
+    (s) => s && typeof s.mtimeMs === "number" && Number.isFinite(s.mtimeMs),
+  );
+  let newestSource = null;
+  for (const source of validSources) {
+    if (!newestSource || source.mtimeMs > newestSource.mtimeMs) {
+      newestSource = source;
+    }
+  }
+  // No datable runner → cannot prove freshness → treat as stale (fail-closed).
+  if (runnerMtimeMs === null || !Number.isFinite(runnerMtimeMs)) {
+    return {
+      stale: true,
+      overridden: allowStale === true,
+      newestSource,
+      deltaMs: 0,
+    };
+  }
+  // No sources to compare against → nothing can be stale.
+  if (!newestSource) {
+    return { stale: false, overridden: false, newestSource: null, deltaMs: 0 };
+  }
+  const stale = newestSource.mtimeMs > runnerMtimeMs;
+  return {
+    stale,
+    overridden: stale && allowStale === true,
+    newestSource,
+    deltaMs: stale ? newestSource.mtimeMs - runnerMtimeMs : 0,
+  };
+}
+
 // ── Console-capture exit classification (#11515) ────────────────────────
 
 /**

--- a/packages/app/scripts/ios-device-lib.test.mjs
+++ b/packages/app/scripts/ios-device-lib.test.mjs
@@ -8,16 +8,20 @@ import crypto from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   buildCodesignPlan,
+  buildOnlyTestingIdentifier,
   buildPlistXml,
   CONSOLE_SIGTRAP_SIGNATURE,
   classifyConsoleExit,
+  classifyIsolatedReruns,
   deriveSigningEntitlements,
+  evaluateRunnerStaleness,
   extractXctestrunAppPaths,
   findDeviceRecord,
   normalizeProvisioningProfile,
   PlistData,
   parseCliArgs,
   parseCodesigningIdentities,
+  parseFailedTestIdentifiers,
   parsePlist,
   profileMatchesTarget,
   resolveDeviceId,
@@ -647,5 +651,238 @@ describe("classifyConsoleExit (#11515)", () => {
     const verdict = classifyConsoleExit({ code: 0, signal: null, logText: "" });
     expect(verdict.kind).toBe("ok");
     expect(verdict.fatal).toBe(false);
+  });
+});
+
+describe("buildOnlyTestingIdentifier (#13566)", () => {
+  it("strips a trailing () and prefixes the target for a Class/method id", () => {
+    expect(
+      buildOnlyTestingIdentifier("GestureSemanticsUITests/testDetentFlick()", {
+        targetName: "AppUITests",
+      }),
+    ).toBe("AppUITests/GestureSemanticsUITests/testDetentFlick");
+  });
+
+  it("keeps an already-target-prefixed 3-segment id verbatim", () => {
+    expect(
+      buildOnlyTestingIdentifier(
+        "AppUITests/GestureSemanticsUITests/testDetentFlick()",
+        { targetName: "AppUITests" },
+      ),
+    ).toBe("AppUITests/GestureSemanticsUITests/testDetentFlick");
+  });
+
+  it("does not double-prefix a 2-segment id whose head is the target", () => {
+    expect(
+      buildOnlyTestingIdentifier("AppUITests/BootCaptureUITests", {
+        targetName: "AppUITests",
+      }),
+    ).toBe("AppUITests/BootCaptureUITests");
+  });
+
+  it("prefixes a bare class (whole-class failure)", () => {
+    expect(
+      buildOnlyTestingIdentifier("BootCaptureUITests", {
+        targetName: "AppUITests",
+      }),
+    ).toBe("AppUITests/BootCaptureUITests");
+  });
+
+  it("returns null for an empty / non-string id", () => {
+    expect(buildOnlyTestingIdentifier("", { targetName: "AppUITests" })).toBe(
+      null,
+    );
+    expect(
+      buildOnlyTestingIdentifier("   ", { targetName: "AppUITests" }),
+    ).toBe(null);
+    expect(buildOnlyTestingIdentifier(null, { targetName: "AppUITests" })).toBe(
+      null,
+    );
+  });
+});
+
+describe("parseFailedTestIdentifiers (#13566)", () => {
+  it("parses Xcode-16 testFailures rows into -only-testing identifiers", () => {
+    const summary = {
+      failedTests: 2,
+      testFailures: [
+        {
+          testName: "testComposerScroll()",
+          testIdentifierString: "GestureSemanticsUITests/testComposerScroll()",
+          targetName: "AppUITests",
+          failureText: "XCTAssertTrue failed",
+        },
+        {
+          testName: "testDetentFlick()",
+          testIdentifierString: "GestureSemanticsUITests/testDetentFlick()",
+          targetName: "AppUITests",
+        },
+      ],
+    };
+    const failures = parseFailedTestIdentifiers(summary);
+    expect(failures.map((f) => f.identifier)).toEqual([
+      "AppUITests/GestureSemanticsUITests/testComposerScroll",
+      "AppUITests/GestureSemanticsUITests/testDetentFlick",
+    ]);
+    expect(failures[0].targetName).toBe("AppUITests");
+  });
+
+  it("accepts a raw JSON string and falls back to the given target", () => {
+    const raw = JSON.stringify({
+      testFailures: [
+        { testIdentifierString: "BootCaptureUITests/testColdBoot()" },
+      ],
+    });
+    const failures = parseFailedTestIdentifiers(raw, {
+      fallbackTarget: "AppUITests",
+    });
+    expect(failures).toHaveLength(1);
+    expect(failures[0].identifier).toBe(
+      "AppUITests/BootCaptureUITests/testColdBoot",
+    );
+  });
+
+  it("dedupes and reads topInsights-nested failures", () => {
+    const summary = {
+      topInsights: [
+        {
+          category: "flaky",
+          testFailures: [
+            { testIdentifierString: "GestureSemanticsUITests/testFlick()" },
+            { testIdentifierString: "GestureSemanticsUITests/testFlick()" },
+          ],
+        },
+      ],
+    };
+    const failures = parseFailedTestIdentifiers(summary);
+    expect(failures).toHaveLength(1);
+    expect(failures[0].identifier).toBe(
+      "AppUITests/GestureSemanticsUITests/testFlick",
+    );
+  });
+
+  it("returns [] for unparseable / non-object input (fail-closed)", () => {
+    expect(parseFailedTestIdentifiers("not json{")).toEqual([]);
+    expect(parseFailedTestIdentifiers(null)).toEqual([]);
+    expect(parseFailedTestIdentifiers(42)).toEqual([]);
+    expect(parseFailedTestIdentifiers({})).toEqual([]);
+  });
+});
+
+describe("classifyIsolatedReruns (#13566)", () => {
+  const suiteFailures = [
+    {
+      identifier: "AppUITests/GestureSemanticsUITests/testComposer",
+      testName: "composer",
+    },
+    {
+      identifier: "AppUITests/GestureSemanticsUITests/testDetent",
+      testName: "detent",
+    },
+  ];
+
+  it("marks a suite failure that passes isolated as a flake and exits 0", () => {
+    const result = classifyIsolatedReruns(suiteFailures, [
+      {
+        identifier: "AppUITests/GestureSemanticsUITests/testComposer",
+        isolatedPassed: true,
+      },
+      {
+        identifier: "AppUITests/GestureSemanticsUITests/testDetent",
+        isolatedPassed: true,
+      },
+    ]);
+    expect(result.flakes).toHaveLength(2);
+    expect(result.realFailures).toEqual([]);
+    expect(result.exitNonZero).toBe(false);
+    expect(result.verdicts.every((v) => v.verdict === "flake")).toBe(true);
+  });
+
+  it("keeps a test that fails both as a real fail and exits nonzero", () => {
+    const result = classifyIsolatedReruns(suiteFailures, [
+      {
+        identifier: "AppUITests/GestureSemanticsUITests/testComposer",
+        isolatedPassed: true,
+      },
+      {
+        identifier: "AppUITests/GestureSemanticsUITests/testDetent",
+        isolatedPassed: false,
+      },
+    ]);
+    expect(result.flakes).toEqual([
+      "AppUITests/GestureSemanticsUITests/testComposer",
+    ]);
+    expect(result.realFailures).toEqual([
+      "AppUITests/GestureSemanticsUITests/testDetent",
+    ]);
+    expect(result.exitNonZero).toBe(true);
+  });
+
+  it("treats a missing isolated result as still-failing (no green-wash)", () => {
+    const result = classifyIsolatedReruns(suiteFailures, [
+      {
+        identifier: "AppUITests/GestureSemanticsUITests/testComposer",
+        isolatedPassed: true,
+      },
+      // testDetent's isolated rerun crashed / never reported
+    ]);
+    expect(result.realFailures).toEqual([
+      "AppUITests/GestureSemanticsUITests/testDetent",
+    ]);
+    expect(result.exitNonZero).toBe(true);
+  });
+});
+
+describe("evaluateRunnerStaleness (#13566)", () => {
+  const RUNNER = 1_000_000;
+
+  it("flags a runner older than any AppUITests source as stale", () => {
+    const decision = evaluateRunnerStaleness({
+      runnerMtimeMs: RUNNER,
+      sources: [
+        { path: "GestureSemanticsUITests.swift", mtimeMs: RUNNER + 5000 },
+        { path: "BootCaptureUITests.swift", mtimeMs: RUNNER - 5000 },
+      ],
+    });
+    expect(decision.stale).toBe(true);
+    expect(decision.overridden).toBe(false);
+    expect(decision.newestSource.path).toBe("GestureSemanticsUITests.swift");
+    expect(decision.deltaMs).toBe(5000);
+  });
+
+  it("is not stale when the runner is newer than every source", () => {
+    const decision = evaluateRunnerStaleness({
+      runnerMtimeMs: RUNNER,
+      sources: [{ path: "A.swift", mtimeMs: RUNNER - 1000 }],
+    });
+    expect(decision.stale).toBe(false);
+    expect(decision.deltaMs).toBe(0);
+  });
+
+  it("honors --allow-stale-runner as overridden (proceed, not blocked)", () => {
+    const decision = evaluateRunnerStaleness({
+      runnerMtimeMs: RUNNER,
+      sources: [{ path: "A.swift", mtimeMs: RUNNER + 1 }],
+      allowStale: true,
+    });
+    expect(decision.stale).toBe(true);
+    expect(decision.overridden).toBe(true);
+  });
+
+  it("fails closed when the runner mtime is unknown", () => {
+    const decision = evaluateRunnerStaleness({
+      runnerMtimeMs: null,
+      sources: [{ path: "A.swift", mtimeMs: RUNNER }],
+    });
+    expect(decision.stale).toBe(true);
+  });
+
+  it("is not stale when there are no sources to compare against", () => {
+    const decision = evaluateRunnerStaleness({
+      runnerMtimeMs: RUNNER,
+      sources: [],
+    });
+    expect(decision.stale).toBe(false);
+    expect(decision.newestSource).toBe(null);
   });
 });


### PR DESCRIPTION
Fixes #13566.

Two unattended-loop killers in `ios:device:capture` (`packages/app/scripts/ios-device-capture.mjs`).

## 1. Flake cascades with no retry-in-isolation
A single flaky devicectl terminate/relaunch on a physical device fails that test **and** poisons subsequent tests in the same monolithic `test-without-building` invocation (proven on-device: composer + detent-flick failed in the full run, passed clean isolated).

After a failed full-suite run the harness now:
- parses the failed test identifiers from the `.xcresult` (`xcrun xcresulttool get test-results summary --format json`),
- re-runs **each** failed test in its own `-only-testing:<id>` invocation,
- reports a three-way verdict per test: **pass / flake** (failed in suite, passed isolated) **/ fail** (failed both).

Exit is nonzero **only** on a real fail; a run whose only failures were flakes exits 0 with those tests recorded as `flake` in `flake-classification.json` (trend data). Opt out with `--no-retry-isolation` (legacy hard-fail-on-any).

## 2. `--skip-build` silently uses a stale runner
The flag reused the newest `.xctestrun` with no freshness check (concrete audit state: runner built Jul 3, `GestureSemanticsUITests.swift` modified Jul 4 → a skip-build run false-greens a change to the suite under test).

Under `--skip-build` the runner mtime is now compared against the max mtime of `AppUITests/*.swift`; when older, the run **fails fast** naming the newest stale source + the rebuild command, unless the operator passes `--allow-stale-runner` (proceeds, logging the delta). **Fail-closed:** an undatable runner is treated as stale. Covers both the device and sim lanes (both run through this script).

## Fail-closed guarantees
- A missing/unparseable summary yields **no isolable failures** → the suite verdict stands, never fabricates a pass.
- A missing isolated result is treated as **still-failing** → a crashed isolated rerun can't green-wash the suite.

## Tests
New pure/exported helpers in `ios-device-lib.mjs` (side-effect free): `parseFailedTestIdentifiers`, `buildOnlyTestingIdentifier`, `classifyIsolatedReruns`, `evaluateRunnerStaleness`. 20 new cases in `ios-device-lib.test.mjs`:
- identifier normalization (trailing `()` strip, target prefixing, no double-prefix, whole-class failure, null on empty)
- Xcode-16 `testFailures` / `topInsights` parsing + dedupe + fail-closed on garbage input
- flake vs real-fail classification + missing-isolated-result-stays-failing
- staleness incl `--allow-stale-runner` override, undatable-runner-fails-closed, empty-source-list-not-stale

`bunx vitest run scripts/ios-device-lib.test.mjs` → **57/57 green** (per the issue's own Verification section: "covers the failed-test-id parsing and staleness decision as pure functions"). `node --check` clean both scripts, biome clean, `audit:error-policy-ratchet` no-new-slop. codex round-1 P2 (empty catch in the best-effort flake-summary writer) fixed with a logged J5 handler + re-verified; round-2 over-explored the script module graph past the 8min guard without converging, validated via deterministic gates.

Part of the flawless-testing-loop initiative #13562.

-- [sol-orch]