### PR TITLE
feat(knowledge): slice 3 — search-tag surfacing, attach-to-chat + send-to-someone, Help fold-in (#13595)

### DIFF
--- a/packages/agent/src/actions/knowledge.test.ts
+++ b/packages/agent/src/actions/knowledge.test.ts
@@ -119,20 +119,25 @@ function msg(entityId: UUID, roomId: UUID): Memory {
   } as Memory;
 }
 
-const call = (
-  action: typeof searchKnowledgeAction,
+const call = async (
+  action: { handler: typeof searchKnowledgeAction.handler },
   runtime: never,
   message: Memory,
   parameters: Record<string, unknown>,
   callback?: (c: unknown, k: string) => Promise<void>,
-) =>
-  action.handler(
+) => {
+  const result = await action.handler(
     runtime,
     message,
     undefined as never,
     { parameters } as never,
     callback as never,
   );
+  if (!result) {
+    throw new Error("Knowledge action did not return an action result.");
+  }
+  return result;
+};
 
 describe("SEARCH_KNOWLEDGE", () => {
   it("free-text search surfaces readable items", async () => {

--- a/packages/agent/src/actions/knowledge.test.ts
+++ b/packages/agent/src/actions/knowledge.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Unit tests for the three global knowledge actions (#13595 / #13974):
+ * SEARCH_KNOWLEDGE, ATTACH_TO_CHAT, SEND_MEDIA_TO. Focus is the scope wall +
+ * the shaw-codex draft blockers:
+ *
+ *  - SEARCH_KNOWLEDGE: free-text AND filter-only (tag/facet) surfacing both work,
+ *    and an owner-private/user-private item is NOT surfaced into a public active
+ *    room even for an OWNER actor (active-room surfacing wall).
+ *  - ATTACH_TO_CHAT: reports FAILURE (not success) when no chat callback is
+ *    supplied, and refuses a private item into a public active room.
+ *  - SEND_MEDIA_TO: refuses an owner-private/user-private item into a public
+ *    target room INCLUDING a THREAD (previously omitted from the public set),
+ *    and fails closed for an unresolvable target room.
+ */
+import { ChannelType, type Memory, type UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  attachToChatAction,
+  searchKnowledgeAction,
+  sendMediaToAction,
+} from "./knowledge.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const OWNER_ENTITY = "00000000-0000-0000-0000-0000000000b1" as UUID;
+const USER_ENTITY = "00000000-0000-0000-0000-0000000000c2" as UUID;
+const DM_ROOM = "00000000-0000-0000-0000-0000000000e1" as UUID;
+const PUBLIC_ROOM = "00000000-0000-0000-0000-0000000000e2" as UUID;
+const THREAD_ROOM = "00000000-0000-0000-0000-0000000000e3" as UUID;
+const DOC_OWNER_PRIVATE = "00000000-0000-0000-0000-0000000000f1" as UUID;
+const DOC_USER_PRIVATE = "00000000-0000-0000-0000-0000000000f2" as UUID;
+const DOC_GLOBAL = "00000000-0000-0000-0000-0000000000f3" as UUID;
+
+const STORED_PDF_URL =
+  "/api/media/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.pdf";
+
+type DocRecord = {
+  id: UUID;
+  content: { text?: string };
+  metadata: Record<string, unknown>;
+  agentId?: UUID;
+};
+
+function doc(
+  id: UUID,
+  scope: string,
+  extra: Record<string, unknown> = {},
+): DocRecord {
+  return {
+    id,
+    content: { text: `body of ${id}` },
+    agentId: AGENT_ID,
+    metadata: {
+      type: "document",
+      documentId: id,
+      title: `title-${id}`,
+      scope,
+      mediaUrl: STORED_PDF_URL,
+      mediaMimeType: "application/pdf",
+      addedBy: scope === "owner-private" ? OWNER_ENTITY : USER_ENTITY,
+      scopedToEntityId: scope === "user-private" ? USER_ENTITY : undefined,
+      tags: ["attachment", "media-format:pdf"],
+      ...extra,
+    },
+  };
+}
+
+const CORPUS: DocRecord[] = [
+  doc(DOC_OWNER_PRIVATE, "owner-private"),
+  doc(DOC_USER_PRIVATE, "user-private"),
+  doc(DOC_GLOBAL, "global"),
+];
+
+function makeService(records: DocRecord[] = CORPUS) {
+  return {
+    searchDocuments: vi.fn(async () => records),
+    getMemories: vi.fn(async ({ offset = 0 }: { offset?: number }) =>
+      offset === 0 ? records : [],
+    ),
+    getDocumentById: vi.fn(
+      async (id: UUID) => records.find((r) => r.id === id) ?? null,
+    ),
+    countMemories: vi.fn(async () => records.length),
+  };
+}
+
+type RoomShape = { type: ChannelType; source?: string };
+
+function makeRuntime(opts: {
+  service: ReturnType<typeof makeService>;
+  rooms?: Record<string, RoomShape>;
+  sendMessageToTarget?: ReturnType<typeof vi.fn>;
+}) {
+  const rooms: Record<string, RoomShape> = opts.rooms ?? {
+    [DM_ROOM]: { type: ChannelType.DM },
+    [PUBLIC_ROOM]: { type: ChannelType.GROUP, source: "discord" },
+    [THREAD_ROOM]: { type: ChannelType.THREAD, source: "discord" },
+  };
+  return {
+    agentId: AGENT_ID,
+    getSetting: (k: string) =>
+      k === "ELIZA_ADMIN_ENTITY_ID" ? OWNER_ENTITY : undefined,
+    getService: (name: string) => (name === "documents" ? opts.service : null),
+    getRoom: async (id: UUID) => rooms[id] ?? null,
+    getMemoryById: async (id: UUID) =>
+      opts.service.getDocumentById(id) as unknown as Memory | null,
+    sendMessageToTarget:
+      opts.sendMessageToTarget ?? vi.fn(async () => ({ id: "sent-1" })),
+  } as never;
+}
+
+function msg(entityId: UUID, roomId: UUID): Memory {
+  return {
+    id: "00000000-0000-0000-0000-0000000000ff" as UUID,
+    entityId,
+    agentId: AGENT_ID,
+    roomId,
+    content: { text: "" },
+    createdAt: Date.now(),
+  } as Memory;
+}
+
+const call = (
+  action: typeof searchKnowledgeAction,
+  runtime: never,
+  message: Memory,
+  parameters: Record<string, unknown>,
+  callback?: (c: unknown, k: string) => Promise<void>,
+) =>
+  action.handler(
+    runtime,
+    message,
+    undefined as never,
+    { parameters } as never,
+    callback as never,
+  );
+
+describe("SEARCH_KNOWLEDGE", () => {
+  it("free-text search surfaces readable items", async () => {
+    const runtime = makeRuntime({ service: makeService() });
+    const res = await call(
+      searchKnowledgeAction,
+      runtime,
+      msg(OWNER_ENTITY, DM_ROOM),
+      {
+        query: "body",
+      },
+    );
+    expect(res.success).toBe(true);
+    expect((res.data as { count: number }).count).toBeGreaterThan(0);
+  });
+
+  it("filter-only (no free text) surfacing works — the slice-3 tag search", async () => {
+    const runtime = makeRuntime({ service: makeService() });
+    const res = await call(
+      searchKnowledgeAction,
+      runtime,
+      msg(OWNER_ENTITY, DM_ROOM),
+      {
+        tags: ["media-format:pdf"],
+      },
+    );
+    expect(res.success).toBe(true);
+    expect((res.data as { count: number }).count).toBeGreaterThan(0);
+  });
+
+  it("rejects a request with neither query nor any filter", async () => {
+    const runtime = makeRuntime({ service: makeService() });
+    const res = await call(
+      searchKnowledgeAction,
+      runtime,
+      msg(OWNER_ENTITY, DM_ROOM),
+      {},
+    );
+    expect(res.success).toBe(false);
+    expect((res.data as { error: string }).error).toBe("KNOWLEDGE_INVALID");
+  });
+
+  it("owner-private item does NOT surface into a PUBLIC active room even for the OWNER", async () => {
+    const runtime = makeRuntime({ service: makeService() });
+    const res = await call(
+      searchKnowledgeAction,
+      runtime,
+      msg(OWNER_ENTITY, PUBLIC_ROOM),
+      {
+        query: "body",
+      },
+    );
+    const items = (res.data as { items: Array<{ id: UUID }> }).items;
+    expect(items.some((i) => i.id === DOC_OWNER_PRIVATE)).toBe(false);
+    expect(items.some((i) => i.id === DOC_USER_PRIVATE)).toBe(false);
+    // global is fine
+    expect(items.some((i) => i.id === DOC_GLOBAL)).toBe(true);
+  });
+
+  it("in a DM active room the OWNER can see their owner-private items", async () => {
+    const runtime = makeRuntime({ service: makeService() });
+    const res = await call(
+      searchKnowledgeAction,
+      runtime,
+      msg(OWNER_ENTITY, DM_ROOM),
+      {
+        query: "body",
+      },
+    );
+    const items = (res.data as { items: Array<{ id: UUID }> }).items;
+    expect(items.some((i) => i.id === DOC_OWNER_PRIVATE)).toBe(true);
+  });
+});
+
+describe("ATTACH_TO_CHAT", () => {
+  it("fails (not success) when no chat callback is supplied", async () => {
+    const runtime = makeRuntime({ service: makeService() });
+    const res = await call(
+      attachToChatAction,
+      runtime,
+      msg(OWNER_ENTITY, DM_ROOM),
+      { itemId: DOC_GLOBAL },
+      // no callback
+    );
+    expect(res.success).toBe(false);
+    expect((res.data as { error: string }).error).toBe("ATTACH_NO_CALLBACK");
+  });
+
+  it("attaches a readable global item when a callback is present", async () => {
+    const runtime = makeRuntime({ service: makeService() });
+    const cb = vi.fn(async () => {});
+    const res = await call(
+      attachToChatAction,
+      runtime,
+      msg(OWNER_ENTITY, DM_ROOM),
+      { itemId: DOC_GLOBAL },
+      cb,
+    );
+    expect(res.success).toBe(true);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses an owner-private item into a PUBLIC active room even with a callback", async () => {
+    const runtime = makeRuntime({ service: makeService() });
+    const cb = vi.fn(async () => {});
+    const res = await call(
+      attachToChatAction,
+      runtime,
+      msg(OWNER_ENTITY, PUBLIC_ROOM),
+      { itemId: DOC_OWNER_PRIVATE },
+      cb,
+    );
+    expect(res.success).toBe(false);
+    expect((res.data as { error: string }).error).toBe("ATTACH_SCOPE_REFUSED");
+    expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+describe("SEND_MEDIA_TO", () => {
+  it("refuses an owner-private item into a PUBLIC (GROUP) target room", async () => {
+    const send = vi.fn(async () => ({ id: "x" }));
+    const runtime = makeRuntime({
+      service: makeService(),
+      sendMessageToTarget: send,
+    });
+    const res = await call(
+      sendMediaToAction,
+      runtime,
+      msg(OWNER_ENTITY, DM_ROOM),
+      {
+        itemId: DOC_OWNER_PRIVATE,
+        roomId: PUBLIC_ROOM,
+      },
+    );
+    expect(res.success).toBe(false);
+    expect((res.data as { error: string }).error).toBe("SEND_SCOPE_REFUSED");
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("refuses a private item into a THREAD (previously omitted from the public set)", async () => {
+    const send = vi.fn(async () => ({ id: "x" }));
+    const runtime = makeRuntime({
+      service: makeService(),
+      sendMessageToTarget: send,
+    });
+    const res = await call(
+      sendMediaToAction,
+      runtime,
+      msg(OWNER_ENTITY, DM_ROOM),
+      {
+        itemId: DOC_OWNER_PRIVATE,
+        roomId: THREAD_ROOM,
+      },
+    );
+    expect(res.success).toBe(false);
+    expect((res.data as { error: string }).error).toBe("SEND_SCOPE_REFUSED");
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("fails CLOSED for an unresolvable target room (treated as public)", async () => {
+    const send = vi.fn(async () => ({ id: "x" }));
+    const runtime = makeRuntime({
+      service: makeService(),
+      rooms: {},
+      sendMessageToTarget: send,
+    });
+    const res = await call(
+      sendMediaToAction,
+      runtime,
+      msg(OWNER_ENTITY, DM_ROOM),
+      {
+        itemId: DOC_OWNER_PRIVATE,
+        roomId: PUBLIC_ROOM,
+      },
+    );
+    expect(res.success).toBe(false);
+    expect((res.data as { error: string }).error).toBe("SEND_SCOPE_REFUSED");
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("sends a global item into a public room (dispatch fires, typed ok)", async () => {
+    const send = vi.fn(async () => ({ id: "sent-9" }));
+    const runtime = makeRuntime({
+      service: makeService(),
+      sendMessageToTarget: send,
+    });
+    const res = await call(
+      sendMediaToAction,
+      runtime,
+      msg(OWNER_ENTITY, DM_ROOM),
+      {
+        itemId: DOC_GLOBAL,
+        roomId: PUBLIC_ROOM,
+      },
+    );
+    expect(res.success).toBe(true);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect((res.data as { dispatch: { ok: boolean } }).dispatch.ok).toBe(true);
+  });
+});

--- a/packages/agent/src/actions/knowledge.ts
+++ b/packages/agent/src/actions/knowledge.ts
@@ -22,7 +22,6 @@
 import {
   type Action,
   type ActionResult,
-  ChannelType,
   type Content,
   type HandlerCallback,
   type HandlerOptions,
@@ -37,15 +36,18 @@ import {
   asUuid,
   canReadDocumentMemory,
   canSendDocumentToPublic,
+  canSurfaceDocumentInRoom,
   type DocumentFilter,
   documentMediaFormat,
   documentTags,
   matchesDocumentFilter,
   type RouteActor,
   type RouteActorRole,
+  roomIsPublicSurface,
 } from "../api/document-access.ts";
 import {
   type DocumentSearchMode,
+  type DocumentsServiceLike,
   getDocumentsService,
 } from "../api/documents-service-loader.ts";
 
@@ -65,16 +67,28 @@ type DispatchResult =
     };
 
 const MEDIA_URL_PREFIX = "/api/media/";
-const PUBLIC_ROOM_TYPES = new Set<ChannelType>([
-  ChannelType.GROUP,
-  ChannelType.VOICE_GROUP,
-  ChannelType.FEED,
-  ChannelType.FORUM,
-  ChannelType.WORLD,
-]);
 
 function fail(text: string, error: string): ActionResult {
   return { success: false, text, data: { error } };
+}
+
+/**
+ * Classify the room a message came from / is targeted at as a public/community
+ * surface. Resolves the room and routes through the SINGLE canonical
+ * classifier (`roomIsPublicSurface`) so the send wall, the active-room surfacing
+ * wall, and the ingest spill guard all agree — including on THREAD, which a
+ * hand-rolled public-types allowlist previously omitted (shaw-codex review).
+ * An unresolvable room fails CLOSED (treated as public) so a missing room record
+ * can never be the reason a private item leaks.
+ */
+async function roomIsPublic(
+  runtime: IAgentRuntime,
+  roomId: UUID | undefined,
+): Promise<boolean> {
+  if (!roomId) return true;
+  const room = await runtime.getRoom(roomId);
+  if (!room) return true;
+  return roomIsPublicSurface(room.type);
 }
 
 /**
@@ -243,6 +257,88 @@ function mediaFromItem(item: {
   };
 }
 
+/** A retrieved knowledge record, from either the semantic or facet path. */
+type KnowledgeSearchRow = {
+  id: UUID;
+  content: { text?: string };
+  similarity?: number;
+  metadata?: Record<string, unknown>;
+};
+
+/** How many document rows to pull per scan batch in the facet-list path. */
+const DOCUMENT_SCAN_BATCH = 200;
+/** Cap the facet scan so a huge corpus can't unbounded-loop an action. */
+const DOCUMENT_SCAN_MAX = 2000;
+
+/**
+ * Free-text retrieval path: semantic/hybrid search over the document store,
+ * scoped by the facet room/entity the same way the REST search route scopes it.
+ */
+async function searchByQuery(
+  service: DocumentsServiceLike,
+  runtime: IAgentRuntime,
+  actor: RouteActor,
+  query: string,
+  filters: DocumentFilter,
+  searchMode: DocumentSearchMode | undefined,
+): Promise<KnowledgeSearchRow[]> {
+  const searchMessage: Memory = {
+    id: crypto.randomUUID() as UUID,
+    entityId: actor.entityId,
+    agentId: runtime.agentId,
+    roomId: (filters.roomId ?? runtime.agentId) as UUID,
+    content: { text: query },
+    createdAt: Date.now(),
+  };
+  const scope: { roomId?: UUID; entityId?: UUID } = {};
+  if (filters.scopedToEntityId) scope.entityId = filters.scopedToEntityId;
+  if (filters.roomId) scope.roomId = filters.roomId;
+  return service.searchDocuments(
+    searchMessage,
+    Object.keys(scope).length > 0 ? scope : undefined,
+    searchMode,
+  );
+}
+
+/**
+ * Filter-only retrieval path (#13595 tag/facet surfacing): scan the documents
+ * table and return every record, letting the caller's shared
+ * `matchesDocumentFilter` + wall filters narrow it. There is no meaningful
+ * embedding for an empty query, so a facet-only request lists by scan instead of
+ * semantic search — the same approach the REST `/api/documents` list route uses.
+ */
+async function listByFacets(
+  service: DocumentsServiceLike,
+  agentId: UUID,
+  _actor: RouteActor,
+  _filters: DocumentFilter,
+): Promise<KnowledgeSearchRow[]> {
+  const rows: KnowledgeSearchRow[] = [];
+  let offset = 0;
+  while (offset < DOCUMENT_SCAN_MAX) {
+    const batch = await service.getMemories({
+      tableName: "documents",
+      count: DOCUMENT_SCAN_BATCH,
+      offset,
+    });
+    if (batch.length === 0) break;
+    for (const memory of batch) {
+      const meta = asRecord(memory.metadata);
+      // Only real document memories for this agent (mirrors isDocumentMemory).
+      if (meta?.type !== "document" && meta?.documentId === undefined) continue;
+      if (memory.agentId && memory.agentId !== agentId) continue;
+      rows.push({
+        id: memory.id as UUID,
+        content: { text: memory.content?.text },
+        metadata: meta,
+      });
+    }
+    if (batch.length < DOCUMENT_SCAN_BATCH) break;
+    offset += DOCUMENT_SCAN_BATCH;
+  }
+  return rows;
+}
+
 export const searchKnowledgeAction: Action = {
   name: "SEARCH_KNOWLEDGE",
   contexts: ["knowledge", "documents", "files", "media", "agent_internal"],
@@ -270,7 +366,6 @@ export const searchKnowledgeAction: Action = {
     const params = ((options as HandlerOptions | undefined)?.parameters ??
       {}) as Record<string, unknown>;
     const query = typeof params.query === "string" ? params.query.trim() : "";
-    if (!query) return fail("A search query is required.", "KNOWLEDGE_INVALID");
 
     const { service, reason } = await getDocumentsService(
       runtime as unknown as Parameters<typeof getDocumentsService>[0],
@@ -284,34 +379,48 @@ export const searchKnowledgeAction: Action = {
 
     const actor = actorFromMessage(runtime, message);
     const filters = filtersFromParams(params);
+    // Filter-only surfacing (#13595): a tag/room/sender/media-format query with
+    // no free text is valid — it lists every item matching those facets. Only a
+    // completely empty request (no text AND no facet) is rejected.
+    const hasFilter =
+      Boolean(filters.scope) ||
+      Boolean(filters.roomId) ||
+      Boolean(filters.addedBy) ||
+      Boolean(filters.mediaFormat) ||
+      Boolean(filters.tags && filters.tags.length > 0);
+    if (!query && !hasFilter) {
+      return fail(
+        "A search query or at least one filter (tags, room, sender, or media format) is required.",
+        "KNOWLEDGE_INVALID",
+      );
+    }
+
     const limit =
       typeof params.limit === "number" && Number.isFinite(params.limit)
         ? Math.max(1, Math.min(50, Math.floor(params.limit)))
         : 10;
     const searchMode = parseSearchMode(params.searchMode);
 
-    const searchMessage: Memory = {
-      id: crypto.randomUUID() as UUID,
-      entityId: actor.entityId,
-      agentId: runtime.agentId,
-      roomId: (message.roomId ?? runtime.agentId) as UUID,
-      content: { text: query },
-      createdAt: Date.now(),
-    };
-
-    const scope: { roomId?: UUID; entityId?: UUID } = {};
-    if (filters.scopedToEntityId) scope.entityId = filters.scopedToEntityId;
-    if (filters.roomId) scope.roomId = filters.roomId;
-
-    const results = await service.searchDocuments(
-      searchMessage,
-      Object.keys(scope).length > 0 ? scope : undefined,
-      searchMode,
+    // The surfacing wall (#13974): SEARCH renders snippets INTO the active room.
+    // If that room is a public/community surface, owner-private and user-private
+    // items must be dropped even for an OWNER actor, or the private snippet
+    // spills to every participant. Private (DM-like) active rooms are open.
+    const activeRoomIsPublic = await roomIsPublic(
+      runtime,
+      message.roomId as UUID | undefined,
     );
 
-    const items = results
+    // Two retrieval paths that converge on the same facet + wall filtering:
+    //  - free text  -> semantic/hybrid searchDocuments
+    //  - filter-only -> scan the documents table (no meaningful vector for "")
+    const raw = query
+      ? await searchByQuery(service, runtime, actor, query, filters, searchMode)
+      : await listByFacets(service, runtime.agentId, actor, filters);
+
+    const items = raw
       .filter((r) => matchesDocumentFilter(r, { ...filters, query: undefined }))
       .filter((r) => canReadDocumentMemory(r, actor, filters))
+      .filter((r) => canSurfaceDocumentInRoom(r, activeRoomIsPublic).ok)
       .slice(0, limit)
       .map((r) => {
         const meta = asRecord(r.metadata);
@@ -328,8 +437,9 @@ export const searchKnowledgeAction: Action = {
         };
       });
 
+    const label = query ? `for "${query}"` : "for those filters";
     const text = items.length
-      ? `Found ${items.length} knowledge item(s) for "${query}":\n${items
+      ? `Found ${items.length} knowledge item(s) ${label}:\n${items
           .map(
             (it, i) =>
               `${i + 1}. ${it.title}${
@@ -337,10 +447,10 @@ export const searchKnowledgeAction: Action = {
               } — ${it.snippet}`,
           )
           .join("\n")}`
-      : `No knowledge items match "${query}".`;
+      : `No knowledge items match ${label}.`;
 
     logger.info(
-      `[SEARCH_KNOWLEDGE] query="${query}" role=${actor.role} matched=${items.length}`,
+      `[SEARCH_KNOWLEDGE] query="${query}" role=${actor.role} activeRoomPublic=${activeRoomIsPublic} matched=${items.length}`,
     );
     return {
       success: true,
@@ -353,8 +463,9 @@ export const searchKnowledgeAction: Action = {
   parameters: [
     {
       name: "query",
-      description: "Free-text search over knowledge titles + content",
-      required: true,
+      description:
+        "Free-text search over knowledge titles + content. Optional: a facet-only search (tags/room/sender/media-format) with no free text lists every matching item.",
+      required: false,
       schema: { type: "string" as const },
     },
     {
@@ -381,6 +492,19 @@ export const searchKnowledgeAction: Action = {
       description: "Optional tag list (array or comma-separated)",
       required: false,
       schema: { type: "array" as const, items: { type: "string" as const } },
+    },
+    {
+      name: "scope",
+      description:
+        "Optional scope facet: global | owner-private | user-private | agent-private",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "searchMode",
+      description: "Optional retrieval mode: hybrid | vector | keyword",
+      required: false,
+      schema: { type: "string" as const },
     },
     {
       name: "limit",
@@ -443,6 +567,27 @@ export const attachToChatAction: Action = {
       );
     }
 
+    // Surfacing wall (#13974): ATTACH delivers the media INTO the active room.
+    // A private item may be readable by an OWNER actor yet must never be
+    // attached into a public/community room where other participants see it.
+    const activeRoomIsPublic = await roomIsPublic(
+      runtime,
+      message.roomId as UUID | undefined,
+    );
+    const surface = canSurfaceDocumentInRoom(item.memory, activeRoomIsPublic);
+    if (!surface.ok) {
+      logger.warn(
+        `[ATTACH_TO_CHAT] refused ${surface.scope} item into public active room ${message.roomId}`,
+      );
+      return {
+        success: false,
+        text: surface.reason,
+        userFacingText: surface.reason,
+        verifiedUserFacing: true,
+        data: { error: "ATTACH_SCOPE_REFUSED", scope: surface.scope },
+      };
+    }
+
     const media = mediaFromItem(item);
     if (!media) {
       return fail(
@@ -451,11 +596,21 @@ export const attachToChatAction: Action = {
       );
     }
 
+    // B1 (#13974): without a chat callback there is no channel to deliver the
+    // attachment on, so the action CANNOT have succeeded. Report a typed failure
+    // instead of a false success the model would relay as "attached".
+    if (!callback) {
+      return fail(
+        "No chat callback is available to attach into; ATTACH_TO_CHAT needs an active conversation. Use SEND_MEDIA_TO to deliver to a specific room.",
+        "ATTACH_NO_CALLBACK",
+      );
+    }
+
     const content: Content = {
       text: `Attached: ${item.title}`,
       attachments: [media],
     };
-    if (callback) await callback(content, "ATTACH_TO_CHAT");
+    await callback(content, "ATTACH_TO_CHAT");
 
     logger.info(
       `[ATTACH_TO_CHAT] item="${item.title}" url=${media.url} role=${actor.role}`,
@@ -535,9 +690,12 @@ export const sendMediaToAction: Action = {
     }
 
     const targetRoom = await runtime.getRoom(targetRoomId);
+    // Classify via the canonical surface classifier (includes THREAD) and fail
+    // CLOSED for an unresolvable room: an unknown room is treated as public so a
+    // missing room record can never be the reason a private item is sent out.
     const targetIsPublic = targetRoom
-      ? PUBLIC_ROOM_TYPES.has(targetRoom.type)
-      : false;
+      ? roomIsPublicSurface(targetRoom.type)
+      : true;
     const wall = canSendDocumentToPublic(item.memory, targetIsPublic);
     if (!wall.ok) {
       logger.warn(

--- a/packages/agent/src/actions/knowledge.ts
+++ b/packages/agent/src/actions/knowledge.ts
@@ -1,0 +1,640 @@
+/**
+ * The three globally-available knowledge actions (#13595) that let the agent do
+ * everything the Knowledge hub's UI affordances do — from any view, not just the
+ * Knowledge view:
+ *
+ *   - SEARCH_KNOWLEDGE — semantic + facet search across the multimedia hub
+ *     (docs, transcripts, ingested attachments), scope-walled so an owner-private
+ *     item never surfaces to a public-room actor.
+ *   - ATTACH_TO_CHAT — resolve a stored item to its content-addressed media URL
+ *     and deliver it into the ACTIVE conversation via the handler callback (the
+ *     agent-side of the reader/list "Attach to chat" button).
+ *   - SEND_MEDIA_TO — DM/send a stored item's media to a target room through the
+ *     runtime's connector dispatch (`sendMessageToTarget`), mapping the outcome
+ *     to a typed `DispatchResult` and REFUSING an owner-/user-private item into a
+ *     public room via the shared send wall.
+ *
+ * All three resolve items and enforce scope through `@elizaos/agent/api/document-access`
+ * — the same wall the REST routes use — so the two surfaces cannot drift. They
+ * live in `@elizaos/agent` (always-loaded) rather than the support-only
+ * `@elizaos/plugin-documents` so they are genuinely global.
+ */
+import {
+  type Action,
+  type ActionResult,
+  type Content,
+  ChannelType,
+  type HandlerCallback,
+  type HandlerOptions,
+  type IAgentRuntime,
+  logger,
+  type Media,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import {
+  asRecord,
+  asUuid,
+  canReadDocumentMemory,
+  canSendDocumentToPublic,
+  type DocumentFilter,
+  documentMediaFormat,
+  documentTags,
+  matchesDocumentFilter,
+  type RouteActor,
+  type RouteActorRole,
+} from "../api/document-access.ts";
+import {
+  type DocumentSearchMode,
+  getDocumentsService,
+} from "../api/documents-service-loader.ts";
+
+type DispatchResult =
+  | { ok: true; messageId?: string }
+  | {
+      ok: false;
+      reason:
+        | "disconnected"
+        | "rate_limited"
+        | "auth_expired"
+        | "unknown_recipient"
+        | "transport_error";
+      retryAfterMinutes?: number;
+      userActionable: boolean;
+      message?: string;
+    };
+
+const MEDIA_URL_PREFIX = "/api/media/";
+const PUBLIC_ROOM_TYPES = new Set<ChannelType>([
+  ChannelType.GROUP,
+  ChannelType.VOICE_GROUP,
+  ChannelType.FEED,
+  ChannelType.FORUM,
+  ChannelType.WORLD,
+]);
+
+function fail(text: string, error: string): ActionResult {
+  return { success: false, text, data: { error } };
+}
+
+/**
+ * The requester's authorization role for the scope wall, derived from the
+ * triggering message: the configured owner entity is OWNER, the agent itself is
+ * AGENT, everyone else is USER. Mirrors the header-derived role the REST routes
+ * resolve so both surfaces enforce the same wall.
+ */
+function actorFromMessage(runtime: IAgentRuntime, message: Memory): RouteActor {
+  const agentId = runtime.agentId;
+  const ownerEntityId = asUuid(runtime.getSetting?.("ELIZA_ADMIN_ENTITY_ID"));
+  const entityId = (message.entityId ?? agentId) as UUID;
+  let role: RouteActorRole = "USER";
+  if (entityId === agentId) role = "AGENT";
+  else if (ownerEntityId && entityId === ownerEntityId) role = "OWNER";
+  return { entityId, role, ownerEntityId };
+}
+
+function parseSearchMode(value: unknown): DocumentSearchMode | undefined {
+  return value === "hybrid" || value === "vector" || value === "keyword"
+    ? value
+    : undefined;
+}
+
+function normalizeTags(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    const tags = value.filter(
+      (v): v is string => typeof v === "string" && v.trim().length > 0,
+    );
+    return tags.length > 0 ? tags : undefined;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value
+      .split(",")
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
+  }
+  return undefined;
+}
+
+function filtersFromParams(params: Record<string, unknown>): DocumentFilter {
+  const filters: DocumentFilter = {};
+  const scope = params.scope;
+  if (
+    scope === "global" ||
+    scope === "owner-private" ||
+    scope === "user-private" ||
+    scope === "agent-private"
+  ) {
+    filters.scope = scope;
+  }
+  const roomId = asUuid(params.roomId);
+  if (roomId) filters.roomId = roomId;
+  const addedBy = asUuid(params.addedBy ?? params.sender);
+  if (addedBy) filters.addedBy = addedBy;
+  const mediaFormat =
+    typeof params.mediaFormat === "string"
+      ? params.mediaFormat
+      : typeof params.format === "string"
+        ? params.format
+        : undefined;
+  if (mediaFormat) filters.mediaFormat = mediaFormat.toLowerCase();
+  const tags = normalizeTags(params.tags);
+  if (tags) filters.tags = tags;
+  return filters;
+}
+
+/**
+ * Resolve a knowledge item to a `{ memory, mediaUrl, mimeType, title }` handle
+ * by document id OR by the sha256 media filename/url it was ingested from. The
+ * memory carries the scope metadata the wall reads; `mediaUrl` is the durable
+ * `/api/media/<sha256>` link the ingest pipeline stored on the record.
+ */
+async function resolveItem(
+  runtime: IAgentRuntime,
+  itemRef: string,
+): Promise<
+  | {
+      memory: Memory;
+      mediaUrl?: string;
+      mimeType?: string;
+      title: string;
+    }
+  | null
+> {
+  const { service } = await getDocumentsService(
+    runtime as unknown as Parameters<typeof getDocumentsService>[0],
+  );
+  const asId = asUuid(itemRef);
+  let memory: Memory | null = null;
+  if (asId) {
+    memory =
+      (await service?.getDocumentById?.(asId)) ??
+      (await runtime.getMemoryById(asId));
+  }
+  if (!memory) {
+    // Fall back to a sha256 media reference: an item may be named by the media
+    // it was ingested from rather than its document id.
+    const fileName = mediaFileNameFromRef(itemRef);
+    if (fileName && service) {
+      const docs = await service.getMemories({
+        tableName: "documents",
+        count: 1000,
+      });
+      memory =
+        docs.find((doc) => {
+          const meta = asRecord(doc.metadata);
+          return (
+            meta?.mediaFileName === fileName ||
+            (typeof meta?.mediaUrl === "string" &&
+              meta.mediaUrl.endsWith(fileName))
+          );
+        }) ?? null;
+    }
+  }
+  if (!memory) return null;
+  const meta = asRecord(memory.metadata);
+  const mediaUrl =
+    typeof meta?.mediaUrl === "string" ? meta.mediaUrl : undefined;
+  const mimeType =
+    typeof meta?.mediaMimeType === "string"
+      ? meta.mediaMimeType
+      : typeof meta?.contentType === "string"
+        ? meta.contentType
+        : undefined;
+  const title =
+    (typeof meta?.title === "string" && meta.title) ||
+    (typeof meta?.filename === "string" && meta.filename) ||
+    (typeof meta?.originalFilename === "string" && meta.originalFilename) ||
+    "knowledge item";
+  return { memory, mediaUrl, mimeType, title };
+}
+
+function mediaFileNameFromRef(ref: string): string | null {
+  const trimmed = ref.trim();
+  if (!trimmed) return null;
+  const withoutPrefix = trimmed.startsWith(MEDIA_URL_PREFIX)
+    ? trimmed.slice(MEDIA_URL_PREFIX.length)
+    : trimmed.split("/").pop() ?? trimmed;
+  // sha256 (64 hex) + extension, e.g. "ab12….pdf"
+  return /^[0-9a-f]{64}\.[a-z0-9]+$/i.test(withoutPrefix)
+    ? withoutPrefix
+    : null;
+}
+
+function contentTypeFromMime(mime: string | undefined): Media["contentType"] {
+  if (!mime) return undefined;
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("video/")) return "video";
+  if (mime.startsWith("audio/")) return "audio";
+  return "document";
+}
+
+function mediaFromItem(item: {
+  memory: Memory;
+  mediaUrl?: string;
+  mimeType?: string;
+  title: string;
+}): Media | null {
+  if (!item.mediaUrl) return null;
+  return {
+    id: (item.memory.id ?? crypto.randomUUID()) as string,
+    url: item.mediaUrl,
+    title: item.title,
+    source: "knowledge",
+    ...(contentTypeFromMime(item.mimeType)
+      ? { contentType: contentTypeFromMime(item.mimeType) }
+      : {}),
+  };
+}
+
+export const searchKnowledgeAction: Action = {
+  name: "SEARCH_KNOWLEDGE",
+  contexts: ["knowledge", "documents", "files", "media", "agent_internal"],
+  similes: [
+    "FIND_KNOWLEDGE",
+    "SEARCH_DOCS",
+    "SEARCH_FILES",
+    "SEARCH_TRANSCRIPTS",
+    "FIND_DOCUMENT",
+    "LOOKUP_KNOWLEDGE",
+  ],
+  description:
+    "Search the multimedia knowledge hub (documents, transcripts, ingested attachments) by free text plus optional facets (roomId, sender/addedBy, mediaFormat, tags, scope). Returns matching items with their titles, media formats, and ids for follow-up ATTACH_TO_CHAT / SEND_MEDIA_TO. Scope-walled: owner-private items never surface to non-owner callers.",
+  descriptionCompressed:
+    "semantic + facet search over the knowledge hub; returns items (scope-walled)",
+  routingHint:
+    "search stored knowledge/documents/transcripts/attachments (by text or by room/sender/media-format/tag) -> SEARCH_KNOWLEDGE; to put a found item INTO this chat -> ATTACH_TO_CHAT; to DM/send it to a contact/room -> SEND_MEDIA_TO",
+  validate: async () => true,
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state,
+    options,
+  ): Promise<ActionResult> => {
+    const params = ((options as HandlerOptions | undefined)?.parameters ??
+      {}) as Record<string, unknown>;
+    const query =
+      typeof params.query === "string" ? params.query.trim() : "";
+    if (!query) return fail("A search query is required.", "KNOWLEDGE_INVALID");
+
+    const { service, reason } = await getDocumentsService(
+      runtime as unknown as Parameters<typeof getDocumentsService>[0],
+    );
+    if (!service) {
+      return fail(
+        "Knowledge store is not available.",
+        `KNOWLEDGE_NO_SERVICE_${reason ?? "unknown"}`.toUpperCase(),
+      );
+    }
+
+    const actor = actorFromMessage(runtime, message);
+    const filters = filtersFromParams(params);
+    const limit =
+      typeof params.limit === "number" && Number.isFinite(params.limit)
+        ? Math.max(1, Math.min(50, Math.floor(params.limit)))
+        : 10;
+    const searchMode = parseSearchMode(params.searchMode);
+
+    const searchMessage: Memory = {
+      id: crypto.randomUUID() as UUID,
+      entityId: actor.entityId,
+      agentId: runtime.agentId,
+      roomId: (message.roomId ?? runtime.agentId) as UUID,
+      content: { text: query },
+      createdAt: Date.now(),
+    };
+
+    const scope: { roomId?: UUID; entityId?: UUID } = {};
+    if (filters.scopedToEntityId) scope.entityId = filters.scopedToEntityId;
+    if (filters.roomId) scope.roomId = filters.roomId;
+
+    const results = await service.searchDocuments(
+      searchMessage,
+      Object.keys(scope).length > 0 ? scope : undefined,
+      searchMode,
+    );
+
+    const items = results
+      .filter((r) => matchesDocumentFilter(r, { ...filters, query: undefined }))
+      .filter((r) => canReadDocumentMemory(r, actor, filters))
+      .slice(0, limit)
+      .map((r) => {
+        const meta = asRecord(r.metadata);
+        const tags = documentTags(meta);
+        return {
+          id: (meta?.documentId as UUID | undefined) ?? r.id,
+          title:
+            (typeof meta?.title === "string" && meta.title) ||
+            (typeof meta?.filename === "string" && meta.filename) ||
+            "Untitled",
+          mediaFormat: documentMediaFormat(meta, tags),
+          similarity: r.similarity,
+          snippet: (r.content.text ?? "").slice(0, 240),
+        };
+      });
+
+    const text = items.length
+      ? `Found ${items.length} knowledge item(s) for "${query}":\n${items
+          .map(
+            (it, i) =>
+              `${i + 1}. ${it.title}${
+                it.mediaFormat ? ` [${it.mediaFormat}]` : ""
+              } — ${it.snippet}`,
+          )
+          .join("\n")}`
+      : `No knowledge items match "${query}".`;
+
+    logger.info(
+      `[SEARCH_KNOWLEDGE] query="${query}" role=${actor.role} matched=${items.length}`,
+    );
+    return {
+      success: true,
+      text,
+      userFacingText: text,
+      verifiedUserFacing: true,
+      data: { query, count: items.length, items },
+    };
+  },
+  parameters: [
+    {
+      name: "query",
+      description: "Free-text search over knowledge titles + content",
+      required: true,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "mediaFormat",
+      description:
+        "Optional facet: image | audio | video | pdf | text | transcript | file",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "roomId",
+      description: "Optional source-room UUID facet",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "addedBy",
+      description: "Optional sender entity UUID facet",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "tags",
+      description: "Optional tag list (array or comma-separated)",
+      required: false,
+      schema: { type: "array" as const, items: { type: "string" as const } },
+    },
+    {
+      name: "limit",
+      description: "Max results (default 10, max 50)",
+      required: false,
+      schema: { type: "number" as const },
+    },
+  ],
+};
+
+export const attachToChatAction: Action = {
+  name: "ATTACH_TO_CHAT",
+  contexts: ["knowledge", "documents", "files", "media", "agent_internal"],
+  similes: ["ATTACH_KNOWLEDGE", "ADD_TO_CHAT", "INSERT_ATTACHMENT", "SHOW_FILE"],
+  description:
+    "Attach a stored knowledge item's media into the ACTIVE conversation so the user sees it inline. Takes the item id or its sha256 media reference. Scope-walled: refuses an item the caller may not read.",
+  descriptionCompressed:
+    "put a stored knowledge item's media into this chat (id | sha256)",
+  routingHint:
+    "insert/attach a stored knowledge item into THIS chat -> ATTACH_TO_CHAT; to send it to someone else's DM/room -> SEND_MEDIA_TO; to find the item first -> SEARCH_KNOWLEDGE",
+  validate: async () => true,
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state,
+    options,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const params = ((options as HandlerOptions | undefined)?.parameters ??
+      {}) as Record<string, unknown>;
+    const itemRef =
+      typeof params.itemId === "string"
+        ? params.itemId
+        : typeof params.sha256 === "string"
+          ? params.sha256
+          : typeof params.id === "string"
+            ? params.id
+            : "";
+    if (!itemRef.trim()) {
+      return fail("An itemId or sha256 reference is required.", "ATTACH_INVALID");
+    }
+
+    const item = await resolveItem(runtime, itemRef.trim());
+    if (!item) return fail(`No knowledge item for "${itemRef}".`, "ATTACH_NOT_FOUND");
+
+    const actor = actorFromMessage(runtime, message);
+    if (!canReadDocumentMemory(item.memory, actor)) {
+      return fail(
+        "You do not have access to that knowledge item.",
+        "ATTACH_FORBIDDEN",
+      );
+    }
+
+    const media = mediaFromItem(item);
+    if (!media) {
+      return fail(
+        `"${item.title}" has no attachable media (text-only knowledge).`,
+        "ATTACH_NO_MEDIA",
+      );
+    }
+
+    const content: Content = {
+      text: `Attached: ${item.title}`,
+      attachments: [media],
+    };
+    if (callback) await callback(content, "ATTACH_TO_CHAT");
+
+    logger.info(
+      `[ATTACH_TO_CHAT] item="${item.title}" url=${media.url} role=${actor.role}`,
+    );
+    return {
+      success: true,
+      text: `Attached "${item.title}" to the chat.`,
+      userFacingText: `Attached "${item.title}" to the chat.`,
+      verifiedUserFacing: true,
+      data: { mediaUrl: media.url, title: item.title },
+    };
+  },
+  parameters: [
+    {
+      name: "itemId",
+      description: "Knowledge item document id, or its sha256 media reference",
+      required: true,
+      schema: { type: "string" as const },
+    },
+  ],
+};
+
+export const sendMediaToAction: Action = {
+  name: "SEND_MEDIA_TO",
+  contexts: ["knowledge", "documents", "files", "media", "agent_internal"],
+  roleGate: { minRole: "OWNER" },
+  similes: ["SEND_KNOWLEDGE", "SEND_FILE_TO", "SHARE_MEDIA", "DM_MEDIA"],
+  description:
+    "Send a stored knowledge item's media to a target room/DM through the connector dispatch. Takes the item id (or sha256) and a target roomId. Enforces the send wall: an owner-private or user-private item is REFUSED into a public room. Returns a typed dispatch outcome.",
+  descriptionCompressed:
+    "send a stored knowledge item's media to a room/DM (scope-walled)",
+  routingHint:
+    "send/DM/share a stored knowledge item to a contact or room -> SEND_MEDIA_TO; to attach it to the CURRENT chat instead -> ATTACH_TO_CHAT",
+  validate: async () => true,
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state,
+    options,
+  ): Promise<ActionResult> => {
+    const params = ((options as HandlerOptions | undefined)?.parameters ??
+      {}) as Record<string, unknown>;
+    const itemRef =
+      typeof params.itemId === "string"
+        ? params.itemId
+        : typeof params.sha256 === "string"
+          ? params.sha256
+          : "";
+    const targetRoomId = asUuid(params.roomId ?? params.target ?? params.contact);
+    if (!itemRef.trim()) {
+      return fail("An itemId or sha256 reference is required.", "SEND_INVALID");
+    }
+    if (!targetRoomId) {
+      return fail("A target roomId is required.", "SEND_NO_TARGET");
+    }
+
+    const item = await resolveItem(runtime, itemRef.trim());
+    if (!item) return fail(`No knowledge item for "${itemRef}".`, "SEND_NOT_FOUND");
+
+    const actor = actorFromMessage(runtime, message);
+    if (!canReadDocumentMemory(item.memory, actor)) {
+      return fail(
+        "You do not have access to that knowledge item.",
+        "SEND_FORBIDDEN",
+      );
+    }
+
+    const media = mediaFromItem(item);
+    if (!media) {
+      return fail(
+        `"${item.title}" has no sendable media (text-only knowledge).`,
+        "SEND_NO_MEDIA",
+      );
+    }
+
+    const targetRoom = await runtime.getRoom(targetRoomId);
+    const targetIsPublic = targetRoom
+      ? PUBLIC_ROOM_TYPES.has(targetRoom.type)
+      : false;
+    const wall = canSendDocumentToPublic(item.memory, targetIsPublic);
+    if (!wall.ok) {
+      logger.warn(
+        `[SEND_MEDIA_TO] refused ${wall.scope} item into public room ${targetRoomId}`,
+      );
+      return {
+        success: false,
+        text: wall.reason,
+        userFacingText: wall.reason,
+        verifiedUserFacing: true,
+        data: { error: "SEND_SCOPE_REFUSED", scope: wall.scope },
+      };
+    }
+
+    const content: Content = {
+      text: `Shared: ${item.title}`,
+      attachments: [media],
+    };
+    const dispatch = await dispatchToRoom(runtime, targetRoom?.source ?? "", {
+      source: targetRoom?.source ?? "",
+      roomId: targetRoomId,
+      ...(targetRoom?.channelId ? { channelId: targetRoom.channelId } : {}),
+      ...(targetRoom?.serverId ? { serverId: targetRoom.serverId } : {}),
+    }, content);
+
+    if (!dispatch.ok) {
+      logger.warn(
+        `[SEND_MEDIA_TO] dispatch failed reason=${dispatch.reason} room=${targetRoomId}`,
+      );
+      return {
+        success: false,
+        text: `Could not send "${item.title}": ${dispatch.message ?? dispatch.reason}.`,
+        data: { error: "SEND_DISPATCH_FAILED", dispatch },
+      };
+    }
+
+    logger.info(
+      `[SEND_MEDIA_TO] sent "${item.title}" to room ${targetRoomId} (msg ${dispatch.messageId ?? "?"})`,
+    );
+    return {
+      success: true,
+      text: `Sent "${item.title}" to the target.`,
+      userFacingText: `Sent "${item.title}" to the target.`,
+      verifiedUserFacing: true,
+      data: { dispatch, title: item.title },
+    };
+  },
+  parameters: [
+    {
+      name: "itemId",
+      description: "Knowledge item document id, or its sha256 media reference",
+      required: true,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "roomId",
+      description: "Target room/DM UUID to send the media into",
+      required: true,
+      schema: { type: "string" as const },
+    },
+  ],
+};
+
+/**
+ * Drive the runtime's connector send and map its outcome to a typed
+ * `DispatchResult`. `sendMessageToTarget` throws when no send handler is
+ * registered for the source (unknown recipient) or when the transport fails;
+ * this is the single J1 boundary translating those into the scheduling spine's
+ * dispatch vocabulary so callers branch on `reason`, never a bare boolean.
+ */
+async function dispatchToRoom(
+  runtime: IAgentRuntime,
+  source: string,
+  target: {
+    source: string;
+    roomId: UUID;
+    channelId?: string;
+    serverId?: string;
+  },
+  content: Content,
+): Promise<DispatchResult> {
+  if (!source) {
+    return {
+      ok: false,
+      reason: "unknown_recipient",
+      userActionable: true,
+      message: "Target room has no connector source.",
+    };
+  }
+  try {
+    const sent = await runtime.sendMessageToTarget(target, content);
+    return { ok: true, ...(sent?.id ? { messageId: sent.id } : {}) };
+  } catch (err) {
+    // error-policy:J1 boundary translation — connector dispatch failures become
+    // a structured DispatchResult the action surfaces to the model/user.
+    const msg = err instanceof Error ? err.message : String(err);
+    const reason = /no send handler|unknown recipient/i.test(msg)
+      ? "unknown_recipient"
+      : "transport_error";
+    return { ok: false, reason, userActionable: true, message: msg };
+  }
+}
+
+export const knowledgeActions: Action[] = [
+  searchKnowledgeAction,
+  attachToChatAction,
+  sendMediaToAction,
+];

--- a/packages/agent/src/actions/knowledge.ts
+++ b/packages/agent/src/actions/knowledge.ts
@@ -22,8 +22,8 @@
 import {
   type Action,
   type ActionResult,
-  type Content,
   ChannelType,
+  type Content,
   type HandlerCallback,
   type HandlerOptions,
   type IAgentRuntime,
@@ -151,15 +151,12 @@ function filtersFromParams(params: Record<string, unknown>): DocumentFilter {
 async function resolveItem(
   runtime: IAgentRuntime,
   itemRef: string,
-): Promise<
-  | {
-      memory: Memory;
-      mediaUrl?: string;
-      mimeType?: string;
-      title: string;
-    }
-  | null
-> {
+): Promise<{
+  memory: Memory;
+  mediaUrl?: string;
+  mimeType?: string;
+  title: string;
+} | null> {
   const { service } = await getDocumentsService(
     runtime as unknown as Parameters<typeof getDocumentsService>[0],
   );
@@ -213,7 +210,7 @@ function mediaFileNameFromRef(ref: string): string | null {
   if (!trimmed) return null;
   const withoutPrefix = trimmed.startsWith(MEDIA_URL_PREFIX)
     ? trimmed.slice(MEDIA_URL_PREFIX.length)
-    : trimmed.split("/").pop() ?? trimmed;
+    : (trimmed.split("/").pop() ?? trimmed);
   // sha256 (64 hex) + extension, e.g. "ab12….pdf"
   return /^[0-9a-f]{64}\.[a-z0-9]+$/i.test(withoutPrefix)
     ? withoutPrefix
@@ -272,8 +269,7 @@ export const searchKnowledgeAction: Action = {
   ): Promise<ActionResult> => {
     const params = ((options as HandlerOptions | undefined)?.parameters ??
       {}) as Record<string, unknown>;
-    const query =
-      typeof params.query === "string" ? params.query.trim() : "";
+    const query = typeof params.query === "string" ? params.query.trim() : "";
     if (!query) return fail("A search query is required.", "KNOWLEDGE_INVALID");
 
     const { service, reason } = await getDocumentsService(
@@ -398,7 +394,12 @@ export const searchKnowledgeAction: Action = {
 export const attachToChatAction: Action = {
   name: "ATTACH_TO_CHAT",
   contexts: ["knowledge", "documents", "files", "media", "agent_internal"],
-  similes: ["ATTACH_KNOWLEDGE", "ADD_TO_CHAT", "INSERT_ATTACHMENT", "SHOW_FILE"],
+  similes: [
+    "ATTACH_KNOWLEDGE",
+    "ADD_TO_CHAT",
+    "INSERT_ATTACHMENT",
+    "SHOW_FILE",
+  ],
   description:
     "Attach a stored knowledge item's media into the ACTIVE conversation so the user sees it inline. Takes the item id or its sha256 media reference. Scope-walled: refuses an item the caller may not read.",
   descriptionCompressed:
@@ -424,11 +425,15 @@ export const attachToChatAction: Action = {
             ? params.id
             : "";
     if (!itemRef.trim()) {
-      return fail("An itemId or sha256 reference is required.", "ATTACH_INVALID");
+      return fail(
+        "An itemId or sha256 reference is required.",
+        "ATTACH_INVALID",
+      );
     }
 
     const item = await resolveItem(runtime, itemRef.trim());
-    if (!item) return fail(`No knowledge item for "${itemRef}".`, "ATTACH_NOT_FOUND");
+    if (!item)
+      return fail(`No knowledge item for "${itemRef}".`, "ATTACH_NOT_FOUND");
 
     const actor = actorFromMessage(runtime, message);
     if (!canReadDocumentMemory(item.memory, actor)) {
@@ -499,7 +504,9 @@ export const sendMediaToAction: Action = {
         : typeof params.sha256 === "string"
           ? params.sha256
           : "";
-    const targetRoomId = asUuid(params.roomId ?? params.target ?? params.contact);
+    const targetRoomId = asUuid(
+      params.roomId ?? params.target ?? params.contact,
+    );
     if (!itemRef.trim()) {
       return fail("An itemId or sha256 reference is required.", "SEND_INVALID");
     }
@@ -508,7 +515,8 @@ export const sendMediaToAction: Action = {
     }
 
     const item = await resolveItem(runtime, itemRef.trim());
-    if (!item) return fail(`No knowledge item for "${itemRef}".`, "SEND_NOT_FOUND");
+    if (!item)
+      return fail(`No knowledge item for "${itemRef}".`, "SEND_NOT_FOUND");
 
     const actor = actorFromMessage(runtime, message);
     if (!canReadDocumentMemory(item.memory, actor)) {
@@ -548,12 +556,17 @@ export const sendMediaToAction: Action = {
       text: `Shared: ${item.title}`,
       attachments: [media],
     };
-    const dispatch = await dispatchToRoom(runtime, targetRoom?.source ?? "", {
-      source: targetRoom?.source ?? "",
-      roomId: targetRoomId,
-      ...(targetRoom?.channelId ? { channelId: targetRoom.channelId } : {}),
-      ...(targetRoom?.serverId ? { serverId: targetRoom.serverId } : {}),
-    }, content);
+    const dispatch = await dispatchToRoom(
+      runtime,
+      targetRoom?.source ?? "",
+      {
+        source: targetRoom?.source ?? "",
+        roomId: targetRoomId,
+        ...(targetRoom?.channelId ? { channelId: targetRoom.channelId } : {}),
+        ...(targetRoom?.serverId ? { serverId: targetRoom.serverId } : {}),
+      },
+      content,
+    );
 
     if (!dispatch.ok) {
       logger.warn(

--- a/packages/agent/src/api/attachment-knowledge-ingest.ts
+++ b/packages/agent/src/api/attachment-knowledge-ingest.ts
@@ -24,11 +24,12 @@
 
 import type { IAgentRuntime, Media, Memory, UUID } from "@elizaos/core";
 import {
-  ChannelType,
+  type ChannelType,
   ContentType,
   ElizaError,
   resolveEntityRole,
 } from "@elizaos/core";
+import { roomIsPrivateSurface as roomIsPrivateSurfaceShared } from "./document-access.ts";
 import { isStoredMediaUrl, mediaFileNameFromUrl } from "./media-store.ts";
 
 /**
@@ -114,19 +115,16 @@ export function attachmentKnowledgeTags(format: MediaFormat): string[] {
  * API room is a "private" surface (owner's own chat); everything else (GROUP,
  * FORUM, FEED, THREAD, WORLD, …) is a "public"/community surface that must not
  * receive owner-private or global writes.
+ *
+ * Delegates to the canonical classifier in `document-access.ts` so the ingest
+ * spill guard, the send wall, and the active-room surfacing wall can never drift
+ * (a channel type omitted from one list but not another silently opened a hole).
+ * Re-exported here to keep the existing ingest import surface stable.
  */
 export function roomIsPrivateSurface(
   channelType: ChannelType | string | undefined,
 ): boolean {
-  switch (channelType) {
-    case ChannelType.DM:
-    case ChannelType.SELF:
-    case ChannelType.VOICE_DM:
-    case ChannelType.API:
-      return true;
-    default:
-      return false;
-  }
+  return roomIsPrivateSurfaceShared(channelType);
 }
 
 export interface IngestScopeDecision {

--- a/packages/agent/src/api/document-access.ts
+++ b/packages/agent/src/api/document-access.ts
@@ -11,11 +11,45 @@
  * agent → plugin-documents cycle; the route plugin imports it the same way it
  * imports `documents-service-loader`.
  */
-import type { Memory, UUID } from "@elizaos/core";
+import { ChannelType, type Memory, type UUID } from "@elizaos/core";
 import type {
   DocumentAddedByRole,
   DocumentVisibilityScope,
 } from "./documents-service-loader.ts";
+
+/**
+ * Room trust classification — the SINGLE source of truth shared by the ingest
+ * spill guard (`attachment-knowledge-ingest.roomIsPrivateSurface`), the send
+ * wall, and the active-room surfacing wall. A DM / SELF / VOICE_DM / API room is
+ * a "private" surface (the owner's own chat); EVERYTHING else — GROUP,
+ * VOICE_GROUP, FEED, THREAD, WORLD, FORUM, AUTONOMOUS — is a "public"/community
+ * surface that must never receive owner-private or user-private knowledge.
+ *
+ * Defined here (not with a hand-rolled public-type allowlist) so no surface can
+ * drift: a THREAD omitted from a public-types set would silently let private
+ * media into a thread. Classifying by the private allowlist + `default: public`
+ * fails closed for any future channel type.
+ */
+export function roomIsPrivateSurface(
+  channelType: ChannelType | string | undefined,
+): boolean {
+  switch (channelType) {
+    case ChannelType.DM:
+    case ChannelType.SELF:
+    case ChannelType.VOICE_DM:
+    case ChannelType.API:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/** A room is a public/community surface iff it is not a private surface. */
+export function roomIsPublicSurface(
+  channelType: ChannelType | string | undefined,
+): boolean {
+  return !roomIsPrivateSurface(channelType);
+}
 
 export const DOCUMENT_SCOPE_VALUES = new Set<DocumentVisibilityScope>([
   "global",
@@ -300,6 +334,41 @@ export function canSendDocumentToPublic(
         scope === "owner-private"
           ? "This is an owner-private item; it cannot be sent into a public room."
           : "This is a private item; it cannot be sent into a public room.",
+      scope,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * The ACTIVE-ROOM surfacing wall (#13974 shaw-codex review). SEARCH_KNOWLEDGE
+ * and ATTACH_TO_CHAT emit user-facing snippets / attachments INTO the room the
+ * triggering message came from. The actor read wall (`canReadDocumentMemory`)
+ * only checks whether the ACTOR may read the item — an OWNER asking in a public
+ * group still passes it for an owner-private item learned in DM. That would spill
+ * the private item to every other participant of the active public room.
+ *
+ * So before any user-facing output, classify the ACTIVE room: if it is a public
+ * surface, an owner-private or user-private item must be refused/filtered even
+ * for an owner actor. Private (DM-like) active rooms are unrestricted. Same rule
+ * shape as the send wall, keyed on the active room's visibility. Returns a typed
+ * refusal so callers surface WHY.
+ */
+export function canSurfaceDocumentInRoom(
+  memory: DocumentReadableMemory,
+  activeRoomIsPublic: boolean,
+):
+  | { ok: true }
+  | { ok: false; reason: string; scope: DocumentVisibilityScope } {
+  const scope = getDocumentVisibilityScope(asRecord(memory.metadata));
+  if (!activeRoomIsPublic) return { ok: true };
+  if (scope === "owner-private" || scope === "user-private") {
+    return {
+      ok: false,
+      reason:
+        scope === "owner-private"
+          ? "This is an owner-private item; it cannot be surfaced in a public room."
+          : "This is a private item; it cannot be surfaced in a public room.",
       scope,
     };
   }

--- a/packages/agent/src/api/document-access.ts
+++ b/packages/agent/src/api/document-access.ts
@@ -130,7 +130,9 @@ export function documentTags(
   metadata: Record<string, unknown> | undefined,
 ): string[] {
   return Array.isArray(metadata?.tags)
-    ? metadata.tags.filter((value): value is string => typeof value === "string")
+    ? metadata.tags.filter(
+        (value): value is string => typeof value === "string",
+      )
     : [];
 }
 

--- a/packages/agent/src/api/document-access.ts
+++ b/packages/agent/src/api/document-access.ts
@@ -1,0 +1,305 @@
+/**
+ * Canonical knowledge-document access wall and facet-filter matcher. Both the
+ * HTTP route layer (`@elizaos/plugin-documents/routes.ts`) and the agent-callable
+ * knowledge actions (`../actions/knowledge.ts`) apply the SAME rules here so an
+ * owner-private item can never spill to a public-room actor through either path
+ * (the #13593 spill guard), and the room/sender/media-format/tag/time-range
+ * facets (#13595) resolve identically for a REST query and an agent SEARCH.
+ *
+ * Lives in `@elizaos/agent` (the inner layer) rather than the route plugin so
+ * the always-loaded agent actions can depend on it without an
+ * agent → plugin-documents cycle; the route plugin imports it the same way it
+ * imports `documents-service-loader`.
+ */
+import type { Memory, UUID } from "@elizaos/core";
+import type {
+  DocumentAddedByRole,
+  DocumentVisibilityScope,
+} from "./documents-service-loader.ts";
+
+export const DOCUMENT_SCOPE_VALUES = new Set<DocumentVisibilityScope>([
+  "global",
+  "owner-private",
+  "user-private",
+  "agent-private",
+]);
+
+/** Namespaced tag prefix carrying the media-format facet on knowledge records. */
+export const MEDIA_FORMAT_TAG_PREFIX = "media-format:";
+
+export type RouteActorRole = "OWNER" | "USER" | "AGENT" | "RUNTIME";
+
+export type RouteActor = {
+  entityId: UUID;
+  role: RouteActorRole;
+  ownerEntityId?: UUID;
+};
+
+/**
+ * Facet filter set for knowledge queries. Every field is an AND constraint; the
+ * media-format facet matches either an explicit `metadata.mediaFormat` or the
+ * `media-format:<format>` tag so ingest-tagged and mime-derived records compose.
+ */
+export type DocumentFilter = {
+  scope?: DocumentVisibilityScope;
+  scopedToEntityId?: UUID;
+  query?: string;
+  addedBy?: UUID;
+  timeRangeStart?: number;
+  timeRangeEnd?: number;
+  tags?: string[];
+  roomId?: UUID;
+  mediaFormat?: string;
+};
+
+export type DocumentReadableMemory = {
+  id?: UUID;
+  agentId?: UUID;
+  entityId?: UUID;
+  createdAt?: number;
+  content?: { text?: string };
+  metadata?: unknown;
+};
+
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export function trimString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+export function asUuid(value: unknown): UUID | undefined {
+  const trimmed = trimString(value);
+  return trimmed ? (trimmed as UUID) : undefined;
+}
+
+export function parseDocumentScope(
+  value: unknown,
+): DocumentVisibilityScope | undefined {
+  return DOCUMENT_SCOPE_VALUES.has(value as DocumentVisibilityScope)
+    ? (value as DocumentVisibilityScope)
+    : undefined;
+}
+
+export function getDocumentVisibilityScope(
+  metadata: Record<string, unknown> | undefined,
+): DocumentVisibilityScope {
+  return DOCUMENT_SCOPE_VALUES.has(metadata?.scope as DocumentVisibilityScope)
+    ? (metadata?.scope as DocumentVisibilityScope)
+    : "global";
+}
+
+export function routeActorAddedByRole(actor: RouteActor): DocumentAddedByRole {
+  return actor.role;
+}
+
+export function actorCanManageOwnerDocuments(actor: RouteActor): boolean {
+  return actor.role === "OWNER" || actor.role === "RUNTIME";
+}
+
+export function actorCanManageAgentDocuments(actor: RouteActor): boolean {
+  return (
+    actor.role === "OWNER" || actor.role === "AGENT" || actor.role === "RUNTIME"
+  );
+}
+
+export function documentScopedEntityId(
+  memory: DocumentReadableMemory,
+): UUID | undefined {
+  const metadata = asRecord(memory.metadata);
+  return (
+    asUuid(metadata?.scopedToEntityId) ??
+    asUuid(metadata?.addedBy) ??
+    asUuid(memory.entityId)
+  );
+}
+
+/** Source-room id recorded on a knowledge record (#13593), if any. */
+export function documentRoomId(
+  metadata: Record<string, unknown> | undefined,
+): UUID | undefined {
+  return asUuid(metadata?.roomId);
+}
+
+export function documentTags(
+  metadata: Record<string, unknown> | undefined,
+): string[] {
+  return Array.isArray(metadata?.tags)
+    ? metadata.tags.filter((value): value is string => typeof value === "string")
+    : [];
+}
+
+/**
+ * Media-format facet for a knowledge record (#13593). Prefer an explicit
+ * `metadata.mediaFormat`; fall back to the `media-format:<format>` tag so
+ * records tagged by the ingest pipeline (or backfill) still match without a
+ * dedicated column.
+ */
+export function documentMediaFormat(
+  metadata: Record<string, unknown> | undefined,
+  tags: string[],
+): string | undefined {
+  const explicit = trimString(metadata?.mediaFormat)?.toLowerCase();
+  if (explicit) return explicit;
+  const tagged = tags.find((tag) => tag.startsWith(MEDIA_FORMAT_TAG_PREFIX));
+  return tagged ? tagged.slice(MEDIA_FORMAT_TAG_PREFIX.length) : undefined;
+}
+
+export function matchesDocumentFilter(
+  memory: DocumentReadableMemory,
+  filters: DocumentFilter,
+): boolean {
+  const metadata = asRecord(memory.metadata);
+  if (filters.scope && getDocumentVisibilityScope(metadata) !== filters.scope) {
+    return false;
+  }
+  if (
+    filters.scopedToEntityId &&
+    documentScopedEntityId(memory) !== filters.scopedToEntityId
+  ) {
+    return false;
+  }
+  if (filters.addedBy && metadata?.addedBy !== filters.addedBy) {
+    return false;
+  }
+  const tags = documentTags(metadata);
+  if (filters.tags && filters.tags.length > 0) {
+    if (!filters.tags.every((tag) => tags.includes(tag))) {
+      return false;
+    }
+  }
+  if (filters.roomId && documentRoomId(metadata) !== filters.roomId) {
+    return false;
+  }
+  if (
+    filters.mediaFormat &&
+    documentMediaFormat(metadata, tags) !== filters.mediaFormat
+  ) {
+    return false;
+  }
+
+  const timestamp =
+    typeof metadata?.timestamp === "number"
+      ? metadata.timestamp
+      : typeof metadata?.addedAt === "number"
+        ? metadata.addedAt
+        : typeof memory.createdAt === "number"
+          ? memory.createdAt
+          : undefined;
+  if (
+    typeof filters.timeRangeStart === "number" &&
+    (typeof timestamp !== "number" || timestamp < filters.timeRangeStart)
+  ) {
+    return false;
+  }
+  if (
+    typeof filters.timeRangeEnd === "number" &&
+    (typeof timestamp !== "number" || timestamp > filters.timeRangeEnd)
+  ) {
+    return false;
+  }
+  if (filters.query) {
+    const query = filters.query.toLowerCase();
+    // content.text carries any text-derived title, so the raw metadata title
+    // fields plus the body cover the same ground the presenter's derived title
+    // would — no need to pull the presenter into the inner layer.
+    const haystack = [
+      memory.content?.text,
+      metadata?.title,
+      metadata?.filename,
+      metadata?.originalFilename,
+      metadata?.source,
+      metadata?.url,
+    ]
+      .filter((value): value is string => typeof value === "string")
+      .join("\n")
+      .toLowerCase();
+    if (!haystack.includes(query)) return false;
+  }
+  return true;
+}
+
+/**
+ * The scope wall: can `actor` READ this document memory? owner-private requires
+ * owner/runtime; agent-private requires owner/agent/runtime; user-private
+ * matches the scoped entity (owner may target a specific entity via
+ * `filters.scopedToEntityId`); global is open. This is the guard that keeps an
+ * owner-chat item from ever surfacing to a public-room actor (#13593).
+ */
+export function canReadDocumentMemory(
+  memory: DocumentReadableMemory,
+  actor: RouteActor,
+  filters: DocumentFilter = {},
+): boolean {
+  const metadata = asRecord(memory.metadata);
+  const scope = getDocumentVisibilityScope(metadata);
+
+  if (scope === "global") return true;
+  if (scope === "owner-private") return actorCanManageOwnerDocuments(actor);
+  if (scope === "agent-private") return actorCanManageAgentDocuments(actor);
+
+  const scopedEntityId = documentScopedEntityId(memory);
+  if (!scopedEntityId) return false;
+
+  if (actor.role === "AGENT" || actor.role === "RUNTIME") return true;
+  if (actor.role === "OWNER") {
+    return filters.scopedToEntityId
+      ? scopedEntityId === filters.scopedToEntityId
+      : scopedEntityId === actor.entityId;
+  }
+  return scopedEntityId === actor.entityId;
+}
+
+export function canMutateDocumentMemory(
+  memory: Memory,
+  actor: RouteActor,
+): boolean {
+  const metadata = asRecord(memory.metadata);
+  const scope = getDocumentVisibilityScope(metadata);
+
+  if (scope === "global" || scope === "owner-private") {
+    return actorCanManageOwnerDocuments(actor);
+  }
+  if (scope === "agent-private") {
+    return actorCanManageAgentDocuments(actor);
+  }
+
+  const scopedEntityId = documentScopedEntityId(memory);
+  return (
+    actorCanManageAgentDocuments(actor) ||
+    (Boolean(scopedEntityId) && scopedEntityId === actor.entityId)
+  );
+}
+
+/**
+ * The send wall for SEND_MEDIA_TO (#13595): can this document be delivered OUT
+ * to a target room of the given visibility? An owner-private or user-private
+ * item may never leave for a public/shared room. Returns a typed refusal
+ * (reason + scope) so callers surface WHY the send was blocked instead of a
+ * bare boolean.
+ */
+export function canSendDocumentToPublic(
+  memory: DocumentReadableMemory,
+  targetIsPublic: boolean,
+):
+  | { ok: true }
+  | { ok: false; reason: string; scope: DocumentVisibilityScope } {
+  const scope = getDocumentVisibilityScope(asRecord(memory.metadata));
+  if (!targetIsPublic) return { ok: true };
+  if (scope === "owner-private" || scope === "user-private") {
+    return {
+      ok: false,
+      reason:
+        scope === "owner-private"
+          ? "This is an owner-private item; it cannot be sent into a public room."
+          : "This is a private item; it cannot be sent into a public room.",
+      scope,
+    };
+  }
+  return { ok: true };
+}

--- a/packages/agent/src/runtime/default-help-documents.ts
+++ b/packages/agent/src/runtime/default-help-documents.ts
@@ -17,6 +17,8 @@ interface HelpEntry {
   answer: string;
 }
 
+export const HELP_KNOWLEDGE_TAG = "help";
+
 function helpDocument(
   key: string,
   title: string,
@@ -33,6 +35,7 @@ function helpDocument(
     contentType: "text/plain",
     text: [`${title}`, "", ...fragments.map((f) => f.text)].join("\n\n"),
     fragments,
+    metadata: { tags: [HELP_KNOWLEDGE_TAG], helpCategory: title },
   };
 }
 

--- a/packages/agent/src/runtime/eliza-plugin.ts
+++ b/packages/agent/src/runtime/eliza-plugin.ts
@@ -23,6 +23,7 @@ import { connectAccountAction } from "../actions/connect-account.ts";
 import { contactAction } from "../actions/contact.ts";
 import { databaseAction } from "../actions/database.ts";
 import { filesAction } from "../actions/files.ts";
+import { knowledgeActions } from "../actions/knowledge.ts";
 import { logsAction } from "../actions/logs.ts";
 import { memoryAction } from "../actions/memories.ts";
 import { notifyAction } from "../actions/notify.ts";
@@ -266,6 +267,9 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
       notifyAction,
       ...promoteSubactionsToActions(memoryAction),
       filesAction,
+      // Global knowledge-hub actions (#13595): search + attach-to-chat +
+      // send-to-someone, callable from any view.
+      ...knowledgeActions,
       // SCHEDULE_FOLLOW_UP is now the `followup` op on contactAction.
       // ARCHIVE_CODING_TASK / REOPEN_CODING_TASK live as ops on the TASKS
       // parent in @elizaos/plugin-agent-orchestrator (also surfaced via the

--- a/packages/ui/src/api/client-chat.ts
+++ b/packages/ui/src/api/client-chat.ts
@@ -121,6 +121,8 @@ type DocumentUrlUploadOptions = {
   scopedToEntityId?: string;
 };
 
+type DocumentSearchMode = "hybrid" | "vector" | "keyword";
+
 type DocumentSearchOptions = {
   threshold?: number;
   limit?: number;
@@ -134,6 +136,7 @@ type DocumentSearchOptions = {
   mediaFormat?: string;
   roomId?: string;
   knowledgeFacet?: string;
+  searchMode?: DocumentSearchMode;
 };
 
 type InboxMessagesOptions = {
@@ -272,6 +275,7 @@ function buildDocumentSearchParams(
   setDefinedNumberParam(params, "threshold", options?.threshold);
   setDefinedNumberParam(params, "limit", options?.limit);
   setTruthyStringParam(params, "query", options?.query);
+  setTruthyStringParam(params, "searchMode", options?.searchMode);
   appendDocumentFilterParams(params, options);
   return params;
 }

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -5,21 +5,7 @@
  * document service (resolved from `@elizaos/agent/api/documents-service-loader`);
  * this module handles HTTP shaping and access-control scoping only.
  */
-import type {
-  AgentRuntime,
-  IFileStorageService,
-  Memory,
-  RouteHelpers,
-  RouteRequestContext,
-  UUID,
-} from "@elizaos/core";
-import {
-  __setDocumentUrlFetchImplForTests,
-  fetchDocumentFromUrl,
-  isYouTubeUrl,
-  ServiceType,
-} from "@elizaos/core";
-import { parseClampedFloat, parsePositiveInteger } from "@elizaos/shared";
+
 import {
   actorCanManageAgentDocuments,
   actorCanManageOwnerDocuments,
@@ -37,6 +23,21 @@ import {
   routeActorAddedByRole,
   trimString,
 } from "@elizaos/agent/api/document-access";
+import type {
+  AgentRuntime,
+  IFileStorageService,
+  Memory,
+  RouteHelpers,
+  RouteRequestContext,
+  UUID,
+} from "@elizaos/core";
+import {
+  __setDocumentUrlFetchImplForTests,
+  fetchDocumentFromUrl,
+  isYouTubeUrl,
+  ServiceType,
+} from "@elizaos/core";
+import { parseClampedFloat, parsePositiveInteger } from "@elizaos/shared";
 import {
   getDocumentContentType,
   getDocumentDeleteability,

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -21,16 +21,31 @@ import {
 } from "@elizaos/core";
 import { parseClampedFloat, parsePositiveInteger } from "@elizaos/shared";
 import {
+  actorCanManageAgentDocuments,
+  actorCanManageOwnerDocuments,
+  asRecord,
+  asUuid,
+  canMutateDocumentMemory,
+  canReadDocumentMemory,
+  documentMediaFormat,
+  documentScopedEntityId,
+  documentTags,
+  type DocumentFilter as SharedDocumentFilter,
+  matchesDocumentFilter as matchesSharedDocumentFilter,
+  parseDocumentScope,
+  type RouteActor,
+  routeActorAddedByRole,
+  trimString,
+} from "@elizaos/agent/api/document-access";
+import {
   getDocumentContentType,
   getDocumentDeleteability,
   getDocumentEditability,
   getDocumentProvenance,
   getDocumentTitleFromMetadata,
-  getDocumentVisibilityScope,
   presentDocument,
 } from "./document-presenter.js";
 import {
-  type DocumentAddedByRole,
   type DocumentAddedFrom,
   type DocumentSearchMode,
   type DocumentsServiceLike,
@@ -56,33 +71,10 @@ const FRAGMENT_BATCH_SIZE = 500;
 const DOCUMENT_UPLOAD_MAX_BODY_BYTES = 32 * 1_048_576; // 32 MB
 const MAX_BULK_DOCUMENTS = 100;
 
-const DOCUMENT_SCOPE_VALUES = new Set<DocumentVisibilityScope>([
-  "global",
-  "owner-private",
-  "user-private",
-  "agent-private",
-]);
-
-type DocumentFilter = {
-  scope?: DocumentVisibilityScope;
-  scopedToEntityId?: UUID;
-  query?: string;
-  addedBy?: UUID;
-  timeRangeStart?: number;
-  timeRangeEnd?: number;
-  tags?: string[];
-  /** First-class source-room filter (#13593). */
-  roomId?: UUID;
-  /**
-   * Media-format facet (#13593): image | audio | video | pdf | text |
-   * transcript | file. Matched against `metadata.mediaFormat` or the
-   * `media-format:<format>` tag, so both explicitly-tagged records and
-   * mime-derived ones compose.
-   */
-  mediaFormat?: string;
+type DocumentFilter = SharedDocumentFilter & {
   /**
    * Hub display facet (#13594): the coarse client-facing bucket the Knowledge
-   * hub's segmented control filters by — all | doc | image | audio | video |
+   * hub's segmented control filters by: all | doc | image | audio | video |
    * transcript. Unlike {@link mediaFormat} (an exact fine-grained match), `doc`
    * groups the pdf/text/file document subtypes, so the hub's facet rows and
    * counts come from the whole readable store, not just the first page.
@@ -117,19 +109,6 @@ function parseKnowledgeFacet(
     ? (normalized as KnowledgeHubFacet)
     : undefined;
 }
-
-/** Namespaced tag prefix carrying the media-format facet on knowledge records. */
-const MEDIA_FORMAT_TAG_PREFIX = "media-format:";
-
-type DocumentReadableMemory = {
-  id?: UUID;
-  agentId?: UUID;
-  entityId?: UUID;
-  createdAt?: number;
-  content?: { text?: string };
-  metadata?: unknown;
-};
-
 type DocumentUploadBody = {
   content: string;
   filename: string;
@@ -141,14 +120,6 @@ type DocumentUploadBody = {
   scope?: string;
   scopedToEntityId?: string;
   addedFrom?: string;
-};
-
-type RouteActorRole = "OWNER" | "USER" | "AGENT" | "RUNTIME";
-
-type RouteActor = {
-  entityId: UUID;
-  role: RouteActorRole;
-  ownerEntityId?: UUID;
 };
 
 function isTextBackedContentType(
@@ -175,23 +146,6 @@ function isTextBackedContentType(
     lowerFilename.endsWith(".csv") ||
     lowerFilename.endsWith(".tsv")
   );
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object"
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
-function trimString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim().length > 0
-    ? value.trim()
-    : undefined;
-}
-
-function asUuid(value: unknown): UUID | undefined {
-  const trimmed = trimString(value);
-  return trimmed ? (trimmed as UUID) : undefined;
 }
 
 function getOwnerEntityId(runtime: AgentRuntime | null): UUID | undefined {
@@ -223,28 +177,6 @@ function resolveRouteActor(
     return { entityId, role: "OWNER", ownerEntityId };
   }
   return { entityId, role: "USER", ownerEntityId };
-}
-
-function routeActorAddedByRole(actor: RouteActor): DocumentAddedByRole {
-  return actor.role;
-}
-
-function actorCanManageOwnerDocuments(actor: RouteActor): boolean {
-  return actor.role === "OWNER" || actor.role === "RUNTIME";
-}
-
-function actorCanManageAgentDocuments(actor: RouteActor): boolean {
-  return (
-    actor.role === "OWNER" || actor.role === "AGENT" || actor.role === "RUNTIME"
-  );
-}
-
-function parseDocumentScope(
-  value: unknown,
-): DocumentVisibilityScope | undefined {
-  return DOCUMENT_SCOPE_VALUES.has(value as DocumentVisibilityScope)
-    ? (value as DocumentVisibilityScope)
-    : undefined;
 }
 
 function parseSearchMode(value: unknown): DocumentSearchMode | undefined {
@@ -395,121 +327,20 @@ function isDocumentMemory(memory: Memory, agentId: UUID): boolean {
   );
 }
 
-function matchesDocumentFilter(
-  memory: DocumentReadableMemory,
-  filters: DocumentFilter,
-): boolean {
+function matchesDocumentFilter(memory: Memory, filters: DocumentFilter): boolean {
+  if (!matchesSharedDocumentFilter(memory, filters)) return false;
+
   const metadata = asRecord(memory.metadata);
-  if (filters.scope && getDocumentVisibilityScope(metadata) !== filters.scope) {
-    return false;
-  }
   if (
-    filters.scopedToEntityId &&
-    documentScopedEntityId(memory) !== filters.scopedToEntityId
+    !filters.knowledgeFacet ||
+    filters.knowledgeFacet === "all" ||
+    documentHubFacet(metadata, documentTags(metadata)) ===
+      filters.knowledgeFacet
   ) {
-    return false;
-  }
-  if (filters.addedBy && metadata?.addedBy !== filters.addedBy) {
-    return false;
-  }
-  const documentTags = Array.isArray(metadata?.tags)
-    ? metadata.tags.filter(
-        (value): value is string => typeof value === "string",
-      )
-    : [];
-  if (filters.tags && filters.tags.length > 0) {
-    if (!filters.tags.every((tag) => documentTags.includes(tag))) {
-      return false;
-    }
-  }
-  if (filters.roomId && documentRoomId(metadata) !== filters.roomId) {
-    return false;
-  }
-  if (
-    filters.mediaFormat &&
-    documentMediaFormat(metadata, documentTags) !== filters.mediaFormat
-  ) {
-    return false;
-  }
-  if (
-    filters.knowledgeFacet &&
-    filters.knowledgeFacet !== "all" &&
-    documentHubFacet(metadata, documentTags) !== filters.knowledgeFacet
-  ) {
-    return false;
+    return true;
   }
 
-  const timestamp =
-    typeof metadata?.timestamp === "number"
-      ? metadata.timestamp
-      : typeof metadata?.addedAt === "number"
-        ? metadata.addedAt
-        : typeof memory.createdAt === "number"
-          ? memory.createdAt
-          : undefined;
-  if (
-    typeof filters.timeRangeStart === "number" &&
-    (typeof timestamp !== "number" || timestamp < filters.timeRangeStart)
-  ) {
-    return false;
-  }
-  if (
-    typeof filters.timeRangeEnd === "number" &&
-    (typeof timestamp !== "number" || timestamp > filters.timeRangeEnd)
-  ) {
-    return false;
-  }
-  if (filters.query) {
-    const query = filters.query.toLowerCase();
-    const haystack = [
-      memory.content?.text,
-      getDocumentTitleFromMetadata(metadata, memory.content?.text),
-      metadata?.title,
-      metadata?.filename,
-      metadata?.originalFilename,
-      metadata?.source,
-      metadata?.url,
-    ]
-      .filter((value): value is string => typeof value === "string")
-      .join("\n")
-      .toLowerCase();
-    if (!haystack.includes(query)) return false;
-  }
-  return true;
-}
-
-function documentScopedEntityId(
-  memory: DocumentReadableMemory,
-): UUID | undefined {
-  const metadata = asRecord(memory.metadata);
-  return (
-    asUuid(metadata?.scopedToEntityId) ??
-    asUuid(metadata?.addedBy) ??
-    asUuid(memory.entityId)
-  );
-}
-
-/** Source-room id recorded on a knowledge record (#13593), if any. */
-function documentRoomId(
-  metadata: Record<string, unknown> | undefined,
-): UUID | undefined {
-  return asUuid(metadata?.roomId);
-}
-
-/**
- * Media-format facet for a knowledge record (#13593). Prefer an explicit
- * `metadata.mediaFormat`; fall back to the `media-format:<format>` tag so
- * records tagged by the ingest pipeline (or backfill) still match without a
- * dedicated column.
- */
-function documentMediaFormat(
-  metadata: Record<string, unknown> | undefined,
-  tags: string[],
-): string | undefined {
-  const explicit = trimString(metadata?.mediaFormat)?.toLowerCase();
-  if (explicit) return explicit;
-  const tagged = tags.find((tag) => tag.startsWith(MEDIA_FORMAT_TAG_PREFIX));
-  return tagged ? tagged.slice(MEDIA_FORMAT_TAG_PREFIX.length) : undefined;
+  return false;
 }
 
 /**
@@ -546,49 +377,6 @@ function documentHubFacet(
   if (mime.startsWith("video/")) return "video";
   return "doc";
 }
-
-function canReadDocumentMemory(
-  memory: DocumentReadableMemory,
-  actor: RouteActor,
-  filters: DocumentFilter = {},
-): boolean {
-  const metadata = asRecord(memory.metadata);
-  const scope = getDocumentVisibilityScope(metadata);
-
-  if (scope === "global") return true;
-  if (scope === "owner-private") return actorCanManageOwnerDocuments(actor);
-  if (scope === "agent-private") return actorCanManageAgentDocuments(actor);
-
-  const scopedEntityId = documentScopedEntityId(memory);
-  if (!scopedEntityId) return false;
-
-  if (actor.role === "AGENT" || actor.role === "RUNTIME") return true;
-  if (actor.role === "OWNER") {
-    return filters.scopedToEntityId
-      ? scopedEntityId === filters.scopedToEntityId
-      : scopedEntityId === actor.entityId;
-  }
-  return scopedEntityId === actor.entityId;
-}
-
-function canMutateDocumentMemory(memory: Memory, actor: RouteActor): boolean {
-  const metadata = asRecord(memory.metadata);
-  const scope = getDocumentVisibilityScope(metadata);
-
-  if (scope === "global" || scope === "owner-private") {
-    return actorCanManageOwnerDocuments(actor);
-  }
-  if (scope === "agent-private") {
-    return actorCanManageAgentDocuments(actor);
-  }
-
-  const scopedEntityId = documentScopedEntityId(memory);
-  return (
-    actorCanManageAgentDocuments(actor) ||
-    (Boolean(scopedEntityId) && scopedEntityId === actor.entityId)
-  );
-}
-
 function buildRouteMessage({
   agentId,
   text,

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -16,11 +16,11 @@ import {
   documentMediaFormat,
   documentScopedEntityId,
   documentTags,
-  type DocumentFilter as SharedDocumentFilter,
   matchesDocumentFilter as matchesSharedDocumentFilter,
   parseDocumentScope,
   type RouteActor,
   routeActorAddedByRole,
+  type DocumentFilter as SharedDocumentFilter,
   trimString,
 } from "@elizaos/agent/api/document-access";
 import type {
@@ -328,7 +328,10 @@ function isDocumentMemory(memory: Memory, agentId: UUID): boolean {
   );
 }
 
-function matchesDocumentFilter(memory: Memory, filters: DocumentFilter): boolean {
+function matchesDocumentFilter(
+  memory: Memory,
+  filters: DocumentFilter,
+): boolean {
   if (!matchesSharedDocumentFilter(memory, filters)) return false;
 
   const metadata = asRecord(memory.metadata);


### PR DESCRIPTION
Implements knowledge slice 3 of the views-redesign epic (#13560). Depends on slice 1 (#13593, merged) and composes with slice 2's hub UI (#13594, open — see dependency note below).

Closes the Help half of #13377.

## What lands here (agent + backend layer — composes with the hub regardless of slice 2)

- **Shared access wall** (`packages/agent/src/api/document-access.ts`): the document scope-wall + facet matcher extracted out of `plugin-documents/routes.ts` into the inner agent layer so REST routes AND the new agent actions enforce ONE rule set. An owner-private item can never spill to a public-room actor through either surface (#13593 guard).
- **Three global knowledge actions** (registered in the always-loaded eliza plugin):
  - `SEARCH_KNOWLEDGE(query, filters)` — semantic + facet (room/sender/mediaFormat/tags/scope) search, scope-walled.
  - `ATTACH_TO_CHAT(itemId|sha256)` — resolve item → content-addressed media URL, deliver into the active conversation via the handler callback.
  - `SEND_MEDIA_TO(itemId, roomId)` — send stored media to a target room via `runtime.sendMessageToTarget`, mapped to a typed `DispatchResult` (never a boolean), refusing owner/user-private items into a public room via the shared send wall.

## Still landing on this branch (in progress)

- Help fold-in: seed former Help content as `help`-tagged default knowledge + retire/redirect the `/help` route.
- Real e2e + scenario (proactive greeting manifest entry) + search relevance/latency benchmark.
- Client full-filter passing + reader/search screenshots (compose with slice 2's hub).

## Dependency note (slice 2, #13594 open)

The folded hub UI, unified reader, filter chips, and audio playback are slice 2's `DocumentsView.tsx`. This slice deliberately implements the **search/actions/data** layer so it composes with that hub once merged; the thin UI affordances (Attach/Send buttons, filter chips wiring) attach to slice 2's surfaces. `plugin-documents/routes.ts` now imports the access wall from `@elizaos/agent/api/document-access` — CI's turbo build compiles agent before plugin-documents.

## Evidence

Draft — evidence (real-LLM scenario trajectories, e2e run, benchmark numbers, before/after desktop+mobile screenshots of reader/search/audio/full-screen) attached before ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)