### PR TITLE
fix(cloud-shared): vertex/video-gen/waifu error-policy annotations + tests (#13415 slice 9)

### DIFF
--- a/.github/issue-evidence/13415-model-media.md
+++ b/.github/issue-evidence/13415-model-media.md
@@ -1,0 +1,16 @@
+# #13415 — cloud-shared fallback sweep slice 9: vertex / video-gen / waifu
+
+vertex-model-registry, vertex-tuning, video-generation-reconcile, waifu-webhook.
+Verified untouched at file level before starting.
+
+## Findings (all already fail-closed — annotations + tests only)
+- **vertex-model-registry** — no source change; no try/catch/console/parseFloat; every dbRead/dbWrite/remote call propagates uncaught. Pinned by test.
+- **vertex-tuning** — `// error-policy:J1` on the gcloud-token optional-source catch (auth boundary throws a structured "No Google access token available" below); fetch handlers already check `.ok` and throw with status+body.
+- **video-generation-reconcile** (MONEY path) — `// error-policy:J1` comment on the provider status-probe catch (already money-safe: a probe failure = UNKNOWN → keeps the hold, never refunds blind). Uses `Number()+isFinite` (strict). `reconcile`/`refundCredits`/`recon:<txid>:refund` idempotency arithmetic left untouched (money-path-flagged).
+- **waifu-webhook** (MONEY/webhook path) — `// error-policy:J1/J3` on the SSRF-guard + transport catches and the URL-parse guard; `receiverPath()` money-routing fallback left untouched (money-path-flagged).
+
+## Verification
+15 new error-path `bun:test` suites pass under `--isolate`, proving internal-failure PROPAGATES vs designed-empty stays distinguishable, driving the real exported functions. Source edits are comment-only annotations (verified: every added line is an `// error-policy:` comment) so no behavior changes. The pre-existing `__tests__/video-generation-reconcile.test.ts` PGlite test FALSE-fails only in a bare run without the CI-provisioned DB — confirmed it fails identically with my changes stashed (environmental, unrelated).
+
+## N/A
+UI/model-trajectory/audio — N/A (server model/media/webhook services). Runtime traces — N/A - comment-only annotations + unit-boundary error-path coverage.

--- a/packages/cloud/shared/src/lib/services/vertex-model-registry.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/vertex-model-registry.error-policy.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Error-policy pin for the vertex model registry (#13415): a FAILED internal
+ * call must surface, and must stay distinguishable from a legitimately-empty
+ * result. `syncJobStatus` resolves a job, then re-syncs it against the remote
+ * Vertex tuning API. Two outcomes that must never collapse into each other:
+ *   - job not visible/found  -> null  (designed-empty; no remote call, no write)
+ *   - remote status call fails -> throws (never swallowed to null, never a write)
+ *
+ * Drives the real exported service; db client + object store are module-mocked
+ * and the remote layer is exercised through the real `getTuningJobStatus` with a
+ * mocked global fetch (restored in afterEach).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.GOOGLE_ACCESS_TOKEN = "test-access-token";
+
+const findFirst = mock(async (): Promise<unknown> => undefined);
+const updateReturning = mock(async (): Promise<unknown[]> => []);
+const update = mock(() => ({
+  set: () => ({ where: () => ({ returning: updateReturning }) }),
+}));
+
+mock.module("../../db/client", () => ({
+  dbRead: { query: { vertexTuningJobs: { findFirst } } },
+  dbWrite: { update },
+}));
+
+mock.module("../storage/object-store", () => ({
+  hydrateJsonField: mock(async () => ({})),
+  offloadJsonField: mock(async () => ({ value: {}, storage: null, key: null })),
+}));
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  findFirst.mockReset();
+  update.mockClear();
+  updateReturning.mockClear();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("vertex-model-registry syncJobStatus — fail-closed error policy", () => {
+  test("not-found job returns null WITHOUT a remote call or write (designed-empty)", async () => {
+    findFirst.mockResolvedValueOnce(undefined);
+    const fetchSpy = mock(async () => new Response("{}", { status: 200 }));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { vertexModelRegistryService } = await import("./vertex-model-registry");
+    const result = await vertexModelRegistryService.syncJobStatus({
+      jobId: "missing-job",
+      viewer: { organizationId: "11111111-1111-1111-1111-111111111111" },
+    });
+
+    expect(result).toBeNull();
+    // A designed-empty result never touches the remote API or the DB write.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("remote status failure PROPAGATES — never swallowed to null, never a write", async () => {
+    findFirst.mockResolvedValueOnce({
+      id: "job-1",
+      vertex_job_name: "projects/p/locations/us-central1/tuningJobs/1",
+      display_name: "Job 1",
+      organization_id: null,
+      scope: "global",
+    });
+    const fetchSpy = mock(async () => new Response("upstream unavailable", { status: 503 }));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { vertexModelRegistryService } = await import("./vertex-model-registry");
+
+    await expect(
+      vertexModelRegistryService.syncJobStatus({ jobId: "job-1", viewer: {} }),
+    ).rejects.toThrow(/Failed to get tuning job status/);
+
+    // The failure was observed BEFORE any write — no fabricated success row.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/vertex-tuning.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/vertex-tuning.error-policy.test.ts
@@ -1,0 +1,69 @@
+// Pins the Vertex tuning transport layer: an internal API failure PROPAGATES as a
+// thrown error, while a legitimately-empty job list stays a distinct empty result —
+// neither is masked into a fabricated success. Deterministic (global fetch mocked).
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  getTuningJobStatus,
+  listTuningJobs,
+} from "./vertex-tuning";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function stubFetch(response: Response): void {
+  globalThis.fetch = (async () => response) as typeof fetch;
+}
+
+describe("listTuningJobs — empty result stays distinct from internal failure", () => {
+  test("designed-empty: ok response with empty list returns [] without throwing", async () => {
+    stubFetch(new Response(JSON.stringify({ tuningJobs: [] }), { status: 200 }));
+    const jobs = await listTuningJobs("proj", "us-central1", "token");
+    expect(jobs).toEqual([]);
+  });
+
+  test("designed-empty: ok response missing the field returns []", async () => {
+    stubFetch(new Response(JSON.stringify({}), { status: 200 }));
+    const jobs = await listTuningJobs("proj", "us-central1", "token");
+    expect(jobs).toEqual([]);
+  });
+
+  test("internal failure: non-ok response propagates as a throw, never []", async () => {
+    stubFetch(new Response("upstream unavailable", { status: 500 }));
+    let empty: unknown[] | undefined;
+    try {
+      empty = await listTuningJobs("proj", "us-central1", "token");
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain("500");
+      expect((err as Error).message).toContain("upstream unavailable");
+    }
+    // The failure must NOT have resolved to an empty array masking the outage.
+    expect(empty).toBeUndefined();
+  });
+});
+
+describe("getTuningJobStatus — internal failure propagates", () => {
+  test("non-ok response throws with status and body, no fabricated job", async () => {
+    stubFetch(new Response("not found", { status: 404 }));
+    await expect(
+      getTuningJobStatus("projects/p/locations/l/tuningJobs/123", "token"),
+    ).rejects.toThrow(/404.*not found/s);
+  });
+
+  test("ok response returns the parsed job", async () => {
+    const job = {
+      name: "projects/p/locations/l/tuningJobs/123",
+      state: "JOB_STATE_SUCCEEDED",
+      tunedModelDisplayName: "tuned-x",
+      createTime: "2026-01-01T00:00:00Z",
+      updateTime: "2026-01-01T01:00:00Z",
+    };
+    stubFetch(new Response(JSON.stringify(job), { status: 200 }));
+    const result = await getTuningJobStatus(job.name, "token");
+    expect(result.state).toBe("JOB_STATE_SUCCEEDED");
+    expect(result.tunedModelDisplayName).toBe("tuned-x");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/vertex-tuning.ts
+++ b/packages/cloud/shared/src/lib/services/vertex-tuning.ts
@@ -94,7 +94,8 @@ async function getAccessToken(providedToken?: string): Promise<string> {
     const token = stdout.trim();
     if (token) return token;
   } catch {
-    // Fall through to the explicit error below.
+    // error-policy:J1 gcloud unavailable/unauthed is an expected optional-source miss;
+    // no token is fabricated — the auth boundary surfaces a structured error below.
   }
 
   throw new Error(

--- a/packages/cloud/shared/src/lib/services/video-generation-reconcile.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/video-generation-reconcile.error-policy.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Error-policy proof for the reconcile sweep's provider status-probe boundary
+ * (#13415): an internal probe failure must stay DISTINGUISHABLE from a designed
+ * terminal state and must never move money blind. Deterministic mock harness —
+ * the repository, provider registry, and credits service are mocked so the test
+ * observes exactly which money lanes the sweep touches per upstream verdict; it
+ * drives the real exported `reconcilePendingVideoGenerations`.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Generation } from "../../db/schemas/generations";
+import type { VideoJobStatus } from "../providers/video/types";
+import { VIDEO_PENDING_SETTLEMENT_MARKER } from "../providers/video/types";
+
+// Recorders for the money lanes: a blind refund/settle on a probe failure would
+// register here. Reset per test.
+const reconcileCalls: unknown[] = [];
+const refundCalls: unknown[] = [];
+const generationUpdateCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
+
+let pendingRows: Generation[] = [];
+// Controllable upstream probe: returns a verdict or throws (transport failure).
+let getJobStatusImpl: () => Promise<VideoJobStatus> = async () => ({ state: "pending" });
+let getJobStatusCalls = 0;
+
+function makeGeneration(overrides: Partial<Generation> & { id: string }): Generation {
+  const base = {
+    organization_id: "org-1",
+    user_id: null,
+    type: "video",
+    model: "fal-ai/veo3",
+    provider: "fal",
+    prompt: "a lighthouse at dusk",
+    status: "pending",
+    job_id: "fal-req-1",
+    created_at: new Date(),
+    metadata: {
+      settlement_marker: VIDEO_PENDING_SETTLEMENT_MARKER,
+      reservation_transaction_id: "resv-1",
+      reserved_amount: 0.5,
+      billed_cost: 0.5,
+      billing_source: "fal",
+    },
+  };
+  return { ...base, ...overrides } as unknown as Generation;
+}
+
+mock.module("../../db/repositories/generations", () => ({
+  generationsRepository: {
+    listPendingVideoSettlements: async () => pendingRows,
+    update: async (id: string, data: Record<string, unknown>) => {
+      generationUpdateCalls.push({ id, data });
+    },
+  },
+}));
+
+mock.module("../providers/video/registry", () => ({
+  findVideoProvider: (billingSource: string) =>
+    billingSource === "fal"
+      ? {
+          billingSource: "fal",
+          generate: async () => {
+            throw new Error("stub does not generate");
+          },
+          getJobStatus: async () => {
+            getJobStatusCalls++;
+            return await getJobStatusImpl();
+          },
+        }
+      : undefined,
+}));
+
+mock.module("./credits", () => ({
+  creditsService: {
+    reconcile: async (params: unknown) => {
+      reconcileCalls.push(params);
+      // A settle-at-0 (refund lane) is what the verified-failure path expects.
+      return {
+        reservedAmount: 0.5,
+        actualCost: 0,
+        reservationTransactionId: "resv-1",
+        settlementTransactionIds: [],
+        adjustmentType: "refund" as const,
+      };
+    },
+    refundCredits: async (params: unknown) => {
+      refundCalls.push(params);
+      return {};
+    },
+  },
+}));
+
+let reconcilePendingVideoGenerations: typeof import("./video-generation-reconcile").reconcilePendingVideoGenerations;
+
+beforeEach(async () => {
+  reconcileCalls.length = 0;
+  refundCalls.length = 0;
+  generationUpdateCalls.length = 0;
+  pendingRows = [];
+  getJobStatusCalls = 0;
+  getJobStatusImpl = async () => ({ state: "pending" });
+  ({ reconcilePendingVideoGenerations } = await import("./video-generation-reconcile"));
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("provider status-probe boundary (error-policy:J1)", () => {
+  test("probe transport failure moves NO money and is counted as skipped, not refunded", async () => {
+    pendingRows = [makeGeneration({ id: "gen-probe-fail", created_at: new Date(0) })];
+    getJobStatusImpl = async () => {
+      throw new Error("provider unreachable");
+    };
+
+    const stats = await reconcilePendingVideoGenerations({ apiKeys: { FAL_KEY: "k" } });
+
+    // The failure is contained as a distinct "skipped" outcome — never a refund
+    // or a charge — and the sweep does not throw (one bad probe can't abort the
+    // batch).
+    expect(stats).toMatchObject({ scanned: 1, skipped: 1, refunded: 0, charged: 0, expired: 0 });
+    expect(getJobStatusCalls).toBe(1);
+    // Critically: no money lane fired and the generation row was never mutated.
+    expect(reconcileCalls).toHaveLength(0);
+    expect(refundCalls).toHaveLength(0);
+    expect(generationUpdateCalls).toHaveLength(0);
+  });
+
+  test("a verified terminal failure DOES move money — distinct from a probe failure", async () => {
+    pendingRows = [makeGeneration({ id: "gen-verified-fail" })];
+    getJobStatusImpl = async () => ({ state: "failed", error: "render exploded" });
+
+    const stats = await reconcilePendingVideoGenerations({ apiKeys: { FAL_KEY: "k" } });
+
+    // The designed terminal-failure path settles the hold (refund lane) and
+    // marks the row failed — proving "internal probe failure" (money untouched)
+    // stays distinguishable from "verified failure" (refunded).
+    expect(stats).toMatchObject({ scanned: 1, refunded: 1, skipped: 0, charged: 0 });
+    expect(reconcileCalls).toHaveLength(1);
+    expect(generationUpdateCalls).toHaveLength(1);
+    expect(generationUpdateCalls[0]?.data).toMatchObject({ status: "failed" });
+  });
+
+  test("one probe failure does not starve a sibling row's verified verdict", async () => {
+    pendingRows = [
+      makeGeneration({ id: "gen-a-probe-fail" }),
+      makeGeneration({ id: "gen-b-verified-fail" }),
+    ];
+    let call = 0;
+    getJobStatusImpl = async () => {
+      call++;
+      if (call === 1) throw new Error("provider unreachable");
+      return { state: "failed", error: "render exploded" };
+    };
+
+    const stats = await reconcilePendingVideoGenerations({ apiKeys: { FAL_KEY: "k" } });
+
+    // First row skipped (probe threw), second row still reconciled — per-item
+    // isolation, no swallow that fabricates a batch-wide default.
+    expect(stats).toMatchObject({ scanned: 2, skipped: 1, refunded: 1 });
+    expect(reconcileCalls).toHaveLength(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/video-generation-reconcile.ts
+++ b/packages/cloud/shared/src/lib/services/video-generation-reconcile.ts
@@ -212,8 +212,13 @@ export async function reconcilePendingVideoGenerations(params: {
         apiKeys: params.apiKeys,
       });
     } catch (error) {
-      // Upstream state unknown — never refund blind. The hold stays for the
-      // next tick; the stranded-reservation sweep is the eventual backstop.
+      // error-policy:J1 provider status-probe transport boundary — a probe
+      // failure means the upstream state is UNKNOWN, which must stay distinct
+      // from a verified failed/succeeded terminal state. Translate it into a
+      // per-item "skipped" outcome so one unreachable probe never aborts the
+      // batch and, critically, never refunds blind. The failure surfaces via
+      // the warn below; the hold is retained for the next tick, with the
+      // stranded-reservation sweep (#11493) as the eventual backstop.
       stats.skipped++;
       logger.warn("[VideoReconcile] Upstream status probe failed; keeping hold", {
         generationId: generation.id,

--- a/packages/cloud/shared/src/lib/services/waifu-webhook.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/waifu-webhook.error-policy.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Error-policy pins for the waifu webhook emitter (#13415).
+ *
+ * Proves the emit boundary keeps three internal-failure shapes DISTINGUISHABLE
+ * from success and from the designed not-configured skip: a transport failure
+ * surfaces as {delivered:false, status:null, error}, an SSRF-guard rejection
+ * surfaces the same way without ever calling fetch, and a non-2xx response
+ * surfaces as {delivered:false, status:<number>} — none of which may ever read
+ * as a delivered success. Drives the real exported `emitWaifuWebhook` through
+ * its documented `target`/`fetchImpl`/`now` seams; a public IP-literal target
+ * exercises the real SSRF guard without a DNS round-trip, and global fetch is
+ * mocked to throw as a hard net-access tripwire (restored in afterEach).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  type EmitWaifuWebhookParams,
+  type WaifuWebhookTarget,
+  emitWaifuWebhook,
+} from "./waifu-webhook";
+
+// Public IPv4 literal (documentation range is forbidden; this one is routable
+// and not reserved) so assertSafeOutboundUrl validates it without resolving DNS.
+const PUBLIC_TARGET: WaifuWebhookTarget = {
+  baseUrl: "https://93.184.216.34",
+  secret: "test-webhook-secret",
+};
+
+const FIXED_NOW = () => new Date("2026-07-04T00:00:00.000Z");
+
+const CONFIG_ENV_KEYS = [
+  "ELIZA_CLOUD_WEBHOOK_URL",
+  "WAIFU_WEBHOOK_URL",
+  "WAIFU_API_BASE_URL",
+  "WAIFU_CORE_URL",
+  "ELIZA_CLOUD_WEBHOOK_SECRET",
+  "WAIFU_WEBHOOK_SECRET",
+  "WEBHOOK_RECEIVER_SECRET",
+] as const;
+
+let savedEnv: Record<string, string | undefined>;
+let savedFetch: typeof fetch;
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of CONFIG_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  savedFetch = globalThis.fetch;
+  // Hard tripwire: any code path that reaches real global fetch fails loudly
+  // instead of hitting the network. The emitter's default is safeFetch, and
+  // every configured test injects fetchImpl, so this must never fire.
+  globalThis.fetch = (() => {
+    throw new Error("global fetch must not be called in this test");
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = savedFetch;
+  for (const key of CONFIG_ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  }
+});
+
+function baseParams(overrides: Partial<EmitWaifuWebhookParams>): EmitWaifuWebhookParams {
+  return {
+    kind: "inference",
+    payload: { event: "inference.spent", organizationId: "org_1" },
+    idempotencyKey: "evt_1",
+    now: FIXED_NOW,
+    ...overrides,
+  };
+}
+
+describe("emitWaifuWebhook error-policy boundary", () => {
+  test("transport failure PROPAGATES as a distinguishable failure, never a fake success", async () => {
+    const result = await emitWaifuWebhook(
+      baseParams({
+        target: PUBLIC_TARGET,
+        fetchImpl: (() => Promise.reject(new Error("ECONNREFUSED boom"))) as typeof fetch,
+      }),
+    );
+
+    expect(result.delivered).toBe(false);
+    expect(result.status).toBeNull();
+    expect(result.error).toContain("ECONNREFUSED");
+    // The failure is NOT laundered into the designed not-configured skip.
+    expect(result.skipped).toBeUndefined();
+  });
+
+  test("designed not-configured skip stays distinct from an internal failure", async () => {
+    // No target arg and no env config → resolveWaifuWebhookTarget() returns null.
+    const result = await emitWaifuWebhook(
+      baseParams({ payload: { event: "inference.spent" }, idempotencyKey: "evt_skip" }),
+    );
+
+    expect(result.skipped).toBe("not_configured");
+    expect(result.delivered).toBe(false);
+    expect(result.status).toBeNull();
+    // Critically: a designed skip carries NO error — it is not a failed call.
+    expect(result.error).toBeUndefined();
+  });
+
+  test("successful delivery is a distinct shape (delivered:true + numeric status)", async () => {
+    let called = 0;
+    const result = await emitWaifuWebhook(
+      baseParams({
+        target: PUBLIC_TARGET,
+        fetchImpl: (() => {
+          called += 1;
+          return Promise.resolve(new Response(null, { status: 200 }));
+        }) as typeof fetch,
+      }),
+    );
+
+    expect(called).toBe(1);
+    expect(result.delivered).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.error).toBeUndefined();
+    expect(result.skipped).toBeUndefined();
+  });
+
+  test("server-rejected (non-2xx) is distinct from unreachable: status:number, not error", async () => {
+    const result = await emitWaifuWebhook(
+      baseParams({
+        target: PUBLIC_TARGET,
+        fetchImpl: (() => Promise.resolve(new Response("nope", { status: 500 }))) as typeof fetch,
+      }),
+    );
+
+    // "The server said no" keeps the real status code and is distinguishable
+    // from "could not reach the server" (status:null + error) above.
+    expect(result.delivered).toBe(false);
+    expect(result.status).toBe(500);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("SSRF-guard rejection fails closed: delivered:false + error, and fetch is never called", async () => {
+    let called = 0;
+    const result = await emitWaifuWebhook(
+      baseParams({
+        // Cloud metadata IP — assertSafeOutboundUrl must reject this before any
+        // socket is opened.
+        target: { baseUrl: "http://169.254.169.254", secret: "s" },
+        fetchImpl: (() => {
+          called += 1;
+          return Promise.resolve(new Response(null, { status: 200 }));
+        }) as typeof fetch,
+      }),
+    );
+
+    expect(called).toBe(0);
+    expect(result.delivered).toBe(false);
+    expect(result.status).toBeNull();
+    expect(result.error).toBeTruthy();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/waifu-webhook.ts
+++ b/packages/cloud/shared/src/lib/services/waifu-webhook.ts
@@ -170,6 +170,9 @@ export function isWaifuWebhookTargetUrl(
     }
     return candidate.pathname.includes(WAIFU_WEBHOOK_PATH_PREFIX);
   } catch {
+    // error-policy:J3 an unparseable candidate URL is definitively not a waifu
+    // receiver — return the explicit invalid answer (false), never fabricate a
+    // match. No signed envelope can target a URL that will not parse.
     return false;
   }
 }
@@ -206,6 +209,9 @@ export async function emitWaifuWebhook(
   try {
     url = await assertSafeOutboundUrl(receiverPath(target.baseUrl, params.kind));
   } catch (err) {
+    // error-policy:J1 SSRF-guard rejection at the outbound boundary, translated
+    // into a structured delivery failure (delivered:false + error). Distinct
+    // from success and from the not_configured skip; fetch never runs.
     const message = err instanceof Error ? err.message : String(err);
     logger.error("[waifu-webhook] refusing unsafe outbound url", { error: message });
     return { delivered: false, status: null, error: message };
@@ -230,6 +236,11 @@ export async function emitWaifuWebhook(
     }
     return { delivered: response.ok, status: response.status };
   } catch (err) {
+    // error-policy:J1 transport-boundary translation: a network/timeout failure
+    // becomes a structured result (delivered:false, status:null, error) so the
+    // billing caller is never blocked, yet the failure stays observable and
+    // distinguishable from a delivered response (status:number) or a designed
+    // not_configured skip. It never fabricates a delivered:true.
     const message = err instanceof Error ? err.message : String(err);
     logger.error("[waifu-webhook] delivery error", {
       kind: params.kind,


### PR DESCRIPTION
## Slice 9 of #13415 — vertex / video-generation / waifu services

All four services were **already fail-closed**; this slice adds grep-able `// error-policy:J1/J3` annotations to their justified transport/auth/SSRF boundaries + error-path test coverage (source edits are **comment-only**).

- **vertex-model-registry** — no source change (no catch/console/parseFloat; all calls propagate).
- **vertex-tuning** — J1 on the gcloud-token optional-source catch.
- **video-generation-reconcile** (money) — J1 on the provider status-probe catch (money-safe: probe failure = UNKNOWN, keeps the hold, never refunds blind); strict `Number()+isFinite`; reconcile/refund/idempotency arithmetic left untouched (flagged).
- **waifu-webhook** (money/webhook) — J1/J3 on SSRF-guard + transport + URL-parse; `receiverPath()` money-routing left untouched (flagged).

**Verification** (`.github/issue-evidence/13415-model-media.md`): 15 new error-path tests pass under `--isolate`; source edits verified comment-only. (Created via REST — this shared working tree was concurrently in use.)