### PR TITLE
fix(orchestrator): drop post-completion teardown-race session errors (#13830 audit)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -156,6 +156,23 @@ async function drive(
   await flush();
 }
 
+/** Poll until the task reaches `status`. The `task_complete` bridge path does
+ * real async IO (change-set mirror, trajectory ingest #13775) before the
+ * `completion_reported` status advance, so a single-macrotask {@link flush}
+ * races it — asserting the post-completion status directly is flaky. */
+async function settleStatus(
+  service: OrchestratorTaskService,
+  taskId: string,
+  status: string,
+): Promise<void> {
+  await expect
+    .poll(async () => must(await service.getTask(taskId), "task").status, {
+      timeout: 5000,
+      interval: 25,
+    })
+    .toBe(status);
+}
+
 /** A started service with one task and one spawned (ready) session, plus the
  * fake ACP wired to its event bridge. */
 async function withSpawnedSession(): Promise<{
@@ -1113,9 +1130,7 @@ describe("OrchestratorTaskService — task status guards", () => {
   it("moves the task to validating on completion, never straight to done", async () => {
     const { service, acp, taskId, sessionId } = await withSpawnedSession();
     await drive(acp, sessionId, "task_complete", { response: "done" });
-    expect(must(await service.getTask(taskId), "detail").status).toBe(
-      "validating",
-    );
+    await settleStatus(service, taskId, "validating");
   });
 
   it("routes blocked and login_required to the right task status", async () => {
@@ -1142,6 +1157,7 @@ describe("OrchestratorTaskService — task status guards", () => {
   it("does not let a later active signal stomp validating", async () => {
     const { service, acp, taskId, sessionId } = await withSpawnedSession();
     await drive(acp, sessionId, "task_complete", { response: "done" });
+    await settleStatus(service, taskId, "validating");
     await drive(acp, sessionId, "tool_running", { toolCall: { title: "ls" } });
     expect(must(await service.getTask(taskId), "detail").status).toBe(
       "validating",
@@ -1151,6 +1167,7 @@ describe("OrchestratorTaskService — task status guards", () => {
   it("never mutates a terminal task from a session event", async () => {
     const { service, acp, taskId, sessionId } = await withSpawnedSession();
     await drive(acp, sessionId, "task_complete", { response: "done" });
+    await settleStatus(service, taskId, "validating");
     await service.validateTask(taskId, { passed: true, summary: "verified" });
     await drive(acp, sessionId, "tool_running", { toolCall: { title: "ls" } });
     expect(must(await service.getTask(taskId), "detail").status).toBe("done");
@@ -1633,5 +1650,52 @@ describe("OrchestratorTaskService — restart reconstruction (#13771)", () => {
     const after = must(await restarted.getTask(task.id), "after restart");
     expect(after.status).toBe("blocked");
     expect(after.events?.some((e) => e.eventType === "blocked")).toBe(true);
+  });
+});
+
+// A late `error` for a session that already posted `task_complete` is a
+// teardown race — the process dropped its state AFTER the deliverable shipped.
+// The router suppresses its respawn for exactly this case (the completion
+// claim in router-loop-guard); the task bridge must be symmetric: keep the
+// `completed` session record, keep the task in `validating` so the in-flight
+// verification can finish (validateTask requires `validating`), and spend
+// nothing from the crash-retry budget.
+describe("OrchestratorTaskService — post-completion teardown race (#13830 audit)", () => {
+  it("drops a late session error after task_complete: task stays validating, session stays completed", async () => {
+    const { service, acp, taskId, sessionId } = await withSpawnedSession();
+    await drive(acp, sessionId, "task_complete", { response: "shipped" });
+    await settleStatus(service, taskId, "validating");
+    expect(
+      must(must(await service.getTask(taskId), "mid").sessions[0], "session")
+        .status,
+    ).toBe("completed");
+
+    await drive(acp, sessionId, "error", {
+      failureKind: "session_state_lost",
+      message: "session state lost during teardown",
+    });
+    // Give the straggler's (fast, in-memory) error path time to land before
+    // asserting it changed nothing.
+    await flush();
+
+    const after = must(await service.getTask(taskId), "after");
+    expect(after.status).toBe("validating");
+    expect(must(after.sessions[0], "session").status).toBe("completed");
+    expect(
+      after.events?.some((e) => e.eventType === "session_error_retrying"),
+    ).toBe(false);
+    expect(after.events?.some((e) => e.eventType === "task_failed")).toBe(
+      false,
+    );
+  });
+
+  it("still fails the task when a plain crash errors a session that never completed", async () => {
+    const { service, acp, taskId, sessionId } = await withSpawnedSession();
+    await drive(acp, sessionId, "error", {
+      message: "process exited with code 1",
+    });
+    await settleStatus(service, taskId, "failed");
+    const detail = must(await service.getTask(taskId), "detail");
+    expect(must(detail.sessions[0], "session").status).toBe("errored");
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -165,12 +165,14 @@ async function settleStatus(
   taskId: string,
   status: string,
 ): Promise<void> {
-  await expect
-    .poll(async () => must(await service.getTask(taskId), "task").status, {
-      timeout: 5000,
-      interval: 25,
-    })
-    .toBe(status);
+  const deadline = Date.now() + 5000;
+  let last: string | undefined;
+  while (Date.now() < deadline) {
+    last = must(await service.getTask(taskId), "task").status;
+    if (last === status) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  expect(last).toBe(status);
 }
 
 /** A started service with one task and one spawned (ready) session, plus the

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -1005,10 +1005,6 @@ export class OrchestratorTaskService extends Service {
         break;
       }
       case "error": {
-        await this.store.updateSession(sessionId, {
-          status: "errored",
-          stoppedAt: Date.now(),
-        });
         const failureKind = str(record.failureKind);
         const message = str(record.message) ?? "";
         if (
@@ -1026,6 +1022,21 @@ export class OrchestratorTaskService extends Service {
             message,
           );
         }
+        // A late error for a session that already delivered its result is a
+        // teardown race (the process dropped its state AFTER task_complete
+        // posted), not a work failure — the router suppresses its respawn for
+        // exactly this case (router-loop-guard `state_lost` completion claim).
+        // It must not overwrite the `completed` session record with `errored`,
+        // inflate the crash-retry budget, or knock a `validating` task back to
+        // `active` mid-verification (that aborts validateTask — status is no
+        // longer `validating` — and wedges the task with no live worker). The
+        // raw event is already on the task timeline via recordSessionEvent.
+        const prior = (await this.store.findSession(sessionId))?.session;
+        if (prior?.status === "completed") break;
+        await this.store.updateSession(sessionId, {
+          status: "errored",
+          stoppedAt: Date.now(),
+        });
         await this.advanceTaskOnSessionError(taskId, sessionId, {
           failureKind,
           message,
@@ -2561,7 +2572,10 @@ export class OrchestratorTaskService extends Service {
         correction,
         "validation_failed",
       );
-      await this.store.updateTask(taskId, { status: "active" });
+      // Route the validating→active retry through the transition table so an
+      // operator archive/pause that landed while the judge was running is not
+      // stomped by a direct status write (illegal moves drop as no-ops).
+      await this.advanceTaskStatus(taskId, "validation_failed");
     } catch (sendErr) {
       // error-policy:J1 boundary — a failed corrective send becomes a structured
       // escalation (event + waiting_on_user), never a silent stall.


### PR DESCRIPTION
Post-merge adversarial audit of #13830 (task-lifecycle rework, issue #13771; follow-up #13909 already fixed the un-respawnable-crash wedge). This PR fixes two remaining defects found on current develop.

## Defect 1: post-completion teardown race wedges a validating task

A late session `error` arriving **after the same session already posted `task_complete`** is a teardown race, not a work failure. `router-loop-guard.ts` (`state_lost` case) explicitly models this — "its deliverable shipped before the process dropped its session state" — and suppresses the respawn. The task event bridge had no symmetric guard:

1. It overwrote the `completed` durable session record with `errored`.
2. It counted the straggler against the crash-retry budget (`SESSION_ERROR_STATUSES` lineage count).
3. Via the `validating → retrying → active` edge #13830 added, it knocked the task out of `validating` **while auto-verification was in flight**. `validateTask` then throws `"Task must be validating"` into the fire-and-forget J7 catch, the verdict is discarded, and the task wedges at `active` with **no live worker** (the router suppressed the respawn) — the same non-terminal-hang class #13771/#13909 exist to prevent, except here the work actually succeeded.

Fix: in the bridge `error` case, read the durable session first; if it is already `completed`, keep the record, spend no budget, and leave the task status alone (the raw event stays on the timeline via `recordSessionEvent`; account-health marking still runs). A crash of a session that never completed is unaffected — regression-tested.

## Defect 2: auto-verify re-engage bypassed the transition table

`reEngageOrEscalate` wrote `store.updateTask(taskId, { status: "active" })` directly. If an operator archived or paused the task while the judge was running, that direct write stomps the operator's state (e.g. an archived task ends up `archived: true, status: "active"`), violating the terminal-immutability the #13830 table exists to enforce. Now routed through `advanceTaskStatus(taskId, "validation_failed")` — identical in the normal `validating → active` case, a legal no-op otherwise.

## Test hardening (pre-existing flake in #13830's own tests)

The `task_complete` bridge path does real async IO (change-set mirror, trajectory ingest #13775) before the `completion_reported` advance, so the single-macrotask `drive()` flush the #13830 tests rely on is racy. On current develop, `moves the task to validating on completion` and `never mutates a terminal task from a session event` **fail when run in isolation** (`vitest ... -t "never mutates a terminal task"`). Added a `settleStatus()` poll helper at the racy assertions.

## Verification

```
vitest run __tests__/unit/orchestrator-task-service.test.ts        # 71 passed
vitest run __tests__/unit/session-crash-terminates.test.ts \
           __tests__/unit/task-status-transitions.test.ts          # 13 passed
vitest run ... -t "never mutates a terminal task"                  # passes in isolation (failed before)
vitest run ... -t "post-completion teardown race"                  # 2 passed (new regression tests)
tsgo --noEmit  # no errors in touched files; biome check clean
```

New regression tests drive the real service over the in-memory store + FakeAcp: `task_complete` → late `session_state_lost` error → task stays `validating`, session stays `completed`, no `session_error_retrying`/`task_failed` events; plain crash without completion still reaches terminal `failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)