### PR TITLE
fix: encapsulate iOS smoke host agent

### DIFF
--- a/.github/issue-evidence/13574-ios-host-agent-helper.md
+++ b/.github/issue-evidence/13574-ios-host-agent-helper.md
@@ -1,0 +1,45 @@
+# Issue #13574 - iOS Host-Agent Helper
+
+## Change
+
+- Added `packages/app/scripts/lib/host-agent.mjs` to start
+  `packages/app-core/scripts/serve-real-local-agent.ts`, choose a requested or
+  free host port, wait for `/api/health`, write `host-agent.log`, and tear down
+  on normal exit or SIGINT/SIGTERM.
+- `ios-onboarding-smoke.mjs` and `ios-attachment-smoke.mjs` now start the
+  deterministic host agent when `--api-base` is omitted. Passing `--api-base`
+  still uses an externally managed API.
+- `mobile-local-chat-smoke.mjs` now supports `--host-agent` for api-base-less
+  remote API runs.
+- `mobile-build-smoke.yml` now calls the script-owned lanes directly and keeps
+  each `host-agent.log` under the existing uploaded `packages/app/test-results`
+  directory.
+
+## Verification
+
+- PASS: `git fetch origin && git rebase origin/develop`
+- PASS: `bun install`
+- PASS: `node --check packages/app/scripts/lib/host-agent.mjs`
+- PASS: `node --check packages/app/scripts/ios-onboarding-smoke.mjs`
+- PASS: `node --check packages/app/scripts/ios-attachment-smoke.mjs`
+- PASS: `node --check packages/app/scripts/mobile-local-chat-smoke.mjs`
+- PASS:
+  `bunx vitest run --config packages/app/vitest.config.ts packages/app/scripts/lib/host-agent.test.mjs`
+  - 5 tests passed, including a subprocess health-server lifecycle check.
+- PASS:
+  `bunx @biomejs/biome check --write packages/app/scripts/lib/host-agent.mjs packages/app/scripts/lib/host-agent.test.mjs packages/app/scripts/ios-onboarding-smoke.mjs packages/app/scripts/ios-attachment-smoke.mjs packages/app/scripts/mobile-local-chat-smoke.mjs`
+- PASS:
+  `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mobile-build-smoke.yml"); puts "yaml ok"'`
+- FAIL (unrelated repo ratchet): `bun run verify`
+  - Failed in `audit:type-safety-ratchet` before this branch's script checks ran.
+  - Reported existing ratchet deltas:
+    - `as unknown as`: 74 current > 73 baseline
+    - `?? []` in core/agent/app-core: 582 current > 581 baseline
+
+## Not Run
+
+- `bun run --cwd packages/app test:e2e:ios:onboarding`: not run in this
+  worktree because the required installed iOS Simulator app/Xcode lane is not
+  available in the current execution environment.
+- Full `mobile-build-smoke.yml`: not run locally; intended to be validated by
+  GitHub Actions on the PR.

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -161,28 +161,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p packages/app/test-results/ios-onboarding-to-home
-          ELIZA_API_PORT=31338 ELIZA_PAIRING_DISABLED=1 \
-            node packages/app-core/scripts/run-node-tsx.mjs packages/app-core/scripts/serve-real-local-agent.ts \
-            > packages/app/test-results/ios-onboarding-to-home/host-agent.log 2>&1 &
-          HOST_AGENT_PID=$!
-          cleanup() {
-            kill "$HOST_AGENT_PID" 2>/dev/null || true
-            wait "$HOST_AGENT_PID" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-          for attempt in $(seq 1 90); do
-            if curl -fsS http://127.0.0.1:31338/api/health >/dev/null; then
-              break
-            fi
-            if ! kill -0 "$HOST_AGENT_PID" 2>/dev/null; then
-              echo "Host agent exited before /api/health became ready"
-              cat packages/app/test-results/ios-onboarding-to-home/host-agent.log
-              exit 1
-            fi
-            sleep 2
-          done
-          curl -fsS http://127.0.0.1:31338/api/health >/dev/null
-          node packages/app/scripts/ios-onboarding-smoke.mjs --api-base http://127.0.0.1:31338
+          node packages/app/scripts/ios-onboarding-smoke.mjs
 
       - name: Upload iOS onboarding evidence
         if: always()
@@ -201,28 +180,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p packages/app/test-results/ios-attachment-smoke
-          ELIZA_API_PORT=31338 ELIZA_PAIRING_DISABLED=1 \
-            node packages/app-core/scripts/run-node-tsx.mjs packages/app-core/scripts/serve-real-local-agent.ts \
-            > packages/app/test-results/ios-attachment-smoke/host-agent.log 2>&1 &
-          HOST_AGENT_PID=$!
-          cleanup() {
-            kill "$HOST_AGENT_PID" 2>/dev/null || true
-            wait "$HOST_AGENT_PID" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-          for attempt in $(seq 1 90); do
-            if curl -fsS http://127.0.0.1:31338/api/health >/dev/null; then
-              break
-            fi
-            if ! kill -0 "$HOST_AGENT_PID" 2>/dev/null; then
-              echo "Host agent exited before /api/health became ready"
-              cat packages/app/test-results/ios-attachment-smoke/host-agent.log
-              exit 1
-            fi
-            sleep 2
-          done
-          curl -fsS http://127.0.0.1:31338/api/health >/dev/null
-          node packages/app/scripts/ios-attachment-smoke.mjs --api-base http://127.0.0.1:31338
+          node packages/app/scripts/ios-attachment-smoke.mjs
 
       - name: Upload iOS native attachment evidence
         if: always()
@@ -244,29 +202,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p packages/app/test-results/ios-local-chat
-          ELIZA_API_PORT=31338 ELIZA_PAIRING_DISABLED=1 \
-            node packages/app-core/scripts/run-node-tsx.mjs packages/app-core/scripts/serve-real-local-agent.ts \
-            > packages/app/test-results/ios-local-chat/host-agent.log 2>&1 &
-          HOST_AGENT_PID=$!
-          cleanup() {
-            kill "$HOST_AGENT_PID" 2>/dev/null || true
-            wait "$HOST_AGENT_PID" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-          for attempt in $(seq 1 90); do
-            if curl -fsS http://127.0.0.1:31338/api/health >/dev/null; then
-              break
-            fi
-            if ! kill -0 "$HOST_AGENT_PID" 2>/dev/null; then
-              echo "Host agent exited before /api/health became ready"
-              cat packages/app/test-results/ios-local-chat/host-agent.log
-              exit 1
-            fi
-            sleep 2
-          done
-          curl -fsS http://127.0.0.1:31338/api/health >/dev/null
           node packages/app/scripts/mobile-local-chat-smoke.mjs \
-            --platform ios --require-installed --api-base http://127.0.0.1:31338
+            --platform ios --require-installed --host-agent \
+            --host-agent-log packages/app/test-results/ios-local-chat/host-agent.log
 
       - name: Upload iOS local-chat evidence
         if: always()

--- a/packages/app/scripts/ios-attachment-smoke.mjs
+++ b/packages/app/scripts/ios-attachment-smoke.mjs
@@ -11,6 +11,10 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  resolveHostAgentRequestedPort,
+  startHostAgent,
+} from "./lib/host-agent.mjs";
+import {
   captureIosSimulatorScreenshot,
   startIosSimulatorVideo,
 } from "./lib/ios-simulator-capture.mjs";
@@ -29,7 +33,6 @@ const ONBOARDING_REQUEST_KEY = "eliza:ios-onboarding-smoke:request";
 const ONBOARDING_RESULT_KEY = "eliza:ios-onboarding-smoke:result";
 const ATTACHMENT_REQUEST_KEY = "eliza:ios-attachment-smoke:request";
 const ATTACHMENT_RESULT_KEY = "eliza:ios-attachment-smoke:result";
-const DEFAULT_API_BASE = "http://127.0.0.1:31338";
 const PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
@@ -394,84 +397,102 @@ async function pollResult(udid, appId) {
 
 async function main() {
   const { appId, urlScheme } = readAppIdentity();
-  const apiBase = val("--api-base", DEFAULT_API_BASE);
+  const explicitApiBase = val("--api-base");
+  let apiBase = explicitApiBase;
+  let hostAgent = null;
   const filename = val("--filename", "eliza-ios-attachment-smoke.png");
   const udid = ensureSimulatorBooted();
   removePathRecursive(resultDir);
   fs.mkdirSync(resultDir, { recursive: true });
-
-  deleteSimulatorPreferenceDomainKeys(udid, appId, FIRST_RUN_STATE_KEYS);
-  flushPreferences(udid);
-  installLatestApp(udid, appId);
-  tryRun("xcrun", ["simctl", "terminate", udid, appId]);
-  clearState(udid, appId);
-  defaultsWriteString(
-    udid,
-    appId,
-    ONBOARDING_REQUEST_KEY,
-    JSON.stringify({ apiBase }),
-  );
-  defaultsWriteString(
-    udid,
-    appId,
-    ONBOARDING_RESULT_KEY,
-    JSON.stringify({
-      ok: false,
-      phase: "requested",
-      apiBase,
-      updatedAt: new Date().toISOString(),
-    }),
-  );
-  defaultsWriteString(
-    udid,
-    appId,
-    ATTACHMENT_REQUEST_KEY,
-    JSON.stringify({
-      apiBase,
-      filename,
-      dataUrl: `data:image/png;base64,${PNG_BASE64}`,
-    }),
-  );
-  defaultsWriteString(
-    udid,
-    appId,
-    ATTACHMENT_RESULT_KEY,
-    JSON.stringify({
-      ok: false,
-      phase: "requested",
-      apiBase,
-      updatedAt: new Date().toISOString(),
-    }),
-  );
-  flushPreferences(udid);
-
-  const recording = startVideo(udid);
   try {
-    log(`launching ${appId} on ${udid}`);
-    simctl(["launch", udid, appId]);
-    await sleep(1500);
-    const deepLink = `${urlScheme}://first-run/runtime/remote?api=${encodeURIComponent(apiBase)}`;
-    if (has("--os-deep-link")) {
-      log(`opening first-run remote deep link: ${deepLink}`);
-      simctl(["openurl", udid, deepLink]);
-    } else {
-      log(`armed in-app first-run remote connect for ${apiBase}`);
+    if (!apiBase) {
+      hostAgent = await startHostAgent({
+        repoRoot,
+        port: resolveHostAgentRequestedPort(),
+        logPath: val(
+          "--host-agent-log",
+          path.join(resultDir, "host-agent.log"),
+        ),
+        log,
+      });
+      apiBase = hostAgent.apiBase;
     }
-    takeScreenshot(udid, "fresh-launch");
-    const result = await pollResult(udid, appId);
-    const screenshot = takeScreenshot(udid, "attachment-result");
-    const video = await stopVideo(recording);
-    fs.writeFileSync(
-      path.join(resultDir, "result.json"),
-      `${JSON.stringify({ ...result, screenshot, video }, null, 2)}\n`,
+
+    deleteSimulatorPreferenceDomainKeys(udid, appId, FIRST_RUN_STATE_KEYS);
+    flushPreferences(udid);
+    installLatestApp(udid, appId);
+    tryRun("xcrun", ["simctl", "terminate", udid, appId]);
+    clearState(udid, appId);
+    defaultsWriteString(
+      udid,
+      appId,
+      ONBOARDING_REQUEST_KEY,
+      JSON.stringify({ apiBase }),
     );
-    log(`PASS ${JSON.stringify({ screenshot, video })}`);
-  } catch (error) {
-    const screenshot = takeScreenshot(udid, "failure");
-    await stopVideo(recording);
-    throw new Error(
-      `${error instanceof Error ? error.message : String(error)}${screenshot ? ` (screenshot: ${screenshot})` : ""}`,
+    defaultsWriteString(
+      udid,
+      appId,
+      ONBOARDING_RESULT_KEY,
+      JSON.stringify({
+        ok: false,
+        phase: "requested",
+        apiBase,
+        updatedAt: new Date().toISOString(),
+      }),
     );
+    defaultsWriteString(
+      udid,
+      appId,
+      ATTACHMENT_REQUEST_KEY,
+      JSON.stringify({
+        apiBase,
+        filename,
+        dataUrl: `data:image/png;base64,${PNG_BASE64}`,
+      }),
+    );
+    defaultsWriteString(
+      udid,
+      appId,
+      ATTACHMENT_RESULT_KEY,
+      JSON.stringify({
+        ok: false,
+        phase: "requested",
+        apiBase,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+    flushPreferences(udid);
+
+    const recording = startVideo(udid);
+    try {
+      log(`launching ${appId} on ${udid}`);
+      simctl(["launch", udid, appId]);
+      await sleep(1500);
+      const deepLink = `${urlScheme}://first-run/runtime/remote?api=${encodeURIComponent(apiBase)}`;
+      if (has("--os-deep-link")) {
+        log(`opening first-run remote deep link: ${deepLink}`);
+        simctl(["openurl", udid, deepLink]);
+      } else {
+        log(`armed in-app first-run remote connect for ${apiBase}`);
+      }
+      takeScreenshot(udid, "fresh-launch");
+      const result = await pollResult(udid, appId);
+      const screenshot = takeScreenshot(udid, "attachment-result");
+      const video = await stopVideo(recording);
+      fs.writeFileSync(
+        path.join(resultDir, "result.json"),
+        `${JSON.stringify({ ...result, screenshot, video }, null, 2)}\n`,
+      );
+      log(`PASS ${JSON.stringify({ screenshot, video })}`);
+    } catch (error) {
+      const screenshot = takeScreenshot(udid, "failure");
+      await stopVideo(recording);
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}${screenshot ? ` (screenshot: ${screenshot})` : ""}`,
+      );
+    }
+  } finally {
+    await hostAgent?.stop("ios-attachment-smoke");
   }
 }
 

--- a/packages/app/scripts/ios-onboarding-smoke.mjs
+++ b/packages/app/scripts/ios-onboarding-smoke.mjs
@@ -11,6 +11,10 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  resolveHostAgentRequestedPort,
+  startHostAgent,
+} from "./lib/host-agent.mjs";
+import {
   assertCandidateIosAppRendererFresh,
   assertInstalledIosAppRendererFresh,
 } from "./lib/ios-renderer-stamp.mjs";
@@ -37,7 +41,6 @@ const MIXED_CONTENT_REQUEST_KEY = "eliza:ios-mixed-content-smoke:request";
 const MIXED_CONTENT_RESULT_KEY = "eliza:ios-mixed-content-smoke:result";
 const ATTACHMENT_REQUEST_KEY = "eliza:ios-attachment-smoke:request";
 const ATTACHMENT_RESULT_KEY = "eliza:ios-attachment-smoke:result";
-const DEFAULT_API_BASE = "http://127.0.0.1:31338";
 
 const has = (flag) => process.argv.includes(flag);
 const val = (flag, fallback = null) => {
@@ -461,134 +464,45 @@ async function pollMixedContentResult(udid, appId) {
 
 async function main() {
   const { appId, urlScheme } = readAppIdentity();
-  const apiBase = val("--api-base", DEFAULT_API_BASE);
+  const explicitApiBase = val("--api-base");
+  let apiBase = explicitApiBase;
+  let hostAgent = null;
   const udid = ensureSimulatorBooted();
   removePathRecursive(resultDir);
   fs.mkdirSync(resultDir, { recursive: true });
-
-  clearIosSmokeDefaults({
-    udid,
-    bundleId: appId,
-    extraKeys: FIRST_RUN_STATE_KEYS,
-    log,
-  });
-  installLatestApp(udid, appId);
-  tryRun("xcrun", ["simctl", "terminate", udid, appId]);
-  clearIosSmokeDefaults({
-    udid,
-    bundleId: appId,
-    extraKeys: FIRST_RUN_STATE_KEYS,
-    log,
-  });
-  defaultsWriteString(udid, appId, REQUEST_KEY, JSON.stringify({ apiBase }));
-  defaultsWriteString(
-    udid,
-    appId,
-    RESULT_KEY,
-    JSON.stringify({
-      ok: false,
-      phase: "requested",
-      apiBase,
-      updatedAt: new Date().toISOString(),
-    }),
-  );
-  flushPreferences(udid);
-  defaultsWriteString(
-    udid,
-    appId,
-    MIXED_CONTENT_REQUEST_KEY,
-    JSON.stringify({ apiBase }),
-  );
-  defaultsWriteString(
-    udid,
-    appId,
-    MIXED_CONTENT_RESULT_KEY,
-    JSON.stringify({
-      ok: false,
-      phase: "requested",
-      apiBase,
-      updatedAt: new Date().toISOString(),
-    }),
-  );
-  flushPreferences(udid);
-
-  const recording = startVideo(udid);
   try {
-    log(`launching ${appId} on ${udid}`);
-    simctl(["launch", udid, appId]);
-    await sleep(1500);
-    const deepLink = `${urlScheme}://first-run/runtime/remote?api=${encodeURIComponent(apiBase)}`;
-    if (has("--os-deep-link")) {
-      log(`opening first-run remote deep link: ${deepLink}`);
-      simctl(["openurl", udid, deepLink]);
-    } else {
-      log(`armed in-app first-run remote connect for ${apiBase}`);
+    if (!apiBase) {
+      hostAgent = await startHostAgent({
+        repoRoot,
+        port: resolveHostAgentRequestedPort(),
+        logPath: val(
+          "--host-agent-log",
+          path.join(resultDir, "host-agent.log"),
+        ),
+        log,
+      });
+      apiBase = hostAgent.apiBase;
     }
-    takeScreenshot(udid, "fresh-onboarding");
-    const result = await pollResult(udid, appId);
-    const screenshot = takeScreenshot(udid, "home-landing");
-    if (result.homeVisible !== true || result.composerVisible !== true) {
-      throw new Error(
-        `iOS onboarding smoke result lacked home/composer: ${JSON.stringify(result)}`,
-      );
-    }
-    if (result.onboardingHidden !== true) {
-      throw new Error(
-        `iOS onboarding smoke did not prove onboarding was hidden: ${JSON.stringify(result)}`,
-      );
-    }
-    const activeServer = result.storage?.["elizaos:active-server"];
-    if (typeof activeServer !== "string" || !activeServer.includes(apiBase)) {
-      throw new Error(
-        `iOS onboarding smoke did not persist active server ${apiBase}: ${JSON.stringify(result.storage)}`,
-      );
-    }
-    const mixedContentResult = await pollMixedContentResult(udid, appId);
-    if (
-      !String(mixedContentResult.webViewOrigin).startsWith("https://localhost")
-    ) {
-      throw new Error(
-        `iOS mixed-content smoke did not run from https://localhost: ${JSON.stringify(mixedContentResult)}`,
-      );
-    }
-    if (mixedContentResult.mixedContentWouldBlockWebSocket !== true) {
-      throw new Error(
-        `iOS mixed-content smoke did not prove an insecure ws:// would be mixed content: ${JSON.stringify(mixedContentResult)}`,
-      );
-    }
-    if (
-      !Array.isArray(mixedContentResult.webSocketConstructorCalls) ||
-      mixedContentResult.webSocketConstructorCalls.length !== 0
-    ) {
-      throw new Error(
-        `iOS mixed-content smoke attempted a WebSocket: ${JSON.stringify(mixedContentResult.webSocketConstructorCalls)}`,
-      );
-    }
-    if (mixedContentResult.connectionState?.state !== "connected") {
-      throw new Error(
-        `iOS mixed-content smoke was not connected-over-REST: ${JSON.stringify(mixedContentResult.connectionState)}`,
-      );
-    }
-    if (mixedContentResult.lostBackendOverlayAbsent !== true) {
-      throw new Error(
-        `iOS mixed-content smoke found the lost backend overlay: ${JSON.stringify(mixedContentResult)}`,
-      );
-    }
-    if (mixedContentResult.restHealth?.ok !== true) {
-      throw new Error(
-        `iOS mixed-content smoke REST health failed: ${JSON.stringify(mixedContentResult.restHealth)}`,
-      );
-    }
+
+    clearIosSmokeDefaults({
+      udid,
+      bundleId: appId,
+      extraKeys: FIRST_RUN_STATE_KEYS,
+      log,
+    });
+    installLatestApp(udid, appId);
+    tryRun("xcrun", ["simctl", "terminate", udid, appId]);
+    clearIosSmokeDefaults({
+      udid,
+      bundleId: appId,
+      extraKeys: FIRST_RUN_STATE_KEYS,
+      log,
+    });
+    defaultsWriteString(udid, appId, REQUEST_KEY, JSON.stringify({ apiBase }));
     defaultsWriteString(
       udid,
       appId,
-      RELAUNCH_REQUEST_KEY,
-      JSON.stringify({ apiBase }),
-    );
-    defaultsWriteString(
-      udid,
-      appId,
-      RELAUNCH_RESULT_KEY,
+      RESULT_KEY,
       JSON.stringify({
         ok: false,
         phase: "requested",
@@ -597,63 +511,172 @@ async function main() {
       }),
     );
     flushPreferences(udid);
-    log(`terminating ${appId} for cold relaunch proof`);
-    simctl(["terminate", udid, appId]);
-    await sleep(1000);
-    log(`relaunching ${appId} for cold relaunch proof`);
-    simctl(["launch", udid, appId]);
-    const relaunchResult = await pollRelaunchResult(udid, appId);
-    const relaunchScreenshot = takeScreenshot(udid, "cold-relaunch-home");
-    const video = await stopVideo(recording);
-    if (
-      relaunchResult.homeVisible !== true ||
-      relaunchResult.composerVisible !== true
-    ) {
-      throw new Error(
-        `iOS relaunch smoke result lacked home/composer: ${JSON.stringify(relaunchResult)}`,
-      );
-    }
-    if (relaunchResult.onboardingHidden !== true) {
-      throw new Error(
-        `iOS relaunch smoke did not prove onboarding was hidden: ${JSON.stringify(relaunchResult)}`,
-      );
-    }
-    clearIosSmokeDefaults({
+    defaultsWriteString(
       udid,
-      bundleId: appId,
-      extraKeys: FIRST_RUN_STATE_KEYS,
-      log,
-    });
-    fs.writeFileSync(
-      path.join(resultDir, "result.json"),
-      `${JSON.stringify(
-        {
-          ...result,
-          screenshot,
-          video,
-          mixedContent: mixedContentResult,
-          coldRelaunch: {
-            ...relaunchResult,
-            screenshot: relaunchScreenshot,
+      appId,
+      MIXED_CONTENT_REQUEST_KEY,
+      JSON.stringify({ apiBase }),
+    );
+    defaultsWriteString(
+      udid,
+      appId,
+      MIXED_CONTENT_RESULT_KEY,
+      JSON.stringify({
+        ok: false,
+        phase: "requested",
+        apiBase,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+    flushPreferences(udid);
+
+    const recording = startVideo(udid);
+    try {
+      log(`launching ${appId} on ${udid}`);
+      simctl(["launch", udid, appId]);
+      await sleep(1500);
+      const deepLink = `${urlScheme}://first-run/runtime/remote?api=${encodeURIComponent(apiBase)}`;
+      if (has("--os-deep-link")) {
+        log(`opening first-run remote deep link: ${deepLink}`);
+        simctl(["openurl", udid, deepLink]);
+      } else {
+        log(`armed in-app first-run remote connect for ${apiBase}`);
+      }
+      takeScreenshot(udid, "fresh-onboarding");
+      const result = await pollResult(udid, appId);
+      const screenshot = takeScreenshot(udid, "home-landing");
+      if (result.homeVisible !== true || result.composerVisible !== true) {
+        throw new Error(
+          `iOS onboarding smoke result lacked home/composer: ${JSON.stringify(result)}`,
+        );
+      }
+      if (result.onboardingHidden !== true) {
+        throw new Error(
+          `iOS onboarding smoke did not prove onboarding was hidden: ${JSON.stringify(result)}`,
+        );
+      }
+      const activeServer = result.storage?.["elizaos:active-server"];
+      if (typeof activeServer !== "string" || !activeServer.includes(apiBase)) {
+        throw new Error(
+          `iOS onboarding smoke did not persist active server ${apiBase}: ${JSON.stringify(result.storage)}`,
+        );
+      }
+      const mixedContentResult = await pollMixedContentResult(udid, appId);
+      if (
+        !String(mixedContentResult.webViewOrigin).startsWith(
+          "https://localhost",
+        )
+      ) {
+        throw new Error(
+          `iOS mixed-content smoke did not run from https://localhost: ${JSON.stringify(mixedContentResult)}`,
+        );
+      }
+      if (mixedContentResult.mixedContentWouldBlockWebSocket !== true) {
+        throw new Error(
+          `iOS mixed-content smoke did not prove an insecure ws:// would be mixed content: ${JSON.stringify(mixedContentResult)}`,
+        );
+      }
+      if (
+        !Array.isArray(mixedContentResult.webSocketConstructorCalls) ||
+        mixedContentResult.webSocketConstructorCalls.length !== 0
+      ) {
+        throw new Error(
+          `iOS mixed-content smoke attempted a WebSocket: ${JSON.stringify(mixedContentResult.webSocketConstructorCalls)}`,
+        );
+      }
+      if (mixedContentResult.connectionState?.state !== "connected") {
+        throw new Error(
+          `iOS mixed-content smoke was not connected-over-REST: ${JSON.stringify(mixedContentResult.connectionState)}`,
+        );
+      }
+      if (mixedContentResult.lostBackendOverlayAbsent !== true) {
+        throw new Error(
+          `iOS mixed-content smoke found the lost backend overlay: ${JSON.stringify(mixedContentResult)}`,
+        );
+      }
+      if (mixedContentResult.restHealth?.ok !== true) {
+        throw new Error(
+          `iOS mixed-content smoke REST health failed: ${JSON.stringify(mixedContentResult.restHealth)}`,
+        );
+      }
+      defaultsWriteString(
+        udid,
+        appId,
+        RELAUNCH_REQUEST_KEY,
+        JSON.stringify({ apiBase }),
+      );
+      defaultsWriteString(
+        udid,
+        appId,
+        RELAUNCH_RESULT_KEY,
+        JSON.stringify({
+          ok: false,
+          phase: "requested",
+          apiBase,
+          updatedAt: new Date().toISOString(),
+        }),
+      );
+      flushPreferences(udid);
+      log(`terminating ${appId} for cold relaunch proof`);
+      simctl(["terminate", udid, appId]);
+      await sleep(1000);
+      log(`relaunching ${appId} for cold relaunch proof`);
+      simctl(["launch", udid, appId]);
+      const relaunchResult = await pollRelaunchResult(udid, appId);
+      const relaunchScreenshot = takeScreenshot(udid, "cold-relaunch-home");
+      const video = await stopVideo(recording);
+      if (
+        relaunchResult.homeVisible !== true ||
+        relaunchResult.composerVisible !== true
+      ) {
+        throw new Error(
+          `iOS relaunch smoke result lacked home/composer: ${JSON.stringify(relaunchResult)}`,
+        );
+      }
+      if (relaunchResult.onboardingHidden !== true) {
+        throw new Error(
+          `iOS relaunch smoke did not prove onboarding was hidden: ${JSON.stringify(relaunchResult)}`,
+        );
+      }
+      clearIosSmokeDefaults({
+        udid,
+        bundleId: appId,
+        extraKeys: FIRST_RUN_STATE_KEYS,
+        log,
+      });
+      fs.writeFileSync(
+        path.join(resultDir, "result.json"),
+        `${JSON.stringify(
+          {
+            ...result,
+            screenshot,
+            video,
+            mixedContent: mixedContentResult,
+            coldRelaunch: {
+              ...relaunchResult,
+              screenshot: relaunchScreenshot,
+            },
           },
-        },
-        null,
-        2,
-      )}\n`,
-    );
-    log(`PASS ${JSON.stringify({ screenshot, relaunchScreenshot, video })}`);
-  } catch (error) {
-    const screenshot = takeScreenshot(udid, "failure");
-    await stopVideo(recording);
-    clearIosSmokeDefaults({
-      udid,
-      bundleId: appId,
-      extraKeys: FIRST_RUN_STATE_KEYS,
-      log,
-    });
-    throw new Error(
-      `${error instanceof Error ? error.message : String(error)}${screenshot ? ` (screenshot: ${screenshot})` : ""}`,
-    );
+          null,
+          2,
+        )}\n`,
+      );
+      log(`PASS ${JSON.stringify({ screenshot, relaunchScreenshot, video })}`);
+    } catch (error) {
+      const screenshot = takeScreenshot(udid, "failure");
+      await stopVideo(recording);
+      clearIosSmokeDefaults({
+        udid,
+        bundleId: appId,
+        extraKeys: FIRST_RUN_STATE_KEYS,
+        log,
+      });
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}${screenshot ? ` (screenshot: ${screenshot})` : ""}`,
+      );
+    }
+  } finally {
+    await hostAgent?.stop("ios-onboarding-smoke");
   }
 }
 

--- a/packages/app/scripts/lib/host-agent.mjs
+++ b/packages/app/scripts/lib/host-agent.mjs
@@ -1,0 +1,287 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(here, "..", "..", "..", "..");
+export const DEFAULT_HOST_AGENT_HOST = "127.0.0.1";
+export const DEFAULT_HOST_AGENT_PORT = 31338;
+const DEFAULT_HEALTH_ATTEMPTS = 90;
+const DEFAULT_HEALTH_DELAY_MS = 2000;
+const DEFAULT_HEALTH_TIMEOUT_MS = 5000;
+
+export function parsePositivePort(raw, label = "port") {
+  if (raw === undefined || raw === null || raw === "") return null;
+  const value = String(raw).trim();
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`Invalid ${label}: ${raw}`);
+  }
+  const port = Number.parseInt(value, 10);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`Invalid ${label}: ${raw}`);
+  }
+  return port;
+}
+
+export async function isTcpPortAvailable(port, host = DEFAULT_HOST_AGENT_HOST) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", () => resolve(false));
+    server.listen({ host, port }, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+export async function findOpenTcpPort(host = DEFAULT_HOST_AGENT_HOST) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", reject);
+    server.listen({ host, port: 0 }, () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : null;
+      server.close(() => {
+        if (port) resolve(port);
+        else reject(new Error("Failed to allocate a free TCP port."));
+      });
+    });
+  });
+}
+
+export function resolveHostAgentRequestedPort(
+  argv = process.argv.slice(2),
+  env = process.env,
+) {
+  const index = argv.indexOf("--host-agent-port");
+  if (index >= 0) {
+    return parsePositivePort(argv[index + 1], "--host-agent-port");
+  }
+  return parsePositivePort(env?.ELIZA_HOST_AGENT_PORT, "ELIZA_HOST_AGENT_PORT");
+}
+
+export async function chooseHostAgentPort({
+  requestedPort = null,
+  preferredPort = DEFAULT_HOST_AGENT_PORT,
+  host = DEFAULT_HOST_AGENT_HOST,
+  checkPortAvailable = isTcpPortAvailable,
+  allocateFreePort = findOpenTcpPort,
+} = {}) {
+  const requested = parsePositivePort(requestedPort, "host agent port");
+  if (requested) {
+    if (!(await checkPortAvailable(requested, host))) {
+      throw new Error(`Host-agent port ${requested} is already in use.`);
+    }
+    return requested;
+  }
+
+  const preferred = parsePositivePort(
+    preferredPort,
+    "preferred host-agent port",
+  );
+  if (preferred && (await checkPortAvailable(preferred, host))) {
+    return preferred;
+  }
+  return allocateFreePort(host);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchHealth(apiBase, timeoutMs) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${apiBase}/api/health`, {
+      signal: controller.signal,
+    });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function readLogTail(logPath, maxBytes = 8000) {
+  if (!logPath || !fs.existsSync(logPath)) return "";
+  const stat = fs.statSync(logPath);
+  const length = Math.min(stat.size, maxBytes);
+  const fd = fs.openSync(logPath, "r");
+  try {
+    const buffer = Buffer.alloc(length);
+    fs.readSync(fd, buffer, 0, length, Math.max(0, stat.size - length));
+    return buffer.toString("utf8");
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+export async function waitForHostAgentHealth({
+  apiBase,
+  child,
+  getChildError = () => null,
+  logPath,
+  attempts = DEFAULT_HEALTH_ATTEMPTS,
+  delayMs = DEFAULT_HEALTH_DELAY_MS,
+  timeoutMs = DEFAULT_HEALTH_TIMEOUT_MS,
+}) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const childError = getChildError();
+    if (childError) {
+      const tail = readLogTail(logPath);
+      throw new Error(
+        `Host agent failed to start: ${childError.message}.${tail ? `\n${tail}` : ""}`,
+      );
+    }
+    const childExitCode = child?.exitCode;
+    const childSignalCode = child?.signalCode;
+    if (
+      (childExitCode !== null && childExitCode !== undefined) ||
+      (childSignalCode !== null && childSignalCode !== undefined)
+    ) {
+      const tail = readLogTail(logPath);
+      throw new Error(
+        `Host agent exited before /api/health became ready (${childSignalCode ? `signal ${childSignalCode}` : `exit ${childExitCode}`}).${tail ? `\n${tail}` : ""}`,
+      );
+    }
+    if (await fetchHealth(apiBase, timeoutMs)) return;
+    await sleep(delayMs);
+  }
+  const tail = readLogTail(logPath);
+  throw new Error(
+    `Host agent did not become healthy at ${apiBase}/api/health after ${attempts} attempts.${tail ? `\n${tail}` : ""}`,
+  );
+}
+
+function defaultHostAgentArgs(repoRoot) {
+  return [
+    path.join(repoRoot, "packages", "app-core", "scripts", "run-node-tsx.mjs"),
+    path.join(
+      repoRoot,
+      "packages",
+      "app-core",
+      "scripts",
+      "serve-real-local-agent.ts",
+    ),
+  ];
+}
+
+function exitCodeForSignal(signal) {
+  return signal === "SIGINT" ? 130 : 143;
+}
+
+export async function startHostAgent({
+  repoRoot = REPO_ROOT,
+  host = DEFAULT_HOST_AGENT_HOST,
+  port = resolveHostAgentRequestedPort(),
+  preferredPort = DEFAULT_HOST_AGENT_PORT,
+  logPath,
+  command = process.execPath,
+  args = defaultHostAgentArgs(repoRoot),
+  env = process.env,
+  log = () => {},
+  signalSafe = true,
+  healthAttempts = DEFAULT_HEALTH_ATTEMPTS,
+  healthDelayMs = DEFAULT_HEALTH_DELAY_MS,
+  healthTimeoutMs = DEFAULT_HEALTH_TIMEOUT_MS,
+} = {}) {
+  const selectedPort = await chooseHostAgentPort({
+    requestedPort: port,
+    preferredPort,
+    host,
+  });
+  const apiBase = `http://${host}:${selectedPort}`;
+  if (logPath) fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  const logStream = logPath
+    ? fs.createWriteStream(logPath, { flags: "a" })
+    : null;
+  const writeLog = (line) => {
+    if (!logStream) return;
+    logStream.write(`${line}\n`);
+  };
+  writeLog(`[host-agent-helper] starting ${apiBase}`);
+  const child = spawn(command, args, {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      ...env,
+      ELIZA_API_PORT: String(selectedPort),
+      ELIZA_PORT: String(selectedPort),
+      ELIZA_PAIRING_DISABLED: "1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout?.pipe(logStream ?? process.stdout);
+  child.stderr?.pipe(logStream ?? process.stderr);
+
+  let stopped = false;
+  let exitInfo = null;
+  let childError = null;
+  const exitPromise = new Promise((resolve) => {
+    child.once("exit", (code, signal) => {
+      exitInfo = { code, signal };
+      resolve(exitInfo);
+    });
+    child.once("error", (error) => {
+      childError = error;
+      exitInfo = { code: null, signal: null, error };
+      resolve(exitInfo);
+    });
+  });
+
+  const signalHandlers = [];
+  const stop = async (reason = "stop") => {
+    if (stopped) return exitInfo;
+    stopped = true;
+    for (const [signal, handler] of signalHandlers) {
+      process.off(signal, handler);
+    }
+    writeLog(`[host-agent-helper] stopping (${reason})`);
+    if (!exitInfo && child.exitCode === null) {
+      child.kill("SIGTERM");
+      const timeout = setTimeout(() => {
+        if (!exitInfo && child.exitCode === null) child.kill("SIGKILL");
+      }, 10_000);
+      await exitPromise.finally(() => clearTimeout(timeout));
+    }
+    if (logStream) {
+      await new Promise((resolve) => logStream.end(resolve));
+    }
+    return exitInfo;
+  };
+
+  if (signalSafe) {
+    for (const signal of ["SIGINT", "SIGTERM"]) {
+      const handler = () => {
+        void stop(signal).finally(() =>
+          process.exit(exitCodeForSignal(signal)),
+        );
+      };
+      process.once(signal, handler);
+      signalHandlers.push([signal, handler]);
+    }
+  }
+
+  try {
+    await waitForHostAgentHealth({
+      apiBase,
+      child,
+      getChildError: () => childError,
+      logPath,
+      attempts: healthAttempts,
+      delayMs: healthDelayMs,
+      timeoutMs: healthTimeoutMs,
+    });
+    log(`host agent ready at ${apiBase}`);
+  } catch (error) {
+    await stop("startup-failed");
+    throw error;
+  }
+
+  return { apiBase, port: selectedPort, child, logPath, stop };
+}

--- a/packages/app/scripts/lib/host-agent.test.mjs
+++ b/packages/app/scripts/lib/host-agent.test.mjs
@@ -1,0 +1,121 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  chooseHostAgentPort,
+  findOpenTcpPort,
+  parsePositivePort,
+  resolveHostAgentRequestedPort,
+  startHostAgent,
+} from "./host-agent.mjs";
+
+const tempDirs = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+function makeTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "host-agent-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("host-agent helper", () => {
+  it("parses only valid positive TCP ports", () => {
+    expect(parsePositivePort("31338")).toBe(31338);
+    expect(parsePositivePort(undefined)).toBe(null);
+    expect(() => parsePositivePort("0")).toThrow(/Invalid/);
+    expect(() => parsePositivePort("65536")).toThrow(/Invalid/);
+    expect(() => parsePositivePort("31338abc")).toThrow(/Invalid/);
+  });
+
+  it("resolves --host-agent-port before env", () => {
+    expect(
+      resolveHostAgentRequestedPort(["--host-agent-port", "44444"], {
+        ELIZA_HOST_AGENT_PORT: "33333",
+      }),
+    ).toBe(44444);
+    expect(
+      resolveHostAgentRequestedPort([], { ELIZA_HOST_AGENT_PORT: "33333" }),
+    ).toBe(33333);
+  });
+
+  it("uses a requested free port and rejects a requested occupied port", async () => {
+    await expect(
+      chooseHostAgentPort({
+        requestedPort: 45678,
+        checkPortAvailable: async () => true,
+      }),
+    ).resolves.toBe(45678);
+    await expect(
+      chooseHostAgentPort({
+        requestedPort: 45678,
+        checkPortAvailable: async () => false,
+      }),
+    ).rejects.toThrow(/already in use/);
+  });
+
+  it("falls back to an allocated free port when the preferred port is occupied", async () => {
+    await expect(
+      chooseHostAgentPort({
+        preferredPort: 31338,
+        checkPortAvailable: async (port) => port !== 31338,
+        allocateFreePort: async () => 45679,
+      }),
+    ).resolves.toBe(45679);
+  });
+
+  it("starts a subprocess, waits for /api/health, writes logs, and stops it", async () => {
+    const dir = makeTempDir();
+    const serverPath = path.join(dir, "server.mjs");
+    fs.writeFileSync(
+      serverPath,
+      `
+import http from "node:http";
+const port = Number.parseInt(process.env.ELIZA_API_PORT, 10);
+const server = http.createServer((req, res) => {
+  if (req.url === "/api/health") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+  res.writeHead(404);
+  res.end();
+});
+server.listen(port, "127.0.0.1", () => {
+  console.log("test host agent ready", port);
+});
+process.once("SIGTERM", () => server.close(() => process.exit(0)));
+      `.trim(),
+      "utf8",
+    );
+    const preferredPort = await findOpenTcpPort();
+    const logPath = path.join(dir, "host-agent.log");
+    const agent = await startHostAgent({
+      repoRoot: dir,
+      preferredPort,
+      logPath,
+      command: process.execPath,
+      args: [serverPath],
+      signalSafe: false,
+      healthAttempts: 20,
+      healthDelayMs: 50,
+      healthTimeoutMs: 500,
+    });
+
+    expect(agent.apiBase).toBe(`http://127.0.0.1:${preferredPort}`);
+    await expect(fetch(`${agent.apiBase}/api/health`)).resolves.toMatchObject({
+      ok: true,
+    });
+    await agent.stop("test");
+    expect(fs.readFileSync(logPath, "utf8")).toContain(
+      "[host-agent-helper] starting",
+    );
+    expect(fs.readFileSync(logPath, "utf8")).toContain("test host agent ready");
+    await expect(fetch(`${agent.apiBase}/api/health`)).rejects.toThrow();
+  });
+});

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -15,6 +15,10 @@ import {
   ANDROID_FULL_TURN_FAILURE_RE,
   IOS_FULL_BUN_SMOKE_FAILURE_RE,
 } from "./lib/chat-failure-strings.mjs";
+import {
+  resolveHostAgentRequestedPort,
+  startHostAgent,
+} from "./lib/host-agent.mjs";
 import { assertInstalledIosAppRendererFresh } from "./lib/ios-renderer-stamp.mjs";
 import { clearIosSmokeDefaults } from "./lib/ios-sim-defaults-hygiene.mjs";
 import { evaluateLocalInferenceReadiness } from "./lib/local-inference-readiness.mjs";
@@ -34,7 +38,10 @@ const platform = argValue("--platform") ?? "ios";
 const apiBase = argValue("--api-base");
 const authTokenArg = argValue("--auth-token");
 const requireInstalled = process.argv.includes("--require-installed");
-const exerciseAppCoreApi = process.argv.includes("--live") || Boolean(apiBase);
+const useHostAgent = process.argv.includes("--host-agent");
+const hostAgentLogPath = argValue("--host-agent-log");
+const exerciseAppCoreApi =
+  process.argv.includes("--live") || Boolean(apiBase) || useHostAgent;
 const iosSelectLocal = process.argv.includes("--ios-select-local");
 const iosFullBunSmoke = process.argv.includes("--ios-full-bun-smoke");
 const androidSelectLocal = process.argv.includes("--android-select-local");
@@ -180,6 +187,9 @@ Options:
   --require-installed              Fail when the selected app/simulator is unavailable
   --live                           Exercise the app-core local-agent HTTP API on Android
   --api-base URL                   Exercise an already-reachable app-core HTTP API
+  --host-agent                     Start the deterministic host app-core API, then exercise it
+  --host-agent-port PORT           Port for --host-agent (default: 31338 if free)
+  --host-agent-log PATH            Log path for --host-agent
   --auth-token TOKEN               Bearer token for protected app-core API routes
   --ios-select-local               Pre-seed iOS first-run/runtime state for Local mode before launch
   --ios-full-bun-smoke             Run a WebView-executed full Bun backend smoke in the iOS app
@@ -2427,7 +2437,11 @@ async function runLocalInferenceApiSmoke(
 async function main() {
   let androidContext = null;
   let iosContext = null;
+  let hostAgent = null;
   try {
+    if (apiBase && useHostAgent) {
+      throw new Error("--api-base and --host-agent are mutually exclusive.");
+    }
     if (platform === "ios" || platform === "both") {
       iosContext = launchIosSimulatorApp();
       if (iosContext?.installed) {
@@ -2443,6 +2457,26 @@ async function main() {
 
     if (apiBase) {
       await runLocalInferenceApiSmoke(apiBase, authTokenArg);
+      return;
+    }
+
+    if (useHostAgent) {
+      hostAgent = await startHostAgent({
+        repoRoot,
+        port: resolveHostAgentRequestedPort(),
+        logPath:
+          hostAgentLogPath ??
+          path.join(
+            repoRoot,
+            "packages",
+            "app",
+            "test-results",
+            "mobile-local-chat",
+            "host-agent.log",
+          ),
+        log: (message) => console.log(`[local-chat-smoke] ${message}`),
+      });
+      await runLocalInferenceApiSmoke(hostAgent.apiBase, authTokenArg);
       return;
     }
 
@@ -2502,6 +2536,7 @@ async function main() {
       );
     }
   } finally {
+    await hostAgent?.stop("mobile-local-chat-smoke");
     if (iosContext?.udid) {
       clearIosSmokeDefaults({
         udid: iosContext.udid,


### PR DESCRIPTION
## Summary

Fixes #13574.

- Add `packages/app/scripts/lib/host-agent.mjs` to start the deterministic `serve-real-local-agent.ts`, choose a requested/free port, wait for `/api/health`, write host-agent logs, and tear down on normal exit/signals.
- Make `ios-onboarding-smoke.mjs` and `ios-attachment-smoke.mjs` boot the host agent by default when `--api-base` is omitted, while preserving explicit externally managed `--api-base` runs.
- Add `mobile-local-chat-smoke.mjs --host-agent` for api-base-less remote host-agent runs.
- Remove the triplicated host-agent shell boot/poll/cleanup blocks from `mobile-build-smoke.yml`; uploaded artifact paths still include each lane's `host-agent.log`.

## Evidence

See `.github/issue-evidence/13574-ios-host-agent-helper.md`.

Verified:

- `git fetch origin && git rebase origin/develop`
- `bun install`
- `node --check packages/app/scripts/lib/host-agent.mjs`
- `node --check packages/app/scripts/ios-onboarding-smoke.mjs`
- `node --check packages/app/scripts/ios-attachment-smoke.mjs`
- `node --check packages/app/scripts/mobile-local-chat-smoke.mjs`
- `bunx vitest run --config packages/app/vitest.config.ts packages/app/scripts/lib/host-agent.test.mjs`
- `bunx @biomejs/biome check packages/app/scripts/lib/host-agent.mjs packages/app/scripts/lib/host-agent.test.mjs packages/app/scripts/ios-onboarding-smoke.mjs packages/app/scripts/ios-attachment-smoke.mjs packages/app/scripts/mobile-local-chat-smoke.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mobile-build-smoke.yml"); puts "yaml ok"'`
- `git diff --check`

Not green:

- `bun run verify` fails before this branch's package checks in `audit:type-safety-ratchet` with existing repo ratchet deltas: `as unknown as` 74 > 73 and core/agent/app-core `?? []` 582 > 581.

Not run locally:

- `bun run --cwd packages/app test:e2e:ios:onboarding` and full `mobile-build-smoke.yml`, because this environment does not have the required installed iOS Simulator app/Xcode lane.