### PR TITLE
fix(core): preserve credit exhaustion across fallback slots

### DIFF
--- a/packages/core/src/__tests__/message-failure-reply.test.ts
+++ b/packages/core/src/__tests__/message-failure-reply.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Exercises the message service's structured failure-reply classifier for model
+ * fallback cascades. Deterministic: the runtime only exposes a queued useModel
+ * stub, so no provider, database, or live model is involved.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { DefaultMessageService } from "../services/message";
+import type { IAgentRuntime } from "../types/runtime";
+
+const logger = {
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	trace: vi.fn(),
+};
+
+function makeRuntimeThrowing(errors: unknown[]): IAgentRuntime {
+	const queue = [...errors];
+	return {
+		useModel: vi.fn(async () => {
+			const error = queue.shift();
+			if (!error) throw new Error("Unexpected useModel call");
+			throw error;
+		}),
+		logger,
+	} as unknown as IAgentRuntime;
+}
+
+function creditError(): Error & { statusCode: number } {
+	return Object.assign(new Error("insufficient_credits"), { statusCode: 402 });
+}
+
+describe("DefaultMessageService structured failure replies", () => {
+	it("preserves credit exhaustion when later fallback model slots fail generically", async () => {
+		const service = new DefaultMessageService() as unknown as {
+			generateFailureReplyText(
+				runtime: IAgentRuntime,
+				prompt: string,
+				stage: string,
+			): Promise<{ kind: string }>;
+		};
+		const runtime = makeRuntimeThrowing([
+			creditError(),
+			new Error("TEXT_LARGE fallback failed"),
+			new Error("TEXT_SMALL fallback failed"),
+			new Error("TEXT_NANO fallback failed"),
+		]);
+
+		await expect(
+			service.generateFailureReplyText(runtime, "recent messages", "test"),
+		).resolves.toEqual({ kind: "creditsExhausted" });
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -10637,15 +10637,15 @@ export class DefaultMessageService implements IMessageService {
 				) {
 					return { kind: "noProvider" };
 				}
-				// Track the most recent slot's cause. Reporting "rate-limited"
-				// only when the LAST attempted slot was a 429 avoids misleading
-				// the user in a mixed-failure run (one slot throttled, others
-				// failed for unrelated reasons where retrying won't help). The
-				// all-429 cascade from the live incident still lands here.
+				// Credit exhaustion is sticky across slots because no later
+				// fallback model can make a drained account retryable. The
+				// rate/auth flags still track the most recent slot's cause:
+				// reporting "rate-limited" only when the LAST attempted slot was
+				// a 429 avoids misleading the user in a mixed-failure run.
 				// Credits are classified before rate limits below: a 429 *with*
 				// billing context is a drained balance ("top up"), not a
 				// transient throttle ("try again in a few seconds").
-				sawCreditsExhausted = isInsufficientCreditsError(error);
+				sawCreditsExhausted ||= isInsufficientCreditsError(error);
 				sawRateLimit = isRateLimitError(error);
 				sawAuthError = isAuthError(error);
 				runtime.logger.warn(


### PR DESCRIPTION
## Summary

Stacked fix for #13928. The current connector 402 branch tracks `sawCreditsExhausted` per fallback model slot, so a later generic slot error can clear an earlier insufficient-credit signal and downgrade the final user-facing reply away from the actionable top-up response.

This keeps credit exhaustion sticky across the fallback cascade while leaving rate-limit/auth reporting as latest-slot-wins, matching the existing comment intent.

## Verification

Run in isolated worktree `/Users/shawwalters/eliza-workspace/milady/eliza-pr-13928-credit`:

- `bun run install:light`
- `bun run --cwd packages/core prebuild`
- `bun run --cwd packages/cloud/routing build`
- `bun test packages/core/src/__tests__/message-failure-reply.test.ts`
- `bunx @biomejs/biome check packages/core/src/services/message.ts packages/core/src/__tests__/message-failure-reply.test.ts --no-errors-on-unmatched`
- `bun run --cwd packages/core typecheck`
- `git diff --check`

Evidence note: this is a deterministic unit regression for the fallback classifier inside #13928. Live-LLM/provider evidence remains owned by the parent PR because this stacked PR only fixes the classifier bug found during review.