### PR TITLE
fix(#13889): restore aria-current on settings section anchor (#13590 regression)

### DIFF
--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -142,10 +142,13 @@ function SettingsSectionFallback({
 function SettingsSectionSurfaceAnchor({
   section,
   label,
+  active,
   onSelect,
 }: {
   section: SettingsSectionDef;
   label: string;
+  /** Whether this is the currently-shown section. */
+  active: boolean;
   onSelect: (id: string) => void;
 }) {
   const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
@@ -165,6 +168,12 @@ function SettingsSectionSurfaceAnchor({
       className="hidden"
       onClick={() => onSelect(section.id)}
       {...agentProps}
+      /* #13889/#13590: the agent-addressable anchor carries `data-agent-id`; the
+         "which section is current" signal must live on the SAME element so the
+         `[data-agent-id^="section-"][aria-current="page"]` contract (agent
+         surface + packaged regression lane) resolves. #13590's SectionNav
+         refactor split these apart. Set after the spread so it always wins. */
+      aria-current={active ? "page" : undefined}
     />
   );
 }
@@ -283,6 +292,7 @@ export function SettingsView({
                 key={section.id}
                 section={section}
                 label={settingsSectionLabel(section, t)}
+                active={section.id === activeSection}
                 onSelect={openSection}
               />
             ))}


### PR DESCRIPTION
Addresses failure **#3** of #13889 (the real regression). Failures #1 and #2 are documented on the issue — one is a product decision, the other needs the packaged lane.

## Root cause (failure #3: `settings-shell` times out at `/settings/voice`)
Not onboarding churn (the test runs with onboarding already complete). It is a DOM-contract regression from **#13590** (Settings rail → SectionNav top-bar tabs), which split two attributes the agent surface + the packaged regression lane depend on:
- `data-agent-id="section-*"` stayed on the hidden `SettingsSectionSurfaceAnchor` (no `aria-current`).
- `aria-current="page"` moved to the visible `SectionNavTab` (no `data-agent-id`).

So nothing satisfied `[data-agent-id^="section-"][aria-current="page"]` and `activeSettingsSection` was always `null` → guaranteed timeout (`electrobun-packaged-regressions.e2e.spec.ts:222-253`).

## Fix
Re-unify the contract on the agent anchor: the **active** section's anchor carries `aria-current="page"` again (`SettingsView.tsx`). Restores the test selector **and** the "which section is current" agent-surface signal #13590 dropped. One call site; `active` threaded from the existing `activeSection` state.

## Not in this PR (documented on #13889)
- **Failure #1** (`runtime:local` chip missing): real, but a **product/config decision** — the runtime chooser is off by default (#13377 cloud-first), and the packaged first-run harness has no pre-boot localStorage seam. Enabling it (build flag `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER=1` for desktop, or a harness seed) is a product call, not an agent edit.
- **Failure #2** (pairing screen): every static link in the pairing chain is intact; likely a never-validated new test (authored the same evening the self-hosted CI wedge blocked the lane). Needs the packaged Linux lane to determine.

## Verification
Biome clean, single call site, `active` typed. Full confirmation needs the packaged Linux Electrobun lane (`playwright.electrobun.packaged.config.ts`) — not locally runnable (this repo is a git submodule; worktree checkouts can't build/run the packaged app).