### PR TITLE
test(app/#13581): enforce the assistant-parser regression lane (was green-by-skip)

### DIFF
--- a/.github/issue-evidence/13581-parser-lane-enforcement/README.md
+++ b/.github/issue-evidence/13581-parser-lane-enforcement/README.md
@@ -1,0 +1,31 @@
+# #13581 verification — the merged parser regression lane was green-by-skip; now enforced
+
+## Verification (Needs-agent-verify pass)
+
+Reviewing the merged #13581 work (PRs #13918 + #14005), the parser logic and its
+14-case suite are genuinely real (pure `string→decision` parsers, a "renamed VIS
+→ ABSENT" regression canary, 61 assertions, no mocks-of-the-thing-under-test).
+
+**But the regression lane was not actually enforced.** The suite is
+`packages/app/scripts/lib/android-assistant-verify-lib.test.mjs`, which the
+`packages/app` vitest lane collects (its `include` covers
+`scripts/**/*.test.mjs`) — yet the file imported `test` from **`node:test`**.
+Under vitest those registrations are not collected, so vitest reported the file
+as **passed with "no tests"**: a parser regression would print a ✗ from node's
+runner but the CI lane stays green. That is exactly the green-by-skip the
+testing-loop epic (#13620/#13621/#13618) and #13581 itself exist to eliminate.
+
+## Fix
+
+One-line runner change: import `test` from `vitest` instead of `node:test`
+(the `node:assert/strict` assertions are unchanged — they throw on failure, so
+vitest fails the test identically). The suite now runs in the always-on
+`packages/app` lane.
+
+## Proof (`before.txt` / `after-negative.txt`)
+
+- **Before** (`node:test`): `Tests  no tests` — file "passed", nothing enforced.
+- **After** (`vitest`): `Tests  14 passed (14)` — collected and enforced.
+- **Negative** (corrupt `parseAssistantSurfaces` to defeat the canary): vitest
+  reports `Test Files  1 failed`, `× parseAssistantSurfaces treats a renamed VIS
+  as ABSENT (regression canary)` — the lane now goes red on a real regression.

--- a/.github/issue-evidence/13581-parser-lane-enforcement/after-negative.txt
+++ b/.github/issue-evidence/13581-parser-lane-enforcement/after-negative.txt
@@ -1,0 +1,8 @@
+AFTER (vitest import), clean:
+ Test Files  1 passed (1)
+      Tests  14 passed (14)
+
+NEGATIVE (parseAssistantSurfaces corrupted to defeat the canary):
+ × parseAssistantSurfaces treats a renamed VIS as ABSENT (regression canary)
+ Test Files  1 failed (1)
+      Tests  2 failed | 12 passed (14)

--- a/.github/issue-evidence/13581-parser-lane-enforcement/before.txt
+++ b/.github/issue-evidence/13581-parser-lane-enforcement/before.txt
@@ -1,0 +1,3 @@
+BEFORE (node:test import) — vitest collects zero:
+ Test Files  1 passed (1)
+      Tests  no tests

--- a/packages/app/scripts/lib/android-assistant-verify-lib.test.mjs
+++ b/packages/app/scripts/lib/android-assistant-verify-lib.test.mjs
@@ -1,15 +1,25 @@
 /**
- * Deterministic `node --test` coverage for the assistant-role/IME/assist-key
+ * Deterministic vitest coverage for the assistant-role/IME/assist-key
  * verification parsers (#13581). Fixtures are real-shaped `adb`/`dumpsys`/`cmd`/
  * `logcat` output slices, not mocks of the parser — the parsers are pure
  * string→decision functions, so this suite proves the string handling that
  * regresses silently off-device (a garbled scrape reading as "absent"), covering
  * the present, absent, short-vs-full component form, and empty/garbage cases.
  *
- * Run: `node --test packages/app/scripts/lib/android-assistant-verify-lib.test.mjs`
+ * Runs in the normal `packages/app` vitest lane (which collects
+ * `scripts/**\/*.test.mjs`) so a parser regression fails CI — the earlier
+ * `node:test` form was loaded by vitest but collected as ZERO tests, an
+ * unenforced green-by-skip.
+ *
+ * Run: `bun run --cwd packages/app test -- scripts/lib/android-assistant-verify-lib.test.mjs`
  */
 import assert from "node:assert/strict";
-import { test } from "node:test";
+// #13581 enforcement fix: run under vitest (the lane that collects
+// scripts/**/*.test.mjs) instead of node:test, which vitest loads but collects
+// as ZERO tests — a green-by-skip that left this regression guard unenforced.
+// node:assert still throws on failure, so every assertion below fails the
+// vitest test the same way; only the test-registration source changes.
+import { test } from "vitest";
 
 import {
   APP_PACKAGE,


### PR DESCRIPTION
Verification follow-up for elizaOS/os#2 (Needs-agent-verify).

## What I verified

Reviewing the merged elizaOS/os#2 work (#13918 + elizaOS/eliza#14005): the parser logic + 14-case suite are **genuinely real** — pure `string→decision` parsers, a "renamed VIS → ABSENT" regression canary, 61 assertions, real-shaped `adb`/`dumpsys` fixtures (no mocks of the thing under test), fail-loud device CI. Good work.

## The gap it left

The regression lane was **not actually enforced.** `packages/app/scripts/lib/android-assistant-verify-lib.test.mjs` is collected by the `packages/app` vitest lane (its `include` covers `scripts/**/*.test.mjs`), but the file imported `test` from **`node:test`**. Vitest loads such files but does **not** collect node:test registrations — so it reported the file as **passed with `Tests  no tests`**. A parser regression would print a ✗ from node's runner while the CI lane stayed green. That's precisely the green-by-skip the testing-loop epic (#13620 "green CI ≠ tested", elizaOS/eliza#13621 "make anti-larp signals gate", elizaOS/eliza#13618) — and elizaOS/os#2 itself — exist to eliminate.

## Fix

One-line runner change: import `test` from `vitest` instead of `node:test`. The `node:assert/strict` assertions are unchanged (they throw on failure, so vitest fails the test identically); only the registration source changes. The 14-case suite now runs in the always-on app lane.

## Proof (`.github/issue-evidence/13581-parser-lane-enforcement/`)

| State | Result |
|---|---|
| before (`node:test`) | `Tests  no tests` — file "passed", nothing enforced |
| after (`vitest`), clean | `Tests  14 passed (14)` |
| after, corrupt `parseAssistantSurfaces` to defeat the canary | `Test Files  1 failed` · `× ...regression canary` — lane now goes red |

```
bun run --cwd packages/app test -- scripts/lib/android-assistant-verify-lib.test.mjs
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

Pure test-lane wiring; no production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)