### PR TITLE
fix: list_connections surfaces listRooms failure instead of fabricating roomCount 0

### DIFF
--- a/packages/core/src/features/advanced-capabilities/actions/message.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.test.ts
@@ -122,7 +122,10 @@ describe("MESSAGE op=list_connections", () => {
 		expect(data.connectionCount).toBe(2);
 	});
 
-	it("a failing connector still appears with roomCount 0", async () => {
+	it("a failing connector appears as unavailable, distinguishable from a genuinely-empty one", async () => {
+		// "Not loaded must never read as zero": a connector whose listRooms throws
+		// must carry an explicit error state (roomCount null + error), while a
+		// connector that really has zero rooms reports roomCount 0 with no error.
 		const broken = {
 			source: "x",
 			label: "X",
@@ -136,14 +139,33 @@ describe("MESSAGE op=list_connections", () => {
 		const runtime = mockRuntime([
 			broken,
 			mockConnector("discord", "Discord", ["#general"]),
+			mockConnector("matrix", "Matrix", []),
 		]);
 		const result = await listConnections(runtime);
 		const data = result.data as {
-			connections: { platform: string; roomCount: number }[];
+			connections: {
+				platform: string;
+				roomCount: number | null;
+				mutedRoomCount: number | null;
+				error?: string;
+			}[];
 		};
 		const x = data.connections.find((c) => c.platform === "x");
 		expect(x).toBeDefined();
-		expect(x?.roomCount).toBe(0);
+		expect(x?.roomCount).toBeNull();
+		expect(x?.mutedRoomCount).toBeNull();
+		expect(x?.error).toContain("connector offline");
+		// the summary flags the broken connector, not just the data payload
+		expect(result.text).toContain("X (unavailable)");
+		// healthy connectors in the same roster keep their real counts
+		const discord = data.connections.find((c) => c.platform === "discord");
+		expect(discord?.roomCount).toBe(1);
+		expect(discord?.error).toBeUndefined();
+		// genuinely empty is a real zero, NOT an error state
+		const matrix = data.connections.find((c) => c.platform === "matrix");
+		expect(matrix?.roomCount).toBe(0);
+		expect(matrix?.error).toBeUndefined();
+		expect(result.text).not.toContain("Matrix (unavailable)");
 	});
 
 	it("bounds the roster at 8 connectors", async () => {

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -2929,8 +2929,11 @@ async function handleListConnections(
 		platform: string;
 		label: string;
 		accountId: string | undefined;
-		roomCount: number;
-		mutedRoomCount: number;
+		// null = the count could not be resolved (see `error`) — a broken
+		// connector must never read as a healthy zero-room connection.
+		roomCount: number | null;
+		mutedRoomCount: number | null;
+		error?: string;
 	}> = [];
 
 	for (const connector of connectors) {
@@ -2947,8 +2950,9 @@ async function handleListConnections(
 			undefined,
 			connector,
 		);
-		let roomCount = 0;
-		let mutedRoomCount = 0;
+		let roomCount: number | null = null;
+		let mutedRoomCount: number | null = null;
+		let listError: string | undefined;
 		try {
 			const targets = (await connector.listRooms?.(context)) ?? [];
 			roomCount = targets.length;
@@ -2956,10 +2960,11 @@ async function handleListConnections(
 				Boolean,
 			).length;
 		} catch (error) {
+			// error-policy:J4 one broken connector must not hide the healthy ones;
+			// its entry carries an explicit error instead of a fabricated count.
+			listError = error instanceof Error ? error.message : String(error);
 			logger.debug(
-				`[MESSAGE/list_connections] listRooms failed for ${connector.source}: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
+				`[MESSAGE/list_connections] listRooms failed for ${connector.source}: ${listError}`,
 			);
 		}
 		connections.push({
@@ -2968,10 +2973,13 @@ async function handleListConnections(
 			accountId: connector.accountId,
 			roomCount,
 			mutedRoomCount,
+			...(listError === undefined ? {} : { error: listError }),
 		});
 	}
 
-	const labels = connections.map((c) => c.label);
+	const labels = connections.map((c) =>
+		c.error === undefined ? c.label : `${c.label} (unavailable)`,
+	);
 	return opSuccess(
 		"list_connections",
 		`Connected via ${connections.length} connection(s): ${labels.join(", ")}.`,


### PR DESCRIPTION
## What happened

`list_connections` (`packages/core/src/features/advanced-capabilities/actions/message.ts`, `handleListConnections`) iterates every connector exposing `listRooms` and reports a per-platform summary. The `catch` around `listRooms()` only logged at debug level and fell through to push `{roomCount: 0, mutedRoomCount: 0}` — so a **broken** connector (auth expired, API down, listRooms throwing) rendered as a **healthy connector with legitimately zero rooms**. The agent then answers "connected to X, 0 rooms" instead of surfacing that X is broken.

This is the banned fabricated-healthy-empty pattern from the root error doctrine: "**Not loaded must never read as zero/empty**" — a catch substituting a default for failed data conflates a broken pipeline with a legitimately empty result. A unit test (`"a failing connector still appears with roomCount 0"`) was locking the defective behavior in.

## Fix

Structural, in the DTO (J4 explicit user-facing degrade, annotated `// error-policy:J4`):

- A connector whose room listing throws now reports `roomCount: null`, `mutedRoomCount: null`, and an explicit `error: "<message>"` field — never a fabricated count. `null` = could-not-resolve, `0` = genuinely empty; the two are distinguishable.
- The summary text marks the broken connector `<label> (unavailable)` so the failure reaches the model through the text the planner reads, not just the data payload.
- Healthy connectors in the same roster keep their real counts; one broken connector no longer hides (or is hidden by) the healthy ones.
- The locking test is rewritten to assert the distinguishability contract: throwing connector → `null` + `error` + `(unavailable)` label; empty connector → `0` and no error; healthy connector → real counts.

No new throw site (the failure surfaces to the model via the action result on the action path, per doctrine), so no new `ElizaError`/`reportError` needed; debug log retained for operators.

## Evidence

- **Before (develop tip, unfixed):** `bunx vitest run src/features/advanced-capabilities/actions/message.test.ts` → **1 failed | 11 passed** — fails exactly on the fabrication: `AssertionError: expected +0 to be null` for the throwing connector (deterministic mock connectors, no env).
- **After (this branch, rebased on develop tip):** same file + adjacent `message.list-muted.test.ts` → **19 passed (19)**.
- `bun run --cwd packages/core typecheck` (tsgo) → clean, exit 0.
- `bun run audit:error-policy-ratchet` → `packages/core/src/.../message.ts: emptyCatch 3->3, serverConsole 0->0 — no new fallback-slop in touched files`.
- Only consumer of this DTO is the action result itself (grep: `roomCount` elsewhere is the unrelated world provider; cloud `connectionCount` matches are separate MCP/OAuth listings) — no downstream reader breaks on `null`.
- Screenshots/video: N/A — server-side action DTO change, no UI surface.
- Live-LLM trajectory: N/A — no prompt/model-call change; the handler is deterministic action code exercised end-to-end by the real handler in the suite above.

Finding + fix signed [core-brain].

🤖 Generated with [Claude Code](https://claude.com/claude-code)
