### PR TITLE
test(#13684): expose tray popover and shortcut bridge seams

### DIFF
--- a/packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts
@@ -24,6 +24,10 @@ type MenuActionBody = {
   action?: string;
 };
 
+type ShortcutPressBody = {
+  id?: string;
+};
+
 function isLoopback(addr: string | undefined): boolean {
   return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
 }
@@ -236,6 +240,38 @@ export async function startDesktopTestBridgeServer(): Promise<
           invoked
             ? { ok: true }
             : { error: "application menu handler unavailable" },
+        );
+        return;
+      }
+
+      if (pathname === "/tray/popover/toggle" && method === "POST") {
+        const desktop = getDesktopManager();
+        const before = await desktop.getShellDiagnosticsState();
+        if (!before.trayPopover.configured) {
+          json(res, 503, { error: "tray popover is not configured" });
+          return;
+        }
+        await desktop.toggleTrayPopover();
+        json(res, 200, {
+          ok: true,
+          trayPopover: (await desktop.getShellDiagnosticsState()).trayPopover,
+        });
+        return;
+      }
+
+      if (pathname === "/shortcut/press" && method === "POST") {
+        const body = await readJsonBody<ShortcutPressBody>(req);
+        const id = body?.id?.trim();
+        if (!id) {
+          json(res, 400, { error: "id is required" });
+          return;
+        }
+        const desktop = getDesktopManager();
+        const invoked = desktop.pressRegisteredShortcut({ id });
+        json(
+          res,
+          invoked ? 200 : 404,
+          invoked ? { ok: true, id } : { error: "shortcut is not registered" },
         );
         return;
       }

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -543,6 +543,48 @@ describe("DesktopManager main window controls", () => {
     );
   });
 
