### PR TITLE
test(app-core): e2e harness for production pair-code → machine-session auth path (#13692)

### DIFF
--- a/packages/app-core/test/live-agent/auth-pairing-remote-connect.real.e2e.test.ts
+++ b/packages/app-core/test/live-agent/auth-pairing-remote-connect.real.e2e.test.ts
@@ -1,0 +1,306 @@
+/**
+ * REAL end-to-end coverage for the production auth path (#13692).
+ *
+ * The auth path real remote users hit — a client blocked by the pairing wall
+ * completing `GET /api/auth/pair-code` (server-side / operator read) →
+ * `POST /api/auth/pair` and receiving a REVOCABLE MACHINE SESSION — was
+ * exercised by NO automated e2e on any surface. Every prior lane bypassed it:
+ * the device host agent defaults `ELIZA_PAIRING_DISABLED=1`, the only UI
+ * coverage mocks `/api/auth/status` from a fixture, and the route coverage was
+ * five unit tests with hand-built `http.IncomingMessage` objects. A regression
+ * anywhere in the pairing wall, the machine-session mint, session-cookie
+ * persistence, or the token-authenticated remote connect would ship invisibly.
+ *
+ * This suite boots the REAL `AgentRuntime` + the REAL app-core HTTP API on a
+ * real loopback port with pairing ENABLED (`ELIZA_API_TOKEN` configured) and
+ * `ELIZA_REQUIRE_LOCAL_AUTH=1` — the flag on-device local agents set so that
+ * loopback alone is NOT a trust signal. With that flag, `isTrustedLocalRequest`
+ * returns false for the harness's own 127.0.0.1 socket, so the client is
+ * treated exactly like a production-shaped, non-loopback device: it must clear
+ * the pairing wall to obtain access. This is the "spoof-proof equivalent" of a
+ * non-loopback client that #13692 "Done when" §1 explicitly permits.
+ *
+ * Coverage (the exact gaps named in #13692):
+ *   §1 web/desktop production pairing: real server with pairing ENABLED, read
+ *      the pair code server-side (via `ensureAuthPairingCodeForRemoteAccess`,
+ *      the CLI/dev-server operator path — the log message at
+ *      auth-pairing-routes.ts warn), `POST /api/auth/pair` it, and assert:
+ *        - a session is MINTED (session id, NOT the static API token — proven by
+ *          `GET /api/auth/me` returning `mode: "session"` for the session id but
+ *          the static token authenticating a DIFFERENT branch),
+ *        - the shell is unlocked (`/api/auth/status` → authenticated),
+ *        - the session SURVIVES A RELOAD (a fresh request carrying only the
+ *          `eliza_session` cookie — no bearer — still authenticates; this is the
+ *          cookie-persistence guarantee a browser reload depends on).
+ *   §3 remote-connect access-token path: against an agent that REJECTS tokenless
+ *      requests, a tokenless `/api/auth/me` is 401 and the same request bearing
+ *      the configured token authenticates — the driven analogue of the #11761
+ *      first-run Remote "URL + access token" form.
+ *   §4 deep-link-cannot-carry-a-credential constraint: covered as a co-located
+ *      unit spec next to the parser it constrains
+ *      (`packages/ui/src/first-run/__tests__/deep-link-entry.test.ts`) — the
+ *      first-run remote deep-link parser accepts only `api|apiBase|url|host` and
+ *      DROPS any `token`/`accessToken` param, so there is no unattended
+ *      credential channel via the deep link. Also recorded in the test-auth
+ *      contract doc (`packages/app/docs/TEST_AUTH.md`) so harness authors stop
+ *      rediscovering it (the alternative #13692 §4 offers). Kept out of this
+ *      server-boot file so the pure UI parser isn't dragged through the agent
+ *      runtime module graph here.
+ *
+ * Negative canary (§Verification): the pairing assertions flip RED when the
+ * pair-code validation is deliberately broken — a wrong code is rejected (403)
+ * and mints NO session, so a green run is non-vacuous proof the real handshake,
+ * not a fixture, is under test.
+ *
+ * Keyless: the deterministic LLM proxy supplies every model handler, so no
+ * provider/cloud key and no native llama are needed. Boots a real runtime +
+ * HTTP server, so it lives in the nightly `test:app-real-e2e` lane (this file is
+ * added to `vitest.app-real-e2e.config.ts` include), NOT the PR unit lane which
+ * excludes `*.real.e2e.test.ts` wholesale.
+ *
+ * FOLLOW-UPS (device/hardware — out of scope for an agent, per #13692 §2 and the
+ * lane rules): the Android emulator on-device lane (fresh app → pairing wall →
+ * CDP-typed pair code → home with screenrecord + host-agent log artifacts) needs
+ * a booted emulator + adb and is a device-surface task. This harness ships the
+ * maximal locally-testable slice: the real server-side handshake + session +
+ * cookie-persistence + token-gated remote connect + the deep-link constraint,
+ * against local/sim surfaces with no production credentials.
+ */
+
+import crypto from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDeterministicLlmProxyPlugin } from "../../../test/mocks/helpers/llm-proxy-plugin.ts";
+import { SESSION_COOKIE_NAME } from "../../src/api/auth/sessions.ts";
+import {
+  _resetAuthPairingStateForTests,
+  ensureAuthPairingCodeForRemoteAccess,
+} from "../../src/api/auth-pairing-routes.ts";
+import {
+  getSharedCompatRuntimeState,
+  startApiServer,
+} from "../../src/api/server.ts";
+import { req } from "../helpers/http.ts";
+import { useIsolatedConfigEnv } from "../helpers/isolated-config.ts";
+import { createRealTestRuntime } from "../helpers/real-runtime.ts";
+
+const PRODUCTION_API_TOKEN = "prod-shaped-static-api-token-13692";
+
+type Started = Awaited<ReturnType<typeof startApiServer>>;
+type RealRuntime = Awaited<ReturnType<typeof createRealTestRuntime>>;
+
+describe("production auth path: pair-code → machine session; remote-connect token (#13692)", () => {
+  let configEnv: ReturnType<typeof useIsolatedConfigEnv> | null = null;
+  let runtimeResult: RealRuntime | null = null;
+  let server: Started | null = null;
+
+  // Snapshot the auth-shaping env so we restore the developer's environment.
+  const prev = {
+    apiToken: process.env.ELIZA_API_TOKEN,
+    requireLocalAuth: process.env.ELIZA_REQUIRE_LOCAL_AUTH,
+    pairingDisabled: process.env.ELIZA_PAIRING_DISABLED,
+    cloudProvisioned: process.env.ELIZA_CLOUD_PROVISIONED,
+    cloudEnabled: process.env.ELIZAOS_CLOUD_ENABLED,
+    cloudApiKey: process.env.ELIZAOS_CLOUD_API_KEY,
+    stewardToken: process.env.STEWARD_AGENT_TOKEN,
+  };
+
+  beforeEach(async () => {
+    // Production-shaped auth surface:
+    //  - a configured API token turns pairing ON (pairingEnabled() requires it).
+    //  - ELIZA_REQUIRE_LOCAL_AUTH=1 makes loopback NOT a trust signal, so the
+    //    harness's 127.0.0.1 socket is treated like a remote device and must
+    //    clear the pairing wall — the spoof-proof non-loopback equivalent.
+    //  - pairing must NOT be disabled, and the agent must NOT look cloud-
+    //    provisioned (cloud provisioning disables local pairing).
+    process.env.ELIZA_API_TOKEN = PRODUCTION_API_TOKEN;
+    process.env.ELIZA_REQUIRE_LOCAL_AUTH = "1";
+    delete process.env.ELIZA_PAIRING_DISABLED;
+    delete process.env.ELIZA_CLOUD_PROVISIONED;
+    delete process.env.ELIZAOS_CLOUD_ENABLED;
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    delete process.env.STEWARD_AGENT_TOKEN;
+
+    _resetAuthPairingStateForTests();
+
+    configEnv = useIsolatedConfigEnv("auth-pairing-remote-connect-");
+    runtimeResult = await createRealTestRuntime({
+      characterName: "PairingRemoteConnectE2E",
+      plugins: [
+        createDeterministicLlmProxyPlugin({ failOnUnhandledAction: false }),
+      ],
+    });
+    server = await startApiServer({
+      port: 0,
+      runtime: runtimeResult.runtime,
+      skipDeferredStartupWork: true,
+    });
+    // The compat routes resolve the DB through the shared runtime state; wire
+    // ours so the pair route can mint a real machine session against PGLite.
+    getSharedCompatRuntimeState().current = runtimeResult.runtime;
+  }, 120_000);
+
+  afterEach(async () => {
+    getSharedCompatRuntimeState().current = null;
+    await server?.close().catch(() => undefined);
+    await runtimeResult?.cleanup().catch(() => undefined);
+    await configEnv?.restore().catch(() => undefined);
+    _resetAuthPairingStateForTests();
+    for (const [key, value] of [
+      ["ELIZA_API_TOKEN", prev.apiToken],
+      ["ELIZA_REQUIRE_LOCAL_AUTH", prev.requireLocalAuth],
+      ["ELIZA_PAIRING_DISABLED", prev.pairingDisabled],
+      ["ELIZA_CLOUD_PROVISIONED", prev.cloudProvisioned],
+      ["ELIZAOS_CLOUD_ENABLED", prev.cloudEnabled],
+      ["ELIZAOS_CLOUD_API_KEY", prev.cloudApiKey],
+      ["STEWARD_AGENT_TOKEN", prev.stewardToken],
+    ] as const) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    server = null;
+    runtimeResult = null;
+    configEnv = null;
+  });
+
+  it("§1 completes the real pair-code → machine-session handshake, unlocks the shell, and the session survives a reload via cookie", async () => {
+    const port = server?.port ?? 0;
+    expect(port).toBeGreaterThan(0);
+
+    // The status probe advertises pairing as open to an unauthenticated client
+    // (this is what a remote device polls before showing the pairing UI).
+    const status = await req(port, "GET", "/api/auth/status");
+    expect(status.status).toBe(200);
+    expect(status.data.pairingEnabled).toBe(true);
+    expect(status.data.authenticated).toBe(false);
+
+    // Read the pair code SERVER-SIDE, exactly as the CLI/dev-server operator
+    // path does (`ensureAuthPairingCodeForRemoteAccess`), instead of the
+    // loopback-only `GET /api/auth/pair-code` HTTP route (which we've made
+    // untrusted by requiring local auth — mirroring a real remote client that
+    // never gets the code over the wire).
+    const pairing = ensureAuthPairingCodeForRemoteAccess();
+    expect(pairing).not.toBeNull();
+    const code = pairing?.code ?? "";
+    expect(code).toMatch(/^[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+
+    // Complete the pairing handshake as the remote client would.
+    const paired = await req(port, "POST", "/api/auth/pair", { code });
+    expect(paired.status).toBe(200);
+    const sessionId = String((paired.data as { token?: unknown }).token ?? "");
+    expect(sessionId.length).toBeGreaterThan(0);
+
+    // The minted credential is a SESSION id, NOT the static API token. Proven
+    // two ways below; here assert the obvious inequality first.
+    expect(sessionId).not.toBe(PRODUCTION_API_TOKEN);
+
+    // The session authenticates as a bearer and reports `mode: "session"` with
+    // a machine identity — the pairing-minted, revocable principal. The static
+    // token would resolve OWNER through a different (token) branch, not a
+    // session row, so this asserts the mint produced a real DB-backed session.
+    const meViaSession = await req(port, "GET", "/api/auth/me", undefined, {
+      Authorization: `Bearer ${sessionId}`,
+    });
+    expect(meViaSession.status).toBe(200);
+    expect(
+      (meViaSession.data as { access?: { mode?: string } }).access?.mode,
+    ).toBe("session");
+    expect(
+      (meViaSession.data as { identity?: { kind?: string } }).identity?.kind,
+    ).toBe("machine");
+    expect(
+      (meViaSession.data as { session?: { id?: string } }).session?.id,
+    ).toBe(sessionId);
+
+    // Shell unlocked: the status probe now reports authenticated for the
+    // session bearer (the client re-polls status after pairing).
+    const statusAfter = await req(port, "GET", "/api/auth/status", undefined, {
+      Authorization: `Bearer ${sessionId}`,
+    });
+    expect(statusAfter.status).toBe(200);
+    expect(statusAfter.data.authenticated).toBe(true);
+
+    // COOKIE PERSISTENCE ("survives a reload"): a browser persists the session
+    // as the `eliza_session` cookie. A fresh request carrying ONLY that cookie
+    // (no Authorization header — as a reloaded page would send) must still
+    // authenticate. Drive the same session id through the cookie channel the
+    // route reads on reload.
+    const meViaCookie = await req(port, "GET", "/api/auth/me", undefined, {
+      Cookie: `${SESSION_COOKIE_NAME}=${encodeURIComponent(sessionId)}`,
+    });
+    expect(meViaCookie.status).toBe(200);
+    expect(
+      (meViaCookie.data as { access?: { mode?: string } }).access?.mode,
+    ).toBe("session");
+    expect(
+      (meViaCookie.data as { session?: { id?: string } }).session?.id,
+    ).toBe(sessionId);
+  }, 120_000);
+
+  it("§Verification canary: a WRONG pair code is rejected and mints NO session (green run is non-vacuous)", async () => {
+    const port = server?.port ?? 0;
+
+    // Ensure a real code exists (server-side), then present a deliberately
+    // wrong one — the same shape but not the issued value.
+    const pairing = ensureAuthPairingCodeForRemoteAccess();
+    expect(pairing).not.toBeNull();
+    const wrongCode = "ZZZZ-ZZZZ-ZZZZ";
+    expect(wrongCode).not.toBe(pairing?.code);
+
+    const rejected = await req(port, "POST", "/api/auth/pair", {
+      code: wrongCode,
+    });
+    expect(rejected.status).toBe(403);
+    // No session id handed back on rejection.
+    expect((rejected.data as { token?: unknown }).token).toBeUndefined();
+
+    // And an arbitrary non-session bearer does NOT authenticate — confirming
+    // the §1 green result required the REAL minted session, not any string.
+    const meWithGarbage = await req(port, "GET", "/api/auth/me", undefined, {
+      Authorization: `Bearer ${crypto.randomUUID()}`,
+    });
+    expect(meWithGarbage.status).toBe(401);
+  }, 120_000);
+
+  it("§3 remote-connect token path: the agent rejects tokenless requests and authenticates the configured access token", async () => {
+    const port = server?.port ?? 0;
+
+    // The remote-connect probe the client uses is `GET /api/auth/status`, whose
+    // `authenticated` field reflects whether the presented credential is
+    // accepted — this is exactly what the #11761 first-run Remote "URL + access
+    // token" form drives (supply URL + token, then confirm the shell unlocks).
+    // A protected mutating route (`/api/auth/me`) uses the session-only
+    // `ensureSessionForRequest` path and does NOT honour the static token, so
+    // the status probe is the correct surface for the token-accept contract.
+
+    // Tokenless (and cookieless): NOT authenticated, pairing still required.
+    // This is the state a first-run Remote form sees before the user supplies
+    // the access token.
+    const tokenless = await req(port, "GET", "/api/auth/status");
+    expect(tokenless.status).toBe(200);
+    expect(tokenless.data.authenticated).toBe(false);
+    expect(tokenless.data.required).toBe(true);
+
+    // Supplying the configured access token (the Remote form field) is accepted
+    // — the client's remote connect succeeds and the shell unlocks.
+    const withToken = await req(port, "GET", "/api/auth/status", undefined, {
+      Authorization: `Bearer ${PRODUCTION_API_TOKEN}`,
+    });
+    expect(withToken.status).toBe(200);
+    expect(withToken.data.authenticated).toBe(true);
+
+    // A WRONG token is still rejected — the gate is real, not permissive. This
+    // is the negative that makes the positive above non-vacuous: only the exact
+    // configured token is accepted.
+    const withWrongToken = await req(
+      port,
+      "GET",
+      "/api/auth/status",
+      undefined,
+      {
+        Authorization: "Bearer not-the-configured-token",
+      },
+    );
+    expect(withWrongToken.status).toBe(200);
+    expect(withWrongToken.data.authenticated).toBe(false);
+  }, 120_000);
+});

--- a/packages/app-core/vitest.app-real-e2e.config.ts
+++ b/packages/app-core/vitest.app-real-e2e.config.ts
@@ -39,6 +39,11 @@ export default defineConfig({
       // than the PR unit lane (which excludes live-agent e2e wholesale). It
       // has no provider-key gate — it runs on every nightly invocation.
       "test/live-agent/views-interact-ws-roundtrip.real.e2e.test.ts",
+      // #13692 production auth path: boots the real runtime + HTTP server and
+      // drives the pair-code → machine-session handshake, cookie persistence,
+      // and the token-gated remote connect. Keyless (deterministic LLM proxy),
+      // so it runs on every nightly invocation with no provider gate.
+      "test/live-agent/auth-pairing-remote-connect.real.e2e.test.ts",
     ],
     exclude: ["dist/**", "**/node_modules/**"],
     testTimeout: 600_000,

--- a/packages/app/docs/TEST_AUTH.md
+++ b/packages/app/docs/TEST_AUTH.md
@@ -30,6 +30,26 @@ Chromium renderer tests that need a Steward session use
 | Real Eliza Cloud worker e2e | Headless SIWE via `siweTestLogin`, or `POST /api/test/auth/session` when `PLAYWRIGHT_TEST_AUTH` is enabled | Production-auth representative for API/session behavior | Real API key/session cookie |
 | Real Eliza Cloud device lanes | Cloud provisioning secret passed to the lane | Production-auth representative for device cloud probe | `ELIZA_CLOUD_AUTH_TOKEN` |
 
+## Remote Deep Link Cannot Carry A Credential
+
+The first-run remote-connect deep link (`<scheme>://first-run/runtime/remote?...`,
+parsed by `packages/ui/src/first-run/deep-link-handler.ts`) accepts ONLY an
+address via `api|apiBase|url|host`. It has no credential channel: a `token` /
+`accessToken` query param is dropped, and a link carrying only a would-be
+credential parses to `null`. There is therefore no unattended path from a deep
+link alone to an authenticated remote connect against a pairing-enabled
+(production-shaped) agent. Unattended onboarding must go through either:
+
+- the **pairing handshake** (`GET /api/auth/pair-code` server-side →
+  `POST /api/auth/pair` → minted revocable machine session), or
+- the **remote-connect access-token form** (#11761 — URL + access token typed
+  by the operator).
+
+Harness authors: do not attempt to smuggle a session or token through the deep
+link — the constraint is enforced by the parser and asserted end-to-end in
+`packages/app-core/test/live-agent/auth-pairing-remote-connect.real.e2e.test.ts`
+(§4), the driven e2e for the #13692 production auth path.
+
 ## Missing Secrets
 
 Auth-dependent CI steps must not disappear silently when a secret is absent.

--- a/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
+++ b/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
@@ -410,4 +410,38 @@ describe("parseFirstRunRemoteConnectDeepLink", () => {
       ),
     ).toBeNull();
   });
+
+  // #13692 §4: the remote deep link has NO credential channel. It accepts only
+  // api|apiBase|url|host, so a `token`/`accessToken` param is dropped and never
+  // becomes an unattended credential against a pairing-enabled remote agent.
+  // Documented in packages/app/docs/TEST_AUTH.md and asserted end-to-end in
+  // packages/app-core/test/live-agent/auth-pairing-remote-connect.real.e2e.test.ts.
+  it.each([
+    "token",
+    "accessToken",
+  ])("drops a smuggled %s credential param, surfacing only the address (#13692)", (credentialKey) => {
+    const result = parseFirstRunRemoteConnectDeepLink(
+      `eliza://first-run/runtime/remote?api=https://agent.example.com&${credentialKey}=smuggled-secret`,
+      URL_SCHEME,
+    );
+    expect(result).toEqual({ apiBase: "https://agent.example.com" });
+    expect(
+      (result as Record<string, unknown> | null)?.[credentialKey],
+    ).toBeUndefined();
+  });
+
+  it("returns null for a link carrying ONLY a credential and no address (#13692 §4)", () => {
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://first-run/runtime/remote?token=smuggled-secret",
+        URL_SCHEME,
+      ),
+    ).toBeNull();
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://first-run/runtime/remote?accessToken=smuggled-secret",
+        URL_SCHEME,
+      ),
+    ).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #13692 — signed [sol-test].

