### PR TITLE
fix(#13687): single-source the mobile chat failure-string vocabulary + wire it into the iOS verifier

### DIFF
--- a/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		AUIT00010000000000000007 /* WidgetGalleryCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000008 /* WidgetGalleryCaptureUITests.swift */; };
 		AUIT00010000000000000009 /* LauncherGestureLoopUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */; };
 		AUIT0001000000000000000B /* DeviceLifecycleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT0001000000000000000C /* DeviceLifecycleUITests.swift */; };
+		AUIT0001000000000000000D /* ChatFailureStrings.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT0001000000000000000E /* ChatFailureStrings.generated.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -166,6 +167,7 @@
 		AUIT00010000000000000008 /* WidgetGalleryCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetGalleryCaptureUITests.swift; sourceTree = "<group>"; };
 		AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherGestureLoopUITests.swift; sourceTree = "<group>"; };
 		AUIT0001000000000000000C /* DeviceLifecycleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceLifecycleUITests.swift; sourceTree = "<group>"; };
+		AUIT0001000000000000000E /* ChatFailureStrings.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFailureStrings.generated.swift; sourceTree = "<group>"; };
 		AUIT00010000000000000101 /* AppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -359,6 +361,7 @@
 				AUIT00010000000000000008 /* WidgetGalleryCaptureUITests.swift */,
 				AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */,
 				AUIT0001000000000000000C /* DeviceLifecycleUITests.swift */,
+				AUIT0001000000000000000E /* ChatFailureStrings.generated.swift */,
 			);
 			path = AppUITests;
 			sourceTree = "<group>";
@@ -726,6 +729,7 @@
 				AUIT00010000000000000007 /* WidgetGalleryCaptureUITests.swift in Sources */,
 				AUIT00010000000000000009 /* LauncherGestureLoopUITests.swift in Sources */,
 				AUIT0001000000000000000B /* DeviceLifecycleUITests.swift in Sources */,
