### PR TITLE
fix(app-core): re-export IOS_FULL_BUN_SMOKE_FAILURE_RE from browser surface (fixes #13700 develop-red)

### DIFF
--- a/packages/app-core/src/browser.ts
+++ b/packages/app-core/src/browser.ts
@@ -64,6 +64,7 @@ export {
 } from "./runtime/desktop";
 export { AppWindowRenderer } from "./runtime/desktop/AppWindowRenderer";
 export { getHostExecutionCapabilities } from "./services/task-host-capabilities";
+export { IOS_FULL_BUN_SMOKE_FAILURE_RE } from "./platform/chat-failure-strings.generated";
 
 export type CompatRuntimeState = {
   current: unknown;


### PR DESCRIPTION
## Develop-red fix (follow-up to #13700, merge 27cc3f75)

**Root cause.** #13700 added an import of `IOS_FULL_BUN_SMOKE_FAILURE_RE` to `packages/app/src/main.tsx` from `@elizaos/app-core`. The renderer (Vite) aliases the bare `@elizaos/app-core` specifier to `packages/app-core/src/browser.ts` ("Keep the renderer on a browser-safe entry", `packages/app/vite.config.ts`). The symbol was only added to `index.ts` (Node barrel), never to `browser.ts`, and no transitive `export *` in `browser.ts` provides it. The renderer production build (rollup) therefore fails to resolve the named export.

Typecheck did not catch it because TS resolves `@elizaos/app-core` via `index.ts` types; only the Vite/renderer build uses the browser alias.

**Fix.** Add the missing browser-safe re-export to `browser.ts`. The source module `platform/chat-failure-strings.generated.ts` is a pure regex/const module with zero imports, so it is browser-safe.

**Verification.** This PR's app-build lane goes green where develop is red; the single-line change is additive (no existing export shadowed) and browser-safe.

Found via adversarial review of the merged PR wave (verified against actual merged `develop` source, not the PR diff).