### PR TITLE
fix(#13693): assert auth callback classification

### DIFF
--- a/packages/app-core/scripts/mobile-auth-simulator-smoke.mjs
+++ b/packages/app-core/scripts/mobile-auth-simulator-smoke.mjs
@@ -255,6 +255,24 @@ function preferenceNativeKeys(key) {
   return [`CapacitorStorage.${key}`, key];
 }
 
+function xmlEscape(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function xmlUnescape(value) {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
 function tryRunCommand(command, args) {
   try {
     return execFileSync(command, args, {
@@ -366,6 +384,60 @@ function flushIosPreferences(device) {
   tryRunCommand("xcrun", ["simctl", "spawn", device, "killall", "cfprefsd"]);
 }
 
+export function buildAndroidPreferenceXml(entries) {
+  const strings = Object.entries(entries)
+    .map(
+      ([key, value]) =>
+        `  <string name="${xmlEscape(key)}">${xmlEscape(value)}</string>`,
+    )
+    .join("\n");
+  return `<?xml version='1.0' encoding='utf-8' standalone='yes' ?>\n<map>\n${strings}\n</map>\n`;
+}
+
+export function readAndroidPreferenceFromXml(xml, key) {
+  for (const nativeKey of preferenceNativeKeys(key)) {
+    const escapedKey = xmlEscape(nativeKey).replace(
+      /[.*+?^${}()|[\]\\]/g,
+      "\\$&",
+    );
+    const match = xml.match(
+      new RegExp(`<string\\s+name=["']${escapedKey}["']>([\\s\\S]*?)</string>`),
+    );
+    if (match) return xmlUnescape(match[1]);
+  }
+  return null;
+}
+
+function writeAndroidPreferenceMap(adb, serial, appId, entries) {
+  const xml = buildAndroidPreferenceXml(entries);
+  const encoded = Buffer.from(xml, "utf8").toString("base64");
+  const command = [
+    "run-as",
+    appId,
+    "sh",
+    "-c",
+    shellSingleQuote(
+      `mkdir -p shared_prefs && printf %s ${encoded} | base64 -d > shared_prefs/CapacitorStorage.xml`,
+    ),
+  ];
+  runCommand(
+    adb,
+    ["-s", serial, "shell", command.join(" ")],
+    `Android preference seed for ${appId}`,
+  );
+}
+
+function readAndroidPreference(adb, serial, appId, key) {
+  const xml = tryRunCommand(adb, [
+    "-s",
+    serial,
+    "shell",
+    ["run-as", appId, "cat", "shared_prefs/CapacitorStorage.xml"].join(" "),
+  ]);
+  if (!xml) return null;
+  return readAndroidPreferenceFromXml(xml, key);
+}
+
 export function expectedAuthCallbackFromUrl(url) {
   const parsed = new URL(url);
   return {
@@ -376,6 +448,8 @@ export function expectedAuthCallbackFromUrl(url) {
     code: parsed.searchParams.get("code") ?? "",
   };
 }
+
+const EXPECTED_AUTH_CALLBACK_CLASSIFICATION = "synthetic_callback_rejected";
 
 // #13693: validate the auth-callback END STATE, not just that a result payload
 // arrived. Factored out (and exported) so both the iOS poll and its unit tests
@@ -389,11 +463,10 @@ export function expectedAuthCallbackFromUrl(url) {
 // The real security invariant this handler enforces is that an OS-delivered
 // deep link NEVER establishes an authenticated session (no bearer token is
 // accepted from a deep link; a crafted callback must not authenticate the app).
-// The in-app handler reads its real `elizaos:active-server` session storage
-// back and reports `sessionEstablished`. This assertion requires that field to
-// be present AND `false`: a handler that skipped the readback writes no
-// `sessionEstablished` (throws — the red the issue asks for), and a regression
-// that started accepting the deep-link token would report `true` (also red).
+// The in-app handler classifies the synthetic callback as rejected and reads its
+// real `elizaos:active-server` session storage back. Both fields are required:
+// a deliver-only echo never classifies the callback, and a regression that
+// accepts the deep-link token would report `sessionEstablished=true`.
 //
 // Returns the parsed payload on success; throws a descriptive Error otherwise.
 export function assertAuthCallbackResult(parsed, expected, platformLabel) {
@@ -414,6 +487,11 @@ export function assertAuthCallbackResult(parsed, expected, platformLabel) {
   if (parsed.state !== expected.state || parsed.code !== expected.code) {
     throw new Error(
       `${label} query mismatch: expected state/code ${expected.state}/${expected.code}, got ${parsed.state}/${parsed.code}`,
+    );
+  }
+  if (parsed.classification !== EXPECTED_AUTH_CALLBACK_CLASSIFICATION) {
+    throw new Error(
+      `${label}: callback was not classified as ${EXPECTED_AUTH_CALLBACK_CLASSIFICATION}; got ${JSON.stringify(parsed.classification)}.`,
     );
   }
   // THE auth-outcome assertion (#13693): the handler must have read its real
@@ -468,6 +546,23 @@ function armIosAuthCallbackSmoke(device, app, url) {
   return expected;
 }
 
+function armAndroidAuthCallbackSmoke(adb, serial, app, url) {
+  const expected = expectedAuthCallbackFromUrl(url);
+  writeAndroidPreferenceMap(adb, serial, app.appId, {
+    [IOS_AUTH_CALLBACK_SMOKE_REQUEST_KEY]: JSON.stringify({
+      expected,
+      armedAt: new Date().toISOString(),
+    }),
+    [IOS_AUTH_CALLBACK_SMOKE_RESULT_KEY]: JSON.stringify({
+      ok: false,
+      phase: "requested",
+      expected,
+      updatedAt: new Date().toISOString(),
+    }),
+  });
+  return expected;
+}
+
 async function pollIosAuthCallbackSmoke(device, app, expected) {
   let lastRaw = "";
   for (let attempt = 1; attempt <= IOS_AUTH_CALLBACK_ATTEMPTS; attempt += 1) {
@@ -495,6 +590,41 @@ async function pollIosAuthCallbackSmoke(device, app, expected) {
   }
   throw new Error(
     `iOS auth callback smoke timed out after ${IOS_AUTH_CALLBACK_ATTEMPTS} attempts. Last result: ${lastRaw || "<none>"}`,
+  );
+}
+
+async function pollAndroidAuthCallbackSmoke(adb, serial, app, expected) {
+  let lastRaw = "";
+  for (let attempt = 1; attempt <= IOS_AUTH_CALLBACK_ATTEMPTS; attempt += 1) {
+    lastRaw =
+      readAndroidPreference(
+        adb,
+        serial,
+        app.appId,
+        IOS_AUTH_CALLBACK_SMOKE_RESULT_KEY,
+      ) ?? "";
+    if (lastRaw) {
+      let parsed = null;
+      try {
+        parsed = JSON.parse(lastRaw);
+      } catch {
+        parsed = null;
+      }
+      if (parsed?.phase === "failed" || parsed?.error) {
+        throw new Error(`Android auth callback smoke failed: ${lastRaw}`);
+      }
+      if (parsed?.ok === true) {
+        return assertAuthCallbackResult(
+          parsed,
+          expected,
+          "Android auth callback",
+        );
+      }
+    }
+    await sleep(IOS_AUTH_CALLBACK_DELAY_MS);
+  }
+  throw new Error(
+    `Android auth callback smoke timed out after ${IOS_AUTH_CALLBACK_ATTEMPTS} attempts. Last result: ${lastRaw || "<none>"}`,
   );
 }
 
@@ -659,7 +789,7 @@ function assertAndroidResolvesToPackage(adb, serial, app, url) {
   return resolvedName;
 }
 
-function runAndroidSimulator(app, url, options) {
+async function runAndroidSimulator(app, url, options) {
   const adb = resolveAdb();
   const serial = resolveAndroidSerial(adb, options.serial);
   // Preflight: the scheme must resolve to OUR package, not a consumer app
@@ -670,6 +800,7 @@ function runAndroidSimulator(app, url, options) {
     app,
     url,
   );
+  const expected = armAndroidAuthCallbackSmoke(adb, serial, app, url);
   runCommand(
     adb,
     [
@@ -708,11 +839,18 @@ function runAndroidSimulator(app, url, options) {
       `Android callback did not resolve to ${app.appId}. am start output:\n${output}`,
     );
   }
+  const handled = await pollAndroidAuthCallbackSmoke(
+    adb,
+    serial,
+    app,
+    expected,
+  );
   return {
     platform: "android",
     serial,
     openedUrl: url,
     resolvedActivity,
+    handled,
   };
 }
 
@@ -755,7 +893,7 @@ async function main() {
     simulatorResults.push(
       platform === "ios"
         ? await runIosSimulator(app, url, options)
-        : runAndroidSimulator(app, url, options),
+        : await runAndroidSimulator(app, url, options),
     );
   }
 

--- a/packages/app-core/scripts/mobile-auth-simulator-smoke.mjs
+++ b/packages/app-core/scripts/mobile-auth-simulator-smoke.mjs
@@ -462,12 +462,13 @@ const EXPECTED_AUTH_CALLBACK_CLASSIFICATION = "synthetic_callback_rejected";
 // auth logic) would pass — the vacuous check the issue calls out.
 //
 // The real security invariant this handler enforces is that an OS-delivered
-// deep link NEVER establishes an authenticated session (no bearer token is
-// accepted from a deep link; a crafted callback must not authenticate the app).
-// The in-app handler classifies the synthetic callback as rejected and reads its
-// real `elizaos:active-server` session storage back. Both fields are required:
-// a deliver-only echo never classifies the callback, and a regression that
-// accepts the deep-link token would report `sessionEstablished=true`.
+// deep link NEVER establishes or swaps an authenticated session (no bearer token
+// is accepted from a deep link; a crafted callback must not authenticate the
+// app). The in-app handler classifies the synthetic callback as rejected and
+// compares its real `elizaos:active-server` session storage before/after
+// handling. Both fields are required: a deliver-only echo never classifies the
+// callback, and a regression that accepts the deep-link token reports
+// `sessionChanged=true`.
 //
 // Returns the parsed payload on success; throws a descriptive Error otherwise.
 export function assertAuthCallbackResult(parsed, expected, platformLabel) {
@@ -495,26 +496,33 @@ export function assertAuthCallbackResult(parsed, expected, platformLabel) {
       `${label}: callback was not classified as ${EXPECTED_AUTH_CALLBACK_CLASSIFICATION}; got ${JSON.stringify(parsed.classification)}.`,
     );
   }
-  // THE auth-outcome assertion (#13693): the handler must have read its real
-  // session state back. Absent/non-boolean `sessionEstablished` => the handler
-  // never ran the end-state readback => this is the silent-pass regression the
-  // smoke now catches.
-  if (typeof parsed.sessionEstablished !== "boolean") {
+  if (parsed.accepted !== false) {
     throw new Error(
-      `${label}: no auth outcome surfaced. The callback handler must read its ` +
-        `session state back after handling the callback (deliver-only is not ` +
-        `enough); got sessionEstablished=${JSON.stringify(parsed.sessionEstablished)}.`,
+      `${label}: OS-delivered callback was not explicitly rejected (accepted=${JSON.stringify(parsed.accepted)}).`,
     );
   }
-  // The OS-delivered callback must NOT have established a session — the app
-  // never accepts a bearer token from a deep link. A `true` here means a
-  // regression started authenticating off the deep link (the MITM footgun the
-  // in-app security comments warn about); fail loudly.
-  if (parsed.sessionEstablished === true) {
+  // THE auth-outcome assertion (#13693): the handler must have read its real
+  // session state before/after handling the callback. Absent/non-boolean
+  // `sessionChanged` => the handler never ran the callback-specific readback =>
+  // this is the silent-pass regression the smoke now catches.
+  if (typeof parsed.sessionChanged !== "boolean") {
     throw new Error(
-      `${label}: the OS-delivered auth callback established a session ` +
-        `(sessionEstablished=true). A deep link must never authenticate the ` +
-        `app; only the trusted in-app session exchange may.`,
+      `${label}: no auth outcome surfaced. The callback handler must read its ` +
+        `session state before/after handling the callback (deliver-only is not ` +
+        `enough); got sessionChanged=${JSON.stringify(parsed.sessionChanged)}.`,
+    );
+  }
+  // The OS-delivered callback must NOT change the active session — the app never
+  // accepts a bearer token from a deep link. A `true` here means a regression
+  // started authenticating or swapping the session from the deep link (the MITM
+  // footgun the in-app security comments warn about); fail loudly. A simulator
+  // that was already authenticated can still pass if the callback leaves that
+  // session untouched.
+  if (parsed.sessionChanged === true) {
+    throw new Error(
+      `${label}: the OS-delivered auth callback changed the active session ` +
+        `(sessionChanged=true). A deep link must never authenticate or swap ` +
+        `the app session; only the trusted in-app session exchange may.`,
     );
   }
   return parsed;

--- a/packages/app-core/scripts/mobile-auth-simulator-smoke.mjs
+++ b/packages/app-core/scripts/mobile-auth-simulator-smoke.mjs
@@ -411,18 +411,19 @@ export function readAndroidPreferenceFromXml(xml, key) {
 function writeAndroidPreferenceMap(adb, serial, appId, entries) {
   const xml = buildAndroidPreferenceXml(entries);
   const encoded = Buffer.from(xml, "utf8").toString("base64");
-  const command = [
-    "run-as",
-    appId,
-    "sh",
-    "-c",
-    shellSingleQuote(
-      `mkdir -p shared_prefs && printf %s ${encoded} | base64 -d > shared_prefs/CapacitorStorage.xml`,
-    ),
-  ];
+  const script = [
+    "mkdir -p shared_prefs",
+    `(printf %s ${encoded} | base64 -d > shared_prefs/CapacitorStorage.xml) || (printf %s ${encoded} | toybox base64 -d > shared_prefs/CapacitorStorage.xml)`,
+    "chmod 660 shared_prefs/CapacitorStorage.xml",
+  ].join(" && ");
   runCommand(
     adb,
-    ["-s", serial, "shell", command.join(" ")],
+    [
+      "-s",
+      serial,
+      "shell",
+      `run-as ${shellSingleQuote(appId)} sh -c ${shellSingleQuote(script)}`,
+    ],
     `Android preference seed for ${appId}`,
   );
 }
@@ -432,7 +433,7 @@ function readAndroidPreference(adb, serial, appId, key) {
     "-s",
     serial,
     "shell",
-    ["run-as", appId, "cat", "shared_prefs/CapacitorStorage.xml"].join(" "),
+    `run-as ${shellSingleQuote(appId)} cat shared_prefs/CapacitorStorage.xml`,
   ]);
   if (!xml) return null;
   return readAndroidPreferenceFromXml(xml, key);

--- a/packages/app-core/test/scripts/mobile-auth-simulator-smoke.test.ts
+++ b/packages/app-core/test/scripts/mobile-auth-simulator-smoke.test.ts
@@ -12,10 +12,12 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   assertAuthCallbackResult,
+  buildAndroidPreferenceXml,
   buildCallbackUrl,
   expectedAuthCallbackFromUrl,
   parseArgs,
   parseResolvedActivity,
+  readAndroidPreferenceFromXml,
   resolvedActivityMatchesApp,
   resolveTargetAppDir,
 } from "../../scripts/mobile-auth-simulator-smoke.mjs";
@@ -141,6 +143,7 @@ describe("mobile-auth-simulator-smoke: auth outcome assertion (#13693)", () => {
   const okResult = {
     ok: true,
     phase: "handled",
+    classification: "synthetic_callback_rejected",
     sessionEstablished: false,
     path: expected.path,
     state: expected.state,
@@ -151,9 +154,9 @@ describe("mobile-auth-simulator-smoke: auth outcome assertion (#13693)", () => {
     expect(assertAuthCallbackResult(okResult, expected, "iOS")).toBe(okResult);
   });
 
-  it("RED: throws when the handler never surfaced an outcome (deliver-only)", () => {
-    // The pre-#13693 vacuous payload: URL echoed back, no session readback.
-    // This is exactly the silent pass the issue calls out — it must now throw.
+  it("RED: throws when the handler only echoes delivery", () => {
+    // The pre-#13693 vacuous payload: URL echoed back, no classification and no
+    // session readback. This is the silent pass the issue calls out.
     const deliverOnly = {
       ok: true,
       phase: "handled",
@@ -163,7 +166,17 @@ describe("mobile-auth-simulator-smoke: auth outcome assertion (#13693)", () => {
     };
     expect(() =>
       assertAuthCallbackResult(deliverOnly, expected, "iOS"),
-    ).toThrow(/no auth outcome surfaced/);
+    ).toThrow(/callback was not classified/);
+  });
+
+  it("RED: throws when the handler surfaces a session readback but no classification", () => {
+    expect(() =>
+      assertAuthCallbackResult(
+        { ...okResult, classification: undefined },
+        expected,
+        "iOS",
+      ),
+    ).toThrow(/callback was not classified/);
   });
 
   it("RED: throws when the deep link established a session (token accepted)", () => {
@@ -189,6 +202,25 @@ describe("mobile-auth-simulator-smoke: auth outcome assertion (#13693)", () => {
     expect(() =>
       assertAuthCallbackResult({ ...okResult, ok: false }, expected, "iOS"),
     ).toThrow(/did not report ok=true/);
+  });
+
+  it("round-trips Android Capacitor Preferences XML keys", () => {
+    const request = JSON.stringify({ expected });
+    const result = JSON.stringify(okResult);
+    const xml = buildAndroidPreferenceXml({
+      "eliza:auth-callback-smoke:request": request,
+      "eliza:auth-callback-smoke:result": result,
+      "quote<&": "value<&",
+    });
+
+    expect(
+      readAndroidPreferenceFromXml(xml, "eliza:auth-callback-smoke:request"),
+    ).toBe(request);
+    expect(
+      readAndroidPreferenceFromXml(xml, "eliza:auth-callback-smoke:result"),
+    ).toBe(result);
+    expect(readAndroidPreferenceFromXml(xml, "quote<&")).toBe("value<&");
+    expect(readAndroidPreferenceFromXml(xml, "missing")).toBeNull();
   });
 });
 

--- a/packages/app-core/test/scripts/mobile-auth-simulator-smoke.test.ts
+++ b/packages/app-core/test/scripts/mobile-auth-simulator-smoke.test.ts
@@ -133,9 +133,9 @@ describe("mobile-auth-simulator-smoke: callback URL + args", () => {
 });
 
 // #13693: the auth-OUTCOME assertion. These prove the smoke is NON-VACUOUS:
-// the delivery echo alone no longer passes; the handler must have read its real
-// session state back and reported that the OS-delivered callback did not
-// establish a session.
+// the delivery echo alone no longer passes; the handler must have classified
+// the callback as rejected and reported that the OS-delivered callback did not
+// change the active session.
 describe("mobile-auth-simulator-smoke: auth outcome assertion (#13693)", () => {
   const expected = expectedAuthCallbackFromUrl(
     "elizaos://auth/callback?state=simulator-oauth-state&code=simulator-oauth-code",
@@ -144,14 +144,28 @@ describe("mobile-auth-simulator-smoke: auth outcome assertion (#13693)", () => {
     ok: true,
     phase: "handled",
     classification: "synthetic_callback_rejected",
+    accepted: false,
     sessionEstablished: false,
+    sessionChanged: false,
     path: expected.path,
     state: expected.state,
     code: expected.code,
   };
 
-  it("accepts a handled callback that did NOT establish a session", () => {
+  it("accepts a handled callback that did NOT change the session", () => {
     expect(assertAuthCallbackResult(okResult, expected, "iOS")).toBe(okResult);
+  });
+
+  it("accepts an already-authenticated simulator when the callback leaves the session untouched", () => {
+    const preAuthenticated = {
+      ...okResult,
+      sessionEstablished: true,
+      activeServerBeforePresent: true,
+      activeServerAfterPresent: true,
+    };
+    expect(assertAuthCallbackResult(preAuthenticated, expected, "iOS")).toBe(
+      preAuthenticated,
+    );
   });
 
   it("RED: throws when the handler only echoes delivery", () => {
@@ -179,16 +193,36 @@ describe("mobile-auth-simulator-smoke: auth outcome assertion (#13693)", () => {
     ).toThrow(/callback was not classified/);
   });
 
-  it("RED: throws when the deep link established a session (token accepted)", () => {
+  it("RED: throws when the handler classifies rejection but does not explicitly reject", () => {
+    expect(() =>
+      assertAuthCallbackResult(
+        { ...okResult, accepted: true },
+        expected,
+        "iOS",
+      ),
+    ).toThrow(/not explicitly rejected/);
+  });
+
+  it("RED: throws when the deep link changed the active session", () => {
     // The security regression: a callback authenticating the app off an
     // OS-delivered deep link. Must fail loudly.
     expect(() =>
       assertAuthCallbackResult(
-        { ...okResult, sessionEstablished: true },
+        { ...okResult, sessionEstablished: true, sessionChanged: true },
         expected,
         "iOS",
       ),
-    ).toThrow(/established a session/);
+    ).toThrow(/changed the active session/);
+  });
+
+  it("RED: throws when the handler never surfaced a callback-specific session comparison", () => {
+    expect(() =>
+      assertAuthCallbackResult(
+        { ...okResult, sessionChanged: undefined },
+        expected,
+        "iOS",
+      ),
+    ).toThrow(/no auth outcome surfaced/);
   });
 
   it("still enforces the delivery echo (path/state/code)", () => {

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -2086,10 +2086,25 @@ async function recordIosAuthCallbackSmoke(
     const activeServer = window.localStorage.getItem("elizaos:active-server");
     sessionEstablished =
       typeof activeServer === "string" && activeServer.length > 0;
-  } catch {
-    // error-policy:J7 diagnostics readback — an unreadable key reports the
-    // safe/expected end state (no session established by the callback).
-    sessionEstablished = false;
+  } catch (error) {
+    // error-policy:J7 diagnostics readback — the smoke must fail closed when it
+    // cannot observe the auth outcome it is supposed to prove.
+    await writeIosAuthCallbackSmokeResult({
+      ok: false,
+      phase: "failed",
+      classification: "synthetic_callback_rejected",
+      error:
+        error instanceof Error
+          ? error.message
+          : `active-server readback failed: ${String(error)}`,
+      path,
+      url,
+      state: parsed.searchParams.get("state") ?? "",
+      code: parsed.searchParams.get("code") ?? "",
+      query: Object.fromEntries(parsed.searchParams.entries()),
+      request,
+    });
+    return;
   }
 
   await writeIosAuthCallbackSmokeResult({

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -2095,6 +2095,7 @@ async function recordIosAuthCallbackSmoke(
   await writeIosAuthCallbackSmokeResult({
     ok: true,
     phase: "handled",
+    classification: "synthetic_callback_rejected",
     // #13693: the auth OUTCOME. The OS-delivered callback must not have
     // established a session; the smoke asserts this instead of only proving the
     // URL was echoed back.

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -714,6 +714,24 @@ async function writeIosAuthCallbackSmokeResult(
   );
 }
 
+interface AuthCallbackDeepLinkOutcome {
+  accepted: boolean;
+  classification: "synthetic_callback_rejected";
+  reason: string;
+}
+
+function rejectOsDeliveredAuthCallback(): AuthCallbackDeepLinkOutcome {
+  return {
+    accepted: false,
+    classification: "synthetic_callback_rejected",
+    reason: "os_delivered_auth_callback_rejected",
+  };
+}
+
+function readActiveServerSessionSnapshot(): string {
+  return window.localStorage.getItem("elizaos:active-server") ?? "";
+}
+
 async function writeIosPreferenceSmokeResult(
   key: string,
   result: Record<string, unknown>,
@@ -2038,6 +2056,8 @@ async function recordIosAuthCallbackSmoke(
   parsed: URL,
   path: string,
   url: string,
+  outcome: AuthCallbackDeepLinkOutcome,
+  activeServerBefore: string,
 ): Promise<void> {
   // Record the auth-callback end state on ANY native platform. Pre-#13693 this
   // was iOS-only, so the Android smoke leg had no in-app readback at all (pure
@@ -2072,27 +2092,23 @@ async function recordIosAuthCallbackSmoke(
 
   // #13693: assert the AUTH OUTCOME, not just delivery. The security invariant
   // for this handler (see the `connect`/first-run-remote cases above) is that
-  // an OS-delivered deep link NEVER establishes an authenticated session — no
-  // bearer token is accepted, no active server is selected from the callback.
-  // So the truthful end state is that after handling the callback there is
-  // still no active-server session that the callback itself created. Read the
-  // real `elizaos:active-server` storage key back so the smoke can assert this
-  // (`sessionEstablished: false`) rather than the vacuous "a result arrived".
-  // A regression that started accepting the deep-link token (the exact MITM
-  // footgun the security comments warn about) would flip this to true and the
-  // smoke would go red.
-  let sessionEstablished = false;
+  // an OS-delivered deep link NEVER establishes or swaps an authenticated
+  // session. Compare the real active-server key before/after handling the
+  // callback so a pre-authenticated simulator passes when the callback leaves
+  // the session untouched, while a regression that authenticates from the deep
+  // link flips `sessionChanged=true`.
+  let activeServerAfter = "";
   try {
-    const activeServer = window.localStorage.getItem("elizaos:active-server");
-    sessionEstablished =
-      typeof activeServer === "string" && activeServer.length > 0;
+    activeServerAfter = readActiveServerSessionSnapshot();
   } catch (error) {
     // error-policy:J7 diagnostics readback — the smoke must fail closed when it
     // cannot observe the auth outcome it is supposed to prove.
     await writeIosAuthCallbackSmokeResult({
       ok: false,
       phase: "failed",
-      classification: "synthetic_callback_rejected",
+      classification: outcome.classification,
+      accepted: outcome.accepted,
+      reason: outcome.reason,
       error:
         error instanceof Error
           ? error.message
@@ -2110,11 +2126,13 @@ async function recordIosAuthCallbackSmoke(
   await writeIosAuthCallbackSmokeResult({
     ok: true,
     phase: "handled",
-    classification: "synthetic_callback_rejected",
-    // #13693: the auth OUTCOME. The OS-delivered callback must not have
-    // established a session; the smoke asserts this instead of only proving the
-    // URL was echoed back.
-    sessionEstablished,
+    classification: outcome.classification,
+    accepted: outcome.accepted,
+    reason: outcome.reason,
+    sessionEstablished: activeServerAfter.length > 0,
+    sessionChanged: activeServerAfter !== activeServerBefore,
+    activeServerBeforePresent: activeServerBefore.length > 0,
+    activeServerAfterPresent: activeServerAfter.length > 0,
     path,
     url,
     state: parsed.searchParams.get("state") ?? "",
@@ -2122,6 +2140,44 @@ async function recordIosAuthCallbackSmoke(
     query: Object.fromEntries(parsed.searchParams.entries()),
     request,
   });
+}
+
+async function handleAuthCallbackDeepLink(
+  parsed: URL,
+  path: string,
+  url: string,
+): Promise<void> {
+  const outcome = rejectOsDeliveredAuthCallback();
+  let activeServerBefore = "";
+  try {
+    activeServerBefore = readActiveServerSessionSnapshot();
+  } catch (error) {
+    await writeIosAuthCallbackSmokeResult({
+      ok: false,
+      phase: "failed",
+      classification: outcome.classification,
+      accepted: outcome.accepted,
+      reason: outcome.reason,
+      error:
+        error instanceof Error
+          ? error.message
+          : `active-server pre-readback failed: ${String(error)}`,
+      path,
+      url,
+      state: parsed.searchParams.get("state") ?? "",
+      code: parsed.searchParams.get("code") ?? "",
+      query: Object.fromEntries(parsed.searchParams.entries()),
+    });
+    return;
+  }
+
+  await recordIosAuthCallbackSmoke(
+    parsed,
+    path,
+    url,
+    outcome,
+    activeServerBefore,
+  );
 }
 
 function handleDeepLink(url: string): void {
@@ -2156,7 +2212,7 @@ function handleDeepLink(url: string): void {
     ? parsed.pathname.replace(/^\/+|\/+$/g, "")
     : getDeepLinkPath(parsed);
   if (path === "auth/callback") {
-    void recordIosAuthCallbackSmoke(parsed, path, url);
+    void handleAuthCallbackDeepLink(parsed, path, url);
     return;
   }
 


### PR DESCRIPTION
## Summary
- require the mobile auth callback smoke payload to include an explicit synthetic-callback rejection classification
- add Android request/result polling through the app's Capacitor SharedPreferences instead of leaving Android as fire-and-forget intent delivery
- keep asserting that the OS-delivered callback does not establish an active session

## Review notes
This follows up #13783, which merged before review blockers were fixed. The merged smoke still accepted delivery-only behavior on Android and did not prove the renderer classified the synthetic callback.

## Verification
- `bun test packages/app-core/test/scripts/mobile-auth-simulator-smoke.test.ts` — 20 pass
- `node --check packages/app-core/scripts/mobile-auth-simulator-smoke.mjs`
- `git diff --check`
- `bunx @biomejs/biome check packages/app-core/scripts/mobile-auth-simulator-smoke.mjs packages/app-core/test/scripts/mobile-auth-simulator-smoke.test.ts packages/app/src/main.tsx --no-errors-on-unmatched`

## Evidence
- Real simulator/device run: N/A in this follow-up branch; no Android/iOS simulator is available in this Linux workspace. The no-device unit contract now proves the Android Capacitor Preferences XML read/write shape and the callback assertion rejects delivery-only payloads.