### PR TITLE
fix(#13773): reclaim ACP scratch dirs on teardown + startup GC

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-gc.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-gc.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Verifies AcpService scratch-dir lifecycle: teardown reclaim + startup GC (#13773).
+ * Drives the real closeSession/deleteSession/stopSession/start code paths against
+ * an InMemory session store and real dirs on a private TMPDIR; no live model.
+ */
+import { mkdir, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { InMemorySessionStore } from "../../src/services/session-store.js";
+import type { SessionInfo, SessionStatus } from "../../src/services/types.js";
+
+// DEFAULT_WORKDIR_ROOT is `join(tmpdir(), "eliza-acp")`, computed once at module
+// load. Point TMPDIR at a private per-run dir BEFORE importing acp-service so the
+// scratch root the service GCs is fully isolated from real state on this host,
+// then dynamic-import the module against that root.
+const TEST_TMPDIR = join(
+  tmpdir(),
+  `acp-scratch-gc-${process.pid}-${Date.now()}`,
+);
+let ROOT: string;
+let AcpService: typeof import("../../src/services/acp-service.js").AcpService;
+let isOwnedScratchDir: typeof import("../../src/services/acp-service.js").isOwnedScratchDir;
+
+beforeAll(async () => {
+  process.env.TMPDIR = TEST_TMPDIR;
+  await mkdir(TEST_TMPDIR, { recursive: true });
+  const mod = await import("../../src/services/acp-service.js");
+  AcpService = mod.AcpService;
+  isOwnedScratchDir = mod.isOwnedScratchDir;
+  ROOT = join(TEST_TMPDIR, "eliza-acp");
+});
+
+afterAll(async () => {
+  await rm(TEST_TMPDIR, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await mkdir(ROOT, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(ROOT, { recursive: true, force: true });
+});
+
+function runtime(settings: Record<string, string | undefined> = {}) {
+  return {
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    getSetting: vi.fn((key: string) => settings[key]),
+    reportError: vi.fn(),
+    services: new Map<string, unknown[]>(),
+  } as never;
+}
+
+function makeService(
+  store: InMemorySessionStore,
+  settings: Record<string, string | undefined> = {},
+): InstanceType<typeof AcpService> {
+  return new AcpService(runtime(settings), { store });
+}
+
+function session(
+  id: string,
+  workdir: string,
+  status: SessionStatus = "running",
+): SessionInfo {
+  const now = new Date();
+  return {
+    id,
+    name: id,
+    agentType: "elizaos",
+    workdir,
+    status,
+    approvalPreset: "standard",
+    createdAt: now,
+    lastActivityAt: now,
+  };
+}
+
+async function makeDir(path: string): Promise<void> {
+  await mkdir(path, { recursive: true });
+  await writeFile(join(path, "scratch.txt"), "work product");
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function backdate(path: string, ageMs: number): Promise<void> {
+  const past = new Date(Date.now() - ageMs);
+  await utimes(path, past, past);
+}
+
+// Access the private startup-GC method by its real name — this drives the
+// actual implementation, not a stand-in.
+function gc(service: InstanceType<typeof AcpService>): Promise<void> {
+  return (
+    service as unknown as { gcOrphanedScratchDirs(): Promise<void> }
+  ).gcOrphanedScratchDirs();
+}
+
+describe("isOwnedScratchDir", () => {
+  it("owns only task-* dirs directly under the eliza-acp scratch root", () => {
+    expect(isOwnedScratchDir(join(ROOT, "task-abc"))).toBe(true);
+    // base root itself (isolate=false landed on the shared root)
+    expect(isOwnedScratchDir(ROOT)).toBe(false);
+    // a sibling, non-task-prefixed dir under the root (e.g. a shared clone)
+    expect(isOwnedScratchDir(join(ROOT, "shared-clone"))).toBe(false);
+    // a nested grandchild is not a direct child
+    expect(isOwnedScratchDir(join(ROOT, "task-abc", "src"))).toBe(false);
+    // an explicit / self-checkout workdir outside the scratch root
+    expect(isOwnedScratchDir(join(TEST_TMPDIR, "user-repo"))).toBe(false);
+    expect(isOwnedScratchDir(process.cwd())).toBe(false);
+  });
+});
+
+describe("teardown reclaims the owned scratch dir", () => {
+  it("closeSession removes the task-<id> dir it created", async () => {
+    const store = new InMemorySessionStore();
+    const id = "close-1";
+    const workdir = join(ROOT, `task-${id}`);
+    await makeDir(workdir);
+    await store.create(session(id, workdir));
+    const service = makeService(store);
+
+    await service.closeSession(id);
+
+    expect(await exists(workdir)).toBe(false);
+  });
+
+  it("deleteSession removes the task-<id> dir it created", async () => {
+    const store = new InMemorySessionStore();
+    const id = "delete-1";
+    const workdir = join(ROOT, `task-${id}`);
+    await makeDir(workdir);
+    await store.create(session(id, workdir));
+    const service = makeService(store);
+
+    await service.deleteSession(id);
+
+    expect(await exists(workdir)).toBe(false);
+    expect(await store.get(id)).toBeNull();
+  });
+
+  it("stopSession removes the task-<id> dir it created", async () => {
+    const store = new InMemorySessionStore();
+    const id = "stop-1";
+    const workdir = join(ROOT, `task-${id}`);
+    await makeDir(workdir);
+    await store.create(session(id, workdir));
+    const service = makeService(store);
+
+    await service.stopSession(id);
+
+    expect(await exists(workdir)).toBe(false);
+  });
+
+  it("never removes a user-supplied workdir the service does not own", async () => {
+    const store = new InMemorySessionStore();
+    // An opt-in / route / self-checkout workdir outside the scratch root.
+    const userWorkdir = join(TEST_TMPDIR, "user-workspace-keepme");
+    await makeDir(userWorkdir);
+    await store.create(session("user-1", userWorkdir));
+    // A dir INSIDE the scratch root but not a task-* dir (e.g. a shared clone).
+    const sharedClone = join(ROOT, "shared-clone");
+    await makeDir(sharedClone);
+    await store.create(session("shared-1", sharedClone));
+    const service = makeService(store);
+
+    await service.closeSession("user-1");
+    await service.deleteSession("shared-1");
+
+    expect(await exists(userWorkdir)).toBe(true);
+    expect(await exists(sharedClone)).toBe(true);
+  });
+});
+
+describe("startup GC reclaims orphaned scratch dirs", () => {
+  it("reclaims a dir whose session is terminal in the store", async () => {
+    const store = new InMemorySessionStore();
+    const id = "term-1";
+    const workdir = join(ROOT, `task-${id}`);
+    await makeDir(workdir);
+    await store.create(session(id, workdir, "errored"));
+    const service = makeService(store);
+
+    await gc(service);
+
+    expect(await exists(workdir)).toBe(false);
+  });
+
+  it("keeps a dir with a live (non-terminal) session", async () => {
+    const store = new InMemorySessionStore();
+    const liveId = "live-1";
+    const liveDir = join(ROOT, `task-${liveId}`);
+    await makeDir(liveDir);
+    await store.create(session(liveId, liveDir, "running"));
+
+    const deadId = "dead-1";
+    const deadDir = join(ROOT, `task-${deadId}`);
+    await makeDir(deadDir);
+    await store.create(session(deadId, deadDir, "stopped"));
+
+    const service = makeService(store);
+    await gc(service);
+
+    expect(await exists(liveDir)).toBe(true);
+    expect(await exists(deadDir)).toBe(false);
+  });
+
+  it("reclaims an untracked stale dir but keeps a fresh untracked dir", async () => {
+    const store = new InMemorySessionStore();
+    // No sessions at all: both dirs are untracked (crashed before store.create,
+    // or a co-tenant's). Age-gate: only the stale one is reclaimed.
+    const staleDir = join(ROOT, "task-orphan-stale");
+    await makeDir(staleDir);
+    await backdate(staleDir, 25 * 60 * 60_000); // 25h — past the 24h floor
+
+    const freshDir = join(ROOT, "task-orphan-fresh");
+    await makeDir(freshDir);
+
+    const service = makeService(store);
+    await gc(service);
+
+    expect(await exists(staleDir)).toBe(false);
+    expect(await exists(freshDir)).toBe(true);
+  });
+
+  it("honors ELIZA_ACP_SCRATCH_GC_MAX_AGE_MS for the untracked age gate", async () => {
+    const store = new InMemorySessionStore();
+    const dir = join(ROOT, "task-orphan-config");
+    await makeDir(dir);
+    await backdate(dir, 5_000); // 5s old
+    const service = makeService(store, {
+      ELIZA_ACP_SCRATCH_GC_MAX_AGE_MS: "1000", // 1s floor
+    });
+
+    await gc(service);
+
+    expect(await exists(dir)).toBe(false);
+  });
+
+  it("start() reclaims a task dir orphaned by a SIGKILL mid-run", async () => {
+    // Simulate a crash: a session left 'running' in the store with its scratch
+    // dir on disk and no live subprocess. On restart, reconcile marks it
+    // terminal and the startup GC reclaims the dir.
+    const store = new InMemorySessionStore();
+    const id = "kill-1";
+    const workdir = join(ROOT, `task-${id}`);
+    await makeDir(workdir);
+    await store.create(session(id, workdir, "running"));
+    const service = makeService(store);
+
+    await service.start();
+    try {
+      expect(await exists(workdir)).toBe(false);
+    } finally {
+      await service.stop();
+    }
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -17,9 +17,9 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readdir, stat, unlink } from "node:fs/promises";
+import { mkdir, readdir, rm, stat, unlink } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import {
   SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE as CORE_SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE,
   type IAgentRuntime,
@@ -167,6 +167,24 @@ export function computeSessionWorkdir(
 ): string {
   return isolate ? resolve(base, `task-${sessionId}`) : resolve(base);
 }
+
+/**
+ * True iff `workdir` is a throwaway scratch dir AcpService itself created under
+ * its default temp root — a `task-<sessionId>` directory directly beneath
+ * DEFAULT_WORKDIR_ROOT (`$TMPDIR/eliza-acp`). This is the ownership guard for
+ * every destructive reclaim (teardown rm + startup GC): a self-checkout
+ * (`process.cwd()`), an explicit route/opt-in workdir, and a git-worktree
+ * workspace the service was handed all live elsewhere, so a reclaim keyed on
+ * this predicate can never delete a directory the service does not own. Pure +
+ * exported so the guarantee is unit-testable.
+ */
+export function isOwnedScratchDir(workdir: string): boolean {
+  const resolved = resolve(workdir);
+  return (
+    dirname(resolved) === resolve(DEFAULT_WORKDIR_ROOT) &&
+    basename(resolved).startsWith("task-")
+  );
+}
 const MAX_CAPTURED_TOOL_OUTPUT_CHARS = 12_000;
 const TOOL_OUTPUT_END_MARKER = "[/tool output]";
 const ACP_HEALTH_CHECK_INTERVAL_MS = 60_000;
@@ -183,6 +201,13 @@ const ACP_MIDFLIGHT_SESSION_STATUSES: ReadonlySet<string> = new Set([
   "tool_running",
 ]);
 const ACP_STALE_LOCK_MAX_AGE_MS = 10 * 60_000;
+// Startup GC only reclaims an UNTRACKED `task-*` scratch dir (no owning session
+// in this instance's store) once it is older than this — a conservative floor
+// so a co-tenant AcpService sharing the same $TMPDIR/eliza-acp root never has
+// its live-but-idle scratch nuked. Dirs whose session IS terminal in this store
+// are unambiguously ours and reclaimed regardless of age. Overridable via
+// ELIZA_ACP_SCRATCH_GC_MAX_AGE_MS. 24h mirrors ACP_REVERSE_ORPHAN_MAX_AGE_MS.
+const ACP_SCRATCH_GC_MAX_AGE_MS = 24 * 60 * 60_000;
 // Untracked acpx stream files older than this get unlinked. Real spawns
 // finalize their store entry in seconds; 24h is grace for in-flight spawns.
 const ACP_REVERSE_ORPHAN_MAX_AGE_MS = 24 * 60 * 60_000;
@@ -374,6 +399,7 @@ export class AcpService extends Service {
       defaultApprovalPreset: this.defaultApprovalPreset,
     });
     await this.reconcileOrphanedSessions();
+    await this.gcOrphanedScratchDirs();
     await this.cleanReverseOrphanedAcpxFiles();
     await this.cleanStaleLocks();
     this.healthCheckTimer = setInterval(() => {
@@ -560,6 +586,121 @@ export class AcpService extends Service {
         deleted,
         lingering,
         olderThanMs: ACP_REVERSE_ORPHAN_MAX_AGE_MS,
+      });
+    }
+  }
+
+  // Delete the per-session scratch dir spawnSession mkdir'd, but ONLY when it is
+  // one we own (a `task-<id>` dir under $TMPDIR/eliza-acp — see isOwnedScratchDir).
+  // A self-checkout cwd, a route/explicit workdir, or a handed-in git-worktree
+  // workspace is never touched. Best-effort: a failed rm on teardown must not
+  // block session close — the startup GC reclaims the dir on the next boot.
+  private async reclaimOwnedScratchDir(session: SessionInfo): Promise<void> {
+    if (!isOwnedScratchDir(session.workdir)) return;
+    try {
+      await rm(session.workdir, { recursive: true, force: true });
+      this.log("debug", "reclaimed session scratch dir", {
+        sessionId: session.id,
+        workdir: session.workdir,
+      });
+    } catch (err) {
+      // error-policy:J6 best-effort scratch reclaim on teardown; surface the
+      // failure so the leak is observable, then let the startup GC retry it.
+      this.log("warn", "failed to reclaim session scratch dir", {
+        sessionId: session.id,
+        workdir: session.workdir,
+        error: errorMessage(err),
+      });
+    }
+  }
+
+  // Reclaim `task-*` scratch dirs left under $TMPDIR/eliza-acp by sessions that
+  // never got a clean teardown — the SIGKILL-mid-run case that made this a
+  // 3.6TB-class leak (#13773). Runs once at startup, after reconcile has marked
+  // crashed orphans terminal, so a dir whose session is terminal in this store
+  // is reclaimed immediately; a live (non-terminal, possibly resumable) session
+  // keeps its workspace; an untracked dir is age-gated (co-tenant safety).
+  private async gcOrphanedScratchDirs(): Promise<void> {
+    const root = DEFAULT_WORKDIR_ROOT;
+    let entries: string[];
+    try {
+      entries = await readdir(root);
+    } catch {
+      // error-policy:J3 an absent scratch root is the expected empty shape →
+      // explicit zero-work result, not a masked read failure.
+      return;
+    }
+    const taskDirs = entries.filter((name) => name.startsWith("task-"));
+    if (taskDirs.length === 0) return;
+
+    let sessions: SessionInfo[];
+    try {
+      sessions = await this.store.list();
+    } catch (err) {
+      // error-policy:J7 store read failed; DATA-LOSS GUARD. A fabricated empty
+      // set would make every live session's scratch dir look orphaned and delete
+      // work out from under a running sub-agent. Surface and skip this pass; the
+      // next boot retries with real data.
+      this.runtime.reportError("AcpService.gcOrphanedScratchDirs", err, {
+        phase: "store.list",
+      });
+      this.log("warn", "scratch GC: store read failed, skipping sweep", {
+        err,
+      });
+      return;
+    }
+    const sessionById = new Map(sessions.map((s) => [s.id, s] as const));
+    const maxAgeMs =
+      parsePositiveInt(this.setting("ELIZA_ACP_SCRATCH_GC_MAX_AGE_MS")) ??
+      ACP_SCRATCH_GC_MAX_AGE_MS;
+    const now = Date.now();
+    let reclaimed = 0;
+    let kept = 0;
+    await Promise.allSettled(
+      taskDirs.map(async (name) => {
+        const sessionId = name.slice("task-".length);
+        const session = sessionById.get(sessionId);
+        // A live (non-terminal) session is still using its workspace — never
+        // reclaim it; resumeOrphanedBusySessions may pick the work back up.
+        if (session && !TERMINAL_SESSION_STATUSES.has(session.status)) {
+          kept++;
+          return;
+        }
+        const path = join(root, name);
+        // No owning session in THIS store: the dir may belong to a co-tenant
+        // AcpService sharing this tmp root, so gate removal on age. A dir whose
+        // session is terminal here is unambiguously ours → reclaim regardless.
+        if (!session) {
+          try {
+            const st = await stat(path);
+            if (now - st.mtimeMs <= maxAgeMs) {
+              kept++;
+              return;
+            }
+          } catch {
+            // error-policy:J6 vanished mid-scan — nothing left to reclaim.
+            return;
+          }
+        }
+        try {
+          await rm(path, { recursive: true, force: true });
+          reclaimed++;
+        } catch (err) {
+          // error-policy:J6 best-effort GC; a locked/vanished dir is skipped so
+          // the sweep continues and retries next boot.
+          this.log("warn", "scratch GC: failed to remove dir", {
+            path,
+            error: errorMessage(err),
+          });
+        }
+      }),
+    );
+    if (reclaimed > 0 || kept > 0) {
+      this.log("info", "reclaimed orphaned scratch dirs", {
+        reclaimed,
+        kept,
+        root,
+        olderThanMs: maxAgeMs,
       });
     }
   }
@@ -1112,6 +1253,7 @@ export class AcpService extends Service {
           this.nativeStoppingSessionIds.delete(sessionId);
         }
       }
+      await this.reclaimOwnedScratchDir(session);
       return;
     }
     await this.stopTrackedProcess(sessionId);
@@ -1137,6 +1279,7 @@ export class AcpService extends Service {
       sessionId,
       response: this.lastOutput(sessionId),
     });
+    await this.reclaimOwnedScratchDir(session);
   }
 
   async deleteSession(sessionId: string): Promise<void> {


### PR DESCRIPTION
## Problem

Part of epic #13766 (WS3) — the 3.6TB-disk-fill class of bug.

`AcpService.spawnSession` mkdir's a per-session scratch dir at
`$TMPDIR/eliza-acp/task-<sessionId>` for the default (~90% of) spawns, but
`closeSession` / `deleteSession` / `stopSession` did **zero `fs.rm`** on
`session.workdir`. The health sweep only reclaims DB rows + in-memory maps.
Result: **every spawned sub-agent leaks its scratch dir permanently** — no TTL,
no startup GC.

This PR delivers the leak-fix + startup GC slice. The git-index-isolation and
unified-registry sub-items in #13773 remain follow-ups.

## Fix

- **`isOwnedScratchDir(workdir)`** (pure, exported): true only for a `task-*`
  directory **directly under** `DEFAULT_WORKDIR_ROOT` (`$TMPDIR/eliza-acp`). A
  self-checkout `process.cwd()`, an explicit route/opt-in workdir, and a
  handed-in git-worktree workspace all live elsewhere, so no reclaim keyed on
  this predicate can delete a directory the service does not own.
- **Teardown reclaim:** `closeSession` (both native and CLI branches;
  `deleteSession`/`stopSession` delegate to it) now `rm(dir, { recursive: true,
  force: true })` the scratch dir it owns. Best-effort (`error-policy:J6`): a
  failed rm warns and the startup GC retries next boot.
- **Startup GC:** `gcOrphanedScratchDirs()` runs once in `start()` after
  reconcile. It reclaims a `task-*` dir whose session is terminal in this
  store immediately (the SIGKILL-mid-teardown case reconcile just marked
  errored), keeps live/resumable sessions, and age-gates *untracked* dirs
  behind a 24h floor (overridable via `ELIZA_ACP_SCRATCH_GC_MAX_AGE_MS`) so a
  co-tenant `AcpService` sharing the shared tmp root is never nuked. Logs the
  reclaimed/kept counts.

## Tests

New `__tests__/unit/acp-scratch-gc.test.ts` (10 tests) drives the **real**
`closeSession`/`deleteSession`/`stopSession`/`start()`/`gcOrphanedScratchDirs`
code paths against an `InMemorySessionStore` + real directories on a private
per-run `TMPDIR`:

- (a) close/delete/stop each rm the owned `task-<id>` dir.
- (c) an opt-in/user workdir (outside the root, or a non-`task-*` dir inside it)
  is never removed.
- (b) startup GC reclaims terminal + stale-orphaned dirs, keeps a live-session
  dir and a fresh untracked dir; honors the TTL env override; a full `start()`
  reclaims a dir orphaned by a simulated SIGKILL mid-run.
- `isOwnedScratchDir` guard unit cases (cwd, base root, sibling, grandchild).

**Falsification:** with the reclaim calls + startup-GC wiring reverted, the 4
teardown/`start()` tests fail (`expected true to be false`); they pass with the
fix. The existing `acp-service.test.ts` (48 tests) still passes.

## Verification

```
bun run --cwd plugins/plugin-agent-orchestrator test __tests__/unit/acp-scratch-gc.test.ts   # 10 passed
bun run --cwd plugins/plugin-agent-orchestrator test __tests__/unit/acp-service.test.ts       # 48 passed
bun run --cwd plugins/plugin-agent-orchestrator typecheck   # only pre-existing missing-decl errors (git-workspace-service, drizzle-orm, …); none cite changed files
bunx biome check .   # clean
bun run audit:error-policy-ratchet   # no new fallback-slop
```

### Evidence checklist
- Real-LLM trajectories — N/A (no agent/prompt/model behavior change; pure filesystem lifecycle).
- Backend logs — the new `[AcpService] reclaimed session scratch dir` / `reclaimed orphaned scratch dirs` structured logs fire on the covered paths.
- UI/screenshots/video — N/A (no user-facing surface).
- Domain artifacts — the reclaimed directories on disk, asserted present-then-absent by the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
