### PR TITLE
fix(app): install iOS e2e simulator build

### DIFF
--- a/.github/issue-evidence/13577-ios-e2e-install/README.md
+++ b/.github/issue-evidence/13577-ios-e2e-install/README.md
@@ -1,0 +1,70 @@
+# #13577 iOS e2e explicit simulator install evidence
+
+## Change
+
+- Added `packages/app/scripts/lib/ios-simulator-app-product.mjs` to select the newest `Debug-iphonesimulator/App.app` from Xcode DerivedData deterministically.
+- Updated `packages/app/scripts/ios-e2e.mjs` so the build path no longer assumes `build:ios:local:sim` installed the app. It now:
+  - runs `bun run build:ios:local:sim`;
+  - locates the newest built simulator `App.app` or accepts `--app-path`;
+  - validates the candidate app bundle id and renderer build stamp;
+  - terminates/uninstalls the previous simulator app;
+  - runs `xcrun simctl install <udid> <App.app>`;
+  - verifies the installed app container and renderer build stamp.
+
+The already-fixed package script/doc wiring from prior work remains present on `develop`.
+
+## Verification run locally
+
+```bash
+node --check packages/app/scripts/ios-e2e.mjs
+node --check packages/app/scripts/lib/ios-simulator-app-product.mjs
+node --check packages/app/scripts/lib/ios-simulator-app-product.test.mjs
+```
+
+Result: passed.
+
+```bash
+bun run --cwd packages/app test -- scripts/lib/ios-simulator-app-product.test.mjs
+```
+
+Result: passed, 1 file / 4 tests.
+
+```bash
+bunx biome check packages/app/scripts/ios-e2e.mjs packages/app/scripts/lib/ios-simulator-app-product.mjs packages/app/scripts/lib/ios-simulator-app-product.test.mjs
+git diff --check
+```
+
+Result: passed.
+
+```bash
+bun run verify
+```
+
+Result: failed before package typecheck/lint in `audit:type-safety-ratchet` on repo-wide baseline drift unrelated to this patch:
+
+- `as unknown as`: 74 current > 73 baseline.
+- `?? []` in core/agent/app-core: 582 current > 581 baseline.
+
+## Real iOS e2e attempt
+
+```bash
+node packages/app/scripts/ios-e2e.mjs --skip-build --skip-auth --skip-local-chat
+```
+
+Result: blocked before this patch's install path because this machine does not have full Xcode/simctl. See `ios-e2e-simctl-failure.txt`.
+
+Commands still required on a macOS host with full Xcode and the staged model:
+
+```bash
+bun run --cwd packages/app test:e2e:ios
+lsof -i :31338
+```
+
+Expected proof: `ios-e2e.mjs` logs the build, candidate renderer stamp, explicit `simctl install`, installed renderer stamp, auth smoke, full-Bun chat smoke, and final `ALL iOS E2E PASSED`.
+
+## Evidence applicability
+
+- Real LLM trajectory: N/A. This is mobile e2e orchestration, not agent prompt/model behavior.
+- Backend logs: N/A for this slice; the changed path is simulator app installation before existing auth/chat legs.
+- Frontend screenshots/video: blocked locally by missing full Xcode/simctl; required on a simulator runner before closing #13577.
+- Domain artifacts: the built and installed `App.app` renderer build stamp is the domain artifact this patch verifies on the real lane.

--- a/.github/issue-evidence/13577-ios-e2e-install/ios-e2e-simctl-failure.txt
+++ b/.github/issue-evidence/13577-ios-e2e-install/ios-e2e-simctl-failure.txt
@@ -1,0 +1,13 @@
+xcrun: error: unable to find utility "simctl", not a developer tool or in PATH
+[ios-e2e] booting simulator iPhone 16 Pro
+xcrun: error: unable to find utility "simctl", not a developer tool or in PATH
+[ios-e2e] FAILED: Could not boot simulator "iPhone 16 Pro": Command failed: xcrun simctl boot iPhone 16 Pro
+xcrun: error: unable to find utility "simctl", not a developer tool or in PATH
+. List devices with `xcrun simctl list devices`.
+
+Environment:
+xcode-select -p
+/Library/Developer/CommandLineTools
+
+xcrun simctl list devices booted --json
+xcrun: error: unable to find utility "simctl", not a developer tool or in PATH

--- a/packages/app/scripts/ios-e2e.mjs
+++ b/packages/app/scripts/ios-e2e.mjs
@@ -10,15 +10,21 @@
 //   4. Deep-link / auth-callback registration + drive (mobile-auth-simulator).
 //   5. (optional) Cloud route: real provisioning probe.
 //
