### PR TITLE
ci(test): wire vacuous-green runner guard

### DIFF
--- a/.github/issue-evidence/13620-runner-guard-ci.md
+++ b/.github/issue-evidence/13620-runner-guard-ci.md
@@ -5,6 +5,9 @@
 - Wired `packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts`
   into `.github/workflows/scenario-pr.yml` next to the other explicit
   `packages/scripts/__tests__` contracts.
+- Wired the same guard into `.github/workflows/test.yml` as an always-on
+  ordinary PR job required by the `ci-ok` aggregate, so the guard no longer
+  depends on the opt-in `ci:full` heavy scenario family.
 - Hardened the guard's "valid min-tasks floor succeeds" case to use a
   self-contained temporary workspace fixture instead of depending on
   `@elizaos/agent` being present in sparse worktrees.
@@ -19,9 +22,11 @@ Passed:
 ```bash
 bun test packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
 bunx @biomejs/biome check \
+  .github/workflows/test.yml \
   .github/workflows/scenario-pr.yml \
+  .github/issue-evidence/13620-runner-guard-ci.md \
   packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
-ruby -e 'require "yaml"; YAML.load_file(".github/workflows/scenario-pr.yml"); puts "workflow yaml ok"'
+bunx yaml-lint .github/workflows/test.yml .github/workflows/scenario-pr.yml
 git diff --check
 ```
 

--- a/.github/issue-evidence/13620-runner-guard-ci.md
+++ b/.github/issue-evidence/13620-runner-guard-ci.md
@@ -1,0 +1,33 @@
+# 13620 runner guard CI wiring
+
+## Scope
+
+- Wired `packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts`
+  into `.github/workflows/scenario-pr.yml` next to the other explicit
+  `packages/scripts/__tests__` contracts.
+- Hardened the guard's "valid min-tasks floor succeeds" case to use a
+  self-contained temporary workspace fixture instead of depending on
+  `@elizaos/agent` being present in sparse worktrees.
+
+Out of scope: the larger #13620 coverage-gate allowlist / changed-source
+coverage tasks remain open.
+
+## Verification
+
+Passed:
+
+```bash
+bun test packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
+bunx @biomejs/biome check \
+  .github/workflows/scenario-pr.yml \
+  packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/scenario-pr.yml"); puts "workflow yaml ok"'
+git diff --check
+```
+
+Result: 11 tests passed, 0 failed, 27 assertions.
+
+N/A:
+
+- Screenshots/video: workflow/test-runner contract only; no UI changed.
+- Live model trajectory: no model/action/provider behavior changed.

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -856,6 +856,12 @@ jobs:
       - name: Test-runner pool + shard unit tests
         run: bun test packages/scripts/__tests__/test-task-pool.test.ts
 
+      # #13620/#12342: spawned real-runner guards for vacuous-green failures.
+      # packages/scripts/__tests__ is outside workspace test discovery, so keep
+      # this explicit or zero-task / no-tests-skip regressions can ship green.
+      - name: Test-runner vacuous-green guard
+        run: bun test packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
+
       # Contract-tests the cloud agent image workflow's Turbo build step.
       # packages/scripts/__tests__ is outside workspace test discovery, so keep
       # this explicit or the workflow contract can silently stop running in CI.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,27 @@ jobs:
             --output "$GITHUB_OUTPUT" \
             --summary "$GITHUB_STEP_SUMMARY"
 
+  test-runner-vacuous-green-guard:
+    name: Test-runner vacuous-green guard
+    needs: changes
+    # #13620/#12342: this guard protects the ordinary PR path from runner lanes
+    # that collect no real tests or swallow a failure as "no tests found".
+    # Keep it outside path gates and outside the opt-in `ci:full` heavy family.
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Test-runner vacuous-green guard
+        run: bun test packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
+
   server-tests:
     name: Server Tests
     needs: changes
@@ -1392,6 +1413,7 @@ jobs:
     if: ${{ !cancelled() && always() }}
     needs:
       - changes
+      - test-runner-vacuous-green-guard
       - merge-quality-gate
       - server-tests
       - client-tests
@@ -1415,6 +1437,7 @@ jobs:
           set -u
           echo "=== Required test job results ==="
           echo "changes:          ${{ needs.changes.result }}"
+          echo "runner guard:     ${{ needs.test-runner-vacuous-green-guard.result }}"
           echo "merge-quality-gate:${{ needs.merge-quality-gate.result }}"
           echo "server-tests:     ${{ needs.server-tests.result }}"
           echo "client-tests:     ${{ needs.client-tests.result }}"
