### PR TITLE
test(app-core): isolate plugin registry deadline helper

### DIFF
--- a/packages/app-core/src/api/plugin-registry-load-deadline.ts
+++ b/packages/app-core/src/api/plugin-registry-load-deadline.ts
@@ -1,0 +1,22 @@
+/** How long a /api/plugins request waits for the lazy plugin-registry module
+ * before answering 503 (the import keeps loading; retries land once warm). */
+export const PLUGIN_REGISTRY_LOAD_DEADLINE_MS = 2_000;
+
+/** Resolve `promise` or null after `ms` - never rejects from the timer side. */
+export async function resolveWithinDeadline<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<T | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), ms);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/packages/app-core/src/api/server-plugins-route-deadline.test.ts
+++ b/packages/app-core/src/api/server-plugins-route-deadline.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { resolveWithinDeadline } from "./server";
+import { resolveWithinDeadline } from "./plugin-registry-load-deadline";
 
 describe("resolveWithinDeadline", () => {
   it("returns the value when the promise settles inside the deadline", async () => {

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -168,6 +168,10 @@ import {
   normalizeRouteKey,
   recordRouteTiming,
 } from "./perf-instrument";
+import {
+  PLUGIN_REGISTRY_LOAD_DEADLINE_MS,
+  resolveWithinDeadline,
+} from "./plugin-registry-load-deadline";
 import { handleSecretsInventoryRoute } from "./secrets-inventory-routes";
 import { handleSecretsManagerRoute } from "./secrets-manager-routes";
 import { handleSensitiveRequestRoutes } from "./sensitive-request-routes";
@@ -202,30 +206,6 @@ function getPluginRegistryApi(): Promise<
 > {
   pluginRegistryApiPromise ??= import("@elizaos/plugin-registry");
   return pluginRegistryApiPromise;
-}
-
-/** How long a /api/plugins request waits for the lazy plugin-registry module
- * before answering 503 (the import keeps loading; retries land once warm). */
-export const PLUGIN_REGISTRY_LOAD_DEADLINE_MS = 2_000;
-
-/** Resolve `promise` or null after `ms` — never rejects from the timer side.
- * Exported for tests (#13859). */
-export async function resolveWithinDeadline<T>(
-  promise: Promise<T>,
-  ms: number,
-): Promise<T | null> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<null>((resolve) => {
-        timer = setTimeout(() => resolve(null), ms);
-        timer.unref?.();
-      }),
-    ]);
-  } finally {
-    if (timer !== undefined) clearTimeout(timer);
-  }
 }
 
 import {


### PR DESCRIPTION
## Summary
- Moves the `/api/plugins` cold-load deadline helper out of `server.ts` into a side-effect-light helper module.
- Updates the deadline unit test to import the helper directly so it no longer drags in the full app-core/agent optional-plugin graph before tests run.

## Verification
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --cwd packages/cloud/routing build`
- `bun run --cwd packages/core build`
- `bun run --cwd packages/security build`
- `bun run --cwd packages/agent build`
- `bunx @biomejs/biome check packages/app-core/src/api/server.ts packages/app-core/src/api/server-plugins-route-deadline.test.ts packages/app-core/src/api/plugin-registry-load-deadline.ts --no-errors-on-unmatched`
- `bun run --cwd packages/app-core test src/api/server-plugins-route-deadline.test.ts --run` (1 file, 3 tests passed)
- `git diff --check origin/develop...HEAD && git diff --check`

## Note
- `bun run --cwd packages/app-core typecheck` is currently blocked in this worktree by pre-existing missing optional/plugin declarations (`@elizaos/plugin-elizacloud/host-routes`, native Capacitor packages, optional plugins) and unrelated existing type errors in `proactive-interaction-decider` / iOS bridge files.