### PR TITLE
fix(#13422): migrate benchmarks aliased env reads to the alias-aware reader (long-tail P4)

### DIFF
--- a/packages/benchmarks/eliza-1/__tests__/engine-resolver-alias.test.ts
+++ b/packages/benchmarks/eliza-1/__tests__/engine-resolver-alias.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Proves #13422: the eliza-1 bench model-dir mirror resolves a NON-ELIZA brand
+ * prefix (MILADY_STATE_DIR / MILADY_NAMESPACE) through the boot-config alias
+ * table via core's non-mutating reader — canonical ELIZA_ wins, empty is unset,
+ * and no ELIZA_ mirror is written. Real function + real resolver, no mocks; only
+ * the boot-config global slot and process.env are saved/restored per case.
+ */
+import { homedir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { benchElizaModelsDir } from "../src/engine-resolver.ts";
+
+const STORE_KEY = Symbol.for("elizaos.app.boot-config");
+const WINDOW_KEY = "__ELIZAOS_APP_BOOT_CONFIG__";
+type Slot = Record<PropertyKey, unknown>;
+
+// A NON-ELIZA prefix is the security-relevant fixture; an ELIZA->ELIZA
+// self-mirror would prove nothing about brand-alias resolution.
+const MILADY_ALIASES = [
+  ["MILADY_STATE_DIR", "ELIZA_STATE_DIR"],
+  ["MILADY_NAMESPACE", "ELIZA_NAMESPACE"],
+] as const;
+
+describe("benchElizaModelsDir resolves a branded prefix without the sync mirror (#13422)", () => {
+  const tracked = [
+    "MILADY_STATE_DIR",
+    "ELIZA_STATE_DIR",
+    "MILADY_NAMESPACE",
+    "ELIZA_NAMESPACE",
+  ];
+  const savedEnv: Record<string, string | undefined> = {};
+  let savedStore: unknown;
+  let savedWindow: unknown;
+
+  beforeEach(() => {
+    const slot = globalThis as Slot;
+    savedStore = slot[STORE_KEY];
+    savedWindow = slot[WINDOW_KEY];
+    for (const key of tracked) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    // Install the alias table exactly as the branded app boot does; this is what
+    // makes the resolver's default alias source resolve branded keys.
+    slot[STORE_KEY] = { current: { envAliases: MILADY_ALIASES } };
+  });
+
+  afterEach(() => {
+    const slot = globalThis as Slot;
+    if (savedStore === undefined) delete slot[STORE_KEY];
+    else slot[STORE_KEY] = savedStore;
+    if (savedWindow === undefined) delete slot[WINDOW_KEY];
+    else slot[WINDOW_KEY] = savedWindow;
+    for (const key of tracked) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  it("derives the models dir from a branded MILADY_STATE_DIR with zero mirror writes", () => {
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+    const before = { ...process.env };
+
+    expect(benchElizaModelsDir()).toBe(
+      path.join("/var/milady/state", "local-inference", "models"),
+    );
+
+    // The migrated read must not materialize the ELIZA_ target.
+    expect(process.env.ELIZA_STATE_DIR).toBeUndefined();
+    expect(process.env).toEqual(before);
+  });
+
+  it("prefers a canonical ELIZA_STATE_DIR over the branded alias", () => {
+    process.env.ELIZA_STATE_DIR = "/var/eliza/state";
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+    expect(benchElizaModelsDir()).toBe(
+      path.join("/var/eliza/state", "local-inference", "models"),
+    );
+  });
+
+  it("resolves a branded MILADY_NAMESPACE for the homedir fallback", () => {
+    process.env.MILADY_NAMESPACE = "brandns";
+    expect(benchElizaModelsDir()).toBe(
+      path.join(homedir(), ".brandns", "local-inference", "models"),
+    );
+  });
+
+  it("treats an empty/whitespace value as unset (empty-is-unset)", () => {
+    process.env.MILADY_STATE_DIR = "   ";
+    process.env.ELIZA_STATE_DIR = "";
+    expect(benchElizaModelsDir()).toBe(
+      path.join(homedir(), ".eliza", "local-inference", "models"),
+    );
+  });
+
+  it("a blank canonical ELIZA_STATE_DIR does not shadow a present branded alias", () => {
+    process.env.ELIZA_STATE_DIR = "";
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+    expect(benchElizaModelsDir()).toBe(
+      path.join("/var/milady/state", "local-inference", "models"),
+    );
+  });
+});

--- a/packages/benchmarks/eliza-1/src/engine-resolver.ts
+++ b/packages/benchmarks/eliza-1/src/engine-resolver.ts
@@ -17,6 +17,7 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import { resolveAliasedEnvValue } from "@elizaos/core";
 
 /**
  * Eliza-1 tier ids — kept in lockstep with `@elizaos/shared` catalog. We
@@ -71,11 +72,15 @@ interface SharedPathsLike {
  * shared import chain is unreachable (the bench is at the edge of the
  * dep graph; some host environments don't have shared's transitive
  * `@elizaos/core` deps resolved). Same precedence as upstream:
- *   ELIZA_STATE_DIR > ELIZA_STATE_DIR > ~/.${ELIZA_NAMESPACE ?? "eliza"}
+ *   ELIZA_STATE_DIR > ~/.${ELIZA_NAMESPACE ?? "eliza"}
+ *
+ * State-dir and namespace resolve through core's non-mutating alias reader so
+ * a branded prefix (e.g. `MILADY_STATE_DIR`) is honoured without depending on
+ * the `syncBrandEnvToEliza` mirror mutation (#13422).
  */
-function benchElizaModelsDir(): string {
-  const explicit = process.env.ELIZA_STATE_DIR ?? process.env.ELIZA_STATE_DIR;
-  const ns = process.env.ELIZA_NAMESPACE ?? "eliza";
+export function benchElizaModelsDir(): string {
+  const explicit = resolveAliasedEnvValue("ELIZA_STATE_DIR");
+  const ns = resolveAliasedEnvValue("ELIZA_NAMESPACE") ?? "eliza";
   const stateDir = explicit ?? path.join(homedir(), `.${ns}`);
   return path.join(stateDir, "local-inference", "models");
 }

--- a/packages/benchmarks/vision-language/src/runtime-resolver.ts
+++ b/packages/benchmarks/vision-language/src/runtime-resolver.ts
@@ -19,6 +19,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveAliasedEnvValue } from "@elizaos/core";
 import {
   actionListPrompt,
   parseActionList,
@@ -152,9 +153,16 @@ function resolveModelPath(tier: Eliza1TierId): string | null {
   return null;
 }
 
-function elizaModelsDir(): string {
-  const explicit = process.env.ELIZA_STATE_DIR ?? process.env.ELIZA_STATE_DIR;
-  const ns = process.env.ELIZA_NAMESPACE ?? "eliza";
+/**
+ * Local mirror of `elizaModelsDir()` from `@elizaos/shared/local-inference/paths`,
+ * kept so the bench resolves model paths without importing shared. State-dir and
+ * namespace resolve through core's non-mutating alias reader so a branded prefix
+ * (e.g. `MILADY_STATE_DIR`) is honoured without the `syncBrandEnvToEliza` mirror
+ * mutation (#13422).
+ */
+export function elizaModelsDir(): string {
+  const explicit = resolveAliasedEnvValue("ELIZA_STATE_DIR");
+  const ns = resolveAliasedEnvValue("ELIZA_NAMESPACE") ?? "eliza";
   const stateDir = explicit ?? path.join(homedir(), `.${ns}`);
   return path.join(stateDir, "local-inference", "models");
 }

--- a/packages/benchmarks/vision-language/tests/runtime-resolver-alias.test.ts
+++ b/packages/benchmarks/vision-language/tests/runtime-resolver-alias.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Proves #13422: the vision-language bench model-dir mirror resolves a NON-ELIZA
+ * brand prefix (MILADY_STATE_DIR / MILADY_NAMESPACE) through the boot-config
+ * alias table via core's non-mutating reader — canonical ELIZA_ wins, empty is
+ * unset, and no ELIZA_ mirror is written. Real function + real resolver, no
+ * mocks; only the boot-config global slot and process.env are saved/restored.
+ */
+import { homedir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { elizaModelsDir } from "../src/runtime-resolver.ts";
+
+const STORE_KEY = Symbol.for("elizaos.app.boot-config");
+const WINDOW_KEY = "__ELIZAOS_APP_BOOT_CONFIG__";
+type Slot = Record<PropertyKey, unknown>;
+
+// A NON-ELIZA prefix is the security-relevant fixture; an ELIZA->ELIZA
+// self-mirror would prove nothing about brand-alias resolution.
+const MILADY_ALIASES = [
+  ["MILADY_STATE_DIR", "ELIZA_STATE_DIR"],
+  ["MILADY_NAMESPACE", "ELIZA_NAMESPACE"],
+] as const;
+
+describe("elizaModelsDir resolves a branded prefix without the sync mirror (#13422)", () => {
+  const tracked = [
+    "MILADY_STATE_DIR",
+    "ELIZA_STATE_DIR",
+    "MILADY_NAMESPACE",
+    "ELIZA_NAMESPACE",
+  ];
+  const savedEnv: Record<string, string | undefined> = {};
+  let savedStore: unknown;
+  let savedWindow: unknown;
+
+  beforeEach(() => {
+    const slot = globalThis as Slot;
+    savedStore = slot[STORE_KEY];
+    savedWindow = slot[WINDOW_KEY];
+    for (const key of tracked) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    // Install the alias table exactly as the branded app boot does; this is what
+    // makes the resolver's default alias source resolve branded keys.
+    slot[STORE_KEY] = { current: { envAliases: MILADY_ALIASES } };
+  });
+
+  afterEach(() => {
+    const slot = globalThis as Slot;
+    if (savedStore === undefined) delete slot[STORE_KEY];
+    else slot[STORE_KEY] = savedStore;
+    if (savedWindow === undefined) delete slot[WINDOW_KEY];
+    else slot[WINDOW_KEY] = savedWindow;
+    for (const key of tracked) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  it("derives the models dir from a branded MILADY_STATE_DIR with zero mirror writes", () => {
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+    const before = { ...process.env };
+
+    expect(elizaModelsDir()).toBe(
+      path.join("/var/milady/state", "local-inference", "models"),
+    );
+
+    // The migrated read must not materialize the ELIZA_ target.
+    expect(process.env.ELIZA_STATE_DIR).toBeUndefined();
+    expect(process.env).toEqual(before);
+  });
+
+  it("prefers a canonical ELIZA_STATE_DIR over the branded alias", () => {
+    process.env.ELIZA_STATE_DIR = "/var/eliza/state";
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+    expect(elizaModelsDir()).toBe(
+      path.join("/var/eliza/state", "local-inference", "models"),
+    );
+  });
+
+  it("resolves a branded MILADY_NAMESPACE for the homedir fallback", () => {
+    process.env.MILADY_NAMESPACE = "brandns";
+    expect(elizaModelsDir()).toBe(
+      path.join(homedir(), ".brandns", "local-inference", "models"),
+    );
+  });
+
+  it("treats an empty/whitespace value as unset (empty-is-unset)", () => {
+    process.env.MILADY_STATE_DIR = "   ";
+    process.env.ELIZA_STATE_DIR = "";
+    expect(elizaModelsDir()).toBe(
+      path.join(homedir(), ".eliza", "local-inference", "models"),
+    );
+  });
+
+  it("a blank canonical ELIZA_STATE_DIR does not shadow a present branded alias", () => {
+    process.env.ELIZA_STATE_DIR = "";
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+    expect(elizaModelsDir()).toBe(
+      path.join("/var/milady/state", "local-inference", "models"),
+    );
+  });
+});


### PR DESCRIPTION
Long-tail slice of #13422 — partition P4 (benchmarks + lifeops-bench).

## What
Route the two bench model-dir inline-mirror helpers' raw aliased env reads through the alias-aware reader so a white-label `<PREFIX>_*` variable resolves without relying on the `syncBrandEnvToEliza` mirror mutation:

- `packages/benchmarks/eliza-1/src/engine-resolver.ts` — `benchElizaModelsDir()`: `process.env.ELIZA_STATE_DIR` (×2, a redundant self-coalesce) + `process.env.ELIZA_NAMESPACE` → `resolveAliasedEnvValue("ELIZA_STATE_DIR")` / `resolveAliasedEnvValue("ELIZA_NAMESPACE")`.
- `packages/benchmarks/vision-language/src/runtime-resolver.ts` — `elizaModelsDir()`: same migration.

The reader used is core's non-mutating `resolveAliasedEnvValue` (the "resolver" that `@elizaos/shared`'s `readAliasedEnv` thinly wraps). It is imported from **`@elizaos/core`**, which is already a declared dependency of both bench packages, whereas `@elizaos/shared` deliberately is NOT (these files are inline mirrors that exist precisely to avoid importing shared). eliza-1 already imports the `@elizaos/core` barrel in `src/tasks/planner.ts`, so no new dependency is introduced.

Both migrated helpers are exported so the new tests can exercise the real code path.

## Skipped reads (verified line-by-line)
- `packages/lifeops-bench/src/server.ts:182` — `process.env.ELIZA_AGENT_ORCHESTRATOR ??= "1"` is a **WRITE** (self-defaulting `??=` assignment), not a read. Writes to aliased keys are the sync-mutation / self-defaulting layer (#13423) and are left exactly as-is. This was the only listed hit in that file, so lifeops-bench is untouched.

## Tests (real, no mocks)
Added one focused vitest per package installing the real MILADY brand alias table on the boot-config global slot and driving the real migrated functions + real resolver:
- `packages/benchmarks/eliza-1/__tests__/engine-resolver-alias.test.ts`
- `packages/benchmarks/vision-language/tests/runtime-resolver-alias.test.ts`

Each proves: a branded `MILADY_STATE_DIR` / `MILADY_NAMESPACE` resolves; a canonical `ELIZA_STATE_DIR` wins over the branded alias; empty/whitespace is unset; a blank canonical does not shadow a present branded alias; and no `ELIZA_*` mirror is written to `process.env`.

## Verification
- `bun run --cwd packages/benchmarks/eliza-1 test` → 3 files, 36 passed (5 new)
- `bun run --cwd packages/benchmarks/vision-language test` → 4 files, 51 passed (5 new)
- `typecheck` (tsgo) → clean, both packages
- `lint:check` (biome) → clean, both packages
- `audit:alias-read-guard` → engine-resolver.ts 3→0, runtime-resolver.ts 3→0 (decrease; pass)
- `audit:error-policy-ratchet` → no new fallback-slop (pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)