### PR TITLE
chore(#13402): enforce one pinned CI Bun version (single source of truth)

### DIFF
--- a/.github/ci-bun-version.json
+++ b/.github/ci-bun-version.json
@@ -1,0 +1,4 @@
+{
+  "$comment": "Single source of truth for the pinned Bun version on every frozen-lockfile CI install path. Floating `canary`/`latest` reserializes bun.lock to lockfileVersion 2 and breaks `bun install --frozen-lockfile` (#11184/#9454), and the repo's packageManager `bun@1.4.0-canary.1` is unresolvable in CI (GH+npm 404) — so the required test/build gates pin a concrete version here instead. Enforced by packages/scripts/ci-bun-version-contract.mjs: every concrete `bun-version`/`BUN_VERSION` pin in .github/workflows must equal `version`, and the gate workflows in that script's GATE_WORKFLOWS list must stay pinned to it and never float back to canary/latest. To bump: change `version` here and update the gate workflows in the SAME PR — the contract fails the branch if they drift apart.",
+  "version": "1.3.14"
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Validate GitHub-native turbo cache contract
         run: node packages/scripts/ci-turbo-cache-contract.mjs
 
+      - name: Validate CI Bun version pin contract
+        run: node packages/scripts/ci-bun-version-contract.mjs
+
       - name: Determine affected test lanes
         id: filter
         shell: bash

--- a/packages/scripts/__tests__/ci-bun-version-contract.test.ts
+++ b/packages/scripts/__tests__/ci-bun-version-contract.test.ts
@@ -1,0 +1,168 @@
+// Pins the CI Bun-version contract (#13402) against synthetic repo trees: a
+// clean tree with every gate pinned to the canonical version passes (and a
+// `canary` named only in a comment is ignored), while a divergent concrete pin,
+// a gate floated back to `canary`, a gate missing the pin, and a floating source
+// of truth each fail. Also runs the shipped contract against the real repo so
+// the guard stays true as workflows change. Deterministic — no workflow runs.
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { runContract } = await import(
+  new URL("../ci-bun-version-contract.mjs", import.meta.url).href
+);
+
+const REAL_REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+const CANONICAL = "1.3.14";
+
+const GATE_WORKFLOWS = [
+  "ci.yaml",
+  "test.yml",
+  "develop-exhaustive.yml",
+  "ci-full-matrix-proof.yml",
+  "benchmark-tests.yml",
+  "windows-desktop-preload-smoke.yml",
+  "feed-env-audit.yml",
+];
+
+// A gate stub that pins via a BUN_VERSION env literal and references it from the
+// step by expression — the shape the real gates use. The comment naming
+// `canary` proves the contract reads YAML wiring, not prose.
+function gateStub(version = CANONICAL): string {
+  return `name: Gate
+on: [push]
+env:
+  # pinned: floating canary writes lockfileVersion 2 and breaks --frozen-lockfile
+  BUN_VERSION: "${version}"
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: \${{ env.BUN_VERSION }}
+`;
+}
+
+const GATE_FLOATING = `name: Gate
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: canary
+`;
+
+const GATE_NO_PIN = `name: Gate
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "no bun setup here"
+`;
+
+// A non-gate workflow carrying a concrete pin that diverges from canonical.
+function driftWorkflow(version: string): string {
+  return `name: Drift
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "${version}"
+`;
+}
+
+function buildRepo({
+  version = CANONICAL,
+  overrides = {},
+  extra = {},
+}: {
+  version?: string;
+  overrides?: Record<string, string>;
+  extra?: Record<string, string>;
+}): string {
+  const root = mkdtempSync(join(tmpdir(), "ci-bun-version-contract-"));
+  mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+  writeFileSync(
+    join(root, ".github", "ci-bun-version.json"),
+    JSON.stringify({ version }),
+  );
+  for (const name of GATE_WORKFLOWS) {
+    writeFileSync(
+      join(root, ".github", "workflows", name),
+      overrides[name] ?? gateStub(),
+    );
+  }
+  for (const [name, content] of Object.entries(extra)) {
+    writeFileSync(join(root, ".github", "workflows", name), content);
+  }
+  return root;
+}
+
+describe("ci-bun-version-contract", () => {
+  test("passes a clean tree with every gate pinned to canonical", () => {
+    const root = buildRepo({});
+    try {
+      const { canonical, gateWorkflows } = runContract(root);
+      expect(canonical).toBe(CANONICAL);
+      expect(gateWorkflows).toEqual(GATE_WORKFLOWS);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails when a concrete pin diverges from the source of truth", () => {
+    const root = buildRepo({ extra: { "drift.yml": driftWorkflow("1.3.99") } });
+    try {
+      expect(() => runContract(root)).toThrow(
+        /canonical CI Bun version is 1\.3\.14/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails when a gate workflow floats back to canary", () => {
+    const root = buildRepo({ overrides: { "test.yml": GATE_FLOATING } });
+    try {
+      expect(() => runContract(root)).toThrow(/wires floating Bun/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails when a gate workflow drops the canonical pin entirely", () => {
+    const root = buildRepo({ overrides: { "ci.yaml": GATE_NO_PIN } });
+    try {
+      expect(() => runContract(root)).toThrow(
+        /does not wire the canonical Bun pin/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails when the source of truth itself floats", () => {
+    const root = buildRepo({ version: "canary" });
+    try {
+      expect(() => runContract(root)).toThrow(/must be a concrete Bun pin/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("the real repo satisfies the contract", () => {
+    const { canonical, gateWorkflows } = runContract(REAL_REPO_ROOT);
+    expect(canonical).toBe(CANONICAL);
+    expect(gateWorkflows.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/scripts/ci-bun-version-contract.mjs
+++ b/packages/scripts/ci-bun-version-contract.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * Contract for the pinned CI Bun version (#13402 item 2 + item 5). Keeps the
+ * frozen-lockfile install path on ONE concrete Bun version so a stale bump or a
+ * regression back to floating `canary`/`latest` cannot slip through unnoticed.
+ *
+ * Background: `bun install --frozen-lockfile` fails when Bun reserializes
+ * bun.lock to lockfileVersion 2, which floating `canary`/`latest` do on their
+ * own cadence (#11184/#9454); the repo's packageManager `bun@1.4.0-canary.1` is
+ * also unresolvable in CI. So the required test/build gates pin a concrete Bun
+ * version rather than tracking the moving channel. The canonical value lives in
+ * `.github/ci-bun-version.json` — GitHub Actions cannot interpolate a file into
+ * `${{ }}` at parse time, so the literal is repeated in each workflow and this
+ * contract is what guarantees those copies never drift from the source of truth.
+ *
+ * Two invariants, checked statically against the checked-in YAML (no workflow is
+ * executed):
+ *
+ *   1. No divergent concrete pin. Every `bun-version:`/`BUN_VERSION:` value in
+ *      `.github/workflows` that is a concrete version (a semver, not a `${{ }}`
+ *      expression and not floating `canary`/`latest`) must equal the canonical
+ *      version. This catches a second concrete pin drifting away from the rest.
+ *
+ *   2. The frozen-lockfile gate workflows stay pinned. Each workflow in
+ *      GATE_WORKFLOWS — the required/scheduled lanes that run a frozen install —
+ *      must wire the canonical pin (as a `BUN_VERSION`/`bun-version` literal) and
+ *      must NOT wire floating `canary`/`latest`. This catches a regression that
+ *      unpins a gate back onto the moving channel.
+ *
+ * Intentionally silent about non-gate workflows that track `canary`/`latest` on
+ * purpose (benchmarks, some release/build lanes). Narrowing those is a separate
+ * judgement call under #13402 item 2; this contract only locks the concrete-pin
+ * source of truth and the frozen-install gates.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_REPO_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+
+const VERSION_FILE = ".github/ci-bun-version.json";
+const WORKFLOW_DIR = ".github/workflows";
+
+// The frozen-lockfile install lanes that must stay on the concrete pin. Each
+// documents the `--frozen-lockfile` rationale inline; the required `ci-ok`
+// aggregate (test.yml) and the main gate (ci.yaml) are the load-bearing two.
+const GATE_WORKFLOWS = [
+  "ci.yaml",
+  "test.yml",
+  "develop-exhaustive.yml",
+  "ci-full-matrix-proof.yml",
+  "benchmark-tests.yml",
+  "windows-desktop-preload-smoke.yml",
+  "feed-env-audit.yml",
+];
+
+// A concrete pin: a plain semver, optionally with a prerelease/build suffix.
+// `canary`, `latest`, and `${{ ... }}` expressions deliberately do not match.
+const CONCRETE_PIN = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*$/;
+const FLOATING = new Set(["canary", "latest"]);
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+// Extract every `bun-version:`/`BUN_VERSION:` value wired in a workflow, as
+// `{ key, raw }` with the inline comment and surrounding quotes stripped. Only
+// real YAML key wiring counts — a version named in a `#` comment (e.g. the
+// unresolvable `bun@1.4.0-canary.1` rationale) is never treated as a pin.
+function bunVersionValues(text) {
+  const out = [];
+  for (const line of text.split("\n")) {
+    const match = line.match(
+      /^\s*(?:-\s+)?(bun-version|BUN_VERSION):\s*(.+?)\s*$/,
+    );
+    if (!match) continue;
+    let raw = match[2].replace(/\s+#.*$/, "").trim();
+    if (raw.startsWith('"') || raw.startsWith("'")) {
+      raw = raw.slice(1, -1);
+    }
+    out.push({ key: match[1], raw });
+  }
+  return out;
+}
+
+function isExpression(raw) {
+  return raw.includes("${{");
+}
+
+// Validate both invariants against a repo layout rooted at `repoRoot`. Pure
+// (no process exit / no console) so tests can drive it against fixture trees;
+// throws on the first violation, returns the canonical version and the scanned
+// concrete-pin sites on success.
+export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
+  const read = (rel) => readFileSync(resolve(repoRoot, rel), "utf8");
+
+  const manifest = JSON.parse(read(VERSION_FILE));
+  const canonical = manifest.version;
+  assert(
+    typeof canonical === "string" && CONCRETE_PIN.test(canonical),
+    `${VERSION_FILE}: "version" must be a concrete Bun pin (semver), got ${JSON.stringify(canonical)}`,
+  );
+  assert(
+    !FLOATING.has(canonical),
+    `${VERSION_FILE}: "version" must not float (${canonical})`,
+  );
+
+  const workflowFiles = readdirSync(resolve(repoRoot, WORKFLOW_DIR)).filter(
+    (name) => name.endsWith(".yml") || name.endsWith(".yaml"),
+  );
+
+  // --- Invariant 1: no concrete pin diverges from the source of truth. ---
+  const concretePins = [];
+  for (const name of workflowFiles) {
+    const rel = join(WORKFLOW_DIR, name);
+    for (const { raw } of bunVersionValues(read(rel))) {
+      if (isExpression(raw) || FLOATING.has(raw) || !CONCRETE_PIN.test(raw)) {
+        continue;
+      }
+      assert(
+        raw === canonical,
+        `${rel}: pins Bun ${raw}, but the canonical CI Bun version is ${canonical} ` +
+          `(${VERSION_FILE}). Update this workflow or bump the source of truth — keep them in lockstep.`,
+      );
+      concretePins.push({ workflow: rel, version: raw });
+    }
+  }
+
+  // --- Invariant 2: the frozen-install gate lanes stay pinned. ---
+  for (const name of GATE_WORKFLOWS) {
+    const rel = join(WORKFLOW_DIR, name);
+    const text = read(rel);
+    const values = bunVersionValues(text);
+
+    const floats = values.find(
+      (v) => !isExpression(v.raw) && FLOATING.has(v.raw),
+    );
+    assert(
+      floats === undefined,
+      `${rel}: is a frozen-lockfile gate but wires floating Bun "${floats?.raw}". ` +
+        `It must stay pinned to ${canonical} (${VERSION_FILE}) so --frozen-lockfile does not break.`,
+    );
+
+    const pinsCanonical = values.some((v) => v.raw === canonical);
+    assert(
+      pinsCanonical,
+      `${rel}: is a frozen-lockfile gate but does not wire the canonical Bun pin ${canonical} ` +
+        `(${VERSION_FILE}). Expected a BUN_VERSION/bun-version: "${canonical}" literal.`,
+    );
+  }
+
+  return { canonical, concretePins, gateWorkflows: GATE_WORKFLOWS };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    const { canonical, concretePins, gateWorkflows } = runContract();
+    console.log(
+      `ci bun version contract passed (canonical ${canonical}; ` +
+        `${concretePins.length} concrete pin(s) in lockstep; ${gateWorkflows.length} gate lane(s) pinned)`,
+    );
+  } catch (error) {
+    console.error(`[ci-bun-version-contract] FAIL ${error.message}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## What landed

Advances **#13402** — the **Bun-version slice only** (issue scope item **2** "standardize Bun version handling ... use one source of truth ... keep installs fail-closed on lockfile drift", plus its item **5** contract sub-bullet "Bun version/frozen-lockfile policy is enforced"). This does **not** touch the duplicate-suite census (item 1), the Windows shard restructure (item 3), or the affected-cone selection (item 4) — those stay open for other lanes. Precondition met: #13363 is merged and its three CI contracts already gate in `test.yml`; this adds the fourth, following the exact same pattern.

Additive — **no workflow behavior changes**:

- **`.github/ci-bun-version.json`** — the single source of truth for the pinned CI Bun version (`1.3.14`), with the `--frozen-lockfile` rationale inline. GitHub Actions can't interpolate a file into `${{ }}` at parse time, so each gate workflow keeps its literal; this file + the contract are what stop those copies drifting.
- **`packages/scripts/ci-bun-version-contract.mjs`** — a static contract (no workflow runs) with two invariants:
  1. **No divergent concrete pin.** Every concrete `bun-version:`/`BUN_VERSION:` value in `.github/workflows` (a semver — not a `${{ }}` expression, not floating `canary`/`latest`) must equal the canonical version.
  2. **Gate lanes stay pinned.** The 7 frozen-lockfile gate workflows (`ci.yaml`, `test.yml`, `develop-exhaustive.yml`, `ci-full-matrix-proof.yml`, `benchmark-tests.yml`, `windows-desktop-preload-smoke.yml`, `feed-env-audit.yml`) must wire the canonical pin and must **not** float to `canary`/`latest` — the exact regression the pin rationale documents (#11184/#9454: floating canary reserializes `bun.lock` to lockfileVersion 2 and breaks `--frozen-lockfile`).

  It is intentionally silent about non-gate workflows that track `canary`/`latest` on purpose (benchmarks, some release/build lanes) — narrowing those is a separate judgement call under item 2.
- **`packages/scripts/__tests__/ci-bun-version-contract.test.ts`** — positive + comment-safety + four negative fixtures (divergent concrete pin, gate floated to canary, gate missing the pin, floating source of truth) + a real-repo assertion.
- **`.github/workflows/test.yml`** — runs the contract in the `changes` job beside the existing `ci-workflow-dedup-contract` / `ci-turbo-cache-contract` steps, so a drift or unpin fails the branch's CI (and the `ci-ok` merge-queue aggregate).

## Verification evidence (run in lane-8 off `origin/develop` @ `f0307874a`)

- `node packages/scripts/ci-bun-version-contract.mjs` →
  `ci bun version contract passed (canonical 1.3.14; 10 concrete pin(s) in lockstep; 7 gate lane(s) pinned)` (exit 0)
- `bun test packages/scripts/__tests__/ci-bun-version-contract.test.ts` → **6 pass / 0 fail**, 8 expect() calls
- `bunx @biomejs/biome check <the 3 new/edited source files>` → **No fixes applied** (clean, after formatting)
- `actionlint .github/workflows/test.yml` → the added `Validate CI Bun version pin contract` step is clean; the only findings are **pre-existing** `hetzner-robot` self-hosted-label warnings (lines 117–1220, untouched by this PR)
- `git diff --check` → clean (no whitespace errors)
- **Real-repo negative proof:** bumping only `.github/ci-bun-version.json` to `1.3.15` (workflows still `1.3.14`) → contract **fails**:
  `FAIL .github/workflows/benchmark-tests.yml: pins Bun 1.3.14, but the canonical CI Bun version is 1.3.15 ... keep them in lockstep.` — restored to green.

## Evidence rows (PR_EVIDENCE.md)

CI-contract / tooling change with no user-visible surface. UI screenshots, model trajectories, audio, native/device captures, and product-domain artifacts are **N/A — this PR only adds a static CI YAML contract + its self-test; it runs no agent, renders no UI, and touches no product runtime path.** Test evidence is the contract + self-test output above.

## Deviations

None from the taken slice. The remaining #13402 items (1, 3, 4) are explicitly out of scope and left for other lanes.

Advances #13402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
