### PR TITLE
fix(#13682): add windows packaged desktop smoke script

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "test:launch-qa:docs": "node packages/scripts/launch-qa/check-docs.mjs --scope=docs --json",
     "test:launch-qa": "bun test packages/scripts/launch-qa/*.test.ts && bun run test:launch-qa:docs && node packages/scripts/launch-qa/check-mobile-artifacts.mjs --json --allow-missing-generated && node packages/scripts/launch-qa/check-model-data.mjs --json && node packages/scripts/launch-qa/run.mjs --suite quick --dry-run",
     "test:launch-qa:release:dry": "node packages/scripts/launch-qa/run.mjs --suite release --dry-run",
+    "test:desktop:packaged": "bun run --cwd packages/app test:desktop:packaged",
+    "test:desktop:packaged:windows": "bun run --cwd packages/app test:desktop:packaged:windows",
     "generate:action-search-keywords": "node packages/scripts/generate-action-search-keywords.mjs && node packages/shared/scripts/generate-keywords.mjs --target ts",
     "lifeops-bench:manifest": "node --conditions=eliza-source --conditions=development --import tsx scripts/lifeops-bench/export-action-manifest.ts",
     "start": "bun run --cwd packages/agent start",

--- a/packages/scripts/audit-scripts.mjs
+++ b/packages/scripts/audit-scripts.mjs
@@ -163,6 +163,14 @@ const ROOT_CWD_WRAPPER_ALLOWLIST = new Map([
   ["dev:core", "day-to-day root core dev entrypoint"],
   ["test:hmr", "root release/regression gate for app HMR behavior"],
   [
+    "test:desktop:packaged",
+    "root release/regression gate for packaged desktop app startup behavior",
+  ],
+  [
+    "test:desktop:packaged:windows",
+    "root release/regression gate for the packaged Windows desktop smoke lane",
+  ],
+  [
     "test:apple-entitlements",
     "root release/regression gate for app entitlement checks",
   ],


### PR DESCRIPTION
## Summary
- add root `test:desktop:packaged` and `test:desktop:packaged:windows` aliases for release/regression entrypoints
- allowlist those root `--cwd` wrappers in `audit-scripts` with explicit release-gate reasons

## Evidence
- `git diff --check origin/develop...HEAD`
- `node -e "JSON.parse(require(\"fs\").readFileSync(\"package.json\",\"utf8\")); JSON.parse(require(\"fs\").readFileSync(\"packages/app/package.json\",\"utf8\")); console.log(\"package json ok\")"`
- `bun run test:desktop:packaged:windows` on macOS: reaches `packages/app` script and exits 1 with the expected Windows-host precondition message, not script-not-found
- `bun run audit:scripts`: remaining 6 findings are pre-existing on current `develop`; this branch removes the two new `cwd-wrapper` findings by adding allowlist reasons

Replaces closed, unmerged PR #13702.