### PR TITLE
fix(cloud): bound legacy steward cookie mutation

### DIFF
--- a/.github/issue-evidence/13406-legacy-steward-cookie-bound.md
+++ b/.github/issue-evidence/13406-legacy-steward-cookie-bound.md
@@ -9,9 +9,10 @@ Non-production Steward session teardown now owns only the environment-suffixed c
 ## Manual Review
 
 - Reviewed `packages/cloud/api/auth/logout/route.ts`: staging reads and clears only `steward-token-staging`, `steward-refresh-token-staging`, and `steward-authed-staging`; production/unset may read and clear the historical unsuffixed cookies.
+- Reviewed `packages/cloud/api/auth/logout/route.ts`: server-side teardown is gated on an environment-owned Steward token, so staging/dev logout cannot resolve a production user through the bounded legacy fallback and end production sessions.
 - Reviewed `packages/cloud/api/auth/steward-session/route.ts`: DELETE clears suffixed cookies in non-production and clears the legacy names only when `canMutateLegacyStewardCookies()` says the Worker owns them.
 - Reviewed `packages/cloud/api/auth/steward-refresh/route.ts`: rejected browser refresh clears the environment-scoped cookie names and does not clear `steward-authed` outside production/unset.
-- Reviewed `packages/cloud/shared/src/lib/auth/steward-cookies.ts`: the mutation guard is explicit and isolated beside the cookie name resolver, so future read-fallback callers do not imply write/delete authority.
+- Reviewed `packages/cloud/shared/src/lib/auth/steward-cookies.ts`: the mutation guard is explicit and isolated beside the cookie name resolver, so future read-fallback callers do not imply write/delete authority. The legacy fallback wording now states that non-production refresh-only sessions re-authenticate because legacy refresh cookies are not read.
 - Reviewed the focused test output by hand; the new assertions check `Set-Cookie` deletion names, including denied legacy deletion in staging and preserved legacy deletion in production.
 
 ## Verification
@@ -34,7 +35,7 @@ git diff --check
 bun test --reporter=dots \
   packages/cloud/api/auth/steward-refresh/route.test.ts \
   packages/cloud/api/auth/logout/route.test.ts
-# 6 pass, 0 fail, 28 expect() calls
+# 7 pass, 0 fail, 37 expect() calls
 
 bun test --reporter=dots --coverage-reporter=lcov \
   packages/cloud/api/__tests__/steward-session-delete-scopes-cookie-clears.test.ts \
@@ -47,7 +48,7 @@ bun run audit:error-policy-ratchet -- --report
 
 ## Evidence Rows
 
-- Real request/response traces: covered by route-level Hono `app.request`/`app.fetch` tests that assert the actual response `Set-Cookie` deletion names for `/api/auth/steward-session`, `/api/auth/steward-refresh`, and `/api/auth/logout`. A full `cloud:mock` deployment was not run for this draft because the change is limited to pure cookie name selection and response headers.
+- Real request/response traces: covered by route-level Hono `app.request`/`app.fetch` tests that assert the actual response `Set-Cookie` deletion names for `/api/auth/steward-session`, `/api/auth/steward-refresh`, and `/api/auth/logout`, plus the staging legacy-only logout test that proves production session teardown is not invoked. A full `cloud:mock` deployment was not run for this draft because the change is limited to cookie/session ownership boundaries in route code.
 - Backend logs: N/A. The touched paths do not add or require new structured log lines; the observable artifact is the response cookie deletion set.
 - DB/domain artifacts: N/A. No database rows, billing records, migrations, memory, knowledge, scheduled tasks, wallet, chain, files, or device artifacts are created or changed.
 - Real LLM trajectories: N/A. No agent, provider, prompt, model, or action behavior changes.

