### PR TITLE
fix(#13475): attribute Android agent deaths + auto-provision the SIGSYS shim

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -2696,6 +2696,102 @@ public class ElizaAgentService extends Service {
     }
 
     /**
+     * Human attribution for an agent child exit code. Codes >= 128 are
+     * 128+signal deaths; the three that actually occur on-device get named
+     * causes so the startup card can say what happened instead of the
+     * generic "transport hung" (#13475): 159 = SIGSYS is the seccomp filter
+     * killing an unshimmed runtime, 137 = SIGKILL is lmkd/OOM or an explicit
+     * pkill, 143 = SIGTERM is a service stop/restart landing mid-boot.
+     */
+    private static String describeAgentExit(String exitCode) {
+        int code;
+        try {
+            code = Integer.parseInt(exitCode.trim());
+        } catch (NumberFormatException error) {
+            return "exit " + exitCode;
+        }
+        if (code < 128) {
+            return "exit " + code;
+        }
+        int signal = code - 128;
+        switch (signal) {
+            case 31:
+                return "SIGSYS (seccomp-blocked syscall - runtime built without the SIGSYS shim? #13475)";
+            case 9:
+                return "SIGKILL (lmkd/OOM or pkill)";
+            case 15:
+                return "SIGTERM (service stop/restart during boot)";
+            case 11:
+                return "SIGSEGV (native crash)";
+            default:
+                return "signal " + signal + " (exit " + code + ")";
+        }
+    }
+
+    /**
+     * Scan the restart-diagnostics JSONL for the newest bridge-side fatal
+     * breadcrumb (`agent-fatal` / `agent-terminated-by-signal`, written by the
+     * capacitor bridge) in this launch's window, so an in-process JS fatal is
+     * attributed alongside the child's exit code.
+     */
+    private String readLatestAgentFatal(long launchStartedAtMs, String startupTraceId) {
+        File log = new File(agentRoot(), AGENT_RESTART_DIAGNOSTICS_NAME);
+        if (!log.isFile()) {
+            return null;
+        }
+        long maxBytes = Math.min(log.length(), AGENT_RESTART_DIAGNOSTICS_MAX_BYTES);
+        if (maxBytes <= 0L) {
+            return null;
+        }
+        byte[] bytes = new byte[(int) maxBytes];
+        int read = 0;
+        try (FileInputStream input = new FileInputStream(log)) {
+            while (read < bytes.length) {
+                int n = input.read(bytes, read, bytes.length - read);
+                if (n < 0) break;
+                read += n;
+            }
+        } catch (IOException error) {
+            // error-policy:J7 diagnostic JSONL read failures must not kill the watchdog loop.
+            Log.w(TAG, "Could not read agent fatal diagnostics", error);
+            return null;
+        }
+        String content = new String(bytes, 0, read, StandardCharsets.UTF_8);
+        String latest = null;
+        long cutoffMs = Math.max(0L, launchStartedAtMs - 2_000L);
+        for (String line : content.split("\\n")) {
+            if (line.trim().isEmpty()) {
+                continue;
+            }
+            try {
+                JSONObject json = new JSONObject(line);
+                String event = json.optString("event", "");
+                if (!"agent-fatal".equals(event) && !"agent-terminated-by-signal".equals(event)) {
+                    continue;
+                }
+                long timestampMs = json.optLong("ts", 0L);
+                if (timestampMs > 0L && timestampMs < cutoffMs) {
+                    continue;
+                }
+                JSONObject details = json.optJSONObject("details");
+                String eventTraceId = details != null ? details.optString("startupTraceId", "") : "";
+                if (startupTraceId != null
+                        && !startupTraceId.isEmpty()
+                        && !eventTraceId.isEmpty()
+                        && !startupTraceId.equals(eventTraceId)) {
+                    continue;
+                }
+                String kind = details != null ? details.optString("kind", event) : event;
+                String message = details != null ? details.optString("message", "") : "";
+                latest = message.isEmpty() ? kind : kind + ": " + message;
+            } catch (JSONException ignored) {
+                // error-policy:J3 partial or malformed diagnostic lines are invalid records; keep scanning.
+            }
+        }
+        return latest;
+    }
+
+    /**
      * Drain a process stream into the agent log file and tee to logcat.
      * One thread per stream; both exit cleanly when the stream closes
      * (process death) or the thread is interrupted.
@@ -2833,16 +2929,32 @@ public class ElizaAgentService extends Service {
                 }
                 AgentChildExit childExit = readLatestAgentChildExit(launchStartedAtMs, startupTraceId);
                 if (childExit != null) {
+                    String attribution = describeAgentExit(childExit.exitCode);
+                    String fatal = readLatestAgentFatal(launchStartedAtMs, startupTraceId);
                     Map<String, String> details = new LinkedHashMap<>();
                     details.put("launchStartedAtMs", String.valueOf(launchStartedAtMs));
                     details.put("startupTraceId", String.valueOf(startupTraceId));
                     details.put("childExitTimestampMs", String.valueOf(childExit.timestampMs));
                     details.put("childPid", childExit.childPid);
                     details.put("exitCode", childExit.exitCode);
+                    details.put("attribution", attribution);
+                    if (fatal != null) {
+                        details.put("agentFatal", fatal);
+                    }
                     appendDiagnosticEvent("detached-agent-child-exited-before-ready", details);
+                    // The death is user-visible: the status (and its
+                    // notification) says WHAT killed the agent instead of
+                    // leaving "starting" up until the generic timeout card.
+                    synchronized (processLock) {
+                        currentStatus = "agent exited: " + attribution;
+                    }
+                    updateNotification();
                     Log.w(TAG, "Detached agent child exited before readiness"
                         + " (pid=" + childExit.childPid
-                        + " code=" + childExit.exitCode + "). Scheduling restart.");
+                        + " code=" + childExit.exitCode
+                        + " cause=" + attribution
+                        + (fatal != null ? " fatal=" + fatal : "")
+                        + "). Scheduling restart.");
                     scheduleRestart();
                     return;
                 }

--- a/packages/app-core/scripts/lib/stage-android-agent.mjs
+++ b/packages/app-core/scripts/lib/stage-android-agent.mjs
@@ -870,6 +870,106 @@ function writeIfChanged(target, content) {
  *
  * Exported for testing.
  */
+/**
+ * Best-effort auto-provision of the compiled SIGSYS shim: download the pinned
+ * zig 0.13.0 toolchain into the eliza cache (same auto-download pattern this
+ * script already uses for bun + the Alpine loader set) and run
+ * compile-shim.mjs for the ABI. Returns true when the shim cache exists
+ * afterwards. Failures return false — the caller decides whether that is
+ * fatal (stock-Android app builds) or tolerated (explicit opt-out).
+ */
+export function autoProvisionSeccompShim({
+  androidAbi,
+  cacheDir = SECCOMP_SHIM_CACHE_DIR,
+  log,
+}) {
+  // Operator/test escape: never download or compile (air-gapped builders,
+  // hermetic tests). The missing-shim hard error downstream still applies.
+  if (process.env.ELIZA_SECCOMP_SHIM_NO_AUTOPROVISION === "1") {
+    return false;
+  }
+  const abiCacheDir = path.join(cacheDir, androidAbi);
+  if (fs.existsSync(path.join(abiCacheDir, "libsigsys-handler.so"))) {
+    return true;
+  }
+  const ZIG_VERSION = "0.13.0";
+  const zigPlatform =
+    process.platform === "darwin"
+      ? "macos"
+      : process.platform === "linux"
+        ? "linux"
+        : null;
+  const zigArch =
+    process.arch === "arm64"
+      ? "aarch64"
+      : process.arch === "x64"
+        ? "x86_64"
+        : null;
+  if (!zigPlatform || !zigArch) {
+    log?.(
+      `Cannot auto-provision the SIGSYS shim on ${process.platform}/${process.arch}; ` +
+        `no pinned zig ${ZIG_VERSION} build for this host.`,
+    );
+    return false;
+  }
+  const zigDirName = `zig-${zigPlatform}-${zigArch}-${ZIG_VERSION}`;
+  const zigCacheRoot = path.join(
+    os.homedir(),
+    ".cache",
+    "eliza-android-agent",
+    "zig",
+  );
+  const zigBin = path.join(zigCacheRoot, zigDirName, "zig");
+  try {
+    if (!fs.existsSync(zigBin)) {
+      fs.mkdirSync(zigCacheRoot, { recursive: true });
+      const tarball = path.join(zigCacheRoot, `${zigDirName}.tar.xz`);
+      const url = `https://ziglang.org/download/${ZIG_VERSION}/${zigDirName}.tar.xz`;
+      log?.(`Downloading pinned zig ${ZIG_VERSION} for the SIGSYS shim: ${url}`);
+      execFileSync("curl", ["-fsSL", "-o", tarball, url], {
+        stdio: ["ignore", "inherit", "inherit"],
+      });
+      execFileSync("tar", ["xJf", tarball, "-C", zigCacheRoot], {
+        stdio: ["ignore", "inherit", "inherit"],
+      });
+      fs.rmSync(tarball, { force: true });
+    }
+    const compileShim = path.join(
+      APP_CORE_ROOT,
+      "scripts",
+      "aosp",
+      "compile-shim.mjs",
+    );
+    log?.(`Compiling SIGSYS shim for ${androidAbi} with pinned zig ${ZIG_VERSION}.`);
+    execFileSync(
+      process.execPath,
+      [
+        compileShim,
+        "--abi",
+        androidAbi,
+        "--cache-dir",
+        cacheDir,
+        "--skip-if-present",
+      ],
+      {
+        stdio: ["ignore", "inherit", "inherit"],
+        env: {
+          ...process.env,
+          PATH: `${path.dirname(zigBin)}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+      },
+    );
+  } catch (error) {
+    log?.(
+      `SIGSYS shim auto-provision failed for ${androidAbi}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return false;
+  }
+  return fs.existsSync(path.join(abiCacheDir, "libsigsys-handler.so"));
+}
+
 export function stageSeccompShimForAbi({
   androidAbi,
   ldName,
@@ -880,6 +980,13 @@ export function stageSeccompShimForAbi({
   const abiCacheDir = path.join(cacheDir, androidAbi);
   const cachedWrap = path.join(abiCacheDir, ldName);
   const cachedShim = path.join(abiCacheDir, "libsigsys-handler.so");
+  if (!fs.existsSync(cachedWrap) || !fs.existsSync(cachedShim)) {
+    // Provision in place before refusing: pinned-zig download + compile-shim,
+    // the same self-sufficiency this script's bun/Alpine downloads already
+    // have, so fresh hosts and CI runners build device-valid APKs without a
+    // manual toolchain step.
+    autoProvisionSeccompShim({ androidAbi, cacheDir, log });
+  }
   if (!fs.existsSync(cachedWrap) || !fs.existsSync(cachedShim)) {
     throw new Error(
       `[stage-android-agent] Missing compiled SIGSYS shim for ${androidAbi}. ` +

--- a/packages/app-core/scripts/lib/stage-android-agent.mjs
+++ b/packages/app-core/scripts/lib/stage-android-agent.mjs
@@ -84,6 +84,26 @@ const SECCOMP_SHIM_CACHE_DIR = path.join(
   "seccomp-shim",
 );
 
+const ZIG_VERSION = "0.13.0";
+const ZIG_TOOLCHAINS = {
+  "linux/x64": {
+    dirName: "zig-linux-x86_64-0.13.0",
+    sha256: "d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea",
+  },
+  "linux/arm64": {
+    dirName: "zig-linux-aarch64-0.13.0",
+    sha256: "041ac42323837eb5624068acd8b00cd5777dac4cf91179e8dad7a7e90dd0c556",
+  },
+  "darwin/x64": {
+    dirName: "zig-macos-x86_64-0.13.0",
+    sha256: "8b06ed1091b2269b700b3b07f8e3be3b833000841bae5aa6a09b1a8b4773effd",
+  },
+  "darwin/arm64": {
+    dirName: "zig-macos-aarch64-0.13.0",
+    sha256: "46fae219656545dfaf4dce12fb4e8685cec5b51d721beee9389ab4194d43394c",
+  },
+};
+
 const ABI_TARGETS = [
   {
     androidAbi: "x86_64",
@@ -286,7 +306,7 @@ append_diag() {
   child_pid=$2
   exit_code=$3
   ts="$(date +%s 2>/dev/null || echo 0)000"
-  printf "{\"ts\":%s,\"event\":\"%s\",\"status\":\"launcher-child\",\"detachedAgentMode\":true,\"restartAttempts\":-1,\"details\":{\"childPid\":\"%s\",\"exitCode\":\"%s\",\"startupTraceId\":\"%s\"}}\\n" "$ts" "$event" "$child_pid" "$exit_code" "$startup_trace_id" >> "$diagnostics_file" 2>/dev/null || true
+  printf '{"ts":%s,"event":"%s","status":"launcher-child","detachedAgentMode":true,"restartAttempts":-1,"details":{"childPid":"%s","exitCode":"%s","startupTraceId":"%s"}}\\n' "$ts" "$event" "$child_pid" "$exit_code" "$startup_trace_id" >> "$diagnostics_file" 2>/dev/null || true
 }
 exec </dev/null >"$log_file" 2>&1
 cd "$agent_root" || exit 1
@@ -403,6 +423,10 @@ function riscv64BunArtifactSource() {
   const url = riscv64BunUrl();
   if (url) return { kind: "url", url };
   return null;
+}
+
+function resolveZigToolchain() {
+  return ZIG_TOOLCHAINS[`${process.platform}/${process.arch}`] ?? null;
 }
 
 function sha256File(filePath) {
@@ -892,43 +916,40 @@ export function autoProvisionSeccompShim({
   if (fs.existsSync(path.join(abiCacheDir, "libsigsys-handler.so"))) {
     return true;
   }
-  const ZIG_VERSION = "0.13.0";
-  const zigPlatform =
-    process.platform === "darwin"
-      ? "macos"
-      : process.platform === "linux"
-        ? "linux"
-        : null;
-  const zigArch =
-    process.arch === "arm64"
-      ? "aarch64"
-      : process.arch === "x64"
-        ? "x86_64"
-        : null;
-  if (!zigPlatform || !zigArch) {
+  const zigToolchain = resolveZigToolchain();
+  if (!zigToolchain) {
     log?.(
       `Cannot auto-provision the SIGSYS shim on ${process.platform}/${process.arch}; ` +
         `no pinned zig ${ZIG_VERSION} build for this host.`,
     );
     return false;
   }
-  const zigDirName = `zig-${zigPlatform}-${zigArch}-${ZIG_VERSION}`;
   const zigCacheRoot = path.join(
     os.homedir(),
     ".cache",
     "eliza-android-agent",
     "zig",
   );
-  const zigBin = path.join(zigCacheRoot, zigDirName, "zig");
+  const zigBin = path.join(zigCacheRoot, zigToolchain.dirName, "zig");
   try {
     if (!fs.existsSync(zigBin)) {
       fs.mkdirSync(zigCacheRoot, { recursive: true });
-      const tarball = path.join(zigCacheRoot, `${zigDirName}.tar.xz`);
-      const url = `https://ziglang.org/download/${ZIG_VERSION}/${zigDirName}.tar.xz`;
-      log?.(`Downloading pinned zig ${ZIG_VERSION} for the SIGSYS shim: ${url}`);
+      const tarball = path.join(zigCacheRoot, `${zigToolchain.dirName}.tar.xz`);
+      const url = `https://ziglang.org/download/${ZIG_VERSION}/${zigToolchain.dirName}.tar.xz`;
+      log?.(
+        `Downloading pinned zig ${ZIG_VERSION} for the SIGSYS shim: ${url}`,
+      );
       execFileSync("curl", ["-fsSL", "-o", tarball, url], {
         stdio: ["ignore", "inherit", "inherit"],
       });
+      const actualSha256 = sha256File(tarball);
+      if (actualSha256 !== zigToolchain.sha256) {
+        fs.rmSync(tarball, { force: true });
+        throw new Error(
+          `zig ${ZIG_VERSION} tarball SHA-256 mismatch: expected ` +
+            `${zigToolchain.sha256}, got ${actualSha256}`,
+        );
+      }
       execFileSync("tar", ["xJf", tarball, "-C", zigCacheRoot], {
         stdio: ["ignore", "inherit", "inherit"],
       });
@@ -940,7 +961,9 @@ export function autoProvisionSeccompShim({
       "aosp",
       "compile-shim.mjs",
     );
-    log?.(`Compiling SIGSYS shim for ${androidAbi} with pinned zig ${ZIG_VERSION}.`);
+    log?.(
+      `Compiling SIGSYS shim for ${androidAbi} with pinned zig ${ZIG_VERSION}.`,
+    );
     execFileSync(
       process.execPath,
       [
@@ -1501,5 +1524,6 @@ export const __testables = {
   riscv64BunFilePath,
   riscv64BunArtifactSource,
   riscv64BunSha256,
+  resolveZigToolchain,
   provenancePath,
 };

--- a/packages/app-core/scripts/stage-android-agent.test.mjs
+++ b/packages/app-core/scripts/stage-android-agent.test.mjs
@@ -73,6 +73,20 @@ test("riscv64 Bun artifact hash resolves from the ELIZA_BUN_RISCV64_SHA256 env",
   assert.equal(resolved, hash);
 });
 
+test("SIGSYS shim Zig auto-provision uses pinned release metadata for this host", () => {
+  const toolchain = __testables.resolveZigToolchain();
+  if (process.platform === "darwin" || process.platform === "linux") {
+    assert.ok(toolchain);
+    assert.match(
+      toolchain.dirName,
+      /^zig-(macos|linux)-(x86_64|aarch64)-0\.13\.0$/,
+    );
+    assert.match(toolchain.sha256, /^[a-f0-9]{64}$/);
+  } else {
+    assert.equal(toolchain, null);
+  }
+});
+
 test("runtime provenance manifest name is exported for APK provenance embedding", () => {
   assert.equal(
     __testables.RUNTIME_PROVENANCE_FILENAME,

--- a/packages/app-core/scripts/stage-android-agent.test.mjs
+++ b/packages/app-core/scripts/stage-android-agent.test.mjs
@@ -94,6 +94,11 @@ test("launch script records the real detached agent child status", () => {
 
 test("stock Android staging fails when the required SIGSYS shim is missing", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-seccomp-missing-"));
+  // Hermetic: an empty cache normally triggers the pinned-zig auto-provision
+  // (download + compile); force it off so this asserts the hard error that
+  // guards air-gapped/unsupported hosts.
+  const priorNoProvision = process.env.ELIZA_SECCOMP_SHIM_NO_AUTOPROVISION;
+  process.env.ELIZA_SECCOMP_SHIM_NO_AUTOPROVISION = "1";
   try {
     const abiAssetsDir = path.join(tmp, "assets", "arm64-v8a");
     fs.mkdirSync(abiAssetsDir, { recursive: true });
@@ -112,6 +117,11 @@ test("stock Android staging fails when the required SIGSYS shim is missing", () 
       /Missing compiled SIGSYS shim for arm64-v8a/,
     );
   } finally {
+    if (priorNoProvision === undefined) {
+      delete process.env.ELIZA_SECCOMP_SHIM_NO_AUTOPROVISION;
+    } else {
+      process.env.ELIZA_SECCOMP_SHIM_NO_AUTOPROVISION = priorNoProvision;
+    }
     removePathRecursive(tmp);
   }
 });

--- a/plugins/plugin-capacitor-bridge/src/android/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/bridge.ts
@@ -326,21 +326,86 @@ export async function runAndroidBridgeCli(): Promise<void> {
 		_origConsoleWarn(...args);
 	};
 
+	// Fatal breadcrumbs land in the SAME restart-diagnostics JSONL the
+	// launcher and ElizaAgentService write/read (launch.sh's shape), so a
+	// death inside the detached agent is attributable from the Java side —
+	// without this, a fatal here is visible only in android-bridge.log, a
+	// file the service never reads, and the user sees a generic "transport
+	// hung" card (#13475).
+	const _appendDiagnostics = (
+		event: string,
+		details: Record<string, string>,
+	) => {
+		try {
+			const file =
+				process.env.DIAGNOSTICS_FILE ||
+				`${process.cwd()}/agent-restart-diagnostics.jsonl`;
+			const record = {
+				ts: Date.now(),
+				event,
+				status: "agent-child",
+				detachedAgentMode: true,
+				restartAttempts: -1,
+				details: {
+					...details,
+					pid: String(process.pid),
+					startupTraceId: process.env.ELIZA_STARTUP_TRACE_ID ?? "",
+				},
+			};
+			nodeFs.appendFileSync(file, `${JSON.stringify(record)}\n`);
+		} catch {
+			// error-policy:J7 diagnostics-must-not-kill-the-loop — the breadcrumb
+			// writer can never take down the agent it is documenting; the fatal
+			// is still mirrored to android-bridge.log below.
+		}
+	};
+
 	process.on("unhandledRejection", (reason) => {
 		const msg =
 			reason instanceof Error ? reason.stack || reason.message : String(reason);
 		_logToFile(`[android-bridge] unhandledRejection: ${msg}`);
+		_appendDiagnostics("agent-fatal", {
+			kind: "unhandledRejection",
+			message: msg.slice(0, 2000),
+		});
 		console.error("[android-bridge] unhandled rejection:", msg);
 	});
 	process.on("uncaughtException", (error) => {
 		_logToFile(
 			`[android-bridge] uncaughtException: ${error.stack || error.message}`,
 		);
+		_appendDiagnostics("agent-fatal", {
+			kind: "uncaughtException",
+			message: (error.stack || error.message).slice(0, 2000),
+		});
 		console.error(
 			"[android-bridge] uncaught exception:",
 			error.stack || error.message,
 		);
+		// Installing this handler suppresses the runtime's default fatal exit;
+		// without an explicit exit a post-boot uncaught exception leaves a
+		// zombie agent the supervisor never learns about. Exit loudly instead.
+		process.exit(1);
 	});
+
+	// Mid-boot SIGTERM/SIGINT window: the graceful stop handlers register only
+	// AFTER startEliza returns, so the entire multi-second boot was previously
+	// a silent-kill window (a service stop/restart pkill landed with zero
+	// breadcrumbs). These early handlers attribute the death, then exit with
+	// the conventional 128+signal code; the post-boot graceful registration
+	// below replaces them.
+	const _earlySignalExit = (signal: "SIGTERM" | "SIGINT") => {
+		_logToFile(`[android-bridge] ${signal} during boot — exiting`);
+		_appendDiagnostics("agent-terminated-by-signal", {
+			kind: signal,
+			stage: "boot",
+		});
+		process.exit(signal === "SIGTERM" ? 143 : 130);
+	};
+	const _earlyTerm = () => _earlySignalExit("SIGTERM");
+	const _earlyInt = () => _earlySignalExit("SIGINT");
+	process.once("SIGTERM", _earlyTerm);
+	process.once("SIGINT", _earlyInt);
 
 	_logToFile("[android-bridge] importing agent module...");
 	const { startEliza, dispatchRoute, coreRoutes } = await loadAgentModule();
@@ -361,6 +426,10 @@ export async function runAndroidBridgeCli(): Promise<void> {
 	} catch (err: unknown) {
 		const msg = err instanceof Error ? err.stack || err.message : String(err);
 		_logToFile(`[android-bridge] startEliza THREW: ${msg}`);
+		_appendDiagnostics("agent-fatal", {
+			kind: "startEliza-threw",
+			message: msg.slice(0, 2000),
+		});
 		throw err;
 	} finally {
 		clearInterval(_hb);
@@ -424,6 +493,10 @@ export async function runAndroidBridgeCli(): Promise<void> {
 	const stopped = new Promise<void>((resolve) => {
 		stop = resolve;
 	});
+	// Boot is over: retire the attribute-and-exit boot handlers in favor of
+	// the graceful server stop.
+	process.removeListener("SIGTERM", _earlyTerm);
+	process.removeListener("SIGINT", _earlyInt);
 	process.once("SIGINT", () => stop?.());
 	process.once("SIGTERM", () => stop?.());
 


### PR DESCRIPTION
## What

Finishes #13475 on top of the already-landed shim build gate (#13555) and child-exit surfacing (#13485):

1. **Death attribution** — `ElizaAgentService`'s startup probe decodes child exit codes to named causes (159 SIGSYS → "seccomp-blocked syscall — runtime built without the SIGSYS shim?", 137 SIGKILL → lmkd/pkill, 143 SIGTERM → service stop/restart), folds in any bridge-side fatal breadcrumb, and surfaces the death in the service status + notification instead of leaving "starting" up until the generic Backend-Timeout card.
2. **Agent-side fatal breadcrumbs** — the capacitor bridge writes `agent-fatal` / `agent-terminated-by-signal` records into the same restart-diagnostics JSONL the service reads (uncaughtException — which now exits loudly instead of zombifying — unhandledRejection, startEliza throw), and registers SIGTERM/SIGINT from the first boot instruction so mid-boot kills exit with conventional 128+signal codes instead of dying silently.
3. **Shim auto-provision** — staging downloads the pinned zig 0.13.0 into the eliza cache and runs `compile-shim.mjs` for the ABI before #13555's hard error fires (same self-sufficiency as the script's existing bun/Alpine downloads), so fresh hosts and CI runners build device-valid APKs with no manual toolchain step. `ELIZA_SECCOMP_SHIM_NO_AUTOPROVISION=1` keeps air-gapped builders on the explicit hard-fail.

## Evidence — verified on device (Moto G Play 2024, Android 14, arm64)

- **The core fix works on real hardware.** Instrumented launch.sh captured the raw death as **exit 159 = SIGSYS**; with the staged shim, `agent.log` shows `sigsys-handler-arm64: installed` and the agent boots all the way through readiness — PGlite → plugin-sql/local-inference registration → `[eliza-api] Started without binding a TCP listener (skipListen; local-agent IPC mode)` → `[OnboardingNotifications] Seeded 3 onboarding notifications` → `deferred:complete`. This is the first time the on-device Android local agent reaches readiness (every prior build died pre-UI).
- Auto-provision exercised live against an empty cache: pinned-zig download → compile → stage succeeds. `stage-android-agent.test.mjs` 7/7 (missing-shim hard-fail test made hermetic via the no-autoprovision knob).
- `:app:compileDebugJavaWithJavac` clean; capacitor-bridge typecheck clean.

Closes #13475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
