### PR TITLE
fix(#13422): migrate app-core boot-critical aliased env reads to the alias-aware reader (P2)

### DIFF
--- a/packages/app-core/src/alias-env-reads.13422.test.ts
+++ b/packages/app-core/src/alias-env-reads.13422.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Proves the P2 boot-critical env reads migrated to the alias-aware reader in
+ * #13422 keep the security contract: a branded `MILADY_<KEY>` resolves through
+ * the real migrated call sites, the canonical `ELIZA_<KEY>` still wins when both
+ * are set, and resolution never materializes the `ELIZA_` mirror on
+ * `process.env` (the property the issue exists to guarantee — see
+ * `packages/shared/src/utils/env.ts`). Drives the actual exported functions
+ * (vault-id state-dir derivation, the steward sidecar factory, steward
+ * credential load, edge-TTS disable) plus the startEliza port/orchestrator
+ * decision expressions, not the reader in isolation.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  getBootConfig,
+  readAliasedEnv,
+  resolveDesktopApiPort,
+  resolveServerOnlyPort,
+  setBootConfig,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  isTextToSpeechProviderDisabled,
+  type TextToSpeechProviderConfig,
+} from "./runtime/tts-provider-registry.ts";
+import {
+  deriveAgentVaultId,
+  resolveCanonicalStateDir,
+} from "./security/agent-vault-id.ts";
+import type { PlatformSecureStore } from "./security/platform-secure-store.ts";
+import { loadStewardCredentials } from "./services/steward-credentials.ts";
+import { createDesktopStewardSidecar } from "./services/steward-sidecar.ts";
+
+const BRAND = "MILADY";
+
+// The exact P2 partition keys migrated in #13422, paired with the branded
+// prefix a Milady deployment sets. Resolution must never write the ELIZA_ side.
+const ALIAS_PAIRS: Array<readonly [string, string]> = [
+  [`${BRAND}_STATE_DIR`, "ELIZA_STATE_DIR"],
+  [`${BRAND}_NAMESPACE`, "ELIZA_NAMESPACE"],
+  [`${BRAND}_AGENT_ORCHESTRATOR`, "ELIZA_AGENT_ORCHESTRATOR"],
+  [`${BRAND}_API_PORT`, "ELIZA_API_PORT"],
+  [`${BRAND}_DISABLE_EDGE_TTS`, "ELIZA_DISABLE_EDGE_TTS"],
+];
+const TRACKED = [
+  ...new Set([
+    ...ALIAS_PAIRS.flat(),
+    "XDG_STATE_HOME",
+    "STEWARD_DATA_DIR",
+    // Cleared so the server-only-port default (2138) is deterministic.
+    "ELIZA_PORT",
+    "ELIZA_UI_PORT",
+  ]),
+];
+
+const savedConfig = getBootConfig();
+const savedEnv: Record<string, string | undefined> = {};
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "milady-13422-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+// A secure store whose backend is unavailable, so credential load falls to the
+// plaintext metadata file — the path we exercise here. Injected via the
+// function's own `secureStore` option, so it is a dependency stand-in, not a
+// stub of the code under test.
+const unavailableSecureStore: PlatformSecureStore = {
+  backend: "none",
+  get: async () => ({ ok: false, reason: "unavailable" }),
+  set: async () => ({ ok: false, reason: "unavailable" }),
+  delete: async () => {},
+  isAvailable: async () => false,
+};
+
+beforeEach(() => {
+  for (const key of TRACKED) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  // Pin the alias table on the immutable BootConfig, exactly as the branded app
+  // boot does — this is what makes MILADY_* resolvable without the env mirror.
+  setBootConfig({ ...savedConfig, envAliases: ALIAS_PAIRS });
+});
+
+afterEach(() => {
+  for (const key of TRACKED) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  setBootConfig(savedConfig);
+});
+
+afterEach(() => {
+  while (tempDirs.length) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("agent-vault-id state dir (ELIZA_STATE_DIR + ELIZA_NAMESPACE)", () => {
+  it("derives the canonical state dir from a branded MILADY_STATE_DIR without the mirror", () => {
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+
+    expect(resolveCanonicalStateDir()).toBe("/var/milady/state");
+    // The vault id is a deterministic hash of that resolved dir — proves the
+    // branded value actually flowed into the keychain namespace.
+    expect(deriveAgentVaultId()).toBe(deriveAgentVaultId("/var/milady/state"));
+    // Security property: the read must not synthesize the ELIZA_ mirror.
+    expect(process.env.ELIZA_STATE_DIR).toBeUndefined();
+  });
+
+  it("prefers the canonical ELIZA_STATE_DIR over the branded alias", () => {
+    process.env.ELIZA_STATE_DIR = "/var/eliza/state";
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+
+    expect(resolveCanonicalStateDir()).toBe("/var/eliza/state");
+  });
+
+  it("derives the state dir from a branded MILADY_NAMESPACE", () => {
+    const xdg = makeTempDir();
+    process.env.XDG_STATE_HOME = xdg;
+    process.env.MILADY_NAMESPACE = "miladybrand";
+
+    expect(resolveCanonicalStateDir()).toBe(path.join(xdg, "miladybrand"));
+    expect(process.env.ELIZA_NAMESPACE).toBeUndefined();
+  });
+});
+
+describe("steward sidecar data dir (ELIZA_NAMESPACE)", () => {
+  // The sidecar exposes no public data-dir getter, so read the resolved config
+  // it built from the (migrated) namespace read.
+  const dataDirOf = (sidecar: unknown): string =>
+    (sidecar as { config: { dataDir: string } }).config.dataDir;
+
+  it("builds the sidecar data dir from a branded MILADY_NAMESPACE", () => {
+    const xdg = makeTempDir();
+    process.env.XDG_STATE_HOME = xdg;
+    process.env.MILADY_NAMESPACE = "miladybrand";
+
+    const sidecar = createDesktopStewardSidecar();
+    expect(dataDirOf(sidecar)).toBe(path.join(xdg, "miladybrand", "steward"));
+    expect(process.env.ELIZA_NAMESPACE).toBeUndefined();
+  });
+
+  it("prefers the canonical ELIZA_NAMESPACE over the branded alias", () => {
+    const xdg = makeTempDir();
+    process.env.XDG_STATE_HOME = xdg;
+    process.env.ELIZA_NAMESPACE = "elizabrand";
+    process.env.MILADY_NAMESPACE = "miladybrand";
+
+    const sidecar = createDesktopStewardSidecar();
+    expect(dataDirOf(sidecar)).toBe(path.join(xdg, "elizabrand", "steward"));
+  });
+});
+
+describe("steward credentials load (ELIZA_STATE_DIR)", () => {
+  function writeCredentials(dir: string): void {
+    fs.writeFileSync(
+      path.join(dir, "steward-credentials.json"),
+      JSON.stringify({
+        apiUrl: "https://steward.milady.test",
+        tenantId: "tenant-milady",
+        agentId: "agent-milady",
+      }),
+    );
+  }
+
+  it("reads persisted credentials from a branded MILADY_STATE_DIR", async () => {
+    const dir = makeTempDir();
+    writeCredentials(dir);
+    process.env.MILADY_STATE_DIR = dir;
+
+    const creds = await loadStewardCredentials({
+      secureStore: unavailableSecureStore,
+    });
+
+    expect(creds).not.toBeNull();
+    expect(creds?.apiUrl).toBe("https://steward.milady.test");
+    expect(creds?.tenantId).toBe("tenant-milady");
+    expect(creds?.agentId).toBe("agent-milady");
+    expect(process.env.ELIZA_STATE_DIR).toBeUndefined();
+  });
+
+  it("prefers the canonical ELIZA_STATE_DIR over the branded alias", async () => {
+    const branded = makeTempDir();
+    writeCredentials(branded);
+    const canonicalEmpty = makeTempDir(); // no credentials file here
+    process.env.MILADY_STATE_DIR = branded;
+    process.env.ELIZA_STATE_DIR = canonicalEmpty;
+
+    // ELIZA_ wins, so the load looks in the empty dir and finds nothing.
+    const creds = await loadStewardCredentials({
+      secureStore: unavailableSecureStore,
+    });
+    expect(creds).toBeNull();
+  });
+});
+
+describe("edge-TTS disable check (ELIZA_DISABLE_EDGE_TTS)", () => {
+  const config: TextToSpeechProviderConfig = {};
+
+  it("honors a branded MILADY_DISABLE_EDGE_TTS", () => {
+    for (const token of ["1", "true", "yes"]) {
+      process.env.MILADY_DISABLE_EDGE_TTS = token;
+      expect(isTextToSpeechProviderDisabled(config)).toBe(true);
+    }
+  });
+
+  it("stays enabled when unset, and never writes the mirror", () => {
+    expect(isTextToSpeechProviderDisabled(config)).toBe(false);
+    isTextToSpeechProviderDisabled(config);
+    expect(process.env.ELIZA_DISABLE_EDGE_TTS).toBeUndefined();
+  });
+
+  it("prefers the canonical ELIZA_DISABLE_EDGE_TTS over the branded alias", () => {
+    // Canonical "0" wins over branded "1": the feature stays enabled.
+    process.env.ELIZA_DISABLE_EDGE_TTS = "0";
+    process.env.MILADY_DISABLE_EDGE_TTS = "1";
+    expect(isTextToSpeechProviderDisabled(config)).toBe(false);
+  });
+});
+
+describe("startEliza boot decision reads (ELIZA_AGENT_ORCHESTRATOR + ELIZA_API_PORT)", () => {
+  // startEliza boots the whole runtime, so assert the exact alias-aware
+  // expressions its migrated lines evaluate (eliza.ts orchestrator gate + api
+  // port branch), against the real shared resolvers those lines call.
+  it("resolves the orchestrator gate from a branded MILADY_AGENT_ORCHESTRATOR", () => {
+    process.env.MILADY_AGENT_ORCHESTRATOR = "0";
+    expect(readAliasedEnv("ELIZA_AGENT_ORCHESTRATOR")?.toLowerCase()).toBe("0");
+    expect(process.env.ELIZA_AGENT_ORCHESTRATOR).toBeUndefined();
+  });
+
+  it("prefers the canonical ELIZA_AGENT_ORCHESTRATOR over the branded alias", () => {
+    process.env.ELIZA_AGENT_ORCHESTRATOR = "1";
+    process.env.MILADY_AGENT_ORCHESTRATOR = "0";
+    expect(readAliasedEnv("ELIZA_AGENT_ORCHESTRATOR")?.toLowerCase()).toBe("1");
+  });
+
+  it("selects the desktop port when a branded MILADY_API_PORT is set", () => {
+    process.env.MILADY_API_PORT = "7777";
+    // The migrated branch condition (alias-aware) and the resolver it calls.
+    expect(Boolean(readAliasedEnv("ELIZA_API_PORT"))).toBe(true);
+    expect(resolveDesktopApiPort(process.env)).toBe(7777);
+    expect(process.env.ELIZA_API_PORT).toBeUndefined();
+  });
+
+  it("falls back to the server-only port when no API port is configured", () => {
+    expect(Boolean(readAliasedEnv("ELIZA_API_PORT"))).toBe(false);
+    expect(resolveServerOnlyPort(process.env)).toBe(2138);
+  });
+
+  it("prefers the canonical ELIZA_API_PORT over the branded alias", () => {
+    process.env.ELIZA_API_PORT = "8888";
+    process.env.MILADY_API_PORT = "7777";
+    expect(resolveDesktopApiPort(process.env)).toBe(8888);
+  });
+});

--- a/packages/app-core/src/cli/program/register.auth.ts
+++ b/packages/app-core/src/cli/program/register.auth.ts
@@ -21,7 +21,12 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { isLoopbackBindHost, resolveApiBindHost, theme } from "@elizaos/shared";
+import {
+  isLoopbackBindHost,
+  readAliasedEnv,
+  resolveApiBindHost,
+  theme,
+} from "@elizaos/shared";
 import type { Command } from "commander";
 import { runCommandWithRuntime } from "../cli-utils";
 
@@ -36,9 +41,9 @@ const RESET_PROOF_FILENAME = "RESET_PROOF.txt";
  * `resolveStateDir`.
  */
 function resolveElizaStateDir(): string {
-  const explicit = process.env.ELIZA_STATE_DIR?.trim();
+  const explicit = readAliasedEnv("ELIZA_STATE_DIR");
   if (explicit) return path.resolve(explicit);
-  const namespace = process.env.ELIZA_NAMESPACE?.trim() || "eliza";
+  const namespace = readAliasedEnv("ELIZA_NAMESPACE") || "eliza";
   const home =
     process.env.HOME?.trim() ||
     process.env.USERPROFILE?.trim() ||

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -69,6 +69,7 @@ import {
   formatError,
   formatErrorWithStack,
   isMobilePlatform,
+  readAliasedEnv,
   resolveApiExposePort,
   resolveDesktopApiPort,
   resolveServerOnlyPort,
@@ -1637,7 +1638,7 @@ export async function startEliza(
 ): Promise<Awaited<ReturnType<typeof upstreamStartEliza>>> {
   syncAppEnvToEliza();
   // Eliza app: load PTY / coding-swarm orchestration unless explicitly opted out.
-  const orchRaw = process.env.ELIZA_AGENT_ORCHESTRATOR?.trim().toLowerCase();
+  const orchRaw = readAliasedEnv("ELIZA_AGENT_ORCHESTRATOR")?.toLowerCase();
   if (orchRaw !== "0" && orchRaw !== "false" && orchRaw !== "no") {
     process.env.ELIZA_AGENT_ORCHESTRATOR = "1";
   }
@@ -1706,7 +1707,9 @@ export async function startEliza(
       // renderer's hardcoded API base; honor it when present. CLI/server-only
       // mode (no ELIZA_API_PORT) keeps the legacy `resolveServerOnlyPort`
       // default (2138) so this change is transparent for non-desktop users.
-      const apiPort = process.env.ELIZA_API_PORT
+      // The presence check is alias-aware so a branded `MILADY_API_PORT` also
+      // selects the desktop port without relying on the process.env mirror.
+      const apiPort = readAliasedEnv("ELIZA_API_PORT")
         ? resolveDesktopApiPort(process.env)
         : resolveServerOnlyPort(process.env);
       let actualApiPort: number;

--- a/packages/app-core/src/runtime/tts-provider-registry.ts
+++ b/packages/app-core/src/runtime/tts-provider-registry.ts
@@ -8,11 +8,11 @@
  * load); this module also exposes the config/env disable check for the resolved
  * provider.
  */
-import process from "node:process";
 import type { AgentRuntime } from "@elizaos/core";
 import firstPartyRegistry from "@elizaos/registry/first-party/generated.json" with {
   type: "json",
 };
+import { readAliasedEnv } from "@elizaos/shared";
 import {
   type EdgeTtsHandler,
   wrapEdgeTtsHandlerWithFirstLineCache,
@@ -124,11 +124,11 @@ export function isTextToSpeechProviderDisabled(
     return true;
   }
 
-  const raw = process.env ? process.env.ELIZA_DISABLE_EDGE_TTS : undefined;
-  if (!raw || typeof raw !== "string") {
+  const raw = readAliasedEnv("ELIZA_DISABLE_EDGE_TTS");
+  if (!raw) {
     return false;
   }
 
-  const normalized = raw.trim().toLowerCase();
+  const normalized = raw.toLowerCase();
   return normalized === "1" || normalized === "true" || normalized === "yes";
 }

--- a/packages/app-core/src/security/agent-vault-id.ts
+++ b/packages/app-core/src/security/agent-vault-id.ts
@@ -3,26 +3,29 @@
  * the OS keychain. The id is a deterministic sha256 over the canonical state dir
  * (XDG / `ELIZA_STATE_DIR` precedence, realpath-normalized), base64url-truncated
  * behind a stable `mldy1-` prefix, so one install always resolves the same vault
- * and two state dirs never collide. Kept dependency-light for the Electrobun
- * bootstrap path (no `@elizaos/core` barrel import), and pairs the vault id with
- * a secret kind to form the keychain account handle.
+ * and two state dirs never collide. The state-dir logic is inlined rather than
+ * imported from core's heavier composition helpers, and the vault id is paired
+ * with a secret kind to form the keychain account handle.
  */
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
+import { readAliasedEnv } from "@elizaos/shared";
 import type { SecureStoreSecretKind } from "./platform-secure-store";
 
 /** Fixed Keychain / Secret Service “service” identifier (see docs/guides/platform-secure-store.md). */
 export const ELIZA_AGENT_VAULT_SERVICE = "ai.elizaos.agent.vault";
 
-// Keep this dependency-light: platform secure-store modules are imported by
-// Electrobun bootstrap code where pulling the @elizaos/core barrel is costly.
+// Inlined state-dir resolution (rather than core's composition helper) that
+// reads via the alias-aware `readAliasedEnv`, so a branded prefix (e.g.
+// `MILADY_STATE_DIR`) resolves the same vault id without depending on the
+// `syncBrandEnvToEliza` process.env mirror.
 function resolveStateDir(): string {
-  const explicit = process.env.ELIZA_STATE_DIR?.trim();
+  const explicit = readAliasedEnv("ELIZA_STATE_DIR");
   if (explicit) return explicit;
-  const namespace = process.env.ELIZA_NAMESPACE?.trim() || "eliza";
+  const namespace = readAliasedEnv("ELIZA_NAMESPACE") || "eliza";
   const xdgStateHome = process.env.XDG_STATE_HOME?.trim();
   const stateHome = xdgStateHome
     ? path.isAbsolute(xdgStateHome)

--- a/packages/app-core/src/services/steward-credentials.ts
+++ b/packages/app-core/src/services/steward-credentials.ts
@@ -11,20 +11,21 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import { readAliasedEnv } from "@elizaos/shared";
 import type {
   PlatformSecureStore,
   SecureStoreSecretKind,
 } from "../security/platform-secure-store";
 import { createNodePlatformSecureStore } from "../security/platform-secure-store-node";
 
-// Inlined to avoid pulling the @elizaos/core source barrel into consumers
-// that only need state-dir resolution (e.g. the Electrobun bun bundle, which
-// would otherwise transitively bundle plugin-sql, transformers, and onnxruntime).
-// Mirrors the canonical implementation in @elizaos/core's state-dir helper.
+// Inlined mirror of @elizaos/core's state-dir helper so this module doesn't pull
+// the heavier core runtime-composition graph. Env reads go through the
+// alias-aware `readAliasedEnv` so branded prefixes (e.g. `MILADY_STATE_DIR`)
+// resolve without depending on the `syncBrandEnvToEliza` process.env mirror.
 function resolveStateDir(): string {
-  const explicit = process.env.ELIZA_STATE_DIR?.trim();
+  const explicit = readAliasedEnv("ELIZA_STATE_DIR");
   if (explicit) return explicit;
-  const namespace = process.env.ELIZA_NAMESPACE?.trim() || "eliza";
+  const namespace = readAliasedEnv("ELIZA_NAMESPACE") || "eliza";
   const xdgStateHome = process.env.XDG_STATE_HOME?.trim();
   const stateHome = xdgStateHome
     ? path.isAbsolute(xdgStateHome)

--- a/packages/app-core/src/services/steward-sidecar.ts
+++ b/packages/app-core/src/services/steward-sidecar.ts
@@ -29,6 +29,7 @@ import * as childProcess from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { logger } from "@elizaos/core";
+import { readAliasedEnv } from "@elizaos/shared";
 import { waitForHealthy } from "./steward-sidecar/health-check";
 import {
   allocateFirstFreeLoopbackPort,
@@ -527,7 +528,7 @@ export function createDesktopStewardSidecar(
   overrides?: Partial<StewardSidecarConfig>,
 ): StewardSidecar {
   const home = process.env.HOME || process.env.USERPROFILE || "";
-  const namespace = process.env.ELIZA_NAMESPACE?.trim() || "eliza";
+  const namespace = readAliasedEnv("ELIZA_NAMESPACE") || "eliza";
   const xdgStateHome = process.env.XDG_STATE_HOME?.trim();
   const stateHome = xdgStateHome
     ? path.isAbsolute(xdgStateHome)


### PR DESCRIPTION
## Boot-critical slice of #13422 (P2: app-core runtime/services/security/cli)

Migrates the **P2** partition of raw `process.env.<KEY>` reads to the alias-aware reader so branded prefixes (e.g. `MILADY_STATE_DIR`, `MILADY_NAMESPACE`, `MILADY_API_PORT`) resolve **without** relying on the `syncBrandEnvToEliza` `process.env` mirror. The canonical `ELIZA_*` key still wins when both are set, and blank/whitespace values stay unset (empty-is-unset). Non-critical long-tail reads are deferred to other slices.

The mirror mutation itself (`syncBrandEnvToEliza` / `syncElizaEnvToBrand`) is intentionally **left in place** — its removal is #13423.

### Migrated reads
| File | Key(s) | Reader |
| --- | --- | --- |
| `services/steward-sidecar.ts` | `ELIZA_NAMESPACE` | `readAliasedEnv` |
| `services/steward-credentials.ts` | `ELIZA_STATE_DIR`, `ELIZA_NAMESPACE` | `readAliasedEnv` |
| `cli/program/register.auth.ts` | `ELIZA_STATE_DIR`, `ELIZA_NAMESPACE` | `readAliasedEnv` |
| `security/agent-vault-id.ts` | `ELIZA_STATE_DIR`, `ELIZA_NAMESPACE` (vault-id path) | `readAliasedEnv` |
| `runtime/eliza.ts` | `ELIZA_AGENT_ORCHESTRATOR` (read; L1642 write untouched) | `readAliasedEnv` |
| `runtime/eliza.ts` | `ELIZA_API_PORT` (desktop-vs-server-only branch condition) | `readAliasedEnv` + `resolveDesktopApiPort` |
| `runtime/tts-provider-registry.ts` | `ELIZA_DISABLE_EDGE_TTS` | `readAliasedEnv` |

All keys verified against `packages/shared/src/config/brand-env-aliases.ts`. No skipped reads — every listed read is a genuine alias-table key and was migrated.

### Notes
- `steward-credentials.ts` and `agent-vault-id.ts` carried comments about avoiding the `@elizaos/core` barrel for the Electrobun bundle. That concern is stale/moot: `@elizaos/core` pulls none of the feared heavy deps (plugin-sql/transformers/onnxruntime), the Electrobun bundle already resolves both `@elizaos/core` and `@elizaos/shared`, and steward-credentials is consumed via the full `@elizaos/app-core` dynamic import anyway. The now-inaccurate comments were corrected to reflect that env reads go through the alias-aware reader.
- `tts-provider-registry.ts`: removed the now-unused `import process from "node:process"` (the `process.env` presence guard is handled inside `readAliasedEnv`).

## Evidence

**Test:** `packages/app-core/src/alias-env-reads.13422.test.ts` drives the **real migrated call sites** (not the reader in isolation): vault-id state-dir derivation, the steward sidecar factory, steward credential load from disk, the edge-TTS disable check, and the `startEliza` port/orchestrator decision expressions. Each key proves (a) a branded `MILADY_<KEY>` resolves, (b) the canonical `ELIZA_<KEY>` wins when both are set, and (c) **zero** `ELIZA_` mirror writes to `process.env`.

```
$ bunx vitest run src/alias-env-reads.13422.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

**Fail-before proof** (reverting `agent-vault-id.ts` to the raw `process.env.ELIZA_STATE_DIR` read):
```
 × derives the canonical state dir from a branded MILADY_STATE_DIR without the mirror
 × derives the state dir from a branded MILADY_NAMESPACE
      Tests  2 failed | 13 passed (15)
```
Restoring the migration → 15/15 pass. Sibling suites (`agent-vault-id.test.ts`, `steward-credentials.test.ts`, `tts-provider-registry.test.ts`) + the new test: **32 passed**, no regressions.

**Typecheck:** package-local `typecheck` shows no new errors in touched files — the only lines matching are pre-existing environment noise (missing `commander`/`drizzle-orm`/`jose` declaration files from the worktree `dist/node_modules`, absent optional plugins), identical to what unmodified files already report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)