### PR TITLE
fix: restore uncapped listConnectorRooms clobbered by merge race (channel counts past 50)

### DIFF
--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -2152,7 +2152,12 @@ export class DiscordService extends Service implements IDiscordService {
 				}
 			}
 		}
-		return this.dedupeConnectorTargets(targets).slice(0, 50);
+		// The complete set is the contract: list_channels/list_connections derive
+		// channel + muted counts from the returned length, so any cap here makes
+		// those counts silently wrong past the cap. The gateway cache already
+		// holds every channel per guild (GUILD_CREATE delivers the full list);
+		// bounding what gets rendered is the op layer's job.
+		return this.dedupeConnectorTargets(targets);
 	}
 
 	public async listRecentConnectorTargets(


### PR DESCRIPTION
## What happened

Regression from the launch-QA churn (merge race, same day, both Jul 4), demo-critical path:

- `167a021ff7` (20:28 UTC) removed the flat cross-guild `slice(0, 50)` in discord `listConnectorRooms` — `list_channels`/`list_connections` derive channel + muted counts from the returned length, so the cap made those counts silently wrong on any deployment past 50 channels.
- `fd6ccb1ebb` (20:53 UTC, the mute/list_servers fix) branched from a pre-fix tree (`git merge-base --is-ancestor 167a021ff7 fd6ccb1ebb` = not an ancestor) and its whole-file `service.ts` won the merge, silently reinstating the cap.
- The fix's own regression test survived the clobber and fails on develop tip: `__tests__/connector-rooms.test.ts` "returns every text channel across all guilds, past 50" — expected 75, got 50.

`git show 167a021ff7:plugins/plugin-discord/service.ts | grep -c 'slice(0, 50)'` = 0; same grep on `fd6ccb1ebb` and develop tip = 1.

## Fix

Restore the plugin half of `167a021ff7`: return the complete deduped set from `listConnectorRooms` (contract comment restored verbatim). The core half survived the merge and still bounds rendering (`MAX_LISTED_CHANNELS` in `packages/core/src/features/advanced-capabilities/actions/message.ts`), and `listRecentConnectorTargets` keeps its intended `slice(0, 25)`. One hunk, +6/-1.

## Evidence

- Before (develop tip, unfixed): `bunx vitest run __tests__/connector-rooms.test.ts` → **1 failed | 1 passed** (expected 75, got 50; deterministic pure logic, no env).
- After (this branch): same command → **2 passed**.
- Full plugin-discord unit suite: 219 passed, 4 failed — the same 4 media-fetch (`fetchGuardedMedia`) failures reproduce identically on unfixed develop tip in this sandbox, zero delta from this change.
- `bun run --cwd plugins/plugin-discord typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
