### PR TITLE
fix(#13587): per-view anticipatory greeting — declared-intent judge

### DIFF
--- a/packages/agent/src/api/builtin-views.ts
+++ b/packages/agent/src/api/builtin-views.ts
@@ -67,6 +67,8 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/chat",
     order: 1,
     tags: ["messaging", "conversation", "agent"],
+    anticipatoryIntent:
+      "Offer to pick up the most recent unfinished thread or summarize new inbound messages across connectors.",
     visibleInManager: true,
     desktopTabEnabled: true,
     platforms: ["web", "desktop", "ios", "android"],
@@ -81,6 +83,8 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/character",
     order: 50,
     tags: ["identity", "personality", "character"],
+    anticipatoryIntent:
+      "Offer the single highest-value identity or personality improvement from the current character state (bio, style, examples, or knowledge gaps).",
     visibleInManager: true,
     desktopTabEnabled: true,
   },
@@ -95,6 +99,8 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     order: 51,
     tags: ["documents", "knowledge", "files", "uploads", "retrieval"],
     relatedActions: ["OWNER_DOCUMENTS"],
+    anticipatoryIntent:
+      "Offer to triage recently ingested attachments — tag, rescope, or clean up new knowledge items from the last few days.",
     visibleInManager: true,
     desktopTabEnabled: true,
   },
@@ -108,6 +114,8 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/automations",
     order: 55,
     tags: ["automation", "tasks", "scheduling"],
+    anticipatoryIntent:
+      "Offer to draft a new workflow/trigger for a routine the user does by hand, or surface any failed automation runs that need attention.",
     visibleInManager: true,
   },
   {
@@ -119,6 +127,8 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     heroImagePath: "assets/view-heroes/plugins-page.png",
     path: "/apps/plugins",
     order: 60,
+    anticipatoryIntent:
+      "Offer the smallest concrete plugin setup or fix — configure credentials for an installed-but-unready plugin, or close a runtime capability gap.",
     tags: [
       "plugins",
       "plugin-browser",
@@ -155,6 +165,8 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/apps/transcripts",
     order: 71,
     tags: ["transcript", "voice", "recording", "audio"],
+    anticipatoryIntent:
+      "Offer to summarize or extract action items from the most recent voice transcript.",
     visibleInManager: true,
   },
   {
@@ -207,6 +219,8 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     order: 90,
     tags: ["configuration", "preferences", "plugins"],
     relatedActions: ["RUNTIME"],
+    anticipatoryIntent:
+      "Offer to finish first-run setup — pick the model and provider, connect the wallet/cloud account, or set the voice — starting with whatever is still unconfigured.",
     visibleInManager: true,
     desktopTabEnabled: true,
   },

--- a/packages/agent/src/api/views-routes.proactive-emit.test.ts
+++ b/packages/agent/src/api/views-routes.proactive-emit.test.ts
@@ -89,6 +89,27 @@ describe("POST /api/views/:id/navigate — VIEW_SWITCHED emission (#8792)", () =
     );
   });
 
