### PR TITLE
fix(orchestrator): wire the `failed` task producer via a legal-transition table — slice of #13771 (epic #13766)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -56,6 +56,7 @@ class FakeAcp {
     | ((sessionId: string, event: string, data: unknown) => void)
     | null = null;
   private counter = 0;
+  private readonly sessionMeta = new Map<string, Record<string, unknown>>();
   readonly spawnArgs: Record<string, unknown>[] = [];
   readonly sent: { sessionId: string; message: string }[] = [];
   readonly stopped: string[] = [];
@@ -80,11 +81,41 @@ class FakeAcp {
     if (this.failSpawn) return Promise.reject(new Error("spawn failed"));
     this.spawnArgs.push(opts);
     this.counter += 1;
+    const sessionId = `session-${this.counter}`;
+    if (opts.metadata && typeof opts.metadata === "object") {
+      this.sessionMeta.set(sessionId, {
+        ...(opts.metadata as Record<string, unknown>),
+      });
+    }
     return Promise.resolve({
-      sessionId: `session-${this.counter}`,
+      sessionId,
       agentType: (opts.agentType as string | undefined) ?? "codex",
       workdir: (opts.workdir as string | undefined) ?? "/repo",
       status: "ready",
+    });
+  }
+
+  /** Set the live ACP-session metadata the orchestrator reads via getSession —
+   * used to seed `buildVerifyRetryCount` so tests drive the real retry-budget
+   * branch of the `failed` producer. */
+  setSessionMetadata(
+    sessionId: string,
+    metadata: Record<string, unknown>,
+  ): void {
+    this.sessionMeta.set(sessionId, metadata);
+  }
+
+  getSession(sessionId: string): Promise<{
+    id: string;
+    workdir: string;
+    status: string;
+    metadata: Record<string, unknown>;
+  } | null> {
+    return Promise.resolve({
+      id: sessionId,
+      workdir: "/repo",
+      status: "ready",
+      metadata: this.sessionMeta.get(sessionId) ?? {},
     });
   }
 
