### PR TITLE
fix(#13573): fail the walkthrough matrix when an attempted lane errors

### DIFF
--- a/.github/issue-evidence/13573-walkthrough-exit.md
+++ b/.github/issue-evidence/13573-walkthrough-exit.md
@@ -1,0 +1,113 @@
+# #13573 Part 1 — walkthrough device matrix must fail when an attempted lane errors
+
+## The bug (vacuous green)
+
+`packages/app/scripts/walkthrough-device-matrix.mjs` computed its process exit
+code **only** from `--require`d lanes. With no `--require` flag (the common CI
+invocation, e.g. `bun run --cwd packages/app test:e2e:walkthrough:ios`), a lane
+that was actually **attempted on an available device/sim and then failed**
+(`status: "error"`) still exited `0`. An available-and-erroring iOS lane merged
+silently.
+
+The issue cited `:225-226 process.exit(0)`; the tree moved since, so line
+numbers shifted. The actual defect lived at the end of `main()`:
+
+```js
+const failures = requiredLaneFailures(matrix, args.require);
+// ...
+process.exit(failures.length ? 1 : 0);
+```
+
+`requiredLaneFailures` returns `[]` unless a lane is explicitly required, so an
+errored lane produced `0`.
+
+### Defect reproduced (before fix)
+
+```
+$ node demo-defect.mjs   # errored ios lane, no --require (as CI runs it)
+errored-lane matrix, no --require → requiredLaneFailures: []
+current process.exit code: 0 (VACUOUS GREEN — bug present)
+```
+
+## The fix
+
+Any lane with `status: "error"` is fatal regardless of `--require` (an `error`
+means the device/sim was reachable and the driven journey/capture broke). Honest
+`n/a` lanes (host lacks the device) stay **non-fatal** with their recorded
+reason — the honest-N/A design and the `--require` escalation are both intact.
+
+New exported pure helpers (unit-testable, single source of truth for the exit
+code):
+
+```js
+export function erroredLanes(matrix) {
+  return Object.entries(matrix).filter(([, result]) => result.status === "error");
+}
+export function computeExitCode(matrix, required) {
+  const fatal =
+    erroredLanes(matrix).length || requiredLaneFailures(matrix, required).length;
+  return fatal ? 1 : 0;
+}
+```
+
+`main()` now logs errored lanes separately and exits via
+`process.exit(computeExitCode(matrix, args.require))`.
+
+### Delegation path (`--platform ios`) verified
+
+`walkthrough-e2e.mjs` delegates native platforms to the device-matrix runner and
+already forwards the child's exit code (`process.exit(code.code ?? 0)`); it only
+ever returned green because the matrix produced a green code. Proven that a
+non-zero from the matrix now propagates through the delegation:
+
+```
+$ node scripts/walkthrough-device-matrix.mjs --platform ios --require ios ; echo $?
+direct exit code: 1
+$ node scripts/walkthrough-e2e.mjs --platform ios --require ios ; echo $?
+delegated exit code: 1
+```
+
+Honest-N/A remains green on a device-less host (no false failure):
+
+```
+$ node scripts/walkthrough-device-matrix.mjs --platform ios ; echo $?
+  ios-simulator      n/a — no booted iOS simulator ...
+device-matrix exit code: 0
+```
+
+## Test (real, mutation-checked)
+
+Added to `packages/app/scripts/walkthrough-device-matrix.test.mjs`
+(`describe("walkthrough device matrix exit code")`): fabricated lane-result sets
+assert the computed exit code — all-ok→0, any-error→non-zero, n/a-only→0,
+mixed n/a+ok→0, mixed error+n/a→non-zero, plus `--require`d n/a→non-zero.
+
+```
+$ bun test scripts/walkthrough-device-matrix.test.mjs
+ 11 pass
+ 0 fail
+Ran 11 tests across 1 file.
+```
+
+Mutation-check — reverting `computeExitCode` to the pre-fix (required-only)
+body fails exactly the two error-lane assertions, proving they guard the bug:
+
+```
+(fail) ... exits non-zero when ANY attempted lane errored, even without --require
+(fail) ... exits non-zero when an errored lane is mixed with honest n/a lanes
+ 9 pass
+ 2 fail
+```
+
+Runs green under the package's CI runner too
+(`bunx vitest run --config vitest.config.ts scripts/walkthrough-device-matrix.test.mjs`
+→ `Test Files 1 passed`). Lint clean: `bunx @biomejs/biome check` on both files.
+
+## Part 2 deferred
+
+Part 2 (real iOS journey composition) deferred — needs a live simulator.
+Composing the full onboarding/chat/gesture journey for the iOS lane (driving
+`ios-onboarding-smoke.mjs` + `mobile-local-chat-smoke.mjs` in-app before the
+single-shot `xcrun simctl` capture, since WKWebView has no CDP) is device-gated
+and left as a `// TODO(#13573 Part 2)` marker at the sim leg in `captureIos`.
+This PR is exit-code correctness only.

--- a/packages/app/scripts/walkthrough-device-matrix.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.mjs
@@ -104,6 +104,27 @@ export function requiredLaneFailures(matrix, required) {
   );
 }
 
