### PR TITLE
fix(#13624): make cloud audit fail closed

### DIFF
--- a/.github/issue-evidence/13624-audit-cloud-fail-closed.md
+++ b/.github/issue-evidence/13624-audit-cloud-fail-closed.md
@@ -1,0 +1,70 @@
+# #13624 audit:cloud fail-closed evidence
+
+## Change
+
+- `audit:cloud` no longer whole-suite-skips when Playwright test auth is missing.
+- `audit:cloud` now writes `report.json` even for zero findings and fails on zero findings, `broken`, or `needs-work`.
+- `run-ui-playwright.mjs` removes `packages/app/dist` before `--project=audit-cloud` when `VITE_PLAYWRIGHT_TEST_AUTH=true`, unless `ELIZA_UI_SMOKE_SKIP_BUILD=1` is explicitly set.
+
+## Verification
+
+```bash
+bunx biome check packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts packages/app/scripts/run-ui-playwright.mjs packages/app/playwright.ui-smoke.config.ts
+node --check packages/app/scripts/run-ui-playwright.mjs
+git diff --check
+```
+
+All passed.
+
+Runner stale-dist probe:
+
+```bash
+mkdir -p packages/app/dist
+printf 'stale-auth-build\n' > packages/app/dist/.audit-cloud-stale-marker
+ELIZA_UI_SMOKE_SKIP_VIEW_BUILD=1 \
+ELIZA_UI_SMOKE_SKIP_CORE_BUILD=1 \
+VITE_PLAYWRIGHT_TEST_AUTH=true \
+node packages/app/scripts/run-ui-playwright.mjs \
+  --config playwright.ui-smoke.config.ts \
+  --project=audit-cloud \
+  --help
+test ! -e packages/app/dist/.audit-cloud-stale-marker
+```
+
+Passed. The runner printed:
+
+```text
+[ui-smoke] Removing app dist before audit-cloud so VITE_PLAYWRIGHT_TEST_AUTH is baked into a fresh renderer build.
+```
+
+Full audit attempt:
+
+```bash
+bun run --cwd packages/app audit:cloud
+```
+
+Result: failed before Playwright screenshots during the pre-run `@elizaos/core`
+build. The run did reach the new stale-dist invalidation line above, then
+`@elizaos/core` declaration generation failed on existing dependency/type
+resolution errors:
+
+```text
+src/features/advanced-capabilities/personality/services/character-file-manager.ts(12,16): error TS7016: Could not find a declaration file for module 'fs-extra'.
+src/features/plugin-manager/services/coreManagerService.ts(17,16): error TS7016: Could not find a declaration file for module 'fs-extra'.
+src/features/plugin-manager/services/pluginManagerService.ts(21,16): error TS7016: Could not find a declaration file for module 'fs-extra'.
+src/markdown/ir.ts(15,24): error TS7016: Could not find a declaration file for module 'markdown-it'.
+src/media/mime.ts(26,34): error TS2307: Cannot find module 'file-type' or its corresponding type declarations.
+```
+
+No `aesthetic-audit-output-cloud` screenshot or manual-review artifacts were
+produced because the failure happened before the Playwright server started.
+
+## PR_EVIDENCE rows
+
+- UI screenshots/video: N/A - fail-closed audit harness behavior, no product UI pixels changed.
+- Real-LLM trajectories: N/A - no agent/action/provider/model behavior changed.
+- Audio artifacts: N/A - no voice/TTS/STT behavior changed.
+- Domain artifacts: N/A - no DB, memory, wallet, chain, or generated domain artifact changed.
+- Full `audit:cloud` rendered run: blocked before screenshots by the
+  `@elizaos/core` declaration-resolution errors listed above; this patch makes
+  the audit fail closed once it reaches the rendered walk.

--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -233,7 +233,8 @@ export default defineConfig({
       // Cloud-surface aesthetic audit (#10725/#11342) — run with `audit:cloud`
       // (`--project=audit-cloud`). Walks every registered cloud route at
       // desktop + mobile internally. Requires a renderer built with
-      // VITE_PLAYWRIGHT_TEST_AUTH=true (the spec self-skips otherwise).
+      // VITE_PLAYWRIGHT_TEST_AUTH=true; the runner invalidates dist for this
+      // project so a cached non-auth build cannot skip the local auth shell.
       name: "audit-cloud",
       testMatch: AUDIT_CLOUD_SPEC,
       use: {

--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -173,6 +173,13 @@ function hasPlaywrightConfig(configName) {
   );
 }
 
+function hasPlaywrightProject(projectName) {
+  return playwrightArgs.some((value, index) => {
+    if (value === `--project=${projectName}`) return true;
+    return value === "--project" && playwrightArgs[index + 1] === projectName;
+  });
+}
+
 function appendNodeOption(value, option) {
   const options =
     typeof value === "string" && value.trim().length > 0
@@ -383,6 +390,19 @@ if (
     releaseLocks();
     process.exit(status);
   }
+}
+
+if (
+  hasPlaywrightConfig("playwright.ui-smoke.config.ts") &&
+  hasPlaywrightProject("audit-cloud") &&
+  env.VITE_PLAYWRIGHT_TEST_AUTH === "true" &&
+  env.ELIZA_UI_SMOKE_SKIP_BUILD !== "1"
+) {
+  const appDistDir = path.join(appDir, "dist");
+  console.log(
+    "[ui-smoke] Removing app dist before audit-cloud so VITE_PLAYWRIGHT_TEST_AUTH is baked into a fresh renderer build.",
+  );
+  removePathRecursive(appDistDir, "app dist for audit-cloud auth build");
 }
 
 // The ui-smoke web server builds the renderer (`packages/app build:web`) whenever

--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -965,14 +965,6 @@ const findings: CloudPageFinding[] = [];
 const findingsBySlug = new Map<string, CloudPageFinding[]>();
 
 test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
-  // Locally, a renderer without the baked test-auth shell is a skip (dev
-  // convenience). Under strict/CI it is NOT — see the guard test below, which
-  // reddens so the audit can never go green having walked nothing (#13624).
-  test.skip(
-    !TEST_AUTH_ENABLED && !REQUIRE_CLOUD_EVIDENCE,
-    "set VITE_PLAYWRIGHT_TEST_AUTH=true (bake it into the renderer build) so StewardProvider renders the local test-auth shell",
-  );
-
   // Hard gate (#13624): under strict/CI the running renderer bundle MUST contain
   // the test-auth shell. A stale turbo-cached `build:web` (built without
   // VITE_PLAYWRIGHT_TEST_AUTH) leaves the runtime env set but the shell absent —
@@ -1004,6 +996,13 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
   const outputDir =
     process.env.ELIZA_AUDIT_CLOUD_DIR ??
     path.join(process.cwd(), "aesthetic-audit-output-cloud");
+
+  test.beforeAll(() => {
+    expect(
+      TEST_AUTH_ENABLED,
+      "audit:cloud requires VITE_PLAYWRIGHT_TEST_AUTH=true baked into the renderer build so StewardProvider renders the local test-auth shell",
+    ).toBe(true);
+  });
 
   // Coverage guard: every registered cloud route must appear in the audit
   // table, so a newly-registered surface fails the audit until it is walked.


### PR DESCRIPTION
## Summary
- make `audit:cloud` fail instead of whole-suite-skipping when Playwright test auth is not enabled
- fail `audit:cloud` on zero findings, `broken`, or `needs-work` findings after writing `report.json`/contact-sheet output
- remove `packages/app/dist` before the `audit-cloud` project when `VITE_PLAYWRIGHT_TEST_AUTH=true` so a cached non-auth renderer cannot bypass the test-auth shell

Refs #13624. This covers the `audit:cloud` fail-closed/stale-auth-build slice; the broader capture/native/window tasks in #13624 remain separate work.

## Verification
- `bunx biome check packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts packages/app/scripts/run-ui-playwright.mjs packages/app/playwright.ui-smoke.config.ts .github/issue-evidence/13624-audit-cloud-fail-closed.md`
- `node --check packages/app/scripts/run-ui-playwright.mjs`
- `git diff --check origin/develop...HEAD`
- Runner stale-dist probe in `.github/issue-evidence/13624-audit-cloud-fail-closed.md`

## Known blocker
- `bun run --cwd packages/app audit:cloud` reaches the new stale-dist invalidation line, then fails before Playwright screenshots in the pre-run `@elizaos/core` declaration build on existing `fs-extra`, `markdown-it`, and `file-type` type/module resolution errors. No cloud screenshot artifacts are produced yet.

## Evidence
- `.github/issue-evidence/13624-audit-cloud-fail-closed.md`

UI screenshots/video: N/A - audit harness behavior only, no product UI pixels changed.
Real-LLM/audio/domain artifacts: N/A - no model, voice, DB, wallet, chain, memory, or generated domain path changed.