### PR TITLE
fix: make UI determinism baseline line-independent

### DIFF
--- a/.github/issue-evidence/13840-ui-determinism-baseline.md
+++ b/.github/issue-evidence/13840-ui-determinism-baseline.md
@@ -1,0 +1,33 @@
+# Issue #13840 - UI determinism baseline drift
+
+## Scope
+
+- Changed `packages/scripts/audit-ui-determinism.mjs` baseline matching from exact `L<line> <kind>` strings to file + finding-kind occurrence counts.
+- Kept line numbers in `ui-determinism-baseline.json` as human review context.
+- Refreshed the checked-in baseline from current `origin/develop` after verifying the only remaining mismatch under count-based matching was the `HeartbeatForm.tsx` -> `TriggerForm.tsx` file move for the same `new Date()` finding.
+
+## Before
+
+- `node packages/scripts/audit-ui-determinism.mjs --json`
+  - Failed on untouched `origin/develop`.
+  - Reported 40 false regressions from line drift across current UI files.
+
+## After
+
+- `node packages/scripts/audit-ui-determinism.mjs`
+  - PASS: `render-time=46 deferred=136 module=246 (baseline 31 files)`
+  - PASS: `OK audit-ui-determinism PASSED (no new render-time nondeterminism)`
+- `node packages/scripts/audit-ui-determinism.mjs --json`
+  - PASS: `regressionCount: 0`
+- `node packages/scripts/audit-ui-determinism.mjs --self-test`
+  - PASS: existing classifier cases plus new line-drift, count-increase, and new-kind baseline cases.
+- `bunx @biomejs/biome check --write packages/scripts/audit-ui-determinism.mjs packages/scripts/ui-determinism-baseline.json`
+  - PASS: formatted baseline JSON.
+- `git diff --check`
+  - PASS.
+
+## Manual Review
+
+- The refreshed baseline now records only current render-time backlog: 46 occurrences across 31 files.
+- Removed baseline entries are stale findings no longer reported by the audit.
+- Line changes are now diagnostic only; a same-file added occurrence of an existing kind still fails by count.

--- a/packages/scripts/audit-ui-determinism.mjs
+++ b/packages/scripts/audit-ui-determinism.mjs
@@ -18,6 +18,10 @@
  *
  * A committed baseline (eslint-style) records the existing render-time backlog
  * so the gate fails on NEW occurrences while the backlog is burned down.
+ * Baseline entries keep line numbers for human review, but comparison is
+ * line-independent: file + finding kind + occurrence count. Pure line drift
+ * from nearby edits must not create false regressions; adding another
+ * occurrence of the same kind in the same file still fails.
  * Regenerate with `--update-baseline`.
  *
  *   node packages/scripts/audit-ui-determinism.mjs            # gate
@@ -285,6 +289,48 @@ function scanFile(file, sourceText) {
   return findings;
 }
 
