### PR TITLE
feat(examples): add SVS verified action example

### DIFF
--- a/packages/examples/svs-verified-action/.env.example
+++ b/packages/examples/svs-verified-action/.env.example
@@ -1,0 +1,10 @@
+# Placeholder values only. Do not commit real API keys or signing secrets.
+SVS_SERVER_URL=https://app.svsprotocol.com
+SVS_BOT_ID=replace-with-dashboard-bot-id
+SVS_BOT_POLICY_ID=memo-human-approved-v1
+SVS_BOT_API_KEY=replace-with-dashboard-issued-api-key
+SVS_BOT_REQUEST_SIGNING_SECRET=replace-with-dashboard-issued-request-signing-secret
+SVS_BOT_EXPECTED_INTEGRATION_CONTRACT_HASH=replace-with-current-contract-hash
+SOLANA_RPC_URL=https://api.devnet.solana.com
+SVS_SERIALIZED_TRANSACTION_BASE64=replace-with-prepared-serialized-transaction
+SVS_RUN_LIVE_SUBMIT=false

--- a/packages/examples/svs-verified-action/README.md
+++ b/packages/examples/svs-verified-action/README.md
@@ -1,0 +1,95 @@
+# SVS Verified Action Example For ElizaOS
+
+This directory is a PR-ready example package for the ElizaOS ecosystem. It is
+intentionally small so a framework maintainer can review it without the private
+SVS implementation details.
+
+## What The Example Shows
+
+The example adds one ElizaOS-compatible plugin/action:
+
+```text
+SVS_VERIFY_AND_SUBMIT_SOLANA_ACTION
+```
+
+The plugin is created from the public SVS package export:
+
+```js
+import { createSvsElizaOsPlugin } from "@svsprotocol/solana/elizaos";
+```
+
+It routes a prepared Solana action through SVS so the action is not trusted
+until SVS checks signed bot identity, production readiness, human wallet
+approval, registry proof, and portable verification.
+
+## Proposed Upstream Placement
+
+Suggested destination in an ElizaOS docs or examples PR:
+
+```text
+packages/examples/svs-verified-action/
+```
+
+The package is safe to copy because it uses only public dependencies and
+placeholder environment values.
+
+## Local Review
+
+From this directory:
+
+```sh
+npm install
+npm run validate
+```
+
+## Protocol Or Wallet Gate
+
+Protocols and wallets can reject unverified automation by requiring the hosted
+SVS registry before accepting an agent action:
+
+```js
+import { createHostedVerifiedAgentRegistryMiddleware } from "@svsprotocol/solana/protocol";
+
+const requireVerifiedAgent = createHostedVerifiedAgentRegistryMiddleware({
+  registryUrl: "https://registry.svsprotocol.com/registry.json",
+  expectedRegistryHash: "PINNED_REGISTRY_HASH",
+  trustPolicy: "high-trust"
+});
+
+await requireVerifiedAgent({ agent: { botId: "svs-demo-devnet-agent" } });
+```
+
+## Public References
+
+- Docs: https://svsprotocol.com/docs
+- Registry: https://registry.svsprotocol.com/registry.json
+- Verified Agent Standard: https://svsprotocol.com/docs#verified-agent-standard
+- Verifier: https://svsprotocol.com/verify
+
+## Run Modes
+
+The default run is import validation only. It does not require SVS credentials,
+read your config, or submit an action:
+
+```sh
+node ./svs-verified-action.mjs
+```
+
+Run `npm run validate` to check the package files and placeholder env template
+before opening the upstream PR.
+
+Live submission is opt-in:
+
+```sh
+SVS_RUN_LIVE_SUBMIT=true node ./svs-verified-action.mjs
+```
+
+Live mode requires a real SVS dashboard, bot API key, request-signing secret,
+controller wallet, current integration-contract hash, and a prepared serialized
+transaction. Do not commit those values.
+
+## Boundary
+
+This package must contain no API keys, request-signing secrets, wallet
+keypairs, local `data/` evidence, private dashboard source, admin endpoints, or
+private operator artifacts.

