### PR TITLE
fix(app): PWA shell — transparent safe-area floor on wallpaper routes, SW shell-cache versioning, theme-color (r3.x upstream)

### DIFF
--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -14,7 +14,11 @@
 "use strict";
 
 const VIEWS_CACHE_NAME = "elizaos-views-v1";
-const SHELL_CACHE_NAME = "elizaos-shell-v1";
+// Bump the shell cache to evict any stale precached index/CSS in an installed
+// iOS standalone PWA (Add-to-Home-Screen runs this SW). The network-first shell
+// still updates on reload, but the version bump forces old caches to be dropped
+// in `activate` so a re-open can't serve a pre-safe-area-fix shell from cache.
+const SHELL_CACHE_NAME = "elizaos-shell-v2";
 const HERO_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 h
 const KNOWN_CACHES = [VIEWS_CACHE_NAME, SHELL_CACHE_NAME];
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -96,6 +96,7 @@ import { useAuthStatus } from "./hooks/useAuthStatus";
 import { useRole } from "./hooks/useRole";
 import { useSecretsManagerModalState } from "./hooks/useSecretsManagerModal";
 import { useSecretsManagerShortcut } from "./hooks/useSecretsManagerShortcut";
+import { cn } from "./lib/utils";
 import {
   APPS_ENABLED,
   getAppSlugFromPath,
@@ -2427,21 +2428,35 @@ export function App() {
           }}
         >
           {/* BOTTOM-BAR / SAFE-AREA FLOOR (do not remove): a viewport-filling
-              dark background-token floor mounted on EVERY route, behind the
-              shader (z-0) and every other layer. html/body/#root paint the
-              orange launch guard (--launch-bg #ef5a1f) as a FOUC color, and on
-              shared-background routes (home/chat) the AppBackground shader was
-              the ONLY thing hiding it. On iOS the composer overlay is anchored
-              by the visualViewport-derived `bottom`, so in the home-indicator
-              safe-area the shader coverage can fall short and the orange host
-              color bled through as a band under the composer. This floor makes
-              the bottom inset (and every unpainted zone) the dark BACKGROUND
-              token — never accent — regardless of route or shader state. The
-              shader/wallpaper renders on top of it unchanged on shared routes. */}
+              floor mounted on EVERY route, behind the shader (z-0) and every
+              other layer. html/body/#root paint the orange launch guard
+              (--launch-bg #ef5a1f) as a FOUC color; this floor guarantees the
+              bottom inset (and every unpainted zone) reads as the BACKGROUND
+              token, never the accent, regardless of route or shader state.
+
+              Standalone-PWA bottom-bar fix: on SHARED-background routes
+              (home/chat) this floor must be TRANSPARENT, not an opaque `bg-bg`
+              slab. The wallpaper (`AppBackground` -> `ImageBackground`, a
+              `fixed inset-0` full-bleed layer that reaches the true viewport
+              bottom incl. the home-indicator safe-area) is what should show
+              beneath the floating composer, edge-to-edge (lockscreen/iMessage
+              style). An opaque floor here painted a dark near-black band in the
+              home-indicator zone under the floating composer even though the
+              wallpaper sits above it. Going transparent on wallpaper routes
+              lets the full-bleed wallpaper own the whole screen down to the
+              bottom edge; the FOUC/orange guard is still covered because the
+              wallpaper layer is opaque cover-fit. On OPAQUE/overlay routes (no
+              wallpaper) the floor keeps `bg-bg` so the orange guard never
+              shows. */}
           <div
             aria-hidden="true"
             data-testid="app-safe-area-floor"
-            className="pointer-events-none fixed inset-0 z-[-1] bg-bg"
+            className={cn(
+              "pointer-events-none fixed inset-0 z-[-1]",
+              // Transparent under the full-bleed wallpaper so it shows to the
+              // very bottom edge; opaque dark elsewhere as the FOUC guard.
+              renderSharedAppBackground ? "bg-transparent" : "bg-bg",
+            )}
           />
           {/* The unified app background, mounted once here so it persists
               seamlessly across shared-background routes. It keeps the


### PR DESCRIPTION
## What

Two generic PWA-shell fixes that kill a **device-visible dark band ("black bar") in the iOS home-indicator safe-area under the floating chat composer** in an installed standalone PWA (Add-to-Home-Screen).

### 1. `packages/ui/src/App.tsx` — transparent safe-area floor on wallpaper routes
The `app-safe-area-floor` was an opaque `bg-bg` slab spanning the full viewport incl. the home-indicator zone. On shared-background (home/chat) routes the full-bleed wallpaper (`AppBackground` → `ImageBackground`, `fixed inset-0`) sits above it and reaches the true bottom edge — but the opaque floor still painted a dark near-black band in the home-indicator safe-area under the **floating** composer.

- In an iOS **browser tab** the Safari bottom toolbar masks that zone, so it looked fine.
- In an installed iOS **standalone** PWA there is no toolbar, so the band was visible.

**Fix:** the floor goes `bg-transparent` on shared-background (wallpaper) routes, so the full-bleed wallpaper owns the whole screen down to the bottom edge (lockscreen / iMessage style). The FOUC / orange launch guard stays covered because the wallpaper layer is opaque cover-fit. On **opaque/overlay** routes (no wallpaper) the floor keeps `bg-bg` so the orange launch guard never shows.

### 2. `packages/app/public/sw.js` — SW shell-cache versioning (`elizaos-shell-v1` → `v2`)
Bumps `SHELL_CACHE_NAME` so an installed standalone PWA evicts any stale precached index/CSS on re-open. The network-first shell still updates on reload, but the version bump forces old caches to be dropped in `activate`, so a re-open can't serve a pre-fix shell from cache.

## Verification
- `packages/ui` typecheck: **0 errors in `App.tsx`** (added `cn` import + `renderSharedAppBackground` ternary resolve clean).
- `packages/app` typecheck: **0 errors in changed files.**
- `node --check packages/app/public/sw.js`: syntax OK.
- Device-verified on iOS standalone PWA (Add-to-Home-Screen) by @wakesync.

_(Remaining typecheck errors in the local env are pre-existing `Cannot find module '@elizaos/*'` from unbuilt workspace packages / uncodegen'd `./generated/*`, unrelated to this diff.)_

## Deliberately left OUT (instance-specific, not upstreamable)
Mined from a downstream branch that also carried an instance-specific dark skin. **Not included here:**
- `theme-color` / launch `backgroundColor` flip `#ef5a1f` → dark, and the dark-first theme resolution (`getSystemTheme`, styles `--launch-bg`). Upstream ships the **light-first curated look by design**; changing theme-color upstream would be wrong.
- Instance-specific build-info stamps and dev-host allowlists.

The composer-float behavior these fixes pair with **already exists on `develop`** (converged independently via the `continuous-chat-bottom-floor` layer + resting `paddingBottom` safe-area inset), so it is **not** re-applied here.

— [sol-orch]