### PR TITLE
ci: fan-out reduction — path-gates + universal cancel-in-progress (#14051 Tier B)

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -6,6 +6,14 @@ on:
   issues:
     types: [opened, edited]
 
+# #14051 Tier B: label runs are pure metadata — a superseded label pass on the
+# same PR/issue is worthless. Cancel the in-flight run when a new event lands so
+# rapid pushes don't pile up 70+ queued Auto Label runs on the fleet. Group by
+# PR number (or issue number) so PR and issue lanes never collide.
+concurrency:
+  group: auto-label-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/setup-bun-workspace-self-test.yml
+++ b/.github/workflows/setup-bun-workspace-self-test.yml
@@ -7,6 +7,12 @@ on:
       - ".github/workflows/setup-bun-workspace-self-test.yml"
   workflow_dispatch:
 
+# #14051 Tier B: cancel superseded self-test runs on rapid pushes to the
+# setup-bun action so iterating on it doesn't queue duplicate fleet jobs.
+concurrency:
+  group: setup-bun-workspace-self-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/supply-chain.yaml
+++ b/.github/workflows/supply-chain.yaml
@@ -9,6 +9,13 @@ on:
   schedule:
     - cron: "0 6 * * 1" # weekly Monday 06:00 UTC
 
+# #14051 Tier B: cancel superseded PR runs (SBOM + scan) on rapid pushes.
+# Only PRs cancel; push-to-main and the weekly schedule always run to
+# completion so the protected-branch supply-chain record is never dropped.
+concurrency:
+  group: supply-chain-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Default to least privilege. Override per-job where needed.
 permissions:
   contents: read

--- a/.github/workflows/terraform-apps-data-plane.yml
+++ b/.github/workflows/terraform-apps-data-plane.yml
@@ -82,8 +82,17 @@ permissions:
 # would otherwise race a concurrent per-env app_node attach. PR validation
 # stays parallel via the format() fallback.
 concurrency:
-  group: ${{ github.event_name == 'workflow_dispatch' && 'terraform-apps-hetzner' || format('pr-{0}', github.ref) }}
-  cancel-in-progress: false
+  # PR group is workflow-scoped (data-plane) so it never collides with the
+  # sibling apps-shared workflow — concurrency groups are repo-wide, and a PR
+  # touching both modules must not have one workflow cancel the other's
+  # fmt/validate. workflow_dispatch keeps the shared 'terraform-apps-hetzner'
+  # group so an apply on either half still serializes against the other.
+  group: ${{ github.event_name == 'workflow_dispatch' && 'terraform-apps-hetzner' || format('terraform-apps-data-plane-pr-{0}', github.ref) }}
+  # #14051 Tier B: PR runs are fmt+validate only (no creds, no state) — safe to
+  # cancel a superseded PR run on the next push. workflow_dispatch (plan/apply
+  # against real state) uses the separate 'terraform-apps-hetzner' group and is
+  # NEVER cancelled, so an in-flight apply cannot be interrupted.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   TF_DIR: packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane

--- a/.github/workflows/terraform-apps-shared.yml
+++ b/.github/workflows/terraform-apps-shared.yml
@@ -57,8 +57,17 @@ permissions:
 # otherwise race a concurrent apps-data-plane apply that's mid-attach. PR
 # validation stays parallel via the format('pr-{0}', github.ref) fallback.
 concurrency:
-  group: ${{ github.event_name == 'workflow_dispatch' && 'terraform-apps-hetzner' || format('pr-{0}', github.ref) }}
-  cancel-in-progress: false
+  # PR group is workflow-scoped (apps-shared) so it never collides with the
+  # sibling apps-data-plane workflow — concurrency groups are repo-wide, and a
+  # PR touching both modules must not have one workflow cancel the other's
+  # fmt/validate. workflow_dispatch keeps the shared 'terraform-apps-hetzner'
+  # group so an apply on either half still serializes against the other.
+  group: ${{ github.event_name == 'workflow_dispatch' && 'terraform-apps-hetzner' || format('terraform-apps-shared-pr-{0}', github.ref) }}
+  # #14051 Tier B: PR runs are fmt+validate only (no creds, no state) — safe to
+  # cancel a superseded PR run on the next push. workflow_dispatch (plan/apply
+  # against real state) uses the separate 'terraform-apps-hetzner' group and is
+  # NEVER cancelled, so an in-flight apply cannot be interrupted.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   TF_DIR: packages/cloud/infra/cloud/terraform/hetzner/apps-shared

--- a/.github/workflows/terraform-control-plane.yml
+++ b/.github/workflows/terraform-control-plane.yml
@@ -62,7 +62,11 @@ permissions:
 # the same env concurrently. PR validation stays parallel (different group).
 concurrency:
   group: terraform-control-plane-${{ github.event.inputs.environment || format('pr-{0}', github.ref) }}
-  cancel-in-progress: false
+  # #14051 Tier B: PR runs are fmt+validate only (no creds, no state) — safe to
+  # cancel a superseded PR run on the next push. workflow_dispatch (plan/apply
+  # against real state) groups by environment and is NEVER cancelled, so an
+  # in-flight apply cannot be interrupted.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   TF_DIR: packages/cloud/infra/cloud/terraform/hetzner/control-plane


### PR DESCRIPTION
## #14051 Tier B — fan-out reduction via universal PR concurrency dedup

Extends #14051 (not a fork). The path-gating levers for the heavy families already landed in **#14056** (coverage-gate path-gate + scenario assertion) and **#14057** (docker-smoke + scenario-pr off per-PR push, ~17 jobs/PR freed). Runner routing landed in **#14041**. The remaining structural lever is **superseded-run dedup**: several workflows queued duplicate runs on every push because they had `concurrency: NONE` or `cancel-in-progress: false`. Orch has been cancelling these by hand (77 Auto Label + 193 superseded runs observed). This makes GitHub do it automatically.

### What this does NOT touch
- No change to `ci-ok`, its `needs` list, or what it requires.
- No path-gate applied to any required leg. Verified the required set: only `ci-ok` gates develop merges; the `main` ruleset requires `Develop Gate (lint)`, `Develop Gate (secret scan + UI determinism)`, `Format + Type Safety Ratchet`, `Homepage Build (PR smoke)`, `gitleaks`, `coverage on changed files`, `check-pr-title`, `stale-base guard`. **None of the 6 workflows below produce a required context or feed `ci-ok`.**
- No trigger logic or job logic changed — only `concurrency:` blocks added/adjusted.

### Inventory (changed workflows)

| Workflow | PR trigger | before | after | required? |
|---|---|---|---|---|
| `auto-label.yml` | pull_request_target, issues | **NONE** | group by PR/issue number, `cancel-in-progress: true` | no |
| `setup-bun-workspace-self-test.yml` | pull_request (path-gated) | **NONE** | group + PR-only cancel | no |
| `supply-chain.yaml` | push:main, PR:main, schedule | **NONE** | group + **PR-only** cancel (push/schedule always complete) | no |
| `terraform-apps-data-plane.yml` | PR (path-gated), dispatch | `cancel: false` | **PR-only** cancel; PR group workflow-scoped | no |
| `terraform-apps-shared.yml` | PR (path-gated), dispatch | `cancel: false` | **PR-only** cancel; PR group workflow-scoped | no |
| `terraform-control-plane.yml` | PR (path-gated), dispatch | `cancel: false` | **PR-only** cancel | no |

### Why the terraform changes are apply-safe
The 3 terraform workflows run **fmt+validate only on PRs** (no creds, no state). The `plan/apply` path is `workflow_dispatch`-only and uses a **separate** concurrency group (`terraform-apps-hetzner` for the two apps modules; `terraform-control-plane-<env>` for control-plane). Because `cancel-in-progress` is gated on `github.event_name == 'pull_request'`, **a dispatch/apply is never cancelled** — an in-flight apply can't be interrupted. The apps-shared/apps-data-plane cross-state serialization on dispatch is preserved (both still share `terraform-apps-hetzner`).

**Codex review caught a real bug** in my first pass: the two Apps Terraform workflows shared the identical PR group `pr-${{ github.ref }}`. Since concurrency groups are repo-wide, with cancel enabled a PR touching both modules would have one workflow cancel the other's validation. Fixed by making the PR groups workflow-scoped (`terraform-apps-data-plane-pr-*` / `terraform-apps-shared-pr-*`).

### Verification
- `actionlint` — clean on all 6 files.
- `ci-merge-gate-contract.mjs` — PASS (classifiers keep hosted fallback, ci-ok enforces quality gate).
- `ci-workflow-dedup-contract.mjs` — PASS.
- `ci-full-matrix-proof.mjs`, `ci-bun-version-contract.mjs`, `ci-turbo-cache-contract.mjs` — PASS.
- `codex review --commit HEAD` (gpt-5.5) — "did not identify any actionable regressions."

### Note on the other levers
- **Path-gating** the heavy Windows/Mobile/UI/Aesthetic workflows: already done. Windows CI is push-only (#14051); `mobile-build-smoke`, `windows-dev-smoke`, `windows-desktop-preload-smoke` already job-gate on an internal `changes` classifier (heavy jobs skip on unrelated PRs, only the cheap hosted classifier runs — kept hosted per the #13617 SPOF guard); `app-aesthetic-audit`, `ui-story-gate`, `ui-fixture-e2e`, `electrobun-submodule-guard` already carry `paths:` filters. `android-device-e2e` is fully opt-in via the `ci:device` label. No new path-gates were needed.
- **gitleaks** already has PR-only cancel + is a required leg (left untouched).

No auto-merge — workflow change, orch to merge on standing authorization after diff review.

Co-authored-by: wakesync <shadow@shad0w.xyz>
