### PR TITLE
fix(#13422): migrate app-core aliased env reads to the alias-aware reader (long-tail)

### DIFF
--- a/packages/app-core/src/api/server-cors.test.ts
+++ b/packages/app-core/src/api/server-cors.test.ts
@@ -178,13 +178,17 @@ describe("server CORS allowlist — branded alias resolution (#13422)", () => {
   it("resolves CORS ports and origins from a non-ELIZA brand prefix", () => {
     process.env[`${BRAND}_API_PORT`] = "43555";
     process.env[`${BRAND}_UI_PORT`] = "44777";
+    // The single-process UI port migrated off a raw `process.env.ELIZA_PORT`
+    // read to `readAliasedEnv("ELIZA_PORT")` (#13422), so a bare `<PREFIX>_PORT`
+    // must now resolve into the CORS port set.
+    process.env[`${BRAND}_PORT`] = "42138";
     process.env[`${BRAND}_GATEWAY_PORT`] = "48789";
     process.env[`${BRAND}_HOME_PORT`] = "42142";
     process.env[`${BRAND}_ALLOWED_ORIGINS`] = "https://dashboard.example.com";
     invalidateCorsAllowedPorts();
 
     const ports = buildCorsAllowedPorts();
-    for (const port of ["43555", "44777", "48789", "42142"]) {
+    for (const port of ["43555", "44777", "42138", "48789", "42142"]) {
       expect(ports.has(port)).toBe(true);
     }
 
@@ -192,6 +196,7 @@ describe("server CORS allowlist — branded alias resolution (#13422)", () => {
       new Set(["https://dashboard.example.com"]),
     );
     expect(isAllowedOrigin("http://localhost:43555")).toBe(true);
+    expect(isAllowedOrigin("http://127.0.0.1:42138")).toBe(true);
     expect(isAllowedOrigin("http://127.0.0.1:48789")).toBe(true);
     expect(isAllowedOrigin("https://dashboard.example.com/settings")).toBe(
       true,
@@ -201,6 +206,7 @@ describe("server CORS allowlist — branded alias resolution (#13422)", () => {
   it("does not materialize the ELIZA_* mirror keys while resolving", () => {
     process.env[`${BRAND}_API_PORT`] = "43555";
     process.env[`${BRAND}_UI_PORT`] = "44777";
+    process.env[`${BRAND}_PORT`] = "42138";
     process.env[`${BRAND}_GATEWAY_PORT`] = "48789";
     process.env[`${BRAND}_HOME_PORT`] = "42142";
     process.env[`${BRAND}_ALLOWED_ORIGINS`] = "https://dashboard.example.com";
@@ -213,6 +219,7 @@ describe("server CORS allowlist — branded alias resolution (#13422)", () => {
     // process.env mutation #13422 removes.
     expect(process.env.ELIZA_API_PORT).toBeUndefined();
     expect(process.env.ELIZA_UI_PORT).toBeUndefined();
+    expect(process.env.ELIZA_PORT).toBeUndefined();
     expect(process.env.ELIZA_GATEWAY_PORT).toBeUndefined();
     expect(process.env.ELIZA_HOME_PORT).toBeUndefined();
     expect(process.env.ELIZA_ALLOWED_ORIGINS).toBeUndefined();
@@ -221,6 +228,8 @@ describe("server CORS allowlist — branded alias resolution (#13422)", () => {
   it("keeps the canonical ELIZA_* value ahead of the branded alias", () => {
     process.env.ELIZA_API_PORT = "30000";
     process.env[`${BRAND}_API_PORT`] = "43555";
+    process.env.ELIZA_PORT = "20000";
+    process.env[`${BRAND}_PORT`] = "42138";
     process.env.ELIZA_GATEWAY_PORT = "18000";
     process.env[`${BRAND}_GATEWAY_PORT`] = "48789";
     process.env.ELIZA_ALLOWED_ORIGINS = "https://canonical.example.com";
@@ -230,6 +239,8 @@ describe("server CORS allowlist — branded alias resolution (#13422)", () => {
     const ports = buildCorsAllowedPorts();
     expect(ports.has("30000")).toBe(true);
     expect(ports.has("43555")).toBe(false);
+    expect(ports.has("20000")).toBe(true);
+    expect(ports.has("42138")).toBe(false);
     expect(ports.has("18000")).toBe(true);
     expect(ports.has("48789")).toBe(false);
 
@@ -242,11 +253,18 @@ describe("server CORS allowlist — branded alias resolution (#13422)", () => {
   it("a blank canonical value falls through to the branded alias (empty-is-unset)", () => {
     process.env.ELIZA_GATEWAY_PORT = "   ";
     process.env[`${BRAND}_GATEWAY_PORT`] = "49000";
+    // Same empty-is-unset contract for the migrated single-process port read.
+    process.env.ELIZA_PORT = "   ";
+    process.env[`${BRAND}_PORT`] = "49100";
     invalidateCorsAllowedPorts();
 
-    expect(buildCorsAllowedPorts().has("49000")).toBe(true);
+    const ports = buildCorsAllowedPorts();
+    expect(ports.has("49000")).toBe(true);
+    expect(ports.has("49100")).toBe(true);
     // The blank canonical value must not shadow the present branded alias, and
     // the read must still not materialize the mirror.
     expect(isAllowedOrigin("http://localhost:49000")).toBe(true);
+    expect(isAllowedOrigin("http://localhost:49100")).toBe(true);
+    expect(process.env.ELIZA_PORT).toBe("   ");
   });
 });

--- a/packages/app-core/src/api/server-cors.ts
+++ b/packages/app-core/src/api/server-cors.ts
@@ -17,15 +17,16 @@ import { readAliasedEnv } from "@elizaos/shared/utils/env";
  * Reads from env vars at call time so tests can override.
  *
  * Ports resolve through the alias-aware readers so a branded deployment's
- * `<PREFIX>_API_PORT` / `<PREFIX>_UI_PORT` / `<PREFIX>_GATEWAY_PORT` /
- * `<PREFIX>_HOME_PORT` are honoured without the `syncBrandEnvToEliza` mirror
- * mutation, with the canonical `ELIZA_*` key still winning when present (#13422).
+ * `<PREFIX>_API_PORT` / `<PREFIX>_UI_PORT` / `<PREFIX>_PORT` /
+ * `<PREFIX>_GATEWAY_PORT` / `<PREFIX>_HOME_PORT` are honoured without the
+ * `syncBrandEnvToEliza` mirror mutation, with the canonical `ELIZA_*` key still
+ * winning when present (#13422).
  */
 export function buildCorsAllowedPorts(): Set<string> {
   const ports = new Set([
     String(resolveDesktopApiPort(process.env)),
     String(resolveUiPort(process.env)),
-    String(process.env.ELIZA_PORT ?? "2138"),
+    String(readAliasedEnv("ELIZA_PORT") ?? "2138"),
     String(readAliasedEnv("ELIZA_GATEWAY_PORT") ?? "18789"),
     String(readAliasedEnv("ELIZA_HOME_PORT") ?? "2142"),
   ]);


### PR DESCRIPTION
## Long-tail slice of #13422 — P2 `packages/app-core`

Migrates the one remaining raw aliased-key **read** in this partition to the alias-aware reader.

### Change
`packages/app-core/src/api/server-cors.ts` — `buildCorsAllowedPorts()` read the single-process UI port via a raw `process.env.ELIZA_PORT`, while the two sibling reads directly below it (`ELIZA_GATEWAY_PORT`, `ELIZA_HOME_PORT`) were already migrated to `readAliasedEnv(...)` for #13422. This lone read is now `readAliasedEnv("ELIZA_PORT")`, so a branded deployment's `<PREFIX>_PORT` resolves into the CORS port set without the `syncBrandEnvToEliza` mirror mutation, with the canonical `ELIZA_PORT` still winning when present.

`ELIZA_PORT` is a member of the alias table (`PORT → ELIZA_PORT`, `packages/shared/src/config/brand-env-aliases.ts`).

### Skipped reads in this partition (verified, deliberately not migrated)
- **electrobun `remotes/*` (8 reads)** — `local-inference-api-client.ts:18/23`, `worker.ts:913/918`, `api-client.ts:255`, `stream-manager.ts:80`, `phase3-smoke.ts:41/47`, `phase2-smoke.ts:40`. These are **separate private bun worker bundles** (`@elizaos/elizalaunch-runtime-remote`, `@elizalaunch/local-model-remote`) with no `@elizaos/*` dependency; they reach shared only via direct relative `.ts` leaf-file imports. They never populate the boot-config alias table (`getBootConfig().envAliases` is `undefined` there), so `readAliasedEnv` would yield **zero** brand resolution while dragging `@elizaos/core` (via `boot-config-store`) into a tiny background worker bundle. Per the migration note, the reader is not reachable/appropriate there — left as-is. Their `ELIZA_RUNTIME_API_TOKEN`/`ELIZA_RUNTIME_API_BASE` primary keys are not aliased anyway.
- **`runtime/eliza.ts:1643`** — `process.env.ELIZA_AGENT_ORCHESTRATOR = "1"` is a **write** (the paired read on :1641 already uses `readAliasedEnv`). Not a read; untouched.

### Test
Extended the existing branded-alias suite in `server-cors.test.ts` to cover the newly migrated `ELIZA_PORT` key across all four required properties: a non-ELIZA `MILADY_PORT` resolves via the reader, canonical `ELIZA_PORT` wins over the branded alias, empty-is-unset (blank canonical falls through), and no `ELIZA_*` mirror key is written.

```
Test Files  1 passed (1)
     Tests  11 passed (11)
```

Proven load-bearing: reverting line 28 to the raw read makes the "resolves CORS ports and origins from a non-ELIZA brand prefix" test fail (`MILADY_PORT=42138` no longer enters the port set, since `MILADY_API_PORT`/`MILADY_UI_PORT` are set so the API/UI resolvers never fall back to PORT).

Diff-scoped guard: `audit:alias-read-guard` → `server-cors.ts: raw-aliased-reads 1->0`.

Typecheck: no errors in `packages/app-core/src`; the only failures in the worktree are pre-existing external-`.d.ts`/generated-optional-plugin resolution issues in `../agent` and `../../plugins/*` against the shared `dist/node_modules`, unrelated to this diff.