### PR TITLE
test(#13920): real interleaving test for task workdir bind serialization

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
@@ -176,6 +176,61 @@ describe("durable task→workdir binding (#13776)", () => {
     }
   });
 
+  it("serializes two in-flight binds so the second observes the first's write (#13920)", async () => {
+    // Unlike the sequential stale-bind tests above, this fires both binds
+    // WITHOUT awaiting between them, so the second chains onto the first
+    // through `taskWorkdirBindQueues` while the first is still in flight —
+    // the exact overlap #13920's per-task serialization exists to make safe.
+    // Both callers hold the same unbound snapshot and target DIFFERENT
+    // workdir+repo pairs; without the queue both would read an unbound record
+    // and the later store write would clobber the earlier binding (a lost
+    // update). Serialized, the first-enqueued bind wins the workdir/repo and
+    // the second reads the freshly persisted record and declines to overwrite.
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const acp = makeWorkdirCapturingAcp();
+    const service = new OrchestratorTaskService(makeRuntime(acp.service), {
+      store,
+    });
+    await service.start();
+    try {
+      const taskId = await seedTask(store);
+      const unbound = (await store.getTask(taskId))?.task;
+      expect(unbound).toBeTruthy();
+      if (!unbound) throw new Error("seeded task was not persisted");
+      const bindTaskWorkdir = (
+        service as unknown as {
+          bindTaskWorkdir: (
+            taskId: string,
+            current: typeof unbound,
+            workdir: string,
+            repo: string | undefined,
+          ) => Promise<void>;
+        }
+      ).bindTaskWorkdir.bind(service);
+
+      await Promise.all([
+        bindTaskWorkdir(
+          taskId,
+          unbound,
+          firstDir,
+          "https://example.com/repo-a.git",
+        ),
+        bindTaskWorkdir(
+          taskId,
+          unbound,
+          overrideDir,
+          "https://example.com/repo-b.git",
+        ),
+      ]);
+
+      const record = await store.getTask(taskId);
+      expect(record?.task.boundWorkdir).toBe(firstDir);
+      expect(record?.task.boundRepo).toBe("https://example.com/repo-a.git");
+    } finally {
+      await service.stop().catch(() => undefined);
+    }
+  });
+
   it("does not let a stale same-workdir bind overwrite the first repo binding", async () => {
     const store = new OrchestratorTaskStore({ backend: "memory" });
     const acp = makeWorkdirCapturingAcp();


### PR DESCRIPTION
## Summary

Test-rigor follow-up to the merged #13947 / #13920 pair (serialize task→workdir binding + same-workdir repo correction). The existing stale-bind tests `await` each `bindTaskWorkdir` call **sequentially**, so the per-task `taskWorkdirBindQueues` chain is never exercised: the method's `finally` deletes the queue tail after each `await`, so the next call starts from an empty queue and passes purely on the fresh `latest` re-read — **even if the serialization queue were removed entirely.**

This adds one test that fires two binds **concurrently** (`Promise.all`, no await between them) from the same unbound snapshot targeting different `workdir`+`repo` pairs. The second bind is registered onto the queue while the first is still in flight, so it chains onto the first (`previous.then(...)`), reads the freshly persisted record, and declines to overwrite — proving the #13920 serialization prevents a lost update.

## Why the existing tests miss this

`OrchestratorTaskStore.updateTask` computes its patch from a `latest` snapshot read **outside** the store's own write-queue. Two concurrent binds can therefore both observe `boundWorkdir` unbound and issue conflicting patches; the store serializes the two writes but the later patch clobbers the earlier binding. `bindTaskWorkdir`'s per-task promise chain is what closes that window — and only a genuinely overlapping (non-awaited) pair drives it.

## Rigor / mutation proof

Neutered the serialization locally (`const previous = Promise.resolve();`, dropping the `taskWorkdirBindQueues.get(taskId)` chain) and re-ran:

- **only the new test fails** — `boundWorkdir`/`boundRepo` flip to the second pair (`repo-b`) instead of staying `repo-a`, the exact lost update the queue prevents.
- The seven pre-existing tests stay green under the mutation (they never exercise the queue), confirming the coverage gap this closes.

Reverted the mutation; committed the test only.

## Verification

- `bun test plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts` -> **8 pass, 0 fail, 32 expect() calls**
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts` -> pass; `git diff --check` -> clean
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` -> pass

## Evidence

- Test-only change to a service-layer durable-binding suite. N/A app screenshots/video (no UI path). N/A live-LLM trajectory (no planner/prompt/model behavior change).

Advances #13920. Follow-up to #13947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
