### PR TITLE
fix: thread of a muted parent reports muted in inbox and channel listings

### DIFF
--- a/packages/agent/src/api/__tests__/inbox-thread-mute.test.ts
+++ b/packages/agent/src/api/__tests__/inbox-thread-mute.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Inbox chats mute honesty for Discord threads: GET /api/inbox/chats must
+ * report a thread muted when its PARENT channel's room carries the persisted
+ * mute — the same [room, parent] inheritance the connector's inbound gate
+ * enforces when it drops the thread's messages. Real handleInboxRoute over a
+ * map-backed runtime and a fake discord client cache; muted flags are
+ * asserted from the JSON the route actually serves.
+ */
+import type http from "node:http";
+import type { AgentRuntime, RouteHelpers, UUID } from "@elizaos/core";
+import { createUniqueUuid } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { handleInboxRoute, type InboxRouteState } from "../inbox-routes";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000a1" as UUID;
+const WORLD_ID = "00000000-0000-0000-0000-0000000000e1" as UUID;
+
+const MUTED_PARENT_CHANNEL_ID = "parent-muted-1";
+const MUTED_THREAD_CHANNEL_ID = "thread-of-muted-1";
+const OPEN_PARENT_CHANNEL_ID = "parent-open-1";
+const OPEN_THREAD_CHANNEL_ID = "thread-of-open-1";
+
+function fakeThreadChannel(id: string, name: string, parentId: string) {
+  return {
+    id,
+    name,
+    parentId,
+    isThread: () => true,
+  };
+}
+
+function makeHarness() {
+  const states = new Map<string, "FOLLOWED" | "MUTED" | null>();
+  const rooms = new Map<string, Record<string, unknown>>();
+  const worlds = new Map<string, Record<string, unknown>>([
+    [WORLD_ID, { id: WORLD_ID, agentId: AGENT_ID, name: "Guild" }],
+  ]);
+  const channels = new Map<string, unknown>();
+
+  const runtime = {
+    agentId: AGENT_ID,
+    getAllWorlds: async () => Array.from(worlds.values()),
+    getRoomsByWorlds: async () => Array.from(rooms.values()),
+    getMemories: async () => [],
+    getMemoriesByRoomIds: async ({ roomIds }: { roomIds: UUID[] }) =>
+      roomIds.map((roomId, index) => ({
+        id: `00000000-0000-0000-0000-00000000f${index}0${index}` as UUID,
+        roomId,
+        entityId: undefined,
+        content: { text: "hello", source: "discord" },
+        createdAt: 1_000 + index,
+      })),
+    getParticipantUserState: async (roomId: UUID, entityId: UUID) =>
+      states.get(`${roomId}:${entityId}`) ?? null,
+    updateParticipantUserState: async (
+      roomId: UUID,
+      entityId: UUID,
+      state: "FOLLOWED" | "MUTED" | null,
+    ) => {
+      states.set(`${roomId}:${entityId}`, state);
+    },
+    getRoom: async (roomId: UUID) => rooms.get(roomId) ?? null,
+    updateRoom: async (room: { id: string }) => {
+      rooms.set(room.id, room);
+    },
+    getWorld: async (worldId: UUID) => worlds.get(worldId) ?? null,
+    updateWorld: async (world: { id: string }) => {
+      worlds.set(world.id, world);
+    },
+    getService: (name: string) =>
+      name === "discord"
+        ? {
+            client: {
+              channels: { cache: { get: (id: string) => channels.get(id) } },
+            },
+          }
+        : null,
+  } as unknown as AgentRuntime;
+
+  const addThreadRoom = (channelId: string, parentChannelId: string) => {
+    const roomId = createUniqueUuid(runtime, channelId);
+    rooms.set(roomId, {
+      id: roomId,
+      name: `#${channelId}`,
+      source: "discord",
+      type: "GROUP",
+      worldId: WORLD_ID,
+      channelId,
+    });
+    channels.set(
+      channelId,
+      fakeThreadChannel(channelId, channelId, parentChannelId),
+    );
+    return roomId;
+  };
+
+  return { runtime, states, addThreadRoom };
+}
+
+async function getChats(runtime: AgentRuntime) {
+  let payload: { chats: Array<Record<string, unknown>> } | undefined;
+  const helpers = {
+    json: (_res: http.ServerResponse, data: unknown) => {
+      payload = data as { chats: Array<Record<string, unknown>> };
+    },
+    error: (_res: http.ServerResponse, message: string) => {
+      throw new Error(`route error: ${message}`);
+    },
+    readJsonBody: async () => null,
+  } as unknown as RouteHelpers;
+
+  const handled = await handleInboxRoute(
+    { url: "/api/inbox/chats" } as http.IncomingMessage,
+    {} as http.ServerResponse,
+    "/api/inbox/chats",
+    "GET",
+    { runtime } as InboxRouteState,
+    helpers,
+  );
+  expect(handled).toBe(true);
+  if (!payload) throw new Error("route did not respond");
+  return payload.chats;
+}
+
+describe("GET /api/inbox/chats — thread inherits parent channel mute", () => {
+  it("reports a thread of a muted parent as muted, an open one as unmuted", async () => {
+    const { runtime, states, addThreadRoom } = makeHarness();
+    const mutedThreadRoomId = addThreadRoom(
+      MUTED_THREAD_CHANNEL_ID,
+      MUTED_PARENT_CHANNEL_ID,
+    );
+    const openThreadRoomId = addThreadRoom(
+      OPEN_THREAD_CHANNEL_ID,
+      OPEN_PARENT_CHANNEL_ID,
+    );
+    // Same persisted state the ROOM action writes and the inbound gate reads
+    // when it drops the thread's messages.
+    const mutedParentRoomId = createUniqueUuid(
+      runtime,
+      MUTED_PARENT_CHANNEL_ID,
+    );
+    states.set(`${mutedParentRoomId}:${AGENT_ID}`, "MUTED");
+
+    const chats = await getChats(runtime);
+    const mutedThreadChat = chats.find((c) => c.id === mutedThreadRoomId);
+    const openThreadChat = chats.find((c) => c.id === openThreadRoomId);
+
+    expect(mutedThreadChat).toBeDefined();
+    expect(openThreadChat).toBeDefined();
+    expect(mutedThreadChat?.muted).toBe(true);
+    expect(mutedThreadChat?.mutedScope).toBe("room");
+    expect(openThreadChat?.muted).toBe(false);
+  });
+});

