### PR TITLE
fix(orchestrator): serialize task workdir binding

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
@@ -136,6 +136,41 @@ describe("durable task→workdir binding (#13776)", () => {
       expect(acp.spawns.at(1)?.workdir).toBe(firstDir);
       const afterFollowUp = await store.getTask(taskId);
       expect(afterFollowUp?.task.boundWorkdir).toBe(firstDir);
+      process.env.ELIZA_ACP_WORKSPACE_ROOT = tmpRoot;
+    } finally {
+      await service.stop().catch(() => undefined);
+    }
+  });
+
+  it("does not let a stale first-spawn binding overwrite an earlier successful binding", async () => {
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const acp = makeWorkdirCapturingAcp();
+    const service = new OrchestratorTaskService(makeRuntime(acp.service), {
+      store,
+    });
+    await service.start();
+    try {
+      const taskId = await seedTask(store);
+      const stale = (await store.getTask(taskId))?.task;
+      expect(stale).toBeTruthy();
+      if (!stale) throw new Error("seeded task was not persisted");
+      const bindTaskWorkdir = (
+        service as unknown as {
+          bindTaskWorkdir: (
+            taskId: string,
+            current: typeof stale,
+            workdir: string,
+            repo: string | undefined,
+          ) => Promise<void>;
+        }
+      ).bindTaskWorkdir.bind(service);
+
+      await bindTaskWorkdir(taskId, stale, overrideDir, undefined);
+      await bindTaskWorkdir(taskId, stale, firstDir, undefined);
+
+      expect((await store.getTask(taskId))?.task.boundWorkdir).toBe(
+        overrideDir,
+      );
     } finally {
       await service.stop().catch(() => undefined);
     }

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -270,11 +270,12 @@ export interface SpawnAgentForTaskOptions {
   nestingDepth?: number;
 }
 
-/** Descriptor for an already-spawned ACP session that we want to bind to an
- *  existing task thread. Only what the attach path genuinely needs — identity,
- *  workdir + status from the spawn, and the caller's context that isn't
- *  discoverable from the SpawnResult (originalTask, model, providerSource,
- *  repo). See {@link OrchestratorTaskService.attachSession}. */
+/**
+ * Descriptor for an already-spawned ACP session that we want to bind to an
+ * existing task thread. Only what the attach path genuinely needs: identity,
+ * workdir and status from the spawn, plus caller context that is not
+ * discoverable from the SpawnResult.
+ */
 export interface AttachSessionInput {
   sessionId: string;
   agentType: string;
@@ -678,6 +679,7 @@ export class OrchestratorTaskService extends Service {
   protected override readonly runtime: RuntimeLike;
   private readonly store: OrchestratorTaskStore;
   private readonly sessionTaskIndex = new Map<string, string>();
+  private readonly taskWorkdirBindQueues = new Map<string, Promise<void>>();
   // Session ids whose event-recording has already logged a failure. A
   // degraded store (e.g. #11641's pglite lookup) would otherwise re-warn on
   // EVERY session event (`ready`, `tool_running`, ...) forever — one line per
@@ -3361,7 +3363,12 @@ export class OrchestratorTaskService extends Service {
       // Pin (or re-pin, on explicit override) the durable workdir/repo binding
       // from the workdir the session actually landed in, so subsequent
       // follow-up spawns of this task reuse it deterministically (#13776).
-      await this.bindTaskWorkdir(taskId, doc.task, result.workdir, opts.repo);
+      await this.bindTaskWorkdir(taskId, doc.task, result.workdir, opts.repo, {
+        allowRebind:
+          Boolean(opts.workdir) &&
+          Boolean(doc.task.boundWorkdir) &&
+          doc.task.boundWorkdir !== result.workdir,
+      });
       await this.advanceTaskStatus(taskId, "session_active");
       return this.getTask(taskId);
     } catch (err) {
@@ -3408,15 +3415,34 @@ export class OrchestratorTaskService extends Service {
     current: OrchestratorTaskRecord,
     workdir: string | undefined,
     repo: string | undefined,
+    opts: { allowRebind?: boolean } = {},
   ): Promise<void> {
     if (!workdir) return;
-    const patch: Partial<OrchestratorTaskRecord> = {};
-    const workdirChanged = current.boundWorkdir !== workdir;
-    if (workdirChanged) patch.boundWorkdir = workdir;
-    if (repo && current.boundRepo !== repo) patch.boundRepo = repo;
-    else if (workdirChanged && current.boundRepo) patch.boundRepo = null;
-    if (Object.keys(patch).length === 0) return;
-    await this.store.updateTask(taskId, patch);
+    const previous =
+      this.taskWorkdirBindQueues.get(taskId)?.catch(() => undefined) ??
+      Promise.resolve();
+    const next = previous.then(async () => {
+      const latest = (await this.store.getTask(taskId))?.task ?? current;
+      const canSetWorkdir = !latest.boundWorkdir || opts.allowRebind === true;
+      const patch: Partial<OrchestratorTaskRecord> = {};
+      const workdirChanged = latest.boundWorkdir !== workdir;
+      if (canSetWorkdir && workdirChanged) patch.boundWorkdir = workdir;
+      if (canSetWorkdir && repo && latest.boundRepo !== repo) {
+        patch.boundRepo = repo;
+      } else if (canSetWorkdir && workdirChanged && latest.boundRepo) {
+        patch.boundRepo = null;
+      }
+      if (Object.keys(patch).length === 0) return;
+      await this.store.updateTask(taskId, patch);
+    });
+    this.taskWorkdirBindQueues.set(taskId, next);
+    try {
+      await next;
+    } finally {
+      if (this.taskWorkdirBindQueues.get(taskId) === next) {
+        this.taskWorkdirBindQueues.delete(taskId);
+      }
+    }
   }
 
   /**
@@ -3501,7 +3527,11 @@ export class OrchestratorTaskService extends Service {
     this.sessionTaskIndex.set(input.sessionId, taskId);
     // Pin the durable workdir/repo binding at first spawn so follow-up spawns of
     // this task reuse it instead of re-resolving from routing env (#13776).
-    await this.bindTaskWorkdir(taskId, doc.task, input.workdir, input.repo);
+    await this.bindTaskWorkdir(taskId, doc.task, input.workdir, input.repo, {
+      allowRebind:
+        Boolean(doc.task.boundWorkdir) &&
+        doc.task.boundWorkdir !== input.workdir,
+    });
     // Only claim liveness if the session actually is live — a terminal-on-
     // arrival session (chat action's runPromptAndClose already stopped it) gets
     // indexed for history + future token attribution without falsely promoting


### PR DESCRIPTION
Follow-up to merged #13801. The merged task→workdir binding reads a stale task document after spawn; concurrent first-spawn completions can overwrite the first durable binding.

This changes binding writes to serialize per task and re-read the current task record before patching. Later stale first-spawn completions no longer overwrite an existing binding; explicit rebinds still work when the task was already bound at spawn start.

Verification:
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts --no-errors-on-unmatched`
- `git diff --check origin/develop...HEAD && git diff --check`
- `bun run --cwd packages/core prebuild` to generate missing local keyword artifacts in the fresh worktree
- `bun test plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts` (5 pass)