### PR TITLE
fix(#13584): use 32k Android smoke GGUF

### DIFF
--- a/packages/app/scripts/android-e2e.mjs
+++ b/packages/app/scripts/android-e2e.mjs
@@ -42,8 +42,9 @@ const log = (m) => console.log(`[android-e2e] ${m}`);
 // Smallest local tier; same id the smoke + catalog use.
 const SMOKE_MODEL = {
   id: "eliza-1-2b",
-  file: "eliza-1-2b-128k.gguf",
-  url: "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/2b/text/eliza-1-2b-128k.gguf?download=true",
+  file: "eliza-1-e2b-32k.gguf",
+  sizeBytes: 1_270_808_512,
+  url: "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/e2b/text/eliza-1-e2b-32k.gguf?download=true",
   cacheDir: path.join(
     process.env.HOME ?? process.env.USERPROFILE ?? ".",
     ".cache/eliza/android-smoke-models",
@@ -174,8 +175,8 @@ function run(cmd, args, env = {}) {
 // model so the smoke reuses it offline instead of failing on the redirect.
 function ensureSmokeModelCached() {
   const dest = path.join(SMOKE_MODEL.cacheDir, SMOKE_MODEL.file);
-  if (fs.existsSync(dest) && fs.statSync(dest).size > 0) {
-    log(`smoke model cached: ${dest}`);
+  if (fs.existsSync(dest) && fs.statSync(dest).size === SMOKE_MODEL.sizeBytes) {
+    log(`smoke model cached: ${dest} (${SMOKE_MODEL.sizeBytes} bytes)`);
     return dest;
   }
   fs.mkdirSync(SMOKE_MODEL.cacheDir, { recursive: true });
@@ -183,6 +184,12 @@ function ensureSmokeModelCached() {
   execFileSync("curl", ["-fsSL", "-o", dest, SMOKE_MODEL.url], {
     stdio: "inherit",
   });
+  const actualSize = fs.statSync(dest).size;
+  if (actualSize !== SMOKE_MODEL.sizeBytes) {
+    throw new Error(
+      `downloaded smoke model ${SMOKE_MODEL.file} size mismatch: expected ${SMOKE_MODEL.sizeBytes} bytes, got ${actualSize} bytes`,
+    );
+  }
   return dest;
 }
 

--- a/packages/app/scripts/android-smoke-model-contract.test.mjs
+++ b/packages/app/scripts/android-smoke-model-contract.test.mjs
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(scriptsDir, "..");
+const androidE2e = fs.readFileSync(
+  path.join(scriptsDir, "android-e2e.mjs"),
+  "utf8",
+);
+const mobileSmoke = fs.readFileSync(
+  path.join(scriptsDir, "mobile-local-chat-smoke.mjs"),
+  "utf8",
+);
+const androidDevice = fs.readFileSync(
+  path.join(scriptsDir, "lib", "android-device.mjs"),
+  "utf8",
+);
+const androidReadme = fs.readFileSync(
+  path.join(appDir, "test", "android", "README.md"),
+  "utf8",
+);
+
+const smokeModel = {
+  file: "eliza-1-e2b-32k.gguf",
+  relativePath: "bundles/e2b/text/eliza-1-e2b-32k.gguf",
+  sizeBytes: "1_270_808_512",
+  docSizeBytes: "1,270,808,512",
+  staleFile: "eliza-1-2b-128k.gguf",
+  staleSizeClaim: "~556MB",
+};
+
+describe("Android smoke model contract (#13584)", () => {
+  it("uses the 32k GGUF in both Android smoke entrypoints", () => {
+    expect(androidE2e).toContain(`file: "${smokeModel.file}"`);
+    expect(androidE2e).toContain(smokeModel.relativePath);
+    expect(mobileSmoke).toContain(`file: "${smokeModel.file}"`);
+    expect(mobileSmoke).toContain(`relativePath: "${smokeModel.relativePath}"`);
+  });
+
+  it("keeps script and README size guidance on the same artifact", () => {
+    for (const source of [androidE2e, mobileSmoke]) {
+      expect(source).toContain(`sizeBytes: ${smokeModel.sizeBytes}`);
+    }
+    for (const source of [androidDevice, androidReadme]) {
+      expect(source).toContain(smokeModel.docSizeBytes);
+      expect(source).not.toContain(smokeModel.staleSizeClaim);
+    }
+    expect(androidReadme).toContain(smokeModel.file);
+  });
+
+  it("does not leave Android defaults on the old 128k smoke artifact", () => {
+    expect(androidE2e).not.toContain(smokeModel.staleFile);
+    expect(mobileSmoke).not.toContain(
+      `relativePath: "bundles/2b/text/${smokeModel.staleFile}"`,
+    );
+    expect(mobileSmoke).not.toContain(`file: "${smokeModel.staleFile}"`);
+  });
+});

--- a/packages/app/scripts/lib/android-device.mjs
+++ b/packages/app/scripts/lib/android-device.mjs
@@ -292,9 +292,9 @@ export async function ensureEmulatorBooted({
   log(`booting emulator AVD ${chosen}`);
   const logFile = path.join(os.tmpdir(), `eliza-emulator-${chosen}.log`);
   const out = fs.openSync(logFile, "a");
-  // The embedded on-device agent (bun + a ~556MB GGUF) needs real headroom;
-  // a stock 2GB AVD OOM-thrashes during model load/inference. Give the test
-  // emulator 6GB RAM + 4 cores unless overridden.
+  // The embedded on-device agent (bun + a 1,270,808,512-byte GGUF) needs real
+  // headroom; a stock 2GB AVD OOM-thrashes during model load/inference. Give
+  // the test emulator 6GB RAM + 4 cores unless overridden.
   const memoryMb = process.env.ELIZA_EMULATOR_MEMORY_MB ?? "6144";
   const cores = process.env.ELIZA_EMULATOR_CORES ?? "4";
   // The on-device agent's bun + llama-cpp are compiled with -mavx2 -mfma -mf16c,

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -124,17 +124,26 @@ const ANDROID_SMOKE_MODEL_CONTEXT_SIZE = Number.parseInt(
 );
 const ANDROID_SMOKE_MODEL_ID =
   process.env.ANDROID_SMOKE_MODEL_ID?.trim() || "eliza-1-2b";
+const DEFAULT_ANDROID_SMOKE_MODEL = {
+  relativePath: "bundles/e2b/text/eliza-1-e2b-32k.gguf",
+  file: "eliza-1-e2b-32k.gguf",
+  sizeBytes: 1_270_808_512,
+};
 const ANDROID_SMOKE_MODEL_RELATIVE_PATH =
   process.env.ANDROID_SMOKE_MODEL_RELATIVE_PATH?.trim() ||
-  "bundles/2b/text/eliza-1-2b-128k.gguf";
+  DEFAULT_ANDROID_SMOKE_MODEL.relativePath;
 const ANDROID_SMOKE_MODEL_FILE =
-  process.env.ANDROID_SMOKE_MODEL_FILE?.trim() || "eliza-1-2b-128k.gguf";
-// Size/sha defaults are unset for the 2B entry tier — set them via env to
-// re-enable the exact-match download verification against a known artifact.
-const ANDROID_SMOKE_MODEL_SIZE_BYTES = Number.parseInt(
-  process.env.ANDROID_SMOKE_MODEL_SIZE_BYTES?.trim() || "",
-  10,
-);
+  process.env.ANDROID_SMOKE_MODEL_FILE?.trim() ||
+  DEFAULT_ANDROID_SMOKE_MODEL.file;
+const androidSmokeModelSizeOverride =
+  process.env.ANDROID_SMOKE_MODEL_SIZE_BYTES?.trim();
+const ANDROID_SMOKE_MODEL_SIZE_BYTES = androidSmokeModelSizeOverride
+  ? Number.parseInt(androidSmokeModelSizeOverride, 10)
+  : ANDROID_SMOKE_MODEL_RELATIVE_PATH ===
+        DEFAULT_ANDROID_SMOKE_MODEL.relativePath &&
+      ANDROID_SMOKE_MODEL_FILE === DEFAULT_ANDROID_SMOKE_MODEL.file
+    ? DEFAULT_ANDROID_SMOKE_MODEL.sizeBytes
+    : Number.NaN;
 const ANDROID_SMOKE_MODEL_SHA256 =
   process.env.ANDROID_SMOKE_MODEL_SHA256?.trim() || "";
 const ANDROID_SMOKE_MODEL_URL =
@@ -762,6 +771,11 @@ async function verifySmokeModelFile(filePath) {
   return true;
 }
 
+function describeAndroidSmokeModelSize(sizeBytes) {
+  if (!Number.isFinite(sizeBytes)) return "unknown size";
+  return `${sizeBytes} bytes`;
+}
+
 async function ensureAndroidSmokeModelLocalFile() {
   const explicit = process.env.ANDROID_SMOKE_MODEL_PATH?.trim();
   if (explicit) {
@@ -840,17 +854,24 @@ async function stageAndroidSmokeModel(context) {
     "Failed to inspect Android smoke model.",
     { allowFailure: true },
   );
-  const expectedSize = String(ANDROID_SMOKE_MODEL_SIZE_BYTES);
-  if (existingBytes?.trim() === expectedSize) {
+  const expectedSize = Number.isFinite(ANDROID_SMOKE_MODEL_SIZE_BYTES)
+    ? String(ANDROID_SMOKE_MODEL_SIZE_BYTES)
+    : null;
+  if (
+    expectedSize
+      ? existingBytes?.trim() === expectedSize
+      : Boolean(existingBytes?.trim())
+  ) {
     writeAndroidSmokeModelManifest(context, targetDir);
     writeAndroidLocalInferenceRegistry(context, localInferenceDir);
     console.log(
-      `[local-chat-smoke] Reused staged Android smoke model ${ANDROID_SMOKE_MODEL_ID}: ${targetFile}`,
+      `[local-chat-smoke] Reused staged Android smoke model ${ANDROID_SMOKE_MODEL_ID} (${existingBytes.trim()} bytes): ${targetFile}`,
     );
     return;
   }
 
   const source = await ensureAndroidSmokeModelLocalFile();
+  const sourceSize = fs.statSync(source).size;
   const tmpTarget = `/data/local/tmp/${ANDROID_SMOKE_MODEL_FILE}`;
   requireExec(
     context.adb,
@@ -876,7 +897,7 @@ async function stageAndroidSmokeModel(context) {
     allowFailure: true,
   });
   console.log(
-    `[local-chat-smoke] Staged Android smoke model ${ANDROID_SMOKE_MODEL_ID}: ${targetFile}`,
+    `[local-chat-smoke] Staged Android smoke model ${ANDROID_SMOKE_MODEL_ID} (${describeAndroidSmokeModelSize(sourceSize)}): ${targetFile}`,
   );
 }
 

--- a/packages/app/test/android/README.md
+++ b/packages/app/test/android/README.md
@@ -81,10 +81,10 @@ bun run --cwd packages/app test:e2e:android:routes
 
 ## Hard-won environment facts
 
-- **Emulator RAM.** The on-device agent (bun + a ~556MB GGUF) needs real
-  headroom. A stock ≤2GB AVD OOM-kills the agent mid model-load. The harness
-  boots emulators with **6GB** (`-memory 6144`); if you reuse an existing AVD,
-  raise `hw.ramSize` to `6144M`.
+- **Emulator RAM.** The on-device agent (bun + the 1,270,808,512-byte
+  `eliza-1-e2b-32k.gguf`) needs real headroom. A stock ≤2GB AVD OOM-kills the
+  agent mid model-load. The harness boots emulators with **6GB** (`-memory
+  6144`); if you reuse an existing AVD, raise `hw.ramSize` to `6144M`.
 - **SELinux.** On a stock emulator the app is `untrusted_app` and SELinux
   (enforcing) blocks the bun runtime's syscalls, so the agent never goes
   healthy. The harness runs `adb root` + `setenforce 0` on emulators
@@ -98,9 +98,11 @@ bun run --cwd packages/app test:e2e:android:routes
 - **Route navigation.** Capacitor's WebView has no SPA fallback for nested
   paths, so a hard `page.goto('/apps/x')` 404s. The harness navigates
   client-side via the History API (`gotoRoute`), like a user tap.
-- **Smallest model.** `eliza-1-2b` (Q-quant, 128k ctx) — the smallest
-  catalog tier. Node `fetch` chokes on HF's Xet LFS redirect; the orchestrator
-  pre-caches via `curl`.
+- **Smallest model.** `eliza-1-2b` (Q-quant, 32k ctx,
+  `eliza-1-e2b-32k.gguf`, 1,270,808,512 bytes) — the smallest catalog tier
+  staged by the Android smoke. The smoke caps runtime context at 4096 tokens,
+  so the 128k artifact does not improve this lane. Node `fetch` chokes on HF's
+  Xet LFS redirect; the orchestrator pre-caches via `curl`.
 
 ## Useful knobs
 


### PR DESCRIPTION
## Summary
- switch Android local-chat smoke defaults from `eliza-1-2b-128k.gguf` to `eliza-1-2b-32k.gguf`
- add exact default size verification/logging for the 1,270,808,512-byte smoke artifact
- update Android RAM/model docs and add a contract test so script/docs model guidance stays aligned

Fixes #13584

## Verification
- `bun run --cwd packages/app test -- scripts/android-smoke-model-contract.test.mjs`
- `bunx @biomejs/biome check packages/app/scripts/android-e2e.mjs packages/app/scripts/mobile-local-chat-smoke.mjs packages/app/scripts/lib/android-device.mjs packages/app/test/android/README.md packages/app/scripts/android-smoke-model-contract.test.mjs --no-errors-on-unmatched`
- `git diff --check`
- `ANDROID_SERIAL=ZL8325M37K bun run --cwd packages/app test:sim:local-chat:android:live` staged/reused the 32k artifact and logged `1270808512 bytes`, but the installed APK did not complete a full chat turn in this device state. First attempt hit a stale `ai.milady.milady` agent owning port 31337; after force-stopping it, the rerun got past auth but no `ai.elizaos.app` local-agent listener/process came up, so the smoke stayed at `fetch failed` and was stopped at attempt 70/240.