### PR TITLE
fix(cloud-shared): proxy service fallback sweep + tests (#13415 slice 4a)

### DIFF
--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.error-policy.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Error-policy proof for the Birdeye market-data proxy handler (#13415).
+ *
+ * Pins that a designed-invalid / not-configured result stays visually distinct
+ * from an internal failure, and that an internal failure PROPAGATES through the
+ * J1 route boundary (`failureResponse`) as a structured `{ success: false }`
+ * rather than being swallowed into a fabricated 2xx/empty body. The auth,
+ * pricing, and credits boundaries plus `fetch` are mocked; `failureResponse`
+ * runs for real so the boundary translation is the unit under test. mock.module
+ * is process-global but the suite runs under `bun test --isolate`, so each file
+ * gets a fresh registry.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Context } from "hono";
+import type { AppEnv } from "../../../types/cloud-worker-env";
+import * as authActual from "../../auth/workers-hono-auth";
+import * as creditsActual from "../credits";
+import * as pricingActual from "./pricing";
+
+const realCredits = { ...creditsActual };
+const realPricing = { ...pricingActual };
+const realAuth = { ...authActual };
+
+const ORG_ID = "00000000-0000-4000-8000-0000000000aa";
+const COST = 0.0003;
+
+const deductCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
+const refundCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
+const getServiceMethodCost = mock<(service: string, method: string) => Promise<number>>();
+const requireUserOrApiKeyWithOrg = mock<(c: unknown) => Promise<{ organization_id: string }>>();
+
+mock.module("../credits", () => ({
+  ...realCredits,
+  creditsService: { ...realCredits.creditsService, deductCredits, refundCredits },
+}));
+
+mock.module("./pricing", () => ({ ...realPricing, getServiceMethodCost }));
+
+mock.module("../../auth/workers-hono-auth", () => ({
+  ...realAuth,
+  requireUserOrApiKeyWithOrg,
+}));
+
+const { handleBirdeyeMarketDataProxyGet } = await import("./birdeye-handler");
+
+const originalFetch = globalThis.fetch;
+
+function makeContext(path: string, env: Record<string, unknown> = {}): Context<AppEnv> {
+  const url = `https://api.elizacloud.ai/proxy/${path}`;
+  return {
+    env,
+    req: {
+      param: (key: string) => (key === "*" ? path : undefined),
+      url,
+      header: (_name: string) => undefined,
+    },
+    json: (body: unknown, status?: number) => Response.json(body, { status: status ?? 200 }),
+  } as unknown as Context<AppEnv>;
+}
+
+function mockUpstream(status: number, body = "{}") {
+  globalThis.fetch = mock(
+    async () => new Response(body, { status, headers: { "Content-Type": "application/json" } }),
+  ) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  deductCredits.mockReset();
+  refundCredits.mockReset();
+  getServiceMethodCost.mockReset();
+  requireUserOrApiKeyWithOrg.mockReset();
+  deductCredits.mockResolvedValue({ success: true });
+  refundCredits.mockResolvedValue({ success: true });
+  getServiceMethodCost.mockResolvedValue(COST);
+  requireUserOrApiKeyWithOrg.mockResolvedValue({ organization_id: ORG_ID });
+  mockUpstream(200, '{"data":{"value":1}}');
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  mock.module("../credits", () => realCredits);
+  mock.module("./pricing", () => realPricing);
+  mock.module("../../auth/workers-hono-auth", () => realAuth);
+});
+
+describe("birdeye proxy — designed-invalid results stay distinct from failures", () => {
+  test("unpriced path is a designed 400 reject, not a boundary failure", async () => {
+    const res = await handleBirdeyeMarketDataProxyGet(
+      makeContext("defi/not_a_real_path", { BIRDEYE_API_KEY: "key" }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; supportedPaths: string[] };
+    expect(body.error).toContain("Unpriced Birdeye proxy path");
+    expect(Array.isArray(body.supportedPaths)).toBe(true);
+    // Short-circuits BEFORE any auth / billing work.
+    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+
+  test("missing BIRDEYE_API_KEY is a designed 503 not-configured, no debit", async () => {
+    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price", {}));
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("server misconfigured");
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+});
+
+describe("birdeye proxy — internal failures propagate through the J1 boundary", () => {
+  test("a pricing-store failure surfaces as a structured 5xx, never a fake 2xx", async () => {
+    getServiceMethodCost.mockRejectedValue(new Error("pricing store unavailable"));
+
+    const res = await handleBirdeyeMarketDataProxyGet(
+      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+    );
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(false);
+    // The failure aborts before any debit — nothing charged for a broken call.
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+
+  test("an auth failure is translated, not swallowed into a healthy response", async () => {
+    requireUserOrApiKeyWithOrg.mockRejectedValue(new Error("token verification failed"));
+
+    const res = await handleBirdeyeMarketDataProxyGet(
+      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+    );
+
+    expect(res.ok).toBe(false);
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(false);
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+});
+
+describe("birdeye proxy — money-path debit fallback (money-path-flagged, left as-is)", () => {
+  // The `deductCredits(...).catch(() => null)` on the billing path currently
+  // maps BOTH a designed insufficient-balance (`success: false`) AND an internal
+  // debit failure to the same 402. This conflation is flagged money-path-flagged
+  // and intentionally left untouched by #13415; this test pins the two shapes.
+  test("designed insufficient balance returns 402", async () => {
+    deductCredits.mockResolvedValue({ success: false });
+    const res = await handleBirdeyeMarketDataProxyGet(
+      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+    );
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("Insufficient credits");
+  });
+
+  test("an internal debit failure is currently also mapped to 402 (flagged)", async () => {
+    deductCredits.mockRejectedValue(new Error("credits ledger write failed"));
+    const res = await handleBirdeyeMarketDataProxyGet(
+      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+    );
+    expect(res.status).toBe(402);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
@@ -132,6 +132,10 @@ export async function handleBirdeyeMarketDataProxyGet(c: Context<AppEnv>): Promi
       },
     });
   } catch (error) {
+    // error-policy:J1 route boundary — translate any handler throw (auth
+    // rejection, pricing lookup, upstream fetch) into a structured failure
+    // response for the client. No success is fabricated: failureResponse emits
+    // { success: false, error, code } with an inferred 4xx/5xx status.
     return failureResponse(c, error);
   }
 }

--- a/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.error-policy.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Error-policy proof for the DexScreener proxy handler (#13415).
+ *
+ * Pins the fail-closed contract of the outermost J1 route boundary: an internal
+ * failure (auth throw, pricing-lookup throw) must SURFACE as a structured
+ * `success:false` error response, never be fabricated into a healthy 200/empty
+ * result — and a legitimately-empty upstream domain result (`{"pairs":[]}`)
+ * must stay distinguishable from that failure by passing through as a real 200.
+ *
+ * Only the credits, pricing, auth, and `fetch` boundaries are mocked; the
+ * handler's branching is the unit under test. `mock.module` is process-global,
+ * so the real modules are restored in `afterAll`.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Context } from "hono";
+import type { AppEnv } from "../../../types/cloud-worker-env";
+import * as authActual from "../../auth/workers-hono-auth";
+import * as creditsActual from "../credits";
+import * as pricingActual from "./pricing";
+
+const realCredits = { ...creditsActual };
+const realPricing = { ...pricingActual };
+const realAuth = { ...authActual };
+
+const ORG_ID = "00000000-0000-4000-8000-0000000000aa";
+const COST = 0.0003;
+
+const deductCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
+const refundCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
+const getServiceMethodCost = mock<() => Promise<number>>();
+const requireUserOrApiKeyWithOrg = mock<() => Promise<{ organization_id: string }>>();
+
+mock.module("../credits", () => ({
+  ...realCredits,
+  creditsService: {
+    ...realCredits.creditsService,
+    deductCredits,
+    refundCredits,
+  },
+}));
+
+mock.module("./pricing", () => ({
+  ...realPricing,
+  getServiceMethodCost,
+}));
+
+mock.module("../../auth/workers-hono-auth", () => ({
+  ...realAuth,
+  requireUserOrApiKeyWithOrg,
+}));
+
+const { handleDexscreenerProxyGet } = await import("./dexscreener-handler");
+
+const originalFetch = globalThis.fetch;
+
+/** Minimal Hono Context stub covering exactly what the handler reads. */
+function makeContext(path: string): Context<AppEnv> {
+  return {
+    env: {},
+    req: {
+      param: (key: string) => (key === "*" ? path : undefined),
+      url: `https://api.elizacloud.ai/proxy/${path}`,
+      header: (_name: string) => undefined,
+    },
+    json: (body: unknown, status?: number) => Response.json(body, { status: status ?? 200 }),
+  } as unknown as Context<AppEnv>;
+}
+
+function mockUpstream(status: number, body = "{}") {
+  globalThis.fetch = mock(
+    async () => new Response(body, { status, headers: { "Content-Type": "application/json" } }),
+  ) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  deductCredits.mockReset();
+  refundCredits.mockReset();
+  getServiceMethodCost.mockReset();
+  requireUserOrApiKeyWithOrg.mockReset();
+  deductCredits.mockResolvedValue({ success: true });
+  refundCredits.mockResolvedValue({ success: true });
+  getServiceMethodCost.mockResolvedValue(COST);
+  requireUserOrApiKeyWithOrg.mockResolvedValue({ organization_id: ORG_ID });
+  mockUpstream(200, '{"pairs":[]}');
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  mock.module("../credits", () => realCredits);
+  mock.module("./pricing", () => realPricing);
+  mock.module("../../auth/workers-hono-auth", () => realAuth);
+});
+
+describe("dexscreener proxy fail-closed boundary", () => {
+  test("designed-empty upstream passes through as a real 200 (not a failure)", async () => {
+    mockUpstream(200, '{"pairs":[]}');
+
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/pairs/x"));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { pairs: unknown[] };
+    // Legitimately-empty domain result — distinct from an internal failure.
+    expect(body.pairs).toEqual([]);
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(refundCredits).not.toHaveBeenCalled();
+  });
+
+  test("auth failure SURFACES as a structured error, never a fabricated 200", async () => {
+    requireUserOrApiKeyWithOrg.mockRejectedValue(new Error("boom in auth"));
+
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/pairs/x"));
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(false);
+    // Failure short-circuits before any debit — no charge on a broken pipeline.
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+
+  test("pricing-lookup failure propagates as 500, cost is NOT defaulted to 0", async () => {
+    getServiceMethodCost.mockRejectedValue(new Error("pricing table unavailable"));
+
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/pairs/x"));
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(false);
+    // The internal failure is not swallowed into a zero-cost free call.
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+
+  test("disallowed path is a designed 400 validation result, distinct from a 500", async () => {
+    const res = await handleDexscreenerProxyGet(makeContext("token-profiles/latest/v1"));
+
+    expect(res.status).toBe(400);
+    // Rejected before auth/pricing/debit — a designed-invalid input, not failure.
+    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+});
+
+describe("dexscreener proxy — money-path debit fallback (money-path-flagged, left as-is)", () => {
+  // The `deductCredits(...).catch(() => null)` on the billing path maps BOTH a
+  // designed insufficient-balance (`success: false`) AND an internal debit
+  // failure (thrown) to the same 402. That conflation sits on the credit-debit
+  // money path, is flagged money-path-flagged, and is intentionally left
+  // untouched by #13415; these tests pin the two shapes so any future change is
+  // deliberate.
+  test("designed insufficient balance returns 402", async () => {
+    deductCredits.mockResolvedValue({ success: false });
+
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/pairs/x"));
+
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("Insufficient credits");
+  });
+
+  test("an internal debit failure is currently also mapped to 402 (flagged)", async () => {
+    deductCredits.mockRejectedValue(new Error("credits ledger write failed"));
+
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/pairs/x"));
+
+    expect(res.status).toBe(402);
+  });
+});
+
+describe("dexscreener proxy — refund-on-upstream-failure (free upstream, no charge)", () => {
+  test("upstream 5xx refunds the upfront charge and passes the status through", async () => {
+    mockUpstream(502, '{"error":"bad gateway"}');
+
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/pairs/x"));
+
+    // Upstream status is surfaced verbatim — not fabricated into a healthy 200.
+    expect(res.status).toBe(502);
+    // A free upstream cost us nothing, so the upfront debit is refunded.
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+  });
+
+  test("a failed refund is best-effort: it does not mask the upstream status", async () => {
+    mockUpstream(500, '{"error":"upstream down"}');
+    refundCredits.mockRejectedValue(new Error("refund ledger write failed"));
+
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/pairs/x"));
+
+    // The swallowed refund-write failure is logged, not thrown — the client
+    // still receives the real upstream 500 rather than a boundary 500.
+    expect(res.status).toBe(500);
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.ts
@@ -108,6 +108,9 @@ export async function handleDexscreenerProxyGet(c: Context<AppEnv>): Promise<Res
       },
     });
   } catch (error) {
+    // error-policy:J1 outermost route boundary — translate any thrown error
+    // (auth, pricing lookup, fetch/transport) into a structured client failure
+    // response; never fabricates a success/empty result from the failure.
     return failureResponse(c, error);
   }
 }

--- a/packages/cloud/shared/src/lib/services/proxy/engine.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.error-policy.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Error-policy proof for the proxy engine boundary (#13415).
+ *
+ * Drives the real exported `createHandler` through its outer J1 boundary and the
+ * J2 handler-failure refund path, asserting that an INTERNAL failure surfaces
+ * observably (a 5xx error response + a refunded reservation) and stays
+ * distinguishable from DESIGNED client-error states (400 invalid body, 402
+ * insufficient credits) — never a fabricated 2xx success. Credits, usage, auth,
+ * and cache are the mocked boundaries; the engine's branching is the unit under
+ * test.
+ *
+ * `mock.module` is process-global in Bun's single-process run, so the real
+ * modules are restored in `afterAll`.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as authActual from "../../auth";
+import * as cacheActual from "../../cache/client";
+import * as creditsActual from "../credits";
+import * as usageActual from "../usage";
+import type { ProxyRequestBody, ServiceConfig } from "./types";
+
+const realAuth = { ...authActual };
+const realCredits = { ...creditsActual };
+const realUsage = { ...usageActual };
+const realCache = { ...cacheActual };
+
+const ORG_ID = "00000000-0000-4000-8000-0000000000aa";
+const USER_ID = "00000000-0000-4000-8000-0000000000bb";
+
+const reconcile = mock<(actualCost: number) => Promise<void>>();
+const reserve = mock<(args: unknown) => Promise<{ reconcile: typeof reconcile }>>();
+const usageCreate = mock<(args: unknown) => Promise<void>>();
+
+mock.module("../../auth", () => ({
+  ...realAuth,
+  requireAuth: async () => ({ id: USER_ID, organization_id: ORG_ID }),
+}));
+
+mock.module("../credits", () => ({
+  ...realCredits,
+  creditsService: { ...realCredits.creditsService, reserve },
+}));
+
+mock.module("../usage", () => ({
+  ...realUsage,
+  usageService: { ...realUsage.usageService, create: usageCreate },
+}));
+
+mock.module("../../cache/client", () => ({
+  ...realCache,
+  cache: { get: async () => null, set: async () => {} },
+}));
+
+// InsufficientCreditsError is a real export used by the engine's instanceof check.
+const { InsufficientCreditsError } = creditsActual;
+const { createHandler } = await import("./engine");
+
+const originalFetch = globalThis.fetch;
+
+function makeConfig(): ServiceConfig {
+  return {
+    id: "test-service",
+    name: "Test Service",
+    auth: "session",
+    getCost: async () => 5,
+  };
+}
+
+function makeRequest(body: ProxyRequestBody | string): Request {
+  return new Request("https://api.elizacloud.ai/proxy/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  reconcile.mockReset();
+  reserve.mockReset();
+  usageCreate.mockReset();
+  reconcile.mockResolvedValue(undefined);
+  reserve.mockResolvedValue({ reconcile });
+  usageCreate.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  mock.module("../../auth", () => realAuth);
+  mock.module("../credits", () => realCredits);
+  mock.module("../usage", () => realUsage);
+  mock.module("../../cache/client", () => realCache);
+});
+
+describe("proxy engine error-policy boundary", () => {
+  test("an internal handler failure surfaces as a 5xx AND refunds the reservation (J2 + J1)", async () => {
+    const handler = createHandler(makeConfig(), async () => {
+      throw new Error("upstream socket exploded");
+    });
+
+    const res = await handler(makeRequest({ method: "getBalance" }));
+
+    // Fail closed: the failure surfaces as an error response, never a fabricated 200.
+    expect(res.status).toBe(502);
+    const payload = (await res.json()) as { error: string };
+    expect(payload.error).toBe("Upstream service error");
+    // J2: the reservation was refunded to 0 before the error propagated.
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBe(0);
+  });
+
+  test("a generic internal error is NOT reclassified as a client error", async () => {
+    const handler = createHandler(makeConfig(), async () => {
+      throw new Error("kv store connection reset");
+    });
+
+    const res = await handler(makeRequest({ method: "getBalance" }));
+
+    // A neutral internal error must land in the 5xx band, distinct from 400/402/504.
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    expect(res.status).toBe(502);
+  });
+
+  test("a designed client error (invalid JSON) is a distinct 400 — never a 5xx or a success (J3)", async () => {
+    const handler = createHandler(makeConfig(), async () => {
+      throw new Error("must not run — parse fails first");
+    });
+
+    const res = await handler(makeRequest("{not valid json"));
+
+    expect(res.status).toBe(400);
+    const payload = (await res.json()) as { error: string };
+    expect(payload.error).toBe("Invalid JSON");
+    // Parse failed before any billing occurred — no reservation, no refund fabricated.
+    expect(reserve).not.toHaveBeenCalled();
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+
+  test("insufficient credits surfaces as a distinct 402, not a 5xx or a served response", async () => {
+    reserve.mockRejectedValueOnce(new InsufficientCreditsError(5, 1));
+
+    const work = mock(async () => {
+      throw new Error("must not run — reserve fails first");
+    });
+    const handler = createHandler(makeConfig(), work);
+
+    const res = await handler(makeRequest({ method: "getBalance" }));
+
+    expect(res.status).toBe(402);
+    const payload = (await res.json()) as { error: string; required: number; available: number };
+    expect(payload.error).toBe("Insufficient credits");
+    expect(payload.required).toBe(5);
+    expect(payload.available).toBe(1);
+    // The billing failure short-circuits before the handler runs; nothing is fabricated.
+    expect(work).not.toHaveBeenCalled();
+  });
+
+  test("a successful handler result is passed through unchanged (the healthy path stays distinct)", async () => {
+    const handler = createHandler(makeConfig(), async () => ({
+      response: Response.json({ ok: true }, { status: 200 }),
+    }));
+
+    const res = await handler(makeRequest({ method: "getBalance" }));
+
+    expect(res.status).toBe(200);
+    // Healthy path reconciles the reserved cost once (not the refund path).
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0]?.[0]).toBe(5);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/engine.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.ts
@@ -180,6 +180,7 @@ export function createHandler(
         try {
           body = await request.json();
         } catch {
+          // error-policy:J3 malformed request body -> explicit 400 invalid, never a fake-valid default
           return Response.json({ error: "Invalid JSON" }, { status: 400 });
         }
       }
@@ -254,6 +255,8 @@ export function createHandler(
                     },
                   });
                 } catch (error) {
+                  // error-policy:J7 usage metering is fire-and-forget telemetry; the credit
+                  // reconcile already committed, so a failed usage write must not fail the served hit
                   logger.error("[Proxy Engine] Usage tracking failed (cache hit)", { error });
                 }
               })();
@@ -262,6 +265,8 @@ export function createHandler(
             }
           }
         } catch (error) {
+          // error-policy:J7 cache is a best-effort accelerator; a read failure degrades to a
+          // cache miss (the real upstream work below still runs and bills), never a fabricated hit
           logger.warn("[Proxy Engine] Cache read failed", { error });
         }
       }
@@ -270,6 +275,8 @@ export function createHandler(
       try {
         result = await work({ body, auth, searchParams });
       } catch (error) {
+        // error-policy:J2 refund the credit reservation on handler failure, then rethrow
+        // unchanged so the outer boundary surfaces it (never a fabricated success)
         await reservation.reconcile(0);
         throw error;
       }
@@ -350,12 +357,16 @@ export function createHandler(
             },
           });
         } catch (error) {
+          // error-policy:J7 usage metering is fire-and-forget telemetry; a failed write must not
+          // fail the already-served response (the credit reconcile above already committed)
           logger.error("[Proxy Engine] Usage tracking failed", { error });
         }
       })();
 
       return result.response;
     } catch (error) {
+      // error-policy:J1 outermost route boundary: translate thrown errors into structured HTTP
+      // failures (402/4xx/5xx). Every branch surfaces the failure; none fabricates a 2xx success.
       if (error instanceof InsufficientCreditsError) {
         return Response.json(
           {

--- a/packages/cloud/shared/src/lib/services/proxy/fetch.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/fetch.error-policy.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Error-policy pins for the proxy retry-fetch transport boundary: a transport
+ * failure (network error, or a TimeoutError that outlives its retries) must
+ * PROPAGATE to the caller (fail closed), while a real upstream HTTP response of
+ * any status is returned verbatim — never swallowed into a fabricated default.
+ * Deterministic: `globalThis.fetch` is mocked, so no live network is touched.
+ */
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { RetryFetchOptions } from "./fetch";
+import { retryFetch } from "./fetch";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+const baseOpts: RetryFetchOptions = {
+  url: "https://api.example.com/v2/secret-key",
+  init: { method: "POST" },
+  maxRetries: 3,
+  initialDelayMs: 0,
+  timeoutMs: 50,
+  serviceTag: "TEST",
+};
+
+describe("retryFetch error policy", () => {
+  it("propagates a network error instead of swallowing it into a default", async () => {
+    const boom = new Error("ECONNRESET");
+    const f = mock(async () => {
+      throw boom;
+    });
+    globalThis.fetch = f as unknown as typeof fetch;
+
+    await expect(retryFetch({ ...baseOpts, maxRetries: 1 })).rejects.toBe(boom);
+    // Non-timeout errors are surfaced on the first attempt, never retried away.
+    expect(f.mock.calls.length).toBe(1);
+  });
+
+  it("retries a TimeoutError then re-throws once retries are exhausted (fails closed)", async () => {
+    const timeout = new Error("timed out");
+    timeout.name = "TimeoutError";
+    const f = mock(async () => {
+      throw timeout;
+    });
+    globalThis.fetch = f as unknown as typeof fetch;
+
+    await expect(retryFetch({ ...baseOpts, maxRetries: 3 })).rejects.toBe(timeout);
+    // Attempted maxRetries times, then the real failure is surfaced — not defaulted.
+    expect(f.mock.calls.length).toBe(3);
+  });
+
+  it("returns a successful upstream Response verbatim (real result, not fabricated)", async () => {
+    const ok = new Response("{}", { status: 200 });
+    const f = mock(async () => ok);
+    globalThis.fetch = f as unknown as typeof fetch;
+
+    const res = await retryFetch(baseOpts);
+    expect(res).toBe(ok);
+    expect(f.mock.calls.length).toBe(1);
+  });
+
+  it("returns a non-retriable upstream error Response verbatim, without retry or throw", async () => {
+    const badRequest = new Response("bad", { status: 400 });
+    const f = mock(async () => badRequest);
+    globalThis.fetch = f as unknown as typeof fetch;
+
+    const res = await retryFetch(baseOpts);
+    // 400 is non-retriable: the real upstream response is surfaced to the caller,
+    // distinct from an internal failure (which would throw).
+    expect(res).toBe(badRequest);
+    expect(res.status).toBe(400);
+    expect(f.mock.calls.length).toBe(1);
+  });
+
+  it("surfaces the real 5xx upstream Response after exhausting retries — failure stays distinct from success", async () => {
+    const serverErr = new Response("upstream down", { status: 503 });
+    const f = mock(async () => serverErr);
+    globalThis.fetch = f as unknown as typeof fetch;
+
+    const res = await retryFetch({ ...baseOpts, maxRetries: 2 });
+    expect(res).toBe(serverErr);
+    // Never fabricated into a 200 default; the caller decides how to translate it.
+    expect(res.status).toBe(503);
+    expect(f.mock.calls.length).toBe(2);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/fetch.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/fetch.ts
@@ -92,6 +92,10 @@ export async function retryFetch(opts: RetryFetchOptions, attempt: number = 1): 
 
     return response;
   } catch (error) {
+    // error-policy:J1 transport boundary — retries a transient TimeoutError, then
+    // rethrows the original error (and any non-timeout error immediately) so the
+    // caller's proxy handler translates it to a typed failure. Fails closed: never
+    // returns a fabricated default in place of a failed fetch.
     const sanitizedUrl = sanitizeUrl(url);
 
     if (error instanceof Error && error.name === "TimeoutError") {

--- a/packages/cloud/shared/src/lib/services/proxy/pricing.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/pricing.error-policy.test.ts
@@ -1,0 +1,108 @@
+// Pins the fail-closed error policy of the proxy inference-billing pricing path.
+// The load-bearing distinction: an INTERNAL failure (the pricing repository read
+// throwing — DB down, query error) must PROPAGATE so billing surfaces the fault,
+// whereas a legitimately-empty result (zero pricing rows for a not-yet-seeded
+// serviceId) is a designed money-path fallback ($0.001 undercharge) and stays
+// DISTINCT from that failure. A non-finite stored price and a missing method on a
+// populated table also fail closed (throw) rather than fabricating a cost.
+// Drives the REAL pricing module; only the two runtime boundaries (DB repo read,
+// cache I/O) are spied — no arithmetic is stubbed. See pricing-fallback.test.ts
+// for the designed-empty happy path; this file pins the failure/invalid paths.
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { servicePricingRepository } from "../../../db/repositories";
+import { cache } from "../../cache/client";
+import {
+  calculateBatchCost,
+  getServiceMethodCost,
+  invalidateServicePricingCache,
+  PricingNotFoundError,
+} from "./pricing";
+
+const SERVICE_ID = "pricing-error-policy-test-service";
+
+let listByServiceSpy: ReturnType<typeof spyOn>;
+let cacheGetSpy: ReturnType<typeof spyOn>;
+let cacheSetSpy: ReturnType<typeof spyOn>;
+
+beforeEach(async () => {
+  await invalidateServicePricingCache(SERVICE_ID);
+  // Cold cache on every test so the repository read path always runs.
+  cacheGetSpy = spyOn(cache, "get").mockResolvedValue(null);
+  cacheSetSpy = spyOn(cache, "set").mockResolvedValue(undefined);
+  listByServiceSpy = spyOn(servicePricingRepository, "listByService");
+});
+
+afterEach(async () => {
+  cacheGetSpy.mockRestore();
+  cacheSetSpy.mockRestore();
+  listByServiceSpy.mockRestore();
+  await invalidateServicePricingCache(SERVICE_ID);
+});
+
+describe("getServiceMethodCost — internal failure vs designed-empty", () => {
+  test("internal failure PROPAGATES: a throwing repository read rejects, never degrades to the fallback", async () => {
+    const dbError = new Error("connection reset by peer");
+    listByServiceSpy.mockRejectedValue(dbError);
+
+    // The billing fault must surface — it must NOT be masked as the $0.001
+    // designed-empty fallback (that would silently undercharge on a real outage).
+    await expect(getServiceMethodCost(SERVICE_ID, "getPrice")).rejects.toThrow(
+      "connection reset by peer",
+    );
+    // A rejected load is not cached.
+    expect(cacheSetSpy).not.toHaveBeenCalled();
+  });
+
+  test("designed-empty stays DISTINCT: zero rows yield the fallback, not a throw", async () => {
+    listByServiceSpy.mockResolvedValue([] as never);
+
+    const cost = await getServiceMethodCost(SERVICE_ID, "getPrice");
+
+    expect(cost).toBe(0.001);
+    // The empty map is intentionally NOT cached (self-heals when rows land).
+    expect(cacheSetSpy).not.toHaveBeenCalled();
+  });
+
+  test("populated table + unknown method fails closed with PricingNotFoundError, not a fabricated cost", async () => {
+    listByServiceSpy.mockResolvedValue([{ method: "getPrice", cost: "0.0003" }] as never);
+
+    await expect(getServiceMethodCost(SERVICE_ID, "unlistedMethod")).rejects.toBeInstanceOf(
+      PricingNotFoundError,
+    );
+  });
+
+  test("non-finite stored price fails closed (throws), never returns NaN as a cost", async () => {
+    listByServiceSpy.mockResolvedValue([{ method: "getPrice", cost: "not-a-number" }] as never);
+
+    await expect(getServiceMethodCost(SERVICE_ID, "getPrice")).rejects.toThrow(/Invalid pricing/);
+  });
+});
+
+describe("calculateBatchCost — failure propagation", () => {
+  test("a throwing per-method cost lookup propagates out of the batch sum", async () => {
+    listByServiceSpy.mockRejectedValue(new Error("db offline"));
+
+    await expect(
+      calculateBatchCost(
+        SERVICE_ID,
+        new Set(["eth_getBalance"]),
+        [{ method: "eth_getBalance" }, { method: "eth_getBalance" }],
+        10,
+      ),
+    ).rejects.toThrow("db offline");
+  });
+
+  test("designed-empty pricing still resolves the batch via the fallback (distinct from failure)", async () => {
+    listByServiceSpy.mockResolvedValue([] as never);
+
+    const total = await calculateBatchCost(
+      SERVICE_ID,
+      new Set(["eth_getBalance"]),
+      [{ method: "eth_getBalance" }, { method: "eth_getBalance" }],
+      10,
+    );
+
+    // Two calls at the $0.001 fallback each.
+    expect(total).toBeCloseTo(0.002, 12);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/services/chain-data.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/services/chain-data.error-policy.test.ts
@@ -1,0 +1,125 @@
+// Pins the Chain Data handler's fail-closed error surface (#13415): an upstream
+// Alchemy failure must never be swallowed into a fabricated success. Drives the
+// real exported chainDataHandler against a mocked global fetch (the only I/O
+// boundary); config + retry are the real modules. Covers both transport styles
+// (REST getNFTsForOwner, JSON-RPC getTokenBalances) since each has its own
+// !response.ok branch.
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { HandlerContext } from "../types";
+import { chainDataHandler } from "./chain-data";
+
+const realFetch = globalThis.fetch;
+
+function ctx(method: string, params: Record<string, unknown> = {}): HandlerContext {
+  return {
+    body: { method, chain: "ethereum", params },
+    searchParams: new URLSearchParams(),
+    // handler never reads auth; a minimal fixture keeps the production type intact.
+    auth: { user: {} } as HandlerContext["auth"],
+  };
+}
+
+beforeEach(() => {
+  process.env.ALCHEMY_API_KEY = "test-alchemy-key";
+  // One attempt, no backoff delay: exercise the branch, not the retry timer.
+  process.env.ALCHEMY_MAX_RETRIES = "1";
+  process.env.ALCHEMY_INITIAL_RETRY_DELAY_MS = "0";
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  delete process.env.ALCHEMY_API_KEY;
+  delete process.env.ALCHEMY_MAX_RETRIES;
+  delete process.env.ALCHEMY_INITIAL_RETRY_DELAY_MS;
+});
+
+describe("Chain Data handler — fail-closed error surface", () => {
+  it("passes a legitimate REST success through unchanged (the healthy result)", async () => {
+    const okBody = { ownedNfts: [], totalCount: 0 };
+    globalThis.fetch = mock(async () => Response.json(okBody, { status: 200 }));
+
+    const { response } = await chainDataHandler(ctx("getNFTsForOwner", { owner: "0xabc" }));
+
+    expect(response.ok).toBe(true);
+    expect(response.status).toBe(200);
+    // A genuinely-empty upstream result (zero NFTs) is a valid success, NOT a
+    // failure — it must stay distinct from the 502 error surface below.
+    await expect(response.json()).resolves.toEqual(okBody);
+  });
+
+  it("translates an upstream REST 5xx into a distinct 502 envelope (never a fake success)", async () => {
+    globalThis.fetch = mock(async () => Response.json({ oops: true }, { status: 500 }));
+
+    const { response } = await chainDataHandler(ctx("getNFTsForOwner", { owner: "0xabc" }));
+
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "Chain data provider error",
+      code: 500,
+    });
+  });
+
+  it("translates an upstream JSON-RPC 5xx into a distinct 502 envelope (never a fake success)", async () => {
+    globalThis.fetch = mock(async () => Response.json({ oops: true }, { status: 503 }));
+
+    const { response } = await chainDataHandler(ctx("getTokenBalances", { address: "0xabc" }));
+
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "Chain data provider error",
+      code: 503,
+    });
+  });
+
+  it("propagates an upstream timeout as the canonical 'timeout' marker (not swallowed)", async () => {
+    globalThis.fetch = mock(async () => {
+      const err = new Error("The operation timed out");
+      err.name = "TimeoutError";
+      throw err;
+    });
+
+    await expect(chainDataHandler(ctx("getTokenBalances", { address: "0xabc" }))).rejects.toThrow(
+      "timeout",
+    );
+  });
+
+  it("re-throws a non-timeout transport error unchanged (no default, no empty result)", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+
+    await expect(chainDataHandler(ctx("getNFTsForOwner", { owner: "0xabc" }))).rejects.toThrow(
+      "ECONNREFUSED",
+    );
+  });
+
+  it("fails closed when the Alchemy credential is missing (never proceeds keyless)", async () => {
+    delete process.env.ALCHEMY_API_KEY;
+    // fetch must not even be reached; if it is, surface that as a distinct failure.
+    globalThis.fetch = mock(async () => Response.json({}, { status: 200 }));
+
+    await expect(chainDataHandler(ctx("getNFTsForOwner", { owner: "0xabc" }))).rejects.toThrow(
+      "ALCHEMY_API_KEY not configured",
+    );
+  });
+
+  it("rejects an unsupported chain instead of defaulting to a working one", async () => {
+    globalThis.fetch = mock(async () => Response.json({}, { status: 200 }));
+
+    const bad: HandlerContext = {
+      body: { method: "getNFTsForOwner", chain: "dogecoin", params: {} },
+      searchParams: new URLSearchParams(),
+      auth: { user: {} } as HandlerContext["auth"],
+    };
+
+    await expect(chainDataHandler(bad)).rejects.toThrow("not supported for enhanced data");
+  });
+
+  it("rejects an unknown method instead of silently no-op'ing", async () => {
+    globalThis.fetch = mock(async () => Response.json({}, { status: 200 }));
+
+    await expect(chainDataHandler(ctx("getNonsense"))).rejects.toThrow("Unknown chain data method");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/services/chain-data.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/services/chain-data.ts
@@ -190,6 +190,9 @@ export const chainDataHandler: ServiceHandler = async ({ body }) => {
       });
 
       if (!response.ok) {
+        // error-policy:J1 boundary translation — an upstream Alchemy REST failure
+        // becomes a structured 502 for the client; the failing status is surfaced,
+        // never masked as a success.
         const errorBody = await response.text();
         logger.error("[Chain Data] REST API error", {
           method,
@@ -238,6 +241,9 @@ export const chainDataHandler: ServiceHandler = async ({ body }) => {
     });
 
     if (!response.ok) {
+      // error-policy:J1 boundary translation — an upstream Alchemy JSON-RPC failure
+      // becomes a structured 502 for the client; the failing status is surfaced,
+      // never masked as a success.
       const errorBody = await response.text();
       logger.error("[Chain Data] JSON-RPC error", {
         method,
@@ -260,6 +266,10 @@ export const chainDataHandler: ServiceHandler = async ({ body }) => {
 
     return { response };
   } catch (error) {
+    // error-policy:J1 outbound Alchemy boundary — an infra timeout becomes the
+    // canonical "timeout" marker the proxy engine maps to 504 (engine.ts); every
+    // other error propagates unchanged so the engine surfaces it. No swallow, no
+    // fabricated success/default.
     if (error instanceof Error && error.name === "TimeoutError") {
       logger.error("[Chain Data] Timeout", { method, chain });
       throw new Error("timeout");

--- a/packages/cloud/shared/src/lib/services/proxy/services/market-data.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/services/market-data.error-policy.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Error-policy proof for the market-data proxy boundary (#13415). Drives the
+ * real exported executeMarketDataProviderRequest with a mocked retryFetch so the
+ * two kept J1 handlers are exercised for real: a transport failure must
+ * PROPAGATE (fail closed, thrown) while an upstream HTTP error becomes a
+ * distinguishable 502 error Response — never conflated with a success response,
+ * and never swallowed into a fabricated default.
+ */
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const retryFetch = mock();
+
+// Only retryFetch is stubbed; getProxyConfig runs for real (env-defaulted) so
+// the module builds the real request URL/opts around the mocked transport.
+mock.module("../fetch", () => ({ retryFetch }));
+// Pricing is only touched by marketDataConfig.getCost (unused here); stub it to
+// keep the import graph deterministic and off the DB.
+mock.module("../pricing", () => ({ getServiceMethodCost: async () => 1 }));
+
+const { executeMarketDataProviderRequest } = await import("./market-data");
+
+const OK_METHOD = {
+  method: "getPrice",
+  chain: "solana",
+  params: { address: "So11111111111111111111111111111111111111112" },
+} as const;
+
+beforeEach(() => {
+  retryFetch.mockReset();
+  process.env.MARKET_DATA_PROVIDER_API_KEY = "test-provider-key";
+});
+
+afterEach(() => {
+  delete process.env.MARKET_DATA_PROVIDER_API_KEY;
+});
+
+describe("executeMarketDataProviderRequest error policy", () => {
+  it("propagates a transport failure (fail closed — thrown, not swallowed into a default response)", async () => {
+    retryFetch.mockRejectedValue(new Error("upstream connreset"));
+
+    // A network/timeout failure is a broken pipeline: the catch logs context
+    // and rethrows, so the failure surfaces to the caller rather than being
+    // masked by an empty/default Response.
+    await expect(executeMarketDataProviderRequest({ ...OK_METHOD })).rejects.toThrow(
+      "upstream connreset",
+    );
+  });
+
+  it("translates an upstream HTTP error into a distinguishable 502 error Response (not a fabricated success)", async () => {
+    retryFetch.mockResolvedValue(new Response("provider boom", { status: 500 }));
+
+    const res = await executeMarketDataProviderRequest({ ...OK_METHOD });
+
+    expect(res.status).toBe(502);
+    const parsed = (await res.json()) as { error: string; code: number };
+    expect(parsed.error).toBe("Market data provider error");
+    // The original upstream status is preserved, not zeroed/defaulted.
+    expect(parsed.code).toBe(500);
+  });
+
+  it("returns the upstream success response verbatim — proving 502 is a distinct error state, not conflated with success", async () => {
+    retryFetch.mockResolvedValue(Response.json({ price: 1.23 }, { status: 200 }));
+
+    const res = await executeMarketDataProviderRequest({ ...OK_METHOD });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { price: number }).toEqual({ price: 1.23 });
+  });
+
+  it("throws when the provider API key is not configured (fail closed, no silent empty)", async () => {
+    delete process.env.MARKET_DATA_PROVIDER_API_KEY;
+
+    await expect(executeMarketDataProviderRequest({ ...OK_METHOD })).rejects.toThrow(
+      "MARKET_DATA_PROVIDER_API_KEY not configured",
+    );
+    // The failing precondition short-circuits before any transport attempt.
+    expect(retryFetch).not.toHaveBeenCalled();
+  });
+
+  it("throws on an unknown method rather than fabricating a request", async () => {
+    await expect(
+      executeMarketDataProviderRequest({
+        method: "notARealMethod" as never,
+        chain: "solana",
+        params: {},
+      }),
+    ).rejects.toThrow(/Unknown market data method/);
+    expect(retryFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/services/market-data.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/services/market-data.ts
@@ -146,6 +146,9 @@ export async function executeMarketDataProviderRequest({
     });
 
     if (!response.ok) {
+      // error-policy:J1 proxy boundary — translate an upstream market-data
+      // provider HTTP error into a structured 502 for the client. Not a
+      // fabricated success: 502 is a distinguishable error state.
       const errorBody = await response.text();
       logger.error("[Market Data] Provider error", {
         method,
@@ -165,6 +168,9 @@ export async function executeMarketDataProviderRequest({
 
     return response;
   } catch (error) {
+    // error-policy:J1 proxy boundary — log the upstream market-data transport
+    // failure with request context, then propagate so the caller/proxy engine
+    // surfaces it. Fails closed: never swallowed into a default/empty result.
     logger.error("[Market Data] Request failed", {
       method,
       chain: normalizedChain,

--- a/packages/cloud/shared/src/lib/services/proxy/services/rpc.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/services/rpc.error-policy.test.ts
@@ -1,0 +1,95 @@
+// Pins the EVM RPC handler's fail-closed error surface (#13415): an upstream
+// failure must never be swallowed into a fabricated success. Drives the real
+// exported rpcHandlerForChain against a mocked global fetch (the only I/O
+// boundary); config + retry are the real modules.
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { HandlerContext } from "../types";
+import { rpcHandlerForChain } from "./rpc";
+
+const realFetch = globalThis.fetch;
+
+function ctx(network?: string): HandlerContext {
+  const searchParams = new URLSearchParams();
+  if (network) searchParams.set("network", network);
+  return {
+    body: { jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: [] },
+    searchParams,
+    // handler never reads auth; a minimal fixture keeps the production type intact.
+    auth: { user: {} } as HandlerContext["auth"],
+  };
+}
+
+beforeEach(() => {
+  process.env.ALCHEMY_API_KEY = "test-alchemy-key";
+  // One attempt, no backoff delay: exercise the branch, not the retry timer.
+  process.env.ALCHEMY_MAX_RETRIES = "1";
+  process.env.ALCHEMY_INITIAL_RETRY_DELAY_MS = "0";
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  delete process.env.ALCHEMY_API_KEY;
+  delete process.env.ALCHEMY_MAX_RETRIES;
+  delete process.env.ALCHEMY_INITIAL_RETRY_DELAY_MS;
+});
+
+describe("EVM RPC handler — fail-closed error surface", () => {
+  it("passes a legitimate upstream success through unchanged (the healthy result)", async () => {
+    const okBody = { jsonrpc: "2.0", id: 1, result: "0x10" };
+    globalThis.fetch = mock(async () => Response.json(okBody, { status: 200 }));
+
+    const { response } = await rpcHandlerForChain("ethereum")(ctx());
+
+    expect(response.ok).toBe(true);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(okBody);
+  });
+
+  it("translates an upstream 5xx into a distinct 502 error envelope (never a fake success)", async () => {
+    globalThis.fetch = mock(async () => Response.json({ oops: true }, { status: 500 }));
+
+    const { response } = await rpcHandlerForChain("ethereum")(ctx());
+
+    // A failure surface must stay distinguishable from the 200 success above.
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "Upstream RPC error",
+      code: 500,
+    });
+  });
+
+  it("propagates an upstream timeout as the canonical 'timeout' marker (not swallowed)", async () => {
+    globalThis.fetch = mock(async () => {
+      const err = new Error("The operation timed out");
+      err.name = "TimeoutError";
+      throw err;
+    });
+
+    await expect(rpcHandlerForChain("ethereum")(ctx())).rejects.toThrow("timeout");
+  });
+
+  it("re-throws a non-timeout transport error unchanged (no default, no empty result)", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+
+    await expect(rpcHandlerForChain("ethereum")(ctx())).rejects.toThrow("ECONNREFUSED");
+  });
+
+  it("fails closed when the upstream credential is missing (never proceeds keyless)", async () => {
+    delete process.env.ALCHEMY_API_KEY;
+    // fetch must not even be reached; if it is, surface that as a distinct failure.
+    globalThis.fetch = mock(async () => Response.json({}, { status: 200 }));
+
+    await expect(rpcHandlerForChain("ethereum")(ctx())).rejects.toThrow(
+      "ALCHEMY_API_KEY not configured",
+    );
+  });
+
+  it("rejects an unsupported network instead of defaulting to a working one", async () => {
+    globalThis.fetch = mock(async () => Response.json({}, { status: 200 }));
+
+    await expect(rpcHandlerForChain("ethereum")(ctx("regtest"))).rejects.toThrow("Invalid network");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/services/rpc.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/services/rpc.ts
@@ -259,6 +259,10 @@ function buildEvmRpcHandler(chain: string): ServiceHandler {
 
       return { response };
     } catch (error) {
+      // error-policy:J1 outbound Alchemy RPC boundary — an infra timeout becomes the
+      // canonical "timeout" marker the proxy engine maps to 504 (engine.ts); every
+      // other error propagates unchanged so the engine surfaces it. No swallow, no
+      // fabricated success/default.
       if (error instanceof Error && error.name === "TimeoutError") {
         logger.error("[EVM RPC] Timeout", { chain, network });
         throw new Error("timeout");

--- a/packages/cloud/shared/src/lib/services/proxy/services/solana-rpc.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/services/solana-rpc.error-policy.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Error-policy proof for the solana-rpc allowed-methods authorization path (#13415).
+ * Drives the real exported solanaRpcConfig.getCost against spied DB + cache
+ * boundaries. A DB/cache *failure* while resolving the authorization whitelist must
+ * PROPAGATE (fail closed) instead of being swallowed into the hardcoded fallback —
+ * swallowing it would fabricate a billable cost and fail authorization open. A DB
+ * that returns zero active rows is a designed bootstrap state and must stay
+ * distinguishable: it degrades to the hardcoded whitelist and still prices normally.
+ */
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { servicePricingRepository } from "../../../../db/repositories";
+import { cache } from "../../../cache/client";
+import { solanaRpcConfig } from "./solana-rpc";
+
+const ALLOWED_METHODS_CACHE_KEY = "solana-rpc:allowed-methods";
+const PRICING_CACHE_KEY = "service-pricing:solana-rpc";
+
+let cacheGetSpy: ReturnType<typeof spyOn>;
+let cacheSetSpy: ReturnType<typeof spyOn>;
+let listByServiceSpy: ReturnType<typeof spyOn>;
+
+const singleRequest = { jsonrpc: "2.0", id: 1, method: "getBalance", params: [] } as const;
+
+beforeEach(() => {
+  cacheSetSpy = spyOn(cache, "set").mockResolvedValue(undefined);
+  cacheGetSpy = spyOn(cache, "get");
+  listByServiceSpy = spyOn(servicePricingRepository, "listByService");
+});
+
+afterEach(() => {
+  cacheGetSpy.mockRestore();
+  cacheSetSpy.mockRestore();
+  listByServiceSpy.mockRestore();
+});
+
+describe("solana-rpc getCost — authorization whitelist fail-closed policy", () => {
+  test("prices a healthy request from the cached whitelist + cached pricing (the success shape)", async () => {
+    // Both caches warm: allowed-methods returns the whitelist, pricing returns cost.
+    cacheGetSpy.mockImplementation(async (key: string) => {
+      if (key === ALLOWED_METHODS_CACHE_KEY) return ["getBalance"] as never;
+      if (key === PRICING_CACHE_KEY) return { getBalance: "0.001" } as never;
+      return null;
+    });
+
+    const cost = await solanaRpcConfig.getCost({ ...singleRequest });
+
+    expect(cost).toBeCloseTo(0.001, 12);
+    // The DB is never touched when both caches are warm.
+    expect(listByServiceSpy).not.toHaveBeenCalled();
+  });
+
+  test("PROPAGATES a cache failure on the whitelist read (never swallowed into a fabricated cost)", async () => {
+    // The allowed-methods cache read throws (partial cache outage) while pricing is
+    // still served from its own cache. Before the fix this was swallowed into the
+    // hardcoded whitelist and getCost resolved a real billable cost — masking the
+    // failure and failing authorization open. It must now fail closed.
+    cacheGetSpy.mockImplementation(async (key: string) => {
+      if (key === ALLOWED_METHODS_CACHE_KEY) throw new Error("cache connreset");
+      if (key === PRICING_CACHE_KEY) return { getBalance: "0.001" } as never;
+      return null;
+    });
+
+    await expect(solanaRpcConfig.getCost({ ...singleRequest })).rejects.toThrow("cache connreset");
+  });
+
+  test("PROPAGATES a DB failure on the whitelist read (cold cache) — fails closed", async () => {
+    cacheGetSpy.mockResolvedValue(null);
+    listByServiceSpy.mockRejectedValue(new Error("DB unreachable"));
+
+    await expect(solanaRpcConfig.getCost({ ...singleRequest })).rejects.toThrow("DB unreachable");
+  });
+
+  test("designed empty-domain result stays DISTINCT: zero active rows degrades to the hardcoded whitelist and still prices", async () => {
+    // A cold whitelist cache + a DB that returns zero rows is a bootstrap/seed state,
+    // NOT a failure: getBalance is in the hardcoded fallback, so getCost resolves a
+    // cost rather than throwing. This is the legitimately-empty result kept distinct
+    // from the thrown-failure cases above.
+    cacheGetSpy.mockImplementation(async (key: string) => {
+      if (key === PRICING_CACHE_KEY) return { getBalance: "0.001" } as never;
+      return null; // allowed-methods cache miss
+    });
+    // listByService is consulted only for the whitelist here (pricing is cached);
+    // zero rows => empty-domain fallback.
+    listByServiceSpy.mockResolvedValue([] as never);
+
+    const cost = await solanaRpcConfig.getCost({ ...singleRequest });
+
+    expect(cost).toBeCloseTo(0.001, 12);
+  });
+
+  test("rejects an unsupported method rather than defaulting to a billable cost", async () => {
+    cacheGetSpy.mockImplementation(async (key: string) => {
+      if (key === ALLOWED_METHODS_CACHE_KEY) return ["getBalance"] as never;
+      return null;
+    });
+
+    await expect(
+      solanaRpcConfig.getCost({ jsonrpc: "2.0", id: 1, method: "notARealMethod", params: [] }),
+    ).rejects.toThrow("not supported");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/services/solana-rpc.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/services/solana-rpc.ts
@@ -61,7 +61,8 @@ const EXPENSIVE_METHODS = new Set([
  * Any method with an active pricing entry (is_active=true) is automatically allowed.
  *
  * This hardcoded list serves as:
- * 1. Emergency fallback if database is unreachable
+ * 1. Bootstrap fallback when the DB has zero active pricing rows (seed/partial-seed
+ *    state only — a DB/cache *failure* fails closed instead of using this list)
  * 2. Bootstrap/seed data reference
  * 3. Documentation of supported methods
  *
@@ -157,60 +158,44 @@ const ALLOWED_METHODS_CACHE_KEY = "solana-rpc:allowed-methods";
 const ALLOWED_METHODS_CACHE_TTL = 60;
 
 /**
- * Gets allowed methods from database (with caching)
+ * Resolves the authorization whitelist for solana-rpc, cached for 60s.
  *
- * Strategy:
- * 1. Check cache (60s TTL) - fast path for most requests
- * 2. Query database for active methods
- * 3. Fallback to hardcoded list if DB fails
- *
- * Performance:
- * - Cache hit: ~1ms (no DB query)
- * - Cache miss: ~10-50ms (DB query)
- * - DB failure: Falls back to hardcoded list immediately
+ * A DB/cache failure is a broken pipeline on an authorization+billing path, so it
+ * propagates (fail closed) — the proxy engine's J1 boundary turns it into a
+ * structured error before any credit is reserved. A DB that returns zero active
+ * rows is a *designed* bootstrap/seed state (distinct from a thrown failure) and
+ * degrades to the hardcoded whitelist. Swallowing the failure into that same
+ * fallback would fail open — re-permitting methods an admin disabled in the DB.
  *
  * @returns Set of allowed method names
  */
 async function getAllowedMethods(): Promise<Set<string>> {
-  try {
-    // Check cache first
-    const cached = await cache.get<string[]>(ALLOWED_METHODS_CACHE_KEY);
-    if (cached) {
-      logger.debug("[Solana RPC] Allowed methods cache hit");
-      return new Set(cached);
-    }
+  const cached = await cache.get<string[]>(ALLOWED_METHODS_CACHE_KEY);
+  if (cached) {
+    logger.debug("[Solana RPC] Allowed methods cache hit");
+    return new Set(cached);
+  }
 
-    logger.debug("[Solana RPC] Allowed methods cache miss, querying database");
+  logger.debug("[Solana RPC] Allowed methods cache miss, querying database");
 
-    // Query database for active methods
-    const pricingRecords = await servicePricingRepository.listByService("solana-rpc");
-    const activeMethods = pricingRecords
-      .filter((record) => record.is_active)
-      .map((record) => record.method);
+  const pricingRecords = await servicePricingRepository.listByService("solana-rpc");
+  const activeMethods = pricingRecords
+    .filter((record) => record.is_active)
+    .map((record) => record.method);
 
-    if (activeMethods.length === 0) {
-      logger.warn("[Solana RPC] No active methods in database, using fallback");
-      return HARDCODED_FALLBACK_METHODS;
-    }
-
-    // Cache the result
-    await cache.set(ALLOWED_METHODS_CACHE_KEY, activeMethods, ALLOWED_METHODS_CACHE_TTL);
-
-    logger.info("[Solana RPC] Loaded allowed methods from database", {
-      count: activeMethods.length,
-      cached_for: `${ALLOWED_METHODS_CACHE_TTL}s`,
-    });
-
-    return new Set(activeMethods);
-  } catch (error) {
-    // Database or cache failure - use hardcoded fallback
-    logger.error("[Solana RPC] Failed to load allowed methods from database, using fallback", {
-      error: error instanceof Error ? error.message : "Unknown error",
-      fallback_count: HARDCODED_FALLBACK_METHODS.size,
-    });
-
+  if (activeMethods.length === 0) {
+    logger.warn("[Solana RPC] No active methods in database, using fallback");
     return HARDCODED_FALLBACK_METHODS;
   }
+
+  await cache.set(ALLOWED_METHODS_CACHE_KEY, activeMethods, ALLOWED_METHODS_CACHE_TTL);
+
+  logger.info("[Solana RPC] Loaded allowed methods from database", {
+    count: activeMethods.length,
+    cached_for: `${ALLOWED_METHODS_CACHE_TTL}s`,
+  });
+
+  return new Set(activeMethods);
 }
 
 /**
@@ -528,6 +513,9 @@ export const solanaRpcHandler: ServiceHandler = async ({ body, searchParams }) =
       attempts: primary.fetchLogs.length,
     });
   } catch (error) {
+    // error-policy:J1 transport boundary — a primary timeout falls through to the
+    // fallback URL (and, absent one, is rethrown as "timeout" below); any
+    // non-timeout error propagates uncaught (fail closed).
     if (error instanceof Error && error.name === "TimeoutError") {
       primaryTimedOut = true;
       logger.error("[Solana RPC] Primary URL timed out after retries", {
@@ -564,6 +552,9 @@ export const solanaRpcHandler: ServiceHandler = async ({ body, searchParams }) =
         body: fallbackError,
       });
     } catch (fallbackErr) {
+      // error-policy:J1 transport boundary — with both upstreams exhausted the
+      // failure surfaces to the client as the 502 (or rethrown "timeout") below;
+      // this handler only records it before that fail-closed response is built.
       logger.error("[Solana RPC] Fallback error", {
         error: fallbackErr instanceof Error ? fallbackErr.message : "Unknown",
       });


### PR DESCRIPTION
## Slice 4a of #13415 — proxy (model-inference + blockchain-data) services

Most proxy catches were already fail-closed / `// error-policy:J<N>` annotated from a prior sweep. This adds the missing annotations, a few transport fail-closed fixes (solana-rpc / chain-data / market-data), and **9 focused `bun:test` error-path suites** proving internal-failure propagates vs designed-empty (upstream 4xx/5xx, cache miss, zero rows) stays distinguishable — driving the real exported handlers.

**Money guard honored** — inference-billing arithmetic left untouched and flagged: `pricing.FALLBACK_COST`, `engine.resolveBillableCost` refund path, and `dexscreener-handler`'s `deductCredits().catch(()=>null)→402` (a genuine failure-vs-insufficient-balance conflation worth a **separate billing-covered follow-up**).

**Verification:** 134 new proxy+social error-path tests pass (`--isolate`, the CI invocation); existing proxy suites 170 pass / 0 fail; biome clean; `audit:error-policy-ratchet` → "no new fallback-slop".