### PR TITLE
fix(#13775): mint traceId at the first MESSAGE_RECEIVED touchpoint so emit-first paths join the trace

### DIFF
--- a/packages/core/src/features/trajectories/index.ts
+++ b/packages/core/src/features/trajectories/index.ts
@@ -17,6 +17,7 @@
  */
 import crypto from "node:crypto";
 import { createUniqueUuid } from "../../entities";
+import { resolveTraceCorrelationFromEnv } from "../../runtime/trace-correlation";
 import type { TrajectoryFinalStatus } from "../../trajectory-utils";
 import type {
 	IAgentRuntime,
@@ -235,6 +236,21 @@ export const trajectoriesPlugin: Plugin = {
 					};
 				}
 				const meta = message.metadata as Record<string, unknown>;
+
+				// Trace correlation (#13775): on emit-first paths (the agent API chat
+				// route and connectors that emit MESSAGE_RECEIVED before calling
+				// messageService.handleMessage) this handler runs BEFORE message.ts
+				// mints the turn's traceId, so the DB row would persist a NULL
+				// trace_id and never join the file trajectory. Mint at the first
+				// touchpoint instead: inherit a spawning parent's ELIZA_TRACE_ID, else
+				// a fresh id, and stamp message.metadata so message.ts reuses it.
+				if (
+					typeof meta.traceId !== "string" ||
+					meta.traceId.trim().length === 0
+				) {
+					meta.traceId =
+						resolveTraceCorrelationFromEnv().traceId ?? crypto.randomUUID();
+				}
 
 				const logger = TrajectoriesService.resolveFromRuntime(runtime);
 				if (!logger) return;

--- a/packages/core/src/features/trajectories/trace-correlation-db.real.test.ts
+++ b/packages/core/src/features/trajectories/trace-correlation-db.real.test.ts
@@ -163,7 +163,10 @@ describe("trajectories trace_id join key (real PGLite)", () => {
 
 		await handler?.({ runtime, message, source: "api" } as MessagePayload);
 
-		const meta = message.metadata as { traceId?: string; trajectoryId?: string };
+		const meta = message.metadata as {
+			traceId?: string;
+			trajectoryId?: string;
+		};
 		expect(typeof meta.traceId).toBe("string");
 		expect((meta.traceId ?? "").length).toBeGreaterThan(0);
 		expect(typeof meta.trajectoryId).toBe("string");

--- a/packages/core/src/features/trajectories/trace-correlation-db.real.test.ts
+++ b/packages/core/src/features/trajectories/trace-correlation-db.real.test.ts
@@ -10,7 +10,8 @@ import { PGlite } from "@electric-sql/pglite";
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { IAgentRuntime } from "../../types";
+import type { IAgentRuntime, Memory, MessagePayload } from "../../types";
+import { trajectoriesPlugin } from "./index";
 import { TrajectoriesService } from "./TrajectoriesService";
 
 let db: ReturnType<typeof drizzle>;
@@ -124,5 +125,53 @@ describe("trajectories trace_id join key (real PGLite)", () => {
 			`SELECT trace_id FROM trajectories WHERE id = '${id}'`,
 		);
 		expect(rows[0]?.trace_id).toBe(traceId);
+	});
+
+	// Emit-first paths (the agent API chat route and connectors) emit
+	// MESSAGE_RECEIVED before messageService.handleMessage mints the turn's
+	// traceId, so the plugin handler is the first touchpoint and must mint +
+	// stamp the id itself or the DB row persists trace_id NULL and never joins
+	// the file trajectory (#13871 audit).
+	it("mints and persists a traceId when MESSAGE_RECEIVED arrives before message.ts stamps one", async () => {
+		const handler = trajectoriesPlugin.events?.MESSAGE_RECEIVED?.[0];
+		expect(typeof handler).toBe("function");
+
+		const runtime = {
+			agentId: "00000000-0000-4000-8000-000000000001",
+			adapter: { db },
+			getService: () => service,
+			getServicesByType: () => [service],
+			logger: {
+				debug() {},
+				info() {},
+				warn(...args: unknown[]) {
+					// The handler swallows failures via logger.warn; surface them so a
+					// broken insert cannot pass as green.
+					throw new Error(`trajectory handler warned: ${JSON.stringify(args)}`);
+				},
+				error() {},
+			},
+		} as unknown as IAgentRuntime;
+
+		const message = {
+			id: "10000000-0000-4000-8000-00000000aaaa",
+			roomId: "20000000-0000-4000-8000-00000000bbbb",
+			entityId: "30000000-0000-4000-8000-00000000cccc",
+			content: { text: "hello", source: "api" },
+			// No metadata: mirrors chat-routes.ts emitting before any stamp exists.
+		} as unknown as Memory;
+
+		await handler?.({ runtime, message, source: "api" } as MessagePayload);
+
+		const meta = message.metadata as { traceId?: string; trajectoryId?: string };
+		expect(typeof meta.traceId).toBe("string");
+		expect((meta.traceId ?? "").length).toBeGreaterThan(0);
+		expect(typeof meta.trajectoryId).toBe("string");
+
+		const rows = await raw(
+			`SELECT trace_id, metadata_json FROM trajectories WHERE id = '${meta.trajectoryId}'`,
+		);
+		expect(rows.length).toBe(1);
+		expect(rows[0]?.trace_id).toBe(meta.traceId);
 	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -8470,8 +8470,7 @@ export class DefaultMessageService implements IMessageService {
 		const preStampedTraceId =
 			typeof message.metadata === "object" &&
 			message.metadata !== null &&
-			typeof (message.metadata as { traceId?: unknown }).traceId ===
-				"string" &&
+			typeof (message.metadata as { traceId?: unknown }).traceId === "string" &&
 			(message.metadata as { traceId: string }).traceId.trim() !== ""
 				? (message.metadata as { traceId: string }).traceId
 				: undefined;

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -8458,13 +8458,27 @@ export class DefaultMessageService implements IMessageService {
 				? message.content.source
 				: "messageService";
 
-		// Mint the root-turn traceId once here (#13775) — inherited from a spawning
-		// parent's env when this runtime is itself a sub-agent, else a fresh id.
-		// Stamped on message.metadata BEFORE MESSAGE_RECEIVED is emitted so the DB
-		// trajectory handler (features/trajectories) records the SAME traceId as
-		// the file recorder, and placed on the turn's trajectory context below so
-		// sub-agent spawns read it too. Both stores then join on one traceId.
-		const traceId = resolveTraceCorrelationFromEnv().traceId ?? asUUID(v4());
+		// Root-turn traceId (#13775). On emit-first paths (agent API chat route,
+		// connectors) the trajectories MESSAGE_RECEIVED handler already minted and
+		// stamped one on message.metadata before we ran — reuse it, or the DB row
+		// and the file trajectory would carry different ids. Otherwise mint here
+		// (inherited from a spawning parent's env when this runtime is itself a
+		// sub-agent, else fresh) and stamp it BEFORE MESSAGE_RECEIVED is emitted
+		// below so the DB trajectory handler records the SAME traceId as the file
+		// recorder. Placed on the turn's trajectory context below so sub-agent
+		// spawns read it too. All stores then join on one traceId.
+		const preStampedTraceId =
+			typeof message.metadata === "object" &&
+			message.metadata !== null &&
+			typeof (message.metadata as { traceId?: unknown }).traceId ===
+				"string" &&
+			(message.metadata as { traceId: string }).traceId.trim() !== ""
+				? (message.metadata as { traceId: string }).traceId
+				: undefined;
+		const traceId =
+			preStampedTraceId ??
+			resolveTraceCorrelationFromEnv().traceId ??
+			asUUID(v4());
 		if (!message.metadata) {
 			message.metadata = { type: "message" };
 		}


### PR DESCRIPTION
## Summary

Post-merge adversarial audit of #13871 (issue #13775) found the trace-correlation join key silently broken on **emit-first message paths** — including the agent HTTP API chat route, i.e. the dashboard's primary path.

**Defect:** `packages/agent/src/api/chat-routes.ts:2351`, `plugins/plugin-imessage/src/service.ts:1712`, Signal/Matrix/Feishu connectors, and the autonomy service all emit `MESSAGE_RECEIVED` **before** calling `messageService.handleMessage`. #13871 stamps `message.metadata.traceId` inside `handleMessage` (message.ts:8467) — which on those paths runs *after* the trajectories plugin's `MESSAGE_RECEIVED` handler has already inserted the DB row. Result:

- DB `trajectories.trace_id` = **NULL** on those paths (the handler copies `traceId` from metadata, which is empty at that point),
- `handleMessage` then mints a *different* traceId that only the file recorder and sub-agent spawn env see,
- file ↔ DB join — the whole point of #13871 — never happens for API-chat / connector turns. It only worked for callers that enter `handleMessage` without a prior emit.

## Fix (mint at the first touchpoint, whichever runs first)

- `packages/core/src/features/trajectories/index.ts` — the `MESSAGE_RECEIVED` handler mints (env-inherited `ELIZA_TRACE_ID`, else fresh) and stamps `message.metadata.traceId` when none is present, so the DB row it inserts carries the id.
- `packages/core/src/services/message.ts` — reuse a pre-stamped `metadata.traceId` instead of unconditionally overwriting it, so the file recorder / trajectory context / spawn env carry the same id the DB row already persisted.

Emit-first path: plugin handler mints → DB row gets it → `handleMessage` reuses it. handleMessage-first path: unchanged (message.ts mints before its own emit).

## Test — real-PGLite regression driving the actual handler

`trace-correlation-db.real.test.ts` gains a case that invokes the real `trajectoriesPlugin.events.MESSAGE_RECEIVED[0]` against the real service + PGLite with a metadata-less message (the chat-routes shape), and asserts the persisted `trace_id` equals the id stamped on `message.metadata`. The stub logger *throws* on `warn` so the handler's swallow-and-warn path cannot pass as green.

Verified red-before / green-after on develop tip:

```
# pre-fix (develop code, new test):  FAIL — meta.traceId undefined
# post-fix: 3 passed (3)
VITEST_LANE=post-merge vitest run src/features/trajectories/trace-correlation-db.real.test.ts
```

Also re-ran the #13871 suites on this branch: `trajectory-gate.test.ts` + `trace-correlation.test.ts` (11 passed), `child-trajectory-ingest.test.ts` (4 passed). Biome clean on touched files; typecheck shows only the pre-existing generated `validation-keyword-data` gaps of a fresh worktree.

Part of the #13766 epic audit sweep; found auditing #13871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
