### PR TITLE
fix(#13422): migrate p4-agent-boot-runtime boot-critical aliased env reads to the alias-aware reader

### DIFF
--- a/packages/agent/src/bin.ts
+++ b/packages/agent/src/bin.ts
@@ -11,6 +11,12 @@
 import * as _earlyFs from "node:fs";
 import { enableCompileCache } from "node:module";
 import { homedir as _earlyHomedir } from "node:os";
+// Resolve a branded `<PREFIX>_STATE_DIR` / `<PREFIX>_PLATFORM` through the
+// boot-config alias table without depending on the syncBrandEnvToEliza mirror
+// (issue #13422). `@elizaos/shared` is already a transitive static import via
+// `./cli/index.ts`, so this adds no new module to the boot graph; before the
+// alias table is seeded these fall back to the raw ELIZA_ value.
+import { isAndroidMobile, readAliasedEnv } from "@elizaos/shared";
 
 // Enable Node 22.8+'s persistent V8 compile cache before any heavy import so
 // the 2nd+ cold boot skips recompiling the ~70k LOC of transpiled plugin
@@ -36,7 +42,7 @@ import { homedir as _earlyHomedir } from "node:os";
     // identically to the rest of the codebase (see state-dir.ts).
     const home = process.env.HOME?.trim() || _earlyHomedir();
     const resolvedStateDir =
-      process.env.ELIZA_STATE_DIR?.trim() ||
+      readAliasedEnv("ELIZA_STATE_DIR") ||
       (xdgStateHome
         ? `${xdgStateHome}/eliza`
         : home
@@ -57,31 +63,31 @@ import { configureMobileDnsIfNeeded } from "./runtime/mobile-dns.ts";
 
 // Early diagnostic logger for Android: captures errors before the fs shim runs.
 // Uses raw node:fs so the shim can't interfere. Writes to $ELIZA_STATE_DIR/bin-debug.log.
-const _binDebugLog =
-  process.env.ELIZA_PLATFORM === "android"
-    ? (() => {
-        const xdgStateHome =
-          process.env.XDG_STATE_HOME ??
-          `${process.env.HOME ?? "/data/local/tmp"}/.local/state`;
-        const stateDir = process.env.ELIZA_STATE_DIR || `${xdgStateHome}/eliza`;
-        const logPath = `${stateDir}/bin-debug.log`;
+const _binDebugLog = isAndroidMobile()
+  ? (() => {
+      const xdgStateHome =
+        process.env.XDG_STATE_HOME ??
+        `${process.env.HOME ?? "/data/local/tmp"}/.local/state`;
+      const stateDir =
+        readAliasedEnv("ELIZA_STATE_DIR") || `${xdgStateHome}/eliza`;
+      const logPath = `${stateDir}/bin-debug.log`;
+      try {
+        _earlyFs.mkdirSync(stateDir, { recursive: true });
+      } catch {
+        /* ignore */
+      }
+      return (msg: string) => {
         try {
-          _earlyFs.mkdirSync(stateDir, { recursive: true });
+          _earlyFs.appendFileSync(
+            logPath,
+            `${new Date().toISOString()} ${msg}\n`,
+          );
         } catch {
           /* ignore */
         }
-        return (msg: string) => {
-          try {
-            _earlyFs.appendFileSync(
-              logPath,
-              `${new Date().toISOString()} ${msg}\n`,
-            );
-          } catch {
-            /* ignore */
-          }
-        };
-      })()
-    : () => {};
+      };
+    })()
+  : () => {};
 _binDebugLog(
   `[bin.ts] started ELIZA_PLATFORM=${process.env.ELIZA_PLATFORM ?? "(unset)"} ELIZA_STATE_DIR=${process.env.ELIZA_STATE_DIR ?? "(unset)"}`,
 );
@@ -93,7 +99,7 @@ _binDebugLog(
 configureMobileDnsIfNeeded();
 
 async function bootstrapMobileEntrypoint(): Promise<void> {
-  if (process.env.ELIZA_PLATFORM === "android") {
+  if (isAndroidMobile()) {
     _binDebugLog("[bin.ts] entering android block");
     try {
       // Bundle anchor: evaluating this literal-specifier import forces

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -124,6 +124,7 @@ import {
   isElizaSettingsDebugEnabled,
   isMobilePlatform,
   migrateLegacyRuntimeConfig,
+  readAliasedEnv,
   resolveApiExposePort,
   resolveDeploymentTargetInConfig,
   resolveDesktopApiPort,
@@ -2044,7 +2045,7 @@ export async function autoFetchCloudGithubToken(
     process.env.ELIZAOS_CLOUD_BASE_URL?.trim() || "https://api.elizacloud.ai";
   if (!cloudApiKey || !agentId) return;
 
-  const managedNs = process.env.ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT?.trim();
+  const managedNs = readAliasedEnv("ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT");
   if (!managedNs) return;
 
   try {
@@ -3675,7 +3676,7 @@ export async function startEliza(
   //     in the slim image, and the second PGlite worker has been observed to
   //     hang vault-pglite init silently — blocking the HTTP listen and
   //     tripping the 180s health check on every fresh provision.
-  const isCloudProvisioned = process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  const isCloudProvisioned = readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
   if (!isMobilePlatform() && !isCloudProvisioned) {
     // pre-resolve-setup's two serial cost centers: the OS-keychain hydrate and
     // the vault PGlite cold-start. Timed separately and surfaced below so the
@@ -3861,7 +3862,7 @@ export async function startEliza(
   // injected by the daemon as env vars, so there's nothing to multiplex. The
   // pool implementation is supplied by the host through the injected agent host
   // bridge (see ./host-bridge.ts) — no app-core import, no boot-time cycle.
-  if (process.env.ELIZA_CLOUD_PROVISIONED !== "1")
+  if (readAliasedEnv("ELIZA_CLOUD_PROVISIONED") !== "1")
     try {
       const accountPool = await importAppCoreRuntime();
       accountPool.getDefaultAccountPool();
@@ -4018,7 +4019,7 @@ export async function startEliza(
   // image; see the boot-time vault hydration block earlier in this function.
   if (
     process.env.ELIZA_DISABLE_VAULT_PROFILE_RESOLVER !== "1" &&
-    process.env.ELIZA_CLOUD_PROVISIONED !== "1"
+    readAliasedEnv("ELIZA_CLOUD_PROVISIONED") !== "1"
   ) {
     try {
       const { sharedVault } = await importAppCoreRuntime();
@@ -4996,7 +4997,7 @@ export async function startEliza(
   > => {
     if (
       process.env.ELIZA_DISABLE_AGENT_WALLET_BOOTSTRAP === "1" ||
-      process.env.ELIZA_CLOUD_PROVISIONED === "1"
+      readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1"
     ) {
       return Promise.resolve([]);
     }
@@ -5432,7 +5433,7 @@ export async function startEliza(
     // the renderer hit "Failed to fetch". Prefer the desktop API port
     // resolver when ELIZA_API_PORT is set; otherwise fall back to the
     // server-only resolver so CLI-mode defaults (2138) stay untouched.
-    const apiPort = process.env.ELIZA_API_PORT
+    const apiPort = readAliasedEnv("ELIZA_API_PORT")
       ? resolveDesktopApiPort(process.env)
       : resolveServerOnlyPort(process.env);
     // Local-agent IPC mode (Android stdio bridge / Capacitor): the WebView

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -28,6 +28,7 @@ import {
   isMobilePlatform,
   migrateLegacyRuntimeConfig,
   type ResolvedElizaCloudTopology,
+  readAliasedEnv,
   resolveDeploymentTargetInConfig,
   resolveElizaCloudTopology,
   resolveServiceRoutingInConfig,
@@ -67,7 +68,7 @@ function orchestratorCompatPluginRequested(config: ElizaConfig): boolean {
   if (typeof fromDefaults === "boolean") {
     return fromDefaults;
   }
-  const raw = process.env.ELIZA_AGENT_ORCHESTRATOR?.trim().toLowerCase();
+  const raw = readAliasedEnv("ELIZA_AGENT_ORCHESTRATOR")?.toLowerCase();
   if (raw === "0" || raw === "false" || raw === "no") {
     return false;
   }
@@ -355,7 +356,7 @@ export function collectPluginNames(
   const hasCanonicalRuntimeConfig = hasExplicitCanonicalRuntimeConfig(
     config as Record<string, unknown>,
   );
-  const isCloudContainer = process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  const isCloudContainer = readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
   const storeBuild = isStoreBuildVariant();
   const cloudExplicitlyDisabled = config.cloud?.enabled === false;
   // `ELIZA_LOCAL_LLAMA=1` is the AOSP / on-device signal that the in-process

--- a/packages/core/src/boot-alias-read-migration.test.ts
+++ b/packages/core/src/boot-alias-read-migration.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Proves the issue #13422 P4 core read-migrations resolve a branded (non-ELIZA)
+ * env prefix through the boot-config alias table WITHOUT the syncBrandEnvToEliza
+ * mirror: resolveTrajectoryDir (ELIZA_STATE_DIR) and isElizaSettingsDebugEnabled
+ * (ELIZA_SETTINGS_DEBUG / VITE_ELIZA_SETTINGS_DEBUG) now read via
+ * resolveAliasedEnvValue. Deterministic; installs and restores the shared
+ * boot-config global slot and process.env around each case. No mocks — the real
+ * migrated functions run against the real alias resolver.
+ */
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveTrajectoryDir } from "./runtime/trajectory-recorder";
+import { isElizaSettingsDebugEnabled } from "./settings-debug";
+
+const STORE_KEY = Symbol.for("elizaos.app.boot-config");
+const WINDOW_KEY = "__ELIZAOS_APP_BOOT_CONFIG__";
+type Slot = Record<PropertyKey, unknown>;
+
+// The real MILADY-branded pairs for the keys under test. A NON-ELIZA prefix is
+// the security-relevant fixture; an ELIZA->ELIZA self-mirror proves nothing.
+const MILADY_ALIASES = [
+	["MILADY_STATE_DIR", "ELIZA_STATE_DIR"],
+	["MILADY_SETTINGS_DEBUG", "ELIZA_SETTINGS_DEBUG"],
+	["VITE_MILADY_SETTINGS_DEBUG", "VITE_ELIZA_SETTINGS_DEBUG"],
+] as const;
+
+describe("issue #13422 core read-migrations resolve a branded prefix without the mirror", () => {
+	const savedEnv: Record<string, string | undefined> = {};
+	const tracked = [
+		"ELIZA_TRAJECTORY_DIR",
+		"MILADY_STATE_DIR",
+		"ELIZA_STATE_DIR",
+		"MILADY_SETTINGS_DEBUG",
+		"ELIZA_SETTINGS_DEBUG",
+		"VITE_MILADY_SETTINGS_DEBUG",
+		"VITE_ELIZA_SETTINGS_DEBUG",
+	];
+	let savedStore: unknown;
+	let savedWindow: unknown;
+
+	beforeEach(() => {
+		const slot = globalThis as Slot;
+		savedStore = slot[STORE_KEY];
+		savedWindow = slot[WINDOW_KEY];
+		for (const key of tracked) {
+			savedEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+		// Install the alias table on the shared boot-config store exactly as the app
+		// boot path does; this is what makes resolveAliasedEnvValue's default alias
+		// source resolve branded keys inside the migrated functions.
+		slot[STORE_KEY] = { current: { envAliases: MILADY_ALIASES } };
+	});
+
+	afterEach(() => {
+		const slot = globalThis as Slot;
+		if (savedStore === undefined) delete slot[STORE_KEY];
+		else slot[STORE_KEY] = savedStore;
+		if (savedWindow === undefined) delete slot[WINDOW_KEY];
+		else slot[WINDOW_KEY] = savedWindow;
+		for (const key of tracked) {
+			if (savedEnv[key] === undefined) delete process.env[key];
+			else process.env[key] = savedEnv[key];
+		}
+	});
+
+	it("resolveTrajectoryDir derives from a branded MILADY_STATE_DIR with zero mirror writes", () => {
+		process.env.MILADY_STATE_DIR = "/var/milady/state";
+		const before = { ...process.env };
+
+		expect(resolveTrajectoryDir()).toBe(
+			path.join("/var/milady/state", "trajectories"),
+		);
+
+		// The migrated read must not materialize the ELIZA_ target.
+		expect(process.env.ELIZA_STATE_DIR).toBeUndefined();
+		expect(process.env).toEqual(before);
+	});
+
+	it("resolveTrajectoryDir prefers a canonical ELIZA_STATE_DIR over the branded alias", () => {
+		process.env.ELIZA_STATE_DIR = "/var/eliza/state";
+		process.env.MILADY_STATE_DIR = "/var/milady/state";
+		expect(resolveTrajectoryDir()).toBe(
+			path.join("/var/eliza/state", "trajectories"),
+		);
+	});
+
+	it("isElizaSettingsDebugEnabled honors a branded MILADY_SETTINGS_DEBUG with zero mirror writes", () => {
+		process.env.MILADY_SETTINGS_DEBUG = "1";
+		const before = { ...process.env };
+
+		expect(isElizaSettingsDebugEnabled()).toBe(true);
+
+		expect(process.env.ELIZA_SETTINGS_DEBUG).toBeUndefined();
+		expect(process.env).toEqual(before);
+	});
+
+	it("isElizaSettingsDebugEnabled honors a branded VITE_MILADY_SETTINGS_DEBUG", () => {
+		process.env.VITE_MILADY_SETTINGS_DEBUG = "true";
+		expect(isElizaSettingsDebugEnabled()).toBe(true);
+		expect(process.env.VITE_ELIZA_SETTINGS_DEBUG).toBeUndefined();
+	});
+
+	it("stays false when neither the branded nor canonical flag is set", () => {
+		expect(isElizaSettingsDebugEnabled()).toBe(false);
+	});
+
+	it("a canonical ELIZA_SETTINGS_DEBUG=0 wins over a branded truthy alias", () => {
+		// Canonical precedence: an explicit ELIZA_ '0' is the resolved value, so the
+		// branded '1' never surfaces — debug stays off.
+		process.env.ELIZA_SETTINGS_DEBUG = "0";
+		process.env.MILADY_SETTINGS_DEBUG = "1";
+		expect(isElizaSettingsDebugEnabled()).toBe(false);
+	});
+});

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -21,6 +21,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import { resolveAliasedEnvValue } from "../boot-env";
 import {
 	computeCallCostUsd,
 	PRICE_TABLE_ID,
@@ -374,7 +375,7 @@ export function resolveTrajectoryDir(): string {
 	const explicit = process.env.ELIZA_TRAJECTORY_DIR?.trim();
 	if (explicit) return explicit;
 
-	const elizaState = process.env.ELIZA_STATE_DIR?.trim();
+	const elizaState = resolveAliasedEnvValue("ELIZA_STATE_DIR")?.trim();
 	if (elizaState) return path.join(elizaState, "trajectories");
 
 	return path.join(resolveStateDir(), "trajectories");

--- a/packages/core/src/settings-debug.ts
+++ b/packages/core/src/settings-debug.ts
@@ -3,6 +3,7 @@
  * Enable with ELIZA_SETTINGS_DEBUG=1 (and Vite: same env at build time, or VITE_ELIZA_SETTINGS_DEBUG=1).
  */
 
+import { resolveAliasedEnvValue } from "./boot-env.js";
 import { isTruthyEnvValue } from "./env-utils.js";
 
 /** Keys whose values are always redacted in debug dumps. */
@@ -35,8 +36,10 @@ export function isElizaSettingsDebugEnabled(options?: {
 		if (isTruthyEnvValue(e.VITE_ELIZA_SETTINGS_DEBUG)) return true;
 	}
 	if (typeof process !== "undefined" && process.env) {
-		if (isTruthyEnvValue(process.env.ELIZA_SETTINGS_DEBUG)) return true;
-		if (isTruthyEnvValue(process.env.VITE_ELIZA_SETTINGS_DEBUG)) return true;
+		if (isTruthyEnvValue(resolveAliasedEnvValue("ELIZA_SETTINGS_DEBUG")))
+			return true;
+		if (isTruthyEnvValue(resolveAliasedEnvValue("VITE_ELIZA_SETTINGS_DEBUG")))
+			return true;
 	}
 	return false;
 }

--- a/packages/shared/src/utils/env.test.ts
+++ b/packages/shared/src/utils/env.test.ts
@@ -10,6 +10,11 @@ import {
   buildBrandEnvSyncAliases,
 } from "../config/brand-env-aliases.js";
 import {
+  isAndroidMobile,
+  resolveDesktopApiPort,
+  resolvePlatform,
+} from "../runtime-env.js";
+import {
   DEFAULT_APP_ROUTE_PLUGIN_MODULES,
   isEnvDisabled,
   normalizeEnvValue,
@@ -322,5 +327,124 @@ describe("syncElizaEnvAliases", () => {
         }
       }
     }
+  });
+});
+
+// Issue #13422 P4 boot-runtime slice: the agent-boot reads migrated to the
+// alias-aware resolvers — state dir (bin.ts / trajectory-recorder), platform
+// (bin.ts), API port (eliza.ts boot), cloud provisioning, managed-agents
+// segment, and the orchestrator toggle (plugin-collector) — must resolve a
+// branded (non-ELIZA) prefix WITHOUT the syncBrandEnvToEliza mirror, with the
+// canonical ELIZA_ key still winning when both are set. A NON-ELIZA prefix is
+// the security-relevant fixture: an ELIZA->ELIZA self-mirror proves nothing.
+describe("issue #13422 P4 agent-boot keys resolve a branded prefix with zero mirror writes", () => {
+  const BRAND = "MILADY";
+  const savedConfig = getBootConfig();
+  const aliases = buildBrandEnvAliases(BRAND);
+  const tracked = [
+    "MILADY_STATE_DIR",
+    "ELIZA_STATE_DIR",
+    "MILADY_PLATFORM",
+    "ELIZA_PLATFORM",
+    "MILADY_API_PORT",
+    "ELIZA_API_PORT",
+    "MILADY_PORT",
+    "ELIZA_PORT",
+    "MILADY_UI_PORT",
+    "ELIZA_UI_PORT",
+    "MILADY_CLOUD_PROVISIONED",
+    "ELIZA_CLOUD_PROVISIONED",
+    "MILADY_CLOUD_MANAGED_AGENTS_API_SEGMENT",
+    "ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT",
+    "MILADY_AGENT_ORCHESTRATOR",
+    "ELIZA_AGENT_ORCHESTRATOR",
+  ];
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of tracked) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    // Pin the alias table on the immutable BootConfig, as the app boot path does.
+    setBootConfig({ ...savedConfig, envAliases: aliases });
+  });
+
+  afterEach(() => {
+    for (const key of tracked) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    setBootConfig(savedConfig);
+  });
+
+  it("readAliasedEnv resolves the boot-critical agent keys from branded values, no mirror", () => {
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+    process.env.MILADY_CLOUD_PROVISIONED = "1";
+    process.env.MILADY_CLOUD_MANAGED_AGENTS_API_SEGMENT = "milady";
+    process.env.MILADY_AGENT_ORCHESTRATOR = "true";
+    const before = { ...process.env };
+
+    expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/var/milady/state");
+    expect(readAliasedEnv("ELIZA_CLOUD_PROVISIONED")).toBe("1");
+    expect(readAliasedEnv("ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT")).toBe(
+      "milady",
+    );
+    // plugin-collector lowercases this for its 0/false/no vs 1/true/yes gate.
+    expect(readAliasedEnv("ELIZA_AGENT_ORCHESTRATOR")?.toLowerCase()).toBe(
+      "true",
+    );
+
+    // A read must never materialize the ELIZA_ target — that mutation is exactly
+    // what #13422 removes the dependency on.
+    expect(process.env.ELIZA_STATE_DIR).toBeUndefined();
+    expect(process.env.ELIZA_CLOUD_PROVISIONED).toBeUndefined();
+    expect(process.env.ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT).toBeUndefined();
+    expect(process.env.ELIZA_AGENT_ORCHESTRATOR).toBeUndefined();
+    expect(process.env).toEqual(before);
+  });
+
+  it("canonical ELIZA_ key wins over the branded alias", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.MILADY_CLOUD_PROVISIONED = "0";
+    expect(readAliasedEnv("ELIZA_CLOUD_PROVISIONED")).toBe("1");
+
+    process.env.ELIZA_STATE_DIR = "/canonical";
+    process.env.MILADY_STATE_DIR = "/branded";
+    expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/canonical");
+  });
+
+  it("resolveDesktopApiPort (eliza.ts boot) honors a branded MILADY_API_PORT, no mirror", () => {
+    process.env.MILADY_API_PORT = "31555";
+    const before = { ...process.env };
+    // The eliza.ts boot guard reads readAliasedEnv('ELIZA_API_PORT') then calls
+    // resolveDesktopApiPort — both must see the branded port.
+    expect(readAliasedEnv("ELIZA_API_PORT")).toBe("31555");
+    expect(resolveDesktopApiPort()).toBe(31555);
+    expect(process.env.ELIZA_API_PORT).toBeUndefined();
+    expect(process.env).toEqual(before);
+  });
+
+  it("canonical ELIZA_API_PORT wins over a branded MILADY_API_PORT", () => {
+    process.env.ELIZA_API_PORT = "31337";
+    process.env.MILADY_API_PORT = "40000";
+    expect(readAliasedEnv("ELIZA_API_PORT")).toBe("31337");
+    expect(resolveDesktopApiPort()).toBe(31337);
+  });
+
+  it("isAndroidMobile / resolvePlatform (bin.ts) honor a branded MILADY_PLATFORM, no mirror", () => {
+    process.env.MILADY_PLATFORM = "android";
+    const before = { ...process.env };
+    expect(resolvePlatform()).toBe("android");
+    expect(isAndroidMobile()).toBe(true);
+    expect(process.env.ELIZA_PLATFORM).toBeUndefined();
+    expect(process.env).toEqual(before);
+  });
+
+  it("canonical ELIZA_PLATFORM wins over a branded MILADY_PLATFORM", () => {
+    process.env.ELIZA_PLATFORM = "ios";
+    process.env.MILADY_PLATFORM = "android";
+    expect(resolvePlatform()).toBe("ios");
+    expect(isAndroidMobile()).toBe(false);
   });
 });


### PR DESCRIPTION
## Boot-critical slice of #13422 (P4 — agent boot runtime + core state/settings)

Migrates raw `process.env.<KEY>` reads of **brand↔eliza alias-table keys** to the alias-aware resolvers, so a branded `<PREFIX>_KEY` (e.g. `MILADY_STATE_DIR`) resolves **without** depending on the `syncBrandEnvToEliza` mirror mutation. Precedence and empty-is-unset are preserved: the canonical `ELIZA_*` key still wins when present, and a blank/whitespace value is treated as absent.

`syncBrandEnvToEliza` / `syncElizaEnvToBrand` are intentionally **kept** (their removal is #13423). Non-critical long-tail reads are deferred.

### Reads migrated (this partition)
| File | Key(s) | Reader |
|---|---|---|
| `packages/agent/src/bin.ts` | `ELIZA_STATE_DIR` (compile-cache anchor + android bin-debug path) | `readAliasedEnv` |
| `packages/agent/src/bin.ts` | `ELIZA_PLATFORM === "android"` (debug logger + mobile bootstrap) | `isAndroidMobile()` |
| `packages/agent/src/runtime/eliza.ts` | `ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT`, `ELIZA_CLOUD_PROVISIONED` ×4 | `readAliasedEnv` |
| `packages/agent/src/runtime/eliza.ts` | `ELIZA_API_PORT` desktop-port guard | `readAliasedEnv` (resolveDesktopApiPort already alias-aware) |
| `packages/agent/src/runtime/plugin-collector.ts` | `ELIZA_AGENT_ORCHESTRATOR`, `ELIZA_CLOUD_PROVISIONED` | `readAliasedEnv` |
| `packages/core/src/runtime/trajectory-recorder.ts` | `ELIZA_STATE_DIR` | `resolveAliasedEnvValue` (core-local; core can't depend on shared) |
| `packages/core/src/settings-debug.ts` | `ELIZA_SETTINGS_DEBUG`, `VITE_ELIZA_SETTINGS_DEBUG` (process.env fallback) | `resolveAliasedEnvValue` |

### Deliberately NOT touched
- `eliza.ts` L2342–2359 `ELIZA_CLOUD_*_DISABLED` — **writes**, excluded per partition.
- `bin.ts` startup **diagnostic echo** — intentionally logs the raw literal env value.
- Non-aliased neighbors (`ELIZAOS_CLOUD_API_KEY`, `ELIZAOS_CLOUD_BASE_URL`, `ELIZA_DISABLE_VAULT_PROFILE_RESOLVER`, `ELIZA_DISABLE_AGENT_WALLET_BOOTSTRAP`) — not in the alias table, left as-is.

### bin.ts import safety
`@elizaos/shared` is already a transitive static import via `./cli/index.ts`, so the added import puts no new module in the boot graph and does not change the ESM evaluation order of the compile-cache IIFE (module body runs after all static imports either way). Before the boot-config alias table is seeded, these earliest-boot reads fall back to the raw `ELIZA_*` value — identical to prior behavior — and resolve the branded alias once the table is present.

## Tests (real, no mocks) — the security proof the issue demands

**`packages/core/src/boot-alias-read-migration.test.ts`** (new) drives the **real migrated functions** `resolveTrajectoryDir()` and `isElizaSettingsDebugEnabled()` with a non-ELIZA `MILADY_` prefix installed on the boot-config alias table:
- branded `MILADY_STATE_DIR` / `MILADY_SETTINGS_DEBUG` / `VITE_MILADY_SETTINGS_DEBUG` resolve,
- canonical `ELIZA_*` wins (incl. `ELIZA_SETTINGS_DEBUG=0` beating branded `1`),
- **zero mirror writes** (`process.env.ELIZA_*` never materialized).

**`packages/shared/src/utils/env.test.ts`** (extended) proves the same for the agent-boot keys via `readAliasedEnv` + `resolveDesktopApiPort` + `isAndroidMobile`/`resolvePlatform` (state dir, platform, API port, cloud provisioning, managed-agents segment, orchestrator) — branded resolution + `ELIZA_*` precedence + zero mirror writes.

```
core boot-alias-read-migration.test.ts   6 passed
shared env.test.ts                       19 passed (6 new)
```

**Fail-before verified:** reverting the two core reads back to raw `process.env` fails exactly the 3 branded-resolution cases (canonical-wins / stays-false still pass), proving the tests pin the migrated code path.

No-regression: existing `core boot-env.test.ts` + `trajectory-recorder.test.ts` (63) and `agent plugin-collector-*` (21) pass. Package-local typechecks show only pre-existing environment noise (missing third-party `.d.ts`, mobile-only `@vite-ignore` anchor imports); nothing in the touched files errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)