### PR TITLE
fix: normalize task project list filter

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-store-project-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-store-project-binding.test.ts
@@ -44,7 +44,9 @@ describe("task store project binding (real PGlite)", () => {
     await db.close();
   });
 
-  it("adds project_id via idempotent migration and keeps old rows readable", { timeout: PGLITE_TIMEOUT }, async () => {
+  it("adds project_id via idempotent migration and keeps old rows readable", {
+    timeout: PGLITE_TIMEOUT,
+  }, async () => {
     // Pre-create the table in its PRE-project_id shape and insert a legacy row,
     // exactly as an installed runtime that predates this change would have it.
     await db.query(`CREATE TABLE orchestrator_tasks (
@@ -119,7 +121,9 @@ describe("task store project binding (real PGlite)", () => {
     await expect(store2.getTask("legacy-1")).resolves.not.toBeNull();
   });
 
-  it("persists project_id and filters listTasks by projectId", { timeout: PGLITE_TIMEOUT }, async () => {
+  it("persists project_id and filters listTasks by projectId", {
+    timeout: PGLITE_TIMEOUT,
+  }, async () => {
     const store = new RuntimeDbTaskStore(pgliteAdapter(db));
     await store.createTask({
       title: "task in project A",
@@ -136,6 +140,9 @@ describe("task store project binding (real PGlite)", () => {
     const inA = await store.listTasks({ projectId: "proj-A" });
     expect(inA.map((t) => t.title)).toEqual(["task in project A"]);
     expect(inA[0]?.projectId).toBe("proj-A");
+
+    const trimmedA = await store.listTasks({ projectId: "  proj-A  " });
+    expect(trimmedA.map((t) => t.title)).toEqual(["task in project A"]);
 
     const inB = await store.listTasks({ projectId: "proj-B" });
     expect(inB.map((t) => t.title)).toEqual(["task in project B"]);

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -976,17 +976,14 @@ export class RuntimeDbTaskStore {
       clauses.push("status = ?");
       params.push(filter.status);
     }
-    if (filter.projectId) {
+    const projectId = filter.projectId?.trim();
+    if (projectId) {
       clauses.push("project_id = ?");
-      params.push(filter.projectId);
+      params.push(projectId);
     }
     if (filter.search?.trim()) {
       clauses.push("search_text LIKE ?");
       params.push(`%${filter.search.trim().toLowerCase()}%`);
-    }
-    if (filter.projectId?.trim()) {
-      clauses.push("project_id = ?");
-      params.push(filter.projectId.trim());
     }
     const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
     const limit =


### PR DESCRIPTION
## Summary

Fixes a residual from #13776: `RuntimeDbTaskStore.listTasks` emitted `project_id = ?` twice when `filter.projectId` was present because it handled the raw value and then the trimmed value.

The store now trims once, emits a single indexed predicate, and ignores whitespace-only project filters. The real PGlite project-binding test now covers a whitespace-padded `projectId` query so this does not regress.

## Verification

- `bun run --cwd plugins/plugin-agent-orchestrator test src/__tests__/task-store-project-binding.test.ts --run`
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts plugins/plugin-agent-orchestrator/src/__tests__/task-store-project-binding.test.ts`
- `git diff --check`

No UI/model behavior changed; screenshots/video/live trajectory are N/A.