### PR TITLE
fix(ui): designed out-of-credits gate + top-up CTA for drained-org chat (#13962)

### DIFF
--- a/.github/issue-evidence/13962-out-of-credits-gate.md
+++ b/.github/issue-evidence/13962-out-of-credits-gate.md
@@ -1,0 +1,14 @@
+# #13962 — drained-org 402 renders as a generic error (client half)
+
+The SERVER half already merged (#13928): a 402 credit-exhaustion connector turn now classifies to `failureKind="insufficient_credits"` with the actionable top-up reply text. But the **client** still rendered `insufficient_credits` as a plain text bubble (`MessageContent.tsx` — it was excluded from the `no_provider` structured gate and fell through to `MessageTextBody`), so there was no designed "Out of credits" state and no top-up affordance — the UI three-state rule (#13962) was unmet.
+
+## Fix
+Add an exclusive `if (message.failureKind === "insufficient_credits")` branch right after the existing `no_provider` gate, mirroring it one-for-one: warn/orange-accented card with an "Out of credits" title, the server's actionable copy (`message.text`, muted), and a primary **"Add credits"** CTA wired to the existing `handleOpenSettings` (`setTab("settings")` — Cloud top-up lives under settings; there is no separate billing tab). Theme-aware, no blue, no server/credit arithmetic touched. Also removed the now-stale `no_provider` comment claiming insufficient_credits renders as text.
+
+## Verification
+Added a real test to `MessageContent.interactions.test.tsx` (vitest + @testing-library/react): renders a `failureKind:"insufficient_credits"` message, asserts the designed gate ("Out of credits" title + "Add credits" button + verbatim server copy, not a plain bubble), and that clicking "Add credits" calls `setTab("settings")`.
+
+**Local test note:** the new test (and all 4 pre-existing tests in this file) currently crash locally on `useRef` from a **stale `dist/node_modules/react`** symlink in this checkout (a build-artifact/env issue — `vitest.config.ts` derives the React alias via `lucide-react` which resolves into the Jun-28 dist copy, mismatching the renderer's React 19.2.5). This is pre-existing and unrelated to the change (identical failure on the untouched tests); a fresh CI install resolves React correctly, so this PR's `ui-story-gate`/`test:client` CI verifies the test. The change is a one-for-one mirror of the proven-green `no_provider` gate.
+
+## N/A
+Full `audit:app` visual — this follows the existing `no_provider` gate's design one-for-one; a reviewer visual pass is welcome. Model-trajectory/audio — N/A.

--- a/packages/ui/src/components/chat/MessageContent.interactions.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.interactions.test.tsx
@@ -5,7 +5,7 @@
 // pickers, inline forms). Mirrors the story inputs in MessageContent.stories so
 // the story-gate screenshots have a fast unit guard that they render at all.
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ConversationMessage } from "../../api/client-types-chat";
@@ -96,5 +96,38 @@ describe("MessageContent non-bytes interaction rendering", () => {
       />,
     );
     expect(container.textContent ?? "").toContain("Destination");
+  });
+
+  it("renders the out-of-credits gate for an insufficient_credits failure and its CTA opens Settings", () => {
+    const setTab = vi.fn();
+    const appValue = {
+      t: (key: string, vars?: Record<string, unknown>) =>
+        String(vars?.defaultValue ?? key),
+      sendActionMessage: vi.fn(),
+      setTab,
+    } as never;
+    __setAppValueForTests(appValue);
+    render(
+      <AppContext.Provider value={appValue}>
+        <MessageContent
+          message={assistant({
+            failureKind: "insufficient_credits",
+            text: "You're out of credits. Add more to keep chatting.",
+          })}
+        />
+      </AppContext.Provider>,
+    );
+
+    // Designed gate, not a plain text bubble.
+    expect(screen.getByText("Out of credits")).toBeTruthy();
+    const cta = screen.getByRole("button", { name: "Add credits" });
+    expect(cta).toBeTruthy();
+    // The actionable server copy is surfaced verbatim.
+    expect(
+      screen.getByText(/out of credits\. Add more to keep chatting/i),
+    ).toBeTruthy();
+
+    fireEvent.click(cta);
+    expect(setTab).toHaveBeenCalledWith("settings");
   });
 });

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -45,6 +45,7 @@ import { renderPermissionCardFromPayload } from "../composites/chat/permission-c
 import { ConfigRenderer } from "../config-ui/config-renderer";
 import { defaultRegistry } from "../config-ui/config-renderer.helpers";
 import { UiRenderer } from "../config-ui/ui-renderer";
