### PR TITLE
ci(#13621): broaden UI story gate paths

### DIFF
--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -3,8 +3,9 @@ name: UI Story Gate
 # Render EVERY Storybook story in headless Chromium and assert it is healthy.
 # Hard-fails on a story that throws, renders blank, or raises an uncaught
 # pageerror — no baseline needed. Console errors + serious/critical axe a11y
-# violations are additionally enforced once their baselines are populated
-# (packages/ui/test/story-gate/baseline/*.json). See
+# violations are enforced against allowlist baselines
+# (packages/ui/test/story-gate/baseline/*.json); empty baselines mean zero
+# tolerance. See
 # packages/ui/test/story-gate/README.md.
 
 on:
@@ -14,13 +15,16 @@ on:
     branches: [main, develop]
     paths:
       - "packages/ui/**"
-      - "plugins/plugin-companion/src/**"
+      - "packages/shared/**"
+      - "plugins/**/src/**"
       - ".github/workflows/ui-story-gate.yml"
   push:
     branches: [main, develop]
     paths:
       - "packages/ui/**"
-      - "plugins/plugin-companion/src/**"
+      - "packages/shared/**"
+      - "plugins/**/src/**"
+      - ".github/workflows/ui-story-gate.yml"
 
 concurrency:
   group: ui-story-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}


### PR DESCRIPTION
## What changed

Closes the remaining #13621 task 3 slice.

- Broadened `ui-story-gate.yml` pull-request and push path filters from `packages/ui/**` + `plugin-companion` to:
  - `packages/ui/**`
  - `packages/shared/**`
  - `plugins/**/src/**`
  - the workflow file itself
- Updated the workflow header comment to match the already-landed #13659 behavior: story-gate console/a11y baselines are allowlists, and empty baselines mean zero tolerance.

## Why

The story gate was path-blind to shared UI-bleeding changes. A shared brand asset or plugin view bundle could regress Storybook rendering/a11y without triggering the gate. This keeps the existing gate and simply makes its trigger surface match the UI code it protects.

## Verification

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ui-story-gate.yml"); puts "yaml parse ok"'`
- `actionlint .github/workflows/ui-story-gate.yml`
- `bunx @biomejs/biome check .github/workflows/ui-story-gate.yml --no-errors-on-unmatched` (reports 0 files, as expected for YAML)

## Evidence rows

- Screenshots/video: N/A - workflow trigger path change only, no rendered UI changed.
- Backend/frontend logs: N/A - no runtime path changed.
- Real trajectories: N/A - no agent/action/model/prompt behavior changed.
- Domain artifact: PR diff + validation commands above; the changed workflow path filters are the artifact under review.

[shaw-codex]