### PR TITLE
test: cover packaged desktop notification bridge

### DIFF
--- a/.github/issue-evidence/13696-packaged-notification-e2e.md
+++ b/.github/issue-evidence/13696-packaged-notification-e2e.md
@@ -1,0 +1,27 @@
+# Issue #13696 - Packaged notification E2E slice
+
+## Scope
+
+- Added native shell notification diagnostics in `DesktopManager` beside the real `Utils.showNotification` call.
+- Exposed loopback-only packaged test bridge support for hiding the main window without destroying it.
+- Added a packaged Electrobun regression that drives the renderer RPC notification bridge while the main window is hidden, then again for a focused urgent notification, and asserts the native shell recorded the exact payloads.
+
+## Verification
+
+- PASS: `bun run --cwd packages/app-core/platforms/electrobun test src/native/desktop-window.test.ts`
+  - Result: 1 file passed, 21 tests passed.
+- PASS: `bunx @biomejs/biome check packages/app-core/platforms/electrobun/src/native/desktop.ts packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts packages/app/test/electrobun-packaged/packaged-app-helpers.ts packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts`
+  - Result: 5 files checked, no fixes applied.
+- ENV-BLOCKED: `bun run --cwd packages/app test:desktop:packaged -- test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts -g "packaged desktop delivers renderer notifications"`
+  - Result: test loaded and ran, then failed at the existing harness gate: `Packaged launcher is required for packaged desktop regressions.`
+  - No packaged Electrobun launcher was present under `packages/app-core/platforms/electrobun/build`, `packages/app-core/platforms/electrobun/artifacts`, or `ELIZA_TEST_PACKAGED_LAUNCHER_PATH`.
+
+## Typecheck Notes
+
+- `bunx tsc --noEmit -p packages/app-core/platforms/electrobun/tsconfig.json --pretty false` was attempted and blocked by the sparse worktree dependency state. First failures include missing `electrobun/bun` and unrelated existing RPC handler/schema errors.
+- `bun run --cwd packages/app typecheck` was attempted and blocked by the sparse worktree dependency state. First failures include missing Capacitor, cloud UI, route, chart, and other app dependencies outside this slice.
+
+## Manual Review
+
+- Reviewed the native diagnostic path: each renderer/native notification still calls `Utils.showNotification`; diagnostics only append a capped recent-history payload for the test bridge.
+- Reviewed the packaged regression path: the hidden-window leg schedules `desktopShowNotification` from renderer JS, hides the main window via the bridge, then polls `/state` for the exact title/body/urgency/silent values. The focused leg restores/focuses the window and sends a critical notification through the same public renderer RPC bridge.

--- a/packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts
@@ -172,6 +172,18 @@ export async function startDesktopTestBridgeServer(): Promise<
         return;
       }
 
