### PR TITLE
fix(#13415): fail closed on corrupt credit_balance in the solo-org vacate gate

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/invite-vacate-credit-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/invite-vacate-credit-fail-closed.test.ts
@@ -66,6 +66,9 @@ let schemas: {
   managedDomains: typeof import("../../../db/schemas/managed-domains").managedDomains;
 };
 
+const SOLO_ORG_CREDITS_BLOCK_MESSAGE =
+  "You cannot join another organization while your current organization holds credits beyond the signup grant. Contact support to transfer them first.";
+
 let seq = 0;
 function uid(): string {
   seq += 1;
@@ -250,9 +253,9 @@ describe("acceptInvite solo-org vacate — corrupt credit_balance fails closed (
       // guard is bypassed, the accept succeeds, and the org is DELETED. The
       // fail-closed parse throws instead, so the accept is rejected and the org
       // (with its unreadable balance) is preserved.
-      await expect(
-        invitesService.acceptInvite(seeded.token, seeded.inviteeUserId),
-      ).rejects.toThrow();
+      await expect(invitesService.acceptInvite(seeded.token, seeded.inviteeUserId)).rejects.toThrow(
+        SOLO_ORG_CREDITS_BLOCK_MESSAGE,
+      );
 
       expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(seeded.inviteeOrgId);
       expect(await orgExists(seeded.inviteeOrgId)).toBe(true);

--- a/packages/cloud/shared/src/lib/services/__tests__/invite-vacate-credit-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/invite-vacate-credit-fail-closed.test.ts
@@ -1,0 +1,280 @@
+/**
+ * acceptInvite solo-org vacate: fail-closed on a corrupt credit_balance (#13415).
+ *
+ * `InvitesService.assertOwnerCanVacateSoloOrganization` guards the auto-delete
+ * of a vacated solo org: an owner may only move into an inviting org (which
+ * deletes their now-empty solo org via `cleanUpVacatedSoloOrganization ->
+ * organizationsService.delete`) if that org holds NO more credits than the
+ * signup grant — otherwise those credits would be silently destroyed.
+ *
+ * `credit_balance` is a Postgres NUMERIC (string at read). The previous gate
+ * read it through a bare `Number(organization.credit_balance) >
+ * getInitialCredits()`, which fails OPEN on a corrupt value: `'NaN'::numeric`
+ * is a valid Postgres NUMERIC (a migration artifact or manual edit can produce
+ * it, and — as this suite's own probe confirms — it even satisfies the
+ * `credit_balance >= 0` CHECK because NaN sorts as greatest), and it reads back
+ * as the string `"NaN"`. `Number("NaN")` is `NaN`, and `NaN > getInitialCredits()`
+ * is FALSE — so the guard was BYPASSED and the org, with whatever real credits
+ * it held, was vacated and DELETED, silently losing the balance.
+ *
+ * Case 1 is the reversion proof: it seeds a corrupt `'NaN'` balance via raw SQL
+ * (bypassing the drizzle insert type-guard, mirroring how the corruption arises
+ * in prod) and asserts the accept is REJECTED and the org PRESERVED. With the
+ * fail-open `Number(...)` restored it fails (the org is deleted). Case 2 is the
+ * no-false-block control: a healthy balance at-or-below the grant still vacates.
+ *
+ * Runs the REAL `InvitesService.acceptInvite` against in-process PGlite (real
+ * users/organizations/invites SQL). Fails loudly via the `pgliteReady` guard if
+ * PGlite/pushSchema ever fails to initialize — never a silent skip.
+ */
+
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+
+// This proof owns its DB: force an isolated in-memory PGlite regardless of the
+// ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports.
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+// Not the seam under test: `invites.ts` imports the email service at module
+// level for createInvite's notification. acceptInvite never sends mail.
+mock.module("../email", () => ({
+  emailService: {
+    sendInviteEmail: mock(async () => false),
+  },
+}));
+
+const PGLITE_TIMEOUT = 60_000;
+
+let pgliteReady = true;
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let invitesService: typeof import("../invites").invitesService;
+let generateInviteToken: typeof import("../../utils/invite-tokens").generateInviteToken;
+let hashInviteToken: typeof import("../../utils/invite-tokens").hashInviteToken;
+let getInitialCredits: typeof import("../../signup-credits").getInitialCredits;
+let schemas: {
+  organizations: typeof import("../../../db/schemas/organizations").organizations;
+  users: typeof import("../../../db/schemas/users").users;
+  organizationInvites: typeof import("../../../db/schemas/organization-invites").organizationInvites;
+  userCharacters: typeof import("../../../db/schemas/user-characters").userCharacters;
+  conversations: typeof import("../../../db/schemas/conversations").conversations;
+  apps: typeof import("../../../db/schemas/apps").apps;
+  containers: typeof import("../../../db/schemas/containers").containers;
+  agentSandboxes: typeof import("../../../db/schemas/agent-sandboxes").agentSandboxes;
+  managedDomains: typeof import("../../../db/schemas/managed-domains").managedDomains;
+};
+
+let seq = 0;
+function uid(): string {
+  seq += 1;
+  return `00000000-0000-4000-8000-${String(seq).padStart(12, "0")}`;
+}
+
+interface SeedResult {
+  inviterOrgId: string;
+  inviterUserId: string;
+  inviteeOrgId: string;
+  inviteeUserId: string;
+  inviteId: string;
+  token: string;
+}
+
+async function seedInviteScenario(options?: {
+  inviteeOrgBalance?: string;
+  invitedRole?: "admin" | "member";
+}): Promise<SeedResult> {
+  const inviterOrgId = uid();
+  const inviterUserId = uid();
+  const inviteeOrgId = uid();
+  const inviteeUserId = uid();
+  const inviteeEmail = `invitee-${inviteeUserId}@example.com`;
+
+  await dbWrite.insert(schemas.organizations).values([
+    { id: inviterOrgId, name: "Team Org", slug: `team-${inviterOrgId}` },
+    {
+      id: inviteeOrgId,
+      name: "Solo Org",
+      slug: `solo-${inviteeOrgId}`,
+      credit_balance: options?.inviteeOrgBalance ?? "5.000000",
+    },
+  ]);
+  await dbWrite.insert(schemas.users).values([
+    {
+      id: inviterUserId,
+      steward_user_id: `steward-${inviterUserId}`,
+      email: `inviter-${inviterUserId}@example.com`,
+      organization_id: inviterOrgId,
+      role: "owner",
+    },
+    {
+      id: inviteeUserId,
+      steward_user_id: `steward-${inviteeUserId}`,
+      email: inviteeEmail,
+      organization_id: inviteeOrgId,
+      role: "owner",
+    },
+  ]);
+
+  const token = generateInviteToken();
+  const inviteId = uid();
+  await dbWrite.insert(schemas.organizationInvites).values({
+    id: inviteId,
+    organization_id: inviterOrgId,
+    inviter_user_id: inviterUserId,
+    invited_email: inviteeEmail,
+    invited_role: options?.invitedRole ?? "member",
+    token_hash: hashInviteToken(token),
+    expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    status: "pending",
+  });
+
+  return { inviterOrgId, inviterUserId, inviteeOrgId, inviteeUserId, inviteId, token };
+}
+
+async function readUser(userId: string): Promise<{ organization_id: string | null }> {
+  const rows = await dbWrite.execute(`SELECT organization_id FROM users WHERE id = '${userId}';`);
+  return rows.rows[0] as { organization_id: string | null };
+}
+
+async function orgExists(orgId: string): Promise<boolean> {
+  const rows = await dbWrite.execute(`SELECT id FROM organizations WHERE id = '${orgId}';`);
+  return rows.rows.length > 0;
+}
+
+async function readOrgBalance(orgId: string): Promise<string> {
+  const rows = await dbWrite.execute(
+    `SELECT credit_balance FROM organizations WHERE id = '${orgId}';`,
+  );
+  return (rows.rows[0] as { credit_balance: string }).credit_balance;
+}
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ invitesService } = await import("../invites"));
+    ({ generateInviteToken, hashInviteToken } = await import("../../utils/invite-tokens"));
+    ({ getInitialCredits } = await import("../../signup-credits"));
+
+    const { organizations } = await import("../../../db/schemas/organizations");
+    const { users } = await import("../../../db/schemas/users");
+    const { organizationInvites } = await import("../../../db/schemas/organization-invites");
+    const { userCharacters } = await import("../../../db/schemas/user-characters");
+    const { conversations } = await import("../../../db/schemas/conversations");
+    const { apiKeys } = await import("../../../db/schemas/api-keys");
+    const { creditTransactions } = await import("../../../db/schemas/credit-transactions");
+    const { apps, appDeploymentStatusEnum, appReviewStatusEnum, userDatabaseStatusEnum } =
+      await import("../../../db/schemas/apps");
+    const { containers } = await import("../../../db/schemas/containers");
+    const { agentSandboxes } = await import("../../../db/schemas/agent-sandboxes");
+    const {
+      domainModerationStatusEnum,
+      domainNameserverModeEnum,
+      domainRegistrarEnum,
+      domainResourceTypeEnum,
+      domainStatusEnum,
+      managedDomains,
+    } = await import("../../../db/schemas/managed-domains");
+    const { mcpPricingTypeEnum, mcpStatusEnum, userMcps } = await import(
+      "../../../db/schemas/user-mcps"
+    );
+    schemas = {
+      organizations,
+      users,
+      organizationInvites,
+      userCharacters,
+      conversations,
+      apps,
+      containers,
+      agentSandboxes,
+      managedDomains,
+    };
+
+    const { pushSchema } = await import("../../../db/push-schema-for-tests");
+    const { apply } = await pushSchema(
+      {
+        organizations,
+        users,
+        organizationInvites,
+        userCharacters,
+        conversations,
+        apiKeys,
+        creditTransactions,
+        apps,
+        containers,
+        agentSandboxes,
+        managedDomains,
+        domainRegistrarEnum,
+        domainNameserverModeEnum,
+        domainResourceTypeEnum,
+        domainModerationStatusEnum,
+        domainStatusEnum,
+        userMcps,
+        mcpPricingTypeEnum,
+        mcpStatusEnum,
+        appDeploymentStatusEnum,
+        appReviewStatusEnum,
+        userDatabaseStatusEnum,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error("[invite-vacate-credit-fail-closed.test] PGlite/pushSchema unavailable.", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("acceptInvite solo-org vacate — corrupt credit_balance fails closed (#13415)", () => {
+  test(
+    "a corrupt 'NaN' credit_balance BLOCKS the vacate and preserves the org (fail-open regression)",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario();
+
+      // Poison the balance the way prod corruption arises: a raw NUMERIC 'NaN'
+      // that the drizzle insert type-guard would reject but the column happily
+      // stores (and which satisfies credit_balance >= 0 because NaN sorts as
+      // greatest in Postgres NUMERIC). Sanity-check it actually persisted.
+      await dbWrite.execute(
+        `UPDATE organizations SET credit_balance = 'NaN' WHERE id = '${seeded.inviteeOrgId}';`,
+      );
+      expect(await readOrgBalance(seeded.inviteeOrgId)).toBe("NaN");
+
+      // With the fail-open Number(...) restored, NaN > grant is false so the
+      // guard is bypassed, the accept succeeds, and the org is DELETED. The
+      // fail-closed parse throws instead, so the accept is rejected and the org
+      // (with its unreadable balance) is preserved.
+      await expect(
+        invitesService.acceptInvite(seeded.token, seeded.inviteeUserId),
+      ).rejects.toThrow();
+
+      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(seeded.inviteeOrgId);
+      expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a healthy balance at-or-below the signup grant still vacates (no false block)",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      // At exactly the grant: `> getInitialCredits()` is false, vacate allowed.
+      const atGrant = getInitialCredits().toFixed(6);
+      const seeded = await seedInviteScenario({ inviteeOrgBalance: atGrant });
+
+      const accepted = await invitesService.acceptInvite(seeded.token, seeded.inviteeUserId);
+      expect(accepted.status).toBe("accepted");
+
+      // Moved into the inviting org; the emptied solo org is deleted as designed.
+      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(seeded.inviterOrgId);
+      expect(await orgExists(seeded.inviteeOrgId)).toBe(false);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/invites.ts
+++ b/packages/cloud/shared/src/lib/services/invites.ts
@@ -12,6 +12,7 @@ import { appsRepository } from "../../db/repositories/apps";
 import { userCharactersRepository } from "../../db/repositories/characters";
 import { containersRepository } from "../../db/repositories/containers";
 import { conversationsRepository } from "../../db/repositories/conversations";
+import { parseOrganizationCreditBalance } from "../../db/repositories/organizations-credit-balance-numeric";
 import { getInitialCredits } from "../signup-credits";
 import { generateInviteToken, hashInviteToken } from "../utils/invite-tokens";
 import { logger } from "../utils/logger";
@@ -261,10 +262,27 @@ export class InvitesService {
     }
 
     const organization = await organizationsService.getById(organizationId);
-    if (organization && Number(organization.credit_balance) > getInitialCredits()) {
-      throw new Error(
-        "You cannot join another organization while your current organization holds credits beyond the signup grant. Contact support to transfer them first.",
+    if (organization) {
+      // Fail closed on a corrupt `credit_balance` (#13415). This guard exists to
+      // stop an owner vacating (and thereby auto-deleting) a solo org that still
+      // holds credits beyond the signup grant. `credit_balance` is a Postgres
+      // NUMERIC (string at read); the previous bare `Number(...)` failed OPEN on
+      // an unreadable value (`'NaN'::numeric` migration artifact / manual edit
+      // reads back `"NaN"`): `NaN > getInitialCredits()` is FALSE, so the guard
+      // was bypassed and the org — with whatever real credits it held — was
+      // vacated and deleted downstream (`cleanUpVacatedSoloOrganization` ->
+      // `organizationsService.delete`), silently destroying the balance. Parsing
+      // fail-closed makes a corrupt balance BLOCK the vacate (surfaced as the
+      // same "contact support" boundary) instead of silently losing credits.
+      const creditBalance = parseOrganizationCreditBalance(
+        organization.credit_balance,
+        "credit_balance",
       );
+      if (creditBalance > getInitialCredits()) {
+        throw new Error(
+          "You cannot join another organization while your current organization holds credits beyond the signup grant. Contact support to transfer them first.",
+        );
+      }
     }
   }
 

--- a/packages/cloud/shared/src/lib/services/invites.ts
+++ b/packages/cloud/shared/src/lib/services/invites.ts
@@ -22,6 +22,9 @@ import { managedDomainsService } from "./managed-domains";
 import { organizationsService } from "./organizations";
 import { usersService } from "./users";
 
+const SOLO_ORG_CREDITS_BLOCK_MESSAGE =
+  "You cannot join another organization while your current organization holds credits beyond the signup grant. Contact support to transfer them first.";
+
 /**
  * Parameters for creating an organization invite.
  */
@@ -274,14 +277,19 @@ export class InvitesService {
       // `organizationsService.delete`), silently destroying the balance. Parsing
       // fail-closed makes a corrupt balance BLOCK the vacate (surfaced as the
       // same "contact support" boundary) instead of silently losing credits.
-      const creditBalance = parseOrganizationCreditBalance(
-        organization.credit_balance,
-        "credit_balance",
-      );
-      if (creditBalance > getInitialCredits()) {
-        throw new Error(
-          "You cannot join another organization while your current organization holds credits beyond the signup grant. Contact support to transfer them first.",
+      let creditBalance: number;
+      try {
+        creditBalance = parseOrganizationCreditBalance(
+          organization.credit_balance,
+          "credit_balance",
         );
+      } catch (error) {
+        // error-policy:J4 corrupt balance data blocks the user-visible invite
+        // vacate path instead of falling through as a generic storage failure.
+        throw new Error(SOLO_ORG_CREDITS_BLOCK_MESSAGE, { cause: error });
+      }
+      if (creditBalance > getInitialCredits()) {
+        throw new Error(SOLO_ORG_CREDITS_BLOCK_MESSAGE);
       }
     }
   }
@@ -322,6 +330,8 @@ export class InvitesService {
       await this.assertOwnerCanVacateSoloOrganization(userId, previousOrganizationId);
       await organizationsService.delete(previousOrganizationId);
     } catch (error) {
+      // error-policy:J6 the invite accept already moved the user; cleanup is
+      // best-effort and must leave a warn breadcrumb for manual recovery.
       logger.warn("[InvitesService] Failed to clean up vacated solo organization", {
         previousOrganizationId,
         userId,


### PR DESCRIPTION
## What

`InvitesService.assertOwnerCanVacateSoloOrganization` gates the auto-delete of a vacated solo org: an owner may only accept another org's invite (which deletes their now-empty solo org via `cleanUpVacatedSoloOrganization` -> `organizationsService.delete`) if that org holds no credits beyond the signup grant.

`organizations.credit_balance` is a Postgres NUMERIC (string at read). The gate read it via a bare `Number(organization.credit_balance) > getInitialCredits()`, which fails **open** on a corrupt value: `'NaN'::numeric` is a valid Postgres NUMERIC (it even satisfies the `credit_balance >= 0` CHECK because NaN sorts greatest — proven by the test's own raw-SQL seed), reads back as `"NaN"`, and `NaN > getInitialCredits()` is FALSE. The guard was bypassed and the org — with whatever real credits it actually held — was vacated and **deleted**, silently destroying the balance. This is the exact money-destruction scenario the guard exists to prevent.

## Fix

The read now delegates to the already-merged `parseOrganizationCreditBalance` fail-closed boundary (#13416 — same `organizations.credit_balance` column `OrganizationsRepository` already parses this way): a corrupt balance now **blocks** the vacate (surfaced at the same "contact support" boundary) instead of silently losing credits. Healthy balances at-or-below the grant vacate unchanged.

Scoped #13415 slice: `services/invites.ts` only. Distinct file from all open #13415 PRs (#14037/#14045/#14049/#14052/#14054/#14055/#14058/#14060/#14061/#14063/#14064).

## Tests

`bun test --isolate src/lib/services/__tests__/invite-vacate-credit-fail-closed.test.ts` — 2/2 green. Runs the REAL `InvitesService.acceptInvite` against in-process PGlite (real users/organizations/invites SQL):

- **Reversion-proven regression:** seeds a corrupt `'NaN'` balance via raw SQL (mirroring how the corruption arises in prod, bypassing drizzle's insert type-guard) and asserts the accept is REJECTED and the org PRESERVED. Verified this case FAILS on the pristine bare-`Number` gate (org gets deleted) and passes with the fix.
- **No-false-block control:** a healthy balance at-or-below the signup grant still vacates.

Gates: tsgo typecheck — 0 errors in touched files (6 pre-existing baseline errors in node-redis-adapter / plugin-mcp json / anthropic-web-search / plugin-elizacloud, identical on develop); biome clean on both files.

## Collision receipts

- No open/closed PR touches the vacate credit gate (`gh pr list --state all --search "invites vacate"` = #11440/#11406/#13989, all different surfaces: vacated-org recheck / empty-solo accept / default api key).
- No merged dup: `git log origin/develop --since=2026-07-05T09:00Z -- services/invites.ts` empty.
- No lalalune/NubsCarson/roninjin10 PR on this file in the last day.

Adopted from an abandoned sibling fleet lane (staged-but-never-committed fix, zero live processes on the worktree for ~2h) per the fleet's adoption precedent — validated, reversion-proven, rebased onto latest origin/develop before push.

Closes nothing — #13415 stays open for the remaining service-layer inventory.

-- [sol-orch]
