### PR TITLE
fix(core): deliver the actionable top-up reply when a connector turn hits 402 credit exhaustion

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -21,6 +21,7 @@ import {
   createMessageMemory,
   EventType,
   getSwarmCoordinatorService,
+  INSUFFICIENT_CREDITS_REPLY,
   isRateLimitError,
   logger,
   MESSAGE_SOURCE_CLIENT_CHAT,
@@ -1115,8 +1116,9 @@ async function resolveExactDocumentValueForChat(
 // Do NOT use as the generic empty-response fallback; that mislabels every
 // IGNORE / empty-action / empty-normalized-text path as a provider failure.
 const PROVIDER_ISSUE_CHAT_REPLY = "Sorry, I'm having a provider issue";
-const INSUFFICIENT_CREDITS_CHAT_REPLY =
-  "Eliza Cloud credits are depleted. Top up the cloud balance and try again.";
+// Shared with the connector failure-reply path in @elizaos/core so every
+// delivery surface phrases credit exhaustion identically.
+const INSUFFICIENT_CREDITS_CHAT_REPLY = INSUFFICIENT_CREDITS_REPLY;
 // A transient 429 (no billing context) — e.g. the shared model key briefly
 // over its requests/min under concurrent load. Tell the user it's momentary so
 // they retry, instead of the generic "provider issue" which reads as broken.

--- a/packages/agent/src/api/credit-detection.ts
+++ b/packages/agent/src/api/credit-detection.ts
@@ -1,57 +1,16 @@
 /**
- * Credit/quota exhaustion detection for provider errors.
+ * Credit/quota exhaustion and rate-limit detection for provider errors — the
+ * agent API's import surface over the canonical classifiers in
+ * `@elizaos/core` (`services/message/fallback-reply.ts`), so the direct chat
+ * path and the connector failure-reply path classify with the same logic.
  *
- * Matches error messages, HTTP status codes (402, 429 with billing context),
- * and structured error bodies from various AI providers.
- *
- * Rate-limit detection lives in `@elizaos/core` (`isRateLimitError`, which adds
- * a structural 429 check over the AI-SDK error envelope); it is re-exported here
- * so callers keep one import surface. Callers MUST check
- * {@link isInsufficientCreditsError} first — a 429 *with* billing context is
- * credit exhaustion ("top up"), whereas a bare 429 is "try again in a moment".
+ * Callers MUST check {@link isInsufficientCreditsError} first — a 429 *with*
+ * billing context is credit exhaustion ("top up"), whereas a bare 429 is
+ * "try again in a moment".
  */
 
-import { getErrorMessage } from "./server-helpers.ts";
-
-export { isRateLimitError } from "@elizaos/core";
-
-const INSUFFICIENT_CREDITS_RE =
-  /\b(?:insufficient(?:[_\s]+(?:credits?|quota|funds))|insufficient_quota|out of credits|max usage reached|quota(?:\s+exceeded)?|rate_limit_exceeded|billing.*disabled|payment.*required|account.*suspended|spending.*limit|budget.*exceeded|no.*api.*credits|credit.*balance.*zero)\b/i;
-
-const BILLING_KEYWORDS_RE =
-  /\b(?:billing|quota|credits?|budget|spending|payment|subscription|plan limit)\b/i;
-
-/** Cap a value before running a regex scan so a pathological provider payload
- *  cannot turn a substring match into a catastrophic-backtracking DoS. */
-function clampForScan(value: string): string {
-  return value.length > 10_000 ? value.slice(0, 10_000) : value;
-}
-
-export function isInsufficientCreditsMessage(message: string): boolean {
-  return INSUFFICIENT_CREDITS_RE.test(clampForScan(message));
-}
-
-export function isInsufficientCreditsError(err: unknown): boolean {
-  if (err == null || typeof err !== "object") {
-    if (typeof err === "string") return isInsufficientCreditsMessage(err);
-    return false;
-  }
-
-  const msg = getErrorMessage(err, "");
-  if (isInsufficientCreditsMessage(msg)) return true;
-
-  const status = (err as { status?: number }).status;
-  if (status === 402) return true;
-  if (status === 429 && BILLING_KEYWORDS_RE.test(clampForScan(msg)))
-    return true;
-
-  const errorBody = (err as { error?: { type?: string; code?: string } }).error;
-  if (errorBody?.type === "insufficient_quota") return true;
-  if (typeof errorBody?.code === "string") {
-    if (INSUFFICIENT_CREDITS_RE.test(clampForScan(errorBody.code))) {
-      return true;
-    }
-  }
-
-  return false;
-}
+export {
+  isInsufficientCreditsError,
+  isInsufficientCreditsMessage,
+  isRateLimitError,
+} from "@elizaos/core";

--- a/packages/core/src/__tests__/message-failure-reply.test.ts
+++ b/packages/core/src/__tests__/message-failure-reply.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Exercises the message service's structured failure-reply classifier for model
+ * fallback cascades. Deterministic: the runtime only exposes a queued useModel
+ * stub, so no provider, database, or live model is involved.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { DefaultMessageService } from "../services/message";
+import type { IAgentRuntime } from "../types/runtime";
+
+const logger = {
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	trace: vi.fn(),
+};
+
+function makeRuntimeThrowing(errors: unknown[]): IAgentRuntime {
+	const queue = [...errors];
+	return {
+		useModel: vi.fn(async () => {
+			const error = queue.shift();
+			if (!error) throw new Error("Unexpected useModel call");
+			throw error;
+		}),
+		logger,
+	} as unknown as IAgentRuntime;
+}
+
+function creditError(): Error & { statusCode: number } {
+	return Object.assign(new Error("insufficient_credits"), { statusCode: 402 });
+}
+
+describe("DefaultMessageService structured failure replies", () => {
+	it("preserves credit exhaustion when later fallback model slots fail generically", async () => {
+		const service = new DefaultMessageService() as unknown as {
+			generateFailureReplyText(
+				runtime: IAgentRuntime,
+				prompt: string,
+				stage: string,
+			): Promise<{ kind: string }>;
+		};
+		const runtime = makeRuntimeThrowing([
+			creditError(),
+			new Error("TEXT_LARGE fallback failed"),
+			new Error("TEXT_SMALL fallback failed"),
+			new Error("TEXT_NANO fallback failed"),
+		]);
+
+		await expect(
+			service.generateFailureReplyText(runtime, "recent messages", "test"),
+		).resolves.toEqual({ kind: "creditsExhausted" });
+	});
+});

--- a/packages/core/src/services/message.credit-exhaustion-reply.test.ts
+++ b/packages/core/src/services/message.credit-exhaustion-reply.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Connector-path failure reply when the model provider is out of credits.
+ *
+ * A 402 insufficient-credits failure is a permanent condition until the user
+ * tops up — the direct API path already classifies it and answers with the
+ * actionable "credits are depleted, top up" reply, but the connector delivery
+ * path (Discord/Telegram turns through `DefaultMessageService.handleMessage`)
+ * used to fall through to the generic "something went wrong, try again"
+ * template, telling users to retry an unretryable failure.
+ *
+ * These tests drive the real `handleMessage` pipeline with only the runtime
+ * I/O surface mocked. `useModel` rejects with the exact error shape
+ * plugin-elizacloud throws on a cloud 402 (`Error` + `.status = 402` +
+ * `.error = { code: "insufficient_credits" }`), and the assertions read what
+ * a connector would actually post to the channel.
+ */
+
+import { v4 } from "uuid";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
+import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
+import { TurnControllerRegistry } from "../runtime/turn-controller";
+import { createMockRuntime } from "../testing/mock-runtime";
+import type { Room } from "../types/environment";
+import type { Memory } from "../types/memory";
+import {
+	asUUID,
+	ChannelType,
+	type Content,
+	type UUID,
+} from "../types/primitives";
+import type { IAgentRuntime } from "../types/runtime";
+import type { State } from "../types/state";
+import { DefaultMessageService, INSUFFICIENT_CREDITS_REPLY } from "./message";
+
+const AGENT = "00000000-0000-0000-0000-00000000001a" as UUID;
+const ENTITY = "00000000-0000-0000-0000-00000000001b" as UUID;
+const ROOM = "00000000-0000-0000-0000-00000000001c" as UUID;
+const RUN_ID = "00000000-0000-0000-0000-00000000001d" as UUID;
+
+/** The error shape plugin-elizacloud throws when Eliza Cloud returns 402. */
+function makeCreditExhaustionError(): Error {
+	return Object.assign(
+		new Error("Insufficient credits. Required: $0.0014, Available: $0.0000"),
+		{
+			status: 402,
+			error: {
+				code: "insufficient_credits",
+				message: "Insufficient credits. Required: $0.0014, Available: $0.0000",
+			},
+		},
+	);
+}
+
+function makeMessage(overrides: Partial<Content> = {}): Memory {
+	return {
+		id: asUUID(v4()),
+		entityId: ENTITY,
+		agentId: AGENT,
+		roomId: ROOM,
+		content: {
+			text: "@Remilio what's the plan?",
+			source: "discord",
+			channelType: ChannelType.GROUP,
+			mentionContext: { isMention: true },
+			...overrides,
+		},
+		createdAt: Date.now(),
+	};
+}
+
+function makeState(): State {
+	return { values: {}, data: {}, text: "" };
+}
+
+function makeFailingRuntime(room: Room, failure: Error): IAgentRuntime {
+	const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
+	for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
+		responseHandlerFieldRegistry.register(evaluator);
+	}
+	return createMockRuntime({
+		agentId: AGENT,
+		character: {
+			name: "Remilio",
+			bio: "test agent",
+		},
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			trace: vi.fn(),
+		} as unknown as IAgentRuntime["logger"],
+		getSetting: vi.fn(() => undefined),
+		getService: vi.fn(() => null),
+		getModel: vi.fn(() => async () => {
+			throw failure;
+		}),
+		// Stage 1 dies with the cloud 402, and every failure-reply fallback
+		// model call fails the same way — exactly what a fully drained cloud
+		// account produces.
+		useModel: vi.fn(async () => {
+			throw failure;
+		}),
+		composeState: vi.fn(async () => makeState()),
+		runActionsByMode: vi.fn(async () => undefined),
+		applyPipelineHooks: vi.fn(async () => undefined),
+		emitEvent: vi.fn(async () => undefined),
+		startRun: vi.fn(() => RUN_ID),
+		getCurrentRunId: vi.fn(() => RUN_ID),
+		endRun: vi.fn(),
+		getMemoryById: vi.fn(async () => null),
+		createMemory: vi.fn(async () => asUUID(v4())),
+		updateMemory: vi.fn(async () => true),
+		queueEmbeddingGeneration: vi.fn(async () => undefined),
+		getParticipantUserState: vi.fn(async () => null),
+		getRoom: vi.fn(async () => room),
+		getRoomsByIds: vi.fn(async () => [room]),
+		getMemories: vi.fn(async () => []),
+		isCheckShouldRespondEnabled: vi.fn(() => true),
+		turnControllers: new TurnControllerRegistry(),
+		responseHandlerFieldRegistry,
+		responseHandlerFieldEvaluators: [
+			...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
+		],
+	});
+}
+
+function makeRoom(type: ChannelType): Room {
+	return {
+		id: ROOM,
+		source: "discord",
+		type,
+	} as Room;
+}
+
+async function runTurn(message: Memory, room: Room, failure: Error) {
+	const runtime = makeFailingRuntime(room, failure);
+	const service = new DefaultMessageService();
+	const deliveries: Content[] = [];
+	const result = await service.handleMessage(
+		runtime,
+		message,
+		async (content) => {
+			deliveries.push(content);
+			return [];
+		},
+	);
+	const visibleTexts = deliveries
+		.map((content) => (typeof content.text === "string" ? content.text : ""))
+		.filter((text) => text.trim().length > 0);
+	return { runtime, result, deliveries, visibleTexts };
+}
+
+describe("connector turn failing on 402 credit exhaustion", () => {
+	beforeEach(() => {
+		vi.stubEnv("ELIZA_TRAJECTORY_RECORDING", "0");
+	});
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("delivers the actionable top-up reply, not the generic retry", async () => {
+		const { result, visibleTexts } = await runTurn(
+			makeMessage(),
+			makeRoom(ChannelType.GROUP),
+			makeCreditExhaustionError(),
+		);
+
+		expect(result.didRespond).toBe(true);
+		expect(visibleTexts).toHaveLength(1);
+		// The user must learn the real, actionable condition — same reply the
+		// direct API path sends — instead of "try again" (retrying a drained
+		// account can never succeed) or the rate-limited "give it a few
+		// seconds" template.
+		expect(visibleTexts[0]).toBe(INSUFFICIENT_CREDITS_REPLY);
+	});
+
+	it("marks the synthetic reply with the structural insufficient_credits kind", async () => {
+		const { deliveries } = await runTurn(
+			makeMessage({ channelType: ChannelType.DM }),
+			makeRoom(ChannelType.DM),
+			makeCreditExhaustionError(),
+		);
+
+		const failureReply = deliveries.find(
+			(content) => content.elizaSyntheticFailure === true,
+		);
+		// Downstream consumers (chat DTO failureKind gate, recent-messages
+		// synthetic-failure filter) key on the structural kind, so the credits
+		// case must not masquerade as a transient failure.
+		expect(failureReply?.failureKind).toBe("insufficient_credits");
+	});
+
+	it("keeps a bare 429 on the rate-limited reply, not the top-up reply", async () => {
+		const { visibleTexts } = await runTurn(
+			makeMessage(),
+			makeRoom(ChannelType.GROUP),
+			Object.assign(new Error("Rate limit exceeded. Try again shortly."), {
+				status: 429,
+				error: { code: "rate_limit_exceeded" },
+			}),
+		);
+
+		expect(visibleTexts).toHaveLength(1);
+		expect(visibleTexts[0].toLowerCase()).toContain("rate-limit");
+		expect(visibleTexts[0]).not.toBe(INSUFFICIENT_CREDITS_REPLY);
+	});
+
+	it("classifies a 402 hidden inside the AI SDK retry envelope", async () => {
+		const { visibleTexts } = await runTurn(
+			makeMessage({ channelType: ChannelType.DM }),
+			makeRoom(ChannelType.DM),
+			Object.assign(new Error("Failed after 3 attempts"), {
+				lastError: Object.assign(new Error("Payment Required"), {
+					statusCode: 402,
+				}),
+			}),
+		);
+
+		expect(visibleTexts).toHaveLength(1);
+		expect(visibleTexts[0]).toBe(INSUFFICIENT_CREDITS_REPLY);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -10637,15 +10637,15 @@ export class DefaultMessageService implements IMessageService {
 				) {
 					return { kind: "noProvider" };
 				}
-				// Track the most recent slot's cause. Reporting "rate-limited"
-				// only when the LAST attempted slot was a 429 avoids misleading
-				// the user in a mixed-failure run (one slot throttled, others
-				// failed for unrelated reasons where retrying won't help). The
-				// all-429 cascade from the live incident still lands here.
+				// Credit exhaustion is sticky across slots because no later
+				// fallback model can make a drained account retryable. The
+				// rate/auth flags still track the most recent slot's cause:
+				// reporting "rate-limited" only when the LAST attempted slot was
+				// a 429 avoids misleading the user in a mixed-failure run.
 				// Credits are classified before rate limits below: a 429 *with*
 				// billing context is a drained balance ("top up"), not a
 				// transient throttle ("try again in a few seconds").
-				sawCreditsExhausted = isInsufficientCreditsError(error);
+				sawCreditsExhausted ||= isInsufficientCreditsError(error);
 				sawRateLimit = isRateLimitError(error);
 				sawAuthError = isAuthError(error);
 				runtime.logger.warn(

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -269,7 +269,9 @@ import {
 } from "./message/direct-action-heuristics";
 import {
 	buildFailureReplyPrompt,
+	INSUFFICIENT_CREDITS_REPLY,
 	isAuthError,
+	isInsufficientCreditsError,
 	isRateLimitError,
 	stripReasoningBlocks,
 } from "./message/fallback-reply";
@@ -1500,6 +1502,7 @@ interface StrategyResult {
 type FailureReplyAttempt =
 	| { kind: "text"; value: string }
 	| { kind: "noProvider" }
+	| { kind: "creditsExhausted" }
 	| { kind: "rateLimited" }
 	| { kind: "authFailed" };
 
@@ -1518,7 +1521,10 @@ export function shouldSkipResponseMemoryPersistence(memory: Memory): boolean {
 
 export {
 	buildFailureReplyPrompt,
+	INSUFFICIENT_CREDITS_REPLY,
 	isAuthError,
+	isInsufficientCreditsError,
+	isInsufficientCreditsMessage,
 	isModelProviderFallbackError,
 	isRateLimitError,
 	stripReasoningBlocks,
@@ -10592,6 +10598,7 @@ export class DefaultMessageService implements IMessageService {
 		prompt: string,
 		stage: string,
 	): Promise<FailureReplyAttempt> {
+		let sawCreditsExhausted = false;
 		let sawRateLimit = false;
 		let sawAuthError = false;
 		for (const modelType of [
@@ -10635,6 +10642,10 @@ export class DefaultMessageService implements IMessageService {
 				// the user in a mixed-failure run (one slot throttled, others
 				// failed for unrelated reasons where retrying won't help). The
 				// all-429 cascade from the live incident still lands here.
+				// Credits are classified before rate limits below: a 429 *with*
+				// billing context is a drained balance ("top up"), not a
+				// transient throttle ("try again in a few seconds").
+				sawCreditsExhausted = isInsufficientCreditsError(error);
 				sawRateLimit = isRateLimitError(error);
 				sawAuthError = isAuthError(error);
 				runtime.logger.warn(
@@ -10649,9 +10660,15 @@ export class DefaultMessageService implements IMessageService {
 			}
 		}
 		// Every model slot failed without a usable reply. When the final cause
-		// was provider rate-limiting (429), tell the user that plainly instead
-		// of the opaque generic message — the honest signal is "try again
-		// shortly", not "something broke".
+		// was credit exhaustion (402/insufficient_credits), the condition is
+		// permanent until the user tops up — "try again" can never succeed, so
+		// surface the actionable top-up message.
+		if (sawCreditsExhausted) {
+			return { kind: "creditsExhausted" };
+		}
+		// When the final cause was provider rate-limiting (429), tell the user
+		// that plainly instead of the opaque generic message — the honest
+		// signal is "try again shortly", not "something broke".
 		if (sawRateLimit) {
 			return { kind: "rateLimited" };
 		}
@@ -10705,17 +10722,20 @@ export class DefaultMessageService implements IMessageService {
 			);
 		}
 
-		let replyText =
-			attempt.kind === "rateLimited" || attempt.kind === "authFailed"
-				? ""
-				: attempt.value;
+		let replyText = attempt.kind === "text" ? attempt.value : "";
 		if (!replyText) {
 			// Last-ditch fallback when every model call above also failed.
 			// Voice-neutral so any character can ship this default; characters
 			// can override with their own phrasing via
 			// character.templates.transientFailureReply (or
-			// rateLimitedReply for the throttling-specific case).
-			if (attempt.kind === "rateLimited") {
+			// rateLimitedReply / insufficientCreditsReply for the specific
+			// cases).
+			if (attempt.kind === "creditsExhausted") {
+				const tmpl = runtime.character.templates?.insufficientCreditsReply;
+				replyText =
+					(typeof tmpl === "function" ? tmpl({ state }) : tmpl) ||
+					INSUFFICIENT_CREDITS_REPLY;
+			} else if (attempt.kind === "rateLimited") {
 				const tmpl = runtime.character.templates?.rateLimitedReply;
 				replyText =
 					(typeof tmpl === "function" ? tmpl({ state }) : tmpl) ||
@@ -10735,10 +10755,17 @@ export class DefaultMessageService implements IMessageService {
 
 		replyText = truncateToCompleteSentence(replyText.trim(), 2000);
 
+		// Credit exhaustion is not transient — it persists until the user tops
+		// up — so the synthetic reply carries the structural kind downstream
+		// consumers already key on (chat DTO failureKind gate, recent-messages
+		// synthetic-failure filter) instead of masquerading as a blip.
 		const responseContent: Content = {
 			thought: `Handle a temporary reply failure during ${stage}.`,
 			actions: ["REPLY"],
-			failureKind: "transient_failure",
+			failureKind:
+				attempt.kind === "creditsExhausted"
+					? "insufficient_credits"
+					: "transient_failure",
 			elizaSyntheticFailure: true,
 			transient: true,
 			doNotPersist: true,

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -1,7 +1,8 @@
 /**
- * Classifies model-call failures — rate-limit/429, auth 401/403, and transient
- * provider errors worth failing over to another provider — and assembles the
- * user-facing fallback reply when a turn's grounding trajectory fails.
+ * Classifies model-call failures — rate-limit/429, credit exhaustion/402,
+ * auth 401/403, and transient provider errors worth failing over to another
+ * provider — and assembles the user-facing fallback reply when a turn's
+ * grounding trajectory fails.
  * Classification unwraps the AI SDK retry envelope and reads the structured HTTP
  * status first, falling back to a message-substring scan for status-less errors.
  * buildFailureReplyPrompt shapes the in-character apology (never answering on the
@@ -14,6 +15,7 @@ type ErrorWithStatus = {
 	statusCode?: unknown;
 	lastError?: unknown;
 	errors?: unknown;
+	error?: unknown;
 };
 
 function asErrorObject(error: unknown): ErrorWithStatus | null {
@@ -76,6 +78,76 @@ export function isRateLimitError(error: unknown): boolean {
 		haystack.includes("usage limit") ||
 		/\b429\b/.test(haystack) ||
 		/\b529\b/.test(haystack)
+	);
+}
+
+/**
+ * The user-facing reply for a credit-exhausted provider. One string for every
+ * delivery path: the direct chat API (`packages/agent` re-uses it) and the
+ * connector failure-reply path below, so a Discord/Telegram user and a
+ * dashboard user read the same actionable condition. Characters override via
+ * `character.templates.insufficientCreditsReply`.
+ */
+export const INSUFFICIENT_CREDITS_REPLY =
+	"Eliza Cloud credits are depleted. Top up the cloud balance and try again.";
+
+// Credits-specific phrases only — deliberately no plain rate-limit tokens
+// (e.g. `rate_limit_exceeded`), so a transient throttle can never classify as
+// "out of credits" and tell the user to spend money on a condition that
+// resolves by waiting.
+const INSUFFICIENT_CREDITS_RE =
+	/\b(?:insufficient(?:[_\s]+(?:credits?|quota|funds))|insufficient_quota|out of credits|max usage reached|quota(?:\s+exceeded)?|billing.*disabled|payment.*required|account.*suspended|spending.*limit|budget.*exceeded|no.*api.*credits|credit.*balance.*zero)\b/i;
+
+const BILLING_KEYWORDS_RE =
+	/\b(?:billing|quota|credits?|budget|spending|payment|subscription|plan limit)\b/i;
+
+/** Cap a value before running a regex scan so a pathological provider payload
+ *  cannot turn a substring match into a catastrophic-backtracking DoS. */
+function clampForScan(value: string): string {
+	return value.length > 10_000 ? value.slice(0, 10_000) : value;
+}
+
+export function isInsufficientCreditsMessage(message: string): boolean {
+	return INSUFFICIENT_CREDITS_RE.test(clampForScan(message));
+}
+
+/**
+ * Detect provider credit/quota exhaustion — HTTP 402, a structured
+ * `insufficient_credits`/`insufficient_quota` error body, or a 429 that
+ * carries billing context — so the user-facing failure reply can say "top up"
+ * instead of suggesting a retry that can never succeed against a drained
+ * balance. Mirrors {@link isRateLimitError}: the structural signal (status
+ * after unwrapping the AI SDK retry envelope, then the provider error body)
+ * runs first; the message-substring scan is only a status-less fallback.
+ *
+ * Callers MUST check this before {@link isRateLimitError}: a 429 *with*
+ * billing context is credit exhaustion ("top up"), whereas a bare 429 is
+ * "try again in a moment".
+ */
+export function isInsufficientCreditsError(error: unknown): boolean {
+	if (typeof error === "string") return isInsufficientCreditsMessage(error);
+	const unwrapped = unwrapRetryError(error);
+	if (hasHttpStatus(unwrapped, [402])) {
+		return true;
+	}
+	const candidate = asErrorObject(unwrapped);
+	if (!candidate) return false;
+	const errorBody =
+		typeof candidate.error === "object" && candidate.error !== null
+			? (candidate.error as { type?: unknown; code?: unknown })
+			: null;
+	if (errorBody?.type === "insufficient_quota") return true;
+	if (
+		typeof errorBody?.code === "string" &&
+		isInsufficientCreditsMessage(errorBody.code)
+	) {
+		return true;
+	}
+	const message = unwrapped instanceof Error ? unwrapped.message : "";
+	if (isInsufficientCreditsMessage(message)) return true;
+	return (
+		hasHttpStatus(unwrapped, [429]) &&
+		BILLING_KEYWORDS_RE.test(clampForScan(message))
 	);
 }
 


### PR DESCRIPTION
## What

A Discord/Telegram (connector) chat turn that fails on **402 credit exhaustion** now delivers the actionable top-up reply — `Eliza Cloud credits are depleted. Top up the cloud balance and try again.` — instead of the generic `Something went wrong on my end. Please try again.` The direct chat API already classified this correctly (`credit-detection.ts`); the connector failure-reply path in core had no 402/credits branch, so it told users to retry a condition that can never succeed until they top up. Item 2 of the cloud-path error-honesty batch claimed on #13406 ([comment](https://github.com/elizaOS/eliza/issues/13406#issuecomment-4884626287)).

## Structural fix — one classifier, one string, for both paths

- **Lift `isInsufficientCreditsError` / `isInsufficientCreditsMessage` into core** (`services/message/fallback-reply.ts`, next to the sibling `isRateLimitError` / `isAuthError` classifiers). `packages/agent/src/api/credit-detection.ts` becomes a re-export — the direct path and the connector path now classify with literally the same function. The lift adds the AI-SDK retry-envelope unwrap and the `statusCode` field read that the sibling classifiers already use, so a 402 hidden inside `RetryError.lastError` is detected too.
- **`creditsExhausted` branch in the failure-reply ladder** (`generateFailureReplyText` → `buildStructuredFailureReply`), checked **before** `rateLimited` — a 429 *with* billing context is a drained balance ("top up"), not a transient throttle ("try again in a few seconds"). Characters override via `character.templates.insufficientCreditsReply`, mirroring `rateLimitedReply` / `authFailedReply`.
- **Shared reply string**: `INSUFFICIENT_CREDITS_REPLY` exported from core; `chat-routes.ts`'s local constant now aliases it. No second string.
- **Honest structured shape**: the synthetic reply carries `failureKind: "insufficient_credits"` (a kind the chat DTO gate and the recent-messages synthetic-failure filter already accept) instead of masquerading as `transient_failure`.

### Deliberate behavior delta (disclosed)

The lifted regex **drops the `rate_limit_exceeded` token** the agent-side copy carried. That token made a *plain throttle* (Eliza Cloud's bare 429 body is `code: "rate_limit_exceeded"`) classify as credit exhaustion on the direct path — telling users to spend money on a condition that resolves by waiting. With the shared classifier, a plain 429 stays on the rate-limited reply everywhere; nothing pinned the old mislabel (no test references it; it dates to the v2.0.4 squash baseline).

## Verify-first — defect proven on develop (0ea85dfaea)

New test (`packages/core/src/services/message.credit-exhaustion-reply.test.ts`) drives the **real `DefaultMessageService.handleMessage` pipeline** (memory persistence, room fetch, Stage 1 dispatch, failure catch, terminal delivery) with only the runtime I/O surface mocked; `useModel` rejects with the exact error shape `plugin-elizacloud` throws on a cloud 402 (`Error` + `.status = 402` + `.error = { code: "insufficient_credits" }`, message `Insufficient credits. Required: $0.0014, Available: $0.0000`). On unmodified develop:

```
Tests  3 failed | 1 passed (4)
AssertionError: expected 'Something went wrong on my end. Pleas…'  ← generic retry delivered for the 402
expected 'transient_failure' to be 'insufficient_credits'
```

(The bare-429 control test passed pre-fix, pinning that rate-limit behavior is untouched.)

## After the fix

- New suite: **4/4** — 402 turn delivers the top-up reply verbatim; DM turn carries `failureKind: "insufficient_credits"`; bare 429 (`code: rate_limit_exceeded`) still gets the rate-limited reply, **not** the top-up reply; enveloped `statusCode: 402` classifies.
- Built-dist probe (`dist/node/index.node.js`, real compiled artifact):

```
cloud 402 insufficient_credits             credits=true  ratelimit=false
bare object status 402                     credits=true  ratelimit=false
AI-SDK envelope statusCode 402             credits=true  ratelimit=false
openai insufficient_quota (429 + type)     credits=true  ratelimit=true   ← credits checked first, wins
plain cloud 429 rate_limit_exceeded        credits=false ratelimit=true   ← no false "top up"
CLI subscription usage limit               credits=false ratelimit=true   ← #10893 failover semantics preserved
unrelated 500                              credits=false ratelimit=false
```

## Test/verify counts (real)

- `packages/core` full suite: **3234 passed | 10 failed | 11 skipped (3255)** — the 10 failures live in 5 files (`media/fetch`, `link-extraction`, `action-handler-callsite-audit`, `runtime-component-precedence`, `tiered-action-surface`) and **fail identically on unmodified develop** (stash-baseline run: same 5 files, same 10 tests — network/env-dependent, zero overlap with this diff).
- Targeted: new suite 4/4 · `message.runtime-failure-suppression` 3/3 · `failure-reply-prompt` + `provider-error-hygiene` 23/23 · agent `credit-detection` 4/4 (now exercising the re-export) · agent failure-kind consumers (`conversation-failurekind-roundtrip`, `conversation-stream-sse-contract`, `persistence-after-done`) 16/16.
- Typecheck: core **0 errors**; agent **14 errors = exact stash-baseline set** (pre-existing fresh-env optional-plugin imports, byte-identical diff of error lists).
- `bun run --cwd packages/core build` (node + browser + edge): green. `audit:error-policy-ratchet`: no new fallback-slop.
- Rebased onto `develop` @ `1fd112f9d8`; upstream delta since base has zero overlap with the credit/failure-reply surfaces (checked).

## Evidence notes

- Live-LLM trajectory: **N/A** — this path fires precisely when every model call is failing (drained account); the delivered reply is the deterministic last-ditch template, and the test drives the full real pipeline that produces it.
- UI screenshots/video: **N/A** — no UI surface changed; connector-delivered text + structured `failureKind` are the artifacts, asserted verbatim.

[core-brain]
