### PR TITLE
feat(#13774): make parent-agent broker discoverable to default subagents

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/subagent-broker-discovery.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/subagent-broker-discovery.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Proves the parent-agent broker is DISCOVERABLE by default sub-agents (#13774):
+ * the operating manual advertises the broker to every profile, and the real
+ * `spawnAgentForTask` path writes a SKILLS.md for a non-economics spawn with a
+ * workdir — not only for economics tasks. Deterministic: real service + store +
+ * a capturing ACP over a real temp workdir; no live model, no subprocess.
+ */
+import { mkdtemp, readFile, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeGrillingRuntime } from "../../test/scenarios/_helpers/orchestrator-grilling-harness.ts";
+import {
+  makeSpawnCapturingAcp,
+  reflexionVerifierModel,
+  seedReflexionTask,
+} from "../../test/scenarios/_helpers/reflexion-scenario.ts";
+import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
+import { SUB_AGENT_IDENTITY_MD } from "../services/sub-agent-identity.js";
+
+function makeBaseRuntime(): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-4000-8000-000000000002",
+    character: { name: "Tester" },
+    databaseAdapter: undefined,
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+    getSetting: () => undefined,
+    getService: () => undefined,
+    useModel: async () => "{}",
+  } as never;
+}
+
+/**
+ * Drive the real durable-task spawn path with a real temp workdir and return the
+ * SKILLS.md content the service wrote (or null if none). `capabilityProfile`
+ * selects the fence; `undefined` is the default coding profile.
+ */
+async function spawnAndReadSkillsManifest(
+  capabilityProfile: "economics" | undefined,
+): Promise<string | null> {
+  const workdir = await realpath(
+    await mkdtemp(join(tmpdir(), "subagent-broker-")),
+  );
+  const savedWorkspaceDir = process.env.ELIZA_WORKSPACE_DIR;
+  // resolveAllowedWorkdir only permits the workspace base, cwd, or a configured
+  // root — point a configured root at the temp workdir so the spawn is allowed.
+  process.env.ELIZA_WORKSPACE_DIR = workdir;
+  try {
+    const { store, taskId } = await seedReflexionTask(["prove the tests pass"]);
+    if (capabilityProfile) {
+      await store.updateTask(taskId, { metadata: { capabilityProfile } });
+    }
+    const acp = makeSpawnCapturingAcp();
+    const service = new OrchestratorTaskService(
+      makeGrillingRuntime(
+        makeBaseRuntime(),
+        acp.service,
+        reflexionVerifierModel,
+      ),
+      { store },
+    );
+    await service.start();
+    try {
+      await service.spawnAgentForTask(taskId, { workdir });
+    } finally {
+      await service.stop().catch(() => undefined);
+    }
+    return await readFile(join(workdir, "SKILLS.md"), "utf8").catch(() => null);
+  } finally {
+    if (savedWorkspaceDir === undefined) delete process.env.ELIZA_WORKSPACE_DIR;
+    else process.env.ELIZA_WORKSPACE_DIR = savedWorkspaceDir;
+    await rm(workdir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+describe("sub-agent broker discovery (#13774)", () => {
+  let savedVerifyFlag: string | undefined;
+  beforeEach(() => {
+    savedVerifyFlag = process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+    delete process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+  });
+  afterEach(() => {
+    if (savedVerifyFlag === undefined)
+      delete process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+    else process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = savedVerifyFlag;
+  });
+
+  it("advertises the parent-agent broker + Cloud surface in the operating manual for every profile", () => {
+    // The manual is profile-independent — it is scaffolded into every bare spawn
+    // workspace, so a default (non-economics) coding sub-agent sees the broker.
+    expect(SUB_AGENT_IDENTITY_MD).toContain(
+      "Asking the parent agent to act (parent-agent broker)",
+    );
+    expect(SUB_AGENT_IDENTITY_MD).toContain("USE_SKILL parent-agent <json>");
+    // The bridge is stated as live for every session, not economics-only.
+    expect(SUB_AGENT_IDENTITY_MD).toContain("live for");
+    expect(SUB_AGENT_IDENTITY_MD).toContain("EVERY spawned session");
+    // The Cloud command surface is enumerated so the manual is self-sufficient.
+    expect(SUB_AGENT_IDENTITY_MD).toContain("list-cloud-commands");
+    expect(SUB_AGENT_IDENTITY_MD).toContain("cloud-command");
+    expect(SUB_AGENT_IDENTITY_MD).toContain("apps.create");
+    expect(SUB_AGENT_IDENTITY_MD).toContain("domains.buy");
+    // Human-confirmation contract for paid/mutating commands is preserved.
+    expect(SUB_AGENT_IDENTITY_MD).toContain("explicit human");
+  });
+
+  it("writes a SKILLS.md advertising the broker for a non-economics spawn with a workdir", async () => {
+    const manifest = await spawnAndReadSkillsManifest(undefined);
+    expect(manifest).not.toBeNull();
+    const md = manifest as string;
+    expect(md).toContain("Parent Eliza Agent");
+    expect(md).toContain("USE_SKILL parent-agent");
+    expect(md).toContain("Task-scoped broker skills");
+    // The ViewKind contract is economics-only and must NOT leak into the generic
+    // (default coding) manifest.
+    expect(md).not.toContain("View kind");
+  });
+
+  it("economics spawn still gets the ViewKind contract (no regression)", async () => {
+    const manifest = await spawnAndReadSkillsManifest("economics");
+    expect(manifest).not.toBeNull();
+    const md = manifest as string;
+    expect(md).toContain("Parent Eliza Agent");
+    expect(md).toContain("USE_SKILL parent-agent");
+    expect(md).toContain("View kind");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -110,7 +110,10 @@ import {
   TERMINAL_TASK_STATUSES,
   type UsageState,
 } from "./orchestrator-task-types.js";
-import { PARENT_AGENT_BROKER_MANIFEST_ENTRY } from "./parent-agent-broker.js";
+import {
+  PARENT_AGENT_BROKER_MANIFEST_ENTRY,
+  PARENT_AGENT_BROKER_SLUG,
+} from "./parent-agent-broker.js";
 import { buildSkillsManifest } from "./skill-manifest.js";
 import {
   configureSpendLedger,
@@ -2751,18 +2754,24 @@ export class OrchestratorTaskService extends Service {
       ...(capabilityProfile ? { capabilityProfile } : {}),
     });
 
-    // Economics tasks drive the monetized-app loop through the parent-agent
-    // Cloud command broker. Write a SKILLS.md into the workdir that advertises
-    // the broker slug + its arg contract so the spawned agent knows how to call
-    // back (the dispatcher in SubAgentRouter executes those requests).
-    if (capabilityProfile === "economics" && workdir) {
+    // The parent-agent broker is live for EVERY spawned session (SubAgentRouter
+    // intercepts `USE_SKILL parent-agent` regardless of capability profile), so
+    // every workdir spawn — not only economics tasks — gets a SKILLS.md that
+    // advertises the broker slug + its arg contract and the parent's installed
+    // skills, so the spawned agent knows how to call back. Economics tasks
+    // additionally pin the monetized-app skills and the ViewKind contract for
+    // the Cloud build→deploy→monetize loop.
+    if (workdir) {
+      const isEconomics = capabilityProfile === "economics";
       try {
         const manifest = await buildSkillsManifest(this.runtime, {
-          recommendedSlugs: ["build-monetized-app", "eliza-cloud"],
+          recommendedSlugs: isEconomics
+            ? ["build-monetized-app", "eliza-cloud"]
+            : [PARENT_AGENT_BROKER_SLUG],
           virtualSkills: [{ ...PARENT_AGENT_BROKER_MANIFEST_ENTRY }],
-          // Economics tasks may deploy Cloud views — teach the sub-agent the
-          // ViewKind contract so views are categorized correctly. (#8917)
-          includeViewKindContract: true,
+          // Only economics tasks deploy Cloud views — the ViewKind contract
+          // (#8917) stays off the generic manifest.
+          includeViewKindContract: isEconomics,
         });
         await writeFile(join(workdir, "SKILLS.md"), manifest.markdown, "utf8");
       } catch (err) {

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-dispatch.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-dispatch.ts
@@ -2,18 +2,19 @@
  * Child → parent `USE_SKILL parent-agent` dispatcher.
  *
  * A spawned coding agent (driven over ACP) cannot run account-bound Eliza Cloud
- * commands itself. The `build-monetized-app` skill and the SKILLS.md written for
- * economics tasks tell it to emit `USE_SKILL parent-agent <json>` in its output
- * instead. This module is the production caller the economics runbook
- * (`docs/economics-goal-runbook.md`) identified as missing: it detects that
- * directive in the child's streamed text, bridges it to `runParentAgentBroker`,
- * and sends the broker's reply back into the child session so the loop
- * continues (read cloud commands, self-authorize spend within the cap, etc.).
+ * commands or the parent's loaded actions itself. The sub-agent operating manual
+ * (`sub-agent-identity.ts`), the `build-monetized-app` skill, and the SKILLS.md
+ * scaffolded into a spawn's workdir all tell it to emit
+ * `USE_SKILL parent-agent <json>` in its output instead. This module is the
+ * production caller the economics runbook (`docs/economics-goal-runbook.md`)
+ * identified as missing: it detects that directive in the child's streamed text,
+ * bridges it to `runParentAgentBroker`, and sends the broker's reply back into
+ * the child session so the loop continues (read cloud commands, self-authorize
+ * spend within the cap, etc.).
  *
  * The detection is intentionally narrow — it only acts on text containing the
- * literal `USE_SKILL parent-agent` marker, which ordinary coding tasks never
- * emit, so wiring it into the session-event hot path is inert for every other
- * flow.
+ * literal `USE_SKILL parent-agent` marker, so wiring it into the session-event
+ * hot path stays inert for any session whose agent never emits it.
  *
  * @module services/parent-agent-dispatch
  */

--- a/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
@@ -9,8 +9,12 @@
  *     match already scores ≥ 0.9 (no need to spend a model call) or when the
  *     runtime model is unavailable.
  *
- * The output is task-aware ranking: the orchestrator can then write the top
- * N into SKILLS.md and reference them in the spawned agent's initial prompt.
+ * The output is a task-aware ranking. It is a ranking service only: producing
+ * the list does not itself write anything. The durable-task spawn path
+ * (`OrchestratorTaskService.spawnAgentForTask`) is the caller that turns a
+ * ranking into a SKILLS.md via `buildSkillsManifest`, and only when the spawn
+ * has a workdir. Direct `/api/coding-agents/*` and `TASKS_SPAWN_AGENT` spawns do
+ * not yet consume this ranking.
  *
  * @module services/skill-recommender
  */

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
@@ -23,7 +23,11 @@ const IDENTITY_FILENAMES = ["AGENTS.md", "CLAUDE.md"] as const;
  * chase a possibly-stale skill file to know it is non-interactive. Bridge facts
  * are stated accurately: `memory` is global semantic search (not the originating
  * room's recent messages), `parent-context` does not expose the original task,
- * and the endpoints only work when `PARALLAX_SESSION_ID` is wired.
+ * and the read-only/credential endpoints only work when `PARALLAX_SESSION_ID` is
+ * wired. The parent-agent broker (`USE_SKILL parent-agent <json>`) is documented
+ * for every profile because `SubAgentRouter` intercepts that directive on every
+ * session, not only economics tasks — the manual is the one place a default
+ * coding spawn learns the bridge exists.
  */
 export const SUB_AGENT_IDENTITY_MD = `# Eliza coding sub-agent — operating manual
 
@@ -76,6 +80,45 @@ state, but only when the bridge is wired (env var \`PARALLAX_SESSION_ID\` set):
 - \`.../memory?q=<query>&limit=<N>\` → GLOBAL semantic search over the parent's
   memory (facts, messages, knowledge) — not the originating room's recency.
 - \`.../active-workspaces\` → sibling sub-agents.
+
+## Asking the parent agent to act (parent-agent broker)
+
+The parent Eliza agent runs with its own loaded capabilities — actions,
+providers, connectors, a human-confirmation flow, and Eliza Cloud commands. When
+your workspace context is not enough and the task needs one of those, ask the
+parent to do it by emitting a single line of the form:
+
+    USE_SKILL parent-agent <json>
+
+The orchestrator intercepts that line in your output, runs the request against
+the running parent, and streams the reply back to you. This bridge is live for
+EVERY spawned session — not just app-building tasks — so an ordinary coding task
+that needs, say, a calendar lookup or a repo's connector can use it too. The
+\`mode\` field selects the operation (default \`ask\`):
+
+- \`{"request":"Find the next free 30-minute slot on my calendar"}\` — free-form
+  request the parent fulfils with its own actions/providers.
+- \`{"mode":"list-actions","query":"github"}\` — enumerate the parent's loaded
+  actions (optional \`query\` filter).
+- \`{"mode":"list-cloud-commands"}\` — list the Eliza Cloud commands the parent
+  can run.
+- \`{"mode":"cloud-command","command":"apps.list"}\` — run ONE Cloud command.
+  Available surfaces include apps (\`apps.create\`, \`apps.update\`,
+  \`apps.monetization.update\`, \`apps.charges.*\`), container deploys
+  (\`containers.create\`, \`containers.quota\`), domains (\`domains.search\`,
+  \`domains.check\`, \`domains.buy\`, \`domains.attach\`), payments
+  (\`x402.requests.*\`), and balances (\`credits.*\`, \`redemptions.*\`).
+- \`{"mode":"spawn-sub-agent","task":"<instruction>","label":"<optional>"}\` —
+  delegate part of your work to a new parallel child on this same task (bounded
+  nesting depth); keep working, do not block waiting on it.
+
+Mutating, paid, or destructive Cloud commands require an explicit human "yes" on
+a follow-up turn — you cannot self-approve them. Read-only commands and
+fixed-cost self-spend commands (e.g. \`containers.create\`) may run within the
+parent's configured spend cap; variable-cost ones (e.g. \`domains.buy\`) always
+need human confirmation. If a \`SKILLS.md\` was scaffolded into your workspace it
+lists the parent's installed skills and this broker, but you do not need it to
+use the broker.
 
 ## Requesting a missing credential
 


### PR DESCRIPTION
## Recovers #13817 (issue #13774, epic #13766)

Both competing PRs for this fix — #13817 (mine) and #13812 (fleet) — were closed unmerged in a dedup collision. **Nothing landed on develop.** Verified before recovery: `develop` still had the old `capabilityProfile === "economics" && workdir` guard at `orchestrator-task-service.ts:2758` and no broker section in `sub-agent-identity.ts`.

### Defect

The parent-agent broker (`USE_SKILL parent-agent`) is live for **every** spawned sub-agent session regardless of capability profile, but:

1. `sub-agent-identity.ts`'s profile-independent operating manual never mentioned it — only economics-profile docs did.
2. `orchestrator-task-service.ts`'s `SKILLS.md` manifest write was gated on `capabilityProfile === "economics" && workdir`, so non-economics spawns never got a manifest advertising the broker slug + arg contract at all.

### Fix

- `sub-agent-identity.ts` — added a factual "Asking the parent agent to act (parent-agent broker)" section to the profile-independent operating manual, so every spawned sub-agent (not just economics tasks) knows how to call back to the parent.
- `orchestrator-task-service.ts` — extended the `buildSkillsManifest` guard from `economics && workdir` to just `workdir`. Economics tasks still additionally pin `build-monetized-app`/`eliza-cloud` skills and the `ViewKind` contract; generic spawns get the broker-only manifest.
- `skill-recommender.ts` + `parent-agent-dispatch.ts` — corrected doc comments that overstated existing behavior.
- `__tests__/subagent-broker-discovery.test.ts` — new regression test driving `spawnAgentForTask` over a real temp workdir, asserting the manifest is written and mentions the broker for a non-economics spawn.

### Verification

- Rebased cleanly onto current `origin/develop` (`cde525e766`) — no conflicts.
- `bunx vitest run --config plugins/plugin-agent-orchestrator/vitest.config.ts plugins/plugin-agent-orchestrator/src/__tests__/subagent-broker-discovery.test.ts` → 3/3 passed.
- Also re-ran `skill-recommender.test.ts`, `parent-agent-broker.test.ts`, `parent-agent-broker-spawn.test.ts`, `skill-manifest.test.ts`, `reflexion-respawn.test.ts`, `task-workdir-binding.test.ts`, `built-apps-registry.test.ts` → 51/51 passed.
- `bun run typecheck` in the package shows only pre-existing, unrelated missing-`.d.ts` errors for third-party deps (drizzle-orm, yaml, git-workspace-service, etc.) from the shared build environment — zero errors in any file this PR touches.