### PR TITLE
feat(#13567): ios:device:provision — mint iOS dev profiles via App Store Connect API

### DIFF
--- a/.github/issue-evidence/13567-ios-device-provision/README.md
+++ b/.github/issue-evidence/13567-ios-device-provision/README.md
@@ -1,0 +1,78 @@
+# Issue #13567 — iOS device lane: automate development-profile minting (App Store Connect API)
+
+## What this delivers (task 1 — the headline "development-profile minting")
+
+`packages/app/scripts/ios-device-provision.mjs` + `ios:device:provision` npm script.
+
+Given the ASC key triplet already used by `apple-store-release.yml`
+(`APP_STORE_API_KEY_ID` / `APP_STORE_API_ISSUER_ID` / `APP_STORE_API_KEY_P8`),
+it non-interactively — no Xcode account session:
+
+1. builds a short-lived **ES256** App Store Connect JWT from the `.p8` (raw
+   `ieee-p1363` r‖s signature, 20-min TTL, `aud: appstoreconnect-v1`);
+2. **registers** the device UDID (`GET`/`POST /v1/devices`) — idempotent;
+3. resolves a **DEVELOPMENT certificate** (`/v1/certificates`), failing fast if none;
+4. **ensures a bundle id** for the app + every appex (`GET`/`POST /v1/bundleIds`) — idempotent;
+5. **mints/refreshes a development profile** per bundle id
+   (`IOS_APP_DEVELOPMENT`; dev profiles are immutable, so a same-named one is
+   deleted + recreated with the current device + cert set);
+6. **downloads** each profile's base64 `profileContent` into
+   `~/Library/MobileDevice/Provisioning Profiles/<uuid>.mobileprovision` — exactly
+   where `ios-device-deploy.mjs` `discoverProfiles()` looks.
+
+Bundle ids come from `--bundle-id` flags or are discovered from
+`--product <App.app>/PlugIns/*.appex` (`CFBundleIdentifier` via `plutil`), so the
+5 appexes (widgets, DeviceActivity ×2, WebsiteBlocker, ElizaKeyboard) get
+profiles and `ios:device:deploy` no longer needs `--skip-appexes`.
+
+`--dry-run` proves the JWT + bundle-id resolution without mutating the ASC team.
+
+## Test evidence (real run on this host)
+
+The API flow, JWT, credential handling, and profile writing are pure functions
+with an injectable `fetchImpl`, unit-tested without real credentials or the
+network:
+
+```
+$ bunx vitest run packages/app/scripts/ios-device-provision.test.mjs
+ Test Files  1 passed (1)
+      Tests  17 passed (17)
+```
+
+Coverage: credential fail-fast (names every missing var; inline PEM vs .p8 path);
+**real ES256 JWT** — asserts the header/claims and that the signature *verifies*
+against the generated EC public key (`crypto.verify`, `ieee-p1363`); non-EC key
+rejected; ASC error bodies surfaced verbatim (fail fast, no swallow); device /
+bundle-id **idempotency** (existing → reused, no POST); profile **refresh**
+(GET → DELETE old → POST new) with the correct `IOS_APP_DEVELOPMENT` +
+device/cert relationships; base64 `profileContent` decoded to
+`<uuid>.mobileprovision`; appex `CFBundleIdentifier` discovery (de-duped); and
+the full `provision()` flow writing a profile per bundle id with the bearer JWT
+on every request.
+
+## Acceptance criteria mapping
+
+- ✅ "development-profile minting via the ASC API, no Xcode UI" — the script,
+  unit-verified above.
+- ⏳ Live acceptance ("with ASC creds set, `ios:device:provision --device <id>` +
+  `ios:device:deploy` (no `--skip-appexes`) installs the full app with all 5
+  appexes on a fresh device") — **needs real ASC credentials + a registered
+  physical device**, which this headless CI host lacks. That is the
+  Needs-agent-verify step (a device-equipped/credentialed runner).
+
+## Scoped follow-ons (from the issue, NOT in this PR)
+
+- Task 2: codify the runner **graft-signing** recipe as the default device path
+  in `ios-device-capture.mjs` (build with `CODE_SIGNING_ALLOWED=NO` → graft-sign
+  from a discovered wildcard/xctrunner profile) so the runner rebuilds without an
+  Xcode session — depends on a profile existing (this script) and needs device
+  verification.
+- Task 3: flip non-`--skip-appexes` back to the deploy default once appex
+  profiles mint on the lane.
+
+## N/A with reason
+
+- Live `ios:device:provision` run against the real ASC team + device
+  registration + on-device install — **N/A here**: no ASC credentials and no
+  physical iOS device on this host. Proven by the 17-test contract suite +
+  inspection; the live run is the device-lane verification step.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -86,6 +86,7 @@
     "install:ios:sideload": "node scripts/ios-sideload-helper.mjs",
     "install:ios:cloud:sideload": "node scripts/ios-sideload-helper.mjs --cloud --build-device",
     "ios:device:deploy": "node scripts/ios-device-deploy.mjs",
+    "ios:device:provision": "node scripts/ios-device-provision.mjs",
     "ios:device:logs": "node scripts/ios-device-logs.mjs",
     "ios:device:capture": "node scripts/ios-device-capture.mjs --platform device",
     "capture:ios-sim:boot": "node scripts/ios-device-capture.mjs --platform sim",

--- a/packages/app/scripts/ios-device-provision.mjs
+++ b/packages/app/scripts/ios-device-provision.mjs
@@ -1,0 +1,423 @@
+#!/usr/bin/env node
+/**
+ * ios:device:provision (#13567) — mint iOS **development** provisioning profiles
+ * for the app + every appex non-interactively via the App Store Connect API, so
+ * the physical-device test lane can install the full app (widgets, keyboard,
+ * DeviceActivity, WebsiteBlocker) and rebuild its XCUITest runner WITHOUT a
+ * signed-in Xcode account session.
+ *
+ * Today `ios:device:deploy` needs one development profile per appex
+ * (`ios-device-deploy.mjs` `discoverProfiles()` scans
+ * `~/Library/MobileDevice/Provisioning Profiles/`); only the main-app profile
+ * exists on the lane host, so #13174 added `--skip-appexes` as a stopgap and the
+ * appex surfaces are missing from every on-device install. The ASC API can
+ * register the device, create bundle ids, and mint development profiles
+ * non-interactively — the same `APP_STORE_API_KEY_ID` / `APP_STORE_API_ISSUER_ID`
+ * / `APP_STORE_API_KEY_P8` triplet `apple-store-release.yml` already uses for
+ * TestFlight. This script wires that path for the DEVELOPMENT test loop
+ * (#13118 covers DISTRIBUTION signing separately).
+ *
+ * Usage:
+ *   ios:device:provision --device <UDID> [--product <App.app>] \
+ *     [--bundle-id <id> ...] [--app-name <name>] [--dry-run]
+ *
+ * Bundle ids are resolved from (in precedence order): explicit `--bundle-id`
+ * flags, then the appexes discovered inside `--product <App.app>/PlugIns/*.appex`
+ * (their `CFBundleIdentifier`) plus the app itself. Idempotent — an already
+ * registered device / existing bundle id is reused; a same-named profile is
+ * refreshed (dev profiles are immutable, so it is deleted + recreated). Minted
+ * profiles are written into the profiles dir where `discoverProfiles()` looks.
+ *
+ * The API-flow, JWT construction, and credential handling are exported as pure
+ * functions with an injectable `fetchImpl` so the contract is unit-tested
+ * without real credentials or the network (`ios-device-provision.test.mjs`); the
+ * live run against real ASC creds + a device is the Needs-agent-verify step.
+ */
+
+import crypto from "node:crypto";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const ASC_API_BASE = "https://api.appstoreconnect.apple.com";
+export const ASC_AUDIENCE = "appstoreconnect-v1";
+export const JWT_TTL_SECONDS = 20 * 60; // ASC rejects tokens older than 20 min.
+export const REQUIRED_ENV = [
+  "APP_STORE_API_KEY_ID",
+  "APP_STORE_API_ISSUER_ID",
+  "APP_STORE_API_KEY_P8",
+];
+
+export function profilesDir() {
+  return path.join(
+    os.homedir(),
+    "Library",
+    "MobileDevice",
+    "Provisioning Profiles",
+  );
+}
+
+/**
+ * Resolve + validate the ASC API credentials from the environment. Fails fast
+ * naming every missing var (mirrors `apple-store-release.yml`), never falling
+ * back to a partial/unauthenticated state. `APP_STORE_API_KEY_P8` may be the
+ * inline PEM contents OR a path to the `.p8` file.
+ */
+export function resolveAscCredentials(env = process.env) {
+  const missing = REQUIRED_ENV.filter(
+    (k) => !env[k] || !String(env[k]).trim(),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing App Store Connect API credentials: ${missing.join(", ")}. ` +
+        "Set all three (same secrets as apple-store-release.yml). " +
+        "APP_STORE_API_KEY_P8 may be the .p8 contents or a path to the key file.",
+    );
+  }
+  let privateKeyPem = String(env.APP_STORE_API_KEY_P8);
+  if (!privateKeyPem.includes("BEGIN") && fs.existsSync(privateKeyPem)) {
+    privateKeyPem = fs.readFileSync(privateKeyPem, "utf8");
+  }
+  return {
+    keyId: String(env.APP_STORE_API_KEY_ID).trim(),
+    issuerId: String(env.APP_STORE_API_ISSUER_ID).trim(),
+    privateKeyPem,
+  };
+}
+
+const base64url = (input) => Buffer.from(input).toString("base64url");
+
+/**
+ * Build a short-lived ES256 App Store Connect JWT from the P8 key. `now`
+ * (unix seconds) is injectable so the token is deterministic under test.
+ */
+export function createAscJwt(
+  { keyId, issuerId, privateKeyPem },
+  now = Math.floor(Date.now() / 1000),
+) {
+  const header = { alg: "ES256", kid: keyId, typ: "JWT" };
+  const payload = {
+    iss: issuerId,
+    iat: now,
+    exp: now + JWT_TTL_SECONDS,
+    aud: ASC_AUDIENCE,
+  };
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(
+    JSON.stringify(payload),
+  )}`;
+  let key;
+  try {
+    key = crypto.createPrivateKey(privateKeyPem);
+  } catch (err) {
+    throw new Error(
+      `APP_STORE_API_KEY_P8 is not a valid private key: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  if (key.asymmetricKeyType !== "ec") {
+    throw new Error(
+      "APP_STORE_API_KEY_P8 must be an EC (P-256) App Store Connect key.",
+    );
+  }
+  // `ieee-p1363` yields the raw r||s signature ES256 (JWS) requires, not DER.
+  const signature = crypto.sign("sha256", Buffer.from(signingInput), {
+    key,
+    dsaEncoding: "ieee-p1363",
+  });
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+/**
+ * A minimal ASC API client bound to a JWT. `fetchImpl` is injectable for tests.
+ * Surfaces API errors verbatim (fail fast) rather than swallowing them.
+ */
+export function makeAscClient({ jwt, fetchImpl = fetch, base = ASC_API_BASE }) {
+  return async function asc(method, endpoint, body) {
+    const res = await fetchImpl(`${base}${endpoint}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        "Content-Type": "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const text = await res.text();
+    const json = text ? JSON.parse(text) : {};
+    if (!res.ok) {
+      const detail =
+        (json.errors || [])
+          .map((e) => e.detail || e.title || e.code)
+          .filter(Boolean)
+          .join("; ") || text || `HTTP ${res.status}`;
+      throw new Error(`ASC ${method} ${endpoint} → ${res.status}: ${detail}`);
+    }
+    return json;
+  };
+}
+
+/** Ensure the device UDID is registered; reuse it if already present. */
+export async function ensureDeviceRegistered(
+  asc,
+  { udid, name = "eliza-device-lane", platform = "IOS" },
+) {
+  const existing = await asc(
+    "GET",
+    `/v1/devices?filter[udid]=${encodeURIComponent(udid)}&limit=1`,
+  );
+  if (existing.data && existing.data.length > 0) {
+    return { id: existing.data[0].id, created: false };
+  }
+  const created = await asc("POST", "/v1/devices", {
+    data: { type: "devices", attributes: { name, platform, udid } },
+  });
+  return { id: created.data.id, created: true };
+}
+
+/**
+ * Pick a usable DEVELOPMENT certificate id — a development profile must
+ * reference at least one. Throws with actionable guidance if none exists.
+ */
+export async function getDevelopmentCertificateIds(asc) {
+  const certs = await asc(
+    "GET",
+    "/v1/certificates?filter[certificateType]=DEVELOPMENT&limit=200",
+  );
+  const ids = (certs.data || []).map((c) => c.id);
+  if (ids.length === 0) {
+    throw new Error(
+      "No DEVELOPMENT certificate found on the App Store Connect team. " +
+        "Create an Apple Development certificate (Xcode > Settings > Accounts, " +
+        "or the ASC API) before minting development profiles.",
+    );
+  }
+  return ids;
+}
+
+/** Ensure a bundle id exists; reuse it if already present. */
+export async function ensureBundleId(
+  asc,
+  { identifier, name, platform = "IOS" },
+) {
+  const existing = await asc(
+    "GET",
+    `/v1/bundleIds?filter[identifier]=${encodeURIComponent(identifier)}&limit=1`,
+  );
+  if (existing.data && existing.data.length > 0) {
+    return { id: existing.data[0].id, created: false };
+  }
+  const created = await asc("POST", "/v1/bundleIds", {
+    data: {
+      type: "bundleIds",
+      attributes: { identifier, name: name || identifier, platform },
+    },
+  });
+  return { id: created.data.id, created: true };
+}
+
+/**
+ * Mint (or refresh) a development profile for a bundle id. Development profiles
+ * are immutable, so a same-named profile is deleted and recreated with the
+ * current device + certificate set.
+ */
+export async function mintDevelopmentProfile(
+  asc,
+  { name, bundleIdRef, deviceIds, certificateIds },
+) {
+  const existing = await asc(
+    "GET",
+    `/v1/profiles?filter[name]=${encodeURIComponent(name)}&limit=1`,
+  );
+  if (existing.data && existing.data.length > 0) {
+    await asc("DELETE", `/v1/profiles/${existing.data[0].id}`);
+  }
+  const created = await asc("POST", "/v1/profiles", {
+    data: {
+      type: "profiles",
+      attributes: { name, profileType: "IOS_APP_DEVELOPMENT" },
+      relationships: {
+        bundleId: { data: { type: "bundleIds", id: bundleIdRef } },
+        devices: {
+          data: deviceIds.map((id) => ({ type: "devices", id })),
+        },
+        certificates: {
+          data: certificateIds.map((id) => ({ type: "certificates", id })),
+        },
+      },
+    },
+  });
+  return created.data;
+}
+
+/**
+ * Write a minted profile's base64 `profileContent` into `dir` as
+ * `<uuid>.mobileprovision` (the shape `discoverProfiles()` reads). Returns the
+ * written path.
+ */
+export function writeProfile(profileData, dir = profilesDir()) {
+  const content = profileData?.attributes?.profileContent;
+  if (!content) {
+    throw new Error(
+      `Minted profile ${
+        profileData?.attributes?.name || profileData?.id || "?"
+      } returned no profileContent.`,
+    );
+  }
+  fs.mkdirSync(dir, { recursive: true });
+  const stem = profileData.attributes?.uuid || profileData.id;
+  const file = path.join(dir, `${stem}.mobileprovision`);
+  fs.writeFileSync(file, Buffer.from(content, "base64"));
+  return file;
+}
+
+/**
+ * Discover the app + appex bundle ids from a built `App.app` product by reading
+ * each `CFBundleIdentifier` (`plutil`, macOS). `runPlutil` is injectable for
+ * tests; the default shells out to `plutil`.
+ */
+export function discoverAppBundleIds(productAppDir, { runPlutil } = {}) {
+  const read =
+    runPlutil ||
+    ((plistPath) =>
+      execFileSync(
+        "plutil",
+        ["-extract", "CFBundleIdentifier", "raw", "-o", "-", plistPath],
+        { encoding: "utf8" },
+      ).trim());
+  const out = [];
+  const appPlist = path.join(productAppDir, "Info.plist");
+  if (fs.existsSync(appPlist)) {
+    out.push({ identifier: read(appPlist), name: "App" });
+  }
+  const plugIns = path.join(productAppDir, "PlugIns");
+  if (fs.existsSync(plugIns)) {
+    for (const appex of fs.readdirSync(plugIns)) {
+      if (!appex.endsWith(".appex")) continue;
+      const plist = path.join(plugIns, appex, "Info.plist");
+      if (fs.existsSync(plist)) {
+        out.push({ identifier: read(plist), name: appex.replace(/\.appex$/, "") });
+      }
+    }
+  }
+  // De-dup by identifier, first-wins.
+  const seen = new Set();
+  return out.filter((b) => {
+    if (!b.identifier || seen.has(b.identifier)) return false;
+    seen.add(b.identifier);
+    return true;
+  });
+}
+
+/**
+ * Full provisioning flow. Idempotent. Returns a per-bundle-id result table.
+ * `fetchImpl`, `dir`, and `now` are injectable for tests.
+ */
+export async function provision({
+  creds,
+  udid,
+  bundleIds,
+  deviceName,
+  fetchImpl = fetch,
+  dir = profilesDir(),
+  now,
+}) {
+  if (!udid) throw new Error("provision: a device UDID is required.");
+  if (!bundleIds || bundleIds.length === 0) {
+    throw new Error(
+      "provision: no bundle ids resolved (pass --bundle-id or --product with appexes).",
+    );
+  }
+  const jwt = createAscJwt(creds, now);
+  const asc = makeAscClient({ jwt, fetchImpl });
+  const device = await ensureDeviceRegistered(asc, { udid, name: deviceName });
+  const certificateIds = await getDevelopmentCertificateIds(asc);
+  const results = [];
+  for (const bid of bundleIds) {
+    const bundle = await ensureBundleId(asc, {
+      identifier: bid.identifier,
+      name: bid.name,
+    });
+    const profileName = `Eliza Dev - ${bid.identifier}`;
+    const profile = await mintDevelopmentProfile(asc, {
+      name: profileName,
+      bundleIdRef: bundle.id,
+      deviceIds: [device.id],
+      certificateIds,
+    });
+    const file = writeProfile(profile, dir);
+    results.push({
+      identifier: bid.identifier,
+      bundleCreated: bundle.created,
+      profile: profile.attributes?.name || profileName,
+      file,
+    });
+  }
+  return { device, certificateIds, results };
+}
+
+function parseArgs(argv) {
+  const args = { bundleIds: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--device") args.udid = argv[++i];
+    else if (a === "--product") args.product = argv[++i];
+    else if (a === "--app-name") args.deviceName = argv[++i];
+    else if (a === "--bundle-id") args.bundleIds.push(argv[++i]);
+    else if (a === "--dry-run") args.dryRun = true;
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.udid) {
+    console.error(
+      "ios:device:provision --device <UDID> [--product <App.app>] [--bundle-id <id> ...]",
+    );
+    process.exit(2);
+  }
+  const creds = resolveAscCredentials();
+  let bundleIds = args.bundleIds.map((identifier) => ({ identifier }));
+  if (bundleIds.length === 0 && args.product) {
+    bundleIds = discoverAppBundleIds(args.product);
+  }
+  if (args.dryRun) {
+    // Prove the JWT + resolution without mutating the ASC team.
+    createAscJwt(creds);
+    console.log(
+      `[provision] dry-run — device ${args.udid}, ${bundleIds.length} bundle id(s):`,
+    );
+    for (const b of bundleIds) console.log(`  - ${b.identifier}`);
+    return;
+  }
+  const { device, results } = await provision({
+    creds,
+    udid: args.udid,
+    bundleIds,
+    deviceName: args.deviceName,
+  });
+  console.log(
+    `[provision] device ${args.udid} → id ${device.id} (${
+      device.created ? "registered" : "already registered"
+    })`,
+  );
+  console.log("[provision] bundle id                         profile → file");
+  for (const r of results) {
+    console.log(
+      `  ${r.identifier.padEnd(38)} ${r.bundleCreated ? "(new bundle) " : ""}${r.file}`,
+    );
+  }
+  console.log(`[provision] ${results.length} development profile(s) written.`);
+}
+
+// Only run when invoked directly, not when imported by the test.
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)
+) {
+  main().catch((err) => {
+    console.error(`[provision] ${err instanceof Error ? err.message : err}`);
+    process.exit(1);
+  });
+}

--- a/packages/app/scripts/ios-device-provision.test.mjs
+++ b/packages/app/scripts/ios-device-provision.test.mjs
@@ -1,0 +1,326 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createAscJwt,
+  discoverAppBundleIds,
+  ensureBundleId,
+  ensureDeviceRegistered,
+  makeAscClient,
+  mintDevelopmentProfile,
+  provision,
+  resolveAscCredentials,
+  writeProfile,
+} from "./ios-device-provision.mjs";
+
+// A P-256 key generated once for the JWT tests (PKCS8 PEM, same shape as a .p8).
+const { privateKey, publicKey } = crypto.generateKeyPairSync("ec", {
+  namedCurve: "P-256",
+});
+const P8 = privateKey.export({ type: "pkcs8", format: "pem" });
+
+const b64urlJson = (seg) =>
+  JSON.parse(Buffer.from(seg, "base64url").toString("utf8"));
+
+/**
+ * A recording fetch double that routes by `METHOD /path` (query stripped) and
+ * returns a Response-like object. `routes[key]` is `{ status?, body }` or a
+ * function `(method, url, body) => {status?, body}`.
+ */
+function mockFetch(routes) {
+  const calls = [];
+  const impl = async (url, init = {}) => {
+    const method = init.method || "GET";
+    const u = new URL(url);
+    const key = `${method} ${u.pathname}`;
+    calls.push({
+      method,
+      path: u.pathname,
+      query: u.search,
+      body: init.body ? JSON.parse(init.body) : undefined,
+      auth: init.headers?.Authorization,
+    });
+    let route = routes[key];
+    if (typeof route === "function") {
+      route = route(method, u, init.body ? JSON.parse(init.body) : undefined);
+    }
+    if (!route) {
+      return { ok: false, status: 404, text: async () => JSON.stringify({ errors: [{ detail: `no route ${key}` }] }) };
+    }
+    const status = route.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => JSON.stringify(route.body ?? {}),
+    };
+  };
+  impl.calls = calls;
+  return impl;
+}
+
+const tmpDirs = [];
+function tmpDir() {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), "ios-prov-"));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+describe("resolveAscCredentials", () => {
+  it("throws naming every missing credential", () => {
+    expect(() => resolveAscCredentials({})).toThrow(
+      /APP_STORE_API_KEY_ID.*APP_STORE_API_ISSUER_ID.*APP_STORE_API_KEY_P8/s,
+    );
+  });
+
+  it("names only the missing one", () => {
+    expect(() =>
+      resolveAscCredentials({
+        APP_STORE_API_KEY_ID: "k",
+        APP_STORE_API_ISSUER_ID: "i",
+        APP_STORE_API_KEY_P8: "   ",
+      }),
+    ).toThrow(/Missing.*APP_STORE_API_KEY_P8/s);
+  });
+
+  it("accepts inline PEM and trims id/issuer", () => {
+    const creds = resolveAscCredentials({
+      APP_STORE_API_KEY_ID: " KID ",
+      APP_STORE_API_ISSUER_ID: " ISS ",
+      APP_STORE_API_KEY_P8: P8,
+    });
+    expect(creds).toMatchObject({ keyId: "KID", issuerId: "ISS" });
+    expect(creds.privateKeyPem).toContain("BEGIN");
+  });
+
+  it("reads the P8 from a file path when it is not inline PEM", () => {
+    const dir = tmpDir();
+    const keyFile = path.join(dir, "AuthKey_KID.p8");
+    fs.writeFileSync(keyFile, P8);
+    const creds = resolveAscCredentials({
+      APP_STORE_API_KEY_ID: "KID",
+      APP_STORE_API_ISSUER_ID: "ISS",
+      APP_STORE_API_KEY_P8: keyFile,
+    });
+    expect(creds.privateKeyPem).toContain("BEGIN");
+  });
+});
+
+describe("createAscJwt", () => {
+  it("builds a valid ES256 token with the ASC claims and a verifiable signature", () => {
+    const now = 1_700_000_000;
+    const jwt = createAscJwt(
+      { keyId: "KID", issuerId: "ISS", privateKeyPem: P8 },
+      now,
+    );
+    const [h, p, s] = jwt.split(".");
+    expect(b64urlJson(h)).toEqual({ alg: "ES256", kid: "KID", typ: "JWT" });
+    expect(b64urlJson(p)).toEqual({
+      iss: "ISS",
+      iat: now,
+      exp: now + 20 * 60,
+      aud: "appstoreconnect-v1",
+    });
+    // The signature must verify against the public key (raw r||s / ieee-p1363).
+    const ok = crypto.verify(
+      "sha256",
+      Buffer.from(`${h}.${p}`),
+      { key: publicKey, dsaEncoding: "ieee-p1363" },
+      Buffer.from(s, "base64url"),
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("rejects a non-EC key", () => {
+    const rsa = crypto
+      .generateKeyPairSync("rsa", { modulusLength: 2048 })
+      .privateKey.export({ type: "pkcs8", format: "pem" });
+    expect(() =>
+      createAscJwt({ keyId: "K", issuerId: "I", privateKeyPem: rsa }),
+    ).toThrow(/EC \(P-256\)/);
+  });
+});
+
+describe("makeAscClient", () => {
+  it("surfaces ASC error bodies verbatim (fail fast, no swallow)", async () => {
+    const fetchImpl = mockFetch({
+      "GET /v1/devices": { status: 409, body: { errors: [{ detail: "boom" }] } },
+    });
+    const asc = makeAscClient({ jwt: "t", fetchImpl });
+    await expect(asc("GET", "/v1/devices")).rejects.toThrow(/409: boom/);
+  });
+});
+
+describe("ensureDeviceRegistered / ensureBundleId — idempotent", () => {
+  it("reuses an existing device and does NOT POST", async () => {
+    const fetchImpl = mockFetch({
+      "GET /v1/devices": { body: { data: [{ id: "DEV1" }] } },
+    });
+    const asc = makeAscClient({ jwt: "t", fetchImpl });
+    const r = await ensureDeviceRegistered(asc, { udid: "UDID" });
+    expect(r).toEqual({ id: "DEV1", created: false });
+    expect(fetchImpl.calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("registers the device when absent", async () => {
+    const fetchImpl = mockFetch({
+      "GET /v1/devices": { body: { data: [] } },
+      "POST /v1/devices": { status: 201, body: { data: { id: "DEV2" } } },
+    });
+    const asc = makeAscClient({ jwt: "t", fetchImpl });
+    const r = await ensureDeviceRegistered(asc, { udid: "UDID", name: "lane" });
+    expect(r).toEqual({ id: "DEV2", created: true });
+    const post = fetchImpl.calls.find((c) => c.method === "POST");
+    expect(post.body.data.attributes).toMatchObject({ udid: "UDID", name: "lane" });
+  });
+
+  it("reuses an existing bundle id", async () => {
+    const fetchImpl = mockFetch({
+      "GET /v1/bundleIds": { body: { data: [{ id: "B1" }] } },
+    });
+    const asc = makeAscClient({ jwt: "t", fetchImpl });
+    const r = await ensureBundleId(asc, { identifier: "ai.elizaos.app" });
+    expect(r).toEqual({ id: "B1", created: false });
+  });
+});
+
+describe("mintDevelopmentProfile", () => {
+  it("deletes a same-named profile then recreates it", async () => {
+    const fetchImpl = mockFetch({
+      "GET /v1/profiles": { body: { data: [{ id: "OLD" }] } },
+      "DELETE /v1/profiles/OLD": { body: {} },
+      "POST /v1/profiles": {
+        status: 201,
+        body: { data: { id: "NEW", attributes: { name: "n", uuid: "U", profileContent: "AA==" } } },
+      },
+    });
+    const asc = makeAscClient({ jwt: "t", fetchImpl });
+    const p = await mintDevelopmentProfile(asc, {
+      name: "n",
+      bundleIdRef: "B1",
+      deviceIds: ["DEV1"],
+      certificateIds: ["C1"],
+    });
+    expect(p.id).toBe("NEW");
+    expect(fetchImpl.calls.map((c) => `${c.method} ${c.path}`)).toEqual([
+      "GET /v1/profiles",
+      "DELETE /v1/profiles/OLD",
+      "POST /v1/profiles",
+    ]);
+    const post = fetchImpl.calls.find((c) => c.method === "POST");
+    expect(post.body.data.attributes.profileType).toBe("IOS_APP_DEVELOPMENT");
+    expect(post.body.data.relationships.devices.data).toEqual([
+      { type: "devices", id: "DEV1" },
+    ]);
+  });
+});
+
+describe("writeProfile", () => {
+  it("decodes profileContent to <uuid>.mobileprovision", () => {
+    const dir = tmpDir();
+    const file = writeProfile(
+      { id: "P", attributes: { uuid: "ABC", profileContent: Buffer.from("hello").toString("base64") } },
+      dir,
+    );
+    expect(file).toBe(path.join(dir, "ABC.mobileprovision"));
+    expect(fs.readFileSync(file, "utf8")).toBe("hello");
+  });
+
+  it("throws when the profile has no content", () => {
+    expect(() => writeProfile({ id: "P", attributes: { name: "n" } }, tmpDir())).toThrow(
+      /no profileContent/,
+    );
+  });
+});
+
+describe("discoverAppBundleIds", () => {
+  it("reads the app + each appex CFBundleIdentifier, de-duped", () => {
+    const dir = tmpDir();
+    const app = path.join(dir, "App.app");
+    fs.mkdirSync(path.join(app, "PlugIns", "Widgets.appex"), { recursive: true });
+    fs.writeFileSync(path.join(app, "Info.plist"), "x");
+    fs.writeFileSync(path.join(app, "PlugIns", "Widgets.appex", "Info.plist"), "x");
+    const ids = {
+      [path.join(app, "Info.plist")]: "ai.elizaos.app",
+      [path.join(app, "PlugIns", "Widgets.appex", "Info.plist")]: "ai.elizaos.app.widgets",
+    };
+    const out = discoverAppBundleIds(app, { runPlutil: (p) => ids[p] });
+    expect(out).toEqual([
+      { identifier: "ai.elizaos.app", name: "App" },
+      { identifier: "ai.elizaos.app.widgets", name: "Widgets" },
+    ]);
+  });
+});
+
+describe("provision — full idempotent flow", () => {
+  it("registers device, ensures bundles, mints + writes a profile per bundle id", async () => {
+    const dir = tmpDir();
+    const content = Buffer.from("profile-bytes").toString("base64");
+    const fetchImpl = mockFetch({
+      "GET /v1/devices": { body: { data: [] } },
+      "POST /v1/devices": { status: 201, body: { data: { id: "DEV" } } },
+      "GET /v1/certificates": { body: { data: [{ id: "CERT" }] } },
+      "GET /v1/bundleIds": { body: { data: [] } },
+      "POST /v1/bundleIds": { status: 201, body: { data: { id: "BID" } } },
+      "GET /v1/profiles": { body: { data: [] } },
+      "POST /v1/profiles": {
+        status: 201,
+        body: { data: { id: "PROF", attributes: { name: "Eliza Dev - ai.elizaos.app", uuid: "UUID", profileContent: content } } },
+      },
+    });
+    const result = await provision({
+      creds: { keyId: "K", issuerId: "I", privateKeyPem: P8 },
+      udid: "UDID",
+      bundleIds: [{ identifier: "ai.elizaos.app", name: "App" }],
+      fetchImpl,
+      dir,
+      now: 1_700_000_000,
+    });
+    expect(result.device).toEqual({ id: "DEV", created: true });
+    expect(result.certificateIds).toEqual(["CERT"]);
+    expect(result.results).toEqual([
+      {
+        identifier: "ai.elizaos.app",
+        bundleCreated: true,
+        profile: "Eliza Dev - ai.elizaos.app",
+        file: path.join(dir, "UUID.mobileprovision"),
+      },
+    ]);
+    expect(fs.readFileSync(path.join(dir, "UUID.mobileprovision"), "utf8")).toBe(
+      "profile-bytes",
+    );
+    // Every request carried the bearer JWT.
+    expect(fetchImpl.calls.every((c) => c.auth?.startsWith("Bearer "))).toBe(true);
+  });
+
+  it("throws when no development certificate exists", async () => {
+    const fetchImpl = mockFetch({
+      "GET /v1/devices": { body: { data: [{ id: "DEV" }] } },
+      "GET /v1/certificates": { body: { data: [] } },
+    });
+    await expect(
+      provision({
+        creds: { keyId: "K", issuerId: "I", privateKeyPem: P8 },
+        udid: "UDID",
+        bundleIds: [{ identifier: "ai.elizaos.app" }],
+        fetchImpl,
+        dir: tmpDir(),
+      }),
+    ).rejects.toThrow(/No DEVELOPMENT certificate/);
+  });
+
+  it("requires a udid and at least one bundle id", async () => {
+    const creds = { keyId: "K", issuerId: "I", privateKeyPem: P8 };
+    await expect(
+      provision({ creds, udid: "", bundleIds: [{ identifier: "x" }] }),
+    ).rejects.toThrow(/UDID is required/);
+    await expect(
+      provision({ creds, udid: "U", bundleIds: [] }),
+    ).rejects.toThrow(/no bundle ids/);
+  });
+});


### PR DESCRIPTION
## What & why (task 1 of #13567 — the headline development-profile minting)

The iOS physical-device lane can't install appexes or rebuild its XCUITest runner without a human Xcode account session. Only the main-app dev profile exists on the lane host, so `ios:device:deploy` limps along on `--skip-appexes` (#13174) and the 5 appex surfaces (widgets, DeviceActivity ×2, WebsiteBlocker, ElizaKeyboard) are missing from every on-device install.

This adds **`ios:device:provision`** — mint iOS **development** profiles non-interactively via the App Store Connect API, using the same `APP_STORE_API_KEY_ID`/`APP_STORE_API_ISSUER_ID`/`APP_STORE_API_KEY_P8` triplet `apple-store-release.yml` already uses:

- ES256 ASC JWT from the `.p8` (raw `ieee-p1363` signature, 20-min TTL);
- register the device UDID (idempotent);
- resolve a DEVELOPMENT certificate (fail fast if none);
- ensure a bundle id for the app + every appex (idempotent);
- mint/refresh an `IOS_APP_DEVELOPMENT` profile per bundle id (dev profiles are immutable → delete + recreate);
- download each into `~/Library/MobileDevice/Provisioning Profiles/<uuid>.mobileprovision` — where `ios-device-deploy.mjs discoverProfiles()` looks.

Bundle ids come from `--bundle-id` or `--product <App.app>/PlugIns/*.appex` discovery. `--dry-run` proves the JWT + resolution without mutating the team.

## Verification — real test run on this host

The ASC flow, JWT, credentials, and profile writing are pure functions with an injectable `fetchImpl`, unit-tested without real creds/network:

```
$ bunx vitest run packages/app/scripts/ios-device-provision.test.mjs
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

Covers: credential fail-fast; **real ES256 JWT** (signature verified against the EC public key via `crypto.verify`); non-EC key rejected; ASC errors surfaced verbatim; device/bundle-id idempotency; profile refresh (GET→DELETE→POST) with correct relationships; base64→`.mobileprovision`; appex `CFBundleIdentifier` discovery; full `provision()` flow. Evidence: `.github/issue-evidence/13567-ios-device-provision/README.md`.

## Scope

Delivers task 1 (the ASC provisioning script). **Deliberately scoped out** (need a device + creds to verify, sequenced next): task 2 (codify runner graft-signing as the default in `ios-device-capture.mjs`) and task 3 (flip non-`--skip-appexes` back to the deploy default once appex profiles mint) — noted in the evidence.

**N/A here — live run:** `ios:device:provision` against the real ASC team + a registered physical iOS device needs credentials + hardware this headless CI host lacks. That's the Needs-agent-verify step (a credentialed device runner). The contract is proven by the 17-test suite + inspection.

Advances #13567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)