### PR TITLE
fix(orchestrator): give stale test runtime mocks getRoom/reportError (11 develop reds)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/control-resume-clears-paused.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/control-resume-clears-paused.test.ts
@@ -155,6 +155,8 @@ async function harness(): Promise<{
       type === OrchestratorTaskService.serviceType ? taskService : acp,
     ),
     hasService: vi.fn(() => true),
+    getRoom: vi.fn(async () => null),
+    reportError: vi.fn(),
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
   } as never as IAgentRuntime;
   const store = new OrchestratorTaskStore({ backend: "memory" });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-history.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-history.test.ts
@@ -61,6 +61,8 @@ function runtimeWithServices(opts: {
         : (opts.acpService ?? null),
     ),
     hasService: vi.fn(() => Boolean(opts.taskService ?? opts.acpService)),
+    getRoom: vi.fn(async () => null),
+    reportError: vi.fn(),
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
   } as never;
 }


### PR DESCRIPTION
Fixes **11 pre-existing develop-tip test failures** across two orchestrator unit files, found by running the full `plugin-agent-orchestrator` suite and isolating the deterministic (non-pollution) reds.

## Failing on develop

```
__tests__/unit/control-resume-clears-paused.test.ts   8 failed
__tests__/unit/task-history.test.ts                   3 failed
```

Both fail identically:

```
TypeError: runtime.reportError is not a function
  at resolveConnectorSource  src/services/task-policy.ts:193
  at requireTaskAgentAccess  src/services/task-policy.ts:285
```

## Root cause

`resolveConnectorSource` (task-policy.ts) gained a room-source lookup:

```ts
try {
  const room = await runtime.getRoom(message.roomId);
  if (typeof room?.source === "string" && ...) return room.source;
} catch (error) {
  // fail closed: surface + access-denied sentinel
  runtime.reportError("task-policy.resolveConnectorSource", error, { roomId });
  return SOURCE_RESOLUTION_FAILED;
}
```

Both files' **inline runtime mocks predate this** — they provide only `getService`/`hasService`/`logger`. So `runtime.getRoom` is `undefined` → the call throws → the catch runs `runtime.reportError` (also `undefined`) → **every test that reaches `requireTaskAgentAccess` dies with the TypeError before its own assertions run**. (These are real reds in isolation, not the cross-file pollution that `isolate:false` also produces in this suite for a few other files.)

## Fix

Add the two missing methods to both mocks:

```ts
getRoom: vi.fn(async () => null),   // reproduces the pre-existing "no room source → GUEST default" path
reportError: vi.fn(),
```

`getRoom → null` means `resolveConnectorSource` returns `null` exactly as it did before the room lookup existed, so the tests get their original intended access behavior. Test-only; no production code touched.

## Verification

```
bun run --cwd plugins/plugin-agent-orchestrator test -- \
  __tests__/unit/task-history.test.ts __tests__/unit/control-resume-clears-paused.test.ts
# before: 8 failed / 3 failed
# after:  Tests  12 passed (12)
```

(Separately noted for the owners: `acp-scratch-gc.test.ts` and one case in `orchestrator-task-service.test.ts` also fail in isolation but with a *different*, non-`reportError` cause — out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)