### PR TITLE
feat(#13772): durable admission queue + typed SessionCapError with worker/system slot classes

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-capacity-slot-class.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-capacity-slot-class.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Real-path coverage for AcpService's worker/system slot accounting (#13772):
+ * getCapacity() counts non-terminal sessions by their stamped slotClass, and
+ * enforceSessionLimit throws a typed SessionCapError per class. Exercises the
+ * production AcpService against a real InMemorySessionStore (not a mock of the
+ * cap logic); only the runtime shell is a stub.
+ */
+
+import { describe, expect, it } from "vitest";
+import { AcpService } from "../services/acp-service.ts";
+import { InMemorySessionStore } from "../services/session-store.ts";
+import { SessionCapError, type SessionInfo } from "../services/types.ts";
+
+function makeRuntime(
+  settings: Record<string, string> = {},
+): Record<string, unknown> {
+  return {
+    agentId: "00000000-0000-4000-8000-000000000001",
+    character: { name: "Tester" },
+    getSetting: (key: string) => settings[key],
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    getService: () => null,
+  };
+}
+
+function session(
+  id: string,
+  slotClass: "worker" | "system",
+  status = "running",
+): SessionInfo {
+  const now = new Date();
+  return {
+    id,
+    name: id,
+    agentType: "opencode",
+    workdir: "/tmp/x",
+    status,
+    approvalPreset: "standard",
+    createdAt: now,
+    lastActivityAt: now,
+    metadata: { slotClass },
+  };
+}
+
+async function serviceWith(
+  sessions: SessionInfo[],
+  settings: Record<string, string> = {},
+): Promise<AcpService> {
+  const store = new InMemorySessionStore();
+  for (const s of sessions) await store.create(s);
+  return new AcpService(makeRuntime(settings) as never, { store });
+}
+
+describe("AcpService slot-class capacity (#13772)", () => {
+  it("defaults to max 8 workers / 2 system headroom", async () => {
+    const svc = await serviceWith([]);
+    const cap = await svc.getCapacity();
+    expect(cap.maxSessions).toBe(8);
+    expect(cap.freeWorkerSlots).toBe(8);
+    expect(cap.activeWorkers).toBe(0);
+    expect(cap.activeSystem).toBe(0);
+  });
+
+  it("counts non-terminal sessions by stamped class", async () => {
+    const svc = await serviceWith(
+      [
+        session("w1", "worker"),
+        session("w2", "worker", "ready"),
+        session("sys1", "system"),
+        // Terminal sessions do not count against either class.
+        session("w3", "worker", "completed"),
+        session("sys2", "system", "stopped"),
+      ],
+      { ELIZA_ACP_MAX_SESSIONS: "5" },
+    );
+    const cap = await svc.getCapacity();
+    expect(cap.maxSessions).toBe(5);
+    expect(cap.activeWorkers).toBe(2);
+    expect(cap.activeSystem).toBe(1);
+    expect(cap.freeWorkerSlots).toBe(3);
+  });
+
+  it("freeWorkerSlots reflects WORKER headroom only, never system saturation", async () => {
+    // Fill system headroom (2) but leave 1 worker slot free — freeWorkerSlots must
+    // still be 1, so the admission queue sees room for a worker.
+    const svc = await serviceWith(
+      [
+        session("w1", "worker"),
+        session("sys1", "system"),
+        session("sys2", "system"),
+      ],
+      { ELIZA_ACP_MAX_SESSIONS: "2", ELIZA_ACP_SYSTEM_SESSION_HEADROOM: "2" },
+    );
+    const cap = await svc.getCapacity();
+    expect(cap.activeWorkers).toBe(1);
+    expect(cap.activeSystem).toBe(2);
+    expect(cap.freeWorkerSlots).toBe(1);
+  });
+
+  it("throws a typed SessionCapError code string for callers to match", () => {
+    const err = new SessionCapError("worker", 2, 2);
+    expect(err.code).toBe("SESSION_CAP_REACHED");
+    expect(err.slotClass).toBe("worker");
+    expect(err.maxSessions).toBe(2);
+    expect(err.activeCount).toBe(2);
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/admission-integration.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admission-integration.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Integration coverage for the durable admission queue (#13772) driving the
+ * real OrchestratorTaskService against a cap-enforcing fake ACP and an in-memory
+ * task store. The fake ACP is a faithful capacity model (worker cap + system
+ * headroom + terminal-event bus), NOT a mock of the queue under test — the
+ * orchestrator's parking, drain-in-order, restart-rebuild, and provider-surface
+ * logic is exercised for real.
+ *
+ * Proven: N-over-cap → deterministic active + queued split with 202/201 status,
+ * drain on completion in priority-FIFO order with zero drops, the verifier
+ * spawns at full worker cap (system headroom), idle-reclaim frees a slot for a
+ * queued task, a restart rebuilds the order from the store, and the provider
+ * surfaces the capacity line.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { activeSubAgentsProvider } from "../providers/active-sub-agents.ts";
+import { AcpService } from "../services/acp-service.ts";
+import { OrchestratorTaskService } from "../services/orchestrator-task-service.ts";
+import { OrchestratorTaskStore } from "../services/orchestrator-task-store.ts";
+import {
+  SessionCapError,
+  type SessionInfo,
+  type SpawnOptions,
+  type SpawnResult,
+} from "../services/types.ts";
+
+type EventHandler = (sessionId: string, event: string, data: unknown) => void;
+
+/** Poll until `predicate` holds or the deadline passes. The drain runs
+ * fire-and-forget off a terminal event, so tests await its settle by polling
+ * observable state rather than reaching into the internal drain promise. */
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error("waitUntil timed out");
+}
+
+/** A minimal but faithful ACP capacity model: enforces the worker cap and the
+ * system headroom exactly as the real AcpService does, tracks live sessions,
+ * and lets the test emit terminal events to free slots. */
+class FakeAcp {
+  static serviceType = AcpService.serviceType;
+  private readonly sessions = new Map<string, SessionInfo>();
+  private handler: EventHandler | undefined;
+  private counter = 0;
+
+  constructor(
+    private readonly maxSessions: number,
+    private readonly systemHeadroom = 2,
+  ) {}
+
+  private countByClass(): { workers: number; system: number } {
+    let workers = 0;
+    let system = 0;
+    for (const s of this.sessions.values()) {
+      if (
+        ["stopped", "completed", "error", "errored", "cancelled"].includes(
+          s.status,
+        )
+      ) {
+        continue;
+      }
+      if ((s.metadata?.slotClass ?? "worker") === "system") system++;
+      else workers++;
+    }
+    return { workers, system };
+  }
+
+  async getCapacity() {
+    const { workers, system } = this.countByClass();
+    return {
+      maxSessions: this.maxSessions,
+      activeWorkers: workers,
+      activeSystem: system,
+      freeWorkerSlots: Math.max(0, this.maxSessions - workers),
+    };
+  }
+
+  async spawnSession(opts: SpawnOptions): Promise<SpawnResult> {
+    const slotClass = opts.slotClass ?? "worker";
+    const { workers, system } = this.countByClass();
+    if (slotClass === "system") {
+      if (system >= this.systemHeadroom)
+        throw new SessionCapError("system", this.systemHeadroom, system);
+    } else if (workers >= this.maxSessions) {
+      throw new SessionCapError("worker", this.maxSessions, workers);
+    }
+    const id = `sess-${++this.counter}`;
+    const now = new Date();
+    const session: SessionInfo = {
+      id,
+      name: opts.name ?? id,
+      agentType: opts.agentType ?? "opencode",
+      workdir: opts.workdir ?? "/tmp/work",
+      status: "running",
+      approvalPreset: opts.approvalPreset ?? "standard",
+      createdAt: now,
+      lastActivityAt: now,
+      metadata: { ...(opts.metadata ?? {}), slotClass },
+    };
+    this.sessions.set(id, session);
+    return {
+      sessionId: id,
+      id,
+      name: session.name ?? id,
+      agentType: session.agentType,
+      workdir: session.workdir,
+      status: session.status,
+      metadata: session.metadata,
+    };
+  }
+
+  listSessions(): SessionInfo[] {
+    return [...this.sessions.values()];
+  }
+
+  async getSession(id: string): Promise<SessionInfo | null> {
+    return this.sessions.get(id) ?? null;
+  }
+
+  async stopSession(id: string): Promise<void> {
+    const s = this.sessions.get(id);
+    if (s) s.status = "stopped";
+    this.handler?.(id, "stopped", {});
+  }
+
+  onSessionEvent(cb: EventHandler): () => void {
+    this.handler = cb;
+    return () => {
+      this.handler = undefined;
+    };
+  }
+
+  getChangedPaths(): string[] {
+    return [];
+  }
+
+  /** Drive a terminal completion for a live session (frees the slot). */
+  complete(id: string): void {
+    const s = this.sessions.get(id);
+    if (s) s.status = "completed";
+    this.handler?.(id, "task_complete", { response: "done" });
+  }
+}
+
+function makeRuntime(acp: FakeAcp): Record<string, unknown> {
+  return {
+    agentId: "00000000-0000-4000-8000-000000000001",
+    character: { name: "Tester" },
+    databaseAdapter: undefined,
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getSetting: () => undefined,
+    useModel: vi.fn(async () => "{}"),
+    reportError: vi.fn(),
+    getService: (type: string) =>
+      type === AcpService.serviceType ? acp : undefined,
+  };
+}
+
+async function newTask(
+  store: OrchestratorTaskStore,
+  title: string,
+  priority: "low" | "normal" | "high" | "urgent" = "normal",
+): Promise<string> {
+  const detail = await store.createTask({
+    title,
+    goal: `goal ${title}`,
+    acceptanceCriteria: [],
+    priority,
+    roomId: "11111111-1111-4111-8111-111111111111",
+  });
+  return detail.task.id;
+}
+
+describe("admission queue integration (#13772)", () => {
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const key of [
+      "ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY",
+      "ELIZA_ACP_ADMISSION_QUEUE",
+    ]) {
+      saved[key] = process.env[key];
+    }
+    // Isolate admission from the completion verifier — a completed task moves to
+    // `validating` without spawning a verifier session that would consume a slot.
+    process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = "0";
+    process.env.ELIZA_ACP_ADMISSION_QUEUE = "1";
+  });
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("parks spawns beyond the worker cap: 2 active + 3 queued at cap=2", async () => {
+    const acp = new FakeAcp(2);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await service.start();
+
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) ids.push(await newTask(store, `t${i}`));
+
+    const details = [];
+    for (const id of ids) details.push(await service.spawnAgentForTask(id));
+
+    // First 2 spawned a live session (no admission); last 3 are queued.
+    const spawned = details.filter((d) => d && !d.admission);
+    const queued = details.filter((d) => d?.admission);
+    expect(spawned.length).toBe(2);
+    expect(queued.length).toBe(3);
+    expect((await acp.getCapacity()).activeWorkers).toBe(2);
+
+    // Queued positions are 1-based and dense.
+    const snapshot = await service.getAdmissionSnapshot();
+    expect(snapshot.queueDepth).toBe(3);
+    for (const d of queued) {
+      expect(d?.admission?.state).toBe("queued");
+      expect(d?.admission?.position).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("drains queued tasks on completion, in order, with zero drops", async () => {
+    const acp = new FakeAcp(2);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await service.start();
+
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) ids.push(await newTask(store, `t${i}`));
+    for (const id of ids) await service.spawnAgentForTask(id);
+
+    // 2 live sessions exist; complete them one at a time and assert each frees a
+    // slot that a queued task claims — until all 5 have run and the queue drains.
+    const live = acp.listSessions().filter((s) => s.status === "running");
+    expect(live.length).toBe(2);
+
+    const seen = new Set(live.map((s) => s.id));
+    while ((await service.getAdmissionSnapshot()).queueDepth > 0) {
+      const running = acp.listSessions().find((s) => s.status === "running");
+      expect(running).toBeDefined();
+      if (!running) break;
+      acp.complete(running.id);
+      // A new session id appears when a queued task is dispatched into the slot.
+      await waitUntil(() =>
+        acp
+          .listSessions()
+          .some((s) => s.status === "running" && !seen.has(s.id)),
+      );
+      for (const s of acp.listSessions()) seen.add(s.id);
+    }
+
+    // Every task ended up with exactly one session — no drops, no doubles.
+    expect(acp.listSessions().length).toBe(5);
+    expect((await service.getAdmissionSnapshot()).queueDepth).toBe(0);
+  });
+
+  it("reclaims an idle keepAlive session whose task is terminal to free a slot", async () => {
+    const acp = new FakeAcp(1);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await service.start();
+
+    // Task A takes the only worker slot; its ACP session is keepAlive (stays
+    // `running` at the transport even after the task finishes).
+    const a = await newTask(store, "a");
+    await service.spawnAgentForTask(a);
+    const liveSession = acp.listSessions()[0];
+    expect(liveSession?.status).toBe("running");
+
+    // Task A reaches a terminal status WITHOUT its ACP session ending — the
+    // keepAlive session now pins a slot with no live work. Mark it done directly
+    // in the store to model that.
+    await store.updateTask(a, { status: "done" });
+
+    // Task B queues behind the pinned slot, then a drain reclaims A's idle
+    // session and dispatches B.
+    const b = await newTask(store, "b");
+    const detail = await service.spawnAgentForTask(b);
+    expect(detail?.admission?.state).toBe("queued");
+
+    await waitUntil(async () => {
+      const cap = await service.getAdmissionSnapshot();
+      // A's session was stopped (reclaimed) and B dispatched into the freed slot.
+      return (
+        cap.queueDepth === 0 &&
+        acp.listSessions().some((s) => s.status === "running")
+      );
+    });
+    expect(
+      acp.listSessions().find((s) => s.id === liveSession?.id)?.status,
+    ).toBe("stopped");
+  });
+
+  it("spawns the read-only verifier at full worker cap via system headroom", async () => {
+    const acp = new FakeAcp(2, 2);
+    // Fill both worker slots directly.
+    await acp.spawnSession({ metadata: {}, slotClass: "worker" });
+    await acp.spawnSession({ metadata: {}, slotClass: "worker" });
+    expect((await acp.getCapacity()).freeWorkerSlots).toBe(0);
+
+    // A system spawn still succeeds (separate headroom).
+    const verifier = await acp.spawnSession({
+      metadata: { source: "independent-verifier" },
+      slotClass: "system",
+    });
+    expect(verifier.sessionId).toBeTruthy();
+    expect((await acp.getCapacity()).activeSystem).toBe(1);
+    // Worker cap is unaffected.
+    expect((await acp.getCapacity()).activeWorkers).toBe(2);
+  });
+
+  it("rebuilds the queue order from the store on restart", async () => {
+    const acp = new FakeAcp(1);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await service.start();
+
+    // cap=1: first spawns, the rest queue with mixed priorities.
+    const active = await newTask(store, "active", "normal");
+    await service.spawnAgentForTask(active);
+    const low = await newTask(store, "low", "low");
+    const urgent = await newTask(store, "urgent", "urgent");
+    const normal = await newTask(store, "normal", "normal");
+    for (const id of [low, urgent, normal]) {
+      await service.spawnAgentForTask(id);
+    }
+    expect((await service.getAdmissionSnapshot()).queueDepth).toBe(3);
+
+    // Simulate a restart: a fresh service over the SAME store rebuilds the order.
+    await service.stop();
+    const restarted = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await restarted.start();
+    const snapshot = await restarted.getAdmissionSnapshot();
+    expect(snapshot.queueDepth).toBe(3);
+    // Priority order: urgent first, then the two normals/low by band.
+    expect(snapshot.queuedTaskIds[0]).toBe(urgent);
+    expect(snapshot.queuedTaskIds[2]).toBe(low);
+    await restarted.stop();
+  });
+
+  it("throws AdmissionQueueFullError past the depth cap (→ 429 at the route)", async () => {
+    const acp = new FakeAcp(1);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await service.start();
+
+    // Depth cap of 2: 1 active + 2 queued fill it; the 4th park must reject.
+    process.env.ELIZA_ACP_ADMISSION_QUEUE_DEPTH = "2";
+    try {
+      const active = await newTask(store, "active");
+      const q1 = await newTask(store, "q1");
+      const q2 = await newTask(store, "q2");
+      const overflow = await newTask(store, "overflow");
+      // First spawns; next two queue; the fourth exceeds the depth cap.
+      await service.spawnAgentForTask(active);
+      await service.spawnAgentForTask(q1);
+      await service.spawnAgentForTask(q2);
+      await expect(service.spawnAgentForTask(overflow)).rejects.toMatchObject({
+        code: "ADMISSION_QUEUE_FULL",
+      });
+    } finally {
+      delete process.env.ELIZA_ACP_ADMISSION_QUEUE_DEPTH;
+    }
+  });
+
+  it("re-throws SessionCapError (hard-fail) when the queue is disabled", async () => {
+    process.env.ELIZA_ACP_ADMISSION_QUEUE = "0";
+    const acp = new FakeAcp(1);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await service.start();
+    const a = await newTask(store, "a");
+    const b = await newTask(store, "b");
+    await service.spawnAgentForTask(a);
+    await expect(service.spawnAgentForTask(b)).rejects.toMatchObject({
+      code: "SESSION_CAP_REACHED",
+    });
+  });
+
+  it("surfaces the capacity line + data.capacity through the provider", async () => {
+    const acp = new FakeAcp(2);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await service.start();
+    const runtime = makeRuntime(acp);
+    // The provider reads both services off the runtime.
+    (runtime as { getService: (t: string) => unknown }).getService = (
+      t: string,
+    ) => {
+      if (t === AcpService.serviceType) return acp;
+      if (t === OrchestratorTaskService.serviceType) return service;
+      return null;
+    };
+
+    const ids: string[] = [];
+    for (let i = 0; i < 4; i++) ids.push(await newTask(store, `t${i}`));
+    for (const id of ids) await service.spawnAgentForTask(id);
+
+    const result = await activeSubAgentsProvider.get(
+      runtime as never,
+      {} as never,
+      {} as never,
+    );
+    expect(result.text).toContain("capacity: 2/2 worker sessions; queued: 2");
+    const capacity = (result.data as { capacity?: Record<string, unknown> })
+      .capacity;
+    expect(capacity?.maxSessions).toBe(2);
+    expect(capacity?.activeWorkers).toBe(2);
+    expect(capacity?.queueDepth).toBe(2);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/admission-queue.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admission-queue.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Pure ordering coverage for the admission queue (#13772): priority bands, FIFO
+ * within a band, the taskId tiebreak, and the aging starvation guard. No store,
+ * no ACP transport, no clock — every function under test takes `now` explicitly,
+ * so these are deterministic against real inputs (not mocks of the thing under
+ * test — this IS the thing under test).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  effectiveBand,
+  orderQueue,
+  priorityBand,
+  type QueueEntry,
+} from "../services/admission-queue.ts";
+
+function entry(
+  taskId: string,
+  priority: QueueEntry["priorityAtEnqueue"],
+  enqueuedAtMs: number,
+): QueueEntry {
+  return {
+    taskId,
+    priorityAtEnqueue: priority,
+    enqueuedAt: new Date(enqueuedAtMs).toISOString(),
+  };
+}
+
+const AGING_MS = 600_000; // 10 min, the production default
+
+describe("admission-queue ordering (#13772)", () => {
+  describe("priority bands", () => {
+    it("ranks urgent > high > normal > low", () => {
+      expect(priorityBand("urgent")).toBeGreaterThan(priorityBand("high"));
+      expect(priorityBand("high")).toBeGreaterThan(priorityBand("normal"));
+      expect(priorityBand("normal")).toBeGreaterThan(priorityBand("low"));
+    });
+  });
+
+  describe("orderQueue", () => {
+    it("orders by band first, ignoring enqueue order", () => {
+      const now = 1_000_000;
+      const ordered = orderQueue(
+        [
+          entry("low-early", "low", now - 5_000),
+          entry("urgent-late", "urgent", now - 1_000),
+          entry("normal-mid", "normal", now - 3_000),
+        ],
+        now,
+        AGING_MS,
+      );
+      expect(ordered.map((e) => e.taskId)).toEqual([
+        "urgent-late",
+        "normal-mid",
+        "low-early",
+      ]);
+    });
+
+    it("is FIFO within a band (earlier enqueue wins)", () => {
+      const now = 1_000_000;
+      const ordered = orderQueue(
+        [
+          entry("b", "normal", now - 1_000),
+          entry("a", "normal", now - 3_000),
+          entry("c", "normal", now - 500),
+        ],
+        now,
+        AGING_MS,
+      );
+      expect(ordered.map((e) => e.taskId)).toEqual(["a", "b", "c"]);
+    });
+
+    it("breaks an exact tie deterministically by taskId", () => {
+      const now = 1_000_000;
+      const ordered = orderQueue(
+        [
+          entry("zzz", "normal", now - 1_000),
+          entry("aaa", "normal", now - 1_000),
+          entry("mmm", "normal", now - 1_000),
+        ],
+        now,
+        AGING_MS,
+      );
+      expect(ordered.map((e) => e.taskId)).toEqual(["aaa", "mmm", "zzz"]);
+    });
+
+    it("does not mutate the input array", () => {
+      const now = 1_000_000;
+      const input = [entry("b", "low", now), entry("a", "urgent", now)];
+      const snapshot = input.map((e) => e.taskId);
+      orderQueue(input, now, AGING_MS);
+      expect(input.map((e) => e.taskId)).toEqual(snapshot);
+    });
+  });
+
+  describe("aging starvation guard", () => {
+    it("promotes a low-priority task one band per aging interval", () => {
+      const enqueuedAt = 0;
+      // Fresh: base band 0.
+      expect(effectiveBand(entry("t", "low", enqueuedAt), 0, AGING_MS)).toBe(0);
+      // After one interval: +1.
+      expect(
+        effectiveBand(entry("t", "low", enqueuedAt), AGING_MS, AGING_MS),
+      ).toBe(1);
+      // After three intervals: +3 (now outranks a fresh urgent at band 3).
+      expect(
+        effectiveBand(entry("t", "low", enqueuedAt), 3 * AGING_MS, AGING_MS),
+      ).toBe(3);
+    });
+
+    it("lets an aged low task overtake a fresh higher-priority arrival", () => {
+      const now = 4 * AGING_MS;
+      const ordered = orderQueue(
+        [
+          // low, waited 4 intervals → effective band 0 + 4 = 4
+          entry("aged-low", "low", 0),
+          // high, just arrived → effective band 2
+          entry("fresh-high", "high", now - 100),
+        ],
+        now,
+        AGING_MS,
+      );
+      expect(ordered[0]?.taskId).toBe("aged-low");
+    });
+
+    it("disables aging when agingMs <= 0 (band stays fixed)", () => {
+      const entryLow = entry("t", "low", 0);
+      expect(effectiveBand(entryLow, 10 * 600_000, 0)).toBe(0);
+      expect(effectiveBand(entryLow, 10 * 600_000, -5)).toBe(0);
+    });
+  });
+
+  describe("rebuild ordering (restart resume)", () => {
+    it("reproduces the same order a fresh enqueue sequence would have", () => {
+      // Simulate: 5 tasks parked at increasing times with mixed priorities. A
+      // restart rebuilds from the store as an unordered set; orderQueue must
+      // recover the canonical dispatch order.
+      const t0 = 2_000_000;
+      const parked = [
+        entry("t3", "normal", t0 + 300),
+        entry("t1", "urgent", t0 + 100),
+        entry("t5", "low", t0 + 500),
+        entry("t2", "urgent", t0 + 200),
+        entry("t4", "high", t0 + 400),
+      ];
+      // now == t0 + 600, well under one aging interval, so bands are raw.
+      const ordered = orderQueue(parked, t0 + 600, AGING_MS);
+      expect(ordered.map((e) => e.taskId)).toEqual([
+        "t1", // urgent, earliest
+        "t2", // urgent, later
+        "t4", // high
+        "t3", // normal
+        "t5", // low
+      ]);
+    });
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
@@ -22,6 +22,7 @@ import { getTaskAgentFrameworkState } from "../services/task-agent-frameworks.js
 import {
   type AgentType,
   type ApprovalPreset,
+  SessionCapError,
   type SessionInfo,
   TERMINAL_SESSION_STATUSES,
 } from "../services/types.js";
@@ -676,7 +677,14 @@ export async function handleAgentRoutes(
         201,
       );
     } catch (error) {
-      // error-policy:J1 route boundary — spawn failure becomes a 500 response.
+      // error-policy:J1 route boundary — the direct-spawn path does not use the
+      // admission queue (it is a raw session spawn), so a full worker cap
+      // surfaces the typed SESSION_CAP_REACHED code at 429 for the caller to
+      // handle; any other spawn failure becomes a 500.
+      if (error instanceof SessionCapError) {
+        sendJson(res, { error: error.message, code: error.code }, 429);
+        return true;
+      }
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to spawn agent",

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -32,6 +32,7 @@ import type {
   OrchestratorTaskPriority,
   TaskProviderPolicy,
 } from "../services/orchestrator-task-types.js";
+import { AdmissionQueueFullError } from "../services/types.js";
 import type { RouteContext } from "./route-utils.js";
 import {
   asBoolean,
@@ -236,16 +237,10 @@ async function dispatchOrchestratorRoutes(
     return true;
   }
 
-  // GET /api/orchestrator/capacity — live session-cap back-pressure: worker and
-  // system slot usage so a client can see whether a spawn would be rejected at
-  // the cap before attempting it.
+  // GET /api/orchestrator/capacity — live worker/system slot accounting plus the
+  // ordered admission queue, for the dashboard's cap-pressure surface (#13772).
   if (method === "GET" && pathname === `${PREFIX}/capacity`) {
-    const acp = ctx.acpService;
-    if (!acp?.getCapacity) {
-      sendServiceUnavailable(res, "ACP service not available");
-      return true;
-    }
-    sendJson(res, await acp.getCapacity());
+    sendJson(res, await service.getCapacityOverview());
     return true;
   }
 
@@ -966,7 +961,14 @@ async function dispatchOrchestratorRoutes(
             task: asString(body.task),
           });
         } catch (error) {
-          // error-policy:J1 route boundary — spawn failure becomes a 500 response.
+          // error-policy:J1 route boundary — a full admission queue is
+          // back-pressure the caller must see (429); any other spawn failure
+          // becomes a 500. A plain SessionCapError should no longer reach here:
+          // spawnAgentForTask parks it in the queue instead of throwing.
+          if (error instanceof AdmissionQueueFullError) {
+            sendError(res, error.message, 429);
+            return true;
+          }
           sendError(
             res,
             error instanceof Error ? error.message : "Failed to spawn agent",
@@ -978,7 +980,9 @@ async function dispatchOrchestratorRoutes(
           sendError(res, "Task not found", 404);
           return true;
         }
-        sendJson(res, task, 201);
+        // 202 when the spawn was parked at the session cap (task carries the
+        // admission DTO with its queue position); 201 when a session spawned.
+        sendJson(res, task, task.admission ? 202 : 201);
         return true;
       }
       // POST /tasks/:taskId/agents/:sessionId/stop

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -15,9 +15,23 @@ import type {
 import { getAcpService } from "../actions/common.js";
 import { TASK_WATCHDOG_SERVICE_TYPE } from "../services/task-watchdog-service.js";
 import {
+  type AcpCapacity,
   type SessionInfo,
   TERMINAL_SESSION_STATUSES,
 } from "../services/types.js";
+
+/** Structural shape the provider needs from the orchestrator task service to
+ * surface the admission queue. Read by serviceType to avoid a hard import of
+ * OrchestratorTaskService (which would pull the whole service graph into the
+ * provider bundle). */
+interface AdmissionSnapshotService {
+  getAdmissionSnapshot?(): Promise<{
+    queueDepth: number;
+    queuedTaskIds: string[];
+  }>;
+}
+
+const ORCHESTRATOR_TASK_SERVICE_TYPE = "ORCHESTRATOR_TASK_SERVICE";
 
 type ApproachingCapKind = "round-trip" | "spend";
 
@@ -136,10 +150,17 @@ export const activeSubAgentsProvider: Provider = {
     // historical noise with current state and lets the planner LLM
     // generalize past failures as predictors for new spawns. If the user
     // asks about history, the planner must call TASKS_HISTORY explicitly.
+    // Cap pressure (worker capacity + admission queue depth) is planner-relevant
+    // even when zero ORIGIN-routed sessions are listed: non-routed workers can
+    // pin every slot while tasks wait. Read it up front so the empty-routed path
+    // can still surface it.
+    const capacity = await readCapacity(service);
+    const admission = await readAdmissionSnapshot(runtime);
+
     const routed = (Array.isArray(all) ? all : [])
       .filter(hasOrigin)
       .filter((s) => !TERMINAL_SESSION_STATUSES.has(s.status));
-    if (routed.length === 0) return emptyResult();
+    if (routed.length === 0) return emptyResult(capacity, admission);
 
     routed.sort((a, b) => a.id.localeCompare(b.id));
 
@@ -176,6 +197,8 @@ export const activeSubAgentsProvider: Provider = {
       "Each line is a live sub-agent. Reply to one with SEND_TO_AGENT { sessionId, text }; terminate with STOP_AGENT { sessionId }. Replying to the user uses the standard REPLY action; you may do both in one turn.",
       "The sub-agent's task_complete event is the ground truth for outcomes. For history about past sub-agents, call TASKS_HISTORY explicitly.",
     ];
+    const capacityLine = formatCapacityLine(capacity, admission);
+    if (capacityLine) lines.push(capacityLine);
     for (const session of routed) {
       lines.push(
         formatLine(
@@ -205,16 +228,88 @@ export const activeSubAgentsProvider: Provider = {
           originUserId: (s.metadata as Record<string, unknown> | undefined)
             ?.userId,
         })),
+        capacity: capacityData(capacity, admission),
       },
     };
   },
 };
 
-function emptyResult() {
+/** The cache-stable capacity payload: counts + queued taskIds only, NEVER
+ * timestamps, so this provider segment's prefix cache survives turn over turn.
+ * Null when capacity is unavailable (the ACP service lacks getCapacity). */
+function capacityData(
+  capacity: AcpCapacity | null,
+  admission: AdmissionSnapshot | null,
+): Record<string, unknown> | null {
+  if (!capacity) return null;
   return {
-    text: "",
-    values: { activeSubAgents: "" },
-    data: { sessions: [] },
+    maxSessions: capacity.maxSessions,
+    activeWorkers: capacity.activeWorkers,
+    queueDepth: admission?.queueDepth ?? 0,
+    queuedTaskIds: admission?.queuedTaskIds ?? [],
+  };
+}
+
+interface AdmissionSnapshot {
+  queueDepth: number;
+  queuedTaskIds: string[];
+}
+
+async function readCapacity(
+  service: { getCapacity?: () => Promise<AcpCapacity> },
+): Promise<AcpCapacity | null> {
+  if (typeof service.getCapacity !== "function") return null;
+  try {
+    return await service.getCapacity();
+  } catch {
+    // error-policy:J4 capacity is a supplementary planner header; an unavailable
+    // getter degrades to no capacity line, never a fabricated count.
+    return null;
+  }
+}
+
+async function readAdmissionSnapshot(
+  runtime: IAgentRuntime,
+): Promise<AdmissionSnapshot | null> {
+  const orchestrator = runtime.getService<Service & AdmissionSnapshotService>(
+    ORCHESTRATOR_TASK_SERVICE_TYPE,
+  );
+  if (!orchestrator || typeof orchestrator.getAdmissionSnapshot !== "function") {
+    return null;
+  }
+  try {
+    return await orchestrator.getAdmissionSnapshot();
+  } catch {
+    // error-policy:J4 the admission snapshot is a supplementary planner header;
+    // an unavailable getter degrades to no queue depth, never a fabricated one.
+    return null;
+  }
+}
+
+/** One-line worker-capacity + queue-depth summary for the planner, or empty
+ * when capacity is unavailable. Counts + a next-queued label only — no
+ * timestamps — to hold the provider's cache-stability contract. */
+function formatCapacityLine(
+  capacity: AcpCapacity | null,
+  admission: AdmissionSnapshot | null,
+): string {
+  if (!capacity) return "";
+  const depth = admission?.queueDepth ?? 0;
+  const base = `capacity: ${capacity.activeWorkers}/${capacity.maxSessions} worker sessions; queued: ${depth}`;
+  const nextTaskId = admission?.queuedTaskIds[0];
+  return nextTaskId ? `${base}; next queued: task ${nextTaskId}` : base;
+}
+
+function emptyResult(
+  capacity: AcpCapacity | null = null,
+  admission: AdmissionSnapshot | null = null,
+) {
+  const capacityLine = formatCapacityLine(capacity, admission);
+  const text = capacityLine ? `## Active sub-agent sessions\n${capacityLine}` : "";
+  return {
+    text,
+    values: { activeSubAgents: text },
+    data: { sessions: [], capacity: capacityData(capacity, admission) },
   };
 }
 

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -274,7 +274,10 @@ async function readAdmissionSnapshot(
   const orchestrator = runtime.getService<Service & AdmissionSnapshotService>(
     ORCHESTRATOR_TASK_SERVICE_TYPE,
   );
-  if (!orchestrator || typeof orchestrator.getAdmissionSnapshot !== "function") {
+  if (
+    !orchestrator ||
+    typeof orchestrator.getAdmissionSnapshot !== "function"
+  ) {
     return null;
   }
   try {
@@ -305,7 +308,9 @@ function emptyResult(
   admission: AdmissionSnapshot | null = null,
 ) {
   const capacityLine = formatCapacityLine(capacity, admission);
-  const text = capacityLine ? `## Active sub-agent sessions\n${capacityLine}` : "";
+  const text = capacityLine
+    ? `## Active sub-agent sessions\n${capacityLine}`
+    : "";
   return {
     text,
     values: { activeSubAgents: text },

--- a/plugins/plugin-agent-orchestrator/src/services/admission-queue.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/admission-queue.ts
@@ -1,0 +1,96 @@
+/**
+ * Priority-FIFO admission ordering for the orchestrator's session-cap queue.
+ *
+ * When a task spawn meets the ACP worker cap, `OrchestratorTaskService` parks it
+ * here instead of hard-failing: the task keeps `open` status and carries the
+ * `AdmissionRecord` below in `task.metadata.admission`. This module owns only
+ * the pure ordering math — band mapping, starvation-guard aging, and the depth
+ * cap — so the ordering is unit-testable in isolation from the store, the ACP
+ * transport, and wall-clock time (every function takes `now` explicitly).
+ *
+ * Ordering: priority bands (urgent > high > normal > low), FIFO within a band by
+ * enqueue time, taskId as the final deterministic tiebreak. A queued task's
+ * effective band is promoted one step per `agingMs` it has waited, so a
+ * low-priority task can never starve behind a steady stream of higher-priority
+ * arrivals (starvation guard #1).
+ */
+
+import type { OrchestratorTaskPriority } from "./orchestrator-task-types.js";
+
+/** Persisted on `task.metadata.admission` while a task waits for a worker slot.
+ * `spawnOpts` is the serializable subset of the original spawn request replayed
+ * verbatim when the task is dispatched, so the parked spawn is identical to the
+ * one the cap rejected. */
+export interface AdmissionRecord {
+  state: "queued";
+  enqueuedAt: string;
+  priorityAtEnqueue: OrchestratorTaskPriority;
+  spawnOpts: SerializableSpawnOpts;
+}
+
+/** The JSON-safe slice of SpawnAgentForTaskOptions the queue persists and
+ * replays. Excludes `nestingDepth` (a live-only recursion counter) — a parked
+ * top-level spawn always re-dispatches at depth 0. */
+export interface SerializableSpawnOpts {
+  framework?: string;
+  model?: string;
+  workdir?: string;
+  repo?: string;
+  label?: string;
+  task?: string;
+  approvalPreset?: string;
+  providerSource?: string;
+}
+
+const PRIORITY_BANDS: Record<OrchestratorTaskPriority, number> = {
+  urgent: 3,
+  high: 2,
+  normal: 1,
+  low: 0,
+};
+
+export function priorityBand(priority: OrchestratorTaskPriority): number {
+  return PRIORITY_BANDS[priority] ?? PRIORITY_BANDS.normal;
+}
+
+/** The band a queued entry competes in right now: its enqueue-time band plus one
+ * promotion step per whole `agingMs` it has waited. A non-positive `agingMs`
+ * disables aging (band stays fixed). */
+export function effectiveBand(
+  entry: QueueEntry,
+  now: number,
+  agingMs: number,
+): number {
+  const base = priorityBand(entry.priorityAtEnqueue);
+  if (agingMs <= 0) return base;
+  const waitMs = Math.max(0, now - Date.parse(entry.enqueuedAt));
+  return base + Math.floor(waitMs / agingMs);
+}
+
+/** The in-memory shape the queue orders. Mirrors the durable AdmissionRecord's
+ * ordering-relevant fields plus the taskId key. */
+export interface QueueEntry {
+  taskId: string;
+  enqueuedAt: string;
+  priorityAtEnqueue: OrchestratorTaskPriority;
+}
+
+/**
+ * Total order over parked entries at instant `now`: higher effective band first,
+ * then earlier enqueue time, then taskId. Returns a NEW sorted array (does not
+ * mutate the input) so callers can hold a stable snapshot for a drain pass.
+ */
+export function orderQueue(
+  entries: readonly QueueEntry[],
+  now: number,
+  agingMs: number,
+): QueueEntry[] {
+  return [...entries].sort((a, b) => {
+    const bandDelta =
+      effectiveBand(b, now, agingMs) - effectiveBand(a, now, agingMs);
+    if (bandDelta !== 0) return bandDelta;
+    const timeDelta = Date.parse(a.enqueuedAt) - Date.parse(b.enqueuedAt);
+    if (timeDelta !== 0) return timeDelta;
+    return a.taskId.localeCompare(b.taskId);
+  });
+}

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-mapper.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-mapper.ts
@@ -26,6 +26,16 @@ import type {
 } from "./orchestrator-task-types.js";
 import { TERMINAL_TASK_SESSION_STATUSES } from "./orchestrator-task-types.js";
 
+/** Admission-queue state surfaced on a task when it is parked at the session
+ * cap (#13772). `position` is 1-based and filled by the service from the live
+ * dispatch order; the mapper derives only `state` + `enqueuedAt` from durable
+ * metadata (it has no view of the in-memory order), leaving `position` at 0. */
+export interface TaskAdmissionDto {
+  state: "queued";
+  position: number;
+  enqueuedAt: string;
+}
+
 export interface TaskThreadDto {
   id: string;
   title: string;
@@ -55,6 +65,8 @@ export interface TaskThreadDto {
   updatedAt: string;
   closedAt: string | null;
   archivedAt: string | null;
+  /** Present only while the task is parked in the admission queue. */
+  admission?: TaskAdmissionDto;
 }
 
 export interface TaskSessionDto {
@@ -410,7 +422,29 @@ export function toTaskThread(doc: OrchestratorTaskDocument): TaskThreadDto {
     updatedAt: doc.task.updatedAt,
     closedAt: doc.task.closedAt ?? null,
     archivedAt: doc.task.archivedAt ?? null,
+    ...(deriveAdmission(doc) ? { admission: deriveAdmission(doc)! } : {}),
   };
+}
+
+/** Derive the admission DTO from a task's durable metadata. `position` stays 0
+ * here — only the service, which holds the live dispatch order, can fill it. */
+function deriveAdmission(
+  doc: OrchestratorTaskDocument,
+): TaskAdmissionDto | null {
+  const admission = doc.task.metadata?.admission;
+  if (
+    typeof admission === "object" &&
+    admission !== null &&
+    (admission as Record<string, unknown>).state === "queued" &&
+    typeof (admission as Record<string, unknown>).enqueuedAt === "string"
+  ) {
+    return {
+      state: "queued",
+      position: 0,
+      enqueuedAt: (admission as Record<string, unknown>).enqueuedAt as string,
+    };
+  }
+  return null;
 }
 
 export function toTaskThreadDetail(

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-mapper.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-mapper.ts
@@ -400,6 +400,7 @@ export function toTaskThread(doc: OrchestratorTaskDocument): TaskThreadDto {
   const activeSessionCount = doc.sessions.filter(
     (session) => !TERMINAL_TASK_SESSION_STATUSES.has(session.status),
   ).length;
+  const admission = deriveAdmission(doc);
   return {
     id: doc.task.id,
     title: doc.task.title,
@@ -422,7 +423,7 @@ export function toTaskThread(doc: OrchestratorTaskDocument): TaskThreadDto {
     updatedAt: doc.task.updatedAt,
     closedAt: doc.task.closedAt ?? null,
     archivedAt: doc.task.archivedAt ?? null,
-    ...(deriveAdmission(doc) ? { admission: deriveAdmission(doc)! } : {}),
+    ...(admission ? { admission } : {}),
   };
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -30,6 +30,12 @@ import {
   shouldRequireGoalContract,
 } from "./acceptance-criteria.js";
 import { AcpService } from "./acp-service.js";
+import {
+  type AdmissionRecord,
+  orderQueue,
+  type QueueEntry,
+  type SerializableSpawnOpts,
+} from "./admission-queue.js";
 import { assignAgentName } from "./agent-name-assignment.js";
 import {
   accountMetaFromSessionMetadata,
@@ -98,6 +104,7 @@ import {
   type OrchestratorRoomRoster,
   type OrchestratorRoomRosterOverview,
   type OrchestratorTaskDocument,
+  type OrchestratorTaskPriority,
   type OrchestratorTaskRecord,
   type OrchestratorTaskSession,
   type OrchestratorTaskStatus,
@@ -116,7 +123,13 @@ import {
   configureSpendLedger,
   createTaskStoreSpendLedger,
 } from "./spend-allowance.js";
-import type { ApprovalPreset } from "./types.js";
+import {
+  AdmissionQueueFullError,
+  type ApprovalPreset,
+  SessionCapError,
+  type SpawnResult,
+  TERMINAL_SESSION_STATUSES,
+} from "./types.js";
 import {
   ensureTaskWorkdir,
   resolveAllowedWorkdir,
@@ -190,6 +203,18 @@ const INDEPENDENT_ACP_VERIFIER_NAME = "independent-acp-verifier";
  *  before its await is abandoned (treated as inconclusive). Overridable via
  *  `ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY_TIMEOUT_MS`. */
 const DEFAULT_INDEPENDENT_VERIFY_TIMEOUT_MS = 600_000;
+
+/** Cadence of the admission-queue reconcile tick. Backstops the terminal-event
+ * drain for slots freed silently (a swept-stale session emits no event). */
+const ADMISSION_RECONCILE_INTERVAL_MS = 30_000;
+
+/** Session events after which a worker slot may have freed, so the admission
+ * queue should drain. Mirrors AcpService's terminal-status set. */
+const ADMISSION_DRAIN_EVENTS: ReadonlySet<string> = new Set([
+  "task_complete",
+  "stopped",
+  "error",
+]);
 
 function independentVerifyTimeoutMs(runtime: {
   getSetting?: (key: string) => unknown;
@@ -333,6 +358,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+/** Parse a positive-integer setting value, falling back to `fallback` when the
+ * value is absent, non-numeric, or ≤ 0. Used for the admission-queue tunables. */
+function parsePositiveIntSetting(
+  value: string | undefined,
+  fallback: number,
+): number {
+  const parsed = value === undefined ? Number.NaN : Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
 }
 
 function str(value: unknown): string | undefined {
@@ -625,6 +660,16 @@ export class OrchestratorTaskService extends Service {
   private readonly autoVerifyInFlight = new Set<string>();
   private unsubscribe: (() => void) | undefined;
   private started = false;
+  // Admission queue (#13772): taskIds parked because the worker cap was full.
+  // The durable truth is each task's `metadata.admission` record; this array is
+  // the in-memory dispatch order, rebuilt from the store on start(). Ordering is
+  // recomputed at drain time (priority band + aging), so insertion order here is
+  // not authoritative — membership is.
+  private readonly admissionQueue: string[] = [];
+  // Serializes drainAdmissionQueue so a terminal-event drain and the reconcile
+  // tick can't both dispatch the same parked task. A promise-chain mutex.
+  private admissionDrainLock = Promise.resolve();
+  private admissionReconcileTimer: NodeJS.Timeout | undefined;
 
   constructor(
     runtime: IAgentRuntime,
@@ -662,6 +707,26 @@ export class OrchestratorTaskService extends Service {
     // Persist self-spend durably so a configured ELIZA_AGENT_SPEND_CAP_USD
     // survives a restart instead of resetting to zero (#8924).
     configureSpendLedger(createTaskStoreSpendLedger(this.store));
+    // Resume any tasks parked before a restart, then arm the reconcile tick that
+    // drains the queue even when no terminal session event fires (a sweptStale
+    // session frees a slot silently). Best-effort: a store hiccup here must not
+    // block session-event binding below.
+    if (this.admissionQueueEnabled()) {
+      await this.rebuildAdmissionQueueFromStore().catch((err) => {
+        // error-policy:J7 admission-queue rebuild is a start-time convenience; a
+        // failure is reported (parked tasks won't auto-resume until a live
+        // enqueue re-seeds them) but must not abort service start.
+        this.runtime.reportError(
+          "OrchestratorTask.rebuildAdmissionQueue",
+          err,
+          {},
+        );
+      });
+      this.admissionReconcileTimer = setInterval(() => {
+        void this.drainAdmissionQueue();
+      }, ADMISSION_RECONCILE_INTERVAL_MS);
+      this.admissionReconcileTimer.unref?.();
+    }
     const acp = this.acp();
     if (acp) {
       this.subscribeToAcp(acp);
@@ -712,6 +777,10 @@ export class OrchestratorTaskService extends Service {
   async stop(): Promise<void> {
     this.unsubscribe?.();
     this.unsubscribe = undefined;
+    if (this.admissionReconcileTimer) {
+      clearInterval(this.admissionReconcileTimer);
+      this.admissionReconcileTimer = undefined;
+    }
     this.started = false;
   }
 
@@ -956,6 +1025,13 @@ export class OrchestratorTaskService extends Service {
       }
       default:
         break;
+    }
+    // A terminal session event frees (or may free) a worker slot. Kick the
+    // admission drain so a parked task dispatches the instant a slot opens,
+    // rather than waiting on the 30s reconcile tick. Fire-and-forget: the drain
+    // is serialized internally and never rejects into this write path.
+    if (ADMISSION_DRAIN_EVENTS.has(event) && this.admissionQueueEnabled()) {
+      void this.drainAdmissionQueue();
     }
   }
 
@@ -1681,6 +1757,9 @@ export class OrchestratorTaskService extends Service {
   async pauseTask(taskId: string): Promise<TaskThreadDetailDto | null> {
     const doc = await this.store.getTask(taskId);
     if (!doc) return null;
+    // A paused task must not dispatch — drop it from the in-memory order but
+    // KEEP its admission record so resume can replay the original spawn.
+    await this.dequeueAdmission(taskId, false);
     await this.stopActiveSessions(doc);
     await this.store.updateTask(taskId, { paused: true });
     return this.getTask(taskId);
@@ -1689,12 +1768,27 @@ export class OrchestratorTaskService extends Service {
   async resumeTask(taskId: string): Promise<TaskThreadDetailDto | null> {
     const updated = await this.store.updateTask(taskId, { paused: false });
     if (!updated) return null;
+    // If the task was parked when paused, re-seed the in-memory order from its
+    // retained admission record so it competes for a slot again. A resumed task
+    // that already ran (had a session) carries no admission record and is a
+    // no-op here.
+    const doc = await this.store.getTask(taskId);
+    const admission = doc && OrchestratorTaskService.admissionOf(doc.task);
+    if (
+      admission &&
+      this.admissionQueueEnabled() &&
+      !this.admissionQueue.includes(taskId)
+    ) {
+      this.admissionQueue.push(taskId);
+      void this.drainAdmissionQueue();
+    }
     return this.getTask(taskId);
   }
 
   async archiveTask(taskId: string): Promise<TaskThreadDetailDto | null> {
     const doc = await this.store.getTask(taskId);
     if (!doc) return null;
+    await this.dequeueAdmission(taskId);
     await this.stopActiveSessions(doc);
     await this.store.updateTask(taskId, {
       archived: true,
@@ -1723,6 +1817,7 @@ export class OrchestratorTaskService extends Service {
   async deleteTask(taskId: string): Promise<boolean> {
     const doc = await this.store.getTask(taskId);
     if (!doc) return false;
+    await this.dequeueAdmission(taskId);
     await this.stopActiveSessions(doc);
     for (const session of doc.sessions) {
       this.sessionTaskIndex.delete(session.sessionId);
@@ -2775,43 +2870,72 @@ export class OrchestratorTaskService extends Service {
       }
     }
 
-    const result = await acp.spawnSession({
-      // Coding-agent selection: explicit request → routing policy → the
-      // deployment's configured default (ELIZA_ACP_DEFAULT_AGENT /
-      // ELIZA_DEFAULT_AGENT_TYPE — e.g. "elizaos" for the eliza-code coding
-      // sub-agent) → opencode as the safe fallback. Honoring the configured
-      // default here keeps this spawn path consistent with acp-service's
-      // `defaultAgent`; previously this hardcoded "opencode" because elizaos had
-      // no ACP command, but elizaos is now a supported ACP agent via
-      // ELIZA_ELIZAOS_ACP_COMMAND, so a host that selects it (local or cloud
-      // image) gets eliza-code, while unconfigured hosts still get opencode.
-      agentType:
-        opts.framework ??
-        policy.preferredFramework ??
-        configuredDefaultAgentType(this.runtime) ??
-        "opencode",
-      workdir,
-      initialTask: goalPrompt,
-      model: opts.model ?? policy.model,
-      approvalPreset: opts.approvalPreset,
-      metadata: {
-        taskId,
-        roomId: doc.task.taskRoomId ?? doc.task.roomId,
-        label: agentName,
-        source: "orchestrator",
-        // Persist the bare goal (the same key the direct-API spawn stamps) so
-        // completion-time consumers that read the task text off session
-        // metadata — the built-apps registry's app-build gate, interruption
-        // relevance — see what this session is building.
-        goal: doc.task.goal,
-        // Orchestrator sessions outlive their first prompt so follow-ups and
-        // validation re-dispatch can reuse them.
-        keepAliveAfterComplete: true,
-        // Carried so a child this sub-agent spawns can compute its own depth
-        // (parent depth + 1) and the nesting guard above can enforce the cap.
-        nestingDepth,
-      },
-    });
+    const framework =
+      opts.framework ??
+      policy.preferredFramework ??
+      configuredDefaultAgentType(this.runtime) ??
+      "opencode";
+    let result: SpawnResult;
+    try {
+      result = await acp.spawnSession({
+        // Coding-agent selection: explicit request → routing policy → the
+        // deployment's configured default (ELIZA_ACP_DEFAULT_AGENT /
+        // ELIZA_DEFAULT_AGENT_TYPE — e.g. "elizaos" for the eliza-code coding
+        // sub-agent) → opencode as the safe fallback. Honoring the configured
+        // default here keeps this spawn path consistent with acp-service's
+        // `defaultAgent`; previously this hardcoded "opencode" because elizaos had
+        // no ACP command, but elizaos is now a supported ACP agent via
+        // ELIZA_ELIZAOS_ACP_COMMAND, so a host that selects it (local or cloud
+        // image) gets eliza-code, while unconfigured hosts still get opencode.
+        agentType: framework,
+        workdir,
+        initialTask: goalPrompt,
+        model: opts.model ?? policy.model,
+        approvalPreset: opts.approvalPreset,
+        metadata: {
+          taskId,
+          roomId: doc.task.taskRoomId ?? doc.task.roomId,
+          label: agentName,
+          source: "orchestrator",
+          // Persist the bare goal (the same key the direct-API spawn stamps) so
+          // completion-time consumers that read the task text off session
+          // metadata — the built-apps registry's app-build gate, interruption
+          // relevance — see what this session is building.
+          goal: doc.task.goal,
+          // Orchestrator sessions outlive their first prompt so follow-ups and
+          // validation re-dispatch can reuse them.
+          keepAliveAfterComplete: true,
+          // Carried so a child this sub-agent spawns can compute its own depth
+          // (parent depth + 1) and the nesting guard above can enforce the cap.
+          nestingDepth,
+        },
+      });
+    } catch (err) {
+      // The worker cap is full. A TOP-LEVEL spawn parks in the admission queue
+      // (task stays `open`, admission metadata persisted) and the caller gets a
+      // truthful detail with the queued position instead of a hard failure. A
+      // NESTED spawn (a running sub-agent spawning a child) must NOT park — its
+      // parent is blocked awaiting the child, so queuing would deadlock; it
+      // re-throws so the parent sees the cap and can back off.
+      if (
+        err instanceof SessionCapError &&
+        err.slotClass === "worker" &&
+        nestingDepth === 0 &&
+        this.admissionQueueEnabled()
+      ) {
+        return this.enqueueAdmission(taskId, doc.task.priority, {
+          framework: opts.framework,
+          model: opts.model ?? policy.model,
+          workdir: opts.workdir,
+          repo: opts.repo,
+          label: opts.label,
+          task: opts.task,
+          approvalPreset: opts.approvalPreset,
+          providerSource: opts.providerSource ?? policy.providerSource,
+        });
+      }
+      throw err;
+    }
 
     const account = accountMetaFromSessionMetadata(
       result.metadata as Record<string, unknown> | undefined,
@@ -3339,6 +3463,319 @@ export class OrchestratorTaskService extends Service {
           failures.length === 1 ? "" : "s"
         }`,
       );
+    }
+  }
+
+  // ---- admission queue (#13772) -----------------------------------------
+
+  /** The queue is on by default; `ELIZA_ACP_ADMISSION_QUEUE=0` disables it and
+   * restores hard-fail-at-cap for spawnAgentForTask (the SessionCapError is
+   * re-thrown). */
+  private admissionQueueEnabled(): boolean {
+    const raw = this.readSetting("ELIZA_ACP_ADMISSION_QUEUE");
+    return raw !== "0";
+  }
+
+  /** Max parked tasks. A cap-park beyond this depth is back-pressure the caller
+   * must see, not more queue (AdmissionQueueFullError → 429). */
+  private admissionQueueDepthCap(): number {
+    return parsePositiveIntSetting(
+      this.readSetting("ELIZA_ACP_ADMISSION_QUEUE_DEPTH"),
+      32,
+    );
+  }
+
+  /** Aging promotion interval: a queued entry gains one priority band per this
+   * many ms waited, so a low-priority task can't starve (guard #1). */
+  private admissionAgingMs(): number {
+    return parsePositiveIntSetting(
+      this.readSetting("ELIZA_ACP_QUEUE_AGING_MS"),
+      600_000,
+    );
+  }
+
+  private readSetting(key: string): string | undefined {
+    const raw = this.runtime.getSetting?.(key);
+    if (typeof raw === "string" && raw.length > 0) return raw;
+    const env = process.env[key];
+    return typeof env === "string" && env.length > 0 ? env : undefined;
+  }
+
+  /** Read the admission record off a task's metadata, or null if not queued. */
+  private static admissionOf(
+    task: OrchestratorTaskRecord,
+  ): AdmissionRecord | null {
+    const admission = task.metadata?.admission;
+    if (
+      isRecord(admission) &&
+      admission.state === "queued" &&
+      typeof admission.enqueuedAt === "string" &&
+      isRecord(admission.spawnOpts)
+    ) {
+      return admission as unknown as AdmissionRecord;
+    }
+    return null;
+  }
+
+  /** Persist (or clear) the admission record on a task's metadata. updateTask
+   * shallow-merges `task`, so we replace the whole metadata object to add/remove
+   * the single `admission` key without disturbing the rest. */
+  private async writeAdmission(
+    taskId: string,
+    admission: AdmissionRecord | null,
+  ): Promise<void> {
+    const doc = await this.store.getTask(taskId);
+    if (!doc) return;
+    const nextMeta = { ...doc.task.metadata };
+    if (admission) nextMeta.admission = admission;
+    else delete nextMeta.admission;
+    await this.store.updateTask(taskId, { metadata: nextMeta });
+  }
+
+  /**
+   * Park a task that met the worker cap. Persists the admission record, seeds
+   * the in-memory order, kicks a drain (a slot may have freed between the cap
+   * check and here), and returns the task detail carrying the queued position.
+   * Throws AdmissionQueueFullError when the queue is at its depth cap.
+   */
+  private async enqueueAdmission(
+    taskId: string,
+    priority: OrchestratorTaskPriority,
+    spawnOpts: SerializableSpawnOpts,
+  ): Promise<TaskThreadDetailDto | null> {
+    if (
+      !this.admissionQueue.includes(taskId) &&
+      this.admissionQueue.length >= this.admissionQueueDepthCap()
+    ) {
+      throw new AdmissionQueueFullError(this.admissionQueueDepthCap());
+    }
+    const admission: AdmissionRecord = {
+      state: "queued",
+      enqueuedAt: nowIso(),
+      priorityAtEnqueue: priority,
+      spawnOpts,
+    };
+    await this.writeAdmission(taskId, admission);
+    if (!this.admissionQueue.includes(taskId)) this.admissionQueue.push(taskId);
+    this.log("info", "task parked in admission queue", {
+      taskId,
+      priority,
+      depth: this.admissionQueue.length,
+    });
+    // A slot may have freed between the cap rejection and this write; try now.
+    void this.drainAdmissionQueue();
+    return this.getTask(taskId);
+  }
+
+  /**
+   * Remove a task from the in-memory dispatch order. Lifecycle transitions call
+   * this so a parked spawn stops competing for a slot.
+   *
+   * `clearMetadata` controls the durable record: archive/delete/cancel clear it
+   * (the parked spawn is moot); pause keeps it so resume can replay the ORIGINAL
+   * spawnOpts instead of re-admitting with an empty request.
+   */
+  private async dequeueAdmission(
+    taskId: string,
+    clearMetadata = true,
+  ): Promise<void> {
+    const idx = this.admissionQueue.indexOf(taskId);
+    if (idx >= 0) this.admissionQueue.splice(idx, 1);
+    if (!clearMetadata) return;
+    const doc = await this.store.getTask(taskId);
+    if (doc && OrchestratorTaskService.admissionOf(doc.task)) {
+      await this.writeAdmission(taskId, null);
+    }
+  }
+
+  /** Rebuild the in-memory dispatch order from the store on start() so a restart
+   * mid-queue resumes deterministically. Scans `open` tasks for a queued
+   * admission record and seeds `admissionQueue` in current priority order. */
+  private async rebuildAdmissionQueueFromStore(): Promise<void> {
+    const open = await this.store.listTasks({ status: "open" });
+    const entries: QueueEntry[] = [];
+    for (const task of open) {
+      const admission = OrchestratorTaskService.admissionOf(task);
+      if (!admission) continue;
+      entries.push({
+        taskId: task.id,
+        enqueuedAt: admission.enqueuedAt,
+        priorityAtEnqueue: admission.priorityAtEnqueue,
+      });
+    }
+    const ordered = orderQueue(entries, Date.now(), this.admissionAgingMs());
+    this.admissionQueue.length = 0;
+    for (const entry of ordered) this.admissionQueue.push(entry.taskId);
+    if (this.admissionQueue.length > 0) {
+      this.log("info", "rebuilt admission queue from store", {
+        depth: this.admissionQueue.length,
+      });
+    }
+  }
+
+  /** Snapshot for the provider + capacity route: current queue depth and the
+   * ordered taskIds. Counts/ids only — NO timestamps — so the provider segment
+   * stays cache-stable turn over turn. */
+  async getAdmissionSnapshot(): Promise<{
+    queueDepth: number;
+    queuedTaskIds: string[];
+  }> {
+    const entries: QueueEntry[] = [];
+    for (const taskId of this.admissionQueue) {
+      const doc = await this.store.getTask(taskId);
+      const admission = doc && OrchestratorTaskService.admissionOf(doc.task);
+      if (!admission) continue;
+      entries.push({
+        taskId,
+        enqueuedAt: admission.enqueuedAt,
+        priorityAtEnqueue: admission.priorityAtEnqueue,
+      });
+    }
+    const ordered = orderQueue(entries, Date.now(), this.admissionAgingMs());
+    return {
+      queueDepth: ordered.length,
+      queuedTaskIds: ordered.map((e) => e.taskId),
+    };
+  }
+
+  /**
+   * Dispatch parked tasks into freed worker slots, most-eligible first.
+   * Serialized via a promise-chain lock so a terminal-event drain and the
+   * reconcile tick never double-dispatch. For each free slot it re-reads the
+   * head task's live state (dropping terminal/paused entries — starvation guard
+   * #2 is covered by idle-reclaim below), clears the admission record, and
+   * replays the saved spawn. A fresh SessionCapError re-parks the head and stops
+   * the pass (another spawn raced us). When no slot is free but the queue is
+   * non-empty, one idle keepAlive session whose task is already terminal is
+   * reclaimed to unblock the queue.
+   */
+  private async drainAdmissionQueue(): Promise<void> {
+    const run = this.admissionDrainLock.then(() => this.drainOnce());
+    this.admissionDrainLock = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private async drainOnce(): Promise<void> {
+    const acp = this.acp();
+    if (!acp) return;
+    // Bound the pass by the current queue length so a task re-parked at the head
+    // (SessionCapError race) can't spin this loop.
+    let budget = this.admissionQueue.length;
+    while (budget-- > 0 && this.admissionQueue.length > 0) {
+      const capacity = await acp.getCapacity();
+      if (capacity.freeWorkerSlots <= 0) {
+        // No worker slot free. Reclaim one idle keepAlive session whose task has
+        // already reached a terminal state (its slot is dead weight) so the
+        // queue isn't starved by workers that finished but stayed alive.
+        const reclaimed = await this.reclaimIdleSession(acp);
+        if (!reclaimed) break;
+        continue;
+      }
+      const ordered = orderQueue(
+        await this.currentQueueEntries(),
+        Date.now(),
+        this.admissionAgingMs(),
+      );
+      const head = ordered[0];
+      if (!head) break;
+      // Drop the head from the in-memory order up front; a re-park below will
+      // re-add it. This keeps the loop from re-selecting the same head when the
+      // task turned out to be terminal/paused.
+      const idx = this.admissionQueue.indexOf(head.taskId);
+      if (idx >= 0) this.admissionQueue.splice(idx, 1);
+      const doc = await this.store.getTask(head.taskId);
+      const admission = doc && OrchestratorTaskService.admissionOf(doc.task);
+      if (!doc || !admission) continue;
+      if (TERMINAL_TASK_STATUSES.has(doc.task.status) || doc.task.paused) {
+        await this.writeAdmission(head.taskId, null);
+        continue;
+      }
+      await this.writeAdmission(head.taskId, null);
+      try {
+        await this.spawnAgentForTask(head.taskId, {
+          ...admission.spawnOpts,
+          approvalPreset: admission.spawnOpts
+            .approvalPreset as ApprovalPreset | undefined,
+        });
+      } catch (err) {
+        if (err instanceof SessionCapError) {
+          // A concurrent spawn took the slot. Re-park at the head and stop —
+          // the next terminal event or reconcile tick drains again.
+          await this.writeAdmission(head.taskId, admission);
+          if (!this.admissionQueue.includes(head.taskId)) {
+            this.admissionQueue.unshift(head.taskId);
+          }
+          break;
+        }
+        // error-policy:J7 the dispatch of a parked task failed for a non-cap
+        // reason (bad workdir, transport error). Report it so the agent/owner
+        // sees the parked task did not launch; do not silently drop or re-park
+        // forever (that would spin the reconcile tick).
+        this.runtime.reportError(
+          "OrchestratorTask.drainAdmissionQueue",
+          err,
+          { taskId: head.taskId },
+        );
+      }
+    }
+  }
+
+  /** The queue's entries with their live admission records, for ordering. */
+  private async currentQueueEntries(): Promise<QueueEntry[]> {
+    const entries: QueueEntry[] = [];
+    for (const taskId of this.admissionQueue) {
+      const doc = await this.store.getTask(taskId);
+      const admission = doc && OrchestratorTaskService.admissionOf(doc.task);
+      if (!admission) continue;
+      entries.push({
+        taskId,
+        enqueuedAt: admission.enqueuedAt,
+        priorityAtEnqueue: admission.priorityAtEnqueue,
+      });
+    }
+    return entries;
+  }
+
+  /**
+   * Free one worker slot for the queue by stopping the oldest live keepAlive
+   * session whose owning task has already reached a terminal state. Such a
+   * session is finished work holding a slot; reclaiming it is safe and unblocks
+   * queued tasks (starvation guard #2). Returns true when a session was stopped.
+   */
+  private async reclaimIdleSession(acp: AcpService): Promise<boolean> {
+    const sessions = await acp.listSessions();
+    const candidates: Array<{ id: string; createdAt: number }> = [];
+    for (const session of sessions) {
+      if (TERMINAL_SESSION_STATUSES.has(session.status)) continue;
+      const taskId = this.sessionTaskIndex.get(session.id);
+      if (!taskId) continue;
+      const doc = await this.store.getTask(taskId);
+      if (!doc || !TERMINAL_TASK_STATUSES.has(doc.task.status)) continue;
+      candidates.push({ id: session.id, createdAt: session.createdAt.getTime() });
+    }
+    if (candidates.length === 0) return false;
+    candidates.sort((a, b) => a.createdAt - b.createdAt);
+    const victim = candidates[0];
+    if (!victim) return false;
+    try {
+      await acp.stopSession(victim.id);
+      this.log("info", "reclaimed idle keepAlive session for queued task", {
+        sessionId: victim.id,
+      });
+      return true;
+    } catch (err) {
+      // error-policy:J7 idle-reclaim is a best-effort starvation guard; a failed
+      // stop is reported (so a wedged session is visible) but must not abort the
+      // drain — the reconcile tick retries.
+      this.runtime.reportError(
+        "OrchestratorTask.reclaimIdleSession",
+        err,
+        { sessionId: victim.id },
+      );
+      return false;
     }
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -1705,7 +1705,24 @@ export class OrchestratorTaskService extends Service {
 
   async getTask(taskId: string): Promise<TaskThreadDetailDto | null> {
     const doc = await this.store.getTask(taskId);
-    return doc ? toTaskThreadDetail(doc) : null;
+    if (!doc) return null;
+    return this.withAdmissionPosition(toTaskThreadDetail(doc));
+  }
+
+  /** Fill the DTO's `admission.position` from the live DISPATCH order (1-based,
+   * priority-band + aging applied), which the mapper cannot see. A parked task
+   * not currently in the in-memory queue keeps position 0. */
+  private async withAdmissionPosition<T extends TaskThreadDetailDto>(
+    detail: T,
+  ): Promise<T> {
+    if (!detail.admission) return detail;
+    const { queuedTaskIds } = await this.getAdmissionSnapshot();
+    const idx = queuedTaskIds.indexOf(detail.id);
+    detail.admission = {
+      ...detail.admission,
+      position: idx >= 0 ? idx + 1 : 0,
+    };
+    return detail;
   }
 
   /**
@@ -3611,6 +3628,55 @@ export class OrchestratorTaskService extends Service {
         depth: this.admissionQueue.length,
       });
     }
+  }
+
+  /**
+   * Full capacity + queue overview for `GET /api/orchestrator/capacity`: live
+   * worker/system slot accounting plus the ordered admission queue with each
+   * entry's 1-based position, priority, and enqueue time. Unlike the provider
+   * snapshot this route payload MAY carry timestamps — it is a live poll, not a
+   * cached planner segment.
+   */
+  async getCapacityOverview(): Promise<{
+    maxSessions: number;
+    activeWorkers: number;
+    activeSystem: number;
+    freeSlots: number;
+    queueDepth: number;
+    queue: Array<{
+      taskId: string;
+      position: number;
+      priority: OrchestratorTaskPriority;
+      enqueuedAt: string;
+    }>;
+  }> {
+    const acp = this.acp();
+    const capacity = acp
+      ? await acp.getCapacity()
+      : {
+          maxSessions: 0,
+          activeWorkers: 0,
+          activeSystem: 0,
+          freeWorkerSlots: 0,
+        };
+    const entries = orderQueue(
+      await this.currentQueueEntries(),
+      Date.now(),
+      this.admissionAgingMs(),
+    );
+    return {
+      maxSessions: capacity.maxSessions,
+      activeWorkers: capacity.activeWorkers,
+      activeSystem: capacity.activeSystem,
+      freeSlots: capacity.freeWorkerSlots,
+      queueDepth: entries.length,
+      queue: entries.map((entry, index) => ({
+        taskId: entry.taskId,
+        position: index + 1,
+        priority: entry.priorityAtEnqueue,
+        enqueuedAt: entry.enqueuedAt,
+      })),
+    };
   }
 
   /** Snapshot for the provider + capacity route: current queue depth and the

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -3763,8 +3763,9 @@ export class OrchestratorTaskService extends Service {
       try {
         await this.spawnAgentForTask(head.taskId, {
           ...admission.spawnOpts,
-          approvalPreset: admission.spawnOpts
-            .approvalPreset as ApprovalPreset | undefined,
+          approvalPreset: admission.spawnOpts.approvalPreset as
+            | ApprovalPreset
+            | undefined,
         });
       } catch (err) {
         if (err instanceof SessionCapError) {
@@ -3780,11 +3781,9 @@ export class OrchestratorTaskService extends Service {
         // reason (bad workdir, transport error). Report it so the agent/owner
         // sees the parked task did not launch; do not silently drop or re-park
         // forever (that would spin the reconcile tick).
-        this.runtime.reportError(
-          "OrchestratorTask.drainAdmissionQueue",
-          err,
-          { taskId: head.taskId },
-        );
+        this.runtime.reportError("OrchestratorTask.drainAdmissionQueue", err, {
+          taskId: head.taskId,
+        });
       }
     }
   }
@@ -3820,7 +3819,10 @@ export class OrchestratorTaskService extends Service {
       if (!taskId) continue;
       const doc = await this.store.getTask(taskId);
       if (!doc || !TERMINAL_TASK_STATUSES.has(doc.task.status)) continue;
-      candidates.push({ id: session.id, createdAt: session.createdAt.getTime() });
+      candidates.push({
+        id: session.id,
+        createdAt: session.createdAt.getTime(),
+      });
     }
     if (candidates.length === 0) return false;
     candidates.sort((a, b) => a.createdAt - b.createdAt);
@@ -3836,11 +3838,9 @@ export class OrchestratorTaskService extends Service {
       // error-policy:J7 idle-reclaim is a best-effort starvation guard; a failed
       // stop is reported (so a wedged session is visible) but must not abort the
       // drain — the reconcile tick retries.
-      this.runtime.reportError(
-        "OrchestratorTask.reclaimIdleSession",
-        err,
-        { sessionId: victim.id },
-      );
+      this.runtime.reportError("OrchestratorTask.reclaimIdleSession", err, {
+        sessionId: victim.id,
+      });
       return false;
     }
   }

--- a/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
@@ -57,6 +57,9 @@ export interface SupervisorTaskView {
   staleness?: string;
   /** The originating chat target; null tasks (no chat origin) are skipped. */
   origin: { roomId: string; source: string } | null;
+  /** True when the task is parked in the admission queue (waiting for a session
+   *  slot). Folded into the digest as a queued count, not a per-task line. */
+  queued?: boolean;
 }
 
 // Coarse staleness bands (minutes → label), highest first. Bucketed on purpose:
@@ -93,13 +96,17 @@ const PROGRESS_EXPECTED_STATUSES: ReadonlySet<OrchestratorTaskStatus> = new Set(
   ["active", "validating"],
 );
 
-/** Compose the digest body for one room's set of live tasks. Deterministic. */
+/** Compose the digest body for one room's set of live tasks. Deterministic.
+ * Queued (admission-parked) tasks are summarized as a count line, not per-task
+ * rows, so a backlog of waiting tasks doesn't flood the digest. */
 export function composeRoomDigest(views: SupervisorTaskView[]): string {
+  const active = views.filter((v) => !v.queued);
+  const queuedCount = views.filter((v) => v.queued).length;
   const header =
-    views.length === 1
+    active.length === 1
       ? "📡 Task update"
-      : `📡 Task update — ${views.length} active`;
-  const lines = views
+      : `📡 Task update — ${active.length} active`;
+  const lines = active
     .slice()
     .sort((a, b) => a.label.localeCompare(b.label))
     .map((v) => {
@@ -109,6 +116,9 @@ export function composeRoomDigest(views: SupervisorTaskView[]): string {
       const stale = v.staleness ? ` ${v.staleness}` : "";
       return `${statusEmoji(v.status)} ${v.label} — ${v.status}${sessions}${detail}${stale}`;
     });
+  if (queuedCount > 0) {
+    lines.push(`⏳ ${queuedCount} queued (waiting for a session slot)`);
+  }
   return [header, ...lines].join("\n");
 }
 
@@ -138,7 +148,9 @@ export async function runSupervisorTick(
     { source: string; views: SupervisorTaskView[] }
   >();
   for (const v of views) {
-    if (!v.origin || !LIVE_STATUSES.has(v.status)) continue;
+    // Queued tasks are `open` (not a LIVE_STATUS) but still belong in the digest
+    // as the queued-count line, so admit them past the status gate.
+    if (!v.origin || (!v.queued && !LIVE_STATUSES.has(v.status))) continue;
     const bucket = byRoom.get(v.origin.roomId) ?? {
       source: v.origin.source,
       views: [],
@@ -210,6 +222,7 @@ interface TaskServiceLike {
       activeSessionCount: number;
       latestSessionLabel: string | null;
       latestActivityAt: number | null;
+      admission?: { state: "queued" } | undefined;
     }>
   >;
   getTaskOriginTarget(
@@ -325,10 +338,14 @@ export class TaskSupervisorService extends Service {
     // calls this fire-and-forget) — noisy, and fatal under strict handling.
     try {
       const tasks = await taskSvc.listTasks({ includeArchived: false });
-      const live = tasks.filter((t) => LIVE_STATUSES.has(t.status));
+      // Live tasks drive per-task lines; admission-parked tasks (status `open`
+      // with an admission record) drive the queued-count line.
+      const surfaced = tasks.filter(
+        (t) => LIVE_STATUSES.has(t.status) || t.admission?.state === "queued",
+      );
       const now = Date.now();
       const views: SupervisorTaskView[] = await Promise.all(
-        live.map(async (t) => ({
+        surfaced.map(async (t) => ({
           id: t.id,
           label: t.title,
           status: t.status,
@@ -340,6 +357,7 @@ export class TaskSupervisorService extends Service {
             ? supervisorStalenessLabel(t.latestActivityAt, now)
             : undefined,
           origin: await taskSvc.getTaskOriginTarget(t.id),
+          queued: t.admission?.state === "queued",
         })),
       );
       const result = await runSupervisorTick(

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -64,6 +64,20 @@ export const TERMINAL_SESSION_STATUSES: ReadonlySet<string> = new Set([
   "cancelled",
 ]);
 
+/**
+ * Thrown by the orchestrator's admission queue when a cap-parked spawn would
+ * exceed `ELIZA_ACP_ADMISSION_QUEUE_DEPTH`. Distinct from `SessionCapError`: the
+ * cap is transient (a slot will free), but a full queue is back-pressure the
+ * caller must see (mapped to HTTP 429 at the route).
+ */
+export class AdmissionQueueFullError extends Error {
+  readonly code = "ADMISSION_QUEUE_FULL";
+  constructor(readonly depth: number) {
+    super(`orchestrator admission queue is full (${depth})`);
+    this.name = "AdmissionQueueFullError";
+  }
+}
+
 export type SessionEventCallback = (
   sessionId: string,
   event: SessionEventName,


### PR DESCRIPTION
## What

Implements #13772 admission control for orchestrator sub-agent spawns. This is the broader replacement for #13829: it keeps the queue decision, then adds durable task admission state, typed `SessionCapError`, worker/system slot classes, route/provider status surfaces, and integration coverage.

## Why

The old `AcpService` cap was a hard throw when `ELIZA_ACP_MAX_SESSIONS` was saturated. A swarm that wanted to fan out more work than the raw cap dropped spawns instead of backpressuring them. The new model lets worker spawns queue durably while preserving fail-closed behavior for exhausted capacity and reserving separate system/verifier headroom so validation cannot deadlock behind worker sessions.

## Changes

- Adds an admission queue service with priority ordering, FIFO tiebreaks, and aging so low-priority work cannot starve indefinitely.
- Adds typed worker/system capacity accounting and `SessionCapError` instead of string-matched generic errors.
- Threads admission/capacity state through task DTOs, API routes, providers, and supervisor surfaces.
- Adds integration and unit coverage for queue ordering, capacity slot classes, and admission behavior.

## Relationship to #13829

#13829 is the narrow acp-service-only queue slice. This PR supersedes it with the durable/task-aware implementation and should be the one to land for #13772.

## Evidence

See the focused admission queue, admission integration, and ACP capacity slot-class tests in this PR. Screenshots/video: N/A, no user-facing UI surface changed in this slice.