### PR TITLE
test/docs(#13693): document sim-auth scope and contract checks

### DIFF
--- a/.github/issue-evidence/13693-sim-auth-endstate.txt
+++ b/.github/issue-evidence/13693-sim-auth-endstate.txt
@@ -1,0 +1,79 @@
+# Issue #13693 — assert in-app auth end-state in the sim auth smoke
+# Captured 2026-07-05T03:38:32Z on macOS 26.2, node v24.15.0
+# Booted iOS simulator: iPhone 16 Pro (iOS 18.1) F165C3A3-5069-4174-A40C-89F0BCC4B9FB
+# Android emulator: NONE connected -> Android live leg N/A (adb present but no device)
+
+===================================================================
+1) node --test of the pure end-state contract + LIVE simulator round-trip
+   (12 tests, incl. a real xcrun simctl defaults write/read/assert/delete)
+===================================================================
+✔ expectedAuthCallbackFromUrl extracts the path/state/code the app must echo (1.099917ms)
+✔ buildCallbackUrl targets the app's own scheme (0.161542ms)
+✔ accepts a handled callback that did NOT change the session (0.139625ms)
+✔ accepts an already-authenticated simulator when the session is untouched (0.080375ms)
+✔ RED: rejects a deliver-only echo (no classification, no readback) (0.299542ms)
+✔ RED: rejects a session readback with no classification (0.101666ms)
+✔ RED: rejects a classified-but-not-explicitly-rejected callback (0.087ms)
+✔ RED: rejects a callback that authenticated/swapped the session (security regression) (0.083ms)
+✔ RED: rejects a payload with no callback-specific session comparison (0.109ms)
+✔ RED: still enforces the delivery echo (path/state/code) (0.144208ms)
+✔ Android Preferences XML round-trips the auth-callback result key (0.401042ms)
+✔ live iOS defaults store round-trips the auth end-state assertion (1631.544583ms)
+ℹ tests 12
+ℹ suites 0
+ℹ pass 12
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 1753.35375
+
+===================================================================
+2) Registration-only contract lane against the materialized native
+   projects (real Info.plist + AndroidManifest.xml), showing the new
+   honest 'lane' descriptor. exit 0.
+===================================================================
+[mobile-auth-smoke] Eliza (ai.elizaos.app) scheme=elizaos appDir=/Users/shawwalters/eliza-workspace/milady/eliza/packages/app (--app-dir) callback URL: elizaos://auth/callback?state=simulator-oauth-state&code=simulator-oauth-code
+{
+  "lane": "auth-callback-delivery+handler-classification (not login; #13693)",
+  "appDir": "/Users/shawwalters/eliza-workspace/milady/eliza/packages/app",
+  "appDirSource": "--app-dir",
+  "app": {
+    "appId": "ai.elizaos.app",
+    "appName": "Eliza",
+    "urlScheme": "elizaos"
+  },
+  "registrationOnly": true,
+  "registrations": [
+    {
+      "platform": "ios",
+      "file": "/Users/shawwalters/eliza-workspace/milady/eliza/packages/app/ios/App/App/Info.plist",
+      "scheme": "elizaos"
+    },
+    {
+      "platform": "android",
+      "file": "/Users/shawwalters/eliza-workspace/milady/eliza/packages/app/android/app/src/main/AndroidManifest.xml",
+      "scheme": "elizaos"
+    }
+  ]
+}
+
+===================================================================
+3) CANARY: full iOS leg against the BOOTED sim with the currently-
+   installed (stale, pre-#13693) app. The lane ARMS the request key,
+   launches, fires openurl, POLLS the real Preferences store, and
+   FAILS (exit 1) because the in-app handler never wrote a handled
+   result. This is the regression the issue demanded be caught:
+   delivery alone no longer passes.
+===================================================================
+[mobile-auth-smoke] Eliza (ai.elizaos.app) scheme=elizaos appDir=/Users/shawwalters/eliza-workspace/milady/eliza/packages/app (--app-dir) callback URL: elizaos://auth/callback?state=simulator-oauth-state&code=simulator-oauth-code
+iOS auth callback smoke timed out after 3 attempts. Last result: {"ok":false,"phase":"requested","expected":{"path":"auth/callback","state":"simulator-oauth-state","code":"simulator-oauth-code"},"updatedAt":"2026-07-05T03:38:53.878Z"}
+   -> script exit code: 1  (1 = correctly failed on missing readback)
+
+===================================================================
+4) Negative proof via real sim readback: a session-swap regression
+   payload written to the real sim defaults store is REJECTED by the
+   exported assertAuthCallbackResult contract.
+===================================================================
+real sim readback: {"ok":true,"phase":"handled","classification":"synthetic_callback_rejected","accepted":false,"sessionEstablished":true,"sessionChanged":true,"path":"auth/callback","state":"simulator-oauth-state","code":"simulator-oauth-code"}
+REGRESSION CAUGHT: iOS: the OS-delivered auth callback changed the active session (sessionChanged=true). A deep link must never authenticate or swap the app session; only the trusted in-app session exchange may.

