### PR TITLE
fix(#13422): migrate cloud-provisioning + CORS alias reads to readAliasedEnv

### DIFF
--- a/packages/app-core/src/api/server-cors.ts
+++ b/packages/app-core/src/api/server-cors.ts
@@ -25,7 +25,7 @@ export function buildCorsAllowedPorts(): Set<string> {
   const ports = new Set([
     String(resolveDesktopApiPort(process.env)),
     String(resolveUiPort(process.env)),
-    String(process.env.ELIZA_PORT ?? "2138"),
+    String(readAliasedEnv("ELIZA_PORT") ?? "2138"),
     String(readAliasedEnv("ELIZA_GATEWAY_PORT") ?? "18789"),
     String(readAliasedEnv("ELIZA_HOME_PORT") ?? "2142"),
   ]);

--- a/plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts
@@ -1,9 +1,11 @@
+import { readAliasedEnv } from "@elizaos/shared";
+
 function hasValue(value: string | undefined): boolean {
   return Boolean(value?.trim());
 }
 
 function hasCompatApiToken(): boolean {
-  return hasValue(process.env.ELIZA_API_TOKEN);
+  return hasValue(readAliasedEnv("ELIZA_API_TOKEN"));
 }
 
 function hasCloudApiKeyProvisioning(): boolean {
@@ -26,7 +28,7 @@ function hasCloudApiKeyProvisioning(): boolean {
  * cloud containers.
  */
 export function isCloudProvisionedContainer(): boolean {
-  const hasCloudFlag = process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  const hasCloudFlag = readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
 
   return (
     hasCloudFlag &&

--- a/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
@@ -20,6 +20,7 @@ import type {
   RegisterGatewayRelaySessionResponse,
 } from "../types/cloud";
 import type { CloudAuthService } from "./cloud-auth";
+import { readAliasedEnv } from "@elizaos/shared";
 
 const POLL_TIMEOUT_MS = 25_000;
 const REQUEST_TIMEOUT_MS = POLL_TIMEOUT_MS + 5_000;
@@ -63,7 +64,7 @@ function isCloudProvisionedRuntime(): boolean {
   if (typeof process === "undefined") {
     return false;
   }
-  return process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  return readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
 }
 
 function isNodeHost(): boolean {


### PR DESCRIPTION
Part of #13422 (agent-ready alias-read sweep).

Migrates four raw `process.env.<aliased-key>` reads of brand-alias-table keys to the alias-aware `readAliasedEnv`, following the established incremental-slice pattern of this issue (P6, app-core boot-critical, electrobun-shell, …). After this, a branded (`<PREFIX>_*`) deployment resolves these without the `syncBrandEnvToEliza` mirror mutation, canonical `ELIZA_*` still wins, and the empty-is-unset contract is honored (`readAliasedEnv` normalizes `""`→`undefined`).

**Reads migrated**
- `plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts` — `ELIZA_API_TOKEN`, `ELIZA_CLOUD_PROVISIONED`. (`ELIZAOS_CLOUD_ENABLED` / `ELIZAOS_CLOUD_API_KEY` left raw — **not** in the alias table, out of scope per the issue's "only migrate alias-table keys" rule.)
- `plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts` — `ELIZA_CLOUD_PROVISIONED`.
- `packages/app-core/src/api/server-cors.ts` — `ELIZA_PORT`, aligning line 28 with the adjacent already-migrated `ELIZA_GATEWAY_PORT` / `ELIZA_HOME_PORT` reads (file already imported `readAliasedEnv` and carries the `#13422` rationale comment — this was a missed read).

**Verification (local, fresh `develop` clone)**
- `audit:alias-read-guard` → pass (no new raw aliased reads; migrated reads removed).
- `plugins/plugin-elizacloud` typecheck → clean (exit 0).
- `plugins/plugin-elizacloud` test → **307 passed / 3 skipped**.
- Confirmed all four raw reads are gone; behavior preserved (canonical-wins + empty-is-unset).

Remaining alias reads for the sweep (STATE_DIR, PLATFORM, NAMESPACE, etc. across ~50 more production reads) continue in follow-up slices; the sync mutation stays until the read migration completes (per the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
