### PR TITLE
refactor(ui): Tasks — uniform ViewHeader, panel header dedup, no CTAs (#13565)

### DIFF
--- a/packages/ui/src/components/pages/TasksPageView.test.tsx
+++ b/packages/ui/src/components/pages/TasksPageView.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+//
+// Structural tests for TasksPageView (#13565, views-redesign epic): the Tasks
+// nav tab hosts the coding-agent tasks panel under the shared, uniform
+// `ViewHeader`. We assert (a) the shell `ViewHeader` renders with the centered
+// "Tasks" title and its icon-only back button, and (b) the panel is mounted in
+// `fullPage` mode so it suppresses its own internal title row (one header per
+// view, no duplicate heading). The panel + shell surface are mocked to isolate
+// the host's composition from the panel's data behavior.
+import { cleanup, render, screen, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const panelProps = vi.hoisted(() => ({ value: null as Record<string, unknown> | null }));
+
+vi.mock("../views/ShellViewAgentSurface", () => ({
+  ShellViewAgentSurface: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+// The slot indirection resolves to the real coding-agent panel at runtime; here
+// we stub it so the test asserts what props the host passes, not panel internals.
+vi.mock("../../slots/task-coordinator-slots.js", () => ({
+  CodingAgentTasksPanel: (props: Record<string, unknown>) => {
+    panelProps.value = props;
+    return <div data-testid="coding-agent-tasks-panel-stub" />;
+  },
+}));
+
+import { TasksPageView } from "./TasksPageView";
+
+afterEach(() => {
+  cleanup();
+  panelProps.value = null;
+});
+
+describe("TasksPageView", () => {
+  it("renders the shared ViewHeader with a centered 'Tasks' title", () => {
+    render(<TasksPageView />);
+    const header = screen.getByTestId("view-header");
+    expect(header).toBeTruthy();
+    // The heading text lives in the ViewHeader's <h1>, not the panel.
+    const heading = within(header).getByRole("heading", { level: 1 });
+    expect(heading.textContent).toBe("Tasks");
+  });
+
+  it("exposes the icon-only launcher back control from the header", () => {
+    render(<TasksPageView />);
+    // ViewBackButton is aria-labeled and icon-only (no visible text label).
+    const back = screen.getByRole("button", { name: /back to launcher/i });
+    expect(back).toBeTruthy();
+    expect(back.textContent?.trim()).toBe("");
+  });
+
+  it("mounts the tasks panel in fullPage mode (panel suppresses its own header)", () => {
+    render(<TasksPageView />);
+    expect(screen.getByTestId("coding-agent-tasks-panel-stub")).toBeTruthy();
+    expect(panelProps.value).toMatchObject({ fullPage: true });
+  });
+
+  it("wraps the view with the tasks-view test id", () => {
+    render(<TasksPageView />);
+    expect(screen.getByTestId("tasks-view")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/pages/TasksPageView.tsx
+++ b/packages/ui/src/components/pages/TasksPageView.tsx
@@ -1,22 +1,31 @@
 /**
- * Hosts the full-page task coordinator panel inside the Tasks shell view
- * without duplicating the panel's own header or empty state.
+ * Tasks — a top-level nav view that hosts the full-page task coordinator panel
+ * under the shared, uniform `ViewHeader` (icon-only back + centered "Tasks"),
+ * matching every other top-level view in the views-redesign epic (#13560).
+ *
+ * The shell header owns the back affordance and the title, so the panel is
+ * mounted in its `fullPage` mode with its own internal title row suppressed —
+ * one header per view, no duplication.
  */
 import { CodingAgentTasksPanel } from "../../slots/task-coordinator-slots.js";
+import { ViewHeader } from "../shared/ViewHeader";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 
 /**
- * The Tasks nav tab. A thin host — the panel owns its own header, filters, and
- * empty state, so this wrapper adds no second heading or explanatory prose.
+ * The Tasks nav tab. The shared `ViewHeader` supplies the uniform top bar; the
+ * panel renders its filters + list beneath it without a second heading.
  */
 export function TasksPageView() {
   return (
     <ShellViewAgentSurface viewId="tasks">
       <div
-        className="device-layout mx-auto flex h-full w-full max-w-4xl flex-col"
+        className="flex h-full min-h-0 w-full flex-col"
         data-testid="tasks-view"
       >
-        <CodingAgentTasksPanel fullPage />
+        <ViewHeader title="Tasks" />
+        <div className="device-layout mx-auto flex min-h-0 w-full min-w-0 max-w-4xl flex-1 flex-col">
+          <CodingAgentTasksPanel fullPage />
+        </div>
       </div>
     </ShellViewAgentSurface>
   );

--- a/plugins/plugin-task-coordinator/__tests__/unit/CodingAgentTasksPanel.test.tsx
+++ b/plugins/plugin-task-coordinator/__tests__/unit/CodingAgentTasksPanel.test.tsx
@@ -397,6 +397,50 @@ describe("CodingAgentTasksPanel — list", () => {
   });
 });
 
+// #13565: in `fullPage` mode the Tasks nav view hosts this panel UNDER the
+// shared, uniform `ViewHeader` (icon-only back + centered "Tasks"). The panel
+// therefore drops its own internal title row (no duplicate heading) and renders
+// a designed-empty state with NO suggestion/create CTAs — the proactive-greeting
+// child offers to start a task in chat instead. The embedded (default) mode
+// keeps its own header + recommendation chips for the surfaces that have no chat
+// rail, which the tests above already cover.
+describe("CodingAgentTasksPanel — fullPage (uniform header host)", () => {
+  it("renders NO internal <h1> title row (the shell ViewHeader owns the title)", async () => {
+    listCodingAgentTaskThreads.mockResolvedValue([ACTIVE_THREAD, DONE_THREAD]);
+    const { container } = render(<CodingAgentTasksPanel fullPage />);
+    await screen.findByText("Fix the broken CI build");
+    expect(container.querySelector("h1")).toBeNull();
+    // The counts survive as a lightweight secondary meta strip instead.
+    expect(screen.getByTestId("task-count-strip")).toBeTruthy();
+  });
+
+  it("the default (embedded) mode STILL renders its own <h1> header", async () => {
+    listCodingAgentTaskThreads.mockResolvedValue([ACTIVE_THREAD, DONE_THREAD]);
+    const { container } = render(<CodingAgentTasksPanel />);
+    await screen.findByText("Fix the broken CI build");
+    const heading = container.querySelector("h1");
+    expect(heading?.textContent).toBe("Coding Tasks");
+  });
+
+  it("the fullPage empty state has NO suggestion/create CTA buttons", async () => {
+    listCodingAgentTaskThreads.mockResolvedValue([]);
+    render(<CodingAgentTasksPanel fullPage />);
+    const empty = await screen.findByTestId("task-empty-state");
+    expect(within(empty).queryAllByRole("button")).toHaveLength(0);
+    // The quiet designed-empty title still names the state.
+    expect(screen.getByText("No coding tasks yet.")).toBeTruthy();
+  });
+
+  it("the default (embedded) empty state KEEPS its recommendation chips", async () => {
+    listCodingAgentTaskThreads.mockResolvedValue([]);
+    render(<CodingAgentTasksPanel />);
+    const empty = await screen.findByTestId("task-empty-state");
+    expect(
+      within(empty).getAllByRole("button").length,
+    ).toBeGreaterThan(0);
+  });
+});
+
 describe("CodingAgentTasksPanel — controls", () => {
   it("typing in search re-fetches the thread list with that search term", async () => {
     listCodingAgentTaskThreads.mockResolvedValue([ACTIVE_THREAD]);

--- a/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx
@@ -10,7 +10,6 @@ import {
   useAppSelectorShallow,
 } from "@elizaos/ui";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
-import { ViewBackButton } from "@elizaos/ui/components";
 import { Archive, Bot, ListChecks, Terminal } from "lucide-react";
 import {
   type ReactNode,
@@ -871,28 +870,49 @@ export function CodingAgentTasksPanel({
       className="relative flex h-full min-h-0 w-full flex-col gap-3 overflow-y-auto bg-bg px-4 pb-28 pt-4 text-txt"
       data-testid="task-coordinator-panel"
     >
-      <TaskListHeader
-        leading={fullPage ? <ViewBackButton /> : null}
-        icon={<ListChecks className="h-5 w-5" />}
-        title={t("taskseventspanel.Tasks", { defaultValue: "Coding Tasks" })}
-        counts={
-          threads.length > 0 ? (
-            <>
-              <TaskCountChip value={threads.length} label="total" />
-              {activeCount > 0 ? (
-                <TaskCountChip
-                  value={activeCount}
-                  label="active"
-                  tone="active"
-                />
-              ) : null}
-              {doneCount > 0 ? (
-                <TaskCountChip value={doneCount} label="done" tone="accent" />
-              ) : null}
-            </>
-          ) : null
-        }
-      />
+      {fullPage ? (
+        // The shell `ViewHeader` (icon-only back + centered "Tasks") owns this
+        // view's top bar, so the panel drops its own title/back row to avoid a
+        // second heading (#13565). The counts survive as a lightweight,
+        // left-aligned meta strip that mirrors the SectionNav secondary-row
+        // geometry beneath the uniform header.
+        threads.length > 0 ? (
+          <div
+            className="flex flex-wrap items-center gap-x-3 gap-y-1 px-1"
+            data-testid="task-count-strip"
+          >
+            <TaskCountChip value={threads.length} label="total" />
+            {activeCount > 0 ? (
+              <TaskCountChip value={activeCount} label="active" tone="active" />
+            ) : null}
+            {doneCount > 0 ? (
+              <TaskCountChip value={doneCount} label="done" tone="accent" />
+            ) : null}
+          </div>
+        ) : null
+      ) : (
+        <TaskListHeader
+          icon={<ListChecks className="h-5 w-5" />}
+          title={t("taskseventspanel.Tasks", { defaultValue: "Coding Tasks" })}
+          counts={
+            threads.length > 0 ? (
+              <>
+                <TaskCountChip value={threads.length} label="total" />
+                {activeCount > 0 ? (
+                  <TaskCountChip
+                    value={activeCount}
+                    label="active"
+                    tone="active"
+                  />
+                ) : null}
+                {doneCount > 0 ? (
+                  <TaskCountChip value={doneCount} label="done" tone="accent" />
+                ) : null}
+              </>
+            ) : null
+          }
+        />
+      )}
 
       {threads.length > 0 || loading ? (
         <div className="flex items-center gap-2">
@@ -910,7 +930,7 @@ export function CodingAgentTasksPanel({
             onClick={() => setShowArchived((value) => !value)}
             aria-pressed={showArchived}
             data-testid="task-show-archived"
-            className={`inline-flex h-9 items-center gap-2 rounded-xl border px-3 text-xs font-medium transition-colors ${
+            className={`inline-flex h-9 min-h-11 items-center gap-2 rounded-xl border px-3 text-xs font-medium transition-colors ${
               showArchived
                 ? "border-accent/40 bg-accent-subtle text-accent"
                 : "border-border/50 bg-bg-accent/30 text-muted hover:text-txt"
@@ -972,21 +992,30 @@ export function CodingAgentTasksPanel({
                   defaultValue: "No coding tasks yet.",
                 })
           }
-          recommendations={[
-            t("codingagenttaskspanel.empty.rec.fixBug", {
-              defaultValue: "Dispatch a coding agent to fix a failing test",
-            }),
-            t("codingagenttaskspanel.empty.rec.addFeature", {
-              defaultValue: "Have a coding agent add a small feature",
-            }),
-            backendAbsent
-              ? t("codingagenttaskspanel.empty.rec.setup", {
-                  defaultValue: "Help me set up coding agents",
-                })
-              : t("codingagenttaskspanel.empty.rec.refactor", {
-                  defaultValue: "Ask a coding agent to refactor a file",
-                }),
-          ]}
+          // Full-page Tasks is a designed-empty surface (#13565): no
+          // suggestion/create CTAs here — the proactive-greeting child offers
+          // to start a task in chat, so the empty state stays a quiet glyph +
+          // one line. The embedded (non-fullPage) panel keeps its recommendation
+          // chips for the spatial/coordinator surfaces that have no chat rail.
+          recommendations={
+            fullPage
+              ? undefined
+              : [
+                  t("codingagenttaskspanel.empty.rec.fixBug", {
+                    defaultValue: "Dispatch a coding agent to fix a failing test",
+                  }),
+                  t("codingagenttaskspanel.empty.rec.addFeature", {
+                    defaultValue: "Have a coding agent add a small feature",
+                  }),
+                  backendAbsent
+                    ? t("codingagenttaskspanel.empty.rec.setup", {
+                        defaultValue: "Help me set up coding agents",
+                      })
+                    : t("codingagenttaskspanel.empty.rec.refactor", {
+                        defaultValue: "Ask a coding agent to refactor a file",
+                      }),
+                ]
+          }
         />
       )}
     </div>

--- a/plugins/plugin-task-coordinator/src/TaskCardList.tsx
+++ b/plugins/plugin-task-coordinator/src/TaskCardList.tsx
@@ -306,9 +306,8 @@ export function TaskListHeader({
   title: string;
   counts: ReactNode;
   action?: ReactNode;
-  /** Optional control rendered flush-left before the icon — the full-page
-   *  Tasks view passes the shared back-to-launcher button here so its header
-   *  chrome matches the other top-level views. */
+  /** Optional control rendered flush-left before the icon (e.g. a back
+   *  affordance) for hosts whose surface has no outer header of its own. */
   leading?: ReactNode;
 }) {
   return (


### PR DESCRIPTION
Closes #13565 (part of the #13560 views-redesign epic).

## What

Presentation pass on the Tasks view — adopt the epic's **uniform top bar** and dedup the panel's internal header, matching the pattern established by #13586 (`ViewHeader` everywhere) and `KnowledgeView`.

- **`TasksPageView`** now mounts the shared `ViewHeader` (icon-only launcher back + centered **"Tasks"**) above the hosted panel, exactly like `KnowledgeView`/`WalletSectionNav`/`SettingsView` in this epic. Keeps the `device-layout` content wrapper.
- **`CodingAgentTasksPanel` (fullPage)** drops its own `TaskListHeader` title/back row — the shell header owns the title now, so there's no duplicate heading. The task counts survive as a lightweight, left-aligned secondary meta strip (`data-testid="task-count-strip"`) mirroring the SectionNav secondary-row geometry.
- **Empty state (fullPage)** becomes a designed-empty surface: **no suggestion/create CTAs** (the proactive-greeting child offers to start a task in chat). The embedded (non-fullPage) panel keeps its own header + recommendation chips for the spatial/coordinator surfaces that have no chat rail.
- **Mobile-first:** filter-row archived toggle bumped to `min-h-11` touch target.

Doctrine: lucide-react icons only, design tokens (no raw hex), no purple/blue, no backdrop-blur, orange accent only. Minimal diff — the embedded/spatial panel behavior is unchanged (gated on `fullPage`).

## Acceptance criteria

- [x] Shared `ViewHeader` (bare-icon back, centered "Tasks") mounted in `TasksPageView`; panel-internal title row stripped in fullPage.
- [x] Filters kept as the secondary row beneath the header (search + archived toggle).
- [x] Create/suggestion CTAs removed from the fullPage empty state → designed-empty render only.
- [x] Mobile touch-target pass on the filter row (`min-h-11`), single-column list unchanged.
- [x] Tasks remains ONE surface — no parallel task UI introduced (embedded/spatial panel path untouched).
- [x] Unit: `TasksPageView` renders `ViewHeader`; fullPage panel renders no internal `<h1>`; fullPage empty state has no CTA buttons.

_e2e walkthrough + scenario (proactive greeting on VIEW_SWITCHED→tasks, view-scoped create-task via interact bridge) + `audit:app` verdicts are follow-ups tracked on the epic; this child is the presentation pass on what ships today._

## Test output

`packages/ui` — `TasksPageView.test.tsx`:
```
 ✓ src/components/pages/TasksPageView.test.tsx (4 tests)
   ✓ renders the shared ViewHeader with a centered 'Tasks' title
   ✓ exposes the icon-only launcher back control from the header
   ✓ mounts the tasks panel in fullPage mode (panel suppresses its own header)
   ✓ wraps the view with the tasks-view test id
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

`plugins/plugin-task-coordinator` — `CodingAgentTasksPanel.test.tsx` (9 existing + 4 new):
```
 ✓ __tests__/unit/CodingAgentTasksPanel.test.tsx (13 tests)
   ✓ fullPage: renders NO internal <h1> title row (+ count strip present)
   ✓ default (embedded): STILL renders its own <h1> "Coding Tasks" header
   ✓ fullPage empty state has NO suggestion/create CTA buttons
   ✓ default (embedded) empty state KEEPS its recommendation chips
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Typecheck: no new errors reference the touched files (pre-existing cross-package resolution noise in the monorepo only).

🤖 authored by Sol — [sol-orch]
