### PR TITLE
fix(ci): install alias guard parser in path classifier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,12 @@ jobs:
       - name: Validate CI Bun version pin contract
         run: node packages/scripts/ci-bun-version-contract.mjs
 
+      - name: Install alias-read guard parser dependency
+        run: npm install --prefix "$RUNNER_TEMP/alias-read-guard-deps" --no-save --no-package-lock --ignore-scripts typescript@6.0.3
+
       - name: Validate brand-env alias-read guard self-test
+        env:
+          NODE_PATH: ${{ runner.temp }}/alias-read-guard-deps/node_modules
         run: node packages/scripts/alias-read-guard.mjs --self-test
 
       - name: Validate merge-gate robustness contract self-test


### PR DESCRIPTION
## Summary
- install the single `typescript` parser dependency before `alias-read-guard.mjs --self-test` in the Tests workflow path classifier
- keeps the classifier from failing before workspace dependencies exist

## Verification
- `node packages/scripts/ci-workflow-dedup-contract.mjs`
- `node packages/scripts/ci-bun-version-contract.mjs`
- `node packages/scripts/ci-path-gate.self-test.mjs`
- `node packages/scripts/alias-read-guard.mjs --self-test`
- `git diff --check`

This is the classifier failure currently blocking #14021 and other open PRs (`Cannot find module typescript` in `alias-read-guard.mjs --self-test`).