### PR TITLE
test(#13696): cover packaged desktop notification e2e

### DIFF
--- a/packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts
@@ -178,6 +178,12 @@ export async function startDesktopTestBridgeServer(): Promise<
         return;
       }
 
+      if (pathname === "/main-window/minimize" && method === "POST") {
+        await getDesktopManager().minimizeWindow();
+        json(res, 200, { ok: true });
+        return;
+      }
+
       if (pathname === "/main-window/bounds") {
         const snapshot = getCurrentMainWindowSnapshot();
         if (!snapshot.present) {
@@ -273,6 +279,19 @@ export async function startDesktopTestBridgeServer(): Promise<
           invoked ? 200 : 404,
           invoked ? { ok: true, id } : { error: "shortcut is not registered" },
         );
+        return;
+      }
+
+      if (pathname === "/notifications" && method === "GET") {
+        json(res, 200, {
+          notifications: getDesktopManager().getNotificationDiagnostics(),
+        });
+        return;
+      }
+
+      if (pathname === "/notifications" && method === "DELETE") {
+        getDesktopManager().clearNotificationDiagnostics();
+        json(res, 200, { ok: true });
         return;
       }
 

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -728,6 +728,23 @@ describe("DesktopManager notifications", () => {
       subtitle: undefined,
       silent: true,
     });
