### PR TITLE
fix(#14040): surface cloud resume progress without no-provider redirects

### DIFF
--- a/packages/ui/src/api/client-agent-resume-progress.test.ts
+++ b/packages/ui/src/api/client-agent-resume-progress.test.ts
@@ -1,0 +1,185 @@
+/**
+ * #14040 sub-defect 2: the cloud dedicated-agent-proxy answers `GET /api/status`
+ * with `202 { data: { status:"starting", jobId, retryAfterMs } }` while a
+ * dedicated agent warms. Previously `getStatus()` sent that through the
+ * `rawRequest` resume-retry loop, which (after exhausting its budget) threw
+ * `agent_resuming` — swallowed by the readiness poll's catch, so the launcher
+ * showed a spinner with no progress signal. `getStatus()` must instead surface
+ * the FIRST 202 body as an explicit progress `AgentStatus` (state:"starting" +
+ * resumeProgress) WITHOUT blocking on the retry loop.
+ *
+ * Transport stubbed, no live agent, no desktop RPC (plain HTTP status path).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config";
+import { ElizaClient } from "./client-base";
+import "./client-agent";
+import type { AgentRequestTransport } from "./transport";
+
+function makeClient(handler: AgentRequestTransport["request"]): ElizaClient {
+  const client = new ElizaClient("http://agent.example:31337", "token");
+  client.setRequestTransport({ request: vi.fn(handler) });
+  return client;
+}
+
+describe("ElizaClient.getStatus cloud resume progress (#14040 sub-defect 2)", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+    vi.restoreAllMocks();
+    // No desktop electrobun RPC / native lifecycle — force the plain HTTP path.
+    Reflect.deleteProperty(globalThis, "window");
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, "window");
+  });
+
+  it("surfaces a 202 resume body as an honest progress AgentStatus (no throw, no retry wait)", async () => {
+    let calls = 0;
+    const client = makeClient(async (url) => {
+      const path = new URL(url).pathname;
+      if (path === "/api/status") {
+        calls += 1;
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              agentId: "agent-1",
+              status: "starting",
+              jobId: "resume-job-42",
+              alreadyInProgress: false,
+              retryAfterMs: 5000,
+            },
+          }),
+          {
+            status: 202,
+            headers: { "content-type": "application/json", "Retry-After": "5" },
+          },
+        );
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const status = await client.getStatus();
+
+    // Explicit progress state — NOT undefined/unreachable, NOT a thrown error.
+    expect(status.state).toBe("starting");
+    expect(status.canRespond).toBe(false);
+    expect(status.resumeProgress).toMatchObject({
+      status: "starting",
+      jobId: "resume-job-42",
+      retryAfterMs: 5000,
+      alreadyInProgress: false,
+    });
+    // Each observation is stamped so a single long-running resume still
+    // advances the launcher's progress signal on every probe (#14040 sub-3).
+    expect(typeof status.resumeProgress?.observedAt).toBe("number");
+    // Crucially: it returned on the FIRST 202 — the resume-retry loop (which
+    // would have re-issued the request up to 6 more times, ~30s of waiting)
+    // was skipped for the status poll.
+    expect(calls).toBe(1);
+  });
+
+  it("returns a normal running status verbatim when the agent is up (200)", async () => {
+    const client = makeClient(async (url) => {
+      const path = new URL(url).pathname;
+      if (path === "/api/status") {
+        return new Response(
+          JSON.stringify({
+            state: "running",
+            agentName: "Eliza",
+            model: "gpt-4",
+            canRespond: true,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    await expect(client.getStatus()).resolves.toEqual({
+      state: "running",
+      agentName: "Eliza",
+      model: "gpt-4",
+      canRespond: true,
+    });
+  });
+
+  it("tolerates a 202 with no parseable resume body (defaults to a starting progress state)", async () => {
+    const client = makeClient(async (url) => {
+      const path = new URL(url).pathname;
+      if (path === "/api/status") {
+        return new Response("not json", { status: 202 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const status = await client.getStatus();
+    expect(status.state).toBe("starting");
+    expect(status.resumeProgress).toMatchObject({ status: "starting" });
+    expect(typeof status.resumeProgress?.observedAt).toBe("number");
+  });
+
+  it("throws on a malformed 200 status body instead of masking it as an empty not-ready status", async () => {
+    const client = makeClient(async (url) => {
+      const path = new URL(url).pathname;
+      if (path === "/api/status") {
+        // 200 OK but non-JSON — a broken/proxy-corrupted status endpoint.
+        return new Response("<html>gateway error</html>", { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    // Must surface as an error (matching the pre-fix `this.fetch` contract),
+    // NOT a silent empty status that leaves the launcher polling forever.
+    await expect(client.getStatus()).rejects.toThrow();
+  });
+
+  it("throws on a non-202 status error (500) instead of masking it as not-ready", async () => {
+    const client = makeClient(async (url) => {
+      const path = new URL(url).pathname;
+      if (path === "/api/status") {
+        return new Response(JSON.stringify({ error: "boom" }), {
+          status: 500,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    // A broken status endpoint must surface as an error (the readiness poll's
+    // catch keeps polling), NOT a silent not-ready spinner — preserving the
+    // pre-fix `this.fetch("/api/status")` throw for non-202 failures.
+    await expect(client.getStatus()).rejects.toThrow();
+  });
+
+  it("stamps a distinct observedAt on successive 202 polls (progress advances even for a stable job)", async () => {
+    const client = makeClient(async (url) => {
+      const path = new URL(url).pathname;
+      if (path === "/api/status") {
+        // SAME status + jobId every poll — a single long-running resume.
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: { status: "starting", jobId: "stable-job" },
+          }),
+          { status: 202, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const a = await client.getStatus();
+    // Ensure the clock advances between observations.
+    await new Promise((r) => setTimeout(r, 2));
+    const b = await client.getStatus();
+
+    expect(a.resumeProgress?.jobId).toBe("stable-job");
+    expect(b.resumeProgress?.jobId).toBe("stable-job");
+    // Same job, but each observation is stamped distinctly → the launcher's
+    // progress token advances, resetting the slow-boot window (#14040 sub-3).
+    expect(b.resumeProgress?.observedAt).toBeGreaterThanOrEqual(
+      a.resumeProgress?.observedAt ?? 0,
+    );
+  });
+});

--- a/packages/ui/src/api/client-agent-resume-progress.test.ts
+++ b/packages/ui/src/api/client-agent-resume-progress.test.ts
@@ -64,7 +64,8 @@ describe("ElizaClient.getStatus cloud resume progress (#14040 sub-defect 2)", ()
 
     // Explicit progress state — NOT undefined/unreachable, NOT a thrown error.
     expect(status.state).toBe("starting");
-    expect(status.canRespond).toBe(false);
+    // A transient cloud wake is not an authoritative no-provider signal.
+    expect(status.canRespond).toBeUndefined();
     expect(status.resumeProgress).toMatchObject({
       status: "starting",
       jobId: "resume-job-42",

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -1276,12 +1276,13 @@ function map202ToResumeProgressStatus(body: unknown): AgentStatus {
   const resumeProgress = { ...parsed, observedAt: Date.now() };
   // An in-flight resume is honest progress, not "unreachable": report a
   // starting state carrying the proxy's progress so `deriveAgentReady` stays
-  // false (correct — not ready yet) while the UI can distinguish it.
+  // false (correct — not ready yet) while the UI can distinguish it. Leave
+  // `canRespond` unknown here; `false` is reserved for the authoritative
+  // no-provider signal and would make a transient cloud wake look misconfigured.
   return {
     state: "starting",
     agentName: "Eliza",
     model: undefined,
-    canRespond: false,
     uptime: undefined,
     startedAt: undefined,
     resumeProgress,

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -1224,6 +1224,88 @@ declare module "./client-base" {
 }
 
 // ---------------------------------------------------------------------------
+// Cloud resume-progress (#14040 sub-defect 2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Map the cloud dedicated-agent-proxy's `202` resume body
+ * (`{success:true,data:{status:"starting",jobId,retryAfterMs,alreadyInProgress}}`)
+ * to an {@link AgentStatus.resumeProgress}. Returns `undefined` when the body
+ * doesn't look like a resume payload (so callers can fall back to their normal
+ * parse), never throws.
+ */
+function parseResumeProgress(
+  body: unknown,
+): AgentStatus["resumeProgress"] | undefined {
+  if (!body || typeof body !== "object") return undefined;
+  const data = (body as { data?: unknown }).data;
+  const src = (data && typeof data === "object" ? data : body) as Record<
+    string,
+    unknown
+  >;
+  const status = typeof src.status === "string" ? src.status : undefined;
+  if (!status) return undefined;
+  const jobId = typeof src.jobId === "string" ? src.jobId : undefined;
+  const retryAfterMs =
+    typeof src.retryAfterMs === "number" && Number.isFinite(src.retryAfterMs)
+      ? src.retryAfterMs
+      : undefined;
+  const alreadyInProgress =
+    typeof src.alreadyInProgress === "boolean"
+      ? src.alreadyInProgress
+      : undefined;
+  return { status, jobId, retryAfterMs, alreadyInProgress };
+}
+
+/**
+ * Fetch `/api/status` as a readiness poll, surfacing an in-flight cloud resume
+ * (`202`) as an explicit progress {@link AgentStatus} instead of blocking on
+ * the resume-retry loop and throwing `agent_resuming` (#14040 sub-defect 2).
+ *
+ * On a `202` the returned status is `state:"starting"` + `resumeProgress`, so
+ * the launcher can render "resuming…" and reset its slow-boot escalation on
+ * fresh progress. On a normal (non-202) response it returns the parsed status
+ * verbatim, so the running/stopped path is byte-for-byte unchanged.
+ */
+function map202ToResumeProgressStatus(body: unknown): AgentStatus {
+  const parsed = parseResumeProgress(body) ?? { status: "starting" };
+  // Stamp THIS observation so a single long-running resume (same status/jobId
+  // across polls) still advances the launcher's progress signal on every
+  // successful probe — otherwise a slow-but-live resume would look stalled and
+  // wrongly trip the slow-boot escalation (#14040 sub-defect 3).
+  const resumeProgress = { ...parsed, observedAt: Date.now() };
+  // An in-flight resume is honest progress, not "unreachable": report a
+  // starting state carrying the proxy's progress so `deriveAgentReady` stays
+  // false (correct — not ready yet) while the UI can distinguish it.
+  return {
+    state: "starting",
+    agentName: "Eliza",
+    model: undefined,
+    canRespond: false,
+    uptime: undefined,
+    startedAt: undefined,
+    resumeProgress,
+  };
+}
+
+async function fetchStatusWithResumeProgress(
+  client: ElizaClient,
+): Promise<AgentStatus> {
+  // Reuse `fetch`'s shared, bounded body-read + strict-parse (a stalled status
+  // body must TIME OUT, never wedge the 1.5s readiness poll — codex review),
+  // and its throw-on-error semantics: a non-202 non-OK status (500/503) or a
+  // malformed 200 body still throws, so a broken status endpoint reads as an
+  // error, not a silent not-ready spinner. `skipResume` returns the FIRST 202
+  // untouched so `on202` can map the cloud resume-progress body ourselves
+  // instead of blocking on the resume loop + throwing `agent_resuming`
+  // (#14040 sub-defect 2).
+  return client.fetch<AgentStatus>("/api/status", undefined, {
+    skipResume: true,
+    on202: map202ToResumeProgressStatus,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Prototype augmentation
 // ---------------------------------------------------------------------------
 
@@ -1300,7 +1382,11 @@ ElizaClient.prototype.getStatus = async function (this: ElizaClient) {
     }
     return native;
   }
-  return this.fetch("/api/status");
+  // Plain HTTP status path (cloud dedicated agent / web): surface an in-flight
+  // resume `202` as explicit progress instead of blocking on the resume-retry
+  // loop and throwing `agent_resuming` that the readiness poll swallows
+  // (#14040 sub-defect 2).
+  return fetchStatusWithResumeProgress(this);
 };
 
 ElizaClient.prototype.getBootProgress = async function (this: ElizaClient) {

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -825,6 +825,15 @@ export class ElizaClient {
        *  loop starts waiting (#8628). Lets the chat surface a `waking` status
        *  while the agent boots. */
       onResuming?: () => void;
+      /** Skip the bounded 202 resume-retry loop and return the FIRST 202 body
+       *  as-is (#14040 sub-defect 2). The chat/stream path wants the eventual
+       *  real reply, so it keeps the loop; the readiness/status poll instead
+       *  wants to surface the 202 progress body (`{status:"starting",jobId,
+       *  retryAfterMs}`) as an honest "resuming" state on EVERY tick, rather
+       *  than blocking ~30s then throwing `agent_resuming` (which the poll
+       *  swallowed → spinner with no progress). Implies `allowNonOk` for the
+       *  202. */
+      skipResume?: boolean;
     },
   ): Promise<Response> {
     if (!this.apiAvailable) {
@@ -860,6 +869,12 @@ export class ElizaClient {
     // loop entirely, so ordinary requests are byte-for-byte unaffected.
     let resumeRetries = 0;
     if (res.status === 202) options?.onResuming?.();
+    // Status/readiness poll opts out of the wait-and-retry loop: it wants the
+    // live 202 progress body back immediately so it can render honest progress
+    // (#14040 sub-defect 2). Return the first 202 response untouched.
+    if (res.status === 202 && options?.skipResume) {
+      return res;
+    }
     while (res.status === 202 && resumeRetries < RESUME_MAX_RETRIES) {
       if (init?.signal?.aborted) break;
       await sleepUnlessAborted(resumeRetryDelayMs(res), init?.signal);
@@ -1099,7 +1114,20 @@ export class ElizaClient {
   async fetch<T>(
     path: string,
     init?: RequestInit,
-    options?: { allowNonOk?: boolean; timeoutMs?: number },
+    options?: {
+      allowNonOk?: boolean;
+      timeoutMs?: number;
+      /** Skip the 202 resume-retry loop (see `rawRequest.skipResume`). */
+      skipResume?: boolean;
+      /**
+       * Called with the (bounded-read, best-effort-parsed) body when the FIRST
+       * response is a 202 and `skipResume` is set — lets the status poll map the
+       * cloud resume-progress body to a real value WITHOUT bypassing the shared
+       * bounded body-read / timeout logic (#14040 sub-defect 2). Non-202
+       * responses go through the normal strict-parse path unchanged.
+       */
+      on202?: (body: unknown) => T;
+    },
   ): Promise<T> {
     const res = await this.rawRequest(
       path,
@@ -1114,6 +1142,23 @@ export class ElizaClient {
     );
     if (res.status === 204) {
       return undefined as T;
+    }
+    // 202 resume-progress (status poll only): read the body with the SAME
+    // bounded budget as any other body (never an unbounded `res.text()` — a
+    // stalled body must time out, not wedge the 1.5s poll), best-effort parse,
+    // and hand it to the caller's mapper. The proxy body is advisory, so a
+    // non-JSON 202 is tolerated (mapper still gets `undefined`).
+    if (res.status === 202 && options?.on202) {
+      const raw = await this.readBodyText(res, path, options?.timeoutMs, init);
+      let body: unknown;
+      if (raw !== "") {
+        try {
+          body = JSON.parse(raw);
+        } catch {
+          /* non-JSON 202 progress body — mapper defaults it */
+        }
+      }
+      return options.on202(body);
     }
     const text = await this.readBodyText(res, path, options?.timeoutMs, init);
     if (text === "") {
@@ -1767,7 +1812,15 @@ export class ElizaClient {
         buffer = buffer.slice(eventBreak.index + eventBreak.length);
         for (const line of rawEvent.split(/\r?\n/)) {
           if (!line.startsWith("data:")) continue;
-          if (applyStreamChatDataLine(line, streamState, onToken, onStatus, onToolEvent)) {
+          if (
+            applyStreamChatDataLine(
+              line,
+              streamState,
+              onToken,
+              onStatus,
+              onToolEvent,
+            )
+          ) {
             buffer = "";
             // error-policy:J6 best-effort reader teardown after terminal done.
             void reader
@@ -1785,7 +1838,13 @@ export class ElizaClient {
     if (!streamState.receivedDone && buffer.trim()) {
       for (const line of buffer.split(/\r?\n/)) {
         if (line.startsWith("data:")) {
-          applyStreamChatDataLine(line, streamState, onToken, onStatus, onToolEvent);
+          applyStreamChatDataLine(
+            line,
+            streamState,
+            onToken,
+            onStatus,
+            onToolEvent,
+          );
         }
       }
     }

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -1155,7 +1155,7 @@ export class ElizaClient {
         try {
           body = JSON.parse(raw);
         } catch {
-          /* non-JSON 202 progress body — mapper defaults it */
+          // error-policy:J3 untrusted 202 progress body defaults to an explicit starting progress state.
         }
       }
       return options.on202(body);

--- a/packages/ui/src/api/client-types-core.ts
+++ b/packages/ui/src/api/client-types-core.ts
@@ -151,6 +151,41 @@ export interface AgentStatus {
   pendingRestart?: boolean;
   pendingRestartReasons?: string[];
   startup?: AgentStartupDiagnostics;
+  /**
+   * Live resume/provision progress for a dedicated cloud agent that answered
+   * the status probe with `202 Accepted` while it warms (#14040 sub-defect 2).
+   * Present only during an in-flight resume; carries the cloud proxy's honest
+   * progress body (`{status,jobId,retryAfterMs}`) so the launcher can render a
+   * "resuming…" state (and reset its slow-boot escalation) instead of an
+   * indistinguishable spinner. Absent for a normal running/stopped status.
+   */
+  resumeProgress?: AgentResumeProgress;
+}
+
+/**
+ * The cloud dedicated-agent-proxy's `202` resume body, mapped onto
+ * {@link AgentStatus.resumeProgress}. A truthy `jobId` (or any freshly-observed
+ * progress) is the launcher's "boot is still making progress" signal.
+ */
+export interface AgentResumeProgress {
+  /** The proxy's `status` field for the in-flight resume (e.g. "starting"). */
+  status: string;
+  /** The resume job's id when the proxy reports one; a change signals progress. */
+  jobId?: string;
+  /** Advertised retry interval (ms) the proxy asked the client to wait. */
+  retryAfterMs?: number;
+  /** True when the proxy reported the resume was already underway. */
+  alreadyInProgress?: boolean;
+  /**
+   * Client-side timestamp (ms) of THIS observed resume probe. A single
+   * long-running resume keeps the same `status`/`jobId` across polls, so those
+   * alone can't distinguish "still progressing" from "stalled"; a fresh
+   * `observedAt` on every successful 202 is the "a live probe just succeeded"
+   * heartbeat that resets the launcher's slow-boot escalation window (#14040
+   * sub-defect 3). Stamped by the status client on each observation, not by the
+   * server.
+   */
+  observedAt?: number;
 }
 
 export interface AgentBootProgress {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.boot-status.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.boot-status.test.tsx
@@ -8,6 +8,7 @@
 // (the callback opens settings; the label must say so, not imply a retry).
 
 import { act, cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -85,5 +86,91 @@ describe("BootStatusIndicator", () => {
     );
 
     expect(container.querySelector(".animate-spin")).toBeNull();
+  });
+});
+
+// #14040 sub-defect 3: the slow-boot escalation must key off ABSENCE of
+// progress, not raw elapsed wall-clock. A boot that keeps reporting fresh
+// progress (a changing `progressSignal`) never trips "taking longer than
+// usual"; a genuinely stalled boot (stable token) still does.
+describe("BootStatusIndicator progress-aware escalation (#14040 sub-defect 3)", () => {
+  it("does NOT escalate while progress keeps arriving, even past BOOT_SLOW_AFTER_MS", () => {
+    vi.useFakeTimers();
+    // A thin harness so we can push a new progressSignal between timer advances.
+    function Harness() {
+      const [signal, setSignal] = React.useState("tick-0");
+      return (
+        <>
+          <button
+            type="button"
+            data-testid="advance-progress"
+            onClick={() => setSignal((s) => `tick-${Number(s.slice(5)) + 1}`)}
+          />
+          <BootStatusIndicator
+            agentName="Eliza"
+            onOpenSettings={vi.fn()}
+            progressSignal={signal}
+          />
+        </>
+      );
+    }
+    render(<Harness />);
+
+    // Advance ALMOST to the threshold, then report progress (resets the window),
+    // repeatedly — total elapsed far exceeds BOOT_SLOW_AFTER_MS but each window
+    // is reset before it fires.
+    for (let i = 0; i < 4; i += 1) {
+      act(() => {
+        vi.advanceTimersByTime(BOOT_SLOW_AFTER_MS - 1_000);
+      });
+      // Fresh progress observed — the escalation window restarts.
+      act(() => {
+        screen.getByTestId("advance-progress").click();
+      });
+    }
+
+    // Cumulative elapsed ≈ 4 × (90s - 1s) = 356s ≫ 90s, yet still not slow.
+    expect(
+      screen.getByTestId("chat-boot-status").getAttribute("data-slow"),
+    ).toBeNull();
+    expect(screen.getByTestId("chat-boot-status").textContent).toContain(
+      "Waking Eliza…",
+    );
+  });
+
+  it("escalates when progress stalls (token stable for the full window)", () => {
+    vi.useFakeTimers();
+    render(
+      <BootStatusIndicator
+        agentName="Eliza"
+        onOpenSettings={vi.fn()}
+        progressSignal="stalled"
+      />,
+    );
+
+    // No new progressSignal for the whole window — a genuine stall still trips.
+    act(() => {
+      vi.advanceTimersByTime(BOOT_SLOW_AFTER_MS);
+    });
+
+    expect(
+      screen.getByTestId("chat-boot-status").getAttribute("data-slow"),
+    ).toBe("true");
+    expect(screen.getByTestId("chat-boot-status").textContent).toContain(
+      "taking longer than usual",
+    );
+  });
+
+  it("falls back to raw-elapsed escalation when no progressSignal is supplied", () => {
+    vi.useFakeTimers();
+    render(<BootStatusIndicator agentName="Eliza" onOpenSettings={vi.fn()} />);
+
+    act(() => {
+      vi.advanceTimersByTime(BOOT_SLOW_AFTER_MS);
+    });
+
+    expect(
+      screen.getByTestId("chat-boot-status").getAttribute("data-slow"),
+    ).toBe("true");
   });
 });

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -86,13 +86,13 @@ import { SensitiveRequestBlock } from "../chat/MessageContent";
 import { findChoiceRegions } from "../chat/message-choice-parser";
 import { ThinkingBlock } from "../chat/ThinkingBlock";
 import { withTranscriptMarker } from "../chat/TranscriptViewerOverlay";
-import { ToolCallEventLog } from "../tool-events/ToolCallEventLog";
 import { ChatMessage } from "../composites/chat/chat-message";
 import type {
   ChatMessageData,
   ChatMessageRenderContext,
 } from "../composites/chat/chat-types";
 import { TurnStatus } from "../composites/chat/chat-typing-indicator";
+import { ToolCallEventLog } from "../tool-events/ToolCallEventLog";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Textarea } from "../ui/textarea";
@@ -630,9 +630,12 @@ function TurnStatusIndicator({
   );
 }
 
-// After this long still booting, the banner escalates to a "taking longer than
-// usual" state with a settings escape, so a stuck boot never reads as a silent
-// hang. Exported for the unit test (see the __-seam note below).
+// After this long WITHOUT OBSERVED PROGRESS still booting, the banner escalates
+// to a "taking longer than usual" state with a settings escape, so a truly
+// stuck boot never reads as a silent hang — but a slow-yet-progressing boot
+// does NOT trip it (#14040 sub-defect 3): the escalation keys off
+// absence-of-progress, not raw elapsed wall-clock. Exported for the unit test
+// (see the __-seam note below).
 export const BOOT_SLOW_AFTER_MS = 90_000;
 
 // Grace before the banner appears: a warm agent leaves the "booting" phase
@@ -653,19 +656,36 @@ export function BootStatusIndicator({
   agentName,
   onOpenSettings,
   reduce,
+  progressSignal,
 }: {
   agentName: string;
   onOpenSettings?: () => void;
   reduce?: boolean;
+  /**
+   * A token that changes whenever fresh boot progress is observed (#14040
+   * sub-defect 3). The slow-boot escalation restarts its timer on each change,
+   * so a slow-but-progressing boot never trips "taking longer than usual" while
+   * a genuinely stalled boot still escalates. When `undefined` (no progress
+   * channel available) the timer falls back to raw-elapsed escalation — the
+   * prior behaviour — by keying off a stable token.
+   */
+  progressSignal?: string;
 }): React.JSX.Element {
-  // Local elapsed timing is the only boot signal the overlay has (agentStatus
-  // carries no boot-start timestamp), and it suffices: the parent unmounts this
-  // the instant readiness flips, so the timer never outlives the boot.
+  // Escalate on ABSENCE of progress, not raw elapsed time (#14040 sub-defect
+  // 3): the timer is (re)armed on mount AND whenever `progressSignal` changes,
+  // so each fresh progress observation pushes the "taking longer than usual"
+  // threshold out by another window. A boot that keeps reporting progress never
+  // trips it; a stalled boot (token stable for BOOT_SLOW_AFTER_MS) still does.
+  // The parent unmounts this the instant readiness flips, so the timer never
+  // outlives the boot.
   const [slow, setSlow] = React.useState(false);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: progressSignal is the RESET trigger, not read in the body — re-running the effect on each change restarts the escalation window (that IS the fix for #14040 sub-defect 3). Removing it would revert to raw-elapsed escalation.
   React.useEffect(() => {
+    // Fresh progress clears any prior escalation and restarts the window.
+    setSlow(false);
     const id = window.setTimeout(() => setSlow(true), BOOT_SLOW_AFTER_MS);
     return () => window.clearTimeout(id);
-  }, []);
+  }, [progressSignal]);
   return (
     <div
       role="status"
@@ -926,6 +946,7 @@ export function ContinuousChatOverlay({
   const {
     messages,
     phase,
+    bootProgressSignal,
     responding,
     turnStatus,
     send,
@@ -3653,6 +3674,7 @@ export function ContinuousChatOverlay({
           agentName={agentName}
           onOpenSettings={openSettings}
           reduce={reduce}
+          progressSignal={bootProgressSignal}
         />
       ) : null}
 

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -211,6 +211,18 @@ export interface ShellController {
    *  showing the "Waking …" boot indicator and to explain the real cause instead.
    *  The controller also auto-navigates to Settings on its rising edge. */
   noProviderConfigured?: boolean;
+  /**
+   * A monotonically-changing token that advances whenever fresh boot progress
+   * is observed while the agent is still waking (#14040 sub-defect 3) — e.g. a
+   * cloud resume `202` reporting a live `jobId`. The boot banner keys its
+   * "taking longer than usual" escalation off ABSENCE of progress: it restarts
+   * its slow-boot timer on every change of this token, so a slow-but-
+   * progressing boot never wrongly reads as stuck, while a truly stalled boot
+   * (token never changes) still escalates. `undefined` when there is no boot
+   * progress channel (older controllers / non-cloud), in which case the banner
+   * falls back to raw-elapsed escalation.
+   */
+  bootProgressSignal?: string;
 }
 
 /**
@@ -1068,6 +1080,24 @@ export function useShellController(): ShellController {
           ? "idle"
           : "summoned";
 
+  // Boot-progress token for the slow-boot escalation (#14040 sub-defect 3). It
+  // advances whenever the readiness poll observes fresh progress while still
+  // waking: the agent process advancing its lifecycle (`state`) / opening its
+  // `port`, OR a cloud resume `202` observation (each stamped with a fresh
+  // `observedAt`, so a single long-running resume that keeps the same
+  // status/jobId STILL advances the token on every successful probe). The
+  // banner restarts its slow-boot timer on each change, so a slow-but-
+  // progressing boot never trips "taking longer than usual"; a genuinely
+  // stalled boot (no fresh observation → token stable) still escalates.
+  // `undefined` while ready so the banner (unmounted anyway) never keys off a
+  // stale token.
+  const bootProgressSignal: string | undefined = ready
+    ? undefined
+    : `${agentStatus?.state ?? ""}|${agentStatus?.port ?? ""}|` +
+      `${agentStatus?.resumeProgress?.status ?? ""}:` +
+      `${agentStatus?.resumeProgress?.jobId ?? ""}:` +
+      `${agentStatus?.resumeProgress?.observedAt ?? ""}`;
+
   // History half of the "no LLM/model provider configured" signal. The server
   // stamps an assistant turn with `failureKind: "no_provider"` when it tried to
   // answer but no provider plugin is wired. Derived from the LATEST assistant
@@ -1388,6 +1418,7 @@ export function useShellController(): ShellController {
 
   return {
     phase,
+    bootProgressSignal,
     responding,
     turnStatus,
     messages,

--- a/packages/ui/src/state/useChatLifecycle.ts
+++ b/packages/ui/src/state/useChatLifecycle.ts
@@ -51,7 +51,18 @@ const RESET_LOG_PREFIX = "[eliza][reset]";
  */
 export function readinessPollSignature(status: AgentStatus | null): string {
   if (status == null) return "∅";
-  return `${status.state}|${status.port ?? ""}|${status.canRespond ?? ""}`;
+  // Include the cloud resume-progress signal so a fresh resume tick re-renders
+  // and `setAgentStatus` fires — the launcher's slow-boot escalation keys off
+  // "a live probe was just observed". A single long-running resume keeps the
+  // same status/jobId across polls, so we key off `observedAt` (stamped per
+  // observation): each successful 202 advances the signature and resets the
+  // escalation window, so a slow-but-progressing boot never looks stalled
+  // (#14040 sub-defect 2/3). No resume in flight → empty, so the running/stopped
+  // dedupe is unchanged.
+  const resume = status.resumeProgress
+    ? `${status.resumeProgress.status}:${status.resumeProgress.jobId ?? ""}:${status.resumeProgress.observedAt ?? ""}`
+    : "";
+  return `${status.state}|${status.port ?? ""}|${status.canRespond ?? ""}|${resume}`;
 }
 
 function logResetDebug(


### PR DESCRIPTION
## Summary
- Supersedes #14075 with the same launcher-half readiness progress fix plus the reviewed no-provider correction.
- Maps cloud wake `GET /api/status -> 202` to explicit `resumeProgress` without setting `canRespond: false`, so transient resume progress cannot trigger the persisted no-provider Settings redirect.
- Keeps the progress-aware slow-boot timer from #14075: progress signals reset the slow-boot escalation, while stalled boots still escalate.

## Verification
- `bun run --cwd packages/cloud/routing build`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/ui test src/api/client-agent-resume-progress.test.ts --run`
- `bunx @biomejs/biome check packages/ui/src/api/client-agent.ts packages/ui/src/api/client-agent-resume-progress.test.ts --no-errors-on-unmatched`
- `git diff --check`

## Evidence
- Required before merge: app audit/rendered desktop+mobile proof, frontend console/network logs, backend logs, and a real cloud resume trace showing `/api/status` 202 progress followed by ready.

Refs #14040. Supersedes #14075.