### PR TITLE
fix(cloud-shared): fail-closed social-media connector sweep (#13415 slice 4b)

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/index.credential-refresh.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/index.credential-refresh.error-policy.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Fail-closed pin for `socialMediaService.getCredentialsForPlatform`'s
+ * token-refresh boundary (#13415, J1 at index.ts:144-168). Complements
+ * `index.error-policy.test.ts` (analytics read paths) by covering the one
+ * load-bearing fail-closed branch it does not: when a stored OAuth token needs
+ * refresh and the outbound refresh FAILS, credential resolution must THROW
+ * "Token expired." (surfacing the failure so the caller refunds and the user
+ * reconnects) — it must NEVER swallow the failure into stale/`null` creds.
+ *
+ * The distinct, legitimately-empty case (a provider that is simply not
+ * configured — no DB row and no env secrets) must stay a `null` return, not a
+ * throw. Failure != designed-empty.
+ *
+ * Drives the real exported method; the DB client, secrets service, and
+ * token-refresh module are mocked so the branch runs without infrastructure.
+ * Each mock reads a mutable module-level config so tests stay isolated.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+interface CredentialRow {
+  id: string;
+  organization_id: string;
+  platform: string;
+  status: string;
+  api_key_secret_id: string | null;
+  access_token_secret_id: string | null;
+  refresh_token_secret_id: string | null;
+  token_expires_at: Date | null;
+  platform_username: string | null;
+  platform_user_id: string | null;
+  source_context: unknown;
+}
+
+// Mutable per-test config the mocks read. Reset in beforeEach.
+let dbRows: CredentialRow[] = [];
+let decryptedValue: string | null = null;
+let envSecret: string | null = null;
+let refreshNeeded = false;
+let refreshThrows = false;
+
+// Spread the real module so sibling exports (getDbConnectionInfo, withReadDb, …)
+// stay present for other importers; override only the two lazy query Proxies so
+// no real connection is ever opened.
+const realDbClient = await import("../../../db/client");
+mock.module("../../../db/client", () => ({
+  ...realDbClient,
+  dbRead: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => dbRows,
+        }),
+      }),
+    }),
+  },
+  dbWrite: {
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+  },
+}));
+
+mock.module("../secrets", () => ({
+  secretsService: {
+    getDecryptedValue: async () => decryptedValue,
+    get: async () => envSecret,
+    create: async () => "new-secret-id",
+  },
+}));
+
+mock.module("./token-refresh", () => ({
+  needsRefresh: () => refreshNeeded,
+  isTokenExpired: () => refreshNeeded,
+  refreshToken: async () => {
+    if (refreshThrows) throw new Error("Twitter token refresh failed: missing access token");
+    return { accessToken: "fresh", refreshToken: "fresh-refresh" };
+  },
+  getRefreshGuidance: () => "Please reconnect your account.",
+}));
+
+mock.module("./alerts", () => ({ alertOnPostFailure: async () => {} }));
+
+const { socialMediaService } = await import("./index");
+
+const ORG_ID = "00000000-0000-4000-8000-00000000c001";
+
+function activeOAuthRow(): CredentialRow {
+  return {
+    id: "cred-1",
+    organization_id: ORG_ID,
+    platform: "twitter",
+    status: "active",
+    api_key_secret_id: null,
+    access_token_secret_id: "acc-secret",
+    refresh_token_secret_id: "ref-secret",
+    token_expires_at: new Date(Date.now() - 60_000),
+    platform_username: "tester",
+    platform_user_id: "uid-1",
+    source_context: null,
+  };
+}
+
+beforeEach(() => {
+  dbRows = [];
+  decryptedValue = null;
+  envSecret = null;
+  refreshNeeded = false;
+  refreshThrows = false;
+});
+
+afterEach(() => {
+  dbRows = [];
+});
+
+describe("getCredentialsForPlatform — refresh failure fails closed (#13415)", () => {
+  test("THROWS 'Token expired' when a needed refresh fails (failure never becomes null/stale)", async () => {
+    dbRows = [activeOAuthRow()];
+    decryptedValue = "stale-access-token";
+    refreshNeeded = true;
+    refreshThrows = true;
+
+    // The outbound refresh failure is caught (J1) and normalized to null, then
+    // the !refreshed branch rethrows a typed guidance error. It must surface as
+    // a throw — returning the stale token here would post with a dead credential.
+    await expect(socialMediaService.getCredentialsForPlatform(ORG_ID, "twitter")).rejects.toThrow(
+      /Token expired\. Please reconnect your account\./,
+    );
+  });
+
+  test("returns refreshed credentials (not stale) when the refresh succeeds", async () => {
+    dbRows = [activeOAuthRow()];
+    decryptedValue = "stale-access-token";
+    refreshNeeded = true;
+    refreshThrows = false;
+
+    const creds = await socialMediaService.getCredentialsForPlatform(ORG_ID, "twitter");
+    expect(creds).not.toBeNull();
+    // A successful refresh must swap in the new token, never keep the stale one.
+    expect(creds?.accessToken).toBe("fresh");
+  });
+
+  test("not-configured provider returns null (designed-empty stays distinct from failure)", async () => {
+    // No DB credential row and no env secret: a legitimately unconfigured
+    // provider is an empty domain result, NOT an internal failure — so this
+    // path returns null, unlike the throwing refresh-failure above.
+    dbRows = [];
+    envSecret = null;
+
+    const creds = await socialMediaService.getCredentialsForPlatform(ORG_ID, "twitter");
+    expect(creds).toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/index.error-policy.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Error-policy pins for the social-media read paths (#13415): a legitimately
+ * unsupported capability (a designed-empty domain result) must stay
+ * distinguishable from an internal failure. `getPostAnalytics` /
+ * `getAccountAnalytics` return `null` ONLY when the provider does not implement
+ * analytics (e.g. Discord); a missing-credentials failure THROWS, and a provider
+ * that throws propagates rather than being swallowed into a fake-empty result.
+ *
+ * Drives the real exported `socialMediaService`; `getCredentialsForPlatform` and
+ * provider methods are spied per the sibling credit-refund test's idiom.
+ */
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+// Alert fan-out is env-gated fire-and-forget; stub so the read paths never touch the network.
+mock.module("./alerts", () => ({
+  alertOnPostFailure: async () => {},
+}));
+
+const { socialMediaService } = await import("./index");
+const { twitterProvider } = await import("./providers/twitter");
+
+const ORG_ID = "00000000-0000-4000-8000-00000000b001";
+
+const spies: Array<{ mockRestore: () => void }> = [];
+afterEach(() => {
+  while (spies.length > 0) spies.pop()?.mockRestore();
+});
+
+describe("analytics read paths — designed-empty stays distinct from failure (#13415)", () => {
+  test("unsupported provider returns null WITHOUT resolving credentials (designed-empty)", async () => {
+    // Discord implements neither analytics method. If the null short-circuit ever
+    // regressed to fall through to credential resolution, this spy would fire.
+    const credsSpy = spyOn(socialMediaService, "getCredentialsForPlatform");
+    spies.push(credsSpy);
+
+    const post = await socialMediaService.getPostAnalytics({
+      organizationId: ORG_ID,
+      platform: "discord",
+      postId: "post-1",
+    });
+    const account = await socialMediaService.getAccountAnalytics({
+      organizationId: ORG_ID,
+      platform: "discord",
+    });
+
+    expect(post).toBeNull();
+    expect(account).toBeNull();
+    // Designed-empty is decided before any credential I/O.
+    expect(credsSpy).not.toHaveBeenCalled();
+  });
+
+  test("missing credentials on a supported provider THROWS (failure != empty)", async () => {
+    const credsSpy = spyOn(socialMediaService, "getCredentialsForPlatform").mockImplementation(
+      async () => null,
+    );
+    spies.push(credsSpy);
+
+    // A null from an analytics-capable platform is an internal failure (no creds),
+    // NOT a designed-empty result — it must surface as a throw, never a null.
+    await expect(
+      socialMediaService.getPostAnalytics({
+        organizationId: ORG_ID,
+        platform: "twitter",
+        postId: "post-1",
+      }),
+    ).rejects.toThrow(/No credentials found for twitter/);
+
+    await expect(
+      socialMediaService.getAccountAnalytics({ organizationId: ORG_ID, platform: "twitter" }),
+    ).rejects.toThrow(/No credentials found for twitter/);
+  });
+
+  test("provider analytics failure PROPAGATES (not swallowed into null)", async () => {
+    const credsSpy = spyOn(socialMediaService, "getCredentialsForPlatform").mockImplementation(
+      async () => ({ platform: "twitter" as const, accessToken: "tok" }),
+    );
+    const analyticsSpy = spyOn(twitterProvider, "getPostAnalytics").mockImplementation(async () => {
+      throw new Error("Twitter API 503: analytics unavailable");
+    });
+    spies.push(credsSpy, analyticsSpy);
+
+    await expect(
+      socialMediaService.getPostAnalytics({
+        organizationId: ORG_ID,
+        platform: "twitter",
+        postId: "post-1",
+      }),
+    ).rejects.toThrow(/analytics unavailable/);
+  });
+
+  test("missing postId is rejected as invalid input, not treated as empty", async () => {
+    await expect(
+      socialMediaService.getPostAnalytics({
+        organizationId: ORG_ID,
+        platform: "twitter",
+        postId: "",
+      }),
+    ).rejects.toThrow(/postId is required/);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/index.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/index.ts
@@ -143,6 +143,8 @@ class SocialMediaService {
     // Auto-refresh if token is expired
     if (needsRefresh(credentials)) {
       const refreshed = await refreshToken(platform, credentials).catch((err) => {
+        // error-policy:J1 outbound OAuth token-refresh failure is normalized to null; the
+        // !refreshed branch below rethrows a typed "Token expired" guidance error (fail-closed).
         logger.warn(`[SocialMedia] Token refresh failed for ${platform}: ${err.message}`);
         return null;
       });
@@ -154,6 +156,9 @@ class SocialMediaService {
           refreshToken: refreshed.refreshToken,
         };
         this.updateStoredToken(organizationId, credential.id, refreshed).catch((err) => {
+          // error-policy:J6 best-effort cache of the refreshed access token; a persist failure
+          // only forces a re-refresh next call (the DB refresh token is untouched) and must not
+          // block returning the valid in-hand credentials for this request.
           logger.error(`[SocialMedia] Failed to persist refreshed token: ${err.message}`);
         });
         logger.info(`[SocialMedia] Token refreshed for ${platform}`);
@@ -362,6 +367,9 @@ class SocialMediaService {
 
           return await provider.createPost(credentials, content, platformOptions);
         } catch (error) {
+          // error-policy:J1 per-platform boundary: a thrown credential/provider error becomes a
+          // settled {success:false} so the refund + alert below run, instead of rejecting the
+          // whole Promise.all (which would skip the refund and charge the user for nothing).
           const errorMessage = extractErrorMessage(error);
           logger.error("[SocialMedia] Post failed", {
             platform,
@@ -388,6 +396,8 @@ class SocialMediaService {
         failed.map((f) => f.platform),
         failed.map((f) => f.error || "Unknown error"),
       ).catch((err) => {
+        // error-policy:J7 best-effort failure alert; a notification error must not corrupt the
+        // already-computed post result the caller is about to receive.
         logger.error(`[SocialMedia] Failed to send alert: ${err.message}`);
       });
     }
@@ -525,6 +535,8 @@ class SocialMediaService {
     try {
       result = await provider.replyToPost(credentials, postId, content, options);
     } catch (error) {
+      // error-policy:J1 boundary: a thrown provider error becomes {success:false} so the refund
+      // below runs; otherwise the user is charged for a reply that never posted.
       const errorMessage = extractErrorMessage(error);
       logger.error("[SocialMedia] Reply failed", {
         platform,

--- a/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.error-policy.test.ts
@@ -1,0 +1,129 @@
+// Pins the fail-closed error policy of the Bluesky provider's analytics readers: an
+// internal fetch failure while retrieving post/account analytics must propagate (throw),
+// while the designed "analytics unavailable for an unconfigured account" result stays a
+// distinct `null`. Deterministic fetch fixtures drive the real exported provider; no live
+// network. Backoff sleeps are collapsed so a retrying failure rejects promptly.
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+mock.module("../../../utils/logger", () => ({
+  logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
+}));
+
+const { blueskyProvider } = await import("./bluesky");
+
+const realFetch = globalThis.fetch;
+const realSetTimeout = globalThis.setTimeout;
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const VALID_SESSION = {
+  did: "did:plc:abc123",
+  handle: "alice.bsky.social",
+  accessJwt: "access-jwt",
+  refreshJwt: "refresh-jwt",
+};
+
+const CREDS = { handle: "alice.bsky.social", appPassword: "app-pass" } as never;
+const NO_CREDS = {} as never;
+
+function urlOf(input: unknown): string {
+  if (typeof input === "string") return input;
+  if (input instanceof Request) return input.url;
+  return String(input);
+}
+
+beforeEach(() => {
+  // Collapse rate-limit / retry backoff sleeps so a failing request rejects without
+  // waiting out the real exponential-backoff delays.
+  (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout = ((fn: () => void) => {
+    fn();
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  globalThis.setTimeout = realSetTimeout;
+});
+
+describe("blueskyProvider analytics error policy", () => {
+  it("getPostAnalytics returns null (designed 'not configured') without any fetch when credentials are absent", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls++;
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    const result = await blueskyProvider.getPostAnalytics?.(
+      NO_CREDS,
+      "at://did/app.bsky.feed.post/1",
+    );
+
+    expect(result).toBeNull();
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("getPostAnalytics propagates an internal fetch failure instead of masking it as null", async () => {
+    globalThis.fetch = mock(async (input: unknown) => {
+      const url = urlOf(input);
+      if (url.includes("createSession")) return jsonResponse(VALID_SESSION);
+      if (url.includes("getPostThread")) {
+        return jsonResponse({ error: "InternalServerError", message: "boom" }, { status: 500 });
+      }
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    await expect(
+      blueskyProvider.getPostAnalytics?.(CREDS, "at://did/app.bsky.feed.post/1"),
+    ).rejects.toThrow();
+  });
+
+  it("getPostAnalytics returns real metrics on success (drives the real reader, not a tautology)", async () => {
+    globalThis.fetch = mock(async (input: unknown) => {
+      const url = urlOf(input);
+      if (url.includes("createSession")) return jsonResponse(VALID_SESSION);
+      if (url.includes("getPostThread")) {
+        return jsonResponse({ post: { likeCount: 5, repostCount: 2, replyCount: 1 } });
+      }
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    const result = await blueskyProvider.getPostAnalytics?.(CREDS, "at://did/app.bsky.feed.post/1");
+
+    expect(result).not.toBeNull();
+    expect(result?.platform).toBe("bluesky");
+    expect(result?.metrics.likes).toBe(5);
+    expect(result?.metrics.reposts).toBe(2);
+    expect(result?.metrics.comments).toBe(1);
+  });
+
+  it("getAccountAnalytics returns null (designed 'not configured') without any fetch when credentials are absent", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls++;
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    const result = await blueskyProvider.getAccountAnalytics?.(NO_CREDS);
+
+    expect(result).toBeNull();
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("getAccountAnalytics propagates an internal fetch failure instead of masking it as null", async () => {
+    globalThis.fetch = mock(async (input: unknown) => {
+      const url = urlOf(input);
+      if (url.includes("createSession")) return jsonResponse(VALID_SESSION);
+      if (url.includes("getProfile"))
+        return jsonResponse({ error: "Boom", message: "profile down" });
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    await expect(blueskyProvider.getAccountAnalytics?.(CREDS)).rejects.toThrow();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts
@@ -178,6 +178,8 @@ export const blueskyProvider: SocialMediaProvider = {
         avatarUrl: profile.data?.avatar,
       };
     } catch (error) {
+      // error-policy:J1 boundary translation of the Bluesky auth call into the typed
+      // invalid-credentials result the caller renders; a failure, not a fabricated success.
       return {
         valid: false,
         error: extractErrorMessage(error),
@@ -299,6 +301,8 @@ export const blueskyProvider: SocialMediaProvider = {
         metadata: { cid: response.cid },
       };
     } catch (error) {
+      // error-policy:J1 boundary translation of the Bluesky post call into the typed
+      // PostResult failure the caller renders; a failure, not a fabricated success.
       logger.error("[Bluesky] Post failed", { error });
       return {
         platform: "bluesky",
@@ -330,6 +334,8 @@ export const blueskyProvider: SocialMediaProvider = {
 
       return { success: true };
     } catch (error) {
+      // error-policy:J1 boundary translation of the Bluesky delete call into the typed
+      // failure result the caller renders; a failure, not a fabricated success.
       return {
         success: false,
         error: extractErrorMessage(error),
@@ -341,62 +347,58 @@ export const blueskyProvider: SocialMediaProvider = {
     credentials: SocialCredentials,
     postId: string,
   ): Promise<PostAnalytics | null> {
+    // `null` is the designed "analytics unavailable for an unconfigured account" signal;
+    // a real session/fetch failure must propagate, not be masked as that empty state.
     if (!credentials.handle || !credentials.appPassword) {
       return null;
     }
 
-    try {
-      const session = await createSession(credentials.handle, credentials.appPassword);
+    const session = await createSession(credentials.handle, credentials.appPassword);
 
-      const response = await bskyApiRequest<{
-        post: {
-          likeCount: number;
-          repostCount: number;
-          replyCount: number;
-        };
-      }>(`app.bsky.feed.getPostThread?uri=${encodeURIComponent(postId)}`, session.accessJwt);
-
-      return {
-        platform: "bluesky",
-        postId,
-        metrics: {
-          likes: response.post.likeCount,
-          reposts: response.post.repostCount,
-          comments: response.post.replyCount,
-        },
-        fetchedAt: new Date(),
+    const response = await bskyApiRequest<{
+      post: {
+        likeCount: number;
+        repostCount: number;
+        replyCount: number;
       };
-    } catch {
-      return null;
-    }
+    }>(`app.bsky.feed.getPostThread?uri=${encodeURIComponent(postId)}`, session.accessJwt);
+
+    return {
+      platform: "bluesky",
+      postId,
+      metrics: {
+        likes: response.post.likeCount,
+        reposts: response.post.repostCount,
+        comments: response.post.replyCount,
+      },
+      fetchedAt: new Date(),
+    };
   },
 
   async getAccountAnalytics(credentials: SocialCredentials): Promise<AccountAnalytics | null> {
+    // `null` is the designed "analytics unavailable for an unconfigured account" signal;
+    // a real session/fetch failure must propagate, not be masked as that empty state.
     if (!credentials.handle || !credentials.appPassword) {
       return null;
     }
 
-    try {
-      const session = await createSession(credentials.handle, credentials.appPassword);
+    const session = await createSession(credentials.handle, credentials.appPassword);
 
-      const response = await bskyApiRequest<BskyProfile>(
-        `app.bsky.actor.getProfile?actor=${session.did}`,
-        session.accessJwt,
-      );
+    const response = await bskyApiRequest<BskyProfile>(
+      `app.bsky.actor.getProfile?actor=${session.did}`,
+      session.accessJwt,
+    );
 
-      return {
-        platform: "bluesky",
-        accountId: response.did,
-        metrics: {
-          followers: response.followersCount,
-          following: response.followsCount,
-          totalPosts: response.postsCount,
-        },
-        fetchedAt: new Date(),
-      };
-    } catch {
-      return null;
-    }
+    return {
+      platform: "bluesky",
+      accountId: response.did,
+      metrics: {
+        followers: response.followersCount,
+        following: response.followsCount,
+        totalPosts: response.postsCount,
+      },
+      fetchedAt: new Date(),
+    };
   },
 
   async uploadMedia(credentials: SocialCredentials, media: MediaAttachment) {
@@ -465,6 +467,8 @@ export const blueskyProvider: SocialMediaProvider = {
 
       return { success: true };
     } catch (error) {
+      // error-policy:J1 boundary translation of the Bluesky like call into the typed
+      // failure result the caller renders; a failure, not a fabricated success.
       return {
         success: false,
         error: extractErrorMessage(error),
@@ -515,6 +519,8 @@ export const blueskyProvider: SocialMediaProvider = {
         postId: response.uri,
       };
     } catch (error) {
+      // error-policy:J1 boundary translation of the Bluesky repost call into the typed
+      // PostResult failure the caller renders; a failure, not a fabricated success.
       return {
         platform: "bluesky",
         success: false,

--- a/packages/cloud/shared/src/lib/services/social-media/providers/discord.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/discord.error-policy.test.ts
@@ -1,0 +1,116 @@
+// Pins the fail-closed error policy of the Discord provider (J1 transport boundaries).
+// An internal transport failure (Discord error code / retries exhausted) must surface as a
+// distinguishable { success:false } / { valid:false } result the socialMediaService caller
+// inspects and refunds on — never as a fabricated success. Designed pre-flight guards
+// (missing channelId / missing token) stay a distinct failure that never touches the network,
+// and the real success path returns a real postId (drives the exported provider, not a
+// tautology). Deterministic fetch fixtures; no live network. Backoff sleeps are collapsed so a
+// retrying failure rejects promptly.
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+mock.module("../../../utils/logger", () => ({
+  logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
+}));
+
+const { discordProvider } = await import("./discord");
+
+const realFetch = globalThis.fetch;
+const realSetTimeout = globalThis.setTimeout;
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const WEBHOOK_CREDS = { webhookUrl: "https://discord.com/api/webhooks/1/abc" } as never;
+const BOT_CREDS = { botToken: "bot-token", channelId: "chan-1" } as never;
+const BOT_CREDS_NO_CHANNEL = { botToken: "bot-token" } as never;
+const CONTENT = { text: "hello world" } as never;
+
+beforeEach(() => {
+  // Collapse exponential-backoff sleeps so a failing request exhausts its retries and rejects
+  // without waiting out the real delays.
+  (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout = ((fn: () => void) => {
+    fn();
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  globalThis.setTimeout = realSetTimeout;
+});
+
+describe("discordProvider error policy", () => {
+  it("createPost surfaces an internal webhook transport failure as { success:false }, not a fabricated success", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls++;
+      // Discord returns an error envelope with a `code`; the provider's parser throws on it,
+      // withRetry exhausts retries, and the provider's J1 catch translates it to a failure.
+      return jsonResponse({ code: 50035, message: "Invalid webhook token" });
+    }) as typeof fetch;
+
+    const result = await discordProvider.createPost(WEBHOOK_CREDS, CONTENT);
+
+    expect(result.success).toBe(false);
+    expect(result.platform).toBe("discord");
+    expect(result.error).toContain("Invalid webhook token");
+    expect(result.postId).toBeUndefined();
+    // Proved the failure actually reached the network (and retried) rather than short-circuiting.
+    expect(fetchCalls).toBeGreaterThan(0);
+  });
+
+  it("createPost returns a real postId on webhook success (drives the real path, not a tautology)", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ id: "msg-123", channel_id: "chan-9" }),
+    ) as typeof fetch;
+
+    const result = await discordProvider.createPost(WEBHOOK_CREDS, CONTENT);
+
+    expect(result.success).toBe(true);
+    expect(result.postId).toBe("msg-123");
+    expect(result.postUrl).toContain("chan-9");
+    expect(result.postUrl).toContain("msg-123");
+  });
+
+  it("createPost designed guard (bot token, no channelId) fails closed WITHOUT touching the network", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls++;
+      return jsonResponse({ id: "should-not-happen", channel_id: "x" });
+    }) as typeof fetch;
+
+    const result = await discordProvider.createPost(BOT_CREDS_NO_CHANNEL, CONTENT);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Channel ID required for bot posting");
+    // Distinct from a transport failure: the designed-invalid guard never hits the API.
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("validateCredentials surfaces a webhook transport failure as { valid:false }, never a false-valid", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("network down");
+    }) as typeof fetch;
+
+    const result = await discordProvider.validateCredentials(WEBHOOK_CREDS);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("network down");
+    expect(result.accountId).toBeUndefined();
+  });
+
+  it("deletePost surfaces an internal bot-API failure as { success:false }, not a fabricated success", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ code: 10008, message: "Unknown Message" }),
+    ) as typeof fetch;
+
+    const result = await discordProvider.deletePost(BOT_CREDS, "chan-1/msg-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Unknown Message");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/providers/discord.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/discord.ts
@@ -101,6 +101,8 @@ export const discordProvider: SocialMediaProvider = {
           accountId: data.id,
           username: data.name,
         };
+        // error-policy:J1 transport boundary — a webhook fetch failure becomes the
+        // structured { valid:false } verdict the caller inspects; the real error is surfaced, not swallowed.
       } catch (error) {
         return {
           valid: false,
@@ -126,6 +128,8 @@ export const discordProvider: SocialMediaProvider = {
           ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`
           : undefined,
       };
+      // error-policy:J1 transport boundary — a Discord bot-token API failure becomes the
+      // structured { valid:false } verdict the caller inspects; the real error is surfaced, not swallowed.
     } catch (error) {
       return {
         valid: false,
@@ -212,6 +216,8 @@ export const discordProvider: SocialMediaProvider = {
         postId: message.id,
         postUrl: `https://discord.com/channels/@me/${message.channel_id}/${message.id}`,
       };
+      // error-policy:J1 transport boundary — an outbound Discord post failure becomes the
+      // structured { success:false } PostResult the socialMediaService caller inspects and refunds on.
     } catch (error) {
       logger.error("[Discord] Post failed", { error });
       return {
@@ -247,6 +253,8 @@ export const discordProvider: SocialMediaProvider = {
       );
 
       return { success: true };
+      // error-policy:J1 transport boundary — an outbound Discord delete failure becomes the
+      // structured { success:false } result the caller inspects; the real error is surfaced, not swallowed.
     } catch (error) {
       return {
         success: false,
@@ -306,6 +314,8 @@ export const discordProvider: SocialMediaProvider = {
         postId: message.id,
         postUrl: `https://discord.com/channels/@me/${channelId}/${message.id}`,
       };
+      // error-policy:J1 transport boundary — an outbound Discord reply failure becomes the
+      // structured { success:false } PostResult the socialMediaService caller inspects and refunds on.
     } catch (error) {
       return {
         platform: "discord",
@@ -338,6 +348,8 @@ export const discordProvider: SocialMediaProvider = {
       );
 
       return { success: true };
+      // error-policy:J1 transport boundary — an outbound Discord reaction failure becomes the
+      // structured { success:false } result the caller inspects; the real error is surfaced, not swallowed.
     } catch (error) {
       return {
         success: false,

--- a/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.error-policy.test.ts
@@ -1,0 +1,200 @@
+// Pins the fail-closed error policy of the LinkedIn provider (#13415). Two
+// distinct failure surfaces are under test, driving the real exported
+// `linkedinProvider` against deterministic fetch fixtures (no live network):
+//   1. Media upload (`uploadMedia`) must NOT fabricate an asset handle when the
+//      image download or the asset-upload PUT returns a non-OK status — the
+//      failure must propagate so callers never attach bytes LinkedIn never
+//      stored. A fully-successful path still returns the real `mediaId`.
+//   2. Analytics readers (`getPostAnalytics`/`getAccountAnalytics`) keep the
+//      designed-empty result (`null` for absent creds / a post with no recorded
+//      social actions) DISTINGUISHABLE from an internal failure, which throws.
+// The rate-limit backoff sleeps are collapsed so a retrying failure rejects
+// promptly instead of waiting out real exponential-backoff delays.
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { MediaAttachment, SocialCredentials } from "../../../types/social-media";
+
+mock.module("../../../utils/logger", () => ({
+  logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
+}));
+
+const { linkedinProvider } = await import("./linkedin");
+
+const realFetch = globalThis.fetch;
+const realSetTimeout = globalThis.setTimeout;
+
+const CREDS = { accessToken: "tok" } as SocialCredentials;
+const NO_CREDS = {} as SocialCredentials;
+
+const UPLOAD_URL = "https://upload.li.example/stream/abc";
+const ASSET_URN = "urn:li:digitalmediaAsset:xyz";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function urlOf(input: unknown): string {
+  if (typeof input === "string") return input;
+  if (input instanceof Request) return input.url;
+  if (input instanceof URL) return input.href;
+  return String(input);
+}
+
+const REGISTER_RESPONSE = {
+  value: {
+    uploadMechanism: {
+      "com.linkedin.digitalmedia.uploading.MediaUploadHttpRequest": {
+        uploadUrl: UPLOAD_URL,
+        headers: {},
+      },
+    },
+    asset: ASSET_URN,
+  },
+};
+
+beforeEach(() => {
+  (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout = ((fn: () => void) => {
+    fn();
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  globalThis.setTimeout = realSetTimeout;
+});
+
+async function rejects(p: Promise<unknown>): Promise<Error> {
+  try {
+    await p;
+  } catch (e) {
+    return e as Error;
+  }
+  throw new Error("expected promise to reject, but it resolved");
+}
+
+/**
+ * Routes the LinkedIn API calls (`/me`, `registerUpload`) to fixtures and lets
+ * the caller decide the outcome of the raw asset-upload PUT and any image
+ * download.
+ */
+function mockLinkedInFetch(opts: { uploadStatus?: number; downloadStatus?: number }): void {
+  globalThis.fetch = mock(async (input: unknown) => {
+    const url = urlOf(input);
+    if (url === UPLOAD_URL) return jsonResponse({}, opts.uploadStatus ?? 200);
+    if (url.includes("/me")) return jsonResponse({ id: "person123" });
+    if (url.includes("registerUpload") || url.includes("/assets"))
+      return jsonResponse(REGISTER_RESPONSE);
+    // Any other URL is treated as a remote image download.
+    if (opts.downloadStatus && opts.downloadStatus >= 400)
+      return jsonResponse({}, opts.downloadStatus);
+    return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+  }) as typeof fetch;
+}
+
+describe("linkedinProvider.uploadMedia — fail closed", () => {
+  it("returns the real asset URN when the upload PUT succeeds (drives the real path)", async () => {
+    mockLinkedInFetch({ uploadStatus: 200 });
+    const media: MediaAttachment = {
+      type: "image",
+      mimeType: "image/png",
+      data: Buffer.from([1, 2, 3]),
+    };
+
+    const result = await linkedinProvider.uploadMedia!(CREDS, media);
+    expect(result.mediaId).toBe(ASSET_URN);
+  });
+
+  it("PROPAGATES a non-OK asset-upload PUT instead of fabricating a media handle", async () => {
+    mockLinkedInFetch({ uploadStatus: 500 });
+    const media: MediaAttachment = {
+      type: "image",
+      mimeType: "image/png",
+      data: Buffer.from([1, 2, 3]),
+    };
+
+    const err = await rejects(linkedinProvider.uploadMedia!(CREDS, media));
+    expect(err.message).toContain("upload failed");
+    expect(err.message).toContain("500");
+  });
+
+  it("PROPAGATES a non-OK image download instead of uploading garbage bytes", async () => {
+    mockLinkedInFetch({ uploadStatus: 200, downloadStatus: 404 });
+    const media: MediaAttachment = {
+      type: "image",
+      mimeType: "image/png",
+      url: "https://cdn.example/missing.png",
+    };
+
+    const err = await rejects(linkedinProvider.uploadMedia!(CREDS, media));
+    expect(err.message).toContain("download failed");
+    expect(err.message).toContain("404");
+  });
+
+  it("throws (designed invalid input) without any fetch when the access token is absent", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls++;
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    await expect(
+      linkedinProvider.uploadMedia!(NO_CREDS, { type: "image", mimeType: "image/png" }),
+    ).rejects.toThrow("Access token required");
+    expect(fetchCalls).toBe(0);
+  });
+});
+
+describe("linkedinProvider analytics — designed-empty vs internal failure", () => {
+  it("getPostAnalytics returns null (not configured) without any fetch when creds are absent", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls++;
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    const result = await linkedinProvider.getPostAnalytics!(NO_CREDS, "urn:li:share:1");
+    expect(result).toBeNull();
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("getPostAnalytics returns null (designed empty) when the post has no social actions", async () => {
+    globalThis.fetch = mock(async () => jsonResponse({ elements: [] })) as typeof fetch;
+
+    const result = await linkedinProvider.getPostAnalytics!(CREDS, "urn:li:share:1");
+    expect(result).toBeNull();
+  });
+
+  it("getPostAnalytics returns real metrics for a post with recorded actions", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({
+        elements: [{ likesSummary: { totalLikes: 9 }, commentsSummary: { totalComments: 4 } }],
+      }),
+    ) as typeof fetch;
+
+    const result = await linkedinProvider.getPostAnalytics!(CREDS, "urn:li:share:1");
+    expect(result).not.toBeNull();
+    expect(result?.metrics.likes).toBe(9);
+    expect(result?.metrics.comments).toBe(4);
+  });
+
+  it("getPostAnalytics PROPAGATES an internal 5xx instead of masking it as null", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ message: "server error", status: 500 }, 500),
+    ) as typeof fetch;
+
+    const err = await rejects(linkedinProvider.getPostAnalytics!(CREDS, "urn:li:share:1"));
+    expect(err.message).toContain("500");
+  });
+
+  it("getAccountAnalytics PROPAGATES an internal /me failure instead of returning null", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ message: "unauthorized", status: 401 }, 401),
+    ) as typeof fetch;
+
+    const err = await rejects(linkedinProvider.getAccountAnalytics!(CREDS));
+    expect(err.message).toContain("401");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.ts
@@ -101,6 +101,7 @@ export const linkedinProvider: SocialMediaProvider = {
         avatarUrl: profile.profilePicture?.displayImage,
       };
     } catch (error) {
+      // error-policy:J1 outbound LinkedIn /me lookup — a failed check is a designed invalid-credentials result the caller reads via `valid: false`, not a fabricated success.
       return {
         valid: false,
         error: extractErrorMessage(error),
@@ -212,11 +213,18 @@ export const linkedinProvider: SocialMediaProvider = {
               ].uploadUrl;
             const asset = registerResponse.value.asset;
 
-            // Download and upload the image
+            // Download and upload the image. A non-OK download or upload must
+            // surface: otherwise the asset below is marked READY and attached to
+            // a published post that references bytes LinkedIn never received.
             const imageResponse = await fetch(media.url);
+            if (!imageResponse.ok) {
+              throw new Error(
+                `LinkedIn image download failed for ${media.url}: ${imageResponse.status}`,
+              );
+            }
             const imageData = await imageResponse.arrayBuffer();
 
-            await fetch(uploadUrl, {
+            const uploadResponse = await fetch(uploadUrl, {
               method: "PUT",
               headers: {
                 Authorization: `Bearer ${credentials.accessToken}`,
@@ -224,6 +232,9 @@ export const linkedinProvider: SocialMediaProvider = {
               },
               body: imageData,
             });
+            if (!uploadResponse.ok) {
+              throw new Error(`LinkedIn asset upload failed: ${uploadResponse.status}`);
+            }
 
             mediaAssets.push({
               status: "READY",
@@ -261,6 +272,7 @@ export const linkedinProvider: SocialMediaProvider = {
         postUrl: `https://www.linkedin.com/feed/update/${shareId}`,
       };
     } catch (error) {
+      // error-policy:J1 outbound LinkedIn publish boundary — the failure surfaces as a typed `success: false` PostResult the caller must check, never a fabricated success.
       logger.error("[LinkedIn] Post failed", { error });
       return {
         platform: "linkedin",
@@ -282,6 +294,7 @@ export const linkedinProvider: SocialMediaProvider = {
 
       return { success: true };
     } catch (error) {
+      // error-policy:J1 outbound LinkedIn delete boundary — failure surfaces as a typed `success: false` result the caller must check.
       return {
         success: false,
         error: extractErrorMessage(error),
@@ -297,30 +310,28 @@ export const linkedinProvider: SocialMediaProvider = {
       return null;
     }
 
-    try {
-      // LinkedIn's social actions API
-      const response = await linkedinApiRequest<{
-        elements?: Array<{
-          likesSummary?: { totalLikes: number };
-          commentsSummary?: { totalComments: number };
-        }>;
-      }>(`/socialActions/${encodeURIComponent(postId)}`, credentials.accessToken);
+    // Internal failures (auth, transport, parse) propagate so the caller can tell
+    // a broken pipeline apart from the designed-empty result: only a missing
+    // `elements[0]` — the post exists but has no recorded social actions — is null.
+    const response = await linkedinApiRequest<{
+      elements?: Array<{
+        likesSummary?: { totalLikes: number };
+        commentsSummary?: { totalComments: number };
+      }>;
+    }>(`/socialActions/${encodeURIComponent(postId)}`, credentials.accessToken);
 
-      const element = response.elements?.[0];
-      if (!element) return null;
+    const element = response.elements?.[0];
+    if (!element) return null;
 
-      return {
-        platform: "linkedin",
-        postId,
-        metrics: {
-          likes: element.likesSummary?.totalLikes || 0,
-          comments: element.commentsSummary?.totalComments || 0,
-        },
-        fetchedAt: new Date(),
-      };
-    } catch {
-      return null;
-    }
+    return {
+      platform: "linkedin",
+      postId,
+      metrics: {
+        likes: element.likesSummary?.totalLikes || 0,
+        comments: element.commentsSummary?.totalComments || 0,
+      },
+      fetchedAt: new Date(),
+    };
   },
 
   async getAccountAnalytics(credentials: SocialCredentials): Promise<AccountAnalytics | null> {
@@ -328,21 +339,17 @@ export const linkedinProvider: SocialMediaProvider = {
       return null;
     }
 
-    try {
-      const profile = await linkedinApiRequest<LinkedInProfile>("/me", credentials.accessToken);
+    // A failed /me lookup propagates rather than masquerading as a valid empty
+    // metrics set. The successful result carries an intentionally empty `metrics`
+    // because LinkedIn's basic API exposes no follower counts (Marketing API only).
+    const profile = await linkedinApiRequest<LinkedInProfile>("/me", credentials.accessToken);
 
-      // LinkedIn doesn't provide follower counts via the basic API
-      // Would need Marketing API for that
-
-      return {
-        platform: "linkedin",
-        accountId: profile.id,
-        metrics: {},
-        fetchedAt: new Date(),
-      };
-    } catch {
-      return null;
-    }
+    return {
+      platform: "linkedin",
+      accountId: profile.id,
+      metrics: {},
+      fetchedAt: new Date(),
+    };
   },
 
   async uploadMedia(credentials: SocialCredentials, media: MediaAttachment) {
@@ -388,13 +395,17 @@ export const linkedinProvider: SocialMediaProvider = {
       imageData = Uint8Array.from(Buffer.from(media.base64, "base64"));
     } else if (media.url) {
       const response = await fetch(media.url);
+      if (!response.ok) {
+        throw new Error(`LinkedIn image download failed for ${media.url}: ${response.status}`);
+      }
       imageData = new Uint8Array(await response.arrayBuffer());
     } else {
       throw new Error("No media data provided");
     }
 
-    // Upload
-    await fetch(uploadUrl, {
+    // A non-OK upload must surface: returning the asset URN as if it succeeded
+    // would hand callers a media handle LinkedIn never actually stored.
+    const uploadResponse = await fetch(uploadUrl, {
       method: "PUT",
       headers: {
         Authorization: `Bearer ${credentials.accessToken}`,
@@ -402,6 +413,9 @@ export const linkedinProvider: SocialMediaProvider = {
       },
       body: Buffer.from(imageData),
     });
+    if (!uploadResponse.ok) {
+      throw new Error(`LinkedIn asset upload failed: ${uploadResponse.status}`);
+    }
 
     return { mediaId: asset };
   },
@@ -440,6 +454,7 @@ export const linkedinProvider: SocialMediaProvider = {
         postId: response.id,
       };
     } catch (error) {
+      // error-policy:J1 outbound LinkedIn comment boundary — failure surfaces as a typed `success: false` PostResult the caller must check.
       return {
         platform: "linkedin",
         success: false,
@@ -469,6 +484,7 @@ export const linkedinProvider: SocialMediaProvider = {
 
       return { success: true };
     } catch (error) {
+      // error-policy:J1 outbound LinkedIn like boundary — failure surfaces as a typed `success: false` result the caller must check.
       return {
         success: false,
         error: extractErrorMessage(error),

--- a/packages/cloud/shared/src/lib/services/social-media/providers/meta.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/meta.error-policy.test.ts
@@ -1,0 +1,193 @@
+// Pins the fail-closed error policy of the Meta (Facebook/Instagram Graph API) provider's
+// analytics readers: an internal Graph API / transport failure while reading post or account
+// analytics must propagate (throw), while the designed "provider not configured" result stays
+// a distinct `null`. Before the sweep both readers wrapped their whole body in try/catch (and
+// getAccountAnalytics silently fell IG→FB) so a broken pipeline read as "no analytics".
+// Deterministic fetch fixtures drive the real exported provider; no live network. Backoff
+// sleeps are collapsed so a retrying failure rejects promptly.
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+mock.module("../../../utils/logger", () => ({
+  logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
+}));
+
+const { metaProvider } = await import("./meta");
+
+const realFetch = globalThis.fetch;
+const realSetTimeout = globalThis.setTimeout;
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// A Graph API error surfaces as a 200 body carrying `.error`; graphApiRequest's parser
+// throws on it, which withRetry re-raises after exhausting retries.
+const GRAPH_ERROR = {
+  error: { message: "Invalid OAuth access token", code: 190, type: "OAuthException" },
+};
+
+const TOKEN = "graph-token";
+
+beforeEach(() => {
+  // Collapse the rate-limit / retry exponential backoff so a failing request rejects without
+  // waiting out the real delays.
+  (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout = ((fn: () => void) => {
+    fn();
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  globalThis.setTimeout = realSetTimeout;
+});
+
+describe("metaProvider.getPostAnalytics — internal failure propagates, empty stays null", () => {
+  it("returns null (designed 'not configured') without any fetch when the access token is absent", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls++;
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    const result = await metaProvider.getPostAnalytics!({} as never, "post-1");
+
+    expect(result).toBeNull();
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("propagates a Graph API failure on the Facebook read instead of masking it as null", async () => {
+    globalThis.fetch = mock(async () => jsonResponse(GRAPH_ERROR)) as typeof fetch;
+
+    await expect(
+      metaProvider.getPostAnalytics!({ accessToken: TOKEN } as never, "post-1"),
+    ).rejects.toThrow();
+  });
+
+  it("propagates a Graph API failure on the Instagram read (accountId route) instead of null", async () => {
+    globalThis.fetch = mock(async () => jsonResponse(GRAPH_ERROR)) as typeof fetch;
+
+    await expect(
+      metaProvider.getPostAnalytics!({ accessToken: TOKEN, accountId: "ig-1" } as never, "post-1"),
+    ).rejects.toThrow();
+  });
+
+  it("returns real Facebook metrics on success (drives the real reader, not a tautology)", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({
+        id: "post-1",
+        likes: { summary: { total_count: 10 } },
+        comments: { summary: { total_count: 4 } },
+        shares: { count: 2 },
+      }),
+    ) as typeof fetch;
+
+    const result = await metaProvider.getPostAnalytics!({ accessToken: TOKEN } as never, "post-1");
+
+    expect(result).not.toBeNull();
+    expect(result?.platform).toBe("facebook");
+    expect(result?.metrics.likes).toBe(10);
+    expect(result?.metrics.comments).toBe(4);
+    expect(result?.metrics.shares).toBe(2);
+  });
+
+  it("returns real Instagram metrics on success when an accountId is configured", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ id: "post-1", like_count: 7, comments_count: 3 }),
+    ) as typeof fetch;
+
+    const result = await metaProvider.getPostAnalytics!(
+      { accessToken: TOKEN, accountId: "ig-1" } as never,
+      "post-1",
+    );
+
+    expect(result?.platform).toBe("instagram");
+    expect(result?.metrics.likes).toBe(7);
+    expect(result?.metrics.comments).toBe(3);
+  });
+});
+
+describe("metaProvider.getAccountAnalytics — internal failure propagates, empty stays null", () => {
+  it("returns null (designed 'not configured') without any fetch when the access token is absent", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls++;
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    const result = await metaProvider.getAccountAnalytics!({} as never);
+
+    expect(result).toBeNull();
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("returns null (designed 'no target configured') without any fetch when neither accountId nor pageId is set", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls++;
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    const result = await metaProvider.getAccountAnalytics!({ accessToken: TOKEN } as never);
+
+    expect(result).toBeNull();
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("propagates an Instagram-account read failure instead of falling through to Facebook as null", async () => {
+    // The pre-sweep code caught the IG failure and fell through to Facebook (then null),
+    // masking the real failure even though the caller only configured an accountId.
+    globalThis.fetch = mock(async () => jsonResponse(GRAPH_ERROR)) as typeof fetch;
+
+    await expect(
+      metaProvider.getAccountAnalytics!({ accessToken: TOKEN, accountId: "ig-1" } as never),
+    ).rejects.toThrow();
+  });
+
+  it("propagates a Facebook-page read failure instead of masking it as null", async () => {
+    globalThis.fetch = mock(async () => jsonResponse(GRAPH_ERROR)) as typeof fetch;
+
+    await expect(
+      metaProvider.getAccountAnalytics!({ accessToken: TOKEN, pageId: "page-1" } as never),
+    ).rejects.toThrow();
+  });
+
+  it("returns real Instagram account metrics on success", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({
+        id: "ig-1",
+        username: "milady",
+        followers_count: 500,
+        follows_count: 42,
+        media_count: 8,
+      }),
+    ) as typeof fetch;
+
+    const result = await metaProvider.getAccountAnalytics!({
+      accessToken: TOKEN,
+      accountId: "ig-1",
+    } as never);
+
+    expect(result?.platform).toBe("instagram");
+    expect(result?.metrics.followers).toBe(500);
+    expect(result?.metrics.following).toBe(42);
+    expect(result?.metrics.totalPosts).toBe(8);
+  });
+
+  it("returns real Facebook page metrics on success", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ id: "page-1", name: "Milady", fan_count: 1234 }),
+    ) as typeof fetch;
+
+    const result = await metaProvider.getAccountAnalytics!({
+      accessToken: TOKEN,
+      pageId: "page-1",
+    } as never);
+
+    expect(result?.platform).toBe("facebook");
+    expect(result?.metrics.followers).toBe(1234);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/providers/meta.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/meta.ts
@@ -176,6 +176,8 @@ async function createFacebookPost(
       postUrl: `https://facebook.com/${postData.id}`,
     };
   } catch (error) {
+    // error-policy:J1 boundary translation — a failed Graph API post becomes a typed
+    // {success:false} PostResult the caller inspects, not a swallowed error.
     logger.error("[Facebook] Post failed", { error });
     return {
       platform: "facebook",
@@ -327,6 +329,8 @@ async function createInstagramPost(
       postUrl: `https://instagram.com/p/${post.id}`,
     };
   } catch (error) {
+    // error-policy:J1 boundary translation — a failed Graph API post becomes a typed
+    // {success:false} PostResult the caller inspects, not a swallowed error.
     logger.error("[Instagram] Post failed", { error });
     return {
       platform: "instagram",
@@ -358,6 +362,8 @@ export const metaProvider: SocialMediaProvider = {
         displayName: response.name,
       };
     } catch (error) {
+      // error-policy:J1 boundary translation — a failed credential check becomes a typed
+      // {valid:false} result the caller inspects, not a swallowed error.
       return {
         valid: false,
         error: extractErrorMessage(error),
@@ -392,6 +398,8 @@ export const metaProvider: SocialMediaProvider = {
 
       return { success: true };
     } catch (error) {
+      // error-policy:J1 boundary translation — a failed Graph API delete becomes a typed
+      // {success:false} result the caller inspects, not a swallowed error.
       return {
         success: false,
         error: extractErrorMessage(error),
@@ -403,104 +411,102 @@ export const metaProvider: SocialMediaProvider = {
     credentials: SocialCredentials,
     postId: string,
   ): Promise<PostAnalytics | null> {
+    // `null` is the designed "provider not configured" signal the service layer reads as
+    // empty; an internal Graph API / transport failure throws out of graphApiRequest and
+    // must stay distinguishable from it, so it is deliberately never caught here.
     if (!credentials.accessToken) {
       return null;
     }
 
-    try {
-      // Try Facebook insights
+    // Instagram vs Facebook is fixed by which credential is configured — the same routing
+    // createPost uses. An accountId addresses an Instagram media node (like_count/
+    // comments_count); otherwise the id is a Facebook post exposing summary insight fields.
+    // A metric absent from a successful response is a real zero (no likes/shares), not a
+    // failed read — the read failing throws instead.
+    if (credentials.accountId) {
       const response = await graphApiRequest<{
         id: string;
-        shares?: { count: number };
-        likes?: { summary: { total_count: number } };
-        comments?: { summary: { total_count: number } };
-      }>(
-        `/${postId}?fields=id,shares,likes.summary(true),comments.summary(true)`,
+        like_count?: number;
+        comments_count?: number;
+      }>(`/${postId}?fields=id,like_count,comments_count`, credentials.accessToken);
+
+      return {
+        platform: "instagram",
+        postId,
+        metrics: {
+          likes: response.like_count || 0,
+          comments: response.comments_count || 0,
+        },
+        fetchedAt: new Date(),
+      };
+    }
+
+    const response = await graphApiRequest<{
+      id: string;
+      shares?: { count: number };
+      likes?: { summary: { total_count: number } };
+      comments?: { summary: { total_count: number } };
+    }>(
+      `/${postId}?fields=id,shares,likes.summary(true),comments.summary(true)`,
+      credentials.accessToken,
+    );
+
+    return {
+      platform: "facebook",
+      postId,
+      metrics: {
+        likes: response.likes?.summary?.total_count || 0,
+        comments: response.comments?.summary?.total_count || 0,
+        shares: response.shares?.count || 0,
+      },
+      fetchedAt: new Date(),
+    };
+  },
+
+  async getAccountAnalytics(credentials: SocialCredentials): Promise<AccountAnalytics | null> {
+    // `null` is the designed "no analytics target configured" signal; a real Graph API /
+    // transport failure throws out of graphApiRequest and is never masked as this empty
+    // state (the prior IG→FB fall-through hid exactly such failures).
+    if (!credentials.accessToken) {
+      return null;
+    }
+
+    // An Instagram account id addresses the Instagram node; otherwise a Facebook page id
+    // addresses the page. The configured credential fixes the platform, so a failure of
+    // that read propagates rather than silently probing the other surface.
+    if (credentials.accountId) {
+      const response = await graphApiRequest<InstagramAccount>(
+        `/${credentials.accountId}?fields=id,username,name,profile_picture_url,followers_count,follows_count,media_count`,
         credentials.accessToken,
       );
 
       return {
-        platform: "facebook",
-        postId,
+        platform: "instagram",
+        accountId: response.id,
         metrics: {
-          likes: response.likes?.summary?.total_count || 0,
-          comments: response.comments?.summary?.total_count || 0,
-          shares: response.shares?.count || 0,
+          followers: response.followers_count,
+          following: response.follows_count,
+          totalPosts: response.media_count,
         },
         fetchedAt: new Date(),
       };
-    } catch {
-      // Try Instagram insights
-      try {
-        const response = await graphApiRequest<{
-          id: string;
-          like_count?: number;
-          comments_count?: number;
-        }>(`/${postId}?fields=id,like_count,comments_count`, credentials.accessToken);
-
-        return {
-          platform: "instagram",
-          postId,
-          metrics: {
-            likes: response.like_count || 0,
-            comments: response.comments_count || 0,
-          },
-          fetchedAt: new Date(),
-        };
-      } catch {
-        return null;
-      }
-    }
-  },
-
-  async getAccountAnalytics(credentials: SocialCredentials): Promise<AccountAnalytics | null> {
-    if (!credentials.accessToken) {
-      return null;
     }
 
-    // Try Instagram account
-    if (credentials.accountId) {
-      try {
-        const response = await graphApiRequest<InstagramAccount>(
-          `/${credentials.accountId}?fields=id,username,name,profile_picture_url,followers_count,follows_count,media_count`,
-          credentials.accessToken,
-        );
-
-        return {
-          platform: "instagram",
-          accountId: response.id,
-          metrics: {
-            followers: response.followers_count,
-            following: response.follows_count,
-            totalPosts: response.media_count,
-          },
-          fetchedAt: new Date(),
-        };
-      } catch {
-        // Fall through to Facebook
-      }
-    }
-
-    // Try Facebook page
     if (credentials.pageId) {
-      try {
-        const response = await graphApiRequest<{
-          id: string;
-          name: string;
-          fan_count?: number;
-        }>(`/${credentials.pageId}?fields=id,name,fan_count`, credentials.accessToken);
+      const response = await graphApiRequest<{
+        id: string;
+        name: string;
+        fan_count?: number;
+      }>(`/${credentials.pageId}?fields=id,name,fan_count`, credentials.accessToken);
 
-        return {
-          platform: "facebook",
-          accountId: response.id,
-          metrics: {
-            followers: response.fan_count,
-          },
-          fetchedAt: new Date(),
-        };
-      } catch {
-        return null;
-      }
+      return {
+        platform: "facebook",
+        accountId: response.id,
+        metrics: {
+          followers: response.fan_count,
+        },
+        fetchedAt: new Date(),
+      };
     }
 
     return null;
@@ -547,6 +553,8 @@ export const metaProvider: SocialMediaProvider = {
         postId: response.id,
       };
     } catch (error) {
+      // error-policy:J1 boundary translation — a failed Graph API comment becomes a typed
+      // {success:false} PostResult the caller inspects, not a swallowed error.
       return {
         platform: "facebook",
         success: false,
@@ -569,6 +577,8 @@ export const metaProvider: SocialMediaProvider = {
 
       return { success: true };
     } catch (error) {
+      // error-policy:J1 boundary translation — a failed Graph API like becomes a typed
+      // {success:false} result the caller inspects, not a swallowed error.
       return {
         success: false,
         error: extractErrorMessage(error),

--- a/packages/cloud/shared/src/lib/services/social-media/providers/reddit.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/reddit.error-policy.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Pins the fail-closed contract of the Reddit analytics readers (#13415).
+ *
+ * Before the sweep, `getPostAnalytics`/`getAccountAnalytics` wrapped their whole
+ * body in `catch { return null }`, so an internal failure (expired auth, 5xx,
+ * transport, rate-limit) returned the SAME `null` that signals a
+ * legitimately-empty result (a post that does not exist / an unsupported
+ * provider). A broken pipeline read as "no analytics". These tests drive the
+ * real exported `redditProvider` methods and prove the two are now
+ * distinguishable: a designed-empty upstream still resolves to `null`, while an
+ * internal request failure PROPAGATES instead of being swallowed.
+ *
+ * The `rate-limit` boundary (`withRetry`) is replaced with a fast, sleepless
+ * pass-through that mirrors its real semantics (throw on non-OK / 429, else run
+ * the parser) so the changed branch — not the retry backoff — is under test.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { SocialCredentials } from "../../../types/social-media";
+
+mock.module("../rate-limit", () => ({
+  withRetry: async (fn: () => Promise<Response>, parser: (r: Response) => Promise<unknown>) => {
+    const response = await fn();
+    if (response.status === 429) throw new Error("Rate limited by reddit");
+    if (!response.ok) throw new Error(`reddit API error ${response.status}`);
+    return { data: await parser(response) };
+  },
+  isRateLimitResponse: (r: Response) => r.status === 429,
+}));
+
+const { redditProvider } = await import("./reddit");
+
+const creds = {
+  apiKey: "client-id",
+  apiSecret: "client-secret",
+  username: "bob",
+  password: "hunter2",
+} as SocialCredentials;
+
+const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+const TOKEN = { access_token: "tok", token_type: "bearer", expires_in: 3600, scope: "*" };
+
+let fetchQueue: Array<() => Response>;
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  fetchQueue = [];
+  globalThis.fetch = mock(async () => {
+    const next = fetchQueue.shift();
+    if (!next) throw new Error("unexpected fetch call — queue empty");
+    return next();
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  mock.restore();
+});
+
+async function rejects(p: Promise<unknown>): Promise<Error> {
+  try {
+    await p;
+  } catch (e) {
+    return e as Error;
+  }
+  throw new Error("expected promise to reject, but it resolved");
+}
+
+describe("redditProvider.getPostAnalytics — fail closed vs designed empty", () => {
+  test("returns null for a genuinely-missing post (empty children)", async () => {
+    fetchQueue = [() => json(TOKEN), () => json([{ data: { children: [] } }])];
+
+    const result = await redditProvider.getPostAnalytics!(creds, "t3_missing");
+    expect(result).toBeNull();
+  });
+
+  test("returns metrics for an existing post", async () => {
+    fetchQueue = [
+      () => json(TOKEN),
+      () =>
+        json([
+          {
+            data: {
+              children: [{ data: { id: "abc", score: 42, num_comments: 7, upvote_ratio: 0.9 } }],
+            },
+          },
+        ]),
+    ];
+
+    const result = await redditProvider.getPostAnalytics!(creds, "t3_abc");
+    expect(result).not.toBeNull();
+    expect(result?.metrics.likes).toBe(42);
+    expect(result?.metrics.comments).toBe(7);
+  });
+
+  test("PROPAGATES an internal failure (5xx on the info call) instead of returning null", async () => {
+    fetchQueue = [() => json(TOKEN), () => json({ error: "server" }, 500)];
+
+    const err = await rejects(redditProvider.getPostAnalytics!(creds, "t3_abc"));
+    expect(err.message).toContain("500");
+  });
+
+  test("PROPAGATES a rate-limit failure instead of returning null", async () => {
+    fetchQueue = [() => json(TOKEN), () => json({}, 429)];
+
+    const err = await rejects(redditProvider.getPostAnalytics!(creds, "t3_abc"));
+    expect(err.message).toContain("Rate limited");
+  });
+
+  test("PROPAGATES an auth failure (token endpoint down) instead of returning null", async () => {
+    fetchQueue = [() => json({ error: "unauthorized" }, 401)];
+
+    const err = await rejects(redditProvider.getPostAnalytics!(creds, "t3_abc"));
+    expect(err.message).toContain("401");
+  });
+});
+
+describe("redditProvider.getAccountAnalytics — fail closed", () => {
+  test("returns metrics on success", async () => {
+    fetchQueue = [
+      () => json(TOKEN),
+      () => json({ data: { id: "u1", name: "bob", link_karma: 5, comment_karma: 3 } }),
+    ];
+
+    const result = await redditProvider.getAccountAnalytics!(creds);
+    expect(result?.accountId).toBe("u1");
+    expect(result?.metrics.totalPosts).toBe(8);
+  });
+
+  test("PROPAGATES an internal failure (5xx on /api/v1/me) instead of returning null", async () => {
+    fetchQueue = [() => json(TOKEN), () => json({ error: "server" }, 503)];
+
+    const err = await rejects(redditProvider.getAccountAnalytics!(creds));
+    expect(err.message).toContain("503");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/providers/reddit.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/reddit.ts
@@ -12,7 +12,6 @@ import type {
   SocialMediaProvider,
 } from "../../../types/social-media";
 import { extractErrorMessage } from "../../../utils/error-handling";
-import { parseJsonErrorBody } from "../../../utils/json-parsing";
 import { logger } from "../../../utils/logger";
 import { withRetry } from "../rate-limit";
 
@@ -115,31 +114,6 @@ async function redditApiRequest<T>(
   return data;
 }
 
-async function _redditApiRequestLegacy<T>(
-  endpoint: string,
-  accessToken: string,
-  options: RequestInit = {},
-): Promise<T> {
-  const url = endpoint.startsWith("http") ? endpoint : `${REDDIT_API_BASE}${endpoint}`;
-
-  const response = await fetch(url, {
-    ...options,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/x-www-form-urlencoded",
-      "User-Agent": "ElizaCloud/1.0 (social-media-automation)",
-      ...options.headers,
-    },
-  });
-
-  if (!response.ok) {
-    const error = await parseJsonErrorBody<{ message?: string }>(response);
-    throw new Error(error.message || `Reddit API error: ${response.status}`);
-  }
-
-  return response.json();
-}
-
 export const redditProvider: SocialMediaProvider = {
   platform: "reddit",
 
@@ -176,6 +150,8 @@ export const redditProvider: SocialMediaProvider = {
         avatarUrl: user.data.icon_img?.split("?")[0],
       };
     } catch (error) {
+      // error-policy:J1 Boundary translation: an outbound Reddit auth/API failure
+      // becomes a structured invalid-credentials result for the caller.
       return {
         valid: false,
         error: extractErrorMessage(error),
@@ -306,6 +282,8 @@ export const redditProvider: SocialMediaProvider = {
         postUrl: `https://reddit.com${postData.url || `/r/${subreddit}/comments/${postData.id}`}`,
       };
     } catch (error) {
+      // error-policy:J1 Boundary translation: a failed Reddit submit call becomes a
+      // structured PostResult failure surfaced to the caller.
       logger.error("[Reddit] Post failed", { error });
       return {
         platform: "reddit",
@@ -343,6 +321,8 @@ export const redditProvider: SocialMediaProvider = {
 
       return { success: true };
     } catch (error) {
+      // error-policy:J1 Boundary translation: a failed Reddit API call becomes a
+      // structured failure result for the caller.
       return {
         success: false,
         error: extractErrorMessage(error),
@@ -363,38 +343,37 @@ export const redditProvider: SocialMediaProvider = {
       return null;
     }
 
-    try {
-      const accessToken = await getAccessToken(
-        credentials.apiKey,
-        credentials.apiSecret,
-        credentials.username,
-        credentials.password,
-      );
+    const accessToken = await getAccessToken(
+      credentials.apiKey,
+      credentials.apiSecret,
+      credentials.username,
+      credentials.password,
+    );
 
-      const cleanId = postId.replace("t3_", "");
+    const cleanId = postId.replace("t3_", "");
 
-      const response = await redditApiRequest<
-        Array<{ data: { children: Array<{ data: RedditSubmission }> } }>
-      >(`/api/info?id=t3_${cleanId}`, accessToken, {
-        headers: { "Content-Type": "application/json" },
-      });
+    const response = await redditApiRequest<
+      Array<{ data: { children: Array<{ data: RedditSubmission }> } }>
+    >(`/api/info?id=t3_${cleanId}`, accessToken, {
+      headers: { "Content-Type": "application/json" },
+    });
 
-      const post = response[0]?.data?.children?.[0]?.data;
-      if (!post) return null;
+    // A missing post (empty children) is a legitimately-empty result and stays
+    // null; internal failures (auth/network/rate-limit) propagate from
+    // redditApiRequest so a broken pipeline never reads as "no analytics".
+    const post = response[0]?.data?.children?.[0]?.data;
+    if (!post) return null;
 
-      return {
-        platform: "reddit",
-        postId,
-        metrics: {
-          likes: post.score,
-          comments: post.num_comments,
-          engagementRate: post.upvote_ratio * 100,
-        },
-        fetchedAt: new Date(),
-      };
-    } catch {
-      return null;
-    }
+    return {
+      platform: "reddit",
+      postId,
+      metrics: {
+        likes: post.score,
+        comments: post.num_comments,
+        engagementRate: post.upvote_ratio * 100,
+      },
+      fetchedAt: new Date(),
+    };
   },
 
   async getAccountAnalytics(credentials: SocialCredentials): Promise<AccountAnalytics | null> {
@@ -407,29 +386,25 @@ export const redditProvider: SocialMediaProvider = {
       return null;
     }
 
-    try {
-      const accessToken = await getAccessToken(
-        credentials.apiKey,
-        credentials.apiSecret,
-        credentials.username,
-        credentials.password,
-      );
+    const accessToken = await getAccessToken(
+      credentials.apiKey,
+      credentials.apiSecret,
+      credentials.username,
+      credentials.password,
+    );
 
-      const user = await redditApiRequest<{ data: RedditUser }>("/api/v1/me", accessToken, {
-        headers: { "Content-Type": "application/json" },
-      });
+    const user = await redditApiRequest<{ data: RedditUser }>("/api/v1/me", accessToken, {
+      headers: { "Content-Type": "application/json" },
+    });
 
-      return {
-        platform: "reddit",
-        accountId: user.data.id,
-        metrics: {
-          totalPosts: (user.data.link_karma || 0) + (user.data.comment_karma || 0),
-        },
-        fetchedAt: new Date(),
-      };
-    } catch {
-      return null;
-    }
+    return {
+      platform: "reddit",
+      accountId: user.data.id,
+      metrics: {
+        totalPosts: (user.data.link_karma || 0) + (user.data.comment_karma || 0),
+      },
+      fetchedAt: new Date(),
+    };
   },
 
   async replyToPost(
@@ -490,6 +465,8 @@ export const redditProvider: SocialMediaProvider = {
         postId: commentId || postId,
       };
     } catch (error) {
+      // error-policy:J1 Boundary translation: a failed Reddit comment call becomes a
+      // structured PostResult failure surfaced to the caller.
       return {
         platform: "reddit",
         success: false,
@@ -528,6 +505,8 @@ export const redditProvider: SocialMediaProvider = {
 
       return { success: true };
     } catch (error) {
+      // error-policy:J1 Boundary translation: a failed Reddit API call becomes a
+      // structured failure result for the caller.
       return {
         success: false,
         error: extractErrorMessage(error),

--- a/packages/cloud/shared/src/lib/services/social-media/providers/slack.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/slack.error-policy.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Pins the fail-closed error policy of the Slack provider (#13415).
+ *
+ * Two contracts are under test against the real exported `slackProvider`:
+ *   1. `uploadMedia` now throws when the source media download fails
+ *      (non-OK HTTP). Before the sweep it read `response.arrayBuffer()`
+ *      unconditionally, so a 404/500 error page was uploaded as the file —
+ *      a failed download silently fabricated a "successful" upload. The
+ *      already-existing fail-closed paths (`data.ok === false`, missing bytes)
+ *      are pinned alongside it.
+ *   2. `createPost`'s outermost J1 boundary translates a genuine send failure
+ *      into a structured `PostResult` with `success:false` (never a fabricated
+ *      "sent"), while the happy path returns `success:true` — the two stay
+ *      distinguishable.
+ *
+ * The `rate-limit` boundary (`withRetry`) is replaced with a sleepless
+ * pass-through mirroring its real throw-on-non-OK semantics so the changed
+ * branch — not the retry backoff — is exercised. `fetch` is stubbed per-test
+ * and restored in afterEach.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { MediaAttachment, PostContent, SocialCredentials } from "../../../types/social-media";
+
+mock.module("../rate-limit", () => ({
+  withRetry: async (fn: () => Promise<Response>, parser: (r: Response) => Promise<unknown>) => {
+    const response = await fn();
+    if (response.status === 429) throw new Error("Rate limited by slack");
+    const json = (await response.json()) as { ok?: boolean; error?: string };
+    if (!json.ok) throw new Error(json.error ?? "Slack API error");
+    // slackApiRequest's parser re-reads response.json(); hand it a clone-equivalent.
+    return {
+      data: json,
+    };
+  },
+  isRateLimitResponse: (r: Response) => r.status === 429,
+}));
+
+const { slackProvider } = await import("./slack");
+
+const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+const raw = (body: string, status = 200): Response =>
+  new Response(body, { status, headers: { "content-type": "text/plain" } });
+
+const BOT_CREDS = { botToken: "xoxb-token", channelId: "C123" } as SocialCredentials;
+
+let fetchQueue: Array<(input: unknown) => Response>;
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  fetchQueue = [];
+  globalThis.fetch = mock(async (input: unknown) => {
+    const next = fetchQueue.shift();
+    if (!next) throw new Error("unexpected fetch call — queue empty");
+    return next(input);
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  mock.restore();
+});
+
+async function rejects(p: Promise<unknown>): Promise<Error> {
+  try {
+    await p;
+  } catch (e) {
+    return e as Error;
+  }
+  throw new Error("expected promise to reject, but it resolved");
+}
+
+describe("slackProvider.uploadMedia — fail closed on a failed source download", () => {
+  const urlMedia = {
+    type: "image",
+    url: "https://cdn.example/pic.png",
+    mimeType: "image/png",
+  } as MediaAttachment;
+
+  test("PROPAGATES a non-OK media download instead of uploading the error body", async () => {
+    // Only the download is attempted; the files.upload fetch must never run.
+    fetchQueue = [() => raw("not found", 404)];
+
+    const err = await rejects(slackProvider.uploadMedia!(BOT_CREDS, urlMedia));
+    expect(err.message).toContain("Failed to download media");
+    expect(err.message).toContain("404");
+    // The upload call was never reached — the download failure short-circuited.
+    expect(fetchQueue.length).toBe(0);
+  });
+
+  test("uploads successfully when the download AND files.upload both succeed (drives the real path)", async () => {
+    fetchQueue = [
+      () => raw("PNGBYTES", 200),
+      () => json({ ok: true, file: { id: "F1", permalink: "https://files/x" } }),
+    ];
+
+    const result = await slackProvider.uploadMedia!(BOT_CREDS, urlMedia);
+    expect(result.mediaId).toBe("F1");
+    expect(result.url).toBe("https://files/x");
+  });
+
+  test("PROPAGATES a files.upload rejection (ok:false) instead of returning a fake mediaId", async () => {
+    fetchQueue = [() => raw("PNGBYTES", 200), () => json({ ok: false, error: "invalid_auth" })];
+
+    const err = await rejects(slackProvider.uploadMedia!(BOT_CREDS, urlMedia));
+    expect(err.message).toContain("invalid_auth");
+  });
+
+  test("throws when no media bytes/url are provided (designed invalid input, distinct from a download failure)", async () => {
+    const err = await rejects(
+      slackProvider.uploadMedia!(BOT_CREDS, {
+        type: "image",
+        mimeType: "image/png",
+      } as MediaAttachment),
+    );
+    expect(err.message).toContain("No media data provided");
+  });
+});
+
+describe("slackProvider.createPost — designed failure vs success stay distinguishable", () => {
+  const content = { text: "hello" } as PostContent;
+
+  test("returns success:true with a postId on a real send", async () => {
+    fetchQueue = [() => json({ ok: true, message: { ts: "1700.1" }, channel: "C123" })];
+
+    const result = await slackProvider.createPost(BOT_CREDS, content);
+    expect(result.success).toBe(true);
+    expect(result.postId).toBe("1700.1");
+  });
+
+  test("returns a structured success:false (never a fabricated 'sent') when Slack rejects the post", async () => {
+    fetchQueue = [() => json({ ok: false, error: "channel_not_found" })];
+
+    const result = await slackProvider.createPost(BOT_CREDS, content);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("channel_not_found");
+    // A failure carries no postId — the caller cannot mistake it for a real message.
+    expect(result.postId).toBeUndefined();
+  });
+
+  test("designed pre-flight failure (missing channel) is a distinct success:false, no fetch attempted", async () => {
+    const result = await slackProvider.createPost(
+      { botToken: "xoxb-token" } as SocialCredentials,
+      content,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Channel ID required");
+    // No outbound call happened — the queue was never touched.
+    expect(fetchQueue.length).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/providers/slack.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/slack.ts
@@ -167,6 +167,7 @@ export const slackProvider: SocialMediaProvider = {
         displayName: response.user?.real_name,
       };
     } catch (error) {
+      // error-policy:J1 outbound auth.test boundary — a reachable API rejecting the token means the credentials are invalid; the upstream error surfaces in the returned `error` field.
       return {
         valid: false,
         error: extractErrorMessage(error),
@@ -243,6 +244,7 @@ export const slackProvider: SocialMediaProvider = {
         metadata: { channel: response.channel },
       };
     } catch (error) {
+      // error-policy:J1 outbound Slack post boundary — translate any send failure into a structured PostResult failure (success:false) the caller renders; the message is not fabricated as sent.
       logger.error("[Slack] Post failed", { error });
       return {
         platform: "slack",
@@ -272,6 +274,7 @@ export const slackProvider: SocialMediaProvider = {
       });
       return { success: true };
     } catch (error) {
+      // error-policy:J1 outbound chat.delete boundary — a failed delete returns a structured failure (success:false) rather than reporting a delete that did not happen.
       return {
         success: false,
         error: extractErrorMessage(error),
@@ -321,6 +324,7 @@ export const slackProvider: SocialMediaProvider = {
       });
       return { success: true };
     } catch (error) {
+      // error-policy:J1 outbound reactions.add boundary — a failed reaction returns a structured failure (success:false) rather than reporting a like that did not land.
       return {
         success: false,
         error: extractErrorMessage(error),
@@ -340,6 +344,9 @@ export const slackProvider: SocialMediaProvider = {
       fileData = Buffer.from(media.base64, "base64");
     } else if (media.url) {
       const response = await fetch(media.url);
+      if (!response.ok) {
+        throw new Error(`Failed to download media from ${media.url}: ${response.status}`);
+      }
       fileData = Buffer.from(await response.arrayBuffer());
       const urlParts = media.url.split("/");
       filename = urlParts[urlParts.length - 1].split("?")[0] || filename;

--- a/packages/cloud/shared/src/lib/services/social-media/providers/telegram.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/telegram.error-policy.test.ts
@@ -1,0 +1,142 @@
+// Pins the fail-closed error policy of the Telegram provider. An upstream Bot API failure
+// (transport reject or a `{ ok:false }` payload) is translated at the J1 boundary into the
+// typed failure DTO the multi-platform caller reads to drive credit refunds — never a
+// fabricated `valid:true` / `success:true`. The designed missing-credential guard is a
+// distinct short-circuit that performs zero fetch, keeping "not configured" separable from
+// "the call failed". Deterministic fetch fixtures drive the real exported provider; no live
+// network. Backoff sleeps are collapsed so a retrying failure rejects promptly.
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+mock.module("../../../utils/logger", () => ({
+  logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
+}));
+
+const { telegramProvider } = await import("./telegram");
+
+const realFetch = globalThis.fetch;
+const realSetTimeout = globalThis.setTimeout;
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function urlOf(input: unknown): string {
+  if (typeof input === "string") return input;
+  if (input instanceof Request) return input.url;
+  return String(input);
+}
+
+const CREDS = { botToken: "123:abc" } as never;
+const NO_CREDS = {} as never;
+
+beforeEach(() => {
+  // Collapse rate-limit / retry backoff so a failing request rejects without waiting out
+  // the real exponential-backoff delays inside withRetry.
+  (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout = ((fn: () => void) => {
+    fn();
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  globalThis.setTimeout = realSetTimeout;
+});
+
+describe("telegramProvider error policy", () => {
+  it("validateCredentials short-circuits to { valid:false } with zero fetch when the bot token is absent (designed 'not configured')", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls++;
+      return jsonResponse({ ok: true, result: {} });
+    }) as typeof fetch;
+
+    const result = await telegramProvider.validateCredentials(NO_CREDS);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Bot token required");
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("validateCredentials never fabricates valid:true from an upstream getMe failure (fail-closed boundary translation)", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async (input: unknown) => {
+      fetchCalls++;
+      expect(urlOf(input)).toContain("getMe");
+      // Telegram returns HTTP 200 with an { ok:false } envelope on auth failure.
+      return jsonResponse({ ok: false, description: "Unauthorized", error_code: 401 });
+    }) as typeof fetch;
+
+    const result = await telegramProvider.validateCredentials(CREDS);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Unauthorized");
+    // The failure genuinely reached the network (distinct from the no-token short-circuit).
+    expect(fetchCalls).toBeGreaterThan(0);
+  });
+
+  it("validateCredentials returns real account identity on success (drives the real reader, not a tautology)", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({
+        ok: true,
+        result: { id: 42, is_bot: true, first_name: "Botty", username: "botty_bot" },
+      }),
+    ) as typeof fetch;
+
+    const result = await telegramProvider.validateCredentials(CREDS);
+
+    expect(result.valid).toBe(true);
+    expect(result.accountId).toBe("42");
+    expect(result.username).toBe("botty_bot");
+    expect(result.displayName).toBe("Botty");
+  });
+
+  it("createPost translates an upstream sendMessage failure into { success:false } — never a fabricated success the refund path would skip", async () => {
+    globalThis.fetch = mock(async (input: unknown) => {
+      expect(urlOf(input)).toContain("sendMessage");
+      return jsonResponse({ ok: false, description: "chat not found", error_code: 400 });
+    }) as typeof fetch;
+
+    const result = await telegramProvider.createPost(CREDS, { text: "hello" }, {
+      telegram: { chatId: "999" },
+    } as never);
+
+    expect(result.success).toBe(false);
+    expect(result.platform).toBe("telegram");
+    expect(result.error).toBe("chat not found");
+  });
+
+  it("createPost short-circuits to { success:false } with zero fetch when chatId is missing (designed guard, distinct from a call failure)", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls++;
+      return jsonResponse({ ok: true, result: {} });
+    }) as typeof fetch;
+
+    const result = await telegramProvider.createPost(CREDS, { text: "hi" }, {} as never);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Chat ID required");
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("createPost returns a real postId on a successful send", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({
+        ok: true,
+        result: { message_id: 7, chat: { id: 999, type: "private" }, text: "hi" },
+      }),
+    ) as typeof fetch;
+
+    const result = await telegramProvider.createPost(CREDS, { text: "hi" }, {
+      telegram: { chatId: "999" },
+    } as never);
+
+    expect(result.success).toBe(true);
+    expect(result.postId).toBe("7");
+    expect(result.metadata).toEqual({ chatId: 999 });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/providers/telegram.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/telegram.ts
@@ -102,6 +102,7 @@ export const telegramProvider: SocialMediaProvider = {
         displayName: user.first_name,
       };
     } catch (error) {
+      // error-policy:J1 boundary translation — an outbound Telegram getMe auth failure becomes the typed { valid:false } result the credential validator returns (never a fabricated valid credential)
       return {
         valid: false,
         error: extractErrorMessage(error),
@@ -204,6 +205,7 @@ export const telegramProvider: SocialMediaProvider = {
         metadata: { chatId: message.chat.id },
       };
     } catch (error) {
+      // error-policy:J1 transport boundary — an outbound Telegram send failure becomes the typed { success:false } PostResult the caller renders (never a fabricated success)
       logger.error("[Telegram] Post failed", { error });
       return {
         platform: "telegram",
@@ -236,6 +238,7 @@ export const telegramProvider: SocialMediaProvider = {
 
       return { success: true };
     } catch (error) {
+      // error-policy:J1 boundary translation — a failed Telegram deleteMessage call becomes the typed { success:false } result (never a fabricated deletion success)
       return {
         success: false,
         error: extractErrorMessage(error),

--- a/packages/cloud/shared/src/lib/services/social-media/providers/tiktok.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/tiktok.error-policy.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Error-policy pin for the TikTok provider (#13415). Drives the real exported
+ * `tiktokProvider` methods and proves the fail-closed split:
+ *   - the analytics readers (`getPostAnalytics`/`getAccountAnalytics`) PROPAGATE an
+ *     internal upstream failure (throw) instead of swallowing it into a fabricated
+ *     `null`, while `null` stays reserved for the designed-empty "no rows" result;
+ *   - `createPost` and `validateCredentials` still translate an upstream failure into
+ *     their structured `{success:false}` / `{valid:false}` DTO (J1 boundary) that the
+ *     credit-refund + connect flows depend on — a returned failure, not a fabricated
+ *     success.
+ *
+ * The rate-limit/transport seam (`../rate-limit`) is replaced with a no-retry
+ * pass-through so the REAL `tiktokApiRequest` parser and provider branching run
+ * without the exponential-backoff sleeps; `globalThis.fetch` supplies the raw
+ * upstream JSON.
+ */
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { SocialCredentials } from "../../../types/social-media";
+
+// Pass-through withRetry: run fetch once, run the REAL parser (which is where
+// tiktokApiRequest turns an upstream error code into a throw), no backoff sleeps.
+mock.module("../rate-limit", () => ({
+  withRetry: async <T>(
+    fn: () => Promise<Response>,
+    parser: (r: Response) => Promise<T>,
+  ): Promise<{ data: T }> => {
+    const response = await fn();
+    return { data: await parser(response) };
+  },
+}));
+
+const { tiktokProvider } = await import("./tiktok");
+
+const CREDS = { accessToken: "tok" } as SocialCredentials;
+
+const originalFetch = globalThis.fetch;
+let fetchImpl: (url: string, init?: RequestInit) => Promise<unknown>;
+
+function upstream(body: unknown): { json: () => Promise<unknown> } {
+  return { json: async () => body };
+}
+
+beforeEach(() => {
+  globalThis.fetch = mock((url: string, init?: RequestInit) =>
+    fetchImpl(url, init),
+  ) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("tiktokProvider.getPostAnalytics — internal failure propagates, empty stays null", () => {
+  it("PROPAGATES an upstream failure instead of returning a fabricated null", async () => {
+    fetchImpl = async () =>
+      upstream({ error: { code: "internal_error", message: "tiktok upstream 500" } });
+
+    const call = tiktokProvider.getPostAnalytics?.(CREDS, "post-1");
+    expect(call).toBeDefined();
+    await expect(call).rejects.toThrow("tiktok upstream 500");
+  });
+
+  it("returns null ONLY for the designed-empty result (upstream reports zero videos)", async () => {
+    fetchImpl = async () => upstream({ data: { videos: [] } });
+
+    const result = await tiktokProvider.getPostAnalytics?.(CREDS, "post-1");
+    expect(result).toBeNull();
+  });
+
+  it("maps real metrics on success", async () => {
+    fetchImpl = async () =>
+      upstream({
+        data: {
+          videos: [
+            { id: "post-1", like_count: 5, comment_count: 2, share_count: 1, view_count: 99 },
+          ],
+        },
+      });
+
+    const result = await tiktokProvider.getPostAnalytics?.(CREDS, "post-1");
+    expect(result?.metrics.likes).toBe(5);
+    expect(result?.metrics.videoViews).toBe(99);
+  });
+
+  it("returns null (not a throw) when no access token is configured", async () => {
+    const result = await tiktokProvider.getPostAnalytics?.({} as SocialCredentials, "post-1");
+    expect(result).toBeNull();
+  });
+});
+
+describe("tiktokProvider.getAccountAnalytics — internal failure propagates", () => {
+  it("PROPAGATES an upstream failure instead of returning a fabricated null", async () => {
+    fetchImpl = async () =>
+      upstream({ error: { code: "rate_limited", message: "tiktok account 429" } });
+
+    const call = tiktokProvider.getAccountAnalytics?.(CREDS);
+    expect(call).toBeDefined();
+    await expect(call).rejects.toThrow("tiktok account 429");
+  });
+
+  it("maps real account metrics on success", async () => {
+    fetchImpl = async () =>
+      upstream({
+        data: {
+          user: {
+            open_id: "acct-1",
+            display_name: "Tester",
+            follower_count: 1000,
+            following_count: 10,
+            video_count: 42,
+          },
+        },
+      });
+
+    const result = await tiktokProvider.getAccountAnalytics?.(CREDS);
+    expect(result?.accountId).toBe("acct-1");
+    expect(result?.metrics.followers).toBe(1000);
+    expect(result?.metrics.totalPosts).toBe(42);
+  });
+});
+
+describe("tiktokProvider J1 boundaries — upstream failure becomes a structured failure DTO", () => {
+  it("createPost returns {success:false} (the refund flow depends on this, not a throw)", async () => {
+    fetchImpl = async () =>
+      upstream({ error: { code: "spam_risk_too_many_posts", message: "post rejected" } });
+
+    const result = await tiktokProvider.createPost(CREDS, {
+      text: "hello",
+      media: [{ type: "video", url: "https://example.com/v.mp4" }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("post rejected");
+  });
+
+  it("validateCredentials returns {valid:false} on an upstream auth failure", async () => {
+    fetchImpl = async () =>
+      upstream({ error: { code: "access_token_invalid", message: "bad token" } });
+
+    const result = await tiktokProvider.validateCredentials(CREDS);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("bad token");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/providers/tiktok.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/tiktok.ts
@@ -134,6 +134,8 @@ export const tiktokProvider: SocialMediaProvider = {
         avatarUrl: user.user.avatar_url,
       };
     } catch (error) {
+      // error-policy:J1 boundary translation — upstream auth-check failure becomes the
+      // structured {valid:false,error} result the credential-connect flow renders.
       return {
         valid: false,
         error: extractErrorMessage(error),
@@ -277,6 +279,9 @@ export const tiktokProvider: SocialMediaProvider = {
         error: "Video URL or data required",
       };
     } catch (error) {
+      // error-policy:J1 boundary translation — a failed post becomes the {success:false}
+      // PostResult the caller inspects; socialMediaService relies on this (not a throw) to
+      // drive the per-platform credit refund (#11680).
       logger.error("[TikTok] Post failed", { error });
       return {
         platform: "tiktok",
@@ -294,44 +299,40 @@ export const tiktokProvider: SocialMediaProvider = {
       return null;
     }
 
-    try {
-      const response = await tiktokApiRequest<{
-        videos: Array<{
-          id: string;
-          like_count?: number;
-          comment_count?: number;
-          share_count?: number;
-          view_count?: number;
-        }>;
-      }>(
-        `/video/query/?fields=id,like_count,comment_count,share_count,view_count`,
-        credentials.accessToken,
-        {
-          method: "POST",
-          body: JSON.stringify({ filters: { video_ids: [postId] } }),
-        },
-      );
+    const response = await tiktokApiRequest<{
+      videos: Array<{
+        id: string;
+        like_count?: number;
+        comment_count?: number;
+        share_count?: number;
+        view_count?: number;
+      }>;
+    }>(
+      `/video/query/?fields=id,like_count,comment_count,share_count,view_count`,
+      credentials.accessToken,
+      {
+        method: "POST",
+        body: JSON.stringify({ filters: { video_ids: [postId] } }),
+      },
+    );
 
-      const video = response.videos?.[0];
-      if (!video) return null;
+    // `null` is the designed-empty result — upstream returned zero matching videos.
+    // An internal failure (transport/5xx/rate-limit) throws out of tiktokApiRequest and
+    // must stay distinguishable from this, so it is deliberately NOT caught here.
+    const video = response.videos?.[0];
+    if (!video) return null;
 
-      return {
-        platform: "tiktok",
-        postId,
-        metrics: {
-          likes: video.like_count,
-          comments: video.comment_count,
-          shares: video.share_count,
-          videoViews: video.view_count,
-        },
-        fetchedAt: new Date(),
-      };
-    } catch (error) {
-      logger.warn("[TikTok] getPostAnalytics failed", {
-        error: extractErrorMessage(error),
-      });
-      return null;
-    }
+    return {
+      platform: "tiktok",
+      postId,
+      metrics: {
+        likes: video.like_count,
+        comments: video.comment_count,
+        shares: video.share_count,
+        videoViews: video.view_count,
+      },
+      fetchedAt: new Date(),
+    };
   },
 
   async getAccountAnalytics(credentials: SocialCredentials): Promise<AccountAnalytics | null> {
@@ -339,28 +340,24 @@ export const tiktokProvider: SocialMediaProvider = {
       return null;
     }
 
-    try {
-      const user = await tiktokApiRequest<{ user: TikTokUser }>(
-        "/user/info/?fields=open_id,display_name,follower_count,following_count,video_count",
-        credentials.accessToken,
-      );
+    // No catch: an upstream failure throws out of tiktokApiRequest and propagates so the
+    // caller sees a broken pipeline, never a fabricated null "no data" result. The only
+    // `null` this method returns is the designed no-credentials guard above.
+    const user = await tiktokApiRequest<{ user: TikTokUser }>(
+      "/user/info/?fields=open_id,display_name,follower_count,following_count,video_count",
+      credentials.accessToken,
+    );
 
-      return {
-        platform: "tiktok",
-        accountId: user.user.open_id,
-        metrics: {
-          followers: user.user.follower_count,
-          following: user.user.following_count,
-          totalPosts: user.user.video_count,
-        },
-        fetchedAt: new Date(),
-      };
-    } catch (error) {
-      logger.warn("[TikTok] getAccountAnalytics failed", {
-        error: extractErrorMessage(error),
-      });
-      return null;
-    }
+    return {
+      platform: "tiktok",
+      accountId: user.user.open_id,
+      metrics: {
+        followers: user.user.follower_count,
+        following: user.user.following_count,
+        totalPosts: user.user.video_count,
+      },
+      fetchedAt: new Date(),
+    };
   },
 
   async uploadMedia(credentials: SocialCredentials, media: MediaAttachment) {

--- a/packages/cloud/shared/src/lib/services/social-media/providers/twitter.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/twitter.error-policy.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Error-policy pin for the Twitter provider (#13415). Drives the real exported
+ * `twitterProvider` methods and proves the fail-closed split:
+ *   - the analytics readers (`getPostAnalytics`/`getAccountAnalytics`) PROPAGATE an
+ *     internal upstream failure (throw) instead of swallowing it into a fabricated
+ *     `null`; `null` stays reserved for the designed no-credentials guard the service
+ *     layer treats as "provider not available";
+ *   - `createPost`, `validateCredentials`, and `deletePost` still translate an upstream
+ *     failure into their structured `{success:false}` / `{valid:false}` DTO (J1 boundary)
+ *     that the connect + credit-refund flows depend on — a returned failure, not a throw
+ *     and not a fabricated success.
+ *
+ * The rate-limit/transport seam (`../rate-limit`) is replaced with a no-backoff
+ * pass-through that mirrors the real `!response.ok` throw, so the REAL provider mapping
+ * and JSON parser run without the exponential-backoff sleeps; `globalThis.fetch` supplies
+ * the raw upstream Response.
+ */
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { SocialCredentials } from "../../../types/social-media";
+
+// Pass-through withRetry: run fetch once, mirror the real non-ok throw, run the parser.
+// No backoff sleeps, no retry loop — the point under test is that the provider does NOT
+// catch what this throws.
+mock.module("../rate-limit", () => ({
+  withRetry: async <T>(
+    fn: () => Promise<Response>,
+    parser: (r: Response) => Promise<T>,
+  ): Promise<{ data: T }> => {
+    const response = await fn();
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`twitter API error ${response.status}: ${body}`);
+    }
+    return { data: await parser(response) };
+  },
+}));
+
+const { twitterProvider } = await import("./twitter");
+
+const CREDS = { accessToken: "tok" } as SocialCredentials;
+
+const originalFetch = globalThis.fetch;
+let fetchImpl: (url: string, init?: RequestInit) => Promise<unknown>;
+
+function okJson(body: unknown): Partial<Response> {
+  return { ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) };
+}
+
+function upstreamFailure(status: number, body: string): Partial<Response> {
+  return { ok: false, status, json: async () => ({}), text: async () => body };
+}
+
+beforeEach(() => {
+  globalThis.fetch = mock((url: string, init?: RequestInit) =>
+    fetchImpl(url, init),
+  ) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("twitterProvider.getPostAnalytics — internal failure propagates, guard stays null", () => {
+  it("PROPAGATES an upstream failure instead of returning a fabricated null", async () => {
+    fetchImpl = async () => upstreamFailure(500, "twitter upstream boom");
+
+    const call = twitterProvider.getPostAnalytics?.(CREDS, "post-1");
+    expect(call).toBeDefined();
+    await expect(call).rejects.toThrow(/twitter API error 500/);
+  });
+
+  it("returns null ONLY for the designed no-credentials guard (never for a failure)", async () => {
+    let fetched = false;
+    fetchImpl = async () => {
+      fetched = true;
+      return okJson({});
+    };
+
+    const result = await twitterProvider.getPostAnalytics?.({} as SocialCredentials, "post-1");
+    expect(result).toBeNull();
+    expect(fetched).toBe(false);
+  });
+
+  it("maps real metrics on success", async () => {
+    fetchImpl = async () =>
+      okJson({
+        data: {
+          public_metrics: {
+            like_count: 5,
+            retweet_count: 3,
+            reply_count: 2,
+            quote_count: 1,
+            impression_count: 99,
+          },
+        },
+      });
+
+    const result = await twitterProvider.getPostAnalytics?.(CREDS, "post-1");
+    expect(result?.metrics.likes).toBe(5);
+    expect(result?.metrics.reposts).toBe(3);
+    expect(result?.metrics.impressions).toBe(99);
+  });
+});
+
+describe("twitterProvider.getAccountAnalytics — internal failure propagates", () => {
+  it("PROPAGATES an upstream failure instead of returning a fabricated null", async () => {
+    fetchImpl = async () => upstreamFailure(429, "twitter account rate limit");
+
+    const call = twitterProvider.getAccountAnalytics?.(CREDS);
+    expect(call).toBeDefined();
+    await expect(call).rejects.toThrow(/twitter API error 429/);
+  });
+
+  it("returns null ONLY for the designed no-credentials guard", async () => {
+    let fetched = false;
+    fetchImpl = async () => {
+      fetched = true;
+      return okJson({});
+    };
+
+    const result = await twitterProvider.getAccountAnalytics?.({} as SocialCredentials);
+    expect(result).toBeNull();
+    expect(fetched).toBe(false);
+  });
+
+  it("maps real account metrics on success", async () => {
+    fetchImpl = async () =>
+      okJson({
+        data: {
+          id: "acct-1",
+          public_metrics: {
+            followers_count: 1000,
+            following_count: 10,
+            tweet_count: 42,
+          },
+        },
+      });
+
+    const result = await twitterProvider.getAccountAnalytics?.(CREDS);
+    expect(result?.accountId).toBe("acct-1");
+    expect(result?.metrics.followers).toBe(1000);
+    expect(result?.metrics.totalPosts).toBe(42);
+  });
+});
+
+describe("twitterProvider J1 boundaries — upstream failure becomes a structured failure DTO", () => {
+  it("createPost returns {success:false} (the refund flow depends on this, not a throw)", async () => {
+    fetchImpl = async () => upstreamFailure(403, "post rejected");
+
+    const result = await twitterProvider.createPost(CREDS, { text: "hello" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("post rejected");
+  });
+
+  it("validateCredentials returns {valid:false} on an upstream auth failure", async () => {
+    fetchImpl = async () => upstreamFailure(401, "bad token");
+
+    const result = await twitterProvider.validateCredentials(CREDS);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("bad token");
+  });
+
+  it("deletePost returns {success:false} on an upstream failure", async () => {
+    fetchImpl = async () => upstreamFailure(404, "not found");
+
+    const result = await twitterProvider.deletePost?.(CREDS, "post-1");
+    expect(result?.success).toBe(false);
+    expect(result?.error).toContain("not found");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/providers/twitter.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/twitter.ts
@@ -214,6 +214,8 @@ export const twitterProvider: SocialMediaProvider = {
         avatarUrl: response.data.profile_image_url,
       };
     } catch (error) {
+      // error-policy:J1 boundary translation — an outbound Twitter auth-check failure becomes
+      // the typed {valid:false} the connect flow depends on, not a fabricated valid credential.
       return {
         valid: false,
         error: extractErrorMessage(error),
@@ -274,6 +276,8 @@ export const twitterProvider: SocialMediaProvider = {
         postUrl: `https://twitter.com/i/status/${response.data.id}`,
       };
     } catch (error) {
+      // error-policy:J1 boundary translation — a failed Twitter post becomes the {success:false}
+      // PostResult the credit-refund flow depends on, never a fabricated success.
       logger.error("[Twitter] Post failed", { error });
       return {
         platform: "twitter",
@@ -295,6 +299,8 @@ export const twitterProvider: SocialMediaProvider = {
 
       return { success: true };
     } catch (error) {
+      // error-policy:J1 boundary translation — a failed Twitter delete becomes a typed
+      // {success:false} result the caller inspects, not a swallowed error.
       return {
         success: false,
         error: extractErrorMessage(error),
@@ -306,80 +312,71 @@ export const twitterProvider: SocialMediaProvider = {
     credentials: SocialCredentials,
     postId: string,
   ): Promise<PostAnalytics | null> {
+    // `null` is reserved for the designed no-credentials guard. An internal upstream
+    // failure throws out of twitterApiRequest and propagates so a broken pipeline never
+    // reads as a fabricated "no analytics" result — it must stay distinguishable from the
+    // provider-not-configured `null` the service layer treats as empty.
     if (!credentials.accessToken) {
       return null;
     }
 
-    try {
-      const response = await twitterApiRequest<{
-        data: {
-          public_metrics: {
-            like_count: number;
-            retweet_count: number;
-            reply_count: number;
-            quote_count: number;
-            impression_count?: number;
-          };
+    const response = await twitterApiRequest<{
+      data: {
+        public_metrics: {
+          like_count: number;
+          retweet_count: number;
+          reply_count: number;
+          quote_count: number;
+          impression_count?: number;
         };
-      }>(`/tweets/${postId}?tweet.fields=public_metrics`, credentials.accessToken);
-
-      const metrics = response.data.public_metrics;
-
-      return {
-        platform: "twitter",
-        postId,
-        metrics: {
-          likes: metrics.like_count,
-          reposts: metrics.retweet_count,
-          comments: metrics.reply_count,
-          shares: metrics.quote_count,
-          impressions: metrics.impression_count,
-        },
-        fetchedAt: new Date(),
       };
-    } catch (error) {
-      logger.warn("[Twitter] getPostAnalytics failed", {
-        error: extractErrorMessage(error),
-      });
-      return null;
-    }
+    }>(`/tweets/${postId}?tweet.fields=public_metrics`, credentials.accessToken);
+
+    const metrics = response.data.public_metrics;
+
+    return {
+      platform: "twitter",
+      postId,
+      metrics: {
+        likes: metrics.like_count,
+        reposts: metrics.retweet_count,
+        comments: metrics.reply_count,
+        shares: metrics.quote_count,
+        impressions: metrics.impression_count,
+      },
+      fetchedAt: new Date(),
+    };
   },
 
   async getAccountAnalytics(credentials: SocialCredentials): Promise<AccountAnalytics | null> {
+    // See getPostAnalytics: `null` is only the no-credentials guard; upstream failures throw.
     if (!credentials.accessToken) {
       return null;
     }
 
-    try {
-      const response = await twitterApiRequest<{
-        data: {
-          id: string;
-          public_metrics: {
-            followers_count: number;
-            following_count: number;
-            tweet_count: number;
-          };
+    const response = await twitterApiRequest<{
+      data: {
+        id: string;
+        public_metrics: {
+          followers_count: number;
+          following_count: number;
+          tweet_count: number;
         };
-      }>("/users/me?user.fields=public_metrics", credentials.accessToken);
-
-      const metrics = response.data.public_metrics;
-
-      return {
-        platform: "twitter",
-        accountId: response.data.id,
-        metrics: {
-          followers: metrics.followers_count,
-          following: metrics.following_count,
-          totalPosts: metrics.tweet_count,
-        },
-        fetchedAt: new Date(),
       };
-    } catch (error) {
-      logger.warn("[Twitter] getAccountAnalytics failed", {
-        error: extractErrorMessage(error),
-      });
-      return null;
-    }
+    }>("/users/me?user.fields=public_metrics", credentials.accessToken);
+
+    const metrics = response.data.public_metrics;
+
+    return {
+      platform: "twitter",
+      accountId: response.data.id,
+      metrics: {
+        followers: metrics.followers_count,
+        following: metrics.following_count,
+        totalPosts: metrics.tweet_count,
+      },
+      fetchedAt: new Date(),
+    };
   },
 
   async uploadMedia(credentials: SocialCredentials, media: MediaAttachment) {
@@ -414,6 +411,8 @@ export const twitterProvider: SocialMediaProvider = {
       });
       return { success: true };
     } catch (error) {
+      // error-policy:J1 boundary translation — a failed Twitter like becomes a typed
+      // {success:false} result the caller inspects, not a swallowed error.
       return { success: false, error: extractErrorMessage(error) };
     }
   },
@@ -437,6 +436,8 @@ export const twitterProvider: SocialMediaProvider = {
       });
       return { platform: "twitter", success: true, postId };
     } catch (error) {
+      // error-policy:J1 boundary translation — a failed Twitter repost becomes the {success:false}
+      // PostResult the caller inspects, never a fabricated success.
       return {
         platform: "twitter",
         success: false,

--- a/packages/cloud/shared/src/lib/services/social-media/rate-limit.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/rate-limit.error-policy.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Fail-closed error propagation for the social-media `withRetry` transport
+ * boundary (#13415). withRetry wraps every outbound platform API call; a
+ * regression that swallowed a transport/HTTP failure into a fabricated
+ * `{ data }` would make a broken connector look healthy. These tests pin the
+ * two distinguishable outcomes: an INTERNAL failure (429 exhaustion, non-ok
+ * status, thrown fn) PROPAGATES as a thrown error, while a legitimately-EMPTY
+ * domain result from the parser passes through as `{ data: [] }` untouched.
+ *
+ * The logger dependency is mocked to silence retry warnings; the real
+ * `withRetry` control flow runs. No real network — `fn` is injected, so we feed
+ * it deterministic `Response` objects.
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+mock.module("../../utils/logger", () => ({
+  logger: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
+}));
+
+const { withRetry, isRateLimitResponse, createRateLimitError } = await import("./rate-limit");
+
+afterEach(() => {
+  mock.restore();
+});
+
+const NO_WAIT = { platform: "twitter" as const, maxRetries: 0, baseDelayMs: 0 };
+
+describe("withRetry — internal failure propagates vs designed-empty passes through", () => {
+  it("PROPAGATES a non-ok HTTP status as a thrown error (never fabricates data)", async () => {
+    const fn = async () => new Response("boom", { status: 500 });
+    const parser = async (r: Response) => r.json();
+    await expect(withRetry(fn, parser, NO_WAIT)).rejects.toThrow("twitter API error 500: boom");
+  });
+
+  it("throws a typed RateLimitError after 429 exhaustion (fail-closed, not empty)", async () => {
+    const fn = async () => new Response("", { status: 429, headers: { "retry-after": "7" } });
+    const parser = async (r: Response) => r.json();
+    const err = await withRetry(fn, parser, NO_WAIT).catch((e) => e);
+    expect(err).toMatchObject({ rateLimited: true, platform: "twitter", retryAfter: 7 });
+  });
+
+  it("PROPAGATES a thrown fn (network/parse) as the final error, not a default", async () => {
+    const fn = async () => {
+      throw new Error("ECONNRESET");
+    };
+    const parser = async (r: Response) => r.json();
+    await expect(withRetry(fn, parser, NO_WAIT)).rejects.toThrow("ECONNRESET");
+  });
+
+  it("passes a legitimately-EMPTY domain result through as { data: [] } (distinct from failure)", async () => {
+    const fn = async () => new Response(JSON.stringify([]), { status: 200 });
+    const parser = async (r: Response) => (await r.json()) as unknown[];
+    const result = await withRetry(fn, parser, NO_WAIT);
+    expect(result).toEqual({ data: [] });
+  });
+
+  it("recovers after a transient 429 then a 200 (retry surfaces success, no swallow)", async () => {
+    let call = 0;
+    const fn = async () => {
+      call += 1;
+      return call === 1
+        ? new Response("", { status: 429 })
+        : new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+    const parser = async (r: Response) => (await r.json()) as { ok: boolean };
+    const result = await withRetry(fn, parser, {
+      platform: "twitter",
+      maxRetries: 1,
+      baseDelayMs: 0,
+    });
+    expect(result).toEqual({ data: { ok: true } });
+    expect(call).toBe(2);
+  });
+
+  it("helpers stay honest: 429 detected, createRateLimitError carries platform + retryAfter", () => {
+    expect(isRateLimitResponse(new Response("", { status: 429 }))).toBe(true);
+    expect(isRateLimitResponse(new Response("", { status: 200 }))).toBe(false);
+    const e = createRateLimitError("bluesky", 12);
+    expect(e).toMatchObject({ rateLimited: true, platform: "bluesky", retryAfter: 12 });
+    expect(e.message).toContain("bluesky");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/rate-limit.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/rate-limit.ts
@@ -88,12 +88,14 @@ export async function withRetry<T>(
       }
 
       if (!response.ok) {
+        // error-policy:J6 best-effort error-body read; the HTTP failure still surfaces via the thrown status error below
         const errorBody = await response.text().catch(() => "");
         throw new Error(`${platform} API error ${response.status}: ${errorBody}`);
       }
 
       return { data: await parser(response) };
     } catch (error) {
+      // error-policy:J1 outbound social-platform API transport boundary — retries transient failures and propagates the last error after exhausting retries (fail-closed)
       lastError = error instanceof Error ? error : new Error(String(error));
       if ((error as RateLimitError).rateLimited) throw error;
 


### PR DESCRIPTION
## Slice 4b of #13415 — social-media platform connectors

bluesky · discord · linkedin · meta · reddit · slack · telegram · tiktok · twitter.

**Fixes real fail-open bugs:** catches/`.catch` that swallowed a failed platform API call (token exchange, post publish, profile fetch) into `null`/`[]`/`false` made a genuine **outbound failure read as "no result" / "not connected"** — silently dropping a post or misreporting connection state. Now those propagate (J1/J2 rethrow with `cause`), while a legitimately-empty platform response (no items, optional field absent) still returns its designed empty result — the two stay **distinguishable**. Best-effort paths (rate-limit writes, teardown) annotated J6/J7; `console`→logger where present. No credit/debit arithmetic touched.

**Verification:** 12 focused `bun:test` error-path suites (part of 134 new proxy+social tests, all pass under `--isolate`); existing social-media suites green (0 regressions); biome clean; `audit:error-policy-ratchet` → "no new fallback-slop". Connector/security-sensitive — flagged for review, not solo-merge.