### PR TITLE
fix(ui): console P3 tail — Agents naming, doubled word, dead page-header contexts

### DIFF
--- a/packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx
+++ b/packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx
@@ -205,7 +205,7 @@ export function ContainersPageWrapper({
 export function ElizaAgentsPageWrapper({
   children,
 }: DashboardRoutePageWrapperProps) {
-  return <DashboardRoutePage title="Instances">{children}</DashboardRoutePage>;
+  return <DashboardRoutePage title="Agents">{children}</DashboardRoutePage>;
 }
 
 export function AppsEmptyState({ description, action }: AppsEmptyStateProps) {
@@ -269,9 +269,7 @@ export function ContainersEmptyState() {
             )}
           >
             <span className="select-none text-muted">$</span>
-            <code className="flex-1 font-mono text-sm text-txt">
-              {cmd}
-            </code>
+            <code className="flex-1 font-mono text-sm text-txt">{cmd}</code>
             <Button
               variant="ghost"
               type="button"

--- a/packages/ui/src/cloud/account-security/AccountPage.tsx
+++ b/packages/ui/src/cloud/account-security/AccountPage.tsx
@@ -10,19 +10,17 @@
 
 import { Lock } from "lucide-react";
 import { Link } from "react-router-dom";
-import { PageHeaderProvider } from "../../cloud-ui/components/layout";
-import { useDocumentTitle } from "../lib/use-document-title";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { AccountSurface } from "./AccountSurface";
 
 export function AccountPage() {
   const t = useCloudT();
-  useDocumentTitle(t("cloud.account.metaTitle", { defaultValue: "Account" }));
+  // No local PageHeaderProvider: the surface's useSetPageHeader must reach
+  // ConsoleShell's provider or the top bar shows no title (a local provider
+  // is a dead context nothing reads). Document title is set by AccountSurface.
   return (
     <div className="mx-auto w-full max-w-4xl px-4 py-6 md:px-6 md:py-8">
-      <PageHeaderProvider>
-        <AccountSurface />
-      </PageHeaderProvider>
+      <AccountSurface />
       {/* Security lost its sidebar slot in the launch nav cut; keep it one
           click away from the account it belongs to. */}
       <Link

--- a/packages/ui/src/cloud/account-security/PermissionsPage.tsx
+++ b/packages/ui/src/cloud/account-security/PermissionsPage.tsx
@@ -8,7 +8,6 @@
  * Default export for `React.lazy` code-splitting from the route registration.
  */
 
-import { PageHeaderProvider } from "../../cloud-ui/components/layout";
 import { useDocumentTitle } from "../lib/use-document-title";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { PermissionsSurface } from "./PermissionsSurface";
@@ -20,9 +19,7 @@ export function PermissionsPage() {
   );
   return (
     <div className="mx-auto w-full max-w-4xl px-4 py-6 md:px-6 md:py-8">
-      <PageHeaderProvider>
-        <PermissionsSurface />
-      </PageHeaderProvider>
+      <PermissionsSurface />
     </div>
   );
 }

--- a/packages/ui/src/cloud/account-security/SecurityPage.tsx
+++ b/packages/ui/src/cloud/account-security/SecurityPage.tsx
@@ -8,7 +8,6 @@
  * Default export for `React.lazy` code-splitting from the route registration.
  */
 
-import { PageHeaderProvider } from "../../cloud-ui/components/layout";
 import { useDocumentTitle } from "../lib/use-document-title";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { SecuritySurface } from "./SecuritySurface";
@@ -18,9 +17,7 @@ export function SecurityPage() {
   useDocumentTitle(t("cloud.security.metaTitle", { defaultValue: "Security" }));
   return (
     <div className="mx-auto w-full max-w-4xl px-4 py-6 md:px-6 md:py-8">
-      <PageHeaderProvider>
-        <SecuritySurface />
-      </PageHeaderProvider>
+      <SecuritySurface />
     </div>
   );
 }

--- a/packages/ui/src/cloud/account-security/StandalonePages.test.tsx
+++ b/packages/ui/src/cloud/account-security/StandalonePages.test.tsx
@@ -3,6 +3,7 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
+import { PageHeaderProvider } from "../../cloud-ui";
 
 vi.mock("../shell/CloudI18nProvider", () => ({
   useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
@@ -47,12 +48,14 @@ import { PermissionsPage } from "./PermissionsPage";
 import { SecurityPage } from "./SecurityPage";
 
 describe("account/security standalone pages", () => {
-  it("wraps the account surface in a page-header provider", () => {
+  it("publishes the account header into the outer (shell) provider", () => {
     // Router context: the page links to the de-navved Security page.
     render(
-      <MemoryRouter>
-        <AccountPage />
-      </MemoryRouter>,
+      <PageHeaderProvider>
+        <MemoryRouter>
+          <AccountPage />
+        </MemoryRouter>
+      </PageHeaderProvider>,
     );
     expect(screen.getByText("account body")).toBeTruthy();
     expect(
@@ -60,13 +63,21 @@ describe("account/security standalone pages", () => {
     ).toBeTruthy();
   });
 
-  it("wraps the security surface in a page-header provider", () => {
-    render(<SecurityPage />);
+  it("publishes the security header into the outer (shell) provider", () => {
+    render(
+      <PageHeaderProvider>
+        <SecurityPage />
+      </PageHeaderProvider>,
+    );
     expect(screen.getByText("security body")).toBeTruthy();
   });
 
-  it("wraps the permissions surface in a page-header provider", () => {
-    render(<PermissionsPage />);
+  it("publishes the permissions header into the outer (shell) provider", () => {
+    render(
+      <PageHeaderProvider>
+        <PermissionsPage />
+      </PageHeaderProvider>,
+    );
     expect(screen.getByText("permissions body")).toBeTruthy();
   });
 });

--- a/packages/ui/src/cloud/account-security/components/account-page-client.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-page-client.tsx
@@ -44,8 +44,7 @@ export function AccountPageClient({ user }: AccountPageClientProps) {
             {user.organization?.name && (
               <p className="text-xs text-muted mt-1">
                 You&apos;re part of{" "}
-                <span className="font-medium">{user.organization.name}</span>{" "}
-                organization
+                <span className="font-medium">{user.organization.name}</span>
               </p>
             )}
           </div>

--- a/packages/ui/src/cloud/api-keys/ApiKeysPage.test.tsx
+++ b/packages/ui/src/cloud/api-keys/ApiKeysPage.test.tsx
@@ -1,7 +1,15 @@
 // @vitest-environment jsdom
 
+/**
+ * ApiKeysPage must NOT mount its own PageHeaderProvider: the surface's
+ * useSetPageHeader has to reach the console shell's provider so the top bar
+ * shows the title and the header "Create API Key" CTA renders (a local
+ * provider is a dead context nothing reads — #13406 audit finding).
+ */
+
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { PageHeaderProvider, usePageHeader } from "../../cloud-ui";
 
 vi.mock("../shell/CloudI18nProvider", () => ({
   useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
@@ -21,9 +29,20 @@ vi.mock("./ApiKeysSurface", async () => {
 
 import { ApiKeysPage } from "./ApiKeysPage";
 
+function ShellHeaderProbe() {
+  const { pageInfo } = usePageHeader();
+  return <div data-testid="shell-title">{pageInfo?.title ?? ""}</div>;
+}
+
 describe("ApiKeysPage", () => {
-  it("wraps the API keys surface in a page-header provider", () => {
-    render(<ApiKeysPage />);
+  it("publishes the surface's page header into the OUTER (shell) provider", () => {
+    render(
+      <PageHeaderProvider>
+        <ShellHeaderProbe />
+        <ApiKeysPage />
+      </PageHeaderProvider>,
+    );
     expect(screen.getByText("api keys body")).toBeTruthy();
+    expect(screen.getByTestId("shell-title").textContent).toBe("API Keys");
   });
 });

--- a/packages/ui/src/cloud/api-keys/ApiKeysPage.tsx
+++ b/packages/ui/src/cloud/api-keys/ApiKeysPage.tsx
@@ -9,19 +9,16 @@
  * Default export for `React.lazy` code-splitting from the route registration.
  */
 
-import { PageHeaderProvider } from "../../cloud-ui/components/layout";
-import { useDocumentTitle } from "../lib/use-document-title";
-import { useCloudT } from "../shell/CloudI18nProvider";
 import { ApiKeysSurface } from "./ApiKeysSurface";
 
 export function ApiKeysPage() {
-  const t = useCloudT();
-  useDocumentTitle(t("cloud.apiKeys.metaTitle", { defaultValue: "API Keys" }));
+  // No local PageHeaderProvider: the surface's useSetPageHeader must reach
+  // ConsoleShell's provider so the top bar shows the title and the header
+  // "Create API Key" CTA actually renders (a local provider is a dead
+  // context nothing reads). Document title is set by ApiKeysSurface.
   return (
     <div className="mx-auto w-full max-w-4xl px-4 py-6 md:px-6 md:py-8">
-      <PageHeaderProvider>
-        <ApiKeysSurface />
-      </PageHeaderProvider>
+      <ApiKeysSurface />
     </div>
   );
 }

--- a/packages/ui/src/cloud/instances/AgentDetailPage.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.tsx
@@ -85,7 +85,7 @@ export default function AgentDetailPage() {
   const titleId = id ? id.slice(0, 8) : "";
   useDocumentTitle(
     t("cloud.agents.detail.metaTitle", {
-      defaultValue: "Agent {{id}} — Instances",
+      defaultValue: "Agent {{id}} — Agents",
       id: titleId,
     }),
   );
@@ -137,7 +137,7 @@ export default function AgentDetailPage() {
           </div>
           <span>
             {t("cloud.agents.detail.backToInstances", {
-              defaultValue: "Instances",
+              defaultValue: "Agents",
             })}
           </span>
         </Link>
@@ -273,7 +273,9 @@ export default function AgentDetailPage() {
                   plural: agent.errorCount !== 1 ? "s" : "",
                 })}
               </p>
-              <p className="text-sm text-destructive/70">{agent.errorMessage}</p>
+              <p className="text-sm text-destructive/70">
+                {agent.errorMessage}
+              </p>
             </div>
           </div>
         )}

--- a/packages/ui/src/cloud/instances/AgentsPage.tsx
+++ b/packages/ui/src/cloud/instances/AgentsPage.tsx
@@ -1,5 +1,5 @@
 /**
- * Instances page (`/dashboard/agents`) — the hosted agent management table.
+ * Agents page (`/dashboard/agents`) — the hosted agent management table.
  */
 
 import type { AgentListItemDto } from "@elizaos/cloud-shared/lib/types/cloud-api";
@@ -50,13 +50,13 @@ export default function AgentsPage() {
   const agentsQuery = useAgents();
   const credits = useCreditsBalance();
 
-  useDocumentTitle(t("cloud.agents.metaTitle", { defaultValue: "Instances" }));
+  useDocumentTitle(t("cloud.agents.metaTitle", { defaultValue: "Agents" }));
 
   if (!session.ready) {
     return (
       <DashboardLoadingState
         label={t("cloud.agents.loading", {
-          defaultValue: "Loading instances",
+          defaultValue: "Loading agents",
         })}
       />
     );
@@ -77,9 +77,9 @@ export default function AgentsPage() {
     <ElizaAgentsPageWrapper>
       <DashboardPageContainer className="space-y-6">
         {/* Page title is surfaced in the console top bar by
-            ElizaAgentsPageWrapper (DashboardRoutePage title="Instances" →
+            ElizaAgentsPageWrapper (DashboardRoutePage title="Agents" →
             useSetPageHeader). No inline page-level heading here — a second
-            "Instances" title under the top bar read as a double title. */}
+            "Agents" title under the top bar read as a double title. */}
         {showSkeleton ? (
           <ContainersSkeleton />
         ) : showAgentsError ? (


### PR DESCRIPTION
Fixes the console-cut tail findings from [stan-cloud]'s fresh-build sweep (#13406 thread) + the functional finding from the 5-rules audit.

- **Instances → Agents**: page header, tab titles (list + detail), loading label, back-link — the launch nav renamed the item but the page kept the old name everywhere else.
- **Doubled word**: account banner `…Organization organization` — org names already end in the word; literal dropped.
- **Dead PageHeaderProvider contexts** (functional): ApiKeys/Account/Security/Permissions pages each mounted a LOCAL provider that shadowed ConsoleShell's — `useSetPageHeader` wrote to a context nothing read → no top-bar title, and the API-keys header **Create API Key CTA rendered nowhere**. Providers removed; duplicate `useDocumentTitle` calls dropped (surfaces own the title).
- Tests re-pinned to the real contract (publish into the OUTER shell provider): 8/8 green.

Live evidence: probed all three on deployed staging before fixing (tab title/h1 'Instances', banner doubled word); org-route claim did NOT reproduce (renders real org page) — corrected on the tracker. [qa-agent]