### PR TITLE
fix(#13772): close admission-queue drain races found in #13841 post-merge audit

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/admission-integration.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admission-integration.test.ts
@@ -520,12 +520,11 @@ describe("admission queue integration (#13772)", () => {
     const running = acp.listSessions().find((s) => s.status === "running");
     expect(running).toBeDefined();
     if (running) acp.complete(running.id);
-    await waitUntil(async () => {
-      const record = (await store.getTask(b))?.task.metadata?.admission as
-        | { enqueuedAt: string }
-        | undefined;
-      return record !== undefined;
-    });
+    // Wait for the drain to actually attempt (and lose) the dispatch, then let
+    // the pass settle — polling for record-presence alone would race ahead of
+    // the drain and vacuously see the original record.
+    await waitUntil(() => !acp.stealNext);
+    await new Promise((r) => setTimeout(r, 50));
 
     // B is re-parked with its original seniority, not a fresh enqueue time.
     const reparked = (await store.getTask(b))?.task.metadata?.admission as

--- a/plugins/plugin-agent-orchestrator/src/__tests__/admission-integration.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admission-integration.test.ts
@@ -402,6 +402,139 @@ describe("admission queue integration (#13772)", () => {
     });
   });
 
+  it("clears the parked state when a queued task is spawned directly (no duplicate dispatch)", async () => {
+    const acp = new FakeAcp(1);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await service.start();
+
+    const a = await newTask(store, "a");
+    await service.spawnAgentForTask(a);
+    const b = await newTask(store, "b");
+    const parked = await service.spawnAgentForTask(b);
+    expect(parked?.admission?.state).toBe("queued");
+
+    // A's slot frees SILENTLY (no terminal event — e.g. a swept-stale session),
+    // so the queue doesn't drain; then the user spawns B directly before the
+    // reconcile tick.
+    const s1 = acp.listSessions().find((s) => s.status === "running");
+    expect(s1).toBeDefined();
+    if (s1) s1.status = "completed";
+    const direct = await service.spawnAgentForTask(b);
+    expect(direct?.admission).toBeUndefined();
+    expect((await service.getAdmissionSnapshot()).queueDepth).toBe(0);
+    const record = (await store.getTask(b))?.task.metadata?.admission;
+    expect(record).toBeUndefined();
+
+    // B's session completing must NOT replay the stale admission record and
+    // spawn a duplicate agent for B.
+    const s2 = acp.listSessions().find((s) => s.status === "running");
+    expect(s2).toBeDefined();
+    if (s2) acp.complete(s2.id);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(acp.listSessions().length).toBe(2);
+  });
+
+  it("keeps a paused parked task's admission record across restart + drain, so resume replays it", async () => {
+    const acp = new FakeAcp(1);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await service.start();
+
+    const a = await newTask(store, "a");
+    await service.spawnAgentForTask(a);
+    const b = await newTask(store, "b");
+    await service.spawnAgentForTask(b);
+    await service.pauseTask(b);
+    // Pause keeps the durable record but removes B from the dispatch order.
+    expect((await service.getAdmissionSnapshot()).queueDepth).toBe(0);
+    expect((await store.getTask(b))?.task.metadata?.admission).toBeDefined();
+
+    // Restart mid-queue: the rebuild must NOT re-seed the paused task, and the
+    // drain after A completes must NOT clear its retained record.
+    await service.stop();
+    const restarted = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await restarted.start();
+    expect((await restarted.getAdmissionSnapshot()).queueDepth).toBe(0);
+    const running = acp.listSessions().find((s) => s.status === "running");
+    expect(running).toBeDefined();
+    if (running) acp.complete(running.id);
+    await new Promise((r) => setTimeout(r, 50));
+    expect((await store.getTask(b))?.task.metadata?.admission).toBeDefined();
+
+    // Resume re-seeds the retained record and the drain dispatches B into the
+    // freed slot.
+    await restarted.resumeTask(b);
+    await waitUntil(async () => {
+      const snapshot = await restarted.getAdmissionSnapshot();
+      return (
+        snapshot.queueDepth === 0 &&
+        acp.listSessions().some((s) => s.status === "running")
+      );
+    });
+    expect((await store.getTask(b))?.task.metadata?.admission).toBeUndefined();
+    await restarted.stop();
+  });
+
+  it("re-parks the head with its ORIGINAL record when a concurrent spawn steals the slot mid-drain", async () => {
+    /** Reports a free slot but throws SessionCapError on the next spawn —
+     * models a direct spawn winning the slot between the drain's capacity
+     * check and its dispatch. */
+    class StealingAcp extends FakeAcp {
+      stealNext = false;
+      override async spawnSession(opts: SpawnOptions): Promise<SpawnResult> {
+        if (this.stealNext) {
+          this.stealNext = false;
+          throw new SessionCapError("worker", 1, 1);
+        }
+        return super.spawnSession(opts);
+      }
+    }
+    const acp = new StealingAcp(1);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await service.start();
+
+    const a = await newTask(store, "a");
+    await service.spawnAgentForTask(a);
+    const b = await newTask(store, "b");
+    await service.spawnAgentForTask(b);
+    const original = (await store.getTask(b))?.task.metadata?.admission as
+      | { enqueuedAt: string }
+      | undefined;
+    expect(original?.enqueuedAt).toBeTruthy();
+
+    // Ensure a re-minted record would carry a measurably later enqueuedAt.
+    await new Promise((r) => setTimeout(r, 15));
+
+    // A completes, freeing the slot — but the drain's dispatch loses the race.
+    acp.stealNext = true;
+    const running = acp.listSessions().find((s) => s.status === "running");
+    expect(running).toBeDefined();
+    if (running) acp.complete(running.id);
+    await waitUntil(async () => {
+      const record = (await store.getTask(b))?.task.metadata?.admission as
+        | { enqueuedAt: string }
+        | undefined;
+      return record !== undefined;
+    });
+
+    // B is re-parked with its original seniority, not a fresh enqueue time.
+    const reparked = (await store.getTask(b))?.task.metadata?.admission as
+      | { enqueuedAt: string }
+      | undefined;
+    expect(reparked?.enqueuedAt).toBe(original?.enqueuedAt);
+    expect((await service.getAdmissionSnapshot()).queueDepth).toBe(1);
+  });
+
   it("surfaces the capacity line + data.capacity through the provider", async () => {
     const acp = new FakeAcp(2);
     const store = new OrchestratorTaskStore({ backend: "memory" });

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -268,6 +268,14 @@ export interface SpawnAgentForTaskOptions {
    * the max-nesting-depth cap so self-spawning can't run away.
    */
   nestingDepth?: number;
+  /**
+   * Internal: the admission-queue drain sets this false so a cap race during a
+   * replayed dispatch RETHROWS SessionCapError instead of self-parking. The
+   * drain then re-parks the task at the head with its ORIGINAL admission record
+   * (seniority + aging preserved); self-parking here would mint a fresh
+   * enqueuedAt and push the task to the back of its band.
+   */
+  parkOnCap?: boolean;
 }
 
 /**
@@ -3281,6 +3289,7 @@ export class OrchestratorTaskService extends Service {
         err instanceof SessionCapError &&
         err.slotClass === "worker" &&
         nestingDepth === 0 &&
+        opts.parkOnCap !== false &&
         this.admissionQueueEnabled()
       ) {
         return this.enqueueAdmission(taskId, doc.task.priority, {
@@ -3359,6 +3368,12 @@ export class OrchestratorTaskService extends Service {
     // session's events even if the durable write below degrades.
     this.sessionTaskIndex.set(result.sessionId, taskId);
     try {
+      // A task can be spawned directly (API/action) while it is still parked in
+      // the admission queue — e.g. a slot freed silently and the user beat the
+      // reconcile tick. Clear the parked state now the spawn succeeded, or the
+      // next drain would replay the stale admission record and dispatch a
+      // DUPLICATE agent for the same goal. No-op for non-parked tasks.
+      await this.dequeueAdmission(taskId);
       await this.store.addSession(session);
       // Pin (or re-pin, on explicit override) the durable workdir/repo binding
       // from the workdir the session actually landed in, so subsequent
@@ -4001,6 +4016,10 @@ export class OrchestratorTaskService extends Service {
     for (const task of open) {
       const admission = OrchestratorTaskService.admissionOf(task);
       if (!admission) continue;
+      // A paused task keeps its durable admission record (pauseTask passes
+      // clearMetadata=false so resume can replay the original spawn) but must
+      // NOT re-enter the dispatch order — resumeTask re-seeds it explicitly.
+      if (task.paused) continue;
       entries.push({
         taskId: task.id,
         enqueuedAt: admission.enqueuedAt,
@@ -4101,10 +4120,12 @@ export class OrchestratorTaskService extends Service {
    * Dispatch parked tasks into freed worker slots, most-eligible first.
    * Serialized via a promise-chain lock so a terminal-event drain and the
    * reconcile tick never double-dispatch. For each free slot it re-reads the
-   * head task's live state (dropping terminal/paused entries — starvation guard
-   * #2 is covered by idle-reclaim below), clears the admission record, and
-   * replays the saved spawn. A fresh SessionCapError re-parks the head and stops
-   * the pass (another spawn raced us). When no slot is free but the queue is
+   * head task's live state (terminal entries are dropped with their record;
+   * paused entries are dropped from the order but KEEP the record for resume),
+   * clears the admission record, and replays the saved spawn with
+   * `parkOnCap: false`. A fresh SessionCapError re-parks the head with its
+   * original record and stops the pass (another spawn raced us). When no slot
+   * is free but the queue is
    * non-empty, one idle keepAlive session whose task is already terminal is
    * reclaimed to unblock the queue.
    */
@@ -4148,10 +4169,14 @@ export class OrchestratorTaskService extends Service {
       const doc = await this.store.getTask(head.taskId);
       const admission = doc && OrchestratorTaskService.admissionOf(doc.task);
       if (!doc || !admission) continue;
-      if (TERMINAL_TASK_STATUSES.has(doc.task.status) || doc.task.paused) {
+      if (TERMINAL_TASK_STATUSES.has(doc.task.status)) {
         await this.writeAdmission(head.taskId, null);
         continue;
       }
+      // A pause that raced this pass: drop the task from the dispatch order but
+      // KEEP the durable record — pauseTask retained it so resume can replay
+      // the original spawn (clearing it here would make resume a silent no-op).
+      if (doc.task.paused) continue;
       await this.writeAdmission(head.taskId, null);
       try {
         await this.spawnAgentForTask(head.taskId, {
@@ -4159,6 +4184,9 @@ export class OrchestratorTaskService extends Service {
           approvalPreset: admission.spawnOpts.approvalPreset as
             | ApprovalPreset
             | undefined,
+          // A cap race must RETHROW so the catch below re-parks with the
+          // original record; the spawn's own self-park would reset seniority.
+          parkOnCap: false,
         });
       } catch (err) {
         if (err instanceof SessionCapError) {


### PR DESCRIPTION
Post-merge adversarial audit of #13841 (admission queue, issue #13772, epic #13766) found three real defects on current `develop`; this PR fixes them forward with regression coverage.

## Defects

**1. Duplicate dispatch when a parked task is spawned directly.** `spawnAgentForTask`'s success path never cleared a pre-existing `metadata.admission` record or the in-memory queue entry. If a worker slot frees *silently* (e.g. swept-stale session — no terminal event) and a user/agent spawns the parked task directly before the 30s reconcile tick, the spawn succeeds but the stale record survives — and the next drain replays it, spawning a **second agent for the same goal**. The drain's promise-chain mutex serializes drains against each other but never covered this direct-spawn path. Fix: the spawn success path now calls `dequeueAdmission(taskId)` (no-op for non-parked tasks).

**2. Paused parked task stranded forever after a restart.** `pauseTask` deliberately retains the durable admission record (`dequeueAdmission(taskId, false)`) so resume can replay the original spawn. But `rebuildAdmissionQueueFromStore` scanned all `open` tasks without checking `paused`, re-seeding the paused task into the dispatch order — and `drainOnce` then **cleared its retained record** on the next pass. A later `resumeTask` found no record (`pausedWithActiveWork` is false for a never-spawned park), so resume was a silent no-op: task stuck `open` forever, no session, no queue entry. Fix: rebuild skips paused tasks; `drainOnce` drops a paused head from the order but keeps its record.

**3. Dead cap-race handler in `drainOnce`; head loses seniority (or is dropped).** The drain replays the saved spawn via `spawnAgentForTask`, which at depth 0 **self-parks** on `SessionCapError` — minting a fresh `enqueuedAt` and pushing to the back of the band — so the drain's re-park-at-head catch was unreachable dead code. A raced head lost its FIFO seniority and accumulated aging; worse, if the queue refilled to its depth cap mid-dispatch, the internal re-park threw `AdmissionQueueFullError` and the task fell out of the queue entirely (admission record already cleared) — stranded `open`. Fix: internal `parkOnCap: false` option; the drain's dispatch rethrows the cap error and the original record is restored at the head, exactly as the existing catch was written to do.

## Verification

All three regression tests fail on unfixed `develop` and pass with the fix:

- unfixed: `clears the parked state…` → FAIL (3 sessions spawned for 2 tasks); `keeps a paused parked task…` → FAIL (record cleared, resume no-op); `re-parks the head…` → FAIL (`expected undefined to be '2026-07-05T15:46:28.366Z'` — record re-minted then consumed).
- fixed: `vitest run` on `admission-integration` + `admission-queue` + `acp-capacity-slot-class` + `task-supervisor` → **4 files, 27 tests passed**.

Biome clean on touched files; `tsc` errors in the worktree are pre-existing missing-codegen artifacts in `packages/core`/`packages/shared`, none in this plugin.

Audit notes (not fixed here, for the record): `GET /api/orchestrator/capacity` and the 202-queued admission DTO currently have **no UI consumer** — only the planner provider + supervisor digest read the admission surface (commandment 10: every GET needs a consuming component/hook).

Part of the #13766 epic audit sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)