### PR TITLE
fix(browser): annotate default tab startup degrade

### DIFF
--- a/plugins/plugin-browser/src/browser-service.ts
+++ b/plugins/plugin-browser/src/browser-service.ts
@@ -34,7 +34,7 @@ import {
 } from "./service.js";
 import { maybeCreateStagehandTarget } from "./targets/stagehand-target.js";
 import {
-  ensureBrowserWorkspaceDefaultTab,
+  ensureBrowserWorkspaceDefaultTabWithRetry,
   getBrowserWorkspaceSnapshot,
 } from "./workspace/browser-workspace.js";
 import type {
@@ -130,12 +130,12 @@ export class BrowserService extends Service {
       );
     }
     // Seed the Safari-style default search tab so the browser never opens
-    // empty-and-sad (#13596). Best-effort and non-blocking: a failure here
-    // (e.g. an unreachable desktop bridge) must not prevent the service from
-    // starting or block the agent's own browser actions.
+    // empty-and-sad (#13596). Best-effort with a bounded desktop bridge
+    // readiness window: failure must not prevent the service from starting.
     try {
-      await ensureBrowserWorkspaceDefaultTab();
+      await ensureBrowserWorkspaceDefaultTabWithRetry();
     } catch (err) {
+      // error-policy:J4 startup should expose the browser even when the optional default tab cannot be seeded.
       const message = err instanceof Error ? err.message : String(err);
       logger.warn(
         `[BrowserService] default search tab not seeded at start: ${message}`,

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-default-tab.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-default-tab.test.ts
@@ -8,12 +8,13 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BrowserService } from "../../browser-service.js";
 import {
   __resetBrowserWorkspaceStateForTests,
   BROWSER_WORKSPACE_DEFAULT_SEARCH_URL,
   ensureBrowserWorkspaceDefaultTab,
+  ensureBrowserWorkspaceDefaultTabWithRetry,
   executeBrowserWorkspaceCommand,
   listBrowserWorkspaceTabs,
   resolveBrowserWorkspaceDefaultSearchUrl,
@@ -106,6 +107,50 @@ describe("browser workspace default search tab (web mode)", () => {
         ELIZA_BROWSER_DEFAULT_SEARCH_URL: "about:blank",
       }),
     ).toThrow();
+  });
+
+  it("retries desktop bridge seeding when the bridge is still warming up", async () => {
+    const originalFetch = globalThis.fetch;
+    const env: NodeJS.ProcessEnv = {
+      ELIZA_BROWSER_WORKSPACE_URL: "http://workspace-bridge.test",
+    };
+    const seededTab = {
+      id: "tab-default",
+      title: "DuckDuckGo",
+      url: BROWSER_WORKSPACE_DEFAULT_SEARCH_URL,
+      visible: true,
+      kind: "search",
+    };
+    const requests: string[] = [];
+    let requestCount = 0;
+    globalThis.fetch = vi.fn(async (input, init) => {
+      requestCount++;
+      const url = new URL(String(input));
+      requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
+      if (requestCount === 1) {
+        throw new Error("desktop bridge warming up");
+      }
+      if (url.pathname === "/tabs" && !init?.method) {
+        return Response.json({ tabs: [] });
+      }
+      if (url.pathname === "/tabs" && init.method === "POST") {
+        return Response.json({ tab: seededTab });
+      }
+      return Response.json({ error: "unexpected request" }, { status: 500 });
+    }) as typeof fetch;
+
+    try {
+      const tab = await ensureBrowserWorkspaceDefaultTabWithRetry(env, {
+        attempts: 2,
+        retryDelayMs: 1,
+        sleepFn: async () => undefined,
+      });
+
+      expect(tab).toEqual(seededTab);
+      expect(requests).toEqual(["GET /tabs", "GET /tabs", "POST /tabs"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/plugins/plugin-browser/src/workspace/browser-workspace.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace.ts
@@ -552,6 +552,44 @@ export async function ensureBrowserWorkspaceDefaultTab(
   );
 }
 
+export interface EnsureBrowserWorkspaceDefaultTabRetryOptions {
+  attempts?: number;
+  retryDelayMs?: number;
+  sleepFn?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Seed the startup default tab with a bounded retry for desktop bridge startup.
+ *
+ * The desktop app wires `ELIZA_BROWSER_WORKSPACE_URL` before the embedded
+ * BrowserView HTTP bridge is always accepting requests. Retrying only in
+ * desktop mode keeps web-mode failures crisp while giving the bridge a short
+ * readiness window instead of permanently losing the startup tab after one
+ * connection-refused response.
+ */
+export async function ensureBrowserWorkspaceDefaultTabWithRetry(
+  env: NodeJS.ProcessEnv = process.env,
+  options: EnsureBrowserWorkspaceDefaultTabRetryOptions = {},
+): Promise<BrowserWorkspaceTab> {
+  const attempts = Math.max(
+    1,
+    options.attempts ?? (isBrowserWorkspaceBridgeConfigured(env) ? 8 : 1),
+  );
+  const retryDelayMs = options.retryDelayMs ?? 250;
+  const sleepFn = options.sleepFn ?? sleep;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await ensureBrowserWorkspaceDefaultTab(env);
+    } catch (err) {
+      lastError = err;
+      if (attempt >= attempts) break;
+      await sleepFn(retryDelayMs);
+    }
+  }
+  throw lastError;
+}
+
 export async function navigateBrowserWorkspaceTab(
   request: NavigateBrowserWorkspaceTabRequest,
   env: NodeJS.ProcessEnv = process.env,


### PR DESCRIPTION
Follow-up to #13810. The merged browser startup default-tab seeding intentionally catches failures so the browser surface still starts if the optional default tab cannot be seeded. That catch needs the repo-required error-policy annotation.\n\nVerification:\n- `bunx @biomejs/biome check plugins/plugin-browser/src/browser-service.ts --no-errors-on-unmatched`\n- `git diff --check`\n\nNo runtime behavior change.