### PR TITLE
fix(ui): consolidate cloud settings security states and light theme tokens

### DIFF
--- a/packages/ui/src/cloud/account-security/SecuritySurface.tsx
+++ b/packages/ui/src/cloud/account-security/SecuritySurface.tsx
@@ -34,7 +34,7 @@ export function SecuritySurface() {
               which is what SettingsView listens to for section switches. */}
           <a
             href="#cloud-plugin-grants"
-            className="rounded-sm bg-white/5 px-3 py-1 text-white/70 hover:bg-white/10"
+            className="rounded-sm bg-surface px-3 py-1 text-txt hover:bg-surface"
           >
             {t("cloud.security.pluginPermissionsLink", {
               defaultValue: "Plugin permissions →",

--- a/packages/ui/src/cloud/account-security/components/AuditEventList.tsx
+++ b/packages/ui/src/cloud/account-security/components/AuditEventList.tsx
@@ -51,7 +51,7 @@ export function AuditEventList({
   }
   return (
     <ul
-      className={`divide-y divide-white/10 ${className ?? ""}`}
+      className={`divide-y divide-line ${className ?? ""}`}
       data-testid="audit-event-list"
     >
       {events.map((event) => {

--- a/packages/ui/src/cloud/account-security/components/AuditEventList.tsx
+++ b/packages/ui/src/cloud/account-security/components/AuditEventList.tsx
@@ -41,7 +41,7 @@ export function AuditEventList({
   const t = useCloudT();
   if (events.length === 0) {
     return (
-      <p className="text-sm text-white/60">
+      <p className="text-sm text-muted">
         {emptyMessage ??
           t("cloud.auditEvents.empty", {
             defaultValue: "No audit events recorded yet.",
@@ -56,7 +56,7 @@ export function AuditEventList({
     >
       {events.map((event) => {
         const Icon = RESULT_ICON[event.result] ?? ShieldAlert;
-        const tone = RESULT_TONE[event.result] ?? "text-white/60";
+        const tone = RESULT_TONE[event.result] ?? "text-muted";
         return (
           <li
             key={event.event_id}
@@ -65,11 +65,11 @@ export function AuditEventList({
             <Icon className={`mt-0.5 h-4 w-4 ${tone}`} aria-hidden />
             <div className="flex-1 space-y-0.5">
               <div className="flex items-center justify-between gap-2">
-                <span className="font-mono font-medium text-white">
+                <span className="font-mono font-medium text-txt-strong">
                   {event.action}
                 </span>
                 <time
-                  className="text-white/40"
+                  className="text-muted"
                   dateTime={event.ts}
                   title={event.ts}
                 >
@@ -77,7 +77,7 @@ export function AuditEventList({
                 </time>
               </div>
               {event.resource ? (
-                <p className="text-white/50">
+                <p className="text-muted">
                   {t("cloud.auditEvents.on", { defaultValue: "on" })}{" "}
                   <span className="font-mono">
                     {event.resource.type}:{event.resource.id}
@@ -85,7 +85,7 @@ export function AuditEventList({
                 </p>
               ) : null}
               {event.ip ? (
-                <p className="font-mono text-[11px] text-white/40">
+                <p className="font-mono text-[11px] text-muted">
                   {t("cloud.auditEvents.ip", {
                     ip: event.ip,
                     defaultValue: "ip {{ip}}",

--- a/packages/ui/src/cloud/account-security/components/account-details.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-details.tsx
@@ -34,13 +34,13 @@ export function AccountDetails({ user }: AccountDetailsProps) {
         <div>
           <div className="flex items-center gap-2 mb-2">
             <Info className="h-5 w-5 text-[var(--brand-orange)]" />
-            <h3 className="text-lg font-bold text-white">
+            <h3 className="text-lg font-bold text-txt-strong">
               {t("cloud.accountDetails.title", {
                 defaultValue: "Account Details",
               })}
             </h3>
           </div>
-          <p className="text-sm text-white/60">
+          <p className="text-sm text-muted">
             {t("cloud.accountDetails.subtitle", {
               defaultValue: "View your account status and important dates",
             })}
@@ -50,17 +50,17 @@ export function AccountDetails({ user }: AccountDetailsProps) {
         <div className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="space-y-1">
-              <p className="text-xs text-white/50 uppercase tracking-wide">
+              <p className="text-xs text-muted uppercase tracking-wide">
                 {t("cloud.accountDetails.accountId", {
                   defaultValue: "Account ID",
                 })}
               </p>
-              <p className="font-mono text-xs text-white/70">{user.id}</p>
+              <p className="font-mono text-xs text-txt">{user.id}</p>
             </div>
 
             {user.email && (
               <div className="space-y-1">
-                <p className="text-xs text-white/50 uppercase tracking-wide">
+                <p className="text-xs text-muted uppercase tracking-wide">
                   {t("cloud.accountDetails.emailVerification", {
                     defaultValue: "Email Verification",
                   })}
@@ -91,7 +91,7 @@ export function AccountDetails({ user }: AccountDetailsProps) {
 
             {user.wallet_address && (
               <div className="space-y-1">
-                <p className="text-xs text-white/50 uppercase tracking-wide flex items-center gap-2">
+                <p className="text-xs text-muted uppercase tracking-wide flex items-center gap-2">
                   <Wallet className="h-4 w-4" />
                   {t("cloud.accountDetails.walletStatus", {
                     defaultValue: "Wallet Status",
@@ -122,7 +122,7 @@ export function AccountDetails({ user }: AccountDetailsProps) {
             )}
 
             <div className="space-y-1">
-              <p className="text-xs text-white/50 uppercase tracking-wide">
+              <p className="text-xs text-muted uppercase tracking-wide">
                 {t("cloud.accountDetails.accountStatus", {
                   defaultValue: "Account Status",
                 })}
@@ -139,53 +139,53 @@ export function AccountDetails({ user }: AccountDetailsProps) {
             </div>
 
             <div className="space-y-1">
-              <p className="text-xs text-white/50 uppercase tracking-wide">
+              <p className="text-xs text-muted uppercase tracking-wide">
                 {t("cloud.accountDetails.role", { defaultValue: "Role" })}
               </p>
-              <span className="rounded-sm bg-white/10 px-2 py-1 text-xs text-white capitalize">
+              <span className="rounded-sm bg-surface px-2 py-1 text-xs text-txt-strong capitalize">
                 {user.role}
               </span>
             </div>
 
             <div className="space-y-1">
-              <p className="text-xs text-white/50 uppercase tracking-wide flex items-center gap-2">
+              <p className="text-xs text-muted uppercase tracking-wide flex items-center gap-2">
                 <Calendar className="h-4 w-4 text-[var(--brand-orange)]" />
                 {t("cloud.accountDetails.accountCreated", {
                   defaultValue: "Account Created",
                 })}
               </p>
-              <p className="text-sm text-white">
+              <p className="text-sm text-txt-strong">
                 {formatDate(user.created_at)}
               </p>
             </div>
 
             <div className="space-y-1">
-              <p className="text-xs text-white/50 uppercase tracking-wide flex items-center gap-2">
+              <p className="text-xs text-muted uppercase tracking-wide flex items-center gap-2">
                 <Calendar className="h-4 w-4 text-[var(--brand-orange)]" />
                 {t("cloud.accountDetails.lastUpdated", {
                   defaultValue: "Last Updated",
                 })}
               </p>
-              <p className="text-sm text-white">
+              <p className="text-sm text-txt-strong">
                 {formatDate(user.updated_at)}
               </p>
             </div>
           </div>
 
           {user.wallet_address && (
-            <div className="pt-4 border-t border-white/10 space-y-3">
+            <div className="pt-4 border-t border-border space-y-3">
               <div className="space-y-1">
-                <p className="text-xs text-white/50 uppercase tracking-wide flex items-center gap-2">
+                <p className="text-xs text-muted uppercase tracking-wide flex items-center gap-2">
                   <Wallet className="h-4 w-4 text-[var(--brand-orange)]" />
                   {t("cloud.accountDetails.walletAddress", {
                     defaultValue: "Wallet Address",
                   })}
                 </p>
-                <p className="font-mono text-xs break-all text-white">
+                <p className="font-mono text-xs break-all text-txt-strong">
                   {user.wallet_address}
                 </p>
                 {user.wallet_chain_type && (
-                  <span className="rounded-sm bg-white/10 px-2 py-0.5 text-xs text-white capitalize">
+                  <span className="rounded-sm bg-surface px-2 py-0.5 text-xs text-txt-strong capitalize">
                     {user.wallet_chain_type}
                   </span>
                 )}

--- a/packages/ui/src/cloud/account-security/components/account-page-client.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-page-client.tsx
@@ -37,12 +37,12 @@ export function AccountPageClient({ user }: AccountPageClientProps) {
         <CornerBrackets size="sm" className="opacity-50" />
         <div className="relative z-10 flex items-start gap-3">
           <div className="flex-1">
-            <p className="text-sm text-white">
+            <p className="text-sm text-txt-strong">
               Welcome back, <span className="font-semibold">{displayName}</span>
               !
             </p>
             {user.organization?.name && (
-              <p className="text-xs text-white/60 mt-1">
+              <p className="text-xs text-muted mt-1">
                 You&apos;re part of{" "}
                 <span className="font-medium">{user.organization.name}</span>{" "}
                 organization

--- a/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
@@ -159,6 +159,19 @@ describe("account-security panels", () => {
     expect(screen.queryByText(/No other active sessions found/i)).toBeNull();
   });
 
+  it("renders malformed session rows as errors instead of ready rows", async () => {
+    apiMock.mockResolvedValueOnce({
+      sessions: [{ id: "", last_seen: "not-a-date" }],
+    });
+
+    render(<ActiveSessionsPanel />);
+
+    expect(
+      await screen.findByText("Malformed session inventory response."),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Unknown device/i)).toBeNull();
+  });
+
   it("renders MFA errors separately from unavailable and disabled", async () => {
     apiMock.mockRejectedValueOnce(new Error("mfa route failed"));
 
@@ -178,6 +191,17 @@ describe("account-security panels", () => {
       await screen.findByText("MFA status response is missing enrolled."),
     ).toBeTruthy();
     expect(screen.queryByText(/MFA is not enabled/i)).toBeNull();
+  });
+
+  it("renders malformed MFA method fields as errors", async () => {
+    apiMock.mockResolvedValueOnce({ enrolled: true, method: "" });
+
+    render(<MfaPanel />);
+
+    expect(
+      await screen.findByText("Malformed MFA status response."),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Enabled/i)).toBeNull();
   });
 
   it("renders audit events unavailable without calling the missing read route", () => {

--- a/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
@@ -56,6 +56,9 @@ vi.mock("lucide-react", () => ({
   Download: () => <span data-testid="icon-download" />,
   Lock: () => <span data-testid="icon-lock" />,
   ScrollText: () => <span data-testid="icon-scroll-text" />,
+  ShieldAlert: () => <span data-testid="icon-shield-alert" />,
+  ShieldCheck: () => <span data-testid="icon-shield-check" />,
+  ShieldX: () => <span data-testid="icon-shield-x" />,
   Trash2: () => <span data-testid="icon-trash" />,
 }));
 
@@ -143,6 +146,19 @@ describe("account-security panels", () => {
     expect(apiMock).toHaveBeenCalledWith("/api/v1/sessions");
   });
 
+  it("renders malformed sessions DTOs as errors instead of healthy empty", async () => {
+    apiMock.mockResolvedValueOnce({});
+
+    render(<ActiveSessionsPanel />);
+
+    expect(
+      await screen.findByText(
+        "Session inventory response is missing sessions.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText(/No other active sessions found/i)).toBeNull();
+  });
+
   it("renders MFA errors separately from unavailable and disabled", async () => {
     apiMock.mockRejectedValueOnce(new Error("mfa route failed"));
 
@@ -150,6 +166,17 @@ describe("account-security panels", () => {
 
     expect(await screen.findByText("mfa route failed")).toBeTruthy();
     expect(screen.queryByText(/MFA enrollment is unavailable/i)).toBeNull();
+    expect(screen.queryByText(/MFA is not enabled/i)).toBeNull();
+  });
+
+  it("renders malformed MFA DTOs as errors instead of disabled", async () => {
+    apiMock.mockResolvedValueOnce({});
+
+    render(<MfaPanel />);
+
+    expect(
+      await screen.findByText("MFA status response is missing enrolled."),
+    ).toBeTruthy();
     expect(screen.queryByText(/MFA is not enabled/i)).toBeNull();
   });
 

--- a/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
@@ -24,11 +24,32 @@ interface SessionsResponse {
   sessions?: SessionRow[];
 }
 
+interface UiSessionRow extends SessionRow {
+  lastSeenLabel: string;
+}
+
 type SessionsState =
   | { kind: "loading" }
   | { kind: "unavailable"; reason: string | null }
-  | { kind: "ready"; sessions: SessionRow[] }
+  | { kind: "ready"; sessions: UiSessionRow[] }
   | { kind: "error"; message: string };
+
+function formatSessionLastSeen(lastSeen: string | null | undefined): string {
+  if (!lastSeen) return "-";
+  const date = new Date(lastSeen);
+  if (Number.isNaN(date.getTime())) return "-";
+  return date.toISOString();
+}
+
+function sessionsFromPayload(payload: SessionsResponse): UiSessionRow[] {
+  if (!Array.isArray(payload.sessions)) {
+    throw new Error("Session inventory response is missing sessions.");
+  }
+  return payload.sessions.map((session) => ({
+    ...session,
+    lastSeenLabel: formatSessionLastSeen(session.last_seen),
+  }));
+}
 
 export function ActiveSessionsPanel() {
   const t = useCloudT();
@@ -48,7 +69,7 @@ export function ActiveSessionsPanel() {
         }
         setState({
           kind: "ready",
-          sessions: Array.isArray(payload.sessions) ? payload.sessions : [],
+          sessions: sessionsFromPayload(payload),
         });
       })
       .catch((error) => {
@@ -68,12 +89,12 @@ export function ActiveSessionsPanel() {
       <CornerBrackets size="sm" className="opacity-50" />
       <div className="relative z-10 space-y-4">
         <div>
-          <h3 className="text-lg font-bold text-white">
+          <h3 className="text-lg font-bold text-txt-strong">
             {t("cloud.activeSessions.title", {
               defaultValue: "Active sessions",
             })}
           </h3>
-          <p className="text-sm text-white/60">
+          <p className="text-sm text-muted">
             {t("cloud.activeSessions.description", {
               defaultValue:
                 "Devices and browsers currently signed in to your account.",
@@ -81,13 +102,13 @@ export function ActiveSessionsPanel() {
           </p>
         </div>
         {state.kind === "loading" ? (
-          <p className="text-sm text-white/50">
+          <p className="text-sm text-muted">
             {t("cloud.activeSessions.loading", {
               defaultValue: "Loading sessions...",
             })}
           </p>
         ) : state.kind === "unavailable" ? (
-          <p className="text-sm text-white/50">
+          <p className="text-sm text-muted">
             {t("cloud.activeSessions.notAvailable", {
               reason: state.reason ?? "",
               defaultValue: "Session listing is unavailable on this server.",
@@ -96,20 +117,20 @@ export function ActiveSessionsPanel() {
         ) : state.kind === "error" ? (
           <p className="text-sm text-red-300">{state.message}</p>
         ) : state.sessions.length === 0 ? (
-          <p className="text-sm text-white/50">
+          <p className="text-sm text-muted">
             {t("cloud.activeSessions.noOther", {
               defaultValue: "No other active sessions found.",
             })}
           </p>
         ) : (
-          <ul className="divide-y divide-white/10">
+          <ul className="divide-y divide-line">
             {state.sessions.map((session) => (
               <li
                 key={session.id}
                 className="flex items-center justify-between gap-3 py-2 text-sm"
               >
                 <div className="space-y-0.5">
-                  <p className="font-medium text-white">
+                  <p className="font-medium text-txt-strong">
                     {session.device ??
                       t("cloud.activeSessions.unknownDevice", {
                         defaultValue: "Unknown device",
@@ -122,12 +143,10 @@ export function ActiveSessionsPanel() {
                       </span>
                     ) : null}
                   </p>
-                  <p className="font-mono text-[11px] text-white/50">
+                  <p className="font-mono text-[11px] text-muted">
                     {t("cloud.activeSessions.ipLastSeen", {
                       ip: session.ip ?? "-",
-                      lastSeen: session.last_seen
-                        ? new Date(session.last_seen).toLocaleString()
-                        : "-",
+                      lastSeen: session.lastSeenLabel,
                       defaultValue: "{{ip}} - last seen {{lastSeen}}",
                     })}
                   </p>

--- a/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
@@ -37,13 +37,36 @@ type SessionsState =
 function formatSessionLastSeen(lastSeen: string | null | undefined): string {
   if (!lastSeen) return "-";
   const date = new Date(lastSeen);
-  if (Number.isNaN(date.getTime())) return "-";
   return date.toISOString();
+}
+
+function isOptionalString(value: unknown): value is string | null | undefined {
+  return value === null || value === undefined || typeof value === "string";
+}
+
+function isValidSessionRow(value: unknown): value is SessionRow {
+  if (!value || typeof value !== "object") return false;
+  const session = value as Record<string, unknown>;
+  if (typeof session.id !== "string" || session.id.length === 0) return false;
+  if (!isOptionalString(session.device)) return false;
+  if (!isOptionalString(session.ip)) return false;
+  if (!isOptionalString(session.user_agent)) return false;
+  if (!isOptionalString(session.last_seen)) return false;
+  if (session.current !== undefined && typeof session.current !== "boolean") {
+    return false;
+  }
+  if (typeof session.last_seen === "string") {
+    return !Number.isNaN(new Date(session.last_seen).getTime());
+  }
+  return true;
 }
 
 function sessionsFromPayload(payload: SessionsResponse): UiSessionRow[] {
   if (!Array.isArray(payload.sessions)) {
     throw new Error("Session inventory response is missing sessions.");
+  }
+  if (payload.sessions.some((session) => !isValidSessionRow(session))) {
+    throw new Error("Malformed session inventory response.");
   }
   return payload.sessions.map((session) => ({
     ...session,

--- a/packages/ui/src/cloud/account-security/components/api-keys-link.tsx
+++ b/packages/ui/src/cloud/account-security/components/api-keys-link.tsx
@@ -18,10 +18,10 @@ export function ApiKeysLink() {
             <KeyRound className="h-4 w-4 text-[var(--brand-orange)]" />
           </div>
           <div className="space-y-0.5">
-            <p className="text-sm font-medium text-white">
+            <p className="text-sm font-medium text-txt-strong">
               {t("cloud.apiKeysLink.title", { defaultValue: "API keys" })}
             </p>
-            <p className="text-xs text-white/60">
+            <p className="text-xs text-muted">
               {t("cloud.apiKeysLink.description", {
                 defaultValue:
                   "Manage long-lived keys, their scopes, and per-key audit history.",

--- a/packages/ui/src/cloud/account-security/components/incident-report-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/incident-report-panel.tsx
@@ -68,12 +68,12 @@ export function IncidentReportPanel() {
       <CornerBrackets size="sm" className="opacity-50" />
       <div className="relative z-10 space-y-3">
         <div>
-          <h3 className="text-lg font-bold text-white">
+          <h3 className="text-lg font-bold text-txt-strong">
             {t("cloud.incidentReport.title", {
               defaultValue: "Report a security incident",
             })}
           </h3>
-          <p className="text-sm text-white/60">
+          <p className="text-sm text-muted">
             {t("cloud.incidentReport.emailPre", { defaultValue: "Email" })}{" "}
             <a
               href={`mailto:${SECURITY_EMAIL}`}

--- a/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
@@ -6,7 +6,7 @@
 
 import { Lock } from "lucide-react";
 import { useEffect, useState } from "react";
-import { BrandCard, CornerBrackets } from "../../../cloud-ui";
+import { BrandButton, BrandCard, CornerBrackets } from "../../../cloud-ui";
 import { api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 
@@ -23,6 +23,20 @@ type MfaState =
   | { kind: "ready"; enrolled: boolean; method: string | null }
   | { kind: "error"; message: string };
 
+function stateFromMfaPayload(payload: MfaStatusResponse): MfaState {
+  if (payload.available === false) {
+    return { kind: "unavailable", reason: payload.reason ?? null };
+  }
+  if (typeof payload.enrolled !== "boolean") {
+    throw new Error("MFA status response is missing enrolled.");
+  }
+  return {
+    kind: "ready",
+    enrolled: payload.enrolled,
+    method: payload.method ?? null,
+  };
+}
+
 export function MfaPanel() {
   const t = useCloudT();
   const [state, setState] = useState<MfaState>({ kind: "loading" });
@@ -32,15 +46,7 @@ export function MfaPanel() {
     void api<MfaStatusResponse>("/api/v1/me/mfa")
       .then((payload) => {
         if (!active) return;
-        if (payload.available === false) {
-          setState({ kind: "unavailable", reason: payload.reason ?? null });
-          return;
-        }
-        setState({
-          kind: "ready",
-          enrolled: Boolean(payload.enrolled),
-          method: payload.method ?? null,
-        });
+        setState(stateFromMfaPayload(payload));
       })
       .catch((error) => {
         if (!active) return;
@@ -60,20 +66,20 @@ export function MfaPanel() {
       <div className="relative z-10 space-y-3">
         <div className="flex items-center gap-2">
           <Lock className="h-5 w-5 text-[var(--brand-orange)]" />
-          <h3 className="text-lg font-bold text-white">
+          <h3 className="text-lg font-bold text-txt-strong">
             {t("cloud.mfaPanel.title", {
               defaultValue: "Two-factor authentication",
             })}
           </h3>
         </div>
         {state.kind === "loading" ? (
-          <p className="text-sm text-white/50">
+          <p className="text-sm text-muted">
             {t("cloud.mfaPanel.loading", {
               defaultValue: "Loading MFA status...",
             })}
           </p>
         ) : state.kind === "unavailable" ? (
-          <p className="text-sm text-white/60">
+          <p className="text-sm text-muted">
             {t("cloud.mfaPanel.notAvailable", {
               reason: state.reason ?? "",
               defaultValue: "MFA enrollment is unavailable on this server.",
@@ -93,12 +99,19 @@ export function MfaPanel() {
             })}
           </p>
         ) : (
-          <p className="text-sm text-white/60">
-            {t("cloud.mfaPanel.notEnabled", {
-              defaultValue:
-                "MFA is not enabled. Adding a second factor protects your account even if your password is compromised.",
-            })}
-          </p>
+          <div className="space-y-2">
+            <p className="text-sm text-muted">
+              {t("cloud.mfaPanel.notEnabled", {
+                defaultValue:
+                  "MFA is not enabled. Adding a second factor protects your account even if your password is compromised.",
+              })}
+            </p>
+            <BrandButton size="sm" variant="outline" disabled>
+              {t("cloud.mfaPanel.enroll", {
+                defaultValue: "Enroll a second factor",
+              })}
+            </BrandButton>
+          </div>
         )}
       </div>
     </BrandCard>

--- a/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
@@ -30,6 +30,11 @@ function stateFromMfaPayload(payload: MfaStatusResponse): MfaState {
   if (typeof payload.enrolled !== "boolean") {
     throw new Error("MFA status response is missing enrolled.");
   }
+  if (payload.method !== null && payload.method !== undefined) {
+    if (typeof payload.method !== "string" || payload.method.length === 0) {
+      throw new Error("Malformed MFA status response.");
+    }
+  }
   return {
     kind: "ready",
     enrolled: payload.enrolled,

--- a/packages/ui/src/cloud/account-security/components/organization-info.tsx
+++ b/packages/ui/src/cloud/account-security/components/organization-info.tsx
@@ -39,13 +39,13 @@ export function OrganizationInfo({ organization }: OrganizationInfoProps) {
         <div>
           <div className="flex items-center gap-2 mb-2">
             <Building2 className="h-5 w-5 text-[var(--brand-orange)]" />
-            <h3 className="text-lg font-bold text-white">
+            <h3 className="text-lg font-bold text-txt-strong">
               {t("cloud.organizationInfo.title", {
                 defaultValue: "Organization",
               })}
             </h3>
           </div>
-          <p className="text-sm text-white/60">
+          <p className="text-sm text-muted">
             {t("cloud.organizationInfo.subtitle", {
               defaultValue: "Information about your organization",
             })}
@@ -55,37 +55,37 @@ export function OrganizationInfo({ organization }: OrganizationInfoProps) {
         <div className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="space-y-1">
-              <p className="text-xs text-white/50 uppercase tracking-wide">
+              <p className="text-xs text-muted uppercase tracking-wide">
                 {t("cloud.organizationInfo.orgName", {
                   defaultValue: "Organization Name",
                 })}
               </p>
-              <p className="font-medium text-white">{organization.name}</p>
+              <p className="font-medium text-txt-strong">{organization.name}</p>
             </div>
 
             <div className="space-y-1">
-              <p className="text-xs text-white/50 uppercase tracking-wide">
+              <p className="text-xs text-muted uppercase tracking-wide">
                 {t("cloud.organizationInfo.slug", { defaultValue: "Slug" })}
               </p>
-              <p className="font-mono text-sm text-white">
+              <p className="font-mono text-sm text-txt-strong">
                 {organization.slug}
               </p>
             </div>
 
             <div className="space-y-1">
-              <p className="text-xs text-white/50 uppercase tracking-wide flex items-center gap-2">
+              <p className="text-xs text-muted uppercase tracking-wide flex items-center gap-2">
                 <CreditCard className="h-4 w-4 text-[var(--brand-orange)]" />
                 {t("cloud.organizationInfo.balance", {
                   defaultValue: "Balance",
                 })}
               </p>
-              <p className="font-semibold text-lg text-white">
+              <p className="font-semibold text-lg text-txt-strong">
                 {formatBalance(organization.credit_balance)}
               </p>
             </div>
 
             <div className="space-y-1">
-              <p className="text-xs text-white/50 uppercase tracking-wide">
+              <p className="text-xs text-muted uppercase tracking-wide">
                 {t("cloud.organizationInfo.status", { defaultValue: "Status" })}
               </p>
               <span
@@ -102,26 +102,28 @@ export function OrganizationInfo({ organization }: OrganizationInfoProps) {
             </div>
 
             <div className="space-y-1">
-              <p className="text-xs text-white/50 uppercase tracking-wide flex items-center gap-2">
+              <p className="text-xs text-muted uppercase tracking-wide flex items-center gap-2">
                 <Calendar className="h-4 w-4 text-[var(--brand-orange)]" />
                 {t("cloud.organizationInfo.memberSince", {
                   defaultValue: "Member Since",
                 })}
               </p>
-              <p className="text-sm text-white">
+              <p className="text-sm text-txt-strong">
                 {formatDate(organization.created_at)}
               </p>
             </div>
           </div>
 
           {organization.billing_email && (
-            <div className="pt-4 border-t border-white/10 space-y-1">
-              <p className="text-xs text-white/50 uppercase tracking-wide">
+            <div className="pt-4 border-t border-border space-y-1">
+              <p className="text-xs text-muted uppercase tracking-wide">
                 {t("cloud.organizationInfo.billingEmail", {
                   defaultValue: "Billing Email",
                 })}
               </p>
-              <p className="text-sm text-white">{organization.billing_email}</p>
+              <p className="text-sm text-txt-strong">
+                {organization.billing_email}
+              </p>
             </div>
           )}
         </div>

--- a/packages/ui/src/cloud/account-security/components/plugin-permissions-page-client.tsx
+++ b/packages/ui/src/cloud/account-security/components/plugin-permissions-page-client.tsx
@@ -123,7 +123,7 @@ export function PluginPermissionsPageClient() {
               No plugin has any permission granted on your account.
             </p>
           ) : (
-            <ul className="divide-y divide-white/10">
+            <ul className="divide-y divide-line">
               {state.grants.map((g) => (
                 <li
                   key={g.grant_id}

--- a/packages/ui/src/cloud/account-security/components/plugin-permissions-page-client.tsx
+++ b/packages/ui/src/cloud/account-security/components/plugin-permissions-page-client.tsx
@@ -106,12 +106,12 @@ export function PluginPermissionsPageClient() {
         <div className="relative z-10 space-y-4">
           <div className="flex items-center gap-2">
             <Puzzle className="h-5 w-5 text-[var(--brand-orange)]" />
-            <h3 className="text-lg font-bold text-white">Active grants</h3>
+            <h3 className="text-lg font-bold text-txt-strong">Active grants</h3>
           </div>
           {state.kind === "loading" ? (
-            <p className="text-sm text-white/50">Loading…</p>
+            <p className="text-sm text-muted">Loading…</p>
           ) : state.kind === "missing" ? (
-            <p className="text-sm text-white/60">
+            <p className="text-sm text-muted">
               Plugin grant tracking isn't exposed yet on this server. Grants
               made from the desktop app will appear here once the backend is
               wired.
@@ -119,7 +119,7 @@ export function PluginPermissionsPageClient() {
           ) : state.kind === "error" ? (
             <p className="text-sm text-red-300">{state.message}</p>
           ) : state.grants.length === 0 ? (
-            <p className="text-sm text-white/60">
+            <p className="text-sm text-muted">
               No plugin has any permission granted on your account.
             </p>
           ) : (
@@ -130,13 +130,13 @@ export function PluginPermissionsPageClient() {
                   className="flex items-center justify-between gap-3 py-2 text-sm"
                 >
                   <div className="space-y-0.5">
-                    <p className="font-medium text-white">
+                    <p className="font-medium text-txt-strong">
                       {g.plugin_name ?? g.plugin_id}{" "}
-                      <span className="ml-1 rounded-sm border border-white/15 bg-white/5 px-1.5 py-0.5 font-mono text-[10px] text-white/70">
+                      <span className="ml-1 rounded-sm border border-border bg-surface px-1.5 py-0.5 font-mono text-[10px] text-txt">
                         {g.permission}
                       </span>
                     </p>
-                    <p className="font-mono text-[11px] text-white/40">
+                    <p className="font-mono text-[11px] text-muted">
                       {g.scope ? `scope: ${g.scope} · ` : ""}granted{" "}
                       {new Date(g.granted_at).toLocaleString()}
                       {g.last_used

--- a/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
@@ -3,8 +3,9 @@
  *   - vision / screen-capture consent toggle (local consent store)
  *   - trajectory logging toggle (local consent store)
  *
- * DSR export/deletion controls are disabled when the Worker does not expose
- * those jobs, so the launch surface never implies that a request was scheduled.
+ * DSR export/deletion jobs are not exposed by the Worker yet. Keep those
+ * controls visible but disabled so the launch surface does not issue dead
+ * `/api/v1/me/*` calls or imply a request was scheduled.
  */
 
 import { Camera, Download, ScrollText, Trash2 } from "lucide-react";
@@ -53,10 +54,10 @@ export function PrivacyPanel() {
       <CornerBrackets size="sm" className="opacity-50" />
       <div className="relative z-10 space-y-4">
         <div>
-          <h3 className="text-lg font-bold text-white">
+          <h3 className="text-lg font-bold text-txt-strong">
             {t("cloud.privacyPanel.title", { defaultValue: "Privacy" })}
           </h3>
-          <p className="text-sm text-white/60">
+          <p className="text-sm text-muted">
             {t("cloud.privacyPanel.subtitle", {
               defaultValue:
                 "Control optional data capture and exercise your data rights.",
@@ -64,18 +65,19 @@ export function PrivacyPanel() {
           </p>
         </div>
 
-        <div className="flex items-start justify-between gap-3 rounded-sm border border-white/10 bg-black/40 p-4">
+        {/* Vision toggle */}
+        <div className="flex items-start justify-between gap-3 rounded-sm border border-border bg-surface p-4">
           <div className="flex items-start gap-3">
             <div className="rounded-sm border border-purple-500/40 bg-purple-500/20 p-2">
               <Camera className="h-4 w-4 text-purple-300" />
             </div>
             <div className="space-y-1">
-              <p className="text-sm font-medium text-white">
+              <p className="text-sm font-medium text-txt-strong">
                 {t("cloud.privacyPanel.visionTitle", {
                   defaultValue: "Allow vision / screen capture",
                 })}
               </p>
-              <p className="text-xs text-white/60">
+              <p className="text-xs text-muted">
                 {t("cloud.privacyPanel.visionDescription", {
                   defaultValue:
                     "Off by default. When on, plugins may request screen frames or webcam capture. Remote models charge per image — review your model's per-call fee in Settings → Billing before enabling.",
@@ -90,18 +92,19 @@ export function PrivacyPanel() {
           />
         </div>
 
-        <div className="flex items-start justify-between gap-3 rounded-sm border border-white/10 bg-black/40 p-4">
+        {/* Trajectory logging toggle */}
+        <div className="flex items-start justify-between gap-3 rounded-sm border border-border bg-surface p-4">
           <div className="flex items-start gap-3">
             <div className="rounded-sm border border-[var(--brand-orange)]/40 bg-[var(--brand-orange)]/15 p-2">
               <ScrollText className="h-4 w-4 text-[var(--brand-orange)]" />
             </div>
             <div className="space-y-1">
-              <p className="text-sm font-medium text-white">
+              <p className="text-sm font-medium text-txt-strong">
                 {t("cloud.privacyPanel.trajectoryTitle", {
                   defaultValue: "Trajectory logging",
                 })}
               </p>
-              <p className="text-xs text-white/60">
+              <p className="text-xs text-muted">
                 {t("cloud.privacyPanel.trajectoryDescription", {
                   defaultValue:
                     "Off by default. When on, Eliza records per-step plan/action traces locally with a 30-day retention. Redacted content is marked separately from raw.",
@@ -116,18 +119,19 @@ export function PrivacyPanel() {
           />
         </div>
 
-        <div className="flex items-start justify-between gap-3 rounded-sm border border-white/10 bg-black/40 p-4">
+        {/* DSR — Export */}
+        <div className="flex items-start justify-between gap-3 rounded-sm border border-border bg-surface p-4">
           <div className="flex items-start gap-3">
             <div className="rounded-sm border border-green-500/40 bg-green-500/20 p-2">
               <Download className="h-4 w-4 text-green-300" />
             </div>
             <div className="space-y-1">
-              <p className="text-sm font-medium text-white">
+              <p className="text-sm font-medium text-txt-strong">
                 {t("cloud.privacyPanel.downloadTitle", {
                   defaultValue: "Download my data",
                 })}
               </p>
-              <p className="text-xs text-white/60">
+              <p className="text-xs text-muted">
                 {t("cloud.privacyPanel.downloadDescription", {
                   defaultValue:
                     "Bundle your conversations, agents, and connector data into a portable archive (GDPR / CCPA right-to-export).",
@@ -140,7 +144,8 @@ export function PrivacyPanel() {
             variant="outline"
             disabled
             title={t("cloud.privacyPanel.exportComingSoon", {
-              defaultValue: "Data export is unavailable on this server.",
+              defaultValue:
+                "Data export is coming soon — not yet available on this server.",
             })}
           >
             {t("cloud.privacyPanel.exportUnavailable", {
@@ -149,18 +154,19 @@ export function PrivacyPanel() {
           </BrandButton>
         </div>
 
+        {/* DSR — Delete */}
         <div className="flex items-start justify-between gap-3 rounded-sm border border-red-500/30 bg-red-500/5 p-4">
           <div className="flex items-start gap-3">
             <div className="rounded-sm border border-red-500/40 bg-red-500/20 p-2">
               <Trash2 className="h-4 w-4 text-red-300" />
             </div>
             <div className="space-y-1">
-              <p className="text-sm font-medium text-white">
+              <p className="text-sm font-medium text-txt-strong">
                 {t("cloud.privacyPanel.deleteTitle", {
                   defaultValue: "Delete my account",
                 })}
               </p>
-              <p className="text-xs text-white/60">
+              <p className="text-xs text-muted">
                 {t("cloud.privacyPanel.deleteDescription", {
                   defaultValue:
                     "Schedules a 30-day soft-delete. You can sign back in during the window to cancel. After 30 days, all data is purged.",
@@ -174,7 +180,8 @@ export function PrivacyPanel() {
             className="border-red-500/40 text-red-300"
             disabled
             title={t("cloud.privacyPanel.deletionComingSoon", {
-              defaultValue: "Account deletion is unavailable on this server.",
+              defaultValue:
+                "Account deletion is coming soon — not yet available on this server.",
             })}
             data-testid="delete-account-trigger"
           >

--- a/packages/ui/src/cloud/account-security/components/recent-audit-events.tsx
+++ b/packages/ui/src/cloud/account-security/components/recent-audit-events.tsx
@@ -4,34 +4,53 @@
  * unavailable state without issuing a dead account-audit request.
  */
 
+import { useState } from "react";
 import { BrandCard, CornerBrackets } from "../../../cloud-ui";
 import { useCloudT } from "../../shell/CloudI18nProvider";
+import { AuditEventList, type AuditEventRow } from "./AuditEventList";
+
+type AuditState =
+  | { kind: "loading" }
+  | { kind: "missing" }
+  | { kind: "ready"; events: AuditEventRow[] }
+  | { kind: "error"; message: string };
 
 export function RecentAuditEvents() {
   const t = useCloudT();
+  const [state] = useState<AuditState>({ kind: "missing" });
 
   return (
     <BrandCard className="relative">
       <CornerBrackets size="sm" className="opacity-50" />
       <div className="relative z-10 space-y-3">
         <div>
-          <h3 className="text-lg font-bold text-white">
+          <h3 className="text-lg font-bold text-txt-strong">
             {t("cloud.recentAuditEvents.title", {
               defaultValue: "Recent security events",
             })}
           </h3>
-          <p className="text-sm text-white/60">
+          <p className="text-sm text-muted">
             {t("cloud.recentAuditEvents.subtitle", {
               defaultValue:
                 "Last 50 audit events recorded against your account.",
             })}
           </p>
         </div>
-        <p className="text-sm text-white/50">
-          {t("cloud.recentAuditEvents.notExposed", {
-            defaultValue: "Audit log reading is unavailable on this server.",
-          })}
-        </p>
+        {state.kind === "loading" ? (
+          <p className="text-sm text-muted">
+            {t("cloud.recentAuditEvents.loading", { defaultValue: "Loading…" })}
+          </p>
+        ) : state.kind === "missing" ? (
+          <p className="text-sm text-muted">
+            {t("cloud.recentAuditEvents.notExposed", {
+              defaultValue: "Audit log isn't exposed yet on this server.",
+            })}
+          </p>
+        ) : state.kind === "error" ? (
+          <p className="text-sm text-red-300">{state.message}</p>
+        ) : (
+          <AuditEventList events={state.events} />
+        )}
       </div>
     </BrandCard>
   );

--- a/packages/ui/src/cloud/api-keys/ApiKeysView.tsx
+++ b/packages/ui/src/cloud/api-keys/ApiKeysView.tsx
@@ -384,7 +384,7 @@ export function ApiKeysView({ keys, summary }: ApiKeysViewProps) {
             <div className="grid gap-2">
               <label
                 htmlFor="api-key-name"
-                className="text-xs font-medium text-white/70 uppercase tracking-wide"
+                className="text-xs font-medium text-txt uppercase tracking-wide"
               >
                 {t("cloud.apiKeys.nameLabel", { defaultValue: "Name" })}
               </label>
@@ -398,14 +398,14 @@ export function ApiKeysView({ keys, summary }: ApiKeysViewProps) {
                   setFormData({ ...formData, name: e.target.value })
                 }
                 autoFocus
-                className="rounded-sm border-white/10 bg-black/40 text-white placeholder:text-white/40   "
+                className="rounded-sm border-border bg-surface text-txt-strong placeholder:text-muted   "
               />
             </div>
 
             <div className="grid gap-2">
               <label
                 htmlFor="api-key-description"
-                className="text-xs font-medium text-white/70 uppercase tracking-wide"
+                className="text-xs font-medium text-txt uppercase tracking-wide"
               >
                 {t("cloud.apiKeys.descriptionLabel", {
                   defaultValue: "Description",
@@ -422,12 +422,12 @@ export function ApiKeysView({ keys, summary }: ApiKeysViewProps) {
                   setFormData({ ...formData, description: e.target.value })
                 }
                 rows={3}
-                className="rounded-sm border-white/10 bg-black/40 text-white placeholder:text-white/40   "
+                className="rounded-sm border-border bg-surface text-txt-strong placeholder:text-muted   "
               />
             </div>
 
             <div className="grid gap-2">
-              <p className="text-xs font-medium text-white/70 uppercase tracking-wide">
+              <p className="text-xs font-medium text-txt uppercase tracking-wide">
                 {t("cloud.apiKeys.rateLimitLabel", {
                   defaultValue: "Rate limit",
                 })}
@@ -438,19 +438,19 @@ export function ApiKeysView({ keys, summary }: ApiKeysViewProps) {
                   setRateLimitPreset(value as RateLimitPreset)
                 }
               >
-                <SelectTrigger className="rounded-sm border-white/10 bg-black/40 text-white  ">
+                <SelectTrigger className="rounded-sm border-border bg-surface text-txt-strong  ">
                   <SelectValue
                     placeholder={t("cloud.apiKeys.selectLimit", {
                       defaultValue: "Select a limit",
                     })}
                   />
                 </SelectTrigger>
-                <SelectContent className="rounded-sm border-white/10 bg-black/90">
+                <SelectContent className="rounded-sm border-border bg-popover">
                   {rateLimitPresets.map((preset) => (
                     <SelectItem
                       key={preset.value}
                       value={preset.value}
-                      className="rounded-sm text-white hover:bg-white/10 "
+                      className="rounded-sm text-txt-strong hover:bg-surface "
                     >
                       {t(preset.labelKey, {
                         defaultValue: preset.defaultLabel,
@@ -460,10 +460,10 @@ export function ApiKeysView({ keys, summary }: ApiKeysViewProps) {
                 </SelectContent>
               </Select>
               {rateLimitPreset === "custom" && (
-                <div className="grid gap-2 rounded-sm border border-dashed border-white/10 bg-black/40 p-4">
+                <div className="grid gap-2 rounded-sm border border-dashed border-border bg-surface p-4">
                   <label
                     htmlFor="api-key-rate-custom"
-                    className="text-xs font-medium text-white/70 uppercase tracking-wide"
+                    className="text-xs font-medium text-txt uppercase tracking-wide"
                   >
                     {t("cloud.apiKeys.customRateLabel", {
                       defaultValue: "Custom requests / minute",
@@ -484,7 +484,7 @@ export function ApiKeysView({ keys, summary }: ApiKeysViewProps) {
                     }
                     min={100}
                     step={100}
-                    className="rounded-sm border-white/10 bg-black/60 text-white placeholder:text-white/40   "
+                    className="rounded-sm border-border bg-surface text-txt-strong placeholder:text-muted   "
                   />
                 </div>
               )}
@@ -531,22 +531,22 @@ export function ApiKeysView({ keys, summary }: ApiKeysViewProps) {
             </DialogHeader>
             <div className="space-y-4">
               <div className="grid gap-2">
-                <p className="text-xs font-medium text-white/70 uppercase tracking-wide">
+                <p className="text-xs font-medium text-txt uppercase tracking-wide">
                   {t("cloud.apiKeys.keyName", { defaultValue: "Key name" })}
                 </p>
-                <div className="font-mono text-sm font-semibold text-white">
+                <div className="font-mono text-sm font-semibold text-txt-strong">
                   {createdKey.name}
                 </div>
               </div>
               <div className="grid gap-2">
-                <p className="text-xs font-medium text-white/70 uppercase tracking-wide">
+                <p className="text-xs font-medium text-txt uppercase tracking-wide">
                   {t("cloud.apiKeys.apiKeyLabel", { defaultValue: "API Key" })}
                 </p>
                 <div className="flex gap-2">
                   <Input
                     value={createdKey.plainKey}
                     readOnly
-                    className="font-mono text-sm rounded-sm border-white/10 bg-black/40 text-white"
+                    className="font-mono text-sm rounded-sm border-border bg-surface text-txt-strong"
                   />
                   <BrandButton
                     variant="outline"

--- a/packages/ui/src/cloud/billing/components/auto-top-up-card.tsx
+++ b/packages/ui/src/cloud/billing/components/auto-top-up-card.tsx
@@ -183,7 +183,7 @@ export function AutoTopUpCard() {
 
         <div className="flex items-start justify-between gap-3">
           <div className="space-y-1">
-            <Label className="text-white font-mono text-sm">
+            <Label className="text-txt-strong font-mono text-sm">
               {t("cloud.autoTopUp.enableLabel", {
                 defaultValue: "Enable card auto top-up",
               })}
@@ -249,7 +249,7 @@ export function AutoTopUpCard() {
           />
         </div>
 
-        <div className="flex items-center justify-end gap-3 border-t border-white/10 pt-4">
+        <div className="flex items-center justify-end gap-3 border-t border-border pt-4">
           {validationError ? (
             <p className="text-xs font-mono text-red-400 mr-auto">
               {validationError}

--- a/packages/ui/src/cloud/billing/components/billing-tab.tsx
+++ b/packages/ui/src/cloud/billing/components/billing-tab.tsx
@@ -251,12 +251,12 @@ export function BillingTab({ user }: BillingTabProps) {
 
           <div className="flex flex-col lg:flex-row gap-6 w-full">
             <div className="w-full lg:w-[400px] flex">
-              <div className="bg-[rgba(10,10,10,0.75)] border border-brand-surface flex-1 flex items-center justify-center py-6 lg:py-8">
+              <div className="bg-surface border border-brand-surface flex-1 flex items-center justify-center py-6 lg:py-8">
                 <div className="flex flex-col items-center justify-center gap-1 px-4">
-                  <p className="text-[40px] font-mono text-white tracking-tight">
+                  <p className="text-[40px] font-mono text-txt-strong tracking-tight">
                     ${balance.toFixed(2)}
                   </p>
-                  <p className="text-sm text-white/60 text-center">
+                  <p className="text-sm text-muted text-center">
                     {t("cloud.billingTab.remainingBalance", {
                       defaultValue: "Remaining balance",
                     })}
@@ -272,7 +272,7 @@ export function BillingTab({ user }: BillingTabProps) {
                     defaultValue: "Add credits to your account",
                   })}
                 </p>
-                <p className="text-sm text-white/60">
+                <p className="text-sm text-muted">
                   {t("cloud.billingTab.amountHint", {
                     min: AMOUNT_LIMITS.MIN,
                     max: AMOUNT_LIMITS.MAX,
@@ -321,7 +321,7 @@ export function BillingTab({ user }: BillingTabProps) {
                   <div className="flex-1 max-w-xs">
                     <Label
                       htmlFor="purchase-amount"
-                      className="mb-1.5 block text-white/60 font-mono text-xs"
+                      className="mb-1.5 block text-muted font-mono text-xs"
                     >
                       {t("cloud.billingTab.amountLabel", {
                         defaultValue: "Amount (USD)",
@@ -353,7 +353,7 @@ export function BillingTab({ user }: BillingTabProps) {
                       variant="primary"
                       onClick={handleBuyCredits}
                       disabled={!isValidAmount || isProcessingCheckout}
-                      className="h-11 px-6 w-full sm:w-auto flex-shrink-0 font-mono text-base whitespace-nowrap disabled:border disabled:border-white/10 disabled:bg-white/[0.06] disabled:text-white/35 disabled:opacity-100"
+                      className="h-11 px-6 w-full sm:w-auto flex-shrink-0 font-mono text-base whitespace-nowrap disabled:border disabled:border-border disabled:bg-surface disabled:text-muted disabled:opacity-100"
                     >
                       {isProcessingCheckout ? (
                         <>
@@ -454,27 +454,27 @@ export function BillingTab({ user }: BillingTabProps) {
           <div className="w-full overflow-x-auto">
             <div className="min-w-[600px]">
               <div className="flex w-full">
-                <div className="bg-[rgba(10,10,10,0.75)] border border-brand-surface flex-[1.5] p-3 md:p-4">
-                  <p className="text-xs md:text-sm font-mono font-bold text-white uppercase">
+                <div className="bg-surface border border-brand-surface flex-[1.5] p-3 md:p-4">
+                  <p className="text-xs md:text-sm font-mono font-bold text-txt-strong uppercase">
                     {t("cloud.billingTab.colDateTime", {
                       defaultValue: "Date & Time",
                     })}
                   </p>
                 </div>
-                <div className="bg-[rgba(10,10,10,0.75)] border-t border-r border-b border-brand-surface flex-1 p-3 md:p-4">
-                  <p className="text-xs md:text-sm font-mono font-bold text-white uppercase">
+                <div className="bg-surface border-t border-r border-b border-brand-surface flex-1 p-3 md:p-4">
+                  <p className="text-xs md:text-sm font-mono font-bold text-txt-strong uppercase">
                     {t("cloud.billingTab.colTotal", { defaultValue: "Total" })}
                   </p>
                 </div>
-                <div className="bg-[rgba(10,10,10,0.75)] border-t border-r border-b border-brand-surface flex-1 p-3 md:p-4">
-                  <p className="text-xs md:text-sm font-mono font-bold text-white uppercase">
+                <div className="bg-surface border-t border-r border-b border-brand-surface flex-1 p-3 md:p-4">
+                  <p className="text-xs md:text-sm font-mono font-bold text-txt-strong uppercase">
                     {t("cloud.billingTab.colStatus", {
                       defaultValue: "Status",
                     })}
                   </p>
                 </div>
-                <div className="bg-[rgba(10,10,10,0.75)] border-t border-r border-b border-brand-surface flex-1 p-3 md:p-4">
-                  <p className="text-xs md:text-sm font-mono font-bold text-white uppercase">
+                <div className="bg-surface border-t border-r border-b border-brand-surface flex-1 p-3 md:p-4">
+                  <p className="text-xs md:text-sm font-mono font-bold text-txt-strong uppercase">
                     {t("cloud.billingTab.colActions", {
                       defaultValue: "Actions",
                     })}
@@ -495,14 +495,14 @@ export function BillingTab({ user }: BillingTabProps) {
                         defaultValue: "Invoice history could not be loaded",
                       })}
                     </p>
-                    <p className="text-xs text-white/45 font-mono">
+                    <p className="text-xs text-muted font-mono">
                       {invoicesError}
                     </p>
                   </div>
                 </div>
               ) : invoices.length === 0 ? (
                 <div className="flex items-center justify-center p-8 border-l border-r border-b border-brand-surface">
-                  <p className="text-xs md:text-sm text-white/60 font-mono">
+                  <p className="text-xs md:text-sm text-muted font-mono">
                     {t("cloud.billingTab.noInvoices", {
                       defaultValue: "No invoices yet",
                     })}
@@ -511,27 +511,27 @@ export function BillingTab({ user }: BillingTabProps) {
               ) : (
                 invoices.map((invoice) => (
                   <div key={invoice.id} className="flex w-full">
-                    <div className="bg-[rgba(10,10,10,0.75)] border-l border-r border-b border-brand-surface flex-[1.5] p-3 md:p-4">
-                      <p className="text-xs md:text-sm font-mono text-white">
+                    <div className="bg-surface border-l border-r border-b border-brand-surface flex-[1.5] p-3 md:p-4">
+                      <p className="text-xs md:text-sm font-mono text-txt-strong">
                         {invoice.date}
                       </p>
                     </div>
-                    <div className="bg-[rgba(10,10,10,0.75)] border-r border-b border-brand-surface flex-1 p-3 md:p-4">
-                      <p className="text-xs md:text-sm font-mono text-white uppercase">
+                    <div className="bg-surface border-r border-b border-brand-surface flex-1 p-3 md:p-4">
+                      <p className="text-xs md:text-sm font-mono text-txt-strong uppercase">
                         {invoice.total}
                       </p>
                     </div>
-                    <div className="bg-[rgba(10,10,10,0.75)] border-r border-b border-brand-surface flex-1 p-3 md:p-4">
-                      <p className="text-xs md:text-sm font-mono text-white uppercase">
+                    <div className="bg-surface border-r border-b border-brand-surface flex-1 p-3 md:p-4">
+                      <p className="text-xs md:text-sm font-mono text-txt-strong uppercase">
                         {invoice.status}
                       </p>
                     </div>
-                    <div className="bg-[rgba(10,10,10,0.75)] border-r border-b border-brand-surface flex-1 p-3 md:p-4">
+                    <div className="bg-surface border-r border-b border-brand-surface flex-1 p-3 md:p-4">
                       <Button
                         variant="ghost"
                         type="button"
                         onClick={() => handleViewInvoice(invoice)}
-                        className="text-xs md:text-sm font-mono text-white underline uppercase hover:text-white/80 transition-colors"
+                        className="text-xs md:text-sm font-mono text-txt-strong underline uppercase hover:text-txt transition-colors"
                       >
                         {t("cloud.billingTab.view", { defaultValue: "View" })}
                       </Button>

--- a/packages/ui/src/cloud/billing/components/numeric-field.tsx
+++ b/packages/ui/src/cloud/billing/components/numeric-field.tsx
@@ -27,7 +27,7 @@ export function NumericField({
 }: NumericFieldProps) {
   return (
     <div className="space-y-1">
-      <Label className="text-white font-mono text-sm">{label}</Label>
+      <Label className="text-txt-strong font-mono text-sm">{label}</Label>
       <div className="relative">
         <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#717171] font-mono z-10 pointer-events-none">
           $

--- a/packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx
+++ b/packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx
@@ -71,7 +71,7 @@ export function PayAsYouGoCard() {
 
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1 flex-1 min-w-0">
-            <Label className="text-white font-mono text-sm flex items-center gap-2">
+            <Label className="text-txt-strong font-mono text-sm flex items-center gap-2">
               <Coins className="h-4 w-4 text-[var(--accent)]" />
               Use my app earnings to pay container hosting
             </Label>

--- a/packages/ui/src/cloud/billing/components/payment-waiting-overlay.tsx
+++ b/packages/ui/src/cloud/billing/components/payment-waiting-overlay.tsx
@@ -93,16 +93,16 @@ export function PaymentWaitingOverlay({
     <div
       role="dialog"
       aria-modal="true"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-surface"
     >
-      <div className="w-full max-w-md border border-white/10 bg-[#0b0d11] p-6 text-white">
+      <div className="w-full max-w-md border border-border bg-card p-6 text-txt-strong">
         <div className="flex flex-col items-center text-center">
           {isConfirmed ? (
             <CheckCircle2 className="h-12 w-12 text-emerald-300" />
           ) : isFailed ? (
             <XCircle className="h-12 w-12 text-red-300" />
           ) : (
-            <Loader2 className="h-12 w-12 animate-spin text-white/80" />
+            <Loader2 className="h-12 w-12 animate-spin text-txt" />
           )}
 
           <h2 className="mt-5 text-xl font-semibold">
@@ -119,7 +119,7 @@ export function PaymentWaitingOverlay({
                   })}
           </h2>
 
-          <p className="mt-2 text-sm text-white/65">
+          <p className="mt-2 text-sm text-muted">
             {isConfirmed
               ? data?.bonusCredits
                 ? t("cloud.paymentWaiting.addedCreditWithBonus", {
@@ -151,12 +151,12 @@ export function PaymentWaitingOverlay({
 
           {data?.txHash && (
             <div className="mt-4 w-full">
-              <div className="text-xs text-white/45">
+              <div className="text-xs text-muted">
                 {t("cloud.paymentWaiting.transaction", {
                   defaultValue: "Transaction",
                 })}
               </div>
-              <div className="mt-1 break-all rounded-xs border border-white/10 bg-white/[0.04] px-3 py-2 font-mono text-xs text-white/85">
+              <div className="mt-1 break-all rounded-xs border border-border bg-surface px-3 py-2 font-mono text-xs text-txt">
                 {data.txHash}
               </div>
               {data.explorerUrl && (
@@ -164,7 +164,7 @@ export function PaymentWaitingOverlay({
                   href={data.explorerUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mt-2 inline-flex items-center gap-1.5 text-xs text-white/70 hover:text-white"
+                  className="mt-2 inline-flex items-center gap-1.5 text-xs text-txt hover:text-txt-strong"
                 >
                   {t("cloud.paymentWaiting.viewOnExplorer", {
                     defaultValue: "View on explorer",
@@ -202,7 +202,7 @@ export function PaymentWaitingOverlay({
               <Button
                 onClick={onDismiss}
                 variant="surface"
-                className="rounded-xs text-white/80"
+                className="rounded-xs text-txt"
               >
                 {t("cloud.paymentWaiting.hideKeepWatching", {
                   defaultValue: "Hide — keep watching in background",
@@ -212,7 +212,7 @@ export function PaymentWaitingOverlay({
           </div>
 
           {isWaiting && data?.expiresAt && (
-            <p className="mt-4 text-xs text-white/40">
+            <p className="mt-4 text-xs text-muted">
               {t("cloud.paymentWaiting.expires", {
                 time: new Date(data.expiresAt).toLocaleTimeString(),
                 defaultValue: "expires {{time}}",

--- a/packages/ui/src/cloud/connectors/discord-gateway-connection.tsx
+++ b/packages/ui/src/cloud/connectors/discord-gateway-connection.tsx
@@ -142,7 +142,7 @@ function getStatusBadge(status: DiscordGatewayConnection["status"], t: TFn) {
       );
     case "pending":
       return (
-        <Badge variant="secondary" className="bg-white/10 text-white/80">
+        <Badge variant="secondary" className="bg-surface text-txt">
           <Clock className="h-3 w-3 mr-1" />
           {t("cloud.discord.statusPending", { defaultValue: "Pending" })}
         </Badge>
@@ -574,7 +574,7 @@ export function DiscordGatewayConnection() {
                     <CollapsibleTrigger asChild>
                       <div className="flex items-center gap-4 p-4 cursor-pointer hover:bg-muted/50 transition-colors">
                         <div className="h-12 w-12 rounded-full bg-accent flex items-center justify-center flex-shrink-0">
-                          <Bot className="h-6 w-6 text-white" />
+                          <Bot className="h-6 w-6 text-txt-strong" />
                         </div>
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2">

--- a/packages/ui/src/cloud/connectors/telegram-connection.tsx
+++ b/packages/ui/src/cloud/connectors/telegram-connection.tsx
@@ -190,7 +190,7 @@ export function TelegramConnection() {
       connectedContent={
         <div className="space-y-4">
           <ConnectionIdentityPanel
-            icon={<Bot className="h-6 w-6 text-white" />}
+            icon={<Bot className="h-6 w-6 text-txt-strong" />}
             iconClassName="bg-accent"
             title={`@${status?.botUsername}`}
             subtitle={`Bot ID: ${status?.botId}`}

--- a/packages/ui/src/cloud/organization/OrganizationSection.tsx
+++ b/packages/ui/src/cloud/organization/OrganizationSection.tsx
@@ -33,8 +33,8 @@ export function OrganizationSection() {
         ? "Sign in to Eliza Cloud to manage your organization."
         : "Unable to load your organization.";
     return (
-      <div className="bg-[rgba(10,10,10,0.75)] border border-brand-surface p-8 text-center">
-        <p className="text-sm font-mono text-white/60">{message}</p>
+      <div className="bg-surface border border-brand-surface p-8 text-center">
+        <p className="text-sm font-mono text-muted">{message}</p>
       </div>
     );
   }

--- a/packages/ui/src/cloud/organization/contribute-credential-dialog.tsx
+++ b/packages/ui/src/cloud/organization/contribute-credential-dialog.tsx
@@ -115,17 +115,17 @@ export function ContributeCredentialDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="bg-neutral-950 border border-brand-surface p-4 sm:p-6 max-w-[95vw] sm:max-w-md">
+      <DialogContent className="bg-popover border border-brand-surface p-4 sm:p-6 max-w-[95vw] sm:max-w-md">
         {result ? (
           <>
             <DialogHeader>
-              <DialogTitle className="flex items-center gap-2 text-white font-mono">
+              <DialogTitle className="flex items-center gap-2 text-txt-strong font-mono">
                 <ShieldCheck className="h-5 w-5 text-green-500" />
                 {t("cloud.contributeCredential.pooledTitle", {
                   defaultValue: "Key Added to the Pool",
                 })}
               </DialogTitle>
-              <DialogDescription className="text-white/60 font-mono text-xs md:text-sm">
+              <DialogDescription className="text-muted font-mono text-xs md:text-sm">
                 {t("cloud.contributeCredential.pooledDescription", {
                   provider: POOLED_PROVIDER_LABELS[provider],
                   defaultValue:
@@ -134,8 +134,8 @@ export function ContributeCredentialDialog({
               </DialogDescription>
             </DialogHeader>
 
-            <div className="bg-[rgba(10,10,10,0.75)] border border-brand-surface p-3">
-              <code className="text-xs font-mono text-white">
+            <div className="bg-surface border border-brand-surface p-3">
+              <code className="text-xs font-mono text-txt-strong">
                 {t("cloud.contributeCredential.maskedAs", {
                   last4: result.last4,
                   defaultValue: "Listed in the pool as ••••{{last4}}",
@@ -159,13 +159,13 @@ export function ContributeCredentialDialog({
         ) : (
           <>
             <DialogHeader>
-              <DialogTitle className="flex items-center gap-2 text-white font-mono">
+              <DialogTitle className="flex items-center gap-2 text-txt-strong font-mono">
                 <KeyRound className="h-5 w-5 text-[var(--accent)]" />
                 {t("cloud.contributeCredential.title", {
                   defaultValue: "Contribute an API Key",
                 })}
               </DialogTitle>
-              <DialogDescription className="text-white/60 font-mono text-xs md:text-sm">
+              <DialogDescription className="text-muted font-mono text-xs md:text-sm">
                 {t("cloud.contributeCredential.description", {
                   defaultValue:
                     "Add a provider API key to your organization's shared pool. The key is validated live against the provider, then encrypted — nobody can ever read it back.",
@@ -189,7 +189,7 @@ export function ContributeCredentialDialog({
               <div className="space-y-2">
                 <Label
                   htmlFor="credential-provider"
-                  className="text-white font-mono text-sm"
+                  className="text-txt-strong font-mono text-sm"
                 >
                   {t("cloud.contributeCredential.provider", {
                     defaultValue: "Provider",
@@ -204,14 +204,14 @@ export function ContributeCredentialDialog({
                 >
                   <SelectTrigger
                     id="credential-provider"
-                    className="bg-transparent border-[#303030] text-white"
+                    className="bg-transparent border-border text-txt-strong"
                   >
                     <SelectValue />
                   </SelectTrigger>
-                  <SelectContent className="bg-[#1a1a1a] border-[#303030]">
+                  <SelectContent className="bg-popover border-border">
                     {POOLED_PROVIDERS.map((id) => (
                       <SelectItem key={id} value={id}>
-                        <span className="font-mono text-white">
+                        <span className="font-mono text-txt-strong">
                           {POOLED_PROVIDER_LABELS[id]}
                         </span>
                       </SelectItem>
@@ -223,7 +223,7 @@ export function ContributeCredentialDialog({
               <div className="space-y-2">
                 <Label
                   htmlFor="credential-api-key"
-                  className="text-white font-mono text-sm"
+                  className="text-txt-strong font-mono text-sm"
                 >
                   {t("cloud.contributeCredential.apiKey", {
                     defaultValue: "API Key",
@@ -239,9 +239,9 @@ export function ContributeCredentialDialog({
                   required
                   autoFocus
                   autoComplete="off"
-                  className="bg-transparent border-[#303030] text-white font-mono"
+                  className="bg-transparent border-border text-txt-strong font-mono"
                 />
-                <p className="text-xs font-mono text-white/40">
+                <p className="text-xs font-mono text-muted">
                   {t("cloud.contributeCredential.apiKeyHint", {
                     defaultValue:
                       "Validated with a live call before it enters the pool",
@@ -252,7 +252,7 @@ export function ContributeCredentialDialog({
               <div className="space-y-2">
                 <Label
                   htmlFor="credential-label"
-                  className="text-white font-mono text-sm"
+                  className="text-txt-strong font-mono text-sm"
                 >
                   {t("cloud.contributeCredential.label", {
                     defaultValue: "Label (optional)",
@@ -269,7 +269,7 @@ export function ContributeCredentialDialog({
                   onChange={(e) => setLabel(e.target.value)}
                   disabled={isSubmitting}
                   maxLength={120}
-                  className="bg-transparent border-[#303030] text-white"
+                  className="bg-transparent border-border text-txt-strong"
                 />
               </div>
 
@@ -279,7 +279,7 @@ export function ContributeCredentialDialog({
                   type="button"
                   onClick={handleClose}
                   disabled={isSubmitting}
-                  className="px-4 py-2 text-white hover:bg-white/5 transition-colors disabled:opacity-50 order-2 sm:order-1"
+                  className="px-4 py-2 text-txt-strong hover:bg-surface transition-colors disabled:opacity-50 order-2 sm:order-1"
                 >
                   {t("cloud.contributeCredential.cancel", {
                     defaultValue: "Cancel",

--- a/packages/ui/src/cloud/organization/credentials-list.tsx
+++ b/packages/ui/src/cloud/organization/credentials-list.tsx
@@ -84,9 +84,9 @@ export function CredentialsList({
 
   if (credentials.length === 0) {
     return (
-      <div className="bg-[rgba(10,10,10,0.75)] border border-brand-surface p-8 text-center">
-        <KeyRound className="h-12 w-12 mx-auto text-white/40 mb-4" />
-        <p className="text-sm font-mono text-white/60">
+      <div className="bg-surface border border-brand-surface p-8 text-center">
+        <KeyRound className="h-12 w-12 mx-auto text-muted mb-4" />
+        <p className="text-sm font-mono text-muted">
           {t("cloud.credentialsList.empty", {
             defaultValue:
               "No pooled credentials yet. Contribute a provider API key to get started.",
@@ -121,14 +121,14 @@ export function CredentialsList({
         return (
           <div
             key={credential.id}
-            className={`bg-[rgba(10,10,10,0.75)] border border-brand-surface p-3 md:p-4 ${credential.enabled ? "" : "opacity-60"}`}
+            className={`bg-surface border border-brand-surface p-3 md:p-4 ${credential.enabled ? "" : "opacity-60"}`}
           >
             <div className="flex flex-col sm:flex-row items-start justify-between gap-3 sm:gap-4">
               <div className="flex-1 min-w-0 w-full space-y-2">
                 {/* Label + provider badge */}
                 <div className="flex items-center gap-2 flex-wrap">
-                  <KeyRound className="h-4 w-4 text-white/40 flex-shrink-0" />
-                  <span className="font-mono font-semibold text-sm md:text-base text-white truncate">
+                  <KeyRound className="h-4 w-4 text-muted flex-shrink-0" />
+                  <span className="font-mono font-semibold text-sm md:text-base text-txt-strong truncate">
                     {credential.label}
                   </span>
                   <span className="px-2 py-0.5 border border-[var(--accent)]/40 bg-[var(--accent)]/10 text-[var(--accent)] text-xs font-mono uppercase">
@@ -137,7 +137,7 @@ export function CredentialsList({
                 </div>
 
                 {/* Masked key + health */}
-                <div className="flex items-center gap-3 flex-wrap text-xs md:text-sm font-mono text-white/60">
+                <div className="flex items-center gap-3 flex-wrap text-xs md:text-sm font-mono text-muted">
                   <span title={`key ending in ${credential.last4}`}>
                     ••••{credential.last4}
                   </span>
@@ -159,7 +159,7 @@ export function CredentialsList({
                 )}
 
                 {/* Usage + contributor */}
-                <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 text-xs font-mono text-white/40">
+                <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 text-xs font-mono text-muted">
                   <span>
                     {t("cloud.credentialsList.callsToday", {
                       count: credential.callsToday,
@@ -221,19 +221,19 @@ export function CredentialsList({
                           label: credential.label,
                           defaultValue: "Remove {{label}}",
                         })}
-                        className="p-2 hover:bg-white/5 transition-colors border border-white/10"
+                        className="p-2 hover:bg-surface transition-colors border border-border"
                       >
                         <Trash2 className="h-4 w-4 text-[#EB4335]" />
                       </Button>
                     </AlertDialogTrigger>
-                    <AlertDialogContent className="bg-neutral-950 border border-brand-surface">
+                    <AlertDialogContent className="bg-popover border border-brand-surface">
                       <AlertDialogHeader>
-                        <AlertDialogTitle className="text-white font-mono">
+                        <AlertDialogTitle className="text-txt-strong font-mono">
                           {t("cloud.credentialsList.removeTitle", {
                             defaultValue: "Remove Credential",
                           })}
                         </AlertDialogTitle>
-                        <AlertDialogDescription className="text-white/60 font-mono text-sm">
+                        <AlertDialogDescription className="text-muted font-mono text-sm">
                           {t("cloud.credentialsList.removeConfirm", {
                             label: credential.label,
                             defaultValue:
@@ -242,14 +242,14 @@ export function CredentialsList({
                         </AlertDialogDescription>
                       </AlertDialogHeader>
                       <AlertDialogFooter>
-                        <AlertDialogCancel className="bg-transparent border-[#303030] text-white hover:bg-white/5">
+                        <AlertDialogCancel className="bg-transparent border-border text-txt-strong hover:bg-surface">
                           {t("cloud.credentialsList.cancel", {
                             defaultValue: "Cancel",
                           })}
                         </AlertDialogCancel>
                         <AlertDialogAction
                           onClick={() => onRemove(credential.id)}
-                          className="bg-[#EB4335] hover:bg-[#EB4335]/90 text-white"
+                          className="bg-[#EB4335] hover:bg-[#EB4335]/90 text-txt-strong"
                         >
                           {t("cloud.credentialsList.remove", {
                             defaultValue: "Remove",

--- a/packages/ui/src/cloud/organization/credentials-list.tsx
+++ b/packages/ui/src/cloud/organization/credentials-list.tsx
@@ -145,7 +145,7 @@ export function CredentialsList({
                     <span
                       data-testid={`health-dot-${credential.id}`}
                       data-health={credential.health}
-                      className={`inline-block w-2 h-2 rounded-full ${credential.enabled ? healthDotClass(credential.health) : "bg-white/30"}`}
+                      className={`inline-block w-2 h-2 rounded-full ${credential.enabled ? healthDotClass(credential.health) : "bg-muted"}`}
                     />
                     <span className="capitalize">
                       {healthLabel(credential)}

--- a/packages/ui/src/cloud/organization/credentials-tab.tsx
+++ b/packages/ui/src/cloud/organization/credentials-tab.tsx
@@ -104,12 +104,12 @@ export function CredentialsTab({
       {/* Header with Contribute + Invite & connect */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <div>
-          <h3 className="text-base md:text-lg font-mono font-semibold text-white">
+          <h3 className="text-base md:text-lg font-mono font-semibold text-txt-strong">
             {t("cloud.credentialsTab.title", {
               defaultValue: "Team Credential Pool",
             })}
           </h3>
-          <p className="text-xs md:text-sm font-mono text-white/60">
+          <p className="text-xs md:text-sm font-mono text-muted">
             {t("cloud.credentialsTab.subtitle", {
               defaultValue:
                 "Provider API keys your org rotates across. Keys are encrypted; only the last 4 characters are ever shown.",

--- a/packages/ui/src/cloud/organization/invite-member-dialog.tsx
+++ b/packages/ui/src/cloud/organization/invite-member-dialog.tsx
@@ -119,15 +119,15 @@ export function InviteMemberDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="bg-neutral-950 border border-brand-surface p-4 sm:p-6 max-w-[95vw] sm:max-w-md">
+      <DialogContent className="bg-popover border border-brand-surface p-4 sm:p-6 max-w-[95vw] sm:max-w-md">
         {inviteLink ? (
           <>
             <DialogHeader>
-              <DialogTitle className="flex items-center gap-2 text-white font-mono">
+              <DialogTitle className="flex items-center gap-2 text-txt-strong font-mono">
                 <Link2 className="h-5 w-5 text-[var(--accent)]" />
                 Invitation Created
               </DialogTitle>
-              <DialogDescription className="text-white/60 font-mono text-xs md:text-sm">
+              <DialogDescription className="text-muted font-mono text-xs md:text-sm">
                 The email is on its way — or share this link directly. It
                 expires in 7 days and can be revoked from Pending Invitations.
                 {connectIntent && (
@@ -140,8 +140,8 @@ export function InviteMemberDialog({
               </DialogDescription>
             </DialogHeader>
 
-            <div className="bg-[rgba(10,10,10,0.75)] border border-brand-surface p-3 flex items-center gap-2">
-              <code className="flex-1 text-xs font-mono text-white break-all">
+            <div className="bg-surface border border-brand-surface p-3 flex items-center gap-2">
+              <code className="flex-1 text-xs font-mono text-txt-strong break-all">
                 {inviteLink}
               </code>
               <Button
@@ -149,12 +149,12 @@ export function InviteMemberDialog({
                 type="button"
                 onClick={handleCopyLink}
                 aria-label="Copy invite link"
-                className="p-2 hover:bg-white/5 transition-colors border border-white/10 flex-shrink-0"
+                className="p-2 hover:bg-surface transition-colors border border-border flex-shrink-0"
               >
-                <Copy className="h-4 w-4 text-white/60" />
+                <Copy className="h-4 w-4 text-muted" />
               </Button>
             </div>
-            <p className="text-xs font-mono text-white/40">
+            <p className="text-xs font-mono text-muted">
               The link contains no secrets — joining still requires signing in
               with the invited email.
             </p>
@@ -173,16 +173,16 @@ export function InviteMemberDialog({
         ) : (
           <>
             <DialogHeader>
-              <DialogTitle className="flex items-center gap-2 text-white font-mono">
+              <DialogTitle className="flex items-center gap-2 text-txt-strong font-mono">
                 <Mail className="h-5 w-5 text-[var(--accent)]" />
                 Invite Team Member
               </DialogTitle>
-              <DialogDescription className="text-white/60 font-mono text-xs md:text-sm">
+              <DialogDescription className="text-muted font-mono text-xs md:text-sm">
                 Send an invitation to join{" "}
-                <span className="text-white">{organizationName}</span>.
+                <span className="text-txt-strong">{organizationName}</span>.
                 They&apos;ll receive an email with a link to accept. Accepting
                 will switch them to{" "}
-                <span className="text-white">{organizationName}</span> — a
+                <span className="text-txt-strong">{organizationName}</span> — a
                 person belongs to one organization at a time, so they&apos;ll
                 leave their current one.
               </DialogDescription>
@@ -199,7 +199,10 @@ export function InviteMemberDialog({
               )}
 
               <div className="space-y-2">
-                <Label htmlFor="email" className="text-white font-mono text-sm">
+                <Label
+                  htmlFor="email"
+                  className="text-txt-strong font-mono text-sm"
+                >
                   Email Address
                 </Label>
                 <Input
@@ -211,9 +214,9 @@ export function InviteMemberDialog({
                   disabled={isSubmitting}
                   required
                   autoFocus
-                  className="bg-transparent border-[#303030] text-white"
+                  className="bg-transparent border-border text-txt-strong"
                 />
-                <p className="text-xs font-mono text-white/40">
+                <p className="text-xs font-mono text-muted">
                   They&apos;ll need to sign up with this email address
                 </p>
               </div>
@@ -221,7 +224,7 @@ export function InviteMemberDialog({
               <div className="space-y-2">
                 <Label
                   htmlFor="role"
-                  className="flex items-center gap-2 text-white font-mono text-sm"
+                  className="flex items-center gap-2 text-txt-strong font-mono text-sm"
                 >
                   <UserCog className="h-4 w-4 text-[var(--accent)]" />
                   Role
@@ -233,27 +236,27 @@ export function InviteMemberDialog({
                 >
                   <SelectTrigger
                     id="role"
-                    className="bg-transparent border-[#303030] text-white"
+                    className="bg-transparent border-border text-txt-strong"
                   >
                     <SelectValue />
                   </SelectTrigger>
-                  <SelectContent className="bg-[#1a1a1a] border-[#303030]">
+                  <SelectContent className="bg-popover border-border">
                     <SelectItem value="member">
                       <div className="flex flex-col items-start">
-                        <span className="font-mono font-medium text-white">
+                        <span className="font-mono font-medium text-txt-strong">
                           Member
                         </span>
-                        <span className="text-xs font-mono text-white/40">
+                        <span className="text-xs font-mono text-muted">
                           Can use resources and view organization
                         </span>
                       </div>
                     </SelectItem>
                     <SelectItem value="admin">
                       <div className="flex flex-col items-start">
-                        <span className="font-mono font-medium text-white">
+                        <span className="font-mono font-medium text-txt-strong">
                           Admin
                         </span>
-                        <span className="text-xs font-mono text-white/40">
+                        <span className="text-xs font-mono text-muted">
                           Can invite and manage members
                         </span>
                       </div>
@@ -268,7 +271,7 @@ export function InviteMemberDialog({
                   type="button"
                   onClick={handleClose}
                   disabled={isSubmitting}
-                  className="px-4 py-2 text-white hover:bg-white/5 transition-colors disabled:opacity-50 order-2 sm:order-1"
+                  className="px-4 py-2 text-txt-strong hover:bg-surface transition-colors disabled:opacity-50 order-2 sm:order-1"
                 >
                   Cancel
                 </Button>

--- a/packages/ui/src/cloud/organization/members-list.tsx
+++ b/packages/ui/src/cloud/organization/members-list.tsx
@@ -59,9 +59,9 @@ export function MembersList({
   const t = useCloudT();
   if (members.length === 0) {
     return (
-      <div className="bg-[rgba(10,10,10,0.75)] border border-brand-surface p-8 text-center">
-        <User className="h-12 w-12 mx-auto text-white/40 mb-4" />
-        <p className="text-sm font-mono text-white/60">
+      <div className="bg-surface border border-brand-surface p-8 text-center">
+        <User className="h-12 w-12 mx-auto text-muted mb-4" />
+        <p className="text-sm font-mono text-muted">
           {t("cloud.membersList.noMembers", {
             defaultValue: "No members found",
           })}
@@ -128,12 +128,12 @@ export function MembersList({
       {members.map((member) => (
         <div
           key={member.id}
-          className="bg-[rgba(10,10,10,0.75)] border border-brand-surface p-3 md:p-4"
+          className="bg-surface border border-brand-surface p-3 md:p-4"
         >
           <div className="flex flex-col sm:flex-row items-start gap-4">
             {/* Avatar */}
             <div className="flex items-center justify-center bg-[rgba(var(--accent-rgb), 0.25)] size-10 md:size-12 flex-shrink-0">
-              <span className="text-white text-sm md:text-base font-mono font-medium">
+              <span className="text-txt-strong text-sm md:text-base font-mono font-medium">
                 {getInitials(member)}
               </span>
             </div>
@@ -143,11 +143,11 @@ export function MembersList({
               <div className="flex flex-col lg:flex-row items-start justify-between gap-3 lg:gap-4">
                 <div className="flex-1 min-w-0 w-full">
                   <div className="flex items-center gap-2 mb-1 flex-wrap">
-                    <h4 className="font-mono font-semibold text-sm md:text-base text-white truncate">
+                    <h4 className="font-mono font-semibold text-sm md:text-base text-txt-strong truncate">
                       {getDisplayName(member)}
                     </h4>
                     {member.id === currentUserId && (
-                      <span className="px-2 py-0.5 border border-white/20 text-xs font-mono text-white/60">
+                      <span className="px-2 py-0.5 border border-border-strong text-xs font-mono text-muted">
                         {t("cloud.membersList.you", { defaultValue: "You" })}
                       </span>
                     )}
@@ -155,13 +155,13 @@ export function MembersList({
 
                   <div className="space-y-1">
                     {member.email && (
-                      <p className="text-xs md:text-sm font-mono text-white/60 flex items-center gap-1.5">
+                      <p className="text-xs md:text-sm font-mono text-muted flex items-center gap-1.5">
                         <Mail className="h-3.5 w-3.5 flex-shrink-0" />
                         <span className="truncate">{member.email}</span>
                       </p>
                     )}
                     {member.wallet_address && (
-                      <p className="text-xs md:text-sm font-mono text-white/60 flex items-center gap-1.5 flex-wrap">
+                      <p className="text-xs md:text-sm font-mono text-muted flex items-center gap-1.5 flex-wrap">
                         <Wallet className="h-3.5 w-3.5 flex-shrink-0" />
                         <span className="font-mono text-xs break-all">
                           {member.wallet_address.substring(0, 10)}...
@@ -170,13 +170,13 @@ export function MembersList({
                           )}
                         </span>
                         {member.wallet_chain_type && (
-                          <span className="px-2 py-0.5 border border-white/20 text-xs font-mono text-white/60">
+                          <span className="px-2 py-0.5 border border-border-strong text-xs font-mono text-muted">
                             {member.wallet_chain_type}
                           </span>
                         )}
                       </p>
                     )}
-                    <p className="text-xs font-mono text-white/40">
+                    <p className="text-xs font-mono text-muted">
                       {t("cloud.membersList.memberSince", {
                         date: format(
                           new Date(member.created_at),
@@ -195,7 +195,7 @@ export function MembersList({
                       value={member.role}
                       onValueChange={(role) => onUpdateRole(member.id, role)}
                     >
-                      <SelectTrigger className="w-full sm:w-32 bg-transparent border-[#303030] text-white">
+                      <SelectTrigger className="w-full sm:w-32 bg-transparent border-border text-txt-strong">
                         <SelectValue>
                           <div className="flex items-center gap-1.5">
                             {getRoleIcon(member.role)}
@@ -205,7 +205,7 @@ export function MembersList({
                           </div>
                         </SelectValue>
                       </SelectTrigger>
-                      <SelectContent className="bg-[#1a1a1a] border-[#303030]">
+                      <SelectContent className="bg-popover border-border">
                         <SelectItem value="admin">
                           <div className="flex items-center gap-1.5">
                             <Shield className="h-4 w-4" />
@@ -230,7 +230,7 @@ export function MembersList({
                     </Select>
                   ) : (
                     <span
-                      className={`px-2 py-1 border text-xs font-mono uppercase flex items-center gap-1.5 ${member.role === "owner" ? "bg-[var(--accent)]/20 text-[var(--accent)] border-[var(--accent)]/40" : member.role === "admin" ? "bg-white/10 text-white border-white/20" : "bg-white/5 text-white/60 border-white/10"}`}
+                      className={`px-2 py-1 border text-xs font-mono uppercase flex items-center gap-1.5 ${member.role === "owner" ? "bg-[var(--accent)]/20 text-[var(--accent)] border-[var(--accent)]/40" : member.role === "admin" ? "bg-surface text-txt-strong border-border-strong" : "bg-surface text-muted border-border"}`}
                     >
                       {getRoleIcon(member.role)}
                       <span className="capitalize">{member.role}</span>
@@ -243,19 +243,19 @@ export function MembersList({
                         <Button
                           variant="ghost"
                           type="button"
-                          className="p-2 hover:bg-white/5 transition-colors border border-white/10"
+                          className="p-2 hover:bg-surface transition-colors border border-border"
                         >
                           <UserMinus className="h-4 w-4 text-[#EB4335]" />
                         </Button>
                       </AlertDialogTrigger>
-                      <AlertDialogContent className="bg-neutral-950 border border-brand-surface">
+                      <AlertDialogContent className="bg-popover border border-brand-surface">
                         <AlertDialogHeader>
-                          <AlertDialogTitle className="text-white font-mono">
+                          <AlertDialogTitle className="text-txt-strong font-mono">
                             {t("cloud.membersList.removeMember", {
                               defaultValue: "Remove Member",
                             })}
                           </AlertDialogTitle>
-                          <AlertDialogDescription className="text-white/60 font-mono text-sm">
+                          <AlertDialogDescription className="text-muted font-mono text-sm">
                             {t("cloud.membersList.removeConfirm", {
                               name: getDisplayName(member),
                               defaultValue:
@@ -264,14 +264,14 @@ export function MembersList({
                           </AlertDialogDescription>
                         </AlertDialogHeader>
                         <AlertDialogFooter>
-                          <AlertDialogCancel className="bg-transparent border-[#303030] text-white hover:bg-white/5">
+                          <AlertDialogCancel className="bg-transparent border-border text-txt-strong hover:bg-surface">
                             {t("cloud.membersList.cancel", {
                               defaultValue: "Cancel",
                             })}
                           </AlertDialogCancel>
                           <AlertDialogAction
                             onClick={() => onRemove(member.id)}
-                            className="bg-[#EB4335] hover:bg-[#EB4335]/90 text-white"
+                            className="bg-[#EB4335] hover:bg-[#EB4335]/90 text-txt-strong"
                           >
                             {t("cloud.membersList.remove", {
                               defaultValue: "Remove",

--- a/packages/ui/src/cloud/organization/members-tab.tsx
+++ b/packages/ui/src/cloud/organization/members-tab.tsx
@@ -140,10 +140,10 @@ export function MembersTab({ user }: MembersTabProps) {
         {/* Header with Invite Button */}
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
           <div>
-            <h3 className="text-base md:text-lg font-mono font-semibold text-white">
+            <h3 className="text-base md:text-lg font-mono font-semibold text-txt-strong">
               {t("cloud.membersTab.title", { defaultValue: "Team Members" })}
             </h3>
-            <p className="text-xs md:text-sm font-mono text-white/60">
+            <p className="text-xs md:text-sm font-mono text-muted">
               {t("cloud.membersTab.subtitle", {
                 defaultValue: "Manage who has access to your organization",
               })}
@@ -182,8 +182,8 @@ export function MembersTab({ user }: MembersTabProps) {
 
         {/* Pending Invites */}
         {canManageMembers && (
-          <div className="pt-4 md:pt-6 border-t border-white/10">
-            <h3 className="text-base md:text-lg font-mono font-semibold mb-3 md:mb-4 text-white">
+          <div className="pt-4 md:pt-6 border-t border-border">
+            <h3 className="text-base md:text-lg font-mono font-semibold mb-3 md:mb-4 text-txt-strong">
               {t("cloud.membersTab.pendingInvitations", {
                 defaultValue: "Pending Invitations",
               })}

--- a/packages/ui/src/cloud/organization/organization-general-tab.tsx
+++ b/packages/ui/src/cloud/organization/organization-general-tab.tsx
@@ -37,23 +37,23 @@ export function OrganizationGeneralTab({
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <p className="text-xs font-mono font-medium text-white/50 uppercase tracking-wide">
+              <p className="text-xs font-mono font-medium text-muted uppercase tracking-wide">
                 Organization Name
               </p>
-              <p className="mt-1 text-sm font-mono font-semibold text-white">
+              <p className="mt-1 text-sm font-mono font-semibold text-txt-strong">
                 {organization.name}
               </p>
             </div>
             <div>
-              <p className="text-xs font-mono font-medium text-white/50 uppercase tracking-wide">
+              <p className="text-xs font-mono font-medium text-muted uppercase tracking-wide">
                 Organization Slug
               </p>
-              <p className="mt-1 text-sm font-mono text-white">
+              <p className="mt-1 text-sm font-mono text-txt-strong">
                 {organization.slug}
               </p>
             </div>
             <div>
-              <p className="text-xs font-mono font-medium text-white/50 uppercase tracking-wide">
+              <p className="text-xs font-mono font-medium text-muted uppercase tracking-wide">
                 Status
               </p>
               <div className="mt-1">
@@ -65,10 +65,10 @@ export function OrganizationGeneralTab({
               </div>
             </div>
             <div>
-              <p className="text-xs font-mono font-medium text-white/50 uppercase tracking-wide">
+              <p className="text-xs font-mono font-medium text-muted uppercase tracking-wide">
                 Created
               </p>
-              <p className="mt-1 text-sm font-mono flex items-center gap-1.5 text-white">
+              <p className="mt-1 text-sm font-mono flex items-center gap-1.5 text-txt-strong">
                 <Calendar className="h-3.5 w-3.5 text-[var(--accent)]" />
                 {format(new Date(organization.created_at), "MMM d, yyyy")}
               </p>
@@ -93,19 +93,19 @@ export function OrganizationGeneralTab({
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <p className="text-xs font-mono font-medium text-white/50 uppercase tracking-wide">
+              <p className="text-xs font-mono font-medium text-muted uppercase tracking-wide">
                 Credit Balance
               </p>
-              <p className="mt-1 text-xl md:text-2xl font-mono font-bold text-white">
+              <p className="mt-1 text-xl md:text-2xl font-mono font-bold text-txt-strong">
                 {Number(organization.credit_balance).toLocaleString()} credits
               </p>
             </div>
             {organization.billing_email && (
               <div>
-                <p className="text-xs font-mono font-medium text-white/50 uppercase tracking-wide">
+                <p className="text-xs font-mono font-medium text-muted uppercase tracking-wide">
                   Billing Email
                 </p>
-                <p className="mt-1 text-sm font-mono text-white break-all">
+                <p className="mt-1 text-sm font-mono text-txt-strong break-all">
                   {organization.billing_email}
                 </p>
               </div>

--- a/packages/ui/src/cloud/organization/organization-tab.tsx
+++ b/packages/ui/src/cloud/organization/organization-tab.tsx
@@ -58,7 +58,7 @@ export function OrganizationTab({ user }: OrganizationTabProps) {
       <BrandCard className="relative">
         <CornerBrackets size="sm" className="opacity-50" />
         <div className="relative z-10 text-center py-12">
-          <p className="text-white/60">No organization found</p>
+          <p className="text-muted">No organization found</p>
         </div>
       </BrandCard>
     );
@@ -77,16 +77,16 @@ export function OrganizationTab({ user }: OrganizationTabProps) {
                 {user.organization.name}
               </h2>
             </div>
-            <p className="text-xs md:text-sm font-mono text-white/60">
+            <p className="text-xs md:text-sm font-mono text-muted">
               {user.organization.slug}
             </p>
           </div>
-          <div className="bg-[rgba(10,10,10,0.75)] border border-brand-surface px-4 py-3">
+          <div className="bg-surface border border-brand-surface px-4 py-3">
             <div className="text-left sm:text-right">
-              <p className="text-xl md:text-2xl font-mono font-bold text-white">
+              <p className="text-xl md:text-2xl font-mono font-bold text-txt-strong">
                 ${Number(user.organization.credit_balance).toFixed(2)}
               </p>
-              <p className="text-xs font-mono text-white/50 uppercase tracking-wide">
+              <p className="text-xs font-mono text-muted uppercase tracking-wide">
                 Credits Available
               </p>
             </div>

--- a/packages/ui/src/cloud/organization/pending-invites-list.tsx
+++ b/packages/ui/src/cloud/organization/pending-invites-list.tsx
@@ -46,11 +46,9 @@ export function PendingInvitesList({
 
   if (pendingInvites.length === 0) {
     return (
-      <div className="bg-[rgba(10,10,10,0.75)] border border-brand-surface p-6 text-center">
-        <Mail className="h-10 w-10 mx-auto text-white/40 mb-3" />
-        <p className="text-sm font-mono text-white/60">
-          No pending invitations
-        </p>
+      <div className="bg-surface border border-brand-surface p-6 text-center">
+        <Mail className="h-10 w-10 mx-auto text-muted mb-3" />
+        <p className="text-sm font-mono text-muted">No pending invitations</p>
       </div>
     );
   }
@@ -80,7 +78,7 @@ export function PendingInvitesList({
     switch (invite.status) {
       case "pending":
         return (
-          <span className="px-2 py-0.5 border border-white/20 bg-white/10 text-white flex items-center gap-1 text-xs font-mono">
+          <span className="px-2 py-0.5 border border-border-strong bg-surface text-txt-strong flex items-center gap-1 text-xs font-mono">
             <Clock className="h-3 w-3" />
             Pending
           </span>
@@ -94,14 +92,14 @@ export function PendingInvitesList({
         );
       case "revoked":
         return (
-          <span className="px-2 py-0.5 border border-white/10 bg-white/5 text-white/40 flex items-center gap-1 text-xs font-mono">
+          <span className="px-2 py-0.5 border border-border bg-surface text-muted flex items-center gap-1 text-xs font-mono">
             <XCircle className="h-3 w-3" />
             Revoked
           </span>
         );
       default:
         return (
-          <span className="px-2 py-0.5 border border-white/10 text-xs font-mono text-white/60">
+          <span className="px-2 py-0.5 border border-border text-xs font-mono text-muted">
             {invite.status}
           </span>
         );
@@ -122,21 +120,21 @@ export function PendingInvitesList({
         return (
           <div
             key={invite.id}
-            className="bg-[rgba(10,10,10,0.75)] border border-brand-surface p-3 md:p-4"
+            className="bg-surface border border-brand-surface p-3 md:p-4"
           >
             <div className="flex flex-col sm:flex-row items-start justify-between gap-3 sm:gap-4">
               <div className="flex-1 min-w-0 w-full space-y-2">
                 {/* Email */}
                 <div className="flex items-center gap-2">
-                  <Mail className="h-4 w-4 text-white/40 flex-shrink-0" />
-                  <span className="font-mono font-medium text-sm md:text-base text-white truncate">
+                  <Mail className="h-4 w-4 text-muted flex-shrink-0" />
+                  <span className="font-mono font-medium text-sm md:text-base text-txt-strong truncate">
                     {invite.email}
                   </span>
                 </div>
 
                 {/* Role */}
                 <div className="flex items-center gap-2 flex-wrap">
-                  <span className="px-2 py-0.5 border border-white/20 text-xs font-mono text-white/60 flex items-center gap-1">
+                  <span className="px-2 py-0.5 border border-border-strong text-xs font-mono text-muted flex items-center gap-1">
                     {getRoleIcon(invite.role)}
                     <span className="capitalize">{invite.role}</span>
                   </span>
@@ -144,7 +142,7 @@ export function PendingInvitesList({
                 </div>
 
                 {/* Metadata */}
-                <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 text-xs font-mono text-white/40">
+                <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 text-xs font-mono text-muted">
                   <span>Invited by {getInviterName(invite)}</span>
                   <span className="hidden sm:inline">•</span>
                   <span>
@@ -173,19 +171,19 @@ export function PendingInvitesList({
                     <Button
                       variant="ghost"
                       type="button"
-                      className="p-2 hover:bg-white/5 transition-colors border border-white/10"
+                      className="p-2 hover:bg-surface transition-colors border border-border"
                     >
                       <X className="h-4 w-4 text-[#EB4335]" />
                     </Button>
                   </AlertDialogTrigger>
-                  <AlertDialogContent className="bg-neutral-950 border border-brand-surface">
+                  <AlertDialogContent className="bg-popover border border-brand-surface">
                     <AlertDialogHeader>
-                      <AlertDialogTitle className="text-white font-mono">
+                      <AlertDialogTitle className="text-txt-strong font-mono">
                         Revoke Invitation
                       </AlertDialogTitle>
-                      <AlertDialogDescription className="text-white/60 font-mono text-sm">
+                      <AlertDialogDescription className="text-muted font-mono text-sm">
                         Are you sure you want to revoke the invitation for{" "}
-                        <span className="font-medium text-white">
+                        <span className="font-medium text-txt-strong">
                           {invite.email}
                         </span>
                         ? They will not be able to join using this invitation
@@ -193,12 +191,12 @@ export function PendingInvitesList({
                       </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
-                      <AlertDialogCancel className="bg-transparent border-[#303030] text-white hover:bg-white/5">
+                      <AlertDialogCancel className="bg-transparent border-border text-txt-strong hover:bg-surface">
                         Cancel
                       </AlertDialogCancel>
                       <AlertDialogAction
                         onClick={() => onRevoke(invite.id)}
-                        className="bg-[#EB4335] hover:bg-[#EB4335]/90 text-white"
+                        className="bg-[#EB4335] hover:bg-[#EB4335]/90 text-txt-strong"
                       >
                         Revoke
                       </AlertDialogAction>
@@ -214,7 +212,7 @@ export function PendingInvitesList({
       {/* Show revoked/accepted invites */}
       {invites.filter((i) => i.status !== "pending").length > 0 && (
         <details className="mt-4 md:mt-6">
-          <summary className="cursor-pointer text-xs md:text-sm font-mono text-white/60 hover:text-white transition-colors">
+          <summary className="cursor-pointer text-xs md:text-sm font-mono text-muted hover:text-txt-strong transition-colors">
             Show past invitations (
             {invites.filter((i) => i.status !== "pending").length})
           </summary>
@@ -224,24 +222,24 @@ export function PendingInvitesList({
               .map((invite) => (
                 <div
                   key={invite.id}
-                  className="bg-[rgba(10,10,10,0.75)] border border-brand-surface p-3 md:p-4 opacity-60"
+                  className="bg-surface border border-brand-surface p-3 md:p-4 opacity-60"
                 >
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex-1 min-w-0 space-y-2">
                       <div className="flex items-center gap-2">
-                        <Mail className="h-4 w-4 text-white/40 flex-shrink-0" />
-                        <span className="font-mono font-medium text-sm text-white truncate">
+                        <Mail className="h-4 w-4 text-muted flex-shrink-0" />
+                        <span className="font-mono font-medium text-sm text-txt-strong truncate">
                           {invite.email}
                         </span>
                       </div>
                       <div className="flex items-center gap-2 flex-wrap">
-                        <span className="px-2 py-0.5 border border-white/20 text-xs font-mono text-white/60 flex items-center gap-1">
+                        <span className="px-2 py-0.5 border border-border-strong text-xs font-mono text-muted flex items-center gap-1">
                           {getRoleIcon(invite.role)}
                           <span className="capitalize">{invite.role}</span>
                         </span>
                         {getStatusBadge(invite)}
                       </div>
-                      <div className="text-xs font-mono text-white/40">
+                      <div className="text-xs font-mono text-muted">
                         {invite.status === "accepted" && invite.accepted_at && (
                           <span>
                             Accepted{" "}

--- a/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
+++ b/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Cloud settings token regression test. Lifted Cloud settings views must remain
+ * readable in both light and dark app shells, so this static scan rejects
+ * dark-island utility classes on the shared settings surfaces.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(fileURLToPath(new URL("..", import.meta.url)));
+
+const SCANNED_PATHS = [
+  "account-security",
+  "organization",
+  "billing/components",
+  "connectors/discord-gateway-connection.tsx",
+  "connectors/telegram-connection.tsx",
+  "api-keys/ApiKeysView.tsx",
+];
+
+const FORBIDDEN_THEME_LOCKED_CLASSES = [
+  "text-white",
+  "text-white/",
+  "bg-white/10",
+  "bg-white/5",
+  "bg-white/[",
+  "border-white/10",
+  "border-white/15",
+  "border-white/20",
+  "bg-black/40",
+  "bg-black/60",
+  "bg-black/90",
+  "bg-[rgba(10,10,10,0.75)]",
+  "bg-[#1a1a1a]",
+  "bg-neutral-950",
+];
+
+const ALLOWED_EXPLICIT_BLACK_CONTROLS = new Set([
+  "billing/components/direct-crypto-credit-card.tsx",
+]);
+
+function collectFiles(path: string): string[] {
+  const fullPath = join(ROOT, path);
+  if (statSync(fullPath).isFile()) return [path];
+
+  return readdirSync(fullPath).flatMap((entry) => {
+    const child = join(path, entry);
+    const childFullPath = join(ROOT, child);
+    if (statSync(childFullPath).isDirectory()) return collectFiles(child);
+    return child.endsWith(".tsx") ? [child] : [];
+  });
+}
+
+describe("Cloud settings theme tokens", () => {
+  it("keeps lifted Cloud settings bodies readable without a dark theme island", () => {
+    const offenders: string[] = [];
+
+    for (const file of SCANNED_PATHS.flatMap(collectFiles)) {
+      if (ALLOWED_EXPLICIT_BLACK_CONTROLS.has(file)) continue;
+
+      const source = readFileSync(join(ROOT, file), "utf8");
+      for (const token of FORBIDDEN_THEME_LOCKED_CLASSES) {
+        if (source.includes(token)) offenders.push(`${file}: ${token}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
+++ b/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
@@ -23,8 +23,10 @@ const SCANNED_PATHS = [
 const FORBIDDEN_THEME_LOCKED_CLASSES = [
   "text-white",
   "text-white/",
+  "divide-white",
   "bg-white/10",
   "bg-white/5",
+  "bg-white/30",
   "bg-white/[",
   "border-white/10",
   "border-white/15",


### PR DESCRIPTION
## Summary
- consolidates #13782 and #13784 on top of current `develop` so the account-security MFA/session panels do not conflict
- keeps the DTO-driven loading/unavailable/error/empty/ready states for `/api/v1/me/mfa` and `/api/v1/sessions` while applying the light/dark token cleanup from the Cloud settings retokenization
- adds malformed DTO regression assertions so missing `enrolled` or `sessions` fields render errors instead of healthy disabled/empty states
- adds the Cloud settings token scan header and preserves the dark utility regression scan

## Verification
- `bun run --cwd packages/shared build:i18n`
- `bun test packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts` (1 pass)
- `bunx biome check packages/ui/src/cloud/account-security/components/mfa-panel.tsx packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts --no-errors-on-unmatched`
- `git diff --check`

## Known local verification blockers
- `bun run --cwd packages/ui test -- src/cloud/account-security/components/account-security-panels.test.tsx src/cloud/settings/cloud-settings-theme-tokens.test.ts --run` reaches the account-security assertions but fails in this `/tmp` worktree with duplicate React invalid-hook errors from the shared node_modules/dist resolution. This matches the local worktree failure reported on #13782 and is not an assertion failure.
- `bun run --cwd packages/app audit:app --help` is not help-only; it starts the app audit build and currently fails before screenshots in `@elizaos/core` declaration generation with existing `dist/node_modules` missing-declaration errors (`drizzle-orm`, `yaml`, `fs-extra`, etc.). Required rendered evidence is therefore still pending.
- `bun run audit:ui-determinism -- --report` fails on a broader existing Cloud UI baseline gap across many files; this consolidation removes the new active-sessions render-time `toLocaleString()` by formatting the timestamp during the async load path.

## Evidence / N/A
- Live LLM trajectories: N/A - no model, prompt, provider, or agent behavior changed.
- Screenshots/video/audit: pending; this PR should not merge until the app audit/visual evidence path is unblocked or captured in CI/artifacts.

Supersedes #13782 and #13784; follow-up to #13760 and #13767.