+      if (pathname === "/main-window/hide" && method === "POST") {
+        const desktop = getDesktopManager();
+        const shellState = await desktop.getShellDiagnosticsState();
+        if (!shellState.mainWindowPresent) {
+          json(res, 503, { error: "main window is not available" });
+          return;
+        }
+        await desktop.hideWindow();
+        json(res, 200, { ok: true });
+        return;
+      }
+
       if (pathname === "/main-window/focus" && method === "POST") {
         await getDesktopManager().focusWindow();
         json(res, 200, { ok: true });

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -728,6 +728,26 @@ describe("DesktopManager notifications", () => {
       subtitle: undefined,
       silent: true,
     });
+    await expect(manager.getShellDiagnosticsState()).resolves.toMatchObject({
+      notifications: {
+        recent: [
+          {
+            id: "notification_1",
+            title: "Build finished",
+            body: "Desktop build completed.",
+            urgency: "critical",
+            silent: false,
+          },
+          {
+            id: "notification_2",
+            title: "Quiet sync",
+            body: "Background sync completed.",
+            urgency: "low",
+            silent: true,
+          },
+        ],
+      },
+    });
   });
 
   it("documents closeNotification as an Electrobun no-op", async () => {

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -190,6 +190,16 @@ const MACOS_CGSESSION_PATH =
 const LINUX_IDLE_THRESHOLD_SECONDS = 60;
 const WINDOWS_IDLE_THRESHOLD_SECONDS = 60;
 const POWER_STATE_PROBE_TIMEOUT_MS = 1_500;
+const RECENT_NOTIFICATION_DIAGNOSTICS_LIMIT = 50;
+
+interface DesktopNotificationDiagnostic {
+  id: string;
+  title: string;
+  body?: string;
+  silent?: boolean;
+  urgency?: NotificationOptions["urgency"];
+  createdAt: string;
+}
 
 let activeDesktopManager: DesktopManager | null = null;
 let nativeContextMenuEventsInstalled = false;
@@ -329,6 +339,7 @@ export class DesktopManager {
   private trayPopoverBlurHideTimer: ReturnType<typeof setTimeout> | null = null;
   private shortcuts: Map<string, ShortcutOptions> = new Map();
   private notificationCounter = 0;
+  private recentNotificationDiagnostics: DesktopNotificationDiagnostic[] = [];
   private sendToWebview: SendToWebview | null = null;
   private _windowFocused = true;
   private _windowHidden = false;
@@ -429,6 +440,9 @@ export class DesktopManager {
       visible: boolean;
       lastAnchorBounds: Rect | null;
     };
+    notifications: {
+      recent: DesktopNotificationDiagnostic[];
+    };
   }> {
     return {
       trayPresent: Boolean(this.tray),
@@ -440,6 +454,9 @@ export class DesktopManager {
         accelerator: shortcut.accelerator,
       })),
       trayPopover: this.getTrayPopoverDiagnostics(),
+      notifications: {
+        recent: [...this.recentNotificationDiagnostics],
+      },
     };
   }
 
