### PR TITLE
fix(cloud-shared): fail-closed eliza-app auth/onboarding sweep (#13415 slice 3)

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/config.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/config.error-policy.test.ts
@@ -1,0 +1,98 @@
+// Pins the fail-closed error policy of the eliza-app config: the required JWT
+// secret and enabled-but-unconfigured channels must THROW (internal
+// misconfiguration surfaces), while a genuinely-optional, unconfigured channel
+// stays a distinguishable designed-empty value rather than a thrown failure.
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+const TOUCHED_ENV = [
+  "NODE_ENV",
+  "ELIZA_APP_JWT_SECRET",
+  "ELIZA_APP_TELEGRAM_ENABLED",
+  "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+  "ELIZA_APP_DISCORD_ENABLED",
+  "ELIZA_APP_DISCORD_BOT_TOKEN",
+  "ELIZA_APP_DISCORD_APPLICATION_ID",
+  "ELIZA_APP_DISCORD_CLIENT_SECRET",
+  "ELIZA_APP_BLOOIO_ENABLED",
+  "ELIZA_APP_BLOOIO_API_KEY",
+] as const;
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = {};
+  for (const key of TOUCHED_ENV) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of TOUCHED_ENV) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+async function loadConfig() {
+  return import("./config");
+}
+
+describe("eliza-app config fail-closed policy", () => {
+  it("throws when the required JWT secret is missing (jwt getter fails closed)", async () => {
+    const { elizaAppConfig } = await loadConfig();
+    delete process.env.ELIZA_APP_JWT_SECRET;
+    // The secret is required for every session flow; a missing value must
+    // surface as a thrown error, never a silent empty string.
+    expect(() => elizaAppConfig.jwt.secret).toThrow(/ELIZA_APP_JWT_SECRET is not set/);
+  });
+
+  it("returns the JWT secret when set (no failure on the healthy path)", async () => {
+    const { elizaAppConfig } = await loadConfig();
+    process.env.ELIZA_APP_JWT_SECRET = "s3cr3t-value";
+    expect(elizaAppConfig.jwt.secret).toBe("s3cr3t-value");
+  });
+
+  it("validateElizaAppConfig throws when the JWT secret is missing", async () => {
+    const { validateElizaAppConfig } = await loadConfig();
+    delete process.env.ELIZA_APP_JWT_SECRET;
+    expect(() => validateElizaAppConfig()).toThrow(/ELIZA_APP_JWT_SECRET is not set/);
+  });
+
+  it("validateElizaAppConfig throws when a channel is enabled but unconfigured", async () => {
+    const { validateElizaAppConfig } = await loadConfig();
+    process.env.ELIZA_APP_JWT_SECRET = "s3cr3t-value";
+    // Enabled Telegram with no bot token is an internal misconfiguration that
+    // must fail closed, not degrade to an empty token silently at request time.
+    process.env.ELIZA_APP_TELEGRAM_ENABLED = "true";
+    delete process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN;
+    expect(() => validateElizaAppConfig()).toThrow(/Telegram is enabled/);
+
+    // Same fail-closed contract for Discord's required trio.
+    delete process.env.ELIZA_APP_TELEGRAM_ENABLED;
+    process.env.ELIZA_APP_DISCORD_ENABLED = "true";
+    delete process.env.ELIZA_APP_DISCORD_BOT_TOKEN;
+    expect(() => validateElizaAppConfig()).toThrow(/Discord is enabled/);
+  });
+
+  it("designed-empty: an unconfigured optional channel yields empty, NOT a throw, and validation passes", async () => {
+    const { elizaAppConfig, validateElizaAppConfig } = await loadConfig();
+    process.env.NODE_ENV = "test";
+    process.env.ELIZA_APP_JWT_SECRET = "s3cr3t-value";
+    // Telegram is genuinely optional here (not enabled): reading it is a
+    // distinguishable empty value, and validation does not fail closed.
+    expect(elizaAppConfig.telegram.botToken).toBe("");
+    expect(() => elizaAppConfig.telegram.botToken).not.toThrow();
+    expect(() => validateElizaAppConfig()).not.toThrow();
+  });
+
+  it("distinguishes designed-empty (optional, empty) from fail-closed (required, throws)", async () => {
+    const { elizaAppConfig } = await loadConfig();
+    process.env.NODE_ENV = "test";
+    delete process.env.ELIZA_APP_JWT_SECRET;
+    // The two states are not conflated: optional channel -> empty string;
+    // required secret -> thrown error. A caller can tell them apart.
+    expect(elizaAppConfig.telegram.botToken).toBe("");
+    expect(() => elizaAppConfig.jwt.secret).toThrow();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
@@ -1,0 +1,111 @@
+// Pins the fail-closed contract of the connection-enforcement gate: an internal cache/oauth
+// failure must PROPAGATE (throw), and stay distinguishable from a legitimately-negative
+// "no required connection" result. Deterministic fixtures — no live cache or oauth.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const cacheGet = mock();
+const cacheSet = mock();
+const getConnectedPlatforms = mock();
+
+mock.module("../../cache/client", () => ({
+  cache: {
+    get: cacheGet,
+    set: cacheSet,
+    del: mock(async () => {}),
+    delPattern: mock(async () => {}),
+  },
+}));
+
+mock.module("../oauth", () => ({
+  oauthService: {
+    getConnectedPlatforms,
+    initiateAuth: mock(async () => ({ authUrl: null })),
+  },
+}));
+
+mock.module("../../providers/language-model", () => ({
+  getLanguageModel: mock(() => "mock-model"),
+}));
+
+mock.module("../../utils/logger", () => ({
+  logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
+}));
+
+mock.module("ai", () => ({
+  generateText: mock(async () => ({ text: "unused in this suite" })),
+}));
+
+const { connectionEnforcementService } = await import(
+  `./connection-enforcement.ts?test=connection-enforcement-error-policy-${Date.now()}`
+);
+
+const ORG = "org-1";
+const USER = "user-1";
+
+describe("ConnectionEnforcementService.hasRequiredConnection — fail-closed contract", () => {
+  beforeEach(() => {
+    cacheGet.mockReset();
+    cacheSet.mockReset();
+    getConnectedPlatforms.mockReset();
+    cacheSet.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cacheGet.mockReset();
+    cacheSet.mockReset();
+    getConnectedPlatforms.mockReset();
+  });
+
+  test("designed-empty: no connected platforms returns false (distinct from failure)", async () => {
+    cacheGet.mockResolvedValue(null);
+    getConnectedPlatforms.mockResolvedValue([]);
+
+    const result = await connectionEnforcementService.hasRequiredConnection(ORG, USER);
+
+    expect(result).toBe(false);
+    // A legitimately-negative result is cached and returned — not thrown.
+    expect(cacheSet).toHaveBeenCalledTimes(1);
+    expect(cacheSet.mock.calls[0]?.[1]).toBe(false);
+  });
+
+  test("returns true when a required platform is connected", async () => {
+    cacheGet.mockResolvedValue(null);
+    getConnectedPlatforms.mockResolvedValue(["google", "slack"]);
+
+    const result = await connectionEnforcementService.hasRequiredConnection(ORG, USER);
+
+    expect(result).toBe(true);
+    expect(cacheSet.mock.calls[0]?.[1]).toBe(true);
+  });
+
+  test("serves a cached boolean without querying oauth", async () => {
+    cacheGet.mockResolvedValue(false);
+
+    const result = await connectionEnforcementService.hasRequiredConnection(ORG, USER);
+
+    expect(result).toBe(false);
+    expect(getConnectedPlatforms).not.toHaveBeenCalled();
+    expect(cacheSet).not.toHaveBeenCalled();
+  });
+
+  test("PROPAGATES an oauth failure instead of fabricating connected=true (fail closed)", async () => {
+    cacheGet.mockResolvedValue(null);
+    getConnectedPlatforms.mockRejectedValue(new Error("oauth provider down"));
+
+    // Pre-fix this returned `true` (fail-open, bypassing enforcement). Now it must reject.
+    await expect(connectionEnforcementService.hasRequiredConnection(ORG, USER)).rejects.toThrow(
+      "oauth provider down",
+    );
+    // Never caches a fabricated status when the check failed.
+    expect(cacheSet).not.toHaveBeenCalled();
+  });
+
+  test("PROPAGATES a cache read failure instead of assuming connected", async () => {
+    cacheGet.mockRejectedValue(new Error("cache unreachable"));
+
+    await expect(connectionEnforcementService.hasRequiredConnection(ORG, USER)).rejects.toThrow(
+      "cache unreachable",
+    );
+    expect(getConnectedPlatforms).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.ts
@@ -151,16 +151,15 @@ async function loadConversationState(
   organizationId: string,
   userId: string,
 ): Promise<ConversationState> {
-  try {
-    return (
-      (await cache.get<ConversationState>(getConversationKey(organizationId, userId))) ?? {
-        messageCount: 0,
-        messages: [],
-      }
-    );
-  } catch {
-    return { messageCount: 0, messages: [] };
-  }
+  // A cache MISS legitimately yields no history (`?? { empty }`, designed-empty). A cache
+  // read ERROR must propagate — masking it as an empty conversation would silently reset the
+  // nudge cadence and drop history, conflating a broken cache with a brand-new conversation.
+  return (
+    (await cache.get<ConversationState>(getConversationKey(organizationId, userId))) ?? {
+      messageCount: 0,
+      messages: [],
+    }
+  );
 }
 
 async function saveConversationState(
@@ -179,6 +178,9 @@ async function saveConversationState(
       CONVERSATION_TTL_SECONDS,
     );
   } catch (error) {
+    // error-policy:J7 auxiliary continuity write — runs after the user-facing reply is already
+    // produced; a cache write blip must not turn a successful reply into a user error. Warns so
+    // the failure stays observable; the only fallout is a degraded nudge cadence next turn.
     logger.warn("[ConnectionEnforcement] Failed to persist conversation state", {
       organizationId,
       userId,
@@ -315,6 +317,9 @@ async function generateOAuthLinks(
     }),
   );
 
+  // error-policy:J4 designed degrade — fan out per provider and return whichever links
+  // succeeded; one provider's auth-init failure must not deny the user the others. Failures
+  // are warned, and the caller renders whatever links come back (or none if all failed).
   return results.flatMap((result) => {
     if (result.status === "fulfilled" && result.value) {
       return [result.value];
@@ -344,29 +349,24 @@ function detectProviderFromMessage(message: string): RequiredPlatform | null {
 }
 
 class ConnectionEnforcementService {
+  // Fail closed: a connection check that cannot complete throws. Substituting `true` on error
+  // would treat every cache/oauth failure as "already connected" and silently disable the
+  // enforcement gate, letting unconnected tenants through. A genuinely-negative result
+  // (`hasRequired === false`) stays distinct from an internal failure (throws).
   async hasRequiredConnection(organizationId: string, userId: string): Promise<boolean> {
-    try {
-      const cacheKey = getConnectionStatusKey(organizationId, userId);
-      const cached = await cache.get<boolean>(cacheKey);
-      if (typeof cached === "boolean") {
-        return cached;
-      }
-
-      const connectedPlatforms = await oauthService.getConnectedPlatforms(organizationId, userId);
-      const hasRequired = connectedPlatforms.some((platform) =>
-        (REQUIRED_PLATFORMS as readonly string[]).includes(platform),
-      );
-
-      await cache.set(cacheKey, hasRequired, CONNECTION_STATUS_TTL_SECONDS);
-      return hasRequired;
-    } catch (error) {
-      logger.error("[ConnectionEnforcement] Failed to check connections", {
-        organizationId,
-        userId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return true;
+    const cacheKey = getConnectionStatusKey(organizationId, userId);
+    const cached = await cache.get<boolean>(cacheKey);
+    if (typeof cached === "boolean") {
+      return cached;
     }
+
+    const connectedPlatforms = await oauthService.getConnectedPlatforms(organizationId, userId);
+    const hasRequired = connectedPlatforms.some((platform) =>
+      (REQUIRED_PLATFORMS as readonly string[]).includes(platform),
+    );
+
+    await cache.set(cacheKey, hasRequired, CONNECTION_STATUS_TTL_SECONDS);
+    return hasRequired;
   }
 
   async invalidateRequiredConnectionCache(organizationId: string, userId?: string): Promise<void> {
@@ -384,6 +384,9 @@ class ConnectionEnforcementService {
         cache.delPattern(`connection-enforcement:conversation:${organizationId}:*`),
       ]);
     } catch (error) {
+      // error-policy:J6 best-effort cache invalidation — a failed del self-heals when the
+      // 30s status TTL expires (worst case: a just-connected user is nudged once more). The
+      // sole caller (oauth generic-callback) also wraps this in its own boundary handler.
       logger.warn("[ConnectionEnforcement] Failed to invalidate connection cache", {
         organizationId,
         userId,
@@ -458,6 +461,9 @@ class ConnectionEnforcementService {
 
       return result.text;
     } catch (error) {
+      // error-policy:J4 designed user-facing degrade — on model failure, reply with a canned
+      // in-character nudge that still steers the user to connect a data source. This is a
+      // designed fallback response, not fabricated pipeline data; the failure is logged.
       logger.error("[ConnectionEnforcement] LLM generation failed", {
         platform,
         mode,

--- a/packages/cloud/shared/src/lib/services/eliza-app/discord-auth.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/discord-auth.error-policy.test.ts
@@ -1,0 +1,163 @@
+// Pins the fail-closed error contract of discordAuthService.verifyOAuthCode:
+// a genuine auth denial (Discord 400 invalid_grant, or a bot/system account)
+// resolves to null, while every internal failure (unconfigured credentials,
+// Discord 401/403/5xx, malformed response, transport error) throws so the route
+// boundary surfaces a 5xx instead of masking a broken pipeline as "invalid code".
+// Deterministic: real exported service driven through a mocked global fetch.
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { logger } from "../../utils/logger";
+import { discordAuthService } from "./discord-auth";
+
+const REDIRECT_URI = "https://app.example.com/auth/discord/callback";
+const OK_USER = {
+  id: "1234567890",
+  username: "cooluser",
+  discriminator: "0",
+  global_name: "Cool User",
+  avatar: "abc123",
+};
+
+type FetchHandlers = {
+  token?: () => Response | Promise<Response>;
+  user?: () => Response | Promise<Response>;
+};
+
+function installFetch(handlers: FetchHandlers) {
+  globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/oauth2/token")) {
+      if (!handlers.token) throw new Error("unexpected token fetch");
+      return handlers.token();
+    }
+    if (url.includes("/users/@me")) {
+      if (!handlers.user) throw new Error("unexpected user fetch");
+      return handlers.user();
+    }
+    throw new Error(`unexpected fetch to ${url}`);
+  }) as typeof fetch;
+}
+
+const savedFetch = globalThis.fetch;
+const savedAppId = process.env.ELIZA_APP_DISCORD_APPLICATION_ID;
+const savedSecret = process.env.ELIZA_APP_DISCORD_CLIENT_SECRET;
+
+beforeEach(() => {
+  process.env.ELIZA_APP_DISCORD_APPLICATION_ID = "app-id-123";
+  process.env.ELIZA_APP_DISCORD_CLIENT_SECRET = "client-secret-456";
+  spyOn(logger, "error").mockImplementation(() => {});
+  spyOn(logger, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  globalThis.fetch = savedFetch;
+  if (savedAppId === undefined) delete process.env.ELIZA_APP_DISCORD_APPLICATION_ID;
+  else process.env.ELIZA_APP_DISCORD_APPLICATION_ID = savedAppId;
+  if (savedSecret === undefined) delete process.env.ELIZA_APP_DISCORD_CLIENT_SECRET;
+  else process.env.ELIZA_APP_DISCORD_CLIENT_SECRET = savedSecret;
+  mock.restore();
+});
+
+describe("verifyOAuthCode — designed auth-denial resolves to null", () => {
+  test("Discord rejects the grant (HTTP 400) -> null, not a throw", async () => {
+    installFetch({
+      token: () => new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 }),
+    });
+    const result = await discordAuthService.verifyOAuthCode("expired-code", REDIRECT_URI);
+    expect(result).toBeNull();
+  });
+
+  test("bot/system account -> null after a valid token exchange", async () => {
+    installFetch({
+      token: () => new Response(JSON.stringify({ access_token: "tok" }), { status: 200 }),
+      user: () => new Response(JSON.stringify({ ...OK_USER, bot: true }), { status: 200 }),
+    });
+    const result = await discordAuthService.verifyOAuthCode("good-code", REDIRECT_URI);
+    expect(result).toBeNull();
+  });
+});
+
+describe("verifyOAuthCode — internal failure throws (distinct from null)", () => {
+  test("unconfigured client credentials throw (was masked as null)", async () => {
+    delete process.env.ELIZA_APP_DISCORD_APPLICATION_ID;
+    delete process.env.ELIZA_APP_DISCORD_CLIENT_SECRET;
+    // No fetch should even be attempted.
+    installFetch({});
+    await expect(discordAuthService.verifyOAuthCode("any-code", REDIRECT_URI)).rejects.toThrow(
+      /not configured/,
+    );
+  });
+
+  test("Discord token endpoint 5xx throws (outage, not a bad code)", async () => {
+    installFetch({
+      token: () => new Response("upstream boom", { status: 503 }),
+    });
+    await expect(discordAuthService.verifyOAuthCode("good-code", REDIRECT_URI)).rejects.toThrow(
+      /status 503/,
+    );
+  });
+
+  test("token endpoint 401 (our misconfigured client) throws, not null", async () => {
+    installFetch({
+      token: () => new Response(JSON.stringify({ error: "invalid_client" }), { status: 401 }),
+    });
+    await expect(discordAuthService.verifyOAuthCode("good-code", REDIRECT_URI)).rejects.toThrow(
+      /status 401/,
+    );
+  });
+
+  test("200 token response missing access_token throws (protocol violation)", async () => {
+    installFetch({
+      token: () => new Response(JSON.stringify({ token_type: "Bearer" }), { status: 200 }),
+    });
+    await expect(discordAuthService.verifyOAuthCode("good-code", REDIRECT_URI)).rejects.toThrow(
+      /missing access_token/,
+    );
+  });
+
+  test("transport error during token exchange propagates", async () => {
+    installFetch({
+      token: () => {
+        throw new Error("ECONNRESET");
+      },
+    });
+    await expect(discordAuthService.verifyOAuthCode("good-code", REDIRECT_URI)).rejects.toThrow(
+      /ECONNRESET/,
+    );
+  });
+
+  test("user profile endpoint 5xx throws (valid token, internal failure)", async () => {
+    installFetch({
+      token: () => new Response(JSON.stringify({ access_token: "tok" }), { status: 200 }),
+      user: () => new Response("nope", { status: 500 }),
+    });
+    await expect(discordAuthService.verifyOAuthCode("good-code", REDIRECT_URI)).rejects.toThrow(
+      /status 500/,
+    );
+  });
+
+  test("user response missing required fields throws (protocol violation)", async () => {
+    installFetch({
+      token: () => new Response(JSON.stringify({ access_token: "tok" }), { status: 200 }),
+      user: () => new Response(JSON.stringify({ avatar: null }), { status: 200 }),
+    });
+    await expect(discordAuthService.verifyOAuthCode("good-code", REDIRECT_URI)).rejects.toThrow(
+      /missing required fields/,
+    );
+  });
+});
+
+describe("verifyOAuthCode — happy path (proves the success branch is real)", () => {
+  test("valid token + valid human user -> DiscordUserData", async () => {
+    installFetch({
+      token: () => new Response(JSON.stringify({ access_token: "tok" }), { status: 200 }),
+      user: () => new Response(JSON.stringify(OK_USER), { status: 200 }),
+    });
+    const result = await discordAuthService.verifyOAuthCode("good-code", REDIRECT_URI);
+    expect(result).toEqual({
+      id: OK_USER.id,
+      username: OK_USER.username,
+      global_name: OK_USER.global_name,
+      avatar: OK_USER.avatar,
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/discord-auth.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/discord-auth.ts
@@ -46,110 +46,111 @@ interface DiscordApiUser {
 
 class DiscordAuthService {
   /**
-   * Exchange an OAuth2 authorization code for an access token,
-   * then fetch the Discord user profile.
+   * Exchange an OAuth2 authorization code for an access token, then fetch the
+   * Discord user profile.
+   *
+   * Returns `null` ONLY for a genuine authentication denial the caller renders
+   * as "invalid code": Discord rejects the grant (HTTP 400 `invalid_grant` —
+   * expired/reused/wrong code), or the resolved account is a bot/system account.
+   * Every other failure — unconfigured client credentials, a Discord 401/403/5xx
+   * (our misconfig or a Discord outage), a malformed response, or a transport
+   * error — is an internal failure and THROWS so the route boundary surfaces it
+   * as a 5xx. Collapsing those into `null` would mask a broken pipeline as the
+   * user's bad code.
    *
    * @param code - The authorization code from Discord OAuth2 redirect
    * @param redirectUri - The redirect_uri used in the original authorization request
-   * @returns Discord user data, or null if verification fails
+   * @returns Discord user data, or null when the code/account is rejected
    */
   async verifyOAuthCode(code: string, redirectUri: string): Promise<DiscordUserData | null> {
     const { applicationId, clientSecret } = elizaAppConfig.discord;
 
     if (!applicationId || !clientSecret) {
-      logger.error("[DiscordAuth] Application ID or client secret not configured");
-      return null;
+      throw new Error("[DiscordAuth] Discord application id or client secret not configured");
     }
 
-    // Step 1: Exchange authorization code for access token
-    let tokenData: DiscordTokenResponse;
-    try {
-      const tokenResponse = await fetch(`${DISCORD_API_BASE}/oauth2/token`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
-        body: new URLSearchParams({
-          client_id: applicationId,
-          client_secret: clientSecret,
-          grant_type: "authorization_code",
-          code,
-          redirect_uri: redirectUri,
-        }),
-      });
+    // Step 1: Exchange the authorization code for an access token.
+    const tokenResponse = await fetch(`${DISCORD_API_BASE}/oauth2/token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id: applicationId,
+        client_secret: clientSecret,
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+      }),
+    });
 
-      if (!tokenResponse.ok) {
-        const errorText = await tokenResponse.text();
-        logger.warn("[DiscordAuth] Token exchange failed", {
+    if (!tokenResponse.ok) {
+      const errorText = await tokenResponse.text();
+      // 400 is Discord rejecting the grant itself (expired/reused/wrong code) —
+      // the one genuine auth denial. Any other status is our misconfigured
+      // credentials or a Discord outage: an internal failure, not the user's code.
+      if (tokenResponse.status === 400) {
+        logger.warn("[DiscordAuth] Authorization code rejected by Discord", {
           status: tokenResponse.status,
           error: errorText.slice(0, 200),
         });
         return null;
       }
-
-      const rawToken = (await tokenResponse.json()) as Partial<DiscordTokenResponse>;
-      if (!rawToken.access_token) {
-        logger.error("[DiscordAuth] Invalid token response - missing access_token");
-        return null;
-      }
-      tokenData = rawToken as DiscordTokenResponse;
-    } catch (error) {
-      logger.error("[DiscordAuth] Token exchange request failed", {
-        error: error instanceof Error ? error.message : String(error),
+      logger.error("[DiscordAuth] Token exchange failed", {
+        status: tokenResponse.status,
+        error: errorText.slice(0, 200),
       });
-      return null;
+      throw new Error(
+        `[DiscordAuth] Discord token endpoint returned status ${tokenResponse.status}`,
+      );
     }
 
-    // Step 2: Fetch user profile using the access token
-    try {
-      const userResponse = await fetch(`${DISCORD_API_BASE}/users/@me`, {
-        headers: {
-          Authorization: `Bearer ${tokenData.access_token}`,
-        },
+    const rawToken = (await tokenResponse.json()) as Partial<DiscordTokenResponse>;
+    if (!rawToken.access_token) {
+      throw new Error("[DiscordAuth] Discord token response missing access_token");
+    }
+    const tokenData = rawToken as DiscordTokenResponse;
+
+    // Step 2: Fetch the user profile with the access token. We now hold a valid
+    // token, so any failure here is internal (transport/Discord/protocol) — never
+    // a user-supplied-code problem — and must surface, not degrade to "invalid code".
+    const userResponse = await fetch(`${DISCORD_API_BASE}/users/@me`, {
+      headers: {
+        Authorization: `Bearer ${tokenData.access_token}`,
+      },
+    });
+
+    if (!userResponse.ok) {
+      const errorText = await userResponse.text();
+      logger.error("[DiscordAuth] User profile fetch failed", {
+        status: userResponse.status,
+        error: errorText.slice(0, 200),
       });
+      throw new Error(`[DiscordAuth] Discord user endpoint returned status ${userResponse.status}`);
+    }
 
-      if (!userResponse.ok) {
-        const errorText = await userResponse.text();
-        logger.warn("[DiscordAuth] User profile fetch failed", {
-          status: userResponse.status,
-          error: errorText.slice(0, 200),
-        });
-        return null;
-      }
+    const discordUser = (await userResponse.json()) as DiscordApiUser;
 
-      const discordUser = (await userResponse.json()) as DiscordApiUser;
+    if (!discordUser.id || !discordUser.username) {
+      throw new Error("[DiscordAuth] Discord user response missing required fields");
+    }
 
-      // Validate required fields
-      if (!discordUser.id || !discordUser.username) {
-        logger.warn("[DiscordAuth] Missing required user fields", {
-          hasId: !!discordUser.id,
-          hasUsername: !!discordUser.username,
-        });
-        return null;
-      }
-
-      // Reject bot/system accounts
-      if (discordUser.bot || discordUser.system) {
-        logger.warn("[DiscordAuth] Bot or system account rejected", {
-          id: discordUser.id,
-          bot: discordUser.bot,
-          system: discordUser.system,
-        });
-        return null;
-      }
-
-      return {
+    // Bot/system accounts are a designed rejection, distinct from a failure.
+    if (discordUser.bot || discordUser.system) {
+      logger.warn("[DiscordAuth] Bot or system account rejected", {
         id: discordUser.id,
-        username: discordUser.username,
-        global_name: discordUser.global_name,
-        avatar: discordUser.avatar,
-      };
-    } catch (error) {
-      logger.error("[DiscordAuth] User profile request failed", {
-        error: error instanceof Error ? error.message : String(error),
+        bot: discordUser.bot,
+        system: discordUser.system,
       });
       return null;
     }
+
+    return {
+      id: discordUser.id,
+      username: discordUser.username,
+      global_name: discordUser.global_name,
+      avatar: discordUser.avatar,
+    };
   }
 
   /**

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
@@ -1,0 +1,140 @@
+// Pins the fail-closed contract of the onboarding phone-link path: a genuine
+// linkPhoneToUser infra failure must PROPAGATE out of runOnboardingChat, while
+// its designed tenant-safety decline (success:false) stays a distinguishable
+// non-throwing outcome that lets onboarding continue. Deterministic lib
+// fixtures (no live model, no network).
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as realCloudBindings from "../../runtime/cloud-bindings";
+
+const sessionCache = new Map<string, unknown>();
+const ensureElizaAppProvisioning = mock();
+const getElizaAppProvisioningStatus = mock();
+const linkPhoneToUser = mock();
+const generateText = mock();
+const launchManagedElizaAgent = mock();
+let cloudEnv: Record<string, string | undefined> = {};
+const REAL_CLOUD_BINDINGS = { ...realCloudBindings };
+
+mock.module("../../cache/client", () => ({
+  cache: {
+    get: mock(async (key: string) => sessionCache.get(key) ?? null),
+    set: mock(async (key: string, value: unknown) => {
+      sessionCache.set(key, value);
+    }),
+  },
+}));
+
+mock.module("../../runtime/cloud-bindings", () => ({
+  ...REAL_CLOUD_BINDINGS,
+  getCloudAwareEnv: mock(() => cloudEnv),
+}));
+
+mock.module("@ai-sdk/openai", () => ({
+  createOpenAI: mock(() => ({ chat: mock(() => "mock-model") })),
+  openai: mock(() => "mock-openai-model"),
+}));
+
+mock.module("ai", () => ({
+  generateText,
+}));
+
+mock.module("../eliza-managed-launch", () => ({
+  launchManagedElizaAgent,
+}));
+
+mock.module("./provisioning", () => ({
+  ensureElizaAppProvisioning,
+  getElizaAppProvisioningStatus,
+}));
+
+mock.module("./user-service", () => ({
+  elizaAppUserService: {
+    linkPhoneToUser,
+  },
+}));
+
+const { runOnboardingChat } = await import(
+  `./onboarding-chat.ts?test=onboarding-error-policy-${Date.now()}`
+);
+
+const PHONE = "+14155550123";
+const PLATFORM_SESSION = `platform:blooio:${PHONE}`;
+
+function provisioning() {
+  return { status: "provisioning", agentId: "agent-1", bridgeUrl: null, sandbox: null };
+}
+
+function authedTrustedPhoneTurn() {
+  return runOnboardingChat({
+    message: "My name is Sam",
+    platform: "blooio",
+    platformUserId: PHONE,
+    sessionId: PLATFORM_SESSION,
+    trustedPlatformIdentity: true,
+    authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+  });
+}
+
+describe("onboarding-chat phone-link error policy", () => {
+  beforeEach(() => {
+    sessionCache.clear();
+    ensureElizaAppProvisioning.mockReset();
+    getElizaAppProvisioningStatus.mockReset();
+    linkPhoneToUser.mockReset();
+    generateText.mockReset();
+    launchManagedElizaAgent.mockReset();
+    ensureElizaAppProvisioning.mockResolvedValue(provisioning());
+    getElizaAppProvisioningStatus.mockResolvedValue(provisioning());
+    cloudEnv = {};
+  });
+
+  afterEach(() => {
+    cloudEnv = process.env;
+  });
+
+  afterAll(() => {
+    mock.module("../../runtime/cloud-bindings", () => REAL_CLOUD_BINDINGS);
+  });
+
+  test("a genuine linkPhoneToUser infra failure PROPAGATES (fail closed, never swallowed)", async () => {
+    linkPhoneToUser.mockRejectedValue(new Error("db connection reset"));
+
+    await expect(authedTrustedPhoneTurn()).rejects.toThrow("db connection reset");
+
+    // The link ran; the throw was not turned into a healthy-looking result.
+    expect(linkPhoneToUser).toHaveBeenCalledWith("user-1", PHONE);
+    // Fail-closed on the link means we never advanced to provisioning this turn.
+    expect(ensureElizaAppProvisioning).not.toHaveBeenCalled();
+  });
+
+  test("a designed tenant-safety decline (success:false) stays distinct: onboarding continues, no throw", async () => {
+    linkPhoneToUser.mockResolvedValue({
+      success: false,
+      error: "This phone number is already linked to another account",
+    });
+
+    const result = await authedTrustedPhoneTurn();
+
+    expect(linkPhoneToUser).toHaveBeenCalledWith("user-1", PHONE);
+    // A business decline is NOT an internal failure — the turn resolves with a
+    // real reply and proceeds through provisioning.
+    expect(typeof result.reply).toBe("string");
+    expect(result.reply.length).toBeGreaterThan(0);
+    expect(result.requiresLogin).toBe(false);
+    expect(ensureElizaAppProvisioning).toHaveBeenCalledWith({
+      userId: "user-1",
+      organizationId: "org-1",
+    });
+    expect(result.provisioning.status).toBe("provisioning");
+  });
+
+  test("a successful link is transparent: onboarding proceeds normally", async () => {
+    linkPhoneToUser.mockResolvedValue({ success: true });
+
+    const result = await authedTrustedPhoneTurn();
+
+    expect(linkPhoneToUser).toHaveBeenCalledWith("user-1", PHONE);
+    expect(result.reply.length).toBeGreaterThan(0);
+    expect(result.provisioning.status).toBe("provisioning");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -326,12 +326,22 @@ async function maybeLinkAuthenticatedPlatformIdentity(
   const phoneNumber = session.platformUserId;
   if (!phoneNumber) return session;
 
-  try {
-    await elizaAppUserService.linkPhoneToUser(input.authenticatedUser.userId, phoneNumber);
-  } catch (error) {
-    logger.warn("[eliza-app onboarding] phone link after login failed", {
+  // linkPhoneToUser returns success:false only for the designed tenant-safety
+  // decline (the phone is already bound to a different account); a genuine
+  // DB/infra failure throws and must propagate — leaving a messaging identity
+  // silently unlinked is a broken pipeline this onboarding domain fails closed
+  // on. It runs on every eligible turn, so a transient throw self-heals on the
+  // next attempt once a boundary has surfaced it.
+  const linkResult = await elizaAppUserService.linkPhoneToUser(
+    input.authenticatedUser.userId,
+    phoneNumber,
+  );
+  if (!linkResult.success) {
+    // error-policy:J4 expected tenant-safety decline (phone owned by another
+    // account); onboarding continues without binding the identity.
+    logger.warn("[eliza-app onboarding] phone link declined", {
       userId: input.authenticatedUser.userId,
-      error: error instanceof Error ? error.message : String(error),
+      error: linkResult.error,
     });
   }
 
@@ -480,6 +490,9 @@ State:
     if (!sanitized) return fallbackReply(args);
     return args.requiresLogin ? ensureExactLoginUrl(sanitized, args.loginUrl) : sanitized;
   } catch (error) {
+    // error-policy:J4 the model is a non-essential enhancement over the always-
+    // valid deterministic fallbackReply; an LLM/transport failure degrades to
+    // that designed reply instead of failing the onboarding turn.
     logger.warn("[eliza-app onboarding] generation failed; using fallback", {
       error: error instanceof Error ? error.message : String(error),
     });
@@ -536,6 +549,8 @@ async function copyTranscriptToManagedAgent(session: OnboardingSession): Promise
     );
 
     if (!rememberResponse.ok) {
+      // error-policy:J6 best-effort read of the error body to enrich the error
+      // we throw next; a failed body read must not mask the non-ok status.
       const body = await rememberResponse.text().catch(() => "");
       throw new Error(`memory copy failed (${rememberResponse.status}) ${body.slice(0, 200)}`);
     }
@@ -550,6 +565,9 @@ async function copyTranscriptToManagedAgent(session: OnboardingSession): Promise
       copied: true,
     };
   } catch (error) {
+    // error-policy:J4 handoff copy is retried on every turn until it lands;
+    // returning copied:false keeps handoffComplete false — a distinguishable
+    // not-yet-copied state, never a fabricated success.
     logger.warn("[eliza-app onboarding] handoff memory copy failed", {
       agentId: session.agentId,
       error: error instanceof Error ? error.message : String(error),

--- a/packages/cloud/shared/src/lib/services/eliza-app/provisioning.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/provisioning.error-policy.test.ts
@@ -1,0 +1,148 @@
+// Pins the fail-closed error policy of eliza-app provisioning: an internal
+// provisioning failure must PROPAGATE (and the compensating teardown must never
+// mask it), while a legitimately-drained org stays a distinguishable
+// designed-empty `insufficient_credits` status rather than a thrown failure.
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { agentSandboxesRepository } from "../../../db/repositories/agent-sandboxes";
+import { containersEnv as actualContainersEnv } from "../../config/containers-env";
+import { elizaSandboxService } from "../eliza-sandbox";
+
+const listByOrganization = mock();
+const createAgent = mock();
+const enqueueAgentProvision = mock();
+const deleteSandbox = mock();
+const hasElizaAppInitialFreeCredits = mock();
+const addCredits = mock();
+const checkAgentCreditGate = mock();
+
+const deleteSandboxSpy = spyOn(agentSandboxesRepository, "delete").mockImplementation(
+  (...args) => deleteSandbox(...args) as never,
+);
+
+// Spread the real containersEnv so this process-global mock.module only overrides
+// defaultAgentImage; bun's mock.module leaks across files in a single process.
+mock.module("../../config/containers-env", () => ({
+  containersEnv: {
+    ...actualContainersEnv,
+    defaultAgentImage: () => "ghcr.io/elizaos/eliza:stable",
+  },
+}));
+
+const listByOrganizationSpy = spyOn(
+  agentSandboxesRepository,
+  "listByOrganization",
+).mockImplementation((...args) => listByOrganization(...args) as never);
+
+mock.module("../../../db/repositories/credit-transactions", () => ({
+  creditTransactionsRepository: { hasElizaAppInitialFreeCredits },
+}));
+
+mock.module("../credits", () => ({
+  creditsService: { addCredits },
+}));
+
+const createAgentSpy = spyOn(elizaSandboxService, "createAgent").mockImplementation(
+  (...args) => createAgent(...args) as never,
+);
+
+mock.module("../provisioning-jobs", () => ({
+  provisioningJobService: { enqueueAgentProvision },
+}));
+
+mock.module("../agent-billing-gate", () => ({ checkAgentCreditGate }));
+
+afterAll(() => {
+  listByOrganizationSpy.mockRestore();
+  createAgentSpy.mockRestore();
+  deleteSandboxSpy.mockRestore();
+});
+
+const { ensureElizaAppProvisioning } = await import(
+  `./provisioning.ts?test=provisioning-error-policy-${Date.now()}`
+);
+
+describe("ensureElizaAppProvisioning error policy", () => {
+  beforeEach(() => {
+    listByOrganization.mockReset();
+    createAgent.mockReset();
+    enqueueAgentProvision.mockReset();
+    deleteSandbox.mockReset();
+    hasElizaAppInitialFreeCredits.mockReset();
+    addCredits.mockReset();
+    checkAgentCreditGate.mockReset();
+  });
+
+  test("propagates the real enqueue failure even when the compensating delete ALSO fails (teardown never masks the cause)", async () => {
+    hasElizaAppInitialFreeCredits.mockResolvedValue(true);
+    listByOrganization.mockResolvedValue([]);
+    checkAgentCreditGate.mockResolvedValue({ allowed: true, balance: 5 });
+    createAgent.mockResolvedValue({
+      agent: { id: "agent-1", status: "pending", bridge_url: null },
+      idempotent: false,
+    });
+    // The enqueue is the primary failure the caller must see.
+    enqueueAgentProvision.mockRejectedValue(new Error("queue down"));
+    // The compensating teardown itself fails — it must NOT swallow or replace the
+    // original enqueue error.
+    deleteSandbox.mockRejectedValue(new Error("db connection reset"));
+
+    await expect(
+      ensureElizaAppProvisioning({ organizationId: "org-1", userId: "user-1" }),
+    ).rejects.toThrow("queue down");
+
+    // The teardown was still attempted (best-effort), and provisioning did not
+    // fabricate a healthy status from the failure.
+    expect(deleteSandbox).toHaveBeenCalledWith("agent-1", "org-1");
+  });
+
+  test("still propagates enqueue failure and deletes the orphan when the teardown succeeds", async () => {
+    hasElizaAppInitialFreeCredits.mockResolvedValue(true);
+    listByOrganization.mockResolvedValue([]);
+    checkAgentCreditGate.mockResolvedValue({ allowed: true, balance: 5 });
+    createAgent.mockResolvedValue({
+      agent: { id: "agent-1", status: "pending", bridge_url: null },
+      idempotent: false,
+    });
+    enqueueAgentProvision.mockRejectedValue(new Error("queue down"));
+    deleteSandbox.mockResolvedValue(true);
+
+    await expect(
+      ensureElizaAppProvisioning({ organizationId: "org-1", userId: "user-1" }),
+    ).rejects.toThrow("queue down");
+    expect(deleteSandbox).toHaveBeenCalledWith("agent-1", "org-1");
+  });
+
+  test("designed-empty stays distinct from failure: a drained org returns insufficient_credits, never throws and never provisions", async () => {
+    hasElizaAppInitialFreeCredits.mockResolvedValue(true);
+    listByOrganization.mockResolvedValue([]);
+    checkAgentCreditGate.mockResolvedValue({ allowed: false, balance: 0 });
+
+    const result = await ensureElizaAppProvisioning({
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    // A legitimately-drained org is NOT an internal failure: it is a distinguishable
+    // status, not a thrown error and not fabricated provisioning.
+    expect(result).toEqual({
+      status: "insufficient_credits",
+      agentId: null,
+      bridgeUrl: null,
+      sandbox: null,
+    });
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+  });
+
+  test("an internal repository failure while reading status PROPAGATES (not swallowed to a healthy-empty status)", async () => {
+    // A DB read failure must surface as a throw, never degrade to status:"none"
+    // (which would look like a legitimately un-provisioned org).
+    hasElizaAppInitialFreeCredits.mockResolvedValue(true);
+    listByOrganization.mockRejectedValue(new Error("sandbox lookup failed"));
+
+    await expect(
+      ensureElizaAppProvisioning({ organizationId: "org-1", userId: "user-1" }),
+    ).rejects.toThrow("sandbox lookup failed");
+    expect(createAgent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/provisioning.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/provisioning.ts
@@ -139,7 +139,18 @@ export async function ensureElizaAppProvisioning(params: {
         agentName: DEFAULT_AGENT_NAME,
       });
     } catch (err) {
-      await agentSandboxesRepository.delete(sandbox.id, params.organizationId);
+      // error-policy:J6 best-effort teardown of the just-created row so the reuse
+      // guard can't hand this job-less sandbox back forever. The compensating
+      // delete must never mask the real enqueue failure: the original error is
+      // always rethrown, and a failed cleanup is only logged.
+      await agentSandboxesRepository
+        .delete(sandbox.id, params.organizationId)
+        .catch((cleanupErr) => {
+          logger.error(
+            "[eliza-app provisioning] Failed to delete stranded sandbox row after enqueue failure",
+            { agentId: sandbox.id, orgId: params.organizationId, cleanupErr },
+          );
+        });
       throw err;
     }
   }

--- a/packages/cloud/shared/src/lib/services/eliza-app/session-service.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/session-service.error-policy.test.ts
@@ -1,0 +1,93 @@
+// Pins the fail-closed error policy of the JWT session service: an invalid
+// bearer token yields the designed null "invalid session" signal, while an
+// internal config failure (missing JWT secret) PROPAGATES rather than being
+// masked as a null denial. Drives the real service (real jose + real config
+// getter reading process.env), no mocks.
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+const SECRET = "test-jwt-secret-error-policy-abc123";
+
+let savedSecret: string | undefined;
+
+beforeEach(() => {
+  savedSecret = process.env.ELIZA_APP_JWT_SECRET;
+  process.env.ELIZA_APP_JWT_SECRET = SECRET;
+});
+
+afterEach(() => {
+  if (savedSecret === undefined) delete process.env.ELIZA_APP_JWT_SECRET;
+  else process.env.ELIZA_APP_JWT_SECRET = savedSecret;
+});
+
+describe("ElizaAppSessionService error policy", () => {
+  it("round-trips a real session: created token validates back to its claims", async () => {
+    const { elizaAppSessionService } = await import("./session-service");
+
+    const { token } = await elizaAppSessionService.createSession("user-1", "org-1", {
+      telegramId: "tg-9",
+    });
+
+    const validated = await elizaAppSessionService.validateSession(token);
+    expect(validated).not.toBeNull();
+    expect(validated?.userId).toBe("user-1");
+    expect(validated?.organizationId).toBe("org-1");
+    expect(validated?.telegramId).toBe("tg-9");
+  });
+
+  it("designed-invalid: a malformed/tampered token yields null (fail-closed deny), not a throw", async () => {
+    const { elizaAppSessionService } = await import("./session-service");
+
+    // Untrusted input (J3): jwtVerify rejects this. Expected result is the
+    // explicit null "not a valid session" signal.
+    const bogus = await elizaAppSessionService.validateSession("not-a-real-jwt.at.all");
+    expect(bogus).toBeNull();
+
+    // A token signed with a different secret is likewise an invalid token → null.
+    const { SignJWT } = await import("jose");
+    const foreign = await new SignJWT({ userId: "u", organizationId: "o" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuer("eliza-app")
+      .setAudience("eliza-app-users")
+      .setExpirationTime("1h")
+      .sign(new TextEncoder().encode("a-different-secret-entirely"));
+    expect(await elizaAppSessionService.validateSession(foreign)).toBeNull();
+  });
+
+  it("valid-but-underspecified token (missing required claims) yields null, distinct from a valid session", async () => {
+    const { elizaAppSessionService } = await import("./session-service");
+    const { SignJWT } = await import("jose");
+
+    // Correctly signed with OUR secret, but missing userId/organizationId.
+    const token = await new SignJWT({ somethingElse: "x" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuer("eliza-app")
+      .setAudience("eliza-app-users")
+      .setExpirationTime("1h")
+      .sign(new TextEncoder().encode(SECRET));
+
+    expect(await elizaAppSessionService.validateSession(token)).toBeNull();
+  });
+
+  it("internal failure PROPAGATES: a missing JWT secret throws instead of masking as null", async () => {
+    const { elizaAppSessionService } = await import("./session-service");
+
+    // Mint a valid token first while the secret is present...
+    const { token } = await elizaAppSessionService.createSession("user-2", "org-2");
+    expect(await elizaAppSessionService.validateSession(token)).not.toBeNull();
+
+    // ...then remove the secret. getSecretKey() now throws inside the config
+    // getter (requireEnv). This is a server misconfiguration, NOT an invalid
+    // token: it must surface as a thrown error, never a null "denied".
+    delete process.env.ELIZA_APP_JWT_SECRET;
+
+    await expect(elizaAppSessionService.validateSession(token)).rejects.toThrow(
+      /ELIZA_APP_JWT_SECRET/,
+    );
+
+    // validateAuthHeader delegates to validateSession, so the config failure
+    // propagates through it too (rather than degrading to a null denial).
+    await expect(elizaAppSessionService.validateAuthHeader(`Bearer ${token}`)).rejects.toThrow(
+      /ELIZA_APP_JWT_SECRET/,
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/session-service.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/session-service.ts
@@ -91,8 +91,12 @@ class ElizaAppSessionService {
   }
 
   async validateSession(token: string): Promise<ValidatedSession | null> {
+    // Resolve the signing key outside the untrusted-input boundary: a missing
+    // JWT secret is a server misconfiguration that must surface (route J1 → 500),
+    // not be swallowed and returned as a null "invalid token" (which reads as 401).
+    const secretKey = this.getSecretKey();
     try {
-      const { payload } = await jwtVerify(token, this.getSecretKey(), {
+      const { payload } = await jwtVerify(token, secretKey, {
         issuer: JWT_ISSUER,
         audience: JWT_AUDIENCE,
       });
@@ -111,6 +115,9 @@ class ElizaAppSessionService {
         phoneNumber: payload.phoneNumber,
       };
     } catch (error) {
+      // error-policy:J3 untrusted bearer token — jwtVerify throws on expired,
+      // tampered, or malformed tokens; null is the explicit fail-closed "not a
+      // valid session" signal, distinct from the config failure raised above.
       logger.debug("[ElizaAppSession] Token validation failed", { error });
       return null;
     }

--- a/packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts
@@ -1,0 +1,114 @@
+// Pins the fail-closed error policy of ElizaAppUserService.findOrCreateByDiscordId:
+// a real failure while linking a phone (tenant-identity write) must propagate, while a
+// cosmetic profile-refresh failure degrades to success. Deterministic repository fixtures.
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const findByDiscordIdWithOrganization = mock();
+const findByPhoneNumberWithOrganization = mock();
+const update = mock();
+
+mock.module("../../../db/repositories/users", () => ({
+  usersRepository: {
+    findByDiscordIdWithOrganization,
+    findByPhoneNumberWithOrganization,
+    findByTelegramIdWithOrganization: mock(),
+    findByEmailWithOrganization: mock(),
+    findByWhatsAppIdWithOrganization: mock(),
+    findWithOrganization: mock(),
+    update,
+    create: mock(),
+  },
+}));
+
+mock.module("../../../db/repositories/organizations", () => ({
+  organizationsRepository: {
+    findBySlug: mock(async () => undefined),
+    create: mock(),
+  },
+}));
+
+mock.module("../../utils/email-validation", () => ({
+  isValidEmail: mock(() => true),
+  maskEmailForLogging: mock((email: string) => email),
+}));
+
+mock.module("../../utils/logger", () => ({
+  logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
+}));
+
+mock.module("../../utils/phone-normalization", () => ({
+  normalizePhoneNumber: mock((phone: string) => phone),
+}));
+
+mock.module("../api-keys", () => ({ apiKeysService: { create: mock() } }));
+mock.module("../credits", () => ({ creditsService: { addCredits: mock() } }));
+mock.module("../signup-code", () => ({ redeemSignupCode: mock() }));
+
+const { elizaAppUserService } = await import("./user-service");
+
+function uniqueConstraintError(): Error {
+  return Object.assign(new Error("duplicate key value violates unique constraint"), {
+    code: "23505",
+  });
+}
+
+describe("ElizaAppUserService.findOrCreateByDiscordId error policy", () => {
+  beforeEach(() => {
+    findByDiscordIdWithOrganization.mockReset();
+    findByPhoneNumberWithOrganization.mockReset();
+    update.mockReset();
+    // Phone is unowned by default so the phone-link branch is reachable.
+    findByPhoneNumberWithOrganization.mockResolvedValue(undefined);
+  });
+
+  test("propagates a real DB failure while linking a phone (fail closed)", async () => {
+    findByDiscordIdWithOrganization.mockResolvedValue({
+      id: "user-1",
+      discord_id: "d1",
+      discord_username: "olduser",
+      phone_number: null,
+      organization: { id: "org-1" },
+    });
+    update.mockRejectedValue(new Error("connection terminated unexpectedly"));
+
+    await expect(
+      elizaAppUserService.findOrCreateByDiscordId("d1", { username: "newuser" }, "+15551234567"),
+    ).rejects.toThrow("connection terminated unexpectedly");
+
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  test("maps a unique-constraint collision on the phone link to PHONE_ALREADY_LINKED", async () => {
+    findByDiscordIdWithOrganization.mockResolvedValue({
+      id: "user-1",
+      discord_id: "d1",
+      discord_username: "olduser",
+      phone_number: null,
+      organization: { id: "org-1" },
+    });
+    update.mockRejectedValue(uniqueConstraintError());
+
+    await expect(
+      elizaAppUserService.findOrCreateByDiscordId("d1", { username: "newuser" }, "+15551234567"),
+    ).rejects.toThrow("PHONE_ALREADY_LINKED");
+  });
+
+  test("degrades a cosmetic-only profile-refresh failure to success (distinguishable)", async () => {
+    findByDiscordIdWithOrganization.mockResolvedValue({
+      id: "user-2",
+      discord_id: "d2",
+      discord_username: "old-name",
+      phone_number: "+15550000000",
+      organization: { id: "org-2" },
+    });
+    update.mockRejectedValue(new Error("connection terminated unexpectedly"));
+
+    const result = await elizaAppUserService.findOrCreateByDiscordId("d2", {
+      username: "new-name",
+    });
+
+    expect(result.isNew).toBe(false);
+    expect(result.user.id).toBe("user-2");
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/user-service.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/user-service.ts
@@ -573,13 +573,19 @@ class ElizaAppUserService {
             phoneAdded: !!normalizedPhone && !existingUser.phone_number,
           });
         } catch (error) {
-          if (isUniqueConstraintError(error)) {
-            // Phone unique constraint hit - another user has this phone
-            if (normalizedPhone) {
+          // A phone link is a tenant-identity write, not a cosmetic refresh. When this
+          // update is adding a phone, a unique constraint means another account owns it
+          // (surface the conflict) and any other failure must propagate — swallowing it
+          // would return success while the refetch below reads back as "no phone".
+          const linkingPhone = !!normalizedPhone && !existingUser.phone_number;
+          if (linkingPhone) {
+            if (isUniqueConstraintError(error)) {
               throw new Error("PHONE_ALREADY_LINKED");
             }
+            throw error;
           }
-          // Profile update is non-critical - log warning and continue with stale data
+          // error-policy:J4 cosmetic Discord profile refresh (username/global name/avatar)
+          // is best-effort; a stale display field degrades gracefully rather than block login.
           logger.warn(
             "[ElizaAppUserService] Failed to update Discord profile, continuing with stale data",
             {
@@ -1039,7 +1045,8 @@ class ElizaAppUserService {
             updated_at: new Date(),
           });
         } catch (error) {
-          // Non-critical - log warning and continue with stale data
+          // error-policy:J4 cosmetic WhatsApp display-name refresh is best-effort; a
+          // stale name degrades gracefully rather than block message handling.
           logger.warn("[ElizaAppUserService] Failed to update WhatsApp name", {
             userId: existingWhatsAppUser.id,
             error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Slice 3 of #13415 — eliza-app auth/onboarding fallback-slop sweep

**Fixes real fail-open auth bugs:**
- **`discord-auth.verifyOAuthCode`** swallowed every failure (unconfigured creds, Discord 401/403/5xx, malformed response, transport error) into `null`, which `route.ts` maps to **401 "Invalid or expired authorization code"** — telling the user their code is bad when Discord is down or *we* are misconfigured. Now `null` is returned **only** for a genuine denial (Discord 400 `invalid_grant`, or a bot/system account); everything else throws to `route.ts:351` `catch → failureResponse` (J1 boundary) as a 5xx. Caller-handling verified.
- **`user-service.findOrCreateByDiscordId`** swallowed a real DB error during a phone link and silently dropped the phone; now propagates (unique-constraint → typed `PHONE_ALREADY_LINKED`), cosmetic display-field refresh kept best-effort (J4).
- `connection-enforcement` / `onboarding-chat` / `provisioning` / `session-service`: fail-closed fixes + J-annotations.

**Money guard honored:** `user-service` signup-code credit redemption left untouched (flagged for dedicated billing coverage); `config.ts` already fails closed (test-only).

**Verification:** 35 error-path tests pass (each proves failure-propagates vs designed-empty stay distinguishable, driving the real functions); existing eliza-app suites 79 pass / 0 fail; biome clean; `audit:error-policy-ratchet` → "no new fallback-slop". Security-sensitive auth code — flagged for review, not solo-merge.