### PR TITLE
fix(cloud): bind Stripe cache to current Worker env

### DIFF
--- a/packages/cloud/shared/src/lib/stripe.guard.test.ts
+++ b/packages/cloud/shared/src/lib/stripe.guard.test.ts
@@ -22,6 +22,7 @@ import { __resetStripeForTests, getStripe, isStripeConfigured } from "./stripe";
 // flag these obviously-fake fixtures as real Stripe keys.
 const LIVE_KEY = ["sk", "live", "FakeKeyForGuardTests000000"].join("_");
 const TEST_KEY = ["sk", "test", "FakeKeyForGuardTests000000"].join("_");
+const RESTRICTED_LIVE_KEY = ["rk", "live", "FakeKeyForGuardTests000000"].join("_");
 
 afterEach(() => {
   __resetStripeForTests();
@@ -145,6 +146,49 @@ describe("stripe client init guard (via Worker bindings)", () => {
     runWithCloudBindings({ STRIPE_SECRET_KEY: TEST_KEY, ENVIRONMENT: "production" }, () => {
       expect(isStripeConfigured()).toBe(true);
       expect(() => getStripe()).not.toThrow();
+    });
+  });
+
+  it("does not reuse a cached production live client under a later staging live binding", () => {
+    runWithCloudBindings({ STRIPE_SECRET_KEY: LIVE_KEY, ENVIRONMENT: "production" }, () => {
+      expect(isStripeConfigured()).toBe(true);
+      expect(() => getStripe()).not.toThrow();
+    });
+
+    runWithCloudBindings({ STRIPE_SECRET_KEY: LIVE_KEY, ENVIRONMENT: "staging" }, () => {
+      expect(isStripeConfigured()).toBe(false);
+      expect(() => getStripe()).toThrow(/LIVE-mode key .* not production/);
+    });
+  });
+
+  it("does not reuse a cached staging test client under a later staging live binding", () => {
+    runWithCloudBindings({ STRIPE_SECRET_KEY: TEST_KEY, ENVIRONMENT: "staging" }, () => {
+      expect(isStripeConfigured()).toBe(true);
+      expect(() => getStripe()).not.toThrow();
+    });
+
+    runWithCloudBindings({ STRIPE_SECRET_KEY: LIVE_KEY, ENVIRONMENT: "staging" }, () => {
+      expect(isStripeConfigured()).toBe(false);
+      expect(() => getStripe()).toThrow(/LIVE-mode key .* not production/);
+    });
+  });
+
+  it("recovers when a later binding is valid after an earlier binding failed closed", () => {
+    runWithCloudBindings({ STRIPE_SECRET_KEY: LIVE_KEY, ENVIRONMENT: "staging" }, () => {
+      expect(isStripeConfigured()).toBe(false);
+      expect(() => getStripe()).toThrow(/LIVE-mode key .* not production/);
+    });
+
+    runWithCloudBindings({ STRIPE_SECRET_KEY: TEST_KEY, ENVIRONMENT: "staging" }, () => {
+      expect(isStripeConfigured()).toBe(true);
+      expect(() => getStripe()).not.toThrow();
+    });
+  });
+
+  it("restricted live keys fail through the live-key guard outside production", () => {
+    runWithCloudBindings({ STRIPE_SECRET_KEY: RESTRICTED_LIVE_KEY, ENVIRONMENT: "staging" }, () => {
+      expect(isStripeConfigured()).toBe(false);
+      expect(() => getStripe()).toThrow(/LIVE-mode key .* not production/);
     });
   });
 });

--- a/packages/cloud/shared/src/lib/stripe.ts
+++ b/packages/cloud/shared/src/lib/stripe.ts
@@ -38,27 +38,44 @@ const STRIPE_API_VERSION: PinnedStripeApiVersion = "2024-11-20.acacia";
 
 let stripeInstance: Stripe | null = null;
 let stripeInitError: Error | null = null;
