### PR TITLE
fix(#13708): document markdown-link checker plugin exclusions

### DIFF
--- a/packages/scripts/script-plugin-coupling.allowlist.json
+++ b/packages/scripts/script-plugin-coupling.allowlist.json
@@ -176,6 +176,17 @@
     "reason": "gates that the facewear plugin's research checkouts, docs, and implemented surface files are present"
   },
   {
+    "file": "scripts/check-markdown-links.mjs",
+    "tokens": [
+      "plugins/plugin-agent-orchestrator",
+      "plugins/plugin-computeruse",
+      "plugins/plugin-local-inference",
+      "plugins/plugin-wallet",
+      "plugins/plugin-xai"
+    ],
+    "reason": "Markdown link hygiene excludes stale/prototype documentation subtrees by concrete path prefix so maintained contributor-facing docs can remain hard-gated"
+  },
+  {
     "file": "scripts/check-smartglasses-completion-gate.mjs",
     "tokens": [
       "@elizaos/plugin-facewear",


### PR DESCRIPTION
## Summary

- Documents the `scripts/check-markdown-links.mjs` plugin-path exclusions in `script-plugin-coupling.allowlist.json`.
- Keeps the coupling audit stale-checked instead of weakening the scanner or removing the Markdown link hygiene gate.

Fixes #13708.

## Evidence

- `bun run audit:scripts` — pass (`[audit-scripts] OK — no orphan/no-op/broken scripts.`)
- `bun run audit:scripts:self-test` — pass (`audit-scripts self-test passed`)

## PR evidence checklist

- Real-LLM trajectories: N/A - repo automation allowlist-only change; no agent/action/prompt/model behavior changed.
- Backend logs: N/A - no backend runtime path changed.
- Frontend logs/network: N/A - no frontend runtime path changed.
- Screenshots/video: N/A - non-UI script audit change.
- Domain artifacts: N/A - no generated domain artifacts.