### PR TITLE
fix: stop pruning cloud.enabled in legacy config migration so local-only mode is reachable

### DIFF
--- a/.github/issue-evidence/13726-local-only-runtime-mode.md
+++ b/.github/issue-evidence/13726-local-only-runtime-mode.md
@@ -1,0 +1,79 @@
+# 13726 — local-only runtime mode survives config migration
+
+`cloud.enabled` is the persisted opt-out bit for local-only mode. This proof
+records the config-migration and live API behavior that the fix restores:
+`migrateLegacyRuntimeConfig()` must prune legacy cloud routing fields without
+deleting `cloud.enabled`, and the disk-backed runtime-mode resolver must then
+hide `/api/cloud/*` with the standard route-mode 404.
+
+## Live API Probe
+
+Booted the real app-core API server (`startApiServer` plus a real
+`AgentRuntime`) with `eliza.json` containing exactly:
+
+```json
+{ "cloud": { "enabled": false } }
+```
+
+Before the fix on develop `035223a063`:
+
+```text
+GET /api/runtime/mode -> {"mode":"local"} [200]
+GET /api/cloud/status -> 401
+```
+
+After the fix on this branch:
+
+```text
+GET /api/runtime/mode -> {"mode":"local-only","deploymentRuntime":"local","isRemoteController":false,"remoteApiBaseConfigured":false} [200]
+GET /api/cloud/status -> {"error":"Not found"} [404]
+```
+
+The same running server re-read config on each request and resolved the other
+persisted modes correctly:
+
+```text
+{"deploymentTarget":{"runtime":"cloud","provider":"elizacloud"}} -> {"mode":"cloud"}
+{"deploymentTarget":{"runtime":"remote","remoteApiBase":"http://192.168.1.50:2138"}} -> {"mode":"remote"}
+{} -> {"mode":"local"}
+{"cloud":{"enabled":false}} -> {"mode":"local-only"}
+```
+
+Guard check: in plain `local` mode, `GET /api/cloud/status` returns 401 (auth),
+which proves the fix does not over-hide the cloud surface.
+
+## Regression Tests
+
+The branch adds two focused regression tests:
+
+- `packages/shared/src/contracts/first-run-options.migration.test.ts`
+  preserves `cloud.enabled` while still pruning legacy routing siblings.
+- `packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts` resolves
+  runtime mode through the real `loadElizaConfig()` path in a throwaway
+  `ELIZA_STATE_DIR`, the seam that was broken on develop.
+
+Local verification reported on the PR:
+
+```bash
+bun run --cwd packages/shared build:i18n
+bun run --cwd packages/core prebuild
+bun test packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts packages/app-core/src/runtime/mode/route-mode-matrix.test.ts
+# 30 pass, 0 fail
+
+bun test packages/shared/src/contracts/first-run-options.migration.test.ts
+# 3 pass, 0 fail
+
+bun test packages/core/src/contracts/contracts-alignment.test.ts packages/core/src/contracts/service-routing.test.ts
+# 13 pass, 0 fail
+
+bunx @biomejs/biome check packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts packages/shared/src/contracts/first-run-options.migration.test.ts packages/shared/src/contracts/first-run-options.ts packages/core/src/contracts/first-run-options.ts
+# pass
+
+git diff --check origin/develop...origin/pr/13721
+# pass
+```
+
+## N/A
+
+Screenshots, video, and live-LLM trajectories are N/A: this is a deterministic
+config migration and HTTP route-mode contract change, with no UI or model path.

--- a/packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts
+++ b/packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Disk-backed runtime-mode resolution through the REAL loadElizaConfig() in a
+ * throwaway ELIZA_STATE_DIR — no mocks. Guards the migration/resolver seam:
+ * `migrateLegacyRuntimeConfig` runs inside every loadElizaConfig(), so a prune
+ * of `cloud.enabled` there makes local-only unreachable from persisted config
+ * while pure-resolver tests (route-mode-matrix.test.ts) stay green.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getRuntimeModeSnapshot } from "./runtime-mode";
+
+const ENV_KEYS = [
+  "ELIZA_STATE_DIR",
+  "ELIZA_HOME",
+  "ELIZA_CONFIG_PATH",
+  "ELIZA_PERSIST_CONFIG_PATH",
+] as const;
+
+let savedEnv: Record<(typeof ENV_KEYS)[number], string | undefined>;
+let stateDir: string;
+
+const writeConfig = (config: Record<string, unknown>) => {
+  fs.writeFileSync(path.join(stateDir, "eliza.json"), JSON.stringify(config));
+};
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(
+    ENV_KEYS.map((key) => [key, process.env[key]]),
+  ) as typeof savedEnv;
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "runtime-mode-disk-"));
+  process.env.ELIZA_STATE_DIR = stateDir;
+  process.env.ELIZA_HOME = stateDir;
+  delete process.env.ELIZA_CONFIG_PATH;
+  delete process.env.ELIZA_PERSIST_CONFIG_PATH;
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  fs.rmSync(stateDir, { recursive: true, force: true });
+});
+
+describe("getRuntimeModeSnapshot (disk-backed)", () => {
+  it("resolves cloud.enabled === false on disk to local-only", () => {
+    writeConfig({ cloud: { enabled: false } });
+    expect(getRuntimeModeSnapshot().mode).toBe("local-only");
+  });
+
+  it("keeps the opt-out when migration prunes sibling legacy keys", () => {
+    writeConfig({ cloud: { enabled: false, inferenceMode: "local" } });
+    expect(getRuntimeModeSnapshot().mode).toBe("local-only");
+  });
+
+  it("resolves an empty config to plain local", () => {
+    writeConfig({});
+    expect(getRuntimeModeSnapshot().mode).toBe("local");
+  });
+
+  it("resolves a persisted cloud deploymentTarget to cloud", () => {
+    writeConfig({
+      deploymentTarget: { runtime: "cloud", provider: "elizacloud" },
+    });
+    expect(getRuntimeModeSnapshot().mode).toBe("cloud");
+  });
+});

