### PR TITLE
fix(#13682): define Windows packaged desktop smoke lane

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "test:launch-qa:docs": "node packages/scripts/launch-qa/check-docs.mjs --scope=docs --json",
     "test:launch-qa": "bun test packages/scripts/launch-qa/*.test.ts && bun run test:launch-qa:docs && node packages/scripts/launch-qa/check-mobile-artifacts.mjs --json --allow-missing-generated && node packages/scripts/launch-qa/check-model-data.mjs --json && node packages/scripts/launch-qa/run.mjs --suite quick --dry-run",
     "test:launch-qa:release:dry": "node packages/scripts/launch-qa/run.mjs --suite release --dry-run",
+    "test:desktop:packaged": "bun run --cwd packages/app test:desktop:packaged",
+    "test:desktop:packaged:windows": "bun run --cwd packages/app test:desktop:packaged:windows",
     "generate:action-search-keywords": "node packages/scripts/generate-action-search-keywords.mjs && node packages/shared/scripts/generate-keywords.mjs --target ts",
     "lifeops-bench:manifest": "node --conditions=eliza-source --conditions=development --import tsx scripts/lifeops-bench/export-action-manifest.ts",
     "start": "bun run --cwd packages/agent start",

--- a/packages/app-core/scripts/release-check.ts
+++ b/packages/app-core/scripts/release-check.ts
@@ -283,6 +283,9 @@ const forbiddenElectrobunPrWorkflowSnippets = [
 ];
 const requiredRootPackageScriptSnippets: Record<string, readonly string[]> = {
   "release:check": ["scripts/run-release-check.mjs"],
+  "test:desktop:packaged:windows": [
+    "bun run --cwd packages/app test:desktop:packaged:windows",
+  ],
   "test:release:contract": ["scripts/run-release-contract-suite.mjs"],
   "test:regression-matrix:release": [
     "scripts/run-eliza-app-core-script.mjs validate-regression-matrix.mjs --workflow release",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -29,6 +29,7 @@
     "audit:app:minimalism:update": "bun scripts/update-minimalism-baseline.mjs",
     "audit:views": "node scripts/audit-views-soak.mjs",
     "test:desktop:packaged": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts",
+    "test:desktop:packaged:windows": "node -e \"if (process.platform !== 'win32') { console.error('[desktop-packaged-windows] Windows packaged smoke requires a win32 host with the packaged Electrobun build artifacts available.'); process.exit(1); }\" && node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts",
     "test:desktop:voice": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/desktop-voice-selftest.e2e.spec.ts",
     "test:desktop:walkthrough": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/desktop-chat-walkthrough.e2e.spec.ts",
     "test:remote-capabilities:ui": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/remote-capability-view.spec.ts",

--- a/packages/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts
@@ -22,7 +22,9 @@ test("packaged Windows app bootstraps the renderer against the external API over
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "eliza-win-e2e-"));
   const extractDir = path.join(tempRoot, "extract");
   const launcherPath = await resolvePackagedLauncher(extractDir);
-  test.skip(!launcherPath, "Windows packaged launcher is required");
+  if (!launcherPath) {
+    throw new Error("Windows packaged launcher is required.");
+  }
 
   let api: MockApiServer | null = null;
   let harness: PackagedDesktopHarness | null = null;


### PR DESCRIPTION
## Summary
- Add root `test:desktop:packaged` and `test:desktop:packaged:windows` script wiring so release workflow/root invocations resolve.
- Add the app-level Windows packaged lane with an explicit win32/artifact precondition before running the existing Windows startup spec.
- Make the Windows startup spec fail on a missing packaged launcher instead of skipping, and add a release-check contract so the root lane cannot disappear again.

Relates to #13682.

## Verification
- `bun run test:desktop:packaged:windows` on macOS: resolves the script and exits 1 with `[desktop-packaged-windows] Windows packaged smoke requires a win32 host with the packaged Electrobun build artifacts available.` This proves it is no longer `Script not found` and fails on a truthful precondition outside Windows.
- `bun run test:regression-matrix:release-contract`: passed.
- `bun run release:check`: reached static asset manifest validation after passing the new script-contract check; failed on pre-existing stale `scripts/generated/static-asset-manifest.json`.

## Evidence / N/A
- UI screenshots/video: N/A - script/release contract only, no rendered UI change.
- Backend logs/LLM trajectories/domain artifacts: N/A - no runtime, model, or data-path behavior changed.

## Local note
The visible checkout has corrupt Git worktree metadata pointing at another worktree, so this PR branch was created through GitHub Contents API from `develop` and verified via GitHub compare. Remote compare shows only the four intended files changed.