### PR TITLE
fix: Added or repaired a purpose-explaining prose header (device

### DIFF
--- a/plugins/plugin-native-macosalarm/__tests__/actions.test.ts
+++ b/plugins/plugin-native-macosalarm/__tests__/actions.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Unit tests for `createAlarmAction`'s context gating, subaction resolution,
+ * and platform `validate()` branch — pure logic, no process spawned (see
+ * `helper.test.ts` for the Swift IPC layer).
+ *
+ * #10471 — the ALARM action must route by the planner's structured context
+ * decision + structured params, NOT by English (or multilingual) keyword
+ * matching on raw message text. These pin that the removed `ALARM_TERMS` keyword
+ * bank and text-regex subaction inference stay gone.
+ */
+
 import type { Memory, State } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -5,13 +16,6 @@ import {
   hasAlarmContext,
   resolveSubaction,
 } from "../src/actions";
-
-/**
- * #10471 — the ALARM action must route by the planner's structured context
- * decision + structured params, NOT by English (or multilingual) keyword
- * matching on raw message text. These pin that the removed `ALARM_TERMS` keyword
- * bank and text-regex subaction inference stay gone.
- */
 
 function msg(text = "", content: Record<string, unknown> = {}): Memory {
   return {

--- a/plugins/plugin-native-macosalarm/__tests__/helper.test.ts
+++ b/plugins/plugin-native-macosalarm/__tests__/helper.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `runHelper`'s stdin/stdout JSON framing, driven against a
+ * fake spawned process (`EventEmitter` + `PassThrough` streams) — no real
+ * Swift binary involved. See `integration.macos.test.ts` for that.
+ */
+
 import { EventEmitter } from "node:events";
 import { PassThrough, Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-native-macosalarm/__tests__/integration.macos.test.ts
+++ b/plugins/plugin-native-macosalarm/__tests__/integration.macos.test.ts
@@ -1,3 +1,18 @@
+/**
+ * requires.os: "macos"
+ *
+ * Darwin-only integration test: compiles `swift-helper/main.swift` with
+ * `swiftc` and invokes the resulting binary end-to-end via `runHelper`.
+ * Skipped on non-darwin so CI on other OSes stays green.
+ *
+ * `UNUserNotificationCenter` requires the binary to run inside a signed app
+ * bundle; invoked as a bare CLI it throws `NSInternalInconsistencyException`
+ * ("bundleProxyForCurrentProcess is nil"). Packaging/signing is owned by
+ * eliza-devops (deferred per T8b), so this test accepts that documented
+ * bundle-proxy error as a valid "ran but unbundled" outcome alongside a real
+ * structured response.
+ */
+
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -5,18 +20,6 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { runHelper } from "../src/helper";
-
-// requires.os: "macos"
-//
-// Builds the Swift helper with swiftc and invokes it end-to-end. Skipped on
-// non-darwin so CI on other OSes stays green.
-//
-// Note: UNUserNotificationCenter requires the binary to live inside a signed
-// app bundle at runtime. Invoked as a bare CLI, it throws
-// NSInternalInconsistencyException about `bundleProxyForCurrentProcess is
-// nil`. Packaging/signing is owned by eliza-devops (deferred per T8b); this
-// test therefore asserts the helper builds and runs, and accepts the known
-// bundle-proxy error as a documented "unbundled" signal.
 
 const isMac = process.platform === "darwin";
 const suite = isMac ? describe : describe.skip;

--- a/plugins/plugin-native-macosalarm/scripts/build-helper.mjs
+++ b/plugins/plugin-native-macosalarm/scripts/build-helper.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
-// Builds the macOS alarm helper binary via `swiftc`.
-//
-// Outputs the binary to `bin/macosalarm-helper` inside this package so the
-// TS runtime can locate it deterministically. Skips on non-darwin platforms.
+/**
+ * Builds the macOS alarm helper binary via `swiftc`, writing it to
+ * `bin/macosalarm-helper` inside this package so the TS runtime
+ * (`src/helper.ts`) can locate it deterministically. Skips on non-darwin
+ * platforms.
+ */
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, statSync } from "node:fs";

--- a/plugins/plugin-native-macosalarm/src/actions.ts
+++ b/plugins/plugin-native-macosalarm/src/actions.ts
@@ -1,3 +1,13 @@
+/**
+ * Implements the ALARM action: resolves the requested subaction (set / cancel
+ * / list) from structured parameters only, then drives the Swift helper
+ * (`helper.ts`) to schedule, cancel, or enumerate macOS notification-based
+ * alarms. Routing is gated to the tasks/calendar/automation contexts and to
+ * the ADMIN role; see `hasAlarmContext` and `resolveSubaction` below for why
+ * routing and subaction inference deliberately never parse raw message text
+ * (#10471).
+ */
+
 import { randomUUID } from "node:crypto";
 import {
   type Action,

--- a/plugins/plugin-native-macosalarm/src/helper.ts
+++ b/plugins/plugin-native-macosalarm/src/helper.ts
@@ -1,3 +1,13 @@
+/**
+ * Spawns the compiled Swift helper binary and speaks its line-delimited JSON
+ * IPC protocol: one JSON request written to stdin, one JSON response taken
+ * from the last non-empty stdout line (earlier lines may be helper debug
+ * output). Refuses to run on non-darwin platforms unless a test supplies
+ * `spawnImpl`, and throws `MacosAlarmHelperUnavailableError` — distinct from a
+ * real alarm-scheduling failure — when darwin but the binary hasn't been
+ * built yet (see `scripts/build-helper.mjs`).
+ */
+
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";

--- a/plugins/plugin-native-macosalarm/src/index.ts
+++ b/plugins/plugin-native-macosalarm/src/index.ts
@@ -1,3 +1,5 @@
+/** Barrel for the macosalarm plugin: actions, the Swift-helper IPC layer, the plugin factory, and shared IPC/action types. Default export is the `macosAlarmPlugin` singleton. */
+
 export * from "./actions";
 export * from "./helper";
 export * from "./plugin";

--- a/plugins/plugin-native-macosalarm/src/plugin.ts
+++ b/plugins/plugin-native-macosalarm/src/plugin.ts
@@ -1,3 +1,11 @@
+/**
+ * Builds the `macosalarm` elizaOS Plugin: a single ALARM action that schedules,
+ * cancels, and lists macOS `UNUserNotificationCenter` alarms through the Swift
+ * helper (see `helper.ts`). Declared `"autoEnable": "darwin"` in `package.json`,
+ * but the actual non-darwin refusal happens in the action's own `validate()` —
+ * this factory is platform-agnostic.
+ */
+
 import type { Plugin } from "@elizaos/core";
 import { createAlarmAction, type MacosAlarmActionDeps } from "./actions";
 

--- a/plugins/plugin-native-macosalarm/src/types.ts
+++ b/plugins/plugin-native-macosalarm/src/types.ts
@@ -1,3 +1,9 @@
+/**
+ * Wire types for the line-delimited JSON IPC protocol between the TS action
+ * layer and the Swift helper binary (`helper.ts`, `swift-helper/main.swift`),
+ * plus the action-level parameter/result shapes consumed by `actions.ts`.
+ */
+
 export type MacosAlarmAction = "schedule" | "cancel" | "list" | "permission";
 
 export interface MacosAlarmHelperRequest {

--- a/plugins/plugin-native-macosalarm/vitest.config.ts
+++ b/plugins/plugin-native-macosalarm/vitest.config.ts
@@ -1,3 +1,5 @@
+/** Vitest config for plugin-native-macosalarm: runs the `__tests__/` suite (helper IPC framing, action routing, darwin integration) with `globals: false`. */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-native-messages/rollup.config.mjs
+++ b/plugins/plugin-native-messages/rollup.config.mjs
@@ -1,3 +1,11 @@
+/**
+ * Rollup config bundling the tsc-emitted ESM output into the two artifacts
+ * Capacitor plugins ship: an IIFE for browser `<script>`/bundler globals and
+ * a CJS build for Node tooling. `inlineDynamicImports` folds the lazy
+ * `import("./web")` in `index.ts` into each bundle so there is no separate
+ * chunk to resolve at load time.
+ */
+
 import nodeResolve from "@rollup/plugin-node-resolve";
 
 const external = ["@capacitor/core"];

--- a/plugins/plugin-native-messages/src/definitions.ts
+++ b/plugins/plugin-native-messages/src/definitions.ts
@@ -1,3 +1,14 @@
+/**
+ * Type definitions for the `@elizaos/capacitor-messages` bridge.
+ *
+ * The native side is implemented in Kotlin under
+ * `android/src/main/java/ai/eliza/plugins/messages/MessagesPlugin.kt` and
+ * registered with Capacitor as `ElizaMessages`, wrapping Android's
+ * `SmsManager` (send) and `content://sms` provider (read). The web fallback
+ * in `./web.ts` throws on `sendSms` and resolves empty from `listMessages`
+ * rather than emulating SMS in the browser.
+ */
+
 export interface SendSmsOptions {
   address: string;
   body: string;

--- a/plugins/plugin-native-messages/src/index.ts
+++ b/plugins/plugin-native-messages/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * `@elizaos/capacitor-messages` — Android SMS bridge (`SmsManager` send,
+ * `content://sms` read). Registers as `ElizaMessages` on the Capacitor
+ * bridge; the web fallback (`./web`) is loaded lazily since it is only ever
+ * needed on non-Android platforms.
+ */
+
 import { registerPlugin } from "@capacitor/core";
 
 import type { MessagesPlugin } from "./definitions";

--- a/plugins/plugin-native-messages/src/web.test.ts
+++ b/plugins/plugin-native-messages/src/web.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the `MessagesWeb` fallback: input validation (address/body/
+ * limit, including hostile coercion attempts) and the always-throws /
+ * always-empty Android-only contract. Does not exercise the real Kotlin
+ * `SmsManager` / `content://sms` side.
+ */
+
 import { describe, expect, it } from "vitest";
 
 import type { ListMessagesOptions, SendSmsOptions } from "./definitions";

--- a/plugins/plugin-native-messages/src/web.ts
+++ b/plugins/plugin-native-messages/src/web.ts
@@ -1,3 +1,11 @@
+/**
+ * Web fallback for `@elizaos/capacitor-messages`. SMS is an Android-only
+ * capability with no browser equivalent, so `sendSms` always rejects and
+ * `listMessages` always resolves empty — but both still run the same input
+ * validation as the native side first, so malformed payloads fail identically
+ * on every platform rather than only surfacing on Android.
+ */
+
 import { WebPlugin } from "@capacitor/core";
 
 import type {

--- a/plugins/plugin-native-mlkit-text/rollup.config.mjs
+++ b/plugins/plugin-native-mlkit-text/rollup.config.mjs
@@ -1,3 +1,9 @@
+/**
+ * Rollup config bundling the tsc-emitted ESM output into the IIFE and CJS
+ * artifacts a Capacitor plugin ships. `inlineDynamicImports` folds the lazy
+ * `import("./web")` in `index.ts` into each bundle so there is no separate
+ * chunk to resolve at load time.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-mlkit-text/src/definitions.ts
+++ b/plugins/plugin-native-mlkit-text/src/definitions.ts
@@ -1,3 +1,11 @@
+/**
+ * Type definitions for the `@elizaos/capacitor-mlkit-text` bridge, published
+ * as the Capacitor plugin `Tesseract` so `@elizaos/plugin-vision`'s
+ * renderer-pulled OCR bridge can call it with a `Tesseract`-compatible
+ * surface without bundling Tesseract binaries. `recognize()` runs Google ML
+ * Kit's text recognizer on Android; there is no iOS or web implementation.
+ */
+
 export interface MlKitTextWord {
   text: string;
   left: number;

--- a/plugins/plugin-native-mlkit-text/src/index.ts
+++ b/plugins/plugin-native-mlkit-text/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * `@elizaos/capacitor-mlkit-text` — registers the Android ML Kit OCR bridge
+ * under the plugin name `Tesseract`, kept for compatibility with the
+ * existing UI bridge lookup and the stale #9649 branch's renderer contract.
+ */
+
 import { registerPlugin } from "@capacitor/core";
 
 import type { MlKitTextPlugin } from "./definitions";

--- a/plugins/plugin-native-mlkit-text/src/web.test.ts
+++ b/plugins/plugin-native-mlkit-text/src/web.test.ts
@@ -1,3 +1,5 @@
+/** Covers only that `MlKitTextWeb.recognize` rejects off-Android; the native ML Kit path is untested here. */
+
 import { describe, expect, it } from "vitest";
 import { MlKitTextWeb } from "./web";
 

--- a/plugins/plugin-native-mlkit-text/src/web.ts
+++ b/plugins/plugin-native-mlkit-text/src/web.ts
@@ -1,3 +1,10 @@
+/**
+ * Web fallback for `@elizaos/capacitor-mlkit-text`. Unlike most native
+ * bridges in this repo, there is no safe empty-data default for OCR — a
+ * caller expecting recognized words cannot be handed an empty result and
+ * proceed — so this throws explicitly rather than resolving.
+ */
+
 import { WebPlugin } from "@capacitor/core";
 
 import type {

--- a/plugins/plugin-native-mobile-agent-bridge/rollup.config.mjs
+++ b/plugins/plugin-native-mobile-agent-bridge/rollup.config.mjs
@@ -1,3 +1,9 @@
+/**
+ * Rollup config bundling the tsc-emitted ESM output into the IIFE and CJS
+ * artifacts a Capacitor plugin ships. `inlineDynamicImports` folds the lazy
+ * `import("./web")` in `index.ts` into each bundle so there is no separate
+ * chunk to resolve at load time.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-mobile-agent-bridge/src/web.test.ts
+++ b/plugins/plugin-native-mobile-agent-bridge/src/web.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers `MobileAgentBridgeWeb`'s option validation and idle/error state
+ * transitions — not the native iOS/Android WebSocket tunnel.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MobileAgentBridgeWeb } from "./web";

--- a/plugins/plugin-native-mobile-signals/rollup.config.mjs
+++ b/plugins/plugin-native-mobile-signals/rollup.config.mjs
@@ -1,3 +1,10 @@
+/**
+ * Rollup config bundling the tsc-emitted ESM output into the IIFE and CJS
+ * artifacts a Capacitor plugin ships. `inlineDynamicImports` folds the lazy
+ * `import("./web")` in `index.ts` into each bundle so there is no separate
+ * chunk to resolve at load time; `nodeResolve` lets Rollup follow that
+ * dynamic import back to its source file during the bundling pass.
+ */
 import nodeResolve from "@rollup/plugin-node-resolve";
 
 const external = ["@capacitor/core"];

--- a/plugins/plugin-native-mobile-signals/scripts/validate-ios-screen-time.mjs
+++ b/plugins/plugin-native-mobile-signals/scripts/validate-ios-screen-time.mjs
@@ -1,4 +1,14 @@
 #!/usr/bin/env node
+/**
+ * Build-time wiring check for iOS Screen Time / DeviceActivity support:
+ * confirms the app entitlements, Xcode build settings, DeviceActivity
+ * extension targets/Info.plists, and podspec framework links are all
+ * present before a build ships a Screen Time feature that Apple's
+ * FamilyControls entitlement (provisioned per-app, not requestable at
+ * runtime) would otherwise silently disable. Optionally inspects a
+ * supplied `.mobileprovision` for the same entitlement — binary profiles
+ * are decoded via macOS's `security cms`, so that check is a no-op off Darwin.
+ */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";

--- a/plugins/plugin-native-mobile-signals/scripts/validate-ios-screen-time.test.mjs
+++ b/plugins/plugin-native-mobile-signals/scripts/validate-ios-screen-time.test.mjs
@@ -1,3 +1,9 @@
+/**
+ * Exercises `validateIosScreenTimeBuildWiring` against real, temp-directory
+ * entitlements/Xcode-project/podspec fixtures (written and torn down per
+ * test) rather than mocking `fs` — the checks are plain text/plist parsing,
+ * so the fixture files are the fastest faithful stand-in for a real iOS app tree.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-native-mobile-signals/src/definitions.ts
+++ b/plugins/plugin-native-mobile-signals/src/definitions.ts
@@ -1,3 +1,14 @@
+/**
+ * Type definitions for the `@elizaos/capacitor-mobile-signals` bridge
+ * (`MobileSignalsPlugin`), which surfaces device wake/lock/battery state
+ * and health/screen-time signals to Eliza mobile agents. iOS backs
+ * `screenTime`/health fields with HealthKit + FamilyControls/DeviceActivity
+ * (permanently coarse — see `rawUsageExportAvailable` below); Android backs
+ * them with Health Connect + `PACKAGE_USAGE_STATS`. `scheduleBackgroundRefresh`
+ * / `cancelBackgroundRefresh` are structurally present but always report
+ * `scheduled: false` / `cancelled: false` — no native implementation
+ * registers a background task today.
+ */
 import type { PluginListenerHandle } from "@capacitor/core";
 
 export type MobileSignalsPlatform = "android" | "ios" | "web";

--- a/plugins/plugin-native-mobile-signals/src/index.ts
+++ b/plugins/plugin-native-mobile-signals/src/index.ts
@@ -1,3 +1,5 @@
+/** `@elizaos/capacitor-mobile-signals` — registers the `MobileSignals` Capacitor bridge, loading the browser fallback in `./web` lazily on non-native platforms. */
+
 import { registerPlugin } from "@capacitor/core";
 import type { MobileSignalsPlugin } from "./definitions";
 

--- a/plugins/plugin-native-mobile-signals/src/web.test.ts
+++ b/plugins/plugin-native-mobile-signals/src/web.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers `MobileSignalsWeb`'s permission/settings/snapshot fallbacks over
+ * mocked `navigator`/`document` shapes — not the native HealthKit, Health
+ * Connect, or Screen Time paths.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MobileSignalsWeb } from "./web";

--- a/plugins/plugin-native-mobile-signals/src/web.ts
+++ b/plugins/plugin-native-mobile-signals/src/web.ts
@@ -1,3 +1,13 @@
+/**
+ * Web fallback for `@elizaos/capacitor-mobile-signals`. Browsers have no
+ * HealthKit/Health Connect or Screen Time/Usage Stats access, so permission
+ * and screen-time state always report `"not-applicable"`/`"unavailable"`
+ * rather than fabricating granted/denied status. Device state (active,
+ * idle, background, battery) is approximated from `document.visibilityState`,
+ * window focus/blur, and the Battery Status API — all optional, feature-detected
+ * per call so a missing API degrades to `null` rather than throwing.
+ */
+
 import { WebPlugin } from "@capacitor/core";
 import type {
   MobileSignalsHealthSnapshot,

--- a/plugins/plugin-native-network-policy/rollup.config.mjs
+++ b/plugins/plugin-native-network-policy/rollup.config.mjs
@@ -1,3 +1,10 @@
+/**
+ * Rollup config bundling the tsc-emitted ESM output into the two artifacts
+ * Capacitor plugins ship: an IIFE for browser `<script>`/bundler globals and
+ * a CJS build for Node tooling. `inlineDynamicImports` folds the lazy
+ * `import("./web")` in `index.ts` into each bundle so there is no separate
+ * chunk to resolve at load time.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-network-policy/src/web.test.ts
+++ b/plugins/plugin-native-network-policy/src/web.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers `NetworkPolicyWeb`'s conservative fallbacks over the various shapes
+ * `navigator.connection` can take across browsers — not the native
+ * Android/iOS bridge.
+ */
+
 import { afterEach, describe, expect, it } from "vitest";
 
 import { NetworkPolicyWeb } from "./web";

--- a/plugins/plugin-native-phone/rollup.config.mjs
+++ b/plugins/plugin-native-phone/rollup.config.mjs
@@ -1,3 +1,9 @@
+/**
+ * Bundles the tsc output (`dist/esm/index.js`) into the two artifacts the
+ * Capacitor host app consumes: an IIFE for browser `<script>` inclusion and
+ * a CJS build for Node-based tooling. `@capacitor/core` stays external since
+ * the host app supplies its own copy.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-phone/src/definitions.ts
+++ b/plugins/plugin-native-phone/src/definitions.ts
@@ -1,3 +1,15 @@
+/**
+ * Type definitions for the @elizaos/capacitor-phone bridge to Android's
+ * Telecom and CallLog APIs.
+ *
+ * The native side is implemented in Kotlin under
+ * android/src/main/java/ai/eliza/plugins/phone/PhonePlugin.kt and is
+ * registered with Capacitor as `ElizaPhone`. The web fallback in `./web.ts`
+ * rejects mutating calls (calling/dialing/transcripts are Android-only) but
+ * resolves `listRecentCalls` with an empty array so read paths compile and
+ * degrade quietly on non-Android platforms.
+ */
+
 export interface PlaceCallOptions {
   number: string;
 }

--- a/plugins/plugin-native-phone/src/index.ts
+++ b/plugins/plugin-native-phone/src/index.ts
@@ -1,3 +1,5 @@
+/** Registers the `ElizaPhone` Capacitor bridge and re-exports its types; see `./definitions.ts` for the API surface. */
+
 import { registerPlugin } from "@capacitor/core";
 
 import type { PhonePlugin } from "./definitions";

--- a/plugins/plugin-native-phone/src/web.test.ts
+++ b/plugins/plugin-native-phone/src/web.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers only the `PhoneWeb` no-op/validation fallback (status disabled,
+ * mutating calls rejected, input sanitized before rejection) — not the
+ * native Kotlin Telecom/CallLog side.
+ */
+
 import { describe, expect, it } from "vitest";
 
 import { PhoneWeb } from "./web";

--- a/plugins/plugin-native-phone/src/web.ts
+++ b/plugins/plugin-native-phone/src/web.ts
@@ -1,3 +1,13 @@
+/**
+ * Web fallback for `@elizaos/capacitor-phone`. Calling, dialing, and
+ * transcript writes are Android-only capabilities with no browser
+ * equivalent, so those methods validate their input and then throw;
+ * `getStatus`/`listRecentCalls` resolve with disabled/empty results instead
+ * of throwing so read paths compile and degrade quietly off-Android.
+ * Validation runs before the Android-only rejection so malformed input is
+ * never silently swallowed by the platform check.
+ */
+
 import { WebPlugin } from "@capacitor/core";
 
 import type {

--- a/plugins/plugin-native-reminders/src/index.ts
+++ b/plugins/plugin-native-reminders/src/index.ts
@@ -1,1 +1,2 @@
+/** Barrel re-export of the macOS Apple Reminders bridge candidate policy (dylib basename + path resolution). */
 export * from "./macos-bridge-policy.js";

--- a/plugins/plugin-native-reminders/src/macos-bridge-policy.test.ts
+++ b/plugins/plugin-native-reminders/src/macos-bridge-policy.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `appleRemindersMacosBridgeCandidates`'s candidate ordering
+ * and env-override opt-in/opt-out. Pure path-string logic — no filesystem or
+ * EventKit access.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   APPLE_REMINDERS_MACOS_BRIDGE_DYLIB_BASENAME,

--- a/plugins/plugin-native-reminders/src/macos-bridge-policy.ts
+++ b/plugins/plugin-native-reminders/src/macos-bridge-policy.ts
@@ -1,3 +1,15 @@
+/**
+ * Candidate-path policy for locating the macOS EventKit dylib
+ * (`libMacWindowEffects.dylib`) that backs Apple Reminders access — the same
+ * dylib the desktop permissions/EventKit bridge uses. Lives here rather than
+ * in `plugin-personal-assistant`/LifeOps so the resolution logic stays a
+ * pure, reusable, testable unit; callers resolve `ELIZA_NATIVE_PERMISSIONS_DYLIB`
+ * themselves and pass it in, so this package never reads env directly.
+ * Candidates are ordered env-override, then packaged (two relative-depth
+ * variants for different install layouts), then local dev build; empty paths
+ * are filtered out.
+ */
+
 export interface AppleRemindersMacosBridgeCandidate {
   label: string;
   path: string;

--- a/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.test.ts
+++ b/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.test.ts
@@ -1,5 +1,14 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers `DeviceSettingsAppView` rendering and interactions against a
+ * hand-mocked `@elizaos/capacitor-system` bridge — populated data display,
+ * apply/refresh/role-request flows, empty states, and hostile bridge values
+ * (NaN brightness, out-of-range volume) that must be clamped before being
+ * written back. Shape fidelity against the real bridge is covered
+ * separately by `device-settings-contract.test.ts`.
+ */
+
 import type {
   DeviceSettingsStatus,
   SystemStatus,

--- a/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.tsx
+++ b/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.tsx
@@ -1,3 +1,18 @@
+/**
+ * Full-screen Android device-settings overlay: brightness, per-stream
+ * volume, default-role assignment (Home/Phone/SMS/Assistant), and shortcuts
+ * into system settings panels — all read/written through the
+ * `@elizaos/capacitor-system` native bridge (`System.*`). Rendered via
+ * `deviceSettingsApp.loader` (`device-settings-app.ts`), so it must stay
+ * self-contained with no module-level side-effect imports.
+ *
+ * Brightness/volume writes require Android's `WRITE_SETTINGS` permission;
+ * the view surfaces a permission button rather than failing silently when
+ * `canWriteSettings` is false. Values from the bridge are clamped
+ * client-side (`clampUnit`/`clampVolumeValue`) since a stale or racing OS
+ * read can report brightness/volume outside the valid range.
+ */
+
 import {
   type AndroidRoleName,
   type AndroidRoleStatus,

--- a/plugins/plugin-native-settings/src/components/DeviceSettingsVisualCopy.test.ts
+++ b/plugins/plugin-native-settings/src/components/DeviceSettingsVisualCopy.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Source-text guard: keeps the overlay's copy compact by asserting removed
+ * paragraph-style helper text doesn't reappear in `DeviceSettingsAppView.tsx`.
+ */
+
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-native-settings/src/components/device-settings-app.test.ts
+++ b/plugins/plugin-native-settings/src/components/device-settings-app.test.ts
@@ -1,3 +1,5 @@
+/** Covers the overlay descriptor's shape and that registration forwards it verbatim to `registerOverlayApp` — a mocked `@elizaos/ui`, not the real registry. */
+
 import { describe, expect, it, vi } from "vitest";
 
 const registerOverlayApp = vi.hoisted(() => vi.fn());

--- a/plugins/plugin-native-settings/src/components/device-settings-app.ts
+++ b/plugins/plugin-native-settings/src/components/device-settings-app.ts
@@ -1,3 +1,11 @@
+/**
+ * `OverlayApp` descriptor for the Android device-settings overlay —
+ * the entire runtime surface this plugin contributes (no actions,
+ * providers, or services). `androidOnly: true` keeps it out of the apps
+ * grid on non-Android shells; the view itself is lazy-loaded so importing
+ * this module never pulls in React/the UI bundle.
+ */
+
 import { type OverlayApp, registerOverlayApp } from "@elizaos/ui";
 
 export const DEVICE_SETTINGS_APP_NAME = "@elizaos/plugin-native-settings";

--- a/plugins/plugin-native-settings/src/components/device-settings-contract.test.ts
+++ b/plugins/plugin-native-settings/src/components/device-settings-contract.test.ts
@@ -1,17 +1,12 @@
 // @vitest-environment jsdom
-//
-// Contract test: validate the view's consumed shape against the REAL
-// @elizaos/capacitor-system implementation rather than hand-written mocks.
-//
-// vitest.config.ts aliases "@elizaos/capacitor-system" to the real
-// plugin-native-system/src/index.ts, so `System` here is the registered
-// Capacitor plugin proxy. In jsdom (no native bridge) it falls back to the
-// real `SystemWeb` web implementation — the same code that runs in a browser
-// build. We instantiate SystemWeb directly to assert its response satisfies the
-// DeviceSettingsStatus / SystemStatus contracts the view reads, then render the
-// view wired to the live `System` proxy and assert the volume cards/percentages
-// render from that real data. This proves the consumer parses the actual API
-// shape, not a fixture that could drift from the provider.
+
+/**
+ * Contract test: verifies `DeviceSettingsAppView` against the REAL
+ * `@elizaos/capacitor-system` web fallback (aliased in `vitest.config.ts`),
+ * not hand-written mocks — protects against the view's parsing assumptions
+ * drifting from the actual `DeviceSettingsStatus`/`SystemStatus` shapes the
+ * provider returns.
+ */
 
 import {
   type AndroidRoleName,

--- a/plugins/plugin-native-settings/src/index.ts
+++ b/plugins/plugin-native-settings/src/index.ts
@@ -1,3 +1,5 @@
+/** Public barrel: the overlay app descriptor, its view, and the bare `Plugin` object (no actions/providers). */
+
 export { DeviceSettingsAppView } from "./components/DeviceSettingsAppView";
 export {
   DEVICE_SETTINGS_APP_NAME,

--- a/plugins/plugin-native-settings/src/plugin.ts
+++ b/plugins/plugin-native-settings/src/plugin.ts
@@ -1,3 +1,10 @@
+/**
+ * Bare `Plugin` descriptor (name + description only, no actions/providers/
+ * services) — the elizaOS-recognizable identity for the device-settings
+ * overlay app. All actual behavior is delivered through the `OverlayApp`
+ * registered by `./components/device-settings-app.ts`, not through this object.
+ */
+
 import type { Plugin } from "@elizaos/core";
 
 export const appDeviceSettingsPlugin: Plugin = {

--- a/plugins/plugin-native-settings/src/register.ts
+++ b/plugins/plugin-native-settings/src/register.ts
@@ -1,3 +1,10 @@
+/**
+ * Side-effect entry point: registers the device-settings overlay app on
+ * import. Guarded by `isElizaOS()` so plain web/dev builds that pull this
+ * package in transitively don't register an Android-only overlay into a
+ * shell that never asked for it.
+ */
+
 import { isElizaOS } from "@elizaos/ui";
 import { registerDeviceSettingsApp } from "./components/device-settings-app";
 

--- a/plugins/plugin-native-settings/src/ui.ts
+++ b/plugins/plugin-native-settings/src/ui.ts
@@ -1,3 +1,5 @@
+/** UI-only barrel (explicit extensions) for bundlers that need to exclude the `register.ts` side effect. */
+
 export { DeviceSettingsAppView } from "./components/DeviceSettingsAppView.tsx";
 export {
   DEVICE_SETTINGS_APP_NAME,

--- a/plugins/plugin-native-settings/vitest.config.ts
+++ b/plugins/plugin-native-settings/vitest.config.ts
@@ -1,3 +1,10 @@
+/**
+ * Aliases `@elizaos/capacitor-system` to its real `src/index.ts` (not a
+ * mock) so `device-settings-contract.test.ts` exercises the actual
+ * `SystemWeb` fallback the view depends on, catching drift between the
+ * view's parsing assumptions and the provider's real output shape.
+ */
+
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";

--- a/plugins/plugin-native-shared-types/src/index.test.ts
+++ b/plugins/plugin-native-shared-types/src/index.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Smoke test for the native shared-types contract package (issue #9943: it
+ * shipped with zero tests). The package exposes only type contracts used across
+ * the Capacitor/Electrobun native bridges, so this (a) proves the module is
+ * importable at runtime and (b) constructs values against the exported generic
+ * contracts and exercises them — a compile-time + runtime guard that the
+ * contracts stay consumable and behave as documented.
+ */
+
 import { describe, expect, test } from "bun:test";
 import type {
   EventCallback,
@@ -7,14 +16,6 @@ import type {
 } from "./index";
 import * as sharedTypes from "./index";
 
-/**
- * Smoke test for the native shared-types contract package (issue #9943: it
- * shipped with zero tests). The package exposes only type contracts used across
- * the Capacitor/Electrobun native bridges, so this (a) proves the module is
- * importable at runtime and (b) constructs values against the exported generic
- * contracts and exercises them — a compile-time + runtime guard that the
- * contracts stay consumable and behave as documented.
- */
 describe("@elizaos/native-plugin-shared-types", () => {
   test("the module is importable at runtime", () => {
     expect(typeof sharedTypes).toBe("object");

--- a/plugins/plugin-native-shared-types/src/index.ts
+++ b/plugins/plugin-native-shared-types/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Shared TypeScript type contracts for elizaOS native plugin bridges
+ * (Capacitor mobile, Electrobun desktop) and the Web Speech API shims that
+ * Swabble/TalkMode need. Type-only — no runtime values and no build step;
+ * consumers resolve straight to this source via `workspace:*`.
+ */
+
 /** Generic event callback used across Capacitor/Electrobun plugin bridges. */
 export type EventCallback<T = unknown> = (event: T) => void;
 

--- a/plugins/plugin-native-swabble/rollup.config.mjs
+++ b/plugins/plugin-native-swabble/rollup.config.mjs
@@ -3,10 +3,18 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import nodeResolve from "@rollup/plugin-node-resolve";
 
+/**
+ * Bundles the tsc output into the IIFE (`dist/plugin.js`) and CJS
+ * (`dist/plugin.cjs.js`) artifacts the Capacitor host app consumes.
+ * Resolves paths against this file's own directory rather than `cwd`
+ * because turbo/bun may invoke rollup from the repo root.
+ */
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const external = ["@capacitor/core"];
 
-// Resolve against this file's directory — turbo/bun may not use the package root as cwd.
+// Fails fast with an actionable message instead of a rollup "could not resolve" error
+// if tsc hasn't run yet — this bundler step depends on the tsc step running first.
 const esmIndex = path.join(__dirname, "dist/esm/index.js");
 if (!fs.existsSync(esmIndex)) {
   throw new Error(

--- a/plugins/plugin-native-swabble/src/definitions.ts
+++ b/plugins/plugin-native-swabble/src/definitions.ts
@@ -1,3 +1,16 @@
+/**
+ * Type definitions for the @elizaos/capacitor-swabble bridge: wake-word
+ * detection and live speech transcription.
+ *
+ * Native implementations: Swift `Speech`/`AVFoundation` on iOS/macOS
+ * (`ios/Sources/SwabblePlugin/SwabblePlugin.swift`), Kotlin
+ * `SpeechRecognizer` on Android (`android/.../SwabblePlugin.kt`). The web
+ * fallback in `./web.ts` uses the Web Speech API directly in-browser, or
+ * delegates to an Electrobun/Whisper.cpp desktop bridge when present —
+ * `postGap`/segment timing fields are only meaningful off-web, since the
+ * Web Speech API exposes no word-level timing.
+ */
+
 import type { PluginListenerHandle } from "@capacitor/core";
 
 /**

--- a/plugins/plugin-native-swabble/src/index.ts
+++ b/plugins/plugin-native-swabble/src/index.ts
@@ -1,3 +1,5 @@
+/** Registers the `Swabble` Capacitor bridge and re-exports its types; see `./definitions.ts` for the API surface. */
+
 import { registerPlugin } from "@capacitor/core";
 
 import type { SwabblePlugin } from "./definitions";

--- a/plugins/plugin-native-swabble/src/web.test.ts
+++ b/plugins/plugin-native-swabble/src/web.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Covers the `SwabbleWeb` fallback against a faked `SpeechRecognition` and
+ * a faked Electrobun desktop bridge — permission reporting, config
+ * validation, wake-word/transcript event emission (including non-Latin
+ * scripts), and native-IPC bridge lifecycle. Not the native Swift/Kotlin
+ * implementations.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { SwabbleWeb } from "./web";

--- a/plugins/plugin-native-swabble/src/web.ts
+++ b/plugins/plugin-native-swabble/src/web.ts
@@ -1,3 +1,14 @@
+/**
+ * Web/desktop fallback for `@elizaos/capacitor-swabble`. In-browser it runs
+ * wake-word detection directly against the Web Speech API via
+ * `WakeWordGate`; on desktop (Electrobun) it detects the
+ * `window.__ELIZA_ELECTROBUN_RPC__` bridge and delegates start/stop/config
+ * to the native Whisper.cpp backend, additionally capturing raw PCM in the
+ * renderer and streaming it to the main process over IPC. `setAudioDevice`
+ * throws unconditionally — the Web Speech API has no device-selection API,
+ * so there is no fallback to provide.
+ */
+
 import { WebPlugin } from "@capacitor/core";
 import type {
   SpeechRecognitionCtor,
@@ -156,13 +167,11 @@ class WakeWordGate {
       const triggerIndex = normalizedTranscript.indexOf(trigger);
       if (triggerIndex === -1) continue;
 
-      // Extract command after the trigger phrase
       const commandStart = triggerIndex + trigger.length;
       const command = transcript.slice(commandStart).trim();
 
       if (command.length < this.minCommandLength) continue;
 
-      // postGap=-1 indicates timing unavailable on web platform
       return { wakeWord: trigger, command, postGap: -1 };
     }
     return null;
@@ -492,7 +501,6 @@ export class SwabbleWeb extends WebPlugin {
   async stop(): Promise<void> {
     this.isActive = false;
 
-    // Clean up native IPC if in native mode
     if (this.usingNativeIpc) {
       this.usingNativeIpc = false;
       this.removeNativeListeners();
@@ -533,7 +541,6 @@ export class SwabbleWeb extends WebPlugin {
       }
     }
 
-    // Sync to native IPC if active
     if (this.usingNativeIpc) {
       void this.invokeDesktopRequest({
         rpcMethod: "swabbleUpdateConfig",

--- a/plugins/plugin-native-system/rollup.config.mjs
+++ b/plugins/plugin-native-system/rollup.config.mjs
@@ -1,3 +1,11 @@
+/**
+ * Bundles the tsc-emitted ESM (`dist/esm/index.js`) into the two artifacts
+ * Capacitor host apps consume: an IIFE for direct `<script>`/bundler use and
+ * a CJS build for Node tooling. `@capacitor/core` stays external — hosts
+ * supply their own copy — and `inlineDynamicImports` folds the web fallback's
+ * dynamic `import("./web")` into each bundle so lazy-loading still works
+ * once flattened to a single file.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-system/src/definitions.ts
+++ b/plugins/plugin-native-system/src/definitions.ts
@@ -1,3 +1,16 @@
+/**
+ * Type definitions for the @elizaos/capacitor-system bridge.
+ *
+ * The native side is implemented in Kotlin under
+ * android/src/main/java/ai/eliza/plugins/system/SystemPlugin.kt and is
+ * registered with Capacitor as `ElizaSystem`. It exposes Android
+ * RoleManager status, system-settings shortcuts, screen-brightness, and
+ * per-stream audio-volume control. The web fallback in `./web.ts` returns
+ * safe read defaults for status/settings queries but throws for every
+ * Android-only action (settings shortcuts, role requests, brightness/volume
+ * writes) — callers must guard those with a platform check rather than
+ * expect empty-data silence.
+ */
 export type AndroidRoleName = "home" | "dialer" | "sms" | "assistant";
 
 export interface AndroidRoleStatus {

--- a/plugins/plugin-native-system/src/index.ts
+++ b/plugins/plugin-native-system/src/index.ts
@@ -1,3 +1,5 @@
+/** Registers the `ElizaSystem` Capacitor plugin and re-exports its types; see `./definitions.ts` for the bridge contract. */
+
 import { registerPlugin } from "@capacitor/core";
 
 import type { SystemPlugin } from "./definitions";

--- a/plugins/plugin-native-system/src/web.test.ts
+++ b/plugins/plugin-native-system/src/web.test.ts
@@ -1,3 +1,5 @@
+/** Covers only the `SystemWeb` fallback's default values and validation/rejection messages; the native Kotlin side is untested here. */
+
 import { describe, expect, it } from "vitest";
 
 import { SystemWeb } from "./web";

--- a/plugins/plugin-native-system/src/web.ts
+++ b/plugins/plugin-native-system/src/web.ts
@@ -1,3 +1,15 @@
+/**
+ * Web fallback for `@elizaos/capacitor-system`, loaded on non-Android
+ * platforms. Read-only status queries (`getStatus`, `getDeviceSettings`)
+ * resolve with safe placeholder data so type-only/non-Android consumers
+ * compile and run cleanly; every action that requires real OS control
+ * (settings shortcuts, role requests, brightness/volume writes) throws,
+ * since silently no-oping a permission or hardware write would be worse
+ * than an explicit error. Input validation (role/stream/range checks) runs
+ * before the platform-unavailable error so malformed calls fail on their
+ * own merits rather than being masked by the Android-only rejection.
+ */
+
 import { WebPlugin } from "@capacitor/core";
 
 import type {

--- a/plugins/plugin-native-talkmode/rollup.config.mjs
+++ b/plugins/plugin-native-talkmode/rollup.config.mjs
@@ -1,3 +1,11 @@
+/**
+ * Bundles the tsc-emitted ESM (`dist/esm/index.js`) into the two artifacts
+ * Capacitor host apps consume: an IIFE for direct `<script>`/bundler use and
+ * a CJS build for Node tooling. `@capacitor/core` stays external — hosts
+ * supply their own copy — and `inlineDynamicImports` folds the web fallback's
+ * dynamic `import("./web")` into each bundle so lazy-loading still works
+ * once flattened to a single file.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-talkmode/src/definitions.ts
+++ b/plugins/plugin-native-talkmode/src/definitions.ts
@@ -1,3 +1,17 @@
+/**
+ * Type definitions for the @elizaos/capacitor-talkmode bridge — the full
+ * voice-conversation surface (start/stop, TTS `speak`, permission checks,
+ * the state/transcript/speaking/playback event stream, and raw PCM frame
+ * capture for diarization/VAD/wake-word).
+ *
+ * Native iOS/Android/Electrobun drive STT via the platform recognizer and
+ * TTS via ElevenLabs streaming (PCM/MP3) with system-TTS fallback; the web
+ * fallback in `./web.ts` uses the Web Speech API only, since ElevenLabs
+ * streaming is CORS-blocked in browsers. `startAudioFrames` is a
+ * native-only diarization tap — Android cannot run `AudioRecord` and
+ * `SpeechRecognizer` concurrently, so starting it suspends STT for the
+ * capture's duration; it no-ops with an explicit error on web.
+ */
 import type { PluginListenerHandle } from "@capacitor/core";
 
 /**

--- a/plugins/plugin-native-talkmode/src/index.ts
+++ b/plugins/plugin-native-talkmode/src/index.ts
@@ -1,3 +1,5 @@
+/** Registers the `TalkMode` Capacitor plugin and re-exports its types; see `./definitions.ts` for the bridge contract. */
+
 import { registerPlugin } from "@capacitor/core";
 import type { TalkModePlugin } from "./definitions";
 

--- a/plugins/plugin-native-talkmode/src/web.test.ts
+++ b/plugins/plugin-native-talkmode/src/web.test.ts
@@ -1,3 +1,5 @@
+/** Covers only the `TalkModeWeb` Web Speech API fallback — unsupported-browser handling, transcript sanitization, and TTS completion/error mapping; the native iOS/Android/Electrobun STT+ElevenLabs paths are untested here. */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { TalkModeWeb } from "./web";

--- a/plugins/plugin-native-talkmode/src/web.ts
+++ b/plugins/plugin-native-talkmode/src/web.ts
@@ -1,3 +1,14 @@
+/**
+ * Web fallback for `@elizaos/capacitor-talkmode`, loaded on browser/desktop
+ * platforms without a native bridge. Bridges the Web Speech API
+ * (`SpeechRecognition` + `SpeechSynthesis`) to the same `TalkModePlugin`
+ * surface the native iOS/Android/Electrobun implementations expose.
+ * ElevenLabs streaming TTS is CORS-blocked in browsers, so `speak()` always
+ * falls through to system `SpeechSynthesis` (`usedSystemTts` is always
+ * `true` here). `startAudioFrames` has no Web Speech equivalent and always
+ * resolves `{ started: false }`.
+ */
+
 import { WebPlugin } from "@capacitor/core";
 import type {
   SpeechRecognitionCtor,
@@ -44,7 +55,6 @@ export class TalkModeWeb extends WebPlugin {
       this.config = { ...this.config, ...options.config };
     }
 
-    // Check for Web Speech API support
     const SpeechRecognitionAPI: SpeechRecognitionCtor | undefined =
       ((window as SpeechRecognitionWindow).SpeechRecognition as
         | SpeechRecognitionCtor
@@ -67,7 +77,6 @@ export class TalkModeWeb extends WebPlugin {
     this.enabled = true;
     this.setState("listening", "Listening");
 
-    // Initialize speech recognition
     this.recognition = new SpeechRecognitionAPI();
     this.recognition.continuous = true;
     this.recognition.interimResults = true;
@@ -83,8 +92,8 @@ export class TalkModeWeb extends WebPlugin {
       this.notifyListeners("transcript", { transcript, isFinal });
 
       if (isFinal && transcript.trim()) {
-        // Note: Full talk mode flow would need Gateway plugin integration
-        // For web, we just emit the transcript
+        // Web only emits the transcript event; it does not drive chat
+        // orchestration itself (unlike the native start()/stop() flow).
       }
     };
 
@@ -227,16 +236,13 @@ export class TalkModeWeb extends WebPlugin {
     };
   }
 
-  async stopAudioFrames(): Promise<void> {
-    // no-op on web
-  }
+  async stopAudioFrames(): Promise<void> {}
 
   async isCapturingAudioFrames(): Promise<{ capturing: boolean }> {
     return { capturing: false };
   }
 
   async checkPermissions(): Promise<TalkModePermissionStatus> {
-    // Check microphone permission
     let microphone: TalkModePermissionStatus["microphone"] = "prompt";
     try {
       const result = await navigator.permissions?.query?.({
@@ -250,10 +256,10 @@ export class TalkModeWeb extends WebPlugin {
         microphone = result.state;
       }
     } catch {
-      // Permissions API may not support microphone query
+      // Older browsers lack the Permissions API microphone descriptor; fall
+      // through to the "prompt" default set above.
     }
 
-    // Check if speech recognition is supported
     const SpeechRecognitionAPI: SpeechRecognitionCtor | undefined =
       ((window as SpeechRecognitionWindow).SpeechRecognition as
         | SpeechRecognitionCtor
@@ -269,7 +275,8 @@ export class TalkModeWeb extends WebPlugin {
   }
 
   async requestPermissions(): Promise<TalkModePermissionStatus> {
-    // Request microphone permission by attempting to get user media
+    // getUserMedia is the only way to trigger the browser's mic permission
+    // prompt; the stream itself is discarded once it has done its job.
     try {
       const stream = await navigator.mediaDevices?.getUserMedia?.({
         audio: true,
@@ -279,7 +286,8 @@ export class TalkModeWeb extends WebPlugin {
         track.stop();
       });
     } catch {
-      // Permission denied or error
+      // Denied or unsupported — checkPermissions() below reports the
+      // resulting state instead of surfacing the raw error here.
     }
 
     return this.checkPermissions();

--- a/plugins/plugin-native-websiteblocker/rollup.config.mjs
+++ b/plugins/plugin-native-websiteblocker/rollup.config.mjs
@@ -1,3 +1,11 @@
+/**
+ * Bundles the tsc-emitted ESM (`dist/esm/index.js`) into the two artifacts
+ * Capacitor host apps consume: an IIFE for direct `<script>`/bundler use and
+ * a CJS build for Node tooling. `@capacitor/core` stays external — hosts
+ * supply their own copy — and `inlineDynamicImports` folds the web fallback's
+ * dynamic `import("./web")` into each bundle so lazy-loading still works
+ * once flattened to a single file.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-websiteblocker/src/backend.test.ts
+++ b/plugins/plugin-native-websiteblocker/src/backend.test.ts
@@ -1,3 +1,5 @@
+/** Covers `createNativeWebsiteBlockerBackend`'s mapping between the Capacitor `WebsiteBlockerPlugin` shape and the `@elizaos/plugin-blocker` engine's `SelfControlStatus`/`SelfControlPermissionState` shapes, against a hand-built fake plugin (no real native or HTTP calls). */
+
 import { describe, expect, it, vi } from "vitest";
 
 import { createNativeWebsiteBlockerBackend } from "./backend";

--- a/plugins/plugin-native-websiteblocker/src/definitions.ts
+++ b/plugins/plugin-native-websiteblocker/src/definitions.ts
@@ -1,3 +1,15 @@
+/**
+ * Type definitions for the @elizaos/capacitor-websiteblocker bridge, which
+ * enforces website blocking with a different mechanism per platform: a
+ * split-tunnel VPN with DNS-level filtering on Android
+ * (android/.../WebsiteBlockerPlugin.kt), a Safari content-blocker extension
+ * backed by shared App Group `UserDefaults` on iOS
+ * (ios/Sources/WebsiteBlockerPlugin/), and a proxy to the Eliza runtime's
+ * `/api/website-blocker` HTTP API on web (`./web.ts`). `engine` and
+ * `settingsTarget` distinguish which mechanism is active so callers can
+ * render platform-appropriate consent/settings UI rather than assuming
+ * hosts-file semantics.
+ */
 export type WebsiteBlockerPermissionStatus =
   | "granted"
   | "denied"

--- a/plugins/plugin-native-websiteblocker/src/index.ts
+++ b/plugins/plugin-native-websiteblocker/src/index.ts
@@ -1,3 +1,5 @@
+/** Registers the `ElizaWebsiteBlocker` Capacitor plugin, re-exports its types, and re-exports the `@elizaos/plugin-blocker` adapter from `./backend.ts`. */
+
 import { registerPlugin } from "@capacitor/core";
 
 import type { WebsiteBlockerPlugin } from "./definitions";

--- a/plugins/plugin-native-websiteblocker/src/web.test.ts
+++ b/plugins/plugin-native-websiteblocker/src/web.test.ts
@@ -1,3 +1,5 @@
+/** Covers only `WebsiteBlockerWeb`'s hostname/duration validation and its HTTP proxying to `/api/website-blocker` against a mocked `fetch`; the Android VPN and iOS content-blocker enforcement paths are untested here. */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { WebsiteBlockerWeb } from "./web";

--- a/plugins/plugin-native-websiteblocker/src/web.ts
+++ b/plugins/plugin-native-websiteblocker/src/web.ts
@@ -1,3 +1,14 @@
+/**
+ * Web fallback for `@elizaos/capacitor-websiteblocker`. Unlike the
+ * Android/iOS implementations, which enforce blocking on-device (VPN DNS /
+ * Safari content blocker), the browser has no equivalent primitive — this
+ * class instead proxies every method to the Eliza runtime's
+ * `/api/website-blocker` HTTP API, which is the actual enforcement point on
+ * web. Hostname inputs are normalized and validated here (protocol/wildcard
+ * stripping, IDN lowercasing, requiring a public dot) before being sent, so
+ * the server only ever receives well-formed hostnames.
+ */
+
 import { WebPlugin } from "@capacitor/core";
 import type {
   StartWebsiteBlockOptions,

--- a/plugins/plugin-native-wifi/rollup.config.mjs
+++ b/plugins/plugin-native-wifi/rollup.config.mjs
@@ -1,3 +1,11 @@
+/**
+ * Bundles the tsc-emitted ESM (`dist/esm/index.js`) into the two artifacts
+ * Capacitor host apps consume: an IIFE for direct `<script>`/bundler use and
+ * a CJS build for Node tooling. `@capacitor/core` stays external — hosts
+ * supply their own copy — and `inlineDynamicImports` folds the web fallback's
+ * dynamic `import("./web")` into each bundle so lazy-loading still works
+ * once flattened to a single file.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-wifi/src/index.ts
+++ b/plugins/plugin-native-wifi/src/index.ts
@@ -1,3 +1,5 @@
+/** Registers the `ElizaWiFi` Capacitor plugin and re-exports its types; see `./definitions.ts` for the bridge contract. */
+
 import { registerPlugin } from "@capacitor/core";
 
 import type { WiFiPlugin } from "./definitions";

--- a/plugins/plugin-native-wifi/src/web.test.ts
+++ b/plugins/plugin-native-wifi/src/web.test.ts
@@ -1,3 +1,5 @@
+/** Covers only the `WiFiWeb` fallback's disabled default state, option validation, and the single-warning behavior; the native Android Kotlin implementation is untested here. */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { WiFiWeb } from "./web";

--- a/plugins/plugin-native-wifi/src/web.ts
+++ b/plugins/plugin-native-wifi/src/web.ts
@@ -1,3 +1,12 @@
+/**
+ * Web fallback for `@elizaos/capacitor-wifi`, loaded on non-Android
+ * platforms. Every read resolves with empty/disabled data (see the class
+ * docblock below) rather than throwing, so browser/desktop dev sessions and
+ * type-only consumers keep working; a single console warning per session
+ * (`warnOnce`) signals that no real Wi-Fi data is available instead of
+ * repeating on every call.
+ */
+
 import { WebPlugin } from "@capacitor/core";
 
 import type {


### PR DESCRIPTION
Fixes #12764

## Summary
Added or repaired a purpose-explaining prose header (device capability + permission/safety boundary) on every in-scope source file across the 14 native-bridge M-Z plugins listed in #12764, and removed a handful of restatement/dead/change-narration comments (e.g. in plugin-native-swabble/src/web.ts and plugin-native-talkmode/src/web.ts). Zero functional diff, mechanically proven by scripts/assert-comment-only-diff.mjs ('OK — 77 source file(s) changed; every code token identical to origin/develop').

## Changes
- `plugins/plugin-native-macosalarm/__tests__/actions.test.ts`
- `plugins/plugin-native-macosalarm/__tests__/helper.test.ts`
- `plugins/plugin-native-macosalarm/__tests__/integration.macos.test.ts`
- `plugins/plugin-native-macosalarm/scripts/build-helper.mjs`
- `plugins/plugin-native-macosalarm/src/actions.ts`
- `plugins/plugin-native-macosalarm/src/helper.ts`
- `plugins/plugin-native-macosalarm/src/index.ts`
- `plugins/plugin-native-macosalarm/src/plugin.ts`
- `plugins/plugin-native-macosalarm/src/types.ts`
- `plugins/plugin-native-macosalarm/vitest.config.ts`
- `plugins/plugin-native-messages/rollup.config.mjs`
- `plugins/plugin-native-messages/src/definitions.ts`
- `plugins/plugin-native-messages/src/index.ts`
- `plugins/plugin-native-messages/src/web.test.ts`
- `plugins/plugin-native-messages/src/web.ts`
- `plugins/plugin-native-mlkit-text/rollup.config.mjs`
- `plugins/plugin-native-mlkit-text/src/definitions.ts`
- `plugins/plugin-native-mlkit-text/src/index.ts`
- `plugins/plugin-native-mlkit-text/src/web.test.ts`
- `plugins/plugin-native-mlkit-text/src/web.ts`
- `plugins/plugin-native-mobile-agent-bridge/rollup.config.mjs`
- `plugins/plugin-native-mobile-agent-bridge/src/web.test.ts`
- `plugins/plugin-native-mobile-signals/rollup.config.mjs`
- `plugins/plugin-native-mobile-signals/scripts/validate-ios-screen-time.mjs`
- `plugins/plugin-native-mobile-signals/scripts/validate-ios-screen-time.test.mjs`
- `plugins/plugin-native-mobile-signals/src/definitions.ts`
- `plugins/plugin-native-mobile-signals/src/index.ts`
- `plugins/plugin-native-mobile-signals/src/web.test.ts`
- `plugins/plugin-native-mobile-signals/src/web.ts`
- `plugins/plugin-native-network-policy/rollup.config.mjs`
- `plugins/plugin-native-network-policy/src/web.test.ts`
- `plugins/plugin-native-phone/rollup.config.mjs`
- `plugins/plugin-native-phone/src/definitions.ts`
- `plugins/plugin-native-phone/src/index.ts`
- `plugins/plugin-native-phone/src/web.test.ts`
- `plugins/plugin-native-phone/src/web.ts`
- `plugins/plugin-native-reminders/src/index.ts`
- `plugins/plugin-native-reminders/src/macos-bridge-policy.test.ts`
- `plugins/plugin-native-reminders/src/macos-bridge-policy.ts`
- `plugins/plugin-native-settings/src/components/DeviceSettingsAppView.test.ts`
- `plugins/plugin-native-settings/src/components/DeviceSettingsAppView.tsx`
- `plugins/plugin-native-settings/src/components/DeviceSettingsVisualCopy.test.ts`
- `plugins/plugin-native-settings/src/components/device-settings-app.test.ts`
- `plugins/plugin-native-settings/src/components/device-settings-app.ts`
- `plugins/plugin-native-settings/src/components/device-settings-contract.test.ts`
- `plugins/plugin-native-settings/src/index.ts`
- `plugins/plugin-native-settings/src/plugin.ts`
- `plugins/plugin-native-settings/src/register.ts`
- `plugins/plugin-native-settings/src/ui.ts`
- `plugins/plugin-native-settings/vitest.config.ts`
- `plugins/plugin-native-shared-types/src/index.test.ts`
- `plugins/plugin-native-shared-types/src/index.ts`
- `plugins/plugin-native-swabble/rollup.config.mjs`
- `plugins/plugin-native-swabble/src/definitions.ts`
- `plugins/plugin-native-swabble/src/index.ts`
- `plugins/plugin-native-swabble/src/web.test.ts`
- `plugins/plugin-native-swabble/src/web.ts`
- `plugins/plugin-native-system/rollup.config.mjs`
- `plugins/plugin-native-system/src/definitions.ts`
- `plugins/plugin-native-system/src/index.ts`
- `plugins/plugin-native-system/src/web.test.ts`
- `plugins/plugin-native-system/src/web.ts`
- `plugins/plugin-native-talkmode/rollup.config.mjs`
- `plugins/plugin-native-talkmode/src/definitions.ts`
- `plugins/plugin-native-talkmode/src/index.ts`
- `plugins/plugin-native-talkmode/src/web.test.ts`
- `plugins/plugin-native-talkmode/src/web.ts`
- `plugins/plugin-native-websiteblocker/rollup.config.mjs`
- `plugins/plugin-native-websiteblocker/src/backend.test.ts`
- `plugins/plugin-native-websiteblocker/src/definitions.ts`
- `plugins/plugin-native-websiteblocker/src/index.ts`
- `plugins/plugin-native-websiteblocker/src/web.test.ts`
- `plugins/plugin-native-websiteblocker/src/web.ts`
- `plugins/plugin-native-wifi/rollup.config.mjs`
- `plugins/plugin-native-wifi/src/index.ts`
- `plugins/plugin-native-wifi/src/web.test.ts`
- `plugins/plugin-native-wifi/src/web.ts`

## How this was tested
Ran `develop` locally.
