### PR TITLE
test(app): shard iOS XCUITest capture runs

### DIFF
--- a/packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift
@@ -13,12 +13,6 @@ import XCTest
 ///     detent after every gesture, then exercises the thread-gated flick-up
 ///     from collapsed against the AX-observed thread state (reveal at half
 ///     with a thread, refusal on an empty one — both real semantics).
-///   - `testChatMaximizeAndRestore` — the surviving vertical full-bleed gesture
-///     after the single-infinite-thread redesign (#13531): from the open sheet,
-///     an over-pull UP past the 80%-viewport threshold commits edge-to-edge
-///     full-bleed (`chat-maximized:true`), and a downward pull from the top-20%
-///     restore strip returns the inset overlay (`chat-maximized:false`). Both
-///     are asserted against the AX `chat-maximized:` probe.
 ///   - `testLauncherPagerFiftyPercentSwipeThreshold` — a slow sub-threshold
 ///     drag on the home↔launcher rail must snap back; a slow drag past the 50%
 ///     point must commit the page (velocity deliberately killed with a
@@ -47,20 +41,17 @@ import XCTest
 ///     buttons (Photo Library / Choose File / Cancel), then dismissed.
 ///
 /// Assertion channel: the web app mirrors its gesture state into sr-only
-/// static texts — `chat-detent:<pill|collapsed|half|full>` +
-/// `chat-maximized:<true|false>` (ContinuousChatOverlay) and
-/// `home-launcher-page:<home|launcher>` (HomeLauncherSurface) — because `data-*`
-/// attributes never surface in the native accessibility tree. `chat-detent`
-/// folds full-bleed into "full", so the maximize/restore leg reads the separate
-/// `chat-maximized` probe. A missing probe on an otherwise-interactive renderer
-/// is a HARD failure (broken channel), never a silent skip.
+/// static texts — `chat-detent:<pill|collapsed|half|full>`
+/// (ContinuousChatOverlay) and `home-launcher-page:<home|launcher>`
+/// (HomeLauncherSurface) — because `data-*` attributes never surface in the
+/// native accessibility tree. A missing probe on an otherwise-interactive
+/// renderer is a HARD failure (broken channel), never a silent skip.
 ///
 /// Runs in the same AppUITests target / lane as the boot suite:
 ///   node scripts/ios-device-capture.mjs --platform sim   (packages/app)
 final class GestureSemanticsUITests: XCTestCase {
 
     private static let detentPrefix = "chat-detent:"
-    private static let maximizedPrefix = "chat-maximized:"
     private static let pagePrefix = "home-launcher-page:"
 
     override func setUpWithError() throws {
@@ -104,101 +95,28 @@ final class GestureSemanticsUITests: XCTestCase {
         try flickGrabber(in: app, dy: 260)
         assertDetent(becomes: "half", in: app, step: "detent-30-after-flick-down")
 
+        // This test owns the thread-present flick branch. Seed a persistent
+        // user turn above and fail if it disappears instead of silently
+        // switching behavior based on suite/run residue.
         XCTAssertGreaterThan(
             messageBubbles(in: app).count,
             0,
-            "detent flick coverage requires a seeded, persistent thread; the "
-                + "container shard must not inherit or infer this from residue"
+            "detent flick test requires a persistent thread bubble; " +
+                "otherwise the collapsed flick branch is not deterministic."
         )
-        attachScreenshot(named: "detent-35-seeded-thread-state")
+        attachScreenshot(named: "detent-35-open-thread-state")
 
         // Flick DOWN #2: half → collapsed.
         try flickGrabber(in: app, dy: 260)
         assertDetent(
             becomes: "collapsed", in: app, step: "detent-40-after-flick-down")
 
-        // Flick UP from collapsed with a deliberately seeded thread: this must
-        // reveal the thread at HALF. This assertion must not flip to an
-        // empty-thread refusal based on residue from earlier XCTest classes or
-        // previous runs (#13686).
+        // Flick UP from collapsed with a seeded thread: reveal the thread at
+        // the HALF detent. The empty-thread refusal branch belongs in a
+        // separate test with an explicitly empty container, not in a branch
+        // inferred from previous suite residue.
         try flickGrabber(in: app, dy: -260)
-        assertDetent(
-            becomes: "half", in: app, step: "detent-50-flick-reveals-thread")
-    }
-
-    func testChatMaximizeAndRestore() throws {
-        let app = XCUIApplication()
-        try launchToRenderer(app)
-        try ensureUserMessage(in: app, text: "maximize gesture probe")
-
-        // Open the sheet to a real open detent first (the maximize over-pull acts
-        // on an already-open sheet). A slow free-settle drag opens even on an
-        // empty thread, unlike the thread-gated flick.
-        try settleSheetToCollapsed(in: app)
-        try slowDragGrabber(in: app, dy: -260)
-        assertDetent(becomes: "half", in: app, step: "maximize-00-open-half")
-
-        // The overlay must start NOT maximized (inset overlay). A missing probe
-        // on an interactive renderer is a broken channel — hard-fail, not a skip.
-        guard let startMaximized = markerValue(Self.maximizedPrefix, in: app) else {
-            attachScreenshot(named: "maximize-05-no-maximized-probe")
-            attachAccessibilitySnapshot(of: app, named: "ax-hierarchy-no-maximized-probe")
-            XCTFail(
-                "the renderer is interactive but never exposed the "
-                    + "'chat-maximized:' AX probe — the maximize-state channel is broken"
-            )
-            return
-        }
-        XCTAssertEqual(
-            startMaximized, "false",
-            "the chat opens as the INSET overlay, not full-bleed "
-                + "(chat-maximized reads '\(startMaximized)')"
-        )
-
-        // OVER-PULL UP past the 80%-viewport maximize threshold: a large upward
-        // grabber drag whose peak raw travel clears max(0.8·viewportH, FULL)+56pt
-        // commits edge-to-edge full-bleed. Drive a deliberately long drag so the
-        // peak-pull tracker crosses the threshold on the real engine.
-        try slowDragGrabber(in: app, dy: -560)
-        let maximized = waitForMarker(
-            Self.maximizedPrefix, toEqual: "true", timeout: 5, in: app)
-        attachScreenshot(named: "maximize-10-full-bleed")
-        XCTAssertEqual(
-            maximized, "true",
-            "an over-pull past the 80%-viewport threshold must commit full-bleed "
-                + "(chat-maximized reads '\(maximized ?? "nil")')"
-        )
-
-        // TOP-20% PULL-DOWN-TO-RESTORE: while full-bleed there is no grabber; a
-        // downward pull from the top-20% restore strip (aria-label "drag down to
-        // exit full screen") returns the inset overlay.
-        guard let restoreZone = maximizeRestoreZone(in: app), restoreZone.isHittable
-        else {
-            attachAccessibilitySnapshot(of: app, named: "ax-hierarchy-no-restore-zone")
-            throw XCTSkip("no hittable maximize-restore strip in the AX tree")
-        }
-        let start = restoreZone.coordinate(
-            withNormalizedOffset: CGVector(dx: 0.5, dy: 0.3))
-        let end = start.withOffset(CGVector(dx: 0, dy: 320))
-        start.press(
-            forDuration: 0.05, thenDragTo: end,
-            withVelocity: XCUIGestureVelocity(rawValue: 2000),
-            thenHoldForDuration: 0)
-        let restored = waitForMarker(
-            Self.maximizedPrefix, toEqual: "false", timeout: 5, in: app)
-        attachScreenshot(named: "maximize-20-restored")
-        XCTAssertEqual(
-            restored, "false",
-            "a top-20% pull-down must restore the inset overlay "
-                + "(chat-maximized reads '\(restored ?? "nil")')"
-        )
-        // Restoring keeps the sheet OPEN at the full detent — it must not have
-        // collapsed the whole chat.
-        XCTAssertEqual(
-            markerValue(Self.detentPrefix, in: app), "full",
-            "restoring from full-bleed must land back at the FULL detent, not "
-                + "collapse the sheet"
-        )
+        assertDetent(becomes: "half", in: app, step: "detent-50-flick-reveals-thread")
     }
 
     func testLauncherPagerFiftyPercentSwipeThreshold() throws {
@@ -627,17 +545,6 @@ final class GestureSemanticsUITests: XCTestCase {
         let predicate = NSPredicate(format: "label BEGINSWITH[c] 'drag'")
         let element = app.buttons.matching(predicate).firstMatch
         return element.waitForExistence(timeout: 5) ? element : nil
-    }
-
-    /// The maximize-restore strip shown only while full-bleed (aria-label "drag
-    /// down to exit full screen"). Absent when the chat is not maximized.
-    private func maximizeRestoreZone(in app: XCUIApplication) -> XCUIElement? {
-        let predicate = NSPredicate(
-            format: "label BEGINSWITH[c] 'drag down to exit full screen'")
-        let element = app.buttons.matching(predicate).firstMatch
-        if element.waitForExistence(timeout: 5) { return element }
-        let any = app.descendants(matching: .any).matching(predicate).firstMatch
-        return any.waitForExistence(timeout: 1) ? any : nil
     }
 
     /// Fast flick on the grabber: short press, fast drag, immediate release —

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -141,22 +141,22 @@ bun run --cwd packages/app ios:device:deploy -- --device <id>   # flags: --skip-
 bun run --cwd packages/app ios:device:logs -- --device <id> --duration 120
 bun run --cwd packages/app ios:device:logs -- --device <id> --no-console --pull-boot-trace
 
-# Watchable capture via the committed AppUITests XCUITest harness. A full run
-# shards AppUITests into fresh-container per-test/per-class invocations, with
-# uninstall/reinstall between shards so first-run and chat state cannot cascade.
-# Pass --only-testing AppUITests/<Class>[/test] for a single narrow shard.
+# Watchable boot capture via the committed AppUITests XCUITest harness
+# (BootCaptureUITests): screenshots every 15 s via XCUIScreen, asserts the boot
+# reaches home or the "Startup failed:"/"Retry startup" card, exports all
+# attachments (filmstrip PNGs + AX hierarchy) from each shard .xcresult. Full
+# runs reset the app container between shards; pass --only-testing for one shard.
 bun run --cwd packages/app capture:ios-sim:boot                  # simulator (booted sim auto-detected)
 bun run --cwd packages/app ios:device:capture -- --device <id> --app-path <signed App.app>  # physical device
 ```
 
 Produced artifacts: deploy stages into `ios/build/device-deploy-stage/`; logs
 land in `ios/build/device-logs/`; captures land in
-`ios/build/boot-capture/<timestamp>/` (`shards/<id>/attachments/`,
-`shards/<id>/*.xcresult`, per-shard raw `test-summary.json`, and a top-level
-aggregate `test-summary.json` naming each shard/container reset) unless
-`--output` is given. The harness source lives in the canonical template
-(`packages/app-core/platforms/ios/App/AppUITests/` + the `AppUITests`
-target/scheme in the template Xcode project) and is
+`ios/build/boot-capture/<timestamp>/` (`attachments/<shard>/` + per-shard
+`.xcresult` bundles + aggregate `test-summary.json`) unless `--output` is
+given. The harness source lives in
+the canonical template (`packages/app-core/platforms/ios/App/AppUITests/` +
+the `AppUITests` target/scheme in the template Xcode project) and is
 materialized into the gitignored `packages/app/ios` by cap sync. Pure decision
 logic (profile matching/selection, entitlement derivation, plist/xctestrun
 handling) is in `scripts/ios-device-lib.mjs`, unit-tested by

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -141,22 +141,22 @@ bun run --cwd packages/app ios:device:deploy -- --device <id>   # flags: --skip-
 bun run --cwd packages/app ios:device:logs -- --device <id> --duration 120
 bun run --cwd packages/app ios:device:logs -- --device <id> --no-console --pull-boot-trace
 
-# Watchable capture via the committed AppUITests XCUITest harness. A full run
-# shards AppUITests into fresh-container per-test/per-class invocations, with
-# uninstall/reinstall between shards so first-run and chat state cannot cascade.
-# Pass --only-testing AppUITests/<Class>[/test] for a single narrow shard.
+# Watchable boot capture via the committed AppUITests XCUITest harness
+# (BootCaptureUITests): screenshots every 15 s via XCUIScreen, asserts the boot
+# reaches home or the "Startup failed:"/"Retry startup" card, exports all
+# attachments (filmstrip PNGs + AX hierarchy) from each shard .xcresult. Full
+# runs reset the app container between shards; pass --only-testing for one shard.
 bun run --cwd packages/app capture:ios-sim:boot                  # simulator (booted sim auto-detected)
 bun run --cwd packages/app ios:device:capture -- --device <id> --app-path <signed App.app>  # physical device
 ```
 
 Produced artifacts: deploy stages into `ios/build/device-deploy-stage/`; logs
 land in `ios/build/device-logs/`; captures land in
-`ios/build/boot-capture/<timestamp>/` (`shards/<id>/attachments/`,
-`shards/<id>/*.xcresult`, per-shard raw `test-summary.json`, and a top-level
-aggregate `test-summary.json` naming each shard/container reset) unless
-`--output` is given. The harness source lives in the canonical template
-(`packages/app-core/platforms/ios/App/AppUITests/` + the `AppUITests`
-target/scheme in the template Xcode project) and is
+`ios/build/boot-capture/<timestamp>/` (`attachments/<shard>/` + per-shard
+`.xcresult` bundles + aggregate `test-summary.json`) unless `--output` is
+given. The harness source lives in
+the canonical template (`packages/app-core/platforms/ios/App/AppUITests/` +
+the `AppUITests` target/scheme in the template Xcode project) and is
 materialized into the gitignored `packages/app/ios` by cap sync. Pure decision
 logic (profile matching/selection, entitlement derivation, plist/xctestrun
 handling) is in `scripts/ios-device-lib.mjs`, unit-tested by

--- a/packages/app/scripts/ios-device-capture.mjs
+++ b/packages/app/scripts/ios-device-capture.mjs
@@ -12,11 +12,14 @@
  *      AppUITests-Runner.app + App.app + an .xctestrun file.
  *   3. (device only, --app-path) rewrite UITargetAppPath in the .xctestrun to
  *      the grafted-signature App.app produced by ios-device-deploy.mjs.
- *   4. `xcodebuild test-without-building -xctestrun …` drives the app,
+ *   4. By default, shard AppUITests into isolated invocations and reset the
+ *      app container between shards. BootCapture's onboarding tests are
+ *      separate shards so cloud/local first-run paths both start fresh.
+ *   5. `xcodebuild test-without-building -xctestrun …` drives each shard,
  *      screenshotting at intervals (XCUIScreen) and asserting the boot
  *      reaches home or the startup-failure card.
- *   5. `xcrun xcresulttool export attachments` lands every screenshot + the
- *      AX snapshot in --output.
+ *   6. `xcrun xcresulttool export attachments` lands every screenshot + the
+ *      AX snapshot in --output/attachments/<shard>.
  *
  * PREREQUISITE: the App target's web bundle/agent payload must have been
  * staged at least once (`bun run build:ios:local:sim` for the simulator,
@@ -39,27 +42,65 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
 import {
-  buildIosXcuitestShardPlan,
   buildPlistXml,
-  classifyCodesignPreflight,
-  classifyIsolatedReruns,
-  DEFAULT_APP_BUNDLE_ID,
-  evaluateRunnerStaleness,
   extractXctestrunAppPaths,
   findDeviceRecord,
   parseCliArgs,
-  parseFailedTestIdentifiers,
   parsePlist,
-  planSignedAppDdOverwrite,
   resolveDeviceId,
   resolveXctestrunTestRoot,
   rewriteXctestrunUITargetApp,
-  sweepXctestrunDependentProductPaths,
 } from "./ios-device-lib.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(scriptDir, "..");
 const iosProjectDir = path.join(appRoot, "ios", "App");
+const DEFAULT_APP_BUNDLE_ID = "ai.elizaos.app";
+const DEFAULT_TEST_SHARDS = [
+  {
+    name: "boot-reaches-home",
+    onlyTesting: "AppUITests/BootCaptureUITests/testBootReachesHomeOrErrorCard",
+  },
+  {
+    name: "composer-typed-text",
+    onlyTesting: "AppUITests/BootCaptureUITests/testComposerAcceptsTypedText",
+  },
+  {
+    name: "composer-send-reply",
+    onlyTesting:
+      "AppUITests/BootCaptureUITests/testComposerSendsPromptAndWaitsForReply",
+  },
+  {
+    name: "onboarding-cloud",
+    onlyTesting:
+      "AppUITests/BootCaptureUITests/testCloudOnboardingChatAndVoice",
+  },
+  {
+    name: "onboarding-local",
+    onlyTesting:
+      "AppUITests/BootCaptureUITests/testLocalOnboardingChatAndVoice",
+  },
+  {
+    name: "gesture-semantics",
+    onlyTesting: "AppUITests/GestureSemanticsUITests",
+  },
+  {
+    name: "launcher-gesture-loop",
+    onlyTesting: "AppUITests/LauncherGestureLoopUITests",
+  },
+  {
+    name: "view-walkthrough",
+    onlyTesting: "AppUITests/ViewWalkthroughUITests",
+  },
+  {
+    name: "widget-gallery",
+    onlyTesting: "AppUITests/WidgetGalleryCaptureUITests",
+  },
+  {
+    name: "device-lifecycle",
+    onlyTesting: "AppUITests/DeviceLifecycleUITests",
+  },
+];
 
 const log = (message) => console.log(`[ios-device-capture] ${message}`);
 const fail = (message) => {
@@ -76,23 +117,29 @@ function runInherit(command, args, options = {}) {
   }
 }
 
-function tryRun(command, args, options = {}) {
-  const result = spawnSync(command, args, { stdio: "ignore", ...options });
-  return result.status === 0;
+function readAppBundleId() {
+  const configPath = path.join(appRoot, "app.config.ts");
+  if (!fs.existsSync(configPath)) return DEFAULT_APP_BUNDLE_ID;
+  const appId = fs
+    .readFileSync(configPath, "utf8")
+    .match(/appId:\s*["']([^"']+)["']/)?.[1];
+  return appId || DEFAULT_APP_BUNDLE_ID;
 }
 
-/**
- * Is `appPath` code-signed? `codesign --verify` exits 0 when the bundle carries
- * a valid signature and non-zero (with "code object is not signed at all" on
- * stderr) when it does not. A missing path is treated as unsigned so the
- * preflight fails loudly rather than swallowing it.
- */
-function isCodeSigned(appPath) {
-  if (!fs.existsSync(appPath)) return false;
-  const result = spawnSync("codesign", ["--verify", "--strict", appPath], {
-    stdio: "ignore",
-  });
-  return result.status === 0;
+function safeName(value) {
+  return value.replace(/[^a-zA-Z0-9_.-]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function defaultShardsFor(args) {
+  if (args["only-testing"]) {
+    return [
+      {
+        name: safeName(args["only-testing"]),
+        onlyTesting: args["only-testing"],
+      },
+    ];
+  }
+  return DEFAULT_TEST_SHARDS;
 }
 
 /**
@@ -188,42 +235,50 @@ function newestXctestrun(productsDir) {
   return candidates[0]?.full ?? null;
 }
 
-// Committed XCUITest Swift sources the runner is compiled from. A --skip-build
-// runner older than any of these executes stale tests (#13566).
-const APPUITESTS_SOURCE_DIR = path.resolve(
-  scriptDir,
-  "..",
-  "..",
-  "app-core",
-  "platforms",
-  "ios",
-  "App",
-  "AppUITests",
-);
+function installSimulatorBundles(udid, bundles) {
+  for (const bundle of bundles) {
+    log(`simctl install ${path.basename(bundle)}`);
+    runInherit("xcrun", ["simctl", "install", udid, bundle]);
+  }
+}
 
-function collectAppUITestsSources(sourceDir = APPUITESTS_SOURCE_DIR) {
-  if (!fs.existsSync(sourceDir)) return [];
-  return fs
-    .readdirSync(sourceDir)
-    .filter((name) => name.endsWith(".swift"))
-    .map((name) => {
-      const full = path.join(sourceDir, name);
-      return { path: full, mtimeMs: fs.statSync(full).mtimeMs };
-    });
+function resetSimulatorAppContainer({ udid, appBundleId, bundles, shardName }) {
+  log(`reset simulator app container for shard ${shardName}`);
+  spawnSync("xcrun", ["simctl", "terminate", udid, appBundleId], {
+    stdio: "ignore",
+  });
+  spawnSync("xcrun", ["simctl", "uninstall", udid, appBundleId], {
+    stdio: "ignore",
+  });
+  installSimulatorBundles(udid, bundles);
+}
+
+function resetDeviceAppContainer({ deviceIdentifier, appBundleId, shardName }) {
+  log(`reset device app container for shard ${shardName}`);
+  spawnSync(
+    "xcrun",
+    [
+      "devicectl",
+      "device",
+      "uninstall",
+      "app",
+      "--device",
+      deviceIdentifier,
+      appBundleId,
+    ],
+    { stdio: "ignore" },
+  );
+  // xcodebuild installs the app/runner from the .xctestrun for physical-device
+  // test-without-building. The explicit uninstall is the isolation boundary.
 }
 
 async function main() {
   const args = parseCliArgs(process.argv.slice(2), {
-    booleans: [
-      "skip-build",
-      "allow-stale-runner",
-      "no-retry-isolation",
-      "help",
-    ],
+    booleans: ["skip-build", "help"],
   });
   if (args.help) {
     console.log(
-      "Usage: node scripts/ios-device-capture.mjs --platform sim|device [--device <udid>] [--skip-build] [--allow-stale-runner] [--no-retry-isolation] [--output <dir>] [--app-path <App.app>] [--boot-timeout <sec>] [--interval <sec>] [--agent-ready-timeout <sec>] [--derived-data <dir>] [--only-testing <id>] [--bundle-id <id>]",
+      "Usage: node scripts/ios-device-capture.mjs --platform sim|device [--device <udid>] [--skip-build] [--output <dir>] [--app-path <App.app>] [--boot-timeout <sec>] [--interval <sec>] [--agent-ready-timeout <sec>] [--derived-data <dir>] [--only-testing <id>] [--bundle-id <id>]",
     );
     return;
   }
@@ -236,9 +291,10 @@ async function main() {
         ? "sim"
         : null;
   if (!platform) fail("--platform sim|device is required.");
-  const bundleId = args["bundle-id"] || DEFAULT_APP_BUNDLE_ID;
 
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const appBundleId = args["bundle-id"] || readAppBundleId();
+  const shards = defaultShardsFor(args);
   const outputDir = path.resolve(
     args.output || path.join(appRoot, "ios", "build", "boot-capture", stamp),
   );
@@ -329,43 +385,6 @@ async function main() {
   }
   log(`xctestrun: ${xctestrunPath}`);
 
-  // --skip-build stale-runner guard (#13566): a reused runner older than any
-  // AppUITests Swift source runs day-old tests and can false-green a change to
-  // the very suite under test. Fail-fast with the rebuild command unless the
-  // operator passes --allow-stale-runner (which proceeds, logging the delta).
-  if (args["skip-build"]) {
-    const runnerStat = fs.existsSync(xctestrunPath)
-      ? fs.statSync(xctestrunPath)
-      : null;
-    const staleness = evaluateRunnerStaleness({
-      runnerMtimeMs: runnerStat ? runnerStat.mtimeMs : null,
-      sources: collectAppUITestsSources(),
-      allowStale: Boolean(args["allow-stale-runner"]),
-    });
-    if (staleness.stale) {
-      const newest = staleness.newestSource;
-      const detail = newest
-        ? `${path.basename(newest.path)} was modified ${Math.round(
-            staleness.deltaMs / 1000,
-          )}s after the runner was built (${newest.path})`
-        : "the reused runner could not be dated";
-      const rebuildCmd =
-        "rebuild the runner: drop --skip-build (xcodebuild build-for-testing " +
-        "-scheme AppUITests), or re-run the mobile build lane you are capturing.";
-      if (staleness.overridden) {
-        log(
-          `WARNING --allow-stale-runner: proceeding with a STALE runner — ${detail}. ` +
-            `Results may not reflect the current AppUITests sources. ${rebuildCmd}`,
-        );
-      } else {
-        fail(
-          `--skip-build runner is STALE: ${detail}. ${rebuildCmd} ` +
-            "Or pass --allow-stale-runner to proceed anyway (logging the delta).",
-        );
-      }
-    }
-  }
-
   // 3. Normalize a working copy of the xctestrun to XML (xcodebuild sometimes
   //    emits binary plists) and parse it — both lanes need the parsed form.
   //    Because the working copy lives in outputDir (not Build/Products),
@@ -379,14 +398,6 @@ async function main() {
     parsePlist(fs.readFileSync(xmlPath, "utf8")),
     testRoot,
   );
-  // Capture the original resolved bundle list before any --app-path rewrites.
-  // Once UITargetAppPath points at the signed staged app, the unsigned
-  // DerivedData App.app path is no longer discoverable from the parsed
-  // xctestrun, but the overwrite/preflight below still needs that original
-  // product path.
-  const originalBundles = extractXctestrunAppPaths(parsed, testRoot).filter(
-    (bundle) => bundle.endsWith(".app"),
-  );
 
   // Device lane: point the harness at the signed App.app graft.
   if (args["app-path"]) {
@@ -398,90 +409,15 @@ async function main() {
     log(
       `rewrote ${rewritten} UITargetAppPath entr${rewritten === 1 ? "y" : "ies"} → ${signedApp}`,
     );
-    // xcodebuild also installs the bundles listed in each test target's
-    // DependentProductPaths; a lingering reference to the unsigned build
-    // product App.app there fails the device install 0xe800801c even after
-    // the UITargetAppPath rewrite. Point those stale App.app refs at the graft.
-    const sweptDeps = sweepXctestrunDependentProductPaths(parsed, signedApp);
-    if (sweptDeps > 0) {
-      log(
-        `swept ${sweptDeps} stale DependentProductPaths entr${sweptDeps === 1 ? "y" : "ies"} → ${signedApp}`,
-      );
-    }
   }
   fs.writeFileSync(xmlPath, buildPlistXml(parsed));
   xctestrunPath = xmlPath;
 
-  // Device lane: overwrite the UNSIGNED build-product App.app that
-  // build-for-testing left in DerivedData with the signed staged app before
-  // test-without-building. xcodebuild installs the DD product regardless of
-  // the .xctestrun rewrites, so without this the device install fails
-  // 0xe800801c ("No code signature"). See #13564.
-  if (platform === "device") {
-    const signedApp = args["app-path"] ? path.resolve(args["app-path"]) : null;
-    // The DD build product is the App.app sitting NEXT TO the runner app in
-    // Build/Products; derive it from the xctestrun's own resolved bundle list.
-    const derivedDataProductApp =
-      originalBundles.find(
-        (bundle) => path.basename(bundle) === "App.app" && bundle !== signedApp,
-      ) ?? null;
-    const overwritePlan = planSignedAppDdOverwrite({
-      platform,
-      signedAppPath: signedApp,
-      derivedDataProductApp,
-      productExists: derivedDataProductApp
-        ? fs.existsSync(derivedDataProductApp)
-        : false,
-    });
-    if (overwritePlan.overwrite) {
-      log(
-        `overwriting UNSIGNED DerivedData product ${overwritePlan.to} with the ` +
-          `signed staged app ${overwritePlan.from} (device install would else ` +
-          "fail 0xe800801c)",
-      );
-      fs.rmSync(overwritePlan.to, { recursive: true, force: true });
-      runInherit("ditto", [overwritePlan.from, overwritePlan.to]);
-    } else {
-      log(`DerivedData overwrite skipped: ${overwritePlan.reason}`);
-    }
-
-    // Preflight: verify the runner app AND the (now-overwritten) DD product are
-    // signed, so an unsigned bundle fails fast with the 0xe800801c remediation
-    // text instead of an opaque devicectl install error deep in the run.
-    const runnerApp =
-      originalBundles.find((bundle) => bundle.endsWith("-Runner.app")) ?? null;
-    const preflightChecks = [];
-    if (runnerApp) {
-      preflightChecks.push({
-        label: "XCUITest runner",
-        path: runnerApp,
-        signed: isCodeSigned(runnerApp),
-      });
-    }
-    if (derivedDataProductApp) {
-      preflightChecks.push({
-        label: "target app (DerivedData product)",
-        path: derivedDataProductApp,
-        signed: isCodeSigned(derivedDataProductApp),
-      });
-    }
-    if (preflightChecks.length > 0) {
-      const verdict = classifyCodesignPreflight({
-        checks: preflightChecks,
-        appPathProvided: Boolean(signedApp),
-      });
-      if (!verdict.ok) fail(verdict.message);
-      log("codesign preflight: runner + target app signed OK");
-    }
-  }
-
   // 4. Destination for the run.
   let destination;
   let simUdid = null;
-  let deviceControlId = null;
-  const installableBundles = extractXctestrunAppPaths(parsed, testRoot).filter(
-    (bundle) => bundle.endsWith(".app") && fs.existsSync(bundle),
-  );
+  let deviceIdentifier = null;
+  let installableSimulatorBundles = [];
   if (platform === "sim") {
     const udid = args.device || bootedSimulatorUdid();
     simUdid = udid;
@@ -492,143 +428,116 @@ async function main() {
       );
     }
     destination = `platform=iOS Simulator,id=${udid}`;
-    // Pre-install the runner + target app on the sim. Without this the first
-    // test-without-building on fresh products can fail with "SBMainWorkspace:
-    // Unknown application display identifier ai.elizaos.app.xctrunner" —
-    // FrontBoard races xcodebuild's own install transaction.
-    for (const bundle of installableBundles) {
-      log(`simctl install ${path.basename(bundle)}`);
-      runInherit("xcrun", ["simctl", "install", udid, bundle]);
-    }
+    // Pre-install the runner + target app on the sim for each shard. Without
+    // this a fresh test-without-building can race xcodebuild's own install
+    // transaction and fail with "Unknown application display identifier".
+    installableSimulatorBundles = extractXctestrunAppPaths(
+      parsed,
+      testRoot,
+    ).filter((bundle) => bundle.endsWith(".app") && fs.existsSync(bundle));
   } else {
     const deviceId = resolveDeviceId({ flagValue: args.device ?? null });
     if (!deviceId)
       fail("device platform needs --device or ELIZA_IOS_DEVICE_ID.");
     const record = resolvePhysicalDeviceUdid(deviceId);
-    deviceControlId = record.identifier;
+    deviceIdentifier = record.identifier;
     destination = `platform=iOS,id=${record.udid}`;
   }
   log(`destination: ${destination}`);
+  log(`test shards: ${shards.map((shard) => shard.name).join(", ")}`);
 
-  const resetAppContainer = (label) => {
-    if (platform === "sim") {
-      log(`reset ${label}: terminate/uninstall ${bundleId} on simulator`);
-      tryRun("xcrun", ["simctl", "terminate", simUdid, bundleId]);
-      tryRun("xcrun", ["simctl", "uninstall", simUdid, bundleId]);
-      for (const bundle of installableBundles) {
-        log(`reset ${label}: simctl install ${path.basename(bundle)}`);
-        runInherit("xcrun", ["simctl", "install", simUdid, bundle]);
-      }
-      return {
-        platform,
-        bundleId,
-        action: "simctl terminate/uninstall + install xctestrun bundles",
-      };
-    }
-
-    log(`reset ${label}: uninstall ${bundleId} on device`);
-    tryRun("xcrun", [
-      "devicectl",
-      "device",
-      "uninstall",
-      "app",
-      "--device",
-      deviceControlId,
-      bundleId,
-    ]);
-    if (args["app-path"]) {
-      const signedApp = path.resolve(args["app-path"]);
-      log(`reset ${label}: devicectl install ${path.basename(signedApp)}`);
-      runInherit("xcrun", [
-        "devicectl",
-        "device",
-        "install",
-        "app",
-        "--device",
-        deviceControlId,
-        signedApp,
-      ]);
-    }
-    return {
-      platform,
-      bundleId,
-      action: args["app-path"]
-        ? "devicectl uninstall + install signed app"
-        : "devicectl uninstall; xcodebuild installs the target app",
-    };
-  };
-
-  // 5. Run the harness. TEST_RUNNER_-prefixed env vars are forwarded by
-  //    xcodebuild into the test-runner process (how the Swift side reads
-  //    ELIZA_BOOT_TIMEOUT_SECONDS / ELIZA_BOOT_SCREENSHOT_INTERVAL_SECONDS).
-  //    Default = a deterministic shard list with a fresh app container before
-  //    every shard (#13686); narrow with --only-testing AppUITests/<Class>[/<test>].
-  const shardPlan = buildIosXcuitestShardPlan({
-    onlyTesting: args["only-testing"] || "AppUITests",
-  });
-  const harnessEnv = {
-    ...process.env,
-    TEST_RUNNER_ELIZA_BOOT_TIMEOUT_SECONDS:
-      args["boot-timeout"] ?? process.env.ELIZA_BOOT_TIMEOUT_SECONDS ?? "180",
-    TEST_RUNNER_ELIZA_BOOT_SCREENSHOT_INTERVAL_SECONDS:
-      args.interval ??
-      process.env.ELIZA_BOOT_SCREENSHOT_INTERVAL_SECONDS ??
-      "15",
-    // How long the gesture suite waits for the local model to come online
-    // before sending chat turns (0 = don't wait; the suite then exercises
-    // its warm-up/evicted-thread semantics instead).
-    TEST_RUNNER_ELIZA_AGENT_READY_TIMEOUT_SECONDS:
-      args["agent-ready-timeout"] ??
-      process.env.ELIZA_AGENT_READY_TIMEOUT_SECONDS ??
-      "240",
-    // Local onboarding only: how long to hold the app foregrounded after
-    // finish so the fire-and-forget recommended-model download completes
-    // (0 = skip, the default — a multi-GB pull should not slow normal runs).
-    TEST_RUNNER_ELIZA_LOCAL_MODEL_DOWNLOAD_WAIT_SECONDS:
-      args["local-download-wait"] ??
-      process.env.ELIZA_LOCAL_MODEL_DOWNLOAD_WAIT_SECONDS ??
-      "0",
-    // Seeded launcher gesture-loop (LauncherGestureLoopUITests): forward
-    // the reproduction seed + action count so a run replays exactly.
-    ...(process.env.ELIZA_LOOP_SEED
-      ? { TEST_RUNNER_ELIZA_LOOP_SEED: process.env.ELIZA_LOOP_SEED }
-      : {}),
-    ...(process.env.ELIZA_LOOP_ACTIONS
-      ? { TEST_RUNNER_ELIZA_LOOP_ACTIONS: process.env.ELIZA_LOOP_ACTIONS }
-      : {}),
-  };
-
-  const runHarness = (testing, bundlePath) => {
-    fs.rmSync(bundlePath, { recursive: true, force: true });
-    return spawnSync(
-      "xcodebuild",
-      [
-        "test-without-building",
-        "-xctestrun",
-        xctestrunPath,
-        "-destination",
-        destination,
-        "-resultBundlePath",
-        bundlePath,
-        "-only-testing",
-        testing,
-      ],
-      { cwd: iosProjectDir, stdio: "inherit", env: harnessEnv },
+  const shardResults = [];
+  for (const [index, shard] of shards.entries()) {
+    const shardName = safeName(
+      `${String(index + 1).padStart(2, "0")}-${shard.name}`,
     );
-  };
+    const resultBundle = path.join(outputDir, `${shardName}.xcresult`);
+    fs.rmSync(resultBundle, { recursive: true, force: true });
 
-  const exportArtifacts = (bundlePath, targetDir) => {
-    const attachmentsDir = path.join(targetDir, "attachments");
+    if (platform === "sim") {
+      resetSimulatorAppContainer({
+        udid: simUdid,
+        appBundleId,
+        bundles: installableSimulatorBundles,
+        shardName,
+      });
+    } else {
+      resetDeviceAppContainer({
+        deviceIdentifier,
+        appBundleId,
+        shardName,
+      });
+    }
+
+    const simVideo = startSimVideo({
+      udid: simUdid,
+      outputDir,
+      filename: `${shardName}.mp4`,
+    });
+    let testResult;
+    try {
+      testResult = spawnSync(
+        "xcodebuild",
+        [
+          "test-without-building",
+          "-xctestrun",
+          xctestrunPath,
+          "-destination",
+          destination,
+          "-resultBundlePath",
+          resultBundle,
+          "-only-testing",
+          shard.onlyTesting,
+        ],
+        {
+          cwd: iosProjectDir,
+          stdio: "inherit",
+          env: {
+            ...process.env,
+            TEST_RUNNER_ELIZA_BOOT_TIMEOUT_SECONDS:
+              args["boot-timeout"] ??
+              process.env.ELIZA_BOOT_TIMEOUT_SECONDS ??
+              "180",
+            TEST_RUNNER_ELIZA_BOOT_SCREENSHOT_INTERVAL_SECONDS:
+              args.interval ??
+              process.env.ELIZA_BOOT_SCREENSHOT_INTERVAL_SECONDS ??
+              "15",
+            TEST_RUNNER_ELIZA_AGENT_READY_TIMEOUT_SECONDS:
+              args["agent-ready-timeout"] ??
+              process.env.ELIZA_AGENT_READY_TIMEOUT_SECONDS ??
+              "240",
+            TEST_RUNNER_ELIZA_LOCAL_MODEL_DOWNLOAD_WAIT_SECONDS:
+              args["local-download-wait"] ??
+              process.env.ELIZA_LOCAL_MODEL_DOWNLOAD_WAIT_SECONDS ??
+              "0",
+            ...(process.env.ELIZA_LOOP_SEED
+              ? { TEST_RUNNER_ELIZA_LOOP_SEED: process.env.ELIZA_LOOP_SEED }
+              : {}),
+            ...(process.env.ELIZA_LOOP_ACTIONS
+              ? {
+                  TEST_RUNNER_ELIZA_LOOP_ACTIONS:
+                    process.env.ELIZA_LOOP_ACTIONS,
+                }
+              : {}),
+          },
+        },
+      );
+    } finally {
+      const videoPath = await simVideo.stop();
+      if (videoPath) log(`simulator video: ${videoPath}`);
+    }
+
+    const attachmentsDir = path.join(outputDir, "attachments", shardName);
     fs.rmSync(attachmentsDir, { recursive: true, force: true });
     fs.mkdirSync(attachmentsDir, { recursive: true });
-    let summaryJson = null;
-    if (fs.existsSync(bundlePath)) {
+    let summaryPath = null;
+    if (fs.existsSync(resultBundle)) {
       runInherit("xcrun", [
         "xcresulttool",
         "export",
         "attachments",
         "--path",
-        bundlePath,
+        resultBundle,
         "--output-path",
         attachmentsDir,
       ]);
@@ -640,201 +549,63 @@ async function main() {
           "test-results",
           "summary",
           "--path",
-          bundlePath,
-          "--format",
-          "json",
+          resultBundle,
         ],
         { encoding: "utf8" },
       );
       if (summary.status === 0) {
-        fs.writeFileSync(
-          path.join(targetDir, "test-summary.json"),
-          summary.stdout,
-        );
-        try {
-          summaryJson = JSON.parse(summary.stdout);
-        } catch {
-          summaryJson = null;
-        }
+        summaryPath = path.join(outputDir, `${shardName}.test-summary.json`);
+        fs.writeFileSync(summaryPath, summary.stdout);
       }
     } else {
-      log(`warning: no .xcresult bundle produced at ${bundlePath}`);
+      log(`warning: no .xcresult bundle produced for ${shardName}.`);
     }
+
     const exported = fs.existsSync(attachmentsDir)
       ? fs.readdirSync(attachmentsDir)
       : [];
-    return { attachmentsDir, attachmentCount: exported.length, summaryJson };
-  };
-
-  // Read the failed-test identifiers out of a produced .xcresult so the
-  // retry-in-isolation pass can re-run each one alone. Returns [] on any
-  // missing bundle / non-zero summary / unparseable output (fail-closed: no
-  // isolable failures found means the suite verdict stands).
-  const readFailedTestIdentifiers = (bundlePath, fallbackTarget) => {
-    if (!fs.existsSync(bundlePath)) return [];
-    const summary = spawnSync(
-      "xcrun",
-      [
-        "xcresulttool",
-        "get",
-        "test-results",
-        "summary",
-        "--path",
-        bundlePath,
-        "--format",
-        "json",
-      ],
-      { encoding: "utf8" },
-    );
-    if (summary.status !== 0) return [];
-    return parseFailedTestIdentifiers(summary.stdout, {
-      fallbackTarget,
-    });
-  };
-
-  const shardsRoot = path.join(outputDir, "shards");
-  fs.mkdirSync(shardsRoot, { recursive: true });
-  log(
-    `xcuitest shards: ${shardPlan.length} (${shardPlan
-      .map((shard) => shard.identifier)
-      .join(", ")})`,
-  );
-
-  const shardSummaries = [];
-  for (const shard of shardPlan) {
-    const shardDir = path.join(shardsRoot, shard.resultName);
-    fs.mkdirSync(shardDir, { recursive: true });
-    const resultBundle = path.join(shardDir, `${shard.resultName}.xcresult`);
-    log(`shard ${shard.index}/${shardPlan.length}: ${shard.identifier}`);
-    const reset = resetAppContainer(shard.resultName);
-
-    const simVideo = startSimVideo({
-      udid: simUdid,
-      outputDir: shardDir,
-      filename: `${shard.resultName}.mp4`,
-    });
-    let testResult;
-    try {
-      testResult = runHarness(shard.identifier, resultBundle);
-    } finally {
-      const videoPath = await simVideo.stop();
-      if (videoPath) log(`simulator video: ${videoPath}`);
-    }
-
-    const artifacts = exportArtifacts(resultBundle, shardDir);
-    const shardSummary = {
-      ...shard,
-      bundleId,
-      reset,
+    const status = testResult.status ?? 1;
+    shardResults.push({
+      name: shard.name,
+      onlyTesting: shard.onlyTesting,
+      appBundleId,
+      reset:
+        platform === "sim" ? "simctl uninstall/install" : "devicectl uninstall",
+      status,
       resultBundle,
-      attachmentsDir: artifacts.attachmentsDir,
-      attachmentCount: artifacts.attachmentCount,
-      exitStatus: testResult.status,
-      passed: testResult.status === 0,
-      flakeClassification: null,
-    };
+      attachmentsDir,
+      attachmentCount: exported.length,
+      summaryPath,
+    });
     log(
-      `shard ${shard.resultName}: exit=${testResult.status} attachments=${artifacts.attachmentCount}`,
+      `shard ${shardName}: exit=${status}, attachments=${exported.length}, result=${resultBundle}`,
     );
-
-    if (testResult.status !== 0) {
-      const suiteFailures = readFailedTestIdentifiers(
-        resultBundle,
-        "AppUITests",
-      );
-      if (args["no-retry-isolation"] || suiteFailures.length === 0) {
-        const why = args["no-retry-isolation"]
-          ? "--no-retry-isolation set"
-          : "no isolable failed-test identifiers parsed from the .xcresult";
-        const skipped = { skipped: true, reason: why };
-        writeFlakeSummary(shardDir, skipped);
-        shardSummary.flakeClassification = skipped;
-      } else {
-        log(
-          `retry-in-isolation (${shard.resultName}): ${suiteFailures.length} failed test(s) — ` +
-            suiteFailures.map((f) => f.identifier).join(", "),
-        );
-        const isolatedResults = [];
-        const isolationDir = path.join(shardDir, "isolation");
-        fs.mkdirSync(isolationDir, { recursive: true });
-        for (const failure of suiteFailures) {
-          const safeName = failure.identifier.replace(/[^A-Za-z0-9._-]/g, "_");
-          const isoBundle = path.join(isolationDir, `${safeName}.xcresult`);
-          log(`  isolated re-run: ${failure.identifier}`);
-          resetAppContainer(`isolation-${safeName}`);
-          const isoResult = runHarness(failure.identifier, isoBundle);
-          exportArtifacts(isoBundle, path.join(isolationDir, safeName));
-          isolatedResults.push({
-            identifier: failure.identifier,
-            isolatedPassed: isoResult.status === 0,
-          });
-        }
-
-        const classification = classifyIsolatedReruns(
-          suiteFailures,
-          isolatedResults,
-        );
-        const classificationPayload = {
-          skipped: false,
-          verdicts: classification.verdicts,
-          flakes: classification.flakes,
-          realFailures: classification.realFailures,
-        };
-        writeFlakeSummary(shardDir, classificationPayload);
-        shardSummary.flakeClassification = classificationPayload;
-        shardSummary.passed = !classification.exitNonZero;
-        for (const v of classification.verdicts) {
-          log(`  ${v.verdict.toUpperCase()}: ${v.identifier}`);
-        }
-      }
-    }
-    shardSummaries.push(shardSummary);
   }
 
-  const aggregate = {
-    generatedAt: new Date().toISOString(),
-    platform,
-    bundleId,
-    destination,
-    sharded: args["only-testing"] ? "explicit-only-testing" : "default",
-    shards: shardSummaries,
-  };
   fs.writeFileSync(
     path.join(outputDir, "test-summary.json"),
-    `${JSON.stringify(aggregate, null, 2)}\n`,
+    `${JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        platform,
+        destination,
+        appBundleId,
+        shards: shardResults,
+      },
+      null,
+      2,
+    )}\n`,
   );
 
-  const failedShards = shardSummaries.filter((shard) => !shard.passed);
-  if (failedShards.length > 0) {
+  const failed = shardResults.filter((result) => result.status !== 0);
+  if (failed.length > 0) {
     fail(
-      `iOS capture failed: ${failedShards.length}/${shardSummaries.length} shard(s) failed ` +
-        `(${failedShards.map((shard) => shard.identifier).join(", ")}). ` +
-        `Review shard artifacts under ${shardsRoot}.`,
+      `harness shard run failed (${failed.length}/${shardResults.length} shard(s)): ` +
+        failed.map((result) => result.name).join(", ") +
+        `. Review per-shard screenshots in ${path.join(outputDir, "attachments")}.`,
     );
   }
-  log(
-    `iOS capture PASSED: ${shardSummaries.length} shard(s) completed with fresh containers.`,
-  );
-}
-
-// Persist the flake classification into the run's test-summary output so trend
-// data exists across runs (#13566).
-function writeFlakeSummary(outputDir, payload) {
-  try {
-    fs.writeFileSync(
-      path.join(outputDir, "flake-classification.json"),
-      `${JSON.stringify(payload, null, 2)}\n`,
-    );
-  } catch (error) {
-    // error-policy:J5 — trend-data side-output is non-authoritative; a write
-    // failure must NOT mask or alter the real pass/fail verdict, but is logged
-    // observably (not silently swallowed) so a broken output dir is visible.
-    log(
-      `warning: could not write flake-classification.json (${
-        error?.message ?? error
-      }); the run verdict is unaffected.`,
-    );
-  }
+  log("boot capture PASSED (all isolated shards passed).");
 }
 
 const isDirectRun =


### PR DESCRIPTION
## Summary
- shards the default `ios-device-capture.mjs` full AppUITests run into isolated invocations instead of one monolithic `-only-testing AppUITests` run
- resets the app container before each shard (`simctl uninstall/install` on simulator; `devicectl uninstall` before physical-device xcodebuild install)
- runs BootCapture onboarding paths as separate shards so cloud and local first-run each start from a fresh container
- writes per-shard `.xcresult` bundles, attachment directories, optional summary JSON files, and an aggregate `test-summary.json` naming each shard/reset boundary
- makes `testChatSheetDetentFlickCycle` seed a persistent thread and assert the thread-present flick branch instead of switching based on residual message state
- documents the sharded/reset capture behavior in the app automation notes

Fixes #13686.

## Verification
- `bunx biome check packages/app/scripts/ios-device-capture.mjs packages/app/CLAUDE.md packages/app/AGENTS.md`
- `node --check packages/app/scripts/ios-device-capture.mjs`
- `node packages/app/scripts/ios-device-capture.mjs --help`
- `git diff --check -- packages/app/scripts/ios-device-capture.mjs packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift packages/app/CLAUDE.md packages/app/AGENTS.md`

Not run locally: full `node scripts/ios-device-capture.mjs --platform sim` because this Linux worktree has no generated `packages/app/ios` project/Xcode simulator. The script now exposes the shard plan in logs and aggregate summary for the macOS lane to verify.