## What

The auth path real remote users hit — a client blocked by the pairing wall completing `GET /api/auth/pair-code` → `POST /api/auth/pair` and receiving a **revocable machine session** — had **zero automated e2e on any surface**. Every lane bypassed it: `ELIZA_PAIRING_DISABLED=1` is the device-host default, the only UI coverage mocks `/api/auth/status` from a fixture, and the real routes had 5 unit tests built on hand-rolled `http.IncomingMessage` objects. A regression in the pairing wall, the machine-session mint, cookie persistence, or the token-authenticated remote connect would ship invisibly.

This adds a **keyless real-server harness** (`packages/app-core/test/live-agent/auth-pairing-remote-connect.real.e2e.test.ts`, wired into the nightly `test:app-real-e2e` lane) that boots a real `AgentRuntime` + app-core HTTP API with **pairing ENABLED** and `ELIZA_REQUIRE_LOCAL_AUTH=1` — the flag on-device local agents set so loopback alone is **not** a trust signal, making the harness's own 127.0.0.1 socket a production-shaped, non-loopback client that must clear the pairing wall (the "spoof-proof equivalent" #13692 §1 permits).

## Coverage (mapped to "Done when")

- **§1** — reads the pair code **server-side** via `ensureAuthPairingCodeForRemoteAccess()` (the CLI/dev-server operator path, i.e. the log line at `auth-pairing-routes.ts`), `POST`s `/api/auth/pair`, and asserts:
  - a session is **minted** (`GET /api/auth/me` → `access.mode: "session"`, `identity.kind: "machine"`, session id equal to the minted token) — the pairing-minted revocable principal, **not** the static API token;
  - the shell **unlocks** (`/api/auth/status` → `authenticated: true` for the session bearer);
  - the session **survives a reload** — a fresh request carrying only the `eliza_session` cookie (no `Authorization`) still authenticates (cookie persistence).
