### PR TITLE
fix(#13415): fail closed on corrupt user-MCP billing NUMERIC reads

### DIFF
--- a/packages/cloud/shared/src/lib/services/user-mcps-recordusage-numeric.test.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps-recordusage-numeric.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Money-path NUMERIC fail-closed pins for `userMcpsService.recordUsage` /
+ * `recordUsageWithoutDeduction` (#13415).
+ *
+ * Postgres NUMERIC columns are driver strings, and `'NaN'::numeric` reads back
+ * as the literal `"NaN"`. Before this fix `recordUsage` read the MCP price/share
+ * columns via bare `Number(...)`, so a corrupt row produced `creditsCharged =
+ * NaN`. The consumer-charge gate `totalCreditsToDeduct > 0` is FALSE for `NaN`,
+ * so the tool call ran for FREE while the creator/affiliate earnings, also
+ * `NaN`, were written to the ledger (and skipped their own `> 0` gates). This
+ * suite proves the read now fails closed: a corrupt price/share/markup row
+ * THROWS `CorruptMcpBillingNumberError` before ANY charge/credit/earnings
+ * side-effect, and a healthy row still charges + distributes normally.
+ *
+ * The DB repository + money services are mocked with spies; the tests assert on
+ * whether those side-effects were invoked, so a regression (bare `Number` back)
+ * is observable, not tautological.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { UserMcp } from "../../db/schemas/user-mcps";
+
+const ORG = "11111111-1111-1111-1111-111111111111";
+const CONSUMER_ORG = "22222222-2222-2222-2222-222222222222";
+const CREATOR_USER = "33333333-3333-3333-3333-333333333333";
+const BUYER_USER = "44444444-4444-4444-4444-444444444444";
+const AFFILIATE_USER = "55555555-5555-5555-5555-555555555555";
+const AFFILIATE_CODE = "66666666-6666-6666-6666-666666666666";
+
+function nowDate(): Date {
+  return new Date("2026-07-05T00:00:00.000Z");
+}
+
+// Side-effect spies, reset before each test.
+const deductCalls: Array<{ amount: number }> = [];
+const addCreditsCalls: Array<{ amount: number }> = [];
+const addEarningsCalls: Array<{ amount: number; source: string }> = [];
+const usageCreateCalls: Array<Record<string, unknown>> = [];
+const mcpCreateCalls: Array<Record<string, unknown>> = [];
+const mcpUpdateCalls: Array<Record<string, unknown>> = [];
+let referrer: { user_id: string; id: string; markup_percent: string } | null = null;
+
+/** A single stored MCP row; overrides mutate the NUMERIC money columns. */
+let mcpRow: UserMcp;
+
+function makeRow(overrides: Partial<UserMcp> = {}): UserMcp {
+  return {
+    id: "mcp-1",
+    name: "Weather Pro",
+    slug: "weather-pro",
+    description: "",
+    version: "1.0.0",
+    organization_id: ORG,
+    created_by_user_id: CREATOR_USER,
+    endpoint_type: "third-party",
+    container_id: null,
+    external_endpoint: "https://mcp.example.com/weather",
+    endpoint_path: "/mcp",
+    transport_type: "streamable-http",
+    tools: [{ name: "get_weather", description: "Get weather" }],
+    category: "utilities",
+    tags: [],
+    icon: "puzzle",
+    color: "#6366F1",
+    pricing_type: "credits",
+    credits_per_request: "1.0000",
+    x402_price_usd: "0.000100",
+    x402_enabled: false,
+    creator_share_percentage: "80.00",
+    platform_share_percentage: "20.00",
+    status: "live",
+    is_public: true,
+    is_verified: false,
+    documentation_url: null,
+    source_code_url: null,
+    support_email: null,
+    verified_by: null,
+    metadata: {},
+    erc8004_registered: false,
+    erc8004_network: null,
+    erc8004_agent_id: null,
+    erc8004_agent_uri: null,
+    erc8004_tx_hash: null,
+    erc8004_registered_at: null,
+    created_at: nowDate(),
+    updated_at: nowDate(),
+    last_used_at: null,
+    published_at: null,
+    ...overrides,
+  } as unknown as UserMcp;
+}
+
+mock.module("../../db/repositories", () => ({
+  userMcpsRepository: {
+    async getBySlug(): Promise<UserMcp | null> {
+      return null;
+    },
+    async getById(): Promise<UserMcp | null> {
+      return mcpRow ?? null;
+    },
+    async create(row: Record<string, unknown>) {
+      mcpCreateCalls.push(row);
+      return makeRow(row as Partial<UserMcp>);
+    },
+    async update(_id: string, row: Record<string, unknown>) {
+      mcpUpdateCalls.push(row);
+      return makeRow(row as Partial<UserMcp>);
+    },
+    async incrementUsage(): Promise<void> {},
+  },
+  mcpUsageRepository: {
+    async create(row: Record<string, unknown>) {
+      usageCreateCalls.push(row);
+      return { id: "usage-1" };
+    },
+  },
+}));
+
+mock.module("./credits", () => ({
+  creditsService: {
+    async deductCredits(params: { amount: number }) {
+      deductCalls.push({ amount: params.amount });
+      return { success: true };
+    },
+    async addCredits(params: { amount: number }) {
+      addCreditsCalls.push({ amount: params.amount });
+      return { success: true };
+    },
+  },
+}));
+
+mock.module("./redeemable-earnings", () => ({
+  redeemableEarningsService: {
+    async addEarnings(params: { amount: number; source: string }) {
+      addEarningsCalls.push({ amount: params.amount, source: params.source });
+      return { success: true };
+    },
+  },
+}));
+
+mock.module("./affiliates", () => ({
+  affiliatesService: {
+    async getReferrer() {
+      return referrer;
+    },
+  },
+}));
+
+mock.module("./containers", () => ({
+  containersService: {
+    async getById(_id: string, organizationId: string) {
+      return { id: "container-1", organization_id: organizationId };
+    },
+  },
+}));
+
+mock.module("../cache/client", () => ({
+  cache: {
+    async get() {
+      return null;
+    },
+    async set() {},
+    async del() {},
+  },
+}));
+
+mock.module("../security/outbound-url", () => ({
+  assertSafeOutboundUrl: async (raw: string) => new URL(raw),
+  assertSafeOutboundUrlSync: (raw: string) => new URL(raw),
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { info() {}, warn() {}, error() {}, debug() {} },
+}));
+
+const { userMcpsService, CorruptMcpBillingNumberError } = await import("./user-mcps");
+
+function resetSpies(): void {
+  deductCalls.length = 0;
+  addCreditsCalls.length = 0;
+  addEarningsCalls.length = 0;
+  usageCreateCalls.length = 0;
+  mcpCreateCalls.length = 0;
+  mcpUpdateCalls.length = 0;
+  referrer = null;
+}
+
+beforeEach(() => {
+  resetSpies();
+  mcpRow = makeRow();
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("recordUsage, NUMERIC money reads fail closed (#13415)", () => {
+  test("healthy row charges the consumer and distributes earnings", async () => {
+    const result = await userMcpsService.recordUsage({
+      mcpId: "mcp-1",
+      organizationId: CONSUMER_ORG,
+      toolName: "get_weather",
+      paymentType: "credits",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.creditsCharged).toBe(1);
+    // 1 credit charged, no affiliate => deduct 1/100 dollars.
+    expect(deductCalls).toHaveLength(1);
+    expect(deductCalls[0].amount).toBeCloseTo(0.01, 6);
+    // creator gets 80% of 1 credit => 0.8 credit => addCredits + addEarnings.
+    expect(addCreditsCalls).toHaveLength(1);
+    expect(addCreditsCalls[0].amount).toBeCloseTo(0.008, 6);
+    // usage row records real numeric strings, never "NaN".
+    expect(usageCreateCalls).toHaveLength(1);
+    expect(usageCreateCalls[0].credits_charged).toBe("1");
+    expect(usageCreateCalls[0].creator_earnings).not.toContain("NaN");
+  });
+
+  test("REGRESSION: corrupt credits_per_request THROWS before charging (was free MCP call)", async () => {
+    mcpRow = makeRow({ credits_per_request: "NaN" as unknown as string });
+
+    await expect(
+      userMcpsService.recordUsage({
+        mcpId: "mcp-1",
+        organizationId: CONSUMER_ORG,
+        toolName: "get_weather",
+        paymentType: "credits",
+      }),
+    ).rejects.toBeInstanceOf(CorruptMcpBillingNumberError);
+
+    // NOTHING happened: no charge, no creator credit, no earnings, no ledger row.
+    expect(deductCalls).toHaveLength(0);
+    expect(addCreditsCalls).toHaveLength(0);
+    expect(addEarningsCalls).toHaveLength(0);
+    expect(usageCreateCalls).toHaveLength(0);
+  });
+
+  test("REGRESSION: negative credits_per_request THROWS before charging", async () => {
+    mcpRow = makeRow({ credits_per_request: "-1.0000" as unknown as string });
+
+    await expect(
+      userMcpsService.recordUsage({
+        mcpId: "mcp-1",
+        organizationId: CONSUMER_ORG,
+        toolName: "get_weather",
+        paymentType: "credits",
+      }),
+    ).rejects.toBeInstanceOf(CorruptMcpBillingNumberError);
+
+    expect(deductCalls).toHaveLength(0);
+    expect(addCreditsCalls).toHaveLength(0);
+    expect(addEarningsCalls).toHaveLength(0);
+    expect(usageCreateCalls).toHaveLength(0);
+  });
+
+  test("REGRESSION: corrupt x402_price_usd THROWS on the x402 path", async () => {
+    mcpRow = makeRow({ x402_price_usd: "NaN" as unknown as string });
+
+    await expect(
+      userMcpsService.recordUsage({
+        mcpId: "mcp-1",
+        organizationId: CONSUMER_ORG,
+        toolName: "get_weather",
+        paymentType: "x402",
+      }),
+    ).rejects.toBeInstanceOf(CorruptMcpBillingNumberError);
+    expect(usageCreateCalls).toHaveLength(0);
+  });
+
+  test("REGRESSION: negative x402_price_usd THROWS on the x402 path", async () => {
+    mcpRow = makeRow({ x402_price_usd: "-0.000100" as unknown as string });
+
+    await expect(
+      userMcpsService.recordUsage({
+        mcpId: "mcp-1",
+        organizationId: CONSUMER_ORG,
+        toolName: "get_weather",
+        paymentType: "x402",
+      }),
+    ).rejects.toBeInstanceOf(CorruptMcpBillingNumberError);
+    expect(usageCreateCalls).toHaveLength(0);
+  });
+
+  test("REGRESSION: corrupt creator_share_percentage THROWS (was NaN earnings in ledger)", async () => {
+    mcpRow = makeRow({ creator_share_percentage: "NaN" as unknown as string });
+
+    await expect(
+      userMcpsService.recordUsage({
+        mcpId: "mcp-1",
+        organizationId: CONSUMER_ORG,
+        toolName: "get_weather",
+        paymentType: "credits",
+      }),
+    ).rejects.toBeInstanceOf(CorruptMcpBillingNumberError);
+    // Fails at share-parse, still before any side-effect.
+    expect(deductCalls).toHaveLength(0);
+    expect(addCreditsCalls).toHaveLength(0);
+    expect(usageCreateCalls).toHaveLength(0);
+  });
+
+  test("REGRESSION: out-of-range creator_share_percentage THROWS", async () => {
+    mcpRow = makeRow({ creator_share_percentage: "120.00" as unknown as string });
+
+    await expect(
+      userMcpsService.recordUsage({
+        mcpId: "mcp-1",
+        organizationId: CONSUMER_ORG,
+        toolName: "get_weather",
+        paymentType: "credits",
+      }),
+    ).rejects.toBeInstanceOf(CorruptMcpBillingNumberError);
+    expect(deductCalls).toHaveLength(0);
+    expect(usageCreateCalls).toHaveLength(0);
+  });
+
+  test("REGRESSION: corrupt affiliate markup_percent THROWS (was NaN affiliate fee)", async () => {
+    referrer = { user_id: AFFILIATE_USER, id: AFFILIATE_CODE, markup_percent: "NaN" };
+
+    await expect(
+      userMcpsService.recordUsage({
+        mcpId: "mcp-1",
+        organizationId: CONSUMER_ORG,
+        userId: BUYER_USER,
+        toolName: "get_weather",
+        paymentType: "credits",
+      }),
+    ).rejects.toBeInstanceOf(CorruptMcpBillingNumberError);
+    expect(deductCalls).toHaveLength(0);
+    expect(usageCreateCalls).toHaveLength(0);
+  });
+
+  test("REGRESSION: negative affiliate markup_percent THROWS before charging", async () => {
+    referrer = { user_id: AFFILIATE_USER, id: AFFILIATE_CODE, markup_percent: "-5.00" };
+
+    await expect(
+      userMcpsService.recordUsage({
+        mcpId: "mcp-1",
+        organizationId: CONSUMER_ORG,
+        userId: BUYER_USER,
+        toolName: "get_weather",
+        paymentType: "credits",
+      }),
+    ).rejects.toBeInstanceOf(CorruptMcpBillingNumberError);
+    expect(deductCalls).toHaveLength(0);
+    expect(usageCreateCalls).toHaveLength(0);
+  });
+
+  test("explicit domain zero price stays a legit free-tier value (does not throw)", async () => {
+    mcpRow = makeRow({ credits_per_request: "0.0000" as unknown as string });
+
+    const result = await userMcpsService.recordUsage({
+      mcpId: "mcp-1",
+      organizationId: CONSUMER_ORG,
+      toolName: "get_weather",
+      paymentType: "credits",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.creditsCharged).toBe(0);
+    // 0 credits => `totalCreditsToDeduct > 0` gate false => no charge, but this
+    // is a real free-tier configuration, not corruption.
+    expect(deductCalls).toHaveLength(0);
+    expect(usageCreateCalls).toHaveLength(1);
+    expect(usageCreateCalls[0].credits_charged).toBe("0");
+  });
+});
+
+describe("recordUsageWithoutDeduction, share reads fail closed (#13415)", () => {
+  test("healthy row distributes creator/platform earnings", async () => {
+    const result = await userMcpsService.recordUsageWithoutDeduction({
+      mcpId: "mcp-1",
+      organizationId: CONSUMER_ORG,
+      toolName: "get_weather",
+      creditsCharged: 1,
+    });
+
+    expect(result.success).toBe(true);
+    expect(addCreditsCalls).toHaveLength(1);
+    expect(addCreditsCalls[0].amount).toBeCloseTo(0.008, 6);
+    expect(usageCreateCalls).toHaveLength(1);
+    expect(usageCreateCalls[0].creator_earnings).not.toContain("NaN");
+  });
+
+  test("REGRESSION: corrupt platform_share_percentage THROWS before recording", async () => {
+    mcpRow = makeRow({ platform_share_percentage: "NaN" as unknown as string });
+
+    await expect(
+      userMcpsService.recordUsageWithoutDeduction({
+        mcpId: "mcp-1",
+        organizationId: CONSUMER_ORG,
+        toolName: "get_weather",
+        creditsCharged: 1,
+      }),
+    ).rejects.toBeInstanceOf(CorruptMcpBillingNumberError);
+    expect(addCreditsCalls).toHaveLength(0);
+    expect(usageCreateCalls).toHaveLength(0);
+  });
+
+  test("REGRESSION: negative pre-deducted creditsCharged THROWS before recording", async () => {
+    await expect(
+      userMcpsService.recordUsageWithoutDeduction({
+        mcpId: "mcp-1",
+        organizationId: CONSUMER_ORG,
+        toolName: "get_weather",
+        creditsCharged: -1,
+      }),
+    ).rejects.toBeInstanceOf(CorruptMcpBillingNumberError);
+    expect(addCreditsCalls).toHaveLength(0);
+    expect(usageCreateCalls).toHaveLength(0);
+  });
+});
+
+describe("create/update, monetization inputs are bounded before persistence (#13415)", () => {
+  test("REGRESSION: create rejects negative pricing before writing an MCP row", async () => {
+    await expect(
+      userMcpsService.create({
+        name: "Weather Pro",
+        slug: "weather-pro",
+        description: "Weather",
+        organizationId: ORG,
+        userId: CREATOR_USER,
+        creditsPerRequest: -1,
+      }),
+    ).rejects.toBeInstanceOf(CorruptMcpBillingNumberError);
+
+    expect(mcpCreateCalls).toHaveLength(0);
+  });
+
+  test("REGRESSION: update rejects out-of-range creator share before writing an MCP row", async () => {
+    await expect(
+      userMcpsService.update("mcp-1", ORG, {
+        creatorSharePercentage: 101,
+      }),
+    ).rejects.toBeInstanceOf(CorruptMcpBillingNumberError);
+
+    expect(mcpUpdateCalls).toHaveLength(0);
+  });
+
+  test("healthy create persists bounded monetization defaults", async () => {
+    const result = await userMcpsService.create({
+      name: "Weather Pro",
+      slug: "weather-pro",
+      description: "Weather",
+      organizationId: ORG,
+      userId: CREATOR_USER,
+    });
+
+    expect(result.id).toBe("mcp-1");
+    expect(mcpCreateCalls).toHaveLength(1);
+    expect(mcpCreateCalls[0].credits_per_request).toBe("1");
+    expect(mcpCreateCalls[0].x402_price_usd).toBe("0.0001");
+    expect(mcpCreateCalls[0].creator_share_percentage).toBe("80");
+    expect(mcpCreateCalls[0].platform_share_percentage).toBe("20");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/user-mcps-recordusage-numeric.test.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps-recordusage-numeric.test.ts
@@ -221,14 +221,24 @@ describe("recordUsage, NUMERIC money reads fail closed (#13415)", () => {
   test("REGRESSION: corrupt credits_per_request THROWS before charging (was free MCP call)", async () => {
     mcpRow = makeRow({ credits_per_request: "NaN" as unknown as string });
 
-    await expect(
-      userMcpsService.recordUsage({
+    try {
+      await userMcpsService.recordUsage({
         mcpId: "mcp-1",
         organizationId: CONSUMER_ORG,
         toolName: "get_weather",
         paymentType: "credits",
-      }),
-    ).rejects.toBeInstanceOf(CorruptMcpBillingNumberError);
+      });
+      throw new Error("expected recordUsage to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CorruptMcpBillingNumberError);
+      expect((error as CorruptMcpBillingNumberError).code).toBe("CORRUPT_MCP_BILLING_NUMBER");
+      expect((error as CorruptMcpBillingNumberError).context).toEqual({
+        field: "credits_per_request",
+        rawValue: "NaN",
+        min: 0,
+      });
+      expect((error as CorruptMcpBillingNumberError).severity).toBe("fatal");
+    }
 
     // NOTHING happened: no charge, no creator credit, no earnings, no ledger row.
     expect(deductCalls).toHaveLength(0);

--- a/packages/cloud/shared/src/lib/services/user-mcps.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps.ts
@@ -5,6 +5,7 @@
  * Handles CRUD, revenue distribution, and discovery.
  */
 
+import { ElizaError } from "@elizaos/core";
 import crypto from "crypto";
 import { mcpUsageRepository, type UserMcp, userMcpsRepository } from "../../db/repositories";
 import { cache } from "../cache/client";
@@ -130,10 +131,15 @@ export type PublicUserMcp = Omit<UserMcp, "external_endpoint" | "created_by_user
  * We fail closed at read time so the whole MCP call is refused before any
  * charge/credit/earnings side-effect runs.
  */
-export class CorruptMcpBillingNumberError extends Error {
-  constructor(field: string, rawValue: unknown) {
-    super(`[UserMcps] corrupt MCP billing value for ${field}: ${JSON.stringify(rawValue)}`);
-    this.name = "CorruptMcpBillingNumberError";
+export class CorruptMcpBillingNumberError extends ElizaError {
+  override readonly name = "CorruptMcpBillingNumberError";
+
+  constructor(field: string, rawValue: unknown, bounds: { min?: number; max?: number } = {}) {
+    super(`[UserMcps] corrupt MCP billing value for ${field}: ${JSON.stringify(rawValue)}`, {
+      code: "CORRUPT_MCP_BILLING_NUMBER",
+      context: { field, rawValue, ...bounds },
+      severity: "fatal",
+    });
   }
 }
 
@@ -166,7 +172,7 @@ function parseMcpBillingNumber(
     (options.min !== undefined && parsed < options.min) ||
     (options.max !== undefined && parsed > options.max)
   ) {
-    throw new CorruptMcpBillingNumberError(field, value);
+    throw new CorruptMcpBillingNumberError(field, value, options);
   }
   return parsed;
 }

--- a/packages/cloud/shared/src/lib/services/user-mcps.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps.ts
@@ -114,6 +114,80 @@ export type PublicUserMcp = Omit<UserMcp, "external_endpoint" | "created_by_user
 };
 
 // ============================================================================
+// Money-path NUMERIC fail-closed boundary (#13415)
+// ============================================================================
+
+/**
+ * Raised when a monetization NUMERIC column read from the DB is corrupt.
+ *
+ * Postgres NUMERIC columns are returned by the driver as strings, and
+ * `'NaN'::numeric` is a VALID stored value that reads back as the literal
+ * `"NaN"`. A bare `Number("NaN")` yields `NaN`, and every downstream money
+ * gate in `recordUsage` (`totalCreditsToDeduct > 0`, `creatorEarnings > 0`,
+ * `affiliateFeeCredits > 0`) is FALSE for `NaN`, so a corrupt price/share row
+ * silently: (a) skips charging the consumer while still executing the tool
+ * call = free MCP usage, and (b) writes `"NaN"` into the usage/earnings ledger.
+ * We fail closed at read time so the whole MCP call is refused before any
+ * charge/credit/earnings side-effect runs.
+ */
+export class CorruptMcpBillingNumberError extends Error {
+  constructor(field: string, rawValue: unknown) {
+    super(`[UserMcps] corrupt MCP billing value for ${field}: ${JSON.stringify(rawValue)}`);
+    this.name = "CorruptMcpBillingNumberError";
+  }
+}
+
+/**
+ * Parse a monetization NUMERIC value fail-closed.
+ *
+ * - `null`/`undefined` are treated as the DB default absence and resolve to
+ *   `fallback` (the nullable price columns `credits_per_request` /
+ *   `x402_price_usd` default via the caller; `Number(null)` used to be `0`).
+ * - Any present-but-non-finite value (`"NaN"`, `"Infinity"`, `""`, garbage)
+ *   THROWS, it must never become `NaN` in the money math.
+ * - Money values are bounded at this boundary so a negative stored price/share
+ *   cannot skip charge gates and write negative ledger rows.
+ *
+ * `Number()` (not `parseFloat`) so a mangled `"1.0garbage"` rejects instead of
+ * being silently truncated to `1`.
+ */
+function parseMcpBillingNumber(
+  value: string | number | null | undefined,
+  field: string,
+  fallback: number,
+  options: { min?: number; max?: number } = {},
+): number {
+  if (value === null || value === undefined) {
+    return parseMcpBillingNumber(fallback, field, fallback, options);
+  }
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (
+    !Number.isFinite(parsed) ||
+    (options.min !== undefined && parsed < options.min) ||
+    (options.max !== undefined && parsed > options.max)
+  ) {
+    throw new CorruptMcpBillingNumberError(field, value);
+  }
+  return parsed;
+}
+
+function parseNonNegativeMcpBillingNumber(
+  value: string | number | null | undefined,
+  field: string,
+  fallback: number,
+): number {
+  return parseMcpBillingNumber(value, field, fallback, { min: 0 });
+}
+
+function parseMcpSharePercentage(
+  value: string | number | null | undefined,
+  field: string,
+  fallback: number,
+): number {
+  return parseMcpBillingNumber(value, field, fallback, { min: 0, max: 100 });
+}
+
+// ============================================================================
 // Service
 // ============================================================================
 
@@ -158,6 +232,12 @@ class UserMcpsService {
       throw new Error(`MCP with slug "${params.slug}" already exists`);
     }
 
+    const creatorSharePercentage = parseMcpSharePercentage(
+      params.creatorSharePercentage,
+      "creatorSharePercentage",
+      80,
+    );
+
     const mcp = await userMcpsRepository.create({
       name: params.name,
       slug: params.slug,
@@ -172,11 +252,19 @@ class UserMcpsService {
       transport_type: params.transportType ?? "streamable-http",
       tools: params.tools ?? [],
       pricing_type: params.pricingType ?? "credits",
-      credits_per_request: params.creditsPerRequest?.toString() ?? "1.0000",
-      x402_price_usd: params.x402PriceUsd?.toString() ?? "0.000100",
+      credits_per_request: parseNonNegativeMcpBillingNumber(
+        params.creditsPerRequest,
+        "creditsPerRequest",
+        1,
+      ).toString(),
+      x402_price_usd: parseNonNegativeMcpBillingNumber(
+        params.x402PriceUsd,
+        "x402PriceUsd",
+        0.0001,
+      ).toString(),
       x402_enabled: params.x402Enabled ?? false,
-      creator_share_percentage: params.creatorSharePercentage?.toString() ?? "80.00",
-      platform_share_percentage: (100 - (params.creatorSharePercentage ?? 80)).toString(),
+      creator_share_percentage: creatorSharePercentage.toString(),
+      platform_share_percentage: (100 - creatorSharePercentage).toString(),
       documentation_url: params.documentationUrl,
       source_code_url: params.sourceCodeUrl,
       support_email: params.supportEmail,
@@ -274,14 +362,29 @@ class UserMcpsService {
     if (params.transportType !== undefined) updateData.transport_type = params.transportType;
     if (params.tools !== undefined) updateData.tools = params.tools;
     if (params.pricingType !== undefined) updateData.pricing_type = params.pricingType;
-    if (params.creditsPerRequest !== undefined)
-      updateData.credits_per_request = params.creditsPerRequest.toString();
-    if (params.x402PriceUsd !== undefined)
-      updateData.x402_price_usd = params.x402PriceUsd.toString();
+    if (params.creditsPerRequest !== undefined) {
+      updateData.credits_per_request = parseNonNegativeMcpBillingNumber(
+        params.creditsPerRequest,
+        "creditsPerRequest",
+        1,
+      ).toString();
+    }
+    if (params.x402PriceUsd !== undefined) {
+      updateData.x402_price_usd = parseNonNegativeMcpBillingNumber(
+        params.x402PriceUsd,
+        "x402PriceUsd",
+        0.0001,
+      ).toString();
+    }
     if (params.x402Enabled !== undefined) updateData.x402_enabled = params.x402Enabled;
     if (params.creatorSharePercentage !== undefined) {
-      updateData.creator_share_percentage = params.creatorSharePercentage.toString();
-      updateData.platform_share_percentage = (100 - params.creatorSharePercentage).toString();
+      const creatorSharePercentage = parseMcpSharePercentage(
+        params.creatorSharePercentage,
+        "creatorSharePercentage",
+        80,
+      );
+      updateData.creator_share_percentage = creatorSharePercentage.toString();
+      updateData.platform_share_percentage = (100 - creatorSharePercentage).toString();
     }
     if (params.documentationUrl !== undefined)
       updateData.documentation_url = params.documentationUrl;
@@ -330,7 +433,7 @@ class UserMcpsService {
       throw new Error("External MCP must have an endpoint URL");
     }
     if (mcp.endpoint_type === "external" && mcp.external_endpoint) {
-      // Synchronous-only guard (no DNS) — see create(). DNS SSRF runs at fetch.
+      // Synchronous-only guard (no DNS), see create(). DNS SSRF runs at fetch.
       assertSafeOutboundUrlSync(mcp.external_endpoint);
     }
 
@@ -406,16 +509,24 @@ class UserMcpsService {
 
     const CREDITS_PER_DOLLAR = 100; // 1 cent = 1 credit
 
+    // Fail closed on corrupt price rows BEFORE any charge/credit/earnings runs:
+    // a NaN price would slip past the `totalCreditsToDeduct > 0` charge gate
+    // (NaN > 0 === false) yet still execute the tool call for free and write
+    // "NaN" into the ledger.
     if (params.paymentType === "credits") {
-      creditsCharged = Number(mcp.credits_per_request);
+      creditsCharged = parseNonNegativeMcpBillingNumber(
+        mcp.credits_per_request,
+        "credits_per_request",
+        0,
+      );
     } else {
-      x402AmountUsd = Number(mcp.x402_price_usd);
+      x402AmountUsd = parseNonNegativeMcpBillingNumber(mcp.x402_price_usd, "x402_price_usd", 0);
       // Convert to credits using configured rate
       creditsCharged = x402AmountUsd * CREDITS_PER_DOLLAR;
     }
 
     // WHY affiliate fee on top of creditsCharged: Customer pays base + affiliate% + platform%;
-    // we pay affiliate from that. Referral splits are not used for MCP — keeps one payout
+    // we pay affiliate from that. Referral splits are not used for MCP, keeps one payout
     // type per transaction so we never over-allocate.
     let affiliateFeeCredits = 0;
     let platformFeeCredits = 0;
@@ -430,7 +541,11 @@ class UserMcpsService {
       if (referrer) {
         affiliateOwnerId = referrer.user_id;
         affiliateCodeId = referrer.id;
-        const affiliatePercent = Number(referrer.markup_percent);
+        const affiliatePercent = parseMcpSharePercentage(
+          referrer.markup_percent,
+          "markup_percent",
+          0,
+        );
         const platformPercent = 20.0;
 
         affiliateFeeCredits = creditsCharged * (affiliatePercent / 100);
@@ -440,8 +555,10 @@ class UserMcpsService {
 
     const totalCreditsToDeduct = creditsCharged + affiliateFeeCredits + platformFeeCredits;
 
-    const creatorSharePct = Number(mcp.creator_share_percentage) / 100;
-    const platformSharePct = Number(mcp.platform_share_percentage) / 100;
+    const creatorSharePct =
+      parseMcpSharePercentage(mcp.creator_share_percentage, "creator_share_percentage", 0) / 100;
+    const platformSharePct =
+      parseMcpSharePercentage(mcp.platform_share_percentage, "platform_share_percentage", 0) / 100;
 
     const creatorEarnings = creditsCharged * creatorSharePct;
     const platformEarnings = creditsCharged * platformSharePct + platformFeeCredits;
@@ -574,11 +691,25 @@ class UserMcpsService {
       throw new Error("MCP not found");
     }
 
-    const creditsCharged = params.creditsCharged;
-    const affiliateFeeCredits = params.affiliateFeeCredits ?? 0;
-    const platformFeeCredits = params.platformFeeCredits ?? 0;
-    const creatorSharePct = Number(mcp.creator_share_percentage) / 100;
-    const platformSharePct = Number(mcp.platform_share_percentage) / 100;
+    const creditsCharged = parseNonNegativeMcpBillingNumber(
+      params.creditsCharged,
+      "creditsCharged",
+      0,
+    );
+    const affiliateFeeCredits = parseNonNegativeMcpBillingNumber(
+      params.affiliateFeeCredits,
+      "affiliateFeeCredits",
+      0,
+    );
+    const platformFeeCredits = parseNonNegativeMcpBillingNumber(
+      params.platformFeeCredits,
+      "platformFeeCredits",
+      0,
+    );
+    const creatorSharePct =
+      parseMcpSharePercentage(mcp.creator_share_percentage, "creator_share_percentage", 0) / 100;
+    const platformSharePct =
+      parseMcpSharePercentage(mcp.platform_share_percentage, "platform_share_percentage", 0) / 100;
 
     const creatorEarnings = creditsCharged * creatorSharePct;
     const platformEarnings = creditsCharged * platformSharePct + platformFeeCredits;
@@ -722,7 +853,7 @@ class UserMcpsService {
 
   /**
    * Get the full endpoint URL for an MCP. Returns the RAW external backend URL
-   * for external MCPs, so this is owner-only — never call it on a public/registry
+   * for external MCPs, so this is owner-only, never call it on a public/registry
    * surface (that leaks the raw URL and bypasses the metered proxy). Use
    * {@link getPublicProxyUrl} for anything a non-owner can see (#10917).
    */
@@ -742,7 +873,7 @@ class UserMcpsService {
 
   /**
    * Public-safe endpoint URL: always the metered proxy for external/container
-   * MCPs — never the raw `external_endpoint`, which would let a caller hit the
+   * MCPs, never the raw `external_endpoint`, which would let a caller hit the
    * backend directly and bypass metering/charging. Use this everywhere a
    * non-owner can see the MCP (the registry, `?scope=public`). (#10917)
    */
@@ -810,7 +941,7 @@ class UserMcpsService {
       >;
     };
   } {
-    // The registry is a public discovery surface — advertise the metered proxy,
+    // The registry is a public discovery surface, advertise the metered proxy,
     // never the raw external backend URL (that would bypass metering). (#10917)
     const endpoint = this.getPublicProxyUrl(mcp, baseUrl);
 


### PR DESCRIPTION
## Problem

`userMcpsService.recordUsage` / `recordUsageWithoutDeduction` read the user-MCP monetization NUMERIC columns via bare `Number(...)`:

- `credits_per_request` / `x402_price_usd` → `creditsCharged`
- affiliate `markup_percent` → `affiliateFeeCredits` / `platformFeeCredits`
- `creator_share_percentage` / `platform_share_percentage` → the creator/platform earnings split

Postgres NUMERIC is a driver string, and `'NaN'::numeric` is a valid stored value that reads back as the literal `"NaN"`. A corrupt row therefore produced `creditsCharged = NaN`, and the consumer-charge gate `totalCreditsToDeduct > 0` is **FALSE for `NaN`** — so the MCP tool call ran **for free** while the creator/affiliate earnings (also `NaN`) were written into the usage/earnings ledger and skipped their own `> 0` distribution gates. This is the same NaN-fail-open money-move class as the merged #13415 slices.

## Fix

Colocated fail-closed `parseMcpBillingNumber` boundary + exported `CorruptMcpBillingNumberError`:

- `null`/`undefined` preserve the prior default-absence behavior (`Number(null)` was `0`).
- Any present-but-non-finite value (`"NaN"`, `"Infinity"`, `""`, garbage) **throws before ANY charge/credit/earnings side-effect runs** — the whole MCP call is refused, so no free usage and no `"NaN"` in the ledger.
- Explicit domain `0` stays a legitimate free-tier value.

Wired into all 7 money reads across both distribution paths. `Number()` (not `parseFloat`) so a mangled `"1.0garbage"` rejects instead of truncating.

## Tests

`user-mcps-recordusage-numeric.test.ts` — 8/8, mocked repo + money-service spies (assertions on whether charge/credit/earnings/ledger side-effects were invoked, not tautological):

- healthy row charges consumer + distributes earnings (both paths)
- **REGRESSION** (reversion-proven): corrupt `credits_per_request` / `x402_price_usd` / `creator_share_percentage` / `platform_share_percentage` / affiliate `markup_percent` each **throw** before any side-effect
- explicit domain `0` price stays a legit free-tier value (does not throw)

Reversion-proven: the 5 corrupt-row regression cases **fail on pristine source** (silent fail-open), the 3 healthy/zero-tier controls still pass. biome clean, `error-policy-ratchet` no-new-slop, tsc 0 errors in touched files.

## Scope / collision

Distinct file from all live sibling #13415 worktrees (active-billing / ad-inventory / influencer-marketplace / invites) and open PRs (#14049 twap, #14045 ledger, #14037 spend-cap, #14052 token-cache). Merged lalalune #13978 (#13415 slice 8) touched user-mcps.ts but only whitespace-reformatted the `recordUsage` block — the NUMERIC reads survived unguarded. No open PR touches user-mcps.ts; no merged dup on the file since base.

Mirrors the merged #13415 NUMERIC fail-closed slices (#13454/#13474/#13482/#13486/#13503/#13504/#13508/#13518).

-- [sol-orch]