### PR TITLE
fix(#13776): narrow project migration catch

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -1064,7 +1064,9 @@ describe("task.projectId binding (#13776)", () => {
     const a = await store.createTask(
       createInput({ title: "sql-a", projectId: "proj-a" }),
     );
-    await store.createTask(createInput({ title: "sql-b", projectId: "proj-b" }));
+    await store.createTask(
+      createInput({ title: "sql-b", projectId: "proj-b" }),
+    );
 
     // The indexed column is populated (not just buried in the JSON document).
     expect(adapter.rows.get(a.task.id)?.project_id).toBe("proj-a");
@@ -1084,9 +1086,29 @@ describe("task.projectId binding (#13776)", () => {
     await expect(
       second.createTask(createInput({ title: "second", projectId: "p2" })),
     ).resolves.toBeDefined();
-    expect((await second.listTasks({ projectId: "p2" })).map((t) => t.title)).toEqual(
-      ["second"],
-    );
+    expect(
+      (await second.listTasks({ projectId: "p2" })).map((t) => t.title),
+    ).toEqual(["second"]);
+  });
+
+  it("surfaces non-idempotent project_id ADD COLUMN migration failures", async () => {
+    class BrokenMigrationAdapter extends FakeSqlAdapter {
+      override async execute(
+        sql: string,
+        params: unknown[] = [],
+      ): Promise<void> {
+        if (sql.trim().toUpperCase().startsWith("ALTER ")) {
+          throw new Error("disk is read-only");
+        }
+        return super.execute(sql, params);
+      }
+    }
+
+    const store = new RuntimeDbTaskStore(new BrokenMigrationAdapter());
+
+    await expect(
+      store.createTask(createInput({ title: "blocked", projectId: "p1" })),
+    ).rejects.toThrow("disk is read-only");
   });
 
   it("surfaces projectId on the detail DTO", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -105,6 +105,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+function isDuplicateColumnError(error: unknown): boolean {
+  if (!isRecord(error)) return false;
+  if (error.code === "42701") return true;
+  const message =
+    typeof error.message === "string" ? error.message.toLowerCase() : "";
+  return (
+    message.includes("duplicate column") ||
+    /column .+ already exists/.test(message)
+  );
+}
+
 /** Boundary guard for documents loaded from disk/JSON. A document must carry a
  * task with an id plus the inline child arrays that existed before the
  * plan-revision rollout. `planRevisions` is filled below for older documents. */
@@ -864,10 +875,11 @@ export class RuntimeDbTaskStore {
       for (const sql of TASK_MIGRATION_SQL) {
         try {
           await this.executor.run(sql);
-        } catch {
+        } catch (err) {
           // error-policy:J6 idempotent DDL — ADD COLUMN throws on a table that
           // already has the column (every boot after the first); the desired
           // post-state is identical, so a duplicate-column failure is success.
+          if (!isDuplicateColumnError(err)) throw err;
         }
       }
       for (const sql of TASK_INDEX_SQL) await this.executor.run(sql);


### PR DESCRIPTION
## What

Follow-up to #13815 / #13776. The project_id SQL migration catch now only treats known duplicate-column errors as idempotent success. Any other `ALTER TABLE ... ADD COLUMN` failure rethrows so a broken migration cannot masquerade as a healthy task store.

Added a regression test proving a non-duplicate migration failure surfaces.

## Verification

- `bun test plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts` -> 49 passed
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts` -> clean
- `bun run audit:error-policy-ratchet` -> clean/no new fallback-slop
- `git diff --check` -> clean

`bun run --cwd plugins/plugin-agent-orchestrator typecheck` is still blocked locally by the existing worktree dependency-resolution issue through `/home/shaw/milady/eliza/dist/node_modules` (missing declarations for drizzle-orm/yaml/fs-extra/etc., plus unrelated `scripts/export-ci-account-secrets.ts` import).

Part of #13776