### PR TITLE
fix(#13550): serve the /api/notifications inbox over the Android UDS

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
@@ -239,6 +239,93 @@ describe("dispatchBufferedRequest", () => {
 		});
 		expect(Buffer.from(res.bodyBase64, "base64").equals(raw)).toBe(true);
 	});
+
+	it("serves the /api/notifications inbox from the runtime service over the UDS (#13550)", async () => {
+		// The dashboard notification center hydrates from GET /api/notifications;
+		// these routes are server-level (not runtime.routes), so without this the
+		// loopback 404s and the widget stays empty on-device. The bridge must
+		// serve them from the NotificationService BEFORE the plugin dispatcher.
+		const seeded = [
+			{ id: "n1", title: "Take the tour", readAt: null },
+			{ id: "n2", title: "Get help", readAt: 123 },
+		];
+		let cleared = false;
+		const readCalls: string[] = [];
+		const notifierRuntime = {
+			getService: (type: string) =>
+				type === "notification"
+					? {
+							list: () => seeded,
+							getUnreadCount: () => 1,
+							markRead: (id: string) => {
+								readCalls.push(id);
+								return Promise.resolve(true);
+							},
+							markAllRead: () => Promise.resolve(1),
+							remove: () => Promise.resolve(true),
+							clear: () => {
+								cleared = true;
+								return Promise.resolve();
+							},
+						}
+					: null,
+		} as unknown as IAgentRuntime;
+		const { route, calls } = fixedRoute(null);
+
+		const list = await dispatchBufferedRequest(notifierRuntime, route, {
+			method: "GET",
+			path: "/api/notifications?limit=100",
+		});
+		expect(list.status).toBe(200);
+		expect(JSON.parse(list.body)).toEqual({
+			notifications: seeded,
+			unreadCount: 1,
+		});
+		// Served inline — the plugin dispatcher was never consulted.
+		expect(calls).toHaveLength(0);
+
+		const read = await dispatchBufferedRequest(notifierRuntime, route, {
+			method: "POST",
+			path: "/api/notifications/n1/read",
+		});
+		expect(read.status).toBe(200);
+		expect(JSON.parse(read.body)).toEqual({ ok: true });
+		expect(readCalls).toEqual(["n1"]);
+
+		const clearRes = await dispatchBufferedRequest(notifierRuntime, route, {
+			method: "DELETE",
+			path: "/api/notifications",
+		});
+		expect(clearRes.status).toBe(200);
+		expect(cleared).toBe(true);
+
+		// Push-token registration is NOT ours — it must fall through.
+		const push = await dispatchBufferedRequest(notifierRuntime, route, {
+			method: "GET",
+			path: "/api/notifications/push-tokens",
+		});
+		expect(calls).toHaveLength(1);
+		expect((calls[0] as { path?: string }).path).toBe(
+			"/api/notifications/push-tokens",
+		);
+		void push;
+	});
+
+	it("serves an empty inbox when the notification service is not up yet", async () => {
+		const noSvcRuntime = {
+			getService: () => null,
+		} as unknown as IAgentRuntime;
+		const { route } = fixedRoute(null);
+		const res = await dispatchBufferedRequest(noSvcRuntime, route, {
+			method: "GET",
+			path: "/api/notifications",
+		});
+		expect(res.status).toBe(200);
+		expect(JSON.parse(res.body)).toEqual({
+			notifications: [],
+			unreadCount: 0,
+		});
+	});
 });
 
 describe("dispatchStreamingRequest", () => {

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
@@ -19,7 +19,12 @@
  */
 
 import { Buffer } from "node:buffer";
-import type { IAgentRuntime, RouteHandlerResult } from "@elizaos/core";
+import type {
+	AgentNotification,
+	IAgentRuntime,
+	RouteHandlerResult,
+} from "@elizaos/core";
+import { ServiceType } from "@elizaos/core";
 import type { StdioBridgeStreamSink } from "../shared/stdio-bridge.ts";
 
 /** In-process route dispatcher (from `@elizaos/agent/api`). */
@@ -163,6 +168,120 @@ export interface AndroidCoreRouteDeps {
 export type AndroidElizaConfigLike = Record<string, unknown> & {
 	meta?: Record<string, unknown>;
 };
+
+/**
+ * Structural view of the runtime NotificationService the bridge serves the
+ * `/api/notifications` surface against. The service lives on the runtime, so
+ * the bridge does not need to import the agent's HTTP route module — it drives
+ * the same service the HTTP `handleNotificationRoute` does (list/read/remove/
+ * clear), which is what the dashboard notification center hydrates from.
+ */
+interface AndroidNotificationServiceLike {
+	list: (query?: {
+		unreadOnly?: boolean;
+		category?: string;
+		limit?: number;
+	}) => AgentNotification[];
+	getUnreadCount: () => number;
+	markRead: (id: string) => Promise<boolean>;
+	markAllRead: () => Promise<number>;
+	remove: (id: string) => Promise<boolean>;
+	clear: () => Promise<void>;
+}
+
+function isAndroidNotifier(
+	value: unknown,
+): value is AndroidNotificationServiceLike {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof (value as AndroidNotificationServiceLike).list === "function" &&
+		typeof (value as AndroidNotificationServiceLike).markRead === "function"
+	);
+}
+
+/**
+ * Serve the `/api/notifications` inbox surface over the Android UDS. These are
+ * server-level routes (not plugin `runtime.routes`), so `dispatchRoute` never
+ * matches them and the loopback 404s — which left the dashboard notification
+ * center empty on every on-device local boot (the store's hydrate `GET
+ * /api/notifications` failed). Drives the runtime NotificationService directly,
+ * mirroring how first-run/health are inline-served above. Returns null for
+ * anything outside the inbox verbs (incl. the push-tokens sub-namespace, which
+ * the push service owns) so it falls through to the plugin dispatcher.
+ */
+async function directAndroidNotificationRoute(
+	runtime: IAgentRuntime,
+	method: string,
+	pathname: string,
+	query: Record<string, string | string[]>,
+): Promise<AndroidBufferedResponse | null> {
+	const queryValue = (key: string): string | undefined => {
+		const raw = query[key];
+		return Array.isArray(raw) ? raw[0] : raw;
+	};
+	if (!pathname.startsWith("/api/notifications")) return null;
+	// Push-token registration is owned by the push delivery service, not the
+	// inbox — leave it to the normal dispatcher.
+	if (pathname.startsWith("/api/notifications/push-tokens")) return null;
+
+	const service = runtime.getService(ServiceType.NOTIFICATION);
+	if (!isAndroidNotifier(service)) {
+		// The service isn't up yet (very early boot). Serve an empty inbox on
+		// GET so the widget shows its empty state instead of erroring; fail the
+		// mutations loudly.
+		if (method === "GET" && pathname === "/api/notifications") {
+			return jsonResponse(200, { notifications: [], unreadCount: 0 });
+		}
+		return jsonResponse(503, { error: "notification service not ready" });
+	}
+
+	if (method === "GET" && pathname === "/api/notifications") {
+		const limitRaw = queryValue("limit");
+		const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+		const limit =
+			typeof parsedLimit === "number" &&
+			Number.isFinite(parsedLimit) &&
+			parsedLimit >= 0
+				? Math.min(parsedLimit, 500)
+				: undefined;
+		const notifications = service.list({
+			unreadOnly: queryValue("unreadOnly") === "true",
+			category: queryValue("category"),
+			limit,
+		});
+		return jsonResponse(200, {
+			notifications,
+			unreadCount: service.getUnreadCount(),
+		});
+	}
+
+	if (method === "POST" && pathname === "/api/notifications/read-all") {
+		const changed = await service.markAllRead();
+		return jsonResponse(200, { changed });
+	}
+
+	const readMatch = pathname.match(/^\/api\/notifications\/([^/]+)\/read$/);
+	if (method === "POST" && readMatch) {
+		const ok = await service.markRead(decodeURIComponent(readMatch[1]));
+		return jsonResponse(200, { ok });
+	}
+
+	if (method === "DELETE" && pathname === "/api/notifications") {
+		await service.clear();
+		return jsonResponse(200, { ok: true });
+	}
+
+	const idMatch = pathname.match(/^\/api\/notifications\/([^/]+)$/);
+	if (method === "DELETE" && idMatch) {
+		const ok = await service.remove(decodeURIComponent(idMatch[1]));
+		return jsonResponse(200, { ok });
+	}
+
+	// A known notifications sub-path with an unsupported verb — 404 here rather
+	// than letting the plugin dispatcher's `:id` matchers mis-handle it.
+	return jsonResponse(404, { error: "notification route not found" });
+}
 
 function directAndroidCoreRoute(
 	runtime: IAgentRuntime,
@@ -367,6 +486,14 @@ export async function dispatchBufferedRequest(
 
 	const direct = directAndroidCoreRoute(runtime, method, pathname, coreRoutes);
 	if (direct) return direct;
+
+	const notif = await directAndroidNotificationRoute(
+		runtime,
+		method,
+		pathname,
+		query,
+	);
+	if (notif) return notif;
 
 	const result = await dispatchRoute({
 		runtime,


### PR DESCRIPTION
## What

The dashboard notification center hydrates from `GET /api/notifications`, but on the Android local-agent path that request returns **404 "No local route for GET /api/notifications"** — so the store's hydrate fails, the inbox stays empty, and the pinned notification widget self-hides on every on-device local boot (even though the agent has seeded onboarding notifications).

**Root cause.** The notification routes are *server-level* (`handleNotificationRoute` in `server-route-dispatch.ts`), not plugin `runtime.routes`. The Android local-agent UDS dispatcher (`dispatchRoute`) only matches `runtime.routes`, so it never serves them — the same class as #13550, which #13559 fixed for the startup routes but not the inbox.

**Fix.** Serve the inbox verbs (list / read / read-all / remove / clear) from the runtime `NotificationService` directly in the Android bridge dispatch (`plugins/plugin-capacitor-bridge/src/android/dispatch.ts`), before the plugin dispatcher — mirroring how first-run/health/auth are inline-served. The `/api/notifications/push-tokens` sub-namespace (owned by the push service) still falls through.

## Evidence

- New unit tests in `dispatch.test.ts`: `GET /api/notifications` returns the service's list + unread count and is served *before* the plugin dispatcher (never consulted); `POST :id/read` and `DELETE` drive the service; `push-tokens` falls through; no-service-yet serves an empty inbox. 16/16 dispatch tests pass.
- **Device-verified** on a Moto G Play 2024 (local runtime): with this + the renderer probe fix (#13748), the local path boots to the dashboard and the notification center renders the seeded onboarding rows (screenshot in a comment).

Completes the Android half of #13550 for the notification surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)