### PR TITLE
fix(#13714): restore shared lint formatting

### DIFF
--- a/packages/shared/src/voice/aec/echo-alignment.ts
+++ b/packages/shared/src/voice/aec/echo-alignment.ts
@@ -85,10 +85,7 @@ export function estimateEchoAlignment(
   far: Float32Array,
   options: EchoAlignmentOptions = {},
 ): EchoAlignmentEstimate {
-  const minOverlap = Math.max(
-    1,
-    Math.floor(options.minOverlapSamples ?? 4000),
-  );
+  const minOverlap = Math.max(1, Math.floor(options.minOverlapSamples ?? 4000));
   const maxOffset = Math.max(
     0,
     Math.floor(options.maxOffsetSamples ?? far.length - minOverlap),


### PR DESCRIPTION
## Summary

- Applies Biome's formatting output to `packages/shared/src/voice/aec/echo-alignment.ts`.
- Restores the package-wide `packages/shared` read-only lint gate that was failing during PR #13675 verification.

Fixes #13714.

## Evidence

- `bun run --cwd packages/shared lint:check` — pass (`Checked 349 files. No fixes applied.`)
- `bunx @biomejs/biome check packages/shared/src/voice/aec/echo-alignment.ts` — pass (`Checked 1 file. No fixes applied.`)
- `git diff --check` — pass

## PR evidence checklist

- Real-LLM trajectories: N/A - formatting-only change; no agent/action/prompt/model behavior changed.
- Backend logs: N/A - no backend runtime path changed.
- Frontend logs/network: N/A - no frontend runtime path changed.
- Screenshots/video: N/A - non-UI formatting change.
- Domain artifacts: N/A - no generated runtime artifacts.