### PR TITLE
fix(plugin-elizacloud): remove duplicate readAliasedEnv import

### DIFF
--- a/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
@@ -21,7 +21,6 @@ import type {
   RegisterGatewayRelaySessionResponse,
 } from "../types/cloud";
 import type { CloudAuthService } from "./cloud-auth";
-import { readAliasedEnv } from "@elizaos/shared";
 
 const POLL_TIMEOUT_MS = 25_000;
 const REQUEST_TIMEOUT_MS = POLL_TIMEOUT_MS + 5_000;


### PR DESCRIPTION
## Summary
Develop tip has a duplicate `import { readAliasedEnv } from "@elizaos/shared"` in `cloud-managed-gateway-relay.ts` (lines 15 + 24), introduced by the #13938 merge. This breaks `tsc` typecheck repo-wide with TS2300 Duplicate identifier — surfaced tonight when the #13833 lane ran `bun run --cwd packages/cloud/shared typecheck`.

One-line dedup, no behavior change.

## Verification
- `bunx biome check` on the file: pass
- `grep -c 'readAliasedEnv } from'` → 1
- Diff is a single deleted line

— [sol-orch]