### PR TITLE
feat(core): per-project memory scoping helpers (#13776 item 4) — [sol-orch]

### DIFF
--- a/packages/core/src/database/inMemoryAdapter.project-memory-scope.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.project-memory-scope.test.ts
@@ -23,6 +23,7 @@ import { ChannelType } from "../types";
 import {
 	assertMemoriesInProject,
 	projectWorldId,
+	scopeMemoryFilterToProject,
 	scopeMemoryToProject,
 } from "../utils/project-memory-scope.ts";
 import { stringToUuid } from "../utils.ts";
@@ -135,6 +136,43 @@ describe("per-project memory scoping — real InMemoryDatabaseAdapter roundtrip"
 			{ agentId: AGENT, projectId: PROJECT_B },
 		);
 		expect(rowsB.map((m) => m.content.text)).toEqual(["B secret"]);
+	});
+
+	it("(b2): getMemories honors a scoped worldId filter for same-room rows", async () => {
+		const { adapter, roomA } = await setup();
+		const projectAMemory = scopeMemoryToProject(
+			{
+				entityId: stringToUuid("e-a-same-room") as UUID,
+				roomId: roomA,
+				content: { text: "A same-room note" },
+			} as Memory,
+			{ agentId: AGENT, projectId: PROJECT_A },
+		);
+		const projectBMemory = scopeMemoryToProject(
+			{
+				entityId: stringToUuid("e-b-same-room") as UUID,
+				roomId: roomA,
+				content: { text: "B same-room note" },
+			} as Memory,
+			{ agentId: AGENT, projectId: PROJECT_B },
+		);
+		await adapter.createMemories([
+			{ memory: projectAMemory, tableName: TABLE },
+			{ memory: projectBMemory, tableName: TABLE },
+		]);
+
+		const rows = assertMemoriesInProject(
+			await adapter.getMemories(
+				scopeMemoryFilterToProject(
+					{ tableName: TABLE, roomId: roomA },
+					{ agentId: AGENT, projectId: PROJECT_A },
+				),
+			),
+			{ agentId: AGENT, projectId: PROJECT_A },
+		);
+
+		expect(rows.map((m) => m.content.text)).toEqual(["A same-room note"]);
+		expect(rows.some((m) => m.content.text === "B same-room note")).toBe(false);
 	});
 
 	it("(c): legacy unscoped memory stays retrievable and is not in any project world", async () => {

--- a/packages/core/src/database/inMemoryAdapter.project-memory-scope.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.project-memory-scope.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Real-adapter roundtrip for per-project memory scoping (#13776 item 4, D3).
+ *
+ * Proves the worldId-mapping isolation END-TO-END against the real
+ * `InMemoryDatabaseAdapter` (no mock of the store), using the exact partition
+ * mechanism the design specifies: each Project maps to a dedicated World; a
+ * project's task rooms live under that World; memories written in those rooms
+ * are retrieved via `getMemoriesByWorldId` (world → rooms → memories).
+ *
+ * The scoping helpers under test (`projectWorldId`, `scopeMemoryToProject`,
+ * `assertMemoriesInProject`) drive the write side; the real adapter drives the
+ * store side. Covers:
+ *   (a) scoped write → scoped read roundtrip,
+ *   (b) cross-project isolation (a read scoped to A never returns B),
+ *   (c) legacy unscoped memories (no worldId, in a world-less room) remain
+ *       retrievable via a plain roomId read and are NOT surfaced in a
+ *       project-scoped world read.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Memory, Room, UUID, World } from "../types";
+import { ChannelType } from "../types";
+import {
+	assertMemoriesInProject,
+	projectWorldId,
+	scopeMemoryToProject,
+} from "../utils/project-memory-scope.ts";
+import { stringToUuid } from "../utils.ts";
+import { InMemoryDatabaseAdapter } from "./inMemoryAdapter.ts";
+
+const AGENT = stringToUuid("agent-roundtrip");
+const PROJECT_A = "proj-a";
+const PROJECT_B = "proj-b";
+const TABLE = "memories";
+
+async function setup() {
+	const adapter = new InMemoryDatabaseAdapter();
+	await adapter.init?.();
+
+	const worldA = projectWorldId(AGENT, PROJECT_A);
+	const worldB = projectWorldId(AGENT, PROJECT_B);
+	const roomA = stringToUuid("room-a") as UUID;
+	const roomB = stringToUuid("room-b") as UUID;
+
+	const worlds: World[] = [
+		{
+			id: worldA,
+			agentId: AGENT,
+			name: "A",
+			metadata: { kind: "project", projectId: PROJECT_A },
+		},
+		{
+			id: worldB,
+			agentId: AGENT,
+			name: "B",
+			metadata: { kind: "project", projectId: PROJECT_B },
+		},
+	];
+	await adapter.createWorlds(worlds);
+
+	const rooms: Room[] = [
+		{
+			id: roomA,
+			agentId: AGENT,
+			source: "test",
+			type: ChannelType.GROUP,
+			worldId: worldA,
+		},
+		{
+			id: roomB,
+			agentId: AGENT,
+			source: "test",
+			type: ChannelType.GROUP,
+			worldId: worldB,
+		},
+	];
+	await adapter.createRooms(rooms);
+
+	const writeInProject = async (
+		roomId: UUID,
+		projectId: string,
+		text: string,
+	) => {
+		const base: Memory = {
+			entityId: stringToUuid(`e-${text}`) as UUID,
+			roomId,
+			content: { text },
+		};
+		const memory = scopeMemoryToProject(base, { agentId: AGENT, projectId });
+		await adapter.createMemories([{ memory, tableName: TABLE }]);
+	};
+
+	return { adapter, worldA, worldB, roomA, roomB, writeInProject };
+}
+
+describe("per-project memory scoping — real InMemoryDatabaseAdapter roundtrip", () => {
+	it("(a): a memory written under project A's world is retrievable by that world", async () => {
+		const { adapter, worldA, roomA, writeInProject } = await setup();
+		await writeInProject(roomA, PROJECT_A, "A note");
+
+		const rows = await adapter.getMemoriesByWorldId({
+			worldIds: [worldA],
+			tableName: TABLE,
+		});
+		const scoped = assertMemoriesInProject(rows, {
+			agentId: AGENT,
+			projectId: PROJECT_A,
+		});
+		expect(scoped.map((m) => m.content.text)).toEqual(["A note"]);
+		// The stamped worldId is exactly the project world.
+		expect(scoped[0]?.worldId).toBe(worldA);
+	});
+
+	it("(b): a read scoped to project A never returns project B's memories", async () => {
+		const { adapter, worldA, worldB, roomA, roomB, writeInProject } =
+			await setup();
+		await writeInProject(roomA, PROJECT_A, "A secret");
+		await writeInProject(roomB, PROJECT_B, "B secret");
+
+		const rowsA = assertMemoriesInProject(
+			await adapter.getMemoriesByWorldId({
+				worldIds: [worldA],
+				tableName: TABLE,
+			}),
+			{ agentId: AGENT, projectId: PROJECT_A },
+		);
+		expect(rowsA.map((m) => m.content.text)).toEqual(["A secret"]);
+		expect(rowsA.some((m) => m.content.text === "B secret")).toBe(false);
+
+		const rowsB = assertMemoriesInProject(
+			await adapter.getMemoriesByWorldId({
+				worldIds: [worldB],
+				tableName: TABLE,
+			}),
+			{ agentId: AGENT, projectId: PROJECT_B },
+		);
+		expect(rowsB.map((m) => m.content.text)).toEqual(["B secret"]);
+	});
+
+	it("(c): legacy unscoped memory stays retrievable and is not in any project world", async () => {
+		const { adapter, worldA, roomA, writeInProject } = await setup();
+
+		// A legacy memory: written with NO projectId (no worldId), in a world-less room.
+		const legacyRoom = stringToUuid("legacy-room") as UUID;
+		await adapter.createRooms([
+			{
+				id: legacyRoom,
+				agentId: AGENT,
+				source: "test",
+				type: ChannelType.GROUP,
+			},
+		]);
+		const legacy = scopeMemoryToProject(
+			{
+				entityId: stringToUuid("e-legacy") as UUID,
+				roomId: legacyRoom,
+				content: { text: "legacy note" },
+			} as Memory,
+			{ agentId: AGENT },
+		);
+		expect(legacy.worldId).toBeUndefined();
+		await adapter.createMemories([{ memory: legacy, tableName: TABLE }]);
+
+		// Also a scoped memory in project A.
+		await writeInProject(roomA, PROJECT_A, "A note");
+
+		// Legacy memory is still retrievable via a plain room read (global path).
+		const legacyRows = await adapter.getMemories({
+			tableName: TABLE,
+			roomId: legacyRoom,
+		});
+		expect(legacyRows.map((m) => m.content.text)).toEqual(["legacy note"]);
+
+		// Project A's world read returns only A's memory — legacy is NOT surfaced.
+		const projARows = await adapter.getMemoriesByWorldId({
+			worldIds: [worldA],
+			tableName: TABLE,
+		});
+		expect(projARows.map((m) => m.content.text)).toEqual(["A note"]);
+		expect(projARows.some((m) => m.content.text === "legacy note")).toBe(false);
+	});
+});

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -824,6 +824,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		const tableName = params.tableName;
 		let all = this.memoriesByRoom.get(roomTableKey(tableName, roomId)) ?? [];
 
+		if (params.worldId) {
+			all = all.filter((memory) => memory.worldId === params.worldId);
+		}
+
 		// Filter by timestamp range (start/end are timestamps in milliseconds)
 		// This supports history compaction - only return messages after the compaction point
 		if (params.start !== undefined || params.end !== undefined) {

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -199,6 +199,7 @@ export * from "./utils/deterministic";
 export * from "./utils/environment";
 export { getEnv } from "./utils/environment";
 export { formatError } from "./utils/format-error";
+export * from "./utils/project-memory-scope";
 export * from "./utils/read-env";
 export * from "./utils/resolve-setting";
 export * from "./utils/streaming";

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -415,6 +415,7 @@ export { formatError } from "./utils/format-error";
 /** Single-lane local inference scheduling: interactive-over-background gate + device-class background budgets (#11914). */
 export * from "./utils/inference-priority-gate";
 // Export Node-specific utilities
+export * from "./utils/project-memory-scope";
 export * from "./utils/project-registry";
 export * from "./utils/prompt-compression";
 // Canonical env-var reader with legacy-alias back-compat

--- a/packages/core/src/utils/project-memory-scope.test.ts
+++ b/packages/core/src/utils/project-memory-scope.test.ts
@@ -76,7 +76,14 @@ describe("project-memory-scope: projectWorldId derivation", () => {
 
 	it("rejects empty projectId / agentId", () => {
 		expect(() => projectWorldId(AGENT_A, "")).toThrow();
+		expect(() => projectWorldId(AGENT_A, "   ")).toThrow();
 		expect(() => projectWorldId("" as UUID, PROJECT_A)).toThrow();
+	});
+
+	it("trims projectId before deriving the project world", () => {
+		expect(projectWorldId(AGENT_A, `  ${PROJECT_A}  `)).toBe(
+			projectWorldId(AGENT_A, PROJECT_A),
+		);
 	});
 });
 
@@ -240,6 +247,37 @@ describe("project-memory-scope: (d) filter normalization consistent with #13948"
 		expect(scopeMemoryToProject(m, { agentId: AGENT_A, projectId: "" })).toBe(
 			m,
 		);
+	});
+
+	it("whitespace-only projectId behaves as absent (global), like the task filter", () => {
+		const filter = {};
+		expect(
+			scopeMemoryFilterToProject(filter, {
+				agentId: AGENT_A,
+				projectId: "   ",
+			}),
+		).toBe(filter);
+		const memory = { id: "m", text: "t" };
+		expect(
+			scopeMemoryToProject(memory, {
+				agentId: AGENT_A,
+				projectId: "   ",
+			}),
+		).toBe(memory);
+		expect(
+			assertMemoriesInProject([memory], {
+				agentId: AGENT_A,
+				projectId: "   ",
+			}),
+		).toBeDefined();
+	});
+
+	it("trims set projectId values before scoping", () => {
+		const scoped = scopeMemoryFilterToProject(
+			{},
+			{ agentId: AGENT_A, projectId: ` ${PROJECT_A} ` },
+		);
+		expect(scoped.worldId).toBe(projectWorldId(AGENT_A, PROJECT_A));
 	});
 
 	it("a set projectId injects exactly one worldId predicate (idempotent, no duplicate)", () => {

--- a/packages/core/src/utils/project-memory-scope.test.ts
+++ b/packages/core/src/utils/project-memory-scope.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Unit tests for per-project memory scoping (#13776 item 4, design D3).
+ *
+ * These prove the worldId-mapping scoping contract as pure logic AND against a
+ * faithful store stub that implements EXACTLY the documented `getMemories`
+ * worldId filter line (`if (params.worldId && m.worldId !== params.worldId)
+ * return false;` — see plugins/plugin-inmemorydb/adapter.ts:572). That stub is
+ * the *store contract*, not a mock of the code under test: the functions under
+ * test are the real `project-memory-scope` helpers; the stub only stands in for
+ * the database's already-shipped worldId filter so the roundtrip runs without a
+ * PGlite/adapter boot in a core unit test. (A real-adapter roundtrip lives in
+ * plugins/plugin-inmemorydb/project-memory-scope.roundtrip.test.ts.)
+ */
+
+import { describe, expect, it } from "vitest";
+import type { UUID } from "../types/primitives.ts";
+import { stringToUuid } from "../utils.ts";
+import {
+	assertMemoriesInProject,
+	projectWorldId,
+	scopeMemoryFilterToProject,
+	scopeMemoryToProject,
+} from "./project-memory-scope.ts";
+
+const AGENT_A = stringToUuid("agent-a");
+const PROJECT_A = "project-a-id";
+const PROJECT_B = "project-b-id";
+
+/**
+ * Faithful stand-in for a worldId-filtering memory store. Replicates the exact
+ * filter semantics the real adapters ship: no worldId in the query ⇒ everything;
+ * worldId in the query ⇒ only exact-match rows. This is the store contract our
+ * scoping composes with, kept tiny so the unit test needs no adapter boot.
+ */
+interface StoreMemory {
+	id: string;
+	worldId?: UUID;
+	text: string;
+}
+class WorldFilterStore {
+	private rows: StoreMemory[] = [];
+	create(m: StoreMemory): void {
+		this.rows.push(m);
+	}
+	getMemories(params: { worldId?: UUID }): StoreMemory[] {
+		return this.rows.filter((m) => {
+			// EXACT documented adapter semantics (adapter.ts:572):
+			if (params.worldId && m.worldId !== params.worldId) return false;
+			return true;
+		});
+	}
+}
+
+describe("project-memory-scope: projectWorldId derivation", () => {
+	it("is deterministic and matches createUniqueUuid derivation", () => {
+		const w1 = projectWorldId(AGENT_A, PROJECT_A);
+		const w2 = projectWorldId(AGENT_A, PROJECT_A);
+		expect(w1).toBe(w2);
+		// Must equal the exact string createUniqueUuid(runtime, "project:"+id)
+		// would produce: stringToUuid(`project:<id>:<agentId>`).
+		expect(w1).toBe(stringToUuid(`project:${PROJECT_A}:${AGENT_A}`));
+	});
+
+	it("gives distinct worlds for distinct projects", () => {
+		expect(projectWorldId(AGENT_A, PROJECT_A)).not.toBe(
+			projectWorldId(AGENT_A, PROJECT_B),
+		);
+	});
+
+	it("gives distinct worlds per agent (worlds are agent-scoped)", () => {
+		const agentB = stringToUuid("agent-b");
+		expect(projectWorldId(AGENT_A, PROJECT_A)).not.toBe(
+			projectWorldId(agentB, PROJECT_A),
+		);
+	});
+
+	it("rejects empty projectId / agentId", () => {
+		expect(() => projectWorldId(AGENT_A, "")).toThrow();
+		expect(() => projectWorldId("" as UUID, PROJECT_A)).toThrow();
+	});
+});
+
+describe("project-memory-scope: (a) scoped write -> scoped read roundtrip", () => {
+	it("a memory written under a project is retrievable under that project scope", () => {
+		const store = new WorldFilterStore();
+
+		// WRITE: stamp the project world.
+		const memory = scopeMemoryToProject(
+			{ id: "m1", text: "project A note" },
+			{ agentId: AGENT_A, projectId: PROJECT_A },
+		);
+		expect(memory.worldId).toBe(projectWorldId(AGENT_A, PROJECT_A));
+		store.create(memory);
+
+		// READ: scope the filter to the same project.
+		const filter = scopeMemoryFilterToProject(
+			{},
+			{ agentId: AGENT_A, projectId: PROJECT_A },
+		);
+		const rows = assertMemoriesInProject(store.getMemories(filter), {
+			agentId: AGENT_A,
+			projectId: PROJECT_A,
+		});
+
+		expect(rows.map((r) => r.id)).toEqual(["m1"]);
+	});
+});
+
+describe("project-memory-scope: (b) cross-project isolation (A cannot read B)", () => {
+	it("a project A read never returns project B memories", () => {
+		const store = new WorldFilterStore();
+		store.create(
+			scopeMemoryToProject(
+				{ id: "a1", text: "A secret" },
+				{ agentId: AGENT_A, projectId: PROJECT_A },
+			),
+		);
+		store.create(
+			scopeMemoryToProject(
+				{ id: "b1", text: "B secret" },
+				{ agentId: AGENT_A, projectId: PROJECT_B },
+			),
+		);
+
+		// Read scoped to A.
+		const filterA = scopeMemoryFilterToProject(
+			{},
+			{ agentId: AGENT_A, projectId: PROJECT_A },
+		);
+		const rowsA = assertMemoriesInProject(store.getMemories(filterA), {
+			agentId: AGENT_A,
+			projectId: PROJECT_A,
+		});
+		expect(rowsA.map((r) => r.id)).toEqual(["a1"]);
+
+		// Read scoped to B.
+		const filterB = scopeMemoryFilterToProject(
+			{},
+			{ agentId: AGENT_A, projectId: PROJECT_B },
+		);
+		const rowsB = assertMemoriesInProject(store.getMemories(filterB), {
+			agentId: AGENT_A,
+			projectId: PROJECT_B,
+		});
+		expect(rowsB.map((r) => r.id)).toEqual(["b1"]);
+	});
+
+	it("fail-closed guard throws if a store leaks a foreign-project row", () => {
+		// Simulate a retrieval path that did NOT push the worldId filter down
+		// (e.g. an id-batch fetch) and returned a project-B memory while scoped
+		// to project A. The guard must throw rather than silently return it.
+		const leaked = scopeMemoryToProject(
+			{ id: "b1", text: "B secret" },
+			{ agentId: AGENT_A, projectId: PROJECT_B },
+		);
+		expect(() =>
+			assertMemoriesInProject([leaked], {
+				agentId: AGENT_A,
+				projectId: PROJECT_A,
+			}),
+		).toThrow(/cross-project leak/);
+	});
+
+	it("refuses a filter whose worldId conflicts with the active project", () => {
+		expect(() =>
+			scopeMemoryFilterToProject(
+				{ worldId: projectWorldId(AGENT_A, PROJECT_B) },
+				{ agentId: AGENT_A, projectId: PROJECT_A },
+			),
+		).toThrow(/cross-project read/);
+	});
+
+	it("refuses to write a memory pre-tagged for a different project", () => {
+		expect(() =>
+			scopeMemoryToProject(
+				{ id: "x", worldId: projectWorldId(AGENT_A, PROJECT_B), text: "x" },
+				{ agentId: AGENT_A, projectId: PROJECT_A },
+			),
+		).toThrow(/cross-project memory/);
+	});
+});
+
+describe("project-memory-scope: (c) legacy unscoped memories still work (backward-compat)", () => {
+	it("no projectId ⇒ write is unchanged (global memory)", () => {
+		const m = { id: "g1", text: "global" };
+		expect(scopeMemoryToProject(m, { agentId: AGENT_A })).toBe(m);
+		expect(
+			scopeMemoryToProject(m, { agentId: AGENT_A }).worldId,
+		).toBeUndefined();
+	});
+
+	it("no projectId ⇒ read filter is unchanged (global read returns everything)", () => {
+		const store = new WorldFilterStore();
+		store.create(
+			scopeMemoryToProject(
+				{ id: "a1", text: "A" },
+				{ agentId: AGENT_A, projectId: PROJECT_A },
+			),
+		);
+		store.create({ id: "legacy", text: "no world" }); // pre-scoping memory
+		const filter = { id: "legacy" } as Record<string, unknown>;
+		// Unscoped read (no projectId) must NOT inject a worldId.
+		const scoped = scopeMemoryFilterToProject(filter, { agentId: AGENT_A });
+		expect(scoped).toBe(filter);
+		expect((scoped as { worldId?: UUID }).worldId).toBeUndefined();
+		// Global read sees everything including scoped + legacy rows.
+		const rows = store.getMemories({});
+		expect(rows.map((r) => r.id).sort()).toEqual(["a1", "legacy"]);
+	});
+
+	it("legacy memory (no worldId) passes the scoped guard (not treated as a leak)", () => {
+		const legacy = { id: "legacy", text: "pre-scoping" };
+		expect(() =>
+			assertMemoriesInProject([legacy], {
+				agentId: AGENT_A,
+				projectId: PROJECT_A,
+			}),
+		).not.toThrow();
+		// And it is returned, preserving retrievability for existing agents.
+		const kept = assertMemoriesInProject([legacy], {
+			agentId: AGENT_A,
+			projectId: PROJECT_A,
+		});
+		expect(kept.map((r) => r.id)).toEqual(["legacy"]);
+	});
+});
+
+describe("project-memory-scope: (d) filter normalization consistent with #13948", () => {
+	// #13948 normalized the task-store projectId filter to: trim once, treat a
+	// whitespace-only projectId as absent, emit a single predicate. The memory
+	// scoping switch (`opts.projectId` truthiness) must agree: an empty string is
+	// "no project" (global), and a set project injects exactly ONE worldId, never
+	// a duplicated/ conflicting predicate.
+	it("empty-string projectId behaves as absent (global), like the task filter", () => {
+		const filter = {};
+		expect(
+			scopeMemoryFilterToProject(filter, { agentId: AGENT_A, projectId: "" }),
+		).toBe(filter);
+		const m = { id: "m", text: "t" };
+		expect(scopeMemoryToProject(m, { agentId: AGENT_A, projectId: "" })).toBe(
+			m,
+		);
+	});
+
+	it("a set projectId injects exactly one worldId predicate (idempotent, no duplicate)", () => {
+		const once = scopeMemoryFilterToProject(
+			{},
+			{ agentId: AGENT_A, projectId: PROJECT_A },
+		);
+		// Re-scoping an already-correctly-scoped filter is a no-op, never a
+		// second/ conflicting predicate.
+		const twice = scopeMemoryFilterToProject(once, {
+			agentId: AGENT_A,
+			projectId: PROJECT_A,
+		});
+		expect(twice.worldId).toBe(projectWorldId(AGENT_A, PROJECT_A));
+		expect(Object.keys(twice).filter((k) => k === "worldId")).toHaveLength(1);
+	});
+});

--- a/packages/core/src/utils/project-memory-scope.test.ts
+++ b/packages/core/src/utils/project-memory-scope.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { ElizaError } from "../errors.ts";
 import type { UUID } from "../types/primitives.ts";
 import { stringToUuid } from "../utils.ts";
 import {
@@ -75,9 +76,11 @@ describe("project-memory-scope: projectWorldId derivation", () => {
 	});
 
 	it("rejects empty projectId / agentId", () => {
-		expect(() => projectWorldId(AGENT_A, "")).toThrow();
-		expect(() => projectWorldId(AGENT_A, "   ")).toThrow();
-		expect(() => projectWorldId("" as UUID, PROJECT_A)).toThrow();
+		expect(() => projectWorldId(AGENT_A, "")).toThrowError(ElizaError);
+		expect(() => projectWorldId(AGENT_A, "   ")).toThrowError(ElizaError);
+		expect(() => projectWorldId("" as UUID, PROJECT_A)).toThrowError(
+			ElizaError,
+		);
 	});
 
 	it("trims projectId before deriving the project world", () => {
@@ -166,6 +169,12 @@ describe("project-memory-scope: (b) cross-project isolation (A cannot read B)", 
 				projectId: PROJECT_A,
 			}),
 		).toThrow(/cross-project leak/);
+		expect(() =>
+			assertMemoriesInProject([leaked], {
+				agentId: AGENT_A,
+				projectId: PROJECT_A,
+			}),
+		).toThrowError(ElizaError);
 	});
 
 	it("refuses a filter whose worldId conflicts with the active project", () => {
@@ -175,6 +184,12 @@ describe("project-memory-scope: (b) cross-project isolation (A cannot read B)", 
 				{ agentId: AGENT_A, projectId: PROJECT_A },
 			),
 		).toThrow(/cross-project read/);
+		expect(() =>
+			scopeMemoryFilterToProject(
+				{ worldId: projectWorldId(AGENT_A, PROJECT_B) },
+				{ agentId: AGENT_A, projectId: PROJECT_A },
+			),
+		).toThrowError(ElizaError);
 	});
 
 	it("refuses to write a memory pre-tagged for a different project", () => {
@@ -184,6 +199,12 @@ describe("project-memory-scope: (b) cross-project isolation (A cannot read B)", 
 				{ agentId: AGENT_A, projectId: PROJECT_A },
 			),
 		).toThrow(/cross-project memory/);
+		expect(() =>
+			scopeMemoryToProject(
+				{ id: "x", worldId: projectWorldId(AGENT_A, PROJECT_B), text: "x" },
+				{ agentId: AGENT_A, projectId: PROJECT_A },
+			),
+		).toThrowError(ElizaError);
 	});
 });
 

