### PR TITLE
fix(orchestrator): expose subagent context skills bridge

### DIFF
--- a/.github/issue-evidence/13774-live-spawn-proof/LIVE_13774_PROOF.json
+++ b/.github/issue-evidence/13774-live-spawn-proof/LIVE_13774_PROOF.json
@@ -1,0 +1,5 @@
+{
+  "parentAgentMentioned": true,
+  "skillsEndpointMentioned": true,
+  "summary": "SKILLS.md documents parent-agent usage and skill-related local instructions."
+}

--- a/.github/issue-evidence/13774-live-spawn-proof/SKILLS.md
+++ b/.github/issue-evidence/13774-live-spawn-proof/SKILLS.md
@@ -1,0 +1,21 @@
+# Available skills
+
+These skills are installed or task-scoped in the parent agent. To use one, send a USE_SKILL request back via the parent (slug + optional args).
+
+Protocol: send a message to the parent of the form `USE_SKILL <slug> <json_args>` and the parent will execute the skill and return the result. The `<json_args>` portion is optional; omit it for skills that take no parameters or use defaults.
+
+## Recommended for this task
+
+- **Parent Eliza Agent** (`parent-agent`) — Task-scoped bridge for asking the running parent Eliza agent to use its loaded capabilities, actions, providers, connectors, and confirmation flow.
+  - Protocol: Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). Fixed-cost self-spend commands such as `containers.create` may auto-authorize within the configured agent spend cap; variable-cost self-spend commands such as `domains.buy`, `media.*`, `promote.*`, and `advertising.*` always require human confirmation because the server-quoted price cannot be trusted from child-declared `params.spendEstimateUsd`. To delegate part of your work to a NEW parallel sub-agent on this same task, use `USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"<instruction for the child>","label":"<optional name>"}` — it spawns a child sub-agent (bounded nesting depth) whose progress shows in this task's thread; keep working, do not block waiting on it.
+
+## All enabled skills
+
+_(none)_
+
+## Task-scoped broker skills
+
+These slugs are requestable only for this spawned task because the parent orchestrator allow-listed them.
+
+- **Parent Eliza Agent** (`parent-agent`) — Task-scoped bridge for asking the running parent Eliza agent to use its loaded capabilities, actions, providers, connectors, and confirmation flow.
+  - Protocol: Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). Fixed-cost self-spend commands such as `containers.create` may auto-authorize within the configured agent spend cap; variable-cost self-spend commands such as `domains.buy`, `media.*`, `promote.*`, and `advertising.*` always require human confirmation because the server-quoted price cannot be trusted from child-declared `params.spendEstimateUsd`. To delegate part of your work to a NEW parallel sub-agent on this same task, use `USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"<instruction for the child>","label":"<optional name>"}` — it spawns a child sub-agent (bounded nesting depth) whose progress shows in this task's thread; keep working, do not block waiting on it.

--- a/.github/issue-evidence/13774-live-spawn-proof/service.log
+++ b/.github/issue-evidence/13774-live-spawn-proof/service.log
@@ -1,0 +1,2 @@
+[debug] [AcpService] AcpService initialized [object Object]
+[debug] [SkillManifest] AGENT_SKILLS_SERVICE not registered; emitting empty manifest

--- a/.github/issue-evidence/13774-subagent-context-delivery.md
+++ b/.github/issue-evidence/13774-subagent-context-delivery.md
@@ -1,0 +1,51 @@
+# 13774 subagent context delivery
+
+## Scope
+
+- Default sub-agent capability prompt advertises `USE_SKILL parent-agent`.
+- Spawn workspaces get `SKILLS.md` from the shared `AcpService.spawnSession` path, not only economics task spawns.
+- Parent-context bridge exposes task goal, acceptance criteria, and recent decisions when a session is task-bound.
+- Loopback bridge adds:
+  - `GET /api/coding-agents/:sessionId/skills`
+  - `GET /api/coding-agents/:sessionId/skills/:slug`
+
+## Verification
+
+Passed:
+
+```bash
+bunx @biomejs/biome check \
+  plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts \
+  plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts \
+  plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts \
+  plugins/plugin-agent-orchestrator/src/services/skill-manifest.ts \
+  plugins/plugin-agent-orchestrator/src/services/acp-service.ts \
+  plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts \
+  plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts \
+  plugins/plugin-agent-orchestrator/src/setup-routes.ts \
+  plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts \
+  plugins/plugin-agent-orchestrator/src/services/parent-agent-manifest.ts \
+  plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts \
+  plugins/plugin-agent-orchestrator/src/__tests__/skill-manifest.test.ts \
+  plugins/plugin-agent-orchestrator/src/__tests__/parent-context-routes.test.ts
+
+bun test \
+  ./plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts \
+  ./plugins/plugin-agent-orchestrator/src/__tests__/skill-manifest.test.ts \
+  ./plugins/plugin-agent-orchestrator/src/__tests__/parent-context-routes.test.ts
+```
+
+Result: 19 tests passed, 0 failed.
+
+Blocked in this sparse checkout:
+
+```bash
+bun run --cwd plugins/plugin-agent-orchestrator typecheck
+```
+
+The command fails before completing because this checkout lacks workspace/dependency materialization, including `@elizaos/auth/*`, `coding-agent-adapters`, `git-workspace-service`, `ai`, `file-type`, and `dotenv`. A grep of the typecheck log after fixing the patch-specific issues found no remaining errors for `parent-context-routes`, `parent-agent-broker`, `skill-manifest`, `PARENT_AGENT_BROKER_SLUG`, or `SkillInstructionsResult`.
+
+N/A:
+
+- Screenshots/video: no UI surface changed.
+- Live model trajectory: no model/action/provider prompt execution path was exercised; this patch changes sub-agent scaffolding/bridge discovery and deterministic route/service behavior.

