### PR TITLE
fix(orchestrator): trim project task filter across backends

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -1042,6 +1042,9 @@ describe("task.projectId binding (#13776)", () => {
     expect(onlyA.map((t) => t.title).sort()).toEqual(["a", "c"]);
     expect(onlyA.every((t) => t.projectId === "proj-a")).toBe(true);
 
+    const trimmedA = await store.listTasks({ projectId: "  proj-a  " });
+    expect(trimmedA.map((t) => t.title).sort()).toEqual(["a", "c"]);
+
     const onlyB = await store.listTasks({ projectId: "proj-b" });
     expect(onlyB.map((t) => t.title)).toEqual(["b"]);
   });
@@ -1056,6 +1059,9 @@ describe("task.projectId binding (#13776)", () => {
     const reader = new FileTaskStore(path);
     const reloaded = await reader.getTask(task.id);
     expect(reloaded?.task.projectId).toBe("proj-file");
+
+    const listed = await reader.listTasks({ projectId: "  proj-file  " });
+    expect(listed.map((t) => t.id)).toEqual([task.id]);
   });
 
   it("writes and filters on the indexed project_id column in the SQL backend", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -340,7 +340,8 @@ function matchesFilter(
   if (!filter.includeArchived && task.archived) return false;
   if (filter.status && filter.status !== "all" && task.status !== filter.status)
     return false;
-  if (filter.projectId && task.projectId !== filter.projectId) return false;
+  const projectId = filter.projectId?.trim();
+  if (projectId && task.projectId !== projectId) return false;
   if (filter.search) {
     const needle = filter.search.trim().toLowerCase();
     if (needle && !searchText.includes(needle)) return false;


### PR DESCRIPTION
## Summary
- trim `TaskListFilter.projectId` in the shared task-store matcher so in-memory and file-backed stores match SQL behavior
- add in-memory and file-backend regressions for whitespace-padded `projectId` filters

## Evidence
- `bun test plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts -t "task.projectId binding"` -> 8 pass, 16 expect calls
- `/Users/shawwalters/eliza-workspace/milady/eliza/node_modules/.bin/biome check plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts --no-errors-on-unmatched` -> pass
- `git diff --check` -> pass

## Notes
- This is the follow-up for the backend parity bug found after #13948 merged: SQL trimmed `projectId`, but memory/file task stores compared the raw filter.
- A full `orchestrator-task-store.test.ts` run in the isolated worktree had the new projectId tests pass, but also hit unrelated local-environment failures: one pre-existing file-store concurrency test timed out at 5s and one Drizzle-backed test could not resolve `drizzle-orm` from this worktree setup.