### PR TITLE
fix(ui): restore account security DTO unavailable states

### DIFF
--- a/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
@@ -1,10 +1,10 @@
 /**
- * Account-security panel tests for unavailable launch surfaces.
+ * Account-security panel tests for explicit unavailable DTOs.
  *
- * The cloud Worker does not expose account-security read/write routes for these
- * panels yet, so the UI must render explicit unavailable states without firing
- * dead account calls, fabricating successful requests, or reading unavailable
- * data as a healthy empty state.
+ * The cloud Worker exposes read contracts for MFA and session inventory even
+ * while those features are unavailable. These tests pin the three-state UI:
+ * loading, designed-unavailable, healthy empty, and transport error must remain
+ * distinguishable.
  */
 
 // @vitest-environment jsdom
@@ -12,9 +12,9 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import type { ButtonHTMLAttributes, PropsWithChildren } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const apiMock = vi.hoisted(() => vi.fn());
 const apiFetchMock = vi.hoisted(() => vi.fn());
@@ -90,22 +90,67 @@ describe("account-security panels", () => {
     apiFetchMock.mockReset();
   });
 
-  it("renders MFA unavailable without calling the missing status endpoint", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders MFA unavailable from the backend DTO", async () => {
+    apiMock.mockResolvedValueOnce({
+      available: false,
+      reason: "mfa_enrollment_unavailable",
+      enrolled: false,
+      method: null,
+    });
+
     render(<MfaPanel />);
 
-    expect(screen.getByText(/MFA enrollment is unavailable/i)).toBeTruthy();
+    expect(screen.getByText(/Loading MFA status/i)).toBeTruthy();
+    expect(
+      await screen.findByText(/MFA enrollment is unavailable/i),
+    ).toBeTruthy();
     expect(screen.queryByText(/MFA is not enabled/i)).toBeNull();
-    expect(apiMock).not.toHaveBeenCalled();
+    expect(apiMock).toHaveBeenCalledWith("/api/v1/me/mfa");
     expect(apiFetchMock).not.toHaveBeenCalled();
   });
 
