### PR TITLE
fix(ui,training): close the two #14068 capability-grant residuals (split-pane surface prop + training grant)

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1102,6 +1102,7 @@ function ViewLayoutSurface({
                       componentExport={view.componentExport}
                       viewId={view.id}
                       viewType={view.viewType}
+                      surface={view.surface}
                     />
                   ) : (
                     <ViewRouter routeOverride={routeOverrideForView(view)} />

--- a/plugins/plugin-training/src/setup-routes.ts
+++ b/plugins/plugin-training/src/setup-routes.ts
@@ -365,6 +365,10 @@ export const trainingPlugin: Plugin = {
       modalities: ["gui", "xr", "tui"],
       bundlePath: "dist/views/bundle.js",
       componentExport: "FineTuningView",
+      // FineTuningView instruments its panels with useAgentElement; without
+      // the grant the capability broker (#14068) denies agent-click/agent-fill
+      // on the one instrumented first-party view that missed the migration.
+      surface: { capabilities: ["agent-surface"] },
       relatedActions: ["RUNTIME"],
       tags: [
         "training",


### PR DESCRIPTION
Post-merge audit of #14068 (full verdict on that PR) confirmed the core regression resolved but found two one-line residuals, both fixed here:

1. **Split-layout panes deny granted views**: the second `DynamicViewLoader` instantiation in `packages/ui/src/App.tsx` (multi-view layout, ~L1100) omitted `surface={view.surface}` — a view with the `agent-surface` grant works in the tabbed mount but resolves to zero grants (mutating capabilities denied) when mounted in a split pane. Now passes the prop exactly like the primary mount at ~L985.
2. **plugin-training's FineTuningView was the one instrumented first-party view the #14068 migration missed** — its panels use `useAgentElement` but the declaration carried no grant, so agent control of the fine-tuning dashboard was broker-denied (developerOnly, but still wrong). Grant added with a why-comment, matching the 24 migrated declarations.

**Verification**: biome clean on both files; package typechecks fail identically with and without this change — the failures are **pre-existing on develop tip** and unrelated (reported on #13406): `packages/ui/src/state/startup-phase-poll.test.ts:2027` TS2322 and `plugins/plugin-training/src/ui/fine-tuning-panels.tsx:461` TS7006.

My commit → no self-merge; lalalune/0xSolace lanes please review + arm. (#13406, #14068 follow-up) `[maintainer]`