### PR TITLE
fix(#13589): view-scoped agent action registration gated on the active view

### DIFF
--- a/packages/agent/src/runtime/active-view-state.ts
+++ b/packages/agent/src/runtime/active-view-state.ts
@@ -1,0 +1,75 @@
+/**
+ * Authoritative process-local record of the view the shell is currently
+ * showing, plus its live addressable-element snapshot. Written by the navigate
+ * route (`POST /api/views/:id/navigate`) and the element-report route, read by
+ * the prompt-optimization layer (`view-action-affinity.ts` awareness block) and
+ * the view-scoped-action gate (`view-scoped-actions.ts`).
+ *
+ * Extracted from `view-action-affinity.ts` so the scoped-action gate and the
+ * affinity/awareness renderer can both read this state without a cycle: this
+ * module depends on nothing, both consumers depend on it.
+ */
+
+/**
+ * One addressable element in the active view, as reported by the shell's
+ * agent-surface registry (`POST /api/views/:id/elements`). Mirrors the
+ * list-elements snapshot shape so the planner (and the scoped-action element
+ * resolver) can act on an element by id without a list-elements round-trip.
+ */
+export interface ActiveViewElement {
+  id: string;
+  role: string;
+  label: string;
+  value?: string;
+  focused?: boolean;
+}
+
+/** Minimal description of the view the shell is currently showing. */
+export interface ActiveViewContext {
+  viewId: string;
+  viewLabel: string;
+  viewType: "gui" | "tui" | "xr";
+  viewPath: string | null;
+  /**
+   * Live snapshot of the view's addressable elements, when the shell has
+   * reported one. Absent until a report arrives (and re-cleared on navigation),
+   * so the awareness block degrades gracefully to "use list-elements".
+   */
+  elements?: readonly ActiveViewElement[];
+  /**
+   * ISO timestamp of the most recent switch INTO this view, and who drove it.
+   * Carried from the navigate route so Stage-1 can acknowledge a just-happened
+   * switch (#8788). Absent when the view was not freshly switched.
+   */
+  switchedAt?: string;
+  source?: "agent" | "user";
+}
+
+let activeView: ActiveViewContext | null = null;
+
+export function setActiveViewContext(view: ActiveViewContext | null): void {
+  activeView = view;
+}
+
+export function getActiveViewContext(): ActiveViewContext | null {
+  return activeView;
+}
+
+export function clearActiveViewContext(): void {
+  activeView = null;
+}
+
+/**
+ * Update the element snapshot for the active view. Gated on `viewId` matching
+ * the current active view so a stale or background view's report (the shell may
+ * have several mounted surfaces) can never overwrite the foreground view's
+ * elements. Returns false when no view is active or the id differs.
+ */
+export function setActiveViewElements(
+  viewId: string,
+  elements: readonly ActiveViewElement[],
+): boolean {
+  if (!activeView || activeView.viewId !== viewId) return false;
+  activeView = { ...activeView, elements };
+  return true;
+}

--- a/packages/agent/src/runtime/view-action-affinity.ts
+++ b/packages/agent/src/runtime/view-action-affinity.ts
@@ -15,46 +15,33 @@
  * active-view awareness block injected into planner prompts.
  */
 import { getView, listViews } from "../api/views-registry.ts";
+import type {
+  ActiveViewContext,
+  ActiveViewElement,
+} from "./active-view-state.ts";
+import {
+  clearActiveViewContext,
+  getActiveViewContext,
+  setActiveViewContext,
+  setActiveViewElements,
+} from "./active-view-state.ts";
+import { viewScopedActionRegistryNames } from "./view-scoped-actions.ts";
+
+// The active-view state (get/set/clear/elements) and its types live in
+// active-view-state.ts so the scoped-action gate can read them without a cycle;
+// re-exported here for the existing import surface (views-routes, tests).
+export type { ActiveViewContext, ActiveViewElement };
+export {
+  clearActiveViewContext,
+  getActiveViewContext,
+  setActiveViewContext,
+  setActiveViewElements,
+};
 
 const VIEW_TYPES = ["gui", "xr", "tui"] as const;
 
-/**
- * One addressable element in the active view, as reported by the shell's
- * agent-surface registry (POST /api/views/:id/elements). Mirrors the
- * list-elements snapshot shape so the planner can act on an element by id
- * (agent-click / agent-fill / agent-focus) without a list-elements round-trip.
- */
-export interface ActiveViewElement {
-  id: string;
-  role: string;
-  label: string;
-  value?: string;
-  focused?: boolean;
-}
-
 /** Cap on elements rendered into the awareness block to bound prompt growth. */
 export const ACTIVE_VIEW_ELEMENT_RENDER_CAP = 40;
-
-/** Minimal description of the view the shell is currently showing. */
-export interface ActiveViewContext {
-  viewId: string;
-  viewLabel: string;
-  viewType: "gui" | "tui" | "xr";
-  viewPath: string | null;
-  /**
-   * Live snapshot of the view's addressable elements, when the shell has
-   * reported one. Absent until a report arrives (and re-cleared on navigation),
-   * so the awareness block degrades gracefully to "use list-elements".
-   */
-  elements?: readonly ActiveViewElement[];
-  /**
-   * ISO timestamp of the most recent switch INTO this view, and who drove it.
-   * Carried from the navigate route so Stage-1 can acknowledge a just-happened
-   * switch (#8788). Absent when the view was not freshly switched.
-   */
-  switchedAt?: string;
-  source?: "agent" | "user";
-}
 
 /**
  * A view switch is "fresh" (worth acknowledging on the immediately-following
@@ -68,35 +55,6 @@ function isActiveViewSwitchFresh(view: ActiveViewContext): boolean {
   const at = Date.parse(view.switchedAt);
   if (Number.isNaN(at)) return false;
   return Date.now() - at <= ACTIVE_VIEW_SWITCH_FRESH_MS;
-}
-
-let activeView: ActiveViewContext | null = null;
-
-export function setActiveViewContext(view: ActiveViewContext | null): void {
-  activeView = view;
-}
-
-export function getActiveViewContext(): ActiveViewContext | null {
-  return activeView;
-}
-
-export function clearActiveViewContext(): void {
-  activeView = null;
-}
-
-/**
- * Update the element snapshot for the active view. Gated on `viewId` matching
- * the current active view so a stale or background view's report (the shell may
- * have several mounted surfaces) can never overwrite the foreground view's
- * elements. Returns false when no view is active or the id differs.
- */
-export function setActiveViewElements(
-  viewId: string,
-  elements: readonly ActiveViewElement[],
-): boolean {
-  if (!activeView || activeView.viewId !== viewId) return false;
-  activeView = { ...activeView, elements };
-  return true;
 }
 
 /**
@@ -149,16 +107,24 @@ function getViewRelatedActions(viewId: string): string[] {
 
 /**
  * Resolve the set of action names to keep at full param detail for the active
- * view. Returns an empty set when no view is active or the view has no mapped
- * actions (control still works through agent-surface capabilities).
+ * view: the view's declared/host affinity actions (global actions worth
+ * upweighting) unioned with any actions registered as *scoped* to this view via
+ * {@link defineViewScopedAction}, which are only available while the view is
+ * active. Returns an empty set when no view is active or nothing applies
+ * (control still works through agent-surface capabilities).
  */
 export function viewScopedActionNames(
   viewId: string | null | undefined,
 ): Set<string> {
   if (!viewId) return new Set();
+  const names = new Set<string>(viewScopedActionRegistryNames(viewId));
   const declared = getViewRelatedActions(viewId);
-  if (declared.length > 0) return new Set(declared);
-  return new Set(HOST_VIEW_ACTION_AFFINITY[viewId] ?? []);
+  if (declared.length > 0) {
+    for (const a of declared) names.add(a);
+    return names;
+  }
+  for (const a of HOST_VIEW_ACTION_AFFINITY[viewId] ?? []) names.add(a);
+  return names;
 }
 
 /**

--- a/packages/agent/src/runtime/view-scoped-actions.test.ts
+++ b/packages/agent/src/runtime/view-scoped-actions.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Covers view-scoped agent actions: a scoped action's `validate()` is gated on
+ * the active view (flips without restart when the view changes), scoped names
+ * flow into the planner full-detail set via `viewScopedActionNames`, and the
+ * element-sequence resolver throws a typed error (never a silent no-op) when the
+ * view is inactive or a target element id is missing. Deterministic — drives the
+ * real gate/registry/resolver against the live active-view state; no model.
+ */
+import { ElizaError } from "@elizaos/core";
+import type { Action, IAgentRuntime, Memory, State } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearActiveViewContext,
+  setActiveViewContext,
+} from "./active-view-state.ts";
+import { buildFullParamActionSet } from "./prompt-compaction.ts";
+import { viewScopedActionNames } from "./view-action-affinity.ts";
+import {
+  activeViewScopedActionNames,
+  clearViewScopedActions,
+  defineViewScopedAction,
+  gateValidatorToActiveView,
+  isViewActive,
+  resolveScopedElementOps,
+  type ScopedActionElementOp,
+  VIEW_SCOPED_ACTION_TAG,
+  viewScopedActionRegistryNames,
+} from "./view-scoped-actions.ts";
+
+const runtime = {} as IAgentRuntime;
+const message = {} as Memory;
+const state = {} as State;
+
+function activate(viewId: string, elements?: { id: string }[]): void {
+  setActiveViewContext({
+    viewId,
+    viewLabel: viewId,
+    viewType: "gui",
+    viewPath: `/${viewId}`,
+    elements: elements?.map((e) => ({ id: e.id, role: "input", label: e.id })),
+  });
+}
+
+const baseAction: Action = {
+  name: "SET_PROVIDER",
+  description: "Set the inference provider in the settings view.",
+  handler: async () => undefined,
+  validate: async () => true,
+};
+
+beforeEach(() => {
+  clearViewScopedActions();
+  clearActiveViewContext();
+});
+
+afterEach(() => {
+  clearViewScopedActions();
+  clearActiveViewContext();
+});
+
+describe("gateValidatorToActiveView", () => {
+  it("returns false when the view is not the active view", async () => {
+    const validate = gateValidatorToActiveView("settings");
+    activate("wallet");
+    expect(await validate(runtime, message, state)).toBe(false);
+  });
+
+  it("returns true when the view is active and there is no inner validator", async () => {
+    const validate = gateValidatorToActiveView("settings");
+    activate("settings");
+    expect(await validate(runtime, message, state)).toBe(true);
+  });
+
+  it("delegates to the inner validator only while the view is active", async () => {
+    let innerCalls = 0;
+    const validate = gateValidatorToActiveView("settings", async () => {
+      innerCalls += 1;
+      return false;
+    });
+    activate("wallet");
+    expect(await validate(runtime, message, state)).toBe(false);
+    expect(innerCalls).toBe(0); // inner is not consulted when view is inactive
+
+    activate("settings");
+    expect(await validate(runtime, message, state)).toBe(false);
+    expect(innerCalls).toBe(1); // inner decides only once the view is active
+  });
+});
+
+describe("defineViewScopedAction", () => {
+  it("gates validate() on the active view and flips on view switch without restart", async () => {
+    const action = defineViewScopedAction("settings", baseAction);
+
+    activate("wallet");
+    expect(await action.validate(runtime, message, state)).toBe(false);
+
+    activate("settings");
+    expect(await action.validate(runtime, message, state)).toBe(true);
+
+    activate("wallet");
+    expect(await action.validate(runtime, message, state)).toBe(false);
+  });
+
+  it("does not mutate the input action and tags the scoped result", () => {
+    const action = defineViewScopedAction("settings", baseAction);
+    expect(baseAction.tags).toBeUndefined();
+    expect(action.tags).toContain(VIEW_SCOPED_ACTION_TAG);
+    expect(action.tags).toContain("view:settings");
+    expect(action.name).toBe("SET_PROVIDER");
+  });
+
+  it("records the scoped name only for its own view", () => {
+    defineViewScopedAction("settings", baseAction);
+    defineViewScopedAction("wallet", { ...baseAction, name: "SWAP_TOKENS" });
+
+    expect(viewScopedActionRegistryNames("settings")).toEqual(["SET_PROVIDER"]);
+    expect(viewScopedActionRegistryNames("wallet")).toEqual(["SWAP_TOKENS"]);
+    expect(viewScopedActionRegistryNames("browser")).toEqual([]);
+  });
+});
+
+describe("active view scoped-name reporting", () => {
+  it("activeViewScopedActionNames tracks the active view", () => {
+    defineViewScopedAction("settings", baseAction);
+    expect(activeViewScopedActionNames()).toEqual([]);
+    activate("settings");
+    expect(activeViewScopedActionNames()).toEqual(["SET_PROVIDER"]);
+    activate("wallet");
+    expect(activeViewScopedActionNames()).toEqual([]);
+  });
+
+  it("scoped names flow into viewScopedActionNames and the planner full-detail set", () => {
+    defineViewScopedAction("settings", baseAction);
+    const scoped = viewScopedActionNames("settings");
+    expect(scoped.has("SET_PROVIDER")).toBe(true);
+
+    // The planner keeps caller-supplied (active-view) actions at full param
+    // detail regardless of detected intent.
+    const full = buildFullParamActionSet([], viewScopedActionNames("settings"));
+    expect(full.has("SET_PROVIDER")).toBe(true);
+    // A view without scoped actions contributes nothing.
+    expect(buildFullParamActionSet([], viewScopedActionNames("browser")).has(
+      "SET_PROVIDER",
+    )).toBe(false);
+  });
+});
+
+describe("isViewActive", () => {
+  it("reflects the active view", () => {
+    expect(isViewActive("settings")).toBe(false);
+    activate("settings");
+    expect(isViewActive("settings")).toBe(true);
+    expect(isViewActive("wallet")).toBe(false);
+  });
+});
+
+describe("resolveScopedElementOps", () => {
+  const ops: ScopedActionElementOp[] = [
+    { op: "agent-fill", elementId: "provider-select", value: "anthropic" },
+    { op: "agent-click", elementId: "save-provider" },
+  ];
+
+  it("returns the ops unchanged when the view is active and all ids exist", () => {
+    activate("settings", [{ id: "provider-select" }, { id: "save-provider" }]);
+    expect(resolveScopedElementOps("settings", ops)).toBe(ops);
+  });
+
+  it("throws a typed error when the declaring view is not active", () => {
+    activate("wallet", [{ id: "provider-select" }, { id: "save-provider" }]);
+    try {
+      resolveScopedElementOps("settings", ops);
+      throw new Error("expected resolveScopedElementOps to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ElizaError);
+      expect((err as ElizaError).code).toBe("VIEW_SCOPED_ACTION_VIEW_INACTIVE");
+    }
+  });
+
+  it("throws a typed error (no silent no-op) when a target element id is missing", () => {
+    activate("settings", [{ id: "provider-select" }]); // save-provider absent
+    try {
+      resolveScopedElementOps("settings", ops);
+      throw new Error("expected resolveScopedElementOps to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ElizaError);
+      const e = err as ElizaError;
+      expect(e.code).toBe("VIEW_SCOPED_ACTION_ELEMENT_MISSING");
+      expect(e.context?.missing).toEqual(["save-provider"]);
+    }
+  });
+
+  it("throws when no view is active at all", () => {
+    expect(() => resolveScopedElementOps("settings", ops)).toThrow(ElizaError);
+  });
+});

--- a/packages/agent/src/runtime/view-scoped-actions.ts
+++ b/packages/agent/src/runtime/view-scoped-actions.ts
@@ -1,0 +1,149 @@
+/**
+ * View-scoped agent actions: named domain actions a view registers that are
+ * only selectable/executable while that view is the foreground surface.
+ *
+ * Where `view-action-affinity.ts` only *upweights* genuinely-global actions
+ * while their view is foreground, this gates availability: a scoped action's
+ * `validate()` returns false unless the declaring view is the active view (read
+ * from the same authoritative `active-view-state` the affinity map uses), so
+ * switching views flips it on/off with no restart. Plugin views register their
+ * scoped actions through their plugin's `actions`, built-in shell views through
+ * `builtin-views.ts`; both wrap the action with {@link defineViewScopedAction}.
+ *
+ * Handlers resolve a named action (e.g. `set-provider`) to a deterministic
+ * sequence of agent-surface element operations (`agent-fill` / `agent-click` /
+ * `agent-focus`) against the same `useAgentElement` ids the interact protocol
+ * drives — {@link resolveScopedElementOps} validates every target id against the
+ * active view's reported element snapshot and throws (never silently no-ops)
+ * when one is missing, so there is no parallel DOM-driving path.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import type { Action, Validator } from "@elizaos/core";
+import {
+  type ActiveViewElement,
+  getActiveViewContext,
+} from "./active-view-state.ts";
+
+/** True when `viewId` is the view the shell is currently showing. */
+export function isViewActive(viewId: string): boolean {
+  return getActiveViewContext()?.viewId === viewId;
+}
+
+/**
+ * Wrap a validator so it only passes while `viewId` is the active view. When
+ * the view is active the inner validator (if any) decides; when it is not, the
+ * action is unavailable regardless of what the inner validator would return.
+ * A scoped action with no domain precondition passes `undefined` and is gated
+ * purely on the active view.
+ */
+export function gateValidatorToActiveView(
+  viewId: string,
+  inner?: Validator,
+): Validator {
+  return async (runtime, message, state, options) => {
+    if (!isViewActive(viewId)) return false;
+    if (!inner) return true;
+    return inner(runtime, message, state, options);
+  };
+}
+
+// viewId -> ordered set of scoped action names registered against it. Drives
+// the planner full-detail set and the awareness-block listing while the view is
+// active; kept separate from the executable Action so the affinity renderer can
+// read names without importing the actions themselves.
+const scopedActionNamesByView = new Map<string, Set<string>>();
+
+/**
+ * Gate an action to a view and record the association so the planner keeps it
+ * at full parameter detail (and lists it in the active-view awareness block)
+ * while the view is foreground. Returns a new `Action`; the input is not
+ * mutated. Register the returned action normally (plugin `actions` / built-in
+ * shell registration) — the runtime treats it like any other action, and the
+ * gated `validate()` makes it available only on its view.
+ */
+export function defineViewScopedAction(viewId: string, action: Action): Action {
+  const names = scopedActionNamesByView.get(viewId) ?? new Set<string>();
+  names.add(action.name);
+  scopedActionNamesByView.set(viewId, names);
+  const tags = new Set(action.tags ?? []);
+  tags.add(VIEW_SCOPED_ACTION_TAG);
+  tags.add(`view:${viewId}`);
+  return {
+    ...action,
+    validate: gateValidatorToActiveView(viewId, action.validate),
+    tags: [...tags],
+  };
+}
+
+/** Tag stamped on every action produced by {@link defineViewScopedAction}. */
+export const VIEW_SCOPED_ACTION_TAG = "view-scoped" as const;
+
+/** Scoped action names registered against `viewId` (empty when none). */
+export function viewScopedActionRegistryNames(
+  viewId: string | null | undefined,
+): string[] {
+  if (!viewId) return [];
+  const names = scopedActionNamesByView.get(viewId);
+  return names ? [...names] : [];
+}
+
+/** Scoped action names whose view is currently the active view. */
+export function activeViewScopedActionNames(): string[] {
+  return viewScopedActionRegistryNames(getActiveViewContext()?.viewId);
+}
+
+/** Drop all scoped-action registrations. Test-only reset. */
+export function clearViewScopedActions(): void {
+  scopedActionNamesByView.clear();
+}
+
+/**
+ * One deterministic element operation a scoped-action handler resolves to,
+ * addressing a `useAgentElement` id the interact protocol can drive.
+ */
+export type ScopedActionElementOp =
+  | { readonly op: "agent-fill"; readonly elementId: string; readonly value: string }
+  | { readonly op: "agent-click"; readonly elementId: string }
+  | { readonly op: "agent-focus"; readonly elementId: string }
+  | { readonly op: "agent-scroll-to"; readonly elementId: string };
+
+/**
+ * Validate a scoped action's element sequence against the active view's live
+ * element snapshot before dispatch. Fails loudly with a typed {@link ElizaError}
+ * — never a silent no-op — when the declaring view is not active or a target
+ * `useAgentElement` id is absent, so a renamed/removed control surfaces to the
+ * agent instead of a fabricated success. Returns the ops unchanged on success
+ * so callers can dispatch them through the interact bridge.
+ */
+export function resolveScopedElementOps(
+  viewId: string,
+  ops: readonly ScopedActionElementOp[],
+): readonly ScopedActionElementOp[] {
+  const active = getActiveViewContext();
+  if (!active || active.viewId !== viewId) {
+    throw new ElizaError(
+      `Cannot resolve scoped element ops for view "${viewId}": it is not the active view`,
+      {
+        code: "VIEW_SCOPED_ACTION_VIEW_INACTIVE",
+        context: { viewId, activeViewId: active?.viewId ?? null },
+      },
+    );
+  }
+  const known = new Set<string>(
+    (active.elements ?? []).map((el: ActiveViewElement) => el.id),
+  );
+  const missing = ops
+    .map((o) => o.elementId)
+    .filter((id) => !known.has(id));
+  if (missing.length > 0) {
+    throw new ElizaError(
+      `Scoped action targets element id(s) not present in view "${viewId}": ${missing.join(", ")}`,
+      {
+        code: "VIEW_SCOPED_ACTION_ELEMENT_MISSING",
+        context: { viewId, missing, known: [...known] },
+      },
+    );
+  }
+  return ops;
+}


### PR DESCRIPTION
Closes #13589.

## What

Ships the **core mechanism** for view-scoped agent actions (redesign spec items 1, 3, 4): named actions a view registers that are only available/selectable while that view is the foreground surface. Larger per-view typed action sets and the client element-dispatch bridge are noted as follow-ups rather than half-done.

### Mechanism (`packages/agent/src/runtime/view-scoped-actions.ts`)
- `gateValidatorToActiveView(viewId, inner?)` — wraps a validator so it only passes while `viewId` is the active view, reading the same authoritative active-view state the affinity map uses. Switching views flips availability with **no restart**.
- `defineViewScopedAction(viewId, action)` — returns a new `Action` with the gated `validate()` and records the scoped name in the registry. Register it normally (plugin `actions` / builtin shell); the runtime treats it like any other action.
- `resolveScopedElementOps(viewId, ops)` — resolves a named action to a deterministic `agent-fill`/`agent-click`/`agent-focus` element sequence, validating every target `useAgentElement` id against the active view's live snapshot. Throws a typed `ElizaError` (`VIEW_SCOPED_ACTION_VIEW_INACTIVE` / `VIEW_SCOPED_ACTION_ELEMENT_MISSING`) — **never a silent no-op** — so a renamed/removed control surfaces to the agent (fail-fast doctrine).

### Wiring
- Extracted the active-view context state + types into `active-view-state.ts` so the scoped-action gate and the affinity/awareness renderer both read it **without a dependency cycle**; `view-action-affinity.ts` re-exports them for the existing import surface (views-routes, tests) — zero churn for callers.
- `viewScopedActionNames` now unions registered scoped names, so scoped actions flow into the planner full-detail action set and the active-view awareness block while their view is foreground. Global affinity weighting for `relatedActions` is unchanged (regression-covered).

## Follow-ups (deferred, not half-done)
- Per-view typed action sets: settings (`set-provider`/`set-model`/…), wallet (`swap-tokens`/…), character (`FILL_BIO`/…), browser, knowledge.
- `builtin-views.ts` registration for built-in shell views.
- Client bridge dispatching resolved element ops through `view-interact`.
- Proactive-greeting ↔ scoped-registry consistency assertion.

## Test evidence
`packages/agent/src/runtime/view-scoped-actions.test.ts` — 13 tests, all green, driving the **real** gate/registry/resolver against the live active-view state (no model, deterministic):
- `validate()` returns false when the view is not active, true when it is, and **flips on view switch without restart**.
- inner validator is consulted only once the view is active.
- scoped names flow into `viewScopedActionNames` and `buildFullParamActionSet` (the planner full-detail set); a view without scoped actions contributes nothing.
- element resolver throws typed `ElizaError` when the view is inactive, when no view is active, and when a target element id is missing (asserting `code` + `context.missing`).

```
Test Files  1 passed (1)
     Tests  13 passed (13)
```

Neighbor `views-routes.navigate-broadcast.test.ts` (exercises the re-exported `setActiveViewContext`) stays green (17/17). Package typecheck reports no errors citing the touched files.

Note: the pre-existing `view-action-affinity.test.ts` source-drift guard fails only in this worktree because optional plugins `plugin-hyperliquid`/`plugin-polymarket` are not checked out (their `PERPETUAL_MARKET`/`POLYMARKET_STATUS` action sources are absent) — unrelated to this change.

| Evidence | |
| --- | --- |
| Real-LLM trajectory | N/A - core registration/gating mechanism, no model/prompt behavior exercised end-to-end yet (deferred to the per-view children that add real actions) |
| Screenshots/video | N/A - no UI surface in this change (client bridge is a follow-up) |
| Unit tests | 13/13 green, drive real code paths, fail without the change |

🤖 Generated with [Claude Code](https://claude.com/claude-code)