### PR TITLE
fix(#13776): stable deterministic id for the legacy-synthesized project (audit of #13851)

### DIFF
--- a/packages/core/src/utils/project-registry.test.ts
+++ b/packages/core/src/utils/project-registry.test.ts
@@ -115,6 +115,33 @@ describe("project-registry", () => {
 		expect(() => readFileSync(projectRegistryPath(env), "utf8")).toThrow();
 	});
 
+	it("synthesized legacy project keeps a stable id across reads and across the first real upsert", () => {
+		writeWorkspaceFolderConfig(
+			{ path: "/tmp/legacy-folder", bookmark: null },
+			env,
+		);
+
+		// The synthesized registry is re-minted per read; the id must not change,
+		// or a task bound during the migration window could never resolve its
+		// project again (#13776 bound-workdir lock would silently no-op).
+		const first = readProjectRegistry(env)?.projects[0]?.id;
+		const second = readProjectRegistry(env)?.projects[0]?.id;
+		expect(first).toBeTruthy();
+		expect(second).toBe(first);
+
+		// The first real write (upsert keyed by localPath) persists the SAME id,
+		// so bindings minted during the migration window survive the switch to
+		// projects.json.
+		const persisted = upsertProject(
+			{ name: "legacy-folder", localPath: "/tmp/legacy-folder" },
+			env,
+		);
+		expect(persisted.id).toBe(first);
+		expect(getProjectById(persisted.id, env)?.localPath).toBe(
+			"/tmp/legacy-folder",
+		);
+	});
+
 	it("writeProjectRegistry round-trips through disk", () => {
 		writeProjectRegistry(
 			{

--- a/packages/core/src/utils/project-registry.test.ts
+++ b/packages/core/src/utils/project-registry.test.ts
@@ -9,7 +9,6 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { writeWorkspaceFolderConfig } from "./workspace-folder-config.ts";
 import {
 	getActiveProject,
 	getProjectById,
@@ -19,6 +18,7 @@ import {
 	upsertProject,
 	writeProjectRegistry,
 } from "./project-registry.ts";
+import { writeWorkspaceFolderConfig } from "./workspace-folder-config.ts";
 
 describe("project-registry", () => {
 	let stateDir: string;

--- a/packages/core/src/utils/project-registry.ts
+++ b/packages/core/src/utils/project-registry.ts
@@ -19,7 +19,7 @@
  * namespace and is intentionally unrelated to a ProjectRecord id.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { resolveStateDir } from "./state-dir.ts";
@@ -119,6 +119,22 @@ export function readProjectRegistry(
 	return synthesizeFromLegacyWorkspaceFolder(env);
 }
 
+/**
+ * Deterministic id for the project synthesized from the legacy
+ * workspace-folder.json. The synthesized registry is re-minted on every read
+ * (reads never write), so a random id would differ between reads: a task bound
+ * during the migration window would persist a projectId that no later
+ * `getProjectById` could ever resolve, silently disabling the bound-workdir
+ * lock (#13776). Hashing the localPath keeps the id stable across reads, and
+ * because `upsertProject` keys by localPath and preserves an existing id, the
+ * first real write to projects.json persists this same id — so migration-window
+ * task bindings survive the switch off the legacy config.
+ */
+function legacyProjectId(localPath: string): string {
+	const digest = createHash("sha256").update(localPath).digest("hex");
+	return `legacy-${digest.slice(0, 16)}`;
+}
+
 function synthesizeFromLegacyWorkspaceFolder(
 	env: NodeJS.ProcessEnv,
 ): ProjectRegistry | null {
@@ -126,7 +142,7 @@ function synthesizeFromLegacyWorkspaceFolder(
 	if (!legacy?.path?.trim()) return null;
 	const now = legacy.updatedAt ?? new Date().toISOString();
 	const project: ProjectRecord = {
-		id: randomUUID(),
+		id: legacyProjectId(legacy.path),
 		name: basename(legacy.path),
 		localPath: legacy.path,
 		bookmark: legacy.bookmark,

--- a/packages/core/src/utils/project-registry.ts
+++ b/packages/core/src/utils/project-registry.ts
@@ -224,7 +224,10 @@ export function setActiveProject(
 	const projects = registry.projects.map((p) =>
 		p.id === projectId ? { ...p, lastOpenedAt: now } : p,
 	);
-	writeProjectRegistry({ ...registry, activeProjectId: projectId, projects }, env);
+	writeProjectRegistry(
+		{ ...registry, activeProjectId: projectId, projects },
+		env,
+	);
 	return { ...target, lastOpenedAt: now };
 }
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
@@ -35,7 +35,9 @@ describe("project-binding", () => {
   it("binds an explicit projectId only when it is registered", () => {
     const p = upsertProject({ name: "a", localPath: "/tmp/a" }, env);
     expect(resolveTaskProjectId({ projectId: p.id }, env)).toBe(p.id);
-    expect(resolveTaskProjectId({ projectId: "unregistered" }, env)).toBeUndefined();
+    expect(
+      resolveTaskProjectId({ projectId: "unregistered" }, env),
+    ).toBeUndefined();
   });
 
   it("binds by realpath match of the workdir against a registered project", () => {
@@ -47,14 +49,19 @@ describe("project-binding", () => {
       const p = upsertProject({ name: "real", localPath: realDir }, env);
       expect(findProjectByWorkdir(link, env)?.id).toBe(p.id);
       expect(resolveTaskProjectId({ workdir: link }, env)).toBe(p.id);
-      expect(resolveTaskProjectId({ workdir: "/tmp/nomatch" }, env)).toBeUndefined();
+      expect(
+        resolveTaskProjectId({ workdir: "/tmp/nomatch" }, env),
+      ).toBeUndefined();
     } finally {
       rmSync(realDir, { recursive: true, force: true });
     }
   });
 
   it("explicit projectId beats a conflicting workdir match", () => {
-    const a = upsertProject({ name: "a", localPath: realpathSync(os.tmpdir()) }, env);
+    const a = upsertProject(
+      { name: "a", localPath: realpathSync(os.tmpdir()) },
+      env,
+    );
     const b = upsertProject({ name: "b", localPath: "/tmp/b-somewhere" }, env);
     // workdir matches A's localPath, but explicit id names B.
     expect(
@@ -64,7 +71,10 @@ describe("project-binding", () => {
   });
 
   it("resolveBoundProjectWorkdir returns the registered localPath or null", () => {
-    const p = upsertProject({ name: "a", localPath: "/tmp/bound-project" }, env);
+    const p = upsertProject(
+      { name: "a", localPath: "/tmp/bound-project" },
+      env,
+    );
     setActiveProject(p.id, env);
     expect(resolveBoundProjectWorkdir(p.id, env)).toBe("/tmp/bound-project");
     expect(resolveBoundProjectWorkdir("stale-id", env)).toBeNull();

--- a/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
@@ -7,7 +7,11 @@
 import { mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
-import { setActiveProject, upsertProject } from "@elizaos/core";
+import {
+  setActiveProject,
+  upsertProject,
+  writeWorkspaceFolderConfig,
+} from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   findProjectByWorkdir,
@@ -65,5 +69,24 @@ describe("project-binding", () => {
     expect(resolveBoundProjectWorkdir(p.id, env)).toBe("/tmp/bound-project");
     expect(resolveBoundProjectWorkdir("stale-id", env)).toBeNull();
     expect(resolveBoundProjectWorkdir(undefined, env)).toBeNull();
+  });
+
+  it("a projectId bound via the legacy workspace-folder.json synthesis resolves back to its workdir", () => {
+    // Migration window: workspace-folder.json exists, projects.json does not.
+    // The synthesized registry is minted fresh on every read, so the bind
+    // (createTask) and the later resolve (follow-up spawn) see two separate
+    // syntheses — the id must be stable between them or the #13776
+    // bound-workdir lock silently no-ops for every legacy install.
+    const legacyDir = mkdtempSync(join(os.tmpdir(), "legacy-workdir-"));
+    try {
+      writeWorkspaceFolderConfig({ path: legacyDir, bookmark: null }, env);
+
+      const bound = resolveTaskProjectId({ workdir: legacyDir }, env);
+      expect(bound).toBeTruthy();
+      expect(resolveTaskProjectId({ workdir: legacyDir }, env)).toBe(bound);
+      expect(resolveBoundProjectWorkdir(bound, env)).toBe(legacyDir);
+    } finally {
+      rmSync(legacyDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Defect (post-merge audit of #13851)

`synthesizeFromLegacyWorkspaceFolder` in `packages/core/src/utils/project-registry.ts` minted a fresh `randomUUID()` on **every read** of the registry (reads deliberately never write). On any install in the migration window — `workspace-folder.json` present, `projects.json` not yet written (i.e. every store-distributed desktop that hasn't re-picked a folder since #13851) — this breaks the PR's own headline feature:

1. `createTask` → `resolveTaskProjectId({workdir})` realpath-matches the synthesized project and **persists** its id onto the durable task record.
2. The follow-up spawn calls `resolveBoundProjectWorkdir(projectId)` → `getProjectById` → a **second synthesis with a different random id** → `null`. The #13776 bound-workdir spawn lock silently no-ops — exactly the population the legacy bridge was built for.
3. Every task created in the window gets a **unique garbage projectId**, so `GET /tasks?projectId=` grouping is useless and the `TaskThreadDto.projectId` field exposes ids that exist in no registry.

Reproduced live with a failing test before the fix (two consecutive `resolveTaskProjectId` calls on the same workdir returned different ids; `resolveBoundProjectWorkdir` of a just-bound id returned null).

## Fix

Derive the synthesized project's id deterministically from `sha256(localPath)` (`legacy-<16 hex>`). Reads now agree with each other, and because `upsertProject` keys by `localPath` and preserves an existing id, the first real write to `projects.json` (desktop picker) persists the **same** id — bindings minted during the migration window survive the switch off the legacy config. The no-write-on-read invariant is untouched.

## Tests

- `packages/core/src/utils/project-registry.test.ts`: synthesized id stable across reads AND across the first real upsert (10/10 pass).
- `plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts`: bind-by-workdir under legacy synthesis round-trips through `resolveBoundProjectWorkdir` (5/5 pass, run with `@elizaos/core` aliased to this branch's source; fails on develop tip).

```
Test Files  1 passed (1)   Tests  10 passed (10)   # core
Test Files  1 passed (1)   Tests  5 passed (5)     # plugin (aliased core)
```

N/A - UI evidence: no rendered surface consumes projectId yet (it is a data-layer binding; the epic's UI slice is separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)