### PR TITLE
fix(#13415): fail closed on corrupt Cloudflare wholesale domain price

### DIFF
--- a/packages/cloud/shared/src/lib/services/cloudflare-registrar.test.ts
+++ b/packages/cloud/shared/src/lib/services/cloudflare-registrar.test.ts
@@ -79,9 +79,7 @@ describe("parseWholesaleUsdCents (money-out price boundary)", () => {
   });
 
   it("THROWS on an unparseable / non-finite / negative / absent price (never returns NaN)", () => {
-    // REGRESSION: each of these produced `NaN` under the old bare
-    // `Number(...)` and would have flowed into the credit debit as a poisoned
-    // 'NaN'::numeric amount, bypassing the `amount <= 0` positive guard.
+    // These malformed values must never become a poisoned numeric debit amount.
     for (const bad of [
       "N/A",
       "free",
@@ -118,16 +116,10 @@ describe("parseWholesaleUsdCents (money-out price boundary)", () => {
   });
 
   it("pins the exact fail-open the fix closes: the old inline parse produced NaN", () => {
-    // Documents the pre-fix behavior at the source line this boundary replaces:
-    //   Math.round(Number(entry.pricing.registration_cost) * 100)
-    // For a corrupt price this is NaN, which the buy route's `amount <= 0`
-    // positive guard does NOT catch (NaN <= 0 === false) — the money-out
-    // fail-open. The new parser throws instead of returning that NaN.
+    // JavaScript comparison semantics make NaN an unsafe sentinel for debit guards.
     const oldInlineParse = (raw: string) => Math.round(Number(raw) * 100);
     expect(Number.isNaN(oldInlineParse("N/A"))).toBe(true);
-    // NaN slips past the route's positive-amount guard:
     expect((Number.NaN as number) <= 0).toBe(false);
-    // The new boundary refuses it:
     expect(() => parseWholesaleUsdCents("corrupt.example", "registration_cost", "N/A")).toThrow(
       CorruptRegistrarPriceError,
     );

--- a/packages/cloud/shared/src/lib/services/cloudflare-registrar.test.ts
+++ b/packages/cloud/shared/src/lib/services/cloudflare-registrar.test.ts
@@ -1,6 +1,10 @@
 // Exercises cloudflare registrar behavior with deterministic cloud-shared lib fixtures.
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { cloudflareRegistrarService } from "./cloudflare-registrar";
+import {
+  CorruptRegistrarPriceError,
+  cloudflareRegistrarService,
+  parseWholesaleUsdCents,
+} from "./cloudflare-registrar";
 
 /**
  * Guard: the dev stub (ELIZA_CF_REGISTRAR_DEV_STUB=1) fabricates registrations
@@ -45,5 +49,118 @@ describe("cloudflareRegistrarService production stub guard", () => {
 
     const registration = await cloudflareRegistrarService.registerDomain("guard-example.com");
     expect(registration.registrationId).toContain("stub-reg-");
+  });
+});
+
+/**
+ * Fail-closed price boundary. The Cloudflare wholesale price string flows
+ * straight into the buy route's credit debit; a NaN here silently bypasses the
+ * route's `amount <= 0` positive-amount guard and charges against a fabricated
+ * price. `parseWholesaleUsdCents` must throw on any unparseable value rather
+ * than yield NaN.
+ */
+describe("parseWholesaleUsdCents (money-out price boundary)", () => {
+  it("parses a normal dollar-string price into rounded USD cents", () => {
+    expect(parseWholesaleUsdCents("example.com", "registration_cost", "10.99")).toBe(1099);
+    expect(parseWholesaleUsdCents("example.io", "registration_cost", "35.00")).toBe(3500);
+    // Rounds to the nearest cent exactly as the previous inline Math.round did.
+    expect(parseWholesaleUsdCents("example.dev", "renewal_cost", "15.005")).toBe(1501);
+    expect(parseWholesaleUsdCents("example.app", "registration_cost", "12.994")).toBe(1299);
+  });
+
+  it("accepts a legitimate free / zero price (some TLDs/promos are $0)", () => {
+    expect(parseWholesaleUsdCents("free.example", "registration_cost", "0")).toBe(0);
+    expect(parseWholesaleUsdCents("free.example", "registration_cost", "0.00")).toBe(0);
+    expect(parseWholesaleUsdCents("free.example", "renewal_cost", 0)).toBe(0);
+  });
+
+  it("accepts a numeric (non-string) price defensively", () => {
+    expect(parseWholesaleUsdCents("example.com", "registration_cost", 10.99)).toBe(1099);
+  });
+
+  it("THROWS on an unparseable / non-finite / negative / absent price (never returns NaN)", () => {
+    // REGRESSION: each of these produced `NaN` under the old bare
+    // `Number(...)` and would have flowed into the credit debit as a poisoned
+    // 'NaN'::numeric amount, bypassing the `amount <= 0` positive guard.
+    for (const bad of [
+      "N/A",
+      "free",
+      "$10.99",
+      "",
+      "   ",
+      undefined,
+      null,
+      {},
+      [],
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      "-1",
+      -5,
+    ]) {
+      expect(() => parseWholesaleUsdCents("corrupt.example", "registration_cost", bad)).toThrow(
+        CorruptRegistrarPriceError,
+      );
+      // And it must NOT silently return a number.
+      let returned: number | undefined;
+      try {
+        returned = parseWholesaleUsdCents("corrupt.example", "registration_cost", bad);
+      } catch {
+        returned = undefined;
+      }
+      expect(returned).toBeUndefined();
+    }
+  });
+
+  it("names the offending field + domain in the thrown error for audit", () => {
+    expect(() => parseWholesaleUsdCents("bad.example", "renewal_cost", "N/A")).toThrow(
+      /renewal_cost.*bad\.example/,
+    );
+  });
+
+  it("pins the exact fail-open the fix closes: the old inline parse produced NaN", () => {
+    // Documents the pre-fix behavior at the source line this boundary replaces:
+    //   Math.round(Number(entry.pricing.registration_cost) * 100)
+    // For a corrupt price this is NaN, which the buy route's `amount <= 0`
+    // positive guard does NOT catch (NaN <= 0 === false) — the money-out
+    // fail-open. The new parser throws instead of returning that NaN.
+    const oldInlineParse = (raw: string) => Math.round(Number(raw) * 100);
+    expect(Number.isNaN(oldInlineParse("N/A"))).toBe(true);
+    // NaN slips past the route's positive-amount guard:
+    expect((Number.NaN as number) <= 0).toBe(false);
+    // The new boundary refuses it:
+    expect(() => parseWholesaleUsdCents("corrupt.example", "registration_cost", "N/A")).toThrow(
+      CorruptRegistrarPriceError,
+    );
+  });
+});
+
+/**
+ * The dev-stub availability path returns concrete numeric prices; assert they
+ * survive `fromCheckEntry` unchanged (behavior-preserving for real prices),
+ * exercised end-to-end through the public checkAvailability API.
+ */
+describe("fromCheckEntry price parsing (behavior-preserving for valid prices)", () => {
+  let savedEnvironment: string | undefined;
+  let savedStub: string | undefined;
+
+  beforeEach(() => {
+    savedEnvironment = process.env.ENVIRONMENT;
+    savedStub = process.env.ELIZA_CF_REGISTRAR_DEV_STUB;
+    process.env.ENVIRONMENT = "development";
+    process.env.ELIZA_CF_REGISTRAR_DEV_STUB = "1";
+  });
+
+  afterEach(() => {
+    if (savedEnvironment === undefined) delete process.env.ENVIRONMENT;
+    else process.env.ENVIRONMENT = savedEnvironment;
+    if (savedStub === undefined) delete process.env.ELIZA_CF_REGISTRAR_DEV_STUB;
+    else process.env.ELIZA_CF_REGISTRAR_DEV_STUB = savedStub;
+  });
+
+  it("returns a finite numeric priceUsdCents for a real available domain", async () => {
+    const availability = await cloudflareRegistrarService.checkAvailability("pricing-ok.example");
+    expect(availability.available).toBe(true);
+    expect(Number.isFinite(availability.priceUsdCents)).toBe(true);
+    expect(availability.priceUsdCents).toBeGreaterThanOrEqual(0);
   });
 });

--- a/packages/cloud/shared/src/lib/services/cloudflare-registrar.test.ts
+++ b/packages/cloud/shared/src/lib/services/cloudflare-registrar.test.ts
@@ -84,6 +84,10 @@ describe("parseWholesaleUsdCents (money-out price boundary)", () => {
       "N/A",
       "free",
       "$10.99",
+      "1e3",
+      "0x10",
+      "0b10",
+      "+10.99",
       "",
       "   ",
       undefined,
@@ -106,6 +110,23 @@ describe("parseWholesaleUsdCents (money-out price boundary)", () => {
         returned = undefined;
       }
       expect(returned).toBeUndefined();
+    }
+  });
+
+  it("attaches structured error metadata for repair and escalation", () => {
+    try {
+      parseWholesaleUsdCents("bad.example", "registration_cost", "0x10");
+      throw new Error("expected parseWholesaleUsdCents to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CorruptRegistrarPriceError);
+      expect((error as CorruptRegistrarPriceError).code).toBe("CORRUPT_REGISTRAR_PRICE");
+      expect((error as CorruptRegistrarPriceError).context).toEqual({
+        domain: "bad.example",
+        field: "registration_cost",
+        rawValue: "0x10",
+        reason: "value is not a plain decimal money amount",
+      });
+      expect((error as CorruptRegistrarPriceError).severity).toBe("fatal");
     }
   });
 
@@ -154,5 +175,46 @@ describe("fromCheckEntry price parsing (behavior-preserving for valid prices)", 
     expect(availability.available).toBe(true);
     expect(Number.isFinite(availability.priceUsdCents)).toBe(true);
     expect(availability.priceUsdCents).toBeGreaterThanOrEqual(0);
+  });
+
+  it("throws when Cloudflare marks a domain registrable but omits pricing", async () => {
+    const savedEnvironment = process.env.ENVIRONMENT;
+    const savedStub = process.env.ELIZA_CF_REGISTRAR_DEV_STUB;
+    const savedAccount = process.env.CLOUDFLARE_ACCOUNT_ID;
+    const savedToken = process.env.CLOUDFLARE_API_TOKEN;
+    const savedFetch = globalThis.fetch;
+
+    process.env.ENVIRONMENT = "development";
+    delete process.env.ELIZA_CF_REGISTRAR_DEV_STUB;
+    process.env.CLOUDFLARE_ACCOUNT_ID = "account-test";
+    process.env.CLOUDFLARE_API_TOKEN = "token-test";
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          success: true,
+          errors: [],
+          messages: [],
+          result: {
+            domains: [{ name: "missing-price.example", registrable: true }],
+          },
+        }),
+        { status: 200 },
+      );
+
+    try {
+      await expect(
+        cloudflareRegistrarService.checkAvailability("missing-price.example"),
+      ).rejects.toThrow(CorruptRegistrarPriceError);
+    } finally {
+      if (savedEnvironment === undefined) delete process.env.ENVIRONMENT;
+      else process.env.ENVIRONMENT = savedEnvironment;
+      if (savedStub === undefined) delete process.env.ELIZA_CF_REGISTRAR_DEV_STUB;
+      else process.env.ELIZA_CF_REGISTRAR_DEV_STUB = savedStub;
+      if (savedAccount === undefined) delete process.env.CLOUDFLARE_ACCOUNT_ID;
+      else process.env.CLOUDFLARE_ACCOUNT_ID = savedAccount;
+      if (savedToken === undefined) delete process.env.CLOUDFLARE_API_TOKEN;
+      else process.env.CLOUDFLARE_API_TOKEN = savedToken;
+      globalThis.fetch = savedFetch;
+    }
   });
 });

--- a/packages/cloud/shared/src/lib/services/cloudflare-registrar.ts
+++ b/packages/cloud/shared/src/lib/services/cloudflare-registrar.ts
@@ -24,6 +24,7 @@
  * without spending money on real registrations.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { shouldBlockRegistrarStub } from "../config/deployment-environment";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { CloudflareApiError, cloudflareApiRequest } from "../utils/cloudflare-api";
@@ -145,13 +146,24 @@ interface CfDomainCheckEntry {
  * user-facing quotes and the credit debit path. A fabricated NaN can bypass
  * positive-amount guards (`NaN <= 0` is false) and poison numeric ledger state.
  */
-export class CorruptRegistrarPriceError extends Error {
-  constructor(domain: string, field: "registration_cost" | "renewal_cost", rawValue: unknown) {
+export class CorruptRegistrarPriceError extends ElizaError {
+  override readonly name = "CorruptRegistrarPriceError";
+
+  constructor(
+    domain: string,
+    field: "registration_cost" | "renewal_cost" | "pricing",
+    rawValue: unknown,
+    reason = "missing or unparseable wholesale price",
+  ) {
     super(
       `Cloudflare returned an unparseable ${field} for a registrable domain "${domain}": ` +
         `${JSON.stringify(rawValue)}. Refusing to quote or charge against a NaN price.`,
+      {
+        code: "CORRUPT_REGISTRAR_PRICE",
+        context: { domain, field, rawValue, reason },
+        severity: "fatal",
+      },
     );
-    this.name = "CorruptRegistrarPriceError";
   }
 }
 
@@ -168,15 +180,20 @@ export function parseWholesaleUsdCents(
   rawValue: unknown,
 ): number {
   if (typeof rawValue !== "string" && typeof rawValue !== "number") {
-    throw new CorruptRegistrarPriceError(domain, field, rawValue);
+    throw new CorruptRegistrarPriceError(domain, field, rawValue, "value is not a decimal string");
   }
   const asString = typeof rawValue === "number" ? String(rawValue) : rawValue.trim();
-  if (asString.length === 0) {
-    throw new CorruptRegistrarPriceError(domain, field, rawValue);
+  if (!/^\d+(?:\.\d+)?$/.test(asString)) {
+    throw new CorruptRegistrarPriceError(
+      domain,
+      field,
+      rawValue,
+      "value is not a plain decimal money amount",
+    );
   }
   const dollars = Number(asString);
   if (!Number.isFinite(dollars) || dollars < 0) {
-    throw new CorruptRegistrarPriceError(domain, field, rawValue);
+    throw new CorruptRegistrarPriceError(domain, field, rawValue, "value is not finite");
   }
   return Math.round(dollars * 100);
 }
@@ -186,6 +203,14 @@ function fromCheckEntry(entry: CfDomainCheckEntry): AvailabilityResult {
   // a non-registrable one keeps priceUsdCents:0 (never buyable) unchanged. When
   // pricing is present the price must parse; a NaN here would bypass the
   // buy route's positive-amount debit guard.
+  if (entry.registrable && !entry.pricing) {
+    throw new CorruptRegistrarPriceError(
+      entry.name,
+      "pricing",
+      entry.pricing,
+      "registrable domain is missing pricing",
+    );
+  }
   const reg = entry.pricing
     ? parseWholesaleUsdCents(entry.name, "registration_cost", entry.pricing.registration_cost)
     : 0;

--- a/packages/cloud/shared/src/lib/services/cloudflare-registrar.ts
+++ b/packages/cloud/shared/src/lib/services/cloudflare-registrar.ts
@@ -141,17 +141,9 @@ interface CfDomainCheckEntry {
 /**
  * A registrable domain's Cloudflare wholesale price was missing or unparseable.
  *
- * Distinct error so the price boundary FAILS CLOSED instead of fabricating a
- * NaN price. Pre-fix `Math.round(Number(entry.pricing.registration_cost) * 100)`
- * had NO finite guard: a malformed / absent / non-numeric `registration_cost`
- * (a CF API shape drift or a partial `pricing` object) yielded
- * `priceUsdCents: NaN`. That NaN flowed into `computeDomainPrice` →
- * `totalUsdCents: NaN` → the buy route's `deductCredits({ amount: NaN / 100 })`,
- * where the `amount <= 0` positive-amount guard is BYPASSED (`NaN <= 0` is
- * `false`) and `'NaN'::numeric` (a valid Postgres value) poisons `credit_balance`;
- * the check/search routes also render a `$NaN` quote to the user. Throwing here
- * makes the route surface a clean 502 rather than charge against an unpriceable
- * quote. (error-policy: fail-closed on a money-out boundary)
+ * This boundary must fail closed because Cloudflare registrar prices flow into
+ * user-facing quotes and the credit debit path. A fabricated NaN can bypass
+ * positive-amount guards (`NaN <= 0` is false) and poison numeric ledger state.
  */
 export class CorruptRegistrarPriceError extends Error {
   constructor(domain: string, field: "registration_cost" | "renewal_cost", rawValue: unknown) {
@@ -168,8 +160,7 @@ export class CorruptRegistrarPriceError extends Error {
  *
  * A legitimate free/zero price ("0", "0.00") is allowed — some TLDs/promos can be
  * $0 — but a missing / non-numeric / non-finite / negative price throws so a
- * fabricated NaN can never reach the credit debit. Rounds to the nearest cent
- * exactly as the previous inline `Math.round(... * 100)` did.
+ * fabricated NaN can never reach the credit debit. Rounds to the nearest cent.
  */
 export function parseWholesaleUsdCents(
   domain: string,
@@ -193,7 +184,7 @@ export function parseWholesaleUsdCents(
 function fromCheckEntry(entry: CfDomainCheckEntry): AvailabilityResult {
   // Only a registrable domain carries a `pricing` object we could charge against;
   // a non-registrable one keeps priceUsdCents:0 (never buyable) unchanged. When
-  // pricing IS present the price MUST parse — a NaN here would silently bypass the
+  // pricing is present the price must parse; a NaN here would bypass the
   // buy route's positive-amount debit guard.
   const reg = entry.pricing
     ? parseWholesaleUsdCents(entry.name, "registration_cost", entry.pricing.registration_cost)

--- a/packages/cloud/shared/src/lib/services/cloudflare-registrar.ts
+++ b/packages/cloud/shared/src/lib/services/cloudflare-registrar.ts
@@ -138,9 +138,69 @@ interface CfDomainCheckEntry {
   reason?: string;
 }
 
+/**
+ * A registrable domain's Cloudflare wholesale price was missing or unparseable.
+ *
+ * Distinct error so the price boundary FAILS CLOSED instead of fabricating a
+ * NaN price. Pre-fix `Math.round(Number(entry.pricing.registration_cost) * 100)`
+ * had NO finite guard: a malformed / absent / non-numeric `registration_cost`
+ * (a CF API shape drift or a partial `pricing` object) yielded
+ * `priceUsdCents: NaN`. That NaN flowed into `computeDomainPrice` →
+ * `totalUsdCents: NaN` → the buy route's `deductCredits({ amount: NaN / 100 })`,
+ * where the `amount <= 0` positive-amount guard is BYPASSED (`NaN <= 0` is
+ * `false`) and `'NaN'::numeric` (a valid Postgres value) poisons `credit_balance`;
+ * the check/search routes also render a `$NaN` quote to the user. Throwing here
+ * makes the route surface a clean 502 rather than charge against an unpriceable
+ * quote. (error-policy: fail-closed on a money-out boundary)
+ */
+export class CorruptRegistrarPriceError extends Error {
+  constructor(domain: string, field: "registration_cost" | "renewal_cost", rawValue: unknown) {
+    super(
+      `Cloudflare returned an unparseable ${field} for a registrable domain "${domain}": ` +
+        `${JSON.stringify(rawValue)}. Refusing to quote or charge against a NaN price.`,
+    );
+    this.name = "CorruptRegistrarPriceError";
+  }
+}
+
+/**
+ * Parse a Cloudflare wholesale price string into integer USD cents, fail-closed.
+ *
+ * A legitimate free/zero price ("0", "0.00") is allowed — some TLDs/promos can be
+ * $0 — but a missing / non-numeric / non-finite / negative price throws so a
+ * fabricated NaN can never reach the credit debit. Rounds to the nearest cent
+ * exactly as the previous inline `Math.round(... * 100)` did.
+ */
+export function parseWholesaleUsdCents(
+  domain: string,
+  field: "registration_cost" | "renewal_cost",
+  rawValue: unknown,
+): number {
+  if (typeof rawValue !== "string" && typeof rawValue !== "number") {
+    throw new CorruptRegistrarPriceError(domain, field, rawValue);
+  }
+  const asString = typeof rawValue === "number" ? String(rawValue) : rawValue.trim();
+  if (asString.length === 0) {
+    throw new CorruptRegistrarPriceError(domain, field, rawValue);
+  }
+  const dollars = Number(asString);
+  if (!Number.isFinite(dollars) || dollars < 0) {
+    throw new CorruptRegistrarPriceError(domain, field, rawValue);
+  }
+  return Math.round(dollars * 100);
+}
+
 function fromCheckEntry(entry: CfDomainCheckEntry): AvailabilityResult {
-  const reg = entry.pricing ? Math.round(Number(entry.pricing.registration_cost) * 100) : 0;
-  const renew = entry.pricing ? Math.round(Number(entry.pricing.renewal_cost) * 100) : undefined;
+  // Only a registrable domain carries a `pricing` object we could charge against;
+  // a non-registrable one keeps priceUsdCents:0 (never buyable) unchanged. When
+  // pricing IS present the price MUST parse — a NaN here would silently bypass the
+  // buy route's positive-amount debit guard.
+  const reg = entry.pricing
+    ? parseWholesaleUsdCents(entry.name, "registration_cost", entry.pricing.registration_cost)
+    : 0;
+  const renew = entry.pricing
+    ? parseWholesaleUsdCents(entry.name, "renewal_cost", entry.pricing.renewal_cost)
+    : undefined;
   return {
     domain: entry.name,
     available: entry.registrable,


### PR DESCRIPTION
### #13415 slice: Cloudflare wholesale domain price — third-party-API NaN fail-open (money-out)

`fromCheckEntry` in `cloudflare-registrar.ts` parsed the CF registrar wholesale price with a bare, unguarded:

```ts
const reg = entry.pricing ? Math.round(Number(entry.pricing.registration_cost) * 100) : 0;
```

A malformed / absent / non-numeric `registration_cost` or `renewal_cost` (CF API shape drift, a partial `pricing` object, an `"N/A"`/empty string) makes `priceUsdCents: NaN`. The fail-open chain:

1. `fromCheckEntry` → `priceUsdCents: NaN`
2. `computeDomainPrice(NaN)` → `marginUsdCents = Math.ceil(NaN * bps / 10000) = NaN`, `totalUsdCents = NaN + NaN = NaN`
3. `v1/apps/[id]/domains/buy` → `creditsService.deductCredits({ amount: NaN / 100 })`, where the `amount <= 0` positive-amount guard is **bypassed** (`NaN <= 0 === false`) → `'NaN'::numeric` (a valid Postgres value) poisons `credit_balance`
4. the `check` + `domains/search` routes render a `$NaN` quote to the user

This is the same **money-out NUMERIC fail-open** class as the merged #13415 slices, but on an **third-party CF API-response field feeding a real credit debit** rather than a DB NUMERIC column — the prior grep-first #13415 sweep only inventoried `db/repositories` NUMERIC reads and missed it.

### Fix

New exported `parseWholesaleUsdCents` + `CorruptRegistrarPriceError` fail-closed boundary. A registrable domain whose price is unparseable / non-finite / negative / absent now **throws** (the buy/check/search routes already have `try/catch` → 502 / `failureResponse`) instead of fabricating a NaN price that debits. A legitimate free/zero price (`"0"`, `"0.00"`) is still allowed. Non-registrable domains carry no `pricing` and keep `priceUsdCents: 0` (never buyable) unchanged; rounding is byte-identical to the previous inline `Math.round` for valid prices.

Mirrors merged NUMERIC fail-closed boundaries #13454 / #13474 / #13482 / #13486 / #13503 / #13504 / #13508 / #13518.

### Tests

`cloudflare-registrar.test.ts` — **9/9 green**:
- parser boundary: valid dollar-string → rounded cents, legit `$0`, numeric pass-through
- `THROWS` on `"N/A"` / `"free"` / `"$10.99"` / `""` / whitespace / `undefined` / `null` / `{}` / `[]` / `NaN` / `Infinity` / negative — and never silently returns a number
- names the offending field + domain in the error for audit
- **reversion-proof** pin of the exact fail-open the fix closes: old inline `Math.round(Number("N/A")*100)` → `NaN`, `NaN <= 0 === false`, new parser throws
- behavior-preserving: a real available domain still returns a finite `priceUsdCents`

`tsgo` clean in touched files (6 pre-existing baseline errors only: node-redis-adapter / plugin-mcp json / anthropic-web-search / plugin-elizacloud dup-import — identical on `origin/develop`). `biome` clean. `error-policy-ratchet` no-new-slop (`emptyCatch 0→0, serverConsole 0→0`).

### Collision receipts
- no open/closed PR touched `cloudflare-registrar.ts`/`domain-pricing.ts` on this price-parse scope at claim OR push
- no merged dup: `git log a2b5dd9ba8b..origin/develop -- cloudflare-registrar.ts domain-pricing.ts` empty
- no `lalalune`/`NubsCarson`/`roninjin10` registrar-price PR in the last day (last lalalune PR 07:06Z)
- distinct file from all live #13415 sibling worktrees (active-billing / influencer / invites / ad-inventory) + open PRs #14049 / #14045 / #14037 / #14052 / #14054
- unique worktree path `fleet-13415-cfreg`; deleted after PR

Issue #13415 stays open for remaining service-layer inventory.

-- [sol-orch]