--- a/packages/agent/src/api/inbox-routes.ts
+++ b/packages/agent/src/api/inbox-routes.ts
@@ -44,6 +44,7 @@ import type {
   World,
 } from "@elizaos/core";
 import {
+  createUniqueUuid,
   resolveEffectiveMuteState,
   setRoomMuteUntil,
   setWorldMuteState,
@@ -441,14 +442,36 @@ function muteUntilIsoFromDuration(
     : undefined;
 }
 
+/**
+ * A Discord thread inherits its parent channel's mute: the connector's
+ * inbound gate drops the thread's messages on the [room, parent] mute chain,
+ * so the inbox must report the thread muted too — never muted:false while its
+ * messages are being dropped. The parent linkage is not persisted on the room
+ * record, so it comes from the same cached live-channel lookup the chat list
+ * already uses for titles. When the Discord client is unreachable the parent
+ * is unknown and only the room's own state answers — consistent, because a
+ * disconnected client is not dropping messages either.
+ */
+async function resolveDiscordParentRoomId(
+  runtime: AgentRuntime,
+  room: Room | undefined,
+): Promise<UUID | undefined> {
+  if (!isDiscordConnectorSource(readRoomSource(room))) return undefined;
+  const profile = await resolveDiscordRoomProfile(runtime, room);
+  return profile?.parentChannelId
+    ? createUniqueUuid(runtime, profile.parentChannelId)
+    : undefined;
+}
+
 async function resolveInboxRoomMuteState(
   runtime: AgentRuntime,
   room: Room | undefined,
   roomId: UUID,
 ): Promise<Pick<InboxChat, "muted" | "mutedScope">> {
   const worldId = readRoomWorldId(room);
+  const parentRoomId = await resolveDiscordParentRoomId(runtime, room);
   const effective = await resolveEffectiveMuteState(runtime, {
-    roomIds: [roomId],
+    roomIds: parentRoomId ? [roomId, parentRoomId] : [roomId],
     ...(worldId ? { worldId: worldId as UUID } : {}),
   });
   if (!effective.muted) {
@@ -1058,6 +1081,7 @@ async function resolveDiscordRoomProfile(
 
   let title: string | null = null;
   let avatarUrl: string | undefined;
+  let parentChannelId: string | undefined;
   if (channel && typeof channel === "object") {
     const namedChannel = channel as { name?: unknown };
     if (typeof namedChannel.name === "string" && namedChannel.name.trim()) {
@@ -1072,6 +1096,13 @@ async function resolveDiscordRoomProfile(
       title = readDiscordDisplayName(recipient) ?? null;
       avatarUrl = readDiscordAvatarUrl(recipient);
     }
+    const parentRecord = channel as { parentId?: unknown };
+    if (
+      typeof parentRecord.parentId === "string" &&
+      parentRecord.parentId.length > 0
+    ) {
+      parentChannelId = parentRecord.parentId;
+    }
   }
 
   const profile: DiscordRoomProfile = {
@@ -1079,6 +1110,7 @@ async function resolveDiscordRoomProfile(
     ...(typeof avatarUrl === "string" && avatarUrl.length > 0
       ? { avatarUrl }
       : {}),
+    ...(parentChannelId ? { parentChannelId } : {}),
   };
 
   discordRoomProfileCache.set(channelId, {
@@ -1766,6 +1798,13 @@ const PostInboxChatMuteRequestSchema = z.object({
 type DiscordRoomProfile = {
   avatarUrl?: string;
   title: string | null;
+  /**
+   * Platform id of the channel this room hangs under (a thread's parent
+   * channel, a channel's category), read off the live channel object. Feeds
+   * mute inheritance: the connector's inbound gate drops messages on the
+   * [room, parent] mute chain, so the inbox must report the same.
+   */
+  parentChannelId?: string;
 };
 
 /**

--- a/packages/core/src/services/message/mute-state.test.ts
+++ b/packages/core/src/services/message/mute-state.test.ts
@@ -6,6 +6,7 @@
  * against the stores, not mocks of the thing under test.
  */
 import { describe, expect, it } from "vitest";
+import { createUniqueUuid } from "../../entities";
 import type { Room, World } from "../../types/environment";
 import type { UUID } from "../../types/primitives";
 import type {
@@ -259,6 +260,61 @@ describe("resolveMutedTargetFlags", () => {
 			false,
 			true,
 		]);
+	});
+
+	it("a thread target inherits its muted parent channel's mute", async () => {
+		// Mirrors the inbound gate: the connector drops a thread's messages when
+		// the thread's PARENT channel room is muted, so the listing must report
+		// the thread muted too — not just the parent.
+		const { runtime, states, rooms } = makeRuntime({ worlds: [world()] });
+		const parentRoomId = createUniqueUuid(runtime, "parent-channel-1");
+		states.set(`${parentRoomId}:${AGENT_ID}`, "MUTED");
+		rooms.set(parentRoomId, room(parentRoomId));
+		const targets: MessageConnectorTarget[] = [
+			{
+				target: {
+					source: "discord",
+					channelId: "thread-channel-1",
+					parentChannelId: "parent-channel-1",
+				},
+			},
+			// Sibling thread under an unmuted parent stays unmuted.
+			{
+				target: {
+					source: "discord",
+					channelId: "thread-channel-2",
+					parentChannelId: "parent-channel-2",
+				},
+			},
+		];
+		expect(await resolveMutedTargetFlags(runtime, targets)).toEqual([
+			true,
+			false,
+		]);
+	});
+
+	it("an expired timed parent mute does not flag the thread", async () => {
+		const past = new Date(Date.now() - 1_000).toISOString();
+		const { runtime, states, rooms } = makeRuntime();
+		const parentRoomId = createUniqueUuid(runtime, "parent-channel-3");
+		states.set(`${parentRoomId}:${AGENT_ID}`, "MUTED");
+		rooms.set(
+			parentRoomId,
+			room(parentRoomId, {
+				worldId: undefined,
+				metadata: { agentMuteUntilIso: past },
+			}),
+		);
+		const targets: MessageConnectorTarget[] = [
+			{
+				target: {
+					source: "discord",
+					channelId: "thread-channel-3",
+					parentChannelId: "parent-channel-3",
+				},
+			},
+		];
+		expect(await resolveMutedTargetFlags(runtime, targets)).toEqual([false]);
 	});
 
 	it("reports an expired timed room mute as unmuted without writing", async () => {

--- a/packages/core/src/services/message/mute-state.ts
+++ b/packages/core/src/services/message/mute-state.ts
@@ -230,7 +230,10 @@ export async function resolveMutedWorldFlags(
  * an expired timed mute simply reports unmuted here. Targets map to rooms via
  * their explicit roomId or the canonical `createUniqueUuid(runtime, channelId)`
  * convention every connector uses for inbound messages; unknown mappings
- * report unmuted.
+ * report unmuted. A target that names a `parentChannelId` (a thread under a
+ * channel, a channel under a category) also inherits that parent room's mute —
+ * the same [room, parent] chain the inbound gate drops on — so a listing never
+ * reports a thread unmuted while its messages are being dropped.
  */
 export async function resolveMutedTargetFlags(
 	runtime: IAgentRuntime,
@@ -254,15 +257,18 @@ export async function resolveMutedTargetFlags(
 				(entry.target.channelId
 					? createUniqueUuid(runtime, entry.target.channelId)
 					: undefined);
-			if (roomId) {
+			const parentRoomId = entry.target.parentChannelId
+				? createUniqueUuid(runtime, entry.target.parentChannelId)
+				: undefined;
+			for (const id of [roomId, parentRoomId]) {
+				if (!id) continue;
 				const state = await runtime.getParticipantUserState(
-					roomId,
+					id,
 					runtime.agentId,
 				);
-				if (state === "MUTED") {
-					const room = await runtime.getRoom(roomId);
-					if (roomMuteActive(state, room, now)) return true;
-				}
+				if (state !== "MUTED") continue;
+				const room = await runtime.getRoom(id);
+				if (roomMuteActive(state, room, now)) return true;
 			}
 			return entry.target.serverId
 				? isServerMuted(entry.target.serverId)

--- a/packages/core/src/types/messaging.ts
+++ b/packages/core/src/types/messaging.ts
@@ -17,6 +17,14 @@ export interface TargetInfo {
 	serverId?: string;
 	threadId?: string;
 	/**
+	 * Platform id of the channel this target hangs under — a thread's parent
+	 * channel, or a channel's category. Connectors whose inbound gate drops
+	 * messages on the [room, parent] mute chain (a muted parent silences its
+	 * threads) set this so muted-state reporting inherits the parent's mute
+	 * and matches the actual drop behavior.
+	 */
+	parentChannelId?: string;
+	/**
 	 * Connector account identifier for multi-account sources.
 	 * Omitted/undefined targets use the legacy source-only route.
 	 */

--- a/plugins/plugin-discord/__tests__/thread-target-parent-mute.test.ts
+++ b/plugins/plugin-discord/__tests__/thread-target-parent-mute.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Muted-display consistency for threads: a thread target listed by
+ * listConnectorRooms carries its parent channel id, and the core muted-flag
+ * resolver behind list_channels / list_connections reports the thread muted
+ * when the PARENT channel's room is muted — the same [room, parent]
+ * inheritance the inbound gate enforces when it drops the thread's messages
+ * ("a muted parent channel silences its thread" in
+ * discord-events-mute-gate.test.ts). Real DiscordService.listConnectorRooms +
+ * real core resolver over a fake discord.js guild cache and map-backed runtime.
+ */
+import {
+	createUniqueUuid,
+	type IAgentRuntime,
+	type MessageConnectorQueryContext,
+	resolveMutedTargetFlags,
+	type UUID,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { DiscordService } from "../service.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000a1" as UUID;
+
+function makeRuntime() {
+	const states = new Map<string, "FOLLOWED" | "MUTED" | null>();
+	const rooms = new Map<string, Record<string, unknown>>();
+	const runtime = {
+		agentId: AGENT_ID,
+		getParticipantUserState: async (roomId: UUID, entityId: UUID) =>
+			states.get(`${roomId}:${entityId}`) ?? null,
+		getRoom: async (roomId: UUID) => rooms.get(roomId) ?? null,
+		getWorld: async () => null,
+	} as unknown as IAgentRuntime;
+	return { runtime, states };
+}
+
+interface FakeGuild {
+	id: string;
+	name: string;
+	channels: { cache: Map<string, unknown> };
+}
+
+function fakeChannel(
+	id: string,
+	name: string,
+	guild: FakeGuild,
+	options?: { parentId?: string; thread?: boolean },
+) {
+	return {
+		id,
+		name,
+		guild,
+		parentId: options?.parentId ?? null,
+		isTextBased: () => true,
+		isVoiceBased: () => false,
+		isThread: () => options?.thread === true,
+	};
+}
+
+function serviceWithGuild(runtime: IAgentRuntime, guild: FakeGuild) {
+	const client = {
+		guilds: { cache: new Map([[guild.id, guild]]) },
+	};
+	return Object.assign(Object.create(DiscordService.prototype), {
+		runtime,
+		client,
+		defaultAccountId: "default",
+		accountPool: { get: () => null, getDefault: () => null },
+	}) as DiscordService;
+}
+
+describe("thread targets — parent-channel mute inheritance in listings", () => {
+	it("a thread of a muted parent lists as muted, matching the drop path", async () => {
+		const { runtime, states } = makeRuntime();
+		const guild: FakeGuild = {
+			id: "guild-1",
+			name: "Guild",
+			channels: { cache: new Map() },
+		};
+		guild.channels.cache.set(
+			"parent-1",
+			fakeChannel("parent-1", "general", guild),
+		);
+		guild.channels.cache.set(
+			"thread-1",
+			fakeChannel("thread-1", "help-thread", guild, {
+				parentId: "parent-1",
+				thread: true,
+			}),
+		);
+		guild.channels.cache.set(
+			"chan-2",
+			fakeChannel("chan-2", "random", guild),
+		);
+		// Same persisted state the ROOM action writes and the inbound gate reads
+		// when it drops the thread's messages.
+		const parentRoomId = createUniqueUuid(runtime, "parent-1");
+		states.set(`${parentRoomId}:${AGENT_ID}`, "MUTED");
+
+		const service = serviceWithGuild(runtime, guild);
+		const targets = await service.listConnectorRooms({
+			runtime,
+		} as MessageConnectorQueryContext);
+
+		const thread = targets.find((t) => t.kind === "thread");
+		expect(thread).toBeDefined();
+		// The listed thread target names its parent so mute inheritance is
+		// resolvable without a live channel lookup downstream.
+		expect(thread?.target.parentChannelId).toBe("parent-1");
+
+		const flags = await resolveMutedTargetFlags(runtime, targets);
+		const flagByChannelId = new Map(
+			targets.map((t, index) => [t.target.channelId, flags[index]]),
+		);
+		expect(flagByChannelId.get("parent-1")).toBe(true);
+		expect(flagByChannelId.get("thread-1")).toBe(true);
+		expect(flagByChannelId.get("chan-2")).toBe(false);
+	});
+});

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -1898,6 +1898,11 @@ export class DiscordService extends Service implements IDiscordService {
 				channelId: channel.id,
 				serverId: guild?.id,
 				threadId: isThread ? channel.id : undefined,
+				// The inbound gate drops messages on the [room, parent] mute chain
+				// (discord-events), so listings carry the same parent linkage for
+				// muted-state inheritance — a thread of a muted parent must never
+				// list as unmuted while its messages are being dropped.
+				parentChannelId: parentId,
 			} as TargetInfo,
 			label,
 			kind: isThread ? "thread" : "channel",


### PR DESCRIPTION
## What

A Discord thread whose PARENT channel is muted showed `muted:false` in the inbox (`GET /api/inbox/chats`) and in the MESSAGE `list_channels` / `list_connections` surfaces, while the connector's inbound gate (from #12892) was correctly DROPPING the thread's messages via the `[room, parent]` mute chain (`plugins/plugin-discord/discord-events.ts:378`). The display lied: the user saw the thread as unmuted while it was effectively muted.

## Structural fix — display inherits the same [room, parent] chain the drop path enforces

- **`TargetInfo.parentChannelId`** (`packages/core/src/types/messaging.ts`): additive optional field naming the channel a target hangs under (thread parent / category). The Discord connector stamps it on listed targets from the same `parentId` the inbound gate drops on (`buildConnectorChannelTarget`).
- **`resolveMutedTargetFlags`** (`packages/core/src/services/message/mute-state.ts`): after the target's own room, the parent room (via the same `createUniqueUuid(runtime, channelId)` convention) is checked — `list_channels` / `list_connections` muted flags now match the drop behavior. Still read-only.
- **Inbox** (`packages/agent/src/api/inbox-routes.ts`): `resolveInboxRoomMuteState` passes the parent room as an ancestor to `resolveEffectiveMuteState` (the resolver's documented ancestor contract). The parent linkage is not persisted on the room record, so it is read from the same cached live-channel lookup the chat list already uses for titles (`DiscordRoomProfile`). When the Discord client is unreachable the parent is unknown and only the room's own state answers — consistent, because a disconnected client is not dropping messages either.

No behavior change for non-thread targets, DMs, or non-Discord connectors (no `parentChannelId` → identical resolution path).

## Evidence (real tests, fail-on-develop → pass-with-fix)

Verify-first: all three tests were written and run against develop tip `0f1c4d7993` BEFORE the fix, each failing on the exact lie:

| Surface | Test | On develop | With fix |
|---|---|---|---|
| core resolver | `packages/core/src/services/message/mute-state.test.ts` — "a thread target inherits its muted parent channel's mute" (+ expired-parent negative) | `[false, false]` where truth is `[true, false]` — **FAILED** | 17/17 pass |
| discord listing | `plugins/plugin-discord/__tests__/thread-target-parent-mute.test.ts` — real `DiscordService.listConnectorRooms` over a fake discord.js guild cache + real core resolver; asserts the thread target carries `parentChannelId` and flags `parent:true, thread:true, sibling:false` | `target.parentChannelId` was `undefined` — **FAILED** | 1/1 pass |
| inbox route | `packages/agent/src/api/__tests__/inbox-thread-mute.test.ts` — real `handleInboxRoute` `GET /api/inbox/chats`, map-backed runtime + fake discord client cache; thread of muted parent vs thread of open parent | muted thread row `muted:false` — **FAILED** | 1/1 pass |

The drop half of the consistency claim is already locked in-tree: `discord-events-mute-gate.test.ts` "a muted parent channel silences its thread" (green before and after) uses the same persisted state seeding (`createUniqueUuid(runtime, parentChannelId)` participant state `MUTED`), so the new tests assert display == drop on identical state.

Verification (real counts):
- `packages/core`: mute-state + full `advanced-capabilities/actions` dir — **61/61 pass**; `bun run typecheck` exit 0; full multi-target build (node + browser + edge + d.ts) green.
- `plugins/plugin-discord`: thread-target + mute-gate + dm-dispatch + target-source + list-servers — **25/25 pass**. `__tests__/connector-rooms.test.ts` has 1 pre-existing failure (expects 75 listed rooms, `listConnectorRooms` caps at 50) — proven pre-existing by stash-run on pristine develop, identical failure without this diff. Typecheck: 4 pre-existing errors (unbuilt workspace deps, e.g. `@elizaos/plugin-commands`), byte-identical error list with and without this diff (stash comparison).
- `packages/agent`: inbox test **1/1 pass**; typecheck 16 pre-existing errors (unbuilt optional-plugin deps), byte-identical with and without this diff.
- `bun run audit:error-policy-ratchet`: no new fallback-slop in touched files.
- `biome lint` on all 7 touched files: clean.

UI evidence: N/A — no rendered UI change; the fix corrects a server-computed DTO flag (`InboxChat.muted`, `list_channels` `muted`) that clients render as-is, verified at the real route/action layer. Live-LLM trajectory: N/A — no model, prompt, or action-routing behavior change; the muted flag is computed outside the model path.

Fixes the "inbox thread-parent mute inheritance" display-honesty finding from the launch-QA loop (#13406 lane). [core-brain]
