### PR TITLE
test(ios): compose walkthrough simulator phases

### DIFF
--- a/packages/app/scripts/walkthrough-device-matrix.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.mjs
@@ -372,10 +372,16 @@ export function captureIos({ duration, deps = {} }) {
     );
 
   const phaseSpecs = [
-    ["ios-onboarding-smoke.mjs", []],
+    ["ios-onboarding-smoke.mjs", ["--app-path", app]],
     [
       "mobile-local-chat-smoke.mjs",
-      ["--platform", "ios", "--require-installed"],
+      [
+        "--platform",
+        "ios",
+        "--require-installed",
+        "--ios-select-local",
+        "--ios-full-bun-smoke",
+      ],
     ],
     [
       "capture-ios-sim.mjs",

--- a/packages/app/scripts/walkthrough-device-matrix.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.mjs
@@ -342,37 +342,68 @@ export function captureIosDevice({ iosDevice, deps = {} } = {}) {
   });
 }
 
-function captureIos({ duration }) {
-  const sim = bootedIosSim();
+function runPhase(run, rel, args, env = {}) {
+  const exitCode = run(rel, args, env);
+  return {
+    script: rel,
+    args,
+    status: exitCode === 0 ? "ok" : "error",
+    exitCode,
+  };
+}
+
+export function captureIos({ duration, deps = {} }) {
+  const {
+    bootedSim = bootedIosSim,
+    appBuilt = iosSimAppBuilt,
+    run = runScript,
+  } = deps;
+  const sim = bootedSim();
   if (!sim)
     return lane(
       "n/a",
       "no booted iOS simulator (boot one with `xcrun simctl boot 'iPhone 16 Pro'`)",
     );
-  const app = iosSimAppBuilt();
+  const app = appBuilt();
   if (!app)
     return lane(
       "n/a",
       "no iOS simulator app build found in DerivedData (run `bun run --cwd packages/app build:ios:local:sim` first; capturing a stale install would violate the rebuild-before-capture rule)",
     );
-  // TODO(#13573 Part 2): compose real journey legs when host can run them —
-  // drive ios-onboarding-smoke.mjs + mobile-local-chat-smoke.mjs (the in-app
-  // WKWebView handshake, since it has no CDP) before this single-shot capture so
-  // the iOS lane records the full onboarding/chat/gesture narrative, not just a
-  // frame of the running app. Device-gated: needs a live simulator.
-  const code = runScript("capture-ios-sim.mjs", [
-    "--issue",
-    "10198",
-    "--slug",
-    "walkthrough-ios-sim",
-    "--duration",
-    String(duration),
-  ]);
-  return lane(code === 0 ? "captured" : "error", null, {
+
+  const phaseSpecs = [
+    ["ios-onboarding-smoke.mjs", []],
+    [
+      "mobile-local-chat-smoke.mjs",
+      ["--platform", "ios", "--require-installed"],
+    ],
+    [
+      "capture-ios-sim.mjs",
+      [
+        "--issue",
+        "10198",
+        "--slug",
+        "walkthrough-ios-sim",
+        "--duration",
+        String(duration),
+      ],
+    ],
+  ];
+  const phases = [];
+  for (const [rel, argv] of phaseSpecs) {
+    const phase = runPhase(run, rel, argv);
+    phases.push(phase);
+    if (phase.status === "error") break;
+  }
+  const failed = phases.find((phase) => phase.status === "error");
+  return lane(failed ? "error" : "captured", failed?.script ?? null, {
     outputDir: ".github/issue-evidence/ (10198-walkthrough-ios-sim-*.png/.mov)",
-    note: "Single-shot simctl capture of the running iOS app. WKWebView has no CDP, so the full DOM-driven narrative parity runs in-app via the onboarding/chat handshake legs (ios-onboarding-smoke.mjs / mobile-local-chat-smoke.mjs); see DEVICE_MATRIX.md.",
+    note: failed
+      ? `iOS simulator walkthrough stopped after ${failed.script} failed; see phases for exit codes.`
+      : "iOS WKWebView has no CDP, so the walkthrough is driven in-app via ios-onboarding-smoke.mjs and mobile-local-chat-smoke.mjs before simctl capture. See DEVICE_MATRIX.md.",
     simUdid: sim,
     appPath: app,
+    phases,
   });
 }
 

--- a/packages/app/scripts/walkthrough-device-matrix.test.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.test.mjs
@@ -372,10 +372,16 @@ describe("iOS simulator lane (captureIos)", () => {
         "capture-ios-sim.mjs",
       ],
     );
+    assert.deepEqual(invocations[0].argv, [
+      "--app-path",
+      "/DerivedData/App.app",
+    ]);
     assert.deepEqual(invocations[1].argv, [
       "--platform",
       "ios",
       "--require-installed",
+      "--ios-select-local",
+      "--ios-full-bun-smoke",
     ]);
     assert.equal(
       invocations[2].argv[invocations[2].argv.indexOf("--duration") + 1],

--- a/packages/app/scripts/walkthrough-device-matrix.test.mjs
+++ b/packages/app/scripts/walkthrough-device-matrix.test.mjs
@@ -5,6 +5,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  captureIos,
   captureIosDevice,
   computeExitCode,
   erroredLanes,
@@ -309,5 +310,103 @@ describe("iOS device lane (captureIosDevice)", () => {
     assert.equal(result.status, "error");
     // An attempted-and-errored lane is always fatal, independent of --require.
     assert.equal(computeExitCode({ "ios-device": result }, new Set()), 1);
+  });
+});
+
+describe("iOS simulator lane (captureIos)", () => {
+  it("records honest n/a without running phases when no simulator is booted", () => {
+    let ran = false;
+    const result = captureIos({
+      duration: 1,
+      deps: {
+        bootedSim: () => null,
+        appBuilt: () => "/DerivedData/App.app",
+        run: () => {
+          ran = true;
+          return 0;
+        },
+      },
+    });
+    assert.equal(result.status, "n/a");
+    assert.match(result.reason, /no booted iOS simulator/);
+    assert.equal(ran, false);
+  });
+
+  it("records honest n/a without running phases when no fresh simulator build exists", () => {
+    let ran = false;
+    const result = captureIos({
+      duration: 1,
+      deps: {
+        bootedSim: () => "SIM-UDID",
+        appBuilt: () => null,
+        run: () => {
+          ran = true;
+          return 0;
+        },
+      },
+    });
+    assert.equal(result.status, "n/a");
+    assert.match(result.reason, /build:ios:local:sim/);
+    assert.equal(ran, false);
+  });
+
+  it("runs onboarding, local chat, then capture for an available simulator", () => {
+    const invocations = [];
+    const result = captureIos({
+      duration: 7,
+      deps: {
+        bootedSim: () => "SIM-UDID",
+        appBuilt: () => "/DerivedData/App.app",
+        run: (rel, argv) => {
+          invocations.push({ rel, argv });
+          return 0;
+        },
+      },
+    });
+    assert.equal(result.status, "captured");
+    assert.deepEqual(
+      invocations.map((entry) => entry.rel),
+      [
+        "ios-onboarding-smoke.mjs",
+        "mobile-local-chat-smoke.mjs",
+        "capture-ios-sim.mjs",
+      ],
+    );
+    assert.deepEqual(invocations[1].argv, [
+      "--platform",
+      "ios",
+      "--require-installed",
+    ]);
+    assert.equal(
+      invocations[2].argv[invocations[2].argv.indexOf("--duration") + 1],
+      "7",
+    );
+    assert.deepEqual(
+      result.phases.map((phase) => phase.status),
+      ["ok", "ok", "ok"],
+    );
+  });
+
+  it("records error and makes the lane fatal when any attempted simulator phase fails", () => {
+    const invocations = [];
+    const result = captureIos({
+      duration: 1,
+      deps: {
+        bootedSim: () => "SIM-UDID",
+        appBuilt: () => "/DerivedData/App.app",
+        run: (rel) => {
+          invocations.push(rel);
+          return rel === "mobile-local-chat-smoke.mjs" ? 23 : 0;
+        },
+      },
+    });
+    assert.equal(result.status, "error");
+    assert.equal(result.reason, "mobile-local-chat-smoke.mjs");
+    assert.equal(result.phases[1].exitCode, 23);
+    assert.deepEqual(invocations, [
+      "ios-onboarding-smoke.mjs",
+      "mobile-local-chat-smoke.mjs",
+    ]);
+    assert.equal(computeExitCode({ "ios-simulator": result }, new Set()), 1);
   });
 });

--- a/packages/app/test/ui-smoke/walkthrough/DEVICE_MATRIX.md
+++ b/packages/app/test/ui-smoke/walkthrough/DEVICE_MATRIX.md
@@ -54,7 +54,8 @@ bun run --cwd packages/app test:e2e:walkthrough:ios
   (single-shot `simctl io` capture of the running app) plus
   `reports/walkthrough/<runId>/device-matrix.json` with per-phase status for
   `ios-onboarding-smoke.mjs` (onboarding), `mobile-local-chat-smoke.mjs` (chat
-  round-trip), and `capture-ios-sim.mjs`.
+  round-trip with `--ios-select-local --ios-full-bun-smoke`), and
+  `capture-ios-sim.mjs`.
 - **Skip reason (recorded automatically):** "not macOS", "no booted iOS
   simulator", or "no iOS simulator app build found in DerivedData".
 

--- a/packages/app/test/ui-smoke/walkthrough/DEVICE_MATRIX.md
+++ b/packages/app/test/ui-smoke/walkthrough/DEVICE_MATRIX.md
@@ -51,9 +51,10 @@ bun run --cwd packages/app test:e2e:walkthrough:ios
   DerivedData. The runner refuses to capture a stale install (per the
   rebuild-before-capture rule).
 - **Produces:** `.github/issue-evidence/10198-walkthrough-ios-sim-*.png/.mov`
-  (single-shot `simctl io` capture of the running app). Drive the in-app journey
-  with `ios-onboarding-smoke.mjs` (onboarding) + `mobile-local-chat-smoke.mjs`
-  (chat round-trip) against a host agent.
+  (single-shot `simctl io` capture of the running app) plus
+  `reports/walkthrough/<runId>/device-matrix.json` with per-phase status for
+  `ios-onboarding-smoke.mjs` (onboarding), `mobile-local-chat-smoke.mjs` (chat
+  round-trip), and `capture-ios-sim.mjs`.
 - **Skip reason (recorded automatically):** "not macOS", "no booted iOS
   simulator", or "no iOS simulator app build found in DerivedData".
 


### PR DESCRIPTION
## Summary
- Makes the iOS simulator walkthrough lane run the in-app onboarding smoke, local-chat smoke, and sim capture phases in order.
- Records per-phase status in `device-matrix.json` and fails fast if an attempted phase fails, so a broken journey cannot continue into a passive capture.
- Preserves honest `n/a` behavior when there is no booted simulator or no fresh simulator build.
- Updates DEVICE_MATRIX docs to describe the per-phase output.

Advances #13573.

## Verification
- `bun test packages/app/scripts/walkthrough-device-matrix.test.mjs`
- `node packages/app/scripts/walkthrough-device-matrix.mjs --platform ios` on this Linux host: recorded honest `n/a` for no booted iOS simulator and exited 0.
- `bunx @biomejs/biome check packages/app/scripts/walkthrough-device-matrix.mjs packages/app/scripts/walkthrough-device-matrix.test.mjs packages/app/test/ui-smoke/walkthrough/DEVICE_MATRIX.md --no-errors-on-unmatched`
- `node --check packages/app/scripts/walkthrough-device-matrix.mjs && git diff --check`

## Evidence
- N/A - no app renderer/UI source changed, so no `audit:app` screenshots from this Linux host.
- N/A - no model/action/provider prompt behavior changed.
- Remaining before closing #13573: macOS/Xcode run with a fresh simulator build proving the three real phases (`ios-onboarding-smoke`, `mobile-local-chat-smoke`, `capture-ios-sim`) complete and the produced `device-matrix.json`/screenshots/movie are manually reviewed.