### PR TITLE
fix(ui): hydrate launcher Recents from persistence on mount

### DIFF
--- a/packages/ui/src/components/pages/LauncherSurface.test.tsx
+++ b/packages/ui/src/components/pages/LauncherSurface.test.tsx
@@ -14,6 +14,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ViewRegistryEntry } from "../../hooks/useAvailableViews";
 import { useRoutableViews } from "../../hooks/useAvailableViews";
+import { saveLauncherRecents } from "../../state/persistence";
 import { useEnabledViewKinds } from "../../state/useViewKinds";
 import { LauncherSurface } from "./LauncherSurface";
 
@@ -118,6 +119,17 @@ describe("LauncherSurface", () => {
   it("collapses duplicate wallet registrations to a single tile", () => {
     render(<LauncherSurface />);
     expect(screen.getAllByTestId("launcher-tile-wallet")).toHaveLength(1);
+  });
+
+  it("hydrates persisted launcher recents on first mount", () => {
+    saveLauncherRecents(["browser", "wallet"]);
+
+    render(<LauncherSurface />);
+
+    expect(screen.getByRole("heading", { name: "Recents" })).toBeTruthy();
+    expect(screen.getByTestId("launcher-zone-recents")).toBeTruthy();
+    expect(screen.getByTestId("launcher-recents-tile-browser")).toBeTruthy();
+    expect(screen.getByTestId("launcher-recents-tile-wallet")).toBeTruthy();
   });
 
   it("hides native-OS tiles off the AOSP fork and shows them on it", () => {

--- a/packages/ui/src/components/pages/LauncherSurface.tsx
+++ b/packages/ui/src/components/pages/LauncherSurface.tsx
@@ -17,6 +17,7 @@ import { getActiveViewModality } from "../../platform/platform-guards";
 import { useAppSelectorShallow } from "../../state";
 import {
   loadLauncherFavorites,
+  loadLauncherRecents,
   recordLauncherRecent,
   saveLauncherFavorites,
 } from "../../state/persistence";
@@ -40,7 +41,9 @@ export const LauncherSurface = React.memo(
     const activeModality = React.useMemo(() => getActiveViewModality(), []);
     const isAosp = React.useMemo(() => isAospShellEnabled(), []);
 
-    const [recentIds, setRecentIds] = React.useState<string[]>([]);
+    const [recentIds, setRecentIds] = React.useState<string[]>(() =>
+      loadLauncherRecents(),
+    );
     const [favoriteIds, setFavoriteIds] = React.useState<string[]>(() =>
       loadLauncherFavorites(),
     );


### PR DESCRIPTION
## Follow-up to #13883 (merged)

#13883 seeded `favoriteIds` from `loadLauncherFavorites()` but left `recentIds` initialized to `[]` and never called the existing `loadLauncherRecents()` (persistence.ts:936). So the persisted Recents zone renders **empty on every mount/reload** and only reappears after the user launches one more tile (which reads the list back) — contradicting the "persisted locally" contract and the Favorites behavior right beside it.

**Fix:** seed `recentIds` lazily from `loadLauncherRecents()`, mirroring `favoriteIds` exactly (one import + one initializer). Found in post-merge review of #13883.