### PR TITLE
fix(cloud): sort waifu webhook test import

### DIFF
--- a/packages/cloud/shared/src/lib/services/waifu-webhook.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/waifu-webhook.error-policy.test.ts
@@ -16,8 +16,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   type EmitWaifuWebhookParams,
-  type WaifuWebhookTarget,
   emitWaifuWebhook,
+  type WaifuWebhookTarget,
 } from "./waifu-webhook";
 
 // Public IPv4 literal (documentation range is forbidden; this one is routable


### PR DESCRIPTION
## Summary
- fixes the remaining Biome import-order residual from #13986/#13993 in `waifu-webhook.error-policy.test.ts`
- changes only the order of named imports; no production behavior or test assertions changed

## Evidence
- `/Users/shawwalters/eliza-workspace/milady/eliza/node_modules/.bin/biome check .github/issue-evidence/13415-model-media.md packages/cloud/shared/src/lib/services/vertex-model-registry.error-policy.test.ts packages/cloud/shared/src/lib/services/vertex-tuning.error-policy.test.ts packages/cloud/shared/src/lib/services/vertex-tuning.ts packages/cloud/shared/src/lib/services/video-generation-reconcile.error-policy.test.ts packages/cloud/shared/src/lib/services/video-generation-reconcile.ts packages/cloud/shared/src/lib/services/waifu-webhook.error-policy.test.ts packages/cloud/shared/src/lib/services/waifu-webhook.ts --no-errors-on-unmatched` -> pass
- `git diff --check` -> pass

## Local test note
- `bun test --isolate packages/cloud/shared/src/lib/services/waifu-webhook.error-policy.test.ts` did not reach assertions in this fresh worktree because Bun could not resolve `/Users/shawwalters/eliza-workspace/milady/node_modules/@elizaos/cloud-routing`. This PR is import-order-only; CI should be authoritative for the existing test execution.

## Evidence N/A
- Screenshots/video: backend test import-order cleanup only.
- Live LLM trajectories: no agent/model path changed.