### PR TITLE
fix(app): encapsulate iOS smoke host agent

### DIFF
--- a/.github/issue-evidence/13574-host-agent-lanes/README.md
+++ b/.github/issue-evidence/13574-host-agent-lanes/README.md
@@ -1,0 +1,83 @@
+# #13574 host-agent lane encapsulation evidence
+
+## Change
+
+- Added `packages/app/scripts/lib/host-agent.mjs`, a shared helper that starts `packages/app-core/scripts/serve-real-local-agent.ts`, chooses `:31338` or a free port, waits for `/api/health`, writes `host-agent.log` into the lane artifact directory, and tears down the child process.
+- `ios-onboarding-smoke.mjs` and `ios-attachment-smoke.mjs` now start that helper by default when `--api-base` is omitted. Existing `--api-base` callers still own the server.
+- `mobile-local-chat-smoke.mjs` gained explicit `--start-host-agent` / `--host-agent-port` flags.
+- `.github/workflows/mobile-build-smoke.yml` now calls the script lanes directly instead of carrying three copies of host-agent boot/poll/cleanup shell.
+
+## Verification run locally
+
+```bash
+node --check packages/app/scripts/lib/host-agent.mjs
+node --check packages/app/scripts/lib/host-agent.test.mjs
+node --check packages/app/scripts/ios-onboarding-smoke.mjs
+node --check packages/app/scripts/ios-attachment-smoke.mjs
+node --check packages/app/scripts/mobile-local-chat-smoke.mjs
+```
+
+Result: passed.
+
+```bash
+bun run --cwd packages/app test -- scripts/lib/host-agent.test.mjs
+```
+
+Result: passed, 1 file / 4 tests. The test starts a real child HTTP process, waits for `/api/health`, verifies `ELIZA_PAIRING_DISABLED=1`, writes `host-agent.log`, stops the child, and proves the port is closed.
+
+```bash
+bunx biome check packages/app/scripts/lib/host-agent.mjs packages/app/scripts/lib/host-agent.test.mjs packages/app/scripts/ios-onboarding-smoke.mjs packages/app/scripts/ios-attachment-smoke.mjs packages/app/scripts/mobile-local-chat-smoke.mjs .github/workflows/mobile-build-smoke.yml
+git diff --check
+```
+
+Result: passed.
+
+```bash
+bun run verify
+```
+
+Result: failed before package typecheck/lint in `audit:type-safety-ratchet` on repo-wide baseline drift unrelated to this patch:
+
+- `as unknown as`: 74 current > 73 baseline.
+- `?? []` in core/agent/app-core: 582 current > 581 baseline.
+
+```bash
+node packages/app/scripts/mobile-local-chat-smoke.mjs --help
+```
+
+Result: help output includes `--start-host-agent` and `--host-agent-port`.
+
+## Real host-agent attempt
+
+Attempted to start the actual deterministic host agent through `startDeviceE2eHostAgent()` and poll `/api/health`. The helper correctly captured the child output and failed loudly because this machine has Node v23.3.0 and `run-node-tsx` requires Node 24+.
+
+Artifact: `host-agent-node23-failure.txt`.
+
+## Simulator proof not run locally
+
+The required real simulator commands need a full Xcode install. This machine is pointed at Command Line Tools and `simctl` is unavailable:
+
+```bash
+xcode-select -p
+# /Library/Developer/CommandLineTools
+
+xcrun simctl list devices booted --json
+# xcrun: error: unable to find utility "simctl", not a developer tool or in PATH
+```
+
+Commands still required on a macOS/Xcode runner or developer machine:
+
+```bash
+bun run --cwd packages/app build:ios:cloud:sim
+bun run --cwd packages/app test:e2e:ios:onboarding
+bun run --cwd packages/app capture:ios-sim:attachment
+bun run --cwd packages/app test:sim:local-chat:ios -- --start-host-agent
+lsof -i :31338
+```
+
+## Evidence applicability
+
+- Real LLM trajectory: N/A. This change only moves deterministic test host-agent orchestration into scripts.
+- Frontend screenshots/video: blocked locally by missing full Xcode/simctl; required on the runner before closing the issue.
+- Backend logs: `host-agent-node23-failure.txt` shows the helper wrote and surfaced the actual child log. Successful real `serve-real-local-agent.ts` logs require Node 24+.
+- Domain artifacts: `host-agent.log` is produced in each lane artifact directory; local generated `.log` is ignored by repo policy, so the relevant failure text is preserved in `host-agent-node23-failure.txt`.

