### PR TITLE
fix(cloud-shared): fail-closed automation-connector sweep (#13415 slice 7)

### DIFF
--- a/.github/issue-evidence/13415-automations.md
+++ b/.github/issue-evidence/13415-automations.md
@@ -1,0 +1,25 @@
+# #13415 — cloud-shared fallback sweep slice 7: platform-automation connectors
+
+Areas: twitter/telegram/discord/whatsapp-automation, agent-google-connector, shared-runtime.
+Verified untouched by every in-flight fallback-sweep branch at file level before starting.
+
+## Changed (behavioral fail-closed / annotation)
+
+| file | verdict summary |
+|---|---|
+| discord-automation/index.ts | fail-closed fixes: swallowed Discord API failures on send/fetch now propagate as typed failures; J-annotations; console→logger |
+| shared-runtime/run-shared-agent-turn.ts | fail-closed fixes on the shared agent-turn REST path |
+| telegram-automation/index.ts, twitter-automation/{app-automation,index}.ts | J1/J4/J6/J7 annotations on already-fail-closed boundary/teardown/enrichment catches |
+| whatsapp-automation/index.ts, agent-google-connector/shared.ts | fail-closed fixes / annotations |
+| telegram/twitter/discord app-automation generate* catches | **money-path-flagged** — refundCredits+rethrow, left untouched |
+
+Connectors were mostly already fail-closed (translate a failed platform send into a typed `Result{success:false,error}` callers branch on); this slice adds the grep-able `// error-policy:J<N>` annotations, a few real fail-closed fixes (discord/shared-runtime), and error-path tests.
+
+## Verification
+- 72 new error-path `bun:test` suites pass under `--isolate` (the CI invocation); driving the real exported send/receive/exchange functions, proving internal-failure PROPAGATES vs designed-empty ("not connected", empty inbox) stays distinguishable.
+- existing automation suites: 107 pass / 0 fail (no regression).
+- `biome check` clean; `audit:error-policy-ratchet` → "no new fallback-slop".
+- Money guard: every credit/refund/promotion-pricing path left untouched and flagged.
+
+## N/A
+UI screenshots / model trajectories / audio — N/A (server connector services). Runtime logs — N/A - service unit boundary only (behavior proven by error-path tests).

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.error-policy.test.ts
@@ -1,0 +1,157 @@
+// Pins the fail-closed contract of the managed Google Calendar connector: a
+// genuinely-empty Google response (2xx with no `items`) yields an empty feed,
+// while every internal failure (Google 4xx/5xx, transport error, partial event
+// payload) throws an AgentGoogleConnectorError so the route boundary surfaces a
+// 4xx/5xx instead of masking a broken pipeline as "no events" / "deleted".
+// Deterministic: the real exported functions run through the real googleFetch
+// fail-closed wrapper, with the OAuth token layer stubbed and global fetch
+// mocked (no source edit was needed — this file locks the current behavior).
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { logger } from "../../utils/logger";
+import {
+  createManagedGoogleCalendarEvent,
+  deleteManagedGoogleCalendarEvent,
+  fetchManagedGoogleCalendarFeed,
+  listManagedGoogleCalendars,
+} from "./calendar";
+import { AgentGoogleConnectorError, managedGoogleConnectorDeps } from "./shared";
+
+const BASE_ARGS = {
+  organizationId: "org-1",
+  userId: "user-1",
+  side: "owner" as const,
+  calendarId: "primary",
+};
+
+const FEED_ARGS = {
+  ...BASE_ARGS,
+  timeMin: "2026-01-01T00:00:00.000Z",
+  timeMax: "2026-02-01T00:00:00.000Z",
+  timeZone: "UTC",
+};
+
+const VALID_EVENT = {
+  id: "evt-1",
+  status: "confirmed",
+  summary: "Standup",
+  start: { dateTime: "2026-01-05T09:00:00.000Z" },
+  end: { dateTime: "2026-01-05T09:30:00.000Z" },
+};
+
+const savedFetch = globalThis.fetch;
+const savedGetToken =
+  managedGoogleConnectorDeps.oauthService.getValidTokenByPlatformWithConnectionId;
+
+function installFetch(handler: () => Response | Promise<Response>) {
+  globalThis.fetch = mock(async () => handler()) as typeof fetch;
+}
+
+beforeEach(() => {
+  // Stub only the token lookup so the real googleFetch fail-closed path runs
+  // against a mocked upstream; this is not the code under test.
+  managedGoogleConnectorDeps.oauthService.getValidTokenByPlatformWithConnectionId = (async () => ({
+    token: { accessToken: "test-token" },
+    connectionId: "conn-1",
+  })) as typeof savedGetToken;
+  spyOn(logger, "error").mockImplementation(() => {});
+  spyOn(logger, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  globalThis.fetch = savedFetch;
+  managedGoogleConnectorDeps.oauthService.getValidTokenByPlatformWithConnectionId = savedGetToken;
+  mock.restore();
+});
+
+describe("designed-empty responses stay distinct from failure", () => {
+  test("feed: 200 with no items -> empty events, not a throw", async () => {
+    installFetch(() => new Response(JSON.stringify({}), { status: 200 }));
+    const result = await fetchManagedGoogleCalendarFeed(FEED_ARGS);
+    expect(result.events).toEqual([]);
+    expect(result.calendarId).toBe("primary");
+  });
+
+  test("feed: 200 with items -> normalized events (success branch is real)", async () => {
+    installFetch(() => new Response(JSON.stringify({ items: [VALID_EVENT] }), { status: 200 }));
+    const result = await fetchManagedGoogleCalendarFeed(FEED_ARGS);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.externalId).toBe("evt-1");
+  });
+
+  test("calendar list: 200 with no items -> empty list, not a throw", async () => {
+    installFetch(() => new Response(JSON.stringify({}), { status: 200 }));
+    const result = await listManagedGoogleCalendars(BASE_ARGS);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("internal failure propagates (never read as empty / deleted)", () => {
+  test("feed: Google 500 throws AgentGoogleConnectorError, not empty events", async () => {
+    installFetch(
+      () => new Response(JSON.stringify({ error: { message: "backend error" } }), { status: 500 }),
+    );
+    await expect(fetchManagedGoogleCalendarFeed(FEED_ARGS)).rejects.toBeInstanceOf(
+      AgentGoogleConnectorError,
+    );
+  });
+
+  test("feed: transport error propagates (not swallowed to [])", async () => {
+    installFetch(() => {
+      throw new Error("ECONNRESET");
+    });
+    await expect(fetchManagedGoogleCalendarFeed(FEED_ARGS)).rejects.toThrow(/ECONNRESET/);
+  });
+
+  test("calendar list: Google 403 throws, not an empty list", async () => {
+    installFetch(
+      () =>
+        new Response(JSON.stringify({ error: { message: "insufficientPermissions" } }), {
+          status: 403,
+        }),
+    );
+    await expect(listManagedGoogleCalendars(BASE_ARGS)).rejects.toBeInstanceOf(
+      AgentGoogleConnectorError,
+    );
+  });
+
+  test("create: 200 but partial payload (no id) throws 502, not a fake event", async () => {
+    installFetch(() => new Response(JSON.stringify({ summary: "Untitled" }), { status: 200 }));
+    let caught: unknown;
+    await createManagedGoogleCalendarEvent({
+      ...BASE_ARGS,
+      title: "Sync",
+      startAt: "2026-01-05T09:00:00.000Z",
+      endAt: "2026-01-05T09:30:00.000Z",
+      timeZone: "UTC",
+    }).catch((error) => {
+      caught = error;
+    });
+    expect(caught).toBeInstanceOf(AgentGoogleConnectorError);
+    expect((caught as AgentGoogleConnectorError).status).toBe(502);
+  });
+
+  test("create: 200 valid payload -> event (success branch is real)", async () => {
+    installFetch(() => new Response(JSON.stringify(VALID_EVENT), { status: 200 }));
+    const result = await createManagedGoogleCalendarEvent({
+      ...BASE_ARGS,
+      title: "Sync",
+      startAt: "2026-01-05T09:00:00.000Z",
+      endAt: "2026-01-05T09:30:00.000Z",
+      timeZone: "UTC",
+    });
+    expect(result.event.externalId).toBe("evt-1");
+  });
+
+  test("delete: Google 500 throws (never fabricates { ok: true })", async () => {
+    installFetch(() => new Response("boom", { status: 500 }));
+    await expect(
+      deleteManagedGoogleCalendarEvent({ ...BASE_ARGS, eventId: "evt-1" }),
+    ).rejects.toBeInstanceOf(AgentGoogleConnectorError);
+  });
+
+  test("delete: 204 -> { ok: true } (success branch is real)", async () => {
+    installFetch(() => new Response(null, { status: 204 }));
+    const result = await deleteManagedGoogleCalendarEvent({ ...BASE_ARGS, eventId: "evt-1" });
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.error-policy.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Error-policy pin (#13415) for the managed Gmail connector service. gmail.ts
+ * routes every Google API call through `googleFetch`, which already fails closed
+ * (throws `AgentGoogleConnectorError` on any token/HTTP/transport failure). This
+ * test pins that a failed platform call PROPAGATES as a throw rather than reading
+ * as "no messages", while a legitimately-empty Gmail list (200 OK, no matches)
+ * stays a distinct, non-error empty result.
+ *
+ * The `./shared` seam is mocked so only `googleFetch` and
+ * `getManagedGoogleConnectorStatus` are controlled; `fail`/`AgentGoogleConnectorError`
+ * and the real normalization logic in gmail.ts are exercised for real. global
+ * fetch is stubbed to throw so a hit to the network (rather than the mocked seam)
+ * would surface as a test failure.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as realShared from "./shared";
+
+type FetchArgs = { url: string; options?: RequestInit };
+
+let fetchImpl: (args: FetchArgs) => Promise<Response>;
+let statusImpl: () => Promise<unknown>;
+
+mock.module("./shared", () => ({
+  ...realShared,
+  googleFetch: (args: FetchArgs) => fetchImpl(args),
+  getManagedGoogleConnectorStatus: () => statusImpl(),
+}));
+
+const { fetchManagedGoogleGmailTriage } = await import("./gmail");
+
+const ORG = "org-1";
+const USER = "user-1";
+const SIDE = "owner" as const;
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const READY_STATUS = {
+  identity: { email: "me@example.com" },
+  grantedScopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+};
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  statusImpl = async () => READY_STATUS;
+  // The service must never reach the real network; the ./shared seam is mocked.
+  globalThis.fetch = (() => {
+    throw new Error("network access is not allowed in this test");
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("gmail.ts error-policy — fail-closed vs designed-empty", () => {
+  test("designed-empty: an empty Gmail list returns [] messages, not an error", async () => {
+    fetchImpl = async ({ url }) => {
+      // Only the list endpoint is hit when there are no messages to expand.
+      expect(url).toContain("/messages?");
+      return jsonResponse({});
+    };
+
+    const result = await fetchManagedGoogleGmailTriage({
+      organizationId: ORG,
+      userId: USER,
+      side: SIDE,
+      maxResults: 10,
+    });
+
+    expect(result.messages).toEqual([]);
+    expect(typeof result.syncedAt).toBe("string");
+  });
+
+  test("populated list normalizes messages (empty is distinct from populated)", async () => {
+    fetchImpl = async ({ url }) => {
+      if (url.includes("/messages/")) {
+        return jsonResponse({
+          id: "m1",
+          threadId: "t1",
+          labelIds: ["INBOX", "UNREAD"],
+          internalDate: "1700000000000",
+          payload: {
+            headers: [
+              { name: "Subject", value: "Hello" },
+              { name: "From", value: "Alice <alice@example.com>" },
+              { name: "To", value: "me@example.com" },
+            ],
+          },
+        });
+      }
+      return jsonResponse({ messages: [{ id: "m1", threadId: "t1" }] });
+    };
+
+    const result = await fetchManagedGoogleGmailTriage({
+      organizationId: ORG,
+      userId: USER,
+      side: SIDE,
+      maxResults: 10,
+    });
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.subject).toBe("Hello");
+  });
+
+  test("internal failure on the LIST call propagates (never fabricates empty)", async () => {
+    fetchImpl = async () => {
+      // Mirrors googleFetch's real behavior: a failed Google call throws.
+      realShared.fail(502, "Google API error: 500");
+    };
+
+    await expect(
+      fetchManagedGoogleGmailTriage({
+        organizationId: ORG,
+        userId: USER,
+        side: SIDE,
+        maxResults: 10,
+      }),
+    ).rejects.toThrow(/Google API error/);
+  });
+
+  test("internal failure on a per-message DETAIL fetch propagates (batch not silently dropped)", async () => {
+    fetchImpl = async ({ url }) => {
+      if (url.includes("/messages/")) {
+        realShared.fail(502, "Google API error: 429");
+      }
+      return jsonResponse({ messages: [{ id: "m1", threadId: "t1" }] });
+    };
+
+    await expect(
+      fetchManagedGoogleGmailTriage({
+        organizationId: ORG,
+        userId: USER,
+        side: SIDE,
+        maxResults: 10,
+      }),
+    ).rejects.toThrow(/Google API error/);
+  });
+
+  test("a connector-status failure propagates rather than yielding an empty inbox", async () => {
+    statusImpl = async () => {
+      realShared.fail(409, "needs_reauth");
+    };
+    fetchImpl = async () => {
+      throw new Error("googleFetch should not be reached when status fails");
+    };
+
+    await expect(
+      fetchManagedGoogleGmailTriage({
+        organizationId: ORG,
+        userId: USER,
+        side: SIDE,
+        maxResults: 10,
+      }),
+    ).rejects.toThrow(/needs_reauth/);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/shared.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/shared.error-policy.test.ts
@@ -1,0 +1,125 @@
+// Pins the fail-closed error policy of getGoogleAccessToken: a designed "unknown
+// grant" (404) must stay distinguishable from an internal token-fetch failure
+// (409), and an internal failure must PROPAGATE as a typed error rather than
+// resolve to a null/empty token. Deps are injected through the module's real
+// `managedGoogleConnectorDeps` seam; no network or DB is touched.
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  AgentGoogleConnectorError,
+  getGoogleAccessToken,
+  managedGoogleConnectorDeps,
+} from "./shared";
+
+const ORIGINAL_OAUTH = { ...managedGoogleConnectorDeps.oauthService };
+
+afterEach(() => {
+  Object.assign(managedGoogleConnectorDeps.oauthService, ORIGINAL_OAUTH);
+});
+
+type Connection = { id: string };
+
+function stubOauth(overrides: Partial<typeof managedGoogleConnectorDeps.oauthService>): void {
+  Object.assign(managedGoogleConnectorDeps.oauthService, overrides);
+}
+
+async function capture(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn();
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected getGoogleAccessToken to throw");
+}
+
+describe("getGoogleAccessToken error policy", () => {
+  it("surfaces an unknown grantId as a distinct 404, not a masked 409", async () => {
+    // Designed-empty: the org has no connection matching the requested grant.
+    // listConnections legitimately returns [] — that must read as "not found",
+    // never get re-labeled by the internal token-fetch catch.
+    stubOauth({
+      listConnections:
+        (async () => []) as typeof managedGoogleConnectorDeps.oauthService.listConnections,
+      getValidToken: (async () => {
+        throw new Error("getValidToken should not be reached for an unknown grant");
+      }) as typeof managedGoogleConnectorDeps.oauthService.getValidToken,
+    });
+
+    const error = await capture(() =>
+      getGoogleAccessToken({
+        organizationId: "org_1",
+        userId: "user_1",
+        side: "agent",
+        grantId: "missing-grant",
+      }),
+    );
+
+    expect(error).toBeInstanceOf(AgentGoogleConnectorError);
+    expect((error as AgentGoogleConnectorError).status).toBe(404);
+  });
+
+  it("propagates an internal token-fetch failure as a 409 (never a fabricated token)", async () => {
+    // The grant exists, but the OAuth token pipeline fails (no valid/refreshable
+    // token). That internal failure must surface as a typed 409, not collapse to
+    // an empty/null accessToken that downstream code would treat as "delivered".
+    stubOauth({
+      listConnections: (async () => [
+        { id: "grant-1" } as Connection,
+      ]) as typeof managedGoogleConnectorDeps.oauthService.listConnections,
+      getValidToken: (async () => {
+        throw new Error("token expired and refresh failed");
+      }) as typeof managedGoogleConnectorDeps.oauthService.getValidToken,
+    });
+
+    const error = await capture(() =>
+      getGoogleAccessToken({
+        organizationId: "org_1",
+        userId: "user_1",
+        side: "agent",
+        grantId: "grant-1",
+      }),
+    );
+
+    expect(error).toBeInstanceOf(AgentGoogleConnectorError);
+    expect((error as AgentGoogleConnectorError).status).toBe(409);
+    expect((error as AgentGoogleConnectorError).message).toContain("token expired");
+  });
+
+  it("propagates a default-side token-fetch failure as a 409", async () => {
+    // No grantId: the default lookup path also throws instead of returning a
+    // hollow token when no active Google connection can produce one.
+    stubOauth({
+      getValidTokenByPlatformWithConnectionId: (async () => {
+        throw new Error("no active google connection");
+      }) as typeof managedGoogleConnectorDeps.oauthService.getValidTokenByPlatformWithConnectionId,
+    });
+
+    const error = await capture(() =>
+      getGoogleAccessToken({
+        organizationId: "org_1",
+        userId: "user_1",
+        side: "owner",
+      }),
+    );
+
+    expect(error).toBeInstanceOf(AgentGoogleConnectorError);
+    expect((error as AgentGoogleConnectorError).status).toBe(409);
+    expect((error as AgentGoogleConnectorError).message).toContain("no active google connection");
+  });
+
+  it("returns the resolved token on the happy path (fail-closed policy does not block success)", async () => {
+    stubOauth({
+      getValidTokenByPlatformWithConnectionId: (async () => ({
+        token: { accessToken: "ya29.real-token" },
+        connectionId: "conn-9",
+      })) as unknown as typeof managedGoogleConnectorDeps.oauthService.getValidTokenByPlatformWithConnectionId,
+    });
+
+    const result = await getGoogleAccessToken({
+      organizationId: "org_1",
+      userId: "user_1",
+      side: "owner",
+    });
+
+    expect(result).toEqual({ accessToken: "ya29.real-token", connectionId: "conn-9" });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/shared.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/shared.ts
@@ -339,6 +339,13 @@ export async function getGoogleAccessToken(args: {
         connectionId: result.connectionId,
       }));
   } catch (error) {
+    // A designed connector failure (e.g. 404 for an unknown grant) is already a
+    // typed boundary error; preserve its distinct status rather than masking it
+    // as a 409, so callers can tell "no such grant" from "token needs reauth".
+    if (error instanceof AgentGoogleConnectorError) {
+      throw error;
+    }
+    // error-policy:J1 translate an oauth token-fetch failure (no valid/refreshable Google token) into a 409 needs-reauth boundary error
     const message = error instanceof Error ? error.message : String(error);
     fail(409, message);
   }
@@ -356,6 +363,7 @@ export async function googleFetch(args: {
   try {
     return await googleFetchWithToken(accessToken, args.url, args.options);
   } catch (error) {
+    // error-policy:J1 translate a Google API transport/timeout failure into a 502 boundary error
     fail(502, error instanceof Error ? error.message : String(error));
   }
 }

--- a/packages/cloud/shared/src/lib/services/discord-automation/app-automation.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/app-automation.error-policy.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Error-policy pins for the Discord app-automation post path (#13415).
+ *
+ * `postAnnouncement` is a connector send: an internal failure from the Discord
+ * REST send must surface as a failed `PostResult` (`success:false` + the error),
+ * NEVER read as delivered, and must NOT record the post in stats. These tests
+ * drive the real exported `discordAppAutomationService.postAnnouncement` and pin
+ * three distinguishable outcomes: (1) a designed validation-empty (automation
+ * disabled) that never touches the wire, (2) an internal send failure that
+ * propagates without mutating stats, and (3) a real delivery that records stats.
+ * The file already fails closed — this locks that in against regression.
+ *
+ * Harness: bun:test with mock.module + dynamic import; no real DB/network.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const ORG_ID = "00000000-0000-4000-8000-00000000c001";
+const APP_ID = "00000000-0000-4000-8000-00000000c002";
+const CHANNEL_ID = "channel-under-test";
+
+interface AppRow {
+  id: string;
+  organization_id: string;
+  name: string;
+  description: string | null;
+  app_url: string;
+  website_url: string | null;
+  logo_url: string | null;
+  promotional_assets: unknown[] | null;
+  discord_automation: unknown;
+}
+
+let appRow: AppRow;
+const updateCalls: Array<{ id: string; patch: Record<string, unknown> }> = [];
+
+let sendResult: { success: boolean; messageId?: string; error?: string };
+const sendCalls: Array<{ channelId: string; content: string }> = [];
+
+let channelExists: boolean;
+
+mock.module("../../../db/repositories/apps", () => ({
+  appsRepository: {
+    findById: async (id: string) => (id === appRow.id ? appRow : null),
+    update: async (id: string, patch: Record<string, unknown>) => {
+      updateCalls.push({ id, patch });
+      return { ...appRow, ...patch };
+    },
+  },
+}));
+
+mock.module("../../../db/repositories/discord-channels", () => ({
+  discordChannelsRepository: {
+    findByChannelId: async (_org: string, channelId: string) =>
+      channelExists ? { channel_id: channelId, channel_name: "general" } : null,
+  },
+}));
+
+mock.module("./index", () => ({
+  discordAutomationService: {
+    sendMessage: async (channelId: string, content: string) => {
+      sendCalls.push({ channelId, content });
+      return sendResult;
+    },
+  },
+}));
+
+// Isolate the send path from the credit/LLM generator: postAnnouncement is
+// called with explicit text so generateAnnouncement is never reached.
+mock.module("../credits", () => ({
+  creditsService: {
+    deductCredits: async () => ({ success: true, newBalance: 100, transaction: null }),
+    refundCredits: async () => ({ transaction: {}, newBalance: 100 }),
+  },
+}));
+
+mock.module("../character-prompt-helper", () => ({
+  getCharacterPromptContext: async () => null,
+  buildCharacterSystemPrompt: () => "",
+}));
+
+const { discordAppAutomationService } = await import("./app-automation");
+
+function makeAppRow(overrides: Partial<AppRow["discord_automation"] & object> = {}): void {
+  appRow = {
+    id: APP_ID,
+    organization_id: ORG_ID,
+    name: "Test App",
+    description: "An app under test",
+    app_url: "https://test-app.example",
+    website_url: "https://test-app.example",
+    logo_url: null,
+    promotional_assets: null,
+    discord_automation: {
+      enabled: true,
+      channelId: CHANNEL_ID,
+      autoAnnounce: true,
+      announceIntervalMin: 120,
+      announceIntervalMax: 240,
+      totalMessages: 7,
+      ...overrides,
+    },
+  };
+}
+
+beforeEach(() => {
+  updateCalls.length = 0;
+  sendCalls.length = 0;
+  channelExists = true;
+  sendResult = { success: true, messageId: "message-ok" };
+  makeAppRow();
+});
+
+describe("postAnnouncement fails closed on internal send failure (#13415)", () => {
+  test("designed validation-empty: automation disabled returns a designed error, never sends, never mutates stats", async () => {
+    makeAppRow({ enabled: false });
+
+    const result = await discordAppAutomationService.postAnnouncement(ORG_ID, APP_ID, "hi");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Automation not enabled for this app");
+    // Designed-empty must not touch the wire or record a post.
+    expect(sendCalls).toHaveLength(0);
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("internal send failure propagates as failure and is NOT recorded as delivered", async () => {
+    sendResult = { success: false, error: "Failed to send message" };
+
+    const result = await discordAppAutomationService.postAnnouncement(ORG_ID, APP_ID, "hi");
+
+    // The send was attempted (distinct from the designed-empty case)...
+    expect(sendCalls).toHaveLength(1);
+    // ...and the failure surfaces instead of reading as delivered.
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Failed to send message");
+    expect(result.messageId).toBeUndefined();
+    // A failed send must never be written into stats.
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("successful send returns a delivered result and records the post in stats", async () => {
+    sendResult = { success: true, messageId: "message-ok" };
+
+    const result = await discordAppAutomationService.postAnnouncement(ORG_ID, APP_ID, "hi");
+
+    expect(result.success).toBe(true);
+    expect(result.messageId).toBe("message-ok");
+    expect(result.channelId).toBe(CHANNEL_ID);
+    // Delivery is distinguishable from failure: exactly one send, stats bumped.
+    expect(sendCalls).toHaveLength(1);
+    expect(updateCalls).toHaveLength(1);
+    const patched = updateCalls[0].patch.discord_automation as { totalMessages: number };
+    expect(patched.totalMessages).toBe(8);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/discord-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.error-policy.test.ts
@@ -1,0 +1,156 @@
+// Pins the fail-closed error policy of the Discord connector (#13415): a failed
+// Discord REST call must PROPAGATE as a throw, while a legitimately-empty guild
+// (no text channels) must stay a distinct, successful [] result. Deterministic
+// harness — global fetch and the DB repositories are mocked; no live Discord.
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// Env is read at module load, so it must be set before the dynamic import below.
+process.env.DISCORD_CLIENT_ID = "test-client-id";
+process.env.DISCORD_CLIENT_SECRET = "test-client-secret";
+process.env.DISCORD_BOT_TOKEN = "test-bot-token";
+
+const channelUpsert = mock(async () => {});
+const guildUpsert = mock(async () => {});
+
+mock.module("../../../db/repositories/discord-channels", () => ({
+  discordChannelsRepository: {
+    upsert: channelUpsert,
+    findByGuild: mock(async () => []),
+    deleteByGuild: mock(async () => {}),
+  },
+}));
+mock.module("../../../db/repositories/discord-guilds", () => ({
+  discordGuildsRepository: {
+    upsert: guildUpsert,
+    findByOrganization: mock(async () => []),
+    delete: mock(async () => {}),
+  },
+}));
+mock.module("../../utils/logger", () => ({
+  logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+}));
+
+const { discordAutomationService } = await import("./index");
+
+const realFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+  const ok = init?.ok ?? true;
+  const status = init?.status ?? (ok ? 200 : 500);
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  channelUpsert.mockClear();
+  guildUpsert.mockClear();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("refreshChannels — internal failure propagates vs designed-empty stays distinct", () => {
+  it("THROWS when the Discord channels API returns a non-2xx status (failure is not [])", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse("missing access", { ok: false, status: 403 }),
+    ) as unknown as typeof fetch;
+
+    await expect(discordAutomationService.refreshChannels("org-1", "guild-1")).rejects.toThrow(
+      /Failed to fetch channels for guild guild-1 \(status 403\)/,
+    );
+    // A failed fetch must not touch the channel cache.
+    expect(channelUpsert).not.toHaveBeenCalled();
+  });
+
+  it("THROWS when the fetch itself rejects (transport failure surfaces)", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("ECONNRESET");
+    }) as unknown as typeof fetch;
+
+    await expect(discordAutomationService.refreshChannels("org-1", "guild-1")).rejects.toThrow(
+      /ECONNRESET/,
+    );
+  });
+
+  it("returns [] (NOT a throw) for a guild whose only channels are non-text — designed empty", async () => {
+    // type 2 = GuildVoice → filtered out by isTextChannel; a successful, empty result.
+    globalThis.fetch = mock(async () =>
+      jsonResponse([{ id: "v1", name: "General", type: 2, parent_id: null, position: 0 }]),
+    ) as unknown as typeof fetch;
+
+    const result = await discordAutomationService.refreshChannels("org-1", "guild-1");
+    expect(result).toEqual([]);
+    // Distinct from failure: no throw, and nothing to cache.
+    expect(channelUpsert).not.toHaveBeenCalled();
+  });
+
+  it("returns the text channels and caches them on a successful fetch", async () => {
+    // type 0 = GuildText → kept.
+    globalThis.fetch = mock(async () =>
+      jsonResponse([
+        { id: "t1", name: "general", type: 0, parent_id: null, position: 0 },
+        { id: "v1", name: "Voice", type: 2, parent_id: null, position: 1 },
+      ]),
+    ) as unknown as typeof fetch;
+
+    const result = await discordAutomationService.refreshChannels("org-1", "guild-1");
+    expect(result.map((c) => c.id)).toEqual(["t1"]);
+    expect(channelUpsert).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("handleBotOAuthCallback — J6 best-effort: channel cache-warm failure does not fail a completed bot-add", () => {
+  it("still returns success when refreshChannels fails after the guild is persisted", async () => {
+    const guildId = "guild-9";
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/oauth2/token")) {
+        return jsonResponse({ access_token: "user-access-token" });
+      }
+      if (url.endsWith("/users/@me")) {
+        return jsonResponse({
+          id: "user-1",
+          username: "owner",
+          global_name: "Owner",
+          avatar: null,
+        });
+      }
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([
+          {
+            id: guildId,
+            name: "My Guild",
+            icon: null,
+            owner: true,
+            permissions: "0",
+            features: [],
+          },
+        ]);
+      }
+      if (url.endsWith(`/guilds/${guildId}/channels`)) {
+        // The cache-warm step fails — must NOT undo the completed bot-add.
+        return jsonResponse("rate limited", { ok: false, status: 429 });
+      }
+      if (url.endsWith(`/guilds/${guildId}`)) {
+        return jsonResponse({ id: guildId, name: "My Guild", icon: null });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const result = await discordAutomationService.handleBotOAuthCallback({
+      code: "auth-code",
+      guildId,
+      oauthState: { organizationId: "org-1", flow: "organization-install" } as never,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.guildId).toBe(guildId);
+    // The guild was persisted even though channel warm-up threw.
+    expect(guildUpsert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/discord-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.ts
@@ -190,6 +190,9 @@ class DiscordAutomationService {
         return null;
       }
     } catch (error) {
+      // error-policy:J1 boundary — token-exchange transport failure is translated
+      // to null, which the only caller (handleBotOAuthCallback) fail-closes into a
+      // "Failed to verify Discord account" result. Not an empty success.
       logger.error("[Discord] Token exchange request failed", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -249,6 +252,9 @@ class DiscordAutomationService {
         },
       };
     } catch (error) {
+      // error-policy:J1 boundary — identity/guilds fetch transport failure is
+      // translated to null; handleBotOAuthCallback fail-closes it into a failed
+      // verification result rather than reading as an authorized identity.
       logger.error("[Discord] Failed to fetch OAuth identity", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -337,7 +343,19 @@ class DiscordAutomationService {
       });
 
       // Fetch and cache channels
-      await this.refreshChannels(args.oauthState.organizationId, guild.id);
+      try {
+        await this.refreshChannels(args.oauthState.organizationId, guild.id);
+      } catch (error) {
+        // error-policy:J6 best-effort cache warm — the guild is already persisted,
+        // so a transient channel-fetch failure must not fail a completed bot-add.
+        // The failure is observable: the refresh route re-runs refreshChannels and
+        // surfaces the throw instead of reporting success with 0 channels.
+        logger.warn("[Discord] Channel cache warm failed after bot add", {
+          organizationId: args.oauthState.organizationId,
+          guildId: guild.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
 
       const requestedNickname = args.oauthState.botNickname?.trim();
       if (requestedNickname) {
@@ -358,6 +376,9 @@ class DiscordAutomationService {
         discordUser: identity.user,
       };
     } catch (error) {
+      // error-policy:J1 boundary — outermost handler for the OAuth-callback flow;
+      // any thrown failure (identity, guild fetch, DB upsert) becomes a structured
+      // { success: false } result for the route to return, never a fake success.
       logger.error("[Discord] Bot OAuth callback error:", {
         error: error instanceof Error ? error.message : "Unknown error",
       });
@@ -399,6 +420,8 @@ class DiscordAutomationService {
 
       return true;
     } catch (error) {
+      // error-policy:J6 best-effort — nickname is cosmetic and the only caller
+      // ignores the return; a failure is warned but must not abort the bot-add.
       logger.warn("[Discord] Failed to set bot nickname", {
         guildId,
         error: error instanceof Error ? error.message : String(error),
@@ -458,6 +481,9 @@ class DiscordAutomationService {
 
       return { connected: true, guilds: guildsWithCounts };
     } catch (error) {
+      // error-policy:J1 boundary — a DB read failure is translated to a status
+      // carrying an explicit `error`, distinct from the connected:false/no-error
+      // "no guilds" state above; callers can tell failure from empty.
       logger.error("[Discord] Status check error:", {
         organizationId,
         error: error instanceof Error ? error.message : "Unknown error",
@@ -471,58 +497,53 @@ class DiscordAutomationService {
    */
   async refreshChannels(organizationId: string, guildId: string): Promise<DiscordChannelInfo[]> {
     if (!DISCORD_BOT_TOKEN) {
-      logger.error("[Discord] Bot token not configured");
-      return [];
+      throw new Error("[Discord] Cannot refresh channels: bot token not configured");
     }
 
-    try {
-      const response = await fetch(`${DISCORD_API_BASE}/guilds/${guildId}/channels`, {
-        headers: {
-          Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
-        },
-      });
+    const response = await fetch(`${DISCORD_API_BASE}/guilds/${guildId}/channels`, {
+      headers: {
+        Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
+      },
+    });
 
-      if (!response.ok) {
-        const error = await response.text();
-        logger.error("[Discord] Failed to fetch channels:", { guildId, error });
-        return [];
-      }
-
-      const channels: DiscordChannelInfo[] = await response.json();
-
-      // Filter to text channels only
-      const textChannels = channels.filter((c) => isTextChannel(c.type));
-
-      // Cache channels in database
-      for (const channel of textChannels) {
-        await discordChannelsRepository.upsert({
-          organization_id: organizationId,
-          guild_id: guildId,
-          channel_id: channel.id,
-          channel_name: channel.name,
-          channel_type: channel.type,
-          parent_id: channel.parent_id,
-          position: channel.position,
-          can_send_messages: true, // We'll assume we can send if we can see it
-          is_nsfw: channel.nsfw ?? false,
-        });
-      }
-
-      logger.info("[Discord] Channels refreshed", {
-        organizationId,
-        guildId,
-        channelCount: textChannels.length,
-      });
-
-      return textChannels;
-    } catch (error) {
-      logger.error("[Discord] Channel refresh error:", {
-        organizationId,
-        guildId,
-        error: error instanceof Error ? error.message : "Unknown error",
-      });
-      return [];
+    // A failed fetch must surface as a thrown error, not an empty channel list:
+    // the caller (refresh route) reports channels.length, so returning [] here
+    // would report a failed refresh as "success, 0 channels".
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(
+        `[Discord] Failed to fetch channels for guild ${guildId} (status ${response.status}): ${error.slice(0, 200)}`,
+      );
     }
+
+    const channels: DiscordChannelInfo[] = await response.json();
+
+    // A guild with no text channels yields [] here — a legitimately-empty
+    // result, distinct from the throws above which signal a failed fetch.
+    const textChannels = channels.filter((c) => isTextChannel(c.type));
+
+    // Cache channels in database
+    for (const channel of textChannels) {
+      await discordChannelsRepository.upsert({
+        organization_id: organizationId,
+        guild_id: guildId,
+        channel_id: channel.id,
+        channel_name: channel.name,
+        channel_type: channel.type,
+        parent_id: channel.parent_id,
+        position: channel.position,
+        can_send_messages: true, // We'll assume we can send if we can see it
+        is_nsfw: channel.nsfw ?? false,
+      });
+    }
+
+    logger.info("[Discord] Channels refreshed", {
+      organizationId,
+      guildId,
+      channelCount: textChannels.length,
+    });
+
+    return textChannels;
   }
 
   /**
@@ -586,6 +607,9 @@ class DiscordAutomationService {
 
       return { success: true, messageId: lastMessageId };
     } catch (error) {
+      // error-policy:J1 boundary — an outbound send failure (transport, timeout,
+      // non-2xx) is translated to a typed { success: false } connector result so a
+      // failed send never reads as delivered.
       logger.error("[Discord] Send message error:", {
         channelId,
         error: error instanceof Error ? error.message : "Unknown error",
@@ -668,6 +692,8 @@ class DiscordAutomationService {
 
       return { success: true };
     } catch (error) {
+      // error-policy:J1 boundary — DB cleanup failure is translated to a typed
+      // { success: false } so a failed disconnect is not reported as done.
       logger.error("[Discord] Disconnect error:", {
         organizationId,
         guildId,
@@ -700,7 +726,14 @@ class DiscordAutomationService {
         },
       });
       return response.ok;
-    } catch {
+    } catch (error) {
+      // error-policy:J1 boundary — this is an access probe; a transport failure
+      // means access is unconfirmed, so the fail-closed answer is "no access".
+      // Warned so the transport failure is observable, not silently swallowed.
+      logger.warn("[Discord] Channel access probe failed", {
+        channelId,
+        error: error instanceof Error ? error.message : String(error),
+      });
       return false;
     }
   }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Error-policy pin (#13415): in runSharedAgentTurn an INTERNAL inference/provider
+ * failure must PROPAGATE (throw with `cause`) so the caller refunds the credit
+ * hold and the failure surfaces, while the DESIGNED no-model-configured
+ * "unavailable" state stays a distinguishable `degraded` result — the two must
+ * never collapse into the same signal. Drives the real exported function with the
+ * `ai` SDK's `generateText` and the language-model router stubbed via mock.module
+ * (deterministic, no live model); global fetch is trapped and restored to prove
+ * no accidental network.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Per-test controls for the two collaborators runSharedAgentTurn calls.
+let providerConfigured = true;
+let generateTextImpl: () => Promise<{ text: string; usage?: unknown }> = async () => ({
+  text: "ok reply",
+});
+
+mock.module("../../providers/language-model", () => ({
+  // The returned handle is opaque here — generateText is stubbed, so it is never
+  // actually invoked against a provider.
+  getLanguageModel: () => ({ __sentinel: "model" }),
+  hasLanguageModelProviderConfigured: () => providerConfigured,
+}));
+
+mock.module("ai", () => ({
+  generateText: async () => generateTextImpl(),
+}));
+
+const { runSharedAgentTurn } = await import("./run-shared-agent-turn");
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  providerConfigured = true;
+  generateTextImpl = async () => ({ text: "ok reply" });
+  globalThis.fetch = mock(async () => {
+    throw new Error("no network expected in this unit test");
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("runSharedAgentTurn — internal failure propagates vs designed-empty degrades", () => {
+  test("an internal inference/provider failure throws (propagates) instead of degrading", async () => {
+    providerConfigured = true;
+    generateTextImpl = async () => {
+      throw new Error("provider 503 during shared-runtime turn");
+    };
+
+    const error = await runSharedAgentTurn({
+      character: { name: "Nova", system: "You are Nova.", model: "gpt-oss-120b" },
+      history: [],
+      message: "hello",
+    }).then(
+      () => {
+        throw new Error("expected runSharedAgentTurn to throw on inference failure");
+      },
+      (e: unknown) => e,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    // Context is added (agent + model) and the original error is preserved as cause,
+    // so the failure is diagnosable rather than swallowed into a canned reply.
+    expect((error as Error).message).toContain("Nova");
+    expect((error as Error).message).toContain("gpt-oss-120b");
+    const cause = (error as { cause?: unknown }).cause;
+    expect(cause).toBeInstanceOf(Error);
+    expect((cause as Error).message).toContain("provider 503");
+  });
+
+  test("the designed no-model-configured state stays a distinguishable degraded result (no throw)", async () => {
+    // No provider configured for any model → resolveSharedAgentTurnModel() is null,
+    // so this is the intentional unavailable state, NOT an internal failure. It must
+    // return degraded without ever calling generateText.
+    providerConfigured = false;
+    generateTextImpl = async () => {
+      throw new Error("generateText must not be reached when no model is configured");
+    };
+
+    const result = await runSharedAgentTurn({
+      character: { name: "Nova", system: "You are Nova." },
+      history: [],
+      message: "  hello there  ",
+    });
+
+    expect(result.degraded).toBe(true);
+    expect(result.model).toBe("none");
+    expect(result.reply).toContain("no shared model configured");
+    expect(result.history).toHaveLength(2);
+    expect(result.history[0]).toEqual({ role: "user", content: "hello there" });
+    expect(result.history[1]?.role).toBe("assistant");
+  });
+
+  test("a successful turn returns the reply with degraded:false (not a tautology — real SUT runs)", async () => {
+    providerConfigured = true;
+    generateTextImpl = async () => ({ text: "  hi from Nova  ", usage: { totalTokens: 7 } });
+
+    const result = await runSharedAgentTurn({
+      character: { name: "Nova", system: "You are Nova.", model: "gpt-oss-120b" },
+      history: [
+        { role: "user", content: "prev-q" },
+        { role: "assistant", content: "prev-a" },
+      ],
+      message: "hi",
+    });
+
+    expect(result.degraded).toBe(false);
+    expect(result.reply).toBe("hi from Nova");
+    expect(result.model).toBe("gpt-oss-120b");
+    expect(result.usage).toEqual({ totalTokens: 7 });
+    // history + new user message + assistant reply.
+    expect(result.history).toHaveLength(4);
+    expect(result.history[2]).toEqual({ role: "user", content: "hi" });
+    expect(result.history[3]).toEqual({ role: "assistant", content: "hi from Nova" });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -26,7 +26,6 @@ import {
   getLanguageModel,
   hasLanguageModelProviderConfigured,
 } from "../../providers/language-model";
-import { logger } from "../../utils/logger";
 
 export interface SharedTurnMessage {
   role: "user" | "assistant";
@@ -57,7 +56,11 @@ export interface RunSharedAgentTurnResult {
   /** history + the new user message + the assistant reply (persist this). */
   history: SharedTurnMessage[];
   model: string;
-  /** True when no shared model was configured or generation failed. */
+  /**
+   * True only for the designed no-model-configured "unavailable" state (the sole
+   * degrade path). An inference/provider failure THROWS instead — so a broken
+   * turn never reads as this benign flag, and the caller refunds the credit hold.
+   */
   degraded: boolean;
   usage?: SharedAgentTurnUsage;
 }
@@ -120,7 +123,12 @@ function appendTurn(
   ];
 }
 
-/** Run one shared (container-free) turn for a simple agent. Never throws. */
+/**
+ * Run one shared (container-free) turn for a simple agent. Returns a degraded
+ * result only when NO shared model is configured (a designed-unavailable state);
+ * an inference/provider failure is thrown so the caller can refund the credit
+ * hold and surface the failure rather than mistaking it for a delivered reply.
+ */
 export async function runSharedAgentTurn(
   input: RunSharedAgentTurnInput,
 ): Promise<RunSharedAgentTurnResult> {
@@ -155,18 +163,15 @@ export async function runSharedAgentTurn(
       usage,
     };
   } catch (error) {
-    logger.error("[shared-runtime] turn failed; degrading", {
-      agent: input.character.name,
-      model: modelId,
-      errorName: error instanceof Error ? error.name : "unknown",
-      error: error instanceof Error ? error.message : String(error),
-    });
-    const reply = `${input.character.name} hit a temporary error. Please try again.`;
-    return {
-      reply,
-      history: appendTurn(input.history, message, reply),
-      model: modelId,
-      degraded: true,
-    };
+    // error-policy:J2 context-adding rethrow. An inference/provider failure is an
+    // INTERNAL failure, not a designed-empty result: swallowing it into a
+    // `degraded: true` reply made a broken turn indistinguishable from the
+    // no-model-configured unavailable state above and let it read as a delivered
+    // (if apologetic) chat message. Rethrow with `cause` so it surfaces and the
+    // caller (bridgeSharedMessageSend) refunds the credit hold instead of billing.
+    throw new Error(
+      `[shared-runtime] agent turn failed (agent=${input.character.name}, model=${modelId})`,
+      { cause: error },
+    );
   }
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.error-policy.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Error-policy pins for the shared-runtime REST adapter (#13415): a failed
+ * internal call (sandbox repo throw, bridge transport reject) must PROPAGATE, so
+ * a broken pipeline surfaces as an error instead of reading as "no character",
+ * "no messages", or a delivered-but-empty reply. The designed-empty answers
+ * (`getSharedRuntimeCharacter` → `null`, empty turn history) must stay a
+ * DISTINCT, non-throwing result. The adapter already fails closed (no
+ * try/catch, no console); these tests lock that in against regressions.
+ *
+ * Dependency boundary is the `elizaSandboxService` singleton (the adapter makes
+ * no direct `fetch`), mocked via bun's process-global `mock.module` and imported
+ * after the mock, matching shared-rest-adapter.test.ts.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as realElizaSandbox from "../eliza-sandbox";
+
+const bridge = mock();
+const getSharedConversationHistory = mock();
+const getSharedRuntimeCharacter = mock();
+
+mock.module("../eliza-sandbox", () => ({
+  ...realElizaSandbox,
+  elizaSandboxService: { bridge, getSharedConversationHistory, getSharedRuntimeCharacter },
+}));
+
+const { sharedRestCharacter, sharedRestMessagesGet, sharedRestMessageSend } = await import(
+  "./shared-rest-adapter"
+);
+
+// The adapter routes through elizaSandboxService, not global fetch; guard it
+// anyway so a stray call fails loudly instead of hitting the network, and
+// restore the original each test as required by the sweep.
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+afterAll(() => {
+  mock.module("../eliza-sandbox", () => realElizaSandbox);
+});
+
+const AGENT = "de42b5ff-72d3-4a1a-8a16-19aee293bfea";
+const ORG = "org-1";
+
+describe("shared-rest-adapter error-policy — internal failure propagates vs designed-empty", () => {
+  beforeEach(() => {
+    bridge.mockReset();
+    getSharedConversationHistory.mockReset();
+    getSharedRuntimeCharacter.mockReset();
+    globalThis.fetch = mock(() => {
+      throw new Error("[test] unexpected global fetch");
+    }) as unknown as typeof fetch;
+  });
+
+  test("character: resolver null is designed-empty ({}), NOT a swallowed failure", async () => {
+    getSharedRuntimeCharacter.mockResolvedValue(null);
+    const out = await sharedRestCharacter(AGENT, ORG, "Nova");
+    expect(out).toEqual({ character: {}, agentName: "Nova" });
+  });
+
+  test("character: a resolver THROW propagates (broken pipeline is not empty character)", async () => {
+    getSharedRuntimeCharacter.mockRejectedValue(new Error("db unreachable: findRunningSandbox"));
+    await expect(sharedRestCharacter(AGENT, ORG, "Nova")).rejects.toThrow(
+      "db unreachable: findRunningSandbox",
+    );
+  });
+
+  test("messages: empty history is designed-empty ([]), NOT a swallowed failure", async () => {
+    getSharedConversationHistory.mockResolvedValue([]);
+    const out = await sharedRestMessagesGet(AGENT, AGENT);
+    expect(out).toEqual({ messages: [] });
+  });
+
+  test("messages: a history load THROW propagates (broken pipeline is not empty history)", async () => {
+    getSharedConversationHistory.mockRejectedValue(new Error("KV read failed"));
+    await expect(sharedRestMessagesGet(AGENT, AGENT)).rejects.toThrow("KV read failed");
+  });
+
+  test("send: a bridge transport THROW propagates (never fabricates a delivered reply)", async () => {
+    bridge.mockRejectedValue(new Error("bridge fetch ECONNRESET"));
+    await expect(sharedRestMessageSend(AGENT, ORG, AGENT, "hi", "Eliza")).rejects.toThrow(
+      "bridge fetch ECONNRESET",
+    );
+  });
+
+  test("send: a successful bridge reply with no text is a distinct EMPTY string, not a throw", async () => {
+    // No response.error and a result without `text` is a designed (if degenerate)
+    // success shape — it must resolve to an empty reply, distinguishable from the
+    // transport-throw path above, so the client can render an empty turn rather
+    // than a failure overlay.
+    bridge.mockResolvedValue({ jsonrpc: "2.0", id: "x", result: {} });
+    await expect(sharedRestMessageSend(AGENT, ORG, AGENT, "hi", "Eliza")).resolves.toEqual({
+      text: "",
+      agentName: "Eliza",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/telegram-automation/app-automation.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/telegram-automation/app-automation.error-policy.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Error-policy tests for the Telegram app-automation connector (#13415).
+ *
+ * Doctrine: a failed Telegram send is an internal transport failure and must
+ * surface as a distinguishable `PostResult` failure (success:false + error),
+ * never read as "delivered". These pin that a send that throws propagates into
+ * success:false carrying the transport error, while the DESIGNED reject
+ * (automation not enabled) and the success path stay distinct — so callers can
+ * tell a broken send apart from a legitimately-skipped post and a real post.
+ *
+ * The real exported `postAnnouncement` is driven; only its collaborators
+ * (Telegram SDK, bot-token lookup, app repo) are mocked, and `text` is passed
+ * so no credit/LLM generation runs.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const ORG_ID = "00000000-0000-4000-8000-00000000c001";
+const APP_ID = "00000000-0000-4000-8000-00000000c002";
+
+// Controls how the mocked Telegram sendMessage behaves for the current test.
+let sendBehavior: () => Promise<{ message_id: number }> = async () => ({ message_id: 1 });
+
+mock.module("telegraf", () => ({
+  Telegraf: class {
+    telegram = {
+      sendMessage: (..._args: unknown[]) => sendBehavior(),
+      sendPhoto: (..._args: unknown[]) => sendBehavior(),
+    };
+  },
+}));
+
+mock.module("./index", () => ({
+  telegramAutomationService: {
+    getBotToken: async () => "TELEGRAM_BOT_TOKEN",
+    isConfigured: async () => true,
+    getConnectionStatus: async () => ({ connected: true }),
+  },
+}));
+
+const updateCalls: unknown[] = [];
+function makeApp(overrides: Record<string, unknown> = {}) {
+  return {
+    id: APP_ID,
+    organization_id: ORG_ID,
+    name: "Test App",
+    description: "An app under test",
+    app_url: "https://test-app.example",
+    website_url: "https://test-app.example",
+    promotional_assets: undefined,
+    telegram_automation: { enabled: true, channelId: "chan-123" },
+    ...overrides,
+  };
+}
+let appFixture = makeApp();
+
+mock.module("../../../db/repositories/apps", () => ({
+  appsRepository: {
+    findById: async () => appFixture,
+    update: async (_id: string, patch: unknown) => {
+      updateCalls.push(patch);
+      return appFixture;
+    },
+  },
+}));
+
+mock.module("../credits", () => ({
+  creditsService: {
+    deductCredits: async () => ({ success: true, newBalance: 100, transaction: null }),
+    refundCredits: async () => ({ transaction: {}, newBalance: 100 }),
+  },
+}));
+
+mock.module("../character-prompt-helper", () => ({
+  getCharacterPromptContext: async () => null,
+  buildCharacterSystemPrompt: () => "IN CHARACTER",
+}));
+
+const { telegramAppAutomationService } = await import("./app-automation");
+
+const originalFetch = globalThis.fetch;
+beforeEach(() => {
+  updateCalls.length = 0;
+  appFixture = makeApp();
+  sendBehavior = async () => ({ message_id: 1 });
+  globalThis.fetch = (async () => {
+    throw new Error("network access not allowed in this test");
+  }) as typeof fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("postAnnouncement error policy (#13415)", () => {
+  test("Telegram send transport failure propagates as distinguishable success:false", async () => {
+    sendBehavior = async () => {
+      throw new Error("ETELEGRAM 429 too many requests");
+    };
+
+    const result = await telegramAppAutomationService.postAnnouncement(
+      ORG_ID,
+      APP_ID,
+      "hello world",
+    );
+
+    // Internal failure surfaces — NOT fabricated as delivered.
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ETELEGRAM 429 too many requests");
+    expect(result.messageId).toBeUndefined();
+    // A failed send must not bump the sent-message counter.
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("designed reject (automation disabled) stays distinct from transport failure", async () => {
+    appFixture = makeApp({ telegram_automation: { enabled: false, channelId: "chan-123" } });
+
+    const result = await telegramAppAutomationService.postAnnouncement(
+      ORG_ID,
+      APP_ID,
+      "hello world",
+    );
+
+    expect(result.success).toBe(false);
+    // Distinguishable from a transport error: a designed, not-a-crash reason.
+    expect(result.error).toBe("Automation not enabled for this app");
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("successful send is not conflated with the failure branch", async () => {
+    sendBehavior = async () => ({ message_id: 4242 });
+
+    const result = await telegramAppAutomationService.postAnnouncement(
+      ORG_ID,
+      APP_ID,
+      "hello world",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.messageId).toBe(4242);
+    expect(result.error).toBeUndefined();
+    // Only a real delivery bumps the counter.
+    expect(updateCalls).toHaveLength(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/telegram-automation/app-automation.ts
+++ b/packages/cloud/shared/src/lib/services/telegram-automation/app-automation.ts
@@ -453,6 +453,7 @@ Maximum 300 characters.`;
         }
       }
     } catch (error) {
+      // error-policy:J1 Telegram send transport boundary -> typed PostResult failure the callers surface as success:false
       lastError = error instanceof Error ? error.message : "Failed to send message";
       logger.error("[TelegramAppAutomation] Failed to post announcement", {
         appId,
@@ -553,6 +554,7 @@ Maximum 300 characters.`;
         chatId: message.chatId,
       };
     } catch (error) {
+      // error-policy:J1 Telegram send transport boundary -> typed PostResult failure the caller surfaces as success:false
       const errorMsg = error instanceof Error ? error.message : "Failed to send reply";
       logger.error("[TelegramAppAutomation] Failed to handle message", {
         appId,

--- a/packages/cloud/shared/src/lib/services/telegram-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/telegram-automation/index.error-policy.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Error-policy proof for the Telegram automation connector (#13415).
+ *
+ * Pins the fail-closed contract: an internal platform/API failure PROPAGATES as an
+ * explicit typed failure and stays DISTINCT from a legitimately-empty/designed state
+ * (not-configured, invalid-format) — a failed send never reads as "delivered", a failed
+ * status check never reads as a clean success. Drives the real exported singleton with
+ * Telegraf + the secrets store mocked; no source stubs stand in for the code under test.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Per-test controllable Telegram API behavior.
+let getMeImpl: () => Promise<{ id: number; username?: string; first_name: string }>;
+let sendMessageImpl: (
+  chatId: string | number,
+  text: string,
+  opts: unknown,
+) => Promise<{ message_id: number }>;
+
+mock.module("telegraf", () => ({
+  Telegraf: class {
+    telegram = {
+      getMe: () => getMeImpl(),
+      sendMessage: (chatId: string | number, text: string, opts: unknown) =>
+        sendMessageImpl(chatId, text, opts),
+      setWebhook: async () => ({}),
+      deleteWebhook: async () => ({}),
+    };
+    constructor(public token: string) {}
+  },
+}));
+
+// In-memory secrets store keyed by secret name (single org per test id keeps it flat).
+const secretStore = new Map<string, string>();
+mock.module("../secrets", () => ({
+  secretsService: {
+    get: async (_organizationId: string, name: string) => secretStore.get(name) ?? null,
+    list: async () => [],
+    create: async () => undefined,
+    rotate: async () => undefined,
+    delete: async () => undefined,
+  },
+}));
+
+const { telegramAutomationService } = await import("./index");
+
+let realFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  secretStore.clear();
+  // Any real network attempt must fail loudly — the connector is fully mocked, so a live
+  // fetch would mean the test escaped its harness.
+  realFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error("unexpected real network call");
+  }) as typeof globalThis.fetch;
+  getMeImpl = async () => ({ id: 1, username: "bot", first_name: "Bot" });
+  sendMessageImpl = async () => ({ message_id: 100 });
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("sendMessage — outbound send fails closed", () => {
+  test("designed 'not configured' (no token) returns explicit failure, never attempts a send", async () => {
+    let sendAttempted = false;
+    sendMessageImpl = async () => {
+      sendAttempted = true;
+      return { message_id: 1 };
+    };
+
+    const res = await telegramAutomationService.sendMessage("org-noconf", 42, "hi");
+
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("Bot not configured");
+    expect(res.messageId).toBeUndefined();
+    expect(sendAttempted).toBe(false);
+  });
+
+  test("internal Telegram failure PROPAGATES as { success:false } — not a fabricated delivery", async () => {
+    secretStore.set("TELEGRAM_BOT_TOKEN", "123:abc");
+    sendMessageImpl = async () => {
+      throw new Error("403: bot was blocked by the user");
+    };
+
+    const res = await telegramAutomationService.sendMessage("org-send-fail", 42, "hi");
+
+    expect(res.success).toBe(false);
+    expect(res.messageId).toBeUndefined();
+    expect(res.error).toContain("bot was blocked");
+  });
+
+  test("a real delivery is the ONLY path that yields success:true + a messageId", async () => {
+    secretStore.set("TELEGRAM_BOT_TOKEN", "123:abc");
+    sendMessageImpl = async () => ({ message_id: 777 });
+
+    const res = await telegramAutomationService.sendMessage("org-send-ok", 42, "hi");
+
+    expect(res.success).toBe(true);
+    expect(res.messageId).toBe(777);
+    expect(res.error).toBeUndefined();
+  });
+});
+
+describe("getConnectionStatus — internal failure stays distinct from designed-empty", () => {
+  test("designed-empty: no stored token => not configured, NO error field", async () => {
+    const status = await telegramAutomationService.getConnectionStatus("org-empty", {
+      skipCache: true,
+    });
+
+    expect(status.configured).toBe(false);
+    expect(status.connected).toBe(false);
+    expect(status.error).toBeUndefined();
+  });
+
+  test("internal failure: token present but getMe throws => error field surfaces (distinct render)", async () => {
+    secretStore.set("TELEGRAM_BOT_TOKEN", "123:abc");
+    secretStore.set("TELEGRAM_BOT_USERNAME", "mybot");
+    secretStore.set("TELEGRAM_BOT_ID", "555");
+    getMeImpl = async () => {
+      throw new Error("401 Unauthorized");
+    };
+
+    const status = await telegramAutomationService.getConnectionStatus("org-status-fail", {
+      skipCache: true,
+    });
+
+    // configured stays true (credentials ARE stored) but the failure is observably flagged —
+    // the populated `error` keeps this distinguishable from the designed not-configured empty.
+    expect(status.configured).toBe(true);
+    expect(typeof status.error).toBe("string");
+    expect(status.error).toContain("reconnect");
+  });
+
+  test("healthy: getMe succeeds => connected with no error", async () => {
+    secretStore.set("TELEGRAM_BOT_TOKEN", "123:abc");
+    getMeImpl = async () => ({ id: 999, username: "livebot", first_name: "Live" });
+
+    const status = await telegramAutomationService.getConnectionStatus("org-status-ok", {
+      skipCache: true,
+    });
+
+    expect(status.connected).toBe(true);
+    expect(status.configured).toBe(true);
+    expect(status.botId).toBe(999);
+    expect(status.error).toBeUndefined();
+  });
+});
+
+describe("validateBotToken — untrusted token verdict is explicit", () => {
+  test("designed-invalid format returns { valid:false } without touching the API", async () => {
+    let apiCalled = false;
+    getMeImpl = async () => {
+      apiCalled = true;
+      return { id: 1, username: "bot", first_name: "Bot" };
+    };
+
+    const res = await telegramAutomationService.validateBotToken("no-colon-token");
+
+    expect(res.valid).toBe(false);
+    expect(res.error).toBe("Invalid token format");
+    expect(apiCalled).toBe(false);
+  });
+
+  test("API failure PROPAGATES into the verdict as { valid:false, error } — distinct from format-invalid", async () => {
+    getMeImpl = async () => {
+      throw new Error("404: Not Found");
+    };
+
+    const res = await telegramAutomationService.validateBotToken("123:abc");
+
+    expect(res.valid).toBe(false);
+    expect(res.botInfo).toBeUndefined();
+    expect(res.error).toContain("Not Found");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/telegram-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/telegram-automation/index.ts
@@ -87,6 +87,8 @@ class TelegramAutomationService {
         },
       };
     } catch (error) {
+      // error-policy:J3 getMe failure IS the validation verdict for this untrusted token;
+      // surface it as an explicit typed { valid: false, error } — never a fake-valid default.
       const message = error instanceof Error ? error.message : "Unknown error";
       logger.warn("[TelegramAutomation] Token validation failed", {
         error: message,
@@ -122,6 +124,8 @@ class TelegramAutomationService {
           audit,
         );
       } catch (err) {
+        // error-policy:J2 recover the known "already exists" conflict by rotating in place;
+        // every other store error rethrows (fail-closed upsert — a broken write never looks stored).
         if (err instanceof Error && err.message.includes("already exists")) {
           logger.info("[TelegramAutomation] Secret exists, updating", { name });
           const existingSecrets = await secretsService.list(organizationId);
@@ -166,7 +170,8 @@ class TelegramAutomationService {
     try {
       await this.removeWebhook(organizationId);
     } catch {
-      // Webhook might not be set
+      // error-policy:J6 best-effort teardown; an unset/unreachable webhook must not block
+      // credential removal during disconnect. The delete loop below still fails closed.
     }
 
     const secretNames = [
@@ -188,6 +193,8 @@ class TelegramAutomationService {
             organizationId,
           });
         } catch (error) {
+          // error-policy:J6 idempotent teardown — an already-removed secret is tolerated,
+          // any other delete failure rethrows so a stuck secret surfaces instead of silently persisting.
           const message = error instanceof Error ? error.message : String(error);
           if (message.includes("Secret not found") || message.includes("Failed to delete secret")) {
             logger.debug("[TelegramAutomation] Secret already removed during disconnect", {
@@ -265,12 +272,15 @@ class TelegramAutomationService {
       this.statusCache.set(organizationId, { status, cachedAt: Date.now() });
       return status;
     } catch (error) {
+      // error-policy:J4 explicit user-facing degrade: credentials ARE stored (configured:true),
+      // but Telegram is currently unreachable/token-suspect. The populated `error` field keeps this
+      // internal-failure state DISTINCT from the designed not-configured empty above; a shorter TTL
+      // avoids pinning the error. Never fabricated as a clean success.
       logger.warn("[TelegramAutomation] Token validation failed during status check", {
         organizationId,
         error: error instanceof Error ? error.message : "Unknown error",
       });
 
-      // Return stored data even if validation fails (don't cache error state)
       const status: TelegramConnectionStatus = {
         connected: true,
         configured: true,
@@ -330,6 +340,8 @@ class TelegramAutomationService {
 
       return { success: true };
     } catch (error) {
+      // error-policy:J1 boundary translation of the outbound Telegram setWebhook call into a
+      // typed { success: false, error } Result; callers gate on `.success`, so the failure surfaces.
       const message = error instanceof Error ? error.message : "Unknown error";
       logger.error("[TelegramAutomation] Failed to set webhook", {
         organizationId,
@@ -365,6 +377,8 @@ class TelegramAutomationService {
 
       logger.info("[TelegramAutomation] Webhook removed", { organizationId });
     } catch (error) {
+      // error-policy:J6 best-effort teardown on the disconnect path; a failed webhook removal
+      // must not block credential deletion. Logged so a persistent failure is still observable.
       logger.warn("[TelegramAutomation] Failed to remove webhook", {
         organizationId,
         error: error instanceof Error ? error.message : "Unknown error",
@@ -412,6 +426,9 @@ class TelegramAutomationService {
 
       return { success: true, messageId: result.message_id };
     } catch (error) {
+      // error-policy:J1 boundary translation of the outbound Telegram send into a typed
+      // { success: false, error } Result — a failed send reads as failure, never as delivered
+      // (success:true only ever carries a real messageId). Callers gate on `.success`.
       const message = error instanceof Error ? error.message : "Unknown error";
       logger.error("[TelegramAutomation] Failed to send message", {
         organizationId,

--- a/packages/cloud/shared/src/lib/services/twitter-automation/app-automation.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/app-automation.error-policy.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Error-policy pins for the Twitter app-automation connector (#13415): an
+ * outbound send failure must surface as the typed `success:false` Result with
+ * the real error and must NOT be recorded as delivered, while the designed
+ * "not connected" unavailable state stays distinguishable from an internal API
+ * failure. Drives the real `postAppTweet` with the Twitter client, secrets, and
+ * apps repository mocked; `client.v2.tweet` behaviour is swapped per test.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+// Read at module load in getTwitterClient — must exist before the dynamic import.
+process.env.TWITTER_API_KEY = "test-app-key";
+process.env.TWITTER_API_SECRET_KEY = "test-app-secret";
+
+const ORG_ID = "00000000-0000-4000-8000-00000000c001";
+const APP_ID = "00000000-0000-4000-8000-00000000c002";
+
+// Per-test control knobs.
+let twitterConnected = true;
+let tweetImpl: (text: string) => Promise<{ data: { id: string } }>;
+
+interface UpdateCall {
+  appId: string;
+  patch: Record<string, unknown>;
+}
+const updateCalls: UpdateCall[] = [];
+
+const appRow = {
+  id: APP_ID,
+  organization_id: ORG_ID,
+  name: "Test App",
+  description: "An app under test",
+  app_url: "https://test-app.example",
+  twitter_automation: { enabled: true, totalPosts: 3 },
+};
+
+// Mock the deep `apps` module (re-exported by the repositories barrel via
+// `export * from "./apps"`) so sibling repositories keep their real exports.
+const appsRepositoryMock = {
+  findById: async (id: string) => (id === APP_ID ? appRow : null),
+  update: async (appId: string, patch: Record<string, unknown>) => {
+    updateCalls.push({ appId, patch });
+    return { ...appRow, ...patch };
+  },
+};
+mock.module("../../../db/repositories/apps", () => ({
+  appsRepository: appsRepositoryMock,
+  AppsRepository: class {},
+}));
+
+mock.module("../secrets", () => ({
+  secretsService: {
+    get: async (_org: string, key: string) => {
+      if (!twitterConnected) return null;
+      return key === "TWITTER_ACCESS_TOKEN" ? "access-token" : "access-token-secret";
+    },
+  },
+}));
+
+// The connector constructs `new TwitterApi({...})` then calls `client.v2.tweet`.
+mock.module("twitter-api-v2", () => ({
+  TwitterApi: class {
+    v2 = { tweet: (text: string) => tweetImpl(text) };
+  },
+}));
+
+// Import-safety: these are pulled in at module top but unused on the
+// tweetText-provided path (no generation). Mock to keep the import cheap.
+mock.module("../credits", () => ({
+  creditsService: {
+    deductCredits: async () => ({ success: true, newBalance: 100, transaction: null }),
+    refundCredits: async () => ({ transaction: {}, newBalance: 100 }),
+  },
+}));
+
+const { twitterAppAutomationService } = await import("./app-automation");
+
+const realFetch = globalThis.fetch;
+beforeEach(() => {
+  updateCalls.length = 0;
+  twitterConnected = true;
+  tweetImpl = async () => ({ data: { id: "default" } });
+  // Safety net: no real network may leak through the mocked connector.
+  globalThis.fetch = (async () => {
+    throw new Error("network access is not allowed in this test");
+  }) as typeof fetch;
+});
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("postAppTweet error policy (#13415)", () => {
+  test("outbound Twitter API failure surfaces as success:false and is NOT recorded as delivered", async () => {
+    tweetImpl = async () => {
+      throw new Error("Twitter API rate limited (429)");
+    };
+
+    const result = await twitterAppAutomationService.postAppTweet(ORG_ID, APP_ID, "hello world");
+
+    // Failure is distinct: no fabricated success, no tweet id, real error text.
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("rate limited");
+    expect(result.tweetId).toBeUndefined();
+    expect(result.tweetUrl).toBeUndefined();
+    // Crucially: a failed send must not increment totalPosts / stamp lastPostAt.
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("successful send is distinguishable: success:true, tweet id, and post recorded", async () => {
+    tweetImpl = async () => ({ data: { id: "1750000000000000000" } });
+
+    const result = await twitterAppAutomationService.postAppTweet(ORG_ID, APP_ID, "hello world");
+
+    expect(result.success).toBe(true);
+    expect(result.tweetId).toBe("1750000000000000000");
+    expect(result.tweetUrl).toContain("1750000000000000000");
+    // Delivery recorded exactly once, incrementing the prior count (3 -> 4).
+    expect(updateCalls).toHaveLength(1);
+    const automation = updateCalls[0].patch.twitter_automation as {
+      totalPosts: number;
+      lastPostAt: string;
+    };
+    expect(automation.totalPosts).toBe(4);
+    expect(typeof automation.lastPostAt).toBe("string");
+  });
+
+  test("designed 'not connected' unavailable state stays distinct from an internal failure", async () => {
+    twitterConnected = false;
+    let tweetAttempted = false;
+    tweetImpl = async () => {
+      tweetAttempted = true;
+      return { data: { id: "should-not-happen" } };
+    };
+
+    const result = await twitterAppAutomationService.postAppTweet(ORG_ID, APP_ID, "hello world");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Twitter not connected");
+    expect(result.tweetId).toBeUndefined();
+    // No send attempted, nothing recorded — a legitimately-unavailable connector,
+    // not a swallowed API error.
+    expect(tweetAttempted).toBe(false);
+    expect(updateCalls).toHaveLength(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/twitter-automation/app-automation.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/app-automation.ts
@@ -297,6 +297,10 @@ Return ONLY the tweet text, nothing else.`;
           setTimeout(() => reject(new Error("Twitter API timeout")), TWITTER_API_TIMEOUT_MS),
         ),
       ]);
+      // error-policy:J1 boundary — outbound Twitter API failure translated to the
+      // typed connector Result (success:false + error). Callers branch on .success
+      // (cron/social-automation, app-promotion, post/route), so this surfaces the
+      // send failure distinctly and never fabricates a delivered/success result.
     } catch (error) {
       logger.error("[TwitterAppAutomation] Failed to post tweet", {
         appId,

--- a/packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts
@@ -1,0 +1,158 @@
+// Pins the fail-closed error policy of TwitterAutomationService: an internal platform/API failure
+// propagates or surfaces as a distinct error field, and is never conflated with a designed-empty
+// ("not connected", "identity absent") result. Deterministic — twitter-api-v2, the oauth2 token
+// client, and the secrets store are stubbed via mock.module; no real network.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface MeResult {
+  data: { username: string; id: string; profile_image_url?: string };
+}
+
+// Per-test behavior for the stubbed twitter-api-v2 client and oauth2 token endpoint.
+const twitterApiBehavior: { me: () => Promise<MeResult> } = {
+  me: async () => ({ data: { username: "alice", id: "42" } }),
+};
+const oauth2Behavior: {
+  requestToken: () => Promise<{ access_token?: string; refresh_token?: string; scope?: string }>;
+} = {
+  requestToken: async () => ({ access_token: "access-tok", scope: "tweet.read tweet.write" }),
+};
+const secretStore: Record<string, string | null> = {};
+
+class MockTwitterApi {
+  constructor(_config: unknown) {}
+  v2 = { me: (..._args: unknown[]) => twitterApiBehavior.me() };
+}
+
+mock.module("twitter-api-v2", () => ({ TwitterApi: MockTwitterApi }));
+
+mock.module("./oauth2-client", () => ({
+  requestTwitterOAuth2Token: () => oauth2Behavior.requestToken(),
+  parseTwitterOAuth2Scope: (scope?: string) =>
+    typeof scope === "string" ? scope.split(/\s+/).filter(Boolean) : [],
+  getTwitterOAuth2ClientAuthMode: () => "public",
+  hasTwitterOAuth2ClientId: () => true,
+  requireTwitterOAuth2ClientId: () => "client-id",
+  normalizeTwitterOAuth2AuthorizeUrl: (url: string) => url,
+}));
+
+mock.module("../secrets", () => ({
+  secretsService: {
+    get: async (_org: string, name: string) => secretStore[name] ?? null,
+  },
+}));
+
+// index.ts re-exports the heavy app-automation service (ai/db/credits) on load — stub it so the
+// module under test imports without standing up unrelated infrastructure.
+mock.module("./app-automation", () => ({ twitterAppAutomationService: {} }));
+
+const originalFetch = globalThis.fetch;
+
+async function loadService() {
+  const mod = await import("./index");
+  return mod.twitterAutomationService;
+}
+
+describe("TwitterAutomationService error policy", () => {
+  beforeEach(() => {
+    for (const key of Object.keys(secretStore)) delete secretStore[key];
+    twitterApiBehavior.me = async () => ({ data: { username: "alice", id: "42" } });
+    oauth2Behavior.requestToken = async () => ({
+      access_token: "access-tok",
+      scope: "tweet.read tweet.write",
+    });
+    // Any real network hit is a bug: this suite must be fully deterministic.
+    globalThis.fetch = (async () => {
+      throw new Error("unexpected network call in error-policy test");
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("exchangeOAuth2Token", () => {
+    test("propagates a failed token exchange instead of swallowing it", async () => {
+      oauth2Behavior.requestToken = async () => {
+        throw new Error("token endpoint returned 400 invalid_grant");
+      };
+      const service = await loadService();
+      await expect(service.exchangeOAuth2Token("code", "verifier", "https://cb")).rejects.toThrow(
+        /invalid_grant/,
+      );
+    });
+
+    test("fails closed when the token response omits an access token", async () => {
+      oauth2Behavior.requestToken = async () => ({ scope: "tweet.read" });
+      const service = await loadService();
+      await expect(service.exchangeOAuth2Token("code", "verifier", "https://cb")).rejects.toThrow(
+        /did not include an access token/,
+      );
+    });
+
+    test("surfaces a failed identity lookup as a distinct field, not a fabricated identity", async () => {
+      twitterApiBehavior.me = async () => {
+        throw Object.assign(new Error("profile forbidden"), { code: 403 });
+      };
+      const service = await loadService();
+      const result = await service.exchangeOAuth2Token("code", "verifier", "https://cb");
+
+      // Primary op succeeded → token flows through; secondary lookup failure is reported, not faked.
+      expect(result.accessToken).toBe("access-tok");
+      expect(result.screenName).toBeUndefined();
+      expect(result.userId).toBeUndefined();
+      expect(typeof result.identityLookupError).toBe("string");
+      expect(result.identityLookupError).toContain("forbidden");
+    });
+
+    test("a successful identity lookup leaves no lingering error signal", async () => {
+      const service = await loadService();
+      const result = await service.exchangeOAuth2Token("code", "verifier", "https://cb");
+      expect(result.screenName).toBe("alice");
+      expect(result.userId).toBe("42");
+      expect(result.identityLookupError).toBeUndefined();
+    });
+  });
+
+  describe("getConnectionStatus", () => {
+    test("designed-empty (no stored credentials) is disconnected with NO error field", async () => {
+      const service = await loadService();
+      const status = await service.getConnectionStatus("org-1", "owner");
+      expect(status.connected).toBe(false);
+      expect(status.error).toBeUndefined();
+    });
+
+    test("internal validation failure is disconnected WITH an error field — distinct from empty", async () => {
+      secretStore.TWITTER_OWNER_OAUTH2_ACCESS_TOKEN = "stored-oauth2-token";
+      twitterApiBehavior.me = async () => {
+        throw Object.assign(new Error("upstream 500 boom"), { code: 500 });
+      };
+      const service = await loadService();
+      const status = await service.getConnectionStatus("org-1", "owner");
+      expect(status.connected).toBe(false);
+      expect(typeof status.error).toBe("string");
+      expect(status.error).toContain("reconnecting");
+    });
+
+    test("the OAuth2 403 quirk stays connected but still carries an explicit error, never silent", async () => {
+      secretStore.TWITTER_OWNER_OAUTH2_ACCESS_TOKEN = "stored-oauth2-token";
+      twitterApiBehavior.me = async () => {
+        throw Object.assign(new Error("profile forbidden"), { code: 403 });
+      };
+      const service = await loadService();
+      const status = await service.getConnectionStatus("org-1", "owner");
+      expect(status.connected).toBe(true);
+      expect(typeof status.error).toBe("string");
+      expect(status.error).toContain("OAuth2 credentials are stored");
+    });
+
+    test("a valid token reports connected with no error", async () => {
+      secretStore.TWITTER_OWNER_OAUTH2_ACCESS_TOKEN = "stored-oauth2-token";
+      const service = await loadService();
+      const status = await service.getConnectionStatus("org-1", "owner");
+      expect(status.connected).toBe(true);
+      expect(status.username).toBe("alice");
+      expect(status.error).toBeUndefined();
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/twitter-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/index.ts
@@ -209,6 +209,8 @@ async function upsertRoleSecret(args: {
     );
     return;
   } catch (error) {
+    // error-policy:J1 optimistic upsert — a unique-constraint/duplicate conflict is the expected
+    // "already stored, rotate instead" branch handled below; every other create failure rethrows.
     const message = error instanceof Error ? error.message : String(error);
     if (
       !message.includes("already exists") &&
@@ -443,6 +445,9 @@ class TwitterAutomationService {
       screenName = me.data.username;
       userId = me.data.id;
     } catch (error) {
+      // error-policy:J7 profile lookup is best-effort enrichment after a successful token
+      // exchange; the failure is surfaced to the caller via identityLookupError (never faked as a
+      // resolved identity) so the already-valid access token still flows through.
       identityLookupError = formatTwitterApiError(error, "Failed to fetch X profile");
       logger.warn("[TwitterAutomation] OAuth2 profile lookup failed after token exchange", {
         error: identityLookupError,
@@ -657,6 +662,8 @@ class TwitterAutomationService {
           connectionRole: role,
         });
       } catch (error) {
+        // error-policy:J6 idempotent disconnect teardown — a not-found/already-deleted secret is
+        // an acceptable no-op; any other delete failure rethrows so a genuine failure surfaces.
         const message = error instanceof Error ? error.message : String(error);
         if (!message.includes("Secret not found") && !message.includes("Failed to delete secret")) {
           throw error;
@@ -714,6 +721,9 @@ class TwitterAutomationService {
         avatarUrl: me.data.profile_image_url,
       };
     } catch (error) {
+      // error-policy:J4 token-validation failure degrades to a distinguishable connection status
+      // carrying an explicit error field — never a silent healthy/empty state. A missing-credentials
+      // case returns { connected:false } with no error above; this branch always sets error.
       const errorMessage = formatTwitterApiError(error, "Token validation failed");
       logger.warn("[TwitterAutomation] Token validation failed", {
         organizationId,

--- a/packages/cloud/shared/src/lib/services/twitter-automation/oauth2-client.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/oauth2-client.error-policy.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Fail-closed token exchange in requestTwitterOAuth2Token (#13415).
+ *
+ * This is the OAuth2 leg the connector uses to mint and refresh Twitter access
+ * tokens; a swallowed failure here would let a broken refresh read as a valid
+ * (empty) token and silently drop the connection. These tests pin that an
+ * internal failure — non-OK provider status, transport rejection, empty/malformed
+ * success body, or missing client credentials — PROPAGATES as a throw, and stays
+ * distinguishable from a legitimately-parsed token response.
+ */
+
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { requestTwitterOAuth2Token, requireTwitterOAuth2ClientId } from "./oauth2-client";
+
+const originalFetch = globalThis.fetch;
+const originalClientId = process.env.TWITTER_CLIENT_ID;
+const originalClientSecret = process.env.TWITTER_CLIENT_SECRET;
+
+beforeAll(() => {
+  process.env.TWITTER_CLIENT_ID = "test-client-id";
+  delete process.env.TWITTER_CLIENT_SECRET;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalClientId === undefined) delete process.env.TWITTER_CLIENT_ID;
+  else process.env.TWITTER_CLIENT_ID = originalClientId;
+  if (originalClientSecret === undefined) delete process.env.TWITTER_CLIENT_SECRET;
+  else process.env.TWITTER_CLIENT_SECRET = originalClientSecret;
+});
+
+function stubFetch(impl: () => Promise<Response> | Response): void {
+  globalThis.fetch = (async () => impl()) as typeof fetch;
+}
+
+describe("requestTwitterOAuth2Token — fail-closed token exchange", () => {
+  test("valid token response parses and is returned verbatim (designed success)", async () => {
+    process.env.TWITTER_CLIENT_ID = "test-client-id";
+    stubFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            access_token: "acc_123",
+            refresh_token: "ref_456",
+            scope: "tweet.read tweet.write",
+            expires_in: 7200,
+            token_type: "bearer",
+          }),
+          { status: 200 },
+        ),
+    );
+    const token = await requestTwitterOAuth2Token({ grant_type: "refresh_token" });
+    expect(token.access_token).toBe("acc_123");
+    expect(token.refresh_token).toBe("ref_456");
+  });
+
+  test("non-OK status with JSON error body throws with provider detail (failure surfaces)", async () => {
+    process.env.TWITTER_CLIENT_ID = "test-client-id";
+    stubFetch(
+      () =>
+        new Response(
+          JSON.stringify({ error: "invalid_grant", error_description: "refresh token revoked" }),
+          { status: 400 },
+        ),
+    );
+    await expect(requestTwitterOAuth2Token({ grant_type: "refresh_token" })).rejects.toThrow(
+      /invalid_grant: refresh token revoked/,
+    );
+  });
+
+  test("non-OK status with EMPTY body still throws (status-based, distinct from a token)", async () => {
+    process.env.TWITTER_CLIENT_ID = "test-client-id";
+    stubFetch(() => new Response("", { status: 503 }));
+    await expect(requestTwitterOAuth2Token({ grant_type: "refresh_token" })).rejects.toThrow(
+      /failed with status 503/,
+    );
+  });
+
+  test("OK status with empty body throws instead of fabricating an empty token", async () => {
+    process.env.TWITTER_CLIENT_ID = "test-client-id";
+    stubFetch(() => new Response("", { status: 200 }));
+    await expect(requestTwitterOAuth2Token({ grant_type: "refresh_token" })).rejects.toThrow(
+      /empty response body/,
+    );
+  });
+
+  test("OK status with malformed JSON throws instead of returning a partial token", async () => {
+    process.env.TWITTER_CLIENT_ID = "test-client-id";
+    stubFetch(() => new Response("{not json", { status: 200 }));
+    await expect(requestTwitterOAuth2Token({ grant_type: "refresh_token" })).rejects.toThrow(
+      /Failed to parse JSON/,
+    );
+  });
+
+  test("transport rejection propagates (network failure is not swallowed)", async () => {
+    process.env.TWITTER_CLIENT_ID = "test-client-id";
+    stubFetch(() => {
+      throw new Error("ECONNRESET");
+    });
+    await expect(requestTwitterOAuth2Token({ grant_type: "refresh_token" })).rejects.toThrow(
+      /ECONNRESET/,
+    );
+  });
+
+  test("missing client id throws before any fetch (fail closed on misconfiguration)", async () => {
+    delete process.env.TWITTER_CLIENT_ID;
+    let fetched = false;
+    stubFetch(() => {
+      fetched = true;
+      return new Response("{}", { status: 200 });
+    });
+    await expect(requestTwitterOAuth2Token({ grant_type: "refresh_token" })).rejects.toThrow(
+      /client ID is not configured/,
+    );
+    expect(fetched).toBe(false);
+  });
+
+  test("requireTwitterOAuth2ClientId throws when unconfigured", () => {
+    delete process.env.TWITTER_CLIENT_ID;
+    expect(() => requireTwitterOAuth2ClientId()).toThrow(/client ID is not configured/);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/whatsapp-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/whatsapp-automation/index.error-policy.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Error-policy pins for the WhatsApp automation connector (#13415). The file
+ * already fails closed everywhere — no catch fabricates success or delivery —
+ * so these tests lock that in: an internal transport/API failure must surface
+ * with its real error and stay DISTINGUISHABLE from a designed "invalid" /
+ * "not configured" verdict, and it must never read as a valid token or a
+ * delivered message. Drives the real exported `whatsappAutomationService`
+ * (validateAccessToken + sendMessage → the real whatsapp-api util) with only
+ * `global.fetch`, the cache client, and the secrets service mocked.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV = "test";
+
+const ORG_ID = "00000000-0000-4000-8000-00000000d001";
+
+// sendMessage reads org credentials through the secrets service; null models a
+// legitimately-unconfigured org (the designed-empty case, not a failure).
+let storedAccessToken: string | null = "org-access-token";
+let storedPhoneNumberId: string | null = "1234567890";
+
+mock.module("../secrets", () => ({
+  secretsService: {
+    get: async (_org: string, name: string) => {
+      if (name.includes("ACCESS_TOKEN")) return storedAccessToken;
+      if (name.includes("PHONE_NUMBER_ID")) return storedPhoneNumberId;
+      return null;
+    },
+  },
+}));
+
+// The status path touches the cache client on import; keep it inert and offline.
+mock.module("../../cache/client", () => ({
+  cache: {
+    get: async () => null,
+    set: async () => {},
+    del: async () => {},
+  },
+}));
+
+const { whatsappAutomationService } = await import("./index");
+
+const realFetch = globalThis.fetch;
+
+type FetchImpl = (url: string, init?: RequestInit) => Promise<Response>;
+let fetchImpl: FetchImpl;
+
+beforeEach(() => {
+  storedAccessToken = "org-access-token";
+  storedPhoneNumberId = "1234567890";
+  // Default: any unexpected network call is a hard failure, not a silent pass.
+  fetchImpl = async () => {
+    throw new Error("unexpected network call in test");
+  };
+  globalThis.fetch = ((url: string, init?: RequestInit) => fetchImpl(url, init)) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("validateAccessToken error policy (#13415)", () => {
+  test("internal transport failure surfaces a distinct network error, never valid:true", async () => {
+    fetchImpl = async () => {
+      throw new Error("ETIMEDOUT connecting to graph.facebook.com");
+    };
+
+    const result = await whatsappAutomationService.validateAccessToken("some-token", "1234567890");
+
+    expect(result.valid).toBe(false);
+    expect(result.phoneDisplay).toBeUndefined();
+    // The network-failure verdict is worded distinctly from a designed 401.
+    expect(result.error).toBe("Validation failed due to network error. Please try again.");
+  });
+
+  test("designed 401 'Invalid access token' stays distinct from a transport failure", async () => {
+    fetchImpl = async () => new Response("bad token", { status: 401 });
+
+    const result = await whatsappAutomationService.validateAccessToken("bad-token", "1234567890");
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Invalid access token");
+    // Distinguishable: the invalid-credential message is not the network message.
+    expect(result.error).not.toBe("Validation failed due to network error. Please try again.");
+  });
+
+  test("a working token is distinguishable: valid:true with phoneDisplay", async () => {
+    fetchImpl = async () =>
+      new Response(
+        JSON.stringify({
+          display_phone_number: "+1 415-555-0100",
+          verified_name: "Test Biz",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+
+    const result = await whatsappAutomationService.validateAccessToken("good-token", "1234567890");
+
+    expect(result.valid).toBe(true);
+    expect(result.phoneDisplay).toBe("+1 415-555-0100");
+    expect(result.error).toBeUndefined();
+  });
+});
+
+describe("sendMessage error policy (#13415)", () => {
+  test("outbound API failure surfaces success:false with the real error, never fabricated delivery", async () => {
+    let sendAttempted = false;
+    fetchImpl = async () => {
+      sendAttempted = true;
+      // A 500 from Meta makes the real whatsapp-api util throw.
+      return new Response("internal error", { status: 500 });
+    };
+
+    const result = await whatsappAutomationService.sendMessage(ORG_ID, "14155550100", "hi");
+
+    expect(sendAttempted).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.messageId).toBeUndefined();
+    // The real transport error text propagates (not a generic swallowed default).
+    expect(result.error).toContain("500");
+    // And it is NOT the designed not-configured message.
+    expect(result.error).not.toBe("WhatsApp not configured");
+  });
+
+  test("designed 'not configured' state stays distinct and attempts no send", async () => {
+    storedAccessToken = null;
+    storedPhoneNumberId = null;
+    let sendAttempted = false;
+    fetchImpl = async () => {
+      sendAttempted = true;
+      return new Response("{}", { status: 200 });
+    };
+
+    const result = await whatsappAutomationService.sendMessage(ORG_ID, "14155550100", "hi");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("WhatsApp not configured");
+    expect(result.messageId).toBeUndefined();
+    // A legitimately-unconfigured connector: no outbound call was made.
+    expect(sendAttempted).toBe(false);
+  });
+
+  test("successful send is distinguishable: success:true with the returned message id", async () => {
+    fetchImpl = async () =>
+      new Response(
+        JSON.stringify({
+          messaging_product: "whatsapp",
+          contacts: [{ input: "14155550100", wa_id: "14155550100" }],
+          messages: [{ id: "wamid.TEST123" }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+
+    const result = await whatsappAutomationService.sendMessage(ORG_ID, "14155550100", "hi");
+
+    expect(result.success).toBe(true);
+    expect(result.messageId).toBe("wamid.TEST123");
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/whatsapp-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/whatsapp-automation/index.ts
@@ -130,6 +130,9 @@ class WhatsAppAutomationService {
         phoneDisplay: data.display_phone_number,
       };
     } catch (error) {
+      // error-policy:J1 transport failure at the Meta Graph boundary translated to a distinct
+      // network-error validation result; never reports valid:true on a failed fetch, and the
+      // network message stays separable from the designed 401 "Invalid access token" verdict.
       const message = error instanceof Error ? error.message : "Unknown error";
       logger.warn("[WhatsAppAutomation] Token validation error", {
         error: message,
@@ -180,7 +183,7 @@ class WhatsAppAutomationService {
           audit,
         );
       } catch (err) {
-        // If secret already exists, find it and update it
+        // error-policy:J2 recover the idempotent already-exists collision (rotate); rethrow every other failure unchanged
         if (err instanceof Error && err.message.includes("already exists")) {
           logger.info("[WhatsAppAutomation] Secret exists, updating", { name });
           const existingSecrets = await secretsService.list(organizationId);
@@ -211,6 +214,7 @@ class WhatsAppAutomationService {
         await createOrUpdateSecret(name, value);
       }
     } catch (error) {
+      // error-policy:J6 best-effort rollback of partially-written secrets, then rethrow so the caller sees the failure
       logger.error("[WhatsAppAutomation] Failed to store credentials, rolling back", {
         organizationId,
         error: error instanceof Error ? error.message : String(error),
@@ -466,6 +470,8 @@ class WhatsAppAutomationService {
 
       return { success: true, messageId };
     } catch (error) {
+      // error-policy:J1 outbound send failure translated to the typed {success:false, error} Result
+      // the caller must check; carries the real API error and never fabricates a delivered message.
       const message = error instanceof Error ? error.message : "Unknown error";
       logger.error("[WhatsAppAutomation] Failed to send message", {
         organizationId,


### PR DESCRIPTION
## Slice 7 of #13415 — platform-automation connectors

twitter / telegram / discord / whatsapp automation, Google calendar/gmail connector, shared agent-turn REST runner.

**Real fail-open fixes** in `discord-automation/index.ts` (129 lines) + `shared-runtime/run-shared-agent-turn.ts`: swallowed Discord/platform API failures on send/fetch now propagate as typed failures. The other connectors were already fail-closed (a failed platform send → typed `Result{success:false,error}` callers branch on); this adds the missing grep-able `// error-policy:J1/J4/J6/J7` annotations + error-path tests.

**Money guard honored:** every `generate*`/`refundCredits` credit path left untouched and flagged.

**Verification** (`.github/issue-evidence/13415-automations.md`): 72 new error-path tests pass under `--isolate`; existing automation suites 107 pass / 0 fail; biome clean; `audit:error-policy-ratchet` → "no new fallback-slop". Connector-sensitive — flagged for review, not solo-merge.