### PR TITLE
fix(#13564): overwrite unsigned DerivedData App.app with signed graft on device capture (0xe800801c)

### DIFF
--- a/packages/app/scripts/ios-device-capture.mjs
+++ b/packages/app/scripts/ios-device-capture.mjs
@@ -370,6 +370,14 @@ async function main() {
     parsePlist(fs.readFileSync(xmlPath, "utf8")),
     testRoot,
   );
+  // Capture the original resolved bundle list before any --app-path rewrites.
+  // Once UITargetAppPath points at the signed staged app, the unsigned
+  // DerivedData App.app path is no longer discoverable from the parsed
+  // xctestrun, but the overwrite/preflight below still needs that original
+  // product path.
+  const originalBundles = extractXctestrunAppPaths(parsed, testRoot).filter(
+    (bundle) => bundle.endsWith(".app"),
+  );
 
   // Device lane: point the harness at the signed App.app graft.
   if (args["app-path"]) {
@@ -404,11 +412,8 @@ async function main() {
     const signedApp = args["app-path"] ? path.resolve(args["app-path"]) : null;
     // The DD build product is the App.app sitting NEXT TO the runner app in
     // Build/Products; derive it from the xctestrun's own resolved bundle list.
-    const bundles = extractXctestrunAppPaths(parsed, testRoot).filter(
-      (bundle) => bundle.endsWith(".app"),
-    );
     const derivedDataProductApp =
-      bundles.find(
+      originalBundles.find(
         (bundle) => path.basename(bundle) === "App.app" && bundle !== signedApp,
       ) ?? null;
     const overwritePlan = planSignedAppDdOverwrite({
@@ -435,7 +440,7 @@ async function main() {
     // signed, so an unsigned bundle fails fast with the 0xe800801c remediation
     // text instead of an opaque devicectl install error deep in the run.
     const runnerApp =
-      bundles.find((bundle) => bundle.endsWith("-Runner.app")) ?? null;
+      originalBundles.find((bundle) => bundle.endsWith("-Runner.app")) ?? null;
     const preflightChecks = [];
     if (runnerApp) {
       preflightChecks.push({

--- a/packages/app/scripts/ios-device-capture.mjs
+++ b/packages/app/scripts/ios-device-capture.mjs
@@ -39,6 +39,7 @@ import { fileURLToPath } from "node:url";
 import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
 import {
   buildPlistXml,
+  classifyCodesignPreflight,
   classifyIsolatedReruns,
   evaluateRunnerStaleness,
   extractXctestrunAppPaths,
@@ -46,9 +47,11 @@ import {
   parseCliArgs,
   parseFailedTestIdentifiers,
   parsePlist,
+  planSignedAppDdOverwrite,
   resolveDeviceId,
   resolveXctestrunTestRoot,
   rewriteXctestrunUITargetApp,
+  sweepXctestrunDependentProductPaths,
 } from "./ios-device-lib.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -68,6 +71,20 @@ function runInherit(command, args, options = {}) {
       `${command} ${args.slice(0, 4).join(" ")} … exited with ${result.status}`,
     );
   }
+}
+
+/**
+ * Is `appPath` code-signed? `codesign --verify` exits 0 when the bundle carries
+ * a valid signature and non-zero (with "code object is not signed at all" on
+ * stderr) when it does not. A missing path is treated as unsigned so the
+ * preflight fails loudly rather than swallowing it.
+ */
+function isCodeSigned(appPath) {
+  if (!fs.existsSync(appPath)) return false;
+  const result = spawnSync("codesign", ["--verify", "--strict", appPath], {
+    stdio: "ignore",
+  });
+  return result.status === 0;
 }
 
 /**
@@ -364,9 +381,85 @@ async function main() {
     log(
       `rewrote ${rewritten} UITargetAppPath entr${rewritten === 1 ? "y" : "ies"} → ${signedApp}`,
     );
+    // xcodebuild also installs the bundles listed in each test target's
+    // DependentProductPaths; a lingering reference to the unsigned build
+    // product App.app there fails the device install 0xe800801c even after
+    // the UITargetAppPath rewrite. Point those stale App.app refs at the graft.
+    const sweptDeps = sweepXctestrunDependentProductPaths(parsed, signedApp);
+    if (sweptDeps > 0) {
+      log(
+        `swept ${sweptDeps} stale DependentProductPaths entr${sweptDeps === 1 ? "y" : "ies"} → ${signedApp}`,
+      );
+    }
   }
   fs.writeFileSync(xmlPath, buildPlistXml(parsed));
   xctestrunPath = xmlPath;
+
+  // Device lane: overwrite the UNSIGNED build-product App.app that
+  // build-for-testing left in DerivedData with the signed staged app before
+  // test-without-building. xcodebuild installs the DD product regardless of
+  // the .xctestrun rewrites, so without this the device install fails
+  // 0xe800801c ("No code signature"). See #13564.
+  if (platform === "device") {
+    const signedApp = args["app-path"] ? path.resolve(args["app-path"]) : null;
+    // The DD build product is the App.app sitting NEXT TO the runner app in
+    // Build/Products; derive it from the xctestrun's own resolved bundle list.
+    const bundles = extractXctestrunAppPaths(parsed, testRoot).filter(
+      (bundle) => bundle.endsWith(".app"),
+    );
+    const derivedDataProductApp =
+      bundles.find(
+        (bundle) => path.basename(bundle) === "App.app" && bundle !== signedApp,
+      ) ?? null;
+    const overwritePlan = planSignedAppDdOverwrite({
+      platform,
+      signedAppPath: signedApp,
+      derivedDataProductApp,
+      productExists: derivedDataProductApp
+        ? fs.existsSync(derivedDataProductApp)
+        : false,
+    });
+    if (overwritePlan.overwrite) {
+      log(
+        `overwriting UNSIGNED DerivedData product ${overwritePlan.to} with the ` +
+          `signed staged app ${overwritePlan.from} (device install would else ` +
+          "fail 0xe800801c)",
+      );
+      fs.rmSync(overwritePlan.to, { recursive: true, force: true });
+      runInherit("ditto", [overwritePlan.from, overwritePlan.to]);
+    } else {
+      log(`DerivedData overwrite skipped: ${overwritePlan.reason}`);
+    }
+
+    // Preflight: verify the runner app AND the (now-overwritten) DD product are
+    // signed, so an unsigned bundle fails fast with the 0xe800801c remediation
+    // text instead of an opaque devicectl install error deep in the run.
+    const runnerApp =
+      bundles.find((bundle) => bundle.endsWith("-Runner.app")) ?? null;
+    const preflightChecks = [];
+    if (runnerApp) {
+      preflightChecks.push({
+        label: "XCUITest runner",
+        path: runnerApp,
+        signed: isCodeSigned(runnerApp),
+      });
+    }
+    if (derivedDataProductApp) {
+      preflightChecks.push({
+        label: "target app (DerivedData product)",
+        path: derivedDataProductApp,
+        signed: isCodeSigned(derivedDataProductApp),
+      });
+    }
+    if (preflightChecks.length > 0) {
+      const verdict = classifyCodesignPreflight({
+        checks: preflightChecks,
+        appPathProvided: Boolean(signedApp),
+      });
+      if (!verdict.ok) fail(verdict.message);
+      log("codesign preflight: runner + target app signed OK");
+    }
+  }
 
   // 4. Destination for the run.
   let destination;

--- a/packages/app/scripts/ios-device-lib.mjs
+++ b/packages/app/scripts/ios-device-lib.mjs
@@ -505,6 +505,171 @@ export function rewriteXctestrunUITargetApp(xctestrun, newAppPath) {
 }
 
 /**
+ * Rewrite stale references to the unsigned build-product App.app in every
+ * DependentProductPaths array of a parsed .xctestrun, pointing them at the
+ * signed replacement app. Device runs graft a signed App.app over the
+ * unsigned one that build-for-testing left in DerivedData; rewriteXctestrun-
+ * UITargetApp only fixes UITargetAppPath, but xcodebuild also installs the
+ * bundles listed in each test target's DependentProductPaths — a lingering
+ * reference to the unsigned `…/App.app` there makes the device install fail
+ * with 0xe800801c ("No code signature") even after the UITargetAppPath rewrite.
+ *
+ * A path is considered stale when its basename equals the signed app's
+ * basename (e.g. `App.app`) but the path itself is not already the signed app.
+ * Runner apps, frameworks, and other dependent products are left untouched.
+ * Returns the number of entries rewritten.
+ *
+ * @param {Record<string, unknown>} xctestrun parsed plist root
+ * @param {string} newAppPath absolute path to the signed App.app (already
+ *   __TESTROOT__-resolved)
+ * @returns {number}
+ */
+export function sweepXctestrunDependentProductPaths(xctestrun, newAppPath) {
+  const targetBase = basenameOf(newAppPath);
+  let rewritten = 0;
+  const sweepTarget = (testTarget) => {
+    if (!testTarget || typeof testTarget !== "object") return;
+    const deps = testTarget.DependentProductPaths;
+    if (!Array.isArray(deps)) return;
+    for (let i = 0; i < deps.length; i += 1) {
+      const dep = deps[i];
+      if (typeof dep !== "string") continue;
+      if (dep === newAppPath) continue;
+      if (basenameOf(dep) === targetBase) {
+        deps[i] = newAppPath;
+        rewritten += 1;
+      }
+    }
+  };
+  // FormatVersion 2: TestConfigurations array at the ROOT of the plist.
+  if (Array.isArray(xctestrun.TestConfigurations)) {
+    for (const config of xctestrun.TestConfigurations) {
+      for (const testTarget of config?.TestTargets ?? []) {
+        sweepTarget(testTarget);
+      }
+    }
+  }
+  // FormatVersion 1: one dict per test target at the root.
+  for (const [key, value] of Object.entries(xctestrun)) {
+    if (key === "__xctestrun_metadata__" || key === "TestConfigurations")
+      continue;
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+    sweepTarget(value);
+  }
+  return rewritten;
+}
+
+/**
+ * Cross-platform basename that treats both `/` and `\` as separators and
+ * ignores a single trailing separator (an .app path may be written with one).
+ * @param {string} p
+ * @returns {string}
+ */
+function basenameOf(p) {
+  const trimmed = p.replace(/[/\\]+$/, "");
+  const idx = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return idx === -1 ? trimmed : trimmed.slice(idx + 1);
+}
+
+/**
+ * Decide whether — and where — to overwrite the DerivedData build product
+ * App.app with the signed staged app before `test-without-building`.
+ *
+ * On a device run, `build-for-testing` leaves an UNSIGNED `App.app` in
+ * `<derivedData>/Build/Products/<config>-iphoneos/App.app`. Even after the
+ * .xctestrun's UITargetAppPath is rewritten to the signed graft, xcodebuild
+ * still installs the DD product, and the device install fails 0xe800801c.
+ * The proven fix is to `ditto` the signed app over the DD product first.
+ *
+ * Pure: returns the overwrite plan (or a skip reason) so the impure script
+ * layer can log + execute the `ditto`. Only overwrites on device runs when a
+ * signed --app-path is provided and the DD product exists.
+ *
+ * @param {{
+ *   platform: 'sim' | 'device',
+ *   signedAppPath: string | null,
+ *   derivedDataProductApp: string | null,
+ *   productExists: boolean,
+ * }} params
+ * @returns {{ overwrite: boolean, from?: string, to?: string, reason?: string }}
+ */
+export function planSignedAppDdOverwrite({
+  platform,
+  signedAppPath,
+  derivedDataProductApp,
+  productExists,
+}) {
+  if (platform !== "device") {
+    return { overwrite: false, reason: "not a device run" };
+  }
+  if (!signedAppPath) {
+    return { overwrite: false, reason: "no --app-path signed app given" };
+  }
+  if (!derivedDataProductApp) {
+    return {
+      overwrite: false,
+      reason: "could not resolve the DerivedData build-product App.app",
+    };
+  }
+  if (derivedDataProductApp === signedAppPath) {
+    return {
+      overwrite: false,
+      reason: "signed app IS the DerivedData product — nothing to overwrite",
+    };
+  }
+  if (!productExists) {
+    return {
+      overwrite: false,
+      reason: `no build product at ${derivedDataProductApp} (run without --skip-build?)`,
+    };
+  }
+  return {
+    overwrite: true,
+    from: signedAppPath,
+    to: derivedDataProductApp,
+  };
+}
+
+/**
+ * Classify the result of a `codesign --verify` preflight over the runner app
+ * and the (post-overwrite) DerivedData App.app. Pure: the caller passes each
+ * check's boolean `signed` verdict; this returns whether to fail-fast and the
+ * exact remediation text naming 0xe800801c so a device operator gets an
+ * actionable error instead of the opaque devicectl install failure.
+ *
+ * @param {{
+ *   checks: Array<{ label: string, path: string, signed: boolean }>,
+ *   appPathProvided: boolean,
+ * }} params
+ * @returns {{ ok: boolean, unsigned: Array<{ label: string, path: string }>, message: string | null }}
+ */
+export function classifyCodesignPreflight({ checks, appPathProvided }) {
+  const unsigned = checks
+    .filter((check) => !check.signed)
+    .map(({ label, path: p }) => ({ label, path: p }));
+  if (unsigned.length === 0) {
+    return { ok: true, unsigned: [], message: null };
+  }
+  const listed = unsigned
+    .map(({ label, path: p }) => `  - ${label}: ${p}`)
+    .join("\n");
+  const remediation = appPathProvided
+    ? "The signed app was grafted but a bundle is still unsigned. Re-stage the " +
+      "signed app with `bun run ios:device:deploy` and pass it via --app-path."
+    : "The DerivedData build product is unsigned. Stage a signed app with " +
+      "`bun run ios:device:deploy` and re-run with " +
+      "`--app-path <ios/build/device-deploy-stage/App.app>`.";
+  return {
+    ok: false,
+    unsigned,
+    message:
+      "codesign preflight failed — installing this on a device would abort with " +
+      '0xe800801c ("No code signature"). Unsigned bundle(s):\n' +
+      `${listed}\n${remediation}`,
+  };
+}
+
+/**
  * Collect every app bundle a parsed .xctestrun references (TestHostPath +
  * UITargetAppPath, both FormatVersion 1 and 2 layouts), resolving the
  * __TESTROOT__ placeholder against the xctestrun's directory. Used to

--- a/packages/app/scripts/ios-device-lib.test.mjs
+++ b/packages/app/scripts/ios-device-lib.test.mjs
@@ -11,6 +11,7 @@ import {
   buildOnlyTestingIdentifier,
   buildPlistXml,
   CONSOLE_SIGTRAP_SIGNATURE,
+  classifyCodesignPreflight,
   classifyConsoleExit,
   classifyIsolatedReruns,
   deriveSigningEntitlements,
@@ -23,12 +24,14 @@ import {
   parseCodesigningIdentities,
   parseFailedTestIdentifiers,
   parsePlist,
+  planSignedAppDdOverwrite,
   profileMatchesTarget,
   resolveDeviceId,
   resolveXctestrunTestRoot,
   rewriteXctestrunUITargetApp,
   selectProvisioningProfile,
   selectSigningIdentity,
+  sweepXctestrunDependentProductPaths,
 } from "./ios-device-lib.mjs";
 
 const TEAM = "25877RY2EH";
@@ -422,6 +425,214 @@ describe("rewriteXctestrunUITargetApp", () => {
 
   it("returns 0 when there is nothing to rewrite", () => {
     expect(rewriteXctestrunUITargetApp({ Foo: { Bar: "baz" } }, "/x")).toBe(0);
+  });
+});
+
+describe("sweepXctestrunDependentProductPaths (#13564)", () => {
+  it("rewrites stale App.app refs in the FormatVersion 2 layout, leaving runner + others untouched", () => {
+    const xctestrun = {
+      __xctestrun_metadata__: { FormatVersion: 2 },
+      TestConfigurations: [
+        {
+          TestTargets: [
+            {
+              BlueprintName: "AppUITests",
+              DependentProductPaths: [
+                "/dd/Build/Products/Debug-iphoneos/AppUITests-Runner.app",
+                "/dd/Build/Products/Debug-iphoneos/App.app",
+                "/dd/Build/Products/Debug-iphoneos/Some.framework",
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const count = sweepXctestrunDependentProductPaths(
+      xctestrun,
+      "/signed/App.app",
+    );
+    expect(count).toBe(1);
+    const deps =
+      xctestrun.TestConfigurations[0].TestTargets[0].DependentProductPaths;
+    expect(deps).toEqual([
+      "/dd/Build/Products/Debug-iphoneos/AppUITests-Runner.app",
+      "/signed/App.app",
+      "/dd/Build/Products/Debug-iphoneos/Some.framework",
+    ]);
+  });
+
+  it("rewrites the flat FormatVersion 1 layout", () => {
+    const xctestrun = {
+      __xctestrun_metadata__: { FormatVersion: 1 },
+      AppUITests: {
+        TestHostPath: "/dd/Build/Products/Debug-iphoneos/AppUITests-Runner.app",
+        DependentProductPaths: [
+          "/dd/Build/Products/Debug-iphoneos/App.app",
+          "/dd/Build/Products/Debug-iphoneos/AppUITests-Runner.app",
+        ],
+      },
+    };
+    const count = sweepXctestrunDependentProductPaths(
+      xctestrun,
+      "/signed/App.app",
+    );
+    expect(count).toBe(1);
+    expect(xctestrun.AppUITests.DependentProductPaths).toEqual([
+      "/signed/App.app",
+      "/dd/Build/Products/Debug-iphoneos/AppUITests-Runner.app",
+    ]);
+  });
+
+  it("is idempotent: an entry already pointing at the signed app is not re-counted", () => {
+    const xctestrun = {
+      __xctestrun_metadata__: { FormatVersion: 1 },
+      AppUITests: {
+        DependentProductPaths: ["/signed/App.app"],
+      },
+    };
+    expect(
+      sweepXctestrunDependentProductPaths(xctestrun, "/signed/App.app"),
+    ).toBe(0);
+    expect(xctestrun.AppUITests.DependentProductPaths).toEqual([
+      "/signed/App.app",
+    ]);
+  });
+
+  it("returns 0 when there are no DependentProductPaths to sweep", () => {
+    expect(
+      sweepXctestrunDependentProductPaths(
+        { AppUITests: { TestHostPath: "/x/Runner.app" } },
+        "/signed/App.app",
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("planSignedAppDdOverwrite (#13564)", () => {
+  const DD = "/dd/Build/Products/Debug-iphoneos/App.app";
+  const SIGNED = "/stage/App.app";
+
+  it("overwrites the DD product with the signed app on a device run", () => {
+    expect(
+      planSignedAppDdOverwrite({
+        platform: "device",
+        signedAppPath: SIGNED,
+        derivedDataProductApp: DD,
+        productExists: true,
+      }),
+    ).toEqual({ overwrite: true, from: SIGNED, to: DD });
+  });
+
+  it("never overwrites on a simulator run", () => {
+    const plan = planSignedAppDdOverwrite({
+      platform: "sim",
+      signedAppPath: SIGNED,
+      derivedDataProductApp: DD,
+      productExists: true,
+    });
+    expect(plan.overwrite).toBe(false);
+    expect(plan.reason).toMatch(/not a device run/);
+  });
+
+  it("skips when no signed --app-path is given", () => {
+    const plan = planSignedAppDdOverwrite({
+      platform: "device",
+      signedAppPath: null,
+      derivedDataProductApp: DD,
+      productExists: true,
+    });
+    expect(plan.overwrite).toBe(false);
+    expect(plan.reason).toMatch(/no --app-path/);
+  });
+
+  it("skips when the DD product path could not be resolved", () => {
+    const plan = planSignedAppDdOverwrite({
+      platform: "device",
+      signedAppPath: SIGNED,
+      derivedDataProductApp: null,
+      productExists: false,
+    });
+    expect(plan.overwrite).toBe(false);
+    expect(plan.reason).toMatch(/could not resolve/);
+  });
+
+  it("skips (no-op) when the signed app IS the DD product", () => {
+    const plan = planSignedAppDdOverwrite({
+      platform: "device",
+      signedAppPath: DD,
+      derivedDataProductApp: DD,
+      productExists: true,
+    });
+    expect(plan.overwrite).toBe(false);
+    expect(plan.reason).toMatch(/nothing to overwrite/);
+  });
+
+  it("skips with an actionable reason when the DD product is missing", () => {
+    const plan = planSignedAppDdOverwrite({
+      platform: "device",
+      signedAppPath: SIGNED,
+      derivedDataProductApp: DD,
+      productExists: false,
+    });
+    expect(plan.overwrite).toBe(false);
+    expect(plan.reason).toMatch(/no build product at .*skip-build/);
+  });
+});
+
+describe("classifyCodesignPreflight (#13564)", () => {
+  it("passes when every bundle is signed", () => {
+    const verdict = classifyCodesignPreflight({
+      checks: [
+        { label: "XCUITest runner", path: "/x/Runner.app", signed: true },
+        { label: "target app", path: "/x/App.app", signed: true },
+      ],
+      appPathProvided: true,
+    });
+    expect(verdict.ok).toBe(true);
+    expect(verdict.unsigned).toEqual([]);
+    expect(verdict.message).toBeNull();
+  });
+
+  it("fails fast naming 0xe800801c + the unsigned bundle(s)", () => {
+    const verdict = classifyCodesignPreflight({
+      checks: [
+        { label: "XCUITest runner", path: "/x/Runner.app", signed: true },
+        { label: "target app", path: "/x/App.app", signed: false },
+      ],
+      appPathProvided: true,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.unsigned).toEqual([
+      { label: "target app", path: "/x/App.app" },
+    ]);
+    expect(verdict.message).toMatch(/0xe800801c/);
+    expect(verdict.message).toContain("/x/App.app");
+  });
+
+  it("points a --app-path run at re-staging via ios:device:deploy", () => {
+    const verdict = classifyCodesignPreflight({
+      checks: [{ label: "target app", path: "/x/App.app", signed: false }],
+      appPathProvided: true,
+    });
+    expect(verdict.message).toMatch(/ios:device:deploy/);
+    expect(verdict.message).toMatch(/--app-path/);
+  });
+
+  it("points a no-app-path run at ios:device:deploy + --app-path remediation", () => {
+    const verdict = classifyCodesignPreflight({
+      checks: [
+        {
+          label: "target app (DerivedData product)",
+          path: "/dd/App.app",
+          signed: false,
+        },
+      ],
+      appPathProvided: false,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.message).toMatch(/0xe800801c/);
+    expect(verdict.message).toMatch(/ios:device:deploy/);
+    expect(verdict.message).toMatch(/--app-path/);
   });
 });
 


### PR DESCRIPTION
## Problem

On a physical-device run, `ios:device:capture --app-path <signed App.app>` rewrites the `.xctestrun`'s `UITargetAppPath` to the grafted-signature `App.app` — but `xcodebuild` still references/installs the **UNSIGNED** `App.app` that `build-for-testing` left in the runner DerivedData products dir (`<derived-data>/Build/Products/Debug-iphoneos/App.app`), plus any stale reference to it in each test target's `DependentProductPaths`. The device install then aborts with `0xe800801c` ("No code signature"). The empirically-proven fix (overwrite the DD product with the signed staged app) was codified nowhere — it lived only in a scratchpad `sign-runner.sh`, so every fresh operator/agent re-hit `0xe800801c`.

## Change

Three pure, unit-tested helpers in `scripts/ios-device-lib.mjs`, wired into `ios-device-capture.mjs`'s device lane:

- **`sweepXctestrunDependentProductPaths(xctestrun, signedApp)`** — rewrites stale `App.app` refs in every `DependentProductPaths` array to the signed graft. Runner apps, frameworks, and entries already pointing at the signed app are left untouched; idempotent. (The existing suite covered `UITargetAppPath` only.)
- **`planSignedAppDdOverwrite(...)`** — decides whether/where to `ditto` the signed staged app over `<DD>/Build/Products/<config>-iphoneos/App.app` before `test-without-building`. Device runs only, with an actionable skip reason (sim run / no `--app-path` / unresolved-or-missing DD product / signed app *is* the product).
- **`classifyCodesignPreflight(...)`** — after the overwrite, `codesign --verify` the runner + DD product. An unsigned bundle **fails fast** with the exact `0xe800801c` remediation text (pointing at `ios:device:deploy` + `--app-path`) instead of an opaque devicectl install error deep in the run.

Fail-closed throughout: a missing bundle counts as unsigned; an unresolvable/missing DD product skips the overwrite with a reason rather than silently proceeding.

## Tests

`bunx vitest run scripts/ios-device-lib.test.mjs` — **54/54 green** (40 pre-existing + 14 new):
- `sweepXctestrunDependentProductPaths`: FormatVersion 1 + 2 layouts, idempotence, no-op when nothing to sweep.
- `planSignedAppDdOverwrite`: full decision matrix (device-overwrite, sim-skip, no-app-path-skip, unresolved-skip, is-product no-op, missing-product actionable-skip).
- `classifyCodesignPreflight`: all-signed pass, fail-fast naming `0xe800801c` + the unsigned bundle(s), both remediation branches (`--app-path` given vs not).

**Reversion-proven**: disabling the basename match in the sweep fails the 2 sweep tests. Also `node --check` clean on all 3 files, `biome check` clean, `error-policy-ratchet` no-new-slop, `audit:scripts` does not flag my files (the sole finding is the pre-existing `check-markdown-links.mjs` coupling, byte-identical to develop).

## Scope note

The decision logic is headlessly provable and fully covered here. A live device install re-verification (fresh unsigned-DD runner + signed staged app → running suite with no `0xe800801c`) is **device-gated** and cannot be produced from a headless lane — called out per the issue's Verification section.

-- [sol-orch]
