### PR TITLE
fix(#13686): harden iOS XCUITest reset proof

### DIFF
--- a/.github/issue-evidence/13686-ios-xcuitest-shards/README.md
+++ b/.github/issue-evidence/13686-ios-xcuitest-shards/README.md
@@ -63,3 +63,29 @@ Reviewed the changed code paths by hand:
 - Both onboarding tests are separate shards, so cloud and local first-run paths start from clean containers.
 - `DeviceLifecycleUITests` remains one class shard, preserving its intentional within-test persistence assertions.
 - `--only-testing AppUITests/<Class>[/test]` remains a single-shard override for narrow/manual runs.
+
+## Follow-Up After PR #13806 Review
+
+Reviewer blockers addressed in follow-up branch `fix/13686-xcuitest-reset-proof`:
+
+- Reset/uninstall is no longer best-effort. Simulator/device uninstall failures now fail the run unless the command output explicitly says the app was already absent.
+- Simulator shard summaries now include fresh-container proof from `simctl get_app_container` and `simctl listapps -j` after reinstall.
+- Default full-run shard planning now validates the committed Swift `AppUITests` sources. A new test method is either covered by a class shard or must be added as a per-test shard, otherwise the capture script fails before running.
+
+Follow-up verification:
+
+```bash
+bun run --cwd packages/app test scripts/ios-device-lib.test.mjs
+bunx biome check packages/app/scripts/ios-device-capture.mjs packages/app/scripts/ios-device-lib.mjs packages/app/scripts/ios-device-lib.test.mjs
+node --check packages/app/scripts/ios-device-capture.mjs
+node --check packages/app/scripts/ios-device-lib.mjs
+node --check packages/app/scripts/ios-device-lib.test.mjs
+git diff --check
+```
+
+Results:
+
+- Package Vitest: `1 passed (1)`, `76 passed (76)`.
+- Biome focused check: `Checked 3 files in 89ms. No fixes applied.`
+- Node syntax checks: passed.
+- Diff whitespace check: passed.

--- a/packages/app/scripts/ios-device-capture.mjs
+++ b/packages/app/scripts/ios-device-capture.mjs
@@ -45,8 +45,11 @@ import {
   classifyIsolatedReruns,
   DEFAULT_APP_BUNDLE_ID,
   evaluateRunnerStaleness,
+  extractSwiftXcuitestEntries,
   extractXctestrunAppPaths,
   findDeviceRecord,
+  findUncoveredIosXcuitestEntries,
+  isBenignIosAppAbsence,
   parseCliArgs,
   parseFailedTestIdentifiers,
   parsePlist,
@@ -76,9 +79,27 @@ function runInherit(command, args, options = {}) {
   }
 }
 
-function tryRun(command, args, options = {}) {
-  const result = spawnSync(command, args, { stdio: "ignore", ...options });
-  return result.status === 0;
+function runResetCommand(command, args, { label, allowAbsentApp = false }) {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+  if (result.status === 0) {
+    return { ok: true, benignAbsent: false, output: output.trim() };
+  }
+  if (allowAbsentApp && isBenignIosAppAbsence(output)) {
+    log(`${label}: already absent (${output.trim() || "no output"})`);
+    return { ok: false, benignAbsent: true, output: output.trim() };
+  }
+  fail(
+    `${label} failed with exit ${result.status}.\n${output.trim() || "(no output)"}`,
+  );
+}
+
+function runCaptureCommand(command, args, { label, required = true } = {}) {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+  if (result.status === 0) return result.stdout.trim();
+  if (!required) return null;
+  fail(`${label} failed with exit ${result.status}.\n${output.trim()}`);
 }
 
 /**
@@ -208,7 +229,11 @@ function collectAppUITestsSources(sourceDir = APPUITESTS_SOURCE_DIR) {
     .filter((name) => name.endsWith(".swift"))
     .map((name) => {
       const full = path.join(sourceDir, name);
-      return { path: full, mtimeMs: fs.statSync(full).mtimeMs };
+      return {
+        path: full,
+        mtimeMs: fs.statSync(full).mtimeMs,
+        text: fs.readFileSync(full, "utf8"),
+      };
     });
 }
 
@@ -510,11 +535,56 @@ async function main() {
   }
   log(`destination: ${destination}`);
 
+  const captureSimulatorContainerProof = (label) => {
+    const appContainer = runCaptureCommand(
+      "xcrun",
+      ["simctl", "get_app_container", simUdid, bundleId, "app"],
+      { label: `reset ${label}: get app container` },
+    );
+    const dataContainer = runCaptureCommand(
+      "xcrun",
+      ["simctl", "get_app_container", simUdid, bundleId, "data"],
+      { label: `reset ${label}: get data container`, required: false },
+    );
+    const listappsRaw = runCaptureCommand(
+      "xcrun",
+      ["simctl", "listapps", "-j", simUdid],
+      { label: `reset ${label}: listapps proof` },
+    );
+    let listappsEntry = null;
+    try {
+      const parsed = JSON.parse(listappsRaw);
+      listappsEntry = parsed?.[bundleId] ?? null;
+    } catch (error) {
+      fail(
+        `reset ${label}: could not parse simctl listapps proof (${error?.message ?? error})`,
+      );
+    }
+    if (!listappsEntry) {
+      fail(`reset ${label}: ${bundleId} missing from simctl listapps proof`);
+    }
+    return {
+      appContainer,
+      dataContainer,
+      listappsEntry,
+    };
+  };
+
   const resetAppContainer = (label) => {
     if (platform === "sim") {
       log(`reset ${label}: terminate/uninstall ${bundleId} on simulator`);
-      tryRun("xcrun", ["simctl", "terminate", simUdid, bundleId]);
-      tryRun("xcrun", ["simctl", "uninstall", simUdid, bundleId]);
+      runResetCommand("xcrun", ["simctl", "terminate", simUdid, bundleId], {
+        label: `reset ${label}: simctl terminate`,
+        allowAbsentApp: true,
+      });
+      const uninstall = runResetCommand(
+        "xcrun",
+        ["simctl", "uninstall", simUdid, bundleId],
+        {
+          label: `reset ${label}: simctl uninstall`,
+          allowAbsentApp: true,
+        },
+      );
       for (const bundle of installableBundles) {
         log(`reset ${label}: simctl install ${path.basename(bundle)}`);
         runInherit("xcrun", ["simctl", "install", simUdid, bundle]);
@@ -522,20 +592,29 @@ async function main() {
       return {
         platform,
         bundleId,
+        uninstall,
         action: "simctl terminate/uninstall + install xctestrun bundles",
+        containerProof: captureSimulatorContainerProof(label),
       };
     }
 
     log(`reset ${label}: uninstall ${bundleId} on device`);
-    tryRun("xcrun", [
-      "devicectl",
-      "device",
-      "uninstall",
-      "app",
-      "--device",
-      deviceControlId,
-      bundleId,
-    ]);
+    const uninstall = runResetCommand(
+      "xcrun",
+      [
+        "devicectl",
+        "device",
+        "uninstall",
+        "app",
+        "--device",
+        deviceControlId,
+        bundleId,
+      ],
+      {
+        label: `reset ${label}: devicectl uninstall`,
+        allowAbsentApp: true,
+      },
+    );
     if (args["app-path"]) {
       const signedApp = path.resolve(args["app-path"]);
       log(`reset ${label}: devicectl install ${path.basename(signedApp)}`);
@@ -552,6 +631,7 @@ async function main() {
     return {
       platform,
       bundleId,
+      uninstall,
       action: args["app-path"]
         ? "devicectl uninstall + install signed app"
         : "devicectl uninstall; xcodebuild installs the target app",
@@ -566,6 +646,19 @@ async function main() {
   const shardPlan = buildIosXcuitestShardPlan({
     onlyTesting: args["only-testing"] || "AppUITests",
   });
+  if (!args["only-testing"]) {
+    const uncovered = findUncoveredIosXcuitestEntries({
+      entries: extractSwiftXcuitestEntries(collectAppUITestsSources()),
+      shards: shardPlan.map((shard) => shard.identifier),
+    });
+    if (uncovered.length > 0) {
+      fail(
+        "default AppUITests shard plan is missing committed XCTest coverage:\n" +
+          uncovered.map((identifier) => `  - ${identifier}`).join("\n") +
+          "\nAdd a class shard or per-test shard before this lane can run.",
+      );
+    }
+  }
   const harnessEnv = {
     ...process.env,
     TEST_RUNNER_ELIZA_BOOT_TIMEOUT_SECONDS:

--- a/packages/app/scripts/ios-device-lib.mjs
+++ b/packages/app/scripts/ios-device-lib.mjs
@@ -783,6 +783,49 @@ export function buildIosXcuitestShardPlan({
   }));
 }
 
+export function extractSwiftXcuitestEntries(sources) {
+  const entries = [];
+  for (const source of sources ?? []) {
+    const text = source?.text;
+    if (typeof text !== "string") continue;
+    const classMatch = text.match(
+      /\b(?:final\s+)?class\s+(\w+)\s*:\s*XCTestCase\b/,
+    );
+    if (!classMatch) continue;
+    const className = classMatch[1];
+    const methods = [...text.matchAll(/\bfunc\s+(test\w+)\s*\(/g)].map(
+      (match) => match[1],
+    );
+    entries.push({
+      className,
+      methods,
+      path: typeof source.path === "string" ? source.path : null,
+    });
+  }
+  return entries;
+}
+
+export function findUncoveredIosXcuitestEntries({ entries, shards }) {
+  const shardSet = new Set(shards ?? []);
+  const uncovered = [];
+  for (const entry of entries ?? []) {
+    if (!entry?.className) continue;
+    const classShard = `AppUITests/${entry.className}`;
+    if (shardSet.has(classShard)) continue;
+    for (const method of entry.methods ?? []) {
+      const methodShard = `${classShard}/${method}`;
+      if (!shardSet.has(methodShard)) uncovered.push(methodShard);
+    }
+  }
+  return uncovered;
+}
+
+export function isBenignIosAppAbsence(output) {
+  return /not installed|not found|no such app|unknown application|does not exist|could not find/i.test(
+    String(output ?? ""),
+  );
+}
+
 /**
  * Boot-trace files inside the app data container, pulled by
  * `ios-device-logs.mjs --pull-boot-trace`.

--- a/packages/app/scripts/ios-device-lib.test.mjs
+++ b/packages/app/scripts/ios-device-lib.test.mjs
@@ -18,8 +18,11 @@ import {
   DEFAULT_IOS_XCUITEST_SHARDS,
   deriveSigningEntitlements,
   evaluateRunnerStaleness,
+  extractSwiftXcuitestEntries,
   extractXctestrunAppPaths,
   findDeviceRecord,
+  findUncoveredIosXcuitestEntries,
+  isBenignIosAppAbsence,
   normalizeProvisioningProfile,
   PlistData,
   parseCliArgs,
@@ -1090,6 +1093,60 @@ describe("buildIosXcuitestShardPlan (#13686)", () => {
   it("sanitizes shard names for filesystem-safe result paths", () => {
     expect(safeShardName("AppUITests/Foo Bar/testThing()")).toBe(
       "Foo_Bar_testThing",
+    );
+  });
+
+  it("finds committed XCTest methods not covered by the default shard plan", () => {
+    const entries = extractSwiftXcuitestEntries([
+      {
+        path: "BootCaptureUITests.swift",
+        text: `
+          import XCTest
+          final class BootCaptureUITests: XCTestCase {
+            func testCloudOnboardingChatAndVoice() throws {}
+            func testNewCoverageMustBeListed() throws {}
+          }
+        `,
+      },
+      {
+        path: "GestureSemanticsUITests.swift",
+        text: `
+          final class GestureSemanticsUITests: XCTestCase {
+            func testAnyFutureMethodIsCoveredByClassShard() throws {}
+          }
+        `,
+      },
+    ]);
+    expect(entries).toEqual([
+      {
+        className: "BootCaptureUITests",
+        methods: [
+          "testCloudOnboardingChatAndVoice",
+          "testNewCoverageMustBeListed",
+        ],
+        path: "BootCaptureUITests.swift",
+      },
+      {
+        className: "GestureSemanticsUITests",
+        methods: ["testAnyFutureMethodIsCoveredByClassShard"],
+        path: "GestureSemanticsUITests.swift",
+      },
+    ]);
+    expect(
+      findUncoveredIosXcuitestEntries({
+        entries,
+        shards: DEFAULT_IOS_XCUITEST_SHARDS,
+      }),
+    ).toEqual(["AppUITests/BootCaptureUITests/testNewCoverageMustBeListed"]);
+  });
+
+  it("classifies only absent-app uninstall failures as benign", () => {
+    expect(isBenignIosAppAbsence("Application is not installed")).toBe(true);
+    expect(
+      isBenignIosAppAbsence("Unknown application display identifier"),
+    ).toBe(true);
+    expect(isBenignIosAppAbsence("simctl failed: service unavailable")).toBe(
+      false,
     );
   });
 });


### PR DESCRIPTION
## Summary
- fail iOS XCUITest shard reset on real terminate/uninstall errors, allowing only explicit already-absent app responses
- record simulator fresh-container proof in shard summaries using `simctl get_app_container` and `simctl listapps -j` after reinstall
- add a committed Swift AppUITests shard-coverage guard so future test methods cannot silently fall out of the default shard plan
- update #13686 evidence with the follow-up verification

Relates to #13686. Follow-up to #13806 review blockers.

## Evidence
- `.github/issue-evidence/13686-ios-xcuitest-shards/README.md`

## Verification
- `bun run --cwd packages/app test scripts/ios-device-lib.test.mjs` — passes, 76 tests
- `bunx biome check packages/app/scripts/ios-device-capture.mjs packages/app/scripts/ios-device-lib.mjs packages/app/scripts/ios-device-lib.test.mjs .github/issue-evidence/13686-ios-xcuitest-shards/README.md` — passes
- `node --check packages/app/scripts/ios-device-capture.mjs && node --check packages/app/scripts/ios-device-lib.mjs && node --check packages/app/scripts/ios-device-lib.test.mjs` — passes
- `git diff --check HEAD~1..HEAD` — passes

## Still Not Run / Blocked Locally
- Real iOS simulator/device XCUITest capture is still blocked on this host: full Xcode is not selected/available and the generated `packages/app/ios/App` project is absent. The issue should stay open/In progress until a macOS/Xcode host captures the two back-to-back full simulator runs and fresh-container evidence requested by #13686.
