### PR TITLE
fix(orchestrator): scratch GC must never reclaim human-named task-* dirs or non-isolated workdirs

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-scratch-lifecycle.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-scratch-lifecycle.test.ts
@@ -130,17 +130,25 @@ describe("ACP scratch workspace lifecycle", () => {
     });
     const shim = service as unknown as ScratchLifecycleShim;
     const humanRepo = join(root, "task-master");
+    const untrackedUuidNamedRepo = join(
+      root,
+      "task-dddddddd-5555-4666-8777-eeeeeeeeeeee",
+    );
     const nonIsolatedId = "aaaaaaaa-1111-4222-8333-bbbbbbbbbbbb";
     const nonIsolatedRepo = join(root, `task-${nonIsolatedId}`);
     const ownedId = "cccccccc-4444-4555-8666-dddddddddddd";
     const ownedScratch = join(root, `task-${ownedId}`);
     await Promise.all([
       mkdir(humanRepo, { recursive: true }),
+      mkdir(untrackedUuidNamedRepo, { recursive: true }),
       mkdir(nonIsolatedRepo, { recursive: true }),
       mkdir(ownedScratch, { recursive: true }),
     ]);
     const oldDate = new Date(Date.now() - 48 * 60 * 60_000);
-    await utimes(humanRepo, oldDate, oldDate);
+    await Promise.all([
+      utimes(humanRepo, oldDate, oldDate),
+      utimes(untrackedUuidNamedRepo, oldDate, oldDate),
+    ]);
     const nonIsolated = makeSession(nonIsolatedId, nonIsolatedRepo, {
       isolatedWorkdir: false,
     });
