### PR TITLE
ci: fall back to protoc GitHub release when the Ubuntu mirror fails

### DIFF
--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -81,6 +81,7 @@ runs:
       shell: bash
       env:
         FORCE_PROTOC_GITHUB_FALLBACK: ${{ inputs.force-protoc-github-fallback }}
+        PROTOC_RUNNER_ARCH: ${{ runner.arch }}
       run: |
         if [ "${FORCE_PROTOC_GITHUB_FALLBACK}" != "true" ] && command -v protoc >/dev/null 2>&1; then
           echo "protoc already installed: $(protoc --version)"
@@ -118,13 +119,26 @@ runs:
           # build dependency from trusting an unauthenticated release asset.
           echo "apt unavailable/failed; installing protoc from GitHub release (sudo-free)"
           protoc_version=27.3
-          protoc_sha256=6dab2adab83f915126cab53540d48957c40e9e9023969c3e84d44bfb936c7741
+          case "${PROTOC_RUNNER_ARCH}" in
+            X64)
+              protoc_asset_arch=x86_64
+              protoc_sha256=6dab2adab83f915126cab53540d48957c40e9e9023969c3e84d44bfb936c7741
+              ;;
+            ARM64)
+              protoc_asset_arch=aarch_64
+              protoc_sha256=bdad36f3ad7472281d90568c4956ea2e203c216e0de005c6bd486f1920f2751c
+              ;;
+            *)
+              echo "unsupported Linux runner architecture for protoc fallback: ${PROTOC_RUNNER_ARCH}"
+              exit 1
+              ;;
+          esac
           dest="${RUNNER_TEMP:-/tmp}/protoc"
           rm -rf "$dest"
           mkdir -p "$dest"
           for attempt in 1 2 3; do
             if curl -fsSL --retry 5 --retry-all-errors -o "$dest/protoc.zip" \
-                "https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-x86_64.zip"; then
+                "https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-${protoc_asset_arch}.zip"; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then

--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -89,12 +89,6 @@ runs:
         apt_ok=""
         if [ "${FORCE_PROTOC_GITHUB_FALLBACK}" = "true" ]; then
           echo "forcing protoc GitHub fallback for setup action self-test"
-        # Only attempt apt when passwordless sudo actually works. GitHub-hosted
-        # runners have it; the self-hosted hetzner-robot runners currently do
-        # NOT, so every `sudo` call fails with "sudo: a password is required",
-        # which reds the entire develop test matrix at this setup step (the exact
-        # wedge that is forcing admin-bypass merges). When apt isn't usable we
-        # fall back to a fully sudo-free protoc install below.
         elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
           # GitHub-hosted Ubuntu images include Microsoft feeds that are unrelated
           # to our protoc install. If those feeds return 403, apt-get update fails

--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Whether to install protoc for Rust plugin builds"
     required: false
     default: "true"
+  force-protoc-github-fallback:
+    description: "Force the pinned GitHub protoc fallback path for setup action self-tests"
+    required: false
+    default: "false"
   install-command:
     description: "Dependency install command"
     required: false
@@ -75,19 +79,23 @@ runs:
       # Without protoc, `cargo test` fails before any test runs.
       if: ${{ inputs.install-protoc == 'true' && runner.os == 'Linux' }}
       shell: bash
+      env:
+        FORCE_PROTOC_GITHUB_FALLBACK: ${{ inputs.force-protoc-github-fallback }}
       run: |
-        if command -v protoc >/dev/null 2>&1; then
+        if [ "${FORCE_PROTOC_GITHUB_FALLBACK}" != "true" ] && command -v protoc >/dev/null 2>&1; then
           echo "protoc already installed: $(protoc --version)"
           exit 0
         fi
         apt_ok=""
+        if [ "${FORCE_PROTOC_GITHUB_FALLBACK}" = "true" ]; then
+          echo "forcing protoc GitHub fallback for setup action self-test"
         # Only attempt apt when passwordless sudo actually works. GitHub-hosted
         # runners have it; the self-hosted hetzner-robot runners currently do
         # NOT, so every `sudo` call fails with "sudo: a password is required",
         # which reds the entire develop test matrix at this setup step (the exact
         # wedge that is forcing admin-bypass merges). When apt isn't usable we
         # fall back to a fully sudo-free protoc install below.
