### PR TITLE
fix(#13637): character username invalid/empty returns 400 not 500

### DIFF
--- a/packages/cloud/shared/src/lib/services/characters/characters.test.ts
+++ b/packages/cloud/shared/src/lib/services/characters/characters.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for CharactersService.create's username handling (#13637 class,
+ * completing the slice #13706 left open for name/#13761 closed for name).
+ * Blank usernames are provided-but-unset and must auto-generate; a genuinely
+ * invalid provided username must fail as caller error (400 ValidationError),
+ * never a raw 500. Repositories and cache are mocked; the real
+ * validateUsername/generateUniqueUsername logic runs unmocked.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { NewUserCharacter } from "../../../db/schemas/user-characters";
+
+const usernameExistsCalls: string[] = [];
+const createCalls: Array<{ username?: string | null }> = [];
+const agentCreateCalls: unknown[] = [];
+const cacheDelCalls: string[] = [];
+
+let usernameExistsResult = false;
+let existingUsernames = new Set<string>();
+
+// Mock the submodule characters.ts imports through the "../../../db/repositories"
+// barrel (which re-exports "./characters"), not the barrel itself — the barrel
+// also re-exports unrelated repositories (apiKeysRepository, etc.) that other
+// modules in the same import graph (usersService) need untouched.
+mock.module("../../../db/repositories/characters", () => ({
+  userCharactersRepository: {
+    usernameExists: async (username: string) => {
+      usernameExistsCalls.push(username);
+      return usernameExistsResult;
+    },
+    create: async (data: { username?: string | null }) => {
+      createCalls.push(data);
+      return { id: "char-1", ...data };
+    },
+    getAllUsernames: async () => existingUsernames,
+  },
+}));
+
+mock.module("../../../db/repositories/agents/agents", () => ({
+  agentsRepository: {
+    create: async (agent: unknown) => {
+      agentCreateCalls.push(agent);
+      return true;
+    },
+  },
+}));
+
+mock.module("../../cache/client", () => ({
+  cache: {
+    del: async (key: string) => {
+      cacheDelCalls.push(key);
+    },
+  },
+}));
+
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+
+function baseData(overrides: Record<string, unknown> = {}): NewUserCharacter {
+  return {
+    organization_id: ORG_ID,
+    user_id: USER_ID,
+    name: "Test Character",
+    bio: ["A test character"],
+    character_data: {},
+    ...overrides,
+  } as never;
+}
+
+describe("CharactersService.create — username handling (#13637 class)", () => {
+  beforeEach(() => {
+    usernameExistsCalls.length = 0;
+    createCalls.length = 0;
+    agentCreateCalls.length = 0;
+    cacheDelCalls.length = 0;
+    usernameExistsResult = false;
+    existingUsernames = new Set<string>();
+  });
+
+  test("empty string username auto-generates (empty-is-unset contract), no throw", async () => {
+    const { charactersService } = await import("./characters");
+
+    const character = await charactersService.create(baseData({ username: "" }));
+
+    expect(createCalls).toHaveLength(1);
+    const created = createCalls[0];
+    expect(created.username).toBeTruthy();
+    expect(created.username).not.toBe("");
+    expect(character.id).toBe("char-1");
+  });
+
+  test("too-short provided username throws ValidationError -> 400, not a plain Error/500", async () => {
+    const { charactersService } = await import("./characters");
+    const { ApiError } = await import("../../api/cloud-worker-errors");
+
+    let caught: unknown;
+    try {
+      await charactersService.create(baseData({ username: "ab" }));
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ApiError);
+    const apiError = caught as InstanceType<typeof ApiError>;
+    expect(apiError.status).toBe(400);
+    expect(apiError.code).toBe("validation_error");
+    expect(apiError.message).toContain("Invalid username");
+    expect(createCalls).toHaveLength(0);
+  });
+
+  test("valid provided username is normalized, checked for uniqueness, and used as-is", async () => {
+    const { charactersService } = await import("./characters");
+
+    const character = await charactersService.create(baseData({ username: "Valid-Name" }));
+
+    expect(usernameExistsCalls).toEqual(["valid-name"]);
+    expect(createCalls[0].username).toBe("valid-name");
+    expect(character.id).toBe("char-1");
+  });
+
+  test("non-string username (shape mismatch) still throws ValidationError -> 400", async () => {
+    const { charactersService } = await import("./characters");
+    const { ApiError } = await import("../../api/cloud-worker-errors");
+
+    let caught: unknown;
+    try {
+      await charactersService.create(baseData({ username: 42 }));
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ApiError);
+    const apiError = caught as InstanceType<typeof ApiError>;
+    expect(apiError.status).toBe(400);
+    expect(apiError.code).toBe("validation_error");
+    expect(createCalls).toHaveLength(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/characters/characters.ts
+++ b/packages/cloud/shared/src/lib/services/characters/characters.ts
@@ -206,7 +206,8 @@ export class CharactersService {
   async create(data: NewUserCharacter): Promise<UserCharacter> {
     // Generate username if not provided
     let username = data.username;
-    if (username === undefined || username === null) {
+    if (username === undefined || username === null || username === "") {
+      // Blank is provided-but-unset (empty-is-unset contract), same as omitting the field.
       username = await this.generateUniqueUsername(data.name);
       logger.info(`[Characters] Generated username: @${username} for "${data.name}"`);
     } else if (typeof username !== "string") {
@@ -219,7 +220,9 @@ export class CharactersService {
       // Validate provided username
       const validation = validateUsername(username);
       if (!validation.valid) {
-        throw new Error(`Invalid username: ${validation.error}`);
+        // A genuinely-invalid provided username is caller error, not a server
+        // fault (#13637 class) — matches the non-string branch above.
+        throw ValidationError(`Invalid username: ${validation.error}`);
       }
 
       // Use normalized (lowercased) username from validation


### PR DESCRIPTION
## Summary

`CharactersService.create()` (`packages/cloud/shared/src/lib/services/characters/characters.ts`) has two remaining shape-mismatch-500 defects in the #13637 class that #13706 left unfixed (it fixed the non-string branch and the `name`/`bio`/etc. fields; #13761 completed the slice for `name`). Both are in the username-validation branch:

1. **Empty string is not treated as unset.** `{username: ""}` is provided-but-blank. Every other branch here follows the "empty-is-unset" contract, but `""` fell through to `validateUsername("")`, which fails the min-length check and throws — instead of being treated the same as omitting the field (auto-generate).
2. **Invalid provided username throws a plain `Error`, not `ValidationError`.** Any genuinely-invalid username (too short, too long, bad chars, reserved) threw `new Error(...)`. `failureResponse`/`inferStatusFromLegacyError` (`packages/cloud/shared/src/lib/api/cloud-worker-errors.ts`) only special-cases specific substrings (`"not found"`, `"forbidden"`, `"rate limit"`, etc.); `validateUsername`'s messages ("Username must be at least 3 characters", "Username can only contain lowercase letters, numbers, and hyphens", …) match none of them, so `inferStatusFromLegacyError` falls through to its final `return 500`. The sibling non-string branch a few lines above already throws `ValidationError(...)` for exactly this reason — this fix makes the format-validation branch match it.

Confirmed the mapping directly in `cloud-worker-errors.ts`: `ValidationError(message)` constructs an `ApiError(400, "validation_error", message)`, and `failureResponse` returns `error.status` (400) for any `ApiError` instance; a plain `Error` instead goes through `inferStatusFromLegacyError`, which returns 500 for these messages.

This is a real, reachable path: `packages/cloud/api/my-agents/characters/route.ts` builds `NewUserCharacter` with `username: elizaCharacter.username ?? null` — `??` does not catch an empty string, so a client-submitted blank username field reaches `create()` as `""` today and 500s.

## Fix

```diff
-    if (username === undefined || username === null) {
+    if (username === undefined || username === null || username === "") {
+      // Blank is provided-but-unset (empty-is-unset contract), same as omitting the field.
       username = await this.generateUniqueUsername(data.name);
...
       if (!validation.valid) {
-        throw new Error(`Invalid username: ${validation.error}`);
+        // A genuinely-invalid provided username is caller error, not a server
+        // fault (#13637 class) — matches the non-string branch above.
+        throw ValidationError(`Invalid username: ${validation.error}`);
       }
```

Minimal, scoped to `create()`'s username branch only — no change to uniqueness checking, normalization, or the auto-generate path itself.

## Test

Added `packages/cloud/shared/src/lib/services/characters/characters.test.ts` (repositories + cache mocked via `mock.module`, following the existing `steward-sync-grant.test.ts` pattern in this package; the real `validateUsername`/`generateUniqueUsername` logic runs unmocked):

- `{username: ""}` → auto-generates, no throw, character created.
- `{username: "ab"}` (too short) → throws, `error instanceof ApiError`, `status === 400`, `code === "validation_error"` — not a bare `Error`.
- `{username: "Valid-Name"}` → normalized to `valid-name`, uniqueness checked, created as-is.
- `{username: 42}` (non-string, pre-existing #13706 guard) → still `ApiError` with `status === 400`.

### Test output

```
bun test v1.4.0-canary.1 (64ae83c2f)

 4 pass
 0 fail
 16 expect() calls
Ran 4 tests across 1 file.
```

### Typecheck

`bun run --cwd packages/cloud/shared typecheck` — no new errors introduced by this change (confirmed by diffing error counts before/after; pre-existing noise in this package is unrelated missing `drizzle-orm` type declarations in the sandboxed install, called out in `packages/cloud/shared/CLAUDE.md`).

### Lint

`bunx biome check` on both changed files — clean, no fixes needed.

Refs #13637, #13706, #13761.

## Test plan

- [x] `bun test packages/cloud/shared/src/lib/services/characters/characters.test.ts` — 4/4 pass
- [x] `bunx biome check` on changed files — clean
- [x] `git diff` reviewed — minimal, only touches `characters.ts` (2 lines changed + comments) and the new test file
- [x] Traced the real caller (`my-agents/characters/route.ts`) that lets an empty-string username reach this code path today

🤖 Generated with [Claude Code](https://claude.com/claude-code)