@@ -1115,6 +1146,52 @@ describe("OrchestratorTaskService — task status guards", () => {
     expect(must(await service.getTask(taskId), "detail").status).toBe(
       "validating",
     );
+  });
+
+  it("advances the task to `failed` on an unrecoverable error with no retry budget", async () => {
+    const { service, acp, taskId, sessionId } = await withSpawnedSession();
+    // A crashed / non-zero-exit sub-agent: an `error` with no failureKind and
+    // no build-verify retry counter on the session — nothing will re-drive it.
+    await drive(acp, sessionId, "error", {
+      message: "process exited with code 1",
+    });
+    expect(must(await service.getTask(taskId), "detail").status).toBe("failed");
+    // The session itself is still marked errored (existing behavior preserved).
+    expect(must((await service.getTask(taskId))?.sessions[0], "s").status).toBe(
+      "errored",
+    );
+  });
+
+  it("does not fail the task on a `session_state_lost` error (router owns respawn)", async () => {
+    const { service, acp, taskId, sessionId } = await withSpawnedSession();
+    await drive(acp, sessionId, "error", {
+      message: "session state lost",
+      failureKind: "session_state_lost",
+    });
+    // The sub-agent router deterministically respawns this lineage and narrates
+    // its own terminal outcome; the durable task must NOT be flipped to failed.
+    expect(must(await service.getTask(taskId), "detail").status).not.toBe(
+      "failed",
+    );
+  });
+
+  it("defers failing while a build-verify retry lineage still has budget", async () => {
+    const { service, acp, taskId, sessionId } = await withSpawnedSession();
+    // Live counter on the ACP session: one retry consumed, cap is 2 → budget
+    // remains, so the router's existing respawn machinery may re-drive it.
+    acp.setSessionMetadata(sessionId, { buildVerifyRetryCount: 1 });
+    await drive(acp, sessionId, "error", { message: "transient crash" });
+    expect(must(await service.getTask(taskId), "detail").status).not.toBe(
+      "failed",
+    );
+  });
+
+  it("fails the task once the build-verify retry budget is exhausted", async () => {
+    const { service, acp, taskId, sessionId } = await withSpawnedSession();
+    // Cap is 2 and both retries are spent → no respawn coming → terminal.
+    acp.setSessionMetadata(sessionId, { buildVerifyRetryCount: 2 });
+    await drive(acp, sessionId, "error", { message: "still crashing" });
+    expect(must(await service.getTask(taskId), "detail").status).toBe("failed");
   });
 
   it("routes blocked and login_required to the right task status", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-status-transition-table.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-status-transition-table.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Pins the durable-task legal-transition table (orchestrator-task-types): the
+ * single source of truth the ACP→task status writer consults. Pure, no runtime.
+ * Guards the invariants that used to live as scattered inline checks —
+ * terminal-no-exit, active-only-from-open, and (the #13771 fix) a reachable
+ * `failed` terminal so a crashed sub-agent can never wedge a task non-terminal.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isLegalTaskTransition,
+  LEGAL_TASK_TRANSITIONS,
+  type OrchestratorTaskStatus,
+  TERMINAL_TASK_STATUSES,
+} from "../../src/services/orchestrator-task-types.js";
+
+const ALL_STATUSES = Object.keys(
+  LEGAL_TASK_TRANSITIONS,
+) as OrchestratorTaskStatus[];
+
+describe("legal task-status transition table", () => {
+  it("declares an entry for every status (no missing rows)", () => {
+    const expected: OrchestratorTaskStatus[] = [
+      "open",
+      "active",
+      "waiting_on_user",
+      "blocked",
+      "validating",
+      "done",
+      "failed",
+      "archived",
+      "interrupted",
+    ];
+    expect(new Set(ALL_STATUSES)).toEqual(new Set(expected));
+  });
+
+  it("gives the unrecoverable-error producer a home: `failed` is reachable from every non-terminal state", () => {
+    for (const from of ALL_STATUSES) {
+      if (TERMINAL_TASK_STATUSES.has(from)) continue;
+      expect(isLegalTaskTransition(from, "failed")).toBe(true);
+    }
+  });
+
+  it("rejects all outgoing transitions from terminal states (once terminal, always terminal)", () => {
+    for (const terminal of TERMINAL_TASK_STATUSES) {
+      for (const to of ALL_STATUSES) {
+        expect(isLegalTaskTransition(terminal, to)).toBe(false);
+      }
+    }
+  });
+
+  it("permits `active` only from `open` (a late ready/reconnect can't stomp blocked/validating)", () => {
+    expect(isLegalTaskTransition("open", "active")).toBe(true);
+    for (const from of ALL_STATUSES) {
+      if (from === "open") continue;
+      expect(isLegalTaskTransition(from, "active")).toBe(false);
+    }
+  });
+
+  it("permits the transitions the event bridge actually drives", () => {
+    // ready/reconnected → active (from open)
+    expect(isLegalTaskTransition("open", "active")).toBe(true);
+    // blocked event → blocked
+    expect(isLegalTaskTransition("active", "blocked")).toBe(true);
+    // login_required → waiting_on_user
+    expect(isLegalTaskTransition("active", "waiting_on_user")).toBe(true);
+    // task_complete → validating
+    expect(isLegalTaskTransition("active", "validating")).toBe(true);
+    // validating → done (validation success)
+    expect(isLegalTaskTransition("validating", "done")).toBe(true);
+    // unrecoverable error mid-validation → failed
+    expect(isLegalTaskTransition("validating", "failed")).toBe(true);
+  });
+
+  it("treats a self-transition as a non-edge (callers no-op it; not enumerated as legal)", () => {
+    for (const status of ALL_STATUSES) {
+      expect(isLegalTaskTransition(status, status)).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -90,6 +90,7 @@ import { OrchestratorTaskStore } from "./orchestrator-task-store.js";
 import {
   type AttemptReflection,
   type CreateTaskInput,
+  isLegalTaskTransition,
   MAX_ATTEMPT_REFLECTIONS,
   type OrchestratorAccountAssignment,
   type OrchestratorAccountOverview,
@@ -178,6 +179,26 @@ function configuredDefaultAgentType(runtime: {
     if (typeof raw === "string" && raw.trim().length > 0) return raw.trim();
   }
   return undefined;
+}
+
+/**
+ * Cap on build-verify retries a sub-agent lineage may consume, read from
+ * `ELIZA_BUILD_VERIFY_MAX_RETRIES` (default 2) with the same env fallback the
+ * sub-agent router uses, so both sides of the retry decision agree on the
+ * budget. Values <= 0 disable retries entirely, so no lineage ever "has
+ * budget" and every unrecoverable crash is terminal.
+ */
+function buildVerifyMaxRetries(runtime: {
+  getSetting?: (key: string) => unknown;
+}): number {
+  const key = "ELIZA_BUILD_VERIFY_MAX_RETRIES";
+  const fromSetting = runtime.getSetting?.(key);
+  const raw =
+    typeof fromSetting === "string" && fromSetting.length > 0
+      ? fromSetting
+      : process.env[key];
+  const value = typeof raw === "string" ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(value) ? value : 2;
 }
 
 /** Provenance stamped on the `validateTask` verdict produced by the independent
@@ -912,6 +933,23 @@ export class OrchestratorTaskService extends Service {
             message,
           );
         }
+        // Wire the `failed` producer: an unrecoverable crash / non-zero exit
+        // must advance the TASK to a terminal state, not just mark the session
+        // `errored` — otherwise the task wedges in `active`/`validating` until
+        // the 3-min stall watchdog or a human clears it (the reported P0).
+        // `session_state_lost` is excluded: the sub-agent router owns that
+        // lineage's deterministic respawn and its own terminal narration. When
+        // an in-flight build-verify retry lineage still has budget the router's
+        // existing respawn machinery may re-drive the work, so defer; otherwise
+        // the crash is terminal. The `failed`-vs-`waiting_on_user` policy (epic
+        // D1) is deferred — this slice always parks an exhausted crash in
+        // `failed`.
+        if (
+          failureKind !== "session_state_lost" &&
+          !(await this.errorRetryBudgetRemains(sessionId))
+        ) {
+          await this.advanceTaskStatus(taskId, "failed");
+        }
         break;
       }
       case "stopped":
@@ -1366,12 +1404,38 @@ export class OrchestratorTaskService extends Service {
     const doc = await this.store.getTask(taskId);
     if (!doc) return;
     const current = doc.task.status;
-    if (TERMINAL_TASK_STATUSES.has(current)) return;
-    if (doc.task.paused) return;
     if (next === current) return;
-    // `active` is the weakest signal: only promote into it from `open`.
-    if (next === "active" && current !== "open") return;
+    // Paused is an orthogonal flag that freezes the status until an explicit
+    // resume, so no session event may advance a paused task.
+    if (doc.task.paused) return;
+    // Single gate: the legal-transition table (orchestrator-task-types) encodes
+    // terminal-no-exit and active-only-from-open, so an undeclared edge — a late
+    // `ready` trying to reactivate a terminal/validating task, or `error`
+    // failing an already-terminal one — is a no-op instead of a silent stomp.
+    if (!isLegalTaskTransition(current, next)) return;
     await this.store.updateTask(taskId, { status: next });
+  }
+
+  /**
+   * Whether an in-flight build-verify retry lineage still has budget, meaning
+   * the sub-agent router's existing respawn machinery may re-drive the crashed
+   * work and the durable task must NOT be flipped to `failed` yet.
+   *
+   * Reuses the single live counter the router stamps on ACP session metadata
+   * (`buildVerifyRetryCount`, see sub-agent-router `retryIncompleteBuild`); the
+   * typed-but-dead `OrchestratorTaskSession.retryCount` field is intentionally
+   * not consulted. Only a session that is ITSELF a retry (`count > 0`) and below
+   * the cap defers — a fresh session (no retry counter) has no in-flight retry,
+   * so its unrecoverable crash is terminal and the caller advances to `failed`.
+   */
+  private async errorRetryBudgetRemains(sessionId: string): Promise<boolean> {
+    const acp = this.acp();
+    const session = acp ? await acp.getSession(sessionId) : undefined;
+    const raw = (session?.metadata as Record<string, unknown> | undefined)
+      ?.buildVerifyRetryCount;
+    const count = typeof raw === "number" && Number.isFinite(raw) ? raw : 0;
+    if (count <= 0) return false;
+    return count < buildVerifyMaxRetries(this.runtime);
   }
 
   private async markSessionAccountUnhealthy(

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
@@ -394,3 +394,90 @@ export const TERMINAL_TASK_SESSION_STATUSES: ReadonlySet<string> = new Set([
 
 export const TERMINAL_TASK_STATUSES: ReadonlySet<OrchestratorTaskStatus> =
   new Set(["done", "failed", "archived"]);
+
+/**
+ * Legal task-status transitions as a `from → allowed(to)` relation — the single
+ * source of truth for the durable-task state machine. Consulted only by
+ * `OrchestratorTaskService.advanceTaskStatus` (the one status writer on the
+ * ACP→task event bridge), so a target that isn't declared legal from the
+ * current state is a structural no-op rather than a silent stomp.
+ *
+ * Invariants encoded here, replacing the ad-hoc guards that used to live inline:
+ *  - Terminal states (`done`, `failed`, `archived`) have no outgoing edges: once
+ *    a task is terminal the bridge never re-opens it.
+ *  - `active` is the weakest signal and is entered only from `open`, so a late
+ *    `ready`/`reconnected` can't stomp `blocked`/`validating`/`waiting_on_user`.
+ *  - Every non-terminal working state can reach `failed`. That gives the
+ *    unrecoverable-error producer (a crashed / non-zero-exit sub-agent) a home,
+ *    so a task can never wedge non-terminal, and keeps "`failed` has no
+ *    producer" structurally impossible to reintroduce — the terminal is
+ *    declared reachable here and only `advanceTaskStatus` can write it.
+ */
+export const LEGAL_TASK_TRANSITIONS: Readonly<
+  Record<OrchestratorTaskStatus, ReadonlySet<OrchestratorTaskStatus>>
+> = {
+  open: new Set([
+    "active",
+    "blocked",
+    "waiting_on_user",
+    "validating",
+    "done",
+    "failed",
+    "interrupted",
+    "archived",
+  ]),
+  active: new Set([
+    "blocked",
+    "waiting_on_user",
+    "validating",
+    "done",
+    "failed",
+    "interrupted",
+    "archived",
+  ]),
+  waiting_on_user: new Set([
+    "blocked",
+    "validating",
+    "done",
+    "failed",
+    "interrupted",
+    "archived",
+  ]),
+  blocked: new Set([
+    "waiting_on_user",
+    "validating",
+    "done",
+    "failed",
+    "interrupted",
+    "archived",
+  ]),
+  validating: new Set([
+    "waiting_on_user",
+    "blocked",
+    "done",
+    "failed",
+    "interrupted",
+    "archived",
+  ]),
+  interrupted: new Set([
+    "blocked",
+    "waiting_on_user",
+    "validating",
+    "done",
+    "failed",
+    "archived",
+  ]),
+  done: new Set<OrchestratorTaskStatus>(),
+  failed: new Set<OrchestratorTaskStatus>(),
+  archived: new Set<OrchestratorTaskStatus>(),
+};
+
+/** Whether the durable task machine permits `from → to`. A self-transition
+ * (`from === to`) is a caller-side no-op and is intentionally not enumerated as
+ * a legal edge. */
+export function isLegalTaskTransition(
+  from: OrchestratorTaskStatus,
+  to: OrchestratorTaskStatus,
+): boolean {
+  return LEGAL_TASK_TRANSITIONS[from].has(to);
+}


### PR DESCRIPTION
Slice of #13771 (epic #13766, WS1). Fixes the "`failed` has no producer" hole: no code path set durable task `status: "failed"` even though it is in `TERMINAL_TASK_STATUSES`, so a crashed / non-zero-exit sub-agent left the task wedged in `active`/`validating` until the 3-min stall watchdog or a human recovered it.

## What changed

**1. One legal-transition table** — `LEGAL_TASK_TRANSITIONS` + `isLegalTaskTransition` in `orchestrator-task-types.ts`, the single source of truth for the durable-task state machine. `OrchestratorTaskService.advanceTaskStatus` (the one status writer on the ACP→task bridge) now routes through it. The table folds in the two guards that used to be inline (`terminal-no-exit`, `active-only-from-open`) and declares `failed` reachable from every non-terminal state, so "failed has no producer" is structurally impossible to reintroduce. This refactor is behavior-preserving for the existing edges (the terminal-immutability and "later active can't stomp blocked/validating" guard tests still pass).

**2. Wire the `failed` producer** — in `applySessionEvent`'s `error` case, an unrecoverable session error now advances the task to terminal `failed`, except:
- `failureKind === "session_state_lost"` is excluded — the sub-agent router owns that lineage's deterministic respawn and its own terminal narration.
- If an in-flight build-verify retry lineage still has budget, defer (the router's existing respawn machinery may re-drive the work). Budget is read from the **live** `session.metadata.buildVerifyRetryCount` counter (the one the router stamps in `retryIncompleteBuild`), not the typed-but-dead `OrchestratorTaskSession.retryCount` field. A fresh session (no counter) has no in-flight retry, so its crash is terminal.

The session is still marked `errored` and account-health failover on auth/429 is unchanged.

## Tests (real code path, fail-before / pass-after)

Two unit suites drive the real bridge (in-memory store + a fake ACP that emits real session events through the real subscription; `getSession` returns the session metadata the producer actually reads):

- `__tests__/unit/task-status-transition-table.test.ts` (new, 6 tests) — terminal-no-exit, active-only-from-open, `failed` reachable from every non-terminal state, self-transition is a non-edge.
- `__tests__/unit/orchestrator-task-service.test.ts` (+4 tests) — `error` with no retry budget → task `failed` (session still `errored`); `session_state_lost` → not failed; build-verify budget remaining → deferred (not failed); budget exhausted → failed.

**Fail-before** (producer disabled): the two tests that assert the task reaches `failed` fail with:
```
AssertionError: expected 'active' to be 'failed' // Object.is equality
 ❯ __tests__/unit/orchestrator-task-service.test.ts:1158  (advances the task to `failed` on an unrecoverable error with no retry budget)
Tests  2 failed | 63 passed (65)
```
(The two "should NOT fail" tests correctly stay green without the producer — the discrimination is exactly right.)

**Pass-after** (both suites):
```
Test Files  2 passed (2)
     Tests  71 passed (71)
```

Ran the 7 potentially-affected suites together (transition table, task-service, account-switch-rekey, task-change-set-mirror, task-watchdog, account-failover-respawn, account-failure-propagation): **105 passed**.

### Note on env / pre-existing failures
`bun test` (bun's built-in runner) is not this plugin's harness — it uses vitest, so tests were run via `bunx vitest run --config vitest.config.ts <file>`. `bun run typecheck` reports only pre-existing environmental noise (missing `@types` in the dist `node_modules`, sparse-checkout-excluded generated i18n files and a sibling plugin dir); **zero** errors reference the touched files. Running the full `__tests__/unit` dir surfaces 6 unrelated failing files (`task-history`, `control-resume-clears-paused`, `provision-workspace`, `task-control-structural`, `archive-reopen-lifecycle`, `active-session-forward`) — all fail with the identical pre-existing `runtime.reportError is not a function` at `src/services/task-policy.ts:192` (a file this PR does not touch, on the TASKS-action access path the change never runs). Verified `task-history.test.ts` fails identically after reverting this branch's source to pristine `develop`.

## Deferred to follow-up (rest of the epic)
- **D1 policy — `failed` vs `waiting_on_user`:** this slice always parks an exhausted crash in `failed`; the failed-vs-user-parked decision is the epic's D1/WS2 design issue.
- **#13771 item 3 — bounded general-crash respawn:** extend the `session_state_lost` respawn path to plain crashes with a cap. Not added here; the retry-budget gate is a forward hook for it.
- **#13771 item 4 — `resumeTask` re-engage symmetry:** resume still only flips the paused flag; re-spawning what `pauseTask` stopped is out of scope.
- **#13771 item 5 — full crash-a-subagent e2e + parent-restart reconstruction test** (does in-flight state rebuild from the store alone / is `sessionTaskIndex` durable).
- **Rerouting ALL scattered task-status writes** (the direct `store.updateTask({status})` sites for `done`/`interrupted`/`archived`/reopen) through the table — only the failed-producer path is routed through it in this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
