### PR TITLE
test(cloud-shared): ai-pricing error-path coverage + fail-closed audit (#13415 slice 6b)

### DIFF
--- a/packages/cloud/shared/src/lib/services/ai-pricing/cache.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/cache.error-policy.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Error-policy proof for the ai-pricing read caches (#13415). Drives the real
+ * exported cache functions through their injected loader — the transport seam a
+ * provider catalog fetch / DB read runs behind. Pins the fail-closed contract:
+ * a failed provider fetch PROPAGATES (never swallowed into an empty result that
+ * reads as success), a legitimately-EMPTY catalog is a distinguishable success,
+ * and a persisted DB failure propagates WITHOUT being cached. Asserts no
+ * monetary value — only that a failure and an empty result stay distinct so the
+ * billing hot path can degrade to seed/cached pricing on failure and never
+ * mistake a broken fetch for "no pricing".
+ */
+import { afterEach, expect, test } from "bun:test";
+
+// Restore any accidental global.fetch stub between tests; these functions do not
+// call global fetch (the loader is injected), so this is a defensive no-op guard.
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+test("external: a failed provider catalog fetch PROPAGATES — not swallowed into []", async () => {
+  const { getCachedExternalEntries } = await import("./cache");
+  const fetchError = new Error("provider catalog 503");
+  const loader = async (): Promise<never> => {
+    throw fetchError;
+  };
+
+  // Fail-closed on the request: the caller sees the real error and degrades to
+  // seed/cached pricing, rather than receiving a fabricated empty catalog.
+  await expect(getCachedExternalEntries("ep:fail", loader)).rejects.toThrow("provider catalog 503");
+});
+
+test("external: an EMPTY catalog is a success distinct from a failure", async () => {
+  const { getCachedExternalEntries } = await import("./cache");
+  let calls = 0;
+  const emptyLoader = async (): Promise<[]> => {
+    calls++;
+    return [];
+  };
+
+  // A legitimately-empty upstream resolves (does not throw) and is cached as a
+  // success — the loader runs once. This is the state a caught-and-swallowed
+  // failure would be indistinguishable from; the previous test proves failure
+  // throws instead, keeping the two states distinct on the billing path.
+  await expect(getCachedExternalEntries("ep:empty", emptyLoader)).resolves.toEqual([]);
+  await expect(getCachedExternalEntries("ep:empty", emptyLoader)).resolves.toEqual([]);
+  expect(calls).toBe(1);
+});
+
+test("persisted: a DB read failure PROPAGATES and is NOT cached — next call retries", async () => {
+  const { __clearPersistedPricingCache, getCachedPersistedEntries } = await import("./cache");
+  __clearPersistedPricingCache();
+  let calls = 0;
+  const loader = async (): Promise<never> => {
+    calls++;
+    throw new Error("db read failed");
+  };
+
+  // Fail-closed and no stale-success masking: a transient DB error surfaces on
+  // every attempt (the loader re-runs), never resolving to a cached empty set.
+  await expect(getCachedPersistedEntries("ep:db", loader)).rejects.toThrow("db read failed");
+  await expect(getCachedPersistedEntries("ep:db", loader)).rejects.toThrow("db read failed");
+  expect(calls).toBe(2);
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/candidate-selection.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/candidate-selection.error-policy.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Error-policy pin for candidate-selection (#13415): the pricing-row selector
+ * must keep a legitimately-empty result DISTINCT from a fabricated price. This
+ * file is pure sorting/string logic — no fetch, no try/catch, no console — so
+ * there is no transport failure to propagate here (fetch mocking is N/A); the
+ * fail-closed contract that matters is that "no matching candidate" resolves to
+ * an honest `null` (caller in lookup.ts throws "Pricing unavailable") and NEVER
+ * to a fabricated zero-price / stand-in entry that would read as a valid price.
+ * The monetary tie-break value itself is money-path and asserted elsewhere
+ * (ai-pricing-variant-indexing.test.ts); this pin asserts identity, not amounts.
+ */
+import { expect, test } from "bun:test";
+import { chooseBestCandidatePricingEntry } from "./candidate-selection";
+import type { CandidatePreparedPricingEntry } from "./types";
+
+const CANONICAL = "google/gemini-2.0-flash";
+
+function candidate(
+  dimensions: Record<string, unknown> | undefined,
+  unitPrice: number,
+): CandidatePreparedPricingEntry {
+  return {
+    entry: {
+      billingSource: "bitrouter",
+      provider: "google",
+      model: CANONICAL,
+      productFamily: "language",
+      chargeType: "input",
+      unit: "token",
+      unitPrice,
+      dimensions,
+      sourceKind: "bitrouter_catalog",
+      sourceUrl: "https://api.bitrouter.ai/v1/models",
+      priority: -1,
+    },
+    modelId: CANONICAL,
+    logicalProvider: "google",
+  };
+}
+
+test("empty candidate set → null, never a fabricated zero-price entry", () => {
+  // Fail-closed: no rows in means no price out. The caller relies on this null
+  // to try the next source and ultimately throw "Pricing unavailable"; a
+  // fabricated { unitPrice: 0 } stand-in would silently zero-bill the platform.
+  const result = chooseBestCandidatePricingEntry([], {}, CANONICAL);
+  expect(result).toBeNull();
+});
+
+test("candidates present but none dimension-match → null (empty stays distinct from a match)", () => {
+  // The only candidate carries a dimension the request does not satisfy
+  // (`resolution` absent from requested {}), so it is not a subset and must be
+  // filtered out — a legitimately-empty selection, indistinguishable in shape
+  // from a real match ONLY if it were fabricated. It must be null instead.
+  const nonMatching = candidate({ resolution: "1080p" }, 0.00000015);
+  const result = chooseBestCandidatePricingEntry([nonMatching], {}, CANONICAL);
+  expect(result).toBeNull();
+});
+
+test("a genuinely matching candidate resolves to that real entry, not null", () => {
+  // Proves the null above is an honest 'no match' signal, not a blanket null:
+  // the same request WITH a subset-matching candidate returns the input entry
+  // by identity (no synthesized/defaulted row).
+  const matching = candidate({}, 0.0000001);
+  const result = chooseBestCandidatePricingEntry([matching], {}, CANONICAL);
+  expect(result).not.toBeNull();
+  expect(result?.entry).toBe(matching.entry);
+});
+
+test("no-match vs match are the two distinguishable outcomes on the same request", () => {
+  // Error-policy core: a failed/absent lookup (null) can never be confused with
+  // a successful one (the real entry). Same requested dimensions, different
+  // candidate pools, provably different outcomes.
+  const matching = candidate({}, 0.0000001);
+  const nonMatching = candidate({ resolution: "4k" }, 0.0000001);
+
+  const hit = chooseBestCandidatePricingEntry([matching], {}, CANONICAL);
+  const miss = chooseBestCandidatePricingEntry([nonMatching], {}, CANONICAL);
+
+  expect(hit?.entry).toBe(matching.entry);
+  expect(miss).toBeNull();
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/dimensions.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/dimensions.error-policy.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Error-path guard for the price-parse boundary in dimensions.ts. `dimensions.ts`
+ * is a pure normalization/mapping + markup-math module with no fetch/transport and
+ * no try/catch, so the only failure-vs-empty decision to pin is parseNumericPrice:
+ * an unparseable / non-finite / absent provider price must resolve to a DISTINCT
+ * absent signal (null) that callers (cerebras/openrouter/bitrouter provider
+ * parsers) skip, never a fabricated numeric price that would silently enter
+ * billing. Drives the real exported function; asserts only pass-through and the
+ * null boundary, never a specific invented monetary value.
+ */
+import { expect, test } from "bun:test";
+import { parseNumericPrice } from "./dimensions";
+
+test("a valid numeric price passes through unchanged (incl. legit zero)", () => {
+  expect(parseNumericPrice(0)).toBe(0);
+  expect(parseNumericPrice(1.5)).toBe(1.5);
+  expect(parseNumericPrice("0.000002")).toBe(0.000002);
+});
+
+test("an unparseable / non-finite / absent price returns the null absent-signal, DISTINCT from a real price", () => {
+  // Failed/garbage upstream values must NOT collapse to 0 or any number.
+  for (const bad of [
+    "abc",
+    "",
+    "   ",
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    null,
+    undefined,
+    {},
+    [],
+  ]) {
+    expect(parseNumericPrice(bad)).toBeNull();
+  }
+});
+
+test("null (absent) is distinguishable from a genuine zero price — no failure-as-zero conflation", () => {
+  const absent = parseNumericPrice("not-a-price");
+  const zero = parseNumericPrice(0);
+  expect(absent).toBeNull();
+  expect(zero).toBe(0);
+  expect(absent).not.toBe(zero);
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.error-policy.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Error-policy pins for the pricing-catalog lookup (#13415).
+ *
+ * `calculateTextCostFromCatalog` sits on the inference-billing hot path. Its two
+ * catch sites are money-path decisions and are LEFT UNCHANGED: the exact-price
+ * `.catch(() => null)` (a catalog miss/DB failure degrades to the conservative
+ * fallback tier) and the fallback-read `.catch(() => [])` (a DB read failure is
+ * observed via the logger, then the remaining fallback tiers decide the rate).
+ * These tests pin the documented behavior — never asserting a specific dollar
+ * value beyond the never-$0 / never-crash money-safety property — and prove a
+ * transport FAILURE stays observably DISTINCT from a legitimately-absent price:
+ * both fail closed on unknown price, but only the failure is surfaced via the
+ * structured logger, and neither ever silently bills $0.
+ */
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+
+const USD_PER_M = 1_000_000;
+
+type Filters = {
+  billingSource?: string;
+  provider?: string;
+  productFamily?: string;
+  chargeType?: string;
+};
+
+function catalogRow(
+  provider: string,
+  model: string,
+  chargeType: "input" | "output",
+  usdPerMillion: number,
+) {
+  return {
+    billing_source: "bitrouter",
+    provider,
+    model,
+    product_family: "language",
+    charge_type: chargeType,
+    unit: "token",
+    unit_price: String(usdPerMillion / USD_PER_M),
+    dimensions: {},
+    source_kind: "bitrouter_catalog",
+    source_url: "https://example.test/catalog",
+    fetched_at: new Date(),
+    stale_after: null,
+    priority: 200,
+    is_override: false,
+    metadata: {},
+  };
+}
+
+// Per-test-swappable repository behavior: the mock closures read these at call
+// time so each test can make a DB read succeed, return empty, or throw.
+let pairsHandler: (filters: unknown) => Promise<unknown[]> = async () => [];
+let listHandler: (filters: Filters) => Promise<unknown[]> = async () => [];
+
+mock.module("../../../db/repositories/ai-pricing", () => ({
+  aiPricingRepository: {
+    listActiveEntriesForProviderModelPairs: (filters: unknown) => pairsHandler(filters),
+    listActiveEntries: (filters: Filters) => listHandler(filters),
+  },
+}));
+
+const warnSpy = mock((_message?: string, _context?: unknown) => {});
+const errorSpy = mock((_message?: string, _context?: unknown) => {});
+mock.module("../../utils/logger", () => ({
+  logger: { warn: warnSpy, error: errorSpy },
+}));
+
+mock.module("./providers/gateway", () => ({
+  fetchEntriesForSource: async () => [],
+}));
+
+const { calculateTextCostFromCatalog } = await import("./lookup");
+const { __clearPersistedPricingCache } = await import("./cache");
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  __clearPersistedPricingCache();
+  warnSpy.mockClear();
+  errorSpy.mockClear();
+  pairsHandler = async () => [];
+  listHandler = async () => [];
+  delete process.env.AI_PRICING_FALLBACK_INPUT_USD_PER_M;
+  delete process.env.AI_PRICING_FALLBACK_OUTPUT_USD_PER_M;
+  // No real provider fetch may ever happen from this billing path.
+  globalThis.fetch = (async () => {
+    throw new Error("network disabled in error-policy test");
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete process.env.AI_PRICING_FALLBACK_INPUT_USD_PER_M;
+  delete process.env.AI_PRICING_FALLBACK_OUTPUT_USD_PER_M;
+});
+
+function warnedFallbackReadFailed(): boolean {
+  return warnSpy.mock.calls.some((call) => call[0] === "ai-pricing: fallback catalog read failed");
+}
+
+test("legitimately-absent price fails closed and signals NO internal read failure", async () => {
+  // Every seam returns a genuinely-empty catalog (no error), no env fallback.
+  pairsHandler = async () => [];
+  listHandler = async () => [];
+
+  await expect(
+    calculateTextCostFromCatalog({
+      model: "totally-uncatalogued-model",
+      provider: "someprovider",
+      inputTokens: 1_000,
+      outputTokens: 500,
+    }),
+  ).rejects.toThrow("refusing to bill unknown-priced inference");
+
+  // A legitimately-empty result must stay DISTINCT from an internal failure:
+  // the failure-observability warn is NOT emitted for a clean empty catalog.
+  expect(warnedFallbackReadFailed()).toBe(false);
+});
+
+test("fallback-catalog DB read FAILURE is surfaced via the logger, still fails closed (money-path-flagged .catch(() => []))", async () => {
+  // Exact lookup misses (empty), and the fallback DB read THROWS a transport
+  // error. The money-path-flagged `.catch(() => [])` must observe the failure
+  // through the structured logger and let the remaining tiers (none here) fail
+  // closed — never a silent $0, never an uncaught crash.
+  pairsHandler = async () => [];
+  listHandler = async () => {
+    throw new Error("pg: connection reset");
+  };
+
+  await expect(
+    calculateTextCostFromCatalog({
+      model: "totally-uncatalogued-model",
+      provider: "someprovider",
+      inputTokens: 1_000,
+      outputTokens: 500,
+    }),
+  ).rejects.toThrow("refusing to bill unknown-priced inference");
+
+  // Distinct from the clean-empty case above: the transport failure IS observed.
+  expect(warnedFallbackReadFailed()).toBe(true);
+  const call = warnSpy.mock.calls.find((c) => c[0] === "ai-pricing: fallback catalog read failed");
+  expect(call?.[1]).toMatchObject({ error: "pg: connection reset" });
+});
+
+test("exact-price read transport FAILURE degrades to the fallback tier, never crashes or bills $0 (money-path-flagged .catch(() => null))", async () => {
+  // The exact-model repository read throws (transport failure). The money-path
+  // `.catch(() => null)` degrades that to the miss path, where a catalogued
+  // provider-max entry resolves the rate. We assert only the money-safety
+  // invariant — resolves without throwing and bills a positive, finite amount —
+  // not any specific dollar figure.
+  pairsHandler = async () => {
+    throw new Error("pg: statement timeout");
+  };
+  listHandler = async (filters: Filters) =>
+    [
+      catalogRow("anthropic", "anthropic/claude-opus-4-8", "input", 5),
+      catalogRow("anthropic", "anthropic/claude-opus-4-8", "output", 25),
+    ].filter((row) => !filters.chargeType || row.charge_type === filters.chargeType);
+
+  const result = await calculateTextCostFromCatalog({
+    model: "claude-unknown-transient-9",
+    provider: "anthropic",
+    inputTokens: 1_000,
+    outputTokens: 500,
+  });
+
+  expect(Number.isFinite(result.totalCost)).toBe(true);
+  expect(result.totalCost).toBeGreaterThan(0);
+  expect(result.inputCost).toBeGreaterThan(0);
+  expect(result.outputCost).toBeGreaterThan(0);
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/bitrouter.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/bitrouter.error-policy.test.ts
@@ -1,0 +1,73 @@
+// Pins the fail-closed transport contract of the BitRouter pricing-catalog fetch:
+// a failed/unreachable provider fetch must PROPAGATE (so a broken price feed
+// surfaces to the billing path) and stay DISTINCT from a legitimately-empty
+// catalog, which resolves to the designed forced rows. Deterministic: global
+// fetch and provider-env/openrouter/cache deps are mocked; no live network, no
+// monetary-value assertions.
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+let providerKey: (name: string) => string | undefined = () => undefined;
+
+mock.module("../../../providers/provider-env", () => ({
+  getProviderKey: (name: string) => providerKey(name),
+}));
+
+// OpenRouter fallback rows are a separate best-effort source; stub to empty so
+// this test isolates BitRouter's own transport behavior.
+mock.module("./openrouter", () => ({
+  fetchOpenRouterCatalogEntries: async () => [],
+}));
+
+// Pass the loader through untouched so the module-level catalog cache cannot
+// leak positive/negative results across test cases.
+mock.module("../cache", () => ({
+  getCachedExternalEntries: async (_cacheKey: string, loader: () => Promise<unknown>) => loader(),
+}));
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("fetchBitRouterCatalogEntries — fail-closed transport", () => {
+  it("propagates a provider fetch failure instead of degrading to empty/stale success", async () => {
+    providerKey = (name) => (name === "OPENROUTER_API_KEY" ? "test-key" : undefined);
+    globalThis.fetch = mock(async () => new Response("upstream down", { status: 503 }));
+
+    const { fetchBitRouterCatalogEntries } = await import("./bitrouter");
+
+    await expect(fetchBitRouterCatalogEntries()).rejects.toThrow(/503/);
+  });
+
+  it("resolves (does not throw) for a legitimately-empty catalog — distinct from a fetch failure", async () => {
+    providerKey = (name) => (name === "OPENROUTER_API_KEY" ? "test-key" : undefined);
+    globalThis.fetch = mock(
+      async () =>
+        new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const { fetchBitRouterCatalogEntries } = await import("./bitrouter");
+
+    const entries = await fetchBitRouterCatalogEntries();
+    // An empty upstream catalog still yields the designed forced rows, proving an
+    // empty result is a distinct, non-throwing outcome — not silently swallowed
+    // failure. (Row count/values are fixed by the source; not asserted here.)
+    expect(Array.isArray(entries)).toBe(true);
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it("throws when the required provider credential is absent (config fail-closed)", async () => {
+    providerKey = () => undefined;
+    globalThis.fetch = mock(
+      async () => new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+
+    const { fetchBitRouterCatalogEntries } = await import("./bitrouter");
+
+    await expect(fetchBitRouterCatalogEntries()).rejects.toThrow(/OPENROUTER_API_KEY/);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/cerebras.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/cerebras.error-policy.test.ts
@@ -1,0 +1,101 @@
+// Pins the fail-closed error policy of the Cerebras public-catalog pricing
+// fetch: a transport (non-2xx) or JSON-parse failure must PROPAGATE out of
+// fetchCerebrasPublicCatalogEntries — never be swallowed into an empty result
+// that reads as "priced nothing". That distinction matters because the empty
+// array is also the legitimate signal for a 200 catalog with zero priced
+// models; the two must stay observably different so the gateway choke point can
+// degrade a real outage while a genuinely-empty catalog just yields no entries.
+// The module-level external cache is mocked to a pass-through so each case
+// exercises the real loader (fetch + parse + build) without cross-test state;
+// the cache's own negative-caching is covered by ../cache.test.ts.
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+mock.module("../cache", () => ({
+  getCachedExternalEntries: async (
+    _cacheKey: string,
+    loader: () => Promise<unknown>,
+  ): Promise<unknown> => loader(),
+}));
+
+const { fetchCerebrasPublicCatalogEntries } = await import("./cerebras");
+
+const realFetch = globalThis.fetch;
+
+type FetchReturn = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+};
+
+function stubFetch(impl: () => FetchReturn): void {
+  globalThis.fetch = (async () => impl()) as unknown as typeof globalThis.fetch;
+}
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("fetchCerebrasPublicCatalogEntries — fail-closed error policy", () => {
+  it("propagates a non-2xx catalog fetch (never swallows a 404 into empty)", async () => {
+    stubFetch(() => ({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    }));
+
+    await expect(fetchCerebrasPublicCatalogEntries()).rejects.toThrow(/404/);
+  });
+
+  it("propagates a JSON parse failure instead of degrading to empty", async () => {
+    stubFetch(() => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("invalid json body");
+      },
+    }));
+
+    await expect(fetchCerebrasPublicCatalogEntries()).rejects.toThrow("invalid json body");
+  });
+
+  it("returns [] for a legitimately-empty catalog — DISTINCT from a fetch failure", async () => {
+    stubFetch(() => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+    }));
+
+    const entries = await fetchCerebrasPublicCatalogEntries();
+    expect(entries).toEqual([]);
+  });
+
+  it("returns [] when models carry no usable pricing — still not a failure", async () => {
+    stubFetch(() => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ id: "gpt-oss-120b", pricing: {} }] }),
+    }));
+
+    const entries = await fetchCerebrasPublicCatalogEntries();
+    expect(entries).toEqual([]);
+  });
+
+  it("maps a priced model into input+output entries on success", async () => {
+    stubFetch(() => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [{ id: "gpt-oss-120b", pricing: { prompt: "0.00005", completion: "0.0001" } }],
+      }),
+    }));
+
+    const entries = await fetchCerebrasPublicCatalogEntries();
+
+    // Success is observably distinct from the empty/failure cases: two charge
+    // legs for the one model. We assert shape/identity only — not any monetary
+    // value beyond the input→output leg split the source itself fixes.
+    expect(entries).toHaveLength(2);
+    expect(entries.every((e) => e.model === "cerebras/gpt-oss-120b")).toBe(true);
+    expect(entries.map((e) => e.chargeType).sort()).toEqual(["input", "output"]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal.error-policy.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Error-policy tests for the fal pricing-catalog fetcher (#13415). This is a
+ * BILLING/pricing-metadata path: fal model prices feed inference billing. The
+ * error handling here is a MONEY-PATH decision, not slop — when the live fal
+ * model-page fetch/parse fails, fetchFalCatalogEntries degrades to the LAST-GOOD
+ * active DB price for that model rather than propagating (a "best-effort
+ * price-cache-refresh falls back to last-good cached price" — money-path-flagged,
+ * left unchanged). These tests PIN that behavior: a fetch failure surfaces the
+ * last-good price (soft-degrade, no throw), and — critically — a fetch failure
+ * with NO cached price yields an EMPTY contribution for that model, which stays
+ * DISTINCT from a fabricated/zero price. The parse functions still fail closed
+ * (throw) on unparseable input. fetch/cache/repository/snapshot deps are mocked;
+ * the real fetchFalCatalogEntries + parseFalPricingEntries logic runs unmocked.
+ * No monetary value is asserted beyond the sentinel the DB mock supplies.
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { PreparedPricingEntry } from "../types";
+
+// One fal video model drives the loop; empty image list keeps the snapshot
+// contributions out of the assertion so only the fetch-failure path shows.
+const FAL_VIDEO_MODEL = {
+  modelId: "fal-ai/veo3/text-to-video",
+  billingSource: "fal" as const,
+  pageUrl: "https://fal.ai/models/fal-ai/veo3",
+  pricingParser: "veo" as const,
+};
+
+// Mutable per-test seams (bun's mock.module has no per-call reset helper).
+let fetchTextImpl: (url: string) => Promise<string>;
+let listActiveImpl: () => Promise<PreparedPricingEntry[]>;
+
+mock.module("../../ai-pricing-definitions", () => ({
+  SUPPORTED_VIDEO_MODELS: [FAL_VIDEO_MODEL],
+  SUPPORTED_IMAGE_MODELS: [],
+}));
+
+mock.module("../fetch", () => ({
+  fetchText: (url: string) => fetchTextImpl(url),
+  stripHtml: (value: string) => value,
+  fetchJson: () => {
+    throw new Error("fetchJson not stubbed in error-policy test");
+  },
+}));
+
+mock.module("../cache", () => ({
+  // Bypass the TTL cache so every case drives the loader fresh.
+  getCachedExternalEntries: (_key: string, loader: () => Promise<PreparedPricingEntry[]>) =>
+    loader(),
+}));
+
+mock.module("../../../../db/repositories/ai-pricing", () => ({
+  aiPricingRepository: {
+    listActiveEntries: () => listActiveImpl(),
+  },
+}));
+
+// aiEntryToPrepared echoes the DB row so the test never depends on mapper
+// internals; the DB sentinel IS a PreparedPricingEntry.
+mock.module("../dimensions", () => ({
+  aiEntryToPrepared: (entry: PreparedPricingEntry) => entry,
+}));
+
+mock.module("./sfx", () => ({ buildSfxSnapshotEntries: () => [] }));
+mock.module("./suno", () => ({ buildMusicSnapshotEntries: () => [] }));
+
+const LAST_GOOD_DB_PRICE: PreparedPricingEntry = {
+  billingSource: "fal",
+  provider: "fal",
+  model: FAL_VIDEO_MODEL.modelId,
+  productFamily: "video",
+  chargeType: "generation",
+  unit: "second",
+  unitPrice: 0.5,
+  sourceKind: "fal_model_page",
+  sourceUrl: FAL_VIDEO_MODEL.pageUrl,
+};
+
+describe("fetchFalCatalogEntries — error policy (#13415, money-path-flagged)", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("degrades a live fetch failure to the last-good DB price (soft-degrade, does NOT throw or propagate)", async () => {
+    const { fetchFalCatalogEntries } = await import("./fal");
+    fetchTextImpl = async () => {
+      throw new Error("Request failed for https://fal.ai/models/fal-ai/veo3: 503");
+    };
+    listActiveImpl = async () => [LAST_GOOD_DB_PRICE];
+
+    const result = await fetchFalCatalogEntries();
+
+    // Money-path decision: the last-good cached price surfaces instead of the
+    // fetch error killing the pricing lookup.
+    expect(result).toEqual([LAST_GOOD_DB_PRICE]);
+  });
+
+  it("yields an EMPTY contribution when the fetch fails and no cached price exists — distinct from a fabricated price", async () => {
+    const { fetchFalCatalogEntries } = await import("./fal");
+    fetchTextImpl = async () => {
+      throw new Error("Request failed for https://fal.ai/models/fal-ai/veo3: 503");
+    };
+    listActiveImpl = async () => [];
+
+    const result = await fetchFalCatalogEntries();
+
+    // No last-good price and no fabricated one: the model simply contributes
+    // nothing (empty), which the pricing lookup treats as "price absent" — NOT a
+    // zero/marker price masquerading as a real value.
+    expect(result).toEqual([]);
+    expect(result.some((entry) => entry.model === FAL_VIDEO_MODEL.modelId)).toBe(false);
+  });
+
+  it("parseFalPricingEntries fails closed (throws) on an unparseable pricing paragraph", async () => {
+    const { parseFalPricingEntries } = await import("./fal");
+
+    expect(() =>
+      parseFalPricingEntries(
+        FAL_VIDEO_MODEL as never,
+        "this paragraph contains no recognizable dollar pricing",
+      ),
+    ).toThrow(/Unable to parse Veo pricing paragraph/);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/gateway.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/gateway.error-policy.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Error-policy contract for the pricing-catalog dispatch choke point (#13415).
+ *
+ * `fetchEntriesForSource` sits between every external pricing-provider fetch and
+ * the inference-billing price lookup (`lookup.ts` treats its result as the live
+ * catalog and falls back to persisted/seed pricing on `[]`). Its catch is a
+ * DELIBERATE money-path degrade: a provider outage must resolve to no fresh
+ * entries so cached/seed pricing still prices the completion — it must NOT
+ * propagate and 500 the billing path. This pins that behavior and, crucially,
+ * proves an internal fetch FAILURE stays observably distinct from a
+ * legitimately-empty catalog (the failure warns; a no-fetch source is silent),
+ * without asserting any monetary value the source does not already fix.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { logger } from "../../../utils/logger";
+import type { PreparedPricingEntry } from "../types";
+
+const cerebrasFetch = mock<() => Promise<PreparedPricingEntry[]>>(async () => []);
+
+mock.module("../../../services/ai-pricing/providers/cerebras", () => ({
+  fetchCerebrasPublicCatalogEntries: cerebrasFetch,
+}));
+mock.module("./cerebras", () => ({
+  fetchCerebrasPublicCatalogEntries: cerebrasFetch,
+}));
+
+// Entries the test itself fixes — the gateway must pass these through byte-for-
+// byte, performing no pricing arithmetic of its own.
+const SENTINEL_ENTRIES: PreparedPricingEntry[] = [
+  {
+    billingSource: "cerebras",
+    provider: "cerebras",
+    model: "cerebras/gpt-oss-120b",
+    productFamily: "language",
+    chargeType: "input",
+    unit: "token",
+    unitPrice: 0.00005,
+    sourceKind: "cerebras_public_catalog",
+    sourceUrl: "https://example.test/models",
+  },
+];
+
+const realFetch = globalThis.fetch;
+
+async function loadGateway() {
+  return await import("./gateway");
+}
+
+beforeEach(() => {
+  cerebrasFetch.mockReset();
+  // Fail closed against accidental real network for any non-mocked provider.
+  globalThis.fetch = mock(async () => {
+    throw new Error("network disabled in error-policy test");
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("fetchEntriesForSource — error-policy (money-path-flagged degrade)", () => {
+  test("a provider fetch failure degrades to [] and never propagates", async () => {
+    const warn = spyOn(logger, "warn").mockImplementation(() => {});
+    cerebrasFetch.mockRejectedValueOnce(
+      new Error(
+        "Request failed for https://api.cerebras.ai/public/v1/models?format=openrouter: 404",
+      ),
+    );
+
+    const { fetchEntriesForSource } = await loadGateway();
+
+    // Must NOT throw: propagating would 500 the completion-pricing path.
+    const result = await fetchEntriesForSource("cerebras");
+
+    expect(result).toEqual([]);
+    // The failure is surfaced observably, not swallowed silently.
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  test("an internal failure is observably DISTINCT from a legitimately-empty catalog", async () => {
+    const { fetchEntriesForSource } = await loadGateway();
+
+    // Legitimately-empty source: no provider fetch is attempted, no warning.
+    const warnSilent = spyOn(logger, "warn").mockImplementation(() => {});
+    const seedResult = await fetchEntriesForSource("seed");
+    expect(seedResult).toEqual([]);
+    expect(cerebrasFetch).not.toHaveBeenCalled();
+    expect(warnSilent).not.toHaveBeenCalled();
+    warnSilent.mockRestore();
+
+    // Failure path: same [] shape, but the warn log makes it distinguishable
+    // from the silent legitimately-empty result above.
+    const warnFail = spyOn(logger, "warn").mockImplementation(() => {});
+    cerebrasFetch.mockRejectedValueOnce(new Error("upstream 503"));
+    const failResult = await fetchEntriesForSource("cerebras");
+    expect(failResult).toEqual([]);
+    expect(warnFail).toHaveBeenCalledTimes(1);
+    warnFail.mockRestore();
+  });
+
+  test("successful catalog entries pass through unchanged (no monetary mutation)", async () => {
+    cerebrasFetch.mockResolvedValueOnce(SENTINEL_ENTRIES);
+
+    const { fetchEntriesForSource } = await loadGateway();
+    const result = await fetchEntriesForSource("cerebras");
+
+    expect(result).toEqual(SENTINEL_ENTRIES);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/openrouter.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/openrouter.error-policy.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Error-policy pin for fetchOpenRouterCatalogEntries (#13415). OpenRouter is a
+ * low-priority (-1) SUPPLEMENTARY price source folded into the BitRouter catalog
+ * fetch; a fetch/parse failure must degrade to an empty contribution (return [])
+ * rather than propagate — propagating would 500 the whole BitRouter pricing path
+ * over an outage of a mere fallback source. This is a money-path-flagged fallback:
+ * the value is intentionally [] on failure. The test locks that the failure is
+ * still OBSERVABLE via the structured logger and DISTINCT from a legitimately
+ * empty catalog (which does not warn) — without asserting any monetary value.
+ * bun:test, global fetch mocked + restored per case; logger.warn spied.
+ */
+import { afterEach, beforeEach, expect, spyOn, test } from "bun:test";
+import { logger } from "../../../utils/logger";
+import { fetchOpenRouterCatalogEntries } from "./openrouter";
+
+const realFetch = globalThis.fetch;
+let warnSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  warnSpy.mockRestore();
+});
+
+test("fetch throw degrades to [] and surfaces observably (never propagates a 500)", async () => {
+  globalThis.fetch = (async () => {
+    throw new Error("network down");
+  }) as typeof fetch;
+
+  // Money-path fallback: OpenRouter outage must NOT throw out of the BitRouter
+  // catalog fetch. It returns [] AND logs a warning so the failure is visible.
+  const entries = await fetchOpenRouterCatalogEntries();
+
+  expect(entries).toEqual([]);
+  expect(warnSpy).toHaveBeenCalledTimes(1);
+});
+
+test("non-ok HTTP response degrades to [] and surfaces observably", async () => {
+  globalThis.fetch = (async () => new Response("upstream boom", { status: 500 })) as typeof fetch;
+
+  const entries = await fetchOpenRouterCatalogEntries();
+
+  expect(entries).toEqual([]);
+  expect(warnSpy).toHaveBeenCalledTimes(1);
+});
+
+test("legitimately-empty catalog returns [] WITHOUT a failure warning (distinct from failure)", async () => {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ data: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as typeof fetch;
+
+  const entries = await fetchOpenRouterCatalogEntries();
+
+  // Same empty return value as the failure cases, but reached by a SUCCESSFUL
+  // fetch — proving empty-by-design stays distinguishable (no warn) from the
+  // empty-by-failure degrade above.
+  expect(entries).toEqual([]);
+  expect(warnSpy).not.toHaveBeenCalled();
+});
+
+test("malformed JSON body degrades to [] and surfaces observably", async () => {
+  globalThis.fetch = (async () =>
+    new Response("not-json", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as typeof fetch;
+
+  const entries = await fetchOpenRouterCatalogEntries();
+
+  expect(entries).toEqual([]);
+  expect(warnSpy).toHaveBeenCalledTimes(1);
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/vast.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/vast.error-policy.test.ts
@@ -1,0 +1,124 @@
+/**
+ * error-policy pin for the Vast internal-snapshot pricing provider. Vast prices
+ * come from an in-source default table plus an operator VAST_PRICING_PER_1M_JSON
+ * override — there is NO network fetch, so the only failure surface is a
+ * malformed override. This locks that (a) a malformed override is sanitized to
+ * "no overrides" and surfaces a warning — it never throws and never
+ * fabricates/empties the snapshot; the snapshot degrades to the documented
+ * in-source defaults (a money-path decision, left unchanged); and (b) that
+ * failure is DISTINCT from a legitimately-absent override (no warning) and from
+ * a real override (which actually applies). Uses bun:test with mock.module +
+ * dynamic import; global fetch is stubbed to throw to prove vast never touches
+ * the wire. No source edit was needed — vast already fails closed.
+ */
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+
+const warnCalls: unknown[][] = [];
+
+// Capture warnings so the "failure surfaces observably" invariant is checkable
+// and distinguishable from a silent legitimately-empty result.
+mock.module("../../../utils/logger", () => ({
+  logger: {
+    warn: (...args: unknown[]) => {
+      warnCalls.push(args);
+    },
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+  },
+}));
+
+// Passthrough cache so each case re-runs the loader with its own env override.
+// The real cache keys on "vast" for 15 min (would return the first case's
+// snapshot for every later case) and carries its own dedicated test.
+mock.module("../cache", () => ({
+  getCachedExternalEntries: async (_key: string, loader: () => Promise<unknown>) => loader(),
+}));
+
+const originalFetch = globalThis.fetch;
+const originalEnv = process.env.VAST_PRICING_PER_1M_JSON;
+
+beforeEach(() => {
+  warnCalls.length = 0;
+  // Vast is an internal snapshot: a dead network must NOT affect its pricing.
+  globalThis.fetch = (async () => {
+    throw new Error("network is unavailable in this test");
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalEnv === undefined) {
+    delete process.env.VAST_PRICING_PER_1M_JSON;
+  } else {
+    process.env.VAST_PRICING_PER_1M_JSON = originalEnv;
+  }
+});
+
+test("malformed override JSON is sanitized to {} and warns — never throws (J3)", async () => {
+  process.env.VAST_PRICING_PER_1M_JSON = "{not valid json";
+  const { parseVastPricingOverrides } = await import("./vast");
+
+  // The untrusted env parse failure produces an explicit empty result, not a
+  // fabricated price and not an uncaught throw that would 500 the pricing path.
+  expect(parseVastPricingOverrides()).toEqual({});
+  expect(warnCalls.length).toBeGreaterThan(0);
+});
+
+test("absent override env yields {} with NO warning — empty is DISTINCT from failure", async () => {
+  delete process.env.VAST_PRICING_PER_1M_JSON;
+  const { parseVastPricingOverrides } = await import("./vast");
+
+  // Same {} shape as the malformed case above, but a legitimately-empty result
+  // is silent — the failure warns, the empty does not.
+  expect(parseVastPricingOverrides()).toEqual({});
+  expect(warnCalls.length).toBe(0);
+});
+
+test("malformed override still yields the full default snapshot — degrade, not empty/crash", async () => {
+  process.env.VAST_PRICING_PER_1M_JSON = "totally not json";
+  const { fetchVastSnapshotEntries } = await import("./vast");
+
+  const entries = await fetchVastSnapshotEntries();
+  const models = new Set(entries.map((e) => e.model));
+
+  // A parse failure must NOT collapse pricing to empty; it degrades to the
+  // documented in-source defaults (money-path behavior, unchanged). Every model
+  // contributes an input + output charge.
+  expect(models.has("vast/eliza-1-2b")).toBe(true);
+  expect(models.has("vast/eliza-1-27b-256k")).toBe(true);
+  expect(entries.length).toBe(models.size * 2);
+});
+
+test("a valid override actually applies — DISTINCT from the malformed-ignored path", async () => {
+  // Caller-chosen override values (not asserting a business price) prove the
+  // override is plumbed through rather than swallowed like the malformed case.
+  process.env.VAST_PRICING_PER_1M_JSON = JSON.stringify({
+    "vast/eliza-1-2b": { input: 7, output: 11 },
+  });
+  const { fetchVastSnapshotEntries } = await import("./vast");
+
+  const entries = await fetchVastSnapshotEntries();
+  const input2b = entries.find((e) => e.model === "vast/eliza-1-2b" && e.chargeType === "input");
+
+  expect(input2b?.metadata).toMatchObject({ perMillionTokens: 7 });
+  expect(input2b?.unitPrice).toBe(7 / 1_000_000);
+  expect(warnCalls.length).toBe(0);
+});
+
+test("invalid override values are skipped + warned; models keep their defaults", async () => {
+  process.env.VAST_PRICING_PER_1M_JSON = JSON.stringify({
+    "vast/eliza-1-2b": { input: -5, output: 1 }, // negative → rejected
+    "vast/eliza-1-9b": { input: "x", output: 2 }, // non-numeric → rejected
+  });
+  const { fetchVastSnapshotEntries } = await import("./vast");
+
+  const entries = await fetchVastSnapshotEntries();
+  const models = new Set(entries.map((e) => e.model));
+
+  // Rejected overrides do not drop the model — it falls back to the in-source
+  // default snapshot, and each rejection is warned (one per invalid entry).
+  expect(models.has("vast/eliza-1-2b")).toBe(true);
+  expect(models.has("vast/eliza-1-9b")).toBe(true);
+  expect(warnCalls.length).toBe(2);
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/refresh.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/refresh.error-policy.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Error-policy guard for the per-source pricing-catalog refresh (#13415). Proves that a
+ * provider FETCH failure surfaces as a structured { success:false } result and that an
+ * empty catalog is a DISTINCT-but-also-fail-closed outcome from a successful refresh —
+ * critically, neither failure nor empty runs the catalog-replace transaction, so a failed
+ * refresh never wipes the last-good active prices (money-path fail-closed). The DB layer
+ * and every provider loader are mocked at the module boundary; the real refreshPricingCatalog
+ * drives the outcome. No monetary value is asserted.
+ */
+import { afterEach, beforeAll, beforeEach, expect, mock, test } from "bun:test";
+import type { PreparedPricingEntry } from "./types";
+
+// Mutable per-test provider behavior, read at call time by the mocked loader closures.
+const providerBehavior: { bitrouter: () => Promise<PreparedPricingEntry[]> } = {
+  bitrouter: async () => [],
+};
+
+// Observable side effects captured from the mocked DB + logger.
+const state = {
+  transactionRan: false,
+  runUpdates: [] as Array<Record<string, unknown>>,
+  loggerErrors: [] as Array<{ msg: string; ctx: unknown }>,
+};
+
+const chainableUpdate = () => ({
+  set: (values: Record<string, unknown>) => ({
+    where: async () => {
+      state.runUpdates.push(values);
+    },
+  }),
+});
+
+const chainableInsert = () => ({
+  values: () => ({ returning: async () => [{ id: "run-1" }] }),
+});
+
+const tx = { update: chainableUpdate, insert: chainableInsert };
+
+mock.module("drizzle-orm", () => ({
+  and: (...args: unknown[]) => ({ __and: args }),
+  eq: (...args: unknown[]) => ({ __eq: args }),
+}));
+
+mock.module("../../../db/helpers", () => ({
+  dbWrite: {
+    insert: chainableInsert,
+    update: chainableUpdate,
+    transaction: async (fn: (t: typeof tx) => Promise<unknown>) => {
+      state.transactionRan = true;
+      return await fn(tx);
+    },
+  },
+}));
+
+mock.module("../../../db/repositories/ai-pricing", () => ({
+  aiPricingRepository: { listActiveEntries: async () => [] },
+}));
+
+mock.module("../../../db/schemas/ai-pricing", () => ({
+  aiPricingEntries: {},
+  aiPricingRefreshRuns: {},
+}));
+
+mock.module("./dimensions", () => ({
+  toDbEntry: (entry: { source_kind?: string }) => ({
+    source_kind: entry.source_kind ?? "bitrouter",
+    ...entry,
+  }),
+}));
+
+mock.module("../../utils/logger", () => ({
+  logger: {
+    info: () => {},
+    warn: () => {},
+    debug: () => {},
+    error: (msg: string, ctx: unknown) => {
+      state.loggerErrors.push({ msg, ctx });
+    },
+  },
+}));
+
+mock.module("./providers/bitrouter", () => ({
+  fetchBitRouterCatalogEntries: () => providerBehavior.bitrouter(),
+}));
+mock.module("./providers/fal", () => ({ fetchFalCatalogEntries: async () => [] }));
+mock.module("./providers/elevenlabs", () => ({ fetchElevenLabsEntries: async () => [] }));
+mock.module("./providers/suno", () => ({ fetchSunoEntries: async () => [] }));
+mock.module("./providers/vast", () => ({ fetchVastSnapshotEntries: async () => [] }));
+
+let refreshPricingCatalog: typeof import("./refresh").refreshPricingCatalog;
+
+const realFetch = globalThis.fetch;
+
+beforeAll(async () => {
+  ({ refreshPricingCatalog } = await import("./refresh"));
+});
+
+beforeEach(() => {
+  state.transactionRan = false;
+  state.runUpdates = [];
+  state.loggerErrors = [];
+  // No provider bytes should ever hit the network here; a leaked real fetch must throw.
+  globalThis.fetch = (() => {
+    throw new Error("network disabled in ai-pricing error-policy test");
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+const entry = (over: Partial<PreparedPricingEntry> = {}) =>
+  ({
+    source_kind: "bitrouter",
+    model: "m",
+    provider: "openrouter",
+    ...over,
+  }) as unknown as PreparedPricingEntry;
+
+test("a provider FETCH failure surfaces as a structured failure and never wipes the catalog", async () => {
+  providerBehavior.bitrouter = async () => {
+    throw new Error("openrouter 503 upstream");
+  };
+
+  const result = await refreshPricingCatalog(["bitrouter"]);
+
+  // The failure propagates observably as success:false with the error text preserved.
+  expect(result.success).toBe(false);
+  expect(result.results[0].success).toBe(false);
+  expect(result.results[0].error).toContain("openrouter 503 upstream");
+  expect(result.results[0].fetchedEntries).toBe(0);
+
+  // Money-path fail-closed: the deactivate-all + reinsert transaction never ran, so the
+  // last-good active prices are untouched. A failed fetch does NOT blank the catalog.
+  expect(state.transactionRan).toBe(false);
+
+  // The failure was recorded (status:"failed" run row) and logged via the structured logger.
+  expect(state.runUpdates.some((u) => u.status === "failed")).toBe(true);
+  expect(state.loggerErrors.length).toBeGreaterThan(0);
+});
+
+test("an empty catalog is a DISTINCT fail-closed outcome — empty never reads as success", async () => {
+  providerBehavior.bitrouter = async () => [];
+
+  const result = await refreshPricingCatalog(["bitrouter"]);
+
+  // Zero fetched entries is treated as a failure by design, not a silent "empty catalog"
+  // success — otherwise a bad fetch would deactivate every active price and leave nothing.
+  expect(result.success).toBe(false);
+  expect(result.results[0].error).toContain("No pricing entries");
+  expect(state.transactionRan).toBe(false);
+});
+
+test("a real catalog succeeds and runs the replace transaction — the distinct healthy path", async () => {
+  providerBehavior.bitrouter = async () => [entry()];
+
+  const result = await refreshPricingCatalog(["bitrouter"]);
+
+  expect(result.success).toBe(true);
+  expect(result.results[0].success).toBe(true);
+  expect(result.results[0].fetchedEntries).toBe(1);
+  // Only real data drives the catalog-replace transaction — the outcome is distinguishable
+  // from both the fetch-failure and empty-catalog paths above.
+  expect(state.transactionRan).toBe(true);
+  expect(state.runUpdates.some((u) => u.status === "failed")).toBe(false);
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/refresh.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/refresh.ts
@@ -94,6 +94,12 @@ async function refreshSourceEntries(
       success: true,
     };
   } catch (error) {
+    // error-policy:J1 boundary translation — the per-source refresh handler. A provider
+    // fetch/parse failure, an empty catalog (zero entries, thrown above), or a DB write
+    // error becomes a structured { success:false, error } result and a status:"failed"
+    // refresh-run row; callers surface it (admin route → 207, cron → success:false). The
+    // catalog-replace transaction never ran on this path, so the last-good active prices
+    // stay untouched — a failed refresh never wipes pricing (money-path fail-closed).
     const message = error instanceof Error ? error.message : String(error);
     logger.error("[AI Pricing] Refresh failed", { source, error: message });
 


### PR DESCRIPTION
## Slice 6b of #13415 — ai-pricing (model-price fetch/cache/lookup → inference billing)

Under the **strong money guard**, this slice is almost entirely **test-only**: the pricing/markup arithmetic and the documented degrade-to-cached/seed-price fallbacks (e.g. `cache.ts` negative-cache that *rethrows* the original error, `lookup.ts` conservative fallback-tier resolution `#11635`, `candidate-selection` higher-unit-price tie-break) are money paths — left **unchanged and flagged**. `refresh.ts` got the only non-money edit (transport-layer annotation).

Adds **11 focused `bun:test` error-path suites** pinning that a provider FETCH/DB failure propagates (or is the documented money-path degrade) and stays **distinct** from a legitimately-empty/absent price — without asserting invented monetary values, driving the real exported functions.

**Verification:** tests pass under `--isolate`; biome clean; `audit:error-policy-ratchet` → "no new fallback-slop".