### PR TITLE
fix(app-core): repair runtime-mode.disk test import (develop red — module moved)

### DIFF
--- a/packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts
+++ b/packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts
@@ -9,7 +9,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getRuntimeModeSnapshot } from "./runtime-mode";
+import { getRuntimeModeSnapshot } from "@elizaos/agent";
 
 const ENV_KEYS = [
   "ELIZA_STATE_DIR",


### PR DESCRIPTION
Fixes a **develop-tip red** found by running the full `packages/app-core` test suite.

## The failure

`src/runtime/mode/runtime-mode.disk.test.ts` fails to load (deterministic):

```
FAIL  src/runtime/mode/runtime-mode.disk.test.ts
Error: Cannot find module './runtime-mode' imported from .../src/runtime/mode/runtime-mode.disk.test.ts
Tests  no tests
```

## Root cause

`src/runtime/mode/` now contains **only** the test — the `runtime-mode.ts` module it imported was moved. `getRuntimeModeSnapshot` lives in **`@elizaos/agent`** now, and app-core's own production code already imports it from there:

- `packages/app-core/src/api/runtime-mode-routes.ts:12` → `import { getRuntimeModeSnapshot } from "@elizaos/agent";`
- `packages/app-core/src/index.ts` re-exports it from `@elizaos/agent`.

The test's import (`./runtime-mode`) was never updated when the module moved, so vitest can't resolve it and the file errors at collection time.

## Fix

```diff
-import { getRuntimeModeSnapshot } from "./runtime-mode";
+import { getRuntimeModeSnapshot } from "@elizaos/agent";
```

One line; the disk-backed resolution the test exercises (real `loadElizaConfig()` over a temp state dir) is unchanged.

## Verification

```
bun run --cwd packages/app-core test -- src/runtime/mode/runtime-mode.disk.test.ts
# before: fail-to-load ("no tests")
# after:  Test Files 1 passed, Tests 4 passed (4)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)