### PR TITLE
fix(#13415): fail closed on corrupt catalog price in ai-pricing selection + cost boundary

### DIFF
--- a/packages/cloud/shared/src/lib/services/ai-pricing/candidate-selection-numeric.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/candidate-selection-numeric.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression (#13415 fallback-slop): a corrupt persisted catalog price must
+ * never be SELECTED, and must never silently bill NaN.
+ *
+ * `aiEntryToPrepared` builds `unitPrice = Number(entry.unit_price)` over a
+ * Postgres NUMERIC column. A corrupt row (`'NaN'::numeric` is a valid Postgres
+ * NUMERIC that reads back as the string "NaN") therefore yields a candidate
+ * whose `unitPrice` is `NaN`. Before this fix `chooseBestCandidatePricingEntry`:
+ *   (a) did NOT filter such a candidate out, and
+ *   (b) used `right.entry.unitPrice - left.entry.unitPrice` as a tie-break,
+ *       which returns `NaN` for a corrupt entry — an INCONSISTENT sort
+ *       comparator that could non-deterministically let the corrupt entry WIN
+ *       over a valid one — after which `asDecimal(NaN).mul(quantity)` bills a
+ *       `NaN` charge that poisons the credit debit / earnings ledger.
+ *
+ * The fix drops any candidate whose `unitPrice` is not a finite, positive
+ * number, mirroring the finite guard already present in
+ * `resolveFallbackTokenRate`. This file locks in that selection behavior; the
+ * cost-boundary defense-in-depth guard is exercised in
+ * lookup-corrupt-price.test.ts.
+ */
+import { expect, test } from "bun:test";
+import type { PricingDimensions } from "../../../db/schemas/ai-pricing";
+import { chooseBestCandidatePricingEntry } from "./candidate-selection";
+import type { CandidatePreparedPricingEntry, PreparedPricingEntry } from "./types";
+
+function candidate(
+  overrides: Partial<PreparedPricingEntry> & { unitPrice: number },
+  modelId = "anthropic/claude-sonnet-5",
+): CandidatePreparedPricingEntry {
+  const entry: PreparedPricingEntry = {
+    billingSource: "bitrouter",
+    provider: "anthropic",
+    model: modelId,
+    productFamily: "language",
+    chargeType: "input",
+    unit: "token",
+    dimensions: {},
+    sourceKind: "bitrouter_catalog",
+    sourceUrl: "https://example.test/catalog",
+    priority: 200,
+    isOverride: false,
+    metadata: {},
+    ...overrides,
+  };
+  return { entry, modelId, logicalProvider: "anthropic" };
+}
+
+const NO_DIMENSIONS: PricingDimensions = {};
+const CANONICAL = "anthropic/claude-sonnet-5";
+
+test("a corrupt (NaN) unit price is never selected — a valid entry wins", () => {
+  // NaN entry declares a HIGHER priority than the valid one, so without the
+  // fail-closed filter it would win priority-first. It must be dropped instead.
+  const corrupt = candidate({ unitPrice: Number("NaN"), priority: 999 });
+  const valid = candidate({ unitPrice: 0.000003, priority: 200 });
+
+  const chosen = chooseBestCandidatePricingEntry([corrupt, valid], NO_DIMENSIONS, CANONICAL);
+
+  expect(chosen).not.toBeNull();
+  expect(chosen?.entry.unitPrice).toBe(0.000003);
+  expect(Number.isFinite(chosen?.entry.unitPrice ?? Number.NaN)).toBe(true);
+});
+
+test("when the ONLY matching entry is corrupt, selection returns null (fail closed)", () => {
+  // A null return degrades the caller to the fallback tier (provider-max / env
+  // default) or fails closed — exactly as an ABSENT price does — instead of
+  // billing a NaN rate.
+  const corrupt = candidate({ unitPrice: Number("NaN") });
+
+  const chosen = chooseBestCandidatePricingEntry([corrupt], NO_DIMENSIONS, CANONICAL);
+
+  expect(chosen).toBeNull();
+});
+
+test("non-positive and non-finite prices are all dropped (0, -1, Infinity, NaN)", () => {
+  const zero = candidate({ unitPrice: 0 });
+  const negative = candidate({ unitPrice: -0.001 });
+  const infinite = candidate({ unitPrice: Number.POSITIVE_INFINITY });
+  const nan = candidate({ unitPrice: Number("NaN") });
+
+  expect(
+    chooseBestCandidatePricingEntry([zero, negative, infinite, nan], NO_DIMENSIONS, CANONICAL),
+  ).toBeNull();
+});
+
+test("a healthy set of finite prices selects the highest by the conservative tie-break", () => {
+  // Same priority/specificity/canonical/provider → the tie-break prefers the
+  // higher unitPrice (never under-bill). Verifies the fix didn't change the
+  // healthy-path ordering.
+  const cheap = candidate({ unitPrice: 0.000001 });
+  const pricey = candidate({ unitPrice: 0.000009 });
+
+  const chosen = chooseBestCandidatePricingEntry([cheap, pricey], NO_DIMENSIONS, CANONICAL);
+
+  expect(chosen?.entry.unitPrice).toBe(0.000009);
+});
+
+test("REGRESSION: a corrupt entry cannot poison the tie-break comparator to win", () => {
+  // The old `right.unitPrice - left.unitPrice` tie-break returns NaN when either
+  // side is corrupt. Depending on the engine's sort, an inconsistent comparator
+  // can leave a corrupt element first. Prove the corrupt one is gone BEFORE the
+  // sort so ordering is always over finite prices only.
+  const corrupt = candidate({ unitPrice: Number("NaN") });
+  const valid = candidate({ unitPrice: 0.000004 });
+
+  // Both orderings must select the same valid entry.
+  expect(
+    chooseBestCandidatePricingEntry([corrupt, valid], NO_DIMENSIONS, CANONICAL)?.entry.unitPrice,
+  ).toBe(0.000004);
+  expect(
+    chooseBestCandidatePricingEntry([valid, corrupt], NO_DIMENSIONS, CANONICAL)?.entry.unitPrice,
+  ).toBe(0.000004);
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/candidate-selection.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/candidate-selection.ts
@@ -27,8 +27,23 @@ export function chooseBestCandidatePricingEntry(
   requestedDimensions: PricingDimensions,
   canonicalModel: string,
 ): CandidatePreparedPricingEntry | null {
-  const matching = candidates.filter(({ entry }) =>
-    dimensionsAreSubset(normalizePricingDimensions(entry.dimensions), requestedDimensions),
+  const matching = candidates.filter(
+    ({ entry }) =>
+      // Drop any candidate whose price failed to parse to a finite, positive
+      // number. `unitPrice` is `Number(entry.unit_price)` over a Postgres
+      // NUMERIC column, so a corrupt row (`'NaN'::numeric` reads back as the
+      // string "NaN") yields `NaN`. Left in place, such a candidate (a) makes
+      // the `right.entry.unitPrice - left.entry.unitPrice` tie-break return
+      // `NaN` — an inconsistent sort comparator that can non-deterministically
+      // let the corrupt entry WIN over a valid one — and (b) if selected, is
+      // billed via `asDecimal(NaN).mul(quantity)` = a `NaN` charge. Fail closed
+      // by excluding it here so a corrupt price can never be chosen; the caller
+      // then degrades to the fallback tier (provider-max / env default) or
+      // fails closed, exactly as an absent price does. Mirrors the finite guard
+      // in `resolveFallbackTokenRate`.
+      Number.isFinite(entry.unitPrice) &&
+      entry.unitPrice > 0 &&
+      dimensionsAreSubset(normalizePricingDimensions(entry.dimensions), requestedDimensions),
   );
 
   if (matching.length === 0) {

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup-corrupt-price.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup-corrupt-price.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Regression (#13415 fallback-slop): a corrupt persisted catalog price must
+ * never bill a NaN charge through the cost boundary.
+ *
+ * `aiEntryToPrepared` reads `unitPrice = Number(entry.unit_price)` over a
+ * Postgres NUMERIC column; a corrupt row (`'NaN'::numeric` reads back as
+ * "NaN") yields `unitPrice: NaN`. Before the fix, such an entry could reach
+ * `asDecimal(entry.unitPrice).mul(quantity)` (flat path) or
+ * `asDecimal(inputEntry.unitPrice)` (token path) and produce a `NaN` cost that
+ * silently poisons the credit debit / earnings ledger.
+ *
+ * The fix (a) filters non-finite prices out of candidate selection so a corrupt
+ * row can't be chosen, degrading the token side to the provider-max/env
+ * fallback tier, and (b) fails closed with an explicit error at the flat-cost
+ * boundary if a corrupt price ever reaches it. Both are exercised here.
+ *
+ * Both DB seams are mocked; the gateway (live) seam is emptied so only the
+ * seeded persisted catalog is in play.
+ */
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+
+const USD_PER_M = 1_000_000;
+
+type CatalogRow = {
+  billing_source: string;
+  provider: string;
+  model: string;
+  product_family: string;
+  charge_type: string;
+  unit: string;
+  unit_price: string;
+  dimensions: Record<string, unknown>;
+  source_kind: string;
+  source_url: string;
+  fetched_at: Date;
+  stale_after: Date | null;
+  priority: number;
+  is_override: boolean;
+  metadata: Record<string, unknown>;
+};
+
+function row(
+  model: string,
+  chargeType: "input" | "output" | "generation",
+  productFamily: string,
+  unit: string,
+  unitPrice: string,
+): CatalogRow {
+  return {
+    billing_source: "bitrouter",
+    provider: "anthropic",
+    model,
+    product_family: productFamily,
+    charge_type: chargeType,
+    unit,
+    unit_price: unitPrice,
+    dimensions: {},
+    source_kind: "bitrouter_catalog",
+    source_url: "https://example.test/catalog",
+    fetched_at: new Date(),
+    stale_after: null,
+    priority: 200,
+    is_override: false,
+    metadata: {},
+  };
+}
+
+// The exact-model rows for the model under test carry a CORRUPT price ("NaN").
+// A SEPARATE valid, more-expensive model exists for the same provider so the
+// provider-max fallback tier has a real rate to fall back to for the token
+// path.
+const seedCatalog: CatalogRow[] = [
+  // corrupt exact-model rows
+  row("anthropic/corrupt-priced-model", "input", "language", "token", "NaN"),
+  row("anthropic/corrupt-priced-model", "output", "language", "token", "NaN"),
+  // valid fallback rows for the same provider (provider-max upper bound)
+  row("anthropic/claude-opus-4-8", "input", "language", "token", String(5 / USD_PER_M)),
+  row("anthropic/claude-opus-4-8", "output", "language", "token", String(25 / USD_PER_M)),
+  // a corrupt flat (image:generation) row with NO valid sibling -> flat boundary
+  row("anthropic/corrupt-image", "generation", "image", "image", "NaN"),
+];
+
+function matchProviderModelPairs(filters: {
+  billingSource?: string;
+  productFamily?: string;
+  chargeType?: string;
+  pairs: readonly { provider: string; model: string }[];
+}): CatalogRow[] {
+  return seedCatalog.filter(
+    (r) =>
+      (!filters.billingSource || r.billing_source === filters.billingSource) &&
+      (!filters.productFamily || r.product_family === filters.productFamily) &&
+      (!filters.chargeType || r.charge_type === filters.chargeType) &&
+      filters.pairs.some((p) => p.provider === r.provider && p.model === r.model),
+  );
+}
+
+function matchListActive(filters?: {
+  billingSource?: string;
+  provider?: string;
+  productFamily?: string;
+  chargeType?: string;
+  model?: string;
+}): CatalogRow[] {
+  return seedCatalog.filter(
+    (r) =>
+      (!filters?.billingSource || r.billing_source === filters.billingSource) &&
+      (!filters?.provider || r.provider === filters.provider) &&
+      (!filters?.productFamily || r.product_family === filters.productFamily) &&
+      (!filters?.chargeType || r.charge_type === filters.chargeType) &&
+      (!filters?.model || r.model === filters.model),
+  );
+}
+
+const errorSpy = mock((..._args: unknown[]) => {});
+
+mock.module("../../../db/repositories/ai-pricing", () => ({
+  aiPricingRepository: {
+    listActiveEntriesForProviderModelPairs: async (
+      filters: Parameters<typeof matchProviderModelPairs>[0],
+    ) => matchProviderModelPairs(filters),
+    listActiveEntries: async (filters?: Parameters<typeof matchListActive>[0]) =>
+      matchListActive(filters),
+  },
+}));
+mock.module("../../utils/logger", () => ({
+  logger: {
+    warn: mock(() => {}),
+    error: errorSpy,
+  },
+}));
+mock.module("./providers/gateway", () => ({
+  fetchEntriesForSource: async () => [],
+}));
+
+const { calculateTextCostFromCatalog, calculateImageGenerationCostFromCatalog } = await import(
+  "./lookup"
+);
+const { __clearPersistedPricingCache } = await import("./cache");
+
+beforeEach(() => {
+  __clearPersistedPricingCache();
+  delete process.env.AI_PRICING_FALLBACK_INPUT_USD_PER_M;
+  delete process.env.AI_PRICING_FALLBACK_OUTPUT_USD_PER_M;
+  errorSpy.mockClear();
+});
+
+afterEach(() => {
+  delete process.env.AI_PRICING_FALLBACK_INPUT_USD_PER_M;
+  delete process.env.AI_PRICING_FALLBACK_OUTPUT_USD_PER_M;
+});
+
+test("token path: a corrupt exact-model price degrades to provider-max fallback, never NaN", async () => {
+  const result = await calculateTextCostFromCatalog({
+    model: "corrupt-priced-model",
+    provider: "anthropic",
+    inputTokens: 1_000_000,
+    outputTokens: 1_000_000,
+  });
+
+  // The corrupt exact-model rows are dropped at selection, so the token side
+  // falls back to the provider's MOST EXPENSIVE catalogued rate (claude-opus
+  // input 5 / output 25 per million) + 20% markup — a REAL, finite charge.
+  expect(Number.isFinite(result.inputCost)).toBe(true);
+  expect(Number.isFinite(result.outputCost)).toBe(true);
+  expect(Number.isFinite(result.totalCost)).toBe(true);
+  expect(result.inputCost).toBe(6); // 5 * 1M * 1.2
+  expect(result.outputCost).toBe(30); // 25 * 1M * 1.2
+});
+
+test("token path: corrupt exact price + NO valid fallback + no env default => fails closed (never $0/NaN)", async () => {
+  // Isolate a provider whose ONLY row is corrupt so there is no provider-max
+  // fallback either. A non-zero token side must refuse, not bill NaN or $0.
+  const onlyCorrupt: CatalogRow[] = [
+    row("solo/only-corrupt", "input", "language", "token", "NaN"),
+    row("solo/only-corrupt", "output", "language", "token", "NaN"),
+  ];
+  onlyCorrupt.forEach((r) => {
+    r.provider = "solo";
+  });
+  seedCatalog.push(...onlyCorrupt);
+  try {
+    __clearPersistedPricingCache();
+    await expect(
+      calculateTextCostFromCatalog({
+        model: "only-corrupt",
+        provider: "solo",
+        inputTokens: 1000,
+        outputTokens: 500,
+      }),
+    ).rejects.toThrow("refusing to bill unknown-priced inference");
+  } finally {
+    seedCatalog.splice(seedCatalog.length - onlyCorrupt.length, onlyCorrupt.length);
+    __clearPersistedPricingCache();
+  }
+});
+
+test("flat path: a corrupt-only image price fails closed at the cost boundary (never NaN)", async () => {
+  // The flat cost path resolves the corrupt image row (no valid sibling), which
+  // is dropped at selection -> resolvePreparedPricingEntry throws "Pricing
+  // unavailable". Even if a corrupt entry reached computeCostFromEntry, the
+  // defense-in-depth guard throws rather than billing NaN. Either way: no NaN.
+  await expect(
+    calculateImageGenerationCostFromCatalog({
+      model: "corrupt-image",
+      provider: "anthropic",
+      imageCount: 1,
+    }),
+  ).rejects.toThrow(/Pricing unavailable|non-finite rate/);
+});
+
+test("REGRESSION: cost is never returned as NaN for a corrupt catalog price", async () => {
+  // Belt-and-suspenders: prove the old fabricated-NaN outcome is gone. A NaN
+  // result would silently poison the ledger; assert we NEVER get one.
+  const result = await calculateTextCostFromCatalog({
+    model: "corrupt-priced-model",
+    provider: "anthropic",
+    inputTokens: 500,
+    outputTokens: 250,
+  });
+  expect(Number.isNaN(result.totalCost)).toBe(false);
+  expect(Number.isNaN(result.inputCost)).toBe(false);
+  expect(Number.isNaN(result.outputCost)).toBe(false);
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup-corrupt-price.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup-corrupt-price.test.ts
@@ -222,3 +222,28 @@ test("REGRESSION: cost is never returned as NaN for a corrupt catalog price", as
   expect(Number.isNaN(result.inputCost)).toBe(false);
   expect(Number.isNaN(result.outputCost)).toBe(false);
 });
+
+test("REGRESSION: a negative catalog price never returns a negative charge", async () => {
+  const negativeOnly: CatalogRow[] = [
+    row("solo/negative-price", "input", "language", "token", "-0.000001"),
+    row("solo/negative-price", "output", "language", "token", "-0.000002"),
+  ];
+  negativeOnly.forEach((r) => {
+    r.provider = "solo";
+  });
+  seedCatalog.push(...negativeOnly);
+  try {
+    __clearPersistedPricingCache();
+    await expect(
+      calculateTextCostFromCatalog({
+        model: "negative-price",
+        provider: "solo",
+        inputTokens: 1000,
+        outputTokens: 500,
+      }),
+    ).rejects.toThrow("refusing to bill unknown-priced inference");
+  } finally {
+    seedCatalog.splice(seedCatalog.length - negativeOnly.length, negativeOnly.length);
+    __clearPersistedPricingCache();
+  }
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup-corrupt-price.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup-corrupt-price.test.ts
@@ -78,6 +78,7 @@ const seedCatalog: CatalogRow[] = [
   row("anthropic/claude-opus-4-8", "output", "language", "token", String(25 / USD_PER_M)),
   // a corrupt flat (image:generation) row with NO valid sibling -> flat boundary
   row("anthropic/corrupt-image", "generation", "image", "image", "NaN"),
+  row("anthropic/valid-image", "generation", "image", "image", "0.05"),
 ];
 
 function matchProviderModelPairs(filters: {
@@ -195,11 +196,10 @@ test("token path: corrupt exact price + NO valid fallback + no env default => fa
   }
 });
 
-test("flat path: a corrupt-only image price fails closed at the cost boundary (never NaN)", async () => {
-  // The flat cost path resolves the corrupt image row (no valid sibling), which
-  // is dropped at selection -> resolvePreparedPricingEntry throws "Pricing
-  // unavailable". Even if a corrupt entry reached computeCostFromEntry, the
-  // defense-in-depth guard throws rather than billing NaN. Either way: no NaN.
+test("flat path: a corrupt-only image price fails closed before billing (never NaN)", async () => {
+  // The corrupt image row is dropped at selection, so
+  // resolvePreparedPricingEntry throws "Pricing unavailable" before any ledger
+  // math. The selected-row test below covers the cost-boundary quantity guard.
   await expect(
     calculateImageGenerationCostFromCatalog({
       model: "corrupt-image",
@@ -207,6 +207,38 @@ test("flat path: a corrupt-only image price fails closed at the cost boundary (n
       imageCount: 1,
     }),
   ).rejects.toThrow(/Pricing unavailable|non-finite rate/);
+});
+
+test("token path: a corrupt input token quantity fails closed before multiplication", async () => {
+  await expect(
+    calculateTextCostFromCatalog({
+      model: "corrupt-priced-model",
+      provider: "anthropic",
+      inputTokens: Number.NaN,
+      outputTokens: 1,
+    }),
+  ).rejects.toThrow("refusing to bill an invalid quantity");
+});
+
+test("token path: a negative output token quantity fails closed before multiplication", async () => {
+  await expect(
+    calculateTextCostFromCatalog({
+      model: "corrupt-priced-model",
+      provider: "anthropic",
+      inputTokens: 1,
+      outputTokens: -1,
+    }),
+  ).rejects.toThrow("refusing to bill an invalid quantity");
+});
+
+test("flat path: a selected image row with a corrupt quantity fails closed at the cost boundary", async () => {
+  await expect(
+    calculateImageGenerationCostFromCatalog({
+      model: "valid-image",
+      provider: "anthropic",
+      imageCount: Number.NaN,
+    }),
+  ).rejects.toThrow("refusing to bill an invalid quantity");
 });
 
 test("REGRESSION: cost is never returned as NaN for a corrupt catalog price", async () => {

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
@@ -277,6 +277,27 @@ async function resolveFallbackTokenRate(params: {
 }
 
 function computeCostFromEntry(entry: PreparedPricingEntry, quantity: number): FlatOperationCost {
+  // Defense-in-depth money-boundary guard. Candidate selection already drops
+  // non-finite prices (see `chooseBestCandidatePricingEntry`), so a resolved
+  // entry reaching here should always carry a real price. Re-assert it anyway:
+  // `asDecimal(NaN).mul(quantity)` silently yields a `NaN` charge that then
+  // poisons the credit debit / earnings ledger with no error. If a corrupt
+  // price ever reaches this sink via any future path, fail closed with an
+  // explicit error the caller surfaces (5xx / refuse) rather than billing NaN.
+  if (!Number.isFinite(entry.unitPrice)) {
+    logger.error("ai-pricing: refusing to bill a non-finite catalog price", {
+      provider: entry.provider,
+      model: entry.model,
+      productFamily: entry.productFamily,
+      chargeType: entry.chargeType,
+      unit: entry.unit,
+      unitPrice: entry.unitPrice,
+    });
+    throw new Error(
+      `Corrupt catalog price for ${entry.productFamily}:${entry.chargeType} ${entry.provider}/${entry.model}; refusing to bill a non-finite rate`,
+    );
+  }
+
   const baseCost = asDecimal(entry.unitPrice).mul(quantity);
   const markedUp = applyPlatformMarkup(baseCost);
 
@@ -412,12 +433,47 @@ export async function calculateTextCostFromCatalog(params: {
     ? null
     : await resolveMissingSide("output", params.outputTokens);
 
-  const inputUnitPrice = inputEntry
-    ? asDecimal(inputEntry.unitPrice)
-    : asDecimal(inputFallback?.unitPrice ?? 0);
-  const outputUnitPrice = outputEntry
-    ? asDecimal(outputEntry.unitPrice)
-    : asDecimal(outputFallback?.unitPrice ?? 0);
+  // Defense-in-depth money-boundary guard mirroring `computeCostFromEntry`.
+  // Candidate selection already drops non-finite catalog prices, but the token
+  // path builds the Decimal directly rather than going through that sink, so
+  // re-assert finiteness before `asDecimal(...).mul(tokens)` — a `NaN` unit
+  // price would otherwise bill `NaN` inference silently. A zero-token side
+  // costs $0 at any rate, so only a side that actually bills tokens fails
+  // closed on a corrupt resolved price.
+  const resolveTokenUnitPrice = (
+    chargeType: "input" | "output",
+    entry: PreparedPricingEntry | null,
+    fallback: FallbackTokenRate | null,
+    tokens: number,
+  ) => {
+    const unitPrice = entry ? entry.unitPrice : (fallback?.unitPrice ?? 0);
+    if (tokens > 0 && !Number.isFinite(unitPrice)) {
+      logger.error("ai-pricing: refusing to bill a non-finite token price", {
+        canonicalModel,
+        provider: params.provider,
+        billingSource: params.billingSource,
+        chargeType,
+        unitPrice,
+      });
+      throw new Error(
+        `Corrupt catalog price for ${productFamily}:${chargeType} ${canonicalModel}; refusing to bill a non-finite rate`,
+      );
+    }
+    return asDecimal(unitPrice);
+  };
+
+  const inputUnitPrice = resolveTokenUnitPrice(
+    "input",
+    inputEntry,
+    inputFallback,
+    params.inputTokens,
+  );
+  const outputUnitPrice = resolveTokenUnitPrice(
+    "output",
+    outputEntry,
+    outputFallback,
+    params.outputTokens,
+  );
 
   const baseInputCost = inputUnitPrice.mul(params.inputTokens);
   const baseOutputCost = outputUnitPrice.mul(params.outputTokens);

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
@@ -163,6 +163,30 @@ const FALLBACK_RATE_ENV_BY_CHARGE_TYPE: Record<"input" | "output", string> = {
   output: "AI_PRICING_FALLBACK_OUTPUT_USD_PER_M",
 };
 
+function assertBillableQuantity(params: {
+  quantity: number;
+  scope: string;
+  provider: string;
+  model: string;
+  productFamily: PricingProductFamily;
+  chargeType: string;
+}) {
+  if (Number.isFinite(params.quantity) && params.quantity >= 0) {
+    return;
+  }
+  logger.error("ai-pricing: refusing to bill an invalid quantity", {
+    provider: params.provider,
+    model: params.model,
+    productFamily: params.productFamily,
+    chargeType: params.chargeType,
+    scope: params.scope,
+    quantity: params.quantity,
+  });
+  throw new Error(
+    `Corrupt billing quantity for ${params.productFamily}:${params.chargeType} ${params.provider}/${params.model}; refusing to bill an invalid quantity`,
+  );
+}
+
 /** Env-configured default rate (USD per million tokens) → per-token unit price. */
 function envFallbackTokenUnitPrice(chargeType: "input" | "output"): number | null {
   const envName = FALLBACK_RATE_ENV_BY_CHARGE_TYPE[chargeType];
@@ -298,6 +322,14 @@ function computeCostFromEntry(entry: PreparedPricingEntry, quantity: number): Fl
       `Corrupt catalog price for ${entry.productFamily}:${entry.chargeType} ${entry.provider}/${entry.model}; refusing to bill an invalid rate`,
     );
   }
+  assertBillableQuantity({
+    quantity,
+    scope: "flat",
+    provider: entry.provider,
+    model: entry.model,
+    productFamily: entry.productFamily,
+    chargeType: entry.chargeType,
+  });
 
   const baseCost = asDecimal(entry.unitPrice).mul(quantity);
   const markedUp = applyPlatformMarkup(baseCost);
@@ -364,6 +396,22 @@ export async function calculateTextCostFromCatalog(params: {
   const productFamily: PricingProductFamily = params.model.includes("embedding")
     ? "embedding"
     : "language";
+  assertBillableQuantity({
+    quantity: params.inputTokens,
+    scope: "inputTokens",
+    provider: params.provider,
+    model: canonicalModel,
+    productFamily,
+    chargeType: "input",
+  });
+  assertBillableQuantity({
+    quantity: params.outputTokens,
+    scope: "outputTokens",
+    provider: params.provider,
+    model: canonicalModel,
+    productFamily,
+    chargeType: "output",
+  });
   // Both lookups degrade to null on a catalog miss. A missing INPUT price used
   // to throw uncaught here (the OUTPUT lookup was already guarded), and the
   // throw propagated through calculateCost → the chat-completions reserve →

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
@@ -278,14 +278,15 @@ async function resolveFallbackTokenRate(params: {
 
 function computeCostFromEntry(entry: PreparedPricingEntry, quantity: number): FlatOperationCost {
   // Defense-in-depth money-boundary guard. Candidate selection already drops
-  // non-finite prices (see `chooseBestCandidatePricingEntry`), so a resolved
+  // non-finite/non-positive prices (see `chooseBestCandidatePricingEntry`), so a resolved
   // entry reaching here should always carry a real price. Re-assert it anyway:
-  // `asDecimal(NaN).mul(quantity)` silently yields a `NaN` charge that then
-  // poisons the credit debit / earnings ledger with no error. If a corrupt
+  // `asDecimal(NaN).mul(quantity)` silently yields a `NaN` charge; a negative
+  // price creates a negative debit. Either poisons the credit debit / earnings
+  // ledger with no error. If a corrupt
   // price ever reaches this sink via any future path, fail closed with an
   // explicit error the caller surfaces (5xx / refuse) rather than billing NaN.
-  if (!Number.isFinite(entry.unitPrice)) {
-    logger.error("ai-pricing: refusing to bill a non-finite catalog price", {
+  if (!Number.isFinite(entry.unitPrice) || entry.unitPrice <= 0) {
+    logger.error("ai-pricing: refusing to bill an invalid catalog price", {
       provider: entry.provider,
       model: entry.model,
       productFamily: entry.productFamily,
@@ -294,7 +295,7 @@ function computeCostFromEntry(entry: PreparedPricingEntry, quantity: number): Fl
       unitPrice: entry.unitPrice,
     });
     throw new Error(
-      `Corrupt catalog price for ${entry.productFamily}:${entry.chargeType} ${entry.provider}/${entry.model}; refusing to bill a non-finite rate`,
+      `Corrupt catalog price for ${entry.productFamily}:${entry.chargeType} ${entry.provider}/${entry.model}; refusing to bill an invalid rate`,
     );
   }
 
@@ -434,12 +435,12 @@ export async function calculateTextCostFromCatalog(params: {
     : await resolveMissingSide("output", params.outputTokens);
 
   // Defense-in-depth money-boundary guard mirroring `computeCostFromEntry`.
-  // Candidate selection already drops non-finite catalog prices, but the token
+  // Candidate selection already drops non-finite/non-positive catalog prices, but the token
   // path builds the Decimal directly rather than going through that sink, so
   // re-assert finiteness before `asDecimal(...).mul(tokens)` — a `NaN` unit
-  // price would otherwise bill `NaN` inference silently. A zero-token side
-  // costs $0 at any rate, so only a side that actually bills tokens fails
-  // closed on a corrupt resolved price.
+  // price would otherwise bill `NaN` inference silently, and a negative price
+  // would credit the caller. A zero-token side costs $0 at any rate, so only a
+  // side that actually bills tokens fails closed on a corrupt resolved price.
   const resolveTokenUnitPrice = (
     chargeType: "input" | "output",
     entry: PreparedPricingEntry | null,
@@ -447,8 +448,8 @@ export async function calculateTextCostFromCatalog(params: {
     tokens: number,
   ) => {
     const unitPrice = entry ? entry.unitPrice : (fallback?.unitPrice ?? 0);
-    if (tokens > 0 && !Number.isFinite(unitPrice)) {
-      logger.error("ai-pricing: refusing to bill a non-finite token price", {
+    if (tokens > 0 && (!Number.isFinite(unitPrice) || unitPrice <= 0)) {
+      logger.error("ai-pricing: refusing to bill an invalid token price", {
         canonicalModel,
         provider: params.provider,
         billingSource: params.billingSource,
@@ -456,7 +457,7 @@ export async function calculateTextCostFromCatalog(params: {
         unitPrice,
       });
       throw new Error(
-        `Corrupt catalog price for ${productFamily}:${chargeType} ${canonicalModel}; refusing to bill a non-finite rate`,
+        `Corrupt catalog price for ${productFamily}:${chargeType} ${canonicalModel}; refusing to bill an invalid rate`,
       );
     }
     return asDecimal(unitPrice);


### PR DESCRIPTION
## What

`aiEntryToPrepared` builds `unitPrice = Number(entry.unit_price)` over a Postgres NUMERIC column. A corrupt row (`'NaN'::numeric` is a valid Postgres NUMERIC that reads back as the string `"NaN"`) yields a pricing candidate whose `unitPrice` is `NaN`. Before this fix, `chooseBestCandidatePricingEntry`:

1. did **not** filter such a candidate out, and
2. used `right.entry.unitPrice - left.entry.unitPrice` as a tie-break, which returns `NaN` for a corrupt entry — an **inconsistent sort comparator** that can non-deterministically let the corrupt entry **win** over a valid one —

after which `asDecimal(NaN).mul(quantity)` silently bills a **`NaN` charge** that poisons the credit debit / earnings ledger. The finite guard existed **only** in `resolveFallbackTokenRate`, never on the primary exact-model selection → cost path (`calculateTextCostFromCatalog` and the flat `computeCostFromEntry` sink used by image/video/music/sfx/tts/stt/voice-clone).

This is the same NUMERIC fail-open class as the merged #13415 slices #13454/#13474/#13482/#13486/#13503/#13504/#13508/#13518, on a distinct file (`ai-pricing/lookup.ts` + `candidate-selection.ts`).

## Fix (two-layer fail-closed)

- **`candidate-selection.ts`** — drop any candidate whose `unitPrice` is not a finite, positive number *before* the tie-break sort, mirroring the existing guard in `resolveFallbackTokenRate`. A corrupt-only match now returns `null`, so the caller degrades to the provider-max / env fallback tier (or fails closed) exactly as an **absent** price does, instead of billing a `NaN` rate. Also removes the NaN-comparator mis-order.
- **`lookup.ts`** — defense-in-depth guards at the shared money boundaries: `computeCostFromEntry` (flat sink) and `calculateTextCostFromCatalog` (token path) re-assert finiteness and throw an explicit, caller-surfaced error (→ 5xx / refuse) rather than billing `NaN` if a corrupt price ever reaches the boundary via any future path.

## Tests

- `candidate-selection-numeric.test.ts` (5, pure selection): corrupt entry never selected, valid wins over higher-priority corrupt, corrupt-only → null (fail closed), 0/-1/Infinity/NaN all dropped, healthy tie-break unchanged, NaN-comparator regression both orderings.
- `lookup-corrupt-price.test.ts` (4, end-to-end): token path degrades a corrupt exact price to provider-max fallback (finite charge, never NaN); corrupt + no fallback + no env default → fails closed (never $0/NaN); flat image path fails closed at the boundary; belt-and-suspenders "cost is never NaN".

**9/9 green, REVERSION-PROVEN** (8 of 9 fail on pristine source, the healthy control passes). Existing `ai-pricing` fallback/missing/error-policy suites unchanged (23/23 together). `tsc` **0 errors in touched files** (4 pre-existing baseline errs in `node-redis-adapter`/`plugin-mcp/json`/`anthropic-web-search`, identical on develop). biome clean. error-policy-ratchet: no new fallback-slop.

## Collision

No open/closed PR touches `lookup.ts`/`candidate-selection.ts` on #13415 scope (#13952 was test-only error-path coverage on the `.error-policy.test.ts` files). No merged dup since base. No lalalune/NubsCarson/roninjin10 ai-pricing PR in the last day on this scope. Unique worktree path. Forbidden files untouched. Issue stays open for remaining service-layer inventory.

— [sol-orch]