### PR TITLE
fix(app-core): /api/plugins load-deadline — 503+Retry-After during registry cold-load (#13859)

### DIFF
--- a/packages/app-core/src/api/server-plugins-route-deadline.test.ts
+++ b/packages/app-core/src/api/server-plugins-route-deadline.test.ts
@@ -1,0 +1,29 @@
+/**
+ * resolveWithinDeadline (#13859): the /api/plugins cold-start guard. A pending
+ * lazy-import resolves null at the deadline (route answers 503 + Retry-After)
+ * instead of holding the socket open; a settled promise passes through
+ * untouched, and a rejection propagates (never masked as a timeout).
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveWithinDeadline } from "./server";
+
+describe("resolveWithinDeadline", () => {
+  it("returns the value when the promise settles inside the deadline", async () => {
+    await expect(
+      resolveWithinDeadline(Promise.resolve("warm"), 1_000),
+    ).resolves.toBe("warm");
+  });
+
+  it("returns null when the promise is still pending at the deadline", async () => {
+    const never = new Promise<string>(() => {});
+    await expect(resolveWithinDeadline(never, 25)).resolves.toBeNull();
+  });
+
+  it("propagates rejection instead of converting it into a timeout null", async () => {
+    const boom = Promise.reject(new Error("registry import failed"));
+    await expect(resolveWithinDeadline(boom, 1_000)).rejects.toThrow(
+      "registry import failed",
+    );
+  });
+});

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -204,6 +204,30 @@ function getPluginRegistryApi(): Promise<
   return pluginRegistryApiPromise;
 }
 
+/** How long a /api/plugins request waits for the lazy plugin-registry module
+ * before answering 503 (the import keeps loading; retries land once warm). */
+export const PLUGIN_REGISTRY_LOAD_DEADLINE_MS = 2_000;
+
+/** Resolve `promise` or null after `ms` — never rejects from the timer side.
+ * Exported for tests (#13859). */
+export async function resolveWithinDeadline<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<T | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), ms);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 import {
   clearCloudSecrets,
   getCloudSecret,
@@ -960,8 +984,23 @@ const COMPAT_ROUTE_CHAIN: readonly CompatRouteChainEntry[] = [
       if (!url.pathname.startsWith("/api/plugins")) {
         return false;
       }
-      const { handlePluginsCompatRoutes } = await getPluginRegistryApi();
-      return handlePluginsCompatRoutes(req, res, state);
+      // error-policy:J4 explicit user-facing degrade — while the heavyweight
+      // registry module is cold-loading (boot window), holding the socket open
+      // starves every /api/plugins poller into proxy "socket hang up" loops
+      // (#13859). Answer 503 + Retry-After instead; the memoized import keeps
+      // loading and the client's next poll lands 200 once warm.
+      const registryApi = await resolveWithinDeadline(
+        getPluginRegistryApi(),
+        PLUGIN_REGISTRY_LOAD_DEADLINE_MS,
+      );
+      if (registryApi === null) {
+        res.setHeader("Retry-After", "2");
+        sendJsonResponse(res, 503, {
+          error: "Plugin registry is still loading",
+        });
+        return true;
+      }
+      return registryApi.handlePluginsCompatRoutes(req, res, state);
     },
   },
   {


### PR DESCRIPTION
Fixes #13859 (found during #13406 local-install QA; root-cause analysis on the issue).

**Bug:** `/api/plugins` awaits the deliberately-lazy `@elizaos/plugin-registry` import with no deadline → during the boot window every request holds its socket until the vite proxy kills it (`socket hang up` loops, `usePluginsSkillsState` starving in 10s-timeout cycles).

**Fix:** `resolveWithinDeadline` races the memoized import against 2s. Cold → **503 + Retry-After: 2** (designed unavailable state per the UI three-state rule; import keeps loading, next poll lands 200). Warm → untouched. Import rejection → propagates (never masked as timeout). Annotated `error-policy:J4`.

**Evidence:** unit tests 3/3 (settle-inside / pending-at-deadline / rejection-propagates) · live dev restart on patched tree: first probe **200 in 4.3s**, zero proxy hang-ups through the boot window (pre-fix log in #13859 shows the hang-up loop) · warm steady-state unchanged (~1.3s incl. registry work).

[qa-agent]