### PR TITLE
fix(#13984): first-run runtime deep link does real work, not a swallowed no-op

### DIFF
--- a/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
+++ b/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
@@ -59,16 +59,30 @@ vi.mock("@capacitor/app", () => ({
   },
 }));
 
+// The deep-link handler now delegates a matched first-run link to the real
+// reload path (`reloadIntoFirstRunRuntime`), which clears the persisted
+// active-server record and navigates via `window.location.href`. We spy on it
+// so the assertions speak in terms of "was the app forced into first-run for
+// target X" rather than a query string nobody reads (#13984).
+const { reloadIntoFirstRunRuntimeMock } = vi.hoisted(() => ({
+  reloadIntoFirstRunRuntimeMock: vi.fn(),
+}));
+
+vi.mock("../reload-into-first-run-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../reload-into-first-run-runtime")>();
+  return {
+    ...actual,
+    reloadIntoFirstRunRuntime: reloadIntoFirstRunRuntimeMock,
+  };
+});
+
 import {
   installFirstRunDeepLinkListener,
   parseFirstRunRemoteConnectDeepLink,
   routeFirstRunDeepLink,
 } from "../deep-link-handler";
-import {
-  FIRST_RUN_QUERY_NAME,
-  FIRST_RUN_QUERY_VALUE,
-  FIRST_RUN_TARGET_QUERY_NAME,
-} from "../reload-into-first-run-runtime";
+import { FIRST_RUN_QUERY_NAME } from "../reload-into-first-run-runtime";
 
 const URL_SCHEME = "eliza";
 
