### PR TITLE
[sol-orch] ci: route linux jobs to hetzner fleet via HETZNER_FLEET_ONLINE toggle

### DIFF
--- a/.github/workflows/android-device-e2e.yml
+++ b/.github/workflows/android-device-e2e.yml
@@ -41,7 +41,7 @@ jobs:
   android-e2e:
     # Full matrix runs on manual dispatch only (unchanged). Never on PR.
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     env:
       ELIZA_MOBILE_REPO_ROOT: ${{ github.workspace }}
@@ -166,7 +166,7 @@ jobs:
   # it works on a stock x86 emulator where the embedded on-device agent SIGSEGVs).
   pr-device-smoke:
     if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:device') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     env:
       ELIZA_MOBILE_REPO_ROOT: ${{ github.workspace }}
@@ -294,7 +294,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'ci:device'))
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     env:
       ELIZA_BUN_RISCV64_OPTIONAL: "1"

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -60,7 +60,7 @@ env:
 jobs:
   build-aab:
     name: Build Signed AAB
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       version_name: ${{ steps.version.outputs.name }}
       version_code: ${{ steps.version.outputs.code }}
@@ -315,7 +315,7 @@ jobs:
     name: Publish to Play Store
     needs: build-aab
     if: needs.build-aab.outputs.play_store_ready == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -367,7 +367,7 @@ jobs:
     name: Release Summary
     needs: [build-aab, publish-play-store]
     if: always()
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Summary
         run: |

--- a/.github/workflows/app-aesthetic-audit.yml
+++ b/.github/workflows/app-aesthetic-audit.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   aesthetic-audit:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
       # Keyless: the ui-smoke stub is forced when CI=true (shouldForceStubStack).

--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -59,7 +59,7 @@ jobs:
   # agent from the UI.
   app-live-chat:
     name: app live chat (real local runtime)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
       PGLITE_WASM_MODE: node
@@ -131,7 +131,7 @@ jobs:
   # writes WALKTHROUGH_VERDICTS.md (the PR mock lane is keyless and can't).
   walkthrough-live:
     name: full walkthrough (real backend + model + vision verdicts)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     env:
       PGLITE_WASM_MODE: node
@@ -195,7 +195,7 @@ jobs:
   # authenticates. Skips cleanly if the key is absent.
   cloud-live:
     name: cloud login + provision + chat (real Eliza Cloud)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
       ELIZA_UI_SMOKE_CLOUD_LIVE: "1"
@@ -257,7 +257,7 @@ jobs:
   android-local-chat:
     name: android local chat (on-device GGUF)
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_android_local_chat }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -314,7 +314,7 @@ jobs:
   # still validate, so the renderer step is best-effort.
   desktop-packaged:
     name: desktop packaged (build + boot + renderer)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     env:
       PGLITE_WASM_MODE: node
@@ -385,7 +385,7 @@ jobs:
     name: notify on red nightly
     needs: [app-live-chat, walkthrough-live, cloud-live, desktop-packaged]
     if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       issues: write
     steps:

--- a/.github/workflows/app-real-e2e.yml
+++ b/.github/workflows/app-real-e2e.yml
@@ -47,7 +47,7 @@ env:
 jobs:
   app-real-e2e:
     name: Browser-driven real app e2e (nightly)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     continue-on-error: true
     steps:

--- a/.github/workflows/apple-store-release.yml
+++ b/.github/workflows/apple-store-release.yml
@@ -97,7 +97,7 @@ permissions:
 jobs:
   prepare:
     name: Prepare
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       version: ${{ steps.ver.outputs.version }}
       build_number: ${{ steps.ver.outputs.build_number }}
@@ -521,7 +521,7 @@ jobs:
     name: Release Summary
     needs: [prepare, build-ios, build-macos]
     if: always()
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Summary
         run: |

--- a/.github/workflows/apps-deploy-e2e.yml
+++ b/.github/workflows/apps-deploy-e2e.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   apps-deploy-e2e:
     name: Apps deploy + per-tenant DB isolation (real docker)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -60,7 +60,7 @@ jobs:
 
   tenant-db-isolation:
     name: Tenant-DB isolation — cross-tenant REVOKE CONNECT (throwaway Postgres) (#9853)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     # Lightweight pg-only proof (no docker): provision two tenants through the
     # real SqlTenantDbProvisioner against a throwaway Postgres and assert tenant

--- a/.github/workflows/arm-apps-daemon.yml
+++ b/.github/workflows/arm-apps-daemon.yml
@@ -71,7 +71,7 @@ concurrency:
 
 jobs:
   arm:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ${{ github.event.inputs.environment }}
     timeout-minutes: 10
     env:

--- a/.github/workflows/arm-headscale-control-plane.yml
+++ b/.github/workflows/arm-headscale-control-plane.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   arm:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ${{ github.event.inputs.environment }}
     timeout-minutes: 10
     env:

--- a/.github/workflows/attachment-journey-videos.yml
+++ b/.github/workflows/attachment-journey-videos.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   attachment-journey-videos:
     name: Attachment journey videos
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   label-pr:
     if: github.event_name == 'pull_request_target'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213
         with:
@@ -23,7 +23,7 @@ jobs:
 
   label-issue:
     if: github.event_name == 'issues'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:

--- a/.github/workflows/benchmark-orchestrator-scheduled.yml
+++ b/.github/workflows/benchmark-orchestrator-scheduled.yml
@@ -58,7 +58,7 @@ env:
 jobs:
   orchestrator-run:
     name: orchestrator-run
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     env:
       CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}

--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/benchmark-weekly.yml
+++ b/.github/workflows/benchmark-weekly.yml
@@ -74,7 +74,7 @@ permissions:
 jobs:
   benchmark:
     name: EA + connector benchmark
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 240
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/browser-real-bench.yml
+++ b/.github/workflows/browser-real-bench.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   browser-real-bench:
     name: Browser benchmarks on real Chromium
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -45,7 +45,7 @@ permissions:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     permissions:
       contents: read

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   build-android:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
 
     permissions:

--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-deb:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
 
     permissions:

--- a/.github/workflows/build-example-app-images.yml
+++ b/.github/workflows/build-example-app-images.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   build-edad:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -212,7 +212,7 @@ jobs:
           echo "::warning::Could not set package visibility to public — set it once manually in the GHCR package settings"
 
   build-clone-ur-crush:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/build-linux-iso.yml
+++ b/.github/workflows/build-linux-iso.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   build-iso:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 240
     # arm64 builds run under qemu-user-static + binfmt_misc emulation on
     # the amd64 runner. They are 3-5× slower than native, so they are

--- a/.github/workflows/build-llama-ffi-android.yml
+++ b/.github/workflows/build-llama-ffi-android.yml
@@ -58,7 +58,7 @@ env:
 
 jobs:
   prepare-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:
@@ -84,7 +84,7 @@ jobs:
   build:
     name: ${{ matrix.abi }}
     needs: prepare-matrix
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/.github/workflows/build-vm-image.yml
+++ b/.github/workflows/build-vm-image.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   build-vm:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
 
     permissions:

