### PR TITLE
fix(orchestrator): pin task workdir across respawns

### DIFF
--- a/.github/issue-evidence/13776-task-workdir-lock.md
+++ b/.github/issue-evidence/13776-task-workdir-lock.md
@@ -1,0 +1,35 @@
+# #13776 task workdir lock evidence
+
+Scope: first rollout step from the D3 Project-entity decision doc. Persist the
+first resolved workdir on the durable orchestrator task and reuse it for later
+task spawns that do not explicitly request a different workdir.
+
+## Verification
+
+- `bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts --testNamePattern 'pins follow-up spawns|assigns distinct names'`
+  - Result: 1 file passed, 2 tests passed, 60 skipped.
+  - Note: Vitest emitted a root `package.json` duplicate-key warning for
+    `test:desktop:packaged:windows`, unrelated to this change.
+- `bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts`
+  - Result: 1 file passed, 62 tests passed.
+  - Note: same unrelated duplicate-key warning as above.
+- `bun run --cwd plugins/plugin-agent-orchestrator typecheck`
+  - Result: passed.
+- `bun run --cwd plugins/plugin-agent-orchestrator lint:check`
+  - Result: passed, 292 files checked.
+- `bun run --cwd plugins/plugin-agent-orchestrator format:check`
+  - Result: passed, 290 files checked before the final rebase; no fixes applied.
+
+## Manual Review
+
+Reviewed the regression test and service diff by hand. The test creates a real
+temporary directory under the checkout, spawns a task agent with that workdir,
+then spawns again without a workdir and asserts both ACP spawns use the same
+directory and the task DTO exposes `metadata.resolvedWorkdir`.
+
+## Evidence Types
+
+- Screenshots/video: N/A - no frontend or rendered UI changed.
+- Live LLM trajectory: N/A - no model prompt/action/provider behavior changed.
+- Backend logs: N/A - covered by the durable service unit path; no live server
+  route behavior changed.

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -13,6 +13,8 @@
  *  - cross-task status aggregation and bulk pause/resume.
  */
 
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
@@ -83,7 +85,7 @@ class FakeAcp {
     return Promise.resolve({
       sessionId: `session-${this.counter}`,
       agentType: (opts.agentType as string | undefined) ?? "codex",
-      workdir: (opts.workdir as string | undefined) ?? "/repo",
+      workdir: (opts.workdir as string | undefined) ?? process.cwd(),
       status: "ready",
     });
   }
@@ -272,6 +274,28 @@ describe("OrchestratorTaskService — sub-agent naming", () => {
     expect(must(first, "first").label.length).toBeGreaterThan(0);
     expect(must(second, "second").label.length).toBeGreaterThan(0);
     expect(must(first, "first").label).not.toBe(must(second, "second").label);
+  });
+
+  it("pins follow-up spawns to the task's first resolved workdir", async () => {
+    const workdir = mkdtempSync(join(process.cwd(), ".orch-workdir-lock-"));
+    try {
+      const acp = new FakeAcp();
+      const service = makeService(acp);
+      await service.start();
+      const task = await service.createTask(createInput());
+
+      await service.spawnAgentForTask(task.id, { workdir });
+      await service.spawnAgentForTask(task.id);
+
+      expect(acp.spawnArgs.map((args) => args.workdir)).toEqual([
+        workdir,
+        workdir,
+      ]);
+      const detail = must(await service.getTask(task.id), "task detail");
+      expect(detail.metadata.resolvedWorkdir).toBe(workdir);
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
   });
 
   it("keeps an explicit caller label instead of assigning a pooled name", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -190,6 +190,7 @@ const INDEPENDENT_ACP_VERIFIER_NAME = "independent-acp-verifier";
  *  before its await is abandoned (treated as inconclusive). Overridable via
  *  `ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY_TIMEOUT_MS`. */
 const DEFAULT_INDEPENDENT_VERIFY_TIMEOUT_MS = 600_000;
+const RESOLVED_WORKDIR_METADATA_KEY = "resolvedWorkdir";
 
 function independentVerifyTimeoutMs(runtime: {
   getSetting?: (key: string) => unknown;
@@ -206,6 +207,15 @@ function independentVerifyTimeoutMs(runtime: {
   return Number.isFinite(value) && value > 0
     ? Math.floor(value)
     : DEFAULT_INDEPENDENT_VERIFY_TIMEOUT_MS;
+}
+
+function storedResolvedWorkdir(
+  metadata: Record<string, unknown> | undefined,
+): string | undefined {
+  const value = metadata?.[RESOLVED_WORKDIR_METADATA_KEY];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 export interface SpawnAgentForTaskOptions {
@@ -2706,8 +2716,10 @@ export class OrchestratorTaskService extends Service {
     }
     const acp = this.acp();
     if (!acp) throw new Error("ACP service unavailable");
-    const workdir = opts.workdir
-      ? await resolveAllowedWorkdir(opts.workdir)
+    const requestedWorkdir =
+      opts.workdir ?? storedResolvedWorkdir(doc.task.metadata);
+    const workdir = requestedWorkdir
+      ? await resolveAllowedWorkdir(requestedWorkdir)
       : undefined;
 
     const policy = doc.task.providerPolicy ?? {};
@@ -2857,6 +2869,14 @@ export class OrchestratorTaskService extends Service {
     this.sessionTaskIndex.set(result.sessionId, taskId);
     try {
       await this.store.addSession(session);
+      if (!storedResolvedWorkdir(doc.task.metadata)) {
+        await this.store.updateTask(taskId, {
+          metadata: {
+            ...doc.task.metadata,
+            [RESOLVED_WORKDIR_METADATA_KEY]: result.workdir,
+          },
+        });
+      }
       await this.advanceTaskStatus(taskId, "active");
       return this.getTask(taskId);
     } catch (err) {


### PR DESCRIPTION
Refs #13776 first rollout slice (stopgap only).

## Summary

This implements the D3 decision-doc stopgap before the full Project registry/API/UI work:

- Persist the first successful orchestrator task spawn workdir as `task.metadata.resolvedWorkdir`.
- Reuse that stored workdir for later `spawnAgentForTask` calls that do not explicitly request a different workdir.
- Keep the existing workdir validator in the path, so a persisted path must still exist and remain inside allowed workspace roots.
- Add regression coverage proving a second task-agent spawn reuses the first spawn's real workdir.

This PR intentionally does not implement the full Project entity, registry, API, UI switcher, project worldId scoping, or Cloud appId binding.

## Evidence

Evidence file: `.github/issue-evidence/13776-task-workdir-lock.md`

Commands run on the final rebased head:

- `bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts --testNamePattern 'pins follow-up spawns|assigns distinct names'` -> 1 file passed, 2 tests passed, 60 skipped.
- `bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts` -> 1 file passed, 62 tests passed.
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` -> passed.
- `bun run --cwd plugins/plugin-agent-orchestrator lint:check` -> passed, 292 files checked.
- `bun run --cwd plugins/plugin-agent-orchestrator format:check` -> passed before final rebase, no fixes applied.
- `git diff --check` -> passed.

N/A: screenshots/video because no UI changed. N/A: live LLM trajectory because no model/action/provider prompt behavior changed.

Note: Vitest emits an unrelated root `package.json` duplicate-key warning for `test:desktop:packaged:windows`; this PR does not touch that file.