### PR TITLE
test(talkmode): add volume mute policy state machine (#13697)

### DIFF
--- a/plugins/plugin-native-talkmode/src/index.ts
+++ b/plugins/plugin-native-talkmode/src/index.ts
@@ -2,6 +2,7 @@ import { registerPlugin } from "@capacitor/core";
 import type { TalkModePlugin } from "./definitions";
 
 export * from "./definitions";
+export * from "./volumeMutePolicy";
 
 const loadWeb = () => import("./web").then((m) => new m.TalkModeWeb());
 

--- a/plugins/plugin-native-talkmode/src/volumeMutePolicy.test.ts
+++ b/plugins/plugin-native-talkmode/src/volumeMutePolicy.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createTalkModeAudioState,
+  getVolumeMutePolicy,
+  reduceTalkModeAudioPolicy,
+  type TalkModeAudioPlatform,
+} from "./volumeMutePolicy";
+
+const platforms: TalkModeAudioPlatform[] = [
+  "ios",
+  "android",
+  "electrobun",
+  "browser",
+];
+
+describe("volume and mute policy", () => {
+  it("defines the platform output lanes without treating mute as capture stop", () => {
+    expect(getVolumeMutePolicy("ios")).toMatchObject({
+      captureContinuesWhenOutputMuted: true,
+      captureIndicatorWhenOutputMuted: "recording",
+      ttsOutputChannel: "ios-play-and-record-voice-chat",
+      ttsProgressWhenOutputMuted: "continue",
+      requiresDeviceAudioVerification: true,
+    });
+    expect(getVolumeMutePolicy("android")).toMatchObject({
+      ttsOutputChannel: "android-voice-communication",
+      requiresDeviceAudioVerification: true,
+    });
+    expect(getVolumeMutePolicy("electrobun")).toMatchObject({
+      ttsOutputChannel: "desktop-system-output",
+      requiresDeviceAudioVerification: true,
+    });
+    expect(getVolumeMutePolicy("browser")).toMatchObject({
+      ttsOutputChannel: "browser-speech-synthesis-output",
+      requiresDeviceAudioVerification: false,
+    });
+  });
+
+  it.each(
+    platforms,
+  )("keeps %s capture live and visibly recording while output is muted", (platform) => {
+    const policy = getVolumeMutePolicy(platform);
+    let state = createTalkModeAudioState();
+
+    state = reduceTalkModeAudioPolicy(state, { type: "capture-started" });
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-mute-changed",
+      muted: true,
+    });
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-volume-changed",
+      volume: 0,
+    });
+
+    expect(policy.captureContinuesWhenOutputMuted).toBe(true);
+    expect(state.captureActive).toBe(true);
+    expect(state.captureIndicator).toBe("recording");
+  });
+
+  it("continues TTS silently when hardware mute or volume 0 is applied", () => {
+    let state = createTalkModeAudioState();
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "tts-started",
+      utteranceId: "reply-1",
+    });
+    expect(state.ttsAudibility).toBe("audible");
+    expect(state.ttsProgress).toBe("continue");
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-volume-changed",
+      volume: 0,
+    });
+    expect(state.ttsAudibility).toBe("silent-by-output-policy");
+    expect(state.ttsProgress).toBe("continue");
+    expect(state.ttsUtteranceId).toBe("reply-1");
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-mute-changed",
+      muted: true,
+    });
+    expect(state.ttsAudibility).toBe("silent-by-output-policy");
+    expect(state.ttsProgress).toBe("continue");
+    expect(state.ttsUtteranceId).toBe("reply-1");
+  });
+
+  it("restores audibility for the same utterance when output volume returns", () => {
+    let state = createTalkModeAudioState({
+      outputMuted: true,
+      outputVolume: 0,
+    });
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "tts-started",
+      utteranceId: "reply-2",
+    });
+    expect(state.ttsAudibility).toBe("silent-by-output-policy");
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-mute-changed",
+      muted: false,
+    });
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-volume-changed",
+      volume: 0.4,
+    });
+
+    expect(state.ttsUtteranceId).toBe("reply-2");
+    expect(state.ttsAudibility).toBe("audible");
+    expect(state.ttsProgress).toBe("continue");
+  });
+
+  it("ignores stale TTS finish events and clamps invalid output volume", () => {
+    let state = createTalkModeAudioState({ outputVolume: Number.NaN });
+    expect(state.outputVolume).toBe(1);
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "output-volume-changed",
+      volume: 2,
+    });
+    expect(state.outputVolume).toBe(1);
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "tts-started",
+      utteranceId: "current",
+    });
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "tts-finished",
+      utteranceId: "stale",
+    });
+    expect(state.ttsUtteranceId).toBe("current");
+
+    state = reduceTalkModeAudioPolicy(state, {
+      type: "tts-finished",
+      utteranceId: "current",
+    });
+    expect(state.ttsUtteranceId).toBeNull();
+    expect(state.ttsAudibility).toBe("not-speaking");
+    expect(state.ttsProgress).toBe("idle");
+  });
+});

