### PR TITLE
fix(#13624): gate audit:cloud + window-scoped desktop capture + de-hardcode capture port

### DIFF
--- a/.github/workflows/cloud-aesthetic-audit.yml
+++ b/.github/workflows/cloud-aesthetic-audit.yml
@@ -1,0 +1,92 @@
+name: Cloud Aesthetic Audit
+
+# Walk EVERY registered Eliza Cloud route (dashboard, payment, auth, admin, …) at
+# desktop + mobile against the deterministic keyless stub stack with the
+# test-auth shell baked into the renderer, capture rest + hover screenshots, run
+# the blank/one-color analyzer + brand-color (no-blue / orange-hover) checks, and
+# write per-view verdicts + a contact sheet + report.json.
+#
+# This is the cloud-surface twin of `app-aesthetic-audit.yml`. Until it existed
+# `audit:cloud` ran in NO CI lane and was a pure reporter — a `broken`/`needs-work`
+# cloud page failed nothing, and a turbo-cached renderer built WITHOUT the
+# test-auth shell made the whole suite skip green with ZERO pages walked (#13624,
+# the same class #9304 fixed for audit:app).
+#
+# Under `ELIZA_AUDIT_CLOUD_STRICT=1` (+ CI auto-on) the audit is a GATE: an
+# undebted `broken` view fails; a missing auth shell or an empty walk is a HARD
+# FAILURE, not a skip. A CLEAN renderer rebuild with VITE_PLAYWRIGHT_TEST_AUTH
+# baked in guarantees the shell is present regardless of the turbo cache.
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "packages/app/**"
+      - "packages/ui/**"
+      - "packages/shared/**"
+      - "packages/cloud/**"
+      - ".github/workflows/cloud-aesthetic-audit.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: cloud-aesthetic-audit-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  BUN_VERSION: "canary"
+  NODE_VERSION: "24.15.0"
+
+jobs:
+  cloud-aesthetic-audit:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      # Keyless: the ui-smoke stub is forced when CI=true (shouldForceStubStack).
+      ELIZA_UI_SMOKE_FORCE_STUB: "1"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+
+      # Force a clean renderer build with the test-auth shell baked in. A stale
+      # dist (built without VITE_PLAYWRIGHT_TEST_AUTH) is the exact #13624 hole —
+      # remove it so the audit cannot walk a shell-less bundle.
+      - name: Clean renderer dist
+        run: rm -rf packages/app/dist
+
+      - name: Run cloud aesthetic audit (strict)
+        # audit:cloud sets VITE_PLAYWRIGHT_TEST_AUTH=true, so the build:web it
+        # triggers bakes the shell. ELIZA_AUDIT_CLOUD_STRICT=1 turns the reporter
+        # into a gate: undebted `broken` fails, missing shell / empty walk fails.
+        env:
+          ELIZA_AUDIT_CLOUD_STRICT: "1"
+        run: bun run --cwd packages/app audit:cloud
+
+      - name: Upload cloud aesthetic-audit artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: cloud-aesthetic-audit-output
+          path: packages/app/aesthetic-audit-output-cloud
+          retention-days: 14
+          if-no-files-found: ignore

--- a/packages/app-core/platforms/electrobun/src/screenshot-dev-server.ts
+++ b/packages/app-core/platforms/electrobun/src/screenshot-dev-server.ts
@@ -4,8 +4,11 @@
  * **Why separate HTTP in Electrobun:** the the app API process cannot capture the desktop; capture
  * runs in the shell process via ScreenCaptureManager → OS tools (e.g. macOS `screencapture`).
  *
- * **Why full screen (for now):** reuses battle-tested `takeScreenshot()`; window-ID capture is
- * platform-specific and not wired here yet.
+ * **Window-scoped when possible:** to keep other windows/cursor/desktop out of agent evidence,
+ * the endpoint prefers `captureWindow({ windowId })` (macOS `screencapture -l <id>`) when an Eliza
+ * window id is resolvable via ELIZA_SCREENSHOT_WINDOW_ID (or an optional `?window=<id>`). When no
+ * window id is available — or window capture is unavailable/errors — it falls back to full-screen
+ * `takeScreenshot()`, preserving prior behavior.
  *
  * **Why loopback + optional token:** reduces accidental exposure on shared machines; dev-platform
  * generates a session token and the API proxy adds a single URL on the familiar API port.
@@ -13,10 +16,44 @@
  * Enable with ELIZA_DESKTOP_SCREENSHOT_SERVER=`1` / `true` / `yes` (dev-platform sets `1` by default
  * for `dev:desktop:*`). Port: ELIZA_SCREENSHOT_SERVER_PORT (default 31339). Auth: ELIZA_SCREENSHOT_SERVER_TOKEN
  * as Bearer header only (query params not supported to avoid token leakage in logs/Referer).
+ * Window capture: ELIZA_SCREENSHOT_WINDOW_ID (window id), ELIZA_SCREENSHOT_SETTLE_MS (frontmost/paint
+ * settle delay before window capture, default 400ms).
  */
 
 import http from "node:http";
-import { getScreenCaptureManager } from "./native/screencapture";
+import {
+  getScreenCaptureManager,
+  type ScreenshotCaptureResult,
+} from "./native/screencapture";
+
+/**
+ * Resolve the Eliza window id for window-scoped capture. Prefers the env var
+ * (set by the dev-platform when it knows the native window id); falls back to
+ * an optional `?window=<id>` query param.
+ *
+ * Query params are forbidden for *tokens* here (secrets leak via logs/Referer),
+ * but a window id is NOT a secret — it is a non-sensitive OS window handle — so
+ * accepting it as a query param is acceptable.
+ */
+function resolveWindowId(u: URL): string | undefined {
+  const fromEnv = process.env.ELIZA_SCREENSHOT_WINDOW_ID?.trim();
+  if (fromEnv) return fromEnv;
+  const fromQuery = u.searchParams.get("window")?.trim();
+  return fromQuery ? fromQuery : undefined;
+}
+
+/**
+ * Best-effort settle before window capture so the Eliza window is frontmost and
+ * painted. ScreenCaptureManager exposes no activate/frontmost hook, so this is a
+ * small fixed delay (overridable via ELIZA_SCREENSHOT_SETTLE_MS). darwin only —
+ * other platforms fall back to full-screen capture inside captureWindow anyway.
+ */
+async function settleBeforeWindowCapture(): Promise<void> {
+  if (process.platform !== "darwin") return;
+  const raw = Number(process.env.ELIZA_SCREENSHOT_SETTLE_MS);
+  const ms = Number.isFinite(raw) && raw >= 0 ? raw : 400;
+  if (ms > 0) await new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 function isLoopback(addr: string | undefined): boolean {
   return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
@@ -66,7 +103,38 @@ export function startScreenshotDevServer(): (() => void) | undefined {
         }
       }
 
-      const shot = await getScreenCaptureManager().takeScreenshot();
+      const manager = getScreenCaptureManager();
+      const windowId = resolveWindowId(u);
+      let shot: ScreenshotCaptureResult;
+      if (windowId) {
+        await settleBeforeWindowCapture();
+        try {
+          const windowShot = await manager.captureWindow({ windowId });
+          if (windowShot.available && windowShot.data) {
+            console.log(
+              `[ScreenshotDev] window-scoped capture (windowId=${windowId})`,
+            );
+            shot = windowShot;
+          } else {
+            console.warn(
+              `[ScreenshotDev] window capture unavailable (windowId=${windowId}); falling back to full screen`,
+            );
+            shot = await manager.takeScreenshot();
+          }
+        } catch (err) {
+          console.warn(
+            `[ScreenshotDev] window capture threw (windowId=${windowId}); falling back to full screen: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+          shot = await manager.takeScreenshot();
+        }
+      } else {
+        console.log(
+          "[ScreenshotDev] full-screen capture (no window id resolvable)",
+        );
+        shot = await manager.takeScreenshot();
+      }
       if (!shot.available || !shot.data) {
         res.writeHead(503, {
           "Content-Type": "application/json; charset=utf-8",

--- a/packages/app-core/platforms/electrobun/src/screenshot-dev-server.ts
+++ b/packages/app-core/platforms/electrobun/src/screenshot-dev-server.ts
@@ -21,6 +21,7 @@
  */
 
 import http from "node:http";
+import { logger } from "./logger";
 import {
   getScreenCaptureManager,
   type ScreenshotCaptureResult,
@@ -111,18 +112,18 @@ export function startScreenshotDevServer(): (() => void) | undefined {
         try {
           const windowShot = await manager.captureWindow({ windowId });
           if (windowShot.available && windowShot.data) {
-            console.log(
+            logger.info(
               `[ScreenshotDev] window-scoped capture (windowId=${windowId})`,
             );
             shot = windowShot;
           } else {
-            console.warn(
+            logger.warn(
               `[ScreenshotDev] window capture unavailable (windowId=${windowId}); falling back to full screen`,
             );
             shot = await manager.takeScreenshot();
           }
         } catch (err) {
-          console.warn(
+          logger.warn(
             `[ScreenshotDev] window capture threw (windowId=${windowId}); falling back to full screen: ${
               err instanceof Error ? err.message : String(err)
             }`,
@@ -130,7 +131,7 @@ export function startScreenshotDevServer(): (() => void) | undefined {
           shot = await manager.takeScreenshot();
         }
       } else {
-        console.log(
+        logger.info(
           "[ScreenshotDev] full-screen capture (no window id resolvable)",
         );
         shot = await manager.takeScreenshot();
@@ -167,14 +168,14 @@ export function startScreenshotDevServer(): (() => void) | undefined {
   });
 
   if (!token) {
-    console.warn(
+    logger.warn(
       "[ScreenshotDev] No ELIZA_SCREENSHOT_SERVER_TOKEN set — screenshot endpoint is unprotected on loopback",
     );
   }
 
   server.on("error", (err: NodeJS.ErrnoException) => {
     const inUse = err.code === "EADDRINUSE";
-    console.warn(
+    logger.warn(
       `[ScreenshotDev] Failed to start loopback server on 127.0.0.1:${port}: ${err.message}` +
         (inUse
           ? " (port in use — set ELIZA_SCREENSHOT_SERVER_PORT to a free port or stop the other process)"
@@ -183,7 +184,7 @@ export function startScreenshotDevServer(): (() => void) | undefined {
   });
 
   server.listen(port, "127.0.0.1", () => {
-    console.log(
+    logger.info(
       `[ScreenshotDev] http://127.0.0.1:${port}/cursor-screenshot.png (loopback only` +
         (token ? "; token required" : "") +
         ")",

--- a/packages/app/scripts/capture-ios-sim.mjs
+++ b/packages/app/scripts/capture-ios-sim.mjs
@@ -11,6 +11,7 @@
 //   --duration <seconds>     recording length (default 6)
 import { execFileSync, spawn } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
+import { resolveApiPort } from "../../../scripts/e2e-recordings/native-capture-common.mjs";
 import {
   captureBackendLog,
   evidenceBaseName,
@@ -112,7 +113,15 @@ async function main() {
     log("recording produced no file (simulator finalize failed)");
   }
 
-  const logPath = captureBackendLog(base);
+  // Backend-log port: an explicit `--api-port <n>` wins (shared resolver, keeps
+  // 31337 as the final fallback); otherwise captureBackendLog keeps resolving
+  // from ELIZA_API_PORT / ELIZA_PORT so port-shifted parallel stacks still work.
+  const logPath =
+    flags["api-port"] !== undefined
+      ? captureBackendLog(base, {
+          port: resolveApiPort(process.argv.slice(2), process.env),
+        })
+      : captureBackendLog(base);
   log(
     logPath
       ? `backend log → ${logPath}`

--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -7,6 +7,10 @@ import path from "node:path";
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { expect, type Page, test } from "@playwright/test";
 import {
+  type AestheticVerdictDebt,
+  evaluateStrictGate,
+} from "./aesthetic-audit-rules";
+import {
   collectBlueColors,
   collectHoverViolations,
 } from "./helpers/brand-color-scans";
@@ -54,6 +58,26 @@ import {
 const TEST_AUTH_ENABLED =
   process.env.VITE_PLAYWRIGHT_TEST_AUTH === "true" ||
   process.env.NEXT_PUBLIC_PLAYWRIGHT_TEST_AUTH === "true";
+
+// Strict gate (#13624), mirroring the app audit (#9304/#10710). Without this the
+// cloud audit was a pure reporter — a `broken`/`needs-work` cloud page failed
+// nothing, and a turbo-cached renderer built WITHOUT the test-auth shell made
+// the whole suite skip green with ZERO pages walked. Under strict the audit is a
+// GATE: an undebted `broken` view fails; with the opt-in needs-work extension an
+// undebted `needs-work` fails too; a missing auth-shell or an empty walk is a
+// HARD FAILURE, not a skip.
+const AUDIT_CLOUD_STRICT = process.env.ELIZA_AUDIT_CLOUD_STRICT === "1";
+const AUDIT_CLOUD_STRICT_NEEDS_WORK =
+  process.env.ELIZA_AUDIT_CLOUD_STRICT_NEEDS_WORK === "1";
+// When true, the audit must not silently no-op: a dist without the baked
+// test-auth shell, or a run that walks zero pages, reddens instead of skipping.
+// Auto-on under CI so no lane can go green with nothing.
+const REQUIRE_CLOUD_EVIDENCE =
+  AUDIT_CLOUD_STRICT || process.env.CI === "true" || process.env.CI === "1";
+// The (currently empty) allowlist for tolerated cloud aesthetic debt: a
+// `slug-viewport` key set to `broken`/`needs-work` exempts that view. Shrink it
+// over time; a NEW regression on an undebted view fails the run.
+const CLOUD_AESTHETIC_VERDICT_DEBT: AestheticVerdictDebt = {};
 
 const VIEWPORTS = [
   { name: "desktop", width: 1440, height: 900 },
@@ -941,10 +965,41 @@ const findings: CloudPageFinding[] = [];
 const findingsBySlug = new Map<string, CloudPageFinding[]>();
 
 test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
+  // Locally, a renderer without the baked test-auth shell is a skip (dev
+  // convenience). Under strict/CI it is NOT — see the guard test below, which
+  // reddens so the audit can never go green having walked nothing (#13624).
   test.skip(
-    !TEST_AUTH_ENABLED,
+    !TEST_AUTH_ENABLED && !REQUIRE_CLOUD_EVIDENCE,
     "set VITE_PLAYWRIGHT_TEST_AUTH=true (bake it into the renderer build) so StewardProvider renders the local test-auth shell",
   );
+
+  // Hard gate (#13624): under strict/CI the running renderer bundle MUST contain
+  // the test-auth shell. A stale turbo-cached `build:web` (built without
+  // VITE_PLAYWRIGHT_TEST_AUTH) leaves the runtime env set but the shell absent —
+  // every authed route bounces to /login and the audit used to skip green. This
+  // test seeds a Steward token, visits an authed route, and reddens if we were
+  // bounced to the login wall (dist lacks the shell) or the runtime flag is off.
+  test("renderer dist was built with the test-auth shell", async ({ page }) => {
+    test.skip(
+      !REQUIRE_CLOUD_EVIDENCE,
+      "auth-shell hard gate only enforced under ELIZA_AUDIT_CLOUD_STRICT / CI",
+    );
+    expect(
+      TEST_AUTH_ENABLED,
+      "audit:cloud (strict/CI) requires VITE_PLAYWRIGHT_TEST_AUTH=true baked into the renderer build",
+    ).toBe(true);
+    await seedStewardToken(page);
+    await installCloudApiStubs(page);
+    await page.goto("/dashboard/agents", { waitUntil: "domcontentloaded" });
+    // Give StewardProvider a beat to resolve the seeded session (or bounce).
+    await page.waitForTimeout(1_500);
+    expect(
+      page.url(),
+      "authed route bounced to /login — the renderer dist lacks the test-auth " +
+        "shell (stale turbo cache built without VITE_PLAYWRIGHT_TEST_AUTH). " +
+        "Force a clean `build:web` with the flag set.",
+    ).not.toMatch(/\/login(\?|#|$)/);
+  });
 
   const outputDir =
     process.env.ELIZA_AUDIT_CLOUD_DIR ??
@@ -1129,7 +1184,21 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
   }
 
   test.afterAll(async () => {
-    if (findings.length === 0) return;
+    if (findings.length === 0) {
+      // Green-with-nothing guard (#13624): under strict/CI a walk that produced
+      // zero findings means the audit no-opped (skipped auth shell, cached dist,
+      // etc.) — that must redden, not pass silently.
+      if (REQUIRE_CLOUD_EVIDENCE) {
+        throw new Error(
+          "[cloud-aesthetic-audit] STRICT/CI run walked ZERO cloud pages — the " +
+            "audit produced no findings. This is the green-with-nothing hole: the " +
+            "renderer likely lacks the test-auth shell (stale turbo-cached " +
+            "build:web without VITE_PLAYWRIGHT_TEST_AUTH). Rebuild the renderer " +
+            "with the flag set and re-run.",
+        );
+      }
+      return;
+    }
     await mkdir(outputDir, { recursive: true });
     await writeFile(
       path.join(outputDir, "report.json"),
@@ -1156,11 +1225,25 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
     );
     const broken = findings.filter((f) => f.verdict === "broken");
     const needsWork = findings.filter((f) => f.verdict === "needs-work");
+    // Strict gate (#13624): fail on any undebted `broken` (a real crash / blank
+    // render / console error) and, with the opt-in needs-work extension, any
+    // undebted `needs-work` (blue / orange-hover design regression). The pure
+    // evaluateStrictGate is unit-tested; here we just thread the flags + throw.
+    const gate = evaluateStrictGate(findings, CLOUD_AESTHETIC_VERDICT_DEBT, {
+      strict: AUDIT_CLOUD_STRICT,
+      needsWorkStrict: AUDIT_CLOUD_STRICT_NEEDS_WORK,
+    });
     console.log(
       `[cloud-aesthetic-audit] ${findings.length} findings — ` +
         `broken=${broken.length} needs-work=${needsWork.length} ` +
         `needs-eyeball=${findings.filter((f) => f.verdict === "needs-eyeball").length} ` +
-        `good=${findings.filter((f) => f.verdict === "good").length}`,
+        `good=${findings.filter((f) => f.verdict === "good").length} ` +
+        `(strict=${AUDIT_CLOUD_STRICT}, needs-work-strict=${AUDIT_CLOUD_STRICT_NEEDS_WORK}, ` +
+        `undebted-broken=${gate.undebtedBroken.length}, ` +
+        `undebted-needs-work=${gate.undebtedNeedsWork.length})`,
     );
+    if (gate.failed) {
+      throw new Error(gate.message);
+    }
   });
 });

--- a/scripts/e2e-recordings/native-capture-common.mjs
+++ b/scripts/e2e-recordings/native-capture-common.mjs
@@ -20,6 +20,37 @@ export function argValue(args, flag, fallback = null) {
   return index >= 0 && args[index + 1] ? args[index + 1] : fallback;
 }
 
+export const DEFAULT_API_PORT = 31337;
+
+/**
+ * Resolve the backend API port a capture run should target. Precedence:
+ *   1. explicit `--api-port <n>` CLI arg,
+ *   2. `ELIZA_API_PORT` env (the orchestrator advertises the auto-shifted port
+ *      here so parallel worktree stacks don't collide on 31337),
+ *   3. the built-in default (31337).
+ * A bare hardcoded 31337 silently probes the wrong backend on a port-shifted
+ * stack; this resolver keeps the same default while honoring an override
+ * (#13624). Only a bare positive integer in range is accepted; anything else
+ * falls through to the next source.
+ *
+ * @param {string[]} [args] argv slice (e.g. process.argv.slice(2))
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {number}
+ */
+export function resolveApiPort(args = [], env = process.env) {
+  const candidates = [argValue(args, "--api-port"), env?.ELIZA_API_PORT];
+  for (const raw of candidates) {
+    if (typeof raw !== "string") continue;
+    const trimmed = raw.trim();
+    if (!/^\d+$/.test(trimmed)) continue;
+    const parsed = Number.parseInt(trimmed, 10);
+    if (Number.isInteger(parsed) && parsed > 0 && parsed <= 65535) {
+      return parsed;
+    }
+  }
+  return DEFAULT_API_PORT;
+}
+
 export function resolveCapturePaths({ repoRoot, platform, slug, args }) {
   const issue = argValue(args, "--issue", process.env.EVIDENCE_ISSUE);
   const prefix =
@@ -121,7 +152,7 @@ async function waitForHealth(url, timeoutMs) {
 
 export async function startDeviceE2EHostAgent({
   repoRoot,
-  port = 31337,
+  port = resolveApiPort(),
   timeoutMs = 180_000,
   logSink,
 }) {


### PR DESCRIPTION
Closes #13624

## What & why

Closes the remaining half of #13624 — the capture/evidence tooling that goes **green with no / stale / wrong-window evidence**. The `--require-evidence` non-zero-on-skip contract (#13727) and the story-gate log-capture wiring (#13735/#13679) already merged; this PR finishes the four still-open task areas.

## Changes

### 1. `audit:cloud` becomes a real gate (was a pure reporter) — task 1
`packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts`
- Imports the shared, unit-tested `evaluateStrictGate` and adds the same strict posture as `audit:app` (#9304/#10710): under `ELIZA_AUDIT_CLOUD_STRICT=1` an **undebted `broken`** cloud page fails the run; with `ELIZA_AUDIT_CLOUD_STRICT_NEEDS_WORK=1` an undebted `needs-work` (blue / orange→black hover) fails too. Empty `CLOUD_AESTHETIC_VERDICT_DEBT` allowlist to shrink over time.
- **Missing auth-shell is now a HARD FAILURE, not a whole-suite skip.** A new guard test seeds a Steward token, visits an authed route, and reddens if we bounce to `/login` (the exact symptom of a stale turbo-cached `build:web` built without `VITE_PLAYWRIGHT_TEST_AUTH` — runtime flag set but shell absent).
- **Zero-findings walk reddens** under strict/CI (the green-with-nothing hole) instead of `return`ing silently.
- Auto-on under `CI` so no lane can go green having walked nothing.

`.github/workflows/cloud-aesthetic-audit.yml` (new) — mirrors `app-aesthetic-audit.yml`: on PRs touching app/ui/shared/cloud, does a **clean renderer rebuild** (`rm -rf packages/app/dist`) with the test-auth shell baked in, runs `audit:cloud` with `ELIZA_AUDIT_CLOUD_STRICT=1`, uploads `aesthetic-audit-output-cloud`. This is the CI lane #13624 asked for and the vehicle for the red→green proof.

### 2. Electrobun `/cursor-screenshot.png` captures the Eliza window, not the whole desktop — task 5
`packages/app-core/platforms/electrobun/src/{screenshot-dev-server.ts,native/screencapture.ts}` — wires the existing `captureWindow({windowId})` into the dev-server endpoint (window id from `ELIZA_SCREENSHOT_WINDOW_ID` / `?window=`), adds a frontmost/paint settle wait (`ELIZA_SCREENSHOT_SETTLE_MS`), and falls back to full-screen when no window id is resolvable so nothing regresses.

### 3. De-hardcode port 31337 in native capture — task 6
`scripts/e2e-recordings/native-capture-common.mjs`, `packages/app/scripts/capture-ios-sim.mjs` — a single `resolveApiPort/Base(args, env)` reads `--api-port` → `ELIZA_API_PORT` → `31337` fallback, used in both scripts instead of the literal, so a port-shifted stack no longer silently drops the backend-log evidence.

## Verification (real, local)
- `evaluateStrictGate` red→green demonstrated: broken view reddens under strict; a debted view greens; strict-off never fails; needs-work gated only under the opt-in flag; failure message names the offending view. **7/7 assertions pass** (transcript in the issue evidence).
- Cloud spec + workflow are Biome-clean; no new type errors (pre-existing `@types/node`/vitest resolution noise in that tsconfig is unchanged).
- `.mjs` files pass `node --check`; edited `.ts` typecheck clean.
- Full red-on-injected-defect → green Playwright proof runs in the new `cloud-aesthetic-audit.yml` lane (needs a renderer build; that's what the CI lane is for).

## Not in scope
The two capture-script copies (`packages/app/scripts/capture-*.mjs` vs `scripts/e2e-recordings/capture-*.mjs`) are genuinely different tools (lightweight photograph vs. full boot+build+drive), not literal duplicates — the real defect there (a skip going green when evidence is required) is already closed by the merged `--require-evidence` contract, which both paths now honor. Full module consolidation deferred as pure refactor.