### PR TITLE
refactor(ui): shared bulk-select kit for console tables (#13916 part 2a)

### DIFF
--- a/packages/ui/src/cloud-ui/components/bulk/bulk-select.test.tsx
+++ b/packages/ui/src/cloud-ui/components/bulk/bulk-select.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+/**
+ * Shared bulk-select kit (#13916): bar renders only while rows are selected,
+ * wires clear/delete, and runBulkDelete partitions allSettled outcomes in
+ * input order without throwing.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { BulkSelectionBar, runBulkDelete } from "./bulk-select";
+
+const labels = {
+  selected: "2 selected",
+  clear: "Clear",
+  deleteSelected: "Delete selected",
+};
+
+describe("BulkSelectionBar", () => {
+  it("renders nothing at count 0", () => {
+    const { container } = render(
+      <BulkSelectionBar
+        count={0}
+        onClear={() => {}}
+        onDelete={() => {}}
+        labels={labels}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("wires clear and delete; delete honors disabled", () => {
+    const onClear = vi.fn();
+    const onDelete = vi.fn();
+    render(
+      <BulkSelectionBar
+        count={2}
+        onClear={onClear}
+        onDelete={onDelete}
+        deleteDisabled
+        labels={labels}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(onClear).toHaveBeenCalledTimes(1);
+    const del = screen.getByRole("button", { name: /Delete selected/ });
+    expect(del).toHaveProperty("disabled", true);
+  });
+});
+
+describe("runBulkDelete", () => {
+  it("partitions fulfilled/rejected in input order and surfaces the first error", async () => {
+    const boom = new Error("nope");
+    const outcome = await runBulkDelete(["a", "b", "c"], (id) =>
+      id === "b" ? Promise.reject(boom) : Promise.resolve(id),
+    );
+    expect(outcome.deleted).toEqual(["a", "c"]);
+    expect(outcome.failed).toEqual(["b"]);
+    expect(outcome.firstError).toBe(boom);
+  });
+
+  it("never throws even when every delete rejects", async () => {
+    const outcome = await runBulkDelete([1, 2], () =>
+      Promise.reject(new Error("all down")),
+    );
+    expect(outcome.deleted).toEqual([]);
+    expect(outcome.failed).toEqual([1, 2]);
+  });
+});

--- a/packages/ui/src/cloud-ui/components/bulk/bulk-select.test.tsx
+++ b/packages/ui/src/cloud-ui/components/bulk/bulk-select.test.tsx
@@ -66,4 +66,14 @@ describe("runBulkDelete", () => {
     expect(outcome.deleted).toEqual([]);
     expect(outcome.failed).toEqual([1, 2]);
   });
+
+  it("treats synchronous delete failures as rejected items", async () => {
+    const outcome = await runBulkDelete(["a", "b"], (id) => {
+      if (id === "b") throw new Error("sync down");
+      return Promise.resolve(id);
+    });
+    expect(outcome.deleted).toEqual(["a"]);
+    expect(outcome.failed).toEqual(["b"]);
+    expect(outcome.firstError).toBeInstanceOf(Error);
+  });
 });

--- a/packages/ui/src/cloud-ui/components/bulk/bulk-select.test.tsx
+++ b/packages/ui/src/cloud-ui/components/bulk/bulk-select.test.tsx
@@ -10,6 +10,10 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { BulkSelectionBar, runBulkDelete } from "./bulk-select";
 
+vi.mock("lucide-react", () => ({
+  Trash2: () => <span aria-hidden="true" data-testid="trash-icon" />,
+}));
+
 const labels = {
   selected: "2 selected",
   clear: "Clear",

--- a/packages/ui/src/cloud-ui/components/bulk/bulk-select.tsx
+++ b/packages/ui/src/cloud-ui/components/bulk/bulk-select.tsx
@@ -136,7 +136,9 @@ export async function runBulkDelete<T>(
   items: readonly T[],
   deleteOne: (item: T) => Promise<unknown>,
 ): Promise<BulkDeleteOutcome<T>> {
-  const results = await Promise.allSettled(items.map((it) => deleteOne(it)));
+  const results = await Promise.allSettled(
+    items.map((it) => Promise.resolve().then(() => deleteOne(it))),
+  );
   const deleted = items.filter((_, i) => results[i].status === "fulfilled");
   const failed = items.filter((_, i) => results[i].status === "rejected");
   const firstError = results.find(

--- a/packages/ui/src/cloud-ui/components/bulk/bulk-select.tsx
+++ b/packages/ui/src/cloud-ui/components/bulk/bulk-select.tsx
@@ -1,0 +1,146 @@
+/**
+ * Shared bulk-selection UI for console tables: the selection bar shown while
+ * rows are checked, the destructive confirm dialog, and the allSettled
+ * partition helper for multi-delete flows. Extracted from the byte-duplicated
+ * implementations in the Apps and Agents tables (#13916); copy is caller-
+ * supplied (each domain keeps its own i18n keys) and styling uses semantic
+ * theme tokens so both tables render correctly on light theme (#13755 class).
+ * Toasts and cache semantics stay at call sites — they differ meaningfully
+ * per domain (query-cache surgery vs tombstones) and are not chrome.
+ */
+
+import { Trash2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../../../components/ui/alert-dialog";
+import { Button } from "../../../components/ui/button";
+
+export interface BulkSelectionBarLabels {
+  selected: string;
+  clear: string;
+  deleteSelected: string;
+}
+
+/** The bar shown above a table while rows are selected; renders nothing at
+ * count 0 so callers can mount it unconditionally. */
+export function BulkSelectionBar({
+  count,
+  onClear,
+  onDelete,
+  deleteDisabled = false,
+  labels,
+}: {
+  count: number;
+  onClear: () => void;
+  onDelete: () => void;
+  deleteDisabled?: boolean;
+  labels: BulkSelectionBarLabels;
+}) {
+  if (count === 0) return null;
+  return (
+    <div className="mb-2 flex items-center justify-between gap-3 rounded-sm border border-border bg-surface px-3 py-2">
+      <span className="text-sm text-txt">{labels.selected}</span>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="ghost"
+          type="button"
+          onClick={onClear}
+          className="h-8 px-3 text-muted hover:text-txt"
+        >
+          {labels.clear}
+        </Button>
+        <Button
+          variant="ghost"
+          type="button"
+          disabled={deleteDisabled}
+          onClick={onDelete}
+          className="h-8 px-3 text-destructive hover:bg-destructive-subtle"
+        >
+          <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+          {labels.deleteSelected}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** Destructive confirm dialog for bulk deletes. Title/description arrive
+ * precomputed (singular/plural phrasing is domain copy, not chrome). */
+export function BulkDeleteDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  cancelLabel,
+  confirmLabel,
+  confirmDisabled = false,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: React.ReactNode;
+  description: React.ReactNode;
+  cancelLabel: string;
+  confirmLabel: React.ReactNode;
+  confirmDisabled?: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="bg-card border-border">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-txt-strong">
+            {title}
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-muted">
+            {description}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel className="border-border bg-transparent text-txt hover:bg-surface">
+            {cancelLabel}
+          </AlertDialogCancel>
+          <Button
+            variant="destructive"
+            type="button"
+            disabled={confirmDisabled}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export interface BulkDeleteOutcome<T> {
+  /** Inputs whose delete fulfilled, in input order. */
+  deleted: T[];
+  /** Inputs whose delete rejected, in input order. */
+  failed: T[];
+  /** The first rejection reason, for the caller's error toast. */
+  firstError: unknown;
+}
+
+/** Run one delete per item via Promise.allSettled and partition the outcome —
+ * the shared skeleton of every console bulk-delete flow. Never throws; the
+ * caller decides how failures surface (per-domain toasts + cache semantics). */
+export async function runBulkDelete<T>(
+  items: readonly T[],
+  deleteOne: (item: T) => Promise<unknown>,
+): Promise<BulkDeleteOutcome<T>> {
+  const results = await Promise.allSettled(items.map((it) => deleteOne(it)));
+  const deleted = items.filter((_, i) => results[i].status === "fulfilled");
+  const failed = items.filter((_, i) => results[i].status === "rejected");
+  const firstError = results.find(
+    (r): r is PromiseRejectedResult => r.status === "rejected",
+  )?.reason;
+  return { deleted, failed, firstError };
+}

--- a/packages/ui/src/cloud-ui/index.ts
+++ b/packages/ui/src/cloud-ui/index.ts
@@ -22,6 +22,13 @@ export {
 export * from "./components/auth/authorize-content";
 export * from "./components/auth/authorize-return";
 export * from "./components/brand";
+export {
+  BulkDeleteDialog,
+  type BulkDeleteOutcome,
+  BulkSelectionBar,
+  type BulkSelectionBarLabels,
+  runBulkDelete,
+} from "./components/bulk/bulk-select";
 export * from "./components/code";
 export * from "./components/connection-card";
 export {

--- a/packages/ui/src/cloud/applications/components/apps-table.tsx
+++ b/packages/ui/src/cloud/applications/components/apps-table.tsx
@@ -15,17 +15,12 @@ import { Trash2 } from "lucide-react";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { toast } from "sonner";
-import { AppsListView } from "../../../cloud-ui/components/data-list";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "../../../components/ui/alert-dialog";
+  BulkDeleteDialog,
+  BulkSelectionBar,
+  runBulkDelete,
+} from "../../../cloud-ui/components/bulk/bulk-select";
+import { AppsListView } from "../../../cloud-ui/components/data-list";
 import { Button } from "../../../components/ui/button";
 import { copyTextToClipboard } from "../../../utils/clipboard";
 import { useCloudT } from "../../shell/CloudI18nProvider";
@@ -70,11 +65,9 @@ export function AppsTable({ apps }: { apps: App[] }) {
     setDeletingIds(new Set(ids));
     setDeleteTargets(null);
     try {
-      const results = await Promise.allSettled(ids.map((id) => deleteApp(id)));
-      const deletedIds = ids.filter(
-        (_, i) => results[i].status === "fulfilled",
-      );
-      const failed = targets.filter((_, i) => results[i].status === "rejected");
+      const outcome = await runBulkDelete(targets, (app) => deleteApp(app.id));
+      const deletedIds = outcome.deleted.map((app) => app.id);
+      const failed = outcome.failed;
 
       if (deletedIds.length > 0) {
         // Drop deleted rows from the cache directly — see the file header for
@@ -98,9 +91,7 @@ export function AppsTable({ apps }: { apps: App[] }) {
       }
 
       if (failed.length > 0) {
-        const firstError = results.find(
-          (r): r is PromiseRejectedResult => r.status === "rejected",
-        )?.reason;
+        const firstError = outcome.firstError;
         toast.error(
           t("cloud.apps.toast.deleteSomeFailed", {
             count: failed.length,
@@ -130,40 +121,24 @@ export function AppsTable({ apps }: { apps: App[] }) {
 
   return (
     <>
-      {selectedIds.size > 0 && (
-        <div className="mb-2 flex items-center justify-between gap-3 rounded-sm border border-white/10 bg-white/5 px-3 py-2">
-          <span className="text-sm text-white">
-            {t("cloud.apps.selectedCount", {
-              count: selectedIds.size,
-              defaultValue: "{{count}} selected",
-            })}
-          </span>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              type="button"
-              onClick={() => setSelectedIds(new Set())}
-              className="h-8 px-3 text-white/62 hover:text-white"
-            >
-              {t("cloud.apps.clearSelection", { defaultValue: "Clear" })}
-            </Button>
-            <Button
-              variant="ghost"
-              type="button"
-              disabled={deletingIds.size > 0}
-              onClick={() =>
-                setDeleteTargets(apps.filter((app) => selectedIds.has(app.id)))
-              }
-              className="h-8 px-3 text-red-400 hover:bg-red-500/10 hover:text-red-300"
-            >
-              <Trash2 className="mr-1.5 h-3.5 w-3.5" />
-              {t("cloud.apps.deleteSelected", {
-                defaultValue: "Delete selected",
-              })}
-            </Button>
-          </div>
-        </div>
-      )}
+      <BulkSelectionBar
+        count={selectedIds.size}
+        onClear={() => setSelectedIds(new Set())}
+        onDelete={() =>
+          setDeleteTargets(apps.filter((app) => selectedIds.has(app.id)))
+        }
+        deleteDisabled={deletingIds.size > 0}
+        labels={{
+          selected: t("cloud.apps.selectedCount", {
+            count: selectedIds.size,
+            defaultValue: "{{count}} selected",
+          }),
+          clear: t("cloud.apps.clearSelection", { defaultValue: "Clear" }),
+          deleteSelected: t("cloud.apps.deleteSelected", {
+            defaultValue: "Delete selected",
+          }),
+        }}
+      />
 
       <AppsListView
         apps={apps}
@@ -186,53 +161,46 @@ export function AppsTable({ apps }: { apps: App[] }) {
         selectedIds={selectedIds}
       />
 
-      <AlertDialog
+      <BulkDeleteDialog
         open={deleteTargets !== null}
         onOpenChange={(open) => !open && setDeleteTargets(null)}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
+        title={
+          dialogCount > 1
+            ? t("cloud.apps.deleteDialog.titleMany", {
+                count: dialogCount,
+                defaultValue: "Delete {{count}} Apps",
+              })
+            : t("cloud.apps.deleteDialog.title", {
+                defaultValue: "Delete App",
+              })
+        }
+        description={
+          <>
+            {t("cloud.apps.deleteDialog.confirmPrefix", {
+              defaultValue: "Are you sure you want to delete",
+            })}{" "}
+            <span className="font-semibold text-txt-strong">
               {dialogCount > 1
-                ? t("cloud.apps.deleteDialog.titleMany", {
+                ? t("cloud.apps.deleteDialog.manyApps", {
                     count: dialogCount,
-                    defaultValue: "Delete {{count}} Apps",
+                    defaultValue: "{{count}} apps",
                   })
-                : t("cloud.apps.deleteDialog.title", {
-                    defaultValue: "Delete App",
-                  })}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {t("cloud.apps.deleteDialog.confirmPrefix", {
-                defaultValue: "Are you sure you want to delete",
-              })}{" "}
-              <span className="font-semibold text-white">
-                {dialogCount > 1
-                  ? t("cloud.apps.deleteDialog.manyApps", {
-                      count: dialogCount,
-                      defaultValue: "{{count}} apps",
-                    })
-                  : `"${deleteTargets?.[0]?.name}"`}
-              </span>
-              ?{" "}
-              {t("cloud.apps.deleteDialog.cannotBeUndone", {
-                defaultValue: "This action cannot be undone.",
-              })}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>
-              {t("cloud.apps.deleteDialog.cancel", { defaultValue: "Cancel" })}
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleConfirmDelete}
-              className="bg-red-600 hover:bg-red-700"
-            >
-              {t("cloud.apps.deleteDialog.delete", { defaultValue: "Delete" })}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+                : `"${deleteTargets?.[0]?.name}"`}
+            </span>
+            ?{" "}
+            {t("cloud.apps.deleteDialog.cannotBeUndone", {
+              defaultValue: "This action cannot be undone.",
+            })}
+          </>
+        }
+        cancelLabel={t("cloud.apps.deleteDialog.cancel", {
+          defaultValue: "Cancel",
+        })}
+        confirmLabel={t("cloud.apps.deleteDialog.delete", {
+          defaultValue: "Delete",
+        })}
+        onConfirm={handleConfirmDelete}
+      />
     </>
   );
 }

--- a/packages/ui/src/cloud/applications/components/apps-table.tsx
+++ b/packages/ui/src/cloud/applications/components/apps-table.tsx
@@ -11,7 +11,6 @@
  */
 
 import { useQueryClient } from "@tanstack/react-query";
-import { Trash2 } from "lucide-react";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { toast } from "sonner";
@@ -21,7 +20,6 @@ import {
   runBulkDelete,
 } from "../../../cloud-ui/components/bulk/bulk-select";
 import { AppsListView } from "../../../cloud-ui/components/data-list";
-import { Button } from "../../../components/ui/button";
 import { copyTextToClipboard } from "../../../utils/clipboard";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import { APPS_QUERY_KEY, type App, deleteApp } from "../lib/apps";

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -5,14 +5,6 @@
 "use client";
 
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
   Badge,
   BulkDeleteDialog,
   BulkSelectionBar,

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -14,12 +14,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   Badge,
+  BulkDeleteDialog,
+  BulkSelectionBar,
   DashboardDataList,
   DashboardDataListDesktop,
   DashboardDataListFilteredCount,
   DashboardDataListMobile,
   DataListEmptyState,
   Input,
+  runBulkDelete,
   Select,
   SelectContent,
   SelectItem,
@@ -655,15 +658,10 @@ export function ElizaAgentsTable({
     for (const id of ids) deletedIdsRef.current.add(id);
     setLocalSandboxes((prev) => prev.filter((sb) => !ids.includes(sb.id)));
     try {
-      const results = await Promise.allSettled(
-        ids.map((id) =>
-          api(`/api/v1/eliza/agents/${id}`, { method: "DELETE" }),
-        ),
+      const outcome = await runBulkDelete(ids, (id) =>
+        api(`/api/v1/eliza/agents/${id}`, { method: "DELETE" }),
       );
-      const failed: string[] = [];
-      ids.forEach((id, i) => {
-        if (results[i].status === "rejected") failed.push(id);
-      });
+      const failed = outcome.failed;
       if (failed.length > 0) {
         for (const id of failed) deletedIdsRef.current.delete(id);
         setLocalSandboxes((prev) => [
@@ -672,9 +670,7 @@ export function ElizaAgentsTable({
             .map((id) => rowById.get(id))
             .filter((sb): sb is ElizaAgentRow => Boolean(sb)),
         ]);
-        const firstError = results.find(
-          (r): r is PromiseRejectedResult => r.status === "rejected",
-        )?.reason;
+        const firstError = outcome.firstError;
         toast.error(
           t("cloud.elizaAgentsTable.deleteSomeFailed", {
             count: failed.length,
@@ -747,46 +743,30 @@ export function ElizaAgentsTable({
   return (
     <TooltipProvider>
       <DashboardDataList>
-        {selectedIds.size > 0 && (
-          <div className="flex items-center justify-between gap-3 rounded-sm border border-border bg-card px-3 py-2">
-            <span className="text-sm text-txt">
-              {t("cloud.elizaAgentsTable.selectedCount", {
-                count: selectedIds.size,
-                defaultValue: "{{count}} selected",
-              })}
-            </span>
-            <div className="flex items-center gap-2">
-              <Button
-                variant="ghost"
-                type="button"
-                onClick={() => setSelectedIds(new Set())}
-                className="h-8 px-3 text-muted hover:text-txt"
-              >
-                {t("cloud.elizaAgentsTable.clearSelection", {
-                  defaultValue: "Clear",
-                })}
-              </Button>
-              <Button
-                variant="ghost"
-                type="button"
-                disabled={isDeleting}
-                onClick={() =>
-                  setDeleteIds(
-                    [...selectedIds].filter((id) =>
-                      localSandboxes.some((sb) => sb.id === id),
-                    ),
-                  )
-                }
-                className="h-8 px-3 text-destructive hover:bg-destructive-subtle"
-              >
-                <Trash2 className="mr-1.5 h-3.5 w-3.5" />
-                {t("cloud.elizaAgentsTable.deleteSelected", {
-                  defaultValue: "Delete selected",
-                })}
-              </Button>
-            </div>
-          </div>
-        )}
+        <BulkSelectionBar
+          count={selectedIds.size}
+          onClear={() => setSelectedIds(new Set())}
+          onDelete={() =>
+            setDeleteIds(
+              [...selectedIds].filter((id) =>
+                localSandboxes.some((sb) => sb.id === id),
+              ),
+            )
+          }
+          deleteDisabled={isDeleting}
+          labels={{
+            selected: t("cloud.elizaAgentsTable.selectedCount", {
+              count: selectedIds.size,
+              defaultValue: "{{count}} selected",
+            }),
+            clear: t("cloud.elizaAgentsTable.clearSelection", {
+              defaultValue: "Clear",
+            }),
+            deleteSelected: t("cloud.elizaAgentsTable.deleteSelected", {
+              defaultValue: "Delete selected",
+            }),
+          }}
+        />
         {/* Search + filter + create */}
         <div className="flex flex-col sm:flex-row gap-3">
           <div className="relative flex-1">
@@ -1363,65 +1343,54 @@ export function ElizaAgentsTable({
       </DashboardDataList>
 
       {/* Delete confirmation — one dialog for the row action and the bulk bar */}
-      <AlertDialog
+      <BulkDeleteDialog
         open={deleteIds !== null}
         onOpenChange={() => setDeleteIds(null)}
-      >
-        <AlertDialogContent className="bg-card border-border">
-          <AlertDialogHeader>
-            <AlertDialogTitle className="text-txt-strong">
-              {(deleteIds?.length ?? 0) > 1
-                ? t("cloud.elizaAgentsTable.deleteAgentsTitle", {
-                    count: deleteIds?.length,
-                    defaultValue: "Delete {{count}} Agents",
-                  })
-                : t("cloud.elizaAgentsTable.deleteAgentTitle", {
-                    defaultValue: "Delete Agent",
-                  })}
-            </AlertDialogTitle>
-            <AlertDialogDescription className="text-muted">
-              {deleteTargetBusy
-                ? t("cloud.elizaAgentsTable.deleteBusyDesc", {
-                    defaultValue:
-                      "This agent is still provisioning. Wait for the job to finish before deleting.",
-                  })
-                : (deleteIds?.length ?? 0) > 1
-                  ? t("cloud.elizaAgentsTable.deleteManyDesc", {
-                      count: deleteIds?.length,
-                      defaultValue:
-                        "This will permanently delete {{count}} agents and stop their running containers.",
-                    })
-                  : t("cloud.elizaAgentsTable.deleteDesc", {
-                      defaultValue:
-                        "This will permanently delete the agent and stop any running container.",
-                    })}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel className="border-border bg-transparent text-txt-strong hover:bg-bg-hover">
-              {t("cloud.elizaAgentsTable.cancel", { defaultValue: "Cancel" })}
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() =>
-                deleteIds &&
-                deleteIds.length > 0 &&
-                !deleteTargetBusy &&
-                handleDelete(deleteIds)
-              }
-              disabled={isDeleting || deleteTargetBusy}
-              className="bg-destructive hover:bg-accent-hover text-accent-foreground disabled:opacity-50"
-            >
-              {isDeleting
-                ? t("cloud.elizaAgentsTable.deleting", {
-                    defaultValue: "Deleting…",
-                  })
-                : t("cloud.elizaAgentsTable.delete", {
-                    defaultValue: "Delete",
-                  })}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        title={
+          (deleteIds?.length ?? 0) > 1
+            ? t("cloud.elizaAgentsTable.deleteAgentsTitle", {
+                count: deleteIds?.length,
+                defaultValue: "Delete {{count}} Agents",
+              })
+            : t("cloud.elizaAgentsTable.deleteAgentTitle", {
+                defaultValue: "Delete Agent",
+              })
+        }
+        description={
+          deleteTargetBusy
+            ? t("cloud.elizaAgentsTable.deleteBusyDesc", {
+                defaultValue:
+                  "This agent is still provisioning. Wait for the job to finish before deleting.",
+              })
+            : (deleteIds?.length ?? 0) > 1
+              ? t("cloud.elizaAgentsTable.deleteManyDesc", {
+                  count: deleteIds?.length,
+                  defaultValue:
+                    "This will permanently delete {{count}} agents and stop their running containers.",
+                })
+              : t("cloud.elizaAgentsTable.deleteDesc", {
+                  defaultValue:
+                    "This will permanently delete the agent and stop any running container.",
+                })
+        }
+        cancelLabel={t("cloud.elizaAgentsTable.cancel", {
+          defaultValue: "Cancel",
+        })}
+        confirmLabel={
+          isDeleting
+            ? t("cloud.elizaAgentsTable.deleting", {
+                defaultValue: "Deleting…",
+              })
+            : t("cloud.elizaAgentsTable.delete", { defaultValue: "Delete" })
+        }
+        confirmDisabled={isDeleting || deleteTargetBusy}
+        onConfirm={() =>
+          deleteIds &&
+          deleteIds.length > 0 &&
+          !deleteTargetBusy &&
+          handleDelete(deleteIds)
+        }
+      />
     </TooltipProvider>
   );
 }


### PR DESCRIPTION
Part 2a of #13916: the Apps + Agents tables each carried byte-similar copies of the bulk-selection bar, the destructive confirm dialog, and the allSettled delete flow. Now one kit in cloud-ui:

- **`BulkSelectionBar`** — renders nothing at count 0; caller-supplied labels (domain i18n keys preserved verbatim).
- **`BulkDeleteDialog`** — chrome only; title/description/confirm arrive precomputed (singular/plural phrasing is domain copy). Supports the agents table's busy-gate via `confirmDisabled`.
- **`runBulkDelete<T>`** — allSettled + in-order partition + firstError; never throws. Toasts/cache semantics deliberately stay at call sites (query-cache surgery ≠ tombstone restore).

**Bonus fix:** the kit uses semantic tokens — the apps-table bar/dialog previously used raw `text-white`/`red-400` utilities (white-on-white on light theme, the #13755 class).

**Verification:** kit tests 4/4 · 33/33 across all touched console suites · typecheck 0 errors · biome clean. Remaining on #13916: part 2b (runAgentJob helper, row view-model, table split, surface catalog). [qa-agent]