### PR TITLE
fix(ui): bound native chat stream liveness — no more forever-hang (#13983)

### DIFF
--- a/.github/issue-evidence/13983-native-stream-liveness.md
+++ b/.github/issue-evidence/13983-native-stream-liveness.md
@@ -1,0 +1,16 @@
+# #13983 — native chat stream can hang forever (Android liveness)
+
+`createNativeStreamingResponse` (`packages/ui/src/api/native-agent-stream.ts`) settled its head only on `agentStreamResponse` and closed the body only on `agentStreamComplete`, with the sole liveness net being the caller's `completion` promise — which **Android's `requestStream` does not supply** (`Promise<{streamId}>`, no `completion`). So a dropped head/terminal event (agent crash, killed loopback, lost Capacitor event) left the awaited promise **never settling**: the reply spinner hung, the buffered fallback (which only catches rejections) was bypassed, and `detach()` never ran → the 3 `agentStream*` listeners leaked (ties #12626).
+
+## Fix (pure liveness/control-flow — no credit/money arithmetic touched)
+- **Completion RESOLUTION is now terminal**, not just rejection: `stream.completion.then(finishStream, failStream)`.
+- **complete-before-head** now always settles the head (200 Response with the body, or reject on error) before touching the body.
+- **Head timeout** (`options.timeoutMs ?? 30000`): if the head never arrives, `failStream` rejects → the Android transport's try/catch falls back to the buffered `request`.
+- **Idle timeout**: re-armed after head + on each chunk; errors the stream on a post-head stall.
+- `clearTimers()` on `detach()`; a `detached` guard prevents double-close on the normal iOS path.
+
+## Verification
+`packages/ui/src/api/native-agent-stream.test.ts` (vitest, `vi.useFakeTimers()`, in-process fake agent) — **13 pass / 0 fail** (9 existing + 4 new): (1) completion resolution with no complete event terminates the stream + `listenerCount()===0`; (2) complete-before-head settles head to a closed 200 body; (3) stalled head → head promise **rejects** (fallback path); (4) post-head idle stall → body errors + listeners cleaned (closes the #12626 leak).
+
+## N/A
+Real Android device/emulator repro — N/A here (deterministic unit-level proof of the liveness contract; the on-device lock is a follow-up per the issue). UI screenshots/model-trajectory/audio — N/A (pure transport-layer stream control).

--- a/packages/ui/src/api/native-agent-stream.test.ts
+++ b/packages/ui/src/api/native-agent-stream.test.ts
@@ -2,7 +2,7 @@
  * Unit coverage for the native streaming-response helper and its capability
  * probe. In-process, no real bridge.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   createNativeStreamingResponse,
@@ -193,6 +193,117 @@ describe("createNativeStreamingResponse", () => {
     rejectCompletion(new Error("native stream died"));
 
     await expect(reader.read()).rejects.toThrow("native stream died");
+  });
+
+  // The liveness net: a resolved/rejected completion, a completion that beats
+  // the head, and head/idle deadlines each must terminate the stream so a
+  // dropped native event can't hang the reply forever (issue #13983). Fake
+  // timers drive the deadlines; `advanceTimersByTimeAsync(0)` also drains the
+  // helper's internal awaits (requestStream + 3 addListener) so listeners are
+  // attached before events are emitted.
+  it("terminates the stream when a successful native completion resolves without a complete event", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveCompletion: () => void = () => {};
+      const completion = new Promise<void>((resolve) => {
+        resolveCompletion = resolve;
+      });
+      const { agent, emit, listenerCount } = makeFakeAgent("s1", completion);
+      const responsePromise = createNativeStreamingResponse(agent, {
+        path: "/x",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      emit("agentStreamResponse", { streamId: "s1", status: 200 });
+      const response = await responsePromise;
+      const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+
+      // Native call resolves successfully but the terminal event never arrives:
+      // resolution alone must close the body (the pre-fix `.catch`-only wiring
+      // would leave this pending forever).
+      resolveCompletion();
+      await vi.advanceTimersByTimeAsync(0);
+
+      const r = await reader.read();
+      expect(r.done).toBe(true);
+      expect(listenerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("settles the head to a closed 200 when completion arrives before any response", async () => {
+    vi.useFakeTimers();
+    try {
+      const { agent, emit, listenerCount } = makeFakeAgent();
+      const responsePromise = createNativeStreamingResponse(agent, {
+        path: "/x",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      emit("agentStreamComplete", { streamId: "s1" });
+      const response = await responsePromise;
+      expect(response.status).toBe(200);
+      const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+      const r = await reader.read();
+      expect(r.done).toBe(true);
+      expect(listenerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects the head on the head timeout so the caller falls back", async () => {
+    vi.useFakeTimers();
+    try {
+      const { agent, listenerCount } = makeFakeAgent();
+      const responsePromise = createNativeStreamingResponse(agent, {
+        path: "/x",
+        timeoutMs: 30000,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      // Attach the rejection handler before firing the timer so the rejection is
+      // never momentarily unhandled.
+      const rejected = expect(responsePromise).rejects.toThrow(
+        "native stream head timeout",
+      );
+      // No response event ever arrives.
+      await vi.advanceTimersByTimeAsync(30000);
+      await rejected;
+      expect(listenerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("errors the body on an idle timeout after the head (also clears listeners, #12626)", async () => {
+    vi.useFakeTimers();
+    try {
+      const { agent, emit, listenerCount } = makeFakeAgent();
+      const responsePromise = createNativeStreamingResponse(agent, {
+        path: "/x",
+        timeoutMs: 30000,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      emit("agentStreamResponse", { streamId: "s1", status: 200 });
+      const response = await responsePromise;
+      const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+
+      emit("agentStreamChunk", {
+        streamId: "s1",
+        dataBase64: b64("data: hi\n\n"),
+      });
+      await reader.read();
+
+      // Stream stalls: the next chunk never comes.
+      const readPromise = reader.read();
+      const rejected = expect(readPromise).rejects.toThrow(
+        "native stream idle timeout",
+      );
+      await vi.advanceTimersByTimeAsync(30000);
+      await rejected;
+      expect(listenerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("detaches all listeners once the stream completes", async () => {

--- a/packages/ui/src/api/native-agent-stream.ts
+++ b/packages/ui/src/api/native-agent-stream.ts
@@ -89,6 +89,18 @@ export async function createNativeStreamingResponse(
   const stream = await agent.requestStream(options);
   const { streamId } = stream;
 
+  // Liveness bounds: the head must arrive within HEAD_TIMEOUT_MS, and once the
+  // body is streaming each chunk must arrive within IDLE_TIMEOUT_MS. Without
+  // these a dropped head/terminal event (agent crash, killed loopback, lost
+  // Capacitor event) would hang the reply forever — Android's `requestStream`
+  // carries no `completion` safety net, so the transport's try/catch fallback
+  // never fires. On timeout the head rejects (caller falls back to the buffered
+  // request) or the body errors, and `detach()` clears both timers.
+  const HEAD_TIMEOUT_MS = options.timeoutMs ?? 30000;
+  const IDLE_TIMEOUT_MS = options.timeoutMs ?? 30000;
+  let headTimer: ReturnType<typeof setTimeout> | null = null;
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
   let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
   // Buffer events that land before `start()` runs (and the terminal state if it
   // arrives before any reader pulls), so nothing is dropped on either edge.
@@ -97,9 +109,17 @@ export async function createNativeStreamingResponse(
   const handles: NativeStreamListenerHandle[] = [];
   let detached = false;
 
+  const clearTimers = (): void => {
+    if (headTimer !== null) clearTimeout(headTimer);
+    if (idleTimer !== null) clearTimeout(idleTimer);
+    headTimer = null;
+    idleTimer = null;
+  };
+
   const detach = (): void => {
     if (detached) return;
     detached = true;
+    clearTimers();
     for (const handle of handles) void handle.remove();
   };
   const trackHandle = (handle: NativeStreamListenerHandle): void => {
@@ -158,6 +178,40 @@ export async function createNativeStreamingResponse(
     }
   };
 
+  // Terminal on a SUCCESSFUL native completion (the resolution, not just the
+  // rejection failStream handles): if the head never arrived, settle it with a
+  // 200 so the caller gets a Response, then close the body. Idempotent — a
+  // later `agentStreamComplete` sees `detached` and no-ops.
+  const finishStream = (): void => {
+    if (detached) return;
+    if (!headSettled) {
+      headSettled = true;
+      resolveHead(new Response(body, { status: 200 }));
+    }
+    if (controller) {
+      controller.close();
+      detach();
+    } else {
+      terminal = { error: null };
+    }
+  };
+
+  // Re-arm the idle deadline; called once the head settles and on every chunk.
+  const bumpIdle = (): void => {
+    if (detached) return;
+    if (idleTimer !== null) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      if (detached) return;
+      const idle = new Error("native stream idle timeout");
+      if (controller) {
+        controller.error(idle);
+        detach();
+      } else {
+        terminal = { error: "native stream idle timeout" };
+      }
+    }, IDLE_TIMEOUT_MS);
+  };
+
   const onResponse = (event: unknown): void => {
     const e = event as NativeStreamResponseEvent;
     if (!e || e.streamId !== streamId || headSettled) return;
@@ -169,6 +223,7 @@ export async function createNativeStreamingResponse(
         headers: e.headers ?? {},
       }),
     );
+    bumpIdle();
   };
 
   const onChunk = (event: unknown): void => {
@@ -177,18 +232,25 @@ export async function createNativeStreamingResponse(
     const bytes = base64ToBytes(e.dataBase64);
     if (controller) controller.enqueue(bytes);
     else pending.push(bytes);
+    bumpIdle();
   };
 
   const onComplete = (event: unknown): void => {
     const e = event as NativeStreamCompleteEvent;
-    if (!e || e.streamId !== streamId) return;
-    // A failure before the head ever arrived can't yield a Response — reject the
-    // head so the caller falls back / surfaces the error.
-    if (e.error && !headSettled) {
+    if (!e || e.streamId !== streamId || detached) return;
+    // Always settle the head before touching the body — a terminal event that
+    // beats the response (empty stream completing head-first, or a dropped head
+    // event) must still resolve/reject the caller's promise, never leave it
+    // hanging. A failure can't yield a Response, so it rejects; a success
+    // resolves a 200 and falls through to close the body.
+    if (!headSettled) {
       headSettled = true;
-      rejectHead(new Error(e.error));
-      detach();
-      return;
+      if (e.error) {
+        rejectHead(new Error(e.error));
+        detach();
+        return;
+      }
+      resolveHead(new Response(body, { status: 200 }));
     }
     if (controller) {
       if (e.error) controller.error(new Error(e.error));
@@ -200,12 +262,21 @@ export async function createNativeStreamingResponse(
   };
 
   if (stream.completion) {
-    void stream.completion.catch(failStream);
+    // Both settlements are terminal: a resolved completion closes the stream via
+    // `finishStream` (missing the terminal event still ends the reply); a
+    // rejected one fails it. Wiring only `.catch` would hang on a silent success.
+    void stream.completion.then(finishStream, failStream);
   }
 
   trackHandle(await agent.addListener("agentStreamResponse", onResponse));
   trackHandle(await agent.addListener("agentStreamChunk", onChunk));
   trackHandle(await agent.addListener("agentStreamComplete", onComplete));
+
+  // Head deadline: if no response arrives in time, fail the head so the caller's
+  // try/catch falls back to the buffered request instead of hanging.
+  headTimer = setTimeout(() => {
+    if (!headSettled) failStream(new Error("native stream head timeout"));
+  }, HEAD_TIMEOUT_MS);
 
   return head;
 }


### PR DESCRIPTION
## Fixes #13983 — native chat stream can hang forever

`createNativeStreamingResponse` settled its head only on `agentStreamResponse` and closed the body only on `agentStreamComplete`; its one liveness net was the caller `completion` promise — which **Android does not supply**. A dropped head/terminal event left the awaited promise **never settling**: hung spinner, buffered fallback bypassed, and `detach()` never ran → the 3 `agentStream*` listeners leaked (#12626).

**Fix (pure liveness/control-flow, no money arithmetic):**
- completion **resolution** is now terminal (`.then(finishStream, failStream)`), not just rejection;
- complete-before-head always settles head first;
- **head timeout** (`options.timeoutMs ?? 30000`) → rejects so the Android transport falls back to the buffered request;
- **idle timeout** re-armed after head + per chunk;
- `clearTimers()` on `detach()`; `detached` guard prevents double-close on the iOS path.

**Verification** (`.github/issue-evidence/13983-native-stream-liveness.md`): `native-agent-stream.test.ts` (vitest, fake timers, fake agent) — **13 pass / 0 fail** (9 existing + 4 new covering all four hang paths + the listener-leak). Real Android device repro is a follow-up (N/A here) — this is deterministic unit-level proof of the liveness contract. (Created via REST — shared working tree in concurrent use.)