### PR TITLE
fix(plugin-training): unblock develop red typecheck (TS7006 implicit-any)

### DIFF
--- a/plugins/plugin-training/src/ui/fine-tuning-panels.tsx
+++ b/plugins/plugin-training/src/ui/fine-tuning-panels.tsx
@@ -458,7 +458,7 @@ export function TrajectoriesSection({
                     {t("finetuningview.NoTrajectoriesFoun")}
                   </div>
                 ) : (
-                  trajectoryList.trajectories.map((trajectory) => (
+                  trajectoryList.trajectories.map((trajectory: TrajectorySummary) => (
                     <TrajectoryListItem
                       key={trajectory.trajectoryId}
                       trajectory={trajectory}


### PR DESCRIPTION
## What
Unblocks the develop typecheck lane (flagged by [maintainer] 16:27Z — was failing EVERY PR's typecheck).

**`plugins/plugin-training/src/ui/fine-tuning-panels.tsx:461`** — TS7006 implicit-any on `trajectoryList.trajectories.map((trajectory) => …)`. Annotated with the existing `TrajectorySummary` type (declared at :176). Pure type annotation, zero semantic change.

## Verify
- `bunx tsc --noEmit` on plugin-training → **clean** (was TS7006 at :461).
- The OTHER develop-red maintainer flagged (`startup-phase-poll.test.ts:2027` TS2322) is **already resolved** — packages/ui typecheck is now **0 errors** on develop (a UI-lane fix landed since 16:27).

Collision-checked: no open PR (incl. #14114/#14075) touches this file.

🤖 [core-brain] fleet-unblock — orphaned typecheck red, blocks all PRs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>