### PR TITLE
fix(#13422): migrate plugin-capacitor-bridge aliased env reads to the alias-aware reader (long-tail P6)

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.state-dir-alias.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.state-dir-alias.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Alias-aware ELIZA_STATE_DIR resolution for the iOS bridge (#13422). Drives the
+ * real `resolveMobileStateDir` against a live MILADY-prefixed boot-config alias
+ * table and the real `process.env` — no mocks — proving brand→eliza resolution,
+ * canonical precedence, empty-is-unset, and no ELIZA_* mirror write.
+ */
+
+import {
+	buildBrandEnvAliases,
+	getBootConfig,
+	readAliasedEnv,
+	setBootConfig,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveMobileStateDir } from "./bridge.ts";
+
+const TOUCHED_KEYS = [
+	"MILADY_STATE_DIR",
+	"ELIZA_STATE_DIR",
+	"ELIZA_HOME",
+	"ELIZA_WORKSPACE_DIR",
+] as const;
+
+describe("iOS bridge ELIZA_STATE_DIR alias resolution", () => {
+	let savedEnv: Record<string, string | undefined>;
+	let savedBootConfig: ReturnType<typeof getBootConfig>;
+
+	beforeEach(() => {
+		savedEnv = {};
+		for (const key of TOUCHED_KEYS) {
+			savedEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+		savedBootConfig = getBootConfig();
+		setBootConfig({
+			...savedBootConfig,
+			envAliases: buildBrandEnvAliases("MILADY"),
+		});
+	});
+
+	afterEach(() => {
+		for (const key of TOUCHED_KEYS) {
+			if (savedEnv[key] === undefined) delete process.env[key];
+			else process.env[key] = savedEnv[key];
+		}
+		setBootConfig(savedBootConfig);
+	});
+
+	it("resolves the MILADY brand prefix through the alias-aware reader", () => {
+		process.env.MILADY_STATE_DIR = "/data/milady/state";
+		expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/data/milady/state");
+		expect(resolveMobileStateDir()).toBe("/data/milady/state");
+	});
+
+	it("prefers the canonical ELIZA_STATE_DIR over the brand alias", () => {
+		process.env.ELIZA_STATE_DIR = "/canonical/state";
+		process.env.MILADY_STATE_DIR = "/data/milady/state";
+		expect(resolveMobileStateDir()).toBe("/canonical/state");
+	});
+
+	it("treats a blank canonical value as unset and falls back to the brand alias", () => {
+		process.env.ELIZA_STATE_DIR = "   ";
+		process.env.MILADY_STATE_DIR = "/data/milady/state";
+		expect(resolveMobileStateDir()).toBe("/data/milady/state");
+	});
+
+	it("does not mirror-write the resolved brand value back to ELIZA_STATE_DIR", () => {
+		process.env.MILADY_STATE_DIR = "/data/milady/state";
+		resolveMobileStateDir();
+		expect(process.env.ELIZA_STATE_DIR).toBeUndefined();
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -35,6 +35,7 @@ import {
 	transcriptPreview,
 	transcriptSpeakerCount,
 } from "@elizaos/shared/transcripts";
+import { readAliasedEnv } from "@elizaos/shared/utils/env";
 import {
 	createWriteStream,
 	existsSync,
@@ -547,7 +548,7 @@ async function startIosBridgeBackend(): Promise<IosBridgeBackend> {
 		process.env.MOBILE_WORKSPACE_ROOT ||
 		argvEnv.appSupportDir ||
 		process.env.ELIZA_WORKSPACE_DIR ||
-		process.env.ELIZA_STATE_DIR ||
+		readAliasedEnv("ELIZA_STATE_DIR") ||
 		process.env.ELIZA_HOME ||
 		(process.env.HOME
 			? `${process.env.HOME}/Library/Application Support/Eliza/workspace`
@@ -1943,11 +1944,8 @@ function callIosHost(
 	});
 }
 
-function resolveMobileStateDir(): string {
-	const explicit =
-		process.env.ELIZA_STATE_DIR ||
-		process.env.ELIZA_STATE_DIR ||
-		process.env.ELIZA_HOME;
+export function resolveMobileStateDir(): string {
+	const explicit = readAliasedEnv("ELIZA_STATE_DIR") || process.env.ELIZA_HOME;
 	if (explicit?.trim()) return explicit.trim();
 	if (process.env.HOME?.trim()) {
 		return path.join(process.env.HOME.trim(), ".eliza");


### PR DESCRIPTION
Long-tail slice of #13422 (partition **P6 — `plugin-capacitor-bridge`**).

Migrates the iOS bridge's raw `process.env.ELIZA_STATE_DIR` reads to the shared alias-aware reader `readAliasedEnv` (from `@elizaos/shared/utils/env`), so a non-ELIZA brand prefix (`MILADY_STATE_DIR`) resolves without relying on the `syncBrandEnvToEliza` mutation, while canonical `ELIZA_STATE_DIR` still wins and empty/whitespace is treated as unset.

### Changed
- `plugins/plugin-capacitor-bridge/src/ios/bridge.ts`
  - `mobileWorkspaceRoot` chain: `process.env.ELIZA_STATE_DIR` → `readAliasedEnv("ELIZA_STATE_DIR")` (the neighboring `ELIZA_WORKSPACE_DIR` / `ELIZA_HOME` operands are **not** in the alias table, left raw).
  - `resolveMobileStateDir()`: the duplicate `process.env.ELIZA_STATE_DIR || process.env.ELIZA_STATE_DIR` pair (a pre-existing botched brand-rename artifact) collapses into the single `readAliasedEnv("ELIZA_STATE_DIR")` call that subsumes both; exported so the new test drives the real path.
- `plugins/plugin-capacitor-bridge/src/ios/bridge.state-dir-alias.test.ts` (new) — real test, no mocks.

### Skipped (documented)
- `ios/bridge.ts:561` — `process.env.ELIZA_PLATFORM = process.env.ELIZA_PLATFORM || "ios"` is a **self-defaulting write**, left exactly as-is (the two remaining raw hits the guard counts).
- All `android/bridge.ts` hits:
  - `:45` `process.env.ELIZA_PLATFORM ||= "android"` — a self-defaulting **write** (`||=`).
  - `:137/138/168/169` `ELIZA_STATE_DIR` **reads** — these run in the **synchronous pre-fs-shim bootstrap** (`setupAndroidBridgeEnvironment`), and `android/bridge.ts` deliberately carries **zero static `@elizaos/*` imports** (only a type-only `IAgentRuntime`; `@elizaos/agent` is reached via a gated dynamic `import(/* @vite-ignore */ …)` **after** the fs shim) so the WebView Vite import-analysis boundary gate does not pull the runtime into the renderer bundle. Introducing a static `@elizaos/shared` import to reach the reader would break that documented invariant and eagerly load core before the shim; migrating safely would need an async refactor of the sync bootstrap — out of scope for a mechanical read migration. Left for a dedicated follow-up if ever needed.

### Verification
- Alias-read guard (diff-scoped): `plugins/plugin-capacitor-bridge/src/ios/bridge.ts: raw-aliased-reads 5->2` (the 2 remaining = the self-defaulting `ELIZA_PLATFORM` write at :561); "no new raw reads".
- New focused test proves: `MILADY_STATE_DIR` resolves via the reader; canonical `ELIZA_STATE_DIR` wins; blank canonical is unset (falls back to brand); no `ELIZA_*` mirror write. **4/4 pass.**
- Full `plugin-capacitor-bridge` suite: **15 files / 112 tests pass**.
- Typecheck: no errors in touched files (`ios/bridge.ts` + the test). The whole-project `tsgo` failure is pre-existing environmental noise in this sparse worktree (missing `@elizaos/auth` + third-party `.d.ts` for drizzle-orm/viem/yaml/etc.), entirely outside this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)