### PR TITLE
feat(browser): uniform ViewHeader above the browser toolbar (#13596) — [sol-orch]

### DIFF
--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -45,6 +45,7 @@ import { SidebarPanel } from "../composites/sidebar/sidebar-panel";
 import { SidebarScrollRegion } from "../composites/sidebar/sidebar-scroll-region";
 import { AppPageSidebar } from "../shared/AppPageSidebar";
 import { CollapsibleSidebarSection } from "../shared/CollapsibleSidebarSection";
+import { ViewHeader } from "../shared/ViewHeader";
 import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import { useConfirm } from "../ui/confirm-dialog.hooks";
@@ -2948,20 +2949,34 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     </div>
   );
 
+  // Uniform top bar (#13451/#13596): a bare-icon ViewHeader with a centered
+  // "Browser" title sits ABOVE the browser toolbar (URL bar + tab control),
+  // never replacing it. The toolbar stays inside WorkspaceLayout's
+  // contentHeader; the ViewHeader is a sibling stacked on top so back always
+  // returns to the launcher and the header reads identically to every other
+  // view. `min-h-0` keeps the WorkspaceLayout free to fill the remaining
+  // height below the fixed-height header.
   const mainNode = (
-    <WorkspaceLayout
-      sidebar={browserTabsSidebar}
-      contentHeader={navNode}
-      contentHeaderClassName="mb-0"
-      headerPlacement="inside"
-      contentPadding={false}
-      contentClassName="overflow-hidden"
-      contentInnerClassName="min-h-0 overflow-hidden"
-      mobileSidebarLabel={tabsLabel}
-      mobileSidebarTriggerClassName="ml-3 mt-3"
-    >
-      {browserSurface}
-    </WorkspaceLayout>
+    <div className="flex h-full min-h-0 w-full flex-col">
+      <ViewHeader
+        title={t("browserworkspace.ViewTitle", { defaultValue: "Browser" })}
+      />
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <WorkspaceLayout
+          sidebar={browserTabsSidebar}
+          contentHeader={navNode}
+          contentHeaderClassName="mb-0"
+          headerPlacement="inside"
+          contentPadding={false}
+          contentClassName="overflow-hidden"
+          contentInnerClassName="min-h-0 overflow-hidden"
+          mobileSidebarLabel={tabsLabel}
+          mobileSidebarTriggerClassName="ml-3 mt-3"
+        >
+          {browserSurface}
+        </WorkspaceLayout>
+      </div>
+    </div>
   );
 
   return (

--- a/packages/ui/src/components/pages/browser-workspace-view-header.test.tsx
+++ b/packages/ui/src/components/pages/browser-workspace-view-header.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+/**
+ * Browser view uniform-header contract (#13451/#13596).
+ *
+ * `BrowserWorkspaceView` historically shipped NO `ViewHeader` — its toolbar
+ * (URL bar + tab control) stood in for the header, so the browser broke the
+ * uniform top-bar doctrine every other built-in view follows. #13596's redesign
+ * spec item 2 requires the standard `ViewHeader` (bare-icon back, centered
+ * "Browser" title) rendered ABOVE the toolbar, never replacing it.
+ *
+ * The full view mounts a native `<electrobun-webview>` OOPIF, localStorage, and
+ * a large hook graph, so a full jsdom mount is neither cheap nor stable. This
+ * test pins the contract in two complementary, real ways:
+ *
+ *  1. Render the SHARED `ViewHeader` with the exact title expression the browser
+ *     view uses ("Browser") and assert it produces the standardized header —
+ *     centered title + icon-only chromeless back. This is the real primitive the
+ *     view renders, so a regression in the header contract is caught here.
+ *  2. A static source-scan guard (same pattern as
+ *     `settings/no-native-select.test.ts`) asserting `BrowserWorkspaceView.tsx`
+ *     imports `ViewHeader` and stacks it ABOVE `WorkspaceLayout`, so the
+ *     integration cannot silently regress back to a header-less toolbar.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../agent-surface", () => ({
+  useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
+}));
+
+vi.mock("../../state/shell-surface-store", () => ({
+  goLauncher: vi.fn(),
+}));
+
+vi.mock("../../navigation", () => ({
+  shouldUseHashNavigation: () => true,
+}));
+
+import { ViewHeader } from "../shared/ViewHeader";
+
+// The exact default the browser view passes to `ViewHeader`
+// (`t("browserworkspace.ViewTitle", { defaultValue: "Browser" })`).
+const BROWSER_VIEW_TITLE = "Browser";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BrowserWorkspaceView uniform header (#13596)", () => {
+  it("renders the standardized centered 'Browser' title", () => {
+    render(<ViewHeader title={BROWSER_VIEW_TITLE} />);
+    const title = screen.getByRole("heading", { name: BROWSER_VIEW_TITLE });
+    // Centered over the full header width, matching every other view.
+    expect(title.className).toContain("absolute");
+    expect(title.className).toContain("inset-x-0");
+    expect(title.className).toContain("text-center");
+  });
+
+  it("renders an icon-only chromeless back control (returns to launcher)", () => {
+    render(<ViewHeader title={BROWSER_VIEW_TITLE} />);
+    const back = screen.getByRole("button", { name: /back/i });
+    // Chromeless at rest — no border/fill; hover-only chip.
+    expect(back.className).toContain("bg-transparent");
+    expect(back.className).not.toContain("border");
+    expect(back.className).toContain("hover:bg-bg-hover");
+    // Icon-only: no visible text label.
+    expect(back.textContent?.trim()).toBe("");
+  });
+
+  describe("integration wiring (static source guard)", () => {
+    const source = readFileSync(
+      resolve(import.meta.dirname, "BrowserWorkspaceView.tsx"),
+      "utf8",
+    );
+
+    it("imports the shared ViewHeader primitive", () => {
+      expect(source).toContain(
+        'import { ViewHeader } from "../shared/ViewHeader"',
+      );
+    });
+
+    it("renders ViewHeader with the Browser title", () => {
+      expect(source).toContain("<ViewHeader");
+      expect(source).toContain('t("browserworkspace.ViewTitle"');
+      expect(source).toContain('defaultValue: "Browser"');
+    });
+
+    it("stacks the header ABOVE the toolbar (WorkspaceLayout below ViewHeader)", () => {
+      const headerIdx = source.indexOf("<ViewHeader");
+      const layoutIdx = source.indexOf("<WorkspaceLayout");
+      expect(headerIdx).toBeGreaterThan(-1);
+      expect(layoutIdx).toBeGreaterThan(-1);
+      // The header must appear before the layout in the mainNode composition:
+      // uniform header on top, toolbar (contentHeader) + surface below it.
+      expect(headerIdx).toBeLessThan(layoutIdx);
+    });
+
+    it("does NOT let the toolbar replace the header (contentHeader still hosts the toolbar)", () => {
+      // The URL bar / tab control stays inside WorkspaceLayout's contentHeader —
+      // the ViewHeader is additive, not a toolbar swap.
+      expect(source).toContain("contentHeader={navNode}");
+    });
+  });
+});

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -382,6 +382,7 @@
   "browserworkspace.Tabs": "Tabs",
   "browserworkspace.UnsupportedProtocol": "Only http and https URLs are supported.",
   "browserworkspace.UserTabs": "User Tabs",
+  "browserworkspace.ViewTitle": "Browser",
   "browserworkspace.Visible": "Visible",
   "browserworkspace.WebWorkspace": "Web iframe workspace",
   "browserworkspace.Working": "Working: {{action}}",

--- a/packages/ui/src/i18n/locales/es.json
+++ b/packages/ui/src/i18n/locales/es.json
@@ -381,6 +381,7 @@
   "browserworkspace.Tabs": "Pestañas",
   "browserworkspace.UnsupportedProtocol": "Solo se admiten URLs http y https.",
   "browserworkspace.UserTabs": "Pestañas del usuario",
+  "browserworkspace.ViewTitle": "Navegador",
   "browserworkspace.Visible": "Visible",
   "browserworkspace.WebWorkspace": "Espacio de trabajo web (iframe)",
   "browserworkspace.Working": "Trabajando: {{action}}",

--- a/packages/ui/src/i18n/locales/ja.json
+++ b/packages/ui/src/i18n/locales/ja.json
@@ -381,6 +381,7 @@
   "browserworkspace.Tabs": "タブ",
   "browserworkspace.UnsupportedProtocol": "httpとhttpsのURLのみ対応しています。",
   "browserworkspace.UserTabs": "ユーザータブ",
+  "browserworkspace.ViewTitle": "ブラウザ",
   "browserworkspace.Visible": "表示中",
   "browserworkspace.WebWorkspace": "Web iframeワークスペース",
   "browserworkspace.Working": "実行中: {{action}}",

--- a/packages/ui/src/i18n/locales/ko.json
+++ b/packages/ui/src/i18n/locales/ko.json
@@ -381,6 +381,7 @@
   "browserworkspace.Tabs": "탭",
   "browserworkspace.UnsupportedProtocol": "http와 https URL만 지원해요.",
   "browserworkspace.UserTabs": "사용자 탭",
+  "browserworkspace.ViewTitle": "브라우저",
   "browserworkspace.Visible": "표시됨",
   "browserworkspace.WebWorkspace": "웹 iframe 워크스페이스",
   "browserworkspace.Working": "작업 중: {{action}}",

--- a/packages/ui/src/i18n/locales/pt.json
+++ b/packages/ui/src/i18n/locales/pt.json
@@ -381,6 +381,7 @@
   "browserworkspace.Tabs": "Abas",
   "browserworkspace.UnsupportedProtocol": "Apenas URLs http e https são suportadas.",
   "browserworkspace.UserTabs": "Abas do usuário",
+  "browserworkspace.ViewTitle": "Navegador",
   "browserworkspace.Visible": "Visível",
   "browserworkspace.WebWorkspace": "Workspace em iframe da Web",
   "browserworkspace.Working": "Trabalhando: {{action}}",

--- a/packages/ui/src/i18n/locales/tl.json
+++ b/packages/ui/src/i18n/locales/tl.json
@@ -381,6 +381,7 @@
   "browserworkspace.Tabs": "Mga tab",
   "browserworkspace.UnsupportedProtocol": "Suportado lamang ang http at https URLs.",
   "browserworkspace.UserTabs": "Mga User Tab",
+  "browserworkspace.ViewTitle": "Browser",
   "browserworkspace.Visible": "Nakikita",
   "browserworkspace.WebWorkspace": "Lugar ng trabaho sa web iframe",
   "browserworkspace.Working": "Ginagawa: {{action}}",

--- a/packages/ui/src/i18n/locales/vi.json
+++ b/packages/ui/src/i18n/locales/vi.json
@@ -381,6 +381,7 @@
   "browserworkspace.Tabs": "Tab",
   "browserworkspace.UnsupportedProtocol": "Chỉ hỗ trợ URL http và https.",
   "browserworkspace.UserTabs": "Tab người dùng",
+  "browserworkspace.ViewTitle": "Trình duyệt",
   "browserworkspace.Visible": "Đang hiển thị",
   "browserworkspace.WebWorkspace": "Không gian làm việc web iframe",
   "browserworkspace.Working": "Đang xử lý: {{action}}",

--- a/packages/ui/src/i18n/locales/zh-CN.json
+++ b/packages/ui/src/i18n/locales/zh-CN.json
@@ -381,6 +381,7 @@
   "browserworkspace.Tabs": "标签页",
   "browserworkspace.UnsupportedProtocol": "仅支持 http 和 https URL。",
   "browserworkspace.UserTabs": "用户标签页",
+  "browserworkspace.ViewTitle": "浏览器",
   "browserworkspace.Visible": "可见",
   "browserworkspace.WebWorkspace": "Web iframe 工作区",
   "browserworkspace.Working": "正在执行：{{action}}",


### PR DESCRIPTION
Part of #13596 (browser view redesign, epic #13560). Implements **spec item 2: the uniform top bar** for the Browser view.

## Remainder analysis (why this scope)

#13596 lists 5 ordered spec items. Current coverage on `develop`:

| # | Spec item | Status |
|---|---|---|
| 1 | Default real-HTML search tab (non-blocking, offline error render) | ✅ **merged** — #13810 + #13825 (`plugin-browser`, `ensureBrowserWorkspaceDefaultTab`, DuckDuckGo html endpoint, rejects `about:blank`, 8 tests) |
| 2 | **Uniform `ViewHeader` above the toolbar** | ⬅️ **this PR** |
| 3 | Folded-tab mobile switcher (Safari/Arc-style) | open — large `BrowserWorkspaceView.tsx` (2974 lines) rewrite, cross-renderer (electrobun OOPIF + companion bridge); left for a dedicated lane |
| 4 | Remove browser suggestion chips → designed empty state | 🔵 in-flight on **#13946** (`refactor/13588`) — swaps the browser empty-state `ChatEmptyStateWithRecommendations` → `ViewEmptyState` |
| 5 | View-scoped browser actions | mostly covered — `open-tab`/`navigate`/`switch-tab`/`close-tab`/`reload`/`list_tabs` already `status: "have"` in `browser-matrix.ts`; only a `search-web` alias + view-scope gate remain (deferred, low value / high collision) |

So the clean, non-overlapping remainder here is the **uniform header** (item 2).

## What

`BrowserWorkspaceView` shipped **no `ViewHeader`** — its toolbar (URL bar + tab control) stood in for the header, breaking the uniform top-bar doctrine (#13451) every other built-in view follows. `AppWorkspaceChrome` is pure layout and its own comment notes views are expected to own a `ViewHeader`; the browser was the outlier.

- Wrap `mainNode` in a `flex flex-col` so a shared `<ViewHeader title="Browser" />` (bare-icon back, centered title) stacks **above** the existing `WorkspaceLayout`. The toolbar stays inside `contentHeader` — additive, **not** a toolbar swap.
- Back returns to the launcher like every other view (shared `navigateBackToLauncher`).
- Adds `browserworkspace.ViewTitle` ("Browser") i18n key.

The `WorkspaceLayout`-owned inline mobile sidebar trigger is left in place (the documented fallback for views whose sidebar open-state is layout-local). Migrating that trigger into the header right-slot via `WorkspaceMobileSidebarScope` would require lifting state out of the `WorkspaceLayout` primitive — a larger refactor, flagged as follow-up polish, not this slice.

Orange accent only, lucide-react `ArrowLeft` (via the shared primitive), no blue/purple, no backdrop-blur, no emoji.

## Tests

`packages/ui/src/components/pages/browser-workspace-view-header.test.tsx` — **6/6 passing**:
- Real `ViewHeader` render with the browser's exact title: centered "Browser" heading + icon-only chromeless back (no rest border/fill, hover-only chip).
- Static source guard (same pattern as `settings/no-native-select.test.ts`): asserts `BrowserWorkspaceView.tsx` imports `ViewHeader`, renders it with the Browser title, stacks it **above** `WorkspaceLayout`, and keeps the toolbar in `contentHeader` — so the integration can't silently regress to a header-less toolbar.

```
✓ src/components/pages/browser-workspace-view-header.test.tsx (6 tests) 208ms
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

**Typecheck (`tsgo`):** zero errors on the touched files (`BrowserWorkspaceView.tsx`, the test, `en.json`). Remaining repo-wide `tsgo` errors are pre-existing and unrelated (`@elizaos/cloud-routing` missing workspace artifact; `todo.test.tsx` / `startup-phase-poll.test.ts` type issues on `develop`).

**biome:** clean on both source files.

> Note: `codex review` hung indefinitely on the CI host this lane ran on (sandbox arg0 temp-dir permission error + a very large post-`bun install` untracked tree). The diff is small and self-reviewed; CI's own review/lint gates apply on this PR.

🤖 Author Sol · Co-authored-by wakesync