+				AUIT0001000000000000000D /* ChatFailureStrings.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/app-core/platforms/ios/App/AppUITests/BootCaptureUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/BootCaptureUITests.swift
@@ -475,7 +475,9 @@ final class BootCaptureUITests: XCTestCase {
             attachAccessibilitySnapshot(of: app)
             throw XCTSkip("no hittable composer after onboarding")
         }
-        let prompt = "Say hello in exactly three words."
+        let replyMarker = "IOS_CHAT_OK"
+        let prompt =
+            "Start your reply with exactly \(replyMarker), then say hello in one short sentence."
         let promptPrefix = String(prompt.prefix(20))
         func looksNotReady(_ s: String) -> Bool {
             let l = s.lowercased()
@@ -504,7 +506,9 @@ final class BootCaptureUITests: XCTestCase {
             }
             return nil
         }
+        var replyClassification: String?
         var failureObservation: String?
+        var unrecognizedObservation: String?
 
         // On-device warm-up can leave the first sends returning the "message
         // didn't reach the agent — still starting up. Retry" fallback. Re-send
@@ -558,11 +562,23 @@ final class BootCaptureUITests: XCTestCase {
                 // An error render was surfaced. Record it (quoted) and stop —
                 // this must FAIL the verifier, never silently retry into a
                 // "no reply after N attempts" that hides WHAT went wrong (#13687).
+                replyClassification = "failure-string:\(failure)"
                 failureObservation = "\(c) [matched failure-string: \(failure)]"
                 break
             }
+            if let c = candidate,
+                c.localizedCaseInsensitiveContains(replyMarker)
+            {
+                replyClassification = "marker-hit"
+                reply = c  // genuine marker-echo model reply
+                break
+            }
             if let c = candidate, !looksNotReady(c) {
-                reply = c  // genuine model reply
+                // A real reply that does not echo the marker is not accepted.
+                // Record it as a classified verifier failure instead of
+                // treating arbitrary new text as success (#13687).
+                replyClassification = "unrecognized-text"
+                unrecognizedObservation = c
                 break
             }
             // Not-ready fallback (or timeout) — let the CPU model warm; retry.
@@ -570,7 +586,8 @@ final class BootCaptureUITests: XCTestCase {
         }
         attachScreenshot(named: "\(tag)-075-reply-\(reply != nil ? "arrived" : "timeout")")
         if let reply {
-            let att = XCTAttachment(string: reply)
+            let att = XCTAttachment(
+                string: "\(reply) [classification: \(replyClassification ?? "unknown")]")
             att.name = "\(tag)-reply-text"
             att.lifetime = .keepAlways
             add(att)
@@ -578,6 +595,15 @@ final class BootCaptureUITests: XCTestCase {
         if let failureObservation {
             let att = XCTAttachment(string: failureObservation)
             att.name = "\(tag)-reply-failure-string"
+            att.lifetime = .keepAlways
+            add(att)
+        }
+        if let unrecognizedObservation {
+            let att = XCTAttachment(
+                string:
+                    "\(unrecognizedObservation) [classification: \(replyClassification ?? "unrecognized-text")]"
+            )
+            att.name = "\(tag)-reply-unrecognized-text"
             att.lifetime = .keepAlways
             add(att)
         }
@@ -591,6 +617,10 @@ final class BootCaptureUITests: XCTestCase {
             failureObservation,
             "[\(tag)] the agent surfaced an error render instead of a genuine "
                 + "model reply: \(failureObservation ?? "").")
+        XCTAssertNil(
+            unrecognizedObservation,
+            "[\(tag)] the agent replied without the required \(replyMarker) "
+                + "marker: \(unrecognizedObservation ?? "").")
         XCTAssertNotNil(
             reply,
             "[\(tag)] no genuine model reply after \(sendAttempts) attempts — "

--- a/packages/app-core/platforms/ios/App/AppUITests/BootCaptureUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/BootCaptureUITests.swift
@@ -508,6 +508,7 @@ final class BootCaptureUITests: XCTestCase {
         }
         var replyClassification: String?
         var failureObservation: String?
+        var notReadyObservation: String?
         var unrecognizedObservation: String?
 
         // On-device warm-up can leave the first sends returning the "message
@@ -563,6 +564,7 @@ final class BootCaptureUITests: XCTestCase {
                 // this must FAIL the verifier, never silently retry into a
                 // "no reply after N attempts" that hides WHAT went wrong (#13687).
                 replyClassification = "failure-string:\(failure)"
+                notReadyObservation = nil
                 failureObservation = "\(c) [matched failure-string: \(failure)]"
                 break
             }
@@ -570,6 +572,7 @@ final class BootCaptureUITests: XCTestCase {
                 c.localizedCaseInsensitiveContains(replyMarker)
             {
                 replyClassification = "marker-hit"
+                notReadyObservation = nil
                 reply = c  // genuine marker-echo model reply
                 break
             }
@@ -578,8 +581,13 @@ final class BootCaptureUITests: XCTestCase {
                 // Record it as a classified verifier failure instead of
                 // treating arbitrary new text as success (#13687).
                 replyClassification = "unrecognized-text"
+                notReadyObservation = nil
                 unrecognizedObservation = c
                 break
+            }
+            if let c = candidate {
+                replyClassification = "not-ready"
+                notReadyObservation = c
             }
             // Not-ready fallback (or timeout) — let the CPU model warm; retry.
             Thread.sleep(forTimeInterval: 45.0)
@@ -598,6 +606,14 @@ final class BootCaptureUITests: XCTestCase {
             att.lifetime = .keepAlways
             add(att)
         }
+        if let notReadyObservation {
+            let att = XCTAttachment(
+                string: "\(notReadyObservation) [classification: not-ready]"
+            )
+            att.name = "\(tag)-reply-not-ready"
+            att.lifetime = .keepAlways
+            add(att)
+        }
         if let unrecognizedObservation {
             let att = XCTAttachment(
                 string:
@@ -613,14 +629,24 @@ final class BootCaptureUITests: XCTestCase {
         // An error render (matched against the shared failure vocabulary) must
         // fail LOUD with the observed text quoted — never count as a reply,
         // never be swallowed as a bland "no reply" (#13687).
-        XCTAssertNil(
-            failureObservation,
-            "[\(tag)] the agent surfaced an error render instead of a genuine "
-                + "model reply: \(failureObservation ?? "").")
-        XCTAssertNil(
-            unrecognizedObservation,
-            "[\(tag)] the agent replied without the required \(replyMarker) "
-                + "marker: \(unrecognizedObservation ?? "").")
+        if let failureObservation {
+            XCTFail(
+                "[\(tag)] the agent surfaced an error render instead of a genuine "
+                    + "model reply: \(failureObservation).")
+            return
+        }
+        if let unrecognizedObservation {
+            XCTFail(
+                "[\(tag)] the agent replied without the required \(replyMarker) "
+                    + "marker: \(unrecognizedObservation).")
+            return
+        }
+        if let notReadyObservation {
+            XCTFail(
+                "[\(tag)] the agent stayed not-ready after \(sendAttempts) attempts: "
+                    + "\(notReadyObservation).")
+            return
+        }
         XCTAssertNotNil(
             reply,
             "[\(tag)] no genuine model reply after \(sendAttempts) attempts — "

--- a/packages/app-core/platforms/ios/App/AppUITests/BootCaptureUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/BootCaptureUITests.swift
@@ -483,6 +483,28 @@ final class BootCaptureUITests: XCTestCase {
                 || l.contains("retry in a moment") || l.contains("still warming")
                 || l.contains("try again in")
         }
+        // Consult the SHARED failure-string vocabulary (issue #13687). A reply
+        // that matches one of these is an error render / broken pipeline
+        // (e.g. the ErrorBoundary "Something went wrong" heading), NOT a genuine
+        // model reply — historically the loop went green on it. The list is
+        // generated from packages/app/scripts/lib/chat-failure-strings.mjs into
+        // ChatFailureStrings.generated.swift and parity-tested, so this verifier
+        // and the mobile-local-chat-smoke share exactly one source of truth.
+        // Returns the matched fragment so the assertion can quote it.
+        func matchedChatFailureString(_ s: String) -> String? {
+            let range = NSRange(s.startIndex..<s.endIndex, in: s)
+            for fragment in ChatFailureStrings.ios {
+                guard
+                    let regex = try? NSRegularExpression(
+                        pattern: fragment, options: [.caseInsensitive])
+                else { continue }
+                if regex.firstMatch(in: s, options: [], range: range) != nil {
+                    return fragment
+                }
+            }
+            return nil
+        }
+        var failureObservation: String?
 
         // On-device warm-up can leave the first sends returning the "message
         // didn't reach the agent — still starting up. Retry" fallback. Re-send
@@ -532,6 +554,13 @@ final class BootCaptureUITests: XCTestCase {
                 Thread.sleep(forTimeInterval: 3.0)
             }
             attachScreenshot(named: "\(tag)-070-reply-attempt-\(attempt)")
+            if let c = candidate, let failure = matchedChatFailureString(c) {
+                // An error render was surfaced. Record it (quoted) and stop —
+                // this must FAIL the verifier, never silently retry into a
+                // "no reply after N attempts" that hides WHAT went wrong (#13687).
+                failureObservation = "\(c) [matched failure-string: \(failure)]"
+                break
+            }
             if let c = candidate, !looksNotReady(c) {
                 reply = c  // genuine model reply
                 break
@@ -546,9 +575,22 @@ final class BootCaptureUITests: XCTestCase {
             att.lifetime = .keepAlways
             add(att)
         }
+        if let failureObservation {
+            let att = XCTAttachment(string: failureObservation)
+            att.name = "\(tag)-reply-failure-string"
+            att.lifetime = .keepAlways
+            add(att)
+        }
         XCTAssertNotEqual(
             app.state, .notRunning,
             "[\(tag)] the app died while waiting for the chat reply.")
+        // An error render (matched against the shared failure vocabulary) must
+        // fail LOUD with the observed text quoted — never count as a reply,
+        // never be swallowed as a bland "no reply" (#13687).
+        XCTAssertNil(
+            failureObservation,
+            "[\(tag)] the agent surfaced an error render instead of a genuine "
+                + "model reply: \(failureObservation ?? "").")
         XCTAssertNotNil(
             reply,
             "[\(tag)] no genuine model reply after \(sendAttempts) attempts — "

--- a/packages/app-core/platforms/ios/App/AppUITests/ChatFailureStrings.generated.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/ChatFailureStrings.generated.swift
@@ -38,5 +38,8 @@ enum ChatFailureStrings {
         "waiting for the model download",
         "set chat routing",
         "progress:\\s*0%",
+        "<think\\b",
+        "<\\/think>",
+        "\\/?\\bno_think\\b",
     ]
 }

--- a/packages/app-core/platforms/ios/App/AppUITests/ChatFailureStrings.generated.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/ChatFailureStrings.generated.swift
@@ -1,0 +1,42 @@
+// GENERATED FILE — DO NOT EDIT BY HAND.
+// Source of truth: packages/app/scripts/lib/chat-failure-strings.mjs
+// Regenerate: node packages/app/scripts/lib/chat-failure-strings.mjs --emit-swift
+// Parity guard: packages/app/scripts/lib/chat-failure-strings.test.mjs
+//
+// The mobile chat-reply FAILURE vocabulary shared with mobile-local-chat-smoke.mjs.
+// A candidate XCUITest reply matching any of these is an error render / broken
+// pipeline and must FAIL the attempt (never count as a "genuine model reply").
+
+enum ChatFailureStrings {
+    static let ios: [String] = [
+        "something went wrong",
+        "backend is not running",
+        "local backend is not running",
+        "no local backend",
+        "no local model",
+        "no model registered",
+        "no provider",
+        "connect a provider",
+        "waiting for the model download",
+        "timed out",
+        "<think\\b",
+        "<\\/think>",
+        "\\/?\\bno_think\\b",
+    ]
+
+    static let android: [String] = [
+        "something went wrong",
+        "no local gguf",
+        "no local model",
+        "no model registered",
+        "no provider",
+        "connect a provider",
+        "device_disconnected",
+        "device_timeout",
+        "timed out",
+        "chat generation failed",
+        "waiting for the model download",
+        "set chat routing",
+        "progress:\\s*0%",
+    ]
+}

--- a/packages/app-core/src/index.ts
+++ b/packages/app-core/src/index.ts
@@ -31,6 +31,7 @@ export * from "./permissions/types";
 // would shadow the real api/server, runtime/eliza, etc. exports above with
 // inert browser aliases. Browser bundlers alias it in via the path map; Node imports
 // the originals directly through this barrel.
+export { IOS_FULL_BUN_SMOKE_FAILURE_RE } from "./platform/chat-failure-strings.generated";
 export * from "./platform/ios-runtime-backends";
 export {
   IOS_FULL_BUN_SMOKE_REQUEST_KEY,

--- a/packages/app-core/src/platform/chat-failure-strings.generated.ts
+++ b/packages/app-core/src/platform/chat-failure-strings.generated.ts
@@ -1,0 +1,51 @@
+// GENERATED FILE - DO NOT EDIT BY HAND.
+// Source of truth: packages/app/scripts/lib/chat-failure-strings.mjs
+// Regenerate: node packages/app/scripts/lib/chat-failure-strings.mjs --emit-ts
+// Parity guard: packages/app/scripts/lib/chat-failure-strings.test.mjs
+
+export const IOS_FAILURE_FRAGMENTS = [
+  "something went wrong",
+  "backend is not running",
+  "local backend is not running",
+  "no local backend",
+  "no local model",
+  "no model registered",
+  "no provider",
+  "connect a provider",
+  "waiting for the model download",
+  "timed out",
+  "<think\\b",
+  "<\\/think>",
+  "\\/?\\bno_think\\b",
+] as const;
+
+export const ANDROID_FAILURE_FRAGMENTS = [
+  "something went wrong",
+  "no local gguf",
+  "no local model",
+  "no model registered",
+  "no provider",
+  "connect a provider",
+  "device_disconnected",
+  "device_timeout",
+  "timed out",
+  "chat generation failed",
+  "waiting for the model download",
+  "set chat routing",
+  "progress:\\s*0%",
+  "<think\\b",
+  "<\\/think>",
+  "\\/?\\bno_think\\b",
+] as const;
+
+function buildFailureRegExp(fragments: readonly string[]): RegExp {
+  return new RegExp(fragments.join("|"), "i");
+}
+
+export const IOS_FULL_BUN_SMOKE_FAILURE_RE = buildFailureRegExp(
+  IOS_FAILURE_FRAGMENTS,
+);
+
+export const ANDROID_FULL_TURN_FAILURE_RE = buildFailureRegExp(
+  ANDROID_FAILURE_FRAGMENTS,
+);

--- a/packages/app-core/src/platform/ios-runtime-bridge.ts
+++ b/packages/app-core/src/platform/ios-runtime-bridge.ts
@@ -11,6 +11,7 @@
 import { Preferences } from "@capacitor/preferences";
 import { formatError } from "@elizaos/shared";
 import { primeIosFullBunRuntime } from "../api/ios-local-agent-transport";
+import { IOS_FULL_BUN_SMOKE_FAILURE_RE } from "./chat-failure-strings.generated";
 
 export const IOS_FULL_BUN_SMOKE_REQUEST_KEY =
   "eliza:ios-full-bun-smoke:request";
@@ -22,8 +23,6 @@ const IOS_FULL_BUN_SMOKE_MESSAGE_TIMEOUT_MS = 600_000;
 const IOS_FULL_BUN_SMOKE_CHAT_TEXT =
   "Reply with exactly these four words: ios smoke model works.";
 const IOS_FULL_BUN_SMOKE_EXPECTED_REPLY = "ios smoke model works";
-const IOS_FULL_BUN_SMOKE_FAILURE_RE =
-  /something went wrong|backend is not running|local backend is not running|no local backend|no local model|no model registered|no provider|connect a provider|waiting for the model download|timed out|<think\b|<\/think>|\/?\bno_think\b/i;
 
 declare global {
   interface Window {

--- a/packages/app/scripts/lib/chat-failure-strings.mjs
+++ b/packages/app/scripts/lib/chat-failure-strings.mjs
@@ -1,0 +1,148 @@
+/**
+ * Single source of truth for the mobile chat-reply FAILURE vocabulary.
+ *
+ * The mobile local-chat smoke (`mobile-local-chat-smoke.mjs`) and the on-device
+ * iOS XCUITest reply verifier (`BootCaptureUITests.swift`) both need to classify
+ * an agent reply that is actually an ERROR render (error boundary, "backend is
+ * not running", think-tag leakage, …) as a FAILURE — never as a "genuine model
+ * reply". Historically each side maintained its own copy of the list, which
+ * drifted (issue #13687): the Swift heuristic only knew 5 warm-up phrases and
+ * accepted an error render as a real reply.
+ *
+ * This module is the ONE checked-in list. `mobile-local-chat-smoke.mjs` derives
+ * its `IOS_FULL_BUN_SMOKE_FAILURE_RE` / `ANDROID_FULL_TURN_FAILURE_RE` regexes
+ * from here, and the generated Swift artifact
+ * (`ChatFailureStrings.generated.swift`) is emitted from here so the XCUITest
+ * bundle keys off the same vocabulary. A parity test
+ * (`chat-failure-strings.test.mjs`) proves the derived regexes and the checked-in
+ * Swift artifact stay in lockstep with this source.
+ *
+ *
+ * Each entry is a RAW regex fragment (case-insensitive), so entries may carry
+ * regex metacharacters (`\b`, `\s*`, `<`, …). Order is significant only for the
+ * byte-for-byte reproduction of the pre-existing regex source; the classifier
+ * semantics are order-independent (first alternative that matches wins, and
+ * every alternative is a failure).
+ */
+
+import { pathToFileURL } from "node:url";
+
+/**
+ * Think-tag / no-think leakage fragments. A model that leaks its raw reasoning
+ * scaffolding into the user-visible reply is a broken pipeline, not a reply.
+ * Shared by the iOS failure regex and used inline by the Android turn check.
+ */
+export const THINK_TAG_FAILURE_FRAGMENTS = Object.freeze([
+  "<think\\b",
+  "<\\/think>",
+  "\\/?\\bno_think\\b",
+]);
+
+/**
+ * iOS full-Bun smoke failure fragments (in the exact alternation order of the
+ * historical `IOS_FULL_BUN_SMOKE_FAILURE_RE`). The trailing three fragments are
+ * the shared think-tag group.
+ */
+export const IOS_FAILURE_FRAGMENTS = Object.freeze([
+  "something went wrong",
+  "backend is not running",
+  "local backend is not running",
+  "no local backend",
+  "no local model",
+  "no model registered",
+  "no provider",
+  "connect a provider",
+  "waiting for the model download",
+  "timed out",
+  ...THINK_TAG_FAILURE_FRAGMENTS,
+]);
+
+/**
+ * Android full-turn failure fragments (in the exact alternation order of the
+ * historical `ANDROID_FULL_TURN_FAILURE_RE`).
+ */
+export const ANDROID_FAILURE_FRAGMENTS = Object.freeze([
+  "something went wrong",
+  "no local gguf",
+  "no local model",
+  "no model registered",
+  "no provider",
+  "connect a provider",
+  "device_disconnected",
+  "device_timeout",
+  "timed out",
+  "chat generation failed",
+  "waiting for the model download",
+  "set chat routing",
+  "progress:\\s*0%",
+]);
+
+/**
+ * Build a case-insensitive alternation RegExp from an ordered list of raw
+ * regex fragments. Behaviour-preserving reproduction of the hand-authored
+ * source regexes.
+ * @param {readonly string[]} fragments
+ * @returns {RegExp}
+ */
+export function buildFailureRegExp(fragments) {
+  if (!Array.isArray(fragments) || fragments.length === 0) {
+    throw new Error(
+      "buildFailureRegExp requires a non-empty array of regex fragments",
+    );
+  }
+  return new RegExp(fragments.join("|"), "i");
+}
+
+export const IOS_FULL_BUN_SMOKE_FAILURE_RE = buildFailureRegExp(
+  IOS_FAILURE_FRAGMENTS,
+);
+export const ANDROID_FULL_TURN_FAILURE_RE = buildFailureRegExp(
+  ANDROID_FAILURE_FRAGMENTS,
+);
+
+/**
+ * Generate the deterministic contents of the checked-in Swift artifact
+ * `ChatFailureStrings.generated.swift`, so the iOS XCUITest reply verifier can
+ * classify a candidate reply against the SAME failure vocabulary as the mjs
+ * smoke. The Swift verifier lowercases the fragment where it is a plain phrase
+ * (no regex metacharacters) for a substring test; regex fragments are exposed
+ * verbatim for an NSRegularExpression match. Keeping this generator here means
+ * the parity test can assert the committed Swift file byte-matches this output.
+ * @returns {string}
+ */
+export function renderSwiftFailureStrings() {
+  const swiftArray = (name, fragments) => {
+    const rows = fragments
+      .map((f) => `        ${JSON.stringify(f)},`)
+      .join("\n");
+    return `    static let ${name}: [String] = [\n${rows}\n    ]`;
+  };
+
+  return `// GENERATED FILE — DO NOT EDIT BY HAND.
+// Source of truth: packages/app/scripts/lib/chat-failure-strings.mjs
+// Regenerate: node packages/app/scripts/lib/chat-failure-strings.mjs --emit-swift
+// Parity guard: packages/app/scripts/lib/chat-failure-strings.test.mjs
+//
+// The mobile chat-reply FAILURE vocabulary shared with mobile-local-chat-smoke.mjs.
+// A candidate XCUITest reply matching any of these is an error render / broken
+// pipeline and must FAIL the attempt (never count as a "genuine model reply").
+
+enum ChatFailureStrings {
+${swiftArray("ios", IOS_FAILURE_FRAGMENTS)}
+
+${swiftArray("android", ANDROID_FAILURE_FRAGMENTS)}
+}
+`;
+}
+
+// Allow `node chat-failure-strings.mjs --emit-swift` to print the Swift artifact
+// (used by the regenerate step + verified byte-for-byte by the parity test). The
+// guard keeps a bare `import` of this module side-effect-free.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  if (process.argv.includes("--emit-swift")) {
+    process.stdout.write(renderSwiftFailureStrings());
+  }
+}

