### PR TITLE
fix(#13953): attach the load-older observer when the sentinel mounts late (empty->populated)

### DIFF
--- a/packages/ui/src/hooks/useLoadOlderOnScroll.test.tsx
+++ b/packages/ui/src/hooks/useLoadOlderOnScroll.test.tsx
@@ -92,6 +92,35 @@ function Harness(props: HarnessProps) {
   return null;
 }
 
+/**
+ * Harness modelling the REAL caller shape (#13953): the sentinel is rendered
+ * only in the transcript's non-empty branch, so on the initial open it is
+ * `null` and mounts LATER when the first page of messages lands. React writes
+ * DOM refs during commit BEFORE effects run, which this harness mirrors by
+ * assigning `sentinelRef.current` during render — by the time the hook's
+ * effect executes, the ref already reflects the (un)mounted sentinel of that
+ * commit.
+ */
+function LateSentinelHarness(props: {
+  scroller: HTMLDivElement;
+  sentinel: HTMLDivElement | null;
+  onLoadOlder: () => Promise<void>;
+  hasMore: boolean;
+  topItemKey: string | number;
+}) {
+  const scrollRef = useRef<HTMLDivElement | null>(props.scroller);
+  const sentinelRef = useRef<HTMLElement | null>(null);
+  sentinelRef.current = props.sentinel;
+  useLoadOlderOnScroll({
+    scrollRef,
+    sentinelRef,
+    onLoadOlder: props.onLoadOlder,
+    hasMore: props.hasMore,
+    topItemKey: props.topItemKey,
+  });
+  return null;
+}
+
 let originalIO: typeof IntersectionObserver | undefined;
 
 beforeEach(() => {
@@ -165,6 +194,106 @@ describe("useLoadOlderOnScroll — prefetch trigger (#13532)", () => {
       FakeIntersectionObserver.last?.fire(true);
     });
     expect(onLoadOlder).not.toHaveBeenCalled();
+  });
+});
+
+describe("useLoadOlderOnScroll — late-mounting sentinel (#13953)", () => {
+  it("attaches the observer once the sentinel mounts on the empty→populated transition", async () => {
+    const { el: scroller } = makeScroller(1000, 400);
+    const sentinel = document.createElement("div");
+    const onLoadOlder = vi.fn(async () => {});
+
+    // Initial open: transcript empty — sentinel not rendered, topItemKey "".
+    const { rerender } = render(
+      <LateSentinelHarness
+        scroller={scroller}
+        sentinel={null}
+        onLoadOlder={onLoadOlder}
+        hasMore
+        topItemKey=""
+      />,
+    );
+    // The effect bailed before constructing an observer — nothing subscribed.
+    expect(FakeIntersectionObserver.last).toBeNull();
+
+    // Messages land asynchronously: the sentinel mounts and the first item's
+    // key changes. enabled/hasMore/refs/trigger are all UNCHANGED — topItemKey
+    // is the only dep that moves, exactly the production transition. Without
+    // topItemKey in the effect deps the observer would never attach (the
+    // pre-fix bug) and this assertion fails.
+    act(() => {
+      rerender(
+        <LateSentinelHarness
+          scroller={scroller}
+          sentinel={sentinel}
+          onLoadOlder={onLoadOlder}
+          hasMore
+          topItemKey="m-oldest"
+        />,
+      );
+    });
+    const io = FakeIntersectionObserver.last;
+    expect(io).not.toBeNull();
+    expect(io?.observed).toContain(sentinel);
+
+    // And the attached observer is live: an intersection pages older history.
+    await act(async () => {
+      io?.fire(true);
+    });
+    expect(onLoadOlder).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-binds to the new sentinel across a conversation switch that transiently clears the thread", () => {
+    const { el: scroller } = makeScroller(1000, 400);
+    const sentinelA = document.createElement("div");
+    const sentinelB = document.createElement("div");
+    const onLoadOlder = vi.fn(async () => {});
+
+    const { rerender } = render(
+      <LateSentinelHarness
+        scroller={scroller}
+        sentinel={sentinelA}
+        onLoadOlder={onLoadOlder}
+        hasMore
+        topItemKey="a-oldest"
+      />,
+    );
+    const first = FakeIntersectionObserver.last;
+    expect(first?.observed).toContain(sentinelA);
+
+    // Switch conversations: messages transiently clear to [] and the old
+    // sentinel unmounts. The observer on the now-detached sentinel must be
+    // torn down, not left observing forever.
+    act(() => {
+      rerender(
+        <LateSentinelHarness
+          scroller={scroller}
+          sentinel={null}
+          onLoadOlder={onLoadOlder}
+          hasMore
+          topItemKey=""
+        />,
+      );
+    });
+    expect(first?.disconnected).toBe(true);
+
+    // The new conversation's page lands: a FRESH observer binds the NEW
+    // sentinel (not the stale detached one).
+    act(() => {
+      rerender(
+        <LateSentinelHarness
+          scroller={scroller}
+          sentinel={sentinelB}
+          onLoadOlder={onLoadOlder}
+          hasMore
+          topItemKey="b-oldest"
+        />,
+      );
+    });
+    const second = FakeIntersectionObserver.last;
+    expect(second).not.toBe(first);
+    expect(second?.observed).toContain(sentinelB);
+    expect(second?.observed).not.toContain(sentinelA);
   });
 });
 

