### PR TITLE
fix(core): correlate trajectories to run/scenario — empty-is-unset env fallback (slice of #13775, epic #13766)

### DIFF
--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -1292,3 +1292,79 @@ describe("finalizeTrajectoryRecording (running-status leak guard)", () => {
 		expect((await readPersisted(id)).status).toBe("finished");
 	});
 });
+
+// The scenario CLI sets ELIZA_LIFEOPS_RUN_ID / ELIZA_LIFEOPS_SCENARIO_ID before
+// each run/scenario (cli.ts) and the message loop constructs this recorder
+// without passing runId/scenarioId, so correlation flows entirely through the
+// recorder's env fallback. These lock in that behavior and the empty-is-unset
+// contract that keeps a blank env var from writing a garbage correlation key.
+describe("run/scenario correlation via env", () => {
+	const rootMessage = { id: "msg-1", text: "hello", sender: "user-1" };
+	const originalRunId = process.env.ELIZA_LIFEOPS_RUN_ID;
+	const originalScenarioId = process.env.ELIZA_LIFEOPS_SCENARIO_ID;
+
+	afterEach(() => {
+		if (originalRunId === undefined) delete process.env.ELIZA_LIFEOPS_RUN_ID;
+		else process.env.ELIZA_LIFEOPS_RUN_ID = originalRunId;
+		if (originalScenarioId === undefined)
+			delete process.env.ELIZA_LIFEOPS_SCENARIO_ID;
+		else process.env.ELIZA_LIFEOPS_SCENARIO_ID = originalScenarioId;
+	});
+
+	async function readPersisted(id: string): Promise<RecordedTrajectory> {
+		const raw = await fs.readFile(
+			path.join(tmpDir, "agent-test", `${id}.json`),
+			"utf8",
+		);
+		return JSON.parse(raw) as RecordedTrajectory;
+	}
+
+	it("tags the trajectory with the run/scenario env even when the call site omits them", async () => {
+		process.env.ELIZA_LIFEOPS_RUN_ID = "run-xyz";
+		process.env.ELIZA_LIFEOPS_SCENARIO_ID = "scenario-abc";
+		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+		const id = recorder.startTrajectory({ agentId: "agent-test", rootMessage });
+		await recorder.endTrajectory(id, "finished");
+
+		const persisted = await readPersisted(id);
+		expect(persisted.runId).toBe("run-xyz");
+		expect(persisted.scenarioId).toBe("scenario-abc");
+	});
+
+	it("leaves run/scenario unset when the env is unset", async () => {
+		delete process.env.ELIZA_LIFEOPS_RUN_ID;
+		delete process.env.ELIZA_LIFEOPS_SCENARIO_ID;
+		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+		const id = recorder.startTrajectory({ agentId: "agent-test", rootMessage });
+		await recorder.endTrajectory(id, "finished");
+
+		const persisted = await readPersisted(id);
+		expect(persisted.runId).toBeUndefined();
+		expect(persisted.scenarioId).toBeUndefined();
+	});
+
+	it("treats a blank/whitespace env value as unset (no empty-string correlation key)", async () => {
+		process.env.ELIZA_LIFEOPS_RUN_ID = "";
+		process.env.ELIZA_LIFEOPS_SCENARIO_ID = "   ";
+		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+		const id = recorder.startTrajectory({ agentId: "agent-test", rootMessage });
+		await recorder.endTrajectory(id, "finished");
+
+		const persisted = await readPersisted(id);
+		expect(persisted.runId).toBeUndefined();
+		expect(persisted.scenarioId).toBeUndefined();
+	});
+
+	it("prefers an explicit call-site value over the env fallback", async () => {
+		process.env.ELIZA_LIFEOPS_RUN_ID = "run-from-env";
+		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+		const id = recorder.startTrajectory({
+			agentId: "agent-test",
+			rootMessage,
+			runId: "run-explicit",
+		});
+		await recorder.endTrajectory(id, "finished");
+
+		expect((await readPersisted(id)).runId).toBe("run-explicit");
+	});
+});

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -27,6 +27,7 @@ import {
 } from "../features/trajectories/pricing";
 import type { EvaluationResult } from "../types/components";
 import type { ChatMessage, ToolChoice } from "../types/model";
+import { readEnv } from "../utils/read-env";
 import { resolveStateDir } from "../utils/state-dir";
 
 // ---------------------------------------------------------------------------