@@ -1465,6 +1482,26 @@ X-GNOME-Autostart-enabled=true
     options: NotificationOptions,
   ): Promise<{ id: string }> {
     const id = `notification_${++this.notificationCounter}`;
+    this.recentNotificationDiagnostics.push({
+      id,
+      title: options.title,
+      ...(typeof options.body === "string" ? { body: options.body } : {}),
+      ...(typeof options.silent === "boolean"
+        ? { silent: options.silent }
+        : {}),
+      ...(options.urgency ? { urgency: options.urgency } : {}),
+      createdAt: new Date().toISOString(),
+    });
+    if (
+      this.recentNotificationDiagnostics.length >
+      RECENT_NOTIFICATION_DIAGNOSTICS_LIMIT
+    ) {
+      this.recentNotificationDiagnostics.splice(
+        0,
+        this.recentNotificationDiagnostics.length -
+          RECENT_NOTIFICATION_DIAGNOSTICS_LIMIT,
+      );
+    }
 
     // Electrobun Utils.showNotification — fire-and-forget, no event callbacks
     Utils.showNotification({

--- a/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
@@ -9,6 +9,7 @@ import { expect, type TestInfo, test } from "@playwright/test";
 import { assertScreenshotNotBlank } from "../ui-smoke/helpers/screenshot-quality";
 import { type MockApiServer, startMockApiServer } from "./mock-api";
 import {
+  type DesktopTestBridgeState,
   PackagedDesktopHarness,
   resolvePackagedLauncher,
 } from "./packaged-app-helpers";
@@ -17,6 +18,9 @@ import { hasPackagedRendererBootstrapRequests } from "./windows-bootstrap";
 type EvalOk<T> = T & { ok: true };
 type EvalErr = { ok: false; error: string };
 type EvalResult<T> = EvalOk<T> | EvalErr;
+type ShellNotificationDiagnostic = NonNullable<
+  DesktopTestBridgeState["shell"]["notifications"]
+>["recent"][number];
 
 const SETTINGS_SELECTOR = '[data-testid="settings-shell"]';
 const PLUGINS_SELECTOR = '[data-testid="plugins-shell"]';
@@ -54,6 +58,15 @@ function getDesktopRpcExpression(): string {
     "window.__ELIZA_ELECTROBUN_RPC__",
     "window.__ELIZAOS_ELECTROBUN_RPC__",
   ].join(" ?? ");
+}
+
+function findShellNotification(
+  state: DesktopTestBridgeState,
+  title: string,
+): ShellNotificationDiagnostic | undefined {
+  return state.shell.notifications?.recent.find(
+    (notification) => notification.title === title,
+  );
 }
 
 function debugPackagedPhase(label: string): void {
@@ -1215,6 +1228,147 @@ test("packaged desktop shortcut bridge summons the main window", async ({
       "Expected shortcut bridge press to summon and focus the main window.",
       30_000,
     );
+  });
+});
+
+test("packaged desktop delivers renderer notifications while hidden and focused", async ({
+  browserName: _browserName,
+}) => {
+  void _browserName;
+  test.skip(
+    !isPackagedPlatform(),
+    "Packaged desktop regressions require a macOS, Windows, or Linux launcher.",
+  );
+
+  await withPackagedHarness(async ({ harness }) => {
+    const backgroundTitle = `Packaged hidden notification ${Date.now()}`;
+    const backgroundBody = "Hidden renderer notification reached native shell.";
+    const focusedTitle = `Packaged urgent notification ${Date.now()}`;
+    const focusedBody = "Focused urgent notification reached native shell.";
+
+    const scheduled = await harness.eval<
+      EvalResult<{ bridgePresent: boolean; scheduled: boolean }>
+    >(
+      `(() => {
+        try {
+          const rpc = ${getDesktopRpcExpression()};
+          const request = rpc?.request?.desktopShowNotification;
+          if (!request || !rpc?.request) {
+            return {
+              ok: false,
+              error: "Desktop notification RPC bridge is missing.",
+            };
+          }
+          window.__ELIZA_PACKAGED_NOTIFICATION_TEST__ = {
+            ...(window.__ELIZA_PACKAGED_NOTIFICATION_TEST__ ?? {}),
+            hiddenNotificationFired: false,
+          };
+          setTimeout(() => {
+            void request.call(rpc.request, {
+              title: ${JSON.stringify(backgroundTitle)},
+              body: ${JSON.stringify(backgroundBody)},
+              urgency: "normal",
+              silent: false,
+            }).then(
+              (result) => {
+                window.__ELIZA_PACKAGED_NOTIFICATION_TEST__ = {
+                  ...(window.__ELIZA_PACKAGED_NOTIFICATION_TEST__ ?? {}),
+                  hiddenNotificationFired: true,
+                  hiddenNotificationResult: result,
+                };
+              },
+              (error) => {
+                window.__ELIZA_PACKAGED_NOTIFICATION_TEST__ = {
+                  ...(window.__ELIZA_PACKAGED_NOTIFICATION_TEST__ ?? {}),
+                  hiddenNotificationFired: false,
+                  hiddenNotificationError:
+                    error instanceof Error ? error.message : String(error),
+                };
+              },
+            );
+          }, 400);
+          return { ok: true, bridgePresent: true, scheduled: true };
+        } catch (error) {
+          return {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      })()`,
+    );
+
+    expect(scheduled.ok, scheduled.ok ? undefined : scheduled.error).toBe(true);
+    await harness.hideMainWindow();
+
+    const hiddenState = await harness.waitForState(
+      (state) =>
+        state.shell.windowVisible === false &&
+        Boolean(findShellNotification(state, backgroundTitle)),
+      "Expected a hidden renderer notification to reach the native shell diagnostics.",
+      30_000,
+    );
+    expect(findShellNotification(hiddenState, backgroundTitle)).toMatchObject({
+      title: backgroundTitle,
+      body: backgroundBody,
+      urgency: "normal",
+      silent: false,
+    });
+
+    await harness.showMainWindow();
+    await harness.focusMainWindow();
+    await harness.waitForState(
+      (state) => state.shell.windowVisible === true,
+      "Expected the main window to be visible before focused urgent notification delivery.",
+      30_000,
+    );
+
+    const focusedResult = await harness.eval<EvalResult<{ id: string | null }>>(
+      `(async () => {
+        try {
+          const rpc = ${getDesktopRpcExpression()};
+          const request = rpc?.request?.desktopShowNotification;
+          if (!request || !rpc?.request) {
+            return {
+              ok: false,
+              error: "Desktop notification RPC bridge is missing.",
+            };
+          }
+          const result = await request.call(rpc.request, {
+            title: ${JSON.stringify(focusedTitle)},
+            body: ${JSON.stringify(focusedBody)},
+            urgency: "critical",
+            silent: false,
+          });
+          return {
+            ok: true,
+            id: typeof result?.id === "string" ? result.id : null,
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      })()`,
+    );
+
+    expect(
+      focusedResult.ok,
+      focusedResult.ok ? undefined : focusedResult.error,
+    ).toBe(true);
+    expect(focusedResult.ok ? focusedResult.id : null).toBeTruthy();
+
+    const focusedState = await harness.waitForState(
+      (state) => Boolean(findShellNotification(state, focusedTitle)),
+      "Expected a focused urgent renderer notification to reach native shell diagnostics.",
+      30_000,
+    );
+    expect(findShellNotification(focusedState, focusedTitle)).toMatchObject({
+      title: focusedTitle,
+      body: focusedBody,
+      urgency: "critical",
+      silent: false,
+    });
   });
 });
 

--- a/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
+++ b/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
@@ -66,6 +66,16 @@ export interface DesktopTestBridgeState {
         height: number;
       } | null;
     };