-        if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
           # GitHub-hosted Ubuntu images include Microsoft feeds that are unrelated
           # to our protoc install. If those feeds return 403, apt-get update fails
           # before it can use the Ubuntu repositories we actually need.
@@ -112,11 +120,13 @@ runs:
         if [ -z "$apt_ok" ]; then
           # Sudo-free fallback: fetch the pinned protoc release into a user-writable
           # dir and put it on PATH. Works on self-hosted runners without passwordless
-          # sudo. The repo has no .proto sources and pins no protoc version
-          # (prost-build accepts any recent protoc), so a stable release suffices.
+          # sudo or when Ubuntu mirrors fail. The checksum keeps the privileged
+          # build dependency from trusting an unauthenticated release asset.
           echo "apt unavailable/failed; installing protoc from GitHub release (sudo-free)"
           protoc_version=27.3
+          protoc_sha256=6dab2adab83f915126cab53540d48957c40e9e9023969c3e84d44bfb936c7741
           dest="${RUNNER_TEMP:-/tmp}/protoc"
+          rm -rf "$dest"
           mkdir -p "$dest"
           for attempt in 1 2 3; do
             if curl -fsSL --retry 5 --retry-all-errors -o "$dest/protoc.zip" \
@@ -129,6 +139,7 @@ runs:
             fi
             sleep $((attempt * 10))
           done
+          echo "${protoc_sha256}  $dest/protoc.zip" | sha256sum -c -
           unzip -o "$dest/protoc.zip" -d "$dest" 'bin/protoc' 'include/*'
           chmod +x "$dest/bin/protoc"
           echo "$dest/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/setup-bun-workspace-self-test.yml
+++ b/.github/workflows/setup-bun-workspace-self-test.yml
@@ -1,0 +1,34 @@
+name: Setup Bun Workspace Self-Test
+
+on:
+  pull_request:
+    paths:
+      - ".github/actions/setup-bun-workspace/**"
+      - ".github/workflows/setup-bun-workspace-self-test.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  protoc-github-fallback:
+    name: forced protoc GitHub fallback
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Exercise pinned protoc fallback path
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          setup-python: "false"
+          install-protoc: "true"
+          force-protoc-github-fallback: "true"
+          install-native-deps: "false"
+          install-command: "true"
+          run-postinstall: "false"
+          init-submodules: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"


### PR DESCRIPTION
## Problem

The shared `setup-bun-workspace` action installs `protobuf-compiler` via apt on **every** test lane. That step is already maximally apt-hardened (Microsoft feeds disabled, `Acquire::ForceIPv4`, `Acquire::Retries=5`, 3 outer attempts) — yet Ubuntu mirrors still intermittently fail to serve the package, and because the step is shared, **one mirror hiccup reds the entire develop `test.yml` matrix at once**.

Observed live on develop — a wave of develop-push runs all failing identically:

```
apt install of protobuf-compiler failed after 3 attempts
##[error]Process completed with exit code 1.
```

(Newly visible because #12337 stopped develop coverage runs from cancelling each other, so these completions surface instead of being masked by cancellation.)

## Fix

When apt still fails after its 3 hardened attempts, **fall back to the pinned protoc release from GitHub** (served by the same infra as Actions, independent of the Ubuntu mirror) instead of `exit 1`.

- **Happy path unchanged** — if apt succeeds, nothing new runs. The fallback can only convert a current hard failure into a success.
- The repo has **no `.proto` sources and pins no protoc version**; `prost-build` (the only consumer, via the crates.io `elizaos` crate build script) accepts any recent protoc.

## Verification

Fallback logic tested end-to-end locally:

```
download OK (3235873 bytes)
unzip OK
protoc version: libprotoc 27.3
```

Release asset URL confirmed reachable (HTTP 200):
`https://github.com/protocolbuffers/protobuf/releases/download/v27.3/protoc-27.3-linux-x86_64.zip`

## Evidence
CI-config-only change to a composite action. N/A for UI/model/audio/domain artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)