### PR TITLE
fix(#13725): require auth before remote runtime forwarding

### DIFF
--- a/.github/issue-evidence/13725-runtime-mode-gate-bare-agent.md
+++ b/.github/issue-evidence/13725-runtime-mode-gate-bare-agent.md
@@ -40,31 +40,37 @@ target hits: []
 [eliza-api] Listening on http://127.0.0.1:4834
 --- mode=remote (deploymentTarget.runtime=remote) ---
 GET /api/local-inference/hub -> 404 {"error":"Not found"}
-POST /api/cloud/login -> 200 {"forwardedToTarget":true}
+POST /api/cloud/login (no auth) -> 401 {"error":"Unauthorized"}
+target hits: []
+POST /api/cloud/login (Authorization: Bearer <api-token>) -> 200 {"forwardedToTarget":true}
 target hits: [{"method":"POST","url":"/api/cloud/login","auth":"Bearer dm1-verify-token"}]
 ```
 
 - Hidden route is a plain 404 (mode state not probeable).
-- The cloud mutation reached the target with the controller's
-  `remoteAccessToken` as the bearer, and the target's response body/status were
-  relayed to the caller.
+- The cloud mutation is forwarded only after the normal API auth gate accepts
+  the request. An unauthenticated caller cannot cause the controller to attach
+  its target token. Once authorized, the mutation reaches the target with the
+  controller's `remoteAccessToken` as the bearer, and the target's response
+  body/status are relayed to the caller.
 
 ## Regression test (fails on the bug)
 
 `packages/agent/test/api/runtime-mode-gate.real-server.test.ts` spawns the same
 bare server as a real `bun` child process and drives the phases above plus
 cloud-mode hiding, the no-target 400, read/OPTIONS passthrough, and
-default-local reachability.
+default-local reachability. The fixture sets `ELIZA_REQUIRE_LOCAL_AUTH=1` and a
+known `ELIZA_API_TOKEN`, so loopback alone is not trusted during the forwarding
+checks.
 
-- On the fixed tree: `Test Files 1 passed — Tests 6 passed`.
+- On the fixed tree: `Test Files 1 passed — Tests 7 passed`.
 - With the `handleRuntimeModePreDispatch` call in
-  `packages/agent/src/api/server.ts` disabled (= develop behavior): 4 of 6
-  fail — the remote-hide, remote-forward, no-target-reject, and cloud-hide
-  assertions.
+  `packages/agent/src/api/server.ts` disabled (= develop behavior), the
+  remote-hide, remote-forward, no-target-reject, and cloud-hide assertions fail.
 
 ## Suite runs (fixed tree)
 
-- `packages/agent`: runtime-mode unit + e2e — 5 files / 53 tests passed.
+- `packages/agent`: runtime-mode unit + e2e — 5 files / 54 tests passed,
+  including the post-auth forwarding regression.
 - `packages/app-core`: server pipeline tests (`server-reset-hop`,
   `route-auth-policy.dispatch`, `server-compat-route-chain.guard`,
   `first-run-persistence.restart`) — 4 files / 20 tests passed.

--- a/packages/agent/src/api/runtime-mode/pre-dispatch.ts
+++ b/packages/agent/src/api/runtime-mode/pre-dispatch.ts
@@ -1,19 +1,15 @@
 /**
- * Runtime-mode pre-dispatch hook: the single entry point every HTTP host runs
- * before its route handlers. Applies the mode-visibility gate (hidden routes
- * respond 404) and, in `remote` mode, forwards cloud-settings mutations to the
- * controlled target instead of executing them locally.
+ * Runtime-mode request hooks shared by every HTTP host. The visibility hook
+ * runs before auth so hidden-in-mode routes return a plain 404 without making
+ * mode state probeable. The remote forwarder hook runs only after the normal
+ * auth gate has accepted the request, because it attaches the controller's
+ * target token and must never turn an unauthenticated caller into the target's
+ * owner.
  *
  * Both the bare `@elizaos/agent` server (`api/server.ts` request dispatch) and
- * the `@elizaos/app-core` compat pipeline call this, so the mode contract holds
- * no matter which host binds the port — the gate used to live only in app-core,
- * leaving `bun run start` (the bare agent) ungated.
- *
- * Returns `true` when the request was fully handled (gated or forwarded) and
- * the caller must stop dispatching. Running it twice on one request is safe:
- * the second pass resolves the same mode, and the forwarder only consumes the
- * request body when it actually forwards (in which case it already returned
- * `true` on the first pass).
+ * the `@elizaos/app-core` compat pipeline call these, so the mode contract
+ * holds no matter which host binds the port — the gate used to live only in
+ * app-core, leaving `bun run start` (the bare agent) ungated.
  */
 
 import type http from "node:http";
@@ -29,9 +25,12 @@ export async function handleRuntimeModePreDispatch(
   runtime?: RouteModeRuntimeLike | null,
 ): Promise<boolean> {
   const gate = applyRouteModeGuard(req, res, runtime);
-  if (gate.handled) return true;
-  if (gate.mode === "remote") {
-    return forwardRemoteCloudMutation(req, res);
-  }
-  return false;
+  return gate.handled;
+}
+
+export async function handleRuntimeModeRemoteForward(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<boolean> {
+  return forwardRemoteCloudMutation(req, res);
 }

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -399,7 +399,10 @@ import {
   buildPluginDiagnosticEntry,
   resolveWalletDiagnosticStatus,
 } from "./plugin-diagnostic.ts";
-import { handleRuntimeModePreDispatch } from "./runtime-mode/pre-dispatch.ts";
+import {
+  handleRuntimeModePreDispatch,
+  handleRuntimeModeRemoteForward,
+} from "./runtime-mode/pre-dispatch.ts";
 import { createRuntimeReadyGate } from "./runtime-ready-gate.ts";
 import { handleRuntimeSwitchRoutes } from "./runtime-switch-routes.ts";
 import {
@@ -1875,13 +1878,12 @@ async function handleRequest(
     if (serveMediaFile(req, res, pathname)) return;
   }
 
-  // ── Runtime-mode gate + remote-mode forwarder ───────────────────────────
+  // ── Runtime-mode visibility gate ────────────────────────────────────────
   // Enforced here, in the server every host shares, so the bare agent
   // (`bun run start`) honors the same mode contract as the app-core wrapper:
-  // routes outside the active runtime mode return 404 before auth runs (hidden,
-  // not probeable), and in remote mode cloud mutations forward to the
-  // controlled target instead of executing on the controller. OPTIONS is
-  // exempt so CORS preflight keeps its unconditional 204 below.
+  // routes outside the active runtime mode return 404 before auth runs
+  // (hidden, not probeable). OPTIONS is exempt so CORS preflight keeps its
+  // unconditional 204 below.
   if (
     method !== "OPTIONS" &&
     (await handleRuntimeModePreDispatch(req, res, state.runtime))
@@ -1904,6 +1906,17 @@ async function handleRequest(
     !isBoundaryRoleAuthorized(req, method, pathname)
   ) {
     json(res, { error: "Unauthorized" }, 401);
+    return;
+  }
+
+  // Remote-mode cloud mutations are forwarded only after the request passes
+  // the normal API auth gate; the forwarder attaches the controller's target
+  // token, so pre-auth forwarding would let an unauthenticated caller mutate
+  // the controlled target.
+  if (
+    method !== "OPTIONS" &&
+    (await handleRuntimeModeRemoteForward(req, res))
+  ) {
     return;
   }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -114,7 +114,10 @@ export { RegistryService } from "./api/registry-service.ts";
 // forwarder). `api/server.ts` enforces it in its own dispatch; the app-core
 // compat pipeline calls the same pre-dispatch hook so every host shares one
 // gate.
-export { handleRuntimeModePreDispatch } from "./api/runtime-mode/pre-dispatch.ts";
+export {
+  handleRuntimeModePreDispatch,
+  handleRuntimeModeRemoteForward,
+} from "./api/runtime-mode/pre-dispatch.ts";
 export {
   forwardRemoteCloudMutation,
   shouldForwardToRemoteTarget,

--- a/packages/agent/test/api/runtime-mode-gate.real-server.test.ts
+++ b/packages/agent/test/api/runtime-mode-gate.real-server.test.ts
@@ -47,6 +47,7 @@ let apiBase = "";
 let target: http.Server | null = null;
 let targetBase = "";
 const targetHits: TargetHit[] = [];
+const API_TOKEN = "gate-api-token";
 
 function writeConfig(config: Record<string, unknown>): void {
   fs.writeFileSync(
@@ -68,10 +69,14 @@ function remoteConfig(): Record<string, unknown> {
 async function request(
   method: string,
   pathname: string,
+  options: { authorized?: boolean } = {},
 ): Promise<{ status: number; body: string }> {
   const res = await fetch(apiBase + pathname, {
     method,
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      ...(options.authorized ? { authorization: `Bearer ${API_TOKEN}` } : {}),
+    },
     body: method === "GET" || method === "OPTIONS" ? undefined : "{}",
   });
   return { status: res.status, body: await res.text() };
@@ -101,6 +106,8 @@ beforeAll(async () => {
         ELIZA_STATE_DIR: stateDir,
         ELIZA_CONFIG_PATH: "",
         ELIZA_API_PORT: "",
+        ELIZA_REQUIRE_LOCAL_AUTH: "1",
+        ELIZA_API_TOKEN: API_TOKEN,
         LOG_LEVEL: "error",
         NODE_ENV: "test",
       },
@@ -141,10 +148,20 @@ describe("bare agent server enforces the runtime-mode contract", () => {
     expect(res.body).not.toContain("catalog");
   });
 
-  it("remote mode forwards POST /api/cloud/login to the target with its access token", async () => {
+  it("remote mode rejects unauthenticated cloud mutations before forwarding", async () => {
     writeConfig(remoteConfig());
     targetHits.length = 0;
     const res = await request("POST", "/api/cloud/login");
+    expect(res.status).toBe(401);
+    expect(targetHits).toHaveLength(0);
+  });
+
+  it("remote mode forwards authorized POST /api/cloud/login to the target with its access token", async () => {
+    writeConfig(remoteConfig());
+    targetHits.length = 0;
+    const res = await request("POST", "/api/cloud/login", {
+      authorized: true,
+    });
     expect(res.status).toBe(200);
     expect(JSON.parse(res.body)).toEqual({ forwardedToTarget: true });
     expect(targetHits).toHaveLength(1);
@@ -167,7 +184,9 @@ describe("bare agent server enforces the runtime-mode contract", () => {
 
   it("remote mode without a valid target rejects cloud mutations instead of running them locally", async () => {
     writeConfig({ deploymentTarget: { runtime: "remote" } });
-    const res = await request("POST", "/api/cloud/login");
+    const res = await request("POST", "/api/cloud/login", {
+      authorized: true,
+    });
     expect(res.status).toBe(400);
     expect(JSON.parse(res.body)).toEqual({
       error: "Remote target not configured",

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -29,6 +29,7 @@ import {
   handleCloudBillingRoute,
   handleCloudCompatRoute,
   handleRuntimeModePreDispatch,
+  handleRuntimeModeRemoteForward,
   isAllowedHost,
   isAuthorized,
   loadElizaConfig,
@@ -677,14 +678,12 @@ async function handleCompatRouteInner(
   const method = (req.method ?? "GET").toUpperCase();
   const url = new URL(req.url ?? "/", "http://localhost");
 
-  // ── Mode visibility gate + remote-mode forward ────────────────────────
+  // ── Mode visibility gate ───────────────────────────────────────────────
   // Shared hook from @elizaos/agent (also enforced in the bare agent
   // server's own dispatch): cloud mode hides /api/local-inference/*,
   // local-only hides /api/cloud/* (hidden = 404, not 403, so callers cannot
-  // probe mode state), and remote mode forwards cloud mutations to the
-  // controlled target instead of the controller's own config. It must also
-  // run here because the compat chain below handles those routes before the
-  // request ever reaches the upstream agent listener.
+  // probe mode state). It must run here because the compat chain below handles
+  // some routes before the request ever reaches the upstream agent listener.
   if (await handleRuntimeModePreDispatch(req, res, state.current)) return true;
 
   const authPolicyDecision = await enforceCompatRouteAuthPolicy(
@@ -696,6 +695,11 @@ async function handleCompatRouteInner(
   );
   if (authPolicyDecision === "denied") return true;
   if (authPolicyDecision === "unmanaged") return false;
+
+  // Remote-mode cloud mutations forward only after compat auth allows the
+  // request; the forwarder attaches the controller's target token, so it must
+  // not run as a pre-auth bypass.
+  if (await handleRuntimeModeRemoteForward(req, res)) return true;
 
   // #12089 item 5: the compat route surface below used to be a ~30-branch
   // order-dependent if-chain (each branch `if (await handleX(...)) return true`)


### PR DESCRIPTION
## Summary
- Splits runtime-mode handling into a pre-auth visibility gate and a post-auth remote forwarder.
- Keeps hidden-in-mode routes as pre-auth 404s, but prevents remote cloud mutations from forwarding until the normal API auth boundary has accepted the request.
- Applies the same ordering to the bare `@elizaos/agent` server and the app-core compat pipeline.
- Extends the real-server e2e to run with `ELIZA_REQUIRE_LOCAL_AUTH=1` and prove unauthenticated `POST /api/cloud/login` returns 401 and does not hit the remote target, while authorized requests still forward with the controller remote token.

## Why
#13746 merged the runtime-mode gate into the shared agent server, but it also extended app-core's existing pre-auth forwarding behavior into the bare server. Because the forwarder attaches the controller's target token, forwarding must be post-auth; otherwise an unauthenticated caller can cause target mutations with controller credentials.

## Verification
```bash
/home/shaw/milady/eliza/node_modules/.bin/biome check packages/agent/src/api/runtime-mode/pre-dispatch.ts packages/agent/src/api/server.ts packages/agent/src/index.ts packages/agent/test/api/runtime-mode-gate.real-server.test.ts packages/app-core/src/api/server.ts
# pass

git diff --check
# pass

bun run --cwd packages/shared build:i18n
bun test ./packages/agent/src/api/runtime-mode/remote-forwarder.test.ts ./packages/agent/src/api/runtime-mode/route-mode-guard.test.ts ./packages/agent/src/api/runtime-mode/route-mode-matrix.test.ts ./packages/agent/src/api/runtime-mode/runtime-mode.test.ts ./packages/agent/test/api/runtime-mode-gate.real-server.test.ts
# 54 pass, 0 fail
```

## Evidence / N/A
- Updated `.github/issue-evidence/13725-runtime-mode-gate-bare-agent.md` with the auth-boundary proof.
- Screenshots/video: N/A - headless HTTP auth/routing contract.
- Live LLM trajectories: N/A - no agent/model/prompt behavior changed.
- Domain artifacts: real loopback target hit log is asserted in the e2e and summarized in the evidence artifact.

[shaw-codex]
