### PR TITLE
fix(core): trajectory-recorder suite red on develop — opt into the #13871 recording gate

### DIFF
--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -25,6 +25,7 @@ let tmpDir: string;
 const originalReviewMode = process.env.ELIZA_TRAJECTORY_REVIEW_MODE;
 const originalMarkdownDir = process.env.ELIZA_TRAJECTORY_MARKDOWN_DIR;
 const originalCerebrasKey = process.env.CEREBRAS_API_KEY;
+const originalTrajectoryLogging = process.env.ELIZA_TRAJECTORY_LOGGING;
 
 beforeEach(async () => {
 	tmpDir = await fs.mkdtemp(
@@ -33,6 +34,11 @@ beforeEach(async () => {
 	delete process.env.ELIZA_TRAJECTORY_REVIEW_MODE;
 	delete process.env.ELIZA_TRAJECTORY_MARKDOWN_DIR;
 	delete process.env.CEREBRAS_API_KEY;
+	// The unified gate (#13775) defaults recording OFF under NODE_ENV=test,
+	// which vitest sets; this suite exercises real file writes, so it opts in
+	// explicitly. The gate's default-off policy stays covered by
+	// trajectory-gate.test.ts and the gate-default test below.
+	process.env.ELIZA_TRAJECTORY_LOGGING = "1";
 });
 
 afterEach(async () => {
@@ -51,6 +57,11 @@ afterEach(async () => {
 		delete process.env.CEREBRAS_API_KEY;
 	} else {
 		process.env.CEREBRAS_API_KEY = originalCerebrasKey;
+	}
+	if (originalTrajectoryLogging === undefined) {
+		delete process.env.ELIZA_TRAJECTORY_LOGGING;
+	} else {
+		process.env.ELIZA_TRAJECTORY_LOGGING = originalTrajectoryLogging;
 	}
 });
 
@@ -789,6 +800,40 @@ describe("JsonFileTrajectoryRecorder", () => {
 		// No files should have been written.
 		const entries = await fs.readdir(tmpDir).catch(() => [] as string[]);
 		expect(entries).toEqual([]);
+	});
+
+	it("defaults to disabled under NODE_ENV=test when no trajectory knob is set (#13775 gate)", async () => {
+		delete process.env.ELIZA_TRAJECTORY_LOGGING;
+		const priorLegacyRecording = process.env.ELIZA_TRAJECTORY_RECORDING;
+		delete process.env.ELIZA_TRAJECTORY_RECORDING;
+		const priorNodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = "test";
+		try {
+			const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+			const id = recorder.startTrajectory({
+				agentId: "gate-default",
+				rootMessage: { id: "0", text: "n" },
+			});
+			await recorder.recordStage(id, {
+				stageId: "ignored",
+				kind: "planner",
+				startedAt: 1,
+				endedAt: 2,
+				latencyMs: 1,
+			});
+			await recorder.endTrajectory(id, "finished");
+
+			// The suite-level ELIZA_TRAJECTORY_LOGGING opt-in is load-bearing:
+			// a bare recorder under the test default stays dark and writes nothing.
+			const entries = await fs.readdir(tmpDir).catch(() => [] as string[]);
+			expect(entries).toEqual([]);
+		} finally {
+			if (priorNodeEnv === undefined) delete process.env.NODE_ENV;
+			else process.env.NODE_ENV = priorNodeEnv;
+			if (priorLegacyRecording === undefined)
+				delete process.env.ELIZA_TRAJECTORY_RECORDING;
+			else process.env.ELIZA_TRAJECTORY_RECORDING = priorLegacyRecording;
+		}
 	});
 
 	it("writes redacted markdown review artifacts when review mode is enabled", async () => {

--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -26,6 +26,8 @@ const originalReviewMode = process.env.ELIZA_TRAJECTORY_REVIEW_MODE;
 const originalMarkdownDir = process.env.ELIZA_TRAJECTORY_MARKDOWN_DIR;
 const originalCerebrasKey = process.env.CEREBRAS_API_KEY;
 const originalTrajectoryLogging = process.env.ELIZA_TRAJECTORY_LOGGING;
+const originalDisableTrajectoryLogging =
+	process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING;
 
 beforeEach(async () => {
 	tmpDir = await fs.mkdtemp(
@@ -34,6 +36,7 @@ beforeEach(async () => {
 	delete process.env.ELIZA_TRAJECTORY_REVIEW_MODE;
 	delete process.env.ELIZA_TRAJECTORY_MARKDOWN_DIR;
 	delete process.env.CEREBRAS_API_KEY;
+	delete process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING;
 	// The unified gate (#13775) defaults recording OFF under NODE_ENV=test,
 	// which vitest sets; this suite exercises real file writes, so it opts in
 	// explicitly. The gate's default-off policy stays covered by
@@ -62,6 +65,12 @@ afterEach(async () => {
 		delete process.env.ELIZA_TRAJECTORY_LOGGING;
 	} else {
 		process.env.ELIZA_TRAJECTORY_LOGGING = originalTrajectoryLogging;
+	}
+	if (originalDisableTrajectoryLogging === undefined) {
+		delete process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING;
+	} else {
+		process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING =
+			originalDisableTrajectoryLogging;
 	}
 });
 
@@ -806,6 +815,8 @@ describe("JsonFileTrajectoryRecorder", () => {
 		delete process.env.ELIZA_TRAJECTORY_LOGGING;
 		const priorLegacyRecording = process.env.ELIZA_TRAJECTORY_RECORDING;
 		delete process.env.ELIZA_TRAJECTORY_RECORDING;
+		const priorDisableLogging = process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING;
+		delete process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING;
 		const priorNodeEnv = process.env.NODE_ENV;
 		process.env.NODE_ENV = "test";
 		try {
@@ -833,6 +844,9 @@ describe("JsonFileTrajectoryRecorder", () => {
 			if (priorLegacyRecording === undefined)
 				delete process.env.ELIZA_TRAJECTORY_RECORDING;
 			else process.env.ELIZA_TRAJECTORY_RECORDING = priorLegacyRecording;
+			if (priorDisableLogging === undefined)
+				delete process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING;
+			else process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING = priorDisableLogging;
 		}
 	});
 


### PR DESCRIPTION
## Summary

Regression from the launch-QA churn, on a demo-critical surface: the trajectory-recorder suite is red on `develop` — 32 of 49 tests fail with `ENOENT` on every expected trajectory file.

#13871 (`0e1432aff1`, "trace-correlation envelope + unified gate + child-trajectory ingest") introduced the unified trajectory gate and made the file recorder delegate its default to it (`trajectory-recorder.ts` → `resolveTrajectoryGate()`). The gate returns `{enabled:false, reason:'test-default-off'}` under `NODE_ENV=test` (`trajectory-gate.ts:63-64`), which vitest always sets — but the 49-test recorder suite was not updated: it constructs bare `createJsonFileTrajectoryRecorder({rootDir})` and asserts real file writes, so every write-asserting test now reads a file that was never written.

The gate semantics themselves are correct and intentional (SOC2 O-5, test-runner hygiene) and stay untouched — this PR opts the suite into recording explicitly, matching #13871's intended contract.

### Bisect proof (identical env, `node ../scripts/run-vitest.mjs run src/runtime/__tests__/trajectory-recorder.test.ts`)

| rev | result |
| --- | --- |
| `0e1432aff1^` (parent) | 49/49 pass |
| `0e1432aff1` (#13871) | 32 failed / 17 passed |
| `646720603a` (develop tip, pre-fix) | 32 failed / 17 passed |
| develop tip + this fix | 50/50 pass |

Not env-specific: core `vitest.config.ts` injects no trajectory env; the suite is red under a plain scoped run.

## Fix (test-only, +45 lines)

- Suite-level `beforeEach` sets `ELIZA_TRAJECTORY_LOGGING="1"` (the canonical knob, which beats the NODE_ENV default by gate precedence); `afterEach` restores the original value — same save/restore idiom the suite already uses for `ELIZA_TRAJECTORY_REVIEW_MODE` / `ELIZA_TRAJECTORY_MARKDOWN_DIR`.
- New guard test pins the changed seam at the recorder level: with the knobs cleared and `NODE_ENV=test`, a bare recorder stays dark and writes nothing (`defaults to disabled under NODE_ENV=test when no trajectory knob is set`). Gate-default policy coverage remains in `trajectory-gate.test.ts` (untouched, still green).
- Mutation-verified the guard bites: temporarily restoring the pre-#13871 default (`envFlagEnabled("ELIZA_TRAJECTORY_RECORDING", true)`) makes the new test fail; reverted.

## Verification (real runs, no mocks)

- Red reproduced pre-fix at `0e1432aff1` and at develop tip: `Tests 32 failed | 17 passed (49)`, first failure `ENOENT: no such file or directory, open '.../agent-test/tj-….json'`.
- Mechanism proven on unmodified code: same suite with `ELIZA_TRAJECTORY_LOGGING=1` → 49/49.
- Post-fix: recorder suite 50/50; recorder + gate suites together 58/58.
- Full core runtime lane: `run src/runtime` → 79 files / 948 tests, all pass.
- `bun run --cwd packages/core typecheck` → exit 0 (test files are tsconfig-excluded; production sources untouched).
- Only diff: `packages/core/src/runtime/__tests__/trajectory-recorder.test.ts`, +45.

## Deploy note (behavior surface of #13871, not changed here)

Production is now opt-in by design (`trajectory-gate.ts:67-68`, SOC2 O-5): live deploys that rely on trajectory capture for debugging must set `ELIZA_TRAJECTORY_LOGGING=1`, or they silently stop recording under `NODE_ENV=production`.

## PR_EVIDENCE

- Real-LLM trajectories: N/A — test-harness-only change; no agent/action/prompt/model behavior touched (the recorder writes hand-fed fixtures to a temp dir).
- Backend/frontend logs, screenshots, video: N/A — no runtime or UI surface; evidence is the vitest red→green outputs above, reproducible with the scoped command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
