### PR TITLE
fix(capacitor): seed iOS bridge env aliases

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.state-dir-alias.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.state-dir-alias.test.ts
@@ -1,16 +1,16 @@
 /**
  * Alias-aware ELIZA_STATE_DIR resolution for the iOS bridge (#13422). Drives the
- * real `resolveMobileStateDir` against a live MILADY-prefixed boot-config alias
- * table and the real `process.env` — no mocks — proving brand→eliza resolution,
- * canonical precedence, empty-is-unset, and no ELIZA_* mirror write.
+ * real `resolveMobileStateDir` against an iOS bridge boot state without a
+ * preloaded alias table and the real `process.env` — no mocks — proving
+ * brand→eliza resolution, canonical precedence, empty-is-unset, and no
+ * ELIZA_* mirror write.
  */
 
 import {
-	buildBrandEnvAliases,
 	getBootConfig,
-	readAliasedEnv,
 	setBootConfig,
-} from "@elizaos/shared";
+} from "@elizaos/shared/config/boot-config-store";
+import { readAliasedEnv } from "@elizaos/shared/utils/env";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveMobileStateDir } from "./bridge.ts";
 
@@ -34,7 +34,7 @@ describe("iOS bridge ELIZA_STATE_DIR alias resolution", () => {
 		savedBootConfig = getBootConfig();
 		setBootConfig({
 			...savedBootConfig,
-			envAliases: buildBrandEnvAliases("MILADY"),
+			envAliases: undefined,
 		});
 	});
 
@@ -48,8 +48,12 @@ describe("iOS bridge ELIZA_STATE_DIR alias resolution", () => {
 
 	it("resolves the MILADY brand prefix through the alias-aware reader", () => {
 		process.env.MILADY_STATE_DIR = "/data/milady/state";
-		expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/data/milady/state");
 		expect(resolveMobileStateDir()).toBe("/data/milady/state");
+		expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/data/milady/state");
+		expect(getBootConfig().envAliases).toContainEqual([
+			"MILADY_STATE_DIR",
+			"ELIZA_STATE_DIR",
+		]);
 	});
 
 	it("prefers the canonical ELIZA_STATE_DIR over the brand alias", () => {

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -25,6 +25,11 @@ import {
 	type UUID,
 } from "@elizaos/core";
 import {
+	getBootConfig,
+	setBootConfig,
+} from "@elizaos/shared/config/boot-config-store";
+import { buildBrandEnvAliases } from "@elizaos/shared/config/brand-env-aliases";
+import {
 	summarizeTranscript,
 	type Transcript,
 	type TranscriptScope,
@@ -168,6 +173,8 @@ type AgentModule = {
 	bootElizaRuntime: () => Promise<IAgentRuntime>;
 	dispatchRoute: DispatchRoute;
 };
+
+const IOS_BRIDGE_DEFAULT_ENV_PREFIX = "MILADY";
 
 async function loadAgentModule(): Promise<AgentModule> {
 	const [{ bootElizaRuntime }, { dispatchRoute }] = await Promise.all([
@@ -534,6 +541,7 @@ async function bootRuntimeWithRetry(
 async function startIosBridgeBackend(): Promise<IosBridgeBackend> {
 	installIosBackendCrashGuards();
 	const argvEnv = hydrateIosEnvFromArgv();
+	installIosBridgeEnvAliases();
 	// ── Mobile filesystem sandbox ────────────────────────────────────────────
 	// Install the fs shim as the very first action — before any runtime code
 	// runs — so that PGlite, trajectory logs, skill files, and all other agent
@@ -1945,12 +1953,22 @@ function callIosHost(
 }
 
 export function resolveMobileStateDir(): string {
+	installIosBridgeEnvAliases();
 	const explicit = readAliasedEnv("ELIZA_STATE_DIR") || process.env.ELIZA_HOME;
 	if (explicit?.trim()) return explicit.trim();
 	if (process.env.HOME?.trim()) {
 		return path.join(process.env.HOME.trim(), ".eliza");
 	}
 	return "/tmp/eliza";
+}
+
+function installIosBridgeEnvAliases(): void {
+	const config = getBootConfig();
+	if (config.envAliases?.length) return;
+	setBootConfig({
+		...config,
+		envAliases: buildBrandEnvAliases(IOS_BRIDGE_DEFAULT_ENV_PREFIX),
+	});
 }
 
 function localInferenceRootPath(): string {


### PR DESCRIPTION
## Summary

- seed the iOS bridge BootConfig alias table before the first mobile workspace/state-dir read
- keep canonical `ELIZA_STATE_DIR` precedence and avoid writing a mirrored `ELIZA_STATE_DIR` value back to `process.env`
- tighten the iOS alias regression test so it starts without a preloaded alias table, matching the native bridge boot path

Follow-up to #13936 after it merged with the iOS bridge still reading `ELIZA_STATE_DIR` before app boot installed aliases.

## Verification

- `bun test plugins/plugin-capacitor-bridge/src/ios/bridge.state-dir-alias.test.ts` (4 pass)
- `bunx @biomejs/biome check plugins/plugin-capacitor-bridge/src/ios/bridge.ts plugins/plugin-capacitor-bridge/src/ios/bridge.state-dir-alias.test.ts --no-errors-on-unmatched`
- `git diff --check origin/develop...HEAD && git diff --check`

## Evidence

- Native iOS device/simulator run: N/A - focused boot-env follow-up covered by the existing iOS bridge state-dir alias test; no packaged native build was run in this sweep.