### PR TITLE
fix(orchestrator): reclaim idle keepAlive sessions after restart

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -17,6 +17,7 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
+import { SessionCapError, type SessionInfo } from "../../src/services/types.js";
 import {
   type CreateTaskInput,
   type OrchestratorTaskSession,
@@ -60,9 +61,19 @@ class FakeAcp {
   readonly spawnArgs: Record<string, unknown>[] = [];
   readonly sent: { sessionId: string; message: string }[] = [];
   readonly stopped: string[] = [];
+  readonly sessions: SessionInfo[] = [];
+  capacity = {
+    maxSessions: 1,
+    systemHeadroom: 1,
+    activeWorkers: 1,
+    activeSystem: 0,
+    freeWorkerSlots: 0,
+    freeSystemSlots: 1,
+  };
   failSend = false;
   failStop = false;
   failSpawn = false;
+  capFull = false;
 
   onSessionEvent(
     cb: (sessionId: string, event: string, data: unknown) => void,
@@ -79,14 +90,36 @@ class FakeAcp {
 
   spawnSession(opts: Record<string, unknown>): Promise<SpawnResult> {
     if (this.failSpawn) return Promise.reject(new Error("spawn failed"));
+    if (this.capFull) {
+      return Promise.reject(new SessionCapError("worker", 1, 1));
+    }
     this.spawnArgs.push(opts);
     this.counter += 1;
-    return Promise.resolve({
+    const result: SpawnResult = {
       sessionId: `session-${this.counter}`,
       agentType: (opts.agentType as string | undefined) ?? "codex",
       workdir: (opts.workdir as string | undefined) ?? "/repo",
       status: "ready",
+    };
+    const createdAt = new Date(this.counter * 1000);
+    this.sessions.push({
+      id: result.sessionId,
+      agentType: result.agentType,
+      workdir: result.workdir,
+      status: result.status,
+      approvalPreset: "standard",
+      createdAt,
+      lastActivityAt: createdAt,
     });
+    return Promise.resolve(result);
+  }
+
+  getCapacity(): Promise<typeof this.capacity> {
+    return Promise.resolve(this.capacity);
+  }
+
+  listSessions(): Promise<SessionInfo[]> {
+    return Promise.resolve([...this.sessions]);
   }
 
   sendToSession(sessionId: string, message: string): Promise<void> {
@@ -98,6 +131,8 @@ class FakeAcp {
   stopSession(sessionId: string): Promise<void> {
     if (this.failStop) return Promise.reject(new Error("stop failed"));
     this.stopped.push(sessionId);
+    const session = this.sessions.find((item) => item.id === sessionId);
+    if (session) session.status = "stopped";
     return Promise.resolve();
   }
 }
@@ -1652,6 +1687,39 @@ describe("OrchestratorTaskService — restart reconstruction (#13771)", () => {
     const after = must(await restarted.getTask(task.id), "after restart");
     expect(after.status).toBe("blocked");
     expect(after.events?.some((e) => e.eventType === "blocked")).toBe(true);
+  });
+
+  it("reclaims pre-restart idle keepAlive sessions through the durable store", async () => {
+    const acp = new FakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const first = new OrchestratorTaskService(runtime(acp), { store });
+    await first.start();
+
+    const finished = await first.createTask(createInput({ title: "finished" }));
+    const detail = must(
+      await first.spawnAgentForTask(finished.id),
+      "spawn detail",
+    );
+    const sessionId = must(detail.sessions[0], "session").sessionId;
+    await first.updateTask(finished.id, { status: "validating" });
+    await first.validateTask(finished.id, {
+      passed: true,
+      summary: "verified",
+    });
+
+    // Simulate restart: the durable store still knows session->task, but the
+    // new service's in-memory sessionTaskIndex is empty. A queued task with no
+    // free worker slots should still reclaim the finished keepAlive session.
+    const restarted = new OrchestratorTaskService(runtime(acp), { store });
+    await restarted.start();
+    const queued = await restarted.createTask(createInput({ title: "queued" }));
+    acp.capFull = true;
+    await restarted.spawnAgentForTask(queued.id);
+    await (
+      restarted as unknown as { drainAdmissionQueue: () => Promise<void> }
+    ).drainAdmissionQueue();
+
+    expect(acp.stopped).toContain(sessionId);
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -17,12 +17,12 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
-import { SessionCapError, type SessionInfo } from "../../src/services/types.js";
 import {
   type CreateTaskInput,
   type OrchestratorTaskSession,
   TERMINAL_TASK_STATUSES,
 } from "../../src/services/orchestrator-task-types.js";
+import { SessionCapError, type SessionInfo } from "../../src/services/types.js";
 
 // This suite pins the status state machine and the ACP→task event bridge — NOT
 // the #8896 default-criteria feature. createTask now auto-populates acceptance

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -22,7 +22,11 @@ import {
   type OrchestratorTaskSession,
   TERMINAL_TASK_STATUSES,
 } from "../../src/services/orchestrator-task-types.js";
-import { SessionCapError, type SessionInfo } from "../../src/services/types.js";
+import {
+  type AcpCapacity,
+  SessionCapError,
+  type SessionInfo,
+} from "../../src/services/types.js";
 
 // This suite pins the status state machine and the ACP→task event bridge — NOT
 // the #8896 default-criteria feature. createTask now auto-populates acceptance
@@ -62,7 +66,7 @@ class FakeAcp {
   readonly sent: { sessionId: string; message: string }[] = [];
   readonly stopped: string[] = [];
   readonly sessions: SessionInfo[] = [];
-  capacity = {
+  capacity: AcpCapacity = {
     maxSessions: 1,
     systemHeadroom: 1,
     activeWorkers: 1,
@@ -114,7 +118,7 @@ class FakeAcp {
     return Promise.resolve(result);
   }
 
-  getCapacity(): Promise<typeof this.capacity> {
+  getCapacity(): Promise<AcpCapacity> {
     return Promise.resolve(this.capacity);
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -4250,7 +4250,7 @@ export class OrchestratorTaskService extends Service {
     const candidates: Array<{ id: string; createdAt: number }> = [];
     for (const session of sessions) {
       if (TERMINAL_SESSION_STATUSES.has(session.status)) continue;
-      const taskId = this.sessionTaskIndex.get(session.id);
+      const taskId = await this.resolveTaskId(session.id);
       if (!taskId) continue;
       const doc = await this.store.getTask(taskId);
       if (!doc || !TERMINAL_TASK_STATUSES.has(doc.task.status)) continue;


### PR DESCRIPTION
## Summary
- make `reclaimIdleSession` resolve session ownership through `resolveTaskId`, so a restarted parent can fall back to `store.findSession` and re-prime `sessionTaskIndex`
- add a regression test that simulates a restarted service with an empty in-memory index, a terminal task with a live keepAlive session, and a queued task stuck behind a full worker pool

Fixes #14106.

## Verification
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts --no-errors-on-unmatched`
- `git -C /tmp/eliza-14106 diff --check 46db9206f39922a2a02b7ffaeb2a27d765234ed0...HEAD`

## Not run / blocked
- `bunx vitest run --config vitest.config.ts __tests__/unit/orchestrator-task-service.test.ts` from the clean sparse worktree currently fails before collecting tests because this host's workspace package resolution is drifted: `@elizaos/shared` resolves through the main checkout dist and then cannot resolve `@elizaos/registry/first-party/curated-app-definitions.json`. Running with the clean source-condition path then exposes other missing workspace links from the sparse test environment. The failure occurs at import/setup time (0 tests collected), not in the changed assertions.

## Evidence
- N/A - backend orchestrator service/test-only change; no UI, model, connector, or external-device behavior changed directly.
