### PR TITLE
fix(ui): fail closed on account-security DTOs

### DIFF
--- a/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
@@ -143,12 +143,36 @@ describe("account-security panels", () => {
     expect(apiMock).toHaveBeenCalledWith("/api/v1/sessions");
   });
 
+  it("renders malformed sessions separately from healthy empty", async () => {
+    apiMock.mockResolvedValueOnce({});
+
+    render(<ActiveSessionsPanel />);
+
+    expect(
+      await screen.findByText("Malformed session inventory response."),
+    ).toBeTruthy();
+    expect(screen.queryByText(/No other active sessions found/i)).toBeNull();
+    expect(screen.queryByText(/Session listing is unavailable/i)).toBeNull();
+  });
+
   it("renders MFA errors separately from unavailable and disabled", async () => {
     apiMock.mockRejectedValueOnce(new Error("mfa route failed"));
 
     render(<MfaPanel />);
 
     expect(await screen.findByText("mfa route failed")).toBeTruthy();
+    expect(screen.queryByText(/MFA enrollment is unavailable/i)).toBeNull();
+    expect(screen.queryByText(/MFA is not enabled/i)).toBeNull();
+  });
+
+  it("renders malformed MFA separately from disabled success", async () => {
+    apiMock.mockResolvedValueOnce({});
+
+    render(<MfaPanel />);
+
+    expect(
+      await screen.findByText("Malformed MFA status response."),
+    ).toBeTruthy();
     expect(screen.queryByText(/MFA enrollment is unavailable/i)).toBeNull();
     expect(screen.queryByText(/MFA is not enabled/i)).toBeNull();
   });

--- a/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
@@ -30,6 +30,37 @@ type SessionsState =
   | { kind: "ready"; sessions: SessionRow[] }
   | { kind: "error"; message: string };
 
+function parseSessionsResponse(payload: SessionsResponse): SessionsState {
+  if (payload.available === false) {
+    return {
+      kind: "unavailable",
+      reason: payload.reason ?? null,
+    };
+  }
+
+  if (!Array.isArray(payload.sessions)) {
+    return {
+      kind: "error",
+      message: "Malformed session inventory response.",
+    };
+  }
+
+  const invalidSession = payload.sessions.find(
+    (session) => typeof session.id !== "string" || session.id.length === 0,
+  );
+  if (invalidSession) {
+    return {
+      kind: "error",
+      message: "Malformed session inventory response.",
+    };
+  }
+
+  return {
+    kind: "ready",
+    sessions: payload.sessions,
+  };
+}
+
 export function ActiveSessionsPanel() {
   const t = useCloudT();
   const [state, setState] = useState<SessionsState>({ kind: "loading" });
@@ -39,17 +70,7 @@ export function ActiveSessionsPanel() {
     void api<SessionsResponse>("/api/v1/sessions")
       .then((payload) => {
         if (!active) return;
-        if (payload.available === false) {
-          setState({
-            kind: "unavailable",
-            reason: payload.reason ?? null,
-          });
-          return;
-        }
-        setState({
-          kind: "ready",
-          sessions: Array.isArray(payload.sessions) ? payload.sessions : [],
-        });
+        setState(parseSessionsResponse(payload));
       })
       .catch((error) => {
         if (!active) return;
@@ -125,9 +146,7 @@ export function ActiveSessionsPanel() {
                   <p className="font-mono text-[11px] text-white/50">
                     {t("cloud.activeSessions.ipLastSeen", {
                       ip: session.ip ?? "-",
-                      lastSeen: session.last_seen
-                        ? new Date(session.last_seen).toLocaleString()
-                        : "-",
+                      lastSeen: session.last_seen ? session.last_seen : "-",
                       defaultValue: "{{ip}} - last seen {{lastSeen}}",
                     })}
                   </p>

--- a/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
@@ -23,6 +23,34 @@ type MfaState =
   | { kind: "ready"; enrolled: boolean; method: string | null }
   | { kind: "error"; message: string };
 
+function parseMfaStatusResponse(payload: MfaStatusResponse): MfaState {
+  if (payload.available === false) {
+    return { kind: "unavailable", reason: payload.reason ?? null };
+  }
+
+  if (typeof payload.enrolled !== "boolean") {
+    return {
+      kind: "error",
+      message: "Malformed MFA status response.",
+    };
+  }
+
+  if (payload.method !== null && payload.method !== undefined) {
+    if (typeof payload.method !== "string" || payload.method.length === 0) {
+      return {
+        kind: "error",
+        message: "Malformed MFA status response.",
+      };
+    }
+  }
+
+  return {
+    kind: "ready",
+    enrolled: payload.enrolled,
+    method: payload.method ?? null,
+  };
+}
+
 export function MfaPanel() {
   const t = useCloudT();
   const [state, setState] = useState<MfaState>({ kind: "loading" });
@@ -32,15 +60,7 @@ export function MfaPanel() {
     void api<MfaStatusResponse>("/api/v1/me/mfa")
       .then((payload) => {
         if (!active) return;
-        if (payload.available === false) {
-          setState({ kind: "unavailable", reason: payload.reason ?? null });
-          return;
-        }
-        setState({
-          kind: "ready",
-          enrolled: Boolean(payload.enrolled),
-          method: payload.method ?? null,
-        });
+        setState(parseMfaStatusResponse(payload));
       })
       .catch((error) => {
         if (!active) return;


### PR DESCRIPTION
## Summary
- follow up the merged #13782 regression by rejecting malformed account-security DTOs instead of rendering healthy-empty/disabled success
- render `{}` from `/api/v1/sessions` as `Malformed session inventory response.` instead of “No other active sessions found”
- render `{}` from `/api/v1/me/mfa` as `Malformed MFA status response.` instead of “MFA is not enabled”
- remove locale-defaulted `toLocaleString()` from the sessions render path

## Verification
```bash
bunx @biomejs/biome check packages/ui/src/cloud/account-security/components/mfa-panel.tsx packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx --no-errors-on-unmatched
# pass

git diff --check
# pass
```

Attempted focused test:
```bash
bun run --cwd packages/ui test -- src/cloud/account-security/components/account-security-panels.test.tsx --coverage.enabled=false
```
This is blocked in the disposable worktree by duplicate React resolution after symlinking the main checkout dependencies (`dist/node_modules/react` vs root `react-dom`), before assertions run. The added tests are still included so CI/package-local installs catch the regression.

## Evidence / N/A
- UI screenshots/video: still needed before merge because this is app-visible shared UI.
- Live LLM trajectories: N/A - no model, prompt, provider, or agent behavior changed.
- Domain artifacts: focused tests cover malformed DTO handling for the two account-security routes.

Fix-forward for the post-merge review of #13782 / #13760.
