### PR TITLE
fix(import): estimate preflight quota from rendered transcripts

### DIFF
--- a/packages/import-conversations/src/core/preflight.test.ts
+++ b/packages/import-conversations/src/core/preflight.test.ts
@@ -9,6 +9,7 @@ import {
   preflightImport,
   type TenantImportQuota,
 } from "./preflight.ts";
+import { renderConversation } from "./render.ts";
 import type { ConversationBundle } from "./types.ts";
 
 const MiB = 1024 * 1024;
@@ -226,7 +227,7 @@ describe("estimateBundleUsage", () => {
     expect(estimate.embeddingUnits).toBe(1);
   });
 
-  it("counts UTF-8 bytes (not code units) and includes attachment text", () => {
+  it("counts the rendered transcript bytes that storage writes", () => {
     const b = bundle([
       conv({
         sourceConversationId: "c1",
@@ -241,8 +242,13 @@ describe("estimateBundleUsage", () => {
       }),
     ]);
     const estimate = estimateBundleUsage(b, 0);
-    // 2 bytes for "é" + 2 bytes for the attachment "ab".
-    expect(estimate.storageBytes).toBe(4);
+    const renderedBytes = new TextEncoder().encode(
+      renderConversation(b.conversations[0], b.source)
+        .map((part) => part.text)
+        .join(""),
+    ).byteLength;
+    expect(estimate.storageBytes).toBe(renderedBytes);
+    expect(estimate.storageBytes).toBeGreaterThan(4);
   });
 
   it("matches platform UTF-8 encoding for malformed surrogate text", () => {
@@ -255,8 +261,33 @@ describe("estimateBundleUsage", () => {
       }),
     ]);
     expect(estimateBundleUsage(b, 0).storageBytes).toBe(
-      new TextEncoder().encode(text).byteLength,
+      new TextEncoder().encode(
+        renderConversation(b.conversations[0], b.source)[0].text,
+      ).byteLength,
     );
+  });
+
+  it("refuses a tight quota that fits raw text but not the rendered transcript", () => {
+    const b = bundle([
+      conv({
+        sourceConversationId: "c1",
+        title: "Tiny",
+        messages: [{ role: "user", text: "ok" }],
+      }),
+    ]);
+    const rawTextBytes = new TextEncoder().encode("Tinyok").byteLength;
+    const estimate = estimateBundleUsage(b, 100);
+
+    expect(estimate.storageBytes).toBeGreaterThan(rawTextBytes);
+    const result = preflightImport(estimate, {
+      quota: { remainingStorageBytes: rawTextBytes },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("quota_storage_exceeded");
+      expect(result.observed).toBe(estimate.storageBytes);
+    }
   });
 
   it("feeds directly into preflightImport for a post-parse quota gate", () => {

--- a/packages/import-conversations/src/core/preflight.ts
+++ b/packages/import-conversations/src/core/preflight.ts
@@ -17,6 +17,7 @@
  * over-quota condition returns an explicit typed rejection rather than throwing.
  */
 
+import { renderConversation } from "./render.ts";
 import type { ConversationBundle } from "./types.ts";
 
 /** Bytes in one mebibyte — ceilings below read in MiB for legibility. */
@@ -219,9 +220,10 @@ export function preflightImport(
 /**
  * Derive a usage estimate from an already-parsed bundle for the post-parse cost
  * gate (the dry-run plan re-checks quota once real counts are known). Storage
- * is the byte length of all message + title text; one embedding unit is charged
- * per non-empty message as a conservative chunk proxy. `uploadBytes` still
- * comes from the transport and is passed through unchanged.
+ * is the byte length of the rendered transcript parts that the importer writes;
+ * one embedding unit is charged per non-empty message as a conservative chunk
+ * proxy. `uploadBytes` still comes from the transport and is passed through
+ * unchanged.
  */
 export function estimateBundleUsage(
   bundle: ConversationBundle,
@@ -230,19 +232,13 @@ export function estimateBundleUsage(
   let storageBytes = 0;
   let embeddingUnits = 0;
   for (const conversation of bundle.conversations) {
-    if (conversation.title) {
-      storageBytes += byteLength(conversation.title);
+    for (const part of renderConversation(conversation, bundle.source)) {
+      storageBytes += byteLength(part.text);
     }
     for (const message of conversation.messages) {
       const text = message.text ?? "";
       if (text.trim().length > 0) {
-        storageBytes += byteLength(text);
         embeddingUnits += 1;
-      }
-      for (const attachment of message.attachments ?? []) {
-        if (attachment.text) {
-          storageBytes += byteLength(attachment.text);
-        }
       }
     }
   }


### PR DESCRIPTION
Follow-up to merged #13901.

The import preflight storage estimator was summing raw titles/message/attachment text, but the importer stores rendered markdown transcript parts with headers, role/timestamp prefixes, attachment markers, separators, and header-only empty conversations. Tight quotas could pass preflight and then fail on the real write path.

This changes `estimateBundleUsage` to charge the bytes of `renderConversation(...).text` and adds a regression where raw text fits quota but the rendered transcript does not.

Verification:
- `bun test ./packages/import-conversations/src/core/preflight.test.ts` (22 pass)
- `bunx @biomejs/biome check packages/import-conversations/src/core/preflight.ts packages/import-conversations/src/core/preflight.test.ts`
- `git diff --check origin/develop...HEAD`
