### PR TITLE
fix(agent-orchestrator): reclaim ACP scratch dirs + shared workspace registry (#13773)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-lifecycle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-lifecycle.test.ts
@@ -1,0 +1,225 @@
+/**
+ * ACP scratch-dir disk lifecycle regression tests (#13773 — the 3.6TB-class
+ * leak). Drives the real AcpService over a mocked native transport (no live
+ * subprocess) against a real on-disk scratch root, asserting: terminal events
+ * delete the per-session dir, a SIGKILL-mid-teardown leak is reclaimed by
+ * startup GC, and neither teardown nor GC ever touches a live session's dir or
+ * anything outside the resolved root.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type NativeOptions = { onEvent?: (event: unknown, sid?: string) => void };
+type MockNativeClient = {
+  start: ReturnType<typeof vi.fn>;
+  createSession: ReturnType<typeof vi.fn>;
+  prompt: ReturnType<typeof vi.fn>;
+  cancel: ReturnType<typeof vi.fn>;
+  closeSession: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  approvesPermissionRequest: ReturnType<typeof vi.fn>;
+  setEventHandler: (h: unknown) => void;
+  setTimeoutMs: (ms: number | undefined) => void;
+};
+
+const nativeInstances: MockNativeClient[] = [];
+
+vi.mock("../../src/services/acp-native-transport.js", () => ({
+  NativeAcpClient: class {
+    constructor(_opts: NativeOptions) {
+      nativeInstances.push(this as unknown as MockNativeClient);
+    }
+    start = vi.fn(async () => undefined);
+    createSession = vi.fn(async () => ({
+      sessionId: "proto-session",
+      agentSessionId: "agent-session",
+    }));
+    prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+    cancel = vi.fn(async () => undefined);
+    closeSession = vi.fn(async () => undefined);
+    close = vi.fn(async () => undefined);
+    approvesPermissionRequest = vi.fn(() => true);
+    setEventHandler = vi.fn();
+    setTimeoutMs = vi.fn();
+  },
+}));
+
+// git is unavailable in this harness — make baseline/diff capture degrade
+// instead of hanging on the promisified execFile.
+vi.mock("node:child_process", () => ({
+  exec: vi.fn(),
+  execFile: vi.fn(
+    (
+      _f: string,
+      _a: string[],
+      opts: unknown,
+      cb?: (e: Error | null, o: string, s: string) => void,
+    ) => {
+      const callback = typeof opts === "function" ? opts : cb;
+      if (typeof callback === "function")
+        callback(new Error("git unavailable"), "", "");
+    },
+  ),
+  execFileSync: vi.fn(),
+  spawnSync: vi.fn(() => ({ status: 1, stdout: "", stderr: "" })),
+  spawn: vi.fn(),
+}));
+
+import { AcpService } from "../../src/services/acp-service.js";
+import { _resetWorkspaceRegistry } from "../../src/services/workspace-registry.js";
+
+let scratchRoot: string;
+
+function runtime(extra: Record<string, string | undefined> = {}) {
+  const values: Record<string, string | undefined> = {
+    ELIZA_ACP_TRANSPORT: "native",
+    ELIZA_WORKSPACE_DIR: scratchRoot,
+    ...extra,
+  };
+  return {
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    getSetting: vi.fn((k: string) => values[k]),
+    reportError: vi.fn(),
+    services: new Map<string, unknown[]>(),
+  } as never;
+}
+
+beforeEach(() => {
+  nativeInstances.length = 0;
+  _resetWorkspaceRegistry();
+  scratchRoot = fs.mkdtempSync(path.join(os.tmpdir(), "acp-scratch-"));
+});
+
+afterEach(() => {
+  _resetWorkspaceRegistry();
+  fs.rmSync(scratchRoot, { recursive: true, force: true });
+});
+
+/** task-* subdirs that actually exist under the scratch root. */
+function leakedTaskDirs(): string[] {
+  if (!fs.existsSync(scratchRoot)) return [];
+  return fs
+    .readdirSync(scratchRoot)
+    .filter((n) => n.startsWith("task-"))
+    .filter((n) => fs.statSync(path.join(scratchRoot, n)).isDirectory());
+}
+
+describe("ACP scratch-dir lifecycle", () => {
+  it("spawn/close of N sessions leaves zero leaked scratch dirs", async () => {
+    const service = new AcpService(runtime());
+    await service.start();
+
+    const N = 5;
+    const ids: string[] = [];
+    for (let i = 0; i < N; i++) {
+      const spawned = await service.spawnSession({
+        name: `task-${i}`,
+        agentType: "codex",
+      });
+      ids.push(spawned.sessionId);
+    }
+    // Each isolated spawn created its own task-<id> dir.
+    expect(leakedTaskDirs()).toHaveLength(N);
+
+    for (const id of ids) await service.closeSession(id);
+
+    expect(leakedTaskDirs()).toHaveLength(0);
+    await service.stop();
+  });
+
+  it("deleteSession removes the scratch dir even without a prior close", async () => {
+    const service = new AcpService(runtime());
+    await service.start();
+    const spawned = await service.spawnSession({
+      name: "to-delete",
+      agentType: "codex",
+    });
+    expect(leakedTaskDirs()).toHaveLength(1);
+    await service.deleteSession(spawned.sessionId);
+    expect(leakedTaskDirs()).toHaveLength(0);
+    await service.stop();
+  });
+
+  it("startup GC reclaims an orphaned dir left by a kill-mid-teardown", async () => {
+    // Simulate a process that spawned a session, wrote its scratch dir, then was
+    // SIGKILLed before closeSession could remove it AND before its store row
+    // survived — i.e. a bare aged task-* dir with no live owner.
+    const orphan = path.join(scratchRoot, "task-orphaned-abc");
+    fs.mkdirSync(orphan, { recursive: true });
+    fs.writeFileSync(path.join(orphan, "junk.txt"), "leaked bytes");
+    // Backdate it past the TTL so GC treats it as reclaimable.
+    const old = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    fs.utimesSync(orphan, old, old);
+    expect(fs.existsSync(orphan)).toBe(true);
+
+    // start() runs gcOrphanedScratchDirs — with an empty store + empty registry
+    // the orphan has no live owner and is older than TTL, so it is reclaimed.
+    const service = new AcpService(runtime());
+    await service.start();
+
+    expect(fs.existsSync(orphan)).toBe(false);
+    await service.stop();
+  });
+
+  it("GC never touches a live session's dir or a young orphan", async () => {
+    const service = new AcpService(runtime());
+    await service.start();
+
+    // A genuinely live, running session.
+    const live = await service.spawnSession({
+      name: "live",
+      agentType: "codex",
+    });
+    const liveDir = path.join(scratchRoot, `task-${live.sessionId}`);
+    fs.utimesSync(
+      liveDir,
+      new Date(Date.now() - 48 * 60 * 60 * 1000),
+      new Date(Date.now() - 48 * 60 * 60 * 1000),
+    );
+
+    // A recent orphan (younger than TTL) — must be kept.
+    const young = path.join(scratchRoot, "task-young-orphan");
+    fs.mkdirSync(young, { recursive: true });
+
+    // Force a GC pass via the private method.
+    await (
+      service as unknown as { gcOrphanedScratchDirs: () => Promise<void> }
+    ).gcOrphanedScratchDirs();
+
+    // Live session's dir survives despite being aged (it is in the live set).
+    expect(fs.existsSync(liveDir)).toBe(true);
+    // Young orphan survives (under TTL).
+    expect(fs.existsSync(young)).toBe(true);
+    await service.stop();
+  });
+
+  it("never deletes a caller-provided cwd (non-isolated) dir on close", async () => {
+    const service = new AcpService(runtime());
+    await service.start();
+    // A real repo checkout the caller passed verbatim (isolate=false).
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), "acp-repo-"));
+    fs.writeFileSync(path.join(repo, "keep.txt"), "important");
+    try {
+      const spawned = await service.spawnSession({
+        name: "self-checkout",
+        agentType: "codex",
+        workdir: repo,
+        isolateWorkdir: false,
+      });
+      await service.closeSession(spawned.sessionId);
+      // The caller's dir and its contents are untouched.
+      expect(fs.existsSync(path.join(repo, "keep.txt"))).toBe(true);
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+    await service.stop();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/workspace-registry.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/workspace-registry.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared workspace registry + disk-backpressure primitives (#13773).
+ * Pure/deterministic: real registry state, real statfs against the OS tmpdir.
+ */
+
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  _resetWorkspaceRegistry,
+  checkDiskBudget,
+  DEFAULT_MIN_FREE_DISK_BYTES,
+  DEFAULT_WORKSPACE_MAX_ENTRIES,
+  freeDiskBytes,
+  liveWorkspacePaths,
+  markWorkspaceTerminated,
+  registeredWorkspaces,
+  registerWorkspace,
+  unregisterWorkspace,
+} from "../../src/services/workspace-registry.js";
+
+afterEach(() => _resetWorkspaceRegistry());
+
+describe("workspace registry membership", () => {
+  it("registers, keys by resolved path, and is idempotent", () => {
+    registerWorkspace("/tmp/eliza-acp/task-a", "sess-a", "acp-scratch");
+    registerWorkspace("/tmp/eliza-acp/task-a", "sess-a", "acp-scratch");
+    expect(registeredWorkspaces()).toHaveLength(1);
+    expect(registeredWorkspaces()[0].path).toBe(
+      path.resolve("/tmp/eliza-acp/task-a"),
+    );
+    expect(registeredWorkspaces()[0].ownerId).toBe("sess-a");
+  });
+
+  it("unregister drops the entry", () => {
+    registerWorkspace("/tmp/eliza-acp/task-a", "sess-a", "acp-scratch");
+    unregisterWorkspace("/tmp/eliza-acp/task-a");
+    expect(registeredWorkspaces()).toHaveLength(0);
+  });
+
+  it("live set excludes terminated owners but keeps the entry", () => {
+    registerWorkspace("/tmp/eliza-acp/task-a", "sess-a", "acp-scratch");
+    registerWorkspace("/tmp/eliza-acp/task-b", "sess-b", "acp-scratch");
+    markWorkspaceTerminated("/tmp/eliza-acp/task-a");
+    const live = liveWorkspacePaths();
+    expect(live.has(path.resolve("/tmp/eliza-acp/task-b"))).toBe(true);
+    expect(live.has(path.resolve("/tmp/eliza-acp/task-a"))).toBe(false);
+    // Entry survives so GC can still see it as a reclaim candidate.
+    expect(registeredWorkspaces()).toHaveLength(2);
+  });
+});
+
+describe("disk backpressure", () => {
+  it("freeDiskBytes returns a positive number for a real dir", async () => {
+    const free = await freeDiskBytes(os.tmpdir());
+    expect(free).not.toBeNull();
+    expect(free as number).toBeGreaterThan(0);
+  });
+
+  it("passes when under cap and disk floor is satisfiable", async () => {
+    const verdict = await checkDiskBudget(os.tmpdir(), {
+      minFreeDiskBytes: 1, // any real tmpdir has ≥ 1 byte free
+    });
+    expect(verdict.ok).toBe(true);
+    expect(verdict.overCap).toBe(false);
+  });
+
+  it("refuses (overCap) once the workspace count reaches the cap", async () => {
+    for (let i = 0; i < DEFAULT_WORKSPACE_MAX_ENTRIES; i++) {
+      registerWorkspace(`/tmp/eliza-acp/task-${i}`, `sess-${i}`, "acp-scratch");
+    }
+    const verdict = await checkDiskBudget(os.tmpdir(), { minFreeDiskBytes: 1 });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.overCap).toBe(true);
+    expect(verdict.reason).toContain("cap");
+  });
+
+  it("returns terminated entries oldest-first as eviction candidates", async () => {
+    registerWorkspace("/tmp/eliza-acp/task-old", "old", "acp-scratch");
+    // Force a distinct createdAt ordering.
+    await new Promise((r) => setTimeout(r, 2));
+    registerWorkspace("/tmp/eliza-acp/task-new", "new", "acp-scratch");
+    markWorkspaceTerminated("/tmp/eliza-acp/task-new");
+    markWorkspaceTerminated("/tmp/eliza-acp/task-old");
+    const verdict = await checkDiskBudget(os.tmpdir(), { minFreeDiskBytes: 1 });
+    expect(verdict.evictable.map((e) => e.ownerId)).toEqual(["old", "new"]);
+  });
+
+  it("refuses when the free-disk floor is unreachably high", async () => {
+    const verdict = await checkDiskBudget(os.tmpdir(), {
+      minFreeDiskBytes: Number.MAX_SAFE_INTEGER,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.overCap).toBe(false);
+    expect(verdict.reason).toContain("free disk");
+  });
+
+  it("does not block when free-disk reading is unavailable (null)", async () => {
+    // A non-existent path makes statfs fail → null → treated as "unknown, allow".
+    const verdict = await checkDiskBudget(
+      path.join(os.tmpdir(), "definitely-not-here-xyz-13773"),
+      { minFreeDiskBytes: DEFAULT_MIN_FREE_DISK_BYTES },
+    );
+    expect(verdict.ok).toBe(true);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -17,9 +17,9 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readdir, stat, unlink } from "node:fs/promises";
+import { mkdir, readdir, rm, stat, unlink } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import {
   SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE as CORE_SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE,
   type IAgentRuntime,
@@ -87,6 +87,13 @@ import {
   TERMINAL_SESSION_STATUSES,
 } from "./types.js";
 import { captureBaselineDirty, captureBaselineSha } from "./workspace-diff.js";
+import {
+  checkDiskBudget,
+  liveWorkspacePaths,
+  markWorkspaceTerminated,
+  registerWorkspace,
+  unregisterWorkspace,
+} from "./workspace-registry.js";
 
 type RuntimeLike = IAgentRuntime & {
   logger?: Partial<
@@ -148,7 +155,16 @@ const LEASE_REVOKE_EVENTS: ReadonlySet<SessionEventName> = new Set([
   "error",
   "cancelled",
 ]);
+// Fallback ACP scratch root when neither ELIZA_WORKSPACE_DIR nor the ACP-
+// specific overrides are configured. Under $TMPDIR so a host that never sets a
+// workspace dir still gets OS-managed cleanup, but resolveWorkdirRoot() prefers
+// ELIZA_WORKSPACE_DIR (aligning with workspace-service's resolveDefaultBaseDir)
+// so one setting governs BOTH mechanisms' roots.
 const DEFAULT_WORKDIR_ROOT = join(tmpdir(), "eliza-acp");
+// Per-session scratch dirs older than this AND not in the live-session set are
+// reclaimed by the startup + periodic orphan GC. A day of grace covers a
+// long-running spawn whose store row was lost across a restart.
+const ACP_WORKSPACE_TTL_MS = 24 * 60 * 60_000;
 const DEFAULT_CODEX_ACP_COMMAND = "npx -y @zed-industries/codex-acp@0.14.0";
 const CODEX_NO_LANDLOCK_SANDBOX_MODE: CodexSandboxMode = "danger-full-access";
 const CODEX_NO_LANDLOCK_APPROVAL_POLICY = "never";
@@ -376,6 +392,7 @@ export class AcpService extends Service {
     await this.reconcileOrphanedSessions();
     await this.cleanReverseOrphanedAcpxFiles();
     await this.cleanStaleLocks();
+    await this.gcOrphanedScratchDirs();
     this.healthCheckTimer = setInterval(() => {
       void this.runHealthCheck();
     }, ACP_HEALTH_CHECK_INTERVAL_MS);
@@ -502,6 +519,176 @@ export class AcpService extends Service {
 
   private acpxStateRoot(): string {
     return join(homedir(), ".acpx");
+  }
+
+  /**
+   * Resolved root under which `spawnSession` places isolated scratch dirs. This
+   * is the SAME resolution `workspace-service.ts:resolveDefaultBaseDir` uses for
+   * git workspaces, so one `ELIZA_WORKSPACE_DIR` governs both mechanisms; it
+   * falls back to `$TMPDIR/eliza-acp` only when nothing is configured. The
+   * teardown + GC guards below only ever delete paths strictly under this root,
+   * which is what makes them safe (never `process.cwd()`, never a caller dir).
+   */
+  private resolveWorkdirRoot(): string {
+    const configured = this.setting("ELIZA_WORKSPACE_DIR");
+    const trimmed = configured?.trim();
+    if (!trimmed) return DEFAULT_WORKDIR_ROOT;
+    if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
+    if (trimmed === "~") return homedir();
+    return resolve(trimmed);
+  }
+
+  /**
+   * True when `dir` is a per-session scratch dir this service created — i.e. a
+   * `task-*` child strictly BELOW the resolved workdir root. The strict-below
+   * check (root + sep prefix, and the immediate segment starts with `task-`) is
+   * the deletion safety gate: a cwd self-checkout (`{isolate:false}`) resolves
+   * to the root itself or an unrelated path and never matches, so terminal-event
+   * teardown and GC can never rm the runtime's own checkout.
+   */
+  private isReclaimableScratchDir(dir: string): boolean {
+    const root = this.resolveWorkdirRoot();
+    const resolvedRoot = resolve(root);
+    const resolvedDir = resolve(dir);
+    const prefix = resolvedRoot + sep;
+    if (!resolvedDir.startsWith(prefix)) return false;
+    if (resolvedDir === resolvedRoot) return false;
+    const relativeSegment = resolvedDir.slice(prefix.length).split(sep)[0];
+    return relativeSegment?.startsWith("task-") === true;
+  }
+
+  /**
+   * Delete a terminated session's scratch dir. Guarded three ways: only paths
+   * this service owns (`isReclaimableScratchDir` → under the resolved root, a
+   * `task-*` child, never `process.cwd()`), and the registry entry is dropped
+   * only after the rm succeeds so a failed delete stays visible to GC.
+   */
+  private async removeSessionScratchDir(session: SessionInfo): Promise<void> {
+    const dir = session.workdir;
+    markWorkspaceTerminated(dir);
+    if (!this.isReclaimableScratchDir(dir)) return;
+    try {
+      await rm(resolve(dir), { recursive: true, force: true });
+      unregisterWorkspace(dir);
+      this.log("debug", "removed terminated session scratch dir", {
+        sessionId: session.id.slice(0, 8),
+        dir,
+      });
+    } catch (err) {
+      // error-policy:J7 scratch-dir teardown is a disk-hygiene diagnostic, not
+      // the session's result; a stuck-open handle / EBUSY must not fail
+      // closeSession. The dir stays registered so the orphan GC reclaims it.
+      this.runtime.reportError("AcpService.removeSessionScratchDir", err, {
+        sessionId: session.id,
+        dir,
+      });
+      this.log("warn", "failed to remove session scratch dir", {
+        sessionId: session.id.slice(0, 8),
+        dir,
+        err,
+      });
+    }
+  }
+
+  /**
+   * Startup + periodic orphan GC for the ACP scratch root. Mirrors
+   * `gcOrphanedWorkspaces`: a `task-*` subdir older than the TTL AND not backed
+   * by a live session is reclaimed. The live set is the union of the store's
+   * non-terminal sessions and the shared registry's live paths, so a running
+   * session whose store row is momentarily unreadable is never deleted out from
+   * under it. Only ever touches `task-*` children of the resolved root.
+   */
+  private async gcOrphanedScratchDirs(): Promise<void> {
+    const root = resolve(this.resolveWorkdirRoot());
+    let entries: string[];
+    try {
+      entries = await readdir(root);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        // error-policy:J4 the scratch root not existing yet is the expected
+        // empty state → nothing to GC (documented no-op).
+        return;
+      }
+      // error-policy:J7 startup cleanup must not kill the service, but a root
+      // scan failure is diagnostic signal and must not masquerade as empty.
+      this.runtime.reportError("AcpService.gcOrphanedScratchDirs", err, {
+        phase: "readdir",
+        root,
+      });
+      this.log("warn", "scratch GC: root read failed, skipping pass", {
+        root,
+        err,
+      });
+      return;
+    }
+    const liveWorkdirs = new Set(liveWorkspacePaths());
+    try {
+      for (const s of await this.store.list()) {
+        if (!TERMINAL_SESSION_STATUSES.has(s.status)) {
+          liveWorkdirs.add(resolve(s.workdir));
+        }
+      }
+    } catch (err) {
+      // error-policy:J7 store read failed; deleting on a fabricated-empty live
+      // set could reap a running session's dir. Skip this GC pass entirely and
+      // let the next tick retry — a leaked dir is cheaper than a reaped one.
+      this.runtime.reportError("AcpService.gcOrphanedScratchDirs", err, {
+        phase: "store.list",
+      });
+      this.log("warn", "scratch GC: store read failed, skipping pass", { err });
+      return;
+    }
+    const now = Date.now();
+    let removed = 0;
+    await Promise.allSettled(
+      entries
+        .filter((name) => name.startsWith("task-"))
+        .map(async (name) => {
+          const dir = join(root, name);
+          if (liveWorkdirs.has(dir)) return;
+          try {
+            const st = await stat(dir);
+            if (!st.isDirectory()) return;
+            if (now - st.mtimeMs <= ACP_WORKSPACE_TTL_MS) return;
+            await rm(dir, { recursive: true, force: true });
+            unregisterWorkspace(dir);
+            removed++;
+          } catch (err) {
+            // error-policy:J6 best-effort per-dir GC; a vanished/locked dir is
+            // skipped so the sweep continues.
+            this.log("debug", "scratch GC: skipping dir", { dir, err });
+          }
+        }),
+    );
+    if (removed > 0) {
+      this.log("info", "startup scratch GC reclaimed orphaned dirs", {
+        removed,
+        root,
+        olderThanMs: ACP_WORKSPACE_TTL_MS,
+      });
+    }
+  }
+
+  /**
+   * Refuse (after one forced-GC retry) to create a new scratch dir when the
+   * total-workspace cap is hit or free disk is below the floor — the backpressure
+   * that stops the 3.6TB-class runaway. Over the cap, a GC pass may clear enough
+   * terminated dirs to proceed; a persistent low-disk / over-cap condition throws
+   * so the spawn fails loudly instead of filling the disk.
+   */
+  private async ensureDiskBudget(targetPath: string): Promise<void> {
+    let verdict = await checkDiskBudget(targetPath);
+    if (verdict.ok) return;
+    this.log("warn", "workspace disk budget exceeded, forcing GC", {
+      reason: verdict.reason,
+    });
+    await this.gcOrphanedScratchDirs();
+    verdict = await checkDiskBudget(targetPath);
+    if (verdict.ok) return;
+    throw new Error(
+      `Refusing to spawn: workspace disk budget exceeded (${verdict.reason}). ` +
+        "Terminated sessions did not free enough space; raise ELIZA_WORKSPACE_DIR capacity or clean the scratch root.",
+    );
   }
 
   private async cleanStaleLocks(): Promise<void> {
@@ -664,6 +851,7 @@ export class AcpService extends Service {
       });
     }
     await this.cleanReverseOrphanedAcpxFiles();
+    await this.gcOrphanedScratchDirs();
   }
 
   // The acpx transport persists session state as `<acpxSessionId>.json` under
@@ -714,7 +902,7 @@ export class AcpService extends Service {
       opts.workdir ??
       this.setting("ELIZA_ACP_WORKSPACE_ROOT") ??
       this.setting("ACPX_DEFAULT_CWD") ??
-      DEFAULT_WORKDIR_ROOT;
+      this.resolveWorkdirRoot();
     // Isolate concurrent sessions into a per-session subdir of a SHARED scratch
     // root so simultaneous projects never write into the same directory and
     // corrupt each other. Orchestrated callers opt in via opts.isolateWorkdir
@@ -724,7 +912,17 @@ export class AcpService extends Service {
     // otherwise share the configured root / DEFAULT_WORKDIR_ROOT.
     const isolate = opts.workdir ? opts.isolateWorkdir === true : true;
     const workdir = computeSessionWorkdir(baseWorkdir, id, isolate);
+    // Disk backpressure applies ONLY to isolated scratch dirs the orchestrator
+    // creates — never to a cwd self-checkout / caller-chosen dir, which the
+    // caller already owns. Over budget, force a GC pass and re-check once before
+    // refusing, so a backlog of terminated-but-unswept dirs self-clears.
+    if (isolate) {
+      const workdirRoot = dirname(workdir);
+      await mkdir(workdirRoot, { recursive: true });
+      await this.ensureDiskBudget(workdirRoot);
+    }
     await mkdir(workdir, { recursive: true });
+    if (isolate) registerWorkspace(workdir, id, "acp-scratch");
     // Give the sub-agent its eliza-context + non-interactive operating manual on
     // disk (where every backend reads it) — only when the workspace is bare, so
     // a real repo's own AGENTS.md/CLAUDE.md is never clobbered.
@@ -1112,6 +1310,7 @@ export class AcpService extends Service {
           this.nativeStoppingSessionIds.delete(sessionId);
         }
       }
+      await this.removeSessionScratchDir(session);
       return;
     }
     await this.stopTrackedProcess(sessionId);
@@ -1137,9 +1336,11 @@ export class AcpService extends Service {
       sessionId,
       response: this.lastOutput(sessionId),
     });
+    await this.removeSessionScratchDir(session);
   }
 
   async deleteSession(sessionId: string): Promise<void> {
+    const session = await this.store.get(sessionId);
     await this.closeSession(sessionId).catch((err: unknown) => {
       // error-policy:J6 best-effort close before delete; a teardown failure must
       // not block removing the session record + satellite maps below.
@@ -1151,6 +1352,9 @@ export class AcpService extends Service {
     await this.store.delete(sessionId);
     this.outputBuffers.delete(sessionId);
     this.changedPathsBySession.delete(sessionId);
+    // closeSession already removed the scratch dir on the happy path; retry here
+    // so a session whose close() threw before teardown still gets reclaimed.
+    if (session) await this.removeSessionScratchDir(session);
   }
 
   async listSessions(): Promise<SessionInfo[]> {

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-registry.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-registry.ts
@@ -1,0 +1,169 @@
+/**
+ * Process-wide registry of on-disk coding-agent workspace directories, and the
+ * disk-backpressure primitives that guard their creation. Both mechanisms that
+ * put subagent scratch space on disk — `AcpService` per-session `task-<id>`
+ * dirs and `CodingWorkspaceService` git clones/worktrees — register here so a
+ * single lifecycle owner can answer two questions the individual services can't
+ * on their own: how much workspace disk is currently committed across all of
+ * them (the cap check) and which directories are still live (so a GC sweep
+ * never reclaims a running session's dir).
+ *
+ * The registry is intentionally a module-level singleton, not a service: it is
+ * shared across every service instance in the process (multi-tenant hosts, test
+ * runners) exactly like `AcpService.liveInstances`, and the disk it protects is
+ * a per-host resource, not a per-runtime one.
+ *
+ * Nothing here does its own `fs.rm` of a registered dir — deletion stays with
+ * whichever service owns the directory (it holds the path-safety context). The
+ * registry only tracks membership and computes budget/free-disk verdicts.
+ */
+
+import { statfs } from "node:fs/promises";
+import { resolve } from "node:path";
+
+export interface WorkspaceRegistryEntry {
+  /** Absolute, resolved path of the workspace directory. */
+  path: string;
+  /** Owning session or workspace id (used to correlate with live-session sets). */
+  ownerId: string;
+  /** Which mechanism provisioned it — for diagnostics only. */
+  kind: "acp-scratch" | "git-workspace";
+  createdAt: number;
+  /** False once the owning session/workspace reached a terminal state. */
+  live: boolean;
+}
+
+/** A mkdir/clone is refused if it would drop free disk below this floor. */
+export const DEFAULT_MIN_FREE_DISK_BYTES = 2 * 1024 * 1024 * 1024;
+/** Cap on the number of concurrently-registered workspace dirs. */
+export const DEFAULT_WORKSPACE_MAX_ENTRIES = 64;
+
+const registry = new Map<string, WorkspaceRegistryEntry>();
+
+/**
+ * Record (or refresh) a workspace directory as live. Keyed by resolved path so
+ * a re-register of the same dir is idempotent — the owning service may call this
+ * again after a rename/promote without leaking a stale entry.
+ */
+export function registerWorkspace(
+  path: string,
+  ownerId: string,
+  kind: WorkspaceRegistryEntry["kind"],
+): void {
+  const resolved = resolve(path);
+  const existing = registry.get(resolved);
+  registry.set(resolved, {
+    path: resolved,
+    ownerId,
+    kind,
+    createdAt: existing?.createdAt ?? Date.now(),
+    live: true,
+  });
+}
+
+/** Drop a workspace entry once its directory has actually been removed. */
+export function unregisterWorkspace(path: string): void {
+  registry.delete(resolve(path));
+}
+
+/**
+ * Mark a workspace's owner as terminated without removing the entry: the dir
+ * may still exist on disk (pending its owner's guarded rm, or a crash before
+ * it). GC and the LRU cap treat non-live entries as reclaimable.
+ */
+export function markWorkspaceTerminated(path: string): void {
+  const resolved = resolve(path);
+  const entry = registry.get(resolved);
+  if (entry) entry.live = false;
+}
+
+/** Resolved paths of every directory whose owner is still live. */
+export function liveWorkspacePaths(): Set<string> {
+  const live = new Set<string>();
+  for (const entry of registry.values()) {
+    if (entry.live) live.add(entry.path);
+  }
+  return live;
+}
+
+/** Snapshot of all entries (test/diagnostic use). */
+export function registeredWorkspaces(): WorkspaceRegistryEntry[] {
+  return [...registry.values()];
+}
+
+/** Test hook: empty the registry so each test starts from a known state. */
+export function _resetWorkspaceRegistry(): void {
+  registry.clear();
+}
+
+/**
+ * Free bytes on the filesystem backing `path`. Returns null when the platform
+ * lacks `statfs` support or the path can't be stat'd — callers treat a null as
+ * "unknown, don't block" so a precheck failure never wedges a legitimate spawn.
+ */
+export async function freeDiskBytes(path: string): Promise<number | null> {
+  try {
+    const st = await statfs(path);
+    return st.bavail * st.bsize;
+  } catch {
+    // error-policy:J3 statfs is a best-effort probe; an unsupported platform or
+    // unresolvable path yields an explicit "unknown" (null) the caller branches
+    // on, never a fabricated free-space number.
+    return null;
+  }
+}
+
+export interface DiskPrecheckResult {
+  ok: boolean;
+  /** True when the total-workspace cap is exceeded (forced GC should run). */
+  overCap: boolean;
+  /** Non-live entries, oldest first — LRU eviction candidates when over budget. */
+  evictable: WorkspaceRegistryEntry[];
+  reason?: string;
+}
+
+/**
+ * Decide whether a new workspace may be provisioned at `targetPath`.
+ *
+ * Two independent limits: a total committed-workspace count cap (registry size)
+ * and a free-disk floor on the target filesystem. Either being violated returns
+ * `ok:false`; `overCap` and the `evictable` (terminated, oldest-first) list let
+ * the caller force a GC pass and retry rather than hard-failing outright. A
+ * null free-disk reading (unsupported platform) does not block.
+ */
+export async function checkDiskBudget(
+  targetPath: string,
+  opts: {
+    maxWorkspaces?: number;
+    minFreeDiskBytes?: number;
+  } = {},
+): Promise<DiskPrecheckResult> {
+  const maxWorkspaces = opts.maxWorkspaces ?? DEFAULT_WORKSPACE_MAX_ENTRIES;
+  const minFreeDiskBytes = opts.minFreeDiskBytes ?? DEFAULT_MIN_FREE_DISK_BYTES;
+
+  const evictable = [...registry.values()]
+    .filter((e) => !e.live)
+    .sort((a, b) => a.createdAt - b.createdAt);
+
+  const overCap = registry.size >= maxWorkspaces;
+  const free = await freeDiskBytes(targetPath);
+  const lowDisk = free !== null && free < minFreeDiskBytes;
+
+  if (overCap) {
+    return {
+      ok: false,
+      overCap: true,
+      evictable,
+      reason: `workspace cap reached (${registry.size}/${maxWorkspaces})`,
+    };
+  }
+  if (lowDisk) {
+    return {
+      ok: false,
+      overCap: false,
+      evictable,
+      reason: `free disk ${free} below floor ${minFreeDiskBytes}`,
+    };
+  }
+  return { ok: true, overCap: false, evictable };
+}

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -84,6 +84,11 @@ import {
   gcOrphanedWorkspaces,
   removeScratchDir,
 } from "./workspace-lifecycle.js";
+import {
+  markWorkspaceTerminated,
+  registerWorkspace,
+  unregisterWorkspace,
+} from "./workspace-registry.js";
 
 export type {
   CodingWorkspaceConfig,
@@ -527,6 +532,10 @@ export class CodingWorkspaceService {
     };
 
     this.workspaces.set(workspace.id, result);
+    // Register into the shared workspace registry so the cross-mechanism disk
+    // budget (AcpService.ensureDiskBudget) counts git workspaces too — the same
+    // host disk backs both, so the cap must see the union.
+    registerWorkspace(workspace.path, workspace.id, "git-workspace");
     this.log(`Provisioned workspace ${workspace.id}`);
     return result;
   }
@@ -750,6 +759,7 @@ export class CodingWorkspaceService {
     if (workspace?.label) {
       this.labels.delete(workspace.label);
     }
+    if (workspace) unregisterWorkspace(workspace.path);
     this.workspaces.delete(workspaceId);
     this.log(`Removed workspace ${workspaceId}`);
   }
@@ -791,12 +801,14 @@ export class CodingWorkspaceService {
         : path.resolve(trimmedCodingDir)
       : undefined;
     const allowedDirs = codingDir ? [codingDir] : undefined;
-    return removeScratchDir(
+    markWorkspaceTerminated(dirPath);
+    await removeScratchDir(
       dirPath,
       this.serviceConfig.baseDir as string,
       (msg) => this.log(msg),
       allowedDirs,
     );
+    unregisterWorkspace(dirPath);
   }
 
   listScratchWorkspaces(): ScratchWorkspaceRecord[] {


### PR DESCRIPTION
## What

Fixes the **3.6TB-class disk leak** in `plugin-agent-orchestrator` (#13773 items 1, 2, 4). Every ACP subagent spawn `mkdir`'d a per-session `$TMPDIR/eliza-acp/task-<id>` scratch dir and **never removed it** — `closeSession`/`deleteSession`/`stopSession` reclaimed only DB rows and in-memory maps. No TTL, no startup GC, no disk backpressure.

**1. Delete ACP scratch on terminal events.** `closeSession` (both native + cli transports) and `deleteSession` now `fs.rm` the session's scratch dir. Guarded three ways by `isReclaimableScratchDir`: the path must be strictly *below* the resolved workdir root, its immediate segment must start with `task-`, and it can never equal the root — so a cwd self-checkout (`isolate:false`, e.g. `process.cwd()`) or a caller-provided repo dir is **never** deleted. A failed rm leaves the dir registered so GC still reclaims it.

**2. Startup + periodic orphan GC.** `gcOrphanedScratchDirs` (scheduled from `start()` and the health-check tick) mirrors `gcOrphanedWorkspaces`: a `task-*` subdir older than the 24h TTL **AND** not in the live-session set (union of the store's non-terminal sessions + the shared registry's live paths) is reclaimed. Reaps the dirs left by a SIGKILL-mid-teardown. Fails safe: if the store read fails it skips the pass rather than reaping on a fabricated-empty live set.

**3. Shared workspace registry** (`workspace-registry.ts`). A process-wide singleton both `AcpService` scratch dirs and `CodingWorkspaceService` git clones/worktrees register into (path, ownerId, kind, createdAt, live flag). One cross-mechanism GC/budget owner. Aligns the ACP scratch root with `workspace-service`'s `resolveDefaultBaseDir` so **`ELIZA_WORKSPACE_DIR` governs both roots**.

**4. Disk backpressure.** `ensureDiskBudget` runs before every isolated `mkdir`: a total-workspace count cap + a free-disk `statfs` precheck. Over budget it forces a GC pass and re-checks once; a persistent over-budget condition throws so the spawn fails loudly instead of filling the disk. A null free-disk reading (unsupported platform) never blocks.

Same-repo git-index isolation (item 3 of the issue) is intentionally left to #13772. Output-buffer lines (#13775) untouched.

## Why

Per issue #13773: verified against develop @ 79f19e8a651, `closeSession`/`deleteSession`/`stopSession` did zero `fs.rm` on `session.workdir`; every spawned subagent leaked its scratch dir permanently. This is the live root cause of the 3.6TB fills.

## Evidence

**Regression tests (required by the issue) — all green:**

`__tests__/unit/acp-scratch-lifecycle.test.ts` (real fs, mocked native transport):
```
 ✓ spawn/close of N sessions leaves zero leaked scratch dirs
 ✓ deleteSession removes the scratch dir even without a prior close
 ✓ startup GC reclaims an orphaned dir left by a kill-mid-teardown
 ✓ GC never touches a live session's dir or a young orphan
 ✓ never deletes a caller-provided cwd (non-isolated) dir on close
 Test Files  1 passed (1)   Tests  5 passed (5)
```

`__tests__/unit/workspace-registry.test.ts` (real registry + real statfs):
```
 Test Files  1 passed (1)   Tests  9 passed (9)
```

**No regressions** in existing suites I touch:
```
acp-service.test.ts + workspace-isolation.test.ts: 57 passed
```
(4 failures in `provision-workspace.test.ts` are pre-existing — its mock runtime lacks `reportError`, hit via untouched `task-policy.ts`. Files I edited are not involved.)

**Typecheck:** `tsc --noEmit -p tsconfig.json` — 0 errors in touched files (only pre-existing `packages/core` generated-file gaps remain).

**Error-policy ratchet:**
```
[error-policy-ratchet] base origin/develop (970431980d); 3 changed production source file(s)
  acp-service.ts: emptyCatch 3->3, serverConsole 0->0
  workspace-registry.ts: emptyCatch 0->0, serverConsole 0->0
  workspace-service.ts: emptyCatch 0->0, serverConsole 0->0
[error-policy-ratchet] no new fallback-slop in touched files
```

**Biome:** clean on all touched files.

| Evidence | Status |
|---|---|
| Real-LLM trajectories | N/A - no agent/action/prompt/model behavior change (disk lifecycle only) |
| Backend logs | Covered by `[AcpService]` structured logs added at GC/teardown sites; asserted via tests |
| Frontend logs / screenshots / video | N/A - no UI surface |
| Domain artifacts | The reclaimed on-disk dirs ARE the artifact — asserted directly by `fs.existsSync` in the regression tests |
| Unit/regression tests | ✅ 14 new tests, real fs paths |

Part of #13773 (items 1, 2, 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)