### PR TITLE
test(electrobun): cover desktop notification RPCs

### DIFF
--- a/packages/app-core/platforms/electrobun/src/background-notice.test.ts
+++ b/packages/app-core/platforms/electrobun/src/background-notice.test.ts
@@ -1,0 +1,71 @@
+/** Exercises one-shot desktop background notice behavior. */
+import { describe, expect, it, vi } from "vitest";
+import {
+  BACKGROUND_NOTICE_MARKER_FILE,
+  hasSeenBackgroundNotice,
+  markBackgroundNoticeSeen,
+  resolveBackgroundNoticeMarkerPath,
+  showBackgroundNoticeOnce,
+} from "./background-notice";
+
+function createMemoryFileSystem(initialFiles: string[] = []) {
+  const files = new Set(initialFiles);
+  return {
+    files,
+    existsSync: vi.fn((filePath: string) => files.has(filePath)),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn((filePath: string) => {
+      files.add(filePath);
+    }),
+  };
+}
+
+describe("background notice", () => {
+  it("resolves and writes the user-data marker file", () => {
+    const userDataDir = "/tmp/eliza-user-data";
+    const markerPath = resolveBackgroundNoticeMarkerPath(userDataDir);
+    const fileSystem = createMemoryFileSystem();
+
+    expect(markerPath).toBe(
+      `/tmp/eliza-user-data/${BACKGROUND_NOTICE_MARKER_FILE}`,
+    );
+    expect(hasSeenBackgroundNotice(fileSystem, userDataDir)).toBe(false);
+    expect(markBackgroundNoticeSeen(fileSystem, userDataDir)).toBe(markerPath);
+    expect(hasSeenBackgroundNotice(fileSystem, userDataDir)).toBe(true);
+    expect(fileSystem.mkdirSync).toHaveBeenCalledWith(userDataDir, {
+      recursive: true,
+    });
+    expect(fileSystem.writeFileSync).toHaveBeenCalledWith(
+      markerPath,
+      '{"seen":true}\n',
+      "utf8",
+    );
+  });
+
+  it("shows the close-to-tray notice only once", () => {
+    const userDataDir = "/tmp/eliza-user-data";
+    const fileSystem = createMemoryFileSystem();
+    const showNotification = vi.fn();
+
+    expect(
+      showBackgroundNoticeOnce({
+        fileSystem,
+        userDataDir,
+        showNotification,
+      }),
+    ).toBe(true);
+    expect(
+      showBackgroundNoticeOnce({
+        fileSystem,
+        userDataDir,
+        showNotification,
+      }),
+    ).toBe(false);
+
+    expect(showNotification).toHaveBeenCalledTimes(1);
+    expect(showNotification.mock.calls[0]?.[0]).toMatchObject({
+      title: expect.stringContaining("Still Running"),
+      body: expect.stringContaining("running in the background"),
+    });
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -612,6 +612,60 @@ describe("DesktopManager main window controls", () => {
   });
 });
 
+describe("DesktopManager notifications", () => {
+  beforeEach(() => {
+    resetDesktopManagerForTesting();
+    electrobunMock.reset();
+  });
+
+  afterEach(() => {
+    resetDesktopManagerForTesting();
+  });
+
+  it("maps notification options to Utils.showNotification and returns monotonic ids", async () => {
+    const manager = new DesktopManager();
+
+    await expect(
+      manager.showNotification({
+        title: "Build finished",
+        body: "Desktop build completed.",
+        urgency: "critical",
+        silent: false,
+      }),
+    ).resolves.toEqual({ id: "notification_1" });
+    await expect(
+      manager.showNotification({
+        title: "Quiet sync",
+        body: "Background sync completed.",
+        urgency: "low",
+        silent: true,
+      }),
+    ).resolves.toEqual({ id: "notification_2" });
+
+    expect(electrobunMock.Utils.showNotification).toHaveBeenNthCalledWith(1, {
+      title: "Build finished",
+      body: "Desktop build completed.",
+      subtitle: undefined,
+      silent: false,
+    });
+    expect(electrobunMock.Utils.showNotification).toHaveBeenNthCalledWith(2, {
+      title: "Quiet sync",
+      body: "Background sync completed.",
+      subtitle: undefined,
+      silent: true,
+    });
+  });
+
+  it("documents closeNotification as an Electrobun no-op", async () => {
+    const manager = new DesktopManager();
+
+    await expect(
+      manager.closeNotification({ id: "notification_1" }),
+    ).resolves.toBeUndefined();
+    expect(electrobunMock.Utils.showNotification).not.toHaveBeenCalled();
+  });
+});
+
 describe("DesktopManager dockless (tray-first) Dock tracking (#12184)", () => {
   const originalPlatform = process.platform;
 

--- a/packages/app-core/platforms/electrobun/src/rpc-handler-slices.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-handler-slices.ts
@@ -1,4 +1,6 @@
 /** Implements Electrobun desktop rpc handler slices ts behavior for app-core shell integration. */
+
+import { showBackgroundNoticeOnce } from "./background-notice";
 import type { DynamicViewRegistry } from "./dynamic-views/registry";
 import type { DynamicViewSessionManager } from "./dynamic-views/session-manager";
 import type {
@@ -8,7 +10,10 @@ import type {
   DynamicViewRegisterParams,
   DynamicViewUnregisterParams,
 } from "./dynamic-views/types";
-import type { DesktopManagedWindowSnapshot } from "./rpc-schema";
+import type {
+  DesktopManagedWindowSnapshot,
+  NotificationOptions,
+} from "./rpc-schema";
 import { isDetachedSurface } from "./surface-windows";
 
 type DetachedWindowSurface =
@@ -34,6 +39,17 @@ interface WindowRpcDesktop {
     alwaysOnTop?: boolean;
   }): Promise<DesktopManagedWindowSnapshot | null>;
   setManagedWindowAlwaysOnTop(id: string, flag: boolean): boolean;
+}
+
+interface NotificationRpcDesktop {
+  showNotification(options: NotificationOptions): Promise<{ id: string }>;
+  closeNotification(options: { id: string }): Promise<void>;
+}
+
+interface NotificationRpcFileSystem {
+  existsSync(filePath: string): boolean;
+  mkdirSync(dirPath: string, options?: { recursive?: boolean }): void;
+  writeFileSync(filePath: string, data: string, encoding: BufferEncoding): void;
 }
 
 export function normalizeRendererRoutePath(path: string): string {
@@ -91,6 +107,32 @@ export function buildWindowRpcHandlers({
       flag: boolean;
     }) => ({
       success: desktop.setManagedWindowAlwaysOnTop(params.id, params.flag),
+    }),
+  };
+}
+
+export function buildNotificationRpcHandlers({
+  desktop,
+  fileSystem,
+  userDataDir,
+  showNotification,
+}: {
+  desktop: NotificationRpcDesktop;
+  fileSystem: NotificationRpcFileSystem;
+  userDataDir: string;
+  showNotification: (options: { title: string; body: string }) => void;
+}) {
+  return {
+    desktopShowNotification: async (params: NotificationOptions) =>
+      desktop.showNotification(params),
+    desktopCloseNotification: async (params: { id: string }) =>
+      desktop.closeNotification(params),
+    desktopShowBackgroundNotice: async () => ({
+      shown: showBackgroundNoticeOnce({
+        fileSystem,
+        userDataDir,
+        showNotification,
+      }),
     }),
   };
 }

--- a/packages/app-core/platforms/electrobun/src/rpc-handlers.test.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-handlers.test.ts
@@ -1,9 +1,17 @@
 /** Exercises rpc handlers behavior with deterministic app-core test fixtures. */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
   buildDynamicViewRpcHandlers,
+  buildNotificationRpcHandlers,
   buildWindowRpcHandlers,
 } from "./rpc-handler-slices";
+import { CHANNEL_TO_RPC_METHOD } from "./rpc-schema";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "../../../../..");
 
 function createDesktopFixture() {
   const desktop = {
@@ -184,6 +192,126 @@ describe("window RPC handlers", () => {
       "missing-window",
       true,
     );
+  });
+});
+
+describe("notification RPC handlers", () => {
+  it("delegates show/close notification requests with exact params", async () => {
+    let nextId = 0;
+    const desktop = {
+      showNotification: vi.fn(async (params) => ({
+        id: `notification_${++nextId}`,
+        params,
+      })),
+      closeNotification: vi.fn(async () => undefined),
+    };
+    const handlers = buildNotificationRpcHandlers({
+      desktop,
+      fileSystem: {
+        existsSync: vi.fn(() => false),
+        mkdirSync: vi.fn(),
+        writeFileSync: vi.fn(),
+      },
+      userDataDir: "/tmp/eliza-user-data",
+      showNotification: vi.fn(),
+    });
+
+    await expect(
+      handlers.desktopShowNotification({
+        title: "Build finished",
+        body: "The desktop build completed.",
+        urgency: "critical",
+        silent: false,
+      }),
+    ).resolves.toMatchObject({ id: "notification_1" });
+    await expect(
+      handlers.desktopShowNotification({
+        title: "Low priority",
+        body: "No sound.",
+        urgency: "low",
+        silent: true,
+      }),
+    ).resolves.toMatchObject({ id: "notification_2" });
+    await expect(
+      handlers.desktopCloseNotification({ id: "notification_2" }),
+    ).resolves.toBeUndefined();
+
+    expect(desktop.showNotification).toHaveBeenNthCalledWith(1, {
+      title: "Build finished",
+      body: "The desktop build completed.",
+      urgency: "critical",
+      silent: false,
+    });
+    expect(desktop.showNotification).toHaveBeenNthCalledWith(2, {
+      title: "Low priority",
+      body: "No sound.",
+      urgency: "low",
+      silent: true,
+    });
+    expect(desktop.closeNotification).toHaveBeenCalledWith({
+      id: "notification_2",
+    });
+  });
+
+  it("routes the background notice through the one-shot marker path", async () => {
+    const seen = new Set<string>();
+    const fileSystem = {
+      existsSync: vi.fn((filePath: string) => seen.has(filePath)),
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn((filePath: string) => {
+        seen.add(filePath);
+      }),
+    };
+    const showNotification = vi.fn();
+    const handlers = buildNotificationRpcHandlers({
+      desktop: {
+        showNotification: vi.fn(),
+        closeNotification: vi.fn(),
+      },
+      fileSystem,
+      userDataDir: "/tmp/eliza-user-data",
+      showNotification,
+    });
+
+    await expect(handlers.desktopShowBackgroundNotice()).resolves.toEqual({
+      shown: true,
+    });
+    await expect(handlers.desktopShowBackgroundNotice()).resolves.toEqual({
+      shown: false,
+    });
+
+    expect(showNotification).toHaveBeenCalledTimes(1);
+    expect(showNotification.mock.calls[0]?.[0]).toMatchObject({
+      title: expect.stringContaining("Still Running"),
+      body: expect.stringContaining("running in the background"),
+    });
+    expect(fileSystem.mkdirSync).toHaveBeenCalledWith("/tmp/eliza-user-data", {
+      recursive: true,
+    });
+    expect(fileSystem.writeFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps renderer notification bridge strings resolvable in the schema", () => {
+    expect(CHANNEL_TO_RPC_METHOD["desktop:showNotification"]).toBe(
+      "desktopShowNotification",
+    );
+
+    for (const relative of [
+      "packages/ui/src/state/notifications/notification-store.ts",
+      "packages/ui/src/state/useChatLifecycle.ts",
+      "packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx",
+    ]) {
+      const source = readFileSync(path.join(REPO_ROOT, relative), "utf8");
+      expect(source, relative).toContain(
+        'rpcMethod: "desktopShowNotification"',
+      );
+      expect(source, relative).toContain(
+        'ipcChannel: "desktop:showNotification"',
+      );
+      expect(CHANNEL_TO_RPC_METHOD["desktop:showNotification"]).toBe(
+        "desktopShowNotification",
+      );
+    }
   });
 });
 

--- a/packages/app-core/platforms/electrobun/src/rpc-handlers.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-handlers.ts
@@ -17,7 +17,6 @@ import {
   readAgentStatusViaHttp,
 } from "./agent-status-rpc";
 import { resolveDesktopRuntimeMode } from "./api-base";
-import { showBackgroundNoticeOnce } from "./background-notice";
 import {
   composeBootProgressSnapshot,
   readAgentHealthSnapshotViaHttp,
@@ -125,6 +124,7 @@ import { getSwabbleManager } from "./native/swabble";
 import { getTalkModeManager } from "./native/talkmode";
 import {
   buildDynamicViewRpcHandlers,
+  buildNotificationRpcHandlers,
   buildWindowRpcHandlers,
 } from "./rpc-handler-slices";
 import { resolveRpcAgentPort } from "./rpc-port-resolver";
@@ -803,21 +803,13 @@ export function buildBunRpcHandlers({
       params: Parameters<typeof desktop.setOpacity>[0],
     ) => desktop.setOpacity(params),
 
-    // ---- Desktop: Notifications ----
-    desktopShowNotification: async (
-      params: Parameters<typeof desktop.showNotification>[0],
-    ) => desktop.showNotification(params),
-    desktopCloseNotification: async (
-      params: Parameters<typeof desktop.closeNotification>[0],
-    ) => desktop.closeNotification(params),
-    desktopShowBackgroundNotice: async () => ({
-      shown: showBackgroundNoticeOnce({
-        fileSystem: fs,
-        userDataDir: Utils.paths.userData,
-        showNotification: (options) => {
-          Utils.showNotification(options);
-        },
-      }),
+    ...buildNotificationRpcHandlers({
+      desktop,
+      fileSystem: fs,
+      userDataDir: Utils.paths.userData,
+      showNotification: (options) => {
+        Utils.showNotification(options);
+      },
     }),
 
     // ---- Desktop: Power ----


### PR DESCRIPTION
## Summary
- factor desktop notification RPC handlers into a testable Electrobun RPC slice used by buildBunRpcHandlers
- add RPC tests for desktopShowNotification, desktopCloseNotification, and desktopShowBackgroundNotice one-shot behavior
- add direct DesktopManager tests for Utils.showNotification payload mapping, monotonic notification ids, and the documented closeNotification no-op
- add background-notice unit coverage and a schema/renderer contract check for desktopShowNotification + desktop:showNotification callsites

Refs #13696.

## Verification
- bunx @biomejs/biome check packages/app-core/platforms/electrobun/src/rpc-handler-slices.ts packages/app-core/platforms/electrobun/src/rpc-handlers.ts packages/app-core/platforms/electrobun/src/rpc-handlers.test.ts packages/app-core/platforms/electrobun/src/background-notice.test.ts packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts --no-errors-on-unmatched
- bun run --cwd packages/app-core/platforms/electrobun test -- src/rpc-handlers.test.ts src/background-notice.test.ts src/native/desktop-window.test.ts
- bun run --cwd packages/app-core/platforms/electrobun typecheck
- git diff --check

## Remaining for #13696
- Packaged Electrobun E2E leg that backgrounds/unfocuses the packaged app, injects a high-priority notification through the real store, and asserts the OS notification spy/log seam fired.
