### PR TITLE
feat(app): lock-screen composer position + swipe-open/close chat sheet

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -492,6 +492,21 @@ describe("ContinuousChatOverlay", () => {
     expect(sheet.getAttribute("data-variant")).toBe("open");
   });
 
+  it("spans a WIDE swipe-up grab zone across the composer top edge", () => {
+    // Lock-screen affordance: the grabber's hit zone must reach across the
+    // composer's width (inset-x-6, not a narrow centred px-16 stub) so a
+    // swipe-up begun anywhere near the bottom opens the chat — while still
+    // floating above the input row so it never eats taps meant for the
+    // textarea.
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const grabber = screen.getByTestId("chat-sheet-grabber");
+    expect(grabber.className).toContain("inset-x-6");
+    expect(grabber.className).not.toContain("px-16");
+    // The zone stops at the handle's own bottom (before:bottom-0) so it can't
+    // overlap the interactive composer controls beneath it.
+    expect(grabber.className).toContain("before:bottom-0");
+  });
+
   it("toggles the sheet open and closed on repeated grabber taps", () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
     const sheet = screen.getByTestId("chat-sheet");
@@ -1099,7 +1114,10 @@ describe("ContinuousChatOverlay", () => {
     expect(screen.queryByTestId("chat-full-launcher")).toBeNull();
 
     const grabber = screen.getByTestId("chat-sheet-grabber");
-    expect(grabber.className).toContain("before:-top-4");
+    // The grab zone reaches a comfortable distance ABOVE the composer (so a
+    // swipe-up begun just over it opens the chat) but stays bounded — it never
+    // balloons up into the home widgets.
+    expect(grabber.className).toContain("before:-top-6");
     expect(grabber.className).not.toContain("before:-top-16");
   });
 
@@ -1579,9 +1597,10 @@ describe("ContinuousChatOverlay", () => {
 
   it("keeps the collapsed pill handle non-interactive while the input is formed", () => {
     // The pill handle is always mounted over the (faded) composer so it can
-    // crossfade pill→input. Its hit zone (px-16/pt-10) sits over the textarea, so
-    // while NOT pilled it must be pointer-events-none — otherwise it intercepts
-    // the tap meant for the composer and the mobile keyboard never opens.
+    // crossfade pill→input. Its hit zone (w-full/pt-10) sits over the textarea,
+    // so while NOT pilled it must be pointer-events-none — otherwise it
+    // intercepts the tap meant for the composer and the mobile keyboard never
+    // opens.
     render(<ContinuousChatOverlay controller={makeController()} />);
     const sheet = screen.getByTestId("chat-sheet");
     expect(sheet.getAttribute("data-detent")).toBe("collapsed");
@@ -1592,6 +1611,9 @@ describe("ContinuousChatOverlay", () => {
     // Kept out of the tab order / a11y tree while it's not the active handle.
     expect(pill.getAttribute("tabindex")).toBe("-1");
     expect(pill.getAttribute("aria-hidden")).toBe("true");
+    // The pill's swipe-up grab zone spans the full width (not a narrow centred
+    // px-16 stub) so a swipe-up from anywhere across the bottom opens.
+    expect(pill.className).toContain("w-full");
   });
 
   it("makes the pill handle interactive (drag-to-open) once collapsed to the pill", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -487,14 +487,17 @@ function SheetGrabber({
         "appearance-none border-0 bg-transparent text-left",
         // ABSOLUTELY positioned over the panel top (zero layout height — it
         // floats slightly on top of the input row, so collapsed height == the
-        // input bar). Keep the invisible hit target local to the visible handle:
-        // it should be forgiving, not register drags far above the bar.
+        // input bar). The grab target is WIDE (a swipe-up from anywhere across
+        // the composer's top edge opens the chat — the lock-screen "swipe up to
+        // open" affordance) but STAYS ABOVE the input row so it never steals
+        // taps meant for the textarea / +/mic controls below it.
         // z-20 keeps it above the input row (z-10) so it always wins the drag.
-        "absolute left-1/2 top-0.5 z-20 -translate-x-1/2 flex cursor-grab touch-none select-none items-center justify-center px-16 py-2 active:cursor-grabbing",
-        // The hit zone reaches only a small distance above the panel and stops
-        // at the handle's own bottom, so the handle does not steal taps intended
-        // for the composer or feel like it starts in empty space.
-        "before:absolute before:-inset-x-4 before:-top-4 before:bottom-0 before:content-['']",
+        "absolute inset-x-6 top-0.5 z-20 flex cursor-grab touch-none select-none items-center justify-center py-2 active:cursor-grabbing",
+        // The invisible hit target reaches a comfortable distance ABOVE the
+        // panel (a swipe-up begun in the empty field just over the composer is
+        // caught) and STOPS at the handle's own bottom, so it never overlaps the
+        // interactive composer row beneath — taps fall through to the input.
+        "before:absolute before:-inset-x-2 before:-top-6 before:bottom-0 before:content-['']",
         "   ",
       )}
     >
@@ -562,8 +565,11 @@ function PillHandle({
       aria-hidden={pilled ? undefined : true}
       className={cn(
         // The bar hugs the BOTTOM (small pb) where the collapsed input sat — not
-        // floating mid-air; the tall pt keeps a generous upward grab/flick zone.
-        "h-auto w-auto cursor-grab touch-none select-none items-end rounded-none bg-transparent px-16 pb-1.5 pt-10 hover:bg-transparent active:cursor-grabbing",
+        // floating mid-air; the tall pt + full width keep a generous upward grab/
+        // flick zone so a swipe-up from anywhere across the bottom opens the chat
+        // (the lock-screen affordance). Flex-center keeps the capsule centred
+        // while the invisible hit area spans wide.
+        "flex h-auto w-full cursor-grab touch-none select-none items-end justify-center rounded-none bg-transparent px-8 pb-1.5 pt-10 hover:bg-transparent active:cursor-grabbing",
         // Interactive only while pilled. When NOT pilled the (faded) handle must
         // let taps fall through to the composer textarea below it — otherwise its
         // tall hit zone steals the tap and the keyboard never opens.
@@ -3512,16 +3518,23 @@ export function ContinuousChatOverlay({
         // Full-bleed fills the screen edge-to-edge: NO overlay bottom padding,
         // so the glass panel reaches the true bottom (no orange gap). The
         // gesture-zone clearance moves INSIDE the composer row (below) so the
-        // input still sits above the home-gesture bar. Non-full-bleed anchors the
-        // composer down: it clears the home-gesture inset (max safe-area /
-        // android inset) and nothing more, so it sits low with no dead gap
-        // beneath. The floor layer below paints that inset zone with the home
-        // surface so it reads continuous, not as a black bar.
+        // input still sits above the home-gesture bar. Non-full-bleed anchors
+        // the composer LOW, lock-screen style. The OS reports a ~34px bottom
+        // safe-area on a home-indicator phone, but the indicator itself is a
+        // thin (~5px) bar seated ~8px off the true bottom — clearing the WHOLE
+        // safe-area floats the pill ~34px up over a dead band. So clear only
+        // what the indicator needs: 60% of the reported inset (clears the bar +
+        // its own margin; the 44px min tap target and the OS bar stay
+        // untouched) with a 0.5rem floor so a device with NO inset still keeps
+        // a hair of breathing room. This seats the pill just above the home
+        // indicator instead of hovering. The floor layer below paints the
+        // reclaimed strip with the home surface so it reads continuous, not as
+        // a black bar.
         paddingBottom: fullBleed
           ? 0
           : keyboardLiftActive
             ? "0.75rem"
-            : "calc(var(--eliza-mobile-nav-offset, 0px) + max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)))",
+            : "calc(var(--eliza-mobile-nav-offset, 0px) + max(max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) * 0.6, 0.5rem))",
       }}
       data-testid="continuous-chat-overlay"
       data-open={sheetOpen ? "true" : undefined}


### PR DESCRIPTION
## What

Two mobile-ergonomics fixes for the PWA lock-screen home surface, from on-device testing:

### 1. Composer seats just above the OS home indicator
The resting overlay cleared the **entire** bottom safe-area (~34px on a home-indicator phone), floating the Ask-Sol pill over a dead band. The indicator itself is a thin bar seated ~8px off the true bottom, so the overlay now clears **60% of the reported inset** (still fully above the OS bar, 44px tap target intact) with a 0.5rem floor for devices with no inset. Net: the pill drops ~13px closer to the true bottom edge, lock-screen style. The bottom-floor paint layer still spans the FULL inset so the reclaimed strip can never reappear as an unpainted band.

### 2. Wide swipe-up grab zone
The sheet grabber was a narrow centred stub (`px-16`); a swipe-up begun off-centre missed it and the gesture felt undiscoverable. It now spans the composer's width (`inset-x-6`) with a taller upward reach (`before:-top-6`), while still **stopping at the handle's own bottom** so it never steals taps meant for the textarea / attach / mic controls. The collapsed pill's grab zone likewise widens to full width, so a swipe-up from anywhere across the bottom opens the chat. Swipe-down dismissal semantics unchanged (grabber/handle owns it; transcript keeps vertical-scroll priority).

## What this is NOT
No gesture-engine changes. The existing recognizers (56px distance OR 0.5px/ms velocity, live finger-tracking drag, spring settle, detent magnetism, prefers-reduced-motion fallbacks) are untouched — this is hit-target geometry + resting position only.

## Tests
- New: widened grab-zone coverage (grabber `inset-x-6`, bounded `before:-top-6`, pill `w-full`)
- Updated: grabber hit-zone bound assertion (`-top-4` → `-top-6`, still asserts not `-top-16`)
- 138/141 pass; the 3 failures (typing-dots row, turn-status label ×2) are **pre-existing on develop** and fail identically without this change
- Typecheck: only pre-existing errors in unrelated files (`todo.test.tsx`, `startup-phase-poll.test.ts`)

## Dependency note
A sibling PR is upstreaming the r3.x safe-area/SW fixes (transparent safe-area floor on wallpaper routes, App.tsx). This PR touches only `ContinuousChatOverlay` and layers cleanly on develop before or after it — no shared hunks.

[sol-orch]