### PR TITLE
ci: preflight stale PR bases before test fanout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,52 @@ permissions:
   contents: read
 
 jobs:
+  stale-base-preflight:
+    name: PR stale-base preflight
+    if: github.event_name == 'pull_request'
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    timeout-minutes: 10
+    env:
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      ACK: ${{ contains(github.event.pull_request.labels.*.name, 'stale-base-ack') && '1' || '' }}
+    steps:
+      - name: Checkout target branch (guard logic comes from the base, not the PR)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 1
+          submodules: false
+
+      - name: Fetch PR head + bounded history (blobless)
+        run: |
+          set -euo pipefail
+          git fetch --quiet --no-tags --filter=blob:none --depth=1500 origin \
+            "$HEAD_SHA" \
+            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+      - name: Self-test the guard on fixture repos
+        run: node packages/scripts/stale-base-guard.self-test.mjs
+
+      - name: Detect silent reverts + stale base before fanning out tests
+        env:
+          GIT_NO_LAZY_FETCH: "1"
+        run: |
+          set -euo pipefail
+          node packages/scripts/stale-base-guard.mjs \
+            --base "refs/remotes/origin/${BASE_REF}" \
+            --head "$HEAD_SHA" \
+            --window 1200 \
+            --max-behind-commits 200 \
+            --max-behind-hours 72 \
+            ${ACK:+--ack} \
+            --github \
+            --summary "$GITHUB_STEP_SUMMARY"
+
   changes:
     name: Classify changed paths
+    needs: stale-base-preflight
+    if: always() && (github.event_name != 'pull_request' || needs.stale-base-preflight.result == 'success')
     # Route with the same fleet-aware conditional as the test lanes. GitHub-hosted
     # runners are billing-frozen (#13481), so a hardcoded ubuntu-24.04 here queued
     # forever and — since every lane needs this classifier — stalled the entire
@@ -1391,6 +1435,7 @@ jobs:
     name: ci-ok
     if: ${{ !cancelled() && always() }}
     needs:
+      - stale-base-preflight
       - changes
       - merge-quality-gate
       - server-tests
@@ -1414,6 +1459,7 @@ jobs:
         run: |
           set -u
           echo "=== Required test job results ==="
+          echo "stale-base-preflight:${{ needs.stale-base-preflight.result }}"
           echo "changes:          ${{ needs.changes.result }}"
           echo "merge-quality-gate:${{ needs.merge-quality-gate.result }}"
           echo "server-tests:     ${{ needs.server-tests.result }}"
@@ -1430,6 +1476,7 @@ jobs:
           strict_results="${{ github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}"
           bad=0
           for pair in \
+            "stale-base-preflight:${{ needs.stale-base-preflight.result }}" \
             "changes:${{ needs.changes.result }}" \
             "merge-quality-gate:${{ needs.merge-quality-gate.result }}" \
             "server-tests:${{ needs.server-tests.result }}" \
@@ -1444,6 +1491,10 @@ jobs:
             "github-live-artifact-validate:${{ needs.github-live-artifact-validate.result }}"; do
             name="${pair%%:*}"
             result="${pair##*:}"
