### PR TITLE
fix(ui): harden account security states

### DIFF
--- a/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx
@@ -143,12 +143,36 @@ describe("account-security panels", () => {
     expect(apiMock).toHaveBeenCalledWith("/api/v1/sessions");
   });
 
+  it("renders malformed session DTOs as errors, not healthy empty state", async () => {
+    apiMock.mockResolvedValueOnce({});
+
+    render(<ActiveSessionsPanel />);
+
+    expect(
+      await screen.findByText(/Session inventory response was malformed/i),
+    ).toBeTruthy();
+    expect(screen.queryByText(/No other active sessions found/i)).toBeNull();
+    expect(screen.queryByText(/Session listing is unavailable/i)).toBeNull();
+  });
+
   it("renders MFA errors separately from unavailable and disabled", async () => {
     apiMock.mockRejectedValueOnce(new Error("mfa route failed"));
 
     render(<MfaPanel />);
 
     expect(await screen.findByText("mfa route failed")).toBeTruthy();
+    expect(screen.queryByText(/MFA enrollment is unavailable/i)).toBeNull();
+    expect(screen.queryByText(/MFA is not enabled/i)).toBeNull();
+  });
+
+  it("renders malformed MFA DTOs as errors, not disabled state", async () => {
+    apiMock.mockResolvedValueOnce({});
+
+    render(<MfaPanel />);
+
+    expect(
+      await screen.findByText(/MFA status response was malformed/i),
+    ).toBeTruthy();
     expect(screen.queryByText(/MFA enrollment is unavailable/i)).toBeNull();
     expect(screen.queryByText(/MFA is not enabled/i)).toBeNull();
   });

--- a/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx
@@ -46,9 +46,16 @@ export function ActiveSessionsPanel() {
           });
           return;
         }
