### PR TITLE
fix(#13422): migrate P6 (plugins + auth + ui) boot-critical aliased env reads to the alias-aware reader

### DIFF
--- a/packages/auth/src/credentials.ts
+++ b/packages/auth/src/credentials.ts
@@ -17,6 +17,7 @@ import {
   getElizaNamespace,
   getSubscriptionAuthProvider,
   logger,
+  resolveAliasedEnvValue,
   resolveStateDir,
   resolveUserPath,
 } from "@elizaos/core";
@@ -248,7 +249,7 @@ export async function getAccessToken(
 
 function readConfiguredAnthropicSetupToken(): string | null {
   const namespace = getElizaNamespace();
-  const explicitConfig = process.env.ELIZA_CONFIG_PATH?.trim();
+  const explicitConfig = resolveAliasedEnvValue("ELIZA_CONFIG_PATH")?.trim();
   const configPath = explicitConfig
     ? resolveUserPath(explicitConfig)
     : path.join(resolveStateDir(), `${namespace}.json`);

--- a/packages/ui/src/services/local-inference/active-model.ts
+++ b/packages/ui/src/services/local-inference/active-model.ts
@@ -13,6 +13,7 @@
 import { existsSync } from "node:fs";
 import { join as pathJoin } from "node:path";
 import type { AgentRuntime } from "@elizaos/core";
+import { resolvePlatform } from "@elizaos/shared/runtime-env";
 import {
   ELIZA_1_PLACEHOLDER_IDS,
   FIRST_RUN_DEFAULT_MODEL_ID,
@@ -341,7 +342,7 @@ function isMobileLocalInferenceRuntime(): boolean {
   if (typeof process === "undefined" || !process.env) return false;
   const platform = (
     process.env.ELIZA_MOBILE_PLATFORM ||
-    process.env.ELIZA_PLATFORM ||
+    resolvePlatform() ||
     ""
   )
     .trim()

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -68,6 +68,7 @@
   },
   "peerDependencies": {
     "@elizaos/core": "workspace:*",
+    "@elizaos/shared": "workspace:*",
     "git-workspace-service": "0.4.5"
   },
   "dependencies": {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -25,6 +25,7 @@ import {
   type IAgentRuntime,
   Service,
 } from "@elizaos/core";
+import { isAndroidMobile } from "@elizaos/shared";
 import { NativeAcpClient } from "./acp-native-transport.js";
 import { augmentTaskWithDeployGuidance } from "./app-deploy-guidance.js";
 import {
@@ -3239,7 +3240,7 @@ export class AcpService extends Service {
   }
 
   private assertTransportAvailable(sessionId: string): void {
-    if (process.env.ELIZA_PLATFORM !== "android") return;
+    if (!isAndroidMobile()) return;
     const message = this.missingCliMessage();
     if (!message) return;
     this.emitMissingCli(sessionId, message);

--- a/plugins/plugin-agent-orchestrator/src/services/config-env.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/config-env.ts
@@ -11,11 +11,12 @@
 import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import { getElizaNamespace, resolveStateDir } from "@elizaos/core";
+import { readAliasedEnv } from "@elizaos/shared";
 import type { AcpMcpServerConfig } from "./acp-native-transport.js";
 
 function readConfig(): Record<string, unknown> | undefined {
   try {
-    const explicitPath = process.env.ELIZA_CONFIG_PATH?.trim();
+    const explicitPath = readAliasedEnv("ELIZA_CONFIG_PATH");
     const configPath = explicitPath
       ? path.resolve(explicitPath)
       : (() => {

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -18,6 +18,7 @@ import {
   resolveStateDir,
   resolveUserPath,
 } from "@elizaos/core";
+import { readAliasedEnv } from "@elizaos/shared";
 import { readConfigCloudKey, readConfigEnvKey } from "./config-env.js";
 import { resolveVendoredOpencodeShim } from "./opencode-config.js";
 
@@ -514,7 +515,7 @@ function extractOauthAccessToken(value: unknown): string | undefined {
 }
 
 function resolveElizaConfigPath(): string {
-  const explicit = process.env.ELIZA_CONFIG_PATH?.trim();
+  const explicit = readAliasedEnv("ELIZA_CONFIG_PATH");
   if (explicit) return resolveUserPath(explicit);
 
   const namespace = getElizaNamespace();

--- a/plugins/plugin-agent-orchestrator/src/services/task-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-policy.ts
@@ -12,6 +12,7 @@ import {
   MESSAGE_SOURCE_CLIENT_CHAT,
   type Memory,
 } from "@elizaos/core";
+import { readAliasedEnv } from "@elizaos/shared";
 
 type RoleName = "OWNER" | "ADMIN" | "USER" | "GUEST";
 type TaskAgentAbility = "create" | "interact";
@@ -202,7 +203,7 @@ async function resolveSenderRole(
   runtime: IAgentRuntime,
   message: Memory,
 ): Promise<RoleCheckResult | null> {
-  if (process.env.ELIZA_SKIP_LOCAL_PLUGIN_ROLES !== "1") {
+  if (readAliasedEnv("ELIZA_SKIP_LOCAL_PLUGIN_ROLES") !== "1") {
     for (const candidate of LOCAL_ROLES_MODULE_CANDIDATES) {
       if (!fs.existsSync(candidate)) {
         continue;

--- a/plugins/plugin-agent-orchestrator/src/services/terminal-capabilities.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/terminal-capabilities.ts
@@ -7,6 +7,7 @@
  */
 import { accessSync, constants } from "node:fs";
 import path from "node:path";
+import { resolvePlatform } from "@elizaos/shared";
 
 export const ORCHESTRATOR_TOOL_NAMES = [
   "sh",
@@ -85,7 +86,7 @@ function envRuntimeMode(env: TerminalSupportEnv): string {
 /** Snapshot the live process env into a {@link TerminalSupportEnv}. */
 function readTerminalSupportEnv(): TerminalSupportEnv {
   return {
-    platform: process.env.ELIZA_PLATFORM,
+    platform: resolvePlatform(),
     buildVariant: process.env.ELIZA_BUILD_VARIANT,
     runtimeMode:
       process.env.ELIZA_RUNTIME_MODE ??

--- a/plugins/plugin-agent-skills/src/api/skills-routes.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.ts
@@ -25,6 +25,7 @@ import {
   PostSkillCreateRequestSchema,
   PutSkillSourceRequestSchema,
   parseClampedInteger,
+  readAliasedEnv,
 } from "@elizaos/shared";
 import {
   installMarketplaceSkill,
@@ -76,10 +77,7 @@ function resolveDefaultAgentWorkspaceDir(): string {
     // Fall through to cwd / state-dir defaults.
   }
 
-  if (
-    !process.env.ELIZA_STATE_DIR?.trim() &&
-    !process.env.ELIZA_STATE_DIR?.trim()
-  ) {
+  if (!readAliasedEnv("ELIZA_STATE_DIR")) {
     const cwd = process.cwd();
     if (cwd.trim() && shouldUseRuntimeCwdWorkspace(cwd)) {
       return resolveUserPath(cwd);
@@ -87,9 +85,7 @@ function resolveDefaultAgentWorkspaceDir(): string {
   }
 
   const stateDir = resolveUserPath(
-    process.env.ELIZA_STATE_DIR?.trim() ??
-      process.env.ELIZA_STATE_DIR?.trim() ??
-      path.join(os.homedir(), ".eliza"),
+    readAliasedEnv("ELIZA_STATE_DIR") ?? path.join(os.homedir(), ".eliza"),
   );
   const profile = process.env.ELIZA_PROFILE?.trim();
   if (profile && profile.toLowerCase() !== "default") {

--- a/plugins/plugin-app-control/src/actions/views-platform.alias-env.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-platform.alias-env.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Proves the #13422 alias-reader migration for the boot-critical env keys in the
+ * P6 partition: a non-ELIZA brand prefix (MILADY_<KEY>) resolves through the
+ * alias-aware readers, the canonical ELIZA_<KEY> wins when both are present, a
+ * blank ELIZA_<KEY> never shadows a real branded alias, and — the
+ * security-critical invariant — resolving a branded-only key NEVER writes the
+ * mirrored ELIZA_<KEY> back onto `process.env`. Drives the real migrated code
+ * path (`isRestrictedPlatform` reads `resolvePlatform`) plus the readers every
+ * other migrated site in this partition now calls.
+ */
+
+import {
+	buildBrandEnvAliases,
+	getBootConfig,
+	readAliasedEnv,
+	resolveApiToken,
+	resolveDesktopApiPort,
+	resolvePlatform,
+	setBootConfig,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { isRestrictedPlatform } from "./views-platform.js";
+
+// Every ELIZA_* key this partition migrated, plus its MILADY_ alias partner.
+const MIGRATED_KEYS = [
+	"ELIZA_PLATFORM",
+	"ELIZA_STATE_DIR",
+	"ELIZA_CONFIG_PATH",
+	"ELIZA_CLOUD_PROVISIONED",
+	"ELIZA_SKIP_LOCAL_PLUGIN_ROLES",
+	"ELIZA_WALLET_EXPORT_TOKEN",
+	"ELIZA_API_TOKEN",
+	"ELIZA_API_PORT",
+	"ELIZA_PORT",
+	"ELIZA_BUILD_VARIANT",
+] as const;
+const BRAND_KEYS = MIGRATED_KEYS.map((k) => k.replace(/^ELIZA_/, "MILADY_"));
+
+let savedEnv: Record<string, string | undefined>;
+let savedBootConfig: ReturnType<typeof getBootConfig>;
+
+beforeEach(() => {
+	savedEnv = {};
+	for (const key of [...MIGRATED_KEYS, ...BRAND_KEYS]) {
+		savedEnv[key] = process.env[key];
+		delete process.env[key];
+	}
+	savedBootConfig = getBootConfig();
+	// Install a genuine non-ELIZA brand alias table (MILADY) so the readers must
+	// consult it — exactly what a rebranded distribution ships.
+	setBootConfig({ branding: {}, envAliases: buildBrandEnvAliases("MILADY") });
+});
+
+afterEach(() => {
+	for (const [key, value] of Object.entries(savedEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	setBootConfig(savedBootConfig);
+});
+
+describe("#13422 P6 alias-reader migration", () => {
+	it("resolves a branded MILADY_PLATFORM through the migrated isRestrictedPlatform path", () => {
+		process.env.MILADY_PLATFORM = "android";
+		expect(resolvePlatform()).toBe("android");
+		expect(isRestrictedPlatform()).toBe(true);
+		// The security-critical invariant: reading the alias must NOT mirror the
+		// value back onto the canonical ELIZA_ key.
+		expect(process.env.ELIZA_PLATFORM).toBeUndefined();
+	});
+
+	it("lets the canonical ELIZA_PLATFORM win over the branded alias", () => {
+		process.env.ELIZA_PLATFORM = "linux";
+		process.env.MILADY_PLATFORM = "android";
+		expect(resolvePlatform()).toBe("linux");
+		// linux is not a restricted mobile platform, so the canonical value drives
+		// the migrated decision even though the branded alias says android.
+		expect(isRestrictedPlatform()).toBe(false);
+	});
+
+	it("treats a blank canonical ELIZA_PLATFORM as unset (does not shadow the alias)", () => {
+		process.env.ELIZA_PLATFORM = "   ";
+		process.env.MILADY_PLATFORM = "android";
+		expect(resolvePlatform()).toBe("android");
+		expect(isRestrictedPlatform()).toBe(true);
+	});
+
+	it("readAliasedEnv resolves branded aliases, honours ELIZA precedence, and never mirrors", () => {
+		const cases: Array<[eliza: string, brand: string]> = [
+			["ELIZA_STATE_DIR", "MILADY_STATE_DIR"],
+			["ELIZA_CONFIG_PATH", "MILADY_CONFIG_PATH"],
+			["ELIZA_CLOUD_PROVISIONED", "MILADY_CLOUD_PROVISIONED"],
+			["ELIZA_SKIP_LOCAL_PLUGIN_ROLES", "MILADY_SKIP_LOCAL_PLUGIN_ROLES"],
+			["ELIZA_WALLET_EXPORT_TOKEN", "MILADY_WALLET_EXPORT_TOKEN"],
+		];
+		for (const [elizaKey, brandKey] of cases) {
+			// Branded alias only → resolves, canonical stays unwritten.
+			process.env[brandKey] = "brand-value";
+			expect(readAliasedEnv(elizaKey)).toBe("brand-value");
+			expect(process.env[elizaKey]).toBeUndefined();
+
+			// Both present → canonical ELIZA_ wins.
+			process.env[elizaKey] = "canonical-value";
+			expect(readAliasedEnv(elizaKey)).toBe("canonical-value");
+
+			// Blank canonical → branded alias resurfaces (empty-is-unset).
+			process.env[elizaKey] = "   ";
+			expect(readAliasedEnv(elizaKey)).toBe("brand-value");
+
+			delete process.env[elizaKey];
+			delete process.env[brandKey];
+		}
+	});
+
+	it("resolveApiToken resolves MILADY_API_TOKEN and prefers the canonical token", () => {
+		process.env.MILADY_API_TOKEN = "brand-token";
+		expect(resolveApiToken()).toBe("brand-token");
+		expect(process.env.ELIZA_API_TOKEN).toBeUndefined();
+
+		process.env.ELIZA_API_TOKEN = "canonical-token";
+		expect(resolveApiToken()).toBe("canonical-token");
+	});
+
+	it("resolveDesktopApiPort resolves MILADY_API_PORT and prefers the canonical port", () => {
+		process.env.MILADY_API_PORT = "41337";
+		expect(resolveDesktopApiPort()).toBe(41337);
+		expect(process.env.ELIZA_API_PORT).toBeUndefined();
+
+		process.env.ELIZA_API_PORT = "42000";
+		expect(resolveDesktopApiPort()).toBe(42000);
+	});
+});

--- a/plugins/plugin-app-control/src/actions/views-platform.ts
+++ b/plugins/plugin-app-control/src/actions/views-platform.ts
@@ -2,9 +2,11 @@
  * Returns true when the agent is running on a platform that prohibits dynamic
  * code loading (iOS App Store and Google Play builds).
  */
+import { resolvePlatform } from "@elizaos/shared";
+
 export function isRestrictedPlatform(): boolean {
 	const variant = (process.env.ELIZA_BUILD_VARIANT ?? "").trim().toLowerCase();
 	if (variant === "store") return true;
-	const platform = (process.env.ELIZA_PLATFORM ?? "").trim().toLowerCase();
+	const platform = resolvePlatform() ?? "";
 	return platform === "ios" || platform === "android";
 }

--- a/plugins/plugin-app-control/src/services/verification-helpers.ts
+++ b/plugins/plugin-app-control/src/services/verification-helpers.ts
@@ -12,6 +12,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { ModelType, resolveStateDir } from "@elizaos/core";
+import { resolveApiToken, resolveDesktopApiPort } from "@elizaos/shared";
 
 export type Diagnostic = {
 	file: string;
@@ -197,18 +198,12 @@ export async function ensureVerificationDir(runId: string): Promise<string> {
 }
 
 function resolveLoopbackApiBase(): string {
-	const port =
-		process.env.ELIZA_API_PORT?.trim() ||
-		process.env.ELIZA_PORT?.trim() ||
-		"31337";
-	return `http://127.0.0.1:${port}`;
+	return `http://127.0.0.1:${resolveDesktopApiPort()}`;
 }
 
 function resolveDevApiToken(): string | undefined {
 	return (
-		process.env.ELIZA_API_TOKEN?.trim() ||
-		process.env.ELIZA_API_AUTH_TOKEN?.trim() ||
-		undefined
+		resolveApiToken() ?? (process.env.ELIZA_API_AUTH_TOKEN?.trim() || undefined)
 	);
 }
 

--- a/plugins/plugin-computeruse/src/routes/computer-use-compat-routes.ts
+++ b/plugins/plugin-computeruse/src/routes/computer-use-compat-routes.ts
@@ -15,6 +15,7 @@
 
 import crypto from "node:crypto";
 import type http from "node:http";
+import { resolveAliasedEnvValue } from "@elizaos/core";
 
 type CompatRuntimeState = {
   current: {
@@ -71,7 +72,7 @@ function tokenMatches(expected: string, provided: string): boolean {
 }
 
 function getCompatApiToken(): string | null {
-  return process.env.ELIZA_API_TOKEN?.trim() || null;
+  return resolveAliasedEnvValue("ELIZA_API_TOKEN")?.trim() || null;
 }
 
 function getProvidedApiToken(

--- a/plugins/plugin-facewear/package.json
+++ b/plugins/plugin-facewear/package.json
@@ -53,6 +53,7 @@
 	"dependencies": {
 		"@elizaos/agent": "workspace:*",
 		"@elizaos/core": "workspace:*",
+		"@elizaos/shared": "workspace:*",
 		"@elizaos/ui": "workspace:*",
 		"lucide-react": "^1.0.0",
 		"ws": "^8.18.0",

--- a/plugins/plugin-facewear/src/actions/view-actions.ts
+++ b/plugins/plugin-facewear/src/actions/view-actions.ts
@@ -10,6 +10,7 @@ import type {
 	Memory,
 	State,
 } from "@elizaos/core";
+import { resolveDesktopApiPort } from "@elizaos/shared";
 import {
 	XR_SERVICE_TYPE,
 	type XRSessionService,
@@ -24,12 +25,11 @@ function firstConnectionId(svc: XRSessionService): string | null {
 }
 
 function agentBaseUrl(): string {
-	// The API port is orchestrator-assigned, so view URLs read it from env.
-	const port =
-		process.env.ELIZA_API_PORT?.trim() ||
-		process.env.ELIZA_PORT?.trim() ||
-		"31337";
-	return process.env.XR_AGENT_URL ?? `http://localhost:${port}`;
+	// The API port is orchestrator-assigned, so view URLs read it from env
+	// (alias-aware: a branded <PREFIX>_API_PORT / _PORT resolves too).
+	return (
+		process.env.XR_AGENT_URL ?? `http://localhost:${resolveDesktopApiPort()}`
+	);
 }
 
 /** Read a structured action param (planner-emitted `options.parameters`, with a

--- a/plugins/plugin-local-inference/src/routes/compat-helpers.ts
+++ b/plugins/plugin-local-inference/src/routes/compat-helpers.ts
@@ -13,7 +13,11 @@ import crypto from "node:crypto";
 import type http from "node:http";
 import { isIP } from "node:net";
 import type { AgentRuntime } from "@elizaos/core";
-import { isLoopbackBindHost, resolveApiToken } from "@elizaos/shared";
+import {
+	isLoopbackBindHost,
+	readAliasedEnv,
+	resolveApiToken,
+} from "@elizaos/shared";
 
 const MAX_BODY_BYTES = 1_048_576;
 
@@ -113,7 +117,7 @@ function proxyClientHeaderBlocksLocalTrust(
 }
 
 function isCloudProvisionedByEnv(): boolean {
-	return process.env.ELIZA_CLOUD_PROVISIONED === "1";
+	return readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
 }
 
 function isLocalAuthRequiredByEnv(): boolean {

--- a/plugins/plugin-local-inference/src/routes/live-diarization-route.ts
+++ b/plugins/plugin-local-inference/src/routes/live-diarization-route.ts
@@ -37,6 +37,7 @@
 import { writeFileSync } from "node:fs";
 import type http from "node:http";
 import path from "node:path";
+import { readAliasedEnv } from "@elizaos/shared";
 import type {
 	AudioFrameEvent,
 	EchoReferenceProvider,
@@ -69,7 +70,7 @@ async function persistAecEvidence(
 	capture: { sampleCount?: number } | null | undefined,
 	status: unknown,
 ): Promise<void> {
-	const stateDir = process.env.ELIZA_STATE_DIR?.trim();
+	const stateDir = readAliasedEnv("ELIZA_STATE_DIR");
 	// Only mirror a capture that actually holds samples — an incidental GET with
 	// nothing captured must not clobber a real prior capture or write noise.
 	if (!stateDir || !capture || (capture.sampleCount ?? 0) <= 0) return;

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -41,6 +41,7 @@ import {
 	type TranscriptionParams,
 	type UUID,
 } from "@elizaos/core";
+import { readAliasedEnv } from "@elizaos/shared";
 import { LocalInferenceUnavailableError } from "../provider";
 import {
 	type LocalInferenceLoader,
@@ -189,7 +190,7 @@ function getRuntimeMode(runtime: IAgentRuntime): string {
 		if (fromEnv) return fromEnv;
 	}
 	if (
-		process.env.ELIZA_CLOUD_PROVISIONED === "1" ||
+		readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1" ||
 		process.env.ELIZAOS_CLOUD_ENABLED === "1"
 	) {
 		return "cloud";

--- a/plugins/plugin-local-inference/src/services/active-model.ts
+++ b/plugins/plugin-local-inference/src/services/active-model.ts
@@ -17,6 +17,7 @@ import {
 	resolve as pathResolve,
 } from "node:path";
 import { type AgentRuntime, logger } from "@elizaos/core";
+import { resolvePlatform } from "@elizaos/shared";
 import {
 	ELIZA_1_PLACEHOLDER_IDS,
 	FIRST_RUN_DEFAULT_MODEL_ID,
@@ -693,7 +694,7 @@ function isMobileLocalInferenceRuntime(): boolean {
 	if (typeof process === "undefined" || !process.env) return false;
 	const platform = (
 		process.env.ELIZA_MOBILE_PLATFORM ||
-		process.env.ELIZA_PLATFORM ||
+		resolvePlatform() ||
 		""
 	)
 		.trim()

--- a/plugins/plugin-local-inference/src/services/service.ts
+++ b/plugins/plugin-local-inference/src/services/service.ts
@@ -16,6 +16,7 @@ import {
 	renderMessageHandlerStablePrefix,
 	type UUID,
 } from "@elizaos/core";
+import { isAndroidMobile, isIosMobile } from "@elizaos/shared";
 import {
 	ActiveModelCoordinator,
 	type LocalInferenceLoadOverrides,
@@ -640,10 +641,8 @@ export class LocalInferenceService {
 			requiredAccelerator: parseImageGenRequiredAccelerator(
 				process.env.ELIZA_IMAGEGEN_ACCELERATOR,
 			),
-			isIos: process.env.ELIZA_PLATFORM === "ios",
-			isAndroid:
-				process.env.ELIZA_PLATFORM === "android" ||
-				process.env.ELIZA_LOCAL_LLAMA === "1",
+			isIos: isIosMobile(),
+			isAndroid: isAndroidMobile() || process.env.ELIZA_LOCAL_LLAMA === "1",
 		} satisfies ImageGenRuntimeProfile;
 		const errors: string[] = [];
 		for (const choice of selectImageGenBackends(profile)) {

--- a/plugins/plugin-scheduling/src/scheduled-task/runner-service.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner-service.ts
@@ -28,6 +28,7 @@ import {
   Service,
   ServiceType,
 } from "@elizaos/core";
+import { resolvePlatform } from "@elizaos/shared/runtime-env";
 import type { DispatchResult } from "../dispatch-types.js";
 import {
   type CompletionCheckRegistry,
@@ -160,7 +161,7 @@ const MOBILE_PROFILES: ReadonlySet<TaskExecutionProfile> =
  * `hostCapabilities` via the deps provider.
  */
 function platformHostCapabilities(): ReadonlySet<TaskExecutionProfile> {
-  const platform = (process.env.ELIZA_PLATFORM ?? "").toLowerCase();
+  const platform = resolvePlatform() ?? "";
   if (platform === "android" || platform === "ios") return MOBILE_PROFILES;
   return ALL_PROFILES;
 }

--- a/plugins/plugin-vision/src/face-detector-ggml.ts
+++ b/plugins/plugin-vision/src/face-detector-ggml.ts
@@ -11,7 +11,7 @@ import { promises as fs } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { logger } from "@elizaos/core";
+import { logger, resolveAliasedEnvValue } from "@elizaos/core";
 import { getSharp } from "./image/sharp-compat";
 import type { BoundingBox } from "./types";
 
@@ -73,7 +73,8 @@ function defaultLibraryPath(): string {
 
 function defaultModelDir(): string {
   const stateDir =
-    process.env.ELIZA_STATE_DIR ?? path.join(os.homedir(), ".eliza");
+    resolveAliasedEnvValue("ELIZA_STATE_DIR") ??
+    path.join(os.homedir(), ".eliza");
   return path.join(stateDir, "models", "face-cpp");
 }
 

--- a/plugins/plugin-vision/src/face-recognition-ggml.ts
+++ b/plugins/plugin-vision/src/face-recognition-ggml.ts
@@ -12,7 +12,7 @@ import { promises as fs } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { logger } from "@elizaos/core";
+import { logger, resolveAliasedEnvValue } from "@elizaos/core";
 import {
   BlazeFaceGgmlDetector,
   type MediaPipeFaceDetection,
@@ -54,7 +54,8 @@ function defaultLibraryPath(): string {
 
 function defaultModelDir(): string {
   const stateDir =
-    process.env.ELIZA_STATE_DIR ?? path.join(os.homedir(), ".eliza");
+    resolveAliasedEnvValue("ELIZA_STATE_DIR") ??
+    path.join(os.homedir(), ".eliza");
   return path.join(stateDir, "models", "face-cpp");
 }
 

--- a/plugins/plugin-vision/src/native/doctr-ffi.ts
+++ b/plugins/plugin-vision/src/native/doctr-ffi.ts
@@ -11,7 +11,7 @@ import { promises as fs } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { logger } from "@elizaos/core";
+import { logger, resolveAliasedEnvValue } from "@elizaos/core";
 
 const MODULE_TAG = "[doctr-ffi]";
 
@@ -43,7 +43,8 @@ function defaultLibraryPath(): string {
 /** Where the runtime expects GGUF weights. */
 export function defaultDetWeightsPath(): string {
   const stateDir =
-    process.env.ELIZA_STATE_DIR ?? path.join(os.homedir(), ".eliza");
+    resolveAliasedEnvValue("ELIZA_STATE_DIR") ??
+    path.join(os.homedir(), ".eliza");
   return (
     process.env.ELIZA_DOCTR_DET_GGUF ??
     path.join(stateDir, "models", "vision", "doctr-det.gguf")
@@ -52,7 +53,8 @@ export function defaultDetWeightsPath(): string {
 
 export function defaultRecWeightsPath(): string {
   const stateDir =
-    process.env.ELIZA_STATE_DIR ?? path.join(os.homedir(), ".eliza");
+    resolveAliasedEnvValue("ELIZA_STATE_DIR") ??
+    path.join(os.homedir(), ".eliza");
   return (
     process.env.ELIZA_DOCTR_REC_GGUF ??
     path.join(stateDir, "models", "vision", "doctr-rec.gguf")

--- a/plugins/plugin-vision/src/native/yolo-ffi.ts
+++ b/plugins/plugin-vision/src/native/yolo-ffi.ts
@@ -9,7 +9,7 @@ import { promises as fs } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { logger } from "@elizaos/core";
+import { logger, resolveAliasedEnvValue } from "@elizaos/core";
 
 const MODULE_TAG = "[yolo-ffi]";
 
@@ -39,7 +39,8 @@ function defaultLibraryPath(): string {
 
 export function defaultYoloWeightsPath(): string {
   const stateDir =
-    process.env.ELIZA_STATE_DIR ?? path.join(os.homedir(), ".eliza");
+    resolveAliasedEnvValue("ELIZA_STATE_DIR") ??
+    path.join(os.homedir(), ".eliza");
   return (
     process.env.ELIZA_YOLO_GGUF ??
     path.join(stateDir, "models", "vision", "yolov8n.gguf")

--- a/plugins/plugin-wallet/src/lib/server-wallet-trade.ts
+++ b/plugins/plugin-wallet/src/lib/server-wallet-trade.ts
@@ -7,7 +7,7 @@
 import crypto from "node:crypto";
 import type http from "node:http";
 import { syncAppEnvToEliza, syncElizaEnvAliases } from "@elizaos/core";
-import type { TradePermissionMode } from "@elizaos/shared";
+import { readAliasedEnv, type TradePermissionMode } from "@elizaos/shared";
 
 import type { WalletExportRequestBody } from "../contracts.js";
 import {
@@ -95,7 +95,7 @@ function resolveBaseWalletExportRejection(
     };
   }
 
-  const expected = process.env.ELIZA_WALLET_EXPORT_TOKEN?.trim();
+  const expected = readAliasedEnv("ELIZA_WALLET_EXPORT_TOKEN");
   if (!expected) {
     return {
       status: 403,

--- a/plugins/plugin-wallet/src/wallet/select-backend.ts
+++ b/plugins/plugin-wallet/src/wallet/select-backend.ts
@@ -4,6 +4,7 @@
  * preferring Steward when the agent is cloud-provisioned.
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { readAliasedEnv } from "@elizaos/shared";
 import type { WalletBackend } from "./backend.js";
 import { LocalEoaBackend } from "./local-eoa-backend.js";
 import { StewardBackend } from "./steward-backend.js";
@@ -25,7 +26,7 @@ function preferStewardInAuto(): boolean {
   if (process.env.ELIZA_WALLET_STEWARD_AUTO === "1") {
     return true;
   }
-  return process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  return readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
 }
 
 /**


### PR DESCRIPTION
Boot-critical slice of #13422 (P6: plugins + auth + ui). Non-critical long-tail reads deferred.

## What
Replace raw `process.env.<KEY>` reads of **alias-table keys** with the non-mutating alias-aware readers, so branded aliases (e.g. `MILADY_*`) resolve WITHOUT relying on the `syncBrandEnvToEliza` / `syncElizaEnvToBrand` mirror mutation. Precedence (canonical `ELIZA_*` wins) and empty-is-unset are preserved. `syncBrandEnvToEliza`/`syncElizaEnvToBrand` are left in place (that removal is #13423).

Every migrated key was verified against `packages/shared/src/config/brand-env-aliases.ts` to be a real alias-table entry.

## Migrated reads
- **Platform flags** → `resolvePlatform` / `isAndroidMobile` / `isIosMobile`:
  - `plugin-agent-orchestrator` acp-service (`ELIZA_PLATFORM` → `isAndroidMobile`), terminal-capabilities (→ `resolvePlatform`)
  - `plugin-local-inference` service (`isIos`/`isAndroid` → `isIosMobile`/`isAndroidMobile`, keeping the raw `ELIZA_LOCAL_LLAMA` OR-clause), active-model (→ `resolvePlatform`)
  - `plugin-app-control` views-platform, `plugin-scheduling` runner-service, `packages/ui` active-model (→ `resolvePlatform`)
- **Ports / token** → `resolveDesktopApiPort` / `resolveApiToken`:
  - `plugin-app-control` verification-helpers (`ELIZA_API_PORT`/`ELIZA_PORT` → `resolveDesktopApiPort`; `ELIZA_API_TOKEN` → `resolveApiToken`, keeping the raw non-aliased `ELIZA_API_AUTH_TOKEN` fallback)
  - `plugin-facewear` view-actions (`ELIZA_API_PORT`/`ELIZA_PORT` → `resolveDesktopApiPort`)
- **State dir / config path / cloud-provisioned / skip-roles / wallet-export / api token** → `readAliasedEnv` (shared) or `resolveAliasedEnvValue` (core, for peer/leaf packages that don't depend on `@elizaos/shared`):
  - orchestrator (config-env, task-agent-frameworks, task-policy), local-inference (live-diarization-route, compat-helpers, ensure-local-inference-handler), wallet (server-wallet-trade, select-backend), agent-skills (skills-routes), computeruse (compat-routes), vision (5 FFI model-path sites), auth (credentials)

`plugin-agent-orchestrator` and `plugin-facewear` gain `@elizaos/shared` as a workspace dependency (peer / regular, mirroring their existing `@elizaos/core` dep). `plugin-computeruse`, `plugin-vision`, and `packages/auth` use core's `resolveAliasedEnvValue` primitive to avoid adding a dependency (computeruse already peers `@elizaos/core`; vision/auth already depend on it).

Also collapses the redundant **double** `ELIZA_STATE_DIR` reads in `agent-skills/skills-routes` into single alias-aware reads.

## Skipped (documented)
`packages/vault` reads (`ELIZA_STATE_DIR`, `ELIZA_NAMESPACE` in `pglite-vault.ts` + `vault.ts`) are **intentionally not migrated**: vault is a hard leaf that "must NOT depend on `@elizaos/agent` / `@elizaos/core`" (`packages/vault/src/master-key.ts`), and `@elizaos/shared` transitively pulls in core. Importing the alias reader would violate that leaf constraint. These are non-critical long-tail reads and belong to a separate architectural decision.

## Test (security-critical proof)
`plugins/plugin-app-control/src/actions/views-platform.alias-env.test.ts` drives the real migrated `isRestrictedPlatform` path plus the readers every other migrated site calls, with a genuine non-ELIZA `MILADY` alias table installed via `setBootConfig(buildBrandEnvAliases("MILADY"))`. It asserts, per migrated key:
- a branded `MILADY_<KEY>` resolves through the reader,
- the canonical `ELIZA_<KEY>` wins when both are set,
- a blank/whitespace `ELIZA_<KEY>` does not shadow the real alias (empty-is-unset),
- **the canonical `ELIZA_<KEY>` is never mirrored back onto `process.env`** (the invariant the issue demands).

**fail-before / pass-after:** reverting `views-platform.ts` to the raw `process.env.ELIZA_PLATFORM` read fails 2 of the 6 cases (branded alias no longer resolves); the migrated code passes all 6.

```
Test Files  1 passed (1)
     Tests  6 passed (6)
```

Package-local typecheck of every touched file is clean (remaining worktree typecheck output is pre-existing environmental noise — TS7016 missing third-party decl files, TS2307 unbuilt sibling subpaths — none referencing the touched files). Biome is clean on all touched files (the one credentials.ts organizeImports hit is a local Biome 2.5.1 vs pinned 2.5.2 version-skew artifact on an import block this PR never touches; develop's unmodified file reproduces it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)