### PR TITLE
ci(ios): add local(full-Bun) + cloud runtime-mode sim lanes (#13578)

### DIFF
--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -7,6 +7,11 @@ on:
     branches: [main, develop]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
+    inputs:
+      cloud_api_base:
+        description: "Eliza Cloud API base for the iOS cloud runtime-mode smoke (defaults to the staging sandbox var, then prod)"
+        required: false
+        default: ""
   schedule:
     # Nightly iOS local (full-Bun on-device engine) lane (#13578). This mode
     # is too heavy for the PR path — a full-Bun engine build, a real ~1.3GB
@@ -405,6 +410,80 @@ jobs:
         with:
           name: ios-full-bun-local-chat
           path: packages/app/test-results/ios-full-bun-local-chat/**
+          if-no-files-found: warn
+          retention-days: 7
+
+  ios-cloud-mode:
+    name: iOS Cloud Runtime-Mode Smoke
+    # Nightly / on-demand only — never on the PR path. Provisioning a real Eliza
+    # Cloud agent (Hetzner-backed) is slow and costs org credit, so the cloud
+    # runtime mode gates the scheduled run alongside the full-Bun local lane.
+    # This closes the third row of the #13578 coverage matrix: remote mode is
+    # PR-blocking and local (full-Bun) mode gates nightly, but cloud mode had no
+    # unattended lane at all — the XCUITest cloud-onboarding path XCTSkips at the
+    # OAuth wall without a device Cloud session, and cloud-provisioning-e2e.mjs
+    # (the programmatic cloud runtime assertion) was only reachable behind the
+    # unwired `ios-e2e.mjs --cloud`. cloud-provisioning-e2e.mjs has no workspace
+    # imports (node built-ins + fetch only) and needs no build/simulator, so the
+    # cloud runtime-mode gate is a fast ubuntu job seeded with a real Cloud
+    # credential rather than a browser OAuth leg.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      # Headless session seed (#13578 done-when #2): a real Cloud credential
+      # injected from the org secret, bypassing the interactive device-code /
+      # OAuth browser leg that XCTSkips on the simulator. ELIZACLOUD_API_KEY is
+      # the same secret launch-hardening-8756.yml uses for its fresh-agent probe.
+      ELIZA_CLOUD_AUTH_TOKEN: ${{ secrets.ELIZACLOUD_API_KEY }}
+      # ORIGIN ONLY — cloud-provisioning-e2e.mjs appends `/api/v1/...` itself, so
+      # this must NOT carry an `/api/v1` suffix (unlike the sandbox-live-smoke
+      # `_URL` var, which does). Overridable via workflow_dispatch to target a
+      # throwaway org; defaults to production Cloud otherwise.
+      ELIZA_CLOUD_API_BASE: ${{ github.event.inputs.cloud_api_base || 'https://api.elizacloud.ai' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+
+      - name: Run iOS cloud runtime-mode provisioning smoke (#13578)
+        # Gating check for the cloud runtime mode. With the seed present this is a
+        # HARD gate (no continue-on-error): a regression in cloud agent creation,
+        # Hetzner provisioning, or the provisioned runtime never answering fails
+        # the scheduled run. cloud-provisioning-e2e.mjs provisions a real agent,
+        # waits for its runtime URL, and probes /api/status|health|me — the same
+        # programmatic cloud path the iOS `ios-e2e.mjs --cloud` route calls. When
+        # the secret is absent (forks without secret access) the lane records an
+        # explicit skip in the step summary rather than silently passing green.
+        run: |
+          set -euo pipefail
+          if [ -z "${ELIZA_CLOUD_AUTH_TOKEN:-}" ]; then
+            {
+              echo "### iOS cloud runtime-mode smoke"
+              echo ""
+              echo "skipped: missing ELIZACLOUD_API_KEY secret (no Cloud session seed available)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "iOS cloud runtime-mode smoke skipped: missing ELIZACLOUD_API_KEY secret"
+            exit 0
+          fi
+          mkdir -p packages/app/test-results/ios-cloud-mode
+          node packages/app/scripts/cloud-provisioning-e2e.mjs \
+            --fresh-agent \
+            --agent-name "Eliza iOS Cloud Runtime-Mode Smoke" \
+            --report packages/app/test-results/ios-cloud-mode/cloud-provisioning.json \
+            2>&1 | tee packages/app/test-results/ios-cloud-mode/smoke.log
+
+      - name: Upload iOS cloud runtime-mode evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ios-cloud-mode
+          path: packages/app/test-results/ios-cloud-mode/**
           if-no-files-found: warn
           retention-days: 7
 

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -175,9 +175,11 @@ The iOS app ships three runtime modes; their unattended (CI) coverage is:
 |---|---|---|---|
 | **remote** (pair to a host agent) | none — proxies to a paired host | `build-ios` job in `.github/workflows/mobile-build-smoke.yml` (onboarding smoke + `serve-real-local-agent` host + local-chat smoke) | PR-blocking |
 | **local** (full-Bun on-device engine) | full Bun runtime + on-device GGUF | `build-ios-local` job in `mobile-build-smoke.yml` — nightly `schedule` (too heavy for the PR path): builds `build:ios:local:sim` (`ELIZA_IOS_FULL_BUN_ENGINE=1`), caches + stages a real small GGUF, boots a sim, installs, runs `test:sim:local-chat:ios:full-bun` and asserts the exact on-device reply | nightly-gating |
-| **cloud** (managed agent) | none — talks to Eliza Cloud | N/A — the XCUITest cloud-onboarding path (`testCloudOnboardingChatAndVoice`) XCTSkips at the OAuth wall with no device Cloud session, and `cloud-provisioning-e2e.mjs` is only reachable behind the unwired `ios-e2e.mjs --cloud`. Needs a documented headless session/JWT seed against a staging Cloud org before it can run unattended (see #13578 done-when #2). | none (blocked) |
+| **cloud** (managed agent) | none — talks to Eliza Cloud | `ios-cloud-mode` job in `mobile-build-smoke.yml` — nightly `schedule` / `workflow_dispatch` (provisioning a real Hetzner-backed agent costs org credit, so it never runs on the PR path). Seeds a real Cloud credential from `secrets.ELIZACLOUD_API_KEY` (the headless session seed — bypasses the interactive device-code / OAuth browser leg that XCTSkips on the simulator) and runs `cloud-provisioning-e2e.mjs --fresh-agent`: creates a Cloud agent, waits for its runtime URL, and probes `/api/status|health|me`. With the seed present it is a HARD gate (no `continue-on-error`); when the secret is absent it records an explicit skip in the step summary. | nightly-gating (when seeded) |
 
 Keep this table honest: an N/A row must name what is missing, not hide it.
+
+The XCUITest cloud-onboarding path (`testCloudOnboardingChatAndVoice`) still XCTSkips at the OAuth wall without a device Cloud session; the `ios-cloud-mode` lane covers the cloud *runtime* mode programmatically (the same path `ios-e2e.mjs --cloud` calls) rather than driving the simulator UI through OAuth. A device-UI cloud-onboarding lane needs the WebView-side session seed (`steward_session_token` / `POST /api/cloud/login/persist`) and is tracked in #13578 done-when #2.
 
 ## Config / env vars
 

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -175,9 +175,11 @@ The iOS app ships three runtime modes; their unattended (CI) coverage is:
 |---|---|---|---|
 | **remote** (pair to a host agent) | none — proxies to a paired host | `build-ios` job in `.github/workflows/mobile-build-smoke.yml` (onboarding smoke + `serve-real-local-agent` host + local-chat smoke) | PR-blocking |
 | **local** (full-Bun on-device engine) | full Bun runtime + on-device GGUF | `build-ios-local` job in `mobile-build-smoke.yml` — nightly `schedule` (too heavy for the PR path): builds `build:ios:local:sim` (`ELIZA_IOS_FULL_BUN_ENGINE=1`), caches + stages a real small GGUF, boots a sim, installs, runs `test:sim:local-chat:ios:full-bun` and asserts the exact on-device reply | nightly-gating |
-| **cloud** (managed agent) | none — talks to Eliza Cloud | N/A — the XCUITest cloud-onboarding path (`testCloudOnboardingChatAndVoice`) XCTSkips at the OAuth wall with no device Cloud session, and `cloud-provisioning-e2e.mjs` is only reachable behind the unwired `ios-e2e.mjs --cloud`. Needs a documented headless session/JWT seed against a staging Cloud org before it can run unattended (see #13578 done-when #2). | none (blocked) |
+| **cloud** (managed agent) | none — talks to Eliza Cloud | `ios-cloud-mode` job in `mobile-build-smoke.yml` — nightly `schedule` / `workflow_dispatch` (provisioning a real Hetzner-backed agent costs org credit, so it never runs on the PR path). Seeds a real Cloud credential from `secrets.ELIZACLOUD_API_KEY` (the headless session seed — bypasses the interactive device-code / OAuth browser leg that XCTSkips on the simulator) and runs `cloud-provisioning-e2e.mjs --fresh-agent`: creates a Cloud agent, waits for its runtime URL, and probes `/api/status|health|me`. With the seed present it is a HARD gate (no `continue-on-error`); when the secret is absent it records an explicit skip in the step summary. | nightly-gating (when seeded) |
 
 Keep this table honest: an N/A row must name what is missing, not hide it.
+
+The XCUITest cloud-onboarding path (`testCloudOnboardingChatAndVoice`) still XCTSkips at the OAuth wall without a device Cloud session; the `ios-cloud-mode` lane covers the cloud *runtime* mode programmatically (the same path `ios-e2e.mjs --cloud` calls) rather than driving the simulator UI through OAuth. A device-UI cloud-onboarding lane needs the WebView-side session seed (`steward_session_token` / `POST /api/cloud/login/persist`) and is tracked in #13578 done-when #2.
 
 ## Config / env vars
 


### PR DESCRIPTION
## Problem

Closes #13578 (partial — see coverage below). The iOS simulator loop's runtime-mode CI matrix was lopsided:

| Mode | Automated coverage (before) |
|---|---|
| **remote** (pair to host agent) | PR-blocking onboarding + local-chat smoke — good |
| **local** (full-Bun on-device engine) | nightly-gating `build-ios-local` job — landed in #13879 |
| **cloud** (managed agent) | **none** — XCUITest cloud-onboarding XCTSkips at the OAuth wall, and `cloud-provisioning-e2e.mjs` was only reachable behind the unwired `ios-e2e.mjs --cloud` |

A regression in cloud provisioning/onboarding could not be caught by any unattended gating lane.

## What this PR does

Adds a real **cloud runtime-mode** lane and records the honest matrix. (The local/full-Bun lane already merged via #13879, so this PR closes the remaining gap — done-when #2 + #3.)

- **New `ios-cloud-mode` job** in `.github/workflows/mobile-build-smoke.yml`:
  - Runs on `schedule` + `workflow_dispatch` only — never on the PR path (provisioning a real Hetzner-backed agent costs org credit).
  - **Headless session seed** (done-when #2): injects a real Cloud credential from `secrets.ELIZACLOUD_API_KEY` into `ELIZA_CLOUD_AUTH_TOKEN`, bypassing the interactive device-code / OAuth browser leg that XCTSkips on the simulator. Same secret `launch-hardening-8756.yml` uses.
  - Runs the **existing, real** `packages/app/scripts/cloud-provisioning-e2e.mjs --fresh-agent`: creates a Cloud agent, waits for its runtime URL, probes `/api/status|health|me` — the same programmatic cloud path `ios-e2e.mjs --cloud` calls. The script has zero workspace imports (node built-ins + `fetch`), so the lane needs **no build and no simulator**.
  - **Real gate, not `continue-on-error`:** with the seed present a provisioning failure fails the scheduled run. When the secret is absent (forks without secret access) it records an explicit skip in `$GITHUB_STEP_SUMMARY` rather than silently passing green.
  - `ELIZA_CLOUD_API_BASE` is an **origin only** (the script appends `/api/v1/...` itself); overridable via a new `cloud_api_base` `workflow_dispatch` input to target a throwaway org.
- **Matrix recorded** (done-when #3) in `packages/app/CLAUDE.md` (mirrored to `AGENTS.md`): the cloud row moves from `none (blocked)` → `nightly-gating (when seeded)`, and notes the still-blocked device-UI cloud-onboarding lane (needs the WebView-side `steward_session_token` seed).

## Verification

Live macOS/cloud CI run: **N/A** — I cannot run the macOS sim / real Cloud provisioning from this sandbox (no runner, no org credential). Instead every referenced script/flag/env is traced to its definition and the wiring is proven mechanically:

- `actionlint .github/workflows/mobile-build-smoke.yml` → **exit 0** (no shellcheck/expression errors).
- YAML parses (pyyaml `safe_load`); job list = `changes, build-ios, build-ios-local, ios-cloud-mode, build-android`.
- `node --check packages/app/scripts/cloud-provisioning-e2e.mjs` → syntax OK.
- Flags traced to source: `--fresh-agent` (`has("--fresh-agent")`, line 137), `--agent-name` (`arg("--agent-name")`, line 33), `--report` (line 38), `ELIZA_CLOUD_AUTH_TOKEN` / `ELIZA_CLOUD_API_BASE` (lines 23, 28).
- **Gate is real (seed present):** `ELIZA_CLOUD_AUTH_TOKEN=fake … --cloud-api-base http://127.0.0.1:59999` → prints `[cloud-e2e] FAILED: fetch failed`, **exit code 1** → the CI step (no `continue-on-error`) turns the run red.
- **Skip is clean (seed absent):** the `if [ -z "$ELIZA_CLOUD_AUTH_TOKEN" ]` branch prints the skip line and `exit 0`.
- `ios-cloud-mode` has no `needs:` on the PR-path `changes` classifier and no `continue-on-error` on the gating step (asserted via parsed YAML).

Path shape is correct: `cloud-provisioning-e2e.mjs` builds `${base}/api/v1/...`, so `ELIZA_CLOUD_API_BASE` is set to a bare origin (`https://api.elizacloud.ai`) — deliberately NOT the sandbox-live-smoke `_URL` var, which carries a trailing `/api/v1` and would double up.

## Residuals

- The **device-UI** cloud-onboarding XCUITest (`testCloudOnboardingChatAndVoice`) still XCTSkips at the OAuth wall — turning that skip into a failure needs the WebView-side `steward_session_token` / `POST /api/cloud/login/persist` seed. This lane covers the cloud *runtime* mode programmatically; the device-UI onboarding seed is left for a follow-up (documented in the matrix).
- First live proof requires the scheduled/dispatch run with `secrets.ELIZACLOUD_API_KEY` populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
