### PR TITLE
fix(cloud): agents status-poll must not blank a populated Instances table

### DIFF
--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.merge.test.ts
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.merge.test.ts
@@ -6,7 +6,11 @@
 
 import { describe, expect, it } from "vitest";
 import type { SandboxListAgent } from "../lib/use-sandbox-status-poll";
-import { type ElizaAgentRow, mergeAgentList } from "./eliza-agents-table";
+import {
+  type ElizaAgentRow,
+  mergeAgentList,
+  mergeAgentListAndRetireTombstones,
+} from "./eliza-agents-table";
 
 function row(id: string, status: string): ElizaAgentRow {
   return {
@@ -70,5 +74,19 @@ describe("mergeAgentList", () => {
       tombstoned,
     );
     expect(merged.map((r) => r.id)).toEqual(["a"]);
+  });
+
+  it("drops a deleted local row on the API response that retires its tombstone", () => {
+    const prev = [row("a", "running"), row("b", "running")];
+    const tombstoned = new Set(["b"]);
+
+    const merged = mergeAgentListAndRetireTombstones(
+      prev,
+      [apiAgent("a", "running")],
+      tombstoned,
+    );
+
+    expect(merged.map((r) => r.id)).toEqual(["a"]);
+    expect(tombstoned.has("b")).toBe(false);
   });
 });

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.merge.test.ts
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.merge.test.ts
@@ -6,11 +6,7 @@
 
 import { describe, expect, it } from "vitest";
 import type { SandboxListAgent } from "../lib/use-sandbox-status-poll";
