### PR TITLE
fix(workflow): skip default seed for existing workflow stores

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts
@@ -423,6 +423,45 @@ describe('EmbeddedWorkflowService', () => {
     }
   }, 90_000);
 
+  test('does not seed the default into an existing non-default workflow store', async () => {
+    const harness = await seedingHarness({ WORKFLOW_SEED_DEFAULTS: false });
+    const first = await harness.start();
+    await first.createWorkflow({
+      id: 'user-nightly-summary',
+      name: 'User nightly summary',
+      active: false,
+      nodes: [
+        {
+          id: 'manual',
+          name: 'Manual Trigger',
+          type: 'workflows-nodes-base.manualTrigger',
+          typeVersion: 1,
+          position: [0, 0],
+          parameters: {},
+        },
+      ],
+      connections: {},
+    });
+    await first.stop();
+    harness.setSetting('WORKFLOW_SEED_DEFAULTS', true);
+
+    const second = await harness.start();
+    try {
+      const workflows = await second.listWorkflows();
+      expect(workflows.data.map((workflow) => workflow.id)).toEqual(['user-nightly-summary']);
+      expect(workflows.data.filter((workflow) => workflow.id === DEFAULT_WORKFLOW_ID)).toHaveLength(
+        0
+      );
+      expect(harness.tasks).toHaveLength(0);
+      expect(harness.cache.get(SEED_MARKER_KEY)).toMatchObject({
+        workflowId: DEFAULT_WORKFLOW_ID,
+      });
+    } finally {
+      await second.stop();
+      await harness.close();
+    }
+  }, 90_000);
+
   test('preserves a pre-marker deletion via the delete revision on upgrade', async () => {
     // Simulate an install upgraded from a pre-marker build where the user had
     // ALREADY deleted the default: seed, delete (leaving a `delete` revision),

--- a/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
+++ b/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
@@ -2311,7 +2311,9 @@ export class EmbeddedWorkflowService extends Service {
    * default is never re-seeded — so a user who deletes it does NOT get a zombie
    * re-seed on the next restart. Seeding also stays a no-op when the default
    * row already exists (covers a pre-marker install that seeded under the old
-   * row-existence check).
+   * row-existence check). A non-empty workflow store also suppresses seeding:
+   * existing installs with user-created workflows are not a first run, even if
+   * the default row/marker is missing.
    */
   private async seedDefaultWorkflows(): Promise<void> {
     // Deletion-respecting gate. Three outcomes:
@@ -2329,23 +2331,21 @@ export class EmbeddedWorkflowService extends Service {
     const rows = await this.getDb()
       .select({ id: embeddedWorkflows.id })
       .from(embeddedWorkflows)
-      .where(eq(embeddedWorkflows.id, DEVICE_HEALTH_CHECK_WORKFLOW_ID))
       .limit(1);
-    // Pre-marker install that already has the row (upgraded from a build that
-    // seeded under the old row-existence-only check): backfill the marker so
+    // Pre-marker install that already has workflows: backfill the marker so
     // future boots take the fast path and the deletion-respecting guard is
-    // active. We do NOT roll back this row on a marker-write failure — it is a
-    // legitimate existing workflow the user may rely on, not one we just
-    // created. Instead, if the marker cannot be persisted we log and retry the
-    // backfill on every subsequent boot until it sticks; the marker-less window
-    // is unavoidable for a row that predates the marker, and re-seeding is
-    // still bounded because the row itself keeps existing.
+    // active. We do NOT roll back or alter these rows on a marker-write
+    // failure — they are legitimate existing workflows the user may rely on,
+    // not rows we just created. Instead, if the marker cannot be persisted we
+    // log and retry the backfill on every subsequent boot until it sticks; the
+    // marker-less window is unavoidable for rows that predate the marker, and
+    // seeding is still bounded because the non-empty store keeps existing.
     if (rows.length > 0) {
       const backfilled = await this.markDefaultWorkflowsSeeded();
       if (!backfilled) {
         logger.warn(
           { src: 'plugin:workflow:embedded' },
-          'Could not backfill default-workflow seed marker for an existing default row; will retry next boot'
+          'Could not backfill default-workflow seed marker for an existing workflow store; will retry next boot'
         );
       }
       return;


### PR DESCRIPTION
## Summary
- do not seed the default device-health workflow when the embedded workflow store already contains any workflow
- backfill the seed marker for existing workflow stores so later boots keep the fast deletion-respecting path
- add a PGlite-backed regression for an upgraded install with a user-created workflow, no marker, and no default row

Follow-up to merged #13699 / #13597 after review found existing installs with non-default workflows could still receive the default seed.

## Verification
- `bun --config=/dev/null --conditions=eliza-source test plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts -t "seeds exactly one default|idempotent across restarts|respects a user deletion|cache-read outage|marker cannot be persisted|false setCache|pre-marker existing default|existing non-default|prior default deletion|WORKFLOW_SEED_DEFAULTS=false"` — 10 pass, 0 fail
- `bunx @biomejs/biome check plugins/plugin-workflow/src/services/embedded-workflow-service.ts plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts --no-errors-on-unmatched` — clean
- `git diff --check origin/develop...HEAD && git diff --check` — clean

## Evidence
- Domain artifact is the real PGlite-backed unit harness for default-seed state across restarts/deletions/cache failure; visual screenshots are N/A for this backend seed guard.