### PR TITLE
fix(cloud-shared): reject misplaced docker CPU percent tokens

### DIFF
--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/docker-stats.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/docker-stats.error-policy.test.ts
@@ -118,6 +118,9 @@ describe("parseDockerStats — internal failure propagates (fail closed)", () =>
       line("50.0%", ". / 512MiB", "0B / 0B", "0B / 0B"), // bare dot -> NaN
       line("50.0%", "12abc / 512MiB", "0B / 0B", "0B / 0B"), // trailing garbage
       line("1e3%", "128MiB / 512MiB", "0B / 0B", "0B / 0B"), // exponent form (not docker output)
+      line("%12", "128MiB / 512MiB", "0B / 0B", "0B / 0B"), // misplaced percent
+      line("12%3", "128MiB / 512MiB", "0B / 0B", "0B / 0B"), // embedded percent
+      line("12.3", "128MiB / 512MiB", "0B / 0B", "0B / 0B"), // missing percent suffix
     ];
     for (const bad of malformed) {
       let err: unknown;

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/docker-stats.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/docker-stats.ts
@@ -57,14 +57,14 @@ const SIZE_UNITS: Record<string, number> = {
  * that is not a single well-formed decimal (throws `invalid_input`).
  */
 function parseCpuPercent(raw: string): number {
-  const token = raw.replace("%", "").trim();
-  if (!/^\d+(?:\.\d+)?$/.test(token)) {
+  const match = raw.trim().match(/^(\d+(?:\.\d+)?)%$/);
+  if (!match) {
     throw new HetznerClientError(
       "invalid_input",
       `Failed to parse docker stats CPU percent: ${JSON.stringify(raw)}`,
     );
   }
-  return Number(token);
+  return Number(match[1]);
 }
 
 function parseSize(raw: string): number {


### PR DESCRIPTION
## Summary

Follow-up to merged #13968 / #13415 slice 5. While verifying the strict docker-stats parser, I found `parseCpuPercent` still used `raw.replace("%", "")`. That removes the first percent anywhere in the token, so malformed CPU values like `%12` or `12%3` can become valid numeric strings and pass the strict parse.

This tightens CPU parsing to require exactly `<decimal>%` and adds regressions for misplaced, embedded, and missing percent suffixes.

## Verification

- `bun test packages/cloud/shared/src/lib/services/containers/hetzner-client/docker-stats.error-policy.test.ts` -> 10 pass, 48 expect calls
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/containers/hetzner-client/docker-stats.ts packages/cloud/shared/src/lib/services/containers/hetzner-client/docker-stats.error-policy.test.ts --no-errors-on-unmatched` -> pass
- `git diff --check origin/develop...HEAD && git diff --check` -> pass
- `bun run audit:error-policy-ratchet` -> no new fallback-slop

## Evidence

N/A UI screenshots/video/model trajectories/audio: lower-level infra parser hardening, no route/UI/model behavior added.

Refs #13415.