### PR TITLE
test(cloud-shared): stabilize eliza app mock exports

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
@@ -25,6 +25,7 @@ mock.module("../oauth", () => ({
 
 mock.module("../../providers/language-model", () => ({
   getLanguageModel: mock(() => "mock-model"),
+  hasLanguageModelProviderConfigured: mock(() => true),
 }));
 
 mock.module("../../utils/logger", () => ({

--- a/packages/cloud/shared/src/lib/services/eliza-app/provisioning.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/provisioning.error-policy.test.ts
@@ -39,6 +39,7 @@ mock.module("../../../db/repositories/credit-transactions", () => ({
 
 mock.module("../credits", () => ({
   creditsService: { addCredits },
+  InsufficientCreditsError: class InsufficientCreditsError extends Error {},
 }));
 
 const createAgentSpy = spyOn(elizaSandboxService, "createAgent").mockImplementation(

--- a/packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts
@@ -41,7 +41,10 @@ mock.module("../../utils/phone-normalization", () => ({
 }));
 
 mock.module("../api-keys", () => ({ apiKeysService: { create: mock() } }));
-mock.module("../credits", () => ({ creditsService: { addCredits: mock() } }));
+mock.module("../credits", () => ({
+  creditsService: { addCredits: mock() },
+  InsufficientCreditsError: class InsufficientCreditsError extends Error {},
+}));
 mock.module("../signup-code", () => ({ redeemSignupCode: mock() }));
 
 const { elizaAppUserService } = await import("./user-service");


### PR DESCRIPTION
## Summary
- Extends eliza-app test mocks so process-global Bun mocks preserve the exports required by later imports in the focused error-policy suite.
- Fixes the merged #13888 focused combined test run failing from leaked partial mocks for credits and language-model providers.

## Verification
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts packages/cloud/shared/src/lib/services/eliza-app/provisioning.error-policy.test.ts packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts --no-errors-on-unmatched`
- `bun test packages/cloud/shared/src/lib/services/eliza-app/config.error-policy.test.ts packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts packages/cloud/shared/src/lib/services/eliza-app/discord-auth.error-policy.test.ts packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts packages/cloud/shared/src/lib/services/eliza-app/provisioning.error-policy.test.ts packages/cloud/shared/src/lib/services/eliza-app/session-service.error-policy.test.ts packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts` (35 pass, 0 fail)
- `git diff --check origin/develop...HEAD && git diff --check`