### PR TITLE
fix: reconcile projectId in orchestrator task DTO<->client contract (develop-red)

### DIFF
--- a/packages/ui/src/api/client-agent-coding-agent-status.test.ts
+++ b/packages/ui/src/api/client-agent-coding-agent-status.test.ts
@@ -22,6 +22,7 @@ function thread(overrides: Partial<CodingAgentTaskThread> = {}) {
     latestSessionLabel: "Worker",
     latestWorkdir: "/repo",
     latestRepo: null,
+    projectId: null,
     latestActivityAt: Date.now(),
     decisionCount: 0,
     usage: {

--- a/packages/ui/src/api/client-types-cloud.ts
+++ b/packages/ui/src/api/client-types-cloud.ts
@@ -911,6 +911,10 @@ export interface CodingAgentTaskThread {
   latestSessionLabel: string | null;
   latestWorkdir: string | null;
   latestRepo: string | null;
+  /** Registered project this task is bound to (null = unbound). Present on the
+   * summary so the task list can group by project without fetching each task's
+   * detail (#13776). */
+  projectId: string | null;
   latestActivityAt: number | null;
   decisionCount: number;
   usage: CodingAgentTaskUsageSummary;
@@ -1085,8 +1089,6 @@ export interface CodingAgentTaskThreadDetail extends CodingAgentTaskThread {
   roomId: string | null;
   taskRoomId: string | null;
   worldId: string | null;
-  /** The project this task is bound to; null for pre-project tasks (#13776). */
-  projectId: string | null;
   ownerUserId: string | null;
   parentTaskId: string | null;
   acceptanceCriteria: string[];

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-mapper-contract.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-mapper-contract.test.ts
@@ -223,6 +223,7 @@ const clientThreadReference: CodingAgentTaskThread = {
   latestSessionLabel: "worker",
   latestWorkdir: "/repo",
   latestRepo: "owner/repo",
+  projectId: "project-1",
   latestActivityAt: 1,
   decisionCount: 1,
   usage: {


### PR DESCRIPTION
## Problem

`plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-mapper-contract.test.ts` was failing on `develop`:

```
AssertionError: thread: expected [ 'activeSessionCount', …(21) ] to deeply equal [ 'activeSessionCount', …(20) ]
+   "projectId",
```

The #13776 project-entity work (merged via #13815 / #13851) added `projectId` to the **server** task-summary DTO (`TaskThreadDto`) and to `toTaskThread` (`projectId: doc.task.projectId ?? null`), and to the **client detail** type (`CodingAgentTaskThreadDetail`) — but the **client summary** type `CodingAgentTaskThread` and the contract test's `clientThreadReference` fixture never received it. The mapper-contract test's runtime key-set comparison (`expectSameKeys`) therefore saw the mapper emit an extra `projectId` key that the client reference lacked, and failed.

## Fix

Reconcile server and client so the contract holds (server DTO shape == client type shape); the key comparison is **not** weakened.

- `packages/ui/src/api/client-types-cloud.ts`: add required `projectId: string | null` to `CodingAgentTaskThread`, mirroring the server `TaskThreadDto` (which always emits it). Removed the now-redundant redeclaration from `CodingAgentTaskThreadDetail` — it inherits the field from the base interface.
- `plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-mapper-contract.test.ts`: add `projectId: "project-1"` to `clientThreadReference` (the detail fixture already carried it).
- `packages/ui/src/api/client-agent-coding-agent-status.test.ts`: add `projectId: null` to the `thread()` summary helper (which builds a `CodingAgentTaskThread` via `satisfies`) so it keeps compiling with the field now required.

## Verification

- `bun run --cwd plugins/plugin-agent-orchestrator test __tests__/unit/orchestrator-task-mapper-contract.test.ts` -> **7 passed** (was 1 failed).
- `bun run --cwd packages/ui test client-agent-coding-agent-status.test.ts` -> 2 passed.
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` -> 36 pre-existing errors, **0 new** (byte-identical to the merge-base baseline; none cite the changed files).
- `bun run --cwd packages/ui typecheck` -> 1164 pre-existing errors, **0 new**.
- Biome check on all 3 changed files: clean.

Pre-existing typecheck errors are unrelated missing-`.d.ts` noise (drizzle-orm, git-workspace-service, coding-agent-adapters) from the local dist-symlinked `node_modules`; captured as a before/after baseline diff to confirm this change adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)