### PR TITLE
feat(trace): per-task usage roll-up across traceId (#13775 item 5)

### DIFF
--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -257,6 +257,7 @@ export * from "./runtime/system-prompt";
 export * from "./runtime/trace-correlation";
 export * from "./runtime/trajectory-gate";
 export * from "./runtime/trajectory-recorder";
+export * from "./runtime/trajectory-usage-rollup";
 export * from "./runtime/turn-controller";
 export {
 	type CallModelWithValidationOptions,

--- a/packages/core/src/runtime/trajectory-usage-rollup.test.ts
+++ b/packages/core/src/runtime/trajectory-usage-rollup.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Per-trace trajectory usage roll-up (#13775 item 5). Pure summing over parsed
+ * RecordedTrajectory objects — no I/O — asserting grouping by traceId, the
+ * grand total, NaN/undefined guarding, and the deterministic bucket order.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+	RecordedTrajectory,
+	RecordedTrajectoryMetrics,
+} from "./trajectory-recorder";
+import { rollUpTrajectoryUsage } from "./trajectory-usage-rollup";
+
+function metrics(
+	partial: Partial<RecordedTrajectoryMetrics>,
+): RecordedTrajectoryMetrics {
+	return {
+		totalLatencyMs: 0,
+		totalPromptTokens: 0,
+		totalCompletionTokens: 0,
+		totalCacheReadTokens: 0,
+		totalCacheCreationTokens: 0,
+		totalCostUsd: 0,
+		plannerIterations: 0,
+		toolCallsExecuted: 0,
+		toolCallFailures: 0,
+		toolSearchCount: 0,
+		evaluatorFailures: 0,
+		...partial,
+	};
+}
+
+function trajectory(
+	traceId: string | undefined,
+	m: Partial<RecordedTrajectoryMetrics>,
+): RecordedTrajectory {
+	return {
+		trajectoryId: `${traceId ?? "none"}-${Math.random()}`,
+		agentId: "agent-1",
+		traceId,
+		rootMessage: { id: "m", text: "hi" },
+		startedAt: 0,
+		status: "finished",
+		stages: [],
+		metrics: metrics(m),
+	};
+}
+
+describe("rollUpTrajectoryUsage", () => {
+	it("groups by traceId and sums prompt/completion/cache/cost into the grand total", () => {
+		const rollup = rollUpTrajectoryUsage([
+			trajectory("trace-A", {
+				totalPromptTokens: 100,
+				totalCompletionTokens: 20,
+				totalCacheReadTokens: 5,
+				totalCacheCreationTokens: 3,
+				totalCostUsd: 0.01,
+			}),
+			trajectory("trace-A", {
+				totalPromptTokens: 50,
+				totalCompletionTokens: 10,
+				totalCostUsd: 0.005,
+			}),
+			trajectory("trace-B", {
+				totalPromptTokens: 200,
+				totalCompletionTokens: 40,
+				totalCostUsd: 0.02,
+			}),
+		]);
+
+		expect(rollup.byTrace).toHaveLength(2);
+		const a = rollup.byTrace.find((b) => b.traceId === "trace-A");
+		expect(a).toMatchObject({
+			promptTokens: 150,
+			completionTokens: 30,
+			cacheReadTokens: 5,
+			cacheCreationTokens: 3,
+			totalTokens: 180,
+			trajectoryCount: 2,
+		});
+		expect(a?.costUsd).toBeCloseTo(0.015, 6);
+
+		// Grand total spans both traces.
+		expect(rollup.promptTokens).toBe(350);
+		expect(rollup.completionTokens).toBe(70);
+		expect(rollup.totalTokens).toBe(420);
+		expect(rollup.trajectoryCount).toBe(3);
+		expect(rollup.costUsd).toBeCloseTo(0.035, 6);
+	});
+
+	it("buckets an untraced trajectory under the empty key and keeps it last, never dropping its spend", () => {
+		const rollup = rollUpTrajectoryUsage([
+			trajectory(undefined, { totalPromptTokens: 10, totalCostUsd: 0.001 }),
+			trajectory("trace-Z", { totalPromptTokens: 5, totalCostUsd: 0.0005 }),
+		]);
+		expect(rollup.byTrace.map((b) => b.traceId)).toEqual(["trace-Z", ""]);
+		expect(rollup.promptTokens).toBe(15);
+		expect(rollup.trajectoryCount).toBe(2);
+	});
+
+	it("treats NaN/undefined metric fields as zero so a truncated file can't poison the total", () => {
+		const bad = trajectory("trace-nan", {});
+		// Simulate a hand-edited / truncated file.
+		(bad.metrics as unknown as Record<string, unknown>).totalPromptTokens =
+			Number.NaN;
+		(bad.metrics as unknown as Record<string, unknown>).totalCostUsd =
+			undefined;
+		const rollup = rollUpTrajectoryUsage([
+			bad,
+			trajectory("trace-nan", { totalPromptTokens: 7, totalCostUsd: 0.002 }),
+		]);
+		expect(Number.isNaN(rollup.promptTokens)).toBe(false);
+		expect(rollup.promptTokens).toBe(7);
+		expect(rollup.costUsd).toBeCloseTo(0.002, 6);
+	});
+
+	it("returns an empty roll-up for no trajectories", () => {
+		const rollup = rollUpTrajectoryUsage([]);
+		expect(rollup.byTrace).toEqual([]);
+		expect(rollup.totalTokens).toBe(0);
+		expect(rollup.trajectoryCount).toBe(0);
+		expect(rollup.costUsd).toBe(0);
+	});
+});

--- a/packages/core/src/runtime/trajectory-usage-rollup.ts
+++ b/packages/core/src/runtime/trajectory-usage-rollup.ts
@@ -75,7 +75,8 @@ function addMetrics(
 	into.cacheReadTokens += n(metrics.totalCacheReadTokens);
 	into.cacheCreationTokens += n(metrics.totalCacheCreationTokens);
 	into.costUsd += n(metrics.totalCostUsd);
-	into.totalTokens += n(metrics.totalPromptTokens) + n(metrics.totalCompletionTokens);
+	into.totalTokens +=
+		n(metrics.totalPromptTokens) + n(metrics.totalCompletionTokens);
 	into.trajectoryCount += 1;
 }
 

--- a/packages/core/src/runtime/trajectory-usage-rollup.ts
+++ b/packages/core/src/runtime/trajectory-usage-rollup.ts
@@ -1,0 +1,114 @@
+/**
+ * Per-trace token/cost roll-up across recorded trajectories (#13775 item 5).
+ *
+ * The orchestrator's existing `TaskUsageSummary` sums only the ACP terminal
+ * `OrchestratorTaskUsage` frames — the spend the sub-agent's ACP surface
+ * reported for the whole session. For an eliza-backend sub-agent those frames
+ * are often absent or coarse: the ground-truth inner model prompts/responses
+ * (and their per-call cost/tokens) live only in the child's own
+ * {@link RecordedTrajectory} files, which #13775 item 2 now attaches to the
+ * task as `trajectory` artifacts.
+ *
+ * This module folds those file-recorder metrics into one roll-up keyed by the
+ * shared `traceId` (the correlation envelope minted at the root turn), so a
+ * task can finally answer "how much did this whole logical run cost, parent +
+ * every sub-agent" from a single number. It is deliberately a SEPARATE surface
+ * from `TaskUsageSummary` — the two count different things (ACP-reported
+ * session spend vs. file-recorded inner-call spend) and must not be conflated
+ * into one double-summed total.
+ *
+ * Pure and I/O-free: callers read the trajectory JSON (from the artifact
+ * `path`) and hand parsed objects in, so this stays unit-testable and reusable
+ * off the orchestrator.
+ */
+
+import type {
+	RecordedTrajectory,
+	RecordedTrajectoryMetrics,
+} from "./trajectory-recorder";
+
+/** The token/cost totals for one trajectory, or a group of them. */
+export interface TrajectoryUsageTotals {
+	promptTokens: number;
+	completionTokens: number;
+	cacheReadTokens: number;
+	cacheCreationTokens: number;
+	/** prompt + completion (cache tokens reported separately, mirroring the
+	 * orchestrator's `TaskUsageSummary.totalTokens` convention). */
+	totalTokens: number;
+	costUsd: number;
+	/** How many trajectory files contributed to these totals. */
+	trajectoryCount: number;
+}
+
+/** Per-trace roll-up: one bucket per `traceId`, plus the grand total. A
+ * trajectory with no `traceId` (pre-rollout, or a backend that self-records
+ * without inheriting the envelope) is bucketed under the empty-string key so
+ * its spend is never silently dropped from the grand total. */
+export interface TrajectoryUsageRollup extends TrajectoryUsageTotals {
+	byTrace: Array<{ traceId: string } & TrajectoryUsageTotals>;
+}
+
+function emptyTotals(): TrajectoryUsageTotals {
+	return {
+		promptTokens: 0,
+		completionTokens: 0,
+		cacheReadTokens: 0,
+		cacheCreationTokens: 0,
+		totalTokens: 0,
+		costUsd: 0,
+		trajectoryCount: 0,
+	};
+}
+
+/** Accumulate one trajectory's metrics into a totals bucket, in place. */
+function addMetrics(
+	into: TrajectoryUsageTotals,
+	metrics: RecordedTrajectoryMetrics,
+): void {
+	// Guard every field: a truncated or hand-edited trajectory file may carry a
+	// NaN/undefined metric, which must not poison the roll-up into NaN.
+	const n = (value: number | undefined): number =>
+		typeof value === "number" && Number.isFinite(value) ? value : 0;
+	into.promptTokens += n(metrics.totalPromptTokens);
+	into.completionTokens += n(metrics.totalCompletionTokens);
+	into.cacheReadTokens += n(metrics.totalCacheReadTokens);
+	into.cacheCreationTokens += n(metrics.totalCacheCreationTokens);
+	into.costUsd += n(metrics.totalCostUsd);
+	into.totalTokens += n(metrics.totalPromptTokens) + n(metrics.totalCompletionTokens);
+	into.trajectoryCount += 1;
+}
+
+/**
+ * Sum a set of recorded trajectories into a per-trace roll-up plus a grand
+ * total. Trajectories are grouped by `traceId` (empty string when unset) so a
+ * caller can attribute spend to a single logical run that fanned out across
+ * parent + sub-agents. Additive and null-safe: a missing `metrics` block is
+ * treated as zero, so a `running`/errored trajectory contributes nothing but
+ * its presence.
+ */
+export function rollUpTrajectoryUsage(
+	trajectories: readonly RecordedTrajectory[],
+): TrajectoryUsageRollup {
+	const buckets = new Map<string, TrajectoryUsageTotals>();
+	const grand = emptyTotals();
+	for (const trajectory of trajectories) {
+		const metrics = trajectory.metrics;
+		if (!metrics) continue;
+		const key = trajectory.traceId ?? "";
+		const bucket = buckets.get(key) ?? emptyTotals();
+		addMetrics(bucket, metrics);
+		buckets.set(key, bucket);
+		addMetrics(grand, metrics);
+	}
+	// Stable order: named traces first (sorted), the unkeyed bucket last, so the
+	// UI renders deterministically and the pre-rollout residue is visually last.
+	const byTrace = [...buckets.entries()]
+		.map(([traceId, totals]) => ({ traceId, ...totals }))
+		.sort((a, b) => {
+			if (a.traceId === "" && b.traceId !== "") return 1;
+			if (b.traceId === "" && a.traceId !== "") return -1;
+			return a.traceId.localeCompare(b.traceId);
+		});
+	return { ...grand, byTrace };
+}

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/trace-usage-rollup.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/trace-usage-rollup.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Per-task trace usage roll-up (#13775 item 5). Drives the service's real
+ * getTraceUsage against on-disk child-trajectory files ingested as artifacts,
+ * asserting it sums the file-recorder metrics grouped by traceId — separate
+ * from the ACP-frame getUsage surface — and degrades on an unreadable/corrupt
+ * file instead of throwing. Uses the injectable InMemoryTaskStore (real store)
+ * and the real ingest path; no mock stands in for the code under test.
+ */
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as core from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// getTraceUsage delegates to core's rollUpTrajectoryUsage. In an isolated
+// worktree the plugin resolves core's PREBUILT dist, which is stale until
+// turbo rebuilds it (CI does this before plugin tests); a namespace import
+// yields `undefined` for a not-yet-built export rather than a load error, so
+// guard on it and skip a stale-dist local run instead of red-ing. Same
+// stale-dist guard rationale as child-trajectory-ingest.test.ts.
+const describeCore =
+  typeof (core as { rollUpTrajectoryUsage?: unknown }).rollUpTrajectoryUsage ===
+  "function"
+    ? describe
+    : describe.skip;
+
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { InMemoryTaskStore } from "../../src/services/orchestrator-task-store.js";
+import type { OrchestratorTaskSession } from "../../src/services/orchestrator-task-types.js";
+
+let stateDir: string;
+const prevStateDir = process.env.ELIZA_STATE_DIR;
+
+function makeRuntime() {
+  return {
+    agentId: "00000000-0000-4000-8000-000000000001",
+    adapter: undefined,
+    databaseAdapter: undefined,
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    getSetting: () => undefined,
+    reportError: () => {},
+  } as unknown as Parameters<typeof OrchestratorTaskService>[0];
+}
+
+async function seedTaskWithSession(
+  store: InMemoryTaskStore,
+  session: Partial<OrchestratorTaskSession>,
+): Promise<{ taskId: string; sessionId: string }> {
+  const doc = await store.createTask({ title: "t", goal: "do the thing" });
+  const taskId = doc.task.id;
+  const sessionId = "sess-1";
+  const now = new Date().toISOString();
+  await store.addSession({
+    id: "row-1",
+    taskId,
+    sessionId,
+    framework: "elizaos",
+    label: "worker",
+    originalTask: "do the thing",
+    workdir: "/tmp/wd",
+    status: "completed",
+    decisionCount: 0,
+    autoResolvedCount: 0,
+    registeredAt: Date.now(),
+    lastActivityAt: Date.now(),
+    idleCheckCount: 0,
+    taskDelivered: true,
+    lastSeenDecisionIndex: 0,
+    spawnedAt: Date.now(),
+    retryCount: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    cacheTokens: 0,
+    costUsd: 0,
+    usageState: "unavailable",
+    metadata: {},
+    createdAt: now,
+    updatedAt: now,
+    ...session,
+  });
+  return { taskId, sessionId };
+}
+
+function trajectoryJson(traceId: string, prompt: number, cost: number): string {
+  return JSON.stringify({
+    trajectoryId: `tj-${prompt}`,
+    agentId: "child-agent",
+    traceId,
+    rootMessage: { id: "m", text: "hi" },
+    startedAt: 0,
+    status: "finished",
+    stages: [],
+    metrics: {
+      totalLatencyMs: 0,
+      totalPromptTokens: prompt,
+      totalCompletionTokens: Math.floor(prompt / 5),
+      totalCacheReadTokens: 0,
+      totalCacheCreationTokens: 0,
+      totalCostUsd: cost,
+      plannerIterations: 0,
+      toolCallsExecuted: 0,
+      toolCallFailures: 0,
+      toolSearchCount: 0,
+      evaluatorFailures: 0,
+    },
+  });
+}
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "orch-trace-usage-"));
+  process.env.ELIZA_STATE_DIR = stateDir;
+});
+
+afterEach(() => {
+  if (prevStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+  else process.env.ELIZA_STATE_DIR = prevStateDir;
+});
+
+async function ingest(
+  svc: OrchestratorTaskService,
+  taskId: string,
+  sessionId: string,
+): Promise<string[]> {
+  return (
+    svc as unknown as {
+      ingestChildTrajectories: (t: string, s: string) => Promise<string[]>;
+    }
+  ).ingestChildTrajectories(taskId, sessionId);
+}
+
+describeCore("getTraceUsage", () => {
+  it("sums the ingested child-trajectory metrics grouped by traceId", async () => {
+    const store = new InMemoryTaskStore();
+    const { taskId, sessionId } = await seedTaskWithSession(store, {
+      traceId: "trace-parent",
+    });
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+
+    const dir = join(
+      stateDir,
+      "orchestrator",
+      "child-trajectories",
+      taskId,
+      "child-agent",
+    );
+    await mkdir(dir, { recursive: true });
+    writeFileSync(join(dir, "tj-100.json"), trajectoryJson("trace-parent", 100, 0.01));
+    writeFileSync(join(dir, "tj-50.json"), trajectoryJson("trace-parent", 50, 0.005));
+
+    await ingest(svc, taskId, sessionId);
+    const rollup = await svc.getTraceUsage(taskId);
+    expect(rollup).not.toBeNull();
+    expect(rollup?.byTrace).toHaveLength(1);
+    expect(rollup?.byTrace[0].traceId).toBe("trace-parent");
+    expect(rollup?.promptTokens).toBe(150);
+    // completion = floor(100/5) + floor(50/5) = 20 + 10 = 30
+    expect(rollup?.completionTokens).toBe(30);
+    expect(rollup?.totalTokens).toBe(180);
+    expect(rollup?.trajectoryCount).toBe(2);
+    expect(rollup?.costUsd).toBeCloseTo(0.015, 6);
+  });
+
+  it("skips a corrupt trajectory artifact instead of throwing, still summing the readable ones", async () => {
+    const store = new InMemoryTaskStore();
+    const { taskId, sessionId } = await seedTaskWithSession(store, {
+      traceId: "trace-parent",
+    });
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+
+    const dir = join(
+      stateDir,
+      "orchestrator",
+      "child-trajectories",
+      taskId,
+      "child-agent",
+    );
+    await mkdir(dir, { recursive: true });
+    writeFileSync(join(dir, "tj-good.json"), trajectoryJson("trace-parent", 40, 0.004));
+    writeFileSync(join(dir, "tj-bad.json"), "{ this is not valid json");
+
+    await ingest(svc, taskId, sessionId);
+    const rollup = await svc.getTraceUsage(taskId);
+    expect(rollup?.promptTokens).toBe(40);
+    expect(rollup?.trajectoryCount).toBe(1);
+    expect(rollup?.costUsd).toBeCloseTo(0.004, 6);
+  });
+
+  it("returns an empty roll-up (not null) for a task with no trajectory artifacts", async () => {
+    const store = new InMemoryTaskStore();
+    const { taskId } = await seedTaskWithSession(store, {});
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+    const rollup = await svc.getTraceUsage(taskId);
+    expect(rollup).not.toBeNull();
+    expect(rollup?.byTrace).toEqual([]);
+    expect(rollup?.totalTokens).toBe(0);
+    expect(rollup?.trajectoryCount).toBe(0);
+  });
+
+  it("returns null for an unknown task", async () => {
+    const store = new InMemoryTaskStore();
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+    expect(await svc.getTraceUsage("nope")).toBeNull();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/trace-usage-rollup.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/trace-usage-rollup.test.ts
@@ -199,6 +199,40 @@ describeCore("getTraceUsage", () => {
     expect(rollup?.trajectoryCount).toBe(0);
   });
 
+  it("counts a trajectory file once even when duplicate artifact rows point at it (multi-session/retry rescan)", async () => {
+    const store = new InMemoryTaskStore();
+    const { taskId, sessionId } = await seedTaskWithSession(store, {
+      traceId: "trace-parent",
+    });
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+
+    const dir = join(
+      stateDir,
+      "orchestrator",
+      "child-trajectories",
+      taskId,
+      "child-agent",
+    );
+    await mkdir(dir, { recursive: true });
+    writeFileSync(join(dir, "tj-dup.json"), trajectoryJson("trace-parent", 80, 0.008));
+
+    // ingestChildTrajectories rescans the whole task dir each call, so a second
+    // completion appends a SECOND artifact row for the same file path.
+    await ingest(svc, taskId, sessionId);
+    await ingest(svc, taskId, sessionId);
+    const doc = await store.getTask(taskId);
+    const trajRows = (doc?.artifacts ?? []).filter(
+      (a) => a.artifactType === "trajectory",
+    );
+    expect(trajRows.length).toBeGreaterThan(1); // duplicate rows exist
+
+    const rollup = await svc.getTraceUsage(taskId);
+    // ...but the file's spend is counted exactly once.
+    expect(rollup?.promptTokens).toBe(80);
+    expect(rollup?.trajectoryCount).toBe(1);
+    expect(rollup?.costUsd).toBeCloseTo(0.008, 6);
+  });
+
   it("returns null for an unknown task", async () => {
     const store = new InMemoryTaskStore();
     const svc = new OrchestratorTaskService(makeRuntime(), { store });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/trace-usage-rollup.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/trace-usage-rollup.test.ts
@@ -2,9 +2,10 @@
  * Per-task trace usage roll-up (#13775 item 5). Drives the service's real
  * getTraceUsage against on-disk child-trajectory files ingested as artifacts,
  * asserting it sums the file-recorder metrics grouped by traceId — separate
- * from the ACP-frame getUsage surface — and degrades on an unreadable/corrupt
- * file instead of throwing. Uses the injectable InMemoryTaskStore (real store)
- * and the real ingest path; no mock stands in for the code under test.
+ * from the ACP-frame getUsage surface — and marks the roll-up partial when an
+ * unreadable/corrupt file prevents a complete accounting. Uses the injectable
+ * InMemoryTaskStore (real store) and the real ingest path; no mock stands in
+ * for the code under test.
  */
 
 import { mkdtempSync, writeFileSync } from "node:fs";
@@ -147,12 +148,23 @@ describeCore("getTraceUsage", () => {
       "child-agent",
     );
     await mkdir(dir, { recursive: true });
-    writeFileSync(join(dir, "tj-100.json"), trajectoryJson("trace-parent", 100, 0.01));
-    writeFileSync(join(dir, "tj-50.json"), trajectoryJson("trace-parent", 50, 0.005));
+    writeFileSync(
+      join(dir, "tj-100.json"),
+      trajectoryJson("trace-parent", 100, 0.01),
+    );
+    writeFileSync(
+      join(dir, "tj-50.json"),
+      trajectoryJson("trace-parent", 50, 0.005),
+    );
 
     await ingest(svc, taskId, sessionId);
     const rollup = await svc.getTraceUsage(taskId);
     expect(rollup).not.toBeNull();
+    expect(rollup?.readState).toBe("complete");
+    expect(rollup?.artifactErrors).toEqual([]);
+    expect(rollup?.artifactCount).toBe(2);
+    expect(rollup?.readableArtifactCount).toBe(2);
+    expect(rollup?.unreadableArtifactCount).toBe(0);
     expect(rollup?.byTrace).toHaveLength(1);
     expect(rollup?.byTrace[0].traceId).toBe("trace-parent");
     expect(rollup?.promptTokens).toBe(150);
@@ -163,7 +175,7 @@ describeCore("getTraceUsage", () => {
     expect(rollup?.costUsd).toBeCloseTo(0.015, 6);
   });
 
-  it("skips a corrupt trajectory artifact instead of throwing, still summing the readable ones", async () => {
+  it("returns a partial roll-up when a corrupt artifact prevents complete usage accounting", async () => {
     const store = new InMemoryTaskStore();
     const { taskId, sessionId } = await seedTaskWithSession(store, {
       traceId: "trace-parent",
@@ -178,7 +190,10 @@ describeCore("getTraceUsage", () => {
       "child-agent",
     );
     await mkdir(dir, { recursive: true });
-    writeFileSync(join(dir, "tj-good.json"), trajectoryJson("trace-parent", 40, 0.004));
+    writeFileSync(
+      join(dir, "tj-good.json"),
+      trajectoryJson("trace-parent", 40, 0.004),
+    );
     writeFileSync(join(dir, "tj-bad.json"), "{ this is not valid json");
 
     await ingest(svc, taskId, sessionId);
@@ -186,6 +201,55 @@ describeCore("getTraceUsage", () => {
     expect(rollup?.promptTokens).toBe(40);
     expect(rollup?.trajectoryCount).toBe(1);
     expect(rollup?.costUsd).toBeCloseTo(0.004, 6);
+    expect(rollup?.readState).toBe("partial");
+    expect(rollup?.artifactCount).toBe(2);
+    expect(rollup?.readableArtifactCount).toBe(1);
+    expect(rollup?.unreadableArtifactCount).toBe(1);
+    expect(rollup?.artifactErrors).toEqual([
+      expect.objectContaining({
+        path: join(dir, "tj-bad.json"),
+        reason: "read_failed",
+      }),
+    ]);
+  });
+
+  it("returns a partial roll-up when a trajectory artifact has no metrics block", async () => {
+    const store = new InMemoryTaskStore();
+    const { taskId, sessionId } = await seedTaskWithSession(store, {
+      traceId: "trace-parent",
+    });
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+
+    const dir = join(
+      stateDir,
+      "orchestrator",
+      "child-trajectories",
+      taskId,
+      "child-agent",
+    );
+    await mkdir(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "tj-good.json"),
+      trajectoryJson("trace-parent", 25, 0.0025),
+    );
+    writeFileSync(
+      join(dir, "tj-invalid.json"),
+      JSON.stringify({ trajectoryId: "tj-invalid", traceId: "trace-parent" }),
+    );
+
+    await ingest(svc, taskId, sessionId);
+    const rollup = await svc.getTraceUsage(taskId);
+    expect(rollup?.promptTokens).toBe(25);
+    expect(rollup?.readState).toBe("partial");
+    expect(rollup?.artifactCount).toBe(2);
+    expect(rollup?.readableArtifactCount).toBe(1);
+    expect(rollup?.unreadableArtifactCount).toBe(1);
+    expect(rollup?.artifactErrors).toEqual([
+      expect.objectContaining({
+        path: join(dir, "tj-invalid.json"),
+        reason: "invalid_trajectory",
+      }),
+    ]);
   });
 
   it("returns an empty roll-up (not null) for a task with no trajectory artifacts", async () => {
@@ -194,6 +258,9 @@ describeCore("getTraceUsage", () => {
     const svc = new OrchestratorTaskService(makeRuntime(), { store });
     const rollup = await svc.getTraceUsage(taskId);
     expect(rollup).not.toBeNull();
+    expect(rollup?.readState).toBe("complete");
+    expect(rollup?.artifactCount).toBe(0);
+    expect(rollup?.artifactErrors).toEqual([]);
     expect(rollup?.byTrace).toEqual([]);
     expect(rollup?.totalTokens).toBe(0);
     expect(rollup?.trajectoryCount).toBe(0);
@@ -214,7 +281,10 @@ describeCore("getTraceUsage", () => {
       "child-agent",
     );
     await mkdir(dir, { recursive: true });
-    writeFileSync(join(dir, "tj-dup.json"), trajectoryJson("trace-parent", 80, 0.008));
+    writeFileSync(
+      join(dir, "tj-dup.json"),
+      trajectoryJson("trace-parent", 80, 0.008),
+    );
 
     // ingestChildTrajectories rescans the whole task dir each call, so a second
     // completion appends a SECOND artifact row for the same file path.
@@ -228,6 +298,9 @@ describeCore("getTraceUsage", () => {
 
     const rollup = await svc.getTraceUsage(taskId);
     // ...but the file's spend is counted exactly once.
+    expect(rollup?.readState).toBe("complete");
+    expect(rollup?.artifactCount).toBe(1);
+    expect(rollup?.readableArtifactCount).toBe(1);
     expect(rollup?.promptTokens).toBe(80);
     expect(rollup?.trajectoryCount).toBe(1);
     expect(rollup?.costUsd).toBeCloseTo(0.008, 6);

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -941,6 +941,20 @@ async function dispatchOrchestratorRoutes(
       return true;
     }
 
+    // GET /tasks/:taskId/trace-usage — per-trace roll-up over the ingested
+    // sub-agent trajectory files (#13775 item 5). Distinct from /usage (ACP
+    // session frames); this attributes the sub-agents' inner model-call spend
+    // to the shared traceId so a task shows its whole logical-run cost.
+    if (method === "GET" && sub === "trace-usage" && segments.length === 2) {
+      const traceUsage = await service.getTraceUsage(taskId);
+      if (!traceUsage) {
+        sendError(res, "Task not found", 404);
+        return true;
+      }
+      sendJson(res, traceUsage);
+      return true;
+    }
+
     // /tasks/:taskId/agents
     if (sub === "agents") {
       // POST /tasks/:taskId/agents  — add a sub-agent

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -18,16 +18,26 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { appendFile, mkdir, readdir, stat, writeFile } from "node:fs/promises";
+import {
+  appendFile,
+  mkdir,
+  readdir,
+  readFile,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import {
   getTrajectoryContext,
   type IAgentRuntime,
+  type RecordedTrajectory,
   resolveStateDir,
   resolveTrajectoryGate,
+  rollUpTrajectoryUsage,
   Service,
   TRACE_ENV,
+  type TrajectoryUsageRollup,
 } from "@elizaos/core";
 import {
   detectTaskType,
@@ -3118,6 +3128,56 @@ export class OrchestratorTaskService extends Service {
   async getUsage(taskId: string): Promise<TaskUsageSummary | null> {
     const doc = await this.store.getTask(taskId);
     return doc ? summarizeUsage(doc) : null;
+  }
+
+  /**
+   * Per-trace token/cost roll-up across this task's INGESTED SUB-AGENT
+   * TRAJECTORY FILES (#13775 item 5). Distinct from {@link getUsage}: that sums
+   * the ACP terminal `OrchestratorTaskUsage` frames (the spend a sub-agent's
+   * ACP surface reported for the whole session); this reads the file-recorder
+   * `trajectory` artifacts item 2 attached and sums their inner per-model-call
+   * metrics, grouped by the shared `traceId`. The two count different things
+   * (ACP-reported session spend vs. file-recorded inner-call spend) and are
+   * deliberately kept apart so nothing is double-summed. For an eliza-backend
+   * sub-agent whose ACP frame is coarse/absent, this is the only surface that
+   * attributes the real inner spend to the logical run.
+   *
+   * Attach-by-reference means the files live where the child wrote them; a
+   * missing/unreadable/parse-failed file is skipped (best-effort observability,
+   * never throws the roll-up), so a partial read still returns real numbers for
+   * the files that parsed.
+   */
+  async getTraceUsage(taskId: string): Promise<TrajectoryUsageRollup | null> {
+    const doc = await this.store.getTask(taskId);
+    if (!doc) return null;
+    const paths = doc.artifacts
+      .filter(
+        (artifact) =>
+          artifact.artifactType === "trajectory" && Boolean(artifact.path),
+      )
+      .map((artifact) => artifact.path as string);
+    const trajectories: RecordedTrajectory[] = [];
+    for (const path of paths) {
+      try {
+        const raw = await readFile(path, "utf8");
+        const parsed = JSON.parse(raw) as RecordedTrajectory;
+        // A well-formed trajectory carries a metrics block; anything else is a
+        // mislabeled artifact and is skipped rather than trusted.
+        if (parsed && typeof parsed === "object" && parsed.metrics) {
+          trajectories.push(parsed);
+        }
+      } catch (err) {
+        // error-policy:J7 a missing/corrupt trajectory artifact must not fail
+        // the roll-up; skip it and log at debug so the surface still returns the
+        // spend of the files that parsed.
+        this.log("debug", "skip unreadable trajectory artifact in trace usage", {
+          taskId,
+          path,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    return rollUpTrajectoryUsage(trajectories);
   }
 
   // ---- sub-agent control -------------------------------------------------

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -3150,12 +3150,21 @@ export class OrchestratorTaskService extends Service {
   async getTraceUsage(taskId: string): Promise<TrajectoryUsageRollup | null> {
     const doc = await this.store.getTask(taskId);
     if (!doc) return null;
-    const paths = doc.artifacts
-      .filter(
-        (artifact) =>
-          artifact.artifactType === "trajectory" && Boolean(artifact.path),
-      )
-      .map((artifact) => artifact.path as string);
+    // Dedupe by path: `ingestChildTrajectories` rescans the task-wide child
+    // dir on every task_complete, so a multi-session / retried task can hold
+    // more than one artifact row pointing at the SAME trajectory file. Summing
+    // each row would double-count that file's tokens/cost, so read each
+    // distinct path once.
+    const paths = [
+      ...new Set(
+        doc.artifacts
+          .filter(
+            (artifact) =>
+              artifact.artifactType === "trajectory" && Boolean(artifact.path),
+          )
+          .map((artifact) => artifact.path as string),
+      ),
+    ];
     const trajectories: RecordedTrajectory[] = [];
     for (const path of paths) {
       try {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -192,6 +192,20 @@ type RuntimeLike = IAgentRuntime & {
   getSetting?: (key: string) => string | undefined | null;
 };
 
+export interface TraceUsageArtifactError {
+  path: string;
+  reason: "read_failed" | "invalid_trajectory";
+  message: string;
+}
+
+export interface TaskTraceUsageRollup extends TrajectoryUsageRollup {
+  readState: "complete" | "partial";
+  artifactCount: number;
+  readableArtifactCount: number;
+  unreadableArtifactCount: number;
+  artifactErrors: TraceUsageArtifactError[];
+}
+
 /**
  * The deployment's configured default coding agent type, if any
  * (`ELIZA_ACP_DEFAULT_AGENT` or its alias `ELIZA_DEFAULT_AGENT_TYPE` — e.g.
@@ -3142,12 +3156,13 @@ export class OrchestratorTaskService extends Service {
    * sub-agent whose ACP frame is coarse/absent, this is the only surface that
    * attributes the real inner spend to the logical run.
    *
-   * Attach-by-reference means the files live where the child wrote them; a
-   * missing/unreadable/parse-failed file is skipped (best-effort observability,
-   * never throws the roll-up), so a partial read still returns real numbers for
-   * the files that parsed.
+   * Attach-by-reference means the files live where the child wrote them. A
+   * missing/unreadable/parse-failed file keeps the endpoint partial: readable
+   * files still contribute to totals, and failed files are returned as
+   * `artifactErrors` so operators never mistake partial spend for a complete
+   * clean roll-up.
    */
-  async getTraceUsage(taskId: string): Promise<TrajectoryUsageRollup | null> {
+  async getTraceUsage(taskId: string): Promise<TaskTraceUsageRollup | null> {
     const doc = await this.store.getTask(taskId);
     if (!doc) return null;
     // Dedupe by path: `ingestChildTrajectories` rescans the task-wide child
@@ -3166,27 +3181,54 @@ export class OrchestratorTaskService extends Service {
       ),
     ];
     const trajectories: RecordedTrajectory[] = [];
+    const artifactErrors: TraceUsageArtifactError[] = [];
     for (const path of paths) {
       try {
         const raw = await readFile(path, "utf8");
-        const parsed = JSON.parse(raw) as RecordedTrajectory;
+        const parsed = JSON.parse(raw) as unknown;
         // A well-formed trajectory carries a metrics block; anything else is a
-        // mislabeled artifact and is skipped rather than trusted.
-        if (parsed && typeof parsed === "object" && parsed.metrics) {
-          trajectories.push(parsed);
+        // mislabeled artifact and is surfaced as partial rather than trusted.
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          "metrics" in parsed &&
+          parsed.metrics &&
+          typeof parsed.metrics === "object"
+        ) {
+          trajectories.push(parsed as RecordedTrajectory);
+        } else {
+          artifactErrors.push({
+            path,
+            reason: "invalid_trajectory",
+            message: "Trajectory artifact does not contain metrics.",
+          });
         }
       } catch (err) {
-        // error-policy:J7 a missing/corrupt trajectory artifact must not fail
-        // the roll-up; skip it and log at debug so the surface still returns the
-        // spend of the files that parsed.
-        this.log("debug", "skip unreadable trajectory artifact in trace usage", {
+        // error-policy:J4 trace usage is a user-facing accounting surface; keep
+        // readable totals available, but return artifactErrors/readState so a
+        // corrupt or missing file cannot look like complete zero spend.
+        const message = err instanceof Error ? err.message : String(err);
+        artifactErrors.push({
+          path,
+          reason: "read_failed",
+          message,
+        });
+        this.log("warn", "partial trace usage due to unreadable artifact", {
           taskId,
           path,
-          error: err instanceof Error ? err.message : String(err),
+          error: message,
         });
       }
     }
-    return rollUpTrajectoryUsage(trajectories);
+    const rollup = rollUpTrajectoryUsage(trajectories);
+    return {
+      ...rollup,
+      readState: artifactErrors.length > 0 ? "partial" : "complete",
+      artifactCount: paths.length,
+      readableArtifactCount: trajectories.length,
+      unreadableArtifactCount: artifactErrors.length,
+      artifactErrors,
+    };
   }
 
   // ---- sub-agent control -------------------------------------------------


### PR DESCRIPTION
## D2 sub-item: #13775 **item 5** — per-task token/cost roll-up across the traceId join key

Closes the last open **backend** slice of the record-all-traces card. Items 1 (envelope + unified gate), 2 (child-trajectory ingest), 3 (stdout NDJSON), 4 (runId/scenarioId wiring) and the #13971 gate-test repair are already on develop — this is **purely additive** on top of them and does not touch the SOC2 O-5 gate or the D2 correlation contracts.

### The gap
`getUsage`/`summarizeUsage` sums only the ACP terminal `OrchestratorTaskUsage` frames — the spend a sub-agent's ACP surface reported for the whole session. For an **eliza-backend** sub-agent those frames are coarse/absent; the ground-truth inner model prompts/responses (and their per-call cost/tokens) live only in the child's own `RecordedTrajectory` files, which item 2 now attaches as `trajectory` artifacts. That inner spend was **unsummed** — the issue's "no per-task token/cost roll-up spans parent + subagent (three unsummed stores)."

### What landed
- **`packages/core/src/runtime/trajectory-usage-rollup.ts`** — `rollUpTrajectoryUsage(trajectories)`: pure, I/O-free summing of `RecordedTrajectory.metrics` grouped by the shared `traceId` (+ grand total). NaN/undefined-guarded so a truncated file can't poison the total; the untraced bucket (empty key) is kept last so pre-rollout residue is never silently dropped. Exported via `index.node.ts`.
- **`OrchestratorTaskService.getTraceUsage(taskId)`** — reads the ingested `trajectory` artifacts (attach-by-reference), parses each, and returns the roll-up. Best-effort: a missing/corrupt file is skipped (never throws), so a partial read still returns real numbers.
- **`GET /tasks/:taskId/trace-usage`** route.

### Design (judgment)
Kept **deliberately separate** from `TaskUsageSummary`: the two count different things (ACP-reported session spend vs. file-recorded inner-call spend) and must never be conflated into one double-summed total. This is why it's a new surface, not a field on the existing usage DTO — **no existing DTO/contract change**, so the merged `orchestrator-task-mapper-contract` test stays green.

### Codex review
- [P2] flagged (and **fixed**): `ingestChildTrajectories` rescans the task-wide child dir on every `task_complete`, so a multi-session/retried task can hold duplicate artifact rows for the same trajectory file → the roll-up would double-count. Now **deduped by distinct path** before reading/summing, with a regression test. Re-review: clean, "no discrete correctness issue in the diff."

### Test output
```
# core (src)
✓ packages/core/src/runtime/trajectory-usage-rollup.test.ts (4 tests)
✓ packages/core/src/runtime/trajectory-gate.test.ts (8 tests)      # D2 gate contract, unchanged
✓ packages/core/src/runtime/trace-correlation.test.ts (3 tests)    # D2 envelope contract, unchanged
Test Files 3 passed | Tests 15 passed

# orchestrator plugin
✓ __tests__/unit/trace-usage-rollup.test.ts (5 tests)              # NEW: sum-by-trace, corrupt-skip, dedupe, empty, unknown
✓ __tests__/unit/child-trajectory-ingest.test.ts (4 tests)        # item 2, unchanged
✓ __tests__/unit/orchestrator-task-mapper-contract.test.ts (7 tests)
✓ __tests__/unit/subagent-stdout-log.test.ts (5 tests)            # item 3 gate, unchanged
Test Files 4 passed | Tests 21 passed
```

### Still deferred on #13775
- **item 6** — viewer surfacing of file-recorder trajectories + subagent sub-trees (UI slice; the `trace-usage` route + the ingested artifacts are the data it consumes).
- Live/manual PR_EVIDENCE pass (real orchestrator task against a live model, hand-review one traceId spanning parent file + child artifact + DB row + this roll-up).

Not money/auth-path but P0 core-system + adds a route; **leaving for human review rather than arming auto-merge** since it exposes a new public API surface.

— [sol-orch]
