### PR TITLE
fix: flip wake readiness when the agent can actually answer

### DIFF
--- a/.github/issue-evidence/14038-wake-signal-mock-openai.mjs
+++ b/.github/issue-evidence/14038-wake-signal-mock-openai.mjs
@@ -12,12 +12,19 @@ const PORT = Number(process.env.MOCK_PORT ?? 18099);
 /** Build a minimal instance of a JSON schema (fills required fields). */
 function instantiate(schema, keyHint = "") {
   if (!schema || typeof schema !== "object") return "pong from mock";
-  if (Array.isArray(schema.anyOf) && schema.anyOf.length) return instantiate(schema.anyOf[0], keyHint);
-  if (Array.isArray(schema.oneOf) && schema.oneOf.length) return instantiate(schema.oneOf[0], keyHint);
-  if (Array.isArray(schema.allOf) && schema.allOf.length) return instantiate(schema.allOf[0], keyHint);
+  if (Array.isArray(schema.anyOf) && schema.anyOf.length)
+    return instantiate(schema.anyOf[0], keyHint);
+  if (Array.isArray(schema.oneOf) && schema.oneOf.length)
+    return instantiate(schema.oneOf[0], keyHint);
+  if (Array.isArray(schema.allOf) && schema.allOf.length)
+    return instantiate(schema.allOf[0], keyHint);
   const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
   if (schema.enum && Array.isArray(schema.enum) && schema.enum.length) {
-    const pref = schema.enum.find((v) => typeof v === "string" && /reply|simple|respond|message|none|chat|direct/i.test(v));
+    const pref = schema.enum.find(
+      (v) =>
+        typeof v === "string" &&
+        /reply|simple|respond|message|none|chat|direct/i.test(v),
+    );
     return pref ?? schema.enum[0];
   }
   if (schema.const !== undefined) return schema.const;
@@ -38,7 +45,8 @@ function instantiate(schema, keyHint = "") {
       return [];
     }
     case "string": {
-      if (/message|text|reply|response|thought|answer|say/i.test(keyHint)) return "pong from mock";
+      if (/message|text|reply|response|thought|answer|say/i.test(keyHint))
+        return "pong from mock";
       if (/name|action|kind|type|route/i.test(keyHint)) return "REPLY";
       return "pong from mock";
     }
@@ -61,7 +69,10 @@ function lastUserText(messages) {
     const c = m?.content;
     if (typeof c === "string") return c;
     if (Array.isArray(c)) {
-      const t = c.filter((p) => p?.type === "text").map((p) => p.text).join("\n");
+      const t = c
+        .filter((p) => p?.type === "text")
+        .map((p) => p.text)
+        .join("\n");
       if (t) return t;
     }
   }
@@ -71,7 +82,7 @@ function lastUserText(messages) {
 function completionContent(body) {
   const schema = body?.response_format?.json_schema?.schema;
   if (schema) return JSON.stringify(instantiate(schema));
-  const prompt = lastUserText(body?.messages) + " " + (body?.messages?.map((m) => (typeof m?.content === "string" ? m.content : "")).join(" ") ?? "");
+  const prompt = `${lastUserText(body?.messages)} ${body?.messages?.map((m) => (typeof m?.content === "string" ? m.content : "")).join(" ") ?? ""}`;
   // Legacy XML response-format prompts ask for a <response> block.
   if (/<response>/.test(prompt)) {
     return "<response><thought>ok</thought><actions>REPLY</actions><providers></providers><text>pong from mock</text><message>pong from mock</message></response>";
@@ -88,32 +99,59 @@ const server = http.createServer(async (req, res) => {
   for await (const c of req) chunks.push(c);
   const raw = Buffer.concat(chunks).toString("utf8");
   let body = null;
-  try { body = raw ? JSON.parse(raw) : null; } catch { body = null; }
+  try {
+    body = raw ? JSON.parse(raw) : null;
+  } catch {
+    body = null;
+  }
   const url = req.url ?? "";
 
   if (req.method === "GET" && /\/models\/?$/.test(url.split("?")[0])) {
     res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify({ object: "list", data: [
-      { id: "gpt-4o-mini", object: "model" }, { id: "gpt-4o", object: "model" },
-      { id: "gpt-5-mini", object: "model" }, { id: "text-embedding-3-small", object: "model" },
-    ] }));
+    res.end(
+      JSON.stringify({
+        object: "list",
+        data: [
+          { id: "gpt-4o-mini", object: "model" },
+          { id: "gpt-4o", object: "model" },
+          { id: "gpt-5-mini", object: "model" },
+          { id: "text-embedding-3-small", object: "model" },
+        ],
+      }),
+    );
     return;
   }
   if (req.method === "POST" && url.includes("/embeddings")) {
     const input = Array.isArray(body?.input) ? body.input : [body?.input ?? ""];
     res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify({ object: "list", model: body?.model ?? "text-embedding-3-small",
-      data: input.map((_, i) => ({ object: "embedding", index: i, embedding: new Array(1536).fill(0.001) })),
-      usage: { prompt_tokens: 1, total_tokens: 1 } }));
+    res.end(
+      JSON.stringify({
+        object: "list",
+        model: body?.model ?? "text-embedding-3-small",
+        data: input.map((_, i) => ({
+          object: "embedding",
+          index: i,
+          embedding: new Array(1536).fill(0.001),
+        })),
+        usage: { prompt_tokens: 1, total_tokens: 1 },
+      }),
+    );
     return;
   }
-  if (req.method === "POST" && (url.includes("/chat/completions") || url.includes("/completions"))) {
+  if (
+    req.method === "POST" &&
+    (url.includes("/chat/completions") || url.includes("/completions"))
+  ) {
     const content = completionContent(body);
     const model = body?.model ?? "gpt-4o-mini";
     if (body?.stream) {
-      res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+      res.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+      });
       const id = "chatcmpl-mock";
-      const mk = (delta, finish = null) => `data: ${JSON.stringify({ id, object: "chat.completion.chunk", created: Math.floor(Date.now() / 1000), model, choices: [{ index: 0, delta, finish_reason: finish }] })}\n\n`;
+      const mk = (delta, finish = null) =>
+        `data: ${JSON.stringify({ id, object: "chat.completion.chunk", created: Math.floor(Date.now() / 1000), model, choices: [{ index: 0, delta, finish_reason: finish }] })}\n\n`;
       res.write(mk({ role: "assistant" }));
       res.write(mk({ content }));
       res.write(mk({}, "stop"));
@@ -122,18 +160,44 @@ const server = http.createServer(async (req, res) => {
       return;
     }
     res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify({ id: "chatcmpl-mock", object: "chat.completion", created: Math.floor(Date.now() / 1000), model,
-      choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
-      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }));
+    res.end(
+      JSON.stringify({
+        id: "chatcmpl-mock",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model,
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      }),
+    );
     return;
   }
   if (req.method === "POST" && url.includes("/responses")) {
     // OpenAI Responses API shim (in case the SDK routes there).
     const content = completionContent(body);
     res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify({ id: "resp-mock", object: "response", status: "completed",
-      output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: content }] }],
-      output_text: content, usage: { input_tokens: 10, output_tokens: 5 } }));
+    res.end(
+      JSON.stringify({
+        id: "resp-mock",
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: content }],
+          },
+        ],
+        output_text: content,
+        usage: { input_tokens: 10, output_tokens: 5 },
+      }),
+    );
     return;
   }
   res.writeHead(200, { "content-type": "application/json" });