@@ -1165,8 +1166,11 @@ class JsonFileTrajectoryRecorder implements TrajectoryRecorder {
 			trajectoryId: id,
 			agentId: input.agentId,
 			roomId: input.roomId,
-			runId: input.runId ?? process.env.ELIZA_LIFEOPS_RUN_ID,
-			scenarioId: input.scenarioId ?? process.env.ELIZA_LIFEOPS_SCENARIO_ID,
+			// The scenario CLI stamps these before each run/scenario (cli.ts); an
+			// explicit call-site value wins. readEnv treats blank/whitespace as
+			// unset so a cleared env var never writes an empty correlation key.
+			runId: input.runId ?? readEnv("ELIZA_LIFEOPS_RUN_ID"),
+			scenarioId: input.scenarioId ?? readEnv("ELIZA_LIFEOPS_SCENARIO_ID"),
 			rootMessage: cloneRootMessageForRecord(input.rootMessage),
 			startedAt: Date.now(),
 			status: "running",


### PR DESCRIPTION
Slice of #13775 (epic #13766, WS5 / D2). Scoped to the "wire runId/scenarioId" item (issue item 4).

## TL;DR — the headline premise is already handled; the real gap was empty-is-unset

Issue #13775 states: *"`message.ts:5957` never passes `runId`/`scenarioId` to `startTrajectory` even though the scenario CLI sets the env and the fields exist"* — implying file-recorder trajectories aren't correlated to the run/scenario.

**Verified on develop: that correlation already works.** The recorder the message loop constructs — `JsonFileTrajectoryRecorder.startTrajectory` (`packages/core/src/runtime/trajectory-recorder.ts:1168-1169`) — already reads `process.env.ELIZA_LIFEOPS_RUN_ID` / `ELIZA_LIFEOPS_SCENARIO_ID` as a fallback, which are exactly the vars the scenario CLI stamps (`packages/scenario-runner/src/cli.ts:320` and `:356`). So a scenario run's trajectory files are tagged with `runId`/`scenarioId` today, without `message.ts` passing anything.

I therefore did **not** add the redundant call-site wiring at `message.ts:5958`: passing the same env through the call site would be a duplicate `process.env` read with zero behavior change (the recorder reads it either way), which is the kind of duplicate fallback the cleanup mandate says to remove, not add.

**The one genuine defect** in this area is the slice's own "respect empty-is-unset" clause: the raw `?? process.env.X` fallback writes an *empty-string* correlation key when the env var is set-but-blank. `effectiveRunId = parsed.runId ?? crypto.randomUUID()` (`cli.ts:308`) means an explicit `--runId ""` is not nullish, so `ELIZA_LIFEOPS_RUN_ID=""` flows through and the trajectory gets `runId: ""` — a garbage grouping key that conflates "blank" with a real id.

## Change

`packages/core/src/runtime/trajectory-recorder.ts` — the `runId`/`scenarioId` env fallback now uses the canonical `readEnv()` (trims, treats blank/whitespace as unset) instead of raw `process.env`. Explicit call-site precedence is preserved (`input.runId ?? readEnv(...)`). This matches the repo convention ("prefer `utils/read-env.ts` over raw `process.env`; empty string treated as unset").

## Test — before/after (real code path, real temp-dir file writes)

New `describe("run/scenario correlation via env")` in `trajectory-recorder.test.ts` drives the real `createJsonFileTrajectoryRecorder` → `startTrajectory` → `endTrajectory` → read persisted JSON (no mocks).

**Before the fix** (on develop's recorder):
```
 3 pass
 1 fail
  run/scenario correlation via env > treats a blank/whitespace env value as unset ...
  error: expect(received).toBeUndefined()
  Received: ""
```
The 3 passing tests confirm correlation-via-env already works (call-site omits ids → trajectory still tagged; env unset → undefined; explicit value wins). The 1 failing test is the empty-is-unset defect.

**After the fix:**
```
 4 pass
 0 fail
```
Full file: `46 pass / 0 fail`. `packages/core` typecheck shows no errors in `trajectory-recorder.ts` (the only typecheck errors are pre-existing worktree-env issues: un-generated `validation-keyword-data` and missing `adze`/`drizzle-orm` decls from the symlinked `dist/node_modules`).

## Deferred to follow-up (explicitly NOT in this slice)

- **D2 correlation envelope (design, fable)** — shared `traceId`/`runId`/`roomId`/`taskId`/`sessionId`/`parentStepId`/`childTrajectoryId` join header across the three trace schemas, and the canonical on/off gate resolver (SOC2 prod opt-in + test-off). Where correlation-id resolution should ultimately live (call site vs recorder) is part of this.
- **Child-trajectory ingest on `task_complete` (issue item 2)** — passing a known child trajectory dir at spawn and attaching the child's `RecordedTrajectory` files as task artifacts under the linked step id. Assessed and deferred: `spawn-trajectory.ts` stamps `ELIZA_PARENT_TRAJECTORY_STEP_ID` but nothing yet ingests child files; passing a child dir now, with no consumer, would be speculative dead code and depends on the D2 layout decision.
- **Raw subagent stdout persistence (item 3)** — append-only rotated per-session NDJSON.
- **Per-task cost + token roll-up (item 5)** — summing parent trajectory metrics + `OrchestratorTaskUsage` across the join key.
- **Viewer surfacing of file-recorder trajectories + subagent sub-trees (item 6)** — after join keys land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
