### PR TITLE
fix: harden inline task activity grouping

### DIFF
--- a/packages/ui/src/state/task-activity-store.test.ts
+++ b/packages/ui/src/state/task-activity-store.test.ts
@@ -13,7 +13,8 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { client } from "../api/client";
 import { __taskActivityInternals } from "./task-activity-store";
 
-const { applyEvent, getSnapshot, reset, subscribe } = __taskActivityInternals;
+const { applyEvent, getSnapshot, limits, reset, subscribe } =
+  __taskActivityInternals;
 
 function ev(
   p: Partial<SwarmEvent> & { type: string; sessionId: string },
@@ -112,6 +113,78 @@ describe("task-activity-store reducer", () => {
     expect(snap.subagents[0].plan).toHaveLength(2);
   });
 
+  it("ignores stale and duplicate seq updates for latest fields", () => {
+    applyEvent(
+      ev({
+        type: "message",
+        sessionId: "a",
+        taskId: "T",
+        seq: 3,
+        data: { text: "new text" },
+      }),
+    );
+    applyEvent(
+      ev({
+        type: "message",
+        sessionId: "a",
+        taskId: "T",
+        seq: 2,
+        data: { text: "stale text" },
+      }),
+    );
+    applyEvent(
+      ev({
+        type: "message",
+        sessionId: "a",
+        taskId: "T",
+        seq: 3,
+        data: { text: "duplicate text" },
+      }),
+    );
+    applyEvent(
+      ev({
+        type: "reasoning",
+        sessionId: "a",
+        taskId: "T",
+        seq: 5,
+        data: { text: "new reasoning" },
+      }),
+    );
+    applyEvent(
+      ev({
+        type: "reasoning",
+        sessionId: "a",
+        taskId: "T",
+        seq: 4,
+        data: { text: "stale reasoning" },
+      }),
+    );
+    applyEvent(
+      ev({
+        type: "task_complete",
+        sessionId: "a",
+        taskId: "T",
+        seq: 7,
+        data: {},
+      }),
+    );
+    applyEvent(
+      ev({
+        type: "tool_running",
+        sessionId: "a",
+        taskId: "T",
+        seq: 6,
+        data: { toolCall: { id: "late-tool", status: "running" } },
+      }),
+    );
+
+    const agent = getSnapshot("T").subagents[0];
+    expect(agent.currentText).toBe("new text");
+    expect(agent.currentReasoning).toBe("new reasoning");
+    expect(agent.status).toBe("success");
+    expect(agent.steps.map((step) => step.id)).toEqual(["late-tool"]);
+  });
+
   it("moves a sub-agent to a terminal status on lifecycle events", () => {
     applyEvent(
       ev({
@@ -169,6 +242,77 @@ describe("task-activity-store reducer", () => {
       (s) => s.sessionId === "child",
     );
     expect(child?.parentSessionId).toBe("parent");
+  });
+
+  it("groups an orphan child event under the known parent task", () => {
+    applyEvent(
+      ev({
+        type: "message",
+        sessionId: "parent",
+        taskId: "T",
+        seq: 1,
+        data: { text: "p" },
+      }),
+    );
+    applyEvent(
+      ev({
+        type: "message",
+        sessionId: "child",
+        parentSessionId: "parent",
+        seq: 2,
+        data: { text: "c" },
+      }),
+    );
+
+    expect(getSnapshot("child").subagents).toHaveLength(0);
+    const child = getSnapshot("T").subagents.find(
+      (agent) => agent.sessionId === "child",
+    );
+    expect(child?.currentText).toBe("c");
+    expect(child?.parentSessionId).toBe("parent");
+  });
+
+  it("bounds idle tasks and sub-agent rows", () => {
+    const unsubscribe = subscribe("pinned", () => {});
+    try {
+      for (let i = 0; i <= limits.maxTasks; i += 1) {
+        applyEvent(
+          ev({
+            type: "message",
+            sessionId: `agent-${i}`,
+            taskId: `task-${i}`,
+            seq: i + 1,
+            data: { text: `message-${i}` },
+          }),
+        );
+      }
+      expect(getSnapshot("task-0").subagents).toHaveLength(0);
+      expect(getSnapshot("pinned").taskId).toBe("pinned");
+
+      for (let i = 0; i <= limits.maxSubagentsPerTask; i += 1) {
+        applyEvent(
+          ev({
+            type: "message",
+            sessionId: `child-${i}`,
+            taskId: "crowded",
+            seq: i + 1,
+            data: { text: `message-${i}` },
+          }),
+        );
+      }
+      const crowded = getSnapshot("crowded");
+      expect(crowded.subagents).toHaveLength(limits.maxSubagentsPerTask);
+      expect(
+        crowded.subagents.some((agent) => agent.sessionId === "child-0"),
+      ).toBe(false);
+      expect(
+        crowded.subagents.some(
+          (agent) => agent.sessionId === `child-${limits.maxSubagentsPerTask}`,
+        ),
+      ).toBe(true);
+    } finally {
+      unsubscribe();
+    }
   });
 
   it("reconstructs the SwarmEvent from a real server pty-session-event frame", () => {

--- a/packages/ui/src/state/task-activity-store.ts
+++ b/packages/ui/src/state/task-activity-store.ts
@@ -28,6 +28,10 @@ import { client } from "../api/client";
 
 /** Cap on retained tool steps per sub-agent — a long task must not grow unbounded. */
 const MAX_STEPS_PER_AGENT = 60;
+/** Cap on retained task snapshots while no mounted card is observing them. */
+const MAX_TASKS = 200;
+/** Cap on retained sub-agent rows per task. */
+const MAX_SUBAGENTS_PER_TASK = 80;
 
 export interface TaskActivityStep {
   /** Stable id: the tool call id, or `seq` when the adapter omits one. */
@@ -76,7 +80,17 @@ interface TaskEntry {
   snapshot: TaskActivity;
   /** Mutable working copy the reducer edits before it re-freezes a snapshot. */
   subagents: Map<string, SubagentActivity>;
+  fieldSeqs: Map<
+    string,
+    {
+      text?: number;
+      reasoning?: number;
+      plan?: number;
+      status?: number;
+    }
+  >;
   plan: SwarmActivityPlanEntry[];
+  planSeq?: number;
   lastSeq: number;
   listeners: Set<() => void>;
 }
@@ -115,6 +129,7 @@ function ensureEntry(taskId: string): TaskEntry {
     entry = {
       snapshot: { ...EMPTY_TASK, taskId },
       subagents: new Map(),
+      fieldSeqs: new Map(),
       plan: [],
       lastSeq: 0,
       listeners: new Set(),
@@ -122,6 +137,46 @@ function ensureEntry(taskId: string): TaskEntry {
     tasks.set(taskId, entry);
   }
   return entry;
+}
+
+function acceptsSeq(prev: number | undefined, next: number): boolean {
+  return prev === undefined || next > prev;
+}
+
+function findTaskIdBySession(sessionId: string): string | undefined {
+  for (const [taskId, entry] of tasks) {
+    if (entry.subagents.has(sessionId)) return taskId;
+  }
+  return undefined;
+}
+
+function evictIdleTasks(protectedTaskId?: string): void {
+  while (tasks.size > MAX_TASKS) {
+    let oldestTaskId: string | undefined;
+    let oldestUpdatedAt = Number.POSITIVE_INFINITY;
+    for (const [taskId, entry] of tasks) {
+      if (taskId === protectedTaskId) continue;
+      if (entry.listeners.size > 0) continue;
+      if (entry.snapshot.updatedAt < oldestUpdatedAt) {
+        oldestTaskId = taskId;
+        oldestUpdatedAt = entry.snapshot.updatedAt;
+      }
+    }
+    if (!oldestTaskId) return;
+    tasks.delete(oldestTaskId);
+  }
+}
+
+function trimSubagents(entry: TaskEntry): void {
+  const extra = entry.subagents.size - MAX_SUBAGENTS_PER_TASK;
+  if (extra <= 0) return;
+  const removable = [...entry.subagents.values()]
+    .sort((a, b) => a.firstSeq - b.firstSeq)
+    .slice(0, extra);
+  for (const agent of removable) {
+    entry.subagents.delete(agent.sessionId);
+    entry.fieldSeqs.delete(agent.sessionId);
+  }
 }
 
 function refreezeSnapshot(entry: TaskEntry, at: number): void {
@@ -141,7 +196,13 @@ function refreezeSnapshot(entry: TaskEntry, at: number): void {
 function applyEvent(raw: SwarmEvent): void {
   const activity = toSwarmActivity(raw);
   if (!activity) return;
-  const taskId = activity.taskId ?? raw.taskId ?? raw.sessionId;
+  const taskId =
+    activity.taskId ??
+    raw.taskId ??
+    (activity.parentSessionId
+      ? findTaskIdBySession(activity.parentSessionId)
+      : undefined) ??
+    raw.sessionId;
   if (!taskId) return;
   const entry = ensureEntry(taskId);
   entry.snapshot = { ...entry.snapshot, taskId };
@@ -155,23 +216,36 @@ function applyEvent(raw: SwarmEvent): void {
     updatedAt: activity.timestamp,
     firstSeq: activity.seq,
   };
+  const seqs = entry.fieldSeqs.get(sessionId) ?? {};
   if (activity.parentSessionId)
     agent.parentSessionId = activity.parentSessionId;
-  agent.updatedAt = activity.timestamp;
+  agent.updatedAt = Math.max(agent.updatedAt, activity.timestamp);
   entry.lastSeq = Math.max(entry.lastSeq, activity.seq);
 
   switch (activity.kind) {
     case "message":
-      agent.currentText = activity.text;
+      if (acceptsSeq(seqs.text, activity.seq)) {
+        agent.currentText = activity.text;
+        seqs.text = activity.seq;
+      }
       break;
     case "reasoning":
-      agent.currentReasoning = activity.text;
+      if (acceptsSeq(seqs.reasoning, activity.seq)) {
+        agent.currentReasoning = activity.text;
+        seqs.reasoning = activity.seq;
+      }
       break;
     case "plan":
-      agent.plan = activity.entries;
-      // The most-recently-updated plan is also the task-level checklist so a
-      // single-agent task surfaces its todos at the card root.
-      entry.plan = activity.entries;
+      if (acceptsSeq(seqs.plan, activity.seq)) {
+        agent.plan = activity.entries;
+        seqs.plan = activity.seq;
+      }
+      if (acceptsSeq(entry.planSeq, activity.seq)) {
+        // The most-recently-updated plan is also the task-level checklist so a
+        // single-agent task surfaces its todos at the card root.
+        entry.plan = activity.entries;
+        entry.planSeq = activity.seq;
+      }
       break;
     case "tool": {
       const stepId = activity.tool.id ?? `seq-${activity.seq}`;
@@ -184,20 +258,30 @@ function applyEvent(raw: SwarmEvent): void {
       const idx = agent.steps.findIndex((s) => s.id === stepId);
       if (idx >= 0) agent.steps[idx] = step;
       else agent.steps.push(step);
+      agent.steps.sort((a, b) => a.seq - b.seq);
       if (agent.steps.length > MAX_STEPS_PER_AGENT) {
         agent.steps.splice(0, agent.steps.length - MAX_STEPS_PER_AGENT);
       }
-      if (agent.status !== "waiting") agent.status = "running";
+      if (agent.status !== "waiting" && acceptsSeq(seqs.status, activity.seq)) {
+        agent.status = "running";
+        seqs.status = activity.seq;
+      }
       break;
     }
     case "lifecycle":
-      agent.status = statusFromLifecycle(activity.event, agent.status);
+      if (acceptsSeq(seqs.status, activity.seq)) {
+        agent.status = statusFromLifecycle(activity.event, agent.status);
+        seqs.status = activity.seq;
+      }
       if (activity.label) agent.label = activity.label;
       break;
   }
 
   entry.subagents.set(sessionId, agent);
+  entry.fieldSeqs.set(sessionId, seqs);
+  trimSubagents(entry);
   refreezeSnapshot(entry, activity.timestamp);
+  evictIdleTasks(taskId);
 }
 
 function bindWs(): void {
@@ -269,6 +353,10 @@ export const __taskActivityInternals = {
   subscribe: subscribeTask,
   getSnapshot: (taskId: string): TaskActivity =>
     tasks.get(taskId)?.snapshot ?? EMPTY_TASK,
+  limits: {
+    maxTasks: MAX_TASKS,
+    maxSubagentsPerTask: MAX_SUBAGENTS_PER_TASK,
+  },
   reset: (): void => {
     tasks.clear();
     if (wsUnsub) wsUnsub();

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -147,6 +147,37 @@ describe("SwarmCoordinatorService", () => {
     await coordinator.stop();
   });
 
+  it("stamps child session events with the parent task thread", async () => {
+    const acp = makeAcpStub();
+    const runtime = makeRuntime({ [AcpService.serviceType]: acp });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const broadcasts: SwarmEvent[] = [];
+    coordinator.setWsBroadcast((event) => broadcasts.push(event));
+
+    acp.emit("parent-session", "message", {
+      threadId: "task-thread",
+      text: "parent started",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    acp.emit("child-session", "message", {
+      parentSessionId: "parent-session",
+      text: "child started",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(broadcasts[1]).toMatchObject({
+      type: "message",
+      sessionId: "child-session",
+      parentSessionId: "parent-session",
+      taskId: "task-thread",
+    });
+    expect(coordinator.tasks.get("child-session")?.threadId).toBe(
+      "task-thread",
+    );
+    await coordinator.stop();
+  });
+
   it("exposes every setter the server bridges call", async () => {
     const acp = makeAcpStub();
     const runtime = makeRuntime({ [AcpService.serviceType]: acp });

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -747,10 +747,16 @@ export class SwarmCoordinatorService
     const existing = this.tasks.get(sessionId);
     const status = this.legacyStatusForEvent(event);
     const label = readString(data, "label") ?? existing?.label;
+    const parentSessionId =
+      readString(data, "parentSessionId") ?? readString(data, "parentSession");
+    const parentTask = parentSessionId
+      ? this.tasks.get(parentSessionId)
+      : undefined;
     const threadId =
       readString(data, "threadId") ??
       readString(data, "taskId") ??
       existing?.threadId ??
+      parentTask?.threadId ??
       sessionId;
     const agentType = readString(data, "agentType") ?? existing?.agentType;
     const originalTask =
@@ -1109,15 +1115,19 @@ export class SwarmCoordinatorService
     // custom-validator dispatches get the same projection.
     this.activitySeq += 1;
     swarmEvent.seq = this.activitySeq;
-    if (swarmEvent.taskId === undefined) {
-      const threadId = this.tasks.get(swarmEvent.sessionId)?.threadId;
-      if (threadId) swarmEvent.taskId = threadId;
-    }
     if (swarmEvent.parentSessionId === undefined && isRecord(swarmEvent.data)) {
       const parent =
         readString(swarmEvent.data, "parentSessionId") ??
         readString(swarmEvent.data, "parentSession");
       if (parent) swarmEvent.parentSessionId = parent;
+    }
+    if (swarmEvent.taskId === undefined) {
+      const threadId =
+        this.tasks.get(swarmEvent.sessionId)?.threadId ??
+        (swarmEvent.parentSessionId
+          ? this.tasks.get(swarmEvent.parentSessionId)?.threadId
+          : undefined);
+      if (threadId) swarmEvent.taskId = threadId;
     }
 
     // Fan out to in-process subscribers (verification-room-bridge et al).


### PR DESCRIPTION
## Summary
- make inline task activity latest fields honor monotonic `seq` and ignore stale/duplicate arrivals
- group child session events under the known parent task when taskId is missing
- bound retained idle task snapshots and sub-agent rows
- stamp orchestrator child events with the parent task thread before broadcasting

Fixes the seq-order, orphan taskId, and unbounded map portions of #13906. The remaining `todo.tsx` polling cleanup is intentionally not folded into this PR because it is a separate widget data-flow change.

## Tests
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/ui test task-activity-store.test.ts`
- `bun run --cwd plugins/plugin-agent-orchestrator test swarm-coordinator-service.test.ts`
- `bunx @biomejs/biome check packages/ui/src/state/task-activity-store.ts packages/ui/src/state/task-activity-store.test.ts plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts`
