### PR TITLE
docs(ui): align first-run deep-link comments

### DIFF
--- a/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
+++ b/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
@@ -8,10 +8,10 @@
  *
  * Two surfaces are exercised:
  *
- *   1. `routeFirstRunDeepLink` — the pure URL parser that mutates
- *      `window.location` via `history.replaceState`. Tested directly so the
- *      assertions speak in terms of the produced query string, not React
- *      state.
+ *   1. `routeFirstRunDeepLink` — the URL parser that delegates matched
+ *      first-run links to the real reload helper. Tested directly so assertions
+ *      prove the app is forced back through first-run rather than only seeing
+ *      a query-string mutation.
  *   2. `installFirstRunDeepLinkListener` — the Capacitor wrapper that wires
  *      `App.addListener("appUrlOpen", ...)` and `App.getLaunchUrl()`. Tested
  *      with a mocked optional-peer `@capacitor/app`. The "Capacitor

--- a/packages/ui/src/first-run/deep-link-handler.ts
+++ b/packages/ui/src/first-run/deep-link-handler.ts
@@ -3,8 +3,9 @@
  *
  * iOS and Android wire `eliza://first-run/runtime/<id>` URLs through Capacitor's
  * `App.addListener("appUrlOpen", ...)`. The native shell hands the URL string
- * to the renderer; this module translates first-run paths into the query
- * contract consumed by the setup screen.
+ * to the renderer; this module routes first-run paths through the same reload
+ * helper used by the in-app runtime switcher, clearing the active server and
+ * forcing startup to re-enter first-run setup.
  *
  * Recognized runtime targets:
  *
@@ -12,7 +13,8 @@
  *   - `cloud`    -> selects cloud.
  *   - `remote`   -> selects remote.
  *
- * Unknown targets fall back to local first-run setup instead of a dead screen.
+ * Unknown targets force first-run setup without pinning a runtime target
+ * instead of landing on a dead screen.
  *
  * Defensive behavior:
  *


### PR DESCRIPTION
Follow-up to #14008 / #13984.

The merged runtime deep-link fix changed `routeFirstRunDeepLink` from an in-place `history.replaceState` query-param mutation to the real `reloadIntoFirstRunRuntime` path. A couple of file/test headers still described the old query-param/replaceState contract and unknown-target local fallback.

This is comment-only: update those headers to describe the live behavior accurately.

Verification:

- `bun run --cwd packages/ui test -- src/first-run/__tests__/deep-link-entry.test.ts` -> 1 file / 28 tests passed
- `bunx biome check packages/ui/src/first-run/deep-link-handler.ts packages/ui/src/first-run/__tests__/deep-link-entry.test.ts` -> clean

Refs #13984, #14008.