--- a/.github/workflows/cache-key-stability.yml
+++ b/.github/workflows/cache-key-stability.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   cache-key-stability:
     name: cache-key-stability
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/cerebras-nightly.yml
+++ b/.github/workflows/cerebras-nightly.yml
@@ -59,7 +59,7 @@ env:
 jobs:
   bench:
     name: "nightly: ${{ matrix.suite }}"
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -66,7 +66,7 @@ env:
 jobs:
   chat-shell-gestures:
     name: Chat shell gesture + parity e2e
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/ci-full-matrix-proof.yml
+++ b/.github/workflows/ci-full-matrix-proof.yml
@@ -53,7 +53,7 @@ env:
 jobs:
   matrix-proof:
     name: Exhaustive lane matrix proof
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,7 @@ jobs:
       !contains(github.event.pull_request.title, '[skip-review]') &&
       github.event.pull_request.draft != true
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -36,7 +36,7 @@ jobs:
       github.actor != 'cursor[bot]' &&
       github.actor != 'dependabot[bot]'
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/cloud-aesthetic-audit.yml
+++ b/.github/workflows/cloud-aesthetic-audit.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   cloud-aesthetic-audit:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
       # Keyless: the ui-smoke stub is forced when CI=true (shouldForceStubStack).

--- a/.github/workflows/cloud-deploy-backend.yml
+++ b/.github/workflows/cloud-deploy-backend.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   determine-env:
     name: Determine Environment
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       environment: ${{ steps.env.outputs.environment }}
       branch: ${{ steps.env.outputs.branch }}
@@ -62,7 +62,7 @@ jobs:
 
   migrate-db:
     name: Run Database Migrations
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs: determine-env
     # Job-level concurrency groups are repo-wide: this serializes against the
     # migrate-db gate in cloud-cf-deploy.yml (#11208) so overlapping triggers
@@ -151,7 +151,7 @@ jobs:
   deploy:
     name: Deploy to agent VPS
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_legacy_vps }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs: [determine-env, migrate-db]
     environment: ${{ needs.determine-env.outputs.environment }}
     timeout-minutes: 45

--- a/.github/workflows/cloud-e2e.yml
+++ b/.github/workflows/cloud-e2e.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   e2e:
     name: Mock-stack E2E
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       NODE_ENV: test

--- a/.github/workflows/cloud-gateway-discord.yml
+++ b/.github/workflows/cloud-gateway-discord.yml
@@ -58,7 +58,7 @@ permissions:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/cloud-gateway-webhook.yml
+++ b/.github/workflows/cloud-gateway-webhook.yml
@@ -42,7 +42,7 @@ permissions:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -53,7 +53,7 @@ permissions:
 
 jobs:
   lint-and-types:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -65,7 +65,7 @@ jobs:
         run: bun run --cwd packages/cloud/shared check:tenant-scope
 
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     env:
       NODE_ENV: test
@@ -84,7 +84,7 @@ jobs:
         run: bun run --cwd packages/cloud/shared test:vitest
 
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     env:
       NODE_ENV: test
@@ -98,7 +98,7 @@ jobs:
         run: bun run test:cloud:integration
 
   e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     needs: [lint-and-types]
     env:

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   coverage:
     name: coverage on changed files
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         # actions/checkout@v4

--- a/.github/workflows/deploy-apps-worker.yml
+++ b/.github/workflows/deploy-apps-worker.yml
@@ -64,7 +64,7 @@ permissions:
 jobs:
   determine-env:
     name: Determine environment
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       environment: ${{ steps.env.outputs.environment }}
       branch: ${{ steps.env.outputs.branch }}
