### PR TITLE
fix(#14083): freshness guard on cloud-cf-deploy — skip stale zombie-run deploys

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -843,7 +843,7 @@ jobs:
       # bypasses for intentional rollbacks.
       - name: Deploy freshness guard
         id: freshness
-        if: steps.cf.outputs.configured == 'true'
+        if: steps.cf.outputs.configured == 'true' && github.event_name != 'pull_request'
         working-directory: ${{ env.CHECKOUT_DIR }}
         env:
           SERVED_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://elizacloud.ai' || 'https://staging.elizacloud.ai' }}
@@ -855,7 +855,7 @@ jobs:
             $([ "$FORCE" = "true" ] && echo --force)
 
       - name: Deploy to Cloudflare Pages
-        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
+        if: steps.cf.outputs.configured == 'true' && (github.event_name == 'pull_request' || steps.freshness.outputs.should_deploy == 'true')
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/app
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -1218,7 +1218,7 @@ jobs:
       # bypasses for rollbacks. See the console job for the full rationale.
       - name: Deploy freshness guard
         id: freshness
-        if: steps.cf.outputs.configured == 'true'
+        if: steps.cf.outputs.configured == 'true' && github.event_name != 'pull_request'
         working-directory: ${{ env.CHECKOUT_DIR }}
         env:
           SERVED_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://app.elizacloud.ai' || 'https://app-staging.elizacloud.ai' }}
@@ -1230,7 +1230,7 @@ jobs:
             $([ "$FORCE" = "true" ] && echo --force)
 
       - name: Deploy to Cloudflare Pages
-        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
+        if: steps.cf.outputs.configured == 'true' && (github.event_name == 'pull_request' || steps.freshness.outputs.should_deploy == 'true')
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/app
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -66,6 +66,15 @@ on:
         options:
           - staging
           - production
+      force:
+        # Bypass the deploy freshness guard (#14083). The guard SKIPS a deploy
+        # when this run's SHA is an ancestor of the currently-served build (a
+        # stale zombie run clobbering a newer bundle — #14082). Set force=true
+        # for an INTENTIONAL rollback to an older ref.
+        description: Bypass the freshness guard (intentional rollback to an older ref)
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   # Serialize branch deploys (push + workflow_dispatch) per ref so the shared-host
@@ -808,8 +817,28 @@ jobs:
             fi
           fi
 
-      - name: Deploy to Cloudflare Pages
+      # Freshness guard (#14083): SKIP this deploy when THIS run's SHA is an
+      # ancestor of the currently-served build's commit — i.e. a stale zombie
+      # run (stuck queued through a freeze) is about to clobber a NEWER bundle
+      # (the #14082 regression: staging fell back to a pre-#13410 ref hours
+      # after newer builds were live). Fail-open: any ambiguous signal deploys;
+      # only a provably-stale run is skipped. workflow_dispatch force=true
+      # bypasses for intentional rollbacks.
+      - name: Deploy freshness guard
+        id: freshness
         if: steps.cf.outputs.configured == 'true'
+        working-directory: ${{ env.CHECKOUT_DIR }}
+        env:
+          SERVED_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://elizacloud.ai' || 'https://staging.elizacloud.ai' }}
+          FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
+        run: |
+          node packages/scripts/cloud/deploy-freshness-guard-cli.mjs \
+            --run-sha "$GITHUB_SHA" \
+            --served-url "$SERVED_URL" \
+            $([ "$FORCE" = "true" ] && echo --force)
+
+      - name: Deploy to Cloudflare Pages
+        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/app
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -1167,8 +1196,24 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: bunx wrangler pages project create eliza-app --production-branch=main 2>/dev/null || true
 
-      - name: Deploy to Cloudflare Pages
+      # Freshness guard (#14083): skip a stale zombie run about to clobber a
+      # newer served build. Fail-open on any ambiguous signal; force=true
+      # bypasses for rollbacks. See the console job for the full rationale.
+      - name: Deploy freshness guard
+        id: freshness
         if: steps.cf.outputs.configured == 'true'
+        working-directory: ${{ env.CHECKOUT_DIR }}
+        env:
+          SERVED_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://app.elizacloud.ai' || 'https://app-staging.elizacloud.ai' }}
+          FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
+        run: |
+          node packages/scripts/cloud/deploy-freshness-guard-cli.mjs \
+            --run-sha "$GITHUB_SHA" \
+            --served-url "$SERVED_URL" \
+            $([ "$FORCE" = "true" ] && echo --force)
+
+      - name: Deploy to Cloudflare Pages
+        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/app
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -520,13 +520,30 @@ jobs:
             publish_secret "$name"
           done
 
-      - name: Deploy to Cloudflare Workers
+      # Freshness guard (#14083): skip a stale Worker deploy about to roll the
+      # API back behind the currently-served `/api/health` commit stamp.
+      # Fail-open on missing/old stamps; force=true bypasses for rollbacks.
+      - name: Deploy freshness guard
+        id: freshness
         if: steps.cf.outputs.configured == 'true'
+        working-directory: ${{ env.CHECKOUT_DIR }}
+        env:
+          SERVED_URL: ${{ steps.env.outputs.deploy_environment == 'production' && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
+          FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
+        run: |
+          node packages/scripts/cloud/deploy-freshness-guard-cli.mjs \
+            --run-sha "$GITHUB_SHA" \
+            --served-url "$SERVED_URL" \
+            --served-path /api/health \
+            $([ "$FORCE" = "true" ] && echo --force)
+
+      - name: Deploy to Cloudflare Workers
+        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/cloud/api
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: bunx wrangler deploy ${{ steps.env.outputs.wrangler_args }}
+        run: bunx wrangler deploy ${{ steps.env.outputs.wrangler_args }} --var ELIZA_DEPLOY_COMMIT:"$GITHUB_SHA"
 
       - name: Clean temp checkout
         if: always()

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -203,6 +203,28 @@ describe("cloud-api worker entrypoint", () => {
     }
   });
 
+  test("includes the deploy commit in API health for stale-run deploy guards", async () => {
+    const response = await cloudApiWorker.fetch(
+      new Request("https://api-staging.elizacloud.ai/api/health", {
+        headers: {
+          host: "api-staging.elizacloud.ai",
+        },
+      }),
+      {
+        CF_REGION: "local-test",
+        ELIZA_DEPLOY_COMMIT: "feedfacefeedfacefeedfacefeedfacefeedface",
+      } as never,
+      {} as never,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: "ok",
+      region: "local-test",
+      commit: "feedfacefeedfacefeedfacefeedfacefeedface",
+    });
+  });
+
   test("routes app-staging custom domain to the staging Worker", async () => {
     const config = Bun.TOML.parse(
       await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -54,6 +54,7 @@ function healthResponse(env: AppEnv["Bindings"]): Response {
       status: "ok",
       timestamp: Date.now(),
       region: (env as { CF_REGION?: string }).CF_REGION ?? "unknown",
+      commit: env.ELIZA_DEPLOY_COMMIT ?? null,
     },
     {
       status: 200,

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -178,6 +178,11 @@ export interface Bindings {
   CONTAINERS_BOOTSTRAP_SECRET?: string;
   CONTAINERS_HCLOUD_LOCATION?: string;
   NODE_ENV?: string;
+  /**
+   * Git commit stamped at deploy time so `/api/health` can prove which Worker
+   * revision is currently served before CI allows another deploy to overwrite it.
+   */
+  ELIZA_DEPLOY_COMMIT?: string;
 
   // ---- Feature flags ----
   REDIS_RATE_LIMITING?: string;

--- a/packages/scripts/__tests__/deploy-freshness-guard.test.ts
+++ b/packages/scripts/__tests__/deploy-freshness-guard.test.ts
@@ -8,12 +8,12 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { isAncestor } from "../cloud/deploy-freshness-guard-cli.mjs";
 import {
   decideDeployFreshness,
   fetchServedCommit,
   parseServedCommit,
 } from "../cloud/deploy-freshness-guard.mjs";
+import { isAncestor } from "../cloud/deploy-freshness-guard-cli.mjs";
 
 const RUN = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const SERVED = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
@@ -267,5 +267,5 @@ describe("isAncestor — shallow checkout hydration", () => {
       process.chdir(previousCwd);
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 60000);
 });

--- a/packages/scripts/__tests__/deploy-freshness-guard.test.ts
+++ b/packages/scripts/__tests__/deploy-freshness-guard.test.ts
@@ -1,0 +1,207 @@
+// Exercises the cloud deploy freshness guard (#14083): stale zombie-run deploys
+// must be SKIPPED, but every ambiguous signal must FAIL OPEN (deploy).
+import { describe, expect, it } from "bun:test";
+
+import {
+  decideDeployFreshness,
+  fetchServedCommit,
+  parseServedCommit,
+} from "../cloud/deploy-freshness-guard.mjs";
+
+const RUN = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SERVED = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+describe("decideDeployFreshness — the narrow SKIP case", () => {
+  it("SKIPS when the run SHA is an ancestor of the served commit (stale zombie run)", () => {
+    const result = decideDeployFreshness({
+      runSha: RUN,
+      servedCommit: SERVED,
+      isAncestor: () => true,
+    });
+    expect(result.decision).toBe("skip");
+    expect(result.reason).toBe("stale_run");
+    expect(result.runSha).toBe(RUN);
+    expect(result.servedCommit).toBe(SERVED);
+  });
+});
+
+describe("decideDeployFreshness — fail-open (DEPLOY) on every ambiguous state", () => {
+  it("deploys when the run SHA is NOT an ancestor (run is newer/divergent)", () => {
+    const result = decideDeployFreshness({
+      runSha: RUN,
+      servedCommit: SERVED,
+      isAncestor: () => false,
+    });
+    expect(result.decision).toBe("deploy");
+    expect(result.reason).toBe("run_is_newer");
+  });
+
+  it("deploys when ancestry is undeterminable (unrelated histories / git error)", () => {
+    const result = decideDeployFreshness({
+      runSha: RUN,
+      servedCommit: SERVED,
+      isAncestor: () => null,
+    });
+    expect(result.decision).toBe("deploy");
+    expect(result.reason).toBe("ancestry_unknown");
+  });
+
+  it("deploys when isAncestor THROWS (never lets a git crash block a deploy)", () => {
+    const result = decideDeployFreshness({
+      runSha: RUN,
+      servedCommit: SERVED,
+      isAncestor: () => {
+        throw new Error("git blew up");
+      },
+    });
+    expect(result.decision).toBe("deploy");
+    expect(result.reason).toBe("ancestry_unknown");
+  });
+
+  it("deploys when there is no served commit (first deploy / unstamped build)", () => {
+    const result = decideDeployFreshness({
+      runSha: RUN,
+      servedCommit: null,
+      isAncestor: () => {
+        throw new Error("should not be called");
+      },
+    });
+    expect(result.decision).toBe("deploy");
+    expect(result.reason).toBe("no_served_commit");
+  });
+
+  it("deploys when there is no run SHA", () => {
+    const result = decideDeployFreshness({
+      runSha: "   ",
+      servedCommit: SERVED,
+      isAncestor: () => {
+        throw new Error("should not be called");
+      },
+    });
+    expect(result.decision).toBe("deploy");
+    expect(result.reason).toBe("no_run_sha");
+  });
+
+  it("deploys (idempotent) when run SHA equals served commit — never skip a same-commit redeploy", () => {
+    const result = decideDeployFreshness({
+      runSha: RUN,
+      servedCommit: RUN,
+      isAncestor: () => {
+        throw new Error("should not be called");
+      },
+    });
+    expect(result.decision).toBe("deploy");
+    expect(result.reason).toBe("same_commit");
+  });
+});
+
+describe("decideDeployFreshness — force bypass", () => {
+  it("deploys with --force even when the run SHA is stale (intentional rollback)", () => {
+    const result = decideDeployFreshness({
+      runSha: RUN,
+      servedCommit: SERVED,
+      force: true,
+      isAncestor: () => true, // would otherwise SKIP
+    });
+    expect(result.decision).toBe("deploy");
+    expect(result.reason).toBe("forced");
+  });
+
+  it("force short-circuits before touching isAncestor", () => {
+    let called = false;
+    const result = decideDeployFreshness({
+      runSha: RUN,
+      servedCommit: SERVED,
+      force: true,
+      isAncestor: () => {
+        called = true;
+        return true;
+      },
+    });
+    expect(result.decision).toBe("deploy");
+    expect(called).toBe(false);
+  });
+});
+
+describe("parseServedCommit", () => {
+  it("extracts the commit from a valid renderer manifest body", () => {
+    const body = JSON.stringify({
+      schema: "elizaos.renderer.build/v1",
+      buildId: "deadbeef",
+      commit: SERVED,
+    });
+    expect(parseServedCommit(body)).toBe(SERVED);
+  });
+
+  it("trims surrounding whitespace on the commit", () => {
+    expect(parseServedCommit(JSON.stringify({ commit: `  ${SERVED}  ` }))).toBe(
+      SERVED,
+    );
+  });
+
+  it("returns null for a manifest with no commit field (unstamped build)", () => {
+    expect(parseServedCommit(JSON.stringify({ buildId: "x" }))).toBeNull();
+  });
+
+  it("returns null for a blank/whitespace commit", () => {
+    expect(parseServedCommit(JSON.stringify({ commit: "   " }))).toBeNull();
+    expect(parseServedCommit(JSON.stringify({ commit: null }))).toBeNull();
+  });
+
+  it("returns null for unparseable / empty / non-object bodies (SPA index.html fallthrough)", () => {
+    expect(parseServedCommit("<!doctype html><html></html>")).toBeNull();
+    expect(parseServedCommit("")).toBeNull();
+    expect(parseServedCommit("   ")).toBeNull();
+    expect(parseServedCommit(JSON.stringify("a string"))).toBeNull();
+    expect(parseServedCommit(JSON.stringify(42))).toBeNull();
+    // @ts-expect-error deliberately wrong type
+    expect(parseServedCommit(undefined)).toBeNull();
+  });
+});
+
+describe("fetchServedCommit — fail-open network boundary", () => {
+  it("returns the commit on a 200 with a valid manifest", async () => {
+    const fetchImpl = (async () => ({
+      ok: true,
+      text: async () => JSON.stringify({ commit: SERVED }),
+    })) as unknown as typeof fetch;
+    expect(
+      await fetchServedCommit("https://staging.elizacloud.ai", { fetchImpl }),
+    ).toBe(SERVED);
+  });
+
+  it("requests the manifest at /eliza-renderer-build.json and strips trailing slashes", async () => {
+    let requested = "";
+    const fetchImpl = (async (url: string) => {
+      requested = url;
+      return { ok: true, text: async () => JSON.stringify({ commit: SERVED }) };
+    }) as unknown as typeof fetch;
+    await fetchServedCommit("https://staging.elizacloud.ai///", { fetchImpl });
+    expect(requested).toBe(
+      "https://staging.elizacloud.ai/eliza-renderer-build.json",
+    );
+  });
+
+  it("returns null on a non-OK response (404 -> deploy, don't block)", async () => {
+    const fetchImpl = (async () => ({
+      ok: false,
+      text: async () => "not found",
+    })) as unknown as typeof fetch;
+    expect(
+      await fetchServedCommit("https://staging.elizacloud.ai", { fetchImpl }),
+    ).toBeNull();
+  });
+
+  it("returns null when fetch throws (network error / timeout)", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNRESET");
+    }) as unknown as typeof fetch;
+    expect(
+      await fetchServedCommit("https://staging.elizacloud.ai", { fetchImpl }),
+    ).toBeNull();
+  });
+
+  it("returns null for a blank base URL", async () => {
+    expect(await fetchServedCommit("")).toBeNull();
+  });
+});

--- a/packages/scripts/__tests__/deploy-freshness-guard.test.ts
+++ b/packages/scripts/__tests__/deploy-freshness-guard.test.ts
@@ -1,7 +1,14 @@
-// Exercises the cloud deploy freshness guard (#14083): stale zombie-run deploys
-// must be SKIPPED, but every ambiguous signal must FAIL OPEN (deploy).
+/**
+ * Exercises the cloud deploy freshness guard (#14083): stale zombie-run deploys
+ * must be skipped, but every ambiguous signal must fail open and deploy.
+ */
 import { describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
+import { isAncestor } from "../cloud/deploy-freshness-guard-cli.mjs";
 import {
   decideDeployFreshness,
   fetchServedCommit,
@@ -182,6 +189,19 @@ describe("fetchServedCommit — fail-open network boundary", () => {
     );
   });
 
+  it("can request the Worker health stamp path", async () => {
+    let requested = "";
+    const fetchImpl = (async (url: string) => {
+      requested = url;
+      return { ok: true, text: async () => JSON.stringify({ commit: SERVED }) };
+    }) as unknown as typeof fetch;
+    await fetchServedCommit("https://api-staging.elizacloud.ai", {
+      fetchImpl,
+      stampPath: "/api/health",
+    });
+    expect(requested).toBe("https://api-staging.elizacloud.ai/api/health");
+  });
+
   it("returns null on a non-OK response (404 -> deploy, don't block)", async () => {
     const fetchImpl = (async () => ({
       ok: false,
@@ -203,5 +223,49 @@ describe("fetchServedCommit — fail-open network boundary", () => {
 
   it("returns null for a blank base URL", async () => {
     expect(await fetchServedCommit("")).toBeNull();
+  });
+});
+
+describe("isAncestor — shallow checkout hydration", () => {
+  it("detects an old stale run beyond the initial shallow fetch depth", () => {
+    const root = mkdtempSync(join(tmpdir(), "deploy-freshness-guard-"));
+    const origin = join(root, "origin");
+    const clone = join(root, "clone");
+    const previousCwd = process.cwd();
+
+    try {
+      execFileSync("git", ["init", origin], { stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], {
+        cwd: origin,
+      });
+      execFileSync("git", ["config", "user.name", "Deploy Guard Test"], {
+        cwd: origin,
+      });
+
+      const commits: string[] = [];
+      for (let i = 0; i < 70; i += 1) {
+        writeFileSync(join(origin, "stamp.txt"), `${i}\n`);
+        execFileSync("git", ["add", "stamp.txt"], { cwd: origin });
+        execFileSync("git", ["commit", "-m", `commit ${i}`], {
+          cwd: origin,
+          stdio: "ignore",
+        });
+        commits.push(
+          execFileSync("git", ["rev-parse", "HEAD"], { cwd: origin })
+            .toString()
+            .trim(),
+        );
+      }
+
+      execFileSync("git", ["clone", "--depth=1", `file://${origin}`, clone], {
+        stdio: "ignore",
+      });
+      process.chdir(clone);
+
+      expect(isAncestor(commits[0], commits.at(-1) ?? "")).toBe(true);
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/scripts/cloud/deploy-freshness-guard-cli.mjs
+++ b/packages/scripts/cloud/deploy-freshness-guard-cli.mjs
@@ -104,32 +104,53 @@ function hydrateHistoryForAncestry() {
   }
 }
 
-/**
- * Best-effort fetch a commit into the local repo so ancestry can be computed off
- * a shallow deploy checkout. Returns true if the commit is resolvable afterward.
- * @param {string} sha
- */
-function ensureCommit(sha) {
-  try {
-    git(["cat-file", "-e", `${sha}^{commit}`]);
-    return true;
-  } catch {
-    // not present locally — fetch it (unshallow-friendly, bounded)
-  }
-  try {
-    execFileSync("git", ["fetch", "--no-tags", "--depth=50", "origin", sha], {
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 120000,
-    });
-  } catch {
-    // ignore — resolvability re-checked below
-  }
+function commitExists(sha) {
   try {
     git(["cat-file", "-e", `${sha}^{commit}`]);
     return true;
   } catch {
     return false;
   }
+}
+
+/**
+ * Best-effort fetch a commit into the local repo so ancestry can be computed off
+ * a shallow deploy checkout. Returns true if the commit is resolvable afterward.
+ * @param {string} sha
+ */
+function ensureCommit(sha) {
+  if (commitExists(sha)) return true;
+  for (const depth of [50, 200, 1000]) {
+    try {
+      execFileSync(
+        "git",
+        ["fetch", "--no-tags", `--depth=${depth}`, "origin", sha],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+          timeout: 120000,
+        },
+      );
+    } catch {
+      // ignore — resolvability re-checked below
+    }
+    if (commitExists(sha)) return true;
+  }
+  try {
+    execFileSync("git", ["fetch", "--no-tags", "--unshallow", "origin"], {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 180000,
+    });
+  } catch {
+    try {
+      execFileSync("git", ["fetch", "--no-tags", "origin"], {
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 180000,
+      });
+    } catch {
+      // ignore — resolvability re-checked below
+    }
+  }
+  return commitExists(sha);
 }
 
 /**

--- a/packages/scripts/cloud/deploy-freshness-guard-cli.mjs
+++ b/packages/scripts/cloud/deploy-freshness-guard-cli.mjs
@@ -6,6 +6,7 @@
  *   node packages/scripts/cloud/deploy-freshness-guard-cli.mjs \
  *     --run-sha "$GITHUB_SHA" \
  *     --served-url "https://staging.elizacloud.ai" \
+ *     [--served-path "/api/health"] \
  *     [--force]
  *
  * Emits `should_deploy=true|false` to $GITHUB_OUTPUT (and reason/detail), so the
@@ -30,6 +31,7 @@ function parseArgs(argv) {
   const out = {
     runSha: null,
     servedUrl: null,
+    servedPath: null,
     servedCommit: null,
     force: false,
   };
@@ -43,6 +45,9 @@ function parseArgs(argv) {
     } else if (arg === "--served-url") {
       i += 1;
       out.servedUrl = argv[i];
+    } else if (arg === "--served-path") {
+      i += 1;
+      out.servedPath = argv[i];
     } else if (arg === "--served-commit") {
       i += 1;
       out.servedCommit = argv[i];
@@ -50,6 +55,8 @@ function parseArgs(argv) {
       out.runSha = arg.slice("--run-sha=".length);
     } else if (arg.startsWith("--served-url=")) {
       out.servedUrl = arg.slice("--served-url=".length);
+    } else if (arg.startsWith("--served-path=")) {
+      out.servedPath = arg.slice("--served-path=".length);
     } else if (arg.startsWith("--served-commit=")) {
       out.servedCommit = arg.slice("--served-commit=".length);
     }
@@ -64,6 +71,37 @@ function git(args) {
   })
     .toString()
     .trim();
+}
+
+function isShallowRepository() {
+  try {
+    return git(["rev-parse", "--is-shallow-repository"]) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function hydrateHistoryForAncestry() {
+  if (!isShallowRepository()) return true;
+  try {
+    execFileSync(
+      "git",
+      [
+        "fetch",
+        "--no-tags",
+        "--unshallow",
+        "origin",
+        "+refs/heads/*:refs/remotes/origin/*",
+      ],
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 180000,
+      },
+    );
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -104,6 +142,7 @@ function ensureCommit(sha) {
  */
 function isAncestor(runSha, servedCommit) {
   if (!ensureCommit(runSha) || !ensureCommit(servedCommit)) return null;
+  if (!hydrateHistoryForAncestry()) return null;
   try {
     execFileSync("git", ["merge-base", "--is-ancestor", runSha, servedCommit], {
       stdio: ["ignore", "pipe", "pipe"],
@@ -143,12 +182,16 @@ async function main() {
   const {
     runSha,
     servedUrl,
+    servedPath,
     servedCommit: servedCommitArg,
     force,
   } = parseArgs(process.argv.slice(2));
 
   const servedCommit =
-    servedCommitArg ?? (servedUrl ? await fetchServedCommit(servedUrl) : null);
+    servedCommitArg ??
+    (servedUrl
+      ? await fetchServedCommit(servedUrl, { stampPath: servedPath })
+      : null);
 
   const result = decideDeployFreshness({
     runSha,

--- a/packages/scripts/cloud/deploy-freshness-guard-cli.mjs
+++ b/packages/scripts/cloud/deploy-freshness-guard-cli.mjs
@@ -179,6 +179,7 @@ function isAncestor(runSha, servedCommit) {
 }
 
 function emitOutput(result) {
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: GitHub Actions provides this path for step outputs.
   const outFile = process.env.GITHUB_OUTPUT;
   const shouldDeploy = result.decision === "deploy";
   const lines = [
@@ -234,6 +235,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
       "deploy-freshness-guard-cli: unexpected error, failing open (deploy)",
     );
     console.error(err);
+    // biome-ignore lint/suspicious/noUndeclaredEnvVars: GitHub Actions provides this path for step outputs.
     const outFile = process.env.GITHUB_OUTPUT;
     if (outFile) {
       fs.appendFileSync(

--- a/packages/scripts/cloud/deploy-freshness-guard-cli.mjs
+++ b/packages/scripts/cloud/deploy-freshness-guard-cli.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * CLI wrapper for the cloud deploy freshness guard (#14083).
+ *
+ * Usage (in a deploy job, BEFORE the wrangler deploy step):
+ *   node packages/scripts/cloud/deploy-freshness-guard-cli.mjs \
+ *     --run-sha "$GITHUB_SHA" \
+ *     --served-url "https://staging.elizacloud.ai" \
+ *     [--force]
+ *
+ * Emits `should_deploy=true|false` to $GITHUB_OUTPUT (and reason/detail), so the
+ * deploy step can gate on `if: steps.freshness.outputs.should_deploy == 'true'`.
+ * Always exits 0 (a signal-fetch failure must not fail the deploy — the guard is
+ * fail-open; see decideDeployFreshness).
+ *
+ * Ancestry is computed with `git merge-base --is-ancestor`. The deploy job's
+ * checkout is shallow (`--depth=1`), so this CLI fetches BOTH commits into the
+ * repo (best-effort, bounded) before asking git. If either commit can't be
+ * fetched, ancestry is reported as `null` and the guard deploys (fail-open).
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+
+import {
+  decideDeployFreshness,
+  fetchServedCommit,
+} from "./deploy-freshness-guard.mjs";
+
+function parseArgs(argv) {
+  const out = {
+    runSha: null,
+    servedUrl: null,
+    servedCommit: null,
+    force: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--force") {
+      out.force = true;
+    } else if (arg === "--run-sha") {
+      i += 1;
+      out.runSha = argv[i];
+    } else if (arg === "--served-url") {
+      i += 1;
+      out.servedUrl = argv[i];
+    } else if (arg === "--served-commit") {
+      i += 1;
+      out.servedCommit = argv[i];
+    } else if (arg.startsWith("--run-sha=")) {
+      out.runSha = arg.slice("--run-sha=".length);
+    } else if (arg.startsWith("--served-url=")) {
+      out.servedUrl = arg.slice("--served-url=".length);
+    } else if (arg.startsWith("--served-commit=")) {
+      out.servedCommit = arg.slice("--served-commit=".length);
+    }
+  }
+  return out;
+}
+
+function git(args) {
+  return execFileSync("git", args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 60000,
+  })
+    .toString()
+    .trim();
+}
+
+/**
+ * Best-effort fetch a commit into the local repo so ancestry can be computed off
+ * a shallow deploy checkout. Returns true if the commit is resolvable afterward.
+ * @param {string} sha
+ */
+function ensureCommit(sha) {
+  try {
+    git(["cat-file", "-e", `${sha}^{commit}`]);
+    return true;
+  } catch {
+    // not present locally — fetch it (unshallow-friendly, bounded)
+  }
+  try {
+    execFileSync("git", ["fetch", "--no-tags", "--depth=50", "origin", sha], {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 120000,
+    });
+  } catch {
+    // ignore — resolvability re-checked below
+  }
+  try {
+    git(["cat-file", "-e", `${sha}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * merge-base --is-ancestor with fetch fallback. Returns true/false when the
+ * relationship is determinable, null when it is not (missing commit / git error
+ * / unrelated histories).
+ * @param {string} runSha
+ * @param {string} servedCommit
+ * @returns {boolean|null}
+ */
+function isAncestor(runSha, servedCommit) {
+  if (!ensureCommit(runSha) || !ensureCommit(servedCommit)) return null;
+  try {
+    execFileSync("git", ["merge-base", "--is-ancestor", runSha, servedCommit], {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 60000,
+    });
+    return true; // exit 0 => is an ancestor
+  } catch (err) {
+    // exit 1 => not an ancestor; any other exit / no merge-base => undeterminable
+    const code = /** @type {{ status?: number }} */ (err)?.status;
+    if (code === 1) return false;
+    return null;
+  }
+}
+
+function emitOutput(result) {
+  const outFile = process.env.GITHUB_OUTPUT;
+  const shouldDeploy = result.decision === "deploy";
+  const lines = [
+    `should_deploy=${shouldDeploy}`,
+    `decision=${result.decision}`,
+    `reason=${result.reason}`,
+  ];
+  if (outFile) {
+    fs.appendFileSync(outFile, `${lines.join("\n")}\n`);
+  }
+  const emoji = shouldDeploy ? "✅" : "⛔";
+  console.log(
+    `${emoji} deploy-freshness-guard: ${result.decision} (${result.reason})`,
+  );
+  console.log(`   ${result.detail}`);
+  if (result.runSha) console.log(`   runSha=${result.runSha}`);
+  if (result.servedCommit)
+    console.log(`   servedCommit=${result.servedCommit}`);
+}
+
+async function main() {
+  const {
+    runSha,
+    servedUrl,
+    servedCommit: servedCommitArg,
+    force,
+  } = parseArgs(process.argv.slice(2));
+
+  const servedCommit =
+    servedCommitArg ?? (servedUrl ? await fetchServedCommit(servedUrl) : null);
+
+  const result = decideDeployFreshness({
+    runSha,
+    servedCommit,
+    force,
+    isAncestor,
+  });
+
+  emitOutput(result);
+  // Always exit 0: the guard signals via should_deploy, never by failing the job.
+  process.exit(0);
+}
+
+// Only run when invoked directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    // Even an unexpected crash must fail-open: log and deploy.
+    console.error(
+      "deploy-freshness-guard-cli: unexpected error, failing open (deploy)",
+    );
+    console.error(err);
+    const outFile = process.env.GITHUB_OUTPUT;
+    if (outFile) {
+      fs.appendFileSync(
+        outFile,
+        "should_deploy=true\ndecision=deploy\nreason=guard_error\n",
+      );
+    }
+    process.exit(0);
+  });
+}
+
+export { isAncestor, parseArgs };

--- a/packages/scripts/cloud/deploy-freshness-guard.mjs
+++ b/packages/scripts/cloud/deploy-freshness-guard.mjs
@@ -8,8 +8,8 @@
  *
  * This guard runs BEFORE `wrangler pages deploy` / `wrangler deploy` and:
  *   1. Fetches the currently-served build stamp (the deployed
- *      `eliza-renderer-build.json` for Pages, whose `commit` field records the
- *      ref that built it).
+ *      `eliza-renderer-build.json` for Pages, or `/api/health` for the Worker,
+ *      whose `commit` field records the ref that built it).
  *   2. Skips the deploy when the run's SHA is an ANCESTOR of the served commit
  *      (`git merge-base --is-ancestor <runSha> <servedCommit>`) — i.e. the
  *      currently-served build is strictly newer than what this run would ship.
@@ -178,21 +178,33 @@ export function parseServedCommit(body) {
 }
 
 /**
- * Fetch the served renderer build manifest and return its recorded commit, or
- * null on any failure (fail-open — an unreachable stamp must not block deploys).
+ * Fetch the served deploy stamp and return its recorded commit, or null on any
+ * failure (fail-open — an unreachable stamp must not block deploys).
  *
  * @param {string} baseUrl e.g. "https://staging.elizacloud.ai"
  * @param {object} [opts]
  * @param {typeof fetch} [opts.fetchImpl]
+ * @param {string} [opts.stampPath]
  * @param {number} [opts.timeoutMs]
  * @returns {Promise<string|null>}
  */
 export async function fetchServedCommit(
   baseUrl,
-  { fetchImpl = fetch, timeoutMs = 15000 } = {},
+  {
+    fetchImpl = fetch,
+    stampPath = "/eliza-renderer-build.json",
+    timeoutMs = 15000,
+  } = {},
 ) {
   if (typeof baseUrl !== "string" || !baseUrl.trim()) return null;
-  const url = `${baseUrl.replace(/\/+$/, "")}/eliza-renderer-build.json`;
+  const normalizedStampPath =
+    typeof stampPath === "string" && stampPath.trim()
+      ? stampPath.trim()
+      : "/eliza-renderer-build.json";
+  const path = normalizedStampPath.startsWith("/")
+    ? normalizedStampPath
+    : `/${normalizedStampPath}`;
+  const url = `${baseUrl.replace(/\/+$/, "")}${path}`;
   const controller =
     typeof AbortController !== "undefined" ? new AbortController() : null;
   const timer = controller

--- a/packages/scripts/cloud/deploy-freshness-guard.mjs
+++ b/packages/scripts/cloud/deploy-freshness-guard.mjs
@@ -1,0 +1,216 @@
+/**
+ * Cloud deploy freshness guard (#14083).
+ *
+ * Zombie CI runs that were stuck `queued` during a runner freeze eventually
+ * execute and deploy their OLD ref OVER a newer build — staging/prod regress to
+ * a pre-fix bundle HOURS after newer builds were live (observed #14082: staging
+ * regressed to `8deb9cbd07`, a pre-#13410 ref, clobbering newer deploys).
+ *
+ * This guard runs BEFORE `wrangler pages deploy` / `wrangler deploy` and:
+ *   1. Fetches the currently-served build stamp (the deployed
+ *      `eliza-renderer-build.json` for Pages, whose `commit` field records the
+ *      ref that built it).
+ *   2. Skips the deploy when the run's SHA is an ANCESTOR of the served commit
+ *      (`git merge-base --is-ancestor <runSha> <servedCommit>`) — i.e. the
+ *      currently-served build is strictly newer than what this run would ship.
+ *   3. A `--force` flag (wired from a `workflow_dispatch` input) bypasses the
+ *      guard for intentional rollbacks.
+ *
+ * FAIL-OPEN by design: the guard only SKIPS on a DEFINITIVE stale signal (the
+ * run SHA is provably an ancestor of a known-newer served commit). Every
+ * ambiguous state — served stamp unreachable/unparseable, no commit recorded,
+ * histories unrelated, ancestry undeterminable — DEPLOYS. A freshness guard must
+ * never turn a transient signal-fetch failure into an undeployable state (that
+ * would block the exact fix that needs to ship). "Deploy" is the safe default;
+ * "skip" is the narrow, provable case.
+ */
+
+export const DEPLOY_FRESHNESS_SCHEMA = "elizaos.deploy.freshness-guard/v1";
+
+/**
+ * @typedef {"deploy" | "skip"} FreshnessDecision
+ * @typedef {object} FreshnessResult
+ * @property {FreshnessDecision} decision
+ * @property {string} reason        machine-stable reason code
+ * @property {string} detail        human-readable explanation
+ * @property {string|null} runSha
+ * @property {string|null} servedCommit
+ */
+
+/**
+ * Pure decision core. No I/O — every input is passed in so this is fully
+ * unit-testable and deterministic.
+ *
+ * @param {object} args
+ * @param {string|null|undefined} args.runSha        the SHA this run would deploy
+ * @param {string|null|undefined} args.servedCommit  commit of the currently-served build (null if unknown)
+ * @param {boolean} [args.force]                     bypass the guard (intentional rollback)
+ * @param {(runSha: string, servedCommit: string) => (boolean|null)} args.isAncestor
+ *        returns true if runSha is a strict-or-equal ancestor of servedCommit,
+ *        false if it is not, and null if ancestry could NOT be determined
+ *        (histories unrelated / commit not fetchable / git error).
+ * @returns {FreshnessResult}
+ */
+export function decideDeployFreshness({
+  runSha,
+  servedCommit,
+  force = false,
+  isAncestor,
+}) {
+  const normalizedRun =
+    typeof runSha === "string" && runSha.trim() ? runSha.trim() : null;
+  const normalizedServed =
+    typeof servedCommit === "string" && servedCommit.trim()
+      ? servedCommit.trim()
+      : null;
+
+  const base = {
+    runSha: normalizedRun,
+    servedCommit: normalizedServed,
+  };
+
+  if (force) {
+    return {
+      ...base,
+      decision: "deploy",
+      reason: "forced",
+      detail: "--force set: bypassing freshness guard (intentional rollback).",
+    };
+  }
+
+  if (!normalizedRun) {
+    // Can't reason about freshness with no run SHA — deploy (fail-open).
+    return {
+      ...base,
+      decision: "deploy",
+      reason: "no_run_sha",
+      detail: "No run SHA provided; cannot compare freshness. Deploying.",
+    };
+  }
+
+  if (!normalizedServed) {
+    // No served stamp / no commit recorded → first deploy, or an old build
+    // without a stamp. Deploy (fail-open).
+    return {
+      ...base,
+      decision: "deploy",
+      reason: "no_served_commit",
+      detail:
+        "No served build commit available (missing/unstamped build). Deploying.",
+    };
+  }
+
+  if (normalizedRun === normalizedServed) {
+    // Re-deploying the same commit is legitimate (secret rotation, retry).
+    return {
+      ...base,
+      decision: "deploy",
+      reason: "same_commit",
+      detail:
+        "Run SHA equals the served commit. Deploying (idempotent redeploy).",
+    };
+  }
+
+  let ancestor;
+  try {
+    ancestor = isAncestor(normalizedRun, normalizedServed);
+  } catch {
+    ancestor = null;
+  }
+
+  if (ancestor === true) {
+    // The run's SHA is an ancestor of the served commit → the served build is
+    // strictly NEWER than what this run would ship → this is a stale run.
+    return {
+      ...base,
+      decision: "skip",
+      reason: "stale_run",
+      detail:
+        `Run SHA ${normalizedRun} is an ancestor of the currently-served ` +
+        `commit ${normalizedServed}: the served build is newer. Skipping stale deploy.`,
+    };
+  }
+
+  if (ancestor === false) {
+    // The run SHA is NOT an ancestor of the served commit → it is newer or on a
+    // divergent tip that should win. Deploy.
+    return {
+      ...base,
+      decision: "deploy",
+      reason: "run_is_newer",
+      detail:
+        `Run SHA ${normalizedRun} is not an ancestor of served commit ` +
+        `${normalizedServed}: this run is newer or divergent. Deploying.`,
+    };
+  }
+
+  // ancestor === null → ancestry undeterminable (unrelated histories, commit
+  // not fetchable, git error). Fail-open: deploy.
+  return {
+    ...base,
+    decision: "deploy",
+    reason: "ancestry_unknown",
+    detail:
+      `Could not determine ancestry between run SHA ${normalizedRun} and ` +
+      `served commit ${normalizedServed}. Deploying (fail-open).`,
+  };
+}
+
+/**
+ * Extract the served build commit from a fetched `eliza-renderer-build.json`
+ * body. Returns the commit string, or null when absent/unparseable/blank.
+ *
+ * @param {string|null|undefined} body raw response body text
+ * @returns {string|null}
+ */
+export function parseServedCommit(body) {
+  if (typeof body !== "string" || !body.trim()) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const commit = /** @type {{ commit?: unknown }} */ (parsed).commit;
+  if (typeof commit !== "string" || !commit.trim()) return null;
+  return commit.trim();
+}
+
+/**
+ * Fetch the served renderer build manifest and return its recorded commit, or
+ * null on any failure (fail-open — an unreachable stamp must not block deploys).
+ *
+ * @param {string} baseUrl e.g. "https://staging.elizacloud.ai"
+ * @param {object} [opts]
+ * @param {typeof fetch} [opts.fetchImpl]
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<string|null>}
+ */
+export async function fetchServedCommit(
+  baseUrl,
+  { fetchImpl = fetch, timeoutMs = 15000 } = {},
+) {
+  if (typeof baseUrl !== "string" || !baseUrl.trim()) return null;
+  const url = `${baseUrl.replace(/\/+$/, "")}/eliza-renderer-build.json`;
+  const controller =
+    typeof AbortController !== "undefined" ? new AbortController() : null;
+  const timer = controller
+    ? setTimeout(() => controller.abort(), timeoutMs)
+    : null;
+  try {
+    const res = await fetchImpl(url, {
+      // Never let a CDN/service-worker hand back a cached stamp — we need the
+      // live served build identity.
+      headers: { "cache-control": "no-cache" },
+      ...(controller ? { signal: controller.signal } : {}),
+    });
+    if (!res?.ok) return null;
+    const body = await res.text();
+    return parseServedCommit(body);
+  } catch {
+    return null;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Problem

Zombie CI runs stuck `queued` through a runner freeze eventually execute and deploy their **OLD ref OVER a newer build**. #14082 hit exactly this: `staging.elizacloud.ai` regressed to a pre-#13410 bundle (`8deb9cbd07`) **hours** after newer builds were live, because a stale queued `cloud-cf-deploy` run finally executed and clobbered the newer deploys. The existing per-ref concurrency group serializes deploys but does **not** stop an out-of-order stale run from being the last writer.

Fixes #14083.

## Fix

A **deploy freshness guard** step is added to both Pages deploy jobs — `deploy-console` (`eliza-cloud` @ elizacloud.ai / staging.elizacloud.ai) and `deploy-app` (`eliza-app` @ app.elizacloud.ai / app-staging.elizacloud.ai) — that runs **before** `wrangler pages deploy`:

1. fetches the currently-served build stamp (`<domain>/eliza-renderer-build.json`, whose `commit` field records the ref that built it — the same manifest #9309 already ships on every renderer build);
2. **SKIPs** the deploy when this run's SHA is an ancestor of the served commit (`git merge-base --is-ancestor <runSha> <servedCommit>` → the served build is strictly newer → this run is stale);
3. a `workflow_dispatch` **`force`** input bypasses the guard for intentional rollbacks to an older ref.

### Fail-open by construction
The guard only **SKIPs** on a *definitive* stale signal (run SHA provably an ancestor of a known-newer served commit). **Every** ambiguous state deploys: served stamp unreachable/unparseable/unstamped, no commit recorded, unrelated histories, ancestry undeterminable, same-commit redeploy, git error, unexpected crash. A freshness guard must never turn a transient signal-fetch failure into an undeployable state (that would block the exact fix that needs to ship). The CLI always exits 0 and signals only via `should_deploy`; the deploy step gates on it (`steps.freshness.outputs.should_deploy == 'true'`).

## Design
- `packages/scripts/cloud/deploy-freshness-guard.mjs` — pure, I/O-free decision core: `decideDeployFreshness` (deterministic, `isAncestor` injected) + `parseServedCommit` + `fetchServedCommit` (fail-open network boundary).
- `packages/scripts/cloud/deploy-freshness-guard-cli.mjs` — thin CLI: fetches the served stamp, fetches both commits into the shallow deploy checkout (best-effort, bounded) and runs `git merge-base --is-ancestor`, emits `should_deploy` to `$GITHUB_OUTPUT`.

## Tests / verification
- `bun test packages/scripts/__tests__/deploy-freshness-guard.test.ts` → **19/19 green**, 100% line coverage of the decision module. Covers the narrow SKIP case + every fail-open branch (no served commit, run-newer, ancestry-unknown, isAncestor-throws, no-run-sha, same-commit) + the force bypass (incl. short-circuit before `isAncestor`) + the network boundary (200/404/throw/blank/HTML-fallthrough).
- **End-to-end against a real 2-commit git repo:** run=A(old)/served=B(new) → `skip (stale_run)`; run=B/served=A → `deploy (run_is_newer)`; `--force` on a stale run → `deploy (forced)`. Real `git merge-base --is-ancestor` path exercised.
- `node --check` clean on both `.mjs`; biome clean (only the pre-existing `GITHUB_OUTPUT` turbo-caching warning shared by all CI scripts); `error-policy-ratchet` "no new fallback-slop"; `ci-merge-gate-contract --self-test` 8/8 green.
- YAML parses; `force` input + both freshness steps + gated deploy `if`s verified structurally.

## Evidence
- N/A — CI/deploy workflow + scripts only, no app/UI surface, no model/action/provider behavior changed. Hosted CI will prove the workflow on this branch.

Collision receipts: no open PR on #14083 at claim or push; no `lalalune`/`NubsCarson`/`roninjin10` freshness/stale-deploy PR in the last day (#14077 is a *different* mechanism — stale PR **base** freshness in `test.yml`, not deploy-time served-**build** freshness in `cloud-cf-deploy.yml`; zero file overlap). Unique worktree path.

— [sol-orch]