### PR TITLE
test(talkmode): pin voice volume mute policy

### DIFF
--- a/.github/issue-evidence/13697-voice-volume-mute-semantics.md
+++ b/.github/issue-evidence/13697-voice-volume-mute-semantics.md
@@ -1,0 +1,50 @@
+# Evidence — #13697 voice volume/mute semantics
+
+## What changed
+
+- Added `plugins/plugin-native-talkmode/README.md` policy for iOS, Android,
+  Electrobun desktop, and browser volume/mute behavior.
+- Added `plugins/plugin-native-talkmode/src/audio-policy-contract.test.ts` to
+  pin the native-source invariants behind that policy:
+  - iOS must stay on `AVAudioSession` `.playAndRecord` + `.voiceChat`.
+  - Android TTS/PCM must stay on `USAGE_VOICE_COMMUNICATION` /
+    `MODE_IN_COMMUNICATION`.
+  - Android recognizer-earcon muting must not include `STREAM_VOICE_CALL`.
+
+## Verification run locally
+
+```bash
+$ bun run --cwd plugins/plugin-native-talkmode test
+Test Files  2 passed (2)
+Tests       7 passed (7)
+
+$ bunx @biomejs/biome check plugins/plugin-native-talkmode/README.md \
+    plugins/plugin-native-talkmode/src/audio-policy-contract.test.ts \
+    .github/issue-evidence/13697-voice-volume-mute-semantics.md
+Checked 1 file. No fixes applied.
+
+$ git diff --check
+passed
+```
+
+Additional checks:
+
+```bash
+$ bun run --cwd plugins/plugin-native-talkmode typecheck
+blocked: pre-existing package resolution failure in origin/develop path
+plugins/plugin-native-talkmode/src/web.ts:
+Cannot find module '@elizaos/native-plugin-shared-types'
+
+$ (cd plugins/plugin-native-talkmode/ios && swift test)
+blocked: this host Swift toolchain cannot import XCTest
+```
+
+## Evidence rows
+
+- Real device / simulator audio proof: N/A for this slice. This host has not
+  run hardware silent-switch, Android stream-mute, or desktop system-mute audio
+  captures. The policy and contract tests prevent silent source drift; the
+  issue still requires real audio-lane evidence before final human approval.
+- Real-LLM trajectory: N/A — no agent prompt/model/action behavior changed.
+- Screenshots/video: N/A — no UI changed.
+- Domain artifact reviewed by hand: README policy and source-contract test.

--- a/.github/issue-evidence/13697-voice-volume-mute-semantics.md
+++ b/.github/issue-evidence/13697-voice-volume-mute-semantics.md
@@ -48,3 +48,37 @@ blocked: this host Swift toolchain cannot import XCTest
 - Real-LLM trajectory: N/A — no agent prompt/model/action behavior changed.
 - Screenshots/video: N/A — no UI changed.
 - Domain artifact reviewed by hand: README policy and source-contract test.
+
+## Follow-up design slice merged into this branch
+
+This branch also pins the headless TalkMode policy contract in
+`plugins/plugin-native-talkmode/src/volumeMutePolicy.ts` with deterministic tests
+in `plugins/plugin-native-talkmode/src/volumeMutePolicy.test.ts`:
+
+- voice capture is input-side state and continues when output is muted or set to
+  volume 0;
+- the capture indicator stays `recording` while capture remains live under muted
+  output;
+- TTS follows the platform output lane and continues progressing silently under
+  mute / volume 0 instead of pausing or canceling;
+- restoring output volume makes the same in-flight utterance audible again;
+- stale TTS finish events cannot clear the current utterance.
+
+Additional verification:
+
+```bash
+$ bun test plugins/plugin-native-talkmode/src/audio-policy-contract.test.ts \
+    plugins/plugin-native-talkmode/src/volumeMutePolicy.test.ts
+11 pass / 53 expects
+
+$ bunx @biomejs/biome check plugins/plugin-native-talkmode/README.md \
+    plugins/plugin-native-talkmode/src/audio-policy-contract.test.ts \
+    plugins/plugin-native-talkmode/src/volumeMutePolicy.ts \
+    plugins/plugin-native-talkmode/src/volumeMutePolicy.test.ts \
+    plugins/plugin-native-talkmode/src/index.ts \
+    .github/issue-evidence/13697-voice-volume-mute-semantics.md
+pass
+
+$ git diff --check
+pass
+```

