### PR TITLE
feat(#13774): subagent context delivery — broker discovery, SKILLS.md every spawn, skills bridge, originating task

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -4,9 +4,16 @@
  */
 import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { promises as fs } from "node:fs";
-import os from "node:os";
+import {
+  existsSync,
+  mkdtempSync,
+  promises as fs,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import os, { tmpdir } from "node:os";
 import path from "node:path";
+import { join } from "node:path";
 import { Writable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -148,7 +155,10 @@ type MockProc = EventEmitter & {
 
 const spawnMock = spawn as unknown as ReturnType<typeof vi.fn>;
 
-function runtime(settings: Record<string, string | undefined> = {}) {
+function runtime(
+  settings: Record<string, string | undefined> = {},
+  services: Record<string, unknown> = {},
+) {
   const values = { ELIZA_ACP_TRANSPORT: "cli", ...settings };
   return {
     logger: {
@@ -158,6 +168,9 @@ function runtime(settings: Record<string, string | undefined> = {}) {
       error: vi.fn(),
     },
     getSetting: vi.fn((key: string) => values[key]),
+    // spawnSession consults getService for the broker-router (isParentAgentBroker
+    // Wired) and the skills service (SKILLS.md manifest); default to none.
+    getService: vi.fn((name: string) => services[name] ?? null),
     services: new Map<string, unknown[]>(),
   } as never;
 }
@@ -359,6 +372,91 @@ describe("AcpService", () => {
       | Record<string, string>
       | undefined;
     expect(env?.PARALLAX_SESSION_ID).toBe(result.sessionId);
+  });
+
+  it("writes SKILLS.md into every spawn workspace (shared spawn path)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "acp-skills-"));
+    try {
+      const skillsService = {
+        getEligibleSkills: async () => [
+          {
+            slug: "github",
+            name: "GitHub",
+            description: "gh CLI usage.",
+            content: "# GitHub\n",
+          },
+        ],
+        isSkillEnabled: () => true,
+      };
+      const reg = nextProc();
+      const service = new AcpService(
+        runtime({}, { AGENT_SKILLS_SERVICE: skillsService }),
+      );
+      await service.start();
+      const promise = service.spawnSession({
+        name: "skills-spawn",
+        agentType: "codex",
+        workdir: dir,
+      });
+      await waitForSpawn(reg);
+      reg.proc.stdout.emit(
+        "data",
+        Buffer.from(
+          '{"jsonrpc":"2.0","method":"session_started","params":{"sessionId":"skills-spawn"}}\n',
+        ),
+      );
+      closeOk(reg);
+      await promise;
+
+      const manifestPath = join(dir, "SKILLS.md");
+      expect(existsSync(manifestPath)).toBe(true);
+      const manifest = readFileSync(manifestPath, "utf8");
+      expect(manifest).toContain("GitHub");
+      expect(manifest).toContain("`github`");
+      // Broker router not registered here → no broker entry advertised.
+      expect(manifest).not.toContain("Parent Eliza Agent");
+      // And the on-disk manual has no broker section either.
+      expect(readFileSync(join(dir, "AGENTS.md"), "utf8")).not.toContain(
+        "Asking the parent Eliza agent to act",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("advertises the broker in SKILLS.md + manual when the router is wired", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "acp-skills-broker-"));
+    try {
+      const router = { isActive: () => true };
+      const reg = nextProc();
+      const service = new AcpService(
+        runtime({}, { ACPX_SUB_AGENT_ROUTER: router }),
+      );
+      await service.start();
+      const promise = service.spawnSession({
+        name: "broker-spawn",
+        agentType: "codex",
+        workdir: dir,
+      });
+      await waitForSpawn(reg);
+      reg.proc.stdout.emit(
+        "data",
+        Buffer.from(
+          '{"jsonrpc":"2.0","method":"session_started","params":{"sessionId":"broker-spawn"}}\n',
+        ),
+      );
+      closeOk(reg);
+      await promise;
+
+      expect(readFileSync(join(dir, "SKILLS.md"), "utf8")).toContain(
+        "Parent Eliza Agent",
+      );
+      expect(readFileSync(join(dir, "AGENTS.md"), "utf8")).toContain(
+        "Asking the parent Eliza agent to act",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("honors explicit terminal capability opt-out", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -6,14 +6,13 @@ import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import {
   existsSync,
-  mkdtempSync,
   promises as fs,
+  mkdtempSync,
   readFileSync,
   rmSync,
 } from "node:fs";
 import os, { tmpdir } from "node:os";
-import path from "node:path";
-import { join } from "node:path";
+import path, { join } from "node:path";
 import { Writable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/parent-context-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/parent-context-routes.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Verifies the read-only parent-context bridge routes: the skills list/body
+ * endpoints and the originatingTask read-back added for #13774.
+ * Deterministic unit test with stubbed runtime + services; no live model.
+ */
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { handleParentContextRoutes } from "../../src/api/parent-context-routes.ts";
+import type { RouteContext } from "../../src/api/route-utils.ts";
+
+function fakeRequest(opts: {
+  method?: string;
+  url: string;
+  remoteAddress?: string;
+}): IncomingMessage {
+  const req = Readable.from([]) as unknown as IncomingMessage;
+  (req as { method: string }).method = opts.method ?? "GET";
+  (req as { url: string }).url = opts.url;
+  (req as { socket: { remoteAddress: string } }).socket = {
+    remoteAddress: opts.remoteAddress ?? "127.0.0.1",
+  };
+  (req as { headers: Record<string, string> }).headers = {
+    host: "localhost:2138",
+  };
+  return req;
+}
+
+function fakeResponse(): {
+  res: ServerResponse;
+  status: () => number;
+  body: () => unknown;
+} {
+  const writes: Buffer[] = [];
+  let statusCode = 0;
+  const res = {
+    statusCode,
+    headersSent: false,
+    setHeader() {
+      return res;
+    },
+    writeHead(code: number) {
+      statusCode = code;
+      res.statusCode = code;
+      res.headersSent = true;
+    },
+    end(chunk?: Buffer | string) {
+      if (chunk) writes.push(Buffer.from(chunk));
+    },
+  } as unknown as ServerResponse;
+  return {
+    res,
+    status: () => statusCode || res.statusCode,
+    body: () => {
+      const text = Buffer.concat(writes).toString("utf8");
+      return text ? JSON.parse(text) : undefined;
+    },
+  };
+}
+
+type Skill = {
+  slug: string;
+  name: string;
+  description: string;
+  content: string;
+};
+
+function makeCtx(opts: {
+  sessionMetadata?: Record<string, unknown>;
+  skills?: Skill[];
+  disabledSlugs?: Set<string>;
+  task?: {
+    goal: string;
+    acceptanceCriteria?: string[];
+    decisions?: Array<Record<string, unknown>>;
+  } | null;
+  noSkillsService?: boolean;
+  noTaskService?: boolean;
+}): RouteContext {
+  const disabled = opts.disabledSlugs ?? new Set<string>();
+  const skillsService = {
+    getEligibleSkills: async () => opts.skills ?? [],
+    isSkillEnabled: (slug: string) => !disabled.has(slug),
+  };
+  const taskService = {
+    getTask: async (_id: string) => opts.task ?? null,
+  };
+  const runtime = {
+    character: { name: "Eliza", bio: [], documents: [], knowledge: [] },
+    getRoom: async () => null,
+    getService: (name: string) => {
+      if (name === "AGENT_SKILLS_SERVICE")
+        return opts.noSkillsService ? null : skillsService;
+      if (name === "ORCHESTRATOR_TASK_SERVICE")
+        return opts.noTaskService ? null : taskService;
+      return null;
+    },
+  } as unknown as RouteContext["runtime"];
+  const acpService = {
+    getSession: (id: string) => ({
+      id,
+      status: "running",
+      workdir: "/tmp/work",
+      metadata: opts.sessionMetadata ?? {},
+    }),
+  } as unknown as RouteContext["acpService"];
+  return { runtime, acpService, workspaceService: null };
+}
+
+const SESSION = "pty-1-abc";
+
+const SKILLS: Skill[] = [
+  {
+    slug: "eliza-cloud",
+    name: "Eliza Cloud",
+    description: "Cloud backend, billing, and monetization reference.",
+    content: "# Eliza Cloud\n\nFull body: how to use Cloud.\n",
+  },
+  {
+    slug: "github",
+    name: "GitHub",
+    description: "Create issues, PRs, and manage repos.",
+    content: "# GitHub\n\nFull body: gh CLI usage.\n",
+  },
+];
+
+async function call(url: string, ctx: RouteContext) {
+  const req = fakeRequest({ url });
+  const { res, status, body } = fakeResponse();
+  const pathname = url.split("?")[0];
+  const handled = await handleParentContextRoutes(req, res, pathname, ctx);
+  return { handled, status: status(), body: body() };
+}
+
+describe("GET /api/coding-agents/<id>/skills", () => {
+  it("lists enabled+eligible skills with full (untruncated) descriptions", async () => {
+    const ctx = makeCtx({ skills: SKILLS });
+    const { handled, status, body } = await call(
+      `/api/coding-agents/${SESSION}/skills`,
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(status).toBe(200);
+    const skills = (body as { skills: Skill[] }).skills;
+    expect(skills.map((s) => s.slug)).toEqual(["eliza-cloud", "github"]);
+    // Full descriptions carried, no body/content leaked into the list.
+    expect(skills[0].description).toBe(
+      "Cloud backend, billing, and monetization reference.",
+    );
+    expect((skills[0] as Record<string, unknown>).body).toBeUndefined();
+  });
+
+  it("drops disabled skills from the list", async () => {
+    const ctx = makeCtx({
+      skills: SKILLS,
+      disabledSlugs: new Set(["github"]),
+    });
+    const { body } = await call(`/api/coding-agents/${SESSION}/skills`, ctx);
+    expect((body as { skills: Skill[] }).skills.map((s) => s.slug)).toEqual([
+      "eliza-cloud",
+    ]);
+  });
+
+  it("returns an empty list when the skills service is absent", async () => {
+    const ctx = makeCtx({ noSkillsService: true });
+    const { status, body } = await call(
+      `/api/coding-agents/${SESSION}/skills`,
+      ctx,
+    );
+    expect(status).toBe(200);
+    expect((body as { skills: Skill[] }).skills).toEqual([]);
+  });
+});
+
+describe("GET /api/coding-agents/<id>/skills/<slug>", () => {
+  it("returns the full SKILL.md body for an enabled slug", async () => {
+    const ctx = makeCtx({ skills: SKILLS });
+    const { status, body } = await call(
+      `/api/coding-agents/${SESSION}/skills/eliza-cloud`,
+      ctx,
+    );
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      slug: "eliza-cloud",
+      name: "Eliza Cloud",
+      body: "# Eliza Cloud\n\nFull body: how to use Cloud.\n",
+    });
+  });
+
+  it("404s an unknown slug", async () => {
+    const ctx = makeCtx({ skills: SKILLS });
+    const { status, body } = await call(
+      `/api/coding-agents/${SESSION}/skills/does-not-exist`,
+      ctx,
+    );
+    expect(status).toBe(404);
+    expect((body as { code: string }).code).toBe("skill_not_found");
+  });
+
+  it("404s a disabled slug (present but not enabled)", async () => {
+    const ctx = makeCtx({
+      skills: SKILLS,
+      disabledSlugs: new Set(["github"]),
+    });
+    const { status, body } = await call(
+      `/api/coding-agents/${SESSION}/skills/github`,
+      ctx,
+    );
+    expect(status).toBe(404);
+    expect((body as { code: string }).code).toBe("skill_not_found");
+  });
+});
+
+describe("parent-context originatingTask", () => {
+  it("exposes the task goal + acceptance criteria + latest decisions", async () => {
+    const decisions = Array.from({ length: 25 }, (_, i) => ({
+      id: `d${i}`,
+      sessionId: SESSION,
+      event: "session_event",
+      decision: `choice-${i}`,
+      reasoning: `because ${i}`,
+      response: null,
+      timestamp: i,
+      createdAt: new Date(i).toISOString(),
+    }));
+    const ctx = makeCtx({
+      sessionMetadata: { taskId: "task-42" },
+      task: {
+        goal: "ship the monetized app",
+        acceptanceCriteria: ["deploys", "charges work"],
+        decisions,
+      },
+    });
+    const { status, body } = await call(
+      `/api/coding-agents/${SESSION}/parent-context`,
+      ctx,
+    );
+    expect(status).toBe(200);
+    const originating = (body as { originatingTask: Record<string, unknown> })
+      .originatingTask;
+    expect(originating.taskId).toBe("task-42");
+    expect(originating.goal).toBe("ship the monetized app");
+    expect(originating.acceptanceCriteria).toEqual(["deploys", "charges work"]);
+    // Capped to the latest 20 decisions, newest last.
+    const got = originating.decisions as Array<{ id: string }>;
+    expect(got).toHaveLength(20);
+    expect(got[0].id).toBe("d5");
+    expect(got[19].id).toBe("d24");
+  });
+
+  it("is null when the session was not spawned from a task", async () => {
+    const ctx = makeCtx({ sessionMetadata: {}, task: null });
+    const { body } = await call(
+      `/api/coding-agents/${SESSION}/parent-context`,
+      ctx,
+    );
+    expect(
+      (body as { originatingTask: unknown }).originatingTask,
+    ).toBeNull();
+  });
+
+  it("is null when the task store is absent", async () => {
+    const ctx = makeCtx({
+      sessionMetadata: { taskId: "task-42" },
+      noTaskService: true,
+    });
+    const { body } = await call(
+      `/api/coding-agents/${SESSION}/parent-context`,
+      ctx,
+    );
+    expect(
+      (body as { originatingTask: unknown }).originatingTask,
+    ).toBeNull();
+  });
+});
+
+describe("bridge route gates still apply to skills", () => {
+  it("rejects non-loopback callers", async () => {
+    const ctx = makeCtx({ skills: SKILLS });
+    const req = fakeRequest({
+      url: `/api/coding-agents/${SESSION}/skills`,
+      remoteAddress: "10.0.0.5",
+    });
+    const { res, status, body } = fakeResponse();
+    await handleParentContextRoutes(
+      req,
+      res,
+      `/api/coding-agents/${SESSION}/skills`,
+      ctx,
+    );
+    expect(status()).toBe(403);
+    expect((body() as { code: string }).code).toBe("loopback_only");
+  });
+
+  it("rejects a non-GET method", async () => {
+    const ctx = makeCtx({ skills: SKILLS });
+    const req = fakeRequest({
+      method: "POST",
+      url: `/api/coding-agents/${SESSION}/skills`,
+    });
+    const { res, status, body } = fakeResponse();
+    await handleParentContextRoutes(
+      req,
+      res,
+      `/api/coding-agents/${SESSION}/skills`,
+      ctx,
+    );
+    expect(status()).toBe(405);
+    expect((body() as { code: string }).code).toBe("method_not_allowed");
+  });
+
+  it("does not treat a stray sub-path on a leaf endpoint as handled", async () => {
+    const ctx = makeCtx({});
+    const { handled } = await call(
+      `/api/coding-agents/${SESSION}/memory/extra`,
+      ctx,
+    );
+    expect(handled).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/parent-context-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/parent-context-routes.test.ts
@@ -254,9 +254,7 @@ describe("parent-context originatingTask", () => {
       `/api/coding-agents/${SESSION}/parent-context`,
       ctx,
     );
-    expect(
-      (body as { originatingTask: unknown }).originatingTask,
-    ).toBeNull();
+    expect((body as { originatingTask: unknown }).originatingTask).toBeNull();
   });
 
   it("is null when the task store is absent", async () => {
@@ -268,9 +266,7 @@ describe("parent-context originatingTask", () => {
       `/api/coding-agents/${SESSION}/parent-context`,
       ctx,
     );
-    expect(
-      (body as { originatingTask: unknown }).originatingTask,
-    ).toBeNull();
+    expect((body as { originatingTask: unknown }).originatingTask).toBeNull();
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-identity.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-identity.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  buildSubAgentIdentityMd,
   SUB_AGENT_IDENTITY_MD,
   writeWorkspaceIdentity,
 } from "../../src/services/sub-agent-identity.js";
@@ -30,12 +31,43 @@ describe("writeWorkspaceIdentity", () => {
     await writeWorkspaceIdentity(dir);
     expect(existsSync(join(dir, "AGENTS.md"))).toBe(true);
     expect(existsSync(join(dir, "CLAUDE.md"))).toBe(true);
-    expect(readFileSync(join(dir, "AGENTS.md"), "utf8")).toBe(
-      SUB_AGENT_IDENTITY_MD,
+    // Default (no broker) renders the manual with the placeholder stripped.
+    const expected = buildSubAgentIdentityMd({ brokerWired: false });
+    expect(readFileSync(join(dir, "AGENTS.md"), "utf8")).toBe(expected);
+    expect(readFileSync(join(dir, "CLAUDE.md"), "utf8")).toBe(expected);
+  });
+
+  it("omits the broker section when the broker is not wired", async () => {
+    await writeWorkspaceIdentity(dir, { brokerWired: false });
+    const manual = readFileSync(join(dir, "AGENTS.md"), "utf8");
+    expect(manual).not.toMatch(/Asking the parent Eliza agent to act/);
+    expect(manual).not.toContain("{{BROKER_SECTION}}");
+  });
+
+  it("includes the broker section only when the broker is wired", async () => {
+    await writeWorkspaceIdentity(dir, { brokerWired: true });
+    const manual = readFileSync(join(dir, "AGENTS.md"), "utf8");
+    expect(manual).toMatch(/Asking the parent Eliza agent to act \(broker\)/);
+    expect(manual).toMatch(/USE_SKILL parent-agent/);
+    // Discovery is advertised, but the spend/mutation gate is stated too.
+    expect(manual).toMatch(/mutating\/paid\/destructive Cloud commands stay gated/);
+    expect(manual).not.toContain("{{BROKER_SECTION}}");
+  });
+
+  it("buildSubAgentIdentityMd never leaves the placeholder in either mode", () => {
+    expect(buildSubAgentIdentityMd({ brokerWired: true })).not.toContain(
+      "{{BROKER_SECTION}}",
     );
-    expect(readFileSync(join(dir, "CLAUDE.md"), "utf8")).toBe(
-      SUB_AGENT_IDENTITY_MD,
+    expect(buildSubAgentIdentityMd({ brokerWired: false })).not.toContain(
+      "{{BROKER_SECTION}}",
     );
+  });
+
+  it("advertises the skills bridge endpoints and originatingTask read-back", () => {
+    const manual = buildSubAgentIdentityMd();
+    expect(manual).toMatch(/\/skills\b/);
+    expect(manual).toMatch(/skills\/<slug>/);
+    expect(manual).toMatch(/originatingTask/);
   });
 
   it("states the non-interactive HARD RULE", () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-identity.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-identity.test.ts
@@ -50,7 +50,9 @@ describe("writeWorkspaceIdentity", () => {
     expect(manual).toMatch(/Asking the parent Eliza agent to act \(broker\)/);
     expect(manual).toMatch(/USE_SKILL parent-agent/);
     // Discovery is advertised, but the spend/mutation gate is stated too.
-    expect(manual).toMatch(/mutating\/paid\/destructive Cloud commands stay gated/);
+    expect(manual).toMatch(
+      /mutating\/paid\/destructive Cloud commands stay gated/,
+    );
     expect(manual).not.toContain("{{BROKER_SECTION}}");
   });
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
@@ -81,6 +81,40 @@ describe("buildGoalPrompt capability fence", () => {
     expect(prompt).toContain("read/search files");
     expect(prompt).not.toContain("domains.buy");
   });
+
+  it("omits the broker capability on the default fence when not wired", () => {
+    const prompt = buildGoalPrompt(baseInput);
+    expect(prompt).not.toContain("parent-agent bridge");
+  });
+
+  it("advertises the broker on the default fence only when wired", () => {
+    const prompt = buildGoalPrompt({ ...baseInput, brokerWired: true });
+    expect(prompt).toContain("Use only coding-relevant capabilities");
+    expect(prompt).toContain("parent-agent bridge");
+    expect(prompt).toContain("paid/mutating commands stay gated");
+  });
+
+  it("does not double-advertise the broker on the economics fence", () => {
+    // Economics already lists the full Cloud command surface; brokerWired must
+    // not append the default-fence broker line on top of it.
+    const prompt = buildGoalPrompt({
+      ...baseInput,
+      capabilityProfile: "economics",
+      brokerWired: true,
+    });
+    expect(prompt).toContain("parent-agent Cloud command bridge");
+    expect(prompt).not.toContain("paid/mutating commands stay gated");
+  });
+
+  it("never widens an explicit allow-list even when wired", () => {
+    const prompt = buildGoalPrompt({
+      ...baseInput,
+      allowedCapabilities: ["read/search files"],
+      brokerWired: true,
+    });
+    expect(prompt).toContain("read/search files");
+    expect(prompt).not.toContain("parent-agent bridge");
+  });
 });
 
 describe("buildGoalPrompt attempt reflections (#8899)", () => {

--- a/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
@@ -18,6 +18,7 @@ import { promisify } from "node:util";
 import { logger } from "@elizaos/core";
 import { assignAgentName } from "../services/agent-name-assignment.js";
 import { buildGoalFollowUp, buildGoalPrompt } from "../services/goal-prompt.js";
+import { isParentAgentBrokerWired } from "../services/parent-agent-broker.js";
 import { getTaskAgentFrameworkState } from "../services/task-agent-frameworks.js";
 import {
   type AgentType,
@@ -643,6 +644,7 @@ export async function handleAgentRoutes(
             workdir,
             taskRoomId,
             worktreeRoomId,
+            brokerWired: isParentAgentBrokerWired(ctx.runtime),
           })
         : undefined;
 

--- a/plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts
@@ -43,6 +43,40 @@ const BRIDGE_TIMEOUT_MS = 5_000;
 const DEFAULT_MEMORY_LIMIT = 10;
 const MAX_MEMORY_LIMIT = 50;
 const MEMORY_TABLES = ["facts", "messages", "documents"] as const;
+/** How many of the most recent orchestrator decisions the bridge exposes. A
+ * resumed/nested session needs the latest choices to avoid re-litigating them,
+ * not the full audit log. */
+const MAX_ORIGINATING_DECISIONS = 20;
+
+/** The narrow slice of the AgentSkillsService the bridge reads. Structural to
+ * avoid a hard dependency on `@elizaos/plugin-agent-skills` (optional at
+ * runtime); `content` is the full SKILL.md body incl. frontmatter. */
+interface SkillsServiceShape {
+  getEligibleSkills: () => Promise<
+    Array<{ slug: string; name: string; description: string; content: string }>
+  >;
+  isSkillEnabled: (slug: string) => boolean;
+}
+
+/** The narrow slice of the orchestrator task store the bridge reads to answer
+ * "what am I working on?". Structural — avoids a value import on the service so
+ * the route stays loosely coupled and the DTO shape can evolve independently. */
+interface OrchestratorTaskServiceShape {
+  getTask: (taskId: string) => Promise<{
+    goal: string;
+    acceptanceCriteria?: string[];
+    decisions?: Array<{
+      id: string;
+      sessionId: string;
+      event: string;
+      decision: string;
+      reasoning: string;
+      response: string | null;
+      timestamp: number;
+      createdAt: string;
+    }>;
+  } | null>;
+}
 
 class BridgeRouteError extends Error {
   constructor(
@@ -257,6 +291,48 @@ function normalizeMemoryHit(
   };
 }
 
+/**
+ * Load the originating orchestrator task a session serves — its goal, acceptance
+ * criteria, and the latest decisions — so a resumed or child-spawned session can
+ * read back what it is working on. Returns null when the session was not spawned
+ * from an orchestrator task (no `taskId` in metadata), the task store is absent,
+ * or the task no longer exists.
+ */
+async function loadOriginatingTask(
+  ctx: RouteContext,
+  metadata: Record<string, unknown>,
+): Promise<JsonValue> {
+  const taskId = readString(metadata.taskId);
+  if (!taskId) return null;
+  const service = ctx.runtime.getService("ORCHESTRATOR_TASK_SERVICE") as
+    | OrchestratorTaskServiceShape
+    | null
+    | undefined;
+  if (!service?.getTask) return null;
+  const task = await service.getTask(taskId);
+  if (!task) return null;
+  const decisions = (task.decisions ?? [])
+    .slice(-MAX_ORIGINATING_DECISIONS)
+    .map((decision) => ({
+      id: decision.id,
+      sessionId: decision.sessionId,
+      event: decision.event,
+      decision: decision.decision,
+      reasoning: decision.reasoning,
+      response: decision.response,
+      timestamp: decision.timestamp,
+      createdAt: decision.createdAt,
+    }));
+  return {
+    taskId,
+    goal: task.goal,
+    acceptanceCriteria: Array.isArray(task.acceptanceCriteria)
+      ? task.acceptanceCriteria
+      : [],
+    decisions,
+  };
+}
+
 async function buildParentContext(
   ctx: RouteContext,
   sessionId: string,
@@ -282,6 +358,7 @@ async function buildParentContext(
     currentRoom: await loadRoom(ctx.runtime, roomId),
     workdir: session?.workdir ?? null,
     model: normalizeModel(session, metadata),
+    originatingTask: await loadOriginatingTask(ctx, metadata),
   };
 }
 
@@ -319,6 +396,62 @@ async function searchParentMemory(
   return { query, limit, hits };
 }
 
+/** Resolve the AgentSkillsService, or null when the skills plugin is not loaded.
+ * The manifest written into the workspace lists slugs a child can request; these
+ * endpoints let the child fetch the full SKILL.md a slug maps to. */
+function getSkillsService(ctx: RouteContext): SkillsServiceShape | null {
+  const service = ctx.runtime.getService("AGENT_SKILLS_SERVICE") as
+    | SkillsServiceShape
+    | null
+    | undefined;
+  return typeof service?.getEligibleSkills === "function" ? service : null;
+}
+
+/**
+ * List the enabled-and-eligible skills with their FULL (untruncated) description
+ * — the SKILLS.md manifest only carries a 200-char preview, so a child reads
+ * this to decide which skill body to fetch. Gated to enabled+eligible so the
+ * list matches exactly what the child can actually request via the parent.
+ */
+async function listSkills(ctx: RouteContext): Promise<JsonValue> {
+  const service = getSkillsService(ctx);
+  if (!service) return { skills: [] };
+  const eligible = await service.getEligibleSkills();
+  const skills = eligible
+    .filter((skill) => service.isSkillEnabled(skill.slug))
+    .map((skill) => ({
+      slug: skill.slug,
+      name: skill.name,
+      description: skill.description,
+    }));
+  return { skills };
+}
+
+/**
+ * Return the full SKILL.md body (including frontmatter) for one slug, or null
+ * when it is not an enabled+eligible skill — the caller turns null into a 404.
+ * Same enabled+eligible gate as {@link listSkills} so a child can only read a
+ * body it could request.
+ */
+async function readSkillBody(
+  ctx: RouteContext,
+  slug: string,
+): Promise<JsonValue | null> {
+  const service = getSkillsService(ctx);
+  if (!service) return null;
+  const eligible = await service.getEligibleSkills();
+  const match = eligible.find(
+    (skill) => skill.slug === slug && service.isSkillEnabled(skill.slug),
+  );
+  if (!match) return null;
+  return {
+    slug: match.slug,
+    name: match.name,
+    description: match.description,
+    body: match.content,
+  };
+}
+
 async function listActiveWorkspaceContext(
   ctx: RouteContext,
 ): Promise<JsonValue> {
@@ -347,9 +480,13 @@ export async function handleParentContextRoutes(
   ctx: RouteContext,
 ): Promise<boolean> {
   const match = pathname.match(
-    /^\/api\/coding-agents\/([^/]+)\/(parent-context|memory|active-workspaces)$/,
+    /^\/api\/coding-agents\/([^/]+)\/(parent-context|memory|active-workspaces|skills)(?:\/([^/]+))?$/,
   );
   if (!match) return false;
+  // `skills` takes an optional trailing slug (`.../skills/<slug>`); every other
+  // endpoint is a leaf and must not carry one.
+  const skillSlugSegment = match[3];
+  if (skillSlugSegment !== undefined && match[2] !== "skills") return false;
 
   if (!isLoopbackRemoteAddress(req.socket.remoteAddress)) {
     sendBridgeError(
@@ -420,6 +557,29 @@ export async function handleParentContextRoutes(
           ),
         ),
       );
+      return true;
+    }
+    if (endpoint === "skills") {
+      if (skillSlugSegment === undefined) {
+        sendJson(res, await withBridgeTimeout(listSkills(ctx)));
+        return true;
+      }
+      const slug = parseSessionId(skillSlugSegment);
+      if (!slug) {
+        sendBridgeError(res, "invalid_skill_slug", "Invalid skill slug.", 400);
+        return true;
+      }
+      const body = await withBridgeTimeout(readSkillBody(ctx, slug));
+      if (body === null) {
+        sendBridgeError(
+          res,
+          "skill_not_found",
+          `No enabled skill matches slug "${slug}".`,
+          404,
+        );
+        return true;
+      }
+      sendJson(res, body);
       return true;
     }
     sendJson(res, await withBridgeTimeout(listActiveWorkspaceContext(ctx)));

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -17,7 +17,7 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readdir, rm, stat, unlink } from "node:fs/promises";
+import { mkdir, readdir, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import {
@@ -63,10 +63,15 @@ import {
   resolveVendoredOpencodeAcpCommand,
 } from "./opencode-config.js";
 import {
+  isParentAgentBrokerWired,
+  PARENT_AGENT_BROKER_MANIFEST_ENTRY,
+} from "./parent-agent-broker.js";
+import {
   AcpSessionStore,
   InMemorySessionStore,
   type SessionStoreBackend,
 } from "./session-store.js";
+import { buildSkillsManifest } from "./skill-manifest.js";
 import { writeWorkspaceIdentity } from "./sub-agent-identity.js";
 import {
   appendSubagentStdout,
@@ -894,10 +899,20 @@ export class AcpService extends Service {
     const isolate = opts.workdir ? opts.isolateWorkdir === true : true;
     const workdir = computeSessionWorkdir(baseWorkdir, id, isolate);
     await mkdir(workdir, { recursive: true });
+    // The parent-agent broker is only reachable when the SubAgentRouter is bound
+    // to the ACP event stream; gate every broker advertisement (manual section,
+    // SKILLS.md broker entry) on that so a child is never told about a bridge it
+    // cannot use.
+    const brokerWired = isParentAgentBrokerWired(this.runtime);
     // Give the sub-agent its eliza-context + non-interactive operating manual on
     // disk (where every backend reads it) — only when the workspace is bare, so
     // a real repo's own AGENTS.md/CLAUDE.md is never clobbered.
-    await writeWorkspaceIdentity(workdir);
+    await writeWorkspaceIdentity(workdir, { brokerWired });
+    // Write SKILLS.md into every spawn workspace so a child can discover (and
+    // request, via the parent) the parent's installed skills — not just the
+    // economics loop. The broker skill is advertised only when wired; the
+    // recommended-slugs / ViewKind extras are opt-in via opts.skillsManifest.
+    await this.writeSkillsManifest(workdir, id, brokerWired, opts);
 
     // Record the workspace HEAD + already-dirty files at spawn so the change
     // set captured at task_complete is scoped to exactly what this sub-agent
@@ -1104,6 +1119,45 @@ export class AcpService extends Service {
     const updated = await this.store.get(id);
     const sessionSnapshot: SessionInfo = { ...session, status: "ready" };
     return toSpawnResult(updated ?? sessionSnapshot);
+  }
+
+  /**
+   * Write SKILLS.md into a spawn workspace so the sub-agent can discover the
+   * parent's installed skills and request them back via the parent. Runs on the
+   * SHARED spawn path (every `spawnSession`) so direct `/api/coding-agents` and
+   * `TASKS_SPAWN_AGENT` spawns get it, not just the economics loop. The broker
+   * skill is advertised only when the router is wired; `opts.skillsManifest`
+   * adds the recommended-slug highlight and Cloud ViewKind contract for
+   * app-building tasks. Best-effort — a failed write warns and the spawn
+   * proceeds without the manifest.
+   */
+  private async writeSkillsManifest(
+    workdir: string,
+    sessionId: string,
+    brokerWired: boolean,
+    opts: SpawnOptions,
+  ): Promise<void> {
+    try {
+      const manifest = await buildSkillsManifest(this.runtime, {
+        ...(opts.skillsManifest?.recommendedSlugs
+          ? { recommendedSlugs: opts.skillsManifest.recommendedSlugs }
+          : {}),
+        ...(brokerWired
+          ? { virtualSkills: [{ ...PARENT_AGENT_BROKER_MANIFEST_ENTRY }] }
+          : {}),
+        includeViewKindContract:
+          opts.skillsManifest?.includeViewKindContract ?? false,
+      });
+      await writeFile(join(workdir, "SKILLS.md"), manifest.markdown, "utf8");
+    } catch (err) {
+      // error-policy:J7 SKILLS.md scaffolding is best-effort; a failed write is
+      // warned and the spawn proceeds without it — a missing manifest only
+      // degrades skill discovery.
+      this.runtime.logger?.warn?.(
+        { src: "acp-service", sessionId, workdir },
+        `failed to write SKILLS.md: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   async sendPrompt(

--- a/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
@@ -28,6 +28,16 @@ export const DEFAULT_GOAL_CAPABILITIES: readonly string[] = [
 ];
 
 /**
+ * The single broker capability line advertised on the DEFAULT fence when the
+ * broker is wired for the spawn. Discovery only: it tells a coding sub-agent the
+ * parent-agent bridge exists so it can ask the parent to run a capability it
+ * lacks. Paid/mutating Cloud commands stay gated server-side and by the broker
+ * spend cap — the economics fence lists the full command surface separately.
+ */
+export const BROKER_GOAL_CAPABILITY =
+  "ask the parent Eliza agent to run its own capabilities via the parent-agent bridge (USE_SKILL parent-agent) — paid/mutating commands stay gated";
+
+/**
  * Capability fence for goal tasks that build and monetize an Eliza Cloud app.
  * Extends the coding capabilities with the parent-agent Cloud command bridge so
  * a `/goal` sub-agent can drive the create-app → deploy → monetize → buy-domain
@@ -102,6 +112,12 @@ export interface GoalPromptInput {
   /** Explicit capability fence; overrides {@link GoalPromptInput.capabilityProfile}
    * and defaults to {@link DEFAULT_GOAL_CAPABILITIES}. */
   allowedCapabilities?: readonly string[];
+  /** Advertise the parent-agent broker on the DEFAULT capability fence. Set only
+   * when the broker is actually wired for the spawn (see
+   * `isParentAgentBrokerWired`). Ignored for the economics profile, which already
+   * lists the full Cloud command surface, and when `allowedCapabilities` is an
+   * explicit override. */
+  brokerWired?: boolean;
   /** Reflexion-style post-mortems from prior failed verification attempts of
    * this same task. Injected on re-spawn so the worker doesn't repeat them. */
   attemptReflections?: readonly AttemptReflection[];
@@ -146,6 +162,16 @@ export function buildGoalPrompt(input: GoalPromptInput): string {
   const capabilities = [
     ...(input.allowedCapabilities ?? resolveGoalCapabilities(profile)),
   ];
+  // Advertise the broker on the DEFAULT fence only. The economics fence already
+  // enumerates the full Cloud command surface, and an explicit
+  // `allowedCapabilities` override is trusted verbatim — never widened here.
+  if (
+    input.brokerWired &&
+    profile === "default" &&
+    input.allowedCapabilities === undefined
+  ) {
+    capabilities.push(BROKER_GOAL_CAPABILITY);
+  }
   const sections: string[] = [
     "--- Goal ---",
     `You are ${input.agentName.trim()}, an autonomous coding sub-agent working as part of a swarm on a durable orchestrator task. Keep working until the goal is met or you are genuinely blocked.`,

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -18,7 +18,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import { appendFile, mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { type IAgentRuntime, Service } from "@elizaos/core";

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -117,7 +117,10 @@ import {
   TERMINAL_TASK_STATUSES,
   type UsageState,
 } from "./orchestrator-task-types.js";
-import { PARENT_AGENT_BROKER_MANIFEST_ENTRY } from "./parent-agent-broker.js";
+import {
+  isParentAgentBrokerWired,
+  PARENT_AGENT_BROKER_MANIFEST_ENTRY,
+} from "./parent-agent-broker.js";
 import { buildSkillsManifest } from "./skill-manifest.js";
 import {
   configureSpendLedger,
@@ -2849,6 +2852,7 @@ export class OrchestratorTaskService extends Service {
     const capabilityProfile = coerceGoalCapabilityProfile(
       doc.task.metadata?.capabilityProfile,
     );
+    const brokerWired = isParentAgentBrokerWired(this.runtime);
     const goalPrompt = buildGoalPrompt({
       agentName,
       goal: doc.task.goal,
@@ -2861,6 +2865,7 @@ export class OrchestratorTaskService extends Service {
       // doesn't repeat them (#8899).
       attemptReflections: readAttemptReflections(doc.task.metadata),
       ...(capabilityProfile ? { capabilityProfile } : {}),
+      brokerWired,
     });
 
     // Economics tasks drive the monetized-app loop through the parent-agent
@@ -2909,6 +2914,18 @@ export class OrchestratorTaskService extends Service {
         initialTask: goalPrompt,
         model: opts.model ?? policy.model,
         approvalPreset: opts.approvalPreset,
+        // Economics tasks drive the monetized-app loop; enrich the always-written
+        // SKILLS.md with the Cloud app-build skills and the ViewKind contract so a
+        // deploying sub-agent categorizes any view it ships (#8917). The broker
+        // skill entry itself is added by spawnSession when the router is wired.
+        ...(capabilityProfile === "economics"
+          ? {
+              skillsManifest: {
+                recommendedSlugs: ["build-monetized-app", "eliza-cloud"],
+                includeViewKindContract: true,
+              },
+            }
+          : {}),
         metadata: {
           taskId,
           roomId: doc.task.taskRoomId ?? doc.task.roomId,

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -63,9 +63,9 @@ export const PARENT_AGENT_BROKER_MANIFEST_ENTRY = {
 export function isParentAgentBrokerWired(runtime: IAgentRuntime): boolean {
   const getService = (runtime as { getService?: unknown }).getService;
   if (typeof getService !== "function") return false;
-  const router = getService.call(runtime, "ACPX_SUB_AGENT_ROUTER") as
-    | { isActive?: () => boolean }
-    | null;
+  const router = getService.call(runtime, "ACPX_SUB_AGENT_ROUTER") as {
+    isActive?: () => boolean;
+  } | null;
   return typeof router?.isActive === "function" && router.isActive();
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -46,6 +46,27 @@ export const PARENT_AGENT_BROKER_MANIFEST_ENTRY = {
     'Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). Fixed-cost self-spend commands such as `containers.create` may auto-authorize within the configured agent spend cap; variable-cost self-spend commands such as `domains.buy`, `media.*`, `promote.*`, and `advertising.*` always require human confirmation because the server-quoted price cannot be trusted from child-declared `params.spendEstimateUsd`. To delegate part of your work to a NEW parallel sub-agent on this same task, use `USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"<instruction for the child>","label":"<optional name>"}` — it spawns a child sub-agent (bounded nesting depth) whose progress shows in this task\'s thread; keep working, do not block waiting on it.',
 } as const;
 
+/**
+ * Is the child→parent broker actually reachable for a spawn happening now?
+ *
+ * The broker only functions when the `SubAgentRouter` is bound to the ACP
+ * session-event stream — that binding is what greps each child's stdout for the
+ * `USE_SKILL parent-agent` directive and dispatches it. When the router is
+ * disabled (`ACPX_SUB_AGENT_ROUTER_DISABLED`), stopped, or has not yet bound,
+ * no directive is ever picked up, so advertising the broker to a sub-agent would
+ * be a lie. Discovery surfaces (the operating manual, the default capability
+ * fence) gate on this so a child is only told about a bridge it can use.
+ *
+ * Read structurally via `isActive()` rather than importing `SubAgentRouter` to
+ * avoid a value/type import cycle (the router imports broker symbols).
+ */
+export function isParentAgentBrokerWired(runtime: IAgentRuntime): boolean {
+  const router = runtime.getService("ACPX_SUB_AGENT_ROUTER") as
+    | { isActive?: () => boolean }
+    | null;
+  return typeof router?.isActive === "function" && router.isActive();
+}
+
 type ParentAgentMode =
   | "ask"
   | "list-actions"

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -61,7 +61,9 @@ export const PARENT_AGENT_BROKER_MANIFEST_ENTRY = {
  * avoid a value/type import cycle (the router imports broker symbols).
  */
 export function isParentAgentBrokerWired(runtime: IAgentRuntime): boolean {
-  const router = runtime.getService("ACPX_SUB_AGENT_ROUTER") as
+  const getService = (runtime as { getService?: unknown }).getService;
+  if (typeof getService !== "function") return false;
+  const router = getService.call(runtime, "ACPX_SUB_AGENT_ROUTER") as
     | { isActive?: () => boolean }
     | null;
   return typeof router?.isActive === "function" && router.isActive();

--- a/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
@@ -9,8 +9,10 @@
  *     match already scores ≥ 0.9 (no need to spend a model call) or when the
  *     runtime model is unavailable.
  *
- * The output is task-aware ranking: the orchestrator can then write the top
- * N into SKILLS.md and reference them in the spawned agent's initial prompt.
+ * The output is a task-aware ranking of installed skill slugs. Callers pass the
+ * top slugs to `buildSkillsManifest` via `recommendedSlugs`, which surfaces them
+ * in a "Recommended for this task" section of the SKILLS.md written into the
+ * spawn workspace. It does not itself write any file or edit the spawn prompt.
  *
  * @module services/skill-recommender
  */

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
@@ -19,11 +19,18 @@ import { logger } from "@elizaos/core";
 const IDENTITY_FILENAMES = ["AGENTS.md", "CLAUDE.md"] as const;
 
 /**
- * The operating manual. Deliberately self-contained — a sub-agent never has to
- * chase a possibly-stale skill file to know it is non-interactive. Bridge facts
- * are stated accurately: `memory` is global semantic search (not the originating
- * room's recent messages), `parent-context` does not expose the original task,
- * and the endpoints only work when `PARALLAX_SESSION_ID` is wired.
+ * The operating manual template. Deliberately self-contained — a sub-agent never
+ * has to chase a possibly-stale skill file to know it is non-interactive. Bridge
+ * facts are stated accurately: `memory` is global semantic search (not the
+ * originating room's recent messages), `parent-context` exposes the originating
+ * task goal + latest decisions, and the endpoints only work when
+ * `PARALLAX_SESSION_ID` is wired.
+ *
+ * Carries a `{{BROKER_SECTION}}` placeholder that {@link buildSubAgentIdentityMd}
+ * fills with the parent-agent broker section only when the broker is actually
+ * wired for the session (the `SubAgentRouter` is bound) — advertising a bridge a
+ * child cannot use would be a lie. Use {@link buildSubAgentIdentityMd}, not this
+ * raw template, to render a manual.
  */
 export const SUB_AGENT_IDENTITY_MD = `# Eliza coding sub-agent — operating manual
 
@@ -72,11 +79,17 @@ If the task depends on context not in the prompt, you can GET read-only parent
 state, but only when the bridge is wired (env var \`PARALLAX_SESSION_ID\` set):
 
 - \`curl "http://127.0.0.1:\${ELIZA_HOOK_PORT:-2138}/api/coding-agents/\${PARALLAX_SESSION_ID}/parent-context"\`
-  → parent character, originating room, model prefs, your workdir.
+  → parent character, originating room, model prefs, your workdir, and
+  \`originatingTask\` (the goal, acceptance criteria, and latest decisions of the
+  task you serve — read this after a resume to know what you are working on).
 - \`.../memory?q=<query>&limit=<N>\` → GLOBAL semantic search over the parent's
   memory (facts, messages, knowledge) — not the originating room's recency.
 - \`.../active-workspaces\` → sibling sub-agents.
-
+- \`.../skills\` → the parent's installed skills (slug + full description).
+  \`.../skills/<slug>\` → the full SKILL.md body for one slug. The SKILLS.md in
+  your workspace lists these; fetch a body here before asking the parent to run
+  a skill you are unsure about.
+{{BROKER_SECTION}}
 ## Requesting a missing credential
 
 If a task truly requires a credential that is not in your sealed environment
@@ -142,20 +155,84 @@ the other end, only chat. Make that message the answer itself:
 `;
 
 /**
+ * The broker section, injected into the manual only when the parent-agent broker
+ * is wired for this spawn. The child reaches it by printing a
+ * `USE_SKILL parent-agent <json>` line on stdout, which the router bridges to the
+ * broker; the guidance here mirrors `PARENT_AGENT_BROKER_MANIFEST_ENTRY` so the
+ * on-disk manual and the SKILLS.md manifest tell the same story. Discovery is
+ * free; spend/mutation gates are enforced parent-side and cannot be bypassed by a
+ * child-declared price.
+ */
+const SUB_AGENT_BROKER_SECTION_MD = `
+## Asking the parent Eliza agent to act (broker)
+
+The parent Eliza agent runs with its own loaded capabilities — actions,
+providers, connectors, and the full Eliza Cloud command surface (create/deploy/
+monetize apps, buy domains, read credits/earnings, x402 payment requests). You
+cannot run those yourself, but you can ask the parent to run them for you and
+relay the result, by printing ONE line on stdout of the form:
+
+\`USE_SKILL parent-agent <json>\`
+
+The parent greps your stdout for this directive, executes the request with its
+own capabilities, and streams the reply back into your session. Examples:
+
+- Delegate to the parent's own tools: \`USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}\`
+- List the parent's actions: \`USE_SKILL parent-agent {"mode":"list-actions","query":"github"}\`
+- List Cloud commands: \`USE_SKILL parent-agent {"mode":"list-cloud-commands"}\`
+- Run a read Cloud command: \`USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}\`
+- Spawn a helper sub-agent on this task: \`USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"<instruction>","label":"<optional name>"}\`
+
+Discovery is free, but mutating/paid/destructive Cloud commands stay gated: they
+require an explicit human "yes" on a follow-up turn, and paid self-spend is
+capped by the parent's spend allowance. You cannot bypass either gate by
+declaring a price — the parent verifies server-side. Use this only when the task
+genuinely needs a parent capability; a self-contained coding task never should.
+`;
+
+/** Options controlling which optional sections the rendered manual includes. */
+export interface SubAgentIdentityOptions {
+  /** Advertise the parent-agent broker section. Only pass `true` when the broker
+   * is actually wired for the session (the `SubAgentRouter` is bound); see
+   * `isParentAgentBrokerWired`. */
+  brokerWired?: boolean;
+}
+
+/**
+ * Render the operating manual, filling the `{{BROKER_SECTION}}` placeholder with
+ * the broker section when `brokerWired` is set and stripping it otherwise. This
+ * is the only supported way to produce a manual — the raw template still carries
+ * the placeholder.
+ */
+export function buildSubAgentIdentityMd(
+  opts: SubAgentIdentityOptions = {},
+): string {
+  return SUB_AGENT_IDENTITY_MD.replace(
+    "{{BROKER_SECTION}}",
+    opts.brokerWired ? SUB_AGENT_BROKER_SECTION_MD : "",
+  );
+}
+
+/**
  * Scaffold the operating manual into a freshly-created spawn workspace, but only
  * when the workspace is "bare" (has neither AGENTS.md nor CLAUDE.md). A real
  * project/repo workdir already carries its own instruction files and must NOT be
- * clobbered — the prompt-level non-interactive directive covers that case.
+ * clobbered — the prompt-level non-interactive directive covers that case. The
+ * broker section is included only when the broker is wired for the session.
  */
-export async function writeWorkspaceIdentity(workdir: string): Promise<void> {
+export async function writeWorkspaceIdentity(
+  workdir: string,
+  opts: SubAgentIdentityOptions = {},
+): Promise<void> {
   try {
     const alreadyHasIdentity = IDENTITY_FILENAMES.some((name) =>
       existsSync(join(workdir, name)),
     );
     if (alreadyHasIdentity) return;
+    const manual = buildSubAgentIdentityMd(opts);
     await Promise.all(
       IDENTITY_FILENAMES.map((name) =>
-        writeFile(join(workdir, name), SUB_AGENT_IDENTITY_MD, "utf8"),
+        writeFile(join(workdir, name), manual, "utf8"),
       ),
     );
     logger.debug(

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -172,6 +172,19 @@ export interface SpawnOptions {
   skipAdapterAutoResponse?: boolean;
   timeoutMs?: number;
   model?: string;
+  /**
+   * Task-specific enrichment for the SKILLS.md manifest that `spawnSession`
+   * writes into every bare workspace. The base manifest (enabled skills + the
+   * broker skill when wired) is always written; these fields only add a
+   * "recommended" highlight and the Cloud ViewKind contract for app-building /
+   * economics tasks. Omit for a plain coding spawn.
+   */
+  skillsManifest?: {
+    /** Slugs to surface in a "Recommended for this task" section. */
+    recommendedSlugs?: string[];
+    /** Append the Cloud ViewKind contract (for view-shipping app builds). */
+    includeViewKindContract?: boolean;
+  };
 }
 
 export interface SpawnResult {

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -130,7 +130,9 @@ export class SessionCapError extends Error {
     maxSessions: number,
     activeCount: number,
   ) {
-    super(`acp ${slotClass} session cap reached (${activeCount}/${maxSessions})`);
+    super(
+      `acp ${slotClass} session cap reached (${activeCount}/${maxSessions})`,
+    );
     this.name = "SessionCapError";
     this.slotClass = slotClass;
     this.maxSessions = maxSessions;


### PR DESCRIPTION
## What & why

Part of #13774 (WS4, epic #13766). Implements items **1–4** — the implementable, non-product-decision slice. Subagents already have the parent-agent broker + installed skills available to them, but the plumbing never told them so. This closes the discovery gap without weakening any spend/mutation gate. **Untouched (owner decisions a/b/c):** cloud-credential forwarding and `appId` plumbing.

### 1. Advertise the broker — gated on it being wired
- New `isParentAgentBrokerWired(runtime)` (`parent-agent-broker.ts`): the broker only works when `SubAgentRouter` is bound to the ACP event stream (it greps child stdout for `USE_SKILL parent-agent`). Everything gates on `router.isActive()`, so a child is never told about a bridge it can't use.
- `sub-agent-identity.ts`: the operating manual now carries a `{{BROKER_SECTION}}` placeholder; `buildSubAgentIdentityMd({ brokerWired })` fills it with the broker section only when wired.
- `goal-prompt.ts`: a single `BROKER_GOAL_CAPABILITY` line is appended to the **default** fence only when wired — never to the economics fence (which already enumerates the Cloud surface) and never over an explicit `allowedCapabilities` override.
- **No gate weakening:** the advertised text states plainly that paid/mutating/destructive Cloud commands stay behind human confirmation + the spend allowance, and a child-declared price can't bypass either.

### 2. SKILLS.md on **every** spawn
- Moved the manifest write out of the economics-only branch (`orchestrator-task-service.ts`) into the shared spawn path (`AcpService.spawnSession` → new `writeSkillsManifest`), alongside `writeWorkspaceIdentity`. Direct `/api/coding-agents/*` and `TASKS_SPAWN_AGENT` spawns now get it too — all three paths funnel through `spawnSession`.
- Economics enrichment (recommended slugs + ViewKind contract) is threaded through the new `SpawnOptions.skillsManifest`. The broker entry is added only when wired.
- Fixed the overstated `skill-recommender.ts` header (it claimed the recommender writes SKILLS.md and edits the spawn prompt; it does neither).

### 3. Skills bridge endpoints (`parent-context-routes.ts`)
- `GET /api/coding-agents/<sessionId>/skills` — list of enabled+eligible skills with **full** (untruncated) descriptions.
- `GET /api/coding-agents/<sessionId>/skills/<slug>` — the full SKILL.md body; **404** for an unknown or disabled slug.
- Same loopback + GET + active-session gates as the existing reads.

### 4. Originating task via the bridge
- `parent-context` now returns `originatingTask` = `{ taskId, goal, acceptanceCriteria, decisions }` (latest 20 decisions) read from `ORCHESTRATOR_TASK_SERVICE` via the session's `taskId`. `null` when the session wasn't spawned from a task or the store is absent. Lets resumed/nested sessions read back what they serve.

## Evidence

**Real tests (deterministic; drive the real route handlers + real `AcpService` spawn path over a mocked ACP transport, real temp-FS writes):**

```
$ bunx vitest run acp-service parent-context-routes sub-agent-identity goal-prompt agent-routes-goal-wrapper
 Test Files  5 passed (5)
      Tests  94 passed (94)
```

Coverage added:
- **All three spawn paths** get SKILLS.md: `acp-service.test.ts` spawns into a real temp dir and asserts `SKILLS.md` is written with the skill entry, and that the broker entry + manual broker section appear **only** when the router `isActive()`.
- **Skills endpoints**: list returns full descriptions (no body leak), drops disabled skills, empty when service absent; `/skills/<slug>` returns the real body and **404s** unknown + disabled slugs; loopback/GET gates still fire.
- **originatingTask**: goal + acceptance criteria + decisions capped at 20 (newest last); `null` with no `taskId` / no task store.
- **Broker gating**: identity manual + default capability fence include the broker section **only** when wired; never widens the economics fence or an explicit allow-list.

**Error-policy ratchet:**
```
$ bun run audit:error-policy-ratchet
[error-policy-ratchet] no new fallback-slop in touched files
```

**Typecheck** (`tsgo -p tsconfig.json`): no errors in any touched file. (Pre-existing unrelated errors in `packages/core/src/i18n/*` from a missing generated file in the worktree — not touched here.)

- Real-LLM trajectories — N/A: no agent/action/prompt/model behavior change; this is context-delivery plumbing (route handlers, spawn-time file writes, prompt-envelope text).
- Frontend/screenshots/video — N/A: no UI surface.

Fixes #13774 items 1–4 (items a/b/c are deferred owner product decisions and are explicitly out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