@@ -1431,6 +1454,7 @@ jobs:
           bad=0
           for pair in \
             "changes:${{ needs.changes.result }}" \
+            "test-runner-vacuous-green-guard:${{ needs.test-runner-vacuous-green-guard.result }}" \
             "merge-quality-gate:${{ needs.merge-quality-gate.result }}" \
             "server-tests:${{ needs.server-tests.result }}" \
             "client-tests:${{ needs.client-tests.result }}" \

--- a/packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
+++ b/packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
@@ -12,17 +12,44 @@ import { fileURLToPath } from "node:url";
 const runner = fileURLToPath(new URL("../run-all-tests.mjs", import.meta.url));
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
 
+// Each case spawns the real runner (workspace discovery over the whole repo),
+// so give bun headroom well past the discovery cost on a cold/contended runner.
+const SPAWN_TIMEOUT_MS = 60_000;
+const OUTPUT_TAIL_CHARS = 4000;
+
+function tail(value) {
+  if (value.length <= OUTPUT_TAIL_CHARS) return value;
+  return value.slice(-OUTPUT_TAIL_CHARS);
+}
+
 function run(args, env = {}) {
-  const result = spawnSync(process.execPath, [runner, ...args], {
+  const command = [process.execPath, runner, ...args];
+  const result = spawnSync(command[0], command.slice(1), {
     cwd: repoRoot,
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
+    timeout: SPAWN_TIMEOUT_MS,
     env: { ...process.env, ...env },
   });
+  const stdout = result.stdout || "";
+  const stderr = result.stderr || "";
+  if (result.error || result.signal) {
+    throw new Error(
+      [
+        `run-all-tests spawn did not complete: ${command.join(" ")}`,
+        `status=${String(result.status)} signal=${String(result.signal)}`,
+        `error=${result.error?.message ?? "none"}`,
+        `stdout tail:\n${tail(stdout)}`,
+        `stderr tail:\n${tail(stderr)}`,
+      ].join("\n\n"),
+    );
+  }
   return {
     status: result.status,
-    stdout: result.stdout || "",
-    stderr: result.stderr || "",
+    signal: result.signal,
+    error: result.error,
+    stdout,
+    stderr,
   };
 }
 
@@ -31,6 +58,11 @@ const TEMP_PACKAGE_DIR = join(
   repoRoot,
   "packages",
   "__run_all_tests_false_no_test_skip__",
+);
+const PLAN_FLOOR_PACKAGE_DIR = join(
+  repoRoot,
+  "packages",
+  "__run_all_tests_plan_floor_fixture__",
 );
 // A second temp package whose `test` script is a SINGLE `bun test <file>`
 // invocation — i.e. one that canSkipWhenOutputHasNoTests() treats as
@@ -47,10 +79,6 @@ const SKIPPABLE_EMPTY_PACKAGE_DIR = join(
   "packages",
   "__run_all_tests_genuinely_no_tests__",
 );
-
-// Each case spawns the real runner (workspace discovery over the whole repo),
-// so give bun headroom well past the discovery cost on a cold/contended runner.
-const SPAWN_TIMEOUT_MS = 60_000;
 
 describe("run-all-tests --min-tasks vacuous-green guard", () => {
   test(
@@ -103,9 +131,12 @@ describe("run-all-tests --min-tasks vacuous-green guard", () => {
     "without the guard, a collapsed lane keeps its historical non-failing exit",
     () => {
       // The guard is strictly additive: omitting --min-tasks must not change the
-      // pre-existing behaviour of a zero-task collapse (it does not exit 3).
+      // pre-existing behaviour of a zero-task collapse (green, no guard text).
       const result = run(["--no-cloud", `--filter=${NOWHERE_FILTER}`]);
-      expect(result.status).not.toBe(3);
+      expect(result.status).toBe(0);
+      expect(`${result.stdout}${result.stderr}`).not.toContain(
+        "VACUOUS-GREEN GUARD",
+      );
     },
     SPAWN_TIMEOUT_MS,
   );
@@ -133,19 +164,41 @@ describe("run-all-tests --min-tasks vacuous-green guard", () => {
   test(
     "plan mode still succeeds with a valid --min-tasks and reaches the floor",
     () => {
-      // Use a stable authored package instead of scanning the entire workspace:
-      // this file also creates/removes a temporary package in another test, and
-      // bun:test may overlap cases enough for an all-workspace plan to observe
-      // that transient fixture. The assertion we need here is narrower: a
-      // valid floor that is met must not make plan mode fail.
-      const result = run([
-        "--plan=json",
-        "--filter=@elizaos/agent",
-        "--min-tasks=1",
-      ]);
-      expect(result.status).toBe(0);
-      const parsed = JSON.parse(result.stdout);
-      expect(parsed.summary.taskCount).toBeGreaterThanOrEqual(1);
+      // Use a self-contained fixture instead of an authored workspace package:
+      // this guard is explicitly invoked from packages/scripts/__tests__, which
+      // can run in sparse worktrees where @elizaos/agent is absent. The runner
+      // only needs to prove a real discovered task satisfies the floor.
+      rmSync(PLAN_FLOOR_PACKAGE_DIR, { recursive: true, force: true });
+      mkdirSync(PLAN_FLOOR_PACKAGE_DIR, { recursive: true });
+      try {
+        writeFileSync(
+          join(PLAN_FLOOR_PACKAGE_DIR, "package.json"),
+          `${JSON.stringify(
+            {
+              name: "@elizaos/run-all-tests-plan-floor-fixture",
+              private: true,
+              type: "module",
+              scripts: {
+                test: 'node -e "process.exit(0)"',
+              },
+            },
+            null,
+            2,
+          )}\n`,
+        );
+
+        const result = run([
+          "--plan=json",
+          "--only=test",
+          "--filter=@elizaos/run-all-tests-plan-floor-fixture",
+          "--min-tasks=1",
+        ]);
+        expect(result.status).toBe(0);
+        const parsed = JSON.parse(result.stdout);
+        expect(parsed.summary.taskCount).toBe(1);
+      } finally {
+        rmSync(PLAN_FLOOR_PACKAGE_DIR, { recursive: true, force: true });
+      }
     },
     SPAWN_TIMEOUT_MS,
   );
@@ -319,6 +372,9 @@ describe("run-all-tests no-test-skip failure-swallow guard (#13620)", () => {
         const output = `${result.stdout}${result.stderr}`;
 
         expect(result.status).toBe(0);
+        expect(output).toContain(
+          "SKIP @elizaos/run-all-tests-genuinely-no-tests-fixture",
+        );
         expect(output).not.toContain(
           "FAIL @elizaos/run-all-tests-genuinely-no-tests-fixture",
         );

--- a/packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
+++ b/packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
@@ -1,8 +1,10 @@
-// Pins the --min-tasks vacuous-green guard in run-all-tests.mjs (#12342): a lane
-// that a filter/shard/glob collapses to (near-)zero collected tasks must fail
-// loudly (exit 3) instead of exiting green having asserted nothing. Runs the
-// real runner in --plan/collection mode with a filter that matches no package —
-// no vitest is spawned, so the harness is deterministic and fast.
+/**
+ * Pins the run-all-tests.mjs vacuous-green guards (#12342/#13620).
+ *
+ * The suite spawns the real runner against temporary workspace packages so a
+ * lane that collects no tasks, swallows a failure as "no tests found", or hides
+ * a test-file mismatch cannot exit green without exercising the runner path.
+ */
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";


### PR DESCRIPTION
## Summary

Addresses the codeable guard-test wiring slice of #13620.

- Adds `packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts` to the explicit `packages/scripts/__tests__` block in `scenario-pr.yml`, so the runner guard no longer relies on workspace discovery that excludes `packages/scripts` tests.
- Hardens the guard test by replacing its dependency on `@elizaos/agent` with a self-contained temporary workspace fixture, so the suite also passes in sparse worktrees.
- Adds spawned-runner timeout/error/signal handling with command and stdout/stderr tails, and tightens assertions so preflight/import failures cannot accidentally satisfy the expected status checks.

Remaining #13620 tasks around coverage-gate allowlists and changed-source coverage are intentionally out of scope.

## Evidence

Evidence file: `.github/issue-evidence/13620-runner-guard-ci.md`

Passed:

```bash
bun test packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
bunx @biomejs/biome check \
  .github/workflows/scenario-pr.yml \
  packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/scenario-pr.yml"); puts "workflow yaml ok"'
git diff --check
```

Result: 11 tests passed, 0 failed, 27 assertions.

N/A:

- Screenshots/video: workflow/test-runner contract only; no UI changed.
- Live model trajectory: no model/action/provider behavior changed.
