### PR TITLE
test(orchestrator): restore task-agent ACL test mocks broken by #13324

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/active-session-forward.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/active-session-forward.test.ts
@@ -42,6 +42,13 @@ function makeRuntime(
     ),
     getSetting: vi.fn((k: string) => settings[k]),
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    // The ACL (`requireTaskAgentAccess` → `resolveConnectorSource`) reads the
+    // room's connector source; a source-less room is genuine client-chat, which
+    // the default GUEST policy above permits. Without `getRoom` the lookup throws
+    // and fails closed (SOURCE_RESOLUTION_FAILED → denied), so every delivery
+    // case would wrongly drop. `reportError` backs the fail-closed path.
+    getRoom: vi.fn(async () => ({ id: "room-1" })),
+    reportError: vi.fn(),
   } as never;
 }
 

--- a/plugins/plugin-agent-orchestrator/src/test-utils/action-test-utils.ts
+++ b/plugins/plugin-agent-orchestrator/src/test-utils/action-test-utils.ts
@@ -71,11 +71,20 @@ export function serviceMock(overrides: Record<string, unknown> = {}) {
 
 export function runtimeWith(service?: unknown): IAgentRuntime {
   return {
+    agentId: "agent1",
     getService: vi.fn(() => service ?? null),
     // tasks.ts validate() requires hasService — mirror getService's truthiness
     // so tests built with `runtimeWith(serviceMock())` see ACP as available.
     hasService: vi.fn(() => Boolean(service)),
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    // The task-agent ACL (`requireTaskAgentAccess` → `resolveConnectorSource`)
+    // reads the room's connector source; a source-less room is genuine
+    // client-chat, which the default GUEST policy permits. Without `getRoom` the
+    // lookup throws and fails closed (SOURCE_RESOLUTION_FAILED → denied), so
+    // every create/interact action test would wrongly deny. `reportError` backs
+    // that fail-closed path. Denial cases override the source/policy explicitly.
+    getRoom: vi.fn(async () => ({ id: "room1" })),
+    reportError: vi.fn(),
   } as never;
 }
 


### PR DESCRIPTION
## Problem
#13324 added the task-agent ACL (`requireTaskAgentAccess` → `resolveConnectorSource`) to the active-session forward handler and the create/interact/control/provision/history actions, but did not update the test mocks. `resolveConnectorSource` calls `runtime.getRoom(roomId)` (to resolve the connector source) and `runtime.reportError(...)` on its fail-closed branch — neither of which the stale mocks provided. So on develop the call throws → returns `SOURCE_RESOLUTION_FAILED` → the ACL denies → the handler never calls `acp.sendPrompt` and the action handlers never reach their work. **Result: a cluster of orchestrator unit tests fail on develop** (surfaced while verifying an unrelated change).

## Fix (test-support only, +16 lines)
Give the two mock builders a source-less room (genuine client-chat, which the default GUEST policy permits) + `reportError`:
- `active-session-forward.test.ts` `makeRuntime` → **13/13 pass** (7 were failing: deliver/queue/interrupt/flush/requeue/thread-match).
- `src/test-utils/action-test-utils.ts` `runtimeWith` shared helper → restores **provision-workspace** (4) + **task-control-structural** (3), and unblocks the ACL path for the other action tests. Verified a denial case still denies (denial tests override source/policy explicitly).

## Verification
`bunx vitest run active-session-forward + provision-workspace + task-control-structural` → **20/20 pass**. Baseline-checked: the change breaks nothing (create-task's 2 failures pre-exist on clean develop, independent of this change).

## Scope
The #13324 ACL stale-mock regression only. Other pre-existing orchestrator unit failures (create-task nyx-options, task-history filters, subagent-stdout-log NDJSON, control-resume durable-flag, orchestrator-task-service status-guards) have **separate causes** and are left for their own fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)