--- a/.github/issue-evidence/14038-wake-signal-mock-openai.mjs
+++ b/.github/issue-evidence/14038-wake-signal-mock-openai.mjs
@@ -1,0 +1,145 @@
+/**
+ * Minimal OpenAI-compatible mock provider for the wake-status probe.
+ * Serves /v1/models, /v1/chat/completions (stream + non-stream, with
+ * json_schema structured-output synthesis), /v1/embeddings and /v1/responses.
+ * Purpose: give the booted agent a REAL registered TEXT handler + real
+ * end-to-end replies with deterministic latency, no external keys.
+ */
+import http from "node:http";
+
+const PORT = Number(process.env.MOCK_PORT ?? 18099);
+
+/** Build a minimal instance of a JSON schema (fills required fields). */
+function instantiate(schema, keyHint = "") {
+  if (!schema || typeof schema !== "object") return "pong from mock";
+  if (Array.isArray(schema.anyOf) && schema.anyOf.length) return instantiate(schema.anyOf[0], keyHint);
+  if (Array.isArray(schema.oneOf) && schema.oneOf.length) return instantiate(schema.oneOf[0], keyHint);
+  if (Array.isArray(schema.allOf) && schema.allOf.length) return instantiate(schema.allOf[0], keyHint);
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  if (schema.enum && Array.isArray(schema.enum) && schema.enum.length) {
+    const pref = schema.enum.find((v) => typeof v === "string" && /reply|simple|respond|message|none|chat|direct/i.test(v));
+    return pref ?? schema.enum[0];
+  }
+  if (schema.const !== undefined) return schema.const;
+  switch (type) {
+    case "object": {
+      const out = {};
+      const props = schema.properties ?? {};
+      const req = new Set(schema.required ?? Object.keys(props));
+      for (const [k, sub] of Object.entries(props)) {
+        if (!req.has(k)) continue;
+        out[k] = instantiate(sub, k);
+      }
+      return out;
+    }
+    case "array": {
+      const min = schema.minItems ?? 0;
+      if (min > 0) return [instantiate(schema.items ?? {}, keyHint)];
+      return [];
+    }
+    case "string": {
+      if (/message|text|reply|response|thought|answer|say/i.test(keyHint)) return "pong from mock";
+      if (/name|action|kind|type|route/i.test(keyHint)) return "REPLY";
+      return "pong from mock";
+    }
+    case "number":
+    case "integer":
+      return 0;
+    case "boolean":
+      return false;
+    case "null":
+      return null;
+    default:
+      return "pong from mock";
+  }
+}
+
+function lastUserText(messages) {
+  if (!Array.isArray(messages)) return "";
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    const c = m?.content;
+    if (typeof c === "string") return c;
+    if (Array.isArray(c)) {
+      const t = c.filter((p) => p?.type === "text").map((p) => p.text).join("\n");
+      if (t) return t;
+    }
+  }
+  return "";
+}
+
+function completionContent(body) {
+  const schema = body?.response_format?.json_schema?.schema;
+  if (schema) return JSON.stringify(instantiate(schema));
+  const prompt = lastUserText(body?.messages) + " " + (body?.messages?.map((m) => (typeof m?.content === "string" ? m.content : "")).join(" ") ?? "");
+  // Legacy XML response-format prompts ask for a <response> block.
+  if (/<response>/.test(prompt)) {
+    return "<response><thought>ok</thought><actions>REPLY</actions><providers></providers><text>pong from mock</text><message>pong from mock</message></response>";
+  }
+  // shouldRespond-style gates often want RESPOND/IGNORE verdicts.
+  if (/RESPOND\b[\s\S]*IGNORE\b/.test(prompt) && /should/i.test(prompt)) {
+    return "<response><action>RESPOND</action><reasoning>probe</reasoning></response>";
+  }
+  return "pong from mock";
+}
+
+const server = http.createServer(async (req, res) => {
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  const raw = Buffer.concat(chunks).toString("utf8");
+  let body = null;
+  try { body = raw ? JSON.parse(raw) : null; } catch { body = null; }
+  const url = req.url ?? "";
+
+  if (req.method === "GET" && /\/models\/?$/.test(url.split("?")[0])) {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ object: "list", data: [
+      { id: "gpt-4o-mini", object: "model" }, { id: "gpt-4o", object: "model" },
+      { id: "gpt-5-mini", object: "model" }, { id: "text-embedding-3-small", object: "model" },
+    ] }));
+    return;
+  }
+  if (req.method === "POST" && url.includes("/embeddings")) {
+    const input = Array.isArray(body?.input) ? body.input : [body?.input ?? ""];
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ object: "list", model: body?.model ?? "text-embedding-3-small",
+      data: input.map((_, i) => ({ object: "embedding", index: i, embedding: new Array(1536).fill(0.001) })),
+      usage: { prompt_tokens: 1, total_tokens: 1 } }));
+    return;
+  }
+  if (req.method === "POST" && (url.includes("/chat/completions") || url.includes("/completions"))) {
+    const content = completionContent(body);
+    const model = body?.model ?? "gpt-4o-mini";
+    if (body?.stream) {
+      res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+      const id = "chatcmpl-mock";
+      const mk = (delta, finish = null) => `data: ${JSON.stringify({ id, object: "chat.completion.chunk", created: Math.floor(Date.now() / 1000), model, choices: [{ index: 0, delta, finish_reason: finish }] })}\n\n`;
+      res.write(mk({ role: "assistant" }));
+      res.write(mk({ content }));
+      res.write(mk({}, "stop"));
+      res.write("data: [DONE]\n\n");
+      res.end();
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ id: "chatcmpl-mock", object: "chat.completion", created: Math.floor(Date.now() / 1000), model,
+      choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }));
+    return;
+  }
+  if (req.method === "POST" && url.includes("/responses")) {
+    // OpenAI Responses API shim (in case the SDK routes there).
+    const content = completionContent(body);
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ id: "resp-mock", object: "response", status: "completed",
+      output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: content }] }],
+      output_text: content, usage: { input_tokens: 10, output_tokens: 5 } }));
+    return;
+  }
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ ok: true }));
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(`[mock-openai] listening on 127.0.0.1:${PORT}`);
+});

--- a/.github/issue-evidence/14038-wake-signal-probe-runs.md
+++ b/.github/issue-evidence/14038-wake-signal-probe-runs.md
@@ -1,0 +1,52 @@
+# 14038 — wake-status readiness-signal probe runs (real server lane)
+
+Harness: `14038-wake-signal-probe.mjs` (+ `14038-wake-signal-mock-openai.mjs`), run against
+the shipped server lane — `bun packages/app-core/dist/entry.js start` with
+`ELIZA_HEADLESS=1`, a fresh `ELIZA_STATE_DIR`, and an OpenAI-compatible mock provider on
+`127.0.0.1:18099` so the boot registers a REAL TEXT_GENERATION handler and produces real
+end-to-end replies (no external keys). The probe polls `GET /api/health` and
+`GET /api/status` every 250ms and concurrently drives a real chat send
+(`POST /api/conversations` + `/messages`) from the first moment HTTP accepts.
+
+Set `PROBE_ROOT=<repo checkout>` and run `node 14038-wake-signal-probe.mjs` from a scratch
+directory; it writes `timeline.json` + `agent-boot.log` beside itself.
+
+## BEFORE (develop e6637aca28) — `14038-wake-signal-timeline-baseline.json`
+
+```
+HTTP accepting (API bound):        6.51s
+first chat reply (any):            11.49s   "This agent has no LLM provider configured. Set ANTHROPIC_API_KEY, ..."  <-- WRONG answer to a real turn (key WAS set)
+second no-provider reply:          12.35s
+/api/health ready=true:            11.53s   (canRespond still false — signals bracket readiness)
+/api/status state=running:         11.57s   (canRespond still false)
+/api/status canRespond=true:       13.14s   <-- +1.65s AFTER the agent started answering chat
+first MODEL-backed chat reply:     14.42s
+```
+
+The warming gate released chat turns at `state=running` while all model-provider plugins
+were still in the deferred wave: the agent answered — wrongly — while the polled readiness
+signal said not-ready, and `canRespond` lagged until the deferred provider registered.
+
+## AFTER (this fix) — `14038-wake-signal-timeline-fixed.json`
+
+```
+HTTP accepting (API bound):        8.75s
+/api/health ready=true:            15.63s   (ready AND canRespond flip in the SAME transition)
+first chat reply (any):            15.84s   <-- model-backed on the FIRST reply; zero no-provider replies
+first MODEL-backed chat reply:     15.85s
+/api/status state=running:         15.99s   (canRespond true in the SAME transition — never running/canRespond:false)
+/api/status canRespond=true:       15.99s
+GAP chat-replied -> canRespond:    0.14s    (within one 250ms probe tick; launcher polls at 1500ms)
+```
+
+Boot log confirms the mechanism: `[boot] configured provider plugin @elizaos/plugin-openai
+loaded before runtime initialization`, `Plugin resolution phase=blocking: 3/17 plugin(s)
+selected` (sql, local-inference, openai), `phase=deferred: 14/17` (provider excluded from
+the deferred wave — no double registration; action-collision warnings identical to
+baseline: 29 = 29).
+
+There is no longer any window where the agent answers chat while the polled readiness
+signal reads not-ready, and the "no LLM provider configured" wrong answer during warm-up
+is gone.
+
+[core-brain]

