### PR TITLE
fix(cloud): self-heal a missing default eliza character on session resolution

### DIFF
--- a/packages/cloud/shared/src/db/repositories/characters.ts
+++ b/packages/cloud/shared/src/db/repositories/characters.ts
@@ -354,6 +354,26 @@ export class UserCharactersRepository {
   }
 
   /**
+   * Checks whether an organization has any character of the given source.
+   * Bounded existence probe for hot paths (e.g. the session-time
+   * default-character self-heal) — never use listByOrganization just to test
+   * emptiness, character rows are fat and the list is unbounded.
+   */
+  async existsForOrganization(
+    organizationId: string,
+    source: "cloud" | "miniapp" = "cloud",
+  ): Promise<boolean> {
+    const result = await dbRead
+      .select({ id: userCharacters.id })
+      .from(userCharacters)
+      .where(
+        and(eq(userCharacters.organization_id, organizationId), eq(userCharacters.source, source)),
+      )
+      .limit(1);
+    return result.length > 0;
+  }
+
+  /**
    * Lists public characters (cloud source only). Always bounded — pass a
    * limit/offset for pagination instead of relying on caller-side slicing.
    * `name` search is pushed into SQL when provided; `bio` is jsonb and is

--- a/packages/cloud/shared/src/lib/auth-default-character-selfheal.test.ts
+++ b/packages/cloud/shared/src/lib/auth-default-character-selfheal.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression: session resolution must self-heal an account left without its
+ * default Eliza character.
+ *
+ * The only create site for the default character is the one-time new-user
+ * signup branch in steward-sync, and a create failure there is swallowed so
+ * the signup survives. Every later login returns at the existing-user branch,
+ * so before this heal existed such an account stayed character-less forever.
+ * This drives the real getCurrentUserFromRequest and the real
+ * ensureDefaultCharacter on a session-cache miss for an existing user whose
+ * org has zero characters, and proves the default is re-seeded. Deterministic
+ * harness: cache/token-verify/db services are in-memory mocks; no live model.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+const existingUser = {
+  id: "user-1",
+  steward_user_id: "steward-123",
+  email: "alice@example.com",
+  name: "alice",
+  role: "owner",
+  is_active: true,
+  organization_id: "org-1",
+  organization: { id: "org-1", name: "alice's Organization", is_active: true },
+};
+
+let characterCreateCalls: Array<Record<string, unknown>> = [];
+
+mock.module("./cache/client", () => ({
+  cache: {
+    get: async () => null,
+    set: async () => undefined,
+    del: async () => undefined,
+  },
+}));
+mock.module("./auth/steward-client", () => ({
+  verifyStewardTokenCached: async () => ({ userId: "steward-123" }),
+  invalidateStewardTokenCache: async () => undefined,
+}));
+mock.module("./auth/playwright-test-session", () => ({
+  isPlaywrightTestAuthEnabled: () => false,
+  verifyPlaywrightTestSessionToken: () => null,
+  PLAYWRIGHT_TEST_SESSION_COOKIE_NAME: "pw-test-session",
+}));
+mock.module("./auth/wallet-auth", () => ({
+  verifyWalletSignature: async () => {
+    throw new Error("unused in this test");
+  },
+}));
+mock.module("./services/admin", () => ({ adminService: {} }));
+mock.module("./services/user-sessions", () => ({
+  userSessionsService: { getOrCreateSession: async () => ({ id: "sess-1" }) },
+}));
+mock.module("./services/users", () => ({
+  usersService: {
+    getByStewardId: async () => existingUser,
+    getByStewardIdForWrite: async () => existingUser,
+    getByEmailWithOrganization: async () => undefined,
+    getByWalletAddress: async () => undefined,
+    getByWalletAddressWithOrganization: async () => undefined,
+    getWithOrganization: async () => existingUser,
+    create: async () => existingUser,
+    update: async () => undefined,
+    linkStewardId: async () => undefined,
+    upsertStewardIdentity: async () => undefined,
+  },
+}));
+// The user already has their default API key, isolating the character heal.
+mock.module("./services/api-keys", () => ({
+  apiKeysService: {
+    listByOrganization: async () => [{ user_id: "user-1" }],
+    create: async () => ({ id: "key-1" }),
+    validateApiKey: async () => null,
+    incrementUsageDebounced: () => undefined,
+  },
+}));
+mock.module("./services/characters/characters", () => ({
+  charactersService: {
+    existsForOrganization: async () => false,
+    create: async (data: Record<string, unknown>) => {
+      characterCreateCalls.push(data);
+      return { id: "char-1" };
+    },
+  },
+}));
+// Remaining steward-sync imports (auth.ts pulls the real module); inert stubs.
+mock.module("./services/credits", () => ({
+  creditsService: { addCredits: async () => ({ success: true }) },
+}));
+mock.module("./services/organizations", () => ({
+  organizationsService: {
+    getBySlug: async () => undefined,
+    create: async () => ({ id: "org-1" }),
+    update: async () => undefined,
+    delete: async () => undefined,
+  },
+}));
+mock.module("./services/invites", () => ({
+  invitesService: { findPendingInviteByEmail: async () => undefined },
+}));
+mock.module("./services/discord", () => ({
+  discordService: { logUserSignup: async () => undefined },
+}));
+mock.module("./services/email", () => ({
+  emailService: { sendWelcomeEmail: async () => undefined },
+}));
+
+const { getCurrentUserFromRequest } = await import("./auth");
+
+describe("session-resolution default-character self-heal", () => {
+  test("cache miss for an existing user with a character-less org re-seeds the default Eliza", async () => {
+    characterCreateCalls = [];
+
+    const request = new Request("http://localhost/api/anything", {
+      headers: { cookie: "steward-token=tok-abc" },
+    });
+
+    const user = await getCurrentUserFromRequest(request);
+    expect(user?.id).toBe("user-1");
+
+    // The heal is awaited inside session resolution (a void-fired promise can
+    // be cancelled on Cloudflare Workers), so it has completed by now.
+    expect(characterCreateCalls.length).toBe(1);
+    expect(characterCreateCalls[0].name).toBe("Eliza");
+    expect(characterCreateCalls[0].user_id).toBe("user-1");
+    expect(characterCreateCalls[0].organization_id).toBe("org-1");
+  });
+});

--- a/packages/cloud/shared/src/lib/auth.ts
+++ b/packages/cloud/shared/src/lib/auth.ts
@@ -21,7 +21,7 @@ import { adminService } from "./services/admin";
 import { apiKeysService } from "./services/api-keys";
 import { userSessionsService } from "./services/user-sessions";
 import { usersService } from "./services/users";
-import { syncUserFromSteward } from "./steward-sync";
+import { ensureDefaultCharacter, syncUserFromSteward } from "./steward-sync";
 import type { ApiKey, UserWithOrganization } from "./types";
 import { logger } from "./utils/logger";
 
@@ -187,6 +187,16 @@ export async function getCurrentUserFromRequest(
     if (user.organization_id) {
       void trackSessionActivity(user.id, user.organization_id, stewardToken);
       void ensureUserHasApiKey(user.id, user.organization_id);
+      // Self-heal a missing default Eliza character: its only create site is
+      // the one-time new-user signup branch in steward-sync, where a failed
+      // create is swallowed so the signup itself survives — without this
+      // session-time re-run such an account would stay character-less
+      // forever. Awaited, not void-fired: this runs on Cloudflare Workers,
+      // where an un-awaited promise may be cancelled once the response
+      // returns — the exact failure mode that loses the signup-time create.
+      // Idempotent (one indexed SELECT per session-cache miss; seeds only
+      // when the org has zero characters) and it never rejects.
+      await ensureDefaultCharacter(user.id, user.organization_id);
     } else {
       logger.error("[AUTH] User missing organization_id:", user.id);
     }

--- a/packages/cloud/shared/src/lib/services/characters/characters.ts
+++ b/packages/cloud/shared/src/lib/services/characters/characters.ts
@@ -140,6 +140,15 @@ export class CharactersService {
     return await userCharactersRepository.listByOrganization(organizationId, source);
   }
 
+  /**
+   * Bounded existence probe: does the organization have any cloud character?
+   * For hot paths that only need emptiness (default-character provisioning),
+   * where listByOrganization would fetch every fat character row.
+   */
+  async existsForOrganization(organizationId: string): Promise<boolean> {
+    return await userCharactersRepository.existsForOrganization(organizationId, "cloud");
+  }
+
   async listPublic(options?: {
     search?: string;
     category?: string;

--- a/packages/cloud/shared/src/lib/steward-sync-default-character-selfheal.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-default-character-selfheal.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Self-heal contract of ensureDefaultCharacter: a default-character create
+ * that fails (and is swallowed so signup/session resolution survive) must be
+ * re-attempted by a later invocation until the org has its default Eliza —
+ * never left as a permanently character-less account. Deterministic harness:
+ * the characters service is a controllable in-memory mock; no live model.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let orgCharacters: Array<{ id: string }> = [];
+let createFailuresRemaining = 0;
+let createCalls: Array<Record<string, unknown>> = [];
+
+mock.module("./services/characters/characters", () => ({
+  charactersService: {
+    existsForOrganization: async () => orgCharacters.length > 0,
+    create: async (data: Record<string, unknown>) => {
+      createCalls.push(data);
+      if (createFailuresRemaining > 0) {
+        createFailuresRemaining--;
+        throw new Error("db write failed");
+      }
+      const created = { id: `char-${createCalls.length}` };
+      orgCharacters.push(created);
+      return created;
+    },
+  },
+}));
+
+// steward-sync's other service imports; inert stubs so the module loads.
+mock.module("./services/credits", () => ({
+  creditsService: { addCredits: async () => ({ success: true }) },
+}));
+mock.module("./services/organizations", () => ({
+  organizationsService: {
+    getBySlug: async () => undefined,
+    create: async () => ({ id: "org-1" }),
+    update: async () => undefined,
+    delete: async () => undefined,
+  },
+}));
+mock.module("./services/users", () => ({
+  usersService: {
+    getByStewardId: async () => undefined,
+    getByStewardIdForWrite: async () => undefined,
+    getByEmailWithOrganization: async () => undefined,
+    getByWalletAddress: async () => undefined,
+    getByWalletAddressWithOrganization: async () => undefined,
+    create: async () => ({ id: "user-1" }),
+    update: async () => undefined,
+    linkStewardId: async () => undefined,
+    upsertStewardIdentity: async () => undefined,
+  },
+}));
+mock.module("./services/invites", () => ({
+  invitesService: { findPendingInviteByEmail: async () => undefined },
+}));
+mock.module("./services/api-keys", () => ({
+  apiKeysService: {
+    listByOrganization: async () => [],
+    create: async () => ({ id: "key-1" }),
+  },
+}));
+mock.module("./services/discord", () => ({
+  discordService: { logUserSignup: async () => undefined },
+}));
+mock.module("./services/email", () => ({
+  emailService: { sendWelcomeEmail: async () => undefined },
+}));
+
+const { ensureDefaultCharacter } = await import("./steward-sync");
+
+beforeEach(() => {
+  orgCharacters = [];
+  createFailuresRemaining = 0;
+  createCalls = [];
+});
+
+describe("ensureDefaultCharacter self-heal", () => {
+  test("a swallowed create failure is retried by the next run, which seeds the default", async () => {
+    createFailuresRemaining = 1;
+
+    // Signup-time run: the create fails; the helper must resolve (signup
+    // survives) but the org is left without its default character.
+    await ensureDefaultCharacter("user-1", "org-1");
+    expect(createCalls.length).toBe(1);
+    expect(orgCharacters.length).toBe(0);
+
+    // Session-time re-run (auth.ts fires this on every session-cache miss):
+    // the org still has zero characters, so the create is re-attempted and
+    // the default Eliza is seeded from the template.
+    await ensureDefaultCharacter("user-1", "org-1");
+    expect(createCalls.length).toBe(2);
+    expect(orgCharacters.length).toBe(1);
+    expect(createCalls[1].name).toBe("Eliza");
+    expect(createCalls[1].user_id).toBe("user-1");
+    expect(createCalls[1].organization_id).toBe("org-1");
+  });
+
+  test("no-op when the organization already has a character", async () => {
+    orgCharacters = [{ id: "char-existing" }];
+    await ensureDefaultCharacter("user-1", "org-1");
+    expect(createCalls.length).toBe(0);
+  });
+
+  test("never rejects, so void-firing from session resolution is safe", async () => {
+    createFailuresRemaining = 1;
+    await expect(ensureDefaultCharacter("user-1", "org-1")).resolves.toBeUndefined();
+  });
+});

--- a/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
@@ -8,9 +8,9 @@
  * where a promise not registered via executionCtx.waitUntil may be cancelled
  * once the response returns — and syncUserFromSteward is a shared-lib function
  * with no request context to reach waitUntil. A cancelled promise left the new
- * user permanently with no default character (ensureDefaultCharacter's only
- * caller is this one-time new-user path; every later login returns at the
- * existing-user branch). Fix: await both.
+ * user with no default character until the session-cache-miss self-heal in
+ * auth.ts runs (every later login returns at the existing-user branch, never
+ * re-entering this one-time signup path). Fix: await both.
  *
  * The api-key and character create() mocks below are deferred promises whose
  * settlement the test controls — modeling slow DB writes that would still be
@@ -95,7 +95,7 @@ mock.module("./services/api-keys", () => ({
 }));
 mock.module("./services/characters/characters", () => ({
   charactersService: {
-    listByOrganization: async () => [],
+    existsForOrganization: async () => false,
     create: async () => {
       const v = await characterCreate.promise;
       characterCreateResolved = true;

--- a/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
@@ -90,7 +90,7 @@ mock.module("./services/api-keys", () => ({
 
 mock.module("./services/characters/characters", () => ({
   charactersService: {
-    listByOrganization: async () => [],
+    existsForOrganization: async () => false,
     create: async () => ({ id: "char-1" }),
   },
 }));

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -701,10 +701,12 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
   // Await default provisioning: on Cloudflare Workers an un-awaited promise is
   // cancelled once the response returns unless registered via
   // executionCtx.waitUntil, which this shared-lib function cannot reach — and a
-  // cancelled create leaves the new user permanently without a default
-  // character/API key (this one-time new-user path is the only caller; later
-  // logins return at the existing-user branch). Both helpers are idempotent and
-  // swallow their own errors, so awaiting cannot fail the signup.
+  // cancelled create would leave the new user without a default character/API
+  // key (later logins return at the existing-user branch, never re-entering
+  // this one-time path; recovery then depends on the session-resolution
+  // self-heal in auth.ts getCurrentUserFromRequest). Both helpers are
+  // idempotent and swallow their own errors, so awaiting cannot fail the
+  // signup.
   await ensureUserHasApiKey(userWithOrg.id, userWithOrg.organization?.id || "");
   await ensureDefaultCharacter(userWithOrg.id, userWithOrg.organization?.id || "");
 
@@ -746,17 +748,28 @@ async function ensureUserHasApiKey(userId: string, organizationId: string): Prom
 }
 
 /**
- * Ensures a new account starts with a default Eliza character.
+ * Ensures an account has a default Eliza character, seeding one from the
+ * default template when the organization has none.
+ *
+ * Idempotent and never rejects. Called from two places: the one-time
+ * new-user signup branch above, and every session-cache miss
+ * (auth.ts getCurrentUserFromRequest). The second call site is the recovery
+ * path: a create that fails at signup is swallowed here (signup must not
+ * fail over provisioning), so without the session-time re-run the account
+ * would stay character-less forever — the default character is
+ * deterministically reconstructable, so re-seeding is always safe.
  */
-async function ensureDefaultCharacter(userId: string, organizationId: string): Promise<void> {
+export async function ensureDefaultCharacter(
+  userId: string,
+  organizationId: string,
+): Promise<void> {
   if (!userId?.trim() || !organizationId?.trim()) {
     logger.warn("[StewardSync] Invalid userId or organizationId, skipping default character");
     return;
   }
 
   try {
-    const existing = await charactersService.listByOrganization(organizationId);
-    if (existing.length > 0) {
+    if (await charactersService.existsForOrganization(organizationId)) {
       return;
     }
 
@@ -769,8 +782,13 @@ async function ensureDefaultCharacter(userId: string, organizationId: string): P
 
     logger.info(`[StewardSync] Created default Eliza character for user ${userId}`);
   } catch (error) {
+    // error-policy:J1 provisioning boundary: a default-character failure
+    // must not fail signup or session resolution; it is logged here and
+    // deterministically retried by the next session-cache-miss re-run
+    // (auth.ts getCurrentUserFromRequest), which is where recovery lands.
     logger.error("[StewardSync] Error creating default character", {
       userId,
+      organizationId,
       error: error instanceof Error ? error.message : String(error),
     });
   }


### PR DESCRIPTION
## What

Self-heals an account that is missing its default Eliza character, instead of leaving it character-less forever after a swallowed provisioning failure.

Item 1 of the provisioning self-heal batch claimed on the launch-QA tracker #13406 (same failure family as #11270: a user ending up without a working default).

## The defect (verified on current develop, `dc3a797223`)

- The **only** create site for the default character is `ensureDefaultCharacter` on the one-time new-user signup branch in `steward-sync.ts`, and its `catch` swallows the create error into a log line (`:771-777` on develop).
- Every later login returns at the existing-user branch (`steward-sync.ts:302`) and never re-enters that branch, and the session-resolution layer has **no** character heal — `auth.ts:189` self-heals the default **API key** on session-cache miss, but nothing equivalent exists for the character.
- Net effect: one transient DB failure (or a cancelled Workers promise, pre-#11270) at signup leaves the account **permanently without its default Eliza** — the runtime proceeds character-less with no recovery path, observable only as a single log line.

## The fix (structural, mirrors the shipped API-key heal)

- Export the already-idempotent `ensureDefaultCharacter` and re-run it in `getCurrentUserFromRequest` on every session-cache miss, right beside the existing `ensureUserHasApiKey` heal. All cookie-session traffic funnels through this site (`requireAuth` / `requireAuthWithOrg` / `requireAuthOrApiKey` fallback / `getUserFromRequest` → 77 route files), so a character-less account converges to healed on its next session resolution.
- **Awaited, not void-fired**: this code runs on Cloudflare Workers, where an un-awaited promise may be cancelled once the response returns — the exact failure mode (#11270) that loses the signup-time create. Cost is one bounded SELECT per session-cache miss.
- The emptiness check now uses a **bounded existence probe** (`existsForOrganization`: `select id … limit 1`, same shape as the existing `usernameExists`) instead of `listByOrganization`, which fetches every fat character row unbounded — too heavy to run per cache miss.
- The kept catch inside `ensureDefaultCharacter` is annotated `error-policy:J1`: a provisioning failure must not fail signup or session resolution; it is logged and deterministically retried by the next session-cache-miss re-run — which satisfies the "self-heal deterministically or surface" doctrine (create failures no longer read as success-with-no-recovery).

Not changed (scope): the Bearer-JWT and workers-hono per-request paths don't heal (the API-key heal doesn't either — the cookie path is the canonical dashboard path and the per-request Hono path has no session cache to bound the probe); the invited-user default-key gap is item 2 of the batch, shipped separately.

Concurrency note (reviewed): two simultaneous cache-miss heals for the same broken org converge to **one** character — `generateUniqueUsername` is deterministic over the same username snapshot, so concurrent creates collide on the same `eliza-N` and the `username` DB UNIQUE constraint rejects the loser, whose error the ensure already swallows-and-logs. Healthy orgs (the steady state) short-circuit at the existence probe.

## Tests (fail on the defect, pass with the fix)

New `auth-default-character-selfheal.test.ts` — drives the **real** `getCurrentUserFromRequest` and the **real** `ensureDefaultCharacter` (deterministic service mocks, no live model): session-cache miss for an existing user whose org has zero characters ⇒ default Eliza re-seeded from the template, session resolution still succeeds.

New `steward-sync-default-character-selfheal.test.ts` — the heal contract itself: a swallowed create failure is retried by the next run which seeds the default; no-op when a character exists; never rejects.

On develop's unfixed source (tests kept, sources reverted):

```
0 pass, 4 fail  —  wiring test fails as: expect(characterCreateCalls.length).toBe(1)  Expected: 1  Received: 0
```

With the fix:

```
bun test --isolate (steward-sync-default-provisioning + both new files):  5 pass, 0 fail
bun test --isolate (all 5 steward-sync/auth suites):                     15 pass, 0 fail, 62 expect() calls
bun run --cwd packages/cloud/shared typecheck:                            exit 0
bun run audit:error-policy-ratchet:  auth.ts 0->0, steward-sync.ts 0->0 — no new fallback-slop
```

## Evidence

- **Real request→response trace**: the wiring test drives a real `Request` (cookie header) through the real auth stack; backend structured logs show `[StewardSync] Error creating default character { userId, organizationId, error }` on the failure leg and the create on the heal leg.
- **Domain artifact**: the seeded character row (`name: "Eliza"`, `user_id`, `organization_id` asserted from the template payload).
- Real-LLM trajectories: N/A — no model/agent/prompt behavior involved (provisioning + auth path only).
- Screenshots/video: N/A — no UI surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
