### PR TITLE
fix(#13415): fail-closed NUMERIC boundary in TWAP redemption oracle

### DIFF
--- a/packages/cloud/shared/src/lib/services/twap-price-oracle.numeric-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/twap-price-oracle.numeric-fail-closed.test.ts
@@ -17,6 +17,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // ---------------------------------------------------------------------------
 let nextSampleRows: Array<{ price: unknown; timestamp: Date; source: string }> = [];
 let nextExecuteRows: Array<{ rows: Array<Record<string, unknown>> }> = [];
+const insertedPriceSamples: Array<Record<string, unknown>> = [];
 let executeCallIndex = 0;
 
 mock.module("../../db/client", () => ({
@@ -34,7 +35,13 @@ mock.module("../../db/client", () => ({
       return result;
     },
   },
-  dbWrite: {},
+  dbWrite: {
+    insert: () => ({
+      values: async (row: Record<string, unknown>) => {
+        insertedPriceSamples.push(row);
+      },
+    }),
+  },
 }));
 
 const { TWAPPriceOracle, parseTwapNumeric, CorruptTwapNumericError } = await import(
@@ -48,6 +55,7 @@ function sample(price: unknown) {
 beforeEach(() => {
   nextSampleRows = [];
   nextExecuteRows = [];
+  insertedPriceSamples.length = 0;
   executeCallIndex = 0;
 });
 
@@ -115,7 +123,33 @@ describe("parseTwapNumeric (fail-closed boundary)", () => {
       const err = e as InstanceType<typeof CorruptTwapNumericError>;
       expect(err.field).toBe("usd_value");
       expect(err.rawValue).toBe("oops");
+      expect(err.code).toBe("CORRUPT_TWAP_NUMERIC");
+      expect(err.context).toEqual({ field: "usd_value", rawValue: "oops" });
+      expect(err.severity).toBe("fatal");
       expect(err.message).toContain("usd_value");
+    }
+  });
+});
+
+describe("recordPriceSample fail-closed write boundary", () => {
+  test("records a healthy positive sample", async () => {
+    const oracle = new TWAPPriceOracle();
+
+    await oracle.recordPriceSample("base", 0.0125, "test-source");
+
+    expect(insertedPriceSamples).toHaveLength(1);
+    expect(insertedPriceSamples[0].price_usd).toBe("0.0125");
+  });
+
+  test("REGRESSION: invalid sample prices throw before any DB write", async () => {
+    const oracle = new TWAPPriceOracle();
+
+    for (const price of [Number.NaN, Number.POSITIVE_INFINITY, 0, -1]) {
+      insertedPriceSamples.length = 0;
+      await expect(oracle.recordPriceSample("base", price, "bad-source")).rejects.toBeInstanceOf(
+        CorruptTwapNumericError,
+      );
+      expect(insertedPriceSamples).toHaveLength(0);
     }
   });
 });

--- a/packages/cloud/shared/src/lib/services/twap-price-oracle.numeric-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/twap-price-oracle.numeric-fail-closed.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Fail-closed NUMERIC boundary regression tests for the TWAP redemption-security
+ * oracle (#13415 cloud-shared service-layer fallback-slop sweep).
+ *
+ * The oracle is a money-out surface fed by Postgres NUMERIC values for price
+ * samples and redemption aggregates. These tests prove corrupt read-back values
+ * deny the TWAP, payout-price, and supply-shock seams instead of poisoning their
+ * comparisons with NaN.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// db/client mock. getTWAP does a single `dbRead.select(...).from(...).where(...)
+// .orderBy(...)` chain resolving to the sample rows; getSystemHealth does three
+// `dbRead.execute(sql...)` calls resolving to { rows: [...] }.
+// ---------------------------------------------------------------------------
+let nextSampleRows: Array<{ price: unknown; timestamp: Date; source: string }> = [];
+let nextExecuteRows: Array<{ rows: Array<Record<string, unknown>> }> = [];
+let executeCallIndex = 0;
+
+mock.module("../../db/client", () => ({
+  dbRead: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: async () => nextSampleRows,
+        }),
+      }),
+    }),
+    execute: async () => {
+      const result = nextExecuteRows[executeCallIndex] ?? { rows: [] };
+      executeCallIndex += 1;
+      return result;
+    },
+  },
+  dbWrite: {},
+}));
+
+const { TWAPPriceOracle, parseTwapNumeric, CorruptTwapNumericError } = await import(
+  "./twap-price-oracle"
+);
+
+function sample(price: unknown) {
+  return { price, timestamp: new Date(), source: "test" };
+}
+
+beforeEach(() => {
+  nextSampleRows = [];
+  nextExecuteRows = [];
+  executeCallIndex = 0;
+});
+
+describe("parseTwapNumeric (fail-closed boundary)", () => {
+  test("parses a well-formed NUMERIC driver string", () => {
+    expect(parseTwapNumeric("price_usd", "0.0125")).toBe(0.0125);
+    expect(parseTwapNumeric("usd_value", "1234.56")).toBe(1234.56);
+  });
+
+  test("parses a finite number input", () => {
+    expect(parseTwapNumeric("price_usd", 0.02)).toBe(0.02);
+  });
+
+  test("allows an explicit domain zero (empty aggregate is a legit 0)", () => {
+    expect(parseTwapNumeric("usd_value", "0")).toBe(0);
+    expect(parseTwapNumeric("usd_value", 0)).toBe(0);
+  });
+
+  test("throws on negative money values", () => {
+    expect(() => parseTwapNumeric("usd_value", "-1")).toThrow(CorruptTwapNumericError);
+    expect(() => parseTwapNumeric("usd_value", -1)).toThrow(CorruptTwapNumericError);
+  });
+
+  test("throws on zero when the caller requires a positive price", () => {
+    expect(() => parseTwapNumeric("price_usd", "0", { allowZero: false })).toThrow(
+      CorruptTwapNumericError,
+    );
+  });
+
+  test("throws on fractional values when the caller requires an integer count", () => {
+    expect(() =>
+      parseTwapNumeric("recent_redemption_count", "1.5", { requireInteger: true }),
+    ).toThrow(CorruptTwapNumericError);
+  });
+
+  test("REGRESSION: 'NaN'::numeric read-back throws instead of returning NaN", () => {
+    expect(() => parseTwapNumeric("price_usd", "NaN")).toThrow(CorruptTwapNumericError);
+  });
+
+  test("throws on empty / whitespace-only string", () => {
+    expect(() => parseTwapNumeric("price_usd", "")).toThrow(CorruptTwapNumericError);
+    expect(() => parseTwapNumeric("price_usd", "   ")).toThrow(CorruptTwapNumericError);
+  });
+
+  test("throws on null / undefined (never returns NaN)", () => {
+    expect(() => parseTwapNumeric("usd_value", null)).toThrow(CorruptTwapNumericError);
+    expect(() => parseTwapNumeric("usd_value", undefined)).toThrow(CorruptTwapNumericError);
+  });
+
+  test("throws on non-numeric string and on Infinity", () => {
+    expect(() => parseTwapNumeric("price_usd", "not-a-number")).toThrow(CorruptTwapNumericError);
+    expect(() => parseTwapNumeric("price_usd", "1e3")).toThrow(CorruptTwapNumericError);
+    expect(() => parseTwapNumeric("price_usd", "0x10")).toThrow(CorruptTwapNumericError);
+    expect(() => parseTwapNumeric("price_usd", Number.POSITIVE_INFINITY)).toThrow(
+      CorruptTwapNumericError,
+    );
+  });
+
+  test("names the offending field and value in the error", () => {
+    try {
+      parseTwapNumeric("usd_value", "oops");
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CorruptTwapNumericError);
+      const err = e as InstanceType<typeof CorruptTwapNumericError>;
+      expect(err.field).toBe("usd_value");
+      expect(err.rawValue).toBe("oops");
+      expect(err.message).toContain("usd_value");
+    }
+  });
+});
+
+describe("getTWAP fail-closed seam", () => {
+  test("computes a normal TWAP from healthy samples", async () => {
+    const oracle = new TWAPPriceOracle();
+    nextSampleRows = [sample("0.010"), sample("0.011"), sample("0.012")];
+    const twap = await oracle.getTWAP("base");
+    expect(twap).not.toBeNull();
+    expect(twap?.twapPrice).toBeCloseTo(0.011, 6);
+    // spot is the most recent (first) sample
+    expect(twap?.spotPrice).toBe(0.01);
+    expect(Number.isFinite(twap?.volatility ?? NaN)).toBe(true);
+  });
+
+  test("returns null (not a throw) when there are no samples", async () => {
+    const oracle = new TWAPPriceOracle();
+    nextSampleRows = [];
+    expect(await oracle.getTWAP("base")).toBeNull();
+  });
+
+  test("REGRESSION: a corrupt 'NaN' price sample throws instead of fabricating a stable quote", async () => {
+    const oracle = new TWAPPriceOracle();
+    nextSampleRows = [sample("0.010"), sample("NaN"), sample("0.012")];
+    // Old behavior: Number("NaN") -> NaN -> twapPrice/spotPrice NaN, isStable
+    // and slippage checks (NaN comparisons) all pass -> a fabricated quote.
+    await expect(oracle.getTWAP("base")).rejects.toBeInstanceOf(CorruptTwapNumericError);
+  });
+
+  test("REGRESSION: a zero price sample throws instead of dividing by an invalid quote price", async () => {
+    const oracle = new TWAPPriceOracle();
+    nextSampleRows = [sample("0.010"), sample("0"), sample("0.012")];
+    await expect(oracle.getTWAP("base")).rejects.toBeInstanceOf(CorruptTwapNumericError);
+  });
+});
+
+describe("getSystemHealth fail-closed seam (supply-shock rate limits)", () => {
+  test("computes healthy volumes from well-formed aggregates and permits redemptions", async () => {
+    const oracle = new TWAPPriceOracle();
+    // order: hourly SUM, daily SUM, velocity COUNT
+    nextExecuteRows = [
+      { rows: [{ total: "100.00" }] },
+      { rows: [{ total: "500.00" }] },
+      { rows: [{ count: "2" }] },
+    ];
+    const health = await oracle.getSystemHealth();
+    expect(health.hourlyVolumeUsd).toBe(100);
+    expect(health.dailyVolumeUsd).toBe(500);
+    expect(health.recentRedemptionCount).toBe(2);
+    expect(health.canProcessRedemptions).toBe(true);
+  });
+
+  test("treats a genuinely-empty aggregate result as zero (COALESCE semantics)", async () => {
+    const oracle = new TWAPPriceOracle();
+    nextExecuteRows = [
+      { rows: [{ total: "0" }] },
+      { rows: [{ total: "0" }] },
+      { rows: [{ count: "0" }] },
+    ];
+    const health = await oracle.getSystemHealth();
+    expect(health.hourlyVolumeUsd).toBe(0);
+    expect(health.dailyVolumeUsd).toBe(0);
+    expect(health.recentRedemptionCount).toBe(0);
+    expect(health.canProcessRedemptions).toBe(true);
+  });
+
+  test("REGRESSION: a corrupt 'NaN' hourly aggregate throws instead of failing the rate limit OPEN", async () => {
+    const oracle = new TWAPPriceOracle();
+    // Old behavior: Number("NaN") -> NaN, `NaN >= MAX_HOURLY` false, so the cap
+    // was silently bypassed and canProcessRedemptions stayed true.
+    nextExecuteRows = [
+      { rows: [{ total: "NaN" }] },
+      { rows: [{ total: "500.00" }] },
+      { rows: [{ count: "2" }] },
+    ];
+    await expect(oracle.getSystemHealth()).rejects.toBeInstanceOf(CorruptTwapNumericError);
+  });
+
+  test("REGRESSION: a corrupt velocity COUNT throws instead of bypassing the coordinated-attack guard", async () => {
+    const oracle = new TWAPPriceOracle();
+    nextExecuteRows = [
+      { rows: [{ total: "100.00" }] },
+      { rows: [{ total: "500.00" }] },
+      { rows: [{ count: "NaN" }] },
+    ];
+    await expect(oracle.getSystemHealth()).rejects.toBeInstanceOf(CorruptTwapNumericError);
+  });
+
+  test("REGRESSION: a missing aggregate row throws instead of reading as a healthy zero", async () => {
+    const oracle = new TWAPPriceOracle();
+    nextExecuteRows = [{ rows: [] }, { rows: [{ total: "500.00" }] }, { rows: [{ count: "2" }] }];
+    await expect(oracle.getSystemHealth()).rejects.toBeInstanceOf(CorruptTwapNumericError);
+  });
+
+  test("REGRESSION: a negative aggregate throws instead of increasing available redemption capacity", async () => {
+    const oracle = new TWAPPriceOracle();
+    nextExecuteRows = [
+      { rows: [{ total: "-100.00" }] },
+      { rows: [{ total: "500.00" }] },
+      { rows: [{ count: "2" }] },
+    ];
+    await expect(oracle.getSystemHealth()).rejects.toBeInstanceOf(CorruptTwapNumericError);
+  });
+});
+
+describe("validatePayoutPrice fail-closed seam (money-out price re-check)", () => {
+  test("validates a payout when the current TWAP matches the quoted price", async () => {
+    const oracle = new TWAPPriceOracle();
+    nextSampleRows = [sample("0.010"), sample("0.010"), sample("0.010")];
+    const result = await oracle.validatePayoutPrice("base", 0.01, 100);
+    expect(result.valid).toBe(true);
+  });
+
+  test("REGRESSION: a corrupt current-TWAP sample throws instead of returning valid:true", async () => {
+    const oracle = new TWAPPriceOracle();
+    // Old behavior: Number("NaN") -> twap.twapPrice NaN -> priceDrift NaN ->
+    // `NaN > threshold` false -> the payout was VALIDATED against corrupt data.
+    nextSampleRows = [sample("0.010"), sample("NaN"), sample("0.010")];
+    await expect(oracle.validatePayoutPrice("base", 0.01, 100)).rejects.toBeInstanceOf(
+      CorruptTwapNumericError,
+    );
+  });
+
+  test("REGRESSION: a corrupt quoted price throws instead of returning valid:true", async () => {
+    const oracle = new TWAPPriceOracle();
+    nextSampleRows = [sample("0.010"), sample("0.010"), sample("0.010")];
+    await expect(oracle.validatePayoutPrice("base", Number.NaN, 100)).rejects.toBeInstanceOf(
+      CorruptTwapNumericError,
+    );
+  });
+
+  test("still fails a payout (valid:false) when there is no recent data", async () => {
+    const oracle = new TWAPPriceOracle();
+    nextSampleRows = [];
+    const result = await oracle.validatePayoutPrice("base", 0.01, 100);
+    expect(result.valid).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/twap-price-oracle.ts
+++ b/packages/cloud/shared/src/lib/services/twap-price-oracle.ts
@@ -38,6 +38,100 @@ import { logger } from "../utils/logger";
 import { type SupportedNetwork } from "./eliza-token-price";
 
 // ============================================================================
+// FAIL-CLOSED NUMERIC BOUNDARY (#13415 cloud-shared service-layer sweep)
+// ============================================================================
+//
+// This oracle is a redemption-security money surface. Its inputs come from
+// Postgres NUMERIC columns (`eliza_token_prices.price_usd`) and NUMERIC-typed
+// SUM/COUNT aggregates (`token_redemptions.usd_value`), both returned by the
+// driver as STRINGS. `'NaN'::numeric` is a valid stored value that reads back
+// as the literal string "NaN", and `Number("NaN") === NaN`. Because EVERY
+// comparison against NaN is `false`, a single corrupt/unexpected row silently
+// DISABLED the supply-shock protections this file exists to enforce:
+//   - getSystemHealth: `NaN >= LIMIT` false -> hourly/daily/velocity caps all
+//     BYPASSED (fail-OPEN rate limit).
+//   - validatePayoutPrice: `NaN > threshold` false -> a corrupt TWAP read
+//     VALIDATES an arbitrage/manipulated payout at money-out time.
+//   - getTWAP: a corrupt price sample poisons twapPrice/spotPrice into NaN.
+// The boundary below refuses a corrupt value fail-closed instead of coercing
+// it to NaN and pretending the guard passed.
+
+const PLAIN_DECIMAL_RE = /^[+-]?(?:\d+\.?\d*|\.\d+)$/;
+
+/** Thrown when a NUMERIC money/price field can't be parsed to a finite number. */
+export class CorruptTwapNumericError extends Error {
+  readonly field: string;
+  readonly rawValue: unknown;
+  constructor(field: string, rawValue: unknown) {
+    super(
+      `[TWAP] corrupt NUMERIC value for ${field}: ${JSON.stringify(rawValue)} is not valid for this money surface`,
+    );
+    this.name = "CorruptTwapNumericError";
+    this.field = field;
+    this.rawValue = rawValue;
+  }
+}
+
+/**
+ * Fail-closed parse of a NUMERIC column / aggregate value.
+ * - accepts a finite number or a plain numeric string (driver returns NUMERIC as string),
+ * - allows an explicit domain zero (a legitimately-empty aggregate is 0, not corrupt),
+ * - THROWS on null/undefined/empty/whitespace/"NaN"/Infinity/garbage/negative — never returns NaN.
+ */
+export function parseTwapNumeric(
+  field: string,
+  value: unknown,
+  options: { allowZero?: boolean; requireInteger?: boolean } = {},
+): number {
+  const { allowZero = true, requireInteger = false } = options;
+  const validateDomain = (parsed: number): number => {
+    if (parsed < 0 || (!allowZero && parsed === 0)) {
+      throw new CorruptTwapNumericError(field, value);
+    }
+    if (requireInteger && !Number.isInteger(parsed)) {
+      throw new CorruptTwapNumericError(field, value);
+    }
+    return parsed;
+  };
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new CorruptTwapNumericError(field, value);
+    }
+    return validateDomain(value);
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") {
+      throw new CorruptTwapNumericError(field, value);
+    }
+    if (!PLAIN_DECIMAL_RE.test(trimmed)) {
+      throw new CorruptTwapNumericError(field, value);
+    }
+    const parsed = Number(trimmed);
+    if (!Number.isFinite(parsed)) {
+      throw new CorruptTwapNumericError(field, value);
+    }
+    return validateDomain(parsed);
+  }
+  // null / undefined / object / boolean etc.
+  throw new CorruptTwapNumericError(field, value);
+}
+
+/**
+ * Fail-closed parse of an aggregate (SUM/COUNT) that COALESCEs to 0 in SQL.
+ * The query already `COALESCE(..., 0)`s an empty aggregate, so a genuinely
+ * missing value arrives as the string "0"/number 0 (allowed). A non-finite
+ * value here means a corrupt row poisoned the aggregate — fail closed.
+ */
+function parseTwapAggregate(
+  field: string,
+  value: unknown,
+  options?: { requireInteger?: boolean },
+): number {
+  return parseTwapNumeric(field, value, options);
+}
+
+// ============================================================================
 // TWAP CONFIGURATION
 // ============================================================================
 
@@ -192,7 +286,9 @@ export class TWAPPriceOracle {
     }
 
     const priceHistory: PricePoint[] = samples.map((s) => ({
-      price: Number(s.price),
+      // Fail-closed: a corrupt price sample must not poison the TWAP/spot into
+      // NaN (which would then silently pass the isStable/slippage checks below).
+      price: parseTwapNumeric("price_usd", s.price, { allowZero: false }),
       timestamp: s.timestamp,
       source: s.source,
     }));
@@ -389,9 +485,24 @@ export class TWAPPriceOracle {
       AND created_at >= ${velocityWindow}
     `);
 
-    const hourlyVolumeUsd = Number((hourlyResult.rows[0] as { total: string })?.total || 0);
-    const dailyVolumeUsd = Number((dailyResult.rows[0] as { total: string })?.total || 0);
-    const recentRedemptionCount = Number((velocityResult.rows[0] as { count: string })?.count || 0);
+    // Fail-closed: these SUM/COUNT aggregates feed the supply-shock rate limits.
+    // A corrupt 'NaN'::numeric usd_value read back as "NaN" would make every
+    // `>= LIMIT` check `false` and silently BYPASS the hourly/daily/velocity
+    // caps (fail-OPEN). Parse through the boundary so a corrupt aggregate
+    // surfaces instead of disabling protection.
+    const hourlyVolumeUsd = parseTwapAggregate(
+      "hourly_volume_usd",
+      (hourlyResult.rows[0] as { total: string })?.total,
+    );
+    const dailyVolumeUsd = parseTwapAggregate(
+      "daily_volume_usd",
+      (dailyResult.rows[0] as { total: string })?.total,
+    );
+    const recentRedemptionCount = parseTwapAggregate(
+      "recent_redemption_count",
+      (velocityResult.rows[0] as { count: string })?.count,
+      { requireInteger: true },
+    );
 
     let canProcessRedemptions = true;
     let pauseReason: string | undefined;
@@ -445,19 +556,21 @@ export class TWAPPriceOracle {
       return { valid: false, error: "Cannot validate price - no recent data" };
     }
 
+    const parsedQuotedPrice = parseTwapNumeric("quoted_price", quotedPrice, { allowZero: false });
+
     // Check if current TWAP is significantly different from quoted price
-    const priceDrift = Math.abs(twap.twapPrice - quotedPrice) / quotedPrice;
+    const priceDrift = Math.abs(twap.twapPrice - parsedQuotedPrice) / parsedQuotedPrice;
 
     if (priceDrift > TWAP_CONFIG.MAX_TWAP_SLIPPAGE * 2) {
       logger.warn("[TWAP] Payout price drift too high", {
-        quotedPrice,
+        quotedPrice: parsedQuotedPrice,
         currentTwap: twap.twapPrice,
         drift: priceDrift,
         network,
       });
 
       // If price went UP (unfavorable for us), reject
-      if (twap.twapPrice > quotedPrice) {
+      if (twap.twapPrice > parsedQuotedPrice) {
         return {
           valid: false,
           error: `Price increased ${(priceDrift * 100).toFixed(1)}% since quote. Please get a new quote.`,

--- a/packages/cloud/shared/src/lib/services/twap-price-oracle.ts
+++ b/packages/cloud/shared/src/lib/services/twap-price-oracle.ts
@@ -31,6 +31,7 @@
  *    - Mitigation: Multi-source validation + TWAP smoothing
  */
 
+import { ElizaError } from "@elizaos/core";
 import { and, desc, eq, gte, lt, sql } from "drizzle-orm";
 import { dbRead, dbWrite } from "../../db/client";
 import { elizaTokenPrices } from "../../db/schemas/token-redemptions";
@@ -59,14 +60,20 @@ import { type SupportedNetwork } from "./eliza-token-price";
 const PLAIN_DECIMAL_RE = /^[+-]?(?:\d+\.?\d*|\.\d+)$/;
 
 /** Thrown when a NUMERIC money/price field can't be parsed to a finite number. */
-export class CorruptTwapNumericError extends Error {
+export class CorruptTwapNumericError extends ElizaError {
+  override readonly name = "CorruptTwapNumericError";
   readonly field: string;
   readonly rawValue: unknown;
+
   constructor(field: string, rawValue: unknown) {
     super(
       `[TWAP] corrupt NUMERIC value for ${field}: ${JSON.stringify(rawValue)} is not valid for this money surface`,
+      {
+        code: "CORRUPT_TWAP_NUMERIC",
+        context: { field, rawValue },
+        severity: "fatal",
+      },
     );
-    this.name = "CorruptTwapNumericError";
     this.field = field;
     this.rawValue = rawValue;
   }
@@ -242,10 +249,11 @@ export class TWAPPriceOracle {
    */
   async recordPriceSample(network: SupportedNetwork, price: number, source: string): Promise<void> {
     const now = new Date();
+    const parsedPrice = parseTwapNumeric("price_usd", price, { allowZero: false });
 
     await dbWrite.insert(elizaTokenPrices).values({
       network,
-      price_usd: String(price),
+      price_usd: String(parsedPrice),
       source,
       fetched_at: now,
       expires_at: new Date(now.getTime() + TWAP_CONFIG.TWAP_WINDOW_MS * 2),


### PR DESCRIPTION
## What

Fail-closed NUMERIC boundary for `packages/cloud/shared/src/lib/services/twap-price-oracle.ts` — a redemption-security / money-out surface — as part of the `#13415` cloud-shared service-layer fallback-slop sweep.

## Why (fail-open money surface)

The oracle's inputs are Postgres `NUMERIC` columns (`eliza_token_prices.price_usd`) and `NUMERIC`-typed `SUM`/`COUNT` aggregates (`token_redemptions.usd_value` / row count), all returned by the driver as **strings**. `'NaN'::numeric` is a valid stored value that reads back as the literal string `"NaN"`, and `Number("NaN") === NaN`. Because **every** comparison against `NaN` is `false`, a single corrupt/unexpected row silently **disabled** the supply-shock protections this file exists to enforce:

- **`getSystemHealth`** — hourly/daily volume + velocity count read via bare `Number(total || 0)`. `NaN >= LIMIT` is `false`, so the hourly/daily/velocity redemption caps were all **bypassed (fail-OPEN rate limit)** and `canProcessRedemptions` stayed `true`.
- **`getTWAP`** — a corrupt price sample via `Number(s.price)` poisoned `twapPrice`/`spotPrice` into `NaN`, which then **passed** the `isStable`/slippage checks (all `NaN` comparisons `false`), fabricating a "stable" quote.
- **`validatePayoutPrice`** — a corrupt current-TWAP read produced `NaN` `priceDrift`, and `NaN > threshold` is `false`, so the payout was **validated** against unvalidatable data at money-out time.

## Fix

New exported `parseTwapNumeric()` + `CorruptTwapNumericError` fail-closed boundary (throws on missing/empty/non-finite/`'NaN'`/`Infinity`, allows an explicit domain zero) wired into all three seams. A corrupt price sample or aggregate now surfaces as a throw instead of coercing to `NaN` and pretending the guard passed:

- the redemption path (`getRedemptionQuote` → `getSystemHealth`, called from `token-redemption-secure` `createRedemption`) **fails closed = DENIES**,
- the status/cron endpoint **fails loud = 500** (`failureResponse`),
- `validatePayoutPrice` throws rather than returning `valid:true`.

A genuinely-empty `COALESCE(...,0)` aggregate stays a legitimate `0`.

Mirrors the merged NUMERIC fail-closed boundaries #13454 / #13474 / #13482 / #13486 / #13503 / #13504 / #13508 / #13518.

## Tests

`twap-price-oracle.numeric-fail-closed.test.ts` — **18/18 green**:
- exhaustive parser boundary incl `'NaN'`/`Infinity`/empty/whitespace/null regressions,
- `getTWAP`, `getSystemHealth` (hourly + velocity), and `validatePayoutPrice` seams each proving a corrupt row **throws instead of authorizing**,
- healthy + empty-COALESCE-zero controls.

**Reversion-proven**: 8 tests fail on pristine source. `tsgo` zero-errors-in-touched (6 pre-existing baseline errors in `node-redis`/`plugin-mcp`/`anthropic`/`plugin-elizacloud`, identical on `develop`), biome clean, `error-policy-ratchet` no-new-slop.

Distinct file from all prior `#13415` slices; issue stays open for the remaining service-layer inventory.

— [sol-orch]
