### PR TITLE
fix(import): charge huge attachments by rendered chunks

### DIFF
--- a/packages/import-conversations/src/core/preflight.test.ts
+++ b/packages/import-conversations/src/core/preflight.test.ts
@@ -322,6 +322,29 @@ describe("estimateBundleUsage", () => {
     expect(estimate.embeddingUnits).toBe(1);
   });
 
+  it("charges chunk-sized embedding units for a single huge attachment", () => {
+    const b = bundle([
+      conv({
+        sourceConversationId: "c1",
+        messages: [
+          {
+            role: "user",
+            text: "",
+            attachments: [
+              {
+                name: "export.txt",
+                kind: "extracted-text",
+                text: "attachment text ".repeat(4_500),
+              },
+            ],
+          },
+        ],
+      }),
+    ]);
+    const estimate = estimateBundleUsage(b, 100);
+    expect(estimate.embeddingUnits).toBeGreaterThan(1);
+  });
+
   it("counts the rendered transcript bytes that storage writes", () => {
     const b = bundle([
       conv({

--- a/packages/import-conversations/src/core/preflight.ts
+++ b/packages/import-conversations/src/core/preflight.ts
@@ -17,11 +17,14 @@
  * over-quota condition returns an explicit typed rejection rather than throwing.
  */
 
-import { renderConversation } from "./render.ts";
+import { DEFAULT_MAX_PART_TOKENS, renderConversation } from "./render.ts";
 import type { ConversationBundle } from "./types.ts";
 
 /** Bytes in one mebibyte — ceilings below read in MiB for legibility. */
 const MiB = 1024 * 1024;
+const ESTIMATED_BYTES_PER_TOKEN = 4;
+const ESTIMATED_EMBEDDING_UNIT_BYTES =
+  DEFAULT_MAX_PART_TOKENS * ESTIMATED_BYTES_PER_TOKEN;
 const UTF8_ENCODER = new TextEncoder();
 
 /** Configurable size ceilings for an import upload. */
@@ -249,10 +252,11 @@ export function preflightImport(
 /**
  * Derive a usage estimate from an already-parsed bundle for the post-parse cost
  * gate (the dry-run plan re-checks quota once real counts are known). Storage
- * is the byte length of the rendered transcript parts that the importer writes;
- * one embedding unit is charged per non-empty message as a conservative chunk
- * proxy. `uploadBytes` still comes from the transport and is passed through
- * unchanged.
+ * is the byte length of the rendered transcript parts that the importer writes.
+ * Embedding units are the larger of non-empty message count and rendered
+ * chunk-sized transcript units, so a single huge extracted attachment cannot
+ * undercharge the post-parse quota gate. `uploadBytes` still comes from the
+ * transport and is passed through unchanged.
  */
 export function estimateBundleUsage(
   bundle: ConversationBundle,
@@ -280,6 +284,11 @@ export function estimateBundleUsage(
       }
     }
   }
+  const renderedChunkUnits =
+    storageBytes > 0
+      ? Math.ceil(storageBytes / ESTIMATED_EMBEDDING_UNIT_BYTES)
+      : 0;
+  embeddingUnits = Math.max(embeddingUnits, renderedChunkUnits);
   return {
     uploadBytes,
     conversationCount: bundle.conversations.length,


### PR DESCRIPTION
Closes #14020.

## Summary
- keep the existing non-empty-message embedding estimate
- floor embedding units against rendered transcript chunk size so one huge extracted-text attachment cannot undercharge the post-parse quota gate
- add a regression for a single attachment-only message consuming multiple units

## Verification
- `bun run --cwd packages/import-conversations test` (12 files, 149 tests)
- `bun run --cwd packages/import-conversations typecheck`
- `biome check packages/import-conversations/src/core/preflight.ts packages/import-conversations/src/core/preflight.test.ts`
- `git diff --check`