### PR TITLE
fix(#13422): migrate packages/core aliased env reads to the alias-aware reader (long-tail)

### DIFF
--- a/packages/core/src/testing/live-provider.alias.test.ts
+++ b/packages/core/src/testing/live-provider.alias.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Proves the live-provider on-disk cloud-key resolution reads ELIZA_NAMESPACE and
+ * ELIZA_CONFIG_PATH through the alias-aware reader (#13422), so a non-eliza brand
+ * prefix (MILADY_*) resolves, the canonical ELIZA_* key wins, a blank canonical
+ * value is treated as unset, and the reader never mirror-writes an ELIZA_* key.
+ * Deterministic: drives the real selectLiveProvider() cloud branch against a
+ * temp config file, mutating and restoring process.env / the boot-config alias
+ * table / HOME around each case.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { peekAmbientSingleton, setAmbientSingleton } from "../ambient-context";
+
+const BOOT_CONFIG_KEY = Symbol.for("elizaos.app.boot-config");
+const MILADY_ALIASES = [
+	["MILADY_NAMESPACE", "ELIZA_NAMESPACE"],
+	["MILADY_CONFIG_PATH", "ELIZA_CONFIG_PATH"],
+	["MILADY_STATE_DIR", "ELIZA_STATE_DIR"],
+] as const;
+
+// Any of these routes selectLiveProvider away from the on-disk cloud-key branch;
+// clearing them makes the alias-resolved config path the ONLY key source.
+const CLEARED_KEYS = [
+	"GROQ_API_KEY",
+	"OPENAI_API_KEY",
+	"CEREBRAS_API_KEY",
+	"ANTHROPIC_API_KEY",
+	"GOOGLE_GENERATIVE_AI_API_KEY",
+	"GOOGLE_API_KEY",
+	"OPENROUTER_API_KEY",
+	"ELIZAOS_CLOUD_API_KEY",
+	"ELIZA_CLOUD_API_KEY",
+	"ELIZA_CHAT_VIA_CLI",
+	"MILADY_NAMESPACE",
+	"MILADY_CONFIG_PATH",
+	"MILADY_STATE_DIR",
+	"ELIZA_NAMESPACE",
+	"ELIZA_CONFIG_PATH",
+	"ELIZA_STATE_DIR",
+];
+
+const saved = new Map<string, string | undefined>();
+let priorBootConfig: unknown;
+let tmpDir: string;
+
+function writeConfig(file: string, apiKey: string): void {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, JSON.stringify({ cloud: { apiKey } }), "utf8");
+}
+
+// A fresh module instance per case resets live-provider's module-level cloud-key
+// cache (getConfiguredCloudApiKey memoizes on first read), so each case observes
+// its own env/alias/file setup.
+async function freshSelectLiveProvider() {
+	vi.resetModules();
+	const mod = await import("./live-provider");
+	return mod.selectLiveProvider;
+}
+
+describe("live-provider alias-aware config resolution (#13422)", () => {
+	beforeEach(() => {
+		for (const key of [...CLEARED_KEYS, "HOME"]) {
+			saved.set(key, process.env[key]);
+		}
+		for (const key of CLEARED_KEYS) delete process.env[key];
+		priorBootConfig = peekAmbientSingleton(BOOT_CONFIG_KEY);
+		setAmbientSingleton(BOOT_CONFIG_KEY, {
+			current: { envAliases: MILADY_ALIASES },
+		});
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "live-provider-alias-"));
+	});
+
+	afterEach(() => {
+		for (const [key, value] of saved) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		saved.clear();
+		setAmbientSingleton(BOOT_CONFIG_KEY, priorBootConfig);
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("resolves MILADY_NAMESPACE via the reader to derive the config path", async () => {
+		// No CONFIG_PATH set: the path is derived from the namespace, so this
+		// exercises resolveAliasedEnvValue("ELIZA_NAMESPACE") picking up MILADY_.
+		process.env.HOME = tmpDir;
+		process.env.MILADY_NAMESPACE = "miladytest";
+		writeConfig(
+			path.join(tmpDir, ".miladytest", "miladytest.json"),
+			"milady-ns-key",
+		);
+
+		const selectLiveProvider = await freshSelectLiveProvider();
+		const provider = selectLiveProvider();
+
+		expect(provider?.name).toBe("openai");
+		expect(provider?.apiKey).toBe("milady-ns-key");
+		expect(provider?.baseUrl).toContain("elizacloud.ai");
+		// Additive read only — no ELIZA_* mirror written.
+		expect(process.env.ELIZA_NAMESPACE).toBeUndefined();
+	});
+
+	it("resolves MILADY_CONFIG_PATH via the reader (explicit path)", async () => {
+		const file = path.join(tmpDir, "milady.json");
+		writeConfig(file, "milady-path-key");
+		process.env.MILADY_CONFIG_PATH = file;
+
+		const selectLiveProvider = await freshSelectLiveProvider();
+		const provider = selectLiveProvider();
+
+		expect(provider?.apiKey).toBe("milady-path-key");
+		expect(process.env.ELIZA_CONFIG_PATH).toBeUndefined();
+	});
+
+	it("prefers the canonical ELIZA_CONFIG_PATH over the MILADY_ alias", async () => {
+		const elizaFile = path.join(tmpDir, "eliza.json");
+		const miladyFile = path.join(tmpDir, "milady.json");
+		writeConfig(elizaFile, "eliza-key");
+		writeConfig(miladyFile, "milady-key");
+		process.env.ELIZA_CONFIG_PATH = elizaFile;
+		process.env.MILADY_CONFIG_PATH = miladyFile;
+
+		const selectLiveProvider = await freshSelectLiveProvider();
+		const provider = selectLiveProvider();
+
+		expect(provider?.apiKey).toBe("eliza-key");
+	});
+
+	it("treats a blank canonical ELIZA_CONFIG_PATH as unset and falls through to MILADY_", async () => {
+		const miladyFile = path.join(tmpDir, "milady.json");
+		writeConfig(miladyFile, "milady-key");
+		process.env.ELIZA_CONFIG_PATH = "   ";
+		process.env.MILADY_CONFIG_PATH = miladyFile;
+
+		const selectLiveProvider = await freshSelectLiveProvider();
+		const provider = selectLiveProvider();
+
+		expect(provider?.apiKey).toBe("milady-key");
+	});
+
+	it("does not mirror-write ELIZA_* keys while resolving MILADY_ aliases", async () => {
+		const file = path.join(tmpDir, "milady.json");
+		writeConfig(file, "milady-key");
+		process.env.MILADY_NAMESPACE = "miladytest";
+		process.env.MILADY_CONFIG_PATH = file;
+		const before = { ...process.env };
+
+		const selectLiveProvider = await freshSelectLiveProvider();
+		selectLiveProvider();
+
+		expect(process.env.ELIZA_NAMESPACE).toBeUndefined();
+		expect(process.env.ELIZA_CONFIG_PATH).toBeUndefined();
+		expect(process.env).toEqual(before);
+	});
+});

--- a/packages/core/src/testing/live-provider.ts
+++ b/packages/core/src/testing/live-provider.ts
@@ -16,15 +16,17 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { resolveAliasedEnvValue } from "../boot-env";
 import { DEFAULT_CEREBRAS_TEXT_MODEL } from "../contracts/service-routing";
 
 const ELIZA_CLOUD_OPENAI_BASE_URL = "https://elizacloud.ai/api/v1";
 const CEREBRAS_OPENAI_BASE_URL = "https://api.cerebras.ai/v1";
 
 function loadConfiguredCloudApiKey(): string {
-	const namespace = process.env.ELIZA_NAMESPACE?.trim() || "eliza";
+	const namespace =
+		resolveAliasedEnvValue("ELIZA_NAMESPACE")?.trim() || "eliza";
 	const configuredPath =
-		process.env.ELIZA_CONFIG_PATH?.trim() ||
+		resolveAliasedEnvValue("ELIZA_CONFIG_PATH")?.trim() ||
 		path.join(os.homedir(), `.${namespace}`, `${namespace}.json`);
 
 	try {


### PR DESCRIPTION
Long-tail slice of #13422 (partition **P5** — `packages/core` + `packages/vault`, 3 files / 6 hits).

## What changed
Migrated the two raw aliased env **reads** in `packages/core/src/testing/live-provider.ts` from `process.env.<KEY>` to core's non-mutating alias-aware reader `resolveAliasedEnvValue` (`packages/core/src/boot-env.ts`):

- `live-provider.ts:25` `ELIZA_NAMESPACE`
- `live-provider.ts:27` `ELIZA_CONFIG_PATH`

Both keys are in the brand↔eliza alias pair table (`NAMESPACE→ELIZA_NAMESPACE`, `CONFIG_PATH→ELIZA_CONFIG_PATH`). Semantics are preserved: the reader returns the present (non-blank) value or its first present alias partner, then the existing `?.trim() || …` fallback runs unchanged. Precedence is unchanged — canonical `ELIZA_*` wins, empty-is-unset.

## Deliberately skipped (4 reads)
The four `packages/vault` reads are **not** migrated:

- `pglite-vault.ts:689` `ELIZA_NAMESPACE`, `pglite-vault.ts:691` `ELIZA_STATE_DIR`
- `vault.ts:22` `ELIZA_NAMESPACE`, `vault.ts:25` `ELIZA_STATE_DIR`

`@elizaos/vault` has **zero** `@elizaos/*` dependencies by design (only `@electric-sql/pglite` + `@napi-rs/keyring`; documented in its `CLAUDE.md`). The alias-aware reader lives in `@elizaos/core` / `@elizaos/shared`, so it is **not reachable** in vault without adding a heavy new package dependency — out of scope for a minimal/mechanical read migration, and it would break vault's lightweight standalone build/publish. These `ELIZA_*` reads already resolve branded values via the retained `syncBrandEnvToEliza` mutation layer (#13423), so behavior is unaffected. All six sites were verified to be reads (no writes/deletes).

## Test
Added `packages/core/src/testing/live-provider.alias.test.ts` — a deterministic test that drives the **real** `selectLiveProvider()` on-disk cloud-key path against a temp config file, seeding a `MILADY_*` alias table into the boot config, proving for both migrated keys:
- a non-eliza brand prefix (`MILADY_NAMESPACE` / `MILADY_CONFIG_PATH`) resolves via the reader,
- canonical `ELIZA_CONFIG_PATH` wins over the `MILADY_` alias,
- a blank canonical value is treated as unset (falls through to `MILADY_`),
- the reader never mirror-writes an `ELIZA_*` key (`process.env` unchanged).

```
Test Files  1 passed (1)
Tests  5 passed (5)
```

Neighboring suites (`boot-env.test.ts`, existing `live-provider.test.ts`, rest of `src/testing/`) still green (27 passed). `packages/core` typecheck shows only pre-existing environment TS7016 "missing type declarations" errors for third-party modules (drizzle-orm/yaml/…); **zero** reference the touched files.

The merged diff-scoped `audit:alias-read-guard` passes: this PR only removes raw aliased reads in touched files and adds none.