+  it("presses a registered shortcut through the test seam", async () => {
+    const manager = new DesktopManager();
+    const sendToWebview = vi.fn();
+    manager.setSendToWebview(sendToWebview);
+    electrobunMock.GlobalShortcut.register.mockReturnValueOnce(true);
+
+    await expect(
+      manager.registerShortcut({
+        id: "chat-overlay",
+        accelerator: "CommandOrControl+Shift+C",
+      }),
+    ).resolves.toEqual({ success: true });
+
+    expect(manager.pressRegisteredShortcut({ id: "chat-overlay" })).toBe(true);
+    expect(manager.pressRegisteredShortcut({ id: "missing-shortcut" })).toBe(
+      false,
+    );
+    expect(sendToWebview).toHaveBeenCalledWith("desktopShortcutPressed", {
+      id: "chat-overlay",
+      accelerator: "CommandOrControl+Shift+C",
+    });
+  });
+
+  it("surfaces registered shortcuts in shell diagnostics", async () => {
+    const manager = new DesktopManager();
+    electrobunMock.GlobalShortcut.register.mockReturnValueOnce(true);
+
+    await manager.registerShortcut({
+      id: "command-palette",
+      accelerator: "CommandOrControl+K",
+    });
+
+    await expect(manager.getShellDiagnosticsState()).resolves.toMatchObject({
+      shortcuts: [
+        {
+          id: "command-palette",
+          accelerator: "CommandOrControl+K",
+        },
+      ],
+    });
+  });
+
   it("opens tray popover as an app renderer with preload, rpc, partition, and API injection", async () => {
     const manager = new DesktopManager();
     const rpc = { request: {}, send: {}, setTransport: vi.fn() };
@@ -588,9 +630,41 @@ describe("DesktopManager main window controls", () => {
     const seen: unknown[] = [];
     manager.forEachTrayPopoverWindow((window) => seen.push(window));
     expect(seen).toEqual([win]);
+    expect(manager.getTrayPopoverDiagnostics()).toEqual({
+      configured: true,
+      windowPresent: true,
+      visible: true,
+      lastAnchorBounds: {
+        x: 100 + 900 - 360 - 8,
+        y: 50 + 8,
+        width: 360,
+        height: 480,
+      },
+    });
 
     win.emitWebview("dom-ready");
     expect(injectApiBase).toHaveBeenCalledWith(win);
+
+    manager.hideTrayPopover();
+    expect(manager.getTrayPopoverDiagnostics()).toMatchObject({
+      configured: true,
+      windowPresent: true,
+      visible: false,
+      lastAnchorBounds: {
+        x: 100 + 900 - 360 - 8,
+        y: 50 + 8,
+        width: 360,
+        height: 480,
+      },
+    });
+
+    manager.closeTrayPopover();
+    expect(manager.getTrayPopoverDiagnostics()).toMatchObject({
+      configured: true,
+      windowPresent: false,
+      visible: false,
+      lastAnchorBounds: null,
+    });
   });
 
   it("awaits tray teardown during dispose", async () => {
@@ -609,60 +683,6 @@ describe("DesktopManager main window controls", () => {
       expect.any(Function),
     );
     expect(tray.remove).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("DesktopManager notifications", () => {
-  beforeEach(() => {
-    resetDesktopManagerForTesting();
-    electrobunMock.reset();
-  });
-
-  afterEach(() => {
-    resetDesktopManagerForTesting();
-  });
-
-  it("maps notification options to Utils.showNotification and returns monotonic ids", async () => {
-    const manager = new DesktopManager();
-
-    await expect(
-      manager.showNotification({
-        title: "Build finished",
-        body: "Desktop build completed.",
-        urgency: "critical",
-        silent: false,
-      }),
-    ).resolves.toEqual({ id: "notification_1" });
-    await expect(
-      manager.showNotification({
-        title: "Quiet sync",
-        body: "Background sync completed.",
-        urgency: "low",
-        silent: true,
-      }),
-    ).resolves.toEqual({ id: "notification_2" });
-
-    expect(electrobunMock.Utils.showNotification).toHaveBeenNthCalledWith(1, {
-      title: "Build finished",
-      body: "Desktop build completed.",
-      subtitle: undefined,
-      silent: false,
-    });
-    expect(electrobunMock.Utils.showNotification).toHaveBeenNthCalledWith(2, {
-      title: "Quiet sync",
-      body: "Background sync completed.",
-      subtitle: undefined,
-      silent: true,
-    });
-  });
-
-  it("documents closeNotification as an Electrobun no-op", async () => {
-    const manager = new DesktopManager();
-
-    await expect(
-      manager.closeNotification({ id: "notification_1" }),
-    ).resolves.toBeUndefined();
-    expect(electrobunMock.Utils.showNotification).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -686,6 +686,60 @@ describe("DesktopManager main window controls", () => {
   });
 });
 
+describe("DesktopManager notifications", () => {
+  beforeEach(() => {
+    resetDesktopManagerForTesting();
+    electrobunMock.reset();
+  });
+
+  afterEach(() => {
+    resetDesktopManagerForTesting();
+  });
+
+  it("maps notification options to Utils.showNotification and returns monotonic ids", async () => {
+    const manager = new DesktopManager();
+
+    await expect(
+      manager.showNotification({
+        title: "Build finished",
+        body: "Desktop build completed.",
+        urgency: "critical",
+        silent: false,
+      }),
+    ).resolves.toEqual({ id: "notification_1" });
+    await expect(
+      manager.showNotification({
+        title: "Quiet sync",
+        body: "Background sync completed.",
+        urgency: "low",
+        silent: true,
+      }),
+    ).resolves.toEqual({ id: "notification_2" });
+
+    expect(electrobunMock.Utils.showNotification).toHaveBeenNthCalledWith(1, {
+      title: "Build finished",
+      body: "Desktop build completed.",
+      subtitle: undefined,
+      silent: false,
+    });
+    expect(electrobunMock.Utils.showNotification).toHaveBeenNthCalledWith(2, {
+      title: "Quiet sync",
+      body: "Background sync completed.",
+      subtitle: undefined,
+      silent: true,
+    });
+  });
+
+  it("documents closeNotification as an Electrobun no-op", async () => {
+    const manager = new DesktopManager();
+
+    await expect(
+      manager.closeNotification({ id: "notification_1" }),
+    ).resolves.toBeUndefined();
+    expect(electrobunMock.Utils.showNotification).not.toHaveBeenCalled();
+  });
+});
+
 describe("DesktopManager dockless (tray-first) Dock tracking (#12184)", () => {
   const originalPlatform = process.platform;
 

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -322,6 +322,7 @@ export class DesktopManager {
   private trayPopoverWindow: BrowserWindow | null = null;
   private trayPopoverConfig: TrayPopoverConfig | null = null;
   private trayPopoverVisible = false;
+  private trayPopoverLastAnchorBounds: Rect | null = null;
   // Deferred blur-to-dismiss: blur schedules a hide ~200ms out; a tray-icon
   // re-click (which fires blur then tray-clicked) cancels the pending hide and
   // toggles closed instead, so a click on the icon never double-fires.
@@ -421,12 +422,24 @@ export class DesktopManager {
     mainWindowPresent: boolean;
     windowVisible: boolean;
     windowFocused: boolean;
+    shortcuts: Array<{ id: string; accelerator: string }>;
+    trayPopover: {
+      configured: boolean;
+      windowPresent: boolean;
+      visible: boolean;
+      lastAnchorBounds: Rect | null;
+    };
   }> {
     return {
       trayPresent: Boolean(this.tray),
       mainWindowPresent: Boolean(this.mainWindow),
       windowVisible: (await this.isWindowVisible()).visible,
       windowFocused: this._windowFocused,
+      shortcuts: Array.from(this.shortcuts.values()).map((shortcut) => ({
+        id: shortcut.id,
+        accelerator: shortcut.accelerator,
+      })),
+      trayPopover: this.getTrayPopoverDiagnostics(),
     };
   }
 
@@ -900,6 +913,18 @@ export class DesktopManager {
     accelerator: string;
   }): Promise<{ registered: boolean }> {
     return { registered: GlobalShortcut.isRegistered(options.accelerator) };
+  }
+
+  pressRegisteredShortcut(options: { id: string }): boolean {
+    const shortcut = this.shortcuts.get(options.id);
+    if (!shortcut) {
+      return false;
+    }
+    this.send("desktopShortcutPressed", {
+      id: shortcut.id,
+      accelerator: shortcut.accelerator,
+    });
+    return true;
   }
 
   // MARK: - Auto Launch
@@ -2059,6 +2084,20 @@ X-GNOME-Autostart-enabled=true
     return this.trayPopoverVisible;
   }
 
+  getTrayPopoverDiagnostics(): {
+    configured: boolean;
+    windowPresent: boolean;
+    visible: boolean;
+    lastAnchorBounds: Rect | null;
+  } {
+    return {
+      configured: Boolean(this.trayPopoverConfig),
+      windowPresent: Boolean(this.trayPopoverWindow),
+      visible: this.trayPopoverVisible,
+      lastAnchorBounds: this.trayPopoverLastAnchorBounds,
+    };
+  }
+
   /** Read the tray icon's screen bounds; zero-rect on any failure or no tray. */
   private readTrayBounds(): Rect {
     const zero: Rect = { x: 0, y: 0, width: 0, height: 0 };
@@ -2125,6 +2164,7 @@ X-GNOME-Autostart-enabled=true
 
     this.clearTrayPopoverBlurTimer();
     const frame = this.resolveTrayPopoverFrame();
+    this.trayPopoverLastAnchorBounds = frame;
 
     if (this.trayPopoverWindow) {
       const win = this.trayPopoverWindow;
@@ -2177,6 +2217,7 @@ X-GNOME-Autostart-enabled=true
     win.on("close", () => {
       this.trayPopoverWindow = null;
       this.trayPopoverVisible = false;
+      this.trayPopoverLastAnchorBounds = null;
       this.clearTrayPopoverBlurTimer();
     });
 
@@ -2220,6 +2261,7 @@ X-GNOME-Autostart-enabled=true
       );
     }
     this.trayPopoverWindow = null;
+    this.trayPopoverLastAnchorBounds = null;
   }
 
   // MARK: - Clipboard

--- a/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
@@ -942,7 +942,10 @@ async function withPackagedHarness(
       // behaviour. Since #10350 flipped the default resting surface to the
       // chromeless bottom bar, opt out here so they keep testing the full window
       // (the bottom-bar default is covered by electrobun-bottom-bar.e2e.spec.ts).
-      extraEnv: { ELIZA_DESKTOP_BOTTOM_BAR: "0" },
+      extraEnv: {
+        ELIZA_DESKTOP_BOTTOM_BAR: "0",
+        ELIZA_DESKTOP_TRAY_POPOVER: "1",
+      },
     });
     debugPackagedPhase("starting initial packaged launch");
     await harness.start({
@@ -1184,6 +1187,37 @@ test("packaged desktop reset from the application menu returns the shell to firs
   });
 });
 
+test("packaged desktop shortcut bridge summons the main window", async ({
+  browserName: _browserName,
+}) => {
+  void _browserName;
+  test.skip(
+    !isPackagedPlatform(),
+    "Packaged desktop regressions require a macOS, Windows, or Linux launcher.",
+  );
+
+  await withPackagedHarness(async ({ harness }) => {
+    const initialState = await harness.getState();
+    expect(initialState.shell.shortcuts ?? []).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "chat-overlay" })]),
+    );
+
+    await harness.closeMainWindow();
+    await harness.waitForState(
+      (state) => !state.mainWindow.present && state.shell.trayPresent,
+      "Expected closing the main window to leave the tray active before shortcut summon.",
+      30_000,
+    );
+
+    await harness.pressShortcut("chat-overlay");
+    await harness.waitForState(
+      (state) => state.mainWindow.present && state.shell.windowFocused,
+      "Expected shortcut bridge press to summon and focus the main window.",
+      30_000,
+    );
+  });
+});
+
 test("packaged macOS desktop keeps the tray alive and preserves vibrancy through resize", async ({
   browserName: _browserName,
 }, testInfo) => {
@@ -1205,6 +1239,11 @@ test("packaged macOS desktop keeps the tray alive and preserves vibrancy through
     );
 
     expect(initialState.mainWindow.titleBarStyle).toBe("hiddenInset");
+    expect(initialState.shell.trayPopover).toMatchObject({
+      configured: true,
+      windowPresent: false,
+      visible: false,
+    });
     await writeHarnessScreenshot(
       harness,
       testInfo,
@@ -1213,6 +1252,27 @@ test("packaged macOS desktop keeps the tray alive and preserves vibrancy through
 
     const initialEffects = await readMainWindowEffects(harness);
     expect(initialEffects.shadowEnabled).toBe(true);
+
+    const openedPopover = await harness.toggleTrayPopover();
+    expect(openedPopover).toMatchObject({
+      configured: true,
+      windowPresent: true,
+      visible: true,
+    });
+    expect(openedPopover.lastAnchorBounds).toMatchObject({
+      width: 360,
+      height: 480,
+    });
+
+    const hiddenPopover = await harness.toggleTrayPopover();
+    expect(hiddenPopover).toMatchObject({
+      configured: true,
+      windowPresent: true,
+      visible: false,
+    });
+    expect(hiddenPopover.lastAnchorBounds).toEqual(
+      openedPopover.lastAnchorBounds,
+    );
 
     await harness.closeMainWindow();
 

--- a/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
+++ b/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
@@ -54,6 +54,18 @@ export interface DesktopTestBridgeState {
     mainWindowPresent: boolean;
     windowVisible: boolean;
     windowFocused: boolean;
+    shortcuts?: Array<{ id: string; accelerator: string }>;
+    trayPopover?: {
+      configured: boolean;
+      windowPresent: boolean;
+      visible: boolean;
+      lastAnchorBounds: {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+      } | null;
+    };
   };
 }
 
@@ -963,6 +975,33 @@ export class PackagedDesktopHarness {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ action }),
+    });
+  }
+
+  async toggleTrayPopover(): Promise<
+    NonNullable<DesktopTestBridgeState["shell"]["trayPopover"]>
+  > {
+    const response = await fetchJson<{
+      ok: boolean;
+      trayPopover: NonNullable<DesktopTestBridgeState["shell"]["trayPopover"]>;
+    }>(`${this.bridgeUrl}/tray/popover/toggle`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.bridgeToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+    return response.trayPopover;
+  }
+
+  async pressShortcut(id: string): Promise<void> {
+    await fetchJson<{ ok: boolean }>(`${this.bridgeUrl}/shortcut/press`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.bridgeToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ id }),
     });
   }
 }


### PR DESCRIPTION
## Summary
- Adds tray popover diagnostics to the desktop test bridge `/state`: configured/window-present/visible/last anchor bounds.
- Adds loopback token-auth bridge endpoints for `POST /tray/popover/toggle` and `POST /shortcut/press`, with shortcut press invoking only registered shortcut ids.
- Adds packaged harness helpers for tray popover toggle and shortcut press.
- Extends native desktop tests and packaged regressions to consume the new tray popover and chat-overlay shortcut seams.

## Scope
- Covers the tray-popover + global-shortcut bridge seam slice of #13684.
- Intentionally does not implement notification observation; #13716 / #13696 owns the desktop notification RPC/test stream.

## Evidence
- `./node_modules/.bin/biome check .codex-tmp-13684/...` across the five touched files - pass with pre-existing undeclared-env warnings only.
- Bun TypeScript transpiler parse check across the five touched files - pass (`55884,20283,8291,23403,32421`).
- Attempted focused unit execution in a detached local worktree, but this local repo ref materialized without workspace package directories, so the test runner could not be invoked there.
- Full packaged execution not run in this API environment because it requires a built packaged Electrobun launcher and GUI shell artifact.

Closes the tray-popover and global-shortcut seam slice of #13684.