### PR TITLE
fix: polish console agents and account copy

### DIFF
--- a/packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx
+++ b/packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx
@@ -205,7 +205,7 @@ export function ContainersPageWrapper({
 export function ElizaAgentsPageWrapper({
   children,
 }: DashboardRoutePageWrapperProps) {
-  return <DashboardRoutePage title="Instances">{children}</DashboardRoutePage>;
+  return <DashboardRoutePage title="Agents">{children}</DashboardRoutePage>;
 }
 
 export function AppsEmptyState({ description, action }: AppsEmptyStateProps) {
@@ -269,9 +269,7 @@ export function ContainersEmptyState() {
             )}
           >
             <span className="select-none text-muted">$</span>
-            <code className="flex-1 font-mono text-sm text-txt">
-              {cmd}
-            </code>
+            <code className="flex-1 font-mono text-sm text-txt">{cmd}</code>
             <Button
               variant="ghost"
               type="button"

--- a/packages/ui/src/cloud/account-security/components/account-page-client.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-page-client.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+/**
+ * Account page banner copy should read naturally for the generated organization
+ * names Cloud creates at signup. The lower panels are mocked so this test stays
+ * focused on the welcome card copy.
+ */
+
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { UserProfile } from "../data/user";
+import { AccountPageClient } from "./account-page-client";
+
+vi.mock("../../../cloud-ui", () => ({
+  BrandCard: ({ children }: { children: ReactNode }) => (
+    <section>{children}</section>
+  ),
+  CornerBrackets: () => null,
+  DashboardPageContainer: ({ children }: { children: ReactNode }) => (
+    <main>{children}</main>
+  ),
+  useSetPageHeader: vi.fn(),
+}));
+
+vi.mock("./account-details", () => ({
+  AccountDetails: () => <div>account details</div>,
+}));
+
+vi.mock("./organization-info", () => ({
+  OrganizationInfo: () => <div>organization info</div>,
+}));
+
+vi.mock("./profile-form", () => ({
+  ProfileForm: () => <div>profile form</div>,
+}));
+
+function makeUser(organizationName: string): UserProfile {
+  const now = new Date("2026-07-05T00:00:00.000Z");
+  return {
+    id: "user-1",
+    email: "user@example.com",
+    email_verified: true,
+    wallet_address: "0x1234567890abcdef",
+    wallet_chain_type: "evm",
+    wallet_verified: true,
+    name: null,
+    avatar: null,
+    organization_id: "org-1",
+    role: "owner",
+    steward_user_id: null,
+    telegram_id: null,
+    telegram_username: null,
+    telegram_first_name: null,
+    telegram_photo_url: null,
+    discord_id: null,
+    discord_username: null,
+    discord_global_name: null,
+    discord_avatar_url: null,
+    whatsapp_id: null,
+    whatsapp_name: null,
+    phone_number: null,
+    phone_verified: null,
+    is_anonymous: false,
+    anonymous_session_id: null,
+    expires_at: null,
+    nickname: null,
+    work_function: null,
+    preferences: null,
+    email_notifications: true,
+    response_notifications: true,
+    is_active: true,
+    created_at: now,
+    updated_at: now,
+    organization: {
+      id: "org-1",
+      name: organizationName,
+      slug: "org-1",
+      billing_email: null,
+      credit_balance: "0",
+      is_active: true,
+      created_at: now,
+      updated_at: now,
+    },
+  };
+}
+
+describe("AccountPageClient", () => {
+  afterEach(() => cleanup());
+
+  it("does not append a second organization noun to generated org names", () => {
+    const { container } = render(
+      <AccountPageClient user={makeUser("0x1234's Organization")} />,
+    );
+    const text = container.textContent ?? "";
+
+    expect(text).toContain("You're part of 0x1234's Organization");
+    expect(text).not.toMatch(/Organization organization/i);
+  });
+
+  it("keeps the noun for organization names that do not include it", () => {
+    const { container } = render(
+      <AccountPageClient user={makeUser("Team Sol")} />,
+    );
+
+    expect(container.textContent).toContain(
+      "You're part of Team Sol organization",
+    );
+  });
+});

--- a/packages/ui/src/cloud/account-security/components/account-page-client.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-page-client.tsx
@@ -18,6 +18,10 @@ interface AccountPageClientProps {
   user: UserProfile;
 }
 
+function organizationMembershipSuffix(name: string): string {
+  return /\borganization$/i.test(name.trim()) ? "" : " organization";
+}
+
 export function AccountPageClient({ user }: AccountPageClientProps) {
   useSetPageHeader({
     title: "Account",
@@ -30,6 +34,7 @@ export function AccountPageClient({ user }: AccountPageClientProps) {
     (user.wallet_address
       ? `${user.wallet_address.substring(0, 6)}...${user.wallet_address.substring(user.wallet_address.length - 4)}`
       : "User");
+  const organizationName = user.organization?.name?.trim();
 
   return (
     <DashboardPageContainer width="narrow" className="flex flex-col gap-6">
@@ -41,11 +46,11 @@ export function AccountPageClient({ user }: AccountPageClientProps) {
               Welcome back, <span className="font-semibold">{displayName}</span>
               !
             </p>
-            {user.organization?.name && (
+            {organizationName && (
               <p className="text-xs text-muted mt-1">
                 You&apos;re part of{" "}
-                <span className="font-medium">{user.organization.name}</span>{" "}
-                organization
+                <span className="font-medium">{organizationName}</span>
+                {organizationMembershipSuffix(organizationName)}
               </p>
             )}
           </div>

--- a/packages/ui/src/cloud/instances/AgentsPage.tsx
+++ b/packages/ui/src/cloud/instances/AgentsPage.tsx
@@ -1,5 +1,5 @@
 /**
- * Instances page (`/dashboard/agents`) — the hosted agent management table.
+ * Agents page (`/dashboard/agents`) — the hosted agent management table.
  */
 
 import type { AgentListItemDto } from "@elizaos/cloud-shared/lib/types/cloud-api";
@@ -50,7 +50,7 @@ export default function AgentsPage() {
   const agentsQuery = useAgents();
   const credits = useCreditsBalance();
 
-  useDocumentTitle(t("cloud.agents.metaTitle", { defaultValue: "Instances" }));
+  useDocumentTitle(t("cloud.agents.metaTitle", { defaultValue: "Agents" }));
 
   if (!session.ready) {
     return (
@@ -77,9 +77,9 @@ export default function AgentsPage() {
     <ElizaAgentsPageWrapper>
       <DashboardPageContainer className="space-y-6">
         {/* Page title is surfaced in the console top bar by
-            ElizaAgentsPageWrapper (DashboardRoutePage title="Instances" →
+            ElizaAgentsPageWrapper (DashboardRoutePage title="Agents" →
             useSetPageHeader). No inline page-level heading here — a second
-            "Instances" title under the top bar read as a double title. */}
+            "Agents" title under the top bar read as a double title. */}
         {showSkeleton ? (
           <ContainersSkeleton />
         ) : showAgentsError ? (

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -787,7 +787,7 @@
   "cloud.agents.detail.webUiPort": "Web UI Port",
   "cloud.agents.loading": "Loading instances",
   "cloud.agents.metaDescription": "View, launch, and manage your instances backed by Eliza Cloud.",
-  "cloud.agents.metaTitle": "Instances",
+  "cloud.agents.metaTitle": "Agents",
   "cloud.analytics.custom": "Custom",
   "cloud.analytics.dataPointsCount": "{{n}} data points",
   "cloud.analytics.filters.aggregation": "Aggregation",


### PR DESCRIPTION
## Summary
- rename the `/dashboard/agents` page header/document-title surface from Instances to Agents
- update the English `cloud.agents.metaTitle` string to match
- avoid rendering generated organization names as `Organization organization` on the Account welcome banner

Covers #13905 items (1) and (2). Items (3) Organization nav intent and (4) earnings CSP noise remain separate investigation items.

## Tests
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/ui test account-page-client.test.tsx`
- `bunx @biomejs/biome check packages/ui/src/cloud/instances/AgentsPage.tsx packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx packages/ui/src/cloud/account-security/components/account-page-client.tsx packages/ui/src/cloud/account-security/components/account-page-client.test.tsx packages/ui/src/i18n/locales/en.json`
