### PR TITLE
fix(ui): keep task activity events monotonic

### DIFF
--- a/packages/ui/src/state/task-activity-store.test.ts
+++ b/packages/ui/src/state/task-activity-store.test.ts
@@ -81,6 +81,48 @@ describe("task-activity-store reducer", () => {
     expect(agent.steps[0].tool.output).toBe("ok");
   });
 
+  it("ignores stale same-id tool updates after a newer result", () => {
+    applyEvent(
+      ev({
+        type: "tool_running",
+        sessionId: "a",
+        taskId: "T",
+        seq: 10,
+        timestamp: 100,
+        data: {
+          toolCall: {
+            id: "t1",
+            title: "Bash",
+            status: "completed",
+            output: "ok",
+          },
+        },
+      }),
+    );
+    applyEvent(
+      ev({
+        type: "tool_running",
+        sessionId: "a",
+        taskId: "T",
+        seq: 9,
+        timestamp: 90,
+        data: {
+          toolCall: {
+            id: "t1",
+            title: "Bash",
+            status: "running",
+          },
+        },
+      }),
+    );
+
+    const agent = getSnapshot("T").subagents[0];
+    expect(agent.steps).toHaveLength(1);
+    expect(agent.steps[0].seq).toBe(10);
+    expect(agent.steps[0].tool.status).toBe("success");
+    expect(agent.steps[0].tool.output).toBe("ok");
+  });
+
   it("tracks the live plan checklist as it mutates", () => {
     applyEvent(
       ev({
@@ -183,6 +225,36 @@ describe("task-activity-store reducer", () => {
     expect(agent.currentReasoning).toBe("new reasoning");
     expect(agent.status).toBe("success");
     expect(agent.steps.map((step) => step.id)).toEqual(["late-tool"]);
+  });
+
+  it("keeps task snapshots monotonic when stale events arrive", () => {
+    applyEvent(
+      ev({
+        type: "message",
+        sessionId: "a",
+        taskId: "T",
+        seq: 10,
+        timestamp: 1000,
+        data: { text: "new text" },
+      }),
+    );
+    expect(getSnapshot("T").updatedAt).toBe(1000);
+
+    applyEvent(
+      ev({
+        type: "message",
+        sessionId: "a",
+        taskId: "T",
+        seq: 9,
+        timestamp: 900,
+        data: { text: "stale text" },
+      }),
+    );
+
+    const snap = getSnapshot("T");
+    expect(snap.updatedAt).toBe(1000);
+    expect(snap.subagents[0].updatedAt).toBe(1000);
+    expect(snap.subagents[0].currentText).toBe("new text");
   });
 
   it("moves a sub-agent to a terminal status on lifecycle events", () => {

--- a/packages/ui/src/state/task-activity-store.ts
+++ b/packages/ui/src/state/task-activity-store.ts
@@ -183,12 +183,13 @@ function refreezeSnapshot(entry: TaskEntry, at: number): void {
   const subagents = [...entry.subagents.values()].sort(
     (a, b) => a.firstSeq - b.firstSeq,
   );
+  const updatedAt = Math.max(entry.snapshot.updatedAt, at);
   entry.snapshot = {
     taskId: entry.snapshot.taskId,
     subagents,
     plan: entry.plan,
     lastSeq: entry.lastSeq,
-    updatedAt: at,
+    updatedAt,
   };
   for (const listener of entry.listeners) listener();
 }
@@ -256,8 +257,11 @@ function applyEvent(raw: SwarmEvent): void {
         timestamp: activity.timestamp,
       };
       const idx = agent.steps.findIndex((s) => s.id === stepId);
-      if (idx >= 0) agent.steps[idx] = step;
-      else agent.steps.push(step);
+      const existingStep = idx >= 0 ? agent.steps[idx] : undefined;
+      if (!existingStep || activity.seq > existingStep.seq) {
+        if (idx >= 0) agent.steps[idx] = step;
+        else agent.steps.push(step);
+      }
       agent.steps.sort((a, b) => a.seq - b.seq);
       if (agent.steps.length > MAX_STEPS_PER_AGENT) {
         agent.steps.splice(0, agent.steps.length - MAX_STEPS_PER_AGENT);


### PR DESCRIPTION
## Summary
- Ignore stale same-id tool events so a delayed `running` event cannot overwrite a newer completed tool result.
- Keep task-level `updatedAt` monotonic when out-of-order events arrive, preserving idle-task eviction ordering.
- Add focused reducer regressions for both stale-event cases.

## Verification
- `bun run --cwd packages/ui test -- src/state/task-activity-store.test.ts` (11 tests)
- `bunx @biomejs/biome check packages/ui/src/state/task-activity-store.ts packages/ui/src/state/task-activity-store.test.ts --no-errors-on-unmatched`
- `git diff --check origin/develop...HEAD && git diff --check`