### PR TITLE
fix(app-core): fail closed on auth-pair no-DB boot window instead of the static token (#13985)

### DIFF
--- a/.github/issue-evidence/13985-auth-pair-static-token.md
+++ b/.github/issue-evidence/13985-auth-pair-static-token.md
@@ -1,0 +1,22 @@
+# #13985 — auth-pair no-DB fallback hands out the forever-valid static token
+
+## Vulnerability
+`packages/app-core/src/api/auth-pairing-routes.ts` — on a correct pairing exchange the handler mints a revocable, TTL-bound machine session **only when `getCompatDrizzleDb(state)` is non-null**. When the runtime DB is not yet up (a real window — compat routes mount before the runtime finishes booting), it fell through to `sendJsonResponse(res, 200, { token })`, returning the **raw `ELIZA_API_TOKEN`** — a **non-expiring, non-revocable** full-authority bearer. A remote device pairing during the boot window kept a permanent connection key.
+
+This directly violates the `getCompatDrizzleDb` contract (its own docstring: *"Callers MUST treat null as 'service unavailable' — it is never authentication."*).
+
+## Fix
+Fail closed: the no-DB branch now returns `503 "Pairing not ready, retry"` instead of the static token. The pairing code's TTL gives the client headroom to retry once the runtime DB is up and a real revocable session can be minted. The DB-present branch (revocable session) and the DB-error catch (already 500, no fallback) are unchanged.
+
+## Verification
+`packages/app-core/src/api/auth-pairing-routes.test.ts` (vitest) — **8 pass / 0 fail**:
+- NEW: "fails closed with 503 (never the static API token) when the runtime DB is not yet up during the boot window (#13985)" — primes a pair code, submits it with `STATE` (`current: null` → `getCompatDrizzleDb` null), asserts `status === 503`, body is **not** `{ token: <static token> }`, and no session was minted.
+- Existing "mints a machine session … returns session id, not the static API token" (DB-present secure path) still passes → the fix doesn't regress the good path.
+
+Repro before the fix: submit the valid pairing code to `POST /api/auth/pair` before the runtime DB is ready → response carried the static token. After: `503`.
+
+## Related (out of scope, noted in the issue, LOW)
+The agent standalone path (`packages/agent/src/api/auth-routes.ts`) still returns the static token by design; the app-core session-minting path is the strictly-safer one and should be the only reachable path in a full deployment.
+
+## N/A
+UI/model-trajectory/audio — N/A (server auth route). Live-LLM trajectory — N/A (no model path). Runtime traces — the boot-window behavior is proven deterministically by the vitest regression above.

--- a/packages/app-core/src/api/auth-pairing-routes.test.ts
+++ b/packages/app-core/src/api/auth-pairing-routes.test.ts
@@ -383,6 +383,41 @@ describe("auth pairing pair-code route", () => {
     );
   });
 
+  it("fails closed with 503 (never the static API token) when the runtime DB is not yet up during the boot window (#13985)", async () => {
+    vi.spyOn(crypto, "randomInt").mockImplementation(() => 0);
+    sessionMocks.createMachineSession.mockClear();
+
+    // Prime the in-memory pair code via the loopback fetch.
+    await handleAuthPairingCompatRoutes(
+      fakeReq({
+        method: "GET",
+        pathname: "/api/auth/pair-code",
+        ip: "127.0.0.1",
+        host: "localhost:2138",
+      }),
+      fakeRes().res,
+      STATE_WITH_DB,
+    );
+
+    const remote = fakeReq({
+      method: "POST",
+      pathname: "/api/auth/pair",
+      ip: "203.0.113.10",
+    });
+    (remote as unknown as { body: unknown }).body = { code: "AAAA-AAAA-AAAA" };
+
+    const res = fakeRes();
+    // `STATE` has `current: null`, so `getCompatDrizzleDb` returns null — the
+    // boot-window case. The handler must NOT fall open to the forever-valid
+    // static `ELIZA_API_TOKEN`; it fails closed so the client retries.
+    await handleAuthPairingCompatRoutes(remote, res.res, STATE);
+
+    expect(res.status()).toBe(503);
+    // The static connection key must never leave via this path.
+    expect(res.body()).not.toEqual({ token: "pairing-test-token" });
+    expect(sessionMocks.createMachineSession).not.toHaveBeenCalled();
+  });
+
   it("reuses an existing owner identity when one is configured", async () => {
     vi.spyOn(crypto, "randomInt").mockImplementation(() => 0);
     sessionMocks.createMachineSession.mockClear();

--- a/packages/app-core/src/api/auth-pairing-routes.ts
+++ b/packages/app-core/src/api/auth-pairing-routes.ts
@@ -393,9 +393,14 @@ export async function handleAuthPairingCompatRoutes(
       }
     }
 
-    // No DB yet — extremely unlikely once the runtime is up enough to serve
-    // requests, but preserve the legacy static-token return as a fallback.
-    sendJsonResponse(res, 200, { token });
+    // No DB yet — `getCompatDrizzleDb` null means "service unavailable, never
+    // authentication" (its contract). Returning the forever-valid static token
+    // here would hand a remote device paired during the boot window a
+    // permanent, non-revocable full-authority bearer — exactly what the
+    // DB-present branch mints a revocable, TTL-bound session to avoid. Fail
+    // closed; the pairing code's TTL gives the client headroom to retry once
+    // the runtime DB is up and a real session can be minted (#13985).
+    sendJsonErrorResponse(res, 503, "Pairing not ready, retry");
     return true;
   }
 


### PR DESCRIPTION
## Security fix — #13985

`POST /api/auth/pair` minted a revocable, TTL-bound session **only when the runtime DB was up**. During the boot window (compat routes mount before the runtime DB is ready), it **fell open** to `sendJsonResponse(res, 200, { token })`, returning the raw **forever-valid, non-revocable `ELIZA_API_TOKEN`**. A remote device pairing in that window kept a permanent full-authority bearer.

This violates `getCompatDrizzleDb`'s own contract: *"Callers MUST treat null as service unavailable — it is never authentication."*

**Fix:** the no-DB branch now returns `503 "Pairing not ready, retry"` (fail closed); the pairing code's TTL lets the client retry once the DB is up. DB-present (revocable session) and the DB-error catch (already 500) are unchanged.

**Verification** (`.github/issue-evidence/13985-auth-pair-static-token.md`): `auth-pairing-routes.test.ts` **8 pass / 0 fail**, including a NEW regression that pairs during the boot window (`STATE.current = null`) and asserts `503` + body is not the static token + no session minted; the existing DB-present secure-path test still passes. (Created via REST — this working tree was concurrently in use.)

Found via adversarial auth-pairing sweep. Security-sensitive — flagged for review.