### PR TITLE
fix(#13686): shard iOS XCUITest capture containers

### DIFF
--- a/.github/issue-evidence/13686-ios-xcuitest-shards/README.md
+++ b/.github/issue-evidence/13686-ios-xcuitest-shards/README.md
@@ -1,0 +1,65 @@
+# Issue #13686 — iOS XCUITest Fresh-Container Shards
+
+## Change
+
+- Default `ios-device-capture.mjs` full runs now expand `AppUITests` into deterministic per-test/per-class shards.
+- Each shard resets the app container before `xcodebuild test-without-building`:
+  - simulator: `simctl terminate`, `simctl uninstall`, then reinstall `.xctestrun` app bundles.
+  - device: `devicectl device uninstall app`, then reinstall the signed app when `--app-path` is supplied.
+- Shard artifacts land under `ios/build/boot-capture/<timestamp>/shards/<id>/`, with per-shard attachments, `.xcresult`, raw summary, and top-level aggregate `test-summary.json`.
+- `GestureSemanticsUITests.testChatSheetDetentFlickCycle` now seeds a persistent user message and asserts the populated-thread flick branch instead of choosing assertions from inherited residue.
+
+## Verification Run
+
+```bash
+bun install
+bun run --cwd packages/app test scripts/ios-device-lib.test.mjs
+bunx biome check packages/app/scripts/ios-device-capture.mjs packages/app/scripts/ios-device-lib.mjs packages/app/scripts/ios-device-lib.test.mjs packages/app/CLAUDE.md packages/app/AGENTS.md packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift
+node --check packages/app/scripts/ios-device-capture.mjs
+node --check packages/app/scripts/ios-device-lib.mjs
+node --check packages/app/scripts/ios-device-lib.test.mjs
+node packages/app/scripts/ios-device-capture.mjs --help
+git diff --check -- packages/app/scripts/ios-device-capture.mjs packages/app/scripts/ios-device-lib.mjs packages/app/scripts/ios-device-lib.test.mjs packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift packages/app/CLAUDE.md packages/app/AGENTS.md
+```
+
+Results:
+
+- Package Vitest: `1 passed (1)`, `74 passed (74)`.
+- Post-rebase package Vitest: `1 passed (1)`, `74 passed (74)`; emitted a pre-existing duplicate root script-key warning for `test:desktop:packaged:windows`.
+- Biome focused check: `Checked 3 files in 110ms. No fixes applied.`
+- Node syntax checks: passed.
+- Help output includes new `--bundle-id <id>` flag.
+- Diff whitespace check: passed.
+
+Broader package gate attempted:
+
+```bash
+bun run --cwd packages/app typecheck
+```
+
+Result: failed before this change's JS harness code, with missing workspace/generated modules (`@elizaos/app-core`, `@elizaos/contracts`, `@elizaos/cloud-routing`, validation keyword data, `@elizaos/tui`) and existing `AccountWithCredentialFlag` property errors in `packages/ui`. This run is not claimed as passing.
+
+## Live iOS Capture
+
+Attempted local Xcode preflight:
+
+```bash
+xcodebuild -version
+```
+
+Result:
+
+```text
+xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
+```
+
+This host also has no generated `packages/app/ios/App` project in the clean worktree, so a real simulator/device XCUITest capture could not be run here. The code path is covered by the pure shard planner tests and syntax checks, but the first real verification run still needs a macOS host with full Xcode selected and a generated iOS project.
+
+## Manual Review
+
+Reviewed the changed code paths by hand:
+
+- Default `AppUITests` no longer maps to one monolithic `-only-testing AppUITests` run.
+- Both onboarding tests are separate shards, so cloud and local first-run paths start from clean containers.
+- `DeviceLifecycleUITests` remains one class shard, preserving its intentional within-test persistence assertions.
+- `--only-testing AppUITests/<Class>[/test]` remains a single-shard override for narrow/manual runs.

--- a/packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift
@@ -73,7 +73,7 @@ final class GestureSemanticsUITests: XCTestCase {
     func testChatSheetDetentFlickCycle() throws {
         let app = XCUIApplication()
         try launchToRenderer(app)
-        try ensureUserMessage(in: app, text: "detent gesture probe")
+        try ensurePersistentUserMessage(in: app, text: "detent gesture probe")
         try settleSheetToCollapsed(in: app)
         attachScreenshot(named: "detent-00-collapsed")
 
@@ -95,39 +95,26 @@ final class GestureSemanticsUITests: XCTestCase {
         try flickGrabber(in: app, dy: 260)
         assertDetent(becomes: "half", in: app, step: "detent-30-after-flick-down")
 
-        // While the sheet is open, capture the AX ground truth for the
-        // thread-gated flick leg below: does the thread actually hold any
-        // message bubbles right now? (The app may have evicted the optimistic
-        // user turn when the agent never became ready — see the warm-up
-        // eviction note on ensurePersistentUserMessage.)
-        let threadHasBubbles = messageBubbles(in: app).count > 0
-        attachScreenshot(named: "detent-35-open-thread-state")
+        XCTAssertGreaterThan(
+            messageBubbles(in: app).count,
+            0,
+            "detent flick coverage requires a seeded, persistent thread; the "
+                + "container shard must not inherit or infer this from residue"
+        )
+        attachScreenshot(named: "detent-35-seeded-thread-state")
 
         // Flick DOWN #2: half → collapsed.
         try flickGrabber(in: app, dy: 260)
         assertDetent(
             becomes: "collapsed", in: app, step: "detent-40-after-flick-down")
 
-        // Flick UP from collapsed — BOTH outcomes are spec'd semantics, chosen
-        // by the observed thread state (never a silent skip):
-        //   thread present → the flick reveals the thread at the HALF detent;
-        //   thread empty   → the flick must be REFUSED (the sheet has nothing
-        //                    to reveal; ContinuousChatOverlay's onPullUp
-        //                    deliberately settles back), so the detent must
-        //                    still read "collapsed" after the poll.
+        // Flick UP from collapsed with a deliberately seeded thread: this must
+        // reveal the thread at HALF. This assertion must not flip to an
+        // empty-thread refusal based on residue from earlier XCTest classes or
+        // previous runs (#13686).
         try flickGrabber(in: app, dy: -260)
-        if threadHasBubbles {
-            assertDetent(
-                becomes: "half", in: app, step: "detent-50-flick-reveals-thread")
-        } else {
-            Thread.sleep(forTimeInterval: 2.0)
-            attachScreenshot(named: "detent-50-flick-refused-empty-thread")
-            XCTAssertEqual(
-                markerValue(Self.detentPrefix, in: app), "collapsed",
-                "a flick-up on a collapsed sheet with an EMPTY thread must be "
-                    + "refused (nothing to reveal) and leave the detent collapsed"
-            )
-        }
+        assertDetent(
+            becomes: "half", in: app, step: "detent-50-flick-reveals-thread")
     }
 
     func testLauncherPagerFiftyPercentSwipeThreshold() throws {

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -141,20 +141,22 @@ bun run --cwd packages/app ios:device:deploy -- --device <id>   # flags: --skip-
 bun run --cwd packages/app ios:device:logs -- --device <id> --duration 120
 bun run --cwd packages/app ios:device:logs -- --device <id> --no-console --pull-boot-trace
 
-# Watchable boot capture via the committed AppUITests XCUITest harness
-# (BootCaptureUITests): screenshots every 15 s via XCUIScreen, asserts the boot
-# reaches home or the "Startup failed:"/"Retry startup" card, exports all
-# attachments (filmstrip PNGs + AX hierarchy) from the .xcresult.
+# Watchable capture via the committed AppUITests XCUITest harness. A full run
+# shards AppUITests into fresh-container per-test/per-class invocations, with
+# uninstall/reinstall between shards so first-run and chat state cannot cascade.
+# Pass --only-testing AppUITests/<Class>[/test] for a single narrow shard.
 bun run --cwd packages/app capture:ios-sim:boot                  # simulator (booted sim auto-detected)
 bun run --cwd packages/app ios:device:capture -- --device <id> --app-path <signed App.app>  # physical device
 ```
 
 Produced artifacts: deploy stages into `ios/build/device-deploy-stage/`; logs
 land in `ios/build/device-logs/`; captures land in
-`ios/build/boot-capture/<timestamp>/` (`attachments/` + `BootCapture.xcresult`
-+ `test-summary.json`) unless `--output` is given. The harness source lives in
-the canonical template (`packages/app-core/platforms/ios/App/AppUITests/` +
-the `AppUITests` target/scheme in the template Xcode project) and is
+`ios/build/boot-capture/<timestamp>/` (`shards/<id>/attachments/`,
+`shards/<id>/*.xcresult`, per-shard raw `test-summary.json`, and a top-level
+aggregate `test-summary.json` naming each shard/container reset) unless
+`--output` is given. The harness source lives in the canonical template
+(`packages/app-core/platforms/ios/App/AppUITests/` + the `AppUITests`
+target/scheme in the template Xcode project) and is
 materialized into the gitignored `packages/app/ios` by cap sync. Pure decision
 logic (profile matching/selection, entitlement derivation, plist/xctestrun
 handling) is in `scripts/ios-device-lib.mjs`, unit-tested by

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -141,20 +141,22 @@ bun run --cwd packages/app ios:device:deploy -- --device <id>   # flags: --skip-
 bun run --cwd packages/app ios:device:logs -- --device <id> --duration 120
 bun run --cwd packages/app ios:device:logs -- --device <id> --no-console --pull-boot-trace
 
-# Watchable boot capture via the committed AppUITests XCUITest harness
-# (BootCaptureUITests): screenshots every 15 s via XCUIScreen, asserts the boot
-# reaches home or the "Startup failed:"/"Retry startup" card, exports all
-# attachments (filmstrip PNGs + AX hierarchy) from the .xcresult.
+# Watchable capture via the committed AppUITests XCUITest harness. A full run
+# shards AppUITests into fresh-container per-test/per-class invocations, with
+# uninstall/reinstall between shards so first-run and chat state cannot cascade.
+# Pass --only-testing AppUITests/<Class>[/test] for a single narrow shard.
 bun run --cwd packages/app capture:ios-sim:boot                  # simulator (booted sim auto-detected)
 bun run --cwd packages/app ios:device:capture -- --device <id> --app-path <signed App.app>  # physical device
 ```
 
 Produced artifacts: deploy stages into `ios/build/device-deploy-stage/`; logs
 land in `ios/build/device-logs/`; captures land in
-`ios/build/boot-capture/<timestamp>/` (`attachments/` + `BootCapture.xcresult`
-+ `test-summary.json`) unless `--output` is given. The harness source lives in
-the canonical template (`packages/app-core/platforms/ios/App/AppUITests/` +
-the `AppUITests` target/scheme in the template Xcode project) and is
+`ios/build/boot-capture/<timestamp>/` (`shards/<id>/attachments/`,
+`shards/<id>/*.xcresult`, per-shard raw `test-summary.json`, and a top-level
+aggregate `test-summary.json` naming each shard/container reset) unless
+`--output` is given. The harness source lives in the canonical template
+(`packages/app-core/platforms/ios/App/AppUITests/` + the `AppUITests`
+target/scheme in the template Xcode project) and is
 materialized into the gitignored `packages/app/ios` by cap sync. Pure decision
 logic (profile matching/selection, entitlement derivation, plist/xctestrun
 handling) is in `scripts/ios-device-lib.mjs`, unit-tested by

--- a/packages/app/scripts/ios-device-capture.mjs
+++ b/packages/app/scripts/ios-device-capture.mjs
@@ -28,6 +28,7 @@
  *     [--device <udid>] [--skip-build] [--output <dir>] [--app-path <App.app>]
  *     [--boot-timeout <sec>] [--interval <sec>] [--agent-ready-timeout <sec>]
  *     [--derived-data <dir>] [--only-testing <Target/Class/test>]
+ *     [--bundle-id <id>]
  *
  * Exit code: non-zero when the harness fails (including "boot never reached
  * home or the error card") — attachments are still exported first.
@@ -38,9 +39,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
 import {
+  buildIosXcuitestShardPlan,
   buildPlistXml,
   classifyCodesignPreflight,
   classifyIsolatedReruns,
+  DEFAULT_APP_BUNDLE_ID,
   evaluateRunnerStaleness,
   extractXctestrunAppPaths,
   findDeviceRecord,
@@ -71,6 +74,11 @@ function runInherit(command, args, options = {}) {
       `${command} ${args.slice(0, 4).join(" ")} … exited with ${result.status}`,
     );
   }
+}
+
+function tryRun(command, args, options = {}) {
+  const result = spawnSync(command, args, { stdio: "ignore", ...options });
+  return result.status === 0;
 }
 
 /**
@@ -215,7 +223,7 @@ async function main() {
   });
   if (args.help) {
     console.log(
-      "Usage: node scripts/ios-device-capture.mjs --platform sim|device [--device <udid>] [--skip-build] [--allow-stale-runner] [--no-retry-isolation] [--output <dir>] [--app-path <App.app>] [--boot-timeout <sec>] [--interval <sec>] [--agent-ready-timeout <sec>] [--derived-data <dir>] [--only-testing <id>]",
+      "Usage: node scripts/ios-device-capture.mjs --platform sim|device [--device <udid>] [--skip-build] [--allow-stale-runner] [--no-retry-isolation] [--output <dir>] [--app-path <App.app>] [--boot-timeout <sec>] [--interval <sec>] [--agent-ready-timeout <sec>] [--derived-data <dir>] [--only-testing <id>] [--bundle-id <id>]",
     );
     return;
   }
@@ -228,6 +236,7 @@ async function main() {
         ? "sim"
         : null;
   if (!platform) fail("--platform sim|device is required.");
+  const bundleId = args["bundle-id"] || DEFAULT_APP_BUNDLE_ID;
 
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
   const outputDir = path.resolve(
@@ -469,6 +478,10 @@ async function main() {
   // 4. Destination for the run.
   let destination;
   let simUdid = null;
+  let deviceControlId = null;
+  const installableBundles = extractXctestrunAppPaths(parsed, testRoot).filter(
+    (bundle) => bundle.endsWith(".app") && fs.existsSync(bundle),
+  );
   if (platform === "sim") {
     const udid = args.device || bootedSimulatorUdid();
     simUdid = udid;
@@ -483,10 +496,7 @@ async function main() {
     // test-without-building on fresh products can fail with "SBMainWorkspace:
     // Unknown application display identifier ai.elizaos.app.xctrunner" —
     // FrontBoard races xcodebuild's own install transaction.
-    const bundles = extractXctestrunAppPaths(parsed, testRoot).filter(
-      (bundle) => bundle.endsWith(".app") && fs.existsSync(bundle),
-    );
-    for (const bundle of bundles) {
+    for (const bundle of installableBundles) {
       log(`simctl install ${path.basename(bundle)}`);
       runInherit("xcrun", ["simctl", "install", udid, bundle]);
     }
@@ -495,21 +505,67 @@ async function main() {
     if (!deviceId)
       fail("device platform needs --device or ELIZA_IOS_DEVICE_ID.");
     const record = resolvePhysicalDeviceUdid(deviceId);
+    deviceControlId = record.identifier;
     destination = `platform=iOS,id=${record.udid}`;
   }
   log(`destination: ${destination}`);
 
-  // runHarness clears each result bundle before writing (so the main run and
-  // every isolated re-run start from a clean .xcresult).
-  const resultBundle = path.join(outputDir, "BootCapture.xcresult");
+  const resetAppContainer = (label) => {
+    if (platform === "sim") {
+      log(`reset ${label}: terminate/uninstall ${bundleId} on simulator`);
+      tryRun("xcrun", ["simctl", "terminate", simUdid, bundleId]);
+      tryRun("xcrun", ["simctl", "uninstall", simUdid, bundleId]);
+      for (const bundle of installableBundles) {
+        log(`reset ${label}: simctl install ${path.basename(bundle)}`);
+        runInherit("xcrun", ["simctl", "install", simUdid, bundle]);
+      }
+      return {
+        platform,
+        bundleId,
+        action: "simctl terminate/uninstall + install xctestrun bundles",
+      };
+    }
+
+    log(`reset ${label}: uninstall ${bundleId} on device`);
+    tryRun("xcrun", [
+      "devicectl",
+      "device",
+      "uninstall",
+      "app",
+      "--device",
+      deviceControlId,
+      bundleId,
+    ]);
+    if (args["app-path"]) {
+      const signedApp = path.resolve(args["app-path"]);
+      log(`reset ${label}: devicectl install ${path.basename(signedApp)}`);
+      runInherit("xcrun", [
+        "devicectl",
+        "device",
+        "install",
+        "app",
+        "--device",
+        deviceControlId,
+        signedApp,
+      ]);
+    }
+    return {
+      platform,
+      bundleId,
+      action: args["app-path"]
+        ? "devicectl uninstall + install signed app"
+        : "devicectl uninstall; xcodebuild installs the target app",
+    };
+  };
 
   // 5. Run the harness. TEST_RUNNER_-prefixed env vars are forwarded by
   //    xcodebuild into the test-runner process (how the Swift side reads
   //    ELIZA_BOOT_TIMEOUT_SECONDS / ELIZA_BOOT_SCREENSHOT_INTERVAL_SECONDS).
-  //    Default = the whole AppUITests target, so the lane exercises both the
-  //    boot-capture suite AND the WKWebView gesture-semantics suite (#11353);
-  //    narrow with --only-testing AppUITests/<Class>[/<test>].
-  const onlyTesting = args["only-testing"] || "AppUITests";
+  //    Default = a deterministic shard list with a fresh app container before
+  //    every shard (#13686); narrow with --only-testing AppUITests/<Class>[/<test>].
+  const shardPlan = buildIosXcuitestShardPlan({
+    onlyTesting: args["only-testing"] || "AppUITests",
+  });
   const harnessEnv = {
     ...process.env,
     TEST_RUNNER_ELIZA_BOOT_TIMEOUT_SECONDS:
@@ -561,11 +617,60 @@ async function main() {
     );
   };
 
+  const exportArtifacts = (bundlePath, targetDir) => {
+    const attachmentsDir = path.join(targetDir, "attachments");
+    fs.rmSync(attachmentsDir, { recursive: true, force: true });
+    fs.mkdirSync(attachmentsDir, { recursive: true });
+    let summaryJson = null;
+    if (fs.existsSync(bundlePath)) {
+      runInherit("xcrun", [
+        "xcresulttool",
+        "export",
+        "attachments",
+        "--path",
+        bundlePath,
+        "--output-path",
+        attachmentsDir,
+      ]);
+      const summary = spawnSync(
+        "xcrun",
+        [
+          "xcresulttool",
+          "get",
+          "test-results",
+          "summary",
+          "--path",
+          bundlePath,
+          "--format",
+          "json",
+        ],
+        { encoding: "utf8" },
+      );
+      if (summary.status === 0) {
+        fs.writeFileSync(
+          path.join(targetDir, "test-summary.json"),
+          summary.stdout,
+        );
+        try {
+          summaryJson = JSON.parse(summary.stdout);
+        } catch {
+          summaryJson = null;
+        }
+      }
+    } else {
+      log(`warning: no .xcresult bundle produced at ${bundlePath}`);
+    }
+    const exported = fs.existsSync(attachmentsDir)
+      ? fs.readdirSync(attachmentsDir)
+      : [];
+    return { attachmentsDir, attachmentCount: exported.length, summaryJson };
+  };
+
   // Read the failed-test identifiers out of a produced .xcresult so the
   // retry-in-isolation pass can re-run each one alone. Returns [] on any
   // missing bundle / non-zero summary / unparseable output (fail-closed: no
   // isolable failures found means the suite verdict stands).
-  const readFailedTestIdentifiers = (bundlePath) => {
+  const readFailedTestIdentifiers = (bundlePath, fallbackTarget) => {
     if (!fs.existsSync(bundlePath)) return [];
     const summary = spawnSync(
       "xcrun",
@@ -583,134 +688,132 @@ async function main() {
     );
     if (summary.status !== 0) return [];
     return parseFailedTestIdentifiers(summary.stdout, {
-      fallbackTarget: onlyTesting.split("/")[0] || "AppUITests",
+      fallbackTarget,
     });
   };
 
-  // Record the whole run on the simulator (walkthrough evidence for the
-  // gesture-loop lane; no-op on a physical device). Started just before the
-  // harness so it captures every gesture, stopped in `finally` so a failing run
-  // still yields its video.
-  const simVideo = startSimVideo({ udid: simUdid, outputDir });
-  let testResult;
-  try {
-    testResult = runHarness(onlyTesting, resultBundle);
-  } finally {
-    const videoPath = await simVideo.stop();
-    if (videoPath) log(`simulator video: ${videoPath}`);
-  }
-
-  // 6. Export attachments regardless of the verdict — a failed boot's
-  //    screenshots are exactly the evidence we want. Clear any prior export
-  //    first: xcresulttool refuses to write manifest.json into a dir that
-  //    already has one (stale attachments would also mix runs).
-  const attachmentsDir = path.join(outputDir, "attachments");
-  fs.rmSync(attachmentsDir, { recursive: true, force: true });
-  fs.mkdirSync(attachmentsDir, { recursive: true });
-  if (fs.existsSync(resultBundle)) {
-    runInherit("xcrun", [
-      "xcresulttool",
-      "export",
-      "attachments",
-      "--path",
-      resultBundle,
-      "--output-path",
-      attachmentsDir,
-    ]);
-    const summary = spawnSync(
-      "xcrun",
-      [
-        "xcresulttool",
-        "get",
-        "test-results",
-        "summary",
-        "--path",
-        resultBundle,
-      ],
-      { encoding: "utf8" },
-    );
-    if (summary.status === 0) {
-      fs.writeFileSync(
-        path.join(outputDir, "test-summary.json"),
-        summary.stdout,
-      );
-    }
-  } else {
-    log("warning: no .xcresult bundle produced — nothing to export.");
-  }
-
-  const exported = fs.existsSync(attachmentsDir)
-    ? fs.readdirSync(attachmentsDir)
-    : [];
-  log(`attachments: ${exported.length} file(s) in ${attachmentsDir}`);
-  log(`result bundle: ${resultBundle}`);
-
-  if (testResult.status === 0) {
-    log("boot capture PASSED (home or startup-failure card reached).");
-    return;
-  }
-
-  // 7. Retry-in-isolation (#13566): device XCUITest terminate/relaunch cycles
-  //    flake through devicectl, and a single flaky termination can poison
-  //    subsequent tests in the same monolithic invocation. Re-run EACH failed
-  //    test alone; a test that passes isolated is a `flake` (exit 0 stands),
-  //    one that fails both is a real `fail` (exit nonzero). Skipped with
-  //    --no-retry-isolation, which keeps the legacy hard-fail-on-any behavior.
-  const suiteFailures = readFailedTestIdentifiers(resultBundle);
-  if (args["no-retry-isolation"] || suiteFailures.length === 0) {
-    const why = args["no-retry-isolation"]
-      ? "--no-retry-isolation set"
-      : "no isolable failed-test identifiers parsed from the .xcresult";
-    writeFlakeSummary(outputDir, { skipped: true, reason: why });
-    fail(
-      `harness run failed (xcodebuild exit ${testResult.status}); ${why}. ` +
-        "Exit 65 means a test assertion failed — e.g. the boot never reached home " +
-        `or the startup-failure card. Review the screenshots in ${attachmentsDir}.`,
-    );
-  }
-
+  const shardsRoot = path.join(outputDir, "shards");
+  fs.mkdirSync(shardsRoot, { recursive: true });
   log(
-    `retry-in-isolation: re-running ${suiteFailures.length} failed test(s) alone — ` +
-      suiteFailures.map((f) => f.identifier).join(", "),
+    `xcuitest shards: ${shardPlan.length} (${shardPlan
+      .map((shard) => shard.identifier)
+      .join(", ")})`,
   );
-  const isolatedResults = [];
-  const isolationDir = path.join(outputDir, "isolation");
-  fs.mkdirSync(isolationDir, { recursive: true });
-  for (const failure of suiteFailures) {
-    const safeName = failure.identifier.replace(/[^A-Za-z0-9._-]/g, "_");
-    const isoBundle = path.join(isolationDir, `${safeName}.xcresult`);
-    log(`  isolated re-run: ${failure.identifier}`);
-    const isoResult = runHarness(failure.identifier, isoBundle);
-    isolatedResults.push({
-      identifier: failure.identifier,
-      isolatedPassed: isoResult.status === 0,
+
+  const shardSummaries = [];
+  for (const shard of shardPlan) {
+    const shardDir = path.join(shardsRoot, shard.resultName);
+    fs.mkdirSync(shardDir, { recursive: true });
+    const resultBundle = path.join(shardDir, `${shard.resultName}.xcresult`);
+    log(`shard ${shard.index}/${shardPlan.length}: ${shard.identifier}`);
+    const reset = resetAppContainer(shard.resultName);
+
+    const simVideo = startSimVideo({
+      udid: simUdid,
+      outputDir: shardDir,
+      filename: `${shard.resultName}.mp4`,
     });
+    let testResult;
+    try {
+      testResult = runHarness(shard.identifier, resultBundle);
+    } finally {
+      const videoPath = await simVideo.stop();
+      if (videoPath) log(`simulator video: ${videoPath}`);
+    }
+
+    const artifacts = exportArtifacts(resultBundle, shardDir);
+    const shardSummary = {
+      ...shard,
+      bundleId,
+      reset,
+      resultBundle,
+      attachmentsDir: artifacts.attachmentsDir,
+      attachmentCount: artifacts.attachmentCount,
+      exitStatus: testResult.status,
+      passed: testResult.status === 0,
+      flakeClassification: null,
+    };
+    log(
+      `shard ${shard.resultName}: exit=${testResult.status} attachments=${artifacts.attachmentCount}`,
+    );
+
+    if (testResult.status !== 0) {
+      const suiteFailures = readFailedTestIdentifiers(
+        resultBundle,
+        "AppUITests",
+      );
+      if (args["no-retry-isolation"] || suiteFailures.length === 0) {
+        const why = args["no-retry-isolation"]
+          ? "--no-retry-isolation set"
+          : "no isolable failed-test identifiers parsed from the .xcresult";
+        const skipped = { skipped: true, reason: why };
+        writeFlakeSummary(shardDir, skipped);
+        shardSummary.flakeClassification = skipped;
+      } else {
+        log(
+          `retry-in-isolation (${shard.resultName}): ${suiteFailures.length} failed test(s) — ` +
+            suiteFailures.map((f) => f.identifier).join(", "),
+        );
+        const isolatedResults = [];
+        const isolationDir = path.join(shardDir, "isolation");
+        fs.mkdirSync(isolationDir, { recursive: true });
+        for (const failure of suiteFailures) {
+          const safeName = failure.identifier.replace(/[^A-Za-z0-9._-]/g, "_");
+          const isoBundle = path.join(isolationDir, `${safeName}.xcresult`);
+          log(`  isolated re-run: ${failure.identifier}`);
+          resetAppContainer(`isolation-${safeName}`);
+          const isoResult = runHarness(failure.identifier, isoBundle);
+          exportArtifacts(isoBundle, path.join(isolationDir, safeName));
+          isolatedResults.push({
+            identifier: failure.identifier,
+            isolatedPassed: isoResult.status === 0,
+          });
+        }
+
+        const classification = classifyIsolatedReruns(
+          suiteFailures,
+          isolatedResults,
+        );
+        const classificationPayload = {
+          skipped: false,
+          verdicts: classification.verdicts,
+          flakes: classification.flakes,
+          realFailures: classification.realFailures,
+        };
+        writeFlakeSummary(shardDir, classificationPayload);
+        shardSummary.flakeClassification = classificationPayload;
+        shardSummary.passed = !classification.exitNonZero;
+        for (const v of classification.verdicts) {
+          log(`  ${v.verdict.toUpperCase()}: ${v.identifier}`);
+        }
+      }
+    }
+    shardSummaries.push(shardSummary);
   }
 
-  const classification = classifyIsolatedReruns(suiteFailures, isolatedResults);
-  writeFlakeSummary(outputDir, {
-    skipped: false,
-    verdicts: classification.verdicts,
-    flakes: classification.flakes,
-    realFailures: classification.realFailures,
-  });
-  for (const v of classification.verdicts) {
-    log(`  ${v.verdict.toUpperCase()}: ${v.identifier}`);
-  }
+  const aggregate = {
+    generatedAt: new Date().toISOString(),
+    platform,
+    bundleId,
+    destination,
+    sharded: args["only-testing"] ? "explicit-only-testing" : "default",
+    shards: shardSummaries,
+  };
+  fs.writeFileSync(
+    path.join(outputDir, "test-summary.json"),
+    `${JSON.stringify(aggregate, null, 2)}\n`,
+  );
 
-  if (classification.exitNonZero) {
+  const failedShards = shardSummaries.filter((shard) => !shard.passed);
+  if (failedShards.length > 0) {
     fail(
-      `harness run failed: ${classification.realFailures.length} test(s) failed ` +
-        `both in-suite AND isolated (${classification.realFailures.join(", ")}). ` +
-        (classification.flakes.length > 0
-          ? `${classification.flakes.length} flake(s) recorded. `
-          : "") +
-        `Review the screenshots in ${attachmentsDir}.`,
+      `iOS capture failed: ${failedShards.length}/${shardSummaries.length} shard(s) failed ` +
+        `(${failedShards.map((shard) => shard.identifier).join(", ")}). ` +
+        `Review shard artifacts under ${shardsRoot}.`,
     );
   }
   log(
-    `boot capture PASSED after isolation: all ${classification.flakes.length} ` +
-      "suite failure(s) were flakes (passed on isolated re-run).",
+    `iOS capture PASSED: ${shardSummaries.length} shard(s) completed with fresh containers.`,
   );
 }
 

--- a/packages/app/scripts/ios-device-lib.mjs
+++ b/packages/app/scripts/ios-device-lib.mjs
@@ -744,6 +744,45 @@ export function resolveXctestrunTestRoot(value, testRoot) {
 
 export const DEFAULT_APP_BUNDLE_ID = "ai.elizaos.app";
 
+export const DEFAULT_IOS_XCUITEST_SHARDS = [
+  "AppUITests/BootCaptureUITests/testBootReachesHomeOrErrorCard",
+  "AppUITests/BootCaptureUITests/testComposerAcceptsTypedText",
+  "AppUITests/BootCaptureUITests/testComposerSendsPromptAndWaitsForReply",
+  "AppUITests/BootCaptureUITests/testCloudOnboardingChatAndVoice",
+  "AppUITests/BootCaptureUITests/testLocalOnboardingChatAndVoice",
+  "AppUITests/GestureSemanticsUITests",
+  "AppUITests/LauncherGestureLoopUITests",
+  "AppUITests/ViewWalkthroughUITests",
+  "AppUITests/WidgetGalleryCaptureUITests",
+  "AppUITests/DeviceLifecycleUITests",
+];
+
+export function safeShardName(identifier) {
+  return String(identifier || "unknown")
+    .replace(/^AppUITests\//, "")
+    .replace(/[^A-Za-z0-9._-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 120);
+}
+
+export function buildIosXcuitestShardPlan({
+  onlyTesting = null,
+  defaultShards = DEFAULT_IOS_XCUITEST_SHARDS,
+} = {}) {
+  const requested =
+    typeof onlyTesting === "string" && onlyTesting.trim()
+      ? onlyTesting.trim()
+      : "AppUITests";
+  const identifiers = requested === "AppUITests" ? defaultShards : [requested];
+  return identifiers.map((identifier, index) => ({
+    index: index + 1,
+    identifier,
+    resultName: `${String(index + 1).padStart(2, "0")}-${safeShardName(
+      identifier,
+    )}`,
+  }));
+}
+
 /**
  * Boot-trace files inside the app data container, pulled by
  * `ios-device-logs.mjs --pull-boot-trace`.

--- a/packages/app/scripts/ios-device-lib.test.mjs
+++ b/packages/app/scripts/ios-device-lib.test.mjs
@@ -8,12 +8,14 @@ import crypto from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   buildCodesignPlan,
+  buildIosXcuitestShardPlan,
   buildOnlyTestingIdentifier,
   buildPlistXml,
   CONSOLE_SIGTRAP_SIGNATURE,
   classifyCodesignPreflight,
   classifyConsoleExit,
   classifyIsolatedReruns,
+  DEFAULT_IOS_XCUITEST_SHARDS,
   deriveSigningEntitlements,
   evaluateRunnerStaleness,
   extractXctestrunAppPaths,
@@ -29,6 +31,7 @@ import {
   resolveDeviceId,
   resolveXctestrunTestRoot,
   rewriteXctestrunUITargetApp,
+  safeShardName,
   selectProvisioningProfile,
   selectSigningIdentity,
   sweepXctestrunDependentProductPaths,
@@ -1041,6 +1044,53 @@ describe("classifyIsolatedReruns (#13566)", () => {
       "AppUITests/GestureSemanticsUITests/testDetent",
     ]);
     expect(result.exitNonZero).toBe(true);
+  });
+});
+
+describe("buildIosXcuitestShardPlan (#13686)", () => {
+  it("expands the default AppUITests run into deterministic fresh-container shards", () => {
+    const plan = buildIosXcuitestShardPlan();
+    expect(plan.map((shard) => shard.identifier)).toEqual(
+      DEFAULT_IOS_XCUITEST_SHARDS,
+    );
+    expect(plan[0]).toEqual({
+      index: 1,
+      identifier:
+        "AppUITests/BootCaptureUITests/testBootReachesHomeOrErrorCard",
+      resultName: "01-BootCaptureUITests_testBootReachesHomeOrErrorCard",
+    });
+    expect(
+      plan.some((shard) =>
+        shard.identifier.endsWith("testCloudOnboardingChatAndVoice"),
+      ),
+    ).toBe(true);
+    expect(
+      plan.some((shard) =>
+        shard.identifier.endsWith("testLocalOnboardingChatAndVoice"),
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves an explicit --only-testing override as a single shard", () => {
+    expect(
+      buildIosXcuitestShardPlan({
+        onlyTesting:
+          "AppUITests/GestureSemanticsUITests/testChatSheetDetentFlickCycle",
+      }),
+    ).toEqual([
+      {
+        index: 1,
+        identifier:
+          "AppUITests/GestureSemanticsUITests/testChatSheetDetentFlickCycle",
+        resultName: "01-GestureSemanticsUITests_testChatSheetDetentFlickCycle",
+      },
+    ]);
+  });
+
+  it("sanitizes shard names for filesystem-safe result paths", () => {
+    expect(safeShardName("AppUITests/Foo Bar/testThing()")).toBe(
+      "Foo_Bar_testThing",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- shard default `ios-device-capture.mjs` AppUITests runs into deterministic fresh-container per-test/per-class invocations
- reset simulator/device app containers before each shard and preserve `--only-testing` as a single-shard override
- make `testChatSheetDetentFlickCycle` seed a persistent thread instead of choosing assertions from inherited residue
- document the sharded iOS capture behavior in package `CLAUDE.md`/`AGENTS.md`

Relates to #13686.

## Evidence
- `.github/issue-evidence/13686-ios-xcuitest-shards/README.md`

## Verification
- `bun run --cwd packages/app test scripts/ios-device-lib.test.mjs` — passes, 74 tests
- `bunx biome check packages/app/scripts/ios-device-capture.mjs packages/app/scripts/ios-device-lib.mjs packages/app/scripts/ios-device-lib.test.mjs packages/app/CLAUDE.md packages/app/AGENTS.md packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift` — passes
- `node --check packages/app/scripts/ios-device-capture.mjs && node --check packages/app/scripts/ios-device-lib.mjs && node --check packages/app/scripts/ios-device-lib.test.mjs` — passes
- `git diff --check HEAD~1..HEAD` — passes

## Not Run / Blocked Locally
- Real iOS simulator/device XCUITest capture: local host has Command Line Tools selected, not full Xcode (`xcodebuild -version` fails), and the generated `packages/app/ios/App` project is absent in the clean worktree.
- `bun run --cwd packages/app typecheck`: fails on pre-existing missing workspace/generated modules and existing UI account type drift; details captured in the evidence README.
