### PR TITLE
fix(#13682): preserve Windows packaged smoke handoff

### DIFF
--- a/.github/issue-evidence/13682-windows-packaged-script/README.md
+++ b/.github/issue-evidence/13682-windows-packaged-script/README.md
@@ -1,0 +1,26 @@
+# Issue #13682 evidence
+
+Verified on macOS (`process.platform === "darwin"`) that the
+`test:desktop:packaged:windows` lane resolves from the repo root and fails
+non-zero on the truthful Windows-host precondition instead of Bun's old
+`Script not found` failure.
+
+Artifacts:
+
+- `focused-vitest.log` - focused guard for the root/app script definitions,
+  canonical call sites, launcher-path handoff contract, macOS precondition
+  failure, and distinct macOS/Windows packaged lanes.
+- `root-command-nonwindows.log` - actual `bun run
+  test:desktop:packaged:windows` invocation from repo root. Expected exit code
+  is `1` on macOS with `requires a windows host`; no `Script not found`.
+- `canonical-call-sites.log` - grep showing the workflow, release check,
+  regression matrix, root script, and app script all reference the canonical
+  lane.
+
+N/A:
+
+- Screenshots/video - no UI surface changed.
+- Frontend logs - no browser/client path changed.
+- Live LLM trajectory - no model/action/provider/prompt behavior changed.
+- Domain artifacts - no memory, DB, wallet, scheduled-task, or generated user
+  artifact path changed.

--- a/.github/issue-evidence/13682-windows-packaged-script/biome-check.log
+++ b/.github/issue-evidence/13682-windows-packaged-script/biome-check.log
@@ -1,0 +1,1 @@
+Checked 3 files in 18ms. No fixes applied.

--- a/.github/issue-evidence/13682-windows-packaged-script/canonical-call-sites.log
+++ b/.github/issue-evidence/13682-windows-packaged-script/canonical-call-sites.log
@@ -1,0 +1,12 @@
+.github/workflows/release-electrobun.yml:1072:          bun run test:desktop:packaged:windows
+package.json:91:    "test:desktop:packaged:windows": "bun run --cwd packages/app test:desktop:packaged:windows",
+packages/app-core/scripts/release-check.ts:204:  "bun run test:desktop:packaged:windows",
+packages/app-core/test/regression-matrix.json:106:      "command": "bun run test:desktop:packaged:windows"
+packages/app/package.json:32:    "test:desktop:packaged:windows": "node scripts/run-desktop-packaged-windows.mjs",
+packages/app/scripts/run-desktop-packaged-windows.mjs:3: * Windows packaged-desktop smoke lane (`test:desktop:packaged:windows`).
+packages/app/scripts/run-desktop-packaged-windows.mjs:55:  const line = `[test:desktop:packaged:windows] ${message}\n`;
+packages/app/test/desktop-packaged-windows-lane.test.ts:2: * Guards the `test:desktop:packaged:windows` packaged-Windows smoke lane wiring
+packages/app/test/desktop-packaged-windows-lane.test.ts:5: * Regression: three call sites invoked `bun run test:desktop:packaged:windows`
+packages/app/test/desktop-packaged-windows-lane.test.ts:27:const CANONICAL_LANE = "test:desktop:packaged:windows";
+packages/app/test/desktop-packaged-windows-lane.test.ts:70:describe("test:desktop:packaged:windows lane wiring (#13682)", () => {
+packages/app/test/desktop-packaged-windows-lane.test.ts:83:    // all execute `bun run test:desktop:packaged:windows` from the repository

--- a/.github/issue-evidence/13682-windows-packaged-script/focused-vitest.log
+++ b/.github/issue-evidence/13682-windows-packaged-script/focused-vitest.log
@@ -1,0 +1,15 @@
+bun test v1.4.0-canary.1 (55f6c899f)
+
+packages/app/test/desktop-packaged-windows-lane.test.ts:
+(pass) test:desktop:packaged:windows lane wiring (#13682) > defines the canonical lane in packages/app/package.json [0.99ms]
+(pass) test:desktop:packaged:windows lane wiring (#13682) > is invokable from the repo root where all three call sites run it [0.28ms]
+(pass) test:desktop:packaged:windows lane wiring (#13682) > ships the preflight runner script the lane points at [0.05ms]
+(pass) test:desktop:packaged:windows lane wiring (#13682) > preserves the release workflow launcher-path handoff contract [0.65ms]
+(pass) test:desktop:packaged:windows lane wiring (#13682) > all three call sites reference the exact canonical lane name [0.56ms]
+(pass) test:desktop:packaged:windows lane wiring (#13682) > distinct named lane from the macOS packaged lane (no rename collapse) [0.08ms]
+(pass) test:desktop:packaged:windows lane wiring (#13682) > fails NON-ZERO with a truthful precondition message on a non-Windows host [65.36ms]
+
+ 7 pass
+ 0 fail
+ 22 expect() calls
+Ran 7 tests across 1 file. [429.00ms]

--- a/.github/issue-evidence/13682-windows-packaged-script/root-command-nonwindows.log
+++ b/.github/issue-evidence/13682-windows-packaged-script/root-command-nonwindows.log
@@ -1,0 +1,6 @@
+$ bun run --cwd packages/app test:desktop:packaged:windows
+$ node scripts/run-desktop-packaged-windows.mjs
+[test:desktop:packaged:windows] packaged Windows smoke test requires a windows host (host is darwin); run this lane on a Windows runner with a packaged build present.
+[test:desktop:packaged:windows] packaged Windows smoke test requires a windows host (host is darwin); run this lane on a Windows runner with a packaged build present.
+error: script "test:desktop:packaged:windows" exited with code 1
+error: script "test:desktop:packaged:windows" exited with code 1

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "test:launch-qa:docs": "node packages/scripts/launch-qa/check-docs.mjs --scope=docs --json",
     "test:launch-qa": "bun test packages/scripts/launch-qa/*.test.ts && bun run test:launch-qa:docs && node packages/scripts/launch-qa/check-mobile-artifacts.mjs --json --allow-missing-generated && node packages/scripts/launch-qa/check-model-data.mjs --json && node packages/scripts/launch-qa/run.mjs --suite quick --dry-run",
     "test:launch-qa:release:dry": "node packages/scripts/launch-qa/run.mjs --suite release --dry-run",
+    "test:desktop:packaged": "bun run --cwd packages/app test:desktop:packaged",
+    "test:desktop:packaged:windows": "bun run --cwd packages/app test:desktop:packaged:windows",
     "generate:action-search-keywords": "node packages/scripts/generate-action-search-keywords.mjs && node packages/shared/scripts/generate-keywords.mjs --target ts",
     "lifeops-bench:manifest": "node --conditions=eliza-source --conditions=development --import tsx scripts/lifeops-bench/export-action-manifest.ts",
     "start": "bun run --cwd packages/agent start",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "cache:prune": "node packages/scripts/prune-turbo-cache.mjs",
     "test:dev-startup": "node packages/app-core/scripts/dev-startup-smoke.mjs",
     "test:hmr": "bun run --cwd packages/app test:hmr",
-    "test:desktop:packaged:windows": "bun run --cwd packages/app test:desktop:packaged:windows",
     "build:core": "node packages/scripts/build-core.mjs",
     "build:server": "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/agent",
     "lint": "node packages/scripts/run-turbo.mjs run lint",

--- a/packages/app/scripts/run-desktop-packaged-windows.mjs
+++ b/packages/app/scripts/run-desktop-packaged-windows.mjs
@@ -8,8 +8,9 @@
  *   - packages/app-core/scripts/release-check.ts
  *   - packages/app-core/test/regression-matrix.json (desktop-packaged-windows)
  *
- * It runs the existing packaged Windows PowerShell smoke on Windows, preserving
- * the workflow's `ELIZA_TEST_WINDOWS_LAUNCHER_PATH_FILE` handoff contract, and
+ * It resolves the packaged Windows launcher, persists the reusable launcher
+ * path requested by `ELIZA_TEST_WINDOWS_LAUNCHER_PATH_FILE`, and runs the
+ * existing `electrobun-windows-startup` Playwright smoke on Windows. It also
  * — critically — fails with a NON-ZERO exit and a truthful precondition message
  * on any non-Windows host, instead of the previous `error: Script not found`
  * (invisible break) or a silent green "skipped" run. A release smoke lane that
@@ -21,22 +22,31 @@
  * the delegated Playwright process unchanged.
  */
 
-import { spawn } from "node:child_process";
-import { accessSync } from "node:fs";
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const appDir = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(appDir, "..", "..");
-const smokeScript = path.join(
+const defaultArtifactsDir = path.join(
   repoRoot,
   "packages",
   "app-core",
   "platforms",
   "electrobun",
-  "scripts",
-  "smoke-test-windows.ps1",
+  "artifacts",
+);
+const defaultBuildDir = path.join(
+  repoRoot,
+  "packages",
+  "app-core",
+  "platforms",
+  "electrobun",
+  "build",
 );
 
 function fail(message) {
@@ -46,6 +56,104 @@ function fail(message) {
   process.stderr.write(line);
   process.stdout.write(line);
   process.exit(1);
+}
+
+async function findFiles(root, matcher) {
+  const found = [];
+  async function walk(currentDir) {
+    const entries = await fs
+      .readdir(currentDir, { withFileTypes: true })
+      .catch(() => []);
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.isFile() && matcher(fullPath)) {
+        found.push(fullPath);
+      }
+    }
+  }
+
+  if (existsSync(root)) {
+    await walk(root);
+  }
+  return found;
+}
+
+async function newestPath(paths) {
+  const withStats = await Promise.all(
+    paths.map(async (candidate) => ({
+      path: candidate,
+      stat: await fs.stat(candidate),
+    })),
+  );
+  withStats.sort((left, right) => right.stat.mtimeMs - left.stat.mtimeMs);
+  return await fs.realpath(withStats[0].path);
+}
+
+async function findLauncherExe(root) {
+  const matches = await findFiles(
+    root,
+    (fullPath) => path.basename(fullPath).toLowerCase() === "launcher.exe",
+  );
+  return matches.length > 0 ? newestPath(matches) : null;
+}
+
+async function resolveWindowsLauncher() {
+  const explicit =
+    process.env.ELIZA_TEST_PACKAGED_LAUNCHER_PATH?.trim() ||
+    process.env.ELIZA_TEST_WINDOWS_LAUNCHER_PATH?.trim();
+  if (explicit) {
+    await fs.access(explicit);
+    return await fs.realpath(explicit);
+  }
+
+  const buildDir =
+    process.env.ELIZA_TEST_WINDOWS_BUILD_DIR?.trim() || defaultBuildDir;
+  const artifactsDir =
+    process.env.ELIZA_TEST_WINDOWS_ARTIFACTS_DIR?.trim() || defaultArtifactsDir;
+
+  const builtLauncher = await findLauncherExe(buildDir);
+  if (builtLauncher) return builtLauncher;
+
+  const artifactLauncher = await findLauncherExe(artifactsDir);
+  if (artifactLauncher) return artifactLauncher;
+
+  const tarballs = await findFiles(artifactsDir, (fullPath) =>
+    fullPath.endsWith(".tar.zst"),
+  );
+  if (tarballs.length === 0) {
+    fail(
+      `no Windows launcher.exe or .tar.zst packaged artifact found under ${buildDir} or ${artifactsDir}`,
+    );
+  }
+
+  const archivePath = await newestPath(tarballs);
+  const extractParent =
+    process.env.ELIZA_TEST_WINDOWS_LAUNCHER_DIR?.trim() ||
+    (await fs.mkdtemp(path.join(os.tmpdir(), "eliza-windows-packaged-")));
+  await fs.mkdir(extractParent, { recursive: true });
+  execFileSync("tar", [
+    "--force-local",
+    "-xf",
+    archivePath,
+    "-C",
+    extractParent,
+  ]);
+
+  const extractedLauncher = await findLauncherExe(extractParent);
+  if (!extractedLauncher) {
+    fail(`failed to find launcher.exe after extracting ${archivePath}`);
+  }
+  return extractedLauncher;
+}
+
+async function persistLauncherPath(launcherPath) {
+  const launcherPathFile =
+    process.env.ELIZA_TEST_WINDOWS_LAUNCHER_PATH_FILE?.trim();
+  if (!launcherPathFile) return;
+  await fs.mkdir(path.dirname(launcherPathFile), { recursive: true });
+  await fs.writeFile(launcherPathFile, `${launcherPath}\n`, "utf8");
 }
 
 if (process.platform !== "win32") {
@@ -58,18 +166,23 @@ if (process.platform !== "win32") {
   );
 }
 
-try {
-  accessSync(smokeScript);
-} catch {
-  fail(`missing Windows smoke script: ${smokeScript}`);
-}
+const launcherPath = await resolveWindowsLauncher();
+await persistLauncherPath(launcherPath);
 
 const child = spawn(
-  "pwsh",
-  ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", smokeScript],
+  process.execPath,
+  [
+    "scripts/run-ui-playwright.mjs",
+    "--config",
+    "playwright.electrobun.packaged.config.ts",
+    "test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts",
+  ],
   {
-    cwd: repoRoot,
-    env: process.env,
+    cwd: appDir,
+    env: {
+      ...process.env,
+      ELIZA_TEST_WINDOWS_LAUNCHER_PATH: launcherPath,
+    },
     stdio: "inherit",
   },
 );

--- a/packages/app/test/desktop-packaged-windows-lane.test.ts
+++ b/packages/app/test/desktop-packaged-windows-lane.test.ts
@@ -104,13 +104,11 @@ describe("test:desktop:packaged:windows lane wiring (#13682)", () => {
     const runner = readText(
       "packages/app/scripts/run-desktop-packaged-windows.mjs",
     );
-    expect(runner).toContain("smoke-test-windows.ps1");
-    expect(runner).toContain("pwsh");
-    expect(
-      readText(
-        "packages/app-core/platforms/electrobun/scripts/smoke-test-windows.ps1",
-      ),
-    ).toContain("ELIZA_TEST_WINDOWS_LAUNCHER_PATH_FILE");
+    expect(runner).toContain("electrobun-windows-startup.e2e.spec.ts");
+    expect(runner).toContain("resolveWindowsLauncher");
+    expect(runner).toContain("ELIZA_TEST_WINDOWS_LAUNCHER_PATH_FILE");
+    expect(runner).toContain("ELIZA_TEST_WINDOWS_LAUNCHER_PATH");
+    expect(runner).not.toContain("smoke-test-windows.ps1");
     expect(readText(".github/workflows/release-electrobun.yml")).toContain(
       "ELIZA_TEST_WINDOWS_LAUNCHER_PATH_FILE",
     );

--- a/packages/scripts/audit-scripts.mjs
+++ b/packages/scripts/audit-scripts.mjs
@@ -163,6 +163,14 @@ const ROOT_CWD_WRAPPER_ALLOWLIST = new Map([
   ["dev:core", "day-to-day root core dev entrypoint"],
   ["test:hmr", "root release/regression gate for app HMR behavior"],
   [
+    "test:desktop:packaged",
+    "root release/regression gate for packaged desktop app startup behavior",
+  ],
+  [
+    "test:desktop:packaged:windows",
+    "root release/regression gate for the packaged Windows desktop smoke lane",
+  ],
+  [
     "test:apple-entitlements",
     "root release/regression gate for app entitlement checks",
   ],


### PR DESCRIPTION
## Summary
- replace the packaged Windows smoke runner path that pointed at missing `packages/app-core/platforms/electrobun/scripts/smoke-test-windows.ps1`
- resolve `launcher.exe` from the packaged build/artifacts, persist `ELIZA_TEST_WINDOWS_LAUNCHER_PATH_FILE`, and run the existing `electrobun-windows-startup` Playwright spec
- add focused guard coverage plus issue evidence for the non-Windows truthful-precondition path
- restore app package dependencies that the prior branch snapshot had accidentally removed

Follow-up to #13682 and merged PR #13790. The issue was closed, but the merged runner still delegated to a missing PowerShell script in this tree.

## Verification
- `bun test packages/app/test/desktop-packaged-windows-lane.test.ts` in clean sparse worktree: 7 pass / 0 fail
- `bun run test:desktop:packaged:windows` in clean sparse worktree on macOS: exits 1 with `requires a windows host`; no `Script not found`
- `bunx @biomejs/biome check packages/app/scripts/run-desktop-packaged-windows.mjs packages/app/test/desktop-packaged-windows-lane.test.ts packages/app/package.json`: passed

## Evidence
- `.github/issue-evidence/13682-windows-packaged-script/focused-vitest.log`
- `.github/issue-evidence/13682-windows-packaged-script/root-command-nonwindows.log`
- `.github/issue-evidence/13682-windows-packaged-script/canonical-call-sites.log`
- `.github/issue-evidence/13682-windows-packaged-script/biome-check.log`

## Evidence rows
- Screenshots/video: N/A - CI/script wiring only, no UI surface changed.
- Frontend logs: N/A - no browser/client path changed.
- Live LLM trajectory: N/A - no model/action/provider/prompt behavior changed.
- Domain artifacts: N/A - no memory, DB, wallet, scheduled-task, or generated user artifact path changed.
- Windows packaged proof: pending a real Windows runner with packaged Electrobun artifacts; this PR fixes the command path so that lane can actually execute the existing Windows startup spec and preserve the launcher handoff.