### PR TITLE
fix(#13682): define the packaged-Windows smoke lane so it resolves + fails truthfully

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "cache:prune": "node packages/scripts/prune-turbo-cache.mjs",
     "test:dev-startup": "node packages/app-core/scripts/dev-startup-smoke.mjs",
     "test:hmr": "bun run --cwd packages/app test:hmr",
+    "test:desktop:packaged:windows": "bun run --cwd packages/app test:desktop:packaged:windows",
     "build:core": "node packages/scripts/build-core.mjs",
     "build:server": "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/agent",
     "lint": "node packages/scripts/run-turbo.mjs run lint",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -29,6 +29,7 @@
     "audit:app:minimalism:update": "bun scripts/update-minimalism-baseline.mjs",
     "audit:views": "node scripts/audit-views-soak.mjs",
     "test:desktop:packaged": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts",
+    "test:desktop:packaged:windows": "node scripts/run-desktop-packaged-windows.mjs",
     "test:desktop:voice": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/desktop-voice-selftest.e2e.spec.ts",
     "test:desktop:walkthrough": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/desktop-chat-walkthrough.e2e.spec.ts",
     "test:remote-capabilities:ui": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/remote-capability-view.spec.ts",

--- a/packages/app/scripts/run-desktop-packaged-windows.mjs
+++ b/packages/app/scripts/run-desktop-packaged-windows.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Windows packaged-desktop smoke lane (`test:desktop:packaged:windows`).
+ *
+ * This is the canonical entry point invoked by three call sites that used to
+ * reference a non-existent script name:
+ *   - .github/workflows/release-electrobun.yml  ("Smoke test packaged Windows app")
+ *   - packages/app-core/scripts/release-check.ts
+ *   - packages/app-core/test/regression-matrix.json (desktop-packaged-windows)
+ *
+ * It runs the win32-only packaged startup spec
+ * (test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts) through the
+ * shared `run-ui-playwright.mjs` harness on Windows, and — critically — fails
+ * with a NON-ZERO exit and a truthful precondition message on any non-Windows
+ * host, instead of the previous `error: Script not found` (invisible break) or
+ * a silent green "skipped" run. A release smoke lane that cannot actually run
+ * must report that as a failure so the packaged-Windows loop is never reported
+ * green with nothing executed.
+ *
+ * The `ELIZA_TEST_WINDOWS_*` env contract set by the workflow step (install
+ * dir, launcher dir, launcher-path file, artifacts/build dirs) is inherited by
+ * the delegated Playwright process unchanged.
+ */
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(scriptDir, "..");
+
+const WINDOWS_SPEC =
+  "test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts";
+const PACKAGED_CONFIG = "playwright.electrobun.packaged.config.ts";
+
+function fail(message) {
+  // Emit on both streams so the precondition reason is captured regardless of
+  // how a harness pipes the child's stdio (stderr is the primary channel).
+  const line = `[test:desktop:packaged:windows] ${message}\n`;
+  process.stderr.write(line);
+  process.stdout.write(line);
+  process.exit(1);
+}
+
+if (process.platform !== "win32") {
+  // Truthful precondition failure: there is no Windows build to smoke-test on a
+  // non-Windows host. Exit non-zero (NOT "Script not found", NOT a green skip)
+  // so the release pipeline sees the lane did not run.
+  fail(
+    `packaged Windows smoke test requires a windows host (host is ${process.platform}); ` +
+      `run this lane on a Windows runner with a packaged build present.`,
+  );
+}
+
+const runnerScript = path.join(scriptDir, "run-ui-playwright.mjs");
+const child = spawn(
+  process.execPath,
+  [runnerScript, "--config", PACKAGED_CONFIG, WINDOWS_SPEC],
+  {
+    cwd: appDir,
+    env: process.env,
+    stdio: "inherit",
+  },
+);
+
+child.on("error", (error) => {
+  fail(`failed to launch the packaged Windows lane: ${error.message}`);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});

--- a/packages/app/scripts/run-desktop-packaged-windows.mjs
+++ b/packages/app/scripts/run-desktop-packaged-windows.mjs
@@ -8,14 +8,13 @@
  *   - packages/app-core/scripts/release-check.ts
  *   - packages/app-core/test/regression-matrix.json (desktop-packaged-windows)
  *
- * It runs the win32-only packaged startup spec
- * (test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts) through the
- * shared `run-ui-playwright.mjs` harness on Windows, and — critically — fails
- * with a NON-ZERO exit and a truthful precondition message on any non-Windows
- * host, instead of the previous `error: Script not found` (invisible break) or
- * a silent green "skipped" run. A release smoke lane that cannot actually run
- * must report that as a failure so the packaged-Windows loop is never reported
- * green with nothing executed.
+ * It runs the existing packaged Windows PowerShell smoke on Windows, preserving
+ * the workflow's `ELIZA_TEST_WINDOWS_LAUNCHER_PATH_FILE` handoff contract, and
+ * — critically — fails with a NON-ZERO exit and a truthful precondition message
+ * on any non-Windows host, instead of the previous `error: Script not found`
+ * (invisible break) or a silent green "skipped" run. A release smoke lane that
+ * cannot actually run must report that as a failure so the packaged-Windows
+ * loop is never reported green with nothing executed.
  *
  * The `ELIZA_TEST_WINDOWS_*` env contract set by the workflow step (install
  * dir, launcher dir, launcher-path file, artifacts/build dirs) is inherited by
@@ -23,15 +22,22 @@
  */
 
 import { spawn } from "node:child_process";
+import { accessSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const appDir = path.resolve(scriptDir, "..");
-
-const WINDOWS_SPEC =
-  "test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts";
-const PACKAGED_CONFIG = "playwright.electrobun.packaged.config.ts";
+const repoRoot = path.resolve(appDir, "..", "..");
+const smokeScript = path.join(
+  repoRoot,
+  "packages",
+  "app-core",
+  "platforms",
+  "electrobun",
+  "scripts",
+  "smoke-test-windows.ps1",
+);
 
 function fail(message) {
   // Emit on both streams so the precondition reason is captured regardless of
@@ -52,12 +58,17 @@ if (process.platform !== "win32") {
   );
 }
 
-const runnerScript = path.join(scriptDir, "run-ui-playwright.mjs");
+try {
+  accessSync(smokeScript);
+} catch {
+  fail(`missing Windows smoke script: ${smokeScript}`);
+}
+
 const child = spawn(
-  process.execPath,
-  [runnerScript, "--config", PACKAGED_CONFIG, WINDOWS_SPEC],
+  "pwsh",
+  ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", smokeScript],
   {
-    cwd: appDir,
+    cwd: repoRoot,
     env: process.env,
     stdio: "inherit",
   },

--- a/packages/app/test/desktop-packaged-windows-lane.test.ts
+++ b/packages/app/test/desktop-packaged-windows-lane.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Guards the `test:desktop:packaged:windows` packaged-Windows smoke lane wiring
+ * (elizaOS/eliza#13682).
+ *
+ * Regression: three call sites invoked `bun run test:desktop:packaged:windows`
+ * but no package.json defined it, so the lane died with `error: Script not
+ * found` — an invisible break (every release-electrobun run since 2026-06-20
+ * concluded `skipped`). These tests assert the canonical lane is defined at the
+ * root (where all three call sites run it) and in packages/app, the three call
+ * sites reference the exact same name, the macOS lane stays distinct (no rename
+ * collapse), and the preflight runner fails NON-ZERO with a truthful message on
+ * a non-Windows host instead of the old "Script not found" or a silent green
+ * skip.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(here, "..");
+const repoRoot = path.resolve(appDir, "..", "..");
+
+const CANONICAL_LANE = "test:desktop:packaged:windows";
+
+function readJson(relFromRepo: string): Record<string, unknown> {
+  return JSON.parse(
+    fs.readFileSync(path.join(repoRoot, relFromRepo), "utf8"),
+  ) as Record<string, unknown>;
+}
+
+function readText(relFromRepo: string): string {
+  return fs.readFileSync(path.join(repoRoot, relFromRepo), "utf8");
+}
+
+function readScripts(relFromRepo: string): Record<string, string> {
+  const pkg = readJson(relFromRepo);
+  return (pkg.scripts ?? {}) as Record<string, string>;
+}
+
+function readSuites(): Record<string, { command?: string }> {
+  const matrix = readJson("packages/app-core/test/regression-matrix.json") as {
+    suites?: Record<string, { command?: string }>;
+  };
+  return matrix.suites ?? {};
+}
+
+// Under `bun test`, `process.execPath` points at the bun binary, which routes
+// an `.mjs` child's stdio differently and can drop captured output. Resolve a
+// real node binary from PATH so the child's precondition message is captured
+// deterministically regardless of the outer test runner.
+function resolveNodeBinary(): string {
+  const isWin = process.platform === "win32";
+  const names = isWin ? ["node.exe", "node"] : ["node"];
+  const pathValue = process.env.PATH ?? process.env.Path ?? "";
+  for (const dir of pathValue.split(path.delimiter)) {
+    if (!dir) continue;
+    for (const name of names) {
+      const candidate = path.join(dir, name);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+  }
+  // Fall back to execPath only if node is not on PATH (best effort).
+  return process.execPath;
+}
+
+describe("test:desktop:packaged:windows lane wiring (#13682)", () => {
+  it("defines the canonical lane in packages/app/package.json", () => {
+    const scripts = readScripts("packages/app/package.json");
+    expect(scripts[CANONICAL_LANE]).toBeTruthy();
+    // Delegates to the dedicated preflight runner (not a raw playwright call
+    // that would green-skip on non-win32).
+    expect(scripts[CANONICAL_LANE]).toContain(
+      "run-desktop-packaged-windows.mjs",
+    );
+  });
+
+  it("is invokable from the repo root where all three call sites run it", () => {
+    // The release workflow step, release-check.ts, and regression-matrix.json
+    // all execute `bun run test:desktop:packaged:windows` from the repository
+    // root (no working-directory / --cwd). A root delegator must exist or Bun
+    // fails with `error: Script not found` from root even though the app-level
+    // lane is defined (elizaOS/eliza#13682 P1).
+    const rootScripts = readScripts("package.json");
+    expect(rootScripts[CANONICAL_LANE]).toBeTruthy();
+    expect(rootScripts[CANONICAL_LANE]).toContain(
+      `--cwd packages/app ${CANONICAL_LANE}`,
+    );
+  });
+
+  it("ships the preflight runner script the lane points at", () => {
+    const runner = path.join(
+      appDir,
+      "scripts",
+      "run-desktop-packaged-windows.mjs",
+    );
+    expect(fs.existsSync(runner)).toBe(true);
+  });
+
+  it("all three call sites reference the exact canonical lane name", () => {
+    // release-electrobun.yml — the Smoke test packaged Windows app step.
+    expect(readText(".github/workflows/release-electrobun.yml")).toContain(
+      `bun run ${CANONICAL_LANE}`,
+    );
+    // release-check.ts required-snippet list.
+    expect(readText("packages/app-core/scripts/release-check.ts")).toContain(
+      `bun run ${CANONICAL_LANE}`,
+    );
+    // regression-matrix.json desktop-packaged-windows suite.
+    expect(readSuites()["desktop-packaged-windows"]?.command).toBe(
+      `bun run ${CANONICAL_LANE}`,
+    );
+  });
+
+  it("distinct named lane from the macOS packaged lane (no rename collapse)", () => {
+    const suites = readSuites();
+    expect(suites["desktop-packaged-macos"]?.command).toBe(
+      "bun run test:desktop:packaged",
+    );
+    expect(suites["desktop-packaged-windows"]?.command).toBe(
+      `bun run ${CANONICAL_LANE}`,
+    );
+    expect(suites["desktop-packaged-windows"]?.command).not.toBe(
+      suites["desktop-packaged-macos"]?.command,
+    );
+  });
+
+  it("fails NON-ZERO with a truthful precondition message on a non-Windows host", () => {
+    if (process.platform === "win32") {
+      // On a real Windows runner this delegates into Playwright and can only be
+      // exercised with a packaged build present; the non-win32 branch is what
+      // guards the "Script not found" -> truthful-precondition regression.
+      return;
+    }
+    const runner = path.join(
+      appDir,
+      "scripts",
+      "run-desktop-packaged-windows.mjs",
+    );
+    const result = spawnSync(resolveNodeBinary(), [runner], {
+      cwd: appDir,
+      encoding: "utf8",
+    });
+    // Non-zero exit (NOT "Script not found", NOT a green 0 skip).
+    expect(result.status).not.toBe(0);
+    expect(result.status).toBeGreaterThan(0);
+    const combined = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    expect(combined).toContain("requires a windows host");
+    expect(combined).toContain(process.platform);
+    expect(combined).not.toContain("Script not found");
+  });
+});

--- a/packages/app/test/desktop-packaged-windows-lane.test.ts
+++ b/packages/app/test/desktop-packaged-windows-lane.test.ts
@@ -72,7 +72,7 @@ describe("test:desktop:packaged:windows lane wiring (#13682)", () => {
     const scripts = readScripts("packages/app/package.json");
     expect(scripts[CANONICAL_LANE]).toBeTruthy();
     // Delegates to the dedicated preflight runner (not a raw playwright call
-    // that would green-skip on non-win32).
+    // that would green-skip on non-win32 or bypass the Windows smoke contract).
     expect(scripts[CANONICAL_LANE]).toContain(
       "run-desktop-packaged-windows.mjs",
     );
@@ -98,6 +98,22 @@ describe("test:desktop:packaged:windows lane wiring (#13682)", () => {
       "run-desktop-packaged-windows.mjs",
     );
     expect(fs.existsSync(runner)).toBe(true);
+  });
+
+  it("preserves the release workflow launcher-path handoff contract", () => {
+    const runner = readText(
+      "packages/app/scripts/run-desktop-packaged-windows.mjs",
+    );
+    expect(runner).toContain("smoke-test-windows.ps1");
+    expect(runner).toContain("pwsh");
+    expect(
+      readText(
+        "packages/app-core/platforms/electrobun/scripts/smoke-test-windows.ps1",
+      ),
+    ).toContain("ELIZA_TEST_WINDOWS_LAUNCHER_PATH_FILE");
+    expect(readText(".github/workflows/release-electrobun.yml")).toContain(
+      "ELIZA_TEST_WINDOWS_LAUNCHER_PATH_FILE",
+    );
   });
 
   it("all three call sites reference the exact canonical lane name", () => {


### PR DESCRIPTION
## Problem

The Windows packaged-desktop smoke lane was wired to `bun run test:desktop:packaged:windows` from three call sites, but no package script defined that command:

- `.github/workflows/release-electrobun.yml` — the "Smoke test packaged Windows app" step, which runs at repo root and expects `ELIZA_TEST_WINDOWS_LAUNCHER_PATH_FILE` to be emitted.
- `packages/app-core/scripts/release-check.ts`.
- `packages/app-core/test/regression-matrix.json` (`desktop-packaged-windows`).

That meant the next real Windows release run would fail at the smoke step with `error: Script not found`.

## Fix

- Defines `test:desktop:packaged:windows` at the repo root and in `packages/app`.
- Adds `packages/app/scripts/run-desktop-packaged-windows.mjs` as the canonical lane entry point.
- On non-Windows hosts, the entry point exits non-zero with a truthful precondition message instead of `Script not found` or a green skip.
- On Windows, the entry point delegates to `packages/app-core/platforms/electrobun/scripts/smoke-test-windows.ps1`, preserving the release workflow's existing `ELIZA_TEST_WINDOWS_LAUNCHER_PATH_FILE` handoff contract.
- Adds a focused lane-wiring test that asserts the root/app scripts, all three call sites, macOS-vs-Windows lane separation, non-Windows precondition failure, and the Windows launcher-path handoff.

## Verification

Passed locally in `/private/tmp/eliza-13682-clone`:

```bash
bun test packages/app/test/desktop-packaged-windows-lane.test.ts
bunx @biomejs/biome check packages/app/scripts/run-desktop-packaged-windows.mjs packages/app/test/desktop-packaged-windows-lane.test.ts
node --check packages/app/scripts/run-desktop-packaged-windows.mjs
bun run test:regression-matrix:release
bun run test:desktop:packaged:windows
```

Observed `bun run test:desktop:packaged:windows` on macOS exits non-zero with:

```text
[test:desktop:packaged:windows] packaged Windows smoke test requires a windows host (host is darwin); run this lane on a Windows runner with a packaged build present.
```

Not run locally: `bun run --cwd packages/app test -- test/desktop-packaged-windows-lane.test.ts` in the fresh clone, because that clone has no installed `node_modules` and the package script could not resolve `vitest`. The equivalent `bun test` focused spec passed.

## Evidence applicability

- UI screenshots/video: N/A - no UI rendering changed.
- Frontend/browser logs: N/A - no browser flow changed.
- Live LLM trajectory: N/A - no agent/model/prompt behavior changed.
- Domain artifacts: N/A - release tooling script fix.

Part of the desktop stream of the unattended-testing umbrella #13562.
