### PR TITLE
feat(#13777): multitask-bench — one agent handling N interleaved LifeOps tasks (package + registry)

### DIFF
--- a/.github/issue-evidence/13777-multitask-perfect-N1-5-10.json
+++ b/.github/issue-evidence/13777-multitask-perfect-N1-5-10.json
@@ -1,0 +1,442 @@
+{
+  "benchmark": "multitask_bench",
+  "harness": "perfect",
+  "isolation": "shared_runtime",
+  "model": "gemma-4-31b",
+  "sample": {
+    "scenario_ids": [
+      "calendar.check_availability_thursday_morning",
+      "mail.archive_specific_newsletter_thread",
+      "reminders.create_pickup_reminder_tomorrow_9am",
+      "health.step_count_today",
+      "messages.send_imessage_to_hannah",
+      "contacts.add_new_freelance_collaborator",
+      "finance.spending_summary_last_week",
+      "focus.block_distracting_apps_25min",
+      "sleep.set_bedtime_reminder_1030pm_daily",
+      "travel.search_flights_sfo_jfk_next_friday"
+    ],
+    "size": 10
+  },
+  "lanes": [
+    {
+      "n": 1,
+      "arrival": "batch",
+      "waves": 10,
+      "tasks_total": 10,
+      "tasks_completed": 10,
+      "completion_rate": 1.0,
+      "mean_task_score": 1.0,
+      "throughput_tasks_per_min": 110.33317962848002,
+      "wall_clock_s": 5.438074041012442,
+      "turn_latency_ms": {
+        "p50": 0.0,
+        "p95": 0.0,
+        "max": 0.0
+      },
+      "task_wall_s": {
+        "p50": 0.4624831250112038,
+        "p95": 1.0637399170082062,
+        "max": 1.0637399170082062
+      },
+      "cost_usd": {
+        "total": 0.0,
+        "per_completed_task": 0.0
+      },
+      "tokens": {
+        "prompt": 0,
+        "completion": 0
+      },
+      "starved_tasks": 0,
+      "starvation_rate": 0.0,
+      "fairness_turns_jain": 1.0,
+      "lifecycle_events": {
+        "send": 1,
+        "spawn": 2
+      },
+      "per_task": [
+        {
+          "scenario_id": "calendar.check_availability_thursday_morning",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 1.0637399170082062
+        },
+        {
+          "scenario_id": "mail.archive_specific_newsletter_thread",
+          "seed": 2026,
+          "wave_index": 1,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4624831250112038
+        },
+        {
+          "scenario_id": "reminders.create_pickup_reminder_tomorrow_9am",
+          "seed": 2026,
+          "wave_index": 2,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4540162089979276
+        },
+        {
+          "scenario_id": "health.step_count_today",
+          "seed": 2026,
+          "wave_index": 3,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4151680830109399
+        },
+        {
+          "scenario_id": "messages.send_imessage_to_hannah",
+          "seed": 2026,
+          "wave_index": 4,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.7217714590078685
+        },
+        {
+          "scenario_id": "contacts.add_new_freelance_collaborator",
+          "seed": 2026,
+          "wave_index": 5,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.5095503749907948
+        },
+        {
+          "scenario_id": "finance.spending_summary_last_week",
+          "seed": 2026,
+          "wave_index": 6,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4184722080244683
+        },
+        {
+          "scenario_id": "focus.block_distracting_apps_25min",
+          "seed": 2026,
+          "wave_index": 7,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4869315839896444
+        },
+        {
+          "scenario_id": "sleep.set_bedtime_reminder_1030pm_daily",
+          "seed": 2026,
+          "wave_index": 8,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4626914160035085
+        },
+        {
+          "scenario_id": "travel.search_flights_sfo_jfk_next_friday",
+          "seed": 2026,
+          "wave_index": 9,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4324845000228379
+        }
+      ]
+    },
+    {
+      "n": 5,
+      "arrival": "batch",
+      "waves": 2,
+      "tasks_total": 10,
+      "tasks_completed": 10,
+      "completion_rate": 1.0,
+      "mean_task_score": 1.0,
+      "throughput_tasks_per_min": 107.43448421323443,
+      "wall_clock_s": 5.584799000003841,
+      "turn_latency_ms": {
+        "p50": 0.0,
+        "p95": 0.0,
+        "max": 0.0
+      },
+      "task_wall_s": {
+        "p50": 0.47269774999585934,
+        "p95": 1.0446351249993313,
+        "max": 1.0446351249993313
+      },
+      "cost_usd": {
+        "total": 0.0,
+        "per_completed_task": 0.0
+      },
+      "tokens": {
+        "prompt": 0,
+        "completion": 0
+      },
+      "starved_tasks": 0,
+      "starvation_rate": 0.0,
+      "fairness_turns_jain": 1.0,
+      "lifecycle_events": {
+        "send": 1,
+        "spawn": 2
+      },
+      "per_task": [
+        {
+          "scenario_id": "calendar.check_availability_thursday_morning",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4795605830149725
+        },
+        {
+          "scenario_id": "mail.archive_specific_newsletter_thread",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.5267708330065943
+        },
+        {
+          "scenario_id": "reminders.create_pickup_reminder_tomorrow_9am",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.47269774999585934
+        },
+        {
+          "scenario_id": "health.step_count_today",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4461282910197042
+        },
+        {
+          "scenario_id": "messages.send_imessage_to_hannah",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.841227583005093
+        },
+        {
+          "scenario_id": "contacts.add_new_freelance_collaborator",
+          "seed": 2026,
+          "wave_index": 1,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 1.0446351249993313
+        },
+        {
+          "scenario_id": "finance.spending_summary_last_week",
+          "seed": 2026,
+          "wave_index": 1,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4381532499974128
+        },
+        {
+          "scenario_id": "focus.block_distracting_apps_25min",
+          "seed": 2026,
+          "wave_index": 1,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.47427050000987947
+        },
+        {
+          "scenario_id": "sleep.set_bedtime_reminder_1030pm_daily",
+          "seed": 2026,
+          "wave_index": 1,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.42990695900516585
+        },
+        {
+          "scenario_id": "travel.search_flights_sfo_jfk_next_friday",
+          "seed": 2026,
+          "wave_index": 1,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4294699589954689
+        }
+      ]
+    },
+    {
+      "n": 10,
+      "arrival": "batch",
+      "waves": 1,
+      "tasks_total": 10,
+      "tasks_completed": 10,
+      "completion_rate": 1.0,
+      "mean_task_score": 1.0,
+      "throughput_tasks_per_min": 138.72009806303694,
+      "wall_clock_s": 4.325256457988871,
+      "turn_latency_ms": {
+        "p50": 0.0,
+        "p95": 0.0,
+        "max": 0.0
+      },
+      "task_wall_s": {
+        "p50": 0.4195368340006098,
+        "p95": 0.501234374998603,
+        "max": 0.501234374998603
+      },
+      "cost_usd": {
+        "total": 0.0,
+        "per_completed_task": 0.0
+      },
+      "tokens": {
+        "prompt": 0,
+        "completion": 0
+      },
+      "starved_tasks": 0,
+      "starvation_rate": 0.0,
+      "fairness_turns_jain": 1.0,
+      "lifecycle_events": {
+        "send": 1,
+        "spawn": 2
+      },
+      "per_task": [
+        {
+          "scenario_id": "calendar.check_availability_thursday_morning",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4484111670171842
+        },
+        {
+          "scenario_id": "mail.archive_specific_newsletter_thread",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.501234374998603
+        },
+        {
+          "scenario_id": "reminders.create_pickup_reminder_tomorrow_9am",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.3852070840075612
+        },
+        {
+          "scenario_id": "health.step_count_today",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4591677080024965
+        },
+        {
+          "scenario_id": "messages.send_imessage_to_hannah",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4195368340006098
+        },
+        {
+          "scenario_id": "contacts.add_new_freelance_collaborator",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4273087080218829
+        },
+        {
+          "scenario_id": "finance.spending_summary_last_week",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4675110840180423
+        },
+        {
+          "scenario_id": "focus.block_distracting_apps_25min",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.3933259590121452
+        },
+        {
+          "scenario_id": "sleep.set_bedtime_reminder_1030pm_daily",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4053436249960214
+        },
+        {
+          "scenario_id": "travel.search_flights_sfo_jfk_next_friday",
+          "seed": 2026,
+          "wave_index": 0,
+          "terminated_reason": "respond",
+          "completed": true,
+          "score": 1.0,
+          "turns": 2,
+          "task_wall_s": 0.4148742920078803
+        }
+      ]
+    }
+  ],
+  "interference": {
+    "n5_minus_n1": 0.0,
+    "n10_minus_n1": 0.0
+  },
+  "timestamp": "2026-07-05T02:28:14.780242+00:00"
+}

--- a/.github/issue-evidence/13777-multitask-perfect-stdout.txt
+++ b/.github/issue-evidence/13777-multitask-perfect-stdout.txt
@@ -1,0 +1,7 @@
+[multitask] harness=perfect isolation=shared_runtime
+[multitask] N=1   completed=10/10 mean_score=1.000 starved=0 jain=1.000
+[multitask] N=5   completed=10/10 mean_score=1.000 starved=0 jain=1.000
+[multitask] N=10  completed=10/10 mean_score=1.000 starved=0 jain=1.000
+[multitask] interference n5_minus_n1=+0.000
+[multitask] interference n10_minus_n1=+0.000
+[multitask] wrote /tmp/mtb_evidence/multitask_20260705T022814Z.json

--- a/packages/benchmarks/multitask-bench/README.md
+++ b/packages/benchmarks/multitask-bench/README.md
@@ -1,0 +1,76 @@
+# MultitaskBench
+
+Measures the interference one long-lived agent incurs when it drives **N tasks
+at once** versus one at a time. The claim under test is "one agent handling N
+tasks" — a single shared agent client per harness driving N interleaved LifeOps
+task conversations — not "N agents" (which would be a different claim).
+
+The headline metric is **interference**: mean per-task score at N minus at
+N=1, over the identical `(scenario, seed)` pairs both lanes run. A delta of
+`0.0` means the shared agent scores each task exactly as well under load as
+alone; a negative delta quantifies degradation.
+
+## What it reuses
+
+MultitaskBench is a thin scheduler on top of
+[`lifeops-bench`](../lifeops-bench): each task is one LifeOps STATIC scenario
+driven through `LifeOpsBenchRunner.run_one`. The sample is a frozen set of 10
+STATIC scenarios (5 SMOKE ids + 5 CORE STATIC ids across the remaining domains)
+so all eleven LifeOps surfaces are represented and every lane scores the same
+world.
+
+## Lanes and waves
+
+Tasks are **batch-presented at t=0** in waves of exactly N: the sample is
+sliced `sample[k*N:(k+1)*N]` and each wave runs concurrently. The N=1 lane is
+10 sequential single-task waves — the interference baseline. N=5 is two waves;
+N=10 is one wave of ten.
+
+## Isolation — disclosed, never erased
+
+| harness  | isolation          | interference means                          |
+|----------|--------------------|---------------------------------------------|
+| eliza    | `shared_runtime`   | N sessions contend for one `AgentRuntime`   |
+| hermes   | `process_per_turn` | shared rate/cost budget only (process-isolated) |
+| openclaw | `process_per_turn` | shared rate/cost budget only (process-isolated) |
+
+The eliza lane's per-session usage attribution depends on the
+AsyncLocalStorage fix in `packages/lifeops-bench/src/server.ts` (issue #13777
+PR 1). Until that is in tree, the eliza live lane is gated behind
+`MULTITASK_ELIZA_USAGE_FIX=1`.
+
+## Metrics per lane
+
+`completion_rate`, `mean_task_score`, `throughput_tasks_per_min`,
+`turn_latency_ms{p50,p95,max}`, `task_wall_s{p50,p95,max}`,
+`cost_usd{total,per_completed_task}`, `tokens{prompt,completion}`,
+`starved_tasks` / `starvation_rate` (a task that timed out while a wave peer
+completed, or produced zero turns), `fairness_turns_jain` (Jain's index over
+per-task turn counts, per wave), and `lifecycle_events` (which orchestration
+stages fired, via `orchestrator_lifecycle.events.extract_lifecycle_events`).
+
+The registry scalar score is the `mean_task_score` of the N=10 lane.
+
+## Running
+
+```bash
+# Hermetic oracle — no keys. Perfect scores 1.0 with zero interference.
+python -m multitask_bench --harness perfect --lanes 1,5,10 --output-dir results
+
+# Live harness (needs CEREBRAS_API_KEY); eliza also needs the server usage fix.
+CEREBRAS_API_KEY=... python -m multitask_bench --harness hermes --lanes 1,5,10 \
+    --model gemma-4-31b --output-dir results
+```
+
+Reports land at `results/multitask_<timestamp>.json`.
+
+## Tests
+
+```bash
+pytest packages/benchmarks/multitask-bench/tests -v
+```
+
+The suite drives the real scheduler + runner through the frozen sample with the
+deterministic Perfect/Wrong oracles (no model, no keys), plus unit coverage for
+wave partitioning, Jain math, starvation classification, percentiles, and the
+report schema round-trip.

--- a/packages/benchmarks/multitask-bench/conftest.py
+++ b/packages/benchmarks/multitask-bench/conftest.py
@@ -1,0 +1,21 @@
+"""Pytest bootstrap: put the benchmark package roots on ``sys.path``.
+
+MultitaskBench imports ``eliza_lifeops_bench`` (from the sibling lifeops-bench
+package) and ``orchestrator_lifecycle`` (a namespace package rooted at
+``packages/benchmarks``). Neither is pip-installed in the repo checkout, so we
+add both roots here the way ``lifeops-bench/conftest.py`` does for its own
+adapters — otherwise the imports raise at collection time.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BENCHMARKS_ROOT = Path(__file__).resolve().parent.parent
+_LIFEOPS_ROOT = _BENCHMARKS_ROOT / "lifeops-bench"
+
+for _root in (_BENCHMARKS_ROOT, _LIFEOPS_ROOT):
+    _str = str(_root)
+    if _str not in sys.path:
+        sys.path.insert(0, _str)

--- a/packages/benchmarks/multitask-bench/multitask_bench/__init__.py
+++ b/packages/benchmarks/multitask-bench/multitask_bench/__init__.py
@@ -1,0 +1,29 @@
+"""MultitaskBench — one agent handling N interleaved LifeOps tasks.
+
+Measures the interference a shared agent incurs when driving N tasks at once
+(N=5, N=10) versus one at a time (N=1), reusing the LifeOpsBench runner and its
+STATIC scenario corpus. The N=1 lane is the baseline; the headline is the
+per-task score delta at N. Harnesses (eliza / hermes / openclaw) differ in
+isolation, disclosed in every report and never erased.
+"""
+
+from __future__ import annotations
+
+from .metrics import compute_interference, compute_lane_metrics
+from .report import build_report, write_report
+from .sample import MULTITASK_SAMPLE, MULTITASK_SCENARIO_IDS
+from .scheduler import partition_waves, run_lane
+from .types import LaneResult, TaskRun
+
+__all__ = [
+    "LaneResult",
+    "MULTITASK_SAMPLE",
+    "MULTITASK_SCENARIO_IDS",
+    "TaskRun",
+    "build_report",
+    "compute_interference",
+    "compute_lane_metrics",
+    "partition_waves",
+    "run_lane",
+    "write_report",
+]

--- a/packages/benchmarks/multitask-bench/multitask_bench/__main__.py
+++ b/packages/benchmarks/multitask-bench/multitask_bench/__main__.py
@@ -1,0 +1,143 @@
+"""MultitaskBench CLI: run the N=1/5/10 lanes for one harness and write a report.
+
+    python -m multitask_bench --harness eliza|hermes|openclaw|perfect|wrong \
+        --lanes 1,5,10 --output-dir <dir> --model gemma-4-31b
+
+Each lane drives the frozen 10-scenario sample through one shared agent at the
+lane's concurrency N; the report carries every lane's metrics plus the
+interference deltas (mean task score @N minus @1). ``perfect``/``wrong`` are the
+hermetic no-key oracles used for smoke and CI; live harnesses need provider
+keys and (for eliza) the server usage-buffer fix — see ``harness.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from .harness import build_agent_factory, build_world_factory
+from .report import build_report, write_report
+from .sample import MULTITASK_SAMPLE, MULTITASK_SCENARIO_IDS
+from .scheduler import run_lane
+from .types import LaneResult
+
+_DEFAULT_TIMEOUT_S = 300.0
+
+
+def _parse_lanes(raw: str) -> list[int]:
+    """Parse ``"1,5,10"`` into ``[1, 5, 10]``, raising on malformed input.
+
+    The N=1 lane must be present: it is the interference baseline, and its
+    absence would make every delta undefined. We fail here rather than let the
+    report builder raise deep in aggregation.
+    """
+    try:
+        lanes = [int(part.strip()) for part in raw.split(",") if part.strip()]
+    except ValueError as exc:
+        raise SystemExit(f"--lanes must be comma-separated ints, got {raw!r}") from exc
+    if not lanes:
+        raise SystemExit("--lanes must name at least one N")
+    if any(n < 1 for n in lanes):
+        raise SystemExit(f"--lanes values must be >= 1, got {lanes}")
+    if 1 not in lanes:
+        raise SystemExit(
+            "--lanes must include 1 (the N=1 interference baseline)"
+        )
+    return lanes
+
+
+async def _run(
+    *,
+    harness: str,
+    lanes: list[int],
+    model: str,
+    timeout_s: float,
+) -> list[LaneResult]:
+    agent_factory = build_agent_factory(harness, model=model)
+    world_factory = build_world_factory()
+    results: list[LaneResult] = []
+    for n in sorted(lanes):
+        results.append(
+            await run_lane(
+                n=n,
+                scenarios=MULTITASK_SAMPLE,
+                agent_factory=agent_factory,
+                world_factory=world_factory,
+                timeout_s=timeout_s,
+            )
+        )
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="MultitaskBench — one agent handling N interleaved LifeOps tasks",
+    )
+    parser.add_argument(
+        "--harness",
+        choices=["eliza", "hermes", "openclaw", "perfect", "wrong"],
+        required=True,
+        help="Which harness drives the shared agent",
+    )
+    parser.add_argument(
+        "--lanes",
+        default="1,5,10",
+        help="Comma-separated concurrency levels; must include 1 (default: 1,5,10)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=os.environ.get("MULTITASK_BENCH_OUTPUT_DIR", "results"),
+        help="Directory to write multitask_<timestamp>.json into",
+    )
+    parser.add_argument(
+        "--model",
+        default=os.environ.get("MULTITASK_BENCH_MODEL", "gemma-4-31b"),
+        help="Model name for the live harnesses (default: gemma-4-31b)",
+    )
+    parser.add_argument(
+        "--per-task-timeout-s",
+        type=float,
+        default=float(os.environ.get("MULTITASK_BENCH_TIMEOUT_S", _DEFAULT_TIMEOUT_S)),
+        help="Per-task wall-clock timeout in seconds (default: 300)",
+    )
+    args = parser.parse_args(argv)
+
+    lanes = _parse_lanes(args.lanes)
+    lane_results = asyncio.run(
+        _run(
+            harness=args.harness,
+            lanes=lanes,
+            model=args.model,
+            timeout_s=args.per_task_timeout_s,
+        )
+    )
+
+    report = build_report(
+        harness=args.harness,
+        model=args.model,
+        lanes=lane_results,
+        scenario_ids=MULTITASK_SCENARIO_IDS,
+    )
+    path = write_report(report, Path(args.output_dir))
+
+    interference = report["interference"]
+    print(f"[multitask] harness={args.harness} isolation={report['isolation']}")
+    for lane in report["lanes"]:  # type: ignore[union-attr]
+        print(
+            f"[multitask] N={lane['n']:<3} "
+            f"completed={lane['tasks_completed']}/{lane['tasks_total']} "
+            f"mean_score={lane['mean_task_score']:.3f} "
+            f"starved={lane['starved_tasks']} "
+            f"jain={lane['fairness_turns_jain']:.3f}"
+        )
+    for key, delta in interference.items():  # type: ignore[union-attr]
+        print(f"[multitask] interference {key}={delta:+.3f}")
+    print(f"[multitask] wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/benchmarks/multitask-bench/multitask_bench/harness.py
+++ b/packages/benchmarks/multitask-bench/multitask_bench/harness.py
@@ -1,0 +1,199 @@
+"""Build the per-lane ``agent_factory`` + ``world_factory`` for each harness.
+
+MultitaskBench's claim is "one long-lived agent handling N tasks", so every
+harness builds a factory that shares one long-lived client across the N tasks
+of a lane while giving each task its own ``agent_fn`` (its own session). The
+harnesses differ only in isolation, which the report discloses:
+
+- **eliza** — one ``ElizaClient`` (one bench-server / AgentRuntime) shared
+  across the lane; each task's ``build_lifeops_bench_agent_fn`` mints a fresh
+  ``lifeops-<uuid>`` session on it. Interference is real: N sessions contend
+  for one runtime. Per-session usage attribution depends on the AsyncLocalStorage
+  fix in ``packages/lifeops-bench/src/server.ts`` (issue #13777 PR 1); until
+  that lands, the eliza live lane double-counts turn usage across overlapping
+  sessions and must not be published — the CLI gates it behind
+  ``MULTITASK_ELIZA_USAGE_FIX=1``.
+- **hermes / openclaw** — one client shared across the lane, each task's
+  ``agent_fn`` driving a per-turn subprocess/in-process call. Process-isolated;
+  interference is only the shared rate/cost budget.
+
+The hermetic ``perfect`` / ``wrong`` factories need no client and no keys —
+they are the conformance path the tests and no-key smoke runs use, and they
+carry ``isolation`` "shared_runtime" only nominally (there is no runtime; the
+oracle is pure).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+from eliza_lifeops_bench.agents import DEFAULT_NOW_ISO, _resolve_default_snapshot_path
+from eliza_lifeops_bench.agents.adapter_paths import (
+    ensure_benchmark_adapter_importable,
+)
+from eliza_lifeops_bench.runner import AgentFactory, AgentFn, WorldFactory
+from eliza_lifeops_bench.types import Scenario
+
+__all__ = [
+    "HARNESS_ISOLATION",
+    "build_agent_factory",
+    "build_world_factory",
+]
+
+# Nominal isolation per harness id. The hermetic oracles report as a shared
+# runtime because they carry no per-turn process boundary, but they are not a
+# live claim — the registry scorer rejects oracle-model reports.
+HARNESS_ISOLATION: dict[str, str] = {
+    "eliza": "shared_runtime",
+    "hermes": "process_per_turn",
+    "openclaw": "process_per_turn",
+    "perfect": "shared_runtime",
+    "wrong": "shared_runtime",
+}
+
+
+def build_world_factory() -> WorldFactory:
+    """Snapshot-aware world factory (seed 2026 → medium snapshot, else fresh).
+
+    Reuses ``eliza_lifeops_bench.__main__._build_world_factory`` so the world
+    the multitask lane runs against is byte-identical to the one the single-task
+    LifeOpsBench lane uses — the interference delta only means something if the
+    two lanes score the same world.
+    """
+    from eliza_lifeops_bench.__main__ import _build_world_factory
+
+    return _build_world_factory()
+
+
+def _perfect_factory() -> AgentFactory:
+    from eliza_lifeops_bench.agents import PerfectAgent
+
+    return lambda scenario: PerfectAgent(scenario)
+
+
+def _wrong_factory() -> AgentFactory:
+    from eliza_lifeops_bench.agents import WrongAgent
+
+    return lambda scenario: WrongAgent(scenario)
+
+
+def _eliza_factory(model: str | None) -> AgentFactory:
+    """One shared ElizaClient; each task gets its own session on the runtime.
+
+    The client is constructed once and closed over, so the lane's N tasks all
+    drive the same bench-server / AgentRuntime — the shared-runtime interference
+    MultitaskBench is measuring.
+    """
+    ensure_benchmark_adapter_importable("eliza")
+    from eliza_adapter.client import ElizaClient
+    from eliza_adapter.lifeops_bench import build_lifeops_bench_agent_fn
+
+    if not os.environ.get("ELIZA_BENCH_URL"):
+        from eliza_adapter.server_manager import ElizaServerManager
+
+        manager = ElizaServerManager()
+        manager.start()
+        # Keep a reference alive for the process lifetime; the manager
+        # registers its own atexit teardown.
+        globals()["_ELIZA_SERVER_MANAGER"] = manager
+        os.environ["ELIZA_BENCH_URL"] = manager.client.base_url
+        os.environ["ELIZA_BENCH_TOKEN"] = manager.token
+
+    shared_client = ElizaClient()
+    shared_client.wait_until_ready(timeout=120)
+    snapshot_path = _resolve_default_snapshot_path()
+
+    def factory(_scenario: Scenario) -> AgentFn:
+        return build_lifeops_bench_agent_fn(
+            client=shared_client,
+            world_snapshot_path=snapshot_path,
+            now_iso=DEFAULT_NOW_ISO,
+            model_name=model,
+        )
+
+    return factory
+
+
+def _hermes_factory(model: str | None) -> AgentFactory:
+    """One shared HermesClient; each task gets its own per-turn agent_fn."""
+    ensure_benchmark_adapter_importable("hermes")
+    from hermes_adapter.client import HermesClient
+    from hermes_adapter.lifeops_bench import build_lifeops_bench_agent_fn
+
+    provider = (
+        os.environ.get("BENCHMARK_MODEL_PROVIDER")
+        or os.environ.get("ELIZA_PROVIDER")
+        or "cerebras"
+    ).strip().lower()
+    model_name = model or os.environ.get("BENCHMARK_MODEL_NAME") or "gemma-4-31b"
+    mode = (os.environ.get("HERMES_ADAPTER_MODE") or "in_process").strip() or "in_process"
+    shared_client = HermesClient(provider=provider, model=model_name, mode=mode)
+    shared_client.wait_until_ready(timeout=60)
+
+    def factory(_scenario: Scenario) -> AgentFn:
+        return build_lifeops_bench_agent_fn(client=shared_client, model_name=model_name)
+
+    return factory
+
+
+def _openclaw_factory(model: str | None) -> AgentFactory:
+    """One shared OpenClawClient; each task gets its own per-turn agent_fn."""
+    ensure_benchmark_adapter_importable("openclaw")
+    from openclaw_adapter.client import OpenClawClient
+    from openclaw_adapter.lifeops_bench import build_lifeops_bench_agent_fn
+
+    provider = (
+        os.environ.get("BENCHMARK_MODEL_PROVIDER")
+        or os.environ.get("ELIZA_PROVIDER")
+        or "cerebras"
+    ).strip().lower()
+    model_name = model or os.environ.get("BENCHMARK_MODEL_NAME") or "gemma-4-31b"
+    shared_client = OpenClawClient(
+        provider=provider, model=model_name, direct_openai_compatible=True
+    )
+    shared_client.wait_until_ready(timeout=120)
+
+    def factory(_scenario: Scenario) -> AgentFn:
+        return build_lifeops_bench_agent_fn(
+            client=shared_client,
+            world_snapshot_path=_resolve_default_snapshot_path(),
+            now_iso=DEFAULT_NOW_ISO,
+            model_name=model_name,
+        )
+
+    return factory
+
+
+_FACTORY_BUILDERS: dict[str, Callable[[str | None], AgentFactory]] = {
+    "eliza": _eliza_factory,
+    "hermes": _hermes_factory,
+    "openclaw": _openclaw_factory,
+    "perfect": lambda _model: _perfect_factory(),
+    "wrong": lambda _model: _wrong_factory(),
+}
+
+
+def build_agent_factory(harness: str, *, model: str | None = None) -> AgentFactory:
+    """Build the per-lane ``agent_factory`` for ``harness``.
+
+    The returned factory shares one long-lived client across the tasks of a
+    lane (the "one agent handling N" contract); ``perfect``/``wrong`` are the
+    hermetic no-key oracles. Unknown harness ids raise immediately.
+    """
+    builder = _FACTORY_BUILDERS.get(harness)
+    if builder is None:
+        raise ValueError(
+            f"unknown harness {harness!r}; expected one of "
+            f"{sorted(_FACTORY_BUILDERS)}"
+        )
+    if harness == "eliza" and not os.environ.get("MULTITASK_ELIZA_USAGE_FIX"):
+        raise SystemExit(
+            "The eliza live lane needs the per-session usage-buffer fix in "
+            "packages/lifeops-bench/src/server.ts (issue #13777 PR 1). Without "
+            "it, MODEL_USED events from overlapping sessions land in one global "
+            "buffer and per-task cost/token attribution is wrong. Set "
+            "MULTITASK_ELIZA_USAGE_FIX=1 once that fix is in your tree to run "
+            "the eliza lane anyway."
+        )
+    return builder(model)

--- a/packages/benchmarks/multitask-bench/multitask_bench/metrics.py
+++ b/packages/benchmarks/multitask-bench/multitask_bench/metrics.py
@@ -1,0 +1,273 @@
+"""Aggregate a lane's task runs into the MultitaskBench metric block.
+
+The headline is *interference*: mean per-task score at N minus at N=1, over the
+identical (scenario, seed) pairs both lanes ran. Everything else characterizes
+how a shared agent degrades under load — completion rate, throughput, per-turn
+and per-task latency spread, cost, fairness (Jain over per-wave turn counts),
+and starvation (a task that timed out while a wave peer completed, or produced
+zero turns). Orchestration quality is surfaced by folding each turn's planner
+actions through ``extract_lifecycle_events`` so a lane reports *which* lifecycle
+stages actually fired, not just a scalar.
+
+A completed task is one whose ``terminated_reason`` is a normal end
+("respond"/"satisfied"/"max_turns"), never a failure sentinel — so completion
+rate and mean score never count a timed-out or errored task as a healthy zero.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from statistics import mean
+
+from orchestrator_lifecycle.events import extract_lifecycle_events
+
+from .types import LaneResult, TaskRun
+
+__all__ = [
+    "COMPLETED_REASONS",
+    "compute_lane_metrics",
+    "is_completed",
+    "is_starved",
+    "jain_fairness",
+    "mean_task_score",
+    "percentiles",
+]
+
+# Terminal reasons that mean the task finished on its own terms. Anything
+# outside this set — "timeout", "error", "cost_exceeded" — is a failure, and a
+# failed task is never counted as a completion nor as a zero-scoring success.
+COMPLETED_REASONS: frozenset[str] = frozenset({"respond", "satisfied", "max_turns"})
+
+
+def is_completed(task: TaskRun) -> bool:
+    """True when the task ended on a normal terminal reason."""
+    return task.terminated_reason in COMPLETED_REASONS
+
+
+def is_starved(task: TaskRun, wave_had_completion: bool) -> bool:
+    """True when the task was starved of the shared agent's attention.
+
+    Two shapes count as starvation: a wall-clock timeout while at least one
+    peer in the same wave completed (the agent served others and left this one
+    hanging), or a task that produced zero turns at all (it never got a slice).
+    """
+    if task.turns == 0:
+        return True
+    return task.terminated_reason == "timeout" and wave_had_completion
+
+
+def mean_task_score(tasks: list[TaskRun]) -> float:
+    """Mean per-task score over ``tasks`` (0.0 for an empty lane)."""
+    if not tasks:
+        return 0.0
+    return mean(task.score for task in tasks)
+
+
+def percentiles(values: list[float]) -> dict[str, float]:
+    """p50/p95/max over ``values`` via nearest-rank (no interpolation).
+
+    Nearest-rank keeps every reported percentile an actually-observed sample,
+    which is the honest thing for the small N (10 tasks) MultitaskBench runs.
+    Returns zeros for an empty input — there is no data to summarize, and the
+    caller renders the lane's ``tasks_completed`` alongside so an all-zero
+    latency block is never mistaken for "instant".
+    """
+    if not values:
+        return {"p50": 0.0, "p95": 0.0, "max": 0.0}
+    ordered = sorted(values)
+    count = len(ordered)
+
+    def nearest_rank(pct: float) -> float:
+        # rank = ceil(pct * count), 1-indexed, clamped into range.
+        rank = max(1, min(count, -(-int(pct * count * 100) // 100)))
+        return ordered[rank - 1]
+
+    return {
+        "p50": nearest_rank(0.50),
+        "p95": nearest_rank(0.95),
+        "max": ordered[-1],
+    }
+
+
+def jain_fairness(turn_counts: list[int]) -> float:
+    """Jain's fairness index (x·1)² / (n·x·x) over per-task turn counts.
+
+    1.0 means every task got the same number of turns; 1/n means one task
+    monopolized the agent. Returns 1.0 for a single task (trivially fair) and
+    0.0 when every task got zero turns (no allocation to be fair about).
+    """
+    if not turn_counts:
+        return 0.0
+    total = sum(turn_counts)
+    if total == 0:
+        return 0.0
+    sum_sq = sum(x * x for x in turn_counts)
+    n = len(turn_counts)
+    return (total * total) / (n * sum_sq)
+
+
+def _fairness_over_waves(tasks: list[TaskRun]) -> float:
+    """Mean per-wave Jain index over per-task turn counts.
+
+    Fairness is a within-wave property (N tasks contending for one agent at
+    once), so we compute Jain per wave and average. The N=1 lane has one task
+    per wave → every wave is trivially fair → 1.0.
+    """
+    by_wave: dict[int, list[int]] = defaultdict(list)
+    for task in tasks:
+        by_wave[task.wave_index].append(task.turns)
+    if not by_wave:
+        return 0.0
+    return mean(jain_fairness(counts) for counts in by_wave.values())
+
+
+def _lane_lifecycle_events(tasks: list[TaskRun]) -> dict[str, int]:
+    """Count lifecycle events fired across every turn of every task in the lane.
+
+    Each turn's planner actions + params are normalized through
+    ``extract_lifecycle_events`` (de-duped within a turn); the lane tally sums
+    those across all turns so the report shows which orchestration stages the
+    agent actually exercised under load.
+    """
+    counts: dict[str, int] = defaultdict(int)
+    for task in tasks:
+        if task.result is None:
+            continue
+        for turn in task.result.turns:
+            actions = [action.name for action in turn.agent_actions]
+            params: dict[str, object] = {}
+            for action in turn.agent_actions:
+                params.update(action.kwargs)
+            for event in extract_lifecycle_events(actions, params):
+                counts[event] += 1
+    return dict(sorted(counts.items()))
+
+
+def compute_lane_metrics(lane: LaneResult) -> dict[str, object]:
+    """Reduce a ``LaneResult`` to the metric dict ``report.py`` serializes."""
+    tasks = lane.tasks
+    total = len(tasks)
+    completed = [task for task in tasks if is_completed(task)]
+
+    waves_with_completion = {
+        task.wave_index for task in tasks if is_completed(task)
+    }
+    starved = [
+        task
+        for task in tasks
+        if is_starved(task, task.wave_index in waves_with_completion)
+    ]
+
+    prompt_tokens = 0
+    completion_tokens = 0
+    cost_total = 0.0
+    turn_latencies_ms: list[float] = []
+    for task in tasks:
+        if task.result is None:
+            continue
+        cost_total += task.result.total_cost_usd
+        for turn in task.result.turns:
+            prompt_tokens += int(turn.input_tokens or 0)
+            completion_tokens += int(turn.output_tokens or 0)
+            if turn.latency_ms is not None:
+                turn_latencies_ms.append(float(turn.latency_ms))
+
+    task_walls_s = [task.task_wall_s for task in tasks]
+    throughput = (
+        len(completed) / (lane.wall_clock_s / 60.0)
+        if lane.wall_clock_s > 0
+        else 0.0
+    )
+    per_completed_cost = (
+        cost_total / len(completed) if completed else 0.0
+    )
+
+    return {
+        "n": lane.n,
+        "arrival": "batch",
+        "waves": lane.waves,
+        "tasks_total": total,
+        "tasks_completed": len(completed),
+        "completion_rate": (len(completed) / total) if total else 0.0,
+        "mean_task_score": mean_task_score(tasks),
+        "throughput_tasks_per_min": throughput,
+        "wall_clock_s": lane.wall_clock_s,
+        "turn_latency_ms": percentiles(turn_latencies_ms),
+        "task_wall_s": percentiles(task_walls_s),
+        "cost_usd": {
+            "total": cost_total,
+            "per_completed_task": per_completed_cost,
+        },
+        "tokens": {
+            "prompt": prompt_tokens,
+            "completion": completion_tokens,
+        },
+        "starved_tasks": len(starved),
+        "starvation_rate": (len(starved) / total) if total else 0.0,
+        "fairness_turns_jain": _fairness_over_waves(tasks),
+        "lifecycle_events": _lane_lifecycle_events(tasks),
+        "per_task": [
+            {
+                "scenario_id": task.scenario_id,
+                "seed": task.seed,
+                "wave_index": task.wave_index,
+                "terminated_reason": task.terminated_reason,
+                "completed": is_completed(task),
+                "score": task.score,
+                "turns": task.turns,
+                "task_wall_s": task.task_wall_s,
+            }
+            for task in tasks
+        ],
+    }
+
+
+def compute_interference(
+    lanes_metrics: list[dict[str, object]],
+) -> dict[str, float]:
+    """Interference delta per non-baseline lane: mean_score@N - mean_score@1.
+
+    Computed over the identical (scenario, seed) sample every lane runs, so the
+    subtraction is well-defined. A delta of 0.0 means the shared agent scored
+    each task exactly as well under load as alone (no interference); a negative
+    delta quantifies degradation. Raises if the N=1 baseline is absent — the
+    metric is undefined without it, and a silent skip would hide that.
+    """
+    baseline = next(
+        (m for m in lanes_metrics if m["n"] == 1),
+        None,
+    )
+    if baseline is None:
+        raise ValueError(
+            "interference requires the N=1 baseline lane; none present"
+        )
+    baseline_by_key = _score_by_key(baseline)
+
+    deltas: dict[str, float] = {}
+    for lane in lanes_metrics:
+        n = lane["n"]
+        if n == 1:
+            continue
+        lane_by_key = _score_by_key(lane)
+        shared_keys = sorted(baseline_by_key.keys() & lane_by_key.keys())
+        if not shared_keys:
+            raise ValueError(
+                f"lane N={n} shares no (scenario, seed) pairs with the "
+                "N=1 baseline; interference is undefined"
+            )
+        delta = mean(
+            lane_by_key[key] - baseline_by_key[key] for key in shared_keys
+        )
+        deltas[f"n{n}_minus_n1"] = delta
+    return deltas
+
+
+def _score_by_key(lane_metrics: dict[str, object]) -> dict[tuple[str, int], float]:
+    """Map (scenario_id, seed) -> score for a lane's per-task block."""
+    per_task = lane_metrics["per_task"]
+    assert isinstance(per_task, list)
+    out: dict[tuple[str, int], float] = {}
+    for entry in per_task:
+        key = (str(entry["scenario_id"]), int(entry["seed"]))
+        out[key] = float(entry["score"])
+    return out

--- a/packages/benchmarks/multitask-bench/multitask_bench/report.py
+++ b/packages/benchmarks/multitask-bench/multitask_bench/report.py
@@ -30,14 +30,14 @@ def build_report(
     scenario_ids: list[str],
 ) -> dict[str, object]:
     """Build the report dict from a set of completed lanes."""
-    lanes_metrics = [compute_lane_metrics(lane) for lane in lanes]
-    interference = compute_interference(lanes_metrics)
     isolation = HARNESS_ISOLATION.get(harness)
     if isolation is None:
         raise ValueError(
             f"unknown harness {harness!r}; expected one of "
             f"{sorted(HARNESS_ISOLATION)}"
         )
+    lanes_metrics = [compute_lane_metrics(lane) for lane in lanes]
+    interference = compute_interference(lanes_metrics)
     return {
         "benchmark": "multitask_bench",
         "harness": harness,

--- a/packages/benchmarks/multitask-bench/multitask_bench/report.py
+++ b/packages/benchmarks/multitask-bench/multitask_bench/report.py
@@ -1,0 +1,62 @@
+"""Assemble and write the ``multitask_<timestamp>.json`` report.
+
+The report is the benchmark's contract with the registry scorer
+(``registry/scores.py::_score_from_multitask_bench_json``): a top-level
+``lanes[]`` of per-lane metric blocks plus the cross-lane ``interference``
+deltas, tagged with the harness's ``isolation`` mode so a shared-runtime eliza
+run is never silently compared against a process-isolated hermes/openclaw run.
+The scalar registry score is the ``mean_task_score`` of the N=10 lane; the
+interference deltas are the headline a human reads.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .harness import HARNESS_ISOLATION
+from .metrics import compute_interference, compute_lane_metrics
+from .types import LaneResult
+
+__all__ = ["build_report", "write_report"]
+
+
+def build_report(
+    *,
+    harness: str,
+    model: str,
+    lanes: list[LaneResult],
+    scenario_ids: list[str],
+) -> dict[str, object]:
+    """Build the report dict from a set of completed lanes."""
+    lanes_metrics = [compute_lane_metrics(lane) for lane in lanes]
+    interference = compute_interference(lanes_metrics)
+    isolation = HARNESS_ISOLATION.get(harness)
+    if isolation is None:
+        raise ValueError(
+            f"unknown harness {harness!r}; expected one of "
+            f"{sorted(HARNESS_ISOLATION)}"
+        )
+    return {
+        "benchmark": "multitask_bench",
+        "harness": harness,
+        "isolation": isolation,
+        "model": model,
+        "sample": {
+            "scenario_ids": scenario_ids,
+            "size": len(scenario_ids),
+        },
+        "lanes": lanes_metrics,
+        "interference": interference,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def write_report(report: dict[str, object], output_dir: Path) -> Path:
+    """Write ``report`` to ``multitask_<utc-timestamp>.json`` under ``output_dir``."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = output_dir / f"multitask_{stamp}.json"
+    path.write_text(json.dumps(report, indent=2, default=str), encoding="utf-8")
+    return path

--- a/packages/benchmarks/multitask-bench/multitask_bench/sample.py
+++ b/packages/benchmarks/multitask-bench/multitask_bench/sample.py
@@ -1,0 +1,77 @@
+"""The fixed 10-scenario STATIC sample MultitaskBench interleaves per lane.
+
+The interference metric — mean per-task score at N minus at N=1 — is only
+meaningful when the N=1 baseline and the N=5/N=10 lanes score the *same*
+(scenario, seed) pairs. That forces a single frozen sample: five SMOKE ids
+plus five CORE STATIC ids drawn from other domains (contacts, finance, focus,
+sleep, travel) so all eleven LifeOps surfaces are represented without
+overlapping the SMOKE set. Every id is STATIC — LIVE scenarios pull in a judge
+and simulated user whose cost and nondeterminism would swamp the interference
+signal.
+
+The ids are validated against ``SCENARIOS_BY_ID`` at import (mirroring
+``eliza_lifeops_bench.suites``) so sample drift fails in CI rather than
+surfacing as a silent skip mid-run. Seeds come from each scenario's
+``world_seed`` so the eliza world_factory resolves the matching on-disk
+snapshot.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from eliza_lifeops_bench.scenarios import SCENARIOS_BY_ID
+from eliza_lifeops_bench.types import Scenario
+
+__all__ = [
+    "MULTITASK_SAMPLE",
+    "MULTITASK_SCENARIO_IDS",
+    "sample_seed",
+]
+
+
+# Five SMOKE ids (calendar/mail/reminders/health/messages) plus five CORE
+# STATIC ids from the remaining domains. Order is fixed: wave partitioning
+# ``sample[k*n:(k+1)*n]`` must be deterministic across lanes, so this list is
+# the canonical order the N=1/N=5/N=10 lanes all slice.
+MULTITASK_SCENARIO_IDS: Final[list[str]] = [
+    # SMOKE — 5 domains
+    "calendar.check_availability_thursday_morning",
+    "mail.archive_specific_newsletter_thread",
+    "reminders.create_pickup_reminder_tomorrow_9am",
+    "health.step_count_today",
+    "messages.send_imessage_to_hannah",
+    # CORE STATIC — 5 further domains, no SMOKE overlap
+    "contacts.add_new_freelance_collaborator",
+    "finance.spending_summary_last_week",
+    "focus.block_distracting_apps_25min",
+    "sleep.set_bedtime_reminder_1030pm_daily",
+    "travel.search_flights_sfo_jfk_next_friday",
+]
+
+
+def _resolve_sample(ids: list[str]) -> list[Scenario]:
+    """Resolve ids against ``SCENARIOS_BY_ID``, raising on any unknown id.
+
+    Unknown ids raise ``ValueError`` at import so a bad sample is caught in
+    CI, never skipped silently at run time.
+    """
+    missing = [sid for sid in ids if sid not in SCENARIOS_BY_ID]
+    if missing:
+        raise ValueError(
+            "Unknown scenario id(s) in multitask sample: " + ", ".join(missing)
+        )
+    return [SCENARIOS_BY_ID[sid] for sid in ids]
+
+
+MULTITASK_SAMPLE: Final[list[Scenario]] = _resolve_sample(MULTITASK_SCENARIO_IDS)
+
+
+def sample_seed(scenario: Scenario) -> int:
+    """The seed a scenario runs at in every lane.
+
+    Fixed to ``world_seed`` (no per-lane offset) so the N=1 baseline and the
+    N=5/N=10 lanes score the identical (scenario, seed) pair the interference
+    delta subtracts across.
+    """
+    return scenario.world_seed

--- a/packages/benchmarks/multitask-bench/multitask_bench/scheduler.py
+++ b/packages/benchmarks/multitask-bench/multitask_bench/scheduler.py
@@ -1,0 +1,135 @@
+"""Wave scheduler: drives one agent through N interleaved LifeOps tasks.
+
+The unit under test is "one long-lived agent handling N tasks at once", so a
+lane holds a single ``LifeOpsBenchRunner`` whose ``agent_factory`` mints a
+fresh ``agent_fn`` per scenario. For the eliza harness that factory hands every
+task its own session on one shared ``AgentRuntime`` (genuine shared-runtime
+interference); for hermes/openclaw it hands every task the same client instance
+driving a per-turn subprocess/in-process call (process-isolated, interference =
+shared rate/cost budget only). The asymmetry is disclosed by the caller as
+``isolation`` — never erased here.
+
+Tasks arrive batch-presented at t=0 in waves of exactly N: the sample is sliced
+``sample[k*N:(k+1)*N]`` and each wave runs concurrently via ``asyncio.gather``.
+Streamed/sliding-window arrival was rejected upstream (nondeterministic /
+throughput-shaped); a wave is the deterministic unit the interference delta is
+computed over. The N=1 lane is 10 sequential single-task waves — the baseline
+the N=5/N=10 deltas subtract against.
+
+Per-task wall-clock timeout is enforced with ``asyncio.wait_for`` so one wedged
+task cannot stall a wave forever; a tripped timeout is recorded as a
+``TaskRun`` with ``terminated_reason="timeout"`` rather than propagated, so the
+lane still yields a full result set for fairness/starvation accounting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+
+from eliza_lifeops_bench.runner import AgentFactory, LifeOpsBenchRunner, WorldFactory
+from eliza_lifeops_bench.types import Scenario
+
+from .sample import sample_seed
+from .types import LaneResult, TaskRun
+
+__all__ = ["partition_waves", "run_lane"]
+
+
+def partition_waves(scenarios: list[Scenario], n: int) -> list[list[Scenario]]:
+    """Slice ``scenarios`` into consecutive waves of exactly ``n``.
+
+    The final wave is short only when ``len(scenarios)`` is not a multiple of
+    ``n``. Deterministic: the same sample and N always produce the same waves,
+    which is what lets the interference delta line up (scenario, seed) pairs
+    across lanes.
+    """
+    if n < 1:
+        raise ValueError(f"wave size must be >= 1, got {n}")
+    return [scenarios[k : k + n] for k in range(0, len(scenarios), n)]
+
+
+async def _run_task(
+    runner: LifeOpsBenchRunner,
+    scenario: Scenario,
+    seed: int,
+    wave_index: int,
+    timeout_s: float,
+) -> TaskRun:
+    """Run one scenario under a wall-clock timeout, classifying the outcome.
+
+    ``run_one`` already translates in-flight failures into a typed
+    ``ScenarioResult`` (terminated_reason "error"/"cost_exceeded"); the only
+    thing it does not bound is total wall time, so we wrap it in
+    ``wait_for``. A timeout or an escaped exception becomes a resultless
+    ``TaskRun`` whose ``terminated_reason`` records why, keeping "did not
+    complete" distinct from "completed with score 0".
+    """
+    started = time.monotonic()
+    try:
+        result = await asyncio.wait_for(
+            runner.run_one(scenario, seed), timeout=timeout_s
+        )
+        wall_s = time.monotonic() - started
+        return TaskRun(
+            scenario_id=scenario.id,
+            seed=seed,
+            wave_index=wave_index,
+            terminated_reason=result.terminated_reason,
+            task_wall_s=wall_s,
+            result=result,
+        )
+    except asyncio.TimeoutError:
+        wall_s = time.monotonic() - started
+        return TaskRun(
+            scenario_id=scenario.id,
+            seed=seed,
+            wave_index=wave_index,
+            terminated_reason="timeout",
+            task_wall_s=wall_s,
+            result=None,
+        )
+
+
+async def run_lane(
+    *,
+    n: int,
+    scenarios: list[Scenario],
+    agent_factory: AgentFactory,
+    world_factory: WorldFactory,
+    timeout_s: float,
+    max_cost_usd: float = 50.0,
+) -> LaneResult:
+    """Run the full sample at concurrency ``n`` and return its lane result.
+
+    One runner per lane owns the shared cost ledger; ``agent_factory`` gives
+    each task a fresh ``agent_fn`` (a fresh session on the shared runtime for
+    eliza). Waves run in order; within a wave every task runs concurrently so
+    the shared agent is genuinely handling N at once.
+    """
+    runner = LifeOpsBenchRunner(
+        agent_factory=agent_factory,
+        world_factory=world_factory,
+        scenarios=scenarios,
+        max_cost_usd=max_cost_usd,
+        # Waves own their own concurrency; the runner-level semaphore only
+        # matters for its own run_all path, which we do not use.
+        concurrency=max(n, 1),
+        abort_on_budget_exceeded=False,
+    )
+
+    waves = partition_waves(scenarios, n)
+    tasks: list[TaskRun] = []
+    lane_started = time.monotonic()
+    for wave_index, wave in enumerate(waves):
+        wave_runs = await asyncio.gather(
+            *(
+                _run_task(runner, scenario, sample_seed(scenario), wave_index, timeout_s)
+                for scenario in wave
+            )
+        )
+        tasks.extend(wave_runs)
+    wall_clock_s = time.monotonic() - lane_started
+
+    return LaneResult(n=n, waves=len(waves), tasks=tasks, wall_clock_s=wall_clock_s)

--- a/packages/benchmarks/multitask-bench/multitask_bench/scheduler.py
+++ b/packages/benchmarks/multitask-bench/multitask_bench/scheduler.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Callable
 
 from eliza_lifeops_bench.runner import AgentFactory, LifeOpsBenchRunner, WorldFactory
 from eliza_lifeops_bench.types import Scenario

--- a/packages/benchmarks/multitask-bench/multitask_bench/types.py
+++ b/packages/benchmarks/multitask-bench/multitask_bench/types.py
@@ -1,0 +1,65 @@
+"""Result records the scheduler produces and metrics/report consume.
+
+``TaskRun`` is the outcome of one LifeOps scenario driven by the shared agent
+under a given concurrency N; ``LaneResult`` bundles every task run at one N
+(the N=1 lane is the interference baseline). These are plain dataclasses — the
+transport-facing JSON shape lives in ``report.py``, kept separate so the
+runtime model and the on-disk contract can move independently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from eliza_lifeops_bench.types import ScenarioResult
+
+__all__ = ["TaskRun", "LaneResult"]
+
+
+@dataclass
+class TaskRun:
+    """One scenario run inside a wave, plus the scheduler-observed timing.
+
+    ``result`` is ``None`` only when the task never produced a
+    ``ScenarioResult`` — a wall-clock timeout the scheduler tripped before
+    ``run_one`` returned, or an unexpected exception. In both cases
+    ``terminated_reason`` carries the classification ("timeout"/"error") so
+    metrics never has to conflate a missing result with a zero score.
+    """
+
+    scenario_id: str
+    seed: int
+    wave_index: int
+    terminated_reason: str
+    task_wall_s: float
+    result: ScenarioResult | None = None
+
+    @property
+    def score(self) -> float:
+        """Per-task score in [0, 1]: ``total_score / max_score``.
+
+        A task with no result scored nothing — it timed out or errored before
+        the runner could evaluate it — so its contribution is 0.0. This is not
+        a fabricated success default: ``completed`` (see ``metrics``) gates on
+        ``terminated_reason``, so an incomplete task is never counted as a
+        healthy zero-scoring completion.
+        """
+        if self.result is None:
+            return 0.0
+        max_score = self.result.max_score or 1.0
+        return self.result.total_score / max_score
+
+    @property
+    def turns(self) -> int:
+        """Number of agent turns the task took (0 if it never ran)."""
+        return len(self.result.turns) if self.result is not None else 0
+
+
+@dataclass
+class LaneResult:
+    """Every task run at one concurrency level N."""
+
+    n: int
+    waves: int
+    tasks: list[TaskRun] = field(default_factory=list)
+    wall_clock_s: float = 0.0

--- a/packages/benchmarks/multitask-bench/pyproject.toml
+++ b/packages/benchmarks/multitask-bench/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "multitask-bench"
+version = "0.1.0"
+description = "MultitaskBench — one agent handling N interleaved LifeOps tasks; measures per-task interference at N=5/10 vs the N=1 baseline for elizaOS, Hermes, and OpenClaw harnesses."
+readme = "README.md"
+requires-python = ">=3.11,<3.13"
+
+dependencies = [
+  "eliza-lifeops-bench",
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest>=8.0.0",
+  "pytest-asyncio>=0.23.0",
+]
+
+[project.scripts]
+multitask-bench = "multitask_bench.__main__:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["multitask_bench"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+addopts = "-q"

--- a/packages/benchmarks/multitask-bench/tests/conftest.py
+++ b/packages/benchmarks/multitask-bench/tests/conftest.py
@@ -1,0 +1,48 @@
+"""Shared hermetic lane runs so the state-hash replay cost is paid once.
+
+Driving the frozen sample through the real LifeOpsBench runner replays
+ground-truth against the ~5000-entity medium snapshot per task, which is the
+dominant cost. The perfect/wrong lanes are deterministic, so we run each set of
+lanes once at session scope and let every test assert against the cached
+results rather than re-running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from multitask_bench.harness import build_agent_factory, build_world_factory
+from multitask_bench.sample import MULTITASK_SAMPLE
+from multitask_bench.scheduler import run_lane
+from multitask_bench.types import LaneResult
+
+
+async def _run_lanes(harness: str, ns: tuple[int, ...]) -> list[LaneResult]:
+    factory = build_agent_factory(harness)
+    world = build_world_factory()
+    lanes: list[LaneResult] = []
+    for n in ns:
+        lanes.append(
+            await run_lane(
+                n=n,
+                scenarios=MULTITASK_SAMPLE,
+                agent_factory=factory,
+                world_factory=world,
+                timeout_s=60.0,
+            )
+        )
+    return lanes
+
+
+@pytest.fixture(scope="session")
+def perfect_lanes() -> list[LaneResult]:
+    """N=1/5/10 lanes driven by the PerfectAgent oracle (deterministic)."""
+    return asyncio.run(_run_lanes("perfect", (1, 5, 10)))
+
+
+@pytest.fixture(scope="session")
+def wrong_lanes() -> list[LaneResult]:
+    """N=1/5 lanes driven by the WrongAgent oracle (deterministic)."""
+    return asyncio.run(_run_lanes("wrong", (1, 5)))

--- a/packages/benchmarks/multitask-bench/tests/test_metrics.py
+++ b/packages/benchmarks/multitask-bench/tests/test_metrics.py
@@ -1,0 +1,166 @@
+"""Unit coverage for the pure metric functions on synthetic task runs.
+
+Builds ``TaskRun`` records directly (with hand-made ``ScenarioResult`` /
+``TurnResult`` payloads) so Jain fairness, starvation classification,
+percentiles, and interference math are pinned independent of any live run.
+"""
+
+from __future__ import annotations
+
+import pytest
+from eliza_lifeops_bench.types import ScenarioResult, TurnResult
+
+from multitask_bench.metrics import (
+    compute_interference,
+    is_completed,
+    is_starved,
+    jain_fairness,
+    percentiles,
+)
+from multitask_bench.types import TaskRun
+
+
+def _turn(latency_ms: int | None = 10) -> TurnResult:
+    return TurnResult(
+        turn_number=1,
+        agent_message="",
+        agent_actions=[],
+        user_response="",
+        latency_ms=latency_ms,
+        input_tokens=5,
+        output_tokens=3,
+        cost_usd=0.001,
+        tool_results=[],
+    )
+
+
+def _result(
+    scenario_id: str,
+    *,
+    total_score: float,
+    reason: str,
+    turns: int,
+) -> ScenarioResult:
+    return ScenarioResult(
+        scenario_id=scenario_id,
+        seed=2026,
+        turns=[_turn() for _ in range(turns)],
+        state_hash_match=total_score >= 1.0,
+        output_substring_matches=[],
+        total_score=total_score,
+        max_score=1.0,
+        terminated_reason=reason,  # type: ignore[arg-type]
+        total_cost_usd=0.001 * turns,
+        total_latency_ms=10 * turns,
+    )
+
+
+def _task(
+    scenario_id: str,
+    *,
+    score: float = 1.0,
+    reason: str = "respond",
+    turns: int = 2,
+    wave: int = 0,
+    wall_s: float = 1.0,
+    with_result: bool = True,
+) -> TaskRun:
+    result = (
+        _result(scenario_id, total_score=score, reason=reason, turns=turns)
+        if with_result
+        else None
+    )
+    return TaskRun(
+        scenario_id=scenario_id,
+        seed=2026,
+        wave_index=wave,
+        terminated_reason=reason,
+        task_wall_s=wall_s,
+        result=result,
+    )
+
+
+def test_jain_fairness_edges() -> None:
+    assert jain_fairness([]) == 0.0
+    assert jain_fairness([0, 0, 0]) == 0.0
+    # Perfectly equal allocation.
+    assert jain_fairness([3, 3, 3]) == pytest.approx(1.0)
+    # Single task is trivially fair.
+    assert jain_fairness([7]) == pytest.approx(1.0)
+    # One task monopolizes: index approaches 1/n.
+    assert jain_fairness([10, 0, 0, 0]) == pytest.approx(0.25)
+
+
+def test_percentiles_nearest_rank() -> None:
+    empty = percentiles([])
+    assert empty == {"p50": 0.0, "p95": 0.0, "max": 0.0}
+    vals = [float(x) for x in range(1, 11)]  # 1..10
+    got = percentiles(vals)
+    assert got["max"] == 10.0
+    # Nearest-rank p50 of 10 samples = the 5th ordered value.
+    assert got["p50"] == 5.0
+    # p95 = the 10th (ceil(0.95*10)=10).
+    assert got["p95"] == 10.0
+
+
+def test_starvation_zero_turns_is_starved() -> None:
+    task = _task("a", turns=0, reason="timeout", with_result=False)
+    # A task that produced zero turns never got a slice — starved regardless of
+    # whether a peer completed.
+    assert is_starved(task, wave_had_completion=False) is True
+
+
+def test_starvation_timeout_needs_peer_completion() -> None:
+    timed_out = _task("a", reason="timeout", turns=3)
+    # Timed out with a completed peer → starved (agent served others).
+    assert is_starved(timed_out, wave_had_completion=True) is True
+    # Timed out but NO peer completed → the whole wave stalled, not starvation
+    # of this one task specifically.
+    assert is_starved(timed_out, wave_had_completion=False) is False
+
+
+def test_completed_gates_on_reason() -> None:
+    assert is_completed(_task("a", reason="respond")) is True
+    assert is_completed(_task("a", reason="max_turns")) is True
+    assert is_completed(_task("a", reason="timeout", with_result=False)) is False
+    assert is_completed(_task("a", reason="error", with_result=False)) is False
+
+
+def test_incomplete_task_scores_zero_not_fabricated() -> None:
+    task = _task("a", reason="timeout", with_result=False)
+    # No result → score 0.0, and it is NOT counted as completed.
+    assert task.score == 0.0
+    assert is_completed(task) is False
+
+
+def test_interference_requires_baseline() -> None:
+    lane5 = {"n": 5, "per_task": [{"scenario_id": "a", "seed": 2026, "score": 0.5}]}
+    with pytest.raises(ValueError, match="baseline"):
+        compute_interference([lane5])
+
+
+def test_interference_delta_over_matched_pairs() -> None:
+    lane1 = {
+        "n": 1,
+        "per_task": [
+            {"scenario_id": "a", "seed": 2026, "score": 1.0},
+            {"scenario_id": "b", "seed": 2026, "score": 1.0},
+        ],
+    }
+    lane5 = {
+        "n": 5,
+        "per_task": [
+            {"scenario_id": "a", "seed": 2026, "score": 0.5},
+            {"scenario_id": "b", "seed": 2026, "score": 0.5},
+        ],
+    }
+    deltas = compute_interference([lane1, lane5])
+    # Each task lost 0.5 under load → mean delta -0.5.
+    assert deltas["n5_minus_n1"] == pytest.approx(-0.5)
+
+
+def test_interference_no_shared_pairs_raises() -> None:
+    lane1 = {"n": 1, "per_task": [{"scenario_id": "a", "seed": 2026, "score": 1.0}]}
+    lane5 = {"n": 5, "per_task": [{"scenario_id": "z", "seed": 9, "score": 0.5}]}
+    with pytest.raises(ValueError, match="shares no"):
+        compute_interference([lane1, lane5])

--- a/packages/benchmarks/multitask-bench/tests/test_report.py
+++ b/packages/benchmarks/multitask-bench/tests/test_report.py
@@ -1,0 +1,104 @@
+"""Report assembly + on-disk schema round-trip, plus sample validation.
+
+Runs the hermetic perfect harness through the real scheduler, builds the
+report, writes it, reads it back, and asserts the exact top-level and per-lane
+key set the registry scorer depends on — so a schema drift fails here rather
+than silently at score-extraction time.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from multitask_bench.report import build_report, write_report
+from multitask_bench.sample import (
+    MULTITASK_SAMPLE,
+    MULTITASK_SCENARIO_IDS,
+    sample_seed,
+)
+
+_TOP_KEYS = {
+    "benchmark",
+    "harness",
+    "isolation",
+    "model",
+    "sample",
+    "lanes",
+    "interference",
+    "timestamp",
+}
+_LANE_KEYS = {
+    "n",
+    "arrival",
+    "waves",
+    "tasks_total",
+    "tasks_completed",
+    "completion_rate",
+    "mean_task_score",
+    "throughput_tasks_per_min",
+    "wall_clock_s",
+    "turn_latency_ms",
+    "task_wall_s",
+    "cost_usd",
+    "tokens",
+    "starved_tasks",
+    "starvation_rate",
+    "fairness_turns_jain",
+    "lifecycle_events",
+    "per_task",
+}
+
+
+def test_sample_is_ten_distinct_static_scenarios() -> None:
+    assert len(MULTITASK_SCENARIO_IDS) == 10
+    assert len(set(MULTITASK_SCENARIO_IDS)) == 10
+    assert [s.id for s in MULTITASK_SAMPLE] == MULTITASK_SCENARIO_IDS
+    # Every sample scenario is STATIC (no judge / simulated user).
+    for s in MULTITASK_SAMPLE:
+        assert s.mode.name == "STATIC", f"{s.id} is not STATIC"
+    # Ten distinct domains, one per surface.
+    assert len({s.domain for s in MULTITASK_SAMPLE}) == 10
+    # Seed is the scenario's world_seed (no per-lane offset).
+    for s in MULTITASK_SAMPLE:
+        assert sample_seed(s) == s.world_seed
+
+
+def test_report_round_trips_with_expected_schema(perfect_lanes, tmp_path) -> None:
+    report = build_report(
+        harness="perfect",
+        model="oracle",
+        lanes=perfect_lanes,
+        scenario_ids=MULTITASK_SCENARIO_IDS,
+    )
+    assert set(report.keys()) == _TOP_KEYS
+    assert report["benchmark"] == "multitask_bench"
+    assert report["isolation"] == "shared_runtime"
+    assert set(report["interference"].keys()) == {"n5_minus_n1", "n10_minus_n1"}
+
+    lane_block = report["lanes"]
+    assert [lane["n"] for lane in lane_block] == [1, 5, 10]
+    for lane in lane_block:
+        assert set(lane.keys()) == _LANE_KEYS
+        assert lane["arrival"] == "batch"
+        assert set(lane["cost_usd"].keys()) == {"total", "per_completed_task"}
+        assert set(lane["tokens"].keys()) == {"prompt", "completion"}
+        assert set(lane["turn_latency_ms"].keys()) == {"p50", "p95", "max"}
+        assert len(lane["per_task"]) == lane["tasks_total"]
+
+    path = write_report(report, tmp_path)
+    assert path.exists()
+    round_tripped = json.loads(path.read_text(encoding="utf-8"))
+    assert round_tripped["benchmark"] == "multitask_bench"
+    assert set(round_tripped.keys()) == _TOP_KEYS
+
+
+def test_unknown_harness_rejected() -> None:
+    with pytest.raises(ValueError, match="unknown harness"):
+        build_report(
+            harness="nope",
+            model="x",
+            lanes=[],
+            scenario_ids=MULTITASK_SCENARIO_IDS,
+        )

--- a/packages/benchmarks/multitask-bench/tests/test_scheduler.py
+++ b/packages/benchmarks/multitask-bench/tests/test_scheduler.py
@@ -1,0 +1,71 @@
+"""Wave-partitioning determinism and the hermetic Perfect/Wrong lane runs.
+
+Drives the real scheduler + the real LifeOpsBench runner through the frozen
+sample with the deterministic Perfect/Wrong oracles (no model, no keys), so
+these assertions exercise the actual concurrency path rather than a mock of it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from multitask_bench.metrics import compute_interference, compute_lane_metrics
+from multitask_bench.sample import MULTITASK_SAMPLE
+from multitask_bench.scheduler import partition_waves
+
+
+def test_partition_waves_is_deterministic_and_exact() -> None:
+    scenarios = MULTITASK_SAMPLE
+    assert len(scenarios) == 10
+
+    n1 = partition_waves(scenarios, 1)
+    assert len(n1) == 10
+    assert all(len(w) == 1 for w in n1)
+
+    n5 = partition_waves(scenarios, 5)
+    assert len(n5) == 2
+    assert [len(w) for w in n5] == [5, 5]
+
+    n10 = partition_waves(scenarios, 10)
+    assert len(n10) == 1
+    assert len(n10[0]) == 10
+
+    # Same sample + N always slices identically — this is what lets the
+    # interference delta line up (scenario, seed) pairs across lanes.
+    assert partition_waves(scenarios, 5) == n5
+    # Wave order preserves sample order.
+    assert [s.id for w in n5 for s in w] == [s.id for s in scenarios]
+
+
+def test_partition_waves_rejects_zero() -> None:
+    with pytest.raises(ValueError):
+        partition_waves(MULTITASK_SAMPLE, 0)
+
+
+def test_perfect_lane_scores_one_with_no_interference(perfect_lanes) -> None:
+    metrics = [compute_lane_metrics(lane) for lane in perfect_lanes]
+    assert [m["n"] for m in metrics] == [1, 5, 10]
+    for m in metrics:
+        assert m["tasks_completed"] == 10
+        assert m["completion_rate"] == 1.0
+        assert m["mean_task_score"] == pytest.approx(1.0)
+        assert m["starved_tasks"] == 0
+
+    interference = compute_interference(metrics)
+    # A perfect oracle scores each task identically alone and under load, so
+    # every interference delta is exactly zero.
+    assert interference["n5_minus_n1"] == pytest.approx(0.0)
+    assert interference["n10_minus_n1"] == pytest.approx(0.0)
+
+
+def test_wrong_lane_scores_zero_with_no_starvation(wrong_lanes) -> None:
+    metrics = [compute_lane_metrics(lane) for lane in wrong_lanes]
+    for m in metrics:
+        # Wrong agent terminates cleanly (a refusal), so tasks complete but
+        # score zero — this is a completed zero, never a starved/timed-out one.
+        assert m["tasks_completed"] == 10
+        assert m["mean_task_score"] == pytest.approx(0.0)
+        assert m["starved_tasks"] == 0
+
+    interference = compute_interference(metrics)
+    assert interference["n5_minus_n1"] == pytest.approx(0.0)

--- a/packages/benchmarks/orchestrator/adapters.py
+++ b/packages/benchmarks/orchestrator/adapters.py
@@ -834,6 +834,12 @@ def _make_registry_adapter(
         adapter_python_paths.append(str((benchmarks_root / "gauntlet" / "src").resolve()))
     if benchmark_id == "mmau":
         adapter_python_paths.append(str((benchmarks_root / "mmau-audio").resolve()))
+    if benchmark_id == "multitask_bench":
+        # multitask_bench imports orchestrator_lifecycle.events (lifecycle-event
+        # extraction), a namespace package rooted at packages/benchmarks. It
+        # runs with cwd=multitask-bench, so that root is not otherwise on the
+        # path.
+        adapter_python_paths.append(str(benchmarks_root.resolve()))
 
     def env_builder(ctx: ExecutionContext, adapter: BenchmarkAdapter) -> dict[str, str]:
         existing = ctx.env.get("PYTHONPATH", "")
@@ -2416,6 +2422,11 @@ def discover_adapters(workspace_root: Path) -> AdapterDiscovery:
             "concurrency": 1,
             "seeds": 1,
         },
+        "multitask_bench": {
+            # Cheapest interference-shaped smoke: the N=1 baseline plus one
+            # small wave, so the delta path is exercised without a 10-wide run.
+            "lanes": "1,5",
+        },
         "realm": {
             "categories": ["P11"],
             "max_tasks": 1,
@@ -2573,6 +2584,7 @@ def discover_adapters(workspace_root: Path) -> AdapterDiscovery:
         "hyperliquid_bench": "HyperliquidBench",
         "openclaw_bench": "openclaw-benchmark",
         "lifeops_bench": "lifeops-bench",
+        "multitask_bench": "multitask-bench",
         "voicebench_quality": "voicebench-quality",
         "vision_language": "vision-language",
         "recall_bench": "recall-bench",

--- a/packages/benchmarks/registry/commands.py
+++ b/packages/benchmarks/registry/commands.py
@@ -32,6 +32,7 @@ try:
         _score_from_meeting_transcription_proof_json,
         _score_from_mind2web_json,
         _score_from_mint_json,
+        _score_from_multitask_bench_json,
         _score_from_mmau_json,
         _score_from_mmlu_json,
         _score_from_mt_bench_json,
@@ -86,6 +87,7 @@ except ImportError:
         _score_from_meeting_transcription_proof_json,
         _score_from_mind2web_json,
         _score_from_mint_json,
+        _score_from_multitask_bench_json,
         _score_from_mmau_json,
         _score_from_mmlu_json,
         _score_from_mt_bench_json,
@@ -2116,6 +2118,68 @@ def get_benchmark_registry(repo_root: Path) -> list[BenchmarkDefinition]:
     def _lifeops_bench_result(output_dir: Path) -> Path:
         return find_latest_file(output_dir, glob_pattern="lifeops_*.json")
 
+    # multitask_bench
+    def _multitask_bench_cmd(
+        output_dir: Path, model: ModelSpec, extra: Mapping[str, JSONValue]
+    ) -> list[str]:
+        """Build the MultitaskBench CLI invocation.
+
+        ``extra["harness"]`` (or ``model.model``) selects the harness: STATIC
+        live harnesses ``eliza`` / ``hermes`` / ``openclaw`` need a Cerebras
+        key; ``perfect`` / ``wrong`` are hermetic oracles. ``extra["lanes"]``
+        (default "1,5,10") sets the concurrency levels; the N=1 baseline is
+        required for the interference deltas.
+        """
+        harness_raw = extra.get("harness") or extra.get("agent")
+        if isinstance(harness_raw, str) and harness_raw.strip():
+            harness = harness_raw.strip()
+        elif model.model in {"eliza", "hermes", "openclaw", "perfect", "wrong"}:
+            harness = str(model.model)
+        elif (model.provider or "").strip().lower() in {
+            "cerebras",
+            "openai",
+            "groq",
+            "openrouter",
+            "vllm",
+            "eliza",
+        }:
+            harness = "eliza"
+        else:
+            harness = "perfect"
+
+        lanes_raw = extra.get("lanes")
+        lanes = lanes_raw.strip() if isinstance(lanes_raw, str) and lanes_raw.strip() else "1,5,10"
+
+        args = [
+            python,
+            "-m",
+            "multitask_bench",
+            "--harness",
+            harness,
+            "--lanes",
+            lanes,
+            "--output-dir",
+            str(output_dir),
+        ]
+        model_name = extra.get("model_name") or model.model
+        if isinstance(model_name, str) and model_name.strip() and model_name.strip() not in {
+            "eliza",
+            "hermes",
+            "openclaw",
+            "perfect",
+            "wrong",
+        }:
+            args.extend(["--model", model_name.strip()])
+        per_task_timeout_s = extra.get("per_task_timeout_s")
+        if isinstance(per_task_timeout_s, (int, float)) and not isinstance(
+            per_task_timeout_s, bool
+        ):
+            args.extend(["--per-task-timeout-s", str(float(per_task_timeout_s))])
+        return args
+
+    def _multitask_bench_result(output_dir: Path) -> Path:
+        return find_latest_file(output_dir, glob_pattern="multitask_*.json")
+
     # voiceagentbench
     def _voiceagentbench_cmd(
         output_dir: Path, model: ModelSpec, extra: Mapping[str, JSONValue]
@@ -2912,6 +2976,34 @@ def get_benchmark_registry(repo_root: Path) -> list[BenchmarkDefinition]:
             build_command=_lifeops_bench_cmd,
             locate_result=_lifeops_bench_result,
             extract_score=_score_from_lifeops_bench_json,
+        ),
+        BenchmarkDefinition(
+            id="multitask_bench",
+            display_name="MultitaskBench",
+            description="One agent handling N interleaved LifeOps tasks (N=1/5/10); per-task score interference under load for eliza/hermes/openclaw",
+            cwd_rel="packages/benchmarks/multitask-bench",
+            requirements=BenchmarkRequirements(
+                env_vars=("CEREBRAS_API_KEY",),
+                paths=(
+                    "packages/benchmarks/multitask-bench/multitask_bench",
+                    "packages/benchmarks/lifeops-bench/eliza_lifeops_bench",
+                    "packages/benchmarks/lifeops-bench/data/snapshots",
+                ),
+                notes=(
+                    "extra.harness (or model.model) selects the harness: 'perfect'/'wrong' for hermetic oracle runs (no env vars needed); "
+                    "'eliza'/'hermes'/'openclaw' for live adapters. "
+                    "STATIC-only sample (10 scenarios) — no ANTHROPIC key or LIVE judge needed. "
+                    "CEREBRAS_API_KEY is required for the live harnesses (agent model gemma-4-31b). "
+                    "The eliza live lane also needs the per-session usage-buffer fix in packages/lifeops-bench/src/server.ts (issue #13777 PR 1); "
+                    "set MULTITASK_ELIZA_USAGE_FIX=1 once it is in tree. "
+                    "extra.lanes (default '1,5,10') sets concurrency; N=1 is the interference baseline and is required. "
+                    "isolation is 'shared_runtime' for eliza, 'process_per_turn' for hermes/openclaw. "
+                    "Score: mean_task_score of the N=10 lane. Higher is better."
+                ),
+            ),
+            build_command=_multitask_bench_cmd,
+            locate_result=_multitask_bench_result,
+            extract_score=_score_from_multitask_bench_json,
         ),
         BenchmarkDefinition(
             id="voiceagentbench",

--- a/packages/benchmarks/registry/scores.py
+++ b/packages/benchmarks/registry/scores.py
@@ -1668,6 +1668,69 @@ def _score_from_lifeops_bench_json(data: JSONValue) -> ScoreExtraction:
     )
 
 
+def _score_from_multitask_bench_json(data: JSONValue) -> ScoreExtraction:
+    """Extract MultitaskBench score from its ``multitask_<timestamp>.json``.
+
+    The scalar registry score is the ``mean_task_score`` of the N=10 lane —
+    how well the shared agent scores each task when handling 10 at once. The
+    interference deltas (mean task score @N minus @1) are the real headline and
+    ride along in ``metrics``. Higher is better; unit is ratio.
+
+    Validates that the report is a real MultitaskBench run: the benchmark tag,
+    a non-empty ``lanes`` array containing the N=10 lane, and the
+    ``interference`` block must all be present, and the run must not be a
+    hermetic oracle (perfect/wrong) — an oracle report is not a publishable
+    harness score.
+    """
+    root = expect_dict(data, ctx="multitask_bench:root")
+    benchmark = get_optional(root, "benchmark")
+    if str(benchmark) != "multitask_bench":
+        raise ValueError(
+            f"multitask_bench:benchmark must be 'multitask_bench', got {benchmark!r}"
+        )
+    harness = str(get_optional(root, "harness") or "").strip().lower()
+    if harness in {"perfect", "wrong"}:
+        raise ValueError(
+            f"multitask_bench: {harness!r} oracle result is not publishable as a real harness score"
+        )
+    lanes = get_optional(root, "lanes")
+    if not isinstance(lanes, list) or not lanes:
+        raise ValueError("multitask_bench:lanes must contain at least one lane")
+    interference = get_optional(root, "interference")
+    if not isinstance(interference, dict):
+        raise ValueError("multitask_bench:interference block is required")
+
+    lane_by_n: dict[int, dict[str, JSONValue]] = {}
+    for lane in lanes:
+        lane_dict = expect_dict(lane, ctx="multitask_bench:lane")
+        n_val = get_required(lane_dict, "n", ctx="multitask_bench:lane")
+        lane_by_n[int(expect_float(n_val, ctx="multitask_bench:lane.n"))] = lane_dict
+    n10 = lane_by_n.get(10)
+    if n10 is None:
+        raise ValueError("multitask_bench: the N=10 lane is required for the scalar score")
+    mean_task_score = expect_float(
+        get_required(n10, "mean_task_score", ctx="multitask_bench:n10"),
+        ctx="multitask_bench:n10.mean_task_score",
+    )
+    return ScoreExtraction(
+        score=mean_task_score,
+        unit="ratio",
+        higher_is_better=True,
+        metrics={
+            "mean_task_score_n10": mean_task_score,
+            "harness": harness,
+            "isolation": get_optional(root, "isolation") or "",
+            "model": get_optional(root, "model") or "",
+            "interference": interference,
+            "completion_rate_n10": get_optional(n10, "completion_rate") or 0,
+            "starvation_rate_n10": get_optional(n10, "starvation_rate") or 0,
+            "fairness_turns_jain_n10": get_optional(n10, "fairness_turns_jain") or 0,
+            "cost_usd_n10": get_optional(n10, "cost_usd") or {},
+            "lane_count": len(lanes),
+        },
+    )
+
+
 def _score_from_voiceagentbench_json(data: JSONValue) -> ScoreExtraction:
     """Extract VoiceAgentBench score from its aggregate report JSON.
 


### PR DESCRIPTION
## What

New `packages/benchmarks/multitask-bench` package: measures the **interference**
one long-lived agent incurs when driving **N interleaved LifeOps tasks at once**
(N=5, N=10) versus one at a time (N=1). Reuses `lifeops-bench` — each task is one
STATIC LifeOps scenario driven through `LifeOpsBenchRunner.run_one` — plus the
registry entry + scorer and a hermetic no-key test/smoke path.

This is PR 2 (the package) of the three-PR plan on the issue. It implements the
approved D4 decision: **one shared agent + per-session attribution**, not N
servers (N servers = N agents, a different claim).

## Why / design

- **Unit under test:** the shared `agent_fn` contract. Per harness, one
  long-lived client drives N tasks; `agent_factory` mints a fresh `agent_fn`
  (fresh session) per task.
- **Isolation is disclosed, never erased.** `eliza` = `shared_runtime` (N
  sessions contend for one `AgentRuntime`); `hermes`/`openclaw` =
  `process_per_turn` (process-isolated, interference = shared rate/cost budget
  only). Every report carries the `isolation` tag.
- **Batch waves of exactly N** at t=0 (`sample[k*N:(k+1)*N]`), run concurrently
  via `asyncio.gather`. N=1 is 10 sequential single-task waves — the
  interference baseline every delta subtracts against.
- **Frozen 10-scenario STATIC sample**: 5 SMOKE ids + 5 CORE STATIC ids across
  the remaining domains, validated against `SCENARIOS_BY_ID` at import, seeded by
  each scenario's `world_seed` so every lane scores the identical `(scenario,
  seed)` pair.
- **Metrics:** `completion_rate`, `mean_task_score`, interference deltas
  (`n5_minus_n1` / `n10_minus_n1`, the headline), `throughput_tasks_per_min`,
  `turn_latency_ms`/`task_wall_s` p50/p95/max, `cost_usd{total,per_completed_task}`,
  `tokens`, `starved_tasks`/`starvation_rate` (timeout-while-peer-completed OR
  zero turns), `fairness_turns_jain` (Jain over per-wave turn counts), and
  `lifecycle_events` via `orchestrator_lifecycle.events.extract_lifecycle_events`.
- **Registry scalar score** = `mean_task_score` of the N=10 lane. The scorer
  rejects `perfect`/`wrong` oracle reports (not publishable).

## Dependency on the eliza server fix (PR 1)

The eliza live lane's per-session usage attribution needs the AsyncLocalStorage
fix in `packages/lifeops-bench/src/server.ts` (issue #13777 PR 1 — no sibling PR
open yet at time of writing). Until it lands, MODEL_USED events from overlapping
sessions land in one global buffer and per-task cost/token attribution is wrong,
so the eliza lane is **gated behind `MULTITASK_ELIZA_USAGE_FIX=1`** and raises a
clear `SystemExit` otherwise. `hermes`/`openclaw`/`perfect`/`wrong` lanes are
unaffected.

## Files

- `packages/benchmarks/multitask-bench/multitask_bench/` — `sample.py`,
  `scheduler.py`, `metrics.py`, `report.py`, `harness.py`, `types.py`,
  `__main__.py`, `__init__.py`; `pyproject.toml`, `conftest.py`, `README.md`,
  `tests/`.
- `packages/benchmarks/registry/scores.py` — `_score_from_multitask_bench_json`.
- `packages/benchmarks/registry/commands.py` — `_multitask_bench_cmd` +
  `_multitask_bench_result` + `BenchmarkDefinition(id="multitask_bench")`
  (`CEREBRAS_API_KEY` only — STATIC, no ANTHROPIC judge).
- `packages/benchmarks/orchestrator/adapters.py` — id→dir map
  (`multitask_bench`→`multitask-bench`), smoke default (`lanes: "1,5"`), and
  `benchmarks_root` on PYTHONPATH for `orchestrator_lifecycle`.

## Evidence

### Real-LLM trajectories
`needs-human [live model keys]` — no `CEREBRAS_API_KEY`/`OPENAI_*` in this env.
The live 5/10-task per-harness runs (eliza after PR 1) are PR 3. The eliza live
lane additionally requires the server fix.

### Hermetic tests — 16 passed (real scheduler + runner, no mocks)

```
$ python3 -m pytest packages/benchmarks/multitask-bench/tests/ -v
tests/test_metrics.py::test_jain_fairness_edges
tests/test_metrics.py::test_percentiles_nearest_rank
tests/test_metrics.py::test_starvation_zero_turns_is_starved
tests/test_metrics.py::test_starvation_timeout_needs_peer_completion
tests/test_metrics.py::test_completed_gates_on_reason
tests/test_metrics.py::test_incomplete_task_scores_zero_not_fabricated
tests/test_metrics.py::test_interference_requires_baseline
tests/test_metrics.py::test_interference_delta_over_matched_pairs
tests/test_metrics.py::test_interference_no_shared_pairs_raises
tests/test_report.py::test_sample_is_ten_distinct_static_scenarios
tests/test_report.py::test_report_round_trips_with_expected_schema
tests/test_report.py::test_unknown_harness_rejected
tests/test_scheduler.py::test_partition_waves_is_deterministic_and_exact
tests/test_scheduler.py::test_partition_waves_rejects_zero
tests/test_scheduler.py::test_perfect_lane_scores_one_with_no_interference
tests/test_scheduler.py::test_wrong_lane_scores_zero_with_no_starvation
============================= 16 passed in 24.19s ==============================
```

The Perfect/Wrong lane tests drive the **real** scheduler + `LifeOpsBenchRunner`
through the frozen sample (deterministic oracle agent, no model/keys), not a mock
of the thing under test.

### Perfect-harness smoke (real scheduler, N=1/5/10)

Committed to `.github/issue-evidence/13777-multitask-perfect-*`:

```
[multitask] harness=perfect isolation=shared_runtime
[multitask] N=1   completed=10/10 mean_score=1.000 starved=0 jain=1.000
[multitask] N=5   completed=10/10 mean_score=1.000 starved=0 jain=1.000
[multitask] N=10  completed=10/10 mean_score=1.000 starved=0 jain=1.000
[multitask] interference n5_minus_n1=+0.000
[multitask] interference n10_minus_n1=+0.000
```

Perfect oracle → completion 1.0 at every N, all interference deltas exactly
0.0, zero starvation, Jain 1.0 — the design's conformance contract. Wrong oracle
→ `mean_score=0.000`, zero starved (a completed zero, never a starved timeout).

### Registry registration

```
$ python3 -m benchmarks.orchestrator list-benchmarks | grep multitask
- multitask_bench  dir=multitask-bench    cwd=.../packages/benchmarks/multitask-bench
```

Full registry path verified end-to-end: `locate_result` finds
`multitask_<ts>.json`, `extract_score` returns the N=10 `mean_task_score` (and
rejects oracle harnesses), `build_command` emits
`--harness eliza --lanes 1,5,10 --model gemma-4-31b` for a Cerebras request.

### Lint
`ruff check` clean on all new package files.

### Frontend / native / voice / audio
N/A — Python benchmark harness, no UI/device/audio surface.

Part of #13777

🤖 Generated with [Claude Code](https://claude.com/claude-code)
