### PR TITLE
ci: move docker-smoke + scenario-pr off per-PR push (throughput, #14051 Tier A)

### DIFF
--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -3,11 +3,17 @@ name: Docker CI Smoke
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
+  # Heavy family moved off per-PR push (#14051 Tier A): PR runs are opt-in via
+  # the `ci:full` label (job-level gate on `changes` below). Unlabeled PRs
+  # skip every job instantly and consume zero runners.
   pull_request:
     branches: [develop]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   push:
     branches: [develop]
+  schedule:
+    # Nightly heavy lane (#14051): 07:00 UTC.
+    - cron: "0 7 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -20,6 +26,10 @@ permissions:
 jobs:
   changes:
     name: Classify changed paths
+    # #14051: PRs only run this heavy family when explicitly opted in with the
+    # `ci:full` label. Every downstream job needs this one, so an unlabeled PR
+    # skips the whole workflow without touching a runner.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full')
     # Path classifier is a git-diff + node script: no self-hosted resources.
     # Keep it on GitHub-hosted so a drained hetzner fleet cannot leave it
     # queued indefinitely and pile up runs (#13617/#8501).

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -8,9 +8,17 @@ name: Scenario PR E2E
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
+  # Heavy family moved off per-PR push (#14051 Tier A): PR runs are opt-in via
+  # the `ci:full` label (job-level gate on `changes` below). Unlabeled PRs
+  # skip every job instantly and consume zero runners.
   pull_request:
     branches: [main, develop]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
+  push:
+    branches: [develop]
+  schedule:
+    # Nightly heavy lane (#14051): 07:00 UTC.
+    - cron: "0 7 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -41,6 +49,10 @@ permissions:
 jobs:
   changes:
     name: Classify changed paths
+    # #14051: PRs only run this heavy family when explicitly opted in with the
+    # `ci:full` label. Every downstream job needs this one, so an unlabeled PR
+    # skips the whole workflow without touching a runner.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full')
     # Path classifier is a git-diff + node script: no self-hosted resources.
     # Keep it on GitHub-hosted so a drained hetzner fleet cannot leave it
     # queued indefinitely and pile up runs (#13617/#8501).

--- a/packages/scenario-runner/src/scenario-pr-workflow.test.ts
+++ b/packages/scenario-runner/src/scenario-pr-workflow.test.ts
@@ -755,7 +755,8 @@ describe("scenario PR workflow contract", () => {
       ].join("$"),
     );
     expect(workflow).toContain("- zero-key-e2e");
-    expect(workflow).toContain("test-status:");
+    // The aggregate merge gate job (required develop ruleset check).
+    expect(workflow).toContain("ci-ok:");
   });
 
   it("keeps PR-gated dynamic view loader coverage on remote load and interact flows", () => {


### PR DESCRIPTION
## What

Tier A item 1 of #14051: move the two biggest non-required heavy workflow families off per-PR push so they stop consuming ~17 runners on every PR push while the required `ci-ok` lane starves.

- **docker-ci-smoke.yml** (2 jobs/PR): drop unconditional PR runs, keep `push: develop`, add nightly `schedule` (`0 7 * * *`), keep `workflow_call` (consumed by develop-exhaustive, #12342).
- **scenario-pr.yml** (~15 jobs/PR): same treatment, plus add `push: develop` so the heavy scenario matrix still runs post-merge. `workflow_call` kept intact.
- **Opt-in escape hatch:** the root `changes` job (which every downstream job `needs:`) is gated with `if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full')`. Add the `ci:full` label to any PR to force the full heavy lane on it (both workflows already trigger on `labeled`/`synchronize`).
- **scenario-pr-workflow.test.ts:** replaced the stale `test-status:` assertion (that string no longer exists anywhere in test.yml) with the real aggregate gate job id `ci-ok:`.

## Why this is safe

`ci-ok` (the ONLY required develop check) needs: `changes, merge-quality-gate, server-tests, client-tests, xr-harness-e2e, plugin-tests-status, integration-tests, desktop-contract, zero-key-e2e, cloud-live-e2e, provider-live-e2e, github-live-artifact-validate`. Neither `docker-ci-smoke` nor any `scenario-pr` job is in that list — verified by reading test.yml at ab9c6b9e1e6 before editing. Coverage is not lost, it moves to push-to-develop + nightly + the develop-exhaustive orchestrator + on-demand `ci:full`.

## Verification

```
scenario-pr-workflow.test.ts        11/11 pass (vitest)
ci-merge-gate-contract.mjs          --self-test: 8 cases passed; full run: pass
ci-workflow-dedup-contract.mjs      pass
ci-full-matrix-proof.mjs            PASS — docker-ci-smoke.yml lane OK, scenario-pr lane OK
                                    (workflow_call wiring for develop-exhaustive preserved)
actionlint 1.7.7                    clean on both files
```

Pre-existing, unrelated: `ui-e2e-runner-coverage.test.ts` fails identically on origin/develop (5 unwired packages/ui `__e2e__` runners) — not touched by this PR.

Refs #14051.

Not arming auto-merge: workflow change, wants a human review.

— [sol-orch]