+        if (!Array.isArray(payload.sessions)) {
+          setState({
+            kind: "error",
+            message: "Session inventory response was malformed.",
+          });
+          return;
+        }
         setState({
           kind: "ready",
-          sessions: Array.isArray(payload.sessions) ? payload.sessions : [],
+          sessions: payload.sessions,
         });
       })
       .catch((error) => {
@@ -94,7 +101,9 @@ export function ActiveSessionsPanel() {
             })}
           </p>
         ) : state.kind === "error" ? (
-          <p className="text-sm text-red-300">{state.message}</p>
+          <p className="text-sm text-red-600 dark:text-red-300">
+            {state.message}
+          </p>
         ) : state.sessions.length === 0 ? (
           <p className="text-sm text-muted">
             {t("cloud.activeSessions.noOther", {
@@ -115,7 +124,7 @@ export function ActiveSessionsPanel() {
                         defaultValue: "Unknown device",
                       })}
                     {session.current ? (
-                      <span className="ml-2 rounded-sm border border-green-500/40 bg-green-500/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-green-300">
+                      <span className="ml-2 rounded-sm border border-green-500/40 bg-green-500/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-green-700 dark:text-green-300">
                         {t("cloud.activeSessions.current", {
                           defaultValue: "current",
                         })}

--- a/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
@@ -36,9 +36,16 @@ export function MfaPanel() {
           setState({ kind: "unavailable", reason: payload.reason ?? null });
           return;
         }
+        if (typeof payload.enrolled !== "boolean") {
+          setState({
+            kind: "error",
+            message: "MFA status response was malformed.",
+          });
+          return;
+        }
         setState({
           kind: "ready",
-          enrolled: Boolean(payload.enrolled),
+          enrolled: payload.enrolled,
           method: payload.method ?? null,
         });
       })
@@ -80,9 +87,11 @@ export function MfaPanel() {
             })}
           </p>
         ) : state.kind === "error" ? (
-          <p className="text-sm text-red-300">{state.message}</p>
+          <p className="text-sm text-red-600 dark:text-red-300">
+            {state.message}
+          </p>
         ) : state.enrolled ? (
-          <p className="text-sm text-green-300">
+          <p className="text-sm text-green-700 dark:text-green-300">
             {t("cloud.mfaPanel.enabled", {
               method:
                 state.method ??

--- a/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
@@ -123,7 +123,7 @@ export function PrivacyPanel() {
         <div className="flex items-start justify-between gap-3 rounded-sm border border-border bg-surface p-4">
           <div className="flex items-start gap-3">
             <div className="rounded-sm border border-green-500/40 bg-green-500/20 p-2">
-              <Download className="h-4 w-4 text-green-300" />
+              <Download className="h-4 w-4 text-green-700 dark:text-green-300" />
             </div>
             <div className="space-y-1">
               <p className="text-sm font-medium text-txt-strong">
@@ -158,7 +158,7 @@ export function PrivacyPanel() {
         <div className="flex items-start justify-between gap-3 rounded-sm border border-red-500/30 bg-red-500/5 p-4">
           <div className="flex items-start gap-3">
             <div className="rounded-sm border border-red-500/40 bg-red-500/20 p-2">
-              <Trash2 className="h-4 w-4 text-red-300" />
+              <Trash2 className="h-4 w-4 text-red-600 dark:text-red-300" />
             </div>
             <div className="space-y-1">
               <p className="text-sm font-medium text-txt-strong">
@@ -177,7 +177,7 @@ export function PrivacyPanel() {
           <BrandButton
             size="sm"
             variant="outline"
-            className="border-red-500/40 text-red-300"
+            className="border-red-500/40 text-red-600 dark:text-red-300"
             disabled
             title={t("cloud.privacyPanel.deletionComingSoon", {
               defaultValue:

--- a/packages/ui/src/cloud/organization/pending-invites-list.tsx
+++ b/packages/ui/src/cloud/organization/pending-invites-list.tsx
@@ -85,7 +85,7 @@ export function PendingInvitesList({
         );
       case "accepted":
         return (
-          <span className="px-2 py-0.5 border border-green-500/40 bg-green-500/20 text-green-400 flex items-center gap-1 text-xs font-mono">
+          <span className="px-2 py-0.5 border border-green-500/40 bg-green-500/20 text-green-700 dark:text-green-300 flex items-center gap-1 text-xs font-mono">
             <CheckCircle2 className="h-3 w-3" />
             Accepted
           </span>

--- a/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
+++ b/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
@@ -33,6 +33,13 @@ const SCANNED_PATHS = [
   "api-keys/ApiKeysView.tsx",
 ];
 
+const STATUS_TOKEN_FILES = [
+  "account-security/components/active-sessions-panel.tsx",
+  "account-security/components/mfa-panel.tsx",
+  "account-security/components/privacy-panel.tsx",
+  "organization/pending-invites-list.tsx",
+];
+
 // Theme-locked color utilities: hardcoded light-on-dark values that render
 // white/near-white text or opaque dark surfaces regardless of the active theme.
 const FORBIDDEN_TOKEN_PATTERNS: RegExp[] = [
@@ -54,7 +61,8 @@ const FORBIDDEN_TOKEN_PATTERNS: RegExp[] = [
 // solid saturated background (white-on-color reads in both themes).
 const SOLID_COLOR_BG =
   /\bbg-(?:accent|primary|destructive)\b|\bbg-\[#(?:eb4335|ff5800|e54f00)\]|\bbg-\[(?:rgba\()?var\(--accent/i;
-const isWhiteTextToken = (pattern: RegExp) => pattern.source.includes("text-white");
+const isWhiteTextToken = (pattern: RegExp) =>
+  pattern.source.includes("text-white");
 
 // direct-crypto-credit-card renders its explicit black/white cloud aesthetic only
 // under an in-component `surface === "cloud"` branch, not on the settings surface.
@@ -76,7 +84,8 @@ function collectFiles(path: string): string[] {
 
 // Every quoted / backtick string literal in the file — className attributes,
 // cn()/ternary class fragments, and `${…}`-nested class strings all surface here.
-const STRING_LITERAL = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|`([^`\\]*(?:\\.[^`\\]*)*)`/g;
+const STRING_LITERAL =
+  /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|`([^`\\]*(?:\\.[^`\\]*)*)`/g;
 
 describe("Cloud settings theme tokens", () => {
   it("keeps lifted Cloud settings bodies readable without a dark theme island", () => {
@@ -93,6 +102,23 @@ describe("Cloud settings theme tokens", () => {
           if (!pattern.test(classString)) continue;
           if (isWhiteTextToken(pattern) && hasSolidColorBg) continue;
           offenders.push(`${file}: ${pattern.source}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps account security status colors readable on light settings surfaces", () => {
+    const offenders: string[] = [];
+    const paleStatusTokens = /\b(?<!dark:)text-(?:red|green)-(?:300|400)\b/;
+
+    for (const file of STATUS_TOKEN_FILES) {
+      const source = readFileSync(join(ROOT, file), "utf8");
+      for (const match of source.matchAll(STRING_LITERAL)) {
+        const classString = match[1] ?? match[2] ?? match[3] ?? "";
+        if (paleStatusTokens.test(classString)) {
+          offenders.push(file);
         }
       }
     }


### PR DESCRIPTION
## Summary
- Treat malformed available session/MFA DTOs as explicit error states instead of healthy empty/disabled UI.
- Replace low-contrast light-surface red/green status text in account security and pending invites with theme-aware tokens.
- Add regression coverage for malformed account-security DTOs and a targeted settings status-token scan.

## Verification
- `bunx @biomejs/biome check packages/ui/src/cloud/account-security/components/active-sessions-panel.tsx packages/ui/src/cloud/account-security/components/mfa-panel.tsx packages/ui/src/cloud/account-security/components/privacy-panel.tsx packages/ui/src/cloud/organization/pending-invites-list.tsx packages/ui/src/cloud/account-security/components/account-security-panels.test.tsx packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts --no-errors-on-unmatched`
- `git diff --check origin/develop...HEAD && git diff --check`
- `bun run --cwd packages/ui test -- src/cloud/settings/cloud-settings-theme-tokens.test.ts` passed in `/home/shaw/milady/eliza`.
- `bun run --cwd packages/ui test -- src/cloud/account-security/components/account-security-panels.test.tsx` currently fails in both the primary checkout and temp worktree before these new assertions execute because the local install resolves app code to `dist/node_modules/react` and `@testing-library/react`/React DOM through Bun cache peers, producing an existing duplicate-React invalid-hook-call failure.