### PR TITLE
fix(#13422): migrate app-core API/CORS/first-run boot-critical aliased env reads to the alias-aware reader

### DIFF
--- a/packages/app-core/src/api/auth-pairing-routes.test.ts
+++ b/packages/app-core/src/api/auth-pairing-routes.test.ts
@@ -13,6 +13,11 @@ import crypto from "node:crypto";
 import * as http from "node:http";
 import { Socket } from "node:net";
 import {
+  buildBrandEnvAliases,
+  getBootConfig,
+  setBootConfig,
+} from "@elizaos/shared";
+import {
   afterEach,
   beforeAll,
   beforeEach,
@@ -438,5 +443,85 @@ describe("auth pairing pair-code route", () => {
 
     expect(res.status()).toBe(503);
     expect(res.body()).toMatchObject({ error: "Pairing not enabled" });
+  });
+
+  // #13422: the pairing gate reads ELIZA_PAIRING_DISABLED through the
+  // alias-aware reader, so a rebranded deployment's MILADY_PAIRING_DISABLED must
+  // disable pairing WITHOUT the syncBrandEnvToEliza mirror mutation, and a
+  // present canonical ELIZA_PAIRING_DISABLED must still win over the branded key.
+  it("does not reveal a code when pairing is disabled via a branded (non-ELIZA) alias", async () => {
+    const savedConfig = getBootConfig();
+    const savedBranded = process.env.MILADY_PAIRING_DISABLED;
+    setBootConfig({
+      ...savedConfig,
+      envAliases: buildBrandEnvAliases("MILADY"),
+    });
+    process.env.MILADY_PAIRING_DISABLED = "1";
+    delete process.env.ELIZA_PAIRING_DISABLED;
+
+    try {
+      const res = fakeRes();
+      await handleAuthPairingCompatRoutes(
+        fakeReq({
+          method: "GET",
+          pathname: "/api/auth/pair-code",
+          ip: "127.0.0.1",
+          host: "localhost:2138",
+        }),
+        res.res,
+        STATE,
+      );
+
+      expect(res.status()).toBe(503);
+      expect(res.body()).toMatchObject({ error: "Pairing not enabled" });
+      // Resolving the branded alias must never materialize the canonical mirror.
+      expect(process.env.ELIZA_PAIRING_DISABLED).toBeUndefined();
+    } finally {
+      setBootConfig(savedConfig);
+      if (savedBranded === undefined) {
+        delete process.env.MILADY_PAIRING_DISABLED;
+      } else {
+        process.env.MILADY_PAIRING_DISABLED = savedBranded;
+      }
+    }
+  });
+
+  it("keeps a present canonical ELIZA_PAIRING_DISABLED ahead of the branded alias", async () => {
+    const savedConfig = getBootConfig();
+    const savedBranded = process.env.MILADY_PAIRING_DISABLED;
+    setBootConfig({
+      ...savedConfig,
+      envAliases: buildBrandEnvAliases("MILADY"),
+    });
+    // Canonical present (and not "1") wins over a branded "1": pairing stays
+    // ENABLED, proving the reader honors the ELIZA_* precedence contract.
+    process.env.ELIZA_PAIRING_DISABLED = "0";
+    process.env.MILADY_PAIRING_DISABLED = "1";
+
+    try {
+      vi.spyOn(crypto, "randomInt").mockImplementation(() => 0);
+      const res = fakeRes();
+      await handleAuthPairingCompatRoutes(
+        fakeReq({
+          method: "GET",
+          pathname: "/api/auth/pair-code",
+          ip: "127.0.0.1",
+          host: "localhost:2138",
+        }),
+        res.res,
+        STATE,
+      );
+
+      expect(res.status()).toBe(200);
+      expect(res.body()).toMatchObject({ code: "AAAA-AAAA-AAAA" });
+    } finally {
+      setBootConfig(savedConfig);
+      delete process.env.ELIZA_PAIRING_DISABLED;
+      if (savedBranded === undefined) {
+        delete process.env.MILADY_PAIRING_DISABLED;
+      } else {
+        process.env.MILADY_PAIRING_DISABLED = savedBranded;
+      }
+    }
   });
 });

--- a/packages/app-core/src/api/auth-pairing-routes.ts
+++ b/packages/app-core/src/api/auth-pairing-routes.ts
@@ -13,6 +13,7 @@ import crypto from "node:crypto";
 import type http from "node:http";
 import { loadElizaConfig } from "@elizaos/agent";
 import { logger } from "@elizaos/core";
