### PR TITLE
fix(search): match typo terms in message search

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -1,0 +1,46 @@
+/**
+ * In-memory message search ranker parity checks for adapters without SQL.
+ * These tests pin the same typo/substring behavior the SQL adapter exposes via
+ * full-text search plus pg_trgm so fallback stores do not silently regress.
+ */
+
+import { describe, expect, it } from "vitest";
+import { rankMessageSearch } from "./search.ts";
+
+describe("rankMessageSearch", () => {
+	it("matches a typo by trigram similarity, not only exact substrings", () => {
+		const hits = rankMessageSearch(
+			[
+				{
+					id: "a",
+					createdAt: 1,
+					content: { text: "how do I edit the configuration file" },
+				},
+				{
+					id: "b",
+					createdAt: 2,
+					content: { text: "unrelated deployment notes" },
+				},
+			],
+			"configuraton",
+		);
+
+		expect(hits.map((hit) => hit.item.id)).toEqual(["a"]);
+		expect(hits[0].ftsRank).toBe(0);
+		expect(hits[0].trigramSimilarity).toBeGreaterThanOrEqual(0.45);
+	});
+
+	it("does not admit unrelated text through the trigram branch", () => {
+		const hits = rankMessageSearch(
+			[
+				{
+					id: "a",
+					content: { text: "how do I edit the configuration file" },
+				},
+			],
+			"zzzzzzzz",
+		);
+
+		expect(hits).toEqual([]);
+	});
+});

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1897,6 +1897,27 @@ function trigramSetSimilarity(a: Set<string>, b: Set<string>): number {
 	return shared / (a.size + b.size - shared);
 }
 
