### PR TITLE
fix(cloud): keep claim affiliate sweep page-safe

### DIFF
--- a/packages/cloud/api/__tests__/my-agents-claim-affiliate-characters.test.ts
+++ b/packages/cloud/api/__tests__/my-agents-claim-affiliate-characters.test.ts
@@ -1,0 +1,156 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const USER = "00000000-0000-4000-8000-0000000000bb";
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+
+const requireUserWithOrg = mock();
+const findRoomsByEntityId = mock();
+const findRoomsByIds = mock();
+const findCharacterById = mock();
+const listCharactersByUser = mock();
+const getUserById = mock();
+const getAnonymousSessionByToken = mock();
+const markAnonymousSessionConverted = mock();
+const claimAffiliateCharacter = mock();
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserWithOrg,
+}));
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: () =>
+    new Response(JSON.stringify({ success: false, error: "auth failed" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    }),
+}));
+
+mock.module("hono/http-exception", () => ({
+  HTTPException: class HTTPException extends Error {
+    status: number;
+
+    constructor(status = 500, options?: { message?: string }) {
+      super(options?.message);
+      this.status = status;
+    }
+  },
+}));
+
+mock.module("@/db/repositories", () => ({
+  participantsRepository: {
+    findRoomsByEntityId,
+  },
+  roomsRepository: {
+    findByIds: findRoomsByIds,
+  },
+  userCharactersRepository: {
+    findById: findCharacterById,
+    listByUser: listCharactersByUser,
+  },
+}));
+
+mock.module("@/lib/services/users", () => ({
+  usersService: {
+    getById: getUserById,
+  },
+}));
+
+mock.module("@/lib/services/anonymous-sessions", () => ({
+  anonymousSessionsService: {
+    getByToken: getAnonymousSessionByToken,
+    markConverted: markAnonymousSessionConverted,
+  },
+}));
+
+mock.module("@/lib/services/characters/characters", () => ({
+  charactersService: {
+    claimAffiliateCharacter,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+let route: { default: { fetch: (req: Request) => Promise<Response> } };
+
+beforeAll(async () => {
+  route = await import("../my-agents/claim-affiliate-characters/route");
+});
+
+beforeEach(() => {
+  requireUserWithOrg.mockReset();
+  findRoomsByEntityId.mockReset();
+  findRoomsByIds.mockReset();
+  findCharacterById.mockReset();
+  listCharactersByUser.mockReset();
+  getUserById.mockReset();
+  getAnonymousSessionByToken.mockReset();
+  markAnonymousSessionConverted.mockReset();
+  claimAffiliateCharacter.mockReset();
+
+  requireUserWithOrg.mockResolvedValue({
+    id: USER,
+    organization_id: ORG,
+  });
+  findRoomsByEntityId.mockResolvedValue([]);
+  findRoomsByIds.mockResolvedValue([]);
+  findCharacterById.mockResolvedValue(null);
+  listCharactersByUser.mockResolvedValue([]);
+  getUserById.mockResolvedValue(null);
+  getAnonymousSessionByToken.mockResolvedValue(null);
+  markAnonymousSessionConverted.mockResolvedValue(undefined);
+  claimAffiliateCharacter.mockResolvedValue({
+    success: true,
+    message: "claimed",
+  });
+});
+
+function postClaim(body: unknown = {}) {
+  return route.default.fetch(
+    new Request("http://test.local/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("POST /api/my-agents/claim-affiliate-characters", () => {
+  test("ignores non-character room agent IDs before querying user_characters UUIDs", async () => {
+    findRoomsByEntityId.mockResolvedValue(["room-1"]);
+    findRoomsByIds.mockResolvedValue([
+      { id: "room-1", agentId: "runtime-agent-not-a-character-uuid" },
+    ]);
+
+    const res = await postClaim();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success?: boolean;
+      claimed?: unknown[];
+    };
+    expect(body.success).toBe(true);
+    expect(body.claimed).toEqual([]);
+    expect(findCharacterById).not.toHaveBeenCalled();
+  });
+
+  test("returns a non-500 response when the post-auth claim sweep fails", async () => {
+    findRoomsByEntityId.mockRejectedValue(new Error("staging schema drift"));
+
+    const res = await postClaim();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success?: boolean;
+      claimed?: unknown[];
+      message?: string;
+    };
+    expect(body.success).toBe(false);
+    expect(body.claimed).toEqual([]);
+    expect(body.message).toContain("page can continue loading");
+  });
+});

--- a/packages/cloud/api/my-agents/claim-affiliate-characters/route.ts
+++ b/packages/cloud/api/my-agents/claim-affiliate-characters/route.ts
@@ -32,6 +32,13 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  */
 const app = new Hono<AppEnv>();
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isUuid(value: string | null | undefined): value is string {
+  return typeof value === "string" && UUID_RE.test(value);
+}
+
 app.post("/", async (c) => {
   try {
     const user = await requireUserWithOrg(c);
@@ -40,173 +47,187 @@ app.post("/", async (c) => {
       `[Claim Affiliate Chars] Starting claim process for user ${user.id}`,
     );
 
-    let sessionToken: string | undefined;
     try {
-      const body = (await c.req.json().catch(() => ({}))) as {
-        sessionToken?: string;
-      };
-      sessionToken = body.sessionToken;
-    } catch {
-      // No body or invalid JSON - that's okay
-    }
-
-    // Find affiliate characters user has interacted with via room associations
-    // New architecture: entityId = userId, rooms.agentId = characterId
-    const claimableCharacters: Array<{
-      characterId: string;
-      characterName: string;
-      ownerId: string;
-      roomId: string;
-    }> = [];
-
-    // Get all rooms the user participates in
-    const userRoomIds = await participantsRepository.findRoomsByEntityId(
-      user.id,
-    );
-
-    if (userRoomIds.length > 0) {
-      // Get the rooms with their agentIds (characterIds)
-      const rooms = await roomsRepository.findByIds(userRoomIds);
-      const characterIds = [
-        ...new Set(rooms.map((r) => r.agentId).filter(Boolean)),
-      ] as string[];
-
-      if (characterIds.length > 0) {
-        // Get characters and check their owners
-        for (const characterId of characterIds) {
-          const char = await userCharactersRepository.findById(characterId);
-          if (!char) continue;
-
-          // Skip if user already owns this character
-          if (char.user_id === user.id) continue;
-
-          // Check if owner is an anonymous/affiliate user
-          const owner = await usersService.getById(char.user_id);
-          if (
-            owner &&
-            (owner.is_anonymous === true ||
-              owner.email?.includes("@anonymous.elizacloud.ai"))
-          ) {
-            const room = rooms.find((r) => r.agentId === char.id);
-            claimableCharacters.push({
-              characterId: char.id,
-              characterName: char.name,
-              ownerId: char.user_id,
-              roomId: room?.id || "",
-            });
-          }
-        }
+      let sessionToken: string | undefined;
+      try {
+        const body = (await c.req.json().catch(() => ({}))) as {
+          sessionToken?: string;
+        };
+        sessionToken = body.sessionToken;
+      } catch {
+        // No body or invalid JSON - that's okay
       }
-    }
 
-    // Also find characters via session token if provided
-    if (sessionToken) {
-      logger.info(
-        `[Claim Affiliate Chars] Session token provided, looking up session...`,
+      // Find affiliate characters user has interacted with via room associations
+      // New architecture: entityId = userId, rooms.agentId = characterId
+      const claimableCharacters: Array<{
+        characterId: string;
+        characterName: string;
+        ownerId: string;
+        roomId: string;
+      }> = [];
+
+      // Get all rooms the user participates in
+      const userRoomIds = await participantsRepository.findRoomsByEntityId(
+        user.id,
       );
 
-      const session = await anonymousSessionsService.getByToken(sessionToken);
+      if (userRoomIds.length > 0) {
+        // Get the rooms with their agentIds (characterIds)
+        const rooms = await roomsRepository.findByIds(userRoomIds);
+        const characterIds = [...new Set(rooms.map((r) => r.agentId))].filter(
+          isUuid,
+        );
 
-      if (session && !session.converted_at) {
-        const sessionOwner = await usersService.getById(session.user_id);
+        if (characterIds.length > 0) {
+          // Get characters and check their owners
+          for (const characterId of characterIds) {
+            const char = await userCharactersRepository.findById(characterId);
+            if (!char) continue;
 
-        if (
-          sessionOwner?.is_anonymous &&
-          sessionOwner.email?.includes("@anonymous.elizacloud.ai")
-        ) {
-          logger.info(
-            `[Claim Affiliate Chars] Found affiliate session owner: ${sessionOwner.id}`,
-          );
+            // Skip if user already owns this character
+            if (char.user_id === user.id) continue;
 
-          // Find characters owned by this anonymous user
-          const sessionCharacters = await userCharactersRepository.listByUser(
-            sessionOwner.id,
-          );
-
-          for (const char of sessionCharacters) {
-            // Only add if not already in the list and owned by the session owner
+            // Check if owner is an anonymous/affiliate user
+            const owner = await usersService.getById(char.user_id);
             if (
-              char.user_id === sessionOwner.id &&
-              !claimableCharacters.some((c) => c.characterId === char.id)
+              owner &&
+              (owner.is_anonymous === true ||
+                owner.email?.includes("@anonymous.elizacloud.ai"))
             ) {
+              const room = rooms.find((r) => r.agentId === char.id);
               claimableCharacters.push({
                 characterId: char.id,
                 characterName: char.name,
-                ownerId: sessionOwner.id,
-                roomId: "", // No room association, but we'll claim via session
+                ownerId: char.user_id,
+                roomId: room?.id || "",
               });
-              logger.info(
-                `[Claim Affiliate Chars] Added character from session: ${char.name}`,
-              );
             }
           }
+        }
+      }
 
-          // Mark session as converted to prevent future claims
-          await anonymousSessionsService.markConverted(session.id);
+      // Also find characters via session token if provided
+      if (sessionToken) {
+        logger.info(
+          `[Claim Affiliate Chars] Session token provided, looking up session...`,
+        );
+
+        const session = await anonymousSessionsService.getByToken(sessionToken);
+
+        if (session && !session.converted_at) {
+          const sessionOwner = await usersService.getById(session.user_id);
+
+          if (
+            sessionOwner?.is_anonymous &&
+            sessionOwner.email?.includes("@anonymous.elizacloud.ai")
+          ) {
+            logger.info(
+              `[Claim Affiliate Chars] Found affiliate session owner: ${sessionOwner.id}`,
+            );
+
+            // Find characters owned by this anonymous user
+            const sessionCharacters = await userCharactersRepository.listByUser(
+              sessionOwner.id,
+            );
+
+            for (const char of sessionCharacters) {
+              // Only add if not already in the list and owned by the session owner
+              if (
+                char.user_id === sessionOwner.id &&
+                !claimableCharacters.some((c) => c.characterId === char.id)
+              ) {
+                claimableCharacters.push({
+                  characterId: char.id,
+                  characterName: char.name,
+                  ownerId: sessionOwner.id,
+                  roomId: "", // No room association, but we'll claim via session
+                });
+                logger.info(
+                  `[Claim Affiliate Chars] Added character from session: ${char.name}`,
+                );
+              }
+            }
+
+            // Mark session as converted to prevent future claims
+            await anonymousSessionsService.markConverted(session.id);
+            logger.info(
+              `[Claim Affiliate Chars] Marked session as converted: ${session.id}`,
+            );
+          }
+        }
+      }
+
+      if (claimableCharacters.length === 0) {
+        logger.info(
+          `[Claim Affiliate Chars] No claimable characters found for user ${user.id}`,
+        );
+        return c.json({
+          success: true,
+          claimed: [],
+          message: "No affiliate characters to claim",
+        });
+      }
+
+      logger.info(
+        `[Claim Affiliate Chars] Found ${claimableCharacters.length} claimable characters`,
+        {
+          characters: claimableCharacters.map((c) => ({
+            id: c.characterId,
+            name: c.characterName,
+          })),
+        },
+      );
+
+      // Claim each character
+      const claimedCharacters: Array<{ id: string; name: string }> = [];
+      const failedClaims: Array<{ id: string; reason: string }> = [];
+
+      for (const char of claimableCharacters) {
+        const result = await charactersService.claimAffiliateCharacter(
+          char.characterId,
+          user.id,
+          user.organization_id,
+        );
+
+        if (result.success) {
+          claimedCharacters.push({
+            id: char.characterId,
+            name: char.characterName,
+          });
           logger.info(
-            `[Claim Affiliate Chars] Marked session as converted: ${session.id}`,
+            `[Claim Affiliate Chars] ✅ Claimed character: ${char.characterName}`,
+          );
+        } else {
+          failedClaims.push({ id: char.characterId, reason: result.message });
+          logger.warn(
+            `[Claim Affiliate Chars] ❌ Failed to claim ${char.characterName}: ${result.message}`,
           );
         }
       }
-    }
 
-    if (claimableCharacters.length === 0) {
-      logger.info(
-        `[Claim Affiliate Chars] No claimable characters found for user ${user.id}`,
-      );
       return c.json({
         success: true,
+        claimed: claimedCharacters,
+        failed: failedClaims,
+        message:
+          claimedCharacters.length > 0
+            ? `Successfully claimed ${claimedCharacters.length} character(s)`
+            : "No characters were claimed",
+      });
+    } catch (error) {
+      logger.error(
+        "[Claim Affiliate Chars] Best-effort claim sweep failed:",
+        error,
+      );
+      return c.json({
+        success: false,
         claimed: [],
-        message: "No affiliate characters to claim",
+        failed: [],
+        message:
+          "Affiliate character claim sweep could not complete. The page can continue loading.",
       });
     }
-
-    logger.info(
-      `[Claim Affiliate Chars] Found ${claimableCharacters.length} claimable characters`,
-      {
-        characters: claimableCharacters.map((c) => ({
-          id: c.characterId,
-          name: c.characterName,
-        })),
-      },
-    );
-
-    // Claim each character
-    const claimedCharacters: Array<{ id: string; name: string }> = [];
-    const failedClaims: Array<{ id: string; reason: string }> = [];
-
-    for (const char of claimableCharacters) {
-      const result = await charactersService.claimAffiliateCharacter(
-        char.characterId,
-        user.id,
-        user.organization_id,
-      );
-
-      if (result.success) {
-        claimedCharacters.push({
-          id: char.characterId,
-          name: char.characterName,
-        });
-        logger.info(
-          `[Claim Affiliate Chars] ✅ Claimed character: ${char.characterName}`,
-        );
-      } else {
-        failedClaims.push({ id: char.characterId, reason: result.message });
-        logger.warn(
-          `[Claim Affiliate Chars] ❌ Failed to claim ${char.characterName}: ${result.message}`,
-        );
-      }
-    }
-
-    return c.json({
-      success: true,
-      claimed: claimedCharacters,
-      failed: failedClaims,
-      message:
-        claimedCharacters.length > 0
-          ? `Successfully claimed ${claimedCharacters.length} character(s)`
-          : "No characters were claimed",
-    });
   } catch (error) {
     logger.error("[Claim Affiliate Chars] Error:", error);
     return failureResponse(c, error);


### PR DESCRIPTION
## Summary
- keep the authenticated claim-affiliate sweep best-effort so My Agents no longer logs a 500 when staging data/repository drift trips the background sweep
- ignore non-UUID room agent IDs before querying user_characters, avoiding stale runtime agent IDs being treated as cloud character UUIDs
- add a route-local regression test for both the stale agent-id path and the post-auth sweep failure path

## Verification
- bun test packages/cloud/api/__tests__/my-agents-claim-affiliate-characters.test.ts
- bunx biome check packages/cloud/api/my-agents/claim-affiliate-characters/route.ts packages/cloud/api/__tests__/my-agents-claim-affiliate-characters.test.ts
- git diff --check -- packages/cloud/api/my-agents/claim-affiliate-characters/route.ts packages/cloud/api/__tests__/my-agents-claim-affiliate-characters.test.ts

## E2E note
- E2E_ONLY=group-c bun run --cwd packages/cloud/api test:e2e was attempted. The local Worker started, but the slice failed before tests with: Cannot find module `@elizaos/cloud-routing` from `packages/core/src/cloud-routing.ts`.

Closes #13753