### PR TITLE
fix(#13713): reject non-string character name (500→400) — the field #13706 missed

### DIFF
--- a/packages/cloud/api/__tests__/my-agents-characters-search-bio-guard.test.ts
+++ b/packages/cloud/api/__tests__/my-agents-characters-search-bio-guard.test.ts
@@ -177,3 +177,58 @@ describe("GET /api/my-agents/characters?search= — non-string bio entries", () 
     expect(body.data.characters).toHaveLength(2);
   });
 });
+
+describe("POST /api/my-agents/characters — malformed name rejected as 400, never 500", () => {
+  // A non-string `name` used to 500: with no username, create() calls
+  // generateUniqueUsername(name) -> slugify(name).toLowerCase() -> TypeError
+  // ("name.toLowerCase is not a function"), which inferStatusFromLegacyError
+  // maps to 500. With a username supplied, slugify is skipped and the
+  // non-string name would persist, then 500 the public discovery/list reads
+  // (char.name.toLowerCase / localeCompare) for every viewer (#13637 / #13713).
+  test("non-string name (number) returns 400, not 500", async () => {
+    expect(pgliteReady).toBe(true);
+    const res = await createCharacter({ name: 42, bio: ["x"] });
+    expect(res.status).toBe(400);
+  });
+
+  test("object / array / null name all return 400", async () => {
+    expect(pgliteReady).toBe(true);
+    for (const bad of [{}, ["a"], null]) {
+      const res = await createCharacter({ name: bad as never, bio: ["x"] });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  test("missing name returns 400", async () => {
+    expect(pgliteReady).toBe(true);
+    const res = await createCharacter({ bio: ["x"] });
+    expect(res.status).toBe(400);
+  });
+
+  test("empty / whitespace-only name returns 400", async () => {
+    expect(pgliteReady).toBe(true);
+    for (const bad of ["", "   "]) {
+      const res = await createCharacter({ name: bad, bio: ["x"] });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  test("non-string name is rejected even when a valid username is supplied (before persist)", async () => {
+    expect(pgliteReady).toBe(true);
+    const res = await createCharacter({
+      name: 7,
+      username: "valid-name-guard",
+      bio: ["x"],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("a normal string name still creates (200) — no over-rejection", async () => {
+    expect(pgliteReady).toBe(true);
+    const res = await createCharacter({
+      name: "Charlie Helper",
+      bio: ["hello"],
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/characters/characters.ts
+++ b/packages/cloud/shared/src/lib/services/characters/characters.ts
@@ -204,6 +204,16 @@ export class CharactersService {
   }
 
   async create(data: NewUserCharacter): Promise<UserCharacter> {
+    // `name` arrives from the same pre-validation request body as `username`
+    // (the route casts raw JSON to ElizaCharacter). A non-string name 500s via
+    // slugify(name).toLowerCase() in generateUniqueUsername below; and when a
+    // username IS supplied so slugify is skipped, a non-string name persists
+    // and then 500s the public discovery/list reads (char.name.toLowerCase(),
+    // localeCompare) for every viewer (#13637 / #13713 class). Reject up front.
+    if (typeof data.name !== "string" || data.name.trim().length === 0) {
+      throw ValidationError("Invalid name: must be a non-empty string");
+    }
+
     // Generate username if not provided
     let username = data.username;
     if (username === undefined || username === null) {


### PR DESCRIPTION
## Summary

Completes the malformed-character-field shape-guard class (#13637 / #13713). The recent sweep #13706 guarded `bio` / `documents` / `knowledge` / `username`, but **left `name` unguarded** — the one field the discovery-500 report (#13713) is about.

## Root cause

`POST /api/my-agents/characters` casts the raw JSON body to `ElizaCharacter` with **no schema** (`packages/cloud/api/my-agents/characters/route.ts`), so `name` can be any JSON value. It flows unguarded into `charactersService.create()`:

- **No username supplied** → `create()` calls `generateUniqueUsername(data.name)` → `slugify(name)` → `name.toLowerCase()`. A non-string `name` throws `TypeError: name.toLowerCase is not a function`, which `inferStatusFromLegacyError` maps to **HTTP 500** on the caller's create.
- **Username supplied** → `slugify` is skipped and the non-string `name` is **persisted**, then 500s the public discovery/list reads (`char.name.toLowerCase()`, `a.name.localeCompare(b.name)` in the GET handler) — one malformed row 500s discovery **for every viewer** (#13713).

## Fix

Guard `name` at the top of `charactersService.create()`, mirroring the existing `username` guard in the same method — throw `ValidationError` (→ clean **400**) before any DB access. Because it lives in the service, it protects **all** callers (create + clone), and a non-string/empty name can never be persisted to 500 discovery.

```ts
if (typeof data.name !== "string" || data.name.trim().length === 0) {
  throw ValidationError("Invalid name: must be a non-empty string");
}
```

A valid string `name` path is byte-for-byte unchanged (no over-rejection).

## Verification

- **Guard fires before DB (proven locally, 7/7):** direct `charactersService.create({ name })` for `name ∈ {42, {}, ["a"], null, undefined, "", "   "}` all reject with `ValidationError: Invalid name: must be a non-empty string` — the guard is the first statement in `create()`, so these never touch the repository/db.

  ```
  bun test __tests__/…guard-probe…   7 pass  0 fail
  ```

- **Route-level regression tests added** in `packages/cloud/api/__tests__/my-agents-characters-search-bio-guard.test.ts` (same real-route + in-process PGlite harness as the merged bio-guard test): non-string number/object/array/null `name` → 400; missing `name` → 400; empty/whitespace `name` → 400; non-string `name` rejected even when a valid username is supplied; a normal string `name` still creates (200). These run in CI (the full PGlite path needs `drizzle-kit`, which isn't installed in the light dev checkout — the same reason the pre-existing bio-guard test is CI-only locally).

## Notes

Found via adversarial review of #13706 after it merged; this is the follow-up that closes the field its sweep missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)