### PR TITLE
fix: wire iOS device walkthrough matrix

### DIFF
--- a/.github/issue-evidence/13568-ios-device-matrix.md
+++ b/.github/issue-evidence/13568-ios-device-matrix.md
@@ -1,0 +1,44 @@
+# Issue #13568 - iOS Device Matrix Lane
+
+## Change
+
+- Replaced the hardcoded `ios-device` `n/a` result in
+  `packages/app/scripts/walkthrough-device-matrix.mjs` with real
+  `devicectl`-based physical-device selection.
+- The lane now honors `--ios-device` / `ELIZA_IOS_DEVICE_ID`, preflights the
+  staged signed app at `packages/app/ios/build/device-deploy-stage/App.app`,
+  and invokes:
+  `ios-device-capture.mjs --platform device --device <id> --skip-build --app-path <staged App.app> --output <matrix run>/ios-device`.
+- Updated `DEVICE_MATRIX.md` so the iOS physical-device prerequisites, artifact
+  path, and skip reasons match the implementation.
+
+## Verification
+
+- PASS: `git fetch origin && git rebase origin/develop`
+- PASS: `bun install`
+- PASS: `node --check packages/app/scripts/walkthrough-device-matrix.mjs`
+- PASS: `node --test packages/app/scripts/walkthrough-device-matrix.test.mjs`
+  - 16 tests passed, including iOS physical-device selection and honest
+    devicectl-derived `n/a` reasons.
+- PASS:
+  `bunx @biomejs/biome check packages/app/scripts/walkthrough-device-matrix.mjs packages/app/scripts/walkthrough-device-matrix.test.mjs packages/app/test/ui-smoke/walkthrough/DEVICE_MATRIX.md`
+- PASS: `node packages/app/scripts/walkthrough-device-matrix.mjs --platform device --skip-android-drive`
+  - Generated `reports/walkthrough/2026-07-05_02-56-58_devices/device-matrix.json`.
+  - Manually inspected the report: `ios-device` is now `n/a` because `xcrun
+    devicectl list devices` is unavailable on this host, proving the lane
+    probes devicectl instead of returning the old canned no-device reason.
+  - `android-device` is `n/a` because `adb` is not installed.
+- PASS: `git diff --check`
+- FAIL (unrelated repo ratchet): `bun run verify`
+  - Failed in `audit:type-safety-ratchet` before this branch's package checks
+    ran.
+  - Reported existing ratchet deltas:
+    - `as unknown as`: 74 current > 73 baseline
+    - `?? []` in core/agent/app-core: 582 current > 581 baseline
+
+## Not Run
+
+- Real iOS physical-device capture with a connected, provisioned iPhone and
+  staged signed app was not run on this host. That requires full devicectl
+  device availability plus `packages/app/ios/build/device-deploy-stage/App.app`
+  from `install:ios:sideload`.

