### PR TITLE
fix(ci): run merge quality gate for strict manual lanes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1272,14 +1272,18 @@ jobs:
   # advisory on develop; #13617 F2). This job restores parity: it runs the same
   # lint / format / typecheck / secret-scan gates that guard `main`, on a
   # GitHub-hosted runner so it stays green-or-red regardless of the self-hosted
-  # fleet's health, and `ci-ok` needs it. It only runs where the queue actually
-  # gates (merge_group) and on develop push; on PRs quality.yml already covers
-  # this surface, so the job self-skips and `ci-ok`'s lenient PR path lets the
-  # skip pass.
+  # fleet's health, and `ci-ok` needs it. It runs anywhere `ci-ok` treats
+  # skipped jobs as failures (merge queue, develop push, manual dispatch, and
+  # nightly schedule); on PRs quality.yml already covers this surface, so the job
+  # self-skips and `ci-ok`'s lenient PR path lets the skip pass.
   merge-quality-gate:
     name: Merge Queue Quality Gate
     needs: changes
-    if: github.event_name == 'merge_group' || github.event_name == 'push'
+    if: >-
+      github.event_name == 'merge_group' ||
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule'
     runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:


### PR DESCRIPTION
## Summary
- runs `merge-quality-gate` on `workflow_dispatch` and `schedule` in addition to merge queue and develop push
- keeps `ci-ok` strict for manual/nightly runs without failing on a skipped quality gate
- updates the nearby workflow comment so the strict-event contract is explicit

## Verification
- `node packages/scripts/ci-merge-gate-contract.mjs --self-test`
- `node packages/scripts/ci-merge-gate-contract.mjs`
- `git diff --check`

## Evidence / N/A
- UI/model/native artifacts: N/A - workflow-only fix.
- Live CI evidence: pending on this PR; this is the follow-up to the post-merge #13742 review finding.

Fix-forward for #13742; refs #13617.