### PR TITLE
feat(#13569): agent-availability preflight + attributed chat-skip accounting + --require-chat — [sol-test]

### DIFF
--- a/packages/app/scripts/ios-device-capture.mjs
+++ b/packages/app/scripts/ios-device-capture.mjs
@@ -70,6 +70,191 @@ const fail = (message) => {
   process.exit(1);
 };
 
+const DEFAULT_ELIZA_CLOUD_BASE = "https://elizacloud.ai";
+
+function readFirstString(env, keys) {
+  for (const key of keys) {
+    const value = env?.[key];
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function withoutTrailingSlash(value) {
+  return value.replace(/\/+$/, "");
+}
+
+function withPath(base, pathname) {
+  const url = new URL(base);
+  url.pathname = pathname;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+/**
+ * Resolve the HTTP endpoint that proves the app's chat/reply path can answer
+ * before the iOS XCUITest suite starts. Prefer the device build's configured
+ * API base (local/remote-mac/hybrid builds), otherwise fall back to the cloud
+ * agent liveness endpoint used by cloud-only builds.
+ */
+export function resolveAgentProbeTarget(env = process.env, args = {}) {
+  const explicit = readFirstString(args, ["agent-probe-url"]);
+  if (explicit) {
+    return { kind: "explicit", url: explicit, source: "--agent-probe-url" };
+  }
+
+  const apiBase = readFirstString(env, [
+    "VITE_ELIZA_IOS_API_BASE",
+    "VITE_ELIZA_MOBILE_API_BASE",
+    "VITE_ELIZA_ANDROID_API_BASE",
+    "ELIZA_IOS_API_BASE",
+    "ELIZA_API_BASE",
+    "ELIZA_API_BASE_URL",
+  ]);
+  if (apiBase) {
+    return {
+      kind: "api-base",
+      url: withPath(withoutTrailingSlash(apiBase), "/api/health"),
+      source: "configured API base",
+    };
+  }
+
+  const cloudBase = withoutTrailingSlash(
+    readFirstString(env, ["VITE_ELIZA_CLOUD_BASE", "VITE_CLOUD_BASE"]) ??
+      DEFAULT_ELIZA_CLOUD_BASE,
+  );
+  return {
+    kind: "cloud-health",
+    url: withPath(cloudBase, "/health"),
+    source: "cloud health endpoint",
+  };
+}
+
+function normalizeProbeVerdict(response, bodyText) {
+  if (!response?.ok) return `not-ready(http ${response?.status ?? "unknown"})`;
+  if (!bodyText?.trim()) return "ready";
+  let body;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    return "ready";
+  }
+  if (body?.ready === false) return "not-ready(ready=false)";
+  if (body?.alive === false) return "not-ready(alive=false)";
+  const status = typeof body?.status === "string" ? body.status : null;
+  if (status && /^(unhealthy|offline|draining|not[-_ ]?ready)$/i.test(status)) {
+    return `not-ready(status=${status})`;
+  }
+  return "ready";
+}
+
+export async function probeAgentAvailability({
+  target,
+  fetchImpl = globalThis.fetch,
+  timeoutMs = 5000,
+} = {}) {
+  if (!target?.url) return { verdict: "unreachable(no target)", target };
+  if (typeof fetchImpl !== "function") {
+    return { verdict: "unreachable(fetch unavailable)", target };
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(target.url, {
+      method: "GET",
+      signal: controller.signal,
+      headers: { accept: "application/json" },
+    });
+    const text = await response.text().catch(() => "");
+    return { verdict: normalizeProbeVerdict(response, text), target };
+  } catch (error) {
+    const detail =
+      error?.name === "AbortError" ? "timeout" : (error?.message ?? error);
+    return { verdict: `unreachable(${String(detail)})`, target };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function collectSkippedChatRows(value, rows = []) {
+  if (!value || typeof value !== "object") return rows;
+  if (Array.isArray(value)) {
+    for (const item of value) collectSkippedChatRows(item, rows);
+    return rows;
+  }
+  const statusFields = [
+    value.status,
+    value.result,
+    value.testStatus,
+    value.state,
+    value.outcome,
+  ]
+    .filter((field) => typeof field === "string")
+    .join(" ");
+  const skipped = /\bskip(?:ped)?\b/i.test(statusFields);
+  const identifier = [
+    value.testIdentifierString,
+    value.testIdentifier,
+    value.identifier,
+    value.testName,
+    value.name,
+  ]
+    .filter((field) => typeof field === "string" && field.trim())
+    .join(" ");
+  const chatLike = /\b(chat|message|reply|onboarding[-_ ]?chat)\b/i.test(
+    identifier,
+  );
+  if (skipped && chatLike) {
+    rows.push({ identifier: identifier.trim() || "unknown-chat-test" });
+  }
+  for (const child of Object.values(value)) collectSkippedChatRows(child, rows);
+  return rows;
+}
+
+export function summarizeChatSkipAccounting(summaryJson, probeVerdict) {
+  const rows = collectSkippedChatRows(summaryJson);
+  const seen = new Set();
+  const tests = [];
+  for (const row of rows) {
+    const identifier = row.identifier.replace(/\s+/g, " ");
+    if (seen.has(identifier)) continue;
+    seen.add(identifier);
+    tests.push(identifier);
+  }
+  const count = tests.length;
+  return {
+    count,
+    tests,
+    message:
+      count > 0
+        ? `${count} chat leg${count === 1 ? "" : "s"} skipped: agent never ready (${probeVerdict})`
+        : null,
+  };
+}
+
+export function buildRequireChatDecision({
+  requireChat = false,
+  agentProbeVerdict = "ready",
+  chatSkippedCount = 0,
+} = {}) {
+  const reasons = [];
+  if (agentProbeVerdict !== "ready") {
+    reasons.push(`agent preflight ${agentProbeVerdict}`);
+  }
+  if (chatSkippedCount > 0) {
+    reasons.push(
+      `${chatSkippedCount} chat leg${chatSkippedCount === 1 ? "" : "s"} skipped`,
+    );
+  }
+  return {
+    exitNonZero: Boolean(requireChat && reasons.length > 0),
+    reason: reasons.join("; "),
+  };
+}
+
 function runInherit(command, args, options = {}) {
   const result = spawnSync(command, args, { stdio: "inherit", ...options });
   if (result.status !== 0) {
@@ -243,12 +428,13 @@ async function main() {
       "skip-build",
       "allow-stale-runner",
       "no-retry-isolation",
+      "require-chat",
       "help",
     ],
   });
   if (args.help) {
     console.log(
-      "Usage: node scripts/ios-device-capture.mjs --platform sim|device [--device <udid>] [--skip-build] [--allow-stale-runner] [--no-retry-isolation] [--output <dir>] [--app-path <App.app>] [--boot-timeout <sec>] [--interval <sec>] [--agent-ready-timeout <sec>] [--derived-data <dir>] [--only-testing <id>] [--bundle-id <id>]",
+      "Usage: node scripts/ios-device-capture.mjs --platform sim|device [--device <udid>] [--skip-build] [--allow-stale-runner] [--no-retry-isolation] [--require-chat] [--output <dir>] [--app-path <App.app>] [--boot-timeout <sec>] [--interval <sec>] [--agent-ready-timeout <sec>] [--derived-data <dir>] [--only-testing <id>] [--bundle-id <id>]",
     );
     return;
   }
@@ -699,6 +885,11 @@ async function main() {
       : {}),
   };
 
+  const agentProbeTarget = resolveAgentProbeTarget(process.env, args);
+  log(`agent availability preflight (${agentProbeTarget.source}): ${agentProbeTarget.url}`);
+  const agentProbe = await probeAgentAvailability({ target: agentProbeTarget });
+  log(`agent availability preflight verdict: ${agentProbe.verdict}`);
+
   const runHarness = (testing, bundlePath) => {
     fs.rmSync(bundlePath, { recursive: true, force: true });
     return spawnSync(
@@ -833,10 +1024,17 @@ async function main() {
       exitStatus: testResult.status,
       passed: testResult.status === 0,
       flakeClassification: null,
+      chatSkipAccounting: summarizeChatSkipAccounting(
+        artifacts.summaryJson,
+        agentProbe.verdict,
+      ),
     };
     log(
       `shard ${shard.resultName}: exit=${testResult.status} attachments=${artifacts.attachmentCount}`,
     );
+    if (shardSummary.chatSkipAccounting.message) {
+      log(shardSummary.chatSkipAccounting.message);
+    }
 
     if (testResult.status !== 0) {
       const suiteFailures = readFailedTestIdentifiers(
@@ -892,18 +1090,54 @@ async function main() {
     shardSummaries.push(shardSummary);
   }
 
+  const chatSkipAccounting = shardSummaries.reduce(
+    (acc, shard) => {
+      const tests = shard.chatSkipAccounting?.tests ?? [];
+      for (const test of tests) {
+        if (!acc.seen.has(test)) {
+          acc.seen.add(test);
+          acc.tests.push(test);
+        }
+      }
+      return acc;
+    },
+    { seen: new Set(), tests: [] },
+  );
+  const aggregateChatSkipAccounting = {
+    count: chatSkipAccounting.tests.length,
+    tests: chatSkipAccounting.tests,
+    message:
+      chatSkipAccounting.tests.length > 0
+        ? `${chatSkipAccounting.tests.length} chat leg${chatSkipAccounting.tests.length === 1 ? "" : "s"} skipped: agent never ready (${agentProbe.verdict})`
+        : null,
+  };
   const aggregate = {
     generatedAt: new Date().toISOString(),
     platform,
     bundleId,
     destination,
     sharded: args["only-testing"] ? "explicit-only-testing" : "default",
+    agentAvailability: agentProbe,
+    requireChat: Boolean(args["require-chat"]),
+    chatSkipAccounting: aggregateChatSkipAccounting,
     shards: shardSummaries,
   };
   fs.writeFileSync(
     path.join(outputDir, "test-summary.json"),
     `${JSON.stringify(aggregate, null, 2)}\n`,
   );
+
+  if (aggregateChatSkipAccounting.message) {
+    log(aggregateChatSkipAccounting.message);
+  }
+  const requireChatDecision = buildRequireChatDecision({
+    requireChat: Boolean(args["require-chat"]),
+    agentProbeVerdict: agentProbe.verdict,
+    chatSkippedCount: aggregateChatSkipAccounting.count,
+  });
+  if (requireChatDecision.exitNonZero) {
+    fail(`--require-chat failed: ${requireChatDecision.reason}.`);
+  }
 
   const failedShards = shardSummaries.filter((shard) => !shard.passed);
   if (failedShards.length > 0) {

--- a/packages/app/scripts/ios-device-capture.mjs
+++ b/packages/app/scripts/ios-device-capture.mjs
@@ -128,7 +128,7 @@ export function resolveAgentProbeTarget(env = process.env, args = {}) {
   );
   return {
     kind: "cloud-health",
-    url: withPath(cloudBase, "/health"),
+    url: withPath(cloudBase, "/api/health"),
     source: "cloud health endpoint",
   };
 }
@@ -204,9 +204,7 @@ function collectSkippedChatRows(value, rows = []) {
   ]
     .filter((field) => typeof field === "string" && field.trim())
     .join(" ");
-  const chatLike = /\b(chat|message|reply|onboarding[-_ ]?chat)\b/i.test(
-    identifier,
-  );
+  const chatLike = /chat|message|reply/i.test(identifier);
   if (skipped && chatLike) {
     rows.push({ identifier: identifier.trim() || "unknown-chat-test" });
   }

--- a/packages/app/scripts/ios-device-lib.test.mjs
+++ b/packages/app/scripts/ios-device-lib.test.mjs
@@ -7,6 +7,12 @@
 import crypto from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
+  buildRequireChatDecision,
+  probeAgentAvailability,
+  resolveAgentProbeTarget,
+  summarizeChatSkipAccounting,
+} from "./ios-device-capture.mjs";
+import {
   buildCodesignPlan,
   buildIosXcuitestShardPlan,
   buildOnlyTestingIdentifier,
@@ -1202,5 +1208,119 @@ describe("evaluateRunnerStaleness (#13566)", () => {
     });
     expect(decision.stale).toBe(false);
     expect(decision.newestSource).toBe(null);
+  });
+});
+
+
+describe("ios-device-capture agent availability preflight (#13569)", () => {
+  it("prefers the configured iOS API base over the cloud health fallback", () => {
+    expect(
+      resolveAgentProbeTarget(
+        {
+          VITE_ELIZA_IOS_API_BASE: "https://mac.example.test/api-root/",
+          VITE_ELIZA_CLOUD_BASE: "https://cloud.example.test",
+        },
+        {},
+      ),
+    ).toMatchObject({
+      kind: "api-base",
+      url: "https://mac.example.test/api/health",
+    });
+  });
+
+  it("falls back to the cloud health endpoint when no device API base is configured", () => {
+    expect(
+      resolveAgentProbeTarget(
+        { VITE_ELIZA_CLOUD_BASE: "https://cloud.example.test/" },
+        {},
+      ),
+    ).toMatchObject({
+      kind: "cloud-health",
+      url: "https://cloud.example.test/health",
+    });
+  });
+
+  it("maps probe responses to ready, not-ready, and unreachable verdicts", async () => {
+    await expect(
+      probeAgentAvailability({
+        target: { url: "https://agent.example.test/health" },
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ ready: true }), { status: 200 }),
+      }),
+    ).resolves.toMatchObject({ verdict: "ready" });
+
+    await expect(
+      probeAgentAvailability({
+        target: { url: "https://agent.example.test/health" },
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ ready: false }), { status: 200 }),
+      }),
+    ).resolves.toMatchObject({ verdict: "not-ready(ready=false)" });
+
+    await expect(
+      probeAgentAvailability({
+        target: { url: "https://agent.example.test/health" },
+        fetchImpl: async () => {
+          throw new Error("ECONNREFUSED");
+        },
+      }),
+    ).resolves.toMatchObject({ verdict: "unreachable(ECONNREFUSED)" });
+  });
+
+  it("summarizes skipped chat legs with the agent preflight verdict", () => {
+    const summary = {
+      tests: [
+        {
+          testIdentifierString: "MessageGestureUITests/testSendsMessage()",
+          testStatus: "Skipped",
+        },
+        {
+          testIdentifierString: "BootCaptureUITests/testBootsHome()",
+          testStatus: "Passed",
+        },
+        {
+          testIdentifierString: "OnboardingChatUITests/testFirstReply()",
+          status: "skipped",
+        },
+      ],
+    };
+
+    expect(
+      summarizeChatSkipAccounting(summary, "not-ready(ready=false)"),
+    ).toEqual({
+      count: 2,
+      tests: [
+        "MessageGestureUITests/testSendsMessage()",
+        "OnboardingChatUITests/testFirstReply()",
+      ],
+      message: "2 chat legs skipped: agent never ready (not-ready(ready=false))",
+    });
+  });
+
+  it("makes --require-chat fail for a bad preflight or skipped chat legs", () => {
+    expect(
+      buildRequireChatDecision({
+        requireChat: true,
+        agentProbeVerdict: "ready",
+        chatSkippedCount: 1,
+      }),
+    ).toMatchObject({ exitNonZero: true, reason: "1 chat leg skipped" });
+    expect(
+      buildRequireChatDecision({
+        requireChat: true,
+        agentProbeVerdict: "unreachable(timeout)",
+        chatSkippedCount: 0,
+      }),
+    ).toMatchObject({
+      exitNonZero: true,
+      reason: "agent preflight unreachable(timeout)",
+    });
+    expect(
+      buildRequireChatDecision({
+        requireChat: false,
+        agentProbeVerdict: "unreachable(timeout)",
+        chatSkippedCount: 1,
+      }),
+    ).toMatchObject({ exitNonZero: false });
   });
 });

