### PR TITLE
test(app-core/#13692): real no-mock e2e for the device-pairing auth path

### DIFF
--- a/.github/issue-evidence/13692-pairing-e2e/README.md
+++ b/.github/issue-evidence/13692-pairing-e2e/README.md
@@ -1,0 +1,52 @@
+# #13692 — production device-pairing auth path: real no-mock e2e
+
+**Issue:** The auth path real users hit — a non-loopback client blocked by the
+pairing wall completing `GET /api/auth/pair-code` → `POST /api/auth/pair` and
+receiving a revocable machine session — had **zero automated e2e on any
+surface**. Every lane bypasses it (`ELIZA_PAIRING_DISABLED=1`), and the only
+route coverage was 5 unit tests that **mock** `AuthStore`, the session layer,
+and the DB — so they prove the route *branches* but never that a minted session
+authenticates subsequent requests, nor that revocation works.
+
+## What this adds
+
+`packages/app-core/src/api/auth-pairing-flow.test.ts` — a real end-to-end that
+drives the whole flow over a **real TCP HTTP server** against a **real
+`AuthStore` backed by a real, migrated PGlite database**. Nothing is mocked:
+the route, the store, the session lifecycle, and the DB are all the production
+code paths.
+
+Covered:
+
+| Behavior | Assertion |
+|---|---|
+| loopback code disclosure | `GET /api/auth/pair-code` from loopback → 200 + rotating code |
+| pairing wall (proxied/remote) | same route with `x-forwarded-for` → 403 |
+| remote wall via status probe | `GET /api/auth/status` (proxied, no auth) → `required:true, pairingEnabled:true` |
+| wrong code | `POST /api/auth/pair` bad code → 403 |
+| **mint + authenticate (the crux)** | correct code → 200 `{token:<sessionId>}`; that bearer makes a proxied `GET /api/auth/status` → `authenticated:true` |
+| session is a real DB row | `store.findSession(id)` → machine-kind, `paired-device` label, `revokedAt:null` |
+| **revocable** | `store.revokeSession(id)`; same bearer → `authenticated:false`, `findActiveSession` → null |
+| single-use replay | replaying a consumed code → 403 |
+| per-IP rate limit | 6th attempt in the window → 429 |
+| pairing disabled | `ELIZA_PAIRING_DISABLED=1` → code 503, pair 403 |
+
+## Evidence
+
+- `verbose-run.txt` — full `vitest --reporter=verbose` output. Shows the **real
+  route** minting real rotating pair codes (`9KLB-XRQR-ED7C`, …) and the **real
+  PGlite DB** (`[PLUGIN:SQL]` logs) — 7/7 passing, ~1.8s test time.
+
+Run it:
+
+```bash
+bun run --cwd packages/app-core test -- src/api/auth-pairing-flow.test.ts
+```
+
+## Why it counts
+
+The pre-existing unit test substitutes a mock for the exact thing under test
+(the session→auth→DB round trip), which the repo standard explicitly does not
+count as coverage. This suite makes the real path reachable in-process (migrated
+PGlite + real HTTP) and asserts the property users depend on: **a paired session
+authenticates real requests and stops the moment it is revoked.**

--- a/.github/issue-evidence/13692-pairing-e2e/verbose-run.txt
+++ b/.github/issue-evidence/13692-pairing-e2e/verbose-run.txt
@@ -1,0 +1,61 @@
+ RUN  v4.1.5 /private/tmp/claude-501/-Users-shawwalters-milaidy-eliza/65e3dadc-1388-4582-8841-3424e9e84ff1/scratchpad/eliza-work/packages/app-core
+stdout | src/api/auth-pairing-flow.test.ts
+ Info       [Migration] Starting pre-1.6.5 → 1.6.5+ schema migration...
+stdout | src/api/auth-pairing-flow.test.ts
+ Info       [Migration] ✓ Migration complete - pre-1.6.5 → 1.6.5+ schema migration finished
+stdout | src/api/auth-pairing-flow.test.ts
+ Info       [PLUGIN:SQL] Initializing migration system
+stdout | src/api/auth-pairing-flow.test.ts
+ Info       [PLUGIN:SQL] Migration system initialized
+stdout | src/api/auth-pairing-flow.test.ts
+ Info       [PLUGIN:SQL] DatabaseMigrationService initialized
+stdout | src/api/auth-pairing-flow.test.ts
+ Info       [PLUGIN:SQL] Plugin schemas discovered (schemasDiscovered=1, totalPlugins=2)
+ Info       [PLUGIN:SQL] Starting migrations (environment=DEVELOPMENT, pluginCount=1, dryRun=false)
+ Info       [PLUGIN:SQL] Starting migration for plugin (pluginName=@elizaos/plugin-sql)
+ Info       [PLUGIN:SQL] Initializing migration system
+stdout | src/api/auth-pairing-flow.test.ts
+ Info       [PLUGIN:SQL] Migration system initialized
+stdout | src/api/auth-pairing-flow.test.ts
+ Info       [PLUGIN:SQL] Executing SQL statements (pluginName=@elizaos/plugin-sql, statementCount=167)
+stdout | src/api/auth-pairing-flow.test.ts
+ Info       [PLUGIN:SQL] Recorded migration (pluginName=@elizaos/plugin-sql, tag=0000_@elizaos/plugin-sql_mr7b7hfi)
+stdout | src/api/auth-pairing-flow.test.ts
+ Info       [PLUGIN:SQL] Migration completed successfully (pluginName=@elizaos/plugin-sql)
+stdout | src/api/auth-pairing-flow.test.ts
+ Info       [PLUGIN:SQL] Migration completed (pluginName=@elizaos/plugin-sql)
+ Info       [PLUGIN:SQL] All migrations completed successfully (successCount=1)
+stderr | src/api/auth-pairing-flow.test.ts
+ Warn       [PLUGIN:SQL] [MessageSearch] pg_trgm unavailable; trigram acceleration disabled (FTS still active) (error=Failed query: CREATE EXTENSION IF NOT EXISTS pg_trgm
+params: )
+stdout | src/api/auth-pairing-flow.test.ts
+ Info       [PLUGIN:SQL] [MessageSearch] full-text search objects applied (trigramAvailable=false)
+stdout | src/api/auth-pairing-flow.test.ts
+ Info       [PLUGIN:SQL] Skipping RLS re-application (ENABLE_DATA_ISOLATION is not true)
+stderr | src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > discloses the pair code to loopback but hides it from proxied/remote callers
+ Warn       [api] Pairing code for remote devices: 9KLB-XRQR-ED7C (valid for 10 minutes)
+stderr | src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > shows the pairing wall to an unauthenticated remote client via /api/auth/status
+ Warn       [api] Pairing code for remote devices: 2YX3-9EW4-Z5F7 (valid for 10 minutes)
+stderr | src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > rejects a wrong pairing code
+ Warn       [api] Pairing code for remote devices: 4RVN-EFNN-ZWQT (valid for 10 minutes)
+stderr | src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > mints a revocable machine session that authenticates and then stops after revoke
+ Warn       [api] Pairing code for remote devices: BX66-Z66Q-344M (valid for 10 minutes)
+stderr | src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > mints a revocable machine session that authenticates and then stops after revoke
+ Warn       [api] Pairing code for remote devices: X4JC-TB7Q-YQ3X (valid for 10 minutes)
+stderr | src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > treats a pairing code as single-use — a replay of a consumed code is rejected
+ Warn       [api] Pairing code for remote devices: C2TA-FKVS-D8V7 (valid for 10 minutes)
+stderr | src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > treats a pairing code as single-use — a replay of a consumed code is rejected
+ Warn       [api] Pairing code for remote devices: U95P-XT6C-466G (valid for 10 minutes)
+stderr | src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > rate-limits repeated pairing attempts from the same client IP
+ Warn       [api] Pairing code for remote devices: 8HG9-NFUX-YNZG (valid for 10 minutes)
+ ✓ src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > discloses the pair code to loopback but hides it from proxied/remote callers 10ms
+ ✓ src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > shows the pairing wall to an unauthenticated remote client via /api/auth/status 3ms
+ ✓ src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > rejects a wrong pairing code 2ms
+ ✓ src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > mints a revocable machine session that authenticates and then stops after revoke 15ms
+ ✓ src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > treats a pairing code as single-use — a replay of a consumed code is rejected 4ms
+ ✓ src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > rate-limits repeated pairing attempts from the same client IP 3ms
+ ✓ src/api/auth-pairing-flow.test.ts > production device-pairing auth path — real DB + real HTTP (#13692) > goes dark when pairing is disabled 1ms
+ Test Files  1 passed (1)
+      Tests  7 passed (7)
+   Start at  00:46:51
+   Duration  10.32s (transform 6.46s, setup 0ms, import 8.39s, tests 1.84s, environment 0ms)

--- a/packages/app-core/src/api/auth-pairing-flow.test.ts
+++ b/packages/app-core/src/api/auth-pairing-flow.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Real end-to-end for the production device-pairing auth path (#13692).
+ *
+ * The sibling `auth-pairing-routes.test.ts` mocks `AuthStore`, the session
+ * layer, and the DB, so it proves the route *branches* but structurally cannot
+ * prove the property real users depend on: that a session minted by pairing
+ * actually authenticates subsequent requests, and that revoking it takes
+ * effect. Every CI lane bypasses this path entirely (`ELIZA_PAIRING_DISABLED=1`
+ * on the device-e2e host + mobile/android workflows), so it had **zero**
+ * no-mock coverage.
+ *
+ * This suite drives the WHOLE flow over a real TCP HTTP server, against a real
+ * `AuthStore` backed by a real, migrated PGlite database — nothing mocked:
+ *
+ *   loopback GET  /api/auth/pair-code            → operator reads rotating code
+ *   proxied  GET  /api/auth/pair-code            → 403 (pairing wall)
+ *   remote   POST /api/auth/pair  (wrong code)   → 403
+ *   remote   POST /api/auth/pair  (correct code) → 200 { token: <sessionId> }
+ *   remote   GET  /api/auth/status Bearer <id>   → authenticated:true  (THE crux)
+ *   revoke the session in the real DB
+ *   remote   GET  /api/auth/status Bearer <id>   → authenticated:false (revocable)
+ *
+ * plus the adversarial matrix the mocked unit test can't reach through stubs:
+ * single-use replay of a consumed code (403), per-IP rate limit (429),
+ * pairing-disabled darkness (503/403), and the session actually landing as a
+ * row in the real `auth_session` table with the `paired-device` label.
+ */
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { UUID } from "@elizaos/core";
+import { plugin as sqlPlugin } from "@elizaos/plugin-sql";
+import { createTestDatabase } from "@elizaos/plugin-sql/__tests__/test-helpers";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { AuthStore } from "../services/auth-store";
+import { findActiveSession } from "./auth/sessions";
+// The route module holds pairing state in module globals; import once and
+// reset between tests via the exported test hook.
+import {
+  _resetAuthPairingStateForTests,
+  handleAuthPairingCompatRoutes,
+} from "./auth-pairing-routes";
+import type { CompatRuntimeState } from "./compat-route-shared";
+
+const TEST_AGENT_ID = "00000000-0000-0000-0000-000000013692" as UUID;
+
+const REMOTE_IP = "203.0.113.10";
+
+interface Harness {
+  baseUrl: string;
+  store: AuthStore;
+  close: () => Promise<void>;
+}
+
+interface HttpResult {
+  status: number;
+  json: Record<string, unknown> | null;
+}
+
+/**
+ * Fire a real HTTP request at the running server. `proxied` attaches an
+ * `x-forwarded-for` header so the request is treated as coming through a proxy
+ * from a non-loopback client — the exact shape a remote device hits, which the
+ * loopback-trust check rejects for code disclosure.
+ */
+async function request(
+  baseUrl: string,
+  opts: {
+    method: string;
+    path: string;
+    proxied?: boolean;
+    bearer?: string;
+    body?: unknown;
+  },
+): Promise<HttpResult> {
+  const url = new URL(opts.path, baseUrl);
+  const payload =
+    opts.body === undefined ? undefined : JSON.stringify(opts.body);
+  const headers: Record<string, string> = {};
+  if (payload !== undefined) {
+    headers["content-type"] = "application/json";
+    headers["content-length"] = String(Buffer.byteLength(payload));
+  }
+  if (opts.proxied) headers["x-forwarded-for"] = REMOTE_IP;
+  if (opts.bearer) headers.authorization = `Bearer ${opts.bearer}`;
+
+  return await new Promise<HttpResult>((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname + url.search,
+        method: opts.method,
+        headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(Buffer.from(c)));
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString("utf8");
+          let json: Record<string, unknown> | null = null;
+          if (text.length > 0) {
+            try {
+              json = JSON.parse(text) as Record<string, unknown>;
+            } catch {
+              json = null;
+            }
+          }
+          resolve({ status: res.statusCode ?? 0, json });
+        });
+      },
+    );
+    req.on("error", reject);
+    if (payload !== undefined) req.write(payload);
+    req.end();
+  });
+}
+
+let harness: Harness;
+let cleanupDb: () => Promise<void>;
+
+const ENV_KEYS = [
+  "ELIZA_API_TOKEN",
+  "ELIZA_PAIRING_DISABLED",
+  "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_REQUIRE_LOCAL_AUTH",
+  "ELIZAOS_CLOUD_ENABLED",
+  "ELIZAOS_CLOUD_API_KEY",
+  "STEWARD_AGENT_TOKEN",
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeAll(async () => {
+  for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+  // Pairing is enabled iff a compat API token is configured, pairing is not
+  // explicitly disabled, and the deployment is not cloud-provisioned.
+  process.env.ELIZA_API_TOKEN = "e2e-pairing-static-token";
+  delete process.env.ELIZA_PAIRING_DISABLED;
+  delete process.env.ELIZA_CLOUD_PROVISIONED;
+  delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+  delete process.env.ELIZAOS_CLOUD_ENABLED;
+  delete process.env.ELIZAOS_CLOUD_API_KEY;
+  delete process.env.STEWARD_AGENT_TOKEN;
+
+  // Real, migrated PGlite database with the plugin-sql auth schema.
+  const db = await createTestDatabase(TEST_AGENT_ID, [sqlPlugin]);
+  cleanupDb = db.cleanup;
+  const drizzle = db.adapter.getDatabase();
+  const store = new AuthStore(
+    drizzle as ConstructorParameters<typeof AuthStore>[0],
+  );
+
+  // The route reads the runtime DB off `state.current.adapter.db`.
+  const state: CompatRuntimeState = {
+    current: {
+      adapter: { db: drizzle },
+    } as unknown as CompatRuntimeState["current"],
+    pendingAgentName: null,
+    pendingRestartReasons: [],
+  };
+
+  const server = http.createServer((req, res) => {
+    handleAuthPairingCompatRoutes(req, res, state)
+      .then((handled) => {
+        if (!handled) {
+          res.writeHead(404, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: "not found" }));
+        }
+      })
+      .catch((err) => {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  harness = {
+    baseUrl: `http://127.0.0.1:${port}`,
+    store,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+});
+
+afterAll(async () => {
+  await harness?.close();
+  await cleanupDb?.();
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+beforeEach(() => {
+  _resetAuthPairingStateForTests();
+});
+
+/** Read the current rotating pair code the way a local operator would. */
+async function fetchPairCode(): Promise<string> {
+  const res = await request(harness.baseUrl, {
+    method: "GET",
+    path: "/api/auth/pair-code",
+  });
+  expect(res.status).toBe(200);
+  const code = res.json?.code;
+  expect(typeof code).toBe("string");
+  return code as string;
+}
+
+describe("production device-pairing auth path — real DB + real HTTP (#13692)", () => {
+  it("discloses the pair code to loopback but hides it from proxied/remote callers", async () => {
+    const local = await request(harness.baseUrl, {
+      method: "GET",
+      path: "/api/auth/pair-code",
+    });
+    expect(local.status).toBe(200);
+    expect(local.json).toMatchObject({
+      code: expect.stringMatching(/^[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/),
+      expiresAt: expect.any(Number),
+    });
+
+    const proxied = await request(harness.baseUrl, {
+      method: "GET",
+      path: "/api/auth/pair-code",
+      proxied: true,
+    });
+    expect(proxied.status).toBe(403);
+    expect(proxied.json).toMatchObject({
+      error: "Pair code visible on loopback only",
+    });
+  });
+
+  it("shows the pairing wall to an unauthenticated remote client via /api/auth/status", async () => {
+    const status = await request(harness.baseUrl, {
+      method: "GET",
+      path: "/api/auth/status",
+      proxied: true,
+    });
+    expect(status.status).toBe(200);
+    expect(status.json).toMatchObject({
+      required: true,
+      authenticated: false,
+      localAccess: false,
+      pairingEnabled: true,
+    });
+  });
+
+  it("rejects a wrong pairing code", async () => {
+    await fetchPairCode();
+    const res = await request(harness.baseUrl, {
+      method: "POST",
+      path: "/api/auth/pair",
+      body: { code: "ZZZZ-ZZZZ-ZZZZ" },
+    });
+    expect(res.status).toBe(403);
+    expect(res.json).toMatchObject({ error: "Invalid pairing code" });
+  });
+
+  it("mints a revocable machine session that authenticates and then stops after revoke", async () => {
+    const code = await fetchPairCode();
+
+    // Remote client completes pairing and receives a session id (NOT the
+    // forever-valid static API token).
+    const paired = await request(harness.baseUrl, {
+      method: "POST",
+      path: "/api/auth/pair",
+      body: { code },
+    });
+    expect(paired.status).toBe(200);
+    const sessionId = paired.json?.token as string;
+    expect(typeof sessionId).toBe("string");
+    expect(sessionId).not.toBe(process.env.ELIZA_API_TOKEN);
+
+    // The session is a real row in the real auth_session table, machine-kind,
+    // labelled by the pairing flow.
+    const row = await harness.store.findSession(sessionId);
+    expect(row).not.toBeNull();
+    expect(row?.kind).toBe("machine");
+    expect(row?.userAgent).toBe("paired-device");
+    expect(row?.revokedAt).toBeNull();
+
+    // THE crux #13692 asks for: the minted session authenticates a subsequent
+    // request against real DB truth — proven by a proxied (non-local) status
+    // probe that is authenticated ONLY because of the bearer session.
+    const authed = await request(harness.baseUrl, {
+      method: "GET",
+      path: "/api/auth/status",
+      proxied: true,
+      bearer: sessionId,
+    });
+    expect(authed.status).toBe(200);
+    expect(authed.json).toMatchObject({
+      authenticated: true,
+      required: false,
+    });
+
+    // Independent confirmation through the real session lookup helper.
+    const active = await findActiveSession(harness.store, sessionId);
+    expect(active?.id).toBe(sessionId);
+
+    // Revoke in the real DB and confirm the bearer no longer authenticates —
+    // sessions are revocable, unlike the static connection key.
+    const revoked = await harness.store.revokeSession(sessionId);
+    expect(revoked).toBe(true);
+
+    const afterRevoke = await request(harness.baseUrl, {
+      method: "GET",
+      path: "/api/auth/status",
+      proxied: true,
+      bearer: sessionId,
+    });
+    expect(afterRevoke.status).toBe(200);
+    expect(afterRevoke.json).toMatchObject({
+      authenticated: false,
+      required: true,
+    });
+    expect(await findActiveSession(harness.store, sessionId)).toBeNull();
+  });
+
+  it("treats a pairing code as single-use — a replay of a consumed code is rejected", async () => {
+    const code = await fetchPairCode();
+
+    const first = await request(harness.baseUrl, {
+      method: "POST",
+      path: "/api/auth/pair",
+      body: { code },
+    });
+    expect(first.status).toBe(200);
+
+    // Same code again: it was cleared on success and a fresh code rotated in,
+    // so the old value no longer matches.
+    const replay = await request(harness.baseUrl, {
+      method: "POST",
+      path: "/api/auth/pair",
+      body: { code },
+    });
+    expect(replay.status).toBe(403);
+    expect(replay.json).toMatchObject({ error: "Invalid pairing code" });
+  });
+
+  it("rate-limits repeated pairing attempts from the same client IP", async () => {
+    await fetchPairCode();
+    // PAIRING_MAX_ATTEMPTS = 5; the 6th attempt in the window is throttled.
+    const statuses: number[] = [];
+    for (let i = 0; i < 6; i += 1) {
+      const res = await request(harness.baseUrl, {
+        method: "POST",
+        path: "/api/auth/pair",
+        body: { code: "ZZZZ-ZZZZ-ZZZZ" },
+      });
+      statuses.push(res.status);
+    }
+    expect(statuses.slice(0, 5)).toEqual([403, 403, 403, 403, 403]);
+    expect(statuses[5]).toBe(429);
+  });
+
+  it("goes dark when pairing is disabled", async () => {
+    process.env.ELIZA_PAIRING_DISABLED = "1";
+    try {
+      const code = await request(harness.baseUrl, {
+        method: "GET",
+        path: "/api/auth/pair-code",
+      });
+      expect(code.status).toBe(503);
+      expect(code.json).toMatchObject({ error: "Pairing not enabled" });
+
+      const pair = await request(harness.baseUrl, {
+        method: "POST",
+        path: "/api/auth/pair",
+        body: { code: "ANY0-CODE-HERE" },
+      });
+      expect(pair.status).toBe(403);
+      expect(pair.json).toMatchObject({ error: "Pairing disabled" });
+    } finally {
+      delete process.env.ELIZA_PAIRING_DISABLED;
+    }
+  });
+});


### PR DESCRIPTION
Closes #13692.

## Problem

The auth path real users hit — a non-loopback client blocked by the pairing wall completing `GET /api/auth/pair-code` → `POST /api/auth/pair` and receiving a **revocable machine session** — had **zero automated e2e on any surface**. Every lane bypasses it (`ELIZA_PAIRING_DISABLED=1` on the device-e2e host + mobile/android workflows), and the only route coverage was 5 unit tests (`auth-pairing-routes.test.ts`) that **mock** `AuthStore`, the session layer, and the DB. Those prove the route *branches* but never the property users depend on: that a minted session actually authenticates subsequent requests, and that revoking it takes effect. Per the repo standard, a test asserting against a mock standing in for the thing under test does not count.

## What this adds

`packages/app-core/src/api/auth-pairing-flow.test.ts` — a real end-to-end that drives the whole flow over a **real TCP HTTP server** against a **real `AuthStore` backed by a real, migrated PGlite database** (`createTestDatabase` + the plugin-sql auth schema). Nothing is mocked: route, store, session lifecycle, and DB are the production paths.

| Behavior | Assertion |
|---|---|
| loopback code disclosure | `GET /api/auth/pair-code` (loopback) → 200 + rotating code |
| pairing wall (proxied/remote) | same route with `x-forwarded-for` → 403 |
| remote wall via status probe | proxied unauth `GET /api/auth/status` → `required:true, pairingEnabled:true` |
| wrong code | `POST /api/auth/pair` bad code → 403 |
| **mint + authenticate (the crux)** | correct code → 200 `{token:<sessionId>}`; that bearer makes a proxied `GET /api/auth/status` return `authenticated:true` |
| session is a real DB row | `store.findSession(id)` → machine-kind, `paired-device` label, `revokedAt:null` |
| **revocable** | `store.revokeSession(id)`; same bearer → `authenticated:false`; `findActiveSession` → null |
| single-use replay | replaying a consumed code → 403 |
| per-IP rate limit | 6th attempt in window → 429 |
| pairing disabled | `ELIZA_PAIRING_DISABLED=1` → code 503, pair 403 |

## Evidence

`.github/issue-evidence/13692-pairing-e2e/` — full `vitest --reporter=verbose` output showing the **real route** minting real rotating pair codes and the **real PGlite DB** (`[PLUGIN:SQL]` logs). **7/7 pass, ~1.8s test time.**

```
bun run --cwd packages/app-core test -- src/api/auth-pairing-flow.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Runs in the default `packages/app-core` vitest lane (real-PGlite precedent: the bootstrap-token suite), so CI exercises it with no opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)