### PR TITLE
fix(ci): route ci-ok-critical jobs off billing-frozen hosted runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,12 @@ permissions:
 jobs:
   changes:
     name: Classify changed paths
-    runs-on: ubuntu-24.04
+    # Route with the same fleet-aware conditional as the test lanes. GitHub-hosted
+    # runners are billing-frozen (#13481), so a hardcoded ubuntu-24.04 here queued
+    # forever and — since every lane needs this classifier — stalled the entire
+    # ci-ok chain while the self-hosted fleet sat idle. Self-hosted when online;
+    # hosted only when an operator flags the fleet down (and billing is restored).
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     outputs:
       server: ${{ steps.filter.outputs.server }}
@@ -497,7 +502,8 @@ jobs:
       - changes
       - plugin-tests
     if: ${{ !cancelled() && always() }}
-    runs-on: ubuntu-24.04
+    # Fleet-aware (see `changes`): hardcoded hosted froze this ci-ok dependency.
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - name: Check plugin shard results
@@ -1270,12 +1276,14 @@ jobs:
   # fails biome lint, is unformatted, or commits a secret could still merge to
   # develop as long as tests passed (all of these are required on `main` but were
   # advisory on develop; #13617 F2). This job restores parity: it runs the same
-  # lint / format / typecheck / secret-scan gates that guard `main`, on a
-  # GitHub-hosted runner so it stays green-or-red regardless of the self-hosted
-  # fleet's health, and `ci-ok` needs it. It runs anywhere `ci-ok` treats
-  # skipped jobs as failures (merge queue, develop push, manual dispatch, and
-  # nightly schedule); on PRs quality.yml already covers this surface, so the job
-  # self-skips and `ci-ok`'s lenient PR path lets the skip pass.
+  # lint / format / typecheck / secret-scan gates that guard `main`, and `ci-ok`
+  # needs it. It runs anywhere `ci-ok` treats skipped jobs as failures (merge
+  # queue, develop push, manual dispatch, and nightly schedule); on PRs
+  # quality.yml already covers this surface, so the job self-skips and `ci-ok`'s
+  # lenient PR path lets the skip pass. Runner: fleet-aware like the test lanes —
+  # it was pinned to GitHub-hosted for independence from the self-hosted fleet,
+  # but with hosted runners billing-frozen (#13481) that pin froze this ci-ok
+  # dependency; route to self-hosted while the fleet is online.
   merge-quality-gate:
     name: Merge Queue Quality Gate
     needs: changes
@@ -1284,7 +1292,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -1390,7 +1398,10 @@ jobs:
       - cloud-live-e2e
       - provider-live-e2e
       - github-live-artifact-validate
-    runs-on: ubuntu-24.04
+    # Fleet-aware (see `changes`): the aggregate gate itself must run to report a
+    # conclusion — a hardcoded hosted pin froze `ci-ok` on the billing-frozen
+    # fleet (#13481), so the required check never posted and nothing could merge.
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - name: Check test results


### PR DESCRIPTION
## The entire develop merge queue is wedged — 0 PRs reach a `ci-ok` conclusion

**Root cause (100% confirmed):** four `ci-ok`-critical jobs in `test.yml` were hardcoded `runs-on: ubuntu-24.04`, but GitHub-hosted runners are **billing-frozen** (#13481). They queue forever while **30 self-hosted `hetzner-robot` runners sit online and idle**.

Evidence, sampled live on PR #14001 (`head 28730368054`):
- `Classify changed paths` job → `status: queued`, `labels: ["ubuntu-24.04"]` — waiting on a frozen runner that never comes.
- Tests workflow run → `status: queued` (not `action_required` — it is runner starvation, not approval).
- `gh api .../actions/runners` → `online: 30, online_idle: 30, online_busy: 0`.
- Every open non-draft PR → `ci-ok = null` (never concludes).

The four frozen jobs:
| job | why it stalls everything |
|---|---|
| `changes` (Classify changed paths) | ci-ok's upstream — **every** lane `needs:` it, so its eternal queue stops the whole chain |
| `plugin-tests-status` | ci-ok dependency |
| `merge-quality-gate` | ci-ok dependency (#13617 F2) |
| `ci-ok` itself | the required aggregate gate never runs → the check never posts |

This regressed when #13742/#13617 pinned the classifier + quality gate to hosted "for independence from the self-hosted fleet" — sound in principle, but incompatible with hosted billing being frozen (#13481, which moved everything else to self-hosted).

## Fix
Route all four to the **same fleet-aware conditional the other 16 `test.yml` jobs already use**:
```yaml
runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
```
Self-hosted while the fleet is online (it is → jobs run now); hosted only when an operator sets `HETZNER_FLEET_ONLINE=false` (and hosted billing is restored).

**No ruleset change, no `ci-ok` needs-list change, no vacuous green** — the gate still hard-requires the full typecheck/unit/integration/e2e set. After this, zero `runs-on: ubuntu-24.04` job pins remain in `test.yml`.

## Verification
- `python3 yaml.safe_load` → valid; `git diff --check` clean; the conditional string is **byte-identical** to the 16 working lines already in this file (so it parses + schedules exactly as they do).
- **Cannot pass `ci-ok` itself** — it fixes the very gate that is frozen (the chicken-and-egg #13481 documented). Admin-merge, then validate by watching a real PR's Tests run land jobs on self-hosted until `ci-ok` reports.

Strictly can't-make-it-worse: `ci-ok` is currently 100% frozen (0 conclusions); this can only let it conclude.