--- a/.github/issue-evidence/13406-legacy-steward-cookie-bound.md
+++ b/.github/issue-evidence/13406-legacy-steward-cookie-bound.md
@@ -1,0 +1,55 @@
+# Legacy Steward Cookie Bound Evidence
+
+Tracker: #13406 project board draft item, "auth) bound legacy-cookie migration so staging/dev stop reading prod cookies".
+
+## Claim
+
+Non-production Steward session teardown now owns only the environment-suffixed cookie names. Production/unset environments still own the historical unsuffixed names, so production logout behavior is preserved while staging/dev can no longer clear production's shared-parent-domain cookies during the bounded legacy migration.
+
+## Manual Review
+
+- Reviewed `packages/cloud/api/auth/logout/route.ts`: staging reads and clears only `steward-token-staging`, `steward-refresh-token-staging`, and `steward-authed-staging`; production/unset may read and clear the historical unsuffixed cookies.
+- Reviewed `packages/cloud/api/auth/steward-session/route.ts`: DELETE clears suffixed cookies in non-production and clears the legacy names only when `canMutateLegacyStewardCookies()` says the Worker owns them.
+- Reviewed `packages/cloud/api/auth/steward-refresh/route.ts`: rejected browser refresh clears the environment-scoped cookie names and does not clear `steward-authed` outside production/unset.
+- Reviewed `packages/cloud/shared/src/lib/auth/steward-cookies.ts`: the mutation guard is explicit and isolated beside the cookie name resolver, so future read-fallback callers do not imply write/delete authority.
+- Reviewed the focused test output by hand; the new assertions check `Set-Cookie` deletion names, including denied legacy deletion in staging and preserved legacy deletion in production.
+
+## Verification
+
+```bash
+bunx @biomejs/biome check \
+  packages/cloud/shared/src/lib/auth/steward-cookies.ts \
+  packages/cloud/shared/src/lib/auth/steward-cookies.test.ts \
+  packages/cloud/api/auth/steward-session/route.ts \
+  packages/cloud/api/auth/steward-refresh/route.ts \
+  packages/cloud/api/auth/logout/route.ts \
+  packages/cloud/api/__tests__/steward-session-delete-scopes-cookie-clears.test.ts \
+  packages/cloud/api/auth/steward-refresh/route.test.ts \
+  packages/cloud/api/auth/logout/route.test.ts
+# Checked 8 files in 37ms. No fixes applied.
+
+git diff --check
+# exit 0
+
+bun test --reporter=dots \
+  packages/cloud/api/auth/steward-refresh/route.test.ts \
+  packages/cloud/api/auth/logout/route.test.ts
+# 6 pass, 0 fail, 28 expect() calls
+
+bun test --reporter=dots --coverage-reporter=lcov \
+  packages/cloud/api/__tests__/steward-session-delete-scopes-cookie-clears.test.ts \
+  packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
+# 5 pass, 0 fail, 21 expect() calls
+
+bun run audit:error-policy-ratchet -- --report
+# no new fallback-slop in touched files
+```
+
+## Evidence Rows
+
+- Real request/response traces: covered by route-level Hono `app.request`/`app.fetch` tests that assert the actual response `Set-Cookie` deletion names for `/api/auth/steward-session`, `/api/auth/steward-refresh`, and `/api/auth/logout`. A full `cloud:mock` deployment was not run for this draft because the change is limited to pure cookie name selection and response headers.
+- Backend logs: N/A. The touched paths do not add or require new structured log lines; the observable artifact is the response cookie deletion set.
+- DB/domain artifacts: N/A. No database rows, billing records, migrations, memory, knowledge, scheduled tasks, wallet, chain, files, or device artifacts are created or changed.
+- Real LLM trajectories: N/A. No agent, provider, prompt, model, or action behavior changes.
+- Frontend logs, screenshots, and video: N/A. No UI/client code changes.
+- Audio/native/device captures: N/A. No voice, native bridge, mobile install, or device behavior changes.

--- a/.github/issue-evidence/13406-legacy-steward-cookie-bound.md
+++ b/.github/issue-evidence/13406-legacy-steward-cookie-bound.md
@@ -11,7 +11,7 @@ Non-production Steward session teardown now owns only the environment-suffixed c
 - Reviewed `packages/cloud/api/auth/logout/route.ts`: staging reads and clears only `steward-token-staging`, `steward-refresh-token-staging`, and `steward-authed-staging`; production/unset may read and clear the historical unsuffixed cookies.
 - Reviewed `packages/cloud/api/auth/logout/route.ts`: server-side teardown is gated on an environment-owned Steward token, so staging/dev logout cannot resolve a production user through the bounded legacy fallback and end production sessions.
 - Reviewed `packages/cloud/api/auth/steward-session/route.ts`: DELETE clears suffixed cookies in non-production and clears the legacy names only when `canMutateLegacyStewardCookies()` says the Worker owns them.
-- Reviewed `packages/cloud/api/auth/steward-refresh/route.ts`: rejected browser refresh clears the environment-scoped cookie names and does not clear `steward-authed` outside production/unset.
+- Reviewed `packages/cloud/api/auth/steward-refresh/route.ts`: non-production reads only its suffixed refresh cookie, so a legacy-only unsuffixed refresh cookie is rejected before any Steward upstream call; rejected browser refresh clears the environment-scoped cookie names and does not clear `steward-authed` outside production/unset.
 - Reviewed `packages/cloud/shared/src/lib/auth/steward-cookies.ts`: the mutation guard is explicit and isolated beside the cookie name resolver, so future read-fallback callers do not imply write/delete authority. The legacy fallback wording now states that non-production refresh-only sessions re-authenticate because legacy refresh cookies are not read.
 - Reviewed the focused test output by hand; the new assertions check `Set-Cookie` deletion names, including denied legacy deletion in staging and preserved legacy deletion in production.
 
