### PR TITLE
test(#13610): enable runtime chooser in packaged first-run lane

### DIFF
--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -987,13 +987,31 @@ function appendApiBaseParam(rendererUrl: string, apiBase: string): string {
   }
 }
 
+function appendRuntimeChooserTestParam(rendererUrl: string): string {
+  if (process.env.ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER !== "1") {
+    return rendererUrl;
+  }
+
+  try {
+    const url = new URL(rendererUrl);
+    url.searchParams.set("enableRuntimeChooser", "1");
+    return url.toString();
+  } catch {
+    return rendererUrl;
+  }
+}
+
 async function resolveRendererUrlForCurrentRuntime(): Promise<string> {
   const rendererUrl = await resolveRendererUrl();
   const runtime = resolveDesktopRuntime();
   if (runtime.mode === "external" && runtime.externalApi.base) {
-    return appendApiBaseParam(rendererUrl, runtime.externalApi.base);
+    const externalRendererUrl = appendApiBaseParam(
+      rendererUrl,
+      runtime.externalApi.base,
+    );
+    return appendRuntimeChooserTestParam(externalRendererUrl);
   }
-  return rendererUrl;
+  return appendRuntimeChooserTestParam(rendererUrl);
 }
 
 /**

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -420,6 +420,21 @@ function getWindowUrlSearchParams(): URLSearchParams {
   return new URLSearchParams(search || hashSearch);
 }
 
+function applyRuntimeChooserOverrideFromUrl(): void {
+  const params = getWindowUrlSearchParams();
+  if (params.get("enableRuntimeChooser") !== "1") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem("eliza:enable-runtime-chooser", "1");
+    removeUrlParameter("enableRuntimeChooser");
+  } catch (error) {
+    // error-policy:J3 storage/history can be unavailable in constrained webviews; keep booting.
+    logger.warn("[App] Failed to persist runtime chooser override", { error });
+  }
+}
+
 function applyCloudPairSessionToken(): void {
   if (typeof window === "undefined") return;
   try {
@@ -463,6 +478,7 @@ if (shouldInstallMainWindowFirstRunPatches(windowShellRoute)) {
 installLocalProviderCloudPreferencePatch(client);
 installDesktopPermissionsClientPatch(client);
 applyCloudPairSessionToken();
+applyRuntimeChooserOverrideFromUrl();
 
 // NOTE: do not gate on isElizaOS() here — that requires the `ElizaOS/` UA
 // marker which only AOSP/branded device images carry, so it excluded the

--- a/packages/app/test/electrobun-packaged/desktop-first-run.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/desktop-first-run.e2e.spec.ts
@@ -147,6 +147,9 @@ async function launchHarness(args: {
     tempRoot,
     launcherPath: launcherPath as string,
     apiBase: args.apiBase,
+    extraEnv: {
+      ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER: "1",
+    },
   });
 
   await harness.start({


### PR DESCRIPTION
## Summary
- add a test-only renderer URL flag that seeds the existing first-run runtime chooser localStorage override before app boot
- append that flag from Electrobun only when packaged tests set `ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER=1`
- enable the flag only for the packaged first-run spec, preserving production/cloud-only desktop onboarding defaults

Repo-side slice for #13610 / #13889. This addresses the packaged first-run failure where the spec expects `runtime:local` while the runtime chooser is intentionally off by default.

## Verification
- Clean branch rebuilt directly from `develop` via GitHub Git Data API to avoid local checkout drift; checked PR files are only the intended three paths.
- `git -C /tmp/eliza-pr14116 diff --check 9f1226ae063104ec823c04f052bca05a3aa7845a...HEAD`
- `bunx @biomejs/biome check packages/app/src/main.tsx packages/app-core/platforms/electrobun/src/index.ts packages/app/test/electrobun-packaged/desktop-first-run.e2e.spec.ts --no-errors-on-unmatched`

## Not run locally
- Packaged Electrobun E2E. This requires a built packaged launcher/GUI lane; the PR remains draft until that lane captures real packaged screenshots/logs/video per `PR_EVIDENCE.md`.
- `bun run --cwd packages/app audit:app` is N/A for this draft slice because no rendered UI layout/styles changed; the production runtime chooser default is unchanged.

## Evidence
- N/A - no user-facing UI layout changed. This is a test-only packaged harness opt-in that removes itself from the URL after seeding localStorage.
