### PR TITLE
test(#13620): seed lane coverage allowlist - [sol-orch]

### DIFF
--- a/packages/scripts/lint-lane-coverage.allowlist.json
+++ b/packages/scripts/lint-lane-coverage.allowlist.json
@@ -1,5 +1,5 @@
 {
-  "generatedFrom": "node packages/scripts/lint-lane-coverage.mjs --json on origin/develop (050adf180, 2026-07-05)",
+  "generatedFrom": "node packages/scripts/lint-lane-coverage.mjs --json on origin/develop (2579e7b75e, 2026-07-05)",
   "issue": "https://github.com/elizaOS/eliza/issues/13620",
   "policy": "This file is the baseline for enforcing lint-lane-coverage without --dry-run. New unsuppressed issues fail; stale entries fail and should be removed.",
   "summary": {

--- a/packages/scripts/lint-lane-coverage.allowlist.json
+++ b/packages/scripts/lint-lane-coverage.allowlist.json
@@ -1,0 +1,623 @@
+{
+  "generatedFrom": "node packages/scripts/lint-lane-coverage.mjs --json on origin/develop (050adf180, 2026-07-05)",
+  "issue": "https://github.com/elizaOS/eliza/issues/13620",
+  "policy": "This file is the baseline for enforcing lint-lane-coverage without --dry-run. New unsuppressed issues fail; stale entries fail and should be removed.",
+  "summary": {
+    "pluginCount": 140,
+    "pluginsWithNoTests": 1,
+    "pluginsWithNoDeterministicE2E": 100,
+    "pluginsWithActions": 44,
+    "pluginsWithViews": 30,
+    "issueCount": 153,
+    "unsuppressedIssueCount": 153,
+    "suppressedIssueCount": 0,
+    "allowlistErrorCount": 0
+  },
+  "entries": [
+    {
+      "plugin": "app-model-tester",
+      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-anthropic-proxy",
+      "issues": ["missing-action-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-app-manager",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-background-runner",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-benchmarks",
+      "issues": ["missing-action-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-birdclaw",
+      "issues": [
+        "missing-action-e2e",
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-blocker",
+      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-bluebubbles",
+      "issues": [
+        "missing-action-e2e",
+        "missing-action-tests",
+        "missing-deterministic-e2e"
+      ],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-bluesky",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-calendar",
+      "issues": [
+        "missing-action-e2e",
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-calendly",
+      "issues": [
+        "missing-action-e2e",
+        "missing-action-tests",
+        "missing-deterministic-e2e"
+      ],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-capacitor-bridge",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-cli",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-cli-inference",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-cloud-apps",
+      "issues": ["missing-action-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-codex-cli",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-coding-tools",
+      "issues": ["missing-action-e2e", "missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-commands",
+      "issues": ["missing-view-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-contacts",
+      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-discord-local",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-documents",
+      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-e2b-sandbox",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-edge-tts",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-elevenlabs",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-elizacloud",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-embeddings",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-farcaster",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-feed",
+      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-feishu",
+      "issues": [
+        "missing-action-e2e",
+        "missing-action-tests",
+        "missing-deterministic-e2e"
+      ],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-finances",
+      "issues": ["missing-action-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-form",
+      "issues": ["missing-action-tests", "missing-view-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-github",
+      "issues": ["missing-action-e2e", "missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-gitpathologist",
+      "issues": ["missing-action-e2e", "missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-google-chat",
+      "issues": [
+        "missing-action-e2e",
+        "missing-action-tests",
+        "missing-deterministic-e2e"
+      ],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-hyperliquid",
+      "issues": ["missing-action-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-imessage",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-inmemorydb",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-instagram",
+      "issues": [
+        "missing-action-e2e",
+        "missing-action-tests",
+        "missing-deterministic-e2e"
+      ],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-line",
+      "issues": ["missing-action-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-lmstudio",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-local-storage",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-localdb",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-matrix",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-mcp",
+      "issues": [
+        "missing-action-e2e",
+        "missing-action-tests",
+        "missing-deterministic-e2e"
+      ],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-messages",
+      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-activity-tracker",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-agent",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-appblocker",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-bun-runtime",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-calendar",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-camera",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-canvas",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-contacts",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-desktop",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-eliza-tasks",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-filesystem",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-gateway",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-llama",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-location",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-macosalarm",
+      "issues": ["missing-action-e2e", "missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-messages",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-mlkit-text",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-mobile-agent-bridge",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-mobile-signals",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-network-policy",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-phone",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-reminders",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-screencapture",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-settings",
+      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-shared-types",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-swabble",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-system",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-talkmode",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-websiteblocker",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-native-wifi",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-ngrok",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-ollama",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-pdf",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-phone",
+      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-pii-guard",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-polymarket",
+      "issues": [
+        "missing-action-e2e",
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-pty",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-registry",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-reminders",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-remote-desktop",
+      "issues": ["missing-action-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-scheduling",
+      "issues": ["missing-view-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-screenshare",
+      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-shell",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-signal",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-slack",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-sql",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-streaming",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-tailscale",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-task-coordinator",
+      "issues": ["missing-action-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-taskboard",
+      "issues": ["missing-deterministic-e2e", "missing-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-tee",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-telegram-standalone",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-todos",
+      "issues": [
+        "missing-action-e2e",
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-training",
+      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-tunnel",
+      "issues": ["missing-action-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-twitch",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-vector-browser",
+      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-video",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-wallet",
+      "issues": ["missing-action-tests"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-wallet-ui",
+      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-web-search",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-wechat",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-whatsapp",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-wifi",
+      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-workflow",
+      "issues": ["missing-action-e2e", "missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-x402",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-xai",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    },
+    {
+      "plugin": "plugin-zai",
+      "issues": ["missing-deterministic-e2e"],
+      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Seeds `packages/scripts/lint-lane-coverage.allowlist.json` from the current `origin/develop` baseline for #13620.
- Converts the existing default allowlist path from theoretical to usable: `node packages/scripts/lint-lane-coverage.mjs` now exits 0 with 153 historical issues suppressed, while new unsuppressed issues and stale entries still fail via the existing loader.
- No workflow files touched. This is the package-level advisory coverage allowlist/ratchet slice only.

## Verification
```
node packages/scripts/lint-lane-coverage.mjs
# [lint-lane-coverage] 140 plugins scanned; 1 missing tests; 100 missing deterministic E2E/scenario coverage; 0 blocking issue(s); 153 suppressed issue(s).

bun test packages/scripts/__tests__/lint-lane-coverage.test.ts
# 3 pass, 0 fail, 13 expect() calls

bun test packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
# 11 pass, 0 fail, 25 expect() calls

bunx @biomejs/biome check packages/scripts/lint-lane-coverage.allowlist.json
# Checked 1 file. No fixes applied.

git diff --check
# pass

node -e "const f=require('./packages/scripts/lint-lane-coverage.allowlist.json'); let keys=[]; for (const e of f.entries) for (const i of e.issues) keys.push(e.plugin+':'+i); console.log('entries', f.entries.length, 'issues', keys.length, 'dupes', keys.length-new Set(keys).size);"
# entries 113 issues 153 dupes 0
```

## Typecheck
```
bun run typecheck
# fails on pre-existing workspace typecheck/dependency-resolution errors under @elizaos/plugin-calendar importing packages/agent, e.g. missing @elizaos/auth/types, @elizaos/plugin-commands, @elizaos/vault, plus existing AccountWithCredentialFlag shape errors. This PR is JSON-only and does not touch TypeScript.
```

## Collision notes
- #13677 already merged the #13620 no-tests substring swallow fix.
- #13640 already merged `--min-tasks` floors on hot-path test scripts.
- #13824 is open for runner guard CI wiring/hardening and touches `.github/workflows/scenario-pr.yml`, non-overlapping with this PR.
- #14056 already path-gated `coverage-gate.yml` for throughput, this PR does not alter it.
