### PR TITLE
fix(android): externalize/stub the AOSP-only local-inference plugin in mobile bundlers

### DIFF
--- a/packages/agent/scripts/build-mobile-bundle.mjs
+++ b/packages/agent/scripts/build-mobile-bundle.mjs
@@ -476,6 +476,15 @@ const optionalPluginStubs = {
   "@elizaos/plugin-agent-orchestrator": path.join(stubsDir, "null-plugin.cjs"),
   "@elizaos/plugin-shell": path.join(stubsDir, "null-plugin.cjs"),
   "@elizaos/plugin-coding-tools": path.join(stubsDir, "null-plugin.cjs"),
+  // AOSP-only companion, reached via a lazy `import(...)` gated on
+  // ELIZA_LOCAL_LLAMA (getAospLocalInferenceApi in local-inference-routes +
+  // agent cli). It is not a declared dependency (present only on AOSP
+  // images), so the stock mobile bundle must stub it or Bun.build fails to
+  // resolve it. The gate never fires on stock, so the stub is never invoked.
+  "@elizaos/plugin-aosp-local-inference": path.join(
+    stubsDir,
+    "null-plugin.cjs",
+  ),
   // NOTE: @elizaos/plugin-commands is intentionally NOT stubbed. Its only
   // dependency is `@elizaos/core` (workspace:*), so it does not drag an
   // incompatible core into the bundle, and `api/commands-routes.ts` imports the

--- a/plugins/plugin-local-inference/build.ts
+++ b/plugins/plugin-local-inference/build.ts
@@ -32,6 +32,12 @@ const external = await externalsFromPackageJson("./package.json", {
 	// binding; bun:* covers the desktop bun:ffi loader.
 	extra: [
 		"@elizaos/agent",
+		// AOSP-only companion plugin, reached via a lazy `import(...)` gated on
+		// ELIZA_LOCAL_LLAMA (getAospLocalInferenceApi in local-inference-routes).
+		// It is not a declared dependency (present only on AOSP images), so the
+		// mobile bundler must treat it as external or the build fails to resolve
+		// it on every stock target.
+		"@elizaos/plugin-aosp-local-inference",
 		"llama-cpp-capacitor",
 		"@reflink/reflink",
 		"ws",


### PR DESCRIPTION
## What

`build:android` fails at bundle time on any clean checkout with:

```
error: Could not resolve: "@elizaos/plugin-aosp-local-inference". Maybe you need to "bun install"?
  at packages/agent/src/cli/index.ts
  at plugins/plugin-local-inference/src/local-inference-routes.ts
```

`plugin-local-inference` reaches `@elizaos/plugin-aosp-local-inference` through a lazy `import(...)` gated on `ELIZA_LOCAL_LLAMA` (`getAospLocalInferenceApi`). That package ships only on AOSP images and is **not a declared dependency**, so on a clean install the mobile bundlers cannot resolve it and the whole Android build fails — even though the gate never fires on a stock build.

## Fix

Handle it exactly like the sibling lazy / AOSP-only imports already are:
- `plugins/plugin-local-inference/build.ts`: add it to the `extra` externals list (next to `@elizaos/agent`).
- `packages/agent/scripts/build-mobile-bundle.mjs`: stub it to `null-plugin.cjs` like the other `aospOnly` plugins (`plugin-shell`, `plugin-coding-tools`). The `ELIZA_LOCAL_LLAMA` gate never fires on stock, so the stub is never invoked.

## Evidence

Found while building a device APK to verify #13748 on a Moto G Play. With both changes, `bun run --cwd packages/app build:android` bundles cleanly (SIGSYS shim staged, sideload artifact audit passes, 408 MB debug APK) where it previously failed at the bundle step on a fresh worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)