### PR TITLE
fix(cloud): reap SIGHUP-immune orphaned docker pulls + self-heal wedged provisioning nodes

### DIFF
--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -254,6 +254,26 @@ export const containersEnv = {
     );
   },
 
+  /**
+   * Auto-recover a node whose dockerd image-pull coordinator has wedged: after
+   * repeated failed pre-pulls the provisioning worker restarts docker on the
+   * node itself (rate-limited) instead of requiring a manual `systemctl
+   * restart docker`. Requires `live-restore=true` on the node so running
+   * agents survive the restart. Read via `CONTAINERS_PREPULL_SELF_HEAL_RESTART`
+   * (with `ELIZA_` fallback); only the literal string `"true"` enables it.
+   * Off by default — a docker restart is a shared-host operation, so it stays
+   * opt-in per environment.
+   */
+  prePullSelfHealRestartEnabled(): boolean {
+    const env = getCloudAwareEnv();
+    return (
+      pick(
+        env.CONTAINERS_PREPULL_SELF_HEAL_RESTART,
+        env.ELIZA_CONTAINERS_PREPULL_SELF_HEAL_RESTART,
+      ) === "true"
+    );
+  },
+
   /** Explicit operator-pinned agent image, without the hardcoded fallback. */
   defaultAgentImageOverride(): string | undefined {
     const env = getCloudAwareEnv();

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-prepull-self-heal.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-prepull-self-heal.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Pre-pull self-heal tests cover the SSH commands that run on Docker nodes
+ * after a timed-out image pre-pull. The harness uses a fake SSH client so the
+ * production safety rules are asserted without killing local processes.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  __resetPrePullFailureStateForTests,
+  buildPrePullReapCommand,
+  buildTrackedPrePullCommand,
+  DockerNodeManager,
+  isPrePullTimeoutError,
+} from "./docker-node-manager";
+
+const IMAGE = "ghcr.io/elizaos/eliza:test-prepull";
+const PID_FILE = "/tmp/eliza-prepull-test.pid";
+
+type RecoveryHarness = {
+  recoverAfterTimedOutPrePull: (
+    ssh: { exec: (command: string, timeoutMs?: number) => Promise<string> },
+    node: { node_id: string; hostname: string },
+    pidFile: string,
+    image: string,
+  ) => Promise<void>;
+};
+
+function managerHarness(): RecoveryHarness {
+  return DockerNodeManager.getInstance() as unknown as RecoveryHarness;
+}
+
+function fakeSsh() {
+  const commands: string[] = [];
+  return {
+    commands,
+    ssh: {
+      exec: mock(async (command: string) => {
+        commands.push(command);
+        return "";
+      }),
+    },
+  };
+}
+
+const originalSelfHealEnv = process.env.CONTAINERS_PREPULL_SELF_HEAL_RESTART;
+const originalLegacySelfHealEnv = process.env.ELIZA_CONTAINERS_PREPULL_SELF_HEAL_RESTART;
+
+beforeEach(() => {
+  __resetPrePullFailureStateForTests();
+  delete process.env.CONTAINERS_PREPULL_SELF_HEAL_RESTART;
+  delete process.env.ELIZA_CONTAINERS_PREPULL_SELF_HEAL_RESTART;
+});
+
+afterEach(() => {
+  __resetPrePullFailureStateForTests();
+  if (originalSelfHealEnv === undefined) {
+    delete process.env.CONTAINERS_PREPULL_SELF_HEAL_RESTART;
+  } else {
+    process.env.CONTAINERS_PREPULL_SELF_HEAL_RESTART = originalSelfHealEnv;
+  }
+  if (originalLegacySelfHealEnv === undefined) {
+    delete process.env.ELIZA_CONTAINERS_PREPULL_SELF_HEAL_RESTART;
+  } else {
+    process.env.ELIZA_CONTAINERS_PREPULL_SELF_HEAL_RESTART = originalLegacySelfHealEnv;
+  }
+});
+
+describe("pre-pull timeout classification", () => {
+  test("recovers only DockerSSHClient timeout failures", () => {
+    expect(
+      isPrePullTimeoutError(
+        new Error("[docker-ssh] Command timed out after 300000ms on node: sh [redacted]"),
+      ),
+    ).toBe(true);
+    expect(
+      isPrePullTimeoutError(
+        new Error("[docker-ssh] Command exited with code 1 on node: manifest unknown"),
+      ),
+    ).toBe(false);
+    expect(isPrePullTimeoutError(new Error("pull access denied"))).toBe(false);
+  });
+});
+
+describe("tracked pre-pull commands", () => {
+  test("wraps docker pull with a per-attempt PID file", () => {
+    const tracked = buildTrackedPrePullCommand(IMAGE, "linux/amd64", "test-marker");
+
+    expect(tracked.pidFile).toBe("/tmp/eliza-prepull-test-marker.pid");
+    expect(tracked.command).toContain("docker pull");
+    expect(tracked.command).toContain("--platform");
+    expect(tracked.command).toContain("linux/amd64");
+    expect(tracked.command).toContain(IMAGE);
+    expect(tracked.command).toContain("printf");
+  });
+
+  test("builds a scoped reap command for only the recorded pre-pull PID", () => {
+    const command = buildPrePullReapCommand(PID_FILE, IMAGE);
+
+    expect(command).toContain(PID_FILE);
+    expect(command).toContain("/proc/$pid/cmdline");
+    expect(command).toContain('grep -F "docker pull"');
+    expect(command).toContain(IMAGE);
+    expect(command).toContain('kill -9 "$pid"');
+    expect(command).not.toContain("pkill");
+  });
+});
+
+describe("pre-pull self-heal restart policy", () => {
+  test("reaps the scoped PID but does not restart docker when self-heal is disabled", async () => {
+    const { ssh, commands } = fakeSsh();
+
+    await managerHarness().recoverAfterTimedOutPrePull(
+      ssh,
+      { node_id: "node-a", hostname: "node-a.example.test" },
+      PID_FILE,
+      IMAGE,
+    );
+
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toContain(PID_FILE);
+    expect(commands[0]).not.toContain("pkill");
+    expect(commands.some((command) => command.includes("systemctl restart docker"))).toBe(false);
+  });
+
+  test("restarts docker only after repeated timeout symptoms and then honors cooldown", async () => {
+    process.env.CONTAINERS_PREPULL_SELF_HEAL_RESTART = "true";
+    const { ssh, commands } = fakeSsh();
+    const node = { node_id: "node-b", hostname: "node-b.example.test" };
+
+    await managerHarness().recoverAfterTimedOutPrePull(ssh, node, PID_FILE, IMAGE);
+    await managerHarness().recoverAfterTimedOutPrePull(ssh, node, PID_FILE, IMAGE);
+
+    expect(commands.filter((command) => command.includes("systemctl restart docker"))).toHaveLength(
+      1,
+    );
+
+    await managerHarness().recoverAfterTimedOutPrePull(ssh, node, PID_FILE, IMAGE);
+    await managerHarness().recoverAfterTimedOutPrePull(ssh, node, PID_FILE, IMAGE);
+
+    expect(commands.filter((command) => command.includes("systemctl restart docker"))).toHaveLength(
+      1,
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-prepull-self-heal.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-prepull-self-heal.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   __resetPrePullFailureStateForTests,
   buildPrePullReapCommand,
+  buildPrePullSelfHealRecoverCommand,
   buildTrackedPrePullCommand,
   DockerNodeManager,
   isPrePullTimeoutError,
@@ -103,6 +104,16 @@ describe("tracked pre-pull commands", () => {
     expect(command).toContain('kill -9 "$pid"');
     expect(command).not.toContain("pkill");
   });
+
+  test("builds a force recovery command for a daemon whose graceful restart hangs", () => {
+    const command = buildPrePullSelfHealRecoverCommand();
+
+    expect(command).toContain("systemctl kill -s SIGKILL docker.service docker.socket");
+    expect(command).toContain("systemctl restart containerd");
+    expect(command).toContain("systemctl reset-failed docker.service");
+    expect(command).toContain("systemctl start docker.service");
+    expect(command).not.toContain("systemctl restart docker");
+  });
 });
 
 describe("pre-pull self-heal restart policy", () => {
@@ -119,10 +130,12 @@ describe("pre-pull self-heal restart policy", () => {
     expect(commands).toHaveLength(1);
     expect(commands[0]).toContain(PID_FILE);
     expect(commands[0]).not.toContain("pkill");
-    expect(commands.some((command) => command.includes("systemctl restart docker"))).toBe(false);
+    expect(
+      commands.some((command) => command.includes("systemctl kill -s SIGKILL docker.service")),
+    ).toBe(false);
   });
 
-  test("restarts docker only after repeated timeout symptoms and then honors cooldown", async () => {
+  test("force-recovers docker only after repeated timeout symptoms and then honors cooldown", async () => {
     process.env.CONTAINERS_PREPULL_SELF_HEAL_RESTART = "true";
     const { ssh, commands } = fakeSsh();
     const node = { node_id: "node-b", hostname: "node-b.example.test" };
@@ -130,15 +143,48 @@ describe("pre-pull self-heal restart policy", () => {
     await managerHarness().recoverAfterTimedOutPrePull(ssh, node, PID_FILE, IMAGE);
     await managerHarness().recoverAfterTimedOutPrePull(ssh, node, PID_FILE, IMAGE);
 
-    expect(commands.filter((command) => command.includes("systemctl restart docker"))).toHaveLength(
-      1,
-    );
+    expect(
+      commands.filter((command) => command.includes("systemctl kill -s SIGKILL docker.service")),
+    ).toHaveLength(1);
+    expect(
+      commands.filter((command) => command.includes("systemctl restart containerd")),
+    ).toHaveLength(1);
+    expect(commands.join("\n")).not.toContain("systemctl restart docker");
 
     await managerHarness().recoverAfterTimedOutPrePull(ssh, node, PID_FILE, IMAGE);
     await managerHarness().recoverAfterTimedOutPrePull(ssh, node, PID_FILE, IMAGE);
 
-    expect(commands.filter((command) => command.includes("systemctl restart docker"))).toHaveLength(
-      1,
-    );
+    expect(
+      commands.filter((command) => command.includes("systemctl kill -s SIGKILL docker.service")),
+    ).toHaveLength(1);
+  });
+
+  test("records cooldown even when force recovery fails", async () => {
+    process.env.CONTAINERS_PREPULL_SELF_HEAL_RESTART = "true";
+    const commands: string[] = [];
+    const ssh = {
+      exec: mock(async (command: string) => {
+        commands.push(command);
+        if (command.includes("systemctl kill -s SIGKILL docker.service")) {
+          throw new Error("force recovery failed");
+        }
+        return "";
+      }),
+    };
+    const node = { node_id: "node-c", hostname: "node-c.example.test" };
+
+    await managerHarness().recoverAfterTimedOutPrePull(ssh, node, PID_FILE, IMAGE);
+    await managerHarness().recoverAfterTimedOutPrePull(ssh, node, PID_FILE, IMAGE);
+
+    expect(
+      commands.filter((command) => command.includes("systemctl kill -s SIGKILL docker.service")),
+    ).toHaveLength(1);
+
+    await managerHarness().recoverAfterTimedOutPrePull(ssh, node, PID_FILE, IMAGE);
+    await managerHarness().recoverAfterTimedOutPrePull(ssh, node, PID_FILE, IMAGE);
+
+    expect(
+      commands.filter((command) => command.includes("systemctl kill -s SIGKILL docker.service")),
+    ).toHaveLength(1);
   });
 });

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.prepull.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.prepull.test.ts
@@ -107,8 +107,10 @@ describe("DockerNodeManager pre-pull recovery", () => {
     const commands: string[] = [];
     mocks.exec.mockImplementation((command: string) => {
       commands.push(command);
-      if (command.startsWith("docker pull ")) {
-        return Promise.reject(new Error("pull timed out"));
+      if (command.includes('wait "$pid"')) {
+        return Promise.reject(
+          new Error("[docker-ssh] Command timed out after 300000ms on node: sh [redacted]"),
+        );
       }
       return Promise.resolve("");
     });
@@ -122,12 +124,17 @@ describe("DockerNodeManager pre-pull recovery", () => {
     expect(result).toMatchObject({
       nodeId: "prepull-reap-node",
       status: "failed",
-      error: "pull timed out",
+      error: "[docker-ssh] Command timed out after 300000ms on node: sh [redacted]",
     });
-    expect(commands).toEqual([
-      "docker pull --platform 'linux/amd64' 'ghcr.io/elizaos/eliza:test'",
-      "pkill -9 -f 'docker pull ' || true",
-    ]);
+    expect(commands).toHaveLength(2);
+    expect(commands[0]).toContain("docker pull");
+    expect(commands[0]).toContain("ghcr.io/elizaos/eliza:test");
+    expect(commands[0]).toContain("/tmp/eliza-prepull-");
+    expect(commands[0]).toContain("printf");
+    expect(commands[1]).toContain("/proc/$pid/cmdline");
+    expect(commands[1]).toContain("ghcr.io/elizaos/eliza:test");
+    expect(commands[1]).toContain('kill -9 "$pid"');
+    expect(commands.join("\n")).not.toContain("pkill");
   });
 
   test("auto-restarts docker only after repeated failed pre-pulls when enabled", async () => {
@@ -138,8 +145,10 @@ describe("DockerNodeManager pre-pull recovery", () => {
     const commands: string[] = [];
     mocks.exec.mockImplementation((command: string) => {
       commands.push(command);
-      if (command.startsWith("docker pull ")) {
-        return Promise.reject(new Error("pull timed out"));
+      if (command.includes('wait "$pid"')) {
+        return Promise.reject(
+          new Error("[docker-ssh] Command timed out after 300000ms on node: sh [redacted]"),
+        );
       }
       return Promise.resolve("");
     });
@@ -148,12 +157,11 @@ describe("DockerNodeManager pre-pull recovery", () => {
     await manager.prePullAgentImageOnAvailableNodes("ghcr.io/elizaos/eliza:test", "linux/amd64");
     await manager.prePullAgentImageOnAvailableNodes("ghcr.io/elizaos/eliza:test", "linux/amd64");
 
-    expect(commands).toEqual([
-      "docker pull --platform 'linux/amd64' 'ghcr.io/elizaos/eliza:test'",
-      "pkill -9 -f 'docker pull ' || true",
-      "docker pull --platform 'linux/amd64' 'ghcr.io/elizaos/eliza:test'",
-      "pkill -9 -f 'docker pull ' || true",
-      "systemctl restart docker",
-    ]);
+    expect(commands.filter((command) => command.includes('wait "$pid"'))).toHaveLength(2);
+    expect(commands.filter((command) => command.includes("/proc/$pid/cmdline"))).toHaveLength(2);
+    expect(commands.filter((command) => command.includes("systemctl restart docker"))).toHaveLength(
+      1,
+    );
+    expect(commands.join("\n")).not.toContain("pkill");
   });
 });

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.prepull.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.prepull.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Pre-pull recovery tests for Docker node image warming. The harness mocks the
+ * repository, workload counter, SSH client, and env boundary so the shared-host
+ * recovery commands can be asserted without touching Docker or SSH.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as realDockerNodesNs from "../../db/repositories/docker-nodes";
+import type { DockerNode } from "../../db/schemas/docker-nodes";
+import { containersEnv as realContainersEnv } from "../config/containers-env";
+import * as realDockerNodeWorkloadsNs from "./docker-node-workloads";
+import * as realDockerSshNs from "./docker-ssh";
+
+const realDockerNodes = { ...realDockerNodesNs };
+const realDockerNodeWorkloads = { ...realDockerNodeWorkloadsNs };
+const realDockerSsh = { ...realDockerSshNs };
+
+const mocks = {
+  nodes: [] as DockerNode[],
+  countAllocated: mock(),
+  connect: mock(),
+  exec: mock(),
+};
+
+mock.module("../../db/repositories/docker-nodes", () => ({
+  dockerNodesRepository: {
+    findEnabled: () => Promise.resolve(mocks.nodes),
+  },
+}));
+
+mock.module("./docker-node-workloads", () => ({
+  countAllocatedWorkloadsOnNode: mocks.countAllocated,
+}));
+
+mock.module("./docker-ssh", () => ({
+  DockerSSHClient: {
+    getClient: () => ({
+      connect: mocks.connect,
+      exec: mocks.exec,
+    }),
+  },
+}));
+
+afterAll(() => {
+  mock.module("../../db/repositories/docker-nodes", () => realDockerNodes);
+  mock.module("./docker-node-workloads", () => realDockerNodeWorkloads);
+  mock.module("./docker-ssh", () => realDockerSsh);
+});
+
+import { DockerNodeManager } from "./docker-node-manager";
+
+const SELF_HEAL_ENV = "CONTAINERS_PREPULL_SELF_HEAL_RESTART";
+const SELF_HEAL_FALLBACK_ENV = "ELIZA_CONTAINERS_PREPULL_SELF_HEAL_RESTART";
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}
+
+function node(nodeId: string): DockerNode {
+  return {
+    id: `${nodeId}-uuid`,
+    node_id: nodeId,
+    hostname: `${nodeId}.example.test`,
+    ssh_port: 22,
+    capacity: 4,
+    enabled: true,
+    status: "healthy",
+    allocated_count: 0,
+    last_health_check: null,
+    ssh_user: "root",
+    host_key_fingerprint: "SHA256:test",
+    metadata: { architecture: "amd64" },
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    updated_at: new Date("2026-01-01T00:00:00.000Z"),
+  };
+}
+
+describe("DockerNodeManager pre-pull recovery", () => {
+  let originalSelfHeal: string | undefined;
+  let originalSelfHealFallback: string | undefined;
+
+  beforeEach(() => {
+    originalSelfHeal = process.env[SELF_HEAL_ENV];
+    originalSelfHealFallback = process.env[SELF_HEAL_FALLBACK_ENV];
+    delete process.env[SELF_HEAL_ENV];
+    delete process.env[SELF_HEAL_FALLBACK_ENV];
+
+    mocks.nodes = [];
+    mocks.countAllocated.mockReset();
+    mocks.countAllocated.mockResolvedValue(0);
+    mocks.connect.mockReset();
+    mocks.connect.mockResolvedValue(undefined);
+    mocks.exec.mockReset();
+  });
+
+  afterEach(() => {
+    restoreEnv(SELF_HEAL_ENV, originalSelfHeal);
+    restoreEnv(SELF_HEAL_FALLBACK_ENV, originalSelfHealFallback);
+  });
+
+  test("reaps orphaned docker pull processes after a failed pre-pull", async () => {
+    mocks.nodes = [node("prepull-reap-node")];
+    const commands: string[] = [];
+    mocks.exec.mockImplementation((command: string) => {
+      commands.push(command);
+      if (command.startsWith("docker pull ")) {
+        return Promise.reject(new Error("pull timed out"));
+      }
+      return Promise.resolve("");
+    });
+
+    const manager = DockerNodeManager.getInstance();
+    const [result] = await manager.prePullAgentImageOnAvailableNodes(
+      "ghcr.io/elizaos/eliza:test",
+      "linux/amd64",
+    );
+
+    expect(result).toMatchObject({
+      nodeId: "prepull-reap-node",
+      status: "failed",
+      error: "pull timed out",
+    });
+    expect(commands).toEqual([
+      "docker pull --platform 'linux/amd64' 'ghcr.io/elizaos/eliza:test'",
+      "pkill -9 -f 'docker pull ' || true",
+    ]);
+  });
+
+  test("auto-restarts docker only after repeated failed pre-pulls when enabled", async () => {
+    process.env[SELF_HEAL_ENV] = "true";
+    expect(realContainersEnv.prePullSelfHealRestartEnabled()).toBe(true);
+
+    mocks.nodes = [node("prepull-self-heal-node")];
+    const commands: string[] = [];
+    mocks.exec.mockImplementation((command: string) => {
+      commands.push(command);
+      if (command.startsWith("docker pull ")) {
+        return Promise.reject(new Error("pull timed out"));
+      }
+      return Promise.resolve("");
+    });
+
+    const manager = DockerNodeManager.getInstance();
+    await manager.prePullAgentImageOnAvailableNodes("ghcr.io/elizaos/eliza:test", "linux/amd64");
+    await manager.prePullAgentImageOnAvailableNodes("ghcr.io/elizaos/eliza:test", "linux/amd64");
+
+    expect(commands).toEqual([
+      "docker pull --platform 'linux/amd64' 'ghcr.io/elizaos/eliza:test'",
+      "pkill -9 -f 'docker pull ' || true",
+      "docker pull --platform 'linux/amd64' 'ghcr.io/elizaos/eliza:test'",
+      "pkill -9 -f 'docker pull ' || true",
+      "systemctl restart docker",
+    ]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.prepull.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.prepull.test.ts
@@ -159,9 +159,13 @@ describe("DockerNodeManager pre-pull recovery", () => {
 
     expect(commands.filter((command) => command.includes('wait "$pid"'))).toHaveLength(2);
     expect(commands.filter((command) => command.includes("/proc/$pid/cmdline"))).toHaveLength(2);
-    expect(commands.filter((command) => command.includes("systemctl restart docker"))).toHaveLength(
-      1,
-    );
+    expect(
+      commands.filter((command) => command.includes("systemctl kill -s SIGKILL docker.service")),
+    ).toHaveLength(1);
+    expect(
+      commands.filter((command) => command.includes("systemctl restart containerd")),
+    ).toHaveLength(1);
+    expect(commands.join("\n")).not.toContain("systemctl restart docker");
     expect(commands.join("\n")).not.toContain("pkill");
   });
 });

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -24,6 +24,22 @@ import { DockerSSHClient } from "./docker-ssh";
 import { type DiskHealthVerdict, diskHealthVerdict, probeNodeDiskUsage } from "./node-disk-manager";
 
 // ---------------------------------------------------------------------------
+// Pre-pull self-heal bookkeeping (see recoverAfterFailedPrePull)
+// ---------------------------------------------------------------------------
+
+/** Per-node consecutive pre-pull failures + last auto-heal timestamp. Cleared
+ * on the first successful pull. In-memory: the provisioning worker is a single
+ * long-lived process, and a restart is itself a clean slate. */
+const prePullFailureState = new Map<
+  string,
+  { consecutiveFailures: number; lastSelfHealMs: number }
+>();
+/** Consecutive failed pre-pulls on a node before an auto docker restart. */
+const PREPULL_SELF_HEAL_FAILURE_THRESHOLD = 2;
+/** Minimum gap between auto docker restarts on the same node (anti-restart-loop). */
+const PREPULL_SELF_HEAL_COOLDOWN_MS = 30 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -471,18 +487,20 @@ export class DockerNodeManager {
           };
         }
 
+        const ssh = DockerSSHClient.getClient(
+          node.hostname,
+          node.ssh_port ?? undefined,
+          node.host_key_fingerprint ?? undefined,
+          node.ssh_user ?? undefined,
+        );
         try {
-          const ssh = DockerSSHClient.getClient(
-            node.hostname,
-            node.ssh_port ?? undefined,
-            node.host_key_fingerprint ?? undefined,
-            node.ssh_user ?? undefined,
-          );
           await ssh.connect();
           await ssh.exec(
             ["docker pull", ...dockerPlatformFlag(platform), shellQuote(image)].join(" "),
             5 * 60 * 1000,
           );
+          // Success: clear any prior wedge / self-heal bookkeeping for this node.
+          prePullFailureState.delete(node.node_id);
           return {
             nodeId: node.node_id,
             hostname: node.hostname,
@@ -496,6 +514,15 @@ export class DockerNodeManager {
             image,
             error: message,
           });
+          // A timed-out `docker pull` is NOT stopped by DockerSSHClient's
+          // channel-close (that only sends SIGHUP, which a detached `docker
+          // pull` ignores), so it keeps running. Left alone, orphaned pulls
+          // pile up until dockerd's pull coordinator wedges and every later
+          // pull dedups onto the stuck one and hangs forever — the outage that
+          // previously required a manual `systemctl restart docker`. SIGKILL
+          // the orphans so retries start clean, and auto-recover an
+          // already-wedged daemon when self-heal is enabled.
+          await this.recoverAfterFailedPrePull(ssh, node);
           return {
             nodeId: node.node_id,
             hostname: node.hostname,
@@ -506,6 +533,67 @@ export class DockerNodeManager {
         }
       }),
     );
+  }
+
+  /**
+   * Cleanup + optional self-heal after a pre-pull fails on a node.
+   *
+   * (a) Always SIGKILL any orphaned `docker pull` processes. DockerSSHClient's
+   *     timeout only closes the ssh channel (SIGHUP), which `docker pull`
+   *     ignores — so without this the timed-out pull keeps running and the
+   *     next cycle's pull dedups onto it and hangs, escalating into a wedged
+   *     dockerd pull coordinator that never lands the image.
+   * (b) If a node keeps failing (its daemon is already wedged) and self-heal
+   *     is enabled, restart docker once per cooldown to recover automatically
+   *     instead of paging an operator. `live-restore` (node bootstrap
+   *     daemon.json) keeps running agent containers alive across the restart.
+   */
+  private async recoverAfterFailedPrePull(
+    ssh: DockerSSHClient,
+    node: DockerNode,
+  ): Promise<void> {
+    // (a) Kill SIGHUP-immune orphaned pulls so retries start from a clean daemon.
+    try {
+      await ssh.exec("pkill -9 -f 'docker pull ' || true", 20_000);
+    } catch (killError) {
+      logger.warn("[docker-node-manager] Failed to reap orphaned docker pull after pre-pull failure", {
+        nodeId: node.node_id,
+        error: killError instanceof Error ? killError.message : String(killError),
+      });
+    }
+
+    // (b) Track consecutive failures; auto-recover a wedged daemon when enabled.
+    const state = prePullFailureState.get(node.node_id) ?? {
+      consecutiveFailures: 0,
+      lastSelfHealMs: 0,
+    };
+    state.consecutiveFailures += 1;
+    prePullFailureState.set(node.node_id, state);
+
+    if (!containersEnv.prePullSelfHealRestartEnabled()) return;
+    if (state.consecutiveFailures < PREPULL_SELF_HEAL_FAILURE_THRESHOLD) return;
+    if (Date.now() - state.lastSelfHealMs < PREPULL_SELF_HEAL_COOLDOWN_MS) return;
+
+    logger.error(
+      "[docker-node-manager] Pre-pull wedged repeatedly; auto-restarting docker to self-heal",
+      {
+        nodeId: node.node_id,
+        hostname: node.hostname,
+        consecutiveFailures: state.consecutiveFailures,
+      },
+    );
+    try {
+      // Requires live-restore=true on the node so running agents survive.
+      await ssh.exec("systemctl restart docker", 90_000);
+      state.lastSelfHealMs = Date.now();
+      state.consecutiveFailures = 0;
+      prePullFailureState.set(node.node_id, state);
+    } catch (restartError) {
+      logger.error("[docker-node-manager] Self-heal docker restart failed", {
+        nodeId: node.node_id,
+        error: restartError instanceof Error ? restartError.message : String(restartError),
+      });
+    }
   }
 
   // ---- Runtime Container Inspection -------------------------------------

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -142,6 +142,17 @@ export function buildPrePullReapCommand(pidFile: string, image: string): string 
   return `sh -c ${shellQuote(script)}`;
 }
 
+export function buildPrePullSelfHealRecoverCommand(): string {
+  return [
+    "systemctl kill -s SIGKILL docker.service docker.socket 2>/dev/null",
+    "sleep 2",
+    "systemctl restart containerd 2>/dev/null",
+    "sleep 4",
+    "systemctl reset-failed docker.service 2>/dev/null",
+    "systemctl start docker.service",
+  ].join("; ");
+}
+
 export function __resetPrePullFailureStateForTests(): void {
   prePullFailureState.clear();
 }
@@ -638,9 +649,13 @@ export class DockerNodeManager {
       },
     );
     try {
-      // Requires live-restore=true on the node so running agents survive.
-      await ssh.exec("systemctl restart docker", 90_000);
+      // Live staging showed graceful `systemctl restart docker` can hang when
+      // dockerd/containerd content ingest is already wedged. Stamp the cooldown
+      // before attempting the shared-host recovery, then force-kill dockerd and
+      // bounce containerd; live-restore plus container shims keep agents alive.
       state.lastSelfHealMs = Date.now();
+      prePullFailureState.set(node.node_id, state);
+      await ssh.exec(buildPrePullSelfHealRecoverCommand(), 120_000);
       state.consecutiveFailures = 0;
       prePullFailureState.set(node.node_id, state);
     } catch (restartError) {

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -548,18 +548,19 @@ export class DockerNodeManager {
    *     instead of paging an operator. `live-restore` (node bootstrap
    *     daemon.json) keeps running agent containers alive across the restart.
    */
-  private async recoverAfterFailedPrePull(
-    ssh: DockerSSHClient,
-    node: DockerNode,
-  ): Promise<void> {
+  private async recoverAfterFailedPrePull(ssh: DockerSSHClient, node: DockerNode): Promise<void> {
     // (a) Kill SIGHUP-immune orphaned pulls so retries start from a clean daemon.
     try {
       await ssh.exec("pkill -9 -f 'docker pull ' || true", 20_000);
     } catch (killError) {
-      logger.warn("[docker-node-manager] Failed to reap orphaned docker pull after pre-pull failure", {
-        nodeId: node.node_id,
-        error: killError instanceof Error ? killError.message : String(killError),
-      });
+      // error-policy:J6 best-effort cleanup must not mask the original pre-pull failure.
+      logger.warn(
+        "[docker-node-manager] Failed to reap orphaned docker pull after pre-pull failure",
+        {
+          nodeId: node.node_id,
+          error: killError instanceof Error ? killError.message : String(killError),
+        },
+      );
     }
 
     // (b) Track consecutive failures; auto-recover a wedged daemon when enabled.
@@ -589,6 +590,7 @@ export class DockerNodeManager {
       state.consecutiveFailures = 0;
       prePullFailureState.set(node.node_id, state);
     } catch (restartError) {
+      // error-policy:J6 best-effort self-heal must report failure while preserving caller status.
       logger.error("[docker-node-manager] Self-heal docker restart failed", {
         nodeId: node.node_id,
         error: restartError instanceof Error ? restartError.message : String(restartError),

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -7,6 +7,7 @@
  * Reference: eliza-cloud/backend/services/node-manager.ts
  */
 
+import crypto from "node:crypto";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import type { DockerNode, DockerNodeStatus } from "../../db/schemas/docker-nodes";
 import { containersEnv } from "../config/containers-env";
@@ -24,7 +25,7 @@ import { DockerSSHClient } from "./docker-ssh";
 import { type DiskHealthVerdict, diskHealthVerdict, probeNodeDiskUsage } from "./node-disk-manager";
 
 // ---------------------------------------------------------------------------
-// Pre-pull self-heal bookkeeping (see recoverAfterFailedPrePull)
+// Pre-pull self-heal bookkeeping (see recoverAfterTimedOutPrePull)
 // ---------------------------------------------------------------------------
 
 /** Per-node consecutive pre-pull failures + last auto-heal timestamp. Cleared
@@ -38,6 +39,7 @@ const prePullFailureState = new Map<
 const PREPULL_SELF_HEAL_FAILURE_THRESHOLD = 2;
 /** Minimum gap between auto docker restarts on the same node (anti-restart-loop). */
 const PREPULL_SELF_HEAL_COOLDOWN_MS = 30 * 60 * 1000;
+const PREPULL_PID_DIR = "/tmp";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -91,6 +93,57 @@ function isAutoscaledNode(node: DockerNode): boolean {
   const meta = node.metadata as Record<string, unknown> | null | undefined;
   if (!meta || typeof meta !== "object") return false;
   return meta.provider === "hetzner-cloud" && meta.autoscaled === true;
+}
+
+function prePullPidFile(marker: string): string {
+  return `${PREPULL_PID_DIR}/eliza-prepull-${marker}.pid`;
+}
+
+export function isPrePullTimeoutError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("Command timed out after");
+}
+
+export function buildTrackedPrePullCommand(
+  image: string,
+  platform: string | null | undefined,
+  marker = crypto.randomUUID(),
+): { command: string; pidFile: string } {
+  const pidFile = prePullPidFile(marker);
+  const pullCommand = ["docker pull", ...dockerPlatformFlag(platform), shellQuote(image)].join(" ");
+  const script = [
+    `pidfile=${shellQuote(pidFile)}`,
+    'rm -f "$pidfile"',
+    `(${pullCommand}) &`,
+    "pid=$!",
+    'printf "%s\\n" "$pid" > "$pidfile"',
+    'wait "$pid"',
+    "status=$?",
+    'rm -f "$pidfile"',
+    'exit "$status"',
+  ].join("; ");
+  return { command: `sh -c ${shellQuote(script)}`, pidFile };
+}
+
+export function buildPrePullReapCommand(pidFile: string, image: string): string {
+  const quotedImage = shellQuote(image);
+  const script = [
+    `pidfile=${shellQuote(pidFile)}`,
+    'if [ -s "$pidfile" ]; then',
+    'pid="$(cat "$pidfile" 2>/dev/null || true)"',
+    'case "$pid" in ""|*[!0-9]*) rm -f "$pidfile"; exit 0 ;; esac',
+    'cmdline="$(tr "\\0" " " < "/proc/$pid/cmdline" 2>/dev/null || true)"',
+    `if printf "%s\\n" "$cmdline" | grep -F "docker pull" >/dev/null && printf "%s\\n" "$cmdline" | grep -F -- ${quotedImage} >/dev/null; then`,
+    'kill -9 "$pid" 2>/dev/null || true',
+    "fi",
+    'rm -f "$pidfile"',
+    "fi",
+  ].join("; ");
+  return `sh -c ${shellQuote(script)}`;
+}
+
+export function __resetPrePullFailureStateForTests(): void {
+  prePullFailureState.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -493,12 +546,10 @@ export class DockerNodeManager {
           node.host_key_fingerprint ?? undefined,
           node.ssh_user ?? undefined,
         );
+        const prePull = buildTrackedPrePullCommand(image, platform);
         try {
           await ssh.connect();
-          await ssh.exec(
-            ["docker pull", ...dockerPlatformFlag(platform), shellQuote(image)].join(" "),
-            5 * 60 * 1000,
-          );
+          await ssh.exec(prePull.command, 5 * 60 * 1000);
           // Success: clear any prior wedge / self-heal bookkeeping for this node.
           prePullFailureState.delete(node.node_id);
           return {
@@ -514,15 +565,16 @@ export class DockerNodeManager {
             image,
             error: message,
           });
-          // A timed-out `docker pull` is NOT stopped by DockerSSHClient's
-          // channel-close (that only sends SIGHUP, which a detached `docker
-          // pull` ignores), so it keeps running. Left alone, orphaned pulls
-          // pile up until dockerd's pull coordinator wedges and every later
-          // pull dedups onto the stuck one and hangs forever — the outage that
-          // previously required a manual `systemctl restart docker`. SIGKILL
-          // the orphans so retries start clean, and auto-recover an
-          // already-wedged daemon when self-heal is enabled.
-          await this.recoverAfterFailedPrePull(ssh, node);
+          if (isPrePullTimeoutError(error)) {
+            // A timed-out `docker pull` is NOT stopped by DockerSSHClient's
+            // channel-close (that only sends SIGHUP, which a detached `docker
+            // pull` ignores), so it can keep running. The tracked wrapper leaves
+            // a PID file only for this pre-pull, so recovery does not kill
+            // unrelated deployment pulls on the same node.
+            await this.recoverAfterTimedOutPrePull(ssh, node, prePull.pidFile, image);
+          } else {
+            prePullFailureState.delete(node.node_id);
+          }
           return {
             nodeId: node.node_id,
             hostname: node.hostname,
@@ -536,24 +588,26 @@ export class DockerNodeManager {
   }
 
   /**
-   * Cleanup + optional self-heal after a pre-pull fails on a node.
+   * Cleanup + optional self-heal after a pre-pull times out on a node.
    *
-   * (a) Always SIGKILL any orphaned `docker pull` processes. DockerSSHClient's
-   *     timeout only closes the ssh channel (SIGHUP), which `docker pull`
-   *     ignores — so without this the timed-out pull keeps running and the
-   *     next cycle's pull dedups onto it and hangs, escalating into a wedged
-   *     dockerd pull coordinator that never lands the image.
+   * (a) SIGKILL only the PID recorded by the timed-out pre-pull wrapper, after
+   *     verifying the process is still a `docker pull` for the same image.
    * (b) If a node keeps failing (its daemon is already wedged) and self-heal
    *     is enabled, restart docker once per cooldown to recover automatically
    *     instead of paging an operator. `live-restore` (node bootstrap
    *     daemon.json) keeps running agent containers alive across the restart.
    */
-  private async recoverAfterFailedPrePull(ssh: DockerSSHClient, node: DockerNode): Promise<void> {
-    // (a) Kill SIGHUP-immune orphaned pulls so retries start from a clean daemon.
+  private async recoverAfterTimedOutPrePull(
+    ssh: DockerSSHClient,
+    node: DockerNode,
+    pidFile: string,
+    image: string,
+  ): Promise<void> {
     try {
-      await ssh.exec("pkill -9 -f 'docker pull ' || true", 20_000);
+      await ssh.exec(buildPrePullReapCommand(pidFile, image), 20_000);
     } catch (killError) {
-      // error-policy:J6 best-effort cleanup must not mask the original pre-pull failure.
+      // error-policy:J6 best-effort timeout orphan cleanup; the pre-pull has
+      // already failed and the next cycle can retry the scoped PID reap.
       logger.warn(
         "[docker-node-manager] Failed to reap orphaned docker pull after pre-pull failure",
         {
@@ -590,7 +644,8 @@ export class DockerNodeManager {
       state.consecutiveFailures = 0;
       prePullFailureState.set(node.node_id, state);
     } catch (restartError) {
-      // error-policy:J6 best-effort self-heal must report failure while preserving caller status.
+      // error-policy:J6 best-effort node self-heal; failure is visible in logs
+      // and the cooldown/threshold state lets a later cycle retry.
       logger.error("[docker-node-manager] Self-heal docker restart failed", {
         nodeId: node.node_id,
         error: restartError instanceof Error ? restartError.message : String(restartError),


### PR DESCRIPTION
## What & why

Agent provisioning on **staging was fully dead** — every new dedicated agent stuck `pending` forever ("Couldn't connect to your agent … still pending after 357s") and it took a **manual `systemctl restart docker`** to recover. Root cause, confirmed live on the robot node:

- The provisioning worker pre-pulls `ghcr.io/elizaos/eliza:*` every ~5 min. When a `docker pull` times out (5 min), `DockerSSHClient` only **closes the ssh channel (SIGHUP)** to stop it — but `docker pull` is a detached Go binary that **ignores SIGHUP**, so the pull keeps running.
- The next cycle's `docker pull` **dedups onto the still-running one and hangs**. Orphans pile up — observed live: **68 stuck `moby.lease/temporary` containerd leases**, 8+ zombie `docker pull` procs, `docker images` empty, dockerd with **no outbound connections** (not downloading — wedged in the pull coordinator).
- The node health-check only probes **liveness** (`docker info`), not **pull-ability**, so the wedged node stays `healthy` and keeps receiving placements → agents stuck.

## Fix

1. **Reap orphaned pulls (always on):** after a failed pre-pull, `SIGKILL` any `docker pull` on the node. SIGKILL (unlike the channel-close SIGHUP) drops the CLI so dockerd cancels the pull → retries start from a clean daemon and can never accumulate into a wedge. This alone would have prevented the incident.
2. **Self-heal (opt-in, `CONTAINERS_PREPULL_SELF_HEAL_RESTART=true`, default off):** after 2 consecutive failed pre-pulls on a node, restart docker on it (rate-limited to one per 30 min) so an already-wedged daemon auto-recovers with no manual ops. Requires `live-restore=true` (already set in the node bootstrap `daemon.json`) so running agent containers survive.
3. A successful pull clears the per-node failure counter.

## Evidence
Live on staging `robot-1`: dockerd responsive (`docker ps/info` fine) but every `docker pull` of the agent image hung with no downloads; 68 accumulated temp leases; a manual `systemctl restart docker` (live-restore on) cleared it **without bouncing the 4 running agents** — this PR automates + prevents that.

## Testing
Not typechecked locally (worktree unbuilt) — relying on CI. Follow-ups: a unit test asserting a timed-out pre-pull issues the `pkill -9` reap + (with the flag) the rate-limited restart; and a **pull-ability probe** in the node health-check so placement routes around a wedged node instead of stalling on it.
