### PR TITLE
fix(#14040): merge /api/status readiness into running desktop RPC status

### DIFF
--- a/packages/ui/src/api/client-agent-desktop-status.test.ts
+++ b/packages/ui/src/api/client-agent-desktop-status.test.ts
@@ -72,17 +72,98 @@ describe("ElizaClient desktop status RPC fallback", () => {
     );
   });
 
-  it("keeps using desktop RPC status when it answers", async () => {
+  it("keeps the desktop RPC status verbatim when it already confirms readiness", async () => {
     installDesktopRpc({
       getAgentStatus: vi.fn(async () => ({
         state: "running",
         agentName: "Eliza",
+        canRespond: true,
       })),
     });
     const { client, request } = makeClientWithTransport({});
 
     await expect(client.getStatus()).resolves.toEqual({
       state: "running",
+      agentName: "Eliza",
+      canRespond: true,
+    });
+
+    // RPC already reports first-turn readiness — no HTTP merge needed.
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("merges /api/status readiness into a running desktop RPC snapshot missing canRespond", async () => {
+    // Regression for #14040 sub-defect 1: the electrobun `AgentStatusSnapshot`
+    // has no `canRespond`, so a cloud-routed / model-less agent that is up but
+    // hasn't confirmed first-turn readiness would poll to
+    // `deriveAgentReady=false` FOREVER off the RPC branch. When the process is
+    // running but the snapshot doesn't confirm `canRespond`, fill readiness from
+    // `/api/status` (mirrors the Android lifecycle branch).
+    const getAgentStatus = vi.fn(async () => ({
+      state: "running",
+      agentName: "Eliza",
+    }));
+    installDesktopRpc({ getAgentStatus });
+    const { client, request } = makeClientWithTransport({
+      "/api/status": {
+        state: "running",
+        canRespond: true,
+        model: "eliza-1-2b",
+      },
+    });
+
+    await expect(client.getStatus()).resolves.toEqual({
+      state: "running",
+      agentName: "Eliza",
+      canRespond: true,
+      model: "eliza-1-2b",
+    });
+
+    expect(getAgentStatus).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:31337/api/status",
+      expect.any(Object),
+      { timeoutMs: 10_000 },
+    );
+  });
+
+  it("falls back to the RPC snapshot when the /api/status merge fetch is unreachable", async () => {
+    // The readiness merge must never make a running agent LOOK worse: an
+    // unreachable `/api/status` keeps the RPC snapshot rather than throwing.
+    const getAgentStatus = vi.fn(async () => ({
+      state: "running",
+      agentName: "Eliza",
+    }));
+    installDesktopRpc({ getAgentStatus });
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      throw new Error("network down");
+    });
+    const client = new ElizaClient("http://agent.example:31337", "token");
+    client.setRequestTransport({ request });
+
+    await expect(client.getStatus()).resolves.toEqual({
+      state: "running",
+      agentName: "Eliza",
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not merge /api/status for a non-running desktop RPC snapshot", async () => {
+    // Only a running-but-unconfirmed process needs the readiness backfill; a
+    // starting/error snapshot is authoritative and must not trigger an HTTP
+    // probe (which would 404/throw during boot).
+    const getAgentStatus = vi.fn(async () => ({
+      state: "starting",
+      agentName: "Eliza",
+    }));
+    installDesktopRpc({ getAgentStatus });
+    const { client, request } = makeClientWithTransport({
+      "/api/status": { state: "running", canRespond: true },
+    });
+
+    await expect(client.getStatus()).resolves.toEqual({
+      state: "starting",
       agentName: "Eliza",
     });
 

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -1250,7 +1250,29 @@ ElizaClient.prototype.getStatus = async function (this: ElizaClient) {
       this.getBaseUrl(),
       "getAgentStatus",
     );
-    if (viaRpc) return viaRpc;
+    if (viaRpc) {
+      // The desktop electrobun RPC snapshot (`AgentStatusSnapshot`) carries the
+      // bun *process* lifecycle but NOT the agent's first-turn readiness
+      // (`canRespond`) or loaded `model` — those exist only in the HTTP
+      // `/api/status` the running agent serves. Without them `deriveAgentReady`
+      // (`canRespond ?? (running && model)`) never flips for a cloud-routed /
+      // model-less agent, so the readiness poll wedges on "Waking…" forever.
+      // Mirror the Android lifecycle branch below: when the process is running
+      // but the snapshot doesn't confirm `canRespond`, fill the readiness fields
+      // from `/api/status`. Behavior-preserving when the RPC already reports
+      // ready.
+      if (viaRpc.state === "running" && viaRpc.canRespond !== true) {
+        try {
+          const http = (await this.fetch("/api/status")) as AgentStatus | null;
+          if (http && typeof http === "object") {
+            return { ...viaRpc, ...http };
+          }
+        } catch {
+          /* /api/status unreachable — fall back to the RPC snapshot */
+        }
+      }
+      return viaRpc;
+    }
   } catch {
     /* fall through */
   }


### PR DESCRIPTION
## What

Fixes #14040 sub-defect 1 (launcher readiness poll — desktop RPC branch).

The desktop electrobun RPC snapshot (`AgentStatusSnapshot`) carries the bun *process* lifecycle but **not** the agent's first-turn readiness (`canRespond`) or loaded `model` — those live only in the HTTP `/api/status` the running agent serves. On the desktop RPC branch of `ElizaClient.getStatus()` the snapshot was returned verbatim, so `deriveAgentReady` (`canRespond ?? (running && model)`) never flipped for a cloud-routed / model-less agent and the launcher readiness poll wedged on **"Waking…" forever**.

## Fix

Mirror the existing Android native-lifecycle branch already in this file: when the process is `running` but the snapshot doesn't confirm `canRespond`, fill the readiness fields from `/api/status`.

- Behavior-preserving when the RPC already reports ready (no HTTP probe).
- Unreachable `/api/status` falls back to the RPC snapshot — never makes a running agent look worse.
- No probe for a non-running (starting/error) snapshot — that state is authoritative and `/api/status` would 404 mid-boot.

Scoped to the launcher half, **sub-defect 1 only**; sub-defects 2 (cloud 202 parse) + 3 (90s escalation off raw elapsed) are left for follow-up and the issue stays open. The runtime/cloud half of the sibling issue #14038 is covered separately by #14039 (disjoint `packages/agent/**` + `cloud/shared` surface — zero overlap with this UI change).

## Tests

4 new cases in `client-agent-desktop-status.test.ts`:
- merges `/api/status` readiness into a running RPC snapshot missing `canRespond` (regression)
- keeps the RPC snapshot verbatim when it already confirms `canRespond` (no HTTP probe)
- falls back to the RPC snapshot when the `/api/status` merge fetch is unreachable
- does **not** merge `/api/status` for a non-running snapshot

Evidence:
- vitest: `9/9` green (`src/api/client-agent-desktop-status.test.ts`)
- tsc (`bunx tsgo --noEmit`): **0 errors in touched files** (3 pre-existing baseline errors in `todo.test.tsx` + `startup-phase-poll.test.ts`, byte-identical on `origin/develop`, untouched here)
- biome: clean

— [sol-orch]