@@ -88,6 +102,7 @@ beforeEach(() => {
   addListenerMock.mockClear();
   getLaunchUrlMock.mockClear();
   removeMock.mockClear();
+  reloadIntoFirstRunRuntimeMock.mockClear();
   addListenerMock.mockImplementation(async (_event, _handler) => ({
     remove: removeMock,
   }));
@@ -99,91 +114,74 @@ afterEach(() => {
 });
 
 describe("routeFirstRunDeepLink", () => {
-  it("local deep link routes to the local runtime target", () => {
+  it.each([
+    "local",
+    "cloud",
+    "remote",
+  ] as const)("%s deep link forces first-run into that runtime target via the real reload path", (target) => {
     const handled = routeFirstRunDeepLink(
-      "eliza://first-run/runtime/local",
+      `eliza://first-run/runtime/${target}`,
       URL_SCHEME,
     );
 
     expect(handled).toBe(true);
-    expect(currentParams().get(FIRST_RUN_TARGET_QUERY_NAME)).toBe("local");
+    // The fix: it does REAL work (clears active-server + location.href reload)
+    // instead of a replaceState no-op that no live code reads (#13984).
+    expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledWith(target);
   });
 
-  it("cloud deep link routes to the cloud runtime target", () => {
-    const handled = routeFirstRunDeepLink(
-      "eliza://first-run/runtime/cloud",
-      URL_SCHEME,
-    );
-
-    expect(handled).toBe(true);
-    expect(currentParams().get(FIRST_RUN_TARGET_QUERY_NAME)).toBe("cloud");
-  });
-
-  it("remote deep link routes to the remote runtime target", () => {
-    const handled = routeFirstRunDeepLink(
-      "eliza://first-run/runtime/remote",
-      URL_SCHEME,
-    );
-
-    expect(handled).toBe(true);
-    expect(currentParams().get(FIRST_RUN_TARGET_QUERY_NAME)).toBe("remote");
-  });
-
-  it("unknown step opens the default first-run flow without a pinned target", () => {
+  it("unknown step forces first-run WITHOUT a pinned target (user picks)", () => {
     const handled = routeFirstRunDeepLink(
       "eliza://first-run/runtime/garbage",
       URL_SCHEME,
     );
 
     expect(handled).toBe(true);
-    const params = currentParams();
-    // The first-run flag is set so FirstRunShell stops auto-completing to local on
-    // ElizaOS, but no target is pinned so the user lands on first-run setup.
-    expect(params.get(FIRST_RUN_QUERY_NAME)).toBe(FIRST_RUN_QUERY_VALUE);
-    expect(params.get(FIRST_RUN_TARGET_QUERY_NAME)).toBeNull();
+    // Still forces first-run, but with no target pinned so the user lands on
+    // the runtime picker rather than a silently-chosen runtime.
+    expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledWith(undefined);
   });
 
-  it("missing step segment opens the default first-run flow (no crash)", () => {
+  it("missing step segment forces the default first-run flow (no crash)", () => {
     const handled = routeFirstRunDeepLink(
       "eliza://first-run/runtime",
       URL_SCHEME,
     );
 
     expect(handled).toBe(true);
-    expect(currentParams().get(FIRST_RUN_QUERY_NAME)).toBe(
-      FIRST_RUN_QUERY_VALUE,
-    );
-    expect(currentParams().get(FIRST_RUN_TARGET_QUERY_NAME)).toBeNull();
+    expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledWith(undefined);
   });
 
-  it("malformed URL is ignored gracefully (no crash, no mutation)", () => {
-    const before = window.location.href;
+  it("malformed URL is ignored gracefully (no crash, no reload, onUnmatched still fires)", () => {
     const handled = routeFirstRunDeepLink("not-a-url", URL_SCHEME);
 
     expect(handled).toBe(false);
-    expect(window.location.href).toBe(before);
+    expect(reloadIntoFirstRunRuntimeMock).not.toHaveBeenCalled();
     expect(currentParams().get(FIRST_RUN_QUERY_NAME)).toBeNull();
   });
 
-  it("wrong scheme is ignored (no mutation)", () => {
-    const before = window.location.href;
+  it("wrong scheme is ignored (returns false so host onUnmatched fires)", () => {
     const handled = routeFirstRunDeepLink(
       "https://example.com/first-run/runtime/local",
       URL_SCHEME,
     );
 
     expect(handled).toBe(false);
-    expect(window.location.href).toBe(before);
+    expect(reloadIntoFirstRunRuntimeMock).not.toHaveBeenCalled();
     expect(currentParams().get(FIRST_RUN_QUERY_NAME)).toBeNull();
   });
 
-  it("right scheme but non-first-run host is ignored (no mutation)", () => {
+  it("right scheme but non-first-run host is NOT swallowed (returns false)", () => {
     // `eliza://chat` is a real, handled deep link in `apps/app/src/main.tsx`.
-    // The first-run router must not swallow it.
+    // The first-run router must not swallow it — it must return false so the
+    // host's onUnmatched switch handles it.
     const handled = routeFirstRunDeepLink("eliza://chat", URL_SCHEME);
 
     expect(handled).toBe(false);
-    expect(currentParams().get(FIRST_RUN_QUERY_NAME)).toBeNull();
+    expect(reloadIntoFirstRunRuntimeMock).not.toHaveBeenCalled();
   });
 
   it("right scheme + first-run host but wrong inner segment is ignored", () => {
@@ -193,30 +191,30 @@ describe("routeFirstRunDeepLink", () => {
     );
 
     expect(handled).toBe(false);
-    expect(currentParams().get(FIRST_RUN_QUERY_NAME)).toBeNull();
+    expect(reloadIntoFirstRunRuntimeMock).not.toHaveBeenCalled();
   });
 
-  it("preserves existing search params unrelated to the first-run contract", () => {
-    window.history.replaceState(null, "", "http://localhost/?session=abc");
+  // #13984 regression: the pre-fix implementation wrote the first-run query
+  // params via `history.replaceState` (no reload, no event) and returned true.
+  // Nothing live reads those params, so a matched `local`/`cloud`/`remote`
+  // link was a silent no-op. Assert the matched link now performs REAL work
+  // (delegates to the reload path) rather than only mutating the URL in place.
+  it("a matched bare-target link is NOT a replaceState no-op (does real work)", () => {
+    const replaceStateSpy = vi.spyOn(window.history, "replaceState");
 
-    routeFirstRunDeepLink("eliza://first-run/runtime/cloud", URL_SCHEME);
-
-    const params = currentParams();
-    expect(params.get("session")).toBe("abc");
-    expect(params.get(FIRST_RUN_QUERY_NAME)).toBe(FIRST_RUN_QUERY_VALUE);
-    expect(params.get(FIRST_RUN_TARGET_QUERY_NAME)).toBe("cloud");
-  });
-
-  it("overwrites a stale runtimeTarget when the deep-link picks a different one", () => {
-    window.history.replaceState(
-      null,
-      "",
-      "http://localhost/?runtime=first-run&runtimeTarget=cloud",
+    const handled = routeFirstRunDeepLink(
+      "eliza://first-run/runtime/local",
+      URL_SCHEME,
     );
 
-    routeFirstRunDeepLink("eliza://first-run/runtime/local", URL_SCHEME);
+    expect(handled).toBe(true);
+    // The fix must drive the real reload path...
+    expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledWith("local");
+    // ...and must NOT fall back to an in-place replaceState param write that no
+    // live code path consumes (the exact swallowed-no-op the issue describes).
+    expect(replaceStateSpy).not.toHaveBeenCalled();
 
-    expect(currentParams().get(FIRST_RUN_TARGET_QUERY_NAME)).toBe("local");
+    replaceStateSpy.mockRestore();
   });
 });
 
@@ -234,12 +232,12 @@ describe("installFirstRunDeepLinkListener", () => {
       expect.any(Function),
     );
 
-    // Drive the registered handler with a first-run URL — it must mutate
-    // the URL params and NOT fall through to the unmatched hook.
+    // Drive the registered handler with a first-run URL — it must force
+    // first-run for the target and NOT fall through to the unmatched hook.
     const handler = addListenerMock.mock.calls[0][1];
     handler({ url: "eliza://first-run/runtime/cloud" });
 
-    expect(currentParams().get(FIRST_RUN_TARGET_QUERY_NAME)).toBe("cloud");
+    expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledWith("cloud");
     expect(onUnmatched).not.toHaveBeenCalled();
 
     await cleanup();
@@ -268,7 +266,7 @@ describe("installFirstRunDeepLinkListener", () => {
     await installFirstRunDeepLinkListener({ urlScheme: URL_SCHEME });
 
     expect(getLaunchUrlMock).toHaveBeenCalledTimes(1);
-    expect(currentParams().get(FIRST_RUN_TARGET_QUERY_NAME)).toBe("local");
+    expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledWith("local");
   });
 
   it("is a no-op when the native Capacitor bridge is unavailable", async () => {
@@ -322,7 +320,7 @@ describe("installFirstRunDeepLinkListener", () => {
     // launch read failed.
     const handler = addListenerMock.mock.calls[0][1];
     handler({ url: "eliza://first-run/runtime/remote" });
-    expect(currentParams().get(FIRST_RUN_TARGET_QUERY_NAME)).toBe("remote");
+    expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledWith("remote");
 
     await cleanup();
     expect(removeMock).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/first-run/deep-link-handler.ts
+++ b/packages/ui/src/first-run/deep-link-handler.ts
@@ -30,10 +30,8 @@
  */
 
 import {
-  FIRST_RUN_QUERY_NAME,
-  FIRST_RUN_QUERY_VALUE,
-  FIRST_RUN_TARGET_QUERY_NAME,
   type FirstRunReloadTarget,
+  reloadIntoFirstRunRuntime,
 } from "./reload-into-first-run-runtime";
 
 const FIRST_RUN_HOST = "first-run";
@@ -113,10 +111,20 @@ export function parseFirstRunRemoteConnectDeepLink(
 
 /**
  * Parses `eliza://first-run/runtime/<id>` (or any scheme matching `urlScheme`)
- * and writes the matching first-run runtime query
- * params to the current location. Returns `true` when the URL matched the
- * first-run contract (so the caller can stop processing); returns `false`
- * for anything else.
+ * and, on a match, forces the app into first-run setup for the requested
+ * runtime target. Returns `true` when the URL matched the first-run contract
+ * (so the caller can stop processing) and the reload was dispatched; returns
+ * `false` for anything else so the caller's own deep-link switch
+ * (`onUnmatched`) still fires.
+ *
+ * The matched link delegates to {@link reloadIntoFirstRunRuntime}, the same
+ * helper the in-app "Switch runtime" action uses. That path does REAL work:
+ * it clears the persisted active-server record and navigates via
+ * `window.location.href`, so the startup coordinator actually re-evaluates and
+ * lands the user on first-run setup. The previous implementation wrote the
+ * query params via `history.replaceState`, which fires no reload and no event
+ * and is read by no live code path — so the bare `local`/`cloud`/`remote`
+ * variants were silently swallowed (#13984).
  *
  * @param url        The raw URL string handed in by Capacitor's
  *                   `appUrlOpen` event.
@@ -146,19 +154,13 @@ export function routeFirstRunDeepLink(url: string, urlScheme: string): boolean {
   if (pathSegments[0] !== RUNTIME_SEGMENT) return false;
 
   const stepId = pathSegments[1] ?? "";
-  const next = new URL(window.location.href);
-  next.searchParams.set(FIRST_RUN_QUERY_NAME, FIRST_RUN_QUERY_VALUE);
+  // A known target pins the runtime; an unknown/missing segment still forces
+  // first-run setup but without a pinned target (undefined) so the user picks.
+  const target: FirstRunReloadTarget | undefined = isFirstRunPathTarget(stepId)
+    ? STEP_TO_FIRST_RUN_TARGET[stepId]
+    : undefined;
 
-  if (isFirstRunPathTarget(stepId)) {
-    next.searchParams.set(
-      FIRST_RUN_TARGET_QUERY_NAME,
-      STEP_TO_FIRST_RUN_TARGET[stepId],
-    );
-  } else {
-    next.searchParams.delete(FIRST_RUN_TARGET_QUERY_NAME);
-  }
-
-  window.history.replaceState(window.history.state, "", next.toString());
+  reloadIntoFirstRunRuntime(target);
   return true;
 }
 


### PR DESCRIPTION
## Problem (#13984)

`routeFirstRunDeepLink` handled `eliza://first-run/runtime/<local|cloud|remote>` by writing `?runtime=first-run&runtimeTarget=<t>` via `window.history.replaceState(...)` and returning `true`. That path was dead three ways over:

1. **Nothing live reads those params.** `readFirstRunRuntimeTarget()` is the sole reader and has **zero non-test callers** — the old `FirstRunScreen` wizard was replaced by the in-chat conductor, and onboarding entry is now driven purely by backend `firstRunStatus.complete` (`useStartupCoordinator`), which never consults the query.
2. **`replaceState` fires no reload and no event**, so even a warm app with a reader would never re-evaluate (contrast the working `reloadIntoFirstRunRuntime`, which sets `window.location.href`).
3. Returning `true` **suppressed the host `onUnmatched` fallback**, so the link wasn't even offered to the app's normal deep-link switch — silently eaten.

The `remote?api=<url>` variant works because it routes through `parseFirstRunRemoteConnectDeepLink` directly, which masked the breakage of the bare `local`/`cloud`/`remote` variants.

## Fix

Make `routeFirstRunDeepLink` do **real work** by delegating a matched link to `reloadIntoFirstRunRuntime(target)` — the same helper the in-app "Switch runtime" action uses. That path:
- clears the persisted `elizaos:active-server` record (so first-run detection can't skip),
- persists the mobile runtime mode for the target, and
- navigates via `window.location.href`, so the startup coordinator actually re-evaluates and lands the user on first-run setup.

A known target (`local`/`cloud`/`remote`) pins the runtime; an unknown/missing segment still forces first-run but with no pinned target (user picks). Non-matches (wrong scheme/host/segment, unparseable) still return `false` so the host `onUnmatched` deep-link switch fires — no more silent swallow.

Reuses the proven working helper; deletes the dead `replaceState` write. No forbidden files touched (`vite.config.*`/`index.html`/`client-base.ts` untouched).

## Tests

`packages/ui/src/first-run/__tests__/deep-link-entry.test.ts` rewritten to assert the **real reload delegation** (`reloadIntoFirstRunRuntime` called with the resolved target) instead of a query string no live code reads, plus a dedicated **#13984 regression** asserting a matched bare-target link is **NOT** a `replaceState` no-op (`history.replaceState` never called, reload path driven).

- **28/28 green** (`vitest run src/first-run/__tests__/deep-link-entry.test.ts`).
- **Reversion-proven:** 9 tests fail on the pristine (pre-fix) source; all pass with the fix applied.
- **tsc:** 0 errors in touched files (the sole `packages/ui` typecheck error is a pre-existing `startup-phase-poll.test.ts` `null`-vs-`PersistedActiveServer` baseline, byte-identical on `origin/develop`, untouched here).
- **biome** clean, **error-policy-ratchet** clean (no new fallback-slop; the change removes a no-op, not adds slop).

— [sol-orch]
