### PR TITLE
fix(ui): route unhandled cloud sign-in CTA

### DIFF
--- a/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
+++ b/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
@@ -173,6 +173,33 @@ describe("ChoiceWidget — pick an option", () => {
     ).toBe(true);
     expect(screen.getByRole("status").textContent).toMatch(/Ship it/);
   });
+
+  it("renders the cloud-only first-run sign-in CTA as a real clickable button", () => {
+    const onChoose = vi.fn();
+    render(
+      <ChoiceWidget
+        id="runtime"
+        scope="first-run"
+        options={[
+          {
+            value: "__first_run__:runtime:cloud",
+            label: "Sign in to Eliza Cloud",
+          },
+        ]}
+        onChoose={onChoose}
+      />,
+    );
+
+    const signIn = screen.getByRole("button", {
+      name: "Sign in to Eliza Cloud",
+    });
+    expect(signIn.tagName).toBe("BUTTON");
+    expect(signIn.closest("button")).toBe(signIn);
+
+    fireEvent.click(signIn);
+    expect(onChoose).toHaveBeenCalledTimes(1);
+    expect(onChoose).toHaveBeenCalledWith("__first_run__:runtime:cloud");
+  });
 });
 
 describe("ChoiceWidget — put their own in (allowCustom)", () => {

--- a/packages/ui/src/first-run/first-run-action-channel.test.ts
+++ b/packages/ui/src/first-run/first-run-action-channel.test.ts
@@ -6,6 +6,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   classifyActionMessage,
   FIRST_RUN_ACTION_PREFIX,
+  FIRST_RUN_CLOUD_LOGIN_ACTION,
+  FIRST_RUN_CLOUD_LOGIN_FALLBACK_PATH,
+  getFirstRunCloudLoginFallbackPath,
   setFirstRunActionHandler,
   setFirstRunTextHandler,
   tryHandleFirstRunAction,
@@ -90,6 +93,29 @@ describe("classifyActionMessage (the send funnel's routing contract)", () => {
   it("routes free text to the conductor while onboarding is active and sends it afterwards", () => {
     expect(classifyActionMessage("hello", false)).toBe("conductor");
     expect(classifyActionMessage("hello", true)).toBe("send");
+  });
+});
+
+describe("cloud sign-in fallback", () => {
+  it("routes an unhandled cloud sign-in CTA to hosted web login before first-run completes", () => {
+    expect(
+      getFirstRunCloudLoginFallbackPath(FIRST_RUN_CLOUD_LOGIN_ACTION, false),
+    ).toBe(FIRST_RUN_CLOUD_LOGIN_FALLBACK_PATH);
+  });
+
+  it("does not route stale first-run widgets after onboarding completes", () => {
+    expect(
+      getFirstRunCloudLoginFallbackPath(FIRST_RUN_CLOUD_LOGIN_ACTION, true),
+    ).toBeNull();
+  });
+
+  it("does not route other first-run actions to login", () => {
+    expect(
+      getFirstRunCloudLoginFallbackPath(
+        `${FIRST_RUN_ACTION_PREFIX}runtime:local`,
+        false,
+      ),
+    ).toBeNull();
   });
 });
 

--- a/packages/ui/src/first-run/first-run-action-channel.ts
+++ b/packages/ui/src/first-run/first-run-action-channel.ts
@@ -17,6 +17,8 @@
 
 /** Reserved sentinel prefix for first-run choice values. Never a real message. */
 export const FIRST_RUN_ACTION_PREFIX = "__first_run__:";
+export const FIRST_RUN_CLOUD_LOGIN_ACTION = `${FIRST_RUN_ACTION_PREFIX}runtime:cloud`;
+export const FIRST_RUN_CLOUD_LOGIN_FALLBACK_PATH = "/login?returnTo=/chat";
 
 type FirstRunActionHandler = (value: string) => boolean;
 type FirstRunTextHandler = (text: string) => boolean;
@@ -49,6 +51,22 @@ export function tryHandleFirstRunAction(value: string): boolean {
   if (!handler) return false;
   if (!value.startsWith(FIRST_RUN_ACTION_PREFIX)) return false;
   return handler(value);
+}
+
+/**
+ * Hosted-web fallback for the cloud-only sign-in CTA. Normally the mounted
+ * conductor consumes `runtime:cloud` and starts the in-app OAuth handoff. If
+ * that handler is absent while first-run is still incomplete, the visible CTA
+ * must still navigate to the login route instead of silently dropping the tap.
+ */
+export function getFirstRunCloudLoginFallbackPath(
+  value: string,
+  firstRunComplete: boolean,
+): string | null {
+  if (firstRunComplete) return null;
+  return value === FIRST_RUN_CLOUD_LOGIN_ACTION
+    ? FIRST_RUN_CLOUD_LOGIN_FALLBACK_PATH
+    : null;
 }
 
 /**

--- a/packages/ui/src/state/AppContext.tsx
+++ b/packages/ui/src/state/AppContext.tsx
@@ -20,6 +20,7 @@ import { getBootConfig } from "../config/boot-config-store";
 import { BrandingContext, DEFAULT_BRANDING } from "../config/branding";
 import {
   classifyActionMessage,
+  getFirstRunCloudLoginFallbackPath,
   tryHandleFirstRunAction,
   tryHandleFirstRunText,
 } from "../first-run/first-run-action-channel";
@@ -1189,9 +1190,19 @@ function AppProviderInner({
       // and NEVER reach the server — regardless of onboarding state.
       if (tryHandleModelAction(text)) return Promise.resolve();
       switch (classifyActionMessage(text, firstRunComplete === true)) {
-        case "first-run":
-          tryHandleFirstRunAction(text);
+        case "first-run": {
+          const handled = tryHandleFirstRunAction(text);
+          const fallbackPath = handled
+            ? null
+            : getFirstRunCloudLoginFallbackPath(
+                text,
+                firstRunComplete === true,
+              );
+          if (fallbackPath && typeof window !== "undefined") {
+            window.location.assign(fallbackPath);
+          }
           return Promise.resolve();
+        }
         case "conductor":
           tryHandleFirstRunText(text);
           return Promise.resolve();


### PR DESCRIPTION
## Summary
- when a first-run `runtime:cloud` sign-in action is visible but no conductor handler consumes it, route hosted web users to `/login?returnTo=/chat` instead of silently dropping the tap
- keep completed/stale first-run widgets inert so old transcript actions still never become chat sends
- add coverage that the cloud-only sign-in CTA renders as a real button and dispatches the expected first-run action

## Verification
- bun run --cwd packages/ui test src/first-run/first-run-action-channel.test.ts src/components/chat/widgets/interaction-widgets.behavior.test.tsx --run
- bunx biome check packages/ui/src/first-run/first-run-action-channel.ts packages/ui/src/first-run/first-run-action-channel.test.ts packages/ui/src/state/AppContext.tsx packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
- git diff --check -- packages/ui/src/first-run/first-run-action-channel.ts packages/ui/src/first-run/first-run-action-channel.test.ts packages/ui/src/state/AppContext.tsx packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx

Closes #13758