### PR TITLE
ci: supersede stale develop-push runs — per-workflow concurrency

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -1,8 +1,16 @@
 name: Benchmark Bridge Tests
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: benchmark-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: benchmark-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 on:
   push:

--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -50,9 +50,17 @@ on:
       - "packages/app/docs/CHAT_GESTURE_COVERAGE.md"
   workflow_dispatch:
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: chat-shell-gestures-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: chat-shell-gestures-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
   contents: read

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -36,9 +36,17 @@ on:
       - ".github/workflows/cloud-tests.yml"
       - ".github/actions/cloud-setup-test-env/**"
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: cloud-tests-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: cloud-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 env:
   DATABASE_URL: postgresql://postgres@127.0.0.1:5432/postgres

--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -19,9 +19,17 @@ on:
       - "packages/ui/**"
   workflow_dispatch:
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: dev-smoke-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: dev-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
   contents: read

--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -16,9 +16,17 @@ on:
     - cron: "0 7 * * *"
   workflow_dispatch:
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: docker-ci-smoke-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: docker-ci-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
   contents: read

--- a/.github/workflows/e1-chip.yml
+++ b/.github/workflows/e1-chip.yml
@@ -11,9 +11,17 @@ on:
       - "packages/research/chip/**"
       - ".github/workflows/e1-chip.yml"
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: e1-chip-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: e1-chip-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 # Default to least privilege. Override per-job where needed.
 permissions:

--- a/.github/workflows/electrobun-submodule-guard.yml
+++ b/.github/workflows/electrobun-submodule-guard.yml
@@ -28,9 +28,17 @@ on:
 # cancel superseded in-flight runs for the same PR to free hosted-runner
 # capacity. only cancels pull_request runs; push runs on protected branches
 # (main/develop) are never cancelled mid-flight.
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
   contents: read

--- a/.github/workflows/feed-env-audit.yml
+++ b/.github/workflows/feed-env-audit.yml
@@ -5,9 +5,17 @@ on:
   push:
     branches: [develop]
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 env:
   CI: true

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -13,9 +13,17 @@ on:
 # cancel superseded in-flight runs for the same PR to free hosted-runner
 # capacity. only cancels pull_request runs; push runs on protected branches
 # (main/develop) are never cancelled mid-flight.
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
   contents: read

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -15,9 +15,17 @@ on:
       - ".github/workflows/markdown-links.yml"
   workflow_dispatch:
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: markdown-links-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: markdown-links-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
   contents: read

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,9 +27,17 @@ on:
       - ".github/pull_request_template.md"
   workflow_dispatch:
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: quality-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: quality-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 env:
   BUN_VERSION: "canary"

--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -36,9 +36,17 @@ on:
         required: false
         default: ""
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: scenario-matrix-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: scenario-matrix-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 env:
   CI: "true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,17 @@ on:
     # Nightly live smoke for container-backed remote capability plugins.
     - cron: "17 9 * * *"
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: test-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 env:
   CI: "true"

--- a/.github/workflows/training-stack.yml
+++ b/.github/workflows/training-stack.yml
@@ -31,9 +31,17 @@ on:
       - ".github/workflows/training-stack.yml"
   workflow_dispatch:
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: training-stack-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: training-stack-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -38,9 +38,17 @@ on:
       - "packages/agent/src/api/interactions-routes.ts"
       - "packages/agent/src/api/server-helpers-swarm.ts"
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: ui-e2e-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ui-e2e-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ui-fixture-e2e.yml
+++ b/.github/workflows/ui-fixture-e2e.yml
@@ -29,9 +29,17 @@ on:
     paths:
       - "packages/ui/src/**"
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: ui-fixture-e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ui-fixture-e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -26,9 +26,17 @@ on:
       - "plugins/**/src/**"
       - ".github/workflows/ui-story-gate.yml"
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: ui-story-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ui-story-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
   contents: read

