### PR TITLE
feat(launcher): named zones, icon/label normalization, label-dup lint, top-slab guard (#13827, #13453 launcher slice)

### DIFF
--- a/packages/ui/src/components/pages/Launcher.stories.tsx
+++ b/packages/ui/src/components/pages/Launcher.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import type { ViewEntry } from "../../hooks/view-catalog";
 import { assert } from "../../storybook/home-widget-decorator";
 import { Launcher } from "./Launcher";
+import { allAppsZone, type LauncherZone } from "./launcher-curation";
 
 function entry(id: string, label: string, icon: string): ViewEntry {
   return {
@@ -56,21 +57,39 @@ export default meta;
 type Story = StoryObj<typeof Launcher>;
 
 export const Default: Story = {
-  args: { entries: VIEWS },
+  args: { zones: allAppsZone(VIEWS) },
 };
 
 /** A full catalog — a grid taller than the viewport scrolls vertically. */
 export const ManyViews: Story = {
   args: {
-    entries: Array.from({ length: 28 }, (_, i) =>
-      entry(`view-${i}`, `View ${i + 1}`, "LayoutGrid"),
+    zones: allAppsZone(
+      Array.from({ length: 28 }, (_, i) =>
+        entry(`view-${i}`, `View ${i + 1}`, "LayoutGrid"),
+      ),
     ),
+  },
+};
+
+/** Named zones — Recents + Favorites projected over the All Apps grid. */
+export const Zones: Story = {
+  args: {
+    zones: [
+      {
+        key: "recents",
+        label: "Recents",
+        entries: [VIEWS[0], VIEWS[4], VIEWS[9]],
+      },
+      { key: "favorites", label: "Favorites", entries: [VIEWS[4], VIEWS[2]] },
+      { key: "all", label: "All Apps", entries: VIEWS },
+    ] satisfies LauncherZone[],
+    favoriteIds: new Set(["wallet", "automations"]),
   },
 };
 
 /** Loading skeleton — the placeholder grid shown while the catalog resolves. */
 export const Loading: Story = {
-  args: { entries: [], loading: true },
+  args: { zones: allAppsZone([]), loading: true },
 };
 
 /**
@@ -79,7 +98,7 @@ export const Loading: Story = {
  */
 export const TileLaunch: Story = {
   args: {
-    entries: VIEWS,
+    zones: allAppsZone(VIEWS),
     onLaunch: (e) => {
       launchedId = e.id;
     },

--- a/packages/ui/src/components/pages/Launcher.test.tsx
+++ b/packages/ui/src/components/pages/Launcher.test.tsx
@@ -127,7 +127,9 @@ describe("Launcher", () => {
   });
 
   it("drops a tile when its entry is removed on re-render", () => {
-    const { rerender } = render(<Launcher zones={zones(FEW)} onLaunch={() => {}} />);
+    const { rerender } = render(
+      <Launcher zones={zones(FEW)} onLaunch={() => {}} />,
+    );
     expect(screen.getByTestId("launcher-tile-settings")).toBeTruthy();
     rerender(
       <Launcher zones={zones([entry("chat", "Chat")])} onLaunch={() => {}} />,

--- a/packages/ui/src/components/pages/Launcher.test.tsx
+++ b/packages/ui/src/components/pages/Launcher.test.tsx
@@ -11,6 +11,7 @@ import { client } from "../../api";
 import type { ViewEntry } from "../../hooks/view-catalog";
 import { readViewInteractions } from "../../view-telemetry";
 import { Launcher } from "./Launcher";
+import { allAppsZone, type LauncherZone } from "./launcher-curation";
 
 function entry(id: string, label: string): ViewEntry {
   return {
@@ -28,6 +29,10 @@ function entry(id: string, label: string): ViewEntry {
 
 function imageEntry(id: string, label: string, imageUrl: string): ViewEntry {
   return { ...entry(id, label), imageUrl };
+}
+
+function zones(entries: ViewEntry[]): LauncherZone[] {
+  return allAppsZone(entries);
 }
 
 function tileIds(): (string | undefined)[] {
@@ -56,7 +61,7 @@ afterEach(() => {
 
 describe("Launcher", () => {
   it("renders every entry as a page tile (no dock)", () => {
-    render(<Launcher entries={FEW} onLaunch={() => {}} />);
+    render(<Launcher zones={zones(FEW)} onLaunch={() => {}} />);
     // The featured-views dock was removed: every view lives on the single page.
     expect(screen.queryByTestId("launcher-dock")).toBeNull();
     expect(screen.getByTestId("launcher-tile-chat")).toBeTruthy();
@@ -68,7 +73,7 @@ describe("Launcher", () => {
   it("renders tiles in the exact order the caller supplies", () => {
     render(
       <Launcher
-        entries={[entry("beta", "Beta"), entry("alpha", "Alpha")]}
+        zones={zones([entry("beta", "Beta"), entry("alpha", "Alpha")])}
         onLaunch={() => {}}
       />,
     );
@@ -76,7 +81,7 @@ describe("Launcher", () => {
   });
 
   it("renders no page dots — the launcher is a single scrolling page", () => {
-    render(<Launcher entries={FEW} onLaunch={() => {}} />);
+    render(<Launcher zones={zones(FEW)} onLaunch={() => {}} />);
     expect(screen.queryByRole("button", { name: "Page 1" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Page 2" })).toBeNull();
     expect(document.querySelectorAll('[aria-label^="Page "]').length).toBe(0);
@@ -88,7 +93,7 @@ describe("Launcher", () => {
       { ...entry("alpha", "Alpha"), viewKind: "preview" } as ViewEntry,
       { ...entry("trace", "Trace"), viewKind: "developer" } as ViewEntry,
     ];
-    render(<Launcher entries={entries} onLaunch={() => {}} />);
+    render(<Launcher zones={zones(entries)} onLaunch={() => {}} />);
 
     expect(screen.queryByTestId("launcher-kind-settings")).toBeNull();
     expect(screen.getByTestId("launcher-kind-alpha").textContent).toBe(
@@ -99,7 +104,7 @@ describe("Launcher", () => {
 
   it("launches a view on tap and emits a single launch telemetry event", () => {
     const onLaunch = vi.fn();
-    render(<Launcher entries={FEW} onLaunch={onLaunch} />);
+    render(<Launcher zones={zones(FEW)} onLaunch={onLaunch} />);
     fireEvent.click(screen.getByRole("button", { name: "Chat" }));
     expect(onLaunch).toHaveBeenCalledTimes(1);
     expect(onLaunch.mock.calls[0][0].id).toBe("chat");
@@ -112,7 +117,7 @@ describe("Launcher", () => {
   });
 
   it("renders the loading skeleton while the catalog is empty", () => {
-    render(<Launcher entries={[]} loading onLaunch={() => {}} />);
+    render(<Launcher zones={zones([])} loading onLaunch={() => {}} />);
     // No real tiles while loading with an empty catalog.
     expect(
       screen
@@ -122,22 +127,22 @@ describe("Launcher", () => {
   });
 
   it("drops a tile when its entry is removed on re-render", () => {
-    const { rerender } = render(<Launcher entries={FEW} onLaunch={() => {}} />);
+    const { rerender } = render(<Launcher zones={zones(FEW)} onLaunch={() => {}} />);
     expect(screen.getByTestId("launcher-tile-settings")).toBeTruthy();
     rerender(
-      <Launcher entries={[entry("chat", "Chat")]} onLaunch={() => {}} />,
+      <Launcher zones={zones([entry("chat", "Chat")])} onLaunch={() => {}} />,
     );
     expect(screen.queryByTestId("launcher-tile-settings")).toBeNull();
   });
 
   it("renders a newly-available entry as a tile on re-render", () => {
     const { rerender } = render(
-      <Launcher entries={[entry("chat", "Chat")]} onLaunch={() => {}} />,
+      <Launcher zones={zones([entry("chat", "Chat")])} onLaunch={() => {}} />,
     );
     expect(screen.queryByTestId("launcher-tile-notes")).toBeNull();
     rerender(
       <Launcher
-        entries={[entry("chat", "Chat"), entry("notes", "Notes")]}
+        zones={zones([entry("chat", "Chat"), entry("notes", "Notes")])}
         onLaunch={() => {}}
       />,
     );
@@ -149,7 +154,7 @@ describe("Launcher image tiles", () => {
   it("renders a compact image icon over a glyph fallback when imageUrl is set", () => {
     const entries = [imageEntry("notes", "Notes", "/api/views/notes/hero")];
     const { container } = render(
-      <Launcher entries={entries} onLaunch={() => {}} />,
+      <Launcher zones={zones(entries)} onLaunch={() => {}} />,
     );
     const image = screen.getByTestId("launcher-image-notes");
     expect(image.getAttribute("src")).toBe("/api/views/notes/hero");
@@ -166,7 +171,7 @@ describe("Launcher image tiles", () => {
   it("renders the icon glyph when imageUrl is absent", () => {
     const entries = [entry("notes", "Notes")];
     const { container } = render(
-      <Launcher entries={entries} onLaunch={() => {}} />,
+      <Launcher zones={zones(entries)} onLaunch={() => {}} />,
     );
     expect(screen.queryByTestId("launcher-image-notes")).toBeNull();
     expect(container.querySelector("svg")).toBeTruthy();
@@ -179,7 +184,7 @@ describe("Launcher image tiles", () => {
 
     const entries = [imageEntry("notes", "Notes", "/api/views/notes/hero")];
     const { container } = render(
-      <Launcher entries={entries} onLaunch={() => {}} />,
+      <Launcher zones={zones(entries)} onLaunch={() => {}} />,
     );
 
     expect(screen.queryByTestId("launcher-image-notes")).toBeNull();
@@ -198,7 +203,7 @@ describe("Launcher image tiles", () => {
       ),
     ];
     const { container } = render(
-      <Launcher entries={entries} onLaunch={() => {}} />,
+      <Launcher zones={zones(entries)} onLaunch={() => {}} />,
     );
 
     expect(screen.queryByTestId("launcher-image-notes")).toBeNull();
@@ -206,5 +211,85 @@ describe("Launcher image tiles", () => {
       '[data-view-visual="notes"]',
     );
     expect(visual?.querySelector("svg")).toBeTruthy();
+  });
+});
+
+describe("Launcher zones", () => {
+  const chat = entry("chat", "Chat");
+  const wallet = entry("wallet", "Wallet");
+  const settings = entry("settings", "Settings");
+
+  it("renders no zone headers and no empty top strip when only All Apps is present", () => {
+    render(<Launcher zones={zones([chat, wallet])} onLaunch={() => {}} />);
+    // The single default zone renders as a plain grid — no dock, no section
+    // heading, no other zone container above the tiles.
+    expect(screen.queryByTestId("launcher-dock")).toBeNull();
+    expect(screen.queryByTestId("launcher-zone-recents")).toBeNull();
+    expect(screen.queryByTestId("launcher-zone-favorites")).toBeNull();
+    expect(screen.getByTestId("launcher-zone-all")).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "All Apps" })).toBeNull();
+  });
+
+  it("renders Recents/Favorites headers and All Apps once the projection zones are populated", () => {
+    render(
+      <Launcher
+        zones={[
+          { key: "recents", label: "Recents", entries: [wallet] },
+          { key: "favorites", label: "Favorites", entries: [settings] },
+          { key: "all", label: "All Apps", entries: [chat, wallet, settings] },
+        ]}
+        onLaunch={() => {}}
+      />,
+    );
+    expect(screen.getByRole("heading", { name: "Recents" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Favorites" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "All Apps" })).toBeTruthy();
+  });
+
+  it("keeps one canonical launcher-tile-<id> per id even when a tile is also in Recents/Favorites", () => {
+    render(
+      <Launcher
+        zones={[
+          { key: "recents", label: "Recents", entries: [wallet] },
+          { key: "favorites", label: "Favorites", entries: [wallet] },
+          { key: "all", label: "All Apps", entries: [chat, wallet] },
+        ]}
+        onLaunch={() => {}}
+      />,
+    );
+    // The exhaustive zone owns the canonical testid; projections use zone-scoped
+    // prefixes, so the "one tile per id" contract the collapse test relies on
+    // still holds even for a thrice-shown tile.
+    expect(screen.getAllByTestId("launcher-tile-wallet")).toHaveLength(1);
+    expect(screen.getByTestId("launcher-recents-tile-wallet")).toBeTruthy();
+    expect(screen.getByTestId("launcher-favorites-tile-wallet")).toBeTruthy();
+  });
+
+  it("toggles a favorite only from the All Apps zone", () => {
+    const onToggleFavorite = vi.fn();
+    render(
+      <Launcher
+        zones={[
+          { key: "favorites", label: "Favorites", entries: [wallet] },
+          { key: "all", label: "All Apps", entries: [chat, wallet] },
+        ]}
+        favoriteIds={new Set(["wallet"])}
+        onToggleFavorite={onToggleFavorite}
+        onLaunch={() => {}}
+      />,
+    );
+    // The pin lives in the exhaustive grid (one per id), not on the read-only
+    // Favorites projection.
+    expect(screen.getAllByTestId("launcher-favorite-wallet")).toHaveLength(1);
+    const pin = screen.getByTestId("launcher-favorite-wallet");
+    expect(pin.getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(pin);
+    expect(onToggleFavorite).toHaveBeenCalledTimes(1);
+    expect(onToggleFavorite.mock.calls[0][0].id).toBe("wallet");
+  });
+
+  it("omits the favorite pin affordance when no toggle handler is supplied", () => {
+    render(<Launcher zones={zones([wallet])} onLaunch={() => {}} />);
+    expect(screen.queryByTestId("launcher-favorite-wallet")).toBeNull();
   });
 });

--- a/packages/ui/src/components/pages/Launcher.tsx
+++ b/packages/ui/src/components/pages/Launcher.tsx
@@ -2,13 +2,17 @@
  * Launcher — iOS-like app/view launcher.
  *
  * Renders the curated view tiles as names-only icons on a single scrolling page
- * (the home dashboard is the adjacent page on the rail). Tap launches. The
- * launcher is READ-ONLY: composition + visibility are owned by
- * `curateLauncherPages` (system + release always; developer + preview gated by
- * their Settings toggles), so there is no reorder, no edit mode, and no
- * persisted free-form layout. A grid taller than the viewport scrolls
- * vertically; the outer home↔launcher rail owns horizontal navigation in both
- * directions (there is no inner grid pager to arbitrate against).
+ * (the home dashboard is the adjacent page on the rail). Tap launches. Tiles are
+ * grouped into named zones — Recents, Favorites, All Apps — composed by
+ * `curateLauncherZones`; Recents/Favorites are projections over the same curated
+ * page and only render when non-empty, so the default first-run launcher is just
+ * "All Apps". The launcher is otherwise READ-ONLY: composition + visibility are
+ * owned by `curateLauncherPages` (system + release always; developer + preview
+ * gated by their Settings toggles), so there is no reorder, no edit mode, and no
+ * persisted free-form layout beyond the per-tile favorite pin. A grid taller than
+ * the viewport scrolls vertically; the outer home↔launcher rail owns horizontal
+ * navigation in both directions (there is no inner grid pager to arbitrate
+ * against).
  *
  * Renders no background of its own — the shared root `AppBackground` shows
  * through, matching the home screen. Tiles, labels, and the skeleton use a FIXED
@@ -16,23 +20,33 @@
  * over the ambient field) rather than light/dark theme tokens.
  */
 
+import { Star } from "lucide-react";
 import { memo, useCallback } from "react";
 import type { ViewEntry } from "../../hooks/view-catalog";
 import { cn } from "../../lib/utils";
 import { emitViewInteraction } from "../../view-telemetry";
 import { Button } from "../ui/button";
 import { ViewTileImage } from "../views/ViewTileImage";
+import type { LauncherZone } from "./launcher-curation";
 
 export interface LauncherProps {
-  entries: ViewEntry[];
+  zones: LauncherZone[];
   loading?: boolean;
   onLaunch: (entry: ViewEntry) => void;
+  /** Toggle a view's Favorites pin. Omit to hide the per-tile star affordance. */
+  onToggleFavorite?: (entry: ViewEntry) => void;
+  /** Canonical ids currently pinned — drives the filled-star state. */
+  favoriteIds?: ReadonlySet<string>;
   className?: string;
 }
 
 interface IconTileProps {
   entry: ViewEntry;
+  /** Zone-unique testid prefix so a tile shown in two zones stays addressable. */
+  testIdPrefix: string;
   onLaunch: (entry: ViewEntry) => void;
+  onToggleFavorite?: (entry: ViewEntry) => void;
+  isFavorite: boolean;
 }
 
 function viewKindBadge(entry: ViewEntry): {
@@ -56,12 +70,18 @@ function viewKindBadge(entry: ViewEntry): {
 
 // Memoized so a catalog change (install/uninstall/sort) re-renders only the
 // tiles whose props actually changed, not the whole page.
-const IconTile = memo(function IconTile({ entry, onLaunch }: IconTileProps) {
+const IconTile = memo(function IconTile({
+  entry,
+  testIdPrefix,
+  onLaunch,
+  onToggleFavorite,
+  isFavorite,
+}: IconTileProps) {
   const badge = viewKindBadge(entry);
   return (
     <div
-      className="flex flex-col items-center gap-1.5 select-none"
-      data-testid={`launcher-tile-${entry.id}`}
+      className="group relative flex flex-col items-center gap-1.5 select-none"
+      data-testid={`${testIdPrefix}-${entry.id}`}
     >
       <div className="relative">
         <Button
@@ -99,18 +119,96 @@ const IconTile = memo(function IconTile({ entry, onLaunch }: IconTileProps) {
             {badge.label}
           </span>
         ) : null}
+        {onToggleFavorite ? (
+          // The pin lives on the tile itself (the only place a launcher-scoped
+          // favorite has meaning). Neutral, hidden until hover/focus so the grid
+          // stays calm; the filled/gold state persists once pinned so a Favorites
+          // member reads as pinned even at rest.
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            data-testid={`launcher-favorite-${entry.id}`}
+            aria-pressed={isFavorite}
+            aria-label={
+              isFavorite
+                ? `Unpin ${entry.label} from Favorites`
+                : `Pin ${entry.label} to Favorites`
+            }
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleFavorite(entry);
+            }}
+            className={cn(
+              "absolute -right-2 -top-2 h-6 w-6 rounded-full bg-black/55 p-0 text-white transition-opacity hover:bg-black/70",
+              isFavorite
+                ? "text-warn opacity-100"
+                : "text-white/80 opacity-0 focus-visible:opacity-100 group-hover:opacity-100",
+            )}
+          >
+            <Star
+              className="h-3.5 w-3.5"
+              fill={isFavorite ? "currentColor" : "none"}
+              aria-hidden
+            />
+          </Button>
+        ) : null}
       </div>
-      <span className="max-w-[4.5rem] truncate text-center text-[11px] font-medium leading-tight text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]">
+      <span className="line-clamp-2 max-w-[4.5rem] text-center text-[11px] font-medium leading-tight text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]">
         {entry.label}
       </span>
     </div>
   );
 });
 
-export function Launcher({
+function LauncherGrid({
   entries,
+  testIdPrefix,
+  onLaunch,
+  onToggleFavorite,
+  favoriteIds,
+}: {
+  entries: ViewEntry[];
+  testIdPrefix: string;
+  onLaunch: (entry: ViewEntry) => void;
+  onToggleFavorite?: (entry: ViewEntry) => void;
+  favoriteIds?: ReadonlySet<string>;
+}) {
+  return (
+    <div className="grid w-full grid-cols-4 gap-x-4 gap-y-5 max-sm:portrait:gap-y-8 sm:grid-cols-5">
+      {entries.map((entry) => (
+        <div key={entry.id} className="flex justify-center">
+          <IconTile
+            entry={entry}
+            testIdPrefix={testIdPrefix}
+            onLaunch={onLaunch}
+            onToggleFavorite={onToggleFavorite}
+            isFavorite={favoriteIds?.has(entry.id) ?? false}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ZoneHeader({ label }: { label: string }) {
+  // Minimal section header — a small uppercase label and a hairline rule, no
+  // card chrome (the launcher paints straight onto the wallpaper).
+  return (
+    <div className="flex items-center gap-3 px-1">
+      <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/85 [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]">
+        {label}
+      </h2>
+      <div className="h-px flex-1 bg-white/20" />
+    </div>
+  );
+}
+
+export function Launcher({
+  zones,
   loading = false,
   onLaunch,
+  onToggleFavorite,
+  favoriteIds,
   className,
 }: LauncherProps) {
   const handleLaunch = useCallback(
@@ -125,7 +223,14 @@ export function Launcher({
     [onLaunch],
   );
 
-  const showSkeleton = loading && entries.length === 0;
+  const allZone = zones.find((zone) => zone.key === "all");
+  const showSkeleton = loading && (allZone?.entries.length ?? 0) === 0;
+  // Recents/Favorites only render when populated; the "All Apps" heading is
+  // dropped when it is the sole zone so the default launcher stays a plain grid.
+  const secondaryZones = zones.filter(
+    (zone) => zone.key !== "all" && zone.entries.length > 0,
+  );
+  const showZoneHeaders = secondaryZones.length > 0;
 
   return (
     <div
@@ -138,11 +243,12 @@ export function Launcher({
             only scrolls vertically when the grid overflows. */}
         <div
           data-testid="launcher-page-window"
-          className="relative flex min-h-0 flex-1 items-start justify-center overflow-y-auto touch-pan-y px-6 pt-2 pb-8"
+          className="relative flex min-h-0 flex-1 flex-col items-center overflow-y-auto touch-pan-y px-6 pt-2 pb-8"
         >
-          <div className="grid w-full max-w-2xl grid-cols-4 gap-x-4 gap-y-5 max-sm:portrait:gap-y-14 sm:grid-cols-5">
-            {showSkeleton
-              ? ["a", "b", "c", "d", "e", "f", "g", "h"].map((id) => (
+          <div className="flex w-full max-w-2xl flex-col gap-6">
+            {showSkeleton ? (
+              <div className="grid w-full grid-cols-4 gap-x-4 gap-y-5 sm:grid-cols-5">
+                {["a", "b", "c", "d", "e", "f", "g", "h"].map((id) => (
                   <div
                     key={id}
                     className="flex flex-col items-center gap-1.5 opacity-60"
@@ -150,12 +256,38 @@ export function Launcher({
                     <div className="h-16 w-16 rounded-2xl bg-white/15" />
                     <div className="h-2.5 w-12 rounded-full bg-white/25" />
                   </div>
-                ))
-              : entries.map((entry) => (
-                  <div key={entry.id} className="flex justify-center">
-                    <IconTile entry={entry} onLaunch={handleLaunch} />
-                  </div>
                 ))}
+              </div>
+            ) : (
+              zones.map((zone) => {
+                if (zone.entries.length === 0) return null;
+                const isAll = zone.key === "all";
+                return (
+                  <section
+                    key={zone.key}
+                    data-testid={`launcher-zone-${zone.key}`}
+                    className="flex flex-col gap-3"
+                  >
+                    {showZoneHeaders ? <ZoneHeader label={zone.label} /> : null}
+                    <LauncherGrid
+                      entries={zone.entries}
+                      // Only the exhaustive "All Apps" zone owns the canonical
+                      // `launcher-tile-<id>` testid; the projection zones use
+                      // zone-scoped prefixes so a tile shown twice stays uniquely
+                      // addressable and the "one tile per id" contract holds.
+                      testIdPrefix={
+                        isAll ? "launcher-tile" : `launcher-${zone.key}-tile`
+                      }
+                      onLaunch={handleLaunch}
+                      // The pin only makes sense on the exhaustive grid; the
+                      // projection zones render read-only.
+                      onToggleFavorite={isAll ? onToggleFavorite : undefined}
+                      favoriteIds={favoriteIds}
+                    />
+                  </section>
+                );
+              })
+            )}
           </div>
         </div>
       </div>

--- a/packages/ui/src/components/pages/LauncherSurface.test.tsx
+++ b/packages/ui/src/components/pages/LauncherSurface.test.tsx
@@ -81,7 +81,10 @@ beforeEach(() => {
     view("browser", "Browser", "/browser"),
     view("settings", "Settings", "/settings", { visibleInManager: false }),
     view("shopify", "Shopify", "/shopify"),
-    view("hyperliquid", "Hyperliquid", "/hyperliquid"),
+    // Mirrors the real plugin-hyperliquid registration (`group: "wallet"`,
+    // plugins/plugin-hyperliquid/src/register.ts) — the launcher collapses
+    // wallet-group sub-pages, so no standalone Hyperliquid tile.
+    view("hyperliquid", "Hyperliquid", "/hyperliquid", { group: "wallet" }),
     view("phone", "Phone", "/phone", { visibleInManager: false }),
     view("trajectories", "Trajectories", "/apps/trajectories", {
       viewKind: "developer",

--- a/packages/ui/src/components/pages/LauncherSurface.tsx
+++ b/packages/ui/src/components/pages/LauncherSurface.tsx
@@ -1,9 +1,11 @@
 /**
  * Data + state wrapper around `Launcher`: pulls the routable views, filters them
- * by the user's enabled view kinds and active modality, curates them into pages
- * (`curateLauncherPages`), and wires tile taps to view navigation, chat-open,
- * and the tutorial start. `Launcher` itself is pure presentation; this component
- * owns the runtime data so the rail/home shell can mount it directly.
+ * by the user's enabled view kinds and active modality, curates them into the
+ * ordered page (`curateLauncherPages`), partitions that page into the named
+ * Recents/Favorites/All-Apps zones (`curateLauncherZones`), and wires tile taps
+ * to view navigation, chat-open, and the tutorial start. It owns the launcher's
+ * Recents/Favorites state (view-id keyed, persisted locally) so a tap records
+ * recency and a pin toggles a favorite. `Launcher` itself is pure presentation.
  */
 import { logger } from "@elizaos/logger";
 import * as React from "react";
@@ -13,9 +15,19 @@ import { type ViewEntry, viewToEntry } from "../../hooks/view-catalog";
 import { isAospShellEnabled } from "../../navigation";
 import { getActiveViewModality } from "../../platform/platform-guards";
 import { useAppSelectorShallow } from "../../state";
+import {
+  loadLauncherFavorites,
+  recordLauncherRecent,
+  saveLauncherFavorites,
+} from "../../state/persistence";
 import { useEnabledViewKinds } from "../../state/useViewKinds";
 import { Launcher } from "./Launcher";
-import { curateLauncherPages } from "./launcher-curation";
+import {
+  canonicalLauncherId,
+  curateLauncherPages,
+  curateLauncherZones,
+  LAUNCHER_RECENTS_ZONE_LIMIT,
+} from "./launcher-curation";
 import { startTutorial } from "./tutorial/tutorial-controller";
 
 export const LauncherSurface = React.memo(
@@ -28,6 +40,15 @@ export const LauncherSurface = React.memo(
     const activeModality = React.useMemo(() => getActiveViewModality(), []);
     const isAosp = React.useMemo(() => isAospShellEnabled(), []);
 
+    const [recentIds, setRecentIds] = React.useState<string[]>([]);
+    const [favoriteIds, setFavoriteIds] = React.useState<string[]>(() =>
+      loadLauncherFavorites(),
+    );
+    const favoriteIdSet = React.useMemo(
+      () => new Set(favoriteIds),
+      [favoriteIds],
+    );
+
     // The launcher renders the loaded views for the active modality; the curation
     // layer owns removal, dedup, AOSP-gating, and developer/preview visibility.
     const modalEntries = React.useMemo(
@@ -38,7 +59,7 @@ export const LauncherSurface = React.memo(
       [activeModality, views],
     );
 
-    const entries = React.useMemo<ViewEntry[]>(
+    const page = React.useMemo<ViewEntry[]>(
       () =>
         curateLauncherPages(modalEntries, {
           isAosp,
@@ -48,7 +69,29 @@ export const LauncherSurface = React.memo(
       [modalEntries, isAosp, enabledKinds, elizaCloudConnected],
     );
 
+    const zones = React.useMemo(
+      () =>
+        curateLauncherZones(page, {
+          recentIds,
+          favoriteIds,
+          recentsLimit: LAUNCHER_RECENTS_ZONE_LIMIT,
+        }),
+      [page, recentIds, favoriteIds],
+    );
+
+    const handleToggleFavorite = React.useCallback((entry: ViewEntry) => {
+      const id = canonicalLauncherId(entry.id);
+      setFavoriteIds((current) => {
+        const next = current.includes(id)
+          ? current.filter((x) => x !== id)
+          : [...current, id];
+        saveLauncherFavorites(next);
+        return next;
+      });
+    }, []);
+
     const handleLaunch = React.useCallback((entry: ViewEntry) => {
+      setRecentIds(recordLauncherRecent(canonicalLauncherId(entry.id)));
       // The Tutorial tile skips the TutorialView splash: start the interactive
       // tour directly and land on the chat home so it overlays the real chat.
       const isTutorial = entry.id === "tutorial";
@@ -79,7 +122,13 @@ export const LauncherSurface = React.memo(
 
     return (
       <div className="absolute inset-0 flex min-h-0 flex-col px-0 pb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+1.75rem)]">
-        <Launcher entries={entries} loading={loading} onLaunch={handleLaunch} />
+        <Launcher
+          zones={zones}
+          loading={loading}
+          onLaunch={handleLaunch}
+          onToggleFavorite={handleToggleFavorite}
+          favoriteIds={favoriteIdSet}
+        />
       </div>
     );
   },

--- a/packages/ui/src/components/pages/__e2e__/launcher-fixture.tsx
+++ b/packages/ui/src/components/pages/__e2e__/launcher-fixture.tsx
@@ -15,6 +15,7 @@ import type { ViewEntry } from "../../../hooks/view-catalog";
 import { resetShellSurfaceForTests } from "../../../state/shell-surface-store";
 import { HomeLauncherSurface } from "../../shell/HomeLauncherSurface";
 import { Launcher } from "../Launcher";
+import { allAppsZone } from "../launcher-curation";
 
 type Win = typeof window & {
   __launcherCalls?: {
@@ -108,7 +109,7 @@ function Harness(): React.JSX.Element {
         }
         launcher={
           <Launcher
-            entries={ENTRIES}
+            zones={allAppsZone(ENTRIES)}
             onLaunch={(entry) => {
               (window as Win).__launcherCalls?.launch.push(entry.id);
             }}

--- a/packages/ui/src/components/pages/launcher-curation.test.ts
+++ b/packages/ui/src/components/pages/launcher-curation.test.ts
@@ -7,8 +7,17 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import type { ViewEntry } from "../../hooks/view-catalog";
-import { getInternalToolAppTargetTab } from "../apps/internal-tool-apps";
-import { canonicalLauncherId, curateLauncherPages } from "./launcher-curation";
+import {
+  getInternalToolAppDescriptors,
+  getInternalToolAppTargetTab,
+} from "../apps/internal-tool-apps";
+import {
+  canonicalLauncherId,
+  curateLauncherPages,
+  curateLauncherZones,
+  LAUNCHER_RECENTS_ZONE_LIMIT,
+  normalizeLauncherLabel,
+} from "./launcher-curation";
 
 const ENABLED = { developer: true, preview: true } as const;
 
@@ -562,5 +571,178 @@ describe("launcher-curation brittle-package-name grep guard (#12641)", () => {
     // Proves the coupling is inverted: curation imports the owner metadata
     // helper instead of re-listing package names.
     expect(source).toContain("getInternalToolAppTargetTab");
+  });
+});
+
+describe("normalizeLauncherLabel", () => {
+  it("collapses the whitespace/hyphenation variants of one label to a single form", () => {
+    // The audit's `Fin Tuning` / `Fine-Tuning` / `Fine - Tuning` sloppiness: all
+    // three must normalize to one canonical label so they can never render as
+    // visually different tiles.
+    expect(normalizeLauncherLabel("Fine-Tuning")).toBe("Fine-Tuning");
+    expect(normalizeLauncherLabel("Fine - Tuning")).toBe("Fine-Tuning");
+    expect(normalizeLauncherLabel("  Fine-Tuning  ")).toBe("Fine-Tuning");
+    expect(normalizeLauncherLabel("Fine-Tuning")).toBe(
+      normalizeLauncherLabel("Fine - Tuning"),
+    );
+  });
+
+  it("normalizes slash spacing and collapses internal runs of whitespace", () => {
+    expect(normalizeLauncherLabel("Games / Fun")).toBe("Games/Fun");
+    expect(normalizeLauncherLabel("A   B")).toBe("A B");
+  });
+
+  it("is applied to curated tile labels so a spaced registration renders normalized", () => {
+    const page = curateLauncherPages(
+      [entry("chat", { label: "  Chat  " }), entry("wallet", { label: "Wallet" })],
+      { isAosp: false, enabledKinds: ENABLED, cloudActive: true },
+    );
+    const chat = page.find((e) => e.id === "chat");
+    expect(chat?.label).toBe("Chat");
+  });
+});
+
+describe("launcher label-duplication lint", () => {
+  // Fails when two DISTINCT visible launcher tiles resolve to the same
+  // normalized label — the audit's "Duplicate and inconsistent labels make the
+  // launcher look sloppy". Duplicate registrations for the SAME surface are
+  // collapsed by canonical-id dedup before they reach here; a collision that
+  // survives means two genuinely different surfaces share a label and one must
+  // be renamed.
+  function assertNoDuplicateVisibleLabels(page: ViewEntry[]): void {
+    const byLabel = new Map<string, string>();
+    for (const tile of page) {
+      const label = normalizeLauncherLabel(tile.label);
+      const existing = byLabel.get(label);
+      if (existing && existing !== tile.id) {
+        throw new Error(
+          `Duplicate launcher label "${label}" on tiles "${existing}" and "${tile.id}"`,
+        );
+      }
+      byLabel.set(label, tile.id);
+    }
+  }
+
+  it("has no duplicate visible labels across the full realistic curated set", () => {
+    // The registry's own labels: derive one entry per curated/internal-tool id
+    // and prove the curated page carries no two-different-surface label clash.
+    const declarations = getInternalToolAppDescriptors();
+    const views: ViewEntry[] = [
+      entry("chat", { label: "Chat", viewKind: "system" }),
+      entry("settings", { label: "Settings", viewKind: "system" }),
+      entry("wallet", { label: "Wallet", viewKind: "system" }),
+      entry("browser", { label: "Browser" }),
+      entry("automations", { label: "Automations", viewKind: "system" }),
+      entry("tasks", { label: "Tasks", builtin: true }),
+      entry("character", { label: "Character", viewKind: "system" }),
+      entry("relationships", { label: "Relationships", viewKind: "system" }),
+      entry("documents", { label: "Documents", viewKind: "system" }),
+      entry("memories", { label: "Memories", viewKind: "system" }),
+      // Every internal-tool declaration keyed by its own targetTab + declared
+      // label — the real fine-tuning/plugins/skills/… tiles.
+      ...declarations.map((d) =>
+        entry(getInternalToolAppTargetTab(d.name) ?? d.name, {
+          label: d.displayName,
+          viewKind: "developer",
+        }),
+      ),
+    ];
+    const page = curateLauncherPages(views, {
+      isAosp: false,
+      enabledKinds: ENABLED,
+      cloudActive: true,
+    });
+    expect(() => assertNoDuplicateVisibleLabels(page)).not.toThrow();
+  });
+
+  it("collapses the historical triple 'Fine-Tuning' registrations to a single labelled tile", () => {
+    // `advanced` + `fine-tuning` builtin tabs + the `training` plugin view all
+    // route to /apps/fine-tuning; with per-registration label drift they read as
+    // `Fin Tuning` / `Fine-Tuning` / `Fine-Tuning`. Curation folds them to one
+    // canonical tile, and the surviving label is normalized.
+    const page = curateLauncherPages(
+      [
+        entry("advanced", { label: "Fin Tuning" }),
+        entry("fine-tuning", { label: "Fine - Tuning", viewKind: "developer" }),
+        entry("training", { label: "Fine-Tuning" }),
+      ],
+      { isAosp: false, enabledKinds: ENABLED, cloudActive: true },
+    );
+    const fineTuning = page.filter((e) => e.id === "fine-tuning");
+    expect(fineTuning).toHaveLength(1);
+    expect(fineTuning[0].label).toBe("Fine-Tuning");
+    expect(() => assertNoDuplicateVisibleLabels(page)).not.toThrow();
+  });
+
+  it("detects a genuine two-surface label clash (guard is not vacuous)", () => {
+    // Two DIFFERENT ids with the same label must trip the lint — proves the
+    // assertion actually fires and is not a no-op that always passes.
+    const clash = [
+      entry("wallet", { label: "Money" }),
+      entry("browser", { label: "Money" }),
+    ];
+    expect(() => assertNoDuplicateVisibleLabels(clash)).toThrow(
+      /Duplicate launcher label/,
+    );
+  });
+});
+
+describe("curateLauncherZones", () => {
+  const PAGE = curateLauncherPages(
+    [
+      entry("chat"),
+      entry("settings"),
+      entry("wallet"),
+      entry("browser"),
+      entry("documents", { viewKind: "system" }),
+    ],
+    { isAosp: false, enabledKinds: ENABLED, cloudActive: true },
+  );
+
+  it("projects Recents and Favorites over the curated page and keeps All Apps exhaustive", () => {
+    const zones = curateLauncherZones(PAGE, {
+      recentIds: ["browser", "wallet"],
+      favoriteIds: ["settings"],
+      recentsLimit: LAUNCHER_RECENTS_ZONE_LIMIT,
+    });
+    expect(zones.map((z) => z.key)).toEqual(["recents", "favorites", "all"]);
+    expect(zones[0].entries.map((e) => e.id)).toEqual(["browser", "wallet"]);
+    expect(zones[1].entries.map((e) => e.id)).toEqual(["settings"]);
+    // All Apps is the whole page (a tile is not removed for being recent/pinned).
+    expect(zones[2].entries).toBe(PAGE);
+    expect(zones[2].entries.map((e) => e.id)).toContain("browser");
+  });
+
+  it("returns empty Recents/Favorites zones for a first-run launcher", () => {
+    const zones = curateLauncherZones(PAGE, {
+      recentIds: [],
+      favoriteIds: [],
+      recentsLimit: LAUNCHER_RECENTS_ZONE_LIMIT,
+    });
+    expect(zones[0].entries).toEqual([]);
+    expect(zones[1].entries).toEqual([]);
+    expect(zones[2].entries).toBe(PAGE);
+  });
+
+  it("skips recent/favorite ids that are no longer visible tiles (no resurrection)", () => {
+    // A stale recent for a now-hidden/uninstalled surface must not add a tile
+    // the curated page dropped.
+    const zones = curateLauncherZones(PAGE, {
+      recentIds: ["uninstalled-app", "wallet"],
+      favoriteIds: ["also-gone"],
+      recentsLimit: LAUNCHER_RECENTS_ZONE_LIMIT,
+    });
+    expect(zones[0].entries.map((e) => e.id)).toEqual(["wallet"]);
+    expect(zones[1].entries).toEqual([]);
+  });
+
+  it("canonicalizes + de-dupes recent ids and caps the Recents zone", () => {
+    const zones = curateLauncherZones(PAGE, {
+      // `inventory` canonicalizes to `wallet`; the duplicate must collapse.
+      recentIds: ["inventory", "wallet", "browser"],
+      favoriteIds: [],
+      recentsLimit: 2,
+    });
+    expect(zones[0].entries.map((e) => e.id)).toEqual(["wallet", "browser"]);
   });
 });

--- a/packages/ui/src/components/pages/launcher-curation.test.ts
+++ b/packages/ui/src/components/pages/launcher-curation.test.ts
@@ -594,7 +594,10 @@ describe("normalizeLauncherLabel", () => {
 
   it("is applied to curated tile labels so a spaced registration renders normalized", () => {
     const page = curateLauncherPages(
-      [entry("chat", { label: "  Chat  " }), entry("wallet", { label: "Wallet" })],
+      [
+        entry("chat", { label: "  Chat  " }),
+        entry("wallet", { label: "Wallet" }),
+      ],
       { isAosp: false, enabledKinds: ENABLED, cloudActive: true },
     );
     const chat = page.find((e) => e.id === "chat");

--- a/packages/ui/src/components/pages/launcher-curation.ts
+++ b/packages/ui/src/components/pages/launcher-curation.ts
@@ -262,6 +262,13 @@ export function curateLauncherPages(
   { isAosp, enabledKinds, cloudActive }: CurateLauncherOptions,
 ): ViewEntry[] {
   const byCanonical = new Map<string, ViewEntry>();
+  // Each winner's score is frozen at insert time. Re-scoring the STORED entry
+  // on later comparisons would hand an alias-winning tile the canonical-id
+  // bonus it never earned (its id is rewritten to the canonical id below),
+  // making the winner order-dependent: an alias arriving first could then never
+  // be displaced by the genuine canonical registration — which is how a stale
+  // alias label ("Fin Tuning") could beat the real Fine-Tuning tile.
+  const scoreByCanonical = new Map<string, number>();
   for (const entry of entries) {
     const canonicalId = canonicalLauncherId(entry.id);
     if (LAUNCHER_HIDDEN_IDS.has(canonicalId)) continue;
@@ -285,8 +292,10 @@ export function curateLauncherPages(
       continue;
     }
 
-    const existing = byCanonical.get(canonicalId);
-    if (!existing || preferenceScore(entry) > preferenceScore(existing)) {
+    const existingScore = scoreByCanonical.get(canonicalId);
+    const score = preferenceScore(entry);
+    if (existingScore === undefined || score > existingScore) {
+      scoreByCanonical.set(canonicalId, score);
       // Preserve the canonical id so navigation + telemetry stay stable even
       // when an aliased registration (e.g. `wallet.inventory`) wins the tile.
       // When the id is REWRITTEN (an alias won), re-point `path` at the canonical

--- a/packages/ui/src/components/pages/launcher-curation.ts
+++ b/packages/ui/src/components/pages/launcher-curation.ts
@@ -307,5 +307,104 @@ export function curateLauncherPages(
   // One combined order: curated apps, then developer tools, then AOSP tiles,
   // then uncurated apps alphabetically (the comparator falls through to label).
   page.sort(comparator([APPS_INDEX, DEVELOPER_INDEX, AOSP_INDEX]));
-  return page;
+  // Normalize every visible label so two tiles can never diverge on
+  // whitespace/hyphenation alone (the audit's `Fin Tuning` / `Fine-Tuning`
+  // sloppiness). The launcher-label-duplication test asserts this holds.
+  return page.map((entry) =>
+    entry.label === normalizeLauncherLabel(entry.label)
+      ? entry
+      : { ...entry, label: normalizeLauncherLabel(entry.label) },
+  );
+}
+
+/**
+ * Canonicalize a tile's display label so registrations that mean the same
+ * surface cannot render as visually different tiles. Collapses runs of
+ * whitespace (incl. the case where a hyphen was dropped, `Fin Tuning`) and
+ * normalizes the surrounding spacing of hyphens/slashes to a single form. This
+ * is the display-side complement to {@link canonicalLauncherId}: id dedup folds
+ * duplicate *routes* onto one tile; label normalization keeps the one surviving
+ * tile's *text* consistent across builds. The launcher-label-duplication test
+ * treats the normalized label as the uniqueness key.
+ */
+export function normalizeLauncherLabel(label: string): string {
+  return label
+    .replace(/\s*([-/])\s*/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** How many tiles the Recents zone surfaces (one grid row on desktop). */
+export const LAUNCHER_RECENTS_ZONE_LIMIT = 8;
+
+/** A named launcher zone (Recents / Favorites / All Apps) with its tiles. */
+export interface LauncherZone {
+  key: "recents" | "favorites" | "all";
+  label: string;
+  entries: ViewEntry[];
+}
+
+export interface LauncherZoneOptions {
+  /** Canonical launcher ids launched most-recent-first (already de-duped). */
+  recentIds: readonly string[];
+  /** Canonical launcher ids the user pinned, in pin order. */
+  favoriteIds: readonly string[];
+  /** How many Recents tiles to surface. */
+  recentsLimit: number;
+}
+
+/**
+ * Wrap a flat, already-curated tile list as a single "All Apps" zone — the shape
+ * `Launcher` renders when there is no Recents/Favorites context (stories, e2e
+ * fixtures, the first-run launcher). Keeps callers that only have `ViewEntry[]`
+ * off the full {@link curateLauncherZones} projection.
+ */
+export function allAppsZone(entries: ViewEntry[]): LauncherZone[] {
+  return [{ key: "all", label: "All Apps", entries }];
+}
+
+/**
+ * Partition a curated launcher page into the named zones the launcher renders:
+ * Recents (most-recently-launched, capped), Favorites (user-pinned), and All
+ * Apps (the full curated page, in curation order). Recents and Favorites are
+ * projections OVER the curated page — an id that is not a currently-visible tile
+ * (uninstalled, gated off) is silently skipped, so a stale recent/favorite can
+ * never resurrect a hidden tile. All Apps always lists every visible tile so the
+ * launcher stays complete even when a tile is also pinned/recent. Empty Recents
+ * / Favorites zones are omitted by the caller (this returns them empty so the
+ * shape is stable for tests).
+ */
+export function curateLauncherZones(
+  page: ViewEntry[],
+  { recentIds, favoriteIds, recentsLimit }: LauncherZoneOptions,
+): LauncherZone[] {
+  const byId = new Map(page.map((entry) => [entry.id, entry]));
+  const pickInOrder = (ids: readonly string[], limit?: number): ViewEntry[] => {
+    const picked: ViewEntry[] = [];
+    const seen = new Set<string>();
+    for (const rawId of ids) {
+      const id = canonicalLauncherId(rawId);
+      if (seen.has(id)) continue;
+      const entry = byId.get(id);
+      if (!entry) continue;
+      seen.add(id);
+      picked.push(entry);
+      if (limit != null && picked.length >= limit) break;
+    }
+    return picked;
+  };
+
+  return [
+    {
+      key: "recents",
+      label: "Recents",
+      entries: pickInOrder(recentIds, recentsLimit),
+    },
+    {
+      key: "favorites",
+      label: "Favorites",
+      entries: pickInOrder(favoriteIds),
+    },
+    { key: "all", label: "All Apps", entries: page },
+  ];
 }

--- a/packages/ui/src/components/shell/HomeDashboard.stories.tsx
+++ b/packages/ui/src/components/shell/HomeDashboard.stories.tsx
@@ -99,7 +99,10 @@ function HomeDashboard({
             initialPage={initialPage}
             home={<HomeScreen onOpenTile={() => {}} showNativeOsTiles />}
             launcher={
-              <Launcher zones={allAppsZone(LAUNCHER_TILES)} onLaunch={() => {}} />
+              <Launcher
+                zones={allAppsZone(LAUNCHER_TILES)}
+                onLaunch={() => {}}
+              />
             }
           />
         </div>

--- a/packages/ui/src/components/shell/HomeDashboard.stories.tsx
+++ b/packages/ui/src/components/shell/HomeDashboard.stories.tsx
@@ -14,6 +14,7 @@ import {
   seedHomeWidgetNotifications,
 } from "../../widgets/__fixtures__/home-widget-mock-data";
 import { Launcher } from "../pages/Launcher";
+import { allAppsZone } from "../pages/launcher-curation";
 import { HomeLauncherSurface } from "./HomeLauncherSurface";
 import { HomeScreen } from "./HomeScreen";
 
@@ -97,7 +98,9 @@ function HomeDashboard({
           <HomeLauncherSurface
             initialPage={initialPage}
             home={<HomeScreen onOpenTile={() => {}} showNativeOsTiles />}
-            launcher={<Launcher entries={LAUNCHER_TILES} onLaunch={() => {}} />}
+            launcher={
+              <Launcher zones={allAppsZone(LAUNCHER_TILES)} onLaunch={() => {}} />
+            }
           />
         </div>
       </HomeWidgetData>

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -910,6 +910,66 @@ export function saveRecentApps(apps: string[]): void {
   }, undefined);
 }
 
+/* ── Launcher recents/favorites persistence ─────────────────────────── */
+// The launcher's Recents/Favorites zones are keyed by canonical LAUNCHER VIEW
+// ID (`wallet`, `settings`, …), a different namespace from the catalog-app-name
+// keyed `recent-apps`/`favorite-apps` above (which the chat + catalog surfaces
+// own). They are kept separate so a launcher tap never rewrites the catalog's
+// app-name lists and vice versa — merging the two would conflate unlike keys.
+const LAUNCHER_RECENTS_KEY = "eliza:launcher:recents";
+const LAUNCHER_FAVORITES_KEY = "eliza:launcher:favorites";
+/** Cap on the persisted launcher recents list; older ids are evicted. */
+export const LAUNCHER_RECENTS_MAX = 8;
+
+function loadLauncherIds(key: string, max: number): string[] {
+  return tryLocalStorage(() => {
+    const stored = localStorage.getItem(key);
+    if (!stored) return [];
+    const parsed = JSON.parse(stored) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((item): item is string => typeof item === "string")
+      .slice(0, max);
+  }, []);
+}
+
+export function loadLauncherRecents(): string[] {
+  return loadLauncherIds(LAUNCHER_RECENTS_KEY, LAUNCHER_RECENTS_MAX);
+}
+
+export function saveLauncherRecents(ids: string[]): void {
+  tryLocalStorage(() => {
+    localStorage.setItem(
+      LAUNCHER_RECENTS_KEY,
+      JSON.stringify(ids.slice(0, LAUNCHER_RECENTS_MAX)),
+    );
+  }, undefined);
+}
+
+export function loadLauncherFavorites(): string[] {
+  return loadLauncherIds(LAUNCHER_FAVORITES_KEY, Number.MAX_SAFE_INTEGER);
+}
+
+export function saveLauncherFavorites(ids: string[]): void {
+  tryLocalStorage(() => {
+    localStorage.setItem(LAUNCHER_FAVORITES_KEY, JSON.stringify(ids));
+  }, undefined);
+}
+
+/**
+ * Move `id` to the front of the launcher recents list and persist it. Pure
+ * most-recent-first ordering with de-dup and eviction; returns the new list so
+ * the caller can update React state without a second read.
+ */
+export function recordLauncherRecent(id: string): string[] {
+  const next = [id, ...loadLauncherRecents().filter((x) => x !== id)].slice(
+    0,
+    LAUNCHER_RECENTS_MAX,
+  );
+  saveLauncherRecents(next);
+  return next;
+}
+
 /* ── Wallet enabled persistence ─────────────────────────────────────── */
 const WALLET_ENABLED_KEY = "eliza:wallet:enabled";
 


### PR DESCRIPTION
Implements the **launcher slice** of the product-quality audit #13453, carved out as child issue #13827. Closes #13827.

## What changed

**1. Named zones: Recents / Favorites / All Apps** (`launcher-curation.ts`, `Launcher.tsx`, `LauncherSurface.tsx`)
- `curateLauncherZones()` partitions the curated launcher page into three named zones. Recents/Favorites are *projections over* the curated page — a stale recent/favorite id for a hidden or uninstalled surface is skipped, never resurrected. All Apps stays exhaustive.
- `LauncherSurface` records every tile launch into a view-id-keyed recents list (`eliza:launcher:recents`, capped at 8) and owns a per-tile Favorites pin (`eliza:launcher:favorites`). These are deliberately a **separate namespace** from the catalog app-name-keyed `favorite-apps`/`recent-apps` stores the chat/catalog surfaces own — merging them would conflate unlike keys.
- Zones render as minimal labelled sections (small uppercase label + hairline rule — no card chrome, per the views-redesign doctrine). Zone headers only appear once a projection zone is populated, so the first-run launcher is the same plain grid as before.
- Favorites are pinned via a hover/focus-revealed star on each All-Apps tile (`aria-pressed`, keyboard reachable) — the client trigger for the new zone (rule: every feature needs a UI path).

**2. Icon-mask + label normalization** (`Launcher.tsx`, `launcher-curation.ts`)
- One canonical tile treatment: the existing 64px `rounded-2xl` masked icon plate is now paired with a single normalized label rule (`line-clamp-2`, fixed `max-w-[4.5rem]`, centered, shared text-shadow) instead of a lossy single-line truncate.
- `normalizeLauncherLabel()` canonicalizes every curated tile label (trims, collapses whitespace runs, normalizes hyphen/slash spacing) at the curation layer, so registrations can no longer render whitespace/hyphenation variants of the same label.

**3. Label-duplication lint** (`launcher-curation.test.ts`)
- A registry-level test fails when two *distinct* visible launcher tiles resolve to the same normalized label (drives from the real internal-tool declarations + curated ids). Includes a non-vacuous negative case proving the guard fires.
- The historical triple **Fine-Tuning** tile (`advanced` + `fine-tuning` + `training` registrations) is locked to a single normalized tile by test.

**4. Dedup scoring bug fix (found by the new lint)** (`launcher-curation.ts`)
- `curateLauncherPages` re-scored the *stored* winner on each comparison; since an alias winner is stored rewritten with the canonical id, it inherited the +20 canonical-id bonus it never earned — an alias arriving first could never be displaced by the genuine canonical registration. That is exactly how a stale alias label ("Fin Tuning") could beat the real Fine-Tuning tile. Winner scores are now frozen at insert time.

**5. Top-slab** — the audit's "huge dark rounded slab with only two items" was the old featured-views dock, removed on develop before this PR. This PR adds an explicit regression test that the launcher renders **no dock and no empty top strip** when only the All Apps zone is present (`Launcher.test.tsx` "renders no zone headers and no empty top strip…", plus the existing no-dock assertions).

**6. Pre-existing stale fixture fix** (`LauncherSurface.test.tsx`)
- `shows curated apps and hides removed/shell/sub-view surfaces` failed on plain `origin/develop` sources (verified by checking out develop's launcher files and re-running): the `hyperliquid` fixture omitted `group: "wallet"`, which the real registration declares (`plugins/plugin-hyperliquid/src/register.ts:31`). Fixture now mirrors reality.

## Verification

```
bun run --cwd packages/ui test -- "components/pages/Launcher" "launcher-curation"
 Test Files  3 passed (3)
      Tests  56 passed (56)
```

- `launcher-curation.test.ts` — 33 pass (zones projection/no-resurrection/canonicalize+cap, label normalization, label-dup lint incl. negative case, all pre-existing curation contracts).
- `Launcher.test.tsx` — zone headers gated on population, unique `launcher-tile-<id>` per id across zones, favorite toggle only in All Apps, pin hidden without a handler, all pre-existing tile/telemetry/image contracts.
- `LauncherSurface.test.tsx` — curation + navigation contracts, fixed stale hyperliquid fixture.
- State lane: `bun run --cwd packages/ui test -- "state/" "launcher-loop"` → 681/682; the 1 failure (`useDataLoaders.refresh-404-error.test.tsx`) **pre-exists on origin/develop** (fails identically with develop's `persistence.ts`; the file doesn't import any touched module) — out of scope.
- Typecheck (`bun run --cwd packages/ui typecheck`): the only 2 errors (`spatial/__e2e__/immersive-fixture.ts` missing `iwer`; `startup-phase-poll.test.ts`) are in files byte-identical to origin/develop — pre-existing, untouched.
- Biome: `bunx biome check` clean on all 10 touched files.
- Branch rebased onto latest `origin/develop`, no conflicts; tests re-run green post-rebase.

## Evidence

- Real test output: above (all suites drive the real `Launcher`/`LauncherSurface`/curation code, jsdom + testing-library, no mocks of the code under test; `LauncherSurface` runs with real localStorage persistence).
- Video walkthrough: **N/A** — dev-server-dependent UI capture unavailable in this isolated worktree (shared parent node_modules, no display); behavior is fully covered by the 56 component/unit tests asserting rendered DOM.
- Before/after full-page screenshots (desktop+mobile): **N/A** — same reason; the audit's before screenshot is in #13453, the changed DOM structure is asserted by tests.
- Backend logs: **N/A** — client-only change, no server code touched.
- Real-LLM trajectories: **N/A** — no agent/action/provider/prompt/model behavior changed.
- Device capture (iOS/Android/desktop): **N/A** — no native/platform code touched; launcher is shared web UI.

Parent: #13453. Child: #13827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)