### PR TITLE
fix(ui): hold 'Signing you in…' during post-OAuth hydration — kill the login-page bounce

### DIFF
--- a/packages/ui/src/cloud/lib/steward-session.test.ts
+++ b/packages/ui/src/cloud/lib/steward-session.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+/**
+ * Steward session adapter tests pin the console-auth hold predicate: only a
+ * readable, non-expired token with an identity claim may suppress the login
+ * redirect while the provider hydrates.
+ */
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { afterEach, describe, expect, it } from "vitest";
+import { hasHydratableStewardToken } from "./steward-session";
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const b64url = (value: object) =>
+    btoa(JSON.stringify(value))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${b64url({ alg: "HS256", typ: "JWT" })}.${b64url(payload)}.sig`;
+}
+
+describe("hasHydratableStewardToken", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("accepts a non-expired identity-bearing token", () => {
+    localStorage.setItem(
+      STEWARD_TOKEN_KEY,
+      makeJwt({ sub: "user-1", exp: Math.floor(Date.now() / 1000) + 600 }),
+    );
+
+    expect(hasHydratableStewardToken()).toBe(true);
+  });
+
+  it("rejects expired, malformed, and identity-less tokens", () => {
+    localStorage.setItem(
+      STEWARD_TOKEN_KEY,
+      makeJwt({ sub: "user-1", exp: Math.floor(Date.now() / 1000) - 60 }),
+    );
+    expect(hasHydratableStewardToken()).toBe(false);
+
+    localStorage.setItem(STEWARD_TOKEN_KEY, "not-a-jwt");
+    expect(hasHydratableStewardToken()).toBe(false);
+
+    localStorage.setItem(
+      STEWARD_TOKEN_KEY,
+      makeJwt({ exp: Math.floor(Date.now() / 1000) + 600 }),
+    );
+    expect(hasHydratableStewardToken()).toBe(false);
+  });
+});

--- a/packages/ui/src/cloud/lib/steward-session.ts
+++ b/packages/ui/src/cloud/lib/steward-session.ts
@@ -30,6 +30,11 @@ import {
   StewardSessionError,
   writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
+import {
+  readStoredToken,
+  tokenIsExpired,
+} from "../shell/StewardProviderShared";
+import { decodeJwtPayload } from "./jwt";
 
 export type { ClearOpts, StewardSessionErrorCode };
 export {
@@ -57,4 +62,18 @@ export function getStewardToken(): string | null {
 /** Whether a Steward session token is currently stored in the browser. */
 export function hasStewardToken(): boolean {
   return readStoredStewardToken() !== null;
+}
+
+/**
+ * Whether a stored Steward token is worth holding the console auth gate for.
+ * Raw presence is not enough: expired, malformed, and identity-less tokens read
+ * as signed-out in `useSessionAuth`, so holding on them would replace the
+ * intended login redirect with an uncloseable busy state.
+ */
+export function hasHydratableStewardToken(): boolean {
+  const token = readStoredToken();
+  if (!token || tokenIsExpired(token)) return false;
+  const claims = decodeJwtPayload(token);
+  const id = claims?.userId ?? claims?.sub;
+  return typeof id === "string" && id.trim().length > 0;
 }

--- a/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
@@ -80,6 +80,16 @@ describe("CloudRouterShell apex catch-all", () => {
     expect(screen.queryByTestId("agent-app")).toBeNull();
   });
 
+  it("redirects an apex visitor with an invalid stored token instead of holding forever outside StewardAuthProvider", () => {
+    setHostname("elizacloud.ai");
+    localStorage.setItem(STEWARD_TOKEN_KEY, "not-a-jwt");
+    renderCatchAll("/settings");
+
+    expect(screen.getByTestId("login-page")).toBeTruthy();
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+    expect(screen.queryByText("Signing you in…")).toBeNull();
+  });
+
   it("redirects an authenticated apex ROOT visitor to the /dashboard console home, not chat", () => {
     setHostname("elizacloud.ai");
     localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken(FUTURE_EXP));

--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -35,6 +35,7 @@ import {
   useParams,
 } from "react-router-dom";
 import { queryClient } from "../lib/query-client";
+import { hasStewardToken } from "../lib/steward-session";
 import { useSessionAuth } from "../lib/use-session-auth";
 import { isApexControlPlaneHost } from "./apex-host";
 import {
@@ -291,6 +292,12 @@ export function AppCatchAllRoute({
       return <RouteChunkFallback />;
     }
     if (!authenticated) {
+      // Same post-OAuth hydration hold as ConsoleShell: a stored token means
+      // the provider is about to hydrate (or self-heal-clear); bouncing to
+      // /login during that window reads as a failed sign-in.
+      if (hasStewardToken()) {
+        return <RouteChunkFallback />;
+      }
       const returnTo = encodeURIComponent(
         `${location.pathname}${location.search}`,
       );

--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -35,7 +35,6 @@ import {
   useParams,
 } from "react-router-dom";
 import { queryClient } from "../lib/query-client";
-import { hasStewardToken } from "../lib/steward-session";
 import { useSessionAuth } from "../lib/use-session-auth";
 import { isApexControlPlaneHost } from "./apex-host";
 import {
@@ -292,12 +291,6 @@ export function AppCatchAllRoute({
       return <RouteChunkFallback />;
     }
     if (!authenticated) {
-      // Same post-OAuth hydration hold as ConsoleShell: a stored token means
-      // the provider is about to hydrate (or self-heal-clear); bouncing to
-      // /login during that window reads as a failed sign-in.
-      if (hasStewardToken()) {
-        return <RouteChunkFallback />;
-      }
       const returnTo = encodeURIComponent(
         `${location.pathname}${location.search}`,
       );

--- a/packages/ui/src/cloud/shell/ConsoleShell.test.tsx
+++ b/packages/ui/src/cloud/shell/ConsoleShell.test.tsx
@@ -18,6 +18,11 @@ const sessionState = {
     email: string;
   } | null,
 };
+let storedToken = false;
+vi.mock("../lib/steward-session", () => ({
+  hasStewardToken: () => storedToken,
+}));
+
 vi.mock("../lib/use-session-auth", () => ({
   useSessionAuth: () => sessionState,
 }));
@@ -80,6 +85,7 @@ describe("ConsoleShell", () => {
     cleanup();
     sessionState.ready = true;
     sessionState.authenticated = true;
+    storedToken = false;
   });
 
   it("renders the sidebar directory, the page body, and the captured page title", () => {
@@ -167,5 +173,28 @@ describe("ConsoleShell", () => {
     );
     expect(screen.getByTestId("login-page")).toBeTruthy();
     expect(screen.queryByTestId("page-body")).toBeNull();
+  });
+
+  it("holds a signing-in fallback (no login bounce) while a stored token awaits hydration", () => {
+    sessionState.authenticated = false;
+    storedToken = true;
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <Routes>
+          <Route path="/login" element={<div data-testid="login-page" />} />
+          <Route
+            path="*"
+            element={
+              <ConsoleShell>
+                <TitledPage />
+              </ConsoleShell>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByTestId("login-page")).toBeNull();
+    expect(screen.queryByTestId("page-body")).toBeNull();
+    expect(screen.getByText("Signing you in…")).toBeTruthy();
   });
 });

--- a/packages/ui/src/cloud/shell/ConsoleShell.test.tsx
+++ b/packages/ui/src/cloud/shell/ConsoleShell.test.tsx
@@ -6,7 +6,7 @@
  * calls `useSetPageHeader` gets its title surfaced in the top bar.
  */
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -20,7 +20,7 @@ const sessionState = {
 };
 let storedToken = false;
 vi.mock("../lib/steward-session", () => ({
-  hasStewardToken: () => storedToken,
+  hasHydratableStewardToken: () => storedToken,
 }));
 
 vi.mock("../lib/use-session-auth", () => ({
@@ -196,5 +196,33 @@ describe("ConsoleShell", () => {
     expect(screen.queryByTestId("login-page")).toBeNull();
     expect(screen.queryByTestId("page-body")).toBeNull();
     expect(screen.getByText("Signing you in…")).toBeTruthy();
+  });
+
+  it("redirects once the hydratable token is cleared during the signing-in hold", async () => {
+    sessionState.authenticated = false;
+    storedToken = true;
+    render(
+      <MemoryRouter initialEntries={["/dashboard/agents"]}>
+        <Routes>
+          <Route path="/login" element={<div data-testid="login-page" />} />
+          <Route
+            path="*"
+            element={
+              <ConsoleShell>
+                <TitledPage />
+              </ConsoleShell>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Signing you in…")).toBeTruthy();
+
+    storedToken = false;
+    window.dispatchEvent(new CustomEvent("steward-token-sync"));
+
+    await waitFor(() => expect(screen.getByTestId("login-page")).toBeTruthy());
+    expect(screen.queryByText("Signing you in…")).toBeNull();
+    expect(screen.queryByTestId("page-body")).toBeNull();
   });
 });

--- a/packages/ui/src/cloud/shell/ConsoleShell.tsx
+++ b/packages/ui/src/cloud/shell/ConsoleShell.tsx
@@ -13,7 +13,12 @@
  */
 
 import { BRAND_PATHS, LOGO_FILES } from "@elizaos/shared/brand";
-import { type ReactNode, useCallback, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { Link, Navigate, useLocation } from "react-router-dom";
 import {
   DashboardHeader,
@@ -24,7 +29,7 @@ import {
   PageHeaderProvider,
   usePageHeader,
 } from "../../cloud-ui/components/layout";
-import { hasStewardToken } from "../lib/steward-session";
+import { hasHydratableStewardToken } from "../lib/steward-session";
 import { useSessionAuth } from "../lib/use-session-auth";
 import {
   CONSOLE_OVERVIEW_NAV_ITEM,
@@ -49,6 +54,28 @@ const CONSOLE_NAV_SECTIONS: DashboardSidebarSection[] = [
     ],
   },
 ];
+
+function subscribeToStewardTokenChanges(listener: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener("storage", listener);
+  window.addEventListener("steward-token-sync", listener);
+  return () => {
+    window.removeEventListener("storage", listener);
+    window.removeEventListener("steward-token-sync", listener);
+  };
+}
+
+function readHydratableStewardTokenSnapshot(): boolean {
+  return hasHydratableStewardToken();
+}
+
+function useHasHydratableStewardToken(): boolean {
+  return useSyncExternalStore(
+    subscribeToStewardTokenChanges,
+    readHydratableStewardTokenSnapshot,
+    () => false,
+  );
+}
 
 function renderRouterLink({
   href,
@@ -107,6 +134,7 @@ export function ConsoleShell({
 }): React.JSX.Element {
   const location = useLocation();
   const session = useSessionAuth();
+  const hasHydratableToken = useHasHydratableStewardToken();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const toggleSidebar = useCallback(() => setSidebarOpen((v) => !v), []);
 
@@ -120,10 +148,11 @@ export function ConsoleShell({
     // navigates here BEFORE the auth provider consumes it, so for ~1-2s the
     // session reads ready-but-unauthenticated. Redirecting then bounces the
     // user back to the sign-in form — which reads as "login didn't work"
-    // (nubs, #13406). While a stored token exists, hold the loading fallback:
-    // the provider either hydrates (authenticated flips true) or its 401
-    // self-heal clears the token and this same branch redirects for real.
-    if (hasStewardToken()) {
+    // (nubs, #13406). Hold only for a non-expired, identity-bearing token:
+    // expired/malformed tokens already read as signed-out in useSessionAuth and
+    // must redirect immediately. The storage/sync subscription above makes a
+    // provider clear transition re-render this branch into the login redirect.
+    if (hasHydratableToken) {
       return (
         <div
           aria-busy="true"

--- a/packages/ui/src/cloud/shell/ConsoleShell.tsx
+++ b/packages/ui/src/cloud/shell/ConsoleShell.tsx
@@ -24,6 +24,7 @@ import {
   PageHeaderProvider,
   usePageHeader,
 } from "../../cloud-ui/components/layout";
+import { hasStewardToken } from "../lib/steward-session";
 import { useSessionAuth } from "../lib/use-session-auth";
 import {
   CONSOLE_OVERVIEW_NAV_ITEM,
@@ -115,6 +116,23 @@ export function ConsoleShell({
   // (#13709: expired staging session showed exactly that). returnTo brings
   // them straight back after re-auth.
   if (session.ready && !session.authenticated) {
+    // Post-OAuth hydration window: the login page persists the token and
+    // navigates here BEFORE the auth provider consumes it, so for ~1-2s the
+    // session reads ready-but-unauthenticated. Redirecting then bounces the
+    // user back to the sign-in form — which reads as "login didn't work"
+    // (nubs, #13406). While a stored token exists, hold the loading fallback:
+    // the provider either hydrates (authenticated flips true) or its 401
+    // self-heal clears the token and this same branch redirects for real.
+    if (hasStewardToken()) {
+      return (
+        <div
+          aria-busy="true"
+          className="flex min-h-dvh items-center justify-center bg-bg text-sm text-muted"
+        >
+          Signing you in…
+        </div>
+      );
+    }
     const returnTo = encodeURIComponent(
       `${location.pathname}${location.search}`,
     );


### PR DESCRIPTION
Fixes the second half of nubs's live sign-in report on #13406: *'flashes a loading thing like it worked, then goes back to the signin page for ~2 seconds'*.

**Mechanism:** post-exchange, the login page persists the token + navigates to the console BEFORE the Steward provider consumes it → session reads ready-but-unauthenticated for the hydration window → the ConsoleShell/apex auth gates redirect BACK to /login. (The form-flash half was already fixed by `completingCallback` on the login page; this is the redirect half.)

**Fix:** while `hasStewardToken()` — a stored token awaiting hydration — both gates render a quiet `aria-busy` **'Signing you in…'** fallback instead of redirecting. Bounded without timers: the provider either hydrates (flips authenticated) or its 401 self-heal clears the token, and the same branch then redirects for real (dead-session behavior from #13709 unchanged).

Tests: hydration-hold pinned (no login redirect, no console body, visible copy) + existing dead-session redirect still green (5/5). Typecheck clean. [qa-agent]