### PR TITLE
fix(desktop): repair capture denial and app details dispatch

### DIFF
--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -2100,7 +2100,9 @@ async function setupUpdater(): Promise<void> {
       return false;
     };
 
-    const handleAppEntryMenuAction = (action: string | undefined): boolean => {
+    const handleAppEntryMenuAction = async (
+      action: string | undefined,
+    ): Promise<boolean> => {
       if (!action?.startsWith("apps:") && !action?.startsWith("tray-app-")) {
         return false;
       }
@@ -2110,7 +2112,7 @@ async function setupUpdater(): Promise<void> {
       const entry = findAppMenuEntryBySlug(slug);
       if (!entry) return true;
       if (entry.hasDetailsPage) {
-        void restoreWindow();
+        await restoreWindow();
         sendToActiveRenderer("desktopAppDetailsRequested", {
           slug: entry.slug,
         });
@@ -2179,7 +2181,7 @@ async function setupUpdater(): Promise<void> {
       if (handleSettingsMenuAction(action)) return;
       if (handleSurfaceMenuAction(action)) return;
       if (handleStewardMenuAction(action)) return;
-      if (handleAppEntryMenuAction(action)) return;
+      if (await handleAppEntryMenuAction(action)) return;
       handleRuntimeMenuAction(action);
     };
 
@@ -2240,7 +2242,7 @@ async function handleDeepLink(url: string): Promise<void> {
       // review screen instead of a direct window so deep links and clicks
       // produce identical UX.
       if (entry.hasDetailsPage) {
-        void restoreWindow();
+        await restoreWindow();
         sendToActiveRenderer("desktopAppDetailsRequested", {
           slug: entry.slug,
         });

--- a/packages/app-core/platforms/electrobun/src/native/screencapture.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/screencapture.test.ts
@@ -1,0 +1,28 @@
+/** Deterministic state-machine tests for desktop frame capture admission. */
+
+import { describe, expect, it, vi } from "vitest";
+import { ScreenCaptureManager } from "./screencapture";
+
+vi.mock("electrobun/bun", () => ({
+  BrowserWindow: vi.fn(),
+}));
+
+describe("ScreenCaptureManager frame capture", () => {
+  it("does not wedge active after a blocked game capture URL", async () => {
+    const manager = new ScreenCaptureManager();
+
+    const first = await manager.startFrameCapture({
+      gameUrl: "https://evil.example/game",
+    });
+    const afterFirst = await manager.isFrameCaptureActive();
+    const second = await manager.startFrameCapture({
+      gameUrl: "https://evil.example/game",
+    });
+    const afterSecond = await manager.isFrameCaptureActive();
+
+    expect(first).toMatchObject({ available: false });
+    expect(afterFirst.active).toBe(false);
+    expect(second).toMatchObject({ available: false });
+    expect(afterSecond.active).toBe(false);
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/native/screencapture.ts
+++ b/packages/app-core/platforms/electrobun/src/native/screencapture.ts
@@ -528,13 +528,17 @@ $bmp.Dispose()`;
     this.frameCaptureActive = true;
 
     if (options?.gameUrl) {
-      return this.startGameCapture(
+      const result = await this.startGameCapture(
         options.gameUrl,
         fps,
         quality,
         endpoint,
         interval,
       );
+      if (!result.available) {
+        this.frameCaptureActive = false;
+      }
+      return result;
     }
 
     return this.startWebviewCapture(fps, quality, endpoint, interval);


### PR DESCRIPTION
Closes #14015.
Closes #14016.

## Summary
- reset `frameCaptureActive` when a game-capture URL is rejected so blocked starts do not wedge future captures as falsely active
- await main-window restoration before sending `desktopAppDetailsRequested` from app menu/tray and app deep-link routes
- add a regression for repeated blocked game-capture starts returning unavailable instead of a false healthy state

## Verification
- `bun ../../../scripts/run-vitest.mjs run --config vitest.electrobun.config.ts src/native/screencapture.test.ts src/desktop-deep-link-events.test.ts` (2 files, 8 tests)
- `biome check packages/app-core/platforms/electrobun/src/index.ts packages/app-core/platforms/electrobun/src/native/screencapture.ts packages/app-core/platforms/electrobun/src/native/screencapture.test.ts`
- `git diff --check`

## Typecheck
- `bun run --cwd packages/app-core typecheck` is blocked in this checkout by existing workspace resolution/type failures through `dist/node_modules` and unrelated packages (for example missing `drizzle-orm` declarations and missing `@elizaos/plugin-elizacloud/host-routes`).
- `bunx tsgo --noEmit -p packages/app-core/platforms/electrobun/tsconfig.json` is also blocked before this diff by existing Electrobun/workspace declaration failures, including missing `electrobun/bun` declarations and unrelated RPC schema errors.