+import { readAliasedEnv } from "@elizaos/shared/utils/env";
 import { AuthStore } from "../services/auth-store";
 import {
   createMachineSession,
@@ -75,7 +76,7 @@ export function _resetAuthPairingStateForTests(): void {
 function pairingEnabled(): boolean {
   return (
     Boolean(getCompatApiToken()) &&
-    process.env.ELIZA_PAIRING_DISABLED !== "1" &&
+    readAliasedEnv("ELIZA_PAIRING_DISABLED") !== "1" &&
     !isCloudProvisioned()
   );
 }

--- a/packages/app-core/src/api/server-cors.test.ts
+++ b/packages/app-core/src/api/server-cors.test.ts
@@ -4,9 +4,19 @@
  * local hosts, that localhost is allowed on every env-configured port
  * (API / UI / single-process / gateway / home plus Electrobun dev ports), that
  * explicit `ELIZA_ALLOWED_ORIGINS` remote origins normalize and gate correctly,
- * and that the env-derived port cache recomputes after invalidation.
+ * that the env-derived port cache recomputes after invalidation, and — the
+ * security-critical proof for #13422 — that a non-ELIZA brand prefix
+ * (`MILADY_*`) resolves the CORS ports/origins through the alias-aware readers
+ * WITHOUT materializing the `ELIZA_*` mirror keys, with the canonical `ELIZA_*`
+ * key still winning when both are set.
  */
-import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildBrandEnvAliases,
+  getBootConfig,
+  setBootConfig,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildCorsAllowedPorts,
   getAllowedRemoteOrigins,
@@ -117,5 +127,126 @@ describe("server CORS origin allowlist", () => {
     expect(isAllowedOrigin("ionic://evil.example")).toBe(false);
     expect(isAllowedOrigin("app://evil.example")).toBe(false);
     expect(isAllowedOrigin("tauri://evil.example")).toBe(false);
+  });
+});
+
+// #13422: the CORS port/origin helpers migrated off raw `process.env.ELIZA_*`
+// reads to the alias-aware readers (`resolveDesktopApiPort` / `resolveUiPort`
+// for the API/UI ports, `resolveAllowedOrigins` for origins, `readAliasedEnv`
+// for the gateway/home ports). A non-ELIZA brand deployment must resolve these
+// from its own `<PREFIX>_*` keys without the `syncBrandEnvToEliza` mirror
+// mutation, and the canonical `ELIZA_*` key must still win when both are set.
+describe("server CORS allowlist — branded alias resolution (#13422)", () => {
+  const BRAND = "MILADY";
+  const savedConfig = getBootConfig();
+  const tracked = [
+    "ELIZA_API_PORT",
+    "ELIZA_UI_PORT",
+    "ELIZA_PORT",
+    "ELIZA_GATEWAY_PORT",
+    "ELIZA_HOME_PORT",
+    "ELIZA_ALLOWED_ORIGINS",
+    `${BRAND}_API_PORT`,
+    `${BRAND}_UI_PORT`,
+    `${BRAND}_PORT`,
+    `${BRAND}_GATEWAY_PORT`,
+    `${BRAND}_HOME_PORT`,
+    `${BRAND}_ALLOWED_ORIGINS`,
+  ];
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of tracked) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    // Pin the brand<->eliza alias table on the immutable BootConfig, exactly as
+    // the app boot path does for a rebranded distribution.
+    setBootConfig({ ...savedConfig, envAliases: buildBrandEnvAliases(BRAND) });
+    invalidateCorsAllowedPorts();
+  });
+
+  afterEach(() => {
+    for (const key of tracked) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    setBootConfig(savedConfig);
+    invalidateCorsAllowedPorts();
+  });
+
+  it("resolves CORS ports and origins from a non-ELIZA brand prefix", () => {
+    process.env[`${BRAND}_API_PORT`] = "43555";
+    process.env[`${BRAND}_UI_PORT`] = "44777";
+    process.env[`${BRAND}_GATEWAY_PORT`] = "48789";
+    process.env[`${BRAND}_HOME_PORT`] = "42142";
+    process.env[`${BRAND}_ALLOWED_ORIGINS`] = "https://dashboard.example.com";
+    invalidateCorsAllowedPorts();
+
+    const ports = buildCorsAllowedPorts();
+    for (const port of ["43555", "44777", "48789", "42142"]) {
+      expect(ports.has(port)).toBe(true);
+    }
+
+    expect(getAllowedRemoteOrigins()).toEqual(
+      new Set(["https://dashboard.example.com"]),
+    );
+    expect(isAllowedOrigin("http://localhost:43555")).toBe(true);
+    expect(isAllowedOrigin("http://127.0.0.1:48789")).toBe(true);
+    expect(isAllowedOrigin("https://dashboard.example.com/settings")).toBe(
+      true,
+    );
+  });
+
+  it("does not materialize the ELIZA_* mirror keys while resolving", () => {
+    process.env[`${BRAND}_API_PORT`] = "43555";
+    process.env[`${BRAND}_UI_PORT`] = "44777";
+    process.env[`${BRAND}_GATEWAY_PORT`] = "48789";
+    process.env[`${BRAND}_HOME_PORT`] = "42142";
+    process.env[`${BRAND}_ALLOWED_ORIGINS`] = "https://dashboard.example.com";
+    invalidateCorsAllowedPorts();
+
+    buildCorsAllowedPorts();
+    getAllowedRemoteOrigins();
+
+    // Reading must never write the canonical mirror — that is exactly the
+    // process.env mutation #13422 removes.
+    expect(process.env.ELIZA_API_PORT).toBeUndefined();
+    expect(process.env.ELIZA_UI_PORT).toBeUndefined();
+    expect(process.env.ELIZA_GATEWAY_PORT).toBeUndefined();
+    expect(process.env.ELIZA_HOME_PORT).toBeUndefined();
+    expect(process.env.ELIZA_ALLOWED_ORIGINS).toBeUndefined();
+  });
+
+  it("keeps the canonical ELIZA_* value ahead of the branded alias", () => {
+    process.env.ELIZA_API_PORT = "30000";
+    process.env[`${BRAND}_API_PORT`] = "43555";
+    process.env.ELIZA_GATEWAY_PORT = "18000";
+    process.env[`${BRAND}_GATEWAY_PORT`] = "48789";
+    process.env.ELIZA_ALLOWED_ORIGINS = "https://canonical.example.com";
+    process.env[`${BRAND}_ALLOWED_ORIGINS`] = "https://branded.example.com";
+    invalidateCorsAllowedPorts();
+
+    const ports = buildCorsAllowedPorts();
+    expect(ports.has("30000")).toBe(true);
+    expect(ports.has("43555")).toBe(false);
+    expect(ports.has("18000")).toBe(true);
+    expect(ports.has("48789")).toBe(false);
+
+    expect(getAllowedRemoteOrigins()).toEqual(
+      new Set(["https://canonical.example.com"]),
+    );
+    expect(isAllowedOrigin("https://branded.example.com")).toBe(false);
+  });
+
+  it("a blank canonical value falls through to the branded alias (empty-is-unset)", () => {
+    process.env.ELIZA_GATEWAY_PORT = "   ";
+    process.env[`${BRAND}_GATEWAY_PORT`] = "49000";
+    invalidateCorsAllowedPorts();
+
+    expect(buildCorsAllowedPorts().has("49000")).toBe(true);
+    // The blank canonical value must not shadow the present branded alias, and
+    // the read must still not materialize the mirror.
+    expect(isAllowedOrigin("http://localhost:49000")).toBe(true);
   });
 });