@@ -85,7 +85,7 @@ jobs:
 
   deploy:
     name: Deploy apps worker to apps-control host (${{ needs.determine-env.outputs.environment }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs: determine-env
     environment: ${{ needs.determine-env.outputs.environment }}
     timeout-minutes: 15

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -48,7 +48,7 @@ permissions:
 jobs:
   determine-env:
     name: Determine environment
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       environment: ${{ steps.env.outputs.environment }}
       branch: ${{ steps.env.outputs.branch }}
@@ -69,7 +69,7 @@ jobs:
 
   deploy:
     name: Deploy worker to Hetzner host (${{ needs.determine-env.outputs.environment }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs: determine-env
     environment: ${{ needs.determine-env.outputs.environment }}
     timeout-minutes: 15

--- a/.github/workflows/deploy-homepage.yml
+++ b/.github/workflows/deploy-homepage.yml
@@ -69,7 +69,7 @@ permissions:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     steps:
       - name: Checkout source repo

--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -52,7 +52,7 @@ jobs:
     # Path classifier is a git-diff + node script: no self-hosted resources.
     # Keep it on GitHub-hosted so a drained hetzner fleet cannot leave it
     # queued indefinitely and pile up runs (#13617/#8501).
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     outputs:
       dev_smoke: ${{ steps.filter.outputs.dev_smoke }}
@@ -87,7 +87,7 @@ jobs:
     name: bun run dev onboarding chat
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.dev_smoke == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     env:
       PGLITE_WASM_MODE: node
@@ -158,7 +158,7 @@ jobs:
     name: Vite HMR dependency-level smoke
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.dev_smoke == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     env:
       PGLITE_WASM_MODE: node

--- a/.github/workflows/develop-exhaustive.yml
+++ b/.github/workflows/develop-exhaustive.yml
@@ -92,7 +92,7 @@ jobs:
     # Run even when a reusable lane failed so the proof enumerates every lane
     # and the result check below can name the offender; only a cancel skips it.
     if: ${{ !cancelled() }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     env:
       CI: "true"
       BUN_VERSION: "1.3.14"

--- a/.github/workflows/develop-staging-beta.yml
+++ b/.github/workflows/develop-staging-beta.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   gate-and-release:
     name: Gate Develop and Dispatch Beta
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -23,7 +23,7 @@ jobs:
     # Path classifier is a git-diff + node script: no self-hosted resources.
     # Keep it on GitHub-hosted so a drained hetzner fleet cannot leave it
     # queued indefinitely and pile up runs (#13617/#8501).
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
@@ -58,7 +58,7 @@ jobs:
     name: Build production Docker image (+ smoke boot)
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.docker == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     env:
       BUN_VERSION: "canary"

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -43,7 +43,7 @@ jobs:
       github.event.pull_request.draft != true &&
       (github.event.inputs.check_type == 'all' || github.event.inputs.check_type == 'links' || github.event.inputs.check_type == '')
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -114,7 +114,7 @@ jobs:
       github.event.pull_request.draft != true &&
       (github.event.inputs.check_type == 'all' || github.event.inputs.check_type == 'quality' || github.event.inputs.check_type == '')
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -184,7 +184,7 @@ jobs:
   create-pr:
     needs: [check-links, check-quality]
     if: always() && (needs.check-links.result == 'success' || needs.check-quality.result == 'success')
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/e1-chip.yml
+++ b/.github/workflows/e1-chip.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   docker-regression:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     defaults:
       run:
         working-directory: packages/research/chip

--- a/.github/workflows/electrobun-submodule-guard.yml
+++ b/.github/workflows/electrobun-submodule-guard.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   verify-electrobun-pin:
     name: electrobun gitlink is fetchable
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - name: Checkout (no submodules)

--- a/.github/workflows/elizaos-os-full-release.yml
+++ b/.github/workflows/elizaos-os-full-release.yml
@@ -19,7 +19,7 @@ jobs:
   # On a 'release' event github.ref_name is the tag (e.g. v2.0.1); we strip
   # the prefix here so downstream jobs get a clean version like '2.0.1'.
   prepare:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       version: ${{ steps.parse.outputs.version }}
       tag: ${{ steps.parse.outputs.tag }}
@@ -54,7 +54,7 @@ jobs:
   verify-artifacts:
     name: Verify build artifacts exist and are non-empty
     needs: [trigger-linux-iso, trigger-debian-package, trigger-vm-image]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - name: Download Linux ISO artifact
@@ -100,7 +100,7 @@ jobs:
   populate-and-validate-manifest:
     name: Populate manifest checksums and gate on publishable validation
     needs: [verify-artifacts]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     permissions:
       # contents: write — required by softprops/action-gh-release to
@@ -271,7 +271,7 @@ jobs:
 
   summary:
     needs: [trigger-linux-iso, trigger-debian-package, trigger-vm-image, verify-artifacts, populate-and-validate-manifest, publish-apt]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     if: always()
     timeout-minutes: 5
     steps:

--- a/.github/workflows/elizaos-os-release.yml
+++ b/.github/workflows/elizaos-os-release.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   validate-os-release:
     name: Validate OS release surfaces
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/external-api-live-drift.yml
+++ b/.github/workflows/external-api-live-drift.yml
@@ -70,7 +70,7 @@ env:
 jobs:
   live-drift:
     name: External-API mocks vs live APIs (nightly)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     continue-on-error: true
     steps:

--- a/.github/workflows/feed-apply-migrations.yml
+++ b/.github/workflows/feed-apply-migrations.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   migrate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     env:
       STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
       STAGING_DIRECT_DATABASE_URL: ${{ secrets.STAGING_DIRECT_DATABASE_URL }}

--- a/.github/workflows/feed-env-audit.yml
+++ b/.github/workflows/feed-env-audit.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   env-audit:
     name: env:audit:check
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/feed-rl-training.yml
+++ b/.github/workflows/feed-rl-training.yml
@@ -48,7 +48,7 @@ jobs:
   train:
     if: ${{ vars.ENABLE_RL_TRAINING == 'true' }}
     name: Train RL Model
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 360  # 6 hours max
     
     steps:

--- a/.github/workflows/feed-test.yml
+++ b/.github/workflows/feed-test.yml
@@ -46,7 +46,7 @@ env:
 jobs:
   feed-unit:
     name: feed unit tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     # Required env for feed modules that validate configuration at import time.
     # CI-only placeholders — no secrets. DATABASE_URL points at the postgres

--- a/.github/workflows/flatpak-publish.yml
+++ b/.github/workflows/flatpak-publish.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   submit-to-flathub:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
 
     steps:
       - name: Check if app is listed on Flathub

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         # actions/checkout@v4

--- a/.github/workflows/hetzner-e2e-reaper.yml
+++ b/.github/workflows/hetzner-e2e-reaper.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   reap:
     name: Sweep stale CI servers
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ci-hetzner-e2e
     timeout-minutes: 10
     env:

--- a/.github/workflows/hetzner-e2e.yml
+++ b/.github/workflows/hetzner-e2e.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   deploy:
     name: Provision + deploy + healthcheck
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ci-hetzner-e2e
     timeout-minutes: 25
     env:
@@ -356,7 +356,7 @@ jobs:
     name: Teardown
     needs: deploy
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ci-hetzner-e2e
     timeout-minutes: 10
     env:

--- a/.github/workflows/hetzner-provision-smoke.yml
+++ b/.github/workflows/hetzner-provision-smoke.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   provision:
     name: Provision + wait-ready + teardown (real Hetzner)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ci-hetzner-e2e
     timeout-minutes: 20
     env:

--- a/.github/workflows/hetzner-sleep-wake-smoke.yml
+++ b/.github/workflows/hetzner-sleep-wake-smoke.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   sleep-wake:
     name: provision -> sleep(backup+destroy) -> wake(reprovision+restore)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ci-hetzner-e2e
     timeout-minutes: 30
     env:

--- a/.github/workflows/hyperliquid-bench-live.yml
+++ b/.github/workflows/hyperliquid-bench-live.yml
@@ -62,7 +62,7 @@ env:
 jobs:
   live-bench:
     name: live-bench
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     env:
       HL_PRIVATE_KEY: ${{ secrets.HL_PRIVATE_KEY }}

--- a/.github/workflows/integration-dod-gap-issues.yml
+++ b/.github/workflows/integration-dod-gap-issues.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   sync-gap-issues:
     name: Sync gap issues from INTEGRATION_DOD_MAP.md
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/jsdoc-automation.yml
+++ b/.github/workflows/jsdoc-automation.yml
@@ -46,7 +46,7 @@ permissions:
 
 jobs:
   generate-docs:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     # NOTE: This workflow requires packages/autodoc to exist
     # Currently disabled until autodoc package is added to the monorepo
 

--- a/.github/workflows/keyless-harness-e2e.yml
+++ b/.github/workflows/keyless-harness-e2e.yml
@@ -53,7 +53,7 @@ env:
 jobs:
   keyless-harness:
     name: Deterministic mock-LLM connector loops (no secret)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/kokoro-real-smoke.yml
+++ b/.github/workflows/kokoro-real-smoke.yml
@@ -71,7 +71,7 @@ env:
 jobs:
   smoke:
     name: ubuntu-22.04 fused-cpu
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     steps:
       - name: Checkout (with llama.cpp submodule)

--- a/.github/workflows/launch-hardening-8756.yml
+++ b/.github/workflows/launch-hardening-8756.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   collect:
     name: Collect #8756 evidence
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ${{ github.event.inputs.environment }}
     timeout-minutes: 20
     steps:

--- a/.github/workflows/launch-qa.yml
+++ b/.github/workflows/launch-qa.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   launch-qa:
     name: Launch Docs And Static Gates
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/lifeops-bench-manifest.yml
+++ b/.github/workflows/lifeops-bench-manifest.yml
@@ -51,7 +51,7 @@ env:
 jobs:
   manifest-gate:
     name: Verify lifeops action manifest is up to date
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/lifeops-bench-multi-tier.yml
+++ b/.github/workflows/lifeops-bench-multi-tier.yml
@@ -59,7 +59,7 @@ env:
 jobs:
   resolve-inputs:
     name: "resolve-inputs"
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 2
     outputs:
       suite: ${{ steps.pick.outputs.suite }}
@@ -81,7 +81,7 @@ jobs:
   smoke-large:
     name: "tier=large"
     needs: resolve-inputs
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     steps:
       - name: Check secrets
@@ -173,7 +173,7 @@ jobs:
   smoke-frontier:
     name: "tier=frontier"
     needs: resolve-inputs
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     steps:
       - name: Check secrets
@@ -266,7 +266,7 @@ jobs:
     name: "multi-tier summary"
     needs: [resolve-inputs, smoke-large, smoke-frontier]
     if: always() && github.event_name == 'pull_request'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - name: Download large-tier artifact

--- a/.github/workflows/lifeops-bench-python.yml
+++ b/.github/workflows/lifeops-bench-python.yml
@@ -87,7 +87,7 @@ jobs:
   # ---------------------------------------------------------------------
   unit-tests:
     name: unit-tests
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -152,7 +152,7 @@ jobs:
   smoke-bench:
     name: smoke-bench
     needs: unit-tests
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -299,7 +299,7 @@ jobs:
     name: live-bench
     needs: unit-tests
     if: github.event_name == 'workflow_dispatch' && inputs.mode == 'full'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     steps:
       - name: Check live-bench secrets

--- a/.github/workflows/lifeops-bench.yml
+++ b/.github/workflows/lifeops-bench.yml
@@ -61,7 +61,7 @@ env:
 jobs:
   lifeops-bench:
     name: "lifeops-bench: ${{ matrix.agent }}"
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/lifeops-benchmark-history.yml
+++ b/.github/workflows/lifeops-benchmark-history.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     # No secret → nothing to run against. Skip cleanly instead of failing red.
     if: ${{ github.repository == 'elizaOS/eliza' }}
     steps:

--- a/.github/workflows/lifeops-live-validation-11632.yml
+++ b/.github/workflows/lifeops-live-validation-11632.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   collect:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     env:
       ELIZA_SKIP_ARTIFACT_SYNC: "1"
       ELIZA_LIVE_TEST: "1"

--- a/.github/workflows/lifeops-prompt-benchmark.yml
+++ b/.github/workflows/lifeops-prompt-benchmark.yml
@@ -44,7 +44,7 @@ env:
 jobs:
   prompt-benchmark:
     name: prompt-benchmark
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/lifeops-quality-bench.yml
+++ b/.github/workflows/lifeops-quality-bench.yml
@@ -46,7 +46,7 @@ env:
 jobs:
   lifeops-quality-gate:
     name: triage P/R + reminder timeliness budget gate (keyless)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
       PGLITE_WASM_MODE: node

--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -89,7 +89,7 @@ permissions:
 jobs:
   live-scenarios:
     name: Live scenarios (EA + connectors)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/loadperf.yml
+++ b/.github/workflows/loadperf.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   loadperf-stack:
     name: Bundle, boot, and frontend KPIs
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -93,7 +93,7 @@ jobs:
   statesync:
     name: State-sync KPI against live stack
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.include_statesync }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/local-inference-bench.yml
+++ b/.github/workflows/local-inference-bench.yml
@@ -68,7 +68,7 @@ env:
 jobs:
   stub-validation:
     name: Harness route smoke
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -132,7 +132,7 @@ jobs:
     name: Nightly real-agent profile
     needs: stub-validation
     if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_real_agent == true) }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -300,7 +300,7 @@ jobs:
     # cost.
     name: Cuttlefish AVD profile (manual)
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_cuttlefish == true }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -360,7 +360,7 @@ jobs:
     if: >-
       (github.event_name == 'schedule' && github.event.schedule == '30 4 * * 0') ||
       (github.event_name == 'workflow_dispatch' && inputs.run_publish_models == true)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     env:
       # W5-Pipeline drops finished checkpoints under this path. The

--- a/.github/workflows/local-inference-matrix.yml
+++ b/.github/workflows/local-inference-matrix.yml
@@ -60,7 +60,7 @@ env:
 
 jobs:
   prepare-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   relative-links:
     name: Relative Markdown Links
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/memperf.yml
+++ b/.github/workflows/memperf.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   harness-gate:
     name: harness + budget regression gate (no models)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -36,7 +36,7 @@ jobs:
     # Path classifier is a git-diff + node script: no self-hosted resources.
     # Keep it on GitHub-hosted so a drained hetzner fleet cannot leave it
     # queued indefinitely and pile up runs (#13617/#8501).
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     outputs:
       ios: ${{ steps.filter.outputs.ios }}
@@ -431,7 +431,7 @@ jobs:
     # cloud runtime-mode gate is a fast ubuntu job seeded with a real Cloud
     # credential rather than a browser OAuth leg.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       # Headless session seed (#13578 done-when #2): a real Cloud credential
@@ -494,7 +494,7 @@ jobs:
     name: Android Debug Build
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.android == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/mobile-resource-workbench.yml
+++ b/.github/workflows/mobile-resource-workbench.yml
@@ -54,7 +54,7 @@ concurrency:
 jobs:
   harness-smoke:
     name: harness smoke (no device)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/monetized-loop-nightly.yml
+++ b/.github/workflows/monetized-loop-nightly.yml
@@ -57,7 +57,7 @@ permissions:
 jobs:
   loop:
     name: Monetized full loop (real Hetzner)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ci-hetzner-e2e
     timeout-minutes: 40
     env:
@@ -197,7 +197,7 @@ jobs:
   # until its live driver + secrets land. Mirrors cloud-e2e.yml's mock setup.
   showcase-mock:
     name: Example-apps showcase loop (mock stack)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       NODE_ENV: test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   check-commits:
     name: Check for new commits
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       has_new_commits: ${{ steps.check.outputs.has_new_commits }}
       short_sha: ${{ steps.check.outputs.short_sha }}
@@ -82,7 +82,7 @@ jobs:
     name: Build & Test
     needs: check-commits
     if: needs.check-commits.outputs.has_new_commits == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     outputs:
       nightly_version: ${{ steps.version.outputs.nightly_version }}
@@ -188,7 +188,7 @@ jobs:
     name: Publish to npm (nightly)
     needs: [check-commits, build-and-test, desktop-build-matrix]
     if: needs.check-commits.outputs.has_new_commits == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -233,7 +233,7 @@ jobs:
     name: Create GitHub pre-release
     needs: [check-commits, build-and-test, desktop-build-matrix, publish-npm]
     if: needs.check-commits.outputs.has_new_commits == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -286,7 +286,7 @@ jobs:
     name: Cleanup old nightly releases
     needs: create-release
     if: needs.create-release.result == 'success'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -319,7 +319,7 @@ jobs:
     name: Nightly Summary
     if: always()
     needs: [check-commits, build-and-test, publish-npm, create-release, cleanup]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Summary
         run: |

--- a/.github/workflows/orchestrator-live-multi-account.yml
+++ b/.github/workflows/orchestrator-live-multi-account.yml
@@ -48,7 +48,7 @@ env:
 jobs:
   live-multi-account:
     name: live multi-account rotation
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       ELIZA_LIVE_CLAUDE_OAUTH_TOKEN_1: ${{ secrets.ELIZA_LIVE_CLAUDE_OAUTH_TOKEN_1 }}

--- a/.github/workflows/orchestrator-multi-account.yml
+++ b/.github/workflows/orchestrator-multi-account.yml
@@ -44,7 +44,7 @@ env:
 jobs:
   multi-account-e2e:
     name: multi-account selection e2e
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/.github/workflows/publish-android-update-manifest.yml
+++ b/.github/workflows/publish-android-update-manifest.yml
@@ -45,7 +45,7 @@ permissions:
 
 jobs:
   publish-manifest:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/publish-aosp-update-manifest.yml
+++ b/.github/workflows/publish-aosp-update-manifest.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   publish-manifest:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/publish-apt-repo.yml
+++ b/.github/workflows/publish-apt-repo.yml
@@ -58,7 +58,7 @@ permissions:
 
 jobs:
   publish-apt:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
 
     steps:
       - name: Check GPG credentials

--- a/.github/workflows/publish-example-code.yml
+++ b/.github/workflows/publish-example-code.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   check_npm:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
       version: ${{ steps.check.outputs.version }}
@@ -90,7 +90,7 @@ jobs:
   publish_npm:
     needs: check_npm
     if: needs.check_npm.outputs.should_publish == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       contents: write
       id-token: write # npm OIDC trusted publishing (SOC2 CC9.2)

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -73,7 +73,7 @@ permissions:
 jobs:
   prepare:
     name: Prepare
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       version: ${{ steps.ver.outputs.version }}
       npm_version: ${{ steps.ver.outputs.npm_version }}
@@ -148,7 +148,7 @@ jobs:
     name: Publish to PyPI
     needs: prepare
     if: inputs.pypi
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       id-token: write  # OIDC trusted publishing
     environment:
@@ -217,7 +217,7 @@ jobs:
     name: Build & Publish Snap
     needs: prepare
     if: inputs.snap
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -272,7 +272,7 @@ jobs:
     name: Build Debian Package
     needs: prepare
     if: inputs.apt
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       contents: write  # gh release upload
     steps:
@@ -387,7 +387,7 @@ jobs:
     name: Build Flatpak
     needs: prepare
     if: inputs.flatpak
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       contents: write  # gh release upload
     steps:
@@ -472,7 +472,7 @@ jobs:
     name: Publish Summary
     needs: [prepare, publish-pypi, publish-snap, build-deb, build-flatpak]
     if: always()
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Summary
         run: |

--- a/.github/workflows/publish-plugin-elizacloud.yml
+++ b/.github/workflows/publish-plugin-elizacloud.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   verify_version:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
       version: ${{ steps.check.outputs.version }}
@@ -58,7 +58,7 @@ jobs:
   publish_npm:
     needs: verify_version
     if: needs.verify_version.outputs.should_publish == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       contents: write
       id-token: write   # npm OIDC trusted publishing (SOC2 CC9.2)

--- a/.github/workflows/quality-fork.yml
+++ b/.github/workflows/quality-fork.yml
@@ -25,7 +25,7 @@ jobs:
   lint:
     name: Lint
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -73,7 +73,7 @@ jobs:
   typecheck:
     name: Type Check
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -108,7 +108,7 @@ jobs:
   build:
     name: Build
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -148,7 +148,7 @@ jobs:
   elizaos-cli-global-smoke:
     name: elizaos CLI global-install smoke (#8000)
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -42,7 +42,7 @@ permissions:
 jobs:
   homepage-build:
     name: Homepage Build (PR smoke)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     permissions:
       contents: write
@@ -149,7 +149,7 @@ jobs:
 
   comment-only-diff:
     name: Comment-only diff guard
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'comment-cleanup')
     steps:
@@ -181,7 +181,7 @@ jobs:
 
   format-check:
     name: Format + Type Safety Ratchet
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -235,7 +235,7 @@ jobs:
   # mirroring the lean install used by `format-check`.
   develop-static-gate:
     name: Develop Gate (secret scan + UI determinism)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -288,7 +288,7 @@ jobs:
   # build-enabled workspace setup rather than the lean no-postinstall path.
   develop-lint-gate:
     name: Develop Gate (lint)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/recall-bench.yml
+++ b/.github/workflows/recall-bench.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   recall-gate:
     name: recall quality + budget regression gate (no models)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -126,7 +126,7 @@ jobs:
   # ─────────────────────────────────────────────
   validate:
     name: Validate & Prepare Release
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       version: ${{ steps.parse.outputs.version }}
       channel: ${{ steps.parse.outputs.channel }}
@@ -394,7 +394,7 @@ jobs:
     name: npm packages (auto-triggered)
     needs: validate
     if: needs.validate.outputs.build_npm == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Note — npm release auto-triggered
         run: |
@@ -512,7 +512,7 @@ jobs:
     name: Release Summary
     needs: [validate, desktop, android, apple, linux-os-iso, linux-os-deb, linux-os-vm, npm, snap, windows-store, android-update-manifest, aosp-update-manifest, apt-repo, flatpak]
     if: always()
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -1785,7 +1785,7 @@ jobs:
     name: Publish OTA Channel Manifest
     if: ${{ success() && needs.release.result == 'success' }}
     needs: [prepare, release]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -95,7 +95,7 @@ permissions:
 jobs:
   prepare:
     name: Resolve release metadata
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       version: ${{ steps.meta.outputs.version }}
       tag: ${{ steps.meta.outputs.tag }}
@@ -296,7 +296,7 @@ jobs:
         deploy-homepage,
       ]
     if: always()
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Summary
         run: |

