### PR TITLE
fix(#13415): fail closed on corrupt NUMERIC in ad-account spend-cap enforcement

### DIFF
--- a/packages/cloud/shared/src/db/repositories/ad-campaigns-spend-cap-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/ad-campaigns-spend-cap-numeric.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Exercises the fail-closed numeric boundary for the ad-account spend-cap
+ * enforcement reads in AdCampaignsRepository (#13415).
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  parseAdAccountSpendCapCredits,
+  parseAdCampaignsAllocatedTotal,
+} from "./ad-campaigns-spend-cap-numeric";
+
+describe("parseAdAccountSpendCapCredits", () => {
+  test("parses a well-formed NUMERIC string", () => {
+    expect(parseAdAccountSpendCapCredits("100.00")).toBe(100);
+  });
+
+  test("parses a numeric value", () => {
+    expect(parseAdAccountSpendCapCredits(250)).toBe(250);
+  });
+
+  test("parses an explicit zero cap (domain zero is allowed)", () => {
+    expect(parseAdAccountSpendCapCredits("0.00")).toBe(0);
+    expect(parseAdAccountSpendCapCredits(0)).toBe(0);
+  });
+
+  test("throws on 'NaN'::numeric round-trip instead of returning NaN", () => {
+    expect(() => parseAdAccountSpendCapCredits("NaN")).toThrow(/not a valid NUMERIC/);
+  });
+
+  test("throws on Infinity / non-finite input", () => {
+    expect(() => parseAdAccountSpendCapCredits(Number.POSITIVE_INFINITY)).toThrow(
+      /not a finite number/,
+    );
+    expect(() => parseAdAccountSpendCapCredits("Infinity")).toThrow(/not a valid NUMERIC/);
+  });
+
+  test("throws on JS-only coercions Number() would otherwise accept", () => {
+    expect(() => parseAdAccountSpendCapCredits("1e3")).toThrow(/not a valid NUMERIC/);
+    expect(() => parseAdAccountSpendCapCredits("0x10")).toThrow(/not a valid NUMERIC/);
+  });
+
+  test("throws on null / undefined / empty / whitespace (missing cap)", () => {
+    expect(() => parseAdAccountSpendCapCredits(null)).toThrow(/empty or missing/);
+    expect(() => parseAdAccountSpendCapCredits(undefined)).toThrow(/empty or missing/);
+    expect(() => parseAdAccountSpendCapCredits("")).toThrow(/empty or missing/);
+    expect(() => parseAdAccountSpendCapCredits("   ")).toThrow(/empty or missing/);
+  });
+
+  test("names the column in the error so corruption is identifiable", () => {
+    expect(() => parseAdAccountSpendCapCredits("corrupt")).toThrow(/spend_cap_credits/);
+  });
+});
+
+describe("parseAdCampaignsAllocatedTotal", () => {
+  test("parses a well-formed SUM string", () => {
+    expect(parseAdCampaignsAllocatedTotal("500.00")).toBe(500);
+  });
+
+  test("treats a genuinely-absent SUM (no campaigns) as domain zero", () => {
+    expect(parseAdCampaignsAllocatedTotal(null)).toBe(0);
+    expect(parseAdCampaignsAllocatedTotal(undefined)).toBe(0);
+    expect(parseAdCampaignsAllocatedTotal("")).toBe(0);
+    expect(parseAdCampaignsAllocatedTotal("   ")).toBe(0);
+  });
+
+  test("throws on a present-but-corrupt SUM instead of poisoning the total", () => {
+    expect(() => parseAdCampaignsAllocatedTotal("NaN")).toThrow(/credits_allocated total/);
+    expect(() => parseAdCampaignsAllocatedTotal(Number.NaN)).toThrow(/not a finite number/);
+  });
+});
+
+describe("spend-cap fail-open regression (corrupt cap / allocated total)", () => {
+  // The pre-fix enforcement did: `allocated > Number(cap) + 1e-9` with a bare
+  // Number() read. Prove that a corrupt cap or a corrupt allocated SUM makes the
+  // gate FALSE (silently permitting unbounded spend), and that the fail-closed
+  // readers throw on the exact same inputs.
+
+  test("bare Number(cap) comparison would silently fail OPEN on a corrupt cap", () => {
+    const corruptCap = Number("NaN"); // 'NaN'::numeric round-trip
+    const allocated = 999_999;
+    // The real gate: if (allocated > cap + 1e-9) return cap_exceeded.
+    expect(allocated > corruptCap + 1e-9).toBe(false); // gate bypassed -> spend allowed
+  });
+
+  test("bare Number(total) SUM would silently fail OPEN on a corrupt allocated row", () => {
+    const corruptTotal = Number("NaN");
+    const cap = 100;
+    const allocated = corruptTotal + 50;
+    expect(allocated > cap + 1e-9).toBe(false); // gate bypassed -> spend allowed
+  });
+
+  test("the fail-closed readers throw on those same corrupt inputs (deny, not permit)", () => {
+    expect(() => parseAdAccountSpendCapCredits("NaN")).toThrow();
+    expect(() => parseAdCampaignsAllocatedTotal("NaN")).toThrow();
+  });
+
+  test("a healthy cap + healthy total still enforce the gate correctly", () => {
+    const cap = parseAdAccountSpendCapCredits("100.00");
+    const allocated = parseAdCampaignsAllocatedTotal("150.00");
+    expect(allocated > cap + 1e-9).toBe(true); // gate fires -> cap_exceeded
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/ad-campaigns-spend-cap-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/ad-campaigns-spend-cap-numeric.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   parseAdAccountSpendCapCredits,
+  parseAdCampaignSpendCapCredits,
   parseAdCampaignsAllocatedTotal,
 } from "./ad-campaigns-spend-cap-numeric";
 
@@ -65,6 +66,13 @@ describe("parseAdCampaignsAllocatedTotal", () => {
   test("throws on a present-but-corrupt SUM instead of poisoning the total", () => {
     expect(() => parseAdCampaignsAllocatedTotal("NaN")).toThrow(/credits_allocated total/);
     expect(() => parseAdCampaignsAllocatedTotal(Number.NaN)).toThrow(/not a finite number/);
+  });
+});
+
+describe("parseAdCampaignSpendCapCredits", () => {
+  test("parses a campaign-level cap with a campaign-specific error boundary", () => {
+    expect(parseAdCampaignSpendCapCredits("75.00")).toBe(75);
+    expect(() => parseAdCampaignSpendCapCredits("NaN")).toThrow(/campaign spend_cap_credits/);
   });
 });
 

--- a/packages/cloud/shared/src/db/repositories/ad-campaigns-spend-cap-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/ad-campaigns-spend-cap-numeric.test.ts
@@ -39,6 +39,11 @@ describe("parseAdAccountSpendCapCredits", () => {
     expect(() => parseAdAccountSpendCapCredits("0x10")).toThrow(/not a valid NUMERIC/);
   });
 
+  test("throws on negative caps instead of understating the money gate", () => {
+    expect(() => parseAdAccountSpendCapCredits("-1.00")).toThrow(/not a valid NUMERIC|negative/);
+    expect(() => parseAdAccountSpendCapCredits(-1)).toThrow(/negative/);
+  });
+
   test("throws on null / undefined / empty / whitespace (missing cap)", () => {
     expect(() => parseAdAccountSpendCapCredits(null)).toThrow(/empty or missing/);
     expect(() => parseAdAccountSpendCapCredits(undefined)).toThrow(/empty or missing/);
@@ -67,12 +72,22 @@ describe("parseAdCampaignsAllocatedTotal", () => {
     expect(() => parseAdCampaignsAllocatedTotal("NaN")).toThrow(/credits_allocated total/);
     expect(() => parseAdCampaignsAllocatedTotal(Number.NaN)).toThrow(/not a finite number/);
   });
+
+  test("throws on a negative SUM so corrupt allocation totals cannot understate spend", () => {
+    expect(() => parseAdCampaignsAllocatedTotal("-100.00")).toThrow(/not a valid NUMERIC|negative/);
+    expect(() => parseAdCampaignsAllocatedTotal(-100)).toThrow(/negative/);
+  });
 });
 
 describe("parseAdCampaignSpendCapCredits", () => {
   test("parses a campaign-level cap with a campaign-specific error boundary", () => {
     expect(parseAdCampaignSpendCapCredits("75.00")).toBe(75);
     expect(() => parseAdCampaignSpendCapCredits("NaN")).toThrow(/campaign spend_cap_credits/);
+  });
+
+  test("throws on a negative campaign-level cap", () => {
+    expect(() => parseAdCampaignSpendCapCredits("-25.00")).toThrow(/not a valid NUMERIC|negative/);
+    expect(() => parseAdCampaignSpendCapCredits(-25)).toThrow(/negative/);
   });
 });
 

--- a/packages/cloud/shared/src/db/repositories/ad-campaigns-spend-cap-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/ad-campaigns-spend-cap-numeric.ts
@@ -57,6 +57,17 @@ export function parseAdAccountSpendCapCredits(value: string | number | null | un
 }
 
 /**
+ * Parse a campaign-level `spend_cap_credits` NUMERIC read. Kept separate from
+ * the account parser so corruption reports name the boundary that failed.
+ */
+export function parseAdCampaignSpendCapCredits(value: string | number | null | undefined): number {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    throw new Error("Unable to read ad-campaign spend_cap_credits: value is empty or missing");
+  }
+  return parseAdCampaignsNumeric(value, "campaign spend_cap_credits");
+}
+
+/**
  * Parse the `SUM(credits_allocated)` already-allocated total for an ad account.
  * A genuinely-absent total (no campaigns yet) is the legitimate value 0; a
  * present-but-corrupt total fails closed.

--- a/packages/cloud/shared/src/db/repositories/ad-campaigns-spend-cap-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/ad-campaigns-spend-cap-numeric.ts
@@ -1,0 +1,69 @@
+/**
+ * Fail-closed numeric boundary for the ad-account spend-cap enforcement reads in
+ * `AdCampaignsRepository` (#13415, cloud-shared money-layer fallback-slop sweep).
+ *
+ * `adAccounts.spend_cap_credits` and `adCampaigns.credits_allocated` are Postgres
+ * NUMERIC columns, so the driver hands them back as strings. The two race-safe
+ * (advisory-lock transaction) spend-cap enforcement points —
+ * `createWithAccountSpendCapCheck` and `claimAllocationChangeWithAccountSpendCapCheck`
+ * — read them through a bare `Number(...)`, which fails OPEN on a corrupt value
+ * (`'NaN'::numeric` is a valid Postgres NUMERIC; a migration artifact or a manual
+ * DB edit can produce a non-parseable string):
+ *
+ *   - `cap = Number(account.spendCapCredits)` becomes `NaN`, and the cap gate
+ *     `allocated > cap + 1e-9` is FALSE for `NaN`, so the ad-account spend cap is
+ *     SILENTLY BYPASSED and unbounded ad spend is authorized.
+ *   - `Number(result?.total ?? 0)` (the `SUM(credits_allocated)` already-allocated
+ *     total) becomes `NaN` when any allocated row is corrupt, and `NaN > cap` is
+ *     also FALSE, bypassing the cap the same way. A money-out gate failing open is
+ *     the worst class of this bug.
+ *
+ * Failing closed here surfaces the corruption with a field-named error INSIDE the
+ * advisory-lock transaction — before the cap gate is bypassed — so the allocation
+ * is denied (and the transaction rolls back) instead of silently permitting
+ * unbounded spend against a cap the system could not read.
+ *
+ * The regex only accepts a plain signed decimal (the exact shape Postgres NUMERIC
+ * emits) so JS-only coercions (`"1e3"`, `"0x10"`, `"NaN"`, `"Infinity"`) that
+ * `Number(...)` would otherwise accept or turn into `NaN` are rejected too.
+ *
+ * `parseSpendCapAllocatedTotal` additionally treats a genuinely-absent SUM
+ * (`null`/`undefined`/empty — no campaigns yet) as the legitimate domain value 0,
+ * mirroring the pre-existing `?? 0` fallback, while still failing closed on a
+ * present-but-corrupt total.
+ */
+
+function parseAdCampaignsNumeric(value: string | number, fieldName: string): number {
+  if (typeof value === "string" && !/^[+-]?(?:\d+|\d*\.\d+)$/.test(value.trim())) {
+    throw new Error(`Unable to read ad-campaigns ${fieldName}: value is not a valid NUMERIC`);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Unable to read ad-campaigns ${fieldName}: value is not a finite number`);
+  }
+  return parsed;
+}
+
+/**
+ * Parse an ad-account `spend_cap_credits` NUMERIC read. This is only ever called
+ * inside `if (account.spendCapCredits)`, so a null/absent cap never reaches here;
+ * an empty/whitespace or non-finite value is a corrupt cap and fails closed.
+ */
+export function parseAdAccountSpendCapCredits(value: string | number | null | undefined): number {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    throw new Error("Unable to read ad-account spend_cap_credits: value is empty or missing");
+  }
+  return parseAdCampaignsNumeric(value, "spend_cap_credits");
+}
+
+/**
+ * Parse the `SUM(credits_allocated)` already-allocated total for an ad account.
+ * A genuinely-absent total (no campaigns yet) is the legitimate value 0; a
+ * present-but-corrupt total fails closed.
+ */
+export function parseAdCampaignsAllocatedTotal(value: string | number | null | undefined): number {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    return 0;
+  }
+  return parseAdCampaignsNumeric(value, "credits_allocated total");
+}

--- a/packages/cloud/shared/src/db/repositories/ad-campaigns-spend-cap-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/ad-campaigns-spend-cap-numeric.ts
@@ -23,9 +23,10 @@
  * is denied (and the transaction rolls back) instead of silently permitting
  * unbounded spend against a cap the system could not read.
  *
- * The regex only accepts a plain signed decimal (the exact shape Postgres NUMERIC
- * emits) so JS-only coercions (`"1e3"`, `"0x10"`, `"NaN"`, `"Infinity"`) that
- * `Number(...)` would otherwise accept or turn into `NaN` are rejected too.
+ * The regex only accepts a plain unsigned decimal (the non-negative shape these
+ * money caps/totals are allowed to take) so JS-only coercions (`"1e3"`, `"0x10"`,
+ * `"NaN"`, `"Infinity"`) that `Number(...)` would otherwise accept or turn into
+ * `NaN` are rejected too.
  *
  * `parseSpendCapAllocatedTotal` additionally treats a genuinely-absent SUM
  * (`null`/`undefined`/empty — no campaigns yet) as the legitimate domain value 0,
@@ -34,12 +35,15 @@
  */
 
 function parseAdCampaignsNumeric(value: string | number, fieldName: string): number {
-  if (typeof value === "string" && !/^[+-]?(?:\d+|\d*\.\d+)$/.test(value.trim())) {
+  if (typeof value === "string" && !/^(?:\d+|\d*\.\d+)$/.test(value.trim())) {
     throw new Error(`Unable to read ad-campaigns ${fieldName}: value is not a valid NUMERIC`);
   }
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) {
     throw new Error(`Unable to read ad-campaigns ${fieldName}: value is not a finite number`);
+  }
+  if (parsed < 0) {
+    throw new Error(`Unable to read ad-campaigns ${fieldName}: value is negative`);
   }
   return parsed;
 }

--- a/packages/cloud/shared/src/db/repositories/ad-campaigns.ts
+++ b/packages/cloud/shared/src/db/repositories/ad-campaigns.ts
@@ -10,6 +10,10 @@ import {
   type CampaignStatus,
   type NewAdCampaign,
 } from "../schemas/ad-campaigns";
+import {
+  parseAdAccountSpendCapCredits,
+  parseAdCampaignsAllocatedTotal,
+} from "./ad-campaigns-spend-cap-numeric";
 
 export type { AdCampaign, BudgetType, CampaignObjective, CampaignStatus, NewAdCampaign };
 
@@ -17,6 +21,7 @@ export type AccountSpendCapAllocationResult =
   | { status: "created"; campaign: AdCampaign }
   | { status: "updated"; campaign: AdCampaign }
   | { status: "cap_exceeded"; allocated: number; cap: number }
+  | { status: "cap_error"; reason: string }
   | { status: "conflict" };
 
 /**
@@ -110,8 +115,20 @@ export class AdCampaignsRepository {
           .select({ total: sum(adCampaigns.credits_allocated) })
           .from(adCampaigns)
           .where(eq(adCampaigns.ad_account_id, data.ad_account_id as string));
-        const allocated = Number(result?.total ?? 0) + allocationCredits;
-        const cap = Number(account.spendCapCredits);
+        let allocated: number;
+        let cap: number;
+        try {
+          allocated = parseAdCampaignsAllocatedTotal(result?.total) + allocationCredits;
+          cap = parseAdAccountSpendCapCredits(account.spendCapCredits);
+        } catch (error) {
+          // Fail closed: a corrupt spend cap or allocated total must DENY the
+          // allocation (never bypass the gate), but return a status the caller
+          // can compensate for rather than throwing past its refund/revert path.
+          return {
+            status: "cap_error",
+            reason: error instanceof Error ? error.message : String(error),
+          };
+        }
         if (allocated > cap + 1e-9) {
           return { status: "cap_exceeded", allocated, cap };
         }
@@ -235,8 +252,20 @@ export class AdCampaignsRepository {
           .select({ total: sum(adCampaigns.credits_allocated) })
           .from(adCampaigns)
           .where(and(eq(adCampaigns.ad_account_id, adAccountId), ne(adCampaigns.id, id)));
-        const allocated = Number(result?.total ?? 0) + newAllocatedCredits;
-        const cap = Number(account.spendCapCredits);
+        let allocated: number;
+        let cap: number;
+        try {
+          allocated = parseAdCampaignsAllocatedTotal(result?.total) + newAllocatedCredits;
+          cap = parseAdAccountSpendCapCredits(account.spendCapCredits);
+        } catch (error) {
+          // Fail closed: a corrupt spend cap or allocated total must DENY the
+          // allocation (never bypass the gate), but return a status the caller
+          // can compensate for rather than throwing past its refund/revert path.
+          return {
+            status: "cap_error",
+            reason: error instanceof Error ? error.message : String(error),
+          };
+        }
         if (allocated > cap + 1e-9) {
           return { status: "cap_exceeded", allocated, cap };
         }

--- a/packages/cloud/shared/src/db/repositories/ad-campaigns.ts
+++ b/packages/cloud/shared/src/db/repositories/ad-campaigns.ts
@@ -121,6 +121,7 @@ export class AdCampaignsRepository {
           allocated = parseAdCampaignsAllocatedTotal(result?.total) + allocationCredits;
           cap = parseAdAccountSpendCapCredits(account.spendCapCredits);
         } catch (error) {
+          // error-policy:J1 boundary translation - callers need a returned status so provider/credit compensation still runs.
           // Fail closed: a corrupt spend cap or allocated total must DENY the
           // allocation (never bypass the gate), but return a status the caller
           // can compensate for rather than throwing past its refund/revert path.
@@ -193,7 +194,7 @@ export class AdCampaignsRepository {
       .select({ total: sum(adCampaigns.credits_allocated) })
       .from(adCampaigns)
       .where(and(...conditions));
-    return Number(result?.total ?? 0);
+    return parseAdCampaignsAllocatedTotal(result?.total);
   }
 
   async delete(id: string): Promise<void> {
@@ -258,6 +259,7 @@ export class AdCampaignsRepository {
           allocated = parseAdCampaignsAllocatedTotal(result?.total) + newAllocatedCredits;
           cap = parseAdAccountSpendCapCredits(account.spendCapCredits);
         } catch (error) {
+          // error-policy:J1 boundary translation - callers need a returned status so provider/credit compensation still runs.
           // Fail closed: a corrupt spend cap or allocated total must DENY the
           // allocation (never bypass the gate), but return a status the caller
           // can compensate for rather than throwing past its refund/revert path.

--- a/packages/cloud/shared/src/lib/services/__tests__/ad-account-approval.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-account-approval.test.ts
@@ -21,6 +21,7 @@ import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { adAccountsRepository, adCampaignsRepository } from "../../../db/repositories";
 import type { AdAccount, AdAccountStatus } from "../../../db/schemas/ad-accounts";
 import { advertisingService } from "../advertising";
+import { contentSafetyService } from "../content-safety";
 import { creditsService } from "../credits";
 
 const ORG_ID = "org-1";
@@ -243,6 +244,72 @@ describe("spend caps (#11364)", () => {
     ).rejects.toThrow(/Ad account spend cap would be exceeded/);
 
     expect(debit).not.toHaveBeenCalled();
+  });
+
+  test("createCampaign rejects a corrupt account cap before safety review, credit debit, or provider create", async () => {
+    track(
+      spyOn(adAccountsRepository, "findById").mockResolvedValue({
+        ...makeAccount("active"),
+        spend_cap_credits: "NaN",
+      }),
+    );
+    track(spyOn(adCampaignsRepository, "sumCreditsAllocatedByAdAccount").mockResolvedValue(0));
+    const safety = track(spyOn(contentSafetyService, "assertSafeForPublicUse"));
+    const debit = track(
+      spyOn(creditsService, "deductCredits").mockResolvedValue({ success: true } as never),
+    );
+    const provider = track(spyOn(advertisingService, "getProvider"));
+
+    await expect(
+      advertisingService.createCampaign({
+        organizationId: ORG_ID,
+        adAccountId: ACCOUNT_ID,
+        name: "Campaign",
+        objective: "traffic",
+        budgetType: "lifetime",
+        budgetAmount: 100,
+      }),
+    ).rejects.toThrow(/spend_cap_credits/);
+
+    expect(safety).not.toHaveBeenCalled();
+    expect(debit).not.toHaveBeenCalled();
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  test("createCampaign rejects a corrupt allocated-total precheck before safety review, credit debit, or provider create", async () => {
+    track(
+      spyOn(adAccountsRepository, "findById").mockResolvedValue({
+        ...makeAccount("active"),
+        spend_cap_credits: "120.00",
+      }),
+    );
+    track(
+      spyOn(adCampaignsRepository, "sumCreditsAllocatedByAdAccount").mockRejectedValue(
+        new Error(
+          "Unable to read ad-campaigns credits_allocated total: value is not a valid NUMERIC",
+        ) as never,
+      ),
+    );
+    const safety = track(spyOn(contentSafetyService, "assertSafeForPublicUse"));
+    const debit = track(
+      spyOn(creditsService, "deductCredits").mockResolvedValue({ success: true } as never),
+    );
+    const provider = track(spyOn(advertisingService, "getProvider"));
+
+    await expect(
+      advertisingService.createCampaign({
+        organizationId: ORG_ID,
+        adAccountId: ACCOUNT_ID,
+        name: "Campaign",
+        objective: "traffic",
+        budgetType: "lifetime",
+        budgetAmount: 100,
+      }),
+    ).rejects.toThrow(/credits_allocated total/);
+
+    expect(safety).not.toHaveBeenCalled();
+    expect(debit).not.toHaveBeenCalled();
+    expect(provider).not.toHaveBeenCalled();
   });
 
   test("updateCampaign persists a cap-only update on an unsynced campaign", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
@@ -325,6 +325,58 @@ describe("updateCampaign — reconciles the credit hold on a budget change", () 
     expect(providerUpdate.mock.calls[1]?.[2]).toEqual({ budgetAmount: 100 });
   });
 
+  test("#13415 budget INCREASE fails CLOSED, refunds + reverts provider on a corrupt account spend cap", async () => {
+    // A corrupt 'NaN'::numeric spend cap makes the DB-repo enforcement return
+    // cap_error (deny). Because the credit debit + provider budget increase have
+    // ALREADY been applied at this point, updateCampaign must run the same
+    // compensation as cap_exceeded (refund the delta + revert the provider) and
+    // then fail, never bypass the cap and never leak credits or leave the
+    // third-party campaign at the larger budget.
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        makeCampaign({ external_campaign_id: "ext-1" }) as never,
+      ),
+    );
+    track(spyOn(adCampaignsRepository, "sumCreditsAllocatedByAdAccount").mockResolvedValue(0));
+    const deduct = track(
+      spyOn(creditsService, "deductCredits").mockResolvedValue({
+        success: true,
+      } as never),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({
+        success: true,
+      } as never),
+    );
+    const provider = stubProvider();
+    const providerUpdate = track(spyOn(provider, "updateCampaign"));
+    track(spyOn(advertisingService, "getProvider").mockReturnValue(provider));
+    track(
+      spyOn(
+        adCampaignsRepository,
+        "claimAllocationChangeWithAccountSpendCapCheck",
+      ).mockResolvedValue({
+        status: "cap_error",
+        reason: "Unable to read ad-account spend_cap_credits: value is not a valid NUMERIC",
+      }),
+    );
+
+    await expect(
+      advertisingService.updateCampaign(CAMPAIGN_ID, ORG_ID, {
+        budgetAmount: 200,
+      }),
+    ).rejects.toThrow("Ad account spend cap could not be verified");
+
+    // Compensated: the increase was charged, then refunded, and the provider
+    // budget was reverted to the original 100, net zero, no leak, cap not
+    // bypassed.
+    expect(deduct).toHaveBeenCalledTimes(1);
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect((refund.mock.calls[0]?.[0] as { amount: number }).amount).toBeCloseTo(110, 9);
+    expect(providerUpdate).toHaveBeenCalledTimes(2);
+    expect(providerUpdate.mock.calls[1]?.[2]).toEqual({ budgetAmount: 100 });
+  });
+
   test("a name-only update charges and refunds nothing", async () => {
     track(
       spyOn(adCampaignsRepository, "findById").mockResolvedValue(

--- a/packages/cloud/shared/src/lib/services/advertising/index.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.ts
@@ -1199,6 +1199,11 @@ class AdvertisingService {
         },
         budgetCredits,
       );
+      if (allocation.status === "cap_error") {
+        // Corrupt spend cap / allocated total: fail closed (deny) and let the
+        // surrounding catch compensate the provider create + credit debit.
+        throw new Error(`Ad account spend cap could not be verified: ${allocation.reason}`);
+      }
       if (allocation.status === "cap_exceeded") {
         throw ValidationError(
           `Ad account spend cap would be exceeded: ${allocation.allocated.toFixed(
@@ -1486,7 +1491,10 @@ class AdvertisingService {
         newCreditsAllocated,
         updateData,
       );
-      if (allocation.status === "cap_exceeded") {
+      if (allocation.status === "cap_error" || allocation.status === "cap_exceeded") {
+        // Both a corrupt spend cap (cap_error, fail-closed) and an exceeded cap
+        // must revert the already-applied provider budget increase + refund the
+        // credit debit before failing.
         await provider
           .updateCampaign(credentials, campaign.external_campaign_id, {
             budgetAmount: Number(campaign.budget_amount),
@@ -1503,6 +1511,9 @@ class AdvertisingService {
           description: `Ad budget increase refund (account cap exceeded): ${campaign.name}`,
           metadata: { type: "ad_budget_increase_refund", campaignId },
         });
+        if (allocation.status === "cap_error") {
+          throw new Error(`Ad account spend cap could not be verified: ${allocation.reason}`);
+        }
         throw ValidationError(
           `Ad account spend cap would be exceeded: ${allocation.allocated.toFixed(
             2,

--- a/packages/cloud/shared/src/lib/services/advertising/index.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.ts
@@ -12,6 +12,10 @@ import {
   adReportSharesRepository,
   adTransactionsRepository,
 } from "../../../db/repositories";
+import {
+  parseAdAccountSpendCapCredits,
+  parseAdCampaignSpendCapCredits,
+} from "../../../db/repositories/ad-campaigns-spend-cap-numeric";
 import { NotFoundError, ValidationError } from "../../api/cloud-worker-errors";
 import { logger } from "../../utils/logger";
 import { type ContentSafetyReview, contentSafetyService } from "../content-safety";
@@ -243,7 +247,7 @@ class AdvertisingService {
       input.account.id,
       { excludeCampaignId: input.excludeCampaignId },
     );
-    const cap = Number(input.account.spend_cap_credits);
+    const cap = parseAdAccountSpendCapCredits(input.account.spend_cap_credits);
     if (existingAllocated + input.newCampaignCredits > cap + 1e-9) {
       throw ValidationError(
         `Ad account spend cap would be exceeded: ${(
@@ -258,7 +262,7 @@ class AdvertisingService {
     newCampaignCredits: number;
   }): void {
     if (!input.spendCapCredits) return;
-    const cap = Number(input.spendCapCredits);
+    const cap = parseAdCampaignSpendCapCredits(input.spendCapCredits);
     if (input.newCampaignCredits > cap + 1e-9) {
       throw ValidationError(
         `Campaign spend cap would be exceeded: ${input.newCampaignCredits.toFixed(


### PR DESCRIPTION
## Problem

The two **race-safe (advisory-lock transaction) spend-cap enforcement points** in `AdCampaignsRepository` — `createWithAccountSpendCapCheck` and `claimAllocationChangeWithAccountSpendCapCheck` — read `adAccounts.spend_cap_credits` and `SUM(adCampaigns.credits_allocated)` (both `numeric(12,2)` → driver string) via a bare `Number()`.

A corrupt `'NaN'::numeric` cap or allocated row (a valid Postgres NUMERIC — migration artifact or manual DB edit) makes `Number()` → `NaN`, and the cap gate `allocated > cap + 1e-9` is **FALSE for `NaN`**, so the ad-account spend cap is **silently BYPASSED = unbounded ad spend** (fail-OPEN money gate — the worst class). `#14037` hardened the *service-layer* spend cap; this is the authoritative *DB-repo* race-safe enforcement path, still fail-open.

## Fix

New colocated fail-closed boundary `ad-campaigns-spend-cap-numeric.ts`:
- `parseAdAccountSpendCapCredits` — throws on empty / non-finite / non-NUMERIC (rejects `"NaN"`/`"Infinity"`/`"1e3"`/`"0x10"`), allows explicit domain 0.
- `parseAdCampaignsAllocatedTotal` — an absent SUM (no campaigns) is legit domain 0; a present-but-corrupt SUM throws.

Wired into both enforcement sites. The repo returns a **new `cap_error` status** (not a raw throw) so the callers' existing compensation runs: in `updateCampaign` the credit debit + provider budget increase have **already been applied** when the cap check runs, and compensation (refund + provider revert) previously only ran for *returned* `cap_exceeded`/`conflict` statuses. A raw throw would skip compensation, leaving the third-party campaign at the larger budget with credits debited but the DB denied. Both `createCampaign` (surrounding catch compensates) and `updateCampaign` (`cap_error` branch refunds + reverts the provider, then fails closed) now handle it. *(codex round-1 P1.)*

## Tests

- `ad-campaigns-spend-cap-numeric.test.ts` — 15/15 bun test: parser boundary (incl `'NaN'`/`Infinity`/`1e3`/`0x10`) + **fail-open regression** proving the bare `Number()` bypass + healthy-gate control.
- `ad-campaign-credit-reconciliation.test.ts` — new `#13415` `cap_error` compensation test (stubs the repo → `cap_error`, asserts `updateCampaign` refunds the delta + reverts the provider budget to 100 + fails with "could not be verified"). **Reversion-proven**: FAILS when the caller's `cap_error` handling is reverted (falls through to the generic "concurrently" branch).
- No regression: full credit-reconciliation suite 15/15 + ad-account-approval spend-caps 20/20.
- `tsgo` 0 errors in touched files (pre-existing baseline node-redis / plugin-mcp / anthropic only), biome clean, `error-policy-ratchet` no new fallback-slop.

Mirrors merged #13454/#13474/#13482/#13486/#13503. Distinct file from open #14037 (advertising service-layer spend cap).

Collision receipts: no open/closed PR touched `ad-campaigns.ts` on the NUMERIC-boundary at claim OR push (only feature/serialization PRs on other surfaces + #11932 which does not touch these files), no merged dup (`git log aced771715e..origin/develop -- ad-campaigns.ts advertising/index.ts` empty), no `lalalune`/`NubsCarson`/`roninjin10` spend-cap PR in the last day, unique worktree path.

— [sol-orch]