### PR TITLE
fix(#13415): fail closed on corrupt credit_balance in container deploy/quota

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/containers-credit-balance-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/containers-credit-balance-numeric.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Fail-closed NUMERIC boundary for the container deploy/quota `credit_balance`
+ * reads in `ContainersRepository` (#13415, cloud-shared DB-repository
+ * fallback-slop sweep).
+ *
+ * `organizations.credit_balance` is a Postgres NUMERIC column, so the driver
+ * hands it back as a string. Before this slice three reads in
+ * `ContainersRepository` coerced it with a bare `Number(...)`, which fails OPEN
+ * on a corrupt value (`'NaN'::numeric` is a valid Postgres NUMERIC and a
+ * migration artifact / manual DB edit can produce a non-parseable string):
+ *
+ *   - `createContainerWithCreditDeduction` (money-out spend gate): the
+ *     insufficient-balance guard `Number(credit_balance) < deploymentCost` is
+ *     FALSE for `NaN`, so the deploy+debit is AUTHORIZED against a corrupt
+ *     balance, the container is created FREE, and `String(NaN - cost)` = `"NaN"`
+ *     is written back into the balance column — permanently poisoning it. A
+ *     money-out gate failing open is the worst class of this bug.
+ *   - `createWithQuotaCheck` and `checkQuota` (container-quota tier): a `NaN`
+ *     feeds `getMaxContainersForOrg`, which silently drops the org into the
+ *     FREE quota tier, mis-labelling a paying org's container allowance.
+ *
+ * All three now delegate to the merged, exported fail-closed boundary
+ * `parseOrganizationCreditBalance` (#13416) — the same helper the two
+ * `OrganizationsRepository` mutation paths already use for this exact column —
+ * so a corrupt read throws a field-named error INSIDE the mutation transaction
+ * (money path) / denies the pre-flight check (read-only path) instead of
+ * bypassing the guard or fabricating a free-tier max.
+ *
+ * A real corrupt NUMERIC cannot be stored in PGlite/Postgres (they reject it),
+ * so the healthy-path regression coverage lives in the PGlite-backed container
+ * suites. These tests pin the reused PARSER boundary against the money-out
+ * class and grep-guard that each wired read site delegates to it — the exact
+ * seam a read-time driver quirk / migration artifact would hit.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { parseOrganizationCreditBalance } from "../organizations-credit-balance-numeric";
+
+describe("parseOrganizationCreditBalance fails closed on the container deploy money-out class", () => {
+  test("parses a well-formed NUMERIC balance", () => {
+    expect(parseOrganizationCreditBalance("10.50", "credit_balance")).toBe(10.5);
+    expect(parseOrganizationCreditBalance("1234.567890", "credit_balance")).toBe(1234.56789);
+  });
+
+  test("allows an explicit domain zero (a genuinely $0 balance still gates deploys)", () => {
+    expect(parseOrganizationCreditBalance("0.00", "credit_balance")).toBe(0);
+    expect(parseOrganizationCreditBalance(0, "credit_balance")).toBe(0);
+  });
+
+  test("allows a negative overdrawn balance (a real value, not corruption)", () => {
+    expect(parseOrganizationCreditBalance("-5.00", "credit_balance")).toBe(-5);
+  });
+
+  test("throws on the literal 'NaN' instead of returning NaN (the fail-open trigger)", () => {
+    // This is the exact value that made `NaN < deploymentCost` FALSE and
+    // bypassed the insufficient-balance spend gate.
+    expect(() => parseOrganizationCreditBalance("NaN", "credit_balance")).toThrow(/credit_balance/);
+  });
+
+  test("regression: the old bare Number('NaN') fail-open path is provably wrong", () => {
+    // Demonstrates the defect this slice closes: with a bare Number(...) a
+    // corrupt balance silently authorizes the deploy AND poisons the column.
+    const corrupt = "NaN";
+    const deploymentCost = 5;
+    const fabricated = Number(corrupt); // old code path
+    expect(Number.isNaN(fabricated)).toBe(true);
+    expect(fabricated < deploymentCost).toBe(false); // guard bypassed
+    expect(String(fabricated - deploymentCost)).toBe("NaN"); // poisoned write
+    // The fix routes this same value through the fail-closed parser, which
+    // throws instead of authorizing / poisoning.
+    expect(() => parseOrganizationCreditBalance(corrupt, "credit_balance")).toThrow();
+  });
+
+  test("throws on Infinity / non-finite JS coercions", () => {
+    expect(() => parseOrganizationCreditBalance("Infinity", "credit_balance")).toThrow();
+    expect(() => parseOrganizationCreditBalance("1e3", "credit_balance")).toThrow();
+    expect(() => parseOrganizationCreditBalance("0x10", "credit_balance")).toThrow();
+  });
+
+  test("throws on null / undefined / empty instead of fabricating 0", () => {
+    expect(() => parseOrganizationCreditBalance(null, "credit_balance")).toThrow(
+      /empty or missing/,
+    );
+    expect(() => parseOrganizationCreditBalance(undefined, "credit_balance")).toThrow(
+      /empty or missing/,
+    );
+    expect(() => parseOrganizationCreditBalance("   ", "credit_balance")).toThrow(
+      /empty or missing/,
+    );
+  });
+});
+
+describe("ContainersRepository wires every credit_balance read through the fail-closed parser", () => {
+  test("source pins all three read sites to parseOrganizationCreditBalance (no bare Number(org.credit_balance) survives)", () => {
+    // Grep-guard against a regression that reintroduces a bare
+    // `Number(org.credit_balance)` on the deploy / quota paths. Reads the actual
+    // source (not a transpiled Function.toString(), which can rename/reorder).
+    const repoPath = fileURLToPath(new URL("../containers.ts", import.meta.url));
+    const src = readFileSync(repoPath, "utf8");
+
+    // The module imports the shared fail-closed boundary.
+    expect(src).toContain(
+      'import { parseOrganizationCreditBalance } from "./organizations-credit-balance-numeric"',
+    );
+
+    // Exactly three call sites delegate to the parser (checkQuota,
+    // createWithQuotaCheck, createContainerWithCreditDeduction).
+    const delegations = src.match(/parseOrganizationCreditBalance\(\s*org\.credit_balance/g) ?? [];
+    expect(delegations.length).toBe(3);
+
+    // No bare Number(...) read of the corrupt-prone NUMERIC field survives.
+    // `\bNumber\(` anchors on the global Number constructor, NOT the tail of a
+    // helper name.
+    expect(src).not.toMatch(/\bNumber\(\s*org\.credit_balance/);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/containers.ts
+++ b/packages/cloud/shared/src/db/repositories/containers.ts
@@ -19,6 +19,7 @@ import { creditTransactions } from "../schemas/credit-transactions";
 import { dockerNodes } from "../schemas/docker-nodes";
 import { organizationConfig } from "../schemas/organization-config";
 import { organizations } from "../schemas/organizations";
+import { parseOrganizationCreditBalance } from "./organizations-credit-balance-numeric";
 
 export type Container = InferSelectModel<typeof containers>;
 export type NewContainer = InferInsertModel<typeof containers>;
@@ -334,8 +335,26 @@ export class ContainersRepository {
         ),
       );
 
+    // error-policy:J4 — a corrupt `credit_balance` NUMERIC (`'NaN'::numeric`
+    // migration artifact / manual DB edit) read through a bare `Number(...)`
+    // would become NaN and silently drop the org into the FREE tier via
+    // getMaxContainersForOrg, mislabelling a paying org's quota. Fail closed:
+    // an unreadable balance denies the pre-flight check with a diagnostic
+    // error rather than fabricating a free-tier max.
+    let creditBalance: number;
+    try {
+      creditBalance = parseOrganizationCreditBalance(org.credit_balance, "credit_balance");
+    } catch (error) {
+      return {
+        allowed: false,
+        current: count,
+        max: 0,
+        error:
+          error instanceof Error ? error.message : "Unable to read organization credit_balance",
+      };
+    }
     const maxContainers = getMaxContainersForOrg(
-      Number(org.credit_balance),
+      creditBalance,
       config?.settings as Record<string, unknown> | undefined,
     );
 
@@ -572,9 +591,14 @@ export class ContainersRepository {
           ),
         );
 
-      // 3. Get max allowed containers for this org
+      // 3. Get max allowed containers for this org.
+      // error-policy:J4 — fail closed on a corrupt `credit_balance` NUMERIC so a
+      // migration artifact / manual DB edit cannot silently drop a paying org
+      // into the FREE quota tier. The throw propagates out of the FOR UPDATE
+      // transaction, rolling back atomically (no container row is created).
+      const creditBalance = parseOrganizationCreditBalance(org.credit_balance, "credit_balance");
       const maxContainers = getMaxContainersForOrg(
-        Number(org.credit_balance),
+        creditBalance,
         config?.settings as Record<string, unknown> | undefined,
       );
 
@@ -645,7 +669,15 @@ export class ContainersRepository {
         throw new Error("Organization not found");
       }
 
-      const currentBalance = Number(org.credit_balance);
+      // error-policy:J1 — money-out spend gate. Read the balance fail-closed:
+      // a corrupt `credit_balance` NUMERIC (`'NaN'::numeric`) through a bare
+      // `Number(...)` becomes NaN, and `NaN < deploymentCost` is FALSE, so the
+      // insufficient-balance guard is BYPASSED — the container deploys FREE and
+      // `String(NaN - cost)` = "NaN" is written back, permanently poisoning the
+      // balance column. Throwing here (still inside the dbWrite.transaction)
+      // rolls the whole deploy+debit back atomically instead of authorizing an
+      // unbacked deployment against an unreadable balance.
+      const currentBalance = parseOrganizationCreditBalance(org.credit_balance, "credit_balance");
 
       if (currentBalance < deploymentCost) {
         throw new Error(


### PR DESCRIPTION
## What

`ContainersRepository` read `organizations.credit_balance` (a Postgres NUMERIC column, handed back as a string by the driver) through a bare `Number(...)` at **three** sites, failing **OPEN** on a corrupt value. `'NaN'::numeric` is a valid Postgres NUMERIC and a migration artifact / manual DB edit can produce a non-parseable string.

- **`createContainerWithCreditDeduction` — money-out spend gate (worst class):** the insufficient-balance guard `Number(credit_balance) < deploymentCost` is **FALSE** for `NaN`, so the deploy+debit was **AUTHORIZED** against a corrupt balance — the container deployed **FREE** and `String(NaN - cost)` = `"NaN"` was written back, **permanently poisoning** the balance column.
- **`createWithQuotaCheck` / `checkQuota` — container-quota tier:** a `NaN` fed `getMaxContainersForOrg`, silently dropping the org into the **FREE quota tier**, mis-labelling a paying org's container allowance.

## Fix

All three reads now delegate to the merged, exported fail-closed boundary **`parseOrganizationCreditBalance`** (from #13416) — the same helper `OrganizationsRepository` already uses for this exact column. A corrupt read now:

- **money path** (`createContainerWithCreditDeduction`, `createWithQuotaCheck`): throws a field-named error **inside** the `dbWrite.transaction` / `FOR UPDATE` transaction, so the whole deploy+debit **rolls back atomically** — no free container, no poisoned balance, no phantom debit row.
- **read-only path** (`checkQuota`): **denies** the pre-flight check with a diagnostic error (matching its existing `Organization not found` fail-closed shape) instead of fabricating a free-tier max.

Explicit domain `0` / negative overdrawn balances stay legit values (behavior-preserving for healthy rows).

## Tests

`packages/cloud/shared/src/db/repositories/__tests__/containers-credit-balance-numeric.test.ts` — **8/8 green**:
- Pins the reused parser against the money-out class (`"NaN"` / `Infinity` / `"1e3"` / null / empty all throw; explicit `0` and negatives allowed).
- **Reversion-proven:** reverting any of the three sites to a bare `Number(org.credit_balance)` fails the grep-guard (delegation count 3→2 + `not.toMatch(/\bNumber\(\s*org\.credit_balance/)`).
- A regression test demonstrates the old bare-`Number("NaN")` path (`NaN < cost` false → guard bypassed → `String(NaN - cost)` = `"NaN"` poison) is provably wrong and that the parser throws on the same value.

Evidence:
- `bun test containers-credit-balance-numeric.test.ts` → 8 pass / 0 fail.
- `tsgo --noEmit` → **0 errors in touched files** (8 pre-existing baseline: node-redis / plugin-mcp / anthropic-web-search unrelated packages + 4 fresh-worktree i18n `validation-keyword-data`, identical on develop).
- biome clean; `error-policy-ratchet` → *no new fallback-slop in touched files*.
- **codex review clean:** *"No discrete correctness issues were found... The new parser wiring consistently fails closed for invalid credit balances."*

Distinct file from all merged/open #13415 slices and every live sibling worktree; mirrors the merged NUMERIC fail-closed boundary family (#13454 / #13474 / #13482 / #13486 / #13503 / #13504 / #13508 / #13518). Issue stays open for remaining service/DB-layer inventory.

— [sol-orch]
