### PR TITLE
fix(cloud): honor stream_options.include_usage on streamed chat completions

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-stream-usage-frame.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-stream-usage-frame.test.ts
@@ -189,6 +189,26 @@ describe("streaming chat — stream_options.include_usage usage frame", () => {
     expect(finalChunk.choices[0].finish_reason).toBe("stop");
   });
 
+  test("empty usage objects do not fabricate a zero-token usage frame", async () => {
+    streamTextDoubleWithFinish({});
+
+    const res = await callStreaming({
+      model: MODEL,
+      messages: [{ role: "user", content: "hello" }],
+      stream: true,
+      stream_options: { include_usage: true },
+    });
+    const { jsonFrames } = await collectJsonFrames(res);
+
+    for (const frame of jsonFrames) {
+      expect(frame.usage ?? null).toBeNull();
+    }
+    const finalChunk = jsonFrames[jsonFrames.length - 1] as {
+      choices: Array<{ finish_reason: string | null }>;
+    };
+    expect(finalChunk.choices[0].finish_reason).toBe("stop");
+  });
+
   test("mid-stream provider error emits the terminal error chunk, never a usage frame", async () => {
     streamTextImpl = () => ({
       fullStream: (async function* () {

--- a/packages/cloud/api/__tests__/chat-completions-stream-usage-frame.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-stream-usage-frame.test.ts
@@ -1,0 +1,215 @@
+/**
+ * OpenAI stream_options.include_usage contract for POST /api/v1/chat/completions
+ * streaming: a terminal usage-only chunk (empty choices) before `data: [DONE]`,
+ * `usage: null` on every other chunk, nothing when not requested, and never a
+ * fabricated usage frame when the SDK reported none. Drives the REAL streaming
+ * handler and asserts on the raw SSE bytes; only `streamText` (the provider
+ * boundary) is substituted, mirroring chat-completions-streaming-credit-leak.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Spread the real module so other test files importing from "ai" are not
+// stranded by the process-wide registry replacement; restore in afterAll.
+const aiActual = require("ai") as Record<string, unknown>;
+
+import * as languageModelActual from "@/lib/providers/language-model";
+
+let streamTextImpl: ((config: Record<string, unknown>) => unknown) | null =
+  null;
+const streamText = mock((config: Record<string, unknown>) => {
+  if (!streamTextImpl) throw new Error("streamTextImpl not set");
+  return streamTextImpl(config);
+});
+mock.module("ai", () => ({
+  ...aiActual,
+  streamText,
+}));
+
+mock.module("@/lib/providers/language-model", () => ({
+  ...languageModelActual,
+  getLanguageModel: () => ({}) as never,
+}));
+
+const { __streamingCreditTestHooks } = await import(
+  "../v1/chat/completions/route"
+);
+const { handleStreamingRequest } = __streamingCreditTestHooks;
+
+afterAll(() => {
+  mock.module("ai", () => aiActual);
+  mock.module("@/lib/providers/language-model", () => languageModelActual);
+});
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+const MODEL = "openai/gpt-oss-120b";
+
+function callStreaming(request: Record<string, unknown>) {
+  return handleStreamingRequest(
+    MODEL,
+    undefined,
+    [{ role: "user", content: "hello" }] as never,
+    request as never,
+    { id: USER, organization_id: ORG },
+    null,
+    null,
+    "idem-1",
+    "req-1",
+    null,
+    Date.now(),
+    undefined,
+    30_000,
+    1,
+    (async () => null) as never,
+    {} as never,
+    undefined,
+    {} as never,
+    "gateway" as never,
+    null,
+    false,
+  );
+}
+
+async function collectJsonFrames(res: Response) {
+  const body = await res.text();
+  const dataLines = body
+    .split("\n")
+    .filter((l) => l.startsWith("data: "))
+    .map((l) => l.slice("data: ".length).trim());
+  const jsonFrames = dataLines
+    .filter((d) => d && d !== "[DONE]")
+    .map((d) => JSON.parse(d) as Record<string, unknown>);
+  return { body, dataLines, jsonFrames };
+}
+
+const FINISH_USAGE = {
+  inputTokens: 72,
+  outputTokens: 60,
+  totalTokens: 132,
+  inputTokenDetails: { cacheReadTokens: 7 },
+};
+
+function streamTextDoubleWithFinish(totalUsage: unknown) {
+  streamTextImpl = () => ({
+    fullStream: (async function* () {
+      yield { type: "text-delta", id: "text-1", text: "ok" };
+      yield {
+        type: "finish",
+        finishReason: "stop",
+        rawFinishReason: "stop",
+        ...(totalUsage !== undefined ? { totalUsage } : {}),
+      };
+    })(),
+  });
+}
+
+beforeEach(() => {
+  streamText.mockClear();
+  streamTextImpl = null;
+});
+
+describe("streaming chat — stream_options.include_usage usage frame", () => {
+  test("terminal usage-only chunk carries the SDK's real token usage before [DONE]", async () => {
+    streamTextDoubleWithFinish(FINISH_USAGE);
+
+    const res = await callStreaming({
+      model: MODEL,
+      messages: [{ role: "user", content: "hello" }],
+      stream: true,
+      stream_options: { include_usage: true },
+    });
+    const { dataLines, jsonFrames } = await collectJsonFrames(res);
+
+    // Stream still terminates correctly.
+    expect(dataLines[dataLines.length - 1]).toBe("[DONE]");
+
+    // The last JSON frame is the usage-only chunk: empty choices, real usage.
+    const usageChunk = jsonFrames[jsonFrames.length - 1];
+    expect(usageChunk.choices).toEqual([]);
+    expect(usageChunk.usage).toMatchObject({
+      prompt_tokens: 72,
+      completion_tokens: 60,
+      total_tokens: 132,
+      prompt_tokens_details: { cached_tokens: 7 },
+    });
+
+    // The finish_reason chunk still precedes it, and every non-terminal chunk
+    // carries usage: null per the OpenAI contract.
+    const finishChunk = jsonFrames[jsonFrames.length - 2] as {
+      choices: Array<{ finish_reason: string | null }>;
+    };
+    expect(finishChunk.choices[0].finish_reason).toBe("stop");
+    for (const frame of jsonFrames.slice(0, -1)) {
+      expect("usage" in frame).toBe(true);
+      expect(frame.usage).toBeNull();
+    }
+  });
+
+  test("without stream_options no chunk carries a usage field (OpenAI default)", async () => {
+    streamTextDoubleWithFinish(FINISH_USAGE);
+
+    const res = await callStreaming({
+      model: MODEL,
+      messages: [{ role: "user", content: "hello" }],
+      stream: true,
+    });
+    const { dataLines, jsonFrames } = await collectJsonFrames(res);
+
+    expect(dataLines[dataLines.length - 1]).toBe("[DONE]");
+    for (const frame of jsonFrames) {
+      expect("usage" in frame).toBe(false);
+    }
+    const finalChunk = jsonFrames[jsonFrames.length - 1] as {
+      choices: Array<{ finish_reason: string | null }>;
+    };
+    expect(finalChunk.choices[0].finish_reason).toBe("stop");
+  });
+
+  test("no usage frame is fabricated when the finish part reports no usage", async () => {
+    streamTextDoubleWithFinish(undefined);
+
+    const res = await callStreaming({
+      model: MODEL,
+      messages: [{ role: "user", content: "hello" }],
+      stream: true,
+      stream_options: { include_usage: true },
+    });
+    const { dataLines, jsonFrames } = await collectJsonFrames(res);
+
+    expect(dataLines[dataLines.length - 1]).toBe("[DONE]");
+    // Chunks still carry usage: null, but no terminal chunk invents token
+    // counts the SDK never reported ("not loaded" must never read as zero).
+    for (const frame of jsonFrames) {
+      expect(frame.usage ?? null).toBeNull();
+    }
+    const finalChunk = jsonFrames[jsonFrames.length - 1] as {
+      choices: Array<{ finish_reason: string | null }>;
+    };
+    expect(finalChunk.choices[0].finish_reason).toBe("stop");
+  });
+
+  test("mid-stream provider error emits the terminal error chunk, never a usage frame", async () => {
+    streamTextImpl = () => ({
+      fullStream: (async function* () {
+        yield { type: "text-delta", id: "text-1", text: "partial" };
+        yield { type: "error", error: new Error("provider exploded") };
+      })(),
+    });
+
+    const res = await callStreaming({
+      model: MODEL,
+      messages: [{ role: "user", content: "hello" }],
+      stream: true,
+      stream_options: { include_usage: true },
+    });
+    const { dataLines, jsonFrames } = await collectJsonFrames(res);
+
+    expect(dataLines[dataLines.length - 1]).toBe("[DONE]");
+    const errorChunk = jsonFrames.find((f) => "error" in f);
+    expect(errorChunk).toBeDefined();
+    for (const frame of jsonFrames) {
+      expect(frame.usage ?? null).toBeNull();
+    }
+  });
+});

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -266,6 +266,14 @@ interface ChatRequest {
   frequency_penalty?: number;
   presence_penalty?: number;
   stream?: boolean;
+  /**
+   * OpenAI `stream_options`: when `include_usage` is true the stream carries
+   * `usage: null` on every chunk and one extra terminal chunk (empty `choices`)
+   * with the real token usage, before `data: [DONE]` — this is how streaming
+   * clients meter token spend (plugin-elizacloud requests it on every
+   * streamed call).
+   */
+  stream_options?: { include_usage?: boolean };
   stop?: string | string[];
   tools?: Array<{
     type: "function";
@@ -661,6 +669,32 @@ function formatOpenAIUsage(
     }
   }
   return out;
+}
+
+/**
+ * Normalize an SDK usage record into the token triple the OpenAI response
+ * shape requires — identical to what billUsage normalizes (inputTokens ??
+ * promptTokens, etc.), so client-visible usage always matches billed usage.
+ */
+function normalizeUsageTokens(usage: unknown): {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+} {
+  const record = (usage ?? {}) as {
+    inputTokens?: number;
+    promptTokens?: number;
+    outputTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+  };
+  const inputTokens = record.inputTokens ?? record.promptTokens ?? 0;
+  const outputTokens = record.outputTokens ?? record.completionTokens ?? 0;
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: record.totalTokens ?? inputTokens + outputTokens,
+  };
 }
 
 function firstNumber(...values: unknown[]): number | undefined {
@@ -1897,12 +1931,21 @@ async function handleStreamingRequest(
   // Convert to OpenAI-compatible SSE stream
   const encoder = new TextEncoder();
 
+  // OpenAI stream_options.include_usage contract: every chunk carries
+  // `usage: null` and one extra terminal chunk (empty `choices`) carries the
+  // real usage, before `data: [DONE]`. Without honoring it, streamed calls
+  // are unmeterable client-side — plugin-elizacloud requests this frame on
+  // every streamed call and emits MODEL_USED metering only when it arrives.
+  const includeUsage = request.stream_options?.include_usage === true;
+  const usageFieldOnChunks = includeUsage ? { usage: null } : {};
+
   const openAIStream = new ReadableStream({
     async start(controller) {
       const responseId = `chatcmpl-${Date.now()}`;
       const toolCallIndexes = new Map<string, number>();
       let nextToolCallIndex = 0;
       let finishReason = "stop";
+      let finishUsage: unknown;
 
       try {
         for await (const part of result.fullStream) {
@@ -1912,6 +1955,7 @@ async function handleStreamingRequest(
               object: "chat.completion.chunk",
               created: Math.floor(Date.now() / 1000),
               model,
+              ...usageFieldOnChunks,
               choices: [
                 {
                   index: 0,
@@ -1937,6 +1981,7 @@ async function handleStreamingRequest(
                   object: "chat.completion.chunk",
                   created: Math.floor(Date.now() / 1000),
                   model,
+                  ...usageFieldOnChunks,
                   choices: [
                     {
                       index: 0,
@@ -1968,6 +2013,7 @@ async function handleStreamingRequest(
                   object: "chat.completion.chunk",
                   created: Math.floor(Date.now() / 1000),
                   model,
+                  ...usageFieldOnChunks,
                   choices: [
                     {
                       index: 0,
@@ -1999,6 +2045,7 @@ async function handleStreamingRequest(
                   object: "chat.completion.chunk",
                   created: Math.floor(Date.now() / 1000),
                   model,
+                  ...usageFieldOnChunks,
                   choices: [
                     {
                       index: 0,
@@ -2030,6 +2077,7 @@ async function handleStreamingRequest(
               part.finishReason === "tool-calls"
                 ? "tool_calls"
                 : part.finishReason;
+            finishUsage = part.totalUsage;
           }
 
           if (part.type === "error") {
@@ -2043,6 +2091,7 @@ async function handleStreamingRequest(
           object: "chat.completion.chunk",
           created: Math.floor(Date.now() / 1000),
           model,
+          ...usageFieldOnChunks,
           choices: [
             {
               index: 0,
@@ -2054,6 +2103,27 @@ async function handleStreamingRequest(
         controller.enqueue(
           encoder.encode(`data: ${JSON.stringify(finalChunk)}\n\n`),
         );
+        // Terminal usage-only chunk (empty choices) per stream_options
+        // .include_usage. Only ever built from the SDK's reported usage — if
+        // the finish part never arrived there is nothing honest to report, so
+        // the frame is omitted rather than fabricated as zeros.
+        if (includeUsage && finishUsage !== undefined) {
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({
+                id: responseId,
+                object: "chat.completion.chunk",
+                created: Math.floor(Date.now() / 1000),
+                model,
+                choices: [],
+                usage: formatOpenAIUsage(
+                  normalizeUsageTokens(finishUsage),
+                  finishUsage,
+                ),
+              })}\n\n`,
+            ),
+          );
+        }
         controller.enqueue(encoder.encode("data: [DONE]\n\n"));
         controller.close();
       } catch (error) {
@@ -2190,27 +2260,9 @@ async function handleNonStreamingRequest(
     } as Parameters<typeof generateText>[0]);
 
     // Token counts for the OpenAI-compat response come straight from the
-    // model's reported usage — identical to what billUsage normalizes
-    // (inputTokens ?? promptTokens, etc.) — so the entire billing/settlement
-    // chain below can run off the response path without changing the bytes the
-    // client receives.
-    const usageRec = (result.usage ?? {}) as {
-      inputTokens?: number;
-      promptTokens?: number;
-      outputTokens?: number;
-      completionTokens?: number;
-      totalTokens?: number;
-    };
-    const responseInputTokens =
-      usageRec.inputTokens ?? usageRec.promptTokens ?? 0;
-    const responseOutputTokens =
-      usageRec.outputTokens ?? usageRec.completionTokens ?? 0;
-    const responseTokens = {
-      inputTokens: responseInputTokens,
-      outputTokens: responseOutputTokens,
-      totalTokens:
-        usageRec.totalTokens ?? responseInputTokens + responseOutputTokens,
-    };
+    // model's reported usage, so the entire billing/settlement chain below can
+    // run off the response path without changing the bytes the client receives.
+    const responseTokens = normalizeUsageTokens(result.usage);
     const responseLatencyMs = Date.now() - startTime;
 
     // Bill using actual usage from SDK response. Deferred via waitUntil so the

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -688,13 +688,33 @@ function normalizeUsageTokens(usage: unknown): {
     completionTokens?: number;
     totalTokens?: number;
   };
-  const inputTokens = record.inputTokens ?? record.promptTokens ?? 0;
-  const outputTokens = record.outputTokens ?? record.completionTokens ?? 0;
+  const inputTokens = firstNumber(record.inputTokens, record.promptTokens) ?? 0;
+  const outputTokens =
+    firstNumber(record.outputTokens, record.completionTokens) ?? 0;
   return {
     inputTokens,
     outputTokens,
-    totalTokens: record.totalTokens ?? inputTokens + outputTokens,
+    totalTokens: firstNumber(record.totalTokens) ?? inputTokens + outputTokens,
   };
+}
+
+function hasReportedUsageTokens(usage: unknown): boolean {
+  const record = (usage ?? {}) as {
+    inputTokens?: number;
+    promptTokens?: number;
+    outputTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+  };
+  return (
+    firstNumber(
+      record.inputTokens,
+      record.promptTokens,
+      record.outputTokens,
+      record.completionTokens,
+      record.totalTokens,
+    ) !== undefined
+  );
 }
 
 function firstNumber(...values: unknown[]): number | undefined {
@@ -2107,7 +2127,7 @@ async function handleStreamingRequest(
         // .include_usage. Only ever built from the SDK's reported usage — if
         // the finish part never arrived there is nothing honest to report, so
         // the frame is omitted rather than fabricated as zeros.
-        if (includeUsage && finishUsage !== undefined) {
+        if (includeUsage && hasReportedUsageTokens(finishUsage)) {
           controller.enqueue(
             encoder.encode(
               `data: ${JSON.stringify({


### PR DESCRIPTION
Part of the #13406 error-honesty batch (`[core-brain]` card 8: stream usage frame). Streamed cloud chat replies carried no usage frame, so OpenAI-compatible clients could not meter token usage on streamed turns — billing itself was unaffected (the server meters from the SDK `onFinish` usage separately), but the client was blind.

## Defect (proven live on prod, before this fix)

`POST /api/v1/chat/completions` with `stream:true` and `stream_options:{include_usage:true}` (real key, prod `elizacloud.ai`, 2026-07-05):

```
[stream] HTTP 200 content-type=text/event-stream
[stream] data frames=3 json=2 frames-with-usage=0 done-marker=true
[stream] last 2 json frames: [
  {"id":"chatcmpl-1783220839086","object":"chat.completion.chunk","created":1783220839,"model":"gpt-oss-120b","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]},
  {"id":"chatcmpl-1783220839086","object":"chat.completion.chunk","created":1783220841,"model":"gpt-oss-120b","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}]
```

The `stream_options` field was silently ignored — `ChatRequest` didn't even declare it, and the SSE conversion never emitted usage. Non-streaming control on the same prompt returns usage fine (confirms the card-5 finding):

```
[non-stream] HTTP 200 usage={"prompt_tokens":72,"completion_tokens":60,"total_tokens":132,...}
```

The client half of the contract already exists and was starving: `plugin-elizacloud` sets `stream_options:{include_usage:true}` on every streamed call (`src/models/text.ts:1389`) and gates its `MODEL_USED` metering event on a usage frame arriving (`text.ts:1570-1589`) — so streamed turns emitted **zero** client-side metering events.

## Fix (structural, server-side emission)

`packages/cloud/api/v1/chat/completions/route.ts`:

- `ChatRequest` declares `stream_options?: { include_usage?: boolean }`.
- The streaming handler captures `totalUsage` from the AI SDK `finish` stream part and, when `include_usage` is requested, emits the OpenAI-spec terminal usage-only chunk (`choices: []`, real `usage`) after the finish_reason chunk and before `data: [DONE]`; every other chunk carries `usage: null`, per the OpenAI contract.
- Usage is never fabricated: if the SDK never reported finish usage, the frame is omitted rather than emitted as zeros ("not loaded" must never read as "zero").
- Token normalization (`inputTokens ?? promptTokens`, etc.) is extracted into one `normalizeUsageTokens` used by both the streaming and non-streaming paths, so client-visible usage always matches billed usage. Non-streaming bytes are unchanged.
- Clients that don't send `stream_options` see a byte-identical stream to before (OpenAI default: no usage fields at all).

No upstream request change was needed: this route is not a raw SSE proxy — it re-emits chunks from AI SDK `streamText`, which already obtains usage internally (that's how streaming `onFinish` billing meters real tokens today). Verified the adjacent proxy surfaces need no change either: `v1/apps/[id]/chat` forwards provider bytes verbatim (a client-sent `stream_options` passes through the direct providers' body spread, and the Vercel gateway provider already appends usage to its final chunk).

## Test (fails on the defect)

`packages/cloud/api/__tests__/chat-completions-stream-usage-frame.test.ts` — drives the real streaming handler through the same seam as the existing `chat-completions-streaming-credit-leak` suite (only `streamText`, the provider boundary, is substituted) and asserts on the raw SSE bytes:

1. `include_usage` → terminal usage-only chunk with the SDK's real tokens (`prompt_tokens:72`, `completion_tokens:60`, `total_tokens:132`, `prompt_tokens_details.cached_tokens:7`), empty `choices`, after the finish_reason chunk, before `[DONE]`; `usage: null` on every other chunk. **RED on unfixed develop** (last frame was the bare finish_reason chunk), GREEN with the fix.
2. No `stream_options` → no chunk carries a usage field (pins the OpenAI default).
3. Finish part without usage → no fabricated zero-usage frame.
4. Mid-stream provider error → terminal error chunk, never a usage frame.

## Verification

- New suite: 4/4 pass with fix; RED confirmed on develop `0ea85dfaea` (1 fail = exactly the defect assertion).
- All six suites covering this route under CI mechanics (`bun test --isolate`, same flag `test:cloud` uses): **53 pass / 0 fail** (`chat-completions-streaming-credit-leak` 12, `chat-completions-optimistic-billing` 8, `chat-completions-tool-choice` 21, `chat-completions-affiliate-reserve` 2, `chat-stream-credit-leak` 6, new suite 4).
- `bun run --cwd packages/cloud/api typecheck`: 0 errors in touched files; the single reported error (`__tests__/my-agents-claim-affiliate-characters.test.ts:83`) fails identically on clean develop with this diff stashed — pre-existing, unrelated route.
- Biome clean on both files; `bun run audit:error-policy-ratchet`: no new fallback-slop.
- Client-half contract pinned by existing `plugin-elizacloud` tests (`__tests__/text-streaming.test.ts` resolves `usage` from a final usage frame); its SSE parser handles the empty-`choices` frame (`asRecord(undefined)` → `{}`).

Post-deploy check: rerun the same prod probe — the streamed call must report `frames-with-usage=1` with `prompt_tokens`/`completion_tokens` matching the non-streaming control.

Evidence rows not applicable to this backend-only response-shape change: UI screenshots/video N/A (no rendered surface), live-LLM trajectories N/A (no agent/prompt/model-behavior change; the live prod SSE traces above are the domain artifact).