--- a/packages/app/scripts/lib/chat-failure-strings.mjs
+++ b/packages/app/scripts/lib/chat-failure-strings.mjs
@@ -30,7 +30,7 @@ import { pathToFileURL } from "node:url";
 /**
  * Think-tag / no-think leakage fragments. A model that leaks its raw reasoning
  * scaffolding into the user-visible reply is a broken pipeline, not a reply.
- * Shared by the iOS failure regex and used inline by the Android turn check.
+ * Shared by the iOS and Android failure regexes.
  */
 export const THINK_TAG_FAILURE_FRAGMENTS = Object.freeze([
   "<think\\b",
@@ -59,7 +59,8 @@ export const IOS_FAILURE_FRAGMENTS = Object.freeze([
 
 /**
  * Android full-turn failure fragments (in the exact alternation order of the
- * historical `ANDROID_FULL_TURN_FAILURE_RE`).
+ * historical `ANDROID_FULL_TURN_FAILURE_RE`, plus the shared think-tag group
+ * that used to be checked inline beside that regex).
  */
 export const ANDROID_FAILURE_FRAGMENTS = Object.freeze([
   "something went wrong",
@@ -75,6 +76,7 @@ export const ANDROID_FAILURE_FRAGMENTS = Object.freeze([
   "waiting for the model download",
   "set chat routing",
   "progress:\\s*0%",
+  ...THINK_TAG_FAILURE_FRAGMENTS,
 ]);
 
 /**
@@ -135,6 +137,41 @@ ${swiftArray("android", ANDROID_FAILURE_FRAGMENTS)}
 `;
 }
 
+/**
+ * Generate the deterministic TypeScript artifact consumed by app-core and the
+ * app renderer. This keeps browser/runtime smoke checks on the same vocabulary
+ * without making app-core import from packages/app/scripts at runtime.
+ * @returns {string}
+ */
+export function renderTypeScriptFailureStrings() {
+  const tsArray = (name, fragments) => {
+    const rows = fragments.map((f) => `  ${JSON.stringify(f)},`).join("\n");
+    return `export const ${name} = [\n${rows}\n] as const;`;
+  };
+
+  return `// GENERATED FILE - DO NOT EDIT BY HAND.
+// Source of truth: packages/app/scripts/lib/chat-failure-strings.mjs
+// Regenerate: node packages/app/scripts/lib/chat-failure-strings.mjs --emit-ts
+// Parity guard: packages/app/scripts/lib/chat-failure-strings.test.mjs
+
+${tsArray("IOS_FAILURE_FRAGMENTS", IOS_FAILURE_FRAGMENTS)}
+
+${tsArray("ANDROID_FAILURE_FRAGMENTS", ANDROID_FAILURE_FRAGMENTS)}
+
+function buildFailureRegExp(fragments: readonly string[]): RegExp {
+  return new RegExp(fragments.join("|"), "i");
+}
+
+export const IOS_FULL_BUN_SMOKE_FAILURE_RE = buildFailureRegExp(
+  IOS_FAILURE_FRAGMENTS,
+);
+
+export const ANDROID_FULL_TURN_FAILURE_RE = buildFailureRegExp(
+  ANDROID_FAILURE_FRAGMENTS,
+);
+`;
+}
+
 // Allow `node chat-failure-strings.mjs --emit-swift` to print the Swift artifact
 // (used by the regenerate step + verified byte-for-byte by the parity test). The
 // guard keeps a bare `import` of this module side-effect-free.
@@ -144,5 +181,7 @@ if (
 ) {
   if (process.argv.includes("--emit-swift")) {
     process.stdout.write(renderSwiftFailureStrings());
+  } else if (process.argv.includes("--emit-ts")) {
+    process.stdout.write(renderTypeScriptFailureStrings());
   }
 }

--- a/packages/app/scripts/lib/chat-failure-strings.test.mjs
+++ b/packages/app/scripts/lib/chat-failure-strings.test.mjs
@@ -88,6 +88,15 @@ describe("chat-failure-strings single source of truth (#13687)", () => {
     expect(bootCapture).toContain("ChatFailureStrings.ios");
   });
 
+  it("the XCUITest verifier only accepts marker-echo replies and classifies every verdict", () => {
+    const bootCapture = fs.readFileSync(bootCaptureUITestsPath, "utf8");
+    expect(bootCapture).toContain("IOS_CHAT_OK");
+    expect(bootCapture).toContain("marker-hit");
+    expect(bootCapture).toContain("failure-string:");
+    expect(bootCapture).toContain("unrecognized-text");
+    expect(bootCapture).toContain("reply-unrecognized-text");
+  });
+
   it("the Swift artifact enumerates the same fragments as the JS lists", () => {
     const swift = renderSwiftFailureStrings();
     for (const fragment of IOS_FAILURE_FRAGMENTS) {

--- a/packages/app/scripts/lib/chat-failure-strings.test.mjs
+++ b/packages/app/scripts/lib/chat-failure-strings.test.mjs
@@ -6,8 +6,8 @@
 // wrong" heading) as a "genuine model reply".
 //
 // This parity test proves:
-//   1. the derived regexes reproduce the historical hand-authored source exactly
-//      (behaviour-preserving), and stay in lockstep with the fragment lists;
+//   1. the derived regexes reproduce the historical hand-authored classifier
+//      behaviour, and stay in lockstep with the fragment lists;
 //   2. the committed Swift artifact byte-matches the generator output (so a hand
 //      edit / stale regen is caught in CI, not on device);
 //   3. representative error renders are classified as failures and a real reply
@@ -23,6 +23,7 @@ import {
   IOS_FAILURE_FRAGMENTS,
   IOS_FULL_BUN_SMOKE_FAILURE_RE,
   renderSwiftFailureStrings,
+  renderTypeScriptFailureStrings,
   THINK_TAG_FAILURE_FRAGMENTS,
 } from "./chat-failure-strings.mjs";
 
@@ -35,17 +36,27 @@ const bootCaptureUITestsPath = path.resolve(
   here,
   "../../../app-core/platforms/ios/App/AppUITests/BootCaptureUITests.swift",
 );
+const appCoreTsArtifactPath = path.resolve(
+  here,
+  "../../../app-core/src/platform/chat-failure-strings.generated.ts",
+);
+const iosRuntimeBridgePath = path.resolve(
+  here,
+  "../../../app-core/src/platform/ios-runtime-bridge.ts",
+);
+const appMainPath = path.resolve(here, "../../src/main.tsx");
 
-// The exact hand-authored source that lived inline in mobile-local-chat-smoke.mjs
-// before #13687. Pinned here so a fragment reorder/edit that changes matching
-// behaviour is caught, not silently accepted.
+// The exact hand-authored classifier sources that lived inline in
+// mobile-local-chat-smoke.mjs before #13687. Android includes the old regex plus
+// its old inline think-tag sidecar. Pinned here so a fragment reorder/edit that
+// changes matching behaviour is caught, not silently accepted.
 const HISTORICAL_IOS_SOURCE =
   "something went wrong|backend is not running|local backend is not running|no local backend|no local model|no model registered|no provider|connect a provider|waiting for the model download|timed out|<think\\b|<\\/think>|\\/?\\bno_think\\b";
 const HISTORICAL_ANDROID_SOURCE =
-  "something went wrong|no local gguf|no local model|no model registered|no provider|connect a provider|device_disconnected|device_timeout|timed out|chat generation failed|waiting for the model download|set chat routing|progress:\\s*0%";
+  "something went wrong|no local gguf|no local model|no model registered|no provider|connect a provider|device_disconnected|device_timeout|timed out|chat generation failed|waiting for the model download|set chat routing|progress:\\s*0%|<think\\b|<\\/think>|\\/?\\bno_think\\b";
 
 describe("chat-failure-strings single source of truth (#13687)", () => {
-  it("reproduces the historical iOS/Android failure regexes byte-for-byte", () => {
+  it("reproduces the historical iOS/Android failure classifiers byte-for-byte", () => {
     expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.source).toBe(HISTORICAL_IOS_SOURCE);
     expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.flags).toBe("i");
     expect(ANDROID_FULL_TURN_FAILURE_RE.source).toBe(HISTORICAL_ANDROID_SOURCE);
@@ -62,9 +73,9 @@ describe("chat-failure-strings single source of truth (#13687)", () => {
   });
 
   it("shares the think-tag leakage fragments across surfaces", () => {
-    // The iOS list carries the shared think-tag group; Android checks it inline.
     for (const fragment of THINK_TAG_FAILURE_FRAGMENTS) {
       expect(IOS_FAILURE_FRAGMENTS).toContain(fragment);
+      expect(ANDROID_FAILURE_FRAGMENTS).toContain(fragment);
     }
     expect(THINK_TAG_FAILURE_FRAGMENTS.length).toBeGreaterThan(0);
   });
@@ -77,6 +88,20 @@ describe("chat-failure-strings single source of truth (#13687)", () => {
   it("committed Swift artifact byte-matches the generator (no drift / stale regen)", () => {
     const committed = fs.readFileSync(swiftArtifactPath, "utf8");
     expect(committed).toBe(renderSwiftFailureStrings());
+  });
+
+  it("committed app-core TypeScript artifact byte-matches the generator", () => {
+    const committed = fs.readFileSync(appCoreTsArtifactPath, "utf8");
+    expect(committed).toBe(renderTypeScriptFailureStrings());
+  });
+
+  it("browser/runtime smoke checks consume the generated TypeScript artifact", () => {
+    const bridge = fs.readFileSync(iosRuntimeBridgePath, "utf8");
+    const appMain = fs.readFileSync(appMainPath, "utf8");
+    expect(bridge).toContain('from "./chat-failure-strings.generated"');
+    expect(appMain).toContain("IOS_FULL_BUN_SMOKE_FAILURE_RE");
+    expect(bridge).not.toContain("backend is not running|local backend");
+    expect(appMain).not.toContain("something went wrong|<think");
   });
 
   it("the XCUITest reply verifier consumes the shared vocabulary (not dead code)", () => {

--- a/packages/app/scripts/lib/chat-failure-strings.test.mjs
+++ b/packages/app/scripts/lib/chat-failure-strings.test.mjs
@@ -1,17 +1,13 @@
-// #13687: the mobile chat-reply FAILURE vocabulary must be single-sourced. The
-// mobile-local-chat-smoke.mjs regexes and the on-device iOS XCUITest reply
-// verifier (via the generated Swift artifact) must classify the SAME error
-// renders as failures — historically the two copies drifted and the Swift
-// heuristic accepted an error render (e.g. the error-boundary "Something went
-// wrong" heading) as a "genuine model reply".
-//
-// This parity test proves:
-//   1. the derived regexes reproduce the historical hand-authored classifier
-//      behaviour, and stay in lockstep with the fragment lists;
-//   2. the committed Swift artifact byte-matches the generator output (so a hand
-//      edit / stale regen is caught in CI, not on device);
-//   3. representative error renders are classified as failures and a real reply
-//      is not — the core anti-false-green property of the whole loop.
+/**
+ * Parity guard for the mobile chat-reply failure vocabulary and the iOS
+ * XCUITest verifier that consumes it.
+ *
+ * The tests pin the historical smoke classifier behaviour, prove the checked-in
+ * Swift and runtime TypeScript artifacts are generated from the shared list, and
+ * guard the #13687 anti-false-green contract: the device verifier accepts only a
+ * marker echo while classifying failure-string, not-ready, and unrecognized
+ * replies distinctly.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -115,11 +111,30 @@ describe("chat-failure-strings single source of truth (#13687)", () => {
 
   it("the XCUITest verifier only accepts marker-echo replies and classifies every verdict", () => {
     const bootCapture = fs.readFileSync(bootCaptureUITestsPath, "utf8");
-    expect(bootCapture).toContain("IOS_CHAT_OK");
+    expect(bootCapture).not.toContain("Say hello in exactly three words.");
+    expect(bootCapture).toContain('let replyMarker = "IOS_CHAT_OK"');
+    expect(bootCapture).toContain(
+      '"Start your reply with exactly \\(replyMarker), then say hello in one short sentence."',
+    );
     expect(bootCapture).toContain("marker-hit");
     expect(bootCapture).toContain("failure-string:");
+    expect(bootCapture).toContain("not-ready");
+    expect(bootCapture).toContain("reply-not-ready");
     expect(bootCapture).toContain("unrecognized-text");
     expect(bootCapture).toContain("reply-unrecognized-text");
+
+    const markerBranch = bootCapture.match(
+      /if let c = candidate,\s*c\.localizedCaseInsensitiveContains\(replyMarker\)\s*\{(?<body>[\s\S]*?)\n            \}/,
+    );
+    expect(markerBranch?.groups?.body).toContain("reply = c");
+
+    const unrecognizedBranch = bootCapture.match(
+      /if let c = candidate, !looksNotReady\(c\) \{(?<body>[\s\S]*?)\n            \}/,
+    );
+    expect(unrecognizedBranch?.groups?.body).toContain(
+      "unrecognizedObservation = c",
+    );
+    expect(unrecognizedBranch?.groups?.body).not.toContain("reply = c");
   });
 
   it("the Swift artifact enumerates the same fragments as the JS lists", () => {

--- a/packages/app/scripts/lib/chat-failure-strings.test.mjs
+++ b/packages/app/scripts/lib/chat-failure-strings.test.mjs
@@ -1,0 +1,141 @@
+// #13687: the mobile chat-reply FAILURE vocabulary must be single-sourced. The
+// mobile-local-chat-smoke.mjs regexes and the on-device iOS XCUITest reply
+// verifier (via the generated Swift artifact) must classify the SAME error
+// renders as failures — historically the two copies drifted and the Swift
+// heuristic accepted an error render (e.g. the error-boundary "Something went
+// wrong" heading) as a "genuine model reply".
+//
+// This parity test proves:
+//   1. the derived regexes reproduce the historical hand-authored source exactly
+//      (behaviour-preserving), and stay in lockstep with the fragment lists;
+//   2. the committed Swift artifact byte-matches the generator output (so a hand
+//      edit / stale regen is caught in CI, not on device);
+//   3. representative error renders are classified as failures and a real reply
+//      is not — the core anti-false-green property of the whole loop.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  ANDROID_FAILURE_FRAGMENTS,
+  ANDROID_FULL_TURN_FAILURE_RE,
+  buildFailureRegExp,
+  IOS_FAILURE_FRAGMENTS,
+  IOS_FULL_BUN_SMOKE_FAILURE_RE,
+  renderSwiftFailureStrings,
+  THINK_TAG_FAILURE_FRAGMENTS,
+} from "./chat-failure-strings.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const swiftArtifactPath = path.resolve(
+  here,
+  "../../../app-core/platforms/ios/App/AppUITests/ChatFailureStrings.generated.swift",
+);
+const bootCaptureUITestsPath = path.resolve(
+  here,
+  "../../../app-core/platforms/ios/App/AppUITests/BootCaptureUITests.swift",
+);
+
+// The exact hand-authored source that lived inline in mobile-local-chat-smoke.mjs
+// before #13687. Pinned here so a fragment reorder/edit that changes matching
+// behaviour is caught, not silently accepted.
+const HISTORICAL_IOS_SOURCE =
+  "something went wrong|backend is not running|local backend is not running|no local backend|no local model|no model registered|no provider|connect a provider|waiting for the model download|timed out|<think\\b|<\\/think>|\\/?\\bno_think\\b";
+const HISTORICAL_ANDROID_SOURCE =
+  "something went wrong|no local gguf|no local model|no model registered|no provider|connect a provider|device_disconnected|device_timeout|timed out|chat generation failed|waiting for the model download|set chat routing|progress:\\s*0%";
+
+describe("chat-failure-strings single source of truth (#13687)", () => {
+  it("reproduces the historical iOS/Android failure regexes byte-for-byte", () => {
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.source).toBe(HISTORICAL_IOS_SOURCE);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.flags).toBe("i");
+    expect(ANDROID_FULL_TURN_FAILURE_RE.source).toBe(HISTORICAL_ANDROID_SOURCE);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.flags).toBe("i");
+  });
+
+  it("derives each regex from its fragment list (join is the only transform)", () => {
+    expect(buildFailureRegExp(IOS_FAILURE_FRAGMENTS).source).toBe(
+      IOS_FULL_BUN_SMOKE_FAILURE_RE.source,
+    );
+    expect(buildFailureRegExp(ANDROID_FAILURE_FRAGMENTS).source).toBe(
+      ANDROID_FULL_TURN_FAILURE_RE.source,
+    );
+  });
+
+  it("shares the think-tag leakage fragments across surfaces", () => {
+    // The iOS list carries the shared think-tag group; Android checks it inline.
+    for (const fragment of THINK_TAG_FAILURE_FRAGMENTS) {
+      expect(IOS_FAILURE_FRAGMENTS).toContain(fragment);
+    }
+    expect(THINK_TAG_FAILURE_FRAGMENTS.length).toBeGreaterThan(0);
+  });
+
+  it("rejects an empty fragment list (fail-closed builder)", () => {
+    expect(() => buildFailureRegExp([])).toThrow(/non-empty/);
+    expect(() => buildFailureRegExp(null)).toThrow(/non-empty/);
+  });
+
+  it("committed Swift artifact byte-matches the generator (no drift / stale regen)", () => {
+    const committed = fs.readFileSync(swiftArtifactPath, "utf8");
+    expect(committed).toBe(renderSwiftFailureStrings());
+  });
+
+  it("the XCUITest reply verifier consumes the shared vocabulary (not dead code)", () => {
+    // Guards against the artifact drifting back into an unreferenced file while
+    // BootCaptureUITests keeps its old "any new text is a reply" heuristic
+    // (the #13687 false-green). The Swift verifier must reference the generated
+    // enum so an error render is classified as a failure, not accepted.
+    const bootCapture = fs.readFileSync(bootCaptureUITestsPath, "utf8");
+    expect(bootCapture).toContain("ChatFailureStrings.ios");
+  });
+
+  it("the Swift artifact enumerates the same fragments as the JS lists", () => {
+    const swift = renderSwiftFailureStrings();
+    for (const fragment of IOS_FAILURE_FRAGMENTS) {
+      expect(swift).toContain(JSON.stringify(fragment));
+    }
+    for (const fragment of ANDROID_FAILURE_FRAGMENTS) {
+      expect(swift).toContain(JSON.stringify(fragment));
+    }
+  });
+
+  describe("classifies error renders as failures, real replies as pass", () => {
+    // The exact heading the ErrorBoundary renders
+    // (packages/ui/src/components/ui/error-boundary.tsx) — the #13687 false-green.
+    it("iOS: error-boundary heading is a failure", () => {
+      expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("Something went wrong")).toBe(
+        true,
+      );
+    });
+
+    it("iOS: backend-down + think-tag leak are failures", () => {
+      expect(
+        IOS_FULL_BUN_SMOKE_FAILURE_RE.test("Local backend is not running"),
+      ).toBe(true);
+      expect(
+        IOS_FULL_BUN_SMOKE_FAILURE_RE.test("<think>chain of thought</think>"),
+      ).toBe(true);
+    });
+
+    it("iOS: the genuine expected reply is NOT a failure", () => {
+      expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("ios smoke model works")).toBe(
+        false,
+      );
+    });
+
+    it("Android: device disconnect / chat-generation-failed are failures", () => {
+      expect(ANDROID_FULL_TURN_FAILURE_RE.test("device_disconnected")).toBe(
+        true,
+      );
+      expect(ANDROID_FULL_TURN_FAILURE_RE.test("chat generation failed")).toBe(
+        true,
+      );
+      expect(ANDROID_FULL_TURN_FAILURE_RE.test("progress: 0%")).toBe(true);
+    });
+
+    it("Android: the genuine expected reply is NOT a failure", () => {
+      expect(
+        ANDROID_FULL_TURN_FAILURE_RE.test("android smoke model works"),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -2269,10 +2269,7 @@ function requireUsableFullTurnReply(done, rawStreamText) {
   if (!reply) {
     throw new Error(`Full-turn smoke returned empty reply: ${rawStreamText}`);
   }
-  if (
-    /<think\b|<\/think>|\/?\bno_think\b/i.test(reply) ||
-    ANDROID_FULL_TURN_FAILURE_RE.test(reply)
-  ) {
+  if (ANDROID_FULL_TURN_FAILURE_RE.test(reply)) {
     throw new Error(`Full-turn smoke returned unusable reply: ${reply}`);
   }
   const normalizedReply = reply

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -11,6 +11,10 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
+import {
+  ANDROID_FULL_TURN_FAILURE_RE,
+  IOS_FULL_BUN_SMOKE_FAILURE_RE,
+} from "./lib/chat-failure-strings.mjs";
 import { assertInstalledIosAppRendererFresh } from "./lib/ios-renderer-stamp.mjs";
 import { clearIosSmokeDefaults } from "./lib/ios-sim-defaults-hygiene.mjs";
 import { evaluateLocalInferenceReadiness } from "./lib/local-inference-readiness.mjs";
@@ -60,8 +64,11 @@ const IOS_FULL_BUN_SMOKE_CONTEXT_SIZE = Number.parseInt(
 const IOS_FULL_BUN_SMOKE_ATTEMPTS = 180;
 const IOS_FULL_BUN_SMOKE_DELAY_MS = 2000;
 const IOS_FULL_BUN_SMOKE_EXPECTED_REPLY = "ios smoke model works";
-const IOS_FULL_BUN_SMOKE_FAILURE_RE =
-  /something went wrong|backend is not running|local backend is not running|no local backend|no local model|no model registered|no provider|connect a provider|waiting for the model download|timed out|<think\b|<\/think>|\/?\bno_think\b/i;
+// IOS_FULL_BUN_SMOKE_FAILURE_RE / ANDROID_FULL_TURN_FAILURE_RE are derived from
+// the single checked-in failure-string source of truth
+// (./lib/chat-failure-strings.mjs), which also generates the Swift artifact the
+// on-device XCUITest reply verifier consumes (issue #13687). A parity test keeps
+// the two sides in lockstep.
 const ANDROID_HEALTH_ATTEMPTS = 240;
 const ANDROID_FULL_TURN_TIMEOUT_MS = Number.parseInt(
   process.env.ANDROID_FULL_TURN_TIMEOUT_MS?.trim() || String(10 * 60_000),
@@ -111,8 +118,6 @@ const ANDROID_LOCAL_INFERENCE_READY_DELAY_MS = Number.parseInt(
 const ANDROID_FULL_TURN_PROMPT =
   "Reply with exactly these four words: android smoke model works.";
 const ANDROID_FULL_TURN_EXPECTED_REPLY = "android smoke model works";
-const ANDROID_FULL_TURN_FAILURE_RE =
-  /something went wrong|no local gguf|no local model|no model registered|no provider|connect a provider|device_disconnected|device_timeout|timed out|chat generation failed|waiting for the model download|set chat routing|progress:\s*0%/i;
 const ANDROID_SMOKE_MODEL_CONTEXT_SIZE = Number.parseInt(
   process.env.ANDROID_SMOKE_MODEL_CONTEXT_SIZE?.trim() || "4096",
   10,

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -48,6 +48,7 @@ import {
   DesktopSurfaceNavigationRuntime,
   DesktopTrayRuntime,
   DetachedShellRoot,
+  IOS_FULL_BUN_SMOKE_FAILURE_RE,
 } from "@elizaos/app-core";
 import {
   installIosLocalAgentFetchBridge,
@@ -1740,9 +1741,7 @@ async function runIosFullBunSmokeIfRequested(): Promise<boolean> {
     );
     if (
       !streamMessage.includes('"type":"done"') ||
-      /something went wrong|<think\b|<\/think>|\/?\bno_think\b/i.test(
-        streamMessage,
-      )
+      IOS_FULL_BUN_SMOKE_FAILURE_RE.test(streamMessage)
     ) {
       throw new Error(
         `full Bun conversation stream returned unusable SSE: ${streamMessage.slice(0, 500)}`,


### PR DESCRIPTION
## Problem

`BootCaptureUITests.verifyChat` accepted any new >=8-character static text that was not the prompt echo as a "genuine model reply." That let error renders such as "Something went wrong" pass the iOS chat-correctness loop. The mobile failure-string vocabulary also lived in multiple places, so Swift, app-core, app renderer, and smoke-script checks could drift.

## Fix

- Adds `packages/app/scripts/lib/chat-failure-strings.mjs` as the single source for mobile chat failure fragments.
- Derives the JS iOS/Android failure regexes from the shared list.
- Folds the Android think-tag sidecar into the shared Android regex so the smoke helper has no inline duplicate matcher.
- Generates and checks in `ChatFailureStrings.generated.swift`, wired into the AppUITests target.
- Generates and checks in `packages/app-core/src/platform/chat-failure-strings.generated.ts` for app-core/runtime consumers.
- Updates `ios-runtime-bridge.ts` and `packages/app/src/main.tsx` to consume the generated app-core regex instead of hand-authored local regexes.
- Updates `BootCaptureUITests.verifyChat` to classify candidate replies against `ChatFailureStrings.ios`.
- Requires the model reply to echo `IOS_CHAT_OK`; arbitrary new text no longer passes.
- Attaches classified verdicts: `marker-hit`, `failure-string:<match>`, or `unrecognized-text`.
- Adds parity tests proving regex behavior, generated artifact freshness, runtime/app wiring, verifier wiring, marker-only acceptance, and verdict classification.

## Verification

Passed locally in `/private/tmp/eliza-13682-clone` on PR head `7c38fc0ff0`:

```bash
node --check packages/app/scripts/lib/chat-failure-strings.mjs
node packages/app/scripts/lib/chat-failure-strings.mjs --emit-ts | diff -u - packages/app-core/src/platform/chat-failure-strings.generated.ts
node packages/app/scripts/lib/chat-failure-strings.mjs --emit-swift | diff -u - packages/app-core/platforms/ios/App/AppUITests/ChatFailureStrings.generated.swift
bun test packages/app/scripts/lib/chat-failure-strings.test.mjs
bunx @biomejs/biome check packages/app/scripts/lib/chat-failure-strings.mjs packages/app/scripts/lib/chat-failure-strings.test.mjs packages/app/scripts/mobile-local-chat-smoke.mjs packages/app-core/src/platform/chat-failure-strings.generated.ts packages/app-core/platforms/ios/App/AppUITests/ChatFailureStrings.generated.swift packages/app-core/platforms/ios/App/AppUITests/BootCaptureUITests.swift packages/app-core/src/platform/ios-runtime-bridge.ts packages/app-core/src/index.ts packages/app/src/main.tsx
swiftc -parse packages/app-core/platforms/ios/App/AppUITests/ChatFailureStrings.generated.swift packages/app-core/platforms/ios/App/AppUITests/BootCaptureUITests.swift
```

Attempted but blocked locally:

```bash
bun run --cwd packages/app-core typecheck
bun run --cwd packages/app typecheck
```

Both failed before typechecking because this clone does not have the `tsgo` binary installed (`/opt/homebrew/bin/bash: line 1: tsgo: command not found`). `@typescript/native-preview` is declared in the root lockfile, but `node_modules/.bin/tsgo` is absent in this clone.

Not run locally: iOS simulator/device XCUITest. This host has command-line `swiftc`, but no `iphonesimulator` SDK (`xcrun --sdk iphonesimulator --show-sdk-path` fails), so the real sim/device leg must be completed by hosted/device CI or a machine with the iOS simulator runtime.

## Evidence applicability

- UI screenshots/video: N/A - verifier/test harness behavior changed, no rendered app UI changed.
- Frontend/browser logs: N/A - no browser flow changed.
- Live LLM trajectory: N/A - no agent/model/prompt implementation changed; verifier prompt text changed for mobile XCUITest.
- Domain artifacts: N/A - no persistent app/domain data changed.

## Remaining external verification

A real simulator/device run should still be attached before closing the issue fully:

- Broken-agent run: fails with the observed failure string quoted.
- Working-agent run: passes only through `IOS_CHAT_OK` / `marker-hit`.

— [shaw-codex]