### PR TITLE
fix(browser): do not block startup on desktop default tab seed

### DIFF
--- a/.github/issue-evidence/13810-browser-default-tab-nonblocking.md
+++ b/.github/issue-evidence/13810-browser-default-tab-nonblocking.md
@@ -1,0 +1,32 @@
+# #13810 browser default-tab startup non-blocking follow-up
+
+## Scope
+
+Follow-up to merged PR #13825 / issue #13810. The default browser search-tab
+seed was annotated, but desktop bridge mode still awaited the optional seed from
+`BrowserService.start()`. Since desktop bridge requests use the workspace HTTP
+request timeout, that could delay service startup and agent browser actions.
+
+This patch keeps web-mode seeding awaited for crisp local failures, but starts
+desktop bridge seeding in the background and logs failures through the existing
+best-effort startup warning path.
+
+## Verification
+
+Run from `/Users/shawwalters/milaidy/eliza-pr13825-fix` on rebased head
+`9551de9751`.
+
+- `bun install --frozen-lockfile --ignore-scripts` - pass
+- `bun run --cwd packages/cloud/routing build` - pass
+- `bun run --cwd packages/shared build:i18n` - pass
+- `bun run --cwd plugins/plugin-browser test -- src/workspace/__tests__/browser-workspace-default-tab.test.ts --coverage.enabled=false` - 9/9 pass
+- `bunx biome check plugins/plugin-browser/src/browser-service.ts plugins/plugin-browser/src/workspace/browser-workspace.ts plugins/plugin-browser/src/workspace/__tests__/browser-workspace-default-tab.test.ts` - pass
+- `git diff --check` - pass
+
+## Evidence N/A
+
+- Screenshots/video: N/A - plugin-browser service startup behavior only; no UI
+  rendering changed.
+- Live LLM trajectory: N/A - no prompt/model/action behavior changed.
+- DB/domain artifacts: N/A - no persistence or schema change.
+

--- a/plugins/plugin-browser/src/browser-service.ts
+++ b/plugins/plugin-browser/src/browser-service.ts
@@ -36,6 +36,7 @@ import { maybeCreateStagehandTarget } from "./targets/stagehand-target.js";
 import {
   ensureBrowserWorkspaceDefaultTabWithRetry,
   getBrowserWorkspaceSnapshot,
+  isBrowserWorkspaceBridgeConfigured,
 } from "./workspace/browser-workspace.js";
 import type {
   BrowserWorkspaceCommand,
@@ -129,18 +130,7 @@ export class BrowserService extends Service {
         `[BrowserService] stagehand target not registered at start: ${message}`,
       );
     }
-    // Seed the Safari-style default search tab so the browser never opens
-    // empty-and-sad (#13596). Best-effort with a bounded desktop bridge
-    // readiness window: failure must not prevent the service from starting.
-    try {
-      await ensureBrowserWorkspaceDefaultTabWithRetry();
-    } catch (err) {
-      // error-policy:J4 startup should expose the browser even when the optional default tab cannot be seeded.
-      const message = err instanceof Error ? err.message : String(err);
-      logger.warn(
-        `[BrowserService] default search tab not seeded at start: ${message}`,
-      );
-    }
+    await seedDefaultSearchTabAtStartup();
     return service;
   }
 
@@ -302,6 +292,31 @@ export class BrowserService extends Service {
       ? lastError
       : new Error("Browser target execution failed.");
   }
+}
+
+async function seedDefaultSearchTabAtStartup(): Promise<void> {
+  const seed = async () => {
+    try {
+      await ensureBrowserWorkspaceDefaultTabWithRetry();
+    } catch (err) {
+      // error-policy:J4 startup exposes the browser even when the optional default tab cannot be seeded.
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        `[BrowserService] default search tab not seeded at start: ${message}`,
+      );
+    }
+  };
+
+  // Desktop bridge startup is allowed a short readiness window, but BrowserService
+  // itself must be returned immediately so agent browser actions are not held by
+  // an optional default-tab seed. Web mode stays awaited so bad local
+  // configuration fails crisply in tests/dev.
+  if (isBrowserWorkspaceBridgeConfigured()) {
+    void seed();
+    return;
+  }
+
+  await seed();
 }
 
 function createWorkspaceTarget(): BrowserTarget {

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-default-tab.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-default-tab.test.ts
@@ -188,4 +188,34 @@ describe("BrowserService seeds the default tab at start", () => {
       }
     }
   });
+
+  it("does not await a pending desktop bridge seed before returning the service", async () => {
+    const originalFetch = globalThis.fetch;
+    process.env.ELIZA_BROWSER_WORKSPACE_URL = "http://workspace-bridge.test";
+    globalThis.fetch = vi.fn(
+      () => new Promise<Response>(() => undefined),
+    ) as typeof fetch;
+    const runtime = {
+      getService: () => null,
+    } as unknown as IAgentRuntime;
+
+    try {
+      const result = await Promise.race([
+        BrowserService.start(runtime).then((service) => service),
+        new Promise<"blocked">((resolve) =>
+          setTimeout(() => resolve("blocked"), 25),
+        ),
+      ]);
+
+      expect(result).not.toBe("blocked");
+      if (result !== "blocked") await result.stop();
+      expect(globalThis.fetch).toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+      for (const key of bridgeKeys) {
+        if (savedBridge[key] === undefined) delete process.env[key];
+        else process.env[key] = savedBridge[key];
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Follow-up to #13810 / #13825: desktop browser-workspace default-tab seeding now runs fire-and-observe when the desktop bridge is configured, so BrowserService.start() is not held behind bridge fetch retries or timeouts.
- Web-mode seeding remains awaited so local/browserless startup still fails visibly when the default search tab cannot be ensured.
- Adds a regression test that holds the bridge fetch open and proves BrowserService.start() returns without waiting.

## Verification
- Head SHA: 378ae41da4463ad5b2f4b577a0dd6e66b9beb3df
- bun run --cwd packages/cloud/routing build
- bun run --cwd packages/shared build:i18n
- bun run --cwd plugins/plugin-browser test -- src/workspace/__tests__/browser-workspace-default-tab.test.ts --coverage.enabled=false
- bunx biome check plugins/plugin-browser/src/browser-service.ts plugins/plugin-browser/src/workspace/browser-workspace.ts plugins/plugin-browser/src/workspace/__tests__/browser-workspace-default-tab.test.ts .github/issue-evidence/13810-browser-default-tab-nonblocking.md
- git diff --check

## Evidence
- .github/issue-evidence/13810-browser-default-tab-nonblocking.md
- Screenshots/video: N/A - service startup timing regression, no user-visible UI changed.
- Live LLM trajectories: N/A - no agent/action/prompt/model behavior changed.
- Backend/frontend logs: N/A - focused service startup unit regression; no server route or frontend flow changed.

Refs #13810