### PR TITLE
fix(cloud): fail closed on live Stripe keys in non-prod envs (#13752 guard slice)

### DIFF
--- a/packages/cloud/shared/src/lib/config/deployment-environment.ts
+++ b/packages/cloud/shared/src/lib/config/deployment-environment.ts
@@ -41,3 +41,35 @@ export function shouldBlockRegistrarStub(env: EnvLike = process.env): boolean {
 export function shouldBlockPayoutAssumeOperational(env: EnvLike = process.env): boolean {
   return env.PAYOUT_STATUS_ASSUME_OPERATIONAL === "1" && isProductionDeployment(env);
 }
+
+/**
+ * True when the given Stripe secret key is a LIVE-mode key. Live secret keys
+ * are prefixed `sk_live_` (restricted live keys use `rk_live_`).
+ */
+export function isLiveStripeSecretKey(key: string | undefined): boolean {
+  const trimmed = key?.trim() ?? "";
+  return trimmed.startsWith("sk_live_") || trimmed.startsWith("rk_live_");
+}
+
+/**
+ * Fail closed when a LIVE Stripe secret key is bound outside production
+ * (#13752): the staging Worker was bound to prod's `sk_live_` key, so
+ * add-funds on staging.elizacloud.ai created `cs_live` checkout sessions and
+ * hands-on QA could pay real money into the staging database. Live keys are
+ * only ever valid in the production deployment; staging/preview/dev must use
+ * test-mode keys (`sk_test_`).
+ */
+export function shouldBlockLiveStripeKeyOutsideProduction(env: EnvLike = process.env): boolean {
+  return isLiveStripeSecretKey(env.STRIPE_SECRET_KEY) && !isProductionDeployment(env);
+}
+
+/**
+ * Loud (non-fatal) misconfiguration signal for the reverse case: production
+ * bound to a TEST-mode Stripe key. Checkouts would "succeed" without moving
+ * real money. Warn instead of failing so a prod deploy is not bricked, but
+ * the log line should be treated as an incident.
+ */
+export function shouldWarnTestStripeKeyInProduction(env: EnvLike = process.env): boolean {
+  const key = env.STRIPE_SECRET_KEY?.trim() ?? "";
+  return key.startsWith("sk_test_") && isProductionDeployment(env);
+}

--- a/packages/cloud/shared/src/lib/stripe.guard.test.ts
+++ b/packages/cloud/shared/src/lib/stripe.guard.test.ts
@@ -1,0 +1,150 @@
+// Exercises the live-Stripe-key deployment guard (#13752) with deterministic env fixtures.
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  isLiveStripeSecretKey,
+  shouldBlockLiveStripeKeyOutsideProduction,
+  shouldWarnTestStripeKeyInProduction,
+} from "./config/deployment-environment";
+import { runWithCloudBindings } from "./runtime/cloud-bindings";
+import { __resetStripeForTests, getStripe, isStripeConfigured } from "./stripe";
+
+/**
+ * #13752: the staging Worker was bound to prod's sk_live_ key, so add-funds on
+ * staging created cs_live checkout sessions — hands-on QA could pay real money
+ * into the staging DB. These tests pin the fail-closed guard: live keys are
+ * rejected outside production; test keys in prod warn (non-fatal).
+ *
+ * Worker secrets are injected via runWithCloudBindings (same path the cloud
+ * API uses per-request), so process.env stays untouched.
+ */
+
+// Built via concatenation so GitHub push protection / secret scanners do not
+// flag these obviously-fake fixtures as real Stripe keys.
+const LIVE_KEY = ["sk", "live", "FakeKeyForGuardTests000000"].join("_");
+const TEST_KEY = ["sk", "test", "FakeKeyForGuardTests000000"].join("_");
+
+afterEach(() => {
+  __resetStripeForTests();
+});
+
+describe("isLiveStripeSecretKey", () => {
+  it("detects live secret and restricted keys", () => {
+    expect(isLiveStripeSecretKey(LIVE_KEY)).toBe(true);
+    expect(isLiveStripeSecretKey("rk_live_abc")).toBe(true);
+    expect(isLiveStripeSecretKey(`  ${LIVE_KEY}  `)).toBe(true);
+  });
+
+  it("does not flag test keys, empty, or unset", () => {
+    expect(isLiveStripeSecretKey(TEST_KEY)).toBe(false);
+    expect(isLiveStripeSecretKey("rk_test_abc")).toBe(false);
+    expect(isLiveStripeSecretKey("")).toBe(false);
+    expect(isLiveStripeSecretKey(undefined)).toBe(false);
+  });
+});
+
+describe("shouldBlockLiveStripeKeyOutsideProduction", () => {
+  it("blocks live keys in staging / preview / dev / test", () => {
+    expect(
+      shouldBlockLiveStripeKeyOutsideProduction({
+        STRIPE_SECRET_KEY: LIVE_KEY,
+        ENVIRONMENT: "staging",
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockLiveStripeKeyOutsideProduction({
+        STRIPE_SECRET_KEY: LIVE_KEY,
+        NODE_ENV: "test",
+      }),
+    ).toBe(true);
+    expect(shouldBlockLiveStripeKeyOutsideProduction({ STRIPE_SECRET_KEY: LIVE_KEY })).toBe(true);
+  });
+
+  it("allows live keys in production (ENVIRONMENT or NODE_ENV)", () => {
+    expect(
+      shouldBlockLiveStripeKeyOutsideProduction({
+        STRIPE_SECRET_KEY: LIVE_KEY,
+        ENVIRONMENT: "production",
+      }),
+    ).toBe(false);
+    expect(
+      shouldBlockLiveStripeKeyOutsideProduction({
+        STRIPE_SECRET_KEY: LIVE_KEY,
+        NODE_ENV: "production",
+      }),
+    ).toBe(false);
+  });
+
+  it("never blocks test keys or unset keys anywhere", () => {
+    expect(
+      shouldBlockLiveStripeKeyOutsideProduction({
+        STRIPE_SECRET_KEY: TEST_KEY,
+        ENVIRONMENT: "staging",
+      }),
+    ).toBe(false);
+    expect(shouldBlockLiveStripeKeyOutsideProduction({ ENVIRONMENT: "staging" })).toBe(false);
+  });
+
+  it("honors ENVIRONMENT over NODE_ENV (staging worker with NODE_ENV=production still blocks)", () => {
+    expect(
+      shouldBlockLiveStripeKeyOutsideProduction({
+        STRIPE_SECRET_KEY: LIVE_KEY,
+        ENVIRONMENT: "staging",
+        NODE_ENV: "production",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("shouldWarnTestStripeKeyInProduction", () => {
+  it("warns only for test keys in production", () => {
+    expect(
+      shouldWarnTestStripeKeyInProduction({
+        STRIPE_SECRET_KEY: TEST_KEY,
+        ENVIRONMENT: "production",
+      }),
+    ).toBe(true);
+    expect(
+      shouldWarnTestStripeKeyInProduction({
+        STRIPE_SECRET_KEY: TEST_KEY,
+        ENVIRONMENT: "staging",
+      }),
+    ).toBe(false);
+    expect(
+      shouldWarnTestStripeKeyInProduction({
+        STRIPE_SECRET_KEY: LIVE_KEY,
+        ENVIRONMENT: "production",
+      }),
+    ).toBe(false);
+    expect(shouldWarnTestStripeKeyInProduction({ ENVIRONMENT: "production" })).toBe(false);
+  });
+});
+
+describe("stripe client init guard (via Worker bindings)", () => {
+  it("staging + sk_live_ fails closed: getStripe throws, isStripeConfigured is false", () => {
+    runWithCloudBindings({ STRIPE_SECRET_KEY: LIVE_KEY, ENVIRONMENT: "staging" }, () => {
+      expect(isStripeConfigured()).toBe(false);
+      expect(() => getStripe()).toThrow(/LIVE-mode key .* not production/);
+    });
+  });
+
+  it("staging + sk_test_ initializes normally", () => {
+    runWithCloudBindings({ STRIPE_SECRET_KEY: TEST_KEY, ENVIRONMENT: "staging" }, () => {
+      expect(isStripeConfigured()).toBe(true);
+      expect(() => getStripe()).not.toThrow();
+    });
+  });
+
+  it("production + sk_live_ initializes normally", () => {
+    runWithCloudBindings({ STRIPE_SECRET_KEY: LIVE_KEY, ENVIRONMENT: "production" }, () => {
+      expect(isStripeConfigured()).toBe(true);
+      expect(() => getStripe()).not.toThrow();
+    });
+  });
+
+  it("production + sk_test_ initializes (warn-only, not fatal)", () => {
+    runWithCloudBindings({ STRIPE_SECRET_KEY: TEST_KEY, ENVIRONMENT: "production" }, () => {
+      expect(isStripeConfigured()).toBe(true);
+      expect(() => getStripe()).not.toThrow();
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/stripe.ts
+++ b/packages/cloud/shared/src/lib/stripe.ts
@@ -24,7 +24,12 @@
  */
 
 import Stripe from "stripe";
+import {
+  shouldBlockLiveStripeKeyOutsideProduction,
+  shouldWarnTestStripeKeyInProduction,
+} from "./config/deployment-environment";
 import { getCloudAwareEnv } from "./runtime/cloud-bindings";
+import { logger } from "./utils/logger";
 
 type PinnedStripeApiVersion = Stripe.WebhookEndpointCreateParams.ApiVersion;
 type StripeConstructorConfig = NonNullable<ConstructorParameters<typeof Stripe>[1]>;
@@ -42,7 +47,8 @@ function initStripe(): Stripe | null {
   if (stripeInstance) return stripeInstance;
   if (stripeInitError) return null;
 
-  const secretKey = getCloudAwareEnv().STRIPE_SECRET_KEY?.trim();
+  const env = getCloudAwareEnv();
+  const secretKey = env.STRIPE_SECRET_KEY?.trim();
 
   if (!secretKey) {
     stripeInitError = new Error("STRIPE_SECRET_KEY is not set in environment variables");
@@ -54,6 +60,26 @@ function initStripe(): Stripe | null {
       `STRIPE_SECRET_KEY appears invalid (should start with 'sk_', got '${secretKey.substring(0, 3)}...'). Please verify your Stripe configuration.`,
     );
     return null;
+  }
+
+  // Fail closed on live keys outside production (#13752). Staging bound to
+  // prod's sk_live_ key produced cs_live checkout sessions, letting QA pay
+  // real money into the staging database. Never initialize a live-mode
+  // client unless this deployment is production.
+  if (shouldBlockLiveStripeKeyOutsideProduction(env)) {
+    stripeInitError = new Error(
+      "SECURITY: STRIPE_SECRET_KEY is a LIVE-mode key (sk_live_/rk_live_) but this deployment is not production (ENVIRONMENT/NODE_ENV). Refusing to initialize Stripe: live keys outside prod let checkouts charge real money into a non-prod database (#13752). Bind a test-mode key (sk_test_) to this environment.",
+    );
+    logger.error(`[Stripe] ${stripeInitError.message}`);
+    return null;
+  }
+
+  // Reverse misconfiguration: production on a TEST key silently "collects"
+  // fake money. Loud warning, not fatal, so a prod deploy is not bricked.
+  if (shouldWarnTestStripeKeyInProduction(env)) {
+    logger.warn(
+      "[Stripe] STRIPE_SECRET_KEY is a TEST-mode key (sk_test_) in a production deployment. Checkouts will not move real money. Verify the environment's Stripe secrets (#13752).",
+    );
   }
 
   stripeInstance = new Stripe(secretKey, {
@@ -98,8 +124,15 @@ export function requireStripe(): Stripe {
  * Use this before calling `requireStripe()` to avoid runtime errors.
  */
 export function isStripeConfigured(): boolean {
-  const key = getCloudAwareEnv().STRIPE_SECRET_KEY?.trim();
-  return !!key && key.startsWith("sk_");
+  const env = getCloudAwareEnv();
+  const key = env.STRIPE_SECRET_KEY?.trim();
+  if (!key || !key.startsWith("sk_")) {
+    return false;
+  }
+  // A live key outside production is treated as NOT configured (#13752):
+  // callers that gate on this helper degrade gracefully instead of creating
+  // real-money checkout sessions against a non-prod database.
+  return !shouldBlockLiveStripeKeyOutsideProduction(env);
 }
 
 /**
@@ -119,6 +152,16 @@ export function assertStripeConfigured(): void {
   if (!isStripeConfigured()) {
     throw new Error("STRIPE_SECRET_KEY is not set in environment variables");
   }
+}
+
+/**
+ * Reset the cached Stripe client/init error. Test-only: lets unit tests
+ * exercise initStripe() under different STRIPE_SECRET_KEY / environment
+ * combinations (the module otherwise caches the first outcome).
+ */
+export function __resetStripeForTests(): void {
+  stripeInstance = null;
+  stripeInitError = null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Guard slice for #13752 (staging Worker bound to prod's live Stripe key, so add-funds on staging.elizacloud.ai opened **cs_live** checkout sessions and hands-on QA could pay real money into the staging DB). The secret **rotation** itself is human/infra scope and stays on the issue; this PR makes the misconfig class impossible to hit silently again.

**HIGH-FLAG: touches money/keys handling. Auto-merge NOT armed — human review required.**

## What changed

**`packages/cloud/shared/src/lib/config/deployment-environment.ts`** (existing prod-gate module, reused its env signal):
- `isLiveStripeSecretKey` — detects `sk_live_` / `rk_live_` prefixes
- `shouldBlockLiveStripeKeyOutsideProduction` — live key AND NOT `isProductionDeployment(env)` (ENVIRONMENT first, NODE_ENV fallback — same signal as the DEVNET / webhook-skip / registrar-stub gates)
- `shouldWarnTestStripeKeyInProduction` — reverse case, loud but non-fatal

**`packages/cloud/shared/src/lib/stripe.ts`** (single chokepoint — every cloud API route goes through `requireStripe()`/`getStripe()`/`isStripeConfigured()` here):
- `initStripe()` now **refuses to construct a live-mode client outside production**: `getStripe()` throws a clear `SECURITY:` error naming #13752; `isStripeConfigured()` returns `false` so gated callers degrade gracefully instead of opening real-money checkouts
- prod + `sk_test_`: loud `logger.warn` only (a prod deploy is not bricked, but the log is an incident signal)
- `__resetStripeForTests()` added (module caches init outcome; matches existing `__reset*ForTests` conventions in cloud-shared)
- **No behavior change for correctly configured envs** (prod+live, non-prod+test, key unset)

## Env signal used
`ENVIRONMENT` (set per-env by `packages/cloud/api/wrangler.toml`: production / staging), falling back to `NODE_ENV` — via the existing `isProductionDeployment()` helper. No new env vars.

## Test matrix (red → green)
New `stripe.guard.test.ts` (11 pass). Red run confirmed: reverting the two source files fails the suite (missing exports / no guard).

- staging + sk_live → `getStripe()` **throws**, `isStripeConfigured()` false ✅
- staging + sk_test → initializes normally ✅
- prod + sk_live → initializes normally ✅
- prod + sk_test → initializes, warn-only ✅
- `ENVIRONMENT=staging` overrides `NODE_ENV=production` (matches existing gate semantics) ✅
- rk_live_ restricted keys also blocked; unset/empty never flagged ✅

Client init cases run through `runWithCloudBindings` (the same per-request Worker-bindings path the cloud API uses), so `process.env` is untouched.

## Verification
- `bun test src/lib/stripe.guard.test.ts` → 11 pass / 0 fail
- Adjacent suites green one-at-a-time: `deployment-environment.test.ts` (7), `deployment-environment.gates.test.ts` (6), `stripe-connect-payout.test.ts` (12)
- `tsgo --noEmit` clean (cloud-shared), biome clean on touched files
- Note: test fixtures build key strings via concatenation so GitHub push protection does not false-positive on the fake `sk_live` literal

Issue: #13752

[sol-verify]