--- a/packages/app-core/src/api/server-cors.ts
+++ b/packages/app-core/src/api/server-cors.ts
@@ -5,17 +5,29 @@
  * full API runtime dependency graph.
  */
 
+import {
+  resolveAllowedOrigins,
+  resolveDesktopApiPort,
+  resolveUiPort,
+} from "@elizaos/shared/runtime-env";
+import { readAliasedEnv } from "@elizaos/shared/utils/env";
+
 /**
  * Build the set of localhost ports allowed for CORS.
  * Reads from env vars at call time so tests can override.
+ *
+ * Ports resolve through the alias-aware readers so a branded deployment's
+ * `<PREFIX>_API_PORT` / `<PREFIX>_UI_PORT` / `<PREFIX>_GATEWAY_PORT` /
+ * `<PREFIX>_HOME_PORT` are honoured without the `syncBrandEnvToEliza` mirror
+ * mutation, with the canonical `ELIZA_*` key still winning when present (#13422).
  */
 export function buildCorsAllowedPorts(): Set<string> {
   const ports = new Set([
-    String(process.env.ELIZA_API_PORT ?? process.env.ELIZA_PORT ?? "31337"),
-    String(process.env.ELIZA_UI_PORT || process.env.ELIZA_PORT || ""),
+    String(resolveDesktopApiPort(process.env)),
+    String(resolveUiPort(process.env)),
     String(process.env.ELIZA_PORT ?? "2138"),
-    String(process.env.ELIZA_GATEWAY_PORT ?? "18789"),
-    String(process.env.ELIZA_HOME_PORT ?? "2142"),
+    String(readAliasedEnv("ELIZA_GATEWAY_PORT") ?? "18789"),
+    String(readAliasedEnv("ELIZA_HOME_PORT") ?? "2142"),
   ]);
   // Electrobun renderer static server picks a free port in the 5174–5200
   // range. Allow the full range so cross-origin fetches from WKWebView
@@ -31,19 +43,17 @@ export function buildCorsAllowedPorts(): Set<string> {
  * way to allow non-loopback hosts.
  */
 export function getAllowedRemoteOrigins(): Set<string> {
-  const raw = process.env.ELIZA_ALLOWED_ORIGINS ?? "";
+  // `resolveAllowedOrigins` reads `ELIZA_ALLOWED_ORIGINS` (and the `CORS_ORIGINS`
+  // fallback) alias-aware, already split/trimmed/filtered, so a branded
+  // `<PREFIX>_ALLOWED_ORIGINS` resolves without the mirror mutation (#13422).
   return new Set(
-    raw
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean)
-      .map((origin) => {
-        try {
-          return originString(new URL(origin));
-        } catch {
-          return origin;
-        }
-      }),
+    resolveAllowedOrigins(process.env).map((origin) => {
+      try {
+        return originString(new URL(origin));
+      } catch {
+        return origin;
+      }
+    }),
   );
 }
 

--- a/packages/app-core/src/api/server-first-run-helpers.ts
+++ b/packages/app-core/src/api/server-first-run-helpers.ts
@@ -22,6 +22,7 @@ import {
   normalizeLinkedAccountFlagsConfig,
   normalizeServiceRoutingConfig,
   PREMADE_VOICES,
+  readAliasedEnv,
   type ServiceRoutingConfig,
 } from "@elizaos/shared";
 import { getCompatApiToken } from "./auth.ts";
@@ -354,7 +355,7 @@ export function deriveFirstRunReplayBody(body: Record<string, unknown>): {
  * `ensureAuthSessionOrBootstrap`.
  */
 export function isCloudProvisioned(): boolean {
-  const hasCloudFlag = process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  const hasCloudFlag = readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
 
   const hasCloudApiKeyProvisioning =
     process.env.ELIZAOS_CLOUD_ENABLED === "true" &&

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -176,6 +176,7 @@ import { getCorsAllowedPorts, isAllowedOrigin } from "./server-cors";
 const _require = createRequire(import.meta.url);
 
 import {
+  readAliasedEnv,
   syncAppEnvToEliza,
   syncElizaEnvAliases,
 } from "@elizaos/shared/utils/env";
@@ -261,8 +262,8 @@ function resolveCompatConfigPaths(): {
   elizaConfigPath?: string;
   appConfigPath?: string;
 } {
-  const explicitConfig = process.env.ELIZA_CONFIG_PATH?.trim();
-  const hasStateOverride = Boolean(process.env.ELIZA_STATE_DIR?.trim());
+  const explicitConfig = readAliasedEnv("ELIZA_CONFIG_PATH");
+  const hasStateOverride = Boolean(readAliasedEnv("ELIZA_STATE_DIR"));
   const configPath =
     explicitConfig ||
     (hasStateOverride ? path.join(resolveStateDir(), "eliza.json") : undefined);

--- a/packages/app-core/src/runtime/dev-server.ts
+++ b/packages/app-core/src/runtime/dev-server.ts
@@ -118,7 +118,7 @@ console.log(
 );
 
 const port = resolveDesktopApiPort(process.env);
-const hadUserApiTokenInEnv = !!process.env.ELIZA_API_TOKEN?.trim();
+const hadUserApiTokenInEnv = !!resolveApiToken(process.env);
 
 /** The currently active runtime — swapped on restart. */
 let currentRuntime: AgentRuntime | null = null;


### PR DESCRIPTION
Boot-critical slice of #13422 (**P1 — app-core API / CORS / first-run boot**: ports, origins, token, pairing, config, state, cloud). Non-critical long-tail reads are deferred to later slices.

## What

Migrate raw `process.env.ELIZA_*` reads of alias-table keys to the non-mutating **alias-aware readers** so a rebranded distribution's `<PREFIX>_*` keys (e.g. `MILADY_*`) resolve **without** relying on the `syncBrandEnvToEliza` / `syncElizaEnvToBrand` mirror mutation. Precedence and empty-is-unset are preserved: the canonical `ELIZA_*` key wins when present (non-blank), and a blank/whitespace `ELIZA_*` value does **not** shadow a real branded alias.

`syncBrandEnvToEliza` / `syncElizaEnvToBrand` are intentionally **not** removed here (that is #13423).

### Reads migrated (10)

| File | Key | Now reads via |
| --- | --- | --- |
| `api/server-cors.ts` | `ELIZA_API_PORT` (+`ELIZA_PORT`) | `resolveDesktopApiPort` |
| `api/server-cors.ts` | `ELIZA_UI_PORT` | `resolveUiPort` |
| `api/server-cors.ts` | `ELIZA_GATEWAY_PORT` | `readAliasedEnv` |
| `api/server-cors.ts` | `ELIZA_HOME_PORT` | `readAliasedEnv` |
| `api/server-cors.ts` | `ELIZA_ALLOWED_ORIGINS` | `resolveAllowedOrigins` |
| `api/auth-pairing-routes.ts` | `ELIZA_PAIRING_DISABLED` | `readAliasedEnv` |
| `api/server.ts` | `ELIZA_CONFIG_PATH` | `readAliasedEnv` |
| `api/server.ts` | `ELIZA_STATE_DIR` | `readAliasedEnv` |
| `api/server-first-run-helpers.ts` | `ELIZA_CLOUD_PROVISIONED` | `readAliasedEnv` |
| `runtime/dev-server.ts` | `ELIZA_API_TOKEN` (presence) | `resolveApiToken` |

Every key was verified against `packages/shared/src/config/brand-env-aliases.ts` as a genuine alias-table entry. `readAliasedEnv` trims + treats empty/whitespace as unset, matching the previous normalized reads (the redundant `.trim()` / `?? ""` guards were dropped).

**Deferred (not this partition):** `server-cors.ts` line 16 `process.env.ELIZA_PORT ?? "2138"` (single-process default) is left as a raw read — it is not in this slice and the `ELIZA_PORT` value it contributes is already represented in the CORS port set via the migrated API/UI reads. It belongs to the non-critical long-tail sweep.

## Security-critical test proof

Extended two suites with a **non-ELIZA brand prefix** (`MILADY_*`) fixture that pins the alias table on the immutable `BootConfig` (as the app boot path does) and asserts, with **zero** `ELIZA_*` mirror writes to `process.env`:

- `api/server-cors.test.ts` — branded `MILADY_API_PORT` / `MILADY_UI_PORT` / `MILADY_GATEWAY_PORT` / `MILADY_HOME_PORT` / `MILADY_ALLOWED_ORIGINS` resolve into the CORS port/origin sets; canonical `ELIZA_*` wins when both are set; a blank canonical value falls through to the branded alias; and no `ELIZA_*` key is materialized while resolving.
- `api/auth-pairing-routes.test.ts` — a branded `MILADY_PAIRING_DISABLED=1` disables the pairing gate through the reader without materializing `ELIZA_PAIRING_DISABLED`; a present canonical `ELIZA_PAIRING_DISABLED` wins over the branded key.

**Fail-before / pass-after:** reverting each migrated read to its raw `process.env.ELIZA_*` form makes the branded-resolution assertions fail (branded value ignored → wrong port set / pairing stays enabled); the migrated readers make them pass.

```
Test Files  2 passed (2)
     Tests  18 passed (18)   # server-cors (11) + auth-pairing (7)
```

## Verification

- `bun run --cwd packages/app-core test` on `server-cors.test.ts`, `auth-pairing-routes.test.ts`, `server-first-run-helpers.masked-key.test.ts` → **21 passed**.
- Package typecheck: no new errors at the edited lines (only pre-existing sparse-worktree noise — missing `@elizaos/plugin-registry` / `dotenv` types — unrelated to this change).
- Biome check clean on all 7 touched files. No `console.*` and no new empty catch added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)