### PR TITLE
fix(browser): do not await default tab seed at startup

### DIFF
--- a/plugins/plugin-browser/src/browser-service.ts
+++ b/plugins/plugin-browser/src/browser-service.ts
@@ -131,16 +131,14 @@ export class BrowserService extends Service {
     }
     // Seed the Safari-style default search tab so the browser never opens
     // empty-and-sad (#13596). Best-effort with a bounded desktop bridge
-    // readiness window: failure must not prevent the service from starting.
-    try {
-      await ensureBrowserWorkspaceDefaultTabWithRetry();
-    } catch (err) {
+    // readiness window, but startup itself must not wait for the bridge.
+    void ensureBrowserWorkspaceDefaultTabWithRetry().catch((err) => {
       // error-policy:J4 startup should expose the browser even when the optional default tab cannot be seeded.
       const message = err instanceof Error ? err.message : String(err);
       logger.warn(
         `[BrowserService] default search tab not seeded at start: ${message}`,
       );
-    }
+    });
     return service;
   }
 

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-default-tab.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-default-tab.test.ts
@@ -8,7 +8,7 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BrowserService } from "../../browser-service.js";
 import {
   __resetBrowserWorkspaceStateForTests,
@@ -21,6 +21,20 @@ import {
 } from "../browser-workspace.js";
 
 const webEnv: NodeJS.ProcessEnv = {};
+const bridgeKeys = [
+  "ELIZA_BROWSER_WORKSPACE_URL",
+  "ELIZA_BROWSER_WORKSPACE_TOKEN",
+];
+const savedBridge: Record<string, string | undefined> = {};
+
+async function waitForWorkspaceTabs(count: number) {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const tabs = await listBrowserWorkspaceTabs();
+    if (tabs.length === count) return tabs;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  return await listBrowserWorkspaceTabs();
+}
 
 describe("browser workspace default search tab (web mode)", () => {
   beforeEach(async () => {
@@ -155,18 +169,20 @@ describe("browser workspace default search tab (web mode)", () => {
 });
 
 describe("BrowserService seeds the default tab at start", () => {
-  const bridgeKeys = [
-    "ELIZA_BROWSER_WORKSPACE_URL",
-    "ELIZA_BROWSER_WORKSPACE_TOKEN",
-  ];
-  const savedBridge: Record<string, string | undefined> = {};
-
   beforeEach(async () => {
     for (const key of bridgeKeys) {
       savedBridge[key] = process.env[key];
       delete process.env[key];
     }
     await __resetBrowserWorkspaceStateForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const key of bridgeKeys) {
+      if (savedBridge[key] === undefined) delete process.env[key];
+      else process.env[key] = savedBridge[key];
+    }
   });
 
   it("opens one default search tab when the service boots in web mode", async () => {
@@ -176,16 +192,37 @@ describe("BrowserService seeds the default tab at start", () => {
 
     const service = await BrowserService.start(runtime);
     try {
-      const tabs = await listBrowserWorkspaceTabs();
+      const tabs = await waitForWorkspaceTabs(1);
       expect(tabs).toHaveLength(1);
       expect(tabs[0]?.url).toBe(BROWSER_WORKSPACE_DEFAULT_SEARCH_URL);
       expect(tabs[0]?.visible).toBe(true);
     } finally {
       await service.stop();
-      for (const key of bridgeKeys) {
-        if (savedBridge[key] === undefined) delete process.env[key];
-        else process.env[key] = savedBridge[key];
-      }
+    }
+  });
+
+  it("does not wait for a pending desktop bridge default-tab seed", async () => {
+    process.env.ELIZA_BROWSER_WORKSPACE_URL = "http://127.0.0.1:39299";
+    process.env.ELIZA_BROWSER_WORKSPACE_TOKEN = "test-token";
+    const pendingRequest = Promise.withResolvers<Response>();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockReturnValue(pendingRequest.promise);
+    const runtime = {
+      getService: () => null,
+    } as unknown as IAgentRuntime;
+
+    const service = await BrowserService.start(runtime);
+    try {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:39299/tabs",
+        expect.any(Object),
+      );
+      expect(fetchMock.mock.results[0]?.type).toBe("return");
+    } finally {
+      pendingRequest.reject(new Error("desktop bridge unavailable"));
+      await Promise.resolve();
+      await service.stop();
     }
   });
 });


### PR DESCRIPTION
## Summary
- make BrowserService startup fire-and-observe the default search tab seed instead of awaiting desktop bridge readiness
- keep the bounded retry path added on develop, but move it behind the non-blocking observer
- add a regression test proving BrowserService.start returns while a desktop bridge /tabs request is still pending

## Verification
- `bun run --cwd plugins/plugin-browser test src/workspace/__tests__/browser-workspace-default-tab.test.ts` (9 passed)
- `bun run --cwd plugins/plugin-browser typecheck`
- `bunx @biomejs/biome check plugins/plugin-browser/src/browser-service.ts plugins/plugin-browser/src/workspace/__tests__/browser-workspace-default-tab.test.ts --no-errors-on-unmatched`
- `git diff --check`

## Evidence
- N/A screenshots/video: backend service startup behavior; no rendered UI changed.
- Logs manually reviewed: focused Vitest output includes the expected `[BrowserService] default search tab not seeded at start: desktop bridge unavailable` warning after the controlled pending bridge request is rejected.

Follow-up to the post-merge review of #13810/#13825: #13825 only annotated the catch and explicitly made no runtime behavior change; this PR preserves that annotation and fixes the startup await behavior.