### PR TITLE
fix(cloud): stop leaking provider-config detail to chat-completions callers on unknown models

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-unknown-model-config-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-unknown-model-config-leak.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Provider-config leak repro for POST /api/v1/chat/completions (#13406).
+ *
+ * On prod, a request for an unknown/unconfigured model surfaced the raw
+ * provider-configuration error to the DIRECT API caller — including the
+ * Vercel AI Gateway SDK's setup guidance naming `AI_GATEWAY_API_KEY`. The
+ * route boundary must translate that class of failure into a clean
+ * "model '<x>' is not available" client error (echoing the model id only)
+ * while the internal detail stays in server logs.
+ *
+ * The harness follows this package's route-test pattern: auth/billing/catalog
+ * are stubbed at their module boundaries, but the components under test are
+ * REAL — the route's error boundary, the real provider resolution
+ * (`getLanguageModel`), the real AI SDK, and the real `@ai-sdk/gateway`
+ * client speaking HTTP to a local stub upstream that answers 401 exactly like
+ * the gateway does, so the SDK raises its real GatewayAuthenticationError
+ * (the message that leaked in prod).
+ */
+
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import * as pricingActual from "@/lib/pricing";
+import * as languageModelActual from "@/lib/providers/language-model";
+import * as aiBillingActual from "@/lib/services/ai-billing";
+import * as contentModerationActual from "@/lib/services/content-moderation";
+import * as inferenceAuthContextActual from "@/lib/services/inference-auth-context";
+import * as fastPathActual from "@/lib/services/inference-billing-fast-path";
+import * as billingLedgerActual from "@/lib/services/inference-billing-ledger";
+import * as modelCatalogActual from "@/lib/services/model-catalog";
+import * as creditReservationActual from "@/lib/utils/credit-reservation";
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+const API_KEY_ID = "00000000-0000-4000-8000-0000000000cc";
+const UNKNOWN_MODEL = "totally/unknown-model";
+
+// Strings from the internal configuration errors (ours and the gateway
+// SDK's contextual auth message) that must never appear in a client body.
+const INTERNAL_MARKERS = [
+  "AI_GATEWAY_API_KEY",
+  "OPENROUTER_API_KEY",
+  "environment variable",
+  "apiKey",
+  "vercel.com",
+];
+
+// --- local stub playing the EXTERNAL Vercel AI Gateway -----------------------
+// Answers every request 401 with the gateway's error shape; the real
+// @ai-sdk/gateway client converts that into GatewayAuthenticationError whose
+// contextual message embeds the AI_GATEWAY_API_KEY setup guidance.
+const gatewayStub = Bun.serve({
+  port: 0,
+  fetch: () =>
+    Response.json(
+      { error: { type: "authentication_error", message: "Invalid API key" } },
+      { status: 401 },
+    ),
+});
+
+const ENV_KEYS = [
+  "AI_GATEWAY_API_KEY",
+  "AIGATEWAY_API_KEY",
+  "AI_GATEWAY_BASE_URL",
+  "OPENROUTER_API_KEY",
+] as const;
+const savedEnv = new Map<string, string | undefined>(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+process.env.AI_GATEWAY_API_KEY = "test-invalid-gateway-key";
+process.env.AI_GATEWAY_BASE_URL = `http://127.0.0.1:${gatewayStub.port}`;
+delete process.env.AIGATEWAY_API_KEY;
+delete process.env.OPENROUTER_API_KEY;
+
+// --- module-boundary stubs (auth + billing, not under test) ------------------
+mock.module("@/lib/services/inference-auth-context", () => ({
+  ...inferenceAuthContextActual,
+  isInferenceHotPathCacheEnabled: () => true,
+  resolveInferenceAuthContext: async () => ({
+    kind: "authorized",
+    ctx: { userId: USER, orgId: ORG, apiKeyId: API_KEY_ID },
+  }),
+}));
+
+mock.module("@/lib/pricing", () => ({
+  ...pricingActual,
+  calculateCost: async () => ({
+    totalCost: 0.01,
+    inputCost: 0.005,
+    outputCost: 0.005,
+  }),
+}));
+
+mock.module("@/lib/services/model-catalog", () => ({
+  ...modelCatalogActual,
+  getCachedGatewayModelById: async () => null,
+}));
+
+mock.module("@/lib/services/content-moderation", () => ({
+  ...contentModerationActual,
+  contentModerationService: {
+    ...contentModerationActual.contentModerationService,
+    shouldBlockUser: async () => false,
+    moderateInBackground: () => {},
+  },
+}));
+
+mock.module("@/lib/services/inference-billing-fast-path", () => ({
+  ...fastPathActual,
+  isOptimisticBillingEnabled: () => true,
+  isOptimisticBackstopAvailable: () => true,
+  getGateBalanceUsd: async () => 100,
+  resolveSafeBalanceThresholdUsd: () => 5,
+  writePendingInferenceCharge: async () => true,
+  createOptimisticDebitSettler: () => async () => null,
+}));
+
+mock.module("@/lib/services/inference-billing-ledger", () => ({
+  ...billingLedgerActual,
+  resolveInferenceBillingLedger: () => "kv",
+  admitInferenceChargeViaLedger: async () => ({ admitted: true }),
+  createLedgerDebitSettler: () => async () => null,
+}));
+
+mock.module("@/lib/services/ai-billing", () => ({
+  ...aiBillingActual,
+  reserveCredits: async () => ({
+    reservedAmount: 0.015,
+    reconcile: async () => null,
+  }),
+}));
+
+mock.module("@/lib/utils/credit-reservation", () => ({
+  ...creditReservationActual,
+  createCreditReservationSettler: () => async () => null,
+}));
+
+// Import the route AFTER the mocks so it binds to the stubs. `ai` and
+// `@/lib/providers/language-model` stay real — they are under test.
+const { handleChatCompletionsPOST } = await import(
+  "../v1/chat/completions/route"
+);
+
+afterAll(() => {
+  gatewayStub.stop(true);
+  for (const [key, value] of savedEnv) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  mock.module(
+    "@/lib/services/inference-auth-context",
+    () => inferenceAuthContextActual,
+  );
+  mock.module("@/lib/pricing", () => pricingActual);
+  mock.module("@/lib/services/model-catalog", () => modelCatalogActual);
+  mock.module(
+    "@/lib/services/content-moderation",
+    () => contentModerationActual,
+  );
+  mock.module(
+    "@/lib/services/inference-billing-fast-path",
+    () => fastPathActual,
+  );
+  mock.module(
+    "@/lib/services/inference-billing-ledger",
+    () => billingLedgerActual,
+  );
+  mock.module("@/lib/services/ai-billing", () => aiBillingActual);
+  mock.module("@/lib/utils/credit-reservation", () => creditReservationActual);
+});
+
+function makeRequest(stream: boolean): Request {
+  return new Request("https://api.test/api/v1/chat/completions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: UNKNOWN_MODEL,
+      messages: [{ role: "user", content: "hello" }],
+      stream,
+    }),
+  });
+}
+
+describe("chat/completions unknown-model provider-config leak (#13406)", () => {
+  test("non-streaming: clean 400 model_not_available, no internal config detail in the body", async () => {
+    const res = await handleChatCompletionsPOST(makeRequest(false), {
+      skipOrgRateLimit: true,
+    });
+    const bodyText = await res.text();
+
+    for (const marker of INTERNAL_MARKERS) {
+      expect(bodyText).not.toContain(marker);
+    }
+
+    expect(res.status).toBe(400);
+    const body = JSON.parse(bodyText) as {
+      error: { message: string; type: string; code: string };
+    };
+    expect(body.error.message).toBe(
+      `model '${UNKNOWN_MODEL}' is not available on this deployment`,
+    );
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.code).toBe("model_not_available");
+  });
+
+  test("streaming: terminal error chunk is sanitized and the stream still ends with [DONE]", async () => {
+    const res = await handleChatCompletionsPOST(makeRequest(true), {
+      skipOrgRateLimit: true,
+    });
+    expect(res.status).toBe(200);
+    const sse = await res.text();
+
+    for (const marker of INTERNAL_MARKERS) {
+      expect(sse).not.toContain(marker);
+    }
+
+    expect(sse).toContain(
+      `model '${UNKNOWN_MODEL}' is not available on this deployment`,
+    );
+    expect(sse).toContain('"type":"invalid_request_error"');
+    expect(sse).toContain("data: [DONE]");
+  });
+
+  test("resolution failure with no serving key is a classified configuration error, internal detail intact for logs", () => {
+    delete process.env.AI_GATEWAY_API_KEY;
+    try {
+      let caught: unknown;
+      try {
+        languageModelActual.getLanguageModel(UNKNOWN_MODEL);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect(languageModelActual.isProviderConfigurationError(caught)).toBe(
+        true,
+      );
+      // The operator-facing message keeps naming the missing configuration —
+      // sanitization happens at the API boundary, not at the throw site.
+      expect((caught as Error).message).toContain("OPENROUTER_API_KEY");
+    } finally {
+      process.env.AI_GATEWAY_API_KEY = "test-invalid-gateway-key";
+    }
+  });
+});

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -53,6 +53,7 @@ import {
   getAiProviderConfigurationError,
   getLanguageModel,
   hasLanguageModelProviderConfigured,
+  isProviderConfigurationError,
   type PooledLanguageModelCredential,
   resolveAiProviderSource,
   resolvePooledDirectProviderForModel,
@@ -889,6 +890,9 @@ export async function handleChatCompletionsPOST(
   let settleReservation:
     | ((actualCost: number) => Promise<CreditReconciliationResult | null>)
     | null = null;
+  // Hoisted so the catch below can echo the requested model in the sanitized
+  // provider-configuration error; set right after the body parses.
+  let model = "";
 
   try {
     // 1. Authenticate (+ moderation). #9899: API-key dedicated-agent requests
@@ -992,7 +996,7 @@ export async function handleChatCompletionsPOST(
     // Collapse decorated Cerebras ids (e.g. "openai/gpt-oss-120b:nitro" emitted
     // by dedicated agents) to the bare Cerebras id so pricing, routing, and
     // billing all agree and route to cerebras-direct instead of OpenRouter.
-    const model = canonicalizeCerebrasModelId(request.model);
+    model = canonicalizeCerebrasModelId(request.model);
     const pooledCredential = await selectPooledInferenceCredential({
       model,
       organizationId: user.organization_id,
@@ -1475,6 +1479,25 @@ export async function handleChatCompletionsPOST(
           ? String((error.cause as Error).message ?? error.cause)
           : undefined,
     });
+    // Provider-configuration failures (missing/invalid provider keys) carry
+    // internal setup guidance ("... AI_GATEWAY_API_KEY ...") that must never
+    // reach a direct API caller; the raw detail is already in the log above.
+    // To the caller the deterministic truth is that this deployment cannot
+    // serve the requested model.
+    if (isProviderConfigurationError(error)) {
+      return addCorsHeaders(
+        Response.json(
+          {
+            error: {
+              message: modelNotAvailableMessage(model),
+              type: "invalid_request_error",
+              code: "model_not_available",
+            },
+          },
+          { status: 400 },
+        ),
+      );
+    }
     const isDbError =
       rawMessage.startsWith("Failed query:") ||
       rawMessage.includes("insert into") ||
@@ -1502,6 +1525,15 @@ export async function handleChatCompletionsPOST(
       ),
     );
   }
+}
+
+/**
+ * Client-facing message for a provider-configuration failure. The requested
+ * model id is the only detail safe to echo back — the underlying errors name
+ * internal env vars and setup steps, which stay in server logs only.
+ */
+function modelNotAvailableMessage(model: string): string {
+  return `model '${model}' is not available on this deployment`;
 }
 
 /**
@@ -2074,12 +2106,33 @@ async function handleStreamingRequest(
           await refundStreamingReservationOnce();
           await recordPooledInferenceFailure(pooledCredential, error);
         }
-        const status =
-          getRecoverableProviderErrorStatus(error) ?? getErrorStatusCode(error);
+        // Same sanitization as the non-streaming path: a provider-
+        // configuration failure surfacing mid-stream (e.g. the gateway's
+        // request-time auth error) names internal env vars — log it, send the
+        // caller the clean model-not-available form. onError does not always
+        // fire before this catch, so the log here is the guaranteed record.
+        const isConfigError = isProviderConfigurationError(error);
+        if (isConfigError) {
+          logger.error(
+            "[Chat Completions] Provider configuration error during stream",
+            {
+              model,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+        }
+        const status = isConfigError
+          ? 400
+          : (getRecoverableProviderErrorStatus(error) ??
+            getErrorStatusCode(error));
         try {
           const errorChunk = {
             error: {
-              message: error instanceof Error ? error.message : String(error),
+              message: isConfigError
+                ? modelNotAvailableMessage(model)
+                : error instanceof Error
+                  ? error.message
+                  : String(error),
               // Same status→type mapping as the non-streaming path — a
               // hardcoded "rate_limit_error" here mislabeled every mid-stream
               // provider failure (schema 400s, upstream 5xx) as rate limiting,

--- a/packages/cloud/shared/src/lib/providers/language-model.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model.ts
@@ -1,6 +1,10 @@
 // Defines cloud shared language model behavior for backend service consumers.
 import { createAnthropic } from "@ai-sdk/anthropic";
-import { createGatewayProvider, type GatewayProvider } from "@ai-sdk/gateway";
+import {
+  createGatewayProvider,
+  GatewayAuthenticationError,
+  type GatewayProvider,
+} from "@ai-sdk/gateway";
 import { createOpenAI } from "@ai-sdk/openai";
 import { APICallError, type LanguageModelMiddleware, RetryError, wrapLanguageModel } from "ai";
 import {
@@ -17,6 +21,45 @@ import { RETRYABLE_UPSTREAM_STATUSES } from "./failover";
 import { toBitRouterModelId } from "./model-id-translation";
 import { getProviderKey } from "./provider-env";
 import { hasAnyVastProviderConfigured, resolveVastEndpointConfig } from "./vast-endpoints";
+
+/**
+ * A model-resolution failure caused by this deployment's provider
+ * configuration (missing/placeholder provider key, unconfigured endpoint) —
+ * as opposed to a bad request or a transient upstream failure. The message
+ * intentionally names the missing env var for operators; API boundaries must
+ * classify with isProviderConfigurationError and return a clean client error
+ * instead of forwarding it (#13406 leaked "AI_GATEWAY_API_KEY" to callers).
+ */
+export class ProviderConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProviderConfigurationError";
+  }
+}
+
+/**
+ * True when an error means "this deployment has no working provider for the
+ * requested model": our own resolution throws, plus the Vercel AI Gateway
+ * SDK's request-time auth failure — its message embeds env-var setup guidance
+ * ("... set the AI_GATEWAY_API_KEY environment variable ...") that must never
+ * reach a client. Unwraps the AI SDK's RetryError to the last real error.
+ *
+ * The gateway auth failure arrives in two shapes: streamText surfaces the raw
+ * GatewayAuthenticationError (marker symbol intact), while generateText
+ * re-wraps it (ai/src/prompt/wrap-gateway-error.ts) into a marker-less error
+ * whose `name` is "GatewayAuthenticationError" (dev) or "GatewayError" with a
+ * "Configure AI_GATEWAY_API_KEY" message (NODE_ENV=production) — so the
+ * wrapped forms are matched by name.
+ */
+export function isProviderConfigurationError(error: unknown): boolean {
+  const unwrapped = RetryError.isInstance(error) ? error.lastError : error;
+  if (unwrapped instanceof ProviderConfigurationError) return true;
+  if (GatewayAuthenticationError.isInstance(unwrapped)) return true;
+  return (
+    unwrapped instanceof Error &&
+    (unwrapped.name === "GatewayAuthenticationError" || unwrapped.name === "GatewayError")
+  );
+}
 
 let groqClient: ReturnType<typeof createOpenAI> | null = null;
 let vastClients = new Map<string, ReturnType<typeof createOpenAI>>();
