### PR TITLE
fix(#13773): reclaim ACP scratch dirs after delete close failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "cache:prune": "node packages/scripts/prune-turbo-cache.mjs",
     "test:dev-startup": "node packages/app-core/scripts/dev-startup-smoke.mjs",
     "test:hmr": "bun run --cwd packages/app test:hmr",
-    "test:desktop:packaged:windows": "bun run --cwd packages/app test:desktop:packaged:windows",
     "build:core": "node packages/scripts/build-core.mjs",
     "build:server": "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/agent",
     "lint": "node packages/scripts/run-turbo.mjs run lint",

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-gc.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-gc.test.ts
@@ -38,7 +38,7 @@ beforeAll(async () => {
   AcpService = mod.AcpService;
   isOwnedScratchDir = mod.isOwnedScratchDir;
   ROOT = join(TEST_TMPDIR, "eliza-acp");
-});
+}, 30_000);
 
 afterAll(async () => {
   await rm(TEST_TMPDIR, { recursive: true, force: true });
@@ -154,6 +154,26 @@ describe("teardown reclaims the owned scratch dir", () => {
     await makeDir(workdir);
     await store.create(session(id, workdir));
     const service = makeService(store);
+
+    await service.deleteSession(id);
+
+    expect(await exists(workdir)).toBe(false);
+    expect(await store.get(id)).toBeNull();
+  });
+
+  it("deleteSession still removes the owned task dir when the best-effort close fails", async () => {
+    const store = new InMemorySessionStore();
+    const id = "delete-close-fails";
+    const workdir = join(ROOT, `task-${id}`);
+    await makeDir(workdir);
+    await store.create(session(id, workdir));
+    const service = makeService(store, { ELIZA_ACP_TRANSPORT: "cli" });
+    vi.spyOn(
+      service as unknown as {
+        runAcpx: InstanceType<typeof AcpService>["runAcpx"];
+      },
+      "runAcpx",
+    ).mockRejectedValueOnce(new Error("simulated close failure"));
 
     await service.deleteSession(id);
 

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -1283,6 +1283,7 @@ export class AcpService extends Service {
   }
 
   async deleteSession(sessionId: string): Promise<void> {
+    const session = await this.requireSession(sessionId);
     await this.closeSession(sessionId).catch((err: unknown) => {
       // error-policy:J6 best-effort close before delete; a teardown failure must
       // not block removing the session record + satellite maps below.
@@ -1291,6 +1292,7 @@ export class AcpService extends Service {
         error: errorMessage(err),
       });
     });
+    await this.reclaimOwnedScratchDir(session);
     await this.store.delete(sessionId);
     this.outputBuffers.delete(sessionId);
     this.changedPathsBySession.delete(sessionId);


### PR DESCRIPTION
## Summary
- follow up merged PR #13792 with the close-failure case it missed
- make `deleteSession()` reclaim an owned `task-*` scratch dir even when best-effort `closeSession()` fails before cleanup
- add regression coverage for the CLI-close failure path
- remove the duplicate root `test:desktop:packaged:windows` script key left on develop after #13790
- give the scratch-GC test dynamic import hook a 30s timeout so cold worktrees do not fail before test logic runs

## Evidence
- `bun run --cwd plugins/plugin-agent-orchestrator test __tests__/unit/acp-scratch-gc.test.ts` — 11 passed
- `bunx biome check package.json plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-gc.test.ts`
- `git diff --check`
- package JSON parse + root `test:desktop:packaged:windows` alias count check = 1

## Notes
- `bun run --cwd plugins/plugin-agent-orchestrator test __tests__/unit/acp-service.test.ts` is still blocked by pre-existing branch/environment failures (`getCodingAgentSelectorBridge` / `resolveCredentialProxyConfig` missing function exports, spawn waits timing out); these failures are outside the changed files and predate this follow-up.