### PR TITLE
fix(ui): align account-security panel tests with the pinned-unavailable design (develop UI lane is red)

### DIFF
--- a/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
@@ -1,9 +1,13 @@
 /**
- * Account-security panel tests for explicit backend-unavailable DTOs.
+ * Account-security panel tests for the pinned-unavailable design (#13666).
  *
- * The Security page used to infer "not available" from route 404s. These tests
- * pin the cleaner contract: the backend responds, and the panels render the
- * designed unavailable copy without turning malformed DTOs into empty success.
+ * The Worker does not currently expose MFA status or session enumeration, so
+ * both panels hold the explicit designed-unavailable state and must not fire
+ * dead requests on Security page load. These tests pin that contract: the
+ * unavailable copy renders, it never reads as a healthy success state, and no
+ * account-security API call leaves either panel. If the backend ships real
+ * /api/v1/me/mfa or /api/v1/sessions data flows, rewire the panels first and
+ * replace these pins with DTO-driven tests.
  */
 
 // @vitest-environment jsdom
@@ -58,54 +62,27 @@ describe("account-security panels", () => {
     apiFetchMock.mockReset();
   });
 
-  it("renders MFA unavailable from the explicit DTO", async () => {
-    apiMock.mockResolvedValue({
-      available: false,
-      reason: "mfa_enrollment_unavailable",
-      enrolled: false,
-      method: null,
-    });
-
+  it("renders the designed MFA-unavailable state without firing a dead request", async () => {
     render(<MfaPanel />);
 
     expect(
       await screen.findByText(/MFA enrollment is not yet available/i),
     ).toBeTruthy();
-    expect(apiMock).toHaveBeenCalledWith("/api/v1/me/mfa");
+    // Unavailable must never read as MFA-disabled success.
+    expect(screen.queryByText(/MFA is not enabled/i)).toBeNull();
+    expect(apiMock).not.toHaveBeenCalled();
+    expect(apiFetchMock).not.toHaveBeenCalled();
   });
 
-  it("renders sessions unavailable from the explicit DTO", async () => {
-    apiMock.mockResolvedValue({
-      available: false,
-      reason: "session_inventory_unavailable",
-      sessions: [],
-    });
-
+  it("renders the designed sessions-unavailable state without firing a dead request", async () => {
     render(<ActiveSessionsPanel />);
 
     expect(
       await screen.findByText(/Session listing isn't available yet/i),
     ).toBeTruthy();
-    expect(apiMock).toHaveBeenCalledWith("/api/v1/sessions");
-  });
-
-  it("does not turn a malformed sessions DTO into a healthy empty state", async () => {
-    apiMock.mockResolvedValue({});
-
-    render(<ActiveSessionsPanel />);
-
-    expect(await screen.findByText("Malformed sessions response")).toBeTruthy();
+    // Unavailable must never read as a healthy empty session list.
     expect(screen.queryByText(/No other active sessions found/i)).toBeNull();
-  });
-
-  it("does not turn a malformed MFA DTO into disabled-MFA success", async () => {
-    apiMock.mockResolvedValue({});
-
-    render(<MfaPanel />);
-
-    expect(
-      await screen.findByText("Malformed MFA status response"),
-    ).toBeTruthy();
-    expect(screen.queryByText(/MFA is not enabled/i)).toBeNull();
+    expect(apiMock).not.toHaveBeenCalled();
+    expect(apiFetchMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem

**develop's UI test lane is red right now** — 4/4 failures in `account-security-panels.test.tsx`. #13666 merged the mfa/sessions panels hardcoded to the designed-unavailable state (no fetch), while the surviving #13649 tests still assert `apiMock).toHaveBeenCalledWith("/api/v1/me/mfa")` / `"/api/v1/sessions"` and the malformed-DTO branches — all four are unreachable in the merged design. Every open PR running `test:client` now fails on develop-caused breakage.

## Fix

Re-pin the suite to the merged contract (this follows the direction shaw chose by merging #13666 — it does not relitigate it): the designed-unavailable copy renders, it never reads as healthy success (`MFA is not enabled` / `No other active sessions found` both asserted absent), and **no account-security API call leaves either panel** (`api` + `apiFetch` both asserted uncalled — pinning #13666's actual goal, no dead requests on Security page load). Header comment documents when to replace these pins (backend ships real routes → rewire panels first).

## Evidence (red/green)

- **RED** — unmodified develop tip (66d66d6f36): `bunx vitest run src/cloud/account-security/components/account-security-panels.test.tsx` → **Test Files 1 failed, Tests 4 failed**
- **GREEN** — with this change: **1 passed, 2 passed** (3.7s); `biome check` clean

## Notes

- Known residual from #13666 (flagged in my review there, unreachable while the panel is pinned `missing`): `revoke()` emits an `auth.session.revoke, result: allow` audit event + success toast without calling any endpoint — should be wired to a real DELETE or removed when the panels get data flows.
- I'm `[maintainer]` and this is my own commit → **no self-merge**; someone from the lalalune/0xSolace lanes please review + arm. It unblocks every UI-lane CI run, so sooner is better.

Fixes the develop UI lane; follow-up to #13666 / #13649. (#13406)