@@ -35,7 +78,7 @@ function getGroqClient() {
   if (!groqClient) {
     const apiKey = getProviderKey("GROQ_API_KEY");
     if (!apiKey) {
-      throw new Error("GROQ_API_KEY environment variable is required");
+      throw new ProviderConfigurationError("GROQ_API_KEY environment variable is required");
     }
 
     groqClient = createOpenAI({
@@ -50,7 +93,7 @@ function getGroqClient() {
 function getVastClient(model: string) {
   const config = resolveVastEndpointConfig(model);
   if (!config) {
-    throw new Error(`Vast endpoint is not configured for ${model}`);
+    throw new ProviderConfigurationError(`Vast endpoint is not configured for ${model}`);
   }
 
   const cacheKey = `${config.apiKey}|${config.baseUrl}`;
@@ -68,7 +111,7 @@ function getVastClient(model: string) {
 function getOpenAIClient() {
   const apiKey = getProviderKey("OPENAI_API_KEY");
   if (!apiKey) {
-    throw new Error("OPENAI_API_KEY environment variable is required");
+    throw new ProviderConfigurationError("OPENAI_API_KEY environment variable is required");
   }
 
   const baseURL = getProviderKey("OPENAI_BASE_URL") ?? undefined;
@@ -90,7 +133,7 @@ function getCerebrasClient() {
   if (!cerebrasClient) {
     const apiKey = getProviderKey("CEREBRAS_API_KEY");
     if (!apiKey) {
-      throw new Error("CEREBRAS_API_KEY environment variable is required");
+      throw new ProviderConfigurationError("CEREBRAS_API_KEY environment variable is required");
     }
 
     cerebrasClient = createOpenAI({
@@ -126,7 +169,7 @@ function getOpenRouterClient() {
   if (!openRouterClient) {
     const apiKey = getOpenRouterApiKey();
     if (!apiKey) {
-      throw new Error("OPENROUTER_API_KEY environment variable is required");
+      throw new ProviderConfigurationError("OPENROUTER_API_KEY environment variable is required");
     }
 
     openRouterClient = createOpenAI({
@@ -156,7 +199,7 @@ function getAnthropicClient() {
   if (!anthropicClient) {
     const apiKey = getProviderKey("ANTHROPIC_API_KEY");
     if (!apiKey) {
-      throw new Error("ANTHROPIC_API_KEY environment variable is required");
+      throw new ProviderConfigurationError("ANTHROPIC_API_KEY environment variable is required");
     }
 
     anthropicClient = createAnthropic({ apiKey });
@@ -213,7 +256,7 @@ function getVercelAIGatewayClient() {
   if (!vercelAIGatewayClient) {
     const apiKey = getVercelAIGatewayApiKey();
     if (!apiKey) {
-      throw new Error("AI_GATEWAY_API_KEY environment variable is required");
+      throw new ProviderConfigurationError("AI_GATEWAY_API_KEY environment variable is required");
     }
 
     vercelAIGatewayClient = createGatewayProvider({
@@ -498,7 +541,7 @@ export function getLanguageModel(model: string, credential?: PooledLanguageModel
     if (getVercelAIGatewayApiKey()) {
       return getVercelAIGatewayClient().languageModel(model as never);
     }
-    throw new Error("OPENROUTER_API_KEY is required for this model");
+    throw new ProviderConfigurationError("OPENROUTER_API_KEY is required for this model");
   }
 
   // Native, DIRECT providers (no hop) when we hold the key, with OpenRouter as
@@ -528,7 +571,7 @@ export function getLanguageModel(model: string, credential?: PooledLanguageModel
     return getOpenRouterLanguageModel(model);
   }
 
-  throw new Error(
+  throw new ProviderConfigurationError(
     "AI language model provider is not configured (set a native provider key or OPENROUTER_API_KEY)",
   );
 }
@@ -546,7 +589,7 @@ export function getTextEmbeddingModel(model: string) {
     return getVercelAIGatewayClient().embeddingModel(model as never);
   }
 
-  throw new Error("AI text embedding provider is not configured");
+  throw new ProviderConfigurationError("AI text embedding provider is not configured");
 }
 
 export function getAiProviderConfigurationError(): string {


### PR DESCRIPTION
## Bug (#13406 error-honesty batch, item 1 — [core-brain])

A chat/completions request for an unknown/unconfigured model surfaces the raw provider-configuration error to the DIRECT API caller. Observed on prod during the card-5 verification pass as `500 "Unauthenticated. Configure AI_GATEWAY_API_KEY …"` — internal env-var setup guidance in a client-facing body.

## Verify-first (defect proven on unmodified develop `0ea85dfaea`)

New test run against develop with the fix stashed — both egress points leak (real route, real AI SDK, real `@ai-sdk/gateway` client speaking HTTP to a local stub upstream answering 401 the way the gateway does):

Non-streaming body (HTTP 500 to the caller):
```
{"error":{"message":"…Unauthenticated request to AI Gateway.…To authenticate, set the AI_GATEWAY_API_KEY environment variable with your API key.…","type":"api_error"}}
```

Streaming terminal SSE chunk:
```
data: {"error":{"message":"AI Gateway authentication failed: Invalid API key.\n\nCreate a new API key: https://vercel.com/d?to=…\n\nProvide via 'apiKey' option or 'AI_GATEWAY_API_KEY' environment variable.","type":"authentication_error","code":401}}
```

The prod `"Unauthenticated. Configure AI_GATEWAY_API_KEY …"` string is the third shape of the same failure: `ai`'s `wrapGatewayError` re-wraps the gateway auth error under `NODE_ENV=production` into an `AISDKError` named `GatewayError` with exactly that message (marker-less, so an `isInstance` check alone misses it).

## Fix (structural, boundary translation per the error doctrine)

- `packages/cloud/shared/src/lib/providers/language-model.ts`
  - new typed `ProviderConfigurationError` thrown by every model-resolution config failure (missing/placeholder provider keys, unconfigured Vast endpoint, no-provider fallthrough) — messages unchanged, they are the operator-facing log detail.
  - `isProviderConfigurationError(error)`: unwraps `RetryError`, matches our typed error, the raw `GatewayAuthenticationError` (marker symbol, streamText shape), and the `ai`-package re-wraps by name (`GatewayAuthenticationError` dev / `GatewayError` prod).
- `packages/cloud/api/v1/chat/completions/route.ts` — at both client egress points (non-streaming outer catch, terminal streaming error chunk), a classified provider-config failure returns
  `400 {"error":{"message":"model '<x>' is not available on this deployment","type":"invalid_request_error","code":"model_not_available"}}`
  (the model id is the only request-derived detail echoed). The raw internal error stays in server logs — the outer catch already logs it, and the stream catch now logs it explicitly since `onError` is not guaranteed to fire before that catch.

No behavior change for any other error class (DB masking, 402 credits, provider 4xx/5xx mapping untouched).

## Test (real end-to-end, no mocks of the unit under test)

`packages/cloud/api/__tests__/chat-completions-unknown-model-config-leak.test.ts` — drives the real `handleChatCompletionsPOST` with the package's established route-test harness (auth/billing stubbed at module boundaries; route, provider resolution, AI SDK, and gateway client all REAL; the "gateway" is a local Bun HTTP server returning the gateway's own 401 error shape):

1. non-streaming: 400, clean body, and asserts NO `AI_GATEWAY_API_KEY` / `OPENROUTER_API_KEY` / `environment variable` / `apiKey` / `vercel.com` anywhere in the body
2. streaming: sanitized terminal error chunk, still `data: [DONE]`, same no-internal-markers assertion on the full SSE text
3. resolution failure with no serving key throws a classified `ProviderConfigurationError` whose message still names the missing config (operator log form retained)

## Verification (real counts)

- new test: fails 3/3 on develop (leak shown above) → passes 3/3 with the fix
- `packages/cloud/shared` providers suite: 97 pass / 1 skip / 0 fail (15 files)
- `packages/cloud/api` full unit lane (`node test/run-unit-isolated.mjs`): 142/145 files pass — the 3 failures (`compat-agent-credit-gate`, `eliza-agents-create-idempotency`, `messages-iac-fast-path`) fail identically on unmodified develop (pre-existing)
- all 10 chat-completions/apps-chat/embeddings route test files: 0 fail
- typecheck: cloud/shared exit 0; cloud/api has one pre-existing error in `__tests__/my-agents-claim-affiliate-characters.test.ts` (unrelated, present on develop)
- `bun run audit:error-policy-ratchet`: no new fallback-slop

## PR_EVIDENCE

- Real request→response traces: in the test output above (real HTTP through the real route; before/after bodies shown)
- Backend structured logs: `[Chat Completions] Error` / `[Chat Completions] Provider configuration error during stream` carry the full internal detail (visible in the test runs)
- Screenshots/video: N/A — no UI surface; API error-path change only
- Model trajectories: N/A — no agent/prompt/model behavior change; deterministic HTTP error boundary
- DB state/migrations: N/A — no schema or billing-path change (error paths refund via the existing idempotent settlers, exercised by the untouched credit-leak suites above)

Closes item 1 of the [core-brain] cloud-path error-honesty batch claimed on #13406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
