### PR TITLE
refactor(ui): console dedup part 1 — alias removal + shared-util reuse (#13916)

### DIFF
--- a/packages/cloud-ui/src/approvals/ApprovalsRoute.tsx
+++ b/packages/cloud-ui/src/approvals/ApprovalsRoute.tsx
@@ -11,13 +11,13 @@
  * endpoints.
  *
  * Gates on the Steward session (the shell wraps non-public routes in
- * `StewardAuthProvider`; this also checks `useRequireAuth` so a signed-out user
+ * `StewardAuthProvider`; this also checks `useSessionAuth` so a signed-out user
  * sees a prompt instead of empty lists). The same {@link ApprovalsSurface} is
  * exported so a settings-section or sidebar host can embed it without the route
  * wrapper.
  */
 
-import { useRequireAuth } from "@elizaos/ui/cloud/lib/use-session-auth";
+import { useSessionAuth } from "@elizaos/ui/cloud/lib/use-session-auth";
 import { DashboardLoadingState } from "@elizaos/ui/cloud-ui/components/dashboard/route-placeholders";
 import {
   Tabs,
@@ -36,7 +36,7 @@ import { SensitiveTab } from "./components/sensitive-tab";
  * standalone route.
  */
 export function ApprovalsSurface() {
-  const { ready, authenticated } = useRequireAuth();
+  const { ready, authenticated } = useSessionAuth();
 
   if (!ready) {
     return <DashboardLoadingState label="Loading approvals" />;

--- a/packages/ui/src/cloud/api-explorer/ApiExplorerPage.tsx
+++ b/packages/ui/src/cloud/api-explorer/ApiExplorerPage.tsx
@@ -49,7 +49,7 @@ import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
 import { api } from "../lib/api-client";
 import { useDocumentTitle } from "../lib/use-document-title";
-import { useRequireAuth } from "../lib/use-session-auth";
+import { useSessionAuth } from "../lib/use-session-auth";
 import { ApiTester } from "./api-tester";
 import { AuthManager } from "./auth-manager";
 import { toast } from "./toast";
@@ -147,7 +147,7 @@ function resolveApiUrl() {
  * section and wrapped by {@link ApiExplorerRoute} for the standalone route.
  */
 export function ApiExplorerSurface() {
-  const session = useRequireAuth();
+  const session = useSessionAuth();
 
   useDocumentTitle("API Explorer");
 

--- a/packages/ui/src/cloud/applications/ApplicationDetailPage.tsx
+++ b/packages/ui/src/cloud/applications/ApplicationDetailPage.tsx
@@ -1,6 +1,6 @@
 /**
  * /dashboard/apps/:id — single Application detail (8 tabs). The app shell owns
- * the document head; auth gating uses `useRequireAuth()`.
+ * the document head; auth gating uses `useSessionAuth()`.
  */
 
 import { useEffect, useState } from "react";
@@ -16,7 +16,7 @@ import {
   DashboardLoadingState,
 } from "../../cloud-ui/components/dashboard/route-placeholders";
 import { DashboardPageContainer } from "../../cloud-ui/components/layout";
-import { useRequireAuth } from "../lib/use-session-auth";
+import { useSessionAuth } from "../lib/use-session-auth";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { AppDetailsTabs } from "./components/app-details-tabs";
 import { AppPageWrapper } from "./components/single-app-page-wrapper";
@@ -28,7 +28,7 @@ import { isValidUUID } from "./lib/utils";
 export default function ApplicationDetailPage() {
   const t = useCloudT();
   const { id } = useParams<{ id: string }>();
-  const session = useRequireAuth();
+  const session = useSessionAuth();
   const [searchParams] = useSearchParams();
   const location = useLocation();
   const navigate = useNavigate();

--- a/packages/ui/src/cloud/applications/ApplicationsPage.tsx
+++ b/packages/ui/src/cloud/applications/ApplicationsPage.tsx
@@ -1,7 +1,7 @@
 /**
  * /dashboard/apps — the Applications list (cloud OAuth apps). Under the app
  * shell the document head is owned by the host, not per-cloud-route. Auth
- * gating uses `useRequireAuth()` (Steward session).
+ * gating uses `useSessionAuth()` (Steward session).
  */
 
 import { Activity, Grid3x3, TrendingUp, Users } from "lucide-react";
@@ -16,7 +16,7 @@ import {
   DashboardPageContainer,
   DashboardStatGrid,
 } from "../../cloud-ui/components/layout";
-import { useRequireAuth } from "../lib/use-session-auth";
+import { useSessionAuth } from "../lib/use-session-auth";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { AppsTable } from "./components/apps-table";
 import { useApps } from "./lib/apps";
@@ -24,7 +24,7 @@ import { useApps } from "./lib/apps";
 /** /dashboard/apps */
 export default function ApplicationsPage() {
   const t = useCloudT();
-  const session = useRequireAuth();
+  const session = useSessionAuth();
   const { data, isLoading, isError, error } = useApps();
 
   const apps = data ?? [];

--- a/packages/ui/src/cloud/applications/NativeAppsStudio.tsx
+++ b/packages/ui/src/cloud/applications/NativeAppsStudio.tsx
@@ -16,7 +16,7 @@
  *  - the cloud providers the pages expect — the shared cloud `QueryClient` and
  *    the cloud i18n context (same pair `CloudRouterShell` wraps its routes in);
  *  - a **native Steward auth context** fed from the stored Steward JWT
- *    (`localStorage[STEWARD_TOKEN_KEY]`), so `useRequireAuth()` resolves
+ *    (`localStorage[STEWARD_TOKEN_KEY]`), so `useSessionAuth()` resolves
  *    immediately to the signed-in user instead of waiting on the heavy
  *    `@stwd/*` runtime (which native never mounts — sign-in is the existing
  *    `launchStewardLogin` launcher, reached before this view).
@@ -152,7 +152,7 @@ function buildStewardAuthValue(token: string | null): LocalStewardAuthValue {
 
 /**
  * Provide the cloud Steward auth context from the stored JWT, kept in sync with
- * token changes (refresh, sign-out, 401 self-heal) so `useRequireAuth()` tracks
+ * token changes (refresh, sign-out, 401 self-heal) so `useSessionAuth()` tracks
  * the live session without the `@stwd/*` runtime.
  */
 function NativeStewardAuthProvider({

--- a/packages/ui/src/cloud/applications/components/apps-table.tsx
+++ b/packages/ui/src/cloud/applications/components/apps-table.tsx
@@ -27,18 +27,15 @@ import {
   AlertDialogTitle,
 } from "../../../components/ui/alert-dialog";
 import { Button } from "../../../components/ui/button";
+import { copyTextToClipboard } from "../../../utils/clipboard";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import { APPS_QUERY_KEY, type App, deleteApp } from "../lib/apps";
-
-interface AppsTableProps {
-  apps: App[];
-}
 
 /** How long to wait before re-syncing the list from the server after a
  * delete — long enough for the API's eventual consistency to settle. */
 const POST_DELETE_RESYNC_MS = 8_000;
 
-export function AppsTable({ apps }: AppsTableProps) {
+export function AppsTable({ apps }: { apps: App[] }) {
   const t = useCloudT();
   const queryClient = useQueryClient();
   const [deletingIds, setDeletingIds] = useState<ReadonlySet<string>>(
@@ -51,7 +48,7 @@ export function AppsTable({ apps }: AppsTableProps) {
 
   const handleCopyUrl = async (url: string) => {
     try {
-      await navigator.clipboard.writeText(url);
+      await copyTextToClipboard(url);
       toast.success(
         t("cloud.apps.toast.urlCopied", {
           defaultValue: "URL copied to clipboard",

--- a/packages/ui/src/cloud/home/DashboardHomePage.test.tsx
+++ b/packages/ui/src/cloud/home/DashboardHomePage.test.tsx
@@ -22,7 +22,6 @@ const sessionState = {
   user: { id: "u1", email: "a@b.test" },
 };
 vi.mock("../lib/use-session-auth", () => ({
-  useRequireAuth: () => sessionState,
   useSessionAuth: () => sessionState,
 }));
 

--- a/packages/ui/src/cloud/home/DashboardHomePage.tsx
+++ b/packages/ui/src/cloud/home/DashboardHomePage.tsx
@@ -24,8 +24,9 @@ import { Link } from "react-router-dom";
 import { DashboardLoadingState } from "../../cloud-ui/components/dashboard/route-placeholders";
 import { useSetPageHeader } from "../../cloud-ui/components/layout";
 import { useCreditsBalance } from "../instances/lib/data/credits";
+import { formatUsd } from "../lib/format-usd";
 import { useDocumentTitle } from "../lib/use-document-title";
-import { useRequireAuth } from "../lib/use-session-auth";
+import { useSessionAuth } from "../lib/use-session-auth";
 import { useCloudT } from "../shell/CloudI18nProvider";
 
 interface ConsoleSurface {
@@ -147,7 +148,7 @@ function BalanceCard() {
             aria-busy={balance === null}
             className="text-2xl font-semibold text-txt-strong"
           >
-            {balance === null ? "—" : `$${balance.toFixed(2)}`}
+            {balance === null ? "—" : formatUsd(balance)}
           </span>
         )}
       </div>
@@ -163,7 +164,7 @@ function BalanceCard() {
 
 export function DashboardHomePage() {
   const t = useCloudT();
-  const session = useRequireAuth();
+  const session = useSessionAuth();
   useDocumentTitle(t("cloud.home.metaTitle", { defaultValue: "Dashboard" }));
   // Title renders in the console chrome's top bar (ConsoleShell captures it).
   useSetPageHeader({

--- a/packages/ui/src/cloud/instances/AgentDetailPage.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.tsx
@@ -23,7 +23,7 @@ import {
 import { Link, Navigate, useParams } from "react-router-dom";
 import { ApiError } from "../lib/api-client";
 import { useDocumentTitle } from "../lib/use-document-title";
-import { useRequireAuth } from "../lib/use-session-auth";
+import { useSessionAuth } from "../lib/use-session-auth";
 import { ElizaAgentActions } from "./components/agent-actions";
 import { DockerLogsViewer } from "./components/docker-logs-viewer";
 import { ElizaAgentBackupsPanel } from "./components/eliza-agent-backups-panel";
@@ -77,7 +77,7 @@ function formatRelativeShort(
 
 export default function AgentDetailPage() {
   const t = useT();
-  const session = useRequireAuth();
+  const session = useSessionAuth();
   const { id } = useParams<{ id: string }>();
   const enabled = session.ready && session.authenticated;
   const query = useAgent(enabled ? id : undefined);

--- a/packages/ui/src/cloud/instances/AgentsPage.tsx
+++ b/packages/ui/src/cloud/instances/AgentsPage.tsx
@@ -11,7 +11,7 @@ import {
   ElizaAgentsPageWrapper,
 } from "@elizaos/ui/cloud-ui";
 import { useDocumentTitle } from "../lib/use-document-title";
-import { useRequireAuth } from "../lib/use-session-auth";
+import { useSessionAuth } from "../lib/use-session-auth";
 import { ElizaAgentPricingBanner } from "./components/eliza-agent-pricing-banner";
 import {
   type ElizaAgentRow,
@@ -45,7 +45,7 @@ function toAgentRow(a: AgentListItem): ElizaAgentRow {
 
 export default function AgentsPage() {
   const t = useT();
-  const session = useRequireAuth();
+  const session = useSessionAuth();
   const enabled = session.ready && session.authenticated;
   const agentsQuery = useAgents();
   const credits = useCreditsBalance();

--- a/packages/ui/src/cloud/instances/MyAgentsPage.tsx
+++ b/packages/ui/src/cloud/instances/MyAgentsPage.tsx
@@ -8,13 +8,13 @@ import {
   EnsurePageHeaderProvider,
 } from "@elizaos/ui/cloud-ui";
 import { useDocumentTitle } from "../lib/use-document-title";
-import { useRequireAuth } from "../lib/use-session-auth";
+import { useSessionAuth } from "../lib/use-session-auth";
 import { MyAgentsClient } from "./components/my-agents";
 import { useT } from "./lib/i18n";
 
 export default function MyAgentsPage() {
   const t = useT();
-  const session = useRequireAuth();
+  const session = useSessionAuth();
 
   useDocumentTitle(t("cloud.myAgents.metaTitle", { defaultValue: "My Agent" }));
 

--- a/packages/ui/src/cloud/instances/components/eliza-agent-backups-panel.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agent-backups-panel.tsx
@@ -337,7 +337,9 @@ export function ElizaAgentBackupsPanel({
                           )}
                           <Badge
                             variant="outline"
-                            className={SNAPSHOT_TYPE_STYLES[backup.snapshotType]}
+                            className={
+                              SNAPSHOT_TYPE_STYLES[backup.snapshotType]
+                            }
                           >
                             {SNAPSHOT_TYPE_LABELS[backup.snapshotType]}
                           </Badge>

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -100,10 +100,6 @@ export interface ElizaAgentRow {
   updated_at: Date | string;
 }
 
-interface ElizaAgentsTableProps {
-  sandboxes: ElizaAgentRow[];
-}
-
 /**
  * Fold one API list-agent onto its existing row (or a fresh row when there is
  * none), preserving the local-only fields the list endpoint doesn't return
@@ -286,7 +282,9 @@ function StatusCell({
 
 export function ElizaAgentsTable({
   sandboxes: initialSandboxes,
-}: ElizaAgentsTableProps) {
+}: {
+  sandboxes: ElizaAgentRow[];
+}) {
   const t = useT();
   const queryClient = useQueryClient();
   const [deleteIds, setDeleteIds] = useState<string[] | null>(null);
@@ -389,6 +387,19 @@ export function ElizaAgentsTable({
       void refreshData();
     },
   });
+
+  const handleProvisionQueued = useCallback(
+    (agentId: string, jobId: string) => {
+      jobActionById.current.set(
+        jobId,
+        t("cloud.elizaAgentsTable.agentProvisioning", {
+          defaultValue: "Agent provisioning",
+        }),
+      );
+      poller.track(agentId, jobId);
+    },
+    [poller, t],
+  );
 
   useSandboxListPoll(
     localSandboxes.map((sb) => ({
@@ -710,15 +721,7 @@ export function ElizaAgentsTable({
         icon={Boxes}
         action={
           <CreateElizaAgentDialog
-            onProvisionQueued={(agentId, jobId) => {
-              jobActionById.current.set(
-                jobId,
-                t("cloud.elizaAgentsTable.agentProvisioning", {
-                  defaultValue: "Agent provisioning",
-                }),
-              );
-              poller.track(agentId, jobId);
-            }}
+            onProvisionQueued={handleProvisionQueued}
             onCreated={refreshData}
           />
         }
@@ -842,15 +845,7 @@ export function ElizaAgentsTable({
             </SelectContent>
           </Select>
           <CreateElizaAgentDialog
-            onProvisionQueued={(agentId, jobId) => {
-              jobActionById.current.set(
-                jobId,
-                t("cloud.elizaAgentsTable.agentProvisioning", {
-                  defaultValue: "Agent provisioning",
-                }),
-              );
-              poller.track(agentId, jobId);
-            }}
+            onProvisionQueued={handleProvisionQueued}
             onCreated={refreshData}
           />
         </div>

--- a/packages/ui/src/cloud/instances/components/eliza-transactions-section.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-transactions-section.tsx
@@ -265,7 +265,9 @@ export function ElizaTransactionsSection({
                       {truncate(tx.request.to)}
                     </span>
                   ) : (
-                    <span className="font-mono text-xs-tight text-muted">—</span>
+                    <span className="font-mono text-xs-tight text-muted">
+                      —
+                    </span>
                   )}
                 </div>
                 <div className="bg-card px-3 py-2.5">
@@ -305,7 +307,9 @@ export function ElizaTransactionsSection({
                       />
                     </a>
                   ) : (
-                    <span className="font-mono text-xs-tight text-muted">—</span>
+                    <span className="font-mono text-xs-tight text-muted">
+                      —
+                    </span>
                   )}
                 </div>
               </div>

--- a/packages/ui/src/cloud/instances/lib/sandbox-status.ts
+++ b/packages/ui/src/cloud/instances/lib/sandbox-status.ts
@@ -42,9 +42,7 @@ export function statusDotColor(status: string): string {
 }
 
 export function statusBadgeColor(status: string): string {
-  return (
-    STATUS_BADGE_COLORS[status] ?? "bg-bg-muted text-muted border-border"
-  );
+  return STATUS_BADGE_COLORS[status] ?? "bg-bg-muted text-muted border-border";
 }
 
 /** Format a date into a human-readable relative time string. */

--- a/packages/ui/src/cloud/lib/use-session-auth.ts
+++ b/packages/ui/src/cloud/lib/use-session-auth.ts
@@ -213,8 +213,3 @@ export function useSessionAuth(): SessionAuthState {
 
   return { ready, authenticated, user };
 }
-
-/** The session state for protected pages (gate rendering on `authenticated`). */
-export function useRequireAuth(): SessionAuthState {
-  return useSessionAuth();
-}

--- a/packages/ui/src/cloud/monetization/MonetizationPage.test.tsx
+++ b/packages/ui/src/cloud/monetization/MonetizationPage.test.tsx
@@ -21,11 +21,6 @@ vi.mock("../lib/use-session-auth", () => ({
     authenticated: true,
     user: { id: "u1", email: "qa@e.test" },
   }),
-  useSessionAuth: () => ({
-    ready: true,
-    authenticated: true,
-    user: { id: "u1", email: "qa@e.test" },
-  }),
 }));
 
 import { MonetizationPage } from "./MonetizationPage";

--- a/packages/ui/src/cloud/monetization/MonetizationPage.test.tsx
+++ b/packages/ui/src/cloud/monetization/MonetizationPage.test.tsx
@@ -16,7 +16,7 @@ vi.mock("../shell/CloudI18nProvider", () => ({
     options?.defaultValue ?? key,
 }));
 vi.mock("../lib/use-session-auth", () => ({
-  useRequireAuth: () => ({
+  useSessionAuth: () => ({
     ready: true,
     authenticated: true,
     user: { id: "u1", email: "qa@e.test" },

--- a/packages/ui/src/cloud/monetization/affiliates/AffiliatesSurface.tsx
+++ b/packages/ui/src/cloud/monetization/affiliates/AffiliatesSurface.tsx
@@ -7,14 +7,14 @@
 
 import { DashboardLoadingState } from "../../../cloud-ui/components/dashboard/route-placeholders";
 import { useDocumentTitle } from "../../lib/use-document-title";
-import { useRequireAuth } from "../../lib/use-session-auth";
+import { useSessionAuth } from "../../lib/use-session-auth";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import { AffiliatesPageClient } from "./AffiliatesPageClient";
 
 /** Bare affiliates surface — auth-gated, no page chrome. */
 export function AffiliatesSurface() {
   const t = useCloudT();
-  const { ready, authenticated } = useRequireAuth();
+  const { ready, authenticated } = useSessionAuth();
 
   useDocumentTitle(
     t("cloud.affiliates.metaTitle", { defaultValue: "Affiliates" }),

--- a/packages/ui/src/cloud/monetization/earnings/EarningsSurface.tsx
+++ b/packages/ui/src/cloud/monetization/earnings/EarningsSurface.tsx
@@ -7,14 +7,14 @@
 
 import { DashboardLoadingState } from "../../../cloud-ui/components/dashboard/route-placeholders";
 import { useDocumentTitle } from "../../lib/use-document-title";
-import { useRequireAuth } from "../../lib/use-session-auth";
+import { useSessionAuth } from "../../lib/use-session-auth";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import { EarningsPageClient } from "./EarningsPageClient";
 
 /** Bare earnings surface — auth-gated, no page chrome. */
 export function EarningsSurface() {
   const t = useCloudT();
-  const { ready, authenticated } = useRequireAuth();
+  const { ready, authenticated } = useSessionAuth();
 
   useDocumentTitle(
     t("cloud.earnings.metaTitle", {

--- a/packages/ui/src/cloud/public-pages/pages/chat/public-chat-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/chat/public-chat-page.tsx
@@ -169,9 +169,7 @@ export default function PublicChatPage() {
         <div className="space-y-2">
           <h1 className="text-2xl font-semibold">{character.name}</h1>
           {character.creatorUsername ? (
-            <p className="text-sm text-muted">
-              @{character.creatorUsername}
-            </p>
+            <p className="text-sm text-muted">@{character.creatorUsername}</p>
           ) : null}
           {character.bio ? (
             <p className="text-sm leading-relaxed text-muted">

--- a/packages/ui/src/cloud/public-pages/pages/legal/privacy-policy-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/legal/privacy-policy-page.tsx
@@ -149,9 +149,7 @@ export default function PrivacyPolicyPage() {
           <div className="space-y-10">
             {sections.map((section) => (
               <section key={section.title} className="space-y-3">
-                <h2 className="text-2xl font-bold text-txt">
-                  {section.title}
-                </h2>
+                <h2 className="text-2xl font-bold text-txt">{section.title}</h2>
                 <p className="leading-relaxed text-muted-strong">
                   {section.body}
                 </p>

--- a/packages/ui/src/cloud/public-pages/pages/legal/terms-of-service-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/legal/terms-of-service-page.tsx
@@ -202,9 +202,7 @@ export default function TermsOfServicePage() {
           <div className="prose prose-invert max-w-none space-y-10">
             {sections.map((section) => (
               <section key={section.title} className="space-y-3">
-                <h2 className="text-2xl font-bold text-txt">
-                  {section.title}
-                </h2>
+                <h2 className="text-2xl font-bold text-txt">{section.title}</h2>
                 {section.body}
               </section>
             ))}

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -66,7 +66,9 @@ export default function LoginPage() {
               })}
             </h1>
             <p className="text-sm text-muted">
-              {t("cloud.login.tagline", { defaultValue: "Run Eliza in Cloud." })}
+              {t("cloud.login.tagline", {
+                defaultValue: "Run Eliza in Cloud.",
+              })}
             </p>
           </div>
         </div>

--- a/packages/ui/src/cloud/shell/ConsoleShell.test.tsx
+++ b/packages/ui/src/cloud/shell/ConsoleShell.test.tsx
@@ -19,7 +19,6 @@ const sessionState = {
   } | null,
 };
 vi.mock("../lib/use-session-auth", () => ({
-  useRequireAuth: () => sessionState,
   useSessionAuth: () => sessionState,
 }));
 

--- a/packages/ui/src/cloud/shell/ConsoleShell.tsx
+++ b/packages/ui/src/cloud/shell/ConsoleShell.tsx
@@ -28,13 +28,12 @@ import {
   DashboardHeader,
   DashboardShellLayout,
   DashboardSidebar,
-  type DashboardSidebarItem,
   type DashboardSidebarLinkRenderProps,
   type DashboardSidebarSection,
   PageHeaderProvider,
   usePageHeader,
 } from "../../cloud-ui/components/layout";
-import { useRequireAuth } from "../lib/use-session-auth";
+import { useSessionAuth } from "../lib/use-session-auth";
 
 /**
  * The console nav: one flat list, launch-core surfaces only (nubs's cut,
@@ -91,13 +90,6 @@ function renderRouterLink({
   );
 }
 
-/** Prefix match so agent/app detail routes keep their parent item lit; the
- * Overview item stays exact so it doesn't light for every console page. */
-function isItemActive(item: DashboardSidebarItem, activePath: string): boolean {
-  if (item.href === "/dashboard") return activePath === "/dashboard";
-  return activePath === item.href || activePath.startsWith(`${item.href}/`);
-}
-
 function ConsoleLogo(): ReactNode {
   return (
     <Link to="/dashboard" aria-label="Eliza Cloud overview">
@@ -141,7 +133,7 @@ export function ConsoleShell({
   children: ReactNode;
 }): React.JSX.Element {
   const location = useLocation();
-  const session = useRequireAuth();
+  const session = useSessionAuth();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const toggleSidebar = useCallback(() => setSidebarOpen((v) => !v), []);
 
@@ -168,7 +160,6 @@ export function ConsoleShell({
             isOpen={sidebarOpen}
             onToggle={toggleSidebar}
             renderLink={renderRouterLink}
-            isItemActive={isItemActive}
             logo={<ConsoleLogo />}
             // The kit's own `md:static` loses the cascade in this bundle: Vite
             // emits per-chunk CSS and a later chunk re-declares `.fixed`, which


### PR DESCRIPTION
Part 1 of #13916 (the 5-rules audit's mechanical/medium slices — behavior-neutral by construction):

- **`useRequireAuth` deleted** (rule 1: same-in-same-out alias of `useSessionAuth`) — 14 call sites updated.
- **`isItemActive` deleted from ConsoleShell** (rule 2: re-implemented the kit's `defaultIsItemActive`; no `dashboard/**/create` route exists so behavior is identical).
- **`formatUsd`** replaces hand-rolled `$${balance.toFixed(2)}` in the home hero (rule 2, canonical USD formatter).
- **`copyTextToClipboard`** replaces raw `navigator.clipboard` in apps-table (rule 2 — and gains desktop-bridge/legacy-webview fallbacks for free).
- Two **single-use prop-type aliases inlined** (rule 3); duplicate `onProvisionQueued` lambdas hoisted to one named callback (rule 2).

**Verification:** 29/29 tests green (ConsoleShell, home, api-keys, account-security, agents-table merge suites); typecheck 0 errors across the touched cloud areas; biome clean. Part 2 (shared bulk-select kit, `runAgentJob`, row view-model, table split, surface catalog) stays on #13916. [qa-agent]