### PR TITLE
fix(app-core): sort browser smoke regex export

### DIFF
--- a/packages/app-core/src/browser.ts
+++ b/packages/app-core/src/browser.ts
@@ -55,6 +55,7 @@ export {
   type AutomationNodeContributorContext,
   registerAutomationNodeContributor,
 } from "./api/automation-node-contributors";
+export { IOS_FULL_BUN_SMOKE_FAILURE_RE } from "./platform/chat-failure-strings.generated";
 export {
   buildLocalizedTrayMenu,
   DESKTOP_TRAY_MENU_ITEMS,
@@ -64,7 +65,6 @@ export {
 } from "./runtime/desktop";
 export { AppWindowRenderer } from "./runtime/desktop/AppWindowRenderer";
 export { getHostExecutionCapabilities } from "./services/task-host-capabilities";
-export { IOS_FULL_BUN_SMOKE_FAILURE_RE } from "./platform/chat-failure-strings.generated";
 
 export type CompatRuntimeState = {
   current: unknown;


### PR DESCRIPTION
## Summary

Follow-up to merged #13764. The browser-surface export was correct functionally, but Biome wants `./platform/...` exports before `./runtime/...`; this moves the existing `IOS_FULL_BUN_SMOKE_FAILURE_RE` export to the sorted location.

## Verification

- `bunx biome check packages/app-core/src/browser.ts`
- `git diff --check origin/develop...HEAD`
- `bun --conditions=eliza-source -e 'import { IOS_FULL_BUN_SMOKE_FAILURE_RE } from "./packages/app-core/src/browser.ts"; if (!(IOS_FULL_BUN_SMOKE_FAILURE_RE instanceof RegExp)) throw new Error("export is not a RegExp"); console.log(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("Something went wrong"));'` -> `true`

## Evidence applicability

- UI screenshots/video: N/A - export ordering only, no rendered UI change.
- Frontend logs/network: N/A - no runtime behavior change.
- Live LLM trajectory: N/A - no model/agent/prompt path changed.
- Domain artifacts: N/A - no persistent data changed.