### PR TITLE
fix(#13772): typed session-cap error + slot classes + capacity surface (admission-control foundation)

### DIFF
--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -264,6 +264,7 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |
+| `ELIZA_ACP_SYSTEM_SESSION_HEADROOM` | `2` | Reserved concurrent slots for short-lived `system` spawns (the #8898 read-only verifier), counted separately from `ELIZA_ACP_MAX_SESSIONS` so validation never deadlocks behind the worker cap |
 | `ELIZA_MAX_SPAWNS_PER_ORIGIN` | `3` | Max sub-agent spawns per root user message before relaying the best captured result instead of re-spawning (bounds the weak-model re-spawn loop) |
 | `ELIZA_ACP_STATE_DIR` | `~/.eliza/plugin-acp` | Session state persistence dir when no runtime DB |
 | `ELIZA_ACP_SESSION_STORE_BACKEND` | unset | Override session store backend (`db`, `file`, or `memory`) |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -264,6 +264,7 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |
+| `ELIZA_ACP_SYSTEM_SESSION_HEADROOM` | `2` | Reserved concurrent slots for short-lived `system` spawns (the #8898 read-only verifier), counted separately from `ELIZA_ACP_MAX_SESSIONS` so validation never deadlocks behind the worker cap |
 | `ELIZA_MAX_SPAWNS_PER_ORIGIN` | `3` | Max sub-agent spawns per root user message before relaying the best captured result instead of re-spawning (bounds the weak-model re-spawn loop) |
 | `ELIZA_ACP_STATE_DIR` | `~/.eliza/plugin-acp` | Session state persistence dir when no runtime DB |
 | `ELIZA_ACP_SESSION_STORE_BACKEND` | unset | Override session store backend (`db`, `file`, or `memory`) |

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -14,9 +14,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // form so the same source compares correctly on both POSIX and Windows.
 const RESOLVED_ACP_WORKDIR = path.resolve("/tmp/acp-test");
 
-import type {
-  AcpJsonRpcMessage,
-  ApprovalPreset,
+import {
+  type AcpJsonRpcMessage,
+  type ApprovalPreset,
+  SessionCapError,
 } from "../../src/services/types.js";
 
 type NativeEventHandler = (
@@ -1931,14 +1932,17 @@ describe("AcpService.runHealthCheck state_lost guards", () => {
 
     const fulfilled = results.filter((r) => r.status === "fulfilled");
     const rejected = results.filter((r) => r.status === "rejected");
-    // The cap must hold exactly: 2 succeed, the rest reject with the limit error.
+    // The cap must hold exactly: 2 succeed, the rest reject with the typed
+    // SessionCapError so a caller (or the admission queue) branches on `code`
+    // instead of string-matching the message.
     expect(fulfilled).toHaveLength(2);
     expect(rejected.length).toBe(4);
     for (const r of rejected) {
-      expect((r as PromiseRejectedResult).reason).toBeInstanceOf(Error);
-      expect(((r as PromiseRejectedResult).reason as Error).message).toContain(
-        "max session limit reached",
-      );
+      const reason = (r as PromiseRejectedResult).reason as SessionCapError;
+      expect(reason).toBeInstanceOf(SessionCapError);
+      expect(reason.code).toBe("SESSION_CAP_REACHED");
+      expect(reason.slotClass).toBe("worker");
+      expect(reason.maxSessions).toBe(2);
     }
 
     // And the store agrees: only 2 active sessions exist.
@@ -1948,6 +1952,118 @@ describe("AcpService.runHealthCheck state_lost guards", () => {
         !["stopped", "errored", "completed", "cancelled"].includes(s.status),
     );
     expect(active).toHaveLength(2);
+  });
+
+  it("getCapacity reports free/used slots for both admission pools", async () => {
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: undefined,
+        ELIZA_ACP_MAX_SESSIONS: "2",
+        ELIZA_ACP_SYSTEM_SESSION_HEADROOM: "1",
+      }),
+    );
+    await service.start();
+
+    expect(await service.getCapacity()).toEqual({
+      maxSessions: 2,
+      systemHeadroom: 1,
+      activeWorkers: 0,
+      activeSystem: 0,
+      freeWorkerSlots: 2,
+      freeSystemSlots: 1,
+    });
+
+    await service.spawnSession({ name: "w1", workdir: "/tmp/acp-test" });
+    const cap = await service.getCapacity();
+    expect(cap.activeWorkers).toBe(1);
+    expect(cap.freeWorkerSlots).toBe(1);
+    expect(cap.activeSystem).toBe(0);
+    expect(cap.freeSystemSlots).toBe(1);
+  });
+
+  it("admits a system spawn on reserved headroom while the worker cap is full (no verifier deadlock)", async () => {
+    // Reproduces the #8898 verifier deadlock guard: at a full worker cap the
+    // read-only verifier still needs a fresh session while the worker it is
+    // verifying holds its slot. A separate `system` pool must let it in.
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: undefined,
+        ELIZA_ACP_MAX_SESSIONS: "1",
+        ELIZA_ACP_SYSTEM_SESSION_HEADROOM: "1",
+      }),
+    );
+    await service.start();
+
+    // Fill the single worker slot.
+    await service.spawnSession({ name: "worker", workdir: "/tmp/acp-test" });
+
+    // A second worker is rejected — the worker pool is full.
+    await expect(
+      service.spawnSession({ name: "worker-2", workdir: "/tmp/acp-test" }),
+    ).rejects.toMatchObject({
+      code: "SESSION_CAP_REACHED",
+      slotClass: "worker",
+    });
+
+    // But a system spawn is admitted despite the full worker pool: it draws on
+    // the reserved headroom, so validation never deadlocks behind its worker.
+    const verifier = await service.spawnSession({
+      name: "verifier",
+      slotClass: "system",
+      workdir: "/tmp/acp-test",
+    });
+    expect(verifier.sessionId).toBeTruthy();
+
+    // The system pool has its own cap: a second system spawn is rejected.
+    await expect(
+      service.spawnSession({
+        name: "verifier-2",
+        slotClass: "system",
+        workdir: "/tmp/acp-test",
+      }),
+    ).rejects.toMatchObject({
+      code: "SESSION_CAP_REACHED",
+      slotClass: "system",
+    });
+
+    const cap = await service.getCapacity();
+    expect(cap).toMatchObject({
+      activeWorkers: 1,
+      activeSystem: 1,
+      freeWorkerSlots: 0,
+      freeSystemSlots: 0,
+    });
+  });
+
+  it("frees a worker slot for a new spawn once a session reaches a terminal status", async () => {
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: undefined,
+        ELIZA_ACP_MAX_SESSIONS: "1",
+      }),
+    );
+    await service.start();
+
+    const first = await service.spawnSession({
+      name: "w1",
+      workdir: "/tmp/acp-test",
+    });
+    // Cap is full: the next worker is rejected.
+    await expect(
+      service.spawnSession({ name: "w2", workdir: "/tmp/acp-test" }),
+    ).rejects.toBeInstanceOf(SessionCapError);
+
+    // Terminate the first session; its slot must free.
+    await service.stopSession(first.sessionId);
+    expect((await service.getCapacity()).freeWorkerSlots).toBe(1);
+
+    // Now a fresh worker is admitted deterministically.
+    const third = await service.spawnSession({
+      name: "w3",
+      workdir: "/tmp/acp-test",
+    });
+    expect(third.sessionId).toBeTruthy();
+    expect((await service.getCapacity()).activeWorkers).toBe(1);
   });
 
   it("rejects a concurrent prompt for the same native session (TOCTOU #11028)", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-capacity-route.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-capacity-route.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Guards GET /api/orchestrator/capacity on two fronts:
+ *  1. The path template is REGISTERED in the runtime route matcher, so the
+ *     handler is reachable over real HTTP (an unregistered handler 404s).
+ *  2. The handler returns the AcpService.getCapacity() shape, and honestly 503s
+ *     when the ACP service is absent instead of fabricating a healthy count.
+ * Deterministic harness: a hand-built RouteContext, no live subprocess.
+ */
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { handleOrchestratorRoutes } from "../../src/api/orchestrator-routes.js";
+import type { RouteContext } from "../../src/api/route-utils.js";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
+import { codingAgentRoutePlugin } from "../../src/setup-routes.ts";
+import type { AcpCapacity } from "../../src/services/types.js";
+
+function makeService(): OrchestratorTaskService {
+  return new OrchestratorTaskService(
+    {
+      getService: () => null,
+      getSetting: () => undefined,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } as never,
+    { store: new OrchestratorTaskStore({ backend: "memory" }) },
+  );
+}
+
+function ctxWith(
+  service: OrchestratorTaskService,
+  capacity: AcpCapacity | null,
+): RouteContext {
+  return {
+    runtime: {
+      getService: () => service,
+      hasService: () => true,
+      getServiceLoadPromise: () => Promise.resolve(undefined),
+    },
+    acpService: capacity
+      ? { getCapacity: () => Promise.resolve(capacity) }
+      : null,
+    workspaceService: null,
+  } as never;
+}
+
+class CapturingResponse {
+  statusCode = 0;
+  body = "";
+  writeHead(status: number): this {
+    this.statusCode = status;
+    return this;
+  }
+  end(chunk?: string): this {
+    if (chunk !== undefined) this.body = chunk;
+    return this;
+  }
+  json(): Record<string, unknown> {
+    return this.body ? (JSON.parse(this.body) as Record<string, unknown>) : {};
+  }
+}
+
+async function get(ctx: RouteContext): Promise<CapturingResponse> {
+  const req = Object.assign(Readable.from([]), {
+    method: "GET",
+    url: "/api/orchestrator/capacity",
+  }) as unknown as IncomingMessage;
+  const res = new CapturingResponse();
+  const matched = await handleOrchestratorRoutes(
+    req,
+    res as unknown as ServerResponse,
+    "/api/orchestrator/capacity",
+    ctx,
+  );
+  expect(matched).toBe(true);
+  return res;
+}
+
+describe("GET /api/orchestrator/capacity", () => {
+  it("is registered as a runtime route template", () => {
+    const registered = (codingAgentRoutePlugin.routes ?? []).some(
+      (r) => r.type === "GET" && r.path === "/api/orchestrator/capacity",
+    );
+    expect(registered).toBe(true);
+  });
+
+  it("returns the AcpService capacity shape", async () => {
+    const capacity: AcpCapacity = {
+      maxSessions: 8,
+      systemHeadroom: 2,
+      activeWorkers: 8,
+      activeSystem: 1,
+      freeWorkerSlots: 0,
+      freeSystemSlots: 1,
+    };
+    const res = await get(ctxWith(makeService(), capacity));
+    expect(res.statusCode === 0 || res.statusCode === 200).toBe(true);
+    expect(res.json()).toEqual(capacity);
+  });
+
+  it("503s when the ACP service is unavailable (never fabricates a count)", async () => {
+    const res = await get(ctxWith(makeService(), null));
+    expect(res.statusCode).toBe(503);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/common.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/common.ts
@@ -15,6 +15,7 @@ import type {
   UUID,
 } from "@elizaos/core";
 import type {
+  AcpCapacity,
   AcpJsonRpcMessage,
   ApprovalPreset,
   AvailableAgentInfo,
@@ -41,6 +42,8 @@ export interface AcpActionService {
   cancelSession?(sessionId: string): Promise<void>;
   getSessionOutput?(sessionId: string, lines?: number): Promise<string>;
   listSessions(): SessionInfo[] | Promise<SessionInfo[]>;
+  /** Live worker/system slot usage for admission-control back-pressure. */
+  getCapacity?(): Promise<AcpCapacity>;
   getSession(
     sessionId: string,
   ): SessionInfo | undefined | Promise<SessionInfo | null | undefined>;

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -236,6 +236,19 @@ async function dispatchOrchestratorRoutes(
     return true;
   }
 
+  // GET /api/orchestrator/capacity — live session-cap back-pressure: worker and
+  // system slot usage so a client can see whether a spawn would be rejected at
+  // the cap before attempting it.
+  if (method === "GET" && pathname === `${PREFIX}/capacity`) {
+    const acp = ctx.acpService;
+    if (!acp?.getCapacity) {
+      sendServiceUnavailable(res, "ACP service not available");
+      return true;
+    }
+    sendJson(res, await acp.getCapacity());
+    return true;
+  }
+
   // GET /api/orchestrator/accounts — connected coding accounts, selection
   // strategy, and the live sub-agent → account assignment map.
   if (method === "GET" && pathname === `${PREFIX}/accounts`) {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -72,15 +72,18 @@ import { normalizeTaskAgentAdapter } from "./task-agent-routing.js";
 import {
   type AcpEventCallback,
   type AcpJsonRpcMessage,
+  type AcpCapacity,
   type AcpToolCall,
   type AgentType,
   type ApprovalPreset,
   type AvailableAgentInfo,
   type PromptResult,
   type SendOptions,
+  SessionCapError,
   type SessionEventCallback,
   type SessionEventName,
   type SessionInfo,
+  type SessionSlotClass,
   type SessionStore,
   type SpawnOptions,
   type SpawnResult,
@@ -315,6 +318,12 @@ export class AcpService extends Service {
   private readonly transportMode: "native" | "cli";
   private readonly defaultAgent: AgentType;
   private readonly maxSessions: number;
+  // Reserved slots for short-lived `system` spawns (the #8898 read-only
+  // verifier) that must NOT compete for a worker slot: at full worker cap the
+  // verifier needs a fresh session while the worker it is verifying still holds
+  // its slot (orchestrator sessions keep the slot after task_complete), so
+  // counting them together deadlocks validation. Counted against a separate pool.
+  private readonly systemHeadroom: number;
   // Serializes the session-limit check-and-reserve so concurrent spawns can't
   // each pass the limit check before any has inserted (which would overshoot
   // ELIZA_ACP_MAX_SESSIONS). A promise-chain mutex: each reservation awaits the
@@ -370,6 +379,8 @@ export class AcpService extends Service {
       "fixed";
     this.maxSessions =
       parsePositiveInt(this.setting("ELIZA_ACP_MAX_SESSIONS")) ?? 8;
+    this.systemHeadroom =
+      parsePositiveInt(this.setting("ELIZA_ACP_SYSTEM_SESSION_HEADROOM")) ?? 2;
     this.sessionTimeoutMs = parsePositiveInt(
       this.setting("ACPX_DEFAULT_TIMEOUT_MS") ??
         this.setting("ELIZA_ACP_PROMPT_TIMEOUT_MS"),
@@ -920,6 +931,11 @@ export class AcpService extends Service {
     }
 
     const now = new Date();
+    // Persist the admission pool on the session so `enforceSessionLimit` and
+    // `getCapacity` can tell worker from system slots by reading the store
+    // (survives restart); a session missing it predates slot classes and counts
+    // as a worker.
+    const slotClass = opts.slotClass ?? "worker";
     const mergedMetadata: Record<string, unknown> = {
       ...(opts.metadata ?? {}),
       ...(baselineSha ? { codingBaselineSha: baselineSha } : {}),
@@ -927,11 +943,8 @@ export class AcpService extends Service {
         ? { codingBaselineDirty: baselineDirty }
         : {}),
       ...(resolvedAccount ? { account: resolvedAccount.meta } : {}),
+      slotClass,
     };
-    const hasMergedMetadata =
-      Boolean(baselineSha) ||
-      Boolean(resolvedAccount) ||
-      Boolean(opts.metadata);
     const session: SessionInfo = {
       id,
       name,
@@ -941,12 +954,12 @@ export class AcpService extends Service {
       approvalPreset,
       createdAt: now,
       lastActivityAt: now,
-      metadata: hasMergedMetadata ? mergedMetadata : opts.metadata,
+      metadata: mergedMetadata,
     };
     // Atomic check-and-reserve: enforces the session limit and inserts under a
-    // single mutex so concurrent spawns can't overshoot maxSessions (the old
+    // single mutex so concurrent spawns can't overshoot the cap (the old
     // separate enforceSessionLimit()/store.create() left a read-then-act race).
-    await this.reserveSessionSlot(session);
+    await this.reserveSessionSlot(session, slotClass);
 
     // Mint the per-spawn model lease BEFORE the transport branch, so the leased
     // token (not the static gateway token) is what buildEnv injects into the
@@ -2591,14 +2604,70 @@ export class AcpService extends Service {
     return session;
   }
 
-  private async enforceSessionLimit(): Promise<void> {
-    const sessions = await this.store.list();
-    const active = sessions.filter(
-      (s) =>
-        !["stopped", "errored", "completed", "cancelled"].includes(s.status),
+  /**
+   * A session occupies a slot until it reaches a terminal status. Kept as a
+   * narrow list (not `TERMINAL_SESSION_STATUSES`) because an `error`-status
+   * session may still be mid-teardown and holding its subprocess; only the
+   * fully-settled statuses free the slot.
+   */
+  private static isActiveSession(session: SessionInfo): boolean {
+    return !["stopped", "errored", "completed", "cancelled"].includes(
+      session.status,
     );
-    if (active.length >= this.maxSessions)
-      throw new Error(`acpx max session limit reached (${this.maxSessions})`);
+  }
+
+  private static slotClassOf(session: SessionInfo): SessionSlotClass {
+    return session.metadata?.slotClass === "system" ? "system" : "worker";
+  }
+
+  /**
+   * Snapshot the two admission pools from the durable store. Worker and system
+   * counts are independent: a full worker pool never blocks a system spawn (the
+   * verifier headroom) and vice-versa.
+   */
+  private async countActiveSlots(): Promise<{
+    activeWorkers: number;
+    activeSystem: number;
+  }> {
+    const sessions = await this.store.list();
+    let activeWorkers = 0;
+    let activeSystem = 0;
+    for (const session of sessions) {
+      if (!AcpService.isActiveSession(session)) continue;
+      if (AcpService.slotClassOf(session) === "system") activeSystem += 1;
+      else activeWorkers += 1;
+    }
+    return { activeWorkers, activeSystem };
+  }
+
+  /**
+   * Live capacity across both admission pools. The queue dispatcher and planner
+   * provider read this instead of re-deriving the count so back-pressure is
+   * reported from one authoritative source.
+   */
+  async getCapacity(): Promise<AcpCapacity> {
+    const { activeWorkers, activeSystem } = await this.countActiveSlots();
+    return {
+      maxSessions: this.maxSessions,
+      systemHeadroom: this.systemHeadroom,
+      activeWorkers,
+      activeSystem,
+      freeWorkerSlots: Math.max(0, this.maxSessions - activeWorkers),
+      freeSystemSlots: Math.max(0, this.systemHeadroom - activeSystem),
+    };
+  }
+
+  private async enforceSessionLimit(
+    slotClass: SessionSlotClass,
+  ): Promise<void> {
+    const { activeWorkers, activeSystem } = await this.countActiveSlots();
+    if (slotClass === "system") {
+      if (activeSystem >= this.systemHeadroom)
+        throw new SessionCapError("system", this.systemHeadroom, activeSystem);
+      return;
+    }
+    if (activeWorkers >= this.maxSessions)
+      throw new SessionCapError("worker", this.maxSessions, activeWorkers);
   }
 
   /**
@@ -2615,7 +2684,10 @@ export class AcpService extends Service {
    * never rejects (we swallow on the tail) so one failed reservation doesn't
    * wedge the lock for later spawns.
    */
-  private async reserveSessionSlot(session: SessionInfo): Promise<void> {
+  private async reserveSessionSlot(
+    session: SessionInfo,
+    slotClass: SessionSlotClass,
+  ): Promise<void> {
     const previous = this.spawnReservationLock;
     let release!: () => void;
     this.spawnReservationLock = new Promise<void>((resolve) => {
@@ -2626,7 +2698,7 @@ export class AcpService extends Service {
     // awaiter; here we only serialize on its settle before counting slots.
     await previous.catch(() => {});
     try {
-      await this.enforceSessionLimit();
+      await this.enforceSessionLimit(slotClass);
       await this.store.create(session);
     } finally {
       release();

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -2230,6 +2230,11 @@ export class OrchestratorTaskService extends Service {
       workdir,
       initialTask: prompt,
       approvalPreset: "verifier",
+      // Draw on the reserved system-session headroom, not a worker slot: the
+      // task being verified still holds its worker slot (orchestrator sessions
+      // stay alive after task_complete), so counting the verifier as a worker
+      // would deadlock validation behind the very cap it is trying to clear.
+      slotClass: "system",
       metadata: {
         taskId,
         source: "independent-verifier",

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -75,10 +75,65 @@ export type AcpEventCallback = (
   sessionId?: string,
 ) => void;
 
+/**
+ * Which capacity pool a session is admitted against. `worker` sessions are the
+ * fan-out coding agents and count against `ELIZA_ACP_MAX_SESSIONS`. `system`
+ * sessions are short-lived infrastructure spawns (the #8898 read-only verifier)
+ * that get reserved headroom (`ELIZA_ACP_SYSTEM_SESSION_HEADROOM`) so validation
+ * can never deadlock behind the very worker cap it is trying to clear.
+ */
+export type SessionSlotClass = "worker" | "system";
+
+/**
+ * Live view of the session cap: how many worker/system slots are in use and how
+ * many remain. Surfaced by `AcpService.getCapacity()` so the planner provider,
+ * the admission queue dispatcher, and `/api/orchestrator/capacity` all read one
+ * authoritative count instead of re-deriving it from the store.
+ */
+export interface AcpCapacity {
+  maxSessions: number;
+  systemHeadroom: number;
+  activeWorkers: number;
+  activeSystem: number;
+  freeWorkerSlots: number;
+  freeSystemSlots: number;
+}
+
+/**
+ * Thrown by `AcpService` when a spawn is rejected because its slot class is at
+ * capacity. Typed (vs the old opaque string) so callers branch on `code` and an
+ * admission queue can park-and-retry on exactly this failure without
+ * string-matching a message. `slotClass` names which pool was full so a queued
+ * worker is not confused with a rejected system spawn.
+ */
+export class SessionCapError extends Error {
+  readonly code = "SESSION_CAP_REACHED" as const;
+  readonly slotClass: SessionSlotClass;
+  readonly maxSessions: number;
+  readonly activeCount: number;
+  constructor(
+    slotClass: SessionSlotClass,
+    maxSessions: number,
+    activeCount: number,
+  ) {
+    super(`acp ${slotClass} session cap reached (${activeCount}/${maxSessions})`);
+    this.name = "SessionCapError";
+    this.slotClass = slotClass;
+    this.maxSessions = maxSessions;
+    this.activeCount = activeCount;
+  }
+}
+
 export interface SpawnOptions {
   name?: string;
   agentType?: AgentType;
   workdir?: string;
+  /**
+   * Capacity pool this spawn is admitted against; defaults to `worker`.
+   * `spawnReadOnlyVerifier` passes `system` so it draws on the reserved headroom
+   * pool instead of competing for a worker slot it could deadlock on.
+   */
+  slotClass?: SessionSlotClass;
   /**
    * When true, spawnSession places this session in a per-session subdir of
    * `workdir` (a SHARED scratch root) so concurrent tasks can't collide.

--- a/plugins/plugin-agent-orchestrator/src/setup-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/setup-routes.ts
@@ -80,6 +80,7 @@ function codingAgentRouteHandler(): LegacyRouteHandler {
 const CODING_AGENT_ROUTE_PATHS: Array<{ type: string; path: string }> = [
   // Orchestrator durable-task surface
   { type: "GET", path: "/api/orchestrator/status" },
+  { type: "GET", path: "/api/orchestrator/capacity" },
   { type: "GET", path: "/api/orchestrator/accounts" },
   { type: "GET", path: "/api/orchestrator/accounts/readiness" },
   { type: "GET", path: "/api/orchestrator/rooms" },


### PR DESCRIPTION
Part of epic #13766 (WS2 / design decision **D1**). Implements **rollout stage 1** of the HYBRID admission-control design documented in the issue.

## Problem

At the concurrent-session cap, `enforceSessionLimit` threw an opaque `Error("acpx max session limit reached")` that callers had to string-match, and there was no distinction between capacity pools. The #8898 read-only verifier competes for the *same* worker pool it is trying to clear: at full worker cap the worker being verified still holds its slot (orchestrator sessions stay alive after `task_complete`), so the verifier's new session can never be admitted — a validation **deadlock**. The rejection was neither typed nor observable.

## Fix

- **Typed error.** `SessionCapError { code: 'SESSION_CAP_REACHED', slotClass, maxSessions, activeCount }` (`services/types.ts`) replaces the opaque throw. Callers — and a future admission queue — branch on `code`/`slotClass` instead of matching a message string.
- **Slot classes.** `SpawnOptions.slotClass?: 'worker' | 'system'` (default `worker`). Worker sessions count against `ELIZA_ACP_MAX_SESSIONS`; `system` sessions draw on a separate reserved pool `ELIZA_ACP_SYSTEM_SESSION_HEADROOM` (default 2). The slot class is persisted on the session (survives restart) so `enforceSessionLimit` / `getCapacity` bucket from the durable store. `spawnReadOnlyVerifier` now spawns as `system`, so validation can never deadlock behind the worker cap.
- **Capacity surface.** `AcpService.getCapacity()` returns live worker/system usage and free slots; exposed at `GET /api/orchestrator/capacity` (registered route template) so a client can see cap back-pressure before attempting a spawn. Honest **503** when the ACP service is unavailable — never a fabricated count.

Consistent with the just-merged task-lifecycle (#13771 / #13789) and scratch-GC (#13773 / #13792) changes; no task-status enum change (queued == `open` + a durable admission entry, per the design).

## Tests

`plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts` (real `AcpService`, deterministic native transport, no live model):
- Concurrent spawns at `maxSessions=2`: exactly 2 admitted, 4 rejected with a `SessionCapError` carrying `code`/`slotClass`/`maxSessions` (updated from the old message-string assertion).
- `getCapacity` reports worker/system pool usage and free slots.
- **No verifier deadlock:** at a full worker cap a `system` spawn is admitted on headroom while a second worker is rejected; the system pool has its own cap.
- A worker slot frees for a new spawn once a session reaches a terminal status.

`__tests__/unit/orchestrator-capacity-route.test.ts` (new): route-template registration, the capacity response shape, and the 503-when-ACP-absent path.

## Evidence

```
Test Files  5 passed (5)
     Tests  140 passed (140)   # acp-service + orchestrator-{routes,accounts-route,capacity-route,task-service}
```

Plugin typecheck: no errors cite touched files (only pre-existing sparse-graph declaration-file errors for external deps in the isolated worktree). N/A for UI/trajectory/device evidence — this is a server-side service + JSON route change with no rendered surface.

## Deferred (follow-ups, per the D1 design doc in #13772)

Scoped out of this PR to keep it reviewable; each is a large, independently-landable sub-item:
- The durable **task-level admission queue** + dispatcher + priority/aging + idle-reclaim in `OrchestratorTaskService` (rollout stages 2-3) so spawns beyond the cap park in `open` and dequeue as slots free.
- `ACTIVE_SUB_AGENTS` provider capacity line; `TaskThreadDto` `admission` field + mapper; **202/429** on `POST /tasks/:id/agents`; supervisor digest count.
- The live 10-tasks-vs-5-cap **E2E** (WS8) — tracked in #13778.

This PR is the trunk those build on: a typed, observable cap with a reserved verifier pool and a capacity readout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