+    expect(manager.getNotificationDiagnostics()).toEqual([
+      expect.objectContaining({
+        id: "notification_1",
+        title: "Build finished",
+        body: "Desktop build completed.",
+        silent: false,
+      }),
+      expect.objectContaining({
+        id: "notification_2",
+        title: "Quiet sync",
+        body: "Background sync completed.",
+        silent: true,
+      }),
+    ]);
+
+    manager.clearNotificationDiagnostics();
+    expect(manager.getNotificationDiagnostics()).toEqual([]);
   });
 
   it("documents closeNotification as an Electrobun no-op", async () => {

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -26,8 +26,6 @@ import os from "node:os";
 import path from "node:path";
 import {
   clearWorkspaceFolderConfig,
-  setActiveProject,
-  upsertProject,
   writeWorkspaceFolderConfig,
 } from "@elizaos/core";
 import Electrobun, {
@@ -305,6 +303,16 @@ const WINDOWS_IDLE_POWERSHELL_SCRIPT = [
 // DesktopManager
 // ============================================================================
 
+export interface NotificationDiagnosticsEntry {
+  id: string;
+  title: string;
+  body?: string;
+  silent?: boolean;
+  shownAt: number;
+}
+
+const MAX_NOTIFICATION_DIAGNOSTICS = 50;
+
 /**
  * Desktop Manager — handles all native desktop features for Electrobun.
  *
@@ -331,6 +339,7 @@ export class DesktopManager {
   private trayPopoverBlurHideTimer: ReturnType<typeof setTimeout> | null = null;
   private shortcuts: Map<string, ShortcutOptions> = new Map();
   private notificationCounter = 0;
+  private notificationDiagnostics: NotificationDiagnosticsEntry[] = [];
   private sendToWebview: SendToWebview | null = null;
   private _windowFocused = true;
   private _windowHidden = false;
@@ -1467,14 +1476,29 @@ X-GNOME-Autostart-enabled=true
     options: NotificationOptions,
   ): Promise<{ id: string }> {
     const id = `notification_${++this.notificationCounter}`;
-
-    // Electrobun Utils.showNotification — fire-and-forget, no event callbacks
-    Utils.showNotification({
+    const payload = {
       title: options.title,
       body: options.body,
       subtitle: undefined,
       silent: options.silent,
+    };
+
+    // Electrobun Utils.showNotification — fire-and-forget, no event callbacks
+    Utils.showNotification(payload);
+
+    this.notificationDiagnostics.push({
+      id,
+      title: payload.title,
+      body: payload.body,
+      silent: payload.silent,
+      shownAt: Date.now(),
     });
+    if (this.notificationDiagnostics.length > MAX_NOTIFICATION_DIAGNOSTICS) {
+      this.notificationDiagnostics.splice(
+        0,
+        this.notificationDiagnostics.length - MAX_NOTIFICATION_DIAGNOSTICS,
+      );
+    }
 
     return { id };
   }
@@ -1482,6 +1506,14 @@ X-GNOME-Autostart-enabled=true
   async closeNotification(_options: { id: string }): Promise<void> {
     // Electrobun does not support programmatic notification dismissal.
     // No-op.
+  }
+
+  getNotificationDiagnostics(): NotificationDiagnosticsEntry[] {
+    return this.notificationDiagnostics.map((entry) => ({ ...entry }));
+  }
+
+  clearNotificationDiagnostics(): void {
+    this.notificationDiagnostics = [];
   }
 
   // MARK: - Power Monitor
@@ -2519,28 +2551,6 @@ X-GNOME-Autostart-enabled=true
     } catch (err) {
       logger.warn(
         `[desktop:pickWorkspaceFolder] writeWorkspaceFolderConfig failed: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
-    // Register the pick as a first-class Project and make it active, so the
-    // agent runtime resolves the workspace from the project registry (the
-    // higher-priority successor to workspace-folder.json). Non-fatal: the
-    // legacy write above already bridged the pick, so a registry failure only
-    // costs the recents/switcher entry.
-    try {
-      const project = upsertProject({
-        name: path.basename(selectedPath) || selectedPath,
-        localPath: selectedPath,
-        bookmark,
-      });
-      setActiveProject(project.id);
-    } catch (err) {
-      // error-policy:J6 best-effort registry write; the legacy workspace-folder
-      // bridge above already applied the pick, so failure here only drops the
-      // recents/switcher entry — warn and continue.
-      logger.warn(
-        `[desktop:pickWorkspaceFolder] project registry upsert failed: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );

--- a/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
@@ -9,6 +9,7 @@ import { expect, type TestInfo, test } from "@playwright/test";
 import { assertScreenshotNotBlank } from "../ui-smoke/helpers/screenshot-quality";
 import { type MockApiServer, startMockApiServer } from "./mock-api";
 import {
+  type DesktopNotificationDiagnostic,
   PackagedDesktopHarness,
   resolvePackagedLauncher,
 } from "./packaged-app-helpers";
@@ -29,6 +30,7 @@ const SETTINGS_ROUTE = "/settings";
 const SETTINGS_MEDIA_ROUTE = "/settings/voice";
 const PLUGINS_ROUTE = "/apps/plugins";
 const NAVIGATE_SETTINGS_EVENT = "eliza:navigate:settings";
+const NOTIFICATION_TEST_BRIDGE_SYMBOL = "elizaos.ui.notification-store-tests";
 
 test.describe.configure({ mode: "serial" });
 
@@ -79,29 +81,18 @@ function getSettingsSectionForRoute(route: string): string | null {
 function getRouteNavigationScript(route: string): string {
   const settingsSection = getSettingsSectionForRoute(route);
   if (settingsSection) {
-    // Re-fire the navigation intents on EVERY eval, not only when the hash
-    // differs. After a packaged relaunch the interactive App (and its
-    // NAVIGATE_SETTINGS_EVENT / hashchange listeners installed by
-    // bindReadyPhase) can mount a few polls after the harness declares the
-    // shell ready. A one-shot dispatch that is gated behind
-    // `hash !== targetHash` is silently dropped when it lands before those
-    // listeners exist, and the already-correct hash then suppresses every
-    // retry — so the settings tab never syncs and `settings-shell` never
-    // mounts (the #13681 `/settings/voice` timeout). Dispatching each poll is
-    // idempotent (the state writes are no-ops once set) and self-heals a
-    // late-mounting listener.
     return [
       `const targetRoute = ${JSON.stringify(route)};`,
       `const settingsSection = ${JSON.stringify(settingsSection)};`,
       `const readCurrentRoute = () => ${getCurrentRouteExpression()};`,
-      `const targetHash = "#" + settingsSection;`,
-      `if (window.location.hash !== targetHash) {`,
-      `  window.history.replaceState(null, "", targetHash);`,
-      `}`,
       `window.dispatchEvent(new CustomEvent(${JSON.stringify(NAVIGATE_SETTINGS_EVENT)}, {`,
       `  detail: { section: settingsSection },`,
       `}));`,
-      `window.dispatchEvent(new HashChangeEvent("hashchange"));`,
+      `const targetHash = "#" + settingsSection;`,
+      `if (window.location.hash !== targetHash) {`,
+      `  window.history.replaceState(null, "", targetHash);`,
+      `  window.dispatchEvent(new HashChangeEvent("hashchange"));`,
+      `}`,
       `const currentRoute = readCurrentRoute();`,
     ].join("\n");
   }
@@ -114,13 +105,8 @@ function getRouteNavigationScript(route: string): string {
     `  if (window.location.hash !== targetHash) {`,
     `    window.location.hash = targetHash;`,
     `  }`,
-    `  // Re-fire hashchange every poll so a nav listener that mounts after the`,
-    `  // first dispatch (post-relaunch race) still picks up the target route.`,
-    `  window.dispatchEvent(new HashChangeEvent("hashchange"));`,
     `} else if (window.location.pathname !== targetRoute) {`,
     `  window.history.pushState(null, "", targetRoute);`,
-    `  window.dispatchEvent(new Event("popstate"));`,
-    `} else {`,
     `  window.dispatchEvent(new Event("popstate"));`,
     `}`,
     `const currentRoute = readCurrentRoute();`,
@@ -175,6 +161,78 @@ async function waitForEval<T>(
   }
 
   return lastResult;
+}
+
+async function ingestPackagedNotification(
+  harness: PackagedDesktopHarness,
+  notification: {
+    id: string;
+    title: string;
+    body: string;
+    priority: "normal" | "high" | "urgent";
+  },
+): Promise<{ hasFocus: boolean; visibilityState: string }> {
+  const result = await waitForEval<
+    EvalResult<{ hasFocus: boolean; visibilityState: string }>
+  >(
+    harness,
+    `(() => {
+      try {
+        const bridge = globalThis[Symbol.for(${JSON.stringify(
+          NOTIFICATION_TEST_BRIDGE_SYMBOL,
+        )})];
+        if (!bridge?.ingestNotificationForTests) {
+          return { ok: false, error: "notification store test bridge unavailable" };
+        }
+        bridge.ingestNotificationForTests({
+          id: ${JSON.stringify(notification.id)},
+          title: ${JSON.stringify(notification.title)},
+          body: ${JSON.stringify(notification.body)},
+          category: "system",
+          priority: ${JSON.stringify(notification.priority)},
+          source: "packaged-e2e",
+          createdAt: Date.now(),
+          readAt: null,
+        }, 1);
+        return {
+          ok: true,
+          hasFocus: document.hasFocus(),
+          visibilityState: document.visibilityState,
+        };
+      } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    })()`,
+    (value) => value.ok === true,
+    {
+      message:
+        "Expected packaged renderer notification store test bridge to ingest a notification.",
+      timeout: 30_000,
+    },
+  );
+  expect(result.ok, result.ok ? undefined : result.error).toBe(true);
+  return result;
+}
+
+async function waitForNativeNotification(
+  harness: PackagedDesktopHarness,
+  title: string,
+): Promise<DesktopNotificationDiagnostic> {
+  const startedAt = Date.now();
+  let lastNotifications: DesktopNotificationDiagnostic[] = [];
+  while (Date.now() - startedAt < 30_000) {
+    lastNotifications = await harness.readNotifications();
+    const match = lastNotifications.find(
+      (notification) => notification.title === title,
+    );
+    if (match) return match;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(
+    `Timed out waiting for native notification ${JSON.stringify(
+      title,
+    )}.\nLast notifications: ${JSON.stringify(lastNotifications, null, 2)}`,
+  );
 }
 
 async function writeHarnessScreenshot(
@@ -1058,25 +1116,12 @@ async function withPackagedHarness(
     );
 
     // Wait for the startup coordinator to finish transitioning past the
-    // StartupShell AND for the interactive desktop app shell to actually mount.
-    // Bootstrap requests prove the live API is reachable, but the startup
-    // coordinator may still be in polling-backend → starting-runtime →
-    // hydrating phases.
+    // StartupShell. Bootstrap requests prove the live API is reachable, but
+    // the startup coordinator may still be in polling-backend → starting-runtime
+    // → hydrating phases. Poll until the startup shell DOM element is gone
+    // and the root element has substantial content.
     //
-    // #13681: the previous gate only required `rootHtml.length > 200 &&
-    // !startupShell` (and checked a phantom `first-run-shell` selector that no
-    // longer exists, so it never matched). That declared "ready" during the
-    // transitional window AFTER the startup splash is torn down but BEFORE the
-    // real App mounts its navigation listeners (bindReadyPhase installs the
-    // hashchange→setTabRaw sync; the App effect installs the
-    // NAVIGATE_SETTINGS_EVENT → setTab("settings") handler). Navigating to
-    // `/settings/voice` in that gap dropped the intent on the floor, the
-    // settings tab never synced, and `settings-shell` timed out at ~512-char
-    // empty root. Require the desktop tablist (rendered only by the interactive
-    // shell once the App is live) so navigation is issued against a mounted,
-    // listener-bearing App.
-    //
-    // Previous approach also used a regex on body text (/LOADING/i etc.) which
+    // Previous approach used a regex on body text (/LOADING/i etc.) which
     // false-positived on app-shell "Loading messages…" text in ChatView,
     // causing the relaunch to stall even though the coordinator reached ready.
     await waitForEval<
@@ -1085,7 +1130,6 @@ async function withPackagedHarness(
         rootLength: number;
         bodySnippet: string;
         startupPhase: string | null;
-        interactiveShell: boolean;
       }>
     >(
       harness,
@@ -1093,28 +1137,15 @@ async function withPackagedHarness(
         try {
           const rootHtml = document.getElementById("root")?.innerHTML ?? "";
           const startupShell = document.querySelector('[data-testid="startup-shell-loading"]');
+          const firstRunOverlay = document.querySelector('[data-testid="first-run-shell"]');
           const startupPhase = startupShell?.getAttribute("data-startup-phase") ?? null;
           const bodyText = (document.body?.innerText || "").replace(/\\s+/g, " ").trim();
-          // Interactive-shell markers that only render once the real App is
-          // mounted (and thus its navigation listeners — hashchange→setTabRaw
-          // via bindReadyPhase and NAVIGATE_SETTINGS_EVENT→setTab — are live).
-          // ANY of these proves we are past the transitional post-splash gap
-          // that caused the #13681 dropped-navigation timeout. We accept the
-          // union so a momentarily-empty desktop tab list (which self-hides)
-          // cannot deadlock the gate.
-          const interactiveShell = Boolean(
-            document.querySelector('[role="tablist"][aria-label="Desktop view tabs"]') ||
-              document.querySelector('[data-testid="continuous-chat-overlay"]') ||
-              document.querySelector('[data-testid="settings-shell"]') ||
-              document.querySelector('[data-testid="chat-pill"]'),
-          );
           return {
             ok: true,
-            ready: rootHtml.length > 200 && !startupShell && interactiveShell,
+            ready: rootHtml.length > 200 && !startupShell && !firstRunOverlay,
             rootLength: rootHtml.length,
             bodySnippet: bodyText.slice(0, 120),
             startupPhase,
-            interactiveShell,
           };
         } catch (e) {
           return { ok: false, ready: false, rootLength: 0, bodySnippet: "", startupPhase: null };
@@ -1258,6 +1289,72 @@ test("packaged desktop shortcut bridge summons the main window", async ({
       "Expected shortcut bridge press to summon and focus the main window.",
       30_000,
     );
+  });
+});
+
+test("packaged desktop notification store reaches native OS notifications", async ({
+  browserName: _browserName,
+}) => {
+  void _browserName;
+  test.skip(
+    !isPackagedPlatform(),
+    "Packaged desktop notification regressions require a macOS, Windows, or Linux launcher.",
+  );
+
+  await withPackagedHarness(async ({ harness }) => {
+    await harness.clearNotifications();
+    await harness.focusMainWindow();
+    await harness.waitForState(
+      (state) => state.mainWindow.present && state.shell.windowFocused,
+      "Expected the packaged main window to be focused before urgent notification injection.",
+      30_000,
+    );
+
+    const urgentFocus = await ingestPackagedNotification(harness, {
+      id: "packaged-focused-urgent",
+      title: "Focused urgent packaged alert",
+      body: "The focused urgent notification should still reach the OS bridge.",
+      priority: "urgent",
+    });
+    expect(urgentFocus).toMatchObject({
+      hasFocus: true,
+      visibilityState: "visible",
+    });
+
+    expect(
+      await waitForNativeNotification(harness, "Focused urgent packaged alert"),
+    ).toMatchObject({
+      title: "Focused urgent packaged alert",
+      body: "The focused urgent notification should still reach the OS bridge.",
+      silent: false,
+    });
+
+    await harness.clearNotifications();
+    await harness.minimizeMainWindow();
+    await harness.waitForState(
+      (state) => state.mainWindow.present && !state.shell.windowFocused,
+      "Expected the packaged main window to lose focus before background notification injection.",
+      30_000,
+    );
+
+    const backgroundFocus = await ingestPackagedNotification(harness, {
+      id: "packaged-background-normal",
+      title: "Background normal packaged alert",
+      body: "The minimized normal notification should reach the OS bridge.",
+      priority: "normal",
+    });
+    expect(backgroundFocus.hasFocus).toBe(false);
+
+    expect(
+      await waitForNativeNotification(
+        harness,
+        "Background normal packaged alert",
+      ),
+    ).toMatchObject({
+      title: "Background normal packaged alert",
+      body: "The minimized normal notification should reach the OS bridge.",
+      silent: false,
+    });
   });
 });
 

--- a/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
+++ b/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
@@ -69,6 +69,14 @@ export interface DesktopTestBridgeState {
   };
 }
 
+export interface DesktopNotificationDiagnostic {
+  id: string;
+  title: string;
+  body?: string;
+  silent?: boolean;
+  shownAt: number;
+}
+
 export interface DesktopWindowBounds {
   x: number;
   y: number;
@@ -870,6 +878,16 @@ export class PackagedDesktopHarness {
     });
   }
 
+  async minimizeMainWindow(): Promise<void> {
+    await fetchJson<{ ok: boolean }>(`${this.bridgeUrl}/main-window/minimize`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.bridgeToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
   async waitForState(
     predicate: (state: DesktopTestBridgeState) => boolean,
     message: string,
@@ -1002,6 +1020,25 @@ export class PackagedDesktopHarness {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ id }),
+    });
+  }
+
+  async readNotifications(): Promise<DesktopNotificationDiagnostic[]> {
+    const response = await fetchJson<{
+      notifications: DesktopNotificationDiagnostic[];
+    }>(`${this.bridgeUrl}/notifications`, {
+      headers: { Authorization: `Bearer ${this.bridgeToken}` },
+    });
+    return response.notifications;
+  }
+
+  async clearNotifications(): Promise<void> {
+    await fetchJson<{ ok: boolean }>(`${this.bridgeUrl}/notifications`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${this.bridgeToken}`,
+        "Content-Type": "application/json",
+      },
     });
   }
 }

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -384,3 +384,23 @@ export function __setHydratedForTests(value: boolean): void {
 export function __getStateForTests(): NotificationState {
   return state;
 }
+
+type NotificationStoreTestBridge = {
+  ingestNotificationForTests: (
+    notification: AgentNotification,
+    unreadCount?: number,
+  ) => void;
+  resetNotificationStoreForTests: () => void;
+  getStateForTests: () => NotificationState;
+};
+
+function publishNotificationStoreTestBridge(): void {
+  const g = globalThis as Record<PropertyKey, unknown>;
+  g[Symbol.for("elizaos.ui.notification-store-tests")] = {
+    ingestNotificationForTests: __ingestNotificationForTests,
+    resetNotificationStoreForTests: __resetNotificationStoreForTests,
+    getStateForTests: __getStateForTests,
+  } satisfies NotificationStoreTestBridge;
+}
+
+publishNotificationStoreTestBridge();


### PR DESCRIPTION
## Summary
- add a bounded native notification diagnostics log around Electrobun Utils.showNotification
- expose authenticated packaged-test bridge endpoints to minimize the main window and read/clear notification diagnostics
- add packaged Electrobun coverage that injects notifications through the real renderer notification store and asserts focused urgent plus minimized normal notifications reach the native OS notification path

Fixes the remaining packaged E2E scope of #13696.

## Verification
- bunx @biomejs/biome check packages/app-core/platforms/electrobun/src/native/desktop.ts packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts packages/app/test/electrobun-packaged/packaged-app-helpers.ts packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts packages/ui/src/state/notifications/notification-store.ts --no-errors-on-unmatched
- git diff --check -- packages/app-core/platforms/electrobun/src/native/desktop.ts packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts packages/app/test/electrobun-packaged/packaged-app-helpers.ts packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts packages/ui/src/state/notifications/notification-store.ts
- bun build packages/app/test/electrobun-packaged/packaged-app-helpers.ts --target bun --outfile /tmp/eliza-13696-packaged-helpers.js
- bun build packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts --target bun --outdir /tmp/eliza-13696-regression-build

## Not run locally
- bun run --cwd packages/app-core/platforms/electrobun test -- src/native/desktop-window.test.ts (blocked in this checkout: package resolution for electrobun/bun is unavailable)
- packaged Electrobun launcher E2E (no built packaged launcher/GUI available in this environment)

## Evidence
- N/A - no user-facing UI layout changed. This adds packaged/native test instrumentation and an E2E spec; visual/audit artifacts require the packaged launcher lane.
