### PR TITLE
fix(#13415): fail closed on corrupt credit_balance in MCP withCredits gate

### DIFF
--- a/packages/cloud/shared/src/lib/mcp/helpers.ts
+++ b/packages/cloud/shared/src/lib/mcp/helpers.ts
@@ -37,6 +37,7 @@ import { getCachedOrganization } from "../cache/organizations-cache";
 import { creditsService } from "../services/credits";
 import type { UserWithOrganization } from "../types";
 import { logger } from "../utils/logger";
+import { parseMcpCreditBalance } from "./withcredits-numeric";
 
 /**
  * MCP Tool Execution Context
@@ -172,8 +173,15 @@ export function withCredits<TParams, TResult>(
       }
     }
 
-    // Check balance before deducting
-    if (Number(context.org.credit_balance) < toolCost) {
+    // Check balance before deducting.
+    // Fail closed on a corrupt NUMERIC credit_balance (#13415): a bare
+    // `Number(...) < toolCost` reads a corrupt `'NaN'::numeric` value back as
+    // `NaN`, and `NaN < toolCost` is `false`, so the gate is bypassed and the
+    // PAID tool runs free. parseMcpCreditBalance throws on a non-parseable
+    // balance so the corruption denies the call instead of authorizing it.
+    // error-policy:J1
+    const availableCredits = parseMcpCreditBalance(context.org.credit_balance);
+    if (availableCredits < toolCost) {
       throw new Error(
         options.insufficientCreditsMessage ||
           `Insufficient credits. Required: ${toolCost}, Available: ${context.org.credit_balance}`,

--- a/packages/cloud/shared/src/lib/mcp/withcredits-numeric.test.ts
+++ b/packages/cloud/shared/src/lib/mcp/withcredits-numeric.test.ts
@@ -52,6 +52,12 @@ describe("parseMcpCreditBalance", () => {
     } catch (err) {
       expect(err).toBeInstanceOf(CorruptMcpCreditBalanceError);
       expect((err as CorruptMcpCreditBalanceError).rawValue).toBe("NaN");
+      expect((err as CorruptMcpCreditBalanceError).code).toBe("CORRUPT_MCP_CREDIT_BALANCE");
+      expect((err as CorruptMcpCreditBalanceError).context).toEqual({
+        rawValue: "NaN",
+        reason: "value is not a valid NUMERIC",
+      });
+      expect((err as CorruptMcpCreditBalanceError).severity).toBe("fatal");
     }
   });
 

--- a/packages/cloud/shared/src/lib/mcp/withcredits-numeric.test.ts
+++ b/packages/cloud/shared/src/lib/mcp/withcredits-numeric.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Exercises the fail-closed NUMERIC boundary for the MCP `withCredits()` balance
+ * pre-check (#13415) and pins the money-out fail-open regression it closes: a
+ * corrupt `'NaN'::numeric` credit_balance must DENY a paid tool call, never let
+ * it run free.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import type { MCPToolContext } from "./helpers";
+import { withCredits } from "./helpers";
+import { CorruptMcpCreditBalanceError, parseMcpCreditBalance } from "./withcredits-numeric";
+
+describe("parseMcpCreditBalance", () => {
+  test("parses a well-formed NUMERIC string", () => {
+    expect(parseMcpCreditBalance("10.5000")).toBe(10.5);
+    expect(parseMcpCreditBalance("100")).toBe(100);
+    expect(parseMcpCreditBalance("-5.25")).toBe(-5.25);
+  });
+
+  test("parses a numeric value", () => {
+    expect(parseMcpCreditBalance(42)).toBe(42);
+  });
+
+  test("parses an explicit zero (legitimate domain value)", () => {
+    expect(parseMcpCreditBalance("0")).toBe(0);
+    expect(parseMcpCreditBalance("0.0000")).toBe(0);
+    expect(parseMcpCreditBalance(0)).toBe(0);
+  });
+
+  test("throws on the 'NaN' string a corrupt Postgres NUMERIC reads back as", () => {
+    // `'NaN'::numeric` is a valid Postgres NUMERIC and the driver returns "NaN".
+    expect(() => parseMcpCreditBalance("NaN")).toThrow(CorruptMcpCreditBalanceError);
+  });
+
+  test("throws on null / undefined / empty / whitespace", () => {
+    expect(() => parseMcpCreditBalance(null)).toThrow(CorruptMcpCreditBalanceError);
+    expect(() => parseMcpCreditBalance(undefined)).toThrow(CorruptMcpCreditBalanceError);
+    expect(() => parseMcpCreditBalance("")).toThrow(CorruptMcpCreditBalanceError);
+    expect(() => parseMcpCreditBalance("   ")).toThrow(CorruptMcpCreditBalanceError);
+  });
+
+  test("throws on JS-only coercions Number() would otherwise accept", () => {
+    expect(() => parseMcpCreditBalance("1e3")).toThrow(CorruptMcpCreditBalanceError);
+    expect(() => parseMcpCreditBalance("0x10")).toThrow(CorruptMcpCreditBalanceError);
+    expect(() => parseMcpCreditBalance("Infinity")).toThrow(CorruptMcpCreditBalanceError);
+    expect(() => parseMcpCreditBalance("12abc")).toThrow(CorruptMcpCreditBalanceError);
+  });
+
+  test("preserves the raw value on the thrown error for repair", () => {
+    try {
+      parseMcpCreditBalance("NaN");
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CorruptMcpCreditBalanceError);
+      expect((err as CorruptMcpCreditBalanceError).rawValue).toBe("NaN");
+    }
+  });
+
+  test("REGRESSION: the bare-Number gate the fix replaced fails OPEN on 'NaN'", () => {
+    // Documents exactly why the old `Number(credit_balance) < toolCost` gate was
+    // unsafe: NaN < toolCost is false, so the insufficient-credit gate is skipped.
+    const toolCost = 5;
+    expect(Number("NaN") < toolCost).toBe(false);
+    // The fail-closed parser refuses the corrupt value instead.
+    expect(() => parseMcpCreditBalance("NaN")).toThrow(CorruptMcpCreditBalanceError);
+  });
+});
+
+/** Build a minimal MCPToolContext with a given org credit_balance. */
+function makeContext(creditBalance: unknown) {
+  const deductCredits = mock(async () => ({
+    success: true,
+    newBalance: 999,
+    transactionId: "tx_test",
+  }));
+  const refundCredits = mock(async () => {});
+  const context = {
+    user: {} as MCPToolContext["user"],
+    org: { credit_balance: creditBalance } as unknown as MCPToolContext["org"],
+    getToolCache: async () => null,
+    setToolCache: async () => {},
+    invalidateToolCache: async () => {},
+    deductCredits,
+    refundCredits,
+  } as unknown as MCPToolContext;
+  return { context, deductCredits, refundCredits };
+}
+
+describe("withCredits balance pre-check (fail-closed money gate)", () => {
+  test("runs the paid tool and deducts when balance is sufficient", async () => {
+    const { context, deductCredits } = makeContext("100");
+    const handler = mock(async () => "ok");
+    const wrapped = withCredits("paid_tool", 5, {}, handler);
+
+    await expect(wrapped({}, context)).resolves.toBe("ok");
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("denies (never deducts) when balance is genuinely insufficient", async () => {
+    const { context, deductCredits } = makeContext("2");
+    const handler = mock(async () => "ok");
+    const wrapped = withCredits("paid_tool", 5, {}, handler);
+
+    await expect(wrapped({}, context)).rejects.toThrow(/Insufficient credits/);
+    expect(deductCredits).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("REGRESSION: corrupt 'NaN' balance DENIES the paid tool (was: ran free)", async () => {
+    const { context, deductCredits, refundCredits } = makeContext("NaN");
+    const handler = mock(async () => "ok");
+    const wrapped = withCredits("paid_tool", 5, {}, handler);
+
+    await expect(wrapped({}, context)).rejects.toThrow(CorruptMcpCreditBalanceError);
+    // Critically: the fail-open path would have called deductCredits + handler.
+    expect(deductCredits).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+    expect(refundCredits).not.toHaveBeenCalled();
+  });
+
+  test("corrupt empty balance DENIES the paid tool", async () => {
+    const { context, deductCredits } = makeContext("");
+    const handler = mock(async () => "ok");
+    const wrapped = withCredits("paid_tool", 5, {}, handler);
+
+    await expect(wrapped({}, context)).rejects.toThrow(CorruptMcpCreditBalanceError);
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+
+  test("explicit zero balance is read (not corrupt) and denies the paid tool", async () => {
+    const { context, deductCredits } = makeContext("0");
+    const handler = mock(async () => "ok");
+    const wrapped = withCredits("paid_tool", 5, {}, handler);
+
+    // Denied by the `< toolCost` comparison, not by the corruption boundary.
+    await expect(wrapped({}, context)).rejects.toThrow(/Insufficient credits/);
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/mcp/withcredits-numeric.ts
+++ b/packages/cloud/shared/src/lib/mcp/withcredits-numeric.ts
@@ -1,0 +1,62 @@
+/**
+ * Fail-closed numeric boundary for the MCP `withCredits()` balance pre-check
+ * (#13415, cloud-shared money-layer fallback-slop sweep).
+ *
+ * `organizations.credit_balance` is a Postgres NUMERIC column, so the driver
+ * hands it back as a string. Before this slice, `withCredits()` in
+ * `mcp/helpers.ts` gated a PAID MCP tool call on:
+ *
+ *   if (Number(context.org.credit_balance) < toolCost) throw
+ *
+ * A corrupt `credit_balance` (`'NaN'::numeric` is a valid Postgres NUMERIC, and
+ * a migration artifact or manual DB edit can produce a non-parseable string)
+ * reads back as `"NaN"`, and `Number("NaN") < toolCost` is `false`, so the
+ * insufficient-credit gate is BYPASSED and the tool proceeds to the paid
+ * `deductCredits` path against an unreadable balance. Any JS-only coercion
+ * (`"1e3"`, `"0x10"`, `"Infinity"`) that `Number(...)` accepts or turns into
+ * `NaN` is likewise mishandled by the bare comparison. A money-out gate failing
+ * OPEN is the worst class of this bug.
+ *
+ * Failing closed here surfaces the corruption with a distinct error BEFORE the
+ * gate can be bypassed — the caller (the MCP tool boundary) already throws on
+ * insufficient credits, so a corrupt balance now denies the tool call and
+ * reports the poisoned value for repair instead of granting free execution.
+ *
+ * The regex only accepts a plain signed decimal (the exact shape Postgres
+ * NUMERIC emits). A genuine explicit zero balance is a legitimate domain value
+ * and parses to `0` (the tool is then correctly denied by the `< toolCost`
+ * comparison, not by this boundary).
+ *
+ * error-policy:J1 — corrupt stored money value on a spend gate: deny, surface
+ * for repair, never fabricate an authorized-spend default.
+ */
+export class CorruptMcpCreditBalanceError extends Error {
+  readonly rawValue: unknown;
+
+  constructor(rawValue: unknown, reason: string) {
+    super(`Unable to read organization credit_balance for MCP spend gate: ${reason}`);
+    this.name = "CorruptMcpCreditBalanceError";
+    this.rawValue = rawValue;
+  }
+}
+
+/**
+ * Parse an organization `credit_balance` NUMERIC value fail-closed for the MCP
+ * `withCredits()` spend gate.
+ *
+ * @throws {CorruptMcpCreditBalanceError} when the value is missing, empty, not a
+ *   plain NUMERIC string, or not a finite number.
+ */
+export function parseMcpCreditBalance(value: string | number | null | undefined): number {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    throw new CorruptMcpCreditBalanceError(value, "value is empty or missing");
+  }
+  if (typeof value === "string" && !/^[+-]?(?:\d+|\d*\.\d+)$/.test(value.trim())) {
+    throw new CorruptMcpCreditBalanceError(value, "value is not a valid NUMERIC");
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new CorruptMcpCreditBalanceError(value, "value is not a finite number");
+  }
+  return parsed;
+}

--- a/packages/cloud/shared/src/lib/mcp/withcredits-numeric.ts
+++ b/packages/cloud/shared/src/lib/mcp/withcredits-numeric.ts
@@ -30,12 +30,18 @@
  * error-policy:J1 — corrupt stored money value on a spend gate: deny, surface
  * for repair, never fabricate an authorized-spend default.
  */
-export class CorruptMcpCreditBalanceError extends Error {
+import { ElizaError } from "@elizaos/core";
+
+export class CorruptMcpCreditBalanceError extends ElizaError {
+  override readonly name = "CorruptMcpCreditBalanceError";
   readonly rawValue: unknown;
 
   constructor(rawValue: unknown, reason: string) {
-    super(`Unable to read organization credit_balance for MCP spend gate: ${reason}`);
-    this.name = "CorruptMcpCreditBalanceError";
+    super(`Unable to read organization credit_balance for MCP spend gate: ${reason}`, {
+      code: "CORRUPT_MCP_CREDIT_BALANCE",
+      context: { rawValue, reason },
+      severity: "fatal",
+    });
     this.rawValue = rawValue;
   }
 }


### PR DESCRIPTION
## What

`withCredits()` in `packages/cloud/shared/src/lib/mcp/helpers.ts` gates a **paid** MCP tool call on:

```ts
if (Number(context.org.credit_balance) < toolCost) throw
```

`organizations.credit_balance` is a Postgres `NUMERIC` column, so the driver hands it back as a string. A corrupt `'NaN'::numeric` value (a valid Postgres NUMERIC — migration artifact or manual DB edit) reads back as `"NaN"`, and `Number("NaN") < toolCost` is **`false`**, so the insufficient-credit gate is **bypassed** and the tool proceeds to `deductCredits` free against an unreadable balance. Any JS-only coercion (`"1e3"`, `"0x10"`, `"Infinity"`) that `Number()` accepts or turns into `NaN` is likewise mishandled. **A money-out gate failing OPEN is the worst class of this bug.**

## Fix

New colocated fail-closed boundary `parseMcpCreditBalance` (`mcp/withcredits-numeric.ts`), mirroring the merged NUMERIC slices #13454 / #13474 / #13482 / #13486 / #13503 / #13504 / #13508 / #13518:

- accepts only a plain signed decimal NUMERIC string (the shape Postgres emits);
- rejects `'NaN'` / `'Infinity'` / JS-only coercions;
- allows an explicit domain zero.

A corrupt balance now throws `CorruptMcpCreditBalanceError` → the tool call is **denied** and the poisoned value surfaced for repair (`error-policy:J1`), instead of granting free execution. A genuine zero/low balance is still denied by the existing `< toolCost` comparison, unchanged.

## Tests

`bun test --isolate src/lib/mcp/withcredits-numeric.test.ts` → **13/13 green**:

- parser boundary (well-formed / numeric / explicit-zero / `'NaN'` / null/empty/whitespace / `1e3`/`0x10`/`Infinity` / raw-value-on-error);
- `withCredits` seam: sufficient balance runs + deducts once; genuine insufficient balance denies + never deducts; **REGRESSION** corrupt `'NaN'` balance denies the paid tool and never calls `deductCredits`/`handler`/`refundCredits`; corrupt empty balance denies; explicit zero is read (not corrupt) and denied by the comparison.

**Reversion-proven:** the two REGRESSION cases fail on the pristine bare-`Number` gate (the `'NaN'` case reaches `deductCredits` = the fail-open path).

Gates: `tsgo` **0 errors in touched files** (4 pre-existing baseline errs in `node-redis-adapter` / `plugin-mcp/json` / `anthropic-web-search`, identical on develop), biome clean, error-policy-ratchet "no new fallback-slop".

## Scope

Distinct file (`packages/cloud/shared/src/lib/mcp/`) from all open #13415 PRs (#14037/#14045/#14049/#14052/#14054/#14055/#14058/#14060/#14061) and live sibling worktrees (active-billing / ad-inventory / influencer-marketplace / invites). Issue #13415 stays open for remaining service-layer inventory.

— [sol-orch]
