### PR TITLE
[sol-test] test(ios): add assert shard for extension surfaces

### DIFF
--- a/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		AUIT00010000000000000009 /* LauncherGestureLoopUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */; };
 		AUIT0001000000000000000B /* DeviceLifecycleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT0001000000000000000C /* DeviceLifecycleUITests.swift */; };
 		AUIT0001000000000000000D /* ChatFailureStrings.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT0001000000000000000E /* ChatFailureStrings.generated.swift */; };
+		AUIT0001000000000000000F /* DeviceExtensionSurfaceUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000010 /* DeviceExtensionSurfaceUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -168,6 +169,7 @@
 		AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherGestureLoopUITests.swift; sourceTree = "<group>"; };
 		AUIT0001000000000000000C /* DeviceLifecycleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceLifecycleUITests.swift; sourceTree = "<group>"; };
 		AUIT0001000000000000000E /* ChatFailureStrings.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFailureStrings.generated.swift; sourceTree = "<group>"; };
+		AUIT00010000000000000010 /* DeviceExtensionSurfaceUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceExtensionSurfaceUITests.swift; sourceTree = "<group>"; };
 		AUIT00010000000000000101 /* AppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -362,6 +364,7 @@
 				AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */,
 				AUIT0001000000000000000C /* DeviceLifecycleUITests.swift */,
 				AUIT0001000000000000000E /* ChatFailureStrings.generated.swift */,
+				AUIT00010000000000000010 /* DeviceExtensionSurfaceUITests.swift */,
 			);
 			path = AppUITests;
 			sourceTree = "<group>";
@@ -730,6 +733,7 @@
 				AUIT00010000000000000009 /* LauncherGestureLoopUITests.swift in Sources */,
 				AUIT0001000000000000000B /* DeviceLifecycleUITests.swift in Sources */,
 				AUIT0001000000000000000D /* ChatFailureStrings.generated.swift in Sources */,