+    notifications?: {
+      recent: Array<{
+        id: string;
+        title: string;
+        body?: string;
+        silent?: boolean;
+        urgency?: "normal" | "critical" | "low";
+        createdAt: string;
+      }>;
+    };
   };
 }
 
@@ -852,6 +862,16 @@ export class PackagedDesktopHarness {
 
   async showMainWindow(): Promise<void> {
     await fetchJson<{ ok: boolean }>(`${this.bridgeUrl}/main-window/show`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.bridgeToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  async hideMainWindow(): Promise<void> {
+    await fetchJson<{ ok: boolean }>(`${this.bridgeUrl}/main-window/hide`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${this.bridgeToken}`,


### PR DESCRIPTION
## Summary
- add native shell notification diagnostics beside the real Electrobun `Utils.showNotification` call
- expose a loopback-only packaged test bridge `main-window/hide` route and harness helper
- add a packaged Electrobun regression for hidden-window and focused urgent renderer notification delivery

Fixes #13696.

## Evidence
- PASS: `bun run --cwd packages/app-core/platforms/electrobun test src/native/desktop-window.test.ts`
  - 1 file passed, 21 tests passed
- PASS: `bunx @biomejs/biome check packages/app-core/platforms/electrobun/src/native/desktop.ts packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts packages/app/test/electrobun-packaged/packaged-app-helpers.ts packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts`
  - 5 files checked, no fixes applied
- ENV-BLOCKED: `bun run --cwd packages/app test:desktop:packaged -- test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts -g "packaged desktop delivers renderer notifications"`
  - test loaded and ran, then failed at the existing harness gate because no packaged Electrobun launcher was present
- ENV-BLOCKED: package typechecks attempted; sparse worktree lacks full app/electrobun dependency graph. See `.github/issue-evidence/13696-packaged-notification-e2e.md`.

## Notes
The diagnostic history is capped and only reported through the existing shell diagnostics state used by the loopback-only test bridge. Notification delivery still goes through the real native `Utils.showNotification` call.
