### PR TITLE
fix(#13682): add windows packaged desktop smoke script

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "test:launch-qa:docs": "node packages/scripts/launch-qa/check-docs.mjs --scope=docs --json",
     "test:launch-qa": "bun test packages/scripts/launch-qa/*.test.ts && bun run test:launch-qa:docs && node packages/scripts/launch-qa/check-mobile-artifacts.mjs --json --allow-missing-generated && node packages/scripts/launch-qa/check-model-data.mjs --json && node packages/scripts/launch-qa/run.mjs --suite quick --dry-run",
     "test:launch-qa:release:dry": "node packages/scripts/launch-qa/run.mjs --suite release --dry-run",
+    "test:desktop:packaged": "bun run --cwd packages/app test:desktop:packaged",
+    "test:desktop:packaged:windows": "bun run --cwd packages/app test:desktop:packaged:windows",
     "generate:action-search-keywords": "node packages/scripts/generate-action-search-keywords.mjs && node packages/shared/scripts/generate-keywords.mjs --target ts",
     "lifeops-bench:manifest": "node --conditions=eliza-source --conditions=development --import tsx scripts/lifeops-bench/export-action-manifest.ts",
     "start": "bun run --cwd packages/agent start",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -29,6 +29,7 @@
     "audit:app:minimalism:update": "bun scripts/update-minimalism-baseline.mjs",
     "audit:views": "node scripts/audit-views-soak.mjs",
     "test:desktop:packaged": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts",
+    "test:desktop:packaged:windows": "node -e \"if (process.platform !== 'win32') { console.error('[desktop-packaged-windows] Windows packaged smoke requires a win32 host with the packaged Electrobun build artifacts available.'); process.exit(1); }\" && node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts",
     "test:desktop:voice": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/desktop-voice-selftest.e2e.spec.ts",
     "test:desktop:walkthrough": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/desktop-chat-walkthrough.e2e.spec.ts",
     "test:remote-capabilities:ui": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/remote-capability-view.spec.ts",


### PR DESCRIPTION
## What changed

Relates to #13682.

- Adds root `test:desktop:packaged` and `test:desktop:packaged:windows` aliases for release workflow/root invocation.
- Adds `packages/app` `test:desktop:packaged:windows`, targeting the existing `electrobun-windows-startup.e2e.spec.ts` through the existing packaged Playwright config.
- Fails with a clear non-Windows precondition before Playwright when run on non-win32 hosts, so the command no longer dies as `Script not found`.

## Why

`release-electrobun.yml`, `release-check.ts`, and `regression-matrix.json` all referenced `bun run test:desktop:packaged:windows`, but no package defined that script. The next real Windows release run would fail before reaching the existing Windows packaged startup spec.

## Verification

- `bun run test:desktop:packaged:windows` on macOS: command resolves and exits with `[desktop-packaged-windows] Windows packaged smoke requires a win32 host with the packaged Electrobun build artifacts available.` This is the expected truthful host precondition, not `Script not found`.
- `bun run test:regression-matrix:release`: passed.
- `node -e "JSON.parse(...)"` for root and app `package.json`: passed.
- `git grep -n 'test:desktop:packaged:windows' -- package.json packages/app/package.json .github/workflows/release-electrobun.yml packages/app-core/scripts/release-check.ts packages/app-core/test/regression-matrix.json`: all references align to the defined lane.

## Evidence rows

- UI screenshots/video: N/A - script wiring only, no UI surface changed.
- Backend/frontend logs: N/A - release/test script wiring only.
- Domain artifacts: N/A - no runtime artifact produced.
- Windows packaged proof: pending CI/human Windows runner with packaged Electrobun artifacts; this PR restores the command path so that real lane can run.
