### PR TITLE
fix(#13773): shared workspace registry + disk backpressure (safe residual of #13803)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-spawn-disk-budget.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-spawn-disk-budget.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Real-path regression for the disk-budget + registry integration in
+ * AcpService.spawnSession (#13773). Drives the production spawn path against a
+ * real InMemorySessionStore and real temp dirs: a spawn that fails AFTER the
+ * isolated scratch dir is created (here: the session-slot cap is already full)
+ * must remove the orphaned dir and drop its registry entry, so a failed spawn
+ * never pins the shared cap (#13803 review blocker #2). No mocks of the cleanup.
+ */
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AcpService } from "../services/acp-service.ts";
+import { InMemorySessionStore } from "../services/session-store.ts";
+import type { SessionInfo } from "../services/types.ts";
+import {
+  getSharedWorkspaceRegistry,
+  resetSharedWorkspaceRegistry,
+} from "../services/workspace-registry.ts";
+
+const roots: string[] = [];
+
+beforeEach(() => {
+  resetSharedWorkspaceRegistry();
+});
+
+afterEach(() => {
+  resetSharedWorkspaceRegistry();
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function tmpRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "acp-disk-budget-"));
+  roots.push(root);
+  return root;
+}
+
+function makeRuntime(
+  settings: Record<string, string> = {},
+): Record<string, unknown> {
+  return {
+    agentId: "00000000-0000-4000-8000-00000013773b",
+    character: { name: "Tester" },
+    getSetting: (key: string) => settings[key],
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    reportError() {},
+    getService: () => null,
+  };
+}
+
+function workerSession(id: string): SessionInfo {
+  const now = new Date();
+  return {
+    id,
+    name: id,
+    agentType: "opencode",
+    workdir: "/tmp/preexisting",
+    status: "running",
+    approvalPreset: "standard",
+    createdAt: now,
+    lastActivityAt: now,
+    metadata: { slotClass: "worker" },
+  };
+}
+
+describe("AcpService spawn disk-budget + registry (#13773)", () => {
+  it("removes the orphaned scratch dir and unregisters when a spawn fails after mkdir", async () => {
+    const root = tmpRoot();
+    const store = new InMemorySessionStore();
+    // Fill the single worker slot so the next spawn's reserveSessionSlot throws
+    // AFTER computeSessionWorkdir + mkdir + register have already run.
+    await store.create(workerSession("existing-1"));
+
+    const svc = new AcpService(
+      makeRuntime({
+        ELIZA_ACP_MAX_SESSIONS: "1",
+        ELIZA_ACP_SYSTEM_SESSION_HEADROOM: "0",
+        ELIZA_ACP_WORKSPACE_ROOT: root,
+      }) as never,
+      { store },
+    );
+    (svc as unknown as { started: boolean }).started = true;
+
+    const registry = getSharedWorkspaceRegistry();
+    const before = registry.size();
+
+    await expect(
+      svc.spawnSession({ agentType: "opencode", slotClass: "worker" }),
+    ).rejects.toThrow();
+
+    // No leaked task-* dir under the configured root, and no live registry entry
+    // pinning the cap.
+    const leaked = readdirSync(root).filter((n) => n.startsWith("task-"));
+    expect(leaked).toEqual([]);
+    expect(registry.size()).toBe(before);
+  });
+
+  it("refuses a spawn when the free-disk floor cannot be met", async () => {
+    const root = tmpRoot();
+    const store = new InMemorySessionStore();
+    const svc = new AcpService(
+      makeRuntime({
+        ELIZA_ACP_WORKSPACE_ROOT: root,
+        // A floor no real filesystem can satisfy forces the precheck to refuse
+        // before any mkdir happens.
+        ELIZA_WORKSPACE_MIN_FREE_BYTES: String(Number.MAX_SAFE_INTEGER),
+      }) as never,
+      { store },
+    );
+    (svc as unknown as { started: boolean }).started = true;
+
+    await expect(
+      svc.spawnSession({ agentType: "opencode", slotClass: "worker" }),
+    ).rejects.toThrow(/disk budget/i);
+
+    expect(readdirSync(root)).toEqual([]);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-spawn-disk-budget.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-spawn-disk-budget.test.ts
@@ -97,6 +97,43 @@ describe("AcpService spawn disk-budget + registry (#13773)", () => {
     expect(registry.size()).toBe(before);
   });
 
+  it("keeps the workdir for a durable errored session when acpx exits nonzero", async () => {
+    const root = tmpRoot();
+    const store = new InMemorySessionStore();
+    const svc = new AcpService(
+      makeRuntime({
+        ELIZA_ACP_WORKSPACE_ROOT: root,
+      }) as never,
+      { store },
+    );
+    (svc as unknown as { started: boolean }).started = true;
+    (
+      svc as unknown as {
+        runAcpx: () => Promise<{ code: number; stdout: string; stderr: string }>;
+      }
+    ).runAcpx = async () => ({
+      code: 42,
+      stdout: "",
+      stderr: "transport refused",
+    });
+
+    await expect(
+      svc.spawnSession({ agentType: "opencode", slotClass: "worker" }),
+    ).rejects.toThrow();
+
+    const scratchDirs = readdirSync(root).filter((n) => n.startsWith("task-"));
+    expect(scratchDirs).toHaveLength(1);
+    const scratchDir = scratchDirs[0] ?? "";
+    expect(scratchDir).not.toBe("");
+    const [session] = await store.list();
+    expect(session?.status).toBe("errored");
+    expect(session?.workdir).toContain(scratchDir);
+
+    const registry = getSharedWorkspaceRegistry();
+    expect(registry.has(session?.workdir ?? "")).toBe(true);
+    expect(registry.isLive(session?.workdir ?? "")).toBe(false);
+  });
+
   it("refuses a spawn when the free-disk floor cannot be met", async () => {
     const root = tmpRoot();
     const store = new InMemorySessionStore();

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-spawn-disk-budget.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-spawn-disk-budget.test.ts
@@ -6,7 +6,7 @@
  * must remove the orphaned dir and drop its registry entry, so a failed spawn
  * never pins the shared cap (#13803 review blocker #2). No mocks of the cleanup.
  */
-import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -97,11 +97,12 @@ describe("AcpService spawn disk-budget + registry (#13773)", () => {
     expect(registry.size()).toBe(before);
   });
 
-  it("keeps the workdir for a durable errored session when acpx exits nonzero", async () => {
+  it("preserves the scratch dir when a durable CLI session fails to start", async () => {
     const root = tmpRoot();
     const store = new InMemorySessionStore();
     const svc = new AcpService(
       makeRuntime({
+        ELIZA_ACP_TRANSPORT: "cli",
         ELIZA_ACP_WORKSPACE_ROOT: root,
       }) as never,
       { store },
@@ -109,29 +110,29 @@ describe("AcpService spawn disk-budget + registry (#13773)", () => {
     (svc as unknown as { started: boolean }).started = true;
     (
       svc as unknown as {
-        runAcpx: () => Promise<{ code: number; stdout: string; stderr: string }>;
+        runAcpx: () => Promise<{
+          code: number;
+          stdout: string;
+          stderr: string;
+        }>;
       }
     ).runAcpx = async () => ({
-      code: 42,
+      code: 1,
       stdout: "",
-      stderr: "transport refused",
+      stderr: "startup failed",
     });
 
     await expect(
       svc.spawnSession({ agentType: "opencode", slotClass: "worker" }),
     ).rejects.toThrow();
 
-    const scratchDirs = readdirSync(root).filter((n) => n.startsWith("task-"));
-    expect(scratchDirs).toHaveLength(1);
-    const scratchDir = scratchDirs[0] ?? "";
-    expect(scratchDir).not.toBe("");
     const [session] = await store.list();
-    expect(session?.status).toBe("errored");
-    expect(session?.workdir).toContain(scratchDir);
-
-    const registry = getSharedWorkspaceRegistry();
-    expect(registry.has(session?.workdir ?? "")).toBe(true);
-    expect(registry.isLive(session?.workdir ?? "")).toBe(false);
+    expect(session).toMatchObject({
+      status: "errored",
+      lastError: expect.stringContaining("startup failed"),
+    });
+    expect(existsSync(session.workdir)).toBe(true);
+    expect(getSharedWorkspaceRegistry().isLive(session.workdir)).toBe(false);
   });
 
   it("refuses a spawn when the free-disk floor cannot be met", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Real-filesystem regression tests for the shared workspace registry + disk
+ * backpressure gate (#13773). Everything runs against real temp dirs and the
+ * real `statfs`/`rm` paths — no mocks — so the ownership invariant ("only a dir
+ * the registry recorded is ever reclaimable") and the cap/floor enforcement are
+ * proven end to end, not asserted against a stub.
+ */
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_WORKSPACE_DISK_CAP_BYTES,
+  DEFAULT_WORKSPACE_MIN_FREE_BYTES,
+  measureDirBytes,
+  parseByteSetting,
+  resolveDiskBudgetConfig,
+  WorkspaceRegistry,
+} from "../services/workspace-registry.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function tmpRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function makeDirWithBytes(path: string, bytes: number): Promise<void> {
+  await mkdir(path, { recursive: true });
+  await writeFile(join(path, "payload.bin"), Buffer.alloc(bytes, 1));
+}
+
+describe("WorkspaceRegistry ownership invariant", () => {
+  it("never deletes a dir it did not register (registry miss)", async () => {
+    const root = tmpRoot("wsreg-miss-");
+    // A caller-owned dir that HAPPENS to match the scratch shape but was never
+    // registered — the exact #13803 data-loss case.
+    const callerOwned = join(root, "task-important");
+    await makeDirWithBytes(callerOwned, 4096);
+
+    const registry = new WorkspaceRegistry();
+    // Cap forced to 0 so the gate tries to reclaim everything it is allowed to.
+    const decision = await registry.checkDiskBudget(root, { capBytes: 0 });
+
+    expect(decision.reclaimedCount).toBe(0);
+    expect(existsSync(callerOwned)).toBe(true);
+  });
+
+  it("never deletes a registered acp-scratch dir (accounting-only)", async () => {
+    const root = tmpRoot("wsreg-acp-");
+    const scratch = join(root, "task-abc");
+    await makeDirWithBytes(scratch, 8192);
+
+    const registry = new WorkspaceRegistry();
+    registry.register("acp-scratch", scratch, "session-1");
+    registry.markTerminal(scratch);
+
+    // Even terminal, an acp-scratch record is never reclaimed by the registry —
+    // AcpService's session-store GC owns ACP deletion.
+    await registry.checkDiskBudget(root, { capBytes: 0 });
+    expect(existsSync(scratch)).toBe(true);
+  });
+
+  it("never deletes a LIVE git workspace", async () => {
+    const root = tmpRoot("wsreg-live-");
+    const ws = join(root, "clone-live");
+    await makeDirWithBytes(ws, 8192);
+
+    const registry = new WorkspaceRegistry();
+    registry.register("git-workspace", ws, "ws-live");
+    // Left live — must survive even an over-cap sweep.
+    await registry.checkDiskBudget(root, { capBytes: 0 });
+    expect(existsSync(ws)).toBe(true);
+  });
+});
+
+describe("WorkspaceRegistry cap enforcement", () => {
+  it("evicts terminal git workspaces oldest-first until under cap", async () => {
+    const root = tmpRoot("wsreg-cap-");
+    const bytes = 64 * 1024;
+    const oldWs = join(root, "clone-old");
+    const newWs = join(root, "clone-new");
+    await makeDirWithBytes(oldWs, bytes);
+    await makeDirWithBytes(newWs, bytes);
+
+    const registry = new WorkspaceRegistry();
+    registry.register("git-workspace", oldWs, "ws-old");
+    // Force a strictly-later createdAt so LRU order is deterministic.
+    await new Promise((r) => setTimeout(r, 5));
+    registry.register("git-workspace", newWs, "ws-new");
+    registry.markTerminal(oldWs);
+    registry.markTerminal(newWs);
+
+    // Cap allows ~one workspace: eviction should stop after freeing the oldest.
+    const decision = await registry.checkDiskBudget(root, {
+      capBytes: bytes + bytes / 2,
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.reclaimedCount).toBe(1);
+    expect(existsSync(oldWs)).toBe(false);
+    expect(existsSync(newWs)).toBe(true);
+  });
+
+  it("refuses when the cap cannot be met even after eviction", async () => {
+    const root = tmpRoot("wsreg-cap-fail-");
+    const liveWs = join(root, "clone-live");
+    await makeDirWithBytes(liveWs, 64 * 1024);
+
+    const registry = new WorkspaceRegistry();
+    // Only a LIVE workspace exists — nothing evictable, so a zero cap must fail.
+    registry.register("git-workspace", liveWs, "ws-live");
+
+    const decision = await registry.checkDiskBudget(root, { capBytes: 0 });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe("cap-exceeded");
+    expect(existsSync(liveWs)).toBe(true);
+  });
+});
+
+describe("WorkspaceRegistry free-disk precheck", () => {
+  it("refuses a provision below the free-disk floor", async () => {
+    const root = tmpRoot("wsreg-df-");
+    // A floor larger than any real filesystem forces the df precheck to fail.
+    const decision = await registry_freeDiskCase(root);
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe("free-disk-floor");
+  });
+
+  it("allows when free disk is above the floor", async () => {
+    const root = tmpRoot("wsreg-df-ok-");
+    const registry = new WorkspaceRegistry();
+    const decision = await registry.checkDiskBudget(root, { minFreeBytes: 1 });
+    expect(decision.allowed).toBe(true);
+    expect(decision.freeBytes).toBeGreaterThan(0);
+  });
+});
+
+async function registry_freeDiskCase(root: string) {
+  const registry = new WorkspaceRegistry();
+  return registry.checkDiskBudget(root, {
+    minFreeBytes: Number.MAX_SAFE_INTEGER,
+  });
+}
+
+describe("measureDirBytes", () => {
+  it("sums file sizes recursively and skips symlinked dirs", async () => {
+    const root = tmpRoot("wsreg-measure-");
+    await makeDirWithBytes(join(root, "a"), 1000);
+    await makeDirWithBytes(join(root, "a", "nested"), 2000);
+    const total = await measureDirBytes(join(root, "a"));
+    expect(total).toBe(3000);
+  });
+
+  it("returns 0 for a missing dir", async () => {
+    const total = await measureDirBytes(join(tmpdir(), "does-not-exist-13773"));
+    expect(total).toBe(0);
+  });
+});
+
+describe("config parsing", () => {
+  it("parses positive byte counts and rejects junk", () => {
+    expect(parseByteSetting("1048576")).toBe(1048576);
+    expect(parseByteSetting("  2048 ")).toBe(2048);
+    expect(parseByteSetting(undefined)).toBeUndefined();
+    expect(parseByteSetting("")).toBeUndefined();
+    expect(parseByteSetting("0")).toBeUndefined();
+    expect(parseByteSetting("-5")).toBeUndefined();
+    expect(parseByteSetting("abc")).toBeUndefined();
+  });
+
+  it("falls back to module defaults when settings are unset", () => {
+    const config = resolveDiskBudgetConfig(() => undefined);
+    expect(config.capBytes).toBe(DEFAULT_WORKSPACE_DISK_CAP_BYTES);
+    expect(config.minFreeBytes).toBe(DEFAULT_WORKSPACE_MIN_FREE_BYTES);
+  });
+
+  it("honors env-tunable overrides", () => {
+    const settings: Record<string, string> = {
+      ELIZA_WORKSPACE_DISK_CAP_BYTES: "12345",
+      ELIZA_WORKSPACE_MIN_FREE_BYTES: "6789",
+    };
+    const config = resolveDiskBudgetConfig((k) => settings[k]);
+    expect(config.capBytes).toBe(12345);
+    expect(config.minFreeBytes).toBe(6789);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts
@@ -13,15 +13,19 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_WORKSPACE_DISK_CAP_BYTES,
   DEFAULT_WORKSPACE_MIN_FREE_BYTES,
+  getSharedWorkspaceRegistry,
   measureDirBytes,
   parseByteSetting,
+  resetSharedWorkspaceRegistry,
   resolveDiskBudgetConfig,
   WorkspaceRegistry,
 } from "../services/workspace-registry.js";
+import { CodingWorkspaceService } from "../services/workspace-service.js";
 
 const roots: string[] = [];
 
 afterEach(() => {
+  resetSharedWorkspaceRegistry();
   for (const root of roots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
   }
@@ -123,6 +127,49 @@ describe("WorkspaceRegistry cap enforcement", () => {
     expect(decision.allowed).toBe(false);
     expect(decision.reason).toBe("cap-exceeded");
     expect(existsSync(liveWs)).toBe(true);
+  });
+});
+
+describe("CodingWorkspaceService registry lifecycle", () => {
+  it("marks retained full-clone workspaces terminal so disk pressure can reclaim them", async () => {
+    const root = tmpRoot("wsreg-service-");
+    const workspacePath = join(root, "clone-retained");
+    await makeDirWithBytes(workspacePath, 8192);
+    resetSharedWorkspaceRegistry();
+    const registry = getSharedWorkspaceRegistry();
+    const service = new CodingWorkspaceService({
+      getSetting: () => undefined,
+    } as never);
+    (
+      service as unknown as {
+        workspaces: Map<
+          string,
+          {
+            id: string;
+            path: string;
+            branch: string;
+            baseBranch: string;
+            isWorktree: boolean;
+            repo: string;
+            status: string;
+          }
+        >;
+      }
+    ).workspaces.set("ws-retained", {
+      id: "ws-retained",
+      path: workspacePath,
+      branch: "feature/test",
+      baseBranch: "develop",
+      isWorktree: false,
+      repo: "https://github.com/elizaOS/eliza.git",
+      status: "ready",
+    });
+    registry.register("git-workspace", workspacePath, "ws-retained");
+
+    service.markWorkspaceTerminal("ws-retained");
+    await registry.checkDiskBudget(root, { capBytes: 0 });
+
+    expect(existsSync(workspacePath)).toBe(false);
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts
@@ -9,7 +9,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_WORKSPACE_DISK_CAP_BYTES,
   DEFAULT_WORKSPACE_MIN_FREE_BYTES,
@@ -23,6 +23,10 @@ import {
 import { CodingWorkspaceService } from "../services/workspace-service.js";
 
 const roots: string[] = [];
+
+beforeEach(() => {
+  resetSharedWorkspaceRegistry();
+});
 
 afterEach(() => {
   resetSharedWorkspaceRegistry();
@@ -130,46 +134,37 @@ describe("WorkspaceRegistry cap enforcement", () => {
   });
 });
 
-describe("CodingWorkspaceService registry lifecycle", () => {
-  it("marks retained full-clone workspaces terminal so disk pressure can reclaim them", async () => {
+describe("CodingWorkspaceService registry integration", () => {
+  it("marks submitted full-clone workspaces terminal so pressure can evict them", async () => {
     const root = tmpRoot("wsreg-service-");
-    const workspacePath = join(root, "clone-retained");
-    await makeDirWithBytes(workspacePath, 8192);
-    resetSharedWorkspaceRegistry();
-    const registry = getSharedWorkspaceRegistry();
+    const clone = join(root, "clone-submitted");
+    await makeDirWithBytes(clone, 64 * 1024);
+
     const service = new CodingWorkspaceService({
       getSetting: () => undefined,
+      logger: { debug() {}, info() {}, warn() {}, error() {} },
     } as never);
     (
       service as unknown as {
-        workspaces: Map<
-          string,
-          {
-            id: string;
-            path: string;
-            branch: string;
-            baseBranch: string;
-            isWorktree: boolean;
-            repo: string;
-            status: string;
-          }
-        >;
+        workspaces: Map<string, unknown>;
       }
-    ).workspaces.set("ws-retained", {
-      id: "ws-retained",
-      path: workspacePath,
-      branch: "feature/test",
-      baseBranch: "develop",
+    ).workspaces.set("ws-submitted", {
+      id: "ws-submitted",
+      path: clone,
+      branch: "feature",
+      baseBranch: "main",
       isWorktree: false,
-      repo: "https://github.com/elizaOS/eliza.git",
+      repo: "elizaOS/eliza",
       status: "ready",
     });
-    registry.register("git-workspace", workspacePath, "ws-retained");
 
-    service.markWorkspaceTerminal("ws-retained");
-    await registry.checkDiskBudget(root, { capBytes: 0 });
+    const registry = getSharedWorkspaceRegistry();
+    registry.register("git-workspace", clone, "ws-submitted");
+    service.markWorkspaceTerminal("ws-submitted");
 
-    expect(existsSync(workspacePath)).toBe(false);
+    const decision = await registry.checkDiskBudget(root, { capBytes: 0 });
+    expect(decision.reclaimedCount).toBe(1);
+    expect(existsSync(clone)).toBe(false);
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -1054,11 +1054,12 @@ export class AcpService extends Service {
     if (isolate) {
       this.workspaceRegistry.register("acp-scratch", workdir, id);
     }
-    // A spawn that throws after the isolated `task-*` dir is created must not
-    // leak it: the session never becomes durable, so on any failure below we rm
-    // the orphaned dir and drop its registry entry. Without this the dir stays
-    // `live` in the registry, pinning the shared cap for the life of the process
-    // (#13803 review blocker #2: auth/transport/lease failures + cancels leaked).
+    // A spawn that throws after the isolated `task-*` dir is created but before
+    // reserveSessionSlot persists a durable session must not leak it. Once the
+    // session is reserved, the workdir belongs to that durable session record
+    // (including errored transport exits) and must remain inspectable until the
+    // normal session teardown/GC path reclaims it.
+    let sessionReserved = false;
     try {
       // The parent-agent broker is only reachable when the SubAgentRouter is bound
       // to the ACP event stream; gate every broker advertisement (manual section,
@@ -1160,6 +1161,7 @@ export class AcpService extends Service {
       // cap (the old separate enforceSessionLimit()/store.create() left a
       // read-then-act race). Throws SessionCapError when the class is full.
       await this.reserveSessionSlot(session, slotClass);
+      sessionReserved = true;
 
       // Mint the per-spawn model lease BEFORE the transport branch, so the leased
       // token (not the static gateway token) is what buildEnv injects into the
@@ -1293,8 +1295,12 @@ export class AcpService extends Service {
       const sessionSnapshot: SessionInfo = { ...session, status: "ready" };
       return toSpawnResult(updated ?? sessionSnapshot);
     } catch (err) {
-      if (isolate) {
+      if (isolate && !sessionReserved) {
         await this.discardOrphanedScratchOnSpawnFailure(workdir);
+      } else if (isolate) {
+        // Durable failed spawns should not pin the shared cap forever, but their
+        // workdir stays on disk for inspection until session teardown owns the rm.
+        this.workspaceRegistry.markTerminal(workdir);
       }
       throw err;
     }

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -101,6 +101,11 @@ import {
   TERMINAL_SESSION_STATUSES,
 } from "./types.js";
 import { captureBaselineDirty, captureBaselineSha } from "./workspace-diff.js";
+import {
+  getSharedWorkspaceRegistry,
+  resolveDiskBudgetConfig,
+  type WorkspaceRegistry,
+} from "./workspace-registry.js";
 
 type RuntimeLike = IAgentRuntime & {
   logger?: Partial<
@@ -384,12 +389,18 @@ export class AcpService extends Service {
   private readonly changedPathsBySession = new Map<string, Set<string>>();
   private started = false;
   private healthCheckTimer: NodeJS.Timeout | undefined;
+  // Shared across every AcpService + CodingWorkspaceService in the process so a
+  // single disk cap spans both scratch and git-workspace consumers (#13773).
+  private readonly workspaceRegistry: WorkspaceRegistry;
 
   constructor(runtime: IAgentRuntime, opts: { store?: SessionStore } = {}) {
     super(runtime);
     this.runtime = runtime as RuntimeLike;
     this.logger = this.runtime.logger as RuntimeLogger;
     this.store = opts.store ?? new InMemorySessionStore();
+    this.workspaceRegistry = getSharedWorkspaceRegistry((level, msg, ctx) =>
+      this.log(level, msg, ctx),
+    );
     this.cliPath = this.setting("ELIZA_ACP_CLI") ?? "acpx";
     this.transportMode =
       normalizeTransportMode(
@@ -635,6 +646,35 @@ export class AcpService extends Service {
     }
   }
 
+  /**
+   * Run the shared disk-backpressure gate before creating an isolated scratch
+   * dir under `targetRoot`. Throws (fails the spawn loudly) when the total cap
+   * or the free-disk floor cannot be satisfied even after evicting terminal git
+   * workspaces — a spawn that would overflow the disk must surface, not proceed
+   * and fabricate a session that fills the volume (the 3.6TB-class leak, #13773).
+   */
+  private async enforceWorkspaceDiskBudget(targetRoot: string): Promise<void> {
+    const config = resolveDiskBudgetConfig((key) => this.setting(key));
+    const decision = await this.workspaceRegistry.checkDiskBudget(
+      targetRoot,
+      config,
+    );
+    if (decision.reclaimedCount > 0) {
+      this.log("info", "workspace disk budget reclaimed terminal workspaces", {
+        targetRoot,
+        reclaimedCount: decision.reclaimedCount,
+        reclaimedBytes: decision.reclaimedBytes,
+      });
+    }
+    if (!decision.allowed) {
+      throw new Error(
+        `workspace disk budget exceeded (${decision.reason}): ` +
+          `used=${decision.usedBytes} free=${decision.freeBytes} ` +
+          `cap=${config.capBytes} minFree=${config.minFreeBytes} root=${targetRoot}`,
+      );
+    }
+  }
+
   private configuredScratchRoots(): string[] {
     const roots = [
       this.setting("ELIZA_ACP_WORKSPACE_ROOT"),
@@ -700,6 +740,10 @@ export class AcpService extends Service {
     }
     try {
       await rm(session.workdir, { recursive: true, force: true });
+      // Drop the shared-cap accounting entry only after the dir is gone, so a
+      // failed rm below leaves the record for startup GC to retry rather than
+      // silently uncounting bytes still on disk.
+      this.workspaceRegistry.unregister(session.workdir);
       this.log("debug", "reclaimed session scratch dir", {
         sessionId: session.id,
         workdir: session.workdir,
@@ -707,6 +751,7 @@ export class AcpService extends Service {
     } catch (err) {
       // error-policy:J6 best-effort scratch reclaim on teardown; surface the
       // failure so the leak is observable, then let the startup GC retry it.
+      this.workspaceRegistry.markTerminal(session.workdir);
       this.log("warn", "failed to reclaim session scratch dir", {
         sessionId: session.id,
         workdir: session.workdir,
@@ -993,7 +1038,22 @@ export class AcpService extends Service {
     // otherwise share the configured root / DEFAULT_WORKDIR_ROOT.
     const isolate = opts.workdir ? opts.isolateWorkdir === true : true;
     const workdir = computeSessionWorkdir(baseWorkdir, id, isolate);
+    // Disk backpressure: only isolated spawns create a throwaway `task-*` dir we
+    // own, so only they are gated + accounted. A self-checkout / explicit routed
+    // workdir is caller-owned and never touched by the registry. Refusing here
+    // (over the total cap or below the free-disk floor) fails the spawn loudly
+    // rather than letting the mkdir fill the disk — the 3.6TB-class leak (#13773).
+    if (isolate) {
+      await this.enforceWorkspaceDiskBudget(resolve(baseWorkdir));
+    }
     await mkdir(workdir, { recursive: true });
+    // Register AFTER a successful mkdir so an unregistered path is never
+    // reclaimable. ACP scratch is accounting-only here — its session-store GC
+    // (removeOwnedScratchWorkdir / cleanOrphanedScratchWorkdirs) stays the sole
+    // deleter; the registry just counts it against the shared cap.
+    if (isolate) {
+      this.workspaceRegistry.register("acp-scratch", workdir, id);
+    }
     // The parent-agent broker is only reachable when the SubAgentRouter is bound
     // to the ACP event stream; gate every broker advertisement (manual section,
     // SKILLS.md broker entry) on that so a child is never told about a bridge it
@@ -1089,35 +1149,121 @@ export class AcpService extends Service {
       lastActivityAt: now,
       metadata: mergedMetadata,
     };
-    // Atomic check-and-reserve: enforces the session limit for this slot class
-    // and inserts under a single mutex so concurrent spawns can't overshoot the
-    // cap (the old separate enforceSessionLimit()/store.create() left a
-    // read-then-act race). Throws SessionCapError when the class is full.
-    await this.reserveSessionSlot(session, slotClass);
+    // A spawn that throws after the isolated `task-*` dir is created must not
+    // leak it: the session never becomes durable, so on any failure below we rm
+    // the orphaned dir and drop its registry entry. Without this the dir stays
+    // `live` in the registry, pinning the shared cap for the life of the process
+    // (#13803 review blocker #2: auth/transport/lease failures + cancels leaked).
+    try {
+      // Atomic check-and-reserve: enforces the session limit for this slot class
+      // and inserts under a single mutex so concurrent spawns can't overshoot the
+      // cap (the old separate enforceSessionLimit()/store.create() left a
+      // read-then-act race). Throws SessionCapError when the class is full.
+      await this.reserveSessionSlot(session, slotClass);
 
-    // Mint the per-spawn model lease BEFORE the transport branch, so the leased
-    // token (not the static gateway token) is what buildEnv injects into the
-    // child. Fail-closed refusals (credit-gate / strict no-broker / strict mint
-    // failure) throw here; undo the reserved slot so a refused spawn leaves no
-    // orphan session record. No-op when gateway mode / lease broker are off.
-    await this.mintSpawnLease(id, agentType, opts.timeoutMs);
+      // Mint the per-spawn model lease BEFORE the transport branch, so the leased
+      // token (not the static gateway token) is what buildEnv injects into the
+      // child. Fail-closed refusals (credit-gate / strict no-broker / strict mint
+      // failure) throw here; undo the reserved slot so a refused spawn leaves no
+      // orphan session record. No-op when gateway mode / lease broker are off.
+      await this.mintSpawnLease(id, agentType, opts.timeoutMs);
 
-    // App-build tasks lose the parent's deploy contract at the spawn boundary.
-    // Re-attach it ONCE here, before the transport branch, so BOTH the native
-    // and the CLI/acpx paths host the app and report a verified URL. No-op for
-    // non-app tasks; applied only to the initial task, never to follow-up sends.
-    const initialTask =
-      opts.initialTask && opts.initialTask.trim().length > 0
-        ? augmentTaskWithDeployGuidance(opts.initialTask, undefined, {
-            monetized: opts.monetized,
+      // App-build tasks lose the parent's deploy contract at the spawn boundary.
+      // Re-attach it ONCE here, before the transport branch, so BOTH the native
+      // and the CLI/acpx paths host the app and report a verified URL. No-op for
+      // non-app tasks; applied only to the initial task, never to follow-up sends.
+      const initialTask =
+        opts.initialTask && opts.initialTask.trim().length > 0
+          ? augmentTaskWithDeployGuidance(opts.initialTask, undefined, {
+              monetized: opts.monetized,
+            })
+          : opts.initialTask;
+
+      if (this.transportMode === "native") {
+        const result = await this.spawnNativeSession(id, session, {
+          ...opts,
+          customCredentials,
+        });
+        if (opts.initialTask?.trim()) {
+          const keepAliveAfterComplete =
+            (opts.metadata as Record<string, unknown> | undefined)
+              ?.keepAliveAfterComplete === true;
+          void this.sendPrompt(id, initialTask ?? "", {
+            timeoutMs: resolveInitialTaskPromptTimeoutMs(opts.timeoutMs),
+            model: opts.model,
           })
-        : opts.initialTask;
+            .catch((err: unknown) => {
+              // error-policy:J5 fire-and-forget initial prompt; the underlying
+              // failure is also surfaced by sendPrompt (errored status + error event).
+              this.log("error", "initial prompt failed", {
+                sessionId: id,
+                agentType,
+                promptLength: initialTask?.length ?? 0,
+                promptPreview: preview(initialTask ?? ""),
+                error: errorMessage(err),
+              });
+            })
+            .finally(() => {
+              if (keepAliveAfterComplete) return;
+              void this.closeInitialTaskSession(id);
+            });
+        }
+        return result;
+      }
 
-    if (this.transportMode === "native") {
-      const result = await this.spawnNativeSession(id, session, {
-        ...opts,
-        customCredentials,
+      const args = this.baseArgs({
+        workdir,
+        approvalPreset,
+        timeoutMs: opts.timeoutMs,
+        model: opts.model,
       });
+      args.push(
+        ...this.agentCommandArgs(agentType, [
+          "sessions",
+          "new",
+          "--name",
+          name,
+        ]),
+      );
+      const result = await this.runAcpx({
+        sessionId: id,
+        sessionName: name,
+        agentType,
+        workdir,
+        args,
+        env: this.buildEnv(
+          opts.env,
+          customCredentials,
+          opts.model,
+          agentType,
+          id,
+        ),
+      });
+
+      if (result.code !== 0) {
+        const message = this.classifyExitError(result.code, result.stderr);
+        await this.store.updateStatus(id, "errored", message);
+        this.emitSessionEvent(id, "error", {
+          message,
+          exitCode: result.code,
+          stderr: result.stderr,
+        });
+        throw new Error(message);
+      }
+
+      const readyPatch: Partial<SessionInfo> = {
+        status: "ready",
+        pid: undefined,
+        lastActivityAt: new Date(),
+      };
+      await this.store.update(id, readyPatch);
+      this.emitSessionEvent(id, "ready", {
+        sessionId: id,
+        name,
+        agentType,
+        workdir,
+      });
+
       if (opts.initialTask?.trim()) {
         const keepAliveAfterComplete =
           (opts.metadata as Record<string, unknown> | undefined)
@@ -1142,85 +1288,39 @@ export class AcpService extends Service {
             void this.closeInitialTaskSession(id);
           });
       }
-      return result;
+
+      const updated = await this.store.get(id);
+      const sessionSnapshot: SessionInfo = { ...session, status: "ready" };
+      return toSpawnResult(updated ?? sessionSnapshot);
+    } catch (err) {
+      if (isolate) {
+        await this.discardOrphanedScratchOnSpawnFailure(workdir);
+      }
+      throw err;
     }
+  }
 
-    const args = this.baseArgs({
-      workdir,
-      approvalPreset,
-      timeoutMs: opts.timeoutMs,
-      model: opts.model,
-    });
-    args.push(
-      ...this.agentCommandArgs(agentType, ["sessions", "new", "--name", name]),
-    );
-    const result = await this.runAcpx({
-      sessionId: id,
-      sessionName: name,
-      agentType,
-      workdir,
-      args,
-      env: this.buildEnv(
-        opts.env,
-        customCredentials,
-        opts.model,
-        agentType,
-        id,
-      ),
-    });
-
-    if (result.code !== 0) {
-      const message = this.classifyExitError(result.code, result.stderr);
-      await this.store.updateStatus(id, "errored", message);
-      this.emitSessionEvent(id, "error", {
-        message,
-        exitCode: result.code,
-        stderr: result.stderr,
+  /**
+   * Reclaim the isolated scratch dir created for a spawn that then failed before
+   * becoming durable, and drop its registry entry so it stops counting against
+   * the shared cap. Only ever called with a `task-<id>` dir spawnSession itself
+   * mkdir'd this call, so the rm target is unambiguously owned; a failure to
+   * remove is surfaced but not fatal — startup GC reclaims a stubborn dir.
+   */
+  private async discardOrphanedScratchOnSpawnFailure(
+    workdir: string,
+  ): Promise<void> {
+    this.workspaceRegistry.unregister(workdir);
+    try {
+      await rm(workdir, { recursive: true, force: true });
+    } catch (err) {
+      // error-policy:J6 best-effort reclaim of a failed-spawn scratch dir; the
+      // leak is surfaced and the startup GC retries it on the next boot.
+      this.log("warn", "failed to reclaim scratch dir after spawn failure", {
+        workdir,
+        error: errorMessage(err),
       });
-      throw new Error(message);
     }
-
-    const readyPatch: Partial<SessionInfo> = {
-      status: "ready",
-      pid: undefined,
-      lastActivityAt: new Date(),
-    };
-    await this.store.update(id, readyPatch);
-    this.emitSessionEvent(id, "ready", {
-      sessionId: id,
-      name,
-      agentType,
-      workdir,
-    });
-
-    if (opts.initialTask?.trim()) {
-      const keepAliveAfterComplete =
-        (opts.metadata as Record<string, unknown> | undefined)
-          ?.keepAliveAfterComplete === true;
-      void this.sendPrompt(id, initialTask ?? "", {
-        timeoutMs: resolveInitialTaskPromptTimeoutMs(opts.timeoutMs),
-        model: opts.model,
-      })
-        .catch((err: unknown) => {
-          // error-policy:J5 fire-and-forget initial prompt; the underlying
-          // failure is also surfaced by sendPrompt (errored status + error event).
-          this.log("error", "initial prompt failed", {
-            sessionId: id,
-            agentType,
-            promptLength: initialTask?.length ?? 0,
-            promptPreview: preview(initialTask ?? ""),
-            error: errorMessage(err),
-          });
-        })
-        .finally(() => {
-          if (keepAliveAfterComplete) return;
-          void this.closeInitialTaskSession(id);
-        });
-    }
-
-    const updated = await this.store.get(id);
-    const sessionSnapshot: SessionInfo = { ...session, status: "ready" };
-    return toSpawnResult(updated ?? sessionSnapshot);
   }
 
   /**
@@ -1399,6 +1499,11 @@ export class AcpService extends Service {
         session.acpxSessionId ?? session.agentSessionId ?? session.id,
       );
       await this.store.updateStatus(sessionId, "cancelled");
+      // Stop the scratch dir counting against the shared cap the moment the
+      // session is terminal; the actual rm still happens on close/delete via
+      // removeOwnedScratchWorkdir (a cancelled session may be reopened/inspected
+      // before teardown). Accounting-only — the registry never rm's ACP dirs.
+      this.workspaceRegistry.markTerminal(session.workdir);
       void this.revokeModelLease(sessionId, "cancelSession:native");
       return;
     }
@@ -1420,6 +1525,7 @@ export class AcpService extends Service {
       });
     }
     await this.store.updateStatus(sessionId, "cancelled");
+    this.workspaceRegistry.markTerminal(session.workdir);
     void this.revokeModelLease(sessionId, "cancelSession");
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -1054,12 +1054,11 @@ export class AcpService extends Service {
     if (isolate) {
       this.workspaceRegistry.register("acp-scratch", workdir, id);
     }
-    // A spawn that throws after the isolated `task-*` dir is created but before
-    // reserveSessionSlot persists a durable session must not leak it. Once the
-    // session is reserved, the workdir belongs to that durable session record
-    // (including errored transport exits) and must remain inspectable until the
-    // normal session teardown/GC path reclaims it.
-    let sessionReserved = false;
+    // A spawn that throws after the isolated `task-*` dir is created has two
+    // cleanup modes: pre-reservation failures have no durable session and can
+    // delete the orphan dir; post-reservation failures keep the dir inspectable
+    // on the errored session and only release it from shared-cap accounting.
+    let sessionCreated = false;
     try {
       // The parent-agent broker is only reachable when the SubAgentRouter is bound
       // to the ACP event stream; gate every broker advertisement (manual section,
@@ -1161,7 +1160,7 @@ export class AcpService extends Service {
       // cap (the old separate enforceSessionLimit()/store.create() left a
       // read-then-act race). Throws SessionCapError when the class is full.
       await this.reserveSessionSlot(session, slotClass);
-      sessionReserved = true;
+      sessionCreated = true;
 
       // Mint the per-spawn model lease BEFORE the transport branch, so the leased
       // token (not the static gateway token) is what buildEnv injects into the
@@ -1295,11 +1294,11 @@ export class AcpService extends Service {
       const sessionSnapshot: SessionInfo = { ...session, status: "ready" };
       return toSpawnResult(updated ?? sessionSnapshot);
     } catch (err) {
-      if (isolate && !sessionReserved) {
+      if (isolate && !sessionCreated) {
         await this.discardOrphanedScratchOnSpawnFailure(workdir);
       } else if (isolate) {
-        // Durable failed spawns should not pin the shared cap forever, but their
-        // workdir stays on disk for inspection until session teardown owns the rm.
+        const message = errorMessage(err);
+        await this.store.updateStatus(id, "errored", message);
         this.workspaceRegistry.markTerminal(workdir);
       }
       throw err;

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -1054,107 +1054,107 @@ export class AcpService extends Service {
     if (isolate) {
       this.workspaceRegistry.register("acp-scratch", workdir, id);
     }
-    // The parent-agent broker is only reachable when the SubAgentRouter is bound
-    // to the ACP event stream; gate every broker advertisement (manual section,
-    // SKILLS.md broker entry) on that so a child is never told about a bridge it
-    // cannot use.
-    const brokerWired = isParentAgentBrokerWired(this.runtime);
-    // Give the sub-agent its eliza-context + non-interactive operating manual on
-    // disk (where every backend reads it) — only when the workspace is bare, so
-    // a real repo's own AGENTS.md/CLAUDE.md is never clobbered.
-    await writeWorkspaceIdentity(workdir, { brokerWired });
-    // Write SKILLS.md into every spawn workspace so a child can discover (and
-    // request, via the parent) the parent's installed skills — not just the
-    // economics loop. The broker skill is advertised only when wired; the
-    // recommended-slugs / ViewKind extras are opt-in via opts.skillsManifest.
-    await this.writeSkillsManifest(workdir, id, brokerWired, opts);
-
-    // Record the workspace HEAD + already-dirty files at spawn so the change
-    // set captured at task_complete is scoped to exactly what this sub-agent
-    // did (and excludes pre-existing churn it never touched). Empty/undefined
-    // when the workspace isn't a git repo — capture then relies on the agent's
-    // own edit/write tool-call paths.
-    const baselineSha = await captureBaselineSha(workdir);
-    const baselineDirty = await captureBaselineDirty(workdir);
-
-    // Multi-account selection: pick the least-used (default) linked subscription
-    // for this agent type and inject its credentials into the spawn env so the
-    // sub-agent authenticates AS that account. Returns null (and we keep the
-    // single-account behavior) when no accounts are linked.
-    const accountStrategy = resolveCodingAccountStrategy(
-      this.setting("ELIZA_CODING_ACCOUNT_STRATEGY"),
-    );
-    const resolvedAccount = await selectCodingAccount(agentType, {
-      sessionKey: id,
-      ...(accountStrategy ? { strategy: accountStrategy } : {}),
-    });
-    const customCredentials = resolvedAccount
-      ? {
-          ...(opts.customCredentials ?? {}),
-          ...resolvedAccount.selection.envPatch,
-        }
-      : opts.customCredentials;
-    if (resolvedAccount) {
-      this.log("info", "coding account selected for spawn", {
-        sessionId: id,
-        agentType,
-        providerId: resolvedAccount.meta.providerId,
-        accountId: resolvedAccount.meta.accountId,
-        label: resolvedAccount.meta.label,
-        strategy: resolvedAccount.meta.strategy,
-      });
-    } else {
-      // A degraded pool must not hard-fail a spawn, but it must not degrade
-      // invisibly either (#9960). Warn loudly only when accounts are connected
-      // yet none are healthy — a benign empty pool stays quiet.
-      const fallbackWarning = diagnoseCodingAccountFallback(agentType);
-      if (fallbackWarning) {
-        this.log("warn", "coding account pool degraded to single-account", {
-          sessionId: id,
-          agentType,
-          detail: fallbackWarning,
-        });
-      }
-    }
-
-    const now = new Date();
-    // Stamp the capacity class onto the session so getCapacity() (and the
-    // admission queue that reads it) can count worker vs system slots off the
-    // durable record. Always persisted — a worker session carries slotClass so
-    // the accounting never has to infer "worker" from an absent field.
-    const slotClass: SessionSlotClass = opts.slotClass ?? "worker";
-    const mergedMetadata: Record<string, unknown> = {
-      ...(opts.metadata ?? {}),
-      ...(isolate
-        ? {
-            [ACP_METADATA_ISOLATED_WORKDIR]: true,
-            [ACP_METADATA_WORKDIR_ROOT]: resolve(baseWorkdir),
-          }
-        : {}),
-      ...(baselineSha ? { codingBaselineSha: baselineSha } : {}),
-      ...(baselineSha && baselineDirty.length > 0
-        ? { codingBaselineDirty: baselineDirty }
-        : {}),
-      ...(resolvedAccount ? { account: resolvedAccount.meta } : {}),
-      slotClass,
-    };
-    const session: SessionInfo = {
-      id,
-      name,
-      agentType,
-      workdir,
-      status: "running",
-      approvalPreset,
-      createdAt: now,
-      lastActivityAt: now,
-      metadata: mergedMetadata,
-    };
     // A spawn that throws after the isolated `task-*` dir is created must not
     // leak it: the session never becomes durable, so on any failure below we rm
     // the orphaned dir and drop its registry entry. Without this the dir stays
     // `live` in the registry, pinning the shared cap for the life of the process
     // (#13803 review blocker #2: auth/transport/lease failures + cancels leaked).
     try {
+      // The parent-agent broker is only reachable when the SubAgentRouter is bound
+      // to the ACP event stream; gate every broker advertisement (manual section,
+      // SKILLS.md broker entry) on that so a child is never told about a bridge it
+      // cannot use.
+      const brokerWired = isParentAgentBrokerWired(this.runtime);
+      // Give the sub-agent its eliza-context + non-interactive operating manual on
+      // disk (where every backend reads it) — only when the workspace is bare, so
+      // a real repo's own AGENTS.md/CLAUDE.md is never clobbered.
+      await writeWorkspaceIdentity(workdir, { brokerWired });
+      // Write SKILLS.md into every spawn workspace so a child can discover (and
+      // request, via the parent) the parent's installed skills — not just the
+      // economics loop. The broker skill is advertised only when wired; the
+      // recommended-slugs / ViewKind extras are opt-in via opts.skillsManifest.
+      await this.writeSkillsManifest(workdir, id, brokerWired, opts);
+
+      // Record the workspace HEAD + already-dirty files at spawn so the change
+      // set captured at task_complete is scoped to exactly what this sub-agent
+      // did (and excludes pre-existing churn it never touched). Empty/undefined
+      // when the workspace isn't a git repo — capture then relies on the agent's
+      // own edit/write tool-call paths.
+      const baselineSha = await captureBaselineSha(workdir);
+      const baselineDirty = await captureBaselineDirty(workdir);
+
+      // Multi-account selection: pick the least-used (default) linked subscription
+      // for this agent type and inject its credentials into the spawn env so the
+      // sub-agent authenticates AS that account. Returns null (and we keep the
+      // single-account behavior) when no accounts are linked.
+      const accountStrategy = resolveCodingAccountStrategy(
+        this.setting("ELIZA_CODING_ACCOUNT_STRATEGY"),
+      );
+      const resolvedAccount = await selectCodingAccount(agentType, {
+        sessionKey: id,
+        ...(accountStrategy ? { strategy: accountStrategy } : {}),
+      });
+      const customCredentials = resolvedAccount
+        ? {
+            ...(opts.customCredentials ?? {}),
+            ...resolvedAccount.selection.envPatch,
+          }
+        : opts.customCredentials;
+      if (resolvedAccount) {
+        this.log("info", "coding account selected for spawn", {
+          sessionId: id,
+          agentType,
+          providerId: resolvedAccount.meta.providerId,
+          accountId: resolvedAccount.meta.accountId,
+          label: resolvedAccount.meta.label,
+          strategy: resolvedAccount.meta.strategy,
+        });
+      } else {
+        // A degraded pool must not hard-fail a spawn, but it must not degrade
+        // invisibly either (#9960). Warn loudly only when accounts are connected
+        // yet none are healthy — a benign empty pool stays quiet.
+        const fallbackWarning = diagnoseCodingAccountFallback(agentType);
+        if (fallbackWarning) {
+          this.log("warn", "coding account pool degraded to single-account", {
+            sessionId: id,
+            agentType,
+            detail: fallbackWarning,
+          });
+        }
+      }
+
+      const now = new Date();
+      // Stamp the capacity class onto the session so getCapacity() (and the
+      // admission queue that reads it) can count worker vs system slots off the
+      // durable record. Always persisted — a worker session carries slotClass so
+      // the accounting never has to infer "worker" from an absent field.
+      const slotClass: SessionSlotClass = opts.slotClass ?? "worker";
+      const mergedMetadata: Record<string, unknown> = {
+        ...(opts.metadata ?? {}),
+        ...(isolate
+          ? {
+              [ACP_METADATA_ISOLATED_WORKDIR]: true,
+              [ACP_METADATA_WORKDIR_ROOT]: resolve(baseWorkdir),
+            }
+          : {}),
+        ...(baselineSha ? { codingBaselineSha: baselineSha } : {}),
+        ...(baselineSha && baselineDirty.length > 0
+          ? { codingBaselineDirty: baselineDirty }
+          : {}),
+        ...(resolvedAccount ? { account: resolvedAccount.meta } : {}),
+        slotClass,
+      };
+      const session: SessionInfo = {
+        id,
+        name,
+        agentType,
+        workdir,
+        status: "running",
+        approvalPreset,
+        createdAt: now,
+        lastActivityAt: now,
+        metadata: mergedMetadata,
+      };
       // Atomic check-and-reserve: enforces the session limit for this slot class
       // and inserts under a single mutex so concurrent spawns can't overshoot the
       // cap (the old separate enforceSessionLimit()/store.create() left a

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-registry.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-registry.ts
@@ -1,0 +1,374 @@
+/**
+ * Process-global accounting ledger for every scratch/workspace directory the
+ * orchestrator creates on disk, and the disk-backpressure gate that runs before
+ * a new one is provisioned. It is the single lifecycle owner that spans the two
+ * otherwise-disjoint disk consumers — `AcpService` per-session scratch dirs and
+ * `CodingWorkspaceService` git clones/worktrees — so a shared total-workspace
+ * cap and a free-disk floor can be enforced across both.
+ *
+ * Safety invariant (the reason #13803 was closed): reclaimability is derived
+ * ONLY from a record this registry wrote in `register()` at creation time. A
+ * path the ledger never saw is never touched, and reclaim never infers
+ * ownership from a `task-*` path shape — that inference is exactly what could
+ * delete a caller-owned `$ELIZA_WORKSPACE_DIR/task-foo`. Deletion authority is
+ * per-record: only `git-workspace` records are reclaimed by this registry (that
+ * clone path has no other GC on the cap); `acp-scratch` records are
+ * accounting-only — `AcpService`'s session-store-owned GC (proven by
+ * `ACP_METADATA_ISOLATED_WORKDIR`) remains their sole deleter, and this ledger
+ * merely flips their `live` flag so they stop counting against the cap.
+ */
+import type { Dirent } from "node:fs";
+import { readdir, rm, stat, statfs } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+export type WorkspaceKind = "acp-scratch" | "git-workspace";
+
+export interface WorkspaceRecord {
+  /** Absolute, resolved directory path — the ledger key. */
+  readonly path: string;
+  readonly kind: WorkspaceKind;
+  /** Owning session id (ACP) or workspace id (git) — for diagnostics only. */
+  readonly ownerId: string;
+  readonly createdAt: number;
+  /**
+   * True while the owner is still using the dir. A live record is never
+   * reclaimed and always counts against the cap; teardown flips it to false.
+   */
+  live: boolean;
+}
+
+export interface DiskBudgetConfig {
+  /**
+   * Total bytes the sum of all registered workspace dirs may occupy before a
+   * new provision forces reclaim of terminal git workspaces. `undefined`
+   * disables the total cap (free-disk floor still applies).
+   */
+  readonly capBytes?: number;
+  /**
+   * Minimum free bytes that must remain on the target filesystem AFTER the new
+   * dir is created. A provision is refused when the filesystem is below this
+   * floor and reclaim cannot recover enough. `undefined` disables the floor.
+   */
+  readonly minFreeBytes?: number;
+}
+
+/** 20 GiB default total cap; a busy swarm of clones stays well under this. */
+export const DEFAULT_WORKSPACE_DISK_CAP_BYTES = 20 * 1024 * 1024 * 1024;
+/** 2 GiB default free-disk floor; below this, clones/mkdirs are refused. */
+export const DEFAULT_WORKSPACE_MIN_FREE_BYTES = 2 * 1024 * 1024 * 1024;
+
+export interface BudgetDecision {
+  readonly allowed: boolean;
+  /** Bytes freed by reclaiming terminal git workspaces during this check. */
+  readonly reclaimedBytes: number;
+  /** Number of terminal git-workspace dirs reclaimed. */
+  readonly reclaimedCount: number;
+  /** Free bytes on the target filesystem after any reclaim. */
+  readonly freeBytes: number;
+  /** Sum of registered workspace bytes after any reclaim. */
+  readonly usedBytes: number;
+  /** Populated only when `allowed` is false. */
+  readonly reason?: "cap-exceeded" | "free-disk-floor";
+}
+
+type Logger = (
+  level: "debug" | "info" | "warn",
+  message: string,
+  context?: Record<string, unknown>,
+) => void;
+
+/**
+ * Recursively sum regular-file sizes under `dir`. Symlinks are stat'd with
+ * `lstat` semantics via `stat`'s follow — but directory recursion uses
+ * `withFileTypes` and never follows symlinked directories, so a workspace that
+ * symlinks a shared store is not double-counted or walked out of bounds. A
+ * vanished entry (concurrent teardown) contributes zero rather than throwing;
+ * the caller is measuring a best-effort footprint, not auditing.
+ */
+export async function measureDirBytes(dir: string): Promise<number> {
+  let total = 0;
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    // A dir that vanished or is unreadable contributes nothing measurable.
+    return 0;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      total += await measureDirBytes(full);
+      continue;
+    }
+    try {
+      const st = await stat(full);
+      total += st.size;
+    } catch {
+      // Raced with teardown — skip.
+    }
+  }
+  return total;
+}
+
+/**
+ * Free bytes on the filesystem backing `path`, or `undefined` when the platform
+ * cannot report it. `undefined` is an explicit "unknown" (never fabricated as
+ * plenty-of-space): the caller treats an unknown reading as a hard refusal when
+ * a floor is configured, so a broken `statfs` fails closed, not open.
+ */
+export async function freeBytesFor(path: string): Promise<number | undefined> {
+  try {
+    const st = await statfs(path);
+    // bavail is blocks available to unprivileged users; bsize the block size.
+    return st.bavail * st.bsize;
+  } catch {
+    return undefined;
+  }
+}
+
+export class WorkspaceRegistry {
+  private readonly records = new Map<string, WorkspaceRecord>();
+
+  constructor(private readonly log: Logger = () => {}) {}
+
+  /**
+   * Record a dir the caller just created. Idempotent on path: re-registering an
+   * existing path refreshes its owner/kind/live and keeps the original
+   * `createdAt` so LRU order survives a re-register. Callers MUST call this only
+   * after the mkdir/clone succeeded — an unregistered path is invisible to the
+   * cap and never reclaimable, which is the intended fail-safe.
+   */
+  register(kind: WorkspaceKind, dir: string, ownerId: string): void {
+    const path = resolve(dir);
+    const existing = this.records.get(path);
+    this.records.set(path, {
+      path,
+      kind,
+      ownerId,
+      createdAt: existing?.createdAt ?? Date.now(),
+      live: true,
+    });
+  }
+
+  /**
+   * Flip a record to terminal. It stops counting toward the cap and becomes a
+   * reclaim candidate (git-workspace only). A no-op for an unregistered path —
+   * the registry never learns about dirs it did not create.
+   */
+  markTerminal(dir: string): void {
+    const record = this.records.get(resolve(dir));
+    if (record) {
+      record.live = false;
+    }
+  }
+
+  /** Drop a record entirely (the owner deleted the dir itself). */
+  unregister(dir: string): void {
+    this.records.delete(resolve(dir));
+  }
+
+  has(dir: string): boolean {
+    return this.records.has(resolve(dir));
+  }
+
+  isLive(dir: string): boolean {
+    return this.records.get(resolve(dir))?.live === true;
+  }
+
+  list(): WorkspaceRecord[] {
+    return Array.from(this.records.values());
+  }
+
+  size(): number {
+    return this.records.size;
+  }
+
+  /** Sum measured bytes across every currently-registered dir. */
+  async usedBytes(): Promise<number> {
+    let total = 0;
+    for (const record of this.records.values()) {
+      total += await measureDirBytes(record.path);
+    }
+    return total;
+  }
+
+  /**
+   * Reclaim terminal `git-workspace` records, oldest first, until at least
+   * `targetFreeBytes` have been freed (or no more candidates remain). Only dirs
+   * this registry recorded are ever passed to `rm`; live records and
+   * `acp-scratch` records are never touched here. Returns freed bytes + count.
+   */
+  private async reclaimTerminalGitWorkspaces(
+    targetFreeBytes: number,
+  ): Promise<{ freed: number; count: number }> {
+    const candidates = Array.from(this.records.values())
+      .filter((r) => r.kind === "git-workspace" && !r.live)
+      .sort((a, b) => a.createdAt - b.createdAt);
+    let freed = 0;
+    let count = 0;
+    for (const record of candidates) {
+      if (freed >= targetFreeBytes) break;
+      const bytes = await measureDirBytes(record.path);
+      try {
+        await rm(record.path, { recursive: true, force: true });
+      } catch (err) {
+        // error-policy:J6 best-effort eviction; a locked/vanished dir is skipped
+        // so the sweep continues and the cap is retried on the next provision.
+        this.log("warn", "workspace registry: failed to evict terminal dir", {
+          path: record.path,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        continue;
+      }
+      this.records.delete(record.path);
+      freed += bytes;
+      count += 1;
+    }
+    return { freed, count };
+  }
+
+  /**
+   * Backpressure gate to run BEFORE creating a new workspace dir under
+   * `targetRoot`. Enforces two independent limits: (1) the total registered-byte
+   * cap, force-reclaiming terminal git workspaces (LRU) to get back under it;
+   * (2) a free-disk floor on the filesystem backing `targetRoot`, likewise
+   * reclaiming to recover headroom. An unknown free-disk reading fails closed
+   * when a floor is set. Never deletes a live or unregistered dir.
+   */
+  async checkDiskBudget(
+    targetRoot: string,
+    config: DiskBudgetConfig,
+  ): Promise<BudgetDecision> {
+    let reclaimedBytes = 0;
+    let reclaimedCount = 0;
+
+    let used = await this.usedBytes();
+    if (config.capBytes !== undefined && used > config.capBytes) {
+      const { freed, count } = await this.reclaimTerminalGitWorkspaces(
+        used - config.capBytes,
+      );
+      reclaimedBytes += freed;
+      reclaimedCount += count;
+      used = Math.max(0, used - freed);
+      if (used > config.capBytes) {
+        this.log("warn", "workspace registry: total cap exceeded", {
+          usedBytes: used,
+          capBytes: config.capBytes,
+          reclaimedBytes,
+        });
+        return {
+          allowed: false,
+          reclaimedBytes,
+          reclaimedCount,
+          freeBytes: (await freeBytesFor(targetRoot)) ?? 0,
+          usedBytes: used,
+          reason: "cap-exceeded",
+        };
+      }
+    }
+
+    if (config.minFreeBytes !== undefined) {
+      let free = await freeBytesFor(targetRoot);
+      if (free === undefined || free < config.minFreeBytes) {
+        const deficit =
+          free === undefined ? config.minFreeBytes : config.minFreeBytes - free;
+        const { freed, count } =
+          await this.reclaimTerminalGitWorkspaces(deficit);
+        reclaimedBytes += freed;
+        reclaimedCount += count;
+        free = await freeBytesFor(targetRoot);
+      }
+      if (free === undefined || free < config.minFreeBytes) {
+        this.log("warn", "workspace registry: free-disk floor breached", {
+          targetRoot,
+          freeBytes: free,
+          minFreeBytes: config.minFreeBytes,
+          reclaimedBytes,
+        });
+        return {
+          allowed: false,
+          reclaimedBytes,
+          reclaimedCount,
+          freeBytes: free ?? 0,
+          usedBytes: used,
+          reason: "free-disk-floor",
+        };
+      }
+      return {
+        allowed: true,
+        reclaimedBytes,
+        reclaimedCount,
+        freeBytes: free,
+        usedBytes: used,
+      };
+    }
+
+    return {
+      allowed: true,
+      reclaimedBytes,
+      reclaimedCount,
+      freeBytes: (await freeBytesFor(targetRoot)) ?? 0,
+      usedBytes: used,
+    };
+  }
+}
+
+/**
+ * Parse a byte-count setting. Accepts a bare integer (bytes). Returns
+ * `undefined` for absent/blank/non-positive input so a caller can distinguish
+ * "unset → use default" from an explicit disable via `0`... which we treat as
+ * unset too: disabling a disk floor is done by leaving it unset, not by 0.
+ */
+export function parseByteSetting(
+  value: string | undefined,
+): number | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  if (trimmed === "") return undefined;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
+}
+
+/**
+ * Resolve the shared disk-budget config from env-style settings. `capBytes` and
+ * `minFreeBytes` fall back to the module defaults when unset; pass `"0"` is
+ * treated as unset (see `parseByteSetting`), so tunables only ever raise or
+ * lower a real limit, never silently remove it.
+ */
+export function resolveDiskBudgetConfig(
+  read: (key: string) => string | undefined,
+): DiskBudgetConfig {
+  return {
+    capBytes:
+      parseByteSetting(read("ELIZA_WORKSPACE_DISK_CAP_BYTES")) ??
+      DEFAULT_WORKSPACE_DISK_CAP_BYTES,
+    minFreeBytes:
+      parseByteSetting(read("ELIZA_WORKSPACE_MIN_FREE_BYTES")) ??
+      DEFAULT_WORKSPACE_MIN_FREE_BYTES,
+  };
+}
+
+let sharedRegistry: WorkspaceRegistry | undefined;
+
+/**
+ * Process-global registry shared by every AcpService and CodingWorkspaceService
+ * instance so the cap spans all disk consumers in the process. A process-global
+ * (not per-runtime) singleton is deliberate: multi-tenant hosts and hot-reload
+ * cycles construct multiple service instances against ONE filesystem, and the
+ * disk budget is a property of the filesystem, not of any one runtime.
+ */
+export function getSharedWorkspaceRegistry(log?: Logger): WorkspaceRegistry {
+  if (!sharedRegistry) {
+    sharedRegistry = new WorkspaceRegistry(log);
+  }
+  return sharedRegistry;
+}
+
+/** Test-only reset of the process-global registry. */
+export function resetSharedWorkspaceRegistry(): void {
+  sharedRegistry = undefined;
+}

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -696,13 +696,15 @@ export class CodingWorkspaceService {
     if (!workspace) {
       throw new Error(`Workspace ${workspaceId} not found`);
     }
-    return gitCreatePR(
+    const pullRequest = await gitCreatePR(
       this.workspaceService,
       workspace,
       workspaceId,
       options,
       (msg) => this.log(msg),
     );
+    this.markWorkspaceTerminal(workspaceId);
+    return pullRequest;
   }
 
   // === Delegated GitHub / Issue Management ===
@@ -823,6 +825,23 @@ export class CodingWorkspaceService {
     }
     this.workspaces.delete(workspaceId);
     this.log(`Removed workspace ${workspaceId}`);
+  }
+
+  /**
+   * Release a full-clone workspace from active use while keeping it on disk for
+   * later inspection. The shared registry may evict released clones under disk
+   * pressure; worktrees are deliberately excluded because their bytes belong to
+   * the parent clone and cleanup remains parent-owned.
+   */
+  markWorkspaceTerminal(workspaceId: string): void {
+    const workspace = this.workspaces.get(workspaceId);
+    if (!workspace) {
+      throw new Error(`Workspace ${workspaceId} not found`);
+    }
+    if (!workspace.isWorktree) {
+      this.workspaceRegistry.markTerminal(workspace.path);
+    }
+    this.log(`Released workspace ${workspaceId} for disk-pressure reclaim`);
   }
 
   onEvent(callback: WorkspaceEventCallback): () => void {

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -84,6 +84,11 @@ import {
   gcOrphanedWorkspaces,
   removeScratchDir,
 } from "./workspace-lifecycle.js";
+import {
+  getSharedWorkspaceRegistry,
+  resolveDiskBudgetConfig,
+  type WorkspaceRegistry,
+} from "./workspace-registry.js";
 
 export type {
   CodingWorkspaceConfig,
@@ -275,6 +280,10 @@ export class CodingWorkspaceService {
   private githubClient: GitHubPatClientInstance | null = null;
   private githubAuthInProgress: Promise<GitHubPatClientInstance> | null = null;
   private serviceConfig: CodingWorkspaceConfig;
+  // Shared with every AcpService so one disk cap spans scratch + git workspaces
+  // (#13773). Git workspaces ARE reclaimable by the registry (this clone path
+  // has no other GC on the cap), unlike accounting-only ACP scratch dirs.
+  private readonly workspaceRegistry: WorkspaceRegistry;
   private workspaces: Map<string, WorkspaceResult> = new Map();
   private ambientCredentialWorkspaceIds = new Set<string>();
   private labels: Map<string, string> = new Map(); // label -> workspaceId
@@ -290,6 +299,7 @@ export class CodingWorkspaceService {
 
   constructor(runtime: IAgentRuntime, config: CodingWorkspaceConfig = {}) {
     this.runtime = runtime;
+    this.workspaceRegistry = getSharedWorkspaceRegistry();
     this.serviceConfig = {
       baseDir: config.baseDir ?? resolveDefaultBaseDir(runtime),
       branchPrefix: config.branchPrefix ?? "eliza",
@@ -492,6 +502,12 @@ export class CodingWorkspaceService {
       "baseBranch",
     );
 
+    // Disk backpressure BEFORE the clone/worktree hits disk: refuse (after
+    // evicting terminal git workspaces LRU) when the shared cap or free-disk
+    // floor cannot be met, so repeated provisions can't fill the volume — the
+    // gap #13803 review blocker #3 flagged (the cap only blocked ACP spawns).
+    await this.enforceWorkspaceDiskBudget(this.serviceConfig.baseDir as string);
+
     const workspaceConfig: WorkspaceConfig = {
       repo,
       strategy: options.useWorktree ? "worktree" : "clone",
@@ -527,8 +543,58 @@ export class CodingWorkspaceService {
     };
 
     this.workspaces.set(workspace.id, result);
+    // Register AFTER a successful provision so an unregistered clone is never
+    // reclaimable. Worktrees share their parent clone's checkout, so only a full
+    // clone is registered as reclaimable disk — a worktree's teardown is owned
+    // by the parent workspace and double-counting it would let the cap evict a
+    // dir whose bytes are the parent's.
+    if (!result.isWorktree) {
+      this.workspaceRegistry.register(
+        "git-workspace",
+        result.path,
+        workspace.id,
+      );
+    }
     this.log(`Provisioned workspace ${workspace.id}`);
     return result;
+  }
+
+  /**
+   * Run the shared disk-backpressure gate before cloning under `targetRoot`.
+   * Throws (fails the provision loudly) when the total cap or free-disk floor
+   * cannot be met even after evicting terminal git workspaces — a clone that
+   * would overflow the disk must surface, never proceed.
+   */
+  private async enforceWorkspaceDiskBudget(targetRoot: string): Promise<void> {
+    const config = resolveDiskBudgetConfig((key) => this.readSetting(key));
+    const decision = await this.workspaceRegistry.checkDiskBudget(
+      targetRoot,
+      config,
+    );
+    if (decision.reclaimedCount > 0) {
+      this.log(
+        `disk budget reclaimed ${decision.reclaimedCount} terminal workspaces ` +
+          `(${decision.reclaimedBytes} bytes)`,
+      );
+    }
+    if (!decision.allowed) {
+      throw new Error(
+        `workspace disk budget exceeded (${decision.reason}): ` +
+          `used=${decision.usedBytes} free=${decision.freeBytes} ` +
+          `cap=${config.capBytes} minFree=${config.minFreeBytes} root=${targetRoot}`,
+      );
+    }
+  }
+
+  private readSetting(key: string): string | undefined {
+    const fromRuntime = this.runtime.getSetting(key);
+    if (typeof fromRuntime === "string" && fromRuntime.length > 0) {
+      return fromRuntime;
+    }
+    const fromConfig = this.readConfigEnvKey(key);
+    if (fromConfig && fromConfig.length > 0) return fromConfig;
+    const fromEnv = process.env[key];
+    return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
   }
 
   getWorkspace(id: string): WorkspaceResult | undefined {
@@ -749,6 +815,11 @@ export class CodingWorkspaceService {
     const workspace = this.workspaces.get(workspaceId);
     if (workspace?.label) {
       this.labels.delete(workspace.label);
+    }
+    // Drop the shared-cap accounting entry after cleanup removed the dir. Only
+    // full clones were registered, so a worktree removal is a no-op here.
+    if (workspace && !workspace.isWorktree) {
+      this.workspaceRegistry.unregister(workspace.path);
     }
     this.workspaces.delete(workspaceId);
     this.log(`Removed workspace ${workspaceId}`);

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -696,7 +696,7 @@ export class CodingWorkspaceService {
     if (!workspace) {
       throw new Error(`Workspace ${workspaceId} not found`);
     }
-    const pullRequest = await gitCreatePR(
+    const result = await gitCreatePR(
       this.workspaceService,
       workspace,
       workspaceId,
@@ -704,7 +704,7 @@ export class CodingWorkspaceService {
       (msg) => this.log(msg),
     );
     this.markWorkspaceTerminal(workspaceId);
-    return pullRequest;
+    return result;
   }
 
   // === Delegated GitHub / Issue Management ===
@@ -828,20 +828,17 @@ export class CodingWorkspaceService {
   }
 
   /**
-   * Release a full-clone workspace from active use while keeping it on disk for
-   * later inspection. The shared registry may evict released clones under disk
-   * pressure; worktrees are deliberately excluded because their bytes belong to
-   * the parent clone and cleanup remains parent-owned.
+   * Release a full-clone workspace from active accounting without deleting it.
+   * A submitted/archived workspace stays inspectable until explicit removal, but
+   * disk pressure may reclaim it later through the registry's LRU path.
    */
   markWorkspaceTerminal(workspaceId: string): void {
     const workspace = this.workspaces.get(workspaceId);
-    if (!workspace) {
-      throw new Error(`Workspace ${workspaceId} not found`);
+    if (!workspace || workspace.isWorktree) {
+      return;
     }
-    if (!workspace.isWorktree) {
-      this.workspaceRegistry.markTerminal(workspace.path);
-    }
-    this.log(`Released workspace ${workspaceId} for disk-pressure reclaim`);
+    this.workspaceRegistry.markTerminal(workspace.path);
+    this.log(`Marked workspace ${workspaceId} terminal for disk reclaim`);
   }
 
   onEvent(callback: WorkspaceEventCallback): () => void {


### PR DESCRIPTION
## Summary

Extracts the **SAFE residual** of closed PR #13803 for issue #13773: a **shared workspace registry** (one lifecycle owner across ACP scratch dirs + `CodingWorkspaceService` git provisions) and **disk backpressure** (env-tunable total cap + free-disk precheck). This is the WS3 slice that #13803 could not ship safely.

Items already landed are **not touched**:
- Item 1 (ACP scratch teardown + startup GC): merged via #13792 / #13808 / #13895.
- Item 3 (git-index isolation for same-repo concurrency): in-flight as #14042.

## How this avoids #13803's fatal flaws

Per @lalalune's review comments on #13803:

| #13803 flaw | Fix here |
|---|---|
| Reclaim guard deleted any `task-*` child of `ELIZA_WORKSPACE_DIR` by **path shape** → could `rm -rf` a caller-owned `$ELIZA_WORKSPACE_DIR/task-foo` with `isolate:false`. | Reclaimability comes **only** from a record the registry wrote in `register()` at creation. A path the ledger never saw is never touched. **No path-shape inference anywhere.** |
| Overlapped the already-merged ACP teardown/GC. | The registry **does not delete ACP scratch dirs**. Develop's session-store-owned GC (`removeOwnedScratchWorkdir` / `cleanOrphanedScratchWorkdirs`, ownership proven by `ACP_METADATA_ISOLATED_WORKDIR`) stays their sole deleter. ACP entries are **accounting-only** — `live` flips on teardown. Only `git-workspace` records (no cap before) are registry-reclaimable via LRU eviction of terminal ones. |
| Blocker 2: failed/cancelled spawns leaked and pinned scratch dirs as `live`. | `spawnSession` wraps post-`register` setup in `try/catch`: any failure (slot cap, lease, transport, CLI) rm's the orphaned dir and `unregister`s it. `cancelSession` marks terminal. |
| Blocker 3: no preflight budget check on the git-provision path. | `provisionWorkspace` runs `enforceWorkspaceDiskBudget` **before** the clone. |

## Design

`workspace-registry.ts` — process-global singleton shared by every `AcpService` + `CodingWorkspaceService` (the disk budget is a property of the filesystem, not a runtime). Records `{ path, kind, ownerId, createdAt, live }`. `checkDiskBudget(root)` enforces the total-registered-bytes cap (force-evicting terminal git workspaces LRU) and a free-disk floor via `statfs` (fails **closed** on an unknown reading). Env tunables: `ELIZA_WORKSPACE_DISK_CAP_BYTES`, `ELIZA_WORKSPACE_MIN_FREE_BYTES`.

## Tests — real fs, no mocks

`src/__tests__/workspace-registry.test.ts` (12) + `src/__tests__/acp-spawn-disk-budget.test.ts` (2), driving real temp dirs, real `statfs`/`rm`, and the production `AcpService.spawnSession` path:

- registry-miss ⇒ **never deletes** (the #13803 caller-owned `task-*` case)
- registered `acp-scratch` + `live` git dirs survive an over-cap sweep
- LRU cap eviction reclaims oldest terminal git workspace only, stops under cap
- cap unsatisfiable (only live dirs) ⇒ refuse, delete nothing
- `statfs` free-disk floor ⇒ refuse below floor, allow above
- real `spawnSession` failure (slot cap full) ⇒ orphan dir removed + unregistered
- `spawnSession` df-floor breach ⇒ refuses before any mkdir

```
$ bun run --cwd plugins/plugin-agent-orchestrator test -- \
    src/__tests__/workspace-registry.test.ts \
    src/__tests__/acp-spawn-disk-budget.test.ts --coverage.enabled=false
 Test Files  2 passed (2)
      Tests  14 passed (14)
```

Existing lifecycle/provision suites (`acp-scratch-lifecycle`, `acp-capacity-slot-class`, `provision-workspace`, `provision-workspace-injection`, `workspace-isolation`) pass unchanged. `bunx biome check` clean on all touched files; `bun run audit:error-policy-ratchet` reports no new fallback-slop. Plugin `typecheck` clean.

### Evidence

- **N/A – no user-facing UI.** This is a server-side disk-lifecycle change in `@elizaos/plugin-agent-orchestrator`; there is no web/desktop/mobile surface to screenshot. The observable behavior (a spawn refused over-budget; an orphaned scratch dir reclaimed on failure) is proven by the real-fs regression tests above, which drive the production `spawnSession`/`provisionWorkspace` code paths against real directories.

Part of #13773

🤖 Generated with [Claude Code](https://claude.com/claude-code)
