### PR TITLE
fix(ui): format push registration listener

### DIFF
--- a/packages/ui/src/state/notifications/push-registration.ts
+++ b/packages/ui/src/state/notifications/push-registration.ts
@@ -179,15 +179,12 @@ async function addPushListeners(
     });
   });
 
-  await addListener(
-    "registrationError",
-    (error: PushRegistrationError) => {
-      logger.error(
-        { src: "push-registration", platform, error: error.error },
-        "[push-registration] OS push registration failed",
-      );
-    },
-  );
+  await addListener("registrationError", (error: PushRegistrationError) => {
+    logger.error(
+      { src: "push-registration", platform, error: error.error },
+      "[push-registration] OS push registration failed",
+    );
+  });
 
   await addListener(
     "pushNotificationActionPerformed",


### PR DESCRIPTION
## Summary
- Fix the Biome formatting issue that landed with #14101 in packages/ui/src/state/notifications/push-registration.ts.
- No behavior change.

## Validation
- bunx @biomejs/biome check packages/ui/src/state/notifications/push-registration.ts
- bun run --cwd packages/ui test -- src/state/notifications/push-registration.test.ts (11 passed)
- git diff --check

Follow-up to #14101 after it merged while local validation was still running.