### PR TITLE
fix(#13844): wire multitask_bench into ci_coverage + results matrix (1:1 guard)

### DIFF
--- a/packages/benchmarks/docs/RESULTS_MATRIX.md
+++ b/packages/benchmarks/docs/RESULTS_MATRIX.md
@@ -4,7 +4,7 @@ This matrix is reconciled against the **registry** (the canonical source of
 truth in `registry/commands.py`) and the orchestrator's adapter discovery
 (#10193). It is split into two clearly-labeled sections:
 
-1. **Registered benchmarks (45)** — every id declared in `registry/commands.py`.
+1. **Registered benchmarks (50)** — every id declared in `registry/commands.py`.
 2. **Adapter-discovered / non-registry (9)** — ids exposed only as orchestrator
    adapters, with no registry entry (`orchestrator.discover_adapters` minus the
    registry). These are runnable but are **not** part of the canonical registry.
@@ -57,7 +57,7 @@ harnesses live there and must never leak into this matrix).
 
 ---
 
-## Registered benchmarks (45)
+## Registered benchmarks (50)
 
 `lane` is the CI lane from `orchestrator/ci_coverage.py`
 (`scheduled` / `smoke` / `manual`). The four score columns show the posted
@@ -92,6 +92,7 @@ or `gated`.
 | mmau | manual | gated | gated | gated | gated |
 | mmlu | smoke | 1.00 | 1.00 | 1.00 | 1.00 |
 | mt_bench | smoke | not-run | not-run | not-run | gated |
+| multitask_bench | smoke | not-run | not-run | not-run | gated |
 | openclaw_bench | smoke | not-run | not-run | not-run | gated |
 | orchestrator_lifecycle | smoke | not-run | not-run | not-run | gated |
 | osworld | manual | gated | gated | gated | gated |
@@ -116,7 +117,7 @@ or `gated`.
 | webshop | smoke | not-run | not-run | not-run | gated |
 | woobench | smoke | 0.89 | 0.89 | 0.93 | 0.91 |
 
-**Registered totals:** 49 benchmarks. 15 have a real posted score (from the
+**Registered totals:** 50 benchmarks. 15 have a real posted score (from the
 2026-05-28 certification pass, `benchmark_results/latest/`); the rest are
 `not-run` (no committed graded run) or `gated` (infra/credentials required).
 
@@ -152,7 +153,7 @@ openclaw agent stacks (infra-gated successor scope, #10199 / #10193).
 ## Adapter-discovered / non-registry (9)
 
 These ids are exposed by `orchestrator.discover_adapters` but have **no entry
-in `registry/commands.py`**. They are not part of the canonical 45 and have no
+in `registry/commands.py`**. They are not part of the canonical 50 and have no
 committed graded `latest/` run — they are shown for completeness only.
 
 | benchmark | lane | eliza | hermes | openclaw | smithers |
@@ -185,7 +186,7 @@ registry in three ways, all fixed here:
   are quarantined into the clearly-labeled non-registry section above; the other
   2 (`compactbench`, `loca_bench`) were part of the phantom set removed.
 
-The registered set (45), the non-registry adapter set (9), the lane cells, and
+The registered set (50), the non-registry adapter set (9), the lane cells, and
 the certified numeric rows here are kept in sync by
 `tests/test_results_matrix_sync.py`; the CI lane taxonomy itself is pinned by
 `tests/test_ci_coverage.py`.

--- a/packages/benchmarks/orchestrator/ci_coverage.py
+++ b/packages/benchmarks/orchestrator/ci_coverage.py
@@ -64,6 +64,7 @@ CI_LANE_BY_BENCHMARK: dict[str, str] = {
     "mt_bench": "smoke",
     "openclaw_bench": "smoke",
     "orchestrator_lifecycle": "smoke",
+    "multitask_bench": "smoke",  # hermetic perfect/wrong oracle lanes; live eliza/hermes/openclaw are key-gated
     "realm": "smoke",
     "recall_bench": "smoke",
     "rlm_bench": "smoke",


### PR DESCRIPTION
## Post-merge audit fix for #13844 (multitask-bench, epic #13766)

PR #13844 registered the `multitask_bench` benchmark in `registry/commands.py` but did **not** wire it into the two 1:1 registry-reconciliation guards. Both suite-level tests are **currently red on develop tip**:

```
tests/test_ci_coverage.py::test_registry_count_matches_classified_registry_subset
  AssertionError: registered benchmarks with NO CI lane: ['multitask_bench']
tests/test_ci_coverage.py::test_every_public_benchmark_has_a_ci_lane_or_manual_marker  FAILED
tests/test_ci_coverage.py::test_classified_count_equals_public_benchmark_count  FAILED
tests/test_results_matrix_sync.py::test_registered_results_matrix_rows_match_registry_exactly
  AssertionError: 45 == 50  (registry has 50 registered benchmarks; matrix header says 45, row for multitask_bench missing)
```

These are the de-larp guards the benchmarks suite maintains (#9475/#10193): a benchmark cannot be registered without an explicit CI lane and a reconciled results-matrix row.

### Fix
- `orchestrator/ci_coverage.py`: add `multitask_bench: smoke`. Its CI-runnable path is the hermetic `perfect`/`wrong` oracle (the 16 pytest cases); the live `eliza`/`hermes`/`openclaw` lanes are Cerebras-key- and (for eliza) `MULTITASK_ELIZA_USAGE_FIX`-gated — the same shape as the other no-key-oracle smoke benchmarks.
- `docs/RESULTS_MATRIX.md`: add the `multitask_bench | smoke | not-run | not-run | not-run | gated` row (honest non-score cells — no certified 4-harness scores exist) and bump every stale registered-count `45 -> 50` (`49 -> 50` in the totals line).

### Verification (develop tip + this branch)
```
python3 -m pytest packages/benchmarks/tests/ -q           -> 168 passed (was 3 failing)
python3 -m pytest packages/benchmarks/multitask-bench/tests/ -q -> 16 passed
python -m benchmarks.orchestrator list-benchmarks | grep multitask -> present
```

No production code touched — registry wiring + doc reconciliation only. Fix-forward on merged work; nothing reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)