### PR TITLE
fix(#13422): electrobun desktop-shell boot-critical aliased env reads → alias-aware reader

### DIFF
--- a/packages/app-core/platforms/electrobun/src/brand-env-reads.test.ts
+++ b/packages/app-core/platforms/electrobun/src/brand-env-reads.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Proves the Electrobun main-process brand-aliased boot reads (#13422) resolve a
+ * NON-ELIZA brand prefix through the alias-aware reader with canonical-`ELIZA_*`
+ * precedence and empty-is-unset, and WITHOUT the process.env mirror mutation.
+ * Deterministic: seeds the shared BootConfig alias table (as app boot does) and
+ * asserts the exact `readAliasedEnv` calls the migrated helpers make.
+ */
+import {
+  buildBrandEnvAliases,
+  getBootConfig,
+  setBootConfig,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  resolveNamespaceFromEnv,
+  resolveRendererUrlFromEnv,
+} from "./brand-env-reads";
+
+const BRAND = "MILADY";
+const aliases = buildBrandEnvAliases(BRAND);
+const savedConfig = getBootConfig();
+const tracked = [
+  "ELIZA_RENDERER_URL",
+  `${BRAND}_RENDERER_URL`,
+  "ELIZA_NAMESPACE",
+  `${BRAND}_NAMESPACE`,
+  "VITE_DEV_SERVER_URL",
+];
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of tracked) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  // Pin the brand<->eliza alias table on the immutable BootConfig, exactly as
+  // the app boot path does, so the reader can resolve MILADY_* -> ELIZA_*.
+  setBootConfig({ ...savedConfig, envAliases: aliases });
+});
+
+afterEach(() => {
+  for (const key of tracked) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  setBootConfig(savedConfig);
+});
+
+describe("resolveRendererUrlFromEnv", () => {
+  it("resolves the branded MILADY_RENDERER_URL alias", () => {
+    process.env.MILADY_RENDERER_URL = "http://127.0.0.1:5199";
+    expect(resolveRendererUrlFromEnv()).toBe("http://127.0.0.1:5199");
+  });
+
+  it("prefers canonical ELIZA_RENDERER_URL over the branded alias", () => {
+    process.env.ELIZA_RENDERER_URL = "http://canonical:6100";
+    process.env.MILADY_RENDERER_URL = "http://branded:6101";
+    expect(resolveRendererUrlFromEnv()).toBe("http://canonical:6100");
+  });
+
+  it("a blank ELIZA_RENDERER_URL does not mask a present branded alias", () => {
+    process.env.ELIZA_RENDERER_URL = "   ";
+    process.env.MILADY_RENDERER_URL = "http://branded:6102";
+    expect(resolveRendererUrlFromEnv()).toBe("http://branded:6102");
+  });
+
+  it("falls through to VITE_DEV_SERVER_URL, then empty string", () => {
+    process.env.VITE_DEV_SERVER_URL = "http://vite:5173";
+    expect(resolveRendererUrlFromEnv()).toBe("http://vite:5173");
+    delete process.env.VITE_DEV_SERVER_URL;
+    expect(resolveRendererUrlFromEnv()).toBe("");
+  });
+
+  it("performs zero alias writes to process.env while resolving", () => {
+    process.env.MILADY_RENDERER_URL = "http://127.0.0.1:5199";
+    const before = { ...process.env };
+    resolveRendererUrlFromEnv();
+    // The migration exists to stop materializing ELIZA_* targets on read.
+    expect(process.env.ELIZA_RENDERER_URL).toBeUndefined();
+    expect(process.env).toEqual(before);
+  });
+});
+
+describe("resolveNamespaceFromEnv", () => {
+  it("resolves the branded MILADY_NAMESPACE alias", () => {
+    process.env.MILADY_NAMESPACE = "milady";
+    expect(resolveNamespaceFromEnv("fallback-brand")).toBe("milady");
+  });
+
+  it("prefers canonical ELIZA_NAMESPACE over the branded alias", () => {
+    process.env.ELIZA_NAMESPACE = "eliza";
+    process.env.MILADY_NAMESPACE = "milady";
+    expect(resolveNamespaceFromEnv("fallback-brand")).toBe("eliza");
+  });
+
+  it("a blank ELIZA_NAMESPACE does not mask a present branded alias", () => {
+    process.env.ELIZA_NAMESPACE = "  ";
+    process.env.MILADY_NAMESPACE = "milady";
+    expect(resolveNamespaceFromEnv("fallback-brand")).toBe("milady");
+  });
+
+  it("falls back to the compiled-in brand namespace when unset", () => {
+    expect(resolveNamespaceFromEnv("fallback-brand")).toBe("fallback-brand");
+  });
+
+  it("performs zero alias writes to process.env while resolving", () => {
+    process.env.MILADY_NAMESPACE = "milady";
+    const before = { ...process.env };
+    resolveNamespaceFromEnv("fallback-brand");
+    expect(process.env.ELIZA_NAMESPACE).toBeUndefined();
+    expect(process.env).toEqual(before);
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/brand-env-reads.ts
+++ b/packages/app-core/platforms/electrobun/src/brand-env-reads.ts
@@ -1,0 +1,33 @@
+/**
+ * Alias-aware resolution of the two brand-aliased env vars the Electrobun main
+ * process reads at boot: the renderer URL and the app namespace. Both keys carry
+ * `<BRAND>_*` partners in the shared alias table, so they are read through
+ * `readAliasedEnv`, which resolves a branded alias off the immutable BootConfig
+ * WITHOUT mutating `process.env` (canonical `ELIZA_*` wins; blank is unset). The
+ * reads live here rather than inline in `index.ts` — the Electrobun entry has
+ * heavy top-level side effects and is not unit-testable — so the resolution
+ * contract can be exercised directly by `brand-env-reads.test.ts`.
+ */
+import { readAliasedEnv } from "@elizaos/shared";
+
+/**
+ * Renderer URL for the desktop webview: an explicit `ELIZA_RENDERER_URL` (or its
+ * brand alias) wins, then Vite's `VITE_DEV_SERVER_URL`, else empty so the caller
+ * falls back to the bundled static server. `VITE_DEV_SERVER_URL` is a Vite
+ * convention with no brand alias and stays a direct read.
+ */
+export function resolveRendererUrlFromEnv(): string {
+  return (
+    readAliasedEnv("ELIZA_RENDERER_URL") ??
+    process.env.VITE_DEV_SERVER_URL ??
+    ""
+  );
+}
+
+/**
+ * App namespace used to locate the per-brand state-dir `.env`. Falls back to the
+ * compiled-in brand namespace when `ELIZA_NAMESPACE` (or its brand alias) is unset.
+ */
+export function resolveNamespaceFromEnv(fallback: string): string {
+  return readAliasedEnv("ELIZA_NAMESPACE") ?? fallback;
+}

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -35,6 +35,10 @@ import {
 import { setApplicationMenuActionHandler } from "./application-menu-action-registry";
 import { showBackgroundNoticeOnce } from "./background-notice";
 import { getBrandConfig } from "./brand-config";
+import {
+  resolveNamespaceFromEnv,
+  resolveRendererUrlFromEnv,
+} from "./brand-env-reads";
 import { startBrowserWorkspaceBridgeServer } from "./browser-workspace-bridge-server";
 import { readNavigationEventUrl } from "./cloud-auth-window";
 import {
@@ -949,8 +953,7 @@ async function resolveRendererUrl(): Promise<string> {
   // Prefer ELIZA_RENDERER_URL / VITE_DEV_SERVER_URL when set (e.g. dev-platform.mjs watch mode).
   // Why: Vite HMR only works against the dev server; serving pre-built dist from this static
   // server would force a full rebuild for every UI change.
-  let rendererUrl =
-    process.env.ELIZA_RENDERER_URL ?? process.env.VITE_DEV_SERVER_URL ?? "";
+  let rendererUrl = resolveRendererUrlFromEnv();
 
   if (!rendererUrl) {
     rendererUrlPromise ??= startRendererServer();
@@ -2352,7 +2355,7 @@ async function loadTheAppEnvFilesForMain(): Promise<void> {
       "..",
       "..",
     );
-    const namespace = process.env.ELIZA_NAMESPACE?.trim() || BRAND.namespace;
+    const namespace = resolveNamespaceFromEnv(BRAND.namespace);
     const xdgStateHome = process.env.XDG_STATE_HOME?.trim();
     const stateHome = xdgStateHome
       ? path.isAbsolute(xdgStateHome)


### PR DESCRIPTION
## Boot-critical slice of #13422 (P5 — electrobun desktop shell)

Migrates the Electrobun **main-process** boot-critical brand-aliased env reads from raw `process.env.*` to the alias-aware, non-mutating reader `readAliasedEnv` (`@elizaos/shared`), so a white-label deployment's branded alias (e.g. `MILADY_*`) resolves **without** relying on the `process.env` mirror mutation.

### Migrated reads
| File | Key | Before → After |
| --- | --- | --- |
| `platforms/electrobun/src/index.ts:953` | `ELIZA_RENDERER_URL` | `process.env.ELIZA_RENDERER_URL ?? …` → `resolveRendererUrlFromEnv()` |
| `platforms/electrobun/src/index.ts:2355` | `ELIZA_NAMESPACE` | `process.env.ELIZA_NAMESPACE?.trim() \|\| BRAND.namespace` → `resolveNamespaceFromEnv(BRAND.namespace)` |

Both keys are confirmed alias-table entries (`brand-env-aliases.ts` `NAMESPACE`, `RENDERER_URL`). Precedence (canonical `ELIZA_*` wins) and empty-is-unset are preserved; the reader never mutates `process.env`. `VITE_DEV_SERVER_URL` is a Vite convention with no brand alias and stays a direct read. The mirror (`syncBrandEnvToEliza`/`syncElizaEnvToBrand`) is left intact — that removal is #13423.

### Why a small extracted module
`index.ts` is the Electrobun entry with heavy top-level side effects and is not unit-testable, so the two reads live in `brand-env-reads.ts` behind a testable seam.

### Real test — `brand-env-reads.test.ts` (10 cases, all green)
Seeds a **non-ELIZA** (`MILADY`) alias table on the BootConfig (as app boot does) and proves, for both migrated keys, that: the branded `MILADY_*` alias resolves; canonical `ELIZA_*` wins when both are set; a **blank** `ELIZA_*` does **not** shadow a present branded alias; and the read performs **zero** writes to `process.env`.

- **Fail-before** (raw pre-migration reads restored): 4/10 fail — the branded-resolution and blank-does-not-shadow cases.
- **Pass-after**: 10/10.

```
Test Files  1 passed (1)
     Tests  10 passed (10)
```

### Deferred (non-critical long tail)
The five runtime/local-model **remote-worker** reads named in the P5 partition (`remotes/runtime/src/bun/{stream-manager,api-client,worker}.ts`, `remotes/local-model/src/bun/local-inference-api-client.ts` — `ELIZA_API_TOKEN`, `ELIZA_DESKTOP_API_BASE`) are intentionally **not** migrated. Those are isolated Electrobun "carrot" remote bundles with **zero** `@elizaos/*` imports, bundled independently and run as separate processes that never seed a BootConfig alias table (`getBootConfig().envAliases` is `undefined` there → `DEFAULT_BOOT_CONFIG`). So the alias-aware reader would be a **behavioral no-op** in those processes while dragging the full `@elizaos/shared` + `@elizaos/core` graph into standalone worker bundles, breaking their deliberate isolation. The branded value already reaches them via parent-process env inheritance; the correct post-#13423 fix is host-passed resolved token (the remotes already accept `getAuthToken`), not per-remote alias re-resolution.

### Verification
- `bunx vitest run --config vitest.electrobun.config.ts src/brand-env-reads.test.ts` → 10/10.
- Package typecheck (`tsgo`): no errors on `brand-env-reads.ts`; no new errors on `index.ts`. Remaining diagnostics are pre-existing worktree env noise (`electrobun/bun`, `dotenv`, `viem`, `lucide-react`, `drizzle-orm` type decls).
- Biome clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)