### PR TITLE
fix(#13685): run HMR smoke in dev-smoke workflow

### DIFF
--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -149,3 +149,60 @@ jobs:
             packages/app/playwright-report/
             packages/app/test-results/
           if-no-files-found: ignore
+
+  hmr-smoke:
+    name: bun run dev HMR dependency levels
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.dev_smoke == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    env:
+      PGLITE_WASM_MODE: node
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Free disk space for browser smoke
+        run: |
+          set -euxo pipefail
+          df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          df -h /
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+
+      - name: Generate shared i18n assets
+        run: bun run --cwd packages/shared build:i18n
+
+      - name: Build @elizaos/core browser bundle
+        run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
+
+      - name: Run bun dev HMR dependency-level smoke
+        run: bun run --cwd packages/app test:hmr
+
+      - name: Upload HMR smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: hmr-smoke-results
+          path: |
+            packages/app/playwright-report/
+            packages/app/test-results/hmr/
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- Add an `hmr-smoke` job to `dev-smoke.yml` behind the existing `dev_smoke` path gate.
- Reuse the dev-smoke setup pattern: checkout, disk cleanup, workspace install, Chromium install, shared i18n build, and core/shared browser bundle build.
- Run `bun run --cwd packages/app test:hmr` and upload HMR Playwright artifacts.

Relates to #13685.

## Verification
- Fetched the PR branch workflow content and parsed it with Ruby YAML: `yaml-ok`.
- Confirmed remote workflow contains `hmr-smoke`, `needs.changes.outputs.dev_smoke`, `bun run --cwd packages/app test:hmr`, and `hmr-smoke-results`.
- GitHub compare against `develop` shows exactly one changed file: `.github/workflows/dev-smoke.yml`.

## Evidence / N/A
- Screenshots/video: N/A - CI workflow wiring only, no UI surface changed.
- Backend logs/LLM trajectories/domain artifacts: N/A - no runtime/model/data path changed.
- Full HMR lane execution: will run in GitHub Actions on this PR as the new CI home; local checkout Git metadata is unsafe, so this branch was created from `develop` via GitHub Contents API.