### PR TITLE
fix(orchestrator): update bound repo for same workdir

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
@@ -207,6 +207,41 @@ describe("durable task→workdir binding (#13776)", () => {
     }
   });
 
+  it("updates a stale repo binding when the explicit workdir stays the same", async () => {
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const acp = makeWorkdirCapturingAcp();
+    const service = new OrchestratorTaskService(makeRuntime(acp.service), {
+      store,
+    });
+    await service.start();
+    try {
+      const taskId = await seedTask(store);
+
+      await service.spawnAgentForTask(taskId, {
+        workdir: firstDir,
+        repo: "https://example.com/repo-a.git",
+      });
+      expect((await service.getTask(taskId))?.latestRepo).toBe(
+        "https://example.com/repo-a.git",
+      );
+
+      const detail = await service.spawnAgentForTask(taskId, {
+        workdir: firstDir,
+        repo: "https://example.com/repo-b.git",
+      });
+
+      expect(acp.spawns.at(1)?.workdir).toBe(firstDir);
+      expect(detail?.latestWorkdir).toBe(firstDir);
+      expect(detail?.latestRepo).toBe("https://example.com/repo-b.git");
+
+      const record = await store.getTask(taskId);
+      expect(record?.task.boundWorkdir).toBe(firstDir);
+      expect(record?.task.boundRepo).toBe("https://example.com/repo-b.git");
+    } finally {
+      await service.stop().catch(() => undefined);
+    }
+  });
+
   it("clears the old repo binding when an explicit workdir override omits repo", async () => {
     const store = new OrchestratorTaskStore({ backend: "memory" });
     const acp = makeWorkdirCapturingAcp();

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
@@ -176,6 +176,50 @@ describe("durable task→workdir binding (#13776)", () => {
     }
   });
 
+  it("does not let a stale same-workdir bind overwrite the first repo binding", async () => {
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const acp = makeWorkdirCapturingAcp();
+    const service = new OrchestratorTaskService(makeRuntime(acp.service), {
+      store,
+    });
+    await service.start();
+    try {
+      const taskId = await seedTask(store);
+      const stale = (await store.getTask(taskId))?.task;
+      expect(stale).toBeTruthy();
+      if (!stale) throw new Error("seeded task was not persisted");
+      const bindTaskWorkdir = (
+        service as unknown as {
+          bindTaskWorkdir: (
+            taskId: string,
+            current: typeof stale,
+            workdir: string,
+            repo: string | undefined,
+          ) => Promise<void>;
+        }
+      ).bindTaskWorkdir.bind(service);
+
+      await bindTaskWorkdir(
+        taskId,
+        stale,
+        firstDir,
+        "https://example.com/repo-a.git",
+      );
+      await bindTaskWorkdir(
+        taskId,
+        stale,
+        firstDir,
+        "https://example.com/repo-b.git",
+      );
+
+      const record = await store.getTask(taskId);
+      expect(record?.task.boundWorkdir).toBe(firstDir);
+      expect(record?.task.boundRepo).toBe("https://example.com/repo-a.git");
+    } finally {
+      await service.stop().catch(() => undefined);
+    }
+  });
+
   it("lets an explicit override win and re-pins the binding (surfaced on the task DTO)", async () => {
     const store = new OrchestratorTaskStore({ backend: "memory" });
     const acp = makeWorkdirCapturingAcp();

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -3419,15 +3419,23 @@ export class OrchestratorTaskService extends Service {
   ): Promise<void> {
     if (!workdir) return;
     const previous =
-      this.taskWorkdirBindQueues.get(taskId)?.catch(() => undefined) ??
-      Promise.resolve();
+      this.taskWorkdirBindQueues.get(taskId)?.catch(
+        // error-policy:J5 bind queue promises are awaited by the originating
+        // bind call; the continuation must still run so one failed bind does
+        // not permanently block later corrections.
+        () => undefined,
+      ) ?? Promise.resolve();
+    const canSetRepo = (latest: OrchestratorTaskRecord) =>
+      !latest.boundWorkdir ||
+      latest.boundWorkdir === workdir ||
+      opts.allowRebind === true;
     const next = previous.then(async () => {
       const latest = (await this.store.getTask(taskId))?.task ?? current;
       const canSetWorkdir = !latest.boundWorkdir || opts.allowRebind === true;
       const patch: Partial<OrchestratorTaskRecord> = {};
       const workdirChanged = latest.boundWorkdir !== workdir;
       if (canSetWorkdir && workdirChanged) patch.boundWorkdir = workdir;
-      if (canSetWorkdir && repo && latest.boundRepo !== repo) {
+      if (canSetRepo(latest) && repo && latest.boundRepo !== repo) {
         patch.boundRepo = repo;
       } else if (canSetWorkdir && workdirChanged && latest.boundRepo) {
         patch.boundRepo = null;

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -3427,7 +3427,7 @@ export class OrchestratorTaskService extends Service {
       ) ?? Promise.resolve();
     const canSetRepo = (latest: OrchestratorTaskRecord) =>
       !latest.boundWorkdir ||
-      latest.boundWorkdir === workdir ||
+      (latest.boundWorkdir === workdir && current.boundWorkdir === workdir) ||
       opts.allowRebind === true;
     const next = previous.then(async () => {
       const latest = (await this.store.getTask(taskId))?.task ?? current;


### PR DESCRIPTION
## Summary
- fix-forward for merged #13920: allow durable `boundRepo` to update when an explicit spawn keeps the already-bound workdir but supplies a corrected repo
- keep the existing workdir rebind guard intact so stale first-spawn binds cannot overwrite an earlier successful binding
- add the required error-policy annotation for the bind queue continuation catch
- add a regression test that proves same-workdir repo correction is reflected in the task DTO and persisted record

## Verification
- `bun test plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts` (6 pass, 26 expectations)
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts && git diff --check`

## Evidence
- Durable task artifact is asserted in the focused test: `boundWorkdir` remains the same and `boundRepo` changes from repo-a to repo-b.
- N/A app screenshots/video: service-layer durable binding behavior only.
- N/A live LLM trajectory: no planner/prompt/model behavior change.