### PR TITLE
fix(cloud): harden invite default api key provisioning

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/invite-accept-default-key.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/invite-accept-default-key.test.ts
@@ -347,6 +347,59 @@ describe("invite accept provisions the personal default API key", () => {
   );
 
   test(
+    "invite accept rejects when the required default-key mint fails",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario();
+      const originalProvision = apiKeysService.provisionDefaultApiKey;
+      apiKeysService.provisionDefaultApiKey = mock(async () => {
+        throw new Error("kms unavailable");
+      }) as typeof apiKeysService.provisionDefaultApiKey;
+
+      try {
+        await expect(
+          invitesService.acceptInvite(seeded.token, seeded.inviteeUserId),
+        ).rejects.toThrow("kms unavailable");
+      } finally {
+        apiKeysService.provisionDefaultApiKey = originalProvision;
+      }
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "concurrent default-key provisioning mints one active default key",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const organizationId = uid();
+      const userId = uid();
+
+      await dbWrite.insert(schemas.organizations).values({
+        id: organizationId,
+        name: "Team Org",
+        slug: `team-${organizationId}`,
+      });
+      await dbWrite.insert(schemas.users).values({
+        id: userId,
+        steward_user_id: `steward-${userId}`,
+        email: `user-${userId}@example.com`,
+        organization_id: organizationId,
+        role: "member",
+      });
+
+      await Promise.all([
+        apiKeysService.provisionDefaultApiKey(userId, organizationId),
+        apiKeysService.provisionDefaultApiKey(userId, organizationId),
+      ]);
+
+      const keys = await readActiveKeys(userId, organizationId);
+      expect(keys.length).toBe(1);
+      expect(keys[0].name).toBe("Default API Key");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
     "brand-new invited signup (steward-sync pending-invite branch) has the default key when sync resolves",
     async () => {
       expect(pgliteReady).toBe(true);

--- a/packages/cloud/shared/src/lib/services/api-keys.ts
+++ b/packages/cloud/shared/src/lib/services/api-keys.ts
@@ -5,8 +5,11 @@
  */
 
 import crypto from "crypto";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { dbWrite } from "../../db/client";
 import { encryptApiKey } from "../../db/crypto/api-keys";
 import { type ApiKey, apiKeysRepository, type NewApiKey } from "../../db/repositories";
+import { apiKeys } from "../../db/schemas/api-keys";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { API_KEY_PREFIX_LENGTH } from "../pricing";
@@ -237,43 +240,97 @@ export class ApiKeysService {
     apiKey: ApiKey;
     plainKey: string;
   }> {
+    const { apiKey, plainKey } = await this.buildApiKeyInsert(data);
+    const created = await apiKeysRepository.create(apiKey);
+
+    return {
+      apiKey: created,
+      plainKey,
+    };
+  }
+
+  private async buildApiKeyInsert(
+    data: Omit<
+      NewApiKey,
+      | "key_hash"
+      | "key_prefix"
+      | "key_ciphertext"
+      | "key_nonce"
+      | "key_auth_tag"
+      | "key_kms_key_id"
+      | "key_kms_key_version"
+    >,
+  ): Promise<{ apiKey: NewApiKey; plainKey: string }> {
     const { key, hash, prefix } = this.generateApiKey();
 
     // Pre-allocate the row id so the encryption AAD can bind to it.
     const rowId = crypto.randomUUID();
     const encrypted = await encryptApiKey(data.organization_id, rowId, key);
 
-    const apiKey = await apiKeysRepository.create({
-      ...data,
-      id: rowId,
-      key_hash: hash,
-      key_prefix: prefix,
-      key_ciphertext: encrypted.ciphertext,
-      key_nonce: encrypted.nonce,
-      key_auth_tag: encrypted.auth_tag,
-      key_kms_key_id: encrypted.kms_key_id,
-      key_kms_key_version: encrypted.kms_key_version,
-    });
-
     return {
-      apiKey,
+      apiKey: {
+        ...data,
+        id: rowId,
+        key_hash: hash,
+        key_prefix: prefix,
+        key_ciphertext: encrypted.ciphertext,
+        key_nonce: encrypted.nonce,
+        key_auth_tag: encrypted.auth_tag,
+        key_kms_key_id: encrypted.kms_key_id,
+        key_kms_key_version: encrypted.kms_key_version,
+      },
       plainKey: key,
     };
   }
 
   /**
-   * Idempotent default-key provisioning: every user gets one personal API key
-   * in their organization so inference works out of the box. The single mint
-   * shared by direct signup (steward-sync), invite accept (both the brand-new
-   * -user pending-invite branch and the existing-user org move), and the
-   * session-auth self-heal. Checks per-user, not per-org — a teammate's key
-   * must not satisfy it.
-   *
-   * Failure is logged, never thrown: every caller runs after the signup or
-   * accept has already committed, so throwing would fail a request whose real
-   * work succeeded. The failure stays observable (logger.error) and heals
-   * deterministically — getCurrentUserFromRequest re-runs this mint on the
-   * next session-cache-miss login.
+   * Required default-key provisioning for flows that must not report success
+   * until the user has a usable personal key in the target organization.
+   * The transaction takes a per-user/org advisory lock and re-checks the
+   * primary connection before inserting, so concurrent accept/sync paths cannot
+   * mint duplicate default keys.
+   */
+  async provisionDefaultApiKey(userId: string, organizationId: string): Promise<void> {
+    if (!userId?.trim() || !organizationId?.trim()) {
+      throw new Error("Invalid userId or organizationId for default API key provisioning");
+    }
+
+    await dbWrite.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext(${`default_api_key:${userId}:${organizationId}`}))`,
+      );
+
+      const now = new Date();
+      const existingKeys = await tx
+        .select()
+        .from(apiKeys)
+        .where(
+          and(
+            eq(apiKeys.user_id, userId),
+            eq(apiKeys.organization_id, organizationId),
+            eq(apiKeys.name, "Default API Key"),
+            eq(apiKeys.is_active, true),
+            isNull(apiKeys.deleted_at),
+          ),
+        );
+      if (existingKeys.some((key) => !key.expires_at || key.expires_at > now)) {
+        return;
+      }
+
+      const { apiKey } = await this.buildApiKeyInsert({
+        user_id: userId,
+        organization_id: organizationId,
+        name: "Default API Key",
+        is_active: true,
+      });
+      await tx.insert(apiKeys).values(apiKey);
+    });
+  }
+
+  /**
+   * Best-effort default-key self-heal for session resolution. Provisioning
+   * surfaces call `provisionDefaultApiKey` so they fail honestly; this wrapper
+   * keeps older session-cache-miss repair observable without taking down auth.
    */
   async ensureUserHasApiKey(userId: string, organizationId: string): Promise<void> {
     if (!userId?.trim() || !organizationId?.trim()) {
@@ -285,31 +342,11 @@ export class ApiKeysService {
     }
 
     try {
-      const now = new Date();
-      const existingKeys = await this.listByUser(userId);
-      if (
-        existingKeys.some(
-          (key) =>
-            key.organization_id === organizationId &&
-            key.is_active &&
-            key.deleted_at === null &&
-            (!key.expires_at || key.expires_at > now),
-        )
-      ) {
-        return;
-      }
-
-      await this.create({
-        user_id: userId,
-        organization_id: organizationId,
-        name: "Default API Key",
-        is_active: true,
-      });
+      await this.provisionDefaultApiKey(userId, organizationId);
     } catch (error) {
-      // error-policy:J1 provisioning boundary: signup/invite/session resolution
-      // has already committed, so a default-key mint failure is logged and
-      // retried by the next session-cache-miss self-heal rather than failing
-      // the completed account transition.
+      // error-policy:J7 diagnostics-must-not-kill-the-loop: this session heal
+      // is a retry path for older broken accounts; signup/invite call the strict
+      // provisioner and fail before reporting success.
       logger.error("[ApiKeysService] Failed to provision default API key", {
         userId,
         organizationId,

--- a/packages/cloud/shared/src/lib/services/invites.ts
+++ b/packages/cloud/shared/src/lib/services/invites.ts
@@ -194,6 +194,9 @@ export class InvitesService {
       role: invite.invited_role,
       updated_at: new Date(),
     });
+    if (!movedUser) {
+      throw new Error("Failed to move user into invited organization");
+    }
 
     const updatedInvite = await organizationInvitesRepository.markAsAccepted(invite.id, userId);
 
@@ -212,15 +215,12 @@ export class InvitesService {
       previousOrganizationId !== vacatedSoloOrgId
     ) {
       await apiKeysService.deactivateByUserAndOrganization(userId, previousOrganizationId);
+      await apiKeysService.invalidateInferenceContextForUser(userId);
     }
 
-    // The user's personal default key belongs to the org they left (a vacated
-    // solo org's cascade even deletes it), so without the same mint a direct
-    // signup gets they would join the team unable to use inference. Awaited:
-    // on Cloudflare Workers a floating promise is cancelled when the response
-    // returns. Idempotent and swallows its own errors — the accept has already
-    // committed.
-    await apiKeysService.ensureUserHasApiKey(userId, invite.organization_id);
+    // The old key is scoped to the org they left; invite accept must not return
+    // success until the new org has a usable personal default key.
+    await apiKeysService.provisionDefaultApiKey(userId, invite.organization_id);
 
     return updatedInvite;
   }

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -371,7 +371,10 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
       // without it an invited user cannot use inference until manually keyed.
       // Awaited for the same Workers-cancellation reason (see the note above
       // the branch-5 provisioning).
-      await apiKeysService.ensureUserHasApiKey(userWithOrg.id, userWithOrg.organization?.id || "");
+      await apiKeysService.provisionDefaultApiKey(
+        userWithOrg.id,
+        userWithOrg.organization?.id || "",
+      );
 
       return userWithOrg;
     }
@@ -709,9 +712,9 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
   // executionCtx.waitUntil, which this shared-lib function cannot reach — and a
   // cancelled create leaves the new user permanently without a default
   // character/API key (later logins return at the existing-user branch). Both
-  // helpers are idempotent and swallow their own errors, so awaiting cannot
-  // fail the signup.
-  await apiKeysService.ensureUserHasApiKey(userWithOrg.id, userWithOrg.organization?.id || "");
+  // default-key provisioning is required for signup to be usable; the default
+  // character helper keeps its own retry-on-next-session behavior.
+  await apiKeysService.provisionDefaultApiKey(userWithOrg.id, userWithOrg.organization?.id || "");
   await ensureDefaultCharacter(userWithOrg.id, userWithOrg.organization?.id || "");
 
   return {


### PR DESCRIPTION
## Summary

Follow-up to #13989 / #13987. The merged invite default-key fix now gets a required hardening pass:

- make default API key provisioning strict for signup/invite success paths; auth session repair remains best-effort
- serialize per-user/org default-key creation with an advisory transaction so concurrent accept/sync paths mint one active default key
- invalidate inference auth context after old-org key revocation during invite accept
- add regressions for mint failure semantics and concurrent default-key provisioning

## Verification

- `bun test --isolate packages/cloud/shared/src/lib/services/__tests__/invite-accept-default-key.test.ts` with coverage disabled locally: 6 pass / 0 fail / 25 expect() calls
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/api-keys.ts packages/cloud/shared/src/lib/services/invites.ts packages/cloud/shared/src/lib/steward-sync.ts packages/cloud/shared/src/lib/services/__tests__/invite-accept-default-key.test.ts --no-errors-on-unmatched`
- `git diff --check origin/develop...HEAD && git diff --check`
- `bun run audit:error-policy-ratchet -- --files packages/cloud/shared/src/lib/services/api-keys.ts packages/cloud/shared/src/lib/services/invites.ts packages/cloud/shared/src/lib/steward-sync.ts`

## Known unrelated local blocker

- `bun run --cwd packages/cloud/shared typecheck` still fails on existing transitive `plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts` duplicate `readAliasedEnv`, not on touched files.

UI/model evidence: N/A, backend provisioning/security path only. Domain artifacts are asserted directly in the PGlite-backed `api_keys` rows.