### PR TITLE
fix(app-core): authorize remote cloud forwarding routes

### DIFF
--- a/packages/app-core/src/api/route-auth-policy.dispatch.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.dispatch.test.ts
@@ -8,23 +8,12 @@
  * own `ensureRoute*` call still cannot ship an unauthenticated compat route as
  * long as its prefix is compat-managed.
  */
+import fs from "node:fs";
 import http from "node:http";
 import { Socket } from "node:net";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-vi.mock(import("@elizaos/core"), async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...actual,
-    logger: {
-      ...actual.logger,
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    },
-  };
-});
 
 import type { CompatRuntimeState } from "./compat-route-shared";
 import { handleElizaCompatRoute } from "./server";
@@ -38,17 +27,82 @@ const STATE: CompatRuntimeState = {
 const ENV_KEYS = [
   "ELIZA_API_BIND",
   "ELIZA_API_TOKEN",
+  "ELIZA_CONFIG_PATH",
+  "ELIZA_REQUIRE_LOCAL_AUTH",
   "ELIZA_RUNTIME_MODE",
+  "ELIZA_STATE_DIR",
 ] as const;
 let saved: Record<string, string | undefined>;
+let stateDir: string | null = null;
+let target: http.Server | null = null;
+let targetBase = "";
+const targetSockets = new Set<Socket>();
+const targetHits: Array<{
+  authorization: string | undefined;
+  method: string;
+  url: string;
+}> = [];
 
-beforeEach(() => {
+beforeEach(async () => {
   saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
   // Force a non-loopback peer + no token so the request is unauthenticated.
   delete process.env.ELIZA_API_TOKEN;
+  delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+  delete process.env.ELIZA_CONFIG_PATH;
+  targetHits.length = 0;
+
+  target = http.createServer((req, res) => {
+    targetHits.push({
+      authorization: req.headers.authorization,
+      method: req.method ?? "",
+      url: req.url ?? "",
+    });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ forwarded: true }));
+  });
+  target.on("connection", (socket) => {
+    targetSockets.add(socket);
+    socket.on("close", () => targetSockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => target?.listen(0, "127.0.0.1", resolve));
+  const address = target.address();
+  if (!address || typeof address === "string") {
+    throw new Error("test target did not bind to a TCP port");
+  }
+  targetBase = `http://127.0.0.1:${address.port}`;
+
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-app-core-mode-"));
+  fs.writeFileSync(
+    path.join(stateDir, "eliza.json"),
+    JSON.stringify(
+      {
+        deploymentTarget: {
+          runtime: "remote",
+          remoteApiBase: targetBase,
+          remoteAccessToken: "target-token",
+        },
+        logging: { level: "error" },
+      },
+      null,
+      2,
+    ),
+  );
+  process.env.ELIZA_STATE_DIR = stateDir;
 });
 
-afterEach(() => {
+afterEach(async () => {
+  if (target) {
+    for (const socket of targetSockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve) => target?.close(() => resolve()));
+    target = null;
+  }
+  targetSockets.clear();
+  if (stateDir) {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+    stateDir = null;
+  }
   for (const k of ENV_KEYS) {
     if (saved[k] === undefined) delete process.env[k];
     else process.env[k] = saved[k];
@@ -61,6 +115,10 @@ function unauthReq(method: string, pathname: string): http.IncomingMessage {
   req.method = method;
   req.url = pathname;
   req.headers = { host: "example.test:2138" };
+  if (method === "POST") {
+    req.push("{}");
+    req.push(null);
+  }
   // A remote (non-loopback) peer is never trusted-local, so with no token the
   // request is fully unauthenticated.
   Object.defineProperty(req.socket, "remoteAddress", {
@@ -70,14 +128,26 @@ function unauthReq(method: string, pathname: string): http.IncomingMessage {
   return req;
 }
 
+function bearerReq(
+  method: string,
+  pathname: string,
+  token: string,
+): http.IncomingMessage {
+  const req = unauthReq(method, pathname);
+  req.headers.authorization = `Bearer ${token}`;
+  return req;
+}
+
 function captureRes() {
   let body = "";
   const req = new http.IncomingMessage(new Socket());
   const res = new http.ServerResponse(req);
-  res.assignSocket(new Socket());
+  const socket = new Socket();
+  res.assignSocket(socket);
   res.end = ((chunk?: string | Buffer) => {
     if (typeof chunk === "string") body += chunk;
     else if (chunk) body += chunk.toString("utf8");
+    socket.destroy();
     return res;
   }) as typeof res.end;
   return {
@@ -141,5 +211,41 @@ describe("compat dispatcher default-deny (H5)", () => {
 
     expect(handled).toBe(true);
     expect(cap.status()).toBe(200);
+  });
+
+  it("denies remote-mode cloud mutations before the forwarder sees unauthenticated callers", async () => {
+    const cap = captureRes();
+    const handled = await handleElizaCompatRoute(
+      unauthReq("POST", "/api/cloud/login"),
+      cap.res,
+      STATE,
+    );
+
+    expect(handled).toBe(true);
+    expect(cap.status()).toBe(401);
+    expect(cap.json()).toEqual({ error: "Unauthorized" });
+    expect(targetHits).toHaveLength(0);
+  });
+
+  it("forwards remote-mode cloud mutations after compat auth accepts the caller", async () => {
+    process.env.ELIZA_API_TOKEN = "local-api-token";
+    process.env.ELIZA_REQUIRE_LOCAL_AUTH = "1";
+    const cap = captureRes();
+    const handled = await handleElizaCompatRoute(
+      bearerReq("POST", "/api/cloud/login", "local-api-token"),
+      cap.res,
+      STATE,
+    );
+
+    expect(handled).toBe(true);
+    expect(cap.status()).toBe(200);
+    expect(cap.json()).toEqual({ forwarded: true });
+    expect(targetHits).toEqual([
+      {
+        authorization: "Bearer target-token",
+        method: "POST",
+        url: "/api/cloud/login",
+      },
+    ]);
   });
 });

--- a/packages/app-core/src/api/route-auth-policy.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.test.ts
@@ -85,6 +85,12 @@ describe("compat route auth policy table", () => {
       resolveCompatRouteAuthPolicy("POST", "/api/background/upload-image"),
     ).toMatchObject({ id: "background.upload-image", tier: "session" });
     expect(
+      resolveCompatRouteAuthPolicy("POST", "/api/cloud/login"),
+    ).toMatchObject({ id: "cloud.login", tier: "session" });
+    expect(
+      resolveCompatRouteAuthPolicy("POST", "/api/cloud/disconnect"),
+    ).toMatchObject({ id: "cloud.disconnect", tier: "session" });
+    expect(
       resolveCompatRouteAuthPolicy("POST", "/api/tts/elevenlabs"),
     ).toMatchObject({
       id: "tts.elevenlabs-passthrough",

--- a/packages/app-core/src/api/route-auth-policy.ts
+++ b/packages/app-core/src/api/route-auth-policy.ts
@@ -114,6 +114,8 @@ export const COMPAT_ROUTE_AUTH_POLICIES: readonly CompatRouteAuthPolicy[] = [
   publicExact("tts.elevenlabs-passthrough", "POST", "/api/tts/elevenlabs"),
 
   sessionExact("runtime.mode", "GET", "/api/runtime/mode"),
+  sessionExact("cloud.login", "POST", "/api/cloud/login"),
+  sessionExact("cloud.disconnect", "POST", "/api/cloud/disconnect"),
   sessionPrefix("cloud.compat", "/api/cloud/compat/"),
   sessionPrefix("cloud.v1", "/api/cloud/v1/"),
   sessionPrefix("cloud.billing", "/api/cloud/billing/"),


### PR DESCRIPTION
## Summary

Follow-up to merged #13757. That PR fixed the bare agent remote-mode cloud mutation auth path, but app-core still denied valid authenticated remote-mode `/api/cloud/login` and `/api/cloud/disconnect` requests before the post-auth forwarder could run because those exact routes had no compat auth-policy entries.

This PR:
- declares `POST /api/cloud/login` and `POST /api/cloud/disconnect` as session compat routes;
- adds auth-policy table coverage for both routes;
- extends the real app-core dispatcher test to prove unauthenticated remote-mode cloud mutations 401 before the target sees them, while bearer-authenticated mutations forward to the configured remote target with the target access token.

## Verification

- `bun run --cwd packages/shared build:i18n`
- `bunx biome check packages/app-core/src/api/route-auth-policy.ts packages/app-core/src/api/route-auth-policy.test.ts packages/app-core/src/api/route-auth-policy.dispatch.test.ts`
- `git diff --check`
- `bun test --reporter=dots ./packages/app-core/src/api/route-auth-policy.test.ts ./packages/app-core/src/api/route-auth-policy.dispatch.test.ts ./packages/agent/src/api/runtime-mode/remote-forwarder.test.ts ./packages/agent/src/api/runtime-mode/route-mode-guard.test.ts ./packages/agent/src/api/runtime-mode/route-mode-matrix.test.ts ./packages/agent/src/api/runtime-mode/runtime-mode.test.ts ./packages/agent/test/api/runtime-mode-gate.real-server.test.ts` — 66 pass, 0 fail

## Evidence

N/A - backend route/auth policy regression; no rendered UI surface changed.