### PR TITLE
feat(#13772): admission-control queue for the orchestrator session cap

### DIFF
--- a/.github/issue-evidence/13772-admission-queue.md
+++ b/.github/issue-evidence/13772-admission-queue.md
@@ -1,0 +1,129 @@
+# Evidence — #13772 Orchestrator admission control: queue vs reject at the session cap
+
+Implements Rollout stages 1–3 of `DESIGN_13772.md` (HYBRID). The live 10-vs-5 E2E
+(WS8) is deferred to #13778, as specified.
+
+## What changed (files)
+
+| File | Purpose |
+| --- | --- |
+| `src/services/types.ts` | New typed errors `SessionCapError` (`code: 'SESSION_CAP_REACHED'`, `maxSessions`, `activeCount`, `slotClass`) + `AdmissionQueueFullError`; `SessionSlotClass`; `SpawnOptions.slotClass`. |
+| `src/services/acp-service.ts` | Slot classes (`worker`/`system`), `systemSessionHeadroom`, `computeCapacity`, public `getCapacity()`, `enforceSessionLimit(slotClass)` throwing `SessionCapError`; `reserveSessionSlot` threads the class; sessions stamp `metadata.slotClass`. |
+| `src/services/orchestrator-task-service.ts` | The admission queue: park-at-cap in `spawnAgentForTask`, durable `metadata.admission`, `orderAdmissionQueue` (bands + FIFO + aging), depth cap, `drainAdmissionQueue` (terminal-event + 30s reconcile), idle reclaim, rebuild-from-store, `getCapacitySnapshot`, `queuedCountsByRoom`, DTO overlay; pause/resume/archive/delete dequeue; verifier spawns `system`. |
+| `src/services/orchestrator-task-mapper.ts` | `TaskThreadDto.admission?: { state; position; enqueuedAt }` (type only; the service overlays the live position). |
+| `src/api/orchestrator-routes.ts` | `GET /capacity`; `POST /tasks/:id/agents` → 202 when queued (201 immediate), `AdmissionQueueFullError` → 429. |
+| `src/providers/active-sub-agents.ts` | `capacity: A/M worker sessions; queued: N (next: …)` header line + `data.capacity` (counts/ids only — cache-stable). |
+| `src/services/task-supervisor-service.ts` | Per-room queued count folded into the digest header. |
+| `__tests__/unit/acp-service.test.ts` | Updated cap test to assert the typed error; added slot-class + `getCapacity` tests. |
+| `src/__tests__/admission-queue-order.test.ts` | Pure order tests. |
+| `src/__tests__/admission-queue.integration.test.ts` | Real-service integration tests. |
+
+## Before / after — the throw site (`acp-service.ts`, `enforceSessionLimit`)
+
+Before (opaque string, no slot classes):
+
+```ts
+private async enforceSessionLimit(): Promise<void> {
+  const sessions = await this.store.list();
+  const active = sessions.filter(
+    (s) => !["stopped", "errored", "completed", "cancelled"].includes(s.status),
+  );
+  if (active.length >= this.maxSessions)
+    throw new Error(`acpx max session limit reached (${this.maxSessions})`);
+}
+```
+
+After (typed error + slot-class accounting, shared with `getCapacity`):
+
+```ts
+private async enforceSessionLimit(slotClass: SessionSlotClass): Promise<void> {
+  const capacity = this.computeCapacity(await this.store.list());
+  if (slotClass === "system") {
+    if (capacity.activeSystem >= this.systemSessionHeadroom) {
+      throw new SessionCapError({
+        maxSessions: this.systemSessionHeadroom,
+        activeCount: capacity.activeSystem,
+        slotClass: "system",
+      });
+    }
+    return;
+  }
+  if (capacity.activeWorkers >= this.maxSessions) {
+    throw new SessionCapError({
+      maxSessions: this.maxSessions,
+      activeCount: capacity.activeWorkers,
+      slotClass: "worker",
+    });
+  }
+}
+```
+
+Direct spawn callers keep fail-fast — but the error message is now actionable
+("Session capacity reached (2/2 worker sessions active). Create a task to queue
+this work, or wait for a running session to finish.") and carries the stable
+`SESSION_CAP_REACHED` code.
+
+## Queue state machine (summary)
+
+- **queued = `open` task + durable `metadata.admission = { state:'queued', enqueuedAt, priorityAtEnqueue, spawnOpts }`.** No new table, no new status.
+- **Park:** `spawnAgentForTask` catches `SessionCapError` (worker cap) → `enqueueAdmission` (throws `AdmissionQueueFullError` past `ELIZA_ACP_ADMISSION_QUEUE_DEPTH`, default 32) → returns 202 DTO with `admission.position`.
+- **Order:** total order `(effectiveBand desc, enqueuedAt asc, taskId asc)`; `effectiveBand = min(urgent, base + floor(wait / ELIZA_ACP_QUEUE_AGING_MS))` (default 10 min) so `low` cannot starve.
+- **Dispatch:** `drainAdmissionQueue` runs on every terminal session event and a 30s reconcile tick. While `freeSlots > 0`: dequeue head → re-read task (skip if terminal/paused) → `spawnAgentForTask(…, 'throw-on-cap')` → clear admission. Lost slot race → catch `SessionCapError`, keep position.
+- **Idle reclaim:** at 0 free slots, stop the oldest keepAlive session whose *task* is terminal (`done`/`failed`/`archived`); never touch `validating`/`active`.
+- **Verifier:** `spawnReadOnlyVerifier` uses `slotClass:'system'` → its own headroom (`ELIZA_ACP_SYSTEM_SESSION_HEADROOM`, default 2), so validation never deadlocks behind a full worker pool.
+- **Lifecycle:** pause dequeues (durable record kept), resume re-enqueues + drains, archive/delete clear the entry.
+- **Flag:** `ELIZA_ACP_ADMISSION_QUEUE=1` default ON; `0` restores reject-at-cap (bisection kill switch).
+
+## Test output (real)
+
+New + updated tests (all green):
+
+```
+$ bunx vitest run src/__tests__/admission-queue-order.test.ts \
+    src/__tests__/admission-queue.integration.test.ts \
+    __tests__/unit/acp-service.test.ts
+ Test Files  3 passed (3)
+      Tests  67 passed (67)
+```
+
+- `admission-queue-order.test.ts` — 8 pure tests: bands, FIFO, taskId tie-break, aging promotion, aging cap, aging-off, no-mutate.
+- `admission-queue.integration.test.ts` — 9 real-service tests (real `OrchestratorTaskService` + real in-memory store + faithful fake ACP throwing the real `SessionCapError`): park-at-cap 202+position, priority-ordered drain with zero drops, depth-cap → `AdmissionQueueFullError`, dequeue-on-pause + re-enqueue-on-resume, archive clears the entry, rebuild-from-store ordering on restart, idle-reclaim, provider capacity line, reject-at-cap kill switch.
+- `acp-service.test.ts` — real `AcpService` (native-mock transport): typed `SESSION_CAP_REACHED` at the worker cap, system-headroom spawn at a full worker cap, `getCapacity` worker/system split.
+
+Typecheck (touched files clean):
+
+```
+$ bun run typecheck    # 0 errors in any src/ or __tests__/ file I touched
+```
+
+Biome:
+
+```
+$ bunx @biomejs/biome check <touched files>
+Checked 10 files in 139ms. No fixes applied.   # clean
+```
+
+## Regression sweep
+
+```
+$ bunx vitest run --exclude '**/*.e2e.test.ts' --exclude '**/*live*' --exclude '**/orchestrator-grilling*'
+ Test Files  6 failed | 151 passed (157)
+      Tests  26 failed | 1616 passed (1642)
+```
+
+The 26 failures are all in 6 TASKS-action test files
+(`control-resume-clears-paused`, `archive-reopen-lifecycle`,
+`task-history`, `provision-workspace`, `active-session-forward`,
+`task-control-structural`). **All 6 are byte-identical to `origin/develop`**, and
+every failure is the same `TypeError: runtime.reportError is not a function`
+raised inside `services/task-policy.ts` `resolveConnectorSource` — a call added
+by #13324 (commit `a60edb63bd`, already in this branch's base) whose test mocks
+were never given a `reportError`. These are **pre-existing develop failures**,
+unrelated to this change; none of the files this PR touches regress.
+
+## Deviations from DESIGN_13772.md
+
+- **DTO `admission.position` is overlaid by the service, not the pure mapper.** `position` is a cross-task live value (it depends on the whole ordered queue), so `getTask` computes it; the mapper only declares the field. This keeps the mapper pure and the position honest (no fake precision).
+- **Router-respawn / `reattachSession` re-queue-at-head (design item 2, second half) is NOT implemented.** `reattachSession` and `sub-agent-router` respawns now throw the typed `SessionCapError` (so they no longer die on an opaque string), but re-queuing a lost session *at the head of the admission queue* would require a session→task-service seam across the ACP (inner) → orchestrator (outer) layer boundary and is a recovery-path refinement, not part of the core admission flow. Deferred; the reconcile tick + terminal-event drain still make forward progress. Called out here honestly rather than half-wired.
+- **Supervisor digest fold is scoped to rooms that already have a live-task digest.** A room whose tasks are *all* queued (no live task, source unknown to the tick) is not given a brand-new digest; the queued count is folded into existing per-room digests only.
+```

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -14,9 +14,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // form so the same source compares correctly on both POSIX and Windows.
 const RESOLVED_ACP_WORKDIR = path.resolve("/tmp/acp-test");
 
-import type {
-  AcpJsonRpcMessage,
-  ApprovalPreset,
+import {
+  type AcpJsonRpcMessage,
+  type ApprovalPreset,
+  SessionCapError,
 } from "../../src/services/types.js";
 
 type NativeEventHandler = (
@@ -1931,14 +1932,17 @@ describe("AcpService.runHealthCheck state_lost guards", () => {
 
     const fulfilled = results.filter((r) => r.status === "fulfilled");
     const rejected = results.filter((r) => r.status === "rejected");
-    // The cap must hold exactly: 2 succeed, the rest reject with the limit error.
+    // The cap must hold exactly: 2 succeed, the rest reject with a typed
+    // SessionCapError carrying the stable code + the pool that was full.
     expect(fulfilled).toHaveLength(2);
     expect(rejected.length).toBe(4);
     for (const r of rejected) {
-      expect((r as PromiseRejectedResult).reason).toBeInstanceOf(Error);
-      expect(((r as PromiseRejectedResult).reason as Error).message).toContain(
-        "max session limit reached",
-      );
+      const reason = (r as PromiseRejectedResult).reason as SessionCapError;
+      expect(reason).toBeInstanceOf(SessionCapError);
+      expect(reason.code).toBe("SESSION_CAP_REACHED");
+      expect(reason.slotClass).toBe("worker");
+      expect(reason.maxSessions).toBe(2);
+      expect(reason.activeCount).toBe(2);
     }
 
     // And the store agrees: only 2 active sessions exist.
@@ -1948,6 +1952,95 @@ describe("AcpService.runHealthCheck state_lost guards", () => {
         !["stopped", "errored", "completed", "cancelled"].includes(s.status),
     );
     expect(active).toHaveLength(2);
+  });
+
+  it("system slot sessions draw from a separate headroom, not the worker cap", async () => {
+    // The verifier deadlock guard (#13772): a `system` spawn must succeed even
+    // when every worker slot is taken, so completion validation can run.
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: undefined,
+        ELIZA_ACP_MAX_SESSIONS: "1",
+        ELIZA_ACP_SYSTEM_SESSION_HEADROOM: "2",
+      }),
+    );
+    await service.start();
+
+    // Fill the single worker slot.
+    await service.spawnSession({ name: "worker-1", workdir: "/tmp/acp-test" });
+    // A second WORKER is rejected: the worker pool is full.
+    await expect(
+      service.spawnSession({ name: "worker-2", workdir: "/tmp/acp-test" }),
+    ).rejects.toMatchObject({
+      code: "SESSION_CAP_REACHED",
+      slotClass: "worker",
+    });
+
+    // But a `system` session spawns from its own headroom, worker cap or not.
+    await service.spawnSession({
+      name: "system-1",
+      workdir: "/tmp/acp-test",
+      slotClass: "system",
+    });
+    await service.spawnSession({
+      name: "system-2",
+      workdir: "/tmp/acp-test",
+      slotClass: "system",
+    });
+    // The system headroom (2) is now full — a third system spawn is rejected
+    // against the headroom, not the worker cap.
+    await expect(
+      service.spawnSession({
+        name: "system-3",
+        workdir: "/tmp/acp-test",
+        slotClass: "system",
+      }),
+    ).rejects.toMatchObject({
+      code: "SESSION_CAP_REACHED",
+      slotClass: "system",
+      maxSessions: 2,
+    });
+
+    const capacity = await service.getCapacity();
+    expect(capacity).toMatchObject({
+      maxSessions: 1,
+      activeWorkers: 1,
+      activeSystem: 2,
+      systemHeadroom: 2,
+      freeSlots: 0,
+    });
+  });
+
+  it("getCapacity reports the worker/system split and remaining worker headroom", async () => {
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: undefined,
+        ELIZA_ACP_MAX_SESSIONS: "3",
+      }),
+    );
+    await service.start();
+
+    expect(await service.getCapacity()).toMatchObject({
+      maxSessions: 3,
+      activeWorkers: 0,
+      activeSystem: 0,
+      freeSlots: 3,
+    });
+
+    await service.spawnSession({ name: "w1", workdir: "/tmp/acp-test" });
+    await service.spawnSession({
+      name: "s1",
+      workdir: "/tmp/acp-test",
+      slotClass: "system",
+    });
+
+    // The system session does NOT consume worker headroom: 1 worker used, 2 free.
+    expect(await service.getCapacity()).toMatchObject({
+      maxSessions: 3,
+      activeWorkers: 1,
+      activeSystem: 1,
+      freeSlots: 2,
+    });
   });
 
   it("rejects a concurrent prompt for the same native session (TOCTOU #11028)", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/admission-queue-order.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admission-queue-order.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure unit coverage for the admission-queue total order (orderAdmissionQueue):
+ * priority bands, FIFO within a band, deterministic taskId tie-break, and aging
+ * promotion. No services, no clock — the ordering function takes `nowMs`.
+ */
+
+import { describe, expect, it } from "vitest";
+import { orderAdmissionQueue } from "../services/orchestrator-task-service.js";
+import type { OrchestratorTaskPriority } from "../services/orchestrator-task-types.js";
+
+interface Entry {
+  taskId: string;
+  enqueuedAt: number;
+  priorityAtEnqueue: OrchestratorTaskPriority;
+}
+
+function entry(
+  taskId: string,
+  priorityAtEnqueue: OrchestratorTaskPriority,
+  enqueuedAt: number,
+): Entry {
+  return { taskId, priorityAtEnqueue, enqueuedAt };
+}
+
+const AGING_MS = 600_000; // 10 min
+const NO_AGING = 0;
+
+describe("orderAdmissionQueue", () => {
+  it("orders by priority band: urgent > high > normal > low", () => {
+    const entries = [
+      entry("t-low", "low", 0),
+      entry("t-urgent", "urgent", 0),
+      entry("t-normal", "normal", 0),
+      entry("t-high", "high", 0),
+    ];
+    const ordered = orderAdmissionQueue(entries, 0, NO_AGING).map(
+      (e) => e.taskId,
+    );
+    expect(ordered).toEqual(["t-urgent", "t-high", "t-normal", "t-low"]);
+  });
+
+  it("is FIFO within a band (earliest enqueuedAt first)", () => {
+    const entries = [
+      entry("c", "normal", 300),
+      entry("a", "normal", 100),
+      entry("b", "normal", 200),
+    ];
+    const ordered = orderAdmissionQueue(entries, 1000, NO_AGING).map(
+      (e) => e.taskId,
+    );
+    expect(ordered).toEqual(["a", "b", "c"]);
+  });
+
+  it("breaks a full tie (same band, same enqueuedAt) by taskId ascending", () => {
+    const entries = [
+      entry("zzz", "high", 500),
+      entry("aaa", "high", 500),
+      entry("mmm", "high", 500),
+    ];
+    const ordered = orderAdmissionQueue(entries, 900, NO_AGING).map(
+      (e) => e.taskId,
+    );
+    expect(ordered).toEqual(["aaa", "mmm", "zzz"]);
+  });
+
+  it("promotes an aged low task one band per aging interval so it cannot starve", () => {
+    // A `low` task waiting 3 aging intervals is promoted 3 bands (low+3 =
+    // urgent). It must overtake a freshly-enqueued `normal`.
+    const now = 3 * AGING_MS;
+    const entries = [
+      entry("aged-low", "low", 0), // effectiveBand = 0 + 3 = 3 (urgent)
+      entry("fresh-normal", "normal", now), // effectiveBand = 1
+    ];
+    const ordered = orderAdmissionQueue(entries, now, AGING_MS).map(
+      (e) => e.taskId,
+    );
+    expect(ordered).toEqual(["aged-low", "fresh-normal"]);
+  });
+
+  it("does not promote before a full aging interval elapses", () => {
+    // Just under one interval of wait → no promotion, so the fresh high wins.
+    const now = AGING_MS - 1;
+    const entries = [
+      entry("young-low", "low", 0), // band 0 (0 promotions)
+      entry("fresh-high", "high", now), // band 2
+    ];
+    const ordered = orderAdmissionQueue(entries, now, AGING_MS).map(
+      (e) => e.taskId,
+    );
+    expect(ordered).toEqual(["fresh-high", "young-low"]);
+  });
+
+  it("caps promotion at the urgent band (aging cannot exceed urgent)", () => {
+    // An ancient low (10 intervals) caps at urgent (band 3); a fresh urgent is
+    // also band 3, so the earlier-enqueued aged-low wins the FIFO tie-break.
+    const now = 10 * AGING_MS;
+    const entries = [
+      entry("ancient-low", "low", 0), // capped at band 3
+      entry("fresh-urgent", "urgent", now), // band 3
+    ];
+    const ordered = orderAdmissionQueue(entries, now, AGING_MS).map(
+      (e) => e.taskId,
+    );
+    expect(ordered).toEqual(["ancient-low", "fresh-urgent"]);
+  });
+
+  it("disables aging when agingMs <= 0 (pure priority + FIFO)", () => {
+    const now = 100 * AGING_MS;
+    const entries = [
+      entry("aged-low", "low", 0),
+      entry("fresh-normal", "normal", now),
+    ];
+    const ordered = orderAdmissionQueue(entries, now, NO_AGING).map(
+      (e) => e.taskId,
+    );
+    // Without aging the low never overtakes the normal, however long it waits.
+    expect(ordered).toEqual(["fresh-normal", "aged-low"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const entries = [entry("b", "normal", 200), entry("a", "urgent", 100)];
+    const snapshot = entries.map((e) => e.taskId);
+    orderAdmissionQueue(entries, 1000, AGING_MS);
+    expect(entries.map((e) => e.taskId)).toEqual(snapshot);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/admission-queue.integration.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admission-queue.integration.test.ts
@@ -1,0 +1,550 @@
+/**
+ * Real-service integration coverage for the orchestrator admission queue
+ * (#13772). Drives the REAL OrchestratorTaskService + REAL in-memory task store
+ * against a faithful fake ACP transport that enforces the same slot-class cap +
+ * throws the real SessionCapError. Proves: park-at-cap (202 + position),
+ * priority-ordered drain with zero drops as sessions complete, depth-cap
+ * rejection, dequeue on pause/archive, rebuild-from-store ordering on restart,
+ * the capacity snapshot, the ACTIVE_SUB_AGENTS provider capacity line, and the
+ * reject-at-cap kill switch.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { activeSubAgentsProvider } from "../providers/active-sub-agents.js";
+import { type AcpCapacity, AcpService } from "../services/acp-service.js";
+import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../services/orchestrator-task-store.js";
+import type { OrchestratorTaskPriority } from "../services/orchestrator-task-types.js";
+import {
+  AdmissionQueueFullError,
+  SessionCapError,
+  type SessionInfo,
+  type SpawnOptions,
+  type SpawnResult,
+  TERMINAL_SESSION_STATUSES,
+} from "../services/types.js";
+
+type EventHandler = (sessionId: string, event: string, data: unknown) => void;
+
+/**
+ * Faithful fake ACP transport: mirrors AcpService's slot-class cap accounting
+ * and throws the REAL SessionCapError so the service's admission path exercises
+ * the true error type. `spawnLog` records dispatch order for assertions.
+ */
+class FakeAcp {
+  readonly spawnLog: string[] = [];
+  private readonly sessions = new Map<string, SessionInfo>();
+  private readonly handlers = new Set<EventHandler>();
+  private counter = 0;
+  private clock = 0;
+
+  constructor(
+    private readonly maxSessions: number,
+    private readonly systemHeadroom = 2,
+  ) {}
+
+  onSessionEvent(handler: EventHandler): () => void {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+
+  private countActive(): { workers: number; system: number } {
+    let workers = 0;
+    let system = 0;
+    for (const session of this.sessions.values()) {
+      if (TERMINAL_SESSION_STATUSES.has(session.status)) continue;
+      if (
+        (session.metadata as Record<string, unknown> | undefined)?.slotClass ===
+        "system"
+      ) {
+        system += 1;
+      } else {
+        workers += 1;
+      }
+    }
+    return { workers, system };
+  }
+
+  async getCapacity(): Promise<AcpCapacity> {
+    const { workers, system } = this.countActive();
+    return {
+      maxSessions: this.maxSessions,
+      activeWorkers: workers,
+      activeSystem: system,
+      systemHeadroom: this.systemHeadroom,
+      freeSlots: Math.max(0, this.maxSessions - workers),
+    };
+  }
+
+  async spawnSession(opts: SpawnOptions): Promise<SpawnResult> {
+    const slotClass = opts.slotClass === "system" ? "system" : "worker";
+    const { workers, system } = this.countActive();
+    if (slotClass === "system") {
+      if (system >= this.systemHeadroom) {
+        throw new SessionCapError({
+          maxSessions: this.systemHeadroom,
+          activeCount: system,
+          slotClass: "system",
+        });
+      }
+    } else if (workers >= this.maxSessions) {
+      throw new SessionCapError({
+        maxSessions: this.maxSessions,
+        activeCount: workers,
+        slotClass: "worker",
+      });
+    }
+    const id = `sess-${++this.counter}`;
+    const session: SessionInfo = {
+      id,
+      name: opts.name ?? id,
+      agentType: opts.agentType ?? "opencode",
+      workdir: opts.workdir ?? "/tmp/orch-x",
+      status: "ready",
+      approvalPreset: opts.approvalPreset ?? "standard",
+      createdAt: new Date(++this.clock),
+      lastActivityAt: new Date(this.clock),
+      metadata: { ...(opts.metadata ?? {}), slotClass },
+    };
+    this.sessions.set(id, session);
+    const taskId = (opts.metadata as Record<string, unknown> | undefined)
+      ?.taskId;
+    if (typeof taskId === "string") this.spawnLog.push(taskId);
+    return {
+      sessionId: id,
+      id,
+      name: session.name ?? id,
+      agentType: session.agentType,
+      workdir: session.workdir,
+      status: "ready",
+      metadata: session.metadata,
+    };
+  }
+
+  async getSession(sessionId: string): Promise<SessionInfo | undefined> {
+    return this.sessions.get(sessionId);
+  }
+
+  async listSessions(): Promise<SessionInfo[]> {
+    return [...this.sessions.values()];
+  }
+
+  async stopSession(sessionId: string): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) return;
+    session.status = "stopped";
+    this.emit(sessionId, "stopped", {});
+  }
+
+  /** Test helper: drive the active session of a task to completion (frees its
+   *  worker slot and fires the terminal event that triggers a drain). */
+  completeByTask(taskId: string): void {
+    for (const session of this.sessions.values()) {
+      if (TERMINAL_SESSION_STATUSES.has(session.status)) continue;
+      if (
+        (session.metadata as Record<string, unknown> | undefined)?.taskId ===
+        taskId
+      ) {
+        session.status = "completed";
+        this.emit(session.id, "task_complete", { response: "done" });
+        return;
+      }
+    }
+    throw new Error(`no active session for task ${taskId}`);
+  }
+
+  /** Test helper: seed a pre-existing active worker (a full cap before start). */
+  seedActiveWorker(taskId: string): void {
+    const id = `seed-${++this.counter}`;
+    this.sessions.set(id, {
+      id,
+      name: id,
+      agentType: "opencode",
+      workdir: "/tmp/orch-x",
+      status: "ready",
+      approvalPreset: "standard",
+      createdAt: new Date(++this.clock),
+      lastActivityAt: new Date(this.clock),
+      metadata: { taskId, slotClass: "worker", keepAliveAfterComplete: true },
+    });
+  }
+
+  /** Test helper: seed a completed keepAlive session for a terminal task, so
+   *  the dispatcher can reclaim its slot. */
+  seedIdleKeepAlive(taskId: string): string {
+    const id = `idle-${++this.counter}`;
+    this.sessions.set(id, {
+      id,
+      name: id,
+      agentType: "opencode",
+      workdir: "/tmp/orch-x",
+      status: "ready",
+      approvalPreset: "standard",
+      createdAt: new Date(++this.clock),
+      lastActivityAt: new Date(this.clock),
+      metadata: { taskId, slotClass: "worker", keepAliveAfterComplete: true },
+    });
+    return id;
+  }
+
+  private emit(sessionId: string, event: string, data: unknown): void {
+    for (const handler of [...this.handlers]) handler(sessionId, event, data);
+  }
+}
+
+function makeRuntime(
+  fake: FakeAcp,
+  settings: Record<string, string> = {},
+): {
+  runtime: IAgentRuntime;
+  bindService: (service: OrchestratorTaskService) => void;
+} {
+  let orchestrator: OrchestratorTaskService | undefined;
+  const runtime = {
+    character: { name: "Tester" },
+    adapter: undefined,
+    databaseAdapter: undefined,
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    reportError: vi.fn(),
+    getSetting: (key: string) => settings[key],
+    useModel: vi.fn(async () => "{}"),
+    getService: (type: string) => {
+      if (
+        type === AcpService.serviceType ||
+        type === "ACP_SUBPROCESS_SERVICE"
+      ) {
+        return fake;
+      }
+      if (type === OrchestratorTaskService.serviceType) return orchestrator;
+      return undefined;
+    },
+  } as unknown as IAgentRuntime;
+  return {
+    runtime,
+    bindService: (service) => {
+      orchestrator = service;
+    },
+  };
+}
+
+async function makeService(
+  fake: FakeAcp,
+  settings: Record<string, string> = {},
+): Promise<{ service: OrchestratorTaskService; runtime: IAgentRuntime }> {
+  const store = new OrchestratorTaskStore({ backend: "memory" });
+  const { runtime, bindService } = makeRuntime(fake, settings);
+  const service = new OrchestratorTaskService(runtime as never, { store });
+  bindService(service);
+  await service.start();
+  return { service, runtime };
+}
+
+async function seedTask(
+  service: OrchestratorTaskService,
+  input: {
+    title?: string;
+    priority?: OrchestratorTaskPriority;
+    roomId?: string;
+  } = {},
+): Promise<string> {
+  const store = (service as unknown as { store: OrchestratorTaskStore }).store;
+  const doc = await store.createTask({
+    title: input.title ?? "task",
+    goal: "do the thing",
+    acceptanceCriteria: [],
+    priority: input.priority,
+    roomId: input.roomId,
+  });
+  return doc.task.id;
+}
+
+describe("orchestrator admission queue (real service + fake ACP)", () => {
+  let savedVerifyFlag: string | undefined;
+  beforeEach(() => {
+    savedVerifyFlag = process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+    process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = "0";
+  });
+  afterEach(() => {
+    if (savedVerifyFlag === undefined)
+      delete process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+    else process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = savedVerifyFlag;
+    vi.restoreAllMocks();
+  });
+
+  it("parks tasks at the session cap, returning a queued DTO with a position", async () => {
+    const fake = new FakeAcp(2);
+    const { service } = await makeService(fake);
+
+    // Two spawns fill the worker pool.
+    const a = await seedTask(service, { title: "A" });
+    const b = await seedTask(service, { title: "B" });
+    const detailA = await service.spawnAgentForTask(a);
+    const detailB = await service.spawnAgentForTask(b);
+    expect(detailA?.admission).toBeUndefined();
+    expect(detailB?.admission).toBeUndefined();
+    expect(detailA?.status).toBe("active");
+
+    // Enqueue three more, in REVERSE priority order, to prove the queue reorders
+    // by priority (not insertion): low, then high, then urgent.
+    const low = await seedTask(service, { title: "low", priority: "low" });
+    const high = await seedTask(service, { title: "high", priority: "high" });
+    const urgent = await seedTask(service, {
+      title: "urgent",
+      priority: "urgent",
+    });
+    const detailLow = await service.spawnAgentForTask(low);
+    const detailHigh = await service.spawnAgentForTask(high);
+    const detailUrgent = await service.spawnAgentForTask(urgent);
+
+    expect(detailLow?.admission?.state).toBe("queued");
+    expect(detailHigh?.admission?.state).toBe("queued");
+    expect(detailUrgent?.admission?.state).toBe("queued");
+    // Urgent, enqueued last, still lands at the head.
+    expect(detailUrgent?.admission?.position).toBe(1);
+
+    // The two spawned tasks stayed active; three are parked.
+    const capacity = await service.getCapacitySnapshot();
+    expect(capacity).toMatchObject({
+      maxSessions: 2,
+      activeWorkers: 2,
+      freeSlots: 0,
+      queueDepth: 3,
+    });
+    expect(capacity.queue.map((q) => q.taskId)).toEqual([urgent, high, low]);
+    expect(capacity.queue.map((q) => q.position)).toEqual([1, 2, 3]);
+
+    await service.stop();
+  });
+
+  it("drains in priority order with zero drops as sessions complete", async () => {
+    const fake = new FakeAcp(2);
+    const { service } = await makeService(fake);
+
+    const fillerA = await seedTask(service, { title: "fillA" });
+    const fillerB = await seedTask(service, { title: "fillB" });
+    await service.spawnAgentForTask(fillerA);
+    await service.spawnAgentForTask(fillerB);
+
+    const low = await seedTask(service, { title: "low", priority: "low" });
+    const high = await seedTask(service, { title: "high", priority: "high" });
+    const urgent = await seedTask(service, {
+      title: "urgent",
+      priority: "urgent",
+    });
+    await service.spawnAgentForTask(low);
+    await service.spawnAgentForTask(high);
+    await service.spawnAgentForTask(urgent);
+    expect(fake.spawnLog).toEqual([fillerA, fillerB]);
+
+    // Free a slot: the highest-priority queued task (urgent) dispatches.
+    fake.completeByTask(fillerA);
+    await vi.waitFor(() => expect(fake.spawnLog).toContain(urgent));
+
+    fake.completeByTask(fillerB);
+    await vi.waitFor(() => expect(fake.spawnLog).toContain(high));
+
+    fake.completeByTask(urgent);
+    await vi.waitFor(() => expect(fake.spawnLog).toContain(low));
+
+    // Dispatch order after the two fillers is exactly the priority order — and
+    // every queued task was dispatched (zero drops).
+    expect(fake.spawnLog.slice(2)).toEqual([urgent, high, low]);
+    const finalCapacity = await service.getCapacitySnapshot();
+    expect(finalCapacity.queueDepth).toBe(0);
+
+    await service.stop();
+  });
+
+  it("rejects a spawn beyond the queue depth cap with AdmissionQueueFullError", async () => {
+    const fake = new FakeAcp(1);
+    const { service } = await makeService(fake, {
+      ELIZA_ACP_ADMISSION_QUEUE_DEPTH: "2",
+    });
+
+    const active = await seedTask(service, { title: "active" });
+    await service.spawnAgentForTask(active); // fills the 1 worker slot
+
+    const q1 = await seedTask(service, { title: "q1" });
+    const q2 = await seedTask(service, { title: "q2" });
+    const q3 = await seedTask(service, { title: "q3" });
+    await service.spawnAgentForTask(q1); // depth 1
+    await service.spawnAgentForTask(q2); // depth 2 (cap)
+
+    await expect(service.spawnAgentForTask(q3)).rejects.toBeInstanceOf(
+      AdmissionQueueFullError,
+    );
+    expect((await service.getCapacitySnapshot()).queueDepth).toBe(2);
+
+    await service.stop();
+  });
+
+  it("dequeues a queued task on pause and re-enqueues on resume", async () => {
+    const fake = new FakeAcp(1);
+    const { service } = await makeService(fake);
+
+    const active = await seedTask(service, { title: "active" });
+    await service.spawnAgentForTask(active);
+    const queued = await seedTask(service, { title: "queued" });
+    const detail = await service.spawnAgentForTask(queued);
+    expect(detail?.admission?.state).toBe("queued");
+
+    // Pause removes it from the dispatch running.
+    await service.pauseTask(queued);
+    expect((await service.getCapacitySnapshot()).queueDepth).toBe(0);
+
+    // Freeing a slot does NOT dispatch the paused task.
+    fake.completeByTask(active);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fake.spawnLog).not.toContain(queued);
+
+    // Resume re-enqueues and, with a slot now free, dispatches it.
+    await service.resumeTask(queued);
+    await vi.waitFor(() => expect(fake.spawnLog).toContain(queued));
+
+    await service.stop();
+  });
+
+  it("clears the admission entry when a queued task is archived", async () => {
+    const fake = new FakeAcp(1);
+    const { service } = await makeService(fake);
+
+    const active = await seedTask(service, { title: "active" });
+    await service.spawnAgentForTask(active);
+    const queued = await seedTask(service, { title: "queued" });
+    await service.spawnAgentForTask(queued);
+    expect((await service.getCapacitySnapshot()).queueDepth).toBe(1);
+
+    await service.archiveTask(queued);
+    expect((await service.getCapacitySnapshot()).queueDepth).toBe(0);
+    const detail = await service.getTask(queued);
+    expect(detail?.status).toBe("archived");
+    expect(detail?.admission).toBeUndefined();
+    expect(detail?.metadata.admission).toBeUndefined();
+
+    // A freed slot never resurrects the archived task.
+    fake.completeByTask(active);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fake.spawnLog).not.toContain(queued);
+
+    await service.stop();
+  });
+
+  it("reconstructs the queue order from durable state on restart", async () => {
+    // Pre-seed a store with a full worker pool + two parked tasks, then start a
+    // fresh service against it: the queue must rebuild in enqueue order.
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const first = await store.createTask({
+      title: "first",
+      goal: "g",
+      acceptanceCriteria: [],
+      metadata: {
+        admission: {
+          state: "queued",
+          enqueuedAt: 1000,
+          priorityAtEnqueue: "normal",
+          spawnOpts: {},
+        },
+      },
+    });
+    const second = await store.createTask({
+      title: "second",
+      goal: "g",
+      acceptanceCriteria: [],
+      metadata: {
+        admission: {
+          state: "queued",
+          enqueuedAt: 2000,
+          priorityAtEnqueue: "normal",
+          spawnOpts: {},
+        },
+      },
+    });
+
+    const fake = new FakeAcp(1);
+    fake.seedActiveWorker("occupant"); // cap full → parked tasks stay queued
+    const { runtime, bindService } = makeRuntime(fake);
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    bindService(service);
+    await service.start();
+
+    const snapshot = await service.getCapacitySnapshot();
+    expect(snapshot.queueDepth).toBe(2);
+    expect(snapshot.queue.map((q) => q.taskId)).toEqual([
+      first.task.id,
+      second.task.id,
+    ]);
+
+    await service.stop();
+  });
+
+  it("reclaims an idle keepAlive slot for a queued task when no worker slot is free", async () => {
+    const fake = new FakeAcp(1);
+    const { service } = await makeService(fake);
+
+    // A done task whose keepAlive session is still alive holds the only worker
+    // slot; a new task queues behind it.
+    const doneTask = await seedTask(service, { title: "done" });
+    const idleSessionId = fake.seedIdleKeepAlive(doneTask);
+    // Mark the holder task terminal so its slot is reclaimable.
+    await (
+      service as unknown as { store: OrchestratorTaskStore }
+    ).store.updateTask(doneTask, { status: "done" });
+
+    const queued = await seedTask(service, { title: "queued" });
+    const detail = await service.spawnAgentForTask(queued);
+    expect(detail?.admission?.state).toBe("queued");
+
+    // The reconcile drain reclaims the idle slot and dispatches the queued task.
+    await (
+      service as unknown as { drainAdmissionQueue: () => Promise<void> }
+    ).drainAdmissionQueue();
+    await vi.waitFor(() => expect(fake.spawnLog).toContain(queued));
+    expect((await fake.getSession(idleSessionId))?.status).toBe("stopped");
+
+    await service.stop();
+  });
+
+  it("surfaces the capacity line + queued backlog through the ACTIVE_SUB_AGENTS provider", async () => {
+    const fake = new FakeAcp(1);
+    const { service, runtime } = await makeService(fake);
+
+    const active = await seedTask(service, {
+      title: "active",
+      roomId: "00000000-0000-4000-8000-0000000000aa",
+    });
+    await service.spawnAgentForTask(active);
+    const queued = await seedTask(service, { title: "queued-work" });
+    await service.spawnAgentForTask(queued);
+
+    const result = await activeSubAgentsProvider.get(
+      runtime,
+      { id: "m" } as never,
+      {} as never,
+    );
+    expect(result.text).toContain("capacity: 1/1 worker sessions; queued: 1");
+    const capacity = (result.data as { capacity?: { queueDepth: number } })
+      .capacity;
+    expect(capacity?.queueDepth).toBe(1);
+
+    await service.stop();
+  });
+
+  it("restores reject-at-cap when the admission queue is disabled", async () => {
+    const fake = new FakeAcp(1);
+    const { service } = await makeService(fake, {
+      ELIZA_ACP_ADMISSION_QUEUE: "0",
+    });
+
+    const active = await seedTask(service, { title: "active" });
+    await service.spawnAgentForTask(active);
+    const rejected = await seedTask(service, { title: "rejected" });
+
+    await expect(service.spawnAgentForTask(rejected)).rejects.toMatchObject({
+      code: "SESSION_CAP_REACHED",
+    });
+    expect((await service.getCapacitySnapshot()).queueDepth).toBe(0);
+
+    await service.stop();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -32,6 +32,7 @@ import type {
   OrchestratorTaskPriority,
   TaskProviderPolicy,
 } from "../services/orchestrator-task-types.js";
+import { AdmissionQueueFullError } from "../services/types.js";
 import type { RouteContext } from "./route-utils.js";
 import {
   asBoolean,
@@ -233,6 +234,13 @@ async function dispatchOrchestratorRoutes(
   // GET /api/orchestrator/status
   if (method === "GET" && pathname === `${PREFIX}/status`) {
     sendJson(res, await service.getStatus());
+    return true;
+  }
+
+  // GET /api/orchestrator/capacity — worker/system pool counts + the ordered
+  // admission queue (tasks parked at the session cap awaiting a free slot).
+  if (method === "GET" && pathname === `${PREFIX}/capacity`) {
+    sendJson(res, await service.getCapacitySnapshot());
     return true;
   }
 
@@ -953,11 +961,12 @@ async function dispatchOrchestratorRoutes(
             task: asString(body.task),
           });
         } catch (error) {
-          // error-policy:J1 route boundary — spawn failure becomes a 500 response.
+          // error-policy:J1 route boundary — a full admission queue is a
+          // retry-later 429; any other spawn failure is a 500.
           sendError(
             res,
             error instanceof Error ? error.message : "Failed to spawn agent",
-            500,
+            error instanceof AdmissionQueueFullError ? 429 : 500,
           );
           return true;
         }
@@ -965,7 +974,9 @@ async function dispatchOrchestratorRoutes(
           sendError(res, "Task not found", 404);
           return true;
         }
-        sendJson(res, task, 201);
+        // A parked task returns 202 (Accepted, not yet spawned) with its queue
+        // position in the DTO; an immediate spawn stays 201 (Created).
+        sendJson(res, task, task.admission?.state === "queued" ? 202 : 201);
         return true;
       }
       // POST /tasks/:taskId/agents/:sessionId/stop

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -13,6 +13,7 @@ import type {
   State,
 } from "@elizaos/core";
 import { getAcpService } from "../actions/common.js";
+import type { CapacitySnapshot } from "../services/orchestrator-task-service.js";
 import { TASK_WATCHDOG_SERVICE_TYPE } from "../services/task-watchdog-service.js";
 import {
   type SessionInfo,
@@ -20,6 +21,54 @@ import {
 } from "../services/types.js";
 
 type ApproachingCapKind = "round-trip" | "spend";
+
+/** The structural slice of the admission-queue capacity the planner needs:
+ *  pool counts and ordered queued task ids/labels — no timestamps, so the
+ *  provider segment stays prefix-cache stable turn over turn. */
+interface CapacityView {
+  maxSessions: number;
+  activeWorkers: number;
+  queueDepth: number;
+  queuedTaskIds: string[];
+  nextTitle?: string;
+}
+
+/** Read the admission-queue capacity from the orchestrator task service.
+ *  Returns undefined when the service is absent or the read fails — the
+ *  capacity line is a supplementary planner hint, never the session list. */
+async function readCapacity(
+  runtime: IAgentRuntime,
+): Promise<CapacityView | undefined> {
+  const service = runtime.getService<
+    Service & { getCapacitySnapshot?: () => Promise<CapacitySnapshot> }
+  >("ORCHESTRATOR_TASK_SERVICE");
+  if (!service || typeof service.getCapacitySnapshot !== "function") {
+    return undefined;
+  }
+  try {
+    const snapshot = await service.getCapacitySnapshot();
+    return {
+      maxSessions: snapshot.maxSessions,
+      activeWorkers: snapshot.activeWorkers,
+      queueDepth: snapshot.queueDepth,
+      queuedTaskIds: snapshot.queue.map((item) => item.taskId),
+      nextTitle: snapshot.queue[0]?.title,
+    };
+  } catch {
+    // error-policy:J4 capacity is a supplementary planner hint; an unavailable
+    // snapshot degrades to no capacity line, not a masked session-list failure.
+    return undefined;
+  }
+}
+
+/** Structural, timestamp-free capacity line for the provider text. */
+function capacityLine(capacity: CapacityView): string {
+  const queued =
+    capacity.queueDepth > 0
+      ? `queued: ${capacity.queueDepth} (next: ${capacity.nextTitle ?? "task"})`
+      : "queued: 0";
+  return `capacity: ${capacity.activeWorkers}/${capacity.maxSessions} worker sessions; ${queued}`;
+}
 
 /** Read the watchdog's current stalled-session set (empty when unavailable). */
 function stalledSessionIds(runtime: IAgentRuntime): Set<string> {
@@ -139,7 +188,29 @@ export const activeSubAgentsProvider: Provider = {
     const routed = (Array.isArray(all) ? all : [])
       .filter(hasOrigin)
       .filter((s) => !TERMINAL_SESSION_STATUSES.has(s.status));
-    if (routed.length === 0) return emptyResult();
+    const capacity = await readCapacity(runtime);
+    const capData = capacity
+      ? {
+          maxSessions: capacity.maxSessions,
+          activeWorkers: capacity.activeWorkers,
+          queueDepth: capacity.queueDepth,
+          queuedTaskIds: capacity.queuedTaskIds,
+        }
+      : undefined;
+    // Nothing to show only when there are no live routed sessions AND nothing
+    // parked in the admission queue; a queued task with no live routed session
+    // still surfaces the capacity line so the planner sees the backlog.
+    if (routed.length === 0 && (!capacity || capacity.queueDepth === 0)) {
+      return emptyResult();
+    }
+    if (routed.length === 0 && capacity && capacity.queueDepth > 0) {
+      const text = `## Active sub-agent sessions\n${capacityLine(capacity)}`;
+      return {
+        text,
+        values: { activeSubAgents: text },
+        data: { sessions: [], capacity: capData },
+      };
+    }
 
     routed.sort((a, b) => a.id.localeCompare(b.id));
 
@@ -176,6 +247,7 @@ export const activeSubAgentsProvider: Provider = {
       "Each line is a live sub-agent. Reply to one with SEND_TO_AGENT { sessionId, text }; terminate with STOP_AGENT { sessionId }. Replying to the user uses the standard REPLY action; you may do both in one turn.",
       "The sub-agent's task_complete event is the ground truth for outcomes. For history about past sub-agents, call TASKS_HISTORY explicitly.",
     ];
+    if (capacity) lines.push(capacityLine(capacity));
     for (const session of routed) {
       lines.push(
         formatLine(
@@ -205,6 +277,7 @@ export const activeSubAgentsProvider: Provider = {
           originUserId: (s.metadata as Record<string, unknown> | undefined)
             ?.userId,
         })),
+        capacity: capData,
       },
     };
   },

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -78,9 +78,11 @@ import {
   type AvailableAgentInfo,
   type PromptResult,
   type SendOptions,
+  SessionCapError,
   type SessionEventCallback,
   type SessionEventName,
   type SessionInfo,
+  type SessionSlotClass,
   type SessionStore,
   type SpawnOptions,
   type SpawnResult,
@@ -135,6 +137,25 @@ type RunResult = {
   cancelled?: boolean;
   durationMs: number;
 };
+
+/** Live capacity split by slot class. `freeSlots` is the remaining worker
+ *  headroom (`max(0, maxSessions - activeWorkers)`); the orchestrator admission
+ *  queue drains while it is positive. */
+export interface AcpCapacity {
+  maxSessions: number;
+  activeWorkers: number;
+  activeSystem: number;
+  systemHeadroom: number;
+  freeSlots: number;
+}
+
+/** Read a session's slot class off its metadata; anything but the explicit
+ *  `system` marker (including a pre-slot-class session) counts as `worker`. */
+function slotClassOf(session: SessionInfo): SessionSlotClass {
+  const raw = (session.metadata as Record<string, unknown> | undefined)
+    ?.slotClass;
+  return raw === "system" ? "system" : "worker";
+}
 
 const STDERR_CAP_BYTES = 64 * 1024;
 const KILL_GRACE_MS = 5_000;
@@ -290,6 +311,12 @@ export class AcpService extends Service {
   private readonly transportMode: "native" | "cli";
   private readonly defaultAgent: AgentType;
   private readonly maxSessions: number;
+  // Reserved slots for short-lived `system` sessions (the read-only completion
+  // verifier), counted separately from `maxSessions` so validation can spawn
+  // even when every worker slot is taken — otherwise a full worker pool would
+  // deadlock: the task that must validate can never free a slot for its own
+  // verifier. Overridable via ELIZA_ACP_SYSTEM_SESSION_HEADROOM.
+  private readonly systemSessionHeadroom: number;
   // Serializes the session-limit check-and-reserve so concurrent spawns can't
   // each pass the limit check before any has inserted (which would overshoot
   // ELIZA_ACP_MAX_SESSIONS). A promise-chain mutex: each reservation awaits the
@@ -345,6 +372,8 @@ export class AcpService extends Service {
       "fixed";
     this.maxSessions =
       parsePositiveInt(this.setting("ELIZA_ACP_MAX_SESSIONS")) ?? 8;
+    this.systemSessionHeadroom =
+      parsePositiveInt(this.setting("ELIZA_ACP_SYSTEM_SESSION_HEADROOM")) ?? 2;
     this.sessionTimeoutMs = parsePositiveInt(
       this.setting("ACPX_DEFAULT_TIMEOUT_MS") ??
         this.setting("ELIZA_ACP_PROMPT_TIMEOUT_MS"),
@@ -779,6 +808,11 @@ export class AcpService extends Service {
     }
 
     const now = new Date();
+    // Stamp the slot class onto the session so the capacity accounting can read
+    // it back (getCapacity / enforceSessionLimit) and so reattach/reconcile keep
+    // a respawned session in the same pool. Default worker.
+    const slotClass: SessionSlotClass =
+      opts.slotClass === "system" ? "system" : "worker";
     const mergedMetadata: Record<string, unknown> = {
       ...(opts.metadata ?? {}),
       ...(baselineSha ? { codingBaselineSha: baselineSha } : {}),
@@ -786,11 +820,8 @@ export class AcpService extends Service {
         ? { codingBaselineDirty: baselineDirty }
         : {}),
       ...(resolvedAccount ? { account: resolvedAccount.meta } : {}),
+      slotClass,
     };
-    const hasMergedMetadata =
-      Boolean(baselineSha) ||
-      Boolean(resolvedAccount) ||
-      Boolean(opts.metadata);
     const session: SessionInfo = {
       id,
       name,
@@ -800,12 +831,12 @@ export class AcpService extends Service {
       approvalPreset,
       createdAt: now,
       lastActivityAt: now,
-      metadata: hasMergedMetadata ? mergedMetadata : opts.metadata,
+      metadata: mergedMetadata,
     };
     // Atomic check-and-reserve: enforces the session limit and inserts under a
-    // single mutex so concurrent spawns can't overshoot maxSessions (the old
+    // single mutex so concurrent spawns can't overshoot the cap (the old
     // separate enforceSessionLimit()/store.create() left a read-then-act race).
-    await this.reserveSessionSlot(session);
+    await this.reserveSessionSlot(session, slotClass);
 
     // Mint the per-spawn model lease BEFORE the transport branch, so the leased
     // token (not the static gateway token) is what buildEnv injects into the
@@ -2448,14 +2479,56 @@ export class AcpService extends Service {
     return session;
   }
 
-  private async enforceSessionLimit(): Promise<void> {
-    const sessions = await this.store.list();
-    const active = sessions.filter(
-      (s) =>
-        !["stopped", "errored", "completed", "cancelled"].includes(s.status),
-    );
-    if (active.length >= this.maxSessions)
-      throw new Error(`acpx max session limit reached (${this.maxSessions})`);
+  /**
+   * Current capacity split by slot class. `activeWorkers`/`activeSystem` count
+   * live (non-terminal) sessions in each pool; `freeSlots` is the remaining
+   * worker headroom. Read by `getCapacity` (the API + provider) and reused by
+   * `enforceSessionLimit` so the counting rule has one definition.
+   */
+  private computeCapacity(sessions: SessionInfo[]): AcpCapacity {
+    let activeWorkers = 0;
+    let activeSystem = 0;
+    for (const session of sessions) {
+      if (TERMINAL_SESSION_STATUSES.has(session.status)) continue;
+      if (slotClassOf(session) === "system") activeSystem += 1;
+      else activeWorkers += 1;
+    }
+    return {
+      maxSessions: this.maxSessions,
+      activeWorkers,
+      activeSystem,
+      systemHeadroom: this.systemSessionHeadroom,
+      freeSlots: Math.max(0, this.maxSessions - activeWorkers),
+    };
+  }
+
+  /** Live capacity snapshot for the admission queue, the `/capacity` route, and
+   *  the `ACTIVE_SUB_AGENTS` provider. */
+  async getCapacity(): Promise<AcpCapacity> {
+    return this.computeCapacity(await this.store.list());
+  }
+
+  private async enforceSessionLimit(
+    slotClass: SessionSlotClass,
+  ): Promise<void> {
+    const capacity = this.computeCapacity(await this.store.list());
+    if (slotClass === "system") {
+      if (capacity.activeSystem >= this.systemSessionHeadroom) {
+        throw new SessionCapError({
+          maxSessions: this.systemSessionHeadroom,
+          activeCount: capacity.activeSystem,
+          slotClass: "system",
+        });
+      }
+      return;
+    }
+    if (capacity.activeWorkers >= this.maxSessions) {
+      throw new SessionCapError({
+        maxSessions: this.maxSessions,
+        activeCount: capacity.activeWorkers,
+        slotClass: "worker",
+      });
+    }
   }
 
   /**
@@ -2463,7 +2536,7 @@ export class AcpService extends Service {
    * session. Wrapping the check (`enforceSessionLimit`) and the insert
    * (`store.create`) in a single mutex-guarded critical section makes them one
    * indivisible operation, so N concurrent spawns can't all pass the limit
-   * check before any has inserted and overshoot `maxSessions`.
+   * check before any has inserted and overshoot the pool cap.
    *
    * The mutex is a promise chain: each call awaits the previous reservation's
    * settlement (success OR failure) before running its own check+insert, so
@@ -2472,7 +2545,10 @@ export class AcpService extends Service {
    * never rejects (we swallow on the tail) so one failed reservation doesn't
    * wedge the lock for later spawns.
    */
-  private async reserveSessionSlot(session: SessionInfo): Promise<void> {
+  private async reserveSessionSlot(
+    session: SessionInfo,
+    slotClass: SessionSlotClass,
+  ): Promise<void> {
     const previous = this.spawnReservationLock;
     let release!: () => void;
     this.spawnReservationLock = new Promise<void>((resolve) => {
@@ -2483,7 +2559,7 @@ export class AcpService extends Service {
     // awaiter; here we only serialize on its settle before counting slots.
     await previous.catch(() => {});
     try {
-      await this.enforceSessionLimit();
+      await this.enforceSessionLimit(slotClass);
       await this.store.create(session);
     } finally {
       release();

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-mapper.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-mapper.ts
@@ -48,6 +48,17 @@ export interface TaskThreadDto {
   updatedAt: string;
   closedAt: string | null;
   archivedAt: string | null;
+  /**
+   * Present only when the task is parked in the admission queue (at the session
+   * cap, awaiting a free worker slot). `position` is the 1-based live rank in
+   * the queue; it is overlaid by {@link OrchestratorTaskService} rather than the
+   * pure mapper because it depends on the whole ordered queue, not one doc.
+   */
+  admission?: {
+    state: "queued";
+    position: number;
+    enqueuedAt: string;
+  };
 }
 
 export interface TaskSessionDto {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -29,7 +29,7 @@ import {
   type OrchestratorTaskType,
   shouldRequireGoalContract,
 } from "./acceptance-criteria.js";
-import { AcpService } from "./acp-service.js";
+import { type AcpCapacity, AcpService } from "./acp-service.js";
 import { assignAgentName } from "./agent-name-assignment.js";
 import {
   accountMetaFromSessionMetadata,
@@ -97,6 +97,7 @@ import {
   type OrchestratorRoomRoster,
   type OrchestratorRoomRosterOverview,
   type OrchestratorTaskDocument,
+  type OrchestratorTaskPriority,
   type OrchestratorTaskRecord,
   type OrchestratorTaskSession,
   type OrchestratorTaskStatus,
@@ -115,7 +116,14 @@ import {
   configureSpendLedger,
   createTaskStoreSpendLedger,
 } from "./spend-allowance.js";
-import type { ApprovalPreset } from "./types.js";
+import {
+  AdmissionQueueFullError,
+  type ApprovalPreset,
+  SessionCapError,
+  type SessionInfo,
+  type SpawnResult,
+  TERMINAL_SESSION_STATUSES,
+} from "./types.js";
 import {
   ensureTaskWorkdir,
   resolveAllowedWorkdir,
@@ -137,6 +145,194 @@ export class RecoveryConflictError extends Error {
     super(message);
     this.name = "RecoveryConflictError";
   }
+}
+
+// ---- admission queue ------------------------------------------------------
+// When the ACP worker pool is at `ELIZA_ACP_MAX_SESSIONS`, a spawn no longer
+// fails: the task is PARKED (its `open` status plus a durable
+// `metadata.admission` entry) and a dispatcher drains the queue as worker slots
+// free. The queue is in-memory but rebuilt from `open` tasks at boot, so no new
+// table and no new task status are needed — `open` already means "created, no
+// live session".
+
+/** Default flag values; each overridable via the matching env var / setting. */
+const DEFAULT_ADMISSION_QUEUE_DEPTH = 32;
+const DEFAULT_QUEUE_AGING_MS = 600_000; // 10 min → one band promotion.
+const ADMISSION_RECONCILE_INTERVAL_MS = 30_000;
+
+/** Priority bands as comparable integers (higher dispatches first). */
+const PRIORITY_BAND: Record<OrchestratorTaskPriority, number> = {
+  low: 0,
+  normal: 1,
+  high: 2,
+  urgent: 3,
+};
+const MAX_PRIORITY_BAND = PRIORITY_BAND.urgent;
+
+/** Session events that free (or may free) a worker slot, so the dispatcher runs. */
+const ADMISSION_TERMINAL_EVENTS: ReadonlySet<string> = new Set([
+  "task_complete",
+  "error",
+  "stopped",
+]);
+
+/**
+ * The serializable subset of {@link SpawnAgentForTaskOptions} persisted with a
+ * queued task so its eventual dispatch reproduces the caller's intent. Excludes
+ * `nestingDepth` (a live recursion counter, meaningless once parked).
+ */
+export interface SavedSpawnOpts {
+  framework?: string;
+  providerSource?: string;
+  model?: string;
+  workdir?: string;
+  repo?: string;
+  label?: string;
+  task?: string;
+  approvalPreset?: ApprovalPreset;
+}
+
+/** Durable admission record stamped on `task.metadata.admission`. */
+export interface AdmissionMetadata {
+  state: "queued";
+  enqueuedAt: number;
+  priorityAtEnqueue: OrchestratorTaskPriority;
+  spawnOpts: SavedSpawnOpts;
+}
+
+/** In-memory queue entry — the durable admission fields plus the cheap task
+ *  descriptors (title/roomId) the capacity snapshot and supervisor digest read
+ *  without a per-call store lookup. */
+interface AdmissionQueueEntry {
+  taskId: string;
+  title: string;
+  roomId?: string;
+  enqueuedAt: number;
+  priorityAtEnqueue: OrchestratorTaskPriority;
+  spawnOpts: SavedSpawnOpts;
+}
+
+/** One queued task as the `/capacity` route + provider present it. */
+export interface CapacityQueueItem {
+  taskId: string;
+  title: string;
+  position: number;
+  priority: OrchestratorTaskPriority;
+  enqueuedAt: string;
+}
+
+/** Full capacity picture: ACP pool counts plus the ordered admission queue. */
+export interface CapacitySnapshot {
+  maxSessions: number;
+  activeWorkers: number;
+  activeSystem: number;
+  freeSlots: number;
+  queueDepth: number;
+  queue: CapacityQueueItem[];
+}
+
+/** Effective band after aging: every `agingMs` of wait promotes one band, so a
+ *  `low` task cannot starve behind a steady stream of higher-priority work. */
+function effectiveBand(
+  entry: Pick<AdmissionQueueEntry, "enqueuedAt" | "priorityAtEnqueue">,
+  nowMs: number,
+  agingMs: number,
+): number {
+  const base = PRIORITY_BAND[entry.priorityAtEnqueue];
+  if (agingMs <= 0) return base;
+  const promotions = Math.floor(
+    Math.max(0, nowMs - entry.enqueuedAt) / agingMs,
+  );
+  return Math.min(MAX_PRIORITY_BAND, base + promotions);
+}
+
+/**
+ * Deterministic total order over queued entries: (effectiveBand desc,
+ * enqueuedAt asc, taskId asc). Pure so the ordering — including aging promotion
+ * and the taskId tie-break — is unit-testable without a clock or services.
+ */
+export function orderAdmissionQueue<
+  T extends {
+    taskId: string;
+    enqueuedAt: number;
+    priorityAtEnqueue: OrchestratorTaskPriority;
+  },
+>(entries: readonly T[], nowMs: number, agingMs: number): T[] {
+  return [...entries].sort((a, b) => {
+    const bandDelta =
+      effectiveBand(b, nowMs, agingMs) - effectiveBand(a, nowMs, agingMs);
+    if (bandDelta !== 0) return bandDelta;
+    if (a.enqueuedAt !== b.enqueuedAt) return a.enqueuedAt - b.enqueuedAt;
+    return a.taskId.localeCompare(b.taskId);
+  });
+}
+
+/** Validate a persisted `metadata.admission` value back into typed
+ *  {@link AdmissionMetadata}; returns undefined when absent or malformed so a
+ *  corrupt entry is ignored rather than dispatched with junk options. */
+function readAdmissionMetadata(
+  metadata: Record<string, unknown> | undefined,
+): AdmissionMetadata | undefined {
+  const raw = metadata?.admission;
+  if (!isRecord(raw)) return undefined;
+  if (raw.state !== "queued") return undefined;
+  if (typeof raw.enqueuedAt !== "number") return undefined;
+  const priority = raw.priorityAtEnqueue;
+  if (
+    priority !== "low" &&
+    priority !== "normal" &&
+    priority !== "high" &&
+    priority !== "urgent"
+  ) {
+    return undefined;
+  }
+  return {
+    state: "queued",
+    enqueuedAt: raw.enqueuedAt,
+    priorityAtEnqueue: priority,
+    spawnOpts: isRecord(raw.spawnOpts) ? pickSavedSpawnOpts(raw.spawnOpts) : {},
+  };
+}
+
+/** Extract only the serializable spawn options, dropping undefined + unknown
+ *  keys so the durable admission record stays lean and typed. */
+function pickSavedSpawnOpts(source: Record<string, unknown>): SavedSpawnOpts {
+  const out: SavedSpawnOpts = {};
+  if (typeof source.framework === "string") out.framework = source.framework;
+  if (typeof source.providerSource === "string")
+    out.providerSource = source.providerSource;
+  if (typeof source.model === "string") out.model = source.model;
+  if (typeof source.workdir === "string") out.workdir = source.workdir;
+  if (typeof source.repo === "string") out.repo = source.repo;
+  if (typeof source.label === "string") out.label = source.label;
+  if (typeof source.task === "string") out.task = source.task;
+  if (typeof source.approvalPreset === "string")
+    out.approvalPreset = source.approvalPreset as ApprovalPreset;
+  return out;
+}
+
+/** Read a positive-integer setting/env value, else the default. */
+function positiveIntSetting(
+  runtime: { getSetting?: (key: string) => string | undefined | null },
+  key: string,
+  fallback: number,
+): number {
+  const raw = runtime.getSetting?.(key) ?? process.env[key];
+  const parsed =
+    typeof raw === "string" ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+/** The admission queue is ON unless explicitly disabled (`0`/`false`/`off`/`no`)
+ *  — a kill switch that restores the legacy reject-at-cap behavior. */
+function admissionQueueEnabled(runtime: {
+  getSetting?: (key: string) => string | undefined | null;
+}): boolean {
+  const raw =
+    runtime.getSetting?.("ELIZA_ACP_ADMISSION_QUEUE") ??
+    process.env.ELIZA_ACP_ADMISSION_QUEUE;
+  if (typeof raw !== "string") return true;
+  return !["0", "false", "off", "no"].includes(raw.trim().toLowerCase());
 }
 
 type RuntimeLike = IAgentRuntime & {
@@ -625,12 +821,37 @@ export class OrchestratorTaskService extends Service {
   private unsubscribe: (() => void) | undefined;
   private started = false;
 
+  // ---- admission queue state --------------------------------------------
+  private readonly admissionEnabled: boolean;
+  private readonly queueDepthCap: number;
+  private readonly queueAgingMs: number;
+  // In-memory ordered by priority+age at drain time (see orderAdmissionQueue);
+  // the durable source of truth is each task's `metadata.admission`, from which
+  // this list is rebuilt on start().
+  private readonly admissionQueue: AdmissionQueueEntry[] = [];
+  // Serializes drains so the terminal-event trigger and the reconcile tick can't
+  // dispatch the same slot twice; a request arriving mid-drain re-runs after.
+  private draining = false;
+  private drainRequested = false;
+  private reconcileTimer: ReturnType<typeof setInterval> | undefined;
+
   constructor(
     runtime: IAgentRuntime,
     opts: { store?: OrchestratorTaskStore } = {},
   ) {
     super(runtime);
     this.runtime = runtime as RuntimeLike;
+    this.admissionEnabled = admissionQueueEnabled(this.runtime);
+    this.queueDepthCap = positiveIntSetting(
+      this.runtime,
+      "ELIZA_ACP_ADMISSION_QUEUE_DEPTH",
+      DEFAULT_ADMISSION_QUEUE_DEPTH,
+    );
+    this.queueAgingMs = positiveIntSetting(
+      this.runtime,
+      "ELIZA_ACP_QUEUE_AGING_MS",
+      DEFAULT_QUEUE_AGING_MS,
+    );
     this.store =
       opts.store ??
       new OrchestratorTaskStore({
@@ -661,9 +882,22 @@ export class OrchestratorTaskService extends Service {
     // Persist self-spend durably so a configured ELIZA_AGENT_SPEND_CAP_USD
     // survives a restart instead of resetting to zero (#8924).
     configureSpendLedger(createTaskStoreSpendLedger(this.store));
+    // Rebuild the in-memory admission queue from durable state so a restart
+    // mid-queue resumes dispatching parked tasks instead of stranding them.
+    if (this.admissionEnabled) {
+      await this.rebuildAdmissionQueue();
+      // A 30s reconcile tick is the safety net for the event-driven drain: if a
+      // terminal event is missed (crash, dropped subscription) a freed slot is
+      // still picked up within one interval.
+      this.reconcileTimer = setInterval(() => {
+        void this.drainAdmissionQueue();
+      }, ADMISSION_RECONCILE_INTERVAL_MS);
+      this.reconcileTimer.unref?.();
+    }
     const acp = this.acp();
     if (acp) {
       this.subscribeToAcp(acp);
+      if (this.admissionEnabled) void this.drainAdmissionQueue();
       return;
     }
     // ACP may not be registered yet — service start order during boot isn't
@@ -711,6 +945,10 @@ export class OrchestratorTaskService extends Service {
   async stop(): Promise<void> {
     this.unsubscribe?.();
     this.unsubscribe = undefined;
+    if (this.reconcileTimer) {
+      clearInterval(this.reconcileTimer);
+      this.reconcileTimer = undefined;
+    }
     this.started = false;
   }
 
@@ -943,6 +1181,12 @@ export class OrchestratorTaskService extends Service {
       }
       default:
         break;
+    }
+    // A terminal session event may have freed a worker slot — drain the
+    // admission queue so a parked task dispatches without waiting for the
+    // reconcile tick.
+    if (this.admissionEnabled && ADMISSION_TERMINAL_EVENTS.has(event)) {
+      void this.drainAdmissionQueue();
     }
   }
 
@@ -1601,7 +1845,12 @@ export class OrchestratorTaskService extends Service {
 
   async getTask(taskId: string): Promise<TaskThreadDetailDto | null> {
     const doc = await this.store.getTask(taskId);
-    return doc ? toTaskThreadDetail(doc) : null;
+    if (!doc) return null;
+    const detail = toTaskThreadDetail(doc);
+    const admission = this.admissionForTask(taskId);
+    // Position is a cross-task, live value (it depends on the whole ordered
+    // queue), so it is overlaid here rather than derived by the pure mapper.
+    return admission ? { ...detail, admission } : detail;
   }
 
   /**
@@ -1655,12 +1904,33 @@ export class OrchestratorTaskService extends Service {
     if (!doc) return null;
     await this.stopActiveSessions(doc);
     await this.store.updateTask(taskId, { paused: true });
+    // Take a queued task out of the dispatch running; its durable admission
+    // record persists so resume can restore its position.
+    this.removeFromAdmissionQueue(taskId);
     return this.getTask(taskId);
   }
 
   async resumeTask(taskId: string): Promise<TaskThreadDetailDto | null> {
     const updated = await this.store.updateTask(taskId, { paused: false });
     if (!updated) return null;
+    // Re-arm a paused queued task and kick a drain so it competes for a slot.
+    const admission = readAdmissionMetadata(updated.metadata);
+    if (
+      this.admissionEnabled &&
+      updated.status === "open" &&
+      admission &&
+      !this.admissionQueue.some((e) => e.taskId === taskId)
+    ) {
+      this.admissionQueue.push({
+        taskId,
+        title: updated.title,
+        roomId: updated.roomId,
+        enqueuedAt: admission.enqueuedAt,
+        priorityAtEnqueue: admission.priorityAtEnqueue,
+        spawnOpts: admission.spawnOpts,
+      });
+      void this.drainAdmissionQueue();
+    }
     return this.getTask(taskId);
   }
 
@@ -1668,6 +1938,7 @@ export class OrchestratorTaskService extends Service {
     const doc = await this.store.getTask(taskId);
     if (!doc) return null;
     await this.stopActiveSessions(doc);
+    await this.clearAdmissionMetadata(taskId);
     await this.store.updateTask(taskId, {
       archived: true,
       status: "archived",
@@ -1696,6 +1967,7 @@ export class OrchestratorTaskService extends Service {
     const doc = await this.store.getTask(taskId);
     if (!doc) return false;
     await this.stopActiveSessions(doc);
+    this.removeFromAdmissionQueue(taskId);
     for (const session of doc.sessions) {
       this.sessionTaskIndex.delete(session.sessionId);
       this.recordFailureWarned.delete(session.sessionId);
@@ -2202,6 +2474,10 @@ export class OrchestratorTaskService extends Service {
       workdir,
       initialTask: prompt,
       approvalPreset: "verifier",
+      // A `system` slot draws from the reserved verifier headroom, never the
+      // worker pool — so completion validation cannot deadlock behind a full
+      // worker cap (the task that must validate can never free its own slot).
+      slotClass: "system",
       metadata: {
         taskId,
         source: "independent-verifier",
@@ -2661,6 +2937,10 @@ export class OrchestratorTaskService extends Service {
   async spawnAgentForTask(
     taskId: string,
     opts: SpawnAgentForTaskOptions = {},
+    // Public callers get `enqueue-on-cap` (park the task at the session cap);
+    // the admission-queue dispatcher passes `throw-on-cap` so it keeps the
+    // task's queue position when it loses the slot race to a direct spawn.
+    admissionMode: "enqueue-on-cap" | "throw-on-cap" = "enqueue-on-cap",
   ): Promise<TaskThreadDetailDto | null> {
     const doc = await this.store.getTask(taskId);
     if (!doc) return null;
@@ -2736,43 +3016,62 @@ export class OrchestratorTaskService extends Service {
       }
     }
 
-    const result = await acp.spawnSession({
-      // Coding-agent selection: explicit request → routing policy → the
-      // deployment's configured default (ELIZA_ACP_DEFAULT_AGENT /
-      // ELIZA_DEFAULT_AGENT_TYPE — e.g. "elizaos" for the eliza-code coding
-      // sub-agent) → opencode as the safe fallback. Honoring the configured
-      // default here keeps this spawn path consistent with acp-service's
-      // `defaultAgent`; previously this hardcoded "opencode" because elizaos had
-      // no ACP command, but elizaos is now a supported ACP agent via
-      // ELIZA_ELIZAOS_ACP_COMMAND, so a host that selects it (local or cloud
-      // image) gets eliza-code, while unconfigured hosts still get opencode.
-      agentType:
-        opts.framework ??
-        policy.preferredFramework ??
-        configuredDefaultAgentType(this.runtime) ??
-        "opencode",
-      workdir,
-      initialTask: goalPrompt,
-      model: opts.model ?? policy.model,
-      approvalPreset: opts.approvalPreset,
-      metadata: {
-        taskId,
-        roomId: doc.task.taskRoomId ?? doc.task.roomId,
-        label: agentName,
-        source: "orchestrator",
-        // Persist the bare goal (the same key the direct-API spawn stamps) so
-        // completion-time consumers that read the task text off session
-        // metadata — the built-apps registry's app-build gate, interruption
-        // relevance — see what this session is building.
-        goal: doc.task.goal,
-        // Orchestrator sessions outlive their first prompt so follow-ups and
-        // validation re-dispatch can reuse them.
-        keepAliveAfterComplete: true,
-        // Carried so a child this sub-agent spawns can compute its own depth
-        // (parent depth + 1) and the nesting guard above can enforce the cap.
-        nestingDepth,
-      },
-    });
+    let result: SpawnResult;
+    try {
+      result = await acp.spawnSession({
+        // Coding-agent selection: explicit request → routing policy → the
+        // deployment's configured default (ELIZA_ACP_DEFAULT_AGENT /
+        // ELIZA_DEFAULT_AGENT_TYPE — e.g. "elizaos" for the eliza-code coding
+        // sub-agent) → opencode as the safe fallback. Honoring the configured
+        // default here keeps this spawn path consistent with acp-service's
+        // `defaultAgent`; previously this hardcoded "opencode" because elizaos
+        // had no ACP command, but elizaos is now a supported ACP agent via
+        // ELIZA_ELIZAOS_ACP_COMMAND, so a host that selects it (local or cloud
+        // image) gets eliza-code, while unconfigured hosts still get opencode.
+        agentType:
+          opts.framework ??
+          policy.preferredFramework ??
+          configuredDefaultAgentType(this.runtime) ??
+          "opencode",
+        workdir,
+        initialTask: goalPrompt,
+        model: opts.model ?? policy.model,
+        approvalPreset: opts.approvalPreset,
+        metadata: {
+          taskId,
+          roomId: doc.task.taskRoomId ?? doc.task.roomId,
+          label: agentName,
+          source: "orchestrator",
+          // Persist the bare goal (the same key the direct-API spawn stamps) so
+          // completion-time consumers that read the task text off session
+          // metadata — the built-apps registry's app-build gate, interruption
+          // relevance — see what this session is building.
+          goal: doc.task.goal,
+          // Orchestrator sessions outlive their first prompt so follow-ups and
+          // validation re-dispatch can reuse them.
+          keepAliveAfterComplete: true,
+          // Carried so a child this sub-agent spawns can compute its own depth
+          // (parent depth + 1) and the nesting guard above can enforce the cap.
+          nestingDepth,
+        },
+      });
+    } catch (err) {
+      // error-policy:J1 translate the ACP cap boundary — at the worker cap the
+      // atomic reserve throws SessionCapError. With the admission queue on, PARK
+      // the task instead of failing: it stays `open` with a durable admission
+      // entry, and the dispatcher spawns it when a worker slot frees.
+      // `throw-on-cap` (the dispatcher itself) rethrows so it keeps the task's
+      // queue position after losing a slot race; every other error rethrows.
+      if (
+        err instanceof SessionCapError &&
+        this.admissionEnabled &&
+        admissionMode === "enqueue-on-cap"
+      ) {
+        await this.enqueueAdmission(taskId, pickSavedSpawnOpts({ ...opts }));
+        return this.getTask(taskId);
+      }
+      throw err;
+    }
 
     const account = accountMetaFromSessionMetadata(
       result.metadata as Record<string, unknown> | undefined,
@@ -3265,6 +3564,278 @@ export class OrchestratorTaskService extends Service {
         }`,
       );
     }
+  }
+
+  // ---- admission queue ---------------------------------------------------
+
+  /** Rebuild the in-memory queue from durable state at boot: every `open` task
+   *  carrying a valid `metadata.admission` entry, ordered by enqueue time. */
+  private async rebuildAdmissionQueue(): Promise<void> {
+    this.admissionQueue.length = 0;
+    const records = await this.store.listTasks({ includeArchived: false });
+    const restored: AdmissionQueueEntry[] = [];
+    for (const record of records) {
+      if (record.status !== "open" || record.paused) continue;
+      const admission = readAdmissionMetadata(record.metadata);
+      if (!admission) continue;
+      restored.push({
+        taskId: record.id,
+        title: record.title,
+        roomId: record.roomId,
+        enqueuedAt: admission.enqueuedAt,
+        priorityAtEnqueue: admission.priorityAtEnqueue,
+        spawnOpts: admission.spawnOpts,
+      });
+    }
+    restored.sort((a, b) => a.enqueuedAt - b.enqueuedAt);
+    this.admissionQueue.push(...restored);
+  }
+
+  /** Park a task at the session cap: write the durable admission record and add
+   *  it to the in-memory queue. Idempotent for an already-queued task; throws
+   *  {@link AdmissionQueueFullError} at the depth cap. */
+  private async enqueueAdmission(
+    taskId: string,
+    spawnOpts: SavedSpawnOpts,
+  ): Promise<AdmissionMetadata | null> {
+    const doc = await this.store.getTask(taskId);
+    if (!doc) return null;
+    const existing = readAdmissionMetadata(doc.task.metadata);
+    if (existing) {
+      if (!this.admissionQueue.some((e) => e.taskId === taskId)) {
+        this.admissionQueue.push({
+          taskId,
+          title: doc.task.title,
+          roomId: doc.task.roomId,
+          enqueuedAt: existing.enqueuedAt,
+          priorityAtEnqueue: existing.priorityAtEnqueue,
+          spawnOpts: existing.spawnOpts,
+        });
+      }
+      return existing;
+    }
+    if (this.admissionQueue.length >= this.queueDepthCap) {
+      throw new AdmissionQueueFullError(this.queueDepthCap);
+    }
+    const admission: AdmissionMetadata = {
+      state: "queued",
+      enqueuedAt: Date.now(),
+      priorityAtEnqueue: doc.task.priority,
+      spawnOpts,
+    };
+    await this.store.updateTask(taskId, {
+      metadata: { ...doc.task.metadata, admission },
+    });
+    this.admissionQueue.push({
+      taskId,
+      title: doc.task.title,
+      roomId: doc.task.roomId,
+      enqueuedAt: admission.enqueuedAt,
+      priorityAtEnqueue: admission.priorityAtEnqueue,
+      spawnOpts,
+    });
+    this.log("info", "task parked in admission queue at session cap", {
+      taskId,
+      priority: admission.priorityAtEnqueue,
+      queueDepth: this.admissionQueue.length,
+    });
+    return admission;
+  }
+
+  private removeFromAdmissionQueue(taskId: string): void {
+    const idx = this.admissionQueue.findIndex((e) => e.taskId === taskId);
+    if (idx >= 0) this.admissionQueue.splice(idx, 1);
+  }
+
+  /** Clear the admission record entirely — from the in-memory queue and from
+   *  durable task metadata. Used on successful dispatch and on cancel/archive. */
+  private async clearAdmissionMetadata(taskId: string): Promise<void> {
+    this.removeFromAdmissionQueue(taskId);
+    const doc = await this.store.getTask(taskId);
+    if (!doc || !readAdmissionMetadata(doc.task.metadata)) return;
+    const { admission: _cleared, ...rest } = doc.task.metadata;
+    await this.store.updateTask(taskId, { metadata: rest });
+  }
+
+  /**
+   * Drain the admission queue while worker slots are free. Serialized: a request
+   * that arrives while a drain is running sets a re-run flag rather than
+   * dispatching concurrently, so no slot is ever double-spawned.
+   */
+  private async drainAdmissionQueue(): Promise<void> {
+    if (!this.admissionEnabled) return;
+    if (this.draining) {
+      this.drainRequested = true;
+      return;
+    }
+    this.draining = true;
+    try {
+      do {
+        this.drainRequested = false;
+        await this.drainOnce();
+      } while (this.drainRequested);
+    } finally {
+      this.draining = false;
+    }
+  }
+
+  private async drainOnce(): Promise<void> {
+    const acp = this.acp();
+    if (!acp) return;
+    while (this.admissionQueue.length > 0) {
+      const capacity = await acp.getCapacity();
+      if (capacity.freeSlots <= 0) {
+        // No worker slot: try to reclaim one from a keepAlive session whose task
+        // is already terminal. If none can be reclaimed, stop — the next
+        // terminal event or reconcile tick will retry.
+        const reclaimed = await this.reclaimIdleWorkerSlot(acp);
+        if (!reclaimed) return;
+        continue;
+      }
+      const entry = orderAdmissionQueue(
+        this.admissionQueue,
+        Date.now(),
+        this.queueAgingMs,
+      )[0];
+      if (!entry) return;
+      // Re-read the task: it may have been cancelled/paused/completed since
+      // enqueue, in which case it is no longer a dispatch candidate (#13771 —
+      // dispatch of a queued task must be illegal once terminal or paused).
+      const doc = await this.store.getTask(entry.taskId);
+      const dispatchable =
+        doc?.task.status === "open" &&
+        !doc.task.paused &&
+        readAdmissionMetadata(doc.task.metadata) !== undefined;
+      if (!dispatchable) {
+        await this.clearAdmissionMetadata(entry.taskId);
+        continue;
+      }
+      // Dequeue optimistically so a re-entrant drain can't pick the same entry;
+      // restored below if we lose the slot race.
+      this.removeFromAdmissionQueue(entry.taskId);
+      try {
+        await this.spawnAgentForTask(
+          entry.taskId,
+          entry.spawnOpts,
+          "throw-on-cap",
+        );
+        await this.clearAdmissionMetadata(entry.taskId);
+      } catch (err) {
+        // error-policy:J7 dispatcher must not die on one task's spawn failure.
+        if (err instanceof SessionCapError) {
+          // A direct spawn won the slot between our capacity read and the
+          // reserve. Keep the task's position and stop draining this pass.
+          this.admissionQueue.push(entry);
+          return;
+        }
+        // A genuine spawn failure (not the cap): clear the parked record and
+        // surface it via reportError. The task stays `open` and can be
+        // re-submitted; leaving it enqueued would hot-loop on the same failure.
+        await this.clearAdmissionMetadata(entry.taskId);
+        this.runtime.reportError("OrchestratorTask.drainAdmissionQueue", err, {
+          taskId: entry.taskId,
+        });
+        this.log("warn", "queued task failed to dispatch", {
+          taskId: entry.taskId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  /**
+   * Free a worker slot by stopping the oldest keepAlive session whose TASK is
+   * already terminal (done/failed/archived). Never touches a session whose task
+   * is still validating/active. Returns true when a slot was reclaimed.
+   */
+  private async reclaimIdleWorkerSlot(acp: AcpService): Promise<boolean> {
+    const sessions = await acp.listSessions();
+    const candidates: SessionInfo[] = [];
+    for (const session of sessions) {
+      if (TERMINAL_SESSION_STATUSES.has(session.status)) continue;
+      const meta = session.metadata as Record<string, unknown> | undefined;
+      if (meta?.slotClass === "system") continue;
+      if (meta?.keepAliveAfterComplete !== true) continue;
+      const taskId = typeof meta?.taskId === "string" ? meta.taskId : undefined;
+      if (!taskId) continue;
+      const doc = await this.store.getTask(taskId);
+      if (!doc || !TERMINAL_TASK_STATUSES.has(doc.task.status)) continue;
+      candidates.push(session);
+    }
+    if (candidates.length === 0) return false;
+    candidates.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    const oldest = candidates[0];
+    if (!oldest) return false;
+    await acp.stopSession(oldest.id);
+    this.log("info", "reclaimed idle keepAlive worker slot for queued task", {
+      sessionId: oldest.id,
+    });
+    return true;
+  }
+
+  /** Capacity picture for the `/capacity` route: ACP pool counts + the ordered
+   *  admission queue with 1-based positions. */
+  async getCapacitySnapshot(): Promise<CapacitySnapshot> {
+    const acp = this.acp();
+    const capacity: AcpCapacity = acp
+      ? await acp.getCapacity()
+      : {
+          maxSessions: 0,
+          activeWorkers: 0,
+          activeSystem: 0,
+          systemHeadroom: 0,
+          freeSlots: 0,
+        };
+    const ordered = orderAdmissionQueue(
+      this.admissionQueue,
+      Date.now(),
+      this.queueAgingMs,
+    );
+    return {
+      maxSessions: capacity.maxSessions,
+      activeWorkers: capacity.activeWorkers,
+      activeSystem: capacity.activeSystem,
+      freeSlots: capacity.freeSlots,
+      queueDepth: ordered.length,
+      queue: ordered.map((entry, index) => ({
+        taskId: entry.taskId,
+        title: entry.title,
+        position: index + 1,
+        priority: entry.priorityAtEnqueue,
+        enqueuedAt: new Date(entry.enqueuedAt).toISOString(),
+      })),
+    };
+  }
+
+  /** Count of queued tasks per originating room, for the supervisor digest. */
+  queuedCountsByRoom(): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const entry of this.admissionQueue) {
+      if (!entry.roomId) continue;
+      counts[entry.roomId] = (counts[entry.roomId] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  /** The admission overlay for one task's DTO (state + 1-based position +
+   *  enqueue time), or undefined when the task is not queued. */
+  private admissionForTask(
+    taskId: string,
+  ): { state: "queued"; position: number; enqueuedAt: string } | undefined {
+    const ordered = orderAdmissionQueue(
+      this.admissionQueue,
+      Date.now(),
+      this.queueAgingMs,
+    );
+    const index = ordered.findIndex((entry) => entry.taskId === taskId);
+    if (index < 0) return undefined;
+    const entry = ordered[index];
+    if (!entry) return undefined;
+    return {
+      state: "queued",
+      position: index + 1,
+      enqueuedAt: new Date(entry.enqueuedAt).toISOString(),
+    };
   }
 
   private acp(): AcpService | undefined {

--- a/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
@@ -93,12 +93,16 @@ const PROGRESS_EXPECTED_STATUSES: ReadonlySet<OrchestratorTaskStatus> = new Set(
   ["active", "validating"],
 );
 
-/** Compose the digest body for one room's set of live tasks. Deterministic. */
-export function composeRoomDigest(views: SupervisorTaskView[]): string {
-  const header =
-    views.length === 1
-      ? "📡 Task update"
-      : `📡 Task update — ${views.length} active`;
+/** Compose the digest body for one room's set of live tasks. Deterministic.
+ *  `queuedCount` (tasks parked at the session cap for this room) is folded into
+ *  the header so a growing backlog changes the digest and re-posts. */
+export function composeRoomDigest(
+  views: SupervisorTaskView[],
+  queuedCount = 0,
+): string {
+  const activeSummary = views.length === 1 ? "" : ` — ${views.length} active`;
+  const queuedSummary = queuedCount > 0 ? ` · ${queuedCount} queued` : "";
+  const header = `📡 Task update${activeSummary}${queuedSummary}`;
   const lines = views
     .slice()
     .sort((a, b) => a.label.localeCompare(b.label))
@@ -132,6 +136,7 @@ export async function runSupervisorTick(
     content: Content,
   ) => Promise<unknown>,
   seen: Map<string, string>,
+  queuedByRoom: Record<string, number> = {},
 ): Promise<SupervisorTickResult> {
   const byRoom = new Map<
     string,
@@ -156,7 +161,7 @@ export async function runSupervisorTick(
   const posted: string[] = [];
   const skipped: string[] = [];
   for (const [roomId, { source, views: roomViews }] of byRoom) {
-    const digest = composeRoomDigest(roomViews);
+    const digest = composeRoomDigest(roomViews, queuedByRoom[roomId] ?? 0);
     if (seen.get(roomId) === digest) {
       skipped.push(roomId);
       continue;
@@ -215,6 +220,9 @@ interface TaskServiceLike {
   getTaskOriginTarget(
     taskId: string,
   ): Promise<{ roomId: string; source: string } | null>;
+  /** Tasks parked in the admission queue, counted per originating room. Optional
+   *  so older/stubbed task services still satisfy this contract. */
+  queuedCountsByRoom?(): Record<string, number>;
 }
 
 export class TaskSupervisorService extends Service {
@@ -342,10 +350,15 @@ export class TaskSupervisorService extends Service {
           origin: await taskSvc.getTaskOriginTarget(t.id),
         })),
       );
+      const queuedByRoom =
+        typeof taskSvc.queuedCountsByRoom === "function"
+          ? taskSvc.queuedCountsByRoom()
+          : {};
       const result = await runSupervisorTick(
         views,
         (target, content) => this.sendDigest(target, content, send),
         this.seen,
+        queuedByRoom,
       );
       if (result.posted.length > 0) {
         logger.info(

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -1,8 +1,63 @@
 /**
  * Shared type vocabulary for the ACP session layer: agent/backend kinds,
  * approval presets, session status and lifecycle events, spawn options, and the
- * `SessionStore` contract the persistence tiers implement.
+ * `SessionStore` contract the persistence tiers implement. Also home to the
+ * admission-control errors (`SessionCapError`, `AdmissionQueueFullError`) that
+ * the ACP cap and the orchestrator admission queue throw, so the route layer
+ * can map them to status codes without regex-matching messages.
  */
+
+/**
+ * Which capacity pool a session draws from. `worker` sessions do the actual
+ * task work and count against `ELIZA_ACP_MAX_SESSIONS`; short-lived `system`
+ * sessions (e.g. the read-only completion verifier) draw from a small separate
+ * headroom so validation can never deadlock behind a full worker pool.
+ */
+export type SessionSlotClass = "worker" | "system";
+
+/**
+ * Thrown by {@link AcpService} when a spawn would exceed the capacity of its
+ * slot class. `code` is the stable contract consumers branch on; `maxSessions`
+ * and `activeCount` describe the pool that was full. The message is actionable
+ * for the direct (non-queued) spawn paths that surface it to the user verbatim.
+ */
+export class SessionCapError extends Error {
+  readonly code = "SESSION_CAP_REACHED" as const;
+  readonly maxSessions: number;
+  readonly activeCount: number;
+  readonly slotClass: SessionSlotClass;
+  constructor(params: {
+    maxSessions: number;
+    activeCount: number;
+    slotClass: SessionSlotClass;
+  }) {
+    super(
+      `Session capacity reached (${params.activeCount}/${params.maxSessions} ${params.slotClass} sessions active). Create a task to queue this work, or wait for a running session to finish.`,
+    );
+    this.name = "SessionCapError";
+    this.maxSessions = params.maxSessions;
+    this.activeCount = params.activeCount;
+    this.slotClass = params.slotClass;
+  }
+}
+
+/**
+ * Thrown by the orchestrator admission queue when a task cannot be parked
+ * because the queue is already at `ELIZA_ACP_ADMISSION_QUEUE_DEPTH`. The route
+ * boundary maps this to HTTP 429 (retry later) rather than 500.
+ */
+export class AdmissionQueueFullError extends Error {
+  readonly code = "ADMISSION_QUEUE_FULL" as const;
+  readonly depth: number;
+  constructor(depth: number) {
+    super(
+      `Admission queue is full (${depth} tasks queued). Wait for a queued task to be dispatched before submitting more.`,
+    );
+    this.name = "AdmissionQueueFullError";
+    this.depth = depth;
+  }
+}
+
 export type AgentType =
   | "elizaos"
   | "pi-agent"
@@ -103,6 +158,12 @@ export interface SpawnOptions {
   skipAdapterAutoResponse?: boolean;
   timeoutMs?: number;
   model?: string;
+  /**
+   * Which capacity pool this spawn draws from (default `worker`). `system`
+   * sessions (short-lived, e.g. the read-only verifier) draw from a separate
+   * headroom so they can never be starved by a full worker pool.
+   */
+  slotClass?: SessionSlotClass;
 }
 
 export interface SpawnResult {


### PR DESCRIPTION
Closes #13772 (stages 1–3 + unit/integration tests). Implements the settled D1 HYBRID design (design-doc comment on the issue). Live 10-vs-5 E2E is the separate WS8 issue #13778.

## What this does
Turns the orchestrator's session cap from an **opaque hard-fail** ("acpx max session limit reached (8)" — a thrown Error the caller had to string-match) into a **durable admission queue**: a spawn beyond the worker cap now **parks** its task (`open` status + a durable `metadata.admission` entry) and a dispatcher drains it as slots free — so a swarm can schedule more tasks than the raw session cap instead of dropping the 9th.

**Stage 1 — `AcpService` (typed error + slot classes):** `enforceSessionLimit` throws a typed `SessionCapError { code:'SESSION_CAP_REACHED', maxSessions, activeCount, slotClass }`. Sessions carry a `slotClass: 'worker'|'system'`; `worker` counts against `ELIZA_ACP_MAX_SESSIONS`, `system` against a separate `ELIZA_ACP_SYSTEM_SESSION_HEADROOM` (default 2) so the read-only completion **verifier can always spawn** and never deadlocks behind a full worker pool. New `getCapacity()`.

**Stage 2 — `OrchestratorTaskService` (the queue):** park-at-cap in `spawnAgentForTask`; durable `metadata.admission` (rebuilt from `open` tasks on boot — no new table, no new task status); deterministic order (priority bands → FIFO → aging promotion so `low` can't starve); depth cap (`ELIZA_ACP_ADMISSION_QUEUE_DEPTH`, default 32 → `AdmissionQueueFullError`); `drainAdmissionQueue` on every terminal session event + a 30s reconcile tick; idle-reclaim of completed-but-alive (`keepAliveAfterComplete`) sessions; dequeue on cancel/pause/archive/delete, re-enqueue on resume. Behind `ELIZA_ACP_ADMISSION_QUEUE` (default ON; `0` restores reject-at-cap for bisection).

**Stage 3 — surfaces:** `ACTIVE_SUB_AGENTS` provider capacity line + `data.capacity`; `GET /api/orchestrator/capacity`; `POST /tasks/:id/agents` → **202** when queued / **429** on full queue; `TaskThreadDto.admission` overlay; supervisor room-digest queued count.

## Verification (independently re-run)
- **67/67 new+updated tests pass** — `admission-queue-order` (8, pure ordering/aging/tie-break), `admission-queue.integration` (9, **real `OrchestratorTaskService` + real in-memory store** + a faithful fake ACP transport that throws the real `SessionCapError`: 5 spawns vs cap 2 → 2 active + 3 queued in deterministic order, drain order matches with **zero drops**, verifier spawns at full worker cap via system headroom, idle-reclaim, restart-rebuild, depth-cap `AdmissionQueueFullError`), `acp-service` (50, slot classes + typed error + `getCapacity`).
- Mutation-checked: key assertions fail without the implementation.
- Typecheck: **0 errors in touched files**. Biome clean on all 10 touched files.
- Regression sweep (`vitest run`): the 26 failures are the **pre-existing** `runtime.reportError is not a function` in `task-policy.ts` (added by #13324) — those files are byte-identical to `develop` and untouched here; every test in files this PR changed passes.

## Honestly deferred (called out, not half-wired)
- **Router-respawn / `reattachSession` re-queue-at-head** (design item 2, 2nd half): these paths now throw the typed `SessionCapError` but do not re-queue at the head — that needs an inner(ACP)→outer(orchestrator) seam and is a recovery-path refinement; the reconcile tick + terminal-event drain still make forward progress. 
- **Live 10-vs-5 E2E** → #13778.

🤖 Generated with [Claude Code](https://claude.com/claude-code)