### PR TITLE
fix(#13774): do not clobber an existing SKILLS.md in a non-isolated spawn workdir

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -423,6 +423,50 @@ describe("AcpService", () => {
     }
   });
 
+  it("does not clobber an existing SKILLS.md in a non-isolated workdir", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "acp-skills-existing-"));
+    try {
+      const existing = "# Repo's own SKILLS.md\nDo not overwrite me.\n";
+      await fs.writeFile(join(dir, "SKILLS.md"), existing, "utf8");
+      const skillsService = {
+        getEligibleSkills: async () => [
+          {
+            slug: "github",
+            name: "GitHub",
+            description: "gh CLI usage.",
+            content: "# GitHub\n",
+          },
+        ],
+        isSkillEnabled: () => true,
+      };
+      const reg = nextProc();
+      const service = new AcpService(
+        runtime({}, { AGENT_SKILLS_SERVICE: skillsService }),
+      );
+      await service.start();
+      // workdir supplied without isolateWorkdir → isolate=false → writes into
+      // the real repo root; the pre-existing SKILLS.md must survive.
+      const promise = service.spawnSession({
+        name: "skills-existing",
+        agentType: "codex",
+        workdir: dir,
+      });
+      await waitForSpawn(reg);
+      reg.proc.stdout.emit(
+        "data",
+        Buffer.from(
+          '{"jsonrpc":"2.0","method":"session_started","params":{"sessionId":"skills-existing"}}\n',
+        ),
+      );
+      closeOk(reg);
+      await promise;
+
+      expect(readFileSync(join(dir, "SKILLS.md"), "utf8")).toBe(existing);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("advertises the broker in SKILLS.md + manual when the router is wired", async () => {
     const dir = mkdtempSync(join(tmpdir(), "acp-skills-broker-"));
     try {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -1232,6 +1232,13 @@ export class AcpService extends Service {
    * adds the recommended-slug highlight and Cloud ViewKind contract for
    * app-building tasks. Best-effort — a failed write warns and the spawn
    * proceeds without the manifest.
+   *
+   * Skips a workspace that already carries its own `SKILLS.md` — a non-isolated
+   * spawn (routed self-checkout / explicit project workdir, `isolate=false`)
+   * runs inside a real repo whose own `SKILLS.md` must never be clobbered. This
+   * mirrors {@link writeWorkspaceIdentity}'s bare-workspace guard for
+   * AGENTS.md/CLAUDE.md; an isolated `task-<id>` scratch dir is always empty so
+   * the guard is a no-op there.
    */
   private async writeSkillsManifest(
     workdir: string,
@@ -1239,6 +1246,7 @@ export class AcpService extends Service {
     brokerWired: boolean,
     opts: SpawnOptions,
   ): Promise<void> {
+    if (existsSync(join(workdir, "SKILLS.md"))) return;
     try {
       const manifest = await buildSkillsManifest(this.runtime, {
         ...(opts.skillsManifest?.recommendedSlugs


### PR DESCRIPTION
## What

Post-merge audit fix for #13838 (subagent context delivery, part of epic #13766).

#13838 writes `SKILLS.md` on the **shared** spawn path (`AcpService.writeSkillsManifest`) for every spawn. Its sibling `writeWorkspaceIdentity` guards `AGENTS.md`/`CLAUDE.md` against clobbering a real repo's own files (bare-workspace `existsSync` check), but the `SKILLS.md` write skipped that guard and did an **unconditional** `writeFile(join(workdir, "SKILLS.md"), …)`.

## Failure scenario

A non-isolated spawn (`isolate=false`) is reachable in production: `actions/tasks.ts:1197` sets `isolateWorkdir = effectiveRoute ? false : …`, and `computeSessionWorkdir(base, id, false)` returns `resolve(base)` — the real project directory the task was routed to. So when a task is routed to a repo that has its own root `SKILLS.md`, the spawn silently overwrites it. Because teardown/startup GC only reclaims owned `task-<id>` scratch dirs (`isOwnedScratchDir`), the clobbered file **persists** after the spawn ends — durable data loss in the user's repo.

The PR author already recognized this hazard for AGENTS.md/CLAUDE.md (see the `writeWorkspaceIdentity` doc comment: "only when the workspace is bare, so a real repo's own AGENTS.md/CLAUDE.md is never clobbered"); SKILLS.md just missed the same guard.

## Fix

Skip the `SKILLS.md` write when the workspace already carries one, mirroring the `writeWorkspaceIdentity` bare-workspace guard. Isolated `task-<id>` scratch dirs are always freshly `mkdir`'d and empty, so the guard is a no-op there — every isolated spawn still gets its manifest.

## Test

Adds a regression test (`does not clobber an existing SKILLS.md in a non-isolated workdir`) that pre-seeds `SKILLS.md` in a `workdir`-supplied (non-isolated) spawn and asserts the original content survives. Verified it **fails** without the guard and **passes** with it. Existing SKILLS.md tests ("writes SKILLS.md into every spawn workspace", broker advertisement) stay green.

## Scope / safety

- No security-gate changes: the `/skills` bridge endpoints keep their loopback + GET + active-session gates; slug still routed through `parseSessionId` (rejects `/` and `..`) and matched exactly against the in-memory eligible-skills list — no path is built from the slug, so no traversal.
- No spend/confirmation gate touched; broker advertisement wiring gate unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)