### PR TITLE
fix(shared): narrow syncElizaKey with an in-guard — develop typecheck is red (#13632 follow-up)

### DIFF
--- a/packages/shared/src/config/brand-env-aliases.ts
+++ b/packages/shared/src/config/brand-env-aliases.ts
@@ -140,6 +140,11 @@ export function buildBrandEnvSyncAliases(prefix: string): BrandEnvAliasPair[] {
       "vite" in definition && definition.vite
         ? `VITE_${normalizedPrefix}_${definition.brandSuffix}`
         : `${normalizedPrefix}_${definition.brandSuffix}`;
-    return [brandKey, definition.syncElizaKey ?? definition.elizaKey] as const;
+    // Only some alias definitions carry a sync-specific target key — narrow
+    // with the same `in` guard the vite flag uses (the union has no common
+    // optional member).
+    const syncKey =
+      "syncElizaKey" in definition ? definition.syncElizaKey : undefined;
+    return [brandKey, syncKey ?? definition.elizaKey] as const;
   });
 }


### PR DESCRIPTION
`bun run --cwd packages/shared typecheck` fails on develop tip: `buildBrandEnvSyncAliases` accesses `definition.syncElizaKey` on the as-const alias-definition union, which only carries the member on entries that declare it (TS2551). Every package whose project references include shared (ui, app, agent) fails typecheck with it.

Fix: narrow with the same `in` guard the `vite` flag uses two lines above. `packages/shared` typecheck green, config suite 58/58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)