### PR TITLE
fix(#13422): migrate boot-critical agent API auth/token/port aliased env reads to the alias-aware reader (P3)

### DIFF
--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -27,7 +27,7 @@ import {
   logger,
   stringToUuid,
 } from "@elizaos/core";
-import { resolveServerOnlyPort } from "@elizaos/shared";
+import { readAliasedEnv, resolveServerOnlyPort } from "@elizaos/shared";
 import { normalizeTerminalCommand } from "../utils/terminal-command.ts";
 
 const TERMINAL_ACTION_NAME = "TERMINAL_SHELL";
@@ -310,7 +310,7 @@ export const terminalAction: Action = {
     }
 
     try {
-      const terminalToken = process.env.ELIZA_TERMINAL_RUN_TOKEN?.trim();
+      const terminalToken = readAliasedEnv("ELIZA_TERMINAL_RUN_TOKEN");
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
       };

--- a/packages/agent/src/api/alias-aware-env-reads.test.ts
+++ b/packages/agent/src/api/alias-aware-env-reads.test.ts
@@ -207,7 +207,9 @@ describe("#13422 P3 — alias-aware boot-critical env reads", () => {
     });
 
     it("reports export disabled when neither the branded nor canonical token is set", () => {
-      const rejection = resolveWalletExportRejection(asReq(), { confirm: true });
+      const rejection = resolveWalletExportRejection(asReq(), {
+        confirm: true,
+      });
       expect(rejection?.status).toBe(403);
       expect(rejection?.reason).toContain("Wallet export is disabled");
     });

--- a/packages/agent/src/api/alias-aware-env-reads.test.ts
+++ b/packages/agent/src/api/alias-aware-env-reads.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Proves the boot-critical auth/token/port env reads migrated to `readAliasedEnv`
+ * (#13422 P3) resolve a NON-ELIZA brand prefix (MILADY_*) through the boot-config
+ * alias table WITHOUT the `syncBrandEnvToEliza` mirror mutation, and that a present
+ * canonical `ELIZA_*` value still wins over the branded alias. Drives the real
+ * exported helpers (`resolveCorsOrigin`, `pairingEnabled`, `resolveTerminalRunRejection`,
+ * `extractAuthToken`, `isWebSocketAuthorized`, `resolveWalletExportRejection`,
+ * `resolveMcpTerminalAuthorizationRejection`) against a live `process.env`; the
+ * server.ts/tui/chat-routes port + chat-timeout reads are covered through the same
+ * `readAliasedEnv` primitive they call plus the alias-aware `resolveDesktopApiPort`.
+ */
+import type http from "node:http";
+import {
+  buildBrandEnvAliases,
+  getBootConfig,
+  readAliasedEnv,
+  resolveDesktopApiPort,
+  setBootConfig,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  extractAuthToken,
+  isWebSocketAuthorized,
+  pairingEnabled,
+  resolveCorsOrigin,
+  resolveTerminalRunRejection,
+} from "./server-helpers-auth.ts";
+import { resolveMcpTerminalAuthorizationRejection } from "./server-helpers-mcp.ts";
+import { resolveWalletExportRejection } from "./server-helpers-wallet.ts";
+
+const MILADY_ALIASES = buildBrandEnvAliases("MILADY");
+
+// Every canonical + branded key any test below touches. Snapshotted and cleared
+// around each test so a leaked value can never make an alias read pass by mirror.
+const TOUCHED_ENV_KEYS = [
+  "MILADY_CLOUD_PROVISIONED",
+  "ELIZA_CLOUD_PROVISIONED",
+  "MILADY_PAIRING_DISABLED",
+  "ELIZA_PAIRING_DISABLED",
+  "MILADY_TERMINAL_RUN_TOKEN",
+  "ELIZA_TERMINAL_RUN_TOKEN",
+  "MILADY_WALLET_EXPORT_TOKEN",
+  "ELIZA_WALLET_EXPORT_TOKEN",
+  "MILADY_ALLOW_WS_QUERY_TOKEN",
+  "ELIZA_ALLOW_WS_QUERY_TOKEN",
+  "MILADY_API_PORT",
+  "ELIZA_API_PORT",
+  "MILADY_CHAT_GENERATION_TIMEOUT_MS",
+  "ELIZA_CHAT_GENERATION_TIMEOUT_MS",
+  "MILADY_API_TOKEN",
+  "ELIZA_API_TOKEN",
+  "ELIZA_API_BIND",
+  "ELIZA_ALLOW_UNAUTHENTICATED_STDIO_MCP",
+] as const;
+
+function asReq(headers: Record<string, string> = {}): http.IncomingMessage {
+  return { headers } as unknown as http.IncomingMessage;
+}
+
+describe("#13422 P3 — alias-aware boot-critical env reads", () => {
+  const savedConfig = getBootConfig();
+  const savedEnv = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of TOUCHED_ENV_KEYS) {
+      savedEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+    setBootConfig({ ...savedConfig, envAliases: MILADY_ALIASES });
+  });
+
+  afterEach(() => {
+    setBootConfig(savedConfig);
+    for (const [key, value] of savedEnv) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    savedEnv.clear();
+  });
+
+  describe("resolveCorsOrigin — ELIZA_CLOUD_PROVISIONED", () => {
+    it("allows any origin from the branded MILADY_CLOUD_PROVISIONED flag without writing the ELIZA mirror", () => {
+      process.env.MILADY_CLOUD_PROVISIONED = "1";
+      expect(resolveCorsOrigin("https://dashboard.milady.example")).toBe(
+        "https://dashboard.milady.example",
+      );
+      expect(process.env.ELIZA_CLOUD_PROVISIONED).toBeUndefined();
+    });
+
+    it("lets a present canonical ELIZA_CLOUD_PROVISIONED win over the branded alias", () => {
+      process.env.ELIZA_CLOUD_PROVISIONED = "0";
+      process.env.MILADY_CLOUD_PROVISIONED = "1";
+      // ELIZA "0" wins → allow-all is OFF → a non-local origin is rejected.
+      expect(resolveCorsOrigin("https://dashboard.milady.example")).toBeNull();
+    });
+  });
+
+  describe("pairingEnabled — ELIZA_PAIRING_DISABLED", () => {
+    it("is disabled by the branded MILADY_PAIRING_DISABLED flag without writing the ELIZA mirror", () => {
+      process.env.ELIZA_API_TOKEN = "pairing-api-token";
+      process.env.MILADY_PAIRING_DISABLED = "1";
+      expect(pairingEnabled()).toBe(false);
+      expect(process.env.ELIZA_PAIRING_DISABLED).toBeUndefined();
+    });
+
+    it("lets a present canonical ELIZA_PAIRING_DISABLED=0 win over the branded disable flag", () => {
+      process.env.ELIZA_API_TOKEN = "pairing-api-token";
+      process.env.ELIZA_PAIRING_DISABLED = "0";
+      process.env.MILADY_PAIRING_DISABLED = "1";
+      expect(pairingEnabled()).toBe(true);
+    });
+  });
+
+  describe("resolveTerminalRunRejection — ELIZA_TERMINAL_RUN_TOKEN", () => {
+    it("authorizes against the branded MILADY_TERMINAL_RUN_TOKEN without writing the ELIZA mirror", () => {
+      process.env.MILADY_TERMINAL_RUN_TOKEN = "milady-terminal-secret";
+      expect(
+        resolveTerminalRunRejection(asReq(), {
+          terminalToken: "milady-terminal-secret",
+        }),
+      ).toBeNull();
+      expect(
+        resolveTerminalRunRejection(asReq(), { terminalToken: "wrong" }),
+      ).toEqual({ status: 401, reason: "Invalid terminal token." });
+      expect(process.env.ELIZA_TERMINAL_RUN_TOKEN).toBeUndefined();
+    });
+
+    it("lets a present canonical ELIZA_TERMINAL_RUN_TOKEN win over the branded alias", () => {
+      process.env.ELIZA_TERMINAL_RUN_TOKEN = "canonical-terminal-secret";
+      process.env.MILADY_TERMINAL_RUN_TOKEN = "brand-terminal-secret";
+      expect(
+        resolveTerminalRunRejection(asReq(), {
+          terminalToken: "canonical-terminal-secret",
+        }),
+      ).toBeNull();
+      // the branded value is NOT the expected secret when ELIZA_ is present
+      expect(
+        resolveTerminalRunRejection(asReq(), {
+          terminalToken: "brand-terminal-secret",
+        }),
+      ).toEqual({ status: 401, reason: "Invalid terminal token." });
+    });
+  });
+
+  describe("WS/SSE query token gate — ELIZA_ALLOW_WS_QUERY_TOKEN", () => {
+    it("opens the SSE query-token path from the branded flag without writing the ELIZA mirror", () => {
+      process.env.MILADY_ALLOW_WS_QUERY_TOKEN = "1";
+      const req = {
+        method: "GET",
+        headers: { accept: "text/event-stream" },
+        url: "/api/stream?token=sse-tok",
+      } as unknown as http.IncomingMessage;
+      expect(extractAuthToken(req)).toBe("sse-tok");
+      expect(process.env.ELIZA_ALLOW_WS_QUERY_TOKEN).toBeUndefined();
+    });
+
+    it("keeps the SSE query-token path closed when the flag is unset", () => {
+      const req = {
+        method: "GET",
+        headers: { accept: "text/event-stream" },
+        url: "/api/stream?token=sse-tok",
+      } as unknown as http.IncomingMessage;
+      expect(extractAuthToken(req)).toBeNull();
+    });
+
+    it("accepts a WebSocket handshake query token when the branded flag is set", () => {
+      process.env.ELIZA_API_TOKEN = "ws-expected-token";
+      process.env.MILADY_ALLOW_WS_QUERY_TOKEN = "1";
+      const request = {
+        method: "GET",
+        headers: {},
+      } as unknown as http.IncomingMessage;
+      const url = new URL("http://localhost/ws?token=ws-expected-token");
+      expect(isWebSocketAuthorized(request, url)).toBe(true);
+    });
+
+    it("lets a present canonical ELIZA_ALLOW_WS_QUERY_TOKEN=0 win over the branded flag", () => {
+      process.env.ELIZA_API_TOKEN = "ws-expected-token";
+      process.env.ELIZA_ALLOW_WS_QUERY_TOKEN = "0";
+      process.env.MILADY_ALLOW_WS_QUERY_TOKEN = "1";
+      const request = {
+        method: "GET",
+        headers: {},
+      } as unknown as http.IncomingMessage;
+      const url = new URL("http://localhost/ws?token=ws-expected-token");
+      // ELIZA "0" wins → query-token path stays closed → no header token → reject.
+      expect(isWebSocketAuthorized(request, url)).toBe(false);
+    });
+  });
+
+  describe("resolveWalletExportRejection — ELIZA_WALLET_EXPORT_TOKEN", () => {
+    it("authorizes against the branded MILADY_WALLET_EXPORT_TOKEN without writing the ELIZA mirror", () => {
+      process.env.MILADY_WALLET_EXPORT_TOKEN = "milady-wallet-secret";
+      expect(
+        resolveWalletExportRejection(
+          asReq({ "x-eliza-export-token": "milady-wallet-secret" }),
+          { confirm: true },
+        ),
+      ).toBeNull();
+      expect(
+        resolveWalletExportRejection(
+          asReq({ "x-eliza-export-token": "wrong" }),
+          { confirm: true },
+        ),
+      ).toEqual({ status: 401, reason: "Invalid export token." });
+      expect(process.env.ELIZA_WALLET_EXPORT_TOKEN).toBeUndefined();
+    });
+
+    it("reports export disabled when neither the branded nor canonical token is set", () => {
+      const rejection = resolveWalletExportRejection(asReq(), { confirm: true });
+      expect(rejection?.status).toBe(403);
+      expect(rejection?.reason).toContain("Wallet export is disabled");
+    });
+
+    it("lets a present canonical ELIZA_WALLET_EXPORT_TOKEN win over the branded alias", () => {
+      process.env.ELIZA_WALLET_EXPORT_TOKEN = "canonical-wallet-secret";
+      process.env.MILADY_WALLET_EXPORT_TOKEN = "brand-wallet-secret";
+      expect(
+        resolveWalletExportRejection(
+          asReq({ "x-eliza-export-token": "canonical-wallet-secret" }),
+          { confirm: true },
+        ),
+      ).toBeNull();
+      expect(
+        resolveWalletExportRejection(
+          asReq({ "x-eliza-export-token": "brand-wallet-secret" }),
+          { confirm: true },
+        ),
+      ).toEqual({ status: 401, reason: "Invalid export token." });
+    });
+  });
+
+  describe("resolveMcpTerminalAuthorizationRejection — ELIZA_TERMINAL_RUN_TOKEN", () => {
+    const stdioServers = {
+      local: { type: "stdio", command: "echo", args: [] },
+    };
+
+    it("treats the branded MILADY_TERMINAL_RUN_TOKEN as configured so the stdio gate demands a token (not 403-unconfigured)", () => {
+      process.env.MILADY_TERMINAL_RUN_TOKEN = "milady-terminal-secret";
+      const rejection = resolveMcpTerminalAuthorizationRejection(
+        asReq(),
+        stdioServers,
+        {},
+      );
+      // expected token IS configured (via the alias) → delegates to the terminal
+      // gate, which 401s on the missing header rather than 403-ing unconfigured.
+      expect(rejection).toEqual({
+        status: 401,
+        reason:
+          "Missing terminal token. Provide X-Eliza-Terminal-Token header or terminalToken in request body.",
+      });
+      expect(process.env.ELIZA_TERMINAL_RUN_TOKEN).toBeUndefined();
+    });
+
+    it("rejects stdio MCP as unconfigured (403) when neither the branded nor canonical token is set", () => {
+      const rejection = resolveMcpTerminalAuthorizationRejection(
+        asReq(),
+        stdioServers,
+        {},
+      );
+      expect(rejection?.status).toBe(403);
+      expect(rejection?.reason).toContain("requires ELIZA_TERMINAL_RUN_TOKEN");
+    });
+  });
+
+  describe("readAliasedEnv primitive — ELIZA_API_PORT / ELIZA_CHAT_GENERATION_TIMEOUT_MS", () => {
+    // server.ts (port selection + HTTP request timeout), tui/agent-terminal-tui.ts
+    // (port selection), and chat-routes.ts (generation timeout) all migrated to the
+    // exact `readAliasedEnv("ELIZA_API_PORT")` / `readAliasedEnv("ELIZA_CHAT_GENERATION_TIMEOUT_MS")`
+    // calls exercised here; the port selection also feeds the alias-aware resolveDesktopApiPort.
+    it("resolves ELIZA_API_PORT from the branded alias, honors ELIZA precedence, and writes no mirror", () => {
+      process.env.MILADY_API_PORT = "45999";
+      expect(readAliasedEnv("ELIZA_API_PORT")).toBe("45999");
+      expect(resolveDesktopApiPort(process.env)).toBe(45999);
+      expect(process.env.ELIZA_API_PORT).toBeUndefined();
+
+      process.env.ELIZA_API_PORT = "31337";
+      expect(readAliasedEnv("ELIZA_API_PORT")).toBe("31337");
+      expect(resolveDesktopApiPort(process.env)).toBe(31337);
+    });
+
+    it("resolves ELIZA_CHAT_GENERATION_TIMEOUT_MS from the branded alias, honors ELIZA precedence, and writes no mirror", () => {
+      process.env.MILADY_CHAT_GENERATION_TIMEOUT_MS = "123456";
+      expect(readAliasedEnv("ELIZA_CHAT_GENERATION_TIMEOUT_MS")).toBe("123456");
+      expect(process.env.ELIZA_CHAT_GENERATION_TIMEOUT_MS).toBeUndefined();
+
+      process.env.ELIZA_CHAT_GENERATION_TIMEOUT_MS = "180000";
+      expect(readAliasedEnv("ELIZA_CHAT_GENERATION_TIMEOUT_MS")).toBe("180000");
+    });
+  });
+});

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -44,6 +44,7 @@ import {
   extractAssistantReplyText,
   isLinkedAccountProviderId,
   normalizeCharacterLanguage,
+  readAliasedEnv,
   resolveStreamingUpdate,
 } from "@elizaos/shared";
 import type { ElizaConfig } from "../config/config.ts";
