### PR TITLE
fix(ui): collapse unavailable account security panels

### DIFF
--- a/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
@@ -1,17 +1,17 @@
 /**
- * Account-security panel tests for the pinned-unavailable design (#13666).
+ * Account-security panel tests for unavailable launch surfaces.
  *
- * The Worker does not currently expose MFA status or session enumeration, so
- * both panels hold the explicit designed-unavailable state and must not fire
- * dead requests on Security page load. These tests pin that contract: the
- * unavailable copy renders, it never reads as a healthy success state, and no
- * account-security API call leaves either panel. If the backend ships real
- * /api/v1/me/mfa or /api/v1/sessions data flows, rewire the panels first and
- * replace these pins with DTO-driven tests.
+ * The cloud Worker does not expose account-security read/write routes for these
+ * panels yet, so the UI must render explicit unavailable states without firing
+ * dead account calls, fabricating successful requests, or reading unavailable
+ * data as a healthy empty state.
  */
 
 // @vitest-environment jsdom
 
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { render, screen } from "@testing-library/react";
 import type { ButtonHTMLAttributes, PropsWithChildren } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -40,10 +40,34 @@ vi.mock("../../../cloud-ui", () => ({
   ),
   BrandCard: ({ children }: PropsWithChildren) => <section>{children}</section>,
   CornerBrackets: () => null,
+  Switch: ({
+    checked,
+    onCheckedChange: _onCheckedChange,
+    ...props
+  }: PropsWithChildren<{
+    checked?: boolean;
+    onCheckedChange?: unknown;
+    "data-testid"?: string;
+  }>) => <input type="checkbox" checked={checked} readOnly {...props} />,
+}));
+
+vi.mock("lucide-react", () => ({
+  Camera: () => <span data-testid="icon-camera" />,
+  Download: () => <span data-testid="icon-download" />,
+  Lock: () => <span data-testid="icon-lock" />,
+  ScrollText: () => <span data-testid="icon-scroll-text" />,
+  Trash2: () => <span data-testid="icon-trash" />,
 }));
 
 vi.mock("../data/audit-client", () => ({
   emitAuditEvent: vi.fn(),
+}));
+
+vi.mock("../data/consent-store", () => ({
+  getTrajectoryLoggingEnabled: vi.fn(() => false),
+  getVisionEnabled: vi.fn(() => false),
+  setTrajectoryLoggingEnabled: vi.fn(),
+  setVisionEnabled: vi.fn(),
 }));
 
 vi.mock("sonner", () => ({
@@ -55,6 +79,10 @@ vi.mock("sonner", () => ({
 
 import { ActiveSessionsPanel } from "./active-sessions-panel";
 import { MfaPanel } from "./mfa-panel";
+import { RecentAuditEvents } from "./recent-audit-events";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PRIVACY_PANEL_SOURCE = path.join(HERE, "privacy-panel.tsx");
 
 describe("account-security panels", () => {
   beforeEach(() => {
@@ -62,27 +90,39 @@ describe("account-security panels", () => {
     apiFetchMock.mockReset();
   });
 
-  it("renders the designed MFA-unavailable state without firing a dead request", async () => {
+  it("renders MFA unavailable without calling the missing status endpoint", () => {
     render(<MfaPanel />);
 
-    expect(
-      await screen.findByText(/MFA enrollment is not yet available/i),
-    ).toBeTruthy();
-    // Unavailable must never read as MFA-disabled success.
+    expect(screen.getByText(/MFA enrollment is unavailable/i)).toBeTruthy();
     expect(screen.queryByText(/MFA is not enabled/i)).toBeNull();
     expect(apiMock).not.toHaveBeenCalled();
     expect(apiFetchMock).not.toHaveBeenCalled();
   });
 
-  it("renders the designed sessions-unavailable state without firing a dead request", async () => {
+  it("renders sessions unavailable without calling session inventory", () => {
     render(<ActiveSessionsPanel />);
 
-    expect(
-      await screen.findByText(/Session listing isn't available yet/i),
-    ).toBeTruthy();
-    // Unavailable must never read as a healthy empty session list.
+    expect(screen.getByText(/Session listing is unavailable/i)).toBeTruthy();
     expect(screen.queryByText(/No other active sessions found/i)).toBeNull();
     expect(apiMock).not.toHaveBeenCalled();
     expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("renders audit events unavailable without calling the missing read route", () => {
+    render(<RecentAuditEvents />);
+
+    expect(screen.getByText(/Audit log reading is unavailable/i)).toBeTruthy();
+    expect(apiMock).not.toHaveBeenCalled();
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps DSR controls disabled without wiring missing export/delete endpoints", () => {
+    const source = readFileSync(PRIVACY_PANEL_SOURCE, "utf8");
+
+    expect(source).toContain("Export unavailable");
+    expect(source).toContain("Deletion unavailable");
+    expect(source).toContain('data-testid="delete-account-trigger"');
+    expect(source).not.toContain("/api/v1/me/export");
+    expect(source).not.toContain("/api/v1/me/delete-request");
   });
 });

--- a/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
@@ -4,55 +4,11 @@
  * instead of issuing dead account-session calls on every Security page load.
  */
 
-import { useState } from "react";
-import { toast } from "sonner";
-import { BrandButton, BrandCard, CornerBrackets } from "../../../cloud-ui";
+import { BrandCard, CornerBrackets } from "../../../cloud-ui";
 import { useCloudT } from "../../shell/CloudI18nProvider";
-import { emitAuditEvent } from "../data/audit-client";
-
-interface SessionRow {
-  id: string;
-  device?: string | null;
-  ip?: string | null;
-  user_agent?: string | null;
-  last_seen?: string | null;
-  current?: boolean;
-}
-
-type SessionsState =
-  | { kind: "loading" }
-  | { kind: "missing" }
-  | { kind: "ready"; sessions: SessionRow[] }
-  | { kind: "error"; message: string };
 
 export function ActiveSessionsPanel() {
   const t = useCloudT();
-  const [state] = useState<SessionsState>({ kind: "missing" });
-  const [revoking, setRevoking] = useState<string | null>(null);
-
-  const revoke = async (id: string) => {
-    setRevoking(id);
-    try {
-      await emitAuditEvent({
-        action: "auth.session.revoke",
-        result: "allow",
-        resource: { type: "session", id },
-      });
-      toast.success(
-        t("cloud.activeSessions.revoked", { defaultValue: "Session revoked" }),
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      toast.error(
-        t("cloud.activeSessions.revokeFailed", {
-          message,
-          defaultValue: "Failed to revoke session: {{message}}",
-        }),
-      );
-    } finally {
-      setRevoking(null);
-    }
-  };
 
   return (
     <BrandCard className="relative">
@@ -71,76 +27,11 @@ export function ActiveSessionsPanel() {
             })}
           </p>
         </div>
-        {state.kind === "loading" ? (
-          <p className="text-sm text-white/50">
-            {t("cloud.activeSessions.loading", {
-              defaultValue: "Loading sessions…",
-            })}
-          </p>
-        ) : state.kind === "missing" ? (
-          <p className="text-sm text-white/50">
-            {t("cloud.activeSessions.notAvailable", {
-              defaultValue:
-                "Session listing isn't available yet on this server.",
-            })}
-          </p>
-        ) : state.kind === "error" ? (
-          <p className="text-sm text-red-300">{state.message}</p>
-        ) : state.sessions.length === 0 ? (
-          <p className="text-sm text-white/50">
-            {t("cloud.activeSessions.noOther", {
-              defaultValue: "No other active sessions found.",
-            })}
-          </p>
-        ) : (
-          <ul className="divide-y divide-white/10">
-            {state.sessions.map((s) => (
-              <li
-                key={s.id}
-                className="flex items-center justify-between gap-3 py-2 text-sm"
-              >
-                <div className="space-y-0.5">
-                  <p className="font-medium text-white">
-                    {s.device ??
-                      t("cloud.activeSessions.unknownDevice", {
-                        defaultValue: "Unknown device",
-                      })}
-                    {s.current ? (
-                      <span className="ml-2 rounded-sm border border-green-500/40 bg-green-500/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-green-300">
-                        {t("cloud.activeSessions.current", {
-                          defaultValue: "current",
-                        })}
-                      </span>
-                    ) : null}
-                  </p>
-                  <p className="font-mono text-[11px] text-white/50">
-                    {t("cloud.activeSessions.ipLastSeen", {
-                      ip: s.ip ?? "—",
-                      lastSeen: s.last_seen
-                        ? new Date(s.last_seen).toLocaleString()
-                        : "—",
-                      defaultValue: "{{ip}} · last seen {{lastSeen}}",
-                    })}
-                  </p>
-                </div>
-                <BrandButton
-                  size="sm"
-                  variant="outline"
-                  disabled={revoking === s.id || s.current}
-                  onClick={() => void revoke(s.id)}
-                >
-                  {revoking === s.id
-                    ? t("cloud.activeSessions.revoking", {
-                        defaultValue: "Revoking…",
-                      })
-                    : t("cloud.activeSessions.revoke", {
-                        defaultValue: "Revoke",
-                      })}
-                </BrandButton>
-              </li>
-            ))}
-          </ul>
-        )}
+        <p className="text-sm text-white/50">
+          {t("cloud.activeSessions.notAvailable", {
+            defaultValue: "Session listing is unavailable on this server.",
+          })}
+        </p>
       </div>
     </BrandCard>
   );

--- a/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
@@ -2,26 +2,14 @@
  * Two-factor authentication status panel. The Worker does not currently expose
  * an MFA status route, so keep the panel in the explicit unavailable state
  * instead of firing a dead request on Security page load.
- *
- * NOTE: the "Enroll a second factor" button is not wired — there is no MFA
- * enrollment endpoint yet (only the read route). The CTA renders so the surface
- * is complete; wire it once the backend ships an enroll flow (TOTP / WebAuthn).
  */
 
 import { Lock } from "lucide-react";
-import { useState } from "react";
-import { BrandButton, BrandCard, CornerBrackets } from "../../../cloud-ui";
+import { BrandCard, CornerBrackets } from "../../../cloud-ui";
 import { useCloudT } from "../../shell/CloudI18nProvider";
-
-type MfaState =
-  | { kind: "loading" }
-  | { kind: "missing" }
-  | { kind: "ready"; enrolled: boolean; method?: string | null }
-  | { kind: "error"; message: string };
 
 export function MfaPanel() {
   const t = useCloudT();
-  const [state] = useState<MfaState>({ kind: "missing" });
 
   return (
     <BrandCard className="relative">
@@ -35,47 +23,11 @@ export function MfaPanel() {
             })}
           </h3>
         </div>
-        {state.kind === "loading" ? (
-          <p className="text-sm text-white/50">
-            {t("cloud.mfaPanel.loading", {
-              defaultValue: "Loading MFA status…",
-            })}
-          </p>
-        ) : state.kind === "missing" ? (
-          <p className="text-sm text-white/60">
-            {t("cloud.mfaPanel.notAvailable", {
-              defaultValue:
-                "MFA enrollment is not yet available on this server. We'll surface this CTA once the backend ships.",
-            })}
-          </p>
-        ) : state.kind === "error" ? (
-          <p className="text-sm text-red-300">{state.message}</p>
-        ) : state.enrolled ? (
-          <p className="text-sm text-green-300">
-            {t("cloud.mfaPanel.enabled", {
-              method:
-                state.method ??
-                t("cloud.mfaPanel.unknownMethod", {
-                  defaultValue: "unknown",
-                }),
-              defaultValue: "Enabled · method: {{method}}",
-            })}
-          </p>
-        ) : (
-          <div className="space-y-2">
-            <p className="text-sm text-white/60">
-              {t("cloud.mfaPanel.notEnabled", {
-                defaultValue:
-                  "MFA is not enabled. Adding a second factor protects your account even if your password is compromised.",
-              })}
-            </p>
-            <BrandButton size="sm" variant="outline" disabled>
-              {t("cloud.mfaPanel.enroll", {
-                defaultValue: "Enroll a second factor",
-              })}
-            </BrandButton>
-          </div>
-        )}
+        <p className="text-sm text-white/60">
+          {t("cloud.mfaPanel.notAvailable", {
+            defaultValue: "MFA enrollment is unavailable on this server.",
+          })}
+        </p>
       </div>
     </BrandCard>
   );

--- a/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
@@ -3,9 +3,8 @@
  *   - vision / screen-capture consent toggle (local consent store)
  *   - trajectory logging toggle (local consent store)
  *
- * DSR export/deletion jobs are not exposed by the Worker yet. Keep those
- * controls visible but disabled so the launch surface does not issue dead
- * `/api/v1/me/*` calls or imply a request was scheduled.
+ * DSR export/deletion controls are disabled when the Worker does not expose
+ * those jobs, so the launch surface never implies that a request was scheduled.
  */
 
 import { Camera, Download, ScrollText, Trash2 } from "lucide-react";
@@ -65,7 +64,6 @@ export function PrivacyPanel() {
           </p>
         </div>
 
-        {/* Vision toggle */}
         <div className="flex items-start justify-between gap-3 rounded-sm border border-white/10 bg-black/40 p-4">
           <div className="flex items-start gap-3">
             <div className="rounded-sm border border-purple-500/40 bg-purple-500/20 p-2">
@@ -92,7 +90,6 @@ export function PrivacyPanel() {
           />
         </div>
 
-        {/* Trajectory logging toggle */}
         <div className="flex items-start justify-between gap-3 rounded-sm border border-white/10 bg-black/40 p-4">
           <div className="flex items-start gap-3">
             <div className="rounded-sm border border-[var(--brand-orange)]/40 bg-[var(--brand-orange)]/15 p-2">
@@ -119,7 +116,6 @@ export function PrivacyPanel() {
           />
         </div>
 
-        {/* DSR — Export */}
         <div className="flex items-start justify-between gap-3 rounded-sm border border-white/10 bg-black/40 p-4">
           <div className="flex items-start gap-3">
             <div className="rounded-sm border border-green-500/40 bg-green-500/20 p-2">
@@ -144,8 +140,7 @@ export function PrivacyPanel() {
             variant="outline"
             disabled
             title={t("cloud.privacyPanel.exportComingSoon", {
-              defaultValue:
-                "Data export is coming soon — not yet available on this server.",
+              defaultValue: "Data export is unavailable on this server.",
             })}
           >
             {t("cloud.privacyPanel.exportUnavailable", {
@@ -154,7 +149,6 @@ export function PrivacyPanel() {
           </BrandButton>
         </div>
 
-        {/* DSR — Delete */}
         <div className="flex items-start justify-between gap-3 rounded-sm border border-red-500/30 bg-red-500/5 p-4">
           <div className="flex items-start gap-3">
             <div className="rounded-sm border border-red-500/40 bg-red-500/20 p-2">
@@ -180,8 +174,7 @@ export function PrivacyPanel() {
             className="border-red-500/40 text-red-300"
             disabled
             title={t("cloud.privacyPanel.deletionComingSoon", {
-              defaultValue:
-                "Account deletion is coming soon — not yet available on this server.",
+              defaultValue: "Account deletion is unavailable on this server.",
             })}
             data-testid="delete-account-trigger"
           >

--- a/packages/ui/src/cloud/account-security/components/recent-audit-events.tsx
+++ b/packages/ui/src/cloud/account-security/components/recent-audit-events.tsx
@@ -4,20 +4,11 @@
  * unavailable state without issuing a dead account-audit request.
  */
 
-import { useState } from "react";
 import { BrandCard, CornerBrackets } from "../../../cloud-ui";
 import { useCloudT } from "../../shell/CloudI18nProvider";
-import { AuditEventList, type AuditEventRow } from "./AuditEventList";
-
-type AuditState =
-  | { kind: "loading" }
-  | { kind: "missing" }
-  | { kind: "ready"; events: AuditEventRow[] }
-  | { kind: "error"; message: string };
 
 export function RecentAuditEvents() {
   const t = useCloudT();
-  const [state] = useState<AuditState>({ kind: "missing" });
 
   return (
     <BrandCard className="relative">
@@ -36,21 +27,11 @@ export function RecentAuditEvents() {
             })}
           </p>
         </div>
-        {state.kind === "loading" ? (
-          <p className="text-sm text-white/50">
-            {t("cloud.recentAuditEvents.loading", { defaultValue: "Loading…" })}
-          </p>
-        ) : state.kind === "missing" ? (
-          <p className="text-sm text-white/50">
-            {t("cloud.recentAuditEvents.notExposed", {
-              defaultValue: "Audit log isn't exposed yet on this server.",
-            })}
-          </p>
-        ) : state.kind === "error" ? (
-          <p className="text-sm text-red-300">{state.message}</p>
-        ) : (
-          <AuditEventList events={state.events} />
-        )}
+        <p className="text-sm text-white/50">
+          {t("cloud.recentAuditEvents.notExposed", {
+            defaultValue: "Audit log reading is unavailable on this server.",
+          })}
+        </p>
       </div>
     </BrandCard>
   );


### PR DESCRIPTION
## Summary
- prune unreachable loading/ready/error branches from the account-security panels that are intentionally unavailable
- remove the unreachable fabricated session-revoke success path
- update the co-located panel tests to assert no dead account-security API calls fire
- tighten unavailable copy for MFA/audit/DSR controls

Follow-up to #13666 / #13662 after the merge left reviewer-identified dead branches and stale tests.

## Verification
- `bun run --cwd packages/ui test -- src/cloud/account-security/components/account-security-panels.test.tsx --coverage.enabled=false` — 4 tests passed
- `bunx @biomejs/biome check packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx packages/ui/src/cloud/account-security/components/mfa-panel.tsx packages/ui/src/cloud/account-security/components/recent-audit-events.tsx packages/ui/src/cloud/account-security/components/privacy-panel.tsx packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx --no-errors-on-unmatched` — clean
- `rg -n "not wired|wire it|coming soon|Malformed sessions response|Malformed MFA status response|/api/v1/sessions|/api/v1/me/mfa|/api/v1/me/audit-events|/api/v1/me/export|/api/v1/me/delete-request" packages/ui/src/cloud/account-security/components` — no matches
- `git diff --check origin/develop...HEAD && git diff --check` — clean

## Evidence still needed
- Desktop/mobile rendered screenshots or audit artifacts for the visible Security/Account unavailable states, per PR_EVIDENCE.md.