### PR TITLE
test(android): wait for assistant route logs

### DIFF
--- a/packages/app/scripts/android-assistant-ime-lane.mjs
+++ b/packages/app/scripts/android-assistant-ime-lane.mjs
@@ -42,6 +42,8 @@ function defaultExec(bin, args) {
   };
 }
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 /** An adb runner bound to a serial. `exec(bin, args) => {status, stdout, stderr}` is injectable. */
 export function makeAdb(serial, exec = defaultExec, bin = "adb") {
   if (!serial) throw new Error("makeAdb: a device serial is required.");
@@ -91,6 +93,8 @@ export async function runLane({
   exec,
   pkg = DEFAULT_PACKAGE,
   imeId = DEFAULT_IME_ID,
+  settleMs = 2_500,
+  sleepFn = sleep,
 }) {
   const adb = makeAdb(serial, exec);
   const cmds = reapplyCommands(pkg, imeId);
@@ -108,6 +112,7 @@ export async function runLane({
   // point cannot hide another broken one.
   adb(["logcat", "-c"]);
   adb(["shell", "cmd", "voiceinteraction", "show"]);
+  await sleepFn(settleMs);
   const assistCaptured =
     (adb(["logcat", "-d"]).stdout || "") +
     "\n" +
@@ -119,6 +124,7 @@ export async function runLane({
 
   adb(["logcat", "-c"]);
   adb(["shell", "input", "keyevent", "KEYCODE_ASSIST"]);
+  await sleepFn(settleMs);
   const keyCaptured =
     (adb(["logcat", "-d"]).stdout || "") +
     "\n" +
@@ -138,6 +144,7 @@ export async function runLane({
     `${IME_SESSION_DEEPLINK}&action=voice&voice=1`,
     `${pkg}/.MainActivity`,
   ]);
+  await sleepFn(settleMs);
   const imeCaptured =
     (adb(["logcat", "-d"]).stdout || "") +
     "\n" +

--- a/packages/app/scripts/android-assistant-ime-lane.test.mjs
+++ b/packages/app/scripts/android-assistant-ime-lane.test.mjs
@@ -160,7 +160,11 @@ describe("runLane", () => {
 
   it("passes when role+IME applied and the assist session lands in MainActivity", async () => {
     const exec = routeAwareExec();
-    const result = await runLane({ serial: "emulator-5554", exec });
+    const result = await runLane({
+      serial: "emulator-5554",
+      exec,
+      settleMs: 0,
+    });
     expect(result.ok).toBe(true);
     expect(result.failures).toEqual([]);
     expect(result.voiceinteractionLanded).toBe(true);
@@ -185,14 +189,14 @@ describe("runLane", () => {
       "shell settings get secure default_input_method": DEFAULT_IME_ID,
       "logcat -d": allRoutesLog,
     });
-    const result = await runLane({ serial: "s", exec });
+    const result = await runLane({ serial: "s", exec, settleMs: 0 });
     expect(result.ok).toBe(false);
     expect(result.failures.join("\n")).toMatch(/assistant role not applied/);
   });
 
   it("fails when cmd voiceinteraction does not route into MainActivity", async () => {
     const exec = routeAwareExec({ voiceinteraction: "no eliza session here" });
-    const result = await runLane({ serial: "s", exec });
+    const result = await runLane({ serial: "s", exec, settleMs: 0 });
     expect(result.ok).toBe(false);
     expect(result.assistKeyLanded).toBe(true);
     expect(result.failures.join("\n")).toMatch(/cmd voiceinteraction/);
@@ -200,7 +204,7 @@ describe("runLane", () => {
 
   it("fails when KEYCODE_ASSIST does not route into MainActivity", async () => {
     const exec = routeAwareExec({ assistKey: "no eliza session here" });
-    const result = await runLane({ serial: "s", exec });
+    const result = await runLane({ serial: "s", exec, settleMs: 0 });
     expect(result.ok).toBe(false);
     expect(result.voiceinteractionLanded).toBe(true);
     expect(result.failures.join("\n")).toMatch(/KEYCODE_ASSIST/);
@@ -208,8 +212,31 @@ describe("runLane", () => {
 
   it("fails when the IME open-app path does not route into MainActivity", async () => {
     const exec = routeAwareExec({ ime: assistRouteLog });
-    const result = await runLane({ serial: "s", exec });
+    const result = await runLane({ serial: "s", exec, settleMs: 0 });
     expect(result.ok).toBe(false);
     expect(result.failures.join("\n")).toMatch(/IME open-app path/);
+  });
+
+  it("waits after each assistant route before reading logs", async () => {
+    const exec = routeAwareExec();
+    const waits = [];
+    await runLane({
+      serial: "s",
+      exec,
+      settleMs: 2_500,
+      sleepFn: async (ms) => {
+        waits.push(ms);
+      },
+    });
+
+    const cmds = exec.calls.map((a) => a.slice(2).join(" "));
+    const voiceIndex = cmds.indexOf("shell cmd voiceinteraction show");
+    const keyIndex = cmds.indexOf("shell input keyevent KEYCODE_ASSIST");
+    const imeIndex = cmds.findIndex((cmd) => cmd.startsWith("shell am start "));
+
+    expect(cmds[voiceIndex + 1]).toBe("logcat -d");
+    expect(cmds[keyIndex + 1]).toBe("logcat -d");
+    expect(cmds[imeIndex + 1]).toBe("logcat -d");
+    expect(waits).toEqual([2_500, 2_500, 2_500]);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to elizaOS/eliza#14079. That PR correctly made the Android assistant verifier fail loud, but the merged `android-assistant-ime-lane.mjs` still fires each route and immediately reads `logcat` / `dumpsys activity`. On real emulators/devices, MainActivity routing and ActivityTaskManager logging can lag behind `adb shell cmd voiceinteraction show`, `KEYCODE_ASSIST`, or the direct IME deep link, so the lane can false-red before the proof has landed.

This adds a 2.5s settle wait after each assistant route before reading logs, matching the older verifier's wait behavior. The wait is injectable so unit tests stay fast and assert all three route waits directly.

## Verification

- `bun run install:light`
- `bun run --cwd packages/app test -- scripts/lib/android-assistant-verify-lib.test.mjs scripts/android-assistant-ime-lane.test.mjs` (25 pass)
- `bunx @biomejs/biome check packages/app/scripts/android-assistant-verify.mjs packages/app/scripts/lib/android-assistant-verify-lib.mjs packages/app/scripts/lib/android-assistant-verify-lib.test.mjs packages/app/scripts/android-assistant-ime-lane.mjs packages/app/scripts/android-assistant-ime-lane.test.mjs --no-errors-on-unmatched`
- `git diff --check`
- `node --check packages/app/scripts/android-assistant-verify.mjs && node --check packages/app/scripts/android-assistant-ime-lane.mjs`

## Evidence

N/A - script/test-only Android verifier change; no app renderer/UI changed, no model/action/provider behavior changed. elizaOS/os#2 still requires rebuilt Android emulator/device evidence before closure.
