### PR TITLE
fix: refresh workbench todos from live events

### DIFF
--- a/packages/ui/src/components/chat/widgets/todo.test.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.test.tsx
@@ -116,6 +116,71 @@ describe("TodoSidebarWidget", () => {
     });
   });
 
+  it("refreshes immediately when a workbench todo change event arrives", async () => {
+    listWorkbenchTodosMock
+      .mockResolvedValueOnce({
+        todos: [
+          {
+            id: "cached-1",
+            name: "Cached todo",
+            description: "",
+            type: "task",
+            isCompleted: false,
+            isUrgent: false,
+            priority: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        todos: [
+          {
+            id: "live-1",
+            name: "Live todo",
+            description: "",
+            type: "task",
+            isCompleted: false,
+            isUrgent: false,
+            priority: null,
+          },
+        ],
+      });
+
+    const { rerender } = render(
+      <TodoWidget slot="chat-sidebar" events={[]} clearEvents={vi.fn()} />,
+    );
+
+    await waitFor(() => {
+      expect(listWorkbenchTodosMock).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <TodoWidget
+        slot="chat-sidebar"
+        clearEvents={vi.fn()}
+        events={[
+          {
+            id: "evt-workbench-1",
+            timestamp: Date.now(),
+            eventType: "workbench.todo.changed",
+            summary: "Todo updated",
+            source: {
+              type: "agent_event",
+              stream: "workbench",
+              data: {
+                type: "workbench.todo.changed",
+                operation: "created",
+                todoId: "live-1",
+              },
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(await screen.findByText("Live todo")).toBeTruthy();
+    expect(listWorkbenchTodosMock).toHaveBeenCalledTimes(2);
+  });
+
   it("home slot: applies the host-supplied spanClassName to its single root grid-item element (#11752)", async () => {
     // Hold the cached todo (no poll) so the card stays rendered while asserting.
     authMock.authenticated = false;

--- a/packages/ui/src/components/chat/widgets/todo.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.tsx
@@ -1,7 +1,7 @@
 /**
  * Chat-sidebar (and home-grid) TODO widget: lists the agent workbench's todos,
- * seeded from the app store's `workbench.todos` and refreshed by a poll that
- * runs only while authenticated and the document is visible. Exports
+ * seeded from the app store's `workbench.todos`, refreshed on live workbench
+ * events, and backed by a visible-tab poll for missed events. Exports
  * `TODO_PLUGIN_WIDGETS`, the widget-registry entry consumed by the sidebar.
  */
 import { ListTodo } from "lucide-react";
@@ -53,6 +53,22 @@ function dedupeTodos(todos: WorkbenchTodo[]): WorkbenchTodo[] {
     byId.set(todo.id, todo);
   }
   return sortTodosForWidget([...byId.values()]);
+}
+
+function isWorkbenchTodoChangeEvent(
+  event: ChatSidebarWidgetProps["events"][number],
+): boolean {
+  const source = event.source;
+  if (source?.type !== "agent_event" || source.stream !== "workbench") {
+    return false;
+  }
+  const data = source.data;
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "type" in data &&
+    data.type === "workbench.todo.changed"
+  );
 }
 
 function TodoRow({ todo }: { todo: WorkbenchTodo }) {
@@ -150,6 +166,7 @@ function TodoItemsContent({
 }
 
 function TodoSidebarWidget({
+  events,
   slot,
   spanClassName = "col-span-2 row-span-1",
 }: ChatSidebarWidgetProps) {
@@ -165,6 +182,7 @@ function TodoSidebarWidget({
     dedupeTodos(workbench?.todos ?? []),
   );
   const [todosLoading, setTodosLoading] = useState(false);
+  const lastHandledTodoEventIdRef = useRef<string | null>(null);
 
   // The async todo fetch can resolve after the widget unmounts; guard the
   // post-await state writes so a late `finally` doesn't setState on an
@@ -218,8 +236,22 @@ function TodoSidebarWidget({
   useEffect(() => {
     void loadTodos(todos.length > 0);
   }, [loadTodos, todos.length]);
+
+  useEffect(() => {
+    const latestTodoEvent = events.find(isWorkbenchTodoChangeEvent);
+    if (
+      !latestTodoEvent ||
+      latestTodoEvent.id === lastHandledTodoEventIdRef.current
+    ) {
+      return;
+    }
+    lastHandledTodoEventIdRef.current = latestTodoEvent.id;
+    void loadTodos(true);
+  }, [events, loadTodos]);
+
   // Refresh only while the document is visible — pause the silent poll in a
-  // backgrounded app/tab instead of refetching the todo list every interval.
+  // backgrounded app/tab. Live workbench events do the normal foreground
+  // refresh; this poll is just a missed-event repair path.
   useIntervalWhenDocumentVisible(
     () => void loadTodos(true),
     TODO_REFRESH_INTERVAL_MS,

--- a/packages/ui/src/hooks/useActivityEvents.ts
+++ b/packages/ui/src/hooks/useActivityEvents.ts
@@ -48,6 +48,12 @@ function readFiniteNumber(value: unknown): number | undefined {
     : undefined;
 }
 
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
 function agentEventSource(data: Record<string, unknown>): ActivityEventSource {
   return {
     type: "agent_event",
@@ -59,6 +65,25 @@ function agentEventSource(data: Record<string, unknown>): ActivityEventSource {
     agentId: readString(data.agentId),
     roomId: readString(data.roomId),
     sessionKey: readString(data.sessionKey),
+  };
+}
+
+function workbenchFallbackActivity(
+  source: ActivityEventSource,
+): { eventType: string; plaintext: string; sessionId?: string } | null {
+  if (source.stream !== "workbench") {
+    return null;
+  }
+  const payload = readRecord(source.data);
+  if (payload?.type !== "workbench.todo.changed") {
+    return null;
+  }
+  const operation = readString(payload.operation) ?? "updated";
+  const todo = readRecord(payload.todo);
+  const name = readString(todo?.name);
+  return {
+    eventType: "workbench.todo.changed",
+    plaintext: name ? `Todo ${operation}: ${name}` : `Todo ${operation}`,
   };
 }
 
@@ -155,11 +180,13 @@ export function useActivityEvents() {
     const unbindAgent = client.onWsEvent(
       "agent_event",
       (data: Record<string, unknown>) => {
-        const activity = activityEventToPlaintext(data, { maxLength: 120 });
+        const source = agentEventSource(data);
+        const activity =
+          activityEventToPlaintext(data, { maxLength: 120 }) ??
+          workbenchFallbackActivity(source);
         if (!activity) {
           return;
         }
-        const source = agentEventSource(data);
         pushEvent({
           timestamp: source.ts ?? Date.now(),
           eventType: activity.eventType,

--- a/plugins/plugin-workflow/__tests__/unit/routes/workbench-todos.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/routes/workbench-todos.test.ts
@@ -12,14 +12,32 @@ import { handleWorkbenchTodosRoutes } from '../../../src/routes/workbench-todos'
 interface TaskStore {
   runtime: AgentRuntime;
   tasks: Map<string, Task>;
+  emittedEvents: Array<{
+    runId: string;
+    stream: string;
+    data: Record<string, unknown>;
+    agentId?: string;
+  }>;
   seed: (task: Partial<Task> & { id: string }) => void;
 }
 
 function createTaskRuntime(): TaskStore {
   const tasks = new Map<string, Task>();
+  const emittedEvents: TaskStore['emittedEvents'] = [];
   let counter = 0;
 
   const runtime = {
+    agentId: 'agent-test',
+    getService(serviceType: string) {
+      if (serviceType !== 'agent_event' && serviceType !== 'AGENT_EVENT') {
+        return null;
+      }
+      return {
+        emit(event: TaskStore['emittedEvents'][number]) {
+          emittedEvents.push(event);
+        },
+      };
+    },
     async getTasks(_params: Record<string, unknown>): Promise<Task[]> {
       return [...tasks.values()];
     },
@@ -45,6 +63,7 @@ function createTaskRuntime(): TaskStore {
   return {
     runtime,
     tasks,
+    emittedEvents,
     seed: (task) => tasks.set(task.id, task as Task),
   };
 }
@@ -235,6 +254,43 @@ describe('workbench todos CRUD route', () => {
 
     const again = await call(store.runtime, 'DELETE', `/api/workbench/todos/${id}`);
     expect(again.status).toBe(404);
+  });
+
+  test('mutations emit workbench todo change events for live clients', async () => {
+    const created = await call(store.runtime, 'POST', '/api/workbench/todos', {
+      name: 'Track live updates',
+    });
+    const id = (created.body as { todo: { id: string } }).todo.id;
+
+    await call(store.runtime, 'PUT', `/api/workbench/todos/${id}`, {
+      name: 'Track live update events',
+    });
+    await call(store.runtime, 'POST', `/api/workbench/todos/${id}/complete`, {
+      isCompleted: true,
+    });
+    await call(store.runtime, 'DELETE', `/api/workbench/todos/${id}`);
+
+    expect(store.emittedEvents.map((event) => event.stream)).toEqual([
+      'workbench',
+      'workbench',
+      'workbench',
+      'workbench',
+    ]);
+    expect(store.emittedEvents.map((event) => event.data.operation)).toEqual([
+      'created',
+      'updated',
+      'completed',
+      'deleted',
+    ]);
+    expect(store.emittedEvents.map((event) => event.data.type)).toEqual([
+      'workbench.todo.changed',
+      'workbench.todo.changed',
+      'workbench.todo.changed',
+      'workbench.todo.changed',
+    ]);
+    expect(store.emittedEvents.map((event) => event.data.todoId)).toEqual([id, id, id, id]);
+    expect(store.emittedEvents[0]?.data.todo).toMatchObject({ id, name: 'Track live updates' });
+    expect(store.emittedEvents[3]?.data.todo).toBeUndefined();
   });
 
   test('returns 503 when the runtime is unavailable', async () => {

--- a/plugins/plugin-workflow/src/routes/workbench-todos.ts
+++ b/plugins/plugin-workflow/src/routes/workbench-todos.ts
@@ -13,7 +13,14 @@
  */
 
 import type http from 'node:http';
-import { type AgentRuntime, sendJson, sendJsonError, type Task, type UUID } from '@elizaos/core';
+import {
+  type AgentRuntime,
+  logger,
+  sendJson,
+  sendJsonError,
+  type Task,
+  type UUID,
+} from '@elizaos/core';
 import {
   PostWorkbenchTodoCompleteRequestSchema,
   PostWorkbenchTodoRequestSchema,
@@ -44,6 +51,17 @@ export interface WorkbenchTodosRouteContext {
   method: string;
   pathname: string;
   runtime: AgentRuntime | null;
+}
+
+type WorkbenchTodoMutation = 'created' | 'updated' | 'completed' | 'deleted';
+
+interface AgentEventEmitterLike {
+  emit(event: {
+    runId: string;
+    stream: string;
+    data: Record<string, unknown>;
+    agentId?: string;
+  }): void;
 }
 
 function parseNullableNumber(value: unknown): number | null {
@@ -118,6 +136,52 @@ function readJsonObjectBody(req: http.IncomingMessage): Record<string, unknown> 
   return {};
 }
 
+function getAgentEventEmitter(runtime: AgentRuntime): AgentEventEmitterLike | null {
+  const runtimeWithServices = runtime as {
+    getService?: (serviceType: string) => unknown;
+    agentId?: string;
+  };
+  const service =
+    runtimeWithServices.getService?.('agent_event') ??
+    runtimeWithServices.getService?.('AGENT_EVENT');
+  if (service && typeof (service as AgentEventEmitterLike).emit === 'function') {
+    return service as AgentEventEmitterLike;
+  }
+  return null;
+}
+
+function emitWorkbenchTodoChanged(
+  runtime: AgentRuntime,
+  operation: WorkbenchTodoMutation,
+  todoId: string,
+  todo?: WorkbenchTodoView
+): void {
+  const emitter = getAgentEventEmitter(runtime);
+  if (!emitter) return;
+
+  try {
+    emitter.emit({
+      runId: 'workbench-todos',
+      stream: 'workbench',
+      agentId: (runtime as { agentId?: string }).agentId,
+      data: {
+        type: 'workbench.todo.changed',
+        operation,
+        todoId,
+        ...(todo ? { todo } : {}),
+      },
+    });
+  } catch (error) {
+    // error-policy:J7 diagnostics/live-view notify must not roll back the
+    // already-committed todo mutation; the mutation response is still the
+    // authoritative result and the client can fall back to manual refresh.
+    logger.warn(
+      { src: 'plugin:workflow:workbench-todos', error, operation, todoId },
+      'Failed to emit workbench todo change event'
+    );
+  }
+}
+
 /**
  * Handle `/api/workbench/todos` CRUD. Returns `true` when the request matched a
  * todos endpoint (and a response was written), `false` otherwise.
@@ -188,6 +252,7 @@ export async function handleWorkbenchTodosRoutes(
       sendJsonError(res, 'Todo created but unavailable', 500);
       return true;
     }
+    emitWorkbenchTodoChanged(runtime, 'created', todo.id, todo);
     sendJson(res, { todo }, 201);
     return true;
   }
@@ -224,6 +289,9 @@ export async function handleWorkbenchTodosRoutes(
         },
       },
     });
+    const refreshed = await runtime.getTask(todoTask.id);
+    const refreshedTodo = refreshed ? toWorkbenchTodoView(refreshed) : null;
+    emitWorkbenchTodoChanged(runtime, 'completed', todoTask.id, refreshedTodo ?? undefined);
     sendJson(res, { ok: true });
     return true;
   }
@@ -256,6 +324,7 @@ export async function handleWorkbenchTodosRoutes(
         return true;
       }
       await runtime.deleteTask(todoTask.id);
+      emitWorkbenchTodoChanged(runtime, 'deleted', todoTask.id);
       sendJson(res, { ok: true });
       return true;
     }
@@ -327,6 +396,7 @@ export async function handleWorkbenchTodosRoutes(
       sendJsonError(res, 'Todo updated but unavailable', 500);
       return true;
     }
+    emitWorkbenchTodoChanged(runtime, 'updated', refreshedTodo.id, refreshedTodo);
     sendJson(res, { todo: refreshedTodo });
     return true;
   }


### PR DESCRIPTION
## Summary
- emit `workbench.todo.changed` agent-events after successful `/api/workbench/todos` create/update/complete/delete mutations
- keep custom workbench agent-events in the UI activity stream so sidebar/home widgets receive them
- refresh the todo widget immediately on those events, keeping the visible-tab poll only as a missed-event fallback

Fixes #13906

## Verification
- `bunx biome check packages/ui/src/hooks/useActivityEvents.ts packages/ui/src/components/chat/widgets/todo.tsx packages/ui/src/components/chat/widgets/todo.test.tsx plugins/plugin-workflow/src/routes/workbench-todos.ts plugins/plugin-workflow/__tests__/unit/routes/workbench-todos.test.ts`
- `bun run audit:error-policy-ratchet --report`

## Local blockers
- `bun test plugins/plugin-workflow/__tests__/unit/routes/workbench-todos.test.ts` fails before running tests with `SyntaxError: export 'syncBrandEnvToEliza' not found in '@elizaos/core'`.\n- `bunx vitest run packages/ui/src/components/chat/widgets/todo.test.tsx` fails before assertions with duplicate-React invalid-hook-call resolution through `dist/node_modules/react`.\n- `bun run --cwd plugins/plugin-workflow typecheck` and `bunx tsc --noEmit --pretty false -p packages/ui/tsconfig.json` fail on existing `dist/node_modules` declaration resolution issues, primarily Drizzle packages.\n\n## Evidence\n- N/A screenshots/video: no visual layout change; this is event plumbing for an existing widget.\n- N/A live-LLM trajectory: no model/action/provider behavior changed.