+  it("carries the view's declared anticipatoryIntent when it has one (#13587)", async () => {
+    const { ctx, emitEvent } = makeCtx("settings", { source: "user" });
+    await handleViewsRoutes(ctx);
+
+    const calls = viewSwitchedCalls(emitEvent);
+    expect(calls).toHaveLength(1);
+    const emitted = calls[0][1] as { anticipatoryIntent?: string };
+    expect(typeof emitted.anticipatoryIntent).toBe("string");
+    expect(emitted.anticipatoryIntent).toMatch(/setup|model|provider|voice/i);
+  });
+
+  it("omits anticipatoryIntent for a view that declares none (#13587)", async () => {
+    // "calendar" is not a builtin view, so no declaration and no intent.
+    const { ctx, emitEvent } = makeCtx("calendar", { source: "user" });
+    await handleViewsRoutes(ctx);
+
+    const calls = viewSwitchedCalls(emitEvent);
+    expect(calls).toHaveLength(1);
+    expect(calls[0][1]).not.toHaveProperty("anticipatoryIntent");
+  });
+
   it("does NOT re-emit when re-navigating to the same view", async () => {
     const first = makeCtx("wallet", { source: "user" });
     await handleViewsRoutes(first.ctx);

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -837,6 +837,12 @@ export async function handleViewsRoutes(
             viewLabel,
             viewPath,
             viewType: resolvedViewType,
+            // Carry the view's declared anticipatory intent (#13587) so the
+            // proactive-interaction judge greets from what the view is FOR,
+            // not just its label. Absent for views that declare none.
+            ...(entry?.anticipatoryIntent
+              ? { anticipatoryIntent: entry.anticipatoryIntent }
+              : {}),
             previousViewId,
             initiatedBy: source,
           })

--- a/packages/agent/src/services/proactive-interaction-decider.test.ts
+++ b/packages/agent/src/services/proactive-interaction-decider.test.ts
@@ -18,6 +18,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildProactiveJudgePrompt,
   decideProactiveComment,
+  type InteractionPayload,
   interactionSurface,
   parseProactiveJudgeDecisionOutput,
   parseProactiveJudgeOutput,
@@ -224,6 +225,69 @@ describe("buildProactiveJudgePrompt", () => {
       initiatedBy: "user",
     };
     expect(buildProactiveJudgePrompt(shortcut)).toContain("open-wallet");
+  });
+
+  it("hands the declared anticipatory intent to the judge (#13587)", () => {
+    const p = buildProactiveJudgePrompt(
+      payload({
+        viewLabel: "Settings",
+        anticipatoryIntent: "Offer to finish first-run model and voice setup.",
+      }),
+    );
+    expect(p).toContain("Declared anticipatory intent for this view:");
+    expect(p).toContain("Offer to finish first-run model and voice setup.");
+  });
+
+  it("falls back to label-only when the view declares no intent (#13587)", () => {
+    const p = buildProactiveJudgePrompt(
+      payload({ viewLabel: "Settings", anticipatoryIntent: undefined }),
+    );
+    expect(p).toContain("The user just opened the Settings view.");
+    expect(p).not.toContain("Declared anticipatory intent");
+  });
+
+  it("no longer instructs the judge to stay silent on settings/config (#13587)", () => {
+    const p = buildProactiveJudgePrompt(payload({ viewLabel: "Settings" }));
+    // The old doctrine-violating imperative ("Stay silent (return null) for
+    // ... settings/config screens") is gone: configuration surfaces are now
+    // greet-eligible, and the copy says so explicitly.
+    expect(p).not.toMatch(/Stay silent \(return null\)[^\n]*settings\/config/);
+    expect(p).toMatch(/do NOT stay silent just because it is a settings/i);
+  });
+});
+
+describe("intent-driven greeting end to end (#13587)", () => {
+  it("admits a scoped settings greeting driven by the declared intent", async () => {
+    const gate = new ProactiveInteractionGate(configForChattiness("subtle"));
+    // The judge sees the intent in the prompt and returns a high-confidence,
+    // scoped offer — the exact case the old 0.65-floor + silent-on-settings
+    // guidance used to suppress.
+    const judge = async (p: InteractionPayload) => {
+      expect(buildProactiveJudgePrompt(p)).toContain(
+        "finish first-run model and voice setup",
+      );
+      return parseProactiveJudgeDecisionOutput(
+        JSON.stringify({
+          comment: "Want me to finish setup — pick your model and voice?",
+          delivery: "chat",
+          confidence: 0.9,
+        }),
+      );
+    };
+    const res = await decideProactiveComment({
+      payload: payload({
+        viewId: "settings",
+        viewLabel: "Settings",
+        anticipatoryIntent: "Offer to finish first-run model and voice setup.",
+      }),
+      gate,
+      judge,
+      now: 0,
+    });
+    expect(res.text).toBe(
+      "Want me to finish setup — pick your model and voice?",
+    );
+    expect(res.delivery).toBe("chat");
   });
 });
 

--- a/packages/agent/src/services/proactive-interaction-decider.ts
+++ b/packages/agent/src/services/proactive-interaction-decider.ts
@@ -6,6 +6,13 @@
  * existing `routeAutonomyTextToUser` → `proactive-message` pipeline with
  * `source: "proactive-interaction"` or the low-priority notification rail.
  *
