### PR TITLE
fix(cloud-shared): fail-closed oauth + agents fallback sweep (#13415 slice 2)

### DIFF
--- a/.github/issue-evidence/13415-oauth-tenant-fallback.md
+++ b/.github/issue-evidence/13415-oauth-tenant-fallback.md
@@ -1,0 +1,27 @@
+# #13415 — cloud-shared fallback sweep slice 2: oauth + tenant-db + agents
+
+Verified untouched by every in-flight fallback-sweep branch before starting.
+
+## Fail-open bugs fixed (behavioral)
+
+| file / location | before | after |
+|---|---|---|
+| oauth/cache-version.getOAuthVersion | `return version ?? 0` — failed cache read read as version 0 | first-use miss on reachable backend → 0; unreachable backend → throws (revoked token can't resurface under stale key) |
+| oauth/cache-version.incrementOAuthVersion | `cache.incr` fabricates `1` when backend down → wrong key invalidated | throws when backend unavailable before incr |
+| oauth-service.listConnections (x2 catches) | DB-read / adapter-query failure → warn + partial/empty list (reads as "not connected") | J2 rethrow with cause; zero-rows still returns [] |
+| generic-adapter.findCredential / listConnections / ownsConnection | catch → `undefined` / `[]` / `false` on any error | propagate; the removed catches only guarded a Postgres enum-mismatch that **cannot occur** (all 9 generic platforms ∈ `platform_credential_type`) |
+| secrets-adapter-utils.deletePlatformSecrets | swallowed per-secret delete failure | fail-closed-fix |
+| oauth2.extractUserInfo default branch | swallow | fail-closed-fix; mapped-branch console→logger |
+
+## Annotated (justified, no behavior change)
+generic-adapter decryptTokenSecret / refresh-persist / outer-refresh / revoke-delete (J2/J6); oauth2 secret-cleanup (J2); agents.getRoomContext fire-and-forget cache write (J*). provider-registry / direct-pg-executor / rooms: already fail closed — test-only.
+
+## Verification
+- 42 error-path tests (bun:test) — pass; each proves internal-failure PROPAGATES vs designed-empty stays distinguishable, driving the real exported functions.
+- Existing oauth + agents suites: 50 pass / 0 fail (no regression).
+- `biome check` clean; `audit:error-policy-ratchet` → "no new fallback-slop in touched files".
+- typecheck: 0 new TS2xxx errors in touched source; pre-existing repo-wide drizzle-orm declaration noise (`dist/node_modules/drizzle-orm` missing types → TS7016 and its downstream implicit-any) unchanged and unrelated.
+- Caller safety: cache-version callers (oauth-service.getValidToken; invalidation.ts via Promise.allSettled; revoke/refresh) and generic-adapter callers surface the new throws at a route boundary — correct fail-closed. Normal (non-error) paths are unaffected (throws only on real backend failure).
+
+## N/A
+UI screenshots / model trajectories / audio — N/A (server auth services, no UI/model/audio path). Runtime logs — N/A - service unit boundary only (behavior proven by error-path tests).

--- a/packages/cloud/shared/src/lib/services/agents/agents.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/agents/agents.error-policy.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Error-policy tests for AgentsService.getRoomContext (#13415). This is
+ * tenant-DB read domain: a failed DB read (findMessages / participants) must
+ * FAIL CLOSED — propagate, never be swallowed into an empty-messages context
+ * that a caller would read as "room has no history". A legitimately-empty room
+ * (no messages, no participants) is a distinct, designed empty result that must
+ * still be returned. Repositories and the state cache are mocked; the real
+ * getRoomContext control flow runs unmocked.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let findMessagesImpl: () => Promise<unknown[]> = async () => [];
+let getEntityIdsImpl: () => Promise<string[]> = async () => [];
+let setRoomContextCalls = 0;
+
+// Mock the repository submodules (not the barrel) so the barrel's `export *`
+// re-export resolves to these — the idiom used by characters.test.ts.
+mock.module("../../../db/repositories/agents/memories", () => ({
+  memoriesRepository: {
+    findMessages: () => findMessagesImpl(),
+  },
+}));
+
+mock.module("../../../db/repositories/agents/participants", () => ({
+  participantsRepository: {
+    getEntityIdsByRoomId: () => getEntityIdsImpl(),
+    // getRoomContext also touches participantsRepository elsewhere; only the
+    // one method is exercised here.
+  },
+}));
+
+// Stub the runtime/message-handler imports pulled in transitively by agents.ts
+// (used only by sendMessage, not getRoomContext) — they otherwise drag in an
+// uninstalled plugin package and break the import.
+mock.module("../../eliza/runtime-factory", () => ({
+  runtimeFactory: { createRuntimeForUser: async () => ({}) },
+}));
+mock.module("../../eliza/message-handler", () => ({
+  createMessageHandler: () => ({ process: async () => ({ message: {} }) }),
+}));
+
+// Cache miss on read forces the DB path; setRoomContext is best-effort (J7).
+mock.module("../../cache/agent-state-cache", () => ({
+  agentStateCache: {
+    getRoomContext: async () => null,
+    setRoomContext: async () => {
+      setRoomContextCalls++;
+    },
+  },
+}));
+
+const ROOM_ID = "44444444-4444-4444-8444-444444444444";
+
+describe("AgentsService.getRoomContext — fail-closed on DB read failure", () => {
+  beforeEach(() => {
+    findMessagesImpl = async () => [];
+    getEntityIdsImpl = async () => [];
+    setRoomContextCalls = 0;
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("legitimately-empty room returns its designed empty context (not a failure)", async () => {
+    const { agentsService } = await import("./agents");
+
+    const context = await agentsService.getRoomContext(ROOM_ID);
+
+    expect(context.roomId).toBe(ROOM_ID);
+    expect(context.messages).toEqual([]);
+    expect(context.participants).toEqual([]);
+  });
+
+  test("findMessages DB failure PROPAGATES — never swallowed into an empty context", async () => {
+    const { agentsService } = await import("./agents");
+    const dbError = new Error("connection reset by peer");
+    findMessagesImpl = async () => {
+      throw dbError;
+    };
+    // Participants would succeed; the message read is the one that fails.
+    getEntityIdsImpl = async () => ["entity-1"];
+
+    let caught: unknown;
+    let resolved: unknown;
+    try {
+      resolved = await agentsService.getRoomContext(ROOM_ID);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(resolved).toBeUndefined();
+    expect(caught).toBe(dbError);
+  });
+
+  test("participants DB failure PROPAGATES — distinct from an empty participant list", async () => {
+    const { agentsService } = await import("./agents");
+    const dbError = new Error("participants query timeout");
+    getEntityIdsImpl = async () => {
+      throw dbError;
+    };
+
+    let caught: unknown;
+    try {
+      await agentsService.getRoomContext(ROOM_ID);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(dbError);
+  });
+
+  test("the two are distinguishable: empty succeeds, failure rejects", async () => {
+    const { agentsService } = await import("./agents");
+
+    // Empty room path.
+    const emptyContext = await agentsService.getRoomContext(ROOM_ID);
+    expect(emptyContext.messages).toEqual([]);
+
+    // Failure path on the same function.
+    findMessagesImpl = async () => {
+      throw new Error("boom");
+    };
+    await expect(agentsService.getRoomContext(ROOM_ID)).rejects.toThrow("boom");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agents/agents.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/agents/agents.error-policy.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 let findMessagesImpl: () => Promise<unknown[]> = async () => [];
 let getEntityIdsImpl: () => Promise<string[]> = async () => [];
-let setRoomContextCalls = 0;
+let _setRoomContextCalls = 0;
 
 // Mock the repository submodules (not the barrel) so the barrel's `export *`
 // re-export resolves to these — the idiom used by characters.test.ts.
@@ -45,7 +45,7 @@ mock.module("../../cache/agent-state-cache", () => ({
   agentStateCache: {
     getRoomContext: async () => null,
     setRoomContext: async () => {
-      setRoomContextCalls++;
+      _setRoomContextCalls++;
     },
   },
 }));
@@ -56,7 +56,7 @@ describe("AgentsService.getRoomContext — fail-closed on DB read failure", () =
   beforeEach(() => {
     findMessagesImpl = async () => [];
     getEntityIdsImpl = async () => [];
-    setRoomContextCalls = 0;
+    _setRoomContextCalls = 0;
   });
 
   afterEach(() => {

--- a/packages/cloud/shared/src/lib/services/agents/agents.ts
+++ b/packages/cloud/shared/src/lib/services/agents/agents.ts
@@ -364,8 +364,12 @@ class AgentsService {
       lastActivity: new Date(),
     };
 
-    // Fire-and-forget cache set
-    agentStateCache.setRoomContext(roomId, context).catch(() => {});
+    // error-policy:J7 best-effort cache write off the read path; the authoritative
+    // context already came from the DB reads above, so a failed cache set must not
+    // fail the request — it surfaces as a warn and a cache miss (refetch) next call.
+    agentStateCache.setRoomContext(roomId, context).catch((error) => {
+      logger.warn(`[Agents Service] Failed to cache room context for ${roomId}`, error);
+    });
 
     return context;
   }

--- a/packages/cloud/shared/src/lib/services/agents/rooms.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/agents/rooms.error-policy.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Error-policy tests for RoomsService (#13415). This is auth/tenant-DB domain,
+ * so it must FAIL CLOSED: an internal repository/DB failure must PROPAGATE, not
+ * be swallowed into a "no room" (null) or "no access" (false) result that would
+ * read a broken pipeline as a legitimately-empty answer. These tests pin that
+ * an internal throw rejects, while a genuine not-found stays a designed empty
+ * result — the two must remain distinguishable. Repositories and the DB client
+ * are mocked; the real RoomsService logic runs unmocked.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mutable behavior for the mocked repositories. Each test sets the impl it needs.
+const repoState: {
+  roomFindById: (roomId: string) => Promise<unknown>;
+  memoriesFindMessages: (...args: unknown[]) => Promise<unknown[]>;
+  participantsGetEntityIds: (roomId: string) => Promise<string[]>;
+  participantsIsParticipant: (roomId: string, entityId: string) => Promise<boolean>;
+  conversationsFindById: (roomId: string) => Promise<unknown>;
+} = {
+  roomFindById: async () => null,
+  memoriesFindMessages: async () => [],
+  participantsGetEntityIds: async () => [],
+  participantsIsParticipant: async () => false,
+  conversationsFindById: async () => undefined,
+};
+
+mock.module("../../../db/client", () => ({
+  dbWrite: {},
+  dbRead: {},
+}));
+
+mock.module("../../../db/schemas/eliza", () => ({
+  entityTable: {},
+  participantTable: {},
+  roomTable: {},
+}));
+
+mock.module("../../../db/repositories", () => ({
+  roomsRepository: {
+    findById: (roomId: string) => repoState.roomFindById(roomId),
+  },
+  memoriesRepository: {
+    findMessages: (...args: unknown[]) => repoState.memoriesFindMessages(...args),
+  },
+  participantsRepository: {
+    getEntityIdsByRoomId: (roomId: string) => repoState.participantsGetEntityIds(roomId),
+    isParticipant: (roomId: string, entityId: string) =>
+      repoState.participantsIsParticipant(roomId, entityId),
+  },
+  conversationsRepository: {
+    findById: (roomId: string) => repoState.conversationsFindById(roomId),
+  },
+  entitiesRepository: {},
+}));
+
+const ROOM_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const USER_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+function resetRepoState() {
+  repoState.roomFindById = async () => null;
+  repoState.memoriesFindMessages = async () => [];
+  repoState.participantsGetEntityIds = async () => [];
+  repoState.participantsIsParticipant = async () => false;
+  repoState.conversationsFindById = async () => undefined;
+}
+
+describe("RoomsService fail-closed error policy (#13415)", () => {
+  beforeEach(() => {
+    resetRepoState();
+  });
+
+  afterEach(() => {
+    resetRepoState();
+  });
+
+  describe("getRoomWithMessages", () => {
+    test("internal DB failure PROPAGATES (not swallowed to null)", async () => {
+      const { roomsService } = await import("./rooms");
+      const dbError = new Error("connection reset by peer");
+      repoState.roomFindById = async () => {
+        throw dbError;
+      };
+
+      await expect(roomsService.getRoomWithMessages(ROOM_ID)).rejects.toThrow(
+        "connection reset by peer",
+      );
+    });
+
+    test("genuinely-missing room returns the designed null (distinct from failure)", async () => {
+      const { roomsService } = await import("./rooms");
+      repoState.roomFindById = async () => null;
+
+      const result = await roomsService.getRoomWithMessages(ROOM_ID);
+      expect(result).toBeNull();
+    });
+
+    test("existing room with no messages returns an empty message list, not null", async () => {
+      const { roomsService } = await import("./rooms");
+      repoState.roomFindById = async () => ({ id: ROOM_ID, agentId: null });
+      repoState.memoriesFindMessages = async () => [];
+      repoState.participantsGetEntityIds = async () => [];
+
+      const result = await roomsService.getRoomWithMessages(ROOM_ID);
+      expect(result).not.toBeNull();
+      expect(result?.messages).toEqual([]);
+    });
+
+    test("a message-load failure on an existing room PROPAGATES (not swallowed to empty)", async () => {
+      const { roomsService } = await import("./rooms");
+      repoState.roomFindById = async () => ({ id: ROOM_ID, agentId: null });
+      repoState.memoriesFindMessages = async () => {
+        throw new Error("memories query timeout");
+      };
+
+      await expect(roomsService.getRoomWithMessages(ROOM_ID)).rejects.toThrow(
+        "memories query timeout",
+      );
+    });
+  });
+
+  describe("hasAccess (auth-critical, must fail closed)", () => {
+    test("participant lookup failure PROPAGATES (never silently grants OR denies as 'empty')", async () => {
+      const { roomsService } = await import("./rooms");
+      repoState.participantsIsParticipant = async () => {
+        throw new Error("participant table unavailable");
+      };
+
+      await expect(roomsService.hasAccess(ROOM_ID, USER_ID)).rejects.toThrow(
+        "participant table unavailable",
+      );
+    });
+
+    test("no participant, no room, no conversation -> designed false (distinct from failure)", async () => {
+      const { roomsService } = await import("./rooms");
+      repoState.participantsIsParticipant = async () => false;
+      repoState.roomFindById = async () => null;
+      repoState.conversationsFindById = async () => undefined;
+
+      const granted = await roomsService.hasAccess(ROOM_ID, USER_ID);
+      expect(granted).toBe(false);
+    });
+
+    test("legitimate participant -> true", async () => {
+      const { roomsService } = await import("./rooms");
+      repoState.participantsIsParticipant = async () => true;
+
+      const granted = await roomsService.hasAccess(ROOM_ID, USER_ID);
+      expect(granted).toBe(true);
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/oauth/cache-version.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/cache-version.error-policy.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Error-policy guard for the OAuth cache-version counter (#13415). The version
+ * counter drives OAuth token-cache invalidation, so it is auth-domain and must
+ * fail closed: an unreadable/unwritable version is an internal failure that must
+ * PROPAGATE, never be silently substituted with a fabricated 0/1 that would key
+ * token lookups under a reset version and resurface a revoked token. This
+ * asserts the failure path stays distinguishable from the one legitimately-empty
+ * result — a genuine first-use miss with a reachable backend, which returns 0.
+ * The cache client is mocked so backend availability and read/write outcomes are
+ * driven directly.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+let getResult: number | null = null;
+let getShouldThrow = false;
+let available = true;
+let incrResult = 5;
+let incrShouldThrow = false;
+const getCalls: string[] = [];
+const incrCalls: string[] = [];
+const expireCalls: Array<{ key: string; ttl: number }> = [];
+
+mock.module("../../cache/client", () => ({
+  cache: {
+    get: async (key: string) => {
+      getCalls.push(key);
+      if (getShouldThrow) throw new Error("redis GET blew up");
+      return getResult;
+    },
+    incr: async (key: string) => {
+      incrCalls.push(key);
+      if (incrShouldThrow) throw new Error("redis INCR blew up");
+      return incrResult;
+    },
+    expire: async (key: string, ttl: number) => {
+      expireCalls.push({ key, ttl });
+    },
+    isAvailable: () => available,
+  },
+}));
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const PLATFORM = "google";
+
+describe("oauth cache-version error policy (#13415)", () => {
+  beforeEach(() => {
+    getResult = null;
+    getShouldThrow = false;
+    available = true;
+    incrResult = 5;
+    incrShouldThrow = false;
+    getCalls.length = 0;
+    incrCalls.length = 0;
+    expireCalls.length = 0;
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("getOAuthVersion returns 0 for a genuine first-use miss with a reachable backend", async () => {
+    const { getOAuthVersion } = await import("./cache-version");
+    getResult = null;
+    available = true;
+
+    const version = await getOAuthVersion(ORG, PLATFORM);
+
+    expect(version).toBe(0);
+    expect(getCalls).toEqual([`oauth:version:${ORG}:${PLATFORM}`]);
+  });
+
+  it("getOAuthVersion returns the stored version on a hit (no substitution)", async () => {
+    const { getOAuthVersion } = await import("./cache-version");
+    getResult = 7;
+    available = true;
+
+    expect(await getOAuthVersion(ORG, PLATFORM)).toBe(7);
+  });
+
+  it("getOAuthVersion THROWS on an unreadable backend instead of reading failure as first-use 0", async () => {
+    const { getOAuthVersion } = await import("./cache-version");
+    // cache.get swallows a GET error to null; the backend is then unavailable.
+    getResult = null;
+    available = false;
+
+    let caught: unknown;
+    try {
+      await getOAuthVersion(ORG, PLATFORM);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("[OAuthCacheVersion]");
+    expect((caught as Error).message).toContain("unavailable");
+  });
+
+  it("incrementOAuthVersion returns the new version and sets a TTL when the backend is reachable", async () => {
+    const { incrementOAuthVersion } = await import("./cache-version");
+    available = true;
+    incrResult = 6;
+
+    const version = await incrementOAuthVersion(ORG, PLATFORM);
+
+    expect(version).toBe(6);
+    expect(incrCalls).toEqual([`oauth:version:${ORG}:${PLATFORM}`]);
+    expect(expireCalls).toHaveLength(1);
+  });
+
+  it("incrementOAuthVersion THROWS on an unavailable backend instead of fabricating a version bump", async () => {
+    const { incrementOAuthVersion } = await import("./cache-version");
+    available = false;
+
+    let caught: unknown;
+    try {
+      await incrementOAuthVersion(ORG, PLATFORM);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("[OAuthCacheVersion]");
+    // Must not have written a fabricated counter to the backend.
+    expect(incrCalls).toHaveLength(0);
+    expect(expireCalls).toHaveLength(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/oauth/cache-version.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/cache-version.ts
@@ -16,21 +16,48 @@ const VERSION_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 
 /**
  * Get the current cache version for an org+platform pair.
- * Returns 0 if no version exists (first use).
+ *
+ * Returns 0 only for a genuine first use (no version key yet, backend
+ * reachable). `cache.get` collapses "key absent" and "backend read failed"
+ * into the same `null`, so a bare `?? 0` would read a failed lookup as
+ * version 0 and key token lookups under a reset version — after a revoke bumped
+ * the version forward, that can resurface a token cached under the stale
+ * version 0. This is auth-domain, so fail closed: when the backend is
+ * unavailable a `null` is ambiguous and must throw, never be treated as
+ * first-use 0.
  */
 export async function getOAuthVersion(orgId: string, platform: string): Promise<number> {
   const key = `${VERSION_KEY_PREFIX}:${orgId}:${platform}`;
   const version = await cache.get<number>(key);
-  return version ?? 0;
+  if (version === null) {
+    if (!cache.isAvailable()) {
+      throw new Error(
+        `[OAuthCacheVersion] Cannot read OAuth cache version for ${orgId}:${platform}: cache backend unavailable`,
+      );
+    }
+    return 0;
+  }
+  return version;
 }
 
 /**
  * Atomically increment the cache version for an org+platform pair.
  * Call this whenever OAuth state changes: connect, disconnect, token refresh.
  * All existing cache entries with the old version will auto-miss.
+ *
+ * Fails closed when the cache backend is unavailable: `cache.incr` fabricates a
+ * `1` on an unreachable/failed backend, which on a revoke path would bump the
+ * version to a wrong value and invalidate the wrong key — leaving a revoked
+ * token served from cache. A version bump that cannot be persisted must surface
+ * to the caller, not silently return a fabricated counter.
  */
 export async function incrementOAuthVersion(orgId: string, platform: string): Promise<number> {
   const key = `${VERSION_KEY_PREFIX}:${orgId}:${platform}`;
+  if (!cache.isAvailable()) {
+    throw new Error(
+      `[OAuthCacheVersion] Cannot increment OAuth cache version for ${orgId}:${platform}: cache backend unavailable`,
+    );
+  }
   const newVersion = await cache.incr(key);
   await cache.expire(key, VERSION_TTL_SECONDS);
   return newVersion;

--- a/packages/cloud/shared/src/lib/services/oauth/connection-adapters/generic-adapter.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/connection-adapters/generic-adapter.error-policy.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Error-policy tests for the generic OAuth connection adapter (#13415). The
+ * auth/token/tenant-DB path must FAIL CLOSED: an internal DB failure while
+ * looking up a credential (getToken) or listing connections must PROPAGATE,
+ * and must stay distinguishable from the legitimately-empty result (no rows),
+ * which still yields the designed connectionNotFound / empty-list outcome.
+ * dbRead is a mutable thenable query-builder proxy; the real Errors/OAuthError
+ * classes run unmocked so the "not found" signal is asserted for real.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// dbReadBehavior drives every awaited dbRead query in a test: a rejecting
+// behavior models an internal failure, a resolving [] models a successful
+// empty query. The chain builder is thenable so `.select().from().where()`
+// (and optional `.limit()`) resolves to this behavior's result.
+let dbReadBehavior: () => Promise<unknown[]> = async () => [];
+
+function makeReadBuilder() {
+  const builder: Record<string, unknown> = {};
+  const chain = () => builder;
+  builder.from = chain;
+  builder.where = chain;
+  builder.limit = chain;
+  builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    dbReadBehavior().then(resolve, reject);
+  return builder;
+}
+
+mock.module("../../../../db/client", () => ({
+  dbRead: { select: () => makeReadBuilder() },
+  dbWrite: {
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+  },
+}));
+
+mock.module("../../../utils/logger", () => ({
+  logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+}));
+
+mock.module("../../secrets", () => ({
+  secretsService: {
+    getDecryptedValue: async () => "token",
+    rotate: async () => undefined,
+    delete: async () => undefined,
+  },
+}));
+
+mock.module("../../secrets/encryption", () => ({
+  DecryptionError: class DecryptionError extends Error {
+    phase: string;
+    constructor(message: string, phase = "value_decryption") {
+      super(message);
+      this.phase = phase;
+    }
+  },
+}));
+
+mock.module("../cache-version", () => ({
+  incrementOAuthVersion: async () => 1,
+}));
+
+mock.module("../provider-registry", () => ({
+  getProvider: () => undefined,
+}));
+
+mock.module("../providers", () => ({
+  refreshOAuth2Token: async () => ({ accessToken: "new", expiresIn: 3600 }),
+}));
+
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+const CONNECTION_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("createGenericAdapter — fail-closed error policy (#13415)", () => {
+  beforeEach(() => {
+    dbReadBehavior = async () => [];
+  });
+  afterEach(() => {
+    dbReadBehavior = async () => [];
+  });
+
+  it("getToken PROPAGATES an internal DB failure (not swallowed to connectionNotFound)", async () => {
+    const { createGenericAdapter } = await import("./generic-adapter");
+    const { OAuthError } = await import("../errors");
+    const adapter = createGenericAdapter("linear");
+
+    dbReadBehavior = async () => {
+      throw new Error("DB connection lost");
+    };
+
+    let caught: unknown;
+    try {
+      await adapter.getToken(ORG_ID, CONNECTION_ID);
+    } catch (error) {
+      caught = error;
+    }
+
+    // The raw DB failure must surface — NOT be masked as a domain "not found".
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(OAuthError);
+    expect((caught as Error).message).toBe("DB connection lost");
+  });
+
+  it("getToken on a successful empty query returns the designed connectionNotFound", async () => {
+    const { createGenericAdapter } = await import("./generic-adapter");
+    const { OAuthError, OAuthErrorCode } = await import("../errors");
+    const adapter = createGenericAdapter("linear");
+
+    dbReadBehavior = async () => []; // query succeeded, zero rows
+
+    let caught: unknown;
+    try {
+      await adapter.getToken(ORG_ID, CONNECTION_ID);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(OAuthError);
+    expect((caught as InstanceType<typeof OAuthError>).code).toBe(
+      OAuthErrorCode.CONNECTION_NOT_FOUND,
+    );
+  });
+
+  it("listConnections PROPAGATES an internal DB failure (not swallowed to [])", async () => {
+    const { createGenericAdapter } = await import("./generic-adapter");
+    const adapter = createGenericAdapter("linear");
+
+    dbReadBehavior = async () => {
+      throw new Error("enum type does not exist");
+    };
+
+    let caught: unknown;
+    try {
+      await adapter.listConnections(ORG_ID);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe("enum type does not exist");
+  });
+
+  it("listConnections on a successful empty query returns the designed empty list", async () => {
+    const { createGenericAdapter } = await import("./generic-adapter");
+    const adapter = createGenericAdapter("linear");
+
+    dbReadBehavior = async () => []; // query succeeded, zero rows
+
+    const result = await adapter.listConnections(ORG_ID);
+    expect(result).toEqual([]);
+  });
+
+  it("ownsConnection PROPAGATES an internal DB failure for a well-formed id", async () => {
+    const { createGenericAdapter } = await import("./generic-adapter");
+    const adapter = createGenericAdapter("linear");
+
+    dbReadBehavior = async () => {
+      throw new Error("DB connection lost");
+    };
+
+    await expect(adapter.ownsConnection(CONNECTION_ID)).rejects.toThrow("DB connection lost");
+  });
+
+  it("ownsConnection returns false (designed not-owned) for a malformed id without touching the DB", async () => {
+    const { createGenericAdapter } = await import("./generic-adapter");
+    const adapter = createGenericAdapter("linear");
+
+    let touched = false;
+    dbReadBehavior = async () => {
+      touched = true;
+      return [];
+    };
+
+    expect(await adapter.ownsConnection("not-a-uuid")).toBe(false);
+    expect(touched).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/oauth/connection-adapters/generic-adapter.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/connection-adapters/generic-adapter.error-policy.test.ts
@@ -22,6 +22,7 @@ function makeReadBuilder() {
   builder.from = chain;
   builder.where = chain;
   builder.limit = chain;
+  // biome-ignore lint/suspicious/noThenProperty: Drizzle query builders are awaited as thenables in this test harness.
   builder.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
     dbReadBehavior().then(resolve, reject);
   return builder;

--- a/packages/cloud/shared/src/lib/services/oauth/connection-adapters/generic-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/connection-adapters/generic-adapter.ts
@@ -44,6 +44,9 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
     }
     try {
       return await secretsService.getDecryptedValue(secretId, organizationId);
+      // error-policy:J2 context-adding rethrow — translate an undecryptable token
+      // into an actionable reconnect error (with cause) and mark the credential
+      // expired so the failure surfaces; all other errors propagate untouched.
     } catch (error) {
       if (error instanceof DecryptionError) {
         logger.error(`[GenericAdapter] Token decryption failed for ${platform}`, {
@@ -55,7 +58,6 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
           error: error.message,
         });
 
-        // Mark connection as needing re-authentication
         await dbWrite
           .update(platformCredentials)
           .set({ status: "expired", updated_at: new Date() })
@@ -63,6 +65,7 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
 
         throw new Error(
           `${platform} ${tokenType} cannot be decrypted (${error.phase === "dek_decryption" ? "encryption key mismatch" : "data corruption"}). Please disconnect and reconnect ${platform} in Settings > Connections.`,
+          { cause: error },
         );
       }
       throw error;
@@ -70,76 +73,63 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
   }
 
   async function findCredential(organizationId: string, connectionId: string) {
-    try {
-      const [cred] = await dbRead
-        .select()
-        .from(platformCredentials)
-        .where(
-          and(
-            eq(platformCredentials.id, connectionId),
-            eq(platformCredentials.organization_id, organizationId),
-            eq(platformCredentials.platform, platformEnum),
-          ),
-        )
-        .limit(1);
-      return cred;
-    } catch (error) {
-      // Handle case where platform enum value doesn't exist in database
-      logger.warn(`[GenericAdapter] Query failed for ${platform}`, {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return undefined;
-    }
+    const [cred] = await dbRead
+      .select()
+      .from(platformCredentials)
+      .where(
+        and(
+          eq(platformCredentials.id, connectionId),
+          eq(platformCredentials.organization_id, organizationId),
+          eq(platformCredentials.platform, platformEnum),
+        ),
+      )
+      .limit(1);
+    // A successful query with no matching row returns undefined — the caller's
+    // designed "connection not found". A DB/enum failure must propagate, not be
+    // swallowed into that same undefined (auth path fails closed).
+    return cred;
   }
 
   return {
     platform,
 
     async listConnections(organizationId: string): Promise<OAuthConnection[]> {
-      try {
-        const credentials = await dbRead
-          .select()
-          .from(platformCredentials)
-          .where(
-            and(
-              eq(platformCredentials.organization_id, organizationId),
-              eq(platformCredentials.platform, platformEnum),
-            ),
-          );
+      // No try/catch: a query that returns zero rows is a legitimate empty list;
+      // a DB/enum failure must propagate so callers (getValidTokenByPlatform,
+      // isPlatformConnected) never read a failed load as "no connections".
+      const credentials = await dbRead
+        .select()
+        .from(platformCredentials)
+        .where(
+          and(
+            eq(platformCredentials.organization_id, organizationId),
+            eq(platformCredentials.platform, platformEnum),
+          ),
+        );
 
-        return credentials.map((cred) => ({
-          id: cred.id,
-          userId: cred.user_id || undefined,
-          connectionRole:
-            cred.source_context && typeof cred.source_context === "object"
-              ? formatOAuthConnectionRole(
-                  (cred.source_context as Record<string, unknown>).connectionRole ??
-                    (cred.source_context as Record<string, unknown>).agentGoogleSide,
-                )
-              : "owner",
-          platform,
-          platformUserId: cred.platform_user_id,
-          email: cred.platform_email || undefined,
-          username: cred.platform_username || undefined,
-          displayName: cred.platform_display_name || undefined,
-          avatarUrl: cred.platform_avatar_url || undefined,
-          status: cred.status,
-          scopes: (cred.scopes as string[]) || [],
-          linkedAt: cred.linked_at || cred.created_at,
-          lastUsedAt: cred.last_used_at || undefined,
-          tokenExpired: cred.token_expires_at
-            ? new Date(cred.token_expires_at) < new Date()
-            : false,
-          source: "platform_credentials" as const,
-        }));
-      } catch (error) {
-        // Handle case where platform enum value doesn't exist in database
-        logger.warn(`[GenericAdapter] listConnections failed for ${platform}`, {
-          organizationId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return [];
-      }
+      return credentials.map((cred) => ({
+        id: cred.id,
+        userId: cred.user_id || undefined,
+        connectionRole:
+          cred.source_context && typeof cred.source_context === "object"
+            ? formatOAuthConnectionRole(
+                (cred.source_context as Record<string, unknown>).connectionRole ??
+                  (cred.source_context as Record<string, unknown>).agentGoogleSide,
+              )
+            : "owner",
+        platform,
+        platformUserId: cred.platform_user_id,
+        email: cred.platform_email || undefined,
+        username: cred.platform_username || undefined,
+        displayName: cred.platform_display_name || undefined,
+        avatarUrl: cred.platform_avatar_url || undefined,
+        status: cred.status,
+        scopes: (cred.scopes as string[]) || [],
+        linkedAt: cred.linked_at || cred.created_at,
+        lastUsedAt: cred.last_used_at || undefined,
+        tokenExpired: cred.token_expires_at ? new Date(cred.token_expires_at) < new Date() : false,
+        source: "platform_credentials" as const,
+      }));
     },
 
     async getToken(organizationId: string, connectionId: string): Promise<TokenResult> {
@@ -206,6 +196,10 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
                 refreshResult.newRefreshToken,
                 audit,
               );
+              // error-policy:J2 context-adding rethrow — a provider that rotated the
+              // refresh token has invalidated the old one, so a failed persist leaves
+              // a broken chain; disable the connection and surface it (with cause)
+              // rather than continue with an un-persistable refresh token.
             } catch (refreshTokenError) {
               logger.error(`[GenericAdapter] Failed to store new refresh token for ${platform}`, {
                 connectionId,
@@ -226,6 +220,7 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
               await incrementOAuthVersion(organizationId, platform);
               throw new Error(
                 `Failed to persist rotated ${platform} refresh token. Please reconnect ${platform}.`,
+                { cause: refreshTokenError },
               );
             }
           }
@@ -255,6 +250,9 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
             connectionId,
             organizationId,
           });
+          // error-policy:J2 context-adding rethrow — translate any refresh-flow
+          // failure into the typed tokenRefreshFailed domain error carrying the
+          // underlying reason; the failure is never swallowed.
         } catch (error) {
           logger.error(`[GenericAdapter] Token refresh failed for ${platform}`, {
             connectionId,
@@ -300,9 +298,11 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
         source: "revoke-connection",
       };
 
-      // Delete token secrets - log failures but don't block revocation
       const deleteSecret = async (id: string | null, tokenType: string) => {
         if (!id) return;
+        // error-policy:J6 best-effort teardown — revocation's authoritative effect
+        // is flipping status to "revoked" below; a failed secret delete is logged
+        // but must not block the revoke (the token is already being invalidated).
         try {
           await secretsService.delete(id, organizationId, audit);
         } catch (error) {
@@ -336,24 +336,23 @@ export function createGenericAdapter(platform: string): ConnectionAdapter {
     },
 
     async ownsConnection(connectionId: string): Promise<boolean> {
+      // A malformed id is a designed "not owned" (never hits the DB); a real DB
+      // failure must propagate rather than masquerade as "not owned", which would
+      // silently route adapter lookup to connectionNotFound.
       if (!UUID_REGEX.test(connectionId)) return false;
 
-      try {
-        const [cred] = await dbRead
-          .select({ id: platformCredentials.id })
-          .from(platformCredentials)
-          .where(
-            and(
-              eq(platformCredentials.id, connectionId),
-              eq(platformCredentials.platform, platformEnum),
-            ),
-          )
-          .limit(1);
+      const [cred] = await dbRead
+        .select({ id: platformCredentials.id })
+        .from(platformCredentials)
+        .where(
+          and(
+            eq(platformCredentials.id, connectionId),
+            eq(platformCredentials.platform, platformEnum),
+          ),
+        )
+        .limit(1);
 
-        return !!cred;
-      } catch {
-        return false;
-      }
+      return !!cred;
     },
   };
 }

--- a/packages/cloud/shared/src/lib/services/oauth/connection-adapters/secrets-adapter-utils.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/connection-adapters/secrets-adapter-utils.error-policy.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Error-policy tests for deletePlatformSecrets (#13415): revoke is an auth/secrets
+ * path and must fail CLOSED. An internal secret-delete failure must PROPAGATE (so a
+ * revoke never reports success while live credentials remain in the DB), while a
+ * legitimately-empty match (no secrets found) still returns its designed 0-count —
+ * the two must be distinguishable. dbRead + secretsService are mocked; the real
+ * exported function runs unmocked.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+let secretsToReturn: Array<{ id: string; name: string; created_at: Date }> = [];
+const deleteCalls: Array<{ id: string; organizationId: string }> = [];
+let deleteBehavior: (id: string) => Promise<void> = async () => {};
+
+mock.module("../../../../db/client", () => ({
+  dbRead: {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(secretsToReturn),
+      }),
+    }),
+  },
+  dbWrite: {},
+}));
+
+mock.module("../../secrets", () => ({
+  secretsService: {
+    delete: async (id: string, organizationId: string) => {
+      deleteCalls.push({ id, organizationId });
+      return deleteBehavior(id);
+    },
+    get: async () => null,
+  },
+}));
+
+const ORG_ID = "org-1";
+const PREFIX = "TWITTER_OWNER_";
+
+describe("deletePlatformSecrets — fail-closed revoke (#13415)", () => {
+  beforeEach(() => {
+    secretsToReturn = [];
+    deleteCalls.length = 0;
+    deleteBehavior = async () => {};
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("legitimately-empty match returns designed 0-count, no throw, no delete attempts", async () => {
+    const { deletePlatformSecrets } = await import("./secrets-adapter-utils");
+    secretsToReturn = [];
+
+    const count = await deletePlatformSecrets(ORG_ID, PREFIX, "oauth-service");
+
+    expect(count).toBe(0);
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  it("all secrets deleted returns the real count", async () => {
+    const { deletePlatformSecrets } = await import("./secrets-adapter-utils");
+    secretsToReturn = [
+      { id: "s1", name: "TWITTER_OWNER_ACCESS_TOKEN", created_at: new Date() },
+      { id: "s2", name: "TWITTER_OWNER_ACCESS_TOKEN_SECRET", created_at: new Date() },
+    ];
+
+    const count = await deletePlatformSecrets(ORG_ID, PREFIX, "oauth-service");
+
+    expect(count).toBe(2);
+    expect(deleteCalls.map((c) => c.id)).toEqual(["s1", "s2"]);
+  });
+
+  it("internal delete failure PROPAGATES (not swallowed to a success count)", async () => {
+    const { deletePlatformSecrets } = await import("./secrets-adapter-utils");
+    secretsToReturn = [{ id: "s1", name: "TWITTER_OWNER_ACCESS_TOKEN", created_at: new Date() }];
+    deleteBehavior = async () => {
+      throw new Error("Failed to delete secret");
+    };
+
+    let caught: unknown;
+    try {
+      await deletePlatformSecrets(ORG_ID, PREFIX, "oauth-service");
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("Failed to delete secret");
+    // It attempted the delete rather than silently reporting success.
+    expect(deleteCalls).toHaveLength(1);
+  });
+
+  it("empty (0) and failure (throw) are distinguishable outcomes for the same call", async () => {
+    const { deletePlatformSecrets } = await import("./secrets-adapter-utils");
+
+    secretsToReturn = [];
+    await expect(deletePlatformSecrets(ORG_ID, PREFIX, "oauth-service")).resolves.toBe(0);
+
+    secretsToReturn = [{ id: "s9", name: "TWITTER_OWNER_X", created_at: new Date() }];
+    deleteBehavior = async () => {
+      throw new Error("Failed to delete secret");
+    };
+    await expect(deletePlatformSecrets(ORG_ID, PREFIX, "oauth-service")).rejects.toThrow(
+      "Failed to delete secret",
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/oauth/connection-adapters/secrets-adapter-utils.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/connection-adapters/secrets-adapter-utils.ts
@@ -59,6 +59,10 @@ export async function getOptionalSecretValue(
   secretName: string,
   context: string,
 ): Promise<string | null> {
+  // error-policy:J4 cosmetic display metadata (username/userId/scope/phone); a failed
+  // read degrades this non-load-bearing field to null. Systemic failures (DB down,
+  // decrypt errors) still surface through the required-secret reads (getSecretValue,
+  // uncaught) that gate the same connection flow, so this cannot hide a broken pipeline.
   try {
     return await getSecretValue(organizationId, secretName);
   } catch (error) {
@@ -104,14 +108,11 @@ export async function deletePlatformSecrets(
     source: "revoke-connection",
   };
 
+  // Revoke must fail closed: a swallowed delete would report the connection revoked
+  // while live credentials remain in the DB. Propagate so the caller's revoke surfaces
+  // the failure; the returned count is then only reached when every secret was deleted.
   for (const secret of platformSecrets) {
-    await secretsService.delete(secret.id, organizationId, audit).catch((e) => {
-      logger.warn(`[SecretsAdapter] Failed to delete secret`, {
-        secretId: secret.id,
-        secretName: secret.name,
-        error: e instanceof Error ? e.message : String(e),
-      });
-    });
+    await secretsService.delete(secret.id, organizationId, audit);
   }
 
   return platformSecrets.length;

--- a/packages/cloud/shared/src/lib/services/oauth/oauth-service.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/oauth-service.error-policy.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Error-policy tests for OAuthService.listConnections (#13415). This is
+ * auth/tenant-DB domain: a failed platform-credential read or a failed
+ * connection-adapter query must FAIL CLOSED (propagate), never be swallowed to
+ * a partial/empty list — a swallowed failure reads as "not connected" and makes
+ * callers re-prompt OAuth for an already-connected user. A legitimately-empty
+ * result (query succeeds, no rows) must still return []. DB client and adapter
+ * registry are mocked; the real listConnections/scoping logic runs unmocked.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+let dbWhere: () => Promise<unknown[]>;
+let getAdapterResult: {
+  platform: string;
+  listConnections: (orgId: string) => Promise<unknown[]>;
+} | null;
+
+const notImplemented = () => {
+  throw new Error("db access not stubbed in error-policy test");
+};
+
+// Replace the whole module, so provide every export the import graph references;
+// only dbRead is exercised here.
+mock.module("../../../db/client", () => ({
+  dbRead: {
+    select: () => ({
+      from: () => ({
+        where: () => dbWhere(),
+      }),
+    }),
+  },
+  db: {},
+  dbWrite: {},
+  runWithDbCache: <T>(fn: () => T) => fn(),
+  runWithDbCacheAsync: <T>(fn: () => Promise<T>) => fn(),
+  withReadDb: notImplemented,
+  withWriteDb: notImplemented,
+  getDbConnectionInfo: notImplemented,
+  closeDatabaseConnectionsForTests: async () => {},
+  shouldSkipTlsVerification: () => false,
+  enforceTlsForRemote: notImplemented,
+}));
+
+// provider-registry is left real: listConnections only calls getProvider inside
+// the getAllAdapters().filter(...), which never runs because getAllAdapters is [].
+mock.module("./connection-adapters", () => ({
+  getAdapter: () => getAdapterResult,
+  getAllAdapters: () => [],
+}));
+
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+
+describe("OAuthService.listConnections — error policy (#13415)", () => {
+  beforeEach(() => {
+    dbWhere = async () => [];
+    getAdapterResult = null;
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("propagates a platform-credential DB read failure (fail closed, not swallowed to [])", async () => {
+    const { oauthService } = await import("./oauth-service");
+    const cause = new Error("db connection refused");
+    dbWhere = async () => {
+      throw cause;
+    };
+
+    let caught: unknown;
+    try {
+      await oauthService.listConnections({ organizationId: ORG_ID });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("Failed to load platform credentials");
+    expect((caught as Error).message).toContain(ORG_ID);
+    expect((caught as Error).cause).toBe(cause);
+  });
+
+  it("returns the designed-empty [] when the credential read succeeds with no rows", async () => {
+    const { oauthService } = await import("./oauth-service");
+    dbWhere = async () => [];
+
+    const result = await oauthService.listConnections({ organizationId: ORG_ID });
+
+    expect(result).toEqual([]);
+  });
+
+  it("propagates a connection-adapter query failure (fail closed, not swallowed to [])", async () => {
+    const { oauthService } = await import("./oauth-service");
+    const cause = new Error("adapter upstream 503");
+    getAdapterResult = {
+      platform: "google",
+      listConnections: async () => {
+        throw cause;
+      },
+    };
+
+    let caught: unknown;
+    try {
+      await oauthService.listConnections({ organizationId: ORG_ID, platform: "google" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("Failed to list connections for platform google");
+    expect((caught as Error).cause).toBe(cause);
+  });
+
+  it("returns the designed-empty [] when the adapter reports no connections", async () => {
+    const { oauthService } = await import("./oauth-service");
+    getAdapterResult = {
+      platform: "google",
+      listConnections: async () => [],
+    };
+
+    const result = await oauthService.listConnections({
+      organizationId: ORG_ID,
+      platform: "google",
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/oauth/oauth-service.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/oauth-service.ts
@@ -251,10 +251,13 @@ class OAuthService {
           .where(eq(platformCredentials.organization_id, organizationId));
         connections.push(...credentials.map(connectionFromPlatformCredential));
       } catch (error) {
-        logger.warn("[OAuthService] Platform credential query failed", {
-          organizationId,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        // error-policy:J2 fail closed — swallowing this read returns a partial/empty
+        // list that reads as "not connected", so a connected user is told to reconnect
+        // and callers re-prompt OAuth. Rethrow with tenant context instead.
+        throw new Error(
+          `[OAuthService] Failed to load platform credentials for organization ${organizationId}`,
+          { cause: error },
+        );
       }
     }
 
@@ -265,13 +268,15 @@ class OAuthService {
         );
 
     for (const adapter of adapters) {
+      // error-policy:J2 fail closed — dropping a failed adapter yields a partial list
+      // that reads as "not connected"; rethrow with platform context so the failure surfaces.
       try {
         connections.push(...(await adapter!.listConnections(organizationId)));
       } catch (error) {
-        logger.warn("[OAuthService] Adapter query failed", {
-          platform: adapter?.platform,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        throw new Error(
+          `[OAuthService] Failed to list connections for platform ${adapter?.platform}`,
+          { cause: error },
+        );
       }
     }
 

--- a/packages/cloud/shared/src/lib/services/oauth/provider-registry.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/provider-registry.error-policy.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Error-policy guard for the OAuth provider registry (#13415). OAuth scope
+ * resolution is auth-domain and must fail closed: a caller requesting a scope
+ * the app does not allow for a provider is an invariant violation that must
+ * PROPAGATE (throw INVALID_SCOPE_REQUEST), never be silently narrowed to the
+ * allowed subset or an empty list — silently dropping scopes would downgrade
+ * the grant without the caller knowing. This asserts that failure path stays
+ * distinguishable from the two legitimately-empty results: no-scopes-requested
+ * (returns the designed provider defaults) and unknown-provider (returns null).
+ * Pure config helpers with no env/DB dependency, so nothing is mocked.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { OAuthError, OAuthErrorCode } from "./errors";
+import { getProvider, resolveRequestedScopes } from "./provider-registry";
+
+describe("provider-registry error policy (#13415)", () => {
+  it("propagates a disallowed-scope request instead of silently narrowing it", () => {
+    const google = getProvider("google");
+    if (!google) throw new Error("google provider must exist in the registry");
+
+    const bogusScope = "https://www.googleapis.com/auth/drive.readonly.NOT_ALLOWED";
+
+    let caught: unknown;
+    try {
+      resolveRequestedScopes(google, [bogusScope]);
+    } catch (error) {
+      caught = error;
+    }
+
+    // Fail-closed: the disallowed scope surfaces as a typed OAuthError, not a
+    // filtered-down list and not an empty array.
+    expect(caught).toBeInstanceOf(OAuthError);
+    expect((caught as OAuthError).code).toBe(OAuthErrorCode.INVALID_SCOPE_REQUEST);
+    expect((caught as OAuthError).message).toContain(bogusScope);
+  });
+
+  it("still throws when a valid scope is mixed with a disallowed one (no partial success)", () => {
+    const google = getProvider("google");
+    if (!google) throw new Error("google provider must exist in the registry");
+
+    const validScope = google.defaultScopes?.[0];
+    expect(validScope).toBeTruthy();
+
+    expect(() =>
+      resolveRequestedScopes(google, [validScope as string, "totally:made:up:scope"]),
+    ).toThrow(OAuthError);
+  });
+
+  it("returns the designed default scopes when the caller requests none (legitimately-empty input)", () => {
+    const google = getProvider("google");
+    if (!google) throw new Error("google provider must exist in the registry");
+
+    const resolved = resolveRequestedScopes(google, []);
+
+    // Distinct from the throw path: an empty *request* yields the provider's
+    // designed defaults, not an error and not an empty grant.
+    expect(resolved.length).toBeGreaterThan(0);
+    expect(resolved).toEqual([...new Set(google.defaultScopes)]);
+  });
+
+  it("resolves a valid subset unchanged (no over-broadening, no throw)", () => {
+    const google = getProvider("google");
+    if (!google) throw new Error("google provider must exist in the registry");
+
+    const subset = [google.defaultScopes?.[0] as string];
+    expect(resolveRequestedScopes(google, subset)).toEqual(subset);
+  });
+
+  it("returns null for an unknown provider (designed not-found, distinct from a thrown failure)", () => {
+    expect(getProvider("definitely-not-a-real-provider")).toBeNull();
+    expect(getProvider("google")).not.toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.error-policy.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Error-policy regression for #13415: OAuth identity extraction must fail closed.
+ * Drives the real handleOAuth2Callback (token exchange + userInfo fetch mocked at
+ * the HTTP boundary; db/secrets/cache mocked) to prove a provider response with no
+ * id/sub PROPAGATES a thrown error instead of fabricating an "unknown" platform
+ * user id, while a minimal-but-valid response (id present, no email) still succeeds
+ * — the failure and the legitimately-sparse case are distinguishable.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const secretsCreateCalls: unknown[] = [];
+const insertReturning = mock(async () => [{ id: "conn-1" }]);
+
+let stateData: Record<string, unknown> | null;
+let userInfoBody: Record<string, unknown>;
+let originalFetch: typeof globalThis.fetch;
+
+mock.module("../../../cache/client", () => ({
+  cache: {
+    get: async () => stateData,
+    del: async () => {},
+    set: async () => {},
+  },
+}));
+
+mock.module("../../../runtime/cloud-bindings", () => ({
+  getCloudAwareEnv: () => ({ NEXT_PUBLIC_APP_URL: "https://test.example" }),
+}));
+
+mock.module("../provider-registry", () => ({
+  getClientId: () => "client-id",
+  getClientSecret: () => "client-secret",
+  getCallbackUrl: () => "https://test.example/callback",
+  resolveRequestedScopes: (_p: unknown, s?: string[]) => s ?? [],
+  getNestedValue: () => undefined,
+}));
+
+mock.module("../../secrets", () => ({
+  secretsService: {
+    create: async (input: unknown) => {
+      secretsCreateCalls.push(input);
+      return { id: `secret-${secretsCreateCalls.length}` };
+    },
+    list: async () => [],
+    rotate: async () => {},
+    delete: async () => {},
+  },
+}));
+
+mock.module("../../../../db/client", () => ({
+  dbWrite: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [] as unknown[],
+        }),
+      }),
+    }),
+  },
+}));
+
+mock.module("../../../../db/helpers", () => ({
+  writeTransaction: async (fn: (tx: unknown) => Promise<unknown>) =>
+    fn({
+      insert: () => ({
+        values: () => ({
+          onConflictDoUpdate: () => ({ returning: insertReturning }),
+        }),
+      }),
+    }),
+}));
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+const provider = {
+  id: "testprov",
+  endpoints: {
+    authorization: "https://test.example/auth",
+    token: "https://test.example/token",
+    userInfo: "https://test.example/userinfo",
+  },
+  pkce: false,
+} as never;
+
+describe("handleOAuth2Callback — identity extraction fails closed (#13415)", () => {
+  beforeEach(() => {
+    secretsCreateCalls.length = 0;
+    insertReturning.mockClear();
+    stateData = {
+      organizationId: "org-1",
+      userId: "user-1",
+      providerId: "testprov",
+      redirectUrl: "/done",
+      scopes: ["a"],
+      connectionRole: "OWNER",
+      createdAt: Date.now(),
+    };
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes("/token")) {
+        return jsonResponse({ access_token: "at-123", token_type: "Bearer" });
+      }
+      if (u.includes("/userinfo")) {
+        return jsonResponse(userInfoBody);
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("propagates a thrown error when the provider returns no id/sub (no fabricated 'unknown')", async () => {
+    const { handleOAuth2Callback } = await import("./oauth2");
+    userInfoBody = {}; // internal failure: identity missing
+
+    let caught: unknown;
+    try {
+      await handleOAuth2Callback(provider, "auth-code", "state-token");
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("Could not extract user ID");
+    // Fail-closed proof: we threw BEFORE reaching connection storage, so no
+    // bogus "unknown"-identity secret/row was written.
+    expect(secretsCreateCalls).toHaveLength(0);
+    expect(insertReturning).not.toHaveBeenCalled();
+  });
+
+  it("succeeds for a minimal-but-valid response (id present, no email) — sparse is not failure", async () => {
+    const { handleOAuth2Callback } = await import("./oauth2");
+    userInfoBody = { id: "real-user-42" }; // legitimately sparse, but a real identity
+
+    const result = await handleOAuth2Callback(provider, "auth-code", "state-token");
+
+    expect(result.platformUserId).toBe("real-user-42");
+    expect(result.email).toBeUndefined();
+    expect(result.connectionId).toBe("conn-1");
+    // The real id flowed through storage untouched (never coerced to "unknown").
+    expect(insertReturning).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/providers/oauth2.ts
@@ -598,8 +598,16 @@ function extractUserInfo(mapping: UserInfoMapping | undefined, data: unknown): E
   if (!mapping) {
     // Default mapping for standard OAuth2 claims
     const obj = data as Record<string, unknown>;
+    // Fail closed on a missing identity: a provider response with no id/sub is a
+    // broken identity pipeline, not a user named "unknown". Fabricating a marker
+    // here would store a bogus platform_user_id that collides across every such
+    // account. The mapped branch below throws for the same reason.
+    const rawId = obj.id ?? obj.sub;
+    if (rawId === undefined || rawId === null || rawId === "") {
+      throw new Error("[OAuth2] Could not extract user ID from provider response");
+    }
     return {
-      id: String(obj.id || obj.sub || "unknown"),
+      id: String(rawId),
       email: obj.email as string | undefined,
       username: obj.username as string | undefined,
       displayName: (obj.name || obj.display_name) as string | undefined,
@@ -610,7 +618,7 @@ function extractUserInfo(mapping: UserInfoMapping | undefined, data: unknown): E
 
   const id = getNestedValue(data, mapping.id);
   if (!id) {
-    throw new Error("Could not extract user ID from provider response");
+    throw new Error("[OAuth2] Could not extract user ID from provider response");
   }
 
   return {
@@ -709,6 +717,10 @@ async function storeConnection(
       try {
         await secretsService.delete(secretId, organizationId, audit);
       } catch (cleanupError) {
+        // error-policy:J6 best-effort teardown — this loop already runs because
+        // the primary connection flow failed; a single failed secret delete must
+        // not abort cleanup of the remaining orphaned secrets. Logged so the leak
+        // is observable; the original failure still propagates to the caller.
         logger.error(`[OAuth2] Failed to cleanup secret ${secretId}`, {
           error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
         });

--- a/packages/cloud/shared/src/lib/services/tenant-db/direct-pg-executor.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/tenant-db/direct-pg-executor.error-policy.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Error-policy guard for DirectPgExecutor (#13415): tenant-DB provisioning must
+ * FAIL CLOSED. An internal Postgres failure (connect/query error) must PROPAGATE
+ * out of databaseExists/execAdmin — never be swallowed into `false`/success —
+ * because SqlTenantDbProvisioner gates `CREATE DATABASE` on databaseExists and a
+ * silent `false` would corrupt provisioning. A legitimately-absent database
+ * (0 rows) must still resolve to its designed empty result (`false`), distinct
+ * from a failure. `pg` is faked (Client) so the real executor logic runs.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+let connectShouldThrow: Error | null = null;
+let queryImpl: (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rowCount: number | null; rows: unknown[] }>;
+const connectCalls: string[] = [];
+const endCalls: number[] = [];
+
+class FakeClient {
+  constructor(public readonly config: { connectionString?: string }) {}
+  async connect(): Promise<void> {
+    connectCalls.push(this.config.connectionString ?? "");
+    if (connectShouldThrow) throw connectShouldThrow;
+  }
+  async query(sql: string, params?: unknown[]) {
+    return queryImpl(sql, params);
+  }
+  async end(): Promise<void> {
+    endCalls.push(1);
+  }
+}
+
+mock.module("pg", () => ({ Client: FakeClient }));
+
+const ADMIN_DSN = "postgres://admin:pw@10.30.1.10:5432/postgres?sslmode=disable";
+
+describe("DirectPgExecutor — fail-closed provisioning (#13415)", () => {
+  beforeEach(() => {
+    connectShouldThrow = null;
+    connectCalls.length = 0;
+    endCalls.length = 0;
+    queryImpl = async () => ({ rowCount: 0, rows: [] });
+  });
+
+  afterEach(() => {
+    connectShouldThrow = null;
+  });
+
+  it("databaseExists PROPAGATES an internal query failure (not swallowed to false) and still closes the client", async () => {
+    const { DirectPgExecutor } = await import("./direct-pg-executor");
+    const boom = new Error("connection reset by peer");
+    queryImpl = async () => {
+      throw boom;
+    };
+
+    const exec = new DirectPgExecutor(ADMIN_DSN);
+    await expect(exec.databaseExists("tenant_db")).rejects.toThrow("connection reset by peer");
+    // finally-block teardown still runs even though the query threw.
+    expect(endCalls.length).toBe(1);
+  });
+
+  it("databaseExists returns the DESIGNED empty result (false) for a legitimately-absent database", async () => {
+    const { DirectPgExecutor } = await import("./direct-pg-executor");
+    queryImpl = async () => ({ rowCount: 0, rows: [] });
+
+    const exec = new DirectPgExecutor(ADMIN_DSN);
+    await expect(exec.databaseExists("missing_db")).resolves.toBe(false);
+    expect(endCalls.length).toBe(1);
+  });
+
+  it("databaseExists returns true when the pg_database row is present", async () => {
+    const { DirectPgExecutor } = await import("./direct-pg-executor");
+    queryImpl = async () => ({ rowCount: 1, rows: [{ "?column?": 1 }] });
+
+    const exec = new DirectPgExecutor(ADMIN_DSN);
+    await expect(exec.databaseExists("present_db")).resolves.toBe(true);
+  });
+
+  it("databaseExists PROPAGATES a connection failure rather than reporting the db absent", async () => {
+    const { DirectPgExecutor } = await import("./direct-pg-executor");
+    connectShouldThrow = new Error("ECONNREFUSED 10.30.1.10:5432");
+
+    const exec = new DirectPgExecutor(ADMIN_DSN);
+    await expect(exec.databaseExists("tenant_db")).rejects.toThrow("ECONNREFUSED");
+    // connect threw before a client existed to end.
+    expect(endCalls.length).toBe(0);
+  });
+
+  it("execAdmin PROPAGATES a DDL failure (provisioning cannot silently succeed)", async () => {
+    const { DirectPgExecutor } = await import("./direct-pg-executor");
+    queryImpl = async (sql) => {
+      if (sql.includes("CREATE DATABASE")) throw new Error("permission denied to create database");
+      return { rowCount: 0, rows: [] };
+    };
+
+    const exec = new DirectPgExecutor(ADMIN_DSN);
+    await expect(exec.execAdmin(["CREATE DATABASE tenant_db"])).rejects.toThrow(
+      "permission denied to create database",
+    );
+    // client is closed via finally despite the thrown statement.
+    expect(endCalls.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Slice 2 of #13415 — oauth + tenant-db + agents fallback-slop sweep

Verified untouched by the in-flight fallback sweeps. **Fixes real fail-open bugs in the OAuth path:**

- **`oauth/cache-version`** — `getOAuthVersion` returned `?? 0` and `incrementOAuthVersion` fabricated `1` when the cache backend was **unreachable**, conflating that with genuine first-use. On the revoke/refresh invalidation path this could bump the wrong version key and **resurface a revoked token from cache**. Now an unreachable backend throws; a first-use miss on a reachable backend still returns 0 — distinguishable.
- **`oauth-service.listConnections` + `generic-adapter.{findCredential,listConnections,ownsConnection}` + `secrets-adapter-utils`** — catches swallowed DB/adapter failures into a partial/empty list or `false`, so a genuinely **connected user reads as "not connected"** (fail-open → needless reconnect prompt). The removed generic-adapter catches only ever guarded a Postgres enum-mismatch that **cannot occur** (all 9 generic platforms are in `platform_credential_type`), so the surviving errors are real DB faults that must propagate. Now they propagate (J2 rethrow with `cause`); a real empty result still returns `[]`/`undefined`/`false`.
- Genuinely-justified handlers annotated `// error-policy:J2/J6`; one `console`→logger.

**Verification** (`.github/issue-evidence/13415-oauth-tenant-fallback.md`): 42 error-path tests pass (each proves failure-propagates vs designed-empty are distinguishable, driving the real functions); existing oauth+agents suites 50 pass / 0 fail; `biome` clean; `audit:error-policy-ratchet` → "no new fallback-slop"; typecheck adds 0 new errors (pre-existing drizzle-orm declaration noise only); caller-safety traced (throws surface at route boundaries; normal paths unaffected).

Security-sensitive OAuth code — flagged for review per the cloud-shared coordination rule, not solo-merge.