### PR TITLE
fix(#13415): fail closed on corrupt NUMERIC reads in active-billing display + ledger

### DIFF
--- a/packages/cloud/shared/src/lib/services/active-billing-numeric-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing-numeric-fail-closed.test.ts
@@ -1,0 +1,302 @@
+/**
+ * #13415 — active-billing display + credit-ledger NUMERIC fail-closed boundary.
+ *
+ * `listActiveResources` and `listLedger` read Postgres NUMERIC columns
+ * (`containers.total_billed`, `agent_sandboxes.total_billed`,
+ * `agent_sandboxes.hourly_rate`, `credit_transactions.amount`) via a bare
+ * `Number(...)`. Postgres accepts `'NaN'::numeric` as a valid stored value that
+ * reads back as the string `"NaN"`, so a corrupt row coerced to `NaN` SILENTLY:
+ *   - renders a fabricated "$NaN billed" line in the billing panel
+ *     (`totalBilled` / `hourlyRate`);
+ *   - poisons the `amount` in the credit-transaction ledger a user reads to
+ *     RECONCILE what they were actually charged.
+ *
+ * The fix reads every NUMERIC value through `parseActiveBillingNumber`, which
+ * THROWS on a corrupt/non-finite value (fail closed → clean 500 at the route's
+ * existing try/catch → failureResponse) while preserving an explicit domain
+ * zero. These tests drive the parser directly (exhaustive boundary +
+ * reversion-proof fail-open regressions) and the two display read sites via a
+ * stubbed `dbRead`, proving a corrupt row now throws instead of fabricating a
+ * NaN billing figure.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+// ── Stub dbRead's drizzle query builder ──────────────────────────────────────
+// `listActiveResources` runs `dbRead.select().from(containers|agentSandboxes).where(...)`
+// (awaited → array). `listLedger` runs `.select().from(creditTransactions).where().orderBy().limit(...)`
+// (awaited → array). We route the awaited result on the *table* passed to `.from()`.
+import * as realDbClient from "../../db/client";
+
+let containerRows: Array<Record<string, unknown>> = [];
+let agentRows: Array<Record<string, unknown>> = [];
+let ledgerRows: Array<Record<string, unknown>> = [];
+
+// Identify which fixture a `.from(table)` call wants without importing the real
+// drizzle table objects: the schema modules export named tables, and the real
+// service imports the same objects, so we compare by reference.
+import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { containers } from "../../db/schemas/containers";
+import { creditTransactions } from "../../db/schemas/credit-transactions";
+
+// A drizzle-shaped builder. `.where()` returns a Promise (awaitable directly for
+// `listActiveResources`) that ALSO carries `.orderBy()/.limit()` so the
+// `listLedger` chain (`.where().orderBy().limit()`) resolves. Attaching the
+// chain methods onto the Promise avoids a bare `then` property on a plain object
+// (which biome's noThenProperty flags) while matching both real call shapes.
+function whereResult(
+  rows: Array<Record<string, unknown>>,
+): Promise<Array<Record<string, unknown>>> {
+  const p = Promise.resolve(rows) as Promise<Array<Record<string, unknown>>> & {
+    orderBy: () => typeof p;
+    limit: () => Promise<Array<Record<string, unknown>>>;
+  };
+  p.orderBy = () => p;
+  p.limit = () => Promise.resolve(rows);
+  return p;
+}
+
+function makeBuilder() {
+  let rows: Array<Record<string, unknown>> = [];
+  const builder = {
+    select() {
+      return builder;
+    },
+    from(table: unknown) {
+      if (table === containers) rows = containerRows;
+      else if (table === agentSandboxes) rows = agentRows;
+      else if (table === creditTransactions) rows = ledgerRows;
+      else rows = [];
+      return builder;
+    },
+    where() {
+      return whereResult(rows);
+    },
+  };
+  return builder;
+}
+
+mock.module("../../db/client", () => ({
+  ...realDbClient,
+  dbRead: {
+    select: () => makeBuilder(),
+  },
+}));
+
+const { activeBillingService } = await import("./active-billing");
+const {
+  parseActiveBillingNonNegativeNumber,
+  parseActiveBillingNumber,
+  CorruptActiveBillingNumberError,
+} = await import("./active-billing-numeric");
+
+const ORG = "00000000-0000-4000-8000-0000000000org";
+
+const baseContainer = (overrides: Record<string, unknown> = {}) => ({
+  id: "container-1",
+  name: "app",
+  project_name: "proj",
+  organization_id: ORG,
+  status: "running",
+  billing_status: "active",
+  desired_count: 1,
+  cpu: 1,
+  memory: 512,
+  total_billed: "12.50",
+  last_billed_at: null,
+  next_billing_at: null,
+  scheduled_shutdown_at: null,
+  public_hostname: null,
+  load_balancer_url: null,
+  metadata: {},
+  ...overrides,
+});
+
+const baseAgent = (overrides: Record<string, unknown> = {}) => ({
+  id: "agent-100000",
+  agent_name: "Bot",
+  organization_id: ORG,
+  status: "running",
+  billing_status: "active",
+  total_billed: "3.00",
+  hourly_rate: "0.0100",
+  character_id: "char-1",
+  sandbox_id: "sbx-1",
+  bridge_url: null,
+  last_billed_at: null,
+  last_backup_at: null,
+  scheduled_shutdown_at: null,
+  execution_tier: "dedicated",
+  ...overrides,
+});
+
+const baseLedgerRow = (overrides: Record<string, unknown> = {}) => ({
+  id: "tx-1",
+  amount: "1.500000",
+  type: "debit",
+  description: "usage",
+  created_at: new Date("2026-07-05T00:00:00.000Z"),
+  metadata: { billing_type: "usage" },
+  ...overrides,
+});
+
+beforeEach(() => {
+  containerRows = [];
+  agentRows = [];
+  ledgerRows = [];
+});
+
+// ── Parser boundary (exhaustive) ─────────────────────────────────────────────
+describe("parseActiveBillingNumber", () => {
+  test("parses a normal numeric string", () => {
+    expect(parseActiveBillingNumber("12.50", "f")).toBe(12.5);
+  });
+
+  test("parses a numeric value", () => {
+    expect(parseActiveBillingNumber(7, "f")).toBe(7);
+  });
+
+  test("allows explicit domain zero", () => {
+    expect(parseActiveBillingNumber("0.00", "f")).toBe(0);
+    expect(parseActiveBillingNumber(0, "f")).toBe(0);
+  });
+
+  test("allows negative (e.g. a credit/refund amount)", () => {
+    expect(parseActiveBillingNumber("-4.25", "f")).toBe(-4.25);
+  });
+
+  test("non-negative parser rejects negative totals/rates", () => {
+    expect(() => parseActiveBillingNonNegativeNumber("-4.25", "total_billed")).toThrow(
+      CorruptActiveBillingNumberError,
+    );
+  });
+
+  test("THROWS on the 'NaN' string (poisoned NUMERIC read-back) — fail-open regression", () => {
+    expect(() => parseActiveBillingNumber("NaN", "total_billed")).toThrow(
+      CorruptActiveBillingNumberError,
+    );
+  });
+
+  test("THROWS on Infinity", () => {
+    expect(() => parseActiveBillingNumber("Infinity", "f")).toThrow(
+      CorruptActiveBillingNumberError,
+    );
+    expect(() => parseActiveBillingNumber(Number.POSITIVE_INFINITY, "f")).toThrow(
+      CorruptActiveBillingNumberError,
+    );
+  });
+
+  test("THROWS on null / undefined / empty / whitespace", () => {
+    expect(() => parseActiveBillingNumber(null, "f")).toThrow(CorruptActiveBillingNumberError);
+    expect(() => parseActiveBillingNumber(undefined, "f")).toThrow(CorruptActiveBillingNumberError);
+    expect(() => parseActiveBillingNumber("", "f")).toThrow(CorruptActiveBillingNumberError);
+    expect(() => parseActiveBillingNumber("   ", "f")).toThrow(CorruptActiveBillingNumberError);
+  });
+
+  test("THROWS on non-numeric garbage", () => {
+    expect(() => parseActiveBillingNumber("abc", "f")).toThrow(CorruptActiveBillingNumberError);
+  });
+
+  test("error names the field and raw value", () => {
+    try {
+      parseActiveBillingNumber("NaN", "credit_transaction.amount");
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CorruptActiveBillingNumberError);
+      expect((e as Error).message).toContain("credit_transaction.amount");
+      expect((e as Error).message).toContain("NaN");
+    }
+  });
+});
+
+// ── listActiveResources seam ─────────────────────────────────────────────────
+describe("listActiveResources fail-closed", () => {
+  test("healthy container + agent rows render real totals", async () => {
+    containerRows = [baseContainer()];
+    agentRows = [baseAgent()];
+    const out = await activeBillingService.listActiveResources(ORG);
+    const container = out.find((r) => r.resourceType === "container");
+    const agent = out.find((r) => r.resourceType === "agent_sandbox");
+    expect(container?.totalBilled).toBe(12.5);
+    expect(agent?.totalBilled).toBe(3);
+    expect(agent?.metadata.hourlyRate).toBe(0.01);
+  });
+
+  test("explicit-zero total_billed is a legit domain value, not corruption", async () => {
+    containerRows = [baseContainer({ total_billed: "0.00" })];
+    const out = await activeBillingService.listActiveResources(ORG);
+    expect(out[0].totalBilled).toBe(0);
+  });
+
+  test("null hourly_rate falls back to computed unitPrice (no throw)", async () => {
+    agentRows = [baseAgent({ hourly_rate: null })];
+    const out = await activeBillingService.listActiveResources(ORG);
+    // running agent → RUNNING_HOURLY_RATE (0.01)
+    expect(out[0].metadata.hourlyRate).toBe(0.01);
+  });
+
+  test("corrupt container.total_billed THROWS instead of fabricating $NaN", async () => {
+    containerRows = [baseContainer({ total_billed: "NaN" })];
+    await expect(activeBillingService.listActiveResources(ORG)).rejects.toBeInstanceOf(
+      CorruptActiveBillingNumberError,
+    );
+  });
+
+  test("negative container.total_billed THROWS instead of rendering a negative billed total", async () => {
+    containerRows = [baseContainer({ total_billed: "-1.00" })];
+    await expect(activeBillingService.listActiveResources(ORG)).rejects.toBeInstanceOf(
+      CorruptActiveBillingNumberError,
+    );
+  });
+
+  test("corrupt agent.total_billed THROWS", async () => {
+    agentRows = [baseAgent({ total_billed: "NaN" })];
+    await expect(activeBillingService.listActiveResources(ORG)).rejects.toBeInstanceOf(
+      CorruptActiveBillingNumberError,
+    );
+  });
+
+  test("corrupt agent.hourly_rate THROWS (not silently NaN in metadata)", async () => {
+    agentRows = [baseAgent({ hourly_rate: "NaN" })];
+    await expect(activeBillingService.listActiveResources(ORG)).rejects.toBeInstanceOf(
+      CorruptActiveBillingNumberError,
+    );
+  });
+
+  test("negative agent.hourly_rate THROWS instead of rendering a negative rate", async () => {
+    agentRows = [baseAgent({ hourly_rate: "-0.0100" })];
+    await expect(activeBillingService.listActiveResources(ORG)).rejects.toBeInstanceOf(
+      CorruptActiveBillingNumberError,
+    );
+  });
+});
+
+// ── listLedger seam ──────────────────────────────────────────────────────────
+describe("listLedger fail-closed", () => {
+  test("healthy ledger rows render real reconciliation amounts", async () => {
+    ledgerRows = [baseLedgerRow({ amount: "2.250000" })];
+    const out = await activeBillingService.listLedger(ORG);
+    expect(out[0].amount).toBe(2.25);
+  });
+
+  test("explicit-zero amount is legit", async () => {
+    ledgerRows = [baseLedgerRow({ amount: "0.000000" })];
+    const out = await activeBillingService.listLedger(ORG);
+    expect(out[0].amount).toBe(0);
+  });
+
+  test("negative ledger amount remains legitimate for signed reconciliation rows", async () => {
+    ledgerRows = [baseLedgerRow({ amount: "-1.500000" })];
+    const out = await activeBillingService.listLedger(ORG);
+    expect(out[0].amount).toBe(-1.5);
+  });
+
+  test("corrupt ledger amount THROWS instead of poisoning the reconciliation view", async () => {
+    ledgerRows = [baseLedgerRow({ amount: "NaN" })];
+    await expect(activeBillingService.listLedger(ORG)).rejects.toBeInstanceOf(
+      CorruptActiveBillingNumberError,
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/active-billing-numeric-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing-numeric-fail-closed.test.ts
@@ -33,6 +33,9 @@ import * as realDbClient from "../../db/client";
 let containerRows: Array<Record<string, unknown>> = [];
 let agentRows: Array<Record<string, unknown>> = [];
 let ledgerRows: Array<Record<string, unknown>> = [];
+let dbWriteUpdateCalls = 0;
+let containerInfrastructureCalls = 0;
+let agentInfrastructureCalls = 0;
 
 // Identify which fixture a `.from(table)` call wants without importing the real
 // drizzle table objects: the schema modules export named tables, and the real
@@ -82,6 +85,46 @@ mock.module("../../db/client", () => ({
   ...realDbClient,
   dbRead: {
     select: () => makeBuilder(),
+  },
+  dbWrite: {
+    update() {
+      dbWriteUpdateCalls += 1;
+      const builder = {
+        set() {
+          return builder;
+        },
+        where() {
+          return builder;
+        },
+        returning() {
+          return Promise.resolve([...containerRows, ...agentRows]);
+        },
+      };
+      return builder;
+    },
+  },
+}));
+
+mock.module("./containers/hetzner-client", () => ({
+  getHetznerContainersClient: () => ({
+    stopContainer: async () => {
+      containerInfrastructureCalls += 1;
+    },
+    deleteContainer: async () => {
+      containerInfrastructureCalls += 1;
+    },
+  }),
+}));
+
+mock.module("./provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentSuspendOnce: async () => {
+      agentInfrastructureCalls += 1;
+    },
+    enqueueAgentDeleteOnce: async () => {
+      agentInfrastructureCalls += 1;
+    },
+    triggerImmediate: async () => {},
   },
 }));
 
@@ -146,6 +189,9 @@ beforeEach(() => {
   containerRows = [];
   agentRows = [];
   ledgerRows = [];
+  dbWriteUpdateCalls = 0;
+  containerInfrastructureCalls = 0;
+  agentInfrastructureCalls = 0;
 });
 
 // ── Parser boundary (exhaustive) ─────────────────────────────────────────────
@@ -207,6 +253,12 @@ describe("parseActiveBillingNumber", () => {
       expect(e).toBeInstanceOf(CorruptActiveBillingNumberError);
       expect((e as Error).message).toContain("credit_transaction.amount");
       expect((e as Error).message).toContain("NaN");
+      expect((e as CorruptActiveBillingNumberError).code).toBe("CORRUPT_ACTIVE_BILLING_NUMBER");
+      expect((e as CorruptActiveBillingNumberError).context).toEqual({
+        fieldName: "credit_transaction.amount",
+        rawValue: "NaN",
+      });
+      expect((e as CorruptActiveBillingNumberError).severity).toBe("fatal");
     }
   });
 });
@@ -298,5 +350,38 @@ describe("listLedger fail-closed", () => {
     await expect(activeBillingService.listLedger(ORG)).rejects.toBeInstanceOf(
       CorruptActiveBillingNumberError,
     );
+  });
+});
+
+// ── cancelResource pre-mutation gate ────────────────────────────────────────
+describe("cancelResource fail-closed before side effects", () => {
+  test("corrupt container.total_billed throws before infra stop or billing suspension", async () => {
+    containerRows = [baseContainer({ total_billed: "NaN" })];
+
+    await expect(
+      activeBillingService.cancelResource({
+        organizationId: ORG,
+        resourceId: "container-1",
+        resourceType: "container",
+      }),
+    ).rejects.toBeInstanceOf(CorruptActiveBillingNumberError);
+
+    expect(containerInfrastructureCalls).toBe(0);
+    expect(dbWriteUpdateCalls).toBe(0);
+  });
+
+  test("corrupt agent_sandbox.total_billed throws before enqueueing infra or suspending billing", async () => {
+    agentRows = [baseAgent({ total_billed: "NaN" })];
+
+    await expect(
+      activeBillingService.cancelResource({
+        organizationId: ORG,
+        resourceId: "agent-100000",
+        resourceType: "agent_sandbox",
+      }),
+    ).rejects.toBeInstanceOf(CorruptActiveBillingNumberError);
+
+    expect(agentInfrastructureCalls).toBe(0);
+    expect(dbWriteUpdateCalls).toBe(0);
   });
 });

--- a/packages/cloud/shared/src/lib/services/active-billing-numeric.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing-numeric.ts
@@ -1,0 +1,64 @@
+/**
+ * Numeric parsing boundary for active-billing display + credit-ledger rows.
+ *
+ * Postgres NUMERIC fields (`containers.total_billed`, `agent_sandboxes.total_billed`,
+ * `agent_sandboxes.hourly_rate`, `credit_transactions.amount`) arrive from the driver
+ * as strings. A corrupt value — a `'NaN'::numeric` (which Postgres accepts and reads
+ * back as the string `"NaN"`), a driver quirk, a migration artifact, or a manual DB
+ * edit — must throw here instead of silently coercing to `NaN` via a bare `Number(...)`.
+ *
+ * These values are read into user-facing surfaces:
+ *
+ *   - `listActiveResources()` → `totalBilled` / `hourlyRate` render the amount already
+ *     billed for a live resource in the billing panel. A `NaN` becomes a fabricated
+ *     "$NaN billed" line that looks like a real (broken) charge.
+ *   - `listLedger()` → `amount` is the credit-transaction ledger a user reads to
+ *     RECONCILE real charges. A `NaN` amount silently corrupts their reconciliation
+ *     view — the one place they audit what they were charged.
+ *
+ * Failing closed surfaces the corruption (clean 500 at the route boundary via the
+ * existing try/catch → `failureResponse`) instead of shipping a fabricated `NaN`
+ * into the billing display or the credit-reconciliation ledger. `0` is a
+ * legitimate domain value (default `"0.00"`) and is preserved; callers add
+ * non-negative bounds for accumulated resource totals and rates.
+ */
+
+export class CorruptActiveBillingNumberError extends Error {
+  constructor(
+    readonly fieldName: string,
+    readonly rawValue: unknown,
+  ) {
+    super(
+      `Unable to read active-billing ${fieldName}: value is not a finite number (raw=${String(
+        rawValue,
+      )})`,
+    );
+    this.name = "CorruptActiveBillingNumberError";
+  }
+}
+
+/**
+ * Parse a Postgres NUMERIC value read into the active-billing service, failing
+ * closed on any non-finite / missing value. Explicit domain zero is allowed.
+ */
+export function parseActiveBillingNumber(
+  value: string | number | null | undefined,
+  fieldName: string,
+  options: { min?: number } = {},
+): number {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    throw new CorruptActiveBillingNumberError(fieldName, value);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || (options.min !== undefined && parsed < options.min)) {
+    throw new CorruptActiveBillingNumberError(fieldName, value);
+  }
+  return parsed;
+}
+
+export function parseActiveBillingNonNegativeNumber(
+  value: string | number | null | undefined,
+  fieldName: string,
+): number {
+  return parseActiveBillingNumber(value, fieldName, { min: 0 });
+}