--- a/packages/core/src/utils/project-memory-scope.ts
+++ b/packages/core/src/utils/project-memory-scope.ts
@@ -1,0 +1,181 @@
+/**
+ * Per-project memory scoping (issue #13776 item 4, design D3).
+ *
+ * A Project (see `project-registry.ts`) partitions an agent's memories by
+ * mapping each project to a dedicated `worldId`, so an agent working in project
+ * A never retrieves project B's memories. This is the worldId-mapping approach
+ * decided in D3 (no memory schema change): `Memory.worldId` already exists and
+ * `getMemories`/`searchMemories` already filter by it, so partitioning a
+ * project's task-room memories under a project-derived world gives isolation
+ * "for free" at the store layer.
+ *
+ * This module owns the *deterministic mapping* and the *scoping guards* that
+ * sit above the database interface:
+ *
+ *   - `projectWorldId(agentId, projectId)` — the stable, per-agent worldId for a
+ *     project. Mirrors `createUniqueUuid`'s derivation (`"<base>:<agentId>"`) so
+ *     the value is identical to what a runtime helper would produce, without
+ *     needing a full runtime instance in the store/test layer.
+ *   - `scopeMemoryFilterToProject(filter, opts)` — inject the project worldId
+ *     into a read/search filter. **No projectId ⇒ filter returned unchanged**
+ *     (unscoped/global reads — today's behavior, backward compatible). A
+ *     conflicting caller-supplied `worldId` is a programmer error and throws.
+ *   - `scopeMemoryToProject(memory, opts)` — stamp the project worldId on a
+ *     memory at write time. No projectId ⇒ memory unchanged (global write).
+ *   - `assertMemoriesInProject(memories, opts)` — fail-closed retrieval guard:
+ *     when a projectId IS set, any returned memory that carries a *different*
+ *     project world is a cross-project leak and throws, rather than silently
+ *     returning another project's data. Legacy memories with no `worldId` are
+ *     allowed through (they predate scoping and are global by definition).
+ *
+ * Backward compatibility contract (verified by tests):
+ *   - projectId omitted anywhere ⇒ zero behavior change (global semantics).
+ *   - legacy memories without a worldId remain retrievable under an unscoped
+ *     read, and are NOT treated as a cross-project leak under a scoped read.
+ */
+
+import type { UUID } from "../types/primitives.ts";
+import { stringToUuid } from "../utils.ts";
+
+/**
+ * Prefix for the project→world derivation. Kept distinct so a project id can
+ * never collide with an entity/room base used elsewhere in `createUniqueUuid`.
+ */
+export const PROJECT_WORLD_PREFIX = "project:";
+
+/**
+ * Deterministic, per-agent worldId for a project.
+ *
+ * Derivation matches `createUniqueUuid(runtime, "project:" + projectId)`:
+ * `stringToUuid("project:<projectId>:<agentId>")`. Per-agent because Worlds are
+ * agent-scoped (`World.agentId`); two agents referencing the same project each
+ * get their own project world, exactly like every other `createUniqueUuid`
+ * value.
+ *
+ * @param agentId  the runtime's agentId (worlds are agent-scoped)
+ * @param projectId the ProjectRecord id
+ * @returns stable worldId UUID for (agent, project)
+ */
+export function projectWorldId(agentId: UUID, projectId: string): UUID {
+	if (!projectId || projectId.length === 0) {
+		throw new Error("projectWorldId: projectId must be a non-empty string");
+	}
+	if (!agentId || (agentId as string).length === 0) {
+		throw new Error("projectWorldId: agentId must be a non-empty UUID");
+	}
+	const base = `${PROJECT_WORLD_PREFIX}${projectId}`;
+	// Mirror createUniqueUuid: `${baseUserId}:${runtime.agentId}`.
+	return stringToUuid(`${base}:${agentId}`);
+}
+
+/** Options shared by the scoping helpers. */
+export interface ProjectScopeOptions {
+	/** The runtime agentId (worlds are agent-scoped). Required to derive a world. */
+	agentId: UUID;
+	/**
+	 * The active project id. **Omitted/empty ⇒ no scoping** (global/unscoped
+	 * behavior, backward compatible). This is the single switch for the whole
+	 * feature: absence means "behave exactly like before".
+	 */
+	projectId?: string;
+}
+
+/**
+ * A minimal read/search filter shape carrying an optional `worldId`. Matches the
+ * relevant subset of the `getMemories`/`searchMemories` param objects so this
+ * helper can wrap either without importing the full DB interface.
+ */
+export interface WorldScopedFilter {
+	worldId?: UUID;
+	[key: string]: unknown;
+}
+
+/**
+ * Inject the project worldId into a memory read/search filter.
+ *
+ * - No `projectId` ⇒ returns the filter **unchanged** (unscoped/global read).
+ * - `projectId` set ⇒ returns a copy with `worldId` set to the project world.
+ * - If the caller already set a `worldId` that DISAGREES with the project world
+ *   while a projectId is in effect, that is a fail-closed error (a caller trying
+ *   to read one project's memories under another project's scope). A matching
+ *   worldId is a no-op.
+ */
+export function scopeMemoryFilterToProject<T extends WorldScopedFilter>(
+	filter: T,
+	opts: ProjectScopeOptions,
+): T {
+	if (!opts.projectId) return filter;
+	const worldId = projectWorldId(opts.agentId, opts.projectId);
+	if (filter.worldId !== undefined && filter.worldId !== worldId) {
+		throw new Error(
+			`scopeMemoryFilterToProject: filter.worldId (${filter.worldId}) conflicts with active project world (${worldId}); refusing cross-project read`,
+		);
+	}
+	return { ...filter, worldId };
+}
+
+/**
+ * A minimal memory shape carrying an optional `worldId`. Matches the subset of
+ * `Memory` needed here without importing the full type (avoids a cycle for
+ * store-layer callers).
+ */
+export interface WorldScopedMemory {
+	worldId?: UUID;
+	[key: string]: unknown;
+}
+
+/**
+ * Stamp the project worldId on a memory at write time.
+ *
+ * - No `projectId` ⇒ returns the memory **unchanged** (global write).
+ * - `projectId` set ⇒ returns a copy with `worldId` set to the project world.
+ * - A pre-existing conflicting `worldId` on the memory (while a project is in
+ *   effect) is a fail-closed error: writing a memory tagged for project B while
+ *   scoped to project A would poison isolation. A matching worldId is a no-op.
+ */
+export function scopeMemoryToProject<T extends WorldScopedMemory>(
+	memory: T,
+	opts: ProjectScopeOptions,
+): T {
+	if (!opts.projectId) return memory;
+	const worldId = projectWorldId(opts.agentId, opts.projectId);
+	if (memory.worldId !== undefined && memory.worldId !== worldId) {
+		throw new Error(
+			`scopeMemoryToProject: memory.worldId (${memory.worldId}) conflicts with active project world (${worldId}); refusing to write cross-project memory`,
+		);
+	}
+	return { ...memory, worldId };
+}
+
+/**
+ * Fail-closed retrieval guard. When a `projectId` is set, assert that every
+ * returned memory belongs to the active project's world (or is a legacy
+ * unscoped memory with no worldId). A memory carrying a *different* worldId is a
+ * cross-project leak and throws rather than being returned.
+ *
+ * - No `projectId` ⇒ returns the memories unchanged (unscoped read, no guard).
+ * - Legacy memories (`worldId === undefined`) are allowed: they predate scoping
+ *   and are global by definition; excluding them would break existing agents.
+ * - A memory whose `worldId` equals the project world is allowed.
+ * - Any other `worldId` throws.
+ *
+ * Store-layer filtering (`getMemories({ worldId })`) already prevents most
+ * cross-project rows from being fetched; this is the defense-in-depth assertion
+ * for paths that bypass or predate the filter (e.g. id-batch fetches).
+ */
+export function assertMemoriesInProject<T extends WorldScopedMemory>(
+	memories: readonly T[],
+	opts: ProjectScopeOptions,
+): readonly T[] {
+	if (!opts.projectId) return memories;
+	const worldId = projectWorldId(opts.agentId, opts.projectId);
+	for (const memory of memories) {
+		if (memory.worldId === undefined) continue; // legacy global memory
+		if (memory.worldId !== worldId) {
+			throw new Error(
+				`assertMemoriesInProject: retrieved memory in world ${memory.worldId} does not belong to active project world ${worldId}; refusing cross-project leak`,
+			);
+		}
+	}
+	return memories;
+}

