### PR TITLE
fix(orchestrator): sort task service imports

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -93,7 +93,6 @@ import {
   toTaskTimelineMessageDto,
 } from "./orchestrator-task-mapper.js";
 import { OrchestratorTaskStore } from "./orchestrator-task-store.js";
-import { resolveTaskProjectId } from "./project-binding.js";
 import {
   type AttemptReflection,
   type CreateTaskInput,
@@ -124,6 +123,7 @@ import {
   isParentAgentBrokerWired,
   PARENT_AGENT_BROKER_MANIFEST_ENTRY,
 } from "./parent-agent-broker.js";
+import { resolveTaskProjectId } from "./project-binding.js";
 import { buildSkillsManifest } from "./skill-manifest.js";
 import {
   configureSpendLedger,


### PR DESCRIPTION
## Summary

Follow-up from agent verification of #13774 on current `develop`.

- Sorts `orchestrator-task-service.ts` imports after the latest project-registry merge introduced a Biome import-order failure.
- No behavior change.

## Verification

```bash
bun test plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/parent-context-routes.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-identity.test.ts plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
# passed

bunx biome check plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/parent-context-routes.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-identity.test.ts plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts plugins/plugin-agent-orchestrator/src/api/agent-routes.ts plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts plugins/plugin-agent-orchestrator/src/services/types.ts
# passed

bun run audit:error-policy-ratchet
git diff --check
# passed
```

## Evidence rows

- Real LLM trajectory: N/A, import-order lint cleanup only.
- UI screenshots/video: N/A, no UI change.
- Domain artifacts: N/A, no runtime behavior change.