+const MESSAGE_SEARCH_TRIGRAM_THRESHOLD = 0.45;
+
+function messageSearchTokens(text: string): string[] {
+	return text.split(/[^\p{L}\p{N}_:/.-]+/u).filter((t) => t.length > 0);
+}
+
+function termTrigramSimilarity(queryTerms: string[], document: string): number {
+	const documentTokens = messageSearchTokens(document);
+	let best = 0;
+	for (const queryTerm of queryTerms) {
+		const queryGrams = toTrigramSet(queryTerm);
+		for (const documentToken of documentTokens) {
+			best = Math.max(
+				best,
+				trigramSetSimilarity(queryGrams, toTrigramSet(documentToken)),
+			);
+		}
+	}
+	return best;
+}
+
 /** A message-shaped record the in-memory search ranker can score and order. */
 export interface SearchableMessage {
 	content: { text?: unknown; attachments?: unknown };
@@ -1931,15 +1952,21 @@ export function rankMessageSearch<T extends SearchableMessage>(
 		const doc = foldForSearch(messageSearchDocument(item.content));
 		const allTermsPresent = queryTerms.every((t) => doc.includes(t));
 		const phraseSubstring = doc.includes(foldedQuery);
-		if (!allTermsPresent && !phraseSubstring) continue;
 		const docLen = Math.max(doc.length, 1);
 		const ftsRank = allTermsPresent
 			? queryTerms.reduce((acc, t) => acc + occurrences(doc, t) / docLen, 0)
 			: 0;
-		const trigramSimilarity = trigramSetSimilarity(
-			queryTrigrams,
-			toTrigramSet(doc),
+		const trigramSimilarity = Math.max(
+			trigramSetSimilarity(queryTrigrams, toTrigramSet(doc)),
+			termTrigramSimilarity(queryTerms, doc),
 		);
+		if (
+			!allTermsPresent &&
+			!phraseSubstring &&
+			trigramSimilarity < MESSAGE_SEARCH_TRIGRAM_THRESHOLD
+		) {
+			continue;
+		}
 		hits.push({ item, ftsRank, trigramSimilarity });
 	}
 

--- a/plugins/plugin-sql/src/__tests__/integration/message-search-fts.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/message-search-fts.test.ts
@@ -26,11 +26,11 @@ const RECALL_CORPUS = Number(process.env.MESSAGE_SEARCH_RECALL_CORPUS ?? 3_000);
 
 describe("searchMessages FTS + trigram (real DB)", () => {
   let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
-  let runtime: Awaited<ReturnType<typeof createIsolatedTestDatabase>>["runtime"];
   let cleanup: () => Promise<void>;
   let agentId: UUID;
   let entityId: UUID;
   let worldId: UUID;
+  let trigramAvailable = false;
   const roomA = v4() as UUID;
   const roomB = v4() as UUID;
   let seq = 0;
@@ -61,7 +61,7 @@ describe("searchMessages FTS + trigram (real DB)", () => {
   };
 
   const searchTexts = async (query: string, room: UUID = roomA) => {
-    const hits = await runtime.searchMessages({
+    const hits = await adapter.searchMessages({
       roomIds: [room],
       query,
       tableName: "messages",
@@ -73,9 +73,18 @@ describe("searchMessages FTS + trigram (real DB)", () => {
   beforeAll(async () => {
     const s = await createIsolatedTestDatabase("message_search_fts");
     adapter = s.adapter;
-    runtime = s.runtime;
     cleanup = s.cleanup;
     agentId = s.testAgentId;
+    try {
+      await (adapter.getDatabase() as DrizzleDatabase).execute(
+        sql`SELECT similarity('configuration', 'configuraton')`
+      );
+      trigramAvailable = true;
+    } catch {
+      // error-policy:J3 extension probing intentionally treats unsupported
+      // `pg_trgm` as absent in the PGlite harness.
+      trigramAvailable = false;
+    }
 
     worldId = v4() as UUID;
     await adapter.createWorld({
@@ -152,6 +161,11 @@ describe("searchMessages FTS + trigram (real DB)", () => {
     expect((await searchTexts("config")).some((t) => t.includes("configuration"))).toBe(true);
   });
 
+  it("4b. typo word (trigram) — 'configuraton' matches 'configuration'", async () => {
+    if (!trigramAvailable) return;
+    expect((await searchTexts("configuraton")).some((t) => t.includes("configuration"))).toBe(true);
+  });
+
   it("5. stemming — 'configure' matches 'configuring'", async () => {
     expect((await searchTexts("configure")).some((t) => t.includes("configuring"))).toBe(true);
   });
@@ -184,7 +198,7 @@ describe("searchMessages FTS + trigram (real DB)", () => {
   });
 
   it("11. near-duplicates all returned, deterministically ordered by recency then id", async () => {
-    const hits = await runtime.searchMessages({
+    const hits = await adapter.searchMessages({
       roomIds: [roomA],
       query: "zephyr",
       tableName: "messages",
@@ -198,7 +212,7 @@ describe("searchMessages FTS + trigram (real DB)", () => {
     const t1 = dups[1].memory.createdAt ?? 0;
     expect(t0).toBeGreaterThanOrEqual(t1);
     // Re-running the same query yields the identical order.
-    const hits2 = await runtime.searchMessages({
+    const hits2 = await adapter.searchMessages({
       roomIds: [roomA],
       query: "zephyr",
       tableName: "messages",
@@ -216,7 +230,7 @@ describe("searchMessages FTS + trigram (real DB)", () => {
   });
 
   it("13. role attribution surfaces via entityId (assistant vs user)", async () => {
-    const hits = await runtime.searchMessages({
+    const hits = await adapter.searchMessages({
       roomIds: [roomA],
       query: "configuring",
       tableName: "messages",
@@ -302,7 +316,7 @@ describe("searchMessages FTS + trigram (real DB)", () => {
       await db.insert(memoryTable).values(rows.slice(start, start + 2000) as never);
     }
     const started = Date.now();
-    const hits = await runtime.searchMessages({
+    const hits = await adapter.searchMessages({
       roomIds: [roomB],
       query: needle,
       tableName: "messages",
@@ -317,7 +331,7 @@ describe("searchMessages FTS + trigram (real DB)", () => {
   }, 120_000);
 
   it("18. empty room set short-circuits to no rows without a query", async () => {
-    const hits = await runtime.searchMessages({
+    const hits = await adapter.searchMessages({
       roomIds: [],
       query: "anything",
       tableName: "messages",

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -1718,14 +1718,15 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       // `similarity()` only exists when pg_trgm is installed; degrade to 0 so the
       // ORDER BY and DTO carry a real (extension-absent) signal, not a fake rank.
       const trigramExpr = trigramAvailable
-        ? sql<number>`similarity(${document}, ${foldedQuery})`
+        ? sql<number>`GREATEST(similarity(${document}, ${foldedQuery}), word_similarity(${foldedQuery}, ${document}))`
         : sql<number>`0`;
+      const trigramMatch = trigramAvailable ? sql`${trigramExpr} >= 0.45` : sql`FALSE`;
 
       const conditions = [
         eq(memoryTable.type, tableName),
         eq(memoryTable.agentId, this.agentId),
         inArray(memoryTable.roomId, params.roomIds),
-        sql`(${tsvector} @@ ${tsquery} OR ${document} LIKE eliza_search_like_pattern(${params.query}))`,
+        sql`(${tsvector} @@ ${tsquery} OR ${document} LIKE eliza_search_like_pattern(${params.query}) OR ${trigramMatch})`,
       ];
 
       const rows = await this.db


### PR DESCRIPTION
## Summary
- follow-up to #13880: include token-level trigram matching in the SQL and in-memory message search paths so typo queries like `configuraton` can match `configuration`
- align the plugin-sql integration harness with its stated adapter boundary by calling `adapter.searchMessages` directly
- add a core ranker regression for fuzzy typo admission and unrelated-query rejection

## Verification
- `bun test ./packages/core/src/search.test.ts`
- `bunx @biomejs/biome check packages/core/src/search.ts packages/core/src/search.test.ts plugins/plugin-sql/src/base.ts plugins/plugin-sql/src/__tests__/integration/message-search-fts.test.ts && git diff --check`
- `timeout 45s bun test ./plugins/plugin-sql/src/__tests__/integration/message-search-fts.test.ts` reports all 19 test cases passing, then times out while the Bun runner sits in coverage output after assertions complete. Local PGlite logs `pg_trgm unavailable`, so the typo-trigram assertion is gated to run only when the extension is available.

## Evidence
- N/A app screenshots/video: backend search behavior only.
- N/A live LLM trajectories: no prompt/action/model behavior change.