### PR TITLE
fix(#13578): add nightly iOS local (full-Bun) simulator smoke CI lane

### DIFF
--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -7,6 +7,12 @@ on:
     branches: [main, develop]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
+  schedule:
+    # Nightly iOS local (full-Bun on-device engine) lane (#13578). This mode
+    # is too heavy for the PR path — a full-Bun engine build, a real ~1.3GB
+    # GGUF, and CPU inference in the simulator — so it runs on a schedule and
+    # gates that nightly run instead of every pull request.
+    - cron: "0 7 * * *"
 
 concurrency:
   group: mobile-smoke-${{ github.ref }}
@@ -257,6 +263,150 @@ jobs:
             fi
           done
           echo "Fastlane config present at packages/app/ios/."
+
+  build-ios-local:
+    name: iOS Local (full-Bun) Simulator Smoke
+    # Nightly / on-demand only — never on the PR path. The full-Bun on-device
+    # engine build + real GGUF + CPU inference is far too heavy to gate every
+    # pull request, so the local runtime mode gates the scheduled run instead.
+    # This closes the coverage gap called out in #13578: remote mode is
+    # CI-blocking, but local (full-Bun) mode had no unattended lane. Mirrors
+    # the remote build-ios job, swapping the direct/loopback host-agent smoke
+    # for the on-device full-Bun engine smoke (no host agent — the engine runs
+    # in-process and the smoke exchanges the request/result via Preferences).
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-15
+    timeout-minutes: 90
+    env:
+      # A real, small on-device GGUF — the same eliza-1 e2b text model the
+      # Android live smoke stages. mobile-local-chat-smoke.mjs copies whatever
+      # ELIZA_IOS_FULL_BUN_SMOKE_MODEL_PATH points at into the sim container and
+      # registers it under the `eliza-1-2b` id, capping the context to 4096 so
+      # model load + first reply stay fast on a simulator.
+      IOS_FULL_BUN_SMOKE_MODEL_URL: "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/e2b/text/eliza-1-e2b-32k.gguf?download=true"
+      IOS_FULL_BUN_SMOKE_MODEL_FILE: "eliza-1-e2b-32k.gguf"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-native-deps: "false"
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          run-postinstall: "true"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Generate protobuf types
+        run: |
+          if [ -d packages/schemas ] && [ -f packages/schemas/buf.gen.yaml ] && [ ! -d packages/core/src/types/generated ]; then
+            cd packages/schemas
+            node node_modules/@bufbuild/buf/install.js 2>/dev/null || true
+            bunx @bufbuild/buf@1.67.0 generate
+          fi
+
+      - name: Build Vite config package deps
+        run: bun turbo run build --filter=@elizaos/ui --filter=@elizaos/vault
+
+      - name: Cache full-Bun smoke GGUF
+        id: model-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ~/.cache/eliza-ios-full-bun-smoke
+          key: ios-full-bun-smoke-model-${{ env.IOS_FULL_BUN_SMOKE_MODEL_FILE }}
+
+      - name: Download full-Bun smoke GGUF (cache miss)
+        if: steps.model-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.cache/eliza-ios-full-bun-smoke"
+          curl -fL --retry 3 --retry-all-errors \
+            -o "$HOME/.cache/eliza-ios-full-bun-smoke/$IOS_FULL_BUN_SMOKE_MODEL_FILE" \
+            "$IOS_FULL_BUN_SMOKE_MODEL_URL"
+          ls -la "$HOME/.cache/eliza-ios-full-bun-smoke/"
+
+      - name: Build iOS simulator app (full-Bun local runtime)
+        # Mirrors `build:ios:local:sim` (run-mobile-build.mjs ios-local with
+        # ELIZA_IOS_FULL_BUN_ENGINE=1). The remote lane builds the same target
+        # with the engine disabled (ELIZA_IOS_FULL_BUN_ENGINE=0); flipping it on
+        # is exactly the coverage this lane adds.
+        run: node --max-old-space-size=8192 packages/app-core/scripts/run-mobile-build.mjs ios-local
+        env:
+          LANG: en_US.UTF-8
+          ELIZA_BUILD_VARIANT: "direct"
+          ELIZA_RELEASE_AUTHORITY: "developer-toolchain"
+          VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK: "1"
+          ELIZA_IOS_FULL_BUN_ENGINE: "1"
+          ELIZA_IOS_BUILD_DESTINATION: "generic/platform=iOS Simulator"
+          ELIZA_IOS_BUILD_SDK: "iphonesimulator"
+          NODE_OPTIONS: "--max-old-space-size=8192"
+
+      - name: Verify .app exists
+        run: |
+          APP_PATH=$(find ~/Library/Developer/Xcode/DerivedData -name "App.app" -path "*/Debug-iphonesimulator/*" | head -1)
+          if [ -z "$APP_PATH" ]; then
+            echo "ERROR: App.app not found in DerivedData"
+            exit 1
+          fi
+          echo "Built app at: $APP_PATH"
+
+      - name: Verify staged renderer is the freshly built one (no stale UI, #9309)
+        run: |
+          node packages/app-core/scripts/verify-ondevice-artifact.mjs --platform ios
+
+      - name: Boot simulator and install the full-Bun app
+        run: |
+          set -euo pipefail
+          # Pick an available iPhone simulator; boot it and wait for readiness.
+          UDID=$(xcrun simctl list devices available -j \
+            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const j=JSON.parse(s);let u="";for(const runtime of Object.keys(j.devices)){if(!/iOS/.test(runtime))continue;for(const dev of j.devices[runtime]){if(dev.isAvailable&&/iPhone/.test(dev.name)){u=dev.udid;break}}if(u)break}process.stdout.write(u)})')
+          if [ -z "$UDID" ]; then
+            echo "ERROR: no available iPhone simulator found"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "Booting simulator $UDID"
+          xcrun simctl boot "$UDID" || true
+          xcrun simctl bootstatus "$UDID" -b
+          APP_PATH=$(find ~/Library/Developer/Xcode/DerivedData -name "App.app" -path "*/Debug-iphonesimulator/*" | head -1)
+          echo "Installing $APP_PATH"
+          xcrun simctl install "$UDID" "$APP_PATH"
+
+      - name: Run iOS full-Bun local-chat simulator smoke (#13578)
+        # Gating check for the nightly lane: build the on-device full-Bun
+        # engine, stage the real GGUF, and assert the exact on-device reply
+        # (`ios smoke model works`). No `continue-on-error` — a regression in
+        # engine boot, the on-device model registry, or first-reply generation
+        # fails the scheduled run.
+        run: |
+          set -euo pipefail
+          mkdir -p packages/app/test-results/ios-full-bun-local-chat
+          # Point the smoke at the cached GGUF via an absolute path it can stat.
+          export ELIZA_IOS_FULL_BUN_SMOKE_MODEL_PATH="$HOME/.cache/eliza-ios-full-bun-smoke/$IOS_FULL_BUN_SMOKE_MODEL_FILE"
+          if [ ! -f "$ELIZA_IOS_FULL_BUN_SMOKE_MODEL_PATH" ]; then
+            echo "ERROR: staged smoke model missing at $ELIZA_IOS_FULL_BUN_SMOKE_MODEL_PATH"
+            exit 1
+          fi
+          node packages/app/scripts/mobile-local-chat-smoke.mjs \
+            --platform ios --require-installed --ios-select-local --ios-full-bun-smoke \
+            2>&1 | tee packages/app/test-results/ios-full-bun-local-chat/smoke.log
+
+      - name: Upload iOS full-Bun local-chat evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ios-full-bun-local-chat
+          path: packages/app/test-results/ios-full-bun-local-chat/**
+          if-no-files-found: warn
+          retention-days: 7
 
   build-android:
     name: Android Debug Build

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -167,6 +167,18 @@ primary file via the Agent plugin's `appendBootTrace` bridge, so there is no
 separate renderer stream) — keep in sync with `ElizaStartupTrace.swift`;
 `ELIZA_IOS_BOOT_TRACE_PATH` overrides the pull path (script-side only).
 
+## iOS runtime-mode CI coverage (#13578)
+
+The iOS app ships three runtime modes; their unattended (CI) coverage is:
+
+| Mode | On-device engine | Automated lane | Gating |
+|---|---|---|---|
+| **remote** (pair to a host agent) | none — proxies to a paired host | `build-ios` job in `.github/workflows/mobile-build-smoke.yml` (onboarding smoke + `serve-real-local-agent` host + local-chat smoke) | PR-blocking |
+| **local** (full-Bun on-device engine) | full Bun runtime + on-device GGUF | `build-ios-local` job in `mobile-build-smoke.yml` — nightly `schedule` (too heavy for the PR path): builds `build:ios:local:sim` (`ELIZA_IOS_FULL_BUN_ENGINE=1`), caches + stages a real small GGUF, boots a sim, installs, runs `test:sim:local-chat:ios:full-bun` and asserts the exact on-device reply | nightly-gating |
+| **cloud** (managed agent) | none — talks to Eliza Cloud | N/A — the XCUITest cloud-onboarding path (`testCloudOnboardingChatAndVoice`) XCTSkips at the OAuth wall with no device Cloud session, and `cloud-provisioning-e2e.mjs` is only reachable behind the unwired `ios-e2e.mjs --cloud`. Needs a documented headless session/JWT seed against a staging Cloud org before it can run unattended (see #13578 done-when #2). | none (blocked) |
+
+Keep this table honest: an N/A row must name what is missing, not hide it.
+
 ## Config / env vars
 
 All env vars use the `ELIZA_` prefix (set in `app.config.ts` → `envPrefix: "ELIZA"`). Key vars read at runtime or build:

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -167,6 +167,18 @@ primary file via the Agent plugin's `appendBootTrace` bridge, so there is no
 separate renderer stream) — keep in sync with `ElizaStartupTrace.swift`;
 `ELIZA_IOS_BOOT_TRACE_PATH` overrides the pull path (script-side only).
 
+## iOS runtime-mode CI coverage (#13578)
+
+The iOS app ships three runtime modes; their unattended (CI) coverage is:
+
+| Mode | On-device engine | Automated lane | Gating |
+|---|---|---|---|
+| **remote** (pair to a host agent) | none — proxies to a paired host | `build-ios` job in `.github/workflows/mobile-build-smoke.yml` (onboarding smoke + `serve-real-local-agent` host + local-chat smoke) | PR-blocking |
+| **local** (full-Bun on-device engine) | full Bun runtime + on-device GGUF | `build-ios-local` job in `mobile-build-smoke.yml` — nightly `schedule` (too heavy for the PR path): builds `build:ios:local:sim` (`ELIZA_IOS_FULL_BUN_ENGINE=1`), caches + stages a real small GGUF, boots a sim, installs, runs `test:sim:local-chat:ios:full-bun` and asserts the exact on-device reply | nightly-gating |
+| **cloud** (managed agent) | none — talks to Eliza Cloud | N/A — the XCUITest cloud-onboarding path (`testCloudOnboardingChatAndVoice`) XCTSkips at the OAuth wall with no device Cloud session, and `cloud-provisioning-e2e.mjs` is only reachable behind the unwired `ios-e2e.mjs --cloud`. Needs a documented headless session/JWT seed against a staging Cloud org before it can run unattended (see #13578 done-when #2). | none (blocked) |
+
+Keep this table honest: an N/A row must name what is missing, not hide it.
+
 ## Config / env vars
 
 All env vars use the `ELIZA_` prefix (set in `app.config.ts` → `envPrefix: "ELIZA"`). Key vars read at runtime or build:


### PR DESCRIPTION
## Problem

iOS runtime-mode coverage in CI is lopsided (#13578). The **remote** mode is PR-blocking (`build-ios` job in `mobile-build-smoke.yml`), but the **local** full-Bun on-device engine mode has **no unattended lane at all**: CI builds with `ELIZA_IOS_FULL_BUN_ENGINE=0` (`mobile-build-smoke.yml:109`) and never exercises the engine. `test:sim:local-chat:ios:full-bun` only ran on a dev host with a hand-staged GGUF. A regression in full-Bun engine boot, the on-device model registry, or first-reply generation could not be caught by any lane that gates.

## Fix (minimal, mirrors the existing remote lane)

`.github/workflows/mobile-build-smoke.yml`:
- New `build-ios-local` job (macos-15), structured like the existing `build-ios` job.
- Runs **nightly** (`schedule: cron 0 7 * * *`) + `workflow_dispatch` only — never on the PR path, because the full-Bun engine build + a real ~1.3GB GGUF + CPU inference in the simulator is far too heavy to gate every PR (this is exactly the "nightly if PR-path is too heavy" allowance in done-when #1). Within the nightly run it is a **hard gating** step (no `continue-on-error`).
- Steps: build `ios-local` with `ELIZA_IOS_FULL_BUN_ENGINE=1` (mirrors `build:ios:local:sim`), `actions/cache` + download a real small GGUF (`elizaos/eliza-1` `bundles/e2b/text/eliza-1-e2b-32k.gguf` — the same model the Android live smoke stages; HF path HEAD-verified 200), boot a simulator, install the `.app`, then run `test:sim:local-chat:ios:full-bun` with `ELIZA_IOS_FULL_BUN_SMOKE_MODEL_PATH` pointed at the cached model. The smoke stages the model into the sim container, caps context to 4096, and asserts the exact on-device reply (`ios smoke model works`).

`packages/app/CLAUDE.md` + `AGENTS.md` (kept identical, per repo convention): add the runtime-mode CI coverage matrix (remote = PR-blocking, local = nightly-gating, cloud = N/A with the reason named) — done-when #3.

## What's validated

- **YAML parses** and the job graph is correct (`changes`, `build-ios`, `build-ios-local`, `build-android`).
- **Reuse of the existing, proven mechanism:** the smoke script already supports the env-pinned model path (`ELIZA_IOS_FULL_BUN_SMOKE_MODEL_PATH`, `mobile-local-chat-smoke.mjs:517`) and the full-Bun path (`--ios-full-bun-smoke`) needs **no host agent** — it launches the installed app, stages the GGUF, and reads the result via `Preferences` (`main()` → `verifyIosFullBunSmoke`). The lane just supplies the model + a booted, app-installed simulator, which is exactly what the script's `--require-installed` contract expects.
- **Model source verified reachable:** `HEAD https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/e2b/text/eliza-1-e2b-32k.gguf` → `200`.

## Residual — needs a real macOS runner to observe green

This PR could not be executed on a hosted macOS runner (repo CI is currently wedged), so the following are reasoned, not observed:
- The full-Bun `ios-local` build succeeding on the hosted runner with `install-native-deps:false` (the `ElizaBunEngine.xcframework` is committed under `packages/native/bun-runtime/artifacts/`, so the prebuilt engine should be present).
- On-device CPU inference in the simulator producing the exact-reply assertion within the timeout, and the model-cache hit path across runs.

If the first nightly run surfaces a runner-specific gap (e.g. an extra native dep or a longer inference budget), that is a follow-up tuning of this same lane, not a design change.

**Not in this PR (separately blocked, done-when #2):** cloud-mode headless session seeding. `testCloudOnboardingChatAndVoice` / `cloud-provisioning-e2e.mjs` XCTSkip at the OAuth wall and require a documented test-only Cloud session/JWT seed against a staging Cloud org plus staging Cloud org credentials — infra/secrets that must be provisioned before that lane can exist. The coverage matrix records this N/A row explicitly.

Refs #13578

🤖 Generated with [Claude Code](https://claude.com/claude-code)