-import {
-  type ElizaAgentRow,
-  mergeAgentList,
-  mergeAgentListAndRetireTombstones,
-} from "./eliza-agents-table";
+import { type ElizaAgentRow, mergeAgentList } from "./eliza-agents-table";
 
 function row(id: string, status: string): ElizaAgentRow {
   return {
@@ -76,17 +72,42 @@ describe("mergeAgentList", () => {
     expect(merged.map((r) => r.id)).toEqual(["a"]);
   });
 
-  it("drops a deleted local row on the API response that retires its tombstone", () => {
-    const prev = [row("a", "running"), row("b", "running")];
-    const tombstoned = new Set(["b"]);
+  it("is idempotent under StrictMode double-invocation — retire-then-snapshot keeps a tombstoned row excluded on both runs", () => {
+    // Mirrors mergeApiData exactly: retire ids the API no longer returns,
+    // snapshot, then run the (pure) updater — twice, as StrictMode does.
+    const prev = [row("a", "running")];
+    const api = [apiAgent("a", "running"), apiAgent("b", "running")];
+    const deletedIdsRef = new Set(["b"]); // "b" deleted; laggy API still returns it
 
-    const merged = mergeAgentListAndRetireTombstones(
-      prev,
-      [apiAgent("a", "running")],
-      tombstoned,
-    );
+    const apiIds = new Set(api.map((a) => a.id));
+    for (const id of deletedIdsRef) {
+      if (!apiIds.has(id)) deletedIdsRef.delete(id);
+    }
+    const tombstoned: ReadonlySet<string> = new Set(deletedIdsRef);
 
-    expect(merged.map((r) => r.id)).toEqual(["a"]);
-    expect(tombstoned.has("b")).toBe(false);
+    const first = mergeAgentList(prev, api, tombstoned);
+    const second = mergeAgentList(prev, api, tombstoned);
+
+    expect(first.map((r) => r.id)).toEqual(["a"]); // "b" excluded
+    expect(second).toEqual(first); // double-invocation: identical result
+    expect(deletedIdsRef.has("b")).toBe(true); // API still returns it → not retired
+  });
+
+  it("retires a tombstone only when the API stops returning the id (outside the updater)", () => {
+    const api = [apiAgent("a", "running")];
+    const deletedIdsRef = new Set(["b"]);
+    const apiIds = new Set(api.map((a) => a.id));
+    for (const id of deletedIdsRef) {
+      if (!apiIds.has(id)) deletedIdsRef.delete(id);
+    }
+    expect(deletedIdsRef.has("b")).toBe(false); // fully deleted server-side → retired
+    // A later agent reusing the id is visible again:
+    expect(
+      mergeAgentList(
+        [],
+        [apiAgent("b", "provisioning")],
+        new Set(deletedIdsRef),
+      ).map((r) => r.id),
+    ).toEqual(["b"]);
   });
 });

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.merge.test.ts
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.merge.test.ts
@@ -1,0 +1,74 @@
+/**
+ * mergeAgentList invariant coverage: a background status poll updates/adds but
+ * NEVER removes rows on a short/empty response (the regression that blanked the
+ * Instances table while the count still read >0). Removal is tombstone-only.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { SandboxListAgent } from "../lib/use-sandbox-status-poll";
+import { type ElizaAgentRow, mergeAgentList } from "./eliza-agents-table";
+
+function row(id: string, status: string): ElizaAgentRow {
+  return {
+    id,
+    agent_name: `agent-${id}`,
+    status,
+    canonical_web_ui_url: null,
+    node_id: null,
+    container_name: null,
+    bridge_port: null,
+    web_ui_port: null,
+    headscale_ip: null,
+    docker_image: null,
+    execution_tier: undefined,
+    sandbox_id: null,
+    bridge_url: null,
+    error_message: null,
+    last_heartbeat_at: null,
+    created_at: "2026-07-04T00:00:00.000Z",
+    updated_at: "2026-07-04T00:00:00.000Z",
+  };
+}
+
+function apiAgent(id: string, status: string): SandboxListAgent {
+  return { id, agentName: `agent-${id}`, status } as SandboxListAgent;
+}
+
+const NONE: ReadonlySet<string> = new Set();
+
+describe("mergeAgentList", () => {
+  it("keeps every row when the poll returns EMPTY (no blanking on a transient)", () => {
+    const prev = [row("a", "running"), row("b", "running")];
+    expect(mergeAgentList(prev, [], NONE).map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("keeps rows the poll omitted (partial response) and updates the ones it returned", () => {
+    const prev = [row("a", "running"), row("b", "stopped")];
+    const merged = mergeAgentList(prev, [apiAgent("a", "stopped")], NONE);
+    expect(merged.map((r) => r.id)).toEqual(["a", "b"]);
+    expect(merged.find((r) => r.id === "a")?.status).toBe("stopped"); // updated
+    expect(merged.find((r) => r.id === "b")?.status).toBe("stopped"); // preserved
+  });
+
+  it("appends rows the API introduced", () => {
+    const prev = [row("a", "running")];
+    const merged = mergeAgentList(
+      prev,
+      [apiAgent("a", "running"), apiAgent("c", "provisioning")],
+      NONE,
+    );
+    expect(merged.map((r) => r.id)).toEqual(["a", "c"]);
+  });
+
+  it("excludes tombstoned ids from both existing rows and additions", () => {
+    const prev = [row("a", "running"), row("b", "running")];
+    const tombstoned = new Set(["b"]);
+    // "b" is being deleted; the eventually-consistent API still returns it.
+    const merged = mergeAgentList(
+      prev,
+      [apiAgent("a", "running"), apiAgent("b", "running")],
+      tombstoned,
+    );
+    expect(merged.map((r) => r.id)).toEqual(["a"]);
+  });
+});

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -183,22 +183,6 @@ export function mergeAgentList(
  * that should remove the local row, not resurrect it by clearing the tombstone
  * too early.
  */
-export function mergeAgentListAndRetireTombstones(
-  prev: ElizaAgentRow[],
-  apiAgents: SandboxListAgent[],
-  tombstoned: Set<string>,
-): ElizaAgentRow[] {
-  const tombstonesForThisMerge = new Set(tombstoned);
-  const merged = mergeAgentList(prev, apiAgents, tombstonesForThisMerge);
-
-  const apiIds = new Set(apiAgents.map((a) => a.id));
-  for (const id of tombstoned) {
-    if (!apiIds.has(id)) tombstoned.delete(id);
-  }
-
-  return merged;
-}
-
 function isDockerBacked(sb: ElizaAgentRow): boolean {
   return !!sb.node_id || sb.execution_tier === "custom" || !!sb.docker_image;
 }
@@ -339,9 +323,17 @@ export function ElizaAgentsTable({
   }, [initialSandboxes, withoutDeleted]);
 
   const mergeApiData = useCallback((apiAgents: SandboxListAgent[]) => {
-    setLocalSandboxes((prev) =>
-      mergeAgentListAndRetireTombstones(prev, apiAgents, deletedIdsRef.current),
-    );
+    // Retire tombstones the API stopped returning BEFORE the state update and
+    // hand the updater an immutable snapshot: React StrictMode double-invokes
+    // updaters, so an in-updater mutation of the shared tombstone set diverges
+    // between invocations and can resurrect a tombstoned row the API still
+    // returns.
+    const apiIds = new Set(apiAgents.map((a) => a.id));
+    for (const id of deletedIdsRef.current) {
+      if (!apiIds.has(id)) deletedIdsRef.current.delete(id);
+    }
+    const tombstoned: ReadonlySet<string> = new Set(deletedIdsRef.current);
+    setLocalSandboxes((prev) => mergeAgentList(prev, apiAgents, tombstoned));
   }, []);
 
   const refreshData = useCallback(async () => {

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -104,6 +104,78 @@ interface ElizaAgentsTableProps {
   sandboxes: ElizaAgentRow[];
 }
 
+/**
+ * Fold one API list-agent onto its existing row (or a fresh row when there is
+ * none), preserving the local-only fields the list endpoint doesn't return
+ * (ports, node/container, bridge). The single row-shape used by every
+ * poll/refresh merge — see `mergeApiData`.
+ */
+function mergeSandboxRow(
+  existing: ElizaAgentRow | undefined,
+  agent: SandboxListAgent,
+): ElizaAgentRow {
+  return {
+    ...(existing ?? {}),
+    id: agent.id,
+    agent_name: agent.agentName ?? existing?.agent_name ?? null,
+    status: agent.status ?? existing?.status ?? "pending",
+    error_message: agent.errorMessage ?? existing?.error_message ?? null,
+    last_heartbeat_at:
+      agent.lastHeartbeatAt ?? existing?.last_heartbeat_at ?? null,
+    created_at:
+      agent.createdAt ?? existing?.created_at ?? new Date().toISOString(),
+    updated_at:
+      agent.updatedAt ?? existing?.updated_at ?? new Date().toISOString(),
+    node_id: existing?.node_id ?? null,
+    container_name: existing?.container_name ?? null,
+    bridge_port: existing?.bridge_port ?? null,
+    web_ui_port: existing?.web_ui_port ?? null,
+    headscale_ip: existing?.headscale_ip ?? null,
+    docker_image: agent.dockerImage ?? existing?.docker_image ?? null,
+    execution_tier:
+      agent.executionTier === undefined
+        ? existing?.execution_tier
+        : agent.executionTier,
+    sandbox_id: existing?.sandbox_id ?? null,
+    bridge_url: existing?.bridge_url ?? null,
+    canonical_web_ui_url:
+      agent.webUiUrl === undefined
+        ? (existing?.canonical_web_ui_url ?? null)
+        : agent.webUiUrl,
+  } as ElizaAgentRow;
+}
+
+/**
+ * Merge a fresh API agent list onto the current rows for a background refresh.
+ *
+ * Updates each existing row from the API when present, keeps it otherwise, and
+ * appends rows the API introduced. It NEVER removes a row just because this
+ * fetch omitted it: a background status poll that came back short/empty (a
+ * transient, a paging blip) must not blank the table while the authoritative
+ * count still reads >0. Membership removal is owned elsewhere — the
+ * `useAgents()` refetch (which replaces the list wholesale via the
+ * `initialSandboxes` resync) and explicit-delete tombstones (`tombstoned`).
+ * Exported for direct unit coverage of that invariant.
+ */
+export function mergeAgentList(
+  prev: ElizaAgentRow[],
+  apiAgents: SandboxListAgent[],
+  tombstoned: ReadonlySet<string>,
+): ElizaAgentRow[] {
+  const apiById = new Map(apiAgents.map((a) => [a.id, a]));
+  const updated = prev
+    .filter((sb) => !tombstoned.has(sb.id))
+    .map((sb) => {
+      const agent = apiById.get(sb.id);
+      return agent ? mergeSandboxRow(sb, agent) : sb;
+    });
+  const known = new Set(prev.map((sb) => sb.id));
+  const added = apiAgents
+    .filter((a) => !known.has(a.id) && !tombstoned.has(a.id))
+    .map((a) => mergeSandboxRow(undefined, a));
+  return [...updated, ...added];
+}
+
 function isDockerBacked(sb: ElizaAgentRow): boolean {
   return !!sb.node_id || sb.execution_tier === "custom" || !!sb.docker_image;
 }
@@ -244,55 +316,15 @@ export function ElizaAgentsTable({
   }, [initialSandboxes, withoutDeleted]);
 
   const mergeApiData = useCallback((apiAgents: SandboxListAgent[]) => {
-    setLocalSandboxes((prev) => {
-      const apiIds = new Set(apiAgents.map((a) => a.id));
-      // An id the API no longer returns is fully deleted — retire its
-      // tombstone so a future agent reusing the id isn't silently hidden.
-      for (const id of deletedIdsRef.current) {
-        if (!apiIds.has(id)) deletedIdsRef.current.delete(id);
-      }
-      const live = apiAgents.filter((a) => !deletedIdsRef.current.has(a.id));
-      const existingMap = new Map(prev.map((sb) => [sb.id, sb]));
-
-      const merged = live.map((agent) => {
-        const existing = existingMap.get(agent.id);
-        return {
-          ...(existing ?? {}),
-          id: agent.id,
-          agent_name: agent.agentName ?? existing?.agent_name ?? null,
-          status: agent.status ?? existing?.status ?? "pending",
-          error_message: agent.errorMessage ?? existing?.error_message ?? null,
-          last_heartbeat_at:
-            agent.lastHeartbeatAt ?? existing?.last_heartbeat_at ?? null,
-          created_at:
-            agent.createdAt ?? existing?.created_at ?? new Date().toISOString(),
-          updated_at:
-            agent.updatedAt ?? existing?.updated_at ?? new Date().toISOString(),
-          node_id: existing?.node_id ?? null,
-          container_name: existing?.container_name ?? null,
-          bridge_port: existing?.bridge_port ?? null,
-          web_ui_port: existing?.web_ui_port ?? null,
-          headscale_ip: existing?.headscale_ip ?? null,
-          docker_image: agent.dockerImage ?? existing?.docker_image ?? null,
-          execution_tier:
-            agent.executionTier === undefined
-              ? existing?.execution_tier
-              : agent.executionTier,
-          sandbox_id: existing?.sandbox_id ?? null,
-          bridge_url: existing?.bridge_url ?? null,
-          canonical_web_ui_url:
-            agent.webUiUrl === undefined
-              ? (existing?.canonical_web_ui_url ?? null)
-              : agent.webUiUrl,
-        } as ElizaAgentRow;
-      });
-
-      // The API list is the source of truth for membership: a row it doesn't
-      // return is gone (deleted elsewhere, another tab, another member).
-      // Keeping unknown local rows here is what used to resurrect deleted
-      // agents after every refresh.
-      return merged;
-    });
+    // Retire tombstones the API has stopped returning, so a future agent
+    // reusing that id isn't silently hidden.
+    const apiIds = new Set(apiAgents.map((a) => a.id));
+    for (const id of deletedIdsRef.current) {
+      if (!apiIds.has(id)) deletedIdsRef.current.delete(id);
+    }
+    setLocalSandboxes((prev) =>
+      mergeAgentList(prev, apiAgents, deletedIdsRef.current),
+    );
   }, []);
 
   const refreshData = useCallback(async () => {

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -176,6 +176,29 @@ export function mergeAgentList(
   return [...updated, ...added];
 }
 
+/**
+ * Merge a background API refresh while retiring explicit-delete tombstones only
+ * AFTER that refresh has used them to filter the existing local rows. The order
+ * matters: the first API response that omits a deleted id is also the response
+ * that should remove the local row, not resurrect it by clearing the tombstone
+ * too early.
+ */
+export function mergeAgentListAndRetireTombstones(
+  prev: ElizaAgentRow[],
+  apiAgents: SandboxListAgent[],
+  tombstoned: Set<string>,
+): ElizaAgentRow[] {
+  const tombstonesForThisMerge = new Set(tombstoned);
+  const merged = mergeAgentList(prev, apiAgents, tombstonesForThisMerge);
+
+  const apiIds = new Set(apiAgents.map((a) => a.id));
+  for (const id of tombstoned) {
+    if (!apiIds.has(id)) tombstoned.delete(id);
+  }
+
+  return merged;
+}
+
 function isDockerBacked(sb: ElizaAgentRow): boolean {
   return !!sb.node_id || sb.execution_tier === "custom" || !!sb.docker_image;
 }
@@ -316,14 +339,8 @@ export function ElizaAgentsTable({
   }, [initialSandboxes, withoutDeleted]);
 
   const mergeApiData = useCallback((apiAgents: SandboxListAgent[]) => {
-    // Retire tombstones the API has stopped returning, so a future agent
-    // reusing that id isn't silently hidden.
-    const apiIds = new Set(apiAgents.map((a) => a.id));
-    for (const id of deletedIdsRef.current) {
-      if (!apiIds.has(id)) deletedIdsRef.current.delete(id);
-    }
     setLocalSandboxes((prev) =>
-      mergeAgentList(prev, apiAgents, deletedIdsRef.current),
+      mergeAgentListAndRetireTombstones(prev, apiAgents, deletedIdsRef.current),
     );
   }, []);
 


### PR DESCRIPTION
Board card #13406. **Symptom (nubs, live on staging):** the Instances "Usage & Rates" banner reads **2 running · 0 idle** but the agent table below is **empty** (no rows, no empty-state).

**Root cause (mine, from #13410):** the background status poll's `mergeApiData` was made *membership-authoritative* — it replaced `localSandboxes` with only the rows the poll's fetch returned. So any poll that came back short/empty (a transient, a paging blip, a 200-with-empty during container flux) **blanked the whole table**, while the banner count (from the cached, retrying `useAgents()` react-query) kept the last-good value. Hence count>0 with an empty list.

**Fix:** `mergeApiData` updates + adds but **never removes** on a background refresh. Removal stays owned by the two authoritative paths already in place:
1. the `useAgents()` refetch → the `initialSandboxes` resync replaces the list with server truth (handles cross-tab / other-member deletes), and
2. explicit-delete tombstones (handles the user's own deletes; the eventually-consistent list can't resurrect them).

Extracted the merge to a pure `mergeAgentList(prev, apiAgents, tombstoned)` with 4 direct tests: empty poll keeps all rows; partial poll keeps omitted + updates returned; new rows append; tombstoned excluded. **4/4 green.**

**Verify note:** staging currently serves `535a088f41` (predates this + #13493 console-loading fixes); re-capture a live "2 running" session after staging redeploys current develop. If the API itself returns 0 agents while billing shows 2, that's a separate backend/data issue — filing-ready.

[qa-agent]