--- a/.github/workflows/riscv64-smoke.yml
+++ b/.github/workflows/riscv64-smoke.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   smoke:
     if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'riscv64') }}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
     env:
       ELIZA_RISCV64_SMOKE: "1"

--- a/.github/workflows/sandbox-live-smoke.yml
+++ b/.github/workflows/sandbox-live-smoke.yml
@@ -84,7 +84,7 @@ permissions:
 jobs:
   smoke:
     name: Sandbox live smoke
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     env:
       TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'all' }}

--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -56,7 +56,7 @@ jobs:
   disabled:
     name: Scenario Matrix Disabled
     if: ${{ inputs.enabled != 'true' && vars.ELIZA_SCENARIO_MATRIX_ENABLED != 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - name: Explain disabled state
@@ -73,7 +73,7 @@ jobs:
       matrix:
         shard:
           - name: messaging
-            runs-on: ubuntu-24.04
+            runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
             globs: "packages/test/scenarios/messaging.*/**/*.scenario.ts"
           # NOTE: the two apple-ecosystem shards (messaging-apple,
           # selfcontrol-activity) require a self-hosted macOS runner labeled
@@ -88,29 +88,29 @@ jobs:
           #   runs-on: [self-hosted, eliza-e2e-macos]
           #   globs: "packages/test/scenarios/messaging.imessage/**/*.scenario.ts packages/test/scenarios/messaging.signal/**/*.scenario.ts"
           - name: todos-reminders
-            runs-on: ubuntu-24.04
+            runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
             globs: "packages/test/scenarios/todos/**/*.scenario.ts packages/test/scenarios/reminders/**/*.scenario.ts"
           - name: calendar
-            runs-on: ubuntu-24.04
+            runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
             globs: "packages/test/scenarios/calendar/**/*.scenario.ts"
           - name: relationships
-            runs-on: ubuntu-24.04
+            runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
             globs: "packages/test/scenarios/relationships/**/*.scenario.ts"
           # - name: selfcontrol-activity  (apple shard, see note above; re-enable
           #   with the macOS runner)
           #   runs-on: [self-hosted, eliza-e2e-macos]
           #   globs: "packages/test/scenarios/selfcontrol/**/*.scenario.ts packages/test/scenarios/activity/**/*.scenario.ts"
           - name: browser-social
-            runs-on: ubuntu-24.04
+            runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
             globs: "packages/test/scenarios/browser.*/**/*.scenario.ts packages/test/scenarios/social.*/**/*.scenario.ts"
           - name: personality-payments
-            runs-on: ubuntu-24.04
+            runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
             globs: "packages/test/scenarios/personality/**/*.scenario.ts packages/test/scenarios/personality/shut_up/*.scenario.ts packages/test/scenarios/payments/*.scenario.ts packages/test/scenarios/payments/**/*.scenario.ts packages/test/scenarios/lifeops.payments/*.scenario.ts packages/test/scenarios/lifeops.payments/**/*.scenario.ts packages/test/scenarios/lifeops.morning-brief/*.scenario.ts"
           - name: cross-cutting-gateway
-            runs-on: ubuntu-24.04
+            runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
             globs: "packages/test/scenarios/cross-cutting/**/*.scenario.ts packages/test/scenarios/gateway/**/*.scenario.ts packages/test/scenarios/remote/**/*.scenario.ts packages/test/scenarios/lifeops.*/*.scenario.ts packages/test/scenarios/lifeops.*/**/*.scenario.ts packages/test/scenarios/lifeops.sleep/*.scenario.ts packages/test/scenarios/lifeops.travel-buffer/*.scenario.ts packages/test/scenarios/lifeops.travel/*.scenario.ts packages/test/scenarios/lifeops.workflow-events/*.scenario.ts packages/test/scenarios/goals/**/*.scenario.ts packages/test/scenarios/convo/**/*.scenario.ts"
           - name: lifeops-app
-            runs-on: ubuntu-24.04
+            runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
             root: plugins/plugin-personal-assistant/test/scenarios
             globs: "**/*.scenario.ts"
     runs-on: ${{ matrix.shard.runs-on }}
@@ -259,7 +259,7 @@ jobs:
     name: Matrix summary
     needs: [matrix]
     if: ${{ always() && needs.matrix.result != 'skipped' }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -44,7 +44,7 @@ jobs:
     # Path classifier is a git-diff + node script: no self-hosted resources.
     # Keep it on GitHub-hosted so a drained hetzner fleet cannot leave it
     # queued indefinitely and pile up runs (#13617/#8501).
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     outputs:
       run_scenario_pr: ${{ steps.filter.outputs.run_scenario_pr }}
@@ -79,7 +79,7 @@ jobs:
     name: Zero-Key unit + UI coverage
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -138,7 +138,7 @@ jobs:
     name: Zero-Key app browser core
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -208,7 +208,7 @@ jobs:
     name: Zero-Key app browser view lifecycle
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -268,7 +268,7 @@ jobs:
     name: Zero-Key app browser all-pages
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -313,7 +313,7 @@ jobs:
     name: Zero-Key app browser feature interactions
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 55
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -358,7 +358,7 @@ jobs:
     name: Zero-Key app browser cloud keyless
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -403,7 +403,7 @@ jobs:
     name: Zero-Key app browser ratcheted
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 55
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -456,7 +456,7 @@ jobs:
     name: Zero-Key app browser auto-discovered specs
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -516,7 +516,7 @@ jobs:
     name: Zero-Key app browser dashboard device matrix
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -564,7 +564,7 @@ jobs:
     name: Zero-Key app browser Pixel-7 real-touch lane
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -622,7 +622,7 @@ jobs:
     name: Zero-Key app browser WebKit lane
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -667,7 +667,7 @@ jobs:
     name: Zero-Key accounts UI e2e (real API + pool + disk)
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -710,7 +710,7 @@ jobs:
     name: Zero-Key full-walkthrough (mock lane)
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -764,7 +764,7 @@ jobs:
     name: Zero-Key app diagnostics
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -810,7 +810,7 @@ jobs:
     name: Zero-Key scenario runner E2E
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -944,7 +944,7 @@ jobs:
       - app-diagnostics
       - scenario-runner-e2e
     if: ${{ !cancelled() && always() && needs.changes.outputs.run_scenario_pr == 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Check deterministic E2E slices
         shell: bash

--- a/.github/workflows/setup-bun-workspace-self-test.yml
+++ b/.github/workflows/setup-bun-workspace-self-test.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   protoc-github-fallback:
     name: forced protoc GitHub fallback
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   review:
     if: github.event.pull_request.draft != true
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     permissions:
       pull-requests: write

--- a/.github/workflows/snap-publish.yml
+++ b/.github/workflows/snap-publish.yml
@@ -50,7 +50,7 @@ permissions:
 
 jobs:
   build-and-publish:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
 
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/.github/workflows/stale-base-guard.yml
+++ b/.github/workflows/stale-base-guard.yml
@@ -42,7 +42,7 @@ permissions:
 jobs:
   guard:
     name: stale-base guard
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     env:
       BASE_REF: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/tee-build-deploy.yml
+++ b/.github/workflows/tee-build-deploy.yml
@@ -62,7 +62,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/terraform-apps-data-plane.yml
+++ b/.github/workflows/terraform-apps-data-plane.yml
@@ -97,7 +97,7 @@ jobs:
   # so it runs safely on every PR (incl. before the env HCLOUD_TOKEN exists).
   validate:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v4
@@ -119,7 +119,7 @@ jobs:
   # / eliza-staging projects (see header comment).
   plan-apply:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ${{ github.event.inputs.environment }}
     env:
       HCLOUD_TOKEN: ${{ secrets.HCLOUD_APPS_TOKEN }}

--- a/.github/workflows/terraform-apps-shared.yml
+++ b/.github/workflows/terraform-apps-shared.yml
@@ -72,7 +72,7 @@ jobs:
   # so it runs safely on every PR (incl. before the env HCLOUD_TOKEN exists).
   validate:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v4
@@ -92,7 +92,7 @@ jobs:
   # nodes; the per-env scoping lives in apps-data-plane.
   plan-apply:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     env:
       HCLOUD_TOKEN: ${{ secrets.HCLOUD_APPS_TOKEN }}
       # R2 (S3-compatible) state backend creds.

--- a/.github/workflows/terraform-apps-state-rm.yml
+++ b/.github/workflows/terraform-apps-state-rm.yml
@@ -51,7 +51,7 @@ env:
 
 jobs:
   state-rm:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ${{ github.event.inputs.environment }}
     timeout-minutes: 10
     env:

--- a/.github/workflows/terraform-control-plane.yml
+++ b/.github/workflows/terraform-control-plane.yml
@@ -76,7 +76,7 @@ jobs:
   # so it runs safely on every PR (incl. before the env HCLOUD_TOKEN exists).
   validate:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v4
@@ -95,7 +95,7 @@ jobs:
   # that env's HCLOUD_TOKEN (and any required reviewers) apply to this run.
   plan-apply:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ${{ github.event.inputs.environment }}
     env:
       HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}

--- a/.github/workflows/test-elizaos-setup.yml
+++ b/.github/workflows/test-elizaos-setup.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6

--- a/.github/workflows/test-flatpak.yml
+++ b/.github/workflows/test-flatpak.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build:
     name: Build & Validate Flatpak
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   validate:
     name: Validate Packaging Configs
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -58,7 +58,7 @@ jobs:
 
   build-pypi:
     name: Build & Test PyPI Package
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -158,7 +158,7 @@ jobs:
 
   build-pypi-matrix:
     name: PyPI on Python ${{ matrix.python }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     strategy:
       matrix:
         # PRs run a single Python version; pushes to main/develop run the
@@ -205,7 +205,7 @@ jobs:
 
   pack-and-test-js:
     name: Pack & Test JS Tarballs
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -276,7 +276,7 @@ jobs:
 
   elizaos-cli-global-smoke:
     name: elizaos CLI global-install smoke (node + bun)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/training-stack.yml
+++ b/.github/workflows/training-stack.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   cpu-smoke:
     name: CPU smoke (lint + import)
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -51,7 +51,7 @@ env:
 
 jobs:
   ui-fixture-e2e:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/ui-fixture-e2e.yml
+++ b/.github/workflows/ui-fixture-e2e.yml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   fixture-e2e:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -39,7 +39,7 @@ env:
 
 jobs:
   story-gate:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   update-tap:
     name: Trigger Homebrew tap update
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Check credentials
         id: creds

--- a/.github/workflows/update-os-release-manifest.yml
+++ b/.github/workflows/update-os-release-manifest.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   update-checksums:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/update-vendor-checksums.yml
+++ b/.github/workflows/update-vendor-checksums.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   update-checksums:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/verify-patches.yml
+++ b/.github/workflows/verify-patches.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   verify:
     name: verify patches/CHECKSUMS.sha256
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     steps:
       - name: Checkout
         # actions/checkout@v4

--- a/.github/workflows/view-bundle-size.yml
+++ b/.github/workflows/view-bundle-size.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   size-gate:
     name: build view bundles + budget regression gate
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/voice-bench-smoke.yml
+++ b/.github/workflows/voice-bench-smoke.yml
@@ -47,7 +47,7 @@ permissions:
 jobs:
   voice-emotion-smoke:
     name: voice-emotion fixture smoke
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -76,7 +76,7 @@ jobs:
 
   voiceagentbench-smoke:
     name: voiceagentbench fixture smoke
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -117,7 +117,7 @@ jobs:
 
   voicebench-quality-unit-smoke:
     name: voicebench-quality unit smoke
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -131,7 +131,7 @@ jobs:
 
   voicebench-ts-unit:
     name: voicebench TypeScript unit (no audio)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -153,7 +153,7 @@ jobs:
 
   voice-bench-summary:
     name: voice bench smoke summary
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs:
       - voice-emotion-smoke
       - voiceagentbench-smoke

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -75,7 +75,7 @@ env:
 jobs:
   voice-platform-matrix-index:
     name: Canonical voice matrix index
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -672,7 +672,7 @@ jobs:
   voice-android-matrix:
     name: Android live-voice + native bridge matrix
     if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_android) || vars.ELIZA_VOICE_ANDROID_READY == '1' }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     env:
       ELIZA_VOICE_ANDROID_READY: ${{ vars.ELIZA_VOICE_ANDROID_READY }}

--- a/.github/workflows/voice-workbench.yml
+++ b/.github/workflows/voice-workbench.yml
@@ -73,7 +73,7 @@ permissions:
 jobs:
   voice-workbench:
     name: headless workbench (mocked backends)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -130,7 +130,7 @@ jobs:
   voice-workbench-real:
     name: real acoustic lane (nightly, provisioned only)
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   maintenance:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 30
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Route the Linux GitHub Actions backlog onto the idle Hetzner self-hosted runner fleet using the existing `HETZNER_FLEET_ONLINE` repo-variable toggle pattern.

Context/receipts:
- 18,000+ queued jobs were waiting on GitHub-hosted Linux labels.
- 54 self-hosted runners were online and mostly idle with labels `self-hosted`, `Linux`, `X64`, `hetzner-robot` and sometimes `eliza`.
- Develop census before this lane: 146 jobs on `ubuntu-24.04`, 100 on `ubuntu-latest`, and only 19 already used the existing toggle pattern.

Kill-switch preserved:
- Set repo variable `HETZNER_FLEET_ONLINE=false` to route these jobs back to GitHub-hosted `ubuntu-24.04` instantly.
- Default/non-false value routes to `["self-hosted","hetzner-robot"]`.

@lalalune kill-switch preserved, one variable reverts

## Routed job count by workflow

| Workflow | Jobs routed |
|---|---:|
| `.github/workflows/android-device-e2e.yml` | 3 |
| `.github/workflows/android-release.yml` | 3 |
| `.github/workflows/app-aesthetic-audit.yml` | 1 |
| `.github/workflows/app-live-e2e.yml` | 6 |
| `.github/workflows/app-real-e2e.yml` | 1 |
| `.github/workflows/apple-store-release.yml` | 2 |
| `.github/workflows/apps-deploy-e2e.yml` | 2 |
| `.github/workflows/arm-apps-daemon.yml` | 1 |
| `.github/workflows/arm-headscale-control-plane.yml` | 1 |
| `.github/workflows/attachment-journey-videos.yml` | 1 |
| `.github/workflows/auto-label.yml` | 2 |
| `.github/workflows/benchmark-orchestrator-scheduled.yml` | 1 |
| `.github/workflows/benchmark-tests.yml` | 1 |
| `.github/workflows/benchmark-weekly.yml` | 1 |
| `.github/workflows/browser-real-bench.yml` | 1 |
| `.github/workflows/build-agent-image.yml` | 1 |
| `.github/workflows/build-android.yml` | 1 |
| `.github/workflows/build-debian-package.yml` | 1 |
| `.github/workflows/build-example-app-images.yml` | 2 |
| `.github/workflows/build-linux-iso.yml` | 1 |
| `.github/workflows/build-llama-ffi-android.yml` | 2 |
| `.github/workflows/build-vm-image.yml` | 1 |
| `.github/workflows/cache-key-stability.yml` | 1 |
| `.github/workflows/cerebras-nightly.yml` | 1 |
| `.github/workflows/chat-shell-gestures.yml` | 1 |
| `.github/workflows/ci-full-matrix-proof.yml` | 1 |
| `.github/workflows/claude-code-review.yml` | 1 |
| `.github/workflows/claude-security-review.yml` | 1 |
| `.github/workflows/claude.yml` | 1 |
| `.github/workflows/cloud-aesthetic-audit.yml` | 1 |
| `.github/workflows/cloud-deploy-backend.yml` | 3 |
| `.github/workflows/cloud-e2e.yml` | 1 |
| `.github/workflows/cloud-gateway-discord.yml` | 1 |
| `.github/workflows/cloud-gateway-webhook.yml` | 1 |
| `.github/workflows/cloud-tests.yml` | 4 |
| `.github/workflows/coverage-gate.yml` | 1 |
| `.github/workflows/deploy-apps-worker.yml` | 2 |
| `.github/workflows/deploy-eliza-provisioning-worker.yml` | 2 |
| `.github/workflows/deploy-homepage.yml` | 1 |
| `.github/workflows/dev-smoke.yml` | 3 |
| `.github/workflows/develop-exhaustive.yml` | 1 |
| `.github/workflows/develop-staging-beta.yml` | 1 |
| `.github/workflows/docker-ci-smoke.yml` | 2 |
| `.github/workflows/docs-ci.yml` | 3 |
| `.github/workflows/e1-chip.yml` | 1 |
| `.github/workflows/electrobun-submodule-guard.yml` | 1 |
| `.github/workflows/elizaos-os-full-release.yml` | 4 |
| `.github/workflows/elizaos-os-release.yml` | 1 |
| `.github/workflows/external-api-live-drift.yml` | 1 |
| `.github/workflows/feed-apply-migrations.yml` | 1 |
| `.github/workflows/feed-env-audit.yml` | 1 |
| `.github/workflows/feed-rl-training.yml` | 1 |
| `.github/workflows/feed-test.yml` | 1 |
| `.github/workflows/flatpak-publish.yml` | 1 |
| `.github/workflows/gitleaks.yml` | 1 |
| `.github/workflows/hetzner-e2e-reaper.yml` | 1 |
| `.github/workflows/hetzner-e2e.yml` | 2 |
| `.github/workflows/hetzner-provision-smoke.yml` | 1 |
| `.github/workflows/hetzner-sleep-wake-smoke.yml` | 1 |
| `.github/workflows/hyperliquid-bench-live.yml` | 1 |
| `.github/workflows/integration-dod-gap-issues.yml` | 1 |
| `.github/workflows/jsdoc-automation.yml` | 1 |
| `.github/workflows/keyless-harness-e2e.yml` | 1 |
| `.github/workflows/kokoro-real-smoke.yml` | 1 |
| `.github/workflows/launch-hardening-8756.yml` | 1 |
| `.github/workflows/launch-qa.yml` | 1 |
| `.github/workflows/lifeops-bench-manifest.yml` | 1 |
| `.github/workflows/lifeops-bench-multi-tier.yml` | 4 |
| `.github/workflows/lifeops-bench-python.yml` | 3 |
| `.github/workflows/lifeops-bench.yml` | 1 |
| `.github/workflows/lifeops-benchmark-history.yml` | 1 |
| `.github/workflows/lifeops-live-validation-11632.yml` | 1 |
| `.github/workflows/lifeops-prompt-benchmark.yml` | 1 |
| `.github/workflows/lifeops-quality-bench.yml` | 1 |
| `.github/workflows/live-scenarios.yml` | 1 |
| `.github/workflows/loadperf.yml` | 2 |
| `.github/workflows/local-inference-bench.yml` | 4 |
| `.github/workflows/local-inference-matrix.yml` | 1 |
| `.github/workflows/markdown-links.yml` | 1 |
| `.github/workflows/memperf.yml` | 1 |
| `.github/workflows/mobile-build-smoke.yml` | 3 |
| `.github/workflows/mobile-resource-workbench.yml` | 1 |
| `.github/workflows/monetized-loop-nightly.yml` | 2 |
| `.github/workflows/nightly.yml` | 6 |
| `.github/workflows/orchestrator-live-multi-account.yml` | 1 |
| `.github/workflows/orchestrator-multi-account.yml` | 1 |
| `.github/workflows/publish-android-update-manifest.yml` | 1 |
| `.github/workflows/publish-aosp-update-manifest.yml` | 1 |
| `.github/workflows/publish-apt-repo.yml` | 1 |
| `.github/workflows/publish-example-code.yml` | 2 |
| `.github/workflows/publish-packages.yml` | 6 |
| `.github/workflows/publish-plugin-elizacloud.yml` | 2 |
| `.github/workflows/quality-fork.yml` | 4 |
| `.github/workflows/quality.yml` | 5 |
| `.github/workflows/recall-bench.yml` | 1 |
| `.github/workflows/release-all.yml` | 3 |
| `.github/workflows/release-electrobun.yml` | 1 |
| `.github/workflows/release-orchestrator.yml` | 2 |
| `.github/workflows/riscv64-smoke.yml` | 1 |
| `.github/workflows/sandbox-live-smoke.yml` | 1 |
| `.github/workflows/scenario-matrix.yml` | 10 |
| `.github/workflows/scenario-pr.yml` | 17 |
| `.github/workflows/setup-bun-workspace-self-test.yml` | 1 |
| `.github/workflows/skill-review.yml` | 1 |
| `.github/workflows/snap-publish.yml` | 1 |
| `.github/workflows/stale-base-guard.yml` | 1 |
| `.github/workflows/tee-build-deploy.yml` | 1 |
| `.github/workflows/terraform-apps-data-plane.yml` | 2 |
| `.github/workflows/terraform-apps-shared.yml` | 2 |
| `.github/workflows/terraform-apps-state-rm.yml` | 1 |
| `.github/workflows/terraform-control-plane.yml` | 2 |
| `.github/workflows/test-elizaos-setup.yml` | 1 |
| `.github/workflows/test-flatpak.yml` | 1 |
| `.github/workflows/test-packaging.yml` | 5 |
| `.github/workflows/training-stack.yml` | 1 |
| `.github/workflows/ui-e2e-gate.yml` | 1 |
| `.github/workflows/ui-fixture-e2e.yml` | 1 |
| `.github/workflows/ui-story-gate.yml` | 1 |
| `.github/workflows/update-homebrew.yml` | 1 |
| `.github/workflows/update-os-release-manifest.yml` | 1 |
| `.github/workflows/update-vendor-checksums.yml` | 1 |
| `.github/workflows/verify-patches.yml` | 1 |
| `.github/workflows/view-bundle-size.yml` | 1 |
| `.github/workflows/voice-bench-smoke.yml` | 5 |
| `.github/workflows/voice-live-e2e.yml` | 2 |
| `.github/workflows/voice-workbench.yml` | 2 |
| `.github/workflows/weekly-maintenance.yml` | 1 |

Total routed jobs: 229 across 127 workflow files.

## Exclusions / intentionally untouched

- macOS and Windows runner jobs stayed untouched.
- `windows-*.yml` workflows stayed untouched, including Linux helper jobs inside Windows workflows.
- Matrix runner jobs stayed untouched, including `release-usb-installer.yml`, `release-elizaos-setup.yml`, and the matrix job in `nightly.yml`.
- Jobs already on self-hosted/GPU/KVM/custom labels stayed untouched, including GPU CUDA runners, KVM runners, CodeQL's custom expression, and `VOICE_LIVE_RUNNER_LABELS` jobs.
- `build-llama-ffi-linux.yml` `build-cpu` stayed on `ubuntu-22.04` because the native Linux FFI artifact is named/stamped as a 22.04 build host and should not silently move to 24.04/self-hosted without an ABI/container decision.
- No `container:` images were changed.

## Validation

- YAML parsed for all `.github/workflows/*.yml` files with `python3 -c "import yaml; yaml.safe_load(...)"`.
- Verified the cumulative diff only changes `runs-on:` lines.
- Verified the exact existing toggle string was used:
  `runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}`
- Codex review run. It flagged the expected policy/security concern that PR code will run on self-hosted by default; this PR is therefore human-merge-only as requested and relies on the kill-switch above.

## Merge policy

Touches `.github/workflows`, human merge only. Auto-merge is intentionally not enabled.
