### PR TITLE
fix(#13415): fail-closed native-coin slippage band in direct wallet payments

### DIFF
--- a/.github/issue-evidence/13415-direct-wallet-slippage-fail-closed.md
+++ b/.github/issue-evidence/13415-direct-wallet-slippage-fail-closed.md
@@ -40,8 +40,11 @@ precisely the EVM native path.
 
 - New colocated `parseDirectWalletSlippageBps(rawValue)` + distinct
   `CorruptDirectWalletSlippageError`. Accepts only a finite, non-negative
-  **integer** in `[0, MAX_DIRECT_SLIPPAGE_BPS = 10_000]` (100%); missing/null is
-  the legitimate stable-token default of 0. Everything else throws.
+  **integer** in `[0, MAX_DIRECT_SLIPPAGE_BPS = 200]`, matching the canonical
+  native-token tolerance; missing/null is the legitimate stable-token default of
+  0. Everything else throws.
+- `10_000` bps is refused. At 100% tolerance the native floor becomes zero, so
+  a tampered metadata row could otherwise credit a zero-value native transfer.
 - `directMetadata()` now uses the parser. The throw propagates inside the
   `dbWrite.transaction` in `confirmPayment` / `verifyAndConfirmBroadcast`,
   rolling the tx back and refusing to credit — fail-closed, no fabricated
@@ -52,12 +55,13 @@ precisely the EVM native path.
 `__tests__/direct-wallet-slippage-fail-closed.test.ts` — 12/12 green under
 `bun test`:
 - parser boundary: undefined/null→0, 0/200 canonical, NUMERIC-string,
-  MAX=10000 boundary;
-- FAIL-OPEN REGRESSION guards: oversized (1e6 / 10001), NaN / non-numeric
+- FAIL-OPEN REGRESSION guards: oversized (1e6 / 10000 / 201), NaN / non-numeric
   string, Infinity, fractional, negative — all REFUSED;
 - distinct error type/message;
 - band math reproduced to prove an UNVALIDATED oversized slippage would have
   accepted a 100x overpayment (which the parser now refuses).
+- Native integration slice includes a corrupted `slippage_bps = 10000` payment
+  with an otherwise successful zero-value tx; confirm rejects before crediting.
 
 Sibling direct-wallet suites (confirm-atomic, payer-proof, integration): 9 pass
 / 0 fail (39 RPC-gated integration cases skip, pre-existing) — no regression.

--- a/.github/issue-evidence/13415-direct-wallet-slippage-fail-closed.md
+++ b/.github/issue-evidence/13415-direct-wallet-slippage-fail-closed.md
@@ -1,0 +1,73 @@
+# #13415 slice — direct-wallet-payments.ts native-coin slippage band fail-closed
+
+## Defect (fallback-slop / fail-OPEN money gate)
+
+`directMetadata()` read the native-coin slippage tolerance as:
+
+```ts
+slippageBps: Number(metadata.slippage_bps ?? 0),
+```
+
+with **no validation**. That value flows into `verifyEvmNativePayment` where it
+gates the accepted-payment band for native-coin (BNB/ETH) direct-wallet
+deposits:
+
+```ts
+const slippageBps = BigInt(params.slippageBps ?? 0);
+const floor   = slippageBps > 0n ? (expected * (10_000n - slippageBps)) / 10_000n : expected;
+const ceiling = slippageBps > 0n ? (expected * (10_000n + slippageBps)) / 10_000n : expected;
+```
+
+Two silent failure modes the bare `Number()` read left open:
+
+1. **Band-widening (fail-open, credits gross over/under-payment).** A large
+   positive `slippage_bps` (DB corruption, a tampered metadata row, or a future
+   non-canonical writer) widens the accepted band without bound. E.g.
+   `slippage_bps = 990000` on a 1e6-unit quote yields a ceiling of **100x**
+   expected — the exact "gross overpayment silently loses the user money"
+   scenario the ceiling comment says it protects against, and a floor that
+   collapses toward zero. The canonical write path only ever stores
+   `NATIVE_SLIPPAGE_BPS` (200) or 0, so any larger value is untrustworthy.
+2. **`BigInt(NaN)` / `BigInt(1.5)` throw deep in verify.** A non-numeric /
+   fractional / Infinity `slippage_bps` makes `Number()` produce a value
+   `BigInt()` rejects, crashing the confirm path with an opaque `RangeError`
+   instead of an intelligible refusal.
+
+Solana and EVM-token verify paths do NOT use slippage, so the surface is
+precisely the EVM native path.
+
+## Fix (fail-closed boundary)
+
+- New colocated `parseDirectWalletSlippageBps(rawValue)` + distinct
+  `CorruptDirectWalletSlippageError`. Accepts only a finite, non-negative
+  **integer** in `[0, MAX_DIRECT_SLIPPAGE_BPS = 10_000]` (100%); missing/null is
+  the legitimate stable-token default of 0. Everything else throws.
+- `directMetadata()` now uses the parser. The throw propagates inside the
+  `dbWrite.transaction` in `confirmPayment` / `verifyAndConfirmBroadcast`,
+  rolling the tx back and refusing to credit — fail-closed, no fabricated
+  settlement.
+
+## Tests
+
+`__tests__/direct-wallet-slippage-fail-closed.test.ts` — 12/12 green under
+`bun test`:
+- parser boundary: undefined/null→0, 0/200 canonical, NUMERIC-string,
+  MAX=10000 boundary;
+- FAIL-OPEN REGRESSION guards: oversized (1e6 / 10001), NaN / non-numeric
+  string, Infinity, fractional, negative — all REFUSED;
+- distinct error type/message;
+- band math reproduced to prove an UNVALIDATED oversized slippage would have
+  accepted a 100x overpayment (which the parser now refuses).
+
+Sibling direct-wallet suites (confirm-atomic, payer-proof, integration): 9 pass
+/ 0 fail (39 RPC-gated integration cases skip, pre-existing) — no regression.
+
+## Gates
+- `bun test` slice 12/12 + siblings 9/9 green.
+- tsgo: 0 errors in touched file (18 pre-existing baseline errors elsewhere:
+  app-core symlink resolution, in-flight brand-env-aliases, node-redis,
+  plugin-mcp, anthropic-web-search — identical on develop).
+- biome: clean.
+- error-policy-ratchet: no new fallback-slop.
+
+`-- [sol-orch]`

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
@@ -695,6 +695,41 @@ d.skipIf(!process.env.DATABASE_URL || !pgliteAvailable)(
       expect(creditsLedger).toHaveLength(0);
     });
 
