### PR TITLE
fix(core): 402 credit exhaustion → designed 'out of credits' reply, not generic retry copy

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -270,6 +270,7 @@ import {
 import {
 	buildFailureReplyPrompt,
 	isAuthError,
+	isCreditsExhaustedError,
 	isRateLimitError,
 	stripReasoningBlocks,
 } from "./message/fallback-reply";
@@ -1501,6 +1502,7 @@ type FailureReplyAttempt =
 	| { kind: "text"; value: string }
 	| { kind: "noProvider" }
 	| { kind: "rateLimited" }
+	| { kind: "creditsExhausted" }
 	| { kind: "authFailed" };
 
 export function shouldSkipResponseMemoryPersistence(memory: Memory): boolean {
@@ -10593,6 +10595,7 @@ export class DefaultMessageService implements IMessageService {
 		stage: string,
 	): Promise<FailureReplyAttempt> {
 		let sawRateLimit = false;
+		let sawCreditsExhausted = false;
 		let sawAuthError = false;
 		for (const modelType of [
 			ModelType.TEXT_LARGE,
@@ -10636,6 +10639,7 @@ export class DefaultMessageService implements IMessageService {
 				// failed for unrelated reasons where retrying won't help). The
 				// all-429 cascade from the live incident still lands here.
 				sawRateLimit = isRateLimitError(error);
+				sawCreditsExhausted = isCreditsExhaustedError(error);
 				sawAuthError = isAuthError(error);
 				runtime.logger.warn(
 					{
@@ -10654,6 +10658,12 @@ export class DefaultMessageService implements IMessageService {
 		// shortly", not "something broke".
 		if (sawRateLimit) {
 			return { kind: "rateLimited" };
+		}
+		// 402 credit exhaustion is the MOST actionable failure: the fix is
+		// topping up, and "try again" is actively wrong (drained-org retry
+		// loop, #13665/#13962) — classify before the broader auth bucket.
+		if (sawCreditsExhausted) {
+			return { kind: "creditsExhausted" };
 		}
 		// An auth failure (bad/expired/unauthorized cloud key) is actionable —
 		// tell the user to fix their key/credits, not the opaque generic message.
@@ -10706,7 +10716,9 @@ export class DefaultMessageService implements IMessageService {
 		}
 
 		let replyText =
-			attempt.kind === "rateLimited" || attempt.kind === "authFailed"
+			attempt.kind === "rateLimited" ||
+			attempt.kind === "authFailed" ||
+			attempt.kind === "creditsExhausted"
 				? ""
 				: attempt.value;
 		if (!replyText) {
@@ -10720,6 +10732,11 @@ export class DefaultMessageService implements IMessageService {
 				replyText =
 					(typeof tmpl === "function" ? tmpl({ state }) : tmpl) ||
 					"My model provider is rate-limiting me right now — give it a few seconds and try again.";
+			} else if (attempt.kind === "creditsExhausted") {
+				const tmpl = runtime.character.templates?.creditsExhaustedReply;
+				replyText =
+					(typeof tmpl === "function" ? tmpl({ state }) : tmpl) ||
+					"I'm out of Eliza Cloud credits, so I can't think right now — add credits to your account (Billing in the Eliza Cloud dashboard), then message me again.";
 			} else if (attempt.kind === "authFailed") {
 				const tmpl = runtime.character.templates?.authFailedReply;
 				replyText =

--- a/packages/core/src/services/message/fallback-reply.classifiers.test.ts
+++ b/packages/core/src/services/message/fallback-reply.classifiers.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Failure-reply classifiers: 402 credit exhaustion must be recognized as its
+ * own kind (actionable "top up", never generic retry copy — #13962), and must
+ * not bleed into the 401/403 auth or 429 rate-limit buckets.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	isAuthError,
+	isCreditsExhaustedError,
+	isRateLimitError,
+} from "./fallback-reply";
+
+function httpError(status: number, message: string): Error {
+	const err = new Error(message) as Error & { status: number };
+	err.status = status;
+	return err;
+}
+
+describe("isCreditsExhaustedError", () => {
+	it("matches a structured 402", () => {
+		expect(isCreditsExhaustedError(httpError(402, "Payment Required"))).toBe(
+			true,
+		);
+	});
+
+	it("matches the cloud insufficient_credits error string", () => {
+		expect(
+			isCreditsExhaustedError(
+				new Error('402 {"error":"insufficient_credits"}'),
+			),
+		).toBe(true);
+	});
+
+	it("does not match 401/403/429 or generic failures", () => {
+		expect(isCreditsExhaustedError(httpError(401, "Unauthorized"))).toBe(false);
+		expect(isCreditsExhaustedError(httpError(429, "Too Many Requests"))).toBe(
+			false,
+		);
+		expect(isCreditsExhaustedError(new Error("fetch failed"))).toBe(false);
+	});
+});
+
+describe("bucket disjointness on a 402", () => {
+	it("a 402 is credits-exhausted, not auth or rate-limit", () => {
+		const err = httpError(402, "insufficient credits");
+		expect(isCreditsExhaustedError(err)).toBe(true);
+		expect(isAuthError(err)).toBe(false);
+		expect(isRateLimitError(err)).toBe(false);
+	});
+});

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -86,6 +86,28 @@ export function isRateLimitError(error: unknown): boolean {
  * "something went wrong". Mirrors {@link isRateLimitError}: structured HTTP status
  * first, message-substring fallback second.
  */
+/**
+ * Detect credit exhaustion (402 insufficient_credits — the org's balance ran
+ * dry) so the failure reply can say "out of credits — top up" instead of the
+ * generic retry copy. Retrying is exactly wrong here: the drained-org retry
+ * loop is what #13665 killed server-side (#13962). Mirrors the siblings:
+ * structured HTTP status first, message-substring fallback second.
+ */
+export function isCreditsExhaustedError(error: unknown): boolean {
+	const unwrapped = unwrapRetryError(error);
+	if (hasHttpStatus(unwrapped, [402])) {
+		return true;
+	}
+	if (!(error instanceof Error)) return false;
+	const haystack = `${error.name} ${error.message}`.toLowerCase();
+	return (
+		haystack.includes("insufficient_credits") ||
+		haystack.includes("insufficient credits") ||
+		haystack.includes("payment required") ||
+		/\b402\b/.test(haystack)
+	);
+}
+
 export function isAuthError(error: unknown): boolean {
 	const unwrapped = unwrapRetryError(error);
 	if (hasHttpStatus(unwrapped, [401, 403])) {


### PR DESCRIPTION
Fixes #13962 (found live on the Seeker during the #13406 phone-surface run: drained org → chat says *'Something went wrong on my end. Please try again'* — retry-inviting copy for the exact failure where retrying is wrong, per #13665's server-side fix).

- **`isCreditsExhaustedError`** in `fallback-reply.ts`: structured HTTP 402 first, substring fallback (`insufficient_credits`, `payment required`, `\b402\b`) second — mirrors the 429/401 siblings exactly.
- **`creditsExhausted` attempt kind** in the failure cascade, classified after rate-limit, before the broader auth bucket (most-actionable-first). Copy: *"I'm out of Eliza Cloud credits, so I can't think right now — add credits to your account (Billing in the Eliza Cloud dashboard), then message me again."* — overridable via `character.templates.creditsExhaustedReply` like its siblings.
- Tests: classifier matches structured 402 + cloud error string, rejects 401/429/generic; bucket disjointness pinned (4/4 green).

On-device evidence chain on #13962/#13406 (logcat with balance 0.005125 + screenshots). [qa-agent]