### PR TITLE
fix(app): align Android smoke GGUF size guidance

### DIFF
--- a/packages/app/scripts/android-e2e.mjs
+++ b/packages/app/scripts/android-e2e.mjs
@@ -6,9 +6,9 @@
 //      none is running) and, for emulators, SELinux is permissive so the
 //      embedded on-device agent can run.
 //   2. Ensure the WebView-debuggable debug APK is installed.
-//   3. Local route: bring up the on-device agent + smallest model and assert a
-//      real chat round-trip (mobile-local-chat-smoke). Loud fail if the local
-//      runtime or model does not come up.
+//   3. Local route: bring up the on-device agent + default smoke model and
+//      assert a real chat round-trip (mobile-local-chat-smoke). Loud fail if
+//      the local runtime or model does not come up.
 //   4. Playwright route coverage: drive the real WebView across every route.
 //   5. (optional) Cloud route: real Hetzner provisioning probe.
 //
@@ -39,10 +39,11 @@ const val = (flag, fb) => {
 };
 const log = (m) => console.log(`[android-e2e] ${m}`);
 
-// Smallest local tier; same id the smoke + catalog use.
+// Default local smoke tier; same id the smoke + catalog use.
 const SMOKE_MODEL = {
   id: "eliza-1-2b",
   file: "eliza-1-2b-128k.gguf",
+  sizeBytes: 4_967_494_592,
   url: "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/2b/text/eliza-1-2b-128k.gguf?download=true",
   cacheDir: path.join(
     process.env.HOME ?? process.env.USERPROFILE ?? ".",
@@ -174,7 +175,7 @@ function run(cmd, args, env = {}) {
 // model so the smoke reuses it offline instead of failing on the redirect.
 function ensureSmokeModelCached() {
   const dest = path.join(SMOKE_MODEL.cacheDir, SMOKE_MODEL.file);
-  if (fs.existsSync(dest) && fs.statSync(dest).size > 0) {
+  if (fs.existsSync(dest) && fs.statSync(dest).size === SMOKE_MODEL.sizeBytes) {
     log(`smoke model cached: ${dest}`);
     return dest;
   }
@@ -183,6 +184,12 @@ function ensureSmokeModelCached() {
   execFileSync("curl", ["-fsSL", "-o", dest, SMOKE_MODEL.url], {
     stdio: "inherit",
   });
+  const size = fs.statSync(dest).size;
+  if (size !== SMOKE_MODEL.sizeBytes) {
+    throw new Error(
+      `Downloaded smoke model size mismatch: expected ${SMOKE_MODEL.sizeBytes} bytes, got ${size} bytes at ${dest}`,
+    );
+  }
   return dest;
 }
 
@@ -215,7 +222,7 @@ async function main() {
 
   if (!has("--skip-local-chat")) {
     const modelPath = ensureSmokeModelCached();
-    log("local route: on-device agent + smallest model + real chat…");
+    log("local route: on-device agent + default smoke model + real chat…");
     run(
       "node",
       [
@@ -229,7 +236,11 @@ async function main() {
         "--serial",
         serial,
       ],
-      { ANDROID_SMOKE_MODEL_PATH: modelPath, ANDROID_SERIAL: serial },
+      {
+        ANDROID_SMOKE_MODEL_PATH: modelPath,
+        ANDROID_SMOKE_MODEL_SIZE_BYTES: String(SMOKE_MODEL.sizeBytes),
+        ANDROID_SERIAL: serial,
+      },
     );
   }
 

--- a/packages/app/scripts/lib/android-device.mjs
+++ b/packages/app/scripts/lib/android-device.mjs
@@ -292,9 +292,9 @@ export async function ensureEmulatorBooted({
   log(`booting emulator AVD ${chosen}`);
   const logFile = path.join(os.tmpdir(), `eliza-emulator-${chosen}.log`);
   const out = fs.openSync(logFile, "a");
-  // The embedded on-device agent (bun + a ~556MB GGUF) needs real headroom;
-  // a stock 2GB AVD OOM-thrashes during model load/inference. Give the test
-  // emulator 6GB RAM + 4 cores unless overridden.
+  // The embedded on-device agent (bun + the 4.97GB eliza-1-2b-128k GGUF) needs
+  // real headroom; a stock 2GB AVD OOM-thrashes during model load/inference.
+  // Give the test emulator 6GB RAM + 4 cores unless overridden.
   const memoryMb = process.env.ELIZA_EMULATOR_MEMORY_MB ?? "6144";
   const cores = process.env.ELIZA_EMULATOR_CORES ?? "4";
   // The on-device agent's bun + llama-cpp are compiled with -mavx2 -mfma -mf16c,

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -46,6 +46,8 @@ const IOS_FULL_BUN_SMOKE_RESULT_KEY = "eliza:ios-full-bun-smoke:result";
 const IOS_FULL_BUN_PREWARM_RESULT_KEY = "eliza:ios-full-bun-prewarm:result";
 const IOS_LOCAL_AGENT_IPC_BASE = "eliza-local-agent://ipc";
 const ANDROID_LOCAL_AGENT_IPC_BASE = IOS_LOCAL_AGENT_IPC_BASE;
+const DEFAULT_ANDROID_SMOKE_MODEL_FILE = "eliza-1-2b-128k.gguf";
+const DEFAULT_ANDROID_SMOKE_MODEL_SIZE_BYTES = 4_967_494_592;
 const IOS_FULL_BUN_SMOKE_MODEL_ID = "eliza-1-2b";
 const IOS_FULL_BUN_SMOKE_MODEL_RELATIVE_PATH =
   "models/eliza-1-2b.bundle/text/eliza-1-2b-128k.gguf";
@@ -123,11 +125,16 @@ const ANDROID_SMOKE_MODEL_RELATIVE_PATH =
   process.env.ANDROID_SMOKE_MODEL_RELATIVE_PATH?.trim() ||
   "bundles/2b/text/eliza-1-2b-128k.gguf";
 const ANDROID_SMOKE_MODEL_FILE =
-  process.env.ANDROID_SMOKE_MODEL_FILE?.trim() || "eliza-1-2b-128k.gguf";
-// Size/sha defaults are unset for the 2B entry tier — set them via env to
-// re-enable the exact-match download verification against a known artifact.
+  process.env.ANDROID_SMOKE_MODEL_FILE?.trim() ||
+  DEFAULT_ANDROID_SMOKE_MODEL_FILE;
+// The default Android smoke artifact is the 4.97GB 128k-context GGUF. Custom
+// model overrides can set ANDROID_SMOKE_MODEL_SIZE_BYTES to keep exact-match
+// download and staged-file verification enabled.
 const ANDROID_SMOKE_MODEL_SIZE_BYTES = Number.parseInt(
-  process.env.ANDROID_SMOKE_MODEL_SIZE_BYTES?.trim() || "",
+  process.env.ANDROID_SMOKE_MODEL_SIZE_BYTES?.trim() ||
+    (ANDROID_SMOKE_MODEL_FILE === DEFAULT_ANDROID_SMOKE_MODEL_FILE
+      ? String(DEFAULT_ANDROID_SMOKE_MODEL_SIZE_BYTES)
+      : ""),
   10,
 );
 const ANDROID_SMOKE_MODEL_SHA256 =
@@ -170,7 +177,7 @@ Options:
   --ios-select-local               Pre-seed iOS first-run/runtime state for Local mode before launch
   --ios-full-bun-smoke             Run a WebView-executed full Bun backend smoke in the iOS app
   --android-select-local           Tap through Android first-run Local runtime selection
-  --android-stage-smoke-model      Stage the smallest active Eliza-1 GGUF into Android app data
+  --android-stage-smoke-model      Stage the default active Eliza-1 GGUF into Android app data
   --android-background             Background Android, force-fire the WorkManager job, and poll /api/health
   --ios-background                 Background iOS, fire a BGTaskScheduler task via LLDB, and poll /api/health
   --ios-background-task-id ID      iOS BGTask identifier to simulate (default: ai.eliza.tasks.refresh)
@@ -835,8 +842,13 @@ async function stageAndroidSmokeModel(context) {
     "Failed to inspect Android smoke model.",
     { allowFailure: true },
   );
-  const expectedSize = String(ANDROID_SMOKE_MODEL_SIZE_BYTES);
-  if (existingBytes?.trim() === expectedSize) {
+  const existingSize = existingBytes?.trim();
+  const hasExpectedSize = Number.isFinite(ANDROID_SMOKE_MODEL_SIZE_BYTES);
+  if (
+    hasExpectedSize
+      ? existingSize === String(ANDROID_SMOKE_MODEL_SIZE_BYTES)
+      : Boolean(existingSize)
+  ) {
     writeAndroidSmokeModelManifest(context, targetDir);
     writeAndroidLocalInferenceRegistry(context, localInferenceDir);
     console.log(

--- a/packages/app/test/android/README.md
+++ b/packages/app/test/android/README.md
@@ -6,7 +6,7 @@ mocked `/api` (that is `playwright.ui-smoke.config.ts`). Two layers:
 
 | Layer | What it proves | Driver |
 |---|---|---|
-| `mobile-local-chat-smoke.mjs` | On-device agent boots, smallest model loads, a real chat round-trips | adb + on-device agent API (`:31337`) |
+| `mobile-local-chat-smoke.mjs` | On-device agent boots, default smoke model loads, a real chat round-trips | adb + on-device agent API (`:31337`) |
 | `onboarding-to-home.android.spec.ts` | Fresh Capacitor first-run onboarding selects a real remote host agent over `adb reverse`, completes first-run, and lands on the home/chat surface with screenshot + screenrecord artifacts | Playwright Android driver + deterministic host `startApiServer` |
 | `native-plugin-view-smoke.android.spec.ts` | The installed app's WebView calls `ElizaSystem` through Capacitor and receives Android/Kotlin-only status + settings values, with JSON, screenshot, screenrecord, console, and logcat artifacts | Playwright Android driver + real Capacitor bridge |
 | `touch-gesture.android.spec.ts` | The installed Android WebView runs the full chat gesture matrix — sheet detents, home↔launcher rail + back, push-to-talk hold, keyboard avoidance, media attachment, long-press — via real OS touch (`adb input`), asserting real touch delivery (never mouse) plus each gesture's semantics, recorded as one chunked screenrecord | Playwright Android driver + `adb shell input swipe` |
@@ -81,10 +81,11 @@ bun run --cwd packages/app test:e2e:android:routes
 
 ## Hard-won environment facts
 
-- **Emulator RAM.** The on-device agent (bun + a ~556MB GGUF) needs real
-  headroom. A stock ≤2GB AVD OOM-kills the agent mid model-load. The harness
-  boots emulators with **6GB** (`-memory 6144`); if you reuse an existing AVD,
-  raise `hw.ramSize` to `6144M`.
+- **Emulator RAM.** The default on-device chat smoke stages
+  `eliza-1-2b-128k.gguf`, a 4.97GB (4,967,494,592-byte) GGUF. Bun plus this
+  model needs real headroom. A stock ≤2GB AVD OOM-kills the agent mid
+  model-load. The harness boots emulators with **6GB** (`-memory 6144`); if you
+  reuse an existing AVD, raise `hw.ramSize` to `6144M`.
 - **SELinux.** On a stock emulator the app is `untrusted_app` and SELinux
   (enforcing) blocks the bun runtime's syscalls, so the agent never goes
   healthy. The harness runs `adb root` + `setenforce 0` on emulators
@@ -98,9 +99,10 @@ bun run --cwd packages/app test:e2e:android:routes
 - **Route navigation.** Capacitor's WebView has no SPA fallback for nested
   paths, so a hard `page.goto('/apps/x')` 404s. The harness navigates
   client-side via the History API (`gotoRoute`), like a user tap.
-- **Smallest model.** `eliza-1-2b` (Q-quant, 128k ctx) — the smallest
-  catalog tier. Node `fetch` chokes on HF's Xet LFS redirect; the orchestrator
-  pre-caches via `curl`.
+- **Smoke model.** `eliza-1-2b` (Q-quant, 128k ctx) is staged from
+  `eliza-1-2b-128k.gguf` and should be 4.97GB (4,967,494,592 bytes). The smoke
+  caps runtime context at 4096 tokens. Node `fetch` chokes on HF's Xet LFS
+  redirect; the orchestrator pre-caches via `curl`.
 
 ## Useful knobs
 


### PR DESCRIPTION
## Summary

Relates to #13584.

- Documents the Android smoke default model as `eliza-1-2b-128k.gguf`, 4.97GB / 4,967,494,592 bytes, in the emulator guidance and Android README.
- Makes `android-e2e.mjs` and `mobile-local-chat-smoke.mjs` use that byte count as the default expected size so cached downloads and staged-device reuse agree with the documented artifact.
- Replaces stale “smallest model” wording with “default smoke model” so the scripts/docs no longer imply the 128k GGUF is small.

## Evidence

- Branch synced: rebased on latest `origin/develop` before push.
- Syntax checks: `node --check packages/app/scripts/android-e2e.mjs && node --check packages/app/scripts/lib/android-device.mjs && node --check packages/app/scripts/mobile-local-chat-smoke.mjs` passed.
- Help path: `node packages/app/scripts/mobile-local-chat-smoke.mjs --help` passed and shows `--android-stage-smoke-model      Stage the default active Eliza-1 GGUF into Android app data`.
- Focused Biome: `bunx @biomejs/biome check packages/app/scripts/android-e2e.mjs packages/app/scripts/lib/android-device.mjs packages/app/scripts/mobile-local-chat-smoke.mjs packages/app/test/android/README.md` passed.
- Whitespace: `git diff --check origin/develop...HEAD` passed.
- Stale reference audit: `rg -n "556|557|~556|~557|Smallest model|smallest active|smallest model" ...` found no matches in the scoped Android smoke files.
- Package lint: `bun run --cwd packages/app lint` passed; it attempted to format an unrelated file, which I reverted before pushing.

## Live Android Evidence

- Requested live lane: `bun run --cwd packages/app test:sim:local-chat:android:live`.
- Result on this host: not executable because Android SDK tooling is absent. Actual output:

```text
[local-chat-smoke] Android SDK platform-tools/adb was not found.
error: script "test:sim:local-chat:android:live" exited with code 1
```

## Evidence Rows

- Real LLM-call trajectory: N/A - no agent/model behavior changed, only Android smoke model staging metadata and docs.
- Backend logs: N/A - no runtime/API code path changed.
- Frontend logs/screenshots/video: N/A - no UI change.
- Domain artifacts: N/A - no persisted domain data is produced by this docs/script metadata change.
- Native/on-device capture: blocked on this host by missing `adb`/`emulator`; exact live command and failure are recorded above.
