### PR TITLE
fix(#13981): guard failed message-delete rollback against cross-conversation + streamed-reply clobber

### DIFF
--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -1768,4 +1768,63 @@ describe("useChatSend — handleChatDelete persistent single-message delete (#13
     expect(ok).toBe(false);
     expect(mocks.client.deleteConversationMessage).not.toHaveBeenCalled();
   });
+
+  it("does NOT clobber another conversation's state when the DELETE fails after a mid-delete conversation switch (#13981)", async () => {
+    const deps = makeDeps({ activeConversationId: "conv-A" });
+    seedMessages(deps, [userMsg("a-1"), userMsg("a-2")]);
+    const convBMessages = [userMsg("b-1", "hi B"), userMsg("b-2", "reply B")];
+    const del = deferred<{ ok: boolean; deletedCount: number }>();
+    mocks.client.deleteConversationMessage.mockReturnValueOnce(del.promise);
+    const { result } = renderHook(() => useChatSend(deps));
+
+    let pending!: Promise<boolean>;
+    act(() => {
+      pending = result.current.handleChatDelete("a-2");
+    });
+    // The optimistic removal has run; the user now switches to conversation B,
+    // which swaps the ref + setter to B's messages. THEN the DELETE fails.
+    deps.activeConversationIdRef.current = "conv-B";
+    deps.conversationMessagesRef.current = convBMessages;
+
+    await act(async () => {
+      del.reject(new Error("network"));
+      await pending;
+    });
+
+    // B's displayed state is untouched — A's pre-delete snapshot never leaks in.
+    expect(deps.conversationMessagesRef.current).toEqual(convBMessages);
+    expect(deps.setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to delete message"),
+      "error",
+      expect.any(Number),
+    );
+  });
+
+  it("restores the target without clobbering a reply that streamed in during the failed DELETE (#13981)", async () => {
+    const deps = makeDeps({ activeConversationId: "conv-A" });
+    seedMessages(deps, [userMsg("a-user"), userMsg("a-target")]);
+    const del = deferred<{ ok: boolean; deletedCount: number }>();
+    mocks.client.deleteConversationMessage.mockReturnValueOnce(del.promise);
+    const { result } = renderHook(() => useChatSend(deps));
+
+    let pending!: Promise<boolean>;
+    act(() => {
+      pending = result.current.handleChatDelete("a-target");
+    });
+    // A reply streams into the SAME conversation while the DELETE is in flight
+    // (appended to the live list). The rollback must not discard it.
+    deps.conversationMessagesRef.current = [
+      ...deps.conversationMessagesRef.current,
+      userMsg("a-streamed", "new reply"),
+    ];
+
+    await act(async () => {
+      del.reject(new Error("network"));
+      await pending;
+    });
+
+    const ids = deps.conversationMessagesRef.current.map((m) => m.id);
+    expect(ids).toContain("a-target"); // deleted message restored on failure
+    expect(ids).toContain("a-streamed"); // the reply that streamed in is NOT lost
+  });
 });

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -2266,10 +2266,25 @@ export function useChatSend(deps: UseChatSendDeps) {
         await client.deleteConversationMessage(convId, messageId);
         return true;
       } catch (err) {
-        // Roll back to the pre-delete list so the message stays visible; never
-        // a silent local-only removal on failure.
-        conversationMessagesRef.current = preserved;
-        setConversationMessages(preserved);
+        // Roll back so the message stays visible — never a silent local-only
+        // removal on failure. Only touch state if we're still viewing the
+        // conversation we deleted from: a switch mid-delete swapped the ref +
+        // setter to another conversation, and restoring this one's snapshot
+        // there would leak state across conversations (same guard every send
+        // path uses). Reconcile against the CURRENT list — re-add the pre-delete
+        // messages while keeping anything that streamed in during the request —
+        // rather than overwriting with the stale snapshot, so a reply that
+        // arrived mid-delete is not clobbered.
+        if (activeConversationIdRef.current === convId) {
+          const live = conversationMessagesRef.current;
+          const preservedIds = new Set(preserved.map((m) => m.id));
+          const restored = [
+            ...preserved,
+            ...live.filter((m) => !preservedIds.has(m.id)),
+          ];
+          conversationMessagesRef.current = restored;
+          setConversationMessages(restored);
+        }
         setActionNotice(
           `Failed to delete message: ${err instanceof Error ? err.message : "network error"}`,
           "error",


### PR DESCRIPTION
Closes #13981.

## Bug

`handleChatDelete` (`packages/ui/src/state/useChatSend.ts`) did an optimistic delete, then on failure restored the pre-delete **snapshot unconditionally** — with no `activeConversationIdRef.current === convId` guard (every *send* path in this file has one) and overwriting with the stale list instead of the current one. On a failed DELETE (e.g. flaky network) that clobbered unrelated state:

1. **Conversation switch mid-delete** → the `catch` wrote conversation A's snapshot into conversation **B**'s displayed state.
2. **Reply streams in mid-delete** → the snapshot restore **discarded the newer message**.

## Fix

Roll back only when still viewing the conversation the delete came from, and reconcile against the **current** list — re-add the pre-delete messages while keeping anything that streamed in — rather than overwriting with the stale snapshot:

```ts
if (activeConversationIdRef.current === convId) {
  const live = conversationMessagesRef.current;
  const preservedIds = new Set(preserved.map((m) => m.id));
  const restored = [...preserved, ...live.filter((m) => !preservedIds.has(m.id))];
  conversationMessagesRef.current = restored;
  setConversationMessages(restored);
}
```

## Verification

Two regression tests added to `useChatSend.test.tsx` (real hook under jsdom, fake client, controlled-timing `deferred()`):
- a failed delete **after a conversation switch** leaves B's state untouched (+ still surfaces the failure notice);
- a reply that **streams in during** a failed delete survives while the target is restored.

The pre-existing same-conversation rollback test is unchanged. Full file: **46 passed** (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)