--- a/packages/app/scripts/ios-device-lib.test.mjs
+++ b/packages/app/scripts/ios-device-lib.test.mjs
@@ -1236,14 +1236,14 @@ describe("ios-device-capture agent availability preflight (#13569)", () => {
       ),
     ).toMatchObject({
       kind: "cloud-health",
-      url: "https://cloud.example.test/health",
+      url: "https://cloud.example.test/api/health",
     });
   });
 
   it("maps probe responses to ready, not-ready, and unreachable verdicts", async () => {
     await expect(
       probeAgentAvailability({
-        target: { url: "https://agent.example.test/health" },
+        target: { url: "https://agent.example.test/api/health" },
         fetchImpl: async () =>
           new Response(JSON.stringify({ ready: true }), { status: 200 }),
       }),
@@ -1251,7 +1251,7 @@ describe("ios-device-capture agent availability preflight (#13569)", () => {
 
     await expect(
       probeAgentAvailability({
-        target: { url: "https://agent.example.test/health" },
+        target: { url: "https://agent.example.test/api/health" },
         fetchImpl: async () =>
           new Response(JSON.stringify({ ready: false }), { status: 200 }),
       }),
@@ -1259,7 +1259,7 @@ describe("ios-device-capture agent availability preflight (#13569)", () => {
 
     await expect(
       probeAgentAvailability({
-        target: { url: "https://agent.example.test/health" },
+        target: { url: "https://agent.example.test/api/health" },
         fetchImpl: async () => {
           throw new Error("ECONNREFUSED");
         },


### PR DESCRIPTION
## Summary
- Adds an iOS device-capture agent availability preflight before XCUITest shards run.
- Records the preflight target/verdict in the aggregate `test-summary.json`.
- Adds attributed chat skip accounting: `N chat legs skipped: agent never ready (<probe verdict>)`.
- Adds `--require-chat`, which fails the capture when the preflight is not ready or chat legs were skipped.

## Covers from #13569 proposal 1
- Preflight probe for the reply path via configured iOS/mobile API base, falling back to cloud health.
- Summary + exit-message surfacing for chat skips caused by agent never ready.
- Require-chat strict mode to prevent green-by-skip chat legs.

## Follow-ups intentionally out of scope
- Proposal 2: host-agent routing knob.
- Proposal 3: device chat smoke twin.
- Swift/XCUITest-side skip attribution remains device-gated follow-up per scope fence.

## Validation
- `node --check packages/app/scripts/ios-device-capture.mjs`
- `node --check packages/app/scripts/ios-device-lib.test.mjs`
- `git diff --check`
- Targeted Vitest attempted, blocked in fresh worktree because dependencies are not installed in the worktree (`Cannot find module .../node_modules/react/index.js` from `packages/app/test/setup.ts`).