### PR TITLE
feat(ios-device-lane): mint development profiles for app + appexes via App Store Connect API (#13567)

### DIFF
--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -103,8 +103,8 @@ bun run --cwd packages/app test:e2e:ios              # Boot sim, build, auth smo
 bun run --cwd packages/app test:e2e:ios:cloud        # iOS e2e plus cloud provisioning probe
 bun run --cwd packages/app test:sim:local-chat        # iOS simulator local-chat smoke; requires installed app
 bun run --cwd packages/app test:sim:local-chat:android # Android emulator local-chat smoke; requires installed app
-bun run --cwd packages/app test:sim:auth:ios
-bun run --cwd packages/app test:sim:auth:android
+bun run --cwd packages/app test:sim:auth:ios         # auth/callback deep-link DELIVERY + in-app handler classification (not login)
+bun run --cwd packages/app test:sim:auth:android     # same; requires an Android emulator + installed app
 
 # Mobile release preflight
 bun run --cwd packages/app preflight:ios:sideload
@@ -193,6 +193,29 @@ The iOS app ships three runtime modes; their unattended (CI) coverage is:
 Keep this table honest: an N/A row must name what is missing, not hide it.
 
 The XCUITest cloud-onboarding path (`testCloudOnboardingChatAndVoice`) still XCTSkips at the OAuth wall without a device Cloud session; the `ios-cloud-mode` lane covers the cloud *runtime* mode programmatically (the same path `ios-e2e.mjs --cloud` calls) rather than driving the simulator UI through OAuth. A device-UI cloud-onboarding lane needs the WebView-side session seed (`steward_session_token` / `POST /api/cloud/login/persist`) and is tracked in #13578 done-when #2.
+
+### What `test:sim:auth` proves (and does not) (#13693)
+
+`test:sim:auth[:ios|:android]` (`packages/app-core/scripts/mobile-auth-simulator-smoke.mjs`)
+is a **callback-delivery + in-app-handler smoke, not a login smoke.** It fires a
+synthetic `<scheme>://auth/callback?state=…&code=…` deep link that no token
+endpoint would accept, then reads back — through the Capacitor-Preferences
+handshake the onboarding smoke pioneered — what the renderer's `auth/callback`
+handler wrote (`recordIosAuthCallbackSmoke` in `src/main.tsx`, armed by the
+smoke's `eliza:auth-callback-smoke:request`/`:result` keys). The shared
+`assertAuthCallbackResult` contract then asserts the security end state: the
+OS-delivered callback is explicitly rejected (`accepted:false`), classified
+(`classification:"synthetic_callback_rejected"`), and **left the active session
+untouched** (`sessionChanged:false`) — a deep link must never authenticate or
+swap the app session. A handler that merely echoed the URL back, dropped it, or
+authenticated off it now fails the lane instead of passing on delivery alone.
+
+It does **not** exercise a genuine OAuth exchange or a logged-in end state; that
+`--real` mode is blocked on the headless staging-Cloud session seed tracked in
+#13578 / #13693 done-when #2. The pure end-state contract is verifiable without a
+device via `node --test packages/app-core/scripts/mobile-auth-simulator-smoke-endstate.test.mjs`
+(which additionally round-trips the assertion through a booted simulator's real
+`xcrun simctl defaults` store when one is available).
 
 ## Config / env vars
 

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -124,6 +124,15 @@ device-boot recipe in `.github/issue-evidence/11030-ios-boot-fix/device-boot-REA
 Device id comes from `--device <devicectl-id|udid|name>` or `ELIZA_IOS_DEVICE_ID`.
 
 ```bash
+# Mint/refresh DEVELOPMENT provisioning profiles for the app + every appex via
+# the App Store Connect API (no Xcode UI, no interactive account session), so the
+# deploy profile scan below finds one profile per bundle id. Needs the ASC key
+# triplet apple-store-release.yml already uses (APP_STORE_API_KEY_ID /
+# APP_STORE_API_ISSUER_ID / APP_STORE_API_KEY_P8, or ..._KEY_PATH for the .p8
+# file). Idempotent; --check-only validates config + key offline (no Apple call);
+# --product <App.app> discovers appexes from the built product's PlugIns/.
+bun run --cwd packages/app ios:device:provision -- --device <udid>   # flags: --check-only --product <App.app> --device-name <name>
+
 # Build (unsigned, run-mobile-build ios-local lane) → auto-discover a matching
 # provisioning profile (~/Library/MobileDevice/'Provisioning Profiles' + prior
 # signed builds in DerivedData; must cover the bundle id + device UDID and be
@@ -160,7 +169,11 @@ target/scheme in the template Xcode project) and is
 materialized into the gitignored `packages/app/ios` by cap sync. Pure decision
 logic (profile matching/selection, entitlement derivation, plist/xctestrun
 handling) is in `scripts/ios-device-lib.mjs`, unit-tested by
-`scripts/ios-device-lib.test.mjs` in the package vitest suite. Boot-trace pull
+`scripts/ios-device-lib.test.mjs` in the package vitest suite; the App Store
+Connect profile-minting logic (JWT claims/signing, request/response shapes,
+bundle-id/appex enumeration, credential + arg parsing) is in
+`scripts/ios-asc-lib.mjs`, unit-tested by `scripts/ios-asc-lib.test.mjs`.
+Boot-trace pull
 path defaults to `Documents/eliza-boot-trace.jsonl` (+ best-effort rotated
 `eliza-boot-trace.prev.jsonl` sibling; the renderer appends into the same
 primary file via the Agent plugin's `appendBootTrace` bridge, so there is no

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -103,8 +103,8 @@ bun run --cwd packages/app test:e2e:ios              # Boot sim, build, auth smo
 bun run --cwd packages/app test:e2e:ios:cloud        # iOS e2e plus cloud provisioning probe
 bun run --cwd packages/app test:sim:local-chat        # iOS simulator local-chat smoke; requires installed app
 bun run --cwd packages/app test:sim:local-chat:android # Android emulator local-chat smoke; requires installed app
-bun run --cwd packages/app test:sim:auth:ios
-bun run --cwd packages/app test:sim:auth:android
+bun run --cwd packages/app test:sim:auth:ios         # auth/callback deep-link DELIVERY + in-app handler classification (not login)
+bun run --cwd packages/app test:sim:auth:android     # same; requires an Android emulator + installed app
 
 # Mobile release preflight
 bun run --cwd packages/app preflight:ios:sideload
@@ -193,6 +193,29 @@ The iOS app ships three runtime modes; their unattended (CI) coverage is:
 Keep this table honest: an N/A row must name what is missing, not hide it.
 
 The XCUITest cloud-onboarding path (`testCloudOnboardingChatAndVoice`) still XCTSkips at the OAuth wall without a device Cloud session; the `ios-cloud-mode` lane covers the cloud *runtime* mode programmatically (the same path `ios-e2e.mjs --cloud` calls) rather than driving the simulator UI through OAuth. A device-UI cloud-onboarding lane needs the WebView-side session seed (`steward_session_token` / `POST /api/cloud/login/persist`) and is tracked in #13578 done-when #2.
+
+### What `test:sim:auth` proves (and does not) (#13693)
+
+`test:sim:auth[:ios|:android]` (`packages/app-core/scripts/mobile-auth-simulator-smoke.mjs`)
+is a **callback-delivery + in-app-handler smoke, not a login smoke.** It fires a
+synthetic `<scheme>://auth/callback?state=…&code=…` deep link that no token
+endpoint would accept, then reads back — through the Capacitor-Preferences
+handshake the onboarding smoke pioneered — what the renderer's `auth/callback`
+handler wrote (`recordIosAuthCallbackSmoke` in `src/main.tsx`, armed by the
+smoke's `eliza:auth-callback-smoke:request`/`:result` keys). The shared
+`assertAuthCallbackResult` contract then asserts the security end state: the
+OS-delivered callback is explicitly rejected (`accepted:false`), classified
+(`classification:"synthetic_callback_rejected"`), and **left the active session
+untouched** (`sessionChanged:false`) — a deep link must never authenticate or
+swap the app session. A handler that merely echoed the URL back, dropped it, or
+authenticated off it now fails the lane instead of passing on delivery alone.
+
+It does **not** exercise a genuine OAuth exchange or a logged-in end state; that
+`--real` mode is blocked on the headless staging-Cloud session seed tracked in
+#13578 / #13693 done-when #2. The pure end-state contract is verifiable without a
+device via `node --test packages/app-core/scripts/mobile-auth-simulator-smoke-endstate.test.mjs`
+(which additionally round-trips the assertion through a booted simulator's real
+`xcrun simctl defaults` store when one is available).
 
 ## Config / env vars
 

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -124,6 +124,15 @@ device-boot recipe in `.github/issue-evidence/11030-ios-boot-fix/device-boot-REA
 Device id comes from `--device <devicectl-id|udid|name>` or `ELIZA_IOS_DEVICE_ID`.
 
 ```bash
+# Mint/refresh DEVELOPMENT provisioning profiles for the app + every appex via
+# the App Store Connect API (no Xcode UI, no interactive account session), so the
+# deploy profile scan below finds one profile per bundle id. Needs the ASC key
+# triplet apple-store-release.yml already uses (APP_STORE_API_KEY_ID /
+# APP_STORE_API_ISSUER_ID / APP_STORE_API_KEY_P8, or ..._KEY_PATH for the .p8
+# file). Idempotent; --check-only validates config + key offline (no Apple call);
+# --product <App.app> discovers appexes from the built product's PlugIns/.
+bun run --cwd packages/app ios:device:provision -- --device <udid>   # flags: --check-only --product <App.app> --device-name <name>
+
 # Build (unsigned, run-mobile-build ios-local lane) → auto-discover a matching
 # provisioning profile (~/Library/MobileDevice/'Provisioning Profiles' + prior
 # signed builds in DerivedData; must cover the bundle id + device UDID and be
@@ -160,7 +169,11 @@ target/scheme in the template Xcode project) and is
 materialized into the gitignored `packages/app/ios` by cap sync. Pure decision
 logic (profile matching/selection, entitlement derivation, plist/xctestrun
 handling) is in `scripts/ios-device-lib.mjs`, unit-tested by
-`scripts/ios-device-lib.test.mjs` in the package vitest suite. Boot-trace pull
+`scripts/ios-device-lib.test.mjs` in the package vitest suite; the App Store
+Connect profile-minting logic (JWT claims/signing, request/response shapes,
+bundle-id/appex enumeration, credential + arg parsing) is in
+`scripts/ios-asc-lib.mjs`, unit-tested by `scripts/ios-asc-lib.test.mjs`.
+Boot-trace pull
 path defaults to `Documents/eliza-boot-trace.jsonl` (+ best-effort rotated
 `eliza-boot-trace.prev.jsonl` sibling; the renderer appends into the same
 primary file via the Agent plugin's `appendBootTrace` bridge, so there is no

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -35,6 +35,7 @@
     "test:remote-capabilities:ui": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/remote-capability-view.spec.ts",
     "test:e2e:cloud-wallet": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/cloud-wallet-import.spec.ts",
     "test:e2e:android": "node scripts/android-e2e.mjs",
+    "test:android:assistant-ime": "node scripts/android-assistant-ime-lane.mjs",
     "test:e2e:ios": "node scripts/ios-e2e.mjs",
     "test:e2e:ios:cloud": "node scripts/ios-e2e.mjs --cloud",
     "test:e2e:android:local": "node scripts/android-e2e.mjs --skip-route-coverage",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -85,6 +85,7 @@
     "preflight:ios:store": "node scripts/mobile-release-preflight.mjs --platform=ios --store",
     "install:ios:sideload": "node scripts/ios-sideload-helper.mjs",
     "install:ios:cloud:sideload": "node scripts/ios-sideload-helper.mjs --cloud --build-device",
+    "ios:device:provision": "node scripts/ios-mint-profiles.mjs",
     "ios:device:deploy": "node scripts/ios-device-deploy.mjs",
     "ios:device:logs": "node scripts/ios-device-logs.mjs",
     "ios:device:capture": "node scripts/ios-device-capture.mjs --platform device",

--- a/packages/app/scripts/ios-asc-lib.mjs
+++ b/packages/app/scripts/ios-asc-lib.mjs
@@ -209,7 +209,10 @@ export function buildCreateBundleIdRequest(bundleId) {
 
 /** ASC bundleId names may not contain dots; map "a.b.c" → "a b c". */
 export function bundleIdToName(bundleId) {
-  return bundleId.replaceAll(/[^A-Za-z0-9 ]/g, " ").replace(/\s+/g, " ").trim();
+  return bundleId
+    .replaceAll(/[^A-Za-z0-9 ]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 /** GET the devices list filtered by UDID. */
@@ -275,7 +278,9 @@ export function buildCreateProfileRequest({
   deviceIds,
 }) {
   if (!bundleIdResourceId) {
-    throw new Error("buildCreateProfileRequest: bundleIdResourceId is required");
+    throw new Error(
+      "buildCreateProfileRequest: bundleIdResourceId is required",
+    );
   }
   if (!Array.isArray(certificateIds) || certificateIds.length === 0) {
     throw new Error(
@@ -283,7 +288,9 @@ export function buildCreateProfileRequest({
     );
   }
   if (!Array.isArray(deviceIds) || deviceIds.length === 0) {
-    throw new Error("buildCreateProfileRequest: at least one deviceId is required");
+    throw new Error(
+      "buildCreateProfileRequest: at least one deviceId is required",
+    );
   }
   return {
     method: "POST",
@@ -343,6 +350,25 @@ export function firstResource(responseJson) {
     throw new Error("firstResource: response `data` is not an array");
   }
   return data.length > 0 ? data[0] : null;
+}
+
+/**
+ * Extract required JSON:API resource ids from a list response. Empty is valid;
+ * malformed is not, because callers use the returned list to decide whether a
+ * real account has no usable resources.
+ */
+export function resourceIdsFromListResponse(responseJson, label) {
+  if (!responseJson || typeof responseJson !== "object") {
+    throw new Error(`${label}: response is not an object`);
+  }
+  const data = responseJson.data;
+  if (data === undefined) {
+    throw new Error(`${label}: response has no \`data\` field`);
+  }
+  if (!Array.isArray(data)) {
+    throw new Error(`${label}: response \`data\` is not an array`);
+  }
+  return data.map((resource) => resource?.id).filter(Boolean);
 }
 
 /**
@@ -475,7 +501,8 @@ export function parseMintArgs(argv, env = {}) {
 }
 
 function splitFlag(token) {
-  if (typeof token !== "string" || !token.startsWith("--")) return [token, null];
+  if (typeof token !== "string" || !token.startsWith("--"))
+    return [token, null];
   const eq = token.indexOf("=");
   if (eq === -1) return [token, null];
   return [token.slice(0, eq), token.slice(eq + 1)];

--- a/packages/app/scripts/ios-asc-lib.mjs
+++ b/packages/app/scripts/ios-asc-lib.mjs
@@ -1,0 +1,495 @@
+/**
+ * Pure decision logic for the App Store Connect (ASC) API device-lane profile
+ * minting script (ios-mint-profiles.mjs). Everything here is deterministic and
+ * side-effect free except `signAscJwt`, which reads a private key it is handed
+ * (the key material never leaves the caller) — so the whole surface is unit
+ * testable in the packages/app vitest suite (see ios-asc-lib.test.mjs) with no
+ * Apple account, no `fetch`, and only node built-ins.
+ *
+ * The script owns the impure edges: reading the .p8 file, calling `fetch`
+ * against api.appstoreconnect.apple.com, and writing the downloaded
+ * .mobileprovision blobs into ~/Library/MobileDevice/Provisioning Profiles/,
+ * where ios-device-deploy's discoverProfiles() already scans for them.
+ *
+ * ASC API reference (as of 2024): profiles / bundleIds / devices are all under
+ * https://api.appstoreconnect.apple.com/v1. Auth is a short-lived ES256 JWT
+ * signed with the .p8 private key, keyed by the key id, issued by the issuer id
+ * (https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests).
+ */
+import crypto from "node:crypto";
+
+/** ASC API base — v1 is the only version these endpoints live under. */
+export const ASC_API_BASE = "https://api.appstoreconnect.apple.com/v1";
+
+/** JWT audience Apple requires for every ASC token. */
+export const ASC_JWT_AUDIENCE = "appstoreconnect-v1";
+
+/**
+ * Apple caps ASC token lifetime at 20 minutes; tokens minted for longer are
+ * rejected 401. We default to a conservative window well under the cap.
+ */
+export const ASC_JWT_MAX_LIFETIME_SECONDS = 20 * 60;
+export const ASC_JWT_DEFAULT_LIFETIME_SECONDS = 15 * 60;
+
+/** The main app bundle id and every app-extension the device lane must cover. */
+export const APP_BUNDLE_ID = "ai.elizaos.app";
+
+/**
+ * The five app-extension suffixes appended to APP_BUNDLE_ID. Kept in sync with
+ * the PRODUCT_BUNDLE_IDENTIFIER values in the canonical iOS Xcode template
+ * (packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj) — a new
+ * appex there must be added here (or discovered from the built product, see
+ * appexBundleIdsFromProduct).
+ */
+export const APPEX_SUFFIXES = Object.freeze([
+  "ElizaKeyboard",
+  "ElizaWidgets",
+  "DeviceActivityMonitorExtension",
+  "DeviceActivityReportExtension",
+  "WebsiteBlockerContentExtension",
+]);
+
+// ── base64url ───────────────────────────────────────────────────────────
+
+/** RFC 7515 base64url: base64 with +/→-_ and no `=` padding. */
+export function base64url(input) {
+  const buf = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  return buf
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+// ── JWT claim construction + signing ────────────────────────────────────
+
+/**
+ * Build the ASC JWT header + payload objects (no signature). Split out from
+ * signing so the claim shape is unit-testable without a private key.
+ *
+ * @param {object} params
+ * @param {string} params.keyId       ASC API key id (the `kid` header)
+ * @param {string} params.issuerId    ASC API issuer id (the `iss` claim)
+ * @param {number} [params.issuedAt]  epoch seconds; defaults to now
+ * @param {number} [params.lifetimeSeconds] token lifetime; clamped to the
+ *   20-minute Apple cap
+ * @returns {{ header: object, payload: object }}
+ */
+export function buildAscJwtClaims({
+  keyId,
+  issuerId,
+  issuedAt = Math.floor(Date.now() / 1000),
+  lifetimeSeconds = ASC_JWT_DEFAULT_LIFETIME_SECONDS,
+}) {
+  if (!keyId || typeof keyId !== "string") {
+    throw new Error("buildAscJwtClaims: keyId is required");
+  }
+  if (!issuerId || typeof issuerId !== "string") {
+    throw new Error("buildAscJwtClaims: issuerId is required");
+  }
+  if (!Number.isInteger(issuedAt)) {
+    throw new Error("buildAscJwtClaims: issuedAt must be an integer");
+  }
+  const lifetime = Math.min(
+    Math.max(1, Math.floor(lifetimeSeconds)),
+    ASC_JWT_MAX_LIFETIME_SECONDS,
+  );
+  return {
+    header: { alg: "ES256", kid: keyId, typ: "JWT" },
+    payload: {
+      iss: issuerId,
+      iat: issuedAt,
+      exp: issuedAt + lifetime,
+      aud: ASC_JWT_AUDIENCE,
+    },
+  };
+}
+
+/**
+ * Sign the ASC JWT with the .p8 EC P-256 private key. ES256 over JOSE requires
+ * the signature in IEEE P1363 (raw r‖s, 64 bytes) form — node's default EC
+ * signature is ASN.1/DER, so we must pass `dsaEncoding: "ieee-p1363"` or Apple
+ * rejects the token.
+ *
+ * @param {{ header: object, payload: object }} claims
+ * @param {string|Buffer|crypto.KeyObject} privateKeyPem the .p8 contents (PEM)
+ * @returns {string} the compact-serialized JWT
+ */
+export function signAscJwt(claims, privateKeyPem) {
+  const signingInput = `${base64url(JSON.stringify(claims.header))}.${base64url(
+    JSON.stringify(claims.payload),
+  )}`;
+  const signature = crypto.sign("sha256", Buffer.from(signingInput), {
+    key: privateKeyPem,
+    dsaEncoding: "ieee-p1363",
+  });
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+// ── bundle-id ↔ appex mapping ───────────────────────────────────────────
+
+/**
+ * The full ordered list of bundle ids the device lane provisions: the main app
+ * first, then one per appex suffix. Deterministic so the printed per-bundle-id
+ * table and the mint order are stable.
+ *
+ * @param {{ appBundleId?: string, appexSuffixes?: readonly string[] }} [opts]
+ * @returns {Array<{ bundleId: string, kind: "app"|"appex", name: string }>}
+ */
+export function enumerateBundleIds({
+  appBundleId = APP_BUNDLE_ID,
+  appexSuffixes = APPEX_SUFFIXES,
+} = {}) {
+  const entries = [{ bundleId: appBundleId, kind: "app", name: "App" }];
+  for (const suffix of appexSuffixes) {
+    entries.push({
+      bundleId: `${appBundleId}.${suffix}`,
+      kind: "appex",
+      name: suffix,
+    });
+  }
+  return entries;
+}
+
+/**
+ * Derive appex bundle ids from a built .app product by listing PlugIns/*.appex.
+ * Preferred over the static APPEX_SUFFIXES list when a real product is present,
+ * so a newly-added extension is provisioned without editing this file. Returns
+ * suffixes only (basename minus ".appex"); the caller prefixes the app id.
+ *
+ * @param {string[]} plugInEntries  readdir of `<App.app>/PlugIns`
+ * @returns {string[]} sorted appex suffixes
+ */
+export function appexSuffixesFromPlugIns(plugInEntries) {
+  const suffixes = [];
+  for (const entry of plugInEntries) {
+    if (typeof entry === "string" && entry.endsWith(".appex")) {
+      suffixes.push(entry.slice(0, -".appex".length));
+    }
+  }
+  return suffixes.sort();
+}
+
+// ── ASC API request construction ────────────────────────────────────────
+//
+// Endpoint/payload builders return plain { method, path, body? } descriptors so
+// the exact wire shape is asserted in tests; the script turns them into fetch
+// calls against ASC_API_BASE with the Bearer JWT + application/json headers.
+
+/** GET the bundleId resource whose `identifier` == bundleId (filter query). */
+export function buildFindBundleIdRequest(bundleId) {
+  const params = new URLSearchParams({
+    "filter[identifier]": bundleId,
+    limit: "200",
+  });
+  return { method: "GET", path: `/bundleIds?${params.toString()}` };
+}
+
+/**
+ * POST a new bundleId. `platform` is IOS for iOS app + extension ids; `name`
+ * must be alphanumeric/space only (Apple rejects dots), so we derive it from
+ * the identifier with dots→spaces.
+ */
+export function buildCreateBundleIdRequest(bundleId) {
+  return {
+    method: "POST",
+    path: "/bundleIds",
+    body: {
+      data: {
+        type: "bundleIds",
+        attributes: {
+          identifier: bundleId,
+          name: bundleIdToName(bundleId),
+          platform: "IOS",
+        },
+      },
+    },
+  };
+}
+
+/** ASC bundleId names may not contain dots; map "a.b.c" → "a b c". */
+export function bundleIdToName(bundleId) {
+  return bundleId.replaceAll(/[^A-Za-z0-9 ]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+/** GET the devices list filtered by UDID. */
+export function buildFindDeviceRequest(udid) {
+  const params = new URLSearchParams({ "filter[udid]": udid, limit: "200" });
+  return { method: "GET", path: `/devices?${params.toString()}` };
+}
+
+/**
+ * POST-register a device UDID. Apple requires a non-empty name; we default to a
+ * lane-recognizable one. platform IOS covers iPhone/iPad development devices.
+ */
+export function buildRegisterDeviceRequest(udid, { name } = {}) {
+  return {
+    method: "POST",
+    path: "/devices",
+    body: {
+      data: {
+        type: "devices",
+        attributes: {
+          name: name || `device-lane ${udid}`,
+          platform: "IOS",
+          udid,
+        },
+      },
+    },
+  };
+}
+
+/** GET development profiles by exact name (we name profiles deterministically). */
+export function buildFindProfileRequest(profileName) {
+  const params = new URLSearchParams({
+    "filter[name]": profileName,
+    limit: "200",
+  });
+  return { method: "GET", path: `/profiles?${params.toString()}` };
+}
+
+/**
+ * The deterministic profile name for a bundle id. Stable naming lets the script
+ * find-and-delete a stale profile before re-minting (dev profiles are pinned to
+ * a device set at creation time, so refreshing a device list means recreate).
+ */
+export function profileNameForBundleId(bundleId) {
+  return `eliza-device-lane ${bundleId}`;
+}
+
+/**
+ * POST a development profile linking a bundleId to the given certificate + device
+ * relationships. profileType IOS_APP_DEVELOPMENT is the development
+ * (not distribution) profile the on-device test loop needs.
+ *
+ * @param {object} params
+ * @param {string} params.bundleId        for the deterministic profile name
+ * @param {string} params.bundleIdResourceId  ASC id of the bundleId resource
+ * @param {string[]} params.certificateIds  ASC ids of dev certificates
+ * @param {string[]} params.deviceIds       ASC ids of registered devices
+ */
+export function buildCreateProfileRequest({
+  bundleId,
+  bundleIdResourceId,
+  certificateIds,
+  deviceIds,
+}) {
+  if (!bundleIdResourceId) {
+    throw new Error("buildCreateProfileRequest: bundleIdResourceId is required");
+  }
+  if (!Array.isArray(certificateIds) || certificateIds.length === 0) {
+    throw new Error(
+      "buildCreateProfileRequest: at least one certificateId is required",
+    );
+  }
+  if (!Array.isArray(deviceIds) || deviceIds.length === 0) {
+    throw new Error("buildCreateProfileRequest: at least one deviceId is required");
+  }
+  return {
+    method: "POST",
+    path: "/profiles",
+    body: {
+      data: {
+        type: "profiles",
+        attributes: {
+          name: profileNameForBundleId(bundleId),
+          profileType: "IOS_APP_DEVELOPMENT",
+        },
+        relationships: {
+          bundleId: { data: { type: "bundleIds", id: bundleIdResourceId } },
+          certificates: {
+            data: certificateIds.map((id) => ({ type: "certificates", id })),
+          },
+          devices: {
+            data: deviceIds.map((id) => ({ type: "devices", id })),
+          },
+        },
+      },
+    },
+  };
+}
+
+/** DELETE a profile by ASC id (used to refresh a stale device-locked profile). */
+export function buildDeleteProfileRequest(profileResourceId) {
+  return { method: "DELETE", path: `/profiles/${profileResourceId}` };
+}
+
+/** GET development certificates (DEVELOPMENT type) to link into new profiles. */
+export function buildListCertificatesRequest() {
+  const params = new URLSearchParams({
+    "filter[certificateType]": "DEVELOPMENT",
+    limit: "200",
+  });
+  return { method: "GET", path: `/certificates?${params.toString()}` };
+}
+
+// ── ASC API response parsing ────────────────────────────────────────────
+
+/**
+ * The single JSON:API resource in a list response, or null when the list is
+ * empty. ASC list endpoints return { data: [...] }; a filtered find returns 0
+ * or 1 rows. Throws on a malformed shape rather than fabricating an empty hit —
+ * a broken pipeline must not read as "not found".
+ */
+export function firstResource(responseJson) {
+  if (!responseJson || typeof responseJson !== "object") {
+    throw new Error("firstResource: response is not an object");
+  }
+  const data = responseJson.data;
+  if (data === undefined) {
+    throw new Error("firstResource: response has no `data` field");
+  }
+  if (!Array.isArray(data)) {
+    throw new Error("firstResource: response `data` is not an array");
+  }
+  return data.length > 0 ? data[0] : null;
+}
+
+/**
+ * Extract the base64 profileContent from a created/read profile resource and
+ * decode it to the raw .mobileprovision bytes. Throws when absent — the file we
+ * write must be a real profile, never an empty placeholder.
+ *
+ * @returns {Buffer}
+ */
+export function decodeProfileContent(profileResource) {
+  const content = profileResource?.attributes?.profileContent;
+  if (typeof content !== "string" || content.length === 0) {
+    throw new Error(
+      "decodeProfileContent: profile resource has no profileContent",
+    );
+  }
+  return Buffer.from(content, "base64");
+}
+
+/**
+ * Turn an ASC error response body into a single actionable line. ASC returns
+ * { errors: [{ status, code, title, detail }] }; we join them so a 409/403 from
+ * Apple surfaces the real cause instead of a bare status code.
+ */
+export function formatAscErrors(responseJson, status) {
+  const errors = Array.isArray(responseJson?.errors) ? responseJson.errors : [];
+  if (errors.length === 0) {
+    return `ASC API returned HTTP ${status} with no error detail`;
+  }
+  return errors
+    .map((e) => {
+      const parts = [e.status, e.code, e.title, e.detail].filter(Boolean);
+      return parts.join(" — ");
+    })
+    .join("; ");
+}
+
+// ── env / arg parsing ───────────────────────────────────────────────────
+
+/**
+ * Resolve the ASC credential triplet from env. Mirrors the three secret names
+ * apple-store-release.yml already validates (APP_STORE_API_KEY_ID /
+ * APP_STORE_API_ISSUER_ID / APP_STORE_API_KEY_P8) and adds APP_STORE_API_KEY_PATH
+ * as the .p8-file alternative to the inline PEM. Returns a `{ missing }` list
+ * instead of throwing so the script can fail-fast naming every absent var at
+ * once (mirroring apple-store-release.yml:411-414).
+ *
+ * @param {Record<string,string|undefined>} env
+ * @returns {{ keyId: string|null, issuerId: string|null, keyPath: string|null,
+ *   keyPem: string|null, missing: string[] }}
+ */
+export function resolveAscCredentials(env) {
+  const keyId = trimOrNull(env.APP_STORE_API_KEY_ID);
+  const issuerId = trimOrNull(env.APP_STORE_API_ISSUER_ID);
+  const keyPath = trimOrNull(env.APP_STORE_API_KEY_PATH);
+  const keyPem = trimOrNull(env.APP_STORE_API_KEY_P8);
+
+  const missing = [];
+  if (!keyId) missing.push("APP_STORE_API_KEY_ID");
+  if (!issuerId) missing.push("APP_STORE_API_ISSUER_ID");
+  // Either an on-disk .p8 path OR the inline PEM satisfies the key requirement.
+  if (!keyPath && !keyPem) {
+    missing.push("APP_STORE_API_KEY_PATH or APP_STORE_API_KEY_P8");
+  }
+  return { keyId, issuerId, keyPath, keyPem, missing };
+}
+
+function trimOrNull(value) {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Parse this script's CLI: `--device <udid>` (required for a live run),
+ * `--check-only` (validate config, never call Apple), `--device-name <name>`,
+ * `--profiles-dir <dir>`, `--product <App.app>` (discover appexes from a built
+ * product instead of the static list). `--device` also falls back to
+ * ELIZA_IOS_DEVICE_UDID / ELIZA_IOS_DEVICE_ID.
+ *
+ * @param {string[]} argv
+ * @param {Record<string,string|undefined>} [env]
+ */
+export function parseMintArgs(argv, env = {}) {
+  const args = {
+    device: null,
+    deviceName: null,
+    profilesDir: null,
+    product: null,
+    checkOnly: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const [flag, inlineValue] = splitFlag(token);
+    // A value flag reads its `--flag=value` form or consumes the next token,
+    // advancing the loop index so it is not re-parsed as a bare flag.
+    const takeValue = () => {
+      if (inlineValue != null) return inlineValue;
+      i += 1;
+      return argv[i] ?? null;
+    };
+    switch (flag) {
+      case "--check-only":
+      case "--dry-run":
+        args.checkOnly = true;
+        break;
+      case "--device":
+        args.device = takeValue();
+        break;
+      case "--device-name":
+        args.deviceName = takeValue();
+        break;
+      case "--profiles-dir":
+        args.profilesDir = takeValue();
+        break;
+      case "--product":
+        args.product = takeValue();
+        break;
+      default:
+        // Unknown tokens are ignored so the script composes with wrapper flags.
+        break;
+    }
+  }
+  if (!args.device) {
+    args.device =
+      trimOrNull(env.ELIZA_IOS_DEVICE_UDID) ??
+      trimOrNull(env.ELIZA_IOS_DEVICE_ID) ??
+      null;
+  }
+  return args;
+}
+
+function splitFlag(token) {
+  if (typeof token !== "string" || !token.startsWith("--")) return [token, null];
+  const eq = token.indexOf("=");
+  if (eq === -1) return [token, null];
+  return [token.slice(0, eq), token.slice(eq + 1)];
+}
+
+/**
+ * A UDID is 40 hex chars (older devices) or the newer 25-char
+ * XXXXXXXX-XXXXXXXXXXXXXXXX form. We validate shape before hitting Apple so an
+ * obvious typo fails locally with an actionable message instead of a 400.
+ */
+export function isPlausibleUdid(udid) {
+  if (typeof udid !== "string") return false;
+  const value = udid.trim();
+  if (/^[0-9a-fA-F]{40}$/.test(value)) return true;
+  if (/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}$/.test(value)) return true;
+  return false;
+}

--- a/packages/app/scripts/ios-asc-lib.test.mjs
+++ b/packages/app/scripts/ios-asc-lib.test.mjs
@@ -9,11 +9,11 @@
 import crypto from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
+  APP_BUNDLE_ID,
+  APPEX_SUFFIXES,
   ASC_API_BASE,
   ASC_JWT_AUDIENCE,
   ASC_JWT_MAX_LIFETIME_SECONDS,
-  APP_BUNDLE_ID,
-  APPEX_SUFFIXES,
   appexSuffixesFromPlugIns,
   base64url,
   buildAscJwtClaims,
@@ -34,6 +34,7 @@ import {
   parseMintArgs,
   profileNameForBundleId,
   resolveAscCredentials,
+  resourceIdsFromListResponse,
   signAscJwt,
 } from "./ios-asc-lib.mjs";
 
@@ -93,12 +94,20 @@ describe("buildAscJwtClaims", () => {
 
   it("floors a fractional lifetime and never drops below 1 second", () => {
     expect(
-      buildAscJwtClaims({ keyId: "k", issuerId: "i", issuedAt: 0, lifetimeSeconds: 0 })
-        .payload.exp,
+      buildAscJwtClaims({
+        keyId: "k",
+        issuerId: "i",
+        issuedAt: 0,
+        lifetimeSeconds: 0,
+      }).payload.exp,
     ).toBe(1);
     expect(
-      buildAscJwtClaims({ keyId: "k", issuerId: "i", issuedAt: 0, lifetimeSeconds: 5.9 })
-        .payload.exp,
+      buildAscJwtClaims({
+        keyId: "k",
+        issuerId: "i",
+        issuedAt: 0,
+        lifetimeSeconds: 5.9,
+      }).payload.exp,
     ).toBe(5);
   });
 
@@ -114,14 +123,21 @@ describe("buildAscJwtClaims", () => {
 describe("signAscJwt", () => {
   it("produces a verifiable ES256 JWT with a 64-byte P1363 signature", () => {
     const { publicKey, privateKey } = makeEcKeypair();
-    const claims = buildAscJwtClaims({ keyId: "KID", issuerId: "ISS", issuedAt: 42 });
+    const claims = buildAscJwtClaims({
+      keyId: "KID",
+      issuerId: "ISS",
+      issuedAt: 42,
+    });
     const jwt = signAscJwt(claims, privateKey);
 
     const [h, p, s] = jwt.split(".");
     expect(b64urlDecodeJson(h)).toEqual(claims.header);
     expect(b64urlDecodeJson(p)).toEqual(claims.payload);
 
-    const sig = Buffer.from(s.replaceAll("-", "+").replaceAll("_", "/"), "base64");
+    const sig = Buffer.from(
+      s.replaceAll("-", "+").replaceAll("_", "/"),
+      "base64",
+    );
     // ES256 over JOSE is raw r‖s for P-256 → exactly 64 bytes (not ASN.1/DER).
     expect(sig.length).toBe(64);
 
@@ -141,7 +157,10 @@ describe("signAscJwt", () => {
       privateKey,
     );
     const [h, p, s] = jwt.split(".");
-    const sig = Buffer.from(s.replaceAll("-", "+").replaceAll("_", "/"), "base64");
+    const sig = Buffer.from(
+      s.replaceAll("-", "+").replaceAll("_", "/"),
+      "base64",
+    );
     const ok = crypto.verify(
       "sha256",
       Buffer.from(`${h}.${p}tampered`),
@@ -155,7 +174,11 @@ describe("signAscJwt", () => {
 describe("enumerateBundleIds", () => {
   it("emits the app first then one entry per appex suffix, in order", () => {
     const entries = enumerateBundleIds();
-    expect(entries[0]).toEqual({ bundleId: APP_BUNDLE_ID, kind: "app", name: "App" });
+    expect(entries[0]).toEqual({
+      bundleId: APP_BUNDLE_ID,
+      kind: "app",
+      name: "App",
+    });
     expect(entries).toHaveLength(1 + APPEX_SUFFIXES.length);
     for (let i = 0; i < APPEX_SUFFIXES.length; i += 1) {
       expect(entries[i + 1]).toEqual({
@@ -237,9 +260,9 @@ describe("ASC request builders", () => {
 
   it("finds and registers a device by UDID", () => {
     const find = buildFindDeviceRequest("00008140-0006491E2E90801C");
-    expect(new URLSearchParams(find.path.split("?")[1]).get("filter[udid]")).toBe(
-      "00008140-0006491E2E90801C",
-    );
+    expect(
+      new URLSearchParams(find.path.split("?")[1]).get("filter[udid]"),
+    ).toBe("00008140-0006491E2E90801C");
 
     const reg = buildRegisterDeviceRequest("00008140-0006491E2E90801C", {
       name: "lab-iphone",
@@ -269,10 +292,12 @@ describe("ASC request builders", () => {
     expect(profileNameForBundleId("ai.elizaos.app")).toBe(
       "eliza-device-lane ai.elizaos.app",
     );
-    const find = buildFindProfileRequest(profileNameForBundleId("ai.elizaos.app"));
-    expect(new URLSearchParams(find.path.split("?")[1]).get("filter[name]")).toBe(
-      "eliza-device-lane ai.elizaos.app",
+    const find = buildFindProfileRequest(
+      profileNameForBundleId("ai.elizaos.app"),
     );
+    expect(
+      new URLSearchParams(find.path.split("?")[1]).get("filter[name]"),
+    ).toBe("eliza-device-lane ai.elizaos.app");
   });
 
   it("builds an IOS_APP_DEVELOPMENT profile linking bundle, certs, and devices", () => {
@@ -328,14 +353,18 @@ describe("ASC request builders", () => {
     });
     const certs = buildListCertificatesRequest();
     expect(
-      new URLSearchParams(certs.path.split("?")[1]).get("filter[certificateType]"),
+      new URLSearchParams(certs.path.split("?")[1]).get(
+        "filter[certificateType]",
+      ),
     ).toBe("DEVELOPMENT");
   });
 });
 
 describe("ASC response parsing", () => {
   it("returns the first resource or null for an empty list", () => {
-    expect(firstResource({ data: [{ id: "a" }, { id: "b" }] })).toEqual({ id: "a" });
+    expect(firstResource({ data: [{ id: "a" }, { id: "b" }] })).toEqual({
+      id: "a",
+    });
     expect(firstResource({ data: [] })).toBeNull();
   });
 
@@ -345,11 +374,34 @@ describe("ASC response parsing", () => {
     expect(() => firstResource({ data: { id: "x" } })).toThrow(/not an array/);
   });
 
+  it("extracts list resource ids without treating malformed responses as empty", () => {
+    expect(
+      resourceIdsFromListResponse(
+        { data: [{ id: "CERT1" }, { id: "" }, {}, { id: "CERT2" }] },
+        "certificates",
+      ),
+    ).toEqual(["CERT1", "CERT2"]);
+    expect(resourceIdsFromListResponse({ data: [] }, "certificates")).toEqual(
+      [],
+    );
+    expect(() => resourceIdsFromListResponse(null, "certificates")).toThrow(
+      /not an object/,
+    );
+    expect(() => resourceIdsFromListResponse({}, "certificates")).toThrow(
+      /no `data`/,
+    );
+    expect(() =>
+      resourceIdsFromListResponse({ data: { id: "CERT1" } }, "certificates"),
+    ).toThrow(/not an array/);
+  });
+
   it("decodes profileContent to raw bytes and throws when absent", () => {
     const raw = Buffer.from("mobileprovision-bytes");
     const resource = { attributes: { profileContent: raw.toString("base64") } };
     expect(decodeProfileContent(resource).equals(raw)).toBe(true);
-    expect(() => decodeProfileContent({ attributes: {} })).toThrow(/profileContent/);
+    expect(() => decodeProfileContent({ attributes: {} })).toThrow(
+      /profileContent/,
+    );
     expect(() => decodeProfileContent(null)).toThrow(/profileContent/);
   });
 
@@ -358,7 +410,12 @@ describe("ASC response parsing", () => {
       formatAscErrors(
         {
           errors: [
-            { status: "409", code: "ENTITY_ERROR", title: "Conflict", detail: "exists" },
+            {
+              status: "409",
+              code: "ENTITY_ERROR",
+              title: "Conflict",
+              detail: "exists",
+            },
           ],
         },
         409,
@@ -411,11 +468,15 @@ describe("resolveAscCredentials", () => {
 
 describe("parseMintArgs", () => {
   it("parses space- and equals-form flags", () => {
-    expect(parseMintArgs(["--device", "ABCD", "--device-name", "lab"])).toMatchObject({
+    expect(
+      parseMintArgs(["--device", "ABCD", "--device-name", "lab"]),
+    ).toMatchObject({
       device: "ABCD",
       deviceName: "lab",
     });
-    expect(parseMintArgs(["--device=ABCD", "--product=/x/App.app"])).toMatchObject({
+    expect(
+      parseMintArgs(["--device=ABCD", "--product=/x/App.app"]),
+    ).toMatchObject({
       device: "ABCD",
       product: "/x/App.app",
     });
@@ -434,10 +495,13 @@ describe("parseMintArgs", () => {
         ELIZA_IOS_DEVICE_ID: "FROM_ID",
       }).device,
     ).toBe("FROM_UDID");
-    expect(parseMintArgs([], { ELIZA_IOS_DEVICE_ID: "FROM_ID" }).device).toBe("FROM_ID");
+    expect(parseMintArgs([], { ELIZA_IOS_DEVICE_ID: "FROM_ID" }).device).toBe(
+      "FROM_ID",
+    );
     // An explicit flag always wins over the env fallback.
     expect(
-      parseMintArgs(["--device", "FLAG"], { ELIZA_IOS_DEVICE_UDID: "ENV" }).device,
+      parseMintArgs(["--device", "FLAG"], { ELIZA_IOS_DEVICE_UDID: "ENV" })
+        .device,
     ).toBe("FLAG");
   });
 
@@ -448,7 +512,9 @@ describe("parseMintArgs", () => {
 
 describe("isPlausibleUdid", () => {
   it("accepts both the 40-hex and 8-16 hex device forms", () => {
-    expect(isPlausibleUdid("0123456789abcdef0123456789abcdef01234567")).toBe(true);
+    expect(isPlausibleUdid("0123456789abcdef0123456789abcdef01234567")).toBe(
+      true,
+    );
     expect(isPlausibleUdid("00008140-0006491E2E90801C")).toBe(true);
   });
 

--- a/packages/app/scripts/ios-asc-lib.test.mjs
+++ b/packages/app/scripts/ios-asc-lib.test.mjs
@@ -1,0 +1,471 @@
+/**
+ * Unit tests for the pure decision logic behind ios-mint-profiles.mjs — the
+ * App Store Connect development-profile minting for the iOS device lane. Runs in
+ * the packages/app vitest suite (`bun run --cwd packages/app test`). No Apple
+ * account and no network: the JWT signer is exercised against a locally-generated
+ * EC P-256 key and verified with the matching public key, so ES256/ieee-p1363
+ * correctness is proven deterministically without a real .p8 or a live token.
+ */
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  ASC_API_BASE,
+  ASC_JWT_AUDIENCE,
+  ASC_JWT_MAX_LIFETIME_SECONDS,
+  APP_BUNDLE_ID,
+  APPEX_SUFFIXES,
+  appexSuffixesFromPlugIns,
+  base64url,
+  buildAscJwtClaims,
+  buildCreateBundleIdRequest,
+  buildCreateProfileRequest,
+  buildDeleteProfileRequest,
+  buildFindBundleIdRequest,
+  buildFindDeviceRequest,
+  buildFindProfileRequest,
+  buildListCertificatesRequest,
+  buildRegisterDeviceRequest,
+  bundleIdToName,
+  decodeProfileContent,
+  enumerateBundleIds,
+  firstResource,
+  formatAscErrors,
+  isPlausibleUdid,
+  parseMintArgs,
+  profileNameForBundleId,
+  resolveAscCredentials,
+  signAscJwt,
+} from "./ios-asc-lib.mjs";
+
+/** Generate a throwaway EC P-256 keypair whose private PEM stands in for a .p8. */
+function makeEcKeypair() {
+  return crypto.generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+}
+
+function b64urlDecodeJson(segment) {
+  const b64 = segment.replaceAll("-", "+").replaceAll("_", "/");
+  return JSON.parse(Buffer.from(b64, "base64").toString("utf8"));
+}
+
+describe("base64url", () => {
+  it("uses the URL alphabet and strips padding", () => {
+    // 0xFB 0xFF encodes to "+/8=" in std base64 → "-_8" url-safe, no pad.
+    expect(base64url(Buffer.from([0xfb, 0xff]))).toBe("-_8");
+    expect(base64url("")).toBe("");
+    expect(base64url("hello")).toBe("aGVsbG8");
+  });
+
+  it("accepts a string or a Buffer identically", () => {
+    expect(base64url("abc")).toBe(base64url(Buffer.from("abc")));
+  });
+});
+
+describe("buildAscJwtClaims", () => {
+  it("builds the fixed ES256 header and the required audience claim", () => {
+    const { header, payload } = buildAscJwtClaims({
+      keyId: "KID123",
+      issuerId: "ISS-abc",
+      issuedAt: 1_000_000,
+      lifetimeSeconds: 600,
+    });
+    expect(header).toEqual({ alg: "ES256", kid: "KID123", typ: "JWT" });
+    expect(payload).toEqual({
+      iss: "ISS-abc",
+      iat: 1_000_000,
+      exp: 1_000_600,
+      aud: ASC_JWT_AUDIENCE,
+    });
+  });
+
+  it("clamps the lifetime to Apple's 20-minute cap", () => {
+    const { payload } = buildAscJwtClaims({
+      keyId: "k",
+      issuerId: "i",
+      issuedAt: 0,
+      lifetimeSeconds: 60 * 60,
+    });
+    expect(payload.exp).toBe(ASC_JWT_MAX_LIFETIME_SECONDS);
+  });
+
+  it("floors a fractional lifetime and never drops below 1 second", () => {
+    expect(
+      buildAscJwtClaims({ keyId: "k", issuerId: "i", issuedAt: 0, lifetimeSeconds: 0 })
+        .payload.exp,
+    ).toBe(1);
+    expect(
+      buildAscJwtClaims({ keyId: "k", issuerId: "i", issuedAt: 0, lifetimeSeconds: 5.9 })
+        .payload.exp,
+    ).toBe(5);
+  });
+
+  it("rejects a missing keyId, issuerId, or non-integer issuedAt", () => {
+    expect(() => buildAscJwtClaims({ issuerId: "i" })).toThrow(/keyId/);
+    expect(() => buildAscJwtClaims({ keyId: "k" })).toThrow(/issuerId/);
+    expect(() =>
+      buildAscJwtClaims({ keyId: "k", issuerId: "i", issuedAt: 1.5 }),
+    ).toThrow(/issuedAt/);
+  });
+});
+
+describe("signAscJwt", () => {
+  it("produces a verifiable ES256 JWT with a 64-byte P1363 signature", () => {
+    const { publicKey, privateKey } = makeEcKeypair();
+    const claims = buildAscJwtClaims({ keyId: "KID", issuerId: "ISS", issuedAt: 42 });
+    const jwt = signAscJwt(claims, privateKey);
+
+    const [h, p, s] = jwt.split(".");
+    expect(b64urlDecodeJson(h)).toEqual(claims.header);
+    expect(b64urlDecodeJson(p)).toEqual(claims.payload);
+
+    const sig = Buffer.from(s.replaceAll("-", "+").replaceAll("_", "/"), "base64");
+    // ES256 over JOSE is raw r‖s for P-256 → exactly 64 bytes (not ASN.1/DER).
+    expect(sig.length).toBe(64);
+
+    const ok = crypto.verify(
+      "sha256",
+      Buffer.from(`${h}.${p}`),
+      { key: publicKey, dsaEncoding: "ieee-p1363" },
+      sig,
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("rejects a token when the signing input is tampered", () => {
+    const { publicKey, privateKey } = makeEcKeypair();
+    const jwt = signAscJwt(
+      buildAscJwtClaims({ keyId: "K", issuerId: "I", issuedAt: 1 }),
+      privateKey,
+    );
+    const [h, p, s] = jwt.split(".");
+    const sig = Buffer.from(s.replaceAll("-", "+").replaceAll("_", "/"), "base64");
+    const ok = crypto.verify(
+      "sha256",
+      Buffer.from(`${h}.${p}tampered`),
+      { key: publicKey, dsaEncoding: "ieee-p1363" },
+      sig,
+    );
+    expect(ok).toBe(false);
+  });
+});
+
+describe("enumerateBundleIds", () => {
+  it("emits the app first then one entry per appex suffix, in order", () => {
+    const entries = enumerateBundleIds();
+    expect(entries[0]).toEqual({ bundleId: APP_BUNDLE_ID, kind: "app", name: "App" });
+    expect(entries).toHaveLength(1 + APPEX_SUFFIXES.length);
+    for (let i = 0; i < APPEX_SUFFIXES.length; i += 1) {
+      expect(entries[i + 1]).toEqual({
+        bundleId: `${APP_BUNDLE_ID}.${APPEX_SUFFIXES[i]}`,
+        kind: "appex",
+        name: APPEX_SUFFIXES[i],
+      });
+    }
+  });
+
+  it("honors explicit app id and discovered suffixes", () => {
+    const entries = enumerateBundleIds({
+      appBundleId: "com.example.thing",
+      appexSuffixes: ["Widgets"],
+    });
+    expect(entries).toEqual([
+      { bundleId: "com.example.thing", kind: "app", name: "App" },
+      { bundleId: "com.example.thing.Widgets", kind: "appex", name: "Widgets" },
+    ]);
+  });
+});
+
+describe("appexSuffixesFromPlugIns", () => {
+  it("keeps only .appex entries, strips the extension, and sorts", () => {
+    expect(
+      appexSuffixesFromPlugIns([
+        "ElizaWidgets.appex",
+        "README.txt",
+        "ElizaKeyboard.appex",
+        ".DS_Store",
+      ]),
+    ).toEqual(["ElizaKeyboard", "ElizaWidgets"]);
+  });
+
+  it("returns empty for a product with no plug-ins", () => {
+    expect(appexSuffixesFromPlugIns([])).toEqual([]);
+  });
+});
+
+describe("bundleIdToName", () => {
+  it("replaces dots with spaces so ASC accepts the name", () => {
+    expect(bundleIdToName("ai.elizaos.app")).toBe("ai elizaos app");
+    expect(bundleIdToName("ai.elizaos.app.ElizaKeyboard")).toBe(
+      "ai elizaos app ElizaKeyboard",
+    );
+  });
+
+  it("collapses runs of separators and trims", () => {
+    expect(bundleIdToName("a__b..c")).toBe("a b c");
+  });
+});
+
+describe("ASC request builders", () => {
+  it("finds a bundle id by identifier filter", () => {
+    const req = buildFindBundleIdRequest("ai.elizaos.app");
+    expect(req.method).toBe("GET");
+    expect(req.path).toContain("/bundleIds?");
+    const q = new URLSearchParams(req.path.split("?")[1]);
+    expect(q.get("filter[identifier]")).toBe("ai.elizaos.app");
+    expect(q.get("limit")).toBe("200");
+  });
+
+  it("creates an iOS bundle id with a dot-free name", () => {
+    expect(buildCreateBundleIdRequest("ai.elizaos.app.ElizaWidgets")).toEqual({
+      method: "POST",
+      path: "/bundleIds",
+      body: {
+        data: {
+          type: "bundleIds",
+          attributes: {
+            identifier: "ai.elizaos.app.ElizaWidgets",
+            name: "ai elizaos app ElizaWidgets",
+            platform: "IOS",
+          },
+        },
+      },
+    });
+  });
+
+  it("finds and registers a device by UDID", () => {
+    const find = buildFindDeviceRequest("00008140-0006491E2E90801C");
+    expect(new URLSearchParams(find.path.split("?")[1]).get("filter[udid]")).toBe(
+      "00008140-0006491E2E90801C",
+    );
+
+    const reg = buildRegisterDeviceRequest("00008140-0006491E2E90801C", {
+      name: "lab-iphone",
+    });
+    expect(reg).toEqual({
+      method: "POST",
+      path: "/devices",
+      body: {
+        data: {
+          type: "devices",
+          attributes: {
+            name: "lab-iphone",
+            platform: "IOS",
+            udid: "00008140-0006491E2E90801C",
+          },
+        },
+      },
+    });
+  });
+
+  it("defaults a device name when none is given", () => {
+    const reg = buildRegisterDeviceRequest("DEAD", {});
+    expect(reg.body.data.attributes.name).toBe("device-lane DEAD");
+  });
+
+  it("names profiles deterministically for find-then-refresh", () => {
+    expect(profileNameForBundleId("ai.elizaos.app")).toBe(
+      "eliza-device-lane ai.elizaos.app",
+    );
+    const find = buildFindProfileRequest(profileNameForBundleId("ai.elizaos.app"));
+    expect(new URLSearchParams(find.path.split("?")[1]).get("filter[name]")).toBe(
+      "eliza-device-lane ai.elizaos.app",
+    );
+  });
+
+  it("builds an IOS_APP_DEVELOPMENT profile linking bundle, certs, and devices", () => {
+    const req = buildCreateProfileRequest({
+      bundleId: "ai.elizaos.app",
+      bundleIdResourceId: "BID1",
+      certificateIds: ["CERT1", "CERT2"],
+      deviceIds: ["DEV1"],
+    });
+    expect(req.method).toBe("POST");
+    expect(req.path).toBe("/profiles");
+    expect(req.body.data.attributes).toEqual({
+      name: "eliza-device-lane ai.elizaos.app",
+      profileType: "IOS_APP_DEVELOPMENT",
+    });
+    expect(req.body.data.relationships.bundleId.data).toEqual({
+      type: "bundleIds",
+      id: "BID1",
+    });
+    expect(req.body.data.relationships.certificates.data).toEqual([
+      { type: "certificates", id: "CERT1" },
+      { type: "certificates", id: "CERT2" },
+    ]);
+    expect(req.body.data.relationships.devices.data).toEqual([
+      { type: "devices", id: "DEV1" },
+    ]);
+  });
+
+  it("refuses to build a profile without a bundle, cert, or device", () => {
+    expect(() =>
+      buildCreateProfileRequest({ certificateIds: ["c"], deviceIds: ["d"] }),
+    ).toThrow(/bundleIdResourceId/);
+    expect(() =>
+      buildCreateProfileRequest({
+        bundleIdResourceId: "b",
+        certificateIds: [],
+        deviceIds: ["d"],
+      }),
+    ).toThrow(/certificateId/);
+    expect(() =>
+      buildCreateProfileRequest({
+        bundleIdResourceId: "b",
+        certificateIds: ["c"],
+        deviceIds: [],
+      }),
+    ).toThrow(/deviceId/);
+  });
+
+  it("deletes a profile by resource id and lists development certificates", () => {
+    expect(buildDeleteProfileRequest("PROF9")).toEqual({
+      method: "DELETE",
+      path: "/profiles/PROF9",
+    });
+    const certs = buildListCertificatesRequest();
+    expect(
+      new URLSearchParams(certs.path.split("?")[1]).get("filter[certificateType]"),
+    ).toBe("DEVELOPMENT");
+  });
+});
+
+describe("ASC response parsing", () => {
+  it("returns the first resource or null for an empty list", () => {
+    expect(firstResource({ data: [{ id: "a" }, { id: "b" }] })).toEqual({ id: "a" });
+    expect(firstResource({ data: [] })).toBeNull();
+  });
+
+  it("throws rather than fabricating a not-found on a malformed body", () => {
+    expect(() => firstResource(null)).toThrow(/not an object/);
+    expect(() => firstResource({})).toThrow(/no `data`/);
+    expect(() => firstResource({ data: { id: "x" } })).toThrow(/not an array/);
+  });
+
+  it("decodes profileContent to raw bytes and throws when absent", () => {
+    const raw = Buffer.from("mobileprovision-bytes");
+    const resource = { attributes: { profileContent: raw.toString("base64") } };
+    expect(decodeProfileContent(resource).equals(raw)).toBe(true);
+    expect(() => decodeProfileContent({ attributes: {} })).toThrow(/profileContent/);
+    expect(() => decodeProfileContent(null)).toThrow(/profileContent/);
+  });
+
+  it("formats ASC error arrays into one actionable line", () => {
+    expect(
+      formatAscErrors(
+        {
+          errors: [
+            { status: "409", code: "ENTITY_ERROR", title: "Conflict", detail: "exists" },
+          ],
+        },
+        409,
+      ),
+    ).toBe("409 — ENTITY_ERROR — Conflict — exists");
+    expect(formatAscErrors({}, 500)).toBe(
+      "ASC API returned HTTP 500 with no error detail",
+    );
+  });
+});
+
+describe("resolveAscCredentials", () => {
+  it("names every missing var when the env is empty", () => {
+    const { missing } = resolveAscCredentials({});
+    expect(missing).toEqual([
+      "APP_STORE_API_KEY_ID",
+      "APP_STORE_API_ISSUER_ID",
+      "APP_STORE_API_KEY_PATH or APP_STORE_API_KEY_P8",
+    ]);
+  });
+
+  it("is satisfied by either the key path or the inline PEM", () => {
+    const byPath = resolveAscCredentials({
+      APP_STORE_API_KEY_ID: "K",
+      APP_STORE_API_ISSUER_ID: "I",
+      APP_STORE_API_KEY_PATH: "/tmp/AuthKey.p8",
+    });
+    expect(byPath.missing).toEqual([]);
+    expect(byPath.keyPath).toBe("/tmp/AuthKey.p8");
+
+    const byPem = resolveAscCredentials({
+      APP_STORE_API_KEY_ID: "K",
+      APP_STORE_API_ISSUER_ID: "I",
+      APP_STORE_API_KEY_P8: "-----BEGIN PRIVATE KEY-----",
+    });
+    expect(byPem.missing).toEqual([]);
+    expect(byPem.keyPem).toBe("-----BEGIN PRIVATE KEY-----");
+  });
+
+  it("treats whitespace-only values as absent", () => {
+    const { missing } = resolveAscCredentials({
+      APP_STORE_API_KEY_ID: "   ",
+      APP_STORE_API_ISSUER_ID: "\t",
+      APP_STORE_API_KEY_P8: "",
+    });
+    expect(missing).toContain("APP_STORE_API_KEY_ID");
+    expect(missing).toContain("APP_STORE_API_ISSUER_ID");
+  });
+});
+
+describe("parseMintArgs", () => {
+  it("parses space- and equals-form flags", () => {
+    expect(parseMintArgs(["--device", "ABCD", "--device-name", "lab"])).toMatchObject({
+      device: "ABCD",
+      deviceName: "lab",
+    });
+    expect(parseMintArgs(["--device=ABCD", "--product=/x/App.app"])).toMatchObject({
+      device: "ABCD",
+      product: "/x/App.app",
+    });
+  });
+
+  it("treats --check-only and --dry-run as the same offline flag", () => {
+    expect(parseMintArgs(["--check-only"]).checkOnly).toBe(true);
+    expect(parseMintArgs(["--dry-run"]).checkOnly).toBe(true);
+    expect(parseMintArgs([]).checkOnly).toBe(false);
+  });
+
+  it("falls back to the device env vars in priority order", () => {
+    expect(
+      parseMintArgs([], {
+        ELIZA_IOS_DEVICE_UDID: "FROM_UDID",
+        ELIZA_IOS_DEVICE_ID: "FROM_ID",
+      }).device,
+    ).toBe("FROM_UDID");
+    expect(parseMintArgs([], { ELIZA_IOS_DEVICE_ID: "FROM_ID" }).device).toBe("FROM_ID");
+    // An explicit flag always wins over the env fallback.
+    expect(
+      parseMintArgs(["--device", "FLAG"], { ELIZA_IOS_DEVICE_UDID: "ENV" }).device,
+    ).toBe("FLAG");
+  });
+
+  it("ignores unknown tokens so wrapper flags pass through", () => {
+    expect(parseMintArgs(["--device", "X", "--verbose"]).device).toBe("X");
+  });
+});
+
+describe("isPlausibleUdid", () => {
+  it("accepts both the 40-hex and 8-16 hex device forms", () => {
+    expect(isPlausibleUdid("0123456789abcdef0123456789abcdef01234567")).toBe(true);
+    expect(isPlausibleUdid("00008140-0006491E2E90801C")).toBe(true);
+  });
+
+  it("rejects malformed or non-string input", () => {
+    expect(isPlausibleUdid("not-a-udid")).toBe(false);
+    expect(isPlausibleUdid("00008140-0006491E2E90801")).toBe(false); // 15 hex tail
+    expect(isPlausibleUdid("")).toBe(false);
+    expect(isPlausibleUdid(null)).toBe(false);
+    expect(isPlausibleUdid(42)).toBe(false);
+  });
+});
+
+describe("constants", () => {
+  it("targets the ASC v1 API and the elizaOS app bundle", () => {
+    expect(ASC_API_BASE).toBe("https://api.appstoreconnect.apple.com/v1");
+    expect(APP_BUNDLE_ID).toBe("ai.elizaos.app");
+    expect(APPEX_SUFFIXES).toContain("ElizaKeyboard");
+    expect(Object.isFrozen(APPEX_SUFFIXES)).toBe(true);
+  });
+});

--- a/packages/app/scripts/ios-mint-profiles.mjs
+++ b/packages/app/scripts/ios-mint-profiles.mjs
@@ -58,6 +58,7 @@ import {
   parseMintArgs,
   profileNameForBundleId,
   resolveAscCredentials,
+  resourceIdsFromListResponse,
   signAscJwt,
 } from "./ios-asc-lib.mjs";
 
@@ -110,9 +111,10 @@ async function ascRequest({ method, path: apiPath, body }, jwt) {
       body: body ? JSON.stringify(body) : undefined,
     });
   } catch (cause) {
-    throw new Error(`ASC ${method} ${apiPath} network failure: ${cause.message}`, {
-      cause,
-    });
+    throw new Error(
+      `ASC ${method} ${apiPath} network failure: ${errorMessage(cause)}`,
+      { cause },
+    );
   }
 
   const text = await response.text();
@@ -135,9 +137,15 @@ function safeJson(text) {
   }
 }
 
+function errorMessage(cause) {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
 /** Ensure the device UDID is registered; return its ASC resource id. */
 async function ensureDevice(jwt, udid, deviceName) {
-  const found = firstResource(await ascRequest(buildFindDeviceRequest(udid), jwt));
+  const found = firstResource(
+    await ascRequest(buildFindDeviceRequest(udid), jwt),
+  );
   if (found) {
     log(`device ${udid} already registered (id ${found.id})`);
     return found.id;
@@ -148,7 +156,8 @@ async function ensureDevice(jwt, udid, deviceName) {
     jwt,
   );
   const resource = created?.data;
-  if (!resource?.id) fail(`device registration returned no resource id for ${udid}`);
+  if (!resource?.id)
+    fail(`device registration returned no resource id for ${udid}`);
   return resource.id;
 }
 
@@ -161,15 +170,15 @@ async function ensureBundleId(jwt, bundleId) {
   log(`creating bundle id ${bundleId}`);
   const created = await ascRequest(buildCreateBundleIdRequest(bundleId), jwt);
   const resource = created?.data;
-  if (!resource?.id) fail(`bundle id creation returned no resource id for ${bundleId}`);
+  if (!resource?.id)
+    fail(`bundle id creation returned no resource id for ${bundleId}`);
   return resource.id;
 }
 
 /** All DEVELOPMENT certificate resource ids for the account. */
 async function listDevelopmentCertificateIds(jwt) {
   const response = await ascRequest(buildListCertificatesRequest(), jwt);
-  const data = Array.isArray(response?.data) ? response.data : [];
-  return data.map((c) => c.id).filter(Boolean);
+  return resourceIdsFromListResponse(response, "listDevelopmentCertificateIds");
 }
 
 /**
@@ -191,7 +200,9 @@ async function mintProfile({
     await ascRequest(buildFindProfileRequest(profileName), jwt),
   );
   if (existing) {
-    log(`refreshing profile "${profileName}" (deleting stale id ${existing.id})`);
+    log(
+      `refreshing profile "${profileName}" (deleting stale id ${existing.id})`,
+    );
     await ascRequest(buildDeleteProfileRequest(existing.id), jwt);
   }
   const created = await ascRequest(
@@ -269,7 +280,7 @@ async function main() {
         signAscJwt(claims, pem);
         log("ASC credentials present; .p8 parsed and a test JWT was signed");
       } catch (cause) {
-        problems.push(`.p8 key unusable: ${cause.message}`);
+        problems.push(`.p8 key unusable: ${errorMessage(cause)}`);
       }
     }
     if (problems.length > 0) {
@@ -286,7 +297,9 @@ async function main() {
     );
   }
   if (!isPlausibleUdid(args.device)) {
-    fail(`--device "${args.device}" is not a plausible UDID (40 hex or 8-16 hex form)`);
+    fail(
+      `--device "${args.device}" is not a plausible UDID (40 hex or 8-16 hex form)`,
+    );
   }
   if (creds.missing.length > 0) {
     fail(

--- a/packages/app/scripts/ios-mint-profiles.mjs
+++ b/packages/app/scripts/ios-mint-profiles.mjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+/**
+ * Mint/refresh iOS DEVELOPMENT provisioning profiles for the device test lane
+ * via the App Store Connect (ASC) API — no Xcode UI, no interactive account
+ * session. Given the ASC key triplet and a device UDID, it ensures the device
+ * is registered, ensures a bundle id exists for the main app AND every
+ * app-extension, mints/refreshes an IOS_APP_DEVELOPMENT profile for each pinned
+ * to that device, and downloads each into
+ * ~/Library/MobileDevice/Provisioning Profiles/ — exactly where
+ * ios-device-deploy's discoverProfiles() (ios-device-deploy.mjs:110-160)
+ * already scans. Idempotent; prints a per-bundle-id table.
+ *
+ * This is the agent-automatable DEVELOPMENT-profile path that unblocks appex
+ * on-device testing (#13567). Distribution signing stays a human step (#13118).
+ *
+ * Credentials (env; mirrors apple-store-release.yml's three secrets + a file
+ * alternative for the key):
+ *   APP_STORE_API_KEY_ID     ASC API key id (the .p8's kid)          [required]
+ *   APP_STORE_API_ISSUER_ID  ASC API issuer id                       [required]
+ *   APP_STORE_API_KEY_PATH   path to AuthKey_<id>.p8    ┐ one of these
+ *   APP_STORE_API_KEY_P8     inline .p8 PEM contents    ┘ two required
+ *
+ * Usage:
+ *   node scripts/ios-mint-profiles.mjs --device <udid> [--device-name <name>]
+ *     [--product <path/to/App.app>] [--profiles-dir <dir>] [--check-only]
+ *
+ *   --check-only   validate config + credentials shape and print the plan
+ *                  WITHOUT calling Apple or writing any file (offline dry run).
+ *   --product      discover appexes from a built .app's PlugIns/ instead of the
+ *                  static suffix list (so a new extension is picked up).
+ *   --device       falls back to ELIZA_IOS_DEVICE_UDID / ELIZA_IOS_DEVICE_ID.
+ *
+ * The pure decision logic (JWT claims, request/response shapes, arg/env parsing,
+ * appex enumeration) lives in ios-asc-lib.mjs, unit-tested by ios-asc-lib.test.mjs
+ * in the packages/app vitest suite. This file owns the impure edges: reading the
+ * .p8, `fetch`, and writing profile files.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  ASC_API_BASE,
+  appexSuffixesFromPlugIns,
+  buildAscJwtClaims,
+  buildCreateBundleIdRequest,
+  buildCreateProfileRequest,
+  buildDeleteProfileRequest,
+  buildFindBundleIdRequest,
+  buildFindDeviceRequest,
+  buildFindProfileRequest,
+  buildListCertificatesRequest,
+  buildRegisterDeviceRequest,
+  decodeProfileContent,
+  enumerateBundleIds,
+  firstResource,
+  formatAscErrors,
+  isPlausibleUdid,
+  parseMintArgs,
+  profileNameForBundleId,
+  resolveAscCredentials,
+  signAscJwt,
+} from "./ios-asc-lib.mjs";
+
+const log = (message) => console.log(`[ios-mint-profiles] ${message}`);
+const fail = (message) => {
+  console.error(`[ios-mint-profiles] ERROR: ${message}`);
+  process.exit(1);
+};
+
+function defaultProfilesDir() {
+  return path.join(
+    os.homedir(),
+    "Library",
+    "MobileDevice",
+    "Provisioning Profiles",
+  );
+}
+
+/** Read the .p8 PEM from the file path or inline env value. */
+function loadPrivateKeyPem({ keyPath, keyPem }) {
+  if (keyPath) {
+    if (!fs.existsSync(keyPath)) {
+      fail(`APP_STORE_API_KEY_PATH points at a missing file: ${keyPath}`);
+    }
+    return fs.readFileSync(keyPath, "utf8");
+  }
+  return keyPem;
+}
+
+/**
+ * One authenticated ASC API call. Mints a fresh JWT per call (well under the
+ * 20-minute cap; a full run is seconds). Returns parsed JSON on 2xx; throws a
+ * boundary error carrying Apple's own error detail on anything else so a
+ * 403/409 surfaces its real cause. DELETE returns 200/204 with no body.
+ *
+ * // error-policy:J1 process/transport boundary — translates a non-2xx ASC
+ * // response (or a fetch/parse failure) into a structured, actionable throw.
+ */
+async function ascRequest({ method, path: apiPath, body }, jwt) {
+  const url = `${ASC_API_BASE}${apiPath}`;
+  let response;
+  try {
+    response = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  } catch (cause) {
+    throw new Error(`ASC ${method} ${apiPath} network failure: ${cause.message}`, {
+      cause,
+    });
+  }
+
+  const text = await response.text();
+  const json = text ? safeJson(text) : null;
+  if (!response.ok) {
+    throw new Error(
+      `ASC ${method} ${apiPath} -> ${formatAscErrors(json, response.status)}`,
+    );
+  }
+  return json;
+}
+
+function safeJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — a non-JSON 2xx body is an
+    // explicit "no parseable resource", not a fabricated empty object.
+    return null;
+  }
+}
+
+/** Ensure the device UDID is registered; return its ASC resource id. */
+async function ensureDevice(jwt, udid, deviceName) {
+  const found = firstResource(await ascRequest(buildFindDeviceRequest(udid), jwt));
+  if (found) {
+    log(`device ${udid} already registered (id ${found.id})`);
+    return found.id;
+  }
+  log(`registering device ${udid}`);
+  const created = await ascRequest(
+    buildRegisterDeviceRequest(udid, { name: deviceName }),
+    jwt,
+  );
+  const resource = created?.data;
+  if (!resource?.id) fail(`device registration returned no resource id for ${udid}`);
+  return resource.id;
+}
+
+/** Ensure a bundle id exists; return its ASC resource id. */
+async function ensureBundleId(jwt, bundleId) {
+  const found = firstResource(
+    await ascRequest(buildFindBundleIdRequest(bundleId), jwt),
+  );
+  if (found) return found.id;
+  log(`creating bundle id ${bundleId}`);
+  const created = await ascRequest(buildCreateBundleIdRequest(bundleId), jwt);
+  const resource = created?.data;
+  if (!resource?.id) fail(`bundle id creation returned no resource id for ${bundleId}`);
+  return resource.id;
+}
+
+/** All DEVELOPMENT certificate resource ids for the account. */
+async function listDevelopmentCertificateIds(jwt) {
+  const response = await ascRequest(buildListCertificatesRequest(), jwt);
+  const data = Array.isArray(response?.data) ? response.data : [];
+  return data.map((c) => c.id).filter(Boolean);
+}
+
+/**
+ * Mint (or refresh) the development profile for one bundle id pinned to the
+ * device set, download it, and write it into profilesDir. Development profiles
+ * are immutably device-locked at creation, so a stale same-name profile is
+ * deleted first, then recreated with the current device — the idempotent path.
+ */
+async function mintProfile({
+  jwt,
+  bundleId,
+  bundleIdResourceId,
+  certificateIds,
+  deviceIds,
+  profilesDir,
+}) {
+  const profileName = profileNameForBundleId(bundleId);
+  const existing = firstResource(
+    await ascRequest(buildFindProfileRequest(profileName), jwt),
+  );
+  if (existing) {
+    log(`refreshing profile "${profileName}" (deleting stale id ${existing.id})`);
+    await ascRequest(buildDeleteProfileRequest(existing.id), jwt);
+  }
+  const created = await ascRequest(
+    buildCreateProfileRequest({
+      bundleId,
+      bundleIdResourceId,
+      certificateIds,
+      deviceIds,
+    }),
+    jwt,
+  );
+  const resource = created?.data;
+  if (!resource) fail(`profile creation returned no resource for ${bundleId}`);
+  const bytes = decodeProfileContent(resource);
+  const outPath = path.join(profilesDir, `${resource.id}.mobileprovision`);
+  fs.writeFileSync(outPath, bytes);
+  return { profileName, resourceId: resource.id, outPath, bytes: bytes.length };
+}
+
+/**
+ * Discover appex suffixes from a built product's PlugIns/ dir, or fall back to
+ * the static enumeration. Returns the full { bundleId, kind, name } list.
+ */
+function resolveBundleEntries(productPath) {
+  if (!productPath) return enumerateBundleIds();
+  const plugIns = path.join(productPath, "PlugIns");
+  if (!fs.existsSync(plugIns)) {
+    fail(
+      `--product ${productPath} has no PlugIns/ dir; point it at a built App.app`,
+    );
+  }
+  const suffixes = appexSuffixesFromPlugIns(fs.readdirSync(plugIns));
+  log(`discovered ${suffixes.length} appex(es) from ${plugIns}`);
+  return enumerateBundleIds({ appexSuffixes: suffixes });
+}
+
+function printPlan(entries, { device, profilesDir, checkOnly }) {
+  log(`bundle ids to provision (device ${device}):`);
+  for (const entry of entries) {
+    log(`  - [${entry.kind}] ${entry.bundleId}`);
+  }
+  log(`profiles dir: ${profilesDir}`);
+  if (checkOnly) log("check-only: no Apple API calls, no files written");
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const args = parseMintArgs(argv, process.env);
+  const profilesDir = args.profilesDir || defaultProfilesDir();
+  const entries = resolveBundleEntries(args.product);
+
+  const creds = resolveAscCredentials(process.env);
+
+  // --check-only: validate everything reachable offline, print the plan, exit.
+  // Device UDID + credential presence + key readability are all verifiable
+  // without touching Apple.
+  if (args.checkOnly) {
+    printPlan(entries, { device: args.device, profilesDir, checkOnly: true });
+    const problems = [];
+    if (!args.device) {
+      problems.push("no --device UDID (or ELIZA_IOS_DEVICE_UDID/_ID)");
+    } else if (!isPlausibleUdid(args.device)) {
+      problems.push(`--device "${args.device}" is not a plausible UDID`);
+    }
+    if (creds.missing.length > 0) {
+      problems.push(`missing ASC credentials: ${creds.missing.join(", ")}`);
+    } else {
+      // Prove the key parses + a JWT can be constructed & signed, all offline.
+      try {
+        const pem = loadPrivateKeyPem(creds);
+        const claims = buildAscJwtClaims({
+          keyId: creds.keyId,
+          issuerId: creds.issuerId,
+        });
+        signAscJwt(claims, pem);
+        log("ASC credentials present; .p8 parsed and a test JWT was signed");
+      } catch (cause) {
+        problems.push(`.p8 key unusable: ${cause.message}`);
+      }
+    }
+    if (problems.length > 0) {
+      fail(`check-only found problems:\n  - ${problems.join("\n  - ")}`);
+    }
+    log("check-only PASSED: config + credentials + key are usable");
+    return;
+  }
+
+  // ── Live run ──────────────────────────────────────────────────────────
+  if (!args.device) {
+    fail(
+      "no device UDID — pass --device <udid> or set ELIZA_IOS_DEVICE_UDID / ELIZA_IOS_DEVICE_ID",
+    );
+  }
+  if (!isPlausibleUdid(args.device)) {
+    fail(`--device "${args.device}" is not a plausible UDID (40 hex or 8-16 hex form)`);
+  }
+  if (creds.missing.length > 0) {
+    fail(
+      `missing ASC credentials: ${creds.missing.join(", ")}. ` +
+        "Set these (see apple-store-release.yml for the same secret names).",
+    );
+  }
+
+  const pem = loadPrivateKeyPem(creds);
+  const jwt = signAscJwt(
+    buildAscJwtClaims({ keyId: creds.keyId, issuerId: creds.issuerId }),
+    pem,
+  );
+
+  fs.mkdirSync(profilesDir, { recursive: true });
+  printPlan(entries, { device: args.device, profilesDir, checkOnly: false });
+
+  const deviceId = await ensureDevice(jwt, args.device, args.deviceName);
+  const certificateIds = await listDevelopmentCertificateIds(jwt);
+  if (certificateIds.length === 0) {
+    fail(
+      "no DEVELOPMENT certificates found in the ASC account — create an Apple " +
+        "Development certificate for this team first (Xcode or ASC portal).",
+    );
+  }
+  log(`linking ${certificateIds.length} development certificate(s)`);
+
+  const results = [];
+  for (const entry of entries) {
+    const bundleIdResourceId = await ensureBundleId(jwt, entry.bundleId);
+    const minted = await mintProfile({
+      jwt,
+      bundleId: entry.bundleId,
+      bundleIdResourceId,
+      certificateIds,
+      deviceIds: [deviceId],
+      profilesDir,
+    });
+    results.push({ ...entry, ...minted });
+  }
+
+  log("minted profiles:");
+  for (const r of results) {
+    log(
+      `  ✓ [${r.kind}] ${r.bundleId} -> ${path.basename(r.outPath)} (${r.bytes} bytes)`,
+    );
+  }
+  log(
+    `done: ${results.length} profile(s) written to ${profilesDir}. ` +
+      "ios:device:deploy will now discover them (one per app + appex).",
+  );
+}
+
+main().catch((error) => {
+  // error-policy:J1 top-level boundary — surface any unhandled failure with a
+  // nonzero exit and Apple's / the pipeline's real cause, never a silent pass.
+  fail(error?.stack || error?.message || String(error));
+});
+
+export { main };


### PR DESCRIPTION
Closes part 1 (development-profile minting) of #13567.

## What

Adds the agent-automatable **DEVELOPMENT provisioning-profile** path for the iOS
physical-device test loop, via the App Store Connect (ASC) API — no Xcode UI, no
interactive account session. With the ASC key triplet set, one command mints one
profile per bundle id (main app + every appex) into the exact dir
`ios-device-deploy`'s `discoverProfiles()` already scans.

```bash
bun run --cwd packages/app ios:device:provision -- --device <udid>
```

Per bundle id it: ensures the device UDID is registered, ensures the bundle id
exists, deletes any stale same-name profile, and mints a fresh
`IOS_APP_DEVELOPMENT` profile pinned to that device, then writes the decoded
`.mobileprovision` blob to `~/Library/MobileDevice/Provisioning Profiles/`.
Idempotent; prints a per-bundle-id table; fail-fast names every missing ASC var.

## Files

- **`scripts/ios-asc-lib.mjs`** — pure, side-effect-free decision logic: ES256
  JWT claim construction + P1363 signing, all ASC request/response builders,
  bundle-id + appex enumeration (static list or discovered from a built product's
  `PlugIns/`), credential + CLI/env parsing. No `fetch`, no `fs`.
- **`scripts/ios-mint-profiles.mjs`** — the impure edges (read `.p8`, `fetch`
  ASC, write profile blobs) + orchestration. `--check-only` validates config,
  key, and a real signed test JWT fully offline. `--product <App.app>` discovers
  appexes from the built product.
- **`scripts/ios-asc-lib.test.mjs`** — 36 vitest cases (see below).
- **`package.json`** — `ios:device:provision` script.
- **`CLAUDE.md` / `AGENTS.md`** — documented the command + the pure-logic/test split.

Credentials mirror the three secrets `apple-store-release.yml` already uses:
`APP_STORE_API_KEY_ID`, `APP_STORE_API_ISSUER_ID`, `APP_STORE_API_KEY_P8` (or
`APP_STORE_API_KEY_PATH` for the `.p8` file).

## Evidence

**Unit tests — 36/36 pass** (`bun run --cwd packages/app test`, scripts lane
190/190). The JWT signer is proven against a locally-generated EC P-256 keypair:
sign → split → `crypto.verify(..., ieee-p1363)` → asserts a 64-byte P1363
signature and a passing verify, plus a tamper-negative. Malformed ASC bodies
throw (never fabricate a not-found). Covers request/response shapes, credential
resolution, arg/env parsing, UDID validation, appex enumeration.

**Real script, exercised offline (no Apple call):**
```
$ APP_STORE_API_KEY_ID=… APP_STORE_API_ISSUER_ID=… APP_STORE_API_KEY_PATH=<generated .p8> \
    ios:device:provision --device 00008140-0006491E2E90801C --check-only
[ios-mint-profiles] bundle ids to provision (device …):
  - [app]   ai.elizaos.app
  - [appex] ai.elizaos.app.ElizaKeyboard
  - [appex] ai.elizaos.app.ElizaWidgets
  - [appex] ai.elizaos.app.DeviceActivityMonitorExtension
  - [appex] ai.elizaos.app.DeviceActivityReportExtension
  - [appex] ai.elizaos.app.WebsiteBlockerContentExtension
[ios-mint-profiles] ASC credentials present; .p8 parsed and a test JWT was signed
[ios-mint-profiles] check-only PASSED
```
Negative (missing creds) exits 1 naming all three vars. `--product <App.app>`
discovery derives appex suffixes from `PlugIns/*.appex`, verified against a
synthetic product.

| Evidence | Status |
|---|---|
| Unit tests (pure logic) | ✅ 36/36 + scripts lane 190/190 |
| Real script offline (check-only, both signs) | ✅ shown above |
| Biome lint | ✅ clean |
| **Live ASC mint against a real Apple dev account** | ⛔ N/A — pending-hardware |
| **On-device install of the minted appex profiles** | ⛔ N/A — pending-hardware |

## Pending hardware — the one leg that cannot run here

The live `fetch` against `api.appstoreconnect.apple.com` (device register /
bundle-id create / profile mint) and the subsequent on-device install require an
**Apple developer account (ASC API key) + a registered physical iPhone**, neither
attached to this lane. The impure orchestration is fully written and driven
offline via `--check-only` (real `.p8` parse + real ES256 JWT signing exercised);
only the network round-trip and the device install are unverifiable here. No
mock stands in for Apple — the boundary is real, just unreachable in CI.

## Scope note

This PR is issue #13567 **part 1** (profile minting). Part 2 (codifying the
XCUITest-runner graft-signing into `ios-device-capture.mjs`) touches the shared
device-capture harness owned by a concurrent iOS session and is left as a
follow-up on this issue to avoid a cross-session conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)