### PR TITLE
fix(#13422): migrate plugin-training aliased env reads to alias-aware reader (long-tail P7)

### DIFF
--- a/plugins/plugin-training/src/cli/train.ts
+++ b/plugins/plugin-training/src/cli/train.ts
@@ -9,6 +9,7 @@
  */
 
 import { parseArgs } from "node:util";
+import { readAliasedEnv } from "@elizaos/shared";
 import { NATIVE_OPTIMIZERS, runNativeBackend } from "../backends/native.js";
 import { ALL_TRAINING_TASKS } from "../core/training-config.js";
 import type { TrajectoryTrainingTask } from "../core/trajectory-task-datasets.js";
@@ -185,7 +186,7 @@ export async function runTrainCli(argv: string[]): Promise<number> {
       const os = await import("node:os");
       const stateDir =
         process.env.TRAINING_STATE_DIR?.trim() ||
-        process.env.ELIZA_STATE_DIR?.trim() ||
+        readAliasedEnv("ELIZA_STATE_DIR") ||
         path.join(os.homedir(), ".eliza");
       const promptTask = task === "context_routing" ? "should_respond" : task;
       const artifactPayload = {

--- a/plugins/plugin-training/src/core/alias-env-reads.13422.test.ts
+++ b/plugins/plugin-training/src/core/alias-env-reads.13422.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Proves the P7 training-CLI env reads migrated to the alias-aware reader in
+ * #13422 keep the brand-alias contract for `ELIZA_STATE_DIR` — the only
+ * alias-table key read at the four migrated sites (`core/cli.ts`
+ * export-trajectories input dir + rollback-prompt store root, `cli/train.ts`
+ * artifact store root). A branded `MILADY_STATE_DIR` resolves through the real
+ * shared `readAliasedEnv` those lines now call, the canonical `ELIZA_STATE_DIR`
+ * wins when both are set, a blank value is treated as unset, and resolution
+ * never materializes the `ELIZA_STATE_DIR` mirror on `process.env`. The migrated
+ * sites are un-exported command handlers that `process.exit`, so this drives the
+ * exact resolver expression they evaluate (same approach as the P2 boot-decision
+ * coverage in `packages/app-core/src/alias-env-reads.13422.test.ts`).
+ */
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  buildBrandEnvAliases,
+  getBootConfig,
+  readAliasedEnv,
+  setBootConfig,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const ALIAS_PAIRS = buildBrandEnvAliases("MILADY");
+const TRACKED = ["MILADY_STATE_DIR", "ELIZA_STATE_DIR", "TRAINING_STATE_DIR"];
+
+const savedConfig = getBootConfig();
+const savedEnv: Record<string, string | undefined> = {};
+
+// The state-dir default shared by all four migrated call sites when neither the
+// branded nor the canonical key is set.
+const DEFAULT_STATE_DIR = join(homedir(), ".eliza");
+
+// core/cli.ts cmdExportTrajectories: the trajectory input dir derived from the
+// migrated `readAliasedEnv("ELIZA_STATE_DIR") ?? ~/.eliza` state root.
+const exportTrajectoriesInputDir = (): string =>
+  join(readAliasedEnv("ELIZA_STATE_DIR") ?? DEFAULT_STATE_DIR, "trajectories");
+
+// cli/train.ts: TRAINING_STATE_DIR (raw, not aliased) still wins; the aliased
+// ELIZA_STATE_DIR read is the second precedence tier.
+const trainStateDir = (): string =>
+  process.env.TRAINING_STATE_DIR?.trim() ||
+  readAliasedEnv("ELIZA_STATE_DIR") ||
+  DEFAULT_STATE_DIR;
+
+beforeEach(() => {
+  for (const key of TRACKED) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  // Pin the alias table on the immutable BootConfig exactly as a branded
+  // (MILADY) app boot does — this is what makes MILADY_* resolvable without the
+  // process.env mirror.
+  setBootConfig({ ...savedConfig, envAliases: ALIAS_PAIRS });
+});
+
+afterEach(() => {
+  for (const key of TRACKED) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  setBootConfig(savedConfig);
+});
+
+describe("plugin-training ELIZA_STATE_DIR alias reads (#13422 P7)", () => {
+  it("resolves a branded MILADY_STATE_DIR without writing the ELIZA_ mirror", () => {
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+
+    expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/var/milady/state");
+    expect(exportTrajectoriesInputDir()).toBe("/var/milady/state/trajectories");
+    expect(trainStateDir()).toBe("/var/milady/state");
+    // Security property: the read must not synthesize the canonical mirror.
+    expect(process.env.ELIZA_STATE_DIR).toBeUndefined();
+  });
+
+  it("prefers the canonical ELIZA_STATE_DIR over the branded alias", () => {
+    process.env.ELIZA_STATE_DIR = "/var/eliza/state";
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+
+    expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/var/eliza/state");
+    expect(exportTrajectoriesInputDir()).toBe("/var/eliza/state/trajectories");
+    expect(trainStateDir()).toBe("/var/eliza/state");
+  });
+
+  it("treats a blank ELIZA_STATE_DIR as unset and still surfaces the branded alias", () => {
+    process.env.ELIZA_STATE_DIR = "   ";
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+
+    // empty-is-unset: the blank canonical value must not shadow the alias.
+    expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/var/milady/state");
+    expect(exportTrajectoriesInputDir()).toBe("/var/milady/state/trajectories");
+  });
+
+  it("falls back to the ~/.eliza default when neither key is set", () => {
+    expect(readAliasedEnv("ELIZA_STATE_DIR")).toBeUndefined();
+    expect(exportTrajectoriesInputDir()).toBe(join(DEFAULT_STATE_DIR, "trajectories"));
+    expect(trainStateDir()).toBe(DEFAULT_STATE_DIR);
+  });
+
+  it("keeps the raw TRAINING_STATE_DIR ahead of the aliased ELIZA_STATE_DIR in train.ts", () => {
+    process.env.TRAINING_STATE_DIR = "/var/training/state";
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+
+    expect(trainStateDir()).toBe("/var/training/state");
+  });
+});

--- a/plugins/plugin-training/src/core/cli.ts
+++ b/plugins/plugin-training/src/core/cli.ts
@@ -14,6 +14,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
+import { readAliasedEnv } from "@elizaos/shared";
 import { AGENT_CONTEXTS, type AgentContext } from "./context-types.js";
 import {
   createAnthropicTeacher,
@@ -483,7 +484,7 @@ async function cmdExportTrajectories(args: string[]) {
     values.input ??
     process.env.ELIZA_TRAJECTORY_DIR ??
     join(
-      process.env.ELIZA_STATE_DIR ?? join(homedir(), ".eliza"),
+      readAliasedEnv("ELIZA_STATE_DIR") ?? join(homedir(), ".eliza"),
       "trajectories",
     );
   const outputDir = values.output ?? "./training-data";
@@ -1211,8 +1212,8 @@ async function cmdRollbackPrompt(args: string[]) {
     // then ELIZA_STATE_DIR then ~/.eliza. Stay aligned so `rollback-prompt`
     // operates on the same store the runtime + train CLI write to.
     const stateDir =
-      process.env.ELIZA_STATE_DIR?.trim() ||
-      process.env.ELIZA_STATE_DIR?.trim() ||
+      readAliasedEnv("ELIZA_STATE_DIR") ||
+      readAliasedEnv("ELIZA_STATE_DIR") ||
       join(homedir(), ".eliza");
     service.setStoreRoot(join(stateDir, "optimized-prompts"));
   }


### PR DESCRIPTION
Long-tail slice of #13422 — partition **P7 (plugin-training, 2 files, 4 hits)**.

## What
Migrates the four raw `process.env.ELIZA_STATE_DIR` **reads** in plugin-training to the alias-aware reader `readAliasedEnv("ELIZA_STATE_DIR")` (`@elizaos/shared`), so a branded prefix (e.g. `MILADY_STATE_DIR`) resolves via the BootConfig alias table while canonical `ELIZA_STATE_DIR` still wins and empty-is-unset.

| File | Site |
|---|---|
| `src/core/cli.ts:487` | `cmdExportTrajectories` trajectory input dir |
| `src/core/cli.ts:1215-1216` | `cmdRollbackPrompt` store root (pre-existing double read, migrated mechanically) |
| `src/cli/train.ts:189` | artifact store root (behind raw `TRAINING_STATE_DIR`) |

`ELIZA_STATE_DIR` is confirmed in `packages/shared/src/config/brand-env-aliases.ts` (`STATE_DIR` suffix). All four sites are **reads**; there are no writes/deletes of this key in the partition. The `syncBrandEnvToEliza` / `syncElizaEnvToBrand` mutation layer (#13423) is untouched.

## Test
Adds `src/core/alias-env-reads.13422.test.ts` (5 cases) driving the real `readAliasedEnv` + a `MILADY`-pinned BootConfig alias table:
- branded `MILADY_STATE_DIR` resolves and **no** `ELIZA_STATE_DIR` mirror is written
- canonical `ELIZA_STATE_DIR` wins over the branded alias
- blank `ELIZA_STATE_DIR` is treated as unset (branded alias surfaces)
- `~/.eliza` default when neither key set
- raw `TRAINING_STATE_DIR` keeps precedence over the aliased read in `train.ts`

```
Test Files  1 passed (1)
Tests  5 passed (5)
```
Existing `src/core/cli.test.ts` still green (16 passed). Typecheck: no errors in the touched files (pre-existing `src/ui/*` implicit-any + unbuilt-`@elizaos/ui` module-resolution errors are unrelated to this diff).

The diff-scoped `audit:alias-read-guard` decreases the aliased-read count in the touched files (4 raw reads → 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)