### PR TITLE
fix(orchestrator): terminate un-respawnable generic session crashes as failed (#13771 regression from #13830)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -1433,7 +1433,11 @@ describe("OrchestratorTaskService — store degradation resilience (#11641)", ()
 // the work pause hard-stopped, and the session->task index must survive a
 // parent restart by rebuilding from the durable store.
 describe("OrchestratorTaskService — crash produces terminal failed (#13771)", () => {
-  it("keeps the task non-terminal while the crash-retry budget remains", async () => {
+  it("keeps a RESPAWNABLE crash (session_state_lost) non-terminal while the budget remains", async () => {
+    // Only a crash the router actually re-drives may stay non-terminal — here a
+    // `session_state_lost`, which respawnStateLost re-spawns under a cap. A plain
+    // crash (no respawn producer) must NOT park like this; see the terminal case
+    // below and session-crash-terminates.test.ts.
     const acp = new FakeAcp();
     const { service, store } = makeServiceWithStore(acp);
     await service.start();
@@ -1443,9 +1447,13 @@ describe("OrchestratorTaskService — crash produces terminal failed (#13771)", 
       "spawn detail",
     );
     const sessionId = must(detail0.sessions[0], "session").sessionId;
-    await drive(acp, sessionId, "error", { message: "boom" });
+    await drive(acp, sessionId, "error", {
+      failureKind: "session_state_lost",
+      message: "ACP session state lost",
+    });
     const detail = must(await service.getTask(task.id), "detail");
-    // First crash: retrying, not terminal — the router's respawn gets a chance.
+    // First respawnable crash: retrying, not terminal — the router's respawn
+    // gets a chance.
     expect(detail.status).not.toBe("failed");
     expect(TERMINAL_TASK_STATUSES.has(detail.status)).toBe(false);
     expect(must(detail.sessions[0], "session").status).toBe("errored");
@@ -1458,14 +1466,38 @@ describe("OrchestratorTaskService — crash produces terminal failed (#13771)", 
     ).toBe(true);
   });
 
-  it("advances the task to terminal failed once the retry budget is spent", async () => {
+  it("fails a plain crash immediately — it has no respawn producer, so parking it would wedge the task", async () => {
+    // #13771 regression guard (#13830): a generic session error is respawned by
+    // NEITHER the account-failover nor the session_state_lost path in
+    // sub-agent-router.ts, so no successor session is ever spawned and no further
+    // error re-enters the budget. Routing the first such crash to
+    // `retrying -> active` wedges the task forever; it must go terminal `failed`.
+    const acp = new FakeAcp();
+    const service = makeService(acp);
+    await service.start();
+    const task = await service.createTask(createInput());
+    const detail0 = must(
+      await service.spawnAgentForTask(task.id),
+      "spawn detail",
+    );
+    const sessionId = must(detail0.sessions[0], "session").sessionId;
+    await drive(acp, sessionId, "error", { message: "boom" });
+
+    const final = must(await service.getTask(task.id), "final");
+    expect(final.status).toBe("failed");
+    expect(TERMINAL_TASK_STATUSES.has(final.status)).toBe(true);
+    expect(final.events?.some((e) => e.eventType === "task_failed")).toBe(true);
+  });
+
+  it("advances the task to terminal failed once the respawnable-crash retry budget is spent", async () => {
     const acp = new FakeAcp();
     const service = makeService(acp);
     await service.start();
     const task = await service.createTask(createInput());
 
-    // Simulate the respawn lineage the router would drive: each crashed session
-    // is replaced by a fresh spawn, until the budget (3) is exhausted.
+    // Simulate the respawn lineage the router would drive for a respawnable
+    // crash: each crashed session is replaced by a fresh spawn, until the budget
+    // (3) is exhausted. `session_state_lost` is the respawnable class.
     for (let attempt = 1; attempt <= 3; attempt += 1) {
       const detail = must(
         await service.spawnAgentForTask(task.id),
@@ -1475,7 +1507,10 @@ describe("OrchestratorTaskService — crash produces terminal failed (#13771)", 
         detail.sessions.at(-1),
         "spawned session",
       ).sessionId;
-      await drive(acp, sessionId, "error", { message: `crash ${attempt}` });
+      await drive(acp, sessionId, "error", {
+        failureKind: "session_state_lost",
+        message: `state lost ${attempt}`,
+      });
     }
 
     const final = must(await service.getTask(task.id), "final");
@@ -1517,7 +1552,9 @@ describe("OrchestratorTaskService — crash produces terminal failed (#13771)", 
     const { service, store } = makeServiceWithStore(acp);
     await service.start();
     const task = await service.createTask(createInput());
-    // Two clean stops + one error must NOT trip the budget (only errors count).
+    // Two clean stops must NOT enter the crash lineage — only `error` events do.
+    // A respawnable crash after them is therefore attempt 1/3 (retryCount === 1),
+    // not 3/3: had the stops counted, the budget would already be spent.
     for (let i = 0; i < 2; i += 1) {
       const d = must(await service.spawnAgentForTask(task.id), "spawn");
       const sid = must(d.sessions.at(-1), "s").sessionId;
@@ -1525,10 +1562,14 @@ describe("OrchestratorTaskService — crash produces terminal failed (#13771)", 
     }
     const d = must(await service.spawnAgentForTask(task.id), "spawn");
     const sid = must(d.sessions.at(-1), "s").sessionId;
-    await drive(acp, sid, "error", { message: "boom" });
+    await drive(acp, sid, "error", {
+      failureKind: "session_state_lost",
+      message: "state lost",
+    });
     const detail = must(await service.getTask(task.id), "detail");
+    // Respawnable + budget remains → non-terminal (the stops didn't burn it).
     expect(detail.status).not.toBe("failed");
-    // Only one errored session in the lineage.
+    // Only one errored session in the lineage — the clean stops are not counted.
     const found = must(await store.findSession(sid), "found");
     expect(found.session.retryCount).toBe(1);
   });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/session-crash-terminates.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/session-crash-terminates.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Pins the `failed` producer for un-respawnable session crashes (#13771,
+ * regression from #13830). Drives the REAL {@link OrchestratorTaskService}
+ * event bridge over a real in-memory store and a FakeAcp emitting real `error`
+ * session events, then reads the resulting durable task status.
+ *
+ * The invariant under test: a plain session crash (non-zero exit / generic
+ * error — NOT an account rate-limit/needs-reauth, NOT `session_state_lost`) has
+ * NO respawn producer in `sub-agent-router.ts` (its `classifyAccountFailure` /
+ * `session_state_lost` respawn gates never fire on a generic error), so the
+ * task MUST reach terminal `failed` on the FIRST such crash. Routing it to a
+ * non-terminal `retrying → active` on the false assumption the router will
+ * re-drive it wedges the task forever — the exact P0 #13771 was meant to fix.
+ * The account-failover / state-lost cases stay non-terminal because the router
+ * DOES respawn them; those are asserted here too so the fix can't over-correct.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
+import { MAX_SESSION_RETRY_ATTEMPTS } from "../../src/services/orchestrator-task-types.js";
+
+// Keep criteria-free tasks criteria-free so a `task_complete` never fires the
+// auto-verifier here (mirrors attach-session.test.ts).
+const PREV_GOAL_CONTRACT = process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+beforeAll(() => {
+  process.env.ELIZA_REQUIRE_GOAL_CONTRACT = "0";
+});
+afterAll(() => {
+  if (PREV_GOAL_CONTRACT === undefined)
+    delete process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+  else process.env.ELIZA_REQUIRE_GOAL_CONTRACT = PREV_GOAL_CONTRACT;
+});
+
+/** Minimal ACP stand-in: captures the orchestrator's event subscription so a
+ * test can drive real `error` session events through the real bridge. */
+class FakeAcp {
+  private handler:
+    | ((sessionId: string, event: string, data: unknown) => void)
+    | null = null;
+
+  onSessionEvent(
+    cb: (sessionId: string, event: string, data: unknown) => void,
+  ): () => void {
+    this.handler = cb;
+    return () => {
+      this.handler = null;
+    };
+  }
+
+  emit(sessionId: string, event: string, data: unknown = {}): void {
+    this.handler?.(sessionId, event, data);
+  }
+}
+
+function runtime(acp: FakeAcp): IAgentRuntime {
+  return {
+    getService: () => acp,
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    reportError: vi.fn(),
+  } as never;
+}
+
+async function makeService(): Promise<{
+  service: OrchestratorTaskService;
+  acp: FakeAcp;
+  taskId: string;
+}> {
+  const acp = new FakeAcp();
+  const store = new OrchestratorTaskStore({ backend: "memory" });
+  const service = new OrchestratorTaskService(runtime(acp), { store });
+  await service.start();
+  const task = await service.createTask({
+    title: "Build the thing",
+    goal: "Ship it",
+  });
+  return { service, acp, taskId: task.id };
+}
+
+/** Attach a live session and emit an `error` for it, letting the bridge settle. */
+async function crash(
+  service: OrchestratorTaskService,
+  acp: FakeAcp,
+  taskId: string,
+  sessionId: string,
+  errorData: Record<string, unknown>,
+): Promise<void> {
+  await service.attachSession(taskId, {
+    sessionId,
+    agentType: "codex",
+    workdir: "/tmp/workdir",
+    status: "ready",
+    label: "worker",
+  });
+  acp.emit(sessionId, "error", errorData);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("OrchestratorTaskService — un-respawnable session crash terminates the task", () => {
+  it("drives the task to terminal `failed` on the FIRST generic (non-account, non-state-lost) crash", async () => {
+    const { service, acp, taskId } = await makeService();
+
+    // A plain process crash: no auth/429 signal, no session_state_lost. The
+    // router respawns NEITHER of those categories — it re-drives only account
+    // failures and session_state_lost — so nothing will ever re-spawn this
+    // lineage. The task must not be parked non-terminal waiting for a respawn
+    // that will never come.
+    await crash(service, acp, taskId, "sess-crash-1", {
+      message: "sub-agent process exited with code 1",
+    });
+
+    const detail = await service.getTask(taskId);
+    expect(detail?.status).toBe("failed");
+  });
+
+  it("terminates a mid-build-verify-retry crash (buildVerifyRetryCount in (0,max)) rather than wedging it", async () => {
+    // The precise P0 shape called out in #13771: a session already partway
+    // through the build-verify retry lineage crashes generically. There is no
+    // remaining respawn producer, so it must go terminal, not sit non-terminal.
+    const { service, acp, taskId } = await makeService();
+
+    await service.attachSession(taskId, {
+      sessionId: "sess-midretry",
+      agentType: "codex",
+      workdir: "/tmp/workdir",
+      status: "ready",
+      label: "worker",
+      metadata: { buildVerifyRetryCount: 1 },
+    });
+    acp.emit("sess-midretry", "error", {
+      message: "build verify step crashed: exit 137",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const detail = await service.getTask(taskId);
+    expect(detail?.status).toBe("failed");
+  });
+
+  it("never leaves the task non-terminal after a generic crash, whatever the budget", async () => {
+    // Even if a generic crash were treated as retryable, a lineage of crashes
+    // must eventually terminate. Emitting MAX crashes (each a fresh session)
+    // must land `failed` — the task can never hang in `active`/`retrying`.
+    const { service, acp, taskId } = await makeService();
+    for (let i = 0; i < MAX_SESSION_RETRY_ATTEMPTS; i++) {
+      await crash(service, acp, taskId, `sess-loop-${i}`, {
+        message: `worker crashed (attempt ${i}): exit 1`,
+      });
+    }
+    const detail = await service.getTask(taskId);
+    expect(detail?.status).toBe("failed");
+  });
+
+  it("keeps a session_state_lost crash NON-terminal (the router deterministically respawns it)", async () => {
+    // The one legitimately-retryable crash: the router's respawnStateLost
+    // re-drives it under a bounded cap, so the durable task must stay
+    // non-terminal for that recovery to land. This guards against the fix
+    // over-correcting and failing a genuinely-recoverable lineage.
+    const { service, acp, taskId } = await makeService();
+
+    await crash(service, acp, taskId, "sess-statelost", {
+      failureKind: "session_state_lost",
+      message: "ACP session state lost; connection dropped",
+    });
+
+    const detail = await service.getTask(taskId);
+    expect(detail?.status).not.toBe("failed");
+    expect(detail?.status).toBe("active");
+  });
+
+  it("keeps an account rate-limit crash NON-terminal (the router fails the account over to a healthy sibling)", async () => {
+    // A pooled-account rate-limit is respawned by the router's in-router
+    // account failover while a healthy sibling remains, so — like state-lost —
+    // the task must stay non-terminal for that respawn.
+    const { service, acp, taskId } = await makeService();
+
+    await crash(service, acp, taskId, "sess-ratelimit", {
+      message: "429 rate limit exceeded",
+    });
+
+    const detail = await service.getTask(taskId);
+    expect(detail?.status).not.toBe("failed");
+    expect(detail?.status).toBe("active");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/session-crash-terminates.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/session-crash-terminates.test.ts
@@ -16,10 +16,42 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
 import { MAX_SESSION_RETRY_ATTEMPTS } from "../../src/services/orchestrator-task-types.js";
+
+const BRIDGE_SYMBOL = CODING_AGENT_SELECTOR_BRIDGE_SYMBOL;
+
+/** Register a global coding-account bridge reporting `healthy` accounts for the
+ * `claude` agent type, so `hasHealthyPooledAccount("claude")` reflects the pool
+ * the way the router's failover gate would see it. */
+function installBridge(healthy: number): void {
+  (globalThis as Record<symbol, unknown>)[BRIDGE_SYMBOL] = {
+    describe: () => ({
+      claude: [
+        { providerId: "anthropic-subscription", total: 2, enabled: 2, healthy },
+      ],
+    }),
+    select: async () => null,
+    markRateLimited: async () => undefined,
+    markNeedsReauth: async () => undefined,
+    recordUsage: async () => undefined,
+  };
+}
+
+afterEach(() => {
+  delete (globalThis as Record<symbol, unknown>)[BRIDGE_SYMBOL];
+});
 
 // Keep criteria-free tasks criteria-free so a `task_complete` never fires the
 // auto-verifier here (mirrors attach-session.test.ts).
@@ -168,18 +200,62 @@ describe("OrchestratorTaskService — un-respawnable session crash terminates th
     expect(detail?.status).toBe("active");
   });
 
-  it("keeps an account rate-limit crash NON-terminal (the router fails the account over to a healthy sibling)", async () => {
+  it("keeps a pooled-account rate-limit crash NON-terminal while a healthy sibling remains (router fails the account over)", async () => {
     // A pooled-account rate-limit is respawned by the router's in-router
     // account failover while a healthy sibling remains, so — like state-lost —
-    // the task must stay non-terminal for that respawn.
+    // the task must stay non-terminal for that respawn. Requires a real pooled
+    // account on the session AND a healthy sibling in the bridge, matching the
+    // router's exact failover gate.
+    installBridge(1);
     const { service, acp, taskId } = await makeService();
-
-    await crash(service, acp, taskId, "sess-ratelimit", {
-      message: "429 rate limit exceeded",
+    await service.attachSession(taskId, {
+      sessionId: "sess-ratelimit",
+      agentType: "claude",
+      workdir: "/tmp/workdir",
+      status: "ready",
+      label: "worker",
+      metadata: {
+        account: {
+          providerId: "anthropic-subscription",
+          accountId: "acct-limited",
+          label: "Work",
+        },
+      },
     });
+    acp.emit("sess-ratelimit", "error", { message: "429 rate limit exceeded" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     const detail = await service.getTask(taskId);
     expect(detail?.status).not.toBe("failed");
     expect(detail?.status).toBe("active");
+  });
+
+  it("TERMINATES a pooled-account rate-limit crash when the pool is exhausted (no sibling to fail over to)", async () => {
+    // The pool has 0 healthy accounts, so the router posts the honest failure
+    // and does NOT respawn — the crash is un-respawnable and the task must
+    // terminate rather than wait for a failover that cannot happen.
+    installBridge(0);
+    const { service, acp, taskId } = await makeService();
+    await service.attachSession(taskId, {
+      sessionId: "sess-ratelimit-exhausted",
+      agentType: "claude",
+      workdir: "/tmp/workdir",
+      status: "ready",
+      label: "worker",
+      metadata: {
+        account: {
+          providerId: "anthropic-subscription",
+          accountId: "acct-limited",
+          label: "Work",
+        },
+      },
+    });
+    acp.emit("sess-ratelimit-exhausted", "error", {
+      message: "429 rate limit exceeded",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const detail = await service.getTask(taskId);
+    expect(detail?.status).toBe("failed");
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
@@ -159,6 +159,29 @@ export function diagnoseCodingAccountFallback(
 }
 
 /**
+ * Whether the pool still has ≥1 healthy pooled account for this agent type —
+ * the gate the router's in-router account failover and the task service's
+ * crash-termination decision BOTH consult, so "will a spawned account failure
+ * be respawned onto a sibling?" is answered in one place. False when the bridge
+ * is absent (single-account host) or the pool is fully exhausted; in that case
+ * there is no sibling to fail over to, so the crash is un-respawnable and the
+ * task must terminate rather than park waiting for a respawn that will never
+ * come. Fails safe to false on a probe error.
+ */
+export function hasHealthyPooledAccount(agentType: string): boolean {
+  const bridge = getCodingAccountBridge();
+  if (!bridge) return false;
+  try {
+    const rows = bridge.describe()[agentType.toLowerCase()] ?? [];
+    return rows.some((row) => row.healthy > 0);
+  } catch {
+    // error-policy:J3 account-bridge probe failure → fail-safe "no healthy
+    // account"; declines failover so the task's honest failure reaches the user.
+    return false;
+  }
+}
+
+/**
  * Per-agent-type readiness verdict: how many healthy pooled accounts back this
  * coding agent vs. how many the requested posture needs.
  */

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -48,7 +48,9 @@ import {
   accountMetaFromSessionMetadata,
   assessCodingAccountReadiness,
   type CodingAccountReadiness,
+  classifyAccountFailure,
   getCodingAccountBridge,
+  hasHealthyPooledAccount,
   resolveCodingAccountStrategy,
 } from "./coding-account-selection.js";
 import {
@@ -1619,26 +1621,37 @@ export class OrchestratorTaskService extends Service {
   }
 
   /**
-   * The `failed` producer. An unrecoverable session error is the trigger that
-   * moves a task to terminal `failed` — but only once the crash-retry budget is
-   * spent. Until this existed, an `error` event marked the SESSION errored and
-   * (for auth/429) failed the account over, but never touched the task status,
-   * so a crashed sub-agent left the task stuck `active`/`validating` forever,
-   * waiting on the 3-minute stall watchdog or a human.
+   * The `failed` producer. An unrecoverable session error moves a task to
+   * terminal `failed`. Until this existed, an `error` event marked the SESSION
+   * errored and (for auth/429) failed the account over, but never touched the
+   * task status, so a crashed sub-agent left the task stuck `active`/`validating`
+   * forever, waiting on the 3-minute stall watchdog or a human.
+   *
+   * Status termination MUST agree with whether `sub-agent-router.ts` will
+   * respawn the crash, because the retry budget below only advances when a
+   * FURTHER error re-enters — and a further error only exists if a respawn
+   * produced a new session. The router respawns exactly two crash classes:
+   *   - `session_state_lost` (respawnStateLost, always under the lineage cap), and
+   *   - a pooled-account failure (rate-limit / needs-reauth) while a healthy
+   *     sibling account remains (in-router account failover).
+   * A PLAIN crash — a non-zero exit, a `TypeError`, a build-tool segfault — is
+   * respawned by NEITHER path, so no successor session is ever spawned, no
+   * further error re-enters, and a `retrying` (non-terminal) verdict wedges the
+   * task forever (the P0 #13771 this producer exists to prevent). Such a crash
+   * is therefore terminal on its FIRST occurrence.
+   *
+   * - Un-respawnable crash → `unrecoverable`: terminal `failed` immediately.
+   * - Respawnable crash under budget → `retrying` (task returns to `active`) so
+   *   the router's respawn can re-engage a fresh worker; if that successor also
+   *   crashes it re-enters here and the budget still drives `failed`.
+   * - Respawnable crash, budget spent → `unrecoverable`: terminal `failed`.
    *
    * Budget = {@link MAX_SESSION_RETRY_ATTEMPTS} errored sessions across THIS
-   * task's lineage (each general-crash respawn is a fresh session row, so the
-   * count of terminally-errored sessions IS the retry count — no separate
-   * counter to drift). The canonical typed `retryCount` on the erroring session
-   * is stamped with that lineage count so the durable record carries the budget
-   * position, reconciling the field the router's respawn lineage also tracks.
-   *
-   * - Under budget → `retrying`: the task returns to `active` so the router's
-   *   bounded general-crash respawn (reusing the `session_state_lost` machinery +
-   *   account failover) re-engages a fresh worker. If no respawn happens (pool
-   *   exhausted, no initialTask), the next error re-enters here and the budget
-   *   still drives the task to `failed` — never a silent hang.
-   * - Budget spent → `unrecoverable`: terminal `failed`, with one honest event.
+   * task's lineage (each respawn is a fresh session row, so the count of
+   * terminally-errored sessions IS the retry count — no separate counter to
+   * drift). The erroring session's typed `retryCount` is stamped with that
+   * lineage count so the durable record carries the budget position, reconciling
+   * the field the router's respawn lineage also tracks.
    *
    * `login_required` is handled separately (→ `waiting_on_user`) because there a
    * human genuinely can unblock; a plain crash cannot, so it must not park.
@@ -1665,13 +1678,21 @@ export class OrchestratorTaskService extends Service {
     // canonical typed counter.
     await this.store.updateSession(sessionId, { retryCount: erroredSessions });
 
+    const respawnable = this.routerWillRespawn(
+      doc.sessions.find((s) => s.sessionId === sessionId),
+      failure,
+    );
     const budgetSpent = erroredSessions >= MAX_SESSION_RETRY_ATTEMPTS;
+    // Terminal unless the router will respawn this crash class AND the lineage
+    // budget still has room. An un-respawnable crash fails on its first
+    // occurrence — nothing will re-drive it, so a non-terminal verdict wedges.
+    const terminal = !respawnable || budgetSpent;
     await this.store.addEvent({
       id: randomUUID(),
       taskId,
       sessionId,
-      eventType: budgetSpent ? "task_failed" : "session_error_retrying",
-      summary: budgetSpent
+      eventType: terminal ? "task_failed" : "session_error_retrying",
+      summary: terminal
         ? `Sub-agent failed unrecoverably after ${erroredSessions} attempt(s); task marked failed.`
         : `Sub-agent errored (attempt ${erroredSessions}/${MAX_SESSION_RETRY_ATTEMPTS}); retrying.`,
       data: {
@@ -1679,15 +1700,36 @@ export class OrchestratorTaskService extends Service {
         message: failure.message,
         attempt: erroredSessions,
         budget: MAX_SESSION_RETRY_ATTEMPTS,
+        respawnable,
       },
       timestamp: Date.now(),
       createdAt: nowIso(),
     });
     await this.advanceTaskStatus(
       taskId,
-      budgetSpent ? "unrecoverable" : "retrying",
+      terminal ? "unrecoverable" : "retrying",
     );
     this.emitChange(taskId);
+  }
+
+  /**
+   * Whether `sub-agent-router.ts` will deterministically respawn this crash —
+   * the same gate the router itself uses, mirrored here so status termination
+   * and respawn agree. Only these two classes get a successor session:
+   *   - `session_state_lost` (unconditional respawn under the lineage cap), and
+   *   - a pooled-account failure whose message classifies as rate-limit /
+   *     needs-reauth, while the session carried a pooled account and a healthy
+   *     sibling remains for failover.
+   * Everything else is un-respawnable and must fail immediately.
+   */
+  private routerWillRespawn(
+    session: OrchestratorTaskSession | undefined,
+    failure: { failureKind?: string; message: string },
+  ): boolean {
+    if (failure.failureKind === "session_state_lost") return true;
+    if (classifyAccountFailure(failure.message) === null) return false;
+    if (!session?.accountProviderId || !session.accountId) return false;
+    return hasHealthyPooledAccount(session.framework);
   }
 
   private async markSessionAccountUnhealthy(

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -29,7 +29,7 @@ import {
   accountMetaFromSessionMetadata,
   type CodingAccountFailureKind,
   classifyAccountFailure,
-  getCodingAccountBridge,
+  hasHealthyPooledAccount,
   reportCodingAccountFailure,
 } from "./coding-account-selection.js";
 import {
@@ -908,7 +908,7 @@ export class SubAgentRouter extends Service {
         // flapping stays bounded, and only fires while a healthy pooled
         // account remains — with the whole pool exhausted the honest failure
         // below reaches the user.
-        if (this.hasHealthyPooledAccount(session.agentType)) {
+        if (hasHealthyPooledAccount(session.agentType)) {
           const { state, decision } = routerLoopTransition(this.loopState, {
             type: "state_lost",
             lineageKey: respawnLineageKey(session, origin),
@@ -1718,26 +1718,6 @@ export class SubAgentRouter extends Service {
           error: err instanceof Error ? err.message : String(err),
         },
       );
-      return false;
-    }
-  }
-
-  /**
-   * Whether the account pool still has ≥1 healthy pooled account for this
-   * agent type — the gate for the in-router account failover. False when the
-   * bridge is absent (single-account host) or the pool is fully exhausted, in
-   * which case the honest failure must reach the user instead of a doomed
-   * respawn burning a lineage-budget slot.
-   */
-  private hasHealthyPooledAccount(agentType: string): boolean {
-    const bridge = getCodingAccountBridge();
-    if (!bridge) return false;
-    try {
-      const rows = bridge.describe()[agentType.toLowerCase()] ?? [];
-      return rows.some((row) => row.healthy > 0);
-    } catch {
-      // error-policy:J3 account-bridge probe failure → fail-safe "no healthy
-      // account"; declines failover so the task's honest failure reaches the user.
       return false;
     }
   }


### PR DESCRIPTION
## Summary

Corrects a **P0 regression** that #13830 (`fix(#13771): orchestrator task lifecycle`) introduced on `develop`: a sub-agent whose session crashes with a **plain (non-account, non-`session_state_lost`) error** is no longer terminated — it is parked non-terminal forever. That is the exact hang #13771 was filed to fix, and #13789 (`fix(#13771): wire the orchestrator failed task producer`) had already fixed it before #13830 overwrote that fix with a worse version.

## Root cause

`OrchestratorTaskService.advanceTaskOnSessionError` (in `plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts`) is the sole producer of the terminal `failed` status. #13830 replaced #13789's classification (`session_state_lost → non-terminal; every other error → failed`) with a retry-budget path:

- **First crash** → `retrying` → task stays `active` (non-terminal), on the assumption *"the router's bounded general-crash respawn re-engages a fresh worker; if no respawn happens, the next error re-enters here and the budget still drives the task to failed."*
- **Budget spent** → `unrecoverable` → `failed`.

That assumption is false. `sub-agent-router.ts` respawns **only two** crash classes:

1. **account failure** — `classifyAccountFailure(message)` returns `rate-limited`/`needs-reauth`, the session carried a pooled account, and `hasHealthyPooledAccount()` holds (in-router account failover, `~L879–942`), and
2. **`session_state_lost`** — `respawnStateLost()` under a bounded cap (`~L946–1002`).

A **plain crash** — a non-zero exit, a `TypeError`, a build-tool segfault, *especially mid-build-verify-retry* — is respawned by **neither** path. So no successor session is ever spawned, no further `error` event re-enters `advanceTaskOnSessionError`, the budget never advances past 1, and the task **wedges at `active` forever**, waiting on a respawn that will never come.

This is verifiable in the pre-existing router test `account-failover-respawn.test.ts` ("delivers a normal task error unchanged (no failover, no pool mark)"): a generic `TypeError` error → `spawnSession` is **not** called.

## Fix

`advanceTaskOnSessionError` now classifies the crash with a new `routerWillRespawn()` helper that **mirrors the router's own gate**:

- `session_state_lost` → respawnable, OR
- an account-failure (`classifyAccountFailure(message) !== null`) on a session that carried a pooled account **and** `hasHealthyPooledAccount(session.framework)` holds → respawnable.

Only a **respawnable** crash **under budget** stays non-terminal (`retrying`). **Everything else terminates `unrecoverable → failed` on its first occurrence** — nothing will re-drive it, so parking it wedges the task.

The router's private `hasHealthyPooledAccount` is extracted into `coding-account-selection.ts` and consumed by both the router and the task service, so status-termination and respawn now consult **one** gate (no drift).

This preserves every legitimate retry/respawn case:
- `session_state_lost` → non-terminal (router respawns).
- pooled-account rate-limit / needs-reauth **with a healthy sibling** → non-terminal (router fails over).
- pooled-account failure **with an exhausted pool** → terminal (router posts the honest failure, does not respawn).
- plain crash → terminal (no respawn producer).

## Evidence — failing → passing test

New test `plugins/plugin-agent-orchestrator/__tests__/unit/session-crash-terminates.test.ts` drives the **real** `OrchestratorTaskService` over a **real** in-memory `OrchestratorTaskStore` and a `FakeAcp` emitting **real** `error` session events, then reads the resulting durable task status.

**Before the fix (on the buggy commit):**

```
× drives the task to terminal `failed` on the FIRST generic crash
    AssertionError: expected 'active' to be 'failed'
× terminates a mid-build-verify-retry crash (buildVerifyRetryCount in (0,max))
    AssertionError: expected 'active' to be 'failed'
  Tests  2 failed | 3 passed (5)
```

**After the fix:**

```
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Coverage: first generic crash → `failed`; mid-build-verify-retry crash → `failed`; pooled-account rate-limit with exhausted pool → `failed`; `session_state_lost` → stays `active`; pooled-account rate-limit with a healthy sibling → stays `active`; a lineage of generic crashes → `failed`.

The #13830 tests in `orchestrator-task-service.test.ts` that **encoded the buggy `retrying` verdict on a generic crash** are corrected to the fixed semantics (a plain crash fails immediately; the "budget remains" / "clean stop doesn't count" cases now use `session_state_lost`, the genuinely respawnable class).

Related router behavior is guarded by the pre-existing `account-failover-respawn.test.ts` (18 tests across the lifecycle files pass).

## Verification

```bash
bunx vitest run --config vitest.config.ts \
  __tests__/unit/session-crash-terminates.test.ts \
  __tests__/unit/account-failover-respawn.test.ts \
  __tests__/unit/task-status-transitions.test.ts
# → Test Files 3 passed (3) · Tests 18 passed (18)

bunx tsc --noEmit -p tsconfig.json   # clean
bunx @biomejs/biome check <touched>  # clean
```

> Note: `orchestrator-task-service.test.ts`'s `spawnAgentForTask`-based cases fail **in this worktree only** on an unrelated stale `@elizaos/core` dist (`TRACE_ENV` from #13775 not present in the shared prebuilt dist) — a `TypeError: Cannot read properties of undefined (reading 'TRACE_ID')` in `buildChildTraceEnv`, code this PR does not touch. CI builds a fresh dist. The corrected assertions in that file are independently proven by `session-crash-terminates.test.ts`, which exercises the same service logic through the working `attachSession` path.

## Corrects

This corrects #13830. Restores and generalizes the fix from #13789 (which #13830 overwrote). Addresses the reopened P0 in #13771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