+import { ToolCallEventLog } from "../tool-events/ToolCallEventLog";
 import { Button } from "../ui/button";
 import { CodeBlock } from "../ui/code-block";
 import { ErrorBoundary } from "../ui/error-boundary";
@@ -61,7 +62,6 @@ import {
   splitInlineCode,
 } from "./message-parser-helpers";
 import { ThinkingBlock } from "./ThinkingBlock";
-import { ToolCallEventLog } from "../tool-events/ToolCallEventLog";
 // Side effect: registers the built-in inline widgets (choice/followups/form/task).
 import "./widgets/inline-builtins";
 import { getInlineWidget } from "./widgets/inline-registry";
@@ -1124,10 +1124,7 @@ export function MessageContent({
   // `no_provider` specifically the user can't make progress without
   // wiring up a provider, so render a structured gate (banner + CTA)
   // instead of the fallback text — clicking jumps to Settings where
-  // ProviderSwitcher lives. Other failure kinds (insufficient_credits,
-  // provider_issue) still render as normal text bubbles; the user has
-  // separate, clearer in-product affordances for those (Cloud billing
-  // banner, retry).
+  // ProviderSwitcher lives.
   if (message.failureKind === "no_provider") {
     return (
       <div className="border border-warn/30 bg-warn/5 rounded-sm p-3 text-sm">
@@ -1137,6 +1134,24 @@ export function MessageContent({
         </div>
         <Button type="button" size="sm" onClick={handleOpenSettings}>
           Open Settings
+        </Button>
+      </div>
+    );
+  }
+
+  // A drained org returns a 402; retrying just re-hits the same empty balance,
+  // so render a designed out-of-credits gate rather than the generic failure
+  // text (which invites the retry loop). The CTA jumps to Settings where the
+  // Cloud top-up/redeem flow lives — there is no separate billing tab.
+  if (message.failureKind === "insufficient_credits") {
+    return (
+      <div className="border border-warn/30 bg-warn/5 rounded-sm p-3 text-sm">
+        <div className="font-medium mb-1">Out of credits</div>
+        <div className="text-muted whitespace-pre-wrap mb-2">
+          {message.text}
+        </div>
+        <Button type="button" size="sm" onClick={handleOpenSettings}>
+          Add credits
         </Button>
       </div>
     );


### PR DESCRIPTION
## Fixes #13962 (client half) — drained-org 402 renders as generic error

The server half merged (#13928): 402 → `failureKind="insufficient_credits"` with actionable copy. But the **client** still rendered it as a plain text bubble (excluded from the `no_provider` gate → fell through to `MessageTextBody`) — no designed "Out of credits" state, no top-up path (UI three-state rule unmet).

**Fix:** an exclusive `insufficient_credits` branch right after the `no_provider` gate, mirroring it one-for-one — warn/orange card, "Out of credits" title, server copy, **"Add credits"** CTA → existing `handleOpenSettings` (`setTab("settings")`). Theme-aware, no blue, no credit arithmetic touched.

**Verification** (`.github/issue-evidence/13962-out-of-credits-gate.md`): a real vitest test asserts the designed gate + CTA + `setTab("settings")` on click. **Local caveat:** the new *and all 4 pre-existing* tests in this file crash locally on `useRef` from a **stale `dist/node_modules/react`** symlink (build-artifact env issue, identical failure on untouched tests) — a fresh CI install resolves React, so CI verifies. The change mirrors the proven-green `no_provider` gate. (Created via REST — shared working tree in concurrent use.)