### PR TITLE
test(cloud-shared): isolate eliza-app user-service mocks

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
@@ -94,6 +94,7 @@ describe("onboarding-chat phone-link error policy", () => {
 
   afterAll(() => {
     mock.module("../../runtime/cloud-bindings", () => REAL_CLOUD_BINDINGS);
+    mock.restore();
   });
 
   test("a genuine linkPhoneToUser infra failure PROPAGATES (fail closed, never swallowed)", async () => {

--- a/packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts
@@ -47,7 +47,9 @@ mock.module("../credits", () => ({
 }));
 mock.module("../signup-code", () => ({ redeemSignupCode: mock() }));
 
-const { elizaAppUserService } = await import("./user-service");
+const { elizaAppUserService } = await import(
+  `./user-service.ts?test=user-service-error-policy-${Date.now()}`
+);
 
 function uniqueConstraintError(): Error {
   return Object.assign(new Error("duplicate key value violates unique constraint"), {


### PR DESCRIPTION
## Summary

Follow-up to merged #13894 / #13888.

The combined eliza-app error-policy suite still failed after #13894 because `onboarding-chat.error-policy.test.ts` registered a process-global Bun mock for `./user-service` with only `linkPhoneToUser`. When `user-service.error-policy.test.ts` ran later in the same Bun process, its `await import("./user-service")` reused that partial mock, so `elizaAppUserService.findOrCreateByDiscordId` was undefined.

Fix:
- restore Bun mocks from the onboarding-chat teardown after its focused tests complete;
- import `user-service.ts` in the user-service contract test with a unique query string, matching the local pattern used by onboarding, so it exercises a fresh real service module instead of a leaked partial mock.

## Verification

- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts --no-errors-on-unmatched`
- `bun test ./packages/cloud/shared/src/lib/services/eliza-app/config.error-policy.test.ts ./packages/cloud/shared/src/lib/services/eliza-app/connection-enforcement.error-policy.test.ts ./packages/cloud/shared/src/lib/services/eliza-app/discord-auth.error-policy.test.ts ./packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts ./packages/cloud/shared/src/lib/services/eliza-app/provisioning.error-policy.test.ts ./packages/cloud/shared/src/lib/services/eliza-app/session-service.error-policy.test.ts ./packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts` — 35 pass, 0 fail
- `git diff --check origin/develop...HEAD && git diff --check`

Evidence type notes: test-only stabilization; no runtime behavior, UI, model, or DB artifacts changed.