### PR TITLE
ci(cloud): sync FAL_API_KEY + voice-catalog signing keys to the Worker on deploy

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -25,6 +25,11 @@ name: Cloud CF Deploy
 # providers directly and uses OpenRouter as the backup):
 #   OPENROUTER_API_KEY, CEREBRAS_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY,
 #   GROQ_API_KEY, AI_GATEWAY_API_KEY, FAL_KEY, ELEVENLABS_API_KEY, VAST_API_KEY, VAST_BASE_URL.
+# Media/voice secrets, likewise published when configured (#13406):
+#   FAL_API_KEY (the video provider registry reads FAL_KEY ?? FAL_API_KEY),
+#   ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64 + ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64
+#   (Ed25519 keypair for the signed voice-model catalog; the catalog route 503s
+#   while the signing key is unset).
 #
 # Source: cloud/.github/workflows/cf-deploy.yml in the original elizaOS/cloud repo.
 
@@ -438,7 +443,16 @@ jobs:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
           FAL_KEY: ${{ secrets.FAL_KEY }}
+          # fal key under its alternate name: the video provider registry reads
+          # FAL_KEY ?? FAL_API_KEY, and prod carries it as FAL_API_KEY (#13406).
+          FAL_API_KEY: ${{ secrets.FAL_API_KEY }}
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+          # Ed25519 keypair for the signed voice-model catalog —
+          # /v1/voice-models/catalog 503s while the signing key is unset
+          # (#13406). publish_secret no-ops with a notice while these are
+          # unset, so they publish on every redeploy once ops adds them.
+          ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64: ${{ secrets.ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64 }}
+          ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64: ${{ secrets.ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64 }}
           VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
           VAST_BASE_URL: ${{ secrets.VAST_BASE_URL }}
           # Platform key the Worker forwards as X-Steward-Platform-Key so per-org
@@ -486,7 +500,10 @@ jobs:
             GROQ_API_KEY \
             AI_GATEWAY_API_KEY \
             FAL_KEY \
+            FAL_API_KEY \
             ELEVENLABS_API_KEY \
+            ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64 \
+            ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64 \
             VAST_API_KEY \
             VAST_BASE_URL \
             STEWARD_PLATFORM_KEYS


### PR DESCRIPTION
## What

Adds three media/voice secret names to the deploy workflow's **Publish Worker AI secrets** step (`env:` block + the `publish_secret` enumeration + the header doc list) so they sync from GitHub environment secrets to the Cloudflare Worker on every deploy, like the other provider keys.

Part of tracker #13406 — staging media-gen breakage found by [stan-cloud]'s funded-guest sweep traced to Worker env vars that the code reads but the deploy pipeline never publishes.

## The three names and why each

| Name | Why |
| --- | --- |
| `FAL_API_KEY` | The video provider registry reads `FAL_KEY ?? FAL_API_KEY` (`packages/cloud/shared/src/lib/providers/video/registry.ts`). Prod has `FAL_API_KEY` set manually on the Worker, but it was never in the sync list — so it silently depends on that one-off manual put surviving. |
| `ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64` | Required by `packages/cloud/api/v1/voice-models/catalog/route.ts` — the route returns **503** while it is unset. It was unset on BOTH envs until today. |
| `ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64` | Same route — serves the key fingerprints alongside the Ed25519-signed catalog body. |

## Behavior / rollout

- **This is a no-op until the GH environment secrets are populated.** The step's existing `publish_secret` helper skips any name whose GH secret is unset with a `::notice::`, so merging this changes nothing until ops adds the secrets — and from then on they re-publish on every redeploy.
- Staging's voice-catalog keys were direct-put onto the Worker today by [cloud-agent] as a stopgap; this PR supersedes that at the next deploy once the GH env secrets are populated (until then the direct-put values stay in place, since unset names are skipped, not cleared).
- No other workflow changes: `git diff` is 17 pure insertions (env entries, loop names, header doc lines, and short why-comments matching the step's existing `STEWARD_PLATFORM_KEYS` comment style).

## Verification

- `python3 -c "import yaml;yaml.safe_load(open('.github/workflows/cloud-cf-deploy.yml'))"` — parses clean.
- `actionlint .github/workflows/cloud-cf-deploy.yml` — clean (system actionlint).
- Diff reviewed: additions only, no reflow of existing lines.

Refs #13406

— [cloud-agent]
