### PR TITLE
fix(notifications): retry native push registration boot

### DIFF
--- a/packages/agent/src/services/push/README.md
+++ b/packages/agent/src/services/push/README.md
@@ -72,6 +72,7 @@ mints an FCM token (see that module's `build.gradle`).
 - Integration: `push-registration-flow.test.ts` drives the full loop — a token
   POSTed through the real HTTP route reaches the provider `send()` on an emitted
   notification.
-- Live: `push-delivery.real.test.ts` sends against Apple's / Google's real
-  servers when creds are set (post-merge lane), asserting a bogus token is
-  rejected end to end. Delivery to a real **enrolled device** is pending-hardware.
+- Live: `bunx vitest run --config packages/agent/vitest.push-real.config.ts`
+  sends against Apple's / Google's real servers when creds are set, asserting a
+  bogus token is rejected end to end. Delivery to a real **enrolled device** is
+  pending-hardware.

--- a/packages/agent/vitest.push-real.config.ts
+++ b/packages/agent/vitest.push-real.config.ts
@@ -1,0 +1,19 @@
+/** Dedicated Vitest entry for the remote-push real delivery check.
+ *
+ * The regular agent harness excludes `*.real.test.ts` in every lane so live
+ * APNs/FCM calls never leak into deterministic package tests. This config keeps
+ * the same aliases and setup, then narrows execution to the credential-gated
+ * push delivery suite so release evidence can run it explicitly when private
+ * provider credentials and enrolled devices are available.
+ */
+import { defineConfig } from "vitest/config";
+import agentConfig from "./vitest.config";
+
+export default defineConfig({
+  ...agentConfig,
+  test: {
+    ...agentConfig.test,
+    include: ["src/services/push/push-delivery.real.test.ts"],
+    exclude: ["dist/**", "**/node_modules/**"],
+  },
+});

--- a/packages/scripts/lib/real-live-suites.mjs
+++ b/packages/scripts/lib/real-live-suites.mjs
@@ -64,7 +64,7 @@ export const GUARDED_REAL_LIVE_SUITES = [
       "packages/agent/src/services/push/fcm-provider.ts",
     ],
     blocked:
-      "packages/agent/vitest.config.ts excludes *.real.test.ts in every lane; run explicitly via `bunx vitest run --config packages/agent/vitest.config.ts src/services/push/push-delivery.real.test.ts` with ELIZA_APNS_* / ELIZA_FCM_SERVICE_ACCOUNT set. Real-device delivery is pending-hardware (needs an enrolled device).",
+      "packages/agent/vitest.config.ts excludes *.real.test.ts in every deterministic lane; run explicitly via `bunx vitest run --config packages/agent/vitest.push-real.config.ts` with ELIZA_APNS_* / ELIZA_FCM_SERVICE_ACCOUNT set. Real-device delivery is pending-hardware (needs an enrolled device).",
   },
   {
     file: "packages/app-core/src/services/coding-account-bridge.live.test.ts",

--- a/packages/ui/src/state/notifications/push-registration.test.ts
+++ b/packages/ui/src/state/notifications/push-registration.test.ts
@@ -120,6 +120,37 @@ describe("initPushRegistration", () => {
     expect(deps.registerToken).not.toHaveBeenCalled();
   });
 
+  it("retries after permission is granted later", async () => {
+    let permission: "granted" | "denied" = "denied";
+    const plugin = makePlugin(permission);
+    plugin.checkPermissions = async () => ({ receive: permission });
+    const deps = makeDeps(plugin, "ios");
+
+    await initPushRegistration(deps);
+    permission = "granted";
+    await initPushRegistration(deps);
+
+    expect(plugin.__registerCalls).toBe(1);
+  });
+
+  it("retries when native register() fails before the OS accepts the request", async () => {
+    const plugin = makePlugin("granted");
+    plugin.register = async function (this: FakePlugin) {
+      this.__registerCalls++;
+      if (this.__registerCalls === 1) {
+        throw new Error("native bridge unavailable");
+      }
+    };
+    const deps = makeDeps(plugin, "ios");
+
+    await expect(initPushRegistration(deps)).rejects.toThrow(
+      "native bridge unavailable",
+    );
+    await initPushRegistration(deps);
+
+    expect(plugin.__registerCalls).toBe(2);
+  });
+
   it("no-ops on non-native platforms (web/desktop)", async () => {
     const plugin = makePlugin("granted");
     const deps = makeDeps(plugin, "web");

--- a/packages/ui/src/state/notifications/push-registration.test.ts
+++ b/packages/ui/src/state/notifications/push-registration.test.ts
@@ -22,9 +22,9 @@ import {
 } from "./push-registration";
 
 type ListenerMap = {
-  registration?: (token: PushRegistrationToken) => void;
-  registrationError?: (error: PushRegistrationError) => void;
-  pushNotificationActionPerformed?: (action: PushActionPerformed) => void;
+  registration: Array<(token: PushRegistrationToken) => void>;
+  registrationError: Array<(error: PushRegistrationError) => void>;
+  pushNotificationActionPerformed: Array<(action: PushActionPerformed) => void>;
 };
 
 interface FakePlugin extends PushNotificationsPluginLike {
@@ -35,7 +35,11 @@ interface FakePlugin extends PushNotificationsPluginLike {
 function makePlugin(
   permission: "granted" | "denied" | "prompt" = "granted",
 ): FakePlugin {
-  const listeners: ListenerMap = {};
+  const listeners: ListenerMap = {
+    registration: [],
+    registrationError: [],
+    pushNotificationActionPerformed: [],
+  };
   const handle: PluginListenerHandle = { remove: async () => {} };
   return {
     __listeners: listeners,
@@ -46,7 +50,7 @@ function makePlugin(
     },
     unregister: async () => {},
     addListener: (async (event: keyof ListenerMap, fn: never) => {
-      listeners[event] = fn as never;
+      listeners[event].push(fn as never);
       return handle;
     }) as PushNotificationsPluginLike["addListener"],
     removeAllListeners: async () => {},
@@ -68,6 +72,21 @@ function makeDeps(
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
+function emitRegistration(plugin: FakePlugin, token: string): void {
+  for (const listener of plugin.__listeners.registration) {
+    listener({ value: token });
+  }
+}
+
+function emitPushTap(plugin: FakePlugin, data: Record<string, unknown>): void {
+  for (const listener of plugin.__listeners.pushNotificationActionPerformed) {
+    listener({
+      actionId: "tap",
+      notification: { data },
+    });
+  }
+}
+
 describe("initPushRegistration", () => {
   beforeEach(() => __resetPushRegistrationForTests());
   afterEach(() => __resetPushRegistrationForTests());
@@ -80,7 +99,7 @@ describe("initPushRegistration", () => {
     expect(plugin.__registerCalls).toBe(1);
 
     // OS mints the token and fires `registration` asynchronously.
-    plugin.__listeners.registration?.({ value: "apns-device-token" });
+    emitRegistration(plugin, "apns-device-token");
     await flush();
 
     expect(deps.registerToken).toHaveBeenCalledWith("ios", "apns-device-token");
@@ -91,7 +110,7 @@ describe("initPushRegistration", () => {
     const deps = makeDeps(plugin, "android");
 
     await initPushRegistration(deps);
-    plugin.__listeners.registration?.({ value: "fcm-token" });
+    emitRegistration(plugin, "fcm-token");
     await flush();
 
     expect(deps.registerToken).toHaveBeenCalledWith("android", "fcm-token");
@@ -102,9 +121,9 @@ describe("initPushRegistration", () => {
     const deps = makeDeps(plugin, "ios");
 
     await initPushRegistration(deps);
-    plugin.__listeners.registration?.({ value: "same-token" });
+    emitRegistration(plugin, "same-token");
     await flush();
-    plugin.__listeners.registration?.({ value: "same-token" });
+    emitRegistration(plugin, "same-token");
     await flush();
 
     expect(deps.registerToken).toHaveBeenCalledTimes(1);
@@ -149,6 +168,16 @@ describe("initPushRegistration", () => {
     await initPushRegistration(deps);
 
     expect(plugin.__registerCalls).toBe(2);
+    expect(plugin.__listeners.registration).toHaveLength(1);
+    expect(plugin.__listeners.registrationError).toHaveLength(1);
+    expect(plugin.__listeners.pushNotificationActionPerformed).toHaveLength(1);
+
+    emitRegistration(plugin, "retry-token");
+    await flush();
+    expect(deps.registerToken).toHaveBeenCalledTimes(1);
+
+    emitPushTap(plugin, { deepLink: "/tasks", notificationId: "abc" });
+    expect(deps.navigate).toHaveBeenCalledTimes(1);
   });
 
   it("no-ops on non-native platforms (web/desktop)", async () => {
@@ -176,10 +205,7 @@ describe("initPushRegistration", () => {
     const deps = makeDeps(plugin, "ios");
 
     await initPushRegistration(deps);
-    plugin.__listeners.pushNotificationActionPerformed?.({
-      actionId: "tap",
-      notification: { data: { deepLink: "/tasks", notificationId: "abc" } },
-    });
+    emitPushTap(plugin, { deepLink: "/tasks", notificationId: "abc" });
 
     expect(deps.navigate).toHaveBeenCalledWith("/tasks");
   });
@@ -189,10 +215,7 @@ describe("initPushRegistration", () => {
     const deps = makeDeps(plugin, "ios");
 
     await initPushRegistration(deps);
-    plugin.__listeners.pushNotificationActionPerformed?.({
-      actionId: "tap",
-      notification: { data: { notificationId: "abc" } },
-    });
+    emitPushTap(plugin, { notificationId: "abc" });
 
     expect(deps.navigate).not.toHaveBeenCalled();
   });
@@ -202,7 +225,7 @@ describe("initPushRegistration", () => {
     const deps = makeDeps(plugin, "ios");
 
     await initPushRegistration(deps);
-    plugin.__listeners.registration?.({ value: "tok-to-drop" });
+    emitRegistration(plugin, "tok-to-drop");
     await flush();
 
     await unregisterPushToken(deps);

--- a/packages/ui/src/state/notifications/push-registration.ts
+++ b/packages/ui/src/state/notifications/push-registration.ts
@@ -63,7 +63,7 @@ const defaultDeps: PushRegistrationDeps = {
   navigate: navigateDeepLink,
 };
 
-let started = false;
+let startPromise: Promise<void> | null = null;
 /** The most recent token we POSTed, so a re-fired `registration` is a no-op. */
 let registeredToken: string | null = null;
 
@@ -106,10 +106,22 @@ async function onRegistration(
 export async function initPushRegistration(
   deps: PushRegistrationDeps = defaultDeps,
 ): Promise<void> {
-  if (started) return;
+  startPromise ??= startPushRegistration(deps)
+    .then((didStart) => {
+      if (!didStart) startPromise = null;
+    })
+    .catch((error: unknown) => {
+      startPromise = null;
+      throw error;
+    });
+  await startPromise;
+}
 
+async function startPushRegistration(
+  deps: PushRegistrationDeps,
+): Promise<boolean> {
   const platform = pushPlatform(deps.getPlatform());
-  if (!platform) return;
+  if (!platform) return false;
 
   const plugin = deps.getPlugin();
   if (
@@ -117,16 +129,14 @@ export async function initPushRegistration(
     typeof plugin.addListener !== "function"
   ) {
     // Native build without the push plugin — nothing to register against.
-    return;
+    return false;
   }
 
   // Gate on an already-granted permission; never prompt from here.
   if (typeof plugin.checkPermissions === "function") {
     const status = await plugin.checkPermissions();
-    if (status.receive !== "granted") return;
+    if (status.receive !== "granted") return false;
   }
-
-  started = true;
 
   await plugin.addListener("registration", (token: PushRegistrationToken) => {
     void onRegistration(deps, platform, token).catch((error: unknown) => {
@@ -158,6 +168,7 @@ export async function initPushRegistration(
   );
 
   await plugin.register();
+  return true;
 }
 
 /** Drop this device's token server-side and locally (logout / revoke). */
@@ -172,6 +183,6 @@ export async function unregisterPushToken(
 
 /** Test-only reset of the module-level registration guards. */
 export function __resetPushRegistrationForTests(): void {
-  started = false;
+  startPromise = null;
   registeredToken = null;
 }

--- a/packages/ui/src/state/notifications/push-registration.ts
+++ b/packages/ui/src/state/notifications/push-registration.ts
@@ -64,6 +64,7 @@ const defaultDeps: PushRegistrationDeps = {
 };
 
 let startPromise: Promise<void> | null = null;
+let listenerPromise: Promise<void> | null = null;
 /** The most recent token we POSTed, so a re-fired `registration` is a no-op. */
 let registeredToken: string | null = null;
 
@@ -138,7 +139,36 @@ async function startPushRegistration(
     if (status.receive !== "granted") return false;
   }
 
-  await plugin.addListener("registration", (token: PushRegistrationToken) => {
+  await ensurePushListeners(deps, plugin, platform);
+
+  await plugin.register();
+  return true;
+}
+
+function ensurePushListeners(
+  deps: PushRegistrationDeps,
+  plugin: PushNotificationsPluginLike,
+  platform: "ios" | "android",
+): Promise<void> {
+  listenerPromise ??= addPushListeners(deps, plugin, platform).catch(
+    (error: unknown) => {
+      listenerPromise = null;
+      throw error;
+    },
+  );
+  return listenerPromise;
+}
+
+async function addPushListeners(
+  deps: PushRegistrationDeps,
+  plugin: PushNotificationsPluginLike,
+  platform: "ios" | "android",
+): Promise<void> {
+  const addListener = plugin.addListener;
+  if (typeof addListener !== "function") {
+    throw new Error("PushNotifications.addListener is unavailable");
+  }
+  await addListener("registration", (token: PushRegistrationToken) => {
     void onRegistration(deps, platform, token).catch((error: unknown) => {
       // error-policy:J1 transport boundary — a failed token POST leaves
       // registeredToken null so the next `registration` retries; surface it.
@@ -149,7 +179,7 @@ async function startPushRegistration(
     });
   });
 
-  await plugin.addListener(
+  await addListener(
     "registrationError",
     (error: PushRegistrationError) => {
       logger.error(
@@ -159,16 +189,13 @@ async function startPushRegistration(
     },
   );
 
-  await plugin.addListener(
+  await addListener(
     "pushNotificationActionPerformed",
     (action: PushActionPerformed) => {
       const deepLink = deepLinkFromAction(action);
       if (deepLink) deps.navigate(deepLink);
     },
   );
-
-  await plugin.register();
-  return true;
 }
 
 /** Drop this device's token server-side and locally (logout / revoke). */
@@ -184,5 +211,6 @@ export async function unregisterPushToken(
 /** Test-only reset of the module-level registration guards. */
 export function __resetPushRegistrationForTests(): void {
   startPromise = null;
+  listenerPromise = null;
   registeredToken = null;
 }


### PR DESCRIPTION
## Summary
- Keep native push registration retryable when permission is granted after an earlier boot no-op or when Capacitor register() fails before the OS accepts the request.
- Add tests for both retry cases so the token registration bridge does not permanently wedge.
- Add a dedicated `packages/agent/vitest.push-real.config.ts` so the APNs/FCM real-delivery test is actually runnable when private credentials are available, and update docs/real-live manifest text.

## Verification
- `bun run --cwd packages/ui test -- src/api/client-notifications.test.ts src/state/notifications/push-registration.test.ts src/state/notifications/notification-store.test.ts` — 3 files, 31 tests passed.
- `bun run --cwd packages/agent test -- src/api/push-token-routes.test.ts src/services/push/push-token-registry.test.ts src/services/push/notification-push-service.test.ts src/services/push/apns-provider.test.ts src/services/push/fcm-provider.test.ts src/services/push/push-registration-flow.test.ts src/api/notification-lazy-route.test.ts` — 7 files, 47 tests passed.
- `bunx biome check packages/agent/vitest.push-real.config.ts packages/agent/src/services/push/README.md packages/scripts/lib/real-live-suites.mjs packages/ui/src/api/client-notifications.ts packages/ui/src/api/client-notifications.test.ts packages/ui/src/state/notifications/push-registration.ts packages/ui/src/state/notifications/push-registration.test.ts packages/agent/src/services/push/push-registration-flow.test.ts packages/agent/src/services/push/push-delivery.real.test.ts` — passed.
- `bunx vitest run --config packages/agent/vitest.push-real.config.ts` — 1 passed, 2 skipped with no APNs/FCM credentials present. This is a credential guard, not real delivery evidence.
- `bun test packages/scripts/__tests__/real-live-suites.test.ts` — 7 passed.

## Blocked Evidence
- Real APNs/FCM server rejection/delivery requires private `ELIZA_APNS_*` or `ELIZA_FCM_SERVICE_ACCOUNT` credentials. Not available in this environment.
- Real device delivery requires an enrolled iOS/Android device/build. Not available in this environment.
- `bun run --cwd packages/ui typecheck` is blocked by existing unrelated UI test fixture type errors.
- `bun run --cwd packages/agent typecheck` is blocked by existing unrelated optional plugin/proactive payload type errors.

Follow-up to #13537 after #13731 merged.