### PR TITLE
fix(agent): dedupe mobile puppeteer stub

### DIFF
--- a/packages/agent/scripts/build-mobile-bundle.mjs
+++ b/packages/agent/scripts/build-mobile-bundle.mjs
@@ -376,7 +376,6 @@ const nativeStubs = {
   // and API dispatch, so keep PDF parsing behind a clear mobile runtime error
   // instead of paying that no-JIT parse cost on every app launch.
   unpdf: path.join(stubsDir, "unpdf.cjs"),
-  "puppeteer-core": path.join(stubsDir, "puppeteer-core.cjs"),
   "pty-manager": path.join(stubsDir, "pty-manager.cjs"),
   sharp: path.join(stubsDir, "sharp.cjs"),
   canvas: path.join(stubsDir, "canvas.cjs"),


### PR DESCRIPTION
## Summary
- remove the overwritten `puppeteer-core` entry from `nativeStubs` in the mobile bundle script
- keep the later documented `null-plugin` stub as the single `puppeteer-core` mobile-bundle mapping for plugin-app-control

## Why
PR #13869 correctly stubs `puppeteer-core` for mobile, but after it merged the object still had an older `puppeteer-core` key earlier in `nativeStubs`. Biome flags that duplicate key, and only the later value is actually used.

## Verification
- `bun install --no-save --ignore-scripts`
- `bunx @biomejs/biome check packages/agent/scripts/build-mobile-bundle.mjs`
- `git diff --check -- packages/agent/scripts/build-mobile-bundle.mjs`
- `bun run --cwd packages/agent build:mobile`

Related: #13869 / #13611 runtime verification follow-up.