### PR TITLE
fix(capacitor): detect iOS bridge env alias prefixes

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.state-dir-alias.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.state-dir-alias.test.ts
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveMobileStateDir } from "./bridge.ts";
 
 const TOUCHED_KEYS = [
+	"ACME_STATE_DIR",
 	"MILADY_STATE_DIR",
 	"ELIZA_STATE_DIR",
 	"ELIZA_HOME",
@@ -52,6 +53,16 @@ describe("iOS bridge ELIZA_STATE_DIR alias resolution", () => {
 		expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/data/milady/state");
 		expect(getBootConfig().envAliases).toContainEqual([
 			"MILADY_STATE_DIR",
+			"ELIZA_STATE_DIR",
+		]);
+	});
+
+	it("seeds aliases for a branded prefix present in the bridge environment", () => {
+		process.env.ACME_STATE_DIR = "/data/acme/state";
+		expect(resolveMobileStateDir()).toBe("/data/acme/state");
+		expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/data/acme/state");
+		expect(getBootConfig().envAliases).toContainEqual([
+			"ACME_STATE_DIR",
 			"ELIZA_STATE_DIR",
 		]);
 	});

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -175,6 +175,12 @@ type AgentModule = {
 };
 
 const IOS_BRIDGE_DEFAULT_ENV_PREFIX = "MILADY";
+const IOS_BRIDGE_BRAND_ENV_SUFFIXES = [
+	"STATE_DIR",
+	"NAMESPACE",
+	"PLATFORM",
+	"API_PORT",
+] as const;
 
 async function loadAgentModule(): Promise<AgentModule> {
 	const [{ bootElizaRuntime }, { dispatchRoute }] = await Promise.all([
@@ -1967,8 +1973,21 @@ function installIosBridgeEnvAliases(): void {
 	if (config.envAliases?.length) return;
 	setBootConfig({
 		...config,
-		envAliases: buildBrandEnvAliases(IOS_BRIDGE_DEFAULT_ENV_PREFIX),
+		envAliases: resolveIosBridgeEnvAliases(),
 	});
+}
+
+function resolveIosBridgeEnvAliases(): ReturnType<typeof buildBrandEnvAliases> {
+	const prefixes = new Set<string>([IOS_BRIDGE_DEFAULT_ENV_PREFIX]);
+	for (const key of Object.keys(process.env)) {
+		for (const suffix of IOS_BRIDGE_BRAND_ENV_SUFFIXES) {
+			const marker = `_${suffix}`;
+			if (!key.endsWith(marker)) continue;
+			const prefix = key.slice(0, -marker.length);
+			if (prefix && prefix !== "ELIZA") prefixes.add(prefix);
+		}
+	}
+	return [...prefixes].flatMap((prefix) => buildBrandEnvAliases(prefix));
 }
 
 function localInferenceRootPath(): string {


### PR DESCRIPTION
## Summary

Follow-up to #13961. That PR merged the iOS bridge pre-boot alias seed using `MILADY` as the only fallback prefix. This keeps the MILADY fallback, but also detects branded env prefixes already present in `process.env` before app boot, so a white-label bridge with `ACME_STATE_DIR` (or another branded prefix) resolves through the same alias-aware reader without requiring an `ELIZA_STATE_DIR` mirror.

## Verification

- `bun test ./plugins/plugin-capacitor-bridge/src/ios/bridge.state-dir-alias.test.ts` -> 5 pass, 9 expectations
- `bunx @biomejs/biome check plugins/plugin-capacitor-bridge/src/ios/bridge.ts plugins/plugin-capacitor-bridge/src/ios/bridge.state-dir-alias.test.ts --no-errors-on-unmatched`
- `git diff --check origin/develop...HEAD && git diff --check`

## Evidence / N/A

- Native iOS device/simulator run: N/A - pure pre-boot env alias table construction, covered by the focused bridge state-dir alias test. No UI/model/provider behavior changed.