### PR TITLE
fix(#13772): align capacity overview contract

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-capacity-route.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-capacity-route.test.ts
@@ -2,8 +2,9 @@
  * Guards GET /api/orchestrator/capacity on two fronts:
  *  1. The path template is REGISTERED in the runtime route matcher, so the
  *     handler is reachable over real HTTP (an unregistered handler 404s).
- *  2. The handler returns the AcpService.getCapacity() shape, and honestly 503s
- *     when the ACP service is absent instead of fabricating a healthy count.
+ *  2. The handler returns the task-service capacity overview: ACP capacity plus
+ *     admission queue metadata. When ACP is absent it renders a zero-capacity
+ *     unavailable shape, not a fabricated healthy count.
  * Deterministic harness: a hand-built RouteContext, no live subprocess.
  */
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -13,13 +14,16 @@ import { handleOrchestratorRoutes } from "../../src/api/orchestrator-routes.js";
 import type { RouteContext } from "../../src/api/route-utils.js";
 import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
-import { codingAgentRoutePlugin } from "../../src/setup-routes.ts";
 import type { AcpCapacity } from "../../src/services/types.js";
+import { codingAgentRoutePlugin } from "../../src/setup-routes.ts";
 
-function makeService(): OrchestratorTaskService {
+function makeService(capacity: AcpCapacity | null): OrchestratorTaskService {
+  const acp = capacity
+    ? { getCapacity: () => Promise.resolve(capacity) }
+    : null;
   return new OrchestratorTaskService(
     {
-      getService: () => null,
+      getService: () => acp,
       getSetting: () => undefined,
       logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     } as never,
@@ -27,19 +31,14 @@ function makeService(): OrchestratorTaskService {
   );
 }
 
-function ctxWith(
-  service: OrchestratorTaskService,
-  capacity: AcpCapacity | null,
-): RouteContext {
+function ctxWith(service: OrchestratorTaskService): RouteContext {
   return {
     runtime: {
       getService: () => service,
       hasService: () => true,
       getServiceLoadPromise: () => Promise.resolve(undefined),
     },
-    acpService: capacity
-      ? { getCapacity: () => Promise.resolve(capacity) }
-      : null,
+    acpService: null,
     workspaceService: null,
   } as never;
 }
@@ -84,7 +83,7 @@ describe("GET /api/orchestrator/capacity", () => {
     expect(registered).toBe(true);
   });
 
-  it("returns the AcpService capacity shape", async () => {
+  it("returns the capacity overview shape", async () => {
     const capacity: AcpCapacity = {
       maxSessions: 8,
       systemHeadroom: 2,
@@ -93,13 +92,27 @@ describe("GET /api/orchestrator/capacity", () => {
       freeWorkerSlots: 0,
       freeSystemSlots: 1,
     };
-    const res = await get(ctxWith(makeService(), capacity));
+    const res = await get(ctxWith(makeService(capacity)));
     expect(res.statusCode === 0 || res.statusCode === 200).toBe(true);
-    expect(res.json()).toEqual(capacity);
+    expect(res.json()).toEqual({
+      ...capacity,
+      queueDepth: 0,
+      queue: [],
+    });
   });
 
-  it("503s when the ACP service is unavailable (never fabricates a count)", async () => {
-    const res = await get(ctxWith(makeService(), null));
-    expect(res.statusCode).toBe(503);
+  it("returns zero-capacity overview when ACP is unavailable", async () => {
+    const res = await get(ctxWith(makeService(null)));
+    expect(res.statusCode === 0 || res.statusCode === 200).toBe(true);
+    expect(res.json()).toEqual({
+      maxSessions: 0,
+      systemHeadroom: 0,
+      activeWorkers: 0,
+      activeSystem: 0,
+      freeWorkerSlots: 0,
+      freeSystemSlots: 0,
+      queueDepth: 0,
+      queue: [],
+    });
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-capacity-slot-class.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-capacity-slot-class.test.ts
@@ -56,7 +56,9 @@ describe("AcpService slot-class capacity (#13772)", () => {
     const svc = await serviceWith([]);
     const cap = await svc.getCapacity();
     expect(cap.maxSessions).toBe(8);
+    expect(cap.systemHeadroom).toBe(2);
     expect(cap.freeWorkerSlots).toBe(8);
+    expect(cap.freeSystemSlots).toBe(2);
     expect(cap.activeWorkers).toBe(0);
     expect(cap.activeSystem).toBe(0);
   });
@@ -81,8 +83,8 @@ describe("AcpService slot-class capacity (#13772)", () => {
   });
 
   it("freeWorkerSlots reflects WORKER headroom only, never system saturation", async () => {
-    // Fill system headroom (2) but leave 1 worker slot free — freeWorkerSlots must
-    // still be 1, so the admission queue sees room for a worker.
+    // Fill system headroom (2) but leave 1 worker slot free — freeWorkerSlots
+    // must still be 1, so the admission queue sees room for a worker.
     const svc = await serviceWith(
       [
         session("w1", "worker"),
@@ -95,6 +97,7 @@ describe("AcpService slot-class capacity (#13772)", () => {
     expect(cap.activeWorkers).toBe(1);
     expect(cap.activeSystem).toBe(2);
     expect(cap.freeWorkerSlots).toBe(1);
+    expect(cap.freeSystemSlots).toBe(0);
   });
 
   it("throws a typed SessionCapError code string for callers to match", () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/admission-integration.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admission-integration.test.ts
@@ -77,9 +77,11 @@ class FakeAcp {
     const { workers, system } = this.countByClass();
     return {
       maxSessions: this.maxSessions,
+      systemHeadroom: this.systemHeadroom,
       activeWorkers: workers,
       activeSystem: system,
       freeWorkerSlots: Math.max(0, this.maxSessions - workers),
+      freeSystemSlots: Math.max(0, this.systemHeadroom - system),
     };
   }
 

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -244,7 +244,11 @@ function capacityData(
   if (!capacity) return null;
   return {
     maxSessions: capacity.maxSessions,
+    systemHeadroom: capacity.systemHeadroom,
     activeWorkers: capacity.activeWorkers,
+    activeSystem: capacity.activeSystem,
+    freeWorkerSlots: capacity.freeWorkerSlots,
+    freeSystemSlots: capacity.freeSystemSlots,
     queueDepth: admission?.queueDepth ?? 0,
     queuedTaskIds: admission?.queuedTaskIds ?? [],
   };
@@ -255,9 +259,9 @@ interface AdmissionSnapshot {
   queuedTaskIds: string[];
 }
 
-async function readCapacity(
-  service: { getCapacity?: () => Promise<AcpCapacity> },
-): Promise<AcpCapacity | null> {
+async function readCapacity(service: {
+  getCapacity?: () => Promise<AcpCapacity>;
+}): Promise<AcpCapacity | null> {
   if (typeof service.getCapacity !== "function") return null;
   try {
     return await service.getCapacity();

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -964,11 +964,11 @@ export class AcpService extends Service {
     }
 
     const now = new Date();
-    // Persist the admission pool on the session so `enforceSessionLimit` and
-    // `getCapacity` can tell worker from system slots by reading the store
-    // (survives restart); a session missing it predates slot classes and counts
-    // as a worker.
-    const slotClass = opts.slotClass ?? "worker";
+    // Stamp the capacity class onto the session so getCapacity() (and the
+    // admission queue that reads it) can count worker vs system slots off the
+    // durable record. Always persisted — a worker session carries slotClass so
+    // the accounting never has to infer "worker" from an absent field.
+    const slotClass: SessionSlotClass = opts.slotClass ?? "worker";
     const mergedMetadata: Record<string, unknown> = {
       ...(opts.metadata ?? {}),
       ...(baselineSha ? { codingBaselineSha: baselineSha } : {}),
@@ -989,9 +989,10 @@ export class AcpService extends Service {
       lastActivityAt: now,
       metadata: mergedMetadata,
     };
-    // Atomic check-and-reserve: enforces the session limit and inserts under a
-    // single mutex so concurrent spawns can't overshoot the cap (the old
-    // separate enforceSessionLimit()/store.create() left a read-then-act race).
+    // Atomic check-and-reserve: enforces the session limit for this slot class
+    // and inserts under a single mutex so concurrent spawns can't overshoot the
+    // cap (the old separate enforceSessionLimit()/store.create() left a
+    // read-then-act race). Throws SessionCapError when the class is full.
     await this.reserveSessionSlot(session, slotClass);
 
     // Mint the per-spawn model lease BEFORE the transport branch, so the leased

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -93,7 +93,6 @@ import {
   toTaskTimelineMessageDto,
 } from "./orchestrator-task-mapper.js";
 import { OrchestratorTaskStore } from "./orchestrator-task-store.js";
-import { resolveTaskProjectId } from "./project-binding.js";
 import {
   type AttemptReflection,
   type CreateTaskInput,
@@ -124,6 +123,7 @@ import {
   isParentAgentBrokerWired,
   PARENT_AGENT_BROKER_MANIFEST_ENTRY,
 } from "./parent-agent-broker.js";
+import { resolveTaskProjectId } from "./project-binding.js";
 import { buildSkillsManifest } from "./skill-manifest.js";
 import {
   configureSpendLedger,
@@ -3786,9 +3786,11 @@ export class OrchestratorTaskService extends Service {
    */
   async getCapacityOverview(): Promise<{
     maxSessions: number;
+    systemHeadroom: number;
     activeWorkers: number;
     activeSystem: number;
-    freeSlots: number;
+    freeWorkerSlots: number;
+    freeSystemSlots: number;
     queueDepth: number;
     queue: Array<{
       taskId: string;
@@ -3802,9 +3804,11 @@ export class OrchestratorTaskService extends Service {
       ? await acp.getCapacity()
       : {
           maxSessions: 0,
+          systemHeadroom: 0,
           activeWorkers: 0,
           activeSystem: 0,
           freeWorkerSlots: 0,
+          freeSystemSlots: 0,
         };
     const entries = orderQueue(
       await this.currentQueueEntries(),
@@ -3813,9 +3817,11 @@ export class OrchestratorTaskService extends Service {
     );
     return {
       maxSessions: capacity.maxSessions,
+      systemHeadroom: capacity.systemHeadroom,
       activeWorkers: capacity.activeWorkers,
       activeSystem: capacity.activeSystem,
-      freeSlots: capacity.freeWorkerSlots,
+      freeWorkerSlots: capacity.freeWorkerSlots,
+      freeSystemSlots: capacity.freeSystemSlots,
       queueDepth: entries.length,
       queue: entries.map((entry, index) => ({
         taskId: entry.taskId,

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -64,20 +64,6 @@ export const TERMINAL_SESSION_STATUSES: ReadonlySet<string> = new Set([
   "cancelled",
 ]);
 
-/**
- * Thrown by the orchestrator's admission queue when a cap-parked spawn would
- * exceed `ELIZA_ACP_ADMISSION_QUEUE_DEPTH`. Distinct from `SessionCapError`: the
- * cap is transient (a slot will free), but a full queue is back-pressure the
- * caller must see (mapped to HTTP 429 at the route).
- */
-export class AdmissionQueueFullError extends Error {
-  readonly code = "ADMISSION_QUEUE_FULL";
-  constructor(readonly depth: number) {
-    super(`orchestrator admission queue is full (${depth})`);
-    this.name = "AdmissionQueueFullError";
-  }
-}
-
 export type SessionEventCallback = (
   sessionId: string,
   event: SessionEventName,
@@ -137,6 +123,22 @@ export class SessionCapError extends Error {
     this.slotClass = slotClass;
     this.maxSessions = maxSessions;
     this.activeCount = activeCount;
+  }
+}
+
+/**
+ * Thrown by the orchestrator's admission queue when a cap-parked spawn would
+ * exceed `ELIZA_ACP_ADMISSION_QUEUE_DEPTH`. Distinct from `SessionCapError`: the
+ * cap is transient (a slot will free), but a full queue is back-pressure the
+ * caller must see (mapped to HTTP 429 at the route).
+ */
+export class AdmissionQueueFullError extends Error {
+  readonly code = "ADMISSION_QUEUE_FULL" as const;
+  readonly depth: number;
+  constructor(depth: number) {
+    super(`orchestrator admission queue is full (${depth})`);
+    this.name = "AdmissionQueueFullError";
+    this.depth = depth;
   }
 }
 


### PR DESCRIPTION
## Summary
- Aligns the post-#13841 capacity overview contract with the existing `AcpCapacity` shape.
- Keeps worker/system slot accounting explicit via `freeWorkerSlots`, `freeSystemSlots`, and `systemHeadroom`.
- Routes `/api/orchestrator/capacity` through the task-service overview so queue state and capacity state are returned together.
- Updates providers and focused tests away from the pre-merge `freeSlots` shape.

Follow-up to merged #13841 for #13772.

## Verification
- `bun test plugins/plugin-agent-orchestrator/src/__tests__/admission-queue.test.ts plugins/plugin-agent-orchestrator/src/__tests__/admission-integration.test.ts plugins/plugin-agent-orchestrator/src/__tests__/acp-capacity-slot-class.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-capacity-route.test.ts`
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-capacity-route.test.ts plugins/plugin-agent-orchestrator/src/__tests__/acp-capacity-slot-class.test.ts plugins/plugin-agent-orchestrator/src/__tests__/admission-integration.test.ts plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts plugins/plugin-agent-orchestrator/src/services/types.ts`
- `bun run audit:error-policy-ratchet`
- `git diff --check`