### PR TITLE
fix(orchestrator): enable trajectory recording in the acp stdout-flush test (develop red)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -1093,7 +1093,7 @@ describe("AcpService", () => {
     const priorRecording = process.env.ELIZA_TRAJECTORY_RECORDING;
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "acp-stdout-"));
     process.env.ELIZA_TRAJECTORY_DIR = tmpDir;
-    delete process.env.ELIZA_TRAJECTORY_RECORDING;
+    process.env.ELIZA_TRAJECTORY_RECORDING = "1";
     try {
       const create = nextProc();
       const service = new AcpService(runtime());


### PR DESCRIPTION
Fixes a pre-existing **develop-tip red** I found while reviewing #14087 (it is orthogonal to that PR).

## The failure

`plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts > AcpService > flushes raw stdout before advertising stdoutLogPath on task_complete` fails on develop:

```
AssertionError: expected undefined to be '…/subagent-stdout/<sessionId>.ndjson'
  at acp-service.test.ts:1131  expect(payload?.stdoutLogPath).toBe(...)
```

## Root cause

The test sets `ELIZA_TRAJECTORY_DIR` but **`delete`s `ELIZA_TRAJECTORY_RECORDING`**, then asserts `stdoutLogPath` is advertised and reads back the persisted ndjson. But subagent stdout logging is gated by `isSubagentStdoutLoggingEnabled()` → `isTrajectoryRecordingEnabled()` → `resolveTrajectoryGate()`, whose precedence is:

1. disable-flag → off · 2. explicit-logging · 3. `ELIZA_TRAJECTORY_RECORDING` explicit · **4. `NODE_ENV=test` → off** · 5. production → off · 6. dev → on

The vitest runner sets `NODE_ENV=test`, so with `ELIZA_TRAJECTORY_RECORDING` unset the gate falls through to rule 4 (**off**). `persistRawStdout` early-returns, `persistedStdoutSessions` never gets the session, `stdoutLogRef` returns `{}`, and `stdoutLogPath` is `undefined` → fail. (Not platform-specific — `NODE_ENV=test` is exactly what CI runs under.)

## Fix

The test must explicitly enable recording — that's the exact condition it exercises (stdout **is** flushed and its path advertised **when recording is on**):

```diff
-    delete process.env.ELIZA_TRAJECTORY_RECORDING;
+    process.env.ELIZA_TRAJECTORY_RECORDING = "1";
```

One-line, test-only, no production code touched.

## Verification

```
bun run --cwd plugins/plugin-agent-orchestrator test -- __tests__/unit/acp-service.test.ts
# before: Tests  1 failed | 53 passed (54)
# after:  Tests  54 passed (54)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)