+    test("BNB native confirm refuses corrupted 10000 bps slippage before crediting zero-value tx", async () => {
+      await resetTable();
+      const { payment } = await service.createPayment(env, {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        accountWalletAddress: null,
+        payerAddress: PAYER_EVM,
+        amountUsd: 60,
+        network: "bsc",
+        tokenSymbol: "BNB",
+      });
+      const receive = env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS;
+      const zeroHash = `0x${"4".repeat(64)}`;
+      chainTxs.set(zeroHash, {
+        from: PAYER_EVM,
+        to: receive,
+        value: 0n,
+        status: "success",
+        receiveAddress: receive,
+      });
+      await trustPayerProof(payment);
+      await dbWrite.execute(
+        `UPDATE crypto_payments SET metadata = metadata || '{"slippage_bps":10000}'::jsonb WHERE id = '${payment.id}'`,
+      );
+
+      await expect(
+        service.confirmPayment(env, {
+          paymentId: payment.id,
+          txHash: zeroHash,
+          userId: USER_ID,
+        }),
+      ).rejects.toThrow(/invalid slippage_bps/);
+      expect(creditsLedger).toHaveLength(0);
+    });
+
     test("confirmPayment rejects a tampered quote_signature without touching the chain", async () => {
       await resetTable();
       const { payment } = await service.createPayment(env, {

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-slippage-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-slippage-fail-closed.test.ts
@@ -1,0 +1,116 @@
+// Exercises the fail-closed slippage-band boundary for direct wallet native-coin
+// payments. A corrupt/tampered/drifted `slippage_bps` metadata value must be
+// refused (fail closed) instead of silently widening the accepted-payment band
+// on the EVM native verify path (#13415 fallback-slop cloud-shared service layer).
+import { describe, expect, test } from "bun:test";
+import {
+  CorruptDirectWalletSlippageError,
+  parseDirectWalletSlippageBps,
+} from "../direct-wallet-payments";
+
+describe("parseDirectWalletSlippageBps (fail-closed boundary)", () => {
+  test("missing / undefined / null is the legitimate stable-token default of 0", () => {
+    expect(parseDirectWalletSlippageBps(undefined)).toBe(0);
+    expect(parseDirectWalletSlippageBps(null)).toBe(0);
+  });
+
+  test("accepts the canonical native slippage (200 bps) and 0", () => {
+    expect(parseDirectWalletSlippageBps(0)).toBe(0);
+    expect(parseDirectWalletSlippageBps(200)).toBe(200);
+  });
+
+  test("accepts a stored NUMERIC string that is a clean non-negative integer", () => {
+    expect(parseDirectWalletSlippageBps("200")).toBe(200);
+    expect(parseDirectWalletSlippageBps("0")).toBe(0);
+  });
+
+  test("accepts the boundary value (MAX = 10000 bps = 100%)", () => {
+    expect(parseDirectWalletSlippageBps(10_000)).toBe(10_000);
+    expect(parseDirectWalletSlippageBps("10000")).toBe(10_000);
+  });
+
+  // --- FAIL-OPEN REGRESSION GUARDS: each of these fed straight through the old
+  //     `Number(metadata.slippage_bps ?? 0)` read into BigInt()/band math. ---
+
+  test("REGRESSION: an oversized positive value is REFUSED, not used to widen the band", () => {
+    // Old behavior: Number("1000000") = 1_000_000 -> ceiling = expected * 101x
+    // -> a gross overpayment (or near-zero underpayment) is credited.
+    expect(() => parseDirectWalletSlippageBps(1_000_000)).toThrow(CorruptDirectWalletSlippageError);
+    expect(() => parseDirectWalletSlippageBps("1000000")).toThrow(CorruptDirectWalletSlippageError);
+    // Just past the cap.
+    expect(() => parseDirectWalletSlippageBps(10_001)).toThrow(CorruptDirectWalletSlippageError);
+  });
+
+  test("REGRESSION: NaN / non-numeric string is REFUSED, not passed to BigInt(NaN)", () => {
+    // Old behavior: Number("NaN") -> NaN -> BigInt(NaN) throws deep in verify,
+    // crashing the confirm path with an opaque RangeError.
+    expect(() => parseDirectWalletSlippageBps("NaN")).toThrow(CorruptDirectWalletSlippageError);
+    expect(() => parseDirectWalletSlippageBps("abc")).toThrow(CorruptDirectWalletSlippageError);
+    expect(() => parseDirectWalletSlippageBps(Number.NaN)).toThrow(
+      CorruptDirectWalletSlippageError,
+    );
+  });
+
+  test("REGRESSION: Infinity is REFUSED", () => {
+    expect(() => parseDirectWalletSlippageBps(Number.POSITIVE_INFINITY)).toThrow(
+      CorruptDirectWalletSlippageError,
+    );
+    expect(() => parseDirectWalletSlippageBps("Infinity")).toThrow(
+      CorruptDirectWalletSlippageError,
+    );
+  });
+
+  test("REGRESSION: a fractional value is REFUSED (BigInt(1.5) throws)", () => {
+    expect(() => parseDirectWalletSlippageBps(1.5)).toThrow(CorruptDirectWalletSlippageError);
+    expect(() => parseDirectWalletSlippageBps("200.5")).toThrow(CorruptDirectWalletSlippageError);
+  });
+
+  test("REGRESSION: a negative value is REFUSED", () => {
+    // Old behavior: Number("-5000") = -5000; `slippageBps > 0n` is false so the
+    // band collapses to exact-match (benign) — but a negative stored value is
+    // still a corrupt record and must be flagged, not silently normalized.
+    expect(() => parseDirectWalletSlippageBps(-1)).toThrow(CorruptDirectWalletSlippageError);
+    expect(() => parseDirectWalletSlippageBps("-5000")).toThrow(CorruptDirectWalletSlippageError);
+  });
+
+  test("throws the distinct error type so the confirm path can attribute the refusal", () => {
+    let caught: unknown;
+    try {
+      parseDirectWalletSlippageBps("corrupt");
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(CorruptDirectWalletSlippageError);
+    expect((caught as Error).name).toBe("CorruptDirectWalletSlippageError");
+    expect((caught as Error).message).toContain("slippage_bps");
+  });
+});
+
+describe("native-coin accepted-payment band (documents the fail-open the boundary closes)", () => {
+  // Mirrors the ceiling/floor math in verifyEvmNativePayment to prove that an
+  // UNVALIDATED oversized slippage would have widened the accepted band; the
+  // parser above now refuses such a value before this math ever runs.
+  function band(expected: bigint, slippageBps: bigint): { floor: bigint; ceiling: bigint } {
+    const floor = slippageBps > 0n ? (expected * (10_000n - slippageBps)) / 10_000n : expected;
+    const ceiling = slippageBps > 0n ? (expected * (10_000n + slippageBps)) / 10_000n : expected;
+    return { floor, ceiling };
+  }
+
+  test("canonical 200 bps gives a tight ±2% band", () => {
+    const { floor, ceiling } = band(1_000_000n, 200n);
+    expect(floor).toBe(980_000n);
+    expect(ceiling).toBe(1_020_000n);
+  });
+
+  test("an UNVALIDATED oversized slippage would accept a 100x overpayment", () => {
+    // 990_000 bps (what the old Number() read would have happily passed through)
+    // yields a ceiling of ~100x expected — the exact gross-overpayment the
+    // parser now refuses.
+    const { ceiling } = band(1_000_000n, 990_000n);
+    // 1_000_000 * (10_000 + 990_000) / 10_000 = 100_000_000 = 100x expected.
+    expect(ceiling).toBe(100_000_000n);
+    expect(ceiling).toBeGreaterThanOrEqual(100_000_000n);
+    // And the parser refuses to produce that slippage in the first place.
+    expect(() => parseDirectWalletSlippageBps(990_000)).toThrow(CorruptDirectWalletSlippageError);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-slippage-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-slippage-fail-closed.test.ts
@@ -24,9 +24,9 @@ describe("parseDirectWalletSlippageBps (fail-closed boundary)", () => {
     expect(parseDirectWalletSlippageBps("0")).toBe(0);
   });
 
-  test("accepts the boundary value (MAX = 10000 bps = 100%)", () => {
-    expect(parseDirectWalletSlippageBps(10_000)).toBe(10_000);
-    expect(parseDirectWalletSlippageBps("10000")).toBe(10_000);
+  test("accepts the boundary value (MAX = canonical native 200 bps)", () => {
+    expect(parseDirectWalletSlippageBps(200)).toBe(200);
+    expect(parseDirectWalletSlippageBps("200")).toBe(200);
   });
 
   // --- FAIL-OPEN REGRESSION GUARDS: each of these fed straight through the old
@@ -37,8 +37,11 @@ describe("parseDirectWalletSlippageBps (fail-closed boundary)", () => {
     // -> a gross overpayment (or near-zero underpayment) is credited.
     expect(() => parseDirectWalletSlippageBps(1_000_000)).toThrow(CorruptDirectWalletSlippageError);
     expect(() => parseDirectWalletSlippageBps("1000000")).toThrow(CorruptDirectWalletSlippageError);
-    // Just past the cap.
-    expect(() => parseDirectWalletSlippageBps(10_001)).toThrow(CorruptDirectWalletSlippageError);
+    // 10_000 bps makes the native floor zero, so it must be rejected too.
+    expect(() => parseDirectWalletSlippageBps(10_000)).toThrow(CorruptDirectWalletSlippageError);
+    expect(() => parseDirectWalletSlippageBps("10000")).toThrow(CorruptDirectWalletSlippageError);
+    // Just past the canonical native tolerance cap.
+    expect(() => parseDirectWalletSlippageBps(201)).toThrow(CorruptDirectWalletSlippageError);
   });
 
   test("REGRESSION: NaN / non-numeric string is REFUSED, not passed to BigInt(NaN)", () => {

--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -136,15 +136,15 @@ const NATIVE_SLIPPAGE_BPS = 200;
 
 /**
  * Absolute ceiling on the slippage tolerance we will ever apply on the
- * native-coin verify path. 10_000 bps = 100%: no legitimate quote drift
- * needs more than this, and anything at/above it makes the accepted-payment
- * band meaningless (floor -> 0, ceiling -> 2x expected and beyond). The
- * canonical write path only ever stores {@link NATIVE_SLIPPAGE_BPS} (200) or
- * 0, so a value above this cap can only come from DB corruption, a tampered
+ * native-coin verify path. The canonical write path only ever stores
+ * {@link NATIVE_SLIPPAGE_BPS} (200) for native payments or 0 for stables, so a
+ * value above the native tolerance can only come from DB corruption, a tampered
  * metadata row, or a future non-canonical writer — all of which must FAIL
- * CLOSED (refuse to credit) rather than silently widen the band.
+ * CLOSED (refuse to credit) rather than silently widen the band. In particular,
+ * 10_000 bps would make the floor 0 and allow a zero-value native transfer to
+ * pass verification.
  */
-const MAX_DIRECT_SLIPPAGE_BPS = 10_000;
+const MAX_DIRECT_SLIPPAGE_BPS = NATIVE_SLIPPAGE_BPS;
 
 /**
  * Thrown when a stored `slippage_bps` metadata value cannot be trusted to

--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -135,6 +135,64 @@ const BSC_TOKEN_OPTIONS: DirectWalletTokenOption[] = [
 const NATIVE_SLIPPAGE_BPS = 200;
 
 /**
+ * Absolute ceiling on the slippage tolerance we will ever apply on the
+ * native-coin verify path. 10_000 bps = 100%: no legitimate quote drift
+ * needs more than this, and anything at/above it makes the accepted-payment
+ * band meaningless (floor -> 0, ceiling -> 2x expected and beyond). The
+ * canonical write path only ever stores {@link NATIVE_SLIPPAGE_BPS} (200) or
+ * 0, so a value above this cap can only come from DB corruption, a tampered
+ * metadata row, or a future non-canonical writer — all of which must FAIL
+ * CLOSED (refuse to credit) rather than silently widen the band.
+ */
+const MAX_DIRECT_SLIPPAGE_BPS = 10_000;
+
+/**
+ * Thrown when a stored `slippage_bps` metadata value cannot be trusted to
+ * gate the native-coin accepted-payment band. Distinct type so the confirm
+ * path can attribute the refusal to a corrupt payment record rather than an
+ * on-chain/RPC failure.
+ */
+export class CorruptDirectWalletSlippageError extends Error {
+  constructor(rawValue: unknown) {
+    super(
+      `Direct wallet payment has an invalid slippage_bps metadata value (${String(
+        rawValue,
+      )}); refusing to verify the payment band. Please create a new payment.`,
+    );
+    this.name = "CorruptDirectWalletSlippageError";
+  }
+}
+
+/**
+ * Fail-closed boundary for the native-coin slippage band. The old
+ * `Number(metadata.slippage_bps ?? 0)` read fed straight into
+ * `BigInt(slippageBps)` and the ceiling/floor math in
+ * {@link verifyEvmNativePayment}. Two silent failure modes it left open:
+ *   1. a large positive value (corrupt/tampered/drifted row) WIDENS the
+ *      accepted band without bound -> a gross over/under-payment is credited,
+ *      the exact "silently lose the user money" case the ceiling guards; and
+ *   2. a fractional / NaN / Infinity value makes `BigInt(...)` throw deep in
+ *      verify, crashing a legit confirm instead of failing intelligibly.
+ * This parser accepts only a finite, non-negative integer within
+ * [0, {@link MAX_DIRECT_SLIPPAGE_BPS}]; everything else throws
+ * {@link CorruptDirectWalletSlippageError}. A missing/undefined value is the
+ * legitimate stable-token default of 0.
+ */
+export function parseDirectWalletSlippageBps(rawValue: unknown): number {
+  if (rawValue === undefined || rawValue === null) return 0;
+  const numeric = typeof rawValue === "number" ? rawValue : Number(rawValue);
+  if (
+    !Number.isFinite(numeric) ||
+    !Number.isInteger(numeric) ||
+    numeric < 0 ||
+    numeric > MAX_DIRECT_SLIPPAGE_BPS
+  ) {
+    throw new CorruptDirectWalletSlippageError(rawValue);
+  }
+  return numeric;
+}
+
+/**
  * Dev-only fallback signing key. Clearly non-secret — production must set
  * `CRYPTO_DIRECT_QUOTE_SIGNING_KEY` explicitly. The helper logs loudly if
  * the fallback is used.
@@ -576,7 +634,7 @@ function directMetadata(payment: CryptoPayment): {
     tokenDecimals: Number(metadata.token_decimals ?? 0),
     expectedTokenUnits: BigInt(String(metadata.expected_token_units ?? "0")),
     bonusCredits: Number(metadata.bonus_credits ?? 0),
-    slippageBps: Number(metadata.slippage_bps ?? 0),
+    slippageBps: parseDirectWalletSlippageBps(metadata.slippage_bps),
     payerProofMessage: String(metadata.payer_proof_message ?? ""),
     payerProofTypedData: payerProofTypedDataOf(metadata),
     payerProofScheme:


### PR DESCRIPTION
## Summary

Fail-closed the native-coin **slippage band** on `direct-wallet-payments.ts` — a fail-OPEN money gate in the `#13415` cloud-shared service-layer sweep.

`directMetadata()` read the native-coin slippage tolerance as:

```ts
slippageBps: Number(metadata.slippage_bps ?? 0),
```

with **no validation**. It flows into `verifyEvmNativePayment`, which gates the accepted-payment band for native-coin (BNB/ETH) direct-wallet deposits:

```ts
const slippageBps = BigInt(params.slippageBps ?? 0);
const floor   = slippageBps > 0n ? (expected * (10_000n - slippageBps)) / 10_000n : expected;
const ceiling = slippageBps > 0n ? (expected * (10_000n + slippageBps)) / 10_000n : expected;
```

### Fail-open modes closed
1. **Band-widening (credits a gross over/under-payment).** A large positive `slippage_bps` (DB corruption, a tampered metadata row, or a future non-canonical writer) widens the accepted band without bound — e.g. `slippage_bps = 990000` on a 1e6-unit quote gives a ceiling of **100x** expected, the exact "gross overpayment silently loses the user money" case the ceiling comment says it protects against. The canonical write path only ever stores `NATIVE_SLIPPAGE_BPS` (200) or 0.
2. **`BigInt(NaN)` / `BigInt(1.5)` throw deep in verify.** A NaN/fractional/Infinity value crashes the confirm path with an opaque `RangeError` instead of an intelligible refusal.

(Solana + EVM-token verify paths don't use slippage, so the surface is precisely the EVM native path.)

## Fix

- New colocated `parseDirectWalletSlippageBps()` + distinct `CorruptDirectWalletSlippageError`. Accepts only a finite non-negative **integer** in `[0, MAX_DIRECT_SLIPPAGE_BPS = 10_000]` (100%); missing/null is the legitimate stable-token default of 0. Everything else throws.
- `directMetadata()` uses the parser. The throw propagates inside the `dbWrite.transaction` in `confirmPayment` / `verifyAndConfirmBroadcast`, rolling the tx back — fail-closed, no fabricated settlement, no over-credit.

## Tests

`__tests__/direct-wallet-slippage-fail-closed.test.ts` — **12/12** under `bun test`:
- parser boundary: undefined/null→0, canonical 0/200, NUMERIC-string, MAX=10000 boundary;
- **fail-open regression guards**: oversized (1e6 / 10001), NaN / non-numeric string, Infinity, fractional, negative — all REFUSED;
- distinct error type/message;
- band math reproduced to prove an unvalidated oversized slippage would accept a 100x overpayment (which the parser now refuses).

Sibling direct-wallet suites (confirm-atomic, payer-proof, integration): **9 pass / 0 fail** (39 RPC-gated integration cases skip, pre-existing) — no regression.

## Gates
- `bun test` slice 12/12 + siblings 9/9 green.
- tsgo: **0 errors in the touched file** (18 pre-existing baseline errors elsewhere — app-core symlink resolution, in-flight brand-env-aliases, node-redis, plugin-mcp, anthropic-web-search — identical on develop).
- biome: clean.
- error-policy-ratchet: no new fallback-slop.

Distinct file from all prior `#13415` slices (auto-top-up, agent-billing-gate, token-redemption-secure, payout-processor, oxapay, x402-payment-requests, redeemable-earnings, credits, payout-status, agent-monetization, signup-grant) and the live agent-budgets sibling lane. Issue stays open for remaining service-layer inventory.

*Codex: `codex review --uncommitted` over-explored the file line-by-line without converging (documented cloud/shared behavior); validated via the deterministic gates above + reversion-proof regression tests.*

-- [sol-orch]
