### PR TITLE
refactor(ui): agents per-row view-model (#13916 part 2b-iii)

### DIFF
--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -57,7 +57,7 @@ import {
   statusBadgeColor,
   statusDotColor,
 } from "../lib/sandbox-status";
-import { useJobPoller } from "../lib/use-job-poller";
+import { type TrackedJob, useJobPoller } from "../lib/use-job-poller";
 import {
   type SandboxListAgent,
   useSandboxListPoll,
@@ -191,6 +191,86 @@ function getRuntimeKind(
     return "sandbox";
   }
   return "notProvisioned";
+}
+
+/**
+ * Per-row values the desktop table row and the mobile card both derive from a
+ * row + poller state. Computed once per row via `buildAgentRowViewModel` so
+ * the two layouts render from the same facts and cannot drift.
+ */
+interface AgentRowViewModel {
+  isDocker: boolean;
+  runtimeKind: ReturnType<typeof getRuntimeKind>;
+  trackedJob: TrackedJob | undefined;
+  isProvisioningActive: boolean;
+  displayStatus: string;
+  busy: boolean;
+  canStart: boolean;
+  canStop: boolean;
+  hasStandaloneWebUi: boolean;
+}
+
+function buildAgentRowViewModel(
+  sb: ElizaAgentRow,
+  poller: {
+    getStatus: (key: string) => TrackedJob | undefined;
+    isActive: (key: string) => boolean;
+  },
+  actionInProgress: string | null,
+): AgentRowViewModel {
+  const isProvisioningActive = poller.isActive(sb.id);
+  const displayStatus = isProvisioningActive ? "provisioning" : sb.status;
+  const busy = actionInProgress === sb.id || isProvisioningActive;
+  return {
+    isDocker: isDockerBacked(sb),
+    runtimeKind: getRuntimeKind(sb),
+    trackedJob: poller.getStatus(sb.id),
+    isProvisioningActive,
+    displayStatus,
+    busy,
+    canStart:
+      ["stopped", "error", "pending", "disconnected"].includes(displayStatus) &&
+      !busy,
+    canStop: displayStatus === "running" && !busy,
+    hasStandaloneWebUi:
+      displayStatus === "running" &&
+      sb.execution_tier !== "shared" &&
+      Boolean(sb.canonical_web_ui_url),
+  };
+}
+
+/**
+ * Docker/Shared/Sandbox execution-kind chip (icon + label) rendered next to
+ * the agent name in both the desktop row and the mobile card.
+ */
+function RuntimeKindLabel({
+  sb,
+  isDocker,
+}: {
+  sb: ElizaAgentRow;
+  isDocker: boolean;
+}) {
+  const t = useT();
+  return (
+    <span className="inline-flex items-center gap-1 text-2xs text-muted">
+      {isDocker ? (
+        <Server className="h-2.5 w-2.5" />
+      ) : (
+        <Cloud className="h-2.5 w-2.5" />
+      )}
+      {isDocker
+        ? t("cloud.elizaAgentsTable.docker", {
+            defaultValue: "Docker",
+          })
+        : sb.execution_tier === "shared"
+          ? t("cloud.elizaAgentsTable.shared", {
+              defaultValue: "Shared",
+            })
+          : t("cloud.elizaAgentsTable.sandbox", {
+              defaultValue: "Sandbox",
+            })}
+    </span>
+  );
 }
 
 function StatusCell({
@@ -906,23 +986,17 @@ export function ElizaAgentsTable({
                 </TableRow>
               ) : (
                 filtered.map((sb) => {
-                  const isDocker = isDockerBacked(sb);
-                  const trackedJob = poller.getStatus(sb.id);
-                  const isProvisioningActive = poller.isActive(sb.id);
-                  const displayStatus = isProvisioningActive
-                    ? "provisioning"
-                    : sb.status;
-                  const busy =
-                    actionInProgress === sb.id || isProvisioningActive;
-                  const canStart =
-                    ["stopped", "error", "pending", "disconnected"].includes(
-                      displayStatus,
-                    ) && !busy;
-                  const canStop = displayStatus === "running" && !busy;
-                  const hasStandaloneWebUi =
-                    displayStatus === "running" &&
-                    sb.execution_tier !== "shared" &&
-                    Boolean(sb.canonical_web_ui_url);
+                  const {
+                    isDocker,
+                    runtimeKind,
+                    trackedJob,
+                    isProvisioningActive,
+                    displayStatus,
+                    busy,
+                    canStart,
+                    canStop,
+                    hasStandaloneWebUi,
+                  } = buildAgentRowViewModel(sb, poller, actionInProgress);
 
                   return (
                     <TableRow
@@ -956,24 +1030,7 @@ export function ElizaAgentsTable({
                             <AgentCostBadge status={displayStatus} />
                           </div>
                           <div className="flex items-center gap-2">
-                            <span className="inline-flex items-center gap-1 text-2xs text-muted">
-                              {isDocker ? (
-                                <Server className="h-2.5 w-2.5" />
-                              ) : (
-                                <Cloud className="h-2.5 w-2.5" />
-                              )}
-                              {isDocker
-                                ? t("cloud.elizaAgentsTable.docker", {
-                                    defaultValue: "Docker",
-                                  })
-                                : sb.execution_tier === "shared"
-                                  ? t("cloud.elizaAgentsTable.shared", {
-                                      defaultValue: "Shared",
-                                    })
-                                  : t("cloud.elizaAgentsTable.sandbox", {
-                                      defaultValue: "Sandbox",
-                                    })}
-                            </span>
+                            <RuntimeKindLabel sb={sb} isDocker={isDocker} />
                             <span className="text-2xs text-muted font-mono tabular-nums">
                               {sb.id.slice(0, 8)}
                             </span>
@@ -992,15 +1049,15 @@ export function ElizaAgentsTable({
 
                       <TableCell>
                         <span className="text-xs text-muted-strong">
-                          {getRuntimeKind(sb) === "managed"
+                          {runtimeKind === "managed"
                             ? t("cloud.elizaAgentsTable.managedRuntime", {
                                 defaultValue: "Managed runtime",
                               })
-                            : getRuntimeKind(sb) === "shared"
+                            : runtimeKind === "shared"
                               ? t("cloud.elizaAgentsTable.sharedRuntime", {
                                   defaultValue: "Shared runtime",
                                 })
-                              : getRuntimeKind(sb) === "sandbox"
+                              : runtimeKind === "sandbox"
                                 ? t("cloud.elizaAgentsTable.cloudSandbox", {
                                     defaultValue: "Cloud sandbox",
                                   })
@@ -1172,22 +1229,16 @@ export function ElizaAgentsTable({
             </div>
           ) : (
             filtered.map((sb) => {
-              const isDocker = isDockerBacked(sb);
-              const trackedJob = poller.getStatus(sb.id);
-              const isProvisioningActive = poller.isActive(sb.id);
-              const displayStatus = isProvisioningActive
-                ? "provisioning"
-                : sb.status;
-              const busy = actionInProgress === sb.id || isProvisioningActive;
-              const canStart =
-                ["stopped", "error", "pending", "disconnected"].includes(
-                  displayStatus,
-                ) && !busy;
-              const canStop = displayStatus === "running" && !busy;
-              const hasStandaloneWebUi =
-                displayStatus === "running" &&
-                sb.execution_tier !== "shared" &&
-                Boolean(sb.canonical_web_ui_url);
+              const {
+                isDocker,
+                trackedJob,
+                isProvisioningActive,
+                displayStatus,
+                busy,
+                canStart,
+                canStop,
+                hasStandaloneWebUi,
+              } = buildAgentRowViewModel(sb, poller, actionInProgress);
 
               return (
                 <div
@@ -1207,24 +1258,7 @@ export function ElizaAgentsTable({
                       </a>
                       <AgentCostBadge status={displayStatus} />
                       <div className="flex items-center gap-2">
-                        <span className="inline-flex items-center gap-1 text-2xs text-muted">
-                          {isDocker ? (
-                            <Server className="h-2.5 w-2.5" />
-                          ) : (
-                            <Cloud className="h-2.5 w-2.5" />
-                          )}
-                          {isDocker
-                            ? t("cloud.elizaAgentsTable.docker", {
-                                defaultValue: "Docker",
-                              })
-                            : sb.execution_tier === "shared"
-                              ? t("cloud.elizaAgentsTable.shared", {
-                                  defaultValue: "Shared",
-                                })
-                              : t("cloud.elizaAgentsTable.sandbox", {
-                                  defaultValue: "Sandbox",
-                                })}
-                        </span>
+                        <RuntimeKindLabel sb={sb} isDocker={isDocker} />
                         <span className="text-2xs text-muted font-mono tabular-nums">
                           {sb.id.slice(0, 8)}
                         </span>


### PR DESCRIPTION
## Summary

Implements the remaining #13916 audit slice (part 2b-iii): **behavior-neutral** dedup of the per-row view-model in the agents table (`packages/ui/src/cloud/instances/components/eliza-agents-table.tsx`).

- The DESKTOP table row and the MOBILE card each independently derived the same per-row values (`isDocker`, tracked job, `displayStatus`, `busy`, `canStart`, `canStop`, `hasStandaloneWebUi`). Both layouts now destructure one `buildAgentRowViewModel(sb, poller, actionInProgress)` helper, so the two layouts render from the same facts and cannot drift.
- The duplicated Docker/Shared/Sandbox chip (icon + label next to the agent name) is extracted into a shared `RuntimeKindLabel` fragment.
- `getRuntimeKind(sb)` was called three times inside the desktop Runtime cell; it is now computed once per row (`runtimeKind` on the view-model).

**No copy, i18n keys, actions, or logic changed** — same rendered output, same handlers. Single-file diff.

## Verify evidence

- `bun run --cwd packages/ui typecheck 2>&1 | grep eliza-agents-table` → **empty** (the 9 remaining typecheck errors are pre-existing on `develop` in unrelated test files: `todo.test.tsx`, `startup-phase-poll.test.ts`, etc. — this diff touches only `eliza-agents-table.tsx`).
- `vitest run src/cloud/instances/components/eliza-agents-table.merge.test.ts` → **6/6 passed**.
- `bunx biome check packages/ui/src/cloud/instances/components/eliza-agents-table.tsx` → clean, no fixes applied.

Frontend rendered-proof rows: N/A — behavior-neutral refactor with byte-identical rendered output by construction (same JSX, same class names, same i18n keys); the merge test covers the row-merge logic surface.

[qa-agent]