--- a/.github/workflows/vault-ci.yaml
+++ b/.github/workflows/vault-ci.yaml
@@ -7,9 +7,17 @@ name: vault-ci
 # CI on every PR that touches packages/vault/** or the app-core
 # wiring that consumes it.
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: vault-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: vault-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 on:
   push:

--- a/.github/workflows/verify-patches.yml
+++ b/.github/workflows/verify-patches.yml
@@ -18,9 +18,17 @@ on:
 # cancel superseded in-flight runs for the same PR to free hosted-runner
 # capacity. only cancels pull_request runs; push runs on protected branches
 # (main/develop) are never cancelled mid-flight.
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
   contents: read

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -9,9 +9,17 @@ name: Windows CI
 # and the helpers under `packages/scripts/`. iOS/macOS/RISC-V/cloud-e2e
 # paths run on their existing dedicated workflows.
 
+# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
+# github.run_id on push, so every develop push got a unique group and
+# nothing ever superseded. A 37-merge wave queued thousands of push runs
+# and starved the self-hosted fleet. Fall back to github.ref (all develop
+# pushes share a group) and cancel superseded runs on push too. PR behavior
+# is unchanged (pull_request.number still wins the key); merge_group and
+# schedule events are not in the cancel set, so the merge queue and nightly
+# runs always complete.
 concurrency:
-  group: windows-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: windows-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).


### PR DESCRIPTION
## Problem (measured)

Every merge to `develop` triggers a full push-event workflow fan-out. This morning a 37-merge wave queued **~2,545 push runs on develop alone**, flooding the self-hosted fleet (46 online runners). PR-required legs starved → auto-merge stalled → maintainers fell back to admin-merging → which pushes `develop` again → **more** fan-out. Death spiral.

### Root cause

The PR-scoped concurrency groups shipped in #14069 use this fallback shape:

