### PR TITLE
fix(cloud): scope steward marker cookies

### DIFF
--- a/.github/issue-evidence/13848-steward-cookie-scope.md
+++ b/.github/issue-evidence/13848-steward-cookie-scope.md
@@ -1,0 +1,47 @@
+# Issue #13848 - Steward Cookie Env Scoping Follow-ups
+
+## Scope
+
+- Env-scoped the non-HttpOnly Steward marker cookie through the existing
+  `stewardCookieNames(c.env.ENVIRONMENT)` helper.
+- Kept production on the historical unsuffixed names and suffixed non-production
+  marker cookies, for example `steward-authed-staging`.
+- Updated logout/session-delete/refresh invalid-token cleanup to clear both the
+  current environment marker and the legacy marker.
+- Added an explicit cutoff for the legacy access-token read fallback:
+  `2026-08-04`, one 30-day refresh-cookie Max-Age after this 2026-07-05
+  follow-up.
+- Normalized the legacy fallback path so `readStewardCookie` returns only
+  `string | null`.
+
+## Verification
+
+- `bun install --frozen-lockfile --ignore-scripts`
+- `bun test packages/cloud/shared/src/lib/auth/steward-cookies.test.ts`
+- `bun run --cwd packages/shared test -- src/steward-session-client/index.test.ts`
+- `bun run --cwd packages/cloud/routing build`
+- `bun run --cwd packages/shared build:i18n`
+- `bun run --cwd packages/logger build`
+- `bun run --cwd packages/contracts build`
+- `bun run --cwd packages/core build:node`
+- `bun test packages/cloud/api/__tests__/steward-session-delete-clears-both-cookie-eras.test.ts`
+- `bunx biome check packages/cloud/shared/src/lib/auth/steward-cookies.ts packages/cloud/shared/src/lib/auth/steward-cookies.test.ts packages/cloud/shared/src/lib/auth/workers-hono-auth.ts packages/cloud/api/auth/steward-session/route.ts packages/cloud/api/auth/steward-refresh/route.ts packages/cloud/api/auth/steward-nonce-exchange/route.ts packages/cloud/api/auth/logout/route.ts packages/cloud/api/__tests__/steward-session-delete-clears-both-cookie-eras.test.ts packages/shared/src/steward-session-client/index.ts packages/shared/src/steward-session-client/index.test.ts`
+- `git diff --check`
+- `bun run --cwd packages/shared typecheck`
+- `bun run --cwd packages/cloud/shared typecheck`
+
+## Known Unrelated Verification Failure
+
+- `bun run --cwd packages/cloud/api typecheck` fails in
+  `__tests__/my-agents-claim-affiliate-characters.test.ts` because the imported
+  route default can return `Response | Promise<Response>` while the test fixture
+  expects `Promise<Response>`. None of the changed Steward auth files are named
+  in that failure.
+
+## Evidence N/A
+
+- Screenshots/video: N/A - backend cookie naming/auth-session helper change, no
+  rendered UI changed.
+- Live LLM trajectories: N/A - no agent/action/provider/prompt/model behavior
+  changed.
+- DB/migration artifacts: N/A - no schema, migration, or DB write path changed.

--- a/packages/cloud/api/__tests__/steward-session-delete-clears-both-cookie-eras.test.ts
+++ b/packages/cloud/api/__tests__/steward-session-delete-clears-both-cookie-eras.test.ts
@@ -34,8 +34,10 @@ describe("DELETE /api/auth/steward-session cookie clearing", () => {
     const cleared = deletedCookieNames(res);
     expect(cleared).toContain("steward-token-staging");
     expect(cleared).toContain("steward-refresh-token-staging");
+    expect(cleared).toContain("steward-authed-staging");
     expect(cleared).toContain("steward-token");
     expect(cleared).toContain("steward-refresh-token");
+    expect(cleared).toContain("steward-authed");
   });
 
   it("production clears the historical pair (both eras resolve to the same names)", async () => {
@@ -54,5 +56,6 @@ describe("DELETE /api/auth/steward-session cookie clearing", () => {
     const cleared = deletedCookieNames(res);
     expect(cleared).toContain("steward-token");
     expect(cleared).toContain("steward-refresh-token");
+    expect(cleared).toContain("steward-authed");
   });
 });