--- a/packages/app-core/scripts/mobile-auth-simulator-smoke-endstate.test.mjs
+++ b/packages/app-core/scripts/mobile-auth-simulator-smoke-endstate.test.mjs
@@ -1,0 +1,271 @@
+/**
+ * End-state contract self-tests for the mobile-auth simulator smoke (#13693).
+ *
+ * `test:sim:auth` fires a synthetic `<scheme>://auth/callback` deep link and then
+ * reads back what the in-app handler wrote to Capacitor Preferences. The value of
+ * the lane is entirely in the READBACK assertion: `assertAuthCallbackResult` is
+ * the single shared contract both the iOS poll and the Android poll run against,
+ * so a regression that made the smoke "pass on delivery alone" (the exact silent
+ * pass the issue calls out) is caught here, not only in a simulator.
+ *
+ * These run under the Node built-in test runner (`node --test`) — no vitest, no
+ * package deps — so they exercise the real exported decision logic even on a
+ * disk-contended host with no install. The vitest twin
+ * (`test/scripts/mobile-auth-simulator-smoke.test.ts`) covers the same surface in
+ * the app-core lane; this file guarantees the pure contract is verifiable
+ * standalone and, when a simulator is booted, round-trips the assertion through
+ * the REAL `xcrun simctl defaults` store the app-side verifier writes into.
+ */
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+
+import {
+  assertAuthCallbackResult,
+  buildAndroidPreferenceXml,
+  buildCallbackUrl,
+  expectedAuthCallbackFromUrl,
+  readAndroidPreferenceFromXml,
+} from "./mobile-auth-simulator-smoke.mjs";
+
+const CALLBACK_URL =
+  "elizaos://auth/callback?state=simulator-oauth-state&code=simulator-oauth-code";
+const AUTH_CALLBACK_RESULT_KEY = "eliza:auth-callback-smoke:result";
+const expected = expectedAuthCallbackFromUrl(CALLBACK_URL);
+
+// The exact payload shape `recordIosAuthCallbackSmoke` (packages/app/src/main.tsx)
+// writes for the default synthetic callback: rejected, classified, session
+// unchanged. Kept in lock-step with that handler — if the app writes a different
+// shape, the assertion (and this fixture) must move together.
+const HANDLED_RESULT = {
+  ok: true,
+  phase: "handled",
+  classification: "synthetic_callback_rejected",
+  accepted: false,
+  sessionEstablished: false,
+  sessionChanged: false,
+  activeServerBeforePresent: false,
+  activeServerAfterPresent: false,
+  path: expected.path,
+  state: expected.state,
+  code: expected.code,
+};
+
+test("expectedAuthCallbackFromUrl extracts the path/state/code the app must echo", () => {
+  assert.deepEqual(expected, {
+    path: "auth/callback",
+    state: "simulator-oauth-state",
+    code: "simulator-oauth-code",
+  });
+});
+
+test("buildCallbackUrl targets the app's own scheme", () => {
+  const url = buildCallbackUrl(
+    { urlScheme: "elizaos" },
+    { path: "auth/callback", query: "state=s&code=c", url: "" },
+  );
+  assert.equal(url, "elizaos://auth/callback?state=s&code=c");
+});
+
+test("accepts a handled callback that did NOT change the session", () => {
+  assert.equal(
+    assertAuthCallbackResult(HANDLED_RESULT, expected, "iOS"),
+    HANDLED_RESULT,
+  );
+});
+
+test("accepts an already-authenticated simulator when the session is untouched", () => {
+  const preAuthenticated = {
+    ...HANDLED_RESULT,
+    sessionEstablished: true,
+    activeServerBeforePresent: true,
+    activeServerAfterPresent: true,
+  };
+  assert.equal(
+    assertAuthCallbackResult(preAuthenticated, expected, "iOS"),
+    preAuthenticated,
+  );
+});
+
+test("RED: rejects a deliver-only echo (no classification, no readback)", () => {
+  const deliverOnly = {
+    ok: true,
+    phase: "handled",
+    path: expected.path,
+    state: expected.state,
+    code: expected.code,
+  };
+  assert.throws(
+    () => assertAuthCallbackResult(deliverOnly, expected, "iOS"),
+    /callback was not classified/,
+  );
+});
+
+test("RED: rejects a session readback with no classification", () => {
+  assert.throws(
+    () =>
+      assertAuthCallbackResult(
+        { ...HANDLED_RESULT, classification: undefined },
+        expected,
+        "iOS",
+      ),
+    /callback was not classified/,
+  );
+});
+
+test("RED: rejects a classified-but-not-explicitly-rejected callback", () => {
+  assert.throws(
+    () =>
+      assertAuthCallbackResult(
+        { ...HANDLED_RESULT, accepted: true },
+        expected,
+        "iOS",
+      ),
+    /not explicitly rejected/,
+  );
+});
+
+test("RED: rejects a callback that authenticated/swapped the session (security regression)", () => {
+  assert.throws(
+    () =>
+      assertAuthCallbackResult(
+        { ...HANDLED_RESULT, sessionEstablished: true, sessionChanged: true },
+        expected,
+        "iOS",
+      ),
+    /changed the active session/,
+  );
+});
+
+test("RED: rejects a payload with no callback-specific session comparison", () => {
+  assert.throws(
+    () =>
+      assertAuthCallbackResult(
+        { ...HANDLED_RESULT, sessionChanged: undefined },
+        expected,
+        "iOS",
+      ),
+    /no auth outcome surfaced/,
+  );
+});
+
+test("RED: still enforces the delivery echo (path/state/code)", () => {
+  assert.throws(
+    () =>
+      assertAuthCallbackResult(
+        { ...HANDLED_RESULT, state: "tampered" },
+        expected,
+        "iOS",
+      ),
+    /query mismatch/,
+  );
+});
+
+test("Android Preferences XML round-trips the auth-callback result key", () => {
+  // The Android leg seeds/reads the same handshake through
+  // shared_prefs/CapacitorStorage.xml; the poll only classifies what it can parse
+  // back out, so the serialize→parse round-trip must be lossless.
+  const xml = buildAndroidPreferenceXml({
+    [AUTH_CALLBACK_RESULT_KEY]: JSON.stringify(HANDLED_RESULT),
+  });
+  const raw = readAndroidPreferenceFromXml(xml, AUTH_CALLBACK_RESULT_KEY);
+  assert.ok(raw, "expected the result key to round-trip out of the XML");
+  assert.deepEqual(
+    assertAuthCallbackResult(JSON.parse(raw), expected, "Android"),
+    {
+      ...HANDLED_RESULT,
+    },
+  );
+});
+
+// When a simulator is booted with the app installed, prove the assertion runs
+// against the REAL `xcrun simctl defaults` store the in-app verifier writes into
+// — not just an in-memory fixture. Skipped (never failed) when no booted device,
+// no `xcrun`, or the app is not installed, so this file stays green in headless CI.
+test("live iOS defaults store round-trips the auth end-state assertion", (t) => {
+  const device = bootedIosDevice();
+  if (!device) {
+    t.skip("no booted iOS simulator with the app installed");
+    return;
+  }
+  const appId = "ai.elizaos.app";
+  const nativeKey = `CapacitorStorage.${AUTH_CALLBACK_RESULT_KEY}`;
+  simctl(device, ["defaults", "delete", appId, nativeKey]);
+  try {
+    simctl(device, [
+      "defaults",
+      "write",
+      appId,
+      nativeKey,
+      "-string",
+      JSON.stringify(HANDLED_RESULT),
+    ]);
+    const readback = simctl(device, ["defaults", "read", appId, nativeKey]);
+    assert.ok(readback, "expected a readback from the real simulator store");
+    const result = assertAuthCallbackResult(
+      JSON.parse(readback),
+      expected,
+      "iOS auth callback (live-sim readback)",
+    );
+    assert.equal(result.classification, "synthetic_callback_rejected");
+    assert.equal(result.sessionChanged, false);
+  } finally {
+    simctl(device, ["defaults", "delete", appId, nativeKey]);
+  }
+});
+
+function simctl(device, args) {
+  try {
+    return execFileSync("xcrun", ["simctl", "spawn", device, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function bootedIosDevice() {
+  let listed = "";
+  try {
+    listed = execFileSync(
+      "xcrun",
+      ["simctl", "list", "devices", "booted", "--json"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+  } catch {
+    return null;
+  }
+  let udid = null;
+  try {
+    const parsed = JSON.parse(listed);
+    for (const devices of Object.values(parsed.devices ?? {})) {
+      for (const device of devices) {
+        if (device.state === "Booted" && device.udid) {
+          udid = device.udid;
+          break;
+        }
+      }
+      if (udid) break;
+    }
+  } catch {
+    return null;
+  }
+  if (!udid) return null;
+  // Only claim the device when the app is actually installed — the live
+  // round-trip reads/writes that app's Preferences domain.
+  return tryAppContainer(udid, "ai.elizaos.app") ? udid : null;
+}
+
+function tryAppContainer(device, appId) {
+  try {
+    return execFileSync(
+      "xcrun",
+      ["simctl", "get_app_container", device, appId, "app"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    ).trim();
+  } catch {
+    return "";
+  }
+}

--- a/packages/app-core/scripts/mobile-auth-simulator-smoke-endstate.test.mjs
+++ b/packages/app-core/scripts/mobile-auth-simulator-smoke-endstate.test.mjs
@@ -222,6 +222,7 @@ function simctl(device, args) {
       stdio: ["ignore", "pipe", "pipe"],
     }).trim();
   } catch {
+    // error-policy:J3 optional simulator probes convert unavailable tools/domains into a typed empty readback.
     return "";
   }
 }
@@ -235,6 +236,7 @@ function bootedIosDevice() {
       { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
     );
   } catch {
+    // error-policy:J3 absent xcrun or no booted simulator means the live-only assertion is invalid for this host.
     return null;
   }
   let udid = null;
@@ -250,6 +252,7 @@ function bootedIosDevice() {
       if (udid) break;
     }
   } catch {
+    // error-policy:J3 malformed simctl output is an invalid optional live-probe result, not a contract-test failure.
     return null;
   }
   if (!udid) return null;
@@ -266,6 +269,7 @@ function tryAppContainer(device, appId) {
       { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
     ).trim();
   } catch {
+    // error-policy:J3 missing installed app makes the live simulator store probe inapplicable on this host.
     return "";
   }
 }

--- a/packages/app-core/scripts/mobile-auth-simulator-smoke.mjs
+++ b/packages/app-core/scripts/mobile-auth-simulator-smoke.mjs
@@ -7,6 +7,13 @@ import { pathToFileURL } from "node:url";
 import { resolveMainAppDir } from "./lib/app-dir.mjs";
 import { resolveRepoRootFromImportMeta } from "./lib/repo-root.mjs";
 
+// Stamped onto the JSON payload so a reader of the run log knows the scope up
+// front: this lane proves callback DELIVERY + in-app handler classification, not
+// login. A genuine OAuth exchange is out of scope until #13578's headless session
+// seed lands (#13693 done-when #2/#3).
+const AUTH_SMOKE_LANE =
+  "auth-callback-delivery+handler-classification (not login; #13693)";
+
 const IOS_AUTH_CALLBACK_SMOKE_REQUEST_KEY = "eliza:auth-callback-smoke:request";
 const IOS_AUTH_CALLBACK_SMOKE_RESULT_KEY = "eliza:auth-callback-smoke:result";
 const IOS_AUTH_CALLBACK_ATTEMPTS = Number.parseInt(
@@ -104,6 +111,12 @@ export function parseArgs(argv) {
 
 function printUsageAndExit() {
   console.log(`usage: node mobile-auth-simulator-smoke.mjs [options]
+
+Fires a synthetic <scheme>://auth/callback deep link at the installed app and
+asserts the in-app handler's END STATE (callback rejected + classified +
+active session unchanged) via a Capacitor-Preferences readback. This is a
+callback-delivery + handler-classification smoke, NOT a login smoke (a real
+OAuth exchange is out of scope until the #13578 headless session seed lands).
 
 Options:
   --platform ios|android|both   Platform to exercise. Default: both
@@ -884,6 +897,7 @@ async function main() {
     console.log(
       JSON.stringify(
         {
+          lane: AUTH_SMOKE_LANE,
           appDir,
           appDirSource,
           app,
@@ -909,6 +923,7 @@ async function main() {
   console.log(
     JSON.stringify(
       {
+        lane: AUTH_SMOKE_LANE,
         appDir,
         appDirSource,
         app,

--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -95,7 +95,10 @@ const pluginAgentOrchestratorSrc = path.join(
   monorepoRoot,
   "plugins/plugin-agent-orchestrator/src",
 );
-const pluginBirdclawSrc = path.join(monorepoRoot, "plugins/plugin-birdclaw/src");
+const pluginBirdclawSrc = path.join(
+  monorepoRoot,
+  "plugins/plugin-birdclaw/src",
+);
 const pluginAppControlSrc = path.join(
   monorepoRoot,
   "plugins/plugin-app-control/src",

--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -171,6 +171,7 @@ export default defineConfig({
       "scripts/aosp/compile-libllama-fused.test.mjs",
       "scripts/mas-smoke.test.mjs",
       // Uses Node.js built-in test runner (node:test), not vitest.
+      "scripts/mobile-auth-simulator-smoke-endstate.test.mjs",
       "scripts/android-sms-gateway-template.test.mjs",
       "scripts/stage-android-agent.test.mjs",
       "scripts/stage-desktop-fused-lib-staleness.test.mjs",

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -103,8 +103,8 @@ bun run --cwd packages/app test:e2e:ios              # Boot sim, build, auth smo
 bun run --cwd packages/app test:e2e:ios:cloud        # iOS e2e plus cloud provisioning probe
 bun run --cwd packages/app test:sim:local-chat        # iOS simulator local-chat smoke; requires installed app
 bun run --cwd packages/app test:sim:local-chat:android # Android emulator local-chat smoke; requires installed app
-bun run --cwd packages/app test:sim:auth:ios
-bun run --cwd packages/app test:sim:auth:android
+bun run --cwd packages/app test:sim:auth:ios         # auth/callback deep-link DELIVERY + in-app handler classification (not login)
+bun run --cwd packages/app test:sim:auth:android     # same; requires an Android emulator + installed app
 
 # Mobile release preflight
 bun run --cwd packages/app preflight:ios:sideload
@@ -180,6 +180,29 @@ The iOS app ships three runtime modes; their unattended (CI) coverage is:
 Keep this table honest: an N/A row must name what is missing, not hide it.
 
 The XCUITest cloud-onboarding path (`testCloudOnboardingChatAndVoice`) still XCTSkips at the OAuth wall without a device Cloud session; the `ios-cloud-mode` lane covers the cloud *runtime* mode programmatically (the same path `ios-e2e.mjs --cloud` calls) rather than driving the simulator UI through OAuth. A device-UI cloud-onboarding lane needs the WebView-side session seed (`steward_session_token` / `POST /api/cloud/login/persist`) and is tracked in #13578 done-when #2.
+
+### What `test:sim:auth` proves (and does not) (#13693)
+
+`test:sim:auth[:ios|:android]` (`packages/app-core/scripts/mobile-auth-simulator-smoke.mjs`)
+is a **callback-delivery + in-app-handler smoke, not a login smoke.** It fires a
+synthetic `<scheme>://auth/callback?state=…&code=…` deep link that no token
+endpoint would accept, then reads back — through the Capacitor-Preferences
+handshake the onboarding smoke pioneered — what the renderer's `auth/callback`
+handler wrote (`recordIosAuthCallbackSmoke` in `src/main.tsx`, armed by the
+smoke's `eliza:auth-callback-smoke:request`/`:result` keys). The shared
+`assertAuthCallbackResult` contract then asserts the security end state: the
+OS-delivered callback is explicitly rejected (`accepted:false`), classified
+(`classification:"synthetic_callback_rejected"`), and **left the active session
+untouched** (`sessionChanged:false`) — a deep link must never authenticate or
+swap the app session. A handler that merely echoed the URL back, dropped it, or
+authenticated off it now fails the lane instead of passing on delivery alone.
+
+It does **not** exercise a genuine OAuth exchange or a logged-in end state; that
+`--real` mode is blocked on the headless staging-Cloud session seed tracked in
+#13578 / #13693 done-when #2. The pure end-state contract is verifiable without a
+device via `node --test packages/app-core/scripts/mobile-auth-simulator-smoke-endstate.test.mjs`
+(which additionally round-trips the assertion through a booted simulator's real
+`xcrun simctl defaults` store when one is available).
 
 ## Config / env vars
 

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -103,8 +103,8 @@ bun run --cwd packages/app test:e2e:ios              # Boot sim, build, auth smo
 bun run --cwd packages/app test:e2e:ios:cloud        # iOS e2e plus cloud provisioning probe
 bun run --cwd packages/app test:sim:local-chat        # iOS simulator local-chat smoke; requires installed app
 bun run --cwd packages/app test:sim:local-chat:android # Android emulator local-chat smoke; requires installed app
-bun run --cwd packages/app test:sim:auth:ios
-bun run --cwd packages/app test:sim:auth:android
+bun run --cwd packages/app test:sim:auth:ios         # auth/callback deep-link DELIVERY + in-app handler classification (not login)
+bun run --cwd packages/app test:sim:auth:android     # same; requires an Android emulator + installed app
 
 # Mobile release preflight
 bun run --cwd packages/app preflight:ios:sideload
@@ -180,6 +180,29 @@ The iOS app ships three runtime modes; their unattended (CI) coverage is:
 Keep this table honest: an N/A row must name what is missing, not hide it.
 
 The XCUITest cloud-onboarding path (`testCloudOnboardingChatAndVoice`) still XCTSkips at the OAuth wall without a device Cloud session; the `ios-cloud-mode` lane covers the cloud *runtime* mode programmatically (the same path `ios-e2e.mjs --cloud` calls) rather than driving the simulator UI through OAuth. A device-UI cloud-onboarding lane needs the WebView-side session seed (`steward_session_token` / `POST /api/cloud/login/persist`) and is tracked in #13578 done-when #2.
+
+### What `test:sim:auth` proves (and does not) (#13693)
+
+`test:sim:auth[:ios|:android]` (`packages/app-core/scripts/mobile-auth-simulator-smoke.mjs`)
+is a **callback-delivery + in-app-handler smoke, not a login smoke.** It fires a
+synthetic `<scheme>://auth/callback?state=…&code=…` deep link that no token
+endpoint would accept, then reads back — through the Capacitor-Preferences
+handshake the onboarding smoke pioneered — what the renderer's `auth/callback`
+handler wrote (`recordIosAuthCallbackSmoke` in `src/main.tsx`, armed by the
+smoke's `eliza:auth-callback-smoke:request`/`:result` keys). The shared
+`assertAuthCallbackResult` contract then asserts the security end state: the
+OS-delivered callback is explicitly rejected (`accepted:false`), classified
+(`classification:"synthetic_callback_rejected"`), and **left the active session
+untouched** (`sessionChanged:false`) — a deep link must never authenticate or
+swap the app session. A handler that merely echoed the URL back, dropped it, or
+authenticated off it now fails the lane instead of passing on delivery alone.
+
+It does **not** exercise a genuine OAuth exchange or a logged-in end state; that
+`--real` mode is blocked on the headless staging-Cloud session seed tracked in
+#13578 / #13693 done-when #2. The pure end-state contract is verifiable without a
+device via `node --test packages/app-core/scripts/mobile-auth-simulator-smoke-endstate.test.mjs`
+(which additionally round-trips the assertion through a booted simulator's real
+`xcrun simctl defaults` store when one is available).
 
 ## Config / env vars
 


### PR DESCRIPTION
Refs #13693. This PR documents what `test:sim:auth` proves and adds standalone contract coverage for the auth-callback end-state assertion. It does **not** close the remaining real simulator/device evidence requirements for #13693.

## What this adds

- `packages/app/CLAUDE.md` / `AGENTS.md` now describe `test:sim:auth[:ios|:android]` as callback delivery + in-app handler classification, not a login/OAuth exchange smoke.
- `mobile-auth-simulator-smoke.mjs` help output now states the same scope and includes a lane descriptor in JSON output.
- `packages/app-core/scripts/mobile-auth-simulator-smoke-endstate.test.mjs` exercises the exported contract helpers with `node --test`, including the RED cases for callback echo-only, missing classification, accepted synthetic callback, and session mutation.

## Verification run after rebase

- `node --test packages/app-core/scripts/mobile-auth-simulator-smoke-endstate.test.mjs` -> 11 pass, 1 skip. The live iOS defaults-store leg skipped because this host had no booted iOS simulator with the app installed.
- `bun run --cwd packages/app-core test -- test/scripts/mobile-auth-simulator-smoke.test.ts` -> 23 pass.
- `bunx @biomejs/biome check packages/app-core/scripts/mobile-auth-simulator-smoke-endstate.test.mjs packages/app-core/scripts/mobile-auth-simulator-smoke.mjs packages/app-core/vitest.config.ts packages/app/CLAUDE.md packages/app/AGENTS.md` -> clean.
- `cmp packages/app/CLAUDE.md packages/app/AGENTS.md` -> clean.

## Still pending for #13693 closure

- Full rebuilt/reinstalled iOS simulator green leg for `test:sim:auth:ios`.
- Android emulator green leg for `test:sim:auth:android`.
- Registration-only check against the materialized native app project. In this checkout, `bun run --cwd packages/app test:sim:auth:contract` cannot run because `packages/app/ios/App/App/Info.plist` is not materialized; a temporary check wired to committed app-core native templates fails because that template does not register the `elizaos` URL scheme from `packages/app/app.config.ts`.
- Real OAuth-exchange/login mode remains out of scope until the headless Cloud session seed tracked by #13578 / #13693 is available.