### PR TITLE
fix(#13422): migrate elizacloud/matrix/streaming/coding-tools aliased env reads to the alias-aware reader (long-tail P8)

### DIFF
--- a/packages/test/vitest/shims/elizaos-core-connector.ts
+++ b/packages/test/vitest/shims/elizaos-core-connector.ts
@@ -12,6 +12,11 @@ export {
   readRequestBodyBuffer,
   writeJsonError,
 } from "../../../core/src/api/http-helpers.ts";
+// Real (unstubbed) alias-aware env reader. Plugins migrated off raw
+// `process.env.<ALIAS_KEY>` reads (#13422) call this so a white-label
+// `<PREFIX>_*` var resolves; keep the genuine resolver so the branded-prefix
+// resolution is exercised, not stubbed.
+export { resolveAliasedEnvValue } from "../../../core/src/boot-env.ts";
 export {
   CONNECTOR_ACCOUNT_SERVICE_TYPE,
   CONNECTOR_ACCOUNT_STORAGE_SERVICE_TYPE,
@@ -42,11 +47,6 @@ export type {
 } from "../../../core/src/types/index.ts";
 export { assertPublicRouteIntent } from "../../../core/src/types/plugin.ts";
 export { Service } from "../../../core/src/types/service.ts";
-// Real (unstubbed) alias-aware env reader. Plugins migrated off raw
-// `process.env.<ALIAS_KEY>` reads (#13422) call this so a white-label
-// `<PREFIX>_*` var resolves; keep the genuine resolver so the branded-prefix
-// resolution is exercised, not stubbed.
-export { resolveAliasedEnvValue } from "../../../core/src/boot-env.ts";
 export { resolveSetting } from "../../../core/src/utils/resolve-setting.ts";
 export { resolveStateDir } from "../../../core/src/utils/state-dir.ts";
 

--- a/packages/test/vitest/shims/elizaos-core-connector.ts
+++ b/packages/test/vitest/shims/elizaos-core-connector.ts
@@ -42,6 +42,11 @@ export type {
 } from "../../../core/src/types/index.ts";
 export { assertPublicRouteIntent } from "../../../core/src/types/plugin.ts";
 export { Service } from "../../../core/src/types/service.ts";
+// Real (unstubbed) alias-aware env reader. Plugins migrated off raw
+// `process.env.<ALIAS_KEY>` reads (#13422) call this so a white-label
+// `<PREFIX>_*` var resolves; keep the genuine resolver so the branded-prefix
+// resolution is exercised, not stubbed.
+export { resolveAliasedEnvValue } from "../../../core/src/boot-env.ts";
 export { resolveSetting } from "../../../core/src/utils/resolve-setting.ts";
 export { resolveStateDir } from "../../../core/src/utils/state-dir.ts";
 

--- a/plugins/plugin-coding-tools/src/lib/terminal-capabilities.ts
+++ b/plugins/plugin-coding-tools/src/lib/terminal-capabilities.ts
@@ -7,6 +7,7 @@
  */
 import { accessSync, constants } from "node:fs";
 import path from "node:path";
+import { readAliasedEnv } from "@elizaos/shared";
 
 export const CODING_TOOL_NAMES = [
   "sh",
@@ -51,13 +52,13 @@ const ANDROID_PATH_ENTRIES = ["/system/bin", "/system/xbin", "/vendor/bin"];
 
 export function isAndroidRuntime(): boolean {
   return (
-    process.env.ELIZA_PLATFORM?.trim().toLowerCase() === "android" ||
+    readAliasedEnv("ELIZA_PLATFORM")?.toLowerCase() === "android" ||
     Boolean(process.env.ANDROID_ROOT || process.env.ANDROID_DATA)
   );
 }
 
 function isIosRuntime(): boolean {
-  return process.env.ELIZA_PLATFORM?.trim().toLowerCase() === "ios";
+  return readAliasedEnv("ELIZA_PLATFORM")?.toLowerCase() === "ios";
 }
 
 function isTruthyEnv(value: string | undefined): boolean {

--- a/plugins/plugin-coding-tools/src/services/sandbox-service.ts
+++ b/plugins/plugin-coding-tools/src/services/sandbox-service.ts
@@ -12,6 +12,7 @@ import {
   type IAgentRuntime,
   Service,
 } from "@elizaos/core";
+import { readAliasedEnv } from "@elizaos/shared";
 import {
   isAbsolutePath,
   isUncPath,
@@ -338,7 +339,7 @@ function defaultBlockedPaths(): string[] {
 
 function isAndroidRuntime(): boolean {
   return (
-    process.env.ELIZA_PLATFORM?.trim().toLowerCase() === "android" ||
+    readAliasedEnv("ELIZA_PLATFORM")?.toLowerCase() === "android" ||
     Boolean(process.env.ANDROID_ROOT || process.env.ANDROID_DATA)
   );
 }

--- a/plugins/plugin-elizacloud/__tests__/unit/brand-env-alias-reads.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/brand-env-alias-reads.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Issue #13422 P8 slice: the aliased env reads migrated to the alias-aware
+ * reader across the elizacloud / matrix / streaming / coding-tools plugins must
+ * resolve a NON-ELIZA brand prefix (MILADY_*) WITHOUT the syncBrandEnvToEliza
+ * mirror, with the canonical ELIZA_* key still winning when both are set and an
+ * empty branded value reading as unset. Drives the real migrated
+ * `isCloudProvisionedContainer()` for its two keys and asserts the shared
+ * `readAliasedEnv` contract for the remaining P8 keys (platform, state dir, the
+ * cloud-TTS toggle). A NON-ELIZA prefix is the security-relevant fixture: an
+ * ELIZA->ELIZA self-mirror would prove nothing.
+ */
+import {
+  buildBrandEnvAliases,
+  getBootConfig,
+  readAliasedEnv,
+  setBootConfig,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { isCloudProvisionedContainer } from "../../src/routes/cloud-provisioning";
+
+const BRAND = "MILADY";
+
+// Every P8 canonical key + its branded alias, plus the other env vars
+// `isCloudProvisionedContainer` consults, tracked so each case starts clean.
+const TRACKED = [
+  "MILADY_CLOUD_PROVISIONED",
+  "ELIZA_CLOUD_PROVISIONED",
+  "MILADY_API_TOKEN",
+  "ELIZA_API_TOKEN",
+  "MILADY_PLATFORM",
+  "ELIZA_PLATFORM",
+  "MILADY_STATE_DIR",
+  "ELIZA_STATE_DIR",
+  "MILADY_CLOUD_TTS_DISABLED",
+  "ELIZA_CLOUD_TTS_DISABLED",
+  "STEWARD_AGENT_TOKEN",
+  "ELIZAOS_CLOUD_ENABLED",
+  "ELIZAOS_CLOUD_API_KEY",
+];
+
+describe("issue #13422 P8 aliased reads resolve a branded prefix with zero mirror writes", () => {
+  const savedConfig = getBootConfig();
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of TRACKED) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    // Pin the alias table on the immutable BootConfig, as the app boot path does.
+    setBootConfig({ ...savedConfig, envAliases: buildBrandEnvAliases(BRAND) });
+  });
+
+  afterEach(() => {
+    for (const key of TRACKED) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    setBootConfig(savedConfig);
+  });
+
+  it("isCloudProvisionedContainer resolves branded flag + token, no ELIZA_ mirror", () => {
+    process.env.MILADY_CLOUD_PROVISIONED = "1";
+    process.env.MILADY_API_TOKEN = "milady-inbound-token";
+    const before = { ...process.env };
+
+    expect(isCloudProvisionedContainer()).toBe(true);
+
+    // A read must never materialize the ELIZA_ target — that mutation is exactly
+    // what #13422 removes the dependency on.
+    expect(process.env.ELIZA_CLOUD_PROVISIONED).toBeUndefined();
+    expect(process.env.ELIZA_API_TOKEN).toBeUndefined();
+    expect(process.env).toEqual(before);
+  });
+
+  it("canonical ELIZA_CLOUD_PROVISIONED wins over the branded alias", () => {
+    // Canonical "0" beats branded "1": provisioning gate stays closed.
+    process.env.ELIZA_CLOUD_PROVISIONED = "0";
+    process.env.MILADY_CLOUD_PROVISIONED = "1";
+    process.env.MILADY_API_TOKEN = "milady-inbound-token";
+    expect(readAliasedEnv("ELIZA_CLOUD_PROVISIONED")).toBe("0");
+    expect(isCloudProvisionedContainer()).toBe(false);
+  });
+
+  it("an empty branded flag reads as unset (normalizeEnvValue contract)", () => {
+    process.env.MILADY_CLOUD_PROVISIONED = "   ";
+    process.env.MILADY_API_TOKEN = "milady-inbound-token";
+    expect(readAliasedEnv("ELIZA_CLOUD_PROVISIONED")).toBeUndefined();
+    expect(isCloudProvisionedContainer()).toBe(false);
+  });
+
+  it("readAliasedEnv resolves platform / state-dir / cloud-TTS from branded keys, no mirror", () => {
+    process.env.MILADY_PLATFORM = "android";
+    process.env.MILADY_STATE_DIR = "/var/milady/state";
+    process.env.MILADY_CLOUD_TTS_DISABLED = "true";
+    const before = { ...process.env };
+
+    expect(readAliasedEnv("ELIZA_PLATFORM")).toBe("android");
+    expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/var/milady/state");
+    expect(readAliasedEnv("ELIZA_CLOUD_TTS_DISABLED")).toBe("true");
+
+    expect(process.env.ELIZA_PLATFORM).toBeUndefined();
+    expect(process.env.ELIZA_STATE_DIR).toBeUndefined();
+    expect(process.env.ELIZA_CLOUD_TTS_DISABLED).toBeUndefined();
+    expect(process.env).toEqual(before);
+  });
+
+  it("canonical ELIZA_ keys win over branded aliases for platform / cloud-TTS", () => {
+    process.env.ELIZA_PLATFORM = "ios";
+    process.env.MILADY_PLATFORM = "android";
+    process.env.ELIZA_CLOUD_TTS_DISABLED = "false";
+    process.env.MILADY_CLOUD_TTS_DISABLED = "true";
+    expect(readAliasedEnv("ELIZA_PLATFORM")).toBe("ios");
+    expect(readAliasedEnv("ELIZA_CLOUD_TTS_DISABLED")).toBe("false");
+  });
+
+  it("an empty branded state dir reads as unset", () => {
+    process.env.MILADY_STATE_DIR = "   ";
+    expect(readAliasedEnv("ELIZA_STATE_DIR")).toBeUndefined();
+  });
+});

--- a/plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts
@@ -1,9 +1,11 @@
+import { readAliasedEnv } from "@elizaos/shared";
+
 function hasValue(value: string | undefined): boolean {
   return Boolean(value?.trim());
 }
 
 function hasCompatApiToken(): boolean {
-  return hasValue(process.env.ELIZA_API_TOKEN);
+  return hasValue(readAliasedEnv("ELIZA_API_TOKEN"));
 }
 
 function hasCloudApiKeyProvisioning(): boolean {
@@ -26,7 +28,7 @@ function hasCloudApiKeyProvisioning(): boolean {
  * cloud containers.
  */
 export function isCloudProvisionedContainer(): boolean {
-  const hasCloudFlag = process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  const hasCloudFlag = readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
 
   return (
     hasCloudFlag &&

--- a/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
@@ -12,6 +12,7 @@ import {
   Service,
   type UUID,
 } from "@elizaos/core";
+import { readAliasedEnv } from "@elizaos/shared";
 import type {
   GatewayRelayRequest,
   GatewayRelayRequestEnvelope,
@@ -63,7 +64,7 @@ function isCloudProvisionedRuntime(): boolean {
   if (typeof process === "undefined") {
     return false;
   }
-  return process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  return readAliasedEnv("ELIZA_CLOUD_PROVISIONED") === "1";
 }
 
 function isNodeHost(): boolean {

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -23,6 +23,7 @@ import {
   type Memory,
   type MessageConnectorChatContext,
   type MessageConnectorTarget,
+  resolveAliasedEnvValue,
   Service,
   type TargetInfo,
   type UUID,
@@ -242,7 +243,10 @@ const ROOM_KEY_NONCE_BYTES = 12;
  * room-key files land next to the rest of the agent's persistent state.
  */
 function resolveStateDir(): string {
-  return process.env.ELIZA_STATE_DIR || join(homedir(), ".local/state/eliza");
+  return (
+    resolveAliasedEnvValue("ELIZA_STATE_DIR") ||
+    join(homedir(), ".local/state/eliza")
+  );
 }
 
 /**

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -243,10 +243,7 @@ const ROOM_KEY_NONCE_BYTES = 12;
  * room-key files land next to the rest of the agent's persistent state.
  */
 function resolveStateDir(): string {
-  return (
-    resolveAliasedEnvValue("ELIZA_STATE_DIR") ||
-    join(homedir(), ".local/state/eliza")
-  );
+  return resolveAliasedEnvValue("ELIZA_STATE_DIR") || join(homedir(), ".local/state/eliza");
 }
 
 /**

--- a/plugins/plugin-streaming/package.json
+++ b/plugins/plugin-streaming/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "@elizaos/cloud-routing": "workspace:*",
     "@elizaos/core": "workspace:*",
-    "@elizaos/plugin-browser": "workspace:*"
+    "@elizaos/plugin-browser": "workspace:*",
+    "@elizaos/shared": "workspace:*"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/plugins/plugin-streaming/src/services/stream-manager.write-frame.test.ts
+++ b/plugins/plugin-streaming/src/services/stream-manager.write-frame.test.ts
@@ -14,14 +14,21 @@
 import { describe, expect, it, vi } from "vitest";
 
 const warn = vi.fn();
-vi.mock("@elizaos/core", () => ({
-  logger: {
-    warn: (...args: unknown[]) => warn(...args),
-    info: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  },
-}));
+// Pass real `@elizaos/core` through (transitively pulled by stream-manager ->
+// tts-stream-bridge -> @elizaos/shared) and override only `logger` so the
+// broken-pipe warning is observable.
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    logger: {
+      warn: (...args: unknown[]) => warn(...args),
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  };
+});
 
 import { streamManager } from "./stream-manager.js";
 

--- a/plugins/plugin-streaming/src/services/tts-stream-bridge.ts
+++ b/plugins/plugin-streaming/src/services/tts-stream-bridge.ts
@@ -17,6 +17,7 @@ import {
   ModelType,
   sanitizeSpeechText,
 } from "@elizaos/core";
+import { readAliasedEnv } from "@elizaos/shared";
 
 export type TtsProvider =
   | "local-inference"
@@ -581,7 +582,7 @@ function resolveKey(
   const legacyCloudTts =
     process.env.ELIZAOS_CLOUD_USE_TTS === undefined &&
     process.env.ELIZAOS_CLOUD_ENABLED === "true" &&
-    process.env.ELIZA_CLOUD_TTS_DISABLED !== "true";
+    readAliasedEnv("ELIZA_CLOUD_TTS_DISABLED") !== "true";
   if (explicitCloudTts || legacyCloudTts) {
     const cloudKey = process.env.ELIZAOS_CLOUD_API_KEY?.trim();
     if (cloudKey && !isRedactedSecret(cloudKey)) {


### PR DESCRIPTION
Long-tail slice (P8) of #13422: route raw `process.env.<KEY>` reads of brand-env-alias keys through the alias-aware reader so a white-label `<PREFIX>_*` value (e.g. `MILADY_STATE_DIR`) resolves **without** the `ELIZA_*` mirror.

### Reads migrated (8, across 6 source files — matches the P8 census)
| File | Key(s) | Reader |
|---|---|---|
| `plugins/plugin-coding-tools/src/lib/terminal-capabilities.ts` | `ELIZA_PLATFORM` ×2 | `readAliasedEnv` (@elizaos/shared) |
| `plugins/plugin-coding-tools/src/services/sandbox-service.ts` | `ELIZA_PLATFORM` | `readAliasedEnv` |
| `plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts` | `ELIZA_API_TOKEN`, `ELIZA_CLOUD_PROVISIONED` | `readAliasedEnv` |
| `plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts` | `ELIZA_CLOUD_PROVISIONED` | `readAliasedEnv` |
| `plugins/plugin-streaming/src/services/tts-stream-bridge.ts` | `ELIZA_CLOUD_TTS_DISABLED` | `readAliasedEnv` |
| `plugins/plugin-matrix/src/service.ts` | `ELIZA_STATE_DIR` | `resolveAliasedEnvValue` (@elizaos/core) |

Every key is in `BRAND_ENV_ALIAS_DEFINITIONS`. Only **reads** were migrated; no write/sync sites touched.

### Why matrix uses `resolveAliasedEnvValue` instead of `readAliasedEnv`
`matrix`'s keyless test lane aliases `@elizaos/core` to a curated connector shim (`packages/test/vitest/shims/elizaos-core-connector.ts`) that cannot load the full `@elizaos/shared` barrel (it pulls dozens of core symbols the shim omits, e.g. `formatError`). `resolveAliasedEnvValue` is the exact resolver `readAliasedEnv` wraps (`readAliasedEnv = normalizeEnvValue(resolveAliasedEnvValue(...))`), and both give canonical-wins + empty-is-unset + zero mirror writes. The shim gains a real re-export of it. The other four plugins use `readAliasedEnv` (their lanes load real `@elizaos/core`).

### Supporting changes
- `plugins/plugin-streaming/package.json`: add `@elizaos/shared` dep (already externalized in tsup).
- `plugins/plugin-streaming/.../stream-manager.write-frame.test.ts`: the shallow full-replacement `vi.mock("@elizaos/core", () => ({ logger }))` is upgraded to `importOriginal`-spread so real core passes through (the migrated import is now in that test's module graph via `stream-manager -> tts-stream-bridge`). Streaming suite: **23/23 green**.
- `packages/test/vitest/shims/elizaos-core-connector.ts`: `+ export { resolveAliasedEnvValue }` (real, from `core/src/boot-env.ts`).

### Test
New `plugins/plugin-elizacloud/__tests__/unit/brand-env-alias-reads.test.ts` (6 cases, all green) drives the **real** migrated `isCloudProvisionedContainer()` plus reader assertions for the P8 keys, proving for a NON-ELIZA (`MILADY_`) prefix: branded value resolves, canonical `ELIZA_*` wins, empty-is-unset, and no `ELIZA_*` mirror write.

### Verification
- `audit:alias-read-guard`: all 6 guarded files `2->0 / 1->0` (no new raw reads).
- `plugin-streaming`: `bun run test` → 5 files, 23 tests pass; `typecheck` clean.
- `plugin-elizacloud`: P8 test 6/6 pass.
- `plugin-coding-tools`: 199/200 (the 1 fail, `bash.test.ts` disk/RAM text, is pre-existing — identical with the migration reverted).
- `plugin-matrix`: with `matrix-js-sdk` linked, 26/28 pass — **identical to the clean tree**; the 2 fails are pre-existing `fake-indexeddb`-absent crypto/IndexedDB cases (unaffected by this diff), and the passing set now includes `service-hardening` loading `service.ts` through the shim.