+/** Lanes that were actually attempted on an available device/sim and then
+ * failed (`status: "error"`). Unlike an honest `n/a` (the host simply lacks the
+ * device), an `error` means the journey we *could* run broke — so it is always
+ * fatal, independent of `--require`. This closes the vacuous-green hole where an
+ * available-and-erroring lane merged silently (#13573). */
+export function erroredLanes(matrix) {
+  return Object.entries(matrix).filter(
+    ([, result]) => result.status === "error",
+  );
+}
+
+/** The process exit code for a completed matrix: non-zero when any attempted
+ * lane errored, or when a `--require`d lane is unavailable/failed; zero when
+ * every lane is `ok`/`captured` or an honestly-`n/a` unavailable host. */
+export function computeExitCode(matrix, required) {
+  const fatal =
+    erroredLanes(matrix).length ||
+    requiredLaneFailures(matrix, required).length;
+  return fatal ? 1 : 0;
+}
+
 function bootedIosSim() {
   if (process.platform !== "darwin") return null;
   const r = sh("xcrun", ["simctl", "list", "devices", "booted"]);
@@ -150,6 +171,11 @@ function captureIos({ duration }) {
       "n/a",
       "no iOS simulator app build found in DerivedData (run `bun run --cwd packages/app build:ios:local:sim` first; capturing a stale install would violate the rebuild-before-capture rule)",
     );
+  // TODO(#13573 Part 2): compose real journey legs when host can run them —
+  // drive ios-onboarding-smoke.mjs + mobile-local-chat-smoke.mjs (the in-app
+  // WKWebView handshake, since it has no CDP) before this single-shot capture so
+  // the iOS lane records the full onboarding/chat/gesture narrative, not just a
+  // frame of the running app. Device-gated: needs a live simulator.
   const code = runScript("capture-ios-sim.mjs", [
     "--issue",
     "10198",
@@ -325,15 +351,23 @@ async function main() {
     );
   }
   console.log(`\n  summary → ${join(runDir, "device-matrix.json")}\n`);
-  const failures = requiredLaneFailures(matrix, args.require);
-  if (failures.length) {
+  const errored = erroredLanes(matrix);
+  if (errored.length) {
     console.error(
-      `[walkthrough] required lane unavailable/failed: ${failures
+      `[walkthrough] lane errored during an attempted run: ${errored
         .map(([name]) => name)
         .join(", ")}`,
     );
   }
-  process.exit(failures.length ? 1 : 0);
+  const requiredFailures = requiredLaneFailures(matrix, args.require);
+  if (requiredFailures.length) {
+    console.error(
+      `[walkthrough] required lane unavailable/failed: ${requiredFailures
+        .map(([name]) => name)
+        .join(", ")}`,
+    );
+  }
+  process.exit(computeExitCode(matrix, args.require));
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/packages/app/scripts/walkthrough-device-matrix.test.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.test.mjs
@@ -1,6 +1,12 @@
+// Unit-tests the walkthrough device-matrix runner's pure lane-aggregation:
+// required-lane selection and the exit-code computation that fails the run when
+// an attempted lane errors while keeping honest-`n/a` unavailable hosts green
+// (#13573). No device is touched — matrices are fabricated in-process.
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  computeExitCode,
+  erroredLanes,
   isLaneRequired,
   parseArgs,
   requiredLaneFailures,
@@ -59,5 +65,66 @@ describe("walkthrough device matrix required lanes", () => {
 
     assert.equal(args.serial, "device-1");
     assert.equal(args.driveAndroid, false);
+  });
+});
+
+describe("walkthrough device matrix exit code", () => {
+  const noRequire = new Set();
+
+  it("exits 0 when every attempted lane succeeded", () => {
+    const matrix = {
+      "ios-simulator": { status: "captured", reason: null },
+      "android-emulator": { status: "captured", reason: null },
+    };
+    assert.deepEqual(erroredLanes(matrix), []);
+    assert.equal(computeExitCode(matrix, noRequire), 0);
+  });
+
+  it("exits non-zero when ANY attempted lane errored, even without --require", () => {
+    const matrix = {
+      "ios-simulator": { status: "error", reason: null },
+      "android-emulator": { status: "captured", reason: null },
+    };
+    assert.deepEqual(
+      erroredLanes(matrix).map(([name]) => name),
+      ["ios-simulator"],
+    );
+    assert.equal(computeExitCode(matrix, noRequire), 1);
+  });
+
+  it("exits 0 when lanes are only honestly n/a (unavailable host)", () => {
+    const matrix = {
+      "ios-simulator": { status: "n/a", reason: "not on macOS" },
+      "android-emulator": { status: "n/a", reason: "no device" },
+    };
+    assert.equal(computeExitCode(matrix, noRequire), 0);
+  });
+
+  it("exits 0 for a mix of n/a and successful lanes", () => {
+    const matrix = {
+      "ios-simulator": { status: "n/a", reason: "no booted simulator" },
+      "android-emulator": { status: "captured", reason: null },
+    };
+    assert.equal(computeExitCode(matrix, noRequire), 0);
+  });
+
+  it("exits non-zero when an errored lane is mixed with honest n/a lanes", () => {
+    const matrix = {
+      "ios-simulator": { status: "n/a", reason: "no booted simulator" },
+      "android-emulator": { status: "error", reason: null },
+    };
+    assert.equal(computeExitCode(matrix, noRequire), 1);
+  });
+
+  it("still fails a --require'd n/a lane (honest-N/A + --require intact)", () => {
+    const matrix = {
+      "android-emulator": { status: "n/a", reason: "adb blocked" },
+    };
+    // No lane errored, so the error path is not what fails this one.
+    assert.deepEqual(erroredLanes(matrix), []);
+    assert.equal(
+      computeExitCode(matrix, parseArgs(["--require", "android"], {}).require),
+      1,
+    );
   });
 });


### PR DESCRIPTION
Closes part 1 of #13573.

## Problem
`bun run --cwd packages/app test:e2e:walkthrough:ios` (→ `walkthrough-device-matrix.mjs`) exited **0 even when an attempted lane reported `status: "error"`** — a vacuous-green hole where an available-and-erroring iOS lane merged silently. The exit code was computed only from `requiredLaneFailures(matrix, --require)`, which returns `[]` in the normal CI invocation (no `--require`), so errored lanes were never fatal. Reproduced empirically on this tree before fixing.

## Fix
Two pure, exported, unit-tested helpers:
- `erroredLanes(matrix)` — lanes with `status === "error"` (attempted-and-broke, distinct from honest `n/a` where the host simply lacks the device).
- `computeExitCode(matrix, required)` — non-zero when **any** lane errored **or** a `--require`d lane is unavailable/failed; zero when every lane is `ok`/`captured` or honestly `n/a`.

`main()` now logs errored lanes separately and exits via `computeExitCode`. The honest-`n/a` design for unavailable hosts is preserved (still non-fatal, with its recorded reason); the `--require` escalation is preserved. `walkthrough-e2e.mjs --platform ios` already forwards the child exit code (`process.exit(code.code ?? 0)`), verified end-to-end.

## Evidence
- `bun test packages/app/scripts/walkthrough-device-matrix.test.mjs` → **11 pass / 0 fail**.
- Mutation check: reverting `computeExitCode` to the pre-fix (required-only) body fails exactly the two error-lane assertions (**9 pass, 2 fail**) — the tests guard the bug.
- Biome clean on both touched files.
- `.github/issue-evidence/13573-walkthrough-exit.md` attached.

## Scope
Part 1 (exit-code correctness) only. **Part 2** of #13573 — composing the real iOS onboarding→chat→gesture journey in the sim leg — is device-gated (needs a live simulator) and left as a documented `// TODO(#13573 Part 2)` follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)