### PR TITLE
fix(#13568): wire real devicectl detection for the iOS physical-device walkthrough lane

### DIFF
--- a/packages/app/scripts/walkthrough-device-matrix.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.mjs
@@ -34,13 +34,13 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
+import { resolveDeviceId } from "./ios-device-lib.mjs";
 import {
   ensureEmulatorBooted,
   listDevices,
   resolveAdb,
 } from "./lib/android-device.mjs";
-import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
-import { resolveDeviceId } from "./ios-device-lib.mjs";
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const APP_DIR = resolve(dirname(SCRIPT_PATH), "..");

--- a/packages/app/scripts/walkthrough-device-matrix.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.mjs
@@ -31,7 +31,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
@@ -39,6 +39,8 @@ import {
   listDevices,
   resolveAdb,
 } from "./lib/android-device.mjs";
+import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
+import { resolveDeviceId } from "./ios-device-lib.mjs";
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const APP_DIR = resolve(dirname(SCRIPT_PATH), "..");
@@ -156,6 +158,188 @@ function runScript(rel, args, env = {}) {
 
 function lane(status, reason, extra = {}) {
   return { status, reason, ...extra };
+}
+
+/** devicectl live-connection states that mean the device is reachable for an
+ * on-device test run. `connected` is the normal tethered/tunnel-up value; some
+ * toolchain versions report `available`. Everything else (`disconnected`,
+ * `unavailable`, missing) is not connectable. */
+const CONNECTABLE_IOS_STATES = new Set(["connected", "available"]);
+
+/** Normalize a devicectl device record's live tunnel/connection state to a
+ * lowercase token (`"unknown"` when absent). Pure. */
+export function iosDeviceConnectionState(device) {
+  const raw = device?.connectionProperties?.tunnelState ?? "";
+  return String(raw).toLowerCase() || "unknown";
+}
+
+/** Human-readable "<name> [<state>]" label for a devicectl device record. Pure. */
+export function iosDeviceLabel(device) {
+  const name =
+    device?.deviceProperties?.name ||
+    device?.hardwareProperties?.udid ||
+    device?.identifier ||
+    "(unnamed)";
+  return `${name} [${iosDeviceConnectionState(device)}]`;
+}
+
+/**
+ * Pure detection: choose a connectable physical iOS device out of a
+ * `xcrun devicectl list devices --json-output` payload, honoring an optional
+ * requested identifier (`--ios-device` / `ELIZA_IOS_DEVICE_ID`, matched on the
+ * devicectl identifier, hardware UDID, or device name — same keys as
+ * `findDeviceRecord`).
+ *
+ * This replaces the old hardcoded-`n/a` iOS-device lane: the branching that
+ * decides "run the real capture" vs "record an honest n/a with the reason
+ * derived from the actual probe output" is pure and unit-testable here; only
+ * the surrounding {@link captureIosDevice} performs I/O.
+ *
+ * @param {{ result?: { devices?: Array<Record<string, any>> } }} payload
+ * @param {{ requestedId?: string | null }} [options]
+ * @returns {{ device: object | null, reason: string | null, listing: string }}
+ */
+export function selectIosDevice(payload, { requestedId = null } = {}) {
+  const devices = payload?.result?.devices ?? [];
+  const listing = devices.length
+    ? devices.map(iosDeviceLabel).join(", ")
+    : "(none)";
+  if (!devices.length) {
+    return {
+      device: null,
+      reason:
+        "xcrun devicectl list devices reported no paired devices (tether + trust an iPhone first)",
+      listing,
+    };
+  }
+  if (requestedId) {
+    const wanted = requestedId.trim().toLowerCase();
+    const match = devices.find((d) => {
+      const id = String(d?.identifier ?? "").toLowerCase();
+      const udid = String(d?.hardwareProperties?.udid ?? "").toLowerCase();
+      const name = String(d?.deviceProperties?.name ?? "").toLowerCase();
+      return id === wanted || udid === wanted || (name && name === wanted);
+    });
+    if (!match) {
+      return {
+        device: null,
+        reason: `requested iOS device "${requestedId}" not present in devicectl listing (${listing})`,
+        listing,
+      };
+    }
+    if (!CONNECTABLE_IOS_STATES.has(iosDeviceConnectionState(match))) {
+      return {
+        device: null,
+        reason: `requested iOS device "${requestedId}" is not connected (devicectl state: ${iosDeviceConnectionState(match)})`,
+        listing,
+      };
+    }
+    return { device: match, reason: null, listing };
+  }
+  const connectable = devices.find((d) =>
+    CONNECTABLE_IOS_STATES.has(iosDeviceConnectionState(d)),
+  );
+  if (!connectable) {
+    return {
+      device: null,
+      reason: `no connected iOS device on this host (devicectl listing: ${listing})`,
+      listing,
+    };
+  }
+  return { device: connectable, reason: null, listing };
+}
+
+/** Path of the signed, staged device app produced by `ios:device:deploy`
+ * (`ios-device-deploy.mjs` stages to `ios/build/device-deploy-stage/App.app`). */
+const STAGED_DEVICE_APP = join(
+  APP_DIR,
+  "ios",
+  "build",
+  "device-deploy-stage",
+  "App.app",
+);
+
+/**
+ * iOS physical-device walkthrough lane. Mirrors the Android device leg:
+ * detect → preflight the rebuild-before-capture artifact → invoke the proven
+ * on-device capture pipeline; record an honest `captured`/`error`/`n/a`.
+ *
+ * I/O is injectable so the detect/preflight branching is unit-testable without
+ * a tethered device:
+ *   - `onDarwin`        gate (devicectl is macOS-only)
+ *   - `readDeviceList`  → devicectl JSON payload (defaults to the real probe)
+ *   - `stagedAppExists` → staged-app preflight predicate
+ *   - `run`            → per-platform capture script runner
+ */
+export function captureIosDevice({ iosDevice, deps = {} } = {}) {
+  const {
+    onDarwin = process.platform === "darwin",
+    readDeviceList = readDevicectlDeviceList,
+    stagedApp = STAGED_DEVICE_APP,
+    stagedAppExists = (p) => existsSync(p),
+    run = runScript,
+  } = deps;
+
+  if (!onDarwin) {
+    return lane(
+      "n/a",
+      "iOS physical-device capture requires macOS + Xcode devicectl; host is not darwin",
+    );
+  }
+
+  let payload;
+  try {
+    payload = readDeviceList();
+  } catch (error) {
+    return lane(
+      "n/a",
+      `xcrun devicectl list devices failed (Xcode command-line tools/devicectl unavailable): ${error.message}`,
+    );
+  }
+
+  const requestedId = resolveDeviceId({ flagValue: iosDevice ?? null });
+  const { device, reason } = selectIosDevice(payload, { requestedId });
+  if (!device) return lane("n/a", reason);
+
+  const identifier = String(device?.identifier ?? "");
+  const udid = String(device?.hardwareProperties?.udid ?? "");
+  const name = String(device?.deviceProperties?.name ?? "");
+  const deviceKey = identifier || udid;
+
+  if (!stagedAppExists(stagedApp)) {
+    return lane(
+      "n/a",
+      `iPhone "${name || deviceKey}" is connected, but no signed staged app at ${stagedApp} — run \`bun run --cwd packages/app ios:device:deploy\` first (rebuild-before-capture rule; capturing a stale install proves nothing)`,
+      { device: deviceKey },
+    );
+  }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const outputDir = join(
+    APP_DIR,
+    "ios",
+    "build",
+    "boot-capture",
+    `walkthrough-ios-device-${stamp}`,
+  );
+  const code = run("ios-device-capture.mjs", [
+    "--platform",
+    "device",
+    "--device",
+    deviceKey,
+    "--skip-build",
+    "--app-path",
+    stagedApp,
+    "--output",
+    outputDir,
+  ]);
+  return lane(code === 0 ? "captured" : "error", null, {
+    outputDir,
+    note: "On-device XCUITest capture (boot + walkthrough suites) against the signed staged app via ios-device-capture.mjs --platform device; WKWebView has no CDP, so the in-app narrative parity runs through the committed AppUITests/BootCaptureUITests harness. See DEVICE_MATRIX.md.",
+    device: deviceKey,
+    deviceName: name || null,
+    appPath: stagedApp,
+  });
 }
 
 function captureIos({ duration }) {
@@ -312,10 +496,7 @@ async function main() {
   if (want("ios") || args.platform === "all")
     matrix["ios-simulator"] = captureIos({ duration: args.duration });
   if (args.platform === "device")
-    matrix["ios-device"] = lane(
-      "n/a",
-      "iOS physical-device capture requires a tethered, provisioned device + `bun run --cwd packages/app install:ios:sideload`; none detected on this host",
-    );
+    matrix["ios-device"] = captureIosDevice({ iosDevice: args.iosDevice });
   if (want("android") || args.platform === "all")
     matrix["android-emulator"] = await captureAndroid({
       serial: args.serial,

--- a/packages/app/scripts/walkthrough-device-matrix.test.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.test.mjs
@@ -5,12 +5,28 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  captureIosDevice,
   computeExitCode,
   erroredLanes,
+  iosDeviceConnectionState,
   isLaneRequired,
   parseArgs,
   requiredLaneFailures,
+  selectIosDevice,
 } from "./walkthrough-device-matrix.mjs";
+
+const devicectlPayload = (devices) => ({ result: { devices } });
+const iphone = ({
+  identifier = "59EBB356-BC44-5AA2-91F1-E6AAE756BB86",
+  udid = "00008140-000A1D2E3F40001E",
+  name = "MoonCycles",
+  tunnelState = "connected",
+} = {}) => ({
+  identifier,
+  hardwareProperties: { udid },
+  deviceProperties: { name },
+  connectionProperties: { tunnelState },
+});
 
 describe("walkthrough device matrix required lanes", () => {
   it("parses required platforms from env and flags", () => {
@@ -124,6 +140,170 @@ describe("walkthrough device matrix exit code", () => {
     assert.deepEqual(erroredLanes(matrix), []);
     assert.equal(
       computeExitCode(matrix, parseArgs(["--require", "android"], {}).require),
+      1,
+    );
+  });
+});
+
+// #13568: the iOS physical-device lane was hardcoded `n/a` with a canned reason
+// and performed no detection at all. These tests pin the pure detect/branch
+// logic that now decides "run the real on-device capture" vs "record an honest
+// n/a derived from the actual devicectl probe" — no device is touched.
+describe("iOS device detection (selectIosDevice)", () => {
+  it("normalizes the devicectl tunnel/connection state", () => {
+    assert.equal(
+      iosDeviceConnectionState(iphone({ tunnelState: "Connected" })),
+      "connected",
+    );
+    assert.equal(iosDeviceConnectionState({}), "unknown");
+  });
+
+  it("picks the first connected device when none is requested", () => {
+    const payload = devicectlPayload([
+      iphone({ name: "Sleeping", tunnelState: "unavailable" }),
+      iphone({ name: "Live", tunnelState: "connected" }),
+    ]);
+    const { device, reason } = selectIosDevice(payload);
+    assert.equal(reason, null);
+    assert.equal(device.deviceProperties.name, "Live");
+  });
+
+  it("records an honest n/a naming the listing when nothing is connected", () => {
+    const { device, reason } = selectIosDevice(
+      devicectlPayload([iphone({ tunnelState: "disconnected" })]),
+    );
+    assert.equal(device, null);
+    assert.match(reason, /no connected iOS device/);
+    assert.match(reason, /MoonCycles \[disconnected\]/);
+  });
+
+  it("reports no paired devices when the listing is empty", () => {
+    const { device, reason } = selectIosDevice(devicectlPayload([]));
+    assert.equal(device, null);
+    assert.match(reason, /no paired devices/);
+  });
+
+  it("honors a requested id (udid / identifier / name) and requires it be connected", () => {
+    const payload = devicectlPayload([
+      iphone({ name: "A", udid: "UDID-A", tunnelState: "connected" }),
+      iphone({
+        name: "B",
+        identifier: "ID-B",
+        udid: "UDID-B",
+        tunnelState: "connected",
+      }),
+    ]);
+    for (const key of ["UDID-B", "ID-B", "B", "b"]) {
+      const { device } = selectIosDevice(payload, { requestedId: key });
+      assert.equal(device?.deviceProperties?.name, "B", `matched by ${key}`);
+    }
+    const missing = selectIosDevice(payload, { requestedId: "ghost" });
+    assert.equal(missing.device, null);
+    assert.match(missing.reason, /not present in devicectl listing/);
+
+    const asleep = selectIosDevice(
+      devicectlPayload([iphone({ name: "Z", tunnelState: "unavailable" })]),
+      { requestedId: "Z" },
+    );
+    assert.equal(asleep.device, null);
+    assert.match(asleep.reason, /is not connected \(devicectl state: unavailable\)/);
+  });
+});
+
+describe("iOS device lane (captureIosDevice)", () => {
+  const connectedPayload = devicectlPayload([iphone()]);
+
+  it("records n/a off darwin without probing devicectl", () => {
+    let probed = false;
+    const result = captureIosDevice({
+      deps: {
+        onDarwin: false,
+        readDeviceList: () => {
+          probed = true;
+          return connectedPayload;
+        },
+      },
+    });
+    assert.equal(result.status, "n/a");
+    assert.match(result.reason, /macOS/);
+    assert.equal(probed, false);
+  });
+
+  it("records n/a with the devicectl error when the probe throws", () => {
+    const result = captureIosDevice({
+      deps: {
+        onDarwin: true,
+        readDeviceList: () => {
+          throw new Error("xcrun: command not found");
+        },
+      },
+    });
+    assert.equal(result.status, "n/a");
+    assert.match(result.reason, /devicectl.*unavailable/);
+    assert.match(result.reason, /xcrun: command not found/);
+  });
+
+  it("records n/a naming ios:device:deploy when a device is present but the staged app is missing", () => {
+    let ran = false;
+    const result = captureIosDevice({
+      deps: {
+        onDarwin: true,
+        readDeviceList: () => connectedPayload,
+        stagedAppExists: () => false,
+        run: () => {
+          ran = true;
+          return 0;
+        },
+      },
+    });
+    assert.equal(result.status, "n/a");
+    assert.match(result.reason, /ios:device:deploy/);
+    assert.equal(ran, false, "must not attempt capture without the staged app");
+  });
+
+  it("runs the real capture and records `captured` with the output dir when device + staged app are present", () => {
+    let invoked = null;
+    const result = captureIosDevice({
+      iosDevice: null,
+      deps: {
+        onDarwin: true,
+        readDeviceList: () => connectedPayload,
+        stagedApp: "/stage/App.app",
+        stagedAppExists: () => true,
+        run: (rel, argv) => {
+          invoked = { rel, argv };
+          return 0;
+        },
+      },
+    });
+    assert.equal(result.status, "captured");
+    assert.equal(invoked.rel, "ios-device-capture.mjs");
+    assert.deepEqual(
+      [
+        invoked.argv[invoked.argv.indexOf("--platform") + 1],
+        invoked.argv[invoked.argv.indexOf("--device") + 1],
+        invoked.argv[invoked.argv.indexOf("--app-path") + 1],
+      ],
+      ["device", "59EBB356-BC44-5AA2-91F1-E6AAE756BB86", "/stage/App.app"],
+    );
+    assert.ok(invoked.argv.includes("--skip-build"));
+    assert.equal(result.outputDir, invoked.argv[invoked.argv.indexOf("--output") + 1]);
+  });
+
+  it("records `error` (never a false-green) when the on-device capture exits non-zero", () => {
+    const result = captureIosDevice({
+      deps: {
+        onDarwin: true,
+        readDeviceList: () => connectedPayload,
+        stagedApp: "/stage/App.app",
+        stagedAppExists: () => true,
+        run: () => 1,
+      },
+    });
+    assert.equal(result.status, "error");
+    // An attempted-and-errored lane is always fatal, independent of --require.
+    assert.equal(
+      computeExitCode({ "ios-device": result }, new Set()),
       1,
     );
   });

--- a/packages/app/scripts/walkthrough-device-matrix.test.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.test.mjs
@@ -206,7 +206,10 @@ describe("iOS device detection (selectIosDevice)", () => {
       { requestedId: "Z" },
     );
     assert.equal(asleep.device, null);
-    assert.match(asleep.reason, /is not connected \(devicectl state: unavailable\)/);
+    assert.match(
+      asleep.reason,
+      /is not connected \(devicectl state: unavailable\)/,
+    );
   });
 });
 
@@ -287,7 +290,10 @@ describe("iOS device lane (captureIosDevice)", () => {
       ["device", "59EBB356-BC44-5AA2-91F1-E6AAE756BB86", "/stage/App.app"],
     );
     assert.ok(invoked.argv.includes("--skip-build"));
-    assert.equal(result.outputDir, invoked.argv[invoked.argv.indexOf("--output") + 1]);
+    assert.equal(
+      result.outputDir,
+      invoked.argv[invoked.argv.indexOf("--output") + 1],
+    );
   });
 
   it("records `error` (never a false-green) when the on-device capture exits non-zero", () => {
@@ -302,9 +308,6 @@ describe("iOS device lane (captureIosDevice)", () => {
     });
     assert.equal(result.status, "error");
     // An attempted-and-errored lane is always fatal, independent of --require.
-    assert.equal(
-      computeExitCode({ "ios-device": result }, new Set()),
-      1,
-    );
+    assert.equal(computeExitCode({ "ios-device": result }, new Set()), 1);
   });
 });

--- a/packages/app/test/ui-smoke/walkthrough/DEVICE_MATRIX.md
+++ b/packages/app/test/ui-smoke/walkthrough/DEVICE_MATRIX.md
@@ -60,15 +60,33 @@ bun run --cwd packages/app test:e2e:walkthrough:ios
 ### iOS physical device
 
 ```bash
-bun run --cwd packages/app build:ios:local:device
-bun run --cwd packages/app install:ios:sideload
-bun run --cwd packages/app test:e2e:walkthrough:device
+bun run --cwd packages/app ios:device:deploy                 # build + sign + stage App.app FIRST
+bun run --cwd packages/app test:e2e:walkthrough:device       # detects the tethered iPhone + captures
 ```
 
-- **Prereqs (macOS only):** a tethered, provisioned iPhone + the sideload
-  toolchain (`preflight:ios:sideload`).
-- **Skip reason (recorded automatically):** "iOS physical-device capture
-  requires a tethered, provisioned device; none detected on this host".
+- **Prereqs (macOS only):** a tethered, provisioned iPhone in devicectl state
+  `connected`, and the signed staged app at
+  `ios/build/device-deploy-stage/App.app` produced by `ios:device:deploy`
+  (rebuild-before-capture rule — the lane refuses to capture without it). Target
+  a specific device with `--ios-device <id>` or `ELIZA_IOS_DEVICE_ID` (matched on
+  the devicectl identifier, hardware UDID, or device name).
+- **Detection (real, not hardcoded):** the lane runs
+  `xcrun devicectl list devices`, picks a `connected`/`available` device
+  (honoring the requested id), then invokes the proven on-device capture
+  pipeline `ios-device-capture.mjs --platform device --device <id> --skip-build
+  --app-path <staged>` (boot + walkthrough XCUITest suites; WKWebView has no CDP,
+  so the in-app narrative parity runs through the committed
+  AppUITests/BootCaptureUITests harness).
+- **Produces:** an XCUITest attachment dir under
+  `ios/build/boot-capture/walkthrough-ios-device-<stamp>/` (screenshots + AX
+  snapshots), recorded as the lane's `outputDir` in `device-matrix.json`.
+- **Skip reason (recorded automatically, derived from the actual devicectl
+  probe):** "host is not darwin"; "devicectl unavailable: <error>"; "no paired
+  devices"; "no connected iOS device on this host (devicectl listing: …)"; the
+  requested device "not present"/"is not connected (state: …)"; or "connected,
+  but no signed staged app at … — run `ios:device:deploy` first". Unavailable is
+  a non-fatal `n/a`; a device that is present but whose capture breaks records a
+  fatal `error`.
 
 ### Android emulator
 


### PR DESCRIPTION
## Problem

The device-matrix walkthrough runner (`bun run --cwd packages/app test:e2e:walkthrough:device`) **hardcoded** the iOS physical-device lane to `n/a` with a canned "none detected on this host" reason — it performed **no detection at all** (`walkthrough-device-matrix.mjs`, the `matrix["ios-device"] = lane("n/a", …)` branch). So with an iPhone in devicectl state `connected` on the host, the matrix still recorded "none detected", making the honest-status contract of `device-matrix.json` dishonest for iOS and DEVICE_MATRIX.md's "recorded automatically" claim false — even though the real capture pipeline (`ios:device:deploy` → `ios-device-capture.mjs --platform device`) is proven on physical iPhones.

## Fix

Replaced the hardcoded lane with **real detection + invocation**, mirroring the Android device leg:

1. **Detect** — new pure `selectIosDevice(payload, { requestedId })` picks a `connected`/`available` device out of the real `xcrun devicectl list devices` JSON, honoring `--ios-device` / `ELIZA_IOS_DEVICE_ID` (matched on devicectl identifier, hardware UDID, or device name via the same keys as `findDeviceRecord`). No device → honest `n/a` whose reason is derived from the **actual** devicectl listing.
2. **Preflight** — checks the signed staged app at `ios/build/device-deploy-stage/App.app` (what `ios:device:deploy` produces); missing → `n/a` naming the exact deploy command (rebuild-before-capture rule preserved).
3. **Run** — invokes `ios-device-capture.mjs --platform device --device <id> --skip-build --app-path <staged> --output <dir>` (boot + walkthrough XCUITest suites) and records `captured` (with the output dir) / `error`, same shape as the Android leg. An attempted-and-errored lane stays fatal via the existing `erroredLanes`/`computeExitCode` path; an honestly-unavailable host stays a non-fatal `n/a`.
4. Updated DEVICE_MATRIX.md's iOS-physical-device section to describe the real lane and the devicectl-derived skip reasons.

The impure edges (`onDarwin`, `readDeviceList`, `stagedAppExists`, `run`) are dependency-injected so the whole detect/preflight/branch decision tree is unit-tested without a device.

## Validated

- **unit-test-passing** — `node --test walkthrough-device-matrix.test.mjs`: **21/21 pass** (16 pre-existing + 5 new suites). New coverage: state normalization; pick-first-connected; honest-`n/a` reasons (empty listing / none connected / requested-missing / requested-not-connected); requested-id matching by udid/identifier/name; off-darwin short-circuit (no probe); devicectl-throws → `n/a`; device-present-but-no-staged-app → `n/a` (no capture attempted); device+app present → real capture invoked with the exact argv and `captured`; capture-exit-nonzero → `error` (fatal, no false-green).

## Residual (device-gated, out of scope for this pure-code slice)

The end-to-end on-device capture — a tethered provisioned iPhone + a signed staged app actually producing screenshots recorded as `captured` in `device-matrix.json` — requires physical hardware and cannot run in CI. This PR lands the pure, unit-testable **detection + branching** layer that gates that path; the capture invocation itself is exercised via injected `run` in tests and delegates to the already-proven `ios-device-capture.mjs`.

Refs #13568