### PR TITLE
fix(#13775): redact secrets in the sub-agent stdout tee before persisting

### DIFF
--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -52,6 +52,16 @@ describe("redactSensitiveText (pattern detection)", () => {
 		expect(out).toContain("…");
 	});
 
+	it("masks a Cerebras inference key (csk-) without leaking it or eating the sk- variant", () => {
+		// csk- is a distinct prefix from OpenAI's sk-; sub-agent stdout echoes it as
+		// the model key in use (#13775 review). The word boundary must not let the
+		// sk- pattern partial-match inside csk-.
+		const csk = "csk-0123456789abcdefghij";
+		const out = redactSensitiveText(`model key ${csk} end`);
+		expect(out).not.toContain(csk);
+		expect(out).toContain("…");
+	});
+
 	it("masks a GitHub PAT and a Bearer token", () => {
 		const ghp = `ghp_${"a".repeat(30)}`;
 		expect(redactSensitiveText(`use ${ghp}`)).not.toContain(ghp);

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -44,6 +44,9 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	String.raw`-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----`,
 	// Common token prefixes.
 	String.raw`\b(sk-[A-Za-z0-9_-]{8,})\b`,
+	// Cerebras inference keys (csk-…) — a distinct prefix from OpenAI's sk-,
+	// routinely echoed by sub-agent stdout as the model key in use.
+	String.raw`\b(csk-[A-Za-z0-9_-]{8,})\b`,
 	// Stripe secret + restricted keys (underscore form) — sk_live_/sk_test_/rk_live_/rk_test_.
 	// Distinct shape from the OpenAI sk- above; Stripe is the payment processor so a leaked
 	// sk_live_ is catastrophic, and these often appear as bare values (not under a *_SECRET name).

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/subagent-stdout-log.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/subagent-stdout-log.test.ts
@@ -111,3 +111,65 @@ describe("appendSubagentStdout", () => {
     await expect(fs.readFile(p, "utf8")).resolves.toContain('"text":"x"');
   });
 });
+
+describe("appendSubagentStdout secret redaction (#13775 review)", () => {
+  // The persisted file outlives the session, so a raw provider credential
+  // echoed to stdout would be a durable on-disk leak. The tee runs each chunk
+  // through core's canonical value-shape redactor (redactSensitiveText) at write
+  // time; these assert the persisted bytes never carry the live secret while
+  // ordinary content is left alone. Cerebras csk- prefix coverage is validated
+  // against the redactor directly in packages/core/src/security/redact.test.ts.
+  const readTexts = async (sessionId: string): Promise<string[]> => {
+    const raw = await fs.readFile(subagentStdoutLogPath(sessionId), "utf8");
+    return raw
+      .trim()
+      .split("\n")
+      .map((l) => (JSON.parse(l) as { text: string }).text);
+  };
+
+  it("redacts sk-/Bearer tokens in a MODEL-USED-style line before it lands", async () => {
+    const key = "sk-abcd1234EFGH5678wxyz";
+    const bearer = `Bearer ${"abcdef0123456789ABCDEF".repeat(2)}`;
+    const line = `MODEL-USED openai/gpt-5.5 key=${key} auth=${bearer}\n`;
+    const returned = await appendSubagentStdout("ses_secret", line);
+    expect(returned).toBe(subagentStdoutLogPath("ses_secret"));
+
+    const [persisted] = await readTexts("ses_secret");
+    // The raw file must never contain the live token bytes.
+    expect(persisted).not.toContain(key);
+    expect(persisted).not.toContain("abcdef0123456789ABCDEF".repeat(2));
+    // …but it is masked in place, not dropped: the redactor keeps a short
+    // head/tail marker (`…`) so the trace stays readable.
+    expect(persisted).toContain("…");
+    // Non-secret tokens on the same line survive.
+    expect(persisted).toContain("MODEL-USED openai/gpt-5.5");
+  });
+
+  it("leaves non-secret content byte-identical", async () => {
+    const clean =
+      "running `bun test`\n  ✓ 3 passed\n  path=/tmp/x done in 1.2s\n";
+    await appendSubagentStdout("ses_clean", clean);
+    const [persisted] = await readTexts("ses_clean");
+    // Nothing here matches a secret shape, so the chunk round-trips unchanged.
+    expect(persisted).toBe(clean);
+  });
+
+  it("redaction does not disturb rotation: the new (redacted) line is the only live content", async () => {
+    const logPath = subagentStdoutLogPath("ses_secret_rotate");
+    await fs.mkdir(path.dirname(logPath), { recursive: true });
+    await fs.writeFile(logPath, "x".repeat(10 * 1024 * 1024 + 1), "utf8");
+
+    const bearer = `Bearer ${"deadbeefcafef00d1234".repeat(2)}`;
+    await appendSubagentStdout(
+      "ses_secret_rotate",
+      `post-rotation auth=${bearer}\n`,
+    );
+
+    const rolled = await fs.readFile(`${logPath}.1`, "utf8");
+    expect(rolled.length).toBeGreaterThan(10 * 1024 * 1024);
+    const [persisted] = await readTexts("ses_secret_rotate");
+    expect(persisted).toContain("post-rotation");
+    expect(persisted).not.toContain("deadbeefcafef00d1234".repeat(2));
+    await expect(fs.stat(`${logPath}.2`)).rejects.toThrow();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/subagent-stdout-log.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/subagent-stdout-log.ts
@@ -10,12 +10,16 @@
  * Gated by the SAME policy as the trajectory recorder
  * (`isTrajectoryRecordingEnabled`): when recording is off, nothing is written.
  * Rotation mirrors the orchestrator audit log (single-generation `.1`) so a
- * long-lived, chatty session cannot grow the file unbounded.
+ * long-lived, chatty session cannot grow the file unbounded. Provider
+ * credentials are masked at write time (`redactSensitiveText`) so this persisted
+ * file — which outlives the session — can never leak the model key the
+ * sub-agent echoed to stdout.
  */
 import { appendFile, mkdir, rename, stat } from "node:fs/promises";
 import { join } from "node:path";
 import {
   isTrajectoryRecordingEnabled,
+  redactSensitiveText,
   resolveTrajectoryDir,
 } from "@elizaos/core";
 
@@ -57,9 +61,17 @@ export async function appendSubagentStdout(
   const path = subagentStdoutLogPath(sessionId);
   await mkdir(stdoutLogDir(), { recursive: true });
   await rotateIfTooLarge(path);
-  // One JSON object per line: ts + the raw chunk. Keeping the chunk verbatim
-  // (not line-split) preserves the exact stream the CLI agent produced.
-  const record = JSON.stringify({ ts: new Date().toISOString(), text });
+  // One JSON object per line: ts + the chunk. Kept verbatim (not line-split) to
+  // preserve the exact stream the CLI agent produced, EXCEPT that provider
+  // credentials are masked first: sub-agent stdout regularly echoes the model
+  // key / Bearer token used, and this file outlives the session, so a raw secret
+  // here would be a durable on-disk leak. redactSensitiveText is core's canonical
+  // value-shape redactor (security/redact.ts) — the same pattern set the log sink
+  // and runtime.redactSecrets apply, so a leaked key shape is masked everywhere.
+  const record = JSON.stringify({
+    ts: new Date().toISOString(),
+    text: redactSensitiveText(text),
+  });
   await appendFile(path, `${record}\n`, "utf8");
   return path;
 }


### PR DESCRIPTION
## What

The raw sub-agent stdout tee — `plugins/plugin-agent-orchestrator/src/services/subagent-stdout-log.ts` `appendSubagentStdout` — persisted every ACP stdout chunk to a per-session NDJSON file **verbatim, with no secret redaction**. Sub-agent stdout routinely echoes the model key / Bearer token in use, and that file **outlives the session** (it's the ground-truth trace referenced from the task document), so a raw provider credential written there was a durable on-disk leak. Flagged in the #13811 post-merge review of #13775.

## Fix

Mask credentials **at write time** using core's canonical value-shape redactor `redactSensitiveText` (`packages/core/src/security/redact.ts`) — the same pattern set the log sink (`redactLogArgs`) and `runtime.redactSecrets` already apply — instead of duplicating patterns in the plugin (smallest correct seam per the review note).

- The persisted file can no longer contain a raw secret; a leaked key shape is masked to a short head/tail marker (`sk-abc…5678`) so the trace stays readable.
- The **in-memory live tail** (`outputBuffers` / `appendOutput`) is a separate call path and is left unchanged — only the persist path (`persistRawStdout` → `appendSubagentStdout`) redacts.

### Gap closed in the shared redactor
`DEFAULT_REDACT_PATTERNS` already covered OpenAI `sk-`, Stripe (`sk_live_`/`rk_test_`…), GitHub (`ghp_`/`github_pat_`), Slack, Google (`AIza`), `Bearer`, and PEM — but **not Cerebras `csk-`** keys, which sub-agents echo as the active model key. Added the `csk-` pattern next to the `sk-` one; the leading word boundary keeps `sk-` from partial-matching inside `csk-`.

## Evidence

**`packages/core/src/security/redact.test.ts`** (imports `./redact.ts` → runs against source):
- New case: `csk-…` key is masked and the `sk-` variant is not eaten.
- **Mutation-checked**: with the new `csk-` pattern removed the case fails (`expected 'model key csk-0123456789abcdefghij end' not to contain 'csk-…'`); restored → green. Proves the test exercises the pattern, not a tautology.
- `24 passed`.

**`plugins/plugin-agent-orchestrator/__tests__/unit/subagent-stdout-log.test.ts`** (real filesystem writes to a temp trajectory dir, no mocks of the unit under test):
- A `MODEL-USED`-style line with `sk-`/`Bearer` tokens lands **masked** in the persisted NDJSON — the live token bytes are absent, non-secret content (`MODEL-USED openai/gpt-5.5`) survives.
- Non-secret content is **byte-identical** after the round-trip.
- The **rotation** path is unaffected: after crossing the 10 MiB cap the oversized content moves to `.1`, the new (redacted) line is the only live content, no `.2` accumulates.
- `8 passed`.

```
Test Files  1 passed (1) — subagent-stdout-log.test.ts     Tests  8 passed
Test Files  1 passed (1) — redact.test.ts                  Tests 24 passed
```

Biome clean on all four touched files. Scoped typecheck: the only errors are a pre-existing codegen gap (`src/i18n/generated/validation-keyword-data` — a gitignored `prebuild` artifact absent in a fresh worktree); nothing references the touched files.

Part of #13775

🤖 Generated with [Claude Code](https://claude.com/claude-code)