### PR TITLE
test(#13693): assert Android auth callback outcome

### DIFF
--- a/packages/app-core/scripts/mobile-auth-simulator-smoke.mjs
+++ b/packages/app-core/scripts/mobile-auth-simulator-smoke.mjs
@@ -583,6 +583,131 @@ function shellSingleQuote(value) {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
+function xmlEscape(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function xmlUnescape(value) {
+  return String(value)
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}
+
+export function readAndroidPreferenceValueFromXml(xml, key) {
+  const keyPattern = escapeRegExp(xmlEscape(key));
+  const match = String(xml).match(
+    new RegExp(`<string\\s+name="${keyPattern}">([\\s\\S]*?)<\\/string>`),
+  );
+  return match ? xmlUnescape(match[1]) : "";
+}
+
+function writeAndroidCapacitorPreferences(adb, serial, appId, entries) {
+  const xml = [
+    "<?xml version='1.0' encoding='utf-8' standalone='yes' ?>",
+    "<map>",
+    ...Object.entries(entries).map(
+      ([key, value]) =>
+        `    <string name="${xmlEscape(key)}">${xmlEscape(value)}</string>`,
+    ),
+    "</map>",
+    "",
+  ].join("\n");
+  const encoded = Buffer.from(xml, "utf8").toString("base64");
+  const script = [
+    "mkdir -p shared_prefs",
+    `(printf %s ${encoded} | base64 -d > shared_prefs/CapacitorStorage.xml) || (printf %s ${encoded} | toybox base64 -d > shared_prefs/CapacitorStorage.xml)`,
+    "chmod 660 shared_prefs/CapacitorStorage.xml",
+  ].join(" && ");
+  runCommand(
+    adb,
+    [
+      "-s",
+      serial,
+      "shell",
+      `run-as ${shellSingleQuote(appId)} sh -c ${shellSingleQuote(script)}`,
+    ],
+    `Android auth callback preference seed for ${appId}`,
+  );
+}
+
+function readAndroidCapacitorPreference(adb, serial, appId, key) {
+  let xml = "";
+  try {
+    xml = runCommand(
+      adb,
+      [
+        "-s",
+        serial,
+        "shell",
+        `run-as ${shellSingleQuote(appId)} cat shared_prefs/CapacitorStorage.xml`,
+      ],
+      `Android auth callback preference read for ${appId}`,
+    );
+  } catch {
+    return "";
+  }
+  return readAndroidPreferenceValueFromXml(xml, key);
+}
+
+function armAndroidAuthCallbackSmoke(adb, serial, app, url) {
+  const expected = expectedAuthCallbackFromUrl(url);
+  writeAndroidCapacitorPreferences(adb, serial, app.appId, {
+    [IOS_AUTH_CALLBACK_SMOKE_REQUEST_KEY]: JSON.stringify({
+      expected,
+      armedAt: new Date().toISOString(),
+    }),
+    [IOS_AUTH_CALLBACK_SMOKE_RESULT_KEY]: JSON.stringify({
+      ok: false,
+      phase: "requested",
+      expected,
+      updatedAt: new Date().toISOString(),
+    }),
+  });
+  return expected;
+}
+
+async function pollAndroidAuthCallbackSmoke(adb, serial, app, expected) {
+  let lastRaw = "";
+  for (let attempt = 1; attempt <= IOS_AUTH_CALLBACK_ATTEMPTS; attempt += 1) {
+    lastRaw = readAndroidCapacitorPreference(
+      adb,
+      serial,
+      app.appId,
+      IOS_AUTH_CALLBACK_SMOKE_RESULT_KEY,
+    );
+    if (lastRaw) {
+      let parsed = null;
+      try {
+        parsed = JSON.parse(lastRaw);
+      } catch {
+        parsed = null;
+      }
+      if (parsed?.phase === "failed" || parsed?.error) {
+        throw new Error(`Android auth callback smoke failed: ${lastRaw}`);
+      }
+      if (parsed?.ok === true) {
+        return assertAuthCallbackResult(
+          parsed,
+          expected,
+          "Android auth callback",
+        );
+      }
+    }
+    await sleep(IOS_AUTH_CALLBACK_DELAY_MS);
+  }
+  throw new Error(
+    `Android auth callback smoke timed out after ${IOS_AUTH_CALLBACK_ATTEMPTS} attempts. Last result: ${lastRaw || "<none>"}`,
+  );
+}
+
 // Parse the winning component from `cmd package resolve-activity` output.
 // We invoke it with `--brief`, which prints the resolved component as a bare
 // `<package>/<activity>` line (e.g. `ai.elizaos.app/.MainActivity`), or
@@ -659,7 +784,7 @@ function assertAndroidResolvesToPackage(adb, serial, app, url) {
   return resolvedName;
 }
 
-function runAndroidSimulator(app, url, options) {
+async function runAndroidSimulator(app, url, options) {
   const adb = resolveAdb();
   const serial = resolveAndroidSerial(adb, options.serial);
   // Preflight: the scheme must resolve to OUR package, not a consumer app
@@ -670,6 +795,7 @@ function runAndroidSimulator(app, url, options) {
     app,
     url,
   );
+  const expected = armAndroidAuthCallbackSmoke(adb, serial, app, url);
   runCommand(
     adb,
     [
@@ -708,11 +834,18 @@ function runAndroidSimulator(app, url, options) {
       `Android callback did not resolve to ${app.appId}. am start output:\n${output}`,
     );
   }
+  const handled = await pollAndroidAuthCallbackSmoke(
+    adb,
+    serial,
+    app,
+    expected,
+  );
   return {
     platform: "android",
     serial,
     openedUrl: url,
     resolvedActivity,
+    handled,
   };
 }
 
@@ -755,7 +888,7 @@ async function main() {
     simulatorResults.push(
       platform === "ios"
         ? await runIosSimulator(app, url, options)
-        : runAndroidSimulator(app, url, options),
+        : await runAndroidSimulator(app, url, options),
     );
   }
 

--- a/packages/app-core/test/scripts/mobile-auth-simulator-smoke.test.ts
+++ b/packages/app-core/test/scripts/mobile-auth-simulator-smoke.test.ts
@@ -16,6 +16,7 @@ import {
   expectedAuthCallbackFromUrl,
   parseArgs,
   parseResolvedActivity,
+  readAndroidPreferenceValueFromXml,
   resolvedActivityMatchesApp,
   resolveTargetAppDir,
 } from "../../scripts/mobile-auth-simulator-smoke.mjs";
@@ -189,6 +190,36 @@ describe("mobile-auth-simulator-smoke: auth outcome assertion (#13693)", () => {
     expect(() =>
       assertAuthCallbackResult({ ...okResult, ok: false }, expected, "iOS"),
     ).toThrow(/did not report ok=true/);
+  });
+});
+
+describe("mobile-auth-simulator-smoke: Android auth outcome preferences (#13693)", () => {
+  it("reads the auth callback result from Capacitor Preferences XML", () => {
+    const result = JSON.stringify({
+      ok: true,
+      phase: "handled",
+      sessionEstablished: false,
+      path: "auth/callback",
+      state: "simulator-oauth-state",
+      code: "simulator-oauth-code",
+    });
+    const xml = [
+      "<?xml version='1.0' encoding='utf-8' standalone='yes' ?>",
+      "<map>",
+      `  <string name="eliza:auth-callback-smoke:result">${result.replaceAll('"', "&quot;")}</string>`,
+      "</map>",
+    ].join("\n");
+
+    expect(
+      readAndroidPreferenceValueFromXml(
+        xml,
+        "eliza:auth-callback-smoke:result",
+      ),
+    ).toBe(result);
+  });
+
+  it("returns empty string when the Android result key is absent", () => {
+    expect(readAndroidPreferenceValueFromXml("<map />", "missing")).toBe("");
   });
 });
 

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -2086,10 +2086,24 @@ async function recordIosAuthCallbackSmoke(
     const activeServer = window.localStorage.getItem("elizaos:active-server");
     sessionEstablished =
       typeof activeServer === "string" && activeServer.length > 0;
-  } catch {
-    // error-policy:J7 diagnostics readback — an unreadable key reports the
-    // safe/expected end state (no session established by the callback).
-    sessionEstablished = false;
+  } catch (error) {
+    // error-policy:J7 diagnostics readback — the smoke observes this as a
+    // failed diagnostic result instead of fabricating the expected outcome.
+    await writeIosAuthCallbackSmokeResult({
+      ok: false,
+      phase: "failed",
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to read active-server outcome.",
+      path,
+      url,
+      state: parsed.searchParams.get("state") ?? "",
+      code: parsed.searchParams.get("code") ?? "",
+      query: Object.fromEntries(parsed.searchParams.entries()),
+      request,
+    });
+    return;
   }
 
   await writeIosAuthCallbackSmokeResult({


### PR DESCRIPTION
Fixes #13693 follow-up after #13783. [shaw-verify]

## What changed
- Android `test:sim:auth` now arms the same Capacitor Preferences request/result keys before firing the callback.
- The Android harness polls `shared_prefs/CapacitorStorage.xml` through `run-as`, parses the smoke result, and passes it through the shared `assertAuthCallbackResult` contract.
- The JSON simulator result now includes the handled Android payload instead of stopping at `am start` / component resolution.
- Added unit coverage for Android Capacitor Preferences result extraction.

## Verification
- `bun run --cwd packages/app-core test -- test/scripts/mobile-auth-simulator-smoke.test.ts` -> 20/20 pass.
- `bunx biome check packages/app-core/scripts/mobile-auth-simulator-smoke.mjs packages/app-core/test/scripts/mobile-auth-simulator-smoke.test.ts packages/app/src/main.tsx` -> clean.
- `git diff --check origin/develop...HEAD && git diff --check` -> clean.
- `bun run --cwd packages/app test:sim:auth:android -- --registration-only` -> passes when the generated Android project is present.
- `bun run --cwd packages/app test:sim:auth:android` -> fails truthfully on this host with `adb not found. Set ADB or ANDROID_HOME before running.`

## Evidence N/A
- Screenshots/video: N/A, this changes a simulator auth smoke harness and no user-visible UI.
- iOS/Android full simulator payload capture: pending a host with usable `simctl`/`adb`; this host has no `adb` and `xcrun simctl` is unavailable.