### PR TITLE
fix: make ui determinism baseline line-stable

### DIFF
--- a/packages/scripts/audit-ui-determinism.mjs
+++ b/packages/scripts/audit-ui-determinism.mjs
@@ -285,6 +285,37 @@ function scanFile(file, sourceText) {
   return findings;
 }
 
+function occurrenceKind(occurrence) {
+  const match = /^L\d+\s+(.+)$/.exec(occurrence);
+  return match?.[1] ?? occurrence;
+}
+
+function countByKind(occurrences) {
+  const counts = new Map();
+  for (const occurrence of occurrences) {
+    const kind = occurrenceKind(occurrence);
+    counts.set(kind, (counts.get(kind) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function regressionsForFile(currentOccurrences, baselineOccurrences) {
+  const allowedCounts = countByKind(baselineOccurrences);
+  const seenCounts = new Map();
+  const fresh = [];
+
+  for (const occurrence of currentOccurrences) {
+    const kind = occurrenceKind(occurrence);
+    const seen = (seenCounts.get(kind) ?? 0) + 1;
+    seenCounts.set(kind, seen);
+    if (seen > (allowedCounts.get(kind) ?? 0)) {
+      fresh.push(occurrence);
+    }
+  }
+
+  return fresh;
+}
+
 // ---------------------------------------------------------------------------
 // self-test
 // ---------------------------------------------------------------------------
@@ -377,6 +408,32 @@ function runSelfTest() {
       console.log(`OK ${label}`);
     }
   }
+  const driftOnly = regressionsForFile(
+    ["L42 Date.now()", "L99 toLocaleString() [no locale]"],
+    ["L12 Date.now()", "L16 toLocaleString() [no locale]"],
+  );
+  if (driftOnly.length) {
+    failed++;
+    console.error(
+      `FAIL baseline line drift: expected no regression, got ${JSON.stringify(driftOnly)}`,
+    );
+  } else {
+    console.log("OK baseline line drift");
+  }
+
+  const extraOccurrence = regressionsForFile(
+    ["L42 Date.now()", "L99 Date.now()"],
+    ["L12 Date.now()"],
+  );
+  if (JSON.stringify(extraOccurrence) !== JSON.stringify(["L99 Date.now()"])) {
+    failed++;
+    console.error(
+      `FAIL baseline extra occurrence: expected one new occurrence, got ${JSON.stringify(extraOccurrence)}`,
+    );
+  } else {
+    console.log("OK baseline extra occurrence");
+  }
+
   if (failed) {
     console.error(`\nself-test FAILED (${failed})`);
     process.exit(1);
@@ -442,9 +499,7 @@ function main() {
   const regressions = {};
   let regressionCount = 0;
   for (const [file, occ] of Object.entries(renderTime)) {
-    const allowed = new Set(baseline[file] || []);
-    const now = new Set(occ);
-    const fresh = [...now].filter((o) => !allowed.has(o));
+    const fresh = regressionsForFile(occ, baseline[file] || []);
     if (fresh.length) {
       regressions[file] = fresh;
       regressionCount += fresh.length;

--- a/packages/ui/src/components/pages/TriggerForm.tsx
+++ b/packages/ui/src/components/pages/TriggerForm.tsx
@@ -1211,8 +1211,17 @@ function SchedulePreview({
   form: TriggerFormState;
   t: TranslateFn;
 }) {
+  const [previewNow, setPreviewNow] = useState<Date | null>(null);
+
+  useEffect(() => {
+    setPreviewNow(new Date());
+    const id = window.setInterval(() => setPreviewNow(new Date()), 60_000);
+    return () => window.clearInterval(id);
+  }, []);
+
   const preview = useMemo(() => {
-    const now = new Date();
+    if (!previewNow) return null;
+    const now = previewNow;
 
     if (form.triggerType === "interval") {
       const value = Number(form.durationValue);
@@ -1258,6 +1267,7 @@ function SchedulePreview({
     form.scheduledAtIso,
     form.cronExpression,
     form.eventKind,
+    previewNow,
     t,
   ]);
 


### PR DESCRIPTION
## Summary

Fixes #13840 by making the UI determinism audit compare baseline entries by finding kind and occurrence count instead of exact line-number strings. Line numbers remain in the baseline output as review context, but nearby code motion no longer creates false regressions.

Also removes the real current regression in `TriggerForm` by moving the schedule preview clock into a client effect, so the audit passes without expanding the baseline.

This overlaps with #13850, but that PR records `TriggerForm` as baseline backlog. This PR keeps the baseline unchanged and fixes the live render-time `new Date()` occurrence instead.

## Verification

- `node packages/scripts/audit-ui-determinism.mjs --self-test`
- `node packages/scripts/audit-ui-determinism.mjs --json` -> `regressionCount: 0`
- `bunx @biomejs/biome check packages/scripts/audit-ui-determinism.mjs packages/ui/src/components/pages/TriggerForm.tsx`
- `git diff --check`

## Visual audit

- `bun run --cwd packages/app audit:app` attempted three times. It built plugin view bundles but failed before Playwright capture in `@elizaos/core` declaration generation because the local/temp dependency layout resolves several packages through root `dist/node_modules`, then after link repair still fails on `fs-extra` and `markdown-it` declaration resolution. No UI audit verdict was produced.