### PR TITLE
test(#13681): route packaged settings voice through settings navigation

### DIFF
--- a/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
@@ -82,6 +82,7 @@ function getRouteNavigationScript(route: string): string {
     return [
       `const targetRoute = ${JSON.stringify(route)};`,
       `const settingsSection = ${JSON.stringify(settingsSection)};`,
+      `const readCurrentRoute = () => ${getCurrentRouteExpression()};`,
       `window.dispatchEvent(new CustomEvent(${JSON.stringify(NAVIGATE_SETTINGS_EVENT)}, {`,
       `  detail: { section: settingsSection },`,
       `}));`,
@@ -90,7 +91,7 @@ function getRouteNavigationScript(route: string): string {
       `  window.history.replaceState(null, "", targetHash);`,
       `  window.dispatchEvent(new HashChangeEvent("hashchange"));`,
       `}`,
-      `const currentRoute = targetRoute;`,
+      `const currentRoute = readCurrentRoute();`,
     ].join("\n");
   }
 
@@ -244,10 +245,13 @@ async function openRouteAndWait(
     })()`,
     (current) =>
       current.ok &&
-      current.route === route &&
       current.selector === selector &&
       current.found &&
-      (route !== SETTINGS_MEDIA_ROUTE || current.voiceSectionActive),
+      (route === SETTINGS_MEDIA_ROUTE
+        ? current.hash === "#voice" &&
+          current.activeSettingsSection === "voice" &&
+          current.voiceSectionActive
+        : current.route === route),
     {
       timeout: 20_000,
       message: `Timed out waiting for ${selector} at ${route}.`,
@@ -307,7 +311,8 @@ async function waitForMediaSettingsRoute(
     (current) =>
       current.ok &&
       current.shellReady &&
-      current.route === SETTINGS_MEDIA_ROUTE &&
+      current.hash === "#voice" &&
+      current.activeSettingsSection === "voice" &&
       current.voiceSectionActive,
     {
       timeout: 20_000,

--- a/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
@@ -28,6 +28,7 @@ const FIRST_RUN_SELECTOR = '[data-testid="continuous-chat-overlay"]';
 const SETTINGS_ROUTE = "/settings";
 const SETTINGS_MEDIA_ROUTE = "/settings/voice";
 const PLUGINS_ROUTE = "/apps/plugins";
+const NAVIGATE_SETTINGS_EVENT = "eliza:navigate:settings";
 
 test.describe.configure({ mode: "serial" });
 
@@ -70,7 +71,29 @@ function getCurrentRouteExpression(): string {
   ].join("\n");
 }
 
+function getSettingsSectionForRoute(route: string): string | null {
+  const match = /^\/settings\/([^/?#]+)$/.exec(route);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
 function getRouteNavigationScript(route: string): string {
+  const settingsSection = getSettingsSectionForRoute(route);
+  if (settingsSection) {
+    return [
+      `const targetRoute = ${JSON.stringify(route)};`,
+      `const settingsSection = ${JSON.stringify(settingsSection)};`,
+      `window.dispatchEvent(new CustomEvent(${JSON.stringify(NAVIGATE_SETTINGS_EVENT)}, {`,
+      `  detail: { section: settingsSection },`,
+      `}));`,
+      `const targetHash = "#" + settingsSection;`,
+      `if (window.location.hash !== targetHash) {`,
+      `  window.history.replaceState(null, "", targetHash);`,
+      `  window.dispatchEvent(new HashChangeEvent("hashchange"));`,
+      `}`,
+      `const currentRoute = targetRoute;`,
+    ].join("\n");
+  }
+
   return [
     `const targetRoute = ${JSON.stringify(route)};`,
     `const readCurrentRoute = () => ${getCurrentRouteExpression()};`,
@@ -172,6 +195,9 @@ async function openRouteAndWait(
       found: boolean;
       text: string;
       firstRunFound: boolean;
+      hash: string;
+      activeSettingsSection: string | null;
+      voiceSectionActive: boolean;
       rootHtmlLength: number;
       bodyText: string;
     }>
@@ -191,6 +217,18 @@ async function openRouteAndWait(
         firstRunFound: Boolean(
           document.querySelector(${JSON.stringify(FIRST_RUN_SELECTOR)}),
         ),
+        hash: window.location.hash,
+        activeSettingsSection:
+          document
+            .querySelector('[data-agent-id^="section-"][aria-current="page"]')
+            ?.getAttribute("data-agent-id")
+            ?.replace(/^section-/, "") ?? null,
+        voiceSectionActive: Boolean(
+          window.location.hash === "#voice" &&
+            document.querySelector(${JSON.stringify(SETTINGS_SELECTOR)}),
+        ) || Boolean(
+          document.querySelector('[data-agent-id="section-voice"][aria-current="page"]'),
+        ),
         rootHtmlLength: document.getElementById("root")?.innerHTML.length ?? 0,
         bodyText: (document.body?.innerText || "")
           .replace(/\\s+/g, " ")
@@ -208,7 +246,8 @@ async function openRouteAndWait(
       current.ok &&
       current.route === route &&
       current.selector === selector &&
-      current.found,
+      current.found &&
+      (route !== SETTINGS_MEDIA_ROUTE || current.voiceSectionActive),
     {
       timeout: 20_000,
       message: `Timed out waiting for ${selector} at ${route}.`,
@@ -225,6 +264,11 @@ async function waitForMediaSettingsRoute(
     EvalResult<{
       shellReady: boolean;
       route: string;
+      hash: string;
+      activeSettingsSection: string | null;
+      voiceSectionActive: boolean;
+      rootHtmlLength: number;
+      bodyText: string;
     }>
   >(
     harness,
@@ -235,6 +279,23 @@ async function waitForMediaSettingsRoute(
           ok: true,
           shellReady: Boolean(document.querySelector(${JSON.stringify(SETTINGS_SELECTOR)})),
           route: currentRoute,
+          hash: window.location.hash,
+          activeSettingsSection:
+            document
+              .querySelector('[data-agent-id^="section-"][aria-current="page"]')
+              ?.getAttribute("data-agent-id")
+              ?.replace(/^section-/, "") ?? null,
+          voiceSectionActive: Boolean(
+            window.location.hash === "#voice" &&
+              document.querySelector(${JSON.stringify(SETTINGS_SELECTOR)}),
+          ) || Boolean(
+            document.querySelector('[data-agent-id="section-voice"][aria-current="page"]'),
+          ),
+          rootHtmlLength: document.getElementById("root")?.innerHTML.length ?? 0,
+          bodyText: (document.body?.innerText || "")
+            .replace(/\\s+/g, " ")
+            .trim()
+            .slice(0, 240),
         };
       } catch (error) {
         return {
@@ -246,7 +307,8 @@ async function waitForMediaSettingsRoute(
     (current) =>
       current.ok &&
       current.shellReady &&
-      current.route === SETTINGS_MEDIA_ROUTE,
+      current.route === SETTINGS_MEDIA_ROUTE &&
+      current.voiceSectionActive,
     {
       timeout: 20_000,
       message: `Timed out waiting for media settings route at ${SETTINGS_MEDIA_ROUTE}.`,


### PR DESCRIPTION
## Summary
- Fixes the packaged regression route helper so `/settings/voice` uses the app-supported settings navigation contract: dispatch `eliza:navigate:settings` with `section: "voice"` and set `#voice` for `SettingsView`.
- Keeps normal path/hash route handling for other packaged regression routes.
- Adds route wait diagnostics for hash, active settings section, voice section state, root HTML length, and body text so future packaged timeouts show the actual renderer state.

## Evidence
- `./node_modules/.bin/biome check --write .codex-tmp-13681/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts` - completed; only pre-existing `ELIZA_TEST_PACKAGED_DEBUG` Turborepo env warning in this file.
- `bun --print "new Bun.Transpiler({ loader: 'ts' }).transformSync(await Bun.file('/tmp/eliza-13681/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts').text()).includes('NAVIGATE_SETTINGS_EVENT')"` - pass / `true`.
- Full packaged execution not run in this API environment because it requires a built packaged Electrobun launcher and GUI shell artifact.

Closes the `/settings/voice` timeout slice of #13681; does not touch #13747 screenshot backend provisioning.