### PR TITLE
fix(#13624): --require-evidence makes capture skips fail non-zero (no more green-with-nothing)

### DIFF
--- a/packages/app/scripts/lib/issue-evidence.mjs
+++ b/packages/app/scripts/lib/issue-evidence.mjs
@@ -20,6 +20,83 @@ export const ISSUE_EVIDENCE_DIR = path.join(
   "issue-evidence",
 );
 
+/**
+ * Truthiness for an env var that carries a boolean intent. Treats the common
+ * falsey spellings (`"0"`, `"false"`, `"no"`, `"off"`, empty/whitespace) as
+ * false and any other non-empty value as true, so `CI=true`, `CI=1`, and a bare
+ * `CI=""` (GitHub sets `CI=true`, but a defensively-empty value should NOT arm
+ * a hard gate) all resolve sanely.
+ */
+function envFlagIsTrue(value) {
+  if (value === undefined || value === null) return false;
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === "") return false;
+  return !(
+    normalized === "0" ||
+    normalized === "false" ||
+    normalized === "no" ||
+    normalized === "off"
+  );
+}
+
+/**
+ * Resolve whether a capture run must PRODUCE evidence (vs. being allowed to
+ * soft-skip when the platform/tooling is absent). This is the fix for the
+ * "green-with-nothing" disease: when evidence was explicitly requested, a
+ * `skip()` (no device / not the right OS / tool missing) must become a hard,
+ * non-zero failure instead of exiting 0 with zero artifacts.
+ *
+ * Sources, in precedence order:
+ *   1. An explicit opt-OUT always wins: `--no-require-evidence`, or
+ *      `--require-evidence false|0|no|off`. This lets an operator run a capture
+ *      locally under CI without the gate arming.
+ *   2. An explicit opt-IN: a bare `--require-evidence` (or `=true|1|yes|on`).
+ *   3. Env opt-in: `E2E_REQUIRE_EVIDENCE` / `ELIZA_REQUIRE_EVIDENCE` truthy.
+ *   4. Auto-on under CI: `CI` truthy (GitHub Actions et al.).
+ * Otherwise false (local ad-hoc runs stay soft-skippable — behavior-preserving).
+ *
+ * Pure + exported so it is unit-testable without spawning a process.
+ */
+export function resolveRequireEvidence(
+  argv = process.argv.slice(2),
+  env = process.env,
+) {
+  // Scan argv for the flag (last occurrence wins) so an explicit value or an
+  // explicit --no- form is authoritative over the env/CI defaults.
+  let explicit; // undefined | true | false
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === "--no-require-evidence") {
+      explicit = false;
+      continue;
+    }
+    if (token === "--require-evidence") {
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        const v = next.trim().toLowerCase();
+        explicit = !(v === "0" || v === "false" || v === "no" || v === "off");
+        i++;
+      } else {
+        explicit = true;
+      }
+      continue;
+    }
+    if (token.startsWith("--require-evidence=")) {
+      const v = token.slice("--require-evidence=".length).trim().toLowerCase();
+      explicit = !(v === "0" || v === "false" || v === "no" || v === "off");
+    }
+  }
+  if (explicit !== undefined) return explicit;
+
+  if (
+    envFlagIsTrue(env?.E2E_REQUIRE_EVIDENCE) ||
+    envFlagIsTrue(env?.ELIZA_REQUIRE_EVIDENCE)
+  ) {
+    return true;
+  }
+  return envFlagIsTrue(env?.CI);
+}
+
 /** Parse `--flag value` and boolean `--flag` from argv into a flat object. */
 export function parseFlags(argv = process.argv.slice(2)) {
   const flags = {};
@@ -103,9 +180,35 @@ export function captureBackendLog(
   return out;
 }
 
-/** Print a skip-with-reason line and exit 0 — capture is non-fatal when the
- * platform/tooling is absent, matching scripts/e2e-recordings/run-all.mjs. */
-export function skip(platform, reason) {
+/**
+ * Print a skip-with-reason line and exit.
+ *
+ * Default (evidence NOT required): exit 0 — capture is non-fatal when the
+ * platform/tooling is absent, matching scripts/e2e-recordings/run-all.mjs.
+ *
+ * When evidence WAS explicitly required (`--require-evidence`, or auto-on under
+ * CI — see resolveRequireEvidence): print a distinct failure line and exit
+ * NON-ZERO (1). A capture that was demanded but produced nothing is a real
+ * failure, not a silent green-skip. This is the core of the #13624 fix: the
+ * skip contract can no longer swallow a missing artifact when the caller asked
+ * for one.
+ *
+ * @param {string} platform
+ * @param {string} reason
+ * @param {{ requireEvidence?: boolean }} [opts] override the resolved default
+ *   (primarily for tests / callers that already parsed the flag).
+ */
+export function skip(platform, reason, opts = {}) {
+  const required =
+    opts.requireEvidence !== undefined
+      ? opts.requireEvidence
+      : resolveRequireEvidence();
+  if (required) {
+    console.error(
+      `[capture:${platform}] [require-evidence] evidence was required but not captured: ${reason}`,
+    );
+    process.exit(1);
+  }
   console.log(`[capture:${platform}] [skip] ${reason}`);
   process.exit(0);
 }

--- a/packages/app/scripts/lib/issue-evidence.test.mjs
+++ b/packages/app/scripts/lib/issue-evidence.test.mjs
@@ -1,0 +1,169 @@
+// #13624: the capture skip contract must not swallow a missing artifact when
+// evidence was explicitly requested. resolveRequireEvidence() decides whether a
+// run must PRODUCE evidence (explicit flag > env > auto-on under CI), and skip()
+// turns a "no device / wrong OS / tool missing" case into a NON-ZERO failure
+// when evidence was required (instead of exiting 0 green with zero artifacts).
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+import { resolveRequireEvidence } from "./issue-evidence.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+describe("resolveRequireEvidence (#13624)", () => {
+  it("defaults to false for a local ad-hoc run (no flag, no env, no CI)", () => {
+    expect(resolveRequireEvidence([], {})).toBe(false);
+  });
+
+  it("is true with a bare --require-evidence flag", () => {
+    expect(resolveRequireEvidence(["--require-evidence"], {})).toBe(true);
+  });
+
+  it("honors --require-evidence <value> (space form)", () => {
+    expect(resolveRequireEvidence(["--require-evidence", "true"], {})).toBe(
+      true,
+    );
+    expect(resolveRequireEvidence(["--require-evidence", "false"], {})).toBe(
+      false,
+    );
+    expect(resolveRequireEvidence(["--require-evidence", "0"], {})).toBe(false);
+    expect(resolveRequireEvidence(["--require-evidence", "off"], {})).toBe(
+      false,
+    );
+  });
+
+  it("honors --require-evidence=<value> (equals form)", () => {
+    expect(resolveRequireEvidence(["--require-evidence=1"], {})).toBe(true);
+    expect(resolveRequireEvidence(["--require-evidence=no"], {})).toBe(false);
+  });
+
+  it("a bare --require-evidence followed by another flag is a true opt-in", () => {
+    // `--require-evidence --issue 13624` — the next token is a flag, not a value.
+    expect(
+      resolveRequireEvidence(["--require-evidence", "--issue", "13624"], {}),
+    ).toBe(true);
+  });
+
+  it("--no-require-evidence is an explicit opt-out that beats CI", () => {
+    expect(
+      resolveRequireEvidence(["--no-require-evidence"], { CI: "true" }),
+    ).toBe(false);
+  });
+
+  it("an explicit --require-evidence false beats a truthy CI env", () => {
+    expect(
+      resolveRequireEvidence(["--require-evidence", "false"], { CI: "true" }),
+    ).toBe(false);
+  });
+
+  it("last flag occurrence wins (explicit off after on)", () => {
+    expect(
+      resolveRequireEvidence(
+        ["--require-evidence", "--no-require-evidence"],
+        {},
+      ),
+    ).toBe(false);
+    expect(
+      resolveRequireEvidence(
+        ["--no-require-evidence", "--require-evidence"],
+        {},
+      ),
+    ).toBe(true);
+  });
+
+  it("auto-on under CI=true / CI=1", () => {
+    expect(resolveRequireEvidence([], { CI: "true" })).toBe(true);
+    expect(resolveRequireEvidence([], { CI: "1" })).toBe(true);
+  });
+
+  it("does NOT arm on falsey CI spellings (0/false/off/empty)", () => {
+    for (const v of ["0", "false", "off", "no", "", "  "]) {
+      expect(resolveRequireEvidence([], { CI: v })).toBe(false);
+    }
+  });
+
+  it("env opt-in E2E_REQUIRE_EVIDENCE / ELIZA_REQUIRE_EVIDENCE", () => {
+    expect(resolveRequireEvidence([], { E2E_REQUIRE_EVIDENCE: "1" })).toBe(
+      true,
+    );
+    expect(resolveRequireEvidence([], { ELIZA_REQUIRE_EVIDENCE: "yes" })).toBe(
+      true,
+    );
+    expect(resolveRequireEvidence([], { E2E_REQUIRE_EVIDENCE: "0" })).toBe(
+      false,
+    );
+  });
+
+  it("REGRESSION: an explicit --require-evidence must not silently degrade to a soft skip", () => {
+    // The whole point of #13624: if the caller demanded evidence, resolve must
+    // report true so skip() exits non-zero. If this ever reverts to ignoring
+    // argv, this assertion fails.
+    expect(resolveRequireEvidence(["--require-evidence"], {})).not.toBe(false);
+  });
+});
+
+// skip() exits the process, so it must be exercised in a subprocess. A tiny
+// harness module (written to a real temp file so process.argv has the normal
+// [node, script, ...argv] shape — `node -e` drops argv[1]) imports the real
+// module and calls skip() with the argv/env under test. Start from a clean env
+// so the ambient host CI var can't leak into a case that expects a soft skip;
+// then layer only the vars the case declares.
+const harnessFiles = [];
+afterAll(() => {
+  for (const f of harnessFiles) {
+    try {
+      fs.rmSync(f, { force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+});
+
+function runSkip({ argv = [], env = {} } = {}) {
+  const modulePath = JSON.stringify(path.join(here, "issue-evidence.mjs"));
+  const harness = `import { skip } from ${modulePath}; skip('ios-sim', 'no booted simulator');`;
+  const harnessPath = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "issue-evidence-skip-")),
+    "harness.mjs",
+  );
+  fs.writeFileSync(harnessPath, harness, "utf8");
+  harnessFiles.push(harnessPath);
+  return spawnSync(process.execPath, [harnessPath, ...argv], {
+    encoding: "utf8",
+    env: { PATH: process.env.PATH, ...env },
+  });
+}
+
+describe("skip() exit contract (#13624)", () => {
+  it("exits 0 with a [skip] line when evidence is NOT required (local default)", () => {
+    const res = runSkip({ argv: [], env: {} });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("[capture:ios-sim] [skip]");
+    expect(res.stdout).toContain("no booted simulator");
+  });
+
+  it("exits NON-ZERO with a [require-evidence] line under --require-evidence", () => {
+    const res = runSkip({ argv: ["--require-evidence"], env: {} });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("[capture:ios-sim] [require-evidence]");
+    expect(res.stderr).toContain("evidence was required but not captured");
+  });
+
+  it("exits NON-ZERO under CI=true (auto-on) even without the flag", () => {
+    const res = runSkip({ argv: [], env: { CI: "true" } });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("[require-evidence]");
+  });
+
+  it("stays a soft skip (exit 0) with an explicit --no-require-evidence even under CI", () => {
+    const res = runSkip({
+      argv: ["--no-require-evidence"],
+      env: { CI: "true" },
+    });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("[skip]");
+  });
+});

--- a/scripts/e2e-recordings/run-all-require-evidence.test.mjs
+++ b/scripts/e2e-recordings/run-all-require-evidence.test.mjs
@@ -1,0 +1,68 @@
+// #13624: the e2e-recordings sweep must not go green having recorded nothing.
+// classifyRunResults folds a `skipped` suite into `failed` under
+// --require-evidence (auto-on under CI) so a headless runner that captured zero
+// artifacts fails the run, while preserving the soft-skip behavior otherwise.
+import { describe, expect, it } from "vitest";
+import { classifyRunResults } from "./run-all.mjs";
+
+const passedSuite = { name: "app", passed: true, skipped: false, exitCode: 0 };
+const failedSuite = {
+  name: "cloud",
+  passed: false,
+  skipped: false,
+  exitCode: 1,
+};
+const skippedSuite = {
+  name: "ios-sim",
+  passed: false,
+  skipped: true,
+  exitCode: 77,
+  reason: "no booted simulator",
+};
+
+describe("classifyRunResults require-evidence contract (#13624)", () => {
+  it("without require-evidence: a skip stays a soft skip and does not fail the run", () => {
+    const c = classifyRunResults([passedSuite, skippedSuite], false);
+    expect(c.passed.map((r) => r.name)).toEqual(["app"]);
+    expect(c.softSkipped.map((r) => r.name)).toEqual(["ios-sim"]);
+    expect(c.failed).toEqual([]);
+    expect(c.shouldFail).toBe(false);
+  });
+
+  it("REGRESSION: WITH require-evidence a skipped suite becomes a failure (green-with-nothing closed)", () => {
+    const c = classifyRunResults([passedSuite, skippedSuite], true);
+    // The skip is no longer counted as a benign skip...
+    expect(c.softSkipped).toEqual([]);
+    // ...it is folded into failed and the run must fail.
+    expect(c.failed.map((r) => r.name)).toEqual(["ios-sim"]);
+    expect(c.skippedButRequired.map((r) => r.name)).toEqual(["ios-sim"]);
+    expect(c.shouldFail).toBe(true);
+  });
+
+  it("a real non-zero failure always fails the run, require-evidence or not", () => {
+    expect(classifyRunResults([failedSuite], false).shouldFail).toBe(true);
+    expect(classifyRunResults([failedSuite], true).shouldFail).toBe(true);
+  });
+
+  it("an all-passing run stays green under require-evidence", () => {
+    const c = classifyRunResults([passedSuite], true);
+    expect(c.shouldFail).toBe(false);
+    expect(c.failed).toEqual([]);
+    expect(c.skippedButRequired).toEqual([]);
+  });
+
+  it("mixed: pass + real-fail + skip under require-evidence folds skip AND fail together", () => {
+    const c = classifyRunResults(
+      [passedSuite, failedSuite, skippedSuite],
+      true,
+    );
+    expect(c.passed.map((r) => r.name)).toEqual(["app"]);
+    expect(c.failed.map((r) => r.name).sort()).toEqual(["cloud", "ios-sim"]);
+    expect(c.shouldFail).toBe(true);
+  });
+
+  it("preserves the skip reason so the failure line can explain what was missing", () => {
+    const c = classifyRunResults([skippedSuite], true);
+    expect(c.failed[0].reason).toBe("no booted simulator");
+  });
+});

--- a/scripts/e2e-recordings/run-all.mjs
+++ b/scripts/e2e-recordings/run-all.mjs
@@ -20,6 +20,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveRequireEvidence } from "../../packages/app/scripts/lib/issue-evidence.mjs";
 import { RECORDINGS_DIR, REPO_ROOT, UI_E2E_SUITES } from "./suites.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -49,6 +50,15 @@ const skipSheets =
   flagMap.get("skip-sheets") === true || flagMap.get("skip-sheets") === "true";
 const skipViewer =
   flagMap.get("skip-viewer") === true || flagMap.get("skip-viewer") === "true";
+
+// When evidence is required (explicit --require-evidence, or auto-on under CI),
+// a suite that soft-skips (SKIP_EXIT_CODE=77, missing dir/script/package.json,
+// or an unavailable availability-check) produced ZERO artifacts and must count
+// as a FAILURE, not a benign skip. Otherwise the recordings sweep goes green on
+// a headless runner with nothing captured (#13624 "green-with-nothing"). We
+// hand argv explicitly (stripping the `=value` join key parsing above only
+// affects flagMap; resolveRequireEvidence re-scans raw argv).
+const requireEvidence = resolveRequireEvidence(args);
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -262,6 +272,14 @@ async function main() {
   // ─── Step 1: Run tests ─────────────────────────────────────
   const results = [];
 
+  if (skipTests && requireEvidence) {
+    console.error(
+      "[require-evidence] --skip-tests cannot be combined with --require-evidence: " +
+        "a run that skips every suite captures no evidence.",
+    );
+    process.exit(1);
+  }
+
   if (skipTests) {
     console.log("Skipping test runs (--skip-tests).");
     for (const pkg of packagesToRun) {
@@ -319,9 +337,8 @@ async function main() {
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
   banner("Summary");
 
-  const passed = results.filter((r) => r.passed && !r.skipped);
-  const failed = results.filter((r) => !r.passed && !r.skipped);
-  const skipped = results.filter((r) => r.skipped);
+  const { passed, failed, softSkipped, skippedButRequired } =
+    classifyRunResults(results, requireEvidence);
 
   if (passed.length > 0) {
     console.log(`\nPassed (${passed.length}):`);
@@ -329,13 +346,23 @@ async function main() {
   }
   if (failed.length > 0) {
     console.log(`\nFailed (${failed.length}):`);
-    for (const r of failed) console.log(`  ✗ ${r.name}  (exit ${r.exitCode})`);
+    for (const r of failed) {
+      const why = r.skipped
+        ? `skipped but evidence required${r.reason ? `: ${r.reason}` : ""}`
+        : `exit ${r.exitCode}`;
+      console.log(`  ✗ ${r.name}  (${why})`);
+    }
   }
-  if (skipped.length > 0) {
-    console.log(`\nSkipped (${skipped.length}):`);
-    for (const r of skipped) {
+  if (softSkipped.length > 0) {
+    console.log(`\nSkipped (${softSkipped.length}):`);
+    for (const r of softSkipped) {
       console.log(`  - ${r.name}${r.reason ? `: ${r.reason}` : ""}`);
     }
+  }
+  if (requireEvidence && skippedButRequired.length > 0) {
+    console.warn(
+      `\n[require-evidence] ${skippedButRequired.length} suite(s) skipped with no artifacts — failing the run.`,
+    );
   }
 
   const indexPath = path.join(RECORDINGS_DIR, "index.html");
@@ -352,7 +379,34 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error("Fatal error:", err);
-  process.exit(1);
-});
+// Exported so the require-evidence exit contract is unit-testable without
+// spawning the full sweep. Under --require-evidence a `skipped` suite captured
+// ZERO artifacts, so it must count as a FAILURE (not a benign skip) — otherwise
+// the recordings sweep goes green on a headless runner having recorded nothing
+// (#13624 "green-with-nothing"). Without the flag, behavior is preserved: a
+// skip stays a soft skip and only real non-zero exits fail the run.
+export function classifyRunResults(results, requireEvidence) {
+  const passed = results.filter((r) => r.passed && !r.skipped);
+  const skipped = results.filter((r) => r.skipped);
+  const failedRuns = results.filter((r) => !r.passed && !r.skipped);
+  const skippedButRequired = requireEvidence ? skipped : [];
+  const softSkipped = requireEvidence ? [] : skipped;
+  const failed = [...failedRuns, ...skippedButRequired];
+  return {
+    passed,
+    failed,
+    softSkipped,
+    skippedButRequired,
+    shouldFail: failed.length > 0,
+  };
+}
+
+// The orchestrator self-executes only when run as a script, so the pure helper
+// above can be imported by tests without kicking off the whole sweep.
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+if (isMain) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the capture-layer half of #13624's "green-with-nothing" disease: the evidence-capture **skip contract** silently swallowed missing artifacts. A capture that was explicitly requested on a headless CI runner would exit **green with zero artifacts**.

Two paths were fail-open:
- `skip(platform, reason)` in `packages/app/scripts/lib/issue-evidence.mjs` unconditionally `process.exit(0)` — a "no device / wrong OS / tool missing" case was always a soft pass.
- The e2e-recordings sweep (`scripts/e2e-recordings/run-all.mjs`) treated a `skipped` suite (`SKIP_EXIT_CODE=77`, missing dir/script) as a benign skip, never failing the run.

This implements **Task 2** of the issue: *"Add `--require-evidence` (auto-on under CI) so `skip()`/`77` become non-zero when a capture was explicitly requested."*

## What changed

- **New exported `resolveRequireEvidence(argv, env)`** (pure, unit-tested). Precedence: explicit `--require-evidence` / `--no-require-evidence` (or `--require-evidence=true|false|0|no|off`) > `E2E_REQUIRE_EVIDENCE` / `ELIZA_REQUIRE_EVIDENCE` env > auto-on under `CI`. An explicit opt-out beats `CI`; falsey `CI` spellings (`0`/`false`/`off`/empty) do not arm.
- **`skip()`** now exits **non-zero** with a distinct `[require-evidence] evidence was required but not captured: …` line when evidence was required; **behavior-preserving** soft skip (exit 0) otherwise, so a local ad-hoc run with no device stays green.
- **`run-all.mjs`**: new exported `classifyRunResults(results, requireEvidence)` folds a `skipped` suite into `failed` under require-evidence so the sweep fails (with a clear per-suite reason); `--skip-tests` + `--require-evidence` errors out early (a run that skips every suite captures nothing). The orchestrator now self-executes only when run as a script, so the pure helper is importable by tests without kicking off the sweep.

## Scope

Tightly scoped to the skip-contract half, which is honestly headless-provable. **NOT** touched (left for follow-up slices, issue stays open): fresh-build-marker assertion, the `audit:cloud` strict-gate + `cloud-aesthetic-audit.yml`, capture-script dedup, Electrobun window-only screenshot. `.github/workflows/*` is **not** touched (that wiring is needs-human). My prior slice #13679 (backend-log port de-hardcode) is a distinct file scope.

## Tests / evidence

- `packages/app/scripts/lib/issue-evidence.test.mjs` — **16 tests**: flag/env/CI resolution (all precedence + falsey-spelling cases) + subprocess `skip()` exit contract (soft-skip exit 0 vs. required non-zero, CI auto-on, explicit opt-out beats CI).
- `scripts/e2e-recordings/run-all-require-evidence.test.mjs` — **6 tests**: `classifyRunResults` folds skip→fail under require-evidence, preserves soft-skip otherwise, real failures always fail, reason preserved.
- **22/22 green.** Reversion-proven: reverting `classifyRunResults` fails 3 tests; reverting `skip()` fails 2 subprocess tests.
- `biome check` clean on all 4 files; `error-policy-ratchet` clean (no new fallback-slop); `audit:scripts` shows only the **pre-existing** `check-markdown-links.mjs` coupling (#13708, byte-identical to develop, untouched — none of my files flagged).
- **codex review clean**: independently ran the 22 tests (22 pass) and *"did not find a discrete correctness issue introduced by the patch."*

Collision receipts: no open PR on #13624 other than my own #13679 (distinct file scope), no merged dup on develop, no lalalune/NubsCarson/roninjin10 require-evidence PR in the last day, unique worktree path fleet-13624.

— [sol-orch]