-// Flags: --device <name|udid>  --skip-build  --skip-local-chat  --skip-auth
-//        --cloud
+// Flags: --device <name|udid>  --app-path <App.app>  --skip-build
+//        --skip-local-chat  --skip-auth  --cloud
 import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  assertCandidateIosAppRendererFresh,
+  assertInstalledIosAppRendererFresh,
+} from "./lib/ios-renderer-stamp.mjs";
 import { clearIosSmokeDefaults } from "./lib/ios-sim-defaults-hygiene.mjs";
+import { findLatestBuiltIosSimulatorApp } from "./lib/ios-simulator-app-product.mjs";
 
 const appDir = path.resolve(fileURLToPath(import.meta.url), "..", "..");
+const repoRoot = path.resolve(appDir, "..", "..");
 const has = (f) => process.argv.includes(f);
 const val = (f, fb) => {
   const i = process.argv.indexOf(f);
@@ -45,6 +51,14 @@ function run(cmd, args, env = {}) {
 
 function simctl(args) {
   return execFileSync("xcrun", ["simctl", ...args], { encoding: "utf8" });
+}
+
+function trySimctl(args) {
+  try {
+    return simctl(args).trim();
+  } catch {
+    return null;
+  }
 }
 
 function bootedUdid() {
@@ -84,6 +98,36 @@ function ensureSimulatorBooted(deviceName) {
   return udid;
 }
 
+function installBuiltSimulatorApp(udid, appId) {
+  const appPath = val("--app-path") ?? findLatestBuiltIosSimulatorApp();
+  if (!appPath) {
+    throw new Error(
+      "Could not find a Debug-iphonesimulator App.app after build. Pass --app-path or inspect Xcode DerivedData.",
+    );
+  }
+
+  assertCandidateIosAppRendererFresh({
+    appPath,
+    bundleId: appId,
+    repoRoot,
+    log,
+  });
+  trySimctl(["terminate", udid, appId]);
+  trySimctl(["uninstall", udid, appId]);
+  log(`installing built simulator app ${appPath}`);
+  simctl(["install", udid, appPath]);
+  const installed = trySimctl(["get_app_container", udid, appId, "app"]);
+  if (!installed) {
+    throw new Error(`${appId} was not installed after simctl install.`);
+  }
+  assertInstalledIosAppRendererFresh({
+    udid,
+    bundleId: appId,
+    repoRoot,
+    log,
+  });
+}
+
 async function main() {
   const appId = readAppId();
   const udid = ensureSimulatorBooted(val("--device"));
@@ -93,8 +137,9 @@ async function main() {
     if (has("--skip-build")) {
       log("skipping build (--skip-build)");
     } else {
-      log("building + installing the iOS Simulator app…");
+      log("building the iOS Simulator app…");
       run("bun", ["run", "build:ios:local:sim"]);
+      installBuiltSimulatorApp(udid, appId);
     }
 
     if (!has("--skip-auth")) {

--- a/packages/app/scripts/lib/ios-simulator-app-product.mjs
+++ b/packages/app/scripts/lib/ios-simulator-app-product.mjs
@@ -1,0 +1,62 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export function selectLatestIosSimulatorAppProduct(entries) {
+  const products = entries
+    .map((entry) => ({
+      path: typeof entry?.path === "string" ? entry.path.trim() : "",
+      mtimeMs: Number(entry?.mtimeMs),
+    }))
+    .filter(
+      (entry) =>
+        entry.path.length > 0 &&
+        Number.isFinite(entry.mtimeMs) &&
+        entry.mtimeMs >= 0,
+    )
+    .sort((a, b) => b.mtimeMs - a.mtimeMs || a.path.localeCompare(b.path));
+
+  return products[0]?.path ?? null;
+}
+
+export function findLatestBuiltIosSimulatorApp({
+  derivedData = path.join(
+    os.homedir(),
+    "Library",
+    "Developer",
+    "Xcode",
+    "DerivedData",
+  ),
+  fsImpl = fs,
+  execFileSyncImpl = execFileSync,
+} = {}) {
+  if (!fsImpl.existsSync(derivedData)) return null;
+
+  const output = execFileSyncImpl(
+    "find",
+    [
+      derivedData,
+      "-name",
+      "App.app",
+      "-path",
+      "*/Debug-iphonesimulator/*",
+      "-type",
+      "d",
+    ],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const entries = String(output)
+    .split("\n")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => ({
+      path: entry,
+      mtimeMs: fsImpl.statSync(entry).mtimeMs,
+    }));
+
+  return selectLatestIosSimulatorAppProduct(entries);
+}

--- a/packages/app/scripts/lib/ios-simulator-app-product.test.mjs
+++ b/packages/app/scripts/lib/ios-simulator-app-product.test.mjs
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  findLatestBuiltIosSimulatorApp,
+  selectLatestIosSimulatorAppProduct,
+} from "./ios-simulator-app-product.mjs";
+
+const tmpDirs = [];
+
+function makeTmpDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-ios-app-product-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("iOS simulator app product discovery", () => {
+  it("selects the newest App.app deterministically", () => {
+    expect(
+      selectLatestIosSimulatorAppProduct([
+        { path: "/tmp/older/App.app", mtimeMs: 100 },
+        { path: "/tmp/newer/App.app", mtimeMs: 200 },
+        { path: "/tmp/invalid/App.app", mtimeMs: Number.NaN },
+      ]),
+    ).toBe("/tmp/newer/App.app");
+  });
+
+  it("uses path order as a stable tie-breaker", () => {
+    expect(
+      selectLatestIosSimulatorAppProduct([
+        { path: "/tmp/z/App.app", mtimeMs: 200 },
+        { path: "/tmp/a/App.app", mtimeMs: 200 },
+      ]),
+    ).toBe("/tmp/a/App.app");
+  });
+
+  it("returns null when DerivedData is absent", () => {
+    expect(
+      findLatestBuiltIosSimulatorApp({
+        derivedData: path.join(makeTmpDir(), "missing"),
+      }),
+    ).toBeNull();
+  });
+
+  it("finds the newest Debug-iphonesimulator product from find output", () => {
+    const root = makeTmpDir();
+    const older = path.join(
+      root,
+      "A/Build/Products/Debug-iphonesimulator/App.app",
+    );
+    const newer = path.join(
+      root,
+      "B/Build/Products/Debug-iphonesimulator/App.app",
+    );
+    fs.mkdirSync(older, { recursive: true });
+    fs.mkdirSync(newer, { recursive: true });
+
+    const fsImpl = {
+      existsSync: () => true,
+      statSync: (target) => ({
+        mtimeMs: target === newer ? 300 : 100,
+      }),
+    };
+    const execFileSyncImpl = () => `${older}\n${newer}\n`;
+
+    expect(
+      findLatestBuiltIosSimulatorApp({
+        derivedData: root,
+        fsImpl,
+        execFileSyncImpl,
+      }),
+    ).toBe(newer);
+  });
+});


### PR DESCRIPTION
## Summary

Relates to #13577.

The original package-script/doc wiring part of this issue is already present on `develop`. This PR addresses the remaining real install-proof slice:

- Add a tested helper to locate the newest `Debug-iphonesimulator/App.app` product in Xcode DerivedData.
- Update `ios-e2e.mjs` so the build path explicitly validates the candidate app renderer stamp, uninstalls any previous simulator app, runs `xcrun simctl install <udid> <App.app>`, and validates the installed renderer stamp.
- Add `--app-path <App.app>` as an explicit override for the product install path.

## Evidence

Artifacts: `.github/issue-evidence/13577-ios-e2e-install/`

Passed locally:

```bash
node --check packages/app/scripts/ios-e2e.mjs
node --check packages/app/scripts/lib/ios-simulator-app-product.mjs
node --check packages/app/scripts/lib/ios-simulator-app-product.test.mjs

bun run --cwd packages/app test -- scripts/lib/ios-simulator-app-product.test.mjs
# 1 file passed, 4 tests passed

bunx biome check packages/app/scripts/ios-e2e.mjs packages/app/scripts/lib/ios-simulator-app-product.mjs packages/app/scripts/lib/ios-simulator-app-product.test.mjs .github/issue-evidence/13577-ios-e2e-install/README.md .github/issue-evidence/13577-ios-e2e-install/ios-e2e-simctl-failure.txt

git diff --check HEAD~1..HEAD
```

Blocked locally:

- Real `test:e2e:ios` proof needs full Xcode/simctl. This host is pointed at `/Library/Developer/CommandLineTools`, and `xcrun simctl` is unavailable. Captured in `.github/issue-evidence/13577-ios-e2e-install/ios-e2e-simctl-failure.txt`.
- `bun run verify` fails before package typecheck/lint in repo-wide `audit:type-safety-ratchet` baseline drift unrelated to this patch (`as unknown as` and `?? []` counts above baseline). Details in the evidence README.

## Evidence rows

- Real LLM trajectory: N/A, mobile e2e orchestration only.
- Backend logs: N/A for this slice; changed path is simulator app installation before existing auth/chat legs.
- Frontend screenshots/video: blocked locally by missing full Xcode/simctl; required on a simulator runner before closing #13577.
- Domain artifacts: built and installed `App.app` renderer build stamp is verified by the updated real lane.