--- a/packages/ui/src/hooks/useLoadOlderOnScroll.ts
+++ b/packages/ui/src/hooks/useLoadOlderOnScroll.ts
@@ -135,7 +135,24 @@ export function useLoadOlderOnScroll<T extends HTMLElement = HTMLDivElement>({
   // `hasMore` is an intentional dependency (not just read via ref): once it
   // flips false there is nothing older to observe, so we tear the observer down;
   // the false→true edge on a conversation switch re-subscribes.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: hasMore is an intentional re-subscribe trigger; the callback reads live gates via refs.
+  //
+  // `topItemKey` is ALSO an intentional dependency (#13953): callers render the
+  // sentinel only in the transcript's non-empty branch, so on the INITIAL open
+  // of a conversation the first effect run sees `sentinelRef.current === null`
+  // and bails without observing. Messages then land asynchronously and mount
+  // the sentinel — but mutating a ref never re-runs an effect, and none of the
+  // other deps are guaranteed to change on the empty→populated transition, so
+  // without this dep the observer would never attach and scroll-up load-older
+  // would be silently dead. `topItemKey` changes exactly when the first item
+  // changes (empty→populated, conversation switch, prepend), so it doubles as
+  // the "sentinel (re)mounted" signal: the effect re-runs, sees the mounted
+  // sentinel, and subscribes. It also tears down + re-binds across a
+  // conversation switch that transiently clears the thread to [] — the old
+  // (now detached) sentinel is dropped instead of being observed forever. A
+  // re-subscribe after an ordinary prepend is cheap (disconnect + observe) and
+  // an immediately-intersecting sentinel just continues paging, which the
+  // in-flight guard already serializes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: hasMore + topItemKey are intentional re-subscribe triggers; the callback reads live gates via refs.
   useEffect(() => {
     if (!enabled) return;
     const root = scrollRef.current;
@@ -161,10 +178,10 @@ export function useLoadOlderOnScroll<T extends HTMLElement = HTMLDivElement>({
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
-    // Re-subscribe when the scroller (re)mounts or hasMore flips — a disabled→
-    // enabled overlay mounts its scroller in the same commit, and once hasMore
-    // goes false there's no reason to keep observing.
-  }, [enabled, hasMore, scrollRef, sentinelRef, triggerLoadOlder]);
+    // Re-subscribe when the scroller (re)mounts, hasMore flips, or the first
+    // item changes (topItemKey) — the latter is what attaches the observer once
+    // the sentinel mounts on the empty→populated transition (#13953).
+  }, [enabled, hasMore, topItemKey, scrollRef, sentinelRef, triggerLoadOlder]);
 
   // Preserve viewport on prepend: after the older page grew the scroller
   // upward, add the height delta back to scrollTop so the previously-top


### PR DESCRIPTION
Closes #13953

## Problem
`useLoadOlderOnScroll`'s top-sentinel `IntersectionObserver` subscribed only inside an effect with deps `[enabled, hasMore, scrollRef, sentinelRef, triggerLoadOlder]`. On the **initial open** of a conversation with history the transcript is empty and the sentinel is rendered only in the non-empty branch, so the first effect run sees `sentinelRef.current === null` and bails. Messages then land asynchronously and mount the sentinel, but **no dep moves** (refs are stable objects, `enabled` is constant for a normal chat, `hasMore`/`triggerLoadOlder` need not change on the empty->populated transition), so the effect never re-runs, the observer never attaches, and scroll-up load-older is silently dead. A conversation switch that transiently clears messages to `[]` could also leave the observer bound to a stale detached sentinel.

## Fix
Add `topItemKey` to the observer effect deps (the issue's suggested option A). `topItemKey` changes exactly when the first (oldest) item changes — empty->populated, conversation switch, prepend — so it doubles as the "sentinel (re)mounted" signal: the effect re-runs, sees the mounted sentinel, and subscribes; across a switch it tears down the observer on the detached sentinel and binds the new one. A re-subscribe after an ordinary prepend is a cheap disconnect+observe, and an immediately-intersecting sentinel just continues paging, which the existing in-flight guard already serializes. No caller changes needed (`ChatView` already passes `topItemKey: visibleMsgs[0]?.id ?? ""`).

## Tests
Two new regression tests in `useLoadOlderOnScroll.test.tsx` drive the exact production sequences the existing suite missed (its harness always passed a sentinel present from mount + fixed `topItemKey`, per the issue's evidence note):
1. **empty->populated late-mounting sentinel**: initial render with `sentinel=null`/`topItemKey=""` constructs no observer; re-render with the mounted sentinel + first-item key attaches the observer, and an intersection fires `onLoadOlder`.
2. **conversation switch through a transiently-empty thread**: the observer on the old (detached) sentinel is disconnected and a fresh observer binds the NEW sentinel only.

- Both new tests **FAIL on the pre-fix hook** (verified by reverting the source change: 2 failed / 7 passed) and pass with the fix.
- Full hook suite green: `useLoadOlderOnScroll.test.tsx` 9/9 + `useLoadOlderOnScroll.cap-yank.test.tsx` (real reducer integration) 1/1 = 10/10.
- biome clean on both files; `tsgo --noEmit` has zero errors in touched files (the only failure is the pre-existing baseline error in `src/state/startup-phase-poll.test.ts`, byte-identical to develop, untouched).

## Collision receipts
No open/closed PR referenced #13953 at claim or at push (`gh pr list --search 13953` empty both times); no merged dup on develop touching `useLoadOlderOnScroll.ts` (`git log HEAD..origin/develop` clean); rebased onto latest develop before push.

-- [sol-orch]