### PR TITLE
fix(#13682): define Windows packaged desktop smoke lane

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test:launch-qa:docs": "node packages/scripts/launch-qa/check-docs.mjs --scope=docs --json",
     "test:launch-qa": "bun test packages/scripts/launch-qa/*.test.ts && bun run test:launch-qa:docs && node packages/scripts/launch-qa/check-mobile-artifacts.mjs --json --allow-missing-generated && node packages/scripts/launch-qa/check-model-data.mjs --json && node packages/scripts/launch-qa/run.mjs --suite quick --dry-run",
     "test:launch-qa:release:dry": "node packages/scripts/launch-qa/run.mjs --suite release --dry-run",
+    "test:desktop:packaged:windows": "bun run --cwd packages/app test:desktop:packaged:windows",
     "generate:action-search-keywords": "node packages/scripts/generate-action-search-keywords.mjs && node packages/shared/scripts/generate-keywords.mjs --target ts",
     "lifeops-bench:manifest": "node --conditions=eliza-source --conditions=development --import tsx scripts/lifeops-bench/export-action-manifest.ts",
     "start": "bun run --cwd packages/agent start",

--- a/packages/app-core/scripts/release-check.ts
+++ b/packages/app-core/scripts/release-check.ts
@@ -283,6 +283,9 @@ const forbiddenElectrobunPrWorkflowSnippets = [
 ];
 const requiredRootPackageScriptSnippets: Record<string, readonly string[]> = {
   "release:check": ["scripts/run-release-check.mjs"],
+  "test:desktop:packaged:windows": [
+    "bun run --cwd packages/app test:desktop:packaged:windows",
+  ],
   "test:release:contract": ["scripts/run-release-contract-suite.mjs"],
   "test:regression-matrix:release": [
     "scripts/run-eliza-app-core-script.mjs validate-regression-matrix.mjs --workflow release",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -29,6 +29,7 @@
     "audit:app:minimalism:update": "bun scripts/update-minimalism-baseline.mjs",
     "audit:views": "node scripts/audit-views-soak.mjs",
     "test:desktop:packaged": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts",
+    "test:desktop:packaged:windows": "node -e \"if (process.platform !== 'win32') { console.error('[desktop-packaged-windows] Windows packaged smoke requires a win32 host with packaged Electrobun artifacts.'); process.exit(1); }\" && pwsh -NoProfile -ExecutionPolicy Bypass -File ../app-core/platforms/electrobun/scripts/smoke-test-windows.ps1",
     "test:desktop:voice": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/desktop-voice-selftest.e2e.spec.ts",
     "test:desktop:walkthrough": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/desktop-chat-walkthrough.e2e.spec.ts",
     "test:remote-capabilities:ui": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/remote-capability-view.spec.ts",


### PR DESCRIPTION
## Summary
- defines the root `test:desktop:packaged:windows` proxy used by the release workflow and regression matrix
- adds the app-level Windows packaged smoke lane with a clear non-Windows precondition failure
- teaches `release:check` to require the root proxy so this lane cannot silently disappear again

Relates to #13682.

## Evidence
- `bun pm pkg get scripts.test:desktop:packaged:windows` -> `bun run --cwd packages/app test:desktop:packaged:windows`
- `bun pm pkg get --cwd packages/app scripts.test:desktop:packaged:windows` -> Windows-only smoke command
- `bun run test:desktop:packaged:windows` on macOS exits non-zero with `[desktop-packaged-windows] Windows packaged smoke requires a win32 host with packaged Electrobun artifacts.` instead of `Script not found`
- `git grep --cached -n 'test:desktop:packaged:windows' -- package.json packages/app/package.json packages/app-core/scripts/release-check.ts packages/app-core/test/regression-matrix.json .github/workflows/release-electrobun.yml` shows the workflow, regression matrix, root proxy, app lane, and release-check guard all aligned
- `bun run test:regression-matrix:release` passed
- `bun run test:regression-matrix:release-contract` passed

## Not run / blocked
- Full `bun run release:check` did not pass in the clean worktree because the repo release gate required generated packaging prerequisites unrelated to this lane repair. After regenerating static/homepage release data and building `packages/app-core`, it still failed on `dist/build-info.json` missing from the app-core pack root.
- Windows execution of `test:desktop:packaged:windows` needs a Windows host plus packaged Electrobun artifacts; this macOS run verified the intended precondition failure only.

## Evidence rows
- UI screenshots/video: N/A - script wiring only, no user-facing UI change.
- Real LLM trajectory: N/A - no agent/model behavior changed.
- Backend/frontend logs: N/A - release lane wiring only.
- Domain artifacts: N/A - no runtime data artifacts produced.