### PR TITLE
fix(#13773): clean ACP scratch workdirs

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-scratch-lifecycle.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-scratch-lifecycle.test.ts
@@ -1,0 +1,117 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdir, utimes } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { AcpService, computeSessionWorkdir } from "../services/acp-service.js";
+import { InMemorySessionStore } from "../services/session-store.js";
+import type { SessionInfo } from "../services/types.js";
+
+type ScratchLifecycleShim = {
+  removeOwnedScratchWorkdir(session: SessionInfo): Promise<void>;
+  cleanOrphanedScratchWorkdirs(): Promise<void>;
+};
+
+function makeRuntime(settings: Record<string, string> = {}): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-4000-8000-00000013773a",
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    reportError() {},
+    getSetting: (key: string) => settings[key],
+  } as never;
+}
+
+function makeSession(
+  id: string,
+  workdir: string,
+  metadata?: Record<string, unknown>,
+): SessionInfo {
+  const now = new Date();
+  return {
+    id,
+    name: id,
+    agentType: "codex",
+    workdir,
+    status: "running",
+    approvalPreset: "on-request",
+    createdAt: now,
+    lastActivityAt: now,
+    metadata,
+  };
+}
+
+describe("ACP scratch workspace lifecycle", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("removes only metadata-owned isolated task workdirs", async () => {
+    const root = mkdtempSync(join(tmpdir(), "acp-scratch-owned-"));
+    roots.push(root);
+    const owned = computeSessionWorkdir(root, "owned", true);
+    const unowned = join(root, "manual");
+    await mkdir(owned, { recursive: true });
+    await mkdir(unowned, { recursive: true });
+    const service = new AcpService(makeRuntime(), {
+      store: new InMemorySessionStore(),
+    });
+    const shim = service as unknown as ScratchLifecycleShim;
+
+    await shim.removeOwnedScratchWorkdir(
+      makeSession("owned", owned, {
+        isolatedWorkdir: true,
+        workdirRoot: root,
+      }),
+    );
+    await shim.removeOwnedScratchWorkdir(makeSession("manual", unowned));
+
+    expect(existsSync(owned)).toBe(false);
+    expect(existsSync(unowned)).toBe(true);
+  });
+
+  it("garbage-collects old untracked task dirs but keeps tracked and fresh dirs", async () => {
+    const root = mkdtempSync(join(tmpdir(), "acp-scratch-gc-"));
+    roots.push(root);
+    const store = new InMemorySessionStore();
+    const service = new AcpService(
+      makeRuntime({ ELIZA_ACP_WORKSPACE_ROOT: root }),
+      {
+        store,
+      },
+    );
+    const shim = service as unknown as ScratchLifecycleShim;
+    const oldOrphan = join(root, "task-old-orphan");
+    const tracked = join(root, "task-tracked");
+    const fresh = join(root, "task-fresh");
+    const manual = join(root, "manual-old");
+    await Promise.all([
+      mkdir(oldOrphan, { recursive: true }),
+      mkdir(tracked, { recursive: true }),
+      mkdir(fresh, { recursive: true }),
+      mkdir(manual, { recursive: true }),
+    ]);
+    const oldDate = new Date(Date.now() - 48 * 60 * 60_000);
+    await Promise.all([
+      utimes(oldOrphan, oldDate, oldDate),
+      utimes(manual, oldDate, oldDate),
+    ]);
+    await store.create(
+      makeSession("tracked", tracked, {
+        isolatedWorkdir: true,
+        workdirRoot: root,
+      }),
+    );
+
+    await shim.cleanOrphanedScratchWorkdirs();
+
+    expect(existsSync(oldOrphan)).toBe(false);
+    expect(existsSync(tracked)).toBe(true);
+    expect(existsSync(fresh)).toBe(true);
+    expect(existsSync(manual)).toBe(true);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -16,16 +16,15 @@
  */
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
-import { mkdir, readdir, rm, stat, unlink, writeFile } from "node:fs/promises";
+import { type Dirent, existsSync } from "node:fs";
+import { mkdir, readdir, rm, stat, unlink } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { join, resolve, sep } from "node:path";
 import {
   SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE as CORE_SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE,
   type IAgentRuntime,
   Service,
 } from "@elizaos/core";
-import { isAndroidMobile } from "@elizaos/shared";
 import { NativeAcpClient } from "./acp-native-transport.js";
 import { augmentTaskWithDeployGuidance } from "./app-deploy-guidance.js";
 import {
@@ -64,24 +63,13 @@ import {
   resolveVendoredOpencodeAcpCommand,
 } from "./opencode-config.js";
 import {
-  isParentAgentBrokerWired,
-  PARENT_AGENT_BROKER_MANIFEST_ENTRY,
-} from "./parent-agent-broker.js";
-import {
   AcpSessionStore,
   InMemorySessionStore,
   type SessionStoreBackend,
 } from "./session-store.js";
-import { buildSkillsManifest } from "./skill-manifest.js";
 import { writeWorkspaceIdentity } from "./sub-agent-identity.js";
-import {
-  appendSubagentStdout,
-  isSubagentStdoutLoggingEnabled,
-  subagentStdoutLogPath,
-} from "./subagent-stdout-log.js";
 import { normalizeTaskAgentAdapter } from "./task-agent-routing.js";
 import {
-  type AcpCapacity,
   type AcpEventCallback,
   type AcpJsonRpcMessage,
   type AcpToolCall,
@@ -90,11 +78,9 @@ import {
   type AvailableAgentInfo,
   type PromptResult,
   type SendOptions,
-  SessionCapError,
   type SessionEventCallback,
   type SessionEventName,
   type SessionInfo,
-  type SessionSlotClass,
   type SessionStore,
   type SpawnOptions,
   type SpawnResult,
@@ -181,24 +167,10 @@ export function computeSessionWorkdir(
 ): string {
   return isolate ? resolve(base, `task-${sessionId}`) : resolve(base);
 }
-
-/**
- * True iff `workdir` is a throwaway scratch dir AcpService itself created under
- * its default temp root — a `task-<sessionId>` directory directly beneath
- * DEFAULT_WORKDIR_ROOT (`$TMPDIR/eliza-acp`). This is the ownership guard for
- * every destructive reclaim (teardown rm + startup GC): a self-checkout
- * (`process.cwd()`), an explicit route/opt-in workdir, and a git-worktree
- * workspace the service was handed all live elsewhere, so a reclaim keyed on
- * this predicate can never delete a directory the service does not own. Pure +
- * exported so the guarantee is unit-testable.
- */
-export function isOwnedScratchDir(workdir: string): boolean {
-  const resolved = resolve(workdir);
-  return (
-    dirname(resolved) === resolve(DEFAULT_WORKDIR_ROOT) &&
-    basename(resolved).startsWith("task-")
-  );
-}
+const ACP_SCRATCH_ORPHAN_MAX_AGE_MS = 24 * 60 * 60_000;
+const ACP_SCRATCH_DIR_PREFIX = "task-";
+const ACP_METADATA_ISOLATED_WORKDIR = "isolatedWorkdir";
+const ACP_METADATA_WORKDIR_ROOT = "workdirRoot";
 const MAX_CAPTURED_TOOL_OUTPUT_CHARS = 12_000;
 const TOOL_OUTPUT_END_MARKER = "[/tool output]";
 const ACP_HEALTH_CHECK_INTERVAL_MS = 60_000;
@@ -215,13 +187,6 @@ const ACP_MIDFLIGHT_SESSION_STATUSES: ReadonlySet<string> = new Set([
   "tool_running",
 ]);
 const ACP_STALE_LOCK_MAX_AGE_MS = 10 * 60_000;
-// Startup GC only reclaims an UNTRACKED `task-*` scratch dir (no owning session
-// in this instance's store) once it is older than this — a conservative floor
-// so a co-tenant AcpService sharing the same $TMPDIR/eliza-acp root never has
-// its live-but-idle scratch nuked. Dirs whose session IS terminal in this store
-// are unambiguously ours and reclaimed regardless of age. Overridable via
-// ELIZA_ACP_SCRATCH_GC_MAX_AGE_MS. 24h mirrors ACP_REVERSE_ORPHAN_MAX_AGE_MS.
-const ACP_SCRATCH_GC_MAX_AGE_MS = 24 * 60 * 60_000;
 // Untracked acpx stream files older than this get unlinked. Real spawns
 // finalize their store entry in seconds; 24h is grace for in-flight spawns.
 const ACP_REVERSE_ORPHAN_MAX_AGE_MS = 24 * 60 * 60_000;
@@ -329,12 +294,6 @@ export class AcpService extends Service {
   private readonly transportMode: "native" | "cli";
   private readonly defaultAgent: AgentType;
   private readonly maxSessions: number;
-  // Reserved slots for short-lived `system` spawns (the #8898 read-only
-  // verifier) that must NOT compete for a worker slot: at full worker cap the
-  // verifier needs a fresh session while the worker it is verifying still holds
-  // its slot (orchestrator sessions keep the slot after task_complete), so
-  // counting them together deadlocks validation. Counted against a separate pool.
-  private readonly systemHeadroom: number;
   // Serializes the session-limit check-and-reserve so concurrent spawns can't
   // each pass the limit check before any has inserted (which would overshoot
   // ELIZA_ACP_MAX_SESSIONS). A promise-chain mutex: each reservation awaits the
@@ -349,16 +308,6 @@ export class AcpService extends Service {
   private readonly nativeCancelledPromptSessionIds = new Set<string>();
   private readonly nativeStoppingSessionIds = new Set<string>();
   private readonly outputBuffers = new Map<string, string[]>();
-  // Sessions whose raw stdout has been teed to disk at least once. Drives the
-  // `task_complete` stdoutLogPath reference: only sessions that actually wrote a
-  // file get the path attached, so the task document never points at a
-  // never-created log. Populated by persistRawStdout; gated by trajectory
-  // recording.
-  private readonly persistedStdoutSessions = new Set<string>();
-  // Raw stdout arrives on the subprocess stream, while task completion is parsed
-  // from that same stream. Queue writes per session so the terminal event can
-  // wait for the tee before persisting a task document that references it.
-  private readonly pendingStdoutWrites = new Map<string, Promise<void>>();
   // Per-session model-gateway lease (#11536 E2 residual). Minted at spawn when
   // gateway mode + a lease broker are configured; the leased token (not the
   // static ELIZA_MODEL_GATEWAY_TOKEN) is injected into the child env, and the
@@ -400,8 +349,6 @@ export class AcpService extends Service {
       "fixed";
     this.maxSessions =
       parsePositiveInt(this.setting("ELIZA_ACP_MAX_SESSIONS")) ?? 8;
-    this.systemHeadroom =
-      parsePositiveInt(this.setting("ELIZA_ACP_SYSTEM_SESSION_HEADROOM")) ?? 2;
     this.sessionTimeoutMs = parsePositiveInt(
       this.setting("ACPX_DEFAULT_TIMEOUT_MS") ??
         this.setting("ELIZA_ACP_PROMPT_TIMEOUT_MS"),
@@ -431,7 +378,7 @@ export class AcpService extends Service {
       defaultApprovalPreset: this.defaultApprovalPreset,
     });
     await this.reconcileOrphanedSessions();
-    await this.gcOrphanedScratchDirs();
+    await this.cleanOrphanedScratchWorkdirs();
     await this.cleanReverseOrphanedAcpxFiles();
     await this.cleanStaleLocks();
     this.healthCheckTimer = setInterval(() => {
@@ -453,6 +400,149 @@ export class AcpService extends Service {
       process.once("SIGTERM", AcpService.sharedShutdownHandler);
       process.once("SIGINT", AcpService.sharedShutdownHandler);
       AcpService.shutdownHookInstalled = true;
+    }
+  }
+
+  private configuredScratchRoots(): string[] {
+    const roots = [
+      this.setting("ELIZA_ACP_WORKSPACE_ROOT"),
+      this.setting("ACPX_DEFAULT_CWD"),
+      this.setting("ELIZA_WORKSPACE_DIR"),
+      this.setting("ELIZA_CODING_WORKSPACE"),
+      this.setting("ELIZA_CODING_DIRECTORY"),
+      DEFAULT_WORKDIR_ROOT,
+    ];
+    return Array.from(
+      new Set(
+        roots
+          .filter((value): value is string => Boolean(value?.trim()))
+          .map((value) => {
+            const trimmed = value.trim();
+            return resolve(
+              trimmed === "~" || trimmed.startsWith("~/")
+                ? join(homedir(), trimmed.slice(2))
+                : trimmed,
+            );
+          }),
+      ),
+    );
+  }
+
+  private isPathUnderRoot(candidate: string, root: string): boolean {
+    const resolved = resolve(candidate);
+    const resolvedRoot = resolve(root);
+    return (
+      resolved === resolvedRoot || resolved.startsWith(`${resolvedRoot}${sep}`)
+    );
+  }
+
+  private isOwnedIsolatedWorkdir(session: SessionInfo): boolean {
+    if (session.metadata?.[ACP_METADATA_ISOLATED_WORKDIR] === true) {
+      return true;
+    }
+    const root = session.metadata?.[ACP_METADATA_WORKDIR_ROOT];
+    return (
+      typeof root === "string" &&
+      this.isPathUnderRoot(session.workdir, root) &&
+      session.workdir.endsWith(`${ACP_SCRATCH_DIR_PREFIX}${session.id}`)
+    );
+  }
+
+  private async removeOwnedScratchWorkdir(session: SessionInfo): Promise<void> {
+    if (!this.isOwnedIsolatedWorkdir(session)) return;
+    const root =
+      typeof session.metadata?.[ACP_METADATA_WORKDIR_ROOT] === "string"
+        ? session.metadata[ACP_METADATA_WORKDIR_ROOT]
+        : undefined;
+    if (!root || !this.isPathUnderRoot(session.workdir, root)) {
+      this.log("warn", "scratch cleanup refused: workdir outside root", {
+        sessionId: session.id,
+        workdir: session.workdir,
+        root,
+      });
+      return;
+    }
+    try {
+      await rm(session.workdir, { recursive: true, force: true });
+      this.log("debug", "removed isolated ACP scratch workdir", {
+        sessionId: session.id,
+        workdir: session.workdir,
+      });
+    } catch (err) {
+      // error-policy:J6 best-effort scratch-dir teardown; retain the session
+      // record/state and retry via later delete/GC paths rather than failing the
+      // user-visible close.
+      this.log("warn", "failed to remove isolated ACP scratch workdir", {
+        sessionId: session.id,
+        workdir: session.workdir,
+        err,
+      });
+    }
+  }
+
+  private async cleanOrphanedScratchWorkdirs(): Promise<void> {
+    let sessions: SessionInfo[];
+    try {
+      sessions = await this.store.list();
+    } catch (err) {
+      this.runtime.reportError("AcpService.cleanOrphanedScratchWorkdirs", err, {
+        phase: "store.list",
+      });
+      this.log("warn", "scratch GC: store read failed, skipping delete pass", {
+        err,
+      });
+      return;
+    }
+    const tracked = new Set(
+      sessions.map((session) => resolve(session.workdir)),
+    );
+    let removed = 0;
+    let kept = 0;
+    const cutoff = Date.now() - ACP_SCRATCH_ORPHAN_MAX_AGE_MS;
+
+    for (const root of this.configuredScratchRoots()) {
+      let entries: Dirent<string>[];
+      try {
+        entries = await readdir(root, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        if (
+          !entry.isDirectory() ||
+          !entry.name.startsWith(ACP_SCRATCH_DIR_PREFIX)
+        ) {
+          continue;
+        }
+        const candidate = resolve(root, entry.name);
+        if (tracked.has(candidate)) {
+          kept++;
+          continue;
+        }
+        try {
+          const st = await stat(candidate);
+          if (st.mtimeMs > cutoff) {
+            kept++;
+            continue;
+          }
+          await rm(candidate, { recursive: true, force: true });
+          removed++;
+        } catch (err) {
+          kept++;
+          this.log("warn", "scratch GC: skipped candidate", {
+            path: candidate,
+            err,
+          });
+        }
+      }
+    }
+
+    if (removed > 0 || kept > 0) {
+      this.log("info", "scratch GC complete", {
+        removed,
+        kept,
+        olderThanMs: ACP_SCRATCH_ORPHAN_MAX_AGE_MS,
+      });
     }
   }
 
@@ -622,121 +712,6 @@ export class AcpService extends Service {
     }
   }
 
-  // Delete the per-session scratch dir spawnSession mkdir'd, but ONLY when it is
-  // one we own (a `task-<id>` dir under $TMPDIR/eliza-acp — see isOwnedScratchDir).
-  // A self-checkout cwd, a route/explicit workdir, or a handed-in git-worktree
-  // workspace is never touched. Best-effort: a failed rm on teardown must not
-  // block session close — the startup GC reclaims the dir on the next boot.
-  private async reclaimOwnedScratchDir(session: SessionInfo): Promise<void> {
-    if (!isOwnedScratchDir(session.workdir)) return;
-    try {
-      await rm(session.workdir, { recursive: true, force: true });
-      this.log("debug", "reclaimed session scratch dir", {
-        sessionId: session.id,
-        workdir: session.workdir,
-      });
-    } catch (err) {
-      // error-policy:J6 best-effort scratch reclaim on teardown; surface the
-      // failure so the leak is observable, then let the startup GC retry it.
-      this.log("warn", "failed to reclaim session scratch dir", {
-        sessionId: session.id,
-        workdir: session.workdir,
-        error: errorMessage(err),
-      });
-    }
-  }
-
-  // Reclaim `task-*` scratch dirs left under $TMPDIR/eliza-acp by sessions that
-  // never got a clean teardown — the SIGKILL-mid-run case that made this a
-  // 3.6TB-class leak (#13773). Runs once at startup, after reconcile has marked
-  // crashed orphans terminal, so a dir whose session is terminal in this store
-  // is reclaimed immediately; a live (non-terminal, possibly resumable) session
-  // keeps its workspace; an untracked dir is age-gated (co-tenant safety).
-  private async gcOrphanedScratchDirs(): Promise<void> {
-    const root = DEFAULT_WORKDIR_ROOT;
-    let entries: string[];
-    try {
-      entries = await readdir(root);
-    } catch {
-      // error-policy:J3 an absent scratch root is the expected empty shape →
-      // explicit zero-work result, not a masked read failure.
-      return;
-    }
-    const taskDirs = entries.filter((name) => name.startsWith("task-"));
-    if (taskDirs.length === 0) return;
-
-    let sessions: SessionInfo[];
-    try {
-      sessions = await this.store.list();
-    } catch (err) {
-      // error-policy:J7 store read failed; DATA-LOSS GUARD. A fabricated empty
-      // set would make every live session's scratch dir look orphaned and delete
-      // work out from under a running sub-agent. Surface and skip this pass; the
-      // next boot retries with real data.
-      this.runtime.reportError("AcpService.gcOrphanedScratchDirs", err, {
-        phase: "store.list",
-      });
-      this.log("warn", "scratch GC: store read failed, skipping sweep", {
-        err,
-      });
-      return;
-    }
-    const sessionById = new Map(sessions.map((s) => [s.id, s] as const));
-    const maxAgeMs =
-      parsePositiveInt(this.setting("ELIZA_ACP_SCRATCH_GC_MAX_AGE_MS")) ??
-      ACP_SCRATCH_GC_MAX_AGE_MS;
-    const now = Date.now();
-    let reclaimed = 0;
-    let kept = 0;
-    await Promise.allSettled(
-      taskDirs.map(async (name) => {
-        const sessionId = name.slice("task-".length);
-        const session = sessionById.get(sessionId);
-        // A live (non-terminal) session is still using its workspace — never
-        // reclaim it; resumeOrphanedBusySessions may pick the work back up.
-        if (session && !TERMINAL_SESSION_STATUSES.has(session.status)) {
-          kept++;
-          return;
-        }
-        const path = join(root, name);
-        // No owning session in THIS store: the dir may belong to a co-tenant
-        // AcpService sharing this tmp root, so gate removal on age. A dir whose
-        // session is terminal here is unambiguously ours → reclaim regardless.
-        if (!session) {
-          try {
-            const st = await stat(path);
-            if (now - st.mtimeMs <= maxAgeMs) {
-              kept++;
-              return;
-            }
-          } catch {
-            // error-policy:J6 vanished mid-scan — nothing left to reclaim.
-            return;
-          }
-        }
-        try {
-          await rm(path, { recursive: true, force: true });
-          reclaimed++;
-        } catch (err) {
-          // error-policy:J6 best-effort GC; a locked/vanished dir is skipped so
-          // the sweep continues and retries next boot.
-          this.log("warn", "scratch GC: failed to remove dir", {
-            path,
-            error: errorMessage(err),
-          });
-        }
-      }),
-    );
-    if (reclaimed > 0 || kept > 0) {
-      this.log("info", "reclaimed orphaned scratch dirs", {
-        reclaimed,
-        kept,
-        root,
-        olderThanMs: maxAgeMs,
-      });
-    }
-  }
-
   private async runHealthCheck(): Promise<void> {
     if (!this.started) return;
     let sessions: SessionInfo[];
@@ -830,8 +805,6 @@ export class AcpService extends Service {
       this.outputBuffers.delete(id);
       this.changedPathsBySession.delete(id);
       this.nativeClients.delete(id);
-      this.persistedStdoutSessions.delete(id);
-      this.pendingStdoutWrites.delete(id);
     }
     if (swept.length > 0) {
       this.log("debug", "health-check reclaimed terminal sessions", {
@@ -900,20 +873,10 @@ export class AcpService extends Service {
     const isolate = opts.workdir ? opts.isolateWorkdir === true : true;
     const workdir = computeSessionWorkdir(baseWorkdir, id, isolate);
     await mkdir(workdir, { recursive: true });
-    // The parent-agent broker is only reachable when the SubAgentRouter is bound
-    // to the ACP event stream; gate every broker advertisement (manual section,
-    // SKILLS.md broker entry) on that so a child is never told about a bridge it
-    // cannot use.
-    const brokerWired = isParentAgentBrokerWired(this.runtime);
     // Give the sub-agent its eliza-context + non-interactive operating manual on
     // disk (where every backend reads it) — only when the workspace is bare, so
     // a real repo's own AGENTS.md/CLAUDE.md is never clobbered.
-    await writeWorkspaceIdentity(workdir, { brokerWired });
-    // Write SKILLS.md into every spawn workspace so a child can discover (and
-    // request, via the parent) the parent's installed skills — not just the
-    // economics loop. The broker skill is advertised only when wired; the
-    // recommended-slugs / ViewKind extras are opt-in via opts.skillsManifest.
-    await this.writeSkillsManifest(workdir, id, brokerWired, opts);
+    await writeWorkspaceIdentity(workdir);
 
     // Record the workspace HEAD + already-dirty files at spawn so the change
     // set captured at task_complete is scoped to exactly what this sub-agent
@@ -964,20 +927,25 @@ export class AcpService extends Service {
     }
 
     const now = new Date();
-    // Stamp the capacity class onto the session so getCapacity() (and the
-    // admission queue that reads it) can count worker vs system slots off the
-    // durable record. Always persisted — a worker session carries slotClass so
-    // the accounting never has to infer "worker" from an absent field.
-    const slotClass: SessionSlotClass = opts.slotClass ?? "worker";
     const mergedMetadata: Record<string, unknown> = {
       ...(opts.metadata ?? {}),
+      ...(isolate
+        ? {
+            [ACP_METADATA_ISOLATED_WORKDIR]: true,
+            [ACP_METADATA_WORKDIR_ROOT]: resolve(baseWorkdir),
+          }
+        : {}),
       ...(baselineSha ? { codingBaselineSha: baselineSha } : {}),
       ...(baselineSha && baselineDirty.length > 0
         ? { codingBaselineDirty: baselineDirty }
         : {}),
       ...(resolvedAccount ? { account: resolvedAccount.meta } : {}),
-      slotClass,
     };
+    const hasMergedMetadata =
+      isolate ||
+      Boolean(baselineSha) ||
+      Boolean(resolvedAccount) ||
+      Boolean(opts.metadata);
     const session: SessionInfo = {
       id,
       name,
@@ -987,13 +955,12 @@ export class AcpService extends Service {
       approvalPreset,
       createdAt: now,
       lastActivityAt: now,
-      metadata: mergedMetadata,
+      metadata: hasMergedMetadata ? mergedMetadata : opts.metadata,
     };
-    // Atomic check-and-reserve: enforces the session limit for this slot class
-    // and inserts under a single mutex so concurrent spawns can't overshoot the
-    // cap (the old separate enforceSessionLimit()/store.create() left a
-    // read-then-act race). Throws SessionCapError when the class is full.
-    await this.reserveSessionSlot(session, slotClass);
+    // Atomic check-and-reserve: enforces the session limit and inserts under a
+    // single mutex so concurrent spawns can't overshoot maxSessions (the old
+    // separate enforceSessionLimit()/store.create() left a read-then-act race).
+    await this.reserveSessionSlot(session);
 
     // Mint the per-spawn model lease BEFORE the transport branch, so the leased
     // token (not the static gateway token) is what buildEnv injects into the
@@ -1121,45 +1088,6 @@ export class AcpService extends Service {
     const updated = await this.store.get(id);
     const sessionSnapshot: SessionInfo = { ...session, status: "ready" };
     return toSpawnResult(updated ?? sessionSnapshot);
-  }
-
-  /**
-   * Write SKILLS.md into a spawn workspace so the sub-agent can discover the
-   * parent's installed skills and request them back via the parent. Runs on the
-   * SHARED spawn path (every `spawnSession`) so direct `/api/coding-agents` and
-   * `TASKS_SPAWN_AGENT` spawns get it, not just the economics loop. The broker
-   * skill is advertised only when the router is wired; `opts.skillsManifest`
-   * adds the recommended-slug highlight and Cloud ViewKind contract for
-   * app-building tasks. Best-effort — a failed write warns and the spawn
-   * proceeds without the manifest.
-   */
-  private async writeSkillsManifest(
-    workdir: string,
-    sessionId: string,
-    brokerWired: boolean,
-    opts: SpawnOptions,
-  ): Promise<void> {
-    try {
-      const manifest = await buildSkillsManifest(this.runtime, {
-        ...(opts.skillsManifest?.recommendedSlugs
-          ? { recommendedSlugs: opts.skillsManifest.recommendedSlugs }
-          : {}),
-        ...(brokerWired
-          ? { virtualSkills: [{ ...PARENT_AGENT_BROKER_MANIFEST_ENTRY }] }
-          : {}),
-        includeViewKindContract:
-          opts.skillsManifest?.includeViewKindContract ?? false,
-      });
-      await writeFile(join(workdir, "SKILLS.md"), manifest.markdown, "utf8");
-    } catch (err) {
-      // error-policy:J7 SKILLS.md scaffolding is best-effort; a failed write is
-      // warned and the spawn proceeds without it — a missing manifest only
-      // degrades skill discovery.
-      this.runtime.logger?.warn?.(
-        { src: "acp-service", sessionId, workdir },
-        `failed to write SKILLS.md: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
   }
 
   async sendPrompt(
@@ -1334,12 +1262,12 @@ export class AcpService extends Service {
           sessionId,
           response: this.lastOutput(sessionId),
         });
+        await this.removeOwnedScratchWorkdir(session);
       } finally {
         if (!this.nativePromptSessionIds.has(sessionId)) {
           this.nativeStoppingSessionIds.delete(sessionId);
         }
       }
-      await this.reclaimOwnedScratchDir(session);
       return;
     }
     await this.stopTrackedProcess(sessionId);
@@ -1365,11 +1293,11 @@ export class AcpService extends Service {
       sessionId,
       response: this.lastOutput(sessionId),
     });
-    await this.reclaimOwnedScratchDir(session);
+    await this.removeOwnedScratchWorkdir(session);
   }
 
   async deleteSession(sessionId: string): Promise<void> {
-    const session = await this.requireSession(sessionId);
+    const session = await this.store.get(sessionId);
     await this.closeSession(sessionId).catch((err: unknown) => {
       // error-policy:J6 best-effort close before delete; a teardown failure must
       // not block removing the session record + satellite maps below.
@@ -1378,12 +1306,12 @@ export class AcpService extends Service {
         error: errorMessage(err),
       });
     });
-    await this.reclaimOwnedScratchDir(session);
+    if (session) {
+      await this.removeOwnedScratchWorkdir(session);
+    }
     await this.store.delete(sessionId);
     this.outputBuffers.delete(sessionId);
     this.changedPathsBySession.delete(sessionId);
-    this.persistedStdoutSessions.delete(sessionId);
-    this.pendingStdoutWrites.delete(sessionId);
   }
 
   async listSessions(): Promise<SessionInfo[]> {
@@ -2129,9 +2057,7 @@ export class AcpService extends Service {
         this.activeProcesses.set(opts.sessionId, record);
 
       proc.stdout.on("data", (chunk: Buffer) => {
-        const rawChunk = chunk.toString("utf8");
-        if (opts.sessionId) this.persistRawStdout(opts.sessionId, rawChunk);
-        record.stdoutBuffer += rawChunk;
+        record.stdoutBuffer += chunk.toString("utf8");
         let newlineIndex = record.stdoutBuffer.indexOf("\n");
         while (newlineIndex >= 0) {
           const line = record.stdoutBuffer.slice(0, newlineIndex).trim();
@@ -2146,7 +2072,6 @@ export class AcpService extends Service {
                 startedAt,
                 opts.activeForSession === true,
                 capturedToolOutputs,
-                opts.activeForSession === true,
               );
               finalText = handled.finalText;
               stopReason = handled.stopReason ?? stopReason;
@@ -2173,7 +2098,7 @@ export class AcpService extends Service {
         }
       });
 
-      proc.on("close", async (code, signal) => {
+      proc.on("close", (code, signal) => {
         record.exited = true;
         if (record.stdoutBuffer.trim()) {
           const parsed = this.parseNdjson(
@@ -2188,7 +2113,6 @@ export class AcpService extends Service {
               startedAt,
               opts.activeForSession === true,
               capturedToolOutputs,
-              opts.activeForSession === true,
             );
             finalText = handled.finalText;
             stopReason = handled.stopReason ?? stopReason;
@@ -2248,7 +2172,6 @@ export class AcpService extends Service {
             }
           });
         }
-        if (opts.sessionId) await this.flushRawStdout(opts.sessionId);
         if (opts.sessionId && opts.activeForSession) {
           // claude-agent-sdk often exits cleanly (code 0) without sending
           // an explicit `{result: {stopReason: "end_turn"}}` ACP message
@@ -2271,11 +2194,6 @@ export class AcpService extends Service {
               exitCode: code,
               signal,
             });
-          } else if (stopReason === "error" && !finalText?.trim()) {
-            this.emitSessionEvent(opts.sessionId, "error", {
-              message: "acpx prompt ended with stopReason error",
-              stopReason,
-            });
           } else if (cleanCompletion) {
             // Emit exactly one terminal event per session-exit. Listeners
             // gating on `stopped` must also accept `task_complete` (the
@@ -2286,7 +2204,6 @@ export class AcpService extends Service {
               durationMs: Date.now() - startedAt,
               stopReason: stopReason ?? "exit",
               exitCode: code,
-              ...this.stdoutLogRef(opts.sessionId),
             });
           } else {
             this.emitSessionEvent(opts.sessionId, "stopped", {
@@ -2340,7 +2257,6 @@ export class AcpService extends Service {
     startedAt: number,
     emitPromptTerminalEvents: boolean,
     capturedToolOutputs: Set<string>,
-    deferPromptTerminalEvent = false,
   ): { finalText: string; stopReason?: string } {
     const protocolSessionId = extractSessionId(event);
     const sessionId = localSessionId ?? protocolSessionId;
@@ -2635,9 +2551,6 @@ export class AcpService extends Service {
         // to a failure if the claimed URLs are dead. Only a stopReason error with
         // NO captured output is a true, user-facing failure — otherwise the user
         // gets a false "hit a snag" for a build that actually succeeded.
-        if (deferPromptTerminalEvent) {
-          return { finalText, stopReason };
-        }
         if (stopReason === "error" && !finalText?.trim()) {
           this.emitSessionEvent(sessionId, "error", {
             message: "acpx prompt ended with stopReason error",
@@ -2648,7 +2561,6 @@ export class AcpService extends Service {
             response: finalText,
             durationMs: Date.now() - startedAt,
             stopReason,
-            ...this.stdoutLogRef(sessionId),
           });
         }
       }
@@ -2697,70 +2609,14 @@ export class AcpService extends Service {
     return session;
   }
 
-  /**
-   * A session occupies a slot until it reaches a terminal status. Kept as a
-   * narrow list (not `TERMINAL_SESSION_STATUSES`) because an `error`-status
-   * session may still be mid-teardown and holding its subprocess; only the
-   * fully-settled statuses free the slot.
-   */
-  private static isActiveSession(session: SessionInfo): boolean {
-    return !["stopped", "errored", "completed", "cancelled"].includes(
-      session.status,
-    );
-  }
-
-  private static slotClassOf(session: SessionInfo): SessionSlotClass {
-    return session.metadata?.slotClass === "system" ? "system" : "worker";
-  }
-
-  /**
-   * Snapshot the two admission pools from the durable store. Worker and system
-   * counts are independent: a full worker pool never blocks a system spawn (the
-   * verifier headroom) and vice-versa.
-   */
-  private async countActiveSlots(): Promise<{
-    activeWorkers: number;
-    activeSystem: number;
-  }> {
+  private async enforceSessionLimit(): Promise<void> {
     const sessions = await this.store.list();
-    let activeWorkers = 0;
-    let activeSystem = 0;
-    for (const session of sessions) {
-      if (!AcpService.isActiveSession(session)) continue;
-      if (AcpService.slotClassOf(session) === "system") activeSystem += 1;
-      else activeWorkers += 1;
-    }
-    return { activeWorkers, activeSystem };
-  }
-
-  /**
-   * Live capacity across both admission pools. The queue dispatcher and planner
-   * provider read this instead of re-deriving the count so back-pressure is
-   * reported from one authoritative source.
-   */
-  async getCapacity(): Promise<AcpCapacity> {
-    const { activeWorkers, activeSystem } = await this.countActiveSlots();
-    return {
-      maxSessions: this.maxSessions,
-      systemHeadroom: this.systemHeadroom,
-      activeWorkers,
-      activeSystem,
-      freeWorkerSlots: Math.max(0, this.maxSessions - activeWorkers),
-      freeSystemSlots: Math.max(0, this.systemHeadroom - activeSystem),
-    };
-  }
-
-  private async enforceSessionLimit(
-    slotClass: SessionSlotClass,
-  ): Promise<void> {
-    const { activeWorkers, activeSystem } = await this.countActiveSlots();
-    if (slotClass === "system") {
-      if (activeSystem >= this.systemHeadroom)
-        throw new SessionCapError("system", this.systemHeadroom, activeSystem);
-      return;
-    }
-    if (activeWorkers >= this.maxSessions)
-      throw new SessionCapError("worker", this.maxSessions, activeWorkers);
+    const active = sessions.filter(
+      (s) =>
+        !["stopped", "errored", "completed", "cancelled"].includes(s.status),
+    );
+    if (active.length >= this.maxSessions)
+      throw new Error(`acpx max session limit reached (${this.maxSessions})`);
   }
 
   /**
@@ -2777,10 +2633,7 @@ export class AcpService extends Service {
    * never rejects (we swallow on the tail) so one failed reservation doesn't
    * wedge the lock for later spawns.
    */
-  private async reserveSessionSlot(
-    session: SessionInfo,
-    slotClass: SessionSlotClass,
-  ): Promise<void> {
+  private async reserveSessionSlot(session: SessionInfo): Promise<void> {
     const previous = this.spawnReservationLock;
     let release!: () => void;
     this.spawnReservationLock = new Promise<void>((resolve) => {
@@ -2791,7 +2644,7 @@ export class AcpService extends Service {
     // awaiter; here we only serialize on its settle before counting slots.
     await previous.catch(() => {});
     try {
-      await this.enforceSessionLimit(slotClass);
+      await this.enforceSessionLimit();
       await this.store.create(session);
     } finally {
       release();
@@ -3140,47 +2993,6 @@ export class AcpService extends Service {
     return (this.outputBuffers.get(sessionId) ?? []).join("");
   }
 
-  // Path of the persisted raw-stdout log for a session, or undefined if no raw
-  // stdout write was queued (recording off, or no output). Merged into the
-  // `task_complete` event data so the task document references the ground-truth
-  // stdout file — the join key downstream tooling follows to the full stream.
-  private stdoutLogRef(
-    sessionId: string,
-  ): { stdoutLogPath: string } | Record<string, never> {
-    return this.persistedStdoutSessions.has(sessionId)
-      ? { stdoutLogPath: subagentStdoutLogPath(sessionId) }
-      : {};
-  }
-
-  private async flushRawStdout(sessionId: string): Promise<void> {
-    await this.pendingStdoutWrites.get(sessionId);
-  }
-
-  private persistRawStdout(sessionId: string, text: string): void {
-    if (!isSubagentStdoutLoggingEnabled()) return;
-    const previous =
-      this.pendingStdoutWrites.get(sessionId) ?? Promise.resolve();
-    const write = previous
-      .then(async () => {
-        const path = await appendSubagentStdout(sessionId, text);
-        if (path) this.persistedStdoutSessions.add(sessionId);
-      })
-      .catch((err: unknown) => {
-        // error-policy:J7 stdout persistence is diagnostics and must not kill the
-        // transport loop; surface it observably instead of swallowing.
-        this.runtime.reportError("AcpService.persistRawStdout", err, {
-          sessionId,
-          phase: "persist-stdout",
-        });
-      });
-    this.pendingStdoutWrites.set(sessionId, write);
-    void write.finally(() => {
-      if (this.pendingStdoutWrites.get(sessionId) === write) {
-        this.pendingStdoutWrites.delete(sessionId);
-      }
-    });
-  }
-
   private appendOutput(sessionId: string, text: string): void {
     const buffer = this.outputBuffers.get(sessionId) ?? [];
     buffer.push(text);
@@ -3295,7 +3107,7 @@ export class AcpService extends Service {
   }
 
   private assertTransportAvailable(sessionId: string): void {
-    if (!isAndroidMobile()) return;
+    if (process.env.ELIZA_PLATFORM !== "android") return;
     const message = this.missingCliMessage();
     if (!message) return;
     this.emitMissingCli(sessionId, message);

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -16,15 +16,16 @@
  */
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { type Dirent, existsSync } from "node:fs";
-import { mkdir, readdir, rm, stat, unlink } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdir, readdir, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { join, resolve, sep } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import {
   SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE as CORE_SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE,
   type IAgentRuntime,
   Service,
 } from "@elizaos/core";
+import { isAndroidMobile } from "@elizaos/shared";
 import { NativeAcpClient } from "./acp-native-transport.js";
 import { augmentTaskWithDeployGuidance } from "./app-deploy-guidance.js";
 import {
@@ -63,13 +64,24 @@ import {
   resolveVendoredOpencodeAcpCommand,
 } from "./opencode-config.js";
 import {
+  isParentAgentBrokerWired,
+  PARENT_AGENT_BROKER_MANIFEST_ENTRY,
+} from "./parent-agent-broker.js";
+import {
   AcpSessionStore,
   InMemorySessionStore,
   type SessionStoreBackend,
 } from "./session-store.js";
+import { buildSkillsManifest } from "./skill-manifest.js";
 import { writeWorkspaceIdentity } from "./sub-agent-identity.js";
+import {
+  appendSubagentStdout,
+  isSubagentStdoutLoggingEnabled,
+  subagentStdoutLogPath,
+} from "./subagent-stdout-log.js";
 import { normalizeTaskAgentAdapter } from "./task-agent-routing.js";
 import {
+  type AcpCapacity,
   type AcpEventCallback,
   type AcpJsonRpcMessage,
   type AcpToolCall,
@@ -78,9 +90,11 @@ import {
   type AvailableAgentInfo,
   type PromptResult,
   type SendOptions,
+  SessionCapError,
   type SessionEventCallback,
   type SessionEventName,
   type SessionInfo,
+  type SessionSlotClass,
   type SessionStore,
   type SpawnOptions,
   type SpawnResult,
@@ -167,7 +181,24 @@ export function computeSessionWorkdir(
 ): string {
   return isolate ? resolve(base, `task-${sessionId}`) : resolve(base);
 }
-const ACP_SCRATCH_ORPHAN_MAX_AGE_MS = 24 * 60 * 60_000;
+
+/**
+ * True iff `workdir` is a throwaway scratch dir AcpService itself created under
+ * its default temp root — a `task-<sessionId>` directory directly beneath
+ * DEFAULT_WORKDIR_ROOT (`$TMPDIR/eliza-acp`). This is the ownership guard for
+ * every destructive reclaim (teardown rm + startup GC): a self-checkout
+ * (`process.cwd()`), an explicit route/opt-in workdir, and a git-worktree
+ * workspace the service was handed all live elsewhere, so a reclaim keyed on
+ * this predicate can never delete a directory the service does not own. Pure +
+ * exported so the guarantee is unit-testable.
+ */
+export function isOwnedScratchDir(workdir: string): boolean {
+  const resolved = resolve(workdir);
+  return (
+    dirname(resolved) === resolve(DEFAULT_WORKDIR_ROOT) &&
+    basename(resolved).startsWith("task-")
+  );
+}
 const ACP_SCRATCH_DIR_PREFIX = "task-";
 const ACP_METADATA_ISOLATED_WORKDIR = "isolatedWorkdir";
 const ACP_METADATA_WORKDIR_ROOT = "workdirRoot";
@@ -187,6 +218,13 @@ const ACP_MIDFLIGHT_SESSION_STATUSES: ReadonlySet<string> = new Set([
   "tool_running",
 ]);
 const ACP_STALE_LOCK_MAX_AGE_MS = 10 * 60_000;
+// Startup GC only reclaims an UNTRACKED `task-*` scratch dir (no owning session
+// in this instance's store) once it is older than this — a conservative floor
+// so a co-tenant AcpService sharing the same $TMPDIR/eliza-acp root never has
+// its live-but-idle scratch nuked. Dirs whose session IS terminal in this store
+// are unambiguously ours and reclaimed regardless of age. Overridable via
+// ELIZA_ACP_SCRATCH_GC_MAX_AGE_MS. 24h mirrors ACP_REVERSE_ORPHAN_MAX_AGE_MS.
+const ACP_SCRATCH_GC_MAX_AGE_MS = 24 * 60 * 60_000;
 // Untracked acpx stream files older than this get unlinked. Real spawns
 // finalize their store entry in seconds; 24h is grace for in-flight spawns.
 const ACP_REVERSE_ORPHAN_MAX_AGE_MS = 24 * 60 * 60_000;
@@ -294,6 +332,12 @@ export class AcpService extends Service {
   private readonly transportMode: "native" | "cli";
   private readonly defaultAgent: AgentType;
   private readonly maxSessions: number;
+  // Reserved slots for short-lived `system` spawns (the #8898 read-only
+  // verifier) that must NOT compete for a worker slot: at full worker cap the
+  // verifier needs a fresh session while the worker it is verifying still holds
+  // its slot (orchestrator sessions keep the slot after task_complete), so
+  // counting them together deadlocks validation. Counted against a separate pool.
+  private readonly systemHeadroom: number;
   // Serializes the session-limit check-and-reserve so concurrent spawns can't
   // each pass the limit check before any has inserted (which would overshoot
   // ELIZA_ACP_MAX_SESSIONS). A promise-chain mutex: each reservation awaits the
@@ -308,6 +352,16 @@ export class AcpService extends Service {
   private readonly nativeCancelledPromptSessionIds = new Set<string>();
   private readonly nativeStoppingSessionIds = new Set<string>();
   private readonly outputBuffers = new Map<string, string[]>();
+  // Sessions whose raw stdout has been teed to disk at least once. Drives the
+  // `task_complete` stdoutLogPath reference: only sessions that actually wrote a
+  // file get the path attached, so the task document never points at a
+  // never-created log. Populated by persistRawStdout; gated by trajectory
+  // recording.
+  private readonly persistedStdoutSessions = new Set<string>();
+  // Raw stdout arrives on the subprocess stream, while task completion is parsed
+  // from that same stream. Queue writes per session so the terminal event can
+  // wait for the tee before persisting a task document that references it.
+  private readonly pendingStdoutWrites = new Map<string, Promise<void>>();
   // Per-session model-gateway lease (#11536 E2 residual). Minted at spawn when
   // gateway mode + a lease broker are configured; the leased token (not the
   // static ELIZA_MODEL_GATEWAY_TOKEN) is injected into the child env, and the
@@ -349,6 +403,8 @@ export class AcpService extends Service {
       "fixed";
     this.maxSessions =
       parsePositiveInt(this.setting("ELIZA_ACP_MAX_SESSIONS")) ?? 8;
+    this.systemHeadroom =
+      parsePositiveInt(this.setting("ELIZA_ACP_SYSTEM_SESSION_HEADROOM")) ?? 2;
     this.sessionTimeoutMs = parsePositiveInt(
       this.setting("ACPX_DEFAULT_TIMEOUT_MS") ??
         this.setting("ELIZA_ACP_PROMPT_TIMEOUT_MS"),
@@ -378,7 +434,7 @@ export class AcpService extends Service {
       defaultApprovalPreset: this.defaultApprovalPreset,
     });
     await this.reconcileOrphanedSessions();
-    await this.cleanOrphanedScratchWorkdirs();
+    await this.gcOrphanedScratchDirs();
     await this.cleanReverseOrphanedAcpxFiles();
     await this.cleanStaleLocks();
     this.healthCheckTimer = setInterval(() => {
@@ -400,149 +456,6 @@ export class AcpService extends Service {
       process.once("SIGTERM", AcpService.sharedShutdownHandler);
       process.once("SIGINT", AcpService.sharedShutdownHandler);
       AcpService.shutdownHookInstalled = true;
-    }
-  }
-
-  private configuredScratchRoots(): string[] {
-    const roots = [
-      this.setting("ELIZA_ACP_WORKSPACE_ROOT"),
-      this.setting("ACPX_DEFAULT_CWD"),
-      this.setting("ELIZA_WORKSPACE_DIR"),
-      this.setting("ELIZA_CODING_WORKSPACE"),
-      this.setting("ELIZA_CODING_DIRECTORY"),
-      DEFAULT_WORKDIR_ROOT,
-    ];
-    return Array.from(
-      new Set(
-        roots
-          .filter((value): value is string => Boolean(value?.trim()))
-          .map((value) => {
-            const trimmed = value.trim();
-            return resolve(
-              trimmed === "~" || trimmed.startsWith("~/")
-                ? join(homedir(), trimmed.slice(2))
-                : trimmed,
-            );
-          }),
-      ),
-    );
-  }
-
-  private isPathUnderRoot(candidate: string, root: string): boolean {
-    const resolved = resolve(candidate);
-    const resolvedRoot = resolve(root);
-    return (
-      resolved === resolvedRoot || resolved.startsWith(`${resolvedRoot}${sep}`)
-    );
-  }
-
-  private isOwnedIsolatedWorkdir(session: SessionInfo): boolean {
-    if (session.metadata?.[ACP_METADATA_ISOLATED_WORKDIR] === true) {
-      return true;
-    }
-    const root = session.metadata?.[ACP_METADATA_WORKDIR_ROOT];
-    return (
-      typeof root === "string" &&
-      this.isPathUnderRoot(session.workdir, root) &&
-      session.workdir.endsWith(`${ACP_SCRATCH_DIR_PREFIX}${session.id}`)
-    );
-  }
-
-  private async removeOwnedScratchWorkdir(session: SessionInfo): Promise<void> {
-    if (!this.isOwnedIsolatedWorkdir(session)) return;
-    const root =
-      typeof session.metadata?.[ACP_METADATA_WORKDIR_ROOT] === "string"
-        ? session.metadata[ACP_METADATA_WORKDIR_ROOT]
-        : undefined;
-    if (!root || !this.isPathUnderRoot(session.workdir, root)) {
-      this.log("warn", "scratch cleanup refused: workdir outside root", {
-        sessionId: session.id,
-        workdir: session.workdir,
-        root,
-      });
-      return;
-    }
-    try {
-      await rm(session.workdir, { recursive: true, force: true });
-      this.log("debug", "removed isolated ACP scratch workdir", {
-        sessionId: session.id,
-        workdir: session.workdir,
-      });
-    } catch (err) {
-      // error-policy:J6 best-effort scratch-dir teardown; retain the session
-      // record/state and retry via later delete/GC paths rather than failing the
-      // user-visible close.
-      this.log("warn", "failed to remove isolated ACP scratch workdir", {
-        sessionId: session.id,
-        workdir: session.workdir,
-        err,
-      });
-    }
-  }
-
-  private async cleanOrphanedScratchWorkdirs(): Promise<void> {
-    let sessions: SessionInfo[];
-    try {
-      sessions = await this.store.list();
-    } catch (err) {
-      this.runtime.reportError("AcpService.cleanOrphanedScratchWorkdirs", err, {
-        phase: "store.list",
-      });
-      this.log("warn", "scratch GC: store read failed, skipping delete pass", {
-        err,
-      });
-      return;
-    }
-    const tracked = new Set(
-      sessions.map((session) => resolve(session.workdir)),
-    );
-    let removed = 0;
-    let kept = 0;
-    const cutoff = Date.now() - ACP_SCRATCH_ORPHAN_MAX_AGE_MS;
-
-    for (const root of this.configuredScratchRoots()) {
-      let entries: Dirent<string>[];
-      try {
-        entries = await readdir(root, { withFileTypes: true });
-      } catch {
-        continue;
-      }
-      for (const entry of entries) {
-        if (
-          !entry.isDirectory() ||
-          !entry.name.startsWith(ACP_SCRATCH_DIR_PREFIX)
-        ) {
-          continue;
-        }
-        const candidate = resolve(root, entry.name);
-        if (tracked.has(candidate)) {
-          kept++;
-          continue;
-        }
-        try {
-          const st = await stat(candidate);
-          if (st.mtimeMs > cutoff) {
-            kept++;
-            continue;
-          }
-          await rm(candidate, { recursive: true, force: true });
-          removed++;
-        } catch (err) {
-          kept++;
-          this.log("warn", "scratch GC: skipped candidate", {
-            path: candidate,
-            err,
-          });
-        }
-      }
-    }
-
-    if (removed > 0 || kept > 0) {
-      this.log("info", "scratch GC complete", {
-        removed,
-        kept,
-        olderThanMs: ACP_SCRATCH_ORPHAN_MAX_AGE_MS,
-      });
     }
   }
 
@@ -712,6 +625,183 @@ export class AcpService extends Service {
     }
   }
 
+  private configuredScratchRoots(): string[] {
+    const roots = [
+      this.setting("ELIZA_ACP_WORKSPACE_ROOT"),
+      this.setting("ACPX_DEFAULT_CWD"),
+      this.setting("ELIZA_WORKSPACE_DIR"),
+      this.setting("ELIZA_CODING_WORKSPACE"),
+      this.setting("ELIZA_CODING_DIRECTORY"),
+      DEFAULT_WORKDIR_ROOT,
+    ];
+    return Array.from(
+      new Set(
+        roots
+          .filter((value): value is string => Boolean(value?.trim()))
+          .map((value) => {
+            const trimmed = value.trim();
+            return resolve(
+              trimmed === "~" || trimmed.startsWith("~/")
+                ? join(homedir(), trimmed.slice(2))
+                : trimmed,
+            );
+          }),
+      ),
+    );
+  }
+
+  private isPathUnderRoot(candidate: string, root: string): boolean {
+    const resolved = resolve(candidate);
+    const resolvedRoot = resolve(root);
+    return (
+      resolved === resolvedRoot || resolved.startsWith(`${resolvedRoot}${sep}`)
+    );
+  }
+
+  private sessionOwnsIsolatedWorkdir(session: SessionInfo): boolean {
+    const root = session.metadata?.[ACP_METADATA_WORKDIR_ROOT];
+    if (session.metadata?.[ACP_METADATA_ISOLATED_WORKDIR] !== true) {
+      return isOwnedScratchDir(session.workdir);
+    }
+    return (
+      typeof root === "string" &&
+      this.isPathUnderRoot(session.workdir, root) &&
+      basename(resolve(session.workdir)) ===
+        `${ACP_SCRATCH_DIR_PREFIX}${session.id}`
+    );
+  }
+
+  // Delete the per-session scratch dir spawnSession mkdir'd, but ONLY when it is
+  // one we own. New sessions carry explicit ownership metadata; older sessions
+  // fall back to the legacy default-root predicate for backward cleanup.
+  private async removeOwnedScratchWorkdir(session: SessionInfo): Promise<void> {
+    if (!this.sessionOwnsIsolatedWorkdir(session)) return;
+    const root = session.metadata?.[ACP_METADATA_WORKDIR_ROOT];
+    if (
+      typeof root === "string" &&
+      !this.isPathUnderRoot(session.workdir, root)
+    ) {
+      this.log("warn", "scratch cleanup refused: workdir outside root", {
+        sessionId: session.id,
+        workdir: session.workdir,
+        root,
+      });
+      return;
+    }
+    try {
+      await rm(session.workdir, { recursive: true, force: true });
+      this.log("debug", "reclaimed session scratch dir", {
+        sessionId: session.id,
+        workdir: session.workdir,
+      });
+    } catch (err) {
+      // error-policy:J6 best-effort scratch reclaim on teardown; surface the
+      // failure so the leak is observable, then let the startup GC retry it.
+      this.log("warn", "failed to reclaim session scratch dir", {
+        sessionId: session.id,
+        workdir: session.workdir,
+        error: errorMessage(err),
+      });
+    }
+  }
+
+  // Reclaim `task-*` scratch dirs left under configured scratch roots by sessions that
+  // never got a clean teardown — the SIGKILL-mid-run case that made this a
+  // 3.6TB-class leak (#13773). Runs once at startup, after reconcile has marked
+  // crashed orphans terminal, so a dir whose session is terminal in this store
+  // is reclaimed immediately; a live (non-terminal, possibly resumable) session
+  // keeps its workspace; an untracked dir is age-gated (co-tenant safety).
+  private async cleanOrphanedScratchWorkdirs(): Promise<void> {
+    let sessions: SessionInfo[];
+    try {
+      sessions = await this.store.list();
+    } catch (err) {
+      // error-policy:J7 store read failed; DATA-LOSS GUARD. A fabricated empty
+      // set would make every live session's scratch dir look orphaned and delete
+      // work out from under a running sub-agent. Surface and skip this pass; the
+      // next boot retries with real data.
+      this.runtime.reportError("AcpService.cleanOrphanedScratchWorkdirs", err, {
+        phase: "store.list",
+      });
+      this.log("warn", "scratch GC: store read failed, skipping sweep", {
+        err,
+      });
+      return;
+    }
+    const sessionByWorkdir = new Map(
+      sessions.map((session) => [resolve(session.workdir), session] as const),
+    );
+    const maxAgeMs =
+      parsePositiveInt(this.setting("ELIZA_ACP_SCRATCH_GC_MAX_AGE_MS")) ??
+      ACP_SCRATCH_GC_MAX_AGE_MS;
+    const now = Date.now();
+    let reclaimed = 0;
+    let kept = 0;
+    for (const root of this.configuredScratchRoots()) {
+      let entries: string[];
+      try {
+        entries = await readdir(root);
+      } catch {
+        // error-policy:J3 an absent scratch root is the expected empty shape →
+        // explicit zero-work result, not a masked read failure.
+        continue;
+      }
+      const taskDirs = entries.filter((name) =>
+        name.startsWith(ACP_SCRATCH_DIR_PREFIX),
+      );
+      await Promise.allSettled(
+        taskDirs.map(async (name) => {
+          const path = join(root, name);
+          const session = sessionByWorkdir.get(resolve(path));
+          // A live (non-terminal) session is still using its workspace — never
+          // reclaim it; resumeOrphanedBusySessions may pick the work back up.
+          if (session && !TERMINAL_SESSION_STATUSES.has(session.status)) {
+            kept++;
+            return;
+          }
+          // No owning session in THIS store: the dir may belong to a co-tenant
+          // AcpService sharing this tmp root, so gate removal on age. A dir whose
+          // session is terminal here is unambiguously ours → reclaim regardless.
+          if (!session) {
+            try {
+              const st = await stat(path);
+              if (now - st.mtimeMs <= maxAgeMs) {
+                kept++;
+                return;
+              }
+            } catch {
+              // error-policy:J6 vanished mid-scan — nothing left to reclaim.
+              return;
+            }
+          }
+          try {
+            await rm(path, { recursive: true, force: true });
+            reclaimed++;
+          } catch (err) {
+            // error-policy:J6 best-effort GC; a locked/vanished dir is skipped so
+            // the sweep continues and retries next boot.
+            this.log("warn", "scratch GC: failed to remove dir", {
+              path,
+              error: errorMessage(err),
+            });
+          }
+        }),
+      );
+    }
+    if (reclaimed > 0 || kept > 0) {
+      this.log("info", "reclaimed orphaned scratch dirs", {
+        reclaimed,
+        kept,
+        roots: this.configuredScratchRoots(),
+        olderThanMs: maxAgeMs,
+      });
+    }
+  }
+
+  private async gcOrphanedScratchDirs(): Promise<void> {
+    await this.cleanOrphanedScratchWorkdirs();
+  }
+
   private async runHealthCheck(): Promise<void> {
     if (!this.started) return;
     let sessions: SessionInfo[];
@@ -805,6 +895,8 @@ export class AcpService extends Service {
       this.outputBuffers.delete(id);
       this.changedPathsBySession.delete(id);
       this.nativeClients.delete(id);
+      this.persistedStdoutSessions.delete(id);
+      this.pendingStdoutWrites.delete(id);
     }
     if (swept.length > 0) {
       this.log("debug", "health-check reclaimed terminal sessions", {
@@ -873,10 +965,20 @@ export class AcpService extends Service {
     const isolate = opts.workdir ? opts.isolateWorkdir === true : true;
     const workdir = computeSessionWorkdir(baseWorkdir, id, isolate);
     await mkdir(workdir, { recursive: true });
+    // The parent-agent broker is only reachable when the SubAgentRouter is bound
+    // to the ACP event stream; gate every broker advertisement (manual section,
+    // SKILLS.md broker entry) on that so a child is never told about a bridge it
+    // cannot use.
+    const brokerWired = isParentAgentBrokerWired(this.runtime);
     // Give the sub-agent its eliza-context + non-interactive operating manual on
     // disk (where every backend reads it) — only when the workspace is bare, so
     // a real repo's own AGENTS.md/CLAUDE.md is never clobbered.
-    await writeWorkspaceIdentity(workdir);
+    await writeWorkspaceIdentity(workdir, { brokerWired });
+    // Write SKILLS.md into every spawn workspace so a child can discover (and
+    // request, via the parent) the parent's installed skills — not just the
+    // economics loop. The broker skill is advertised only when wired; the
+    // recommended-slugs / ViewKind extras are opt-in via opts.skillsManifest.
+    await this.writeSkillsManifest(workdir, id, brokerWired, opts);
 
     // Record the workspace HEAD + already-dirty files at spawn so the change
     // set captured at task_complete is scoped to exactly what this sub-agent
@@ -927,6 +1029,11 @@ export class AcpService extends Service {
     }
 
     const now = new Date();
+    // Stamp the capacity class onto the session so getCapacity() (and the
+    // admission queue that reads it) can count worker vs system slots off the
+    // durable record. Always persisted — a worker session carries slotClass so
+    // the accounting never has to infer "worker" from an absent field.
+    const slotClass: SessionSlotClass = opts.slotClass ?? "worker";
     const mergedMetadata: Record<string, unknown> = {
       ...(opts.metadata ?? {}),
       ...(isolate
@@ -940,12 +1047,8 @@ export class AcpService extends Service {
         ? { codingBaselineDirty: baselineDirty }
         : {}),
       ...(resolvedAccount ? { account: resolvedAccount.meta } : {}),
+      slotClass,
     };
-    const hasMergedMetadata =
-      isolate ||
-      Boolean(baselineSha) ||
-      Boolean(resolvedAccount) ||
-      Boolean(opts.metadata);
     const session: SessionInfo = {
       id,
       name,
@@ -955,12 +1058,13 @@ export class AcpService extends Service {
       approvalPreset,
       createdAt: now,
       lastActivityAt: now,
-      metadata: hasMergedMetadata ? mergedMetadata : opts.metadata,
+      metadata: mergedMetadata,
     };
-    // Atomic check-and-reserve: enforces the session limit and inserts under a
-    // single mutex so concurrent spawns can't overshoot maxSessions (the old
-    // separate enforceSessionLimit()/store.create() left a read-then-act race).
-    await this.reserveSessionSlot(session);
+    // Atomic check-and-reserve: enforces the session limit for this slot class
+    // and inserts under a single mutex so concurrent spawns can't overshoot the
+    // cap (the old separate enforceSessionLimit()/store.create() left a
+    // read-then-act race). Throws SessionCapError when the class is full.
+    await this.reserveSessionSlot(session, slotClass);
 
     // Mint the per-spawn model lease BEFORE the transport branch, so the leased
     // token (not the static gateway token) is what buildEnv injects into the
@@ -1088,6 +1192,45 @@ export class AcpService extends Service {
     const updated = await this.store.get(id);
     const sessionSnapshot: SessionInfo = { ...session, status: "ready" };
     return toSpawnResult(updated ?? sessionSnapshot);
+  }
+
+  /**
+   * Write SKILLS.md into a spawn workspace so the sub-agent can discover the
+   * parent's installed skills and request them back via the parent. Runs on the
+   * SHARED spawn path (every `spawnSession`) so direct `/api/coding-agents` and
+   * `TASKS_SPAWN_AGENT` spawns get it, not just the economics loop. The broker
+   * skill is advertised only when the router is wired; `opts.skillsManifest`
+   * adds the recommended-slug highlight and Cloud ViewKind contract for
+   * app-building tasks. Best-effort — a failed write warns and the spawn
+   * proceeds without the manifest.
+   */
+  private async writeSkillsManifest(
+    workdir: string,
+    sessionId: string,
+    brokerWired: boolean,
+    opts: SpawnOptions,
+  ): Promise<void> {
+    try {
+      const manifest = await buildSkillsManifest(this.runtime, {
+        ...(opts.skillsManifest?.recommendedSlugs
+          ? { recommendedSlugs: opts.skillsManifest.recommendedSlugs }
+          : {}),
+        ...(brokerWired
+          ? { virtualSkills: [{ ...PARENT_AGENT_BROKER_MANIFEST_ENTRY }] }
+          : {}),
+        includeViewKindContract:
+          opts.skillsManifest?.includeViewKindContract ?? false,
+      });
+      await writeFile(join(workdir, "SKILLS.md"), manifest.markdown, "utf8");
+    } catch (err) {
+      // error-policy:J7 SKILLS.md scaffolding is best-effort; a failed write is
+      // warned and the spawn proceeds without it — a missing manifest only
+      // degrades skill discovery.
+      this.runtime.logger?.warn?.(
+        { src: "acp-service", sessionId, workdir },
+        `failed to write SKILLS.md: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   async sendPrompt(
@@ -1262,12 +1405,12 @@ export class AcpService extends Service {
           sessionId,
           response: this.lastOutput(sessionId),
         });
-        await this.removeOwnedScratchWorkdir(session);
       } finally {
         if (!this.nativePromptSessionIds.has(sessionId)) {
           this.nativeStoppingSessionIds.delete(sessionId);
         }
       }
+      await this.removeOwnedScratchWorkdir(session);
       return;
     }
     await this.stopTrackedProcess(sessionId);
@@ -1297,7 +1440,7 @@ export class AcpService extends Service {
   }
 
   async deleteSession(sessionId: string): Promise<void> {
-    const session = await this.store.get(sessionId);
+    const session = await this.requireSession(sessionId);
     await this.closeSession(sessionId).catch((err: unknown) => {
       // error-policy:J6 best-effort close before delete; a teardown failure must
       // not block removing the session record + satellite maps below.
@@ -1306,12 +1449,12 @@ export class AcpService extends Service {
         error: errorMessage(err),
       });
     });
-    if (session) {
-      await this.removeOwnedScratchWorkdir(session);
-    }
+    await this.removeOwnedScratchWorkdir(session);
     await this.store.delete(sessionId);
     this.outputBuffers.delete(sessionId);
     this.changedPathsBySession.delete(sessionId);
+    this.persistedStdoutSessions.delete(sessionId);
+    this.pendingStdoutWrites.delete(sessionId);
   }
 
   async listSessions(): Promise<SessionInfo[]> {
@@ -2057,7 +2200,9 @@ export class AcpService extends Service {
         this.activeProcesses.set(opts.sessionId, record);
 
       proc.stdout.on("data", (chunk: Buffer) => {
-        record.stdoutBuffer += chunk.toString("utf8");
+        const rawChunk = chunk.toString("utf8");
+        if (opts.sessionId) this.persistRawStdout(opts.sessionId, rawChunk);
+        record.stdoutBuffer += rawChunk;
         let newlineIndex = record.stdoutBuffer.indexOf("\n");
         while (newlineIndex >= 0) {
           const line = record.stdoutBuffer.slice(0, newlineIndex).trim();
@@ -2072,6 +2217,7 @@ export class AcpService extends Service {
                 startedAt,
                 opts.activeForSession === true,
                 capturedToolOutputs,
+                opts.activeForSession === true,
               );
               finalText = handled.finalText;
               stopReason = handled.stopReason ?? stopReason;
@@ -2098,7 +2244,7 @@ export class AcpService extends Service {
         }
       });
 
-      proc.on("close", (code, signal) => {
+      proc.on("close", async (code, signal) => {
         record.exited = true;
         if (record.stdoutBuffer.trim()) {
           const parsed = this.parseNdjson(
@@ -2113,6 +2259,7 @@ export class AcpService extends Service {
               startedAt,
               opts.activeForSession === true,
               capturedToolOutputs,
+              opts.activeForSession === true,
             );
             finalText = handled.finalText;
             stopReason = handled.stopReason ?? stopReason;
@@ -2172,6 +2319,7 @@ export class AcpService extends Service {
             }
           });
         }
+        if (opts.sessionId) await this.flushRawStdout(opts.sessionId);
         if (opts.sessionId && opts.activeForSession) {
           // claude-agent-sdk often exits cleanly (code 0) without sending
           // an explicit `{result: {stopReason: "end_turn"}}` ACP message
@@ -2194,6 +2342,11 @@ export class AcpService extends Service {
               exitCode: code,
               signal,
             });
+          } else if (stopReason === "error" && !finalText?.trim()) {
+            this.emitSessionEvent(opts.sessionId, "error", {
+              message: "acpx prompt ended with stopReason error",
+              stopReason,
+            });
           } else if (cleanCompletion) {
             // Emit exactly one terminal event per session-exit. Listeners
             // gating on `stopped` must also accept `task_complete` (the
@@ -2204,6 +2357,7 @@ export class AcpService extends Service {
               durationMs: Date.now() - startedAt,
               stopReason: stopReason ?? "exit",
               exitCode: code,
+              ...this.stdoutLogRef(opts.sessionId),
             });
           } else {
             this.emitSessionEvent(opts.sessionId, "stopped", {
@@ -2257,6 +2411,7 @@ export class AcpService extends Service {
     startedAt: number,
     emitPromptTerminalEvents: boolean,
     capturedToolOutputs: Set<string>,
+    deferPromptTerminalEvent = false,
   ): { finalText: string; stopReason?: string } {
     const protocolSessionId = extractSessionId(event);
     const sessionId = localSessionId ?? protocolSessionId;
@@ -2551,6 +2706,9 @@ export class AcpService extends Service {
         // to a failure if the claimed URLs are dead. Only a stopReason error with
         // NO captured output is a true, user-facing failure — otherwise the user
         // gets a false "hit a snag" for a build that actually succeeded.
+        if (deferPromptTerminalEvent) {
+          return { finalText, stopReason };
+        }
         if (stopReason === "error" && !finalText?.trim()) {
           this.emitSessionEvent(sessionId, "error", {
             message: "acpx prompt ended with stopReason error",
@@ -2561,6 +2719,7 @@ export class AcpService extends Service {
             response: finalText,
             durationMs: Date.now() - startedAt,
             stopReason,
+            ...this.stdoutLogRef(sessionId),
           });
         }
       }
@@ -2609,14 +2768,70 @@ export class AcpService extends Service {
     return session;
   }
 
-  private async enforceSessionLimit(): Promise<void> {
-    const sessions = await this.store.list();
-    const active = sessions.filter(
-      (s) =>
-        !["stopped", "errored", "completed", "cancelled"].includes(s.status),
+  /**
+   * A session occupies a slot until it reaches a terminal status. Kept as a
+   * narrow list (not `TERMINAL_SESSION_STATUSES`) because an `error`-status
+   * session may still be mid-teardown and holding its subprocess; only the
+   * fully-settled statuses free the slot.
+   */
+  private static isActiveSession(session: SessionInfo): boolean {
+    return !["stopped", "errored", "completed", "cancelled"].includes(
+      session.status,
     );
-    if (active.length >= this.maxSessions)
-      throw new Error(`acpx max session limit reached (${this.maxSessions})`);
+  }
+
+  private static slotClassOf(session: SessionInfo): SessionSlotClass {
+    return session.metadata?.slotClass === "system" ? "system" : "worker";
+  }
+
+  /**
+   * Snapshot the two admission pools from the durable store. Worker and system
+   * counts are independent: a full worker pool never blocks a system spawn (the
+   * verifier headroom) and vice-versa.
+   */
+  private async countActiveSlots(): Promise<{
+    activeWorkers: number;
+    activeSystem: number;
+  }> {
+    const sessions = await this.store.list();
+    let activeWorkers = 0;
+    let activeSystem = 0;
+    for (const session of sessions) {
+      if (!AcpService.isActiveSession(session)) continue;
+      if (AcpService.slotClassOf(session) === "system") activeSystem += 1;
+      else activeWorkers += 1;
+    }
+    return { activeWorkers, activeSystem };
+  }
+
+  /**
+   * Live capacity across both admission pools. The queue dispatcher and planner
+   * provider read this instead of re-deriving the count so back-pressure is
+   * reported from one authoritative source.
+   */
+  async getCapacity(): Promise<AcpCapacity> {
+    const { activeWorkers, activeSystem } = await this.countActiveSlots();
+    return {
+      maxSessions: this.maxSessions,
+      systemHeadroom: this.systemHeadroom,
+      activeWorkers,
+      activeSystem,
+      freeWorkerSlots: Math.max(0, this.maxSessions - activeWorkers),
+      freeSystemSlots: Math.max(0, this.systemHeadroom - activeSystem),
+    };
+  }
+
+  private async enforceSessionLimit(
+    slotClass: SessionSlotClass,
+  ): Promise<void> {
+    const { activeWorkers, activeSystem } = await this.countActiveSlots();
+    if (slotClass === "system") {
+      if (activeSystem >= this.systemHeadroom)
+        throw new SessionCapError("system", this.systemHeadroom, activeSystem);
+      return;
+    }
+    if (activeWorkers >= this.maxSessions)
+      throw new SessionCapError("worker", this.maxSessions, activeWorkers);
   }
 
   /**
@@ -2633,7 +2848,10 @@ export class AcpService extends Service {
    * never rejects (we swallow on the tail) so one failed reservation doesn't
    * wedge the lock for later spawns.
    */
-  private async reserveSessionSlot(session: SessionInfo): Promise<void> {
+  private async reserveSessionSlot(
+    session: SessionInfo,
+    slotClass: SessionSlotClass,
+  ): Promise<void> {
     const previous = this.spawnReservationLock;
     let release!: () => void;
     this.spawnReservationLock = new Promise<void>((resolve) => {
@@ -2644,7 +2862,7 @@ export class AcpService extends Service {
     // awaiter; here we only serialize on its settle before counting slots.
     await previous.catch(() => {});
     try {
-      await this.enforceSessionLimit();
+      await this.enforceSessionLimit(slotClass);
       await this.store.create(session);
     } finally {
       release();
@@ -2993,6 +3211,47 @@ export class AcpService extends Service {
     return (this.outputBuffers.get(sessionId) ?? []).join("");
   }
 
+  // Path of the persisted raw-stdout log for a session, or undefined if no raw
+  // stdout write was queued (recording off, or no output). Merged into the
+  // `task_complete` event data so the task document references the ground-truth
+  // stdout file — the join key downstream tooling follows to the full stream.
+  private stdoutLogRef(
+    sessionId: string,
+  ): { stdoutLogPath: string } | Record<string, never> {
+    return this.persistedStdoutSessions.has(sessionId)
+      ? { stdoutLogPath: subagentStdoutLogPath(sessionId) }
+      : {};
+  }
+
+  private async flushRawStdout(sessionId: string): Promise<void> {
+    await this.pendingStdoutWrites.get(sessionId);
+  }
+
+  private persistRawStdout(sessionId: string, text: string): void {
+    if (!isSubagentStdoutLoggingEnabled()) return;
+    const previous =
+      this.pendingStdoutWrites.get(sessionId) ?? Promise.resolve();
+    const write = previous
+      .then(async () => {
+        const path = await appendSubagentStdout(sessionId, text);
+        if (path) this.persistedStdoutSessions.add(sessionId);
+      })
+      .catch((err: unknown) => {
+        // error-policy:J7 stdout persistence is diagnostics and must not kill the
+        // transport loop; surface it observably instead of swallowing.
+        this.runtime.reportError("AcpService.persistRawStdout", err, {
+          sessionId,
+          phase: "persist-stdout",
+        });
+      });
+    this.pendingStdoutWrites.set(sessionId, write);
+    void write.finally(() => {
+      if (this.pendingStdoutWrites.get(sessionId) === write) {
+        this.pendingStdoutWrites.delete(sessionId);
+      }
+    });
+  }
+
   private appendOutput(sessionId: string, text: string): void {
     const buffer = this.outputBuffers.get(sessionId) ?? [];
     buffer.push(text);
@@ -3107,7 +3366,7 @@ export class AcpService extends Service {
   }
 
   private assertTransportAvailable(sessionId: string): void {
-    if (process.env.ELIZA_PLATFORM !== "android") return;
+    if (!isAndroidMobile()) return;
     const message = this.missingCliMessage();
     if (!message) return;
     this.emitMissingCli(sessionId, message);


### PR DESCRIPTION
## Summary
- mark isolated ACP session workdirs in session metadata without changing the session DB schema
- remove only owned isolated `task-<sessionId>` scratch dirs after terminal close/delete paths
- add startup orphan GC for old untracked `task-*` dirs under configured ACP workspace roots while preserving tracked/fresh/manual dirs
- add focused regression coverage for owned scratch cleanup and startup orphan GC guards

Fixes part of #13773.

## Verification
- `bun run --cwd plugins/plugin-agent-orchestrator test src/__tests__/acp-scratch-lifecycle.test.ts --run`
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/src/__tests__/acp-scratch-lifecycle.test.ts`
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck`

## Notes
- This is the ACP scratch leak slice. It intentionally does not solve the broader same-repo git index isolation / shared workspace registry / disk backpressure items from #13773.