--- a/packages/cloud/api/auth/logout/route.ts
+++ b/packages/cloud/api/auth/logout/route.ts
@@ -46,7 +46,8 @@ app.post("/", async (c) => {
   deleteCookie(c, cookieNames.refreshToken, stewardOpts);
   deleteCookie(c, LEGACY_STEWARD_COOKIES.token, stewardOpts);
   deleteCookie(c, LEGACY_STEWARD_COOKIES.refreshToken, stewardOpts);
-  deleteCookie(c, "steward-authed", stewardOpts);
+  deleteCookie(c, cookieNames.authed, stewardOpts);
+  deleteCookie(c, LEGACY_STEWARD_COOKIES.authed, stewardOpts);
   deleteCookie(c, "eliza-anon-session", { path: "/" });
 
   try {

--- a/packages/cloud/api/auth/steward-nonce-exchange/route.ts
+++ b/packages/cloud/api/auth/steward-nonce-exchange/route.ts
@@ -23,10 +23,7 @@
  * localhost in non-production).
  */
 
-import {
-  STEWARD_AUTHED_COOKIE,
-  type StewardSessionErrorCode,
-} from "@elizaos/shared/steward-session-client";
+import type { StewardSessionErrorCode } from "@elizaos/shared/steward-session-client";
 import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
@@ -449,7 +446,9 @@ app.post("/", async (c) => {
   const secure = c.env.NODE_ENV === "production";
   const domain = cookieDomainForHost(c.req.header("host"));
 
-  setCookie(c, stewardCookieNames(c.env.ENVIRONMENT).token, token, {
+  const cookieNames = stewardCookieNames(c.env.ENVIRONMENT);
+
+  setCookie(c, cookieNames.token, token, {
     httpOnly: true,
     secure,
     sameSite: "Lax",
@@ -459,22 +458,17 @@ app.post("/", async (c) => {
   });
 
   if (typeof refreshToken === "string" && refreshToken.length > 0) {
-    setCookie(
-      c,
-      stewardCookieNames(c.env.ENVIRONMENT).refreshToken,
-      refreshToken,
-      {
-        httpOnly: true,
-        secure,
-        sameSite: "Lax",
-        path: "/",
-        ...(domain ? { domain } : {}),
-        maxAge: STEWARD_REFRESH_COOKIE_MAX_AGE,
-      },
-    );
+    setCookie(c, cookieNames.refreshToken, refreshToken, {
+      httpOnly: true,
+      secure,
+      sameSite: "Lax",
+      path: "/",
+      ...(domain ? { domain } : {}),
+      maxAge: STEWARD_REFRESH_COOKIE_MAX_AGE,
+    });
   }
 
-  setCookie(c, STEWARD_AUTHED_COOKIE, "1", {
+  setCookie(c, cookieNames.authed, "1", {
     httpOnly: false,
     secure,
     sameSite: "Lax",

--- a/packages/cloud/api/auth/steward-refresh/route.ts
+++ b/packages/cloud/api/auth/steward-refresh/route.ts
@@ -12,7 +12,8 @@
  *  3. Verifies the new access token (same path as
  *     `/api/auth/steward-session`).
  *  4. Sets new HttpOnly cookies (`steward-token`, `steward-refresh-token`)
- *     and the non-HttpOnly `steward-authed=1` marker.
+ *     and the non-HttpOnly `steward-authed=1` marker, using environment-
+ *     scoped names outside production.
  *  5. Returns `{ ok, expiresAt }`. Trusted first-party browser origins also
  *     receive the short-lived access token so the SPA can hydrate its
  *     localStorage mirror while route auth remains synchronous.
@@ -24,10 +25,7 @@
  * to `/api/auth/steward-session` continue to work during the rollout window.
  */
 
-import {
-  STEWARD_AUTHED_COOKIE,
-  type StewardSessionErrorCode,
-} from "@elizaos/shared/steward-session-client";
+import type { StewardSessionErrorCode } from "@elizaos/shared/steward-session-client";
 import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
@@ -37,7 +35,10 @@ import {
   type StewardVerifyEnv,
   verifyStewardTokenCached,
 } from "@/lib/auth/steward-client";
-import { stewardCookieNames } from "@/lib/auth/steward-cookies";
+import {
+  LEGACY_STEWARD_COOKIES,
+  stewardCookieNames,
+} from "@/lib/auth/steward-cookies";
 import { signStewardMutatingRequest } from "@/lib/steward/sign";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -388,7 +389,8 @@ app.post("/", async (c) => {
       const opts = domain ? { path: "/", domain } : { path: "/" };
       deleteCookie(c, cookieNames.token, opts);
       deleteCookie(c, cookieNames.refreshToken, opts);
-      deleteCookie(c, STEWARD_AUTHED_COOKIE, opts);
+      deleteCookie(c, cookieNames.authed, opts);
+      deleteCookie(c, LEGACY_STEWARD_COOKIES.authed, opts);
       return c.json(errorBody("Refresh token rejected", "invalid_token"), 401);
     }
     return c.json(
@@ -431,7 +433,7 @@ app.post("/", async (c) => {
     });
   }
 
-  setCookie(c, STEWARD_AUTHED_COOKIE, "1", {
+  setCookie(c, cookieNames.authed, "1", {
     httpOnly: false,
     secure,
     sameSite: "Lax",

--- a/packages/cloud/api/auth/steward-session/route.ts
+++ b/packages/cloud/api/auth/steward-session/route.ts
@@ -3,11 +3,10 @@
  * DELETE /api/auth/steward-session — clear steward cookies (logout).
  */
 
-import {
-  STEWARD_AUTHED_COOKIE,
-  type StewardSessionErrorCode,
-  type StewardSessionRequest,
-  type StewardSessionResponse,
+import type {
+  StewardSessionErrorCode,
+  StewardSessionRequest,
+  StewardSessionResponse,
 } from "@elizaos/shared/steward-session-client";
 import { Hono } from "hono";
 import { deleteCookie, setCookie } from "hono/cookie";
@@ -254,7 +253,9 @@ app.post("/", async (c) => {
     const secure = c.env.NODE_ENV === "production";
     const domain = cookieDomainForHost(c.req.header("host"));
 
-    setCookie(c, stewardCookieNames(c.env.ENVIRONMENT).token, token, {
+    const cookieNames = stewardCookieNames(c.env.ENVIRONMENT);
+
+    setCookie(c, cookieNames.token, token, {
       httpOnly: true,
       secure,
       sameSite: "Lax",
@@ -264,22 +265,17 @@ app.post("/", async (c) => {
     });
 
     if (typeof refreshToken === "string" && refreshToken.length > 0) {
-      setCookie(
-        c,
-        stewardCookieNames(c.env.ENVIRONMENT).refreshToken,
-        refreshToken,
-        {
-          httpOnly: true,
-          secure,
-          sameSite: "Lax",
-          path: "/",
-          ...(domain ? { domain } : {}),
-          maxAge: STEWARD_REFRESH_COOKIE_MAX_AGE,
-        },
-      );
+      setCookie(c, cookieNames.refreshToken, refreshToken, {
+        httpOnly: true,
+        secure,
+        sameSite: "Lax",
+        path: "/",
+        ...(domain ? { domain } : {}),
+        maxAge: STEWARD_REFRESH_COOKIE_MAX_AGE,
+      });
     }
 
-    setCookie(c, STEWARD_AUTHED_COOKIE, "1", {
+    setCookie(c, cookieNames.authed, "1", {
       httpOnly: false,
       secure,
       sameSite: "Lax",
@@ -340,13 +336,15 @@ app.delete("/", (c) => {
   // Sign-out must clear BOTH naming eras, exactly like /logout: this DELETE is
   // the clear path clearStaleStewardSession uses, and a pre-rename session
   // whose legacy pair survives here gets resurrected by the legacy read
-  // fallback + 30-day legacy refresh cookie (ghost session). (#13728)
+  // fallback + 30-day legacy refresh cookie (ghost session). The legacy read
+  // fallback itself shuts off after 2026-08-04. (#13728)
   const names = stewardCookieNames(c.env.ENVIRONMENT);
   deleteCookie(c, names.token, opts);
   deleteCookie(c, names.refreshToken, opts);
   deleteCookie(c, LEGACY_STEWARD_COOKIES.token, opts);
   deleteCookie(c, LEGACY_STEWARD_COOKIES.refreshToken, opts);
-  deleteCookie(c, STEWARD_AUTHED_COOKIE, opts);
+  deleteCookie(c, names.authed, opts);
+  deleteCookie(c, LEGACY_STEWARD_COOKIES.authed, opts);
   logStewardAuth("deleted", null);
   return c.json({ ok: true });
 });

--- a/packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
@@ -18,8 +18,10 @@ describe("stewardCookieNames", () => {
     expect(staging).toEqual({
       token: "steward-token-staging",
       refreshToken: "steward-refresh-token-staging",
+      authed: "steward-authed-staging",
     });
     expect(staging.token).not.toBe(LEGACY_STEWARD_COOKIES.token);
     expect(staging.refreshToken).not.toBe(LEGACY_STEWARD_COOKIES.refreshToken);
+    expect(staging.authed).not.toBe(LEGACY_STEWARD_COOKIES.authed);
   });
 });

--- a/packages/cloud/shared/src/lib/auth/steward-cookies.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-cookies.ts
@@ -16,10 +16,12 @@
 export interface StewardCookieNames {
   token: string;
   refreshToken: string;
+  authed: string;
 }
 
 const BASE_TOKEN = "steward-token";
 const BASE_REFRESH = "steward-refresh-token";
+const BASE_AUTHED = "steward-authed";
 
 /**
  * The historical unsuffixed names: production's live names, and on
@@ -30,6 +32,7 @@ const BASE_REFRESH = "steward-refresh-token";
 export const LEGACY_STEWARD_COOKIES: StewardCookieNames = {
   token: BASE_TOKEN,
   refreshToken: BASE_REFRESH,
+  authed: BASE_AUTHED,
 };
 
 /** Resolve the cookie names for a Worker environment (`c.env.ENVIRONMENT`).
@@ -42,5 +45,6 @@ export function stewardCookieNames(environment: string | undefined): StewardCook
   return {
     token: `${BASE_TOKEN}-${environment}`,
     refreshToken: `${BASE_REFRESH}-${environment}`,
+    authed: `${BASE_AUTHED}-${environment}`,
   };
 }

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
@@ -24,7 +24,9 @@ import {
   verifyPlaywrightTestSessionToken,
 } from "./playwright-test-session";
 import { verifyStewardTokenCached } from "./steward-client";
-import { stewardCookieNames } from "./steward-cookies";
+import { LEGACY_STEWARD_COOKIES, stewardCookieNames } from "./steward-cookies";
+
+const LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS = Date.UTC(2026, 7, 4);
 
 function readStewardCookie(c: AppContext): string | null {
   const names = stewardCookieNames(c.env?.ENVIRONMENT);
@@ -33,11 +35,17 @@ function readStewardCookie(c: AppContext): string | null {
   // locally (jose), never rotating or invalidating the shared legacy refresh
   // token, so a non-prod read of prod's legacy cookie cannot sign prod out
   // (#13728). On production the two names are identical. Legacy cookies expire
-  // naturally; nothing here deletes them.
-  return (
-    readCookie(c, names.token) ??
-    (names.token === "steward-token" ? null : readCookie(c, "steward-token"))
-  );
+  // naturally; the fallback shuts off after 2026-08-04, one 30-day refresh
+  // cookie Max-Age after the 2026-07-05 scoped-cookie follow-up.
+  const ownCookie = readCookie(c, names.token);
+  if (ownCookie) return ownCookie;
+  if (
+    names.token === LEGACY_STEWARD_COOKIES.token ||
+    Date.now() >= LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS
+  ) {
+    return null;
+  }
+  return readCookie(c, LEGACY_STEWARD_COOKIES.token) ?? null;
 }
 
 function readCookie(c: AppContext, name: string): string | null {

--- a/packages/shared/src/steward-session-client/index.test.ts
+++ b/packages/shared/src/steward-session-client/index.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { hasStewardAuthedCookie, stewardAuthedCookieName } from "./index";
+
+function stubDocumentCookie(cookie: string): void {
+  vi.stubGlobal("document", { cookie });
+}
+
+describe("steward session marker cookie", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps production and unset environments on the historical marker", () => {
+    expect(stewardAuthedCookieName()).toBe("steward-authed");
+    expect(stewardAuthedCookieName("production")).toBe("steward-authed");
+  });
+
+  it("suffixes non-production marker cookies by environment", () => {
+    expect(stewardAuthedCookieName("staging")).toBe("steward-authed-staging");
+    expect(stewardAuthedCookieName("dev")).toBe("steward-authed-dev");
+  });
+
+  it("does not let a staging page trust the production marker", () => {
+    stubDocumentCookie("steward-authed=1");
+    expect(hasStewardAuthedCookie("staging")).toBe(false);
+
+    stubDocumentCookie("steward-authed-staging=1; steward-authed=1");
+    expect(hasStewardAuthedCookie("staging")).toBe(true);
+  });
+});

--- a/packages/shared/src/steward-session-client/index.ts
+++ b/packages/shared/src/steward-session-client/index.ts
@@ -175,11 +175,40 @@ export function clearStoredStewardToken(): void {
  * present. The JWT cookie itself is HttpOnly, so JS uses this hint to know
  * "there is a server session" without ever touching the token.
  */
-export function hasStewardAuthedCookie(): boolean {
+export function stewardAuthedCookieName(environment?: string | null): string {
+  const env = environment?.trim();
+  if (!env || env === "production") return STEWARD_AUTHED_COOKIE;
+  return `${STEWARD_AUTHED_COOKIE}-${env}`;
+}
+
+function inferStewardCookieEnvironment(): string | null {
+  if (typeof window === "undefined") return null;
+  const hostname = window.location.hostname.toLowerCase();
+  if (
+    hostname === "staging.elizacloud.ai" ||
+    hostname === "app-staging.elizacloud.ai" ||
+    hostname === "api-staging.elizacloud.ai"
+  ) {
+    return "staging";
+  }
+  if (
+    hostname === "dev.elizacloud.ai" ||
+    hostname === "app-dev.elizacloud.ai" ||
+    hostname === "api-dev.elizacloud.ai"
+  ) {
+    return "dev";
+  }
+  return null;
+}
+
+export function hasStewardAuthedCookie(environment?: string | null): boolean {
   if (typeof document === "undefined") return false;
+  const cookieName = stewardAuthedCookieName(
+    environment ?? inferStewardCookieEnvironment(),
+  );
   return document.cookie
     .split(";")
-    .some((part) => part.trim().startsWith(`${STEWARD_AUTHED_COOKIE}=1`));
+    .some((part) => part.trim().startsWith(`${cookieName}=1`));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Env-scope the non-HttpOnly Steward marker cookie through the existing `stewardCookieNames(c.env.ENVIRONMENT)` helper, keeping production on `steward-authed` and non-production on names like `steward-authed-staging`.
- Update session exchange, nonce exchange, refresh invalid-token cleanup, logout, and DELETE session cleanup to set/delete the scoped marker and the legacy marker where needed.
- Add a dated cutoff for the legacy access-token read fallback: 2026-08-04, one 30-day refresh-cookie Max-Age after this 2026-07-05 follow-up.
- Add focused coverage for the cookie-name helper, browser marker helper, and staging delete cleanup.

## Verification
- Head SHA: `aca6a31fca6ad11c7bdb111b998a8cbe5476518b`
- `bun install --frozen-lockfile --ignore-scripts`
- `bun test packages/cloud/shared/src/lib/auth/steward-cookies.test.ts`
- `bun run --cwd packages/shared test -- src/steward-session-client/index.test.ts`
- `bun run --cwd packages/cloud/routing build`
- `bun run --cwd packages/shared build:i18n`
- `bun run --cwd packages/logger build`
- `bun run --cwd packages/contracts build`
- `bun run --cwd packages/core build:node`
- `bun test packages/cloud/api/__tests__/steward-session-delete-clears-both-cookie-eras.test.ts`
- `bunx biome check packages/cloud/shared/src/lib/auth/steward-cookies.ts packages/cloud/shared/src/lib/auth/steward-cookies.test.ts packages/cloud/shared/src/lib/auth/workers-hono-auth.ts packages/cloud/api/auth/steward-session/route.ts packages/cloud/api/auth/steward-refresh/route.ts packages/cloud/api/auth/steward-nonce-exchange/route.ts packages/cloud/api/auth/logout/route.ts packages/cloud/api/__tests__/steward-session-delete-clears-both-cookie-eras.test.ts packages/shared/src/steward-session-client/index.ts packages/shared/src/steward-session-client/index.test.ts`
- `git diff --check`
- `bun run --cwd packages/shared typecheck`
- `bun run --cwd packages/cloud/shared typecheck`

Known unrelated failure:
- `bun run --cwd packages/cloud/api typecheck` fails in `__tests__/my-agents-claim-affiliate-characters.test.ts` because the imported route default can return `Response | Promise<Response>` while the fixture expects `Promise<Response>`. None of the changed Steward auth files are named in that failure.

## Evidence
- `.github/issue-evidence/13848-steward-cookie-scope.md`
- Screenshots/video: N/A - backend cookie naming/auth-session helper change, no rendered UI changed.
- Live LLM trajectories: N/A - no agent/action/provider/prompt/model behavior changed.
- DB/migration artifacts: N/A - no schema, migration, or DB write path changed.

Closes #13848