### PR TITLE
fix(plugin-elizacloud): surface concrete model ids to the runtime model self-report

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/model-selfreport.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/model-selfreport.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Cloud-brained model self-report: drives the REAL registerTextInferenceModels
+ * into an AgentRuntime-shaped model registry, then runs core's REAL
+ * RUNTIME_MODEL_CONTEXT provider against it — the integration seam that decides
+ * whether "what model are you?" can name the concrete cloud model. Deterministic
+ * (no live model); process env for every model-tier key is isolated per test.
+ */
+
+import type { IAgentRuntime, Memory, ModelRegistrationMetadata } from "@elizaos/core";
+import {
+  DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
+  ModelType,
+  runtimeModelContextProvider,
+} from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { registerTextInferenceModels } from "../../src/index";
+import { DEFAULT_ELIZA_CLOUD_LARGE_MODEL } from "../../src/utils/config";
+
+// Every env key either the plugin's tier getters (resolveSetting → process.env)
+// or the provider's slot fallback (readSetting → readEnv) consults. Cleared per
+// test so a host-written model var can't mask the resolution under test.
+const MODEL_ENV_KEYS = (() => {
+  const suffixes = [
+    "NANO_MODEL",
+    "SMALL_MODEL",
+    "MEDIUM_MODEL",
+    "LARGE_MODEL",
+    "MEGA_MODEL",
+    "RESPONSE_HANDLER_MODEL",
+    "SHOULD_RESPOND_MODEL",
+    "ACTION_PLANNER_MODEL",
+    "PLANNER_MODEL",
+    "RESPONSE_MODEL",
+    "REASONING_SMALL_MODEL",
+    "REASONING_LARGE_MODEL",
+    "COMPLETION_MODEL",
+  ];
+  const keys: string[] = ["ELIZAOS_CLOUD_USE_INFERENCE"];
+  for (const prefix of ["", "OLLAMA_", "OPENAI_", "ANTHROPIC_", "ELIZAOS_CLOUD_"]) {
+    for (const suffix of suffixes) keys.push(`${prefix}${suffix}`);
+  }
+  return keys;
+})();
+
+let savedEnv: Record<string, string | undefined> = {};
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of MODEL_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+afterEach(() => {
+  for (const key of MODEL_ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+interface RegisteredModel {
+  handler: unknown;
+  metadata?: ModelRegistrationMetadata;
+  provider: string;
+  priority: number;
+  registrationOrder: number;
+}
+
+// Mirrors AgentRuntime's registerModel storage (push + priority-desc sort into
+// the `models` map) so the provider's registry reads exercise the same shape a
+// live cloud-brained agent exposes.
+function makeCloudBrainedRuntime(settings: Record<string, string>) {
+  const models = new Map<string, RegisteredModel[]>();
+  const runtime = {
+    getSetting: (key: string) => settings[key] ?? null,
+    models,
+    registerModel: (
+      modelType: string,
+      handler: unknown,
+      provider: string,
+      priority?: number,
+      metadata?: ModelRegistrationMetadata
+    ) => {
+      const list = models.get(modelType) ?? [];
+      list.push({
+        handler,
+        metadata,
+        provider,
+        priority: priority || 0,
+        registrationOrder: list.length,
+      });
+      list.sort((a, b) => (b.priority || 0) - (a.priority || 0));
+      models.set(modelType, list);
+    },
+  } as unknown as IAgentRuntime;
+  return runtime;
+}
+
+function selfModelQuestion(): Memory {
+  return { content: { text: "what model are you?", source: "test" } } as Memory;
+}
+
+describe("cloud-brained model self-report", () => {
+  it("reports the concrete default cloud model when no tier is configured", async () => {
+    // The default cloud deployment: an API key and nothing else — every tier
+    // resolves inside the plugin's getters to a code default the runtime's
+    // *_MODEL env fallbacks cannot see.
+    const runtime = makeCloudBrainedRuntime({
+      ELIZAOS_CLOUD_API_KEY: "eliza_test_key",
+    });
+    registerTextInferenceModels(runtime);
+
+    const result = await runtimeModelContextProvider.get(
+      runtime,
+      selfModelQuestion(),
+      {} as never
+    );
+
+    expect(result.text).toContain(`Response handler model: ${DEFAULT_ELIZA_CLOUD_TEXT_MODEL}`);
+    expect(result.text).toContain(`Large text model: ${DEFAULT_ELIZA_CLOUD_LARGE_MODEL}`);
+    expect(result.text).toContain("Response handler provider adapter: elizaOSCloud");
+    // The provider's omit-rather-than-leak contract still holds.
+    expect(result.text).not.toContain("RESPONSE_HANDLER");
+    expect(result.text).not.toContain("TEXT_LARGE");
+    expect(result.data?.responseHandlerModel).toBe(DEFAULT_ELIZA_CLOUD_TEXT_MODEL);
+    expect(result.data?.textLargeModel).toBe(DEFAULT_ELIZA_CLOUD_LARGE_MODEL);
+  });
+
+  it("reports ELIZAOS_CLOUD_* configured tiers the runtime env fallbacks cannot see", async () => {
+    const runtime = makeCloudBrainedRuntime({
+      ELIZAOS_CLOUD_API_KEY: "eliza_test_key",
+      ELIZAOS_CLOUD_SMALL_MODEL: "gpt-oss-120b",
+      ELIZAOS_CLOUD_LARGE_MODEL: "zai-glm-4.7",
+    });
+    registerTextInferenceModels(runtime);
+
+    const result = await runtimeModelContextProvider.get(
+      runtime,
+      selfModelQuestion(),
+      {} as never
+    );
+
+    // Response handler falls back to the small tier, planner to the large tier
+    // — the same chains the handlers resolve per call.
+    expect(result.text).toContain("Response handler model: gpt-oss-120b");
+    expect(result.text).toContain("Action planner model: zai-glm-4.7");
+    expect(result.text).toContain("Large text model: zai-glm-4.7");
+    expect(result.text).toContain("Small text model: gpt-oss-120b");
+  });
+
+  it("registers every chat-brain slot with its resolved concrete display model", () => {
+    const runtime = makeCloudBrainedRuntime({
+      ELIZAOS_CLOUD_API_KEY: "eliza_test_key",
+      ELIZAOS_CLOUD_LARGE_MODEL: "zai-glm-4.7",
+    });
+    registerTextInferenceModels(runtime);
+
+    const models = (runtime as unknown as { models: Map<string, RegisteredModel[]> }).models;
+    const displayFor = (slot: string) => models.get(slot)?.[0]?.metadata?.displayModel;
+
+    expect(displayFor(String(ModelType.TEXT_LARGE))).toBe("zai-glm-4.7");
+    expect(displayFor(String(ModelType.TEXT_MEGA ?? "TEXT_MEGA"))).toBe("zai-glm-4.7");
+    expect(displayFor(String(ModelType.ACTION_PLANNER ?? "ACTION_PLANNER"))).toBe("zai-glm-4.7");
+    for (const slot of [
+      String(ModelType.TEXT_NANO ?? "TEXT_NANO"),
+      String(ModelType.TEXT_SMALL),
+      String(ModelType.TEXT_MEDIUM ?? "TEXT_MEDIUM"),
+      String(ModelType.RESPONSE_HANDLER ?? "RESPONSE_HANDLER"),
+    ]) {
+      expect(displayFor(slot)).toBe(DEFAULT_ELIZA_CLOUD_TEXT_MODEL);
+    }
+  });
+});

--- a/plugins/plugin-elizacloud/src/index.ts
+++ b/plugins/plugin-elizacloud/src/index.ts
@@ -34,7 +34,16 @@ import { CloudContainerService } from "./services/cloud-container";
 import { CloudCredentialProvider } from "./services/cloud-credential-provider";
 import { CloudManagedGatewayRelayService } from "./services/cloud-managed-gateway-relay";
 import { CloudModelRegistryService } from "./services/cloud-model-registry";
-import { getSetting } from "./utils/config";
+import {
+  getActionPlannerModel,
+  getLargeModel,
+  getMediumModel,
+  getMegaModel,
+  getNanoModel,
+  getResponseHandlerModel,
+  getSetting,
+  getSmallModel,
+} from "./utils/config";
 import { createCloudApiClient } from "./utils/sdk-client";
 import { createWaifuMeteringHandler } from "./utils/waifu-metering";
 
@@ -88,6 +97,25 @@ const textInferenceModels: NonNullable<Plugin["models"]> = {
   [ACTION_PLANNER_MODEL_TYPE]: handleActionPlanner,
 };
 
+// Per-slot resolvers for the concrete model id each chat-brain handler will
+// call — the same getters `getModelNameForType` (models/text.ts) uses per
+// request. The cloud tier resolution (`ELIZAOS_CLOUD_*_MODEL` → bare `*_MODEL`
+// → code default) lives entirely in this plugin, so the runtime's model
+// self-report (RUNTIME_MODEL_CONTEXT) can only name the concrete model when
+// registration declares it as `metadata.displayModel`; without it a
+// cloud-brained agent asked "what model are you?" can name its provider
+// adapter but not its model. Resolved once at registration — a post-boot tier
+// setting change shows up on the next registration, not live.
+const textInferenceDisplayModels: Record<string, (runtime: IAgentRuntime) => string> = {
+  [TEXT_NANO_MODEL_TYPE]: getNanoModel,
+  [TEXT_MEDIUM_MODEL_TYPE]: getMediumModel,
+  [ModelType.TEXT_SMALL]: getSmallModel,
+  [ModelType.TEXT_LARGE]: getLargeModel,
+  [TEXT_MEGA_MODEL_TYPE]: getMegaModel,
+  [RESPONSE_HANDLER_MODEL_TYPE]: getResponseHandlerModel,
+  [ACTION_PLANNER_MODEL_TYPE]: getActionPlannerModel,
+};
+
 function isExplicitFalseFlag(value: string | undefined): boolean {
   return value?.trim().toLowerCase() === "false";
 }
@@ -105,7 +133,8 @@ export function registerTextInferenceModels(runtime: IAgentRuntime): void {
       modelType,
       handler as Parameters<IAgentRuntime["registerModel"]>[1],
       elizaOSCloudPlugin.name,
-      elizaOSCloudPlugin.priority
+      elizaOSCloudPlugin.priority,
+      { displayModel: textInferenceDisplayModels[modelType](runtime) }
     );
   }
 }


### PR DESCRIPTION
## Problem

A cloud-brained agent (plugin-elizacloud owns the chat-brain slots) cannot self-report its concrete model. Asked "what model are you?", the runtime's `RUNTIME_MODEL_CONTEXT` provider rendered only the adapter lines and omitted every model line — even when tiers were explicitly configured via `ELIZAOS_CLOUD_*_MODEL`.

Root cause: the provider resolves a slot via (1) `runtime.resolveProviderModelString` and (2) its env fallback, which both check only `OLLAMA_`/`OPENAI_`/`ANTHROPIC_`/bare `*_MODEL` keys, then (3) registration `metadata.displayModel`/`displayModelSetting`. The cloud tier resolution (`ELIZAOS_CLOUD_*_MODEL` → bare `*_MODEL` → code default, `plugins/plugin-elizacloud/src/utils/config.ts`) lives entirely in the plugin, and `registerTextInferenceModels` registered without metadata — so nothing on the self-report path could see the concrete model.

## Fix (structural, no core change)

Register each chat-brain slot with `metadata.displayModel` resolved through the same getters the handlers use per call (`getModelNameForType`, `src/models/text.ts`). This is the established provider-declared channel (`ModelRegistrationMetadata`, already consumed by the provider and used by plugin-codex-cli via `displayModelSetting`). Resolved once at registration; serializable and handler-free per the metadata contract.

+31/-2 in `plugins/plugin-elizacloud/src/index.ts`, plus a real integration test.

## Evidence (real, no mocks of the units under test)

Rendered provider block for a default cloud-brained agent (API key only, no tier config), captured from the REAL `registerTextInferenceModels` + REAL core `runtimeModelContextProvider`:

**Before (develop dc3a797223)** — no model lines at all:

```
# Runtime Model Context
Use these runtime facts when asked what model, provider, or coding agent is currently in use. ...
- Response handler provider adapter: elizaOSCloud
- Action planner provider adapter: elizaOSCloud
```

**After** — concrete model on every rendered slot:

```
# Runtime Model Context
Use these runtime facts when asked what model, provider, or coding agent is currently in use. ...
- Response handler model: gemma-4-31b
- Action planner model: gemma-4-31b
- Large text model: gemma-4-31b
- Small text model: gemma-4-31b
- Response handler provider adapter: elizaOSCloud
- Action planner provider adapter: elizaOSCloud
```

## Test

`__tests__/unit/model-selfreport.test.ts` drives the real registration into an AgentRuntime-shaped model registry and runs core's real provider against it (env-isolated per test):

- default deployment reports the concrete code-default model (fails on develop: 3/3 failed before the fix)
- `ELIZAOS_CLOUD_*` configured tiers are reported, including the response-handler→small and planner→large fallback chains
- every chat-brain slot registers with its resolved `displayModel`

## Verification (real counts)

- new test: 3 failed on develop → 3 passed with fix
- existing chat-brain gating suite (#10819): 4/4 passed
- full plugin suite: 310 passed, 3 skipped (36 files)
- core provider suite (`runtimeModelContext.test.ts`): 7/7 passed
- `bun run --cwd plugins/plugin-elizacloud typecheck`: clean
- `bun run --cwd plugins/plugin-elizacloud build`: node + browser bundles clean
- `bun run audit:error-policy-ratchet`: no new fallback-slop

N/A - screenshots/video: no UI surface; the deliverable is the prompt context block, shown above as rendered.
N/A - live-LLM trajectory: the change alters provider-rendered context only, deterministically asserted at the seam; no model-behavior change beyond the added context lines.

[core-brain]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
