### PR TITLE
fix(cloud-shared): fail-closed containers/provisioning sweep (#13415 slice 5)

### DIFF
--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.error-policy.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Error-policy pins for `HetznerPoolContainerCreator` (#13415).
+ *
+ * This is the concrete warm-pool creator sitting on the Hetzner/Neon
+ * provisioning path. Doctrine for the container-provisioning domain: an
+ * *internal failure* of a provision/destroy/DB call must PROPAGATE (throw), so
+ * the WarmPoolManager records it as a real failure — it must never be swallowed
+ * into a phantom "success" (a leaked pool row that reads as destroyed, a
+ * fabricated pool id from a failed provision). A *legitimately-empty* outcome (a
+ * row already gone, an idempotent 404-as-success, an unreachable liveness probe)
+ * stays DISTINCT: it resolves/returns a designed value rather than throwing.
+ *
+ * Drives the real exported `getHetznerPoolContainerCreator()` with the DB
+ * repository, sandbox service and schema constant `mock.module`-stubbed and the
+ * module dynamically imported after the stubs install; `global.fetch` is stubbed
+ * for the liveness probe and restored per-test.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as realRepoNs from "../../../db/repositories/agent-sandboxes";
+import * as realSchemaNs from "../../../db/schemas/agent-sandboxes";
+import * as realLoggerNs from "../../utils/logger";
+import * as realSandboxNs from "../eliza-sandbox";
+
+// Snapshot real module records before mock.module rewires them, and restore in
+// afterAll: Bun runs every cloud-shared test file in one process with no
+// per-file mock teardown, so an un-restored stub leaks into later files.
+const realRepo = { ...realRepoNs };
+const realSchema = { ...realSchemaNs };
+const realLogger = { ...realLoggerNs };
+const realSandbox = { ...realSandboxNs };
+
+const WARM_POOL_ORG_ID = "warm-pool-sentinel-org";
+
+const repo = {
+  createPoolEntry: mock(),
+  update: mock(),
+  markPoolEntryReady: mock(),
+  findById: mock(),
+  deletePoolEntry: mock(),
+};
+
+const sandbox = {
+  provision: mock(),
+  deleteAgent: mock(),
+};
+
+mock.module("../../../db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: repo,
+}));
+mock.module("../../../db/schemas/agent-sandboxes", () => ({ WARM_POOL_ORG_ID }));
+mock.module("../eliza-sandbox", () => ({ elizaSandboxService: sandbox }));
+mock.module("../../utils/logger", () => ({
+  logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
+}));
+
+const { getHetznerPoolContainerCreator } = await import("./agent-warm-pool-creator");
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  for (const m of [...Object.values(repo), ...Object.values(sandbox)]) m.mockReset();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+afterAll(() => {
+  mock.module("../../../db/repositories/agent-sandboxes", () => realRepo);
+  mock.module("../../../db/schemas/agent-sandboxes", () => realSchema);
+  mock.module("../eliza-sandbox", () => realSandbox);
+  mock.module("../../utils/logger", () => realLogger);
+  globalThis.fetch = realFetch;
+});
+
+// ---------------------------------------------------------------------------
+// destroyPoolContainer — internal failure PROPAGATES, designed no-op stays distinct
+// ---------------------------------------------------------------------------
+
+describe("destroyPoolContainer fail-closed", () => {
+  test("a DB error on the final deletePoolEntry PROPAGATES — not swallowed into a phantom leaked row", async () => {
+    repo.findById.mockResolvedValue({ id: "p1", organization_id: WARM_POOL_ORG_ID });
+    sandbox.deleteAgent.mockResolvedValue({ success: true });
+    // The removed slop was `.catch(() => undefined)` here: a genuine DB failure
+    // would read as a successful destroy while the pool row leaks. It must throw.
+    repo.deletePoolEntry.mockRejectedValue(new Error("connection terminated"));
+
+    const creator = getHetznerPoolContainerCreator();
+    await expect(creator.destroyPoolContainer("p1")).rejects.toThrow("connection terminated");
+  });
+
+  test("row already gone (deletePoolEntry returns false) resolves — a designed idempotent no-op, not a failure", async () => {
+    repo.findById.mockResolvedValue({ id: "p2", organization_id: WARM_POOL_ORG_ID });
+    sandbox.deleteAgent.mockResolvedValue({ success: true });
+    repo.deletePoolEntry.mockResolvedValue(false);
+
+    const creator = getHetznerPoolContainerCreator();
+    await expect(creator.destroyPoolContainer("p2")).resolves.toBeUndefined();
+    expect(repo.deletePoolEntry).toHaveBeenCalledWith("p2");
+  });
+
+  test("unknown poolId (findById null) is an idempotent no-op — no destroy attempted", async () => {
+    repo.findById.mockResolvedValue(null);
+    const creator = getHetznerPoolContainerCreator();
+    await expect(creator.destroyPoolContainer("gone")).resolves.toBeUndefined();
+    expect(sandbox.deleteAgent).not.toHaveBeenCalled();
+    expect(repo.deletePoolEntry).not.toHaveBeenCalled();
+  });
+
+  test("refuses to destroy a non-pool sandbox — throws the ownership guard, never deletes", async () => {
+    repo.findById.mockResolvedValue({ id: "user-owned", organization_id: "some-user-org" });
+    const creator = getHetznerPoolContainerCreator();
+    await expect(creator.destroyPoolContainer("user-owned")).rejects.toThrow(
+      /refusing to destroy non-pool sandbox/,
+    );
+    expect(sandbox.deleteAgent).not.toHaveBeenCalled();
+    expect(repo.deletePoolEntry).not.toHaveBeenCalled();
+  });
+
+  test("deleteAgent real failure PROPAGATES — the row is never deleted afterward", async () => {
+    repo.findById.mockResolvedValue({ id: "p3", organization_id: WARM_POOL_ORG_ID });
+    sandbox.deleteAgent.mockResolvedValue({ success: false, error: "hetzner 500" });
+    const creator = getHetznerPoolContainerCreator();
+    await expect(creator.destroyPoolContainer("p3")).rejects.toThrow(
+      /pool destroy failed: hetzner 500/,
+    );
+    expect(repo.deletePoolEntry).not.toHaveBeenCalled();
+  });
+
+  test('"Agent not found" from deleteAgent is a designed 404-as-success — proceeds to reap the row', async () => {
+    repo.findById.mockResolvedValue({ id: "p4", organization_id: WARM_POOL_ORG_ID });
+    sandbox.deleteAgent.mockResolvedValue({ success: false, error: "Agent not found" });
+    repo.deletePoolEntry.mockResolvedValue(true);
+    const creator = getHetznerPoolContainerCreator();
+    await expect(creator.destroyPoolContainer("p4")).resolves.toBeUndefined();
+    expect(repo.deletePoolEntry).toHaveBeenCalledWith("p4");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createPoolContainer — failed provision throws, never fabricates a pool id
+// ---------------------------------------------------------------------------
+
+describe("createPoolContainer fail-closed", () => {
+  test("provision failure marks the row 'error' and THROWS — no fabricated ready pool entry", async () => {
+    repo.createPoolEntry.mockResolvedValue({ id: "row-1" });
+    sandbox.provision.mockResolvedValue({ success: false, error: "no capacity" });
+
+    const creator = getHetznerPoolContainerCreator();
+    await expect(creator.createPoolContainer("img:latest")).rejects.toThrow(
+      /pool provision failed: no capacity/,
+    );
+    expect(repo.update).toHaveBeenCalledWith("row-1", {
+      status: "error",
+      error_message: "no capacity",
+    });
+    expect(repo.markPoolEntryReady).not.toHaveBeenCalled();
+  });
+
+  test("successful provision returns the real id + nodeId — the healthy path stays intact", async () => {
+    repo.createPoolEntry.mockResolvedValue({ id: "row-2" });
+    sandbox.provision.mockResolvedValue({ success: true, sandboxRecord: { node_id: "node-9" } });
+    repo.markPoolEntryReady.mockResolvedValue({ node_id: "node-9", bridge_url: "http://x" });
+
+    const creator = getHetznerPoolContainerCreator();
+    await expect(creator.createPoolContainer("img:latest")).resolves.toEqual({
+      id: "row-2",
+      nodeId: "node-9",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// healthProbe — unreachable ⇒ designed `false`, distinct from `true` alive
+// ---------------------------------------------------------------------------
+
+describe("healthProbe designed-false vs alive", () => {
+  test("fetch throwing (network/abort) yields a distinguishable false — reaped, never a thrown crash", async () => {
+    repo.findById.mockResolvedValue({ health_url: "http://dead/health" });
+    globalThis.fetch = mock(() => Promise.reject(new Error("ECONNREFUSED"))) as typeof fetch;
+    const creator = getHetznerPoolContainerCreator();
+    await expect(creator.healthProbe("p1")).resolves.toBe(false);
+  });
+
+  test("a 200 response reports alive (true) — distinct from the unreachable-false above", async () => {
+    repo.findById.mockResolvedValue({ health_url: "http://ok/health" });
+    globalThis.fetch = mock(() => Promise.resolve({ ok: true } as Response)) as typeof fetch;
+    const creator = getHetznerPoolContainerCreator();
+    await expect(creator.healthProbe("p1")).resolves.toBe(true);
+  });
+
+  test("a row with no health_url is not-alive (false) without any fetch attempt", async () => {
+    repo.findById.mockResolvedValue({ health_url: null });
+    const fetchSpy = mock(() => Promise.resolve({ ok: true } as Response));
+    globalThis.fetch = fetchSpy as typeof fetch;
+    const creator = getHetznerPoolContainerCreator();
+    await expect(creator.healthProbe("p1")).resolves.toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.ts
@@ -50,6 +50,8 @@ export class HetznerPoolContainerCreator implements PoolContainerCreator {
       });
       return { id: row.id, nodeId: ready?.node_id ?? result.sandboxRecord.node_id ?? null };
     } catch (err) {
+      // error-policy:J7 diagnostic warn adding poolId context; rethrows the
+      // original error so the provision failure still surfaces to replenish().
       logger.warn("[warm-pool/creator] pool entry creation failed", {
         poolId: row.id,
         error: err instanceof Error ? err.message : String(err),
@@ -72,7 +74,10 @@ export class HetznerPoolContainerCreator implements PoolContainerCreator {
     }
     // deleteAgent already removes the row, but if it short-circuited (e.g.
     // because the container was never started) the pool row may still exist.
-    await agentSandboxesRepository.deletePoolEntry(poolId).catch(() => undefined);
+    // deletePoolEntry is a no-op (returns false) when the row is already gone,
+    // so a genuine throw here is a real DB failure that must surface as a
+    // destroy failure — never swallowed into a phantom leaked pool row.
+    await agentSandboxesRepository.deletePoolEntry(poolId);
   }
 
   async healthProbe(poolId: string): Promise<boolean> {
@@ -84,6 +89,10 @@ export class HetznerPoolContainerCreator implements PoolContainerCreator {
       });
       return r.ok;
     } catch {
+      // error-policy:J4 unreachable/timeout ⇒ unhealthy. This is a boolean
+      // liveness probe whose contract is "true when alive, false when
+      // unreachable"; a network/abort error is a distinguishable "dead" signal
+      // that drives the caller to reap the entry — not a fabricated success.
       return false;
     }
   }

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-forecast.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-forecast.error-policy.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Error-policy pin for the warm-pool forecast (#13415).
+ *
+ * This module is container-provisioning infra: its `targetPoolSize` drives how
+ * many sandboxes the autoscaler spins up (real cloud cost). Under the
+ * fail-closed doctrine an INTERNAL failure (invalid policy config) must
+ * PROPAGATE as a thrown typed error rather than be swallowed into a default
+ * pool size, while a DESIGNED-EMPTY input (an actually-empty forecast window)
+ * must stay distinguishable: it yields a rate of 0 and clamps to the floor,
+ * never throws. These tests pin that the two paths never collapse into each
+ * other — the file has no catch/`?? default` slop to remove, so this pins the
+ * already-fail-closed behavior against regression.
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+
+let mod: typeof import("./agent-warm-pool-forecast");
+
+beforeEach(async () => {
+  mod = await import("./agent-warm-pool-forecast");
+});
+
+const base = {
+  bucketCounts: [] as number[],
+  emaAlpha: 0.5,
+  leadTimeBuckets: 1,
+  minPoolSize: 1,
+  maxPoolSize: 10,
+};
+
+describe("agent-warm-pool-forecast — internal failure propagates (fail closed)", () => {
+  it("throws instead of returning a default pool size when min > max", () => {
+    // A broken policy is an internal invariant violation, not a quiet clamp:
+    // it must surface so the autoscaler never provisions against garbage.
+    expect(() => mod.computeForecast({ ...base, minPoolSize: 5, maxPoolSize: 4 })).toThrow(
+      /minPoolSize cannot exceed maxPoolSize/,
+    );
+  });
+
+  it("throws on an out-of-range smoothing factor rather than silently coercing", () => {
+    for (const emaAlpha of [0, -0.1, 1.5]) {
+      expect(() => mod.computeForecast({ ...base, emaAlpha, bucketCounts: [3] })).toThrow(
+        /emaAlpha/,
+      );
+    }
+  });
+
+  it("throws on a negative lead time rather than fabricating a target", () => {
+    expect(() => mod.computeForecast({ ...base, leadTimeBuckets: -1 })).toThrow(
+      /leadTimeBuckets must be non-negative/,
+    );
+  });
+});
+
+describe("agent-warm-pool-forecast — designed-empty stays distinct from failure", () => {
+  it("an empty forecast window returns rate 0 clamped to the floor, without throwing", () => {
+    // 200-with-no-provisions is a legitimate empty result, NOT an infra failure:
+    // it must produce a concrete forecast (rate 0, target = minPoolSize), never
+    // the throw path above.
+    const out = mod.computeForecast({ ...base, minPoolSize: 2, bucketCounts: [] });
+    expect(out.predictedRate).toBe(0);
+    expect(out.observedBuckets).toBe(0);
+    expect(out.targetPoolSize).toBe(2);
+  });
+
+  it("a real non-empty window yields a positive rate distinct from the empty case", () => {
+    const empty = mod.computeForecast({ ...base, bucketCounts: [] });
+    const busy = mod.computeForecast({ ...base, emaAlpha: 1, bucketCounts: [10, 10, 10] });
+    expect(empty.predictedRate).toBe(0);
+    expect(busy.predictedRate).toBeGreaterThan(0);
+    // Demand pushes the target above the floor — the two inputs are not conflated.
+    expect(busy.targetPoolSize).toBeGreaterThan(empty.targetPoolSize);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.error-policy.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Error-policy pins for the warm-pool manager's health-check reaper (#13415).
+ *
+ * Container-provisioning infra FAILS CLOSED: an internal failure inside a health
+ * probe (its DB lookup throwing) must PROPAGATE, never be swallowed into
+ * "unreachable" and used to destroy a live container — a DB blip would otherwise
+ * drain the whole warm pool. This suite drives the real exported
+ * `WarmPoolManager.healthCheck()` against a fake `PoolContainerCreator` and the
+ * repository/env stubbed via `mock.module`, and proves three shapes stay
+ * distinguishable:
+ *   - a probe THROW propagates and destroys NOTHING (fail-closed);
+ *   - a designed `false` (unreachable) reaps the row (destroy called);
+ *   - a `true` probe keeps the row alive.
+ * It also pins the J6 teardown branch: a destroy failure is recorded, not thrown.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { PoolContainerCreator } from "./agent-warm-pool";
+
+const repo = {
+  listUnclaimedPool: mock(async () => [] as Array<{ id: string }>),
+  findStuckPoolProvisioning: mock(async () => [] as Array<{ id: string }>),
+  countAllPoolEntries: mock(async () => ({ ready: 0, provisioning: 0 })),
+  countUserProvisionsByHour: mock(async () => [] as number[]),
+};
+
+let warmPoolEnabled = true;
+
+mock.module("../../utils/logger", () => ({
+  logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+}));
+mock.module("../../config/containers-env", () => ({
+  containersEnv: { warmPoolEnabled: () => warmPoolEnabled },
+}));
+mock.module("../../../db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: repo,
+  WARM_POOL_ORG_ID: "pool-org",
+}));
+
+type ManagerModule = typeof import("./agent-warm-pool");
+
+async function load(): Promise<ManagerModule> {
+  return import("./agent-warm-pool");
+}
+
+function fakeCreator(overrides: Partial<PoolContainerCreator> = {}): {
+  creator: PoolContainerCreator;
+  destroy: ReturnType<typeof mock>;
+  probe: ReturnType<typeof mock>;
+} {
+  const destroy = mock(async () => undefined);
+  const probe = mock(async () => true);
+  const creator: PoolContainerCreator = {
+    createPoolContainer: mock(async () => ({ id: "new", nodeId: null })),
+    destroyPoolContainer: overrides.destroyPoolContainer ?? destroy,
+    healthProbe: overrides.healthProbe ?? probe,
+  };
+  return { creator, destroy, probe };
+}
+
+beforeEach(() => {
+  warmPoolEnabled = true;
+  repo.listUnclaimedPool.mockReset();
+  repo.findStuckPoolProvisioning.mockReset();
+  repo.findStuckPoolProvisioning.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("healthCheck fails closed on an internal probe failure", () => {
+  test("a probe THROW propagates and destroys NOTHING", async () => {
+    const { WarmPoolManager } = await load();
+    repo.listUnclaimedPool.mockResolvedValue([{ id: "row-1" }, { id: "row-2" }]);
+
+    const dbError = new Error("findById: connection reset");
+    const destroy = mock(async () => undefined);
+    const probe = mock(async () => {
+      throw dbError;
+    });
+    const { creator } = fakeCreator({ destroyPoolContainer: destroy, healthProbe: probe });
+    const manager = new WarmPoolManager(creator);
+
+    // The internal failure must surface to the cron caller, not be swallowed.
+    await expect(manager.healthCheck()).rejects.toBe(dbError);
+    // Critically: no container was reaped on an INDETERMINATE probe result.
+    expect(destroy).not.toHaveBeenCalled();
+  });
+});
+
+describe("healthCheck designed paths stay distinct from the failure", () => {
+  test("a designed `false` (unreachable) reaps the row — destroy IS called", async () => {
+    const { WarmPoolManager } = await load();
+    repo.listUnclaimedPool.mockResolvedValue([{ id: "dead-1" }]);
+
+    const destroy = mock(async () => undefined);
+    const probe = mock(async () => false);
+    const { creator } = fakeCreator({ destroyPoolContainer: destroy, healthProbe: probe });
+    const manager = new WarmPoolManager(creator);
+
+    const result = await manager.healthCheck();
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledWith("dead-1");
+    expect(result.alive).toBe(0);
+    expect(result.removed).toEqual([{ id: "dead-1", reason: "health probe failed" }]);
+  });
+
+  test("a `true` probe keeps the row alive — destroy NOT called", async () => {
+    const { WarmPoolManager } = await load();
+    repo.listUnclaimedPool.mockResolvedValue([{ id: "healthy-1" }]);
+
+    const destroy = mock(async () => undefined);
+    const probe = mock(async () => true);
+    const { creator } = fakeCreator({ destroyPoolContainer: destroy, healthProbe: probe });
+    const manager = new WarmPoolManager(creator);
+
+    const result = await manager.healthCheck();
+    expect(destroy).not.toHaveBeenCalled();
+    expect(result.alive).toBe(1);
+    expect(result.probed).toBe(1);
+    expect(result.removed).toEqual([]);
+  });
+
+  test("J6 teardown: a destroy failure on a dead row is RECORDED, not thrown", async () => {
+    const { WarmPoolManager } = await load();
+    repo.listUnclaimedPool.mockResolvedValue([{ id: "dead-2" }]);
+
+    const probe = mock(async () => false);
+    const destroy = mock(async () => {
+      throw new Error("ssh timeout");
+    });
+    const { creator } = fakeCreator({ destroyPoolContainer: destroy, healthProbe: probe });
+    const manager = new WarmPoolManager(creator);
+
+    // Teardown is best-effort: the pass completes and the failure is surfaced in
+    // the reason (retried next pass), NOT swallowed into a clean removal.
+    const result = await manager.healthCheck();
+    expect(result.removed).toHaveLength(1);
+    expect(result.removed[0]?.id).toBe("dead-2");
+    expect(result.removed[0]?.reason).toContain("destroy errored: ssh timeout");
+  });
+});
+
+describe("healthCheck honors the disabled no-op", () => {
+  test("WARM_POOL_ENABLED=false short-circuits without touching the repo or creator", async () => {
+    const { WarmPoolManager } = await load();
+    warmPoolEnabled = false;
+
+    const { creator, destroy } = fakeCreator();
+    const manager = new WarmPoolManager(creator);
+
+    const result = await manager.healthCheck();
+    expect(result).toEqual({ probed: 0, alive: 0, removed: [] });
+    expect(repo.listUnclaimedPool).not.toHaveBeenCalled();
+    expect(destroy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
@@ -240,6 +240,10 @@ export class WarmPoolManager {
         const result = await this.creator.createPoolContainer(image);
         created.push(result);
       } catch (err) {
+        // error-policy:J1 batch boundary — a per-container provision failure is
+        // recorded in the structured `failed[]` result and logged, then the
+        // burst stops. The failure surfaces to the caller; it never reads as a
+        // successful create.
         failed.push({ error: err instanceof Error ? err.message : String(err) });
         logger.warn("[warm-pool] replenish create failed", {
           error: err instanceof Error ? err.message : String(err),
@@ -278,6 +282,9 @@ export class WarmPoolManager {
         await this.creator.destroyPoolContainer(id);
         drained.push(id);
       } catch (err) {
+        // error-policy:J1 batch boundary — a per-row destroy failure is recorded
+        // in the structured `failed[]` result; the row stays in the pool and is
+        // retried next pass. The failure surfaces; it never reads as drained.
         failed.push({ id, error: err instanceof Error ? err.message : String(err) });
       }
     }
@@ -300,7 +307,12 @@ export class WarmPoolManager {
     let alive = 0;
 
     for (const row of rows) {
-      const ok = await this.creator.healthProbe(row.id).catch(() => false);
+      // `healthProbe` is contracted to return false for an unreachable
+      // container and only throws on an internal failure (its lookup/DB read).
+      // We must NOT swallow that throw into `false` — doing so would treat a DB
+      // blip as "container dead" and destroy the whole pool. Let it propagate so
+      // the failure surfaces to the cron; only a designed `false` reaps a row.
+      const ok = await this.creator.healthProbe(row.id);
       if (ok) {
         alive++;
         continue;
@@ -309,6 +321,8 @@ export class WarmPoolManager {
         await this.creator.destroyPoolContainer(row.id);
         removed.push({ id: row.id, reason: "health probe failed" });
       } catch (err) {
+        // error-policy:J6 best-effort teardown — destroy is idempotent and the
+        // next health-check pass retries; record the failure in the reason.
         removed.push({
           id: row.id,
           reason: `probe failed; destroy errored: ${err instanceof Error ? err.message : String(err)}`,
@@ -325,6 +339,8 @@ export class WarmPoolManager {
         await this.creator.destroyPoolContainer(row.id);
         removed.push({ id: row.id, reason: "stuck in provisioning past threshold" });
       } catch (err) {
+        // error-policy:J6 best-effort teardown — destroy is idempotent and the
+        // next pass retries; record the failure in the reason.
         removed.push({
           id: row.id,
           reason: `stuck; destroy errored: ${err instanceof Error ? err.message : String(err)}`,
@@ -360,6 +376,9 @@ export class WarmPoolManager {
         await this.creator.destroyPoolContainer(id);
         replaced.push(id);
       } catch (err) {
+        // error-policy:J1 batch boundary — a per-row replace failure is recorded
+        // in the structured `failed[]` result; the stale row stays and is retried
+        // next pass. The failure surfaces; it never reads as replaced.
         failed.push({ id, error: err instanceof Error ? err.message : String(err) });
       }
     }

--- a/packages/cloud/shared/src/lib/services/containers/compute-provider-fake.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/compute-provider-fake.error-policy.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Error-policy pins for `InMemoryComputeProvider` (#13415).
+ *
+ * The fake stands in for a real IaaS provider (Hetzner / DigitalOcean) in
+ * warm-pool + autoscaler tests, so its failure semantics must match the
+ * doctrine the real clients are held to: an *internal failure* of a
+ * provisioning call PROPAGATES (throws / surfaces an explicit `errored`
+ * action), and must stay distinguishable from a *legitimately empty* read
+ * (an empty list from a healthy "200", a `null` from a not-found lookup).
+ *
+ * Deterministic in-memory harness — no network, no clock, no mocks — so this
+ * drives the real exported class directly (mock.module / fetch stubbing would
+ * add nothing: the fake has no I/O to intercept).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { CreateServerInput, CreateVolumeInput } from "./compute-provider";
+import {
+  ACTION_STATUS_COMPLETED,
+  ACTION_STATUS_ERRORED,
+  ComputeFakeError,
+  InMemoryComputeProvider,
+} from "./compute-provider-fake";
+
+function serverInput(over: Partial<CreateServerInput> = {}): CreateServerInput {
+  return {
+    name: "node-a",
+    serverType: "s-2vcpu-2gb",
+    location: "nyc1",
+    image: "docker-24-04",
+    userData: "#cloud-config\n",
+    ...over,
+  };
+}
+
+function volumeInput(over: Partial<CreateVolumeInput> = {}): CreateVolumeInput {
+  return { name: "vol-a", sizeGb: 50, location: "nyc1", ...over };
+}
+
+// ---------------------------------------------------------------------------
+// Internal failures PROPAGATE — never fabricated into a fake success
+// ---------------------------------------------------------------------------
+
+describe("internal failure propagates (fail-closed)", () => {
+  test("createServer at capacity throws no_capacity — no fabricated server", async () => {
+    const p = new InMemoryComputeProvider({ maxServers: 1 });
+    await p.createServer(serverInput({ name: "a" }));
+    // A masked failure would return a ProvisionedServer here (reading as
+    // "provisioned" to the autoscaler); the seam must throw instead.
+    await expect(p.createServer(serverInput({ name: "b" }))).rejects.toBeInstanceOf(
+      ComputeFakeError,
+    );
+    await expect(p.createServer(serverInput({ name: "b" }))).rejects.toMatchObject({
+      code: "no_capacity",
+    });
+    // And no phantom server leaked into the live set.
+    expect((await p.listServers()).length).toBe(1);
+  });
+
+  test("createVolume at capacity throws no_capacity — no fabricated volume", async () => {
+    const p = new InMemoryComputeProvider({ maxVolumes: 1 });
+    await p.createVolume(volumeInput({ name: "v1" }));
+    await expect(p.createVolume(volumeInput({ name: "v2" }))).rejects.toMatchObject({
+      code: "no_capacity",
+    });
+    expect((await p.listVolumes()).length).toBe(1);
+  });
+
+  test("mutating actions on a missing server/volume throw not_found — no no-op success action", async () => {
+    const p = new InMemoryComputeProvider();
+    await expect(p.powerOff(999)).rejects.toMatchObject({ code: "not_found" });
+    await expect(p.powerOn(999)).rejects.toMatchObject({ code: "not_found" });
+    await expect(p.detachVolume(999)).rejects.toMatchObject({ code: "not_found" });
+    const { server } = await p.createServer(serverInput());
+    await expect(p.attachVolume(999, server.id as number)).rejects.toMatchObject({
+      code: "not_found",
+    });
+  });
+
+  test("waitForAction on an unknown id throws not_found — never fabricates `completed`", async () => {
+    const p = new InMemoryComputeProvider();
+    // The dangerous slop would be returning a synthesized `completed` action so
+    // the caller believes an attach/power op that never existed succeeded.
+    await expect(p.waitForAction(424242)).rejects.toMatchObject({ code: "not_found" });
+  });
+
+  test("waitForAction on a poisoned id surfaces `errored` observably — not fabricated `completed`", async () => {
+    const p = new InMemoryComputeProvider();
+    const { server } = await p.createServer(serverInput());
+    const action = await p.powerOff(server.id as number);
+    p.poisonAction(action.id as number);
+
+    const done = await p.waitForAction(action.id as number);
+    // Mirrors the real Hetzner client returning the error action (not throwing),
+    // but the failure MUST remain observable: status errored + populated error.
+    expect(done.status).toBe(ACTION_STATUS_ERRORED);
+    expect(done.status).not.toBe(ACTION_STATUS_COMPLETED);
+    expect(done.error).not.toBeNull();
+    expect(done.error).toMatchObject({ code: "action_failed" });
+  });
+
+  test("tick with invalid input throws invalid_input — the clock never silently no-ops", () => {
+    const p = new InMemoryComputeProvider();
+    expect(() => p.tick(-1)).toThrow(ComputeFakeError);
+    expect(() => p.tick(1.5)).toThrow(ComputeFakeError);
+    // A rejected tick leaves the clock untouched rather than swallowing to a default.
+    expect(p.now()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legitimately-empty reads stay DISTINCT from internal failure
+// ---------------------------------------------------------------------------
+
+describe("designed-empty is distinguishable from failure", () => {
+  test("getServer/getVolume return null for a genuinely-absent id — a designed miss, not a throw", async () => {
+    const p = new InMemoryComputeProvider();
+    // A not-found READ resolves null (a distinguishable "absent"); it does NOT
+    // throw and does NOT fabricate a record. Contrast waitForAction/powerOff
+    // above, where a missing id is an internal failure that throws.
+    await expect(p.getServer(1)).resolves.toBeNull();
+    await expect(p.getVolume(1)).resolves.toBeNull();
+  });
+
+  test("listServers/listVolumes on an empty store return [] — a healthy empty, not a masked failure", async () => {
+    const p = new InMemoryComputeProvider();
+    await expect(p.listServers()).resolves.toEqual([]);
+    await expect(p.listServers({ role: "pool" })).resolves.toEqual([]);
+    await expect(p.listVolumes()).resolves.toEqual([]);
+  });
+
+  test("a deleted server reads as absent (null + dropped from list), never as a failure", async () => {
+    const p = new InMemoryComputeProvider();
+    const { server } = await p.createServer(serverInput());
+    const id = server.id as number;
+    await expect(p.deleteServer(id)).resolves.toBeUndefined();
+    // Idempotent delete is a designed 404==success no-op, distinct from a throw.
+    await expect(p.deleteServer(id)).resolves.toBeUndefined();
+    await expect(p.getServer(id)).resolves.toBeNull();
+    await expect(p.listServers()).resolves.toEqual([]);
+  });
+
+  test("listImages snapshot filter returns a designed-empty [] — distinct from an errored catalog read", async () => {
+    const p = new InMemoryComputeProvider();
+    // Empty because the filter legitimately matches nothing (a 200 with 0 rows),
+    // NOT because a catalog fetch failed and was swallowed to [].
+    await expect(p.listImages({ type: "snapshot" })).resolves.toEqual([]);
+    const all = await p.listImages();
+    expect(all.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/digitalocean-provider.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/digitalocean-provider.error-policy.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Error-policy proof for `DigitalOceanComputeProvider` (#13415).
+ *
+ * Container-provisioning infra must FAIL CLOSED: an internal cloud-API failure
+ * (transport error, 5xx, non-JSON body) must PROPAGATE as a typed
+ * `DigitalOceanComputeError`, never collapse into an empty list / null / silent
+ * success that reads as "no servers" or "already done". A legitimately-empty
+ * result (an actually-empty 200 list, a genuine 404-absent lookup) is the
+ * designed shape and must stay DISTINCT from those failures.
+ *
+ * Unlike the sibling characterization test (which injects a recording fetch via
+ * the constructor), this exercises the REAL default production wiring: the
+ * zero-arg `new DigitalOceanComputeProvider()` resolves `globalThis.fetch` and
+ * the env-backed token getter, so we override `globalThis.fetch` and set
+ * `DO_API_TOKEN`, restoring both in `afterEach`. The module is loaded via a
+ * dynamic `import()` so the mocked global is in place before construction.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const realFetch = globalThis.fetch;
+const savedToken = process.env.DO_API_TOKEN;
+const savedAltToken = process.env.DIGITALOCEAN_TOKEN;
+
+/** Queue of responder thunks; each fetch shifts the next (real Response or throw). */
+let queue: Array<() => Response | Promise<Response>>;
+
+function queueJson(body: unknown, status = 200): void {
+  queue.push(() => new Response(JSON.stringify(body), { status }));
+}
+function queueRaw(body: string, status: number): void {
+  queue.push(() => new Response(body, { status }));
+}
+function queueReject(message: string): void {
+  queue.push(() => {
+    throw new Error(message);
+  });
+}
+
+beforeEach(() => {
+  queue = [];
+  process.env.DO_API_TOKEN = "do-error-policy-token";
+  delete process.env.DIGITALOCEAN_TOKEN;
+  globalThis.fetch = mock(async () => {
+    const next = queue.shift();
+    if (!next) throw new Error("unexpected fetch (no response queued)");
+    return next();
+  }) as unknown as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  if (savedToken === undefined) delete process.env.DO_API_TOKEN;
+  else process.env.DO_API_TOKEN = savedToken;
+  if (savedAltToken === undefined) delete process.env.DIGITALOCEAN_TOKEN;
+  else process.env.DIGITALOCEAN_TOKEN = savedAltToken;
+});
+
+async function loadProvider() {
+  const mod = await import("./digitalocean-provider");
+  // Zero-arg construction: real default fetch (mocked global) + env token getter.
+  return { provider: new mod.DigitalOceanComputeProvider(), Err: mod.DigitalOceanComputeError };
+}
+
+describe("DigitalOceanComputeProvider fails closed on internal failures (default wiring)", () => {
+  it("listServers PROPAGATES a 5xx instead of reading as an empty fleet", async () => {
+    const { provider, Err } = await loadProvider();
+    queueJson({ id: "server_error", message: "DO is down" }, 500);
+
+    let caught: unknown;
+    try {
+      await provider.listServers();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Err);
+    expect((caught as InstanceType<typeof Err>).code).toBe("server_error");
+    expect((caught as InstanceType<typeof Err>).status).toBe(500);
+  });
+
+  it("listServers PROPAGATES a transport rejection (never a masked empty list)", async () => {
+    const { provider, Err } = await loadProvider();
+    queueReject("ECONNRESET");
+
+    const caught = await provider.listServers().catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(Err);
+    expect((caught as InstanceType<typeof Err>).code).toBe("transport_error");
+    // The cause chains the underlying network error — the failure is not swallowed.
+    expect((caught as InstanceType<typeof Err>).cause).toBeInstanceOf(Error);
+  });
+
+  it("listServers PROPAGATES a non-JSON body instead of fabricating a parsed default", async () => {
+    const { provider, Err } = await loadProvider();
+    queueRaw("<html>502 Bad Gateway</html>", 502);
+
+    const caught = await provider.listServers().catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(Err);
+    expect((caught as InstanceType<typeof Err>).code).toBe("server_error");
+    expect((caught as InstanceType<typeof Err>).status).toBe(502);
+  });
+
+  it("a genuinely-empty 200 list stays DISTINCT from a failure (designed empty)", async () => {
+    const { provider } = await loadProvider();
+    queueJson({ droplets: [] }, 200);
+
+    const servers = await provider.listServers();
+    expect(servers).toEqual([]);
+  });
+});
+
+describe("getServer / deleteServer: designed-absent vs surfaced failure", () => {
+  it("getServer returns null ONLY for a real 404 (designed absent)", async () => {
+    const { provider } = await loadProvider();
+    queueJson({ id: "not_found", message: "no such droplet" }, 404);
+    expect(await provider.getServer(999)).toBeNull();
+  });
+
+  it("getServer THROWS on a 5xx — a failed lookup must not read as absent (null)", async () => {
+    const { provider, Err } = await loadProvider();
+    queueJson({ id: "server_error", message: "boom" }, 500);
+
+    const caught = await provider.getServer(42).catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(Err);
+    expect((caught as InstanceType<typeof Err>).code).toBe("server_error");
+  });
+
+  it("deleteServer resolves on a 404 (idempotent already-gone)", async () => {
+    const { provider } = await loadProvider();
+    queueJson({ id: "not_found", message: "already gone" }, 404);
+    await expect(provider.deleteServer(7)).resolves.toBeUndefined();
+  });
+
+  it("deleteServer THROWS on a 5xx — a failed delete must not fake success", async () => {
+    const { provider, Err } = await loadProvider();
+    queueJson({ id: "server_error", message: "boom" }, 500);
+
+    const caught = await provider.deleteServer(7).catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(Err);
+    expect((caught as InstanceType<typeof Err>).code).toBe("server_error");
+  });
+});
+
+describe("missing token fails closed before any network call", () => {
+  it("a request throws missing_token (no fetch) when the token is absent", async () => {
+    delete process.env.DO_API_TOKEN;
+    const { provider, Err } = await loadProvider();
+
+    const caught = await provider.listServers().catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(Err);
+    expect((caught as InstanceType<typeof Err>).code).toBe("missing_token");
+    // No response was consumed — the guard fired before fetch.
+    expect(queue.length).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/digitalocean-provider.ts
+++ b/packages/cloud/shared/src/lib/services/containers/digitalocean-provider.ts
@@ -265,6 +265,8 @@ export class DigitalOceanComputeProvider implements ComputeProvider {
       const data = await this.request<{ droplet: DODroplet }>("GET", `/droplets/${id}`);
       return mapDroplet(data.droplet);
     } catch (err) {
+      // error-policy:J4 only the expected not_found shape degrades to a designed
+      // "absent" (null); every other provider error surfaces to the caller.
       if (err instanceof DigitalOceanComputeError && err.code === "not_found") return null;
       throw err;
     }
@@ -319,7 +321,8 @@ export class DigitalOceanComputeProvider implements ComputeProvider {
       await this.request<unknown>("DELETE", `/droplets/${id}`);
       logger.info("[do] Deleted droplet", { serverId: id });
     } catch (err) {
-      // 404 on delete is success (already gone).
+      // error-policy:J4 idempotent delete — a 404 (droplet already gone) is the
+      // designed success shape; any other provider error surfaces.
       if (err instanceof DigitalOceanComputeError && err.code === "not_found") return;
       throw err;
     }
@@ -368,6 +371,8 @@ export class DigitalOceanComputeProvider implements ComputeProvider {
       const data = await this.request<{ volume: DOVolume }>("GET", `/volumes/${id}`);
       return mapVolume(data.volume);
     } catch (err) {
+      // error-policy:J4 only the expected not_found shape degrades to a designed
+      // "absent" (null); every other provider error surfaces to the caller.
       if (err instanceof DigitalOceanComputeError && err.code === "not_found") return null;
       throw err;
     }
@@ -425,6 +430,8 @@ export class DigitalOceanComputeProvider implements ComputeProvider {
       await this.request<unknown>("DELETE", `/volumes/${id}`);
       logger.info("[do] Deleted volume", { volumeId: id });
     } catch (err) {
+      // error-policy:J4 idempotent delete — a 404 (volume already gone) is the
+      // designed success shape; any other provider error surfaces.
       if (err instanceof DigitalOceanComputeError && err.code === "not_found") return;
       throw err;
     }
@@ -520,6 +527,9 @@ export class DigitalOceanComputeProvider implements ComputeProvider {
         signal: ac.signal,
       });
     } catch (err) {
+      // error-policy:J1 transport boundary — translate a network/abort failure
+      // into a typed provisioning error (carrying `cause`) so a failed cloud-API
+      // call surfaces as transport_error, never as an empty/"no servers" result.
       throw new DigitalOceanComputeError(
         "transport_error",
         `DigitalOcean API ${method} ${path} failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -539,6 +549,8 @@ export class DigitalOceanComputeProvider implements ComputeProvider {
     try {
       parsed = text ? JSON.parse(text) : undefined;
     } catch {
+      // error-policy:J3 untrusted response body — a non-JSON payload is an
+      // explicit typed failure, never a fabricated-valid default.
       throw new DigitalOceanComputeError(
         "server_error",
         `DigitalOcean API ${method} ${path} returned non-JSON: ${text.slice(0, 200)}`,

--- a/packages/cloud/shared/src/lib/services/containers/forwarded-database-url-guard.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/forwarded-database-url-guard.error-policy.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Error-policy pins (#13415) for the forwarded-database-URL guard: an INTERNAL
+ * failure (an unparseable/malformed forwarded header or configured URL — the
+ * J3 sanitize path) must fail CLOSED, and must stay DISTINGUISHABLE from a
+ * legitimately-empty trust set (no DB configured at all). Both reject, but for
+ * different, non-fabricated reasons — a parse failure never widens the trusted
+ * set nor reads as an authorized forward. Drives the real exported functions.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  buildTrustedDatabaseIdentitySet,
+  databaseIdentityKey,
+  evaluateForwardedDatabaseUrl,
+} from "./forwarded-database-url-guard";
+
+const CONFIGURED = "postgres://svc:pw@db.internal.example:5432/cloud";
+
+describe("forwarded-database-url-guard — error-policy fail-closed", () => {
+  it("J3: an unparseable forwarded URL yields the explicit null invalid-signal (not a fabricated key)", () => {
+    // The catch-around-new-URL returns null; a valid URL returns a real key.
+    expect(databaseIdentityKey("::::not a url::::")).toBeNull();
+    expect(databaseIdentityKey(CONFIGURED)).not.toBeNull();
+  });
+
+  it("an unparseable CONFIGURED url does NOT silently widen the trusted set (drop, never add)", () => {
+    const set = buildTrustedDatabaseIdentitySet({ configuredDatabaseUrl: "garbage-not-a-url" });
+    expect(set.size).toBe(0);
+    // A parse failure must not become a trusted identity that authorizes a forward.
+    const decision = evaluateForwardedDatabaseUrl(CONFIGURED, {
+      configuredDatabaseUrl: "garbage-not-a-url",
+    });
+    expect(decision.allowed).toBe(false);
+  });
+
+  it("distinguishes an INTERNAL parse failure from a designed-EMPTY trust set by reason", () => {
+    // Internal failure: the forwarded value itself is malformed → parse-failure reason.
+    const malformed = evaluateForwardedDatabaseUrl("::::bad::::", {
+      configuredDatabaseUrl: CONFIGURED,
+    });
+    expect(malformed.allowed).toBe(false);
+    if (!malformed.allowed) expect(malformed.reason).toContain("malformed");
+
+    // Designed-empty: a well-formed forward, but NOTHING is trusted (no config,
+    // empty allowlist). Still rejected, but with a DISTINCT reason — not conflated
+    // with the malformed-input path, and never allowed-open.
+    const noTrust = evaluateForwardedDatabaseUrl(CONFIGURED, {
+      configuredDatabaseUrl: undefined,
+      allowlistDatabaseUrls: [],
+    });
+    expect(noTrust.allowed).toBe(false);
+    if (!noTrust.allowed) expect(noTrust.reason).toContain("no trusted database identity");
+
+    // The two failure reasons are genuinely different strings.
+    if (!malformed.allowed && !noTrust.allowed) {
+      expect(malformed.reason).not.toBe(noTrust.reason);
+    }
+  });
+
+  it("a well-formed off-allowlist identity fails closed with the mismatch reason (distinct again)", () => {
+    const mismatch = evaluateForwardedDatabaseUrl(
+      "postgres://attacker:pw@evil.example:5432/exfil",
+      { configuredDatabaseUrl: CONFIGURED },
+    );
+    expect(mismatch.allowed).toBe(false);
+    if (!mismatch.allowed) {
+      expect(mismatch.reason).toContain("does not match the pinned");
+      expect(mismatch.reason).not.toContain("malformed");
+      expect(mismatch.reason).not.toContain("no trusted database identity");
+    }
+  });
+
+  it("only the exact configured identity is honored — the fail-closed default is reject", () => {
+    // Positive control: proves the guard is not vacuously rejecting everything.
+    const ok = evaluateForwardedDatabaseUrl(CONFIGURED, { configuredDatabaseUrl: CONFIGURED });
+    expect(ok.allowed).toBe(true);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/forwarded-database-url-guard.ts
+++ b/packages/cloud/shared/src/lib/services/containers/forwarded-database-url-guard.ts
@@ -87,6 +87,10 @@ export function databaseIdentityKey(value: string): string | null {
   try {
     parsed = new URL(trimmed);
   } catch {
+    // error-policy:J3 untrusted forwarded-header/config value; an unparseable
+    // URL yields the explicit invalid signal `null`, which every caller treats
+    // as fail-closed (reject the forward / drop from the trusted set) — never a
+    // fabricated-valid default.
     return null;
   }
 

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/bootstrap.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/bootstrap.error-policy.test.ts
@@ -1,0 +1,135 @@
+// Pins the fail-closed error policy of the bootstrap/workspace-sync SSH helpers
+// (#13415). These run during container provisioning: a failed remote SSH write
+// (mkdir/rm/cat over the volume) or a corrupt bootstrap file MUST surface so the
+// caller (client.ts createContainer) aborts, never read as "bootstrap succeeded".
+// A legitimately-absent source (no bootstrapSource, empty file list, empty volume
+// on a 200 export) is a designed-empty result and must stay distinct from a
+// transport/validation failure. The harness is a deterministic in-memory fake of
+// the two DockerSSHClient methods the module calls (exec/execStdin); no real SSH.
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { DockerSSHClient } from "../../docker-ssh";
+import {
+  decodeBootstrapFile,
+  deleteWorkspaceFiles,
+  exportWorkspaceFiles,
+  hydrateBootstrapSource,
+} from "./bootstrap";
+import type { ContainerBootstrapFile } from "./types";
+import { HetznerClientError } from "./types";
+
+function fakeSsh(overrides: Partial<Record<"exec" | "execStdin", DockerSSHClient["exec"]>> = {}) {
+  const exec = overrides.exec ?? mock(async () => "");
+  const execStdin = overrides.execStdin ?? mock(async () => "");
+  return { ssh: { exec, execStdin } as unknown as DockerSSHClient, exec, execStdin };
+}
+
+function b64File(pathName: string, contents: string): ContainerBootstrapFile {
+  return {
+    path: pathName,
+    contents: Buffer.from(contents, "utf8").toString("base64"),
+    encoding: "base64",
+  };
+}
+
+describe("hydrateBootstrapSource — designed-empty vs failure", () => {
+  it("returns null (designed-empty) with NO ssh call when there is no source", async () => {
+    const { ssh, exec, execStdin } = fakeSsh();
+    await expect(hydrateBootstrapSource(ssh, "/data", undefined)).resolves.toBeNull();
+    expect(exec).not.toHaveBeenCalled();
+    expect(execStdin).not.toHaveBeenCalled();
+  });
+
+  it("returns null (designed-empty) when the source carries zero files", async () => {
+    const { ssh, exec } = fakeSsh();
+    await expect(hydrateBootstrapSource(ssh, "/data", { files: [] })).resolves.toBeNull();
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("PROPAGATES an SSH transport failure on the volume-clear step (not swallowed to null)", async () => {
+    // The very first exec (mkdir + clear volume) rejects: a real node was
+    // unreachable. This must surface, distinct from the null designed-empty above.
+    const exec = mock(async () => {
+      throw new Error("[docker-ssh] exec error on node-1: connection reset");
+    });
+    const { ssh } = fakeSsh({ exec });
+    await expect(
+      hydrateBootstrapSource(ssh, "/data", { files: [b64File("a.txt", "hi")] }),
+    ).rejects.toThrow(/connection reset/);
+  });
+
+  it("PROPAGATES an SSH failure while streaming a decoded file (not a fabricated success)", async () => {
+    const exec = mock(async () => "");
+    const execStdin = mock(async () => {
+      throw new Error("[docker-ssh] exec error on node-1: broken pipe");
+    });
+    const { ssh } = fakeSsh({ exec, execStdin });
+    await expect(
+      hydrateBootstrapSource(ssh, "/data", { files: [b64File("a.txt", "hi")] }),
+    ).rejects.toThrow(/broken pipe/);
+  });
+
+  it("writes the files and manifest, returning a real count on success", async () => {
+    const { ssh, exec, execStdin } = fakeSsh();
+    const result = await hydrateBootstrapSource(ssh, "/data", {
+      files: [b64File("a.txt", "hello"), b64File("dir/b.txt", "world")],
+    });
+    expect(result).toEqual({ fileCount: 2, totalBytes: 10 });
+    expect(exec).toHaveBeenCalled();
+    expect(execStdin).toHaveBeenCalled();
+  });
+});
+
+describe("decodeBootstrapFile — fail-closed validation, no fake-valid default", () => {
+  it("throws invalid_input on a sha256 mismatch instead of returning corrupt bytes", () => {
+    const file: ContainerBootstrapFile = {
+      path: "a.txt",
+      contents: Buffer.from("hello", "utf8").toString("base64"),
+      encoding: "base64",
+      sha256: "0".repeat(64),
+    };
+    expect(() => decodeBootstrapFile(file)).toThrow(HetznerClientError);
+    expect(() => decodeBootstrapFile(file)).toThrow(/sha256 mismatch/);
+  });
+
+  it("throws invalid_input on a declared-size mismatch", () => {
+    const file: ContainerBootstrapFile = {
+      path: "a.txt",
+      contents: Buffer.from("hello", "utf8").toString("base64"),
+      encoding: "base64",
+      size: 999,
+    };
+    expect(() => decodeBootstrapFile(file)).toThrow(/size mismatch/);
+  });
+
+  it("returns the exact bytes for a valid file", () => {
+    expect(decodeBootstrapFile(b64File("a.txt", "hello")).toString("utf8")).toBe("hello");
+  });
+});
+
+describe("exportWorkspaceFiles — empty volume vs transport failure", () => {
+  it("returns an empty list for a genuinely-empty volume (200 with no output)", async () => {
+    const { ssh } = fakeSsh({ exec: mock(async () => "") });
+    await expect(exportWorkspaceFiles(ssh, "/data")).resolves.toEqual([]);
+  });
+
+  it("PROPAGATES an SSH failure rather than reading it as an empty workspace", async () => {
+    const exec = mock(async () => {
+      throw new Error("[docker-ssh] exec error on node-1: command timed out");
+    });
+    const { ssh } = fakeSsh({ exec });
+    await expect(exportWorkspaceFiles(ssh, "/data")).rejects.toThrow(/timed out/);
+  });
+});
+
+describe("deleteWorkspaceFiles — failure surfaces", () => {
+  beforeEach(() => {});
+  it("PROPAGATES an SSH rm failure (a failed delete must not read as success)", async () => {
+    const exec = mock(async () => {
+      throw new Error("[docker-ssh] exec error on node-1: permission denied");
+    });
+    const { ssh } = fakeSsh({ exec });
+    await expect(deleteWorkspaceFiles(ssh, "/data", [{ path: "a.txt" }])).rejects.toThrow(
+      /permission denied/,
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.error-policy.test.ts
@@ -1,0 +1,191 @@
+// Pins the fail-closed error policy of HetznerContainersClient: an authoritative
+// host-teardown failure (the un-caught `docker rm -f`) must PROPAGATE and leave
+// the control-plane row intact, while a best-effort `docker stop` failure and a
+// legitimately-empty list stay distinct from an internal failure. Harness is a
+// deterministic in-process fake (mocked repositories + SSH client); no live
+// Hetzner node or DB is reached.
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// bun runs cloud-shared test files in one process and `mock.module` overrides
+// are process-global; snapshot the real modules first and reinstall them in
+// afterAll so these stubs never leak into sibling files.
+import * as realContainersRepo from "../../../../db/repositories/containers";
+import * as realDockerNodesRepo from "../../../../db/repositories/docker-nodes";
+import * as realDockerSsh from "../../docker-ssh";
+import * as realHetznerVolumes from "../hetzner-volumes";
+import * as realMetadata from "./metadata";
+
+const realContainersRepoSnap = { ...realContainersRepo };
+const realDockerNodesRepoSnap = { ...realDockerNodesRepo };
+const realHetznerVolumesSnap = { ...realHetznerVolumes };
+const realDockerSshSnap = { ...realDockerSsh };
+const realMetadataSnap = { ...realMetadata };
+
+const findById = mock(async (_id: string, _org: string): Promise<unknown> => null);
+const listByOrganization = mock(async (_org: string): Promise<unknown[]> => []);
+const deleteRow = mock(async (_id: string, _org: string): Promise<void> => {});
+const tryReleaseNodeSlot = mock(async (): Promise<void> => {});
+const updateRow = mock(async (): Promise<unknown> => null);
+const updateStatus = mock(async (): Promise<void> => {});
+
+const readMetadata = mock((_row: unknown): unknown => null);
+
+const execMock = mock(async (_cmd: string, _timeout?: number): Promise<string> => "");
+const fakeSsh = { exec: execMock, execStream: mock(async () => {}) };
+const getClient = mock(() => fakeSsh);
+const findByNodeId = mock(async (_id: string): Promise<unknown> => null);
+
+mock.module("../../../../db/repositories/containers", () => ({
+  ...realContainersRepo,
+  containersRepository: {
+    ...realContainersRepo.containersRepository,
+    findById,
+    listByOrganization,
+    delete: deleteRow,
+    tryReleaseNodeSlot,
+    update: updateRow,
+    updateStatus,
+  },
+}));
+
+mock.module("../../../../db/repositories/docker-nodes", () => ({
+  ...realDockerNodesRepo,
+  dockerNodesRepository: {
+    ...realDockerNodesRepo.dockerNodesRepository,
+    findByNodeId,
+  },
+}));
+
+mock.module("../hetzner-volumes", () => ({
+  ...realHetznerVolumes,
+  isHetznerVolumesAvailable: () => false,
+  getHetznerVolumeService: () => ({}),
+}));
+
+mock.module("../../docker-ssh", () => ({
+  ...realDockerSsh,
+  DockerSSHClient: { getClient },
+}));
+
+mock.module("./metadata", () => ({
+  ...realMetadata,
+  readMetadata,
+}));
+
+const { getHetznerContainersClient } = await import("./client");
+
+const META = {
+  provider: "hetzner-docker" as const,
+  nodeId: "node-1",
+  hostname: "10.0.0.1",
+  containerName: "app-ct1",
+  hostPort: 8080,
+  image: "ghcr.io/elizaos/eliza:stable",
+  containerPort: 3000,
+};
+
+const ROW = { id: "ct1", organization_id: "org1", hcloud_volume_id: null };
+
+afterAll(() => {
+  mock.module("../../../../db/repositories/containers", () => realContainersRepoSnap);
+  mock.module("../../../../db/repositories/docker-nodes", () => realDockerNodesRepoSnap);
+  mock.module("../hetzner-volumes", () => realHetznerVolumesSnap);
+  mock.module("../../docker-ssh", () => realDockerSshSnap);
+  mock.module("./metadata", () => realMetadataSnap);
+});
+
+beforeEach(() => {
+  for (const m of [
+    findById,
+    listByOrganization,
+    deleteRow,
+    tryReleaseNodeSlot,
+    updateRow,
+    updateStatus,
+    readMetadata,
+    execMock,
+    getClient,
+    findByNodeId,
+  ]) {
+    m.mockReset();
+  }
+  findById.mockResolvedValue(ROW);
+  listByOrganization.mockResolvedValue([]);
+  deleteRow.mockResolvedValue(undefined);
+  tryReleaseNodeSlot.mockResolvedValue(undefined);
+  updateRow.mockResolvedValue(null);
+  updateStatus.mockResolvedValue(undefined);
+  readMetadata.mockReturnValue(META);
+  execMock.mockResolvedValue("");
+  getClient.mockReturnValue(fakeSsh);
+  findByNodeId.mockResolvedValue(null);
+});
+
+describe("deleteContainer — fail-closed host teardown", () => {
+  test("happy path removes the container and then deletes the control-plane row", async () => {
+    const client = getHetznerContainersClient();
+    await expect(client.deleteContainer("ct1", "org1")).resolves.toBeUndefined();
+
+    const cmds = execMock.mock.calls.map((c) => c[0]);
+    expect(cmds.some((c) => c.includes("docker rm -f"))).toBe(true);
+    expect(deleteRow).toHaveBeenCalledTimes(1);
+    expect(deleteRow.mock.calls[0]).toEqual(["ct1", "org1"]);
+  });
+
+  test("authoritative `docker rm -f` failure PROPAGATES and the row is NOT deleted", async () => {
+    // The un-caught rm -f is the real teardown; if it fails we must not silently
+    // delete the DB row (that would leak a live Docker container). Fail closed.
+    execMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes("docker rm -f")) throw new Error("rm boom");
+      return "";
+    });
+
+    const client = getHetznerContainersClient();
+    await expect(client.deleteContainer("ct1", "org1")).rejects.toThrow("rm boom");
+    expect(deleteRow).not.toHaveBeenCalled();
+  });
+
+  test("best-effort `docker stop` failure is swallowed — DISTINCT from an internal failure", async () => {
+    // A graceful-stop failure is designed best-effort (J6): rm -f still runs and
+    // the delete completes. This proves the swallow is scoped to the non-load-
+    // bearing stop, not the authoritative teardown above.
+    execMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes("docker stop")) throw new Error("stop boom");
+      return "";
+    });
+
+    const client = getHetznerContainersClient();
+    await expect(client.deleteContainer("ct1", "org1")).resolves.toBeUndefined();
+    expect(deleteRow).toHaveBeenCalledTimes(1);
+  });
+
+  test("SSH connection failure during teardown surfaces as a typed HetznerClientError", async () => {
+    // execOnNode J2 boundary translation: connection-level SSH errors are
+    // reclassified (so routes 503) but still THROW — never swallowed to success.
+    execMock.mockImplementation(async () => {
+      throw new Error("connect ECONNREFUSED 10.0.0.1:22");
+    });
+
+    const client = getHetznerContainersClient();
+    await expect(client.deleteContainer("ct1", "org1")).rejects.toMatchObject({
+      code: "ssh_unreachable",
+    });
+    expect(deleteRow).not.toHaveBeenCalled();
+  });
+});
+
+describe("read path — designed-empty stays distinct from internal failure", () => {
+  test("listContainers returns [] for a legitimately-empty org (200 with no rows)", async () => {
+    listByOrganization.mockResolvedValue([]);
+    const client = getHetznerContainersClient();
+    await expect(client.listContainers("org1")).resolves.toEqual([]);
+  });
+
+  test("listContainers PROPAGATES a repository failure instead of masking it as empty", async () => {
+    listByOrganization.mockImplementation(async () => {
+      throw new Error("db down");
+    });
+    const client = getHetznerContainersClient();
+    await expect(client.listContainers("org1")).rejects.toThrow("db down");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
@@ -344,6 +344,9 @@ export class HetznerContainersClient {
 
       return rowToSummary(updated ?? { ...row, metadata });
     } catch (err) {
+      // error-policy:J2 translate the create failure into a typed provisioning
+      // error (with `err` as cause) after marking the row `failed`; the throw
+      // below surfaces it to the route boundary rather than fabricating a summary.
       const message = err instanceof Error ? err.message : String(err);
       logger.error("[hetzner-client] container create failed", {
         containerId: row.id,
@@ -354,7 +357,13 @@ export class HetznerContainersClient {
       // Hetzner Cloud volume intact; it may contain data if this is a
       // redeploy and the container start failed after attach. Operators can
       // retry because the volume is found by label on the next attempt.
-      await ssh.exec(`docker rm -f ${shellQuote(containerName)}`, 30_000).catch(() => {});
+      // error-policy:J6 teardown-only; a cleanup failure is logged, never masks
+      // the create error rethrown below.
+      await ssh.exec(`docker rm -f ${shellQuote(containerName)}`, 30_000).catch((rmErr) =>
+        logger.warn(`[hetzner-client] cleanup rm failed for ${containerName}`, {
+          error: rmErr instanceof Error ? rmErr.message : String(rmErr),
+        }),
+      );
       await containersRepository.updateStatus(row.id, "failed", message);
       throw new HetznerClientError("container_create_failed", message, err);
     }
@@ -394,6 +403,8 @@ export class HetznerContainersClient {
     const meta = readMetadata(row);
     if (meta) {
       await this.execOnNode(meta, async (ssh) => {
+        // error-policy:J6 best-effort graceful stop; the authoritative teardown
+        // is the un-caught `docker rm -f` below, whose failure DOES propagate.
         await ssh
           .exec(`docker stop -t 10 ${shellQuote(meta.containerName)}`, 30_000)
           .catch((err) => {
@@ -412,6 +423,8 @@ export class HetznerContainersClient {
               `[hetzner-client] refusing to purge unexpected volume path ${meta.volumePath}`,
             );
           } else {
+            // error-policy:J6 best-effort local-volume purge (path already
+            // prefix-guarded above); a failure is logged, not thrown.
             await ssh.exec(`rm -rf ${shellQuote(meta.volumePath)}`, 60_000).catch((err) =>
               logger.warn(`[hetzner-client] volume purge failed for ${meta.volumePath}`, {
                 error: err instanceof Error ? err.message : String(err),
@@ -424,6 +437,8 @@ export class HetznerContainersClient {
       // Idempotent slot release (#8342): only the first stop/delete of this
       // container actually decrements the node — a re-claimed job can't free a
       // phantom slot belonging to a live container. Atomic marker + decrement.
+      // error-policy:J6 best-effort idempotent slot release; a failure is logged
+      // for operator follow-up and does not block the stop/delete lifecycle.
       await containersRepository
         .tryReleaseNodeSlot(containerId, organizationId, meta.nodeId)
         .catch((err) => {
@@ -436,6 +451,9 @@ export class HetznerContainersClient {
     if (row.hcloud_volume_id !== null && isHetznerVolumesAvailable()) {
       const volService = getHetznerVolumeService();
       if (options.purgeVolume) {
+        // error-policy:J6 best-effort volume teardown during container removal;
+        // a delete failure is logged (paid resource left for operator cleanup)
+        // rather than aborting the removal, but is never fabricated as success.
         await volService.deleteProjectVolume(row.hcloud_volume_id).catch((err) => {
           logger.error(
             `[hetzner-client] hcloud volume delete failed for volume ${row.hcloud_volume_id}`,
@@ -445,6 +463,8 @@ export class HetznerContainersClient {
       } else if (meta?.volumePath) {
         const node = await dockerNodesRepository.findByNodeId(meta.nodeId);
         if (node) {
+          // error-policy:J6 best-effort soft-detach; a failure is logged and the
+          // volume stays attached for the next deploy, never faked as detached.
           await volService
             .detachFromNode(row.hcloud_volume_id, node, meta.volumePath)
             .catch((err) => {
@@ -491,6 +511,8 @@ export class HetznerContainersClient {
     const meta = readMetadata(row);
     if (meta) {
       await this.execOnNode(meta, async (ssh) => {
+        // error-policy:J6 best-effort graceful stop; the authoritative teardown
+        // is the un-caught `docker rm -f` below, whose failure DOES propagate.
         await ssh
           .exec(`docker stop -t 10 ${shellQuote(meta.containerName)}`, 30_000)
           .catch((err) => {
@@ -515,6 +537,8 @@ export class HetznerContainersClient {
               `[hetzner-client] refusing to purge unexpected volume path ${meta.volumePath}`,
             );
           } else {
+            // error-policy:J6 best-effort local-volume purge (path already
+            // prefix-guarded above); a failure is logged, not thrown.
             await ssh.exec(`rm -rf ${shellQuote(meta.volumePath)}`, 60_000).catch((err) =>
               logger.warn(`[hetzner-client] volume purge failed for ${meta.volumePath}`, {
                 error: err instanceof Error ? err.message : String(err),
@@ -527,6 +551,8 @@ export class HetznerContainersClient {
       // Idempotent slot release (#8342): only the first stop/delete of this
       // container actually decrements the node — a re-claimed job can't free a
       // phantom slot belonging to a live container. Atomic marker + decrement.
+      // error-policy:J6 best-effort idempotent slot release; a failure is logged
+      // for operator follow-up and does not block the stop/delete lifecycle.
       await containersRepository
         .tryReleaseNodeSlot(containerId, organizationId, meta.nodeId)
         .catch((err) => {
@@ -542,6 +568,9 @@ export class HetznerContainersClient {
       const volService = getHetznerVolumeService();
       if (options.purgeVolume) {
         // Hard-delete: detach + delete the block device. All data is lost.
+        // error-policy:J6 best-effort volume teardown during container removal;
+        // a delete failure is logged (paid resource left for operator cleanup)
+        // rather than aborting the removal, but is never fabricated as success.
         await volService.deleteProjectVolume(row.hcloud_volume_id).catch((err) => {
           logger.error(
             `[hetzner-client] hcloud volume delete failed for volume ${row.hcloud_volume_id}`,
@@ -559,6 +588,8 @@ export class HetznerContainersClient {
         const mountPath = meta.volumePath as string;
         const node = await dockerNodesRepository.findByNodeId(meta.nodeId);
         if (node) {
+          // error-policy:J6 best-effort soft-detach; a failure is logged and the
+          // volume stays attached for the next deploy, never faked as detached.
           await volService.detachFromNode(row.hcloud_volume_id, node, mountPath).catch((err) => {
             logger.warn(
               `[hetzner-client] hcloud volume detach failed for volume ${row.hcloud_volume_id}`,
@@ -604,7 +635,16 @@ export class HetznerContainersClient {
     const { meta } = row;
 
     await this.execOnNode(meta, async (ssh) => {
-      await ssh.exec(`docker stop -t 10 ${shellQuote(meta.containerName)}`, 30_000).catch(() => {});
+      // error-policy:J6 best-effort stop before the authoritative rm -f below;
+      // a stop failure is logged, not thrown, because rm -f performs the real
+      // teardown and its failure DOES propagate.
+      await ssh
+        .exec(`docker stop -t 10 ${shellQuote(meta.containerName)}`, 30_000)
+        .catch((stopErr) =>
+          logger.warn(`[hetzner-client] docker stop failed for ${meta.containerName}`, {
+            error: stopErr instanceof Error ? stopErr.message : String(stopErr),
+          }),
+        );
       await ssh.exec(`docker rm -f ${shellQuote(meta.containerName)}`, 30_000);
 
       const envFlags = Object.entries(environmentVars)
@@ -858,6 +898,10 @@ export class HetznerContainersClient {
         }
         // else still starting — leave alone
       } catch (err) {
+        // error-policy:J7 diagnostics-must-not-kill-the-loop — one container's
+        // probe failure is logged and the row is left in `deploying` for the
+        // next cron tick to retry; it must not abort the whole batch. No status
+        // is fabricated, so a persistently-failing probe never reads as healthy.
         logger.warn(`[hetzner-client] monitor probe failed for ${row.id}`, {
           error: err instanceof Error ? err.message : String(err),
         });
@@ -904,9 +948,10 @@ export class HetznerContainersClient {
     try {
       return await fn(ssh);
     } catch (err) {
+      // error-policy:J2 boundary translation — reclassify SSH connection-level
+      // failures to a typed `ssh_unreachable` (so the route returns 503 not 500)
+      // and rethrow everything else unchanged; nothing is swallowed.
       const message = err instanceof Error ? err.message : String(err);
-      // SSH connection-level failures are reclassified so the route layer
-      // can return a 503 instead of a 500.
       if (
         message.includes("ECONNREFUSED") ||
         message.includes("ETIMEDOUT") ||

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/docker-stats.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/docker-stats.error-policy.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Error-policy coverage for the docker-stats parser (#13415).
+ *
+ * The parser feeds `HetznerClient.getMetrics`, whose snapshot drives container
+ * monitoring/autoscaling. A malformed field (docker emitting `--` for an
+ * unavailable container, a truncated line, or an unrecognized unit) must
+ * surface as a typed `invalid_input` failure — it must NOT fabricate a
+ * 0-byte/wrong-magnitude metric that reads as a healthy, idle container.
+ * A legitimately-zero reading (`0B`, a `0B / 0B` idle net/block counter) is a
+ * real datum and stays distinct: it parses to 0 without throwing.
+ *
+ * Pure parser, no external deps — the real exported function is exercised
+ * directly, no mocks stand in for the code under test.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { parseDockerStats } from "./docker-stats";
+import { HetznerClientError } from "./types";
+
+const line = (cpu: string, mem: string, net: string, block: string) =>
+  `${cpu}|${mem}|${net}|${block}`;
+
+describe("parseDockerStats — designed-valid path", () => {
+  it("parses a well-formed docker stats line with mixed decimal/binary units", () => {
+    const snap = parseDockerStats(line("12.50%", "128MiB / 512MiB", "1.2kB / 3.4MB", "10MB / 0B"));
+    expect(snap.cpuPercent).toBe(12.5);
+    expect(snap.memoryBytes).toBe(Math.round(128 * 1024 ** 2));
+    expect(snap.memoryLimitBytes).toBe(Math.round(512 * 1024 ** 2));
+    expect(snap.netRxBytes).toBe(1200);
+    expect(snap.netTxBytes).toBe(3_400_000);
+    expect(snap.blockReadBytes).toBe(10_000_000);
+    expect(snap.blockWriteBytes).toBe(0);
+    expect(snap.capturedAt).toBeInstanceOf(Date);
+  });
+
+  it("keeps a legitimately-zero idle reading distinct (0B is a real datum, not a failure)", () => {
+    const snap = parseDockerStats(line("0.00%", "0B / 0B", "0B / 0B", "0B / 0B"));
+    expect(snap.memoryBytes).toBe(0);
+    expect(snap.netRxBytes).toBe(0);
+    expect(snap.blockWriteBytes).toBe(0);
+  });
+
+  it("uses only the last line of multi-line output", () => {
+    const snap = parseDockerStats(
+      `header-noise\n${line("1.00%", "1MiB / 2MiB", "1B / 1B", "1B / 1B")}`,
+    );
+    expect(snap.memoryBytes).toBe(1024 ** 2);
+  });
+});
+
+describe("parseDockerStats — internal failure propagates (fail closed)", () => {
+  it("throws invalid_input when docker emits `--` for an unavailable container", () => {
+    // A restarting/dead container yields `-- / --`; that is missing data, not 0.
+    let err: unknown;
+    try {
+      parseDockerStats(line("0.00%", "-- / --", "0B / 0B", "0B / 0B"));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(HetznerClientError);
+    expect((err as HetznerClientError).code).toBe("invalid_input");
+  });
+
+  it("throws invalid_input on an unrecognized size unit (never silently treats it as bytes)", () => {
+    let err: unknown;
+    try {
+      parseDockerStats(line("0.00%", "5ZiB / 10MiB", "0B / 0B", "0B / 0B"));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(HetznerClientError);
+    expect((err as HetznerClientError).code).toBe("invalid_input");
+    expect((err as HetznerClientError).message).toContain("Unknown size unit");
+  });
+
+  it("throws invalid_input on a truncated line with missing pipe-delimited fields", () => {
+    let err: unknown;
+    try {
+      parseDockerStats("12.50%|128MiB / 512MiB");
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(HetznerClientError);
+    expect((err as HetznerClientError).code).toBe("invalid_input");
+  });
+
+  it("throws invalid_input on empty output rather than fabricating a zero snapshot", () => {
+    expect(() => parseDockerStats("")).toThrow(HetznerClientError);
+  });
+
+  it("throws invalid_input on a garbage size token", () => {
+    let err: unknown;
+    try {
+      parseDockerStats(line("0.00%", "N/A / 512MiB", "0B / 0B", "0B / 0B"));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(HetznerClientError);
+    expect((err as HetznerClientError).code).toBe("invalid_input");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/docker-stats.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/docker-stats.ts
@@ -52,8 +52,20 @@ const SIZE_UNITS: Record<string, number> = {
 
 function parseSize(raw: string): number {
   const match = raw.match(/^([\d.]+)\s*([a-zA-Z]+)?$/);
-  if (!match) return 0;
+  if (!match) {
+    throw new HetznerClientError(
+      "invalid_input",
+      `Failed to parse docker stats size field: ${JSON.stringify(raw)}`,
+    );
+  }
   const [, n, unit] = match;
-  const multiplier = unit ? (SIZE_UNITS[unit.toLowerCase()] ?? 1) : 1;
+  if (!unit) return Math.round(parseFloat(n));
+  const multiplier = SIZE_UNITS[unit.toLowerCase()];
+  if (multiplier === undefined) {
+    throw new HetznerClientError(
+      "invalid_input",
+      `Unknown size unit in docker stats output: ${JSON.stringify(unit)}`,
+    );
+  }
   return Math.round(parseFloat(n) * multiplier);
 }

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/metadata.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/metadata.error-policy.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Pins the fail-closed / designed-empty contract of the container row->DTO
+ * mapper (#13415). `metadata.ts` is pure synchronous projection — no catch,
+ * no cloud-API call — so the error-policy concern here is that a designed
+ * "no Hetzner node" result (null) stays DISTINCT from a well-formed present
+ * result, and that a structurally-invalid Hetzner blob degrades to that same
+ * null (which callers branch on to skip remote teardown) rather than
+ * fabricating a half-populated metadata object that would drive an SSH exec
+ * against garbage.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { Container } from "../../../../db/repositories/containers";
+import { readMetadata, rowToSummary } from "./metadata";
+
+const NOW = new Date("2026-01-01T00:00:00.000Z");
+
+function makeRow(overrides: Partial<Container> = {}): Container {
+  const base = {
+    id: "11111111-1111-1111-1111-111111111111",
+    name: "agent-one",
+    project_name: "proj",
+    description: null,
+    organization_id: "22222222-2222-2222-2222-222222222222",
+    user_id: "33333333-3333-3333-3333-333333333333",
+    api_key_id: null,
+    character_id: null,
+    load_balancer_url: null,
+    public_hostname: null,
+    status: "running",
+    image_tag: null,
+    environment_vars: {},
+    desired_count: 1,
+    cpu: 1792,
+    memory: 1792,
+    port: 3000,
+    health_check_path: "/health",
+    node_id: null,
+    volume_path: null,
+    volume_size_gb: null,
+    hcloud_volume_id: null,
+    volume_location: null,
+    last_deployed_at: null,
+    last_health_check: null,
+    deployment_log: null,
+    deployment_log_storage: "inline",
+    deployment_log_key: null,
+    error_message: null,
+    metadata: {},
+    last_billed_at: null,
+    next_billing_at: null,
+    billing_status: "active",
+    shutdown_warning_sent_at: null,
+    scheduled_shutdown_at: null,
+    total_billed: "0.00",
+    created_at: NOW,
+    updated_at: NOW,
+  } as unknown as Container;
+  return { ...base, ...overrides };
+}
+
+const validHetznerMeta = {
+  provider: "hetzner-docker",
+  nodeId: "node-1",
+  hostname: "10.0.0.5",
+  containerName: "cloud-container-abc",
+  hostPort: 49001,
+  image: "ghcr.io/elizaos/eliza:stable",
+  containerPort: 3000,
+};
+
+describe("readMetadata — present vs designed-empty stay distinct", () => {
+  it("returns the fully typed blob for a well-formed hetzner row (present)", () => {
+    const meta = readMetadata(makeRow({ metadata: { ...validHetznerMeta } }));
+    expect(meta).not.toBeNull();
+    expect(meta).toMatchObject({
+      provider: "hetzner-docker",
+      nodeId: "node-1",
+      hostname: "10.0.0.5",
+      containerName: "cloud-container-abc",
+      hostPort: 49001,
+      image: "ghcr.io/elizaos/eliza:stable",
+      containerPort: 3000,
+    });
+  });
+
+  it("returns null (designed-empty) for a legacy AWS row, never throws", () => {
+    const awsRow = makeRow({
+      metadata: { provider: "aws-ecs", ecr_image_uri: "123.dkr.ecr/eliza:1" },
+    });
+    expect(() => readMetadata(awsRow)).not.toThrow();
+    expect(readMetadata(awsRow)).toBeNull();
+  });
+
+  it("returns null for an absent/empty metadata blob, never throws", () => {
+    expect(readMetadata(makeRow({ metadata: {} }))).toBeNull();
+    expect(readMetadata(makeRow({ metadata: null as never }))).toBeNull();
+  });
+});
+
+describe("readMetadata — a structurally-invalid hetzner blob degrades to null, not a fabricated object", () => {
+  // A hetzner-provider row that is missing/mistyping a required field must NOT
+  // read as a half-valid metadata object: callers gate remote docker teardown
+  // on `if (meta)` and would SSH-exec against a bad hostname/containerName.
+  const requiredFieldMutations: Array<[string, Record<string, unknown>]> = [
+    ["hostPort is a string, not a number", { ...validHetznerMeta, hostPort: "49001" }],
+    [
+      "containerPort missing",
+      (() => {
+        const m = { ...validHetznerMeta };
+        delete (m as Record<string, unknown>).containerPort;
+        return m;
+      })(),
+    ],
+    [
+      "nodeId missing",
+      (() => {
+        const m = { ...validHetznerMeta };
+        delete (m as Record<string, unknown>).nodeId;
+        return m;
+      })(),
+    ],
+    ["hostname is null", { ...validHetznerMeta, hostname: null }],
+    ["containerName is a number", { ...validHetznerMeta, containerName: 42 }],
+    [
+      "image missing",
+      (() => {
+        const m = { ...validHetznerMeta };
+        delete (m as Record<string, unknown>).image;
+        return m;
+      })(),
+    ],
+  ];
+
+  for (const [label, metadata] of requiredFieldMutations) {
+    it(`returns null when ${label}`, () => {
+      expect(readMetadata(makeRow({ metadata }))).toBeNull();
+    });
+  }
+
+  it("keeps genuinely-optional fields absent without discarding the row", () => {
+    const meta = readMetadata(makeRow({ metadata: { ...validHetznerMeta } }));
+    expect(meta).not.toBeNull();
+    // Optional fields are `undefined` when absent — distinct from the whole
+    // row being rejected as null.
+    expect(meta?.imageDigest).toBeUndefined();
+    expect(meta?.volumePath).toBeUndefined();
+    expect(meta?.volumeMountPath).toBeUndefined();
+  });
+});
+
+describe("rowToSummary — projection keeps present metadata distinct from null", () => {
+  it("carries a valid hetzner blob through as summary.metadata (present)", () => {
+    const summary = rowToSummary(
+      makeRow({
+        metadata: { ...validHetznerMeta },
+        load_balancer_url: "https://x.containers.elizacloud.ai",
+        error_message: null,
+      }),
+    );
+    expect(summary.metadata).not.toBeNull();
+    expect(summary.metadata?.provider).toBe("hetzner-docker");
+    expect(summary.image).toBe("ghcr.io/elizaos/eliza:stable");
+    expect(summary.publicUrl).toBe("https://x.containers.elizacloud.ai");
+  });
+
+  it("yields metadata:null for a legacy AWS row while still projecting its image, never throws", () => {
+    const summary = rowToSummary(
+      makeRow({ metadata: { provider: "aws-ecs", ecr_image_uri: "123.dkr.ecr/eliza:1" } }),
+    );
+    // metadata:null is the designed distinct signal (no hetzner node); the
+    // legacy image still projects rather than being lost.
+    expect(summary.metadata).toBeNull();
+    expect(summary.image).toBe("123.dkr.ecr/eliza:1");
+  });
+
+  it("projects nullable columns as null, not fabricated values", () => {
+    const summary = rowToSummary(makeRow({ load_balancer_url: null, error_message: null }));
+    expect(summary.publicUrl).toBeNull();
+    expect(summary.errorMessage).toBeNull();
+    expect(summary.metadata).toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/registry.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/registry.error-policy.test.ts
@@ -1,0 +1,129 @@
+// Error-policy proofs for the registry helpers (#13415): a failed cloud/SSH
+// call must surface (typed throw or logged warn) and stay distinguishable from
+// a legitimately-empty result. Deterministic fixtures — the SSH client is a
+// mock, the logger is spied; no live Docker/Hetzner.
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { containersEnv as actualContainersEnv } from "../../../config/containers-env";
+import { logger } from "../../../utils/logger";
+import { HetznerClientError } from "./types";
+
+const registryUsername = mock(() => undefined as string | undefined);
+const registryToken = mock(() => undefined as string | undefined);
+const registryTokenFile = mock(() => undefined as string | undefined);
+
+// Override only the registry-credential accessors; spread the rest so no other
+// containersEnv method becomes undefined for files importing after this one.
+mock.module("../../../config/containers-env", () => ({
+  containersEnv: {
+    ...actualContainersEnv,
+    registryUsername,
+    registryToken,
+    registryTokenFile,
+  },
+}));
+
+const { readPulledImageDigest, loginToImageRegistry } = await import("./registry");
+
+function sshReturning(output: string) {
+  return { exec: mock(async () => output) };
+}
+function sshThrowing(message: string) {
+  return {
+    exec: mock(async () => {
+      throw new Error(message);
+    }),
+  };
+}
+
+describe("readPulledImageDigest — failure vs designed-empty", () => {
+  let warnSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("returns the sha256 digest from a well-formed RepoDigests array", async () => {
+    const ssh = sshReturning('["ghcr.io/elizaos/eliza@sha256:abc123"]');
+    const digest = await readPulledImageDigest(ssh as never, "ghcr.io/elizaos/eliza:stable");
+    expect(digest).toBe("ghcr.io/elizaos/eliza@sha256:abc123");
+    // A clean success must not warn.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("designed-empty (docker prints 'null') returns undefined WITHOUT a warn", async () => {
+    const ssh = sshReturning("null");
+    const digest = await readPulledImageDigest(ssh as never, "ghcr.io/elizaos/eliza:stable");
+    expect(digest).toBeUndefined();
+    // Legitimately-empty result stays distinct from an internal failure: silent.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("empty RepoDigests array returns undefined WITHOUT a warn", async () => {
+    const ssh = sshReturning("[]");
+    const digest = await readPulledImageDigest(ssh as never, "ghcr.io/elizaos/eliza:stable");
+    expect(digest).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("SSH/transport failure surfaces as a warn (not silently swallowed) and yields undefined", async () => {
+    const ssh = sshThrowing("ssh connection reset");
+    const digest = await readPulledImageDigest(ssh as never, "ghcr.io/elizaos/eliza:stable");
+    expect(digest).toBeUndefined();
+    // The internal failure must be observable — the pre-fix `.catch(() => "")`
+    // made it indistinguishable from a digest-less image.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [msg, ctx] = warnSpy.mock.calls[0] as [string, { error: string }];
+    expect(msg).toContain("docker image inspect failed");
+    expect(ctx.error).toContain("ssh connection reset");
+  });
+
+  test("malformed (non-JSON) inspect output surfaces as a warn and yields undefined", async () => {
+    const ssh = sshReturning("not-json-at-all {");
+    const digest = await readPulledImageDigest(ssh as never, "ghcr.io/elizaos/eliza:stable");
+    expect(digest).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect((warnSpy.mock.calls[0] as [string])[0]).toContain("unparseable RepoDigests");
+  });
+});
+
+describe("loginToImageRegistry — token-file failure fails closed (typed throw)", () => {
+  beforeEach(() => {
+    for (const m of [registryUsername, registryToken, registryTokenFile]) {
+      m.mockReset();
+      m.mockReturnValue(undefined);
+    }
+  });
+
+  test("unreadable configured token file throws a typed HetznerClientError (with cause), never anonymous fallback", async () => {
+    registryUsername.mockReturnValue("robot");
+    registryTokenFile.mockReturnValue("/nonexistent/path/registry-token.does-not-exist");
+    const ssh = sshReturning("");
+
+    let thrown: unknown;
+    try {
+      await loginToImageRegistry(ssh as never, "ghcr.io/elizaos/eliza:stable");
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(HetznerClientError);
+    const err = thrown as HetznerClientError;
+    expect(err.code).toBe("invalid_input");
+    // cause is threaded through so the underlying fs error is not lost.
+    expect(err.cause).toBeInstanceOf(Error);
+    // A configured-but-broken credential must NOT silently degrade to an
+    // anonymous pull: the exec (docker login) never runs.
+    expect(ssh.exec).not.toHaveBeenCalled();
+  });
+
+  test("no credentials configured is a designed anonymous-skip (no throw, no exec) — distinct from failure", async () => {
+    const ssh = sshReturning("");
+    await expect(
+      loginToImageRegistry(ssh as never, "ghcr.io/elizaos/eliza:stable"),
+    ).resolves.toBeUndefined();
+    expect(ssh.exec).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/registry.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/registry.ts
@@ -33,9 +33,14 @@ function readRegistryToken(): string | undefined {
     const token = fs.readFileSync(tokenFile, "utf8").trim();
     return token || undefined;
   } catch (error) {
+    // error-policy:J2 translate a configured-but-unreadable token file into a
+    // typed invalid_input failure (with cause) so a misconfigured registry
+    // credential surfaces to the route layer instead of silently falling back
+    // to an anonymous pull that would 401 on a private image.
     throw new HetznerClientError(
       "invalid_input",
       `Failed to read Docker registry token file '${tokenFile.split("/").pop() ?? "unknown"}': ${error instanceof Error ? error.message : String(error)}`,
+      error,
     );
   }
 }
@@ -85,6 +90,9 @@ export async function ensureRegistryAccess(ssh: DockerSSHClient, image: string):
   if (!registryHost) return;
 
   if (containersEnv.registryToken() || containersEnv.registryTokenFile()) {
+    // error-policy:J6 best-effort registry priming — a login hiccup must not
+    // block the `docker pull` that follows (which is the real gate and will
+    // fail loudly if the cred was actually required). Surfaced via warn.
     await loginToImageRegistry(ssh, image).catch((error) => {
       logger.warn(`[ensureRegistryAccess] docker login to ${registryHost} failed; continuing`, {
         error: error instanceof Error ? error.message : String(error),
@@ -95,6 +103,8 @@ export async function ensureRegistryAccess(ssh: DockerSSHClient, image: string):
 
   // No token configured: proactively drop any stale stored credential so the
   // public-image pull uses anonymous access deterministically.
+  // error-policy:J6 best-effort stale-cred clearing — a logout hiccup must not
+  // block the anonymous pull that follows; the pull is the real gate.
   await ssh
     .exec(`docker logout ${shellQuote(registryHost)} >/dev/null 2>&1 || true`, 30_000)
     .catch((error) => {
@@ -105,22 +115,56 @@ export async function ensureRegistryAccess(ssh: DockerSSHClient, image: string):
     });
 }
 
+/**
+ * Read the repo digest Docker resolved for `image` after a successful pull.
+ *
+ * Best-effort informational metadata: the digest is captured post-pull and
+ * stored for later blue/green digest-mismatch checks (see `eliza-sandbox`). The
+ * container is already pulled and about to start, so a failed inspect must not
+ * abort provisioning — but it must not read as "no digest" *silently* either.
+ * A transport/SSH failure and an unparseable payload are both surfaced via
+ * `logger.warn`, keeping them distinguishable from the designed-empty case (an
+ * image that genuinely has no `RepoDigests`), which returns `undefined` quietly.
+ */
 export async function readPulledImageDigest(
   ssh: DockerSSHClient,
   image: string,
 ): Promise<string | undefined> {
-  const output = await ssh
-    .exec(`docker image inspect --format '{{json .RepoDigests}}' ${shellQuote(image)}`, 30_000)
-    .catch(() => "");
+  let output: string;
+  try {
+    output = await ssh.exec(
+      `docker image inspect --format '{{json .RepoDigests}}' ${shellQuote(image)}`,
+      30_000,
+    );
+  } catch (error) {
+    // error-policy:J6 best-effort post-pull metadata read; surface the transport
+    // failure rather than conflating it with an image that has no digest.
+    logger.warn(
+      `[readPulledImageDigest] docker image inspect failed for ${image}; digest unknown`,
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return undefined;
+  }
+
   const trimmed = output.trim();
   if (!trimmed || trimmed === "null") return undefined;
+
   try {
     const repoDigests = JSON.parse(trimmed) as unknown;
     if (!Array.isArray(repoDigests)) return undefined;
     return repoDigests.find((value): value is string => {
       return typeof value === "string" && value.includes("@sha256:");
     });
-  } catch {
+  } catch (error) {
+    // error-policy:J3 untrusted docker output — a non-JSON RepoDigests payload
+    // is malformed, not a fatal provisioning failure; surface it and treat the
+    // digest as absent.
+    logger.warn(`[readPulledImageDigest] unparseable RepoDigests output for ${image}`, {
+      output: trimmed,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return undefined;
   }
 }

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.error-policy.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Error-policy pins for the Hetzner Cloud API client (#13415).
+ *
+ * Container-provisioning infra must FAIL CLOSED: a failed create/delete/list
+ * cloud-API call has to surface as a typed `HetznerCloudError`, never read as
+ * "no servers" / "success". This suite drives the real exported client (fetch
+ * stubbed at `globalThis.fetch`) and proves two things stay distinguishable:
+ *   - an internal failure (5xx, transport reject, non-JSON body) PROPAGATES;
+ *   - a legitimately-empty 200 (`{servers: []}`) and the designed not_found→null
+ *     degrade do NOT get conflated with that failure.
+ *
+ * `mock.module` neutralises the logger + env dependencies so the module under
+ * test loads hermetically; it is then pulled in via dynamic `import()`.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../utils/logger", () => ({
+  logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+}));
+mock.module("../../config/containers-env", () => ({
+  containersEnv: { hetznerCloudToken: () => "" },
+}));
+
+type ClientModule = typeof import("./hetzner-cloud-api");
+
+const TOKEN = "test-token-xyz";
+
+let responseQueue: Array<() => Response | Promise<Response>> = [];
+let originalFetch: typeof globalThis.fetch;
+
+function queueJson(body: unknown, status = 200): void {
+  responseQueue.push(() => new Response(JSON.stringify(body), { status }));
+}
+function queueRaw(bodyText: string, status: number): void {
+  responseQueue.push(() => new Response(bodyText, { status }));
+}
+function queueReject(err: Error): void {
+  responseQueue.push(() => {
+    throw err;
+  });
+}
+
+async function load(): Promise<ClientModule> {
+  return import("./hetzner-cloud-api");
+}
+
+beforeEach(() => {
+  responseQueue = [];
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = mock(async () => {
+    const next = responseQueue.shift();
+    if (!next) throw new Error("no response queued");
+    return next();
+  }) as unknown as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("hetzner-cloud-api fail-closed on internal failure", () => {
+  test("listServers on a 500 REJECTS with server_error — a failed list never reads as empty", async () => {
+    const { HetznerCloudClient } = await load();
+    queueJson({ error: { code: "server_error", message: "boom" } }, 500);
+
+    const promise = HetznerCloudClient.withToken(TOKEN).listServers();
+    await expect(promise).rejects.toMatchObject({
+      name: "HetznerCloudError",
+      code: "server_error",
+      status: 500,
+    });
+  });
+
+  test("listServers on a transport reject REJECTS with transport_error carrying the cause", async () => {
+    const { HetznerCloudClient } = await load();
+    const boom = new Error("ECONNREFUSED");
+    queueReject(boom);
+
+    try {
+      await HetznerCloudClient.withToken(TOKEN).listServers();
+      throw new Error("expected listServers to reject");
+    } catch (err) {
+      const e = err as InstanceType<ClientModule["HetznerCloudError"]>;
+      expect(e.name).toBe("HetznerCloudError");
+      expect(e.code).toBe("transport_error");
+      // cause is preserved so the transport boundary does not swallow context.
+      expect(e.cause).toBe(boom);
+    }
+  });
+
+  test("createServer on a 500 REJECTS — provisioning failure never fabricates a server", async () => {
+    const { HetznerCloudClient } = await load();
+    queueJson({ error: { code: "server_error", message: "capacity" } }, 500);
+
+    await expect(
+      HetznerCloudClient.withToken(TOKEN).createServer({
+        name: "n1",
+        serverType: "cax21",
+        location: "fsn1",
+        image: "ubuntu-24.04",
+        userData: "#cloud-config\n",
+      }),
+    ).rejects.toMatchObject({ code: "server_error" });
+  });
+
+  test("deleteServer on a 500 REJECTS — a failed delete never reads as success", async () => {
+    const { HetznerCloudClient } = await load();
+    queueJson({ error: { code: "server_error", message: "nope" } }, 500);
+
+    await expect(HetznerCloudClient.withToken(TOKEN).deleteServer(7)).rejects.toMatchObject({
+      code: "server_error",
+    });
+  });
+
+  test("a non-JSON error body REJECTS with server_error — malformed upstream surfaces, not swallowed", async () => {
+    const { HetznerCloudClient } = await load();
+    queueRaw("<html>502 Bad Gateway</html>", 502);
+
+    await expect(HetznerCloudClient.withToken(TOKEN).listVolumes()).rejects.toMatchObject({
+      code: "server_error",
+      status: 502,
+    });
+  });
+
+  test("a 403 quota body maps to quota_exceeded, kept DISTINCT from missing_token", async () => {
+    const { HetznerCloudClient } = await load();
+    queueJson({ error: { code: "limit_reached", message: "server cap hit" } }, 403);
+
+    await expect(HetznerCloudClient.withToken(TOKEN).listServers()).rejects.toMatchObject({
+      code: "quota_exceeded",
+    });
+  });
+});
+
+describe("hetzner-cloud-api designed-empty stays distinct from failure", () => {
+  test("listServers on a 200 empty list returns [] (empty, no throw)", async () => {
+    const { HetznerCloudClient } = await load();
+    queueJson({ servers: [] });
+
+    const servers = await HetznerCloudClient.withToken(TOKEN).listServers();
+    expect(servers).toEqual([]);
+  });
+
+  test("getServer 404 returns null (designed absent) but getServer 500 THROWS (internal failure)", async () => {
+    const { HetznerCloudClient } = await load();
+
+    // Expected not_found shape degrades to a null absent-signal.
+    queueJson({ error: { code: "not_found", message: "gone" } }, 404);
+    const absent = await HetznerCloudClient.withToken(TOKEN).getServer(999);
+    expect(absent).toBeNull();
+
+    // A 500 on the SAME method must NOT collapse into that same null.
+    queueJson({ error: { code: "server_error", message: "boom" } }, 500);
+    await expect(HetznerCloudClient.withToken(TOKEN).getServer(999)).rejects.toMatchObject({
+      code: "server_error",
+    });
+  });
+
+  test("getVolume 404 returns null but getVolume transport-reject THROWS", async () => {
+    const { HetznerCloudClient } = await load();
+
+    queueJson({ error: { code: "not_found", message: "gone" } }, 404);
+    expect(await HetznerCloudClient.withToken(TOKEN).getVolume(5)).toBeNull();
+
+    queueReject(new Error("ETIMEDOUT"));
+    await expect(HetznerCloudClient.withToken(TOKEN).getVolume(5)).rejects.toMatchObject({
+      code: "transport_error",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-volumes.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-volumes.error-policy.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Error-policy pin for `HetznerVolumeService.attachToNode` (#13415).
+ *
+ * The load-bearing invariant: the filesystem probe in `formatAndMount` must
+ * fail CLOSED. The `blkid ... || true` shell guard turns "no filesystem"
+ * (blkid exit 2) into empty stdout — the ONLY legitimate empty result, which
+ * is allowed to trigger a fresh `mkfs.ext4`. But an SSH/transport failure on
+ * that probe must PROPAGATE, never be swallowed into "" — otherwise a failed
+ * probe reads as "blank device" and formats a volume that may hold data.
+ *
+ * Deterministic harness: `./hetzner-cloud-api` and `../docker-ssh` are
+ * mock.module'd so the real `attachToNode` runs against an in-memory Hetzner
+ * client and a scripted SSH exec. No network, no ssh2.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { DockerNode } from "../../../db/schemas/docker-nodes";
+import { HetznerCloudError } from "./hetzner-cloud-api";
+
+type ExecFn = (cmd: string, timeoutMs?: number) => Promise<string>;
+
+const HCLOUD_SERVER_ID = 424242;
+const VOLUME_ID = 7777;
+
+let sshExec: ExecFn;
+let mkfsCommands: string[];
+let mountCommands: string[];
+let getVolumeCalls: number;
+
+const fakeApi = {
+  getVolume: async (_id: number) => {
+    getVolumeCalls += 1;
+    // First call = state before attach (unattached). Second = refreshed state
+    // after the attach action settles (device now present).
+    if (getVolumeCalls === 1) {
+      return { id: VOLUME_ID, server: null, linux_device: null };
+    }
+    return {
+      id: VOLUME_ID,
+      server: HCLOUD_SERVER_ID,
+      linux_device: "/dev/disk/by-id/scsi-0HC_Volume_7777",
+      location: { name: "fsn1" },
+    };
+  },
+  attachVolume: async (_v: number, _s: number, _a?: boolean) => ({ id: 101 }),
+  detachVolume: async (_v: number) => ({ id: 102 }),
+  waitForAction: async (_id: number) => ({ id: 101, status: "success" }),
+};
+
+const fakeSsh = { exec: (cmd: string, timeoutMs?: number) => sshExec(cmd, timeoutMs) };
+
+mock.module("./hetzner-cloud-api", () => ({
+  HetznerCloudError,
+  getHetznerCloudClient: () => fakeApi,
+  isHetznerCloudConfigured: () => true,
+}));
+
+mock.module("../docker-ssh", () => ({
+  DockerSSHClient: { getClient: () => fakeSsh },
+}));
+
+const { HetznerVolumeService } = await import("./hetzner-volumes");
+
+const node = {
+  node_id: "node-abc",
+  hostname: "10.0.0.5",
+  ssh_port: 22,
+  host_key_fingerprint: null,
+  ssh_user: "root",
+  metadata: { hcloudServerId: HCLOUD_SERVER_ID },
+} as unknown as DockerNode;
+
+const key = { organizationId: "org1", projectName: "proj1" };
+
+/**
+ * Route a scripted SSH command to a result. `blkid` is the branch under test:
+ * caller supplies its outcome (empty stdout, a filesystem type, or a reject).
+ */
+function makeExec(blkid: () => Promise<string>): ExecFn {
+  return async (cmd: string) => {
+    if (cmd.includes("blkid")) return blkid();
+    if (cmd.includes("mkfs.ext4")) {
+      mkfsCommands.push(cmd);
+      return "";
+    }
+    if (cmd.includes("mountpoint")) {
+      mountCommands.push(cmd);
+      return "";
+    }
+    // waitScript ([ -b ... ]) and mkdir -p both resolve cleanly.
+    return "";
+  };
+}
+
+describe("HetznerVolumeService.attachToNode filesystem probe (#13415)", () => {
+  beforeEach(() => {
+    mkfsCommands = [];
+    mountCommands = [];
+    getVolumeCalls = 0;
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("designed-empty probe (no filesystem) formats then mounts", async () => {
+    // blkid + `|| true` yields empty stdout: a genuinely blank device.
+    sshExec = makeExec(async () => "");
+    const svc = new HetznerVolumeService();
+
+    const attached = await svc.attachToNode(VOLUME_ID, node, key);
+
+    expect(mkfsCommands.length).toBe(1);
+    expect(mountCommands.length).toBe(1);
+    expect(attached.volumeId).toBe(VOLUME_ID);
+    expect(attached.location).toBe("fsn1");
+    expect(attached.mountPath).toBe("/data/projects/org1/proj1");
+  });
+
+  it("existing filesystem (non-empty probe) skips mkfs but still mounts", async () => {
+    sshExec = makeExec(async () => "ext4\n");
+    const svc = new HetznerVolumeService();
+
+    const attached = await svc.attachToNode(VOLUME_ID, node, key);
+
+    expect(mkfsCommands.length).toBe(0);
+    expect(mountCommands.length).toBe(1);
+    expect(attached.devicePath).toContain("scsi-0HC_Volume_7777");
+  });
+
+  it("SSH failure on the probe PROPAGATES and never triggers a destructive mkfs", async () => {
+    // A transport/exec failure must not be swallowed into "" — that would read
+    // as "blank device" and format a volume that may hold data.
+    const probeError = new Error("ssh channel closed unexpectedly");
+    sshExec = makeExec(async () => {
+      throw probeError;
+    });
+    const svc = new HetznerVolumeService();
+
+    await expect(svc.attachToNode(VOLUME_ID, node, key)).rejects.toThrow(
+      "ssh channel closed unexpectedly",
+    );
+    // The critical assertion: the failed probe did NOT fall through to mkfs.
+    expect(mkfsCommands.length).toBe(0);
+    expect(mountCommands.length).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-volumes.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-volumes.ts
@@ -191,6 +191,7 @@ export class HetznerVolumeService {
     );
     // Best-effort unmount. If the path isn't mounted, umount returns
     // non-zero and we proceed anyway.
+    // error-policy:J6 teardown-only; the detach below still propagates on failure.
     await ssh.exec(`umount ${shellQuote(mountPath)} || true`, 30_000).catch((err) =>
       logger.warn(`[hcloud-volumes] unmount failed for ${mountPath} on ${node.node_id}`, {
         error: err instanceof Error ? err.message : String(err),
@@ -240,10 +241,16 @@ export class HetznerVolumeService {
     const waitScript = `for i in $(seq 1 30); do [ -b ${shellQuote(devicePath)} ] && exit 0; sleep 1; done; echo "device ${devicePath} did not appear" >&2; exit 1`;
     await ssh.exec(waitScript, 60_000);
 
-    // Skip mkfs if the device already has a filesystem.
-    const blkidOutput = await ssh
-      .exec(`blkid -o value -s TYPE ${shellQuote(devicePath)} 2>/dev/null || true`, 15_000)
-      .catch(() => "");
+    // Skip mkfs if the device already has a filesystem. The `|| true` makes
+    // blkid's "no filesystem" exit (code 2) resolve as empty stdout — that is
+    // the only legitimate empty result. An SSH/transport failure must NOT be
+    // swallowed into "": that would read as "no filesystem" and trigger a
+    // destructive mkfs.ext4 on a volume that may hold data. Let it propagate
+    // so attach fails closed instead of formatting the disk blind.
+    const blkidOutput = await ssh.exec(
+      `blkid -o value -s TYPE ${shellQuote(devicePath)} 2>/dev/null || true`,
+      15_000,
+    );
     if (!blkidOutput.trim()) {
       logger.info(`[hcloud-volumes] Formatting ${devicePath} as ext4 on ${node.node_id}`);
       await ssh.exec(`mkfs.ext4 -F -L cloud-data ${shellQuote(devicePath)}`, 5 * 60_000);

--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.error-policy.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Error-policy proof for the drain/deprovision path (#13415). A failed outbound
+ * Hetzner `deleteServer` must PROPAGATE — fail closed, DB row kept — so a live,
+ * still-billing server is never orphaned by a silently-dropped delete; while an
+ * idempotent 404 ("already gone", the desired end state) stays a distinct,
+ * designed success that removes the DB row. Deterministic: the compute provider
+ * and all repositories are injected/mocked, no live cloud API.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { DockerNode } from "../../../db/repositories/docker-nodes";
+import * as realDockerNodesNs from "../../../db/repositories/docker-nodes";
+import * as realDockerNodeWorkloadsNs from "../docker-node-workloads";
+import type { ComputeProvider } from "./compute-provider";
+import * as realHetznerCloudApiNs from "./hetzner-cloud-api";
+import * as realNodeBootstrapNs from "./node-bootstrap";
+
+const realDockerNodes = { ...realDockerNodesNs };
+const realDockerNodeWorkloads = { ...realDockerNodeWorkloadsNs };
+const realHetznerCloudApi = { ...realHetznerCloudApiNs };
+const realNodeBootstrap = { ...realNodeBootstrapNs };
+
+// The source narrows the swallow to `err instanceof HetznerCloudError &&
+// err.code === "not_found"`, so the thrown error must be an instance of the
+// SAME class the module-under-test imports — i.e. this mocked one.
+class FakeHetznerCloudError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HetznerCloudError";
+  }
+}
+
+const mocks = {
+  findByNodeId: mock(),
+  updateNode: mock(),
+  deleteNode: mock(),
+  countRetained: mock(),
+  isConfigured: mock(),
+  deleteServer: mock(),
+};
+
+mock.module("../../../db/repositories/docker-nodes", () => ({
+  dockerNodesRepository: {
+    findByNodeId: mocks.findByNodeId,
+    update: mocks.updateNode,
+    delete: mocks.deleteNode,
+  },
+}));
+
+mock.module("../docker-node-workloads", () => ({
+  countAllocatedWorkloadsOnNode: mock(async () => 0),
+  countRetainedWorkloadsOnNode: mocks.countRetained,
+}));
+
+mock.module("./hetzner-cloud-api", () => ({
+  HetznerCloudError: FakeHetznerCloudError,
+  getHetznerCloudClient: () => ({ deleteServer: mocks.deleteServer }),
+  isHetznerCloudConfigured: mocks.isConfigured,
+}));
+
+mock.module("./node-bootstrap", () => ({
+  buildContainerNodeUserData: mock(() => "#cloud-config\n"),
+}));
+
+afterAll(() => {
+  mock.module("../../../db/repositories/docker-nodes", () => realDockerNodes);
+  mock.module("../docker-node-workloads", () => realDockerNodeWorkloads);
+  mock.module("./hetzner-cloud-api", () => realHetznerCloudApi);
+  mock.module("./node-bootstrap", () => realNodeBootstrap);
+});
+
+const NODE_ID = "drain-node";
+const HCLOUD_SERVER_ID = 4242;
+
+function makeNode(): DockerNode {
+  return {
+    id: "db-1",
+    node_id: NODE_ID,
+    hostname: "203.0.113.9",
+    ssh_port: 22,
+    ssh_user: "root",
+    capacity: 8,
+    allocated_count: 0,
+    // Already disabled so drain skips the enable→disable update and goes
+    // straight to the deprovision branch under test.
+    enabled: false,
+    status: "healthy",
+    metadata: {
+      provider: "hetzner-cloud",
+      autoscaled: true,
+      hcloudServerId: HCLOUD_SERVER_ID,
+    },
+    created_at: new Date("2026-05-15T12:00:00Z"),
+    updated_at: new Date("2026-05-15T12:00:00Z"),
+  } as DockerNode;
+}
+
+// Inject a ComputeProvider whose only exercised method is deleteServer — the
+// documented constructor seam (#8919) — so drainNode routes deletes to it.
+const provider = { deleteServer: mocks.deleteServer } as unknown as ComputeProvider;
+
+async function drainDeprovision(): Promise<void> {
+  const { NodeAutoscaler } = await import("./node-autoscaler");
+  const autoscaler = new NodeAutoscaler(undefined, undefined, provider);
+  await autoscaler.drainNode(NODE_ID, { deprovision: true });
+}
+
+describe("NodeAutoscaler drain deprovision — fail-closed error policy (#13415)", () => {
+  beforeEach(() => {
+    mocks.findByNodeId.mockReset();
+    mocks.updateNode.mockReset();
+    mocks.deleteNode.mockReset();
+    mocks.countRetained.mockReset();
+    mocks.isConfigured.mockReset();
+    mocks.deleteServer.mockReset();
+
+    mocks.findByNodeId.mockResolvedValue(makeNode());
+    mocks.updateNode.mockResolvedValue(true);
+    mocks.deleteNode.mockResolvedValue(true);
+    mocks.countRetained.mockResolvedValue(0);
+    mocks.isConfigured.mockReturnValue(true);
+  });
+
+  test("propagates a typed Hetzner API failure and KEEPS the DB row (no orphaned server)", async () => {
+    mocks.deleteServer.mockRejectedValue(
+      new FakeHetznerCloudError("rate_limit_exceeded", "429 from Hetzner"),
+    );
+
+    await expect(drainDeprovision()).rejects.toMatchObject({
+      code: "rate_limit_exceeded",
+    });
+
+    // The delete failed → the node row must remain so a later drain retries.
+    expect(mocks.deleteServer).toHaveBeenCalledWith(HCLOUD_SERVER_ID);
+    expect(mocks.deleteNode).not.toHaveBeenCalled();
+  });
+
+  test("propagates a generic (non-typed) transport failure and KEEPS the DB row", async () => {
+    mocks.deleteServer.mockRejectedValue(new Error("ECONNRESET"));
+
+    await expect(drainDeprovision()).rejects.toThrow("ECONNRESET");
+
+    expect(mocks.deleteNode).not.toHaveBeenCalled();
+  });
+
+  test("treats an idempotent not_found as designed success and removes the DB row", async () => {
+    mocks.deleteServer.mockRejectedValue(
+      new FakeHetznerCloudError("not_found", "server already deleted"),
+    );
+
+    await expect(drainDeprovision()).resolves.toBeUndefined();
+
+    // 404 = already deprovisioned (desired end state) → the row is cleaned up,
+    // distinct from the failure paths above which retain it.
+    expect(mocks.deleteServer).toHaveBeenCalledWith(HCLOUD_SERVER_ID);
+    expect(mocks.deleteNode).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteNode).toHaveBeenCalledWith("db-1");
+  });
+
+  test("a clean delete removes the DB row (baseline distinct from failure)", async () => {
+    mocks.deleteServer.mockResolvedValue(undefined);
+
+    await expect(drainDeprovision()).resolves.toBeUndefined();
+
+    expect(mocks.deleteNode).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteNode).toHaveBeenCalledWith("db-1");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
@@ -372,6 +372,10 @@ export class NodeAutoscaler {
     try {
       await client.deleteServer(hcloudServerId);
     } catch (err) {
+      // error-policy:J6 idempotent teardown — a not_found means the server is
+      // already deprovisioned (the desired end state), so the DB row is safe to
+      // delete below. Every other outbound-API failure (auth/rate-limit/5xx)
+      // rethrows so a live server is never orphaned by a silently-dropped delete.
       if (err instanceof HetznerCloudError && err.code === "not_found") {
         logger.info("[autoscaler] Hetzner server already gone", {
           nodeId,

--- a/packages/cloud/shared/src/lib/services/containers/registry-probe.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/registry-probe.error-policy.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Error-policy pins for the ghcr registry probe (#13415).
+ *
+ * The probe feeds the fleet-upgrade reconciler and the post-provision metadata
+ * read; both treat null as "digest unknown → skip, retry next tick". Because
+ * the risky action (blue/green upgrade) is the thing that gets skipped, the
+ * probe fails SAFE to null on transport/5xx errors rather than throwing (a throw
+ * would abort an already-provisioned container or kill the reconciler loop).
+ * These tests prove that an INTERNAL failure still surfaces observably — it
+ * warns — and stays distinguishable from the designed-empty paths (bare image
+ * name, 404) which resolve to null WITHOUT a warning. Drives the real exported
+ * function with a mocked global fetch; no network.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { logger } from "../../utils/logger";
+import { clearRegistryProbeCache, resolveImageDigest } from "./registry-probe";
+
+const DIGEST = `sha256:${"a".repeat(64)}`;
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function headResponse(digest: string | null, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    headers: { get: (k: string) => (k === "docker-content-digest" ? digest : null) },
+  } as unknown as Response;
+}
+
+let warnSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  clearRegistryProbeCache();
+  warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  warnSpy.mockRestore();
+  clearRegistryProbeCache();
+});
+
+describe("resolveImageDigest — designed-empty stays distinct from internal failure", () => {
+  it("resolves a healthy ghcr tag to the manifest digest (real success path)", async () => {
+    globalThis.fetch = mock(async (url: string, init?: RequestInit) => {
+      if (url.includes("/token")) return jsonResponse({ token: "tok" });
+      expect(init?.method).toBe("HEAD");
+      return headResponse(DIGEST);
+    }) as unknown as typeof fetch;
+
+    const out = await resolveImageDigest("ghcr.io/elizaos/eliza:develop");
+    expect(out).toBe(DIGEST);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("designed-empty: a bare (non-ghcr) image name is null with NO fetch and NO warn", async () => {
+    const fetchMock = mock(async () => jsonResponse({}));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const out = await resolveImageDigest("eliza-agent:prod-good");
+    expect(out).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("designed-empty: a 404 manifest (tag absent) is null with NO warn", async () => {
+    globalThis.fetch = mock(async (url: string) => {
+      if (url.includes("/token")) return jsonResponse({ token: "tok" });
+      return headResponse(null, false, 404);
+    }) as unknown as typeof fetch;
+
+    const out = await resolveImageDigest("ghcr.io/elizaos/eliza:missing");
+    expect(out).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("INTERNAL failure: a token transport error fails safe to null but WARNS (observable)", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("ECONNRESET");
+    }) as unknown as typeof fetch;
+
+    const out = await resolveImageDigest("ghcr.io/elizaos/eliza:develop");
+    expect(out).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("ghcr token network error");
+  });
+
+  it("INTERNAL failure: a 500 from the token endpoint is null but WARNS", async () => {
+    globalThis.fetch = mock(async (url: string) => {
+      if (url.includes("/token")) return jsonResponse({}, false, 500);
+      return headResponse(DIGEST);
+    }) as unknown as typeof fetch;
+
+    const out = await resolveImageDigest("ghcr.io/elizaos/eliza:develop");
+    expect(out).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("ghcr token fetch failed");
+  });
+
+  it("INTERNAL failure: a manifest transport error (after a good token) is null but WARNS", async () => {
+    globalThis.fetch = mock(async (url: string) => {
+      if (url.includes("/token")) return jsonResponse({ token: "tok" });
+      throw new Error("socket hang up");
+    }) as unknown as typeof fetch;
+
+    const out = await resolveImageDigest("ghcr.io/elizaos/eliza:develop");
+    expect(out).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("ghcr manifest network error");
+  });
+
+  it("INTERNAL failure: a non-404 manifest error (503) is null but WARNS", async () => {
+    globalThis.fetch = mock(async (url: string) => {
+      if (url.includes("/token")) return jsonResponse({ token: "tok" });
+      return headResponse(null, false, 503);
+    }) as unknown as typeof fetch;
+
+    const out = await resolveImageDigest("ghcr.io/elizaos/eliza:develop");
+    expect(out).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("ghcr manifest fetch failed");
+  });
+
+  it("designed-success: a digest-pinned ref short-circuits to the digest with NO fetch/warn", async () => {
+    const fetchMock = mock(async () => jsonResponse({}));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const out = await resolveImageDigest(`ghcr.io/elizaos/eliza@${DIGEST}`);
+    expect(out).toBe(DIGEST);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/registry-probe.ts
+++ b/packages/cloud/shared/src/lib/services/containers/registry-probe.ts
@@ -126,6 +126,13 @@ async function fetchGhcrDigest(
     if (!tokenJson.token) return null;
     token = tokenJson.token;
   } catch (err) {
+    // error-policy:J7 best-effort ghcr probe for a retrying reconciler. This is
+    // an outbound-HTTP transport boundary whose only consumers (fleet-upgrade
+    // reconciler tick + post-provision metadata read) treat null as "digest
+    // unknown → skip, retry next tick"; a transport error must not abort an
+    // already-provisioned container or kill the reconciler loop. Surface it via
+    // warn (distinct from the silent designed-empty paths) and fail safe to null
+    // — the risky action (blue/green upgrade) is what gets skipped.
     logger.warn(
       `[registry-probe] ghcr token network error for ${repo}: ${err instanceof Error ? err.message : String(err)}`,
     );
@@ -159,6 +166,9 @@ async function fetchGhcrDigest(
     }
     return manifestResp.headers.get("docker-content-digest");
   } catch (err) {
+    // error-policy:J7 same best-effort reconciler-probe boundary as the token
+    // fetch above: a manifest-HEAD transport error surfaces via warn and fails
+    // safe to null so the caller skips + retries, never aborting provisioning.
     logger.warn(
       `[registry-probe] ghcr manifest network error for ${repo}:${tag}: ${err instanceof Error ? err.message : String(err)}`,
     );


### PR DESCRIPTION
## Slice 5 of #13415 — container-provisioning infra

Hetzner/DigitalOcean cloud-API clients, warm-pool, autoscaler, registry probe.

**Real fail-open bugs fixed:**
- `agent-warm-pool-creator.destroyPoolContainer` — `.catch(() => undefined)` swallowed a DB delete failure into a **phantom leaked pool row** that read as a successful destroy; now propagates to `WarmPoolManager` as a failed destroy (verified `deletePoolEntry` returns `false` on already-gone rows, so the idempotent path is unaffected).
- `hetzner-client` (client/registry/docker-stats), `hetzner-volumes`, `digitalocean-provider` — cloud-API catches that swallowed a failed create/delete/list into empty/null/success now propagate (a failed "list servers" must not read as "no servers"); designed-empty (real empty 200, idempotent delete no-op) stays distinct.
- `registry-probe` (J7 best-effort ghcr digest for a retrying reconciler — verified both callers treat null as "skip the risky upgrade, retry next tick"), `forwarded-database-url-guard` (J3 untrusted-header sanitize), warm-pool health probe (J4) annotated.

**Money guard honored** (provisioning-cost arithmetic untouched/flagged).
**Verification:** 114 new error-path tests pass (`--isolate`); existing containers suites 369 pass / 0 fail; biome clean; `audit:error-policy-ratchet` → "no new fallback-slop". Infra/security-sensitive — flagged for review, not solo-merge.