### PR TITLE
refactor(ui): single console surface catalog (#13916 part 2b-i)

### DIFF
--- a/packages/ui/src/cloud/home/DashboardHomePage.tsx
+++ b/packages/ui/src/cloud/home/DashboardHomePage.tsx
@@ -2,24 +2,14 @@
  * Cloud console home mounted by the cloud router shell at `dashboard` — the
  * authenticated landing for apex control-plane hosts (elizacloud.ai), where
  * the agent app never mounts (see `AppCatchAllRoute`). One screen answers
- * "where is everything": the org credit balance with an add-funds path, and a
- * directory card for every console surface (agents, apps, analytics, billing,
- * API keys, monetization, connectors, account, security, organization). Cards
- * navigate to the standalone `dashboard/*` routes, so the whole console is
- * reachable from here without ever entering the agent app.
+ * "where is everything": the org credit balance with an add-funds path, and
+ * directory cards for the promoted console surfaces. Cards navigate to the
+ * standalone `dashboard/*` routes, so the core console is reachable from here
+ * without ever entering the agent app.
  *
  * Default export for `React.lazy` code-splitting from the route registration.
  */
 
-import type { LucideIcon } from "lucide-react";
-import {
-  Bot,
-  Building2,
-  CreditCard,
-  Grid3x3,
-  KeyRound,
-  User,
-} from "lucide-react";
 import { Link } from "react-router-dom";
 import { DashboardLoadingState } from "../../cloud-ui/components/dashboard/route-placeholders";
 import { useSetPageHeader } from "../../cloud-ui/components/layout";

--- a/packages/ui/src/cloud/home/DashboardHomePage.tsx
+++ b/packages/ui/src/cloud/home/DashboardHomePage.tsx
@@ -28,79 +28,17 @@ import { formatUsd } from "../lib/format-usd";
 import { useDocumentTitle } from "../lib/use-document-title";
 import { useSessionAuth } from "../lib/use-session-auth";
 import { useCloudT } from "../shell/CloudI18nProvider";
-
-interface ConsoleSurface {
-  to: string;
-  icon: LucideIcon;
-  titleKey: string;
-  titleDefault: string;
-  descKey: string;
-  descDefault: string;
-}
-
-/**
- * The launch-core surfaces (nubs's cut, 2026-07-04) — mirrors the console
- * sidebar exactly: agents, apps, money, keys, account plumbing. De-navved
- * surfaces (my-agents, analytics, api-explorer, mcps, monetization,
- * connectors, security) stay routable but aren't advertised here.
- */
-const CONSOLE_SURFACES: ReadonlyArray<ConsoleSurface> = [
-  {
-    to: "/dashboard/agents",
-    icon: Bot,
-    titleKey: "cloud.home.agents",
-    titleDefault: "Agents",
-    descKey: "cloud.home.agentsDesc",
-    descDefault: "Hosted agents: create, wake, sleep, logs.",
-  },
-  {
-    to: "/dashboard/apps",
-    icon: Grid3x3,
-    titleKey: "cloud.home.apps",
-    titleDefault: "Apps",
-    descKey: "cloud.home.appsDesc",
-    descDefault: "Hosted apps: monetization, domains, users.",
-  },
-  {
-    to: "/dashboard/billing",
-    icon: CreditCard,
-    titleKey: "cloud.home.billing",
-    titleDefault: "Billing",
-    descKey: "cloud.home.billingDesc",
-    descDefault: "Add funds, payment methods, invoices.",
-  },
-  {
-    to: "/dashboard/api-keys",
-    icon: KeyRound,
-    titleKey: "cloud.home.apiKeys",
-    titleDefault: "API Keys",
-    descKey: "cloud.home.apiKeysDesc",
-    descDefault: "Create and revoke inference API keys.",
-  },
-  {
-    to: "/dashboard/account",
-    icon: User,
-    titleKey: "cloud.home.account",
-    titleDefault: "Account",
-    descKey: "cloud.home.accountDesc",
-    descDefault: "Profile, email, identity, and security.",
-  },
-  {
-    to: "/dashboard/organization",
-    icon: Building2,
-    titleKey: "cloud.home.organization",
-    titleDefault: "Organization",
-    descKey: "cloud.home.organizationDesc",
-    descDefault: "Members, credentials, and invites.",
-  },
-];
+import {
+  CONSOLE_SURFACES,
+  type ConsoleSurface,
+} from "../shell/console-surfaces";
 
 function SurfaceCard({ surface }: { surface: ConsoleSurface }) {
   const t = useCloudT();
   const Icon = surface.icon;
   return (
     <Link
-      to={surface.to}
+      to={surface.href}
       className="group flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-4 transition-colors hover:border-accent/40 hover:bg-surface"
     >
       <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-accent/12 text-accent">
@@ -187,7 +125,7 @@ export function DashboardHomePage() {
       <BalanceCard />
       <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {CONSOLE_SURFACES.map((surface) => (
-          <SurfaceCard key={surface.to} surface={surface} />
+          <SurfaceCard key={surface.href} surface={surface} />
         ))}
       </div>
     </div>

--- a/packages/ui/src/cloud/shell/ConsoleShell.tsx
+++ b/packages/ui/src/cloud/shell/ConsoleShell.tsx
@@ -13,15 +13,6 @@
  */
 
 import { BRAND_PATHS, LOGO_FILES } from "@elizaos/shared/brand";
-import {
-  Bot,
-  Building2,
-  CreditCard,
-  Grid3x3,
-  Home,
-  KeyRound,
-  User,
-} from "lucide-react";
 import { type ReactNode, useCallback, useState } from "react";
 import { Link, Navigate, useLocation } from "react-router-dom";
 import {
@@ -40,12 +31,9 @@ import {
 } from "./console-surfaces";
 
 /**
- * The console nav: one flat list, launch-core surfaces only (nubs's cut,
- * 2026-07-04 — manage account, funds, agents, apps, API keys). Everything
- * else (my-agents, mcps, analytics, api-explorer, monetization, connectors,
- * security) stays REGISTERED and deep-linkable — it just isn't advertised
- * here until it earns its slot back. One unsectioned list means no section
- * titles at all, which also settles the Account/Account double-label.
+ * The console nav is one flat list so sidebar section labels never compete
+ * with Account and Organization route labels. Specialist routes stay registered
+ * for deep links but are not promoted into the default console chrome.
  */
 const CONSOLE_NAV_SECTIONS: DashboardSidebarSection[] = [
   {

--- a/packages/ui/src/cloud/shell/ConsoleShell.tsx
+++ b/packages/ui/src/cloud/shell/ConsoleShell.tsx
@@ -34,6 +34,10 @@ import {
   usePageHeader,
 } from "../../cloud-ui/components/layout";
 import { useSessionAuth } from "../lib/use-session-auth";
+import {
+  CONSOLE_OVERVIEW_NAV_ITEM,
+  CONSOLE_SURFACES,
+} from "./console-surfaces";
 
 /**
  * The console nav: one flat list, launch-core surfaces only (nubs's cut,
@@ -46,33 +50,13 @@ import { useSessionAuth } from "../lib/use-session-auth";
 const CONSOLE_NAV_SECTIONS: DashboardSidebarSection[] = [
   {
     items: [
-      { id: "overview", label: "Overview", href: "/dashboard", icon: Home },
-      { id: "agents", label: "Agents", href: "/dashboard/agents", icon: Bot },
-      { id: "apps", label: "Apps", href: "/dashboard/apps", icon: Grid3x3 },
-      {
-        id: "billing",
-        label: "Billing",
-        href: "/dashboard/billing",
-        icon: CreditCard,
-      },
-      {
-        id: "api-keys",
-        label: "API Keys",
-        href: "/dashboard/api-keys",
-        icon: KeyRound,
-      },
-      {
-        id: "account",
-        label: "Account",
-        href: "/dashboard/account",
-        icon: User,
-      },
-      {
-        id: "organization",
-        label: "Organization",
-        href: "/dashboard/organization",
-        icon: Building2,
-      },
+      CONSOLE_OVERVIEW_NAV_ITEM,
+      ...CONSOLE_SURFACES.map(({ id, label, href, icon }) => ({
+        id,
+        label,
+        href,
+        icon,
+      })),
     ],
   },
 ];

--- a/packages/ui/src/cloud/shell/console-surfaces.ts
+++ b/packages/ui/src/cloud/shell/console-surfaces.ts
@@ -1,0 +1,103 @@
+/**
+ * The console's launch-core surface catalog (nubs's 2026-07-04 cut): agents,
+ * apps, money, keys, account plumbing. Single source for BOTH the ConsoleShell
+ * sidebar and the /dashboard overview cards — the two previously maintained
+ * parallel constants that could only drift (#13916). De-navved surfaces
+ * (my-agents, analytics, api-explorer, mcps, monetization, connectors,
+ * security) stay routable but aren't advertised by either consumer.
+ */
+
+import {
+  Bot,
+  Building2,
+  CreditCard,
+  Grid3x3,
+  Home,
+  KeyRound,
+  type LucideIcon,
+  User,
+} from "lucide-react";
+
+export interface ConsoleSurface {
+  id: string;
+  href: string;
+  icon: LucideIcon;
+  /** Sidebar label (the nav renders plain labels). */
+  label: string;
+  /** Overview-card copy (i18n key + fallback). */
+  titleKey: string;
+  titleDefault: string;
+  descKey: string;
+  descDefault: string;
+}
+
+/** Overview is nav-only: it IS the page the cards live on. */
+export const CONSOLE_OVERVIEW_NAV_ITEM = {
+  id: "overview",
+  label: "Overview",
+  href: "/dashboard",
+  icon: Home,
+} as const;
+
+export const CONSOLE_SURFACES: ReadonlyArray<ConsoleSurface> = [
+  {
+    id: "agents",
+    href: "/dashboard/agents",
+    icon: Bot,
+    label: "Agents",
+    titleKey: "cloud.home.agents",
+    titleDefault: "Agents",
+    descKey: "cloud.home.agentsDesc",
+    descDefault: "Hosted agents: create, wake, sleep, logs.",
+  },
+  {
+    id: "apps",
+    href: "/dashboard/apps",
+    icon: Grid3x3,
+    label: "Apps",
+    titleKey: "cloud.home.apps",
+    titleDefault: "Apps",
+    descKey: "cloud.home.appsDesc",
+    descDefault: "Hosted apps: monetization, domains, users.",
+  },
+  {
+    id: "billing",
+    href: "/dashboard/billing",
+    icon: CreditCard,
+    label: "Billing",
+    titleKey: "cloud.home.billing",
+    titleDefault: "Billing",
+    descKey: "cloud.home.billingDesc",
+    descDefault: "Add funds, payment methods, invoices.",
+  },
+  {
+    id: "api-keys",
+    href: "/dashboard/api-keys",
+    icon: KeyRound,
+    label: "API Keys",
+    titleKey: "cloud.home.apiKeys",
+    titleDefault: "API Keys",
+    descKey: "cloud.home.apiKeysDesc",
+    descDefault: "Create and revoke inference API keys.",
+  },
+  {
+    id: "account",
+    href: "/dashboard/account",
+    icon: User,
+    label: "Account",
+    titleKey: "cloud.home.account",
+    titleDefault: "Account",
+    descKey: "cloud.home.accountDesc",
+    descDefault: "Profile, email, identity, and security.",
+  },
+  {
+    id: "organization",
+    href: "/dashboard/organization",
+    icon: Building2,
+    label: "Organization",
+    titleKey: "cloud.home.organization",
+    titleDefault: "Organization",
+    descKey: "cloud.home.organizationDesc",
+    descDefault: "Members, credentials, and invites.",
+  },
+];

--- a/packages/ui/src/cloud/shell/console-surfaces.ts
+++ b/packages/ui/src/cloud/shell/console-surfaces.ts
@@ -1,10 +1,8 @@
 /**
- * The console's launch-core surface catalog (nubs's 2026-07-04 cut): agents,
- * apps, money, keys, account plumbing. Single source for BOTH the ConsoleShell
- * sidebar and the /dashboard overview cards — the two previously maintained
- * parallel constants that could only drift (#13916). De-navved surfaces
- * (my-agents, analytics, api-explorer, mcps, monetization, connectors,
- * security) stay routable but aren't advertised by either consumer.
+ * Console surface catalog shared by the sidebar and overview cards. The
+ * advertised control-plane routes are intentionally narrower than the complete
+ * router: deep-linkable specialist surfaces stay registered, but only the core
+ * agent, app, billing, key, account, and organization paths are promoted here.
  */
 
 import {


### PR DESCRIPTION
Part 2b-i of #13916: ConsoleShell nav + /dashboard overview cards maintained the same six surfaces as two parallel constants that could only drift (the home file's comment literally said it 'mirrors the console sidebar exactly'). Now one catalog (`cloud/shell/console-surfaces.ts`) both derive from — Overview stays nav-only since it IS the cards' page. Zero behavior change: same 7 nav items, 6 cards, identical keys/copy/icons. 9/9 tests, typecheck clean. Placed in `cloud/shell/` (not the cloud-ui barrel) to stay conflict-free with queued #14001. Remaining on the card: runAgentJob helper, row view-model, table split (blocked until #14001 lands — same file). [qa-agent]