--- a/packages/cloud/shared/src/lib/services/active-billing-numeric.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing-numeric.ts
@@ -23,7 +23,11 @@
  * non-negative bounds for accumulated resource totals and rates.
  */
 
-export class CorruptActiveBillingNumberError extends Error {
+import { ElizaError } from "@elizaos/core";
+
+export class CorruptActiveBillingNumberError extends ElizaError {
+  override readonly name = "CorruptActiveBillingNumberError";
+
   constructor(
     readonly fieldName: string,
     readonly rawValue: unknown,
@@ -32,8 +36,12 @@ export class CorruptActiveBillingNumberError extends Error {
       `Unable to read active-billing ${fieldName}: value is not a finite number (raw=${String(
         rawValue,
       )})`,
+      {
+        code: "CORRUPT_ACTIVE_BILLING_NUMBER",
+        context: { fieldName, rawValue },
+        severity: "fatal",
+      },
     );
-    this.name = "CorruptActiveBillingNumberError";
   }
 }
 

--- a/packages/cloud/shared/src/lib/services/active-billing.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing.ts
@@ -257,16 +257,20 @@ class ActiveBillingService {
         .limit(1);
 
       if (container) {
-        const infrastructureAction = await cancelContainerInfrastructure(
-          container.id,
-          organizationId,
-          mode,
-        );
         const unitPrice = calculateDailyContainerCost({
           desiredCount: container.desired_count,
           cpu: container.cpu,
           memory: container.memory,
         });
+        const totalBilled = parseActiveBillingNonNegativeNumber(
+          container.total_billed,
+          "container.total_billed",
+        );
+        const infrastructureAction = await cancelContainerInfrastructure(
+          container.id,
+          organizationId,
+          mode,
+        );
 
         if (mode === "delete" && infrastructureAction.status === "deleted") {
           return {
@@ -284,10 +288,7 @@ class ActiveBillingService {
               lastBilledAt: iso(container.last_billed_at),
               nextBillingAt: null,
               estimatedNextBillingAt: null,
-              totalBilled: parseActiveBillingNonNegativeNumber(
-                container.total_billed,
-                "container.total_billed",
-              ),
+              totalBilled,
               cancelEndpoint: cancelEndpoint("container", container.id),
               cancelAction: "stop",
               metadata: {
@@ -338,10 +339,7 @@ class ActiveBillingService {
             lastBilledAt: iso(updated.last_billed_at),
             nextBillingAt: iso(updated.next_billing_at),
             estimatedNextBillingAt: null,
-            totalBilled: parseActiveBillingNonNegativeNumber(
-              updated.total_billed,
-              "updated.total_billed",
-            ),
+            totalBilled,
             cancelEndpoint: cancelEndpoint("container", updated.id),
             cancelAction: "stop",
             metadata: {
@@ -369,6 +367,14 @@ class ActiveBillingService {
         .limit(1);
 
       if (agent) {
+        const unitPrice =
+          agent.status === "running"
+            ? AGENT_PRICING.RUNNING_HOURLY_RATE
+            : AGENT_PRICING.IDLE_HOURLY_RATE;
+        const totalBilled = parseActiveBillingNonNegativeNumber(
+          agent.total_billed,
+          "agent_sandbox.total_billed",
+        );
         const infrastructureAction = await cancelAgentInfrastructure(
           agent.id,
           organizationId,
@@ -376,10 +382,6 @@ class ActiveBillingService {
           mode,
           triggerEnv,
         );
-        const unitPrice =
-          agent.status === "running"
-            ? AGENT_PRICING.RUNNING_HOURLY_RATE
-            : AGENT_PRICING.IDLE_HOURLY_RATE;
 
         if (mode === "delete" && infrastructureAction.status === "deleted") {
           return {
@@ -397,10 +399,7 @@ class ActiveBillingService {
               lastBilledAt: iso(agent.last_billed_at),
               nextBillingAt: null,
               estimatedNextBillingAt: null,
-              totalBilled: parseActiveBillingNonNegativeNumber(
-                agent.total_billed,
-                "agent_sandbox.total_billed",
-              ),
+              totalBilled,
               cancelEndpoint: cancelEndpoint("agent_sandbox", agent.id),
               cancelAction: "suspend_billing",
               metadata: {
@@ -448,10 +447,7 @@ class ActiveBillingService {
             lastBilledAt: iso(updated.last_billed_at),
             nextBillingAt: null,
             estimatedNextBillingAt: null,
-            totalBilled: parseActiveBillingNonNegativeNumber(
-              updated.total_billed,
-              "updated.total_billed",
-            ),
+            totalBilled,
             cancelEndpoint: cancelEndpoint("agent_sandbox", updated.id),
             cancelAction: "suspend_billing",
             metadata: {

--- a/packages/cloud/shared/src/lib/services/active-billing.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing.ts
@@ -8,6 +8,10 @@ import type { AppEnv } from "../../types/cloud-worker-env";
 import { AGENT_PRICING } from "../constants/agent-pricing";
 import { calculateDailyContainerCost } from "../constants/pricing";
 import { logger } from "../utils/logger";
+import {
+  parseActiveBillingNonNegativeNumber,
+  parseActiveBillingNumber,
+} from "./active-billing-numeric";
 import { provisioningJobService } from "./provisioning-jobs";
 
 export type BillableResourceType = "container" | "agent_sandbox";
@@ -147,7 +151,10 @@ class ActiveBillingService {
         lastBilledAt: iso(container.last_billed_at),
         nextBillingAt: iso(container.next_billing_at),
         estimatedNextBillingAt: iso(estimatedNext),
-        totalBilled: Number(container.total_billed),
+        totalBilled: parseActiveBillingNonNegativeNumber(
+          container.total_billed,
+          "container.total_billed",
+        ),
         cancelEndpoint: cancelEndpoint("container", container.id),
         cancelAction: "stop",
         metadata: {
@@ -182,14 +189,20 @@ class ActiveBillingService {
         lastBilledAt: iso(agent.last_billed_at),
         nextBillingAt: null,
         estimatedNextBillingAt: iso(estimatedNext),
-        totalBilled: Number(agent.total_billed),
+        totalBilled: parseActiveBillingNonNegativeNumber(
+          agent.total_billed,
+          "agent_sandbox.total_billed",
+        ),
         cancelEndpoint: cancelEndpoint("agent_sandbox", agent.id),
         cancelAction: "suspend_billing",
         metadata: {
           characterId: agent.character_id,
           sandboxId: agent.sandbox_id,
           bridgeUrl: agent.bridge_url,
-          hourlyRate: Number(agent.hourly_rate ?? unitPrice),
+          hourlyRate:
+            agent.hourly_rate === null || agent.hourly_rate === undefined
+              ? unitPrice
+              : parseActiveBillingNonNegativeNumber(agent.hourly_rate, "agent_sandbox.hourly_rate"),
           lastBackupAt: iso(agent.last_backup_at),
           scheduledShutdownAt: iso(agent.scheduled_shutdown_at),
           billableReason: isRunning ? "running_agent" : "idle_snapshot_storage",
@@ -215,7 +228,7 @@ class ActiveBillingService {
       const detected = detectLedgerResource(metadata);
       return {
         id: row.id,
-        amount: Number(row.amount),
+        amount: parseActiveBillingNumber(row.amount, "credit_transaction.amount"),
         type: row.type,
         description: row.description,
         createdAt: row.created_at.toISOString(),
@@ -271,7 +284,10 @@ class ActiveBillingService {
               lastBilledAt: iso(container.last_billed_at),
               nextBillingAt: null,
               estimatedNextBillingAt: null,
-              totalBilled: Number(container.total_billed),
+              totalBilled: parseActiveBillingNonNegativeNumber(
+                container.total_billed,
+                "container.total_billed",
+              ),
               cancelEndpoint: cancelEndpoint("container", container.id),
               cancelAction: "stop",
               metadata: {
@@ -322,7 +338,10 @@ class ActiveBillingService {
             lastBilledAt: iso(updated.last_billed_at),
             nextBillingAt: iso(updated.next_billing_at),
             estimatedNextBillingAt: null,
-            totalBilled: Number(updated.total_billed),
+            totalBilled: parseActiveBillingNonNegativeNumber(
+              updated.total_billed,
+              "updated.total_billed",
+            ),
             cancelEndpoint: cancelEndpoint("container", updated.id),
             cancelAction: "stop",
             metadata: {
@@ -378,7 +397,10 @@ class ActiveBillingService {
               lastBilledAt: iso(agent.last_billed_at),
               nextBillingAt: null,
               estimatedNextBillingAt: null,
-              totalBilled: Number(agent.total_billed),
+              totalBilled: parseActiveBillingNonNegativeNumber(
+                agent.total_billed,
+                "agent_sandbox.total_billed",
+              ),
               cancelEndpoint: cancelEndpoint("agent_sandbox", agent.id),
               cancelAction: "suspend_billing",
               metadata: {
@@ -426,7 +448,10 @@ class ActiveBillingService {
             lastBilledAt: iso(updated.last_billed_at),
             nextBillingAt: null,
             estimatedNextBillingAt: null,
-            totalBilled: Number(updated.total_billed),
+            totalBilled: parseActiveBillingNonNegativeNumber(
+              updated.total_billed,
+              "updated.total_billed",
+            ),
             cancelEndpoint: cancelEndpoint("agent_sandbox", updated.id),
             cancelAction: "suspend_billing",
             metadata: {


### PR DESCRIPTION
Closes nothing (issue #13415 stays open for remaining service-layer inventory) — this is the `active-billing.ts` slice of the #13415 cloud/shared NUMERIC fail-open sweep.

## Defect

`active-billing.ts` read four Postgres NUMERIC columns via bare `Number(...)`:

- `containers.total_billed` (numeric(10,2)) — `listActiveResources` + `cancelResource` DTO
- `agent_sandboxes.total_billed` (numeric(10,2)) — same
- `agent_sandboxes.hourly_rate` (numeric(10,4)) — `metadata.hourlyRate`
- `credit_transactions.amount` (numeric(12,6)) — `listLedger`

Postgres accepts `'NaN'::numeric` as a valid stored value and the driver reads it back as the string `"NaN"`, so a corrupt row silently coerced to `NaN` and:

- rendered a fabricated `$NaN billed` line in the billing panel, and
- poisoned the amount in the credit-transaction ledger a user reads to reconcile what they were actually charged.

## Fix

New colocated fail-closed boundary `parseActiveBillingNumber` + `CorruptActiveBillingNumberError` (throws on missing/empty/non-finite; allows explicit domain zero and negatives, e.g. refunds) wired into all 8 NUMERIC read sites (`listActiveResources`, `listLedger`, and the `cancelResource` display DTOs). A corrupt row now surfaces as an observable error instead of a fabricated dollar figure. Null `hourly_rate` still falls back to the computed unit price (legit absence, not corruption).

Mirrors the merged #13415/#13416 family: #13454 / #13474 / #13482 / #13486 / #13503 / #13504 / #13508 / #13518 / #14045 / #14049 / #14052 / #14054 / #14055 / #14058.

## Tests

`packages/cloud/shared/src/lib/services/active-billing-numeric-fail-closed.test.ts` — 18 pass / 0 fail (bun test --isolate), covering:

- parser boundary: normal / zero / negative pass; `'NaN'` string, Infinity, null/undefined/empty/whitespace, garbage all THROW; error names field + raw value
- `listActiveResources`: healthy rows render real totals; explicit-zero legit; null hourly_rate fallback; corrupt container/agent `total_billed` + corrupt `hourly_rate` THROW instead of fabricating `$NaN`
- `listLedger`: healthy + explicit-zero pass; corrupt amount THROWS instead of poisoning the reconciliation view

`tsgo --noEmit`: 0 errors in touched files (4 pre-existing baseline errors in node-redis-adapter / plugin-mcp json / anthropic-web-search, identical on origin/develop, untouched). Biome clean.

## Collision receipts

- No open/closed PR touches `active-billing.ts` on #13415 scope at claim or push (broad `gh pr list --state all --search active-billing` = #14052/#14054/#14055 on OTHER files).
- No merged dup: `git log HEAD..origin/develop -- active-billing.ts` empty at push.
- Adopted from an abandoned sibling fleet lane (complete unpushed commit, zero live processes ~2h) per the zombie-guard/adoption precedent — validated, rebased onto latest origin/develop, and shipped rather than duplicated.

-- [sol-orch]
