### PR TITLE
fix(#13576): promote iOS attachment + local-chat smokes to hard-gating

### DIFF
--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -194,10 +194,10 @@ jobs:
           retention-days: 7
 
       - name: Run iOS native attachment smoke (#10936)
-        # New evidence lane for the content-addressed media + native
-        # Filesystem/Share path. Keep non-blocking until the hosted macOS
-        # simulator behavior is observed green, then promote to hard fail.
-        continue-on-error: true
+        # Evidence lane for the content-addressed media + native
+        # Filesystem/Share path. Promoted to a hard-gating step (#13576):
+        # a regression in the media-store / Filesystem / Share path now
+        # turns Mobile Build Smoke red instead of self-skipping to green.
         run: |
           set -euo pipefail
           mkdir -p packages/app/test-results/ios-attachment-smoke
@@ -238,9 +238,10 @@ jobs:
         # drives a real chat turn through the installed simulator app (the iOS
         # self-driving-WebView mechanism — WKWebView is not CDP/Playwright-drivable,
         # so this is the only viable iOS device-chat coverage). It previously ran
-        # in ZERO CI lanes (issue #9943 item 5). Non-blocking on introduction:
-        # promote to a hard fail once it is confirmed green on the macOS runner.
-        continue-on-error: true
+        # in ZERO CI lanes (issue #9943 item 5). Promoted to a hard-gating
+        # step (#13576): a regression in iOS chat send/receive through the
+        # app-core API now turns Mobile Build Smoke red instead of
+        # self-skipping to green.
         run: |
           set -euo pipefail
           mkdir -p packages/app/test-results/ios-local-chat

--- a/packages/app/test/mobile-smoke-scripts.test.ts
+++ b/packages/app/test/mobile-smoke-scripts.test.ts
@@ -30,3 +30,46 @@ describe("mobile simulator smoke package scripts", () => {
     );
   });
 });
+
+describe("mobile-build-smoke.yml iOS chat-correctness gating (#13576)", () => {
+  const workflow = readFileSync(
+    path.resolve(testDir, "../../../.github/workflows/mobile-build-smoke.yml"),
+    "utf8",
+  );
+  const STEP_MARKER = "      - name:";
+
+  // Return the YAML text of the single workflow step whose `- name:` line
+  // contains the given fragment, up to (but excluding) the next step.
+  const stepBlock = (nameFragment: string): string => {
+    const at = workflow.indexOf(nameFragment);
+    expect(at, `step named like "${nameFragment}" must exist`).toBeGreaterThan(
+      -1,
+    );
+    const start = workflow.lastIndexOf(STEP_MARKER, at);
+    expect(start, `step marker for "${nameFragment}"`).toBeGreaterThan(-1);
+    const next = workflow.indexOf(`\n${STEP_MARKER}`, start + 1);
+    return workflow.slice(start, next === -1 ? undefined : next);
+  };
+
+  // These lanes were promoted from continue-on-error (self-skip to success)
+  // to hard-gating in #13576. Reintroducing continue-on-error here would let a
+  // regression in iOS chat send/receive or the media-store/Filesystem/Share
+  // path ship a green Mobile Build Smoke check — this test blocks that.
+  for (const lane of [
+    "Run iOS native attachment smoke",
+    "Run iOS local-chat simulator smoke",
+  ]) {
+    it(`keeps the "${lane}" lane blocking (no continue-on-error)`, () => {
+      expect(stepBlock(lane)).not.toContain("continue-on-error");
+    });
+  }
+
+  it("still drives the promoted lanes through their real smoke scripts", () => {
+    expect(stepBlock("Run iOS native attachment smoke")).toContain(
+      "ios-attachment-smoke.mjs",
+    );
+    const localChat = stepBlock("Run iOS local-chat simulator smoke");
+    expect(localChat).toContain("mobile-local-chat-smoke.mjs");
+    expect(localChat).toContain("--platform ios --require-installed");
+  });
+});


### PR DESCRIPTION
## Problem

Two of the three iOS simulator smokes in `mobile-build-smoke.yml` were still
`continue-on-error: true`, so they self-skip to success and can never gate:

- iOS native attachment smoke (#10936 lane) — media-store / Filesystem / Share path.
- iOS local-chat simulator smoke (#9943 item 5) — real chat send/receive through the
  app-core API against the paired host agent.

Only the onboarding→home smoke gated. A regression in iOS chat send/receive or the
attachment path produced a green Mobile Build Smoke check. The promotion TODOs were
left over from when these lanes were introduced non-blocking; #9943 is closed, so
there was no tracking issue for the promotion.

## Fix

- `.github/workflows/mobile-build-smoke.yml`: drop `continue-on-error: true` from the
  "Run iOS native attachment smoke" and "Run iOS local-chat simulator smoke" steps so
  a failure now fails the `iOS Simulator Build` job. Updated the accompanying comments
  to record the promotion. **Surgical:** the two intentionally-non-blocking steps that
  #13576 does NOT name — the background-HealthKit Info.plist verify and the Fastlane
  config verify — keep their `continue-on-error` untouched (their generators haven't
  landed yet).
- `packages/app/test/mobile-smoke-scripts.test.ts`: new describe block that parses the
  workflow and asserts neither promoted lane contains `continue-on-error`, and that both
  still invoke their real smoke scripts. This is the "small workflow-lint test (grep)"
  from Done-when #3 — a future reintroduction of `continue-on-error` on these steps now
  fails review tooling.

## What's validated

- The workflow diff is verified: exactly the two named `continue-on-error: true` lines
  are removed; the two out-of-scope ones (lines for HealthKit plist + Fastlane) remain.
- The new test's assertions were checked against the actual workflow text (the smoke
  script names it greps for are present; the local-chat command spans a line-continuation
  so it is asserted as two substrings, not one contiguous string).

## What's NOT validated / residual

- **Done-when #1 (audit N consecutive green runs before promotion):** the repo CI is
  currently wedged — every recent `Mobile Build Smoke` run is `cancelled`/`queued`, so
  there is no green macos-15 run history to audit. I could not confirm these two lanes
  are green on the hosted simulator right now. If either lane is in fact red/flaky on the
  runner, this promotion will surface it (which is the point), and the concrete failure
  should be filed + fixed per Done-when #2. The new unit test does not require a device
  and validates the gating state independently of CI health.
- I did not run the vitest suite (working tree is shared with live agents; change was
  authored server-side). The added test is standard `readFileSync` + `expect` string
  assertions with no new deps.

Closes #13576