### PR TITLE
fix(#13680): provision Linux desktop screenshot capture tools

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -329,13 +329,14 @@ jobs:
         # ERR_DLOPEN_FAILED before the test bridge comes up (the lane was red
         # for 5+ days with "Packaged app exited before the desktop test bridge
         # became ready").
-        # ffmpeg: the desktop chat-walkthrough spec pumps bridge screenshots into
-        # a real-time MP4 (bridge-frame-recorder.ts) and fails loudly without it.
+        # scrot/imagemagick/x11-apps/ffmpeg: ScreenCaptureManager tries, in
+        # order, scrot, ImageMagick import, ffmpeg x11grab, then xwd+ffmpeg for
+        # /main-window/screenshot. ffmpeg also stitches the walkthrough MP4.
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             xvfb libwebkit2gtk-4.1-0 libgtk-3-0 mesa-utils libgl1-mesa-dri \
-            libayatana-appindicator3-1 ffmpeg
+            libayatana-appindicator3-1 scrot imagemagick x11-apps ffmpeg
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts
@@ -212,7 +212,10 @@ export async function startDesktopTestBridgeServer(): Promise<
       if (pathname === "/main-window/screenshot" && method === "GET") {
         const shot = await getScreenCaptureManager().takeScreenshot();
         if (!shot.available || !shot.data) {
-          json(res, 503, { error: "screenshot unavailable" });
+          json(res, 503, {
+            error: "screenshot unavailable",
+            reason: shot.reason ?? "screen capture backend returned no image",
+          });
           return;
         }
         json(res, 200, { data: shot.data });

--- a/packages/app-core/platforms/electrobun/src/native/screencapture.ts
+++ b/packages/app-core/platforms/electrobun/src/native/screencapture.ts
@@ -70,19 +70,23 @@ async function runCaptureCommand(
 async function captureLinuxRootWindow(
   tmpPath: string,
   options: { quality?: number } = {},
-): Promise<boolean> {
+): Promise<{ ok: boolean; reason?: string }> {
+  const attempted: string[] = [];
   const scrotCommand = options.quality
     ? ["scrot", "--quality", String(options.quality), tmpPath]
     : ["scrot", tmpPath];
-  if (await runCaptureCommand(scrotCommand, tmpPath)) return true;
+  attempted.push("scrot");
+  if (await runCaptureCommand(scrotCommand, tmpPath)) return { ok: true };
 
+  attempted.push("import");
   if (
     await runCaptureCommand(["import", "-window", "root", tmpPath], tmpPath)
   ) {
-    return true;
+    return { ok: true };
   }
 
   const display = process.env.DISPLAY?.trim();
+  attempted.push("ffmpeg x11grab");
   if (
     display &&
     (await runCaptureCommand(
@@ -103,9 +107,10 @@ async function captureLinuxRootWindow(
       tmpPath,
     ))
   ) {
-    return true;
+    return { ok: true };
   }
 
+  attempted.push("xwd + ffmpeg");
   const xwdPath = `${tmpPath}.xwd`;
   try {
     if (
@@ -114,9 +119,12 @@ async function captureLinuxRootWindow(
         xwdPath,
       ))
     ) {
-      return false;
+      return {
+        ok: false,
+        reason: linuxCaptureUnavailableReason(attempted, display),
+      };
     }
-    return runCaptureCommand(
+    const converted = await runCaptureCommand(
       [
         "ffmpeg",
         "-y",
@@ -129,6 +137,12 @@ async function captureLinuxRootWindow(
       ],
       tmpPath,
     );
+    return converted
+      ? { ok: true }
+      : {
+          ok: false,
+          reason: linuxCaptureUnavailableReason(attempted, display),
+        };
   } finally {
     try {
       if (fs.existsSync(xwdPath)) fs.unlinkSync(xwdPath);
@@ -140,6 +154,24 @@ async function captureLinuxRootWindow(
     }
   }
 }
+
+function linuxCaptureUnavailableReason(
+  attempted: string[],
+  display: string | undefined,
+): string {
+  const displayHint = display
+    ? `DISPLAY=${display}`
+    : "DISPLAY is unset, so ffmpeg/xwd X11 capture cannot run";
+  return `Linux screenshot capture unavailable after trying ${attempted.join(
+    ", ",
+  )}; install scrot, imagemagick, ffmpeg, and x11-apps on the runner (${displayHint})`;
+}
+
+export type ScreenshotCaptureResult = {
+  available: boolean;
+  data?: string;
+  reason?: string;
+};
 
 /**
  * Allow-list for game-capture URLs.
@@ -208,7 +240,7 @@ export class ScreenCaptureManager {
     };
   }
 
-  async takeScreenshot(): Promise<{ available: boolean; data?: string }> {
+  async takeScreenshot(): Promise<ScreenshotCaptureResult> {
     const tmpPath = path.join(
       os.tmpdir(),
       `elizaos-screenshot-${Date.now()}.png`,
@@ -236,7 +268,10 @@ $bmp.Dispose()`;
           stderr: "ignore",
         });
       } else {
-        await captureLinuxRootWindow(tmpPath);
+        const linuxCapture = await captureLinuxRootWindow(tmpPath);
+        if (!linuxCapture.ok) {
+          return { available: false, reason: linuxCapture.reason };
+        }
       }
 
       if (proc) await proc.exited;
@@ -247,7 +282,17 @@ $bmp.Dispose()`;
           ? `${tmpPath}.png`
           : null;
 
-      if (!actualPath) return { available: false };
+      if (!actualPath) {
+        return {
+          available: false,
+          reason:
+            process.platform === "darwin"
+              ? "macOS screencapture produced no output; verify Screen Recording/TCC access and that the runner display is unlocked"
+              : process.platform === "win32"
+                ? "Windows CopyFromScreen produced no output; verify an interactive desktop is available"
+                : "Linux screenshot capture produced no output file",
+        };
+      }
 
       const data = fs.readFileSync(actualPath).toString("base64");
       return { available: true, data: `data:image/png;base64,${data}` };
@@ -256,7 +301,10 @@ $bmp.Dispose()`;
         error: screenCaptureErrorMessage(err),
         tmpPath,
       });
-      return { available: false };
+      return {
+        available: false,
+        reason: `screenshot capture failed: ${screenCaptureErrorMessage(err)}`,
+      };
     } finally {
       for (const p of [tmpPath, `${tmpPath}.png`]) {
         try {
@@ -273,7 +321,7 @@ $bmp.Dispose()`;
 
   async captureWindow(options?: {
     windowId?: string;
-  }): Promise<{ available: boolean; data?: string }> {
+  }): Promise<ScreenshotCaptureResult> {
     // macOS: use screencapture -l <windowId> if a windowId is provided.
     // Other platforms: fall back to full-screen capture.
     if (process.platform === "darwin" && options?.windowId) {

--- a/packages/app-core/platforms/electrobun/src/screenshot-dev-server.ts
+++ b/packages/app-core/platforms/electrobun/src/screenshot-dev-server.ts
@@ -72,7 +72,10 @@ export function startScreenshotDevServer(): (() => void) | undefined {
           "Content-Type": "application/json; charset=utf-8",
         });
         res.end(
-          JSON.stringify({ error: "screen capture failed or unavailable" }),
+          JSON.stringify({
+            error: "screen capture failed or unavailable",
+            reason: shot.reason ?? "screen capture backend returned no image",
+          }),
         );
         return;
       }


### PR DESCRIPTION
## Scope

Partial fix for #13680: make the Linux packaged desktop lane provision the host tools that the current Electrobun screenshot bridge already depends on, and surface actionable failure reasons when capture is unavailable.

This does **not** fully close #13680. The bridge still captures through OS screen-capture backends rather than an in-process app-window pixel seam, and the macOS TCC/black-frame/wrong-window parts remain to be fixed separately.

## Changes

- `.github/workflows/app-live-e2e.yml`: install `scrot`, `imagemagick`, `x11-apps`, and `ffmpeg` before the packaged desktop run. These match `ScreenCaptureManager`'s Linux fallback order: `scrot` -> ImageMagick `import` -> `ffmpeg x11grab` -> `xwd + ffmpeg`.
- `ScreenCaptureManager.takeScreenshot()`: return structured unavailable reasons instead of a bare `{ available: false }`.
- `/main-window/screenshot` and the screenshot dev server: include `reason` in 503 JSON responses so CI logs show the missing backend/display/TCC class directly.

## Verification

Local validation on rebased head `faa43bd829`:

```bash
python3 - <<'PY'
import yaml
with open('.github/workflows/app-live-e2e.yml') as fh:
    yaml.safe_load(fh)
print('yaml-ok .github/workflows/app-live-e2e.yml')
PY

go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/app-live-e2e.yml
bunx @biomejs/biome check \
  packages/app-core/platforms/electrobun/src/native/screencapture.ts \
  packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts \
  packages/app-core/platforms/electrobun/src/screenshot-dev-server.ts \
  .github/workflows/app-live-e2e.yml

git diff --check origin/develop...HEAD
```

All passed.

## Required before merge

Run `App Live E2E` by `workflow_dispatch` on this branch and inspect the `app-live-e2e-desktop` artifact. Merge only if the Linux packaged run proves `/main-window/screenshot` returns nonblank UI pixels and the packaged screenshots/video artifacts are present.

N/A: model trajectories/audio/domain artifacts. This is CI/Electrobun capture infrastructure only.