+ * On a USER-initiated view switch the judge is driven by the view's declared
+ * anticipatory intent (#13587): a view that declares one is expected to produce
+ * a scoped greeting; a view without one is judged from its label only and may
+ * stay silent. The `ProactiveInteractionGate` (cooldown/cap/dedup/debounce) is
+ * the rate-limit backstop in every case, and agent-initiated switches are always
+ * skipped (the agent already acknowledged the move, #8788).
+ *
  * Two layers, both testable in isolation:
  *  - {@link decideProactiveComment} — the pure policy + governance decision
  *    (injected judge / gate / clock), no runtime, no model, no network.
@@ -202,14 +209,21 @@ export async function decideProactiveComment(
 }
 
 const JUDGE_INSTRUCTION = [
-  "The user just took an action in the app. Decide if there is ONE specific, helpful thing you can proactively offer right now.",
-  'Examples: switched to wallet → "Want me to pull your latest balances?"; opened task-coordinator → "Want me to summarize your open tasks?".',
-  'Use delivery "chat" only when the current view benefits from a visible suggestion. Use delivery "notify" for useful but low-urgency offers that should land quietly outside chat.',
-  "Stay silent (return null) for ambiguous or low-value interactions, settings/config screens, or anything where an offer would be noise.",
+  "The user just switched into a view. Anticipate what they came here to do and offer ONE specific, scoped, immediately useful thing.",
+  "When an anticipatory intent is declared for the view, fulfill it: propose that action in a single short sentence, grounded in the view — do NOT stay silent just because it is a settings/config screen.",
+  'Examples: wallet → "Want your latest balances and today\'s P&L?"; settings → "Want me to finish setup — pick your model and voice?"; knowledge → "You have new attachments to triage — want me to file them?".',
+  "A user-initiated switch is itself a signal they want help here, so prefer offering over silence whenever the view declares an intent.",
+  'Use delivery "chat" for a visible in-view suggestion. Use delivery "notify" for useful but low-urgency offers that should land quietly outside chat.',
+  "Return null only when there is genuinely nothing scoped and useful to offer — typically a view with no declared intent and no live signal — never merely because the screen looks like configuration.",
   'Respond as JSON: {"comment": <a short offer, or null>, "delivery": "chat" | "notify", "confidence": 0..1, "urgency": "low" | "medium" | "high", "title": <optional notification title>}.',
 ].join("\n");
 
-/** Describe the interaction for the judge prompt. */
+/**
+ * Describe the interaction for the judge prompt. A view switch that carries a
+ * declared {@link ViewSwitchedPayload.anticipatoryIntent} (#13587) hands that
+ * intent to the judge so the greeting anticipates the view's purpose; without
+ * one the judge only knows the label and may legitimately stay silent.
+ */
 function describeInteraction(payload: InteractionPayload): string {
   if ("command" in payload) {
     return `The user just ran the /${payload.command} command.`;
@@ -218,7 +232,12 @@ function describeInteraction(payload: InteractionPayload): string {
     return `The user just used the "${payload.shortcutId}" shortcut.`;
   }
   const where = payload.viewLabel ?? payload.viewId;
-  return `The user just opened the ${where} view.`;
+  const lines = [`The user just opened the ${where} view.`];
+  const intent = payload.anticipatoryIntent?.trim();
+  if (intent) {
+    lines.push(`Declared anticipatory intent for this view: ${intent}`);
+  }
+  return lines.join("\n");
 }
 
 /** Build the small-model judge prompt for an interaction. */

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -375,6 +375,13 @@ export interface ViewSwitchedPayload extends EventPayload {
 	viewLabel?: string;
 	viewPath?: string | null;
 	viewType?: string;
+	/**
+	 * The switched-to view's declared anticipatory intent (#13587), copied from
+	 * its {@link ViewDeclaration.anticipatoryIntent}. Present only when the view
+	 * declares one; drives the proactive-interaction judge toward a scoped
+	 * greeting instead of guessing from the label.
+	 */
+	anticipatoryIntent?: string;
 	/** Where the user was before this switch, when known. */
 	previousViewId?: string | null;
 	initiatedBy: InteractionInitiator;

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -833,6 +833,19 @@ export interface ViewDeclaration {
 	 * Optional free-form planner hints for this view.
 	 */
 	contextHints?: string[];
+	/**
+	 * What the agent should proactively offer the moment the user switches INTO
+	 * this view (#13587). One short, imperative sentence naming the single most
+	 * useful anticipatory action for the surface — e.g. wallet → "Offer a
+	 * portfolio summary and a fund/swap next step", settings → "Offer to set up
+	 * the model, provider, and voice". The proactive-interaction decider reads
+	 * this declared intent instead of guessing from the label: a view WITH an
+	 * intent is expected to produce a scoped greeting on a user-initiated switch;
+	 * a view WITHOUT one falls back to label-only judging and may stay silent.
+	 * The `ProactiveInteractionGate` (cooldown/cap/dedup/debounce) remains the
+	 * rate-limit backstop regardless.
+	 */
+	anticipatoryIntent?: string;
 	/** Relative path from the plugin's package root to its hero image. */
 	heroImagePath?: string;
 	/** Screen background policy for this view. Defaults to `"opaque"`. */


### PR DESCRIPTION
## What & why

Board Todo #13587 (parent #13560, views-redesign). The proactive-interaction machinery already existed (VIEW_SWITCHED → TEXT_SMALL judge → `ProactiveInteractionGate`) but was tuned to **stay silent**: the judge was told to keep quiet on settings/config screens and only knew the view *label*, so greetings were both suppressed and generic. This ships the **core mechanism**: a per-view **declared anticipatory intent** that drives the judge, so a user-initiated switch into a view produces one scoped, useful greeting — while the gate stays the rate-limit backstop.

## Changes

- **`ViewDeclaration.anticipatoryIntent`** (`packages/core/src/types/plugin.ts`) — one imperative sentence naming the single most useful thing to offer on entry. Carried on **`ViewSwitchedPayload.anticipatoryIntent`** (`packages/core/src/types/events.ts`).
- **Builtin-view manifest** (`packages/agent/src/api/builtin-views.ts`) — declared intents for settings, knowledge/documents, character, automations, plugins, transcripts, and chat.
- **Emission** (`packages/agent/src/api/views-routes.ts`) — `POST /api/views/:id/navigate` copies the view's declared intent into the VIEW_SWITCHED payload (only when the view declares one).
- **Judge rework** (`packages/agent/src/services/proactive-interaction-decider.ts`) — removed the "stay silent … settings/config screens" imperative; the judge now prompts anticipatorily from the declared intent and prefers offering over silence on a user-initiated switch. `describeInteraction` hands the declared intent to the judge; a view **without** an intent falls back to label-only judging and may still stay silent. The confidence mechanism and the chat/notify delivery split are kept.
- **`ProactiveInteractionGate` is untouched** (cooldown / per-surface cooldown / daily cap / dedup / debounce) and agent-initiated switches are still skipped (#8788).

## Tests (real paths, fail without the change)

`bun run --cwd packages/agent test src/services/proactive-interaction-decider.test.ts src/api/views-routes.proactive-emit.test.ts` → **34 passed**. Neighboring suites (`*.wiring.test.ts`, `proactive-interaction-gate.test.ts`, `proactive-interaction-pipeline.test.ts`, `views-registry.kinds`, `view-id-drift`, `views-routes.hero-coverage`) → green.

- Navigate emission carries `anticipatoryIntent` for a view that declares one (settings) and **omits** it for a view that declares none (calendar) — drives `handleViewsRoutes` end to end.
- The judge prompt carries the declared intent, falls back to label-only when absent, and **no longer** contains the old "Stay silent (return null) … settings/config" imperative.
- An intent-driven settings greeting is **admitted end to end** through the real `ProactiveInteractionGate` — the exact case the old silent-on-settings + 0.65-floor guidance suppressed.

## Deferred follow-ups (noted, not half-done)

Per the redesign spec, two larger sub-items are intentionally scoped out of this core child and left as follow-ups:

1. **Live-state enrichment inside the judge** via `renderLiveStateForScope` (spec item 3): injecting the wallet/knowledge/transcripts live state into the greeting requires wiring the provider-internal scope renderer + a view-id→scope map into the decider's judge. The declared-**purpose** injection (the core) ships here; the live-**state** injection is the follow-up.
2. **Live-model scenario harness** (spec item 5 / the per-view scenario requirement): the reusable VIEW_SWITCHED greeting scenario pattern under `packages/scenario-runner` must run against a **live** model with hand-read trajectories (PR_EVIDENCE.md). That needs live-cloud/model access and belongs with the per-view children; this PR lands the unit + route-level coverage that proves the mechanism deterministically.

## Evidence

- Real-LLM trajectories: **N/A in this PR** — deferred to the live-model scenario harness follow-up (needs live-cloud access). Deterministic unit + route tests drive the actual code paths here.
- Screenshots/video: **N/A** — no rendered UI surface changed (server-side judge + manifest + event payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)