### PR TITLE
fix(orchestrator): scratch GC must not delete user dirs outside the ACP root (#13773 regression)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-gc.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-gc.test.ts
@@ -265,6 +265,29 @@ describe("startup GC reclaims orphaned scratch dirs", () => {
     expect(await exists(freshDir)).toBe(true);
   });
 
+  it("keeps an untracked stale task-* dir under a user-configured coding root (#13773 data-loss guard)", async () => {
+    const store = new InMemorySessionStore();
+    // A real user project that merely happens to be named `task-*`, under a
+    // user-configured coding root (ELIZA_CODING_DIRECTORY) — NOT the ACP scratch
+    // root. It is untracked and stale, but it is not ACP's to delete. Before the
+    // ownership guard the GC scanned this root and rm -rf'd it (data loss).
+    const userRoot = join(TEST_TMPDIR, "user-code");
+    const userProject = join(userRoot, "task-manager");
+    await makeDir(userProject);
+    await backdate(userProject, 25 * 60 * 60_000); // 25h — past the age gate
+
+    // Control: a same-shape orphan under the ACP-exclusive root IS reclaimed.
+    const acpOrphan = join(ROOT, "task-orphan-under-acp-root");
+    await makeDir(acpOrphan);
+    await backdate(acpOrphan, 25 * 60 * 60_000);
+
+    const service = makeService(store, { ELIZA_CODING_DIRECTORY: userRoot });
+    await gc(service);
+
+    expect(await exists(userProject)).toBe(true); // preserved — not ACP-owned
+    expect(await exists(acpOrphan)).toBe(false); // reclaimed — under ACP root
+  });
+
   it("honors ELIZA_ACP_SCRATCH_GC_MAX_AGE_MS for the untracked age gate", async () => {
     const store = new InMemorySessionStore();
     const dir = join(ROOT, "task-orphan-config");

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -738,6 +738,13 @@ export class AcpService extends Service {
     let reclaimed = 0;
     let kept = 0;
     for (const root of this.configuredScratchRoots()) {
+      // Only the ACP-exclusive scratch root (DEFAULT_WORKDIR_ROOT) is owned
+      // solely by AcpService, so an UNTRACKED `task-*` dir there is unambiguously
+      // orphaned ACP work. The other configured roots are real user coding/
+      // workspace dirs (ELIZA_CODING_DIRECTORY, ELIZA_WORKSPACE_DIR, …) that may
+      // legitimately contain a `task-*` directory (e.g. a `task-manager` project),
+      // so untracked dirs there must never be deleted (#13773 data-loss guard).
+      const isAcpOwnedRoot = resolve(root) === resolve(DEFAULT_WORKDIR_ROOT);
       let entries: string[];
       try {
         entries = await readdir(root);
@@ -759,10 +766,16 @@ export class AcpService extends Service {
             kept++;
             return;
           }
-          // No owning session in THIS store: the dir may belong to a co-tenant
-          // AcpService sharing this tmp root, so gate removal on age. A dir whose
-          // session is terminal here is unambiguously ours → reclaim regardless.
+          // No owning session in THIS store. Under a user-configured root an
+          // untracked `task-*` dir is not ours (it could be a real user project)
+          // → never reclaim it. Only under the ACP-exclusive root is it orphaned
+          // ACP work; there it may belong to a co-tenant AcpService sharing the
+          // tmp root, so gate removal on age.
           if (!session) {
+            if (!isAcpOwnedRoot) {
+              kept++;
+              return;
+            }
             try {
               const st = await stat(path);
               if (now - st.mtimeMs <= maxAgeMs) {


### PR DESCRIPTION
## Data-loss regression (from #13895 / #13773) — fix

**#13895** widened the startup scratch GC (`cleanOrphanedScratchWorkdirs`) from the ACP-exclusive `DEFAULT_WORKDIR_ROOT` (`$TMPDIR/eliza-acp`) to **every** `configuredScratchRoots()` entry — which includes the user-configurable coding/workspace roots `ELIZA_CODING_DIRECTORY`, `ELIZA_WORKSPACE_DIR`, `ELIZA_CODING_WORKSPACE`, `ACPX_DEFAULT_CWD`. In the untracked-dir branch (`if (!session)`) the GC then `rm -rf`s **any** subdirectory whose name merely starts with `task-` and is >24h old, with **no ownership check**.

**Failure scenario:** operator sets `ELIZA_CODING_DIRECTORY=/home/user/code`; the user has `/home/user/code/task-manager` (a real project) that isn't a tracked ACP session and is >24h old. On the next orchestrator startup, `gcOrphanedScratchDirs()` iterates the configured roots, finds `task-manager` (starts with `task-`), sees no owning session, passes the age gate, and `rm('/home/user/code/task-manager', {recursive:true,force:true})` — **the user's project is destroyed.** Before #13895 the GC only touched `$TMPDIR/eliza-acp`, so this was impossible. It also violates #13773's own stated guard ("only under the ACP root, only isolate=true, never process.cwd()").

## Fix
Gate the untracked-dir reclaim on ACP-root ownership (`resolve(root) === resolve(DEFAULT_WORKDIR_ROOT)`): an untracked `task-*` dir is only orphaned ACP work under the ACP-exclusive root (owned solely by AcpService / co-tenant ACP services sharing the tmp root). Under a user-configured root an untracked `task-*` dir is **not** ours → kept. Tracked-**terminal** sessions (unambiguously ACP-created) are still reclaimed under any root, so real orphan cleanup is unaffected.

## Verification
`bunx vitest run acp-scratch-gc.test.ts` → **12/12 pass**, including a new case: an untracked stale `task-*` under `ELIZA_CODING_DIRECTORY` **survives** GC while a same-shape orphan under the ACP root is reclaimed. **Mutation-checked:** reverting the src guard makes the new test fail (the user project gets deleted).

Found via a ground-truth verification sweep of merged PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)