@@ -1328,7 +1329,7 @@ function resolveChatGenerationTimeoutMs(explicit?: number): number {
     return Math.max(1, Math.floor(explicit));
   }
 
-  const fromEnv = process.env.ELIZA_CHAT_GENERATION_TIMEOUT_MS?.trim();
+  const fromEnv = readAliasedEnv("ELIZA_CHAT_GENERATION_TIMEOUT_MS");
   if (!fromEnv) return DEFAULT_CHAT_GENERATION_TIMEOUT_MS;
 
   const parsed = Number.parseInt(fromEnv, 10);

--- a/packages/agent/src/api/server-helpers-auth.ts
+++ b/packages/agent/src/api/server-helpers-auth.ts
@@ -11,6 +11,7 @@ import {
   isNullOriginAllowed,
   isTrustedLocalRequest as isTrustedLocalRequestShared,
   isWildcardBindHost,
+  readAliasedEnv,
   resolveAllowedHosts,
   resolveAllowedOrigins,
   resolveApiBindHost,
@@ -116,7 +117,7 @@ export function resolveCorsOrigin(origin?: string): string | null {
 
   // Cloud-provisioned containers default to allowing all origins so the
   // browser web UI can reach the agent API without extra config.
-  if (process.env.ELIZA_CLOUD_PROVISIONED === "1") {
+  if (readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1") {
     return trimmed;
   }
 
@@ -251,7 +252,7 @@ export function getConfiguredApiToken(): string | undefined {
  * `getConfiguredApiToken()` — same crypto.timingSafeEqual path as Bearer.
  */
 function extractSseQueryToken(req: http.IncomingMessage): string | null {
-  if (process.env.ELIZA_ALLOW_WS_QUERY_TOKEN !== "1") return null;
+  if (readAliasedEnv("ELIZA_ALLOW_WS_QUERY_TOKEN") !== "1") return null;
   if ((req.method ?? "GET").toUpperCase() !== "GET") return null;
   const accept = firstHeaderValue(req.headers.accept) ?? "";
   if (!accept.toLowerCase().includes("text/event-stream")) return null;
@@ -486,7 +487,7 @@ const pairingAttempts = new Map<string, { count: number; resetAt: number }>();
 export function pairingEnabled(): boolean {
   return (
     Boolean(getConfiguredApiToken()) &&
-    process.env.ELIZA_PAIRING_DISABLED !== "1"
+    readAliasedEnv("ELIZA_PAIRING_DISABLED") !== "1"
   );
 }
 
@@ -592,7 +593,7 @@ export function resolveTerminalRunRejection(
   req: http.IncomingMessage,
   body: TerminalRunRequestBody,
 ): TerminalRunRejection | null {
-  const expected = process.env.ELIZA_TERMINAL_RUN_TOKEN?.trim();
+  const expected = readAliasedEnv("ELIZA_TERMINAL_RUN_TOKEN");
   const apiTokenEnabled = Boolean(getConfiguredApiToken());
 
   // Compatibility mode: local loopback sessions without API token keep
@@ -640,7 +641,7 @@ export function resolveTerminalRunRejection(
 // ---------------------------------------------------------------------------
 
 function extractWsQueryToken(url: URL): string | null {
-  const allowQueryToken = process.env.ELIZA_ALLOW_WS_QUERY_TOKEN === "1";
+  const allowQueryToken = readAliasedEnv("ELIZA_ALLOW_WS_QUERY_TOKEN") === "1";
   if (!allowQueryToken) return null;
 
   const token =

--- a/packages/agent/src/api/server-helpers-mcp.ts
+++ b/packages/agent/src/api/server-helpers-mcp.ts
@@ -3,6 +3,7 @@
  */
 
 import type http from "node:http";
+import { readAliasedEnv } from "@elizaos/shared";
 import { validateMcpServerConfig } from "../security/mcp-server-config.ts";
 import { hasBlockedObjectKeyDeep } from "./server-helpers.ts";
 import type { TerminalRunRejection } from "./server-helpers-auth.ts";
@@ -71,7 +72,7 @@ export function resolveMcpTerminalAuthorizationRejection(
     return resolveTerminalRunRejection(req as http.IncomingMessage, body);
   }
 
-  const expected = process.env.ELIZA_TERMINAL_RUN_TOKEN?.trim();
+  const expected = readAliasedEnv("ELIZA_TERMINAL_RUN_TOKEN");
   if (!expected) {
     return {
       status: 403,

--- a/packages/agent/src/api/server-helpers-wallet.ts
+++ b/packages/agent/src/api/server-helpers-wallet.ts
@@ -4,6 +4,7 @@
 
 import crypto from "node:crypto";
 import type http from "node:http";
+import { readAliasedEnv } from "@elizaos/shared";
 import type {
   WalletExportRejection,
   WalletExportRequestBody,
@@ -34,7 +35,7 @@ export function resolveWalletExportRejection(
     };
   }
 
-  const expected = process.env.ELIZA_WALLET_EXPORT_TOKEN?.trim();
+  const expected = readAliasedEnv("ELIZA_WALLET_EXPORT_TOKEN");
   if (!expected) {
     return {
       status: 403,

--- a/packages/agent/src/api/server-helpers-wallet.ts
+++ b/packages/agent/src/api/server-helpers-wallet.ts
@@ -4,11 +4,11 @@
 
 import crypto from "node:crypto";
 import type http from "node:http";
-import { readAliasedEnv } from "@elizaos/shared";
 import type {
   WalletExportRejection,
   WalletExportRequestBody,
 } from "@elizaos/shared";
+import { readAliasedEnv } from "@elizaos/shared";
 
 export type { WalletExportRejection };
 

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -48,6 +48,7 @@ import type {
   FavoriteAppsStore,
 } from "@elizaos/plugin-app-manager";
 import type { WalletRouteDependencies } from "@elizaos/plugin-wallet";
+import { readAliasedEnv } from "@elizaos/shared";
 import {
   getStylePresets,
   normalizeCharacterLanguage,
@@ -3616,7 +3617,7 @@ export async function startApiServer(opts?: {
   // of 2138, so this change is transparent for non-desktop users.
   const port =
     opts?.port ??
-    (process.env.ELIZA_API_PORT
+    (readAliasedEnv("ELIZA_API_PORT")
       ? resolveDesktopApiPort(process.env)
       : resolveServerOnlyPort(process.env));
   const host = resolveApiBindHost(process.env);
@@ -4064,7 +4065,7 @@ export async function startApiServer(opts?: {
   const requestTimeoutEnvRaw =
     process.env.ELIZA_HTTP_REQUEST_TIMEOUT_MS?.trim() ?? "";
   const chatTimeoutEnvRaw =
-    process.env.ELIZA_CHAT_GENERATION_TIMEOUT_MS?.trim() ?? "";
+    readAliasedEnv("ELIZA_CHAT_GENERATION_TIMEOUT_MS") ?? "";
   const requestTimeoutMs = (() => {
     const explicit = Number.parseInt(requestTimeoutEnvRaw, 10);
     if (Number.isFinite(explicit) && explicit > 0) return explicit;

--- a/packages/agent/src/tui/agent-terminal-tui.ts
+++ b/packages/agent/src/tui/agent-terminal-tui.ts
@@ -9,6 +9,7 @@
  * sessions.
  */
 import {
+  readAliasedEnv,
   resolveApiBindHost,
   resolveDesktopApiPort,
   resolveServerOnlyPort,
@@ -68,7 +69,7 @@ const editorTheme: EditorTheme = {
 
 function resolveDefaultApiBaseUrl(): string {
   const host = resolveApiBindHost(process.env);
-  const port = process.env.ELIZA_API_PORT
+  const port = readAliasedEnv("ELIZA_API_PORT")
     ? resolveDesktopApiPort(process.env)
     : resolveServerOnlyPort(process.env);
   const displayHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;


### PR DESCRIPTION
## What

Boot-critical slice of #13422 (**P3 — agent API server + auth/token helpers**: cloud, ws-token, pairing, terminal/wallet tokens, api port, chat timeout). Migrates raw `process.env.<ELIZA_*>` reads to the alias-aware, **non-mutating** `readAliasedEnv(...)` so branded prefixes (e.g. `MILADY_*`) resolve through the boot-config alias table **without** relying on the `syncBrandEnvToEliza` / `syncElizaEnvToBrand` mirror mutation.

Precedence and empty-is-unset are preserved: the canonical `ELIZA_*` key wins whenever its own value is present (non-empty after trim), and only when `ELIZA_*` is absent/blank does the branded alias partner surface. A blank `ELIZA_*` no longer shadows a real branded value.

## Migrated reads (12 reads across 7 files)

| File | Key(s) |
| --- | --- |
| `api/server-helpers-auth.ts` | `ELIZA_CLOUD_PROVISIONED` (CORS allow-all), `ELIZA_ALLOW_WS_QUERY_TOKEN` (SSE gate + WS gate), `ELIZA_PAIRING_DISABLED`, `ELIZA_TERMINAL_RUN_TOKEN` |
| `api/server-helpers-wallet.ts` | `ELIZA_WALLET_EXPORT_TOKEN` |
| `api/server-helpers-mcp.ts` | `ELIZA_TERMINAL_RUN_TOKEN` |
| `actions/terminal.ts` | `ELIZA_TERMINAL_RUN_TOKEN` |
| `api/server.ts` | `ELIZA_API_PORT` (port selection), `ELIZA_CHAT_GENERATION_TIMEOUT_MS` |
| `api/chat-routes.ts` | `ELIZA_CHAT_GENERATION_TIMEOUT_MS` |
| `tui/agent-terminal-tui.ts` | `ELIZA_API_PORT` |

All keys verified present in the alias table (`packages/shared/src/config/brand-env-aliases.ts`). Port keys route through the alias-aware `resolveDesktopApiPort`/`resolveServerOnlyPort` resolvers, which already consult the alias table; only the raw presence check gating the branch was migrated. `?.trim()` was dropped where present because `readAliasedEnv` already trims and returns `undefined` for empty/whitespace — behavior-equivalent at every call site (all consumers treat `""` and `undefined` identically).

**Not touched** (out of scope): the `syncBrandEnvToEliza` / `syncElizaEnvToBrand` mirror removal (deferred to #13423), and `ELIZA_ALLOW_UNAUTHENTICATED_STDIO_MCP` / `ELIZA_HTTP_REQUEST_TIMEOUT_MS` (not alias-table keys). Non-critical long-tail reads outside this partition are deferred.

## Test — the security-critical proof

New focused suite `packages/agent/src/api/alias-aware-env-reads.test.ts` (17 tests) drives the **real** exported helpers against a live `process.env` with a `MILADY`-prefixed alias table installed in the boot config, and asserts for every migrated key:

1. a branded `MILADY_<KEY>` resolves correctly through the reader (auth/token/port behavior fires),
2. the canonical `ELIZA_<KEY>` still **wins** when both are set,
3. the `ELIZA_<KEY>` mirror property is **never written** to `process.env`.

Helpers exercised end-to-end: `resolveCorsOrigin`, `pairingEnabled`, `resolveTerminalRunRejection`, `extractAuthToken` (SSE), `isWebSocketAuthorized` (WS query token), `resolveWalletExportRejection`, `resolveMcpTerminalAuthorizationRejection`; the port + chat-timeout reads are covered through the same `readAliasedEnv` primitive they call plus the alias-aware `resolveDesktopApiPort`.

```
Test Files  1 passed (1)
     Tests  17 passed (17)
```

**Fail-before / pass-after:** temporarily reverting the `resolveTerminalRunRejection` read to raw `process.env.ELIZA_TERMINAL_RUN_TOKEN?.trim()` fails the terminal test (`expected null to deeply equal { status: 401 }`) — the branded token no longer resolves — proving the test pins the migrated code path. Restored to green.

Existing helper tests still pass (`server-helpers-auth.wildcard-token`, `server-helpers-auth-trust`, `server-helpers-auth.isAllowedHost`, `auth-routes.role`, `misc-routes.agent-event` → 26/26).

## Verification

- `bunx vitest run` on the new suite: 17/17 pass; on the 5 existing touched-helper suites: 26/26 pass.
- Package-local typecheck: no errors on any touched file or the `readAliasedEnv` import. Remaining `bun run typecheck` output is pre-existing environment noise (unbuilt workspace subpath exports like `@elizaos/plugin-streaming`, and missing `.d.ts` for `viem`/`drizzle-orm`/`@solana/web3.js`) at lines this branch did not touch.