### PR TITLE
feat(#13776): first-class task→project binding + project registry (data-model core)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -114,6 +114,7 @@ class FakeSqlAdapter {
         searchText,
         updatedAt,
         lastActivityAt,
+        projectId,
         document,
       ] = params;
       this.rows.set(id as string, {
@@ -125,6 +126,7 @@ class FakeSqlAdapter {
         search_text: searchText,
         updated_at: updatedAt,
         last_activity_at: lastActivityAt,
+        project_id: projectId,
         document,
       });
       return;
@@ -152,6 +154,10 @@ class FakeSqlAdapter {
     if (sql.includes("status = ?")) {
       const status = params[paramIndex++];
       rows = rows.filter((row) => row.status === status);
+    }
+    if (sql.includes("project_id = ?")) {
+      const projectId = params[paramIndex++];
+      rows = rows.filter((row) => row.project_id === projectId);
     }
     if (sql.includes("search_text LIKE ?")) {
       const needle = String(params[paramIndex++]).replace(/%/g, "");
@@ -995,5 +1001,142 @@ describe("orchestrator-task-store audit follow-ups (#11028)", () => {
     const reader = new FileTaskStore(path);
     const after = await reader.getTask(t.task.id);
     expect(after?.task.status).toBe("done");
+  });
+});
+
+describe("task ↔ project binding (#13776)", () => {
+  it("InMemoryTaskStore persists the first-class projectId/repo/workdir on the record", async () => {
+    const store = new InMemoryTaskStore();
+    const { task } = await store.createTask(
+      createInput({
+        projectId: "proj-1",
+        repo: "elizaOS/eliza",
+        workdir: "/repo/eliza",
+      }),
+    );
+    const loaded = await store.getTask(task.id);
+    expect(loaded?.task.projectId).toBe("proj-1");
+    expect(loaded?.task.repo).toBe("elizaOS/eliza");
+    expect(loaded?.task.workdir).toBe("/repo/eliza");
+  });
+
+  it("leaves projectId unset when the create input omits it (back-compat)", async () => {
+    const store = new InMemoryTaskStore();
+    const { task } = await store.createTask(createInput());
+    expect((await store.getTask(task.id))?.task.projectId).toBeUndefined();
+  });
+
+  it("filters the in-memory list by projectId", async () => {
+    const store = new InMemoryTaskStore();
+    const bound = await store.createTask(
+      createInput({ title: "bound", projectId: "proj-A" }),
+    );
+    await store.createTask(createInput({ title: "unbound" }));
+    await store.createTask(
+      createInput({ title: "other", projectId: "proj-B" }),
+    );
+    const onlyA = await store.listTasks({ projectId: "proj-A" });
+    expect(onlyA.map((t) => t.id)).toEqual([bound.task.id]);
+  });
+
+  it("FileTaskStore round-trips projectId through JSON persistence and a fresh reopen", async () => {
+    const file = await tempFile();
+    const store = new FileTaskStore(file);
+    const { task } = await store.createTask(
+      createInput({ title: "durable bind", projectId: "proj-file" }),
+    );
+
+    // The projectId is inside the persisted document JSON, not lost on write.
+    const raw = JSON.parse(await readFile(file, "utf8")) as Array<{
+      task: { projectId?: string };
+    }>;
+    expect(raw[0]?.task.projectId).toBe("proj-file");
+
+    const reopened = new FileTaskStore(file);
+    expect((await reopened.getTask(task.id))?.task.projectId).toBe("proj-file");
+  });
+
+  it("RuntimeDbTaskStore round-trips projectId and writes it to the dedicated column", async () => {
+    const adapter = new FakeSqlAdapter();
+    const store = new RuntimeDbTaskStore(adapter);
+    const { task } = await store.createTask(
+      createInput({ title: "sql bind", projectId: "proj-sql" }),
+    );
+    // Survives via the document JSON on read-back...
+    expect((await store.getTask(task.id))?.task.projectId).toBe("proj-sql");
+    // ...and is mirrored into the indexed `project_id` column.
+    expect(adapter.rows.get(task.id)?.project_id).toBe("proj-sql");
+  });
+
+  it("RuntimeDbTaskStore filters listTasks through the project_id WHERE clause", async () => {
+    const seenSql: string[] = [];
+    const adapter = new FakeSqlAdapter();
+    const capturing = {
+      execute: (sql: string, params?: unknown[]) =>
+        adapter.execute(sql, params),
+      all: (sql: string, params?: unknown[]) => {
+        seenSql.push(sql);
+        return adapter.all(sql, params);
+      },
+    };
+    const store = new RuntimeDbTaskStore(capturing);
+    const bound = await store.createTask(
+      createInput({ title: "bound", projectId: "proj-Q" }),
+    );
+    await store.createTask(createInput({ title: "unbound" }));
+
+    const listed = await store.listTasks({ projectId: "proj-Q" });
+    expect(listed.map((t) => t.id)).toEqual([bound.task.id]);
+    expect(seenSql.some((s) => /project_id = \?/.test(s))).toBe(true);
+  });
+
+  it("creates the orchestrator_tasks table with a project_id column", async () => {
+    const seenSql: string[] = [];
+    const adapter = new FakeSqlAdapter();
+    const capturing = {
+      execute: (sql: string, params?: unknown[]) => {
+        seenSql.push(sql);
+        return adapter.execute(sql, params);
+      },
+      all: (sql: string, params?: unknown[]) => adapter.all(sql, params),
+    };
+    const store = new RuntimeDbTaskStore(capturing);
+    await store.createTask(createInput({ title: "schema" }));
+    const createTable = seenSql.find((s) => /CREATE TABLE/i.test(s));
+    expect(createTable).toMatch(/project_id TEXT/i);
+  });
+
+  it("additively migrates a legacy table that predates the project_id column", async () => {
+    // A legacy adapter whose table rejects any `project_id` reference until the
+    // ALTER lands — reproducing an on-disk DB created before #13776.
+    class LegacyProjectlessAdapter extends FakeSqlAdapter {
+      hasProjectId = false;
+      alterCount = 0;
+
+      override async execute(sql: string, params: unknown[] = []) {
+        if (/ALTER TABLE orchestrator_tasks ADD COLUMN project_id/i.test(sql)) {
+          this.hasProjectId = true;
+          this.alterCount++;
+          return;
+        }
+        return super.execute(sql, params);
+      }
+
+      override async all(sql: string, params: unknown[] = []) {
+        if (/project_id/i.test(sql) && !this.hasProjectId) {
+          throw new Error("no such column: project_id");
+        }
+        return super.all(sql, params);
+      }
+    }
+    const adapter = new LegacyProjectlessAdapter();
+    const store = new RuntimeDbTaskStore(adapter);
+    // Initialization runs the probe → column missing → ALTER exactly once.
+    const { task } = await store.createTask(
+      createInput({ title: "migrated", projectId: "proj-legacy" }),
+    );
+    expect(adapter.alterCount).toBe(1);
+    expect(adapter.hasProjectId).toBe(true);
+    expect((await store.getTask(task.id))?.task.projectId).toBe("proj-legacy");
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/project-registry.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/project-registry.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Verifies the ProjectRegistry create/list/resolve surface and its tiered
+ * backend selection (#13776). Runs against real temp files and an in-process
+ * SQL adapter fake; deterministic, no live DB.
+ */
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  FileProjectStore,
+  InMemoryProjectStore,
+  ProjectRegistry,
+  RuntimeDbProjectStore,
+} from "../../src/services/project-registry.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+async function tempFile(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "project-registry-"));
+  tempDirs.push(dir);
+  return join(dir, "projects.json");
+}
+
+/** Faithful in-memory emulation of the narrow SQL surface
+ * {@link RuntimeDbProjectStore} relies on: an id-keyed row table plus the
+ * specific WHERE/ORDER BY/LIMIT shapes it issues. */
+class ProjectsFakeSqlAdapter {
+  readonly rows = new Map<string, Record<string, unknown>>();
+
+  async execute(sql: string, params: unknown[] = []): Promise<void> {
+    const head = sql.trim().slice(0, 6).toUpperCase();
+    if (head === "CREATE") return;
+    if (head === "INSERT") {
+      const [id, name, rootDir, createdAt] = params;
+      this.rows.set(id as string, {
+        id,
+        name,
+        root_dir: rootDir,
+        created_at: createdAt,
+      });
+    }
+  }
+
+  async all(sql: string, params: unknown[] = []): Promise<unknown[]> {
+    let rows = [...this.rows.values()];
+    if (sql.includes("WHERE id = ?")) {
+      return rows.filter((row) => row.id === params[0]);
+    }
+    if (sql.includes("WHERE root_dir = ?")) {
+      rows = rows.filter((row) => row.root_dir === params[0]);
+    }
+    rows.sort((a, b) =>
+      String(a.created_at).localeCompare(String(b.created_at)),
+    );
+    if (/LIMIT 1/.test(sql)) rows = rows.slice(0, 1);
+    return rows;
+  }
+}
+
+describe("ProjectRegistry backend selection", () => {
+  it("defaults to the file backend when no adapter is present", () => {
+    expect(new ProjectRegistry().backend).toBe("file");
+  });
+
+  it("uses memory when explicitly requested", () => {
+    expect(new ProjectRegistry({ backend: "memory" }).backend).toBe("memory");
+  });
+
+  it("selects runtime-db when a SQL adapter is supplied", () => {
+    const store = new ProjectRegistry({
+      runtime: { adapter: new ProjectsFakeSqlAdapter() },
+    });
+    expect(store.backend).toBe("runtime-db");
+  });
+
+  it("falls back to file when runtime-db is requested without an adapter", () => {
+    expect(new ProjectRegistry({ backend: "runtime-db" }).backend).toBe("file");
+  });
+});
+
+describe.each<[string, () => InMemoryProjectStore | RuntimeDbProjectStore]>([
+  ["InMemoryProjectStore", () => new InMemoryProjectStore()],
+  [
+    "RuntimeDbProjectStore",
+    () => new RuntimeDbProjectStore(new ProjectsFakeSqlAdapter()),
+  ],
+])("%s create/list/resolve", (_name, makeStore) => {
+  it("creates a project with an id, trimmed name, absolute root, and timestamp", async () => {
+    const store = makeStore();
+    const project = await store.createProject({
+      name: "  Eliza  ",
+      rootDir: "/repo/eliza",
+    });
+    expect(project.id).toMatch(/[0-9a-f-]{36}/);
+    expect(project.name).toBe("Eliza");
+    expect(project.rootDir).toBe(resolvePath("/repo/eliza"));
+    expect(Number.isNaN(Date.parse(project.createdAt))).toBe(false);
+  });
+
+  it("lists every created project", async () => {
+    const store = makeStore();
+    await store.createProject({ name: "A", rootDir: "/repo/a" });
+    await store.createProject({ name: "B", rootDir: "/repo/b" });
+    const names = (await store.listProjects()).map((p) => p.name).sort();
+    expect(names).toEqual(["A", "B"]);
+  });
+
+  it("resolves a project by its root dir, normalizing the lookup", async () => {
+    const store = makeStore();
+    const created = await store.createProject({
+      name: "Eliza",
+      rootDir: "/repo/eliza",
+    });
+    // Trailing slash / dot-segment resolve to the same natural key.
+    const resolved = await store.resolveProject("/repo/eliza/");
+    expect(resolved?.id).toBe(created.id);
+    expect((await store.resolveProject("/repo/eliza/."))?.id).toBe(created.id);
+  });
+
+  it("returns null when resolving an unregistered root", async () => {
+    const store = makeStore();
+    await store.createProject({ name: "Eliza", rootDir: "/repo/eliza" });
+    expect(await store.resolveProject("/repo/other")).toBeNull();
+  });
+
+  it("looks a project up by id and returns null for a miss", async () => {
+    const store = makeStore();
+    const created = await store.createProject({
+      name: "Eliza",
+      rootDir: "/repo/eliza",
+    });
+    expect((await store.getProject(created.id))?.name).toBe("Eliza");
+    expect(await store.getProject("no-such-id")).toBeNull();
+  });
+
+  it("is idempotent on rootDir: creating the same root twice yields one project", async () => {
+    const store = makeStore();
+    const first = await store.createProject({
+      name: "Eliza",
+      rootDir: "/repo/eliza",
+    });
+    const second = await store.createProject({
+      name: "Eliza (again)",
+      rootDir: "/repo/eliza/",
+    });
+    expect(second.id).toBe(first.id);
+    expect(await store.listProjects()).toHaveLength(1);
+    // First write wins the name; the binding stays stable.
+    expect(second.name).toBe("Eliza");
+  });
+});
+
+describe("FileProjectStore", () => {
+  it("persists projects to JSON and reloads them in a fresh store", async () => {
+    const file = await tempFile();
+    const store = new FileProjectStore(file);
+    const created = await store.createProject({
+      name: "durable",
+      rootDir: "/repo/durable",
+    });
+
+    const raw = JSON.parse(await readFile(file, "utf8")) as unknown[];
+    expect(raw).toHaveLength(1);
+
+    const reopened = new FileProjectStore(file);
+    expect((await reopened.getProject(created.id))?.name).toBe("durable");
+    expect((await reopened.resolveProject("/repo/durable"))?.id).toBe(
+      created.id,
+    );
+  });
+
+  it("merges a concurrent insert from another instance instead of clobbering it", async () => {
+    const file = await tempFile();
+    const a = new FileProjectStore(file);
+    const b = new FileProjectStore(file);
+    await a.listProjects();
+    await b.listProjects();
+    const pa = await a.createProject({ name: "from A", rootDir: "/repo/a" });
+    const pb = await b.createProject({ name: "from B", rootDir: "/repo/b" });
+    const reader = new FileProjectStore(file);
+    const ids = (await reader.listProjects()).map((p) => p.id);
+    expect(ids).toContain(pa.id);
+    expect(ids).toContain(pb.id);
+  });
+
+  it("discards malformed records when loading from disk", async () => {
+    const file = await tempFile();
+    const seed = new FileProjectStore(file);
+    const good = await seed.createProject({
+      name: "good",
+      rootDir: "/repo/good",
+    });
+    const { writeFile } = await import("node:fs/promises");
+    const valid = JSON.parse(await readFile(file, "utf8")) as unknown[];
+    await writeFile(
+      file,
+      JSON.stringify([...valid, { id: "x" }, "garbage", 7]),
+      "utf8",
+    );
+    const reopened = new FileProjectStore(file);
+    const listed = await reopened.listProjects();
+    expect(listed.map((p) => p.id)).toEqual([good.id]);
+  });
+});
+
+describe("RuntimeDbProjectStore durability", () => {
+  it("survives a restart: a fresh store over the same adapter still resolves the project", async () => {
+    const adapter = new ProjectsFakeSqlAdapter();
+    const first = new RuntimeDbProjectStore(adapter);
+    const created = await first.createProject({
+      name: "persisted",
+      rootDir: "/repo/persisted",
+    });
+    // Discard `first` entirely; rows live in the durable adapter.
+    const second = new RuntimeDbProjectStore(adapter);
+    expect((await second.getProject(created.id))?.name).toBe("persisted");
+    expect((await second.resolveProject("/repo/persisted"))?.id).toBe(
+      created.id,
+    );
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -910,6 +910,10 @@ async function runCreate(
   ) as OrchestratorTaskService | null | undefined;
   try {
     if (taskService && typeof taskService.createTask === "function") {
+      // Bind the durable task to the spawn's repo/workdir at creation so every
+      // session it later attaches shares one project root, instead of the task
+      // inferring a workdir from whichever session ran most recently (#13776).
+      const taskRepo = pickString(params, content, "repo");
       const detail = await taskService.createTask({
         title: taskTitle,
         goal: taskGoal,
@@ -920,6 +924,8 @@ async function runCreate(
           ? { roomId: originRoomId ?? taskRoomId }
           : {}),
         ...(taskRoomId ? { taskRoomId } : {}),
+        ...(explicitWorkdir ? { workdir: explicitWorkdir } : {}),
+        ...(taskRepo ? { repo: taskRepo } : {}),
         acceptanceCriteria,
       });
       threadId = detail?.id ?? null;

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -45,7 +45,7 @@ interface Logger {
   debug?: (message: string, ...args: unknown[]) => void;
 }
 
-interface TaskStoreRuntime {
+export interface TaskStoreRuntime {
   /** Modern eliza runtime exposes the DB adapter as `runtime.adapter`. */
   adapter?: unknown;
   /** Legacy alias kept for pre-2026 runtimes and custom container harnesses. */
@@ -56,7 +56,7 @@ interface TaskStoreRuntime {
 
 /** Raw shape: an adapter that exposes flat SQL methods directly. Older test
  * harnesses (and hand-rolled sqlite bindings) look like this. */
-type RawSqlDatabaseAdapter = {
+export type RawSqlDatabaseAdapter = {
   query?: (sql: string, params?: unknown[]) => Promise<unknown> | unknown;
   execute?: (sql: string, params?: unknown[]) => Promise<unknown> | unknown;
   run?: (sql: string, params?: unknown[]) => Promise<unknown> | unknown;
@@ -69,7 +69,7 @@ type RawSqlDatabaseAdapter = {
  * executor lives on `adapter.db.execute(sql\`...\`)` (drizzle's tagged-template
  * SQL). We only need `.execute` here. It returns a rowset for SELECTs and an
  * ack for writes, which is all this store's storage-layer touches. */
-type ElizaDrizzleAdapter = {
+export type ElizaDrizzleAdapter = {
   db: {
     execute: (query: unknown) => Promise<unknown> | unknown;
   };
@@ -77,7 +77,7 @@ type ElizaDrizzleAdapter = {
 
 /** Unified low-level executor. `run` performs a mutation and ignores the
  * result; `all` runs a SELECT and returns rows. */
-interface SqlExecutor {
+export interface SqlExecutor {
   run(sql: string, params?: unknown[]): Promise<void>;
   all(sql: string, params?: unknown[]): Promise<unknown[]>;
 }
@@ -145,7 +145,7 @@ function isElizaDrizzleAdapter(value: unknown): value is ElizaDrizzleAdapter {
   return isRecord(db) && typeof db.execute === "function";
 }
 
-function isPersistableAdapter(
+export function isPersistableAdapter(
   value: unknown,
 ): value is RawSqlDatabaseAdapter | ElizaDrizzleAdapter {
   return isRawSqlDatabaseAdapter(value) || isElizaDrizzleAdapter(value);
@@ -163,7 +163,7 @@ function isPersistableAdapter(
  * that ships `@elizaos/plugin-sql` (drizzle-orm is present), we require it
  * lazily at first use to avoid a hard dependency here.
  */
-async function resolveSqlExecutor(
+export async function resolveSqlExecutor(
   adapter: RawSqlDatabaseAdapter | ElizaDrizzleAdapter,
 ): Promise<SqlExecutor> {
   if (isElizaDrizzleAdapter(adapter)) {
@@ -286,6 +286,9 @@ function newTaskDocument(input: CreateTaskInput): OrchestratorTaskDocument {
     taskRoomId: input.taskRoomId,
     parentTaskId: input.parentTaskId,
     forkSource: input.forkSource,
+    projectId: input.projectId,
+    repo: input.repo,
+    workdir: input.workdir,
     providerPolicy: input.providerPolicy,
     paused: false,
     archived: false,
@@ -328,6 +331,7 @@ function matchesFilter(
   if (!filter.includeArchived && task.archived) return false;
   if (filter.status && filter.status !== "all" && task.status !== filter.status)
     return false;
+  if (filter.projectId && task.projectId !== filter.projectId) return false;
   if (filter.search) {
     const needle = filter.search.trim().toLowerCase();
     if (needle && !searchText.includes(needle)) return false;
@@ -810,6 +814,7 @@ const TASK_TABLE_SQL = `CREATE TABLE IF NOT EXISTS orchestrator_tasks (
   search_text TEXT,
   updated_at TEXT NOT NULL,
   last_activity_at BIGINT NOT NULL,
+  project_id TEXT,
   document TEXT NOT NULL
 )`;
 
@@ -817,6 +822,27 @@ const TASK_INDEX_SQL = [
   "CREATE INDEX IF NOT EXISTS idx_orch_tasks_status ON orchestrator_tasks(status)",
   "CREATE INDEX IF NOT EXISTS idx_orch_tasks_activity ON orchestrator_tasks(last_activity_at)",
 ];
+
+/**
+ * Additive migration for the `project_id` column (#13776), which was added
+ * after the initial schema — a table created earlier lacks it, and `CREATE
+ * TABLE IF NOT EXISTS` above won't add it. A probe `SELECT` distinguishes a
+ * current table (succeeds) from a legacy one (the driver rejects the unknown
+ * column), so the portable `ADD COLUMN` (no backend-specific `IF NOT EXISTS`)
+ * fires at most once per legacy table and never on the happy path.
+ */
+async function ensureProjectIdColumn(executor: SqlExecutor): Promise<void> {
+  try {
+    await executor.all("SELECT project_id FROM orchestrator_tasks LIMIT 1");
+  } catch {
+    // error-policy:J3 additive-migration probe — the SELECT rejecting means the
+    // column predates this schema, so add it. Any other failure re-surfaces
+    // from the ALTER below (fail-fast), never a swallowed no-op.
+    await executor.run(
+      "ALTER TABLE orchestrator_tasks ADD COLUMN project_id TEXT",
+    );
+  }
+}
 
 /** SQL backend. Stores the whole document as a JSON column with indexed
  * columns for the list query, so all reads/writes are single-row operations.
@@ -846,9 +872,11 @@ export class RuntimeDbTaskStore {
 
   private async ensureInitialized(): Promise<void> {
     this.initPromise ??= (async () => {
-      this.executor = await resolveSqlExecutor(this.adapter);
-      await this.executor.run(TASK_TABLE_SQL);
-      for (const sql of TASK_INDEX_SQL) await this.executor.run(sql);
+      const executor = await resolveSqlExecutor(this.adapter);
+      this.executor = executor;
+      await executor.run(TASK_TABLE_SQL);
+      for (const sql of TASK_INDEX_SQL) await executor.run(sql);
+      await ensureProjectIdColumn(executor);
     })();
     await this.initPromise;
   }
@@ -882,8 +910,8 @@ export class RuntimeDbTaskStore {
     // sqlite-only INSERT OR REPLACE form.
     await this.exec().run(
       `INSERT INTO orchestrator_tasks
-       (id, status, archived, priority, title, search_text, updated_at, last_activity_at, document)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       (id, status, archived, priority, title, search_text, updated_at, last_activity_at, project_id, document)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT (id) DO UPDATE SET
          status = excluded.status,
          archived = excluded.archived,
@@ -892,6 +920,7 @@ export class RuntimeDbTaskStore {
          search_text = excluded.search_text,
          updated_at = excluded.updated_at,
          last_activity_at = excluded.last_activity_at,
+         project_id = excluded.project_id,
          document = excluded.document`,
       [
         doc.task.id,
@@ -902,6 +931,9 @@ export class RuntimeDbTaskStore {
         searchText,
         doc.task.updatedAt,
         doc.task.lastActivityAt,
+        // Optional binding → SQL NULL (a genuinely nullable column), not a
+        // fabricated default: the authoritative value round-trips in `document`.
+        doc.task.projectId ?? null,
         JSON.stringify(doc),
       ],
     );
@@ -939,6 +971,10 @@ export class RuntimeDbTaskStore {
     if (filter.status && filter.status !== "all") {
       clauses.push("status = ?");
       params.push(filter.status);
+    }
+    if (filter.projectId) {
+      clauses.push("project_id = ?");
+      params.push(filter.projectId);
     }
     if (filter.search?.trim()) {
       clauses.push("search_text LIKE ?");

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
@@ -67,6 +67,21 @@ export interface OrchestratorTaskRecord {
   /** Lineage: the task this one was forked from, if any. */
   parentTaskId?: string;
   forkSource?: string;
+  /** First-class binding to a {@link ProjectRecord} in the project registry
+   * (`project-registry.ts`). Pins the task to one project so every session it
+   * spawns targets the same workspace root instead of drifting per-session
+   * (#13776). Optional + nullable: rows created before this field, and tasks
+   * with no resolved project, leave it unset. */
+  projectId?: string;
+  /** Canonical repository this task targets, captured at creation from the
+   * spawn context. First-class task binding, distinct from the per-session
+   * `repo` (which two sessions of one task can set differently) and from the
+   * derived `latestRepo` the mapper reads off the most-recent session. */
+  repo?: string;
+  /** Canonical working directory this task targets, captured at creation.
+   * First-class task binding, distinct from the derived `latestWorkdir`
+   * (most-recent session) the mapper still surfaces for back-compat. */
+  workdir?: string;
   /** Provider/model/subscription policy applied to spawned sub-agents. */
   providerPolicy?: TaskProviderPolicy;
   paused: boolean;
@@ -339,6 +354,8 @@ export interface TaskListFilter {
   search?: string;
   includeArchived?: boolean;
   limit?: number;
+  /** Restrict to tasks bound to this project (`OrchestratorTaskRecord.projectId`). */
+  projectId?: string;
 }
 
 export interface CreateTaskInput {
@@ -354,6 +371,10 @@ export interface CreateTaskInput {
   taskRoomId?: string;
   parentTaskId?: string;
   forkSource?: string;
+  /** Bind the new task to a registry project + its repo/workdir at creation. */
+  projectId?: string;
+  repo?: string;
+  workdir?: string;
   providerPolicy?: TaskProviderPolicy;
   currentPlan?: Record<string, unknown>;
   metadata?: Record<string, unknown>;

--- a/plugins/plugin-agent-orchestrator/src/services/project-registry.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/project-registry.ts
@@ -1,0 +1,468 @@
+/**
+ * Durable registry of coding "projects": a stable `id → { name, rootDir }`
+ * binding a task pins via {@link OrchestratorTaskRecord.projectId} so every
+ * session it spawns targets one workspace root instead of drifting per spawn
+ * (#13776). `rootDir` is the natural key — one project per resolved absolute
+ * root — which keeps {@link ProjectRegistry.resolveProject} unambiguous.
+ *
+ * Persistence mirrors the task store's tiered backend selection: a runtime SQL
+ * adapter when present, else a lock-guarded JSON file, else process memory. It
+ * reuses that store's SQL executor plumbing ({@link resolveSqlExecutor},
+ * {@link isPersistableAdapter}) so both tables sit on the same adapter behind
+ * one code path for the drizzle / raw-sqlite / pglite shapes.
+ *
+ * Records are immutable after creation (a project's name, root, and createdAt
+ * never change), which is why the file backend can union-merge concurrent
+ * inserts by id with no dirty-tracking or tombstones.
+ *
+ * @module services/project-registry
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  mkdir,
+  open,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve as resolvePath } from "node:path";
+import {
+  type ElizaDrizzleAdapter,
+  isPersistableAdapter,
+  type RawSqlDatabaseAdapter,
+  resolveSqlExecutor,
+  type SqlExecutor,
+  type TaskStoreRuntime,
+} from "./orchestrator-task-store.js";
+
+export type ProjectRegistryBackend = "runtime-db" | "file" | "memory";
+
+export interface ProjectRecord {
+  id: string;
+  name: string;
+  /** Absolute, normalized workspace root — the registry's natural key. */
+  rootDir: string;
+  createdAt: string;
+}
+
+export interface CreateProjectInput {
+  name: string;
+  rootDir: string;
+}
+
+interface Logger {
+  warn?: (message: string, ...args: unknown[]) => void;
+}
+
+const FILE_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
+const FILE_LOCK_STALE_MS = 10_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** Normalize a workspace root to the registry's natural key: an absolute path
+ * with trailing separators collapsed, so `/repo`, `/repo/`, and `/repo/.` all
+ * resolve to the same project. */
+function normalizeRootDir(rootDir: string): string {
+  return resolvePath(rootDir);
+}
+
+function normalizeProject(value: unknown): ProjectRecord | null {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.id !== "string" ||
+    typeof value.name !== "string" ||
+    typeof value.rootDir !== "string" ||
+    typeof value.createdAt !== "string"
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    name: value.name,
+    rootDir: value.rootDir,
+    createdAt: value.createdAt,
+  };
+}
+
+function newProject(input: CreateProjectInput): ProjectRecord {
+  return {
+    id: randomUUID(),
+    name: input.name.trim() || "Untitled project",
+    rootDir: normalizeRootDir(input.rootDir),
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * In-memory backend. The file backend extends this with JSON persistence; the
+ * SQL backend reimplements the same surface against a runtime adapter.
+ *
+ * `createProject` is idempotent on the normalized `rootDir` (returns the
+ * existing project rather than minting a duplicate), so `resolveProject` always
+ * has at most one candidate — the whole point of a first-class binding.
+ */
+export class InMemoryProjectStore {
+  protected readonly projects = new Map<string, ProjectRecord>();
+  private tail = Promise.resolve();
+
+  protected enqueue<T>(operation: () => Promise<T> | T): Promise<T> {
+    const run = this.tail.then(operation, operation);
+    this.tail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  async createProject(input: CreateProjectInput): Promise<ProjectRecord> {
+    return this.enqueue(async () => {
+      const rootDir = normalizeRootDir(input.rootDir);
+      const existing = this.findByRoot(rootDir);
+      if (existing) return { ...existing };
+      const project = newProject({ name: input.name, rootDir });
+      this.projects.set(project.id, project);
+      await this.afterWrite();
+      return { ...project };
+    });
+  }
+
+  async listProjects(): Promise<ProjectRecord[]> {
+    return [...this.projects.values()]
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+      .map((project) => ({ ...project }));
+  }
+
+  async getProject(id: string): Promise<ProjectRecord | null> {
+    const project = this.projects.get(id);
+    return project ? { ...project } : null;
+  }
+
+  async resolveProject(rootDir: string): Promise<ProjectRecord | null> {
+    const found = this.findByRoot(normalizeRootDir(rootDir));
+    return found ? { ...found } : null;
+  }
+
+  private findByRoot(rootDir: string): ProjectRecord | undefined {
+    for (const project of this.projects.values()) {
+      if (project.rootDir === rootDir) return project;
+    }
+    return undefined;
+  }
+
+  protected async afterWrite(): Promise<void> {
+    // Durable subclasses persist here.
+  }
+
+  /** Replace the in-memory set from a durable source. */
+  hydrate(projects: ProjectRecord[]): void {
+    this.projects.clear();
+    for (const project of projects) this.projects.set(project.id, project);
+  }
+}
+
+function defaultProjectsFile(runtime?: TaskStoreRuntime): string {
+  const configured =
+    process.env.ELIZA_ACP_STATE_DIR ??
+    runtime?.getSetting?.("ELIZA_ACP_STATE_DIR");
+  const base = configured ?? join(homedir(), ".eliza", "plugin-acp");
+  return join(base, "orchestrator-projects.json");
+}
+
+export class FileProjectStore extends InMemoryProjectStore {
+  private readonly lockFile: string;
+  private loaded = false;
+
+  constructor(
+    private readonly filePath: string,
+    private readonly logger?: Logger,
+  ) {
+    super();
+    this.lockFile = `${filePath}.lock`;
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    await this.enqueue(async () => {
+      if (this.loaded) return;
+      this.hydrate(await this.readFromDisk());
+      this.loaded = true;
+    });
+  }
+
+  private async readFromDisk(): Promise<ProjectRecord[]> {
+    try {
+      const parsed = JSON.parse(
+        await readFile(this.filePath, "utf8"),
+      ) as unknown;
+      if (!Array.isArray(parsed)) return [];
+      return parsed
+        .map(normalizeProject)
+        .filter((project): project is ProjectRecord => project !== null);
+    } catch (error) {
+      // error-policy:J3 persisted-store load: ENOENT = no file yet, any other
+      // read/parse error warns and starts empty (observable recovery).
+      const code =
+        isRecord(error) && typeof error.code === "string" ? error.code : "";
+      if (code !== "ENOENT") {
+        this.logger?.warn?.(
+          "[ProjectRegistry] projects file unreadable; starting empty",
+          error,
+        );
+      }
+      return [];
+    }
+  }
+
+  override async createProject(input: CreateProjectInput) {
+    await this.ensureLoaded();
+    return super.createProject(input);
+  }
+  override async listProjects() {
+    await this.ensureLoaded();
+    return super.listProjects();
+  }
+  override async getProject(id: string) {
+    await this.ensureLoaded();
+    return super.getProject(id);
+  }
+  override async resolveProject(rootDir: string) {
+    await this.ensureLoaded();
+    return super.resolveProject(rootDir);
+  }
+
+  protected override async afterWrite(): Promise<void> {
+    await this.withLock(async () => {
+      await mkdir(dirname(this.filePath), { recursive: true });
+      // Read-merge-write under the lock so a concurrent process's inserts
+      // survive. Records are immutable, so a union by id is exact: seed from
+      // disk, then overlay this process's in-memory set.
+      const merged = new Map<string, ProjectRecord>();
+      for (const project of await this.readFromDisk()) {
+        merged.set(project.id, project);
+      }
+      for (const [id, project] of this.projects) merged.set(id, project);
+      this.hydrate([...merged.values()]);
+      const tempPath = `${this.filePath}.${process.pid}.${Date.now()}.tmp`;
+      await writeFile(
+        tempPath,
+        `${JSON.stringify([...merged.values()], null, 2)}\n`,
+        "utf8",
+      );
+      await rename(tempPath, this.filePath);
+    });
+  }
+
+  private async withLock<T>(operation: () => Promise<T>): Promise<T> {
+    await mkdir(dirname(this.lockFile), { recursive: true });
+    const deadline = Date.now() + FILE_LOCK_ACQUIRE_TIMEOUT_MS;
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    while (!handle) {
+      let pending: Awaited<ReturnType<typeof open>> | undefined;
+      try {
+        pending = await open(this.lockFile, "wx");
+        await pending.writeFile(`${process.pid}\n${Date.now()}\n`, "utf8");
+        handle = pending;
+      } catch (error) {
+        // error-policy:J3 lock-acquire: EEXIST (lock held) is retried until the
+        // deadline; every other error is rethrown below (fail-fast).
+        if (pending) {
+          // error-policy:J6 best-effort teardown — unwind a partial acquire.
+          await pending.close().catch(() => {});
+          await rm(this.lockFile, { force: true }).catch(() => {});
+        }
+        const code =
+          isRecord(error) && typeof error.code === "string" ? error.code : "";
+        if (code !== "EEXIST" || Date.now() > deadline) throw error;
+        await this.removeStaleLock();
+        await new Promise((r) => setTimeout(r, 25));
+      }
+    }
+    try {
+      return await operation();
+    } finally {
+      await handle.close();
+      await rm(this.lockFile, { force: true });
+    }
+  }
+
+  private async removeStaleLock(): Promise<void> {
+    try {
+      const info = await stat(this.lockFile);
+      if (Date.now() - info.mtimeMs < FILE_LOCK_STALE_MS) return;
+      await rm(this.lockFile, { force: true });
+    } catch (error) {
+      // error-policy:J3 stale-lock stat: ENOENT = lock already gone (fine); any
+      // other stat error is rethrown (fail-fast).
+      const code =
+        isRecord(error) && typeof error.code === "string" ? error.code : "";
+      if (code !== "ENOENT") throw error;
+    }
+  }
+}
+
+const PROJECT_TABLE_SQL = `CREATE TABLE IF NOT EXISTS orchestrator_projects (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  root_dir TEXT NOT NULL,
+  created_at TEXT NOT NULL
+)`;
+
+const PROJECT_INDEX_SQL =
+  "CREATE INDEX IF NOT EXISTS idx_orch_projects_root ON orchestrator_projects(root_dir)";
+
+/** SQL backend. One row per project; reuses the task store's executor so it
+ * runs on the same drizzle / raw / pglite adapter. */
+export class RuntimeDbProjectStore {
+  private initPromise: Promise<void> | undefined;
+  private executor: SqlExecutor | undefined;
+  private tail = Promise.resolve();
+
+  constructor(
+    private readonly adapter: RawSqlDatabaseAdapter | ElizaDrizzleAdapter,
+  ) {}
+
+  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.tail.then(operation, operation);
+    this.tail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    this.initPromise ??= (async () => {
+      const executor = await resolveSqlExecutor(this.adapter);
+      this.executor = executor;
+      await executor.run(PROJECT_TABLE_SQL);
+      await executor.run(PROJECT_INDEX_SQL);
+    })();
+    await this.initPromise;
+  }
+
+  private exec(): SqlExecutor {
+    if (!this.executor) {
+      throw new Error(
+        "project-registry: executor accessed before ensureInitialized()",
+      );
+    }
+    return this.executor;
+  }
+
+  private parseRow(row: unknown): ProjectRecord | null {
+    if (!isRecord(row)) return null;
+    return normalizeProject({
+      id: row.id,
+      name: row.name,
+      rootDir: row.root_dir,
+      createdAt: row.created_at,
+    });
+  }
+
+  async createProject(input: CreateProjectInput): Promise<ProjectRecord> {
+    return this.enqueue(async () => {
+      await this.ensureInitialized();
+      const rootDir = normalizeRootDir(input.rootDir);
+      const existing = await this.selectByRoot(rootDir);
+      if (existing) return existing;
+      const project = newProject({ name: input.name, rootDir });
+      await this.exec().run(
+        `INSERT INTO orchestrator_projects (id, name, root_dir, created_at)
+         VALUES (?, ?, ?, ?)`,
+        [project.id, project.name, project.rootDir, project.createdAt],
+      );
+      return project;
+    });
+  }
+
+  async listProjects(): Promise<ProjectRecord[]> {
+    await this.ensureInitialized();
+    const rows = await this.exec().all(
+      "SELECT id, name, root_dir, created_at FROM orchestrator_projects ORDER BY created_at ASC",
+    );
+    return rows
+      .map((row) => this.parseRow(row))
+      .filter((project): project is ProjectRecord => project !== null);
+  }
+
+  async getProject(id: string): Promise<ProjectRecord | null> {
+    await this.ensureInitialized();
+    const rows = await this.exec().all(
+      "SELECT id, name, root_dir, created_at FROM orchestrator_projects WHERE id = ?",
+      [id],
+    );
+    return rows.length > 0 ? this.parseRow(rows[0]) : null;
+  }
+
+  async resolveProject(rootDir: string): Promise<ProjectRecord | null> {
+    await this.ensureInitialized();
+    return this.selectByRoot(normalizeRootDir(rootDir));
+  }
+
+  private async selectByRoot(rootDir: string): Promise<ProjectRecord | null> {
+    const rows = await this.exec().all(
+      "SELECT id, name, root_dir, created_at FROM orchestrator_projects WHERE root_dir = ? ORDER BY created_at ASC LIMIT 1",
+      [rootDir],
+    );
+    return rows.length > 0 ? this.parseRow(rows[0]) : null;
+  }
+}
+
+export interface ProjectRegistryOptions {
+  runtime?: TaskStoreRuntime;
+  stateFile?: string;
+  backend?: ProjectRegistryBackend;
+}
+
+/**
+ * Backend-selecting facade — the registry consumers use. Mirrors
+ * {@link OrchestratorTaskStore}'s selection order so a runtime with a SQL
+ * adapter persists projects alongside tasks, while a no-DB runtime falls back
+ * to a JSON file (then memory).
+ */
+export class ProjectRegistry {
+  readonly backend: ProjectRegistryBackend;
+  private readonly delegate: InMemoryProjectStore | RuntimeDbProjectStore;
+
+  constructor(options: ProjectRegistryOptions = {}) {
+    const adapter =
+      options.runtime?.adapter ?? options.runtime?.databaseAdapter;
+    if (
+      (options.backend === undefined || options.backend === "runtime-db") &&
+      isPersistableAdapter(adapter)
+    ) {
+      this.backend = "runtime-db";
+      this.delegate = new RuntimeDbProjectStore(adapter);
+      return;
+    }
+    if (options.backend === "memory") {
+      this.backend = "memory";
+      this.delegate = new InMemoryProjectStore();
+      return;
+    }
+    this.backend = "file";
+    this.delegate = new FileProjectStore(
+      options.stateFile ?? defaultProjectsFile(options.runtime),
+      options.runtime?.logger,
+    );
+  }
+
+  createProject(input: CreateProjectInput) {
+    return this.delegate.createProject(input);
+  }
+  listProjects() {
+    return this.delegate.listProjects();
+  }
+  getProject(id: string) {
+    return this.delegate.getProject(id);
+  }
+  resolveProject(rootDir: string) {
+    return this.delegate.resolveProject(rootDir);
+  }
+}


### PR DESCRIPTION
## What & why

Slice of **#13776** (epic **#13766**) — the **durable-data core** of "First-class Project entity". Data-model only.

### Verified defect (develop @ 53d14d0908)
`OrchestratorTaskRecord` (`orchestrator-task-types.ts:52-83`) had **no** `projectId`/`repo`/`workdir`. Those lived per-**session** only (`:128-129`), had no SQL column (`orchestrator-task-store.ts:804-814`), and were surfaced as **derived** `latestWorkdir`/`latestRepo` off the most-recent session (`orchestrator-task-mapper.ts:393-394`). Two sessions of one task could silently target different repos, and the task had no canonical binding.

## Changes

**1. First-class task binding (`orchestrator-task-types.ts`)**
- `OrchestratorTaskRecord` gains optional `projectId?`, `repo?`, `workdir?` (additive; existing rows leave them unset).
- `CreateTaskInput` and `TaskListFilter` widened additively (`projectId` filter).

**2. Store: SQL column + additive migration (`orchestrator-task-store.ts`)**
- `orchestrator_tasks` gains a `project_id TEXT` column. A **probe-gated** `ADD COLUMN` migration (`SELECT project_id … LIMIT 1` → on reject, `ALTER TABLE … ADD COLUMN`) upgrades legacy tables at most once and never on the happy path; portable across sqlite/pglite/postgres. Legacy rows read back `NULL`.
- `persist()` mirrors `projectId` into the indexed column on upsert (`?? null` → SQL NULL for a genuinely nullable column — the authoritative value still round-trips inside the `document` JSON).
- `newTaskDocument()` populates the binding from `CreateTaskInput`; `listTasks({ projectId })` filters on it (memory + SQL WHERE).
- Exported the store's SQL executor plumbing (`resolveSqlExecutor`, `isPersistableAdapter`, adapter/executor types) so the registry reuses one code path.

**3. Populate at task creation (`actions/tasks.ts`)**
- The `create` action pins the durable task to the spawn's explicit `workdir`/`repo` so every attached session shares one root.

**4. Project registry (`services/project-registry.ts`, new)**
- `ProjectRegistry` with `createProject` / `listProjects` / `resolveProject` / `getProject`, persisted via the same tiered backends as the task store (runtime-db → lock-guarded JSON file → memory).
- `rootDir` (normalized absolute path) is the natural key, so `resolveProject` is unambiguous and `createProject` is idempotent per root.

`latestWorkdir`/`latestRepo` on the mapper DTO are **left as-is for back-compat** (as the issue asked). The mapper contract test is untouched and green.

> Note: kept ADDITIVE and localized (new record field + new file) to avoid textual conflict with the concurrent status-transition edit to `orchestrator-task-types.ts` (#13771); no status-transition logic touched.

## Tests (real code path, fail-before / pass-after)

New store tests in `orchestrator-task-store.test.ts` (drive the real `InMemory`/`File`/`RuntimeDb` stores) + new `project-registry.test.ts` (real temp files + in-process SQL fake). Covers: projectId/repo/workdir round-trip through memory/file/SQL, JSON-persist round-trip, the `project_id` column + WHERE-clause filter, the **legacy-table additive migration** (probe→ALTER once), and the registry's create/list/resolve/getProject + rootDir normalization + idempotency + restart durability.

**Fail-before** (projectId population reverted): `6 failed | 2 passed` in the binding block.
**Pass-after** (restored): store + registry + mapper-contract = **76 passed (76)**.

```
Test Files  3 passed (3)
     Tests  76 passed (76)
```

- `bun run audit:error-policy-ratchet` → `no new fallback-slop in touched files` (emptyCatch 0→0, serverConsole 0→0 on all 4 changed src files).
- biome clean on all touched files.
- Typecheck: no new errors in touched files (only pre-existing environmental missing-declaration noise for `drizzle-orm`/`git-workspace-service`/`coding-agent-adapters`, present on develop).

_Unrelated pre-existing failure:_ `task-history.test.ts` (3) fails with `runtime.reportError is not a function` from `task-policy.ts:192` (unchanged; the test's mock runtime lacks `reportError`) — not in this diff.

## Deferred to follow-up (D3 design-heavy parts, per the issue)
- UI project switcher + surfacing `projectId` on the task DTO / `@elizaos/ui` client types.
- Per-project memory/knowledge scoping (`memory.ts` dimension).
- Workspace-resolution refactor (`workspace-resolution.ts`) — resolve-and-bind `projectId` from a workdir at spawn time.
- Desktop picker recents.
- Wiring `ProjectRegistry` as a live runtime `Service` into the plugin (kept a plain persisted class here to avoid shipping an unwired/dead Service).

Refs #13776, epic #13766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