+            if [ "$name" = "stale-base-preflight" ] && [ "$result" = "skipped" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
+              echo "::notice title=Test gate::PR stale-base preflight is skipped for ${{ github.event_name }}; merge-quality-gate runs the strict stale-base guard for this event."
+              continue
+            fi
             if [ "$name" = "github-live-artifact-validate" ] && [ "$result" = "skipped" ] && [ "${{ github.event_name }}" != "workflow_dispatch" ] && [ "${{ github.event_name }}" != "schedule" ]; then
               echo "::notice title=Test gate::Live artifact validation is observed only on workflow_dispatch/schedule, so its skip is allowed for ${{ github.event_name }}."
               continue

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
     timeout-minutes: 10
     env:
       BASE_REF: ${{ github.event.pull_request.base.ref }}
+      HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       ACK: ${{ contains(github.event.pull_request.labels.*.name, 'stale-base-ack') && '1' || '' }}
     steps:
@@ -57,11 +58,17 @@ jobs:
           fetch-depth: 1
           submodules: false
 
+      - name: Setup Node.js for stale-base guard
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Fetch PR head + bounded history (blobless)
         run: |
           set -euo pipefail
+          git fetch --quiet --no-tags --filter=blob:none --depth=1500 \
+            "https://github.com/${HEAD_REPO}.git" "$HEAD_SHA"
           git fetch --quiet --no-tags --filter=blob:none --depth=1500 origin \
-            "$HEAD_SHA" \
             "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
 
       - name: Self-test the guard on fixture repos

--- a/packages/scripts/ci-merge-gate-contract.mjs
+++ b/packages/scripts/ci-merge-gate-contract.mjs
@@ -167,6 +167,33 @@ function checkWorkflowText(fileName, text, problems) {
       problems.push(
         "test.yml: 'ci-ok' does not need 'merge-quality-gate' — the merge queue would not enforce lint/format/typecheck/secret gates",
       );
+    } else if (!ciOkNeeds.has("stale-base-preflight")) {
+      problems.push(
+        "test.yml: 'ci-ok' does not need 'stale-base-preflight' — stale PRs could skip the test fan-out without failing the required aggregate",
+      );
+    }
+
+    const preflight = jobBody(text, "stale-base-preflight");
+    if (preflight === null) {
+      problems.push("test.yml: no 'stale-base-preflight' job found");
+    } else {
+      const preflightRunsOn =
+        preflight.match(/^\s+runs-on:\s*(.+?)\s*$/m)?.[1] ?? "";
+      if (!hasHostedRunnerOrFleetFallback(preflightRunsOn)) {
+        problems.push(
+          `test.yml: 'stale-base-preflight' runs-on is '${preflightRunsOn || "missing"}', expected ubuntu-* or the ${FLEET_FALLBACK_VAR} hosted fallback expression`,
+        );
+      }
+      if (!/github\.event_name\s*==\s*'pull_request'/.test(preflight)) {
+        problems.push(
+          "test.yml: 'stale-base-preflight' must be PR-only so non-PR ci-ok lanes keep using merge-quality-gate",
+        );
+      }
+      if (!/stale-base-guard\.mjs[\s\S]*--head "\$HEAD_SHA"/.test(preflight)) {
+        problems.push(
+          "test.yml: 'stale-base-preflight' is missing the PR-head stale-base guard step",
+        );
+      }
     }
 
     const gate = jobBody(text, "merge-quality-gate");
@@ -222,8 +249,15 @@ function run(repoRoot) {
 
 function selfTest() {
   const good = `jobs:
+  stale-base-preflight:
+    name: PR stale-base preflight
+    if: github.event_name == 'pull_request'
+    runs-on: \${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    steps:
+      - run: node packages/scripts/stale-base-guard.mjs --base "refs/remotes/origin/\${BASE_REF}" --head "$HEAD_SHA"
   changes:
     name: Classify changed paths
+    needs: stale-base-preflight
     runs-on: \${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
   server-tests:
@@ -243,6 +277,7 @@ function selfTest() {
   ci-ok:
     name: ci-ok
     needs:
+      - stale-base-preflight
       - changes
       - merge-quality-gate
       - server-tests
@@ -275,6 +310,21 @@ function selfTest() {
       text: good.replace("      - merge-quality-gate\n", ""),
     },
     {
+      name: "ci-ok missing stale-base preflight",
+      text: good.replace("      - stale-base-preflight\n", ""),
+    },
+    {
+      name: "missing stale-base preflight job",
+      text: good.replace(
+        / {2}stale-base-preflight:[\s\S]*?(?= {2}changes:\n)/,
+        "",
+      ),
+    },
+    {
+      name: "preflight not PR-only",
+      text: good.replace("if: github.event_name == 'pull_request'", ""),
+    },
+    {
       name: "gate missing typecheck",
       text: good.replace("      - run: bun run typecheck\n", ""),
     },
@@ -301,7 +351,9 @@ function selfTest() {
       throw new Error(`self-test: invalid fixture '${name}' was not caught`);
     }
   }
-  console.log("ci-merge-gate-contract self-test: 8 cases passed");
+  console.log(
+    `ci-merge-gate-contract self-test: ${badCases.length + 1} cases passed`,
+  );
 }
 
 function main() {

--- a/packages/scripts/ci-merge-gate-contract.mjs
+++ b/packages/scripts/ci-merge-gate-contract.mjs
@@ -92,6 +92,11 @@ function jobNeeds(text, jobId) {
   for (let i = header + 1; i < lines.length; i += 1) {
     const line = lines[i];
     if (/^ {2}\S/.test(line)) break; // next top-level job
+    const inlineNeeds = line.match(/^ {4}needs:\s*(\S+)\s*$/);
+    if (inlineNeeds) {
+      needs.add(inlineNeeds[1]);
+      continue;
+    }
     if (/^ {4}needs:\s*$/.test(line)) {
       inNeeds = true;
       continue;
@@ -196,6 +201,30 @@ function checkWorkflowText(fileName, text, problems) {
       }
     }
 
+    const changesNeeds = jobNeeds(text, "changes");
+    const changes = jobBody(text, "changes");
+    if (!changesNeeds?.has("stale-base-preflight")) {
+      problems.push(
+        "test.yml: 'changes' must need 'stale-base-preflight' so stale PRs fail before test fanout",
+      );
+    }
+    if (changes === null) {
+      problems.push("test.yml: no 'changes' job found");
+    } else {
+      if (
+        !/needs\.stale-base-preflight\.result\s*==\s*'success'/.test(changes)
+      ) {
+        problems.push(
+          "test.yml: 'changes' must require stale-base-preflight success for pull_request fanout",
+        );
+      }
+      if (!/github\.event_name\s*!=\s*'pull_request'/.test(changes)) {
+        problems.push(
+          "test.yml: 'changes' must continue for non-PR events where stale-base-preflight is skipped",
+        );
+      }
+    }
+
     const gate = jobBody(text, "merge-quality-gate");
     if (gate === null) {
       problems.push("test.yml: no 'merge-quality-gate' job found");
@@ -258,6 +287,7 @@ function selfTest() {
   changes:
     name: Classify changed paths
     needs: stale-base-preflight
+    if: always() && (github.event_name != 'pull_request' || needs.stale-base-preflight.result == 'success')
     runs-on: \${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
   server-tests:
@@ -323,6 +353,21 @@ function selfTest() {
     {
       name: "preflight not PR-only",
       text: good.replace("if: github.event_name == 'pull_request'", ""),
+    },
+    {
+      name: "changes missing preflight need",
+      text: good.replace("    needs: stale-base-preflight\n", ""),
+    },
+    {
+      name: "changes missing preflight success gate",
+      text: good.replace(
+        " || needs.stale-base-preflight.result == 'success'",
+        "",
+      ),
+    },
+    {
+      name: "changes missing non-PR continuation",
+      text: good.replace("github.event_name != 'pull_request' || ", ""),
     },
     {
       name: "gate missing typecheck",

--- a/packages/scripts/ci-merge-gate-contract.mjs
+++ b/packages/scripts/ci-merge-gate-contract.mjs
@@ -194,6 +194,29 @@ function checkWorkflowText(fileName, text, problems) {
           "test.yml: 'stale-base-preflight' must be PR-only so non-PR ci-ok lanes keep using merge-quality-gate",
         );
       }
+      if (!/actions\/setup-node@/.test(preflight)) {
+        problems.push(
+          "test.yml: 'stale-base-preflight' must set up Node before running the stale-base guard scripts",
+        );
+      }
+      if (
+        !/HEAD_REPO:[\s\S]*github\.event\.pull_request\.head\.repo\.full_name/.test(
+          preflight,
+        )
+      ) {
+        problems.push(
+          "test.yml: 'stale-base-preflight' must fetch the PR head from the head repository so fork PRs are supported",
+        );
+      }
+      if (
+        !/https:\/\/github\.com\/\$\{HEAD_REPO\}\.git[\s\S]*"\$HEAD_SHA"/.test(
+          preflight,
+        )
+      ) {
+        problems.push(
+          "test.yml: 'stale-base-preflight' fetch must use the PR head repository URL for HEAD_SHA",
+        );
+      }
       if (!/stale-base-guard\.mjs[\s\S]*--head "\$HEAD_SHA"/.test(preflight)) {
         problems.push(
           "test.yml: 'stale-base-preflight' is missing the PR-head stale-base guard step",
@@ -282,8 +305,12 @@ function selfTest() {
     name: PR stale-base preflight
     if: github.event_name == 'pull_request'
     runs-on: \${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    env:
+      HEAD_REPO: \${{ github.event.pull_request.head.repo.full_name }}
     steps:
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       - run: node packages/scripts/stale-base-guard.mjs --base "refs/remotes/origin/\${BASE_REF}" --head "$HEAD_SHA"
+      - run: git fetch "https://github.com/\${HEAD_REPO}.git" "$HEAD_SHA"
   changes:
     name: Classify changed paths
     needs: stale-base-preflight
@@ -353,6 +380,28 @@ function selfTest() {
     {
       name: "preflight not PR-only",
       text: good.replace("if: github.event_name == 'pull_request'", ""),
+    },
+    {
+      name: "preflight missing node setup",
+      text: good.replace(
+        "      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e\n",
+        "",
+      ),
+    },
+    {
+      name: "preflight missing head repo env",
+      text: good.replace(
+        "      HEAD_REPO: $" +
+          "{{ github.event.pull_request.head.repo.full_name }}\n",
+        "",
+      ),
+    },
+    {
+      name: "preflight fetches head from origin",
+      text: good.replace(
+        'git fetch "https://github.com/$' + '{HEAD_REPO}.git" "$HEAD_SHA"',
+        'git fetch origin "$HEAD_SHA"',
+      ),
     },
     {
       name: "changes missing preflight need",


### PR DESCRIPTION
## Summary
- Adds a PR-only `stale-base-preflight` job at the top of `test.yml`.
- Gates the path classifier and downstream test fanout on that preflight passing, so stale PRs fail before queuing the heavy matrix.
- Wires the preflight into `ci-ok` and extends `ci-merge-gate-contract.mjs` so the topology is guarded.

Advances #14051 Tier A: PR-side stale-base pre-gate.

## Verification
- `node packages/scripts/ci-merge-gate-contract.mjs --self-test && node packages/scripts/ci-merge-gate-contract.mjs`
- `bunx @biomejs/biome check .github/workflows/test.yml packages/scripts/ci-merge-gate-contract.mjs --no-errors-on-unmatched`
- `actionlint .github/workflows/test.yml`
- `git diff --check`

## Evidence
- N/A - workflow-only CI topology change, no app/UI surface.
- N/A - no model/action/provider prompt behavior changed.
- Hosted PR checks will prove the workflow behavior on this branch.