### PR TITLE
test(#13581): automated Android assistant-role/IME/key verification lane

### DIFF
--- a/.github/issue-evidence/13581-android-assistant-verify/README.md
+++ b/.github/issue-evidence/13581-android-assistant-verify/README.md
@@ -1,0 +1,58 @@
+# #13581 — Automated Android assistant-role / voice-IME / assist-key verification lane
+
+Before this change the Android assistant surface (VoiceInteractionService default-assistant role, the voice-input IME, the assist-key glue) had **manual-only** adb verification, the one coded instrumented test (`ElizaOsInstrumentedTest`) `assumeSystemEliza()`-gated itself off every non-AOSP APK (vacuously green), and `:app:connectedDebugAndroidTest` ran in no CI job. This adds an automated, repeatable lane plus a retail-path instrumented test and wires both into CI.
+
+## What was added
+
+| File | Role |
+|---|---|
+| `packages/app/scripts/lib/android-assistant-verify-lib.mjs` | Pure `dumpsys`/`cmd`/`logcat`/`settings` parsers → typed decisions. No I/O, no device. |
+| `packages/app/scripts/lib/android-assistant-verify-lib.test.mjs` | `node --test` coverage of the parsers (14 cases, real-shaped fixtures). |
+| `packages/app/scripts/android-assistant-verify.mjs` | adb-driven lane: assert surfaces registered → re-apply role+IME → assert secure settings → fire `cmd voiceinteraction show` / `KEYCODE_ASSIST` / IME deep-link → assert landing in MainActivity → classify IME ASR outcome. |
+| `packages/app-core/platforms/android/app/src/androidTest/.../ElizaAssistantSurfaceInstrumentedTest.java` | Retail-path (non-`assumeSystemEliza`) androidTest asserting the assistant/IME/assist surfaces are declared, bind-guarded, and intent-resolvable on ANY debug APK. |
+| `.github/workflows/android-device-e2e.yml` | `native-plugin-androidtest` now runs `:app:connectedDebugAndroidTest` AND the adb lane on the emulator. |
+| `packages/app/package.json` | `test:e2e:android:assistant` script. |
+
+## What the lane asserts (issue done-when → mechanism)
+
+1. **VIS/IME registered** — `dumpsys package ai.elizaos.app` → `parseAssistantSurfaces` (VIS + session + recognition + IME + assist activity all present; a renamed/dropped surface reads ABSENT, boundary-matched so `…ServiceRENAMED` ≠ `…Service`).
+2. **Role + IME re-applied after reinstall, secure settings asserted** — `cmd role add-role-holder android.app.role.ASSISTANT`, `ime enable`+`ime set`, then read back `voice_interaction_service` / `default_input_method` / `cmd role holders` / `ime list -s`.
+3. **Assistant/IME invocation reaches the Eliza entry point** — fire `cmd voiceinteraction show`, `input keyevent KEYCODE_ASSIST`, and the IME `elizaos://voice?source=android-ime` deep-link; assert MainActivity resumed **and** the expected `source=` tag via `dumpsys activity activities` + logcat (both required — a coincidental foreground MainActivity can't pass).
+4. **IME ASR round-trip** — `classifyImeAsrOutcome` distinguishes `committed` (full engine) from the designed `engineOff` state — asserted, never skipped silently.
+
+## Honest device gating — never green-by-skip
+
+Two **independent** gates:
+
+- `--require-device` / `ELIZA_ANDROID_REQUIRE_AGENT=1`: a required-but-missing **device** is a hard failure.
+- `--require-engine` / `ELIZA_ANDROID_REQUIRE_ENGINE=1`: only then does an `engineOff` ASR outcome fail (kept separate because the emulator has no on-device engine).
+
+With no device attached and no require flag, the lane prints an N/A verdict and exits 0. See `device-gating-exit-paths.txt`:
+
+```
+$ node scripts/android-assistant-verify.mjs                       → N/A, exit 0
+$ node scripts/android-assistant-verify.mjs --require-device      → FAIL, exit 1
+$ ELIZA_ANDROID_REQUIRE_AGENT=1 node scripts/android-assistant-verify.mjs → FAIL, exit 1
+```
+
+## Evidence in this directory
+
+- `parser-node-test.txt` — `node --test` run, 14/14 pass. **Runnable here (no device).**
+- `device-gating-exit-paths.txt` — the three device-gating exit paths on a host with no device. **Runnable here.**
+- `regression-canary.txt` — deliberate regression (rename the VIS) flips the parser + lane verdict RED (done-when "regression canary turns the lane red", proven at the parser level; the on-device flip needs a device).
+
+## N/A here — needs an Android device/emulator
+
+The **on-device** run of `android-assistant-verify.mjs` and the CI `:app:connectedDebugAndroidTest` + adb lane were **not** executed in this worktree — **no Android device or emulator is attached**, and this host is macOS (the CI emulator lane is a KVM Linux runner). This is the honest N/A the lane is designed to surface (exit 0 without a require flag). To run for real:
+
+```bash
+# device/emulator attached, app APK installed:
+bun run --cwd packages/app test:e2e:android:assistant
+# CI: android-device-e2e.yml → native-plugin-androidtest (label ci:device or workflow_dispatch)
+```
+
+The lane and the retail-path instrumented test are wired correctly (YAML parses; `:app:connectedDebugAndroidTest` and the adb lane are in the emulator script); the CI-run link with a non-skipped assistant/IME test is the remaining artifact to attach once the labeled/dispatched run executes.
+
+## #12393 hardware assistant-key remap — re-tracked, not silently closed
+
+The `input keyevent KEYCODE_ASSIST` path (software-injectable) is now covered. The **hardware** key remap (a physical key → `KEYCODE_ASSIST` via a `.kl` keylayout overlay in the AOSP vendor tree) is not implementable here — no `.kl` mechanism exists under `packages/scripts/distro-android/` and there is no AOSP build host. Per the done-when, this is re-tracked on #12393 rather than left closed-but-unimplemented (see the issue comment linking this PR).

--- a/.github/issue-evidence/13581-android-assistant-verify/device-gating-exit-paths.txt
+++ b/.github/issue-evidence/13581-android-assistant-verify/device-gating-exit-paths.txt
@@ -1,0 +1,13 @@
+# android-assistant-verify — device gating exit paths (host has NO device)
+
+$ node scripts/android-assistant-verify.mjs   # default: honest N/A
+[android-assistant-verify] N/A (skipped honestly): no Android device/emulator attached — assistant/IME/assist-key checks need a device.
+exit=0
+
+$ node scripts/android-assistant-verify.mjs --require-device   # required-but-missing -> FAIL
+[android-assistant-verify] REQUIRED device missing: no Android device/emulator attached — assistant/IME/assist-key checks need a device.
+exit=1
+
+$ ELIZA_ANDROID_REQUIRE_AGENT=1 node scripts/android-assistant-verify.mjs   # env flag -> FAIL
+[android-assistant-verify] REQUIRED device missing: no Android device/emulator attached — assistant/IME/assist-key checks need a device.
+exit=1

--- a/.github/issue-evidence/13581-android-assistant-verify/parser-node-test.txt
+++ b/.github/issue-evidence/13581-android-assistant-verify/parser-node-test.txt
@@ -1,0 +1,22 @@
+✔ normalizeComponent canonicalizes short and full forms equally (5.1945ms)
+✔ parseServiceRegistration finds the VIS in a real dumpsys package slice (short form) (2.379667ms)
+✔ parseServiceRegistration reports absence when the component is missing (0.245292ms)
+✔ parseAssistantSurfaces detects every declared surface, and reports the missing one (1.426167ms)
+✔ parseAssistantSurfaces treats a renamed VIS as ABSENT (regression canary) (0.325208ms)
+✔ parseRoleHolders recognizes the held ROLE_ASSISTANT and rejects noise lines (0.309125ms)
+✔ parseVoiceInteractionService reads dumpsys ComponentInfo and flattened settings forms (0.327917ms)
+✔ parseDefaultInputMethod distinguishes selected Eliza IME from another keyboard and null (2.44525ms)
+✔ parseEnabledImes finds the Eliza IME in an `ime list -s` set (0.626834ms)
+✔ detectSurfaceInvocation catches the IME class tag, bracket marker, and deep-link source (2.298791ms)
+✔ assertDeepLinkLanded requires BOTH resumed MainActivity and the expected source tag (0.448084ms)
+✔ classifyImeAsrOutcome distinguishes committed / engineOff / modelNotReady / error (0.292292ms)
+✔ summarizeLaneVerdict passes only when every required surface checks out (0.291291ms)
+✔ exported component ids match the native manifest components (0.066458ms)
+ℹ tests 14
+ℹ suites 0
+ℹ pass 14
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 219.667208

--- a/.github/issue-evidence/13581-android-assistant-verify/regression-canary.txt
+++ b/.github/issue-evidence/13581-android-assistant-verify/regression-canary.txt
@@ -1,0 +1,9 @@
+== HEALTHY manifest ==
+surfaces.allPresent: true missing: []
+lane verdict: {"pass":true,"failures":[]}
+
+== REGRESSED (VIS renamed to ...ServiceRENAMED) ==
+surfaces.allPresent: false missing: ["voiceInteractionService"]
+lane verdict: {"pass":false,"failures":["assistant/IME surfaces not registered"]}
+
+CANARY RESULT: OK -- deliberate regression turns the lane RED

--- a/.github/workflows/android-device-e2e.yml
+++ b/.github/workflows/android-device-e2e.yml
@@ -349,7 +349,13 @@ jobs:
 
             # The gate: build + install + run every native-plugin androidTest on the
             # emulator in one invocation. gradle fails the job on any test failure.
+            # `:app:connectedDebugAndroidTest` adds the app-level assistant/IME/
+            # assist-surface instrumented tests (#13581) — the RETAIL-path
+            # ElizaAssistantSurfaceInstrumentedTest runs on the plain debug APK
+            # (not assumeSystemEliza-gated), so this app run is not vacuously
+            # green off-AOSP.
             "$GRADLEW" -p "$ANDROID_DIR" --no-daemon \
+              :app:connectedDebugAndroidTest \
               :elizaos-capacitor-system:connectedDebugAndroidTest \
               :elizaos-capacitor-wifi:connectedDebugAndroidTest \
               :elizaos-capacitor-phone:connectedDebugAndroidTest \
@@ -380,6 +386,30 @@ jobs:
               echo "mobile-signals UsageStats run did not complete cleanly"
               exit 1
             }
+
+            # Assistant-role / voice-IME / assist-key adb verification lane
+            # (#13581). The gradle gate above uninstalled its test APKs, so
+            # install the app APK the Capacitor build produced, then drive the
+            # RUNTIME surface: re-apply the role + IME that `adb install -r`
+            # clears, assert the secure settings, fire `cmd voiceinteraction
+            # show` / `KEYCODE_ASSIST` / the IME deep-link, and assert they land
+            # in MainActivity. `--require-device` makes a missing device fatal
+            # (it is present here, so this only guards against a silent skip).
+            # `--require-engine` is intentionally NOT passed: the emulator carries
+            # no on-device ASR engine, so the IME ASR round-trip legitimately
+            # resolves to the designed ENGINE_OFF state — the lane asserts that
+            # state rather than requiring a transcript. All other assertions
+            # (registration, role, IME selection, deep-link landing) still gate
+            # the job.
+            APP_APK="$GITHUB_WORKSPACE/packages/app-core/platforms/android/app/build/outputs/apk/debug/app-debug.apk"
+            if [ -f "$APP_APK" ]; then
+              adb install -r -t "$APP_APK"
+            else
+              echo "app-debug.apk not found at $APP_APK — build:android should have produced it"
+              exit 1
+            fi
+            node "$GITHUB_WORKSPACE/packages/app/scripts/android-assistant-verify.mjs" \
+              --require-device --json
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/packages/app-core/platforms/android/app/src/androidTest/java/ai/elizaos/app/ElizaAssistantSurfaceInstrumentedTest.java
+++ b/packages/app-core/platforms/android/app/src/androidTest/java/ai/elizaos/app/ElizaAssistantSurfaceInstrumentedTest.java
@@ -1,0 +1,131 @@
+package ai.elizaos.app;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.content.pm.ServiceInfo;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import java.util.List;
+
+/**
+ * Retail-path (non-{@code assumeSystemEliza}) assertions that Eliza's Android
+ * assistant surfaces survived install-time manifest parsing on ANY debug build.
+ *
+ * The pre-existing {@code ElizaOsInstrumentedTest} only asserts held default
+ * roles, and every one of its cases {@code assumeSystemEliza()}-gates to the
+ * {@code /system/priv-app/Eliza/} AOSP APK — so on a normal sideload/CI APK it
+ * vacuously assume-skips and the {@code :app:} androidTest run proves nothing.
+ * This class fixes that (#13581): its assertions run on the plain debug APK the
+ * emulator installs, so wiring {@code :app:connectedDebugAndroidTest} into CI
+ * is not green-by-skip.
+ *
+ * These are the checks that regress when a manifest edit or a missing paired
+ * service (e.g. a VoiceInteractionService whose recognitionService is absent —
+ * the framework then rejects it and it never appears as an assistant candidate)
+ * silently drops a surface. The lane's device-side adb scrape (dumpsys/cmd)
+ * covers the *runtime* role/IME selection; this covers the *declaration* that
+ * must exist before any of that can work.
+ */
+@RunWith(AndroidJUnit4.class)
+public class ElizaAssistantSurfaceInstrumentedTest {
+
+    private static final String PACKAGE_NAME = "ai.elizaos.app";
+
+    private Context context() {
+        return InstrumentationRegistry.getInstrumentation().getTargetContext();
+    }
+
+    private ServiceInfo declaredService(String className) throws Exception {
+        ComponentName component = new ComponentName(PACKAGE_NAME, className);
+        // GET_META_DATA so the parse of the service's <meta-data> (voice
+        // interaction / input-method descriptors) is exercised too — a broken
+        // descriptor throws NameNotFoundException here.
+        return context().getPackageManager()
+                .getServiceInfo(component, PackageManager.GET_META_DATA);
+    }
+
+    @Test
+    public void voiceInteractionServiceIsDeclaredAndBindGuarded() throws Exception {
+        ServiceInfo info = declaredService("ai.elizaos.app.ElizaVoiceInteractionService");
+        assertNotNull("ElizaVoiceInteractionService must be declared", info);
+        assertTrue("VIS must be exported so the framework can bind it", info.exported);
+        assertTrue(
+                "VIS must be guarded by BIND_VOICE_INTERACTION",
+                "android.permission.BIND_VOICE_INTERACTION".equals(info.permission));
+    }
+
+    @Test
+    public void pairedSessionAndRecognitionServicesAreDeclared() throws Exception {
+        // The VoiceInteractionServiceInfo parser rejects the VIS unless BOTH the
+        // session and recognition services it references exist; asserting they
+        // are present is asserting the VIS could parse at all.
+        assertNotNull(declaredService("ai.elizaos.app.ElizaVoiceInteractionSessionService"));
+        assertNotNull(declaredService("ai.elizaos.app.ElizaRecognitionService"));
+    }
+
+    @Test
+    public void voiceImeIsDeclaredAndBindGuarded() throws Exception {
+        ServiceInfo info = declaredService("ai.elizaos.app.ElizaVoiceInputMethodService");
+        assertNotNull("ElizaVoiceInputMethodService must be declared", info);
+        assertTrue("IME must be exported", info.exported);
+        assertTrue(
+                "IME must be guarded by BIND_INPUT_METHOD",
+                "android.permission.BIND_INPUT_METHOD".equals(info.permission));
+    }
+
+    @Test
+    public void voiceImeResolvesForTheInputMethodAction() {
+        Intent imeIntent = new Intent("android.view.InputMethod");
+        List<ResolveInfo> resolved = context().getPackageManager()
+                .queryIntentServices(imeIntent, 0);
+        boolean elizaImePresent = false;
+        for (ResolveInfo candidate : resolved) {
+            if (candidate.serviceInfo != null
+                    && PACKAGE_NAME.equals(candidate.serviceInfo.packageName)
+                    && "ai.elizaos.app.ElizaVoiceInputMethodService"
+                            .equals(candidate.serviceInfo.name)) {
+                elizaImePresent = true;
+                break;
+            }
+        }
+        assertTrue(
+                "Eliza voice IME must resolve for android.view.InputMethod",
+                elizaImePresent);
+    }
+
+    @Test
+    public void assistActivityResolvesTheAssistAction() {
+        // ACTION_ASSIST must resolve to Eliza's fallback assist activity (the OEM
+        // direct-intent path that stays valid whether or not the role is held).
+        Intent assist = new Intent(Intent.ACTION_ASSIST);
+        assist.setPackage(PACKAGE_NAME);
+        ResolveInfo resolved = context().getPackageManager()
+                .resolveActivity(assist, 0);
+        assertNotNull("ACTION_ASSIST must resolve within Eliza", resolved);
+        assertTrue(
+                "ACTION_ASSIST must route to ElizaAssistActivity",
+                resolved.activityInfo != null
+                        && "ai.elizaos.app.ElizaAssistActivity"
+                                .equals(resolved.activityInfo.name));
+    }
+
+    @Test
+    public void voiceCommandActionResolvesWithinEliza() {
+        Intent voiceCommand = new Intent(Intent.ACTION_VOICE_COMMAND);
+        voiceCommand.setPackage(PACKAGE_NAME);
+        ResolveInfo resolved = context().getPackageManager()
+                .resolveActivity(voiceCommand, 0);
+        assertNotNull("ACTION_VOICE_COMMAND must resolve within Eliza", resolved);
+    }
+}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -39,6 +39,7 @@
     "test:e2e:ios:cloud": "node scripts/ios-e2e.mjs --cloud",
     "test:e2e:android:local": "node scripts/android-e2e.mjs --skip-route-coverage",
     "test:e2e:android:routes": "node scripts/android-e2e.mjs --skip-local-chat",
+    "test:e2e:android:assistant": "node scripts/android-assistant-verify.mjs --require-device --json",
     "test:e2e:android:onboarding": "ELIZA_ANDROID_BACKEND=host ELIZA_ANDROID_REQUIRE_AGENT=1 bunx playwright test --config playwright.android.config.ts test/android/onboarding-to-home.android.spec.ts",
     "test:e2e:android:native-plugin-view": "ELIZA_ANDROID_BACKEND=${ELIZA_ANDROID_BACKEND:-host} ELIZA_ANDROID_REQUIRE_AGENT=${ELIZA_ANDROID_REQUIRE_AGENT:-1} bunx playwright test --config playwright.android.config.ts test/android/native-plugin-view-smoke.android.spec.ts",
     "test:e2e:android:view-runtime-soak": "ELIZA_ANDROID_BACKEND=${ELIZA_ANDROID_BACKEND:-host} ELIZA_ANDROID_REQUIRE_AGENT=${ELIZA_ANDROID_REQUIRE_AGENT:-1} bunx playwright test --config playwright.android.config.ts test/android/view-runtime-soak.android.spec.ts",

--- a/packages/app/scripts/android-assistant-verify.mjs
+++ b/packages/app/scripts/android-assistant-verify.mjs
@@ -27,28 +27,31 @@
  * Honest device gating (never green-by-skip): with NO device attached the lane
  * prints an N/A verdict and exits 0 — UNLESS `ELIZA_ANDROID_REQUIRE_AGENT=1`
  * (or `--require-device`), which makes a missing device a hard failure (exit 1).
- * When the agent is required, an ENGINE_OFF ASR outcome also fails. All decision
- * logic lives in the pure, unit-tested `android-assistant-verify-lib.mjs`; this
- * file only runs adb and feeds its stdout to those parsers.
+ * The ASR engine is gated SEPARATELY (`--require-engine` /
+ * `ELIZA_ANDROID_REQUIRE_ENGINE=1`): only then does an ENGINE_OFF ASR outcome
+ * fail — the engine-less emulator leaves it unset and asserts the designed
+ * ENGINE_OFF state instead. All decision logic lives in the pure, unit-tested
+ * `android-assistant-verify-lib.mjs`; this file only runs adb and feeds its
+ * stdout to those parsers.
  *
- * Flags: --serial <s>  --require-device  --json  --no-apply
- * Env:   ANDROID_SERIAL, ELIZA_ANDROID_REQUIRE_AGENT
+ * Flags: --serial <s>  --require-device  --require-engine  --json  --no-apply
+ * Env:   ANDROID_SERIAL, ELIZA_ANDROID_REQUIRE_AGENT, ELIZA_ANDROID_REQUIRE_ENGINE
  */
 import {
   APP_PACKAGE,
   ASSISTANT_IME_COMPONENT,
   ASSISTANT_VIS_COMPONENT,
-  DEEP_LINK_SOURCES,
-  LOG_TAGS,
-  ROLE_ASSISTANT,
   assertDeepLinkLanded,
   classifyImeAsrOutcome,
+  DEEP_LINK_SOURCES,
   detectSurfaceInvocation,
+  LOG_TAGS,
   parseAssistantSurfaces,
   parseDefaultInputMethod,
   parseEnabledImes,
   parseRoleHolders,
   parseVoiceInteractionService,
+  ROLE_ASSISTANT,
   summarizeLaneVerdict,
 } from "./lib/android-assistant-verify-lib.mjs";
 import {
@@ -67,10 +70,24 @@ const val = (flag, fb) => {
 };
 const log = (m) => console.log(`[android-assistant-verify] ${m}`);
 
+// Two INDEPENDENT gates — do not conflate them.
+//  REQUIRE_DEVICE governs device presence: a required-but-missing device is a
+//    hard failure (the #13581 "never green-by-skip" ask). Also set by
+//    ELIZA_ANDROID_REQUIRE_AGENT, the repo's standing "the device/agent must be
+//    real" flag used across the android lanes.
+//  REQUIRE_ENGINE governs the on-device ASR engine: when set, an ENGINE_OFF IME
+//    ASR outcome fails. It is SEPARATE because the emulator carries no engine —
+//    on a full-engine build (or a real device with a staged model) set it to
+//    require a committed transcript; on the engine-less emulator leave it unset
+//    so the lane asserts the designed ENGINE_OFF state instead.
 const REQUIRE_DEVICE =
   has("--require-device") ||
   process.env.ELIZA_ANDROID_REQUIRE_AGENT === "1" ||
   process.env.ELIZA_ANDROID_REQUIRE_AGENT === "true";
+const REQUIRE_ENGINE =
+  has("--require-engine") ||
+  process.env.ELIZA_ANDROID_REQUIRE_ENGINE === "1" ||
+  process.env.ELIZA_ANDROID_REQUIRE_ENGINE === "true";
 const APPLY = !has("--no-apply");
 const JSON_OUT = has("--json");
 
@@ -104,8 +121,20 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 function applyRoleAndIme(adb, serial) {
   log("re-applying assistant role + IME (cleared by adb install -r)…");
   // The role grant needs the role framework; --user 0 targets the primary user.
-  sh(adb, serial, ["cmd", "role", "add-role-holder", ROLE_ASSISTANT, APP_PACKAGE]);
-  sh(adb, serial, ["settings", "put", "secure", "voice_interaction_service", VIS_COMPONENT]);
+  sh(adb, serial, [
+    "cmd",
+    "role",
+    "add-role-holder",
+    ROLE_ASSISTANT,
+    APP_PACKAGE,
+  ]);
+  sh(adb, serial, [
+    "settings",
+    "put",
+    "secure",
+    "voice_interaction_service",
+    VIS_COMPONENT,
+  ]);
   sh(adb, serial, ["settings", "put", "secure", "assistant", VIS_COMPONENT]);
   sh(adb, serial, ["ime", "enable", IME_COMPONENT]);
   sh(adb, serial, ["ime", "set", IME_COMPONENT]);
@@ -116,7 +145,14 @@ async function verifyOnDevice(adb, serial) {
 
   // (1) Surfaces registered — dumpsys package for the app, then fall back to a
   // full package dump if the per-package form is unavailable on this image.
-  let pkgDump = adbTry(adb, ["-s", serial, "shell", "dumpsys", "package", APP_PACKAGE]);
+  let pkgDump = adbTry(adb, [
+    "-s",
+    serial,
+    "shell",
+    "dumpsys",
+    "package",
+    APP_PACKAGE,
+  ]);
   if (!pkgDump.includes(APP_PACKAGE)) {
     pkgDump = adbTry(adb, ["-s", serial, "shell", "dumpsys", "package"]);
   }
@@ -146,14 +182,23 @@ async function verifyOnDevice(adb, serial) {
   checks.imeEnabled = imeEnabled;
   log(`role held by Eliza: ${role.heldByExpected}`);
   log(`voice_interaction_service is Eliza: ${visSetting.isEliza}`);
-  log(`default_input_method is Eliza IME: ${imeSetting.isEliza} (enabled: ${imeEnabled.elizaEnabled})`);
+  log(
+    `default_input_method is Eliza IME: ${imeSetting.isEliza} (enabled: ${imeEnabled.elizaEnabled})`,
+  );
 
   // (3a) Assist-gesture invocation via cmd voiceinteraction show.
   clearLogcat(adb, serial);
   sh(adb, serial, ["cmd", "voiceinteraction", "show"]);
   await sleep(2_500);
-  let assistLog = dumpLogcat(adb, serial);
-  let assistDump = adbTry(adb, ["-s", serial, "shell", "dumpsys", "activity", "activities"]);
+  const assistLog = dumpLogcat(adb, serial);
+  const assistDump = adbTry(adb, [
+    "-s",
+    serial,
+    "shell",
+    "dumpsys",
+    "activity",
+    "activities",
+  ]);
   const visInvoked = detectSurfaceInvocation(assistLog, {
     tag: LOG_TAGS.vis,
     bracket: "ElizaVoiceInteractionSession",
@@ -173,9 +218,17 @@ async function verifyOnDevice(adb, serial) {
   sh(adb, serial, ["input", "keyevent", "KEYCODE_ASSIST"]);
   await sleep(2_500);
   const keyLog = dumpLogcat(adb, serial);
-  const keyDump = adbTry(adb, ["-s", serial, "shell", "dumpsys", "activity", "activities"]);
+  const keyDump = adbTry(adb, [
+    "-s",
+    serial,
+    "shell",
+    "dumpsys",
+    "activity",
+    "activities",
+  ]);
   const keyLanded =
-    assertDeepLinkLanded(keyDump, keyLog, DEEP_LINK_SOURCES.assistantSession).landed ||
+    assertDeepLinkLanded(keyDump, keyLog, DEEP_LINK_SOURCES.assistantSession)
+      .landed ||
     assertDeepLinkLanded(keyDump, keyLog, DEEP_LINK_SOURCES.assist).landed;
   checks.assistKeyLanded = keyLanded;
   log(`assist key (KEYCODE_ASSIST) reached Eliza: ${keyLanded}`);
@@ -198,13 +251,24 @@ async function verifyOnDevice(adb, serial) {
   ]);
   await sleep(2_500);
   const imeLog = dumpLogcat(adb, serial);
-  const imeDump = adbTry(adb, ["-s", serial, "shell", "dumpsys", "activity", "activities"]);
-  const imeLanded = assertDeepLinkLanded(imeDump, imeLog, DEEP_LINK_SOURCES.ime);
+  const imeDump = adbTry(adb, [
+    "-s",
+    serial,
+    "shell",
+    "dumpsys",
+    "activity",
+    "activities",
+  ]);
+  const imeLanded = assertDeepLinkLanded(
+    imeDump,
+    imeLog,
+    DEEP_LINK_SOURCES.ime,
+  );
   checks.imeLanded = imeLanded;
   log(`IME deep-link reached MainActivity: ${imeLanded.landed}`);
 
   // (4) IME ASR round-trip classification (committed vs. designed ENGINE_OFF).
-  const asrOutcome = classifyImeAsrOutcome(imeLog + "\n" + assistLog);
+  const asrOutcome = classifyImeAsrOutcome(`${imeLog}\n${assistLog}`);
   checks.asrOutcome = asrOutcome;
   log(`IME ASR outcome: ${asrOutcome}`);
 
@@ -217,7 +281,7 @@ async function verifyOnDevice(adb, serial) {
       imeLanded: imeLanded.landed,
       asrOutcome,
     },
-    REQUIRE_DEVICE,
+    REQUIRE_ENGINE,
   );
   checks.verdict = verdict;
   return checks;
@@ -243,7 +307,10 @@ async function main() {
     });
   }
 
-  const serial = resolveSerial(adb, val("--serial", process.env.ANDROID_SERIAL));
+  const serial = resolveSerial(
+    adb,
+    val("--serial", process.env.ANDROID_SERIAL),
+  );
   process.env.ANDROID_SERIAL = serial;
   log(`device serial=${serial}`);
   await ensureEmulatorPermissive(adb, serial, { log });
@@ -281,7 +348,9 @@ function finish(result) {
   if (result.status === "fail") {
     console.error(
       `[android-assistant-verify] FAILED: ${
-        result.reason ?? result.checks?.verdict?.failures?.join("; ") ?? "verification failed"
+        result.reason ??
+        result.checks?.verdict?.failures?.join("; ") ??
+        "verification failed"
       }`,
     );
     process.exit(1);

--- a/packages/app/scripts/android-assistant-verify.mjs
+++ b/packages/app/scripts/android-assistant-verify.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+/**
+ * Automated, repeatable adb-driven verification lane for Eliza's Android
+ * assistant surfaces (issue #13581): the ROLE_ASSISTANT VoiceInteractionService,
+ * the voice-input IME, and the assist-key / assist-gesture routing. It is the
+ * regression lane the surfaces shipped without — every `adb install -r` clears
+ * the assistant role and the enabled/selected IME, so a dev-loop reinstall
+ * silently un-configures the surface and, until now, nothing noticed.
+ *
+ * What it does, against whatever build is installed on the attached device:
+ *   1. Assert the manifest-declared surfaces survived install-time parsing —
+ *      the VIS/session/recognition services, the IME service, the assist
+ *      activity — via `dumpsys package` (a rejected VoiceInteractionServiceInfo
+ *      never registers, so this catches a broken manifest as a hard failure).
+ *   2. Re-apply the assistant role (`cmd role add-role-holder …ASSISTANT`) and
+ *      the IME (`ime enable` + `ime set`) that a reinstall clears, then assert
+ *      the secure settings (`voice_interaction_service`, `default_input_method`).
+ *   3. Fire the assistant (`cmd voiceinteraction show`), the assist key
+ *      (`input keyevent KEYCODE_ASSIST`), and the IME open-app path, and assert
+ *      via logcat + `dumpsys activity` that the Eliza deep-link
+ *      (`elizaos://voice?source=android-assistant-session` / `…=android-ime`)
+ *      lands in MainActivity.
+ *   4. Classify the IME ASR round-trip: a committed transcript when a full
+ *      engine is up, or the designed ENGINE_OFF state when it is not — asserted,
+ *      never skipped silently.
+ *
+ * Honest device gating (never green-by-skip): with NO device attached the lane
+ * prints an N/A verdict and exits 0 — UNLESS `ELIZA_ANDROID_REQUIRE_AGENT=1`
+ * (or `--require-device`), which makes a missing device a hard failure (exit 1).
+ * When the agent is required, an ENGINE_OFF ASR outcome also fails. All decision
+ * logic lives in the pure, unit-tested `android-assistant-verify-lib.mjs`; this
+ * file only runs adb and feeds its stdout to those parsers.
+ *
+ * Flags: --serial <s>  --require-device  --json  --no-apply
+ * Env:   ANDROID_SERIAL, ELIZA_ANDROID_REQUIRE_AGENT
+ */
+import {
+  APP_PACKAGE,
+  ASSISTANT_IME_COMPONENT,
+  ASSISTANT_VIS_COMPONENT,
+  DEEP_LINK_SOURCES,
+  LOG_TAGS,
+  ROLE_ASSISTANT,
+  assertDeepLinkLanded,
+  classifyImeAsrOutcome,
+  detectSurfaceInvocation,
+  parseAssistantSurfaces,
+  parseDefaultInputMethod,
+  parseEnabledImes,
+  parseRoleHolders,
+  parseVoiceInteractionService,
+  summarizeLaneVerdict,
+} from "./lib/android-assistant-verify-lib.mjs";
+import {
+  adbTry,
+  ensureEmulatorPermissive,
+  isInstalled,
+  listDevices,
+  resolveAdb,
+  resolveSerial,
+} from "./lib/android-device.mjs";
+
+const has = (flag) => process.argv.includes(flag);
+const val = (flag, fb) => {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : fb;
+};
+const log = (m) => console.log(`[android-assistant-verify] ${m}`);
+
+const REQUIRE_DEVICE =
+  has("--require-device") ||
+  process.env.ELIZA_ANDROID_REQUIRE_AGENT === "1" ||
+  process.env.ELIZA_ANDROID_REQUIRE_AGENT === "true";
+const APPLY = !has("--no-apply");
+const JSON_OUT = has("--json");
+
+const IME_COMPONENT = ASSISTANT_IME_COMPONENT;
+const VIS_COMPONENT = ASSISTANT_VIS_COMPONENT;
+
+/** Run an adb shell command on the device, returning trimmed stdout (or "" on failure). */
+function sh(adb, serial, args) {
+  return adbTry(adb, ["-s", serial, "shell", ...args]).trim();
+}
+
+/** Clear the logcat ring so a subsequent scrape only sees this run's lines. */
+function clearLogcat(adb, serial) {
+  adbTry(adb, ["-s", serial, "logcat", "-c"], { stdio: "ignore" });
+}
+
+/** Dump and return the current logcat buffer (bounded to the assistant tags). */
+function dumpLogcat(adb, serial) {
+  return adbTry(adb, ["-s", serial, "logcat", "-d", "-v", "brief"]);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Re-apply the assistant role + IME a reinstall clears. Idempotent: re-running
+ * on an already-configured device is a no-op. Emulators are rooted by
+ * ensureEmulatorPermissive so `cmd role add-role-holder` succeeds; on a retail
+ * device without root the grant may be refused — the subsequent secure-settings
+ * assertion is what turns that into a visible failure rather than a false pass.
+ */
+function applyRoleAndIme(adb, serial) {
+  log("re-applying assistant role + IME (cleared by adb install -r)…");
+  // The role grant needs the role framework; --user 0 targets the primary user.
+  sh(adb, serial, ["cmd", "role", "add-role-holder", ROLE_ASSISTANT, APP_PACKAGE]);
+  sh(adb, serial, ["settings", "put", "secure", "voice_interaction_service", VIS_COMPONENT]);
+  sh(adb, serial, ["settings", "put", "secure", "assistant", VIS_COMPONENT]);
+  sh(adb, serial, ["ime", "enable", IME_COMPONENT]);
+  sh(adb, serial, ["ime", "set", IME_COMPONENT]);
+}
+
+async function verifyOnDevice(adb, serial) {
+  const checks = {};
+
+  // (1) Surfaces registered — dumpsys package for the app, then fall back to a
+  // full package dump if the per-package form is unavailable on this image.
+  let pkgDump = adbTry(adb, ["-s", serial, "shell", "dumpsys", "package", APP_PACKAGE]);
+  if (!pkgDump.includes(APP_PACKAGE)) {
+    pkgDump = adbTry(adb, ["-s", serial, "shell", "dumpsys", "package"]);
+  }
+  const surfaces = parseAssistantSurfaces(pkgDump);
+  checks.surfaces = surfaces;
+  log(
+    surfaces.allPresent
+      ? "surfaces: VIS + session + recognition + IME + assist activity all registered"
+      : `surfaces MISSING: ${surfaces.missing.join(", ")}`,
+  );
+
+  if (APPLY) applyRoleAndIme(adb, serial);
+
+  // (2) Secure settings + role holders reflect Eliza.
+  const roleOut = sh(adb, serial, ["cmd", "role", "holders", ROLE_ASSISTANT]);
+  const role = parseRoleHolders(roleOut);
+  const visSetting = parseVoiceInteractionService(
+    sh(adb, serial, ["settings", "get", "secure", "voice_interaction_service"]),
+  );
+  const imeSetting = parseDefaultInputMethod(
+    sh(adb, serial, ["settings", "get", "secure", "default_input_method"]),
+  );
+  const imeEnabled = parseEnabledImes(sh(adb, serial, ["ime", "list", "-s"]));
+  checks.role = role;
+  checks.visSetting = visSetting;
+  checks.imeSetting = imeSetting;
+  checks.imeEnabled = imeEnabled;
+  log(`role held by Eliza: ${role.heldByExpected}`);
+  log(`voice_interaction_service is Eliza: ${visSetting.isEliza}`);
+  log(`default_input_method is Eliza IME: ${imeSetting.isEliza} (enabled: ${imeEnabled.elizaEnabled})`);
+
+  // (3a) Assist-gesture invocation via cmd voiceinteraction show.
+  clearLogcat(adb, serial);
+  sh(adb, serial, ["cmd", "voiceinteraction", "show"]);
+  await sleep(2_500);
+  let assistLog = dumpLogcat(adb, serial);
+  let assistDump = adbTry(adb, ["-s", serial, "shell", "dumpsys", "activity", "activities"]);
+  const visInvoked = detectSurfaceInvocation(assistLog, {
+    tag: LOG_TAGS.vis,
+    bracket: "ElizaVoiceInteractionSession",
+    source: DEEP_LINK_SOURCES.assistantSession,
+  });
+  const assistLanded = assertDeepLinkLanded(
+    assistDump,
+    assistLog,
+    DEEP_LINK_SOURCES.assistantSession,
+  );
+  checks.visInvoked = visInvoked;
+  checks.assistLanded = assistLanded;
+
+  // (3b) Hardware assist key: input keyevent KEYCODE_ASSIST → should reach the
+  // VIS session (role held) or the ACTION_ASSIST fallback activity.
+  clearLogcat(adb, serial);
+  sh(adb, serial, ["input", "keyevent", "KEYCODE_ASSIST"]);
+  await sleep(2_500);
+  const keyLog = dumpLogcat(adb, serial);
+  const keyDump = adbTry(adb, ["-s", serial, "shell", "dumpsys", "activity", "activities"]);
+  const keyLanded =
+    assertDeepLinkLanded(keyDump, keyLog, DEEP_LINK_SOURCES.assistantSession).landed ||
+    assertDeepLinkLanded(keyDump, keyLog, DEEP_LINK_SOURCES.assist).landed;
+  checks.assistKeyLanded = keyLanded;
+  log(`assist key (KEYCODE_ASSIST) reached Eliza: ${keyLanded}`);
+
+  // (3c) IME invocation → open-app deep link. Fire the IME's open-Eliza intent
+  // directly (elizaos://voice?source=android-ime) so the entry point runs even
+  // headless where no editor has focus to raise the keyboard.
+  clearLogcat(adb, serial);
+  adbTry(adb, [
+    "-s",
+    serial,
+    "shell",
+    "am",
+    "start",
+    "-a",
+    "android.intent.action.VIEW",
+    "-d",
+    `'elizaos://voice?source=${DEEP_LINK_SOURCES.ime}&action=voice&voice=1'`,
+    `${APP_PACKAGE}/.MainActivity`,
+  ]);
+  await sleep(2_500);
+  const imeLog = dumpLogcat(adb, serial);
+  const imeDump = adbTry(adb, ["-s", serial, "shell", "dumpsys", "activity", "activities"]);
+  const imeLanded = assertDeepLinkLanded(imeDump, imeLog, DEEP_LINK_SOURCES.ime);
+  checks.imeLanded = imeLanded;
+  log(`IME deep-link reached MainActivity: ${imeLanded.landed}`);
+
+  // (4) IME ASR round-trip classification (committed vs. designed ENGINE_OFF).
+  const asrOutcome = classifyImeAsrOutcome(imeLog + "\n" + assistLog);
+  checks.asrOutcome = asrOutcome;
+  log(`IME ASR outcome: ${asrOutcome}`);
+
+  const verdict = summarizeLaneVerdict(
+    {
+      surfacesRegistered: surfaces.allPresent,
+      roleHeld: role.heldByExpected,
+      imeSelected: imeSetting.isEliza && imeEnabled.elizaEnabled,
+      assistLanded: assistLanded.landed || keyLanded,
+      imeLanded: imeLanded.landed,
+      asrOutcome,
+    },
+    REQUIRE_DEVICE,
+  );
+  checks.verdict = verdict;
+  return checks;
+}
+
+async function main() {
+  let adb;
+  try {
+    adb = resolveAdb();
+  } catch (error) {
+    return finish({
+      status: "na",
+      reason: `adb unavailable: ${error.message}`,
+    });
+  }
+
+  const devices = listDevices(adb);
+  if (devices.length === 0) {
+    return finish({
+      status: "na",
+      reason:
+        "no Android device/emulator attached — assistant/IME/assist-key checks need a device.",
+    });
+  }
+
+  const serial = resolveSerial(adb, val("--serial", process.env.ANDROID_SERIAL));
+  process.env.ANDROID_SERIAL = serial;
+  log(`device serial=${serial}`);
+  await ensureEmulatorPermissive(adb, serial, { log });
+
+  if (!isInstalled(adb, serial)) {
+    return finish({
+      status: REQUIRE_DEVICE ? "fail" : "na",
+      reason: `${APP_PACKAGE} not installed on ${serial}. Install the app APK first (bun run --cwd packages/app install:android:adb).`,
+    });
+  }
+
+  const checks = await verifyOnDevice(adb, serial);
+  return finish({
+    status: checks.verdict.pass ? "pass" : "fail",
+    serial,
+    requireDevice: REQUIRE_DEVICE,
+    checks,
+  });
+}
+
+function finish(result) {
+  if (JSON_OUT) {
+    console.log(JSON.stringify(result, null, 2));
+  }
+  if (result.status === "na") {
+    if (REQUIRE_DEVICE) {
+      console.error(
+        `[android-assistant-verify] REQUIRED device missing: ${result.reason}`,
+      );
+      process.exit(1);
+    }
+    log(`N/A (skipped honestly): ${result.reason}`);
+    process.exit(0);
+  }
+  if (result.status === "fail") {
+    console.error(
+      `[android-assistant-verify] FAILED: ${
+        result.reason ?? result.checks?.verdict?.failures?.join("; ") ?? "verification failed"
+      }`,
+    );
+    process.exit(1);
+  }
+  log("PASSED ✅ Android assistant-role / IME / assist-key verification");
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error(`[android-assistant-verify] ERROR: ${error?.stack ?? error}`);
+  process.exit(1);
+});

--- a/packages/app/scripts/lib/android-assistant-verify-lib.mjs
+++ b/packages/app/scripts/lib/android-assistant-verify-lib.mjs
@@ -1,0 +1,308 @@
+/**
+ * Pure parsers for the Android assistant-role / voice-IME / assist-key
+ * verification lane (issue #13581). Every function here takes the raw stdout of
+ * an `adb`/`cmd`/`dumpsys`/`logcat` invocation and returns a typed decision
+ * object — no process spawning, no I/O, no device. The orchestrator
+ * (`android-assistant-verify.mjs`) owns the adb calls and feeds their output
+ * here; keeping the string→decision logic in this file is what lets the whole
+ * verification lane be unit-tested with `node --test` on a host with no device
+ * attached (the parsers are the part that regresses silently, so they are the
+ * part that must be covered off-device).
+ *
+ * Naming/constants mirror the native surfaces under
+ * `packages/app-core/platforms/android/app/src/main/`:
+ *   - {@link ASSISTANT_VIS_COMPONENT} — ElizaVoiceInteractionService (ROLE_ASSISTANT).
+ *   - {@link ASSISTANT_IME_COMPONENT} — ElizaVoiceInputMethodService (voice IME).
+ *   - deep-link source tags — the exact `source=` params the native entry
+ *     points stamp so a logcat/`dumpsys activity` scrape can prove which surface
+ *     drove the app (ElizaVoiceInteractionSession / ElizaVoiceInputMethodService /
+ *     ElizaAssistActivity).
+ */
+
+export const APP_PACKAGE = "ai.elizaos.app";
+
+/** VoiceInteractionService that surfaces Eliza as the digital-assistant (ROLE_ASSISTANT) candidate. */
+export const ASSISTANT_VIS_COMPONENT = `${APP_PACKAGE}/.ElizaVoiceInteractionService`;
+/** Paired session service the framework requires alongside the VIS. */
+export const ASSISTANT_SESSION_COMPONENT = `${APP_PACKAGE}/.ElizaVoiceInteractionSessionService`;
+/** Paired recognition service the framework requires alongside the VIS. */
+export const ASSISTANT_RECOGNITION_COMPONENT = `${APP_PACKAGE}/.ElizaRecognitionService`;
+/** Voice-input keyboard (IME) that surfaces under Languages & input. */
+export const ASSISTANT_IME_COMPONENT = `${APP_PACKAGE}/.ElizaVoiceInputMethodService`;
+/** ACTION_ASSIST / ACTION_VOICE_COMMAND fallback activity. */
+export const ASSIST_ACTIVITY_COMPONENT = `${APP_PACKAGE}/.ElizaAssistActivity`;
+/** The single entry activity every deep-link lands in. */
+export const MAIN_ACTIVITY_COMPONENT = `${APP_PACKAGE}/.MainActivity`;
+
+export const ROLE_ASSISTANT = "android.app.role.ASSISTANT";
+
+/**
+ * Deep-link source tags stamped by each native entry point. The value is the
+ * `source=` query param in the `elizaos://…` URI the surface hands to
+ * MainActivity; asserting the tag lands in `dumpsys activity`/logcat is how the
+ * lane proves the invocation reached the Eliza entry point rather than any other
+ * assistant. Keep in exact sync with the Java sources.
+ */
+export const DEEP_LINK_SOURCES = Object.freeze({
+  assistantSession: "android-assistant-session",
+  ime: "android-ime",
+  assist: "android-assist",
+  voiceCommand: "android-voice-command",
+});
+
+/** logcat source tags each native surface logs under (Log.i(TAG, …)). */
+export const LOG_TAGS = Object.freeze({
+  vis: "ElizaVoiceInteraction",
+  ime: "ElizaVoiceIme",
+});
+
+const COMPONENT_ID_RE = /^[A-Za-z0-9_.]+\/\.?[A-Za-z0-9_$.]+$/;
+
+/**
+ * Normalize a component id to `pkg/pkg.Class` fully-qualified form. `dumpsys`
+ * variously prints `pkg/.Class` (short) and `pkg/pkg.Class` (full); the two must
+ * compare equal. Throws on a shape that isn't a component id so a garbled scrape
+ * can never silently "match nothing" and read as absence.
+ */
+export function normalizeComponent(componentId) {
+  if (typeof componentId !== "string" || !COMPONENT_ID_RE.test(componentId.trim())) {
+    throw new Error(`Not a component id: ${JSON.stringify(componentId)}`);
+  }
+  const [pkg, cls] = componentId.trim().split("/");
+  const fqcn = cls.startsWith(".") ? `${pkg}${cls}` : cls;
+  return `${pkg}/${fqcn}`;
+}
+
+function componentMatches(haystack, componentId) {
+  const full = normalizeComponent(componentId);
+  const [pkg, fqcn] = full.split("/");
+  const shortCls = fqcn.startsWith(pkg) ? fqcn.slice(pkg.length) : `.${fqcn}`;
+  const short = `${pkg}/${shortCls}`;
+  return haystack.includes(full) || haystack.includes(short);
+}
+
+/**
+ * Parse `dumpsys package <pkg>` (or the `Service Resolver Table` section of a
+ * bare `dumpsys package`) for whether a given service component is registered
+ * for an intent action. Registration is what makes the surface a *candidate*
+ * (assistant / IME) at all; a missing entry means the manifest declaration
+ * failed to parse (e.g. VoiceInteractionServiceInfo rejected the VIS for a
+ * missing recognitionService), which the lane must catch as a hard failure —
+ * not skip.
+ *
+ * @returns {{ registered: boolean, actionSeen: boolean }}
+ */
+export function parseServiceRegistration(dumpsysOutput, componentId, intentAction) {
+  const text = String(dumpsysOutput ?? "");
+  const registered = componentMatches(text, componentId);
+  const actionSeen = intentAction ? text.includes(intentAction) : true;
+  return { registered, actionSeen };
+}
+
+/**
+ * Parse `dumpsys package <pkg>` for the manifest-declared assistant + IME
+ * surfaces in one pass. Returns a per-component boolean map plus an `allPresent`
+ * summary so the caller asserts every surface the manifest declares actually
+ * survived install-time parsing.
+ */
+export function parseAssistantSurfaces(dumpsysPackageOutput) {
+  const text = String(dumpsysPackageOutput ?? "");
+  const components = {
+    voiceInteractionService: ASSISTANT_VIS_COMPONENT,
+    voiceInteractionSessionService: ASSISTANT_SESSION_COMPONENT,
+    recognitionService: ASSISTANT_RECOGNITION_COMPONENT,
+    inputMethodService: ASSISTANT_IME_COMPONENT,
+    assistActivity: ASSIST_ACTIVITY_COMPONENT,
+  };
+  const present = {};
+  for (const [key, componentId] of Object.entries(components)) {
+    present[key] = componentMatches(text, componentId);
+  }
+  return {
+    present,
+    allPresent: Object.values(present).every(Boolean),
+    missing: Object.entries(present)
+      .filter(([, ok]) => !ok)
+      .map(([key]) => key),
+  };
+}
+
+/**
+ * Parse `cmd role holders android.app.role.ASSISTANT` output for whether our
+ * package holds the assistant role. The command prints one holder package per
+ * line (empty when no holder). A held role is the precondition for the assist
+ * gesture / assist-key routing to Eliza's VIS session.
+ */
+export function parseRoleHolders(cmdRoleOutput, expectedPackage = APP_PACKAGE) {
+  const holders = String(cmdRoleOutput ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !/^Exception|^Error|^usage:/i.test(line));
+  return {
+    holders,
+    heldByExpected: holders.includes(expectedPackage),
+  };
+}
+
+/**
+ * Parse `dumpsys voiceinteraction` (or a `settings get secure
+ * voice_interaction_service`) for the currently-selected assistant component,
+ * and decide whether it is ours. The lane fires `cmd voiceinteraction show`
+ * only when this resolves to the Eliza VIS — otherwise the invocation would
+ * drive whatever *other* assistant is selected and prove nothing.
+ *
+ * `dumpsys voiceinteraction` prints a line like:
+ *   mCurInteractor=ComponentInfo{ai.elizaos.app/ai.elizaos.app.ElizaVoiceInteractionService}
+ * and `settings get secure voice_interaction_service` prints the flattened
+ * `pkg/cls`. Both shapes are accepted.
+ */
+export function parseVoiceInteractionService(output) {
+  const text = String(output ?? "");
+  const componentInfo = text.match(/ComponentInfo\{([^}]+)\}/);
+  const flattened = text.match(/([A-Za-z0-9_.]+\/[A-Za-z0-9_$.]+)/);
+  const selected = (componentInfo?.[1] ?? flattened?.[1] ?? "").trim();
+  return {
+    selected: selected || null,
+    isEliza: selected ? componentMatches(selected, ASSISTANT_VIS_COMPONENT) : false,
+  };
+}
+
+/**
+ * Parse `settings get secure default_input_method` (a flattened component) for
+ * whether the Eliza voice IME is the selected keyboard. Selecting the IME is
+ * what makes a mic long-press hand off to Eliza; the lane must re-apply and
+ * re-assert this after every reinstall because `adb install -r` clears it.
+ */
+export function parseDefaultInputMethod(settingsOutput) {
+  const selected = String(settingsOutput ?? "").trim().split(/\s+/)[0] ?? "";
+  return {
+    selected: selected && selected !== "null" ? selected : null,
+    isEliza: selected ? componentMatches(selected, ASSISTANT_IME_COMPONENT) : false,
+  };
+}
+
+/**
+ * Parse `ime list -s` (short form: one enabled IME id per line) for whether the
+ * Eliza IME is in the *enabled* set. Enabling is separate from selecting — an
+ * IME must be enabled before `ime set` can select it — so the lane asserts both.
+ */
+export function parseEnabledImes(imeListOutput) {
+  const enabled = String(imeListOutput ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => COMPONENT_ID_RE.test(line));
+  return {
+    enabled,
+    elizaEnabled: enabled.some((id) => componentMatches(id, ASSISTANT_IME_COMPONENT)),
+  };
+}
+
+/**
+ * Scan a logcat buffer for the source tag of a given native surface, proving the
+ * invocation actually reached the Eliza entry point. Matches either the
+ * bracketed class marker the surfaces log (`[ElizaVoiceInputMethodService] …`)
+ * or the deep-link `source=<tag>` param, so it works whether we scrape the
+ * service's own logs or the ActivityManager's intent log.
+ *
+ * @param {string} logcatOutput raw `adb logcat -d` buffer
+ * @param {{ tag?: string, source?: string }} probe class TAG and/or deep-link source
+ */
+export function detectSurfaceInvocation(logcatOutput, probe) {
+  const text = String(logcatOutput ?? "");
+  const tagHit = probe?.tag ? new RegExp(`\\b${escapeRe(probe.tag)}\\b`).test(text) : false;
+  const bracketHit = probe?.bracket
+    ? text.includes(`[${probe.bracket}]`)
+    : false;
+  const sourceHit = probe?.source
+    ? text.includes(`source=${probe.source}`)
+    : false;
+  return {
+    tagHit,
+    bracketHit,
+    sourceHit,
+    detected: tagHit || bracketHit || sourceHit,
+  };
+}
+
+/**
+ * Decide whether an assist/IME deep-link landed in MainActivity. Accepts a
+ * combined blob of `dumpsys activity activities` (top of the resumed stack) plus
+ * the same-run logcat, and asserts BOTH that MainActivity is resumed AND that
+ * the expected deep-link source tag appears — so a coincidental foreground
+ * MainActivity from an unrelated launch can't pass.
+ *
+ * @param {string} activityDump `dumpsys activity activities` / `top-activity` output
+ * @param {string} logcatOutput same-run logcat buffer
+ * @param {string} expectedSource one of DEEP_LINK_SOURCES
+ */
+export function assertDeepLinkLanded(activityDump, logcatOutput, expectedSource) {
+  const dump = String(activityDump ?? "");
+  const mainActivityResumed =
+    /ResumedActivity[:\s].*ai\.elizaos\.app\/[.A-Za-z0-9_]*MainActivity/.test(dump) ||
+    /mResumedActivity[:\s].*ai\.elizaos\.app\/[.A-Za-z0-9_]*MainActivity/.test(dump) ||
+    /topResumedActivity[:\s].*ai\.elizaos\.app\/[.A-Za-z0-9_]*MainActivity/.test(dump) ||
+    componentMatches(dump, MAIN_ACTIVITY_COMPONENT);
+  const sourceInLog = String(logcatOutput ?? "").includes(`source=${expectedSource}`);
+  const sourceInDump = dump.includes(`source=${expectedSource}`);
+  return {
+    mainActivityResumed,
+    sourceSeen: sourceInLog || sourceInDump,
+    landed: mainActivityResumed && (sourceInLog || sourceInDump),
+    expectedSource,
+  };
+}
+
+/**
+ * Classify the IME ASR round-trip outcome from the IME's own logcat lines. The
+ * engine may legitimately be off (loopback refused) — that is the designed
+ * ENGINE_OFF state, not a failure — so this distinguishes the three real
+ * outcomes the native code produces rather than collapsing them:
+ *   - committed: "transcript committed (N chars)"
+ *   - engineOff: "ASR loopback unreachable"
+ *   - modelNotReady: "ASR responded 503"
+ * The caller decides which outcomes are acceptable given whether a full engine
+ * is expected (ELIZA_ANDROID_REQUIRE_AGENT-style gating).
+ */
+export function classifyImeAsrOutcome(logcatOutput) {
+  const text = String(logcatOutput ?? "");
+  if (/transcript committed \(\d+ chars\)/.test(text)) return "committed";
+  if (/ASR loopback unreachable/.test(text)) return "engineOff";
+  if (/ASR responded 503/.test(text) || /model_not_ready|MODEL_NOT_READY/.test(text)) {
+    return "modelNotReady";
+  }
+  if (/transcription error|error_transcribe/.test(text)) return "error";
+  return "unknown";
+}
+
+/**
+ * Roll the individual scrape results into one lane verdict. Fails the lane if
+ * any required surface is missing/misrouted; when a full engine is required, an
+ * engine-off ASR outcome fails too (an honest ENGINE_OFF is only acceptable
+ * when the engine is not required to be present).
+ *
+ * @param {object} results
+ * @param {boolean} results.surfacesRegistered
+ * @param {boolean} results.roleHeld
+ * @param {boolean} results.imeSelected
+ * @param {boolean} results.assistLanded
+ * @param {boolean} results.imeLanded
+ * @param {string}  results.asrOutcome  from classifyImeAsrOutcome
+ * @param {boolean} requireAgent        when true, engine must be up (committed/modelNotReady only)
+ */
+export function summarizeLaneVerdict(results, requireAgent) {
+  const failures = [];
+  if (!results.surfacesRegistered) failures.push("assistant/IME surfaces not registered");
+  if (!results.roleHeld) failures.push("assistant role not held by Eliza");
+  if (!results.imeSelected) failures.push("Eliza IME not selected");
+  if (!results.assistLanded) failures.push("assist invocation did not reach MainActivity");
+  if (!results.imeLanded) failures.push("IME invocation did not reach MainActivity");
+  if (requireAgent && results.asrOutcome === "engineOff") {
+    failures.push("full engine required but ASR loopback was unreachable (ENGINE_OFF)");
+  }
+  if (results.asrOutcome === "error") failures.push("IME ASR round-trip errored");
+  return { pass: failures.length === 0, failures };
+}
+
+function escapeRe(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/app/scripts/lib/android-assistant-verify-lib.mjs
+++ b/packages/app/scripts/lib/android-assistant-verify-lib.mjs
@@ -65,7 +65,10 @@ const COMPONENT_ID_RE = /^[A-Za-z0-9_.]+\/\.?[A-Za-z0-9_$.]+$/;
  * can never silently "match nothing" and read as absence.
  */
 export function normalizeComponent(componentId) {
-  if (typeof componentId !== "string" || !COMPONENT_ID_RE.test(componentId.trim())) {
+  if (
+    typeof componentId !== "string" ||
+    !COMPONENT_ID_RE.test(componentId.trim())
+  ) {
     throw new Error(`Not a component id: ${JSON.stringify(componentId)}`);
   }
   const [pkg, cls] = componentId.trim().split("/");
@@ -73,12 +76,26 @@ export function normalizeComponent(componentId) {
   return `${pkg}/${fqcn}`;
 }
 
+/**
+ * Whether `haystack` contains the given component in either its full
+ * (`pkg/pkg.Class`) or short (`pkg/.Class`) form. The match requires a right
+ * BOUNDARY — the component id must not be a prefix of a longer class token — so
+ * a renamed surface (e.g. `…ElizaVoiceInteractionServiceRENAMED`) reads as
+ * ABSENT rather than falsely matching `…ElizaVoiceInteractionService`. That is
+ * exactly the regression the lane exists to catch, so the matcher must not
+ * paper over it. Java class chars are `[A-Za-z0-9_$.]`; the boundary is any
+ * character outside that set (or end of string).
+ */
 function componentMatches(haystack, componentId) {
   const full = normalizeComponent(componentId);
   const [pkg, fqcn] = full.split("/");
   const shortCls = fqcn.startsWith(pkg) ? fqcn.slice(pkg.length) : `.${fqcn}`;
   const short = `${pkg}/${shortCls}`;
-  return haystack.includes(full) || haystack.includes(short);
+  const boundary = "(?![A-Za-z0-9_$.])";
+  return (
+    new RegExp(escapeRe(full) + boundary).test(haystack) ||
+    new RegExp(escapeRe(short) + boundary).test(haystack)
+  );
 }
 
 /**
@@ -92,7 +109,11 @@ function componentMatches(haystack, componentId) {
  *
  * @returns {{ registered: boolean, actionSeen: boolean }}
  */
-export function parseServiceRegistration(dumpsysOutput, componentId, intentAction) {
+export function parseServiceRegistration(
+  dumpsysOutput,
+  componentId,
+  intentAction,
+) {
   const text = String(dumpsysOutput ?? "");
   const registered = componentMatches(text, componentId);
   const actionSeen = intentAction ? text.includes(intentAction) : true;
@@ -137,7 +158,9 @@ export function parseRoleHolders(cmdRoleOutput, expectedPackage = APP_PACKAGE) {
   const holders = String(cmdRoleOutput ?? "")
     .split("\n")
     .map((line) => line.trim())
-    .filter((line) => line.length > 0 && !/^Exception|^Error|^usage:/i.test(line));
+    .filter(
+      (line) => line.length > 0 && !/^Exception|^Error|^usage:/i.test(line),
+    );
   return {
     holders,
     heldByExpected: holders.includes(expectedPackage),
@@ -163,7 +186,9 @@ export function parseVoiceInteractionService(output) {
   const selected = (componentInfo?.[1] ?? flattened?.[1] ?? "").trim();
   return {
     selected: selected || null,
-    isEliza: selected ? componentMatches(selected, ASSISTANT_VIS_COMPONENT) : false,
+    isEliza: selected
+      ? componentMatches(selected, ASSISTANT_VIS_COMPONENT)
+      : false,
   };
 }
 
@@ -174,10 +199,15 @@ export function parseVoiceInteractionService(output) {
  * re-assert this after every reinstall because `adb install -r` clears it.
  */
 export function parseDefaultInputMethod(settingsOutput) {
-  const selected = String(settingsOutput ?? "").trim().split(/\s+/)[0] ?? "";
+  const selected =
+    String(settingsOutput ?? "")
+      .trim()
+      .split(/\s+/)[0] ?? "";
   return {
     selected: selected && selected !== "null" ? selected : null,
-    isEliza: selected ? componentMatches(selected, ASSISTANT_IME_COMPONENT) : false,
+    isEliza: selected
+      ? componentMatches(selected, ASSISTANT_IME_COMPONENT)
+      : false,
   };
 }
 
@@ -193,7 +223,9 @@ export function parseEnabledImes(imeListOutput) {
     .filter((line) => COMPONENT_ID_RE.test(line));
   return {
     enabled,
-    elizaEnabled: enabled.some((id) => componentMatches(id, ASSISTANT_IME_COMPONENT)),
+    elizaEnabled: enabled.some((id) =>
+      componentMatches(id, ASSISTANT_IME_COMPONENT),
+    ),
   };
 }
 
@@ -209,7 +241,9 @@ export function parseEnabledImes(imeListOutput) {
  */
 export function detectSurfaceInvocation(logcatOutput, probe) {
   const text = String(logcatOutput ?? "");
-  const tagHit = probe?.tag ? new RegExp(`\\b${escapeRe(probe.tag)}\\b`).test(text) : false;
+  const tagHit = probe?.tag
+    ? new RegExp(`\\b${escapeRe(probe.tag)}\\b`).test(text)
+    : false;
   const bracketHit = probe?.bracket
     ? text.includes(`[${probe.bracket}]`)
     : false;
@@ -235,14 +269,26 @@ export function detectSurfaceInvocation(logcatOutput, probe) {
  * @param {string} logcatOutput same-run logcat buffer
  * @param {string} expectedSource one of DEEP_LINK_SOURCES
  */
-export function assertDeepLinkLanded(activityDump, logcatOutput, expectedSource) {
+export function assertDeepLinkLanded(
+  activityDump,
+  logcatOutput,
+  expectedSource,
+) {
   const dump = String(activityDump ?? "");
   const mainActivityResumed =
-    /ResumedActivity[:\s].*ai\.elizaos\.app\/[.A-Za-z0-9_]*MainActivity/.test(dump) ||
-    /mResumedActivity[:\s].*ai\.elizaos\.app\/[.A-Za-z0-9_]*MainActivity/.test(dump) ||
-    /topResumedActivity[:\s].*ai\.elizaos\.app\/[.A-Za-z0-9_]*MainActivity/.test(dump) ||
+    /ResumedActivity[:\s].*ai\.elizaos\.app\/[.A-Za-z0-9_]*MainActivity/.test(
+      dump,
+    ) ||
+    /mResumedActivity[:\s].*ai\.elizaos\.app\/[.A-Za-z0-9_]*MainActivity/.test(
+      dump,
+    ) ||
+    /topResumedActivity[:\s].*ai\.elizaos\.app\/[.A-Za-z0-9_]*MainActivity/.test(
+      dump,
+    ) ||
     componentMatches(dump, MAIN_ACTIVITY_COMPONENT);
-  const sourceInLog = String(logcatOutput ?? "").includes(`source=${expectedSource}`);
+  const sourceInLog = String(logcatOutput ?? "").includes(
+    `source=${expectedSource}`,
+  );
   const sourceInDump = dump.includes(`source=${expectedSource}`);
   return {
     mainActivityResumed,
@@ -267,7 +313,10 @@ export function classifyImeAsrOutcome(logcatOutput) {
   const text = String(logcatOutput ?? "");
   if (/transcript committed \(\d+ chars\)/.test(text)) return "committed";
   if (/ASR loopback unreachable/.test(text)) return "engineOff";
-  if (/ASR responded 503/.test(text) || /model_not_ready|MODEL_NOT_READY/.test(text)) {
+  if (
+    /ASR responded 503/.test(text) ||
+    /model_not_ready|MODEL_NOT_READY/.test(text)
+  ) {
     return "modelNotReady";
   }
   if (/transcription error|error_transcribe/.test(text)) return "error";
@@ -291,15 +340,21 @@ export function classifyImeAsrOutcome(logcatOutput) {
  */
 export function summarizeLaneVerdict(results, requireAgent) {
   const failures = [];
-  if (!results.surfacesRegistered) failures.push("assistant/IME surfaces not registered");
+  if (!results.surfacesRegistered)
+    failures.push("assistant/IME surfaces not registered");
   if (!results.roleHeld) failures.push("assistant role not held by Eliza");
   if (!results.imeSelected) failures.push("Eliza IME not selected");
-  if (!results.assistLanded) failures.push("assist invocation did not reach MainActivity");
-  if (!results.imeLanded) failures.push("IME invocation did not reach MainActivity");
+  if (!results.assistLanded)
+    failures.push("assist invocation did not reach MainActivity");
+  if (!results.imeLanded)
+    failures.push("IME invocation did not reach MainActivity");
   if (requireAgent && results.asrOutcome === "engineOff") {
-    failures.push("full engine required but ASR loopback was unreachable (ENGINE_OFF)");
+    failures.push(
+      "full engine required but ASR loopback was unreachable (ENGINE_OFF)",
+    );
   }
-  if (results.asrOutcome === "error") failures.push("IME ASR round-trip errored");
+  if (results.asrOutcome === "error")
+    failures.push("IME ASR round-trip errored");
   return { pass: failures.length === 0, failures };
 }
 

--- a/packages/app/scripts/lib/android-assistant-verify-lib.test.mjs
+++ b/packages/app/scripts/lib/android-assistant-verify-lib.test.mjs
@@ -1,0 +1,239 @@
+/**
+ * Deterministic `node --test` coverage for the assistant-role/IME/assist-key
+ * verification parsers (#13581). Fixtures are real-shaped `adb`/`dumpsys`/`cmd`/
+ * `logcat` output slices, not mocks of the parser — the parsers are pure
+ * string→decision functions, so this suite proves the string handling that
+ * regresses silently off-device (a garbled scrape reading as "absent"), covering
+ * the present, absent, short-vs-full component form, and empty/garbage cases.
+ *
+ * Run: `node --test packages/app/scripts/lib/android-assistant-verify-lib.test.mjs`
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  APP_PACKAGE,
+  ASSISTANT_IME_COMPONENT,
+  ASSISTANT_VIS_COMPONENT,
+  DEEP_LINK_SOURCES,
+  LOG_TAGS,
+  ROLE_ASSISTANT,
+  assertDeepLinkLanded,
+  classifyImeAsrOutcome,
+  detectSurfaceInvocation,
+  normalizeComponent,
+  parseAssistantSurfaces,
+  parseDefaultInputMethod,
+  parseEnabledImes,
+  parseRoleHolders,
+  parseServiceRegistration,
+  parseVoiceInteractionService,
+  summarizeLaneVerdict,
+} from "./android-assistant-verify-lib.mjs";
+
+test("normalizeComponent canonicalizes short and full forms equally", () => {
+  const full = "ai.elizaos.app/ai.elizaos.app.ElizaVoiceInteractionService";
+  assert.equal(normalizeComponent("ai.elizaos.app/.ElizaVoiceInteractionService"), full);
+  assert.equal(normalizeComponent(full), full);
+  assert.throws(() => normalizeComponent("not a component"));
+  assert.throws(() => normalizeComponent(""));
+  assert.throws(() => normalizeComponent(undefined));
+});
+
+test("parseServiceRegistration finds the VIS in a real dumpsys package slice (short form)", () => {
+  const dump = `
+  Service Resolver Table:
+    Non-Data Actions:
+      android.service.voice.VoiceInteractionService:
+        4f2a1c ai.elizaos.app/.ElizaVoiceInteractionService filter 88b
+          Action: "android.service.voice.VoiceInteractionService"
+`;
+  const result = parseServiceRegistration(
+    dump,
+    ASSISTANT_VIS_COMPONENT,
+    "android.service.voice.VoiceInteractionService",
+  );
+  assert.equal(result.registered, true);
+  assert.equal(result.actionSeen, true);
+});
+
+test("parseServiceRegistration reports absence when the component is missing", () => {
+  const dump = `Service Resolver Table:\n  android.view.InputMethod:\n    ce01 com.other.keyboard/.SomeIme filter aa\n`;
+  const result = parseServiceRegistration(dump, ASSISTANT_IME_COMPONENT, "android.view.InputMethod");
+  assert.equal(result.registered, false);
+});
+
+test("parseAssistantSurfaces detects every declared surface, and reports the missing one", () => {
+  const full = `
+      ai.elizaos.app/.ElizaVoiceInteractionService
+      ai.elizaos.app/.ElizaVoiceInteractionSessionService
+      ai.elizaos.app/.ElizaRecognitionService
+      ai.elizaos.app/.ElizaVoiceInputMethodService
+      ai.elizaos.app/.ElizaAssistActivity
+`;
+  const ok = parseAssistantSurfaces(full);
+  assert.equal(ok.allPresent, true);
+  assert.deepEqual(ok.missing, []);
+
+  const missingIme = full.replace("ai.elizaos.app/.ElizaVoiceInputMethodService\n", "");
+  const partial = parseAssistantSurfaces(missingIme);
+  assert.equal(partial.allPresent, false);
+  assert.deepEqual(partial.missing, ["inputMethodService"]);
+  assert.equal(partial.present.voiceInteractionService, true);
+});
+
+test("parseRoleHolders recognizes the held ROLE_ASSISTANT and rejects noise lines", () => {
+  const held = parseRoleHolders("ai.elizaos.app\n");
+  assert.equal(held.heldByExpected, true);
+  assert.deepEqual(held.holders, [APP_PACKAGE]);
+
+  const none = parseRoleHolders("");
+  assert.equal(none.heldByExpected, false);
+
+  const other = parseRoleHolders("com.google.android.googlequicksearchbox\n");
+  assert.equal(other.heldByExpected, false);
+
+  const errorLine = parseRoleHolders("Exception occurred while executing 'holders'");
+  assert.deepEqual(errorLine.holders, []);
+  assert.equal(errorLine.heldByExpected, false);
+
+  assert.equal(ROLE_ASSISTANT, "android.app.role.ASSISTANT");
+});
+
+test("parseVoiceInteractionService reads dumpsys ComponentInfo and flattened settings forms", () => {
+  const dumpsys =
+    "  mCurInteractor=ComponentInfo{ai.elizaos.app/ai.elizaos.app.ElizaVoiceInteractionService}";
+  const fromDump = parseVoiceInteractionService(dumpsys);
+  assert.equal(fromDump.isEliza, true);
+
+  const settings = "ai.elizaos.app/ai.elizaos.app.ElizaVoiceInteractionService\n";
+  assert.equal(parseVoiceInteractionService(settings).isEliza, true);
+
+  const other =
+    "  mCurInteractor=ComponentInfo{com.google.android.googlequicksearchbox/com.google.VoiceInteractionService}";
+  assert.equal(parseVoiceInteractionService(other).isEliza, false);
+
+  assert.equal(parseVoiceInteractionService("").selected, null);
+});
+
+test("parseDefaultInputMethod distinguishes selected Eliza IME from another keyboard and null", () => {
+  const eliza = parseDefaultInputMethod("ai.elizaos.app/.ElizaVoiceInputMethodService\n");
+  assert.equal(eliza.isEliza, true);
+
+  const other = parseDefaultInputMethod("com.google.android.inputmethod.latin/.LatinIME");
+  assert.equal(other.isEliza, false);
+  assert.equal(other.selected, "com.google.android.inputmethod.latin/.LatinIME");
+
+  assert.equal(parseDefaultInputMethod("null").selected, null);
+  assert.equal(parseDefaultInputMethod("").selected, null);
+});
+
+test("parseEnabledImes finds the Eliza IME in an `ime list -s` set", () => {
+  const list = [
+    "com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME",
+    "ai.elizaos.app/.ElizaVoiceInputMethodService",
+  ].join("\n");
+  const parsed = parseEnabledImes(list);
+  assert.equal(parsed.elizaEnabled, true);
+  assert.equal(parsed.enabled.length, 2);
+
+  const without = parseEnabledImes(
+    "com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME",
+  );
+  assert.equal(without.elizaEnabled, false);
+});
+
+test("detectSurfaceInvocation catches the IME class tag, bracket marker, and deep-link source", () => {
+  const byTag = detectSurfaceInvocation(
+    "07-04 12:00:01.234  4210  4210 I ElizaVoiceIme: [ElizaVoiceInputMethodService] opening Eliza",
+    { tag: LOG_TAGS.ime, bracket: "ElizaVoiceInputMethodService", source: DEEP_LINK_SOURCES.ime },
+  );
+  assert.equal(byTag.tagHit, true);
+  assert.equal(byTag.bracketHit, true);
+  assert.equal(byTag.detected, true);
+
+  const bySource = detectSurfaceInvocation(
+    "ActivityTaskManager: START u0 {act=android.intent.action.VIEW dat=elizaos://voice?source=android-ime...}",
+    { source: DEEP_LINK_SOURCES.ime },
+  );
+  assert.equal(bySource.sourceHit, true);
+  assert.equal(bySource.detected, true);
+
+  const miss = detectSurfaceInvocation("nothing relevant here", {
+    tag: LOG_TAGS.vis,
+    source: DEEP_LINK_SOURCES.assistantSession,
+  });
+  assert.equal(miss.detected, false);
+});
+
+test("assertDeepLinkLanded requires BOTH resumed MainActivity and the expected source tag", () => {
+  const activityDump =
+    "  ResumedActivity: ActivityRecord{a1b2 u0 ai.elizaos.app/.MainActivity t42}";
+  const logcat =
+    "ActivityTaskManager: START u0 {dat=elizaos://voice?source=android-assistant-session&voice=1 cmp=ai.elizaos.app/.MainActivity}";
+  const landed = assertDeepLinkLanded(activityDump, logcat, DEEP_LINK_SOURCES.assistantSession);
+  assert.equal(landed.landed, true);
+  assert.equal(landed.mainActivityResumed, true);
+  assert.equal(landed.sourceSeen, true);
+
+  // Foreground MainActivity but no matching source tag → NOT landed (guards
+  // against a coincidental unrelated foreground pass).
+  const wrongSource = assertDeepLinkLanded(activityDump, "unrelated log", DEEP_LINK_SOURCES.ime);
+  assert.equal(wrongSource.mainActivityResumed, true);
+  assert.equal(wrongSource.landed, false);
+
+  // Source present but MainActivity not resumed → NOT landed.
+  const notResumed = assertDeepLinkLanded("ResumedActivity: com.other/.Home", logcat, DEEP_LINK_SOURCES.assistantSession);
+  assert.equal(notResumed.landed, false);
+});
+
+test("classifyImeAsrOutcome distinguishes committed / engineOff / modelNotReady / error", () => {
+  assert.equal(
+    classifyImeAsrOutcome("ElizaVoiceIme: [ElizaVoiceInputMethodService] transcript committed (14 chars)"),
+    "committed",
+  );
+  assert.equal(
+    classifyImeAsrOutcome("ElizaVoiceIme: [ElizaVoiceInputMethodService] ASR loopback unreachable: Connection refused"),
+    "engineOff",
+  );
+  assert.equal(
+    classifyImeAsrOutcome("ElizaVoiceIme: [ElizaVoiceInputMethodService] ASR responded 503"),
+    "modelNotReady",
+  );
+  assert.equal(
+    classifyImeAsrOutcome("ElizaVoiceIme: [ElizaVoiceInputMethodService] transcription error"),
+    "error",
+  );
+  assert.equal(classifyImeAsrOutcome("nothing"), "unknown");
+});
+
+test("summarizeLaneVerdict passes only when every required surface checks out", () => {
+  const green = {
+    surfacesRegistered: true,
+    roleHeld: true,
+    imeSelected: true,
+    assistLanded: true,
+    imeLanded: true,
+    asrOutcome: "committed",
+  };
+  assert.equal(summarizeLaneVerdict(green, true).pass, true);
+
+  // Engine off is acceptable when the agent is NOT required...
+  assert.equal(summarizeLaneVerdict({ ...green, asrOutcome: "engineOff" }, false).pass, true);
+  // ...but a hard failure when the agent IS required (never green-by-skip).
+  const requiredButOff = summarizeLaneVerdict({ ...green, asrOutcome: "engineOff" }, true);
+  assert.equal(requiredButOff.pass, false);
+  assert.match(requiredButOff.failures.join(" "), /ENGINE_OFF/);
+
+  const roleMissing = summarizeLaneVerdict({ ...green, roleHeld: false }, false);
+  assert.equal(roleMissing.pass, false);
+  assert.match(roleMissing.failures.join(" "), /assistant role/);
+
+  const notRegistered = summarizeLaneVerdict({ ...green, surfacesRegistered: false }, false);
+  assert.equal(notRegistered.pass, false);
+});
+
+test("exported component ids match the native manifest components", () => {
+  assert.equal(ASSISTANT_VIS_COMPONENT, "ai.elizaos.app/.ElizaVoiceInteractionService");
+  assert.equal(ASSISTANT_IME_COMPONENT, "ai.elizaos.app/.ElizaVoiceInputMethodService");
+});

--- a/packages/app/scripts/lib/android-assistant-verify-lib.test.mjs
+++ b/packages/app/scripts/lib/android-assistant-verify-lib.test.mjs
@@ -15,12 +15,11 @@ import {
   APP_PACKAGE,
   ASSISTANT_IME_COMPONENT,
   ASSISTANT_VIS_COMPONENT,
-  DEEP_LINK_SOURCES,
-  LOG_TAGS,
-  ROLE_ASSISTANT,
   assertDeepLinkLanded,
   classifyImeAsrOutcome,
+  DEEP_LINK_SOURCES,
   detectSurfaceInvocation,
+  LOG_TAGS,
   normalizeComponent,
   parseAssistantSurfaces,
   parseDefaultInputMethod,
@@ -28,12 +27,16 @@ import {
   parseRoleHolders,
   parseServiceRegistration,
   parseVoiceInteractionService,
+  ROLE_ASSISTANT,
   summarizeLaneVerdict,
 } from "./android-assistant-verify-lib.mjs";
 
 test("normalizeComponent canonicalizes short and full forms equally", () => {
   const full = "ai.elizaos.app/ai.elizaos.app.ElizaVoiceInteractionService";
-  assert.equal(normalizeComponent("ai.elizaos.app/.ElizaVoiceInteractionService"), full);
+  assert.equal(
+    normalizeComponent("ai.elizaos.app/.ElizaVoiceInteractionService"),
+    full,
+  );
   assert.equal(normalizeComponent(full), full);
   assert.throws(() => normalizeComponent("not a component"));
   assert.throws(() => normalizeComponent(""));
@@ -59,7 +62,11 @@ test("parseServiceRegistration finds the VIS in a real dumpsys package slice (sh
 
 test("parseServiceRegistration reports absence when the component is missing", () => {
   const dump = `Service Resolver Table:\n  android.view.InputMethod:\n    ce01 com.other.keyboard/.SomeIme filter aa\n`;
-  const result = parseServiceRegistration(dump, ASSISTANT_IME_COMPONENT, "android.view.InputMethod");
+  const result = parseServiceRegistration(
+    dump,
+    ASSISTANT_IME_COMPONENT,
+    "android.view.InputMethod",
+  );
   assert.equal(result.registered, false);
 });
 
@@ -75,11 +82,32 @@ test("parseAssistantSurfaces detects every declared surface, and reports the mis
   assert.equal(ok.allPresent, true);
   assert.deepEqual(ok.missing, []);
 
-  const missingIme = full.replace("ai.elizaos.app/.ElizaVoiceInputMethodService\n", "");
+  const missingIme = full.replace(
+    "ai.elizaos.app/.ElizaVoiceInputMethodService\n",
+    "",
+  );
   const partial = parseAssistantSurfaces(missingIme);
   assert.equal(partial.allPresent, false);
   assert.deepEqual(partial.missing, ["inputMethodService"]);
   assert.equal(partial.present.voiceInteractionService, true);
+});
+
+test("parseAssistantSurfaces treats a renamed VIS as ABSENT (regression canary)", () => {
+  // A renamed component must not prefix-match the expected id — this is exactly
+  // the regression the lane exists to catch (rename the VIS → it stops
+  // registering under its expected component id).
+  const renamed = `
+      ai.elizaos.app/.ElizaVoiceInteractionServiceRENAMED
+      ai.elizaos.app/.ElizaVoiceInteractionSessionService
+      ai.elizaos.app/.ElizaRecognitionService
+      ai.elizaos.app/.ElizaVoiceInputMethodService
+      ai.elizaos.app/.ElizaAssistActivity
+`;
+  const parsed = parseAssistantSurfaces(renamed);
+  assert.equal(parsed.allPresent, false);
+  assert.deepEqual(parsed.missing, ["voiceInteractionService"]);
+  // The session service must still match despite sharing a prefix with the VIS.
+  assert.equal(parsed.present.voiceInteractionSessionService, true);
 });
 
 test("parseRoleHolders recognizes the held ROLE_ASSISTANT and rejects noise lines", () => {
@@ -93,7 +121,9 @@ test("parseRoleHolders recognizes the held ROLE_ASSISTANT and rejects noise line
   const other = parseRoleHolders("com.google.android.googlequicksearchbox\n");
   assert.equal(other.heldByExpected, false);
 
-  const errorLine = parseRoleHolders("Exception occurred while executing 'holders'");
+  const errorLine = parseRoleHolders(
+    "Exception occurred while executing 'holders'",
+  );
   assert.deepEqual(errorLine.holders, []);
   assert.equal(errorLine.heldByExpected, false);
 
@@ -106,7 +136,8 @@ test("parseVoiceInteractionService reads dumpsys ComponentInfo and flattened set
   const fromDump = parseVoiceInteractionService(dumpsys);
   assert.equal(fromDump.isEliza, true);
 
-  const settings = "ai.elizaos.app/ai.elizaos.app.ElizaVoiceInteractionService\n";
+  const settings =
+    "ai.elizaos.app/ai.elizaos.app.ElizaVoiceInteractionService\n";
   assert.equal(parseVoiceInteractionService(settings).isEliza, true);
 
   const other =
@@ -117,12 +148,19 @@ test("parseVoiceInteractionService reads dumpsys ComponentInfo and flattened set
 });
 
 test("parseDefaultInputMethod distinguishes selected Eliza IME from another keyboard and null", () => {
-  const eliza = parseDefaultInputMethod("ai.elizaos.app/.ElizaVoiceInputMethodService\n");
+  const eliza = parseDefaultInputMethod(
+    "ai.elizaos.app/.ElizaVoiceInputMethodService\n",
+  );
   assert.equal(eliza.isEliza, true);
 
-  const other = parseDefaultInputMethod("com.google.android.inputmethod.latin/.LatinIME");
+  const other = parseDefaultInputMethod(
+    "com.google.android.inputmethod.latin/.LatinIME",
+  );
   assert.equal(other.isEliza, false);
-  assert.equal(other.selected, "com.google.android.inputmethod.latin/.LatinIME");
+  assert.equal(
+    other.selected,
+    "com.google.android.inputmethod.latin/.LatinIME",
+  );
 
   assert.equal(parseDefaultInputMethod("null").selected, null);
   assert.equal(parseDefaultInputMethod("").selected, null);
@@ -146,7 +184,11 @@ test("parseEnabledImes finds the Eliza IME in an `ime list -s` set", () => {
 test("detectSurfaceInvocation catches the IME class tag, bracket marker, and deep-link source", () => {
   const byTag = detectSurfaceInvocation(
     "07-04 12:00:01.234  4210  4210 I ElizaVoiceIme: [ElizaVoiceInputMethodService] opening Eliza",
-    { tag: LOG_TAGS.ime, bracket: "ElizaVoiceInputMethodService", source: DEEP_LINK_SOURCES.ime },
+    {
+      tag: LOG_TAGS.ime,
+      bracket: "ElizaVoiceInputMethodService",
+      source: DEEP_LINK_SOURCES.ime,
+    },
   );
   assert.equal(byTag.tagHit, true);
   assert.equal(byTag.bracketHit, true);
@@ -171,37 +213,57 @@ test("assertDeepLinkLanded requires BOTH resumed MainActivity and the expected s
     "  ResumedActivity: ActivityRecord{a1b2 u0 ai.elizaos.app/.MainActivity t42}";
   const logcat =
     "ActivityTaskManager: START u0 {dat=elizaos://voice?source=android-assistant-session&voice=1 cmp=ai.elizaos.app/.MainActivity}";
-  const landed = assertDeepLinkLanded(activityDump, logcat, DEEP_LINK_SOURCES.assistantSession);
+  const landed = assertDeepLinkLanded(
+    activityDump,
+    logcat,
+    DEEP_LINK_SOURCES.assistantSession,
+  );
   assert.equal(landed.landed, true);
   assert.equal(landed.mainActivityResumed, true);
   assert.equal(landed.sourceSeen, true);
 
   // Foreground MainActivity but no matching source tag → NOT landed (guards
   // against a coincidental unrelated foreground pass).
-  const wrongSource = assertDeepLinkLanded(activityDump, "unrelated log", DEEP_LINK_SOURCES.ime);
+  const wrongSource = assertDeepLinkLanded(
+    activityDump,
+    "unrelated log",
+    DEEP_LINK_SOURCES.ime,
+  );
   assert.equal(wrongSource.mainActivityResumed, true);
   assert.equal(wrongSource.landed, false);
 
   // Source present but MainActivity not resumed → NOT landed.
-  const notResumed = assertDeepLinkLanded("ResumedActivity: com.other/.Home", logcat, DEEP_LINK_SOURCES.assistantSession);
+  const notResumed = assertDeepLinkLanded(
+    "ResumedActivity: com.other/.Home",
+    logcat,
+    DEEP_LINK_SOURCES.assistantSession,
+  );
   assert.equal(notResumed.landed, false);
 });
 
 test("classifyImeAsrOutcome distinguishes committed / engineOff / modelNotReady / error", () => {
   assert.equal(
-    classifyImeAsrOutcome("ElizaVoiceIme: [ElizaVoiceInputMethodService] transcript committed (14 chars)"),
+    classifyImeAsrOutcome(
+      "ElizaVoiceIme: [ElizaVoiceInputMethodService] transcript committed (14 chars)",
+    ),
     "committed",
   );
   assert.equal(
-    classifyImeAsrOutcome("ElizaVoiceIme: [ElizaVoiceInputMethodService] ASR loopback unreachable: Connection refused"),
+    classifyImeAsrOutcome(
+      "ElizaVoiceIme: [ElizaVoiceInputMethodService] ASR loopback unreachable: Connection refused",
+    ),
     "engineOff",
   );
   assert.equal(
-    classifyImeAsrOutcome("ElizaVoiceIme: [ElizaVoiceInputMethodService] ASR responded 503"),
+    classifyImeAsrOutcome(
+      "ElizaVoiceIme: [ElizaVoiceInputMethodService] ASR responded 503",
+    ),
     "modelNotReady",
   );
   assert.equal(
-    classifyImeAsrOutcome("ElizaVoiceIme: [ElizaVoiceInputMethodService] transcription error"),
+    classifyImeAsrOutcome(
+      "ElizaVoiceIme: [ElizaVoiceInputMethodService] transcription error",
+    ),
     "error",
   );
   assert.equal(classifyImeAsrOutcome("nothing"), "unknown");
@@ -219,21 +281,39 @@ test("summarizeLaneVerdict passes only when every required surface checks out", 
   assert.equal(summarizeLaneVerdict(green, true).pass, true);
 
   // Engine off is acceptable when the agent is NOT required...
-  assert.equal(summarizeLaneVerdict({ ...green, asrOutcome: "engineOff" }, false).pass, true);
+  assert.equal(
+    summarizeLaneVerdict({ ...green, asrOutcome: "engineOff" }, false).pass,
+    true,
+  );
   // ...but a hard failure when the agent IS required (never green-by-skip).
-  const requiredButOff = summarizeLaneVerdict({ ...green, asrOutcome: "engineOff" }, true);
+  const requiredButOff = summarizeLaneVerdict(
+    { ...green, asrOutcome: "engineOff" },
+    true,
+  );
   assert.equal(requiredButOff.pass, false);
   assert.match(requiredButOff.failures.join(" "), /ENGINE_OFF/);
 
-  const roleMissing = summarizeLaneVerdict({ ...green, roleHeld: false }, false);
+  const roleMissing = summarizeLaneVerdict(
+    { ...green, roleHeld: false },
+    false,
+  );
   assert.equal(roleMissing.pass, false);
   assert.match(roleMissing.failures.join(" "), /assistant role/);
 
-  const notRegistered = summarizeLaneVerdict({ ...green, surfacesRegistered: false }, false);
+  const notRegistered = summarizeLaneVerdict(
+    { ...green, surfacesRegistered: false },
+    false,
+  );
   assert.equal(notRegistered.pass, false);
 });
 
 test("exported component ids match the native manifest components", () => {
-  assert.equal(ASSISTANT_VIS_COMPONENT, "ai.elizaos.app/.ElizaVoiceInteractionService");
-  assert.equal(ASSISTANT_IME_COMPONENT, "ai.elizaos.app/.ElizaVoiceInputMethodService");
+  assert.equal(
+    ASSISTANT_VIS_COMPONENT,
+    "ai.elizaos.app/.ElizaVoiceInteractionService",
+  );
+  assert.equal(
+    ASSISTANT_IME_COMPONENT,
+    "ai.elizaos.app/.ElizaVoiceInputMethodService",
+  );
 });


### PR DESCRIPTION
## Problem (#13581)

Eliza's Android assistant surface — the `ROLE_ASSISTANT` `VoiceInteractionService`, the voice-input IME, and the assist-key glue — shipped with **manual-only** adb verification. The one coded instrumented test (`ElizaOsInstrumentedTest`) `assumeSystemEliza()`-gates itself off every non-AOSP APK (vacuously green), and `:app:connectedDebugAndroidTest` ran in **no** CI job. Worse, every `adb install -r` clears the assistant role and the enabled/selected IME, so each dev-loop reinstall silently un-configures the surface and nothing noticed.

## What this adds

An automated, repeatable adb-driven verification lane, a retail-path instrumented test, and CI wiring for both.

| File | Role |
|---|---|
| `packages/app/scripts/lib/android-assistant-verify-lib.mjs` | Pure `dumpsys`/`cmd`/`logcat`/`settings` parsers → typed decisions (no I/O, no device). |
| `packages/app/scripts/lib/android-assistant-verify-lib.test.mjs` | `node --test` coverage — 14 cases, real-shaped fixtures. |
| `packages/app/scripts/android-assistant-verify.mjs` | adb lane: assert surfaces registered → re-apply role+IME → assert secure settings → fire `cmd voiceinteraction show` / `KEYCODE_ASSIST` / IME deep-link → assert landing in `MainActivity` → classify IME ASR outcome. |
| `…/androidTest/…/ElizaAssistantSurfaceInstrumentedTest.java` | Retail-path (non-`assumeSystemEliza`) androidTest — surfaces declared, bind-guarded, intent-resolvable on ANY debug APK. |
| `.github/workflows/android-device-e2e.yml` | `native-plugin-androidtest` now runs `:app:connectedDebugAndroidTest` **and** the adb lane on the emulator. |
| `packages/app/package.json` | `test:e2e:android:assistant` script. |

### Done-when → mechanism
1. **VIS/IME registered** — `dumpsys package` → `parseAssistantSurfaces` (boundary-matched: a renamed surface reads ABSENT, not a prefix hit).
2. **Role + IME re-applied after reinstall, secure settings asserted** — `cmd role add-role-holder …ASSISTANT`, `ime enable`+`ime set`, then read back `voice_interaction_service` / `default_input_method` / `cmd role holders` / `ime list -s`.
3. **Invocation reaches the Eliza entry point** — `cmd voiceinteraction show`, `input keyevent KEYCODE_ASSIST`, and the `elizaos://voice?source=android-ime` deep-link; assert MainActivity resumed **and** the expected `source=` tag (both required — a coincidental foreground can't pass).
4. **IME ASR round-trip** — `committed` (full engine) vs. the designed `engineOff` state — asserted, never skipped silently.

### Honest device gating — never green-by-skip
Two **independent** gates:
- `--require-device` / `ELIZA_ANDROID_REQUIRE_AGENT=1` — a required-but-missing **device** hard-fails.
- `--require-engine` / `ELIZA_ANDROID_REQUIRE_ENGINE=1` — only then does `engineOff` fail (kept separate: the emulator has no on-device engine).

With no device and no require flag: N/A verdict, exit 0.

## Verification (runnable here, no device)
- `node --test …/android-assistant-verify-lib.test.mjs` → **14/14 pass** (`parser-node-test.txt`).
- Device-gating exit paths on a host with no device (`device-gating-exit-paths.txt`):
  - default → N/A, exit 0 · `--require-device` → FAIL, exit 1 · `ELIZA_ANDROID_REQUIRE_AGENT=1` → FAIL, exit 1
- Regression canary: renaming the VIS flips the parser + lane verdict RED (`regression-canary.txt`).
- Biome clean; workflow YAML parses; `:app:connectedDebugAndroidTest` + the adb lane are in the emulator script.

## N/A — needs an Android device/emulator
The **on-device** lane run and the CI `:app:connectedDebugAndroidTest` + adb lane were **not** executed here — no Android device/emulator is attached and this host is macOS (the CI lane is a KVM Linux runner). This is the honest N/A the lane is designed to surface. The CI-run link with a non-skipped assistant/IME test is the remaining artifact, obtainable via the `ci:device` label or `workflow_dispatch` on `android-device-e2e.yml`. Full detail: `.github/issue-evidence/13581-android-assistant-verify/README.md`.

## elizaOS/eliza#12393 hardware assistant-key remap
The software-injectable `KEYCODE_ASSIST` path is now covered. The **hardware** key remap (physical key → `KEYCODE_ASSIST` via a `.kl` overlay) needs the AOSP vendor tree — not implementable here (no `.kl` mechanism under `packages/scripts/distro-android/`, no AOSP build host). Re-tracked on elizaOS/eliza#12393 (comment) rather than left closed-but-unimplemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)