### PR TITLE
fix(ui): reject native stream head on pre-head idle

### DIFF
--- a/packages/ui/src/api/native-agent-stream.test.ts
+++ b/packages/ui/src/api/native-agent-stream.test.ts
@@ -18,7 +18,10 @@ import {
 function makeFakeAgent(
   streamId = "s1",
   completion?: Promise<unknown>,
-  options: { addListenerDelayMs?: number } = {},
+  options: {
+    addListenerDelayMs?: number;
+    emitOnAdd?: { eventName: string; payload: unknown };
+  } = {},
 ) {
   const listeners = new Map<string, Array<(e: unknown) => void>>();
   const agent: NativeStreamingAgentPlugin = {
@@ -34,6 +37,9 @@ function makeFakeAgent(
       const arr = listeners.get(eventName) ?? [];
       arr.push(listener);
       listeners.set(eventName, arr);
+      if (options.emitOnAdd?.eventName === eventName) {
+        listener(options.emitOnAdd.payload);
+      }
       return {
         remove() {
           listeners.set(
@@ -296,6 +302,34 @@ describe("createNativeStreamingResponse", () => {
       // Stream stalls: the next chunk never comes.
       const readPromise = reader.read();
       const rejected = expect(readPromise).rejects.toThrow(
+        "native stream idle timeout",
+      );
+      await vi.advanceTimersByTimeAsync(30000);
+      await rejected;
+      expect(listenerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects the head if a chunk arrives before the response and then the stream stalls", async () => {
+    vi.useFakeTimers();
+    try {
+      const { agent, listenerCount } = makeFakeAgent("s1", undefined, {
+        emitOnAdd: {
+          eventName: "agentStreamChunk",
+          payload: {
+            streamId: "s1",
+            dataBase64: b64("data: early\n\n"),
+          },
+        },
+      });
+      const responsePromise = createNativeStreamingResponse(agent, {
+        path: "/x",
+        timeoutMs: 30000,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      const rejected = expect(responsePromise).rejects.toThrow(
         "native stream idle timeout",
       );
       await vi.advanceTimersByTimeAsync(30000);

--- a/packages/ui/src/api/native-agent-stream.ts
+++ b/packages/ui/src/api/native-agent-stream.ts
@@ -203,6 +203,10 @@ export async function createNativeStreamingResponse(
     idleTimer = setTimeout(() => {
       if (detached) return;
       const idle = new Error("native stream idle timeout");
+      if (!headSettled) {
+        failStream(idle);
+        return;
+      }
       if (controller) {
         controller.error(idle);
         detach();


### PR DESCRIPTION
Follow-up to #14010 / #13983.

During review of the merged native stream liveness fix, I found one remaining ordering edge: if a native chunk is delivered during listener registration before the response head and then the head is lost, the idle timer can fire before the head timer is armed. Without routing that pre-head idle through `failStream`, the body can error/detach while the returned head promise stays pending.

This changes the idle-timeout path to reject the head when the head has not settled yet, and adds a regression test that emits a chunk during listener registration before the head timer is armed.

Verification:

- `bun run --cwd packages/ui test -- src/api/native-agent-stream.test.ts` -> 1 file / 14 tests passed
- `bunx biome check packages/ui/src/api/native-agent-stream.ts packages/ui/src/api/native-agent-stream.test.ts .github/issue-evidence/13983-native-stream-liveness.md` -> clean

Refs #13983, #14010.