--- a/.github/issue-evidence/13774-subagent-context-delivery.md
+++ b/.github/issue-evidence/13774-subagent-context-delivery.md
@@ -11,6 +11,24 @@
 
 ## Verification
 
+Live spawned-agent proof:
+
+```text
+bun .codex-tmp-13774/live-13774-proof.ts
+
+{"phase":"spawned","sessionId":"ee378fc4-b201-4a30-b47d-eeb281f1f748","workdir":"/var/folders/n9/khgbz07x3vn8lny5vxd8v1080000gn/T/eliza-13774-live-Jx2hSq/workdir","skillsMdExists":true,"skillsMdHasParentAgent":true}
+{"phase":"prompt-result","stopReason":"end_turn","proofExists":true,"proof":"{\"parentAgentMentioned\":true,\"skillsEndpointMentioned\":true,\"summary\":\"SKILLS.md documents parent-agent usage and skill-related local instructions.\"}\n"}
+{"phase":"events","events":["ready", "...", "task_complete"]}
+```
+
+Manually reviewed live artifacts:
+
+- `.github/issue-evidence/13774-live-spawn-proof/LIVE_13774_PROOF.json`
+- `.github/issue-evidence/13774-live-spawn-proof/SKILLS.md`
+- `.github/issue-evidence/13774-live-spawn-proof/service.log`
+
+The live run used the machine's real Codex login through native ACP. The spawned agent read the generated `SKILLS.md`, wrote `LIVE_13774_PROOF.json`, and emitted `task_complete`. The copied artifacts exclude Codex auth/cache files.
+
 Passed:
 
 ```bash
@@ -48,4 +66,4 @@ The command fails before completing because this checkout lacks workspace/depend
 N/A:
 
 - Screenshots/video: no UI surface changed.
-- Live model trajectory: no model/action/provider prompt execution path was exercised; this patch changes sub-agent scaffolding/bridge discovery and deterministic route/service behavior.
+- Real-LLM trajectory: captured by the live Codex ACP proof above.

--- a/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
@@ -45,6 +45,7 @@ describe("buildGoalPrompt capability fence", () => {
     const prompt = buildGoalPrompt(baseInput);
     expect(prompt).toContain("Use only coding-relevant capabilities");
     expect(prompt).toContain("edit/apply patches");
+    expect(prompt).toContain("USE_SKILL parent-agent");
     expect(prompt).not.toContain("parent-agent Cloud command bridge");
   });
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-context-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-context-routes.test.ts
@@ -1,0 +1,175 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handleParentContextRoutes } from "../api/parent-context-routes.js";
+import type { RouteContext } from "../api/route-utils.js";
+import { PARENT_AGENT_BROKER_SLUG } from "../services/parent-agent-manifest.js";
+import type { SessionInfo } from "../services/types.js";
+
+function makeResponse() {
+  const res = {
+    statusCode: 0,
+    headers: undefined as Record<string, string> | undefined,
+    body: "",
+    writeHead(status: number, headers: Record<string, string>) {
+      this.statusCode = status;
+      this.headers = headers;
+    },
+    end(body: string) {
+      this.body = body;
+    },
+  };
+  return res as unknown as ServerResponse & typeof res;
+}
+
+function makeRequest(pathname: string): IncomingMessage {
+  return {
+    method: "GET",
+    url: pathname,
+    socket: { remoteAddress: "127.0.0.1" },
+  } as unknown as IncomingMessage;
+}
+
+function makeSession(metadata: Record<string, unknown>): SessionInfo {
+  const now = new Date();
+  return {
+    id: "session-1",
+    name: "Ada",
+    agentType: "codex",
+    workdir: "/tmp/work",
+    status: "ready",
+    approvalPreset: "standard",
+    createdAt: now,
+    lastActivityAt: now,
+    metadata,
+  };
+}
+
+function makeContext(session: SessionInfo, services: Record<string, unknown>) {
+  const runtime = {
+    character: { name: "Eliza", bio: "Assistant" },
+    getRoom: vi.fn(async () => ({
+      id: "room-1",
+      channelId: "chat",
+      source: "web",
+      type: "dm",
+      worldId: "world-1",
+    })),
+    getService: vi.fn((name: string) => services[name]),
+  } as unknown as IAgentRuntime;
+  return {
+    runtime,
+    acpService: {
+      getSession: vi.fn(async (id: string) =>
+        id === session.id ? session : null,
+      ),
+    } as unknown as RouteContext["acpService"],
+    workspaceService: null,
+  } satisfies RouteContext;
+}
+
+async function runRoute(ctx: RouteContext, pathname: string) {
+  const res = makeResponse();
+  const handled = await handleParentContextRoutes(
+    makeRequest(pathname),
+    res,
+    pathname,
+    ctx,
+  );
+  return { handled, status: res.statusCode, body: JSON.parse(res.body) };
+}
+
+describe("parent-context bridge routes", () => {
+  it("exposes originating task goal, acceptance criteria, and decisions", async () => {
+    const session = makeSession({
+      taskId: "task-1",
+      roomId: "room-1",
+      capabilityProfile: "economics",
+    });
+    const ctx = makeContext(session, {
+      ORCHESTRATOR_TASK_SERVICE: {
+        getTask: vi.fn(async () => ({
+          task: {
+            id: "task-1",
+            goal: "Ship the app",
+            acceptanceCriteria: ["tests pass"],
+          },
+          decisions: [
+            {
+              id: "decision-1",
+              taskId: "task-1",
+              sessionId: "session-1",
+              event: "tool_running",
+              decisionType: "route",
+              actionSelected: "spawn_agent",
+              promptText: "full prompt",
+              promptExcerpt: "full",
+              response: "ok",
+              reasoning: "needed a worker",
+              timestamp: 1,
+              createdAt: "2026-07-05T00:00:00.000Z",
+            },
+          ],
+        })),
+      },
+    });
+
+    const result = await runRoute(
+      ctx,
+      "/api/coding-agents/session-1/parent-context",
+    );
+
+    expect(result.handled).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.body.task).toMatchObject({
+      id: "task-1",
+      goal: "Ship the app",
+      acceptanceCriteria: ["tests pass"],
+      capabilityProfile: "economics",
+    });
+    expect(result.body.task.decisions).toEqual([
+      expect.objectContaining({
+        id: "decision-1",
+        actionSelected: "spawn_agent",
+        reasoning: "needed a worker",
+      }),
+    ]);
+  });
+
+  it("serves requestable skills and full virtual skill bodies", async () => {
+    const session = makeSession({});
+    const ctx = makeContext(session, {
+      AGENT_SKILLS_SERVICE: {
+        getLoadedSkills: vi.fn(() => [
+          {
+            slug: "repo-review",
+            name: "Repo Review",
+            description: "Review repository code.",
+          },
+        ]),
+        getSkillInstructions: vi.fn((slug: string) =>
+          slug === "repo-review"
+            ? {
+                slug,
+                body: "# Repo Review\n\nRead the code.",
+                estimatedTokens: 9,
+              }
+            : null,
+        ),
+      },
+    });
+
+    const list = await runRoute(ctx, "/api/coding-agents/session-1/skills");
+    expect(list.status).toBe(200);
+    expect(list.body.slugs).toContain("repo-review");
+    expect(list.body.slugs).toContain(PARENT_AGENT_BROKER_SLUG);
+
+    const body = await runRoute(
+      ctx,
+      `/api/coding-agents/session-1/skills/${PARENT_AGENT_BROKER_SLUG}`,
+    );
+    expect(body.status).toBe(200);
+    expect(body.body.source).toBe("virtual");
+    expect(body.body.body).toContain("USE_SKILL parent-agent");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/skill-manifest.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/skill-manifest.test.ts
@@ -7,8 +7,11 @@ import { describe, expect, it, vi } from "vitest";
 import {
   PARENT_AGENT_BROKER_MANIFEST_ENTRY,
   PARENT_AGENT_BROKER_SLUG,
-} from "../services/parent-agent-broker.js";
-import { buildSkillsManifest } from "../services/skill-manifest.js";
+} from "../services/parent-agent-manifest.js";
+import {
+  buildSkillsManifest,
+  readSkillInstructions,
+} from "../services/skill-manifest.js";
 
 function createRuntime(service?: unknown): IAgentRuntime {
   return {
@@ -101,5 +104,84 @@ describe("buildSkillsManifest", () => {
 
     // The generic manifest must stay clean — ViewKind is app-build-only.
     expect(manifest.markdown).not.toContain("View kind");
+  });
+
+  it("falls back to getLoadedSkills when eligible-skill filtering is unavailable", async () => {
+    const service = {
+      getLoadedSkills: vi.fn(() => [
+        {
+          slug: "repo-review",
+          name: "Repo Review",
+          description: "Review repository code.",
+        },
+      ]),
+    };
+
+    const manifest = await buildSkillsManifest(createRuntime(service), {
+      virtualSkills: [PARENT_AGENT_BROKER_MANIFEST_ENTRY],
+    });
+
+    expect(manifest.slugs).toEqual(["repo-review", PARENT_AGENT_BROKER_SLUG]);
+    expect(manifest.markdown).toContain("Repo Review");
+  });
+
+  it("serves full installed and virtual skill instruction bodies", async () => {
+    const service = {
+      getLoadedSkills: vi.fn(() => [
+        {
+          slug: "repo-review",
+          name: "Repo Review",
+          description: "Review repository code.",
+        },
+      ]),
+      getSkillInstructions: vi.fn((slug: string) =>
+        slug === "repo-review"
+          ? {
+              slug,
+              body: "# Repo Review\n\nRead the code and report risks.",
+              estimatedTokens: 17,
+            }
+          : null,
+      ),
+    };
+
+    await expect(
+      readSkillInstructions(createRuntime(service), "repo-review"),
+    ).resolves.toEqual({
+      slug: "repo-review",
+      body: "# Repo Review\n\nRead the code and report risks.",
+      estimatedTokens: 17,
+      source: "installed",
+    });
+
+    const virtual = await readSkillInstructions(
+      createRuntime(service),
+      PARENT_AGENT_BROKER_SLUG,
+      { virtualSkills: [PARENT_AGENT_BROKER_MANIFEST_ENTRY] },
+    );
+    expect(virtual?.source).toBe("virtual");
+    expect(virtual?.body).toContain("USE_SKILL parent-agent");
+  });
+
+  it("does not serve installed skill bodies for disabled skills", async () => {
+    const service = {
+      getEligibleSkills: vi.fn(async () => [
+        {
+          slug: "disabled-skill",
+          name: "Disabled",
+          description: "Should not be requestable.",
+        },
+      ]),
+      isSkillEnabled: vi.fn(() => false),
+      getSkillInstructions: vi.fn((slug: string) => ({
+        slug,
+        body: "# Disabled\n\nDo not expose.",
+        estimatedTokens: 7,
+      })),
+    };
+
+    await expect(
+      readSkillInstructions(createRuntime(service), "disabled-skill"),
+    ).resolves.toBeNull();
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts
@@ -9,9 +9,16 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { IAgentRuntime, Memory } from "@elizaos/core";
-import { ModelType } from "@elizaos/core";
-import { activeWorkspaceContextProvider } from "../providers/active-workspace-context.js";
+import type { IAgentRuntime, Memory, Service } from "@elizaos/core";
+import type {
+  OrchestratorTaskDecision,
+  OrchestratorTaskDocument,
+} from "../services/orchestrator-task-types.js";
+import { PARENT_AGENT_BROKER_MANIFEST_ENTRY } from "../services/parent-agent-manifest.js";
+import {
+  buildSkillsManifest,
+  readSkillInstructions,
+} from "../services/skill-manifest.js";
 import {
   type SessionInfo,
   TERMINAL_SESSION_STATUSES,
@@ -38,6 +45,10 @@ type ParentMemoryHit = { [key: string]: JsonValue } & {
   createdAt: number | null;
   metadata: JsonValue;
 };
+
+interface TaskServiceShape {
+  getTask: (taskId: string) => Promise<OrchestratorTaskDocument | null>;
+}
 
 const BRIDGE_TIMEOUT_MS = 5_000;
 const DEFAULT_MEMORY_LIMIT = 10;
@@ -158,6 +169,63 @@ function toJsonValue(value: unknown): JsonValue {
 
 function readOriginRoomId(metadata: Record<string, unknown>): string | null {
   return readString(metadata.originRoomId) ?? readString(metadata.roomId);
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (entry): entry is string =>
+      typeof entry === "string" && entry.trim().length > 0,
+  );
+}
+
+async function loadTaskDocument(
+  runtime: IAgentRuntime,
+  taskId: string | null,
+): Promise<OrchestratorTaskDocument | null> {
+  if (!taskId) return null;
+  const service = runtime.getService("ORCHESTRATOR_TASK_SERVICE") as
+    | (Service & TaskServiceShape)
+    | undefined;
+  if (!service?.getTask) return null;
+  return await service.getTask(taskId);
+}
+
+function normalizeDecision(decision: OrchestratorTaskDecision): JsonValue {
+  return {
+    id: decision.id,
+    sessionId: decision.sessionId ?? null,
+    event: decision.event,
+    decisionType: decision.decisionType,
+    actionSelected: decision.actionSelected,
+    promptExcerpt: decision.promptExcerpt,
+    response: decision.response ?? null,
+    reasoning: decision.reasoning,
+    timestamp: decision.timestamp,
+  };
+}
+
+async function buildTaskContext(
+  runtime: IAgentRuntime,
+  metadata: Record<string, unknown>,
+): Promise<JsonValue> {
+  const taskId = readString(metadata.taskId);
+  const doc = await loadTaskDocument(runtime, taskId);
+  const goal = doc?.task.goal ?? readString(metadata.goal);
+  const acceptanceCriteria =
+    doc?.task.acceptanceCriteria ??
+    readStringArray(metadata.acceptanceCriteria);
+  const decisions = (doc?.decisions ?? [])
+    .slice(-20)
+    .map((decision) => normalizeDecision(decision));
+  if (!taskId && !goal && acceptanceCriteria.length === 0) return null;
+  return {
+    id: taskId,
+    goal,
+    acceptanceCriteria,
+    capabilityProfile: readString(metadata.capabilityProfile),
+    decisions,
+  };
 }
 
 function normalizeDocumentSources(value: unknown): JsonValue[] {
@@ -282,7 +350,53 @@ async function buildParentContext(
     currentRoom: await loadRoom(ctx.runtime, roomId),
     workdir: session?.workdir ?? null,
     model: normalizeModel(session, metadata),
+    task: await buildTaskContext(ctx.runtime, metadata),
   };
+}
+
+async function listSessionSkills(ctx: RouteContext): Promise<JsonValue> {
+  const manifest = await buildSkillsManifest(ctx.runtime, {
+    recommendedSlugs: ["parent-agent"],
+    virtualSkills: [{ ...PARENT_AGENT_BROKER_MANIFEST_ENTRY }],
+  });
+  return {
+    slugs: manifest.slugs,
+    skills: manifest.entries.map((entry) => ({
+      slug: entry.slug,
+      name: entry.name,
+      description: entry.description,
+      hasBody: true,
+      source:
+        entry.slug === PARENT_AGENT_BROKER_MANIFEST_ENTRY.slug
+          ? "virtual"
+          : "installed",
+    })),
+  };
+}
+
+async function loadSessionSkill(
+  ctx: RouteContext,
+  rawSlug: string,
+): Promise<JsonValue> {
+  const slug = parseSessionId(rawSlug);
+  if (!slug) {
+    throw new BridgeRouteError(
+      "invalid_skill_slug",
+      400,
+      "Invalid skill slug.",
+    );
+  }
+  const instructions = await readSkillInstructions(ctx.runtime, slug, {
+    virtualSkills: [{ ...PARENT_AGENT_BROKER_MANIFEST_ENTRY }],
+  });
+  if (!instructions) {
+    throw new BridgeRouteError(
+      "skill_not_found",
+      404,
+      "Skill is not requestable in this parent runtime.",
+    );
+  }
+  return toJsonValue(instructions);
 }
 
 async function searchParentMemory(
@@ -290,7 +404,7 @@ async function searchParentMemory(
   query: string,
   limit: number,
 ): Promise<JsonValue> {
-  const embedding = await ctx.runtime.useModel(ModelType.TEXT_EMBEDDING, {
+  const embedding = await ctx.runtime.useModel("TEXT_EMBEDDING", {
     text: query,
   });
   const perTableLimit = Math.max(
@@ -322,6 +436,9 @@ async function searchParentMemory(
 async function listActiveWorkspaceContext(
   ctx: RouteContext,
 ): Promise<JsonValue> {
+  const { activeWorkspaceContextProvider } = await import(
+    "../providers/active-workspace-context.js"
+  );
   const result = await activeWorkspaceContextProvider.get(
     ctx.runtime,
     {
@@ -347,7 +464,7 @@ export async function handleParentContextRoutes(
   ctx: RouteContext,
 ): Promise<boolean> {
   const match = pathname.match(
-    /^\/api\/coding-agents\/([^/]+)\/(parent-context|memory|active-workspaces)$/,
+    /^\/api\/coding-agents\/([^/]+)\/(parent-context|memory|active-workspaces|skills)(?:\/([^/]+))?$/,
   );
   if (!match) return false;
 
@@ -418,6 +535,16 @@ export async function handleParentContextRoutes(
             query,
             parseLimit(url.searchParams.get("limit")),
           ),
+        ),
+      );
+      return true;
+    }
+    if (endpoint === "skills") {
+      const rawSlug = match[3];
+      sendJson(
+        res,
+        await withBridgeTimeout(
+          rawSlug ? loadSessionSkill(ctx, rawSlug) : listSessionSkills(ctx),
         ),
       );
       return true;

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -62,11 +62,13 @@ import {
   buildOpencodeAcpEnv,
   resolveVendoredOpencodeAcpCommand,
 } from "./opencode-config.js";
+import { PARENT_AGENT_BROKER_MANIFEST_ENTRY } from "./parent-agent-manifest.js";
 import {
   AcpSessionStore,
   InMemorySessionStore,
   type SessionStoreBackend,
 } from "./session-store.js";
+import { writeSkillsManifest } from "./skill-manifest.js";
 import { writeWorkspaceIdentity } from "./sub-agent-identity.js";
 import { normalizeTaskAgentAdapter } from "./task-agent-routing.js";
 import {
@@ -881,6 +883,7 @@ export class AcpService extends Service {
     // disk (where every backend reads it) — only when the workspace is bare, so
     // a real repo's own AGENTS.md/CLAUDE.md is never clobbered.
     await writeWorkspaceIdentity(workdir);
+    await this.writeSpawnSkillsManifest(workdir, opts.metadata);
 
     // Record the workspace HEAD + already-dirty files at spawn so the change
     // set captured at task_complete is scoped to exactly what this sub-agent
@@ -1650,6 +1653,31 @@ export class AcpService extends Service {
       this.codexNoLandlockSandboxMode(),
       this.codexAcpApprovalPolicy() ?? CODEX_NO_LANDLOCK_APPROVAL_POLICY,
     );
+  }
+
+  private async writeSpawnSkillsManifest(
+    workdir: string,
+    metadata: Record<string, unknown> | undefined,
+  ): Promise<void> {
+    const capabilityProfile =
+      typeof metadata?.capabilityProfile === "string"
+        ? metadata.capabilityProfile.trim().toLowerCase()
+        : undefined;
+    const economics = capabilityProfile === "economics";
+    try {
+      await writeSkillsManifest(this.runtime, workdir, {
+        recommendedSlugs: economics
+          ? ["build-monetized-app", "eliza-cloud", "parent-agent"]
+          : ["parent-agent"],
+        virtualSkills: [{ ...PARENT_AGENT_BROKER_MANIFEST_ENTRY }],
+        includeViewKindContract: economics,
+      });
+    } catch (err) {
+      this.log("warn", "failed to write SKILLS.md", {
+        workdir,
+        error: errorMessage(err),
+      });
+    }
   }
 
   private codexLandlockFallbackCommand(

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -72,9 +72,9 @@ import { writeSkillsManifest } from "./skill-manifest.js";
 import { writeWorkspaceIdentity } from "./sub-agent-identity.js";
 import { normalizeTaskAgentAdapter } from "./task-agent-routing.js";
 import {
+  type AcpCapacity,
   type AcpEventCallback,
   type AcpJsonRpcMessage,
-  type AcpCapacity,
   type AcpToolCall,
   type AgentType,
   type ApprovalPreset,

--- a/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
@@ -25,6 +25,7 @@ export const DEFAULT_GOAL_CAPABILITIES: readonly string[] = [
   "run shell/test commands",
   "inspect git diff/status",
   "communicate with the parent/swarm",
+  "use the parent-agent bridge for parent-owned context, skill bodies, and delegated parent capabilities (USE_SKILL parent-agent)",
 ];
 
 /**

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -18,7 +18,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import { appendFile, mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { type IAgentRuntime, Service } from "@elizaos/core";
@@ -110,8 +110,6 @@ import {
   TERMINAL_TASK_STATUSES,
   type UsageState,
 } from "./orchestrator-task-types.js";
-import { PARENT_AGENT_BROKER_MANIFEST_ENTRY } from "./parent-agent-broker.js";
-import { buildSkillsManifest } from "./skill-manifest.js";
 import {
   configureSpendLedger,
   createTaskStoreSpendLedger,
@@ -2745,30 +2743,6 @@ export class OrchestratorTaskService extends Service {
       ...(capabilityProfile ? { capabilityProfile } : {}),
     });
 
-    // Economics tasks drive the monetized-app loop through the parent-agent
-    // Cloud command broker. Write a SKILLS.md into the workdir that advertises
-    // the broker slug + its arg contract so the spawned agent knows how to call
-    // back (the dispatcher in SubAgentRouter executes those requests).
-    if (capabilityProfile === "economics" && workdir) {
-      try {
-        const manifest = await buildSkillsManifest(this.runtime, {
-          recommendedSlugs: ["build-monetized-app", "eliza-cloud"],
-          virtualSkills: [{ ...PARENT_AGENT_BROKER_MANIFEST_ENTRY }],
-          // Economics tasks may deploy Cloud views — teach the sub-agent the
-          // ViewKind contract so views are categorized correctly. (#8917)
-          includeViewKindContract: true,
-        });
-        await writeFile(join(workdir, "SKILLS.md"), manifest.markdown, "utf8");
-      } catch (err) {
-        // error-policy:J7 SKILLS.md scaffolding is best-effort; a failed write is
-        // warned and the spawn proceeds without it.
-        this.runtime.logger?.warn?.(
-          { src: "orchestrator-task-service", taskId, workdir },
-          `failed to write SKILLS.md: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-    }
-
     const result = await acp.spawnSession({
       // Coding-agent selection: explicit request → routing policy → the
       // deployment's configured default (ELIZA_ACP_DEFAULT_AGENT /
@@ -2798,6 +2772,8 @@ export class OrchestratorTaskService extends Service {
         // metadata — the built-apps registry's app-build gate, interruption
         // relevance — see what this session is building.
         goal: doc.task.goal,
+        ...(capabilityProfile ? { capabilityProfile } : {}),
+        acceptanceCriteria: doc.task.acceptanceCriteria,
         // Orchestrator sessions outlive their first prompt so follow-ups and
         // validation re-dispatch can reuse them.
         keepAliveAfterComplete: true,

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -17,6 +17,7 @@ import type {
 } from "@elizaos/core";
 import { requireConfirmation } from "@elizaos/core";
 import { readConfigCloudKey, readConfigEnvKey } from "./config-env.js";
+import { PARENT_AGENT_BROKER_SLUG } from "./parent-agent-manifest.js";
 import {
   addSessionSpendUsd,
   decideSpendAuthorization,
@@ -28,23 +29,17 @@ import {
 } from "./spend-allowance.js";
 import type { SessionInfo } from "./types.js";
 
+export {
+  PARENT_AGENT_BROKER_MANIFEST_ENTRY,
+  PARENT_AGENT_BROKER_SLUG,
+} from "./parent-agent-manifest.js";
+
 const LOG_PREFIX = "[ParentAgentBroker]";
 const REQUEST_MAX_CHARS = 4000;
 const ACTION_LIST_LIMIT_DEFAULT = 60;
 const ACTION_LIST_LIMIT_MAX = 200;
 const CLOUD_RESPONSE_MAX_CHARS = 8000;
 const DEFAULT_CLOUD_BASE_URL = "https://elizacloud.ai";
-
-export const PARENT_AGENT_BROKER_SLUG = "parent-agent";
-
-export const PARENT_AGENT_BROKER_MANIFEST_ENTRY = {
-  slug: PARENT_AGENT_BROKER_SLUG,
-  name: "Parent Eliza Agent",
-  description:
-    "Task-scoped bridge for asking the running parent Eliza agent to use its loaded capabilities, actions, providers, connectors, and confirmation flow.",
-  guidance:
-    'Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). Fixed-cost self-spend commands such as `containers.create` may auto-authorize within the configured agent spend cap; variable-cost self-spend commands such as `domains.buy`, `media.*`, `promote.*`, and `advertising.*` always require human confirmation because the server-quoted price cannot be trusted from child-declared `params.spendEstimateUsd`. To delegate part of your work to a NEW parallel sub-agent on this same task, use `USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"<instruction for the child>","label":"<optional name>"}` — it spawns a child sub-agent (bounded nesting depth) whose progress shows in this task\'s thread; keep working, do not block waiting on it.',
-} as const;
 
 type ParentAgentMode =
   | "ask"

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-manifest.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-manifest.ts
@@ -1,0 +1,10 @@
+export const PARENT_AGENT_BROKER_SLUG = "parent-agent";
+
+export const PARENT_AGENT_BROKER_MANIFEST_ENTRY = {
+  slug: PARENT_AGENT_BROKER_SLUG,
+  name: "Parent Eliza Agent",
+  description:
+    "Task-scoped bridge for asking the running parent Eliza agent to use its loaded capabilities, actions, providers, connectors, and confirmation flow.",
+  guidance:
+    'Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). Fixed-cost self-spend commands such as `containers.create` may auto-authorize within the configured agent spend cap; variable-cost self-spend commands such as `domains.buy`, `media.*`, `promote.*`, and `advertising.*` always require human confirmation because the server-quoted price cannot be trusted from child-declared `params.spendEstimateUsd`. To delegate part of your work to a NEW parallel sub-agent on this same task, use `USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"<instruction for the child>","label":"<optional name>"}` — it spawns a child sub-agent (bounded nesting depth) whose progress shows in this task\'s thread; keep working, do not block waiting on it.',
+} as const;

--- a/plugins/plugin-agent-orchestrator/src/services/skill-manifest.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/skill-manifest.ts
@@ -12,6 +12,8 @@
  * @module services/skill-manifest
  */
 
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import type { IAgentRuntime, Logger, Service } from "@elizaos/core";
 
 const LOG_PREFIX = "[SkillManifest]";
@@ -31,10 +33,18 @@ export interface ManifestSkillEntry {
  * dependency on @elizaos/plugin-agent-skills (it is optional at runtime).
  */
 interface SkillsServiceShape {
-  getEligibleSkills: () => Promise<
+  getEligibleSkills?: () => Promise<
     Array<{ slug: string; name: string; description: string }>
   >;
-  isSkillEnabled: (slug: string) => boolean;
+  getLoadedSkills?: () => Array<{
+    slug: string;
+    name: string;
+    description: string;
+  }>;
+  isSkillEnabled?: (slug: string) => boolean;
+  getSkillInstructions?: (
+    slug: string,
+  ) => { slug: string; body: string; estimatedTokens: number } | null;
 }
 
 export interface BuildSkillsManifestOptions {
@@ -62,6 +72,15 @@ export interface SkillsManifestResult {
   markdown: string;
   /** Slugs that the spawned agent can actually request via USE_SKILL. */
   slugs: string[];
+  /** Requestable entries backing the rendered manifest. */
+  entries: ManifestSkillEntry[];
+}
+
+export interface SkillInstructionsResult {
+  slug: string;
+  body: string;
+  estimatedTokens: number | null;
+  source: "installed" | "virtual";
 }
 
 function truncateDescription(value: string): string {
@@ -73,6 +92,25 @@ function truncateDescription(value: string): string {
 function getLogger(runtime: IAgentRuntime): Logger | Console {
   const candidate = (runtime as { logger?: Logger }).logger;
   return candidate ?? console;
+}
+
+async function getAvailableSkillEntries(
+  service: SkillsServiceShape,
+  onlyEligible: boolean,
+): Promise<ManifestSkillEntry[]> {
+  const rawSkills = service.getEligibleSkills
+    ? await service.getEligibleSkills()
+    : (service.getLoadedSkills?.() ?? []);
+  return rawSkills
+    .filter(
+      (skill) =>
+        !onlyEligible || (service.isSkillEnabled?.(skill.slug) ?? true),
+    )
+    .map((skill) => ({
+      slug: skill.slug,
+      name: skill.name,
+      description: skill.description,
+    }));
 }
 
 function renderEntries(entries: ManifestSkillEntry[]): string {
@@ -194,24 +232,17 @@ export async function buildSkillsManifest(
         opts.includeViewKindContract ?? false,
       ),
       slugs: virtualEntries.map((entry) => entry.slug),
+      entries: virtualEntries,
     };
   }
-
-  const eligible = await service.getEligibleSkills();
-  const enabledEligible = eligible.filter((skill) =>
-    service.isSkillEnabled(skill.slug),
-  );
 
   // onlyEligible defaults to true — for the spawned agent surface we only
   // want skills it can actually invoke.
   const onlyEligible = opts.onlyEligible ?? true;
-  const availableSet = onlyEligible ? enabledEligible : eligible;
-
-  const availableEntries: ManifestSkillEntry[] = availableSet.map((skill) => ({
-    slug: skill.slug,
-    name: skill.name,
-    description: skill.description,
-  }));
+  const availableEntries = await getAvailableSkillEntries(
+    service,
+    onlyEligible,
+  );
 
   const virtualEntries = opts.virtualSkills ?? [];
   const requestableBySlug = new Map<string, ManifestSkillEntry>();
@@ -244,5 +275,75 @@ export async function buildSkillsManifest(
       opts.includeViewKindContract ?? false,
     ),
     slugs: dedupedSlugs,
+    entries: [...availableEntries, ...virtualEntries],
+  };
+}
+
+export async function writeSkillsManifest(
+  runtime: IAgentRuntime,
+  workdir: string,
+  opts: BuildSkillsManifestOptions = {},
+): Promise<SkillsManifestResult> {
+  const manifest = await buildSkillsManifest(runtime, opts);
+  await writeFile(join(workdir, "SKILLS.md"), manifest.markdown, "utf8");
+  return manifest;
+}
+
+export async function readSkillInstructions(
+  runtime: IAgentRuntime,
+  slug: string,
+  opts: BuildSkillsManifestOptions = {},
+): Promise<SkillInstructionsResult | null> {
+  const normalized = slug.trim().toLowerCase();
+  if (!normalized) return null;
+
+  const virtualSkill = (opts.virtualSkills ?? []).find(
+    (entry) => entry.slug.toLowerCase() === normalized,
+  );
+  if (virtualSkill) {
+    return {
+      slug: virtualSkill.slug,
+      source: "virtual",
+      estimatedTokens: null,
+      body: [
+        `# ${virtualSkill.name}`,
+        "",
+        virtualSkill.description,
+        "",
+        virtualSkill.guidance
+          ? `Protocol: ${virtualSkill.guidance}`
+          : `Protocol: USE_SKILL ${virtualSkill.slug} <json_args>`,
+      ].join("\n"),
+    };
+  }
+
+  const service = runtime.getService("AGENT_SKILLS_SERVICE") as
+    | (Service & SkillsServiceShape)
+    | undefined;
+  if (!service) return null;
+
+  const canCheckAvailability = Boolean(
+    service.getEligibleSkills || service.getLoadedSkills,
+  );
+  let installedSlug = slug;
+  if (canCheckAvailability) {
+    const availableEntries = await getAvailableSkillEntries(
+      service,
+      opts.onlyEligible ?? true,
+    );
+    const availableEntry = availableEntries.find(
+      (entry) => entry.slug.toLowerCase() === normalized,
+    );
+    if (!availableEntry) return null;
+    installedSlug = availableEntry.slug;
+  }
+
+  const instructions = service.getSkillInstructions?.(installedSlug);
+  if (!instructions) return null;
+  return {
+    slug: instructions.slug,
+    body: instructions.body,
+    estimatedTokens: instructions.estimatedTokens,
+    source: "installed",
   };
 }

--- a/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
@@ -9,8 +9,9 @@
  *     match already scores ≥ 0.9 (no need to spend a model call) or when the
  *     runtime model is unavailable.
  *
- * The output is task-aware ranking: the orchestrator can then write the top
- * N into SKILLS.md and reference them in the spawned agent's initial prompt.
+ * The output is task-aware ranking: the shared ACP spawn path can then write
+ * the top N into SKILLS.md and expose them through the spawned agent's
+ * loopback skills bridge.
  *
  * @module services/skill-recommender
  */

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
@@ -2,10 +2,7 @@
  * Self-contained operating manual scaffolded into a spawned sub-agent's
  * workspace so every backend (claude reads CLAUDE.md, codex reads AGENTS.md,
  * opencode reads both) receives the same eliza-context + non-interactive
- * directive regardless of where the spawn cwd lands. The ACP spawn path injects
- * nothing but the task string, so without this a sub-agent in a bare/scratch
- * cwd gets zero orientation — codex in particular ("expected identity files are
- * not present") starves because it only reads AGENTS.md.
+ * directive regardless of where the spawn cwd lands.
  *
  * @module services/sub-agent-identity
  */
@@ -22,8 +19,8 @@ const IDENTITY_FILENAMES = ["AGENTS.md", "CLAUDE.md"] as const;
  * The operating manual. Deliberately self-contained — a sub-agent never has to
  * chase a possibly-stale skill file to know it is non-interactive. Bridge facts
  * are stated accurately: `memory` is global semantic search (not the originating
- * room's recent messages), `parent-context` does not expose the original task,
- * and the endpoints only work when `PARALLAX_SESSION_ID` is wired.
+ * room's recent messages), and the endpoints only work when
+ * `PARALLAX_SESSION_ID` is wired.
  */
 export const SUB_AGENT_IDENTITY_MD = `# Eliza coding sub-agent — operating manual
 
@@ -72,10 +69,23 @@ If the task depends on context not in the prompt, you can GET read-only parent
 state, but only when the bridge is wired (env var \`PARALLAX_SESSION_ID\` set):
 
 - \`curl "http://127.0.0.1:\${ELIZA_HOOK_PORT:-2138}/api/coding-agents/\${PARALLAX_SESSION_ID}/parent-context"\`
-  → parent character, originating room, model prefs, your workdir.
+  → parent character, originating room, model prefs, your workdir, and the
+  originating task goal/acceptance criteria when the spawn is bound to a task.
 - \`.../memory?q=<query>&limit=<N>\` → GLOBAL semantic search over the parent's
   memory (facts, messages, knowledge) — not the originating room's recency.
 - \`.../active-workspaces\` → sibling sub-agents.
+- \`.../skills\` → requestable installed skills plus task-scoped broker skills.
+- \`.../skills/<slug>\` → the full instruction body for that skill.
+
+If you need the parent to use capabilities that only it has — cloud app
+commands, calendar/account connectors, GitHub project state, or spawning a
+parallel child for this same task — emit a line like:
+\`USE_SKILL parent-agent {"request":"<what you need>"}\`
+
+For Cloud commands, ask the bridge to list commands first:
+\`USE_SKILL parent-agent {"mode":"list-cloud-commands"}\`
+Mutating, paid, or destructive Cloud commands are still gated by the parent and
+may require explicit owner confirmation; do not fabricate confirmation.
 
 ## Requesting a missing credential
 

--- a/plugins/plugin-agent-orchestrator/src/setup-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/setup-routes.ts
@@ -141,6 +141,8 @@ const CODING_AGENT_ROUTE_PATHS: Array<{ type: string; path: string }> = [
   { type: "GET", path: "/api/coding-agents/:sessionId/parent-context" },
   { type: "GET", path: "/api/coding-agents/:sessionId/memory" },
   { type: "GET", path: "/api/coding-agents/:sessionId/active-workspaces" },
+  { type: "GET", path: "/api/coding-agents/:sessionId/skills" },
+  { type: "GET", path: "/api/coding-agents/:sessionId/skills/:slug" },
   { type: "POST", path: "/api/coding-agents/:sessionId/credentials/request" },
   {
     type: "GET",


### PR DESCRIPTION
## Summary

Addresses the implementable-now scope of #13774.

- Advertises `USE_SKILL parent-agent` in the default sub-agent capability fence and operating manual.
- Writes `SKILLS.md` from the shared ACP spawn path so non-economics direct/task spawns get the parent-agent broker surface too.
- Adds loopback `GET /api/coding-agents/:sessionId/skills` and `/skills/:slug` endpoints with session-gated access and eligibility filtering for installed skill bodies.
- Extends parent-context with originating task goal, acceptance criteria, capability profile, and recent decisions.

Product-decision items from #13774 are intentionally unchanged: replacing raw Cloud keys with broker-only execution and binding tasks to a pre-existing Cloud appId still need owner confirmation.

## Evidence

Evidence file: `.github/issue-evidence/13774-subagent-context-delivery.md`

Live spawned-agent proof:

- `.github/issue-evidence/13774-live-spawn-proof/LIVE_13774_PROOF.json`
- `.github/issue-evidence/13774-live-spawn-proof/SKILLS.md`
- `.github/issue-evidence/13774-live-spawn-proof/service.log`

The live run used the machine's real Codex login through native ACP. The spawned agent read the generated `SKILLS.md`, wrote `LIVE_13774_PROOF.json`, and emitted `task_complete`; the artifacts above were manually reviewed and exclude auth/cache files.

Passed after rebasing onto latest `origin/develop`:

```bash
bun test \
  ./plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts \
  ./plugins/plugin-agent-orchestrator/src/__tests__/skill-manifest.test.ts \
  ./plugins/plugin-agent-orchestrator/src/__tests__/parent-context-routes.test.ts

bunx @biomejs/biome check <14 touched files/evidence files>

git diff --check -- <scoped touched files/evidence files>
```

Result: 19 tests passed, 0 failed.

Blocked in this sparse checkout:

```bash
bun install
bun run --cwd plugins/plugin-agent-orchestrator typecheck
```

`bun install` fails because this sparse worktree lacks several workspace paths now listed by root `package.json` (`packages/security/soc2-verify`, benchmark packages, cloud packages, and cloud test packages). The package typecheck likewise fails before completion because this sparse checkout lacks workspace/dependency materialization, including `@elizaos/auth/*`, `coding-agent-adapters`, `git-workspace-service`, `ai`, `file-type`, and `dotenv`. After the patch-specific fixes, the focused tests and touched-file checks pass.

N/A:

- Screenshots/video: no UI surface changed.
