### PR TITLE
fix(#13985): pair endpoint must not hand out the forever-valid static token when the DB isn't ready

### DIFF
--- a/packages/app-core/src/api/auth-pairing-routes.test.ts
+++ b/packages/app-core/src/api/auth-pairing-routes.test.ts
@@ -332,6 +332,53 @@ describe("auth pairing pair-code route", () => {
     }
   });
 
+  it("fails closed with a retryable 503 (never the static token) when the runtime DB is not ready, and keeps the code valid for retry (#13985)", async () => {
+    vi.spyOn(crypto, "randomInt").mockImplementation(() => 0);
+    sessionMocks.createMachineSession.mockClear();
+
+    // Prime the in-memory pair code (it lives in module state, not the DB).
+    await handleAuthPairingCompatRoutes(
+      fakeReq({
+        method: "GET",
+        pathname: "/api/auth/pair-code",
+        ip: "127.0.0.1",
+        host: "localhost:2138",
+      }),
+      fakeRes().res,
+      STATE,
+    );
+
+    // A remote device submits the correct code during the boot window, before
+    // the runtime DB is up (STATE.current === null → getCompatDrizzleDb null).
+    const remote = fakeReq({
+      method: "POST",
+      pathname: "/api/auth/pair",
+      ip: "203.0.113.10",
+    });
+    (remote as unknown as { body: unknown }).body = { code: "AAAA-AAAA-AAAA" };
+    const res = fakeRes();
+    await handleAuthPairingCompatRoutes(remote, res.res, STATE);
+
+    // Fail closed: retryable 503, no session minted, and — critically — the
+    // forever-valid static ELIZA_API_TOKEN is NEVER returned.
+    expect(res.status()).toBe(503);
+    expect(sessionMocks.createMachineSession).not.toHaveBeenCalled();
+    expect(JSON.stringify(res.body())).not.toContain("pairing-test-token");
+
+    // The 503 did NOT consume the code, so a retry once the DB is up completes
+    // normally and mints a revocable session (not the static token).
+    const retry = fakeReq({
+      method: "POST",
+      pathname: "/api/auth/pair",
+      ip: "203.0.113.10",
+    });
+    (retry as unknown as { body: unknown }).body = { code: "AAAA-AAAA-AAAA" };
+    const res2 = fakeRes();
+    await handleAuthPairingCompatRoutes(retry, res2.res, STATE_WITH_DB);
+    expect(res2.status()).toBe(200);
+    expect(res2.body()).toEqual({ token: "test-machine-session-id" });
+  });
+
   it("mints a machine session on successful pair (returns session id, not the static API token)", async () => {
     vi.spyOn(crypto, "randomInt").mockImplementation(() => 0);
     sessionMocks.createMachineSession.mockClear();

--- a/packages/app-core/src/api/auth-pairing-routes.ts
+++ b/packages/app-core/src/api/auth-pairing-routes.ts
@@ -355,48 +355,51 @@ export async function handleAuthPairingCompatRoutes(
       return true;
     }
 
+    // Mint a machine session so the paired client gets a session-id bearer
+    // token that authenticates against `ensureCompatApiAuthorizedAsync`.
+    // Sessions are TTL-bound and revocable; the raw static connection key is
+    // forever-valid and non-revocable, so it must NEVER be returned here
+    // (#13985): the compat routes mount before the runtime DB finishes booting,
+    // and a device that paired during that window would keep a permanent
+    // full-authority bearer. If the DB isn't ready yet, fail closed with a
+    // retryable 503 and leave the pairing code intact — its TTL gives the
+    // client headroom to retry once the runtime is up.
+    const db = getCompatDrizzleDb(state);
+    if (!db) {
+      sendJsonErrorResponse(res, 503, "Pairing not ready yet, retry shortly");
+      return true;
+    }
+
+    // Consume the code only now that a session can actually be minted, so the
+    // transient DB-not-ready 503 above does not burn a still-valid code.
     pairingCode = null;
     pairingExpiresAt = 0;
 
-    // Mint a machine session so the paired client gets a session-id bearer
-    // token that authenticates against `ensureCompatApiAuthorizedAsync`.
-    // Returning the raw connection key here would auth `/api/auth/status`
-    // (static-token branch) but get rejected on every other route once the
-    // runtime DB is up. Sessions are TTL-bound and revocable; the static
-    // connection key is forever-valid until the operator rotates it.
-    const db = getCompatDrizzleDb(state);
-    if (db) {
-      try {
-        const store = new AuthStore(
-          db as ConstructorParameters<typeof AuthStore>[0],
-        );
-        const identityId = await ensurePairedDeviceIdentityId(store);
-        const { session } = await createMachineSession(store, {
-          identityId,
-          scopes: [],
-          label: "paired-device",
-          ip: remoteAddress,
-        });
-        sendJsonResponse(res, 200, { token: session.id });
-        return true;
-      } catch (err) {
-        // Surface the failure rather than silently falling back to a path
-        // that mints a forever-valid static-token bearer. Operators should
-        // see the underlying error and fix it; clients retry pairing.
-        logger.error(
-          `[api] pair: failed to mint machine session: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-        sendJsonErrorResponse(res, 500, "Failed to mint session");
-        return true;
-      }
+    try {
+      const store = new AuthStore(
+        db as ConstructorParameters<typeof AuthStore>[0],
+      );
+      const identityId = await ensurePairedDeviceIdentityId(store);
+      const { session } = await createMachineSession(store, {
+        identityId,
+        scopes: [],
+        label: "paired-device",
+        ip: remoteAddress,
+      });
+      sendJsonResponse(res, 200, { token: session.id });
+      return true;
+    } catch (err) {
+      // Surface the failure rather than silently falling back to a path that
+      // mints a forever-valid static-token bearer. Operators should see the
+      // underlying error and fix it; clients retry pairing.
+      logger.error(
+        `[api] pair: failed to mint machine session: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      sendJsonErrorResponse(res, 500, "Failed to mint session");
+      return true;
     }
-
-    // No DB yet — extremely unlikely once the runtime is up enough to serve
-    // requests, but preserve the legacy static-token return as a fallback.
-    sendJsonResponse(res, 200, { token });
-    return true;
   }
 
   return false;


### PR DESCRIPTION
Closes #13985.

## Security bug

`POST /api/auth/pair` (`packages/app-core/src/api/auth-pairing-routes.ts`) minted a revocable, TTL-bound machine session only when `getCompatDrizzleDb(state)` was non-null. When the runtime DB was not up yet — a **real window**, since the compat routes mount before the runtime finishes booting — it fell through to `sendJsonResponse(res, 200, { token })`, returning the raw static **`ELIZA_API_TOKEN`**. That connection key is **non-expiring and non-revocable**, so a device that paired during the boot window kept a **permanent full-authority bearer**.

**Repro:** submit the valid pairing code before the runtime DB is ready → the response carries the static token instead of a session id; it authenticates every route indefinitely.

## Fix (fail closed)

Check DB readiness **before** consuming the pairing code, and return a retryable **`503`** instead of the static token when it isn't ready. The code is left intact (its TTL gives headroom), so a retry once the runtime is up mints the session normally — the forever-token is never emitted. Moving the DB check ahead of the code-consumption is what makes the 503 retryable.

## Verification

Added a test to `auth-pairing-routes.test.ts` (real handler, mocked auth/session/store): a correct pair submitted with **no DB yet** returns 503, mints no session, never emits the static `ELIZA_API_TOKEN`, and leaves the code valid so a retry with the DB up returns the session id. The pre-existing success/loopback tests are unchanged.

```
Test Files  1 passed (1)
     Tests  8 passed (8)
```

(There is a related LOW note in the issue about the agent standalone path always returning the static token with per-IP-only rate limiting; that is a separate module and out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)