### PR TITLE
fix(#13681): alert on red nightly App Live E2E via issue comment

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -374,3 +374,40 @@ jobs:
             packages/app/test-results/
           if-no-files-found: ignore
           retention-days: 7
+
+  # A nightly that is always red is indistinguishable from no lane: without an
+  # alert, nobody notices the desktop loop has no green unattended cadence and
+  # regressions accumulate silently (issue #13681). This job turns a red
+  # scheduled run into an actionable signal by commenting on the tracking issue
+  # with the per-job results and a link to the run. Scheduled runs only —
+  # manual workflow_dispatch runs stay quiet to avoid noise.
+  notify-on-failure:
+    name: notify on red nightly
+    needs: [app-live-chat, walkthrough-live, cloud-live, desktop-packaged]
+    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - name: Comment red-nightly diagnostic on tracking issue #13681
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          R_CHAT: ${{ needs.app-live-chat.result }}
+          R_WALK: ${{ needs.walkthrough-live.result }}
+          R_CLOUD: ${{ needs.cloud-live.result }}
+          R_DESKTOP: ${{ needs.desktop-packaged.result }}
+        run: |
+          set -euo pipefail
+          {
+            printf '## 🌙 Nightly App Live E2E failed (scheduled run)\n\n'
+            printf 'The only scheduled desktop-packaged lane went red. Per-job results:\n\n'
+            printf -- '- app live chat: `%s`\n' "$R_CHAT"
+            printf -- '- full walkthrough: `%s`\n' "$R_WALK"
+            printf -- '- cloud login+provision+chat: `%s`\n' "$R_CLOUD"
+            printf -- '- desktop packaged (build+boot+renderer): `%s`\n' "$R_DESKTOP"
+            printf '\nRun log + failure artifacts: %s\n\n' "$RUN_URL"
+            printf '_Auto-posted by app-live-e2e.yml so a red nightly notifies someone (Done-when, #13681)._\n'
+          } > "$RUNNER_TEMP/nightly-red.md"
+          gh issue comment 13681 --repo "$REPO" --body-file "$RUNNER_TEMP/nightly-red.md"


### PR DESCRIPTION
## Problem

`app-live-e2e.yml` is the only scheduled CI home for the packaged Electrobun
desktop suite, and it has failed every night for multiple consecutive nights
(#13681). The failure is invisible: the workflow has **no notification of any
kind**, so a nightly that is always red is indistinguishable from having no lane
— nobody is alerted, and desktop regressions accumulate silently.

## Fix

Add a `notify-on-failure` job that runs after the four e2e jobs and, on a
**scheduled** run where any of them reported `failure`, posts a diagnostic
comment on tracking issue #13681 with the per-job results (`app-live-chat`,
`walkthrough-live`, `cloud-live`, `desktop-packaged`) and a link to the run +
failure artifacts. This directly satisfies the "a red nightly notifies someone
(issue comment …)" acceptance bullet, turning a silent red into an actionable
signal. Manual `workflow_dispatch` runs stay quiet to avoid noise. The job takes
job-scoped `issues: write` (the workflow default stays `contents: read`).

## What is validated

- YAML parses and the job graph is well-formed (`needs` resolves to the four
  existing jobs; `notify-on-failure` is a new leaf).
- The `if:` guard (`always() && github.event_name == 'schedule' &&
  contains(needs.*.result, 'failure')`) fires only on a red scheduled run.
- Reasoned-only: I could not execute the scheduled lane (repo CI is wedged, and
  the desktop leg needs a Linux WebKitGTK GPU host).

## Residual — needs a device, out of scope here

Two other "Done when" bullets need a real Linux WebKitGTK GPU host to resolve
and cannot be fixed blind from config:

- **Screenshot backend** — already landed on `develop` in #13680 / #13747, which
  provisions `scrot`/`imagemagick`/`x11-apps`/`ffmpeg` in the desktop job. The
  `[ScreenCapture] Executable not found` failure from the issue no longer
  reproduces on current `develop`.
- **`/settings/voice` settings-shell timeout** — the packaged renderer routing
  failure under WebKitGTK (`Timed out waiting for [data-testid="settings-shell"]`)
  needs to be reproduced on a Linux WebKitGTK GPU device to root-cause (renderer
  hash-routing under `file:` vs live-api server-shape drift). It is intentionally
  not skipped or softened here, per the issue's "fixed, not skipped" requirement.

Refs #13681