@@ -157,6 +165,8 @@ describe("ACP scratch workspace lifecycle", () => {
 
     // Human-named repo: filtered out by the UUID-shape match despite age.
     expect(existsSync(humanRepo)).toBe(true);
+    // UUID-shaped but untracked under a user root: name alone is not ownership.
+    expect(existsSync(untrackedUuidNamedRepo)).toBe(true);
     // Terminal but NOT isolation-owned: the ownership gate keeps it.
     expect(existsSync(nonIsolatedRepo)).toBe(true);
     // Terminal AND isolation-owned: reclaimed regardless of age.

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-scratch-lifecycle.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-scratch-lifecycle.test.ts
@@ -85,9 +85,12 @@ describe("ACP scratch workspace lifecycle", () => {
       },
     );
     const shim = service as unknown as ScratchLifecycleShim;
-    const oldOrphan = join(root, "task-old-orphan");
-    const tracked = join(root, "task-tracked");
-    const fresh = join(root, "task-fresh");
+    // Real scratch dirs are always `task-<randomUUID()>`; only that shape may
+    // ever be reclaimed.
+    const trackedId = "11111111-2222-4333-8444-555555555555";
+    const oldOrphan = join(root, "task-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee");
+    const tracked = join(root, `task-${trackedId}`);
+    const fresh = join(root, "task-99999999-8888-4777-8666-555555555544");
     const manual = join(root, "manual-old");
     await Promise.all([
       mkdir(oldOrphan, { recursive: true }),
@@ -101,7 +104,7 @@ describe("ACP scratch workspace lifecycle", () => {
       utimes(manual, oldDate, oldDate),
     ]);
     await store.create(
-      makeSession("tracked", tracked, {
+      makeSession(trackedId, tracked, {
         isolatedWorkdir: true,
         workdirRoot: root,
       }),
@@ -113,5 +116,50 @@ describe("ACP scratch workspace lifecycle", () => {
     expect(existsSync(tracked)).toBe(true);
     expect(existsSync(fresh)).toBe(true);
     expect(existsSync(manual)).toBe(true);
+  });
+
+  it("never reclaims human-named task-* dirs or non-isolated sessions' real workdirs under a workspace root", async () => {
+    // The false-positive class from #13895: workspace roots double as scratch
+    // roots, so a user repo named `task-master` (48h idle) and a real repo a
+    // NON-isolated terminal session ran inside must both survive boot GC.
+    const root = mkdtempSync(join(tmpdir(), "acp-scratch-guard-"));
+    roots.push(root);
+    const store = new InMemorySessionStore();
+    const service = new AcpService(makeRuntime({ ELIZA_WORKSPACE_DIR: root }), {
+      store,
+    });
+    const shim = service as unknown as ScratchLifecycleShim;
+    const humanRepo = join(root, "task-master");
+    const nonIsolatedId = "aaaaaaaa-1111-4222-8333-bbbbbbbbbbbb";
+    const nonIsolatedRepo = join(root, `task-${nonIsolatedId}`);
+    const ownedId = "cccccccc-4444-4555-8666-dddddddddddd";
+    const ownedScratch = join(root, `task-${ownedId}`);
+    await Promise.all([
+      mkdir(humanRepo, { recursive: true }),
+      mkdir(nonIsolatedRepo, { recursive: true }),
+      mkdir(ownedScratch, { recursive: true }),
+    ]);
+    const oldDate = new Date(Date.now() - 48 * 60 * 60_000);
+    await utimes(humanRepo, oldDate, oldDate);
+    const nonIsolated = makeSession(nonIsolatedId, nonIsolatedRepo, {
+      isolatedWorkdir: false,
+    });
+    nonIsolated.status = "stopped";
+    await store.create(nonIsolated);
+    const owned = makeSession(ownedId, ownedScratch, {
+      isolatedWorkdir: true,
+      workdirRoot: root,
+    });
+    owned.status = "stopped";
+    await store.create(owned);
+
+    await shim.cleanOrphanedScratchWorkdirs();
+
+    // Human-named repo: filtered out by the UUID-shape match despite age.
+    expect(existsSync(humanRepo)).toBe(true);
+    // Terminal but NOT isolation-owned: the ownership gate keeps it.
+    expect(existsSync(nonIsolatedRepo)).toBe(true);
+    // Terminal AND isolation-owned: reclaimed regardless of age.
+    expect(existsSync(ownedScratch)).toBe(false);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -747,7 +747,16 @@ export class AcpService extends Service {
     const now = Date.now();
     let reclaimed = 0;
     let kept = 0;
+    const configuredAcpRoot = this.setting("ELIZA_ACP_WORKSPACE_ROOT")?.trim();
     for (const root of this.configuredScratchRoots()) {
+      // Only ACP-exclusive scratch roots are wholly owned by this service.
+      // Coding/workspace roots can contain user projects, so an untracked
+      // directory there is never orphaned ACP work by name alone.
+      const isAcpOwnedRoot =
+        resolve(root) === resolve(DEFAULT_WORKDIR_ROOT) ||
+        (configuredAcpRoot
+          ? resolve(root) === resolve(configuredAcpRoot)
+          : false);
       let entries: string[];
       try {
         entries = await readdir(root);
@@ -776,9 +785,13 @@ export class AcpService extends Service {
             return;
           }
           // No owning session in THIS store: the dir may belong to a co-tenant
-          // AcpService sharing this tmp root, so gate removal on age. A dir whose
-          // session is terminal here is unambiguously ours → reclaim regardless.
+          // AcpService sharing the ACP-owned tmp root, so gate removal on age.
+          // Under user-configured roots, UUID shape is still not ownership.
           if (!session) {
+            if (!isAcpOwnedRoot) {
+              kept++;
+              return;
+            }
             try {
               const st = await stat(path);
               if (now - st.mtimeMs <= maxAgeMs) {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -200,6 +200,16 @@ export function isOwnedScratchDir(workdir: string): boolean {
   );
 }
 const ACP_SCRATCH_DIR_PREFIX = "task-";
+// Every scratch dir this service creates is `task-<randomUUID()>` (spawnSession
+// is computeSessionWorkdir's only production caller), so destructive reclaim
+// matches the full UUID shape rather than the bare prefix: workspace roots
+// double as scratch roots above, and a human repo named `task-master` or
+// `task-runner` sitting under one must never look reclaimable (#13895).
+const ACP_SCRATCH_DIR_NAME_RE =
+  /^task-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export function isAcpScratchDirName(name: string): boolean {
+  return ACP_SCRATCH_DIR_NAME_RE.test(name);
+}
 const ACP_METADATA_ISOLATED_WORKDIR = "isolatedWorkdir";
 const ACP_METADATA_WORKDIR_ROOT = "workdirRoot";
 const MAX_CAPTURED_TOOL_OUTPUT_CHARS = 12_000;
@@ -746,9 +756,7 @@ export class AcpService extends Service {
         // explicit zero-work result, not a masked read failure.
         continue;
       }
-      const taskDirs = entries.filter((name) =>
-        name.startsWith(ACP_SCRATCH_DIR_PREFIX),
-      );
+      const taskDirs = entries.filter((name) => isAcpScratchDirName(name));
       await Promise.allSettled(
         taskDirs.map(async (name) => {
           const path = join(root, name);
@@ -756,6 +764,14 @@ export class AcpService extends Service {
           // A live (non-terminal) session is still using its workspace — never
           // reclaim it; resumeOrphanedBusySessions may pick the work back up.
           if (session && !TERMINAL_SESSION_STATUSES.has(session.status)) {
+            kept++;
+            return;
+          }
+          // A terminal session that did NOT own an isolated scratch dir ran
+          // inside a directory handed to it (explicit route workdir, opt-out,
+          // self-checkout) — never reclaimable here, even when the dir name
+          // happens to match the scratch shape (#13895).
+          if (session && !this.sessionOwnsIsolatedWorkdir(session)) {
             kept++;
             return;
           }


### PR DESCRIPTION
## Problem (data loss at boot, live on develop since #13895 @ 03:42Z)

#13895's startup GC sweeps the operator's REAL workspace roots (`ELIZA_WORKSPACE_DIR` / `ELIZA_CODING_WORKSPACE` / `ELIZA_CODING_DIRECTORY` — 'the common case' per the code's own comments) with only a bare `task-` prefix filter. Two data-eating paths:

1. Any user directory named `task-*` (task-master, task-runner, …) directly under a configured root, untracked + idle >24h → **`rm -rf` at boot**.
2. The tracked-terminal branch matches by workdir equality, so a **non-isolated** session that ran inside a real `task-*`-named repo marks that repo deletable — **no age gate, no ownership check**.

Full analysis in the sweep-gate verdict on #13895. NOT in prod (promote #13828's cut predates the merge) — but every develop boot risks it until this lands.

## Fix (per the prescription on #13895)

- Scratch dirs are always `task-<randomUUID()>` — `spawnSession` (`id = randomUUID()`) is `computeSessionWorkdir`'s only production caller — so the GC now matches the **full UUID shape** (`isAcpScratchDirName`, exported/testable) instead of the bare prefix. Zero leak-regression: every dir the service ever created still matches.
- Tracked-terminal reclaims are additionally gated on the existing `sessionOwnsIsolatedWorkdir` predicate — a terminal session that ran in a handed-to-it directory is never reclaimable, even if the name happens to match.
- The teardown path was already metadata-gated and is untouched.

## Evidence (red/green)

- **RED**: new guard test vs unmodified GC → **1 failed** (`task-master` + the non-isolated repo get deleted)
- **GREEN**: with the fix → **3/3 pass** (guard test + updated GC test + owned-teardown test); the terminal+isolation-owned reclaim (the actual #13773 3.6TB-leak case) still collects, pinned in the same test
- Existing GC test updated to UUID-shaped names (the only shape production ever creates); `biome` clean; plugin typecheck clean

## Notes

- Fixture note: the pre-existing test's `manual` fixtures deliberately avoided `task-` names — the new guard test covers exactly the class they skipped.
- My commit → **no self-merge**; @lalalune / `[sol-orch]` please review + arm. Boot-time data deletion on develop, so sooner is better. (#13406)