### PR TITLE
test(orchestrator): real-engine admission-queue e2e — 10 tasks vs session cap (#13778)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-admission-queue.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-admission-queue.test.ts
@@ -1,12 +1,12 @@
 /**
  * Real-engine admission-queue e2e (issue #13778 item 1).
  *
- * Drives N tasks through the REAL orchestrator → REAL AcpService admission
- * queue (added in #13772), not a fake ACP: `spawnAgentForTask` →
- * `runtime.getService(AcpService)` → `acp.spawnSession` → `reserveSessionSlot`
- * → `awaitSessionSlot`. Only the subprocess leaf (`NativeAcpClient`) is stubbed
- * (native transport), so every spawn deterministically reaches "ready" without
- * a live acp binary while the queue logic runs 100% real.
+ * Drives N tasks through the REAL orchestrator admission queue and REAL
+ * AcpService worker cap, not a fake ACP: `spawnAgentForTask` →
+ * `runtime.getService(AcpService)` → `acp.spawnSession` → `reserveSessionSlot`.
+ * Only the subprocess leaf (`NativeAcpClient`) is stubbed (native transport), so
+ * every admitted spawn deterministically reaches "ready" without a live acp
+ * binary while the queue logic runs 100% real.
  *
  * Asserts the WS2 admission-control decision: N > maxSessions spawns QUEUE
  * (they don't reject and no task is dropped), the cap is never overshot, and
@@ -17,10 +17,16 @@
  *  - the terminal `failed` producer (native mock resolves "ready"),
  *  - zero-leaked-workspace GC assertion (acp-scratch-gc.test.ts).
  */
-import type { AcpJsonRpcMessage, ApprovalPreset } from "../../src/services/types.js";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type {
+  AcpJsonRpcMessage,
+  ApprovalPreset,
+} from "../../src/services/types.js";
 
-type NativeEventHandler = (event: AcpJsonRpcMessage, sessionId?: string) => void;
+type NativeEventHandler = (
+  event: AcpJsonRpcMessage,
+  sessionId?: string,
+) => void;
 type NativeOptions = {
   command: string;
   cwd: string;
@@ -62,7 +68,9 @@ function getNativeMockState(): NativeMockState {
 // Stub only the subprocess leaf so each spawn deterministically reaches "ready".
 vi.mock("../../src/services/acp-native-transport.js", () => {
   const state = getNativeMockState();
-  state.NativeAcpClient = class MockNativeAcpClient implements MockNativeClient {
+  state.NativeAcpClient = class MockNativeAcpClient
+    implements MockNativeClient
+  {
     opts: NativeOptions;
     eventHandler?: NativeEventHandler;
     start = vi.fn(async () => {
@@ -199,53 +207,49 @@ describe("orchestrator admission queue — N tasks vs maxSessions (#13778)", () 
     const tasks = [];
     for (let i = 0; i < N; i++) {
       tasks.push(
-        await service.createTask({ title: `t-${i}`, goal: "Implement and verify" }),
+        await service.createTask({
+          title: `t-${i}`,
+          goal: "Implement and verify",
+        }),
       );
     }
 
-    // Fire all N spawns concurrently through the real orchestrator; they hit the
-    // reservation mutex near-simultaneously.
-    const settled: number[] = [];
-    const spawns = tasks.map((t, i) =>
-      service.spawnAgentForTask(t.id).then((r) => {
-        settled.push(i);
-        return r;
-      }),
+    // Fire all N spawns concurrently through the real orchestrator. The first
+    // CAP admit; the rest return queued task DTOs (not rejects, not drops).
+    const details = await Promise.all(
+      tasks.map((t) => service.spawnAgentForTask(t.id)),
+    );
+    expect(details.filter((detail) => detail?.admission).length).toBe(N - CAP);
+    expect(details.filter((detail) => detail && !detail.admission).length).toBe(
+      CAP,
     );
 
-    // Only CAP admit; the other N-CAP QUEUE (not reject, not dropped).
-    await poll(
-      async () =>
-        (await activeSessions()).length === CAP &&
-        acp.getAdmissionState().queuedSpawns === N - CAP,
-    );
+    await poll(async () => (await activeSessions()).length === CAP);
     expect((await activeSessions()).length).toBe(CAP);
-    expect(acp.getAdmissionState()).toEqual({
-      maxSessions: CAP,
-      queuedSpawns: N - CAP,
+    expect(await service.getAdmissionSnapshot()).toMatchObject({
+      queueDepth: N - CAP,
     });
-    expect(settled).toHaveLength(CAP);
 
     // Free slots one at a time; each freed slot admits exactly one queued spawn
     // and the cap is never overshot.
     for (let expectedQueued = N - CAP; expectedQueued > 0; expectedQueued--) {
       const active = await activeSessions();
       expect(active.length).toBeLessThanOrEqual(CAP);
-      await acp.cancelSession(active[0].id);
+      await acp.stopSession(active[0].id);
       await poll(
-        () => acp.getAdmissionState().queuedSpawns === expectedQueued - 1,
+        async () =>
+          (await service.getAdmissionSnapshot()).queueDepth ===
+          expectedQueued - 1,
       );
       expect((await activeSessions()).length).toBeLessThanOrEqual(CAP);
     }
 
-    // All N tasks eventually admit — nothing dropped, nothing rejected. (Assert
-    // the admitted SET; arrival order at the reservation mutex is not the task
-    // creation index.)
-    await Promise.all(spawns);
-    expect([...settled].sort((a, b) => a - b)).toEqual(
-      Array.from({ length: N }, (_, i) => i),
-    );
-    expect(acp.getAdmissionState().queuedSpawns).toBe(0);
+    // All N tasks eventually admitted exactly one session — nothing dropped,
+    // nothing rejected, and the worker cap was never overshot.
+    expect(await service.getAdmissionSnapshot()).toMatchObject({
+      queueDepth: 0,
+    });
+    expect(await acp.listSessions()).toHaveLength(N);
 
     await service.stop();
     await acp.stop();

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-admission-queue.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-admission-queue.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Real-engine admission-queue e2e (issue #13778 item 1).
+ *
+ * Drives N tasks through the REAL orchestrator → REAL AcpService admission
+ * queue (added in #13772), not a fake ACP: `spawnAgentForTask` →
+ * `runtime.getService(AcpService)` → `acp.spawnSession` → `reserveSessionSlot`
+ * → `awaitSessionSlot`. Only the subprocess leaf (`NativeAcpClient`) is stubbed
+ * (native transport), so every spawn deterministically reaches "ready" without
+ * a live acp binary while the queue logic runs 100% real.
+ *
+ * Asserts the WS2 admission-control decision: N > maxSessions spawns QUEUE
+ * (they don't reject and no task is dropped), the cap is never overshot, and
+ * freeing a slot admits the next queued spawn — until all N are admitted.
+ *
+ * Deliberately OUT OF SCOPE here (each has/needs its own suite, per #13778):
+ *  - stall-watchdog firing on a wedged session (task-watchdog.test.ts),
+ *  - the terminal `failed` producer (native mock resolves "ready"),
+ *  - zero-leaked-workspace GC assertion (acp-scratch-gc.test.ts).
+ */
+import type { AcpJsonRpcMessage, ApprovalPreset } from "../../src/services/types.js";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+type NativeEventHandler = (event: AcpJsonRpcMessage, sessionId?: string) => void;
+type NativeOptions = {
+  command: string;
+  cwd: string;
+  approvalPreset: ApprovalPreset;
+  timeoutMs?: number;
+  terminal?: boolean;
+  env?: NodeJS.ProcessEnv;
+  onEvent?: NativeEventHandler;
+  onStderr?: (chunk: string) => void;
+};
+type MockNativeClient = {
+  opts: NativeOptions;
+  eventHandler?: NativeEventHandler;
+  start: ReturnType<typeof vi.fn>;
+  createSession: ReturnType<typeof vi.fn>;
+  prompt: ReturnType<typeof vi.fn>;
+  cancel: ReturnType<typeof vi.fn>;
+  closeSession: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  approvesPermissionRequest: ReturnType<typeof vi.fn>;
+  setEventHandler: (handler: NativeEventHandler | undefined) => void;
+  setTimeoutMs: (timeoutMs: number | undefined) => void;
+  emit: (event: AcpJsonRpcMessage, sessionId?: string) => void;
+};
+type NativeMockState = {
+  NativeAcpClient?: new (opts: NativeOptions) => MockNativeClient;
+  instances: MockNativeClient[];
+  startImplementation?: (client: MockNativeClient) => Promise<void>;
+};
+
+function getNativeMockState(): NativeMockState {
+  const g = globalThis as typeof globalThis & {
+    __acpAdmissionQueueNativeMock?: NativeMockState;
+  };
+  g.__acpAdmissionQueueNativeMock ??= { instances: [] };
+  return g.__acpAdmissionQueueNativeMock;
+}
+
+// Stub only the subprocess leaf so each spawn deterministically reaches "ready".
+vi.mock("../../src/services/acp-native-transport.js", () => {
+  const state = getNativeMockState();
+  state.NativeAcpClient = class MockNativeAcpClient implements MockNativeClient {
+    opts: NativeOptions;
+    eventHandler?: NativeEventHandler;
+    start = vi.fn(async () => {
+      await getNativeMockState().startImplementation?.(this);
+    });
+    createSession = vi.fn(async () => ({
+      sessionId: "protocol-session",
+      agentSessionId: "agent-session",
+    }));
+    prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+    cancel = vi.fn(async () => undefined);
+    closeSession = vi.fn(async () => undefined);
+    close = vi.fn(async () => undefined);
+    approvesPermissionRequest = vi.fn((_params: unknown) => true);
+    constructor(opts: NativeOptions) {
+      this.opts = opts;
+      this.eventHandler = opts.onEvent;
+      getNativeMockState().instances.push(this);
+    }
+    setEventHandler(handler: NativeEventHandler | undefined) {
+      this.eventHandler = handler;
+      this.opts.onEvent = handler;
+    }
+    setTimeoutMs(timeoutMs: number | undefined) {
+      this.opts.timeoutMs = timeoutMs;
+    }
+    emit(event: AcpJsonRpcMessage, sessionId?: string) {
+      this.eventHandler?.(event, sessionId);
+    }
+  };
+  return { NativeAcpClient: state.NativeAcpClient };
+});
+
+// git is unavailable in the test; make workspace-diff's promisified execFile
+// degrade instead of hanging every spawn.
+vi.mock("node:child_process", () => ({
+  exec: vi.fn(),
+  execFile: vi.fn(
+    (
+      _file: string,
+      _args: string[],
+      _opts: unknown,
+      cb?: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      const callback = typeof _opts === "function" ? _opts : cb;
+      if (typeof callback === "function")
+        callback(new Error("git unavailable in test"), "", "");
+    },
+  ),
+  execFileSync: vi.fn(),
+  spawnSync: vi.fn(() => ({ status: 1, stdout: "", stderr: "" })),
+  spawn: vi.fn(),
+}));
+
+import { AcpService } from "../../src/services/acp-service.js";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
+
+// createTask auto-populates acceptance criteria for criteria-free goals; disable
+// so tasks stay on the fast path and don't pull in the goal-contract machinery.
+const PREV_GOAL_CONTRACT = process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+beforeAll(() => {
+  process.env.ELIZA_REQUIRE_GOAL_CONTRACT = "0";
+});
+afterAll(() => {
+  if (PREV_GOAL_CONTRACT === undefined)
+    delete process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+  else process.env.ELIZA_REQUIRE_GOAL_CONTRACT = PREV_GOAL_CONTRACT;
+});
+
+// Runtime for the AcpService itself (native transport, small cap, fast poll).
+function acpRuntime(settings: Record<string, string | undefined> = {}) {
+  const values: Record<string, string | undefined> = {
+    ELIZA_ACP_TRANSPORT: undefined, // native
+    ...settings,
+  };
+  return {
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getSetting: vi.fn((key: string) => values[key]),
+    services: new Map<string, unknown[]>(),
+  } as never;
+}
+
+// Runtime the orchestrator sees: getService returns the REAL AcpService so
+// spawnAgentForTask drives the real admission queue.
+function orchestratorRuntime(acp: AcpService) {
+  return {
+    getService: (type: string) =>
+      type === AcpService.serviceType ? acp : null,
+    getSetting: () => undefined,
+    character: { name: "Test" },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as never;
+}
+
+const isActive = (s: { status: string }) =>
+  !["stopped", "errored", "completed", "cancelled"].includes(s.status);
+
+async function poll(
+  cond: () => Promise<boolean> | boolean,
+  ms = 4000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < ms) {
+    if (await cond()) return;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error("poll timed out waiting for admission-queue condition");
+}
+
+describe("orchestrator admission queue — N tasks vs maxSessions (#13778)", () => {
+  it("queues tasks beyond the session cap through the real orchestrator and admits them as slots free", async () => {
+    const CAP = 5;
+    const N = 10;
+
+    const acp = new AcpService(
+      acpRuntime({
+        ELIZA_ACP_MAX_SESSIONS: String(CAP),
+        ELIZA_ACP_ADMISSION_POLL_MS: "5",
+      }),
+    );
+    await acp.start();
+
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(orchestratorRuntime(acp), {
+      store,
+    });
+    await service.start();
+
+    const activeSessions = async () =>
+      (await acp.listSessions()).filter(isActive);
+
+    // Create N distinct tasks (distinct avoids sibling-name-pool contention).
+    const tasks = [];
+    for (let i = 0; i < N; i++) {
+      tasks.push(
+        await service.createTask({ title: `t-${i}`, goal: "Implement and verify" }),
+      );
+    }
+
+    // Fire all N spawns concurrently through the real orchestrator; they hit the
+    // reservation mutex near-simultaneously.
+    const settled: number[] = [];
+    const spawns = tasks.map((t, i) =>
+      service.spawnAgentForTask(t.id).then((r) => {
+        settled.push(i);
+        return r;
+      }),
+    );
+
+    // Only CAP admit; the other N-CAP QUEUE (not reject, not dropped).
+    await poll(
+      async () =>
+        (await activeSessions()).length === CAP &&
+        acp.getAdmissionState().queuedSpawns === N - CAP,
+    );
+    expect((await activeSessions()).length).toBe(CAP);
+    expect(acp.getAdmissionState()).toEqual({
+      maxSessions: CAP,
+      queuedSpawns: N - CAP,
+    });
+    expect(settled).toHaveLength(CAP);
+
+    // Free slots one at a time; each freed slot admits exactly one queued spawn
+    // and the cap is never overshot.
+    for (let expectedQueued = N - CAP; expectedQueued > 0; expectedQueued--) {
+      const active = await activeSessions();
+      expect(active.length).toBeLessThanOrEqual(CAP);
+      await acp.cancelSession(active[0].id);
+      await poll(
+        () => acp.getAdmissionState().queuedSpawns === expectedQueued - 1,
+      );
+      expect((await activeSessions()).length).toBeLessThanOrEqual(CAP);
+    }
+
+    // All N tasks eventually admit — nothing dropped, nothing rejected. (Assert
+    // the admitted SET; arrival order at the reservation mutex is not the task
+    // creation index.)
+    await Promise.all(spawns);
+    expect([...settled].sort((a, b) => a - b)).toEqual(
+      Array.from({ length: N }, (_, i) => i),
+    );
+    expect(acp.getAdmissionState().queuedSpawns).toBe(0);
+
+    await service.stop();
+    await acp.stop();
+  });
+});


### PR DESCRIPTION
Implements #13778 item 1: the deterministic-backend, real-engine admission-queue e2e (WS8), now retargeted directly to `develop` after #13841 landed.

## What this does

A single e2e drives **10 tasks vs `ELIZA_ACP_MAX_SESSIONS=5`** through the **real** orchestrator admission queue and the **real** `AcpService` worker cap:

`OrchestratorTaskService.spawnAgentForTask` → `runtime.getService(AcpService)` → `acp.spawnSession` → `reserveSessionSlot`.

Only the subprocess leaf (`NativeAcpClient`) is stubbed (native transport), so admitted spawns deterministically reach `ready` without a live acp binary while the queue logic and ACP cap run through real services.

## Assertions

- N > cap spawns queue via task DTO `admission` rather than rejecting or dropping work.
- active ACP sessions never exceed the cap.
- stopping one active session drains one queued task through `service.getAdmissionSnapshot()`.
- all 10 tasks eventually get one ACP session and queue depth reaches 0.

## Verification

- `bun run --cwd plugins/plugin-agent-orchestrator test -- __tests__/unit/orchestrator-admission-queue.test.ts --coverage.enabled=false`
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-admission-queue.test.ts`
- `git diff --check origin/develop...HEAD`
- `git diff --check`

N/A: no UI/live-model/device surface; deterministic concurrency e2e only.

Part of epic #13766 (WS8).