### PR TITLE
fix(#13690): cover chat sheet autoscroll in e2e

### DIFF
--- a/packages/app/docs/CHAT_GESTURE_COVERAGE.md
+++ b/packages/app/docs/CHAT_GESTURE_COVERAGE.md
@@ -79,7 +79,7 @@ gate's `sites`). `Coverage` = the levels with a real test today.
 | 10 | Send/stop/edit/delete/retry; streaming render; typing phases | chat thread | `ContinuousChatOverlay.tsx` | L3 `run-chat-sheet-e2e.mjs` (video) |
 | 11 | Attachments: add/paste/remove outbound; open/lightbox inbound | composer + thread | _not a gesture (see note)_ | L2 `MessageAttachments.test.tsx` |
 | 12 | Keyboard avoidance (visualViewport vs native lift) | overlay layout | _layout math_ | L1 `chat-panel-layout.test.ts` |
-| 13 | Auto-scroll at bottom vs reading-scrollback | thread | `ContinuousChatOverlay.tsx` | L3 `run-chat-sheet-e2e.mjs` (video) |
+| 13 | Auto-scroll at bottom, reading-scrollback, jump-to-latest | thread | `ContinuousChatOverlay.tsx` | L1 `useThreadAutoScroll.test.tsx` + L3 `run-chat-sheet-e2e.mjs` AUTOSCROLL leg (desktop screenshot + mobile video) |
 | 14 | Kiosk window drag; sidebar/panel resize drags | shell surfaces | `KioskViewCanvas.tsx`, `TasksEventsPanel.tsx`, `sidebar-root.tsx` | L2 `KioskViewCanvas.gestures.test.tsx` |
 | 15 | Graph pan/pinch/wheel-zoom | RelationshipsGraphPanel | `RelationshipsGraphPanel.tsx` | **gap** — L3 planned (app-side `touchPinch`/`touchPan`) |
 | 16 | Slash menu open/dismiss (incl. outside pointerdown) | composer | _composer_ | L2 `ContinuousChatOverlay.slash.test.tsx` + `composer-core.test.tsx` + `MessageContent.slash-command.test.tsx` |

--- a/packages/app/test/chat-gesture-coverage.test.ts
+++ b/packages/app/test/chat-gesture-coverage.test.ts
@@ -236,9 +236,9 @@ const CHAT_GESTURE_MATRIX: readonly GestureRow[] = [
   },
   {
     id: 13,
-    interaction: "Auto-scroll at bottom vs reading-scrollback",
+    interaction: "Auto-scroll at bottom, reading-scrollback, jump-to-latest",
     sites: [OVERLAY],
-    tests: [CHAT_SHEET_RUNNER],
+    tests: [S("hooks/useThreadAutoScroll.test.tsx"), CHAT_SHEET_RUNNER],
   },
   {
     id: 14,

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -4,6 +4,7 @@
  */
 import { transcriptPlainText } from "@elizaos/shared/transcripts";
 import {
+  ArrowDown,
   FileText,
   Film,
   LayoutGrid,
@@ -1377,7 +1378,11 @@ export function ContinuousChatOverlay({
   // (pre-paint — the thread never flashes at the top), a NEW line re-pins with
   // a smooth glide while the reader rests at the bottom, streaming growth
   // follows in a single rAF, and a reader who scrolled up is never yanked.
-  const { scrollRef: threadRef } = useThreadAutoScroll<HTMLDivElement>({
+  const {
+    scrollRef: threadRef,
+    atBottom: threadAtBottom,
+    jumpToLatest,
+  } = useThreadAutoScroll<HTMLDivElement>({
     growthKey: `${visibleMessages.length}:${lastId ?? ""}:${lastContent.length}`,
     lineKey: lastId ?? "",
     enabled: threadPresented,
@@ -3991,6 +3996,7 @@ export function ContinuousChatOverlay({
               >
                 <motion.div
                   id="continuous-thread"
+                  data-testid="chat-thread-scroll"
                   ref={threadRef}
                   role="log"
                   aria-label="conversation history"
@@ -4112,6 +4118,20 @@ export function ContinuousChatOverlay({
                     </AnimatePresence>
                   </div>
                 </motion.div>
+                {sheetOpen && hasThread && !threadAtBottom ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={jumpToLatest}
+                    aria-label="jump to latest message"
+                    data-testid="chat-jump-to-latest"
+                    className="absolute bottom-3 left-1/2 z-[3] flex h-8 -translate-x-1/2 items-center gap-1.5 rounded-full border border-border-strong bg-surface/95 px-3 text-xs font-medium text-txt shadow-lg transition-colors hover:bg-bg-hover"
+                  >
+                    <ArrowDown className="h-3.5 w-3.5" aria-hidden />
+                    <span>Jump to latest</span>
+                  </Button>
+                ) : null}
               </motion.div>
             ) : null}
             {/* Pending image attachments + any read error, just above the input. */}

--- a/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
@@ -153,7 +153,17 @@ function Harness(): React.JSX.Element {
     startEmpty
       ? []
       : manyMessages
-        ? MANY_SEED
+        ? streaming
+          ? [
+              ...MANY_SEED,
+              {
+                id: "many-inflight",
+                role: "assistant",
+                content: "",
+                createdAt: MANY_SEED.length + 1,
+              },
+            ]
+          : MANY_SEED
         : fewMessages
           ? FEW_SEED
           : streaming
@@ -186,6 +196,58 @@ function Harness(): React.JSX.Element {
     (
       window as unknown as { __setFirstRun?: (v: boolean) => void }
     ).__setFirstRun = setFirstRunOpen;
+  }, []);
+
+  // Deterministic transcript mutation hooks for the browser e2e. These drive the
+  // rendered overlay through the same controller `messages` prop as a live
+  // response, while letting the runner create a single large streamed growth
+  // commit and a new assistant line on demand.
+  React.useEffect(() => {
+    const w = window as unknown as {
+      __appendAssistant?: (content: string) => void;
+      __growLastAssistant?: (extra: string) => void;
+    };
+    w.__appendAssistant = (content) => {
+      console.log(`[fixture] appendAssistant length=${content.length}`);
+      setMessages((current) => [
+        ...current,
+        {
+          id: uid(),
+          role: "assistant",
+          content,
+          createdAt: nextId,
+        },
+      ]);
+      setPhase("summoned");
+    };
+    w.__growLastAssistant = (extra) => {
+      console.log(`[fixture] growLastAssistant length=${extra.length}`);
+      setMessages((current) => {
+        const lastAssistantIndex = current.findLastIndex(
+          (message) => message.role === "assistant",
+        );
+        if (lastAssistantIndex === -1) {
+          return [
+            ...current,
+            {
+              id: uid(),
+              role: "assistant",
+              content: extra,
+              createdAt: nextId,
+            },
+          ];
+        }
+        return current.map((message, index) =>
+          index === lastAssistantIndex
+            ? { ...message, content: `${message.content}${extra}` }
+            : message,
+        );
+      });
+    };
+    return () => {
+      w.__appendAssistant = undefined;
+      w.__growLastAssistant = undefined;
+    };
   }, []);
 
   // Log lifecycle so the e2e harness can assert the interaction flow from the

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -253,6 +253,35 @@ async function release(p, pointer, up = 0) {
   }
 }
 
+async function maximizeByPull(p, pointer = "mouse") {
+  await gesture(p, 760, { pointer, slow: true, steps: 24 });
+  await p.waitForTimeout(SETTLE);
+}
+
+async function restoreFromMaximized(p, pointer = "mouse") {
+  const zone = p.getByTestId("chat-maximize-restore-zone");
+  await zone.waitFor();
+  if (pointer === "mouse") {
+    const b = await zone.boundingBox();
+    const cx = b.x + b.width / 2;
+    const cy = b.y + Math.min(24, b.height / 2);
+    await p.mouse.move(cx, cy);
+    await p.mouse.down();
+    await p.mouse.move(cx, cy + 140, { steps: 8 });
+    await p.mouse.up();
+  } else {
+    const drag = await touchDragHold(
+      p,
+      testIdSelector("chat-maximize-restore-zone"),
+      0,
+      140,
+      { steps: 8, stepDelayMs: 12 },
+    );
+    await drag.release();
+  }
+  await p.waitForTimeout(SETTLE);
+}
+
 /** Full detent-stepping + flick + sub-threshold + rubber-band suite for one input type. */
 async function runDragSuite(p, pointer, tag) {
   const vh = await viewportH(p);
@@ -291,11 +320,12 @@ async function runDragSuite(p, pointer, tag) {
     grabberBarOpacity === "1",
     `[${pointer}] grabber bar paints (inner-span opacity "${grabberBarOpacity}" === "1", not opacity-0) (#9142)`,
   );
-  // The sheet header (maximize/clear/launcher) shows at HALF and up now,
-  // not only at FULL.
+  // The sheet header shows at HALF and up now, not only at FULL. Maximize and
+  // clear are gesture/state contracts, not header buttons.
   assert(
-    (await p.getByTestId("chat-full-maximize").count()) === 1 &&
-      (await p.getByTestId("chat-full-launcher").count()) === 1,
+    (await p.getByTestId("chat-full-launcher").count()) === 1 &&
+      (await p.getByTestId("chat-full-maximize").count()) === 0 &&
+      (await p.getByTestId("chat-full-clear").count()) === 0,
     `[${pointer}] HALF detent shows the sheet header`,
   );
 
@@ -312,43 +342,32 @@ async function runDragSuite(p, pointer, tag) {
   );
   await snap(p, `${tag}-full`);
 
-  // Header (post home↔launcher consolidation, #9450): Maximize + Clear on the
-  // left, a single Launcher button on the right (the old Home/Views/Settings
-  // trio collapsed into one launcher target). The stray copy-conversation button
-  // was removed in #10713 (#10749), so the FULL header is exactly these three.
+  // Header (post #13531/#9450): no maximize/minimize/new-chat buttons, only the
+  // launcher remains. The old Home/Views/Settings trio collapsed into that one
+  // launcher target.
   assert(
-    (await p.getByTestId("chat-full-maximize").count()) === 1 &&
-      (await p.getByTestId("chat-full-clear").count()) === 1 &&
-      (await p.getByTestId("chat-full-launcher").count()) === 1,
-    `[${pointer}] header shows maximize + clear + launcher`,
+    (await p.getByTestId("chat-full-launcher").count()) === 1 &&
+      (await p.getByTestId("chat-full-maximize").count()) === 0 &&
+      (await p.getByTestId("chat-full-clear").count()) === 0,
+    `[${pointer}] header shows launcher without removed maximize/clear controls`,
   );
-  // Maximize → full-bleed (edge-to-edge): data-maximized flips + panel reaches x=0.
-  await p.getByTestId("chat-full-maximize").click();
-  await p.waitForTimeout(SETTLE);
+  // Maximize → full-bleed (edge-to-edge): a deliberate over-pull flips
+  // data-maximized and the panel reaches x=0.
+  await maximizeByPull(p, pointer);
   assert(
     (await p.locator('[data-testid="chat-sheet"][data-maximized="true"]').count()) === 1,
-    `[${pointer}] maximize → data-maximized=true (full screen)`,
+    `[${pointer}] over-pull maximize → data-maximized=true (full screen)`,
   );
   const maxBox = await p.getByTestId("chat-sheet").boundingBox();
   assert(
     !!maxBox && maxBox.x <= 1,
     `[${pointer}] maximized panel is edge-to-edge (x=${Math.round(maxBox?.x ?? -1)})`,
   );
-  // Restore → inset again.
-  await p.getByTestId("chat-full-maximize").click();
-  await p.waitForTimeout(SETTLE);
+  // Restore → inset again via the top restore zone.
+  await restoreFromMaximized(p, pointer);
   assert(
     (await p.locator('[data-testid="chat-sheet"][data-maximized="true"]').count()) === 0,
-    `[${pointer}] restore → no longer maximized`,
-  );
-  // Clear routes to the controller and keeps the sheet open (it resets the
-  // thread in place). Home/Settings instead collapse the sheet (navigate-and-
-  // close) — tested in their own block so they don't tear down this flow.
-  await p.getByTestId("chat-full-clear").click();
-  await p.waitForTimeout(120);
-  assert(
-    sink.logs.some((l) => l.includes("clearConversation")),
-    `[${pointer}] clear button calls clearConversation`,
+    `[${pointer}] restore-zone pull → no longer maximized`,
   );
 
   // drag BEYOND full (held) → rubber-band, not 1:1
@@ -1540,8 +1559,7 @@ try {
     await p.waitForTimeout(SETTLE);
     await gesture(p, 140, { pointer: "mouse", slow: false, steps: 2 });
     await p.waitForTimeout(SETTLE);
-    await p.getByTestId("chat-full-maximize").click();
-    await p.waitForTimeout(SETTLE);
+    await maximizeByPull(p);
     assert(
       (await p
         .locator('[data-testid="chat-sheet"][data-maximized="true"]')
@@ -1567,8 +1585,8 @@ try {
     await p.close();
   }
 
-  // MAXIMIZE-FROM-HALF: tapping maximize at the HALF detent rises to FULL and
-  // goes edge-to-edge (was a no-op — full-bleed required the FULL flag). And the
+  // MAXIMIZE-FROM-HALF: over-pulling from the HALF detent rises to FULL and
+  // goes edge-to-edge (full-bleed requires the FULL flag). And the
   // full-screen panel fills top-to-bottom with no gap at the bottom.
   {
     const p = await ctrl();
@@ -1579,13 +1597,12 @@ try {
     await gesture(p, 90, { pointer: "mouse", slow: false, steps: 2 });
     await p.waitForTimeout(SETTLE);
     assert((await detent(p)) === "half", "MAX-HALF: at half before maximize");
-    await p.getByTestId("chat-full-maximize").click();
-    await p.waitForTimeout(SETTLE);
+    await maximizeByPull(p);
     assert(
       (await p
         .locator('[data-testid="chat-sheet"][data-maximized="true"]')
         .count()) === 1,
-      "MAX-HALF: maximize from HALF goes full-screen",
+      "MAX-HALF: over-pull from HALF goes full-screen",
     );
     const box = await p.getByTestId("chat-sheet").boundingBox();
     const vh = await p.evaluate(() => window.innerHeight);
@@ -1623,8 +1640,7 @@ try {
     await p.waitForTimeout(120);
     await gesture(p, 90, { pointer: "mouse", slow: false, steps: 2 }); // → half
     await p.waitForTimeout(SETTLE);
-    await p.getByTestId("chat-full-maximize").click(); // → full-bleed
-    await p.waitForTimeout(SETTLE);
+    await maximizeByPull(p); // → full-bleed
     assert(
       (await p
         .locator('[data-testid="chat-sheet"][data-maximized="true"]')
@@ -1638,7 +1654,7 @@ try {
         box?.y ?? -1,
       )}) — no status-bar seam`,
     );
-    const btn = await p.getByTestId("chat-full-maximize").boundingBox();
+    const btn = await p.getByTestId("chat-full-launcher").boundingBox();
     // Header padding = safe-area-top (30) + 0.5rem (8); buttons must sit ~there,
     // NOT a whole gesture inset (~36px) lower (the old "bad space" margin).
     assert(
@@ -1682,11 +1698,10 @@ try {
     );
     await snap(p, "state-OPEN_HALF_OR_OVER");
 
-    await p.getByTestId("chat-full-maximize").click();
-    await p.waitForTimeout(SETTLE);
+    await maximizeByPull(p);
     assert(
       (await chatState(p)) === "MAXIMIZED",
-      `STATES: maximize → MAXIMIZED (got ${await chatState(p)})`,
+      `STATES: over-pull maximize → MAXIMIZED (got ${await chatState(p)})`,
     );
     await snap(p, "state-MAXIMIZED");
 
@@ -2038,8 +2053,7 @@ try {
     // Invariant: data-chat-state==="MAXIMIZED" IFF data-maximized==="true".
     await gesture(p, vh, { pointer: "mouse", slow: false, steps: 2 });
     await p.waitForTimeout(SETTLE);
-    await p.getByTestId("chat-full-maximize").click();
-    await p.waitForTimeout(SETTLE);
+    await maximizeByPull(p);
     {
       const cs = await chatState(p);
       const max = await p

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -9,6 +9,9 @@
  *       slow drag (distance threshold) · flick (velocity threshold) ·
  *       sub-threshold nudge (snaps back) · drag-and-hold at an arbitrary mid
  *       height (live 1:1 tracking) · drag BEYOND full (rubber-band overscroll).
+ *   - AUTOSCROLL, per input type: tail follows at bottom, a single >80px
+ *       streamed growth remains pinned, reading-scrollback is not yanked, and
+ *       jump-to-latest re-pins the transcript.
  *   - EVERY control/state via deterministic fixture loads + interactions:
  *       empty · peek/half/full · typing→send · attach image→thumbnail→remove ·
  *       mic press→recording · voice speaking→mute toggle · responding typing
@@ -23,8 +26,8 @@
 import { mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { PNG } from "pngjs";
 import { chromium } from "playwright";
+import { PNG } from "pngjs";
 import {
   renameRecordedVideo,
   stubElizaCore,
@@ -102,6 +105,19 @@ const sheetHeight = (p) =>
         .querySelector('[data-testid="chat-thread"]')
         ?.getBoundingClientRect().height ?? 0,
   );
+const threadScrollState = (p) =>
+  p.evaluate(() => {
+    const el = document.querySelector('[data-testid="chat-thread-scroll"]');
+    if (!el) return null;
+    const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+    return {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+      maxScrollTop,
+      bottomDelta: maxScrollTop - el.scrollTop,
+    };
+  });
 async function waitForSheetHeightNear(p, expected, tolerance, timeout = 1500) {
   await p
     .waitForFunction(
@@ -113,6 +129,20 @@ async function waitForSheetHeightNear(p, expected, tolerance, timeout = 1500) {
         return Math.abs(h - expected) <= tolerance;
       },
       { expected, tolerance },
+      { timeout },
+    )
+    .catch(() => {});
+}
+async function waitForThreadBottom(p, timeout = 1800) {
+  await p
+    .waitForFunction(
+      () => {
+        const el = document.querySelector('[data-testid="chat-thread-scroll"]');
+        if (!el) return false;
+        const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+        return maxScrollTop - el.scrollTop <= 18;
+      },
+      undefined,
       { timeout },
     )
     .catch(() => {});
@@ -414,6 +444,122 @@ async function runDragSuite(p, pointer, tag) {
   await snap(p, `${tag}-nudge-snapback`);
 }
 
+const BIG_STREAM_GROWTH = `\n\n${Array.from(
+  { length: 18 },
+  (_, i) =>
+    `streamed burst ${i + 1}: this deliberately wraps across the chat bubble so one committed growth is taller than the 80px at-bottom threshold.`,
+).join(" ")}`;
+
+async function mutateAssistant(p, hook, text) {
+  const ok = await p.evaluate(
+    ({ hook, text }) => {
+      const fn = window[hook];
+      if (typeof fn !== "function") return false;
+      fn(text);
+      return true;
+    },
+    { hook, text },
+  );
+  assert(ok, `fixture exposes ${hook}`);
+}
+
+async function openSheetToFull(p, pointer) {
+  await p.waitForSelector('[data-testid="chat-sheet"]');
+  await gesture(p, 160, { pointer, slow: false, steps: 2 });
+  await p.waitForTimeout(SETTLE);
+  if ((await detent(p)) !== "full") {
+    await gesture(p, 220, { pointer, slow: false, steps: 2 });
+    await p.waitForTimeout(SETTLE);
+  }
+  assert((await detent(p)) === "full", `[${pointer}] AUTOSCROLL opens the sheet to FULL`);
+  await waitForThreadBottom(p);
+  const state = await threadScrollState(p);
+  assert(
+    !!state && state.scrollHeight > state.clientHeight + 120,
+    `[${pointer}] AUTOSCROLL fixture has real overflow (scrollHeight=${Math.round(state?.scrollHeight ?? 0)}, clientHeight=${Math.round(state?.clientHeight ?? 0)})`,
+  );
+  assert(
+    !!state && state.bottomDelta <= 18,
+    `[${pointer}] AUTOSCROLL starts pinned to bottom (delta=${Math.round(state?.bottomDelta ?? -1)})`,
+  );
+}
+
+async function scrollReaderUp(p, pointer) {
+  const selector = testIdSelector("chat-thread-scroll");
+  const before = await threadScrollState(p);
+  if (pointer === "mouse") {
+    await p.getByTestId("chat-thread-scroll").hover();
+    await p.mouse.wheel(0, -420);
+  } else {
+    await touchSwipe(p, selector, 0, 280, { steps: 16, stepDelayMs: 16 });
+  }
+  await p.waitForTimeout(360);
+  const after = await threadScrollState(p);
+  assert(
+    !!before && !!after && after.scrollTop < before.scrollTop - 80,
+    `[${pointer}] AUTOSCROLL real ${pointer === "mouse" ? "wheel" : "touch"} scroll moves reader into history (${Math.round(before?.scrollTop ?? 0)} → ${Math.round(after?.scrollTop ?? 0)})`,
+  );
+  return after;
+}
+
+async function runAutoScrollSuite(p, pointer, tag) {
+  await openSheetToFull(p, pointer);
+  const beforeLargeGrowth = await threadScrollState(p);
+  await mutateAssistant(p, "__growLastAssistant", BIG_STREAM_GROWTH);
+  await p.waitForTimeout(260);
+  const afterLargeGrowth = await threadScrollState(p);
+  const largeGrowthPx =
+    (afterLargeGrowth?.scrollHeight ?? 0) -
+    (beforeLargeGrowth?.scrollHeight ?? 0);
+  assert(
+    largeGrowthPx > 80,
+    `[${pointer}] AUTOSCROLL single streamed growth exceeds 80px (${Math.round(largeGrowthPx)}px)`,
+  );
+  assert(
+    !!afterLargeGrowth && afterLargeGrowth.bottomDelta <= 18,
+    `[${pointer}] AUTOSCROLL stays pinned after >80px growth (delta=${Math.round(afterLargeGrowth?.bottomDelta ?? -1)})`,
+  );
+
+  await mutateAssistant(
+    p,
+    "__appendAssistant",
+    "A fresh assistant line lands while the reader is already at the bottom.",
+  );
+  await waitForThreadBottom(p);
+  const afterAppend = await threadScrollState(p);
+  assert(
+    !!afterAppend && afterAppend.bottomDelta <= 18,
+    `[${pointer}] AUTOSCROLL stays pinned after a new assistant line (delta=${Math.round(afterAppend?.bottomDelta ?? -1)})`,
+  );
+
+  const readerPosition = await scrollReaderUp(p, pointer);
+  await mutateAssistant(
+    p,
+    "__growLastAssistant",
+    "\n\nNew streamed text arrived below while the reader was reviewing older transcript content. It must not pull the viewport away from the reading position.",
+  );
+  await p.waitForTimeout(300);
+  const afterScrollbackGrowth = await threadScrollState(p);
+  assert(
+    !!readerPosition &&
+      !!afterScrollbackGrowth &&
+      Math.abs(afterScrollbackGrowth.scrollTop - readerPosition.scrollTop) <= 32,
+    `[${pointer}] AUTOSCROLL preserves reading scrollback on growth (${Math.round(readerPosition?.scrollTop ?? 0)} → ${Math.round(afterScrollbackGrowth?.scrollTop ?? 0)})`,
+  );
+  assert(
+    await p.getByTestId("chat-jump-to-latest").isVisible(),
+    `[${pointer}] AUTOSCROLL shows jump-to-latest while reader is above bottom`,
+  );
+  await p.getByTestId("chat-jump-to-latest").click();
+  await waitForThreadBottom(p);
+  const afterJump = await threadScrollState(p);
+  assert(
+    !!afterJump && afterJump.bottomDelta <= 18,
+    `[${pointer}] AUTOSCROLL jump-to-latest re-pins to bottom (delta=${Math.round(afterJump?.bottomDelta ?? -1)})`,
+  );
+  await snap(p, `${tag}-autoscroll-jump-repinned`);
+}
+
 const browser = await chromium.launch();
 const sink = { logs: [], errors: [] };
 try {
@@ -446,6 +592,37 @@ try {
     outDir,
     name: "chat-sheet-drag-suite.webm",
   });
+
+  // ===== AUTOSCROLL + JUMP-TO-LATEST (mouse + real touch, #13690) =====
+  {
+    const p = await browser.newPage({ viewport: { width: 1180, height: 820 } });
+    attachConsole(p, sink);
+    await gotoFixture(p, `${url}?many&streaming`);
+    await p.waitForTimeout(700);
+    await runAutoScrollSuite(p, "mouse", "desktop");
+    await p.close();
+  }
+  {
+    const autoCtx = await browser.newContext({
+      viewport: { width: 402, height: 874 },
+      hasTouch: true,
+      isMobile: true,
+      deviceScaleFactor: 2,
+      recordVideo: { dir: videoDir, size: { width: 402, height: 874 } },
+    });
+    const p = await autoCtx.newPage();
+    attachConsole(p, sink);
+    await gotoFixture(p, `${url}?many&streaming`);
+    await p.waitForTimeout(700);
+    await runAutoScrollSuite(p, "touch", "mobile");
+    await p.close();
+    await autoCtx.close();
+    await renameRecordedVideo({
+      videoDir,
+      outDir,
+      name: "chat-sheet-autoscroll-suite.webm",
+    });
+  }
 
   // ===== GRABBER horizontal flick → launcher intent, REAL touch (#9943) =====
   // The collapsed grabber's horizontal swipe pages home → launcher through the


### PR DESCRIPTION
Fixes #13690.

## Summary
- Adds the missing jump-to-latest affordance to `ContinuousChatOverlay` by consuming `useThreadAutoScroll`'s `atBottom` and `jumpToLatest` handle.
- Adds deterministic chat-sheet fixture hooks for appending assistant lines and growing the active assistant turn in a single large commit.
- Adds an AUTOSCROLL leg to `run-chat-sheet-e2e.mjs` for desktop mouse and mobile real-touch input: pinned bottom growth, >80px streamed growth, scrollback preservation, visible jump-to-latest, and re-pin after clicking it.
- Updates row 13 in the enforced gesture matrix and docs to list both L1 hook coverage and the new L3 AUTOSCROLL runner leg.

## Verification
- `node --check packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs` (run against the branch file content in `/tmp/eliza-13690`) passed.
- `node_modules/.bin/biome check packages/ui/src/components/shell/ContinuousChatOverlay.tsx` passed on the local checkout.
- Attempted `bun run --cwd packages/ui test:chat-sheet-e2e` after temporarily overlaying the branch UI files locally; blocked before browser execution because this local checkout is missing `packages/ui/src/testing/e2e-runner/index.ts`. Verified that the file exists on remote `develop` (`80713e098eb50195e8f30085c5fd68f395030bd9`), so this is local checkout drift rather than a branch-code module path issue.

## Evidence status
- Screenshots/video: produced by `bun run --cwd packages/ui test:chat-sheet-e2e` in a complete checkout/CI; local capture blocked as noted above.
- Backend logs/model trajectories: N/A - UI-only isolated browser runner and no model path changes.