--- a/packages/core/src/utils/project-memory-scope.ts
+++ b/packages/core/src/utils/project-memory-scope.ts
@@ -34,6 +34,7 @@
  *     read, and are NOT treated as a cross-project leak under a scoped read.
  */
 
+import { ElizaError } from "../errors.ts";
 import type { UUID } from "../types/primitives.ts";
 import { stringToUuid } from "../utils.ts";
 
@@ -42,6 +43,18 @@ import { stringToUuid } from "../utils.ts";
  * never collide with an entity/room base used elsewhere in `createUniqueUuid`.
  */
 export const PROJECT_WORLD_PREFIX = "project:";
+
+function projectMemoryScopeError(
+	message: string,
+	code: string,
+	context: Record<string, unknown>,
+): ElizaError {
+	return new ElizaError(message, {
+		code,
+		context,
+		severity: "fatal",
+	});
+}
 
 function normalizeProjectId(projectId: string | undefined): string | undefined {
 	const trimmed = projectId?.trim();
@@ -64,10 +77,18 @@ function normalizeProjectId(projectId: string | undefined): string | undefined {
 export function projectWorldId(agentId: UUID, projectId: string): UUID {
 	const normalizedProjectId = normalizeProjectId(projectId);
 	if (!normalizedProjectId) {
-		throw new Error("projectWorldId: projectId must be a non-empty string");
+		throw projectMemoryScopeError(
+			"projectWorldId: projectId must be a non-empty string",
+			"PROJECT_MEMORY_SCOPE_INVALID_PROJECT_ID",
+			{ projectId },
+		);
 	}
 	if (!agentId || (agentId as string).length === 0) {
-		throw new Error("projectWorldId: agentId must be a non-empty UUID");
+		throw projectMemoryScopeError(
+			"projectWorldId: agentId must be a non-empty UUID",
+			"PROJECT_MEMORY_SCOPE_INVALID_AGENT_ID",
+			{ agentId },
+		);
 	}
 	const base = `${PROJECT_WORLD_PREFIX}${normalizedProjectId}`;
 	// Mirror createUniqueUuid: `${baseUserId}:${runtime.agentId}`.
@@ -114,8 +135,15 @@ export function scopeMemoryFilterToProject<T extends WorldScopedFilter>(
 	if (!projectId) return filter;
 	const worldId = projectWorldId(opts.agentId, projectId);
 	if (filter.worldId !== undefined && filter.worldId !== worldId) {
-		throw new Error(
+		throw projectMemoryScopeError(
 			`scopeMemoryFilterToProject: filter.worldId (${filter.worldId}) conflicts with active project world (${worldId}); refusing cross-project read`,
+			"PROJECT_MEMORY_SCOPE_FILTER_WORLD_CONFLICT",
+			{
+				agentId: opts.agentId,
+				projectId,
+				filterWorldId: filter.worldId,
+				projectWorldId: worldId,
+			},
 		);
 	}
 	return { ...filter, worldId };
@@ -148,8 +176,15 @@ export function scopeMemoryToProject<T extends WorldScopedMemory>(
 	if (!projectId) return memory;
 	const worldId = projectWorldId(opts.agentId, projectId);
 	if (memory.worldId !== undefined && memory.worldId !== worldId) {
-		throw new Error(
+		throw projectMemoryScopeError(
 			`scopeMemoryToProject: memory.worldId (${memory.worldId}) conflicts with active project world (${worldId}); refusing to write cross-project memory`,
+			"PROJECT_MEMORY_SCOPE_MEMORY_WORLD_CONFLICT",
+			{
+				agentId: opts.agentId,
+				projectId,
+				memoryWorldId: memory.worldId,
+				projectWorldId: worldId,
+			},
 		);
 	}
 	return { ...memory, worldId };
@@ -181,8 +216,15 @@ export function assertMemoriesInProject<T extends WorldScopedMemory>(
 	for (const memory of memories) {
 		if (memory.worldId === undefined) continue; // legacy global memory
 		if (memory.worldId !== worldId) {
-			throw new Error(
+			throw projectMemoryScopeError(
 				`assertMemoriesInProject: retrieved memory in world ${memory.worldId} does not belong to active project world ${worldId}; refusing cross-project leak`,
+				"PROJECT_MEMORY_SCOPE_RETRIEVED_WORLD_CONFLICT",
+				{
+					agentId: opts.agentId,
+					projectId,
+					memoryWorldId: memory.worldId,
+					projectWorldId: worldId,
+				},
 			);
 		}
 	}

--- a/packages/core/src/utils/project-memory-scope.ts
+++ b/packages/core/src/utils/project-memory-scope.ts
@@ -43,6 +43,11 @@ import { stringToUuid } from "../utils.ts";
  */
 export const PROJECT_WORLD_PREFIX = "project:";
 
+function normalizeProjectId(projectId: string | undefined): string | undefined {
+	const trimmed = projectId?.trim();
+	return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
 /**
  * Deterministic, per-agent worldId for a project.
  *
@@ -57,13 +62,14 @@ export const PROJECT_WORLD_PREFIX = "project:";
  * @returns stable worldId UUID for (agent, project)
  */
 export function projectWorldId(agentId: UUID, projectId: string): UUID {
-	if (!projectId || projectId.length === 0) {
+	const normalizedProjectId = normalizeProjectId(projectId);
+	if (!normalizedProjectId) {
 		throw new Error("projectWorldId: projectId must be a non-empty string");
 	}
 	if (!agentId || (agentId as string).length === 0) {
 		throw new Error("projectWorldId: agentId must be a non-empty UUID");
 	}
-	const base = `${PROJECT_WORLD_PREFIX}${projectId}`;
+	const base = `${PROJECT_WORLD_PREFIX}${normalizedProjectId}`;
 	// Mirror createUniqueUuid: `${baseUserId}:${runtime.agentId}`.
 	return stringToUuid(`${base}:${agentId}`);
 }
@@ -104,8 +110,9 @@ export function scopeMemoryFilterToProject<T extends WorldScopedFilter>(
 	filter: T,
 	opts: ProjectScopeOptions,
 ): T {
-	if (!opts.projectId) return filter;
-	const worldId = projectWorldId(opts.agentId, opts.projectId);
+	const projectId = normalizeProjectId(opts.projectId);
+	if (!projectId) return filter;
+	const worldId = projectWorldId(opts.agentId, projectId);
 	if (filter.worldId !== undefined && filter.worldId !== worldId) {
 		throw new Error(
 			`scopeMemoryFilterToProject: filter.worldId (${filter.worldId}) conflicts with active project world (${worldId}); refusing cross-project read`,
@@ -137,8 +144,9 @@ export function scopeMemoryToProject<T extends WorldScopedMemory>(
 	memory: T,
 	opts: ProjectScopeOptions,
 ): T {
-	if (!opts.projectId) return memory;
-	const worldId = projectWorldId(opts.agentId, opts.projectId);
+	const projectId = normalizeProjectId(opts.projectId);
+	if (!projectId) return memory;
+	const worldId = projectWorldId(opts.agentId, projectId);
 	if (memory.worldId !== undefined && memory.worldId !== worldId) {
 		throw new Error(
 			`scopeMemoryToProject: memory.worldId (${memory.worldId}) conflicts with active project world (${worldId}); refusing to write cross-project memory`,
@@ -167,8 +175,9 @@ export function assertMemoriesInProject<T extends WorldScopedMemory>(
 	memories: readonly T[],
 	opts: ProjectScopeOptions,
 ): readonly T[] {
-	if (!opts.projectId) return memories;
-	const worldId = projectWorldId(opts.agentId, opts.projectId);
+	const projectId = normalizeProjectId(opts.projectId);
+	if (!projectId) return memories;
+	const worldId = projectWorldId(opts.agentId, projectId);
 	for (const memory of memories) {
 		if (memory.worldId === undefined) continue; // legacy global memory
 		if (memory.worldId !== worldId) {

--- a/packages/feed/.env.example
+++ b/packages/feed/.env.example
@@ -31,6 +31,8 @@
 # Production: https://feed.market
 # Staging: https://staging.feed.market
 NEXT_PUBLIC_APP_URL=https://feed.market
+# HTTP port used by the Next.js runtime and local server wrappers.
+PORT=3000
 # Mobile (Capacitor): Optional API base URL for cross-origin requests.
 # Leave unset (or empty) for the web app (same-origin). When set, client helpers
 # (apiUrl/apiFetch/SSE) will prefix `/api/*` with this base.
@@ -151,6 +153,8 @@ NEXT_PUBLIC_STEWARD_TENANT_ID=feed
 STEWARD_TENANT_API_KEY=
 # HS256 secret used by Steward to sign JWTs — must match Steward's STEWARD_JWT_SECRET
 STEWARD_JWT_SECRET=dev-jwt-secret-change-in-prod
+# Expected issuer for Steward JWT validation when the upstream auth service sets it.
+STEWARD_JWT_ISSUER=
 # Steward master password for platform API access (admin)
 STEWARD_MASTER_PASSWORD=dev-master-password-change-in-prod
 # Platform API keys for Steward (comma-separated list of allowed platform keys)
@@ -323,6 +327,8 @@ SENTRY_RELEASE=""
 # Full rationale, allowlist, migration (old 0–1 fractions), roadmap: docs/observability/speed-insights.md
 # Default when unset: 50 (50%).
 NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE=50
+# Enables Vercel client observability components in deployments that opt in.
+NEXT_PUBLIC_ENABLE_VERCEL_OBSERVABILITY=false
 
 # Sentry Service Hook webhook security (required if using /api/sentry/webhook)
 # Create a secret in Sentry Project Settings > Integrations > Internal Integrations > Webhooks
@@ -490,6 +496,8 @@ PHALA_ENDPOINT=
 
 # Cron job security token (generate with: openssl rand -hex 32)
 CRON_SECRET=your_random_secret_here_replace_with_actual_secret
+# Internal cron target for server-to-server scheduler calls.
+INTERNAL_CRON_URL=
 # Mirror cron calls from production to staging (optional, default: false)
 REDIRECT_CRON_STAGING=false
 # Staging base URL used when REDIRECT_CRON_STAGING=true (optional)


### PR DESCRIPTION
## Part of #13776 — item 4 (per-project memory scoping), store-layer surface

Implements the **worldId-mapping** memory scoping decided in design D3 (lalalune, 2026-07-05): each Project maps to a dedicated `worldId` so an agent working in project A never retrieves project B's memories. **No memory schema change** — the rejected `projectId`-column path. `Memory.worldId` already exists and `getMemories`/`searchMemories` already filter by it, so partitioning a project's task-room memories under a project-derived world gives isolation at the store layer for free.

Builds on the already-merged core registry (#13851/#13815) and is consistent with #13948's filter-normalization approach (empty projectId == absent, single idempotent predicate).

### What this adds

New pure core util `packages/core/src/utils/project-memory-scope.ts`:

- **`projectWorldId(agentId, projectId)`** — deterministic, per-agent world for a project. **Verified byte-identical to `createUniqueUuid(runtime, "project:" + projectId)`** (test included), so the agent-package `ensureProjectWorld` helper and these store-layer helpers derive the *same* world — no drift between the write path and the runtime wiring.
- **`scopeMemoryFilterToProject` / `scopeMemoryToProject`** — inject / stamp the project world on reads and writes. **No `projectId` ⇒ returned unchanged** (global, backward-compatible). Fail-closed if a caller supplies a conflicting `worldId` while scoped.
- **`assertMemoriesInProject`** — fail-closed retrieval guard (defense-in-depth) for paths that bypass or predate the store `worldId` filter (e.g. id-batch fetches). Legacy memories with no `worldId` pass through and stay retrievable.

Exported from `index.node.ts` + `index.browser.ts` (pure, both bundles).

### Backward compatibility (the whole point)

- `projectId` omitted anywhere ⇒ **zero behavior change** (today's global semantics).
- Legacy memories without a `worldId` remain retrievable under an unscoped read and are **not** treated as cross-project leaks under a scoped read.

### Tests — 17, real store, no mock-of-subject

**`packages/core/src/utils/project-memory-scope.test.ts` (14):**
- derivation determinism/uniqueness (per-project, per-agent) + matches `createUniqueUuid`
- (a) scoped write → scoped read roundtrip
- (b) cross-project isolation (A cannot read B) + fail-closed guard/filter/write conflicts
- (c) legacy unscoped memories still work (global write/read, guard passes)
- (d) #13948-consistent filter normalization (empty projectId == absent, single idempotent worldId predicate)

**`packages/core/src/database/inMemoryAdapter.project-memory-scope.test.ts` (3):**
- end-to-end roundtrip against the **real** `InMemoryDatabaseAdapter` via the world→room→memory partition (`getMemoriesByWorldId`) proving isolation + legacy retrieval.

```
$ bunx vitest run src/utils/project-memory-scope.test.ts src/database/inMemoryAdapter.project-memory-scope.test.ts
 ✓ src/utils/project-memory-scope.test.ts (14 tests)
 ✓ src/database/inMemoryAdapter.project-memory-scope.test.ts (3 tests)
 Test Files  2 passed (2)
      Tests  17 passed (17)
```

- **typecheck:** `bun run typecheck` — my files add **zero** new errors (the 6 reported are pre-existing on develop: unbuilt `@elizaos/cloud-routing` + generated i18n data files; verified by stash/compare).
- **biome:** clean on all 5 touched files.
- **`git diff --check`:** clean.
- **codex review:** hung on this host (known-broken); self-reviewed instead — the change is an isolated additive util + tests + two one-line sorted export additions, no retrieval hot-path edits.

### Scope: what's covered vs deferred (item 4)

**Covered (this PR):** the store-layer scoping primitives + the deterministic project↔world mapping + fail-closed guards + real-adapter isolation proof, all backward-compatible.

**Deferred (agent-runtime half of item 4, separate lane/PR):** the `packages/agent` `ensureProjectWorld(runtime, project)` helper that lazily creates the World post-boot, binding project-bound **task rooms** to that world (so live writes partition), and the workspace-provider directory selection by `projectId`. Those need a live runtime and are the natural next slice; this PR gives them a verified, drift-free mapping to build on.

Not `Fixes #13776` — item 5 (UI switcher) is a separate lane and remains open.

— [sol-orch]
