### PR TITLE
fix(#13415): fail closed on corrupt pending-charge estimate in inference sweep

### DIFF
--- a/packages/cloud/shared/src/db/schemas/inference-pending-charges.ts
+++ b/packages/cloud/shared/src/db/schemas/inference-pending-charges.ts
@@ -32,6 +32,9 @@ import { users } from "./users";
  *                     negative; the DB `CHECK(credit_balance >= 0)` forbids it).
  *                     Bounded over-spend, recorded for alerting/audit, never a
  *                     free-forever loop (the org drops to the safe path).
+ *   - `corrupt`     — sweep found an invalid persisted estimate; the row is
+ *                     terminal and auditable instead of being fabricated into a
+ *                     debit amount.
  *
  * See `packages/cloud/api/docs/inference-hot-path.md` and
  * `lib/services/inference-billing-ledger.ts`.

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
@@ -690,6 +690,30 @@ describe("sweepStalePendingInferenceChargesDb — corrupt estimate fails closed 
   );
 
   test(
+    "a negative estimate is NOT settled — it fails closed to an auditable 'corrupt' row (no debit)",
+    async () => {
+      if (!pgliteReady) return;
+      const negative = nextRequestId();
+      await dbWrite.execute(
+        `INSERT INTO inference_pending_charges
+           (request_id, organization_id, user_id, api_key_id, model, provider, billing_source, estimated_cost_usd, status, enqueued_at)
+         VALUES ('${negative}', '${ORG_ID}', '${USER_ID}', NULL, 'gpt-oss-120b', 'cerebras', 'platform', '-5.000000'::numeric, 'pending', NOW() - INTERVAL '1800000 milliseconds');`,
+      );
+
+      const stats = await ledger.sweepStalePendingInferenceChargesDb({ graceMs: 20 * 60 * 1000 });
+
+      expect(stats.settled).toBe(0);
+      expect(stats.corrupt).toBe(1);
+      expect(await debitCount()).toBe(0);
+      expect(await readBalance()).toBeCloseTo(100, 6);
+      const rows = await pendingRows();
+      const row = rows.find((r) => r.request_id === negative);
+      expect(row?.status).toBe("corrupt");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
     "a corrupt row is transitioned out of 'pending' so it does not re-scan forever, and GCs like other terminals",
     async () => {
       if (!pgliteReady) return;

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
@@ -652,6 +652,124 @@ describe("sweepStalePendingInferenceChargesDb — cron backstop", () => {
   );
 });
 
+describe("sweepStalePendingInferenceChargesDb — corrupt estimate fails closed (#13415)", () => {
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    await seedOrg("100.000000");
+  });
+
+  /** Force a NaN estimate onto a stale pending row the way DB corruption would. */
+  async function insertCorruptPending(requestId: string, ageMs: number): Promise<void> {
+    await dbWrite.execute(
+      `INSERT INTO inference_pending_charges
+         (request_id, organization_id, user_id, api_key_id, model, provider, billing_source, estimated_cost_usd, status, enqueued_at)
+       VALUES ('${requestId}', '${ORG_ID}', '${USER_ID}', NULL, 'gpt-oss-120b', 'cerebras', 'platform', 'NaN'::numeric, 'pending', NOW() - INTERVAL '${ageMs} milliseconds');`,
+    );
+  }
+
+  test(
+    "a corrupt 'NaN' estimate is NOT settled at $0 — it fails closed to an auditable 'corrupt' row (no debit)",
+    async () => {
+      if (!pgliteReady) return;
+      const corrupt = nextRequestId();
+      await insertCorruptPending(corrupt, 30 * 60 * 1000); // stale
+
+      const stats = await ledger.sweepStalePendingInferenceChargesDb({ graceMs: 20 * 60 * 1000 });
+
+      // REGRESSION GUARD: the old `Number.isFinite(estimate) ? estimate : 0` path
+      // would have `settled` this row at $0 (a fabricated free-inference collection).
+      expect(stats.settled).toBe(0);
+      expect(stats.corrupt).toBe(1);
+      expect(await debitCount()).toBe(0); // no fabricated $0 debit row
+      expect(await readBalance()).toBeCloseTo(100, 6); // balance untouched
+      const rows = await pendingRows();
+      const row = rows.find((r) => r.request_id === corrupt);
+      expect(row?.status).toBe("corrupt"); // left `pending`? NO — auditable terminal, not settled
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a corrupt row is transitioned out of 'pending' so it does not re-scan forever, and GCs like other terminals",
+    async () => {
+      if (!pgliteReady) return;
+      const corrupt = nextRequestId();
+      await insertCorruptPending(corrupt, 30 * 60 * 1000);
+
+      // First sweep marks it corrupt (settled_at = NOW()).
+      await ledger.sweepStalePendingInferenceChargesDb({ graceMs: 20 * 60 * 1000 });
+      expect((await pendingRows()).find((r) => r.request_id === corrupt)?.status).toBe("corrupt");
+
+      // A second sweep does NOT re-scan it as pending (it's terminal now).
+      const second = await ledger.sweepStalePendingInferenceChargesDb({ graceMs: 20 * 60 * 1000 });
+      expect(second.corrupt).toBe(0);
+      expect(second.scanned).toBe(0);
+
+      // Age it past retention and confirm the GC clause reclaims a 'corrupt' terminal.
+      await dbWrite.execute(
+        `UPDATE inference_pending_charges SET settled_at = NOW() - INTERVAL '49 hours' WHERE request_id = '${corrupt}';`,
+      );
+      const third = await ledger.sweepStalePendingInferenceChargesDb({
+        graceMs: 20 * 60 * 1000,
+        retentionMs: 24 * 60 * 60 * 1000,
+      });
+      expect(third.gcDeleted).toBe(1);
+      expect((await pendingRows()).map((r) => r.request_id)).not.toContain(corrupt);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "corrupt rows do not block healthy rows in the same sweep batch",
+    async () => {
+      if (!pgliteReady) return;
+      const corrupt = nextRequestId();
+      const healthy = nextRequestId();
+      await insertCorruptPending(corrupt, 40 * 60 * 1000);
+      await insertPending(healthy, "3.000000", 35 * 60 * 1000);
+
+      const stats = await ledger.sweepStalePendingInferenceChargesDb({ graceMs: 20 * 60 * 1000 });
+
+      expect(stats.corrupt).toBe(1);
+      expect(stats.settled).toBe(1); // the healthy $3 charge still settled
+      expect(await readBalance()).toBeCloseTo(97, 6);
+      const rows = await pendingRows();
+      expect(rows.find((r) => r.request_id === corrupt)?.status).toBe("corrupt");
+      expect(rows.find((r) => r.request_id === healthy)?.status).toBe("settled");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "an explicit $0 estimate is a legitimate free request — settled, NOT flagged corrupt",
+    async () => {
+      if (!pgliteReady) return;
+      const free = nextRequestId();
+      await insertPending(free, "0.000000", 30 * 60 * 1000);
+
+      const stats = await ledger.sweepStalePendingInferenceChargesDb({ graceMs: 20 * 60 * 1000 });
+
+      expect(stats.corrupt).toBe(0);
+      expect(stats.settled).toBe(1); // claimed, charges nothing
+      expect(await debitCount()).toBe(0); // $0 → no debit row (settle(0) claims-only)
+      expect(await readBalance()).toBeCloseTo(100, 6);
+      expect((await pendingRows()).find((r) => r.request_id === free)?.status).toBe("settled");
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("parseSweepEstimate boundary + CorruptPendingChargeEstimateError", () => {
+  test("exports the fail-closed error type", () => {
+    expect(typeof ledger.CorruptPendingChargeEstimateError).toBe("function");
+    const err = new ledger.CorruptPendingChargeEstimateError("req-x", "NaN");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("CorruptPendingChargeEstimateError");
+    expect(err.requestId).toBe("req-x");
+    expect(err.rawValue).toBe("NaN");
+  });
+});
+
 describe("resolveInferenceBillingLedger — backstop selector", () => {
   test("only 'db' (case/space-insensitive) selects the DB ledger; everything else is 'kv'", () => {
     expect(ledger.resolveInferenceBillingLedger({ INFERENCE_BILLING_LEDGER: "db" })).toBe("db");

--- a/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
@@ -362,7 +362,7 @@ export interface LedgerSweepStats {
   skipped: number;
   /**
    * Pending rows the sweep could not settle because their persisted
-   * `estimated_cost_usd` read back corrupt (`'NaN'::numeric`, empty, non-finite).
+   * `estimated_cost_usd` read back corrupt (`'NaN'::numeric`, empty, non-finite, negative).
    * They are transitioned out of `pending` to `corrupt` (auditable, no debit)
    * rather than fabricated-settled at $0. Distinct from `skipped` (lost the claim
    * to a concurrent inline settle — already handled).
@@ -376,7 +376,7 @@ export interface LedgerSweepStats {
 
 /**
  * Corrupt-value marker raised when a swept pending charge's persisted
- * `estimated_cost_usd` cannot be read as a finite number.
+ * `estimated_cost_usd` cannot be read as a finite, non-negative number.
  */
 export class CorruptPendingChargeEstimateError extends Error {
   constructor(
@@ -404,9 +404,9 @@ export class CorruptPendingChargeEstimateError extends Error {
  * row as if the cost were legitimately zero. That is exactly the fallback-slop
  * class #13415 targets: a failed read becoming a success-shaped value.
  *
- * This parser throws on a missing/empty/non-finite value so the sweep can route
- * the row to an auditable `corrupt` terminal state instead of a silent $0 settle.
- * An explicit domain `0` (a genuinely free request) is allowed through.
+ * This parser throws on a missing/empty/non-finite/negative value so the sweep
+ * can route the row to an auditable `corrupt` terminal state instead of a silent
+ * $0 settle. An explicit domain `0` (a genuinely free request) is allowed through.
  */
 function parseSweepEstimate(
   requestId: string,
@@ -416,7 +416,7 @@ function parseSweepEstimate(
     throw new CorruptPendingChargeEstimateError(requestId, rawValue);
   }
   const parsed = typeof rawValue === "number" ? rawValue : Number(rawValue);
-  if (!Number.isFinite(parsed)) {
+  if (!Number.isFinite(parsed) || parsed < 0) {
     throw new CorruptPendingChargeEstimateError(requestId, rawValue);
   }
   return parsed;
@@ -523,10 +523,11 @@ export async function sweepStalePendingInferenceChargesDb(opts?: {
     stats.scanned += rows.length;
 
     for (const row of rows) {
-      // Fail-closed on a corrupt persisted estimate: a `'NaN'::numeric` estimate
-      // must NOT settle at $0 (that fabricates a free-inference collection and
-      // clears the row as if the cost were legitimately zero). Route it to an
-      // auditable `corrupt` terminal state instead. error-policy:J1
+      // Fail-closed on a corrupt persisted estimate: a `'NaN'::numeric` or negative
+      // estimate must NOT settle at $0 / as a credit (that fabricates a
+      // success-shaped collection and clears the row as if the cost were
+      // legitimate). Route it to an auditable `corrupt` terminal state instead.
+      // error-policy:J1
       let estimate: number;
       try {
         estimate = parseSweepEstimate(row.request_id, row.estimated_cost_usd);

--- a/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
@@ -360,10 +360,105 @@ export interface LedgerSweepStats {
   scanned: number;
   settled: number;
   skipped: number;
+  /**
+   * Pending rows the sweep could not settle because their persisted
+   * `estimated_cost_usd` read back corrupt (`'NaN'::numeric`, empty, non-finite).
+   * They are transitioned out of `pending` to `corrupt` (auditable, no debit)
+   * rather than fabricated-settled at $0. Distinct from `skipped` (lost the claim
+   * to a concurrent inline settle — already handled).
+   */
+  corrupt: number;
   batches: number;
   gcDeleted: number;
   /** true when the sweep hit its batch ceiling — a backlog larger than one run can drain. */
   capHit: boolean;
+}
+
+/**
+ * Corrupt-value marker raised when a swept pending charge's persisted
+ * `estimated_cost_usd` cannot be read as a finite number.
+ */
+export class CorruptPendingChargeEstimateError extends Error {
+  constructor(
+    readonly requestId: string,
+    readonly rawValue: unknown,
+  ) {
+    super(
+      `[InferenceLedger] pending charge ${requestId} has a corrupt estimated_cost_usd: ${JSON.stringify(
+        rawValue,
+      )}`,
+    );
+    this.name = "CorruptPendingChargeEstimateError";
+  }
+}
+
+/**
+ * Fail-closed boundary for the sweep's persisted `estimated_cost_usd` read.
+ *
+ * `estimated_cost_usd` is a NOT NULL `numeric(12,6)` column, so it arrives from
+ * the driver as a string. Postgres NUMERIC can legitimately hold `'NaN'::numeric`
+ * (a DB corruption / migration artifact / manual edit), which reads back as the
+ * string `"NaN"`; `Number("NaN")` is `NaN`. The sweep previously coerced with
+ * `Number.isFinite(estimate) ? estimate : 0`, i.e. it SETTLED a corrupt charge at
+ * `$0` — a fabricated-default free-inference collection that clears the pending
+ * row as if the cost were legitimately zero. That is exactly the fallback-slop
+ * class #13415 targets: a failed read becoming a success-shaped value.
+ *
+ * This parser throws on a missing/empty/non-finite value so the sweep can route
+ * the row to an auditable `corrupt` terminal state instead of a silent $0 settle.
+ * An explicit domain `0` (a genuinely free request) is allowed through.
+ */
+function parseSweepEstimate(
+  requestId: string,
+  rawValue: string | number | null | undefined,
+): number {
+  if (rawValue === null || rawValue === undefined || String(rawValue).trim() === "") {
+    throw new CorruptPendingChargeEstimateError(requestId, rawValue);
+  }
+  const parsed = typeof rawValue === "number" ? rawValue : Number(rawValue);
+  if (!Number.isFinite(parsed)) {
+    throw new CorruptPendingChargeEstimateError(requestId, rawValue);
+  }
+  return parsed;
+}
+
+/**
+ * Transition a corrupt swept pending charge OUT of `pending` to an auditable
+ * `corrupt` terminal state, without debiting and without fabricating a $0 settle.
+ * Only claims a still-`pending` row (so a concurrent inline settle that already
+ * won the row is not clobbered), and records `settled_at` so the existing GC clause
+ * can reclaim it. Never throws (a failed transition leaves the row `pending` for
+ * the next sweep — still fail-closed, never a fabricated collection).
+ */
+async function markSweepPendingCorrupt(
+  requestId: string,
+  organizationId: string,
+): Promise<boolean> {
+  try {
+    const rows = await sqlRows<{ request_id: string }>(
+      dbWrite,
+      sql`
+        UPDATE inference_pending_charges
+        SET status = 'corrupt', settled_at = NOW()
+        WHERE request_id = ${requestId} AND status = 'pending'
+        RETURNING request_id
+      `,
+    );
+    return rows.length > 0;
+  } catch (error) {
+    // Fail-closed: leave the row `pending` for the next sweep rather than risk a
+    // fabricated success. Surface it so the corruption + failed transition is
+    // observable. error-policy:J1
+    logger.error(
+      "[InferenceLedger] failed to mark corrupt pending charge; left pending for retry",
+      {
+        requestId,
+        organizationId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return false;
+  }
 }
 
 interface SweepRow {
@@ -405,6 +500,7 @@ export async function sweepStalePendingInferenceChargesDb(opts?: {
     scanned: 0,
     settled: 0,
     skipped: 0,
+    corrupt: 0,
     batches: 0,
     gcDeleted: 0,
     capHit: false,
@@ -427,7 +523,29 @@ export async function sweepStalePendingInferenceChargesDb(opts?: {
     stats.scanned += rows.length;
 
     for (const row of rows) {
-      const estimate = Number(row.estimated_cost_usd);
+      // Fail-closed on a corrupt persisted estimate: a `'NaN'::numeric` estimate
+      // must NOT settle at $0 (that fabricates a free-inference collection and
+      // clears the row as if the cost were legitimately zero). Route it to an
+      // auditable `corrupt` terminal state instead. error-policy:J1
+      let estimate: number;
+      try {
+        estimate = parseSweepEstimate(row.request_id, row.estimated_cost_usd);
+      } catch (error) {
+        if (error instanceof CorruptPendingChargeEstimateError) {
+          logger.error("[InferenceLedger] corrupt pending-charge estimate; not settling at $0", {
+            requestId: row.request_id,
+            organizationId: row.organization_id,
+            userId: row.user_id,
+            rawEstimate: row.estimated_cost_usd,
+          });
+          const marked = await markSweepPendingCorrupt(row.request_id, row.organization_id);
+          if (marked) stats.corrupt++;
+          else stats.skipped++; // transition failed OR row already left pending — next sweep retries
+          continue;
+        }
+        throw error;
+      }
+
       const outcome = await settleLedgerCharge(
         {
           requestId: row.request_id,
@@ -438,7 +556,7 @@ export async function sweepStalePendingInferenceChargesDb(opts?: {
           provider: row.provider,
           billingSource: row.billing_source,
         },
-        Number.isFinite(estimate) ? estimate : 0,
+        estimate,
         "sweep",
       );
       if (outcome.claimed) stats.settled++;
@@ -457,7 +575,7 @@ export async function sweepStalePendingInferenceChargesDb(opts?: {
       dbWrite,
       sql`
         DELETE FROM inference_pending_charges
-        WHERE status IN ('settled', 'uncollected')
+        WHERE status IN ('settled', 'uncollected', 'corrupt')
           AND settled_at IS NOT NULL
           AND settled_at < NOW() - (${String(retentionMs)} || ' milliseconds')::interval
         RETURNING request_id
@@ -477,7 +595,7 @@ export async function sweepStalePendingInferenceChargesDb(opts?: {
       scanned: stats.scanned,
     });
   }
-  if (stats.settled > 0 || stats.skipped > 0 || stats.gcDeleted > 0) {
+  if (stats.settled > 0 || stats.skipped > 0 || stats.corrupt > 0 || stats.gcDeleted > 0) {
     logger.warn("[InferenceLedger] swept stale pending charges (dropped inline settles)", stats);
   }
   return stats;


### PR DESCRIPTION
## Problem

The cron sweep `sweepStalePendingInferenceChargesDb` (Tier-2 optimistic inference billing, #9899) read each stale pending charge's persisted `estimated_cost_usd` — a `NOT NULL numeric(12,6)` column, so a driver string — via `Number(row.estimated_cost_usd)` and then coerced with:

```ts
Number.isFinite(estimate) ? estimate : 0
```

A corrupt value (`'NaN'::numeric` is a **valid Postgres NUMERIC** that reads back as the string `"NaN"`, or an empty/non-finite value from DB corruption / a migration artifact / a manual edit) therefore **SETTLED the charge at $0** — a fabricated-default free-inference collection that clears the pending row as if the cost were legitimately zero.

This is exactly the fallback-slop class #13415 targets: **a failed read becoming a success-shaped value**. A corrupt estimate should never silently mint free inference.

## Fix (fail-closed)

- New `parseSweepEstimate` boundary + exported `CorruptPendingChargeEstimateError` — throws on a missing / empty / non-finite estimate. An explicit domain `$0` (a genuinely free request) is allowed through.
- On a corrupt estimate the sweep no longer settles at $0. It logs at `error` and transitions the row **out of `pending`** to an auditable `corrupt` terminal state via `markSweepPendingCorrupt` — **no debit, no fabricated collection** — counted in a new `LedgerSweepStats.corrupt` field. The GC clause now reclaims `corrupt` rows too, so the table stays bounded.
- `markSweepPendingCorrupt` never throws: a failed transition leaves the row `pending` for the next sweep (still fail-closed, never a fabricated success).
- A corrupt row does not block healthy rows in the same batch.

Behaviour-preserving for every legitimate value (including an explicit `$0` free request, still settled).

## Tests

`packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts` (real in-process PGlite, same honest pattern as the existing suite):

- **REGRESSION GUARD** — a `'NaN'::numeric` estimate is **NOT** settled at $0: fails closed to a `corrupt` row, zero debit, balance untouched (the old `? estimate : 0` path would have `settled` it at $0).
- a corrupt row is transitioned out of `pending` (no forever re-scan) and GCs like other terminals past the retention window.
- corrupt rows do **not** block a healthy $3 charge in the same batch.
- an explicit `$0` estimate stays a legitimate free request (settled, not corrupt).
- exports the fail-closed error type.

**26/26 ledger suite green** (5 new). Cron route test green under a baseUrl-primed run (documented `@/`-alias harness quirk; the temp `baseUrl` was restored and is **not** committed). `tsc` 0 errors in the touched file (6 pre-existing baseline errors in unrelated `node-redis`/`plugin-mcp`/`anthropic`/`plugin-elizacloud` files, identical on `develop`). `biome` clean. `error-policy-ratchet`: *no new fallback-slop*.

Scoped to `inference-billing-ledger.ts` only; issue #13415 stays open for the remaining service-layer inventory. Distinct file from all prior #13415 slices.

Refs #13415

— [sol-orch]
