### PR TITLE
fix(cloud-shared): stabilize eliza-app error-policy mocks

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts
@@ -24,7 +24,22 @@ mock.module("../oauth", () => ({
 }));
 
 mock.module("../../providers/language-model", () => ({
+  canonicalizeCerebrasModelId: mock((model: string) => model),
+  getAiProviderConfigurationError: mock(() => "mock provider unavailable"),
+  getAiProviderConfigurationStatus: mock(() => ({ configured: true, providers: [] })),
+  getAiProviderConfigurationSummary: mock(() => "mock provider configured"),
   getLanguageModel: mock(() => "mock-model"),
+  getTextEmbeddingModel: mock(() => "mock-embedding-model"),
+  hasAnthropicProviderConfigured: mock(() => true),
+  hasAnyAiProviderConfigured: mock(() => true),
+  hasGatewayProviderConfigured: mock(() => false),
+  hasGroqLanguageModelProviderConfigured: mock(() => false),
+  hasLanguageModelProviderConfigured: mock(() => true),
+  hasOpenAIProviderConfigured: mock(() => true),
+  hasTextEmbeddingProviderConfigured: mock(() => true),
+  resolveAiProviderSource: mock(() => "openai"),
+  resolveEmbeddingProviderSource: mock(() => "openai"),
+  resolvePooledDirectProviderForModel: mock(() => null),
 }));
 
 mock.module("../../utils/logger", () => ({

--- a/packages/cloud/shared/src/lib/services/eliza-app/provisioning.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/provisioning.error-policy.test.ts
@@ -15,6 +15,21 @@ const hasElizaAppInitialFreeCredits = mock();
 const addCredits = mock();
 const checkAgentCreditGate = mock();
 
+class InsufficientCreditsError extends Error {
+  constructor(
+    public readonly required: number,
+    public readonly available: number,
+    public readonly reason?: string,
+  ) {
+    super(
+      `Insufficient credits. Required: $${required.toFixed(4)}, Available: $${available.toFixed(4)}`,
+    );
+    this.name = "InsufficientCreditsError";
+  }
+}
+
+class CreditsService {}
+
 const deleteSandboxSpy = spyOn(agentSandboxesRepository, "delete").mockImplementation(
   (...args) => deleteSandbox(...args) as never,
 );
@@ -39,6 +54,12 @@ mock.module("../../../db/repositories/credit-transactions", () => ({
 
 mock.module("../credits", () => ({
   creditsService: { addCredits },
+  CreditsService,
+  InsufficientCreditsError,
+  COST_BUFFER: 1.5,
+  MIN_RESERVATION: 0.000001,
+  EPSILON: 0.0000001,
+  DEFAULT_OUTPUT_TOKENS: 500,
 }));
 
 const createAgentSpy = spyOn(elizaSandboxService, "createAgent").mockImplementation(

--- a/packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts
@@ -6,6 +6,22 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 const findByDiscordIdWithOrganization = mock();
 const findByPhoneNumberWithOrganization = mock();
 const update = mock();
+const addCredits = mock();
+
+class InsufficientCreditsError extends Error {
+  constructor(
+    public readonly required: number,
+    public readonly available: number,
+    public readonly reason?: string,
+  ) {
+    super(
+      `Insufficient credits. Required: $${required.toFixed(4)}, Available: $${available.toFixed(4)}`,
+    );
+    this.name = "InsufficientCreditsError";
+  }
+}
+
+class CreditsService {}
 
 mock.module("../../../db/repositories/users", () => ({
   usersRepository: {
@@ -41,7 +57,15 @@ mock.module("../../utils/phone-normalization", () => ({
 }));
 
 mock.module("../api-keys", () => ({ apiKeysService: { create: mock() } }));
-mock.module("../credits", () => ({ creditsService: { addCredits: mock() } }));
+mock.module("../credits", () => ({
+  creditsService: { addCredits },
+  CreditsService,
+  InsufficientCreditsError,
+  COST_BUFFER: 1.5,
+  MIN_RESERVATION: 0.000001,
+  EPSILON: 0.0000001,
+  DEFAULT_OUTPUT_TOKENS: 500,
+}));
 mock.module("../signup-code", () => ({ redeemSignupCode: mock() }));
 
 const { elizaAppUserService } = await import("./user-service");
@@ -57,6 +81,7 @@ describe("ElizaAppUserService.findOrCreateByDiscordId error policy", () => {
     findByDiscordIdWithOrganization.mockReset();
     findByPhoneNumberWithOrganization.mockReset();
     update.mockReset();
+    addCredits.mockReset();
     // Phone is unowned by default so the phone-link branch is reachable.
     findByPhoneNumberWithOrganization.mockResolvedValue(undefined);
   });


### PR DESCRIPTION
## Summary
- Stabilizes the eliza-app error-policy Bun tests after #13888 by making process-global mocks preserve the exports expected by adjacent imports.
- Widens the `../credits` mocks used by provisioning/user-service tests and the `language-model` mock used by connection enforcement so grouped runs do not fail during module load.

## Verification
- `bun run --cwd packages/shared build:i18n`
- `bun run --cwd packages/cloud/routing build`
- `bun run --cwd packages/core build`
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts packages/cloud/shared/src/lib/services/eliza-app/provisioning.error-policy.test.ts packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts`
- `bun test packages/cloud/shared/src/lib/services/eliza-app/*.error-policy.test.ts` (35 pass, 0 fail)

Issue: #13415