### PR TITLE
fix(search): require multi-term coverage for typo matches

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -30,6 +30,26 @@ describe("rankMessageSearch", () => {
 		expect(hits[0].trigramSimilarity).toBeGreaterThanOrEqual(0.45);
 	});
 
+	it("requires every multi-term query token to match before using typo recall", () => {
+		const items = [
+			{
+				id: "a",
+				createdAt: 1,
+				content: { text: "how do I edit the configuration file" },
+			},
+			{
+				id: "b",
+				createdAt: 2,
+				content: { text: "deployment notes without the requested setup token" },
+			},
+		];
+
+		expect(
+			rankMessageSearch(items, "configuraton file").map((hit) => hit.item.id),
+		).toEqual(["a"]);
+		expect(rankMessageSearch(items, "configuraton deployment")).toEqual([]);
+	});
+
 	it("does not admit unrelated text through the trigram branch", () => {
 		const hits = rankMessageSearch(
 			[

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1905,17 +1905,21 @@ function messageSearchTokens(text: string): string[] {
 
 function termTrigramSimilarity(queryTerms: string[], document: string): number {
 	const documentTokens = messageSearchTokens(document);
-	let best = 0;
+	if (queryTerms.length === 0 || documentTokens.length === 0) return 0;
+	let total = 0;
 	for (const queryTerm of queryTerms) {
+		let bestForTerm = document.includes(queryTerm) ? 1 : 0;
 		const queryGrams = toTrigramSet(queryTerm);
 		for (const documentToken of documentTokens) {
-			best = Math.max(
-				best,
+			bestForTerm = Math.max(
+				bestForTerm,
 				trigramSetSimilarity(queryGrams, toTrigramSet(documentToken)),
 			);
 		}
+		if (bestForTerm < MESSAGE_SEARCH_TRIGRAM_THRESHOLD) return 0;
+		total += bestForTerm;
 	}
-	return best;
+	return total / queryTerms.length;
 }
 
 /** A message-shaped record the in-memory search ranker can score and order. */

--- a/plugins/plugin-sql/src/__tests__/integration/message-search-fts.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/message-search-fts.test.ts
@@ -166,6 +166,14 @@ describe("searchMessages FTS + trigram (real DB)", () => {
     expect((await searchTexts("configuraton")).some((t) => t.includes("configuration"))).toBe(true);
   });
 
+  it("4c. typo fallback still requires every multi-term query token", async () => {
+    if (!trigramAvailable) return;
+    expect(
+      (await searchTexts("configuraton file")).some((t) => t.includes("configuration file"))
+    ).toBe(true);
+    expect(await searchTexts("configuraton deployment")).toEqual([]);
+  });
+
   it("5. stemming — 'configure' matches 'configuring'", async () => {
     expect((await searchTexts("configure")).some((t) => t.includes("configuring"))).toBe(true);
   });

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -1720,7 +1720,17 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       const trigramExpr = trigramAvailable
         ? sql<number>`GREATEST(similarity(${document}, ${foldedQuery}), word_similarity(${foldedQuery}, ${document}))`
         : sql<number>`0`;
-      const trigramMatch = trigramAvailable ? sql`${trigramExpr} >= 0.45` : sql`FALSE`;
+      const trigramMatch = trigramAvailable
+        ? sql`NOT EXISTS (
+            SELECT 1
+            FROM unnest(regexp_split_to_array(${foldedQuery}, '[[:space:]]+')) AS query_terms(term)
+            WHERE query_terms.term <> ''
+              AND NOT (
+                ${document} LIKE eliza_search_like_pattern(query_terms.term)
+                OR word_similarity(query_terms.term, ${document}) >= 0.45
+              )
+          )`
+        : sql`FALSE`;
 
       const conditions = [
         eq(memoryTable.type, tableName),


### PR DESCRIPTION
## Summary
- tighten the in-memory message typo ranker so every query term must be represented before a trigram match is admitted
- apply the same per-query-token requirement to the SQL trigram fallback path
- add regressions for the #13940 follow-up case where `configuraton deployment` matched a `configuration file` result through a single typo-similar token

## Evidence
- `bun test packages/core/src/search.test.ts` -> 3 pass / 6 expects
- `bun test plugins/plugin-sql/src/__tests__/integration/message-search-fts.test.ts` with local coverage temporarily disabled -> 20 pass / 31 expects
- `./node_modules/.bin/biome check packages/core/src/search.ts packages/core/src/search.test.ts plugins/plugin-sql/src/base.ts plugins/plugin-sql/src/__tests__/integration/message-search-fts.test.ts` -> pass
- `git diff --check` -> pass

## Evidence notes
- Local PGlite logs `pg_trgm unavailable; trigram acceleration disabled`, so the new SQL regression is extension-gated in this environment. There is no `POSTGRES_URL` available locally to exercise the real `pg_trgm` branch; the PR keeps that explicit rather than claiming unrun Postgres coverage.
- N/A screenshots/video: search scoring and SQL predicate behavior only; no UI surface changed.
- N/A live LLM trajectories: deterministic search/ranking fix, no agent/model behavior path changed.