### PR TITLE
fix(#13422): migrate packages/agent aliased env reads to alias-aware reader (long-tail P1)

### DIFF
--- a/packages/agent/src/bin-alias-aware-env-reads.test.ts
+++ b/packages/agent/src/bin-alias-aware-env-reads.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Proves the bin.ts boot debug-log env reads migrated to `readAliasedEnv`
+ * (#13422 P1 long-tail) resolve a NON-ELIZA brand prefix (MILADY_*) through the
+ * boot-config alias table WITHOUT the `syncBrandEnvToEliza` mirror mutation, that
+ * a present canonical `ELIZA_*` value wins over the branded alias, and that an
+ * empty value reads as unset. bin.ts itself is not import-testable (its module
+ * eval configures mobile DNS and pins bootstrap symbols onto globalThis), so this
+ * drives the exact `readAliasedEnv("ELIZA_PLATFORM")` / `readAliasedEnv("ELIZA_STATE_DIR")`
+ * primitive calls the migrated line makes — the same pattern the P3 suite uses for
+ * its non-importable server.ts/tui port reads.
+ */
+import {
+  buildBrandEnvAliases,
+  getBootConfig,
+  readAliasedEnv,
+  setBootConfig,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const MILADY_ALIASES = buildBrandEnvAliases("MILADY");
+
+const TOUCHED_ENV_KEYS = [
+  "MILADY_PLATFORM",
+  "ELIZA_PLATFORM",
+  "MILADY_STATE_DIR",
+  "ELIZA_STATE_DIR",
+] as const;
+
+describe("#13422 P1 — alias-aware bin.ts boot debug-log env reads", () => {
+  const savedConfig = getBootConfig();
+  const savedEnv = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of TOUCHED_ENV_KEYS) {
+      savedEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+    setBootConfig({ ...savedConfig, envAliases: MILADY_ALIASES });
+  });
+
+  afterEach(() => {
+    setBootConfig(savedConfig);
+    for (const [key, value] of savedEnv) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    savedEnv.clear();
+  });
+
+  describe("ELIZA_PLATFORM", () => {
+    it("resolves from the branded MILADY_PLATFORM without writing the ELIZA mirror", () => {
+      process.env.MILADY_PLATFORM = "android";
+      expect(readAliasedEnv("ELIZA_PLATFORM")).toBe("android");
+      expect(process.env.ELIZA_PLATFORM).toBeUndefined();
+    });
+
+    it("lets a present canonical ELIZA_PLATFORM win over the branded alias", () => {
+      process.env.ELIZA_PLATFORM = "ios";
+      process.env.MILADY_PLATFORM = "android";
+      expect(readAliasedEnv("ELIZA_PLATFORM")).toBe("ios");
+    });
+
+    it("reads an empty branded value as unset", () => {
+      process.env.MILADY_PLATFORM = "   ";
+      expect(readAliasedEnv("ELIZA_PLATFORM")).toBeUndefined();
+    });
+  });
+
+  describe("ELIZA_STATE_DIR", () => {
+    it("resolves from the branded MILADY_STATE_DIR without writing the ELIZA mirror", () => {
+      process.env.MILADY_STATE_DIR = "/data/milady/state";
+      expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/data/milady/state");
+      expect(process.env.ELIZA_STATE_DIR).toBeUndefined();
+    });
+
+    it("lets a present canonical ELIZA_STATE_DIR win over the branded alias", () => {
+      process.env.ELIZA_STATE_DIR = "/canonical/state";
+      process.env.MILADY_STATE_DIR = "/data/milady/state";
+      expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/canonical/state");
+    });
+
+    it("reads an empty canonical value as unset (falls through to no value)", () => {
+      process.env.ELIZA_STATE_DIR = "";
+      expect(readAliasedEnv("ELIZA_STATE_DIR")).toBeUndefined();
+    });
+  });
+});

--- a/packages/agent/src/bin.ts
+++ b/packages/agent/src/bin.ts
@@ -89,7 +89,7 @@ const _binDebugLog = isAndroidMobile()
     })()
   : () => {};
 _binDebugLog(
-  `[bin.ts] started ELIZA_PLATFORM=${process.env.ELIZA_PLATFORM ?? "(unset)"} ELIZA_STATE_DIR=${process.env.ELIZA_STATE_DIR ?? "(unset)"}`,
+  `[bin.ts] started ELIZA_PLATFORM=${readAliasedEnv("ELIZA_PLATFORM") ?? "(unset)"} ELIZA_STATE_DIR=${readAliasedEnv("ELIZA_STATE_DIR") ?? "(unset)"}`,
 );
 
 // Mobile devices ship no /etc/resolv.conf, so the musl bun agent can't resolve


### PR DESCRIPTION
Long-tail slice of #13422 — migrate the P1 partition (`packages/agent`) raw `process.env` reads of brand-env alias-table keys to the alias-aware `readAliasedEnv` reader.

## What changed
- `packages/agent/src/bin.ts:92` — the boot debug-log line read `process.env.ELIZA_PLATFORM` and `process.env.ELIZA_STATE_DIR` raw. Both keys are in `packages/shared/src/config/brand-env-aliases.ts` (`PLATFORM`, `STATE_DIR`). They now go through `readAliasedEnv(...)`, which is **already imported** in this file (lines 19, 45, 72). No new import, no new dependency.

## Skipped (per partition rules) — writes, not reads
The other 8 census hits are in `packages/agent/src/runtime/eliza.ts:2348-2365` and are **all assignments/deletes** of `ELIZA_CLOUD_{TTS,MEDIA,EMBEDDINGS,RPC}_DISABLED`:
```
2348: process.env.ELIZA_CLOUD_TTS_DISABLED = "true";
2350: delete process.env.ELIZA_CLOUD_TTS_DISABLED;
... (media / embeddings / rpc, same write+delete shape)
```
These are the sync-mutation / self-defaulting layer (#13423). A write cannot be migrated to a reader, so they are left exactly as-is.

## Semantics preserved
`readAliasedEnv` → `resolveAliasedEnvValue` (canonical `ELIZA_*` wins; blank does not shadow a present alias partner) wrapped in `normalizeEnvValue` (trim + empty→undefined). This matches the prior normalized `process.env.<key>` contract for a debug-log value, and is consistent with the sibling `readAliasedEnv("ELIZA_STATE_DIR")` calls already in this file.

## Test
New focused suite `packages/agent/src/bin-alias-aware-env-reads.test.ts` drives the exact `readAliasedEnv("ELIZA_PLATFORM")` / `readAliasedEnv("ELIZA_STATE_DIR")` primitive calls the migrated line makes (bin.ts is not import-testable — its module eval configures mobile DNS + pins bootstrap globals — so this mirrors the P3 suite's pattern for non-importable modules). Proves, per key:
- a branded `MILADY_*` value resolves via the reader,
- canonical `ELIZA_*` wins over the branded alias,
- empty/whitespace reads as unset,
- **no** `ELIZA_*` mirror is written.

```
$ bunx vitest run src/bin-alias-aware-env-reads.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)
```
Sibling P3 suite still green (`src/api/alias-aware-env-reads.test.ts` — 17 passed). Typecheck of the touched files is clean; the remaining worktree typecheck errors are pre-existing missing-`@types` / unresolved-declaration issues from the isolated env's symlinked `dist/node_modules` (plugin-sql, plugin-wallet, ui, and the two pre-existing dynamic-import anchors at bin.ts:110/135) — none introduced here.

Diff is minimal and mechanical; the merged diff-scoped `audit:alias-read-guard` decreases in the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)