### PR TITLE
fix(ui): wrap fine-tuning route in agent surface

### DIFF
--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -53,15 +53,18 @@ const dynamicViewLoaderMock = vi.hoisted(() => ({
   render: vi.fn(
     ({
       bundleUrl,
+      surface,
       viewId,
       viewType,
     }: {
       bundleUrl: string;
+      surface?: { capabilities?: string[] };
       viewId: string;
       viewType?: string;
     }) => (
       <div
         data-bundle-url={bundleUrl}
+        data-surface-capabilities={surface?.capabilities?.join(",") ?? ""}
         data-testid="dynamic-view-loader"
         data-view-id={viewId}
         data-view-type={viewType ?? ""}
@@ -104,6 +107,7 @@ const shopifyView = {
   path: "/shopify",
   bundleUrl: "/api/views/shopify/bundle.js",
   viewType: "gui" as const,
+  surface: { capabilities: ["agent-surface"] },
 };
 
 const calendarView = {
@@ -614,6 +618,10 @@ describe("App navigate-view event wiring", () => {
     expect(
       loaders.map((loader) => loader.getAttribute("data-view-id")),
     ).toEqual(["shopify", "calendar"]);
+    expect(loaders[0]?.getAttribute("data-surface-capabilities")).toBe(
+      "agent-surface",
+    );
+    expect(loaders[1]?.getAttribute("data-surface-capabilities")).toBe("");
     expect(desktopTabsMock.openTab).toHaveBeenCalledWith(shopifyView, {
       pinned: false,
     });

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -107,6 +107,10 @@ const shopifyView = {
   path: "/shopify",
   bundleUrl: "/api/views/shopify/bundle.js",
   viewType: "gui" as const,
+};
+
+const shopifyAgentSurfaceView = {
+  ...shopifyView,
   surface: { capabilities: ["agent-surface"] },
 };
 
@@ -150,6 +154,20 @@ const mockAvailableViews = [
   sharedCanvasView,
   documentsView,
 ];
+
+function resetMockAvailableViews() {
+  mockAvailableViews.splice(
+    0,
+    mockAvailableViews.length,
+    remoteLedgerView,
+    viewsManagerView,
+    viewsManagerTuiView,
+    shopifyView,
+    calendarView,
+    sharedCanvasView,
+    documentsView,
+  );
+}
 
 vi.mock("@capacitor/keyboard", () => ({
   Keyboard: { setScroll: vi.fn(async () => undefined) },
@@ -395,6 +413,7 @@ describe("App navigate-view event wiring", () => {
     Reflect.deleteProperty(window, "__ELIZAOS_API_TOKEN__");
     appState.tab = "chat";
     desktopTabsState.tabs = [];
+    resetMockAvailableViews();
     appState.setTab.mockClear();
     desktopTabsMock.openTab.mockClear();
     desktopTabsMock.closeTab.mockClear();
@@ -601,6 +620,9 @@ describe("App navigate-view event wiring", () => {
 
     const { getAllByTestId, getByTestId } = render(<App />);
 
+    const splitViews = [shopifyAgentSurfaceView, calendarView];
+    mockAvailableViews.splice(0, mockAvailableViews.length, ...splitViews);
+
     navigateView({
       action: "split-view",
       viewId: "shopify",
@@ -622,9 +644,12 @@ describe("App navigate-view event wiring", () => {
       "agent-surface",
     );
     expect(loaders[1]?.getAttribute("data-surface-capabilities")).toBe("");
-    expect(desktopTabsMock.openTab).toHaveBeenCalledWith(shopifyView, {
-      pinned: false,
-    });
+    expect(desktopTabsMock.openTab).toHaveBeenCalledWith(
+      shopifyAgentSurfaceView,
+      {
+        pinned: false,
+      },
+    );
     expect(desktopTabsMock.openTab).toHaveBeenCalledWith(calendarView, {
       pinned: false,
     });

--- a/packages/ui/src/components/training/injected.test.tsx
+++ b/packages/ui/src/components/training/injected.test.tsx
@@ -4,13 +4,19 @@
  * `bootConfig.fineTuningView` when present, and the install hint when absent.
  * Real render in jsdom with a stubbed boot context.
  */
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentButton } from "../../agent-surface";
 import { DEFAULT_BOOT_CONFIG } from "../../config/boot-config";
 import { AppBootContext } from "../../config/boot-config-react.hooks";
+import { invokeViewInteract } from "../views/view-interact-registry";
 import { FineTuningView } from "./injected";
 
+const sendWsMessage = vi.hoisted(() => vi.fn());
+vi.mock("../../api", () => ({ client: { sendWsMessage } }));
+
 afterEach(cleanup);
+beforeEach(() => sendWsMessage.mockClear());
 
 describe("trunk FineTuningView wrapper", () => {
   it("renders the dashboard the host injects through bootConfig.fineTuningView", () => {
@@ -29,6 +35,37 @@ describe("trunk FineTuningView wrapper", () => {
       </AppBootContext.Provider>,
     );
     expect(screen.getByTestId("plugin-fine-tuning")).toBeTruthy();
+  });
+
+  it("mounts the injected dashboard inside the fine-tuning agent surface", async () => {
+    function PluginFineTuningDashboard() {
+      return (
+        <AgentButton agentId="start-training" agentLabel="Start training">
+          Start
+        </AgentButton>
+      );
+    }
+    render(
+      <AppBootContext.Provider
+        value={{
+          ...DEFAULT_BOOT_CONFIG,
+          fineTuningView: PluginFineTuningDashboard,
+        }}
+      >
+        <FineTuningView />
+      </AppBootContext.Provider>,
+    );
+
+    await waitFor(async () => {
+      const result = await invokeViewInteract(
+        "fine-tuning",
+        "gui",
+        "list-elements",
+      );
+      expect((result as Array<{ id: string }>).map((e) => e.id)).toContain(
+        "start-training",
+      );
+    });
   });
 
   it("shows an install hint (no trunk fallback dashboard) when the Training plugin is absent", () => {

--- a/packages/ui/src/components/training/injected.tsx
+++ b/packages/ui/src/components/training/injected.tsx
@@ -4,6 +4,7 @@
  */
 import type { FineTuningViewProps } from "../../config/boot-config";
 import { useBootConfig } from "../../config/boot-config-react.hooks";
+import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 
 /**
  * Renders the fine-tuning dashboard the host injects through
@@ -21,5 +22,9 @@ export function FineTuningView(props: FineTuningViewProps) {
       </div>
     );
   }
-  return <FineTuningViewComponent {...props} />;
+  return (
+    <ShellViewAgentSurface viewId="fine-tuning">
+      <FineTuningViewComponent {...props} />
+    </ShellViewAgentSurface>
+  );
 }


### PR DESCRIPTION
## Summary

Follow-up to #14114. The plugin-training view declaration now grants `agent-surface`, but `/apps/fine-tuning` is a built-in shell route that renders `packages/ui/src/components/training/injected.tsx` directly instead of going through `DynamicViewLoader`. This wraps that injected route in `ShellViewAgentSurface viewId="fine-tuning"` so the instrumented `FineTuningView` panels register for agent interaction on the real route.

Also adds regression coverage for:
- split-pane `DynamicViewLoader` forwarding `surface.capabilities` to granted views
- injected fine-tuning dashboard registering an element through the `fine-tuning` shell surface

## Validation

- `bunx biome check packages/ui/src/App.navigate-view-wiring.test.tsx packages/ui/src/components/training/injected.tsx packages/ui/src/components/training/injected.test.tsx`
- `git diff --check origin/develop...HEAD`
- `git rev-list --left-right --count origin/develop...HEAD` -> `0 1`

Attempted targeted Vitest command after generating keyword data:

`bun run --cwd packages/ui test src/components/training/injected.test.tsx src/App.navigate-view-wiring.test.tsx`

It failed in the temp worktree because React resolved from both `/home/shaw/milady/eliza/dist/node_modules/react` and Bun's `react-dom`, producing duplicate-React invalid-hook-call failures across pre-existing App tests. This is the same symlinked temp-worktree dependency issue seen in review sidecars; hosted CI should be the reliable signal.

## Evidence

N/A - regression is covered at the unit/component layer; no visual layout change intended. CI/aesthetic gates should still run because this touches `packages/ui`.
