### PR TITLE
fix(cloud-shared): fail-closed credential-pool + secrets fallback sweep (#13415)

### DIFF
--- a/.github/issue-evidence/13415-cloud-shared-services-fallback.md
+++ b/.github/issue-evidence/13415-cloud-shared-services-fallback.md
@@ -1,0 +1,55 @@
+# #13415 — cloud-shared services fallback-slop sweep: team-credential-pool + secrets
+
+Slice of the #13415 sweep. Scope chosen: `team-credential-pool` (6 files) + `secrets`
+(2 files), verified untouched by every in-flight fallback-sweep branch before starting.
+
+## Before/after fallback census (touched files)
+
+| file | before | after |
+|---|---|---|
+| team-credential-pool/bootstrap-env.ts | 1 blanket try/catch swallowing all faults → `return params.env` | 0 catches; faults propagate (fail closed); designed-empty (`!selected`) skips |
+| secrets/secrets.ts | 1 unannotated catch, defaults | 1 catch annotated `J1` (batch partial-success); defaults verified domain-correct |
+| secrets/encryption.ts | 2 unannotated rethrow catches | 2 annotated `J2` (context-adding rethrow with `cause`) |
+| team-credential-pool/probe.ts | 2 unannotated catches | 2 annotated (`J1` boundary, `J3`/best-effort body-read) |
+| team-credential-pool/service.ts | 2 unannotated catches | 2 annotated `J6`/`J2` (teardown / rethrow) |
+| team-credential-pool/pool-deps.ts | 1 unannotated catch | 1 annotated `J6` (best-effort secret cleanup) |
+| team-credential-pool/account-pool.ts | 0 catches (DI brain) | no change — already fails closed (deps throw, uncaught) |
+| team-credential-pool/registry.ts | 6 catches | no change — already annotated (J4/J7 boundary) |
+
+## Verdict table (every changed/annotated fallback)
+
+| location | kind | verdict | rationale |
+|---|---|---|---|
+| bootstrap-env.applyPooledCredentialsToBootstrapEnv | blanket catch | **fail-closed-fix** | returned unchanged env on ANY error → could boot an agent missing a credential; now propagates internal faults, skips only the registry's designed-null |
+| eliza-sandbox.ts:~620 caller comment | comment | **corrected** | stale "strict fallback: passes through unchanged" now describes fail-closed-vs-designed-empty |
+| secrets.bulkCreate encrypt catch | catch | **J1** | per-item failure → structured `errors[]` (public partial-success shape); systemic repo failure is outside the try and propagates |
+| encryption.decrypt DEK/GCM catches (x2) | catch | **J2** | rethrow `DecryptionError` with KMS error as `cause`; never decodes to partial/empty |
+| probe.probePooledApiKey outer / body-read | catch | **J1/best-effort** | transport failure → structured probe result distinct from revoked(401/403)/healthy(200) |
+| service.contribute/remove teardown catches | catch | **J6/J2** | best-effort secret teardown / rethrow; internal DB/vault failure still propagates |
+| pool-deps.deleteAccount secret cleanup | catch | **J6** | best-effort orphan-secret cleanup on a already-committed delete |
+
+## Focused test output (real, non-larp)
+
+```
+bun test --isolate <8 error-policy files>
+ 39 pass  0 fail  92 expect() calls  (8 files, 2.13s)
+```
+Each test drives the real exported function and asserts an internal failure PROPAGATES
+(is not swallowed to empty/default) while a legitimately-empty/not-found case still
+returns its designed empty result — the two stay distinguishable.
+
+Regression: existing `team-credential-pool` + `secrets` suites — 50 pass / 0 fail.
+No existing test pinned the removed swallow behavior.
+
+## Other verification
+
+- `bunx @biomejs/biome check <touched>` — clean.
+- `bun run audit:error-policy-ratchet` — "no new fallback-slop in touched files" (emptyCatch/serverConsole 0→0 on all 7 changed source files).
+- `bun run --cwd packages/cloud/shared typecheck` — 0 new errors in touched service files; pre-existing repo-wide drizzle-orm declaration noise (`dist/node_modules/drizzle-orm` missing types) unchanged and unrelated.
+
+## N/A evidence rows
+
+- UI screenshots — N/A (no UI touched).
+- Model trajectories — N/A (no agent/model/prompt path touched).
+- Audio — N/A.
+- Runtime structured logs — N/A - service unit boundary only (behavior proven by the error-path unit tests above).

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -617,7 +617,11 @@ export class ElizaSandboxService {
     // filled from the org's pooled credentials. Merged only into this
     // in-memory bootstrap payload (→ settings.secrets via
     // buildRuntimeBootstrapAgent) — never persisted to environment_vars.
-    // Strict fallback: on any pool failure the env passes through unchanged.
+    // A provider with no eligible pooled credential leaves the env unchanged
+    // (the registry degrades a missing/unhealthy pool to null, its J4); a
+    // genuine internal pool fault propagates and fails provisioning closed —
+    // consistent with the decrypt/create throws above — rather than silently
+    // booting an agent missing a credential it was meant to receive.
     const pooledEnv = await applyPooledCredentialsToBootstrapEnv({
       organizationId: rec.organization_id,
       userId: rec.user_id,

--- a/packages/cloud/shared/src/lib/services/secrets/encryption.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/secrets/encryption.error-policy.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Error-policy regression guard (#13415) for the secrets envelope: an internal
+ * failure while unwrapping the DEK or verifying the ciphertext must PROPAGATE as
+ * a typed DecryptionError — never be swallowed into an empty/partial plaintext a
+ * caller would trust. Pairs each failure with the designed success so the two
+ * are distinguishable. Real AES-256-GCM via LocalKMSProvider; the only stub is a
+ * KMSProvider that throws, standing in for a KMS outage / rotated master key.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  DecryptionError,
+  type KMSProvider,
+  LocalKMSProvider,
+  SecretsEncryptionService,
+} from "./encryption";
+
+const KEY = "b".repeat(64); // 32-byte hex master key
+
+// KMS whose DEK unwrap always fails — models a rotated/lost SECRETS_MASTER_KEY
+// or a KMS transport outage. generateDataKey succeeds so we can produce a
+// well-formed envelope and then observe decrypt fail at the unwrap phase.
+class FailingDecryptKMS implements KMSProvider {
+  private inner = new LocalKMSProvider(KEY);
+  generateDataKey() {
+    return this.inner.generateDataKey();
+  }
+  async decrypt(): Promise<Buffer> {
+    throw new Error("KMS unavailable");
+  }
+  isConfigured = () => true;
+}
+
+describe("#13415 — SecretsEncryptionService.decrypt fails observably, never silently", () => {
+  test("designed success: a real round-trip returns the exact plaintext", async () => {
+    const svc = new SecretsEncryptionService(new LocalKMSProvider(KEY));
+    const enc = await svc.encrypt("real-access-token");
+    const dec = await svc.decrypt(enc);
+    // Distinguishes the healthy path from the failure paths below: a genuine
+    // secret, not an empty/default string.
+    expect(dec).toBe("real-access-token");
+    expect(dec).not.toBe("");
+  });
+
+  test("DEK unwrap failure propagates as DecryptionError (not swallowed to empty)", async () => {
+    const good = new SecretsEncryptionService(new LocalKMSProvider(KEY));
+    const enc = await good.encrypt("real-access-token");
+
+    const svc = new SecretsEncryptionService(new FailingDecryptKMS());
+    // The J2 catch must rethrow with phase + cause, not return "" / default.
+    const err = (await svc.decrypt(enc).catch((e) => e)) as DecryptionError;
+    expect(err).toBeInstanceOf(DecryptionError);
+    expect(err.phase).toBe("dek_decryption");
+    expect(err.cause).toBeInstanceOf(Error);
+    expect((err.cause as Error).message).toBe("KMS unavailable");
+  });
+
+  test("ciphertext tamper fails GCM verification as DecryptionError (value phase)", async () => {
+    const svc = new SecretsEncryptionService(new LocalKMSProvider(KEY));
+    const enc = await svc.encrypt("real-access-token");
+    // Flip the auth tag: GCM verification must reject, and the J2 value-phase
+    // catch must surface it rather than decode a partial/empty string.
+    const tag = Buffer.from(enc.authTag, "base64");
+    tag[0] ^= 0xff;
+    const err = (await svc
+      .decrypt({ ...enc, authTag: tag.toString("base64") })
+      .catch((e) => e)) as DecryptionError;
+    expect(err).toBeInstanceOf(DecryptionError);
+    expect(err.phase).toBe("value_decryption");
+    expect(err.cause).toBeInstanceOf(Error);
+  });
+
+  test("AAD mismatch is a failure, not a silent empty decrypt", async () => {
+    const svc = new SecretsEncryptionService(new LocalKMSProvider(KEY));
+    const enc = await svc.encrypt("scoped-secret", "vendor_connections|row-1|access_token");
+    // Correct AAD -> designed plaintext; wrong AAD -> throws. The two outcomes
+    // must be distinguishable, never both an empty string.
+    expect(await svc.decrypt(enc, "vendor_connections|row-1|access_token")).toBe("scoped-secret");
+    await expect(svc.decrypt(enc, "vendor_connections|row-2|access_token")).rejects.toBeInstanceOf(
+      DecryptionError,
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/secrets/encryption.ts
+++ b/packages/cloud/shared/src/lib/services/secrets/encryption.ts
@@ -226,6 +226,9 @@ export class SecretsEncryptionService {
     try {
       dek = await this.kms.decrypt(encryptedDek);
     } catch (error) {
+      // error-policy:J2 context-adding rethrow — tag the failing phase and
+      // preserve the underlying KMS error as `cause`; never swallow, a failed
+      // DEK unwrap must surface so the caller cannot read a secret as usable.
       throw new DecryptionError(
         "Failed to decrypt data encryption key — SECRETS_MASTER_KEY may have changed since this secret was stored",
         "dek_decryption",
@@ -243,6 +246,9 @@ export class SecretsEncryptionService {
       ]).toString("utf8");
       return result;
     } catch (error) {
+      // error-policy:J2 context-adding rethrow — GCM auth-tag/AAD verification
+      // failure is preserved as `cause`; a corrupt or relocated ciphertext must
+      // throw, never decode to a partial/empty string the caller trusts.
       throw new DecryptionError(
         "Failed to decrypt secret value — stored encryption data may be corrupted or AAD mismatch (row/column relocation)",
         "value_decryption",

--- a/packages/cloud/shared/src/lib/services/secrets/secrets.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/secrets/secrets.error-policy.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Error-policy proof for the secrets bulk-create boundary (#13415). Drives the
+ * real SecretsService with real AES encryption (fake in-memory KMS) and a
+ * mocked repository so the changed catch is exercised for real: a systemic
+ * repository failure must PROPAGATE (fail closed), while a per-item
+ * encrypt/size-validation failure is captured as a structured errors[] entry —
+ * the two outcomes are distinguishable, never conflated into an all-errors batch.
+ */
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const secretsRepository = {
+  findByName: mock(),
+  create: mock(),
+};
+const secretAuditLogRepository = {
+  create: mock(),
+};
+
+// Mock the repository barrel that SecretsService imports from. The barrel also
+// exports bindings/oauth/app-requirement repositories that the service module
+// pulls in at import time, so they must be present (unused here).
+mock.module("../../../db/repositories/secrets", () => ({
+  secretsRepository,
+  secretAuditLogRepository,
+  secretBindingsRepository: {},
+  oauthSessionsRepository: {},
+  appSecretRequirementsRepository: {},
+}));
+
+import { createEncryptionService, type KMSProvider } from "./encryption";
+import { SecretsService } from "./secrets";
+
+const fakeKms: KMSProvider = {
+  async generateDataKey() {
+    return { plaintext: Buffer.alloc(32, 7), ciphertext: "fake-dek", keyId: "test-key" };
+  },
+  async decrypt() {
+    return Buffer.alloc(32, 7);
+  },
+  isConfigured: () => true,
+};
+
+const audit = { actorType: "system", actorId: "test", source: "test" } as const;
+
+function makeSecretRow(name: string) {
+  return {
+    id: `id-${name}`,
+    organization_id: "org1",
+    name,
+    description: null,
+    scope: "organization",
+    project_id: null,
+    project_type: null,
+    environment: null,
+    provider: null,
+    provider_metadata: null,
+    encrypted_value: "x",
+    encryption_key_id: "test-key",
+    encrypted_dek: "d",
+    nonce: "n",
+    auth_tag: "t",
+    version: 1,
+    expires_at: null,
+    last_rotated_at: null,
+    last_accessed_at: null,
+    access_count: 0,
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+}
+
+function newService() {
+  return new SecretsService(createEncryptionService(fakeKms));
+}
+
+describe("SecretsService.bulkCreate error policy", () => {
+  beforeEach(() => {
+    secretsRepository.findByName.mockReset();
+    secretsRepository.create.mockReset();
+    secretAuditLogRepository.create.mockReset();
+  });
+
+  it("propagates a systemic repository failure (fail closed, not swallowed into errors[])", async () => {
+    secretsRepository.findByName.mockResolvedValue(undefined);
+    secretsRepository.create.mockRejectedValue(new Error("db down"));
+    secretAuditLogRepository.create.mockResolvedValue(undefined);
+
+    const svc = newService();
+
+    // A repository outage is a broken pipeline, not a per-item validation
+    // failure: it must throw out of bulkCreate rather than be reported as a
+    // structured errors[] entry that masks the outage.
+    await expect(
+      svc.bulkCreate(
+        {
+          organizationId: "org1",
+          secrets: [{ name: "A", value: "value" }],
+          createdBy: "u1",
+        },
+        audit,
+      ),
+    ).rejects.toThrow("db down");
+  });
+
+  it("captures a per-item size-validation failure as a structured errors[] entry while still creating the valid item", async () => {
+    secretsRepository.findByName.mockResolvedValue(undefined);
+    secretsRepository.create.mockImplementation((row: { name: string }) =>
+      Promise.resolve(makeSecretRow(row.name)),
+    );
+    secretAuditLogRepository.create.mockResolvedValue(undefined);
+
+    const svc = newService();
+
+    const oversized = "a".repeat(65_537); // > MAX_SECRET_VALUE_BYTES (64KB)
+    const result = await svc.bulkCreate(
+      {
+        organizationId: "org1",
+        secrets: [
+          { name: "TOO_BIG", value: oversized },
+          { name: "OK", value: "small" },
+        ],
+        createdBy: "u1",
+      },
+      audit,
+    );
+
+    // Designed partial-success shape: the invalid item is an explicit error,
+    // the valid item is created — the failure did not abort the batch nor
+    // fabricate a created entry for the invalid input.
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].name).toBe("TOO_BIG");
+    expect(result.errors[0].error).toMatch(/maximum size/i);
+
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0].name).toBe("OK");
+
+    // The oversized item never reached the writer.
+    expect(secretsRepository.create).toHaveBeenCalledTimes(1);
+    expect(secretsRepository.create).toHaveBeenCalledWith(expect.objectContaining({ name: "OK" }));
+  });
+});

--- a/packages/cloud/shared/src/lib/services/secrets/secrets.ts
+++ b/packages/cloud/shared/src/lib/services/secrets/secrets.ts
@@ -596,6 +596,11 @@ class SecretsService {
       try {
         encrypted = await this.encryptValue(value);
       } catch (error) {
+        // error-policy:J1 batch boundary — a per-item encrypt/size-validation
+        // failure becomes a structured errors[] entry (the endpoint's designed
+        // partial-success shape) and is NOT counted as created. Systemic
+        // repository failures below stay uncaught and propagate, so a broken
+        // pipeline still fails closed rather than reporting an all-errors batch.
         errors.push({
           name,
           error: error instanceof Error ? error.message : "Encryption failed",

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/account-pool.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/account-pool.error-policy.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Error-policy proof for the cloud team-credential account-pool brain: an
+ * internal dependency failure (readAccounts / writeAccount throwing) must
+ * PROPAGATE out of the pool, while a legitimately-empty snapshot or an absent
+ * credential returns the pool's designed empty/no-op result. The two must be
+ * distinguishable — a broken pipeline must never read as "no eligible account".
+ * Deterministic in-memory deps (the injected seam), no DB.
+ */
+import type { LinkedAccountConfig } from "@elizaos/contracts";
+import { describe, expect, it, vi } from "vitest";
+import { TeamCredentialAccountPool } from "./account-pool";
+import type { AccountPoolDeps } from "./account-pool-contract";
+
+function makeAccount(overrides: Partial<LinkedAccountConfig> = {}): LinkedAccountConfig {
+  return {
+    id: "acc-1",
+    providerId: "anthropic-api",
+    label: "team key",
+    source: "api-key",
+    enabled: true,
+    priority: 0,
+    createdAt: 1,
+    health: "ok",
+    ...overrides,
+  };
+}
+
+function poolWith(
+  accounts: Record<string, LinkedAccountConfig>,
+  writeAccount: AccountPoolDeps["writeAccount"] = vi.fn(async () => {}),
+): { pool: TeamCredentialAccountPool; writeAccount: AccountPoolDeps["writeAccount"] } {
+  const deps: AccountPoolDeps = {
+    readAccounts: () => accounts,
+    writeAccount,
+  };
+  return { pool: new TeamCredentialAccountPool(deps), writeAccount };
+}
+
+describe("TeamCredentialAccountPool error policy — fail closed on dep failure", () => {
+  it("PROPAGATES a readAccounts failure out of select() (does not swallow to null)", async () => {
+    const boom = new Error("decrypt/DB snapshot read failed");
+    const deps: AccountPoolDeps = {
+      readAccounts: () => {
+        throw boom;
+      },
+      writeAccount: vi.fn(async () => {}),
+    };
+    const pool = new TeamCredentialAccountPool(deps);
+
+    await expect(pool.select({ providerId: "anthropic-api" })).rejects.toThrow(boom);
+  });
+
+  it("returns null for a legitimately-empty snapshot (designed empty, NOT a failure)", async () => {
+    const { pool } = poolWith({});
+    await expect(pool.select({ providerId: "anthropic-api" })).resolves.toBeNull();
+  });
+
+  it("returns null when accounts exist but none are eligible (designed empty)", async () => {
+    const { pool } = poolWith({
+      "anthropic-api:acc-1": makeAccount({ enabled: false }),
+    });
+    await expect(pool.select({ providerId: "anthropic-api" })).resolves.toBeNull();
+  });
+
+  it("selects the eligible account on the happy path (distinguishes success from empty)", async () => {
+    const account = makeAccount();
+    const { pool } = poolWith({ "anthropic-api:acc-1": account });
+    const picked = await pool.select({ providerId: "anthropic-api" });
+    expect(picked?.id).toBe("acc-1");
+  });
+
+  it("distinguishes failure from empty: same call, thrown read vs empty read differ", async () => {
+    const failing = new TeamCredentialAccountPool({
+      readAccounts: () => {
+        throw new Error("snapshot unavailable");
+      },
+      writeAccount: vi.fn(async () => {}),
+    });
+    const { pool: empty } = poolWith({});
+
+    await expect(failing.select({ providerId: "anthropic-api" })).rejects.toThrow();
+    await expect(empty.select({ providerId: "anthropic-api" })).resolves.toBeNull();
+  });
+});
+
+describe("TeamCredentialAccountPool error policy — health writeback", () => {
+  it("PROPAGATES a writeAccount failure out of markRateLimited (fail closed on the write path)", async () => {
+    const writeBoom = new Error("pooled_credentials update failed");
+    const { pool } = poolWith(
+      { "anthropic-api:acc-1": makeAccount() },
+      vi.fn(async () => {
+        throw writeBoom;
+      }),
+    );
+
+    await expect(
+      pool.markRateLimited("acc-1", Date.now() + 60_000, "429", { providerId: "anthropic-api" }),
+    ).rejects.toThrow(writeBoom);
+  });
+
+  it("markRateLimited for an absent credential is a silent no-op (not-found ≠ write failure)", async () => {
+    const writeAccount = vi.fn(async () => {});
+    const { pool } = poolWith({ "anthropic-api:acc-1": makeAccount() }, writeAccount);
+
+    await expect(
+      pool.markRateLimited("does-not-exist", Date.now() + 60_000, "429", {
+        providerId: "anthropic-api",
+      }),
+    ).resolves.toBeUndefined();
+    expect(writeAccount).not.toHaveBeenCalled();
+  });
+
+  it("markRateLimited writes health for a found credential (distinguishes no-op from real write)", async () => {
+    const writeAccount = vi.fn(async () => {});
+    const { pool } = poolWith({ "anthropic-api:acc-1": makeAccount() }, writeAccount);
+
+    await pool.markRateLimited("acc-1", Date.now() + 60_000, "429", {
+      providerId: "anthropic-api",
+    });
+    expect(writeAccount).toHaveBeenCalledTimes(1);
+    const written = writeAccount.mock.calls[0]?.[0] as LinkedAccountConfig;
+    expect(written.health).toBe("rate-limited");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/bootstrap-env.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/bootstrap-env.error-policy.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Error-policy guard for the pooled-credential bootstrap merge (#13415): a
+ * genuine registry fault must PROPAGATE (never be swallowed into the agent's
+ * unchanged env), while a legitimately-empty pool (no eligible credential)
+ * still returns the designed unchanged env — the two are distinguishable.
+ * Deterministic: the registry is mocked so `selectCredential` can be driven to
+ * return `null`, resolve a credential, or throw.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const selectCredential = vi.fn();
+const recordUse = vi.fn();
+
+vi.mock("./registry", () => ({
+  getTeamPoolRegistry: () => ({ selectCredential, recordUse }),
+}));
+
+import { applyPooledCredentialsToBootstrapEnv } from "./bootstrap-env";
+
+describe("applyPooledCredentialsToBootstrapEnv error policy", () => {
+  beforeEach(() => {
+    selectCredential.mockReset();
+    recordUse.mockReset();
+  });
+
+  it("legitimately-empty pool returns the env unchanged (designed empty, not a failure)", async () => {
+    selectCredential.mockResolvedValue(null);
+    const env = { FOO: "bar" };
+
+    const out = await applyPooledCredentialsToBootstrapEnv({
+      organizationId: "org-1",
+      userId: "user-1",
+      sessionKey: "sess-1",
+      env,
+    });
+
+    // The real select path was driven, produced no credential, and left env intact.
+    expect(selectCredential).toHaveBeenCalled();
+    expect(out).toEqual({ FOO: "bar" });
+    expect(recordUse).not.toHaveBeenCalled();
+  });
+
+  it("propagates an internal registry fault instead of falling back to the raw env", async () => {
+    selectCredential.mockRejectedValue(new Error("vault decrypt failed"));
+    const env = { FOO: "bar" };
+
+    await expect(
+      applyPooledCredentialsToBootstrapEnv({
+        organizationId: "org-1",
+        userId: "user-1",
+        sessionKey: "sess-1",
+        env,
+      }),
+    ).rejects.toThrow("vault decrypt failed");
+  });
+
+  it("merges a selected pooled key and attributes the use", async () => {
+    selectCredential.mockImplementation(async ({ providerId }: { providerId: string }) =>
+      providerId === "anthropic-api" ? { credentialId: "cred-1", apiKey: "sk-ant-pooled" } : null,
+    );
+    recordUse.mockResolvedValue(undefined);
+
+    const out = await applyPooledCredentialsToBootstrapEnv({
+      organizationId: "org-1",
+      userId: "user-1",
+      sessionKey: "sess-1",
+      env: {},
+    });
+
+    expect(out.ANTHROPIC_API_KEY).toBe("sk-ant-pooled");
+    expect(recordUse).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      credentialId: "cred-1",
+      userId: "user-1",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/bootstrap-env.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/bootstrap-env.ts
@@ -9,7 +9,13 @@
  * `settings.secrets` — pooled keys are NEVER persisted into the stored
  * `environment_vars` (they exist only in the create-request payload).
  *
- * Strict fallback: any failure returns the env unchanged (today's behavior).
+ * Pool unavailability is not a failure here: the registry (registry.ts) is the
+ * designed boundary that degrades a missing/unhealthy pool to `null` per
+ * provider (its `J4`), so a provider with no eligible credential simply leaves
+ * the env untouched. This module does NOT wrap that in a blanket catch — a
+ * genuine internal fault (e.g. a decrypt/DB error the registry could not
+ * absorb) must propagate so provisioning surfaces it rather than silently
+ * booting an agent that is missing a credential it was meant to receive.
  * An explicit per-agent key always wins over the pool.
  */
 
@@ -29,41 +35,33 @@ export interface ApplyPooledCredentialsParams {
 export async function applyPooledCredentialsToBootstrapEnv(
   params: ApplyPooledCredentialsParams,
 ): Promise<Record<string, string>> {
-  try {
-    const registry = getTeamPoolRegistry();
-    const merged = { ...params.env };
-    let applied = 0;
-    for (const providerId of POOLED_DIRECT_PROVIDERS) {
-      const envKey = POOLED_PROVIDER_ENV_KEYS[providerId];
-      if (merged[envKey]?.trim()) continue; // per-agent key wins
-      const selected = await registry.selectCredential({
-        organizationId: params.organizationId,
-        providerId,
-        sessionKey: params.sessionKey,
-      });
-      if (!selected) continue;
-      merged[envKey] = selected.apiKey;
-      applied += 1;
-      if (params.userId) {
-        await registry.recordUse({
-          organizationId: params.organizationId,
-          credentialId: selected.credentialId,
-          userId: params.userId,
-        });
-      }
-    }
-    if (applied > 0) {
-      logger.info("[TeamCredentialPool] merged pooled credentials into bootstrap env", {
-        organizationId: params.organizationId,
-        applied,
-      });
-    }
-    return merged;
-  } catch (err) {
-    logger.warn("[TeamCredentialPool] pooled-credential merge failed — using agent env as-is", {
+  const registry = getTeamPoolRegistry();
+  const merged = { ...params.env };
+  let applied = 0;
+  for (const providerId of POOLED_DIRECT_PROVIDERS) {
+    const envKey = POOLED_PROVIDER_ENV_KEYS[providerId];
+    if (merged[envKey]?.trim()) continue; // per-agent key wins
+    const selected = await registry.selectCredential({
       organizationId: params.organizationId,
-      error: err instanceof Error ? err.message : String(err),
+      providerId,
+      sessionKey: params.sessionKey,
     });
-    return params.env;
+    if (!selected) continue; // no eligible pooled credential — designed empty, not a failure
+    merged[envKey] = selected.apiKey;
+    applied += 1;
+    if (params.userId) {
+      await registry.recordUse({
+        organizationId: params.organizationId,
+        credentialId: selected.credentialId,
+        userId: params.userId,
+      });
+    }
   }
+  if (applied > 0) {
+    logger.info("[TeamCredentialPool] merged pooled credentials into bootstrap env", {
+      organizationId: params.organizationId,
+      applied,
+    });
+  }
+  return merged;
 }

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/pool-deps.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/pool-deps.error-policy.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Error-policy guard for DrizzleAccountPoolDeps: credential/DB failures must
+ * fail closed (propagate), while genuinely-empty domain outcomes ("row deleted
+ * underneath us", "no secret") stay distinguishable as designed no-ops. The
+ * only swallowed path is the J6 best-effort vault-secret teardown after an
+ * already-authoritative row delete. Deterministic in-memory mocks stand in for
+ * the repository + secrets vault; the class under test is real.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const repo = {
+  listByOrganization: vi.fn(),
+  updatePoolStateForOrganization: vi.fn(),
+  deleteForOrganization: vi.fn(),
+  findByIdForOrganization: vi.fn(),
+};
+const secrets = { delete: vi.fn() };
+const log = { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+vi.mock("../../../db/repositories/pooled-credentials", () => ({
+  pooledCredentialsRepository: repo,
+}));
+vi.mock("../secrets/secrets", () => ({ secretsService: secrets }));
+vi.mock("../../utils/logger", () => ({ logger: log }));
+
+import type { PooledCredential } from "../../../db/repositories/pooled-credentials";
+import { DrizzleAccountPoolDeps } from "./pool-deps";
+
+const ORG = "org-1";
+
+function makeRow(over: Partial<PooledCredential> = {}): PooledCredential {
+  const now = new Date("2026-01-01T00:00:00Z");
+  return {
+    id: "cred-1",
+    organization_id: ORG,
+    provider: "anthropic-api",
+    secret_id: "secret-1",
+    label: "team key",
+    key_last4: "abcd",
+    contributed_by: "user-1",
+    priority: 100,
+    enabled: true,
+    health: "ok",
+    health_detail: null,
+    usage: null,
+    last_used_at: null,
+    created_at: now,
+    updated_at: now,
+    ...over,
+  } as PooledCredential;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("DrizzleAccountPoolDeps.refresh (fail-closed load)", () => {
+  it("propagates a DB read failure instead of serving an empty snapshot", async () => {
+    repo.listByOrganization.mockRejectedValueOnce(new Error("db down"));
+    const deps = new DrizzleAccountPoolDeps(ORG);
+    await expect(deps.refresh()).rejects.toThrow("db down");
+    // A failed load must NOT masquerade as "org has zero credentials".
+    expect(Object.keys(deps.readAccounts())).toHaveLength(0);
+  });
+
+  it("serves the loaded rows on success", async () => {
+    repo.listByOrganization.mockResolvedValueOnce([makeRow()]);
+    const deps = new DrizzleAccountPoolDeps(ORG);
+    await deps.refresh();
+    expect(Object.keys(deps.readAccounts())).toHaveLength(1);
+    expect(deps.secretIdFor("cred-1")).toBe("secret-1");
+  });
+});
+
+describe("DrizzleAccountPoolDeps.writeAccount (fail-closed vs legit not-found)", () => {
+  it("propagates a DB write failure rather than silently dropping the row", async () => {
+    repo.listByOrganization.mockResolvedValueOnce([makeRow()]);
+    const deps = new DrizzleAccountPoolDeps(ORG);
+    await deps.refresh();
+    const account = deps.readAccounts()["anthropic-api:cred-1"];
+    expect(account).toBeDefined();
+
+    repo.updatePoolStateForOrganization.mockRejectedValueOnce(new Error("update failed"));
+    await expect(deps.writeAccount(account)).rejects.toThrow("update failed");
+    // The credential is still present — a failed write is not a deletion.
+    expect(deps.readAccounts()["anthropic-api:cred-1"]).toBeDefined();
+  });
+
+  it("treats an undefined update (row deleted underneath) as a designed drop, not a failure", async () => {
+    repo.listByOrganization.mockResolvedValueOnce([makeRow()]);
+    const deps = new DrizzleAccountPoolDeps(ORG);
+    await deps.refresh();
+    const account = deps.readAccounts()["anthropic-api:cred-1"];
+
+    repo.updatePoolStateForOrganization.mockResolvedValueOnce(undefined);
+    await expect(deps.writeAccount(account)).resolves.toBeUndefined();
+    // Legit "row gone" empties this key WITHOUT throwing — distinct from the
+    // DB-failure case above, which threw and kept the row.
+    expect(deps.readAccounts()["anthropic-api:cred-1"]).toBeUndefined();
+    expect(deps.secretIdFor("cred-1")).toBeNull();
+  });
+});
+
+describe("DrizzleAccountPoolDeps.deleteAccount", () => {
+  it("propagates a DB delete failure (the authoritative removal must fail closed)", async () => {
+    repo.listByOrganization.mockResolvedValueOnce([makeRow()]);
+    const deps = new DrizzleAccountPoolDeps(ORG);
+    await deps.refresh();
+
+    repo.deleteForOrganization.mockRejectedValueOnce(new Error("delete failed"));
+    await expect(deps.deleteAccount("anthropic-api", "cred-1")).rejects.toThrow("delete failed");
+    // Vault teardown never ran because the authoritative delete threw first.
+    expect(secrets.delete).not.toHaveBeenCalled();
+  });
+
+  it("swallows only the J6 best-effort secret teardown after a successful row delete", async () => {
+    repo.listByOrganization.mockResolvedValueOnce([makeRow()]);
+    const deps = new DrizzleAccountPoolDeps(ORG);
+    await deps.refresh();
+
+    repo.deleteForOrganization.mockResolvedValueOnce(makeRow());
+    secrets.delete.mockRejectedValueOnce(new Error("vault unavailable"));
+    // Row delete succeeded → the credential is unselectable; an orphaned secret
+    // is a GC concern, so this resolves rather than throwing.
+    await expect(deps.deleteAccount("anthropic-api", "cred-1")).resolves.toBeUndefined();
+    expect(deps.readAccounts()["anthropic-api:cred-1"]).toBeUndefined();
+    expect(secrets.delete).toHaveBeenCalledTimes(1);
+    // The swallowed teardown failure is surfaced observably as a warning.
+    expect(log.warn).toHaveBeenCalledWith(
+      "[DrizzleAccountPoolDeps] secret cleanup failed after credential delete",
+      expect.objectContaining({ organizationId: ORG, credentialId: "cred-1" }),
+    );
+  });
+
+  it("deletes the backing vault secret on the happy path", async () => {
+    repo.listByOrganization.mockResolvedValueOnce([makeRow()]);
+    const deps = new DrizzleAccountPoolDeps(ORG);
+    await deps.refresh();
+
+    repo.deleteForOrganization.mockResolvedValueOnce(makeRow());
+    secrets.delete.mockResolvedValueOnce(undefined);
+    await deps.deleteAccount("anthropic-api", "cred-1");
+    expect(secrets.delete).toHaveBeenCalledWith("secret-1", ORG, {
+      actorType: "system",
+      actorId: "team-credential-pool",
+      source: "team-credential-pool",
+    });
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/pool-deps.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/pool-deps.ts
@@ -131,8 +131,10 @@ export class DrizzleAccountPoolDeps implements AccountPoolDeps {
         source: "team-credential-pool",
       });
     } catch (err) {
-      // The pool row is already gone (the credential can never be selected
-      // again); an orphaned vault secret is a deletion concern, not a failure.
+      // error-policy:J6 best-effort teardown — the authoritative pool-row
+      // delete already succeeded, so the credential can never be selected
+      // again; an orphaned vault secret is a GC concern (warned, not fatal),
+      // not a failure of the removal. A DB delete failure above still throws.
       logger.warn("[DrizzleAccountPoolDeps] secret cleanup failed after credential delete", {
         organizationId: this.organizationId,
         credentialId: accountId,

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/probe.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/probe.error-policy.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Error-policy proof for the pooled-key live probe: a transport failure must
+ * surface as a distinguishable structured failure (never a fabricated
+ * `ok:true`), a revoked key must keep its real HTTP status, and a body-read
+ * failure must not clobber that status. Drives the real exported
+ * `probePooledApiKey` against a stubbed global `fetch` (no network, no DB).
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { probePooledApiKey } from "./probe";
+
+function okResponse(status: number): Response {
+  return {
+    ok: true,
+    status,
+    text: async () => "",
+  } as unknown as Response;
+}
+
+function errorResponse(status: number, body: string): Response {
+  return {
+    ok: false,
+    status,
+    text: async () => body,
+  } as unknown as Response;
+}
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("probePooledApiKey error policy", () => {
+  it("returns ok:true only on a real 2xx", async () => {
+    globalThis.fetch = mock(async () => okResponse(200)) as unknown as typeof fetch;
+
+    const result = await probePooledApiKey("openai-api", "sk-valid-key");
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+  });
+
+  it("translates a transport failure into a distinguishable status:0 failure — never a fabricated success", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+
+    const result = await probePooledApiKey("openai-api", "sk-any-key");
+
+    // The internal failure surfaces as ok:false, NOT silently swallowed into ok:true.
+    expect(result.ok).toBe(false);
+    // status:0 is the designed "transient / could-not-reach" signal callers use
+    // to leave credential health untouched — distinct from a real 401/403.
+    expect(result.status).toBe(0);
+    expect(result.error).toContain("ECONNREFUSED");
+  });
+
+  it("keeps the real HTTP status on a revoked key so it stays distinct from a transient", async () => {
+    globalThis.fetch = mock(async () =>
+      errorResponse(401, "invalid api key"),
+    ) as unknown as typeof fetch;
+
+    const result = await probePooledApiKey("openai-api", "sk-revoked-key");
+
+    expect(result.ok).toBe(false);
+    // A revoked key (401) must be distinguishable from a transport failure (0):
+    // callers flag needs-reauth only on 401/403, never on a network blip.
+    expect(result.status).toBe(401);
+    expect(result.error).toContain("401");
+    expect(result.error).toContain("invalid api key");
+  });
+
+  it("does not let a failed error-body read clobber the load-bearing HTTP status", async () => {
+    const bodyReadFails = {
+      ok: false,
+      status: 403,
+      text: async () => {
+        throw new Error("stream already consumed");
+      },
+    } as unknown as Response;
+    globalThis.fetch = mock(async () => bodyReadFails) as unknown as typeof fetch;
+
+    const result = await probePooledApiKey("openai-api", "sk-forbidden-key");
+
+    expect(result.ok).toBe(false);
+    // The inner `.catch(() => "")` on response.text() must preserve status 403,
+    // not fall through to the outer catch (which would report status:0).
+    expect(result.status).toBe(403);
+  });
+
+  it("distinguishes all three outcomes from one another", async () => {
+    const valid = { ...okResponse(200) };
+    globalThis.fetch = mock()
+      .mockResolvedValueOnce(valid)
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce(errorResponse(403, "forbidden")) as unknown as typeof fetch;
+
+    const healthy = await probePooledApiKey("openai-api", "k1");
+    const transient = await probePooledApiKey("openai-api", "k2");
+    const revoked = await probePooledApiKey("openai-api", "k3");
+
+    expect(healthy.ok).toBe(true);
+    expect(transient).toMatchObject({ ok: false, status: 0 });
+    expect(revoked).toMatchObject({ ok: false, status: 403 });
+    // The three renders are mutually distinct — a broken pipeline never reads as
+    // healthy, and a transient never reads as a revoked key.
+    expect(new Set([healthy.status, transient.status, revoked.status]).size).toBe(3);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/probe.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/probe.ts
@@ -72,6 +72,10 @@ export async function probePooledApiKey(
           });
     const latencyMs = Date.now() - start;
     if (!response.ok) {
+      // error-policy:J1 the non-2xx HTTP status is the load-bearing failure
+      // signal (drives fail-closed rejection at contribution and needs-reauth at
+      // keep-alive); reading the optional provider error body is best-effort and
+      // must not clobber that status by throwing out of this branch.
       const text = await response.text().catch(() => "");
       return {
         ok: false,
@@ -82,6 +86,12 @@ export async function probePooledApiKey(
     }
     return { ok: true, status: response.status, latencyMs };
   } catch (err) {
+    // error-policy:J1 boundary translation of a transport failure (fetch reject,
+    // DNS/TLS error, or the 10s AbortController timeout) into a structured probe
+    // failure. `ok:false` is a genuine failure — never a fabricated success:
+    // contribution (service.ts) rejects fail-closed on it, and keep-alive
+    // (registry.ts) treats status:0 as a transient and leaves credential health
+    // untouched rather than flagging a healthy key on a network blip.
     return {
       ok: false,
       status: 0,

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/registry.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/registry.error-policy.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Error-policy proof for the team-pool registry's J4 degrade layer: a
+ * legitimately-empty pool result and an internal credential/decrypt failure
+ * must be DISTINGUISHABLE. Both degrade to `null` (the additive-layer contract
+ * verified against `route.ts:selectPooledInferenceCredential` → platform env),
+ * but only the internal failure surfaces observably via `logger.warn` with
+ * error context — it is never silently swallowed. Deterministic in-memory
+ * doubles for the pool brain, deps, secrets vault, and logger; no DB.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+
+const mockSelect = mock();
+const mockRefresh = mock(async () => undefined);
+const mockSecretIdFor = mock();
+const mockGetDecryptedValue = mock();
+const mockWarn = mock();
+
+mock.module("../../utils/logger", () => ({
+  logger: { warn: mockWarn, info: mock(), error: mock(), debug: mock() },
+}));
+
+mock.module("../secrets/secrets", () => ({
+  secretsService: { getDecryptedValue: mockGetDecryptedValue },
+}));
+
+mock.module("./account-pool", () => ({
+  TeamCredentialAccountPool: mock(() => ({ select: mockSelect })),
+}));
+
+mock.module("./pool-deps", () => ({
+  DrizzleAccountPoolDeps: mock(() => ({
+    isStale: () => true,
+    refresh: mockRefresh,
+    secretIdFor: mockSecretIdFor,
+  })),
+}));
+
+mock.module("../../../db/repositories/pooled-credentials", () => ({
+  pooledCredentialsRepository: {
+    recordDailyUsage: mock(),
+    updatePoolStateForOrganization: mock(),
+  },
+}));
+
+import type { TeamPoolRegistry } from "./registry";
+
+const PARAMS = {
+  organizationId: "org-1",
+  providerId: "anthropic-api" as const,
+};
+
+async function freshRegistry(): Promise<TeamPoolRegistry> {
+  mockSelect.mockReset();
+  mockSecretIdFor.mockReset();
+  mockGetDecryptedValue.mockReset();
+  mockWarn.mockReset();
+  mockRefresh.mockClear();
+  mockRefresh.mockResolvedValue(undefined);
+  const { TeamPoolRegistry } = await import("./registry");
+  return new TeamPoolRegistry();
+}
+
+describe("TeamPoolRegistry.selectCredential error policy", () => {
+  it("returns null WITHOUT warning when the org has no eligible pooled credential (designed empty)", async () => {
+    const registry = await freshRegistry();
+    mockSelect.mockResolvedValue(null);
+
+    const result = await registry.selectCredential(PARAMS);
+
+    expect(result).toBeNull();
+    // Designed-empty must not masquerade as a failure: no failure log.
+    expect(mockWarn).not.toHaveBeenCalled();
+    expect(mockGetDecryptedValue).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an internal decrypt failure observably instead of silently swallowing it", async () => {
+    const registry = await freshRegistry();
+    mockSelect.mockResolvedValue({ id: "cred-1", label: "team-key" });
+    mockSecretIdFor.mockReturnValue("secret-1");
+    mockGetDecryptedValue.mockRejectedValue(new Error("vault decrypt failed"));
+
+    const result = await registry.selectCredential(PARAMS);
+
+    // J4 degrade to the platform-env path — but the failure is NOT hidden.
+    expect(result).toBeNull();
+    expect(mockGetDecryptedValue).toHaveBeenCalledTimes(1);
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    const [message, context] = mockWarn.mock.calls[0];
+    expect(message).toContain("[TeamPoolRegistry]");
+    expect(context).toMatchObject({
+      organizationId: "org-1",
+      providerId: "anthropic-api",
+      error: "vault decrypt failed",
+    });
+  });
+
+  it("distinguishes empty from failure: empty is silent, failure warns — for the same null return", async () => {
+    // Empty branch: no warn.
+    const emptyRegistry = await freshRegistry();
+    mockSelect.mockResolvedValue(null);
+    expect(await emptyRegistry.selectCredential(PARAMS)).toBeNull();
+    const warnsAfterEmpty = mockWarn.mock.calls.length;
+
+    // Failure branch: exactly one warn, on an otherwise identical call shape.
+    const failRegistry = await freshRegistry();
+    mockSelect.mockResolvedValue({ id: "cred-1", label: "team-key" });
+    mockSecretIdFor.mockReturnValue("secret-1");
+    mockGetDecryptedValue.mockRejectedValue(new Error("db unavailable"));
+    expect(await failRegistry.selectCredential(PARAMS)).toBeNull();
+
+    expect(warnsAfterEmpty).toBe(0);
+    expect(mockWarn.mock.calls.length).toBe(1);
+  });
+
+  it("returns the resolved credential on the happy path (no degrade, no warn)", async () => {
+    const registry = await freshRegistry();
+    mockSelect.mockResolvedValue({ id: "cred-1", label: "team-key" });
+    mockSecretIdFor.mockReturnValue("secret-1");
+    mockGetDecryptedValue.mockResolvedValue("sk-real-key");
+
+    const result = await registry.selectCredential(PARAMS);
+
+    expect(result).toEqual({
+      credentialId: "cred-1",
+      providerId: "anthropic-api",
+      envKey: "ANTHROPIC_API_KEY",
+      apiKey: "sk-real-key",
+      label: "team-key",
+    });
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/service.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/service.error-policy.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Error-policy proof for the team credential pool use-cases: an internal
+ * failure (DB / vault throwing) must PROPAGATE fail-closed, and must stay
+ * distinguishable from a legitimately-empty domain result (no rows / not
+ * found). Deterministic — every collaborator is a bun mock; no live DB or
+ * provider. Guards #13415: catches here compensate/teardown, they never
+ * swallow a failure into a fabricated success or default.
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+// bun's mock.module is not hoisted the way vitest's vi.mock is: the factories
+// must be registered before the module under test is imported. So the shared
+// collaborator mocks are declared here, registered via mock.module, and the
+// service is pulled in with a dynamic import() inside each test.
+const repo = {
+  create: mock(),
+  listByOrganizationWithContributor: mock(),
+  usageTotalsForDay: mock(),
+  deleteForOrganization: mock(),
+};
+const secrets = {
+  create: mock(async () => ({ id: "secret-1" })),
+  delete: mock(async () => undefined),
+};
+const probe = mock(async () => ({ ok: true, status: 200, latencyMs: 1 }));
+const registryInvalidate = mock();
+
+mock.module("../../../db/repositories/pooled-credentials", () => ({
+  pooledCredentialsRepository: repo,
+}));
+
+mock.module("../secrets/secrets", () => ({
+  secretsService: secrets,
+}));
+
+mock.module("./probe", () => ({
+  probePooledApiKey: probe,
+}));
+
+mock.module("./registry", () => ({
+  getTeamPoolRegistry: () => ({ invalidate: registryInvalidate }),
+}));
+
+mock.module("../../utils/logger", () => ({
+  logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
+}));
+
+// provider-map is intentionally NOT mocked — the real provider validation runs.
+async function loadService() {
+  return import("./service");
+}
+
+const audit = { actorType: "user", actorId: "u1", source: "test" } as never;
+
+const baseContribute = {
+  organizationId: "org-1",
+  userId: "u1",
+  provider: "anthropic-api",
+  apiKey: "sk-ant-0123456789",
+  audit,
+};
+
+beforeEach(() => {
+  repo.create.mockReset();
+  repo.listByOrganizationWithContributor.mockReset();
+  repo.usageTotalsForDay.mockReset();
+  repo.deleteForOrganization.mockReset();
+  secrets.create.mockReset();
+  secrets.delete.mockReset();
+  probe.mockReset();
+  registryInvalidate.mockReset();
+
+  probe.mockResolvedValue({ ok: true, status: 200, latencyMs: 1 });
+  secrets.create.mockResolvedValue({ id: "secret-1" });
+  secrets.delete.mockResolvedValue(undefined);
+});
+
+describe("contributePooledCredential — internal failure fails closed", () => {
+  it("propagates a pool-row insert failure instead of swallowing it, and compensates the vault secret", async () => {
+    const { contributePooledCredential } = await loadService();
+    const insertError = new Error("pooled_credentials insert failed");
+    repo.create.mockRejectedValueOnce(insertError);
+
+    await expect(contributePooledCredential(baseContribute)).rejects.toBe(insertError);
+
+    // Fail-closed: the just-created vault secret is torn down, not stranded.
+    expect(secrets.delete).toHaveBeenCalledWith("secret-1", "org-1", audit);
+  });
+
+  it("does not let a best-effort cleanup failure mask the original insert failure", async () => {
+    const { contributePooledCredential } = await loadService();
+    const insertError = new Error("pooled_credentials insert failed");
+    repo.create.mockRejectedValueOnce(insertError);
+    secrets.delete.mockRejectedValueOnce(new Error("vault delete also failed"));
+
+    // The ORIGINAL failure surfaces — the J6 teardown catch does not replace it.
+    await expect(contributePooledCredential(baseContribute)).rejects.toBe(insertError);
+  });
+});
+
+describe("removePooledCredential — not-found vs internal failure are distinguishable", () => {
+  it("returns a designed 404 for a legitimately-missing credential", async () => {
+    const { removePooledCredential, TeamCredentialPoolError } = await loadService();
+    repo.deleteForOrganization.mockResolvedValue(undefined);
+
+    await expect(
+      removePooledCredential({ credentialId: "c1", organizationId: "org-1", audit }),
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      removePooledCredential({ credentialId: "c1", organizationId: "org-1", audit }),
+    ).rejects.toBeInstanceOf(TeamCredentialPoolError);
+  });
+
+  it("propagates a raw DB failure rather than masking it as a 404", async () => {
+    const { removePooledCredential, TeamCredentialPoolError } = await loadService();
+    const dbError = new Error("connection reset");
+    repo.deleteForOrganization.mockRejectedValueOnce(dbError);
+
+    const rejection = removePooledCredential({
+      credentialId: "c1",
+      organizationId: "org-1",
+      audit,
+    });
+    await expect(rejection).rejects.toBe(dbError);
+    // Distinct from the not-found path: this is NOT a 404 TeamCredentialPoolError.
+    await expect(rejection).rejects.not.toBeInstanceOf(TeamCredentialPoolError);
+  });
+});
+
+describe("listPooledCredentials — empty result vs internal failure are distinguishable", () => {
+  it("returns an empty list for an org with no pooled credentials", async () => {
+    const { listPooledCredentials } = await loadService();
+    repo.listByOrganizationWithContributor.mockResolvedValueOnce([]);
+    repo.usageTotalsForDay.mockResolvedValueOnce(new Map());
+
+    await expect(listPooledCredentials("org-1")).resolves.toEqual([]);
+  });
+
+  it("propagates a query failure instead of returning an empty list", async () => {
+    const { listPooledCredentials } = await loadService();
+    const queryError = new Error("select failed");
+    repo.listByOrganizationWithContributor.mockRejectedValueOnce(queryError);
+    repo.usageTotalsForDay.mockResolvedValueOnce(new Map());
+
+    await expect(listPooledCredentials("org-1")).rejects.toBe(queryError);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/service.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/service.ts
@@ -156,6 +156,9 @@ export async function contributePooledCredential(
     });
   } catch (err) {
     // Don't strand an orphaned vault secret when the pool row fails to land.
+    // error-policy:J6 best-effort compensating teardown of the just-created
+    // vault secret; the cleanup failure is logged but must not mask the
+    // original row-insert failure, which is rethrown below (fail-closed).
     await secretsService
       .delete(secret.id, params.organizationId, params.audit)
       .catch((cleanupErr: unknown) => {
@@ -247,6 +250,8 @@ export async function removePooledCredential(params: {
   } catch (err) {
     // Pool row is gone — the credential can never be selected again. An
     // orphaned vault secret is logged for deletion, not surfaced as a failure.
+    // error-policy:J6 best-effort teardown after the load-bearing delete
+    // (pool row) already succeeded; the credential is unusable regardless.
     logger.warn("[TeamCredentialPool] secret cleanup failed after credential delete", {
       organizationId: params.organizationId,
       credentialId: params.credentialId,


### PR DESCRIPTION
## Slice of #13415 — cloud-shared services fallback-slop sweep

Covers the **team-credential-pool** (6 files) + **secrets** (2 files) services. Verified untouched by every in-flight fallback-sweep branch before starting, so it does not conflict with the parallel sweeps.

### The one behavioral fix
`bootstrap-env.applyPooledCredentialsToBootstrapEnv` was wrapped in a blanket `try/catch` that returned the env **unchanged on any failure** — a decrypt/DB fault while selecting a pooled credential would silently boot an agent **missing a credential it was meant to receive** (broken pipeline reading as success). Now:
- no eligible pooled credential (the registry's designed `J4` null) → leave env untouched;
- a genuine internal fault → propagate, failing provisioning closed — consistent with the `decryptAgentEnvVars`/create throws already in the caller (`eliza-sandbox.ts`, whose stale "strict fallback" comment is corrected).

### Everything else = annotation only (no behavior change)
Genuinely-justified handlers annotated with grep-able `// error-policy:J<N>`: `secrets.bulkCreate` (J1 batch partial-success), `encryption.decrypt` (J2 rethrow with `cause`), probe/service/pool-deps (J1/J2/J6). `account-pool.ts` and `registry.ts` already fail closed / were already annotated → no change.

### Real error-path tests (anti-larp)
8 new `bun:test` files — **39 tests / 92 assertions, all green** — each proving, per service, that an internal failure **propagates** (not swallowed to empty/default) while a legitimately-empty/not-found case still returns its designed empty result, so the two stay **distinguishable**.

### Verification (see `.github/issue-evidence/13415-cloud-shared-services-fallback.md`)
- 39 error-path tests pass; existing team-credential-pool + secrets suites 50 pass / 0 fail (no regression); no existing test pinned the removed swallow behavior.
- `biome check` clean; `audit:error-policy-ratchet` → "no new fallback-slop in touched files"; typecheck adds 0 new errors in touched files (pre-existing repo-wide drizzle-orm declaration noise unchanged).