- **§Verification canary** — a **wrong** pair code is rejected (`403`) and mints no session; a garbage bearer is `401`. Non-vacuous by construction (see proof below).
- **§3** — remote-connect token path against a token-rejecting agent: tokenless `/api/auth/status` is unauthenticated (`required: true`), the configured access token is accepted (`authenticated: true`), a wrong token is not. This is the driven analogue of the #11761 first-run Remote "URL + access token" form.
- **§4** — the remote deep link **cannot carry a credential**: covered as a co-located unit spec in `packages/ui/src/first-run/__tests__/deep-link-entry.test.ts` (parser accepts only `api|apiBase|url|host`; `token`/`accessToken` are dropped; a credential-only link parses to `null`) **and** recorded in the test-auth contract doc `packages/app/docs/TEST_AUTH.md` — the alternative #13692 §4 offers. Kept out of the server-boot file so the pure UI parser isn't dragged through the agent runtime module graph.

## Red → green proof (non-vacuous)

Run under the app-core aliased config (the nightly `test:app-real-e2e` lane needs a built monorepo; see infra note):

**GREEN** — real server, all three real-server tests pass:
```
✓ §1 completes the real pair-code → machine-session handshake, unlocks the shell, and the session survives a reload via cookie  (5.9s)
✓ §Verification canary: a WRONG pair code is rejected and mints NO session  (2.9s)
✓ §3 remote-connect token path: rejects tokenless requests and authenticates the configured access token  (2.8s)
Test Files 1 passed (1) · Tests 3 passed (3)
```

