### PR TITLE
refactor(ui): Settings — desktop rail → SectionNav top-bar tabs (#13590)

### DIFF
--- a/packages/ui/src/components/pages/SettingsView.test.tsx
+++ b/packages/ui/src/components/pages/SettingsView.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 
 // Renders the real SettingsView against mocked state + stub sections to cover
-// hub navigation (tile → full-width section → back), the initialSection prop,
-// per-section error boundaries (isolate a throwing section, recover on retry),
-// and the responsive layout switch (single-column hub vs two-pane rail by
-// width/orientation). jsdom; sections and state barrel are stubbed.
+// the #13590 uniform layout: ONE shared ViewHeader + a folded top-bar section
+// nav (no desktop `w-60` rail, no divergent mobile hub, no responsive branch),
+// hub → section navigation (section tab → section body → back to hub), the
+// initialSection prop, and per-section error boundaries (isolate a throwing
+// section, recover on retry). jsdom; sections and state barrel are stubbed.
 
 import {
   cleanup,
@@ -90,6 +91,12 @@ vi.mock("../settings/settings-sections", () => {
             </div>
           ),
   }));
+  const groupLabels: Record<string, string> = {
+    agent: "Agent",
+    system: "System",
+    security: "Security",
+  };
+  const groupOrder = ["agent", "system", "security"];
   return {
     SECTION_TONE_ICON_CLASS: {
       ok: "",
@@ -98,14 +105,29 @@ vi.mock("../settings/settings-sections", () => {
       accent: "",
       neutral: "",
     },
-    SETTINGS_GROUP_LABEL: {
-      agent: "Agent",
-      system: "System",
-      security: "Security",
-    },
-    SETTINGS_GROUP_ORDER: ["agent", "system", "security"],
+    SETTINGS_GROUP_LABEL: groupLabels,
+    SETTINGS_GROUP_ORDER: groupOrder,
     SETTINGS_SECTIONS: sections,
     getAllSettingsSections: () => sections,
+    // Group the stub sections the way the real helper does (bucket by group,
+    // ordered by SETTINGS_GROUP_ORDER) so the folded section-nav renders.
+    groupSettingsSections: (input: typeof sections) => {
+      const buckets = new Map<string, typeof sections>();
+      for (const section of input) {
+        const bucket = buckets.get(section.group);
+        if (bucket) bucket.push(section);
+        else buckets.set(section.group, [section]);
+      }
+      return [...buckets.entries()]
+        .map(([group, items]) => ({
+          group,
+          label: groupLabels[group] ?? "Other",
+          items,
+          order: groupOrder.indexOf(group),
+        }))
+        .sort((a, b) => a.order - b.order)
+        .map(({ group, label, items }) => ({ group, label, items }));
+    },
     readSettingsHashSection: () => null,
     replaceSettingsHash: vi.fn(),
     settingsSectionLabel: (section: { defaultLabel: string }) =>
@@ -130,6 +152,20 @@ function makeContext(
   };
 }
 
+/** The folded section-nav strip rendered under the shared header. */
+function sectionNav(): HTMLElement {
+  return screen.getByTestId("settings-section-nav");
+}
+
+/** A section tab in the folded nav, by its visible label. */
+function sectionTab(label: string): HTMLButtonElement {
+  const tab = Array.from(sectionNav().querySelectorAll("button")).find(
+    (button) => button.textContent?.trim() === label,
+  );
+  if (!tab) throw new Error(`no section tab labelled "${label}"`);
+  return tab as HTMLButtonElement;
+}
+
 beforeEach(() => {
   appMock.value = makeContext();
   crashControl.shouldThrow = true;
@@ -138,34 +174,51 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("SettingsView", () => {
-  it("calls loadPlugins on mount and renders the hub tiles", async () => {
+  it("calls loadPlugins on mount and renders the uniform header + folded nav", async () => {
     render(<SettingsView />);
 
     await waitFor(() => {
       expect(appMock.value.loadPlugins).toHaveBeenCalled();
     });
-    // The hub shows a tile per registered section; no section body is mounted
-    // until a tile is selected.
-    expect(screen.getByText("Basics")).toBeTruthy();
-    expect(screen.getByText("Runtime")).toBeTruthy();
+    // The shared ViewHeader renders once, titled "Settings" on the hub.
+    const header = screen.getByTestId("view-header");
+    expect(header.textContent).toContain("Settings");
+    // The folded section nav lists a tab per registered section; no section
+    // body is mounted until a tab is selected.
+    expect(sectionTab("Basics")).toBeTruthy();
+    expect(sectionTab("Runtime")).toBeTruthy();
     expect(screen.queryByTestId("stub-identity")).toBeNull();
     expect(screen.queryByTestId("stub-runtime")).toBeNull();
+    // The hub rests on its deterministic empty state, not a section body.
+    expect(screen.getByTestId("settings-hub-empty")).toBeTruthy();
   });
 
-  it("clicking a hub tile opens that section full-width", () => {
+  it("renders exactly ONE header and NO desktop w-60 rail", () => {
+    const { container } = render(<SettingsView />);
+    // Uniform top bar: a single shared header, never two stacked.
+    expect(screen.getAllByTestId("view-header")).toHaveLength(1);
+    // The old persistent desktop rail (`nav.w-60`) is gone in every layout.
+    expect(container.querySelector("nav.w-60")).toBeNull();
+  });
+
+  it("groups the section tabs by Agent / System under the header", () => {
+    render(<SettingsView />);
+    const nav = sectionNav();
+    expect(nav.textContent).toContain("Agent");
+    expect(nav.textContent).toContain("System");
+  });
+
+  it("clicking a section tab opens that section under the same header", () => {
     render(<SettingsView />);
 
-    const runtimeTile = screen
-      .getByText("Runtime")
-      .closest("button") as HTMLButtonElement;
-    expect(runtimeTile).toBeTruthy();
+    fireEvent.click(sectionTab("Runtime"));
 
-    fireEvent.click(runtimeTile);
-
-    // The section body is now mounted, and a back affordance is present.
+    // The section body is now mounted and the shared header retitles to it.
     expect(screen.getByTestId("stub-runtime")).toBeTruthy();
     expect(screen.queryByTestId("stub-identity")).toBeNull();
-    expect(screen.getByText("Settings")).toBeTruthy();
+    expect(screen.getByTestId("view-header").textContent).toContain("Runtime");
+    // Still exactly one header — the section did not stack a second one.
+    expect(screen.getAllByTestId("view-header")).toHaveLength(1);
   });
 
   it("respects an initialSection prop by opening that section directly", () => {
@@ -173,17 +226,18 @@ describe("SettingsView", () => {
 
     expect(screen.getByTestId("stub-runtime")).toBeTruthy();
     expect(screen.queryByTestId("stub-identity")).toBeNull();
+    expect(screen.getByTestId("view-header").textContent).toContain("Runtime");
   });
 
-  it("back affordance returns to the hub", () => {
+  it("the header back affordance returns from a section to the hub", () => {
     render(<SettingsView initialSection="runtime" />);
 
-    const back = screen.getByText("Settings").closest("button");
-    expect(back).toBeTruthy();
-    fireEvent.click(back as HTMLButtonElement);
+    const back = screen.getByRole("button", { name: "Back to Settings" });
+    fireEvent.click(back);
 
-    // Both tiles are visible again and no section body is mounted.
-    expect(screen.getByText("Basics")).toBeTruthy();
+    // Back on the hub: header titled "Settings", empty state, no section body.
+    expect(screen.getByTestId("view-header").textContent).toContain("Settings");
+    expect(screen.getByTestId("settings-hub-empty")).toBeTruthy();
     expect(screen.queryByTestId("stub-runtime")).toBeNull();
   });
 
@@ -197,10 +251,10 @@ describe("SettingsView", () => {
       render(<SettingsView initialSection="crash" />);
 
       // The section body crashed, but the shell did NOT blank: the inline
-      // per-section fallback renders and the nav back-affordance stays usable.
+      // per-section fallback renders and the header/nav stay usable.
       expect(screen.getByTestId("settings-section-error")).toBeTruthy();
       expect(screen.queryByTestId("stub-crash")).toBeNull();
-      expect(screen.getByText("Settings")).toBeTruthy();
+      expect(screen.getByTestId("view-header").textContent).toContain("Crash");
     } finally {
       consoleError.mockRestore();
     }
@@ -226,34 +280,11 @@ describe("SettingsView", () => {
     }
   });
 
-  it("on desktop, shows a persistent rail with a section selected in the pane", () => {
-    // Force the desktop media query to match so the two-pane layout renders.
-    const original = window.matchMedia;
-    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
-      matches: true,
-      media: query,
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })) as unknown as typeof window.matchMedia;
-    try {
-      render(<SettingsView />);
-      // The rail lists every section AND the detail pane shows the first one
-      // (no tap + no back button needed on desktop). "Basics" appears twice on
-      // desktop: the rail item and the detail-pane title.
-      expect(screen.getAllByText("Basics").length).toBeGreaterThan(0);
-      expect(screen.getByText("Runtime")).toBeTruthy();
-      expect(screen.getByTestId("stub-identity")).toBeTruthy();
-      expect(screen.queryByText("Settings")).not.toBeNull();
-    } finally {
-      window.matchMedia = original;
-    }
-  });
-
-  // ── #9945: orientation-aware two-pane selection ───────────────────────────
+  // ── #13590: form-factor independence ──────────────────────────────────────
+  //
+  // The uniform layout has NO responsive branch (the desktop rail + mobile-hub
+  // split is gone). The same header + folded nav render regardless of viewport,
+  // so a mocked matchMedia must NOT change what is shown.
 
   /** Mock matchMedia so each query resolves by the supplied predicate. */
   function mockMatchMedia(matches: (query: string) => boolean) {
@@ -273,29 +304,29 @@ describe("SettingsView", () => {
     };
   }
 
-  it("uses the two-pane layout for a landscape phone (narrow width, landscape)", () => {
-    // Landscape phone: NOT min-width:1024, but it IS min-width:768 + landscape.
-    // A plain width-only check would wrongly drop it into the hub.
-    const restore = mockMatchMedia(
-      (query) => query === "(min-width: 768px) and (orientation: landscape)",
-    );
+  it("renders the same folded nav + hub on a wide (desktop) viewport", () => {
+    const restore = mockMatchMedia(() => true);
     try {
       render(<SettingsView />);
-      // Two-pane auto-selects the first section's body (no tap needed).
-      expect(screen.getByTestId("stub-identity")).toBeTruthy();
+      // No auto-selected pane, no rail — just the hub + folded nav, as on mobile.
+      expect(sectionTab("Basics")).toBeTruthy();
+      expect(sectionTab("Runtime")).toBeTruthy();
+      expect(screen.getByTestId("settings-hub-empty")).toBeTruthy();
+      expect(screen.queryByTestId("stub-identity")).toBeNull();
+      expect(screen.getAllByTestId("view-header")).toHaveLength(1);
     } finally {
       restore();
     }
   });
 
-  it("uses the single-column hub for a portrait tablet (narrow width, portrait)", () => {
-    // Portrait tablet: neither min-width:1024 nor the landscape combo matches.
+  it("renders the same folded nav + hub on a narrow (mobile) viewport", () => {
     const restore = mockMatchMedia(() => false);
     try {
       render(<SettingsView />);
-      // Hub shows the nav rows but does not auto-render a section body.
+      expect(sectionTab("Basics")).toBeTruthy();
+      expect(screen.getByTestId("settings-hub-empty")).toBeTruthy();
       expect(screen.queryByTestId("stub-identity")).toBeNull();
-      expect(screen.getByText("Basics")).toBeTruthy();
+      expect(screen.getAllByTestId("view-header")).toHaveLength(1);
     } finally {
       restore();
     }

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -1,197 +1,47 @@
 /**
- * The Settings view (`/settings`): a sectioned settings surface that adapts
- * between a two-pane rail+detail layout on wide/landscape viewports and a
- * single-column hub on narrow ones. Section content is lazy-loaded and gated by
- * `isViewVisible`; `initialSection` deep-links a specific pane. Also reusable in
- * modal form (`inModal`).
+ * The Settings view (`/settings`): a sectioned settings surface with ONE
+ * uniform top bar in every layout (#13590). A shared `ViewHeader` (icon-only
+ * back, centered title) sits above a folded top-bar section nav
+ * (`SettingsSectionNav`) that replaces the old desktop `w-60` LEFT RAIL and the
+ * divergent mobile hub; one nav + one detail region for all form factors.
+ *
+ * - Hub (no section open): header title = "Settings", back → launcher; the
+ *   section nav lets the user pick a section.
+ * - Section open: header title = section label, back → hub; the nav keeps the
+ *   active section marked.
+ *
+ * Section content is lazy-loaded and gated by `isViewVisible`; `initialSection`
+ * deep-links a specific section. Also reusable in modal form (`inModal`).
  */
 import { isViewVisible } from "@elizaos/core";
-import type * as React from "react";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
-import { listExtraSettingsGroups } from "../../cloud/settings/cloud-settings-group";
-import { useMediaQuery } from "../../hooks/useMediaQuery";
 import { ContentLayout } from "../../layouts/content-layout";
-import { cn } from "../../lib/utils";
 import { isAndroidCloudBuild } from "../../platform/android-runtime";
 import { useAppSelectorShallow } from "../../state";
 import { useEnabledViewKinds } from "../../state/useViewKinds";
+import { SettingsSectionNav } from "../settings/SettingsSectionNav";
 import {
-  SettingsGroup,
-  SettingsRow,
-  SettingsStack,
-} from "../settings/settings-layout";
-import {
+  type GroupedSettingsSections,
   getAllSettingsSections,
+  groupSettingsSections,
   readSettingsHashSection,
   replaceSettingsHash,
-  SECTION_TONE_ICON_CLASS,
-  SETTINGS_GROUP_LABEL,
-  SETTINGS_GROUP_ORDER,
   type SettingsSectionDef,
   settingsSectionLabel,
   settingsSectionTitle,
 } from "../settings/settings-sections";
-import { ViewHeader } from "../shared/ViewHeader";
+import { navigateBackToLauncher, ViewHeader } from "../shared/ViewHeader";
 import { Button } from "../ui/button";
 import { ErrorBoundary } from "../ui/error-boundary";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 
 type Translate = (key: string, vars?: Record<string, unknown>) => string;
 
-type GroupedSections = {
-  group: string;
-  label: string;
-  items: SettingsSectionDef[];
-}[];
-
-function isCloudThemedSettingsSection(section: SettingsSectionDef): boolean {
-  // The id-prefix intentionally also covers cloud-owned panes registered under
-  // non-cloud groups (cloud-security / cloud-plugin-grants under "security",
-  // cloud-connectors under "agent"): their bodies hardcode light-on-dark
-  // styling (text-white, white/10 borders, bg-black/40) and need the dark
-  // theme-cloud island to stay readable.
-  return (
-    section.id.startsWith("cloud-") ||
-    section.group === "cloud" ||
-    section.group === "developer"
-  );
-}
-
-/**
- * Group sections for display. Built-in groups keep their pinned order + labels;
- * any extra group a section declares (e.g. the `cloud` group) is interleaved by
- * its registered order with a registered label. A section whose group is neither
- * built-in nor registered falls into an "Other" bucket so it is never dropped.
- */
-function groupSections(sections: SettingsSectionDef[]): GroupedSections {
-  const extra = listExtraSettingsGroups();
-  // Built-in groups order by their position in the pinned list (0,1,2). Extra
-  // groups slot between them by their declared order (e.g. cloud at 1.5 between
-  // System=1 and Security=2).
-  const orderOf = new Map<string, number>();
-  const labels = new Map<string, string>();
-  SETTINGS_GROUP_ORDER.forEach((group, index) => {
-    orderOf.set(group, index);
-    labels.set(group, SETTINGS_GROUP_LABEL[group]);
-  });
-  for (const group of extra) {
-    orderOf.set(group.id, group.order);
-    labels.set(group.id, group.label);
-  }
-
-  const buckets = new Map<string, SettingsSectionDef[]>();
-  for (const section of sections) {
-    const bucket = buckets.get(section.group);
-    if (bucket) bucket.push(section);
-    else buckets.set(section.group, [section]);
-  }
-
-  const FALLBACK_ORDER = Number.MAX_SAFE_INTEGER;
-  return [...buckets.entries()]
-    .map(([group, items]) => ({
-      group,
-      label: labels.get(group) ?? "Other",
-      items,
-      order: orderOf.get(group) ?? FALLBACK_ORDER,
-    }))
-    .filter((entry) => entry.items.length > 0)
-    .sort((a, b) => a.order - b.order)
-    .map(({ group, label, items }) => ({ group, label, items }));
-}
-
-/** Status chip shown on a nav row when cheap to derive. */
-function sectionChip(
-  section: SettingsSectionDef,
-  walletEnabled: boolean | undefined,
-): string | null {
-  if (section.id === "wallet-rpc") return walletEnabled ? "On" : null;
-  return null;
-}
-
-function Chip({ children }: { children: React.ReactNode }) {
-  return (
-    <span className="inline-flex items-center text-[11px] font-medium text-accent">
-      {children}
-    </span>
-  );
-}
-
-/**
- * One navigation entry. Renders as a tappable list row on mobile and a compact
- * rail item on desktop, sharing a single agent-surface registration so the
- * agent can open any section by id from chat.
- */
-function SettingsNavItem({
-  section,
-  label,
-  chip,
-  active,
-  variant,
-  onSelect,
-}: {
-  section: SettingsSectionDef;
-  label: string;
-  chip: string | null;
-  active: boolean;
-  variant: "list" | "rail";
-  onSelect: (id: string) => void;
-}) {
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: `section-${section.id}`,
-    role: "card",
-    label,
-    group: "settings-sections",
-    description: `Open the ${label} settings section`,
-    onActivate: () => onSelect(section.id),
-  });
-  const Icon = section.icon;
-
-  if (variant === "list") {
-    return (
-      <SettingsRow
-        icon={Icon}
-        iconClassName={SECTION_TONE_ICON_CLASS[section.tone]}
-        label={label}
-        onClick={() => onSelect(section.id)}
-        buttonRef={ref}
-        buttonProps={agentProps}
-        trailing={chip ? <Chip>{chip}</Chip> : undefined}
-        chevron={!chip}
-      />
-    );
-  }
-
-  return (
-    <Button
-      ref={ref}
-      variant="ghost"
-      size="sm"
-      onClick={() => onSelect(section.id)}
-      aria-current={active ? "page" : undefined}
-      className={cn(
-        "h-auto w-full justify-start gap-2.5 rounded-md px-2.5 py-2 text-left text-sm transition-colors",
-        active ? "font-medium text-accent" : "text-txt hover:bg-surface",
-      )}
-      {...agentProps}
-    >
-      <Icon
-        className={cn(
-          "h-4 w-4 shrink-0",
-          active ? "text-accent" : SECTION_TONE_ICON_CLASS[section.tone],
-        )}
-        aria-hidden
-      />
-      <span className="min-w-0 flex-1 truncate">{label}</span>
-      {chip ? <Chip>{chip}</Chip> : null}
-    </Button>
-  );
-}
-
 /**
  * Loading placeholder for a lazily-loaded section body (#11351). Deliberately
  * minimal — a single muted, `aria-busy` line so the split is visually quiet and
- * never shifts the section header or nav rail while the chunk resolves.
+ * never shifts the header while the chunk resolves.
  */
 function SettingsSectionLoading() {
   return (
@@ -202,78 +52,48 @@ function SettingsSectionLoading() {
   );
 }
 
-/** The active section's body: optional back, header (icon + title), content. */
+/**
+ * The active section's body. The uniform `ViewHeader` lives at the view root
+ * (not per-section), so this only renders the lazy section component behind a
+ * transparent Suspense + error boundary. One opaque token surface for the whole
+ * view — no per-section `theme-cloud bg-black` islands (#13452).
+ */
 function SettingsSectionContent({
   section,
   t,
-  onBack,
 }: {
   section: SettingsSectionDef;
   t: Translate;
-  onBack?: () => void;
 }) {
   const Component = section.Component;
-  const Icon = section.icon;
   const title = settingsSectionTitle(section, t);
-  const cloudThemed = isCloudThemedSettingsSection(section);
   return (
-    <div
-      id={section.id}
-      className={cn(
-        cloudThemed &&
-          "theme-cloud min-h-[calc(100dvh-8rem)] bg-black px-3 py-4 text-white sm:px-5 sm:py-5",
-      )}
-    >
-      {onBack ? (
-        /* Section → hub back uses the shared normal-view header (#13451):
-           icon-only, left-aligned back arrow with a centered section title,
-           replacing the old section-local text "Settings" button + separate
-           icon heading. The shell already owns horizontal padding, so the
-           header is flush with the section body. */
-        <ViewHeader
-          title={title}
-          onBack={onBack}
-          backLabel="Back to Settings"
-          className="mb-5 px-0"
-        />
-      ) : (
-        /* Desktop detail pane: the rail owns navigation, so there is no header
-           back control — keep the icon + title heading for the selected pane. */
-        <div className="mb-5 flex items-center gap-2.5">
-          <Icon className="h-5 w-5 shrink-0 text-muted/80" aria-hidden />
-          <h1 className="text-lg font-semibold tracking-tight text-txt-strong">
-            {title}
-          </h1>
-        </div>
-      )}
-      {/* Flat — no card/border. The shell owns the page's horizontal padding. */}
-      <div className={section.bodyClassName}>
-        <ErrorBoundary
-          key={section.id}
-          fallback={(error, reset) => (
-            <SettingsSectionFallback
-              title={title}
-              error={error}
-              onRetry={reset}
-              t={t}
-            />
-          )}
-        >
-          {/* Section bodies are `React.lazy` (#11351); the boundary keeps the
-              split transparent with a minimal, unobtrusive loading state. */}
-          <Suspense fallback={<SettingsSectionLoading />}>
-            <Component />
-          </Suspense>
-        </ErrorBoundary>
-      </div>
+    <div id={section.id} className={section.bodyClassName}>
+      <ErrorBoundary
+        key={section.id}
+        fallback={(error, reset) => (
+          <SettingsSectionFallback
+            title={title}
+            error={error}
+            onRetry={reset}
+            t={t}
+          />
+        )}
+      >
+        {/* Section bodies are `React.lazy` (#11351); the boundary keeps the
+            split transparent with a minimal, unobtrusive loading state. */}
+        <Suspense fallback={<SettingsSectionLoading />}>
+          <Component />
+        </Suspense>
+      </ErrorBoundary>
     </div>
   );
 }
 
 /**
  * Inline per-section error fallback. A section that throws on mount/render must
- * degrade to this card — never blank the whole shell — so the settings nav rail
- * and every other section stay interactive. Uses the settings `warn` token
+ * degrade to this card — never blank the whole shell — so the settings nav and
+ * every other section stay interactive. Uses the settings `warn` token
  * vocabulary for visual consistency with the rest of the surface.
  */
 function SettingsSectionFallback({
@@ -314,98 +134,38 @@ function SettingsSectionFallback({
   );
 }
 
-function MobileHub({
-  grouped,
-  t,
-  walletEnabled,
+/**
+ * A per-section agent-surface registration so the agent can open any section by
+ * id from chat (`section-<id>`), independent of which section is currently
+ * shown. Renders nothing — it only wires the surface element.
+ */
+function SettingsSectionSurfaceAnchor({
+  section,
+  label,
   onSelect,
 }: {
-  grouped: GroupedSections;
-  t: Translate;
-  walletEnabled: boolean | undefined;
+  section: SettingsSectionDef;
+  label: string;
   onSelect: (id: string) => void;
 }) {
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: `section-${section.id}`,
+    role: "button",
+    label,
+    group: "settings-sections",
+    description: `Open the ${label} settings section`,
+    onActivate: () => onSelect(section.id),
+  });
   return (
-    <div className="w-full pb-32">
-      {/* Top-level view header: centered "Settings" title with a launcher back
-          arrow on mobile (iOS-style nav bar). Only the single-column hub renders
-          it — the desktop split already owns its own "Settings" H1 in the rail,
-          and the per-section view keeps its own shared ViewHeader (section→hub). */}
-      <ViewHeader
-        title={t("nav.settings", { defaultValue: "Settings" })}
-        className="mb-2"
-      />
-      <SettingsStack>
-        {grouped.map(({ group, label, items }) => (
-          <SettingsGroup key={group} title={label}>
-            {items.map((section) => (
-              <SettingsNavItem
-                key={section.id}
-                section={section}
-                label={settingsSectionLabel(section, t)}
-                chip={sectionChip(section, walletEnabled)}
-                active={false}
-                variant="list"
-                onSelect={onSelect}
-              />
-            ))}
-          </SettingsGroup>
-        ))}
-      </SettingsStack>
-    </div>
-  );
-}
-
-function DesktopLayout({
-  grouped,
-  t,
-  walletEnabled,
-  activeId,
-  activeSection,
-  onSelect,
-}: {
-  grouped: GroupedSections;
-  t: Translate;
-  walletEnabled: boolean | undefined;
-  activeId: string | null;
-  activeSection: SettingsSectionDef | null;
-  onSelect: (id: string) => void;
-}) {
-  return (
-    <div className="flex w-full gap-7 pb-32">
-      <nav className="w-60 shrink-0" aria-label="Settings sections">
-        <div className="sticky top-2 space-y-5">
-          <h1 className="min-h-8 px-2.5 pl-12 text-lg font-semibold tracking-tight text-txt-strong">
-            {t("nav.settings", { defaultValue: "Settings" })}
-          </h1>
-          {grouped.map(({ group, label, items }) => (
-            <div key={group}>
-              <h2 className="mb-1 px-2.5 text-xs font-medium text-muted">
-                {label}
-              </h2>
-              <div className="space-y-0.5">
-                {items.map((section) => (
-                  <SettingsNavItem
-                    key={section.id}
-                    section={section}
-                    label={settingsSectionLabel(section, t)}
-                    chip={sectionChip(section, walletEnabled)}
-                    active={section.id === activeId}
-                    variant="rail"
-                    onSelect={onSelect}
-                  />
-                ))}
-              </div>
-            </div>
-          ))}
-        </div>
-      </nav>
-      <div className="min-w-0 flex-1">
-        {activeSection ? (
-          <SettingsSectionContent section={activeSection} t={t} />
-        ) : null}
-      </div>
-    </div>
+    <button
+      ref={ref}
+      type="button"
+      aria-hidden
+      tabIndex={-1}
+      className="hidden"
+      onClick={() => onSelect(section.id)}
+      {...agentProps}
+    />
   );
 }
 
@@ -422,17 +182,6 @@ export function SettingsView({
     loadPlugins: s.loadPlugins,
     walletEnabled: s.walletEnabled,
   }));
-  // The two-pane (rail + detail) layout needs real horizontal room. A plain
-  // `min-width: 1024px` check sends a landscape phone (≈900px wide, but with
-  // ample horizontal space) to the single-column hub, and can push a narrow
-  // portrait tablet into the cramped two-pane. Combine width with orientation:
-  // two-pane when the viewport is genuinely wide (≥1024, any orientation, e.g. a
-  // portrait desktop monitor) OR when it is landscape and at least tablet-wide.
-  const isWide = useMediaQuery("(min-width: 1024px)");
-  const isWideLandscape = useMediaQuery(
-    "(min-width: 768px) and (orientation: landscape)",
-  );
-  const isTwoPane = isWide || isWideLandscape;
   const enabledKinds = useEnabledViewKinds();
   const [activeSection, setActiveSection] = useState<string | null>(
     () => initialSection ?? readSettingsHashSection(),
@@ -450,8 +199,8 @@ export function SettingsView({
     () => new Set(visibleSections.map((section) => section.id)),
     [visibleSections],
   );
-  const grouped = useMemo(
-    () => groupSections(visibleSections),
+  const grouped: GroupedSettingsSections = useMemo(
+    () => groupSettingsSections(visibleSections),
     [visibleSections],
   );
 
@@ -496,41 +245,82 @@ export function SettingsView({
         null)
       : null;
 
-  // Desktop keeps a section selected in the detail pane; mobile shows the
-  // grouped list until a row is tapped.
-  const desktopSection = activeSectionDef ?? visibleSections[0] ?? null;
+  // Uniform top bar: a hub shows "Settings" with a launcher back; an open
+  // section shows its label with a back to the hub. One header, both states.
+  const headerTitle = activeSectionDef
+    ? settingsSectionTitle(activeSectionDef, t)
+    : t("nav.settings", { defaultValue: "Settings" });
+  const onBack = activeSectionDef ? backToHub : navigateBackToLauncher;
+  const backLabel = activeSectionDef ? "Back to Settings" : "Back to launcher";
 
   return (
     <ShellViewAgentSurface viewId="settings">
       <ContentLayout inModal={inModal} contentClassName="max-sm:pt-1">
-        <div data-testid="settings-shell">
-          {isTwoPane ? (
-            <DesktopLayout
-              grouped={grouped}
-              t={t}
-              walletEnabled={walletEnabled}
-              activeId={desktopSection?.id ?? null}
-              activeSection={desktopSection}
-              onSelect={openSection}
-            />
-          ) : activeSectionDef ? (
-            <div className="w-full pb-32 max-sm:pt-8">
-              <SettingsSectionContent
-                section={activeSectionDef}
-                t={t}
-                onBack={backToHub}
+        <div data-testid="settings-shell" className="flex w-full flex-col">
+          <ViewHeader
+            title={headerTitle}
+            onBack={onBack}
+            backLabel={backLabel}
+            className="px-0"
+          />
+          {/* The folded top-bar section nav (was the desktop `w-60` rail).
+              One strip, grouped by Agent/System/Security/Cloud, for every form
+              factor — it self-scrolls on narrow viewports. */}
+          <SettingsSectionNav
+            grouped={grouped}
+            activeId={activeSectionDef?.id ?? null}
+            onSelect={openSection}
+            label={(labelKey, fallback) =>
+              t(labelKey, { defaultValue: fallback })
+            }
+            className="mb-4 border-b border-border/45 px-0"
+          />
+          {/* Agent-surface anchors: the agent addresses every section by
+              `section-<id>` regardless of which one is shown. */}
+          <div className="hidden">
+            {visibleSections.map((section) => (
+              <SettingsSectionSurfaceAnchor
+                key={section.id}
+                section={section}
+                label={settingsSectionLabel(section, t)}
+                onSelect={openSection}
               />
-            </div>
-          ) : (
-            <MobileHub
-              grouped={grouped}
-              t={t}
-              walletEnabled={walletEnabled}
-              onSelect={openSection}
-            />
-          )}
+            ))}
+          </div>
+          <div className="min-w-0 flex-1 pb-32">
+            {activeSectionDef ? (
+              <SettingsSectionContent section={activeSectionDef} t={t} />
+            ) : (
+              <SettingsHubEmptyState t={t} />
+            )}
+          </div>
         </div>
       </ContentLayout>
     </ShellViewAgentSurface>
+  );
+}
+
+/**
+ * The hub's resting state (no section chosen). The doctrine drops the old
+ * grouped list — the top-bar section nav IS the picker now — so the body
+ * teaches the interface rather than restating the nav: a quiet prompt to choose
+ * a section above. Deterministic empty state per the design system.
+ */
+function SettingsHubEmptyState({ t }: { t: Translate }) {
+  return (
+    <div
+      data-testid="settings-hub-empty"
+      className="flex min-h-[12rem] flex-col items-start justify-center gap-1"
+    >
+      <p className="text-sm font-medium text-txt-strong">
+        {t("settings.hubEmptyTitle", { defaultValue: "Choose a setting" })}
+      </p>
+      <p className="max-w-prose text-sm text-muted">
+        {t("settings.hubEmptyBody", {
+          defaultValue:
+            "Pick a section from the bar above to configure your agent, system, or security.",
+        })}
+      </p>
+    </div>
   );
 }

--- a/packages/ui/src/components/settings/SettingsSectionNav.test.tsx
+++ b/packages/ui/src/components/settings/SettingsSectionNav.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+
+/**
+ * Integration test for the settings section-nav (#13590): the folded top-bar
+ * strip that replaced the desktop `w-60` rail. It renders REAL sections through
+ * the SHARED `SectionNavTab` primitive (from `../shared/SectionNav`), so this
+ * doubles as the "SectionNav-integration test for the settings group" — it
+ * confirms Settings drives the same ghost-tab primitive the app-shell families
+ * use, grouped by Agent / System / Security, with active-tab marking + select.
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Settings } from "lucide-react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SettingsSectionNav } from "./SettingsSectionNav";
+import type { GroupedSettingsSections } from "./settings-sections";
+
+/** A minimal section def shaped like the registry's, enough for the nav. */
+function section(id: string, label: string, group: string) {
+  return {
+    id,
+    label: `settings.sections.${id}.label`,
+    defaultLabel: label,
+    icon: Settings,
+    tone: "neutral" as const,
+    hue: "slate" as const,
+    group,
+    titleKey: `settings.sections.${id}.label`,
+    defaultTitle: label,
+    Component: () => null,
+  };
+}
+
+const grouped: GroupedSettingsSections = [
+  {
+    group: "agent",
+    label: "Agent",
+    items: [
+      section("identity", "Basics", "agent"),
+      section("ai-model", "Models & Providers", "agent"),
+    ],
+  },
+  {
+    group: "system",
+    label: "System",
+    items: [section("runtime", "Runtime", "system")],
+  },
+  {
+    group: "security",
+    label: "Security",
+    items: [
+      section("secrets", "Vault", "security"),
+      section("security", "Security", "security"),
+    ],
+  },
+] as unknown as GroupedSettingsSections;
+
+/** Resolve labels straight to their fallback (no i18n table in the test). */
+const label = (_key: string, fallback: string) => fallback;
+
+afterEach(() => cleanup());
+
+describe("SettingsSectionNav", () => {
+  it("renders one ghost tab per section, clustered under each group label", () => {
+    render(
+      <SettingsSectionNav
+        grouped={grouped}
+        activeId={null}
+        onSelect={vi.fn()}
+        label={label}
+      />,
+    );
+    const nav = screen.getByTestId("settings-section-nav");
+    // Group labels are present as cluster headers.
+    expect(nav.textContent).toContain("Agent");
+    expect(nav.textContent).toContain("System");
+    expect(nav.textContent).toContain("Security");
+    // One tab (button) per section, in group + declared order.
+    const tabLabels = Array.from(nav.querySelectorAll("button")).map((b) =>
+      b.textContent?.trim(),
+    );
+    expect(tabLabels).toEqual([
+      "Basics",
+      "Models & Providers",
+      "Runtime",
+      "Vault",
+      "Security",
+    ]);
+  });
+
+  it("marks only the active section's tab with aria-current=page", () => {
+    render(
+      <SettingsSectionNav
+        grouped={grouped}
+        activeId="runtime"
+        onSelect={vi.fn()}
+        label={label}
+      />,
+    );
+    expect(
+      screen
+        .getByRole("button", { name: "Runtime" })
+        .getAttribute("aria-current"),
+    ).toBe("page");
+    expect(
+      screen
+        .getByRole("button", { name: "Basics" })
+        .getAttribute("aria-current"),
+    ).toBeNull();
+  });
+
+  it("calls onSelect with the section id when an inactive tab is clicked", () => {
+    const onSelect = vi.fn();
+    render(
+      <SettingsSectionNav
+        grouped={grouped}
+        activeId="runtime"
+        onSelect={onSelect}
+        label={label}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Vault" }));
+    expect(onSelect).toHaveBeenCalledWith("secrets");
+  });
+
+  it("does not re-select the already-active tab (shared primitive guard)", () => {
+    const onSelect = vi.fn();
+    render(
+      <SettingsSectionNav
+        grouped={grouped}
+        activeId="runtime"
+        onSelect={onSelect}
+        label={label}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Runtime" }));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("keeps a single-section group's lone tab (unlike the app-shell strip)", () => {
+    // The System group has exactly one section here; Settings still shows it
+    // (the whole view is the section family), whereas SectionTabStrip hides a
+    // single-member app-shell section. Assert the lone System tab renders.
+    render(
+      <SettingsSectionNav
+        grouped={grouped}
+        activeId={null}
+        onSelect={vi.fn()}
+        label={label}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Runtime" })).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/settings/SettingsSectionNav.tsx
+++ b/packages/ui/src/components/settings/SettingsSectionNav.tsx
@@ -1,0 +1,76 @@
+/**
+ * Settings section navigation (#13590).
+ *
+ * The old Settings view carried a persistent desktop LEFT RAIL (`nav.w-60`) with
+ * its own inline `<h1>Settings</h1>` and a divergent mobile hub. The redesign
+ * doctrine (#13451/#13586/#13452) folds that rail into a single top-bar section
+ * nav that sits BENEATH the shared `ViewHeader` — the same Wallet pattern
+ * (`WalletSectionNav`), one nav + one detail region for every form factor.
+ *
+ * Settings is NOT an app-shell-page family, so it cannot drive the registry-
+ * bound `SectionNav` (which reads `listAppShellPages()` + path routing).
+ * Settings owns its own hash-routed registry (`settings-sections.ts`) grouped
+ * into Agent / System / Security / Cloud fold groups. To avoid a parallel
+ * tab renderer, this component reuses the SAME presentational primitive the
+ * app-shell family uses — `SectionTabStrip` from `../shared/SectionNav` — for
+ * the doctrine ghost-tab geometry + styling. It only supplies the grouped
+ * settings entries + hash-selection; the strip owns the pixels.
+ *
+ * The strip is a single horizontal, scrollable row of section tabs delimited by
+ * their group label, so Agent/System/Security/Cloud read as folded clusters
+ * without a second nav level. On mobile it scrolls; on desktop it wraps to the
+ * available width. A group with a single section still shows its lone tab (the
+ * whole view is the "section" here, unlike the app-shell single-member case).
+ */
+
+import { cn } from "../../lib/utils";
+import { SectionNavTab } from "../shared/SectionNav";
+import type { GroupedSettingsSections } from "./settings-sections";
+
+/**
+ * The horizontal grouped section strip. Renders one ghost tab per section,
+ * clustered under its group label, marking `activeId` active. `onSelect` opens
+ * that section (hash-routed by the caller). Purely presentational otherwise —
+ * it defers every tab's pixels to the shared `SectionNavTab`.
+ */
+export function SettingsSectionNav({
+  grouped,
+  activeId,
+  onSelect,
+  label,
+  className,
+}: {
+  grouped: GroupedSettingsSections;
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  /** Rendered group label + accessible section label (i18n-resolved by caller). */
+  label: (labelKey: string, fallback: string) => string;
+  className?: string;
+}): React.JSX.Element {
+  return (
+    <nav
+      aria-label="Settings sections"
+      data-testid="settings-section-nav"
+      className={cn(
+        "flex min-w-0 shrink-0 items-center gap-4 overflow-x-auto px-3 py-2",
+        className,
+      )}
+    >
+      {grouped.map(({ group, label: groupLabel, items }) => (
+        <div key={group} className="flex shrink-0 items-center gap-1.5">
+          <span className="shrink-0 select-none pr-0.5 text-2xs font-medium uppercase tracking-wide text-muted/70">
+            {groupLabel}
+          </span>
+          {items.map((section) => (
+            <SectionNavTab
+              key={section.id}
+              label={label(section.label, section.defaultLabel)}
+              isActive={section.id === activeId}
+              onSelect={() => onSelect(section.id)}
+            />
+          ))}
+        </div>
+      ))}
+    </nav>
+  );
+}

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -34,6 +34,7 @@ import { type ComponentType, type LazyExoticComponent, lazy } from "react";
 import { registerCloudConnectorsSettingsSection } from "../../cloud/connectors";
 import {
   CLOUD_SETTINGS_GROUP_ID,
+  listExtraSettingsGroups,
   registerSettingsGroup,
 } from "../../cloud/settings/cloud-settings-group";
 import {
@@ -643,6 +644,56 @@ export function settingsSectionLabel(
   t: (key: string, vars?: Record<string, unknown>) => string,
 ): string {
   return t(section.label, { defaultValue: section.defaultLabel });
+}
+
+/** One display group: a labelled bucket of sections in display order. */
+export type GroupedSettingsSections = {
+  group: string;
+  label: string;
+  items: SettingsSectionDef[];
+}[];
+
+/**
+ * Group sections for display (shared by the Settings view header/nav and the
+ * folded section-nav strip). Built-in groups keep their pinned order + labels;
+ * any extra group a section declares (e.g. the `cloud` group) is interleaved by
+ * its registered order with a registered label. A section whose group is
+ * neither built-in nor registered falls into an "Other" bucket so it is never
+ * dropped.
+ */
+export function groupSettingsSections(
+  sections: SettingsSectionDef[],
+): GroupedSettingsSections {
+  const extra = listExtraSettingsGroups();
+  const orderOf = new Map<string, number>();
+  const labels = new Map<string, string>();
+  SETTINGS_GROUP_ORDER.forEach((group, index) => {
+    orderOf.set(group, index);
+    labels.set(group, SETTINGS_GROUP_LABEL[group]);
+  });
+  for (const group of extra) {
+    orderOf.set(group.id, group.order);
+    labels.set(group.id, group.label);
+  }
+
+  const buckets = new Map<string, SettingsSectionDef[]>();
+  for (const section of sections) {
+    const bucket = buckets.get(section.group);
+    if (bucket) bucket.push(section);
+    else buckets.set(section.group, [section]);
+  }
+
+  const FALLBACK_ORDER = Number.MAX_SAFE_INTEGER;
+  return [...buckets.entries()]
+    .map(([group, items]) => ({
+      group,
+      label: labels.get(group) ?? "Other",
+      items,
+      order: orderOf.get(group) ?? FALLBACK_ORDER,
+    }))
+    .filter((entry) => entry.items.length > 0)
+    .sort((a, b) => a.order - b.order)
+    .map(({ group, label, items }) => ({ group, label, items }));
 }
 
 export function settingsSectionTitle(

--- a/packages/ui/src/components/shared/SectionNav.tsx
+++ b/packages/ui/src/components/shared/SectionNav.tsx
@@ -135,6 +135,91 @@ function navigate(path: string): void {
 }
 
 /**
+ * A single ghost tab within a {@link SectionTabStrip}. Shared so the doctrine
+ * tab styling (active `bg-accent/15 text-accent`, inactive neutral → neutral/
+ * opacity hover) lives in exactly one place across every section-nav consumer.
+ */
+export function SectionNavTab({
+  label,
+  isActive,
+  onSelect,
+}: {
+  label: React.ReactNode;
+  isActive: boolean;
+  onSelect: () => void;
+}): React.JSX.Element {
+  return (
+    <Button
+      aria-current={isActive ? "page" : undefined}
+      onClick={() => {
+        if (!isActive) onSelect();
+      }}
+      variant="ghost"
+      size="sm"
+      className={cn(
+        "h-auto shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+        isActive
+          ? "bg-accent/15 text-accent"
+          : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
+      )}
+    >
+      {label}
+    </Button>
+  );
+}
+
+/**
+ * The presentational section-tab strip: a horizontal `nav` of ghost tabs, one
+ * per entry, marked active by `activeId`. Purely presentational — it does not
+ * know where the tabs come from (app-shell pages, the settings registry, …) or
+ * how selection navigates; callers own that. Both the registry-driven
+ * {@link SectionNav} and the Settings section-nav render through THIS strip so
+ * the doctrine geometry + ghost-tab styling stay identical everywhere.
+ *
+ * Renders `null` for a section with fewer than two entries (one tab is not a
+ * nav; the header alone suffices).
+ */
+export function SectionTabStrip({
+  entries,
+  activeId,
+  onSelect,
+  testId,
+  ariaLabel,
+  className,
+}: {
+  entries: readonly { id: string; label: React.ReactNode }[];
+  activeId: string;
+  onSelect: (id: string) => void;
+  /** `data-testid` for the nav landmark (e.g. `section-nav-wallet`). */
+  testId?: string;
+  /** Accessible name for the nav landmark. */
+  ariaLabel: string;
+  className?: string;
+}): React.JSX.Element | null {
+  // A single-entry section is just its header; no secondary nav to render.
+  if (entries.length < 2) return null;
+  return (
+    <nav
+      aria-label={ariaLabel}
+      data-testid={testId}
+      className={cn(
+        "flex min-w-0 shrink-0 items-center gap-1 overflow-x-auto px-3 py-2",
+        className,
+      )}
+    >
+      {entries.map((entry) => (
+        <SectionNavTab
+          key={entry.id}
+          label={entry.label}
+          isActive={entry.id === activeId}
+          onSelect={() => onSelect(entry.id)}
+        />
+      ))}
+    </nav>
+  );
+}
+
+/**
  * The secondary section-nav strip. Renders one ghost tab per registered page in
  * `group`, sorted and marked active from `activePath`. Renders `null` when the
  * section has fewer than two members (a single tab is not a nav).
@@ -160,37 +245,18 @@ export function SectionNav({
     getAppShellPageRegistrySnapshot,
   );
   const tabs = sectionTabs(group, rewrite);
-  // A single-member section is just its header; no secondary nav to render.
-  if (tabs.length < 2) return null;
   const active = activeTabId(activePath, tabs);
   return (
-    <nav
-      aria-label={ariaLabel ?? `${group} sections`}
-      data-testid={`section-nav-${group}`}
-      className={cn("flex shrink-0 items-center gap-1 px-3 py-2", className)}
-    >
-      {tabs.map((tab) => {
-        const isActive = tab.id === active;
-        return (
-          <Button
-            key={tab.id}
-            aria-current={isActive ? "page" : undefined}
-            onClick={() => {
-              if (!isActive) navigate(tab.path);
-            }}
-            variant="ghost"
-            size="sm"
-            className={cn(
-              "h-auto rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
-              isActive
-                ? "bg-accent/15 text-accent"
-                : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
-            )}
-          >
-            {tab.label}
-          </Button>
-        );
-      })}
-    </nav>
+    <SectionTabStrip
+      entries={tabs}
+      activeId={active}
+      onSelect={(id) => {
+        const tab = tabs.find((candidate) => candidate.id === id);
+        if (tab) navigate(tab.path);
+      }}
+      testId={`section-nav-${group}`}
+      ariaLabel={ariaLabel ?? `${group} sections`}
+      className={className}
+    />
   );
 }

--- a/packages/ui/src/components/shared/ViewHeader.tsx
+++ b/packages/ui/src/components/shared/ViewHeader.tsx
@@ -40,7 +40,9 @@ export function navigateBackToLauncher(): void {
  * affordance is icon-only, with no border/background/circle at rest). Fixing
  * the primitive fixes every consumer at once. A subtle neutral `bg-hover` chip
  * (square-cornered `rounded-md`, NOT the old `rounded-full` disc) only appears
- * on hover/focus for affordance, never in the resting state.
+ * on hover for affordance, never in the resting state. Focus styling is NOT
+ * sprinkled here: it is centralized in CSS (`--focus`) per the no-focus-ring
+ * gate, so this primitive carries no `focus`/`ring` utilities.
  */
 export function ViewBackButton({
   onBack,
@@ -68,7 +70,7 @@ export function ViewBackButton({
       onClick={handleBack}
       aria-label={label}
       className={cn(
-        "inline-flex h-9 w-9 items-center justify-center rounded-md bg-transparent text-txt transition-colors hover:bg-bg-hover focus-visible:bg-bg-hover",
+        "inline-flex h-9 w-9 items-center justify-center rounded-md bg-transparent text-txt transition-colors hover:bg-bg-hover",
         className,
       )}
       {...agentProps}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -277,8 +277,10 @@ export { AppPageSidebar } from "./components/shared/AppPageSidebar";
 export {
   isSectionPath,
   SectionNav,
+  SectionNavTab,
   type SectionPathRewrite,
   type SectionTab,
+  SectionTabStrip,
   sectionTabs,
 } from "./components/shared/SectionNav";
 export {


### PR DESCRIPTION
Closes #13590 (parent epic #13560).

## What

Folds the Settings desktop `w-60` LEFT RAIL and the divergent mobile hub into ONE uniform layout for every form factor, per the #13451/#13586 doctrine:

- **Uniform top bar everywhere**: shared `ViewHeader` — icon-only back, centered title. Hub → title "Settings", back → launcher (`navigateBackToLauncher`). Section open → title = section label, back → hub. The rail `<h1>` and the bespoke `SectionBackButton` path are gone.
- **Top-bar section nav**: new `SettingsSectionNav`, a horizontal scrollable strip grouped by Agent / System / Security / Cloud cluster labels. It renders through the SHARED `SectionNavTab` ghost-tab primitive extracted from `SectionNav` (the #13586/#13673 group mechanism), so the settings tabs and the app-shell family tabs share identical pixels.
- **`isTwoPane` branch collapsed**: `DesktopLayout`, `MobileHub`, `SettingsNavItem`, and the `useMediaQuery` orientation logic are deleted. One nav + one detail region, all form factors.
- **Surface policy (#13452)**: the per-section `theme-cloud bg-black` islands are removed — one opaque token surface for the whole view.
- **Agent surface preserved**: hidden per-section anchors keep every section addressable via `section-<id>` from chat regardless of what's shown; `ShellViewAgentSurface` bridge unchanged.
- **Registry untouched**: `groupSettingsSections` (formerly view-local `groupSections`) moved into `settings-sections.ts` as a shared typed helper; hash routing, aliases, visibility gating (`developerOnly`/`hideOnCloud`/`walletEnabled`), and lazy bodies (#11351) unchanged.

## Shared-file tweak (flagged per lane rules)

`SectionNav.tsx`: extracted the presentational `SectionTabStrip` + `SectionNavTab` from the registry-driven `SectionNav` so Settings (hash-routed, not an app-shell page family) can reuse the exact doctrine tab styling without a parallel renderer. `SectionNav`'s behavior is unchanged (its own test suite still passes 9/9). `ViewHeader.tsx`: dropped a `focus-visible:` utility from `ViewBackButton` per the build-failing no-focus-ring gate.

## Dependency

Branch includes `origin/feat/13586-uniform-topbar` (PR #13673, the ViewHeader/ViewBackButton + group mechanism). Until #13673 merges, its commits appear in this diff; after it merges into develop this PR reduces to the settings-only changes.

## Tests

- `SettingsView.test.tsx` (10/10): uniform header + folded nav, exactly ONE header, no `nav.w-60` rail, tab → section → back-to-hub, initialSection, per-section error boundary isolation + retry, and form-factor independence (mocked matchMedia wide vs narrow renders identically).
- `SettingsSectionNav.test.tsx` (5/5, new): grouped tabs in order, aria-current marking, select/no-reselect, lone-tab-in-group rendering.
- `SectionNav.test.tsx` 9/9, `ViewHeader.test.tsx` 9/9, `view-header-audit.test.ts` 7/7 (no regressions in the shared primitives).
- Settings registry suites green: `settings-section-registry` 3/3, `settings-sections.registration` 8/8, `settings-section-tokens` 10/10, `settings-layout` 6/6.
- Anti-slop gates green: no-focus-ring, no-backdrop-blur, no-widget-chrome, will-change.
- `tsgo --noEmit` clean; biome clean on all touched files.

## Out of scope

Character files (#13591), non-settings chip targets (#13588), typed view-scoped actions + proactive-greeting scenario (tracked on the issue, separate slice).

— [sol-ui]
