### PR TITLE
test(app-core): import conversation restore from agent api

### DIFF
--- a/packages/app-core/src/api/conversation-restore-relaunch.test.ts
+++ b/packages/app-core/src/api/conversation-restore-relaunch.test.ts
@@ -19,7 +19,7 @@
  * deleted-this-session id is never resurrected.
  */
 
-import { restoreConversationsFromDb } from "@elizaos/agent/api";
+import { restoreConversationsFromDb } from "@elizaos/agent/api/conversation-restore";
 import {
   type AgentRuntime,
   ChannelType,

--- a/packages/app-core/src/api/conversation-restore-relaunch.test.ts
+++ b/packages/app-core/src/api/conversation-restore-relaunch.test.ts
@@ -19,7 +19,7 @@
  * deleted-this-session id is never resurrected.
  */
 
-import { restoreConversationsFromDb } from "@elizaos/agent";
+import { restoreConversationsFromDb } from "@elizaos/agent/api";
 import {
   type AgentRuntime,
   ChannelType,


### PR DESCRIPTION
Follow-up to #14006.

The merged relaunch-persistence test imported `restoreConversationsFromDb` from the full `@elizaos/agent` barrel. In this checkout, that makes Vite analyze the agent runtime optional-plugin import table before the test even collects, failing on `@elizaos/plugin-native-filesystem` package-entry resolution.

This imports the helper from the narrower `@elizaos/agent/api` subpath instead. That is the package surface that owns `conversation-restore.ts`, avoids pulling runtime optional plugin imports into this app-core test, and preserves the same production helper under test.

Verification:

- `bunx biome check packages/app-core/src/api/conversation-restore-relaunch.test.ts`
- `bun run --cwd packages/app-core test -- src/api/conversation-restore-relaunch.test.ts` — 4 passed

No UI/model behavior; screenshots and trajectories are N/A.