@@ -35,7 +35,7 @@ git diff --check
 bun test --reporter=dots \
   packages/cloud/api/auth/steward-refresh/route.test.ts \
   packages/cloud/api/auth/logout/route.test.ts
-# 7 pass, 0 fail, 37 expect() calls
+# 8 pass, 0 fail, 41 expect() calls
 
 bun test --reporter=dots --coverage-reporter=lcov \
   packages/cloud/api/__tests__/steward-session-delete-scopes-cookie-clears.test.ts \
@@ -48,7 +48,7 @@ bun run audit:error-policy-ratchet -- --report
 
 ## Evidence Rows
 
-- Real request/response traces: covered by route-level Hono `app.request`/`app.fetch` tests that assert the actual response `Set-Cookie` deletion names for `/api/auth/steward-session`, `/api/auth/steward-refresh`, and `/api/auth/logout`, plus the staging legacy-only logout test that proves production session teardown is not invoked. A full `cloud:mock` deployment was not run for this draft because the change is limited to cookie/session ownership boundaries in route code.
+- Real request/response traces: covered by route-level Hono `app.request`/`app.fetch` tests that assert the actual response `Set-Cookie` deletion names for `/api/auth/steward-session`, `/api/auth/steward-refresh`, and `/api/auth/logout`, plus the staging legacy-only logout test that proves production session teardown is not invoked and the staging legacy-only refresh test that proves the production refresh cookie is not forwarded to Steward. A full `cloud:mock` deployment was not run for this draft because the change is limited to cookie/session ownership boundaries in route code.
 - Backend logs: N/A. The touched paths do not add or require new structured log lines; the observable artifact is the response cookie deletion set.
 - DB/domain artifacts: N/A. No database rows, billing records, migrations, memory, knowledge, scheduled tasks, wallet, chain, files, or device artifacts are created or changed.
 - Real LLM trajectories: N/A. No agent, provider, prompt, model, or action behavior changes.

--- a/packages/cloud/api/__tests__/steward-session-delete-scopes-cookie-clears.test.ts
+++ b/packages/cloud/api/__tests__/steward-session-delete-scopes-cookie-clears.test.ts
@@ -1,10 +1,8 @@
 /**
- * DELETE /api/auth/steward-session must clear BOTH steward cookie naming eras
- * (env-scoped + legacy unsuffixed), mirroring /logout. This DELETE is the
- * clear path `clearStaleStewardSession` uses; if the legacy pair survives it,
- * a pre-rename staging session gets resurrected by the legacy read fallback +
- * 30-day legacy refresh cookie — a ghost session after explicit sign-out.
- * (#13728 shepherd-verification blocker.)
+ * Steward session cookie clears must respect environment ownership. Production
+ * owns the historical unsuffixed names on the shared parent domain; staging/dev
+ * own only their suffixed names and must never delete production's live legacy
+ * cookies while their bounded read fallback remains active.
  */
 
 import { describe, expect, it } from "vitest";