-  it("renders sessions unavailable without calling session inventory", () => {
+  it("renders sessions unavailable from the backend DTO", async () => {
+    apiMock.mockResolvedValueOnce({
+      available: false,
+      reason: "session_inventory_unavailable",
+      sessions: [],
+    });
+
     render(<ActiveSessionsPanel />);
 
-    expect(screen.getByText(/Session listing is unavailable/i)).toBeTruthy();
+    expect(screen.getByText(/Loading sessions/i)).toBeTruthy();
+    expect(
+      await screen.findByText(/Session listing is unavailable/i),
+    ).toBeTruthy();
     expect(screen.queryByText(/No other active sessions found/i)).toBeNull();
-    expect(apiMock).not.toHaveBeenCalled();
+    expect(apiMock).toHaveBeenCalledWith("/api/v1/sessions");
     expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("renders healthy empty sessions only when the DTO is available", async () => {
+    apiMock.mockResolvedValueOnce({ sessions: [] });
+
+    render(<ActiveSessionsPanel />);
+
+    expect(
+      await screen.findByText(/No other active sessions found/i),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Session listing is unavailable/i)).toBeNull();
+    expect(apiMock).toHaveBeenCalledWith("/api/v1/sessions");
+  });
+
+  it("renders MFA errors separately from unavailable and disabled", async () => {
+    apiMock.mockRejectedValueOnce(new Error("mfa route failed"));
+
+    render(<MfaPanel />);
+
+    expect(await screen.findByText("mfa route failed")).toBeTruthy();
+    expect(screen.queryByText(/MFA enrollment is unavailable/i)).toBeNull();
+    expect(screen.queryByText(/MFA is not enabled/i)).toBeNull();
   });
 
   it("renders audit events unavailable without calling the missing read route", () => {

--- a/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
@@ -1,14 +1,67 @@
 /**
- * Active sessions panel. The Worker does not currently expose session
- * enumeration/revocation, so keep this panel in the explicit unavailable state
- * instead of issuing dead account-session calls on every Security page load.
+ * Active sessions panel. The Cloud API exposes an explicit session-inventory
+ * contract even while revocable sessions are unavailable, so the panel renders
+ * loading / unavailable / empty / error / ready from the DTO.
  */
 
+import { useEffect, useState } from "react";
 import { BrandCard, CornerBrackets } from "../../../cloud-ui";
+import { api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
+
+interface SessionRow {
+  id: string;
+  device?: string | null;
+  ip?: string | null;
+  user_agent?: string | null;
+  last_seen?: string | null;
+  current?: boolean;
+}
+
+interface SessionsResponse {
+  available?: boolean;
+  reason?: string | null;
+  sessions?: SessionRow[];
+}
+
+type SessionsState =
+  | { kind: "loading" }
+  | { kind: "unavailable"; reason: string | null }
+  | { kind: "ready"; sessions: SessionRow[] }
+  | { kind: "error"; message: string };
 
 export function ActiveSessionsPanel() {
   const t = useCloudT();
+  const [state, setState] = useState<SessionsState>({ kind: "loading" });
+
+  useEffect(() => {
+    let active = true;
+    void api<SessionsResponse>("/api/v1/sessions")
+      .then((payload) => {
+        if (!active) return;
+        if (payload.available === false) {
+          setState({
+            kind: "unavailable",
+            reason: payload.reason ?? null,
+          });
+          return;
+        }
+        setState({
+          kind: "ready",
+          sessions: Array.isArray(payload.sessions) ? payload.sessions : [],
+        });
+      })
+      .catch((error) => {
+        if (!active) return;
+        setState({
+          kind: "error",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   return (
     <BrandCard className="relative">
@@ -27,11 +80,62 @@ export function ActiveSessionsPanel() {
             })}
           </p>
         </div>
-        <p className="text-sm text-white/50">
-          {t("cloud.activeSessions.notAvailable", {
-            defaultValue: "Session listing is unavailable on this server.",
-          })}
-        </p>
+        {state.kind === "loading" ? (
+          <p className="text-sm text-white/50">
+            {t("cloud.activeSessions.loading", {
+              defaultValue: "Loading sessions...",
+            })}
+          </p>
+        ) : state.kind === "unavailable" ? (
+          <p className="text-sm text-white/50">
+            {t("cloud.activeSessions.notAvailable", {
+              reason: state.reason ?? "",
+              defaultValue: "Session listing is unavailable on this server.",
+            })}
+          </p>
+        ) : state.kind === "error" ? (
+          <p className="text-sm text-red-300">{state.message}</p>
+        ) : state.sessions.length === 0 ? (
+          <p className="text-sm text-white/50">
+            {t("cloud.activeSessions.noOther", {
+              defaultValue: "No other active sessions found.",
+            })}
+          </p>
+        ) : (
+          <ul className="divide-y divide-white/10">
+            {state.sessions.map((session) => (
+              <li
+                key={session.id}
+                className="flex items-center justify-between gap-3 py-2 text-sm"
+              >
+                <div className="space-y-0.5">
+                  <p className="font-medium text-white">
+                    {session.device ??
+                      t("cloud.activeSessions.unknownDevice", {
+                        defaultValue: "Unknown device",
+                      })}
+                    {session.current ? (
+                      <span className="ml-2 rounded-sm border border-green-500/40 bg-green-500/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-green-300">
+                        {t("cloud.activeSessions.current", {
+                          defaultValue: "current",
+                        })}
+                      </span>
+                    ) : null}
+                  </p>
+                  <p className="font-mono text-[11px] text-white/50">
+                    {t("cloud.activeSessions.ipLastSeen", {
+                      ip: session.ip ?? "-",
+                      lastSeen: session.last_seen
+                        ? new Date(session.last_seen).toLocaleString()
+                        : "-",
+                      defaultValue: "{{ip}} - last seen {{lastSeen}}",
+                    })}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </BrandCard>
   );

--- a/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
@@ -1,15 +1,58 @@
 /**
- * Two-factor authentication status panel. The Worker does not currently expose
- * an MFA status route, so keep the panel in the explicit unavailable state
- * instead of firing a dead request on Security page load.
+ * Two-factor authentication status panel. The Cloud API exposes a status
+ * contract even while enrollment is unavailable, so the panel reads the DTO and
+ * renders loading / unavailable / error / ready as distinct states.
  */
 
 import { Lock } from "lucide-react";
+import { useEffect, useState } from "react";
 import { BrandCard, CornerBrackets } from "../../../cloud-ui";
+import { api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
+
+interface MfaStatusResponse {
+  available?: boolean;
+  reason?: string | null;
+  enrolled?: boolean;
+  method?: string | null;
+}
+
+type MfaState =
+  | { kind: "loading" }
+  | { kind: "unavailable"; reason: string | null }
+  | { kind: "ready"; enrolled: boolean; method: string | null }
+  | { kind: "error"; message: string };
 
 export function MfaPanel() {
   const t = useCloudT();
+  const [state, setState] = useState<MfaState>({ kind: "loading" });
+
+  useEffect(() => {
+    let active = true;
+    void api<MfaStatusResponse>("/api/v1/me/mfa")
+      .then((payload) => {
+        if (!active) return;
+        if (payload.available === false) {
+          setState({ kind: "unavailable", reason: payload.reason ?? null });
+          return;
+        }
+        setState({
+          kind: "ready",
+          enrolled: Boolean(payload.enrolled),
+          method: payload.method ?? null,
+        });
+      })
+      .catch((error) => {
+        if (!active) return;
+        setState({
+          kind: "error",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   return (
     <BrandCard className="relative">
@@ -23,11 +66,40 @@ export function MfaPanel() {
             })}
           </h3>
         </div>
-        <p className="text-sm text-white/60">
-          {t("cloud.mfaPanel.notAvailable", {
-            defaultValue: "MFA enrollment is unavailable on this server.",
-          })}
-        </p>
+        {state.kind === "loading" ? (
+          <p className="text-sm text-white/50">
+            {t("cloud.mfaPanel.loading", {
+              defaultValue: "Loading MFA status...",
+            })}
+          </p>
+        ) : state.kind === "unavailable" ? (
+          <p className="text-sm text-white/60">
+            {t("cloud.mfaPanel.notAvailable", {
+              reason: state.reason ?? "",
+              defaultValue: "MFA enrollment is unavailable on this server.",
+            })}
+          </p>
+        ) : state.kind === "error" ? (
+          <p className="text-sm text-red-300">{state.message}</p>
+        ) : state.enrolled ? (
+          <p className="text-sm text-green-300">
+            {t("cloud.mfaPanel.enabled", {
+              method:
+                state.method ??
+                t("cloud.mfaPanel.unknownMethod", {
+                  defaultValue: "unknown",
+                }),
+              defaultValue: "Enabled - method: {{method}}",
+            })}
+          </p>
+        ) : (
+          <p className="text-sm text-white/60">
+            {t("cloud.mfaPanel.notEnabled", {
+              defaultValue:
+                "MFA is not enabled. Adding a second factor protects your account even if your password is compromised.",
+            })}
+          </p>
+        )}
       </div>
     </BrandCard>
   );


### PR DESCRIPTION
## Summary
- Restores the account-security MFA and active-session panels to read the explicit Cloud API DTO routes added for unavailable features.
- Keeps loading, designed-unavailable, healthy-empty, error, and ready states visually distinct instead of hardcoding static unavailable panels.
- Expands the focused panel tests so unavailable DTOs do not read as healthy empty/disabled success, while transport failures render separately.

## Verification
```bash
bun run --cwd packages/shared build:i18n
# generated keyword data for this fresh worktree

bun run --cwd packages/ui test -- src/cloud/account-security/components/account-security-panels.test.tsx
# 1 file passed, 6 tests passed

bunx @biomejs/biome check packages/ui/src/cloud/account-security/components/mfa-panel.tsx packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx --no-errors-on-unmatched
# Checked 3 files. No fixes applied.

git diff --check
# clean
```

Direct `bun test packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx` is not the valid runner for this existing Vitest file in this environment: it fails before assertions because Bun's shim does not provide `vi.hoisted`. The package Vitest runner above is the authoritative check and passed.

## Evidence / N/A
- UI screenshots/video: N/A for this corrective unit-level follow-up; it restores API-driven state branching without changing layout composition. The original merged PR still lacks rendered UI evidence and should not be treated as fully evidenced until the Settings visual pass is captured.
- Live LLM trajectories: N/A - no model, prompt, provider, or agent behavior changed.
- Domain artifact: focused tests assert the actual `/api/v1/me/mfa` and `/api/v1/sessions` client calls and the unavailable DTO render path.

Follow-up to #13760.