+function findingKindFromOccurrence(occurrence) {
+  const match = /^L\d+\s+(.+)$/.exec(String(occurrence));
+  return match ? match[1] : String(occurrence);
+}
+
+function countByKind(occurrences) {
+  const counts = new Map();
+  for (const occurrence of occurrences ?? []) {
+    const kind = findingKindFromOccurrence(occurrence);
+    counts.set(kind, (counts.get(kind) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function selectNewOccurrences(currentOccurrences, baselineOccurrences) {
+  const remainingAllowed = countByKind(baselineOccurrences);
+  const fresh = [];
+  for (const occurrence of currentOccurrences) {
+    const kind = findingKindFromOccurrence(occurrence);
+    const allowed = remainingAllowed.get(kind) ?? 0;
+    if (allowed > 0) {
+      remainingAllowed.set(kind, allowed - 1);
+    } else {
+      fresh.push(occurrence);
+    }
+  }
+  return fresh;
+}
+
+function collectRegressions(renderTime, baseline) {
+  const regressions = {};
+  let regressionCount = 0;
+  for (const [file, occurrences] of Object.entries(renderTime)) {
+    const fresh = selectNewOccurrences(occurrences, baseline[file] || []);
+    if (fresh.length) {
+      regressions[file] = fresh;
+      regressionCount += fresh.length;
+    }
+  }
+  return { regressions, regressionCount };
+}
+
 // ---------------------------------------------------------------------------
 // self-test
 // ---------------------------------------------------------------------------
@@ -381,6 +427,63 @@ function runSelfTest() {
     console.error(`\nself-test FAILED (${failed})`);
     process.exit(1);
   }
+  const baseline = {
+    "component.tsx": ["L10 Date.now()", "L20 toLocaleString() [no locale]"],
+  };
+  const lineDrift = {
+    "component.tsx": ["L15 Date.now()", "L25 toLocaleString() [no locale]"],
+  };
+  const countIncrease = {
+    "component.tsx": [
+      "L15 Date.now()",
+      "L25 toLocaleString() [no locale]",
+      "L30 Date.now()",
+    ],
+  };
+  const differentKind = {
+    "component.tsx": [
+      "L15 Date.now()",
+      "L25 toLocaleString() [no locale]",
+      "L30 Math.random()",
+    ],
+  };
+  const driftResult = collectRegressions(lineDrift, baseline);
+  if (driftResult.regressionCount !== 0) {
+    failed++;
+    console.error(
+      `FAIL baseline line drift: expected no regressions, got ${JSON.stringify(driftResult.regressions)}`,
+    );
+  } else {
+    console.log("OK baseline line drift");
+  }
+  const countResult = collectRegressions(countIncrease, baseline);
+  if (
+    countResult.regressionCount !== 1 ||
+    countResult.regressions["component.tsx"]?.[0] !== "L30 Date.now()"
+  ) {
+    failed++;
+    console.error(
+      `FAIL baseline count increase: expected one Date.now regression, got ${JSON.stringify(countResult.regressions)}`,
+    );
+  } else {
+    console.log("OK baseline count increase");
+  }
+  const kindResult = collectRegressions(differentKind, baseline);
+  if (
+    kindResult.regressionCount !== 1 ||
+    kindResult.regressions["component.tsx"]?.[0] !== "L30 Math.random()"
+  ) {
+    failed++;
+    console.error(
+      `FAIL baseline new kind: expected one Math.random regression, got ${JSON.stringify(kindResult.regressions)}`,
+    );
+  } else {
+    console.log("OK baseline new kind");
+  }
+  if (failed) {
+    console.error(`\nself-test FAILED (${failed})`);
+    process.exit(1);
+  }
   console.log("\nself-test PASSED");
 }
 
@@ -438,18 +541,13 @@ function main() {
     baseline = {};
   }
 
-  // A regression = a render-time occurrence present now but not in baseline.
-  const regressions = {};
-  let regressionCount = 0;
-  for (const [file, occ] of Object.entries(renderTime)) {
-    const allowed = new Set(baseline[file] || []);
-    const now = new Set(occ);
-    const fresh = [...now].filter((o) => !allowed.has(o));
-    if (fresh.length) {
-      regressions[file] = fresh;
-      regressionCount += fresh.length;
-    }
-  }
+  // A regression = a render-time occurrence count present now but not in
+  // baseline. Lines are diagnostic context only; matching them makes the gate
+  // fail on harmless drift after nearby code moves.
+  const { regressions, regressionCount } = collectRegressions(
+    renderTime,
+    baseline,
+  );
 
   if (asJson) {
     console.log(

--- a/packages/scripts/ui-determinism-baseline.json
+++ b/packages/scripts/ui-determinism-baseline.json
@@ -1,134 +1,98 @@
 {
   "packages/ui/src/cloud-ui/components/data-list/api-keys-summary.tsx": [
-    "L37 toLocaleString() [no locale]",
-    "L43 toLocaleDateString() [no locale]"
-  ],
-  "packages/ui/src/cloud-ui/components/data-list/api-keys-table.tsx": [
-    "L196 toLocaleString() [no locale]",
-    "L199 toLocaleString() [no locale]",
-    "L272 toLocaleString() [no locale]",
-    "L275 toLocaleString() [no locale]"
+    "L40 toLocaleString() [no locale]",
+    "L46 toLocaleDateString() [no locale]"
   ],
   "packages/ui/src/cloud-ui/components/data-list/apps-list-view.tsx": [
-    "L168 toLocaleString() [no locale]",
-    "L172 toLocaleString() [no locale]"
-  ],
-  "packages/ui/src/cloud-ui/components/image-gen/enhanced-loading.tsx": [
-    "L29 Math.random()"
+    "L187 toLocaleString() [no locale]",
+    "L191 toLocaleString() [no locale]"
   ],
   "packages/ui/src/cloud-ui/components/log-viewer.tsx": [
-    "L259 toLocaleTimeString() [no locale]"
+    "L263 toLocaleTimeString() [no locale]"
   ],
   "packages/ui/src/cloud-ui/components/voice/voice-status-badge.tsx": [
     "L35 new Date()"
   ],
-  "packages/ui/src/cloud-ui/runtime/render-telemetry.tsx": ["L47 Date.now()"],
+  "packages/ui/src/cloud-ui/runtime/render-telemetry.tsx": ["L52 Date.now()"],
   "packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx": [
     "L129 toLocaleString() [no locale]"
   ],
   "packages/ui/src/cloud/account-security/components/plugin-permissions-page-client.tsx": [
-    "L142 toLocaleString() [no locale]",
-    "L144 toLocaleString() [no locale]"
+    "L141 toLocaleString() [no locale]",
+    "L143 toLocaleString() [no locale]"
   ],
   "packages/ui/src/cloud/admin/ModerationPage.tsx": [
-    "L356 toLocaleString() [no locale]",
-    "L610 toLocaleDateString() [no locale]"
+    "L346 toLocaleString() [no locale]",
+    "L600 toLocaleDateString() [no locale]"
   ],
   "packages/ui/src/cloud/admin/RpcStatusPage.tsx": [
-    "L168 toLocaleString() [no locale]",
-    "L192 toLocaleString() [no locale]"
+    "L162 toLocaleString() [no locale]",
+    "L186 toLocaleString() [no locale]"
   ],
   "packages/ui/src/cloud/analytics/_components/analytics-page-client.tsx": [
-    "L127 toLocaleString() [no locale]",
-    "L172 toLocaleString() [no locale]",
-    "L189 toLocaleString() [no locale]",
-    "L225 toLocaleString() [no locale]"
+    "L124 toLocaleString() [no locale]",
+    "L169 toLocaleString() [no locale]",
+    "L186 toLocaleString() [no locale]",
+    "L222 toLocaleString() [no locale]"
   ],
-  "packages/ui/src/cloud/analytics/_components/filters.tsx": ["L58 new Date()"],
+  "packages/ui/src/cloud/analytics/_components/filters.tsx": ["L56 new Date()"],
   "packages/ui/src/cloud/analytics/_components/usage-chart.tsx": [
-    "L109 toLocaleString() [no locale]",
-    "L214 toLocaleString() [no locale]"
+    "L107 toLocaleString() [no locale]",
+    "L212 toLocaleString() [no locale]"
   ],
   "packages/ui/src/cloud/applications/ApplicationsPage.tsx": [
-    "L66 toLocaleString() [no locale]",
-    "L73 toLocaleString() [no locale]"
-  ],
-  "packages/ui/src/cloud/applications/components/app-analytics.tsx": [
-    "L299 toLocaleDateString() [no locale]",
-    "L386 toLocaleString() [no locale]",
-    "L391 toLocaleString() [no locale]",
-    "L500 toLocaleString() [no locale]",
-    "L505 toLocaleString() [no locale]",
-    "L513 toLocaleString() [no locale]",
-    "L567 toLocaleString() [no locale]",
-    "L613 toLocaleString() [no locale]",
-    "L649 toLocaleString() [no locale]",
-    "L656 toLocaleString() [no locale]",
-    "L723 toLocaleString() [no locale]",
-    "L753 toLocaleString() [no locale]"
-  ],
-  "packages/ui/src/cloud/applications/components/app-domains.tsx": [
-    "L950 toLocaleTimeString() [no locale]"
-  ],
-  "packages/ui/src/cloud/applications/components/app-overview.tsx": [
-    "L228 toLocaleString() [no locale]",
-    "L236 toLocaleString() [no locale]"
+    "L57 toLocaleString() [no locale]",
+    "L64 toLocaleString() [no locale]"
   ],
   "packages/ui/src/cloud/applications/components/app-users.tsx": [
-    "L251 toLocaleString() [no locale]"
+    "L249 toLocaleString() [no locale]"
   ],
   "packages/ui/src/cloud/billing/components/direct-crypto-credit-card.tsx": [
-    "L341 Date.now()",
-    "L357 Date.now()"
+    "L428 Date.now()",
+    "L445 Date.now()"
   ],
   "packages/ui/src/cloud/billing/components/payment-waiting-overlay.tsx": [
     "L217 toLocaleTimeString() [no locale]"
   ],
   "packages/ui/src/cloud/instances/components/create-eliza-agent-dialog.tsx": [
-    "L437 Date.now()",
-    "L509 Date.now()"
+    "L443 Date.now()",
+    "L515 Date.now()"
   ],
   "packages/ui/src/cloud/instances/components/docker-logs-viewer.tsx": [
     "L103 new Date()"
   ],
   "packages/ui/src/cloud/instances/components/eliza-agent-logs-viewer.tsx": [
-    "L254 new Date()"
+    "L257 new Date()"
   ],
   "packages/ui/src/cloud/mcps/McpDetailDrawer.tsx": [
-    "L275 toLocaleString() [no locale]",
-    "L281 toLocaleString() [no locale]",
-    "L293 toLocaleString() [no locale]"
+    "L277 toLocaleString() [no locale]",
+    "L283 toLocaleString() [no locale]",
+    "L295 toLocaleString() [no locale]"
   ],
   "packages/ui/src/cloud/monetization/earnings/EarningsPageClient.tsx": [
-    "L887 toLocaleTimeString() [no locale]"
+    "L876 toLocaleTimeString() [no locale]"
   ],
   "packages/ui/src/cloud/organization/organization-general-tab.tsx": [
-    "L102 toLocaleString() [no locale]"
+    "L100 toLocaleString() [no locale]"
   ],
   "packages/ui/src/cloud/organization/pending-invites-list.tsx": [
-    "L47 Date.now()",
-    "L70 new Date()"
+    "L45 Date.now()",
+    "L66 new Date()"
   ],
   "packages/ui/src/cloud/public-pages/pages/invite/invite-accept-page.tsx": [
-    "L241 Date.now()"
+    "L254 Date.now()"
   ],
   "packages/ui/src/cloud/public-pages/pages/payment/app-charge-page.tsx": [
     "L150 Date.now()"
   ],
-  "packages/ui/src/components/connectors/XRPairingPanel.tsx": [
-    "L86 toLocaleTimeString() [no locale]"
-  ],
-  "packages/ui/src/components/pages/chat-view-hooks.tsx": ["L812 Date.now()"],
+  "packages/ui/src/components/pages/chat-view-hooks.tsx": ["L817 Date.now()"],
   "packages/ui/src/components/pages/ElizaCloudDashboard.tsx": [
-    "L594 Date.now()"
+    "L605 Date.now()"
   ],
-  "packages/ui/src/components/pages/ElizaOsAppsView.tsx": [
-    "L1758 toLocaleString() [no locale]"
-  ],
-  "packages/ui/src/components/pages/HeartbeatForm.tsx": ["L1206 new Date()"],
-  "packages/ui/src/components/shell/PairingView.tsx": ["L49 Date.now()"],
+  "packages/ui/src/components/pages/TriggerForm.tsx": ["L1215 new Date()"],
+  "packages/ui/src/components/shell/PairingView.tsx": ["L55 Date.now()"],
   "packages/ui/src/components/shell/usePromptSuggestions.ts": [
-    "L279 new Date()"
+    "L287 new Date()"
   ],
   "packages/ui/src/widgets/__fixtures__/home-widget-mock-data.ts": [
     "L69 Date.now()"


### PR DESCRIPTION
## Summary
- compare UI determinism baseline entries by file + finding kind + occurrence count instead of exact line strings
- keep line numbers in the baseline as review context, but stop failing on pure line drift
- refresh the current baseline after verifying the remaining count-based mismatch was the HeartbeatForm -> TriggerForm file move

Fixes #13840.

## Evidence
- BEFORE: `node packages/scripts/audit-ui-determinism.mjs --json` failed on untouched develop with 40 false regressions.
- PASS: `node packages/scripts/audit-ui-determinism.mjs`
  - `render-time=46 deferred=136 module=246 (baseline 31 files)`
  - `OK audit-ui-determinism PASSED (no new render-time nondeterminism)`
- PASS: `node packages/scripts/audit-ui-determinism.mjs --json`
  - `regressionCount: 0`
- PASS: `node packages/scripts/audit-ui-determinism.mjs --self-test`
  - includes new line-drift, count-increase, and new-kind baseline cases
- PASS: `bunx @biomejs/biome check --write packages/scripts/audit-ui-determinism.mjs packages/scripts/ui-determinism-baseline.json`
- PASS: `git diff --check`

## Evidence file
- `.github/issue-evidence/13840-ui-determinism-baseline.md`

Screenshots/video: N/A - script/baseline gate only; no UI runtime pixels changed.
