### PR TITLE
fix(cloud-shared): user/DB service fail-closed audit + error-path tests (#13415 slice 8)

### DIFF
--- a/.github/issue-evidence/13415-user-services.md
+++ b/.github/issue-evidence/13415-user-services.md
@@ -1,0 +1,36 @@
+# #13415 — cloud-shared fallback sweep slice 8: user/DB services
+
+users, user-metrics, user-mcps, wallet-signup. Verified untouched at file level.
+
+## Findings
+These services now keep read-path DB failures distinct from designed-empty
+results (no swallow-to-null/[]/false), and wallet signup parses
+`INITIAL_FREE_CREDITS` strictly with `Number()` after full-token validation.
+- **users.ts** — added grep-able `// error-policy:J2/J6` on the 4 kept catches
+  (read-replica→primary failover rethrow; best-effort IAC cache eviction; org-
+  detach rollback that rethrows the original error). No behavior change. The
+  personal-org `$0.00` credit seed + old-org key deactivation left untouched
+  (money-path-flagged).
+- **user-metrics** — no source change; already fail closed.
+- **user-mcps** — read paths were already fail closed; the affiliate/referrer
+  money-path lookup now propagates instead of log-and-continuing into a charge
+  that silently drops owed fee metadata.
+- **wallet-signup** — malformed or negative `INITIAL_FREE_CREDITS` now throws
+  during config resolution instead of accepting a `parseFloat` prefix or
+  falling back to the default. Kept race-recovery catches are annotated; optional
+  welcome-credit grant failure returns explicit withheld metadata when the caller
+  does not require the grant.
+
+## Verification
+24 new error-path `bun:test` cases pass under `--isolate` (the CI invocation),
+proving an internal DB failure PROPAGATES (never reads as "no user"/"no MCP")
+while a genuine not-found stays a distinct designed-empty signal — driving the
+real exported services. biome clean; `audit:error-policy-ratchet` → "no new
+fallback-slop".
+
+(`user-database` deferred: its tenant-DB-provisioning error-path test is
+timing-sensitive in grouped runs; needs a deterministic harness — separate PR.)
+
+## N/A
+UI/model-trajectory/audio — N/A (server user-data services). Runtime traces —
+N/A - unit-boundary error-path coverage; no route surface added.

--- a/packages/cloud/shared/src/lib/services/user-mcps.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps.error-policy.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Error-policy pins for `userMcpsService` read paths (#13415).
+ *
+ * Proves the fail-closed invariant on the user-MCP registry: an INTERNAL DB
+ * failure PROPAGATES (it must never be swallowed into `null` / "not found"),
+ * while a legitimately-absent row stays a DISTINCT designed-empty signal
+ * (`getById` -> null; `update`/`delete` -> the "MCP not found" sentinel). The DB
+ * repository is toggled between "empty store" and "throws" so the two shapes are
+ * observably different from the exported service, not a tautology.
+ *
+ * No `fetch` is involved on these paths; the module boundary mocked here is the
+ * Drizzle repository. Mocks are declared before the singleton is imported so it
+ * binds to them.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { UserMcp } from "../../db/schemas/user-mcps";
+
+const ORG = "11111111-1111-1111-1111-111111111111";
+
+class RepositoryDown extends Error {
+  constructor() {
+    super("connection terminated unexpectedly");
+    this.name = "RepositoryDown";
+  }
+}
+
+// Toggle shared by every mocked repository read: `true` => the DB layer throws
+// (internal failure), `false` => the store answers normally (designed empty).
+let failMode = false;
+let referrerFailMode = false;
+let store: Map<string, UserMcp>;
+
+function guard(): void {
+  if (failMode) throw new RepositoryDown();
+}
+
+function makeRow(id: string): UserMcp {
+  return {
+    id,
+    name: "Weather Pro",
+    slug: "weather-pro",
+    description: "",
+    version: "1.0.0",
+    organization_id: ORG,
+    created_by_user_id: "33333333-3333-3333-3333-333333333333",
+    endpoint_type: "external",
+    container_id: null,
+    external_endpoint: "https://mcp.example.com/weather",
+    endpoint_path: "/mcp",
+    transport_type: "streamable-http",
+    tools: [{ name: "get_weather", description: "Get weather" }],
+    category: "utilities",
+    tags: [],
+    icon: "puzzle",
+    color: "#6366F1",
+    pricing_type: "credits",
+    credits_per_request: "1.0000",
+    x402_price_usd: "0.000100",
+    x402_enabled: false,
+    creator_share_percentage: "80.00",
+    platform_share_percentage: "20.00",
+    status: "draft",
+    is_public: true,
+    is_verified: false,
+    documentation_url: null,
+    source_code_url: null,
+    support_email: null,
+    metadata: {},
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    updated_at: new Date("2026-01-01T00:00:00.000Z"),
+  } as unknown as UserMcp;
+}
+
+mock.module("../../db/repositories", () => ({
+  userMcpsRepository: {
+    async getById(id: string): Promise<UserMcp | null> {
+      guard();
+      return store.get(id) ?? null;
+    },
+    async getBySlug(slug: string, organizationId: string): Promise<UserMcp | null> {
+      guard();
+      for (const row of store.values()) {
+        if (row.slug === slug && row.organization_id === organizationId) return row;
+      }
+      return null;
+    },
+    async update(id: string, data: Partial<UserMcp>): Promise<UserMcp | null> {
+      guard();
+      const existing = store.get(id);
+      if (!existing) return null;
+      const updated = { ...existing, ...data } as UserMcp;
+      store.set(id, updated);
+      return updated;
+    },
+    async delete(): Promise<boolean> {
+      guard();
+      return true;
+    },
+  },
+  mcpUsageRepository: {},
+}));
+
+mock.module("../cache/client", () => ({
+  cache: {
+    async get() {
+      return null;
+    },
+    async set() {},
+    async del() {},
+  },
+}));
+
+mock.module("../security/outbound-url", () => ({
+  assertSafeOutboundUrl: async (raw: string) => new URL(raw),
+  assertSafeOutboundUrlSync: (raw: string) => new URL(raw),
+}));
+
+mock.module("./containers", () => ({ containersService: {} }));
+mock.module("./credits", () => ({ creditsService: {} }));
+mock.module("./redeemable-earnings", () => ({ redeemableEarningsService: {} }));
+mock.module("./affiliates", () => ({
+  affiliatesService: {
+    async getReferrer() {
+      if (referrerFailMode) throw new RepositoryDown();
+      return null;
+    },
+  },
+}));
+mock.module("../utils/logger", () => ({
+  logger: { info() {}, warn() {}, error() {}, debug() {} },
+}));
+
+const { userMcpsService } = await import("./user-mcps");
+
+beforeEach(() => {
+  store = new Map();
+  failMode = false;
+  referrerFailMode = false;
+});
+
+afterEach(() => {
+  failMode = false;
+  referrerFailMode = false;
+});
+
+describe("userMcpsService.getById — internal failure vs designed empty", () => {
+  test("returns null for a genuinely-absent MCP (designed empty)", async () => {
+    expect(await userMcpsService.getById("does-not-exist")).toBeNull();
+  });
+
+  test("PROPAGATES a repository failure — must NOT read as 'no such MCP' (null)", async () => {
+    failMode = true;
+    await expect(userMcpsService.getById("mcp-1")).rejects.toThrow(RepositoryDown);
+  });
+
+  test("the two outcomes are distinguishable from the same call site", async () => {
+    // Absent -> null (never throws); down -> throws (never null). If a catch ever
+    // swallowed the DB error into null these two would collapse into one shape.
+    expect(await userMcpsService.getById("mcp-1")).toBeNull();
+    failMode = true;
+    let threw = false;
+    try {
+      await userMcpsService.getById("mcp-1");
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+  });
+});
+
+describe("userMcpsService.getBySlug — internal failure vs designed empty", () => {
+  test("returns null when no MCP matches the slug (designed empty)", async () => {
+    expect(await userMcpsService.getBySlug("nope", ORG)).toBeNull();
+  });
+
+  test("PROPAGATES a repository failure instead of masking it as 'not found'", async () => {
+    failMode = true;
+    await expect(userMcpsService.getBySlug("weather-pro", ORG)).rejects.toThrow(RepositoryDown);
+  });
+});
+
+describe("userMcpsService.update — not-found sentinel stays distinct from DB failure", () => {
+  test("throws the 'MCP not found' sentinel when the row is genuinely absent", async () => {
+    await expect(userMcpsService.update("missing", ORG, { name: "x" })).rejects.toThrow(
+      /MCP not found/,
+    );
+  });
+
+  test("PROPAGATES the raw repository failure (distinct from the not-found sentinel)", async () => {
+    store.set("mcp-1", makeRow("mcp-1"));
+    failMode = true;
+    // A masked failure would surface as "MCP not found"; the real DB error must
+    // surface untranslated so callers see the outage, not a phantom 404.
+    const err = await userMcpsService.update("mcp-1", ORG, { name: "x" }).catch((e) => e);
+    expect(err).toBeInstanceOf(RepositoryDown);
+    expect((err as Error).message).not.toMatch(/MCP not found/);
+  });
+});
+
+describe("userMcpsService.recordUsage — money-path failures fail closed", () => {
+  test("PROPAGATES affiliate/referrer lookup failure before charging", async () => {
+    store.set("mcp-1", makeRow("mcp-1"));
+    referrerFailMode = true;
+
+    await expect(
+      userMcpsService.recordUsage({
+        mcpId: "mcp-1",
+        organizationId: ORG,
+        userId: "user-1",
+        toolName: "get_weather",
+        paymentType: "credits",
+      }),
+    ).rejects.toThrow(RepositoryDown);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/user-mcps.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps.ts
@@ -423,20 +423,18 @@ class UserMcpsService {
     let affiliateCodeId: string | null = null;
 
     if (params.userId) {
-      try {
-        const { affiliatesService } = await import("./affiliates");
-        const referrer = await affiliatesService.getReferrer(params.userId!);
-        if (referrer) {
-          affiliateOwnerId = referrer.user_id;
-          affiliateCodeId = referrer.id;
-          const affiliatePercent = Number(referrer.markup_percent);
-          const platformPercent = 20.0;
+      // The affiliate lookup participates in the money path. If it is unavailable,
+      // fail before charging so the transaction cannot silently drop owed fees.
+      const { affiliatesService } = await import("./affiliates");
+      const referrer = await affiliatesService.getReferrer(params.userId);
+      if (referrer) {
+        affiliateOwnerId = referrer.user_id;
+        affiliateCodeId = referrer.id;
+        const affiliatePercent = Number(referrer.markup_percent);
+        const platformPercent = 20.0;
 
-          affiliateFeeCredits = creditsCharged * (affiliatePercent / 100);
-          platformFeeCredits = creditsCharged * (platformPercent / 100);
-        }
-      } catch (e) {
-        logger.error(`[UserMcps] Error fetching referrer for ${params.userId}`, e);
+        affiliateFeeCredits = creditsCharged * (affiliatePercent / 100);
+        platformFeeCredits = creditsCharged * (platformPercent / 100);
       }
     }
 

--- a/packages/cloud/shared/src/lib/services/user-metrics.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/user-metrics.error-policy.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Pins the fail-closed contract of UserMetricsService: an internal DB read
+ * failure must PROPAGATE (reject) out of the exported service, and must stay
+ * distinguishable from a legitimately-empty result (zero users / no
+ * credentials), which resolves to a well-formed zeroed DTO. Uses a chainable
+ * thenable stub for `dbRead` so no real Postgres/PGlite is touched.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+// Per-test resolvers for the two distinct query builders getOAuthConnectionRate
+// issues: `.select()` (COUNT of non-anonymous users) and `.selectDistinct()`
+// (active platform credentials). A resolver may throw to simulate a DB failure.
+let selectResolver: () => unknown = () => [{ cnt: 0 }];
+let selectDistinctResolver: () => unknown = () => [];
+
+// Minimal Drizzle-shaped chainable thenable: every builder method returns the
+// same object, and awaiting it runs the resolver. Throwing inside the resolver
+// rejects the await, mirroring a real driver-level query failure.
+function chain(resolver: () => unknown) {
+  const builder: Record<string, unknown> = {};
+  for (const m of ["from", "leftJoin", "innerJoin", "where", "groupBy", "orderBy", "limit"]) {
+    builder[m] = () => builder;
+  }
+  // biome-ignore lint/suspicious/noThenProperty: Drizzle query builders are awaitable thenables.
+  builder.then = (res: (v: unknown) => unknown, rej: (e: unknown) => unknown) =>
+    Promise.resolve().then(resolver).then(res, rej);
+  builder.catch = (rej: (e: unknown) => unknown) => Promise.resolve().then(resolver).catch(rej);
+  builder.finally = (f: () => void) => Promise.resolve().then(resolver).finally(f);
+  return builder;
+}
+
+const dbStub = {
+  select: () => chain(selectResolver),
+  selectDistinct: () => chain(selectDistinctResolver),
+};
+
+mock.module("../../db/client", () => ({ dbRead: dbStub, dbWrite: dbStub }));
+
+const { userMetricsService } = await import("./user-metrics");
+
+beforeEach(() => {
+  selectResolver = () => [{ cnt: 0 }];
+  selectDistinctResolver = () => [];
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("UserMetricsService fail-closed contract", () => {
+  test("designed-empty: no users and no credentials resolves to a zeroed DTO", async () => {
+    selectResolver = () => [{ cnt: 0 }];
+    selectDistinctResolver = () => [];
+
+    const result = await userMetricsService.getOAuthConnectionRate();
+
+    expect(result).toEqual({
+      total_users: 0,
+      connected_users: 0,
+      rate: 0,
+      byService: {},
+    });
+  });
+
+  test("populated: real counts flow through untouched", async () => {
+    selectResolver = () => [{ cnt: 4 }];
+    selectDistinctResolver = () => [
+      { userId: "u1", platform: "discord" },
+      { userId: "u2", platform: "discord" },
+      { userId: "u1", platform: "telegram" },
+    ];
+
+    const result = await userMetricsService.getOAuthConnectionRate();
+
+    expect(result.total_users).toBe(4);
+    expect(result.connected_users).toBe(2); // distinct users u1, u2
+    expect(result.byService).toEqual({ discord: 2, telegram: 1 });
+    expect(result.rate).toBeCloseTo(0.5, 10);
+  });
+
+  test("internal failure: a failed user-count read PROPAGATES, never reads as zero", async () => {
+    const boom = new Error("connection terminated unexpectedly");
+    selectResolver = () => {
+      throw boom;
+    };
+    selectDistinctResolver = () => [];
+
+    // The failure must surface as a rejection — it must NOT be swallowed into a
+    // { total_users: 0, ... } success that conflates "DB down" with "no users".
+    await expect(userMetricsService.getOAuthConnectionRate()).rejects.toThrow(
+      "connection terminated unexpectedly",
+    );
+  });
+
+  test("internal failure: a failed credentials read PROPAGATES", async () => {
+    selectResolver = () => [{ cnt: 4 }];
+    selectDistinctResolver = () => {
+      throw new Error("relation platform_credentials does not exist");
+    };
+
+    await expect(userMetricsService.getOAuthConnectionRate()).rejects.toThrow(
+      "relation platform_credentials does not exist",
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/users.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/users.error-policy.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Pins the fail-closed error policy of UsersService: an internal DB failure on a
+ * user read must PROPAGATE (a broken pipeline must never read as "no user"),
+ * while a genuine not-found result stays a distinct `undefined`. Deterministic
+ * repository fixtures; the retry helper is a pass-through so the real failover
+ * branch in getByStewardId is exercised.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const findById = mock();
+const findByStewardIdWithOrganization = mock();
+const findByStewardIdWithOrganizationForWrite = mock();
+
+mock.module("../../db/repositories", () => ({
+  usersRepository: {
+    findById,
+    findByStewardIdWithOrganization,
+    findByStewardIdWithOrganizationForWrite,
+  },
+  apiKeysRepository: { listByUser: mock(async () => []) },
+  organizationsRepository: { findBySlug: mock(), create: mock(), delete: mock() },
+}));
+
+// Pass-through: invoke the wrapped query once and let its errors surface, so the
+// read→primary failover and the terminal rethrow in getByStewardId run for real.
+mock.module("../../db/retry-transient", () => ({
+  retryOnTransientDbError: async <T>(fn: () => Promise<T>): Promise<T> => fn(),
+}));
+
+mock.module("../cache/client", () => ({
+  cache: {
+    get: mock(async () => undefined),
+    set: mock(async () => undefined),
+    del: mock(async () => undefined),
+  },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
+}));
+
+mock.module("./inference-auth-cache", () => ({
+  invalidateInferenceAuthContextsByKeyHashes: mock(async () => undefined),
+}));
+
+const { UsersService } = await import(`./users.ts?test=users-error-policy-${Date.now()}`);
+const service = new UsersService();
+
+beforeEach(() => {
+  findById.mockReset();
+  findByStewardIdWithOrganization.mockReset();
+  findByStewardIdWithOrganizationForWrite.mockReset();
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("UsersService error policy — internal failure vs designed-empty", () => {
+  test("getById propagates a DB read failure (fail closed, not undefined)", async () => {
+    findById.mockRejectedValue(new Error("connection terminated unexpectedly"));
+
+    await expect(service.getById("user-1")).rejects.toThrow("connection terminated unexpectedly");
+    expect(findById).toHaveBeenCalledTimes(1);
+  });
+
+  test("getById returns undefined for a genuine not-found (designed empty, distinct)", async () => {
+    findById.mockResolvedValue(undefined);
+
+    await expect(service.getById("missing")).resolves.toBeUndefined();
+  });
+
+  test("getByStewardId rethrows when both replica and primary fail (never fabricates no-user)", async () => {
+    findByStewardIdWithOrganization.mockRejectedValue(new Error("replica EOF"));
+    findByStewardIdWithOrganizationForWrite.mockRejectedValue(new Error("primary down"));
+
+    // Fails closed: the auth hot path must 500, not treat the session as unknown.
+    await expect(service.getByStewardId("steward-1")).rejects.toThrow("primary down");
+    expect(findByStewardIdWithOrganization).toHaveBeenCalledTimes(1);
+    expect(findByStewardIdWithOrganizationForWrite).toHaveBeenCalledTimes(1);
+  });
+
+  test("getByStewardId recovers via the primary when only the replica fails", async () => {
+    findByStewardIdWithOrganization.mockRejectedValue(new Error("replica EOF"));
+    findByStewardIdWithOrganizationForWrite.mockResolvedValue({
+      id: "user-9",
+      organization: { id: "org-9" },
+    });
+
+    const user = await service.getByStewardId("steward-9");
+    expect(user?.id).toBe("user-9");
+  });
+
+  test("getByStewardId returns undefined for a genuine not-found (distinct from failure)", async () => {
+    findByStewardIdWithOrganization.mockResolvedValue(undefined);
+
+    await expect(service.getByStewardId("steward-none")).resolves.toBeUndefined();
+    expect(findByStewardIdWithOrganizationForWrite).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/users.ts
+++ b/packages/cloud/shared/src/lib/services/users.ts
@@ -126,9 +126,9 @@ export class UsersService {
         logger.debug("[UsersService] Cached user data by stewardId");
       }
       return user;
+    } catch (error) {
       // error-policy:J2 auth hot path — read-replica lookup failed; add context and
       // fail over to the primary. Never fabricates a user; rethrows via the inner catch.
-    } catch (error) {
       const errorDetails = getErrorDetails(error);
 
       logger.warn("[UsersService] Read-path Steward lookup failed, retrying on primary", {
@@ -140,9 +140,9 @@ export class UsersService {
         return await retryOnTransientDbError(() => this.getByStewardIdForWrite(stewardUserId), {
           attempts: 2,
         });
+      } catch (fallbackError) {
         // error-policy:J2 both replica and primary failed — record combined context and
         // rethrow the primary error (its cause chain is preserved) so the caller 500s.
-      } catch (fallbackError) {
         logger.error("[UsersService] Primary Steward lookup retry failed", {
           stewardUserId,
           readError: errorDetails,
@@ -257,9 +257,9 @@ export class UsersService {
     try {
       const keys = await apiKeysRepository.listByUser(userId);
       await invalidateInferenceAuthContextsByKeyHashes(keys.map((k) => k.key_hash));
+    } catch (error) {
       // error-policy:J6 best-effort IAC cache eviction — a cache blip must not break the
       // lifecycle write (deactivate/detach/delete). The slow path still enforces is_active.
-    } catch (error) {
       logger.warn("[UsersService] Failed to invalidate inference auth cache for user", {
         userId,
         ...getErrorDetails(error),
@@ -374,9 +374,9 @@ export class UsersService {
       // Don't strand an empty org when the move fails.
       try {
         await organizationsRepository.delete(organization.id);
+      } catch (rollbackError) {
         // error-policy:J6 best-effort rollback of the just-created empty org; log and
         // fall through to rethrow the original move failure (never masks it).
-      } catch (rollbackError) {
         logger.error("[UsersService] Failed to roll back personal org after detach failure", {
           userId: id,
           organizationId: organization.id,

--- a/packages/cloud/shared/src/lib/services/users.ts
+++ b/packages/cloud/shared/src/lib/services/users.ts
@@ -126,6 +126,8 @@ export class UsersService {
         logger.debug("[UsersService] Cached user data by stewardId");
       }
       return user;
+      // error-policy:J2 auth hot path — read-replica lookup failed; add context and
+      // fail over to the primary. Never fabricates a user; rethrows via the inner catch.
     } catch (error) {
       const errorDetails = getErrorDetails(error);
 
@@ -138,6 +140,8 @@ export class UsersService {
         return await retryOnTransientDbError(() => this.getByStewardIdForWrite(stewardUserId), {
           attempts: 2,
         });
+        // error-policy:J2 both replica and primary failed — record combined context and
+        // rethrow the primary error (its cause chain is preserved) so the caller 500s.
       } catch (fallbackError) {
         logger.error("[UsersService] Primary Steward lookup retry failed", {
           stewardUserId,
@@ -253,6 +257,8 @@ export class UsersService {
     try {
       const keys = await apiKeysRepository.listByUser(userId);
       await invalidateInferenceAuthContextsByKeyHashes(keys.map((k) => k.key_hash));
+      // error-policy:J6 best-effort IAC cache eviction — a cache blip must not break the
+      // lifecycle write (deactivate/detach/delete). The slow path still enforces is_active.
     } catch (error) {
       logger.warn("[UsersService] Failed to invalidate inference auth cache for user", {
         userId,
@@ -368,6 +374,8 @@ export class UsersService {
       // Don't strand an empty org when the move fails.
       try {
         await organizationsRepository.delete(organization.id);
+        // error-policy:J6 best-effort rollback of the just-created empty org; log and
+        // fall through to rethrow the original move failure (never masks it).
       } catch (rollbackError) {
         logger.error("[UsersService] Failed to roll back personal org after detach failure", {
           userId: id,

--- a/packages/cloud/shared/src/lib/services/wallet-signup.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/wallet-signup.error-policy.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Fail-closed error semantics for wallet signup: an internal DB failure during
+ * org/user creation must PROPAGATE (never swallow into a fabricated user),
+ * while the designed unique-violation race recovers to the winning row and a
+ * genuinely-found existing user returns distinctly. Collaborators are mocked to
+ * inject the two failure shapes; the real findOrCreateUserByWalletAddress
+ * control flow is under test (deterministic mocks, no live DB, no network).
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.INITIAL_FREE_CREDITS = "0";
+process.env.NODE_ENV ||= "test";
+
+const EVM_ADDRESS = `0x${"cd".repeat(20)}`;
+
+// Mutable behavior holders — each test rewires the collaborator responses.
+let getByWallet: (addr: string) => Promise<unknown>;
+let findBySlug: (slug: string) => Promise<unknown>;
+let orgCreate: (input: unknown) => Promise<unknown>;
+let userCreate: (input: { organization_id: string; role: string }) => Promise<unknown>;
+
+mock.module("../../db/repositories/organizations", () => ({
+  organizationsRepository: { findBySlug: (s: string) => findBySlug(s) },
+}));
+mock.module("../../db/repositories/users", () => ({
+  usersRepository: { create: (i: { organization_id: string; role: string }) => userCreate(i) },
+}));
+mock.module("./organizations", () => ({
+  organizationsService: { create: (i: unknown) => orgCreate(i) },
+}));
+mock.module("./users", () => ({
+  usersService: {
+    getByWalletAddressWithOrganization: (a: string) => getByWallet(a),
+    findBySolanaWalletAddressWithOrganization: (a: string) => getByWallet(a),
+  },
+}));
+mock.module("./credits", () => ({
+  creditsService: {
+    addCredits: () => {
+      throw new Error("credits must not be touched with grantInitialCredits:false");
+    },
+  },
+}));
+mock.module("./signup-grant-guard", () => ({
+  runWithSignupGrantIpCapDetailed: () => {
+    throw new Error("grant guard must not run with grantInitialCredits:false");
+  },
+}));
+mock.module("../runtime/request-context", () => ({ getClientIp: () => "1.2.3.4" }));
+
+let walletSignup: typeof import("./wallet-signup");
+
+beforeAll(async () => {
+  walletSignup = await import("./wallet-signup");
+});
+
+const originalFetch = globalThis.fetch;
+beforeEach(() => {
+  globalThis.fetch = mock(() => {
+    throw new Error("no network allowed in this test");
+  }) as never;
+  // Sensible defaults; individual tests override.
+  getByWallet = async () => null;
+  findBySlug = async () => null;
+  orgCreate = async () => {
+    throw new Error("orgCreate not configured");
+  };
+  userCreate = async () => {
+    throw new Error("userCreate not configured");
+  };
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("wallet-signup fail-closed error policy", () => {
+  test("rejects malformed INITIAL_FREE_CREDITS instead of accepting a partial parse", async () => {
+    process.env.INITIAL_FREE_CREDITS = "12abc";
+
+    await expect(import(`./wallet-signup.ts?bad-credits-${Date.now()}`)).rejects.toThrow(
+      /INITIAL_FREE_CREDITS/,
+    );
+  });
+
+  test("rejects negative INITIAL_FREE_CREDITS instead of falling back to the default", async () => {
+    process.env.INITIAL_FREE_CREDITS = "-1";
+
+    await expect(import(`./wallet-signup.ts?negative-credits-${Date.now()}`)).rejects.toThrow(
+      /INITIAL_FREE_CREDITS/,
+    );
+  });
+
+  test("internal DB failure during org creation PROPAGATES (not swallowed into a fake user)", async () => {
+    process.env.INITIAL_FREE_CREDITS = "0";
+    getByWallet = async () => null;
+    findBySlug = async () => null;
+    orgCreate = async () => {
+      throw new Error("connection terminated unexpectedly");
+    };
+
+    await expect(
+      walletSignup.findOrCreateUserByWalletAddress(EVM_ADDRESS, { grantInitialCredits: false }),
+    ).rejects.toThrow("connection terminated unexpectedly");
+  });
+
+  test("unique-violation on org create is a DESIGNED race recovery to the winning org", async () => {
+    const racedOrg = { id: "org-raced", slug: "wallet-slug" };
+    let slugCalls = 0;
+    getByWallet = async () => null;
+    findBySlug = async () => (slugCalls++ === 0 ? null : racedOrg);
+    orgCreate = async () => {
+      throw new Error("duplicate key value violates unique constraint");
+    };
+    userCreate = async (input) => ({
+      id: "user-1",
+      organization_id: input.organization_id,
+      role: input.role,
+    });
+
+    const res = await walletSignup.findOrCreateUserByWalletAddress(EVM_ADDRESS, {
+      grantInitialCredits: false,
+    });
+
+    expect(res.isNewAccount).toBe(true);
+    expect(res.user.organization).toBe(racedOrg as never);
+    expect(res.user.organization_id).toBe("org-raced");
+  });
+
+  test("internal DB failure during user creation PROPAGATES", async () => {
+    const org = { id: "org-1", slug: "wallet-slug" };
+    getByWallet = async () => null;
+    findBySlug = async () => org;
+    userCreate = async () => {
+      throw new Error("deadlock detected");
+    };
+
+    await expect(
+      walletSignup.findOrCreateUserByWalletAddress(EVM_ADDRESS, { grantInitialCredits: false }),
+    ).rejects.toThrow("deadlock detected");
+  });
+
+  test("user-create unique-violation with unrecoverable re-fetch RETHROWS (never fabricates a user)", async () => {
+    const org = { id: "org-1", slug: "wallet-slug" };
+    // Both the initial lookup and the post-race re-fetch return null: the race
+    // handler must not invent a user, it must rethrow the original error.
+    getByWallet = async () => null;
+    findBySlug = async () => org;
+    userCreate = async () => {
+      throw new Error("duplicate key value violates unique constraint users_wallet_address");
+    };
+
+    await expect(
+      walletSignup.findOrCreateUserByWalletAddress(EVM_ADDRESS, { grantInitialCredits: false }),
+    ).rejects.toThrow("duplicate key value violates unique constraint");
+  });
+
+  test("a genuinely-found existing user returns distinctly (isNewAccount=false, no creation)", async () => {
+    const existing = { id: "u-existing", organization: { id: "o-existing" }, role: "owner" };
+    getByWallet = async () => existing;
+
+    const res = await walletSignup.findOrCreateUserByWalletAddress(EVM_ADDRESS, {
+      grantInitialCredits: false,
+    });
+
+    expect(res.isNewAccount).toBe(false);
+    expect(res.user).toBe(existing as never);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/wallet-signup.ts
+++ b/packages/cloud/shared/src/lib/services/wallet-signup.ts
@@ -21,9 +21,16 @@ import { usersService } from "./users";
 
 export const INITIAL_FREE_CREDITS = ((): number => {
   const v = process.env.INITIAL_FREE_CREDITS;
-  if (v === undefined || v === "") return 5;
-  const n = Number.parseFloat(v);
-  return Number.isNaN(n) || n < 0 ? 5 : n;
+  if (v === undefined || v.trim() === "") return 5;
+  const trimmed = v.trim();
+  if (!/^\d+(?:\.\d+)?$/.test(trimmed)) {
+    throw new Error(`[WalletSignup] INITIAL_FREE_CREDITS must be a non-negative decimal`);
+  }
+  const n = Number(trimmed);
+  if (!Number.isFinite(n)) {
+    throw new Error(`[WalletSignup] INITIAL_FREE_CREDITS must be finite`);
+  }
+  return n;
 })();
 
 export interface FindOrCreateWalletOptions {
@@ -79,11 +86,19 @@ async function grantWalletSignupCredits(params: {
         : {}),
     };
   } catch (err) {
+    // error-policy:J4 explicit user-facing degrade — wallet signup may continue
+    // without optional welcome credits only when the caller has not required the
+    // grant; metadata distinguishes the withheld bonus from a normal zero grant.
     logger.error("[WalletSignup] Failed to grant initial credits:", err);
     if (params.requireInitialCredits) {
       throw err;
     }
-    return { initialCreditsGranted: false, initialFreeCreditsUsd: 0 };
+    return {
+      initialCreditsGranted: false,
+      initialFreeCreditsUsd: 0,
+      welcomeBonusWithheld: true,
+      welcomeBonusWithheldMessage: "Initial credit grant failed; signup continued without bonus.",
+    };
   }
 }
 
@@ -153,18 +168,16 @@ export async function findOrCreateUserByWalletAddress(
         credit_balance: "0.00",
       });
     } catch (e) {
-      // Note: Handle race condition where two concurrent requests try to create the same org
+      // error-policy:J3 unique-violation race recovery — retry only the expected
+      // concurrent org-create collision; all other creation failures propagate.
       const isUniqueViolation =
         e instanceof Error && (e.message.includes("unique") || e.message.includes("duplicate"));
       if (!isUniqueViolation) throw e;
 
-      // Important: For race conditions, retry finding the org that won the race
       org = (await organizationsRepository.findBySlug(slug)) ?? null;
       if (!org) {
-        // If we still can't find it, something else went wrong
         throw new Error("Organization creation failed and could not find existing org");
       }
-      // Note: Skip initial credits for raced org - first creator already granted them
     }
   }
   const initialCreditGrant =
@@ -198,7 +211,8 @@ export async function findOrCreateUserByWalletAddress(
       ...initialCreditGrant,
     };
   } catch (e) {
-    /* WHY handle unique violation: two concurrent signups for same wallet; second should see the first's user. */
+    // error-policy:J3 unique-violation race recovery — the losing concurrent
+    // signup returns the winner's row; missing re-fetch rethrows the original.
     const isUniqueViolation =
       e instanceof Error && (e.message.includes("unique") || e.message.includes("duplicate"));
     if (!isUniqueViolation) throw e;
@@ -247,6 +261,8 @@ export async function findOrCreateSolanaUserByWalletAddress(
         credit_balance: "0.00",
       });
     } catch (e) {
+      // error-policy:J3 unique-violation race recovery — retry only the expected
+      // concurrent org-create collision; all other creation failures propagate.
       const isUniqueViolation =
         e instanceof Error && (e.message.includes("unique") || e.message.includes("duplicate"));
       if (!isUniqueViolation) throw e;
@@ -285,6 +301,8 @@ export async function findOrCreateSolanaUserByWalletAddress(
       ...initialCreditGrant,
     };
   } catch (e) {
+    // error-policy:J3 unique-violation race recovery — the losing concurrent
+    // signup returns the winner's row; missing re-fetch rethrows the original.
     const isUniqueViolation =
       e instanceof Error && (e.message.includes("unique") || e.message.includes("duplicate"));
     if (!isUniqueViolation) throw e;


### PR DESCRIPTION
## Slice 8 of #13415 — user/DB services

users · user-metrics · user-mcps · wallet-signup.

- **users.ts** — grep-able `// error-policy:J2/J6` annotations on the 4 kept catches (read-replica→primary failover rethrow; best-effort IAC cache eviction; org-detach rollback that rethrows the original error). The personal-org `$0.00` seed + old-org key deactivation remain untouched (money-path-flagged).
- **user-metrics** — no source change; already fail closed.
- **user-mcps** — read paths were already fail closed; the affiliate/referrer money-path lookup now propagates instead of log-and-continuing into a charge that silently drops owed fee metadata.
- **wallet-signup** — `INITIAL_FREE_CREDITS` now uses strict full-token validation + `Number()` and throws for malformed/negative config instead of accepting a `parseFloat` prefix or falling back to the default. Kept race-recovery catches are annotated, and optional welcome-credit grant failure returns explicit withheld metadata when the caller does not require the grant.

**Verification** (`.github/issue-evidence/13415-user-services.md`): 24 error-path cases pass under `--isolate` at assertion level (the local Bun reporter printed all 24 passes but then hung in coverage/handle cleanup and had to be interrupted); targeted Biome on touched files passes; `audit:error-policy-ratchet --report` passes with user-mcps/users/wallet-signup as the changed production files. `user-database` remains deferred to a deterministic harness slice.