--- a/.github/issue-evidence/13574-host-agent-lanes/host-agent-node23-failure.txt
+++ b/.github/issue-evidence/13574-host-agent-lanes/host-agent-node23-failure.txt
@@ -1,0 +1,16 @@
+[host-agent-proof] starting host agent at http://127.0.0.1:31338 (log: .github/issue-evidence/13574-host-agent-lanes/host-agent.log)
+Error: Host agent exited before http://127.0.0.1:31338/api/health became ready.
+file:///Users/shawwalters/milaidy/eliza-13686/packages/app-core/scripts/run-node-runtime.mjs:229
+  throw new Error(
+        ^
+
+Error: No usable Node.js 24+ executable found (/usr/bin/node: spawnSync /usr/bin/node ENOENT). Install Node.js 24+ or set ELIZA_NODE_PATH=/absolute/path/to/node.
+    at resolveNodeExecPathFromCandidates (file:///Users/shawwalters/milaidy/eliza-13686/packages/app-core/scripts/run-node-runtime.mjs:229:9)
+    at resolveNodeCmd (file:///Users/shawwalters/milaidy/eliza-13686/packages/app-core/scripts/run-node-tsx.mjs:15:10)
+    at file:///Users/shawwalters/milaidy/eliza-13686/packages/app-core/scripts/run-node-tsx.mjs:59:21
+
+Local environment:
+node -v: v23.3.0
+which node: /opt/homebrew/bin/node
+bun -v: 1.4.0
+which bun: /Users/shawwalters/.bun/bin/bun

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -160,29 +160,7 @@ jobs:
       - name: Run iOS onboarding -> home simulator smoke
         run: |
           set -euo pipefail
-          mkdir -p packages/app/test-results/ios-onboarding-to-home
-          ELIZA_API_PORT=31338 ELIZA_PAIRING_DISABLED=1 \
-            node packages/app-core/scripts/run-node-tsx.mjs packages/app-core/scripts/serve-real-local-agent.ts \
-            > packages/app/test-results/ios-onboarding-to-home/host-agent.log 2>&1 &
-          HOST_AGENT_PID=$!
-          cleanup() {
-            kill "$HOST_AGENT_PID" 2>/dev/null || true
-            wait "$HOST_AGENT_PID" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-          for attempt in $(seq 1 90); do
-            if curl -fsS http://127.0.0.1:31338/api/health >/dev/null; then
-              break
-            fi
-            if ! kill -0 "$HOST_AGENT_PID" 2>/dev/null; then
-              echo "Host agent exited before /api/health became ready"
-              cat packages/app/test-results/ios-onboarding-to-home/host-agent.log
-              exit 1
-            fi
-            sleep 2
-          done
-          curl -fsS http://127.0.0.1:31338/api/health >/dev/null
-          node packages/app/scripts/ios-onboarding-smoke.mjs --api-base http://127.0.0.1:31338
+          node packages/app/scripts/ios-onboarding-smoke.mjs
 
       - name: Upload iOS onboarding evidence
         if: always()
@@ -200,29 +178,7 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          mkdir -p packages/app/test-results/ios-attachment-smoke
-          ELIZA_API_PORT=31338 ELIZA_PAIRING_DISABLED=1 \
-            node packages/app-core/scripts/run-node-tsx.mjs packages/app-core/scripts/serve-real-local-agent.ts \
-            > packages/app/test-results/ios-attachment-smoke/host-agent.log 2>&1 &
-          HOST_AGENT_PID=$!
-          cleanup() {
-            kill "$HOST_AGENT_PID" 2>/dev/null || true
-            wait "$HOST_AGENT_PID" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-          for attempt in $(seq 1 90); do
-            if curl -fsS http://127.0.0.1:31338/api/health >/dev/null; then
-              break
-            fi
-            if ! kill -0 "$HOST_AGENT_PID" 2>/dev/null; then
-              echo "Host agent exited before /api/health became ready"
-              cat packages/app/test-results/ios-attachment-smoke/host-agent.log
-              exit 1
-            fi
-            sleep 2
-          done
-          curl -fsS http://127.0.0.1:31338/api/health >/dev/null
-          node packages/app/scripts/ios-attachment-smoke.mjs --api-base http://127.0.0.1:31338
+          node packages/app/scripts/ios-attachment-smoke.mjs
 
       - name: Upload iOS native attachment evidence
         if: always()
@@ -243,30 +199,8 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          mkdir -p packages/app/test-results/ios-local-chat
-          ELIZA_API_PORT=31338 ELIZA_PAIRING_DISABLED=1 \
-            node packages/app-core/scripts/run-node-tsx.mjs packages/app-core/scripts/serve-real-local-agent.ts \
-            > packages/app/test-results/ios-local-chat/host-agent.log 2>&1 &
-          HOST_AGENT_PID=$!
-          cleanup() {
-            kill "$HOST_AGENT_PID" 2>/dev/null || true
-            wait "$HOST_AGENT_PID" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-          for attempt in $(seq 1 90); do
-            if curl -fsS http://127.0.0.1:31338/api/health >/dev/null; then
-              break
-            fi
-            if ! kill -0 "$HOST_AGENT_PID" 2>/dev/null; then
-              echo "Host agent exited before /api/health became ready"
-              cat packages/app/test-results/ios-local-chat/host-agent.log
-              exit 1
-            fi
-            sleep 2
-          done
-          curl -fsS http://127.0.0.1:31338/api/health >/dev/null
           node packages/app/scripts/mobile-local-chat-smoke.mjs \
-            --platform ios --require-installed --api-base http://127.0.0.1:31338
+            --platform ios --require-installed --start-host-agent
 
       - name: Upload iOS local-chat evidence
         if: always()

--- a/packages/app/scripts/ios-attachment-smoke.mjs
+++ b/packages/app/scripts/ios-attachment-smoke.mjs
@@ -11,6 +11,10 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  DEFAULT_HOST_AGENT_PORT,
+  startDeviceE2eHostAgent,
+} from "./lib/host-agent.mjs";
+import {
   captureIosSimulatorScreenshot,
   startIosSimulatorVideo,
 } from "./lib/ios-simulator-capture.mjs";
@@ -29,7 +33,7 @@ const ONBOARDING_REQUEST_KEY = "eliza:ios-onboarding-smoke:request";
 const ONBOARDING_RESULT_KEY = "eliza:ios-onboarding-smoke:result";
 const ATTACHMENT_REQUEST_KEY = "eliza:ios-attachment-smoke:request";
 const ATTACHMENT_RESULT_KEY = "eliza:ios-attachment-smoke:result";
-const DEFAULT_API_BASE = "http://127.0.0.1:31338";
+const DEFAULT_HOST_AGENT_PORT_STRING = String(DEFAULT_HOST_AGENT_PORT);
 const PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
@@ -394,59 +398,72 @@ async function pollResult(udid, appId) {
 
 async function main() {
   const { appId, urlScheme } = readAppIdentity();
-  const apiBase = val("--api-base", DEFAULT_API_BASE);
+  let apiBase = val("--api-base");
   const filename = val("--filename", "eliza-ios-attachment-smoke.png");
   const udid = ensureSimulatorBooted();
   removePathRecursive(resultDir);
   fs.mkdirSync(resultDir, { recursive: true });
+  const hostAgent = apiBase
+    ? null
+    : await startDeviceE2eHostAgent({
+        repoRoot,
+        artifactDir: resultDir,
+        requestedPort: val("--host-agent-port"),
+        preferredPort:
+          process.env.ELIZA_IOS_HOST_AGENT_PORT ??
+          DEFAULT_HOST_AGENT_PORT_STRING,
+        log,
+      });
+  apiBase = apiBase ?? hostAgent.apiBase;
+  let recording = null;
 
-  deleteSimulatorPreferenceDomainKeys(udid, appId, FIRST_RUN_STATE_KEYS);
-  flushPreferences(udid);
-  installLatestApp(udid, appId);
-  tryRun("xcrun", ["simctl", "terminate", udid, appId]);
-  clearState(udid, appId);
-  defaultsWriteString(
-    udid,
-    appId,
-    ONBOARDING_REQUEST_KEY,
-    JSON.stringify({ apiBase }),
-  );
-  defaultsWriteString(
-    udid,
-    appId,
-    ONBOARDING_RESULT_KEY,
-    JSON.stringify({
-      ok: false,
-      phase: "requested",
-      apiBase,
-      updatedAt: new Date().toISOString(),
-    }),
-  );
-  defaultsWriteString(
-    udid,
-    appId,
-    ATTACHMENT_REQUEST_KEY,
-    JSON.stringify({
-      apiBase,
-      filename,
-      dataUrl: `data:image/png;base64,${PNG_BASE64}`,
-    }),
-  );
-  defaultsWriteString(
-    udid,
-    appId,
-    ATTACHMENT_RESULT_KEY,
-    JSON.stringify({
-      ok: false,
-      phase: "requested",
-      apiBase,
-      updatedAt: new Date().toISOString(),
-    }),
-  );
-  flushPreferences(udid);
-
-  const recording = startVideo(udid);
   try {
+    deleteSimulatorPreferenceDomainKeys(udid, appId, FIRST_RUN_STATE_KEYS);
+    flushPreferences(udid);
+    installLatestApp(udid, appId);
+    tryRun("xcrun", ["simctl", "terminate", udid, appId]);
+    clearState(udid, appId);
+    defaultsWriteString(
+      udid,
+      appId,
+      ONBOARDING_REQUEST_KEY,
+      JSON.stringify({ apiBase }),
+    );
+    defaultsWriteString(
+      udid,
+      appId,
+      ONBOARDING_RESULT_KEY,
+      JSON.stringify({
+        ok: false,
+        phase: "requested",
+        apiBase,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+    defaultsWriteString(
+      udid,
+      appId,
+      ATTACHMENT_REQUEST_KEY,
+      JSON.stringify({
+        apiBase,
+        filename,
+        dataUrl: `data:image/png;base64,${PNG_BASE64}`,
+      }),
+    );
+    defaultsWriteString(
+      udid,
+      appId,
+      ATTACHMENT_RESULT_KEY,
+      JSON.stringify({
+        ok: false,
+        phase: "requested",
+        apiBase,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+    flushPreferences(udid);
+
+    recording = startVideo(udid);
     log(`launching ${appId} on ${udid}`);
     simctl(["launch", udid, appId]);
     await sleep(1500);
@@ -472,6 +489,8 @@ async function main() {
     throw new Error(
       `${error instanceof Error ? error.message : String(error)}${screenshot ? ` (screenshot: ${screenshot})` : ""}`,
     );
+  } finally {
+    await hostAgent?.stop();
   }
 }
 

--- a/packages/app/scripts/ios-onboarding-smoke.mjs
+++ b/packages/app/scripts/ios-onboarding-smoke.mjs
@@ -11,6 +11,10 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  DEFAULT_HOST_AGENT_PORT,
+  startDeviceE2eHostAgent,
+} from "./lib/host-agent.mjs";
+import {
   assertCandidateIosAppRendererFresh,
   assertInstalledIosAppRendererFresh,
 } from "./lib/ios-renderer-stamp.mjs";
@@ -37,7 +41,7 @@ const MIXED_CONTENT_REQUEST_KEY = "eliza:ios-mixed-content-smoke:request";
 const MIXED_CONTENT_RESULT_KEY = "eliza:ios-mixed-content-smoke:result";
 const ATTACHMENT_REQUEST_KEY = "eliza:ios-attachment-smoke:request";
 const ATTACHMENT_RESULT_KEY = "eliza:ios-attachment-smoke:result";
-const DEFAULT_API_BASE = "http://127.0.0.1:31338";
+const DEFAULT_HOST_AGENT_PORT_STRING = String(DEFAULT_HOST_AGENT_PORT);
 
 const has = (flag) => process.argv.includes(flag);
 const val = (flag, fallback = null) => {
@@ -461,59 +465,72 @@ async function pollMixedContentResult(udid, appId) {
 
 async function main() {
   const { appId, urlScheme } = readAppIdentity();
-  const apiBase = val("--api-base", DEFAULT_API_BASE);
+  let apiBase = val("--api-base");
   const udid = ensureSimulatorBooted();
   removePathRecursive(resultDir);
   fs.mkdirSync(resultDir, { recursive: true });
+  const hostAgent = apiBase
+    ? null
+    : await startDeviceE2eHostAgent({
+        repoRoot,
+        artifactDir: resultDir,
+        requestedPort: val("--host-agent-port"),
+        preferredPort:
+          process.env.ELIZA_IOS_HOST_AGENT_PORT ??
+          DEFAULT_HOST_AGENT_PORT_STRING,
+        log,
+      });
+  apiBase = apiBase ?? hostAgent.apiBase;
+  let recording = null;
 
-  clearIosSmokeDefaults({
-    udid,
-    bundleId: appId,
-    extraKeys: FIRST_RUN_STATE_KEYS,
-    log,
-  });
-  installLatestApp(udid, appId);
-  tryRun("xcrun", ["simctl", "terminate", udid, appId]);
-  clearIosSmokeDefaults({
-    udid,
-    bundleId: appId,
-    extraKeys: FIRST_RUN_STATE_KEYS,
-    log,
-  });
-  defaultsWriteString(udid, appId, REQUEST_KEY, JSON.stringify({ apiBase }));
-  defaultsWriteString(
-    udid,
-    appId,
-    RESULT_KEY,
-    JSON.stringify({
-      ok: false,
-      phase: "requested",
-      apiBase,
-      updatedAt: new Date().toISOString(),
-    }),
-  );
-  flushPreferences(udid);
-  defaultsWriteString(
-    udid,
-    appId,
-    MIXED_CONTENT_REQUEST_KEY,
-    JSON.stringify({ apiBase }),
-  );
-  defaultsWriteString(
-    udid,
-    appId,
-    MIXED_CONTENT_RESULT_KEY,
-    JSON.stringify({
-      ok: false,
-      phase: "requested",
-      apiBase,
-      updatedAt: new Date().toISOString(),
-    }),
-  );
-  flushPreferences(udid);
-
-  const recording = startVideo(udid);
   try {
+    clearIosSmokeDefaults({
+      udid,
+      bundleId: appId,
+      extraKeys: FIRST_RUN_STATE_KEYS,
+      log,
+    });
+    installLatestApp(udid, appId);
+    tryRun("xcrun", ["simctl", "terminate", udid, appId]);
+    clearIosSmokeDefaults({
+      udid,
+      bundleId: appId,
+      extraKeys: FIRST_RUN_STATE_KEYS,
+      log,
+    });
+    defaultsWriteString(udid, appId, REQUEST_KEY, JSON.stringify({ apiBase }));
+    defaultsWriteString(
+      udid,
+      appId,
+      RESULT_KEY,
+      JSON.stringify({
+        ok: false,
+        phase: "requested",
+        apiBase,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+    flushPreferences(udid);
+    defaultsWriteString(
+      udid,
+      appId,
+      MIXED_CONTENT_REQUEST_KEY,
+      JSON.stringify({ apiBase }),
+    );
+    defaultsWriteString(
+      udid,
+      appId,
+      MIXED_CONTENT_RESULT_KEY,
+      JSON.stringify({
+        ok: false,
+        phase: "requested",
+        apiBase,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+    flushPreferences(udid);
+
+    recording = startVideo(udid);
     log(`launching ${appId} on ${udid}`);
     simctl(["launch", udid, appId]);
     await sleep(1500);
@@ -654,6 +671,8 @@ async function main() {
     throw new Error(
       `${error instanceof Error ? error.message : String(error)}${screenshot ? ` (screenshot: ${screenshot})` : ""}`,
     );
+  } finally {
+    await hostAgent?.stop();
   }
 }
 

--- a/packages/app/scripts/lib/host-agent.mjs
+++ b/packages/app/scripts/lib/host-agent.mjs
@@ -1,0 +1,286 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+
+export const DEFAULT_HOST_AGENT_PORT = 31338;
+export const DEFAULT_HOST_AGENT_HOST = "127.0.0.1";
+export const DEFAULT_HOST_AGENT_HEALTH_PATH = "/api/health";
+
+const SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"];
+const DEFAULT_READY_ATTEMPTS = 90;
+const DEFAULT_READY_DELAY_MS = 2000;
+
+export function parsePort(value, label = "port") {
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  const port = Number.parseInt(raw, 10);
+  if (port < 1 || port > 65535) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  return port;
+}
+
+export function hostAgentApiBase(port, host = DEFAULT_HOST_AGENT_HOST) {
+  return `http://${host}:${port}`;
+}
+
+export async function isPortAvailable(port, host = DEFAULT_HOST_AGENT_HOST) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, host);
+  });
+}
+
+export async function chooseHostAgentPort({
+  preferredPort = DEFAULT_HOST_AGENT_PORT,
+  requestedPort = null,
+  host = DEFAULT_HOST_AGENT_HOST,
+} = {}) {
+  if (requestedPort !== null && requestedPort !== undefined) {
+    const port = parsePort(requestedPort, "host-agent port");
+    if (!(await isPortAvailable(port, host))) {
+      throw new Error(`Requested host-agent port ${port} is already in use.`);
+    }
+    return port;
+  }
+
+  const preferred = parsePort(preferredPort, "host-agent preferred port");
+  if (await isPortAvailable(preferred, host)) return preferred;
+
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.once("listening", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : null;
+      server.close(() => {
+        if (typeof port === "number") resolve(port);
+        else reject(new Error("Unable to allocate a free host-agent port."));
+      });
+    });
+    server.listen(0, host);
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function tailFile(filePath, maxBytes = 12_000) {
+  try {
+    const stats = fs.statSync(filePath);
+    const start = Math.max(0, stats.size - maxBytes);
+    const fd = fs.openSync(filePath, "r");
+    try {
+      const buffer = Buffer.alloc(stats.size - start);
+      fs.readSync(fd, buffer, 0, buffer.length, start);
+      return buffer.toString("utf8").trim();
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return "";
+  }
+}
+
+async function waitForHealth({
+  apiBase,
+  child,
+  getChildError,
+  logPath,
+  attempts,
+  delayMs,
+  log,
+}) {
+  const healthUrl = new URL(DEFAULT_HOST_AGENT_HEALTH_PATH, apiBase).toString();
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const childError = getChildError?.();
+    if (childError) {
+      throw new Error(
+        [`Host agent failed to start: ${childError.message}`, tailFile(logPath)]
+          .filter(Boolean)
+          .join("\n"),
+      );
+    }
+
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(
+        [
+          `Host agent exited before ${healthUrl} became ready.`,
+          tailFile(logPath),
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      );
+    }
+
+    try {
+      const response = await fetch(healthUrl);
+      if (response.ok) {
+        log?.(`host agent ready at ${apiBase}`);
+        return;
+      }
+    } catch {
+      // Retry until attempts are exhausted or the child exits.
+    }
+
+    await sleep(delayMs);
+  }
+
+  throw new Error(
+    [
+      `Timed out waiting for host agent health at ${healthUrl}.`,
+      tailFile(logPath),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
+}
+
+export async function startDeviceE2eHostAgent({
+  repoRoot,
+  artifactDir,
+  requestedPort = null,
+  preferredPort = process.env.ELIZA_IOS_HOST_AGENT_PORT ??
+    DEFAULT_HOST_AGENT_PORT,
+  host = DEFAULT_HOST_AGENT_HOST,
+  readyAttempts = Number.parseInt(
+    process.env.ELIZA_HOST_AGENT_READY_ATTEMPTS ??
+      String(DEFAULT_READY_ATTEMPTS),
+    10,
+  ),
+  readyDelayMs = Number.parseInt(
+    process.env.ELIZA_HOST_AGENT_READY_DELAY_MS ??
+      String(DEFAULT_READY_DELAY_MS),
+    10,
+  ),
+  log = null,
+  command = process.execPath,
+  args = [
+    path.join(repoRoot, "packages/app-core/scripts/run-node-tsx.mjs"),
+    path.join(repoRoot, "packages/app-core/scripts/serve-real-local-agent.ts"),
+  ],
+  env = process.env,
+} = {}) {
+  if (!repoRoot) throw new Error("startDeviceE2eHostAgent requires repoRoot.");
+  if (!artifactDir) {
+    throw new Error("startDeviceE2eHostAgent requires artifactDir.");
+  }
+
+  const port = await chooseHostAgentPort({
+    preferredPort,
+    requestedPort,
+    host,
+  });
+  const apiBase = hostAgentApiBase(port, host);
+  fs.mkdirSync(artifactDir, { recursive: true });
+  const logPath = path.join(artifactDir, "host-agent.log");
+  const logFd = fs.openSync(logPath, "w");
+  const child = spawn(command, args, {
+    cwd: repoRoot,
+    env: {
+      ...env,
+      ELIZA_API_PORT: String(port),
+      ELIZA_PAIRING_DISABLED: "1",
+    },
+    stdio: ["ignore", logFd, logFd],
+  });
+  let childError = null;
+  let childExited = false;
+  child.once("error", (error) => {
+    childError = error;
+  });
+  child.once("exit", () => {
+    childExited = true;
+  });
+
+  let stopped = false;
+  let stopPromise = null;
+  const stop = async () => {
+    if (stopped) return stopPromise;
+    stopped = true;
+    stopPromise = new Promise((resolve) => {
+      const finish = () => {
+        try {
+          fs.closeSync(logFd);
+        } catch {
+          // Already closed by the platform.
+        }
+        resolve();
+      };
+
+      if (
+        child.pid === undefined ||
+        childExited ||
+        child.exitCode !== null ||
+        child.signalCode !== null
+      ) {
+        finish();
+        return;
+      }
+
+      const timer = setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGKILL");
+        }
+      }, 10_000);
+      timer.unref?.();
+      child.once("exit", () => {
+        clearTimeout(timer);
+        finish();
+      });
+      child.kill("SIGTERM");
+    });
+    return stopPromise;
+  };
+
+  const signalHandlers = new Map();
+  for (const signal of SIGNALS) {
+    const handler = () => {
+      void stop().finally(() =>
+        process.exit(
+          128 + (signal === "SIGHUP" ? 1 : signal === "SIGINT" ? 2 : 15),
+        ),
+      );
+    };
+    signalHandlers.set(signal, handler);
+    process.once(signal, handler);
+  }
+
+  try {
+    log?.(`starting host agent at ${apiBase} (log: ${logPath})`);
+    await waitForHealth({
+      apiBase,
+      child,
+      getChildError: () => childError,
+      logPath,
+      attempts: readyAttempts,
+      delayMs: readyDelayMs,
+      log,
+    });
+  } catch (error) {
+    await stop();
+    throw error;
+  }
+
+  return {
+    apiBase,
+    port,
+    logPath,
+    pid: child.pid,
+    async stop() {
+      for (const [signal, handler] of signalHandlers) {
+        process.off(signal, handler);
+      }
+      await stop();
+      log?.(`stopped host agent at ${apiBase}`);
+    },
+  };
+}

--- a/packages/app/scripts/lib/host-agent.test.mjs
+++ b/packages/app/scripts/lib/host-agent.test.mjs
@@ -1,0 +1,153 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  chooseHostAgentPort,
+  DEFAULT_HOST_AGENT_PORT,
+  hostAgentApiBase,
+  isPortAvailable,
+  parsePort,
+  startDeviceE2eHostAgent,
+} from "./host-agent.mjs";
+
+const tmpDirs = [];
+
+function makeTmpDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-host-agent-test-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function fakeHostAgentScript() {
+  return `
+    const http = require("node:http");
+    const port = Number.parseInt(process.env.ELIZA_API_PORT, 10);
+    const server = http.createServer((req, res) => {
+      if (req.url === "/api/health") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, pairingDisabled: process.env.ELIZA_PAIRING_DISABLED }));
+        return;
+      }
+      res.writeHead(404);
+      res.end("not found");
+    });
+    server.listen(port, "127.0.0.1", () => {
+      console.log("fake host agent up on :" + port);
+    });
+    const stop = () => server.close(() => process.exit(0));
+    process.once("SIGTERM", stop);
+    process.once("SIGINT", stop);
+  `;
+}
+
+async function listen(port = 0) {
+  const server = http.createServer((_, response) => {
+    response.writeHead(200);
+    response.end("occupied");
+  });
+  await new Promise((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return server;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("host-agent helper", () => {
+  it("validates ports without coercing malformed values", () => {
+    expect(parsePort("31338")).toBe(DEFAULT_HOST_AGENT_PORT);
+    for (const value of ["", "0", "-1", "123abc", "70000"]) {
+      expect(() => parsePort(value)).toThrow(/Invalid/);
+    }
+  });
+
+  it("keeps explicit requested ports exclusive", async () => {
+    const server = await listen();
+    try {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      await expect(
+        chooseHostAgentPort({ requestedPort: port }),
+      ).rejects.toThrow(`Requested host-agent port ${port} is already in use.`);
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it("falls back to a free port when the preferred default is occupied", async () => {
+    const server = await listen();
+    try {
+      const address = server.address();
+      const occupiedPort =
+        typeof address === "object" && address ? address.port : 0;
+      const selected = await chooseHostAgentPort({
+        preferredPort: occupiedPort,
+      });
+      expect(selected).not.toBe(occupiedPort);
+      expect(await isPortAvailable(selected)).toBe(true);
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it("starts a child host agent, waits for health, writes logs, and stops it", async () => {
+    const artifactDir = makeTmpDir();
+    const requestedPort = await chooseHostAgentPort();
+    const agent = await startDeviceE2eHostAgent({
+      repoRoot: process.cwd(),
+      artifactDir,
+      requestedPort,
+      readyAttempts: 50,
+      readyDelayMs: 20,
+      command: process.execPath,
+      args: ["-e", fakeHostAgentScript()],
+      env: {},
+    });
+
+    expect(agent.apiBase).toBe(hostAgentApiBase(requestedPort));
+    const response = await fetch(`${agent.apiBase}/api/health`);
+    expect(response.ok).toBe(true);
+    expect(await response.json()).toEqual({
+      ok: true,
+      pairingDisabled: "1",
+    });
+
+    await agent.stop();
+    expect(fs.readFileSync(agent.logPath, "utf8")).toContain(
+      `fake host agent up on :${requestedPort}`,
+    );
+
+    const probe = spawnSync(process.execPath, [
+      "-e",
+      `
+        fetch("${agent.apiBase}/api/health")
+          .then(() => process.exit(1))
+          .catch(() => process.exit(0));
+      `,
+    ]);
+    expect(probe.status).toBe(0);
+  });
+
+  it("fails fast and closes the log fd when the child cannot spawn", async () => {
+    const artifactDir = makeTmpDir();
+    await expect(
+      startDeviceE2eHostAgent({
+        repoRoot: process.cwd(),
+        artifactDir,
+        requestedPort: await chooseHostAgentPort(),
+        readyAttempts: 2,
+        readyDelayMs: 20,
+        command: path.join(artifactDir, "missing-node"),
+        args: ["--version"],
+      }),
+    ).rejects.toThrow(/Host agent failed to start|ENOENT/);
+
+    fs.rmSync(path.join(artifactDir, "host-agent.log"));
+    expect(fs.existsSync(path.join(artifactDir, "host-agent.log"))).toBe(false);
+  });
+});

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -15,6 +15,7 @@ import {
   ANDROID_FULL_TURN_FAILURE_RE,
   IOS_FULL_BUN_SMOKE_FAILURE_RE,
 } from "./lib/chat-failure-strings.mjs";
+import { startDeviceE2eHostAgent } from "./lib/host-agent.mjs";
 import { assertInstalledIosAppRendererFresh } from "./lib/ios-renderer-stamp.mjs";
 import { clearIosSmokeDefaults } from "./lib/ios-sim-defaults-hygiene.mjs";
 import { evaluateLocalInferenceReadiness } from "./lib/local-inference-readiness.mjs";
@@ -24,6 +25,10 @@ const repoRoot = path.resolve(
   "../../..",
 );
 const appConfigPath = path.join(repoRoot, "packages/app/app.config.ts");
+const iosLocalChatResultDir = path.join(
+  repoRoot,
+  "packages/app/test-results/ios-local-chat",
+);
 
 function argValue(name) {
   const index = process.argv.indexOf(name);
@@ -31,10 +36,13 @@ function argValue(name) {
 }
 
 const platform = argValue("--platform") ?? "ios";
-const apiBase = argValue("--api-base");
+let apiBase = argValue("--api-base");
 const authTokenArg = argValue("--auth-token");
+const startHostAgent = process.argv.includes("--start-host-agent");
+const hostAgentPort = argValue("--host-agent-port");
 const requireInstalled = process.argv.includes("--require-installed");
-const exerciseAppCoreApi = process.argv.includes("--live") || Boolean(apiBase);
+const exerciseAppCoreApi =
+  process.argv.includes("--live") || Boolean(apiBase) || startHostAgent;
 const iosSelectLocal = process.argv.includes("--ios-select-local");
 const iosFullBunSmoke = process.argv.includes("--ios-full-bun-smoke");
 const androidSelectLocal = process.argv.includes("--android-select-local");
@@ -180,6 +188,8 @@ Options:
   --require-installed              Fail when the selected app/simulator is unavailable
   --live                           Exercise the app-core local-agent HTTP API on Android
   --api-base URL                   Exercise an already-reachable app-core HTTP API
+  --start-host-agent               Start the deterministic host app-core API when --api-base is omitted
+  --host-agent-port PORT           Port for --start-host-agent (default: 31338, or a free port if busy)
   --auth-token TOKEN               Bearer token for protected app-core API routes
   --ios-select-local               Pre-seed iOS first-run/runtime state for Local mode before launch
   --ios-full-bun-smoke             Run a WebView-executed full Bun backend smoke in the iOS app
@@ -2427,7 +2437,23 @@ async function runLocalInferenceApiSmoke(
 async function main() {
   let androidContext = null;
   let iosContext = null;
+  let hostAgent = null;
   try {
+    if (startHostAgent) {
+      if (apiBase) {
+        throw new Error(
+          "--start-host-agent cannot be combined with --api-base.",
+        );
+      }
+      hostAgent = await startDeviceE2eHostAgent({
+        repoRoot,
+        artifactDir: iosLocalChatResultDir,
+        requestedPort: hostAgentPort,
+        log: (message) => console.log(`[local-chat-smoke] ${message}`),
+      });
+      apiBase = hostAgent.apiBase;
+    }
+
     if (platform === "ios" || platform === "both") {
       iosContext = launchIosSimulatorApp();
       if (iosContext?.installed) {
@@ -2502,6 +2528,7 @@ async function main() {
       );
     }
   } finally {
+    await hostAgent?.stop();
     if (iosContext?.udid) {
       clearIosSmokeDefaults({
         udid: iosContext.udid,


### PR DESCRIPTION
## Summary

Relates to #13574.

- Add `packages/app/scripts/lib/host-agent.mjs` to start the deterministic `serve-real-local-agent.ts`, wait for `/api/health`, write `host-agent.log`, and tear down the child process.
- Make `ios-onboarding-smoke.mjs` and `ios-attachment-smoke.mjs` start that host agent by default when `--api-base` is omitted, preserving explicit `--api-base` for externally managed agents.
- Add `mobile-local-chat-smoke.mjs --start-host-agent` and simplify `mobile-build-smoke.yml` so CI calls the lanes directly instead of duplicating host-agent shell boot/poll/cleanup.

## Evidence

Artifacts: `.github/issue-evidence/13574-host-agent-lanes/`

Passed locally:

```bash
node --check packages/app/scripts/lib/host-agent.mjs
node --check packages/app/scripts/lib/host-agent.test.mjs
node --check packages/app/scripts/ios-onboarding-smoke.mjs
node --check packages/app/scripts/ios-attachment-smoke.mjs
node --check packages/app/scripts/mobile-local-chat-smoke.mjs

bun run --cwd packages/app test -- scripts/lib/host-agent.test.mjs
# 1 file passed, 5 tests passed

bunx biome check packages/app/scripts/lib/host-agent.mjs packages/app/scripts/lib/host-agent.test.mjs packages/app/scripts/ios-onboarding-smoke.mjs packages/app/scripts/ios-attachment-smoke.mjs packages/app/scripts/mobile-local-chat-smoke.mjs .github/workflows/mobile-build-smoke.yml .github/issue-evidence/13574-host-agent-lanes/README.md .github/issue-evidence/13574-host-agent-lanes/host-agent-node23-failure.txt

git diff --check HEAD~1..HEAD
```

Additional review: a parallel code review pass checked teardown, `--api-base` compatibility, artifact paths, and workflow upload globs; no regressions found.

Blocked locally:

- Real `serve-real-local-agent.ts` proof could not start because this shell has Node v23.3.0 and the repo runner requires Node 24+. Captured in `.github/issue-evidence/13574-host-agent-lanes/host-agent-node23-failure.txt`.
- Real iOS simulator proof could not run because this machine is pointed at `/Library/Developer/CommandLineTools` and `xcrun simctl` is unavailable.
- `bun run verify` failed before package typecheck/lint in repo-wide `audit:type-safety-ratchet` baseline drift unrelated to this patch (`as unknown as` and `?? []` counts above baseline). Details are in the evidence README.

## Evidence rows

- Real LLM trajectory: N/A, deterministic test-lane orchestration only.
- Backend logs: attempted real host-agent boot, failure log attached due local Node 23 blocker.
- Frontend screenshots/video: N/A for code shape; real simulator screenshots/video remain required on macOS/Xcode before closing #13574.
- Domain artifacts: `host-agent.log` is now produced in each lane result directory and covered by workflow upload globs.