--- a/.github/issue-evidence/14038-wake-signal-probe.mjs
+++ b/.github/issue-evidence/14038-wake-signal-probe.mjs
@@ -1,0 +1,189 @@
+/**
+ * Wake-status readiness-signal probe (develop tip).
+ *
+ * Spawns the real server lane (`bun run packages/app-core/dist/entry.js start`
+ * — the exact process the desktop launcher and cloud container run), then
+ * concurrently:
+ *   - polls GET /api/health   (the desktop launcher's boot gate: `ready`)
+ *   - polls GET /api/status   (the app shell's readiness poll: `canRespond`,
+ *                              via deriveAgentReady — the "Waking…" banner gate)
+ *   - drives a REAL chat send (POST /api/conversations + /messages) from the
+ *     first moment HTTP accepts, recording when the FIRST assistant reply lands.
+ *
+ * Output: a timeline proving when TRUE readiness (chat answered) happens vs
+ * when each polled signal flips.
+ */
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = process.env.PROBE_ROOT ?? ".";
+const DIR = process.cwd();
+const API_PORT = Number(process.env.PROBE_API_PORT ?? 31881);
+const BASE = `http://127.0.0.1:${API_PORT}`;
+const TOKEN = "wakeprobe-token";
+const STATE_DIR = path.join(DIR, `state-${Date.now()}`);
+const TIMEOUT_MS = Number(process.env.PROBE_TIMEOUT_MS ?? 240_000);
+const DEFER = process.env.PROBE_DEFER ?? "1";
+
+fs.mkdirSync(STATE_DIR, { recursive: true });
+const t0 = Date.now();
+const el = () => ((Date.now() - t0) / 1000).toFixed(2).padStart(7) + "s";
+const events = [];
+const mark = (name, detail = "") => {
+  events.push({ t: Date.now() - t0, name, detail });
+  console.log(`[probe] ${el()}  ${name}${detail ? `  ${detail}` : ""}`);
+};
+
+const child = spawn("bun", ["run", "packages/app-core/dist/entry.js", "start"], {
+  cwd: ROOT,
+  env: {
+    ...process.env,
+    ELIZA_HEADLESS: "1",
+    ELIZA_API_PORT: String(API_PORT),
+    ELIZA_DEFER_APP_ROUTES: DEFER,
+    ELIZA_STATE_DIR: STATE_DIR,
+    ELIZA_API_TOKEN: TOKEN,
+    OPENAI_API_KEY: "sk-wakeprobe-mock-000000000000",
+    OPENAI_BASE_URL: "http://127.0.0.1:18099/v1",
+    OPENAI_SMALL_MODEL: "gpt-4o-mini",
+    OPENAI_LARGE_MODEL: "gpt-4o",
+    LOG_LEVEL: "info",
+  },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+const logPath = path.join(DIR, "agent-boot.log");
+const logStream = fs.createWriteStream(logPath);
+child.stdout.on("data", (d) => logStream.write(d));
+child.stderr.on("data", (d) => logStream.write(d));
+child.on("exit", (code, sig) => mark("CHILD_EXIT", `code=${code} sig=${sig}`));
+mark("SPAWNED", `pid=${child.pid} defer=${DEFER}`);
+
+const H = { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" };
+const jf = async (url, init) => {
+  const res = await fetch(url, { ...init, signal: AbortSignal.timeout(60_000) });
+  let body = null;
+  try { body = await res.json(); } catch { body = null; }
+  return { status: res.status, body };
+};
+
+let firstHttp = 0;
+let healthReadyAt = 0;
+let statusCanRespondAt = 0;
+let statusRunningAt = 0;
+let chatRepliedAt = 0;
+let firstAnyReplyAt = 0;
+let chatReplyText = "";
+let convId = null;
+let lastHealth = "";
+let lastStatus = "";
+let chatSentAt = 0;
+let chatInFlight = false;
+
+async function pollOnce() {
+  // /api/health — the desktop launcher's boot gate
+  try {
+    const { status, body } = await jf(`${BASE}/api/health`, { headers: H });
+    if (!firstHttp) { firstHttp = Date.now() - t0; mark("HTTP_ACCEPTING", `health HTTP ${status}`); }
+    const sig = JSON.stringify({ s: status, ready: body?.ready, canRespond: body?.canRespond, st: body?.agentState });
+    if (sig !== lastHealth) {
+      lastHealth = sig;
+      mark("HEALTH_CHANGE", sig);
+      if (body?.ready === true && !healthReadyAt) { healthReadyAt = Date.now() - t0; mark("HEALTH_READY_TRUE"); }
+    }
+  } catch { /* not accepting yet */ }
+  // /api/status — the app shell readiness poll (deriveAgentReady ← canRespond)
+  try {
+    const { status, body } = await jf(`${BASE}/api/status`, { headers: H });
+    const sig = JSON.stringify({ s: status, state: body?.state, canRespond: body?.canRespond, model: body?.model ?? null });
+    if (sig !== lastStatus) {
+      lastStatus = sig;
+      mark("STATUS_CHANGE", sig);
+      if (body?.state === "running" && !statusRunningAt) { statusRunningAt = Date.now() - t0; mark("STATUS_STATE_RUNNING"); }
+      if (body?.canRespond === true && !statusCanRespondAt) { statusCanRespondAt = Date.now() - t0; mark("STATUS_CANRESPOND_TRUE"); }
+    }
+  } catch { /* not accepting yet */ }
+}
+
+async function chatAttempt() {
+  if (chatRepliedAt || chatInFlight || !firstHttp) return;
+  chatInFlight = true;
+  try {
+    if (!convId) {
+      const { status, body } = await jf(`${BASE}/api/conversations`, {
+        method: "POST", headers: H, body: JSON.stringify({ title: "wakeprobe" }),
+      });
+      if (status === 200 && body?.conversation?.id) {
+        convId = body.conversation.id;
+        mark("CONV_CREATED", `id=${convId}`);
+      } else {
+        mark("CONV_CREATE_FAIL", `HTTP ${status} ${JSON.stringify(body).slice(0, 160)}`);
+      }
+    }
+    if (convId && !chatSentAt) {
+      chatSentAt = Date.now() - t0;
+      const { status, body } = await jf(`${BASE}/api/conversations/${convId}/messages`, {
+        method: "POST", headers: H,
+        body: JSON.stringify({ text: "ping — reply with one word" }),
+      });
+      if (status === 200 && typeof body?.text === "string" && body.text.trim()) {
+        const text = body.text.trim().slice(0, 120);
+        const modelBacked = !/no llm provider|not configured|configure/i.test(text);
+        if (!firstAnyReplyAt) {
+          firstAnyReplyAt = Date.now() - t0;
+          mark("CHAT_REPLIED_ANY", `HTTP 200 text=${JSON.stringify(text)}`);
+        }
+        if (modelBacked && !chatRepliedAt) {
+          chatRepliedAt = Date.now() - t0;
+          chatReplyText = text;
+          mark("CHAT_REPLIED_MODEL", `HTTP 200 text=${JSON.stringify(text)}`);
+        } else if (!modelBacked) {
+          mark("CHAT_REPLY_NOPROVIDER", JSON.stringify(text.slice(0, 60)));
+          chatSentAt = 0; // keep probing until a model-backed reply lands
+        }
+      } else {
+        mark("CHAT_FAIL", `HTTP ${status} ${JSON.stringify(body).slice(0, 200)}`);
+        chatSentAt = 0; // retry
+      }
+    }
+  } catch (err) {
+    mark("CHAT_ERROR", String(err).slice(0, 160));
+    chatSentAt = 0;
+  } finally {
+    chatInFlight = false;
+  }
+}
+
+const iv = setInterval(pollOnce, 250);
+const civ = setInterval(chatAttempt, 1500);
+
+const done = () => (chatRepliedAt && statusCanRespondAt && healthReadyAt) || Date.now() - t0 > TIMEOUT_MS;
+await new Promise((resolve) => {
+  const check = setInterval(() => {
+    if (done()) { clearInterval(check); resolve(); }
+  }, 500);
+});
+// small settle to catch trailing flips
+await new Promise((r) => setTimeout(r, 4000));
+await pollOnce();
+clearInterval(iv);
+clearInterval(civ);
+
+console.log("\n=== WAKE-STATUS SIGNAL TIMELINE (develop tip, server lane) ===");
+console.log(`defer_app_routes=${DEFER}`);
+const fmt = (v) => (v ? (v / 1000).toFixed(2) + "s" : "NEVER (within timeout)");
+console.log(`HTTP accepting (API bound):        ${fmt(firstHttp)}`);
+console.log(`first chat reply (any):            ${fmt(firstAnyReplyAt)}`);
+console.log(`first MODEL-backed chat reply:     ${fmt(chatRepliedAt)}   reply=${JSON.stringify(chatReplyText)}`);
+console.log(`/api/status state=running:         ${fmt(statusRunningAt)}`);
+console.log(`/api/status canRespond=true:       ${fmt(statusCanRespondAt)}   <-- deriveAgentReady flips here (banner clears)`);
+console.log(`/api/health ready=true:            ${fmt(healthReadyAt)}   <-- desktop launcher boot gate`);
+if (chatRepliedAt && statusCanRespondAt) {
+  console.log(`GAP chat-replied -> canRespond:    ${((statusCanRespondAt - chatRepliedAt) / 1000).toFixed(2)}s`);
+}
+fs.writeFileSync(path.join(DIR, "timeline.json"), JSON.stringify({ defer: DEFER, firstHttp, chatRepliedAt, statusRunningAt, statusCanRespondAt, healthReadyAt, events }, null, 2));
+
+child.kill("SIGTERM");
+await new Promise((r) => setTimeout(r, 1500));
+try { child.kill("SIGKILL"); } catch {}
+process.exit(0);

--- a/.github/issue-evidence/14038-wake-signal-probe.mjs
+++ b/.github/issue-evidence/14038-wake-signal-probe.mjs
@@ -28,30 +28,34 @@ const DEFER = process.env.PROBE_DEFER ?? "1";
 
 fs.mkdirSync(STATE_DIR, { recursive: true });
 const t0 = Date.now();
-const el = () => ((Date.now() - t0) / 1000).toFixed(2).padStart(7) + "s";
+const el = () => `${((Date.now() - t0) / 1000).toFixed(2).padStart(7)}s`;
 const events = [];
 const mark = (name, detail = "") => {
   events.push({ t: Date.now() - t0, name, detail });
   console.log(`[probe] ${el()}  ${name}${detail ? `  ${detail}` : ""}`);
 };
 
-const child = spawn("bun", ["run", "packages/app-core/dist/entry.js", "start"], {
-  cwd: ROOT,
-  env: {
-    ...process.env,
-    ELIZA_HEADLESS: "1",
-    ELIZA_API_PORT: String(API_PORT),
-    ELIZA_DEFER_APP_ROUTES: DEFER,
-    ELIZA_STATE_DIR: STATE_DIR,
-    ELIZA_API_TOKEN: TOKEN,
-    OPENAI_API_KEY: "sk-wakeprobe-mock-000000000000",
-    OPENAI_BASE_URL: "http://127.0.0.1:18099/v1",
-    OPENAI_SMALL_MODEL: "gpt-4o-mini",
-    OPENAI_LARGE_MODEL: "gpt-4o",
-    LOG_LEVEL: "info",
+const child = spawn(
+  "bun",
+  ["run", "packages/app-core/dist/entry.js", "start"],
+  {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      ELIZA_HEADLESS: "1",
+      ELIZA_API_PORT: String(API_PORT),
+      ELIZA_DEFER_APP_ROUTES: DEFER,
+      ELIZA_STATE_DIR: STATE_DIR,
+      ELIZA_API_TOKEN: TOKEN,
+      OPENAI_API_KEY: "sk-wakeprobe-mock-000000000000",
+      OPENAI_BASE_URL: "http://127.0.0.1:18099/v1",
+      OPENAI_SMALL_MODEL: "gpt-4o-mini",
+      OPENAI_LARGE_MODEL: "gpt-4o",
+      LOG_LEVEL: "info",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
   },
-  stdio: ["ignore", "pipe", "pipe"],
-});
+);
 const logPath = path.join(DIR, "agent-boot.log");
 const logStream = fs.createWriteStream(logPath);
 child.stdout.on("data", (d) => logStream.write(d));
@@ -59,11 +63,21 @@ child.stderr.on("data", (d) => logStream.write(d));
 child.on("exit", (code, sig) => mark("CHILD_EXIT", `code=${code} sig=${sig}`));
 mark("SPAWNED", `pid=${child.pid} defer=${DEFER}`);
 
-const H = { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" };
+const H = {
+  authorization: `Bearer ${TOKEN}`,
+  "content-type": "application/json",
+};
 const jf = async (url, init) => {
-  const res = await fetch(url, { ...init, signal: AbortSignal.timeout(60_000) });
+  const res = await fetch(url, {
+    ...init,
+    signal: AbortSignal.timeout(60_000),
+  });
   let body = null;
-  try { body = await res.json(); } catch { body = null; }
+  try {
+    body = await res.json();
+  } catch {
+    body = null;
+  }
   return { status: res.status, body };
 };
 
@@ -84,25 +98,51 @@ async function pollOnce() {
   // /api/health — the desktop launcher's boot gate
   try {
     const { status, body } = await jf(`${BASE}/api/health`, { headers: H });
-    if (!firstHttp) { firstHttp = Date.now() - t0; mark("HTTP_ACCEPTING", `health HTTP ${status}`); }
-    const sig = JSON.stringify({ s: status, ready: body?.ready, canRespond: body?.canRespond, st: body?.agentState });
+    if (!firstHttp) {
+      firstHttp = Date.now() - t0;
+      mark("HTTP_ACCEPTING", `health HTTP ${status}`);
+    }
+    const sig = JSON.stringify({
+      s: status,
+      ready: body?.ready,
+      canRespond: body?.canRespond,
+      st: body?.agentState,
+    });
     if (sig !== lastHealth) {
       lastHealth = sig;
       mark("HEALTH_CHANGE", sig);
-      if (body?.ready === true && !healthReadyAt) { healthReadyAt = Date.now() - t0; mark("HEALTH_READY_TRUE"); }
+      if (body?.ready === true && !healthReadyAt) {
+        healthReadyAt = Date.now() - t0;
+        mark("HEALTH_READY_TRUE");
+      }
     }
-  } catch { /* not accepting yet */ }
+  } catch {
+    /* not accepting yet */
+  }
   // /api/status — the app shell readiness poll (deriveAgentReady ← canRespond)
   try {
     const { status, body } = await jf(`${BASE}/api/status`, { headers: H });
-    const sig = JSON.stringify({ s: status, state: body?.state, canRespond: body?.canRespond, model: body?.model ?? null });
+    const sig = JSON.stringify({
+      s: status,
+      state: body?.state,
+      canRespond: body?.canRespond,
+      model: body?.model ?? null,
+    });
     if (sig !== lastStatus) {
       lastStatus = sig;
       mark("STATUS_CHANGE", sig);
-      if (body?.state === "running" && !statusRunningAt) { statusRunningAt = Date.now() - t0; mark("STATUS_STATE_RUNNING"); }
-      if (body?.canRespond === true && !statusCanRespondAt) { statusCanRespondAt = Date.now() - t0; mark("STATUS_CANRESPOND_TRUE"); }
+      if (body?.state === "running" && !statusRunningAt) {
+        statusRunningAt = Date.now() - t0;
+        mark("STATUS_STATE_RUNNING");
+      }
+      if (body?.canRespond === true && !statusCanRespondAt) {
+        statusCanRespondAt = Date.now() - t0;
+        mark("STATUS_CANRESPOND_TRUE");
+      }
     }
-  } catch { /* not accepting yet */ }
+  } catch {
+    /* not accepting yet */
+  }
 }
 
 async function chatAttempt() {
@@ -111,24 +151,39 @@ async function chatAttempt() {
   try {
     if (!convId) {
       const { status, body } = await jf(`${BASE}/api/conversations`, {
-        method: "POST", headers: H, body: JSON.stringify({ title: "wakeprobe" }),
+        method: "POST",
+        headers: H,
+        body: JSON.stringify({ title: "wakeprobe" }),
       });
       if (status === 200 && body?.conversation?.id) {
         convId = body.conversation.id;
         mark("CONV_CREATED", `id=${convId}`);
       } else {
-        mark("CONV_CREATE_FAIL", `HTTP ${status} ${JSON.stringify(body).slice(0, 160)}`);
+        mark(
+          "CONV_CREATE_FAIL",
+          `HTTP ${status} ${JSON.stringify(body).slice(0, 160)}`,
+        );
       }
     }
     if (convId && !chatSentAt) {
       chatSentAt = Date.now() - t0;
-      const { status, body } = await jf(`${BASE}/api/conversations/${convId}/messages`, {
-        method: "POST", headers: H,
-        body: JSON.stringify({ text: "ping — reply with one word" }),
-      });
-      if (status === 200 && typeof body?.text === "string" && body.text.trim()) {
+      const { status, body } = await jf(
+        `${BASE}/api/conversations/${convId}/messages`,
+        {
+          method: "POST",
+          headers: H,
+          body: JSON.stringify({ text: "ping — reply with one word" }),
+        },
+      );
+      if (
+        status === 200 &&
+        typeof body?.text === "string" &&
+        body.text.trim()
+      ) {
         const text = body.text.trim().slice(0, 120);
-        const modelBacked = !/no llm provider|not configured|configure/i.test(text);
+        const modelBacked = !/no llm provider|not configured|configure/i.test(
+          text,
+        );
         if (!firstAnyReplyAt) {
           firstAnyReplyAt = Date.now() - t0;
           mark("CHAT_REPLIED_ANY", `HTTP 200 text=${JSON.stringify(text)}`);
@@ -142,7 +197,10 @@ async function chatAttempt() {
           chatSentAt = 0; // keep probing until a model-backed reply lands
         }
       } else {
-        mark("CHAT_FAIL", `HTTP ${status} ${JSON.stringify(body).slice(0, 200)}`);
+        mark(
+          "CHAT_FAIL",
+          `HTTP ${status} ${JSON.stringify(body).slice(0, 200)}`,
+        );
         chatSentAt = 0; // retry
       }
     }
@@ -157,10 +215,15 @@ async function chatAttempt() {
 const iv = setInterval(pollOnce, 250);
 const civ = setInterval(chatAttempt, 1500);
 
-const done = () => (chatRepliedAt && statusCanRespondAt && healthReadyAt) || Date.now() - t0 > TIMEOUT_MS;
+const done = () =>
+  (chatRepliedAt && statusCanRespondAt && healthReadyAt) ||
+  Date.now() - t0 > TIMEOUT_MS;
 await new Promise((resolve) => {
   const check = setInterval(() => {
-    if (done()) { clearInterval(check); resolve(); }
+    if (done()) {
+      clearInterval(check);
+      resolve();
+    }
   }, 500);
 });
 // small settle to catch trailing flips
@@ -171,19 +234,44 @@ clearInterval(civ);
 
 console.log("\n=== WAKE-STATUS SIGNAL TIMELINE (develop tip, server lane) ===");
 console.log(`defer_app_routes=${DEFER}`);
-const fmt = (v) => (v ? (v / 1000).toFixed(2) + "s" : "NEVER (within timeout)");
+const fmt = (v) => (v ? `${(v / 1000).toFixed(2)}s` : "NEVER (within timeout)");
 console.log(`HTTP accepting (API bound):        ${fmt(firstHttp)}`);
 console.log(`first chat reply (any):            ${fmt(firstAnyReplyAt)}`);
-console.log(`first MODEL-backed chat reply:     ${fmt(chatRepliedAt)}   reply=${JSON.stringify(chatReplyText)}`);
+console.log(
+  `first MODEL-backed chat reply:     ${fmt(chatRepliedAt)}   reply=${JSON.stringify(chatReplyText)}`,
+);
 console.log(`/api/status state=running:         ${fmt(statusRunningAt)}`);
-console.log(`/api/status canRespond=true:       ${fmt(statusCanRespondAt)}   <-- deriveAgentReady flips here (banner clears)`);
-console.log(`/api/health ready=true:            ${fmt(healthReadyAt)}   <-- desktop launcher boot gate`);
+console.log(
+  `/api/status canRespond=true:       ${fmt(statusCanRespondAt)}   <-- deriveAgentReady flips here (banner clears)`,
+);
+console.log(
+  `/api/health ready=true:            ${fmt(healthReadyAt)}   <-- desktop launcher boot gate`,
+);
 if (chatRepliedAt && statusCanRespondAt) {
-  console.log(`GAP chat-replied -> canRespond:    ${((statusCanRespondAt - chatRepliedAt) / 1000).toFixed(2)}s`);
+  console.log(
+    `GAP chat-replied -> canRespond:    ${((statusCanRespondAt - chatRepliedAt) / 1000).toFixed(2)}s`,
+  );
 }
-fs.writeFileSync(path.join(DIR, "timeline.json"), JSON.stringify({ defer: DEFER, firstHttp, chatRepliedAt, statusRunningAt, statusCanRespondAt, healthReadyAt, events }, null, 2));
+fs.writeFileSync(
+  path.join(DIR, "timeline.json"),
+  JSON.stringify(
+    {
+      defer: DEFER,
+      firstHttp,
+      chatRepliedAt,
+      statusRunningAt,
+      statusCanRespondAt,
+      healthReadyAt,
+      events,
+    },
+    null,
+    2,
+  ),
+);
 
 child.kill("SIGTERM");
 await new Promise((r) => setTimeout(r, 1500));
-try { child.kill("SIGKILL"); } catch {}
+try {
+  child.kill("SIGKILL");
+} catch {}
 process.exit(0);

--- a/.github/issue-evidence/14038-wake-signal-timeline-baseline.json
+++ b/.github/issue-evidence/14038-wake-signal-timeline-baseline.json
@@ -1,0 +1,90 @@
+{
+  "defer": "1",
+  "firstHttp": 6505,
+  "chatRepliedAt": 14418,
+  "statusRunningAt": 11573,
+  "statusCanRespondAt": 13143,
+  "healthReadyAt": 11533,
+  "events": [
+    {
+      "t": 9,
+      "name": "SPAWNED",
+      "detail": "pid=972163 defer=1"
+    },
+    {
+      "t": 6505,
+      "name": "HTTP_ACCEPTING",
+      "detail": "health HTTP 200"
+    },
+    {
+      "t": 6506,
+      "name": "HEALTH_CHANGE",
+      "detail": "{\"s\":200,\"ready\":false,\"canRespond\":false,\"st\":\"starting\"}"
+    },
+    {
+      "t": 6768,
+      "name": "STATUS_CHANGE",
+      "detail": "{\"s\":200,\"state\":\"starting\",\"canRespond\":false,\"model\":null}"
+    },
+    {
+      "t": 9284,
+      "name": "CONV_CREATED",
+      "detail": "id=1e0d684d-84b5-4aa7-8b89-b5dfc50574a1"
+    },
+    {
+      "t": 11488,
+      "name": "CHAT_REPLIED_ANY",
+      "detail": "HTTP 200 text=\"This agent has no LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or OPENROUTER_API_KEY in your environm\""
+    },
+    {
+      "t": 11488,
+      "name": "CHAT_REPLY_NOPROVIDER",
+      "detail": "\"This agent has no LLM provider configured. Set ANTHROPIC_API\""
+    },
+    {
+      "t": 11533,
+      "name": "HEALTH_CHANGE",
+      "detail": "{\"s\":200,\"ready\":true,\"canRespond\":false,\"st\":\"running\"}"
+    },
+    {
+      "t": 11533,
+      "name": "HEALTH_READY_TRUE",
+      "detail": ""
+    },
+    {
+      "t": 11573,
+      "name": "STATUS_CHANGE",
+      "detail": "{\"s\":200,\"state\":\"running\",\"canRespond\":false,\"model\":\"openai\"}"
+    },
+    {
+      "t": 11573,
+      "name": "STATUS_STATE_RUNNING",
+      "detail": ""
+    },
+    {
+      "t": 12346,
+      "name": "CHAT_REPLY_NOPROVIDER",
+      "detail": "\"This agent has no LLM provider configured. Set ANTHROPIC_API\""
+    },
+    {
+      "t": 13073,
+      "name": "HEALTH_CHANGE",
+      "detail": "{\"s\":200,\"ready\":true,\"canRespond\":true,\"st\":\"running\"}"
+    },
+    {
+      "t": 13143,
+      "name": "STATUS_CHANGE",
+      "detail": "{\"s\":200,\"state\":\"running\",\"canRespond\":true,\"model\":\"openai\"}"
+    },
+    {
+      "t": 13143,
+      "name": "STATUS_CANRESPOND_TRUE",
+      "detail": ""
+    },
+    {
+      "t": 14418,
+      "name": "CHAT_REPLIED_MODEL",
+      "detail": "HTTP 200 text=\"<response><action>RESPOND</action><reasoning>probe</reasoning></response>\""
+    }
+  ]
+}

--- a/.github/issue-evidence/14038-wake-signal-timeline-fixed.json
+++ b/.github/issue-evidence/14038-wake-signal-timeline-fixed.json
@@ -1,0 +1,70 @@
+{
+  "defer": "1",
+  "firstHttp": 8748,
+  "chatRepliedAt": 15847,
+  "statusRunningAt": 15992,
+  "statusCanRespondAt": 15992,
+  "healthReadyAt": 15627,
+  "events": [
+    {
+      "t": 8,
+      "name": "SPAWNED",
+      "detail": "pid=991461 defer=1"
+    },
+    {
+      "t": 8748,
+      "name": "HTTP_ACCEPTING",
+      "detail": "health HTTP 200"
+    },
+    {
+      "t": 8748,
+      "name": "HEALTH_CHANGE",
+      "detail": "{\"s\":200,\"ready\":false,\"canRespond\":false,\"st\":\"starting\"}"
+    },
+    {
+      "t": 9262,
+      "name": "CONV_CREATED",
+      "detail": "id=3851e4a5-2953-4bd0-b352-5e0425fd0fa6"
+    },
+    {
+      "t": 9309,
+      "name": "STATUS_CHANGE",
+      "detail": "{\"s\":200,\"state\":\"starting\",\"canRespond\":false,\"model\":null}"
+    },
+    {
+      "t": 15626,
+      "name": "HEALTH_CHANGE",
+      "detail": "{\"s\":200,\"ready\":true,\"canRespond\":true,\"st\":\"running\"}"
+    },
+    {
+      "t": 15627,
+      "name": "HEALTH_READY_TRUE",
+      "detail": ""
+    },
+    {
+      "t": 15844,
+      "name": "CHAT_REPLIED_ANY",
+      "detail": "HTTP 200 text=\"<response><action>RESPOND</action><reasoning>probe</reasoning></response>\""
+    },
+    {
+      "t": 15847,
+      "name": "CHAT_REPLIED_MODEL",
+      "detail": "HTTP 200 text=\"<response><action>RESPOND</action><reasoning>probe</reasoning></response>\""
+    },
+    {
+      "t": 15991,
+      "name": "STATUS_CHANGE",
+      "detail": "{\"s\":200,\"state\":\"running\",\"canRespond\":true,\"model\":\"openai\"}"
+    },
+    {
+      "t": 15992,
+      "name": "STATUS_STATE_RUNNING",
+      "detail": ""
+    },
+    {
+      "t": 15992,
+      "name": "STATUS_CANRESPOND_TRUE",
+      "detail": ""
+    }
+  ]
+}

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -26,6 +26,7 @@ const MAX_BACKUP_BODY_BYTES = 128 * 1024 * 1024; // 128 MB
 import path from "node:path";
 import {
   type AgentRuntime,
+  EventType,
   type IAgentRuntime,
   type IScreenCaptureService,
   isStreamingDestinationConfigured,
@@ -3991,6 +3992,7 @@ export async function startApiServer(opts?: {
         onRestart,
         onRuntimeSwapped: () => {
           bindRuntimeStreams(state.runtime);
+          wireModelRegistrationBroadcast(state.runtime);
           void wireCoordinatorBridgesWhenReady(state, {
             wireChatBridge: wireCodingAgentChatBridge,
             wireWsBridge: wireCodingAgentWsBridge,
@@ -5060,6 +5062,28 @@ export async function startApiServer(opts?: {
   // Make broadcastStatus accessible to route handlers via state
   state.broadcastStatus = broadcastStatus;
 
+  // Flip the WS status lane the moment a model handler registers instead of
+  // waiting for the next 5s statusInterval tick: `canRespond` turns true when a
+  // late-registering provider (deferred wave, first-run configure, runtime
+  // plugin install) adds its TEXT_GENERATION handler, and the launcher clears
+  // its "Waking…" banner on that signal. A provider registers one handler per
+  // model type, so coalesce the burst into a single broadcast per tick.
+  const modelBroadcastWiredRuntimes = new WeakSet<AgentRuntime>();
+  let modelBroadcastScheduled = false;
+  const wireModelRegistrationBroadcast = (rt: AgentRuntime | null): void => {
+    if (!rt || modelBroadcastWiredRuntimes.has(rt)) return;
+    modelBroadcastWiredRuntimes.add(rt);
+    rt.registerEvent(EventType.MODEL_REGISTERED, async () => {
+      if (modelBroadcastScheduled) return;
+      modelBroadcastScheduled = true;
+      setTimeout(() => {
+        modelBroadcastScheduled = false;
+        broadcastStatus();
+      }, 0);
+    });
+  };
+  wireModelRegistrationBroadcast(state.runtime);
+
   // Generic broadcast — sends an arbitrary JSON payload to all WS clients.
   state.broadcastWs = (data: object) => {
     const message = JSON.stringify(data);
@@ -5283,6 +5307,7 @@ export async function startApiServer(opts?: {
     state.chatConnectionReady = null;
     state.chatConnectionPromise = null;
     bindRuntimeStreams(rt);
+    wireModelRegistrationBroadcast(rt);
     // Wake any chat turns held through the warming window — first-turn
     // capability is now online, so they stream their response instead of 503.
     runtimeReadyGate.markReady(rt);

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -62,6 +62,7 @@ export {
   PROVIDER_PLUGIN_MAP,
 } from "./plugin-collector.ts";
 
+import { PROVIDER_PLUGIN_MAP } from "./plugin-collector.ts";
 import { STATIC_ELIZA_PLUGIN_LOADERS } from "./plugin-types.ts";
 
 export {
@@ -627,7 +628,7 @@ async function ensureStaticPluginsRegisteredByName(
   );
   if (missing.length > 0) {
     logger.debug(
-      `[boot] no static registration for preferred provider plugin(s): ${missing.join(", ")}`,
+      `[boot] no static registration for configured provider plugin(s): ${missing.join(", ")}`,
     );
   }
 
@@ -643,12 +644,12 @@ async function ensureStaticPluginsRegisteredByName(
         if (mod) {
           STATIC_ELIZA_PLUGINS[registryName] = mod;
           logger.info(
-            `[boot] preferred provider plugin ${registration.packageName} loaded before runtime initialization`,
+            `[boot] configured provider plugin ${registration.packageName} loaded before runtime initialization`,
           );
         }
       } catch (err) {
         logger.warn(
-          `[boot] preferred provider plugin ${registration.packageName} unavailable before runtime initialization: ${formatError(err)}`,
+          `[boot] configured provider plugin ${registration.packageName} unavailable before runtime initialization: ${formatError(err)}`,
         );
       }
     }),
@@ -4067,10 +4068,25 @@ export async function startEliza(
   const blockDeferredPluginImports = shouldBlockDeferredPluginImports();
   const initialPluginResolutionPhase: PluginResolutionPhase =
     blockDeferredPluginImports ? "all" : "blocking";
-  const initialForceIncludePluginNames =
-    !blockDeferredPluginImports && preferredProviderPluginName
-      ? [preferredProviderPluginName]
-      : [];
+  // Model-provider plugins load in the BLOCKING phase (see the phase filter in
+  // resolvePlugins): a configured provider must register its TEXT_GENERATION
+  // handler before the runtime reports ready, or /api/status flips `running`
+  // with `canRespond:false` and the warming gate releases chat turns into
+  // "no LLM provider configured" replies. Bundled runtimes (mobile: no
+  // node_modules) can only resolve statically registered modules, so import
+  // the providers whose auto-enable env key is present up front — the same
+  // modules the deferred static wave would have imported moments later.
+  const configuredProviderPluginNames = Object.entries(PROVIDER_PLUGIN_MAP)
+    .filter(([envKey]) => Boolean(process.env[envKey]?.trim()))
+    .map(([, pluginName]) => pluginName);
+  const initialForceIncludePluginNames = !blockDeferredPluginImports
+    ? [
+        ...new Set([
+          ...(preferredProviderPluginName ? [preferredProviderPluginName] : []),
+          ...configuredProviderPluginNames,
+        ]),
+      ]
+    : [];
   await ensureStaticPluginsRegisteredByName(initialForceIncludePluginNames);
   const resolvedPlugins = await resolvePlugins(config, {
     quiet: preOnboarding,

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -219,6 +219,19 @@ export const CHANNEL_PLUGIN_MAP: Readonly<Record<string, string>> =
 export const PROVIDER_PLUGIN_MAP: Readonly<Record<string, string>> =
   providerPluginMap;
 
+/**
+ * Every model-provider plugin package (the values of {@link PROVIDER_PLUGIN_MAP}).
+ * A configured provider is first-turn capability — chat cannot answer without a
+ * TEXT_GENERATION handler — so the boot phase split treats these as blocking:
+ * a provider that made it into the load set registers BEFORE the runtime
+ * reports ready (agentState `running` / `canRespond`), never in the deferred
+ * wave. Otherwise the readiness signal flips while the first chat turns still
+ * answer "no LLM provider configured" (#14038 wake-status lag).
+ */
+export const MODEL_PROVIDER_PLUGIN_NAMES: ReadonlySet<string> = new Set(
+  Object.values(PROVIDER_PLUGIN_MAP),
+);
+
 const LOCAL_MODEL_PROVIDER_PLUGINS = new Set<string>([
   "@elizaos/plugin-ollama",
   "@elizaos/plugin-local-inference",

--- a/packages/agent/src/runtime/plugin-resolver.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver.test.ts
@@ -8,11 +8,16 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import type { Plugin } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   resolvePlugins,
   resolveRuntimePluginImportSpecifier,
 } from "./plugin-resolver";
+import {
+  STATIC_ELIZA_PLUGIN_LOADERS,
+  STATIC_ELIZA_PLUGINS,
+} from "./plugin-types";
 
 describe("resolveRuntimePluginImportSpecifier", () => {
   it("uses app plugin runtime entrypoints for core app plugins", () => {
@@ -160,5 +165,112 @@ describe("resolvePlugins boot-phase split for model providers (#14038)", () => {
       process.chdir(previousCwd);
       await rm(workspace, { recursive: true, force: true });
     }
+  }, 120_000);
+});
+
+describe("resolvePlugins mobile blocking-phase loadability gate (#14039)", () => {
+  // On mobile the bundle has no node_modules, so the blocking pass may only
+  // CLAIM (force-load now / exclude from the deferred pass) a model-provider
+  // plugin whose module is already loadable — present in STATIC_ELIZA_PLUGINS
+  // or STATIC_ELIZA_PLUGIN_LOADERS. Claiming a provider that
+  // ensureStaticPluginsRegisteredByName() could not register (no static entry)
+  // strands it: the blocking pass records it claimed but fails to load it, and
+  // the deferred pass then excludes it because the shared claimed set says
+  // blocking already owns it — dropping the configured provider from BOTH
+  // phases and deadlocking readiness on a provider that can never register.
+  const PROVIDER = "@elizaos/plugin-anthropic"; // in MOBILE_MODEL_PROVIDER_PLUGINS
+  const seededRegistryKeys: string[] = [];
+  const seededLoaderKeys: string[] = [];
+  let previousPlatform: string | undefined;
+  let previousApiKey: string | undefined;
+
+  const fakeProviderPlugin: Plugin = {
+    name: PROVIDER,
+    description: "mobile loadability gate fixture",
+    // A capability field so looksLikePlugin() accepts the seeded module
+    // (a bare { name, description } is treated as a provider, not a plugin).
+    services: [],
+  };
+
+  beforeEach(() => {
+    seededRegistryKeys.length = 0;
+    seededLoaderKeys.length = 0;
+    previousPlatform = process.env.ELIZA_PLATFORM;
+    previousApiKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ELIZA_PLATFORM = "android";
+    process.env.ANTHROPIC_API_KEY = "sk-mobile-loadability-gate-fixture";
+  });
+
+  afterEach(() => {
+    for (const key of seededRegistryKeys) delete STATIC_ELIZA_PLUGINS[key];
+    for (const key of seededLoaderKeys) delete STATIC_ELIZA_PLUGIN_LOADERS[key];
+    if (previousPlatform === undefined) delete process.env.ELIZA_PLATFORM;
+    else process.env.ELIZA_PLATFORM = previousPlatform;
+    if (previousApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = previousApiKey;
+  });
+
+  const config = () =>
+    ({
+      plugins: { allow: [PROVIDER], entries: {} },
+    }) as unknown as import("../config/config.ts").ElizaConfig;
+
+  it("does NOT claim a force-included provider absent from the static bundle at blocking time, so readiness does not deadlock and the deferred pass (once the static wave registers it) still owns it", async () => {
+    // No static registration for the provider at BLOCKING time — mirrors
+    // ensureStaticPluginsRegisteredByName() failing to bake it into the bundle
+    // before the blocking pass runs.
+    expect(STATIC_ELIZA_PLUGINS[PROVIDER]).toBeUndefined();
+    expect(STATIC_ELIZA_PLUGIN_LOADERS[PROVIDER]).toBeUndefined();
+
+    // eliza.ts force-includes every env-configured provider into the blocking
+    // pass; reproduce that here.
+    const blocking = await resolvePlugins(config(), {
+      quiet: true,
+      phase: "blocking",
+      forceIncludePluginNames: [PROVIDER],
+    });
+    const blockingNames = blocking.map((p) => p.name);
+    // The not-yet-loadable provider must NOT be force-kept in the blocking set —
+    // it cannot register at blocking time on mobile, so readiness cannot wait
+    // on it (the deadlock the reviewer flagged).
+    expect(blockingNames).not.toContain(PROVIDER);
+
+    // The deferred static wave runs AFTER the blocking pass and registers the
+    // provider's module. Because the blocking pass did NOT claim it into the
+    // shared claimed set, the deferred pass is free to own it rather than
+    // filtering it out — so the provider is not silently dropped from BOTH
+    // phases (the regression). Seed the loader to model the static wave growing.
+    STATIC_ELIZA_PLUGIN_LOADERS[PROVIDER] = async () => ({
+      default: fakeProviderPlugin,
+    });
+    seededLoaderKeys.push(PROVIDER);
+
+    const deferred = await resolvePlugins(config(), {
+      quiet: true,
+      phase: "deferred",
+    });
+    const deferredNames = deferred.map((p) => p.name);
+    expect(deferredNames).toContain(PROVIDER);
+  }, 120_000);
+
+  it("DOES claim a statically-bundled env-selected provider in the blocking phase (control)", async () => {
+    // Provider baked into the bundle — loadable now, so the blocking pass may
+    // claim it and the runtime blocks readiness on it (the #14038 invariant).
+    STATIC_ELIZA_PLUGINS[PROVIDER] = { default: fakeProviderPlugin };
+    seededRegistryKeys.push(PROVIDER);
+
+    const blocking = await resolvePlugins(config(), {
+      quiet: true,
+      phase: "blocking",
+      forceIncludePluginNames: [PROVIDER],
+    });
+    expect(blocking.map((p) => p.name)).toContain(PROVIDER);
+
+    const deferred = await resolvePlugins(config(), {
+      quiet: true,
+      phase: "deferred",
+    });
+    // Claimed by blocking => excluded from deferred (the two phases partition).
+    expect(deferred.map((p) => p.name)).not.toContain(PROVIDER);
   }, 120_000);
 });

--- a/packages/agent/src/runtime/plugin-resolver.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver.test.ts
@@ -95,3 +95,70 @@ describe("resolvePlugins manifest discovery", () => {
     }
   });
 });
+
+describe("resolvePlugins boot-phase split for model providers (#14038)", () => {
+  // A configured model provider is first-turn capability: it must load in the
+  // BLOCKING phase (before the runtime reports ready/canRespond), never the
+  // deferred wave. Driven through the real resolver with an on-disk drop-in
+  // package carrying a model-provider package name, plus a non-provider
+  // drop-in proving the deferred wave still owns everything else.
+  it("loads a model-provider plugin in the blocking phase and excludes it from the deferred phase", async () => {
+    const previousCwd = process.cwd();
+    const workspace = await mkdtemp(path.join(tmpdir(), "eliza-plugin-phase-"));
+    const dropinsDir = path.join(workspace, "dropin-plugins");
+    const writeDropIn = async (dirName: string, packageName: string) => {
+      const root = path.join(dropinsDir, dirName);
+      await mkdir(root, { recursive: true });
+      await writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({
+          name: packageName,
+          version: "0.0.0-test",
+          type: "module",
+          main: "./index.js",
+        }),
+        "utf8",
+      );
+      await writeFile(
+        path.join(root, "index.js"),
+        `export default { name: ${JSON.stringify(packageName)}, description: "phase-split test fixture.", views: [] };\n`,
+        "utf8",
+      );
+    };
+
+    try {
+      // The provider fixture reuses a real PROVIDER_PLUGIN_MAP package name so
+      // the phase filter classifies it as a model provider; the plain fixture
+      // is an ordinary custom plugin.
+      await writeDropIn("deepseek", "@elizaos/plugin-deepseek");
+      await writeDropIn("plain", "@dropins/plugin-plainfixture");
+      process.chdir(workspace);
+      const config = {
+        plugins: {
+          allow: [],
+          entries: {},
+          load: { paths: [dropinsDir] },
+        },
+      };
+
+      const blocking = await resolvePlugins(config, {
+        quiet: true,
+        phase: "blocking",
+      });
+      const blockingNames = blocking.map((p) => p.name);
+      expect(blockingNames).toContain("@elizaos/plugin-deepseek");
+      expect(blockingNames).not.toContain("@dropins/plugin-plainfixture");
+
+      const deferred = await resolvePlugins(config, {
+        quiet: true,
+        phase: "deferred",
+      });
+      const deferredNames = deferred.map((p) => p.name);
+      expect(deferredNames).not.toContain("@elizaos/plugin-deepseek");
+      expect(deferredNames).toContain("@dropins/plugin-plainfixture");
+    } finally {
+      process.chdir(previousCwd);
+      await rm(workspace, { recursive: true, force: true });
+    }
+  }, 120_000);
+});

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -1796,28 +1796,50 @@ export async function resolvePlugins(
     // which grows between the two passes — re-deriving would classify a
     // provider deferred in the blocking pass but blocking in the deferred
     // pass, dropping it from both.
+    // A model-provider plugin can only be CLAIMED by the blocking pass (and
+    // thus force-loaded now / excluded from the deferred pass) if it is
+    // actually loadable in the current phase. Off-mobile, node_modules is
+    // present so any provider is loadable. On mobile the bundle has no
+    // node_modules, so a provider is loadable only when its module is already
+    // in the static registry (STATIC_ELIZA_PLUGINS) or has a static loader
+    // (STATIC_ELIZA_PLUGIN_LOADERS) — the boot pre-registers configured
+    // providers' statics up front via ensureStaticPluginsRegisteredByName(),
+    // but a provider whose module is not baked into the bundle (e.g.
+    // DEEPSEEK_API_KEY -> @elizaos/plugin-deepseek) never becomes loadable.
+    // Claiming such a provider would strand it: the blocking pass records it as
+    // claimed but fails to load it (no static entry), and the deferred pass
+    // then excludes it because the claimed set says blocking owns it — dropping
+    // the configured provider from BOTH phases and deadlocking readiness on a
+    // provider that can never register (#14039).
+    const isProviderLoadableNow = (pluginName: string): boolean =>
+      !isMobilePlatform() ||
+      Boolean(STATIC_ELIZA_PLUGINS[pluginName]) ||
+      Boolean(STATIC_ELIZA_PLUGIN_LOADERS[pluginName]);
     if (phase === "blocking") {
       blockingPhaseClaimedProviderNames.clear();
       for (const pluginName of pluginsToLoad) {
         if (!MODEL_PROVIDER_PLUGIN_NAMES.has(pluginName)) continue;
-        const loadableNow =
-          !isMobilePlatform() ||
-          Boolean(STATIC_ELIZA_PLUGINS[pluginName]) ||
-          Boolean(STATIC_ELIZA_PLUGIN_LOADERS[pluginName]);
-        if (loadableNow) {
+        if (isProviderLoadableNow(pluginName)) {
           blockingPhaseClaimedProviderNames.add(pluginName);
         }
       }
     }
     for (const pluginName of Array.from(pluginsToLoad)) {
       if (forceIncludePluginNames.has(pluginName)) {
-        if (
-          phase === "blocking" &&
-          MODEL_PROVIDER_PLUGIN_NAMES.has(pluginName)
-        ) {
-          blockingPhaseClaimedProviderNames.add(pluginName);
+        // Force-include only applies to model providers that are loadable in
+        // this phase. An unloadable-on-mobile provider must NOT be force-kept
+        // in the blocking set (it can never register) and must NOT be claimed —
+        // fall through to the normal partition so the deferred pass can still
+        // own it. For non-provider force-includes, keep the original behaviour.
+        const isProvider = MODEL_PROVIDER_PLUGIN_NAMES.has(pluginName);
+        if (!isProvider || isProviderLoadableNow(pluginName)) {
+          if (phase === "blocking" && isProvider) {
+            blockingPhaseClaimedProviderNames.add(pluginName);
+          }
+          continue;
         }
-        continue;
+        // Unloadable-on-mobile forced provider: do not claim, do not force-keep.
+        // Fall through to the standard phase partition below.
       }
       const isBlocking =
         blockingPluginSet.has(pluginName) ||

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -41,6 +41,7 @@ import {
 import {
   CHANNEL_PLUGIN_MAP,
   collectPluginNames,
+  MODEL_PROVIDER_PLUGIN_NAMES,
   OPTIONAL_PLUGIN_MAP,
   type PluginLoadReasons,
   resolvePluginPackageAlias,
@@ -1603,6 +1604,15 @@ async function discoverPluginCandidatesUncached(): Promise<
  */
 export type PluginResolutionPhase = "all" | "blocking" | "deferred";
 
+/**
+ * Model-provider plugin names the most recent blocking-phase resolve claimed
+ * (kept in its load set). The deferred pass excludes exactly this set so the
+ * two phases partition providers deterministically even though the static
+ * plugin registry — which decides mobile loadability — grows between the
+ * passes. Reset at the start of every blocking-phase resolve.
+ */
+const blockingPhaseClaimedProviderNames = new Set<string>();
+
 export async function resolvePlugins(
   config: ElizaConfig,
   opts?: {
@@ -1769,11 +1779,49 @@ export async function resolvePlugins(
 
   if (phase !== "all") {
     const beforePhaseFilter = pluginsToLoad.size;
+    // Model-provider plugins in the load set are blocking alongside
+    // BLOCKING_CORE_PLUGINS: a TEXT_GENERATION handler is the one capability a
+    // chat turn cannot answer without, so a configured provider must register
+    // before the runtime flips ready (agentState `running`, `canRespond`, and
+    // the warming-gate release all key off that flip). Left in the deferred
+    // wave, the readiness signal reads not-ready while early turns answer
+    // "no LLM provider configured" (#14038).
+    //
+    // Mobile bundles can only import statically registered modules, and the
+    // deferred static wave has not run when the blocking pass resolves — so on
+    // mobile a provider is promoted only when its module is already loadable
+    // (the boot pre-registers configured providers' statics up front). The
+    // deferred pass then excludes exactly the set the blocking pass claimed
+    // (recorded below) rather than re-deriving it from the static registry,
+    // which grows between the two passes — re-deriving would classify a
+    // provider deferred in the blocking pass but blocking in the deferred
+    // pass, dropping it from both.
+    if (phase === "blocking") {
+      blockingPhaseClaimedProviderNames.clear();
+      for (const pluginName of pluginsToLoad) {
+        if (!MODEL_PROVIDER_PLUGIN_NAMES.has(pluginName)) continue;
+        const loadableNow =
+          !isMobilePlatform() ||
+          Boolean(STATIC_ELIZA_PLUGINS[pluginName]) ||
+          Boolean(STATIC_ELIZA_PLUGIN_LOADERS[pluginName]);
+        if (loadableNow) {
+          blockingPhaseClaimedProviderNames.add(pluginName);
+        }
+      }
+    }
     for (const pluginName of Array.from(pluginsToLoad)) {
       if (forceIncludePluginNames.has(pluginName)) {
+        if (
+          phase === "blocking" &&
+          MODEL_PROVIDER_PLUGIN_NAMES.has(pluginName)
+        ) {
+          blockingPhaseClaimedProviderNames.add(pluginName);
+        }
         continue;
       }
-      const isBlocking = blockingPluginSet.has(pluginName);
+      const isBlocking =
+        blockingPluginSet.has(pluginName) ||
+        blockingPhaseClaimedProviderNames.has(pluginName);
       if (
         (phase === "blocking" && !isBlocking) ||
         (phase === "deferred" && isBlocking)

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -1621,6 +1621,180 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       lockSpy.mockRestore();
     }
   });
+
+  test("(8) status='running' persists BEFORE the backup-restore push (#14038 wake-lag)", async () => {
+    // The status column is the reachability gate: the dedicated-agent proxy
+    // synthesizes 202 "starting" for every request (including the launcher's
+    // /api/status poll) until status='running'. The container serves the moment
+    // the health check + runtime-agent start succeed, so the flip must not wait
+    // for the (potentially long) state restore — that ordering is exactly the
+    // "agent answers in ~8s but launcher says waking for 90s+" prod window.
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const row = provisioningReadyRow();
+    const backup: AgentSandboxBackup = {
+      id: "33333333-3333-4333-8333-333333333333",
+      sandbox_record_id: row.id,
+      snapshot_type: "pre-shutdown",
+      state_data: { memories: [], config: {}, workspaceFiles: {} },
+      state_data_storage: "inline",
+      state_data_key: null,
+      size_bytes: 2,
+      backup_kind: "full",
+      parent_backup_id: null,
+      content_hash: null,
+      created_at: new Date("2026-06-04T12:05:00.000Z"),
+    };
+    const order: string[] = [];
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+      ...row,
+      status: "provisioning",
+    });
+    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(backup);
+    const reconstructedSpy = spyOn(
+      agentSandboxesRepository,
+      "getReconstructedBackupState",
+    ).mockResolvedValue({ memories: [], config: {}, workspaceFiles: {} });
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, data) => {
+        if (data.status === "running") order.push("status-running");
+        return { ...row, ...data };
+      },
+    );
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      plainKey: "eliza_test_agent_key",
+      prefix: "eliza_test",
+    });
+    const svc = new ElizaSandboxService();
+    const ensureStartedSpy = spyOn(
+      svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
+      "ensureRuntimeAgentStarted",
+    ).mockResolvedValue(null);
+    const pushStateSpy = spyOn(
+      svc as unknown as { pushState: () => Promise<unknown> },
+      "pushState",
+    ).mockImplementation(async () => {
+      order.push("push-state");
+      return null;
+    });
+    const getProviderSpy = spyOn(
+      svc as unknown as { getProvider: () => Promise<SandboxProvider> },
+      "getProvider",
+    ).mockResolvedValue({
+      create: mock(async () => providerHandle()),
+      stop: mock(async () => {}),
+      checkHealth: async () => true,
+    } as SandboxProvider);
+    try {
+      const res = await svc.provision(AGENT, ORG);
+      expect(res.success).toBe(true);
+      expect(order).toEqual(["status-running", "push-state"]);
+    } finally {
+      findSpy.mockRestore();
+      lockSpy.mockRestore();
+      backupSpy.mockRestore();
+      reconstructedSpy.mockRestore();
+      updateSpy.mockRestore();
+      apiKeySpy.mockRestore();
+      ensureStartedSpy.mockRestore();
+      pushStateSpy.mockRestore();
+      getProviderSpy.mockRestore();
+    }
+  });
+
+  test("(9) restore failure after the early running-write still ends in markError", async () => {
+    // 'running' must never stick on a failed provision: a restore failure takes
+    // the same catch as before (ghost cleanup → markError), so the early
+    // reachability flip cannot leave a broken agent advertised as running.
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const row: AgentSandbox = {
+      ...provisioningReadyRow(),
+      execution_tier: "dedicated-lazy",
+    };
+    const backup: AgentSandboxBackup = {
+      id: "44444444-4444-4444-8444-444444444444",
+      sandbox_record_id: row.id,
+      snapshot_type: "pre-shutdown",
+      state_data: { memories: [], config: {}, workspaceFiles: {} },
+      state_data_storage: "inline",
+      state_data_key: null,
+      size_bytes: 2,
+      backup_kind: "full",
+      parent_backup_id: null,
+      content_hash: null,
+      created_at: new Date("2026-06-04T12:05:00.000Z"),
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue({
+      ...row,
+      status: "error",
+    });
+    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+      ...row,
+      status: "provisioning",
+    });
+    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(backup);
+    const reconstructedSpy = spyOn(
+      agentSandboxesRepository,
+      "getReconstructedBackupState",
+    ).mockResolvedValue({ memories: [], config: {}, workspaceFiles: {} });
+    let runningWrites = 0;
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, data) => {
+        if (data.status === "running") runningWrites += 1;
+        return { ...row, ...data };
+      },
+    );
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      plainKey: "eliza_test_agent_key",
+      prefix: "eliza_test",
+    });
+    const svc = new ElizaSandboxService();
+    const markErrorSpy = spyOn(
+      svc as unknown as { markError: (rec: AgentSandbox, msg: string) => Promise<void> },
+      "markError",
+    ).mockResolvedValue(undefined);
+    const ensureStartedSpy = spyOn(
+      svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
+      "ensureRuntimeAgentStarted",
+    ).mockResolvedValue(null);
+    const pushStateSpy = spyOn(
+      svc as unknown as { pushState: () => Promise<unknown> },
+      "pushState",
+    ).mockRejectedValue(new Error("State restore failed: HTTP 500"));
+    const stop = mock(async () => {});
+    const getProviderSpy = spyOn(
+      svc as unknown as { getProvider: () => Promise<SandboxProvider> },
+      "getProvider",
+    ).mockResolvedValue({
+      create: mock(async () => providerHandle()),
+      stop,
+      checkHealth: async () => true,
+    } as SandboxProvider);
+    try {
+      const res = await svc.provision(AGENT, ORG);
+      expect(res.success).toBe(false);
+      expect(res.error).toBe("State restore failed: HTTP 500");
+      expect(runningWrites).toBe(1);
+      expect(markErrorSpy).toHaveBeenCalledTimes(1);
+      // Ghost cleanup still stops the container whose restore failed.
+      expect(stop).toHaveBeenCalledWith("sandbox-blue-1");
+    } finally {
+      findSpy.mockRestore();
+      findByIdSpy.mockRestore();
+      lockSpy.mockRestore();
+      backupSpy.mockRestore();
+      reconstructedSpy.mockRestore();
+      updateSpy.mockRestore();
+      apiKeySpy.mockRestore();
+      markErrorSpy.mockRestore();
+      ensureStartedSpy.mockRestore();
+      pushStateSpy.mockRestore();
+      getProviderSpy.mockRestore();
+    }
+  });
 });
 
 // LARP H3 — executeUpgrade() blue/green rollback, digest-mismatch, and the

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1437,40 +1437,19 @@ export class ElizaSandboxService {
 
         await this.ensureRuntimeAgentStarted(runtimeRec);
 
-        // 4. Restore from backup (reconstructs incrementals back to a full).
-        const backup = await agentSandboxesRepository.getLatestBackup(rec.id);
-        if (backup) {
-          const restoreState = await agentSandboxesRepository.getReconstructedBackupState(
-            backup.id,
-          );
-          if (restoreState) {
-            try {
-              await this.pushState(handle.bridgeUrl, restoreState, { trusted: true });
-            } catch (error) {
-              const message = error instanceof Error ? error.message : String(error);
-              if (
-                rec.execution_tier !== "custom" ||
-                !message.startsWith("State restore failed: HTTP 404")
-              ) {
-                throw error;
-              }
-              logger.info(
-                "[agent-sandbox] Backup restore skipped: custom image has no restore endpoint",
-                {
-                  agentId: rec.id,
-                  backupId: backup.id,
-                },
-              );
-            }
-          } else {
-            logger.warn("[agent-sandbox] Backup restore skipped: reconstructed state was null", {
-              agentId: rec.id,
-              backupId: backup.id,
-            });
-          }
-        }
-
-        // 5. Mark running + persist provider-specific metadata
+        // 4. Mark running + persist provider-specific metadata.
+        //
+        // This write happens BEFORE the backup restore on purpose: the status
+        // column is the reachability gate — the dedicated-agent proxy
+        // synthesizes a 202 "starting" for EVERY request (including the
+        // launcher's /api/status poll) until status='running'. The container is
+        // serving from this moment (health checked, runtime agent started), so
+        // gating the flip on the restore tail made a responsive agent read as
+        // "waking" for the whole restore — the launcher escalated to "taking
+        // longer than usual" while chat already answered (#14038). A restore
+        // failure still flips the row out of 'running' via the catch below
+        // (ghost cleanup → retry or markError), so 'running' never sticks on a
+        // failed provision.
         const updateData: Parameters<typeof agentSandboxesRepository.update>[1] = {
           status: "running",
           sandbox_id: handle.sandboxId,
@@ -1504,6 +1483,39 @@ export class ElizaSandboxService {
         // already reactivate; do it here so ALL provision paths re-enter billing.
         // Idempotent + exempt-guarded (ne billing_status 'exempt').
         await agentBillingRepository.reactivateSandboxBillingAfterFunding(rec.id, new Date());
+
+        // 5. Restore from backup (reconstructs incrementals back to a full).
+        const backup = await agentSandboxesRepository.getLatestBackup(rec.id);
+        if (backup) {
+          const restoreState = await agentSandboxesRepository.getReconstructedBackupState(
+            backup.id,
+          );
+          if (restoreState) {
+            try {
+              await this.pushState(handle.bridgeUrl, restoreState, { trusted: true });
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              if (
+                rec.execution_tier !== "custom" ||
+                !message.startsWith("State restore failed: HTTP 404")
+              ) {
+                throw error;
+              }
+              logger.info(
+                "[agent-sandbox] Backup restore skipped: custom image has no restore endpoint",
+                {
+                  agentId: rec.id,
+                  backupId: backup.id,
+                },
+              );
+            }
+          } else {
+            logger.warn("[agent-sandbox] Backup restore skipped: reconstructed state was null", {
+              agentId: rec.id,
+              backupId: backup.id,
+            });
+          }
+        }
 
         logger.info("[agent-sandbox] Provisioned", {
           agentId: rec.id,


### PR DESCRIPTION
## What

Fixes #14038 — the launcher shows "Eliza is taking longer than usual to wake…" while the agent is already responsive (stan-cloud prod e2e: bridge 200 + valid reply in ~8s). The polled readiness signal now flips exactly when the agent can answer a first turn, at both layers this repo owns:

**Runtime (`packages/agent`)** — model-provider plugins load in the BLOCKING boot phase instead of the deferred wave:
- `MODEL_PROVIDER_PLUGIN_NAMES` (the `PROVIDER_PLUGIN_MAP` values) is the classification source; the phase filter in `resolvePlugins` claims configured providers for the blocking pass and excludes exactly that claimed set from the deferred pass (stable partition even though the static registry grows between passes; on mobile a provider is only promoted when its module is already statically loadable, so nothing can drop from both phases).
- boot pre-registers the static modules for providers whose auto-enable env key is present (bundled runtimes have no node_modules to fall back to) — the same modules the deferred static wave imported moments later.
- effect: `agentState=running`, `canRespond`, `/api/health ready`, and the warming-gate release (`runtimeReadyGate.markReady`) all flip at the same instant a TEXT_GENERATION handler exists. This also removes a wrong answer served to real users: turns admitted between `updateRuntime` and deferred provider registration got "This agent has no LLM provider configured" while the key WAS set (captured in the baseline probe).
- WS lane: `broadcastStatus()` now fires on `MODEL_REGISTERED` (coalesced per tick), so a late-registering provider (first-run configure, plugin install) flips the WS status in ms instead of waiting for the 5s `statusInterval`.

**Cloud control plane (`packages/cloud/shared`)** — `provision()` (wake = `executeWake` → `provision`) persists `status='running'` + bridge/health metadata right after `checkHealth` + `ensureRuntimeAgentStarted` succeed and BEFORE the backup restore:
- the status column is the reachability gate — `dedicated-agent-proxy` synthesizes `202 {status:"starting"}` for EVERY proxied request (including the launcher's `/api/status` poll) until the row says running. Gating that flip on the restore tail is what made a responsive agent read as "waking" long enough to hit the 90s escalation.
- the restore still runs inside the same try: a restore failure takes the existing catch (ghost cleanup → retry or `markError`), so `running` never sticks on a failed provision. Concurrency is unchanged — after the early write the row is `running` WITH `sandbox_id`/`container_name` set, which fails `trySetProvisioning`'s steal predicate, and a concurrent `provision()` returns the already-running success path.

The remaining launcher-side half (desktop RPC strips `canRespond`; 202 body parses as empty status; 90s escalation keys off raw elapsed) is filed for [phone-ui] separately — see the linked issue.

## Why the signal lied (measured, real server lane)

Baseline on develop `e6637aca28` (`bun packages/app-core/dist/entry.js start`, OpenAI-compatible mock provider = a REAL registered TEXT handler, probe polling `/api/health` + `/api/status` every 250ms while driving a real chat send):

```
first chat reply (any):        11.49s  "This agent has no LLM provider configured…"  <- wrong answer, key was set
/api/health ready=true:        11.53s  (canRespond still false)
/api/status state=running:     11.57s  (canRespond still false)
/api/status canRespond=true:   13.14s  <- +1.65s AFTER the agent started answering
first MODEL-backed reply:      14.42s
```

After this PR (same harness, same lane):

```
/api/health ready=true:        15.63s  (ready AND canRespond flip in the SAME transition)
first chat reply (any):        15.84s  model-backed on the FIRST reply; zero no-provider replies
/api/status running+canRespond:15.99s  (one transition; never running/canRespond:false)
GAP chat-replied -> canRespond: 0.14s  (within one 250ms probe tick; launcher polls at 1.5s)
```

Boot log: `Plugin resolution phase=blocking: 3/17` (sql, local-inference, openai), `phase=deferred: 14/17`; no double registration (action-collision warnings identical to baseline, 29 = 29). Normalized time-to-first-true-answer is unchanged (baseline 7.9s from HTTP-accept vs 7.1s fixed).

## Evidence

`.github/issue-evidence/14038-*`: before/after `timeline.json`s, the probe harness + mock provider (re-runnable: `PROBE_ROOT=<checkout> node 14038-wake-signal-probe.mjs`), and `14038-wake-signal-probe-runs.md` with the annotated runs.

- Real-LLM trajectories: N/A — readiness-signal timing fix; no prompt/action/model behavior change. The probe drives the real server lane end-to-end with a real registered TEXT handler and real chat turns (harness + raw timelines attached and reviewed).
- Backend logs: probe boot logs reviewed (`[boot] configured provider plugin @elizaos/plugin-openai loaded before runtime initialization`, phase-split counts above).
- Screenshots/video: N/A — no rendered UI change in this PR (launcher-side work is the linked [phone-ui] issue).

## Tests

- `packages/agent` `plugin-resolver.test.ts` — new: real-resolver phase-split test (provider drop-in loads in blocking, excluded from deferred; non-provider drop-in stays deferred): 4/4 pass.
- `packages/cloud/shared` `eliza-sandbox.test.ts` — new: (8) `status='running'` persists BEFORE the restore push (order-asserted), (9) restore failure after the early write still ends in `markError` + ghost cleanup: full file 54/54 pass.
- Adjacent suites: `core-plugins`, `core-static-plugin-registrations`, `server-skip-listen`, `eliza-embedding-boot-order`, `optional-plugins` — 33/33 pass; `dedicated-agent-proxy` 9/9; `eliza-sandbox-dedicated-bootstrap` + `provisioning-jobs-delete-lifecycle` 12/12.
- Typecheck: `packages/agent` and `packages/cloud/shared` — zero new errors (error sets byte-identical to develop baseline via stash comparison; the pre-existing failures are the known aosp-local-inference / plugin-elizacloud transitive noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
