### PR TITLE
fix(test): repair merged review regressions

### DIFF
--- a/packages/app/test/hmr-coverage.test.ts
+++ b/packages/app/test/hmr-coverage.test.ts
@@ -1,6 +1,8 @@
 /**
  * Unit tests for the Hmr Coverage app shell contract and coverage guardrail.
  */
+
+import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,26 +20,9 @@ const ROOT_PACKAGE_JSON = path.join(REPO_ROOT, "package.json");
 const APP_PACKAGE_JSON = path.join(REPO_ROOT, "packages/app/package.json");
 
 const EXPECTED_NON_WORKSPACE_HMR_PROBES = new Set([
-  "birdclaw plugins/plugin-birdclaw/src/components/birdclaw/BirdclawView.tsx",
-  "cockpit plugins/plugin-task-coordinator/src/CockpitRoute.tsx",
-  "documents plugins/plugin-documents/src/components/documents/DocumentsView.tsx",
-  "feed plugins/plugin-feed/src/components/FeedView.tsx",
-  "focus plugins/plugin-blocker/src/components/focus/FocusView.tsx",
-  "goals plugins/plugin-goals/src/components/goals/GoalsView.tsx",
-  "hyperliquid plugins/plugin-hyperliquid/src/HyperliquidView.tsx",
-  "messages plugins/plugin-messages/src/components/MessagesView.tsx",
-  "model-tester plugins/app-model-tester/src/ModelTesterAppView.tsx",
-  "orchestrator plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx",
-  "phone plugins/plugin-phone/src/components/PhoneView.tsx",
-  "polymarket plugins/plugin-polymarket/src/PolymarketView.tsx",
-  "screenshare plugins/plugin-screenshare/src/components/ScreenshareView.tsx",
   "shopify plugins/plugin-shopify/src/ShopifyView.tsx",
   "social-alpha plugins/plugin-social-alpha/src/frontend/SocialAlphaView.tsx",
-  "task-coordinator plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx",
-  "training plugins/plugin-training/src/ui/FineTuningView.tsx",
   "trajectory-logger plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.tsx",
-  "vector-browser plugins/plugin-vector-browser/src/VectorBrowserView.tsx",
-  "wallet plugins/plugin-wallet-ui/src/InventoryView.tsx",
 ]);
 
 type GuiViewCase = {
@@ -128,6 +113,21 @@ function readWorkflowJobBlock(workflow: string, jobName: string): string {
   return match?.[1] ?? "";
 }
 
+function probePathExists(repoRelativePath: string): boolean {
+  if (existsSync(path.join(REPO_ROOT, repoRelativePath))) {
+    return true;
+  }
+  const result = spawnSync(
+    "git",
+    ["cat-file", "-e", `HEAD:${repoRelativePath}`],
+    {
+      cwd: REPO_ROOT,
+      stdio: "ignore",
+    },
+  );
+  return result.status === 0;
+}
+
 describe("plugin view HMR coverage", () => {
   it("keeps the HMR source-probe matrix in lockstep with every GUI view", () => {
     const guiCases = readGuiVisualCases();
@@ -143,7 +143,7 @@ describe("plugin view HMR coverage", () => {
       .filter((level) => !guiById.has(level.id))
       .map((level) => `${level.id} ${level.file}`);
     const missingFiles = hmrLevels
-      .filter((level) => !existsSync(path.join(REPO_ROOT, level.file)))
+      .filter((level) => !probePathExists(level.file))
       .map((level) => `${level.id} ${level.file}`);
     const unexpectedMissingFiles = missingFiles.filter(
       (entry) => !EXPECTED_NON_WORKSPACE_HMR_PROBES.has(entry),
@@ -156,7 +156,7 @@ describe("plugin view HMR coverage", () => {
     );
     const missingRootGraphFiles = hmrLevels
       .filter((level) => rootGraphPluginViews.has(level.name))
-      .filter((level) => !existsSync(path.join(REPO_ROOT, level.file)))
+      .filter((level) => !probePathExists(level.file))
       .map((level) => `${level.id} ${level.file}`);
 
     expect(missing, "Add HMR source probes for new GUI views.").toEqual([]);

--- a/packages/cloud/shared/src/lib/services/characters/characters.test.ts
+++ b/packages/cloud/shared/src/lib/services/characters/characters.test.ts
@@ -118,6 +118,27 @@ describe("CharactersService.create — username handling (#13637 class)", () => 
     expect(character.id).toBe("char-1");
   });
 
+  test("duplicate provided username throws ValidationError -> 400, not a plain Error/500", async () => {
+    const { charactersService } = await import("./characters");
+    const { ApiError } = await import("../../api/cloud-worker-errors");
+    usernameExistsResult = true;
+
+    let caught: unknown;
+    try {
+      await charactersService.create(baseData({ username: "taken-name" }));
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(usernameExistsCalls).toEqual(["taken-name"]);
+    expect(caught).toBeInstanceOf(ApiError);
+    const apiError = caught as InstanceType<typeof ApiError>;
+    expect(apiError.status).toBe(400);
+    expect(apiError.code).toBe("validation_error");
+    expect(apiError.message).toContain("Username is already taken");
+    expect(createCalls).toHaveLength(0);
+  });
+
   test("non-string username (shape mismatch) still throws ValidationError -> 400", async () => {
     const { charactersService } = await import("./characters");
     const { ApiError } = await import("../../api/cloud-worker-errors");

--- a/packages/cloud/shared/src/lib/services/characters/characters.ts
+++ b/packages/cloud/shared/src/lib/services/characters/characters.ts
@@ -241,7 +241,7 @@ export class CharactersService {
       // Check uniqueness
       const exists = await userCharactersRepository.usernameExists(username);
       if (exists) {
-        throw new Error("Username is already taken");
+        throw ValidationError("Username is already taken");
       }
     }
 


### PR DESCRIPTION
## Summary
- fix the merged #13788 HMR guard so sparse/local worktrees pass when a probe path is tracked at HEAD, while still failing paths missing from both checkout and git
- reduce the non-workspace HMR probe allowlist to the three probe paths that are genuinely absent from the tree
- fix the residual #13787 character username collision path so duplicate usernames throw a typed 400 ValidationError instead of a plain Error that can map to 500

## Verification
```bash
bun run --cwd packages/shared build:i18n
bun test ./packages/cloud/shared/src/lib/services/characters/characters.test.ts
# 5 pass, 0 fail

bun test packages/app/test/hmr-coverage.test.ts
# 2 pass, 0 fail

bunx @biomejs/biome check packages/app/test/hmr-coverage.test.ts packages/cloud/shared/src/lib/services/characters/characters.ts packages/cloud/shared/src/lib/services/characters/characters.test.ts --no-errors-on-unmatched
# pass

git diff --check
# pass
```

## Evidence / N/A
- UI screenshots/video: N/A - test/backend validation only; no rendered UI changed.
- Live LLM trajectories: N/A - no model, prompt, provider, or agent behavior changed.
- Domain artifacts: N/A - focused unit tests assert the typed duplicate-username error and HMR path guard behavior.

Follow-up to post-merge reviews of #13787 and #13788.
