### PR TITLE
fix: keep steward session minting available during Redis outage

### DIFF
--- a/packages/cloud/api/auth/steward-session/route.ts
+++ b/packages/cloud/api/auth/steward-session/route.ts
@@ -147,14 +147,14 @@ function errorBody(
 const app = new Hono<AppEnv>();
 
 // Pre-auth session-mint endpoint: previously guarded only by the Origin
-// allowlist + JWT verify, with no per-IP throttle. Add a strict, per-IP,
-// fail-closed rate limit so a credential-stuffing / token-spray flood on a
-// money/auth surface is bounded even if Redis blips at request time (M11).
+// allowlist + JWT verify, with no per-IP throttle. Keep the strict per-IP
+// bucket, but let a Redis outage fall open: login availability must not depend
+// on the rate-limit backing store, while money routes still opt into
+// fail-closed behavior.
 app.use(
   rateLimit({
     ...RateLimitPresets.STRICT,
     keyGenerator: getIpKey,
-    failClosed: true,
   }),
 );
 

--- a/packages/cloud/api/auth/steward-session/steward-session-rate-limit.test.ts
+++ b/packages/cloud/api/auth/steward-session/steward-session-rate-limit.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Steward session minting must keep login available when the rate-limit Redis
+ * backing store is down. The limiter still runs and reports the degraded policy,
+ * but the request reaches the normal auth validation path instead of returning
+ * `rate_limit_unavailable` before the browser can mint a session cookie.
+ */
+
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+const throwingRedis = {
+  incr: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  pttl: async () => 1,
+  pexpire: async () => 1,
+};
+
+mock.module("@/lib/cache/redis-factory", () => ({
+  buildRedisClient: () => throwingRedis,
+  hasRedisConfig: () => true,
+  isCloudflareWorkerRuntime: () => false,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+const { default: app } = await import("./route");
+
+const ENV = {
+  ENVIRONMENT: "staging",
+  NODE_ENV: "production",
+  REDIS_URL: "redis://mock:6379",
+};
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("POST /api/auth/steward-session rate limiting", () => {
+  test("falls open on Redis outage and reaches normal auth validation", async () => {
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "cf-connecting-ip": "203.0.113.19",
+          host: "api-staging.elizacloud.ai",
+          origin: "https://staging.elizacloud.ai",
+        },
+        body: "{}",
+      },
+      ENV,
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      code: "missing_token",
+    });
+    expect(res.headers.get("X-RateLimit-Policy")).toBe("redis-unavailable");
+  });
+});

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
@@ -2,10 +2,10 @@
  * Rate limiter fail-closed behavior on a runtime Redis error (#12227 M11).
  *
  * The limiter falls OPEN on a Redis error at request time — correct for
- * ordinary routes (a store outage shouldn't 500 the app). But money/auth
- * routes (steward-session mint, crypto top-up) must fail CLOSED: losing the
- * limiter there is worse than a brief 503. `RateLimitConfig.failClosed` opts a
- * route into rejecting (503) instead of serving unlimited when Redis throws.
+ * ordinary routes (a store outage shouldn't 500 the app). Money routes such as
+ * crypto top-up must fail CLOSED: losing the limiter there is worse than a
+ * brief 503. `RateLimitConfig.failClosed` opts a route into rejecting (503)
+ * instead of serving unlimited when Redis throws.
  *
  * The Redis DEPENDENCY is mocked to simulate the outage (that outage is the
  * condition under test); the real `rateLimit` middleware logic runs.


### PR DESCRIPTION
## Summary
- let `/api/auth/steward-session` fall open when the rate-limit Redis store throws, so login/session minting reaches normal auth validation instead of returning `rate_limit_unavailable`
- keep money/top-up fail-closed behavior unchanged
- add route coverage for steward-session Redis outage behavior and retain top-up/shared fail-closed coverage

Addresses the code-coupling portion of #13890. The staging Redis wiring itself is still an ops task.

## Tests
- `bun test packages/cloud/api/auth/steward-session/steward-session-rate-limit.test.ts`
- `bun test packages/cloud/api/v1/topup/topup-rate-limit.test.ts`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun test packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts`
- `bunx @biomejs/biome check packages/cloud/api/auth/steward-session/route.ts packages/cloud/api/auth/steward-session/steward-session-rate-limit.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts`