--- a/plugins/plugin-native-talkmode/README.md
+++ b/plugins/plugin-native-talkmode/README.md
@@ -128,6 +128,28 @@ All config is passed to `start()` or `updateConfig()` — no process env vars ar
 | Electrobun (desktop) | Native STT | ElevenLabs streaming + system TTS fallback |
 | Browser | Web Speech API | `SpeechSynthesis` only (ElevenLabs blocked by CORS) |
 
+## Volume and mute policy
+
+TalkMode treats voice as an active communication session. The policy is:
+
+- **iOS:** configure `AVAudioSession` as `.playAndRecord` with `.voiceChat` and
+  `.defaultToSpeaker` while allowing Bluetooth output. TTS is expected to stay
+  audible during a voice session even when the hardware silent switch is on;
+  volume buttons control the active output route volume. Microphone capture is
+  unaffected by output volume or silent switch state.
+- **Android:** route TTS/PCM playback through `USAGE_VOICE_COMMUNICATION` while
+  the app is in `MODE_IN_COMMUNICATION`, defaulting to speaker unless a headset
+  is connected. The plugin may mute recognizer earcon streams during a session,
+  but it must not mute the voice-communication output path. Hardware volume keys
+  control the communication stream; OS mute can silence output, but capture and
+  the agent turn must remain interactive and recoverable.
+- **Electrobun desktop:** honor the operating system output volume/mute state.
+  Muting output may make TTS inaudible, but it must not stop microphone capture,
+  chat orchestration, or completion events.
+- **Browser:** `SpeechSynthesis` follows browser/OS output controls. Microphone
+  capture is governed by browser permission and should continue independently of
+  output volume.
+
 ## Building
 
 ```bash

--- a/plugins/plugin-native-talkmode/src/audio-policy-contract.test.ts
+++ b/plugins/plugin-native-talkmode/src/audio-policy-contract.test.ts
@@ -1,0 +1,52 @@
+/// <reference types="node" />
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(root, relativePath), "utf8");
+}
+
+describe("TalkMode volume and mute policy contracts", () => {
+  it("documents the cross-platform volume and mute semantics", () => {
+    const readme = read("README.md");
+
+    expect(readme).toContain("## Volume and mute policy");
+    expect(readme).toContain("AVAudioSession");
+    expect(readme).toContain("USAGE_VOICE_COMMUNICATION");
+    expect(readme).toContain("Electrobun desktop");
+    expect(readme).toContain("SpeechSynthesis");
+  });
+
+  it("keeps iOS TalkMode on a voice-chat play-and-record session", () => {
+    const source = read("ios/Sources/TalkModePlugin/TalkModePlugin.swift");
+
+    expect(source).toContain("setCategory(.playAndRecord");
+    expect(source).toContain("mode: .voiceChat");
+    expect(source).toContain(".defaultToSpeaker");
+    expect(source).toContain(".allowBluetoothA2DP");
+    expect(source).not.toContain("setCategory(.playback");
+    expect(source).not.toContain("setCategory(.ambient");
+  });
+
+  it("keeps Android TalkMode output on the voice-communication path", () => {
+    const source = read(
+      "android/src/main/java/ai/eliza/plugins/talkmode/TalkModePlugin.kt",
+    );
+
+    expect(source).toContain("AudioAttributes.USAGE_VOICE_COMMUNICATION");
+    expect(source).toContain("AudioAttributes.CONTENT_TYPE_SPEECH");
+    expect(source).toContain("AudioManager.MODE_IN_COMMUNICATION");
+    expect(source).toContain(
+      "AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE",
+    );
+    expect(source).toContain("AudioManager.STREAM_MUSIC");
+    expect(source).toContain("AudioManager.STREAM_SYSTEM");
+    expect(source).toContain("AudioManager.STREAM_NOTIFICATION");
+    expect(source).not.toMatch(/earconStreams[\s\S]*STREAM_VOICE_CALL/);
+  });
+});

--- a/plugins/plugin-native-talkmode/src/index.ts
+++ b/plugins/plugin-native-talkmode/src/index.ts
@@ -2,6 +2,7 @@ import { registerPlugin } from "@capacitor/core";
 import type { TalkModePlugin } from "./definitions";
 
 export * from "./definitions";
+export * from "./volumeMutePolicy";
 
 const loadWeb = () => import("./web").then((m) => new m.TalkModeWeb());
 

--- a/plugins/plugin-native-talkmode/src/volumeMutePolicy.test.ts
+++ b/plugins/plugin-native-talkmode/src/volumeMutePolicy.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Deterministic coverage for TalkMode's output mute policy. The harness proves
+ * state transitions that do not require hardware audio, while explicitly
+ * leaving real mute/silent-switch routing to native device evidence.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createTalkModeAudioState,
+  getVolumeMutePolicy,
+  reduceTalkModeAudioPolicy,
+  type TalkModeAudioPlatform,
+} from "./volumeMutePolicy";
+
+const platforms: TalkModeAudioPlatform[] = [
+  "ios",
+  "android",
+  "electrobun",
+  "browser",
+];
+
+describe("volume and mute policy", () => {
+  it("defines the platform output lanes without treating mute as capture stop", () => {
+    expect(getVolumeMutePolicy("ios")).toMatchObject({
+      captureContinuesWhenOutputMuted: true,
+      captureIndicatorWhenOutputMuted: "recording",
+      ttsOutputChannel: "ios-play-and-record-voice-chat",
+      ttsProgressWhenOutputMuted: "continue",
+      requiresDeviceAudioVerification: true,
+    });
+    expect(getVolumeMutePolicy("android")).toMatchObject({
+      ttsOutputChannel: "android-voice-communication",
+      requiresDeviceAudioVerification: true,
+    });
+    expect(getVolumeMutePolicy("electrobun")).toMatchObject({
+      ttsOutputChannel: "desktop-system-output",
+      requiresDeviceAudioVerification: true,
+    });
+    expect(getVolumeMutePolicy("browser")).toMatchObject({
+      ttsOutputChannel: "browser-speech-synthesis-output",
+      requiresDeviceAudioVerification: false,
+    });
+  });
+
+  it.each(
+    platforms,
+  )("keeps %s capture live and visibly recording while output is muted", (platform) => {
+    const policy = getVolumeMutePolicy(platform);
+    let state = createTalkModeAudioState();
+
+    state = reduceTalkModeAudioPolicy(state, { type: "capture-started" });
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-mute-changed",
+      muted: true,
+    });
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-volume-changed",
+      volume: 0,
+    });
+
+    expect(policy.captureContinuesWhenOutputMuted).toBe(true);
+    expect(state.captureActive).toBe(true);
+    expect(state.captureIndicator).toBe("recording");
+  });
+
+  it("continues TTS silently when hardware mute or volume 0 is applied", () => {
+    let state = createTalkModeAudioState();
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "tts-started",
+      utteranceId: "reply-1",
+    });
+    expect(state.ttsAudibility).toBe("audible");
+    expect(state.ttsProgress).toBe("continue");
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-volume-changed",
+      volume: 0,
+    });
+    expect(state.ttsAudibility).toBe("silent-by-output-policy");
+    expect(state.ttsProgress).toBe("continue");
+    expect(state.ttsUtteranceId).toBe("reply-1");
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-mute-changed",
+      muted: true,
+    });
+    expect(state.ttsAudibility).toBe("silent-by-output-policy");
+    expect(state.ttsProgress).toBe("continue");
+    expect(state.ttsUtteranceId).toBe("reply-1");
+  });
+
+  it("restores audibility for the same utterance when output volume returns", () => {
+    let state = createTalkModeAudioState({
+      outputMuted: true,
+      outputVolume: 0,
+    });
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "tts-started",
+      utteranceId: "reply-2",
+    });
+    expect(state.ttsAudibility).toBe("silent-by-output-policy");
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-mute-changed",
+      muted: false,
+    });
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-volume-changed",
+      volume: 0.4,
+    });
+
+    expect(state.ttsUtteranceId).toBe("reply-2");
+    expect(state.ttsAudibility).toBe("audible");
+    expect(state.ttsProgress).toBe("continue");
+  });
+
+  it("ignores stale TTS finish events and clamps invalid output volume", () => {
+    let state = createTalkModeAudioState({ outputVolume: Number.NaN });
+    expect(state.outputVolume).toBe(1);
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-volume-changed",
+      volume: 2,
+    });
+    expect(state.outputVolume).toBe(1);
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "tts-started",
+      utteranceId: "current",
+    });
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "tts-finished",
+      utteranceId: "stale",
+    });
+    expect(state.ttsUtteranceId).toBe("current");
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "tts-finished",
+      utteranceId: "current",
+    });
+    expect(state.ttsUtteranceId).toBeNull();
+    expect(state.ttsAudibility).toBe("not-speaking");
+    expect(state.ttsProgress).toBe("idle");
+  });
+});

--- a/plugins/plugin-native-talkmode/src/volumeMutePolicy.ts
+++ b/plugins/plugin-native-talkmode/src/volumeMutePolicy.ts
@@ -1,0 +1,174 @@
+/**
+ * Headless TalkMode audio policy for the boundary between input capture and
+ * platform output mute/volume state. Native implementations still own real
+ * audio routing; this module gives UI and tests one deterministic contract for
+ * whether capture, indicators, and in-flight TTS should continue under mute.
+ */
+
+export type TalkModeAudioPlatform =
+  | "ios"
+  | "android"
+  | "electrobun"
+  | "browser";
+
+export type TalkModeCaptureIndicator = "recording" | "idle";
+
+export type TalkModeTtsAudibility =
+  | "audible"
+  | "silent-by-output-policy"
+  | "not-speaking";
+
+export type TalkModeTtsProgressPolicy = "continue";
+
+export type TalkModeTtsOutputChannel =
+  | "ios-play-and-record-voice-chat"
+  | "android-voice-communication"
+  | "desktop-system-output"
+  | "browser-speech-synthesis-output";
+
+export interface VolumeMutePolicy {
+  platform: TalkModeAudioPlatform;
+  /** Voice capture is input-side state and does not stop because output is muted or at volume 0. */
+  captureContinuesWhenOutputMuted: true;
+  /** UI affordance to keep showing while capture stays live under ringer/media mute. */
+  captureIndicatorWhenOutputMuted: "recording";
+  /** TTS follows the platform output lane listed here instead of inventing an app-local mute lane. */
+  ttsOutputChannel: TalkModeTtsOutputChannel;
+  /** Muting or setting output volume to 0 makes TTS inaudible but does not pause or cancel playback. */
+  ttsProgressWhenOutputMuted: TalkModeTtsProgressPolicy;
+  /** Hardware/device validation is required because simulators and headless tests cannot prove real audio routing. */
+  requiresDeviceAudioVerification: boolean;
+}
+
+export interface TalkModeAudioState {
+  captureActive: boolean;
+  captureIndicator: TalkModeCaptureIndicator;
+  ttsUtteranceId: string | null;
+  ttsProgress: TalkModeTtsProgressPolicy | "idle";
+  ttsAudibility: TalkModeTtsAudibility;
+  outputMuted: boolean;
+  outputVolume: number;
+}
+
+export type TalkModeAudioPolicyEvent =
+  | { type: "capture-started" }
+  | { type: "capture-stopped" }
+  | { type: "tts-started"; utteranceId: string }
+  | { type: "tts-finished"; utteranceId: string }
+  | { type: "output-mute-changed"; muted: boolean }
+  | { type: "output-volume-changed"; volume: number };
+
+const TTS_OUTPUT_CHANNEL_BY_PLATFORM = {
+  ios: "ios-play-and-record-voice-chat",
+  android: "android-voice-communication",
+  electrobun: "desktop-system-output",
+  browser: "browser-speech-synthesis-output",
+} as const satisfies Record<TalkModeAudioPlatform, TalkModeTtsOutputChannel>;
+
+export function getVolumeMutePolicy(
+  platform: TalkModeAudioPlatform,
+): VolumeMutePolicy {
+  return {
+    platform,
+    captureContinuesWhenOutputMuted: true,
+    captureIndicatorWhenOutputMuted: "recording",
+    ttsOutputChannel: TTS_OUTPUT_CHANNEL_BY_PLATFORM[platform],
+    ttsProgressWhenOutputMuted: "continue",
+    requiresDeviceAudioVerification: platform !== "browser",
+  };
+}
+
+export function createTalkModeAudioState(options?: {
+  outputMuted?: boolean;
+  outputVolume?: number;
+}): TalkModeAudioState {
+  const outputMuted = options?.outputMuted ?? false;
+  const outputVolume = normalizeOutputVolume(options?.outputVolume ?? 1);
+
+  return deriveTalkModeAudioState({
+    captureActive: false,
+    captureIndicator: "idle",
+    ttsUtteranceId: null,
+    ttsProgress: "idle",
+    ttsAudibility: "not-speaking",
+    outputMuted,
+    outputVolume,
+  });
+}
+
+export function reduceTalkModeAudioPolicy(
+  state: TalkModeAudioState,
+  event: TalkModeAudioPolicyEvent,
+): TalkModeAudioState {
+  switch (event.type) {
+    case "capture-started":
+      return deriveTalkModeAudioState({
+        ...state,
+        captureActive: true,
+        captureIndicator: "recording",
+      });
+    case "capture-stopped":
+      return deriveTalkModeAudioState({
+        ...state,
+        captureActive: false,
+        captureIndicator: "idle",
+      });
+    case "tts-started":
+      return deriveTalkModeAudioState({
+        ...state,
+        ttsUtteranceId: event.utteranceId,
+        ttsProgress: "continue",
+      });
+    case "tts-finished":
+      if (event.utteranceId !== state.ttsUtteranceId) {
+        return state;
+      }
+      return deriveTalkModeAudioState({
+        ...state,
+        ttsUtteranceId: null,
+        ttsProgress: "idle",
+      });
+    case "output-mute-changed":
+      return deriveTalkModeAudioState({
+        ...state,
+        outputMuted: event.muted,
+      });
+    case "output-volume-changed":
+      return deriveTalkModeAudioState({
+        ...state,
+        outputVolume: normalizeOutputVolume(event.volume),
+      });
+  }
+}
+
+function deriveTalkModeAudioState(
+  state: TalkModeAudioState,
+): TalkModeAudioState {
+  const ttsAudibility = getTtsAudibility(state);
+  const captureIndicator = state.captureActive ? "recording" : "idle";
+  const ttsProgress = state.ttsUtteranceId ? "continue" : "idle";
+
+  return {
+    ...state,
+    captureIndicator,
+    ttsProgress,
+    ttsAudibility,
+  };
+}
+
+function getTtsAudibility(state: TalkModeAudioState): TalkModeTtsAudibility {
+  if (!state.ttsUtteranceId) {
+    return "not-speaking";
+  }
+  if (state.outputMuted || state.outputVolume === 0) {
+    return "silent-by-output-policy";
+  }
+  return "audible";
+}
+
+function normalizeOutputVolume(volume: number): number {
+  if (!Number.isFinite(volume)) {
+    return 1;
+  }
+  return Math.min(1, Math.max(0, volume));
+}


### PR DESCRIPTION
## What changed

Implements the first concrete #13697 slice and folds in the headless policy design:

- Added a `Volume and mute policy` section to `plugins/plugin-native-talkmode/README.md` for iOS, Android, Electrobun desktop, and browser.
- Added `audio-policy-contract.test.ts`, a source contract test that fails if iOS leaves `.playAndRecord` / `.voiceChat`, Android stops using `USAGE_VOICE_COMMUNICATION` / `MODE_IN_COMMUNICATION`, or Android earcon muting starts muting `STREAM_VOICE_CALL`.
- Added `volumeMutePolicy.ts`, a pure TalkMode policy + reducer that pins the headless product behavior: capture continues under output mute / volume 0, capture indicator stays recording, TTS continues silently under muted output, restored volume makes the same utterance audible again, and stale TTS finish events cannot clear the current utterance.
- Exported the policy surface from the plugin entrypoint.
- Added issue evidence at `.github/issue-evidence/13697-voice-volume-mute-semantics.md`.

## Why

#13697 identified that hardware volume/mute behavior was undefined. The native code already had important choices baked in, but no product policy or regression guard. This PR makes the intended behavior explicit, pins the native source invariants, and gives the UI/tests a deterministic headless contract for output mute vs input capture.

## Verification

- `bun test plugins/plugin-native-talkmode/src/audio-policy-contract.test.ts plugins/plugin-native-talkmode/src/volumeMutePolicy.test.ts` — passed, 11 tests / 53 expects.
- `bunx @biomejs/biome check plugins/plugin-native-talkmode/README.md plugins/plugin-native-talkmode/src/audio-policy-contract.test.ts plugins/plugin-native-talkmode/src/volumeMutePolicy.ts plugins/plugin-native-talkmode/src/volumeMutePolicy.test.ts plugins/plugin-native-talkmode/src/index.ts .github/issue-evidence/13697-voice-volume-mute-semantics.md` — passed.
- `git diff --check` — passed.
- `codex review --uncommitted` — no discrete regression found.

Blocked / not claimed as proven here:

- `bun run --cwd plugins/plugin-native-talkmode test` is blocked in the temp takeover clone because `vitest` is not installed there; the same test files pass under `bun test` directly.
- `bun run --cwd plugins/plugin-native-talkmode typecheck` is blocked in this temp checkout by missing `tsgo` / dependency install plus the existing `src/web.ts` import resolution failure for `@elizaos/native-plugin-shared-types` noted in the original draft.
- `(cd plugins/plugin-native-talkmode/ios && swift test)` is blocked because this host Swift toolchain cannot import `XCTest`.
- Real hardware silent-switch, Android stream-mute, and desktop system-mute audio captures are not included in this slice; they remain required before final human approval of the full #13697 card.

## Evidence

See `.github/issue-evidence/13697-voice-volume-mute-semantics.md`.

Part of #13697.
