### PR TITLE
fix(#13596): seed a real-HTML default search tab at browser startup

### DIFF
--- a/plugins/plugin-browser/src/browser-service.ts
+++ b/plugins/plugin-browser/src/browser-service.ts
@@ -33,7 +33,10 @@ import {
   type BrowserBridgeRouteService,
 } from "./service.js";
 import { maybeCreateStagehandTarget } from "./targets/stagehand-target.js";
-import { getBrowserWorkspaceSnapshot } from "./workspace/browser-workspace.js";
+import {
+  ensureBrowserWorkspaceDefaultTab,
+  getBrowserWorkspaceSnapshot,
+} from "./workspace/browser-workspace.js";
 import type {
   BrowserWorkspaceCommand,
   BrowserWorkspaceCommandResult,
@@ -124,6 +127,18 @@ export class BrowserService extends Service {
       const message = err instanceof Error ? err.message : String(err);
       logger.debug(
         `[BrowserService] stagehand target not registered at start: ${message}`,
+      );
+    }
+    // Seed the Safari-style default search tab so the browser never opens
+    // empty-and-sad (#13596). Best-effort and non-blocking: a failure here
+    // (e.g. an unreachable desktop bridge) must not prevent the service from
+    // starting or block the agent's own browser actions.
+    try {
+      await ensureBrowserWorkspaceDefaultTab();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        `[BrowserService] default search tab not seeded at start: ${message}`,
       );
     }
     return service;

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-default-tab.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-default-tab.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Startup default-search-tab coverage for the browser workspace (#13596).
+ *
+ * Drives the real web-mode (JSDOM) path: no network, no desktop bridge, so the
+ * seeding + idempotency + non-blocking guarantees are exercised in-process.
+ * Also drives `BrowserService.start` to assert the service wires the default
+ * tab at boot.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { BrowserService } from "../../browser-service.js";
+import {
+  __resetBrowserWorkspaceStateForTests,
+  BROWSER_WORKSPACE_DEFAULT_SEARCH_URL,
+  ensureBrowserWorkspaceDefaultTab,
+  executeBrowserWorkspaceCommand,
+  listBrowserWorkspaceTabs,
+  resolveBrowserWorkspaceDefaultSearchUrl,
+} from "../browser-workspace.js";
+
+const webEnv: NodeJS.ProcessEnv = {};
+
+describe("browser workspace default search tab (web mode)", () => {
+  beforeEach(async () => {
+    await __resetBrowserWorkspaceStateForTests();
+  });
+
+  it("seeds exactly one visible tab pointed at a real search site (not about:blank)", async () => {
+    expect(await listBrowserWorkspaceTabs(webEnv)).toHaveLength(0);
+
+    const tab = await ensureBrowserWorkspaceDefaultTab(webEnv);
+
+    expect(tab.url).toBe(BROWSER_WORKSPACE_DEFAULT_SEARCH_URL);
+    expect(tab.url).not.toBe("about:blank");
+    expect(tab.visible).toBe(true);
+
+    const tabs = await listBrowserWorkspaceTabs(webEnv);
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]?.url).toBe(BROWSER_WORKSPACE_DEFAULT_SEARCH_URL);
+    // Default search endpoint is a real https HTML page.
+    expect(new URL(tabs[0]?.url ?? "").protocol).toBe("https:");
+  });
+
+  it("is idempotent — a second call never spawns a duplicate tab", async () => {
+    const first = await ensureBrowserWorkspaceDefaultTab(webEnv);
+    const second = await ensureBrowserWorkspaceDefaultTab(webEnv);
+
+    expect(second.id).toBe(first.id);
+    expect(await listBrowserWorkspaceTabs(webEnv)).toHaveLength(1);
+  });
+
+  it("leaves an already-populated workspace untouched", async () => {
+    const opened = await executeBrowserWorkspaceCommand(
+      { subaction: "tab", tabAction: "new", url: "https://example.com/" },
+      webEnv,
+    );
+    const openedId = opened.tab?.id as string;
+
+    const resolved = await ensureBrowserWorkspaceDefaultTab(webEnv);
+
+    // No default tab is seeded on top of an existing session.
+    expect(resolved.id).toBe(openedId);
+    const tabs = await listBrowserWorkspaceTabs(webEnv);
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]?.url).toBe("https://example.com/");
+  });
+
+  it("does not block agent tab actions while the default tab is loading", async () => {
+    // The default tab is seeded but never navigated/loaded here — the agent
+    // must still be able to open a fresh tab immediately.
+    await ensureBrowserWorkspaceDefaultTab(webEnv);
+
+    const created = await executeBrowserWorkspaceCommand(
+      {
+        subaction: "tab",
+        tabAction: "new",
+        url: "https://agent.example/task",
+      },
+      webEnv,
+    );
+    expect(created.tab?.url).toBe("https://agent.example/task");
+
+    const tabs = await listBrowserWorkspaceTabs(webEnv);
+    expect(tabs).toHaveLength(2);
+    expect(tabs.map((tab) => tab.url)).toContain(
+      BROWSER_WORKSPACE_DEFAULT_SEARCH_URL,
+    );
+  });
+
+  it("honors the ELIZA_BROWSER_DEFAULT_SEARCH_URL override", async () => {
+    const overrideEnv: NodeJS.ProcessEnv = {
+      ELIZA_BROWSER_DEFAULT_SEARCH_URL: "https://lite.duckduckgo.com/lite/",
+    };
+    expect(resolveBrowserWorkspaceDefaultSearchUrl(overrideEnv)).toBe(
+      "https://lite.duckduckgo.com/lite/",
+    );
+
+    const tab = await ensureBrowserWorkspaceDefaultTab(overrideEnv);
+    expect(tab.url).toBe("https://lite.duckduckgo.com/lite/");
+  });
+
+  it("rejects a non-http override rather than seeding a broken tab", () => {
+    expect(() =>
+      resolveBrowserWorkspaceDefaultSearchUrl({
+        ELIZA_BROWSER_DEFAULT_SEARCH_URL: "about:blank",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("BrowserService seeds the default tab at start", () => {
+  const bridgeKeys = [
+    "ELIZA_BROWSER_WORKSPACE_URL",
+    "ELIZA_BROWSER_WORKSPACE_TOKEN",
+  ];
+  const savedBridge: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    for (const key of bridgeKeys) {
+      savedBridge[key] = process.env[key];
+      delete process.env[key];
+    }
+    await __resetBrowserWorkspaceStateForTests();
+  });
+
+  it("opens one default search tab when the service boots in web mode", async () => {
+    const runtime = {
+      getService: () => null,
+    } as unknown as IAgentRuntime;
+
+    const service = await BrowserService.start(runtime);
+    try {
+      const tabs = await listBrowserWorkspaceTabs();
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0]?.url).toBe(BROWSER_WORKSPACE_DEFAULT_SEARCH_URL);
+      expect(tabs[0]?.visible).toBe(true);
+    } finally {
+      await service.stop();
+      for (const key of bridgeKeys) {
+        if (savedBridge[key] === undefined) delete process.env[key];
+        else process.env[key] = savedBridge[key];
+      }
+    }
+  });
+});

--- a/plugins/plugin-browser/src/workspace/browser-workspace.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace.ts
@@ -492,6 +492,66 @@ export async function openBrowserWorkspaceTab(
   return payload.tab;
 }
 
+/**
+ * Canonical startup search page. The default tab must render real HTML from a
+ * real search site (never `about:blank`) — DuckDuckGo's html endpoint is chosen
+ * because it is iframe-/embed-tolerant and does not trip the bot-walls that
+ * block Google/Bing inside an embedded webview (#13596).
+ */
+export const BROWSER_WORKSPACE_DEFAULT_SEARCH_URL =
+  "https://duckduckgo.com/html/";
+
+/**
+ * Resolve the startup search URL, honoring the `ELIZA_BROWSER_DEFAULT_SEARCH_URL`
+ * override. The result is validated (http/https only) so a misconfigured
+ * override fails loudly at startup rather than silently seeding a broken tab.
+ */
+export function resolveBrowserWorkspaceDefaultSearchUrl(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const override = env.ELIZA_BROWSER_DEFAULT_SEARCH_URL?.trim();
+  const resolved = assertBrowserWorkspaceUrl(
+    override || BROWSER_WORKSPACE_DEFAULT_SEARCH_URL,
+  );
+  // The default tab exists to avoid the empty-and-sad about:blank start, so an
+  // about:blank override defeats the whole feature — reject it rather than seed
+  // a blank default.
+  if (resolved === "about:blank") {
+    throw new Error(
+      "ELIZA_BROWSER_DEFAULT_SEARCH_URL must be a real http/https search page, not about:blank.",
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Ensure the workspace opens with exactly one default search tab at startup.
+ *
+ * Idempotent by tab presence: if any tab already exists the workspace is left
+ * untouched, so a restart or a repeated call never spawns duplicate tabs. The
+ * seeded tab points at a real search site and is loaded lazily/non-blocking —
+ * the agent can open or navigate tabs immediately while the default tab is
+ * still loading, and an offline start degrades to the designed in-tab error
+ * render (the search URL is not `about:blank`, so the web backend loads real
+ * HTML on demand). Returns the default tab, whether pre-existing or newly
+ * seeded. Callers must not assume the tab finished loading.
+ */
+export async function ensureBrowserWorkspaceDefaultTab(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<BrowserWorkspaceTab> {
+  const existing = await listBrowserWorkspaceTabs(env);
+  if (existing.length > 0) {
+    return existing.find((tab) => tab.visible) ?? existing[0];
+  }
+  return openBrowserWorkspaceTab(
+    {
+      show: true,
+      url: resolveBrowserWorkspaceDefaultSearchUrl(env),
+    },
+    env,
+  );
+}
+
 export async function navigateBrowserWorkspaceTab(
   request: NavigateBrowserWorkspaceTabRequest,
   env: NodeJS.ProcessEnv = process.env,


### PR DESCRIPTION
## Problem

Per #13596 (parent #13560, views-redesign epic), the browser opens **empty-and-sad**: the default new tab is `about:blank`, not a real search page. The doctrine calls for a Safari/Arc-mobile-style default: at startup the browser should open exactly one default tab pointed at a **real search site** (real HTML, not `about:blank`), and that default tab must be **non-blocking** — the agent can open/navigate tabs immediately while it loads, and an offline start must not wedge the surface.

This PR delivers the **core, self-contained plugin-browser slice** of that spec: the startup default-search-tab wiring. The larger UI redesign items in the issue (ViewHeader above the toolbar, folded Safari/Arc tab switcher, suggestion-chip removal, view-scoped actions, proactive-greeting scenario) live in `packages/ui` / `packages/agent` and are **deferred** — see below.

## Fix

`plugins/plugin-browser`, self-contained:

- **`browser-workspace.ts`** — new `ensureBrowserWorkspaceDefaultTab(env)`: if the workspace has zero tabs it seeds exactly one **visible** default tab at `BROWSER_WORKSPACE_DEFAULT_SEARCH_URL` (`https://duckduckgo.com/html/` — chosen because DuckDuckGo's html endpoint is iframe-/embed-tolerant and does not trip the Google/Bing bot-walls in an embedded webview, per the issue's search-site constraint). Idempotent by tab presence (restart/second call never duplicates). Works in both web (JSDOM) and desktop-bridge modes via the existing mode-aware `listBrowserWorkspaceTabs` / `openBrowserWorkspaceTab`. `resolveBrowserWorkspaceDefaultSearchUrl` honors an `ELIZA_BROWSER_DEFAULT_SEARCH_URL` override, validated http/https-only and rejecting `about:blank` so a misconfig fails loudly instead of re-seeding a blank tab.
- **`browser-service.ts`** — `BrowserService.start` calls the seam after registering targets, wrapped so a failure (e.g. unreachable desktop bridge) is `logger.warn`'d and **never blocks** service start or agent browser actions.

The seeded tab is a **user** tab in the default partition (`persist:eliza-browser`), structurally separate from the agent partition (`persist:eliza-browser-agent`) — so it cannot block the agent, matching the issue's note that isolation plumbing already exists.

## Tests

New `src/workspace/__tests__/browser-workspace-default-tab.test.ts` (7 tests, drive the real web-mode + `BrowserService.start` paths, no mocks of the unit under test):

- seeds exactly one visible tab at the real https search URL (asserts it is **not** `about:blank`);
- idempotent — a second `ensure` call never spawns a duplicate;
- leaves an already-populated workspace untouched;
- **non-blocking** — after seeding, an agent `tab.new` open succeeds immediately while the default tab is unloaded;
- `ELIZA_BROWSER_DEFAULT_SEARCH_URL` override honored;
- override rejects a non-real (`about:blank`) value;
- `BrowserService.start` in web mode seeds one default search tab at boot.

## Evidence

```
$ vitest run src/workspace/__tests__/browser-workspace-default-tab.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```
Neighboring existing suites still green: `browser-workspace-tab-lifecycle.test.ts` + `browser-service.test.ts` → 12 passed. `plugin-browser` typecheck: no errors cite the touched files (only pre-existing sparse-graph `dist/node_modules` / `@elizaos/vault` resolution errors). Biome clean on all three files.

- Real-LLM trajectory: N/A — this change is startup tab-seeding wiring in plugin-browser, no agent prompt/model/action behavior changed.
- Rendered UI proof: N/A — the UI-facing redesign (ViewHeader, folded switcher, chips) is the deferred `packages/ui` slice; this PR touches only plugin-browser workspace state + service startup.

## Deferred sub-items (follow-ups, out of scope for this plugin-browser slice)

- `ViewHeader` above the browser toolbar; folded Safari/Arc-mobile tab switcher (`BrowserWorkspaceView.tsx`, ~2974 lines) — `packages/ui`.
- Remove browser suggestion chips; designed three-state empty/error tab renders — `packages/ui`.
- View-scoped actions (open-tab / navigate-url / close-tab / switch-tab / search-web / reload-tab) gated on active view — `packages/agent` + `plugin-app-control`.
- Proactive-greeting scenario (skip on agent-initiated opens) — scenario-runner.
- Re-seed the default tab when the last tab is closed (never zero-tab state) — natural next step on this same seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
