### PR TITLE
feat(agent,ui): view-scoped agent action registration gated on active view (#13589)

### DIFF
--- a/packages/agent/src/api/server-lazy-routes.ts
+++ b/packages/agent/src/api/server-lazy-routes.ts
@@ -692,8 +692,20 @@ export async function handleViewsRoutes(
   return handleViewsRoutes(...args);
 }
 
-export async function registerBuiltinViews(): Promise<void> {
+export async function registerBuiltinViews(
+  runtime?: import("@elizaos/core").IAgentRuntime | null,
+): Promise<void> {
   (await import("./views-registry.ts")).registerBuiltinViews();
+  // Register the built-in shell views' scoped actions once the runtime exists.
+  // Mechanism only: BUILTIN_VIEWS carries no scoped actions until per-view
+  // children add them, so this is a no-op today but wires the boot path.
+  if (runtime) {
+    const { BUILTIN_VIEWS } = await import("./builtin-views.ts");
+    const { registerViewScopedActions } = await import(
+      "../runtime/view-scoped-actions.ts"
+    );
+    registerViewScopedActions(runtime, "@elizaos/builtin", BUILTIN_VIEWS);
+  }
 }
 
 type WorkbenchRoutesModule = typeof import("./workbench-routes.ts");

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -4203,7 +4203,7 @@ export async function startApiServer(opts?: {
   // ── Deferred startup work (non-blocking) ────────────────────────────────
   // Keep API startup fast: listen first, then warm optional subsystems.
   const startDeferredStartupWork = async (): Promise<void> => {
-    void registerBuiltinViews().catch((err) => {
+    void registerBuiltinViews(state.runtime).catch((err) => {
       logger.warn(
         `[eliza-api] Built-in view registration failed after listen: ${
           err instanceof Error ? err.message : String(err)
@@ -5076,6 +5076,19 @@ export async function startApiServer(opts?: {
       }
     }
   };
+
+  // Give the views module a process-level broadcaster so the view-scoped action
+  // handler (which fires from the planner loop, outside any HTTP request) can
+  // drive a mounted shell through the same `view:interact` path the route uses.
+  void import("./views-routes.ts")
+    .then(({ setViewsBroadcastWs }) => {
+      setViewsBroadcastWs(state.broadcastWs ?? null);
+    })
+    .catch((err) => {
+      logger.error(
+        `[eliza-api] failed to wire views broadcaster: ${err instanceof Error ? err.message : err}`,
+      );
+    });
 
   state.broadcastWsToClientId = (clientId: string, data: object) => {
     const message = JSON.stringify(data);

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -156,6 +156,28 @@ const STANDARD_CAPABILITY_IDS: ReadonlySet<string> = new Set<string>([
 /** Module-level map of pending interact requests awaiting a frontend result. */
 const pendingInteractRequests = new PendingRequestMap();
 
+/**
+ * Module-level WS broadcaster, wired once by server.ts at boot. Lets code that
+ * runs outside an HTTP request — notably the view-scoped action handler, which
+ * fires from the planner loop, not a `/interact` request — dispatch a
+ * `view:interact` frame to mounted shells through the SAME path the route uses.
+ * Null until wired (or in headless test/CI); dispatch degrades to a route-error
+ * result rather than silently succeeding when it is unset.
+ */
+let moduleBroadcastWs: ((payload: object) => void) | null = null;
+
+/** Wire the process WS broadcaster into the views module. Called once at boot. */
+export function setViewsBroadcastWs(
+  broadcast: ((payload: object) => void) | null,
+): void {
+  moduleBroadcastWs = broadcast;
+}
+
+/** The wired process WS broadcaster, or null when none is installed. */
+export function getViewsBroadcastWs(): ((payload: object) => void) | null {
+  return moduleBroadcastWs;
+}
+
 export interface CurrentViewState {
   viewId: string;
   viewPath: string | null;
@@ -1132,7 +1154,7 @@ export async function handleViewsRoutes(
  * Result of dispatching a capability to a view — the union of the two interact
  * paths (a `serverInteract` handler, or a frontend `view:interact` round-trip).
  */
-interface ViewInteractDispatchResult {
+export interface ViewInteractDispatchResult {
   requestId: string;
   success: boolean;
   result?: unknown;
@@ -1143,10 +1165,10 @@ interface ViewInteractDispatchResult {
  * Dispatch a capability to a view, reusing the established interact semantics:
  * a `serverInteract` handler when the view declares one, else a frontend
  * `view:interact` WebSocket round-trip resolved via the pending-request map.
- * Shared by POST /:id/activate (CLICK_ELEMENT) so activation never re-implements
- * the dispatch.
+ * Shared by POST /:id/activate (CLICK_ELEMENT) and the view-scoped action
+ * handler (view-scoped-actions.ts) so neither re-implements the dispatch.
  */
-async function dispatchViewInteract(
+export async function dispatchViewInteract(
   entry: ViewRegistryEntry,
   viewId: string,
   capability: string,

--- a/packages/agent/src/runtime/plugin-lifecycle.ts
+++ b/packages/agent/src/runtime/plugin-lifecycle.ts
@@ -33,6 +33,10 @@ import {
   unregisterPluginViews,
 } from "../api/views-registry.ts";
 import { applyPluginRoleGating } from "./plugin-role-gating.ts";
+import {
+  registerViewScopedActions,
+  unregisterViewScopedActions,
+} from "./view-scoped-actions.ts";
 import type { ToolCallCache } from "./tool-call-cache/index.ts";
 import {
   createToolCallCacheFromConfig,
@@ -712,8 +716,10 @@ function installPluginViewSync(runtime: RuntimeWithPluginLifecycle): void {
       applyPluginRoleGating([plugin]);
       await migratePluginSchemasIfReady(runtime, plugin);
       await registerPluginViews(plugin);
+      registerViewScopedActions(runtime, plugin.name, plugin.views ?? []);
     } catch (error) {
       unregisterPluginViews(plugin.name);
+      unregisterViewScopedActions(runtime, plugin.name);
       if (baseUnloadPlugin) {
         await baseUnloadPlugin(plugin.name);
       }
@@ -725,6 +731,7 @@ function installPluginViewSync(runtime: RuntimeWithPluginLifecycle): void {
     runtime.unloadPlugin = async (pluginName: string) => {
       const ownership = await baseUnloadPlugin(pluginName);
       unregisterPluginViews(pluginName);
+      unregisterViewScopedActions(runtime, pluginName);
       return ownership as RuntimePluginOwnership | null;
     };
   }
@@ -738,6 +745,9 @@ function installPluginViewSync(runtime: RuntimeWithPluginLifecycle): void {
       // fresh, un-wrapped provider.get functions).
       applyPluginRoleGating([plugin]);
       await registerPluginViews(plugin);
+      // registerViewScopedActions reconciles: it unregisters this plugin's
+      // previous scoped actions before registering the reloaded set.
+      registerViewScopedActions(runtime, plugin.name, plugin.views ?? []);
     };
   }
 }

--- a/packages/agent/src/runtime/view-action-affinity.test.ts
+++ b/packages/agent/src/runtime/view-action-affinity.test.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  registerBuiltinViews,
   registerPluginViews,
   unregisterPluginViews,
 } from "../api/views-registry.ts";
@@ -30,6 +31,7 @@ import {
   validateViewCoverage,
   viewActionAffinityMap,
   viewScopedActionNames,
+  viewScopedNamedActions,
 } from "./view-action-affinity.ts";
 
 const AWARE_VIEW = {
@@ -249,6 +251,19 @@ describe("view-action-affinity", () => {
     expect(viewActionAffinityMap().documents).toContain("OWNER_DOCUMENTS");
   });
 
+  it("built-in plugins-page/settings keep RUNTIME affinity via their declarations (#13589 stub migration)", () => {
+    // The 2-entry HOST_VIEW_ACTION_AFFINITY stub ({plugins-page,settings}→RUNTIME)
+    // was deleted; both built-in views declare relatedActions: ["RUNTIME"] in
+    // builtin-views.ts, so once registered the derived map (and the scoped-name
+    // resolver the planner reads) must still yield RUNTIME — no behavior change.
+    registerBuiltinViews();
+    const map = viewActionAffinityMap();
+    expect(map["plugins-page"]).toContain("RUNTIME");
+    expect(map.settings).toContain("RUNTIME");
+    expect(viewScopedActionNames("plugins-page").has("RUNTIME")).toBe(true);
+    expect(viewScopedActionNames("settings").has("RUNTIME")).toBe(true);
+  });
+
   it("validateViewCoverage warns for a registered view with no affinity and no capabilities", () => {
     const warnings: string[] = [];
     const uncovered = validateViewCoverage(
@@ -276,6 +291,49 @@ describe("view-action-affinity", () => {
     // The wallet view scopes actions → the block names them for the planner.
     expect(block).toContain("most relevant while on this view");
     expect(block).toContain("EVM_SWAP");
+  });
+
+  it("surfaces a view's named scopedActions in the awareness block (#13589)", async () => {
+    // A view that declares scopedActions (gated named actions) → the awareness
+    // block names them so the planner knows what it can invoke while here.
+    const SCOPED_PLUGIN = "@test/view-scoped-named";
+    // Unique view id — the beforeEach fixture already owns "wallet", and the
+    // registry's conflict guard keeps the first registration for a shared id.
+    await registerPluginViews({
+      name: SCOPED_PLUGIN,
+      description: "Scoped named action fixture.",
+      views: [
+        {
+          id: "scoped-wallet",
+          label: "Scoped Wallet",
+          scopedActions: [
+            {
+              name: "VIEW_WALLET_SWAP_TOKENS",
+              description: "Swap tokens using the wallet view controls",
+              steps: [{ kind: "agent-click", target: "swap-button" }],
+            },
+          ],
+        },
+      ],
+    });
+    try {
+      expect(viewScopedNamedActions("scoped-wallet")).toEqual([
+        {
+          name: "VIEW_WALLET_SWAP_TOKENS",
+          description: "Swap tokens using the wallet view controls",
+        },
+      ]);
+      const block = renderActiveViewContextBlock({
+        viewId: "scoped-wallet",
+        viewLabel: "Scoped Wallet",
+        viewType: "gui",
+        viewPath: "/scoped-wallet",
+      });
+      expect(block).toContain("Named actions this view exposes only while");
+      expect(block).toContain("VIEW_WALLET_SWAP_TOKENS: Swap tokens");
+    } finally {
+      unregisterPluginViews(SCOPED_PLUGIN);
+    }
   });
 
   it("acknowledges a just-happened switch only while it is fresh (#8788)", () => {

--- a/packages/agent/src/runtime/view-action-affinity.ts
+++ b/packages/agent/src/runtime/view-action-affinity.ts
@@ -99,30 +99,21 @@ export function setActiveViewElements(
   return true;
 }
 
-/**
- * Host-owned action affinity. Plugin-owned views declare their own
- * `ViewDeclaration.relatedActions`; the live view registry is the source of
- * truth for those relationships. This small fallback remains only for built-in
- * shell views without plugin declarations.
- */
-const HOST_VIEW_ACTION_AFFINITY: Readonly<Record<string, readonly string[]>> = {
-  "plugins-page": ["RUNTIME"],
-  settings: ["RUNTIME"],
-};
-
 function normalizeRelatedActions(actions: readonly string[] | undefined) {
   return [...new Set((actions ?? []).map((a) => a.trim()).filter(Boolean))];
 }
 
 /**
- * Current view-id -> related action map derived from registered view
- * declarations plus host-owned built-in affinities.
+ * Current view-id -> related action map derived entirely from registered view
+ * declarations. The live view registry — plugin views AND the built-in shell
+ * views (registered from `builtin-views.ts`, which carry their own
+ * `relatedActions`) — is the single source of truth. There is no host-owned
+ * fallback table: a view that wants an action weighted while it is foreground
+ * declares `relatedActions`; a view that wants a GATED action it exposes only
+ * while active declares `scopedActions` (see view-scoped-actions.ts).
  */
 export function viewActionAffinityMap(): Record<string, readonly string[]> {
   const map = new Map<string, string[]>();
-  for (const [viewId, actions] of Object.entries(HOST_VIEW_ACTION_AFFINITY)) {
-    map.set(viewId, [...actions]);
-  }
   for (const viewType of VIEW_TYPES) {
     for (const view of listViews({
       developerMode: true,
@@ -149,16 +140,36 @@ function getViewRelatedActions(viewId: string): string[] {
 
 /**
  * Resolve the set of action names to keep at full param detail for the active
- * view. Returns an empty set when no view is active or the view has no mapped
- * actions (control still works through agent-surface capabilities).
+ * view — its declared `relatedActions`. Returns an empty set when no view is
+ * active or the view declares none (control still works through agent-surface
+ * capabilities and, for gated named actions, the view-scoped action registry).
  */
 export function viewScopedActionNames(
   viewId: string | null | undefined,
 ): Set<string> {
   if (!viewId) return new Set();
-  const declared = getViewRelatedActions(viewId);
-  if (declared.length > 0) return new Set(declared);
-  return new Set(HOST_VIEW_ACTION_AFFINITY[viewId] ?? []);
+  return new Set(getViewRelatedActions(viewId));
+}
+
+/**
+ * Named view-scoped agent actions (`ViewDeclaration.scopedActions`) a view
+ * exposes, as `{ name, description }`. These are gated actions — the host only
+ * exposes them to the planner while this view is active (see
+ * view-scoped-actions.ts) — so the awareness block names them for the planner.
+ * Read from the registry entry (which carries the declaration) rather than the
+ * action registry to avoid an import cycle with the registration module.
+ */
+export function viewScopedNamedActions(
+  viewId: string | null | undefined,
+): { name: string; description: string }[] {
+  if (!viewId) return [];
+  for (const viewType of VIEW_TYPES) {
+    const scoped = getView(viewId, { viewType })?.scopedActions;
+    if (scoped && scoped.length > 0) {
+      return scoped.map((a) => ({ name: a.name, description: a.description }));
+    }
+  }
+  return [];
 }
 
 /**
@@ -259,6 +270,15 @@ export function renderActiveViewContextBlock(view: ActiveViewContext): string {
     lines.push(
       `Actions most relevant while on this view (prefer these when the request fits): ${scoped.join(", ")}.`,
     );
+  }
+  const named = viewScopedNamedActions(view.viewId);
+  if (named.length > 0) {
+    lines.push(
+      "Named actions this view exposes only while it is active (invoke by name — they drive its controls for you):",
+    );
+    for (const action of named) {
+      lines.push(`- ${action.name}: ${action.description}`);
+    }
   }
   const elements = view.elements ?? [];
   if (elements.length > 0) {

--- a/packages/agent/src/runtime/view-scoped-actions.test.ts
+++ b/packages/agent/src/runtime/view-scoped-actions.test.ts
@@ -1,0 +1,376 @@
+/**
+ * View-scoped agent actions: a view's `scopedActions` become real runtime
+ * actions gated on the declaring view being active, driving that view's
+ * `useAgentElement` controls through the EXISTING interact protocol. Exercises
+ * the real path — registers a view in the live views-registry, flips the active
+ * view via the actual POST /api/views/:id/navigate route handler, and dispatches
+ * scoped-action steps through the shared views-routes dispatch (serverInteract
+ * branch stands in for the mounted shell's agent-surface registry). No mock of
+ * the unit under test: validate() reads the real active-view context and the
+ * handler runs the real dispatch + missing-element detection.
+ */
+import type http from "node:http";
+import { Readable } from "node:stream";
+import type { Action, IAgentRuntime } from "@elizaos/core";
+import { ElizaError, isElizaError } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  registerPluginViews,
+  unregisterPluginViews,
+} from "../api/views-registry.ts";
+import {
+  clearCurrentViewState,
+  handleViewsRoutes,
+  setViewsBroadcastWs,
+  type ViewsRouteContext,
+} from "../api/views-routes.ts";
+import { clearActiveViewContext } from "./view-action-affinity.ts";
+import {
+  __resetViewScopedActionRegistryForTests,
+  buildViewScopedAction,
+  registerViewScopedActions,
+  scopedActionNames,
+  unregisterViewScopedActions,
+} from "./view-scoped-actions.ts";
+
+const TEST_PLUGIN = "@test/view-scoped-actions";
+
+/**
+ * Mounted view whose serverInteract stands in for the shell's agent-surface
+ * registry: `agent-fill`/`agent-click`/`agent-focus` succeed against the ids in
+ * `mountedIds`, and report `{ ok: false, reason: "element not found" }` for any
+ * other id — exactly what the real registry returns for an unmounted element.
+ */
+function makeInteractiveView(id: string, mountedIds: Set<string>) {
+  const filled: Record<string, string> = {};
+  const clicked: string[] = [];
+  return {
+    filled,
+    clicked,
+    view: {
+      id,
+      label: `${id} view`,
+      path: `/${id}`,
+      relatedActions: [] as string[],
+      scopedActions: [
+        {
+          name: `VIEW_${id.toUpperCase()}_SET_PROVIDER`,
+          description: `Set the provider on the ${id} view`,
+          parameters: ["provider"],
+          steps: [
+            { kind: "agent-focus" as const, target: "provider-select" },
+            {
+              kind: "agent-fill" as const,
+              target: "provider-select",
+              value: "{{provider}}",
+            },
+            { kind: "agent-click" as const, target: "save-button" },
+          ],
+        },
+        {
+          name: `VIEW_${id.toUpperCase()}_MISSING_TARGET`,
+          description: "Drives an element that is not mounted",
+          steps: [
+            { kind: "agent-click" as const, target: "ghost-button" },
+          ],
+        },
+      ],
+      serverInteract: async (
+        capability: string,
+        params?: Record<string, unknown>,
+      ) => {
+        const targetId = typeof params?.id === "string" ? params.id : "";
+        if (!mountedIds.has(targetId)) {
+          return { ok: false, id: targetId, reason: "element not found" };
+        }
+        if (capability === "agent-fill") {
+          filled[targetId] =
+            typeof params?.value === "string" ? params.value : "";
+          return { ok: true, id: targetId, value: filled[targetId] };
+        }
+        if (capability === "agent-click") {
+          clicked.push(targetId);
+        }
+        return { ok: true, id: targetId };
+      },
+    },
+  };
+}
+
+/** Drive the REAL navigate route so setActiveViewContext runs as it does live. */
+async function navigateTo(id: string): Promise<void> {
+  const req = Readable.from([
+    Buffer.from(JSON.stringify({})),
+  ]) as unknown as http.IncomingMessage;
+  const pathname = `/api/views/${encodeURIComponent(id)}/navigate`;
+  const ctx: ViewsRouteContext = {
+    req,
+    res: {} as http.ServerResponse,
+    method: "POST",
+    pathname,
+    url: new URL(`http://local${pathname}`),
+    json: vi.fn(),
+    error: vi.fn(),
+    broadcastWs: vi.fn(),
+  };
+  await handleViewsRoutes(ctx);
+}
+
+/**
+ * Minimal runtime whose registerAction/unregisterAction mutate a name→action
+ * map, so the test can register scoped actions and then invoke the real
+ * validate()/handler() the mechanism built.
+ */
+function makeRuntime(): {
+  runtime: Pick<IAgentRuntime, "registerAction" | "unregisterAction">;
+  actions: Map<string, Action>;
+} {
+  const actions = new Map<string, Action>();
+  return {
+    actions,
+    runtime: {
+      registerAction: (action: Action) => {
+        actions.set(action.name, action);
+      },
+      unregisterAction: (name: string) => actions.delete(name),
+    } as Pick<IAgentRuntime, "registerAction" | "unregisterAction">,
+  };
+}
+
+const fakeMessage = {} as never;
+
+beforeEach(async () => {
+  __resetViewScopedActionRegistryForTests();
+  clearCurrentViewState();
+  clearActiveViewContext();
+  // Give the module a broadcaster so the "no shell to reach" guard never fires
+  // in this test — the mounted serverInteract is what actually resolves steps.
+  setViewsBroadcastWs(() => {});
+});
+
+afterEach(() => {
+  unregisterPluginViews(TEST_PLUGIN);
+  clearCurrentViewState();
+  clearActiveViewContext();
+  setViewsBroadcastWs(null);
+  __resetViewScopedActionRegistryForTests();
+  vi.restoreAllMocks();
+});
+
+describe("view-scoped action validate() gating on the active view", () => {
+  it("returns false when the declaring view is not active and true when it is", async () => {
+    const settings = makeInteractiveView("settings", new Set());
+    await registerPluginViews(
+      {
+        name: TEST_PLUGIN,
+        description: "scoped action fixtures",
+        views: [settings.view],
+      },
+      process.cwd(),
+    );
+    const action = buildViewScopedAction(
+      "settings",
+      settings.view.scopedActions[0],
+    );
+
+    // No active view → gated closed.
+    expect(await action.validate({} as IAgentRuntime, fakeMessage)).toBe(false);
+
+    // Switch to a DIFFERENT view → still closed.
+    await navigateTo("chat");
+    expect(await action.validate({} as IAgentRuntime, fakeMessage)).toBe(false);
+
+    // Switch INTO the declaring view via the real navigate route → open.
+    await navigateTo("settings");
+    expect(await action.validate({} as IAgentRuntime, fakeMessage)).toBe(true);
+
+    // Switch away again → closes without any restart.
+    await navigateTo("chat");
+    expect(await action.validate({} as IAgentRuntime, fakeMessage)).toBe(false);
+  });
+});
+
+describe("view-scoped action handler drives the interact protocol", () => {
+  it("resolves a named action to the real agent-fill/click sequence", async () => {
+    const settings = makeInteractiveView(
+      "settings",
+      new Set(["provider-select", "save-button"]),
+    );
+    await registerPluginViews(
+      {
+        name: TEST_PLUGIN,
+        description: "scoped action fixtures",
+        views: [settings.view],
+      },
+      process.cwd(),
+    );
+    await navigateTo("settings");
+
+    const action = buildViewScopedAction(
+      "settings",
+      settings.view.scopedActions[0],
+    );
+    const result = await action.handler(
+      {} as IAgentRuntime,
+      fakeMessage,
+      undefined,
+      { parameters: { provider: "anthropic" } },
+    );
+
+    expect(result?.success).toBe(true);
+    // The fill drove the real serverInteract with the resolved param value…
+    expect(settings.filled["provider-select"]).toBe("anthropic");
+    // …and the click step ran.
+    expect(settings.clicked).toContain("save-button");
+    // The step trace is reported for observability.
+    expect(result?.data?.steps).toEqual([
+      "agent-focus:provider-select",
+      "agent-fill:provider-select",
+      "agent-click:save-button",
+    ]);
+  });
+
+  it("throws a typed missing-element error when a target useAgentElement id is not mounted", async () => {
+    const settings = makeInteractiveView("settings", new Set(["provider-select"]));
+    await registerPluginViews(
+      {
+        name: TEST_PLUGIN,
+        description: "scoped action fixtures",
+        views: [settings.view],
+      },
+      process.cwd(),
+    );
+    await navigateTo("settings");
+
+    // The MISSING_TARGET action clicks "ghost-button", which is never mounted.
+    const action = buildViewScopedAction(
+      "settings",
+      settings.view.scopedActions[1],
+    );
+
+    let thrown: unknown;
+    try {
+      await action.handler({} as IAgentRuntime, fakeMessage, undefined, {});
+    } catch (err) {
+      thrown = err;
+    }
+    expect(isElizaError(thrown)).toBe(true);
+    const elizaErr = thrown as ElizaError;
+    expect(elizaErr.code).toBe("VIEW_SCOPED_ACTION_ELEMENT_MISSING");
+    expect(elizaErr.context?.target).toBe("ghost-button");
+    expect(elizaErr.message).toContain("not mounted");
+  });
+
+  it("throws a typed param-missing error when a {{param}} value is not supplied", async () => {
+    const settings = makeInteractiveView(
+      "settings",
+      new Set(["provider-select", "save-button"]),
+    );
+    await registerPluginViews(
+      {
+        name: TEST_PLUGIN,
+        description: "scoped action fixtures",
+        views: [settings.view],
+      },
+      process.cwd(),
+    );
+    await navigateTo("settings");
+
+    const action = buildViewScopedAction(
+      "settings",
+      settings.view.scopedActions[0],
+    );
+    // No `provider` param → the {{provider}} fill step must fail loudly, not
+    // fill an empty string into the real control.
+    await expect(
+      action.handler({} as IAgentRuntime, fakeMessage, undefined, {
+        parameters: {},
+      }),
+    ).rejects.toMatchObject({ code: "VIEW_SCOPED_ACTION_PARAM_MISSING" });
+    // The control was never touched.
+    expect(settings.filled["provider-select"]).toBeUndefined();
+  });
+
+  it("throws VIEW_SCOPED_ACTION_VIEW_INACTIVE when invoked while its view is not active", async () => {
+    const settings = makeInteractiveView(
+      "settings",
+      new Set(["provider-select", "save-button"]),
+    );
+    await registerPluginViews(
+      {
+        name: TEST_PLUGIN,
+        description: "scoped action fixtures",
+        views: [settings.view],
+      },
+      process.cwd(),
+    );
+    // Navigate to a different view so the handler's defense-in-depth gate fires
+    // even though the executor would normally block on validate().
+    await navigateTo("chat");
+
+    const action = buildViewScopedAction(
+      "settings",
+      settings.view.scopedActions[0],
+    );
+    await expect(
+      action.handler({} as IAgentRuntime, fakeMessage, undefined, {
+        parameters: { provider: "anthropic" },
+      }),
+    ).rejects.toMatchObject({ code: "VIEW_SCOPED_ACTION_VIEW_INACTIVE" });
+  });
+});
+
+describe("view-scoped action registration reconciliation", () => {
+  it("registers a view's scoped actions and unregisters exactly its set", () => {
+    const { runtime, actions } = makeRuntime();
+    const settings = makeInteractiveView("settings", new Set());
+    const registered = registerViewScopedActions(runtime, TEST_PLUGIN, [
+      settings.view,
+    ]);
+
+    expect(registered).toEqual(
+      scopedActionNames(settings.view.scopedActions),
+    );
+    expect(actions.has("VIEW_SETTINGS_SET_PROVIDER")).toBe(true);
+    expect(actions.has("VIEW_SETTINGS_MISSING_TARGET")).toBe(true);
+
+    unregisterViewScopedActions(runtime, TEST_PLUGIN);
+    expect(actions.size).toBe(0);
+  });
+
+  it("reconciles on reload: a removed scoped action is unregistered", () => {
+    const { runtime, actions } = makeRuntime();
+    const settings = makeInteractiveView("settings", new Set());
+    registerViewScopedActions(runtime, TEST_PLUGIN, [settings.view]);
+    expect(actions.size).toBe(2);
+
+    // Reload with only the first action → the second is dropped.
+    registerViewScopedActions(runtime, TEST_PLUGIN, [
+      { ...settings.view, scopedActions: [settings.view.scopedActions[0]] },
+    ]);
+    expect(actions.has("VIEW_SETTINGS_SET_PROVIDER")).toBe(true);
+    expect(actions.has("VIEW_SETTINGS_MISSING_TARGET")).toBe(false);
+  });
+
+  it("keeps the first of a duplicate scoped-action name across views", () => {
+    const { runtime, actions } = makeRuntime();
+    const warn = vi.fn();
+    const a = makeInteractiveView("a", new Set());
+    const dupName = a.view.scopedActions[0].name;
+    const b = {
+      id: "b",
+      scopedActions: [
+        { ...a.view.scopedActions[0], description: "duplicate name" },
+      ],
+    };
+    const registered = registerViewScopedActions(runtime, TEST_PLUGIN, [
+      { id: "a", scopedActions: [a.view.scopedActions[0]] },
+      b,
+    ]);
+    expect(registered).toContain(dupName);
+    expect(actions.get(dupName)?.description).toBe(
+      a.view.scopedActions[0].description,
+    );
+    void warn;
+  });
+});

--- a/packages/agent/src/runtime/view-scoped-actions.ts
+++ b/packages/agent/src/runtime/view-scoped-actions.ts
@@ -1,0 +1,399 @@
+/**
+ * View-scoped agent actions: turns a view's `ViewScopedAction` declarations into
+ * real runtime actions that are gated on the declaring view being foreground.
+ *
+ * A scoped action's `validate()` returns false unless the declaring view is the
+ * active view (read from the same authoritative active-view context the affinity
+ * map uses via view-action-affinity.ts) — so the agent cannot invoke a wallet
+ * action while sitting in Settings, and a view switch flips availability without
+ * a restart. The handler expands the declaration's `steps` into the view's
+ * EXISTING agent-surface interact sequence (`agent-fill`/`agent-click`/
+ * `agent-focus` against `useAgentElement` ids), dispatched through the shared
+ * `dispatchViewInteract` in views-routes.ts — there is no parallel DOM-driving
+ * path. A step whose target `useAgentElement` id is not mounted fails loudly
+ * with a typed {@link ElizaError} (`VIEW_SCOPED_ACTION_ELEMENT_MISSING`), never
+ * a silent no-op.
+ *
+ * plugin-lifecycle registers these when a view's plugin loads and unregisters
+ * them on unload/reload; builtin views register theirs at server boot. This is
+ * the mechanism only — per-view children declare the concrete actions.
+ */
+
+import {
+  type Action,
+  type ActionResult,
+  ElizaError,
+  type IAgentRuntime,
+  logger,
+  type Memory,
+  type State,
+  type ViewScopedAction,
+  type ViewScopedActionStep,
+  type ViewType,
+} from "@elizaos/core";
+import {
+  dispatchViewInteract,
+  getViewsBroadcastWs,
+} from "../api/views-routes.ts";
+import { getView } from "../api/views-registry.ts";
+import { getActiveViewContext } from "./view-action-affinity.ts";
+
+/** How long a single agent-surface step waits for the frontend to resolve. */
+const SCOPED_ACTION_STEP_TIMEOUT_MS = 5_000;
+
+/** Whole-string `{{paramName}}` token; the token must be the entire value. */
+const PARAM_TOKEN = /^\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}$/;
+
+/**
+ * Read the action parameters the planner passes. The runtime nests validated
+ * params under `options.parameters` (the #10677 contract); fall back to the flat
+ * `options` object for direct/test callers. Returns an empty object when absent.
+ */
+function readActionParams(
+  options: unknown,
+): Record<string, unknown> {
+  if (!options || typeof options !== "object") return {};
+  const record = options as Record<string, unknown>;
+  const nested = record.parameters;
+  if (nested && typeof nested === "object" && !Array.isArray(nested)) {
+    return nested as Record<string, unknown>;
+  }
+  return record;
+}
+
+/**
+ * Resolve a step's fill value: a bare `{{param}}` token pulls that parameter,
+ * anything else is a literal. Throws a typed error when a referenced parameter
+ * is missing rather than filling an empty/placeholder value into the control.
+ */
+function resolveStepValue(
+  step: ViewScopedActionStep,
+  params: Record<string, unknown>,
+  actionName: string,
+): string {
+  const raw = step.value ?? "";
+  const match = PARAM_TOKEN.exec(raw.trim());
+  if (!match) return raw;
+  const key = match[1];
+  const value = params[key];
+  if (value === undefined || value === null || value === "") {
+    throw new ElizaError(
+      `View-scoped action "${actionName}" step fills "${step.target}" from parameter "${key}", which was not provided`,
+      {
+        code: "VIEW_SCOPED_ACTION_PARAM_MISSING",
+        context: { actionName, target: step.target, parameter: key },
+        severity: "ephemeral",
+      },
+    );
+  }
+  return String(value);
+}
+
+/** Map a declared step to its interact capability + params payload. */
+function stepToCapability(
+  step: ViewScopedActionStep,
+  params: Record<string, unknown>,
+  actionName: string,
+): { capability: string; params: Record<string, unknown> } {
+  switch (step.kind) {
+    case "agent-fill":
+      return {
+        capability: "agent-fill",
+        params: {
+          id: step.target,
+          value: resolveStepValue(step, params, actionName),
+        },
+      };
+    case "agent-click":
+      return { capability: "agent-click", params: { id: step.target } };
+    case "agent-focus":
+      return { capability: "agent-focus", params: { id: step.target } };
+  }
+}
+
+/**
+ * True when an interact dispatch result signals the target element was not
+ * mounted. The agent-surface registry does not throw for a missing id — it
+ * returns `{ ok: false, reason: "element not found" | "element not mounted" }`,
+ * which the frontend relays as a SUCCESSFUL interact carrying that payload. So a
+ * missing element reads as `dispatch.success === true` with `result.ok === false`;
+ * detect it here so the handler can throw loudly instead of reporting success.
+ */
+function isMissingElementResult(result: unknown): boolean {
+  const payload = unwrapInteractResult(result);
+  if (!payload || typeof payload !== "object") return false;
+  const record = payload as Record<string, unknown>;
+  if (record.ok !== false) return false;
+  const reason = typeof record.reason === "string" ? record.reason : "";
+  return /not found|not mounted/i.test(reason);
+}
+
+/** The reason string from a `{ ok: false, reason }` agent-surface result, if any. */
+function failureReason(result: unknown): string | undefined {
+  const payload = unwrapInteractResult(result);
+  if (!payload || typeof payload !== "object") return undefined;
+  const reason = (payload as Record<string, unknown>).reason;
+  return typeof reason === "string" ? reason : undefined;
+}
+
+/**
+ * Peel the interact envelope down to the agent-surface `AgentActionResult`. The
+ * frontend round-trip wraps it as `{ success, result: <payload> }`; a direct
+ * `serverInteract` returns the payload itself. Handle both.
+ */
+function unwrapInteractResult(result: unknown): unknown {
+  if (!result || typeof result !== "object") return result;
+  const record = result as Record<string, unknown>;
+  return "result" in record ? record.result : record;
+}
+
+/**
+ * Resolve the concrete view type the scoped action's view is registered under,
+ * preferring the active view's type. Scoped actions only validate while their
+ * view is active, so at handler time the active view IS the declaring view.
+ */
+function resolveViewType(viewId: string): ViewType {
+  const active = getActiveViewContext();
+  if (active?.viewId === viewId) return active.viewType;
+  return getView(viewId)?.viewType ?? "gui";
+}
+
+/**
+ * Build a runtime {@link Action} from a view's scoped-action declaration.
+ *
+ * @param viewId - the declaring view's id (the active-view gate).
+ * @param decl   - the scoped-action declaration.
+ */
+export function buildViewScopedAction(
+  viewId: string,
+  decl: ViewScopedAction,
+): Action {
+  const paramList = decl.parameters ?? [];
+  const paramLine =
+    paramList.length > 0 ? ` (parameters: ${paramList.join(", ")})` : "";
+
+  return {
+    name: decl.name,
+    description: decl.description,
+    similes: decl.similes,
+    routingHint: `only available while the "${viewId}" view is active -> ${decl.name}${paramLine}; drives that view's controls, unavailable elsewhere`,
+    // The declaring view must be the FOREGROUND active view. This is the gate
+    // that keeps the agent from driving a view's controls while looking at a
+    // different one; a view switch (POST /api/views/:id/navigate) re-stamps the
+    // active context and flips this without a restart.
+    validate: async (): Promise<boolean> => {
+      return getActiveViewContext()?.viewId === viewId;
+    },
+    handler: async (
+      _runtime: IAgentRuntime,
+      _message: Memory,
+      _state?: State,
+      options?: unknown,
+    ): Promise<ActionResult> => {
+      // Defense in depth: the executor already gates on validate(), but a
+      // hallucinated direct call must not drive a background view's controls.
+      const active = getActiveViewContext();
+      if (active?.viewId !== viewId) {
+        throw new ElizaError(
+          `View-scoped action "${decl.name}" requires the "${viewId}" view to be active (active view: ${active?.viewId ?? "none"})`,
+          {
+            code: "VIEW_SCOPED_ACTION_VIEW_INACTIVE",
+            context: {
+              actionName: decl.name,
+              requiredView: viewId,
+              activeView: active?.viewId ?? null,
+            },
+            severity: "ephemeral",
+          },
+        );
+      }
+
+      const broadcastWs = getViewsBroadcastWs();
+      const entry = getView(viewId, { viewType: active.viewType });
+      // A scoped action drives a MOUNTED view surface. With no way to reach a
+      // shell (no server-side handler and no WS broadcaster), the dispatch would
+      // block on the pending-request timeout and then read as a plain failure —
+      // fail loudly instead so the missing wiring surfaces to the agent.
+      if (!entry?.serverInteract && !broadcastWs) {
+        throw new ElizaError(
+          `View-scoped action "${decl.name}" cannot reach the "${viewId}" view: no mounted shell to dispatch to`,
+          {
+            code: "VIEW_SCOPED_ACTION_NO_SHELL",
+            context: { actionName: decl.name, viewId },
+            severity: "ephemeral",
+          },
+        );
+      }
+      if (!entry) {
+        throw new ElizaError(
+          `View-scoped action "${decl.name}" references view "${viewId}" which is not registered`,
+          {
+            code: "VIEW_SCOPED_ACTION_VIEW_UNREGISTERED",
+            context: { actionName: decl.name, viewId },
+            severity: "fatal",
+          },
+        );
+      }
+
+      const params = readActionParams(options);
+      const viewType = resolveViewType(viewId);
+      const driven: string[] = [];
+
+      for (const step of decl.steps) {
+        const { capability, params: stepParams } = stepToCapability(
+          step,
+          params,
+          decl.name,
+        );
+        const dispatch = await dispatchViewInteract(
+          entry,
+          viewId,
+          capability,
+          stepParams,
+          broadcastWs ?? undefined,
+          SCOPED_ACTION_STEP_TIMEOUT_MS,
+        );
+
+        if (isMissingElementResult(dispatch.result)) {
+          throw new ElizaError(
+            `View-scoped action "${decl.name}" targets element "${step.target}" in view "${viewId}", which is not mounted`,
+            {
+              code: "VIEW_SCOPED_ACTION_ELEMENT_MISSING",
+              context: {
+                actionName: decl.name,
+                viewId,
+                target: step.target,
+                capability,
+              },
+              severity: "ephemeral",
+            },
+          );
+        }
+        if (!dispatch.success) {
+          const reason = dispatch.error ?? failureReason(dispatch.result);
+          throw new ElizaError(
+            `View-scoped action "${decl.name}" step ${capability} on "${step.target}" failed${reason ? `: ${reason}` : ""}`,
+            {
+              code: "VIEW_SCOPED_ACTION_STEP_FAILED",
+              context: {
+                actionName: decl.name,
+                viewId,
+                target: step.target,
+                capability,
+                reason,
+              },
+              severity: "ephemeral",
+            },
+          );
+        }
+        driven.push(`${capability}:${step.target}`);
+      }
+
+      logger.info(
+        { src: "ViewScopedActions", actionName: decl.name, viewId, driven },
+        `[ViewScopedActions] "${decl.name}" drove ${driven.length} step(s) on view "${viewId}"`,
+      );
+
+      const text = `Ran "${decl.name}" on the ${entry.label} view (${driven.length} step${driven.length === 1 ? "" : "s"}).`;
+      return {
+        success: true,
+        text,
+        userFacingText: text,
+        data: { viewId, actionName: decl.name, steps: driven },
+      };
+    },
+  };
+}
+
+/**
+ * Names of the scoped actions a view declares. Used to reconcile the runtime
+ * registry on plugin reload (unregister the previous set before registering the
+ * new one) and to surface the view's named actions to the awareness block.
+ */
+export function scopedActionNames(
+  scopedActions: readonly ViewScopedAction[] | undefined,
+): string[] {
+  return [
+    ...new Set(
+      (scopedActions ?? []).map((a) => a.name.trim()).filter(Boolean),
+    ),
+  ];
+}
+
+/** A view (any modality) that can carry scoped-action declarations. */
+interface ScopedActionSourceView {
+  id: string;
+  scopedActions?: ViewScopedAction[];
+}
+
+/**
+ * Per-owner set of scoped-action names currently registered in the runtime, so
+ * a reload/unload can remove exactly the previously-registered set without
+ * touching another owner's actions. Keyed by the owner passed to
+ * {@link registerViewScopedActions} (plugin name, or "@elizaos/builtin").
+ */
+const registeredByOwner = new Map<string, Set<string>>();
+
+/**
+ * Reconcile the runtime action registry with the scoped actions declared by
+ * `owner`'s views: unregister the owner's previously-registered scoped actions,
+ * then register the current set. Idempotent — safe to call on every plugin
+ * (re)load. A duplicate action name across views is registered once (first
+ * wins) and warned, since the runtime registry is keyed by name.
+ *
+ * @returns the scoped-action names now registered for this owner.
+ */
+export function registerViewScopedActions(
+  runtime: Pick<IAgentRuntime, "registerAction" | "unregisterAction">,
+  owner: string,
+  views: readonly ScopedActionSourceView[],
+): string[] {
+  const previous = registeredByOwner.get(owner);
+  if (previous) {
+    for (const name of previous) runtime.unregisterAction(name);
+  }
+
+  const registered = new Set<string>();
+  for (const view of views) {
+    for (const decl of view.scopedActions ?? []) {
+      const name = decl.name.trim();
+      if (!name) continue;
+      if (registered.has(name)) {
+        logger.warn(
+          { src: "ViewScopedActions", owner, viewId: view.id, actionName: name },
+          `[ViewScopedActions] duplicate scoped-action name "${name}" for owner "${owner}" — keeping first`,
+        );
+        continue;
+      }
+      runtime.registerAction(buildViewScopedAction(view.id, decl));
+      registered.add(name);
+    }
+  }
+
+  if (registered.size > 0) {
+    registeredByOwner.set(owner, registered);
+    logger.info(
+      { src: "ViewScopedActions", owner, count: registered.size },
+      `[ViewScopedActions] registered ${registered.size} scoped action(s) for owner "${owner}"`,
+    );
+  } else {
+    registeredByOwner.delete(owner);
+  }
+  return [...registered];
+}
+
+/** Unregister all scoped actions registered for `owner` (plugin unload). */
+export function unregisterViewScopedActions(
+  runtime: Pick<IAgentRuntime, "unregisterAction">,
+  owner: string,
+): void {
+  const previous = registeredByOwner.get(owner);
+  if (!previous) return;
+  for (const name of previous) runtime.unregisterAction(name);
+  registeredByOwner.delete(owner);
+}
+
+/** Test-only: forget all owner→action bookkeeping (does not touch a runtime). */
+export function __resetViewScopedActionRegistryForTests(): void {
+  registeredByOwner.clear();
+}

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -773,6 +773,70 @@ export interface ViewCapability {
 }
 
 /**
+ * One agent-surface interaction step a {@link ViewScopedAction} expands into.
+ * The `kind` maps to the exact interact capability the view already dispatches
+ * (`agent-fill`/`agent-click`/`agent-focus`) so a named domain action never
+ * builds a parallel DOM-automation path — it resolves to the same
+ * `useAgentElement` id sequence the element-level protocol drives.
+ *
+ * `target` is a `useAgentElement` id declared in the view. `value` is required
+ * for `agent-fill` and may reference an action parameter with `{{paramName}}`
+ * (whole-token substitution; the token must be the entire string). A `fill`
+ * step whose `value` is a bare literal fills that literal verbatim.
+ */
+export interface ViewScopedActionStep {
+	/** The interact capability this step dispatches. */
+	kind: "agent-fill" | "agent-click" | "agent-focus";
+	/** `useAgentElement` id in the declaring view this step acts on. */
+	target: string;
+	/**
+	 * Value to fill. Required when `kind === "agent-fill"`, ignored otherwise.
+	 * `"{{amount}}"` pulls the `amount` action parameter; any other string is
+	 * filled literally.
+	 */
+	value?: string;
+}
+
+/**
+ * A named, view-scoped agent action a view exposes while it is the active view.
+ *
+ * The host builds a real runtime {@link Action} from each declaration whose
+ * `validate()` returns false unless the declaring view is the foreground active
+ * view — so the agent cannot invoke a wallet action while sitting in Settings.
+ * The action's handler expands `steps` into the view's existing agent-surface
+ * interact sequence (`agent-fill`/`agent-click`/`agent-focus` against
+ * `useAgentElement` ids). A step whose `target` id is not mounted fails loudly
+ * with a typed error — never a silent no-op.
+ *
+ * This is the mechanism only; per-view children register concrete actions
+ * (settings `set-provider`, wallet `swap-tokens`, …) on top of it.
+ */
+export interface ViewScopedAction {
+	/**
+	 * Runtime action name, unique across the whole action registry. Convention:
+	 * `VIEW_<VIEWID>_<VERB>` in UPPER_SNAKE_CASE (e.g. `VIEW_SETTINGS_SET_PROVIDER`)
+	 * so it never collides with a global action or another view's scoped action.
+	 */
+	name: string;
+	/** One-line description surfaced to the planner. */
+	description: string;
+	/** Optional planner similes / aliases for this action. */
+	similes?: string[];
+	/**
+	 * Ordered agent-surface steps this action expands into. Each references a
+	 * `useAgentElement` id in the declaring view; the host dispatches them in
+	 * order through the interact protocol and stops on the first failure.
+	 */
+	steps: ViewScopedActionStep[];
+	/**
+	 * Action parameter names referenced by `{{param}}` tokens in step values.
+	 * Declared so the planner surfaces them and the host can validate presence
+	 * before dispatching. Empty when the action's steps are fully literal.
+	 */
+	parameters?: string[];
+}
+
+/**
  * A UI view contributed by a plugin.
  *
  * Views are compiled to JavaScript bundles, served by the agent router at
@@ -826,9 +890,20 @@ export interface ViewDeclaration {
 	/**
 	 * Runtime action names especially relevant while this view is foreground.
 	 * Hosts use these as view-scoped affinity hints so plugins keep their own
-	 * view -> action relationship with the view declaration.
+	 * view -> action relationship with the view declaration. Weighting only —
+	 * these are existing global actions kept at full param detail while the view
+	 * is active. For actions that only make sense in this view (gated so the
+	 * agent cannot invoke them elsewhere) declare {@link scopedActions} instead.
 	 */
 	relatedActions?: string[];
+	/**
+	 * Named agent actions this view exposes ONLY while it is the active view.
+	 * The host registers a real runtime action per entry whose `validate()`
+	 * gates on this view being foreground, and whose handler drives the view's
+	 * `useAgentElement` controls through the existing interact protocol. See
+	 * {@link ViewScopedAction}.
+	 */
+	scopedActions?: ViewScopedAction[];
 	/**
 	 * Optional free-form planner hints for this view.
 	 */

--- a/packages/ui/src/agent-surface/registry.test.ts
+++ b/packages/ui/src/agent-surface/registry.test.ts
@@ -264,6 +264,33 @@ describe("handleAgentSurfaceCapability", () => {
     ).toThrow(/requires an `id`/);
   });
 
+  // The signal the server-side view-scoped action handler keys on to throw a
+  // typed VIEW_SCOPED_ACTION_ELEMENT_MISSING error (#13589): a fill/click/focus
+  // against an UNMOUNTED useAgentElement id must resolve to `{ ok: false,
+  // reason: "element not found" }`, never a thrown capability error and never a
+  // silent success. This pins the cross-boundary contract on the UI side.
+  it("reports { ok:false, reason } for a missing element id (never silent, never throw)", () => {
+    const registry = getOrCreateViewRegistry("test-view", "gui");
+    // No elements registered → every action targets an unmounted id.
+    for (const capability of [
+      "agent-fill",
+      "agent-click",
+      "agent-focus",
+    ] as const) {
+      const params =
+        capability === "agent-fill"
+          ? { id: "ghost", value: "x" }
+          : { id: "ghost" };
+      const result = handleAgentSurfaceCapability(
+        registry,
+        capability,
+        params,
+      ) as { ok: boolean; reason?: string };
+      expect(result.ok).toBe(false);
+      expect(result.reason ?? "").toMatch(/not found|not mounted/i);
+    }
+  });
+
   it("exposes the same registry instance through the module map", () => {
     const a = getOrCreateViewRegistry("test-view", "gui");
     const b = getViewRegistry("test-view", "gui");


### PR DESCRIPTION
Closes #13589. Parent epic #13560.

## What & why

Ships the **mechanism** for a view to expose named, typed agent actions that are available **only while it is the foreground active view** — the agent cannot invoke a wallet action while sitting in Settings. This is the prerequisite for the per-view children's concrete typed actions (settings `set-provider`, wallet `swap-tokens`, character `FILL_BIO`, …); those land on this mechanism in later issues. No per-view actions are declared here.

### The contract (ordered per the issue spec)

1. **`ViewDeclaration.scopedActions`** (`packages/core/src/types/plugin.ts`) — a view declares named actions, each with an ordered `steps` sequence of agent-surface interactions (`agent-fill`/`agent-click`/`agent-focus`) against `useAgentElement` ids, plus `parameters` for `{{param}}` step-value tokens.
2. **`validate()` gates on the active view** — `view-scoped-actions.ts` builds a real runtime `Action` per declaration whose `validate()` returns false unless the declaring view is the active view (read from the same authoritative active-view context the affinity map uses). A view switch flips availability with **no restart**.
3. **Reuses the existing interact protocol** — the handler expands `steps` through the **shared** `dispatchViewInteract` in `views-routes.ts`. No parallel DOM-automation path: a named action like `set-provider` resolves to deterministic `agent-fill`/`agent-click` sequences against `useAgentElement` ids.
4. **Loud typed error on a missing element** — a step whose target `useAgentElement` id is not mounted throws `ElizaError` (`VIEW_SCOPED_ACTION_ELEMENT_MISSING`), never a silent no-op. Missing `{{param}}` values (`VIEW_SCOPED_ACTION_PARAM_MISSING`) and an inactive-view invocation (`VIEW_SCOPED_ACTION_VIEW_INACTIVE`) throw their own typed codes.
5. **Affinity stub deleted** — the 2-entry `HOST_VIEW_ACTION_AFFINITY` (`{plugins-page,settings}→RUNTIME`) is removed. Both built-in views already declare `relatedActions: ["RUNTIME"]`, so the derived map is now sourced entirely from view declarations. A regression test pins the RUNTIME parity, so this migrates with **no behavior change**.
6. **Awareness** — the active-view planner block names a view's scoped actions so the agent knows what it can invoke while there.

### Registration wiring
Scoped actions register / unregister / reconcile alongside plugin views (`plugin-lifecycle` register/unload/reload) and at builtin-view boot. The server wires a process-level WS broadcaster into the views module (`setViewsBroadcastWs`) so the handler — which runs from the planner loop, not an HTTP request — can drive a mounted shell through the same interact path the route uses; when no shell is reachable it fails loudly (`VIEW_SCOPED_ACTION_NO_SHELL`) rather than hanging.

### Concurrency note (#13587)
The sibling intent-manifest child adds a distinct field to `ViewDeclaration`/`builtin-views`. My additions are named distinctly (`scopedActions` / `ViewScopedAction`), the fields do not overlap, and this branch rebased cleanly onto the current `develop` tip.

## Test evidence

Real path, no mock of the unit under test. `validate()` reads the real active-view context; the active view is flipped via the **real** `POST /api/views/:id/navigate` route handler; steps dispatch through the real `dispatchViewInteract`.

```
# packages/agent — view-scoped-actions.test.ts + view-action-affinity.test.ts
Test Files  2 passed (2)
     Tests  36 passed (36)

# packages/ui — agent-surface/registry.test.ts (capability surface)
Test Files  1 passed (1)
     Tests  14 passed (14)

# related view suites (regression — stub removal + server wiring)
#   view-capability-audit, view-id-drift, views-routes.navigate-broadcast,
#   views-routes.activate, views-system-smoke
Test Files  5 passed (5)
     Tests  71 passed (71)
```

- Runtime test: register a scoped action → flip the active view via the real navigate route → assert `validate()` gating flips; drive the real `agent-focus`/`agent-fill`/`agent-click` sequence (asserts the real `serverInteract` received the resolved param value + the click ran); assert the typed missing-element / missing-param / inactive-view errors; registration reconciliation on reload/unload + duplicate-name-across-views.
- UI test: the capability surface reports `{ ok:false, reason }` for an unmounted id across fill/click/focus (never throws, never silent) — the exact signal the server converts to the typed `ElizaError`.

```
# error-policy ratchet (touched production source)
[error-policy-ratchet] base origin/develop; 7 changed production source file(s)
[error-policy-ratchet] no new fallback-slop in touched files

# typecheck (only pre-existing @elizaos/plugin-aosp-local-inference module-resolution errors remain — unrelated optional native plugin)
packages/core   typecheck: clean
packages/agent  typecheck: clean (except pre-existing aosp)
```

## Evidence checklist
- Real-LLM trajectories — **N/A** — this ships the registration mechanism only; no per-view action or prompt/model behavior change to exercise against a live model (the awareness block is unit-tested; per-view children that add concrete actions will attach live trajectories).
- Backend logs — covered by the structured `[ViewScopedActions]` info lines the handler/registrar emit; asserted indirectly via the step-trace `data.steps` in tests.
- Before/after screenshots + video — **N/A** — no user-visible UI change in this PR (mechanism + types + registration only; the UI capability surface is unchanged, only newly test-covered).
- Per-platform capture — **N/A** — no native/mobile/desktop surface changed.
- Audio walkthrough — **N/A** — no voice/TTS/STT change.
- Domain artifacts — the scoped `Action` objects registered into the runtime registry, verified by the reconciliation tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
