### PR TITLE
test(ui): stabilize startup probe timeout coverage

### DIFF
--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -109,7 +109,7 @@ function createDeps(): PollingBackendDeps {
 const originalWindow = (globalThis as { window?: unknown }).window;
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
   clientMock.getAuthStatus.mockResolvedValue({
     required: false,
     pairingEnabled: false,
@@ -131,6 +131,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   (globalThis as { window?: unknown }).window = originalWindow;
 });
 
@@ -1465,6 +1466,9 @@ describe("runPollingBackend bounded native boot (#11030)", () => {
 });
 
 describe("runPollingBackend progress-aware native budget + dead-cloud recovery (iOS boot automation D1)", () => {
+  const originalIosFullBunAvailable =
+    process.env.VITE_ELIZA_IOS_FULL_BUN_AVAILABLE;
+
   const nativePolicy = {
     supportsLocalRuntime: true,
     backendTimeoutMs: 30_000,
@@ -1521,7 +1525,19 @@ describe("runPollingBackend progress-aware native budget + dead-cloud recovery (
     return { setItemCalls };
   }
 
+  beforeEach(async () => {
+    process.env.VITE_ELIZA_IOS_FULL_BUN_AVAILABLE = "true";
+    const transport = await import("../api/ios-local-agent-transport");
+    transport.resetIosNativeAgentBootProgressForTests();
+  });
+
   afterEach(async () => {
+    if (originalIosFullBunAvailable === undefined) {
+      delete process.env.VITE_ELIZA_IOS_FULL_BUN_AVAILABLE;
+    } else {
+      process.env.VITE_ELIZA_IOS_FULL_BUN_AVAILABLE =
+        originalIosFullBunAvailable;
+    }
     delete (globalThis as Record<string, unknown>).Capacitor;
     const transport = await import("../api/ios-local-agent-transport");
     transport.resetIosNativeAgentBootProgressForTests();
@@ -1838,6 +1854,9 @@ describe("runPollingBackend progress-aware native budget + dead-cloud recovery (
     // consecutive-failure budget, a local-capable native build with a stale
     // persisted cloud mode flips to the bundled agent instead of stranding
     // the user on the timeout card.
+    vi.useFakeTimers();
+    const transport = await import("../api/ios-local-agent-transport");
+    transport.resetIosNativeAgentBootProgressForTests();
     const deps = createDeps();
     const dispatch = vi.fn();
     const { setItemCalls } = installNativeWindow({
@@ -1869,16 +1888,33 @@ describe("runPollingBackend progress-aware native budget + dead-cloud recovery (
       cloudProvisioned: false,
     });
 
-    await runPollingBackend(
-      deps,
-      dispatch,
-      { ...nativePolicy, nativeConsecutiveFailureBudgetMs: 150 },
-      nativeCtx(deadCloudServer),
-      1,
-      { current: 1 },
-      { current: false },
-      { current: null },
-    );
+    try {
+      const run = runPollingBackend(
+        deps,
+        dispatch,
+        { ...nativePolicy, nativeConsecutiveFailureBudgetMs: 150 },
+        nativeCtx(deadCloudServer),
+        1,
+        { current: 1 },
+        { current: false },
+        { current: null },
+      );
+      let settled = false;
+      const settledRun = run.finally(() => {
+        settled = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      for (let i = 0; i < 800 && !settled; i++) {
+        (globalThis as Record<string, unknown>).Capacitor = {
+          isNativePlatform: () => true,
+        };
+        await vi.advanceTimersByTimeAsync(50);
+      }
+      expect(settled).toBe(true);
+      await settledRun;
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(clientMock.setBaseUrl).toHaveBeenCalledWith(
       "eliza-local-agent://ipc",
@@ -1892,6 +1928,7 @@ describe("runPollingBackend progress-aware native budget + dead-cloud recovery (
   });
 
   it("never auto-flips a user-configured remote-mac mode to the on-device agent", async () => {
+    vi.useFakeTimers();
     const deps = createDeps();
     const dispatch = vi.fn();
     const { setItemCalls } = installNativeWindow({
@@ -1912,7 +1949,7 @@ describe("runPollingBackend progress-aware native budget + dead-cloud recovery (
       }),
     );
 
-    await runPollingBackend(
+    const run = runPollingBackend(
       deps,
       dispatch,
       { ...nativePolicy, nativeConsecutiveFailureBudgetMs: 150 },
@@ -1922,6 +1959,19 @@ describe("runPollingBackend progress-aware native budget + dead-cloud recovery (
       { current: false },
       { current: null },
     );
+    let settled = false;
+    const settledRun = run.finally(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    for (let i = 0; i < 800 && !settled; i++) {
+      (globalThis as Record<string, unknown>).Capacitor = {
+        isNativePlatform: () => true,
+      };
+      await vi.advanceTimersByTimeAsync(50);
+    }
+    expect(settled).toBe(true);
+    await settledRun;
 
     // Dead-ends on the timeout card (with Retry) — the explicit remote
     // choice is respected, no silent mode flip.

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -571,10 +571,7 @@ export async function runPollingBackend(
    */
   const boundedProbe = <T>(promise: Promise<T>): Promise<T> => {
     const remainingMs = Math.max(0, deadline - Date.now());
-    const capMs = Math.max(
-      1_000,
-      Math.min(PROBE_REQUEST_TIMEOUT_MS, remainingMs),
-    );
+    const capMs = Math.max(1, Math.min(PROBE_REQUEST_TIMEOUT_MS, remainingMs));
     return new Promise<T>((resolve, reject) => {
       const hangTid = setTimeout(() => {
         reject(


### PR DESCRIPTION
## Summary
- cap startup probe timeout by the actual remaining deadline instead of forcing a 1s minimum
- reset startup poll mocks/timers between tests and make native dead-cloud budget tests deterministic under fake timers
- explicitly stamp local-engine build truth for the native dead-cloud recovery test scenario

## Verification
- `bun run --cwd packages/ui test -- src/state/startup-phase-poll.test.ts --coverage.enabled=false --testTimeout=30000`
- `bun run --cwd packages/ui test -- src/state/startup-phase-poll.test.ts -t "recovers a stale persisted cloud mode to the ON-DEVICE agent when the dedicated cloud agent is DELETED|recovers to the on-device agent when the persisted cloud base dead-ends" --coverage.enabled=false --testTimeout=20000`
- `bunx biome check packages/ui/src/state/startup-phase-poll.ts packages/ui/src/state/startup-phase-poll.test.ts`
- `git diff --check HEAD~1..HEAD`

Follow-up to #13748 / #13737; #13748 merged before this local stabilization commit landed.