### PR TITLE
fix(#13773): reclaim ACP scratch dirs on teardown + startup GC (slice of #13773, epic #13766)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/scratch-dir-gc.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/scratch-dir-gc.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression coverage for the ACP scratch-dir disk leak (issue #13773): every
+ * isolated spawn mkdirs `<scratchRoot>/task-<sessionId>` and nothing ever
+ * reclaimed it. Drives the REAL AcpService teardown (closeSession/stopSession)
+ * and the REAL startup GC (gcOrphanedScratchDirs) against a real in-memory
+ * session store, with the scratch root pointed at a per-test tmp dir via the
+ * production ELIZA_ACP_WORKSPACE_ROOT knob. No subprocesses are spawned.
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AcpService } from "../services/acp-service.js";
+import { InMemorySessionStore } from "../services/session-store.js";
+import type { SessionInfo, SessionStatus } from "../services/types.js";
+import { isIsolatedScratchDir } from "../services/workspace-lifecycle.js";
+
+function makeRuntime(settings: Record<string, string>): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-4000-8000-0000000acpgc",
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    getSetting: (key: string) => settings[key],
+    reportError() {},
+  } as never;
+}
+
+function makeSession(
+  id: string,
+  workdir: string,
+  status: SessionStatus = "ready",
+): SessionInfo {
+  const now = new Date();
+  return {
+    id,
+    name: id,
+    agentType: "elizaos",
+    workdir,
+    status,
+    approvalPreset: "approve-all",
+    createdAt: now,
+    lastActivityAt: now,
+  };
+}
+
+async function makeDirWithFile(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "artifact.txt"), "sub-agent scratch output");
+}
+
+describe("ACP scratch-dir reclamation (#13773)", () => {
+  let root: string;
+  let store: InMemorySessionStore;
+  let service: AcpService;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "acp-scratch-gc-"));
+    store = new InMemorySessionStore();
+    // ELIZA_ACP_WORKSPACE_ROOT is the production knob; setting it makes the
+    // service's scratch-root set exactly [root] (DEFAULT_WORKDIR_ROOT is
+    // excluded when this key is set), so the GC scan is confined to the tmp dir.
+    service = new AcpService(makeRuntime({ ELIZA_ACP_WORKSPACE_ROOT: root }), {
+      store,
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("removes an isolated session's scratch dir on closeSession, and leaves a non-isolated workdir alone", async () => {
+    // Owned isolated dir: basename `task-<id>` directly under the scratch root.
+    const isolatedId = randomUUID();
+    const isolatedDir = join(root, `task-${isolatedId}`);
+    await makeDirWithFile(isolatedDir);
+    await store.create(makeSession(isolatedId, isolatedDir));
+
+    // Non-isolated workdir: a self-checkout-style dir whose basename is NOT
+    // `task-<id>` — the guard must refuse to touch it.
+    const selfCheckoutId = randomUUID();
+    const selfCheckoutDir = join(root, "my-real-project");
+    await makeDirWithFile(selfCheckoutDir);
+    await store.create(makeSession(selfCheckoutId, selfCheckoutDir));
+
+    expect(existsSync(isolatedDir)).toBe(true);
+
+    await service.closeSession(isolatedId);
+    // stopSession is the public alias; it routes through closeSession.
+    await service.stopSession(selfCheckoutId);
+
+    expect(existsSync(isolatedDir)).toBe(false);
+    // The non-isolated workdir and its contents survive untouched.
+    expect(existsSync(selfCheckoutDir)).toBe(true);
+    expect(await readFile(join(selfCheckoutDir, "artifact.txt"), "utf8")).toBe(
+      "sub-agent scratch output",
+    );
+  });
+
+  it("never authorizes removing process.cwd() or a dir outside the scratch roots", () => {
+    const id = randomUUID();
+    // cwd is refused even if it somehow carried the task basename.
+    expect(isIsolatedScratchDir(process.cwd(), id, [root])).toBe(false);
+    // A correctly-named dir under an UNlisted root is refused.
+    expect(
+      isIsolatedScratchDir(join("/some/other/root", `task-${id}`), id, [root]),
+    ).toBe(false);
+    // A dir whose basename belongs to a DIFFERENT session id is refused.
+    expect(
+      isIsolatedScratchDir(join(root, `task-${randomUUID()}`), id, [root]),
+    ).toBe(false);
+    // The exact owned shape is accepted.
+    expect(isIsolatedScratchDir(join(root, `task-${id}`), id, [root])).toBe(
+      true,
+    );
+  });
+
+  it("startup GC reclaims orphaned task dirs with no live session while sparing live sessions and non-task dirs", async () => {
+    const orphanId = randomUUID();
+    const liveId = randomUUID();
+    const orphanDir = join(root, `task-${orphanId}`);
+    const liveDir = join(root, `task-${liveId}`);
+    const realProjectDir = join(root, "checked-out-repo");
+
+    await makeDirWithFile(orphanDir);
+    await makeDirWithFile(liveDir);
+    await makeDirWithFile(realProjectDir);
+
+    // Only the live session is registered, and it is mid-flight (non-terminal).
+    await store.create(makeSession(liveId, liveDir, "running"));
+
+    const removed = await service.gcOrphanedScratchDirs();
+
+    expect(removed).toBe(1);
+    expect(existsSync(orphanDir)).toBe(false);
+    // Live session's dir is protected.
+    expect(existsSync(liveDir)).toBe(true);
+    // A non-`task-` dir (a real checkout that happens to sit under the root) is
+    // never a GC candidate.
+    expect(existsSync(realProjectDir)).toBe(true);
+  });
+
+  it("startup GC treats a terminal session's leftover dir as reclaimable (SIGKILL-mid-teardown survivor)", async () => {
+    // A session that reached a terminal status but whose dir was never removed
+    // (process was SIGKILLed before reclaimSessionScratchDir ran).
+    const terminalId = randomUUID();
+    const terminalDir = join(root, `task-${terminalId}`);
+    await makeDirWithFile(terminalDir);
+    await store.create(makeSession(terminalId, terminalDir, "errored"));
+
+    const removed = await service.gcOrphanedScratchDirs();
+
+    expect(removed).toBe(1);
+    expect(existsSync(terminalDir)).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -19,7 +19,7 @@ import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readdir, stat, unlink } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import {
   SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE as CORE_SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE,
   type IAgentRuntime,
@@ -87,6 +87,11 @@ import {
   TERMINAL_SESSION_STATUSES,
 } from "./types.js";
 import { captureBaselineDirty, captureBaselineSha } from "./workspace-diff.js";
+import {
+  isIsolatedScratchDir,
+  reclaimOrphanedScratchDirs,
+  removeScratchDir,
+} from "./workspace-lifecycle.js";
 
 type RuntimeLike = IAgentRuntime & {
   logger?: Partial<
@@ -376,6 +381,7 @@ export class AcpService extends Service {
     await this.reconcileOrphanedSessions();
     await this.cleanReverseOrphanedAcpxFiles();
     await this.cleanStaleLocks();
+    await this.gcOrphanedScratchDirs();
     this.healthCheckTimer = setInterval(() => {
       void this.runHealthCheck();
     }, ACP_HEALTH_CHECK_INTERVAL_MS);
@@ -692,6 +698,88 @@ export class AcpService extends Service {
 
   private async hasAcpxSessionState(acpxSessionId: string): Promise<boolean> {
     return (await this.acpxSessionStateStat(acpxSessionId)).exists;
+  }
+
+  // The roots under which spawnSession may place a per-session `task-<id>`
+  // scratch dir. Kept in exact lockstep with where spawns actually land: the
+  // DIRECT-caller precedence (ELIZA_ACP_WORKSPACE_ROOT ?? ACPX_DEFAULT_CWD ??
+  // DEFAULT_WORKDIR_ROOT) plus the extra roots the orchestrated resolver
+  // (resolveDefaultSpawnWorkdir) may land on. DEFAULT_WORKDIR_ROOT is included
+  // ONLY when neither of the two DIRECT-caller keys is set — otherwise spawns
+  // never fall back to it, and scanning it would let an empty store reclaim
+  // another live orchestrator's scratch dirs. A workdir is only ever reclaimable
+  // when it is a DIRECT `task-<id>` child of one of these — never a cwd
+  // self-checkout or a caller-chosen repo.
+  private acpScratchRoots(): string[] {
+    const acpRoot = this.setting("ELIZA_ACP_WORKSPACE_ROOT")?.trim();
+    const acpxCwd = this.setting("ACPX_DEFAULT_CWD")?.trim();
+    const roots = [
+      acpRoot,
+      acpxCwd,
+      this.setting("ELIZA_WORKSPACE_DIR")?.trim(),
+      this.setting("ELIZA_CODING_WORKSPACE")?.trim(),
+      this.setting("ELIZA_CODING_DIRECTORY")?.trim(),
+    ].filter((value): value is string => Boolean(value));
+    if (!acpRoot && !acpxCwd) roots.push(DEFAULT_WORKDIR_ROOT);
+    return roots;
+  }
+
+  // Remove a terminal session's isolated scratch dir. spawnSession mkdirs a
+  // fresh `<scratchRoot>/task-<id>` for every isolated spawn and nothing ever
+  // reclaimed it, so each completed sub-agent leaked its scratch tree forever
+  // (issue #13773). Guarded twice: isIsolatedScratchDir proves the dir is this
+  // service's own per-session dir, and removeScratchDir re-checks it sits under
+  // the root. A non-isolated workdir (self-checkout / explicit dir) is a no-op.
+  private async reclaimSessionScratchDir(session: SessionInfo): Promise<void> {
+    if (!session.workdir) return;
+    if (
+      !isIsolatedScratchDir(session.workdir, session.id, this.acpScratchRoots())
+    ) {
+      return;
+    }
+    await removeScratchDir(
+      session.workdir,
+      dirname(resolve(session.workdir)),
+      (msg) => this.log("debug", msg),
+    );
+  }
+
+  /**
+   * Reclaim per-session scratch dirs orphaned by a SIGKILL that hit mid-teardown
+   * (the terminal-event removal in reclaimSessionScratchDir never ran). Runs on
+   * service start after session reconciliation, so a session reconciled to a
+   * terminal status counts as non-live and its dir is reclaimed here. Only
+   * `task-<id>` dirs whose id is not a currently-live session are removed.
+   */
+  async gcOrphanedScratchDirs(): Promise<number> {
+    let liveIds: Set<string>;
+    try {
+      const sessions = await this.store.list();
+      liveIds = new Set(
+        sessions
+          .filter((s) => !TERMINAL_SESSION_STATUSES.has(s.status))
+          .map((s) => s.id),
+      );
+    } catch (err) {
+      // error-policy:J7 store read failed; skip this GC pass rather than risk
+      // treating a live session's dir as orphaned. Next startup retries.
+      this.runtime.reportError("AcpService.gcOrphanedScratchDirs", err, {
+        phase: "store.list",
+      });
+      this.log("warn", "scratch GC skipped: store read failed", { err });
+      return 0;
+    }
+    const removed = await reclaimOrphanedScratchDirs(
+      this.acpScratchRoots(),
+      (id) => liveIds.has(id),
+      (msg) => this.log("info", msg),
+    );
+    if (removed > 0) {
+      this.log("info", "scratch GC reclaimed orphaned session dirs", {
+        removed,
+      });
+    }
+    return removed;
   }
 
   async spawnSession(opts: SpawnOptions): Promise<SpawnResult> {
@@ -1112,6 +1200,7 @@ export class AcpService extends Service {
           this.nativeStoppingSessionIds.delete(sessionId);
         }
       }
+      await this.reclaimSessionScratchDir(session);
       return;
     }
     await this.stopTrackedProcess(sessionId);
@@ -1137,6 +1226,7 @@ export class AcpService extends Service {
       sessionId,
       response: this.lastOutput(sessionId),
     });
+    await this.reclaimSessionScratchDir(session);
   }
 
   async deleteSession(sessionId: string): Promise<void> {

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-lifecycle.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-lifecycle.ts
@@ -104,3 +104,74 @@ export async function gcOrphanedWorkspaces(
     );
   }
 }
+
+/**
+ * True only for an isolated per-session scratch dir the AcpService itself
+ * created: `spawnSession` names an isolated workdir exactly `task-<sessionId>`
+ * (`computeSessionWorkdir` with isolate=true) as a DIRECT child of a scratch
+ * root. A cwd self-checkout, or a route/convention/explicit workdir, never
+ * carries this basename — so this can never authorize removing a user's repo or
+ * the runtime's own checkout. `sessionId` is an unguessable UUID, making the
+ * basename match a strong ownership proof; the root check is defense in depth.
+ */
+export function isIsolatedScratchDir(
+  workdir: string,
+  sessionId: string,
+  scratchRoots: readonly string[],
+): boolean {
+  const resolved = path.resolve(workdir);
+  if (resolved === path.resolve(process.cwd())) return false;
+  if (path.basename(resolved) !== `task-${sessionId}`) return false;
+  const parent = path.dirname(resolved);
+  return scratchRoots.some((root) => path.resolve(root) === parent);
+}
+
+/**
+ * Reclaim per-session `task-<id>` scratch dirs left behind when a SIGKILL hit
+ * mid-teardown so the terminal-event removal never ran. Scans each scratch root
+ * and removes every `task-<id>` child whose id is not currently live; a
+ * non-`task-` entry is never considered, so a configured root that also holds
+ * real project checkouts is safe. Returns the number of dirs reclaimed.
+ */
+export async function reclaimOrphanedScratchDirs(
+  scratchRoots: readonly string[],
+  isLiveSessionId: (id: string) => boolean,
+  log: (msg: string) => void,
+): Promise<number> {
+  const prefix = "task-";
+  let removed = 0;
+  const scanned = new Set<string>();
+  for (const root of scratchRoots) {
+    const resolvedRoot = path.resolve(root);
+    if (scanned.has(resolvedRoot)) continue;
+    scanned.add(resolvedRoot);
+
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(resolvedRoot, {
+        withFileTypes: true,
+      });
+    } catch {
+      // error-policy:J4 root absent (readdir failed) → nothing to reclaim; designed no-op
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !entry.name.startsWith(prefix)) continue;
+      const id = entry.name.slice(prefix.length);
+      if (id.length === 0 || isLiveSessionId(id)) continue;
+      const dir = path.join(resolvedRoot, entry.name);
+      // Re-validate through the same ownership guard the teardown path uses.
+      if (!isIsolatedScratchDir(dir, id, [resolvedRoot])) continue;
+      try {
+        await fs.promises.rm(dir, { recursive: true, force: true });
+        removed++;
+        log(`Startup scratch GC: reclaimed orphaned session dir ${dir}`);
+      } catch (err) {
+        // error-policy:J6 best-effort orphan reclaim; per-dir rm failure is logged and skipped so the scan continues
+        log(`Startup scratch GC: failed to remove ${dir}: ${err}`);
+      }
+    }
+  }
+  return removed;
+}


### PR DESCRIPTION
## Slice of #13773 (epic #13766) — the direct disk-leak fix

`AcpService.spawnSession` mkdirs `<scratchRoot>/task-<sessionId>` for every isolated spawn (`src/services/acp-service.ts` `computeSessionWorkdir` + `mkdir`), but **no teardown path ever removed it**: `closeSession` / `deleteSession` / `stopSession` do zero `fs.rm` on `session.workdir`, and the health sweep only reclaims DB rows + in-memory maps (`sweepStale`). Every spawned sub-agent leaked its scratch tree permanently — the 3.6TB-class disk leak. There was no TTL and no startup GC.

This slice implements the two behaviors that stop and recover the leak, and nothing else.

### What changed
- **Terminal-event teardown removal** — `reclaimSessionScratchDir(session)` is called at the end of both transport branches of `closeSession`, which is the chokepoint for stop / delete / initial-task-complete teardown (`stopSession → closeSession`, `deleteSession → closeSession`, `closeInitialTaskSession → closeSession` — the latter fires for **every** completed spawned sub-agent's initial task, i.e. the dominant leak path).
- **Startup orphan GC** — `gcOrphanedScratchDirs()` runs in `start()` after session reconciliation. It scans the scratch roots and removes any `task-<id>` dir whose id is **not** a currently-live (non-terminal) session — reclaiming dirs leaked by a SIGKILL that hit mid-teardown, and dirs of sessions reconciled-to-errored on this boot.
- **Guards (mirrors `gcOrphanedWorkspaces` safety)** — new pure helpers in `workspace-lifecycle.ts`:
  - `isIsolatedScratchDir(workdir, sessionId, roots)` returns true **only** for a `task-<sessionId>` dir that is a DIRECT child of a known scratch root, and **never** for `process.cwd()`. `sessionId` is an unguessable UUID, so the basename match is a strong ownership proof; the under-root check is defense-in-depth. This can never authorize removing a cwd self-checkout, the runtime's own checkout, or a caller-chosen repo.
  - `reclaimOrphanedScratchDirs(roots, isLive, log)` only ever considers `task-` entries, so a configured root that also holds real project checkouts is safe.
  - `acpScratchRoots()` tracks exactly where spawns land; `DEFAULT_WORKDIR_ROOT` (`$TMPDIR/eliza-acp`) is scanned **only** when neither `ELIZA_ACP_WORKSPACE_ROOT` nor `ACPX_DEFAULT_CWD` is set, so an empty store can't reclaim another live orchestrator's dirs.
- `removeScratchDir` (existing, J6-annotated) does the actual guarded `fs.rm`, so removal goes through the same vetted safety net.

### Real regression test (no larp)
`src/__tests__/scratch-dir-gc.test.ts` drives the **real** `AcpService.closeSession` / `stopSession` / `gcOrphanedScratchDirs` against a **real** `InMemorySessionStore`, with the scratch root pointed at a per-test `mkdtemp` dir via the production `ELIZA_ACP_WORKSPACE_ROOT` knob. No subprocesses are spawned. It asserts: owned `task-<id>` dir removed on `closeSession`; a non-isolated workdir left untouched; `process.cwd()` / outside-root / wrong-id all refused by the guard; startup GC reclaims an orphan while sparing a live session's dir and a non-`task-` real checkout; a terminal (errored) session's leftover dir is reclaimable.

**Fail-before** (fix temporarily neutered — teardown reclaim and GC made no-ops):
```
FAIL  ... removes an isolated session's scratch dir on closeSession ...
  expect(existsSync(isolatedDir)).toBe(false)   // dir still present
FAIL  ... startup GC reclaims orphaned task dirs ...   expected +0 to be 1
FAIL  ... startup GC treats a terminal session's leftover dir as reclaimable ...   expected +0 to be 1
 Tests  3 failed | 1 passed (4)   (the 1 pass is the pure-guard test, independent of the neutered methods)
```
**Pass-after** (fix in place):
```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```
Adjacent existing suites still green: `follow-up-account-pinning` + `workdir-routes` → 28 passed. Biome clean on all touched files. Package typecheck shows only pre-existing env `@types` resolution errors in `packages/core` / `packages/logger` (symlinked-deps worktree limitation) — zero in the touched files.

### Deferred to follow-up (explicitly NOT in this slice)
Per the issue's marked design-decision parts and the epic:
- **#13773 item 2** — unifying scratch-dir mechanisms A+B+C into one registry.
- **#13773 item 3** — same-repo git-index isolation.
- **#13773 item 4** — disk backpressure / LRU eviction.
- **#13773 item 5** — dependency-install strategy.
- **#13773 item 6b** — the 5-concurrent-agents index-corruption test.
- In-process reclamation on `cancelSession` / error-path terminal transitions and retention-sweep dir cleanup were intentionally left out to avoid the reattach-after-cancel work-loss edge and keep the slice tight; those terminal dirs are reclaimed by the startup GC on next boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
