### PR TITLE
fix(cloud-shared): repair vertex tuning test header

### DIFF
--- a/packages/cloud/shared/src/lib/services/vertex-tuning.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/vertex-tuning.error-policy.test.ts
@@ -1,11 +1,11 @@
-// Pins the Vertex tuning transport layer: an internal API failure PROPAGATES as a
-// thrown error, while a legitimately-empty job list stays a distinct empty result —
-// neither is masked into a fabricated success. Deterministic (global fetch mocked).
+/**
+ * Pins the Vertex tuning transport layer: an internal API failure PROPAGATES as
+ * a thrown error, while a legitimately-empty job list stays a distinct empty
+ * result — neither is masked into a fabricated success. Deterministic harness:
+ * global fetch is mocked and restored per test.
+ */
 import { afterEach, describe, expect, test } from "bun:test";
-import {
-  getTuningJobStatus,
-  listTuningJobs,
-} from "./vertex-tuning";
+import { getTuningJobStatus, listTuningJobs } from "./vertex-tuning";
 
 const realFetch = globalThis.fetch;
 


### PR DESCRIPTION
## Summary

Follow-up to #13986 after it merged at the detached PR head. Repairs the new `vertex-tuning.error-policy.test.ts` file header to the repo-required top-level `/** ... */` prose block and applies the Biome import formatting that was also failing for that file.

## Verification

- `bunx biome check packages/cloud/shared/src/lib/services/vertex-tuning.error-policy.test.ts` -> pass
- `git diff --check` -> pass

## Evidence

N/A UI/model/audio/runtime traces: test-file comment/format cleanup only.