--- a/packages/core/src/contracts/first-run-options.ts
+++ b/packages/core/src/contracts/first-run-options.ts
@@ -1079,8 +1079,13 @@ function buildElizaCloudTextRoute(args: {
 	};
 }
 
+// `cloud.enabled` is deliberately NOT in this list: it is the live cloud
+// opt-in/out flag, not a legacy routing field. `enabled === false` is the only
+// persisted representation of the local-only opt-out — the runtime-mode
+// resolver, the plugin collector, and settings-debug all read it after
+// migration, and the agent boot path still writes `enabled: true`. Pruning it
+// here would destroy the opt-out before any of those consumers run.
 const LEGACY_CLOUD_ROUTING_KEYS = [
-	"enabled",
 	"provider",
 	"remoteApiBase",
 	"remoteAccessToken",

--- a/packages/shared/src/contracts/first-run-options.migration.test.ts
+++ b/packages/shared/src/contracts/first-run-options.migration.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Legacy-runtime-config migration contract: pruning must remove only fields
+ * that have a modern replacement. `cloud.enabled === false` is the sole
+ * persisted representation of the local-only opt-out (no deploymentTarget or
+ * serviceRouting equivalent exists), and migrated configs are written back to
+ * disk by the provider-switch/first-run routes — so pruning it destroys the
+ * opt-out permanently.
+ */
+import { describe, expect, it } from "vitest";
+import { migrateLegacyRuntimeConfig } from "./first-run-options";
+
+describe("migrateLegacyRuntimeConfig", () => {
+  it("preserves cloud.enabled === false while pruning legacy routing keys", () => {
+    const config: Record<string, unknown> = {
+      cloud: { enabled: false, inferenceMode: "local", runtime: "local" },
+    };
+    migrateLegacyRuntimeConfig(config);
+    expect(config.cloud).toEqual({ enabled: false });
+  });
+
+  it("preserves cloud.enabled === true alongside its migrated routing", () => {
+    const config: Record<string, unknown> = {
+      cloud: { enabled: true, provider: "elizacloud" },
+    };
+    migrateLegacyRuntimeConfig(config);
+    expect(config.cloud).toEqual({ enabled: true });
+    expect(config.serviceRouting).toMatchObject({
+      llmText: { backend: "elizacloud", transport: "cloud-proxy" },
+    });
+  });
+
+  it("still drops a cloud block that only held legacy routing keys", () => {
+    const config: Record<string, unknown> = {
+      cloud: { inferenceMode: "local" },
+    };
+    migrateLegacyRuntimeConfig(config);
+    expect(config.cloud).toBeUndefined();
+  });
+});

--- a/packages/shared/src/contracts/first-run-options.ts
+++ b/packages/shared/src/contracts/first-run-options.ts
@@ -1079,8 +1079,13 @@ function buildElizaCloudTextRoute(args: {
   };
 }
 
+// `cloud.enabled` is deliberately NOT in this list: it is the live cloud
+// opt-in/out flag, not a legacy routing field. `enabled === false` is the only
+// persisted representation of the local-only opt-out — the runtime-mode
+// resolver, the plugin collector, and settings-debug all read it after
+// migration, and the agent boot path still writes `enabled: true`. Pruning it
+// here would destroy the opt-out before any of those consumers run.
 const LEGACY_CLOUD_ROUTING_KEYS = [
-  "enabled",
   "provider",
   "remoteApiBase",
   "remoteAccessToken",


### PR DESCRIPTION
Closes #13726

## What

`local-only` mode was unreachable from persisted config: the legacy-config migration deleted `cloud.enabled` before the runtime-mode resolver could read it. This removes `"enabled"` from `LEGACY_CLOUD_ROUTING_KEYS` (shared + core mirror) so the flag survives migration, and adds a disk-backed regression test that resolves through the real `loadElizaConfig()`.

## Root cause

- `packages/shared/src/contracts/first-run-options.ts` listed `"enabled"` in `LEGACY_CLOUD_ROUTING_KEYS`, and `pruneLegacyCloudRoutingFields` (called from `migrateLegacyRuntimeConfig`) deleted it.
- `packages/agent/src/config/config.ts` runs that migration inside **every** `loadElizaConfig()`.
- `packages/app-core/src/runtime/mode/runtime-mode.ts` keys the local-only collapse on `config.cloud?.enabled === false` — so the disk-backed `getRuntimeModeSnapshot()` could never yield `local-only`.

`cloud.enabled` is not a legacy field. It is the live cloud opt-in/out flag: the agent boot path still **writes** `enabled: true` (`packages/agent/src/runtime/eliza.ts`), and three consumers **read** it post-migration (runtime-mode resolver, `plugin-collector.ts` `cloudExplicitlyDisabled` gate, `settings-debug.ts`). No modern field (`deploymentTarget` / `serviceRouting`) carries the opt-out, so pruning destroyed state with no replacement. Worse, the provider-switch/first-run/wallet routes persist the migrated config back to disk, making the loss permanent.

Two collateral defects fixed by the same change:
- `plugin-collector.ts` `cloudExplicitlyDisabled` could never be true from disk config (local-only inference gate dead).
- `eliza.ts` change-detection (`config.cloud?.enabled !== true`) was always true after migration, forcing a config rewrite on every boot for cloud users.

Unit tests stayed green through all of this because `route-mode-matrix.test.ts` feeds `{cloud:{enabled:false}}` straight to the pure resolver, bypassing `loadElizaConfig()`.

## Fix

One source of truth: `cloud.enabled` stays out of the prune list (with a comment explaining why), in both the shared canonical and the core mirror (kept whitespace-identical). Keys with modern replacements (`provider`, `remoteApiBase`, `remoteAccessToken`, `inferenceMode`, `runtime`) are still pruned.

## Tests

- **`packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts`** (new) — resolves through the REAL `loadElizaConfig()` from a throwaway `ELIZA_STATE_DIR` (no mocks): `{cloud:{enabled:false}}` → `local-only`, opt-out survives sibling-key pruning, empty config → `local`, persisted cloud target → `cloud`. **Red on develop** (both local-only cases fail with `expected 'local' to be 'local-only'`), green with the fix.
- **`packages/shared/src/contracts/first-run-options.migration.test.ts`** (new) — pins the migration contract: `enabled: false`/`true` preserved, legacy-only cloud blocks still dropped. Red on develop, green with the fix.

## Evidence (real end-to-end, no mocks)

Booted the real app-core API server (`startApiServer` + real `AgentRuntime`) with `eliza.json` = exactly `{"cloud":{"enabled":false}}`:

Before (develop, live-proven on 035223a063): `GET /api/runtime/mode` → `{"mode":"local"}`; `GET /api/cloud/status` → 401 (surface served, not hidden).

After (this branch):

```
GET /api/runtime/mode  → {"mode":"local-only","deploymentRuntime":"local","isRemoteController":false,"remoteApiBaseConfigured":false} [200]
GET /api/cloud/status  → {"error":"Not found"} [404]   (contract 404 — surface hidden)
```

Mode flips on the same running server (config re-read per request):

```
{"deploymentTarget":{"runtime":"cloud","provider":"elizacloud"}}          → {"mode":"cloud"}
{"deploymentTarget":{"runtime":"remote","remoteApiBase":"http://192.168.1.50:2138"}} → {"mode":"remote"}
{}                                                                         → {"mode":"local"}
{"cloud":{"enabled":false}}                                                → {"mode":"local-only"}
```

Guard is not over-hiding: in plain `local` mode `GET /api/cloud/status` → 401 (auth, surface served).

## Verification (real counts)

- `packages/app-core` `src/runtime/mode/`: **5 files, 51/51 pass** (includes the 4 new disk-backed tests)
- `packages/shared` full suite: **105/106 files, 1225/1226 pass** — the 1 failure (`src/utils/env.test.ts` brand alias) fails identically on unmodified develop (#13632 fallout), unrelated
- `packages/core` `src/contracts/`: **3 files, 18/18 pass**
- Typecheck `shared`/`core`/`app-core`: only pre-existing error is `shared/src/config/brand-env-aliases.ts:143` (introduced by #13632), present on clean develop; **zero errors in touched files**
- Biome: shared + both test files clean; the core mirror's format noise (tabs) pre-exists on develop's copy of the file

- [x] evidence: real server probes above, captured against a live boot of this branch
- [ ] screenshots/video: N/A — no UI surface; runtime/API contract change proven via HTTP probes
- [ ] LLM trajectories: N/A — no agent/prompt/model behavior change; deterministic config resolution

findings signed [core-brain]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

