### PR TITLE
feat(orchestrator): admission queue instead of hard-throw at session cap (#13772)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -1906,48 +1906,107 @@ describe("AcpService.runHealthCheck state_lost guards", () => {
     expect(after?.status).toBe("errored");
   });
 
-  it("enforces ELIZA_ACP_MAX_SESSIONS atomically under concurrent spawns", async () => {
+  it("queues spawns beyond ELIZA_ACP_MAX_SESSIONS and admits them FIFO as slots free (#13772)", async () => {
     // Native transport: each spawn resolves to an active ("ready") session
-    // without the proc-mock dance, so we can fire many in parallel and let the
-    // check-and-reserve race. Before the fix, the limit check (list) and the
-    // insert (create) were separate awaited ops, so N concurrent spawns could
-    // all pass the check before any inserted and overshoot the cap.
+    // without the proc-mock dance, so we can fire more than the cap and observe
+    // the admission queue. The cap must never overshoot (the mutex invariant),
+    // AND spawns beyond it must QUEUE (not reject) and admit in arrival order as
+    // slots free.
     const service = new AcpService(
       runtime({
         ELIZA_ACP_TRANSPORT: undefined,
         ELIZA_ACP_MAX_SESSIONS: "2",
+        ELIZA_ACP_ADMISSION_POLL_MS: "5",
       }),
     );
     await service.start();
 
-    const results = await Promise.allSettled(
-      Array.from({ length: 6 }, (_, i) =>
-        service.spawnSession({
-          name: `concurrent-${i}`,
-          workdir: "/tmp/acp-test",
+    const isActive = (s: { status: string }) =>
+      !["stopped", "errored", "completed", "cancelled"].includes(s.status);
+    const activeSessions = async () =>
+      (await service.listSessions()).filter(isActive);
+    const poll = async (cond: () => Promise<boolean> | boolean, ms = 3000) => {
+      const start = Date.now();
+      while (Date.now() - start < ms) {
+        if (await cond()) return;
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      throw new Error("poll timed out waiting for admission-queue condition");
+    };
+
+    const settled: number[] = [];
+    const spawns = Array.from({ length: 6 }, (_, i) =>
+      service
+        .spawnSession({ name: `q-${i}`, workdir: "/tmp/acp-test" })
+        .then((r) => {
+          settled.push(i);
+          return r;
         }),
-      ),
     );
 
-    const fulfilled = results.filter((r) => r.status === "fulfilled");
-    const rejected = results.filter((r) => r.status === "rejected");
-    // The cap must hold exactly: 2 succeed, the rest reject with the limit error.
-    expect(fulfilled).toHaveLength(2);
-    expect(rejected.length).toBe(4);
-    for (const r of rejected) {
-      expect((r as PromiseRejectedResult).reason).toBeInstanceOf(Error);
-      expect(((r as PromiseRejectedResult).reason as Error).message).toContain(
-        "max session limit reached",
+    // Only the cap admits immediately; the other four QUEUE (not reject).
+    await poll(
+      async () =>
+        (await activeSessions()).length === 2 &&
+        service.getAdmissionState().queuedSpawns === 4,
+    );
+    expect((await activeSessions()).length).toBe(2);
+    expect(service.getAdmissionState()).toEqual({
+      maxSessions: 2,
+      queuedSpawns: 4,
+    });
+    // Exactly the cap admitted so far; the rest are queued, not rejected.
+    expect(settled).toHaveLength(2);
+
+    // Free slots one at a time; each freed slot admits exactly one queued spawn
+    // and the cap is never overshot.
+    for (let expectedQueued = 4; expectedQueued > 0; expectedQueued--) {
+      const active = await activeSessions();
+      expect(active.length).toBeLessThanOrEqual(2);
+      await service.cancelSession(active[0].id);
+      await poll(
+        () => service.getAdmissionState().queuedSpawns === expectedQueued - 1,
       );
+      expect((await activeSessions()).length).toBeLessThanOrEqual(2);
     }
 
-    // And the store agrees: only 2 active sessions exist.
-    const sessions = await service.listSessions();
-    const active = sessions.filter(
+    // All six eventually admit — nothing dropped, nothing rejected. (The queue
+    // is FIFO by arrival at the reservation mutex; arrival order is not the
+    // creation index, because spawnSession does async pre-work before reserving
+    // — so we assert the admitted SET, not an index order.)
+    await Promise.all(spawns);
+    expect([...settled].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(service.getAdmissionState().queuedSpawns).toBe(0);
+  });
+
+  it("falls back to the hard-cap error when the admission wait expires (#13772)", async () => {
+    // The bounded wait preserves the original fail-closed behavior: if the cap
+    // stays saturated (a wedged session that never frees its slot), a queued
+    // spawn throws the original hard-cap error rather than parking forever.
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: undefined,
+        ELIZA_ACP_MAX_SESSIONS: "1",
+        ELIZA_ACP_ADMISSION_MAX_WAIT_MS: "40",
+        ELIZA_ACP_ADMISSION_POLL_MS: "5",
+      }),
+    );
+    await service.start();
+
+    // Fill the single slot and keep it occupied (never freed).
+    await service.spawnSession({ name: "holder", workdir: "/tmp/acp-test" });
+
+    await expect(
+      service.spawnSession({ name: "overflow", workdir: "/tmp/acp-test" }),
+    ).rejects.toThrow("max session limit reached");
+
+    // The cap held: still exactly one active session, and the queue drained.
+    const active = (await service.listSessions()).filter(
       (s) =>
         !["stopped", "errored", "completed", "cancelled"].includes(s.status),
     );
-    expect(active).toHaveLength(2);
+    expect(active).toHaveLength(1);
+    expect(service.getAdmissionState().queuedSpawns).toBe(0);
   });
 
   it("rejects a concurrent prompt for the same native session (TOCTOU #11028)", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -320,6 +320,15 @@ export class AcpService extends Service {
   // ELIZA_ACP_MAX_SESSIONS). A promise-chain mutex: each reservation awaits the
   // previous one's completion. See reserveSessionSlot.
   private spawnReservationLock: Promise<void> = Promise.resolve();
+  // Admission queue (issue #13772): spawns beyond maxSessions wait FIFO for a
+  // slot instead of hard-failing. Bounded by admissionMaxWaitMs; on expiry we
+  // throw the original hard-cap error (fail-closed backstop).
+  private readonly admissionMaxWaitMs: number;
+  private readonly admissionPollMs: number;
+  // Spawns currently waiting for a session slot (parked in the reservation
+  // mutex or polling awaitSessionSlot, not yet admitted). Surfaced via
+  // getAdmissionState() so the planner provider / status can show backpressure.
+  private admissionQueueDepth = 0;
   private readonly sessionTimeoutMs?: number;
   private readonly sessionCallbacks: SessionEventCallback[] = [];
   private readonly acpCallbacks: AcpEventCallback[] = [];
@@ -370,6 +379,11 @@ export class AcpService extends Service {
       "fixed";
     this.maxSessions =
       parsePositiveInt(this.setting("ELIZA_ACP_MAX_SESSIONS")) ?? 8;
+    this.admissionMaxWaitMs =
+      parsePositiveInt(this.setting("ELIZA_ACP_ADMISSION_MAX_WAIT_MS")) ??
+      5 * 60_000;
+    this.admissionPollMs =
+      parsePositiveInt(this.setting("ELIZA_ACP_ADMISSION_POLL_MS")) ?? 500;
     this.sessionTimeoutMs = parsePositiveInt(
       this.setting("ACPX_DEFAULT_TIMEOUT_MS") ??
         this.setting("ELIZA_ACP_PROMPT_TIMEOUT_MS"),
@@ -943,9 +957,10 @@ export class AcpService extends Service {
       lastActivityAt: now,
       metadata: hasMergedMetadata ? mergedMetadata : opts.metadata,
     };
-    // Atomic check-and-reserve: enforces the session limit and inserts under a
-    // single mutex so concurrent spawns can't overshoot maxSessions (the old
-    // separate enforceSessionLimit()/store.create() left a read-then-act race).
+    // Atomic admit-and-reserve: waits (FIFO, bounded) for a session slot and
+    // inserts under a single mutex, so concurrent spawns can't overshoot
+    // maxSessions and spawns beyond the cap queue instead of hard-failing
+    // (issue #13772). See reserveSessionSlot / awaitSessionSlot.
     await this.reserveSessionSlot(session);
 
     // Mint the per-spawn model lease BEFORE the transport branch, so the leased
@@ -2591,45 +2606,88 @@ export class AcpService extends Service {
     return session;
   }
 
-  private async enforceSessionLimit(): Promise<void> {
+  private async countActiveSessions(): Promise<number> {
     const sessions = await this.store.list();
-    const active = sessions.filter(
+    return sessions.filter(
       (s) =>
         !["stopped", "errored", "completed", "cancelled"].includes(s.status),
-    );
-    if (active.length >= this.maxSessions)
-      throw new Error(`acpx max session limit reached (${this.maxSessions})`);
+    ).length;
   }
 
   /**
-   * Atomically enforce the session limit and reserve the slot by inserting the
-   * session. Wrapping the check (`enforceSessionLimit`) and the insert
-   * (`store.create`) in a single mutex-guarded critical section makes them one
-   * indivisible operation, so N concurrent spawns can't all pass the limit
-   * check before any has inserted and overshoot `maxSessions`.
+   * Admission snapshot (issue #13772) for the planner provider / orchestrator
+   * status: the session cap and how many spawns are currently queued waiting
+   * for a slot (0 when the cap has spare capacity).
+   */
+  getAdmissionState(): { maxSessions: number; queuedSpawns: number } {
+    return {
+      maxSessions: this.maxSessions,
+      queuedSpawns: this.admissionQueueDepth,
+    };
+  }
+
+  /**
+   * Admission gate (issue #13772). Waits — FIFO, bounded — for a free session
+   * slot. Called inside the reservation mutex, so the head-of-line spawn holds
+   * the lock until it is admitted and every later spawn queues behind it
+   * deterministically; the cap can never be overshot (the same invariant the
+   * mutex gave the old atomic check-and-insert). If the cap stays saturated
+   * past `admissionMaxWaitMs` (e.g. wedged sessions) we throw the original
+   * hard-cap error so a spawn can never park forever.
+   */
+  private async awaitSessionSlot(): Promise<void> {
+    const deadline = Date.now() + this.admissionMaxWaitMs;
+    for (;;) {
+      if ((await this.countActiveSessions()) < this.maxSessions) return;
+      if (Date.now() >= deadline)
+        throw new Error(`acpx max session limit reached (${this.maxSessions})`);
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, this.admissionPollMs),
+      );
+    }
+  }
+
+  /**
+   * Reserve a session slot, queueing (FIFO) when the cap is full instead of
+   * hard-failing. The check (`awaitSessionSlot`) and the insert
+   * (`store.create`) run in one mutex-guarded critical section so N concurrent
+   * spawns can't all pass the check before any has inserted and overshoot
+   * `maxSessions`.
    *
    * The mutex is a promise chain: each call awaits the previous reservation's
-   * settlement (success OR failure) before running its own check+insert, so
-   * the count observed by `enforceSessionLimit` always includes every
-   * already-reserved session. Errors propagate to the caller; the chain itself
-   * never rejects (we swallow on the tail) so one failed reservation doesn't
-   * wedge the lock for later spawns.
+   * settlement (success OR failure) before observing the count, so the head of
+   * the queue holds the lock — polling for a slot — while later spawns block
+   * on it in arrival order. Errors (only the bounded-wait backstop) propagate
+   * to the caller; the chain itself never rejects (we swallow on the tail) so
+   * one failed reservation doesn't wedge the lock for later spawns.
    */
   private async reserveSessionSlot(session: SessionInfo): Promise<void> {
-    const previous = this.spawnReservationLock;
-    let release!: () => void;
-    this.spawnReservationLock = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    // Wait for the prior reservation to finish before observing the count.
-    // error-policy:J5 the prior reservation's rejection is observed by its own
-    // awaiter; here we only serialize on its settle before counting slots.
-    await previous.catch(() => {});
+    // Counted as queued for the whole time it waits for a slot, so
+    // getAdmissionState() reflects real backpressure (mutex waiters + the
+    // head-of-line spawn in awaitSessionSlot). Decremented the instant a slot
+    // is secured; failed/aborted waits decrement in the outer finally.
+    this.admissionQueueDepth++;
+    let admitted = false;
     try {
-      await this.enforceSessionLimit();
-      await this.store.create(session);
+      const previous = this.spawnReservationLock;
+      let release!: () => void;
+      this.spawnReservationLock = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      // Wait for the prior reservation to finish before observing the count.
+      // error-policy:J5 the prior reservation's rejection is observed by its
+      // own awaiter; here we only serialize on its settle before counting.
+      await previous.catch(() => {});
+      try {
+        await this.awaitSessionSlot();
+        admitted = true;
+        this.admissionQueueDepth--;
+        await this.store.create(session);
+      } finally {
+        release();
+      }
     } finally {
-      release();
+      if (!admitted) this.admissionQueueDepth--;
     }
   }
 


### PR DESCRIPTION
Implements the trunk decision of #13772 (epic #13766, WS2): the orchestrator's admission model.

## Problem

`AcpService.enforceSessionLimit()` threw `acpx max session limit reached (${cap})` once `ELIZA_ACP_MAX_SESSIONS` (default 8) sessions were active. There was **no queue** — the (cap+1)th concurrent spawn hard-failed and the rejection propagated as an opaque thrown `Error` the caller had to string-match. For a swarm orchestrator that fans out work, that means it **cannot schedule more tasks than the raw session cap; it drops them.** #13772 calls this "the single biggest open design question in the orchestrator."

## Decision: QUEUE (bounded, fail-closed backstop)

Of QUEUE / REJECT / auto-worktree, this ships **QUEUE** — the only option that lets a swarm absorb a board's worth of tasks past the cap (which #13469's taskboard goal-loop assumes). To avoid over-deciding the ambiguous "unbounded wait" question, the queue is **bounded**: if the cap stays saturated past `ELIZA_ACP_ADMISSION_MAX_WAIT_MS` (default 5m, e.g. a wedged session that never frees its slot), the spawn throws the **original** hard-cap error — so failure semantics are preserved as a backstop and no spawn parks forever.

## Implementation (minimal, low blast-radius)

Entirely inside the existing reservation chokepoint (`reserveSessionSlot` / new `awaitSessionSlot`) in `acp-service.ts`:

- The reservation promise-chain mutex already serializes spawns. The head-of-line spawn now **holds the lock while polling for a free slot**, so later spawns queue behind it in arrival order — FIFO by construction, and the cap **can never be overshot** (same invariant the old atomic check-and-insert gave).
- **No new session/task state** — a queued spawn is simply the caller's `await` not-yet-resolved (no session row exists until admitted).
- **No caller changes** — every `await service.spawnSession(...)` site is untouched; the promise just resolves later instead of rejecting.
- `getAdmissionState()` exposes `{ maxSessions, queuedSpawns }` for the planner provider / `/status` to surface backpressure.

Config: `ELIZA_ACP_ADMISSION_MAX_WAIT_MS` (default 300000), `ELIZA_ACP_ADMISSION_POLL_MS` (default 500).

## Evidence (real, in an isolated build)

Rewrote the throw-behavior test into two:
- **queue behavior** — 6 spawns vs cap 2: exactly 2 admit, **4 queue (not reject)**, cap never overshot; cancelling active sessions admits the queued spawns one-per-freed-slot; all 6 eventually fulfill (nothing dropped); `queuedSpawns` tracks 4→0.
- **fail-closed backstop** — cap 1, a held slot, `MAX_WAIT_MS=40`: the overflow spawn queues then throws the original `max session limit reached`; the cap holds.

```
Test Files  1 passed (1)
Tests  49 passed (49)     # 2 new + 47 existing acp-service unit tests
```
Package `typecheck` clean (exit 0). Built the `@elizaos/{core,auth,shared}` dep chain and ran the suite locally (repo CI is currently wedged — see #13745).

> N/A rows (PR_EVIDENCE): no UI/visual, no live-model trajectory, no device — this is a service-layer concurrency change covered by deterministic native-transport unit tests.

## Deliberately scoped follow-ups
- Surfacing `queuedSpawns` in the `active-sub-agents` provider **text** and `/api/orchestrator/status` — kept separate to avoid the provider prefix-cache churn the epic review flagged; `getAdmissionState()` is the ready API.
- Reconciling with the soft `waitForSpawnSlot` throttle (`ELIZA_MAX_CONCURRENT_SPAWNS`) and per-project fairness — noted in #13772 as open, not decided here.

Closes the WS2 admission-model decision for #13772 (unblocks the #13778 concurrency e2e). Part of epic #13766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
