### PR TITLE
fix(#13859): keep plugin list routes responsive

### DIFF
--- a/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   loadRegistry: vi.fn(),
   readCompatJsonBody: vi.fn(),
   saveElizaConfig: vi.fn(),
+  sendJson: vi.fn(),
   sendJsonError: vi.fn(),
 }));
 
@@ -38,7 +39,7 @@ vi.mock("@elizaos/app-core/api/compat-route-shared", () => ({
 }));
 
 vi.mock("@elizaos/app-core/api/response", () => ({
-  sendJson: vi.fn(),
+  sendJson: mocks.sendJson,
   sendJsonError: mocks.sendJsonError,
 }));
 
@@ -116,7 +117,7 @@ function makePlugin(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe("persistCompatPluginMutation", () => {
+describe("app plugin compatibility routes", () => {
   let currentConfig: Record<string, unknown>;
   let savedConfig: Record<string, unknown> | undefined;
 
@@ -132,11 +133,13 @@ describe("persistCompatPluginMutation", () => {
     savedConfig = undefined;
     mocks.loadElizaConfig.mockImplementation(() => currentConfig);
     mocks.loadRegistry.mockReturnValue({ all: [], byId: new Map() });
+    mocks.loadRegistry.mockClear();
     mocks.saveElizaConfig.mockImplementation((config) => {
       savedConfig = clone(config);
     });
     mocks.ensureRouteAuthorized.mockResolvedValue(true);
     mocks.readCompatJsonBody.mockResolvedValue({});
+    mocks.sendJson.mockClear();
     mocks.sendJsonError.mockClear();
   });
 
@@ -255,6 +258,47 @@ describe("persistCompatPluginMutation", () => {
 
     expect(response.plugins.find((plugin) => plugin.id === "discord")).toEqual(
       expect.objectContaining({ isActive: false }),
+    );
+  });
+
+  it("builds the plugin list once for GET /api/plugins", async () => {
+    const discordEntry = {
+      id: "discord",
+      name: "Discord",
+      npmName: "@elizaos/plugin-discord",
+      description: "",
+      tags: [],
+      kind: "connector",
+      subtype: "chat",
+      config: {},
+      render: {},
+      resources: {},
+      version: "1.0.0",
+    };
+    mocks.loadRegistry.mockReturnValue({
+      all: [discordEntry],
+      byId: new Map([["discord", discordEntry]]),
+    });
+
+    const handled = await handlePluginsCompatRoutes(
+      {
+        method: "GET",
+        url: "/api/plugins",
+      } as never,
+      {} as never,
+      { current: null } as never,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.loadRegistry).toHaveBeenCalledTimes(1);
+    expect(mocks.sendJson).toHaveBeenCalledWith(
+      expect.anything(),
+      200,
+      expect.objectContaining({
+        plugins: expect.arrayContaining([
+          expect.objectContaining({ id: "discord" }),
+        ]),
+      }),
     );
   });
 

--- a/plugins/plugin-registry/src/api/app-plugins-routes.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.ts
@@ -666,7 +666,14 @@ export function analyzePluginStateDrift(
 function buildPluginDriftDiagnostics(
   runtime: AgentRuntime | null,
 ): PluginDriftDiagnosticsReport {
-  const pluginList = buildPluginListResponse(runtime).plugins;
+  return buildPluginDriftDiagnosticsForList(
+    buildPluginListResponse(runtime).plugins,
+  );
+}
+
+function buildPluginDriftDiagnosticsForList(
+  pluginList: CompatPluginRecord[],
+): PluginDriftDiagnosticsReport {
   const config = loadElizaConfig();
   const configRecord = config as Record<string, unknown>;
   const configEntries = config.plugins?.entries ?? {};
@@ -1530,7 +1537,9 @@ export async function handlePluginsCompatRoutes(
     logger.debug(
       `[api/plugins] source=registry total=${pluginResponse.plugins.length} runtime=${state.current ? "active" : "null"}`,
     );
-    maybeLogPluginStateDrift(buildPluginDriftDiagnostics(state.current));
+    maybeLogPluginStateDrift(
+      buildPluginDriftDiagnosticsForList(pluginResponse.plugins),
+    );
     sendJsonResponse(res, 200, pluginResponse);
     return true;
   }

--- a/plugins/plugin-registry/src/api/plugin-routes.test.ts
+++ b/plugins/plugin-registry/src/api/plugin-routes.test.ts
@@ -1,3 +1,4 @@
+import { logger } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -233,5 +234,59 @@ describe("handlePluginRoutes config persistence", () => {
     expect(handled).toBe(true);
     expect(requirePluginManager).not.toHaveBeenCalled();
     expect(ctx.error).toHaveBeenCalledWith(ctx.res, expect.any(String), 400);
+  });
+
+  it("returns /api/plugins with best-effort metadata when registry refresh hangs", async () => {
+    vi.useFakeTimers();
+    try {
+      const config = { env: {}, plugins: { entries: {} } };
+      const ctx = makeContext({}, config, {
+        method: "GET",
+        pathname: "/api/plugins",
+        url: new URL("http://localhost/api/plugins"),
+      });
+      const never = new Promise<Map<string, never>>(() => {});
+      const listInstalledPlugins = vi.fn().mockResolvedValue([
+        {
+          name: "@elizaos/plugin-discord",
+          version: "1.2.3",
+          releaseStream: "latest",
+          requestedVersion: "1.2.3",
+          latestVersion: "1.2.3",
+          betaVersion: null,
+        },
+      ]);
+      const refreshRegistry = vi.fn(() => never);
+      ctx.requirePluginManager = vi.fn(() => ({
+        listInstalledPlugins,
+        refreshRegistry,
+      })) as never;
+      ctx.buildPluginEvmDiagnosticEntry = vi.fn(() => ({
+        ...makePlugin(),
+        id: "evm",
+        name: "EVM",
+        npmName: "@elizaos/plugin-evm",
+      })) as never;
+
+      const handled = handlePluginRoutes(ctx);
+
+      await vi.advanceTimersByTimeAsync(2500);
+
+      await expect(handled).resolves.toBe(true);
+      expect(ctx.json).toHaveBeenCalledWith(ctx.res, {
+        plugins: expect.arrayContaining([
+          expect.objectContaining({
+            id: "discord",
+            version: "1.2.3",
+            latestVersion: "1.2.3",
+          }),
+        ]),
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("registry plugin metadata"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/plugins/plugin-registry/src/api/plugin-routes.ts
+++ b/plugins/plugin-registry/src/api/plugin-routes.ts
@@ -302,6 +302,35 @@ const pluginsListInFlight = new WeakMap<
   PluginRouteContext["state"],
   Promise<PluginEntry[]>
 >();
+const PLUGIN_METADATA_TIMEOUT_MS = 2_500;
+
+async function withPluginMetadataTimeout<T>(
+  promise: Promise<T>,
+  label: string,
+): Promise<T | null> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(
+            new Error(
+              `${label} timed out after ${PLUGIN_METADATA_TIMEOUT_MS}ms`,
+            ),
+          );
+        }, PLUGIN_METADATA_TIMEOUT_MS);
+      }),
+    ]);
+  } catch (err) {
+    logger.warn(
+      `[plugin-routes] Failed to load ${label}; returning plugin list with best-effort metadata: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
 
 function readCompatEnabledFromConfig(
   config: ElizaConfig,
@@ -415,26 +444,39 @@ export async function handlePluginRoutes(
     let registryMetadataByName = new Map<string, RegistryPluginInfo>();
     try {
       const pluginManager = requirePluginManager(state.runtime);
-      const installed = await pluginManager.listInstalledPlugins();
-      installedMetadataByName = new Map(
-        installed.map((plugin) => [
-          plugin.name,
-          {
-            version: plugin.version,
-            releaseStream: plugin.releaseStream,
-            requestedVersion: plugin.requestedVersion,
-            latestVersion: plugin.latestVersion,
-            betaVersion: plugin.betaVersion,
-          },
-        ]),
-      );
+      const [installed, registry] = await Promise.all([
+        withPluginMetadataTimeout(
+          pluginManager.listInstalledPlugins(),
+          "installed plugin metadata",
+        ),
+        withPluginMetadataTimeout(
+          pluginManager.refreshRegistry(),
+          "registry plugin metadata",
+        ),
+      ]);
 
-      const registry = await pluginManager.refreshRegistry();
-      registryMetadataByName = new Map<string, RegistryPluginInfo>();
-      for (const [key, info] of registry) {
-        for (const candidate of [key, info.name, info.npm.package]) {
-          const normalized = normalizeRegistryLookupKey(candidate);
-          if (normalized) registryMetadataByName.set(normalized, info);
+      if (installed) {
+        installedMetadataByName = new Map(
+          installed.map((plugin) => [
+            plugin.name,
+            {
+              version: plugin.version,
+              releaseStream: plugin.releaseStream,
+              requestedVersion: plugin.requestedVersion,
+              latestVersion: plugin.latestVersion,
+              betaVersion: plugin.betaVersion,
+            },
+          ]),
+        );
+      }
+
+      if (registry) {
+        registryMetadataByName = new Map<string, RegistryPluginInfo>();
+        for (const [key, info] of registry) {
+          for (const candidate of [key, info.name, info.npm.package]) {
+            const normalized = normalizeRegistryLookupKey(candidate);
+            if (normalized) registryMetadataByName.set(normalized, info);
+          }
         }
       }
     } catch {


### PR DESCRIPTION
## Summary
- make app-core compat `GET /api/plugins` analyze drift from the already-built list instead of rebuilding the full plugin list a second time on every UI poll
- add a bounded best-effort metadata fallback for the agent-tier plugin list route when installed/registry metadata enrichment hangs
- add regression coverage for the single-pass compat route and hung registry refresh fallback

Fixes #13859

## Verification
- `bun run --cwd plugins/plugin-registry test src/api/app-plugins-routes.test.ts src/api/plugin-routes.test.ts`
- `bunx @biomejs/biome check plugins/plugin-registry/src/api/app-plugins-routes.ts plugins/plugin-registry/src/api/app-plugins-routes.test.ts plugins/plugin-registry/src/api/plugin-routes.ts plugins/plugin-registry/src/api/plugin-routes.test.ts`
- `git diff --check HEAD^ HEAD -- plugins/plugin-registry/src/api/app-plugins-routes.ts plugins/plugin-registry/src/api/app-plugins-routes.test.ts plugins/plugin-registry/src/api/plugin-routes.ts plugins/plugin-registry/src/api/plugin-routes.test.ts`
- `bun run --cwd plugins/plugin-registry build`

## Notes
- `bun run --cwd plugins/plugin-registry typecheck` was attempted in a fresh worktree, but it stopped before these files on missing optional workspace package outputs such as `@elizaos/auth`, `@elizaos/plugin-sql`, and other optional plugin packages. The package build and focused route tests pass after building the direct local package prerequisites.