### PR TITLE
fix(import): fail closed on malformed quota preflight

### DIFF
--- a/packages/import-conversations/src/core/preflight.test.ts
+++ b/packages/import-conversations/src/core/preflight.test.ts
@@ -185,6 +185,77 @@ describe("preflightImport — malformed input fails fast", () => {
     ).toThrow(/conversationCount/);
   });
 
+  it("throws on malformed quota dimensions rather than admitting unknown capacity", () => {
+    expect(() =>
+      preflightImport(
+        { uploadBytes: 1, storageBytes: 1 },
+        { quota: { remainingStorageBytes: Number.NaN } },
+      ),
+    ).toThrow(/remainingStorageBytes/);
+    expect(() =>
+      preflightImport(
+        { uploadBytes: 1, embeddingUnits: 1 },
+        { quota: { remainingEmbeddingUnits: -1 } },
+      ),
+    ).toThrow(/remainingEmbeddingUnits/);
+    expect(() =>
+      preflightImport(
+        { uploadBytes: 1, conversationCount: 1 },
+        { quota: { remainingConversations: Number.POSITIVE_INFINITY } },
+      ),
+    ).toThrow(/remainingConversations/);
+  });
+
+  it("throws on malformed caller-supplied limits rather than failing open", () => {
+    expect(() =>
+      preflightImport(
+        { uploadBytes: 1 },
+        {
+          limits: {
+            maxDirectUploadBytes: Number.NaN,
+            maxResumableUploadBytes: 100,
+          },
+        },
+      ),
+    ).toThrow(/maxDirectUploadBytes/);
+    expect(() =>
+      preflightImport(
+        { uploadBytes: 1 },
+        {
+          limits: {
+            maxDirectUploadBytes: 10,
+            maxResumableUploadBytes: -1,
+          },
+        },
+      ),
+    ).toThrow(/maxResumableUploadBytes/);
+    expect(() =>
+      preflightImport(
+        { uploadBytes: 1 },
+        {
+          limits: {
+            maxDirectUploadBytes: 10,
+            maxResumableUploadBytes: Number.POSITIVE_INFINITY,
+          },
+        },
+      ),
+    ).toThrow(/maxResumableUploadBytes/);
+  });
+
+  it("throws when the direct upload ceiling is larger than the resumable ceiling", () => {
+    expect(() =>
+      preflightImport(
+        { uploadBytes: 50 },
+        {
+          limits: {
+            maxDirectUploadBytes: 100,
+            maxResumableUploadBytes: 10,
+          },
+        },
+      ),
+    ).toThrow(/maxDirectUploadBytes/);
+  });
+
   it("never mutates the caller's estimate", () => {
     const estimate = { uploadBytes: 1 * MiB, conversationCount: 2 };
     const snapshot = { ...estimate };
@@ -220,6 +291,30 @@ describe("estimateBundleUsage", () => {
         messages: [
           { role: "user", text: "   " },
           { role: "assistant", text: "real answer" },
+        ],
+      }),
+    ]);
+    const estimate = estimateBundleUsage(b, 100);
+    expect(estimate.embeddingUnits).toBe(1);
+  });
+
+  it("charges an embedding unit for attachment-only rendered content", () => {
+    const b = bundle([
+      conv({
+        sourceConversationId: "c1",
+        messages: [
+          {
+            role: "user",
+            text: "   ",
+            attachments: [
+              { name: "notes.txt", kind: "extracted-text", text: "embed me" },
+            ],
+          },
+          {
+            role: "assistant",
+            text: "",
+            attachments: [{ name: "empty.txt", kind: "file", text: "   " }],
+          },
         ],
       }),
     ]);

--- a/packages/import-conversations/src/core/preflight.ts
+++ b/packages/import-conversations/src/core/preflight.ts
@@ -130,12 +130,28 @@ function reject(
 
 function assertNonNegativeFinite(
   value: number | undefined,
-  field: keyof ImportUsageEstimate,
+  field:
+    | keyof ImportUsageEstimate
+    | keyof TenantImportQuota
+    | keyof ImportLimits,
 ): void {
   if (value === undefined) return;
   if (!Number.isFinite(value) || value < 0) {
     throw new Error(
       `preflightImport: ${field} must be a non-negative finite number, got ${value}`,
+    );
+  }
+}
+
+function assertValidLimits(limits: ImportLimits): void {
+  assertNonNegativeFinite(limits.maxDirectUploadBytes, "maxDirectUploadBytes");
+  assertNonNegativeFinite(
+    limits.maxResumableUploadBytes,
+    "maxResumableUploadBytes",
+  );
+  if (limits.maxDirectUploadBytes > limits.maxResumableUploadBytes) {
+    throw new Error(
+      "preflightImport: maxDirectUploadBytes must be less than or equal to maxResumableUploadBytes",
     );
   }
 }
@@ -157,10 +173,23 @@ export function preflightImport(
   const limits = options.limits ?? DEFAULT_IMPORT_LIMITS;
   const quota = options.quota;
 
+  assertValidLimits(limits);
   assertNonNegativeFinite(estimate.uploadBytes, "uploadBytes");
   assertNonNegativeFinite(estimate.storageBytes, "storageBytes");
   assertNonNegativeFinite(estimate.embeddingUnits, "embeddingUnits");
   assertNonNegativeFinite(estimate.conversationCount, "conversationCount");
+  assertNonNegativeFinite(
+    quota?.remainingStorageBytes,
+    "remainingStorageBytes",
+  );
+  assertNonNegativeFinite(
+    quota?.remainingEmbeddingUnits,
+    "remainingEmbeddingUnits",
+  );
+  assertNonNegativeFinite(
+    quota?.remainingConversations,
+    "remainingConversations",
+  );
 
   if (estimate.uploadBytes > limits.maxResumableUploadBytes) {
     return reject(
@@ -236,8 +265,17 @@ export function estimateBundleUsage(
       storageBytes += byteLength(part.text);
     }
     for (const message of conversation.messages) {
+      let renderedText = false;
       const text = message.text ?? "";
       if (text.trim().length > 0) {
+        renderedText = true;
+      }
+      for (const attachment of message.attachments ?? []) {
+        if (attachment.text?.trim()) {
+          renderedText = true;
+        }
+      }
+      if (renderedText) {
         embeddingUnits += 1;
       }
     }


### PR DESCRIPTION
## Summary
- validates tenant import quota fields as non-negative finite numbers before any quota comparison, so NaN/Infinity capacity cannot silently admit an import
- charges an embedding unit for attachment-only rendered content, matching the rendered transcript path that stores extracted attachment text
- adds focused regression coverage for both fail-closed behaviors

## Verification
- `bun test packages/import-conversations/src/core/preflight.test.ts` (23 pass, 0 fail)
- `bunx @biomejs/biome check packages/import-conversations/src/core/preflight.ts packages/import-conversations/src/core/preflight.test.ts --no-errors-on-unmatched`
- `git diff --check`

## Evidence / N/A
- UI screenshots/video: N/A - pure import admission-control library code, no UI surface changed.
- Live model trajectories: N/A - no model/provider/agent behavior changed.
- Domain artifacts: focused unit assertions inspect the preflight decision objects directly.

Fix-forward for review findings on #13901; refs #13432.