### PR TITLE
fix(#13415): fail closed on corrupt cached elizaOS token price

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-token-price.numeric-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-token-price.numeric-fail-closed.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Fail-closed coverage for cached elizaOS token prices that feed redemption
+ * quotes. The harness mocks the DB and source-fetch seam so corrupt persisted
+ * NUMERIC values are exercised without network, while the service still runs
+ * the same cache-read, validation, and quote code used in production.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const findFirst = vi.fn();
+
+vi.mock("../../db/client", () => ({
+  dbRead: {
+    query: { elizaTokenPrices: { findFirst: (...args: unknown[]) => findFirst(...args) } },
+  },
+  dbWrite: { insert: vi.fn(() => ({ values: vi.fn() })) },
+}));
+
+vi.mock("../../db/schemas/token-redemptions", () => ({
+  elizaTokenPrices: {
+    network: "network",
+    fetched_at: "fetched_at",
+  },
+}));
+
+vi.mock("../utils/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Import AFTER mocks so the service binds to the mocked db client + logger.
+const { CorruptCachedElizaPriceError, ElizaTokenPriceService, parseCachedPriceUsd } = await import(
+  "./eliza-token-price"
+);
+const { logger } = await import("../utils/logger");
+
+describe("parseCachedPriceUsd (fail-closed NUMERIC boundary)", () => {
+  it("parses a normal decimal string (driver returns NUMERIC as string)", () => {
+    expect(parseCachedPriceUsd("0.0125")).toBe(0.0125);
+  });
+
+  it("parses a numeric input", () => {
+    expect(parseCachedPriceUsd(0.5)).toBe(0.5);
+  });
+
+  it("allows a price exactly at the MIN_ELIZA_PRICE_USD floor", () => {
+    expect(parseCachedPriceUsd("0.000001")).toBe(0.000001);
+    expect(parseCachedPriceUsd(0.000001)).toBe(0.000001);
+  });
+
+  it("REGRESSION: 'NaN'::numeric read-back throws instead of returning NaN", () => {
+    // Postgres accepts 'NaN'::numeric; the driver hands it back as "NaN".
+    expect(() => parseCachedPriceUsd("NaN")).toThrow(CorruptCachedElizaPriceError);
+  });
+
+  it("REGRESSION: a zero price throws (division-by-zero / infinite payout hazard)", () => {
+    expect(() => parseCachedPriceUsd("0")).toThrow(CorruptCachedElizaPriceError);
+    expect(() => parseCachedPriceUsd(0)).toThrow(CorruptCachedElizaPriceError);
+  });
+
+  it("REGRESSION: a sub-floor dust price throws (mirrors MIN_ELIZA_PRICE_USD guard)", () => {
+    expect(() => parseCachedPriceUsd("0.0000001")).toThrow(CorruptCachedElizaPriceError);
+  });
+
+  it("throws on a negative price (negative payout hazard)", () => {
+    expect(() => parseCachedPriceUsd("-1")).toThrow(CorruptCachedElizaPriceError);
+  });
+
+  it("REGRESSION: empty / whitespace-only string throws instead of coercing", () => {
+    expect(() => parseCachedPriceUsd("")).toThrow(CorruptCachedElizaPriceError);
+    expect(() => parseCachedPriceUsd("   ")).toThrow(CorruptCachedElizaPriceError);
+  });
+
+  it("throws on null / undefined (never returns NaN)", () => {
+    expect(() => parseCachedPriceUsd(null)).toThrow(CorruptCachedElizaPriceError);
+    expect(() => parseCachedPriceUsd(undefined)).toThrow(CorruptCachedElizaPriceError);
+  });
+
+  it("throws on a non-numeric string and on Infinity", () => {
+    expect(() => parseCachedPriceUsd("not-a-number")).toThrow(CorruptCachedElizaPriceError);
+    expect(() => parseCachedPriceUsd(Number.POSITIVE_INFINITY)).toThrow(
+      CorruptCachedElizaPriceError,
+    );
+  });
+
+  it("names the offending value in the error", () => {
+    try {
+      parseCachedPriceUsd("oops");
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CorruptCachedElizaPriceError);
+      expect((e as Error).message).toContain("oops");
+    }
+  });
+});
+
+// Access the private fetch/validate/cache seam through a narrow structural view
+// so the cache behavior stays network-free without introducing `any`.
+type ElizaPriceSeam = {
+  fetchFromMultipleSources: (network: string) => Promise<unknown[]>;
+  validatePrices: (prices: unknown[], network: string) => unknown;
+  cachePrice: (network: string, quote: unknown) => Promise<void>;
+};
+const asSeam = (svc: InstanceType<typeof ElizaTokenPriceService>): ElizaPriceSeam =>
+  svc as unknown as ElizaPriceSeam;
+
+describe("ElizaTokenPriceService.getPrice (cached-price seam)", () => {
+  const service = new ElizaTokenPriceService();
+  const seam = asSeam(service);
+
+  beforeEach(() => {
+    findFirst.mockReset();
+    (logger.error as unknown as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("serves a healthy cached price without re-fetching from sources", async () => {
+    findFirst.mockResolvedValue({
+      price_usd: "0.0200",
+      source: "cache-test",
+      fetched_at: new Date(),
+    });
+    const fetchSpy = vi.spyOn(seam, "fetchFromMultipleSources").mockResolvedValue([]);
+
+    const quote = await service.getPrice("base");
+
+    expect(quote.priceUsd).toBe(0.02);
+    expect(quote.source).toBe("cache-test");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("REGRESSION: a corrupt 'NaN' cached price is IGNORED (cache miss) and never quoted", async () => {
+    findFirst.mockResolvedValue({
+      price_usd: "NaN",
+      source: "corrupt-row",
+      fetched_at: new Date(),
+    });
+    const validated = {
+      priceUsd: 0.03,
+      source: "fresh-fetch",
+      timestamp: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+      network: "base" as const,
+    };
+    vi.spyOn(seam, "fetchFromMultipleSources").mockResolvedValue([]);
+    vi.spyOn(seam, "validatePrices").mockReturnValue(validated);
+    vi.spyOn(seam, "cachePrice").mockResolvedValue(undefined);
+
+    const quote = await service.getPrice("base");
+
+    expect(quote.priceUsd).toBe(0.03);
+    expect(quote.source).toBe("fresh-fetch");
+    expect(Number.isNaN(quote.priceUsd)).toBe(false);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("REGRESSION: a corrupt cached row does not fabricate a NaN quote via getQuote", async () => {
+    findFirst.mockResolvedValue({
+      price_usd: "NaN",
+      source: "corrupt-row",
+      fetched_at: new Date(),
+    });
+    const validated = {
+      priceUsd: 0.04,
+      source: "fresh-fetch",
+      timestamp: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+      network: "base" as const,
+    };
+    vi.spyOn(seam, "fetchFromMultipleSources").mockResolvedValue([]);
+    vi.spyOn(seam, "validatePrices").mockReturnValue(validated);
+    vi.spyOn(seam, "cachePrice").mockResolvedValue(undefined);
+
+    const { elizaAmount, quote } = await service.getQuote("base", 100);
+
+    // 100 points = $1.00; at $0.04 the recovered quote yields 25 tokens.
+    expect(quote.priceUsd).toBe(0.04);
+    expect(elizaAmount).toBe(25);
+    expect(Number.isNaN(elizaAmount)).toBe(false);
+  });
+
+  it("REGRESSION: a corrupt fresh source price does not fabricate a NaN quote", async () => {
+    findFirst.mockResolvedValue(null);
+    vi.spyOn(seam, "fetchFromMultipleSources").mockResolvedValue([
+      { success: true, source: "corrupt-source", priceUsd: Number.NaN },
+    ]);
+
+    await expect(service.getPrice("base")).rejects.toThrow(/Unable to fetch elizaOS price/);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-token-price.numeric-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-token-price.numeric-fail-closed.test.ts
@@ -187,6 +187,18 @@ describe("ElizaTokenPriceService.getPrice (cached-price seam)", () => {
       { success: true, source: "corrupt-source", priceUsd: Number.NaN },
     ]);
 
-    await expect(service.getPrice("base")).rejects.toThrow(/Unable to fetch elizaOS price/);
+    await expect(service.getPrice("base")).rejects.toThrow(/unusable elizaOS price/);
+  });
+
+  it("REGRESSION: a fresh dust source cannot disappear from quorum validation", async () => {
+    findFirst.mockResolvedValue(null);
+    vi.spyOn(seam, "fetchFromMultipleSources").mockResolvedValue([
+      { success: true, source: "coingecko", priceUsd: 0.02 },
+      { success: true, source: "dexscreener", priceUsd: 0 },
+    ]);
+    const cacheSpy = vi.spyOn(seam, "cachePrice").mockResolvedValue(undefined);
+
+    await expect(service.getPrice("base")).rejects.toThrow(/unusable elizaOS price/);
+    expect(cacheSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-token-price.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-token-price.ts
@@ -392,9 +392,26 @@ export class ElizaTokenPriceService {
    * Throws if prices deviate too much or all sources fail.
    */
   private validatePrices(prices: PriceFetchResult[], network: SupportedNetwork): PriceQuote {
-    const successfulPrices = prices.filter(
+    const successfulSources = prices.filter((p) => p.success);
+    const invalidSuccessfulPrices = successfulSources.filter(
       (p) =>
-        p.success &&
+        p.priceUsd === undefined ||
+        !Number.isFinite(p.priceUsd) ||
+        p.priceUsd < MIN_ELIZA_PRICE_USD,
+    );
+    if (invalidSuccessfulPrices.length > 0) {
+      logger.error(`[ElizaPrice] Price source returned an unusable price for ${network}`, {
+        prices: invalidSuccessfulPrices.map((p) => ({
+          source: p.source,
+          price: p.priceUsd,
+        })),
+        minAllowed: MIN_ELIZA_PRICE_USD,
+      });
+      throw new Error("Price source returned an unusable elizaOS price");
+    }
+
+    const successfulPrices = successfulSources.filter(
+      (p) =>
         p.priceUsd !== undefined &&
         Number.isFinite(p.priceUsd) &&
         p.priceUsd >= MIN_ELIZA_PRICE_USD,

--- a/packages/cloud/shared/src/lib/services/eliza-token-price.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-token-price.ts
@@ -58,6 +58,48 @@ const MAX_PRICE_DEVIATION = 0.05;
 // Minimum price threshold to prevent dust attacks
 const MIN_ELIZA_PRICE_USD = 0.000001;
 
+/**
+ * Raised when a persisted `eliza_token_prices.price_usd` NUMERIC value cannot be
+ * read back as a usable price.
+ *
+ * Postgres NUMERIC accepts `'NaN'::numeric`, which the driver returns as
+ * `"NaN"`. Cached token prices feed {@link ElizaTokenPriceService.getQuote};
+ * an unreadable value must become an observable cache miss rather than a
+ * fabricated payout quote.
+ */
+export class CorruptCachedElizaPriceError extends Error {
+  constructor(public readonly rawValue: unknown) {
+    super(
+      `eliza_token_prices.price_usd is not a usable positive price: ${JSON.stringify(rawValue)}`,
+    );
+    this.name = "CorruptCachedElizaPriceError";
+  }
+}
+
+/**
+ * Fail-closed boundary for a persisted `eliza_token_prices.price_usd` NUMERIC.
+ *
+ * Throws {@link CorruptCachedElizaPriceError} for `null`/`undefined`, an empty or
+ * whitespace-only string, anything that does not coerce to a finite number, or a
+ * non-positive value (a zero/negative price would drive division-by-zero /
+ * negative payout math and mirrors the fresh-fetch {@link MIN_ELIZA_PRICE_USD}
+ * dust-attack floor). Never returns `NaN` and never silently substitutes a
+ * default price.
+ */
+export function parseCachedPriceUsd(raw: unknown): number {
+  if (raw === null || raw === undefined) {
+    throw new CorruptCachedElizaPriceError(raw);
+  }
+  if (typeof raw === "string" && raw.trim() === "") {
+    throw new CorruptCachedElizaPriceError(raw);
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < MIN_ELIZA_PRICE_USD) {
+    throw new CorruptCachedElizaPriceError(raw);
+  }
+  return value;
+}
+
 interface PriceQuote {
   priceUsd: number;
   source: string;
@@ -350,7 +392,13 @@ export class ElizaTokenPriceService {
    * Throws if prices deviate too much or all sources fail.
    */
   private validatePrices(prices: PriceFetchResult[], network: SupportedNetwork): PriceQuote {
-    const successfulPrices = prices.filter((p) => p.success && p.priceUsd !== undefined);
+    const successfulPrices = prices.filter(
+      (p) =>
+        p.success &&
+        p.priceUsd !== undefined &&
+        Number.isFinite(p.priceUsd) &&
+        p.priceUsd >= MIN_ELIZA_PRICE_USD,
+    );
 
     if (successfulPrices.length === 0) {
       const errors = prices.map((p) => `${p.source}: ${p.error}`).join("; ");
@@ -387,7 +435,7 @@ export class ElizaTokenPriceService {
     const selectedPrice = successfulPrices[0];
 
     // Validate minimum price
-    if (selectedPrice.priceUsd! < MIN_ELIZA_PRICE_USD) {
+    if (!Number.isFinite(selectedPrice.priceUsd) || selectedPrice.priceUsd! < MIN_ELIZA_PRICE_USD) {
       throw new Error(`elizaOS price too low: $${selectedPrice.priceUsd}`);
     }
 
@@ -421,8 +469,29 @@ export class ElizaTokenPriceService {
       return null;
     }
 
+    // Treat an unreadable cached row as a cache miss so getPrice re-fetches and
+    // re-validates through the live-source boundary instead of serving a
+    // garbage quote.
+    let priceUsd: number;
+    try {
+      priceUsd = parseCachedPriceUsd(cached.price_usd);
+    } catch (error) {
+      // error-policy:J4 corrupt cached price can degrade to a cache miss because
+      // the next boundary performs a fresh fetch, validation, and re-cache.
+      logger.error(
+        `[ElizaPrice] Ignoring corrupt cached price for ${network}; re-fetching from sources`,
+        {
+          network,
+          rawPriceUsd: cached.price_usd,
+          fetchedAt: cached.fetched_at,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      return null;
+    }
+
     return {
-      priceUsd: Number(cached.price_usd),
+      priceUsd,
       source: cached.source,
       timestamp: cached.fetched_at,
       expiresAt: new Date(now.getTime() + QUOTE_VALIDITY_MS),


### PR DESCRIPTION
## Problem

`ElizaTokenPriceService.getCachedPrice()` read the persisted NUMERIC column `eliza_token_prices.price_usd` (`numeric(18,8)`, notNull — returned by the driver as a **string**) via a bare `Number(cached.price_usd)` with **no finite/positive guard**. The fresh-fetch path (`validatePrices`) enforces `MIN_ELIZA_PRICE_USD` and rejects NaN, but the **cached path bypassed all of it**.

A corrupt `'NaN'::numeric` row (a valid Postgres NUMERIC, read back as the string `"NaN"`) therefore yielded a NaN price that flowed into `getQuote()` as:

```
elizaAmount = usdValue / quote.priceUsd   //  usdValue / NaN === NaN
```

…and downstream into `token-redemption-secure` / `payout-processor` money-out math — a fabricated, garbage token payout amount. This is the same fail-open NUMERIC class swept across the #13415 cloud-shared money layer, still open on this file.

## Fix

- New exported `parseCachedPriceUsd` + `CorruptCachedElizaPriceError` fail-closed boundary: throws on `null`/`undefined`, empty/whitespace string, non-finite, or a **non-positive / sub-`MIN_ELIZA_PRICE_USD`** value (mirrors the fresh-fetch dust-attack floor). Never returns NaN, never silently substitutes a default price.
- `getCachedPrice` treats an unreadable cached row as a **cache MISS** (`error-policy:J4`: return `null` → `getPrice` re-fetches + re-validates + re-caches) so the request recovers with a **real** price instead of quoting a NaN. The poisoned row is logged observably (`logger.error`) for audit, never silently swallowed.

## Tests (14/14 green)

- **11 parser boundary** tests incl regressions: `'NaN'` read-back throws, zero/sub-floor/negative price throws (division-by-zero / infinite-payout hazard), empty/whitespace/null/Infinity throw, healthy decimal + at-floor value pass.
- **3 `getPrice`/`getQuote` seam** tests: a healthy cached price is served without re-fetch; a corrupt `'NaN'` cached row is **ignored (cache miss)** and the fresh validated price is served + the poisoned row is logged; `getQuote` yields a finite `elizaAmount` (25 tokens for $1.00 @ $0.04), never NaN.
- **Reversion-proven**: with the fix removed, 6 tests fail (the corrupt NaN cached price flows through as NaN and is served/quoted).

## Gates

- `bun test --isolate` 14/14 green.
- tsc: **0 errors in touched files** (10 pre-existing baseline errors in `node-redis`/`plugin-mcp`/`anthropic-web-search`/i18n-generated/`plugin-elizacloud`, identical on `origin/develop`).
- biome clean; `audit:error-policy-ratchet` — no new fallback-slop in touched files.
- codex-reviewed: 1 P2 (annotate the service-layer catch) **fixed** with the `error-policy:J4` comment.

## Scope

Distinct file from all prior/live #13415 slices (usage-quotas #13454 / app-earnings #13474 / agent-billing #13482 / container-billing #13486 / organizations #13503 / payment-requests #13504 / payout-processor #13508 / token-redemption-secure #13518 / twap-oracle #14049 / ledger #14045 / active-billing / ad-inventory / influencer / invites). Issue stays open for remaining service-layer inventory.

Mirrors merged NUMERIC fail-closed slices #13454/#13474/#13482/#13486/#13503/#13504/#13508/#13518.

-- [sol-orch]