### PR TITLE
ci: path-gate coverage-gate + fix stale scenario-pr assertion (#14051 Tier A)

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -17,6 +17,10 @@ name: coverage-gate
 on:
   pull_request:
     branches: ["main", "develop"]
+    paths:
+      - "packages/**"
+      - "plugins/**"
+      - "apps/**"
 
 # cancel superseded in-flight runs for the same PR to free hosted-runner
 # capacity. only cancels pull_request runs; push runs on protected branches


### PR DESCRIPTION
## Summary
- Path-gates `.github/workflows/coverage-gate.yml` so it only runs for PR changes under `packages/**`, `plugins/**`, or `apps/**`.
- Updates `scenario-pr-workflow.test.ts` to assert current `test.yml` aggregate job IDs, `plugin-tests-status:` and `ci-ok:`, instead of stale `test-status:`.
- Confirms `coverage-gate` is not part of `ci-ok` needs.

Refs #14051, Tier A items 3 and 4.

## Verification
```console
$ bun test packages/scenario-runner/src/scenario-pr-workflow.test.ts
bun test v1.3.9 (cf6cdbbb)

packages/scenario-runner/src/scenario-pr-workflow.test.ts:
(pass) scenario PR workflow contract > runs deterministic zero-cost coverage on every PR without path filtering [11.00ms]
(pass) scenario PR workflow contract > keeps cloud Playwright CI wired to real Playwright, including visual screenshot checks [1.00ms]
(pass) scenario PR workflow contract > keeps actual app screenshots failing on blank or one-color captures
(pass) scenario PR workflow contract > keeps design-review screenshots on the same one-color failure guard
(pass) scenario PR workflow contract > keeps packaged desktop screenshots failing on blank or one-color captures
(pass) scenario PR workflow contract > keeps app-core live screenshots failing on blank or one-color captures
(pass) scenario PR workflow contract > keeps computer-use browser screenshots failing on blank or one-color captures [1.00ms]
(pass) scenario PR workflow contract > keeps actual app pill/chat coverage on repeated open-close-send cycles
(pass) scenario PR workflow contract > keeps bidirectional and always-on voice coverage in the PR gate [1.00ms]
(pass) scenario PR workflow contract > folds per-plugin keyless harness proofs into the required zero-key test status
(pass) scenario PR workflow contract > keeps PR-gated dynamic view loader coverage on remote load and interact flows

 11 pass
 0 fail
 218 expect() calls
Ran 11 tests across 1 file. [337.00ms]
```

```console
$ actionlint .github/workflows/coverage-gate.yml
actionlint not installed in this environment
```

```console
$ awk '/^  ci-ok:/,/^  [^ ]/' .github/workflows/test.yml | grep -n "coverage" || echo "no coverage-gate/coverage dependency in ci-ok block"
no coverage-gate/coverage dependency in ci-ok block
```

## Review
- `codex review --uncommitted` ran. It raised one P2 suggestion to include repo-root sources such as `scripts/**`; I did not apply it because #14051 Tier A explicitly scoped this path gate to `packages/**`, `plugins/**`, and `apps/**`, excluding docs/config/workflow-only PRs.

— [sol-orch]
