### PR TITLE
fix(#13681): self-heal packaged desktop settings navigation across relaunch — [sol-orch]

### DIFF
--- a/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
@@ -79,18 +79,29 @@ function getSettingsSectionForRoute(route: string): string | null {
 function getRouteNavigationScript(route: string): string {
   const settingsSection = getSettingsSectionForRoute(route);
   if (settingsSection) {
+    // Re-fire the navigation intents on EVERY eval, not only when the hash
+    // differs. After a packaged relaunch the interactive App (and its
+    // NAVIGATE_SETTINGS_EVENT / hashchange listeners installed by
+    // bindReadyPhase) can mount a few polls after the harness declares the
+    // shell ready. A one-shot dispatch that is gated behind
+    // `hash !== targetHash` is silently dropped when it lands before those
+    // listeners exist, and the already-correct hash then suppresses every
+    // retry — so the settings tab never syncs and `settings-shell` never
+    // mounts (the #13681 `/settings/voice` timeout). Dispatching each poll is
+    // idempotent (the state writes are no-ops once set) and self-heals a
+    // late-mounting listener.
     return [
       `const targetRoute = ${JSON.stringify(route)};`,
       `const settingsSection = ${JSON.stringify(settingsSection)};`,
       `const readCurrentRoute = () => ${getCurrentRouteExpression()};`,
-      `window.dispatchEvent(new CustomEvent(${JSON.stringify(NAVIGATE_SETTINGS_EVENT)}, {`,
-      `  detail: { section: settingsSection },`,
-      `}));`,
       `const targetHash = "#" + settingsSection;`,
       `if (window.location.hash !== targetHash) {`,
       `  window.history.replaceState(null, "", targetHash);`,
-      `  window.dispatchEvent(new HashChangeEvent("hashchange"));`,
       `}`,
+      `window.dispatchEvent(new CustomEvent(${JSON.stringify(NAVIGATE_SETTINGS_EVENT)}, {`,
+      `  detail: { section: settingsSection },`,
+      `}));`,
+      `window.dispatchEvent(new HashChangeEvent("hashchange"));`,
       `const currentRoute = readCurrentRoute();`,
     ].join("\n");
   }
@@ -103,8 +114,13 @@ function getRouteNavigationScript(route: string): string {
     `  if (window.location.hash !== targetHash) {`,
     `    window.location.hash = targetHash;`,
     `  }`,
+    `  // Re-fire hashchange every poll so a nav listener that mounts after the`,
+    `  // first dispatch (post-relaunch race) still picks up the target route.`,
+    `  window.dispatchEvent(new HashChangeEvent("hashchange"));`,
     `} else if (window.location.pathname !== targetRoute) {`,
     `  window.history.pushState(null, "", targetRoute);`,
+    `  window.dispatchEvent(new Event("popstate"));`,
+    `} else {`,
     `  window.dispatchEvent(new Event("popstate"));`,
     `}`,
     `const currentRoute = readCurrentRoute();`,
@@ -1042,12 +1058,25 @@ async function withPackagedHarness(
     );
 
     // Wait for the startup coordinator to finish transitioning past the
-    // StartupShell. Bootstrap requests prove the live API is reachable, but
-    // the startup coordinator may still be in polling-backend → starting-runtime
-    // → hydrating phases. Poll until the startup shell DOM element is gone
-    // and the root element has substantial content.
+    // StartupShell AND for the interactive desktop app shell to actually mount.
+    // Bootstrap requests prove the live API is reachable, but the startup
+    // coordinator may still be in polling-backend → starting-runtime →
+    // hydrating phases.
     //
-    // Previous approach used a regex on body text (/LOADING/i etc.) which
+    // #13681: the previous gate only required `rootHtml.length > 200 &&
+    // !startupShell` (and checked a phantom `first-run-shell` selector that no
+    // longer exists, so it never matched). That declared "ready" during the
+    // transitional window AFTER the startup splash is torn down but BEFORE the
+    // real App mounts its navigation listeners (bindReadyPhase installs the
+    // hashchange→setTabRaw sync; the App effect installs the
+    // NAVIGATE_SETTINGS_EVENT → setTab("settings") handler). Navigating to
+    // `/settings/voice` in that gap dropped the intent on the floor, the
+    // settings tab never synced, and `settings-shell` timed out at ~512-char
+    // empty root. Require the desktop tablist (rendered only by the interactive
+    // shell once the App is live) so navigation is issued against a mounted,
+    // listener-bearing App.
+    //
+    // Previous approach also used a regex on body text (/LOADING/i etc.) which
     // false-positived on app-shell "Loading messages…" text in ChatView,
     // causing the relaunch to stall even though the coordinator reached ready.
     await waitForEval<
@@ -1056,6 +1085,7 @@ async function withPackagedHarness(
         rootLength: number;
         bodySnippet: string;
         startupPhase: string | null;
+        interactiveShell: boolean;
       }>
     >(
       harness,
@@ -1063,15 +1093,28 @@ async function withPackagedHarness(
         try {
           const rootHtml = document.getElementById("root")?.innerHTML ?? "";
           const startupShell = document.querySelector('[data-testid="startup-shell-loading"]');
-          const firstRunOverlay = document.querySelector('[data-testid="first-run-shell"]');
           const startupPhase = startupShell?.getAttribute("data-startup-phase") ?? null;
           const bodyText = (document.body?.innerText || "").replace(/\\s+/g, " ").trim();
+          // Interactive-shell markers that only render once the real App is
+          // mounted (and thus its navigation listeners — hashchange→setTabRaw
+          // via bindReadyPhase and NAVIGATE_SETTINGS_EVENT→setTab — are live).
+          // ANY of these proves we are past the transitional post-splash gap
+          // that caused the #13681 dropped-navigation timeout. We accept the
+          // union so a momentarily-empty desktop tab list (which self-hides)
+          // cannot deadlock the gate.
+          const interactiveShell = Boolean(
+            document.querySelector('[role="tablist"][aria-label="Desktop view tabs"]') ||
+              document.querySelector('[data-testid="continuous-chat-overlay"]') ||
+              document.querySelector('[data-testid="settings-shell"]') ||
+              document.querySelector('[data-testid="chat-pill"]'),
+          );
           return {
             ok: true,
-            ready: rootHtml.length > 200 && !startupShell && !firstRunOverlay,
+            ready: rootHtml.length > 200 && !startupShell && interactiveShell,
             rootLength: rootHtml.length,
             bodySnippet: bodyText.slice(0, 120),
             startupPhase,
+            interactiveShell,
           };
         } catch (e) {
           return { ok: false, ready: false, rootLength: 0, bodySnippet: "", startupPhase: null };


### PR DESCRIPTION
## What

Fixes the nightly **App Live E2E** `desktop packaged` job's recurring
`Timed out waiting for [data-testid="settings-shell"] at /settings/voice`
failure (#13681). Harness-only change — no production/app code touched.

## Root cause (settings-shell timeout)

From the last real failure (run 28647271527, 2026-07-03), the desktop job's second failure was the settings-shell timeout, render showing `{found:false, firstRunFound:false, rootHtmlLength:512, bodyText:""}`.

This is a **post-relaunch race** in `electrobun-packaged-regressions.e2e.spec.ts`:

1. The post-relaunch ready-gate declared "ready" on `rootHtml.length > 200 && !startup-shell-loading && !first-run-shell`. `first-run-shell` is a **phantom selector** (removed when onboarding moved in-chat), so that clause was dead. The gate therefore passed during the transitional window **after** the startup splash is torn down but **before** the interactive App mounts its navigation listeners:
   - `bindReadyPhase` installs `hashchange → setTabRaw` (`startup-phase-hydrate.ts`)
   - the App effect installs `NAVIGATE_SETTINGS_EVENT → setTab("settings")` (`App.tsx`)
2. `getRouteNavigationScript` dispatched the settings navigation **once**, gated behind `hash !== targetHash`. The first dispatch landed **before** those listeners existed and was dropped; the now-correct hash then suppressed every retry. The settings tab never synced → the lazy `SettingsView` never mounted → 20s timeout on a ~512-char empty root.

## Fix

1. **Re-dispatch the navigation intent on every poll** (`NAVIGATE_SETTINGS_EVENT` + `hashchange` for settings routes; `hashchange`/`popstate` for others). The underlying state writes are idempotent, so a nav listener that mounts a few polls late still picks up the target route instead of the intent being lost forever.
2. **Strengthen the post-relaunch ready-gate** to require an interactive-shell marker (desktop tablist, `continuous-chat-overlay`, `settings-shell`, or `chat-pill`) so navigation is only issued against a mounted, listener-bearing App. Drops the dead `first-run-shell` selector.

## Screenshot 503 (companion, already handled)

The desktop job's other failure — screenshot `503` because `scrot`/`import`/`ffmpeg`/`xwd` weren't installed — is **already fixed on develop by #13680** (the workflow now installs `scrot imagemagick x11-apps ffmpeg`). This PR closes the remaining settings-shell cause so the nightly can go green.

## Validation

- Project typecheck (`tsgo --noEmit -p tsconfig.typecheck.json`) is clean for the edited spec.
- The full packaged-desktop run needs `libwebkit2gtk` (unavailable on the authoring host, apt needs sudo); the fix is a static-traced race repair exercised end-to-end by the CI `desktop packaged` leg. Watch three consecutive scheduled runs per the issue's Done-when.

Closes part of #13681 (settings-shell timeout leg).

— [sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>