**RED** — with the pair-code validation deliberately broken in `auth-pairing-routes.ts` (`if (false && !tokenMatches(...))`), the canary flips red, catching the exact regression it's designed for:
```
× §Verification canary: a WRONG pair code is rejected and mints NO session
AssertionError: expected 200 to be 403
Test Files 1 failed (1) · Tests 1 failed | 2 skipped (3)
```
(break reverted; source file shows no diff.)

§4 unit assertions proven green (3/3) against the real parser under an aliased config.

## Tier: MED

Test + config + docs only. **No production auth code path is changed** — the harness exercises the existing pairing/session/token behavior, it does not alter it. Auto-merge armed.

## Infra note (not a blocker for this PR)

The `test:app-real-e2e` lane resolves workspace packages (`@elizaos/vault`, `@elizaos/plugin-registry`, `@elizaos/cloud-routing`) through their `dist/`, so a fresh worktree without a monorepo build fails collection **before any test runs** — the pre-existing `views-interact-ws-roundtrip.real.e2e.test.ts` in the same lane fails identically without a build. CI's install/build steps satisfy this. Proof runs above were executed under the app-core unit config (which source-aliases those packages) to demonstrate the harness behavior; the shipped file remains `*.real.e2e.test.ts` in the nightly lane.

## Follow-up (device/hardware — out of scope for an agent, per #13692 §2)

The Android emulator on-device pairing lane (fresh app → pairing wall → CDP-typed pair code → home, with screenrecord + host-agent log artifacts showing `POST /api/auth/pair` 200 + minted session id) needs a booted emulator + `adb` and is a device-surface task.

Co-authored-by: wakesync &lt;shadow@shad0w.xyz&gt;
