### PR TITLE
chore(security): allowlist gitleaks false positive — env-var name in test cleanup list

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -31,3 +31,8 @@ f9184d51cc60210ad6be388f3b1f1eae529a9904:packages/research/chip/scripts/test_rel
 # infra columns (deployment_log_key is a storage path, not a credential).
 # The test exists precisely to prove this field never reaches API responses.
 69e4235edffd5a526c7ff4b920d1c6b3d9a429f9:packages/cloud/api/v1/containers/route.test.ts:generic-api-key:148
+
+# Env-var NAME (not a value) in a test's env-cleanup list: the string literal
+# "ELIZA_APP_DISCORD_CLIENT_SECRET" matches the discord-client-secret regex by
+# identifier shape alone. No secret material on this line.
+8177acbf458c2c7ae164584e79408aac048bb17b:packages/cloud/shared/src/lib/services/eliza-app/config.error-policy.test.ts:discord-client-secret:13

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -32,7 +32,7 @@ f9184d51cc60210ad6be388f3b1f1eae529a9904:packages/research/chip/scripts/test_rel
 # The test exists precisely to prove this field never reaches API responses.
 69e4235edffd5a526c7ff4b920d1c6b3d9a429f9:packages/cloud/api/v1/containers/route.test.ts:generic-api-key:148
 
-# Env-var NAME (not a value) in a test's env-cleanup list: the string literal
-# "ELIZA_APP_DISCORD_CLIENT_SECRET" matches the discord-client-secret regex by
-# identifier shape alone. No secret material on this line.
+# Env-var NAMES (not values) in a test's env-cleanup list: the string literals
+# "ELIZA_APP_DISCORD_BOT_TOKEN" and "ELIZA_APP_DISCORD_APPLICATION_ID" match the
+# discord-client-secret regex by identifier shape alone. No secret material here.
 8177acbf458c2c7ae164584e79408aac048bb17b:packages/cloud/shared/src/lib/services/eliza-app/config.error-policy.test.ts:discord-client-secret:13


### PR DESCRIPTION
Main's post-promote gitleaks run ([28744302250](https://github.com/elizaOS/eliza/actions/runs/28744302250)) is red on ONE finding: `discord-client-secret` matching line 13 of `config.error-policy.test.ts` — the string literal `"ELIZA_APP_DISCORD_CLIENT_SECRET"` in the test's `TOUCHED_ENV` cleanup list. That's an env-var **name**, not secret material (verified by reading the line; SARIF fingerprint scoped to commit 8177acbf).

Fingerprint-scoped `.gitleaksignore` entry, same pattern as the existing entry for the containers-route fixture. Keeps main's secret-scan signal meaningful during launch (two REAL secret incidents were handled today — this false positive would train everyone to ignore the red X).

My commit → no self-merge; anyone from the lalalune/0xSolace lanes please review + arm. (#13406) `[maintainer]`