--- a/plugins/plugin-native-talkmode/src/volumeMutePolicy.test.ts
+++ b/plugins/plugin-native-talkmode/src/volumeMutePolicy.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Deterministic coverage for TalkMode's output mute policy. The harness proves
+ * state transitions that do not require hardware audio, while explicitly
+ * leaving real mute/silent-switch routing to native device evidence.
+ */
+
 import { describe, expect, it } from "vitest";
 
 import {

--- a/plugins/plugin-native-talkmode/src/volumeMutePolicy.ts
+++ b/plugins/plugin-native-talkmode/src/volumeMutePolicy.ts
@@ -1,3 +1,10 @@
+/**
+ * Headless TalkMode audio policy for the boundary between input capture and
+ * platform output mute/volume state. Native implementations still own real
+ * audio routing; this module gives UI and tests one deterministic contract for
+ * whether capture, indicators, and in-flight TTS should continue under mute.
+ */
+
 export type TalkModeAudioPlatform =
   | "ios"
   | "android"

--- a/plugins/plugin-native-talkmode/src/volumeMutePolicy.ts
+++ b/plugins/plugin-native-talkmode/src/volumeMutePolicy.ts
@@ -1,0 +1,167 @@
+export type TalkModeAudioPlatform =
+  | "ios"
+  | "android"
+  | "electrobun"
+  | "browser";
+
+export type TalkModeCaptureIndicator = "recording" | "idle";
+
+export type TalkModeTtsAudibility =
+  | "audible"
+  | "silent-by-output-policy"
+  | "not-speaking";
+
+export type TalkModeTtsProgressPolicy = "continue";
+
+export type TalkModeTtsOutputChannel =
+  | "ios-play-and-record-voice-chat"
+  | "android-voice-communication"
+  | "desktop-system-output"
+  | "browser-speech-synthesis-output";
+
+export interface VolumeMutePolicy {
+  platform: TalkModeAudioPlatform;
+  /** Voice capture is input-side state and does not stop because output is muted or at volume 0. */
+  captureContinuesWhenOutputMuted: true;
+  /** UI affordance to keep showing while capture stays live under ringer/media mute. */
+  captureIndicatorWhenOutputMuted: "recording";
+  /** TTS follows the platform output lane listed here instead of inventing an app-local mute lane. */
+  ttsOutputChannel: TalkModeTtsOutputChannel;
+  /** Muting or setting output volume to 0 makes TTS inaudible but does not pause or cancel playback. */
+  ttsProgressWhenOutputMuted: TalkModeTtsProgressPolicy;
+  /** Hardware/device validation is required because simulators and headless tests cannot prove real audio routing. */
+  requiresDeviceAudioVerification: boolean;
+}
+
+export interface TalkModeAudioState {
+  captureActive: boolean;
+  captureIndicator: TalkModeCaptureIndicator;
+  ttsUtteranceId: string | null;
+  ttsProgress: TalkModeTtsProgressPolicy | "idle";
+  ttsAudibility: TalkModeTtsAudibility;
+  outputMuted: boolean;
+  outputVolume: number;
+}
+
+export type TalkModeAudioPolicyEvent =
+  | { type: "capture-started" }
+  | { type: "capture-stopped" }
+  | { type: "tts-started"; utteranceId: string }
+  | { type: "tts-finished"; utteranceId: string }
+  | { type: "output-mute-changed"; muted: boolean }
+  | { type: "output-volume-changed"; volume: number };
+
+const TTS_OUTPUT_CHANNEL_BY_PLATFORM = {
+  ios: "ios-play-and-record-voice-chat",
+  android: "android-voice-communication",
+  electrobun: "desktop-system-output",
+  browser: "browser-speech-synthesis-output",
+} as const satisfies Record<TalkModeAudioPlatform, TalkModeTtsOutputChannel>;
+
+export function getVolumeMutePolicy(
+  platform: TalkModeAudioPlatform,
+): VolumeMutePolicy {
+  return {
+    platform,
+    captureContinuesWhenOutputMuted: true,
+    captureIndicatorWhenOutputMuted: "recording",
+    ttsOutputChannel: TTS_OUTPUT_CHANNEL_BY_PLATFORM[platform],
+    ttsProgressWhenOutputMuted: "continue",
+    requiresDeviceAudioVerification: platform !== "browser",
+  };
+}
+
+export function createTalkModeAudioState(options?: {
+  outputMuted?: boolean;
+  outputVolume?: number;
+}): TalkModeAudioState {
+  const outputMuted = options?.outputMuted ?? false;
+  const outputVolume = normalizeOutputVolume(options?.outputVolume ?? 1);
+
+  return deriveTalkModeAudioState({
+    captureActive: false,
+    captureIndicator: "idle",
+    ttsUtteranceId: null,
+    ttsProgress: "idle",
+    ttsAudibility: "not-speaking",
+    outputMuted,
+    outputVolume,
+  });
+}
+
+export function reduceTalkModeAudioPolicy(
+  state: TalkModeAudioState,
+  event: TalkModeAudioPolicyEvent,
+): TalkModeAudioState {
+  switch (event.type) {
+    case "capture-started":
+      return deriveTalkModeAudioState({
+        ...state,
+        captureActive: true,
+        captureIndicator: "recording",
+      });
+    case "capture-stopped":
+      return deriveTalkModeAudioState({
+        ...state,
+        captureActive: false,
+        captureIndicator: "idle",
+      });
+    case "tts-started":
+      return deriveTalkModeAudioState({
+        ...state,
+        ttsUtteranceId: event.utteranceId,
+        ttsProgress: "continue",
+      });
+    case "tts-finished":
+      if (event.utteranceId !== state.ttsUtteranceId) {
+        return state;
+      }
+      return deriveTalkModeAudioState({
+        ...state,
+        ttsUtteranceId: null,
+        ttsProgress: "idle",
+      });
+    case "output-mute-changed":
+      return deriveTalkModeAudioState({
+        ...state,
+        outputMuted: event.muted,
+      });
+    case "output-volume-changed":
+      return deriveTalkModeAudioState({
+        ...state,
+        outputVolume: normalizeOutputVolume(event.volume),
+      });
+  }
+}
+
+function deriveTalkModeAudioState(
+  state: TalkModeAudioState,
+): TalkModeAudioState {
+  const ttsAudibility = getTtsAudibility(state);
+  const captureIndicator = state.captureActive ? "recording" : "idle";
+  const ttsProgress = state.ttsUtteranceId ? "continue" : "idle";
+
+  return {
+    ...state,
+    captureIndicator,
+    ttsProgress,
+    ttsAudibility,
+  };
+}
+
+function getTtsAudibility(state: TalkModeAudioState): TalkModeTtsAudibility {
+  if (!state.ttsUtteranceId) {
+    return "not-speaking";
+  }
+  if (state.outputMuted || state.outputVolume === 0) {
+    return "silent-by-output-policy";
+  }
+  return "audible";
+}
+
+function normalizeOutputVolume(volume: number): number {
+  if (!Number.isFinite(volume)) {
+    return 1;
+  }
+  return Math.min(1, Math.max(0, volume));
+}


### PR DESCRIPTION
## What changed

This implements the uncovered, non-overlapping [sol-verify] slice for #13697 after checking PR #13908.

PR #13908 is open, not merged, and covers the README/source-contract/evidence slice. This PR avoids those files and adds the headless-provable policy module + state machine that was still missing:

- Adds `volumeMutePolicy.ts`, a pure TalkMode volume/mute policy and reducer.
- Exports the policy surface from the plugin entrypoint.
- Adds tests for the explicit product behavior:
  - hardware/system output mute or volume 0 does not stop voice capture;
  - the capture indicator remains `recording` while capture is live under muted output;
  - TTS continues progressing silently under mute/volume 0 instead of pausing or canceling;
  - restoring output volume makes the same utterance audible again;
  - stale TTS finish events do not clear the current utterance.

## Policy pinned here

- Voice capture is input-side state. It continues when the output lane is muted or set to volume 0.
- UI should keep the capture indicator in the `recording` state while capture is live, even if output is muted.
- TTS uses the platform output lane: iOS play-and-record voice chat, Android voice communication, desktop system output, or browser speech synthesis output.
- Muting during TTS makes playback inaudible through the platform output policy, but playback continues. It is not paused, canceled, or treated as an interruption.
- Real iOS silent-switch, Android hardware stream mute, and desktop output-mute audio proof remain device-gated. This PR only claims the headless state-machine slice.

## Verification

- `bun test plugins/plugin-native-talkmode/src/volumeMutePolicy.test.ts` - pass, 8 tests / 34 expects.
- `bunx @biomejs/biome check plugins/plugin-native-talkmode/src/volumeMutePolicy.ts plugins/plugin-native-talkmode/src/volumeMutePolicy.test.ts plugins/plugin-native-talkmode/src/index.ts` - pass.
- `bunx tsc --ignoreConfig --noEmit --strict --target ES2020 --module ESNext --moduleResolution bundler --lib ES2020,DOM plugins/plugin-native-talkmode/src/volumeMutePolicy.ts` - pass.
- `git diff --check` - pass.
- `codex review --uncommitted` - initial P2 about stale anonymous TTS finish clearing current utterance fixed by requiring matched utterance ids; rerun reported no actionable correctness issues.

Blocked in this worktree:

- `bun install --frozen-lockfile` fails because the existing lockfile would change.
- `bun run --cwd plugins/plugin-native-talkmode test` fails because `vitest` is not installed in this worktree.
- `bun run --cwd plugins/plugin-native-talkmode typecheck` fails because `tsgo` is not installed in this worktree.

Part of #13697.

[sol-verify]
