### PR TITLE
test(orchestrator): opt stdout trace test into gate

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/subagent-stdout-log.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/subagent-stdout-log.test.ts
@@ -15,18 +15,22 @@ import {
 
 let tmpDir: string;
 const priorTrajDir = process.env.ELIZA_TRAJECTORY_DIR;
+const priorLogging = process.env.ELIZA_TRAJECTORY_LOGGING;
 const priorRecording = process.env.ELIZA_TRAJECTORY_RECORDING;
 
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "subagent-stdout-test-"));
   process.env.ELIZA_TRAJECTORY_DIR = tmpDir;
-  delete process.env.ELIZA_TRAJECTORY_RECORDING; // default ON
+  process.env.ELIZA_TRAJECTORY_LOGGING = "1";
+  delete process.env.ELIZA_TRAJECTORY_RECORDING;
 });
 
 afterEach(async () => {
   await fs.rm(tmpDir, { recursive: true, force: true });
   if (priorTrajDir === undefined) delete process.env.ELIZA_TRAJECTORY_DIR;
   else process.env.ELIZA_TRAJECTORY_DIR = priorTrajDir;
+  if (priorLogging === undefined) delete process.env.ELIZA_TRAJECTORY_LOGGING;
+  else process.env.ELIZA_TRAJECTORY_LOGGING = priorLogging;
   if (priorRecording === undefined)
     delete process.env.ELIZA_TRAJECTORY_RECORDING;
   else process.env.ELIZA_TRAJECTORY_RECORDING = priorRecording;
@@ -63,6 +67,7 @@ describe("appendSubagentStdout", () => {
   });
 
   it("no-ops (writes nothing, returns undefined) when recording is disabled", async () => {
+    delete process.env.ELIZA_TRAJECTORY_LOGGING;
     process.env.ELIZA_TRAJECTORY_RECORDING = "0";
     const returned = await appendSubagentStdout(
       "ses_off",


### PR DESCRIPTION
## Summary
- opt the subagent stdout trajectory-log unit test into the new `ELIZA_TRAJECTORY_LOGGING=1` gate
- restore the logging env after each test so the suite does not leak process state
- keep the legacy `ELIZA_TRAJECTORY_RECORDING=0` disabled-path assertion explicit by clearing the new gate first

## Evidence
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun test packages/core/src/runtime/trajectory-gate.test.ts packages/core/src/runtime/trace-correlation.test.ts packages/core/src/features/trajectories/trace-correlation-db.real.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/child-trajectory-ingest.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/subagent-stdout-log.test.ts`
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/__tests__/unit/subagent-stdout-log.test.ts --no-errors-on-unmatched`
- `git diff --check`

## Notes
- This is a focused #13775 guard repair. It does not claim the full live-LLM trajectory evidence/viewer acceptance for #13775 is complete.