--- a/packages/app/scripts/walkthrough-device-matrix.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.mjs
@@ -31,9 +31,10 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
 import {
   ensureEmulatorBooted,
   listDevices,
@@ -43,13 +44,20 @@ import {
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const APP_DIR = resolve(dirname(SCRIPT_PATH), "..");
 const REPO_ROOT = resolve(APP_DIR, "../..");
+const IOS_DEVICE_STAGED_APP = join(
+  APP_DIR,
+  "ios",
+  "build",
+  "device-deploy-stage",
+  "App.app",
+);
 
 export function parseArgs(argv, env = process.env) {
   const a = {
     platform: "all",
     serial: env.ANDROID_SERIAL || null,
     avd: null,
-    iosDevice: null,
+    iosDevice: env.ELIZA_IOS_DEVICE_ID || null,
     duration: 30,
     require: parseRequiredPlatforms(env.WALKTHROUGH_REQUIRE),
     driveAndroid: env.WALKTHROUGH_ANDROID_DRIVE !== "0",
@@ -156,6 +164,115 @@ function runScript(rel, args, env = {}) {
 
 function lane(status, reason, extra = {}) {
   return { status, reason, ...extra };
+}
+
+function devicectlDevices(payload) {
+  return Array.isArray(payload?.result?.devices) ? payload.result.devices : [];
+}
+
+function fieldString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normalizedDeviceRecord(device) {
+  return {
+    identifier: fieldString(device?.identifier),
+    udid: fieldString(device?.hardwareProperties?.udid),
+    name: fieldString(device?.deviceProperties?.name),
+    state:
+      fieldString(device?.state) ??
+      fieldString(device?.status) ??
+      fieldString(device?.availability) ??
+      fieldString(device?.connectionProperties?.state) ??
+      fieldString(device?.connectionProperties?.status) ??
+      fieldString(device?.connectionProperties?.pairingState) ??
+      fieldString(device?.connectionProperties?.tunnelState) ??
+      fieldString(device?.visibilityClass),
+    raw: device,
+  };
+}
+
+export function formatDevicectlDeviceList(payload) {
+  const devices = devicectlDevices(payload).map(normalizedDeviceRecord);
+  if (devices.length === 0) return "devicectl returned zero devices";
+  return devices
+    .map((device) => {
+      const name = device.name ?? "(unnamed)";
+      const id = device.identifier ?? "(no identifier)";
+      const udid = device.udid ?? "(no udid)";
+      const state = device.state ?? "state unavailable";
+      return `${name} id=${id} udid=${udid} state=${state}`;
+    })
+    .join("; ");
+}
+
+function deviceMatches(record, wanted) {
+  if (!wanted) return false;
+  const normalized = wanted.toLowerCase();
+  return [record.identifier, record.udid, record.name]
+    .filter(Boolean)
+    .some((value) => value.toLowerCase() === normalized);
+}
+
+export function isDevicectlDeviceUsable(device) {
+  const record = normalizedDeviceRecord(device);
+  if (!record.identifier || !record.udid) return false;
+  const statusValues = [
+    device?.state,
+    device?.status,
+    device?.availability,
+    device?.connectionProperties?.state,
+    device?.connectionProperties?.status,
+    device?.connectionProperties?.pairingState,
+    device?.connectionProperties?.tunnelState,
+    device?.visibilityClass,
+  ]
+    .map((value) => (typeof value === "string" ? value.toLowerCase() : ""))
+    .filter(Boolean);
+  if (statusValues.length === 0) {
+    // Older devicectl JSON shapes list only attached devices and do not expose a
+    // state field. Treat a record with identifier+UDID as usable, but include
+    // the raw listing in any later failure output.
+    return true;
+  }
+  const negative = ["disconnected", "unavailable", "unpaired", "offline"];
+  if (statusValues.some((value) => negative.some((bad) => value.includes(bad))))
+    return false;
+  const positive = ["connected", "available", "paired", "trusted", "enabled"];
+  return statusValues.some((value) =>
+    positive.some((good) => value.includes(good)),
+  );
+}
+
+export function selectIosDeviceForMatrix(payload, requestedDevice = null) {
+  const devices = devicectlDevices(payload);
+  const records = devices.map(normalizedDeviceRecord);
+  const requested = requestedDevice?.trim() || null;
+  if (requested) {
+    const index = records.findIndex((record) =>
+      deviceMatches(record, requested),
+    );
+    if (index < 0) {
+      return {
+        record: null,
+        reason: `requested iOS device "${requested}" was not found in devicectl list: ${formatDevicectlDeviceList(payload)}`,
+      };
+    }
+    if (!isDevicectlDeviceUsable(devices[index])) {
+      return {
+        record: null,
+        reason: `requested iOS device "${requested}" is not connected/available: ${formatDevicectlDeviceList(payload)}`,
+      };
+    }
+    return { record: records[index], reason: null };
+  }
+
+  const index = devices.findIndex((device) => isDevicectlDeviceUsable(device));
+  if (index >= 0) return { record: records[index], reason: null };
+  return {
+    record: null,
+    reason: `no connected/available iOS physical device found in devicectl list: ${formatDevicectlDeviceList(payload)}`,
+  };
 }
 
 function captureIos({ duration }) {
@@ -295,6 +412,55 @@ async function captureAndroid({
   });
 }
 
+function captureIosDevice({ iosDevice, runDir }) {
+  if (process.platform !== "darwin") {
+    return lane("n/a", "iOS physical-device capture requires macOS/devicectl");
+  }
+
+  let payload;
+  try {
+    payload = readDevicectlDeviceList();
+  } catch (error) {
+    return lane(
+      "n/a",
+      `unable to read devicectl device list: ${error?.message ?? String(error)}`,
+    );
+  }
+
+  const selected = selectIosDeviceForMatrix(payload, iosDevice);
+  if (!selected.record) return lane("n/a", selected.reason);
+
+  if (!existsSync(IOS_DEVICE_STAGED_APP)) {
+    return lane(
+      "n/a",
+      `signed iOS device app is missing at ${IOS_DEVICE_STAGED_APP}; run \`bun run --cwd packages/app install:ios:sideload -- --device ${selected.record.identifier}\` before capture`,
+      {
+        device: selected.record,
+        stagedAppPath: IOS_DEVICE_STAGED_APP,
+      },
+    );
+  }
+
+  const outputDir = join(runDir, "ios-device");
+  const code = runScript("ios-device-capture.mjs", [
+    "--platform",
+    "device",
+    "--device",
+    selected.record.identifier,
+    "--skip-build",
+    "--app-path",
+    IOS_DEVICE_STAGED_APP,
+    "--output",
+    outputDir,
+  ]);
+  return lane(code === 0 ? "captured" : "error", null, {
+    outputDir,
+    note: "Physical iOS device capture via ios-device-capture.mjs --platform device --skip-build using the staged signed App.app from install:ios:sideload.",
+    device: selected.record,
+    stagedAppPath: IOS_DEVICE_STAGED_APP,
+  });
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const runId = new Date()
@@ -312,10 +478,10 @@ async function main() {
   if (want("ios") || args.platform === "all")
     matrix["ios-simulator"] = captureIos({ duration: args.duration });
   if (args.platform === "device")
-    matrix["ios-device"] = lane(
-      "n/a",
-      "iOS physical-device capture requires a tethered, provisioned device + `bun run --cwd packages/app install:ios:sideload`; none detected on this host",
-    );
+    matrix["ios-device"] = captureIosDevice({
+      iosDevice: args.iosDevice,
+      runDir,
+    });
   if (want("android") || args.platform === "all")
     matrix["android-emulator"] = await captureAndroid({
       serial: args.serial,

--- a/packages/app/scripts/walkthrough-device-matrix.test.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.test.mjs
@@ -7,9 +7,12 @@ import { describe, it } from "node:test";
 import {
   computeExitCode,
   erroredLanes,
+  formatDevicectlDeviceList,
+  isDevicectlDeviceUsable,
   isLaneRequired,
   parseArgs,
   requiredLaneFailures,
+  selectIosDeviceForMatrix,
 } from "./walkthrough-device-matrix.mjs";
 
 describe("walkthrough device matrix required lanes", () => {
@@ -61,9 +64,11 @@ describe("walkthrough device matrix required lanes", () => {
   it("preserves explicit serials and allows disabling Android drive", () => {
     const args = parseArgs(["--serial", "device-1", "--skip-android-drive"], {
       ANDROID_SERIAL: "env-device",
+      ELIZA_IOS_DEVICE_ID: "env-ios",
     });
 
     assert.equal(args.serial, "device-1");
+    assert.equal(args.iosDevice, "env-ios");
     assert.equal(args.driveAndroid, false);
   });
 });
@@ -125,6 +130,83 @@ describe("walkthrough device matrix exit code", () => {
     assert.equal(
       computeExitCode(matrix, parseArgs(["--require", "android"], {}).require),
       1,
+    );
+  });
+});
+
+describe("walkthrough device matrix iOS physical-device planning (#13568)", () => {
+  const payload = {
+    result: {
+      devices: [
+        {
+          identifier: "DISCONNECTED-ID",
+          hardwareProperties: { udid: "DISCONNECTED-UDID" },
+          deviceProperties: { name: "Old Phone" },
+          state: "disconnected",
+        },
+        {
+          identifier: "CONNECTED-ID",
+          hardwareProperties: { udid: "CONNECTED-UDID" },
+          deviceProperties: { name: "Lane iPhone" },
+          state: "connected",
+        },
+      ],
+    },
+  };
+
+  it("selects a connected iOS device instead of returning hardcoded n/a", () => {
+    const selected = selectIosDeviceForMatrix(payload);
+
+    assert.equal(selected.reason, null);
+    assert.equal(selected.record.identifier, "CONNECTED-ID");
+    assert.equal(selected.record.udid, "CONNECTED-UDID");
+    assert.equal(selected.record.name, "Lane iPhone");
+  });
+
+  it("honors --ios-device by identifier, UDID, or name", () => {
+    for (const requested of ["CONNECTED-ID", "CONNECTED-UDID", "Lane iPhone"]) {
+      const selected = selectIosDeviceForMatrix(payload, requested);
+      assert.equal(selected.record.identifier, "CONNECTED-ID");
+      assert.equal(selected.reason, null);
+    }
+  });
+
+  it("returns an honest devicectl-derived n/a reason for absent or unavailable devices", () => {
+    assert.match(
+      selectIosDeviceForMatrix(payload, "missing-phone").reason,
+      /requested iOS device "missing-phone" was not found/,
+    );
+    assert.match(
+      selectIosDeviceForMatrix(payload, "Old Phone").reason,
+      /not connected\/available/,
+    );
+    assert.match(
+      selectIosDeviceForMatrix({ result: { devices: [] } }).reason,
+      /devicectl returned zero devices/,
+    );
+  });
+
+  it("formats devicectl listings for matrix evidence", () => {
+    const listing = formatDevicectlDeviceList(payload);
+
+    assert.match(listing, /Old Phone id=DISCONNECTED-ID/);
+    assert.match(listing, /Lane iPhone id=CONNECTED-ID/);
+  });
+
+  it("accepts older devicectl records without explicit state when identifier and UDID are present", () => {
+    assert.equal(
+      isDevicectlDeviceUsable({
+        identifier: "LEGACY-ID",
+        hardwareProperties: { udid: "LEGACY-UDID" },
+      }),
+      true,
+    );
+    assert.equal(
+      isDevicectlDeviceUsable({
+        identifier: "NO-UDID",
+        state: "connected",
+      }),
+      false,
     );
   });
 });

--- a/packages/app/test/ui-smoke/walkthrough/DEVICE_MATRIX.md
+++ b/packages/app/test/ui-smoke/walkthrough/DEVICE_MATRIX.md
@@ -65,10 +65,19 @@ bun run --cwd packages/app install:ios:sideload
 bun run --cwd packages/app test:e2e:walkthrough:device
 ```
 
-- **Prereqs (macOS only):** a tethered, provisioned iPhone + the sideload
-  toolchain (`preflight:ios:sideload`).
-- **Skip reason (recorded automatically):** "iOS physical-device capture
-  requires a tethered, provisioned device; none detected on this host".
+- **Prereqs (macOS only):** a tethered, provisioned iPhone visible to
+  `xcrun devicectl list devices`, plus a freshly staged signed app at
+  `packages/app/ios/build/device-deploy-stage/App.app` from
+  `install:ios:sideload`. Pass `--ios-device <devicectl-id|udid|name>` or set
+  `ELIZA_IOS_DEVICE_ID` when more than one phone is attached.
+- **Produces:** `reports/walkthrough/<runId>/ios-device/test-summary.json` and
+  per-shard XCUITest artifacts from
+  `ios-device-capture.mjs --platform device --skip-build --app-path
+  ios/build/device-deploy-stage/App.app`.
+- **Skip reason (recorded automatically):** not macOS, `devicectl` unavailable,
+  no connected/available iOS device in the actual `devicectl` listing, requested
+  device not found/unavailable, or missing staged signed app with the exact
+  sideload command to run first.
 
 ### Android emulator
 


### PR DESCRIPTION
## Summary

Fixes #13568.

- Replace the hardcoded iOS physical-device `n/a` result in `walkthrough-device-matrix.mjs` with real `devicectl` device selection.
- Honor `--ios-device` / `ELIZA_IOS_DEVICE_ID`, preflight the staged signed `ios/build/device-deploy-stage/App.app`, and invoke `ios-device-capture.mjs --platform device --skip-build --app-path ...` into the matrix run output.
- Add pure tests for iOS device selection, unavailable-device reasons, and legacy devicectl JSON shapes.
- Update `DEVICE_MATRIX.md` with the real iOS physical-device prerequisites, output, and skip reasons.

## Evidence

See `.github/issue-evidence/13568-ios-device-matrix.md`.

Verified:

- `git fetch origin && git rebase origin/develop`
- `bun install`
- `node --check packages/app/scripts/walkthrough-device-matrix.mjs`
- `node --test packages/app/scripts/walkthrough-device-matrix.test.mjs`
- `bunx @biomejs/biome check packages/app/scripts/walkthrough-device-matrix.mjs packages/app/scripts/walkthrough-device-matrix.test.mjs packages/app/test/ui-smoke/walkthrough/DEVICE_MATRIX.md`
- `node packages/app/scripts/walkthrough-device-matrix.mjs --platform device --skip-android-drive`
- `git diff --check`

Not green:

- `bun run verify` fails before this branch's package checks in `audit:type-safety-ratchet` with existing repo ratchet deltas: `as unknown as` 74 > 73 and core/agent/app-core `?? []` 582 > 581.

Not run locally:

- Real iOS physical-device capture with a connected provisioned iPhone and staged signed app. This host has `xcrun` but `devicectl` is unavailable, so the local matrix run records an honest `ios-device` `n/a` from the failed devicectl probe.