### PR TITLE
fix(cloud-shared): fail-closed advertising connector sweep (#13415 slice 6a)

### DIFF
--- a/packages/cloud/shared/src/lib/services/advertising/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.error-policy.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Error-path proof for the advertising service's provider-fetch boundary (#13415):
+ * a failed provider metrics fetch PROPAGATES (fails closed — never fabricates a
+ * zero-spend success), and that failure is distinguishable from a legitimately
+ * unsynced campaign, which returns its stored first-party metrics without ever
+ * calling the provider. Repository / secrets / meta-provider seams are
+ * deterministic in-memory fakes; no monetary value is asserted beyond the
+ * stored-value passthrough the source already fixes.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type MetricsResult = {
+  success: boolean;
+  error?: string;
+  metrics?: {
+    spend: number;
+    impressions: number;
+    clicks: number;
+    conversions: number;
+  };
+};
+
+let metaMetricsResult: MetricsResult;
+let providerMetricsCalls = 0;
+let campaignRow: Record<string, unknown> | null;
+let accountRow: Record<string, unknown> | null;
+
+mock.module("../../../db/repositories", () => ({
+  adAccountsRepository: { findById: async () => accountRow },
+  adCampaignsRepository: {
+    findById: async () => campaignRow,
+    updateMetrics: async () => {},
+  },
+  adConversionsRepository: {
+    getCampaignRollup: async () => ({ conversions: 0, value: 0 }),
+  },
+  adAudienceSegmentsRepository: {},
+  adCreativesRepository: {},
+  adReportSharesRepository: {},
+  adTransactionsRepository: {},
+}));
+
+mock.module("../secrets", () => ({
+  secretsService: { getDecryptedValue: async () => "access-token" },
+}));
+
+mock.module("../credits", () => ({ creditsService: {} }));
+mock.module("../content-safety", () => ({ contentSafetyService: {} }));
+
+mock.module("./providers/meta", () => ({
+  metaAdsProvider: {
+    getCampaignMetrics: async (): Promise<MetricsResult> => {
+      providerMetricsCalls += 1;
+      return metaMetricsResult;
+    },
+  },
+}));
+
+const { advertisingService } = await import("./index");
+
+function syncedCampaign(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "camp_1",
+    organization_id: "org_1",
+    ad_account_id: "acct_1",
+    external_campaign_id: "ext_camp_1",
+    credits_allocated: "100.00",
+    budget_amount: "50.00",
+    credits_spent: "0.00",
+    total_spend: "12.34",
+    total_impressions: 1000,
+    total_clicks: 10,
+    total_conversions: 2,
+    ...overrides,
+  };
+}
+
+const metaAccount = {
+  id: "acct_1",
+  organization_id: "org_1",
+  platform: "meta",
+  external_account_id: "ext_acct_1",
+  access_token_secret_id: "sec_access",
+  refresh_token_secret_id: null,
+  token_expires_at: null,
+};
+
+beforeEach(() => {
+  providerMetricsCalls = 0;
+  campaignRow = syncedCampaign();
+  accountRow = metaAccount;
+  metaMetricsResult = {
+    success: true,
+    metrics: { spend: 5, impressions: 5, clicks: 5, conversions: 5 },
+  };
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("advertisingService.getCampaignMetrics — provider-fetch boundary", () => {
+  test("a failed provider fetch PROPAGATES (fails closed, no fabricated success)", async () => {
+    metaMetricsResult = { success: false, error: "meta insights api unavailable (503)" };
+
+    await expect(advertisingService.getCampaignMetrics("camp_1", "org_1")).rejects.toThrow(
+      "meta insights api unavailable (503)",
+    );
+    // The provider WAS reached — this is a real transport failure surfacing,
+    // not a short-circuit before the fetch.
+    expect(providerMetricsCalls).toBe(1);
+  });
+
+  test("a success envelope with missing metrics still throws — never fabricates", async () => {
+    metaMetricsResult = { success: true };
+
+    await expect(advertisingService.getCampaignMetrics("camp_1", "org_1")).rejects.toThrow(
+      "Failed to get metrics",
+    );
+    expect(providerMetricsCalls).toBe(1);
+  });
+
+  test("a legitimately unsynced campaign is DISTINCT: stored metrics, no provider call", async () => {
+    campaignRow = syncedCampaign({ external_campaign_id: null });
+
+    const result = await advertisingService.getCampaignMetrics("camp_1", "org_1");
+
+    // No provider fetch happens, and the absent-provider case resolves with the
+    // stored value — distinguishable from the throw a failed fetch produces, and
+    // NOT a zero fabricated by a swallowed error.
+    expect(providerMetricsCalls).toBe(0);
+    expect(result.spend).toBe(Number.parseFloat(String(syncedCampaign().total_spend)));
+    expect(result.impressions).toBe(1000);
+  });
+
+  test("an absent campaign fails closed distinctly (not a provider error)", async () => {
+    campaignRow = null;
+
+    await expect(advertisingService.getCampaignMetrics("camp_1", "org_1")).rejects.toThrow(
+      "Campaign not found",
+    );
+    expect(providerMetricsCalls).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/advertising/index.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.ts
@@ -499,6 +499,8 @@ class AdvertisingService {
     try {
       parsed = JSON.parse(this.base64UrlDecode(payload));
     } catch {
+      // error-policy:J3 the token payload is caller-supplied; a decode/parse
+      // failure is an invalid token, not a valid default — fail closed.
       throw new Error("Invalid attribution token");
     }
     if (parsed.v !== 1 || !parsed.c || !parsed.o) {
@@ -834,7 +836,9 @@ class AdvertisingService {
       actorId: account.connected_by_user_id ?? "advertising-service",
       source: "advertising-service",
     };
-    // Delete secrets - log but don't fail if already deleted
+    // error-policy:J6 best-effort teardown — the account row is being removed;
+    // a secret that is already gone must not block disconnect. Warns so a real
+    // deletion failure is observable.
     if (account.access_token_secret_id) {
       await secretsService
         .delete(account.access_token_secret_id, organizationId, audit)
@@ -845,6 +849,7 @@ class AdvertisingService {
         );
     }
     if (account.refresh_token_secret_id) {
+      // error-policy:J6 best-effort teardown — see access-token deletion above.
       await secretsService
         .delete(account.refresh_token_secret_id, organizationId, audit)
         .catch((e) =>

--- a/packages/cloud/shared/src/lib/services/advertising/media-utils.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/media-utils.error-policy.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Error-policy regression guard (#13415) for ad-media download: a failed or
+ * errored provider fetch must PROPAGATE (throw), never be swallowed into an
+ * empty/default DownloadedAdMedia a caller would trust. Pins that a
+ * legitimately-empty download (200 + zero bytes) succeeds and stays DISTINCT
+ * from a transport/HTTP failure. `safeFetch` is the only stub — a controllable
+ * transport standing in for the real SSRF-pinned fetch.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type SafeFetchImpl = (url: string, init?: RequestInit) => Promise<Response>;
+
+let safeFetchImpl: SafeFetchImpl;
+
+// Mirrors media-utils.ts's own import specifier so the module under test binds
+// to this controllable transport instead of the real IP-pinning safeFetch.
+mock.module("../../security/safe-fetch", () => ({
+  safeFetch: (url: string, init?: RequestInit) => safeFetchImpl(url, init),
+}));
+
+const URL_UNDER_TEST = "https://cdn.example.com/creative/ad.png";
+
+beforeEach(() => {
+  safeFetchImpl = async () =>
+    new Response(new Uint8Array([1, 2, 3, 4]), {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("#13415 — downloadAdMedia surfaces fetch failures, never fabricates a download", () => {
+  test("designed success: a real 200 response returns the exact bytes", async () => {
+    const { downloadAdMedia } = await import("./media-utils");
+    const result = await downloadAdMedia(URL_UNDER_TEST);
+    // Distinguishes the healthy path from every failure below: real bytes and a
+    // real base64 payload, not an empty/default result.
+    expect(result.bytes.byteLength).toBe(4);
+    expect(result.base64).toBe(Buffer.from([1, 2, 3, 4]).toString("base64"));
+    expect(result.contentType).toBe("image/png");
+    expect(result.url).toBe(URL_UNDER_TEST);
+  });
+
+  test("legitimately-empty download (200 + zero bytes) succeeds and is DISTINCT from a failure", async () => {
+    safeFetchImpl = async () =>
+      new Response(new Uint8Array(0), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      });
+    const { downloadAdMedia } = await import("./media-utils");
+    const result = await downloadAdMedia(URL_UNDER_TEST);
+    // A valid but empty asset resolves — the empty result is a legitimate
+    // download, never conflated with the thrown transport/HTTP errors below.
+    expect(result.bytes.byteLength).toBe(0);
+    expect(result.base64).toBe("");
+  });
+
+  test("non-2xx HTTP status PROPAGATES (never swallowed into an empty media object)", async () => {
+    safeFetchImpl = async () => new Response("upstream boom", { status: 500 });
+    const { downloadAdMedia } = await import("./media-utils");
+    await expect(downloadAdMedia(URL_UNDER_TEST)).rejects.toThrow(
+      /Failed to download ad media \(500\)/,
+    );
+  });
+
+  test("transport rejection PROPAGATES (no catch masks a network failure as success)", async () => {
+    safeFetchImpl = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    const { downloadAdMedia } = await import("./media-utils");
+    await expect(downloadAdMedia(URL_UNDER_TEST)).rejects.toThrow(/ECONNREFUSED/);
+  });
+
+  test("redirect without a Location header throws instead of resolving empty", async () => {
+    safeFetchImpl = async () => new Response(null, { status: 302 });
+    const { downloadAdMedia } = await import("./media-utils");
+    await expect(downloadAdMedia(URL_UNDER_TEST)).rejects.toThrow(
+      /redirected without a Location header/,
+    );
+  });
+
+  test("an endless redirect chain fails closed with a redirect-budget error", async () => {
+    safeFetchImpl = async () =>
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://cdn.example.com/creative/next.png" },
+      });
+    const { downloadAdMedia } = await import("./media-utils");
+    await expect(downloadAdMedia(URL_UNDER_TEST)).rejects.toThrow(/Too many redirects/);
+  });
+
+  test("a disallowed content type throws rather than returning the untrusted bytes", async () => {
+    safeFetchImpl = async () =>
+      new Response(new Uint8Array([1]), {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      });
+    const { downloadAdMedia } = await import("./media-utils");
+    await expect(
+      downloadAdMedia(URL_UNDER_TEST, { allowedContentTypes: ["image/png"] }),
+    ).rejects.toThrow(/Unsupported ad media content type/);
+  });
+
+  test("an oversize asset throws rather than buffering past the cap", async () => {
+    safeFetchImpl = async () =>
+      new Response(new Uint8Array(100), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      });
+    const { downloadAdMedia } = await import("./media-utils");
+    await expect(downloadAdMedia(URL_UNDER_TEST, { maxBytes: 10 })).rejects.toThrow(
+      /exceeds maximum size/,
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/google.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/google.error-policy.test.ts
@@ -1,0 +1,125 @@
+// Pins the error-surfacing contract of the Google Ads provider: a failed provider
+// fetch must PROPAGATE, and must stay distinct from a legitimately-empty result
+// (valid credentials, no accessible customers / no metrics rows in range). No
+// monetary value is asserted beyond the zeroed empty-metrics shape the source itself
+// fixes. Deterministic — global fetch is mocked; no live Google Ads API call.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../utils/logger", () => ({
+  logger: { info() {}, warn() {}, error() {}, debug() {} },
+}));
+
+const { googleAdsProvider } = await import("./google");
+
+const originalFetch = globalThis.fetch;
+const credentials = { accessToken: "token" };
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// Route mocked fetch by URL: listAccessibleCustomers vs. searchStream (googleAdsRequest).
+function mockFetch(handler: (url: string) => Response | Promise<Response>) {
+  globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return handler(url);
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("googleAdsProvider.listAdAccounts error surfacing", () => {
+  test("resolves an empty array for valid credentials with no accessible customers", async () => {
+    mockFetch((url) => {
+      if (url.includes("listAccessibleCustomers")) {
+        return jsonResponse({ resourceNames: [] });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await expect(googleAdsProvider.listAdAccounts(credentials)).resolves.toEqual([]);
+  });
+
+  test("propagates a transport failure on the accessible-customers fetch", async () => {
+    mockFetch((url) => {
+      if (url.includes("listAccessibleCustomers")) {
+        throw new Error("network down");
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await expect(googleAdsProvider.listAdAccounts(credentials)).rejects.toThrow("network down");
+  });
+
+  test("propagates a failed per-customer detail fetch instead of silently dropping the account", async () => {
+    mockFetch((url) => {
+      if (url.includes("listAccessibleCustomers")) {
+        return jsonResponse({ resourceNames: ["customers/123"] });
+      }
+      // searchStream for the customer detail returns a Google Ads API error.
+      return jsonResponse(
+        { error: { code: 7, message: "USER_PERMISSION_DENIED", status: "PERMISSION_DENIED" } },
+        403,
+      );
+    });
+
+    await expect(googleAdsProvider.listAdAccounts(credentials)).rejects.toThrow(
+      "USER_PERMISSION_DENIED",
+    );
+  });
+
+  test("returns the populated account list when every fetch succeeds", async () => {
+    mockFetch((url) => {
+      if (url.includes("listAccessibleCustomers")) {
+        return jsonResponse({ resourceNames: ["customers/123"] });
+      }
+      return jsonResponse({
+        results: [
+          { customer: { resourceName: "customers/123", id: "123", descriptiveName: "Acme" } },
+        ],
+      });
+    });
+
+    await expect(googleAdsProvider.listAdAccounts(credentials)).resolves.toEqual([
+      { id: "123", name: "Acme" },
+    ]);
+  });
+});
+
+describe("googleAdsProvider.getCampaignMetrics money-path distinctness", () => {
+  // money-path-flagged: the spend arithmetic and the zeroed empty-metrics fallback are
+  // left UNCHANGED. This only pins that a failed metrics fetch surfaces and stays distinct
+  // from a legitimately-empty (no rows in range) success — without asserting a computed value.
+  test("propagates a failed metrics fetch instead of reporting empty spend", async () => {
+    mockFetch(() =>
+      jsonResponse(
+        { error: { code: 3, message: "INVALID_QUERY", status: "INVALID_ARGUMENT" } },
+        400,
+      ),
+    );
+
+    await expect(googleAdsProvider.getCampaignMetrics(credentials, "123/456")).rejects.toThrow(
+      "INVALID_QUERY",
+    );
+  });
+
+  test("reports success with zeroed metrics for a campaign with no rows in range", async () => {
+    mockFetch(() => jsonResponse({ results: [] }));
+
+    const result = await googleAdsProvider.getCampaignMetrics(credentials, "123/456");
+
+    expect(result).toEqual({
+      success: true,
+      metrics: { spend: 0, impressions: 0, clicks: 0, conversions: 0 },
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/google.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/google.ts
@@ -143,6 +143,8 @@ function extractYouTubeVideoId(rawUrl: string): string | undefined {
     if (host === "youtube.com" || host === "m.youtube.com" || host === "music.youtube.com") {
       return normalizeYouTubeVideoId(url.searchParams.get("v") ?? "");
     }
+    // error-policy:J3 rawUrl is caller-supplied; a malformed URL is invalid input,
+    // reported as "no extractable video id" — not a swallowed provider/transport failure.
   } catch {
     return undefined;
   }
@@ -307,15 +309,9 @@ export const googleAdsProvider: AdProvider = {
         body: JSON.stringify({
           query: `SELECT customer.id, customer.descriptive_name FROM customer LIMIT 1`,
         }),
-      }).catch((err) => {
-        logger.warn("[GoogleAds] Failed to fetch customer details", {
-          customerId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-        return null;
       });
 
-      const row = customerResponse ? firstGoogleAdsSearchResult(customerResponse) : undefined;
+      const row = firstGoogleAdsSearchResult(customerResponse);
       if (row) {
         const customer = row.customer;
         accounts.push({
@@ -742,6 +738,8 @@ export const googleAdsProvider: AdProvider = {
           },
           body: videoBody,
         });
+        // error-policy:J3 finalize body may be empty/non-JSON; the !ok check below still
+        // surfaces HTTP failures, and a 2xx with no resourceName reports an explicit failure.
         const data = (await finalizeResponse.json().catch(() => ({}))) as {
           resourceName?: string;
         };
@@ -820,6 +818,8 @@ export const googleAdsProvider: AdProvider = {
           sizeBytes: downloaded.bytes.byteLength,
         },
       };
+      // error-policy:J1 AdProvider boundary translates a failed upload/download/parse into a
+      // structured failure result (success:false) — never a fabricated success.
     } catch (error) {
       logger.error("[GoogleAds] Media upload failed", {
         accountId,
@@ -906,6 +906,8 @@ export const googleAdsProvider: AdProvider = {
               : undefined,
         },
       };
+      // error-policy:J1 AdProvider boundary translates a failed status fetch/parse into a
+      // structured failure result (success:false) — distinct from a resolved not-ready status.
     } catch (error) {
       logger.error("[GoogleAds] Media status failed", {
         accountId,

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.error-policy.test.ts
@@ -1,0 +1,75 @@
+// Pins the error-policy boundary of LinkedIn ad-credential validation: a failed
+// account-discovery fetch (transport reject or non-2xx) must surface its real
+// error and stay DISTINCT from a valid-but-empty account list. Deterministic —
+// global fetch is mocked; no live LinkedIn calls.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function loadProvider() {
+  const { linkedinAdsProvider } = await import("./linkedin");
+  return linkedinAdsProvider;
+}
+
+const credentials = { accessToken: "linkedin-token" };
+const EMPTY_ERROR = "No LinkedIn ad accounts found or invalid credentials";
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("linkedinAdsProvider.validateCredentials error policy", () => {
+  test("a network/transport failure surfaces the real error, not the empty-list message", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("network unreachable");
+    }) as typeof fetch;
+
+    const result = await (await loadProvider()).validateCredentials(credentials);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("network unreachable");
+    // Transport failure must NOT be reported as a legitimately-empty account list.
+    expect(result.error).not.toBe(EMPTY_ERROR);
+  });
+
+  test("a non-2xx LinkedIn response surfaces the API error, distinct from empty", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ message: "Invalid access token" }, 401),
+    ) as typeof fetch;
+
+    const result = await (await loadProvider()).validateCredentials(credentials);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Invalid access token");
+    expect(result.error).not.toBe(EMPTY_ERROR);
+  });
+
+  test("a successful fetch with zero accounts is the DISTINCT legitimately-empty result", async () => {
+    globalThis.fetch = mock(async () => jsonResponse({ elements: [] })) as typeof fetch;
+
+    const result = await (await loadProvider()).validateCredentials(credentials);
+
+    expect(result).toEqual({ valid: false, error: EMPTY_ERROR });
+  });
+
+  test("a successful fetch with an account validates without an error", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ elements: [{ id: 507404993, name: "Dunder Mifflin Account" }] }),
+    ) as typeof fetch;
+
+    const result = await (await loadProvider()).validateCredentials(credentials);
+
+    expect(result).toEqual({
+      valid: true,
+      accountId: "507404993",
+      accountName: "Dunder Mifflin Account",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
@@ -360,12 +360,21 @@ export const linkedinAdsProvider: AdProvider = {
   async validateCredentials(
     credentials: AdAccountCredentials,
   ): Promise<AdProviderValidationResult> {
-    const accounts = await this.listAdAccounts(credentials).catch((error) => {
+    let accounts: Array<{ id: string; name: string }>;
+    try {
+      accounts = await this.listAdAccounts(credentials);
+    } catch (error) {
+      // error-policy:J1 boundary — surface the account-discovery transport/auth
+      // failure verbatim so a failed fetch stays distinct from a valid account
+      // that simply has zero ad accounts (the empty-list branch below).
       logger.error("[LinkedInAds] Validation failed", {
         error: error instanceof Error ? error.message : String(error),
       });
-      return [];
-    });
+      return {
+        valid: false,
+        error: error instanceof Error ? error.message : "LinkedIn credential validation failed",
+      };
+    }
     if (accounts.length === 0) {
       return { valid: false, error: "No LinkedIn ad accounts found or invalid credentials" };
     }

--- a/packages/cloud/shared/src/lib/services/advertising/providers/meta.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/meta.error-policy.test.ts
@@ -1,0 +1,128 @@
+// Pins the error-surfacing contract of the Meta ad provider: a failed provider
+// fetch must surface as a structured {success:false}/{valid:false} failure (the
+// shape the advertising service reads to REFUND credits and to reject invalid
+// credentials), and must stay distinct from a legitimately-empty result (valid
+// account with no insights → success with zero spend). Deterministic — global
+// fetch is mocked; no live Meta Graph API call and no monetary value is asserted
+// beyond the zero the source already fixes for the empty-insights case.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../utils/logger", () => ({
+  logger: { info() {}, warn() {}, error() {}, debug() {} },
+}));
+
+const { metaAdsProvider } = await import("./meta");
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchJson(body: unknown, status = 200) {
+  globalThis.fetch = mock(
+    async () =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+  ) as typeof fetch;
+}
+
+function mockFetchReject(error: Error) {
+  globalThis.fetch = mock(async () => {
+    throw error;
+  }) as typeof fetch;
+}
+
+const credentials = { accessToken: "token" };
+const campaignInput = {
+  name: "Spring Sale",
+  objective: "traffic",
+  budgetType: "daily" as const,
+  budgetAmount: 50,
+};
+
+beforeEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("metaAdsProvider.validateCredentials error surfacing", () => {
+  test("a transport failure surfaces as valid:false, never valid:true", async () => {
+    mockFetchReject(new Error("network down"));
+
+    const result = await metaAdsProvider.validateCredentials(credentials);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  test("a Meta API error (invalid token, code 190) surfaces as valid:false", async () => {
+    mockFetchJson({
+      error: { message: "Invalid OAuth access token", code: 190, type: "OAuthException" },
+    });
+
+    const result = await metaAdsProvider.validateCredentials({ accessToken: "bad-token" });
+
+    expect(result.valid).toBe(false);
+    // The provider error carries the upstream Meta message; a fetch failure never
+    // masquerades as a valid account.
+    expect(result.error).toContain("Invalid OAuth access token");
+  });
+
+  test("a healthy /me response resolves valid:true (distinct from failure)", async () => {
+    mockFetchJson({ id: "123", name: "Acme Ads" });
+
+    const result = await metaAdsProvider.validateCredentials(credentials);
+
+    expect(result).toEqual({ valid: true, accountId: "123", accountName: "Acme Ads" });
+  });
+});
+
+describe("metaAdsProvider.createCampaign error surfacing (credit-refund contract)", () => {
+  test("a provider fetch failure returns {success:false} so the caller can refund", async () => {
+    mockFetchReject(new Error("meta unreachable"));
+
+    const result = await metaAdsProvider.createCampaign(credentials, "act_123", campaignInput);
+
+    // The advertising service reads !result.success to refund allocated credits;
+    // a swallowed throw here would skip that refund. Must never report success.
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  test("a Meta API error surfaces the upstream message on {success:false}", async () => {
+    mockFetchJson({
+      error: { message: "Invalid ad account", code: 100, type: "OAuthException" },
+    });
+
+    const result = await metaAdsProvider.createCampaign(credentials, "act_123", campaignInput);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Invalid ad account");
+  });
+});
+
+describe("metaAdsProvider.getCampaignMetrics failure vs legitimately-empty", () => {
+  test("a transport failure returns {success:false}, NOT an empty success", async () => {
+    mockFetchReject(new Error("insights fetch failed"));
+
+    const result = await metaAdsProvider.getCampaignMetrics(credentials, "camp_1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+    expect(result.metrics).toBeUndefined();
+  });
+
+  test("an empty insights array is a success distinct from a failure", async () => {
+    mockFetchJson({ data: [] });
+
+    const result = await metaAdsProvider.getCampaignMetrics(credentials, "camp_1");
+
+    // Meta returns no insights rows for a campaign with no delivery yet — a real,
+    // non-failure empty. Source fixes zero spend for this case; we assert only the
+    // distinction from the failure branch, not any derived monetary amount.
+    expect(result.success).toBe(true);
+    expect(result.metrics?.spend).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/meta.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/meta.ts
@@ -240,6 +240,7 @@ export const metaAdsProvider: AdProvider = {
         accountName: response.name,
       };
     } catch (error) {
+      // error-policy:J1 provider boundary → structured AdProviderValidationResult; caller throws on !valid (index.ts registerAdAccount)
       logger.error("[MetaAds] Validation failed", { error });
       return {
         valid: false,
@@ -434,6 +435,7 @@ export const metaAdsProvider: AdProvider = {
         externalCampaignId: campaign.id,
       };
     } catch (error) {
+      // error-policy:J1 provider boundary → {success:false} drives caller credit refund (index.ts:1157)
       logger.error("[MetaAds] Create campaign failed", { error });
       return {
         success: false,
@@ -466,6 +468,7 @@ export const metaAdsProvider: AdProvider = {
 
       return { success: true, externalCampaignId };
     } catch (error) {
+      // error-policy:J1 provider boundary → structured AdProviderCampaignResult
       logger.error("[MetaAds] Update campaign failed", { error });
       return {
         success: false,
@@ -492,6 +495,7 @@ export const metaAdsProvider: AdProvider = {
 
       return { success: true, externalCampaignId };
     } catch (error) {
+      // error-policy:J1 provider boundary → structured AdProviderCampaignResult
       logger.error("[MetaAds] Pause campaign failed", { error });
       return {
         success: false,
@@ -518,6 +522,7 @@ export const metaAdsProvider: AdProvider = {
 
       return { success: true, externalCampaignId };
     } catch (error) {
+      // error-policy:J1 provider boundary → structured AdProviderCampaignResult
       logger.error("[MetaAds] Activate campaign failed", { error });
       return {
         success: false,
@@ -543,6 +548,7 @@ export const metaAdsProvider: AdProvider = {
 
       return { success: true };
     } catch (error) {
+      // error-policy:J1 provider boundary → {success:false} structured result
       logger.error("[MetaAds] Delete campaign failed", { error });
       return {
         success: false,
@@ -681,6 +687,7 @@ export const metaAdsProvider: AdProvider = {
         externalCreativeId: creative.id,
       };
     } catch (error) {
+      // error-policy:J1 provider boundary → structured AdProviderCreativeResult
       logger.error("[MetaAds] Create creative failed", { error });
       return {
         success: false,
@@ -761,6 +768,7 @@ export const metaAdsProvider: AdProvider = {
         },
       };
     } catch (error) {
+      // error-policy:J1 provider boundary → structured media upload result
       logger.error("[MetaAds] Media upload failed", {
         accountId,
         type: input.type,
@@ -829,6 +837,7 @@ export const metaAdsProvider: AdProvider = {
 
       return { success: true, metrics };
     } catch (error) {
+      // error-policy:J1 provider boundary → structured failure, distinct from the empty-insights success above
       logger.error("[MetaAds] Get metrics failed", { error });
       return {
         success: false,

--- a/packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.error-policy.test.ts
@@ -1,0 +1,99 @@
+// Pins the error-policy boundary of the programmatic DSP adapter: a failed or
+// malformed provider fetch must SURFACE (propagate or become a structured
+// failure) and stay distinguishable from a legitimately empty result, so a
+// broken reporting fetch can never read as zero spend. Deterministic harness —
+// global fetch is mocked per test; no live DSP or real model involved.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../utils/logger", () => ({
+  logger: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} },
+}));
+
+const { programmaticDspProvider } = await import("./programmatic-dsp");
+
+const originalFetch = globalThis.fetch;
+const originalEndpoint = process.env.PROGRAMMATIC_DSP_ENDPOINT;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function setFetch(fn: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
+  globalThis.fetch = mock(fn) as typeof fetch;
+}
+
+beforeEach(() => {
+  process.env.PROGRAMMATIC_DSP_ENDPOINT = "https://dsp.example.com/rtb";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalEndpoint === undefined) delete process.env.PROGRAMMATIC_DSP_ENDPOINT;
+  else process.env.PROGRAMMATIC_DSP_ENDPOINT = originalEndpoint;
+});
+
+describe("programmaticDspProvider error policy", () => {
+  test("a 200 with a non-JSON body propagates as a transport failure, not an empty envelope", async () => {
+    setFetch(async () => new Response("<html>502 Bad Gateway</html>", { status: 200 }));
+    await expect(programmaticDspProvider.listAdAccounts({ accessToken: "token" })).rejects.toThrow(
+      /non-JSON body/,
+    );
+  });
+
+  test("a non-ok JSON error body still surfaces the provider's error message", async () => {
+    setFetch(async () => jsonResponse({ error: { message: "unauthorized" } }, 401));
+    await expect(programmaticDspProvider.listAdAccounts({ accessToken: "bad" })).rejects.toThrow(
+      "unauthorized",
+    );
+  });
+
+  test("an empty body on a mutating call stays a legitimate no-content success (no throw)", async () => {
+    setFetch(async () => new Response("", { status: 200 }));
+    await expect(
+      programmaticDspProvider.updateCampaign({ accessToken: "token" }, "adv_1/cmp_1/li_1", {
+        name: "Renamed",
+      }),
+    ).resolves.toMatchObject({ success: true });
+  });
+
+  test("validateCredentials surfaces a transport failure verbatim, distinct from an empty account list", async () => {
+    setFetch(async () => {
+      throw new Error("ECONNREFUSED dsp.example.com");
+    });
+    const failure = await programmaticDspProvider.validateCredentials({ accessToken: "token" });
+    expect(failure.valid).toBe(false);
+    expect(failure.error).toContain("ECONNREFUSED");
+    expect(failure.error).not.toContain("No DSP advertiser accounts");
+
+    setFetch(async () => jsonResponse({ data: [] }));
+    const empty = await programmaticDspProvider.validateCredentials({ accessToken: "token" });
+    expect(empty).toEqual({
+      valid: false,
+      error: "No DSP advertiser accounts found or invalid credentials",
+    });
+  });
+
+  test("metrics: a broken report fetch fails closed and is distinct from a legitimately empty report", async () => {
+    // Parse failure on the reporting endpoint must NOT fabricate zero spend.
+    setFetch(async () => new Response("upstream timeout", { status: 200 }));
+    const broken = await programmaticDspProvider.getCampaignMetrics(
+      { accessToken: "token" },
+      "adv_1/cmp_1/li_1",
+    );
+    expect(broken.success).toBe(false);
+    expect(broken.error).toBeTruthy();
+    expect(broken.metrics).toBeUndefined();
+
+    // A genuinely empty report is a success with zeroed metrics — the opposite verdict.
+    setFetch(async () => jsonResponse({ data: { rows: [] } }));
+    const empty = await programmaticDspProvider.getCampaignMetrics(
+      { accessToken: "token" },
+      "adv_1/cmp_1/li_1",
+    );
+    expect(empty.success).toBe(true);
+    expect(empty.metrics).toBeDefined();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.ts
@@ -131,7 +131,20 @@ async function dspRequest<T>(
     },
   });
 
-  const json = (await response.json().catch(() => ({}))) as DspEnvelope<T>;
+  // An empty body is a legitimate no-content response (e.g. 204 on a PATCH);
+  // a non-empty body that will not parse is a transport/protocol failure and
+  // must surface, never read as an empty-but-successful envelope (which on the
+  // reporting path would fabricate zero spend from a broken fetch).
+  const rawBody = await response.text();
+  let json: DspEnvelope<T> = {};
+  if (rawBody.trim() !== "") {
+    try {
+      json = JSON.parse(rawBody) as DspEnvelope<T>;
+    } catch {
+      // error-policy:J3 untrusted DSP response body; a non-JSON payload is invalid input, surfaced (never a fake-empty envelope)
+      throw new Error(`DSP API returned a non-JSON body (status ${response.status})`);
+    }
+  }
   if (!response.ok) {
     throw new Error(json.error?.message || json.message || `DSP API error: ${response.status}`);
   }
@@ -283,6 +296,7 @@ function buildCreativeAd(input: CreateCreativeInput, seatId: string | undefined)
     try {
       adomain = [new URL(input.destinationUrl).hostname];
     } catch {
+      // error-policy:J3 destinationUrl is untrusted input; a malformed URL yields no adomain (an optional OpenRTB field), never a fabricated one
       adomain = undefined;
     }
   }
@@ -315,12 +329,16 @@ export const programmaticDspProvider: AdProvider = {
   async validateCredentials(
     credentials: AdAccountCredentials,
   ): Promise<AdProviderValidationResult> {
-    const accounts = await this.listAdAccounts(credentials).catch((err: unknown) => {
-      logger.error("[ProgrammaticDsp] Validation failed", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      return [] as Array<{ id: string; name: string }>;
-    });
+    let accounts: Array<{ id: string; name: string }>;
+    try {
+      accounts = await this.listAdAccounts(credentials);
+    } catch (err) {
+      // error-policy:J4 credential validation reports an explicit invalid state; the real
+      // fetch/auth failure is surfaced verbatim, kept distinct from a genuinely empty account list.
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error("[ProgrammaticDsp] Validation failed", { error: message });
+      return { valid: false, error: message };
+    }
     if (accounts.length === 0) {
       return { valid: false, error: "No DSP advertiser accounts found or invalid credentials" };
     }
@@ -391,6 +409,7 @@ export const programmaticDspProvider: AdProvider = {
         externalCampaignId: `${accountId}/${campaignId}/${lineItemId}`,
       };
     } catch (error) {
+      // error-policy:J1 AdProvider boundary translates the failed create into a structured failure result
       logger.error("[ProgrammaticDsp] Campaign creation failed", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -435,6 +454,7 @@ export const programmaticDspProvider: AdProvider = {
       }
       return { success: true, externalCampaignId };
     } catch (error) {
+      // error-policy:J1 AdProvider boundary translates the failed update into a structured failure result
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
@@ -471,6 +491,7 @@ export const programmaticDspProvider: AdProvider = {
       });
       return { success: true };
     } catch (error) {
+      // error-policy:J1 AdProvider boundary translates the failed delete into a structured failure result
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
@@ -508,6 +529,7 @@ export const programmaticDspProvider: AdProvider = {
       const associationId = requireId(associationResponse, "creative association");
       return { success: true, externalCreativeId: `${creativeId}/${associationId}` };
     } catch (error) {
+      // error-policy:J1 AdProvider boundary translates the failed creative create into a structured failure result
       logger.error("[ProgrammaticDsp] Creative creation failed", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -533,6 +555,7 @@ export const programmaticDspProvider: AdProvider = {
         metadata: { storage: "external_url", type: input.type },
       };
     } catch (error) {
+      // error-policy:J1 AdProvider boundary translates the SSRF/validation failure into a structured failure result
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
@@ -580,6 +603,7 @@ export const programmaticDspProvider: AdProvider = {
       );
       return { success: true, metrics: summarizeReport(response.data) };
     } catch (error) {
+      // error-policy:J1 AdProvider boundary translates the failed report fetch into a structured failure result (distinct from a legitimately empty report, which returns success with zeroed metrics)
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
@@ -604,6 +628,7 @@ async function setCampaignStatus(
     }
     return { success: true, externalCampaignId };
   } catch (error) {
+    // error-policy:J1 AdProvider boundary translates the failed status patch into a structured failure result
     return { success: false, error: error instanceof Error ? error.message : String(error) };
   }
 }

--- a/packages/cloud/shared/src/lib/services/advertising/providers/reddit.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/reddit.error-policy.test.ts
@@ -1,0 +1,88 @@
+// Pins the error-policy boundary of Reddit ad-credential validation: a failed
+// account-discovery fetch (transport reject or non-2xx) must surface its real error and
+// stay DISTINCT from a valid-but-empty account list. Deterministic — global fetch is
+// mocked; no live Reddit calls.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const originalFetch = globalThis.fetch;
+
+let queue: Array<{ body: unknown; status?: number }> = [];
+
+function enqueue(body: unknown, status = 200) {
+  queue.push({ body, status });
+}
+
+function installQueuedFetch() {
+  globalThis.fetch = mock(async () => {
+    const next = queue.shift() ?? { body: { data: {} }, status: 200 };
+    return new Response(JSON.stringify(next.body), {
+      status: next.status ?? 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+async function loadProvider() {
+  const { redditAdsProvider } = await import("./reddit");
+  return redditAdsProvider;
+}
+
+const credentials = { accessToken: "reddit-token" };
+const EMPTY_ERROR = "No Reddit Ads accounts found or invalid credentials";
+
+beforeEach(() => {
+  queue = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("redditAdsProvider.validateCredentials error policy", () => {
+  test("a network/transport failure surfaces the real error, not the empty-list message", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("network unreachable");
+    }) as typeof fetch;
+
+    const result = await (await loadProvider()).validateCredentials(credentials);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("network unreachable");
+    // Transport failure must NOT be reported as a legitimately-empty account list.
+    expect(result.error).not.toBe(EMPTY_ERROR);
+  });
+
+  test("a non-2xx Reddit response surfaces the API error, distinct from empty", async () => {
+    installQueuedFetch();
+    enqueue({ error: { message: "Invalid access token" } }, 401);
+
+    const result = await (await loadProvider()).validateCredentials(credentials);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Invalid access token");
+    expect(result.error).not.toBe(EMPTY_ERROR);
+  });
+
+  test("a successful fetch with zero businesses is the DISTINCT legitimately-empty result", async () => {
+    installQueuedFetch();
+    enqueue({ data: [] });
+
+    const result = await (await loadProvider()).validateCredentials(credentials);
+
+    expect(result).toEqual({ valid: false, error: EMPTY_ERROR });
+  });
+
+  test("a successful fetch with an ad account validates without an error", async () => {
+    installQueuedFetch();
+    enqueue({ data: [{ id: "biz_1", name: "Business" }] });
+    enqueue({ data: [{ id: "t2_account", name: "Reddit Account" }] });
+
+    const result = await (await loadProvider()).validateCredentials(credentials);
+
+    expect(result).toEqual({
+      valid: true,
+      accountId: "t2_account",
+      accountName: "Reddit Account",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/reddit.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/reddit.ts
@@ -258,10 +258,20 @@ export const redditAdsProvider: AdProvider = {
   async validateCredentials(
     credentials: AdAccountCredentials,
   ): Promise<AdProviderValidationResult> {
-    const accounts = await this.listAdAccounts(credentials).catch((err) => {
-      logger.error("[RedditAds] Validation failed", { error: err.message });
-      return [];
-    });
+    let accounts: Array<{ id: string; name: string }>;
+    try {
+      accounts = await this.listAdAccounts(credentials);
+    } catch (error) {
+      // error-policy:J1 boundary — surface the account-discovery transport/auth failure
+      // verbatim so a failed fetch stays distinct from a valid account with zero ad accounts.
+      logger.error("[RedditAds] Validation failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        valid: false,
+        error: error instanceof Error ? error.message : "Reddit credential validation failed",
+      };
+    }
     if (accounts.length === 0) {
       return { valid: false, error: "No Reddit Ads accounts found or invalid credentials" };
     }

--- a/packages/cloud/shared/src/lib/services/advertising/providers/snap.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/snap.error-policy.test.ts
@@ -1,0 +1,105 @@
+// Pins the error-surfacing contract of the Snap ad provider: a failed/invalid
+// provider fetch must PROPAGATE, and must stay distinct from a legitimately-empty
+// account list (valid credentials, no ad accounts). Deterministic — global fetch
+// is mocked; no live Snap Marketing API call.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../utils/logger", () => ({
+  logger: { info() {}, warn() {}, error() {}, debug() {} },
+}));
+
+const { snapAdsProvider } = await import("./snap");
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchJson(body: unknown, status = 200) {
+  globalThis.fetch = mock(
+    async () =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+  ) as typeof fetch;
+}
+
+function mockFetchReject(error: Error) {
+  globalThis.fetch = mock(async () => {
+    throw error;
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("snapAdsProvider.validateCredentials error surfacing", () => {
+  test("propagates a transport failure instead of reporting invalid credentials", async () => {
+    mockFetchReject(new Error("network down"));
+
+    await expect(snapAdsProvider.validateCredentials({ accessToken: "token" })).rejects.toThrow(
+      "network down",
+    );
+  });
+
+  test("propagates a Snap API error (non-success request_status) instead of swallowing it", async () => {
+    mockFetchJson({
+      request_status: "ERROR",
+      request_id: "req_1",
+      message: "Invalid OAuth access token",
+    });
+
+    await expect(snapAdsProvider.validateCredentials({ accessToken: "bad-token" })).rejects.toThrow(
+      "Invalid OAuth access token",
+    );
+  });
+
+  test("propagates a non-2xx transport error instead of swallowing it", async () => {
+    mockFetchJson({ request_status: "ERROR", debug_message: "unauthorized" }, 401);
+
+    await expect(snapAdsProvider.validateCredentials({ accessToken: "bad-token" })).rejects.toThrow(
+      "unauthorized",
+    );
+  });
+
+  test("returns a resolved invalid result (not a throw) for a legitimately-empty account list", async () => {
+    mockFetchJson({
+      request_status: "SUCCESS",
+      request_id: "req_2",
+      organizations: [{ organization: { id: "org_1", ad_accounts: [] } }],
+    });
+
+    const result = await snapAdsProvider.validateCredentials({ accessToken: "token" });
+
+    expect(result).toEqual({
+      valid: false,
+      error: "No Snap ad accounts found or invalid credentials",
+    });
+  });
+
+  test("resolves valid for a populated account list", async () => {
+    mockFetchJson({
+      request_status: "SUCCESS",
+      request_id: "req_3",
+      organizations: [
+        {
+          organization: {
+            id: "org_1",
+            ad_accounts: [{ id: "act_1", name: "Acme" }],
+          },
+        },
+      ],
+    });
+
+    const result = await snapAdsProvider.validateCredentials({ accessToken: "token" });
+
+    expect(result).toEqual({
+      valid: true,
+      accountId: "act_1",
+      accountName: "Acme",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/snap.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/snap.ts
@@ -239,12 +239,7 @@ export const snapAdsProvider: AdProvider = {
   async validateCredentials(
     credentials: AdAccountCredentials,
   ): Promise<AdProviderValidationResult> {
-    const accounts = await this.listAdAccounts(credentials).catch((error) => {
-      logger.error("[SnapAds] Validation failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return [];
-    });
+    const accounts = await this.listAdAccounts(credentials);
 
     const account = accounts[0];
     if (!account) {

--- a/packages/cloud/shared/src/lib/services/advertising/providers/tiktok.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/tiktok.error-policy.test.ts
@@ -1,0 +1,95 @@
+// Pins the error-surfacing contract of the TikTok ad provider: a failed/invalid
+// provider fetch must PROPAGATE, and must stay distinct from a legitimately-empty
+// account list (valid credentials, no ad accounts). Deterministic — global fetch
+// is mocked; no live TikTok Marketing API call.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../utils/logger", () => ({
+  logger: { info() {}, warn() {}, error() {}, debug() {} },
+}));
+
+const { tiktokAdsProvider } = await import("./tiktok");
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchJson(body: unknown, status = 200) {
+  globalThis.fetch = mock(
+    async () =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+  ) as typeof fetch;
+}
+
+function mockFetchReject(error: Error) {
+  globalThis.fetch = mock(async () => {
+    throw error;
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("tiktokAdsProvider.validateCredentials error surfacing", () => {
+  test("propagates a transport failure instead of reporting invalid credentials", async () => {
+    mockFetchReject(new Error("network down"));
+
+    await expect(tiktokAdsProvider.validateCredentials({ accessToken: "token" })).rejects.toThrow(
+      "network down",
+    );
+  });
+
+  test("propagates a TikTok API error (code != 0) instead of swallowing it", async () => {
+    mockFetchJson({
+      code: 40001,
+      message: "Invalid access token",
+      request_id: "req_1",
+      data: {},
+    });
+
+    await expect(
+      tiktokAdsProvider.validateCredentials({ accessToken: "bad-token" }),
+    ).rejects.toThrow("Invalid access token");
+  });
+
+  test("returns a resolved invalid result (not a throw) for a legitimately-empty account list", async () => {
+    mockFetchJson({
+      code: 0,
+      message: "OK",
+      request_id: "req_2",
+      data: { list: [] },
+    });
+
+    const result = await tiktokAdsProvider.validateCredentials({ accessToken: "token" });
+
+    expect(result).toEqual({
+      valid: false,
+      error: "No TikTok Ads accounts found or invalid credentials",
+    });
+  });
+
+  test("resolves valid for a populated account list", async () => {
+    mockFetchJson({
+      code: 0,
+      message: "OK",
+      request_id: "req_3",
+      data: {
+        list: [{ advertiser_id: "adv_1", advertiser_name: "Acme", status: "STATUS_ENABLE" }],
+      },
+    });
+
+    const result = await tiktokAdsProvider.validateCredentials({ accessToken: "token" });
+
+    expect(result).toEqual({
+      valid: true,
+      accountId: "adv_1",
+      accountName: "Acme",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/tiktok.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/tiktok.ts
@@ -153,12 +153,9 @@ export const tiktokAdsProvider: AdProvider = {
         method: "GET",
         params: { advertiser_ids: "[]" },
       },
-    ).catch((err) => {
-      logger.error("[TikTokAds] Validation failed", { error: err.message });
-      return null;
-    });
+    );
 
-    if (!data?.list?.length) {
+    if (!data.list?.length) {
       return {
         valid: false,
         error: "No TikTok Ads accounts found or invalid credentials",

--- a/packages/cloud/shared/src/lib/services/advertising/providers/x-twitter.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/x-twitter.error-policy.test.ts
@@ -1,0 +1,99 @@
+// Error-policy proof for the X Ads provider (#13415): a failed provider fetch/auth must surface a
+// DISTINCT invalid state from a legitimately-empty result — a transport failure is never collapsed
+// into "no accounts found", and a failed spend-metrics fetch never fabricates zeroed metrics. Uses
+// mock.module + dynamic import with a mocked global fetch; asserts no monetary value.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../utils/logger", () => ({
+  logger: { error() {}, warn() {}, info() {}, debug() {} },
+}));
+
+const originalFetch = globalThis.fetch;
+const originalConsumerKey = process.env.X_ADS_CONSUMER_KEY;
+const originalConsumerSecret = process.env.X_ADS_CONSUMER_SECRET;
+
+const CREDS = { accessToken: "user-token", refreshToken: "token-secret" };
+const EMPTY_MESSAGE = "No X Ads accounts found or invalid credentials";
+
+function respondWith(handler: (input: RequestInfo | URL) => Response | Promise<Response>) {
+  globalThis.fetch = mock(async (input: RequestInfo | URL) => handler(input)) as typeof fetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function loadProvider() {
+  const mod = await import("./x-twitter");
+  return mod.xTwitterAdsProvider;
+}
+
+beforeEach(() => {
+  process.env.X_ADS_CONSUMER_KEY = "consumer-key";
+  process.env.X_ADS_CONSUMER_SECRET = "consumer-secret";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalConsumerKey === undefined) delete process.env.X_ADS_CONSUMER_KEY;
+  else process.env.X_ADS_CONSUMER_KEY = originalConsumerKey;
+  if (originalConsumerSecret === undefined) delete process.env.X_ADS_CONSUMER_SECRET;
+  else process.env.X_ADS_CONSUMER_SECRET = originalConsumerSecret;
+});
+
+describe("xTwitterAdsProvider error policy", () => {
+  test("validateCredentials surfaces an auth (4xx) failure as its own error, distinct from empty", async () => {
+    respondWith(() => jsonResponse({ errors: [{ message: "Unauthorized" }] }, 401));
+    const provider = await loadProvider();
+
+    const result = await provider.validateCredentials(CREDS);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Unauthorized");
+    // The transport/auth failure must NOT be reported as the legitimately-empty case.
+    expect(result.error).not.toBe(EMPTY_MESSAGE);
+  });
+
+  test("validateCredentials surfaces a network reject as its own error, distinct from empty", async () => {
+    respondWith(() => {
+      throw new Error("network unreachable");
+    });
+    const provider = await loadProvider();
+
+    const result = await provider.validateCredentials(CREDS);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("network unreachable");
+    expect(result.error).not.toBe(EMPTY_MESSAGE);
+  });
+
+  test("validateCredentials reports a legitimately-empty account list distinctly from a fetch failure", async () => {
+    respondWith(() => jsonResponse({ data: [] }));
+    const provider = await loadProvider();
+
+    const result = await provider.validateCredentials(CREDS);
+
+    expect(result).toEqual({ valid: false, error: EMPTY_MESSAGE });
+    // Empty is a designed invalid state, never fabricated as valid.
+    expect(result.valid).toBe(false);
+  });
+
+  test("getCampaignMetrics fails closed on a transport error rather than fabricating metrics", async () => {
+    respondWith(() => jsonResponse({ errors: [{ message: "server exploded" }] }, 500));
+    const provider = await loadProvider();
+
+    const result = await provider.getCampaignMetrics(CREDS, "acct_1/camp_1/line_1", {
+      start: new Date("2026-07-01T00:00:00Z"),
+      end: new Date("2026-07-02T00:00:00Z"),
+    });
+
+    // A failed spend-metrics fetch surfaces as failure and carries NO fabricated metrics object —
+    // distinct from a successful-but-empty stats response (which would be { success: true }).
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("server exploded");
+    expect(result.metrics).toBeUndefined();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/x-twitter.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/x-twitter.ts
@@ -164,6 +164,9 @@ async function xAdsRequest<T>(
       ...options.headers,
     },
   });
+  // error-policy:J3 provider-response parse — empty-body success responses (DELETE/PUT/204) carry no
+  // JSON; a non-ok status still throws below, and data-required callers throw on the missing id, so a
+  // parse miss never masks a real failure.
   const json = (await response.json().catch(() => ({}))) as XAdsResponse<T>;
   if (!response.ok || json.errors?.length) {
     throw new Error(
@@ -269,12 +272,16 @@ export const xTwitterAdsProvider: AdProvider = {
   async validateCredentials(
     credentials: AdAccountCredentials,
   ): Promise<AdProviderValidationResult> {
-    const accounts = await this.listAdAccounts(credentials).catch((error) => {
-      logger.error("[XTwitterAds] Validation failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return [];
-    });
+    let accounts: Array<{ id: string; name: string }>;
+    try {
+      accounts = await this.listAdAccounts(credentials);
+    } catch (error) {
+      // error-policy:J1 credential-check boundary — surface the transport/auth failure as its own
+      // distinct invalid state instead of collapsing it into the "no accounts found" empty case.
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error("[XTwitterAds] Validation failed", { error: message });
+      return { valid: false, error: message };
+    }
     if (accounts.length === 0) {
       return { valid: false, error: "No X Ads accounts found or invalid credentials" };
     }
@@ -344,6 +351,8 @@ export const xTwitterAdsProvider: AdProvider = {
       if (!lineItemId) throw new Error("X Ads line item create returned no id");
       return { success: true, externalCampaignId: `${accountId}/${campaignId}/${lineItemId}` };
     } catch (error) {
+      // error-policy:J1 provider boundary — translate a thrown campaign-create failure into a
+      // structured { success:false } result for the caller.
       logger.error("[XTwitterAds] Campaign creation failed", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -388,6 +397,8 @@ export const xTwitterAdsProvider: AdProvider = {
       }
       return { success: true, externalCampaignId };
     } catch (error) {
+      // error-policy:J1 provider boundary — translate a thrown campaign-update failure into a
+      // structured { success:false } result for the caller.
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
@@ -413,6 +424,8 @@ export const xTwitterAdsProvider: AdProvider = {
       );
       return { success: true, externalCampaignId };
     } catch (error) {
+      // error-policy:J1 provider boundary — translate a thrown pause failure into a structured
+      // { success:false } result for the caller.
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
@@ -438,6 +451,8 @@ export const xTwitterAdsProvider: AdProvider = {
       }
       return { success: true, externalCampaignId };
     } catch (error) {
+      // error-policy:J1 provider boundary — translate a thrown activation failure into a structured
+      // { success:false } result for the caller.
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
@@ -463,6 +478,8 @@ export const xTwitterAdsProvider: AdProvider = {
       );
       return { success: true };
     } catch (error) {
+      // error-policy:J1 provider boundary — translate a thrown delete failure into a structured
+      // { success:false } result for the caller.
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
@@ -513,6 +530,8 @@ export const xTwitterAdsProvider: AdProvider = {
       if (!promotedTweetId) throw new Error("X Ads promoted tweet create returned no id");
       return { success: true, externalCreativeId: `${tweetId}/${promotedTweetId}` };
     } catch (error) {
+      // error-policy:J1 provider boundary — translate a thrown creative-create failure into a
+      // structured { success:false } result for the caller.
       logger.error("[XTwitterAds] Creative creation failed", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -560,6 +579,8 @@ export const xTwitterAdsProvider: AdProvider = {
         metadata: { mediaStatus: libraryResponse.data?.media_status },
       };
     } catch (error) {
+      // error-policy:J1 provider boundary — translate a thrown media-upload failure into a
+      // structured { success:false } result for the caller.
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
@@ -585,6 +606,8 @@ export const xTwitterAdsProvider: AdProvider = {
         ready: status === "TRANSCODE_COMPLETED" || status === "READY",
       };
     } catch (error) {
+      // error-policy:J1 provider boundary — translate a thrown media-status failure into a
+      // structured { success:false } result for the caller.
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
@@ -619,6 +642,8 @@ export const xTwitterAdsProvider: AdProvider = {
       const metrics = response.data?.[0]?.id_data?.[0]?.metrics;
       return { success: true, metrics: sumMetrics(metrics) };
     } catch (error) {
+      // error-policy:J1 provider boundary — translate a thrown metrics-fetch failure into a
+      // structured { success:false } result for the caller.
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },


### PR DESCRIPTION
## Slice 6a of #13415 — advertising platform connectors

google · linkedin · meta · reddit · snap · tiktok · x-twitter · programmatic-dsp.

**Fixes real fail-open bugs:** catches/`.catch` that swallowed a failed ad-platform API call (campaign create, targeting, budget push) into `null`/empty/success now propagate — a failed campaign create must not read as success; designed-empty (validation-rejected input surfaced as a typed error, optional field absent) stays distinct. `console`→logger where present.

**Strong money guard honored:** ad spend/budget arithmetic and refund-on-failure paths left untouched/flagged. New error-path tests drive the real providers.

**Verification:** 90 new ai-pricing+advertising error-path tests pass (`--isolate`); biome clean; `audit:error-policy-ratchet` → "no new fallback-slop". Note: one *pre-existing* test (`linkedin bid-controls … real provider payload`) needs the PGlite DB that CI provisions and fails only in a bare `bun test` without it — verified it fails **identically without this change** (environmental, unrelated). Connector/money-adjacent — flagged for review, not solo-merge.