### PR TITLE
fix(#13422): migrate plugin-elizacloud aliased env reads to readAliasedEnv

### DIFF
--- a/plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts
@@ -1,9 +1,11 @@
+import { readAliasedEnv } from "@elizaos/shared";
+
 function hasValue(value: string | undefined): boolean {
   return Boolean(value?.trim());
 }
 
 function hasCompatApiToken(): boolean {
-  return hasValue(process.env.ELIZA_API_TOKEN);
+  return hasValue(readAliasedEnv("ELIZA_API_TOKEN"));
 }
 
 function hasCloudApiKeyProvisioning(): boolean {
@@ -26,7 +28,7 @@ function hasCloudApiKeyProvisioning(): boolean {
  * cloud containers.
  */
 export function isCloudProvisionedContainer(): boolean {
-  const hasCloudFlag = process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  const hasCloudFlag = readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
 
   return (
     hasCloudFlag &&

--- a/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
@@ -20,6 +20,7 @@ import type {
   RegisterGatewayRelaySessionResponse,
 } from "../types/cloud";
 import type { CloudAuthService } from "./cloud-auth";
+import { readAliasedEnv } from "@elizaos/shared";
 
 const POLL_TIMEOUT_MS = 25_000;
 const REQUEST_TIMEOUT_MS = POLL_TIMEOUT_MS + 5_000;
@@ -63,7 +64,7 @@ function isCloudProvisionedRuntime(): boolean {
   if (typeof process === "undefined") {
     return false;
   }
-  return process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  return readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
 }
 
 function isNodeHost(): boolean {


### PR DESCRIPTION
Long-tail #13422 slice — `plugin-elizacloud` was missed by the parallel long-tail PRs (#13926/#13931/#13936). Migrates the remaining raw alias-table reads to `readAliasedEnv`:
- `routes/cloud-provisioning.ts`: `ELIZA_API_TOKEN`, `ELIZA_CLOUD_PROVISIONED`
- `services/cloud-managed-gateway-relay.ts`: `ELIZA_CLOUD_PROVISIONED`

`ELIZAOS_CLOUD_ENABLED`/`ELIZAOS_CLOUD_API_KEY` left raw (not in the alias table). `plugin-elizacloud` already depends on `@elizaos/shared`.

**Verified locally** (fresh develop clone): `audit:alias-read-guard` pass; `plugin-elizacloud` typecheck clean; `plugin-elizacloud` test **307 passed / 3 skipped**. Re-scoped from the now-closed #13938 to drop the server-cors read #13926 already landed (conflict-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