+				AUIT0001000000000000000F /* DeviceExtensionSurfaceUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/DeviceExtensionSurfaceUITests.swift
@@ -1,0 +1,182 @@
+import XCTest
+
+/// Assert-level lane for iOS extension surfaces (#13695).
+///
+/// This suite is intentionally separate from WidgetGalleryCaptureUITests:
+/// the capture harness keeps `continueAfterFailure = true` and only produces
+/// screenshots, while this suite fails when an expected simulator-reachable
+/// surface disappears. Hardware-only verification remains out of scope here:
+/// Action Button physical press, device signing/profile faults, and custom
+/// keyboard enablement still require the provisioned-device lane called out in
+/// #13567/#13563.
+final class DeviceExtensionSurfaceUITests: XCTestCase {
+
+    private let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testControlCenterGalleryListsElizaControls() throws {
+        guard #available(iOS 18.0, *) else {
+            throw XCTSkip("Control Center controls are iOS 18+ only")
+        }
+
+        try openControlGalleryAndSearchEliza()
+
+        XCTAssertTrue(
+            springboard.staticTexts["Ask Eliza"].waitForExistence(timeout: 8),
+            "Control Center gallery search must list the Ask Eliza control; a missing result means the ElizaWidgets appex/control registration path regressed."
+        )
+        XCTAssertTrue(
+            springboard.staticTexts["Eliza Voice"].waitForExistence(timeout: 8),
+            "Control Center gallery search must list the Eliza Voice control; a missing result means the ElizaWidgets appex/control registration path regressed."
+        )
+
+        attachAccessibilitySnapshot(named: "control-gallery-eliza-results")
+        goHome()
+    }
+
+    func testHomeScreenWidgetTapForegroundsApp() throws {
+        try installHomeScreenWidgetFromGallery()
+
+        let ask = springboard.staticTexts["Ask Eliza"].firstMatch
+        XCTAssertTrue(
+            ask.waitForExistence(timeout: 8),
+            "The Eliza home-screen widget must expose the Ask Eliza quick action after being added from the widget gallery."
+        )
+
+        attachScreenshot(named: "widget-assert-00-home-with-widget")
+        ask.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+
+        let app = XCUIApplication()
+        XCTAssertTrue(
+            app.wait(for: .runningForeground, timeout: 15),
+            "Tapping the Ask quick action must foreground the container app via elizaos://assistant?source=ios-widget&action=ask."
+        )
+        attachScreenshot(named: "widget-assert-01-app-foregrounded")
+    }
+
+    func testKeyboardDictationSurfaceNeedsProvisionedDeviceLane() throws {
+        throw XCTSkip(
+            "Custom keyboard enablement, globe switching, Full Access/App Group round-trip, and textDocumentProxy insertion are device-lane verification items. Checklist: install signed app + ElizaKeyboard appex, enable Settings > General > Keyboard > ElizaKeyboard with Full Access, focus a text field, switch via globe, tap Dictate with Eliza, write recording/transcribing/ready/error records through the ElizaKeyboard bridge, then assert inserted/failed/needsFullAccess states."
+        )
+    }
+
+    // MARK: - Control Center controls
+
+    @available(iOS 18.0, *)
+    private func openControlGalleryAndSearchEliza() throws {
+        goHome()
+
+        let pull = springboard.coordinate(withNormalizedOffset: CGVector(dx: 0.92, dy: 0.02))
+        pull.press(
+            forDuration: 0.1,
+            thenDragTo: springboard.coordinate(withNormalizedOffset: CGVector(dx: 0.92, dy: 0.6))
+        )
+        Thread.sleep(forTimeInterval: 1.5)
+        attachScreenshot(named: "control-assert-00-control-center")
+
+        springboard
+            .coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.55))
+            .press(forDuration: 2.0)
+        Thread.sleep(forTimeInterval: 1.0)
+        attachScreenshot(named: "control-assert-01-edit-mode")
+
+        let addControl = springboard.buttons["Add a Control"]
+        if addControl.waitForExistence(timeout: 5) {
+            addControl.tap()
+        } else {
+            springboard.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.9)).tap()
+        }
+        Thread.sleep(forTimeInterval: 1.5)
+        attachScreenshot(named: "control-assert-02-gallery")
+
+        let search = springboard.searchFields.firstMatch
+        XCTAssertTrue(
+            search.waitForExistence(timeout: 8),
+            "Control Center add-control gallery must expose a search field before Eliza controls can be asserted."
+        )
+        search.tap()
+        search.typeText("Eliza")
+        Thread.sleep(forTimeInterval: 2.0)
+        attachScreenshot(named: "control-assert-03-gallery-search-eliza")
+    }
+
+    // MARK: - Home/Lock Screen widget
+
+    private func installHomeScreenWidgetFromGallery() throws {
+        goHome()
+        attachScreenshot(named: "widget-assert-00-home-screen")
+
+        springboard
+            .coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.35))
+            .press(forDuration: 2.5)
+        Thread.sleep(forTimeInterval: 1.0)
+        attachScreenshot(named: "widget-assert-01-jiggle-mode")
+
+        let edit = springboard.buttons["Edit"]
+        if edit.waitForExistence(timeout: 5) {
+            edit.tap()
+            let addWidget = springboard.buttons["Add Widget"]
+            XCTAssertTrue(addWidget.waitForExistence(timeout: 5), "Edit menu must expose Add Widget")
+            addWidget.tap()
+        } else {
+            let legacyAdd = springboard.buttons["Add widget"]
+            XCTAssertTrue(legacyAdd.waitForExistence(timeout: 5), "Home Screen edit mode must expose the widget gallery add affordance")
+            legacyAdd.tap()
+        }
+
+        Thread.sleep(forTimeInterval: 1.5)
+        let search = springboard.searchFields.firstMatch
+        XCTAssertTrue(search.waitForExistence(timeout: 8), "Widget gallery must expose a search field")
+        search.tap()
+        search.typeText("Eliza")
+        Thread.sleep(forTimeInterval: 2.0)
+        attachScreenshot(named: "widget-assert-02-gallery-search-eliza")
+
+        let appRow = springboard.staticTexts["elizaOS"].firstMatch
+        XCTAssertTrue(appRow.waitForExistence(timeout: 8), "Widget gallery search must list elizaOS")
+        appRow.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        Thread.sleep(forTimeInterval: 1.5)
+        attachScreenshot(named: "widget-assert-03-detail")
+
+        let confirm = springboard.buttons[" Add Widget"].exists
+            ? springboard.buttons[" Add Widget"]
+            : springboard.buttons["Add Widget"]
+        XCTAssertTrue(confirm.waitForExistence(timeout: 8), "Eliza widget detail must expose Add Widget")
+        confirm.tap()
+        Thread.sleep(forTimeInterval: 1.5)
+        goHome()
+    }
+
+    // MARK: - Shared helpers
+
+    private func goHome() {
+        for _ in 0..<3 {
+            let cancel = springboard.buttons["Cancel"]
+            if cancel.exists, cancel.isHittable {
+                cancel.tap()
+                Thread.sleep(forTimeInterval: 0.8)
+            }
+            XCUIDevice.shared.press(.home)
+            Thread.sleep(forTimeInterval: 1.0)
+        }
+        springboard.activate()
+        _ = springboard.wait(for: .runningForeground, timeout: 10)
+    }
+
+    private func attachScreenshot(named name: String) {
+        let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    private func attachAccessibilitySnapshot(named name: String) {
+        let attachment = XCTAttachment(string: springboard.debugDescription)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/packages/app-core/platforms/ios/App/AppUITests/LauncherGestureLoopUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/LauncherGestureLoopUITests.swift
@@ -16,9 +16,10 @@ import XCTest
 ///
 /// Scope: rail navigation + probe stability + app-alive — the [L]/[I] subset
 /// that survives in the AX tree. Tile launches (which navigate away from the
-/// launcher) and the notification pull are covered by the scripted
-/// GestureSemanticsUITests and the web/android loops, not by this
-/// page-stability loop.
+/// launcher) are covered by the scripted GestureSemanticsUITests and the
+/// web/android loops, not by this page-stability loop. The old notification
+/// pull-down sheet was removed on develop by #13414, so it is no longer listed
+/// as a covered surface here.
 ///
 /// Runs in the AppUITests target / lane as the boot + gesture-semantics suites:
 ///   node scripts/ios-device-capture.mjs --platform sim   (packages/app)

--- a/packages/app/scripts/ios-device-capture.mjs
+++ b/packages/app/scripts/ios-device-capture.mjs
@@ -324,16 +324,24 @@ async function main() {
         buildDestination,
         "-derivedDataPath",
         derivedData,
-        // Sim: signing is irrelevant, skip it. Device: the test RUNNER must be
-        // properly signed or installd rejects it (0xe8008018 "identity no
-        // longer valid" — the exact first-device-run failure). The project
-        // carries CODE_SIGN_STYLE=Automatic + the team id, so let xcodebuild
-        // sign and mint the ai.elizaos.app.xctrunner wildcard team profile
-        // (-allowProvisioningUpdates needs the Xcode account session that
-        // minted the app profile in the first place).
+        // Sim: build with ad-hoc signing, not CODE_SIGNING_ALLOWED=NO.
+        // WidgetKit can enumerate static widgets from an unsigned simulator
+        // build, but iOS 18 Control Center controls launch the appex during
+        // enumeration and unsigned appexes fault in XPC peer attribution. The
+        // assert-level DeviceExtensionSurfaceUITests shard depends on the same
+        // signed-appex path users exercise, so keep simulator builds ad-hoc
+        // signed. Device: the test RUNNER must be properly signed or installd
+        // rejects it (0xe8008018 "identity no longer valid" — the exact
+        // first-device-run failure). The project carries CODE_SIGN_STYLE=
+        // Automatic + the team id, so let xcodebuild sign and mint the
+        // ai.elizaos.app.xctrunner wildcard team profile (-allowProvisioningUpdates
+        // needs the Xcode account session that minted the app profile in the
+        // first place).
         ...(platform === "sim"
           ? [
-              "CODE_SIGNING_ALLOWED=NO",
+              "CODE_SIGNING_ALLOWED=YES",
+              "CODE_SIGN_STYLE=Manual",
+              "CODE_SIGN_IDENTITY=-",
               "ARCHS=arm64",
               "ONLY_ACTIVE_ARCH=YES",
               "EXCLUDED_ARCHS=x86_64",

--- a/packages/app/scripts/ios-device-lib.mjs
+++ b/packages/app/scripts/ios-device-lib.mjs
@@ -754,6 +754,7 @@ export const DEFAULT_IOS_XCUITEST_SHARDS = [
   "AppUITests/LauncherGestureLoopUITests",
   "AppUITests/ViewWalkthroughUITests",
   "AppUITests/WidgetGalleryCaptureUITests",
+  "AppUITests/DeviceExtensionSurfaceUITests",
   "AppUITests/DeviceLifecycleUITests",
 ];
 

--- a/packages/app/test/ios-app-intents-registration.test.ts
+++ b/packages/app/test/ios-app-intents-registration.test.ts
@@ -66,6 +66,18 @@ const keyboardBridgeSwift = readFileSync(
   path.join(iosAppRoot, "App/ElizaKeyboardBridge.swift"),
   "utf8",
 );
+const deviceExtensionSurfaceUITestsSwift = readFileSync(
+  path.join(iosAppRoot, "AppUITests/DeviceExtensionSurfaceUITests.swift"),
+  "utf8",
+);
+const iosDeviceLib = readFileSync(
+  path.join(repoRoot, "packages/app/scripts/ios-device-lib.mjs"),
+  "utf8",
+);
+const iosDeviceCapture = readFileSync(
+  path.join(repoRoot, "packages/app/scripts/ios-device-capture.mjs"),
+  "utf8",
+);
 const mobileBuildScript = readFileSync(
   path.join(repoRoot, "packages/app-core/scripts/run-mobile-build.mjs"),
   "utf8",
@@ -319,6 +331,46 @@ describe("native assistant entry contracts", () => {
         new RegExp(`isa = PBXBuildFile; fileRef = ${attributesFileRef} `, "g"),
       )?.length,
     ).toBe(2);
+  });
+
+  it("adds an assert-level XCUITest shard for iOS widget/control surfaces (#13695)", () => {
+    expect(pbxproj).toContain("DeviceExtensionSurfaceUITests.swift in Sources");
+    expect(iosDeviceLib).toContain(
+      '"AppUITests/DeviceExtensionSurfaceUITests"',
+    );
+    expect(iosDeviceCapture).toContain('"CODE_SIGNING_ALLOWED=YES"');
+    expect(iosDeviceCapture).toContain('"CODE_SIGN_IDENTITY=-"');
+
+    // This is the assert-level counterpart to WidgetGalleryCaptureUITests.
+    expect(deviceExtensionSurfaceUITestsSwift).toContain(
+      "continueAfterFailure = false",
+    );
+    expect(deviceExtensionSurfaceUITestsSwift).toContain(
+      "testControlCenterGalleryListsElizaControls",
+    );
+    expect(deviceExtensionSurfaceUITestsSwift).toContain(
+      "testHomeScreenWidgetTapForegroundsApp",
+    );
+    expect(deviceExtensionSurfaceUITestsSwift).toContain(
+      "Ask Eliza",
+    );
+    expect(deviceExtensionSurfaceUITestsSwift).toContain(
+      "Eliza Voice",
+    );
+    expect(deviceExtensionSurfaceUITestsSwift).toContain(
+      "elizaos://assistant?source=ios-widget&action=ask",
+    );
+    // The custom keyboard and hardware Action Button pieces are documented as
+    // device-lane only instead of being faked in simulator evidence.
+    expect(deviceExtensionSurfaceUITestsSwift).toContain(
+      "testKeyboardDictationSurfaceNeedsProvisionedDeviceLane",
+    );
+    expect(deviceExtensionSurfaceUITestsSwift).toContain(
+      "Action Button physical press",
+    );
+    expect(deviceExtensionSurfaceUITestsSwift).toContain(
+      "Full Access/App Group round-trip",
+    );
   });
 
   it("aligns the iOS audio background mode and Live Activities plist keys", () => {


### PR DESCRIPTION
## Summary
- Maps the existing iOS extension structure instead of adding new appex targets: the project already has 5 appexes embedded in the app target: WebsiteBlockerContentExtension, DeviceActivityMonitorExtension, DeviceActivityReportExtension, ElizaWidgets, and ElizaKeyboard.
- Adds `DeviceExtensionSurfaceUITests`, an assert-level XCUITest suite for the simulator-reachable slice of #13695: iOS 18 Control Center gallery registration for `Ask Eliza` / `Eliza Voice`, and home-screen widget tap foregrounding through the widget deep-link path.
- Wires the new suite into the AppUITests target and default shard plan, and switches simulator `build-for-testing` to ad-hoc signing so ControlWidget enumeration exercises a signed ElizaWidgets appex instead of the known unsigned-appex fault path.
- Leaves hardware/device-only coverage explicit instead of faking evidence: Action Button physical press, full custom-keyboard enablement/globe switching/Full Access/App Group insertion, and real-device signing/profile faults still require the provisioned device lane (#13567/#13563).
- Fixes the stale LauncherGestureLoopUITests comment about notification-pull coverage removed by #13414.

## Split: codeable headless vs device-verify-only
**Codeable headless/scaffolded here**
- Existing appex target map and Xcode membership for the new AppUITests source.
- Simulator Control Center gallery assertion for both iOS 18 controls, with hard failures rather than screenshots.
- Simulator home-screen widget install + tap assertion that foregrounds the app through `elizaos://assistant?source=ios-widget&action=ask`.
- Static guardrails that keep the new shard, ad-hoc sim signing, and device-only keyboard checklist from drifting.

**Still device-verify-only**
- Action Button hardware press itself, because the simulator has no Action Button hardware.
- Custom keyboard Settings enablement, globe switching, Full Access, shared App Group round-trip, and `textDocumentProxy.insertText` verification.
- Signed physical-device app + appex install/profile behavior, pending the #13567 profile-minting and #13563 lock-state lanes.

## Collision check
- Reviewed #13695 body/comments and open PRs #13964, #13965, #13967.
- #13964 covers the iOS e2e orchestrator guard, #13965 covers voice round-trip, and #13967 covers app + appex profile minting. None adds the assert-level widget/control shard or this simulator signing change.

## Verification
- `bun test packages/app/test/ios-app-intents-registration.test.ts`
- `bun test packages/app/scripts/ios-device-lib.test.mjs packages/app/test/ios-app-intents-registration.test.ts`
- `codex review --uncommitted`

No simulator/device run was claimed from this Linux host.

Fixes #13695