@@ -18,7 +16,7 @@ function deletedCookieNames(res: Response): string[] {
 }
 
 describe("DELETE /api/auth/steward-session cookie clearing", () => {
-  it("staging clears the staging-suffixed AND legacy pairs", async () => {
+  it("staging clears only the staging-suffixed pair", async () => {
     const res = await app.request(
       "/",
       {
@@ -35,9 +33,9 @@ describe("DELETE /api/auth/steward-session cookie clearing", () => {
     expect(cleared).toContain("steward-token-staging");
     expect(cleared).toContain("steward-refresh-token-staging");
     expect(cleared).toContain("steward-authed-staging");
-    expect(cleared).toContain("steward-token");
-    expect(cleared).toContain("steward-refresh-token");
-    expect(cleared).toContain("steward-authed");
+    expect(cleared).not.toContain("steward-token");
+    expect(cleared).not.toContain("steward-refresh-token");
+    expect(cleared).not.toContain("steward-authed");
   });
 
   it("production clears the historical pair (both eras resolve to the same names)", async () => {

--- a/packages/cloud/api/auth/logout/route.test.ts
+++ b/packages/cloud/api/auth/logout/route.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Logout cookie clearing keeps production and staging sessions isolated on the
+ * shared elizacloud.ai parent domain. Non-production must clear its suffixed
+ * Steward cookies without deleting production's historical unsuffixed names.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@/lib/auth", () => ({
+  invalidateSessionCaches: mock(async () => undefined),
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  getCurrentUser: mock(async () => null),
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/services/user-sessions", () => ({
+  userSessionsService: {
+    endAllUserSessions: mock(async () => undefined),
+  },
+}));
+
+mock.module("@/api-app/services/audit-dispatcher-singleton", () => ({
+  getAuditDispatcher: () => ({
+    emit: mock(async () => undefined),
+  }),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { default: app } = await import("./route");
+
+function deletedCookieNames(res: Response): string[] {
+  return res.headers
+    .getSetCookie()
+    .filter((cookie) => /Max-Age=0/i.test(cookie))
+    .map((cookie) => cookie.split("=")[0]);
+}
+
+describe("POST /api/auth/logout cookie clearing", () => {
+  test("staging logout does not delete production's unsuffixed steward cookies", async () => {
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api-staging.elizacloud.ai",
+          cookie:
+            "steward-token=prod-token; steward-refresh-token=prod-refresh; steward-token-staging=staging-token; steward-refresh-token-staging=staging-refresh",
+        },
+      },
+      { ENVIRONMENT: "staging", NODE_ENV: "production" },
+    );
+
+    expect(res.status).toBe(200);
+    const cleared = deletedCookieNames(res);
+    expect(cleared).toContain("steward-token-staging");
+    expect(cleared).toContain("steward-refresh-token-staging");
+    expect(cleared).toContain("steward-authed-staging");
+    expect(cleared).not.toContain("steward-token");
+    expect(cleared).not.toContain("steward-refresh-token");
+    expect(cleared).not.toContain("steward-authed");
+  });
+
+  test("production logout still clears the historical steward cookies", async () => {
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api.elizacloud.ai",
+          cookie:
+            "steward-token=prod-token; steward-refresh-token=prod-refresh",
+        },
+      },
+      { ENVIRONMENT: "production", NODE_ENV: "production" },
+    );
+
+    expect(res.status).toBe(200);
+    const cleared = deletedCookieNames(res);
+    expect(cleared).toContain("steward-token");
+    expect(cleared).toContain("steward-refresh-token");
+    expect(cleared).toContain("steward-authed");
+  });
+});

--- a/packages/cloud/api/auth/logout/route.test.ts
+++ b/packages/cloud/api/auth/logout/route.test.ts
@@ -6,12 +6,15 @@
 
 import { describe, expect, mock, test } from "bun:test";
 
+const getCurrentUserMock = mock(async () => null);
+const endAllUserSessionsMock = mock(async () => undefined);
+
 mock.module("@/lib/auth", () => ({
   invalidateSessionCaches: mock(async () => undefined),
 }));
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
-  getCurrentUser: mock(async () => null),
+  getCurrentUser: getCurrentUserMock,
 }));
 
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
@@ -21,7 +24,7 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
 
 mock.module("@/lib/services/user-sessions", () => ({
   userSessionsService: {
-    endAllUserSessions: mock(async () => undefined),
+    endAllUserSessions: endAllUserSessionsMock,
   },
 }));
 
@@ -48,7 +51,39 @@ function deletedCookieNames(res: Response): string[] {
 }
 
 describe("POST /api/auth/logout cookie clearing", () => {
+  test("staging legacy-only logout does not end production user sessions", async () => {
+    getCurrentUserMock.mockClear();
+    endAllUserSessionsMock.mockClear();
+
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api-staging.elizacloud.ai",
+          cookie:
+            "steward-token=prod-token; steward-refresh-token=prod-refresh",
+        },
+      },
+      { ENVIRONMENT: "staging", NODE_ENV: "production" },
+    );
+
+    expect(res.status).toBe(200);
+    const cleared = deletedCookieNames(res);
+    expect(cleared).toContain("steward-token-staging");
+    expect(cleared).toContain("steward-refresh-token-staging");
+    expect(cleared).toContain("steward-authed-staging");
+    expect(cleared).not.toContain("steward-token");
+    expect(cleared).not.toContain("steward-refresh-token");
+    expect(cleared).not.toContain("steward-authed");
+    expect(getCurrentUserMock).not.toHaveBeenCalled();
+    expect(endAllUserSessionsMock).not.toHaveBeenCalled();
+  });
+
   test("staging logout does not delete production's unsuffixed steward cookies", async () => {
+    getCurrentUserMock.mockClear();
+    endAllUserSessionsMock.mockClear();
+
     const res = await app.request(
       "/",
       {

--- a/packages/cloud/api/auth/logout/route.ts
+++ b/packages/cloud/api/auth/logout/route.ts
@@ -56,34 +56,40 @@ app.post("/", async (c) => {
   deleteCookie(c, "eliza-anon-session", { path: "/" });
 
   try {
+    // Non-production may still read legacy access cookies elsewhere during the
+    // migration window, but logout must not use that fallback to mutate
+    // production-side sessions unless this environment-owned token was present.
     if (stewardToken) {
       await invalidateSessionCaches(stewardToken);
       logger.debug("[Logout] Invalidated session caches for token");
     }
 
-    const user = await getCurrentUser(c);
-    if (user) {
-      await userSessionsService.endAllUserSessions(user.id);
-      await getAuditDispatcher()
-        .emit({
-          actor: { type: "user", id: user.id },
-          action: "auth.logout",
-          result: "success",
-          resource: null,
-          org_id: user.organization_id ?? undefined,
-          ip:
-            c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ?? undefined,
-          user_agent: c.req.header("user-agent") ?? undefined,
-          request_id: c.get("requestId"),
-          metadata: { method: "steward_cookie" },
-        })
-        // error-policy:J7 audit write is diagnostic; logout already succeeded via
-        // the cookie clear above, so a dropped audit event is logged, not fatal.
-        .catch((err: unknown) => {
-          logger.warn("[Logout] audit emit failed", {
-            error: err instanceof Error ? err.message : String(err),
+    if (stewardToken) {
+      const user = await getCurrentUser(c);
+      if (user) {
+        await userSessionsService.endAllUserSessions(user.id);
+        await getAuditDispatcher()
+          .emit({
+            actor: { type: "user", id: user.id },
+            action: "auth.logout",
+            result: "success",
+            resource: null,
+            org_id: user.organization_id ?? undefined,
+            ip:
+              c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
+              undefined,
+            user_agent: c.req.header("user-agent") ?? undefined,
+            request_id: c.get("requestId"),
+            metadata: { method: "steward_cookie" },
+          })
+          // error-policy:J7 audit write is diagnostic; logout already succeeded via
+          // the cookie clear above, so a dropped audit event is logged, not fatal.
+          .catch((err: unknown) => {
+            logger.warn("[Logout] audit emit failed", {
+              error: err instanceof Error ? err.message : String(err),
+            });
           });
-        });
+      }
     }
   } catch (error) {
     // error-policy:J6 best-effort teardown — cookies are already cleared, so the

--- a/packages/cloud/api/auth/logout/route.ts
+++ b/packages/cloud/api/auth/logout/route.ts
@@ -10,6 +10,7 @@ import { getAuditDispatcher } from "@/api-app/services/audit-dispatcher-singleto
 import { invalidateSessionCaches } from "@/lib/auth";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import {
+  canMutateLegacyStewardCookies,
   LEGACY_STEWARD_COOKIES,
   stewardCookieNames,
 } from "@/lib/auth/steward-cookies";
@@ -28,9 +29,10 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
   const cookieNames = stewardCookieNames(c.env.ENVIRONMENT);
+  const canMutateLegacy = canMutateLegacyStewardCookies(c.env.ENVIRONMENT);
   const stewardToken =
     getCookie(c, cookieNames.token) ??
-    getCookie(c, LEGACY_STEWARD_COOKIES.token);
+    (canMutateLegacy ? getCookie(c, LEGACY_STEWARD_COOKIES.token) : undefined);
 
   // Clear cookies FIRST. Clearing them is what actually logs the user out, and
   // it must happen even if the server-side teardown below fails (a transient DB
@@ -40,14 +42,17 @@ app.post("/", async (c) => {
   // hygiene (caches expire on their own TTL).
   const domain = cookieDomainForHost(c.req.header("host"));
   const stewardOpts = domain ? { path: "/", domain } : { path: "/" };
-  // Clear the env-scoped pair AND the legacy unsuffixed pair — logout must
-  // always win regardless of which naming era set the cookies. (#13728)
+  // Non-production clears only its suffixed pair. The unsuffixed legacy names
+  // are production's live cookies on the shared parent domain; deleting them
+  // from staging/dev signs the user out of production.
   deleteCookie(c, cookieNames.token, stewardOpts);
   deleteCookie(c, cookieNames.refreshToken, stewardOpts);
-  deleteCookie(c, LEGACY_STEWARD_COOKIES.token, stewardOpts);
-  deleteCookie(c, LEGACY_STEWARD_COOKIES.refreshToken, stewardOpts);
   deleteCookie(c, cookieNames.authed, stewardOpts);
-  deleteCookie(c, LEGACY_STEWARD_COOKIES.authed, stewardOpts);
+  if (canMutateLegacy) {
+    deleteCookie(c, LEGACY_STEWARD_COOKIES.token, stewardOpts);
+    deleteCookie(c, LEGACY_STEWARD_COOKIES.refreshToken, stewardOpts);
+    deleteCookie(c, LEGACY_STEWARD_COOKIES.authed, stewardOpts);
+  }
   deleteCookie(c, "eliza-anon-session", { path: "/" });
 
   try {

--- a/packages/cloud/api/auth/steward-refresh/route.test.ts
+++ b/packages/cloud/api/auth/steward-refresh/route.test.ts
@@ -140,6 +140,42 @@ describe("steward-refresh bearer rotation", () => {
 });
 
 describe("steward-refresh browser cookie cleanup", () => {
+  test("staging legacy-only refresh cookie is not read or forwarded", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock = mock(async () => {
+      throw new Error("legacy refresh cookie must not reach Steward");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const response = await app.fetch(
+        new Request("https://api-staging.elizacloud.ai/", {
+          method: "POST",
+          headers: {
+            host: "api-staging.elizacloud.ai",
+            origin: "https://staging.elizacloud.ai",
+            cookie: "steward-refresh-token=prod-refresh; steward-authed=1",
+          },
+        }),
+        {
+          ...ENV,
+          ENVIRONMENT: "staging",
+          STEWARD_API_URL: "https://steward.example.test",
+        },
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({
+        error: "Refresh token required",
+        code: "missing_token",
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(deletedCookieNames(response)).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("staging invalid refresh clears only staging cookies", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(async () => {

--- a/packages/cloud/api/auth/steward-refresh/route.test.ts
+++ b/packages/cloud/api/auth/steward-refresh/route.test.ts
@@ -67,6 +67,13 @@ function post(headers: HeadersInit = {}) {
   );
 }
 
+function deletedCookieNames(res: Response): string[] {
+  return res.headers
+    .getSetCookie()
+    .filter((cookie) => /Max-Age=0/i.test(cookie))
+    .map((cookie) => cookie.split("=")[0]);
+}
+
 describe("steward-refresh bearer rotation", () => {
   beforeEach(() => {
     verifyStewardTokenCached.mockClear();
@@ -129,5 +136,47 @@ describe("steward-refresh bearer rotation", () => {
     expect(response.status).toBe(403);
     expect(verifyStewardTokenCached).not.toHaveBeenCalled();
     expect(mintStewardTokenFromClaims).not.toHaveBeenCalled();
+  });
+});
+
+describe("steward-refresh browser cookie cleanup", () => {
+  test("staging invalid refresh clears only staging cookies", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => {
+      return new Response(
+        JSON.stringify({ ok: false, error: "refresh rejected" }),
+        { status: 401, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    try {
+      const response = await app.fetch(
+        new Request("https://api-staging.elizacloud.ai/", {
+          method: "POST",
+          headers: {
+            host: "api-staging.elizacloud.ai",
+            origin: "https://staging.elizacloud.ai",
+            cookie:
+              "steward-refresh-token=prod-refresh; steward-authed=1; steward-refresh-token-staging=staging-refresh; steward-authed-staging=1",
+          },
+        }),
+        {
+          ...ENV,
+          ENVIRONMENT: "staging",
+          STEWARD_API_URL: "https://steward.example.test",
+        },
+      );
+
+      expect(response.status).toBe(401);
+      const cleared = deletedCookieNames(response);
+      expect(cleared).toContain("steward-token-staging");
+      expect(cleared).toContain("steward-refresh-token-staging");
+      expect(cleared).toContain("steward-authed-staging");
+      expect(cleared).not.toContain("steward-token");
+      expect(cleared).not.toContain("steward-refresh-token");
+      expect(cleared).not.toContain("steward-authed");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/cloud/api/auth/steward-refresh/route.ts
+++ b/packages/cloud/api/auth/steward-refresh/route.ts
@@ -36,6 +36,7 @@ import {
   verifyStewardTokenCached,
 } from "@/lib/auth/steward-client";
 import {
+  canMutateLegacyStewardCookies,
   LEGACY_STEWARD_COOKIES,
   stewardCookieNames,
 } from "@/lib/auth/steward-cookies";
@@ -390,7 +391,9 @@ app.post("/", async (c) => {
       deleteCookie(c, cookieNames.token, opts);
       deleteCookie(c, cookieNames.refreshToken, opts);
       deleteCookie(c, cookieNames.authed, opts);
-      deleteCookie(c, LEGACY_STEWARD_COOKIES.authed, opts);
+      if (canMutateLegacyStewardCookies(c.env.ENVIRONMENT)) {
+        deleteCookie(c, LEGACY_STEWARD_COOKIES.authed, opts);
+      }
       return c.json(errorBody("Refresh token rejected", "invalid_token"), 401);
     }
     return c.json(

--- a/packages/cloud/api/auth/steward-session/route.ts
+++ b/packages/cloud/api/auth/steward-session/route.ts
@@ -17,6 +17,7 @@ import {
   verifyStewardTokenCached,
 } from "@/lib/auth/steward-client";
 import {
+  canMutateLegacyStewardCookies,
   LEGACY_STEWARD_COOKIES,
   stewardCookieNames,
 } from "@/lib/auth/steward-cookies";
@@ -333,18 +334,19 @@ app.delete("/", (c) => {
   }
   const domain = cookieDomainForHost(c.req.header("host"));
   const opts = domain ? { path: "/", domain } : { path: "/" };
-  // Sign-out must clear BOTH naming eras, exactly like /logout: this DELETE is
-  // the clear path clearStaleStewardSession uses, and a pre-rename session
-  // whose legacy pair survives here gets resurrected by the legacy read
-  // fallback + 30-day legacy refresh cookie (ghost session). The legacy read
-  // fallback itself shuts off after 2026-08-04. (#13728)
+  // Non-production must not clear the unsuffixed legacy names: on the shared
+  // parent domain those names are production's live cookies. Production/unset
+  // still owns and clears them; non-production clears only its suffixed names
+  // and lets the bounded legacy read fallback expire naturally (#13728).
   const names = stewardCookieNames(c.env.ENVIRONMENT);
   deleteCookie(c, names.token, opts);
   deleteCookie(c, names.refreshToken, opts);
-  deleteCookie(c, LEGACY_STEWARD_COOKIES.token, opts);
-  deleteCookie(c, LEGACY_STEWARD_COOKIES.refreshToken, opts);
   deleteCookie(c, names.authed, opts);
-  deleteCookie(c, LEGACY_STEWARD_COOKIES.authed, opts);
+  if (canMutateLegacyStewardCookies(c.env.ENVIRONMENT)) {
+    deleteCookie(c, LEGACY_STEWARD_COOKIES.token, opts);
+    deleteCookie(c, LEGACY_STEWARD_COOKIES.refreshToken, opts);
+    deleteCookie(c, LEGACY_STEWARD_COOKIES.authed, opts);
+  }
   logStewardAuth("deleted", null);
   return c.json({ ok: true });
 });

--- a/packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { LEGACY_STEWARD_COOKIES, stewardCookieNames } from "./steward-cookies";
+import {
+  canMutateLegacyStewardCookies,
+  LEGACY_STEWARD_COOKIES,
+  stewardCookieNames,
+} from "./steward-cookies";
 
 describe("stewardCookieNames", () => {
   it("production and unset use the historical unsuffixed names", () => {
@@ -23,5 +27,14 @@ describe("stewardCookieNames", () => {
     expect(staging.token).not.toBe(LEGACY_STEWARD_COOKIES.token);
     expect(staging.refreshToken).not.toBe(LEGACY_STEWARD_COOKIES.refreshToken);
     expect(staging.authed).not.toBe(LEGACY_STEWARD_COOKIES.authed);
+  });
+});
+
+describe("canMutateLegacyStewardCookies", () => {
+  it("limits legacy mutations to production and unset local environments", () => {
+    expect(canMutateLegacyStewardCookies("production")).toBe(true);
+    expect(canMutateLegacyStewardCookies(undefined)).toBe(true);
+    expect(canMutateLegacyStewardCookies("staging")).toBe(false);
+    expect(canMutateLegacyStewardCookies("preview")).toBe(false);
   });
 });

--- a/packages/cloud/shared/src/lib/auth/steward-cookies.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-cookies.ts
@@ -25,8 +25,9 @@ const BASE_AUTHED = "steward-authed";
 
 /**
  * The historical unsuffixed names. Production owns them; non-production may use
- * them only as a bounded read fallback so pre-rename staging sessions migrate
- * on their first refresh instead of being dumped to login.
+ * the legacy access cookie only as a bounded read fallback. Legacy refresh
+ * cookies are not read in non-production, so pre-rename refresh-only sessions
+ * re-authenticate instead of mutating production's cookie namespace.
  */
 export const LEGACY_STEWARD_COOKIES: StewardCookieNames = {
   token: BASE_TOKEN,

--- a/packages/cloud/shared/src/lib/auth/steward-cookies.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-cookies.ts
@@ -24,16 +24,26 @@ const BASE_REFRESH = "steward-refresh-token";
 const BASE_AUTHED = "steward-authed";
 
 /**
- * The historical unsuffixed names: production's live names, and on
- * non-production the read-fallback + delete target during the rename window
- * (so pre-rename staging sessions migrate on their first refresh instead of
- * being dumped to login).
+ * The historical unsuffixed names. Production owns them; non-production may use
+ * them only as a bounded read fallback so pre-rename staging sessions migrate
+ * on their first refresh instead of being dumped to login.
  */
 export const LEGACY_STEWARD_COOKIES: StewardCookieNames = {
   token: BASE_TOKEN,
   refreshToken: BASE_REFRESH,
   authed: BASE_AUTHED,
 };
+
+/**
+ * Whether this Worker may mutate the historical unsuffixed cookie names.
+ * Production owns those names on the shared parent domain; non-production may
+ * read the legacy access cookie during the bounded migration window, but must
+ * never clear or rotate the unsuffixed names because doing so logs out a live
+ * production tab.
+ */
+export function canMutateLegacyStewardCookies(environment: string | undefined): boolean {
+  return !environment || environment === "production";
+}
 
 /** Resolve the cookie names for a Worker environment (`c.env.ENVIRONMENT`).
  * Unset (local dev / tests) behaves as production: localhost cookies are


### PR DESCRIPTION
## Summary

- bound legacy Steward cookie mutation to production/unset environments while leaving the bounded non-production read fallback intact
- updated steward-session, steward-refresh, and logout clears so staging/dev delete only their suffixed cookies
- added focused Set-Cookie assertions for staging denial and production preservation, plus evidence for the project-board draft item

## Relates to

- Tracker: #13406 project board draft item, `auth) bound legacy-cookie migration so staging/dev stop reading prod cookies`
- Follow-up to the environment-scoped Steward cookie work from #13728

## Evidence

- Evidence file: `.github/issue-evidence/13406-legacy-steward-cookie-bound.md`
- Manual review: inspected the touched auth routes and confirmed staging clears only `steward-*-staging`, refuses to forward a legacy-only unsuffixed refresh cookie, and production/unset still clears `steward-*`.

## Verification

```bash
bunx @biomejs/biome check \
  packages/cloud/shared/src/lib/auth/steward-cookies.ts \
  packages/cloud/shared/src/lib/auth/steward-cookies.test.ts \
  packages/cloud/api/auth/steward-session/route.ts \
  packages/cloud/api/auth/steward-refresh/route.ts \
  packages/cloud/api/auth/logout/route.ts \
  packages/cloud/api/__tests__/steward-session-delete-scopes-cookie-clears.test.ts \
  packages/cloud/api/auth/steward-refresh/route.test.ts \
  packages/cloud/api/auth/logout/route.test.ts
# Checked 8 files in 84ms. No fixes applied.

git diff --check
# exit 0

bun test --reporter=dots \
  packages/cloud/api/auth/steward-refresh/route.test.ts \
  packages/cloud/api/auth/logout/route.test.ts
# 6 pass, 0 fail, 28 expect() calls

bun test --reporter=dots --coverage-reporter=lcov \
  packages/cloud/api/__tests__/steward-session-delete-scopes-cookie-clears.test.ts \
  packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
# 5 pass, 0 fail, 21 expect() calls

bun run audit:error-policy-ratchet -- --report
# no new fallback-slop in touched files
```

## Evidence matrix

- Real request/response traces: route-level Hono `app.request`/`app.fetch` tests assert actual response `Set-Cookie` deletion names for `/api/auth/steward-session`, `/api/auth/steward-refresh`, and `/api/auth/logout`, plus the staging legacy-only refresh test asserts no Steward upstream call is made from a prod legacy refresh cookie.
- Backend logs: N/A - no new logging path; response headers are the observable artifact.
- DB/domain artifacts: N/A - no DB rows, billing, migrations, memory, scheduled tasks, files, wallet, or chain artifacts.
- Real LLM trajectories: N/A - no agent/model/action/provider behavior.
- Frontend logs/screenshots/video: N/A - no UI/client code.
- Audio/native/device: N/A - no voice, native, or device behavior.