### PR TITLE
fix(#13771): wire the orchestrator `failed` task producer + legal-transition table

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-failed-lifecycle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-failed-lifecycle.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Pins the `failed` task-lifecycle producer and the legal-transition table
+ * (#13771). Drives the real ACP→task event bridge on an in-memory store: an
+ * unrecoverable session `error` must advance the durable task to terminal
+ * `failed`, a resumable `session_state_lost` must NOT (the router re-spawns it),
+ * and `advanceTaskStatus` must reject transitions the table forbids. The table
+ * predicate itself is also unit-tested directly.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
+import {
+  isLegalTaskStatusTransition,
+  type OrchestratorTaskStatus,
+} from "../../src/services/orchestrator-task-types.js";
+
+// The default-criteria contract would auto-populate acceptance criteria and
+// change the validating/completion path; disable it so these tasks exercise the
+// plain criteria-free lifecycle this suite targets.
+beforeAll(() => {
+  process.env.ELIZA_REQUIRE_GOAL_CONTRACT = "0";
+});
+
+interface SpawnResult {
+  sessionId: string;
+  agentType: string;
+  workdir: string;
+  status: string;
+}
+
+/** Minimal AcpService stand-in that captures the orchestrator's session-event
+ * subscription so a test can drive real events through the bridge. */
+class FakeAcp {
+  private handler:
+    | ((sessionId: string, event: string, data: unknown) => void)
+    | null = null;
+  private counter = 0;
+  readonly stopped: string[] = [];
+
+  onSessionEvent(
+    cb: (sessionId: string, event: string, data: unknown) => void,
+  ): () => void {
+    this.handler = cb;
+    return () => {
+      this.handler = null;
+    };
+  }
+
+  emit(sessionId: string, event: string, data: unknown = {}): void {
+    this.handler?.(sessionId, event, data);
+  }
+
+  spawnSession(opts: Record<string, unknown>): Promise<SpawnResult> {
+    this.counter += 1;
+    return Promise.resolve({
+      sessionId: `session-${this.counter}`,
+      agentType: (opts.agentType as string | undefined) ?? "codex",
+      workdir: (opts.workdir as string | undefined) ?? "/repo",
+      status: "ready",
+    });
+  }
+
+  sendToSession(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  stopSession(sessionId: string): Promise<void> {
+    this.stopped.push(sessionId);
+    return Promise.resolve();
+  }
+}
+
+const warn = vi.fn();
+
+function runtime(acp?: FakeAcp): IAgentRuntime {
+  return {
+    getService: () => acp ?? null,
+    logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+  } as never;
+}
+
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+async function drive(
+  acp: FakeAcp,
+  sessionId: string,
+  event: string,
+  data: unknown = {},
+): Promise<void> {
+  acp.emit(sessionId, event, data);
+  await flush();
+}
+
+function must<T>(value: T | null | undefined, message: string): T {
+  if (value === null || value === undefined) throw new Error(message);
+  return value;
+}
+
+async function withSpawnedSession(): Promise<{
+  service: OrchestratorTaskService;
+  store: OrchestratorTaskStore;
+  acp: FakeAcp;
+  taskId: string;
+  sessionId: string;
+}> {
+  const acp = new FakeAcp();
+  const store = new OrchestratorTaskStore({ backend: "memory" });
+  const service = new OrchestratorTaskService(runtime(acp), { store });
+  await service.start();
+  const task = await service.createTask({
+    title: "Ship feature",
+    goal: "Implement and verify",
+  });
+  const detail = must(
+    await service.spawnAgentForTask(task.id),
+    "expected spawn detail",
+  );
+  const sessionId = must(detail.sessions[0], "expected session").sessionId;
+  return { service, store, acp, taskId: task.id, sessionId };
+}
+
+describe("orchestrator task `failed` producer (#13771)", () => {
+  it("drives the durable task to terminal `failed` on an unrecoverable session error", async () => {
+    const { service, acp, taskId, sessionId } = await withSpawnedSession();
+    expect((await service.getTask(taskId))?.status).toBe("active");
+
+    await drive(acp, sessionId, "error", {
+      failureKind: "crash",
+      message: "sub-agent process exited with code 1",
+    });
+
+    const detail = must(await service.getTask(taskId), "detail");
+    expect(detail.status).toBe("failed");
+    expect(must(detail.sessions[0], "session").status).toBe("errored");
+  });
+
+  it("does NOT fail the task on a resumable `session_state_lost` — the router re-spawns it", async () => {
+    const { service, acp, taskId, sessionId } = await withSpawnedSession();
+
+    await drive(acp, sessionId, "error", {
+      failureKind: "session_state_lost",
+      message: "session state lost mid-turn",
+    });
+
+    const detail = must(await service.getTask(taskId), "detail");
+    // Session is marked errored/stopped, but the TASK stays non-terminal so the
+    // router's deterministic respawn path can recover it.
+    expect(detail.status).toBe("active");
+    expect(must(detail.sessions[0], "session").status).toBe("errored");
+  });
+
+  it("marks failed even for an auth failure (no respawn producer exists for it)", async () => {
+    const { service, acp, taskId, sessionId } = await withSpawnedSession();
+
+    await drive(acp, sessionId, "error", {
+      failureKind: "auth",
+      message: "401 unauthorized",
+    });
+
+    expect((await service.getTask(taskId))?.status).toBe("failed");
+  });
+});
+
+describe("legal task-status transition table (#13771)", () => {
+  it("permits `failed` from every non-terminal working state and `done` only from validating", () => {
+    const nonTerminal: OrchestratorTaskStatus[] = [
+      "open",
+      "active",
+      "waiting_on_user",
+      "blocked",
+      "validating",
+      "interrupted",
+    ];
+    for (const from of nonTerminal) {
+      expect(isLegalTaskStatusTransition(from, "failed")).toBe(true);
+    }
+    expect(isLegalTaskStatusTransition("validating", "done")).toBe(true);
+    expect(isLegalTaskStatusTransition("active", "done")).toBe(false);
+    expect(isLegalTaskStatusTransition("open", "done")).toBe(false);
+  });
+
+  it("forbids any transition out of a terminal status", () => {
+    for (const from of ["done", "failed", "archived"] as const) {
+      for (const to of ["active", "failed", "done", "open"] as const) {
+        expect(isLegalTaskStatusTransition(from, to)).toBe(false);
+      }
+    }
+  });
+
+  it("advanceTaskStatus rejects an illegal transition, logs a warning, and leaves the task unchanged", async () => {
+    const { service, taskId } = await withSpawnedSession();
+    expect((await service.getTask(taskId))?.status).toBe("active");
+    warn.mockClear();
+
+    // `active → done` is not modeled (done is validating-only); the private
+    // status funnel is the real enforcement point, so drive it directly.
+    await (
+      service as unknown as {
+        advanceTaskStatus: (
+          id: string,
+          next: OrchestratorTaskStatus,
+        ) => Promise<void>;
+      }
+    ).advanceTaskStatus(taskId, "done");
+
+    expect((await service.getTask(taskId))?.status).toBe("active");
+    expect(warn).toHaveBeenCalledWith(
+      "[OrchestratorTaskService] rejected illegal task status transition",
+      expect.objectContaining({ from: "active", to: "done" }),
+    );
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -90,6 +90,7 @@ import { OrchestratorTaskStore } from "./orchestrator-task-store.js";
 import {
   type AttemptReflection,
   type CreateTaskInput,
+  isLegalTaskStatusTransition,
   MAX_ATTEMPT_REFLECTIONS,
   type OrchestratorAccountAssignment,
   type OrchestratorAccountOverview,
@@ -912,6 +913,18 @@ export class OrchestratorTaskService extends Service {
             message,
           );
         }
+        // A `session_state_lost` failure is resumable: the sub-agent router
+        // (respawnStateLost) deterministically re-spawns the child under a
+        // bounded cap, so the durable task must stay non-terminal for that
+        // recovery to land. Every other session error — non-zero exit, crash,
+        // unrecoverable auth/quota — has no respawn producer, so drive the task
+        // to the terminal `failed` status here. Without this the task is
+        // stranded in active/validating forever, waiting on the 3-minute stall
+        // watchdog or a human (#13771). `advanceTaskStatus` gates this through
+        // the legal-transition table, so a paused/terminal task is left alone.
+        if (failureKind !== "session_state_lost") {
+          await this.advanceTaskStatus(taskId, "failed");
+        }
         break;
       }
       case "stopped":
@@ -1369,8 +1382,23 @@ export class OrchestratorTaskService extends Service {
     if (TERMINAL_TASK_STATUSES.has(current)) return;
     if (doc.task.paused) return;
     if (next === current) return;
-    // `active` is the weakest signal: only promote into it from `open`.
+    // `active` is the weakest signal: only promote into it from `open`. A live
+    // event (ready/tool_running) arriving while the task already parked on a
+    // stronger state (blocked/validating/waiting_on_user) must not stomp it
+    // back to active — short out silently here rather than routing an ordinary
+    // event through the illegal-transition log below.
     if (next === "active" && current !== "open") return;
+    if (!isLegalTaskStatusTransition(current, next)) {
+      // A write the lifecycle table forbids means a caller wired a transition
+      // the state machine does not model. Surface it instead of silently
+      // corrupting the durable task status.
+      this.log("warn", "rejected illegal task status transition", {
+        taskId,
+        from: current,
+        to: next,
+      });
+      return;
+    }
     await this.store.updateTask(taskId, { status: next });
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
@@ -394,3 +394,79 @@ export const TERMINAL_TASK_SESSION_STATUSES: ReadonlySet<string> = new Set([
 
 export const TERMINAL_TASK_STATUSES: ReadonlySet<OrchestratorTaskStatus> =
   new Set(["done", "failed", "archived"]);
+
+/**
+ * Legal task-status transitions keyed by the current status. A task moves
+ * between working states as its sub-agent sessions report progress, parks on
+ * `waiting_on_user`/`blocked` when it needs input, and reaches exactly one
+ * terminal status (`done`, `failed`, `archived`) that it can never leave.
+ *
+ * Two invariants make this the single source of truth: `failed` is reachable
+ * from every non-terminal working state (a session can crash at any point), and
+ * `done` is reachable only from `validating` (completion is gated on
+ * verification). `advanceTaskStatus` enforces the map so an unmodeled write —
+ * e.g. the historically missing `failed` producer (#13771), or a stray attempt
+ * to jump straight to `done` without verifying — is rejected and logged rather
+ * than silently corrupting the durable task record.
+ */
+export const LEGAL_TASK_STATUS_TRANSITIONS: Record<
+  OrchestratorTaskStatus,
+  ReadonlySet<OrchestratorTaskStatus>
+> = {
+  open: new Set([
+    "active",
+    "waiting_on_user",
+    "blocked",
+    "validating",
+    "failed",
+    "interrupted",
+  ]),
+  active: new Set([
+    "waiting_on_user",
+    "blocked",
+    "validating",
+    "failed",
+    "interrupted",
+  ]),
+  waiting_on_user: new Set([
+    "active",
+    "blocked",
+    "validating",
+    "failed",
+    "interrupted",
+  ]),
+  blocked: new Set([
+    "active",
+    "waiting_on_user",
+    "validating",
+    "failed",
+    "interrupted",
+  ]),
+  validating: new Set([
+    "active",
+    "waiting_on_user",
+    "blocked",
+    "done",
+    "failed",
+    "interrupted",
+  ]),
+  interrupted: new Set([
+    "active",
+    "waiting_on_user",
+    "blocked",
+    "validating",
+    "failed",
+  ]),
+  done: new Set(),
+  failed: new Set(),
+  archived: new Set(),
+};
+
+/** Whether the task lifecycle permits moving directly from `from` to `to`.
+ * Terminal statuses have no outbound transitions. */
+export function isLegalTaskStatusTransition(
+  from: OrchestratorTaskStatus,
+  to: OrchestratorTaskStatus,
+): boolean {
+  return LEGAL_TASK_STATUS_TRANSITIONS[from]?.has(to) ?? false;
+}


### PR DESCRIPTION
Fixes #13771 (WS1 of epic #13766).

## Problem
The durable orchestrator task status was **never set to `failed`**. In `applySessionEvent` (`orchestrator-task-service.ts`), the session `error` event marked the SESSION `errored`, stopped it, and did account-health failover — but never advanced the durable TASK. A sub-agent that died with a non-zero exit / crash left its task stuck in `active`/`validating` **forever**, relying on the 3-minute stall watchdog or a human. `failed` was already in `TERMINAL_TASK_STATUSES` and the type/UI layer expected it, but it had **no producer**.

Task-status writes were also scattered with no single legal-transition table, so a missing/wrong transition could be reintroduced or silently applied.

## Fix (scoped to the `failed` producer + transition table)
1. **`failed` producer** — in the `error` case of `applySessionEvent`, after the existing auth/rate-limit account-health marking, advance the task to terminal `failed` for **every** failure *except* a resumable `session_state_lost`. `session_state_lost` is deterministically re-spawned by `SubAgentRouter.respawnStateLost` under a bounded cap, so that path must keep the task non-terminal; all other errors (non-zero exit, crash, unrecoverable auth/quota) have no respawn producer and now terminate deterministically.
2. **Legal-transition table** — added `LEGAL_TASK_STATUS_TRANSITIONS` + `isLegalTaskStatusTransition(from, to)` in `orchestrator-task-types.ts` as the single source of truth (`failed` reachable from every non-terminal working state; `done` only from `validating`; terminal statuses have no outbound edges). `advanceTaskStatus` now enforces it — an unmodeled transition is rejected and logged (`[OrchestratorTaskService] rejected illegal task status transition`) instead of corrupting task status. The existing `active`-only-from-`open` guard is preserved and short-circuits before the table check so ordinary live events don't log spurious warnings.

Out of scope by design (kept lighter per the issue): retry-counter reconciliation, general-crash bounded respawn, and `resumeTask` re-engagement symmetry.

## Tests — `__tests__/unit/task-failed-lifecycle.test.ts` (6, all real code paths)
Driven through the actual ACP→task event bridge on an in-memory store:
- (a) a session `error` event advances the task to `failed` (session marked `errored`).
- (b) a resumable `session_state_lost` error does **NOT** fail the task (stays `active` for router respawn).
- an `auth` failure also reaches `failed` (no respawn producer exists for it).
- (c) `advanceTaskStatus` rejects an illegal `active→done` transition, logs the warning, and leaves the task unchanged.
- direct predicate coverage: `failed` legal from all non-terminal states, `done` only from `validating`, no transition out of any terminal status.

## Evidence
```
bun run --cwd plugins/plugin-agent-orchestrator test __tests__/unit/task-failed-lifecycle.test.ts
  Test Files  1 passed (1)   Tests  6 passed (6)
```
Load-bearing check: neutralizing the producer (`if (false)`) fails exactly the two producer tests (`failed`/`auth`), then passes again once restored.
```
bun run --cwd plugins/plugin-agent-orchestrator test __tests__/unit/orchestrator-task-service.test.ts
  Test Files  1 passed (1)   Tests  61 passed (61)   # no regressions
```
`typecheck`: only pre-existing sparse-graph env errors (missing external module declarations — `git-workspace-service`, `drizzle-orm`, `coding-agent-adapters`, `fast-redact`); **none cite the touched files**. `biome check` on the three touched files is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)