```yaml
group: <slug>-${{ github.event.pull_request.number || github.run_id }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

On a **push** event, `github.event.pull_request.number` is empty, so the key falls back to `github.run_id` — **unique per run**. Every develop push therefore lands in its own concurrency group and *nothing ever supersedes the previous run*. And `cancel-in-progress` is gated to `pull_request` only, so push runs never cancel regardless. Push CI piles up unbounded.

## Fix

For 20 pure-CI workflows, change the push fallback from `github.run_id` → `github.ref`, and extend `cancel-in-progress` to fire on push too:

```yaml
group: <slug>-${{ github.event.pull_request.number || github.ref }}
cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
```

- On **push**: `github.ref` = `refs/heads/develop` → all develop pushes share one workflow-scoped group → a newer push cancels the superseded older run of the same workflow.
- On **PR**: `pull_request.number` still wins the key → dedup behavior identical to #14069, unchanged.
- Groups stay **workflow-scoped** (each keeps its own prefix / `github.workflow`), never a shared repo-wide group (the exact bug #14069's codex round caught on the terraform pair).

## Safety

| Concern | Handling |
|---|---|
| Deploy/publish/build-push workflows | **UNTOUCHED.** `cloud-cf-deploy`, `cloud-deploy-backend`, `deploy-apps-worker`, `deploy-eliza-provisioning-worker`, `deploy-homepage`, `publish-example-code`, `publish-plugin-elizacloud`, `build-agent-image`, `build-example-app-images`, `tee-build-deploy`, `release-all`, `release.yaml`, terraform-* all keep `cancel-in-progress: false`. An in-flight deploy is never interrupted. |
| Merge queue | `merge_group` event is NOT in the cancel set → merge queue runs always complete (verified on `test.yml`). |
| Scheduled runs | `schedule` event is NOT in the cancel set → nightly / cron runs always complete. |
| gateway-discord / gateway-webhook | Already dedup correctly on push (keyed on `pull_request.number \|\| github.ref`, `cancel-in-progress: true`). Left as-is. |
| Different PRs colliding | Impossible — PR events key on `pull_request.number`; only push events use `github.ref`, and different branches have different refs. |

## Workflows changed (fix set — all pure CI)

| Workflow | Group key (push → ) | Cancel on | Why safe |
|---|---|---|---|
| benchmark-tests.yml | `benchmark-tests-${workflow}-${ref}` | pull_request, push | lifeops-bench tests, no side effects |
| chat-shell-gestures.yml | `chat-shell-gestures-${ref}` | pull_request, push | UI gesture tests |
| cloud-tests.yml | `cloud-tests-${ref}` | pull_request, push | cloud unit/integration tests |
| dev-smoke.yml | `dev-smoke-${ref}` | pull_request, push | dev smoke checks |
| docker-ci-smoke.yml | `docker-ci-smoke-${ref}` | pull_request, push | docker build smoke (no push/registry) |
| e1-chip.yml | `e1-chip-${ref}` | pull_request, push | research/chip tests |
| electrobun-submodule-guard.yml | `${workflow}-${ref}` | pull_request, push | submodule guard check |
| feed-env-audit.yml | `${workflow}-${ref}` | pull_request, push | env audit (read-only) |
| gitleaks.yml | `${workflow}-${ref}` | pull_request, push | secret scan (read-only) |
| markdown-links.yml | `markdown-links-${ref}` | pull_request, push | link checker |
| quality.yml | `quality-${ref}` | pull_request, push | lint/typecheck/quality |
| scenario-matrix.yml | `scenario-matrix-${ref}` | pull_request, push | scenario test matrix |
| test.yml | `test-${ref}` | pull_request, push | **required ci-ok legs**; merge_group + schedule excluded, verified |
| training-stack.yml | `training-stack-${ref}` | pull_request, push | training package tests |
| ui-e2e-gate.yml | `ui-e2e-gate-${workflow}-${ref}` | pull_request, push | UI e2e gate |
| ui-fixture-e2e.yml | `ui-fixture-e2e-${workflow}-${ref}` | pull_request, push | UI fixture e2e |
| ui-story-gate.yml | `ui-story-gate-${workflow}-${ref}` | pull_request, push | UI story gate |
| vault-ci.yaml | `vault-ci-${workflow}-${ref}` | pull_request, push | vault tests |
| verify-patches.yml | `${workflow}-${ref}` | pull_request, push | patch verification |
| windows-ci.yml | `windows-ci-${workflow}-${ref}` | pull_request, push | Windows CI tests |

## Workflows deliberately SKIPPED

- **Deploy / publish / build-and-push:** `cloud-cf-deploy`, `cloud-deploy-backend`, `deploy-apps-worker`, `deploy-eliza-provisioning-worker`, `deploy-homepage`, `publish-example-code`, `publish-plugin-elizacloud`, `build-agent-image`, `build-example-app-images`, `tee-build-deploy`, `release-all`, `release.yaml`, `terraform-*` — cancelling mid-flight = broken prod / partial publish. All keep `cancel-in-progress: false`.
- **Already-correct on push:** `cloud-gateway-discord`, `cloud-gateway-webhook` (ref-keyed, `cancel-in-progress: true`).
- **Tag / release-triggered only** (`build-llama-ffi-*`, `kokoro-real-smoke`, `voice-bench-smoke`, `voice-workbench`, `snap-build-test`): not develop-push fan-out contributors, already ref-scoped.

## Validation

- `actionlint` (v1.7.7): **0 findings** across all 20 touched files.
- Contract tests pass (real-repo assertions included):
  - `ci-workflow-dedup-contract.test.ts` — 5 pass
  - `ci-turbo-cache-contract.test.ts` — 5 pass
  - `windows-ci-workflow.test.ts` — 2 pass
  - `scenario-pr-workflow.test.ts` — 11 pass

No auto-merge (workflow-touching). Verified + merged by orchestrator under standing authorization.

— [sol-orch]