--- a/packages/examples/svs-verified-action/package.json
+++ b/packages/examples/svs-verified-action/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "svs-elizaos-verified-action-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Reviewable ElizaOS example that routes Solana actions through SVS human approval and proof verification.",
+  "scripts": {
+    "validate": "node ./validate.mjs"
+  },
+  "dependencies": {
+    "@elizaos/core": "^1.7.2",
+    "@svsprotocol/solana": "^0.2.0"
+  }
+}

--- a/packages/examples/svs-verified-action/svs-verified-action.mjs
+++ b/packages/examples/svs-verified-action/svs-verified-action.mjs
@@ -1,0 +1,165 @@
+import * as ElizaCore from "@elizaos/core";
+import {
+  ELIZAOS_ACTION_NAME,
+  ELIZAOS_ADAPTER_VERSION,
+  ELIZAOS_PLUGIN_NAME,
+  createSvsElizaOsPlugin
+} from "@svsprotocol/solana/elizaos";
+
+const REQUIRED_ENV = [
+  "SVS_SERVER_URL",
+  "SVS_BOT_ID",
+  "SVS_BOT_POLICY_ID",
+  "SVS_BOT_API_KEY",
+  "SVS_BOT_REQUEST_SIGNING_SECRET",
+  "SVS_BOT_EXPECTED_INTEGRATION_CONTRACT_HASH",
+  "SOLANA_RPC_URL"
+];
+
+const LIVE_SUBMIT_REQUIRED_ENV = [
+  ...REQUIRED_ENV,
+  "SVS_SERIALIZED_TRANSACTION_BASE64"
+];
+
+export function createSvsVerifiedElizaOsPlugin(env = process.env) {
+  assertRequiredEnv(env);
+
+  return createSvsElizaOsPlugin({
+    baseUrl: env.SVS_SERVER_URL,
+    apiKey: env.SVS_BOT_API_KEY,
+    requestSigningSecret: env.SVS_BOT_REQUEST_SIGNING_SECRET,
+    expectedIntegrationContractHash: env.SVS_BOT_EXPECTED_INTEGRATION_CONTRACT_HASH,
+    botId: env.SVS_BOT_ID,
+    policyId: env.SVS_BOT_POLICY_ID,
+    rpcUrl: env.SOLANA_RPC_URL,
+    waitForProof: env.SVS_WAIT_FOR_PROOF === "true",
+    fetchProof: true,
+    checkReceiptRegistryChain: true
+  });
+}
+
+export async function requireSvsVerifiedElizaOsReady(env = process.env) {
+  const plugin = createSvsVerifiedElizaOsPlugin(env);
+  const action = plugin.actions.find((candidate) => candidate.name === ELIZAOS_ACTION_NAME);
+
+  if (!action) {
+    throw new Error(`SVS ElizaOS plugin did not expose ${ELIZAOS_ACTION_NAME}.`);
+  }
+
+  const ready = await action.validate();
+
+  if (ready !== true) {
+    throw new Error("SVS production readiness check failed.");
+  }
+
+  return {
+    ok: true,
+    pluginName: plugin.name,
+    actionName: action.name
+  };
+}
+
+export async function submitSvsVerifiedElizaOsAction({
+  requestId,
+  intent,
+  serializedTransaction,
+  simulation,
+  metadata = {}
+}, env = process.env) {
+  const plugin = createSvsVerifiedElizaOsPlugin(env);
+  const action = plugin.actions.find((candidate) => candidate.name === ELIZAOS_ACTION_NAME);
+
+  if (!action) {
+    throw new Error(`SVS ElizaOS plugin did not expose ${ELIZAOS_ACTION_NAME}.`);
+  }
+
+  const runtime = {};
+  const state = { source: "svs-elizaos-example" };
+  const message = {
+    id: requestId,
+    roomId: "svs-elizaos-example-room",
+    userId: env.SVS_BOT_ID,
+    content: {
+      requestId,
+      intent,
+      serializedTransaction,
+      simulation,
+      metadata
+    }
+  };
+
+  return action.handler(runtime, message, state, {
+    requestId,
+    idempotencyKey: requestId,
+    intent,
+    serializedTransaction,
+    simulation,
+    metadata,
+    source: {
+      agentFramework: "elizaos",
+      adapter: ELIZAOS_ADAPTER_VERSION,
+      example: "svs-verified-action"
+    }
+  });
+}
+
+export function getSvsElizaOsExampleInfo() {
+  return {
+    ok: true,
+    runtime: "ElizaOS",
+    hostPackageImported: typeof ElizaCore === "object",
+    hostExportCount: Object.keys(ElizaCore).length,
+    adapterVersion: ELIZAOS_ADAPTER_VERSION,
+    pluginName: ELIZAOS_PLUGIN_NAME,
+    actionName: ELIZAOS_ACTION_NAME,
+    packageExport: "@svsprotocol/solana/elizaos",
+    liveSubmitOptIn: "SVS_RUN_LIVE_SUBMIT=true"
+  };
+}
+
+function assertRequiredEnv(env) {
+  const missing = REQUIRED_ENV.filter((name) => !env[name]);
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required SVS env values: ${missing.join(", ")}`);
+  }
+}
+
+function assertLiveSubmitEnv(env) {
+  const missing = LIVE_SUBMIT_REQUIRED_ENV.filter((name) => !env[name]);
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required SVS live-submit env values: ${missing.join(", ")}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const info = getSvsElizaOsExampleInfo();
+
+  if (process.env.SVS_RUN_LIVE_SUBMIT !== "true") {
+    console.log(JSON.stringify({
+      ...info,
+      status: "dry_run",
+      nextAction: "Set SVS_RUN_LIVE_SUBMIT=true only after filling real SVS credentials and a prepared transaction."
+    }, null, 2));
+    process.exit(0);
+  }
+
+  assertLiveSubmitEnv(process.env);
+
+  const result = await submitSvsVerifiedElizaOsAction({
+    requestId: `svs-elizaos-${Date.now()}`,
+    intent: {
+      botId: process.env.SVS_BOT_ID,
+      type: "memo",
+      summary: "Submit an ElizaOS Solana action through SVS human approval."
+    },
+    serializedTransaction: process.env.SVS_SERIALIZED_TRANSACTION_BASE64,
+    simulation: {
+      ok: true,
+      source: "provided-by-agent"
+    }
+  });
+
+  console.log(JSON.stringify(result, null, 2));
+}

--- a/packages/examples/svs-verified-action/validate.mjs
+++ b/packages/examples/svs-verified-action/validate.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const files = {
+  readme: await readFile(new URL("./README.md", import.meta.url), "utf8"),
+  packageJson: JSON.parse(await readFile(new URL("./package.json", import.meta.url), "utf8")),
+  envExample: await readFile(new URL("./.env.example", import.meta.url), "utf8"),
+  example: await readFile(new URL("./svs-verified-action.mjs", import.meta.url), "utf8")
+};
+
+assert.equal(files.packageJson.private, true);
+assert.equal(files.packageJson.type, "module");
+assert.equal(files.packageJson.dependencies["@svsprotocol/solana"], "^0.2.0");
+assert.equal(files.packageJson.dependencies["@elizaos/core"], "^1.7.2");
+assert.equal(files.packageJson.scripts.validate, "node ./validate.mjs");
+
+for (const required of [
+  "ElizaOS",
+  "packages/examples/svs-verified-action/",
+  "Protocol Or Wallet Gate",
+  "createHostedVerifiedAgentRegistryMiddleware",
+  "https://svsprotocol.com/docs",
+  "https://registry.svsprotocol.com/registry.json",
+  "https://svsprotocol.com/docs#verified-agent-standard",
+  "https://svsprotocol.com/verify",
+  "SVS_RUN_LIVE_SUBMIT=true",
+  "no API keys"
+]) {
+  assert.match(files.readme, new RegExp(escapeRegExp(required)));
+}
+
+assert.match(files.readme, /The default run is import validation only/);
+assert.doesNotMatch(files.readme, /import\/config validation only/);
+assert.doesNotMatch(files.readme, /private SVS operator repository/);
+assert.doesNotMatch(files.readme, /From the SVS repository/);
+
+for (const required of [
+  "SVS_SERVER_URL",
+  "SVS_BOT_ID",
+  "SVS_BOT_POLICY_ID",
+  "SVS_BOT_API_KEY",
+  "SVS_BOT_REQUEST_SIGNING_SECRET",
+  "SVS_BOT_EXPECTED_INTEGRATION_CONTRACT_HASH",
+  "SOLANA_RPC_URL",
+  "SVS_SERIALIZED_TRANSACTION_BASE64",
+  "SVS_RUN_LIVE_SUBMIT=false"
+]) {
+  assert.match(files.envExample, new RegExp(escapeRegExp(required)));
+}
+
+for (const required of [
+  "@elizaos/core",
+  "@svsprotocol/solana/elizaos",
+  "ELIZAOS_ADAPTER_VERSION",
+  "ELIZAOS_PLUGIN_NAME",
+  "ELIZAOS_ACTION_NAME",
+  "createSvsElizaOsPlugin",
+  "action.validate",
+  "action.handler",
+  "assertLiveSubmitEnv",
+  "SVS_SERIALIZED_TRANSACTION_BASE64",
+  "SVS_RUN_LIVE_SUBMIT"
+]) {
+  assert.match(files.example, new RegExp(escapeRegExp(required)));
+}
+
+for (const [name, text] of Object.entries({
+  readme: files.readme,
+  envExample: files.envExample,
+  example: files.example
+})) {
+  assertNoCommittedSecret(name, text);
+}
+
+console.log(JSON.stringify({
+  ok: true,
+  package: files.packageJson.name,
+  target: "elizaos",
+  packageExport: "@svsprotocol/solana/elizaos",
+  actionName: "SVS_VERIFY_AND_SUBMIT_SOLANA_ACTION"
+}, null, 2));
+
+function assertNoCommittedSecret(name, text) {
+  const secretPatterns = [
+    /svs_live_[A-Za-z0-9_-]{8,}/,
+    /svs_req_live_[A-Za-z0-9_-]{8,}/,
+    /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/,
+    /\[[\d,\s]{80,}\]/
+  ];
+
+  for (const pattern of secretPatterns) {
+    assert.doesNotMatch(text, pattern, `${name} includes secret-looking material`);
+  }
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary

Adds a small SVS verified-action example for ElizaOS under `packages/examples/svs-verified-action/`.

The example shows how an agent can route a prepared Solana action through SVS before the action is trusted. SVS checks signed bot identity, production readiness, human wallet approval, registry proof, and portable verification.

The example covers:
- installing `@svsprotocol/solana`
- creating one ElizaOS compatible SVS verification/submission tool
- checking SVS production readiness before submitting an action
- requiring a hosted SVS registry gate so protocols or wallets can reject unverified automation
- linking public SVS docs, registry, verifier, and Verified Agent Standard

## Files

- `.env.example` sha256=`5331106847e54a3aea71f4331b1794ba75bbe58dd77b45600774a1a0027a456d` bytes=566
- `README.md` sha256=`57d7a2e13eac410124a24548c524bdc062c9f2db6604659475e3f7aa49da66ac` bytes=2604
- `package.json` sha256=`f52d985c2eeaa3690e1df33b072b1207b1eab71f95af7c9b69f0b0668412e287` bytes=388
- `svs-verified-action.mjs` sha256=`d35b21931811ebc7917cf92d2428e4f4c1bd9f423a9513f2a4d5fe8e1e99bd70` bytes=4373
- `validate.mjs` sha256=`12ae1bac54fb3df5ed4a066c1af261e9543a2261c2de249afb150797b349b558` bytes=3094

## Public References

- Docs: https://svsprotocol.com/docs
- Registry: https://registry.svsprotocol.com/registry.json
- Verified Agent Standard: https://svsprotocol.com/docs#verified-agent-standard
- Verifier: https://svsprotocol.com/verify

## Validation

```sh
cd packages/examples/svs-verified-action
npm install
npm run validate
node ./svs-verified-action.mjs
```

The default run is import validation only. Live submission is opt-in with `SVS_RUN_LIVE_SUBMIT=true` and requires a prepared serialized transaction in `SVS_SERIALIZED_TRANSACTION_BASE64`.

## Safety Boundary

This example uses only public dependencies and placeholder environment values. It intentionally excludes API keys, request-signing secrets, wallet keypairs, local `data/` evidence, private dashboard source, admin endpoints, and private operator artifacts.
