### PR TITLE
fix(#13726): preserve local-only opt-out through config migration

### DIFF
--- a/packages/app-core/src/runtime/mode/route-mode-matrix.test.ts
+++ b/packages/app-core/src/runtime/mode/route-mode-matrix.test.ts
@@ -9,6 +9,8 @@
  * un-matrixed routes outside any protected namespace default-allow
  * (arch-audit #12633).
  */
+
+import { migrateLegacyRuntimeConfig } from "@elizaos/shared";
 import { describe, expect, test } from "vitest";
 import { findRegisteredRouteModeRule } from "./route-mode-guard";
 import {
@@ -96,6 +98,20 @@ describe("resolveRuntimeMode", () => {
     expect(
       resolveRuntimeMode({ deploymentTarget: { runtime: "local" } }).mode,
     ).toBe("local");
+  });
+
+  test("migrated legacy cloud.enabled=false still resolves to local-only", () => {
+    const config = {
+      cloud: {
+        enabled: false,
+        provider: "elizacloud",
+        inferenceMode: "cloud",
+      },
+    };
+    migrateLegacyRuntimeConfig(config);
+
+    expect(config).toEqual({ cloud: { enabled: false } });
+    expect(resolveRuntimeMode(config).mode).toBe("local-only");
   });
 });
 

--- a/packages/shared/src/contracts/first-run-options.test.ts
+++ b/packages/shared/src/contracts/first-run-options.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { migrateLegacyRuntimeConfig } from "./first-run-options.js";
+
+describe("migrateLegacyRuntimeConfig", () => {
+  it("preserves cloud.enabled=false as the local-only runtime-mode signal", () => {
+    const config = {
+      cloud: {
+        enabled: false,
+        provider: "elizacloud",
+        inferenceMode: "cloud",
+        services: {
+          tts: false,
+        },
+      },
+    };
+
+    migrateLegacyRuntimeConfig(config);
+
+    expect(config).toEqual({
+      cloud: {
+        enabled: false,
+      },
+    });
+  });
+
+  it("still prunes cloud.enabled=true with the other legacy routing fields", () => {
+    const config = {
+      cloud: {
+        enabled: true,
+        provider: "elizacloud",
+        runtime: "local",
+        services: {
+          tts: false,
+        },
+      },
+    };
+
+    migrateLegacyRuntimeConfig(config);
+
+    expect(config).toEqual({
+      serviceRouting: {
+        llmText: {
+          accountId: "elizacloud",
+          backend: "elizacloud",
+          transport: "cloud-proxy",
+        },
+      },
+    });
+  });
+});

--- a/packages/shared/src/contracts/first-run-options.ts
+++ b/packages/shared/src/contracts/first-run-options.ts
@@ -1226,6 +1226,9 @@ function pruneLegacyCloudRoutingFields(
   }
 
   for (const key of LEGACY_CLOUD_ROUTING_KEYS) {
+    if (key === "enabled" && cloud.enabled === false) {
+      continue;
+    }
     delete cloud[key];
   }
 


### PR DESCRIPTION
## Summary
- keep `cloud.enabled: false` during legacy runtime config migration because it is the persisted local-only opt-out signal
- continue pruning `cloud.enabled: true` and the other legacy cloud routing fields
- add shared migration coverage and a runtime-mode regression proving migrated config resolves to `local-only`

Fixes #13726

## Verification
- `bun run --cwd packages/shared test -- src/contracts/first-run-options.test.ts`
- `bunx vitest run --config packages/app-core/vitest.config.ts packages/app-core/src/runtime/mode/route-mode-matrix.test.ts`
- `bunx @biomejs/biome check packages/shared/src/contracts/first-run-options.ts packages/shared/src/contracts/first-run-options.test.ts packages/app-core/src/runtime/mode/route-mode-matrix.test.ts --no-errors-on-unmatched`
- `bun run --cwd packages/shared typecheck`
- `git diff --check`

Note: `bun run --cwd packages/app-core typecheck` was attempted and is blocked by pre-existing missing declarations for `@elizaos/plugin-elizacloud/host-routes` and `@elizaos/plugin-aosp-local-inference`; no diagnostics referenced the touched files.