+let stripeCacheKey: string | null = null;
+
+function isPotentialStripeSecretKey(key: string): boolean {
+  return key.startsWith("sk_") || key.startsWith("rk_");
+}
+
+function buildStripeCacheKey(
+  env: Record<string, string | undefined>,
+  secretKey: string | undefined,
+): string {
+  return [env.ENVIRONMENT ?? "", env.NODE_ENV ?? "", secretKey ?? "missing"].join("\0");
+}
 
 /**
  * Get the Stripe client instance (lazy initialization).
  * Returns null if STRIPE_SECRET_KEY is not configured.
  */
 function initStripe(): Stripe | null {
-  if (stripeInstance) return stripeInstance;
-  if (stripeInitError) return null;
-
   const env = getCloudAwareEnv();
   const secretKey = env.STRIPE_SECRET_KEY?.trim();
+  const cacheKey = buildStripeCacheKey(env, secretKey);
+
+  if (stripeInstance && stripeCacheKey === cacheKey) return stripeInstance;
+  if (stripeInitError && stripeCacheKey === cacheKey) return null;
 
   if (!secretKey) {
     stripeInitError = new Error("STRIPE_SECRET_KEY is not set in environment variables");
+    stripeInstance = null;
+    stripeCacheKey = cacheKey;
     return null;
   }
 
-  if (!secretKey.startsWith("sk_")) {
+  if (!isPotentialStripeSecretKey(secretKey)) {
     stripeInitError = new Error(
-      `STRIPE_SECRET_KEY appears invalid (should start with 'sk_', got '${secretKey.substring(0, 3)}...'). Please verify your Stripe configuration.`,
+      `STRIPE_SECRET_KEY appears invalid (should start with 'sk_' or 'rk_', got '${secretKey.substring(0, 3)}...'). Please verify your Stripe configuration.`,
     );
+    stripeInstance = null;
+    stripeCacheKey = cacheKey;
     return null;
   }
 
@@ -70,6 +87,8 @@ function initStripe(): Stripe | null {
     stripeInitError = new Error(
       "SECURITY: STRIPE_SECRET_KEY is a LIVE-mode key (sk_live_/rk_live_) but this deployment is not production (ENVIRONMENT/NODE_ENV). Refusing to initialize Stripe: live keys outside prod let checkouts charge real money into a non-prod database (#13752). Bind a test-mode key (sk_test_) to this environment.",
     );
+    stripeInstance = null;
+    stripeCacheKey = cacheKey;
     logger.error(`[Stripe] ${stripeInitError.message}`);
     return null;
   }
@@ -86,6 +105,8 @@ function initStripe(): Stripe | null {
     typescript: true,
     apiVersion: STRIPE_API_VERSION as StripeConstructorConfig["apiVersion"],
   });
+  stripeInitError = null;
+  stripeCacheKey = cacheKey;
   return stripeInstance;
 }
 
@@ -126,7 +147,7 @@ export function requireStripe(): Stripe {
 export function isStripeConfigured(): boolean {
   const env = getCloudAwareEnv();
   const key = env.STRIPE_SECRET_KEY?.trim();
-  if (!key || !key.startsWith("sk_")) {
+  if (!key || !isPotentialStripeSecretKey(key)) {
     return false;
   }
   // A live key outside production is treated as NOT configured (#13752):
@@ -162,6 +183,7 @@ export function assertStripeConfigured(): void {
 export function __resetStripeForTests(): void {
   stripeInstance = null;
   stripeInitError = null;
+  stripeCacheKey = null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- bind the module-level Stripe client/error cache to the current Worker environment and secret binding before reuse
- clear stale cached clients when a later binding is missing, invalid, or blocked by the live-key guard
- treat restricted `rk_` keys consistently with `sk_` keys in configuration checks and regression tests

## Verification
- `bun run --cwd packages/shared build:i18n`
- `bun test src/lib/config/deployment-environment.test.ts src/lib/config/deployment-environment.gates.test.ts src/lib/services/stripe-connect-payout.test.ts src/lib/stripe.guard.test.ts` (40 pass)
- `bunx biome check src/lib/config/deployment-environment.ts src/lib/stripe.ts src/lib/stripe.guard.test.ts`
- `git diff --check`
- `bun run typecheck` currently fails on existing package-wide declaration-resolution noise from `dist/node_modules`/plugin-sql; touched-file filter shows only the pre-existing `src/lib/stripe.ts(26,20)` missing declaration for module `stripe`.

## Evidence
- N/A screenshots/video: backend Stripe configuration guard only.
- N/A live Stripe calls: fake key fixtures intentionally avoid contacting Stripe while exercising the real guard path.