### PR TITLE
fix(auth): scope shared Steward cookie reads

### DIFF
--- a/packages/cloud/shared/src/lib/auth.ts
+++ b/packages/cloud/shared/src/lib/auth.ts
@@ -12,6 +12,7 @@ import {
   type StewardVerifyEnv,
   verifyStewardTokenCached,
 } from "./auth/steward-client";
+import { readStewardAccessCookieFromHeader } from "./auth/steward-cookies";
 import { verifyWalletSignature } from "./auth/wallet-auth";
 import { cache as redisCache } from "./cache/client";
 import { CacheKeys, CacheTTL } from "./cache/keys";
@@ -118,7 +119,7 @@ export async function getCurrentUserFromRequest(
     const playwrightTestUser = await getPlaywrightTestUserFromHeader(cookieHeader);
     if (playwrightTestUser) return playwrightTestUser;
 
-    const stewardToken = getCookieValueFromHeader(cookieHeader, "steward-token");
+    const stewardToken = readStewardAccessCookieFromHeader(cookieHeader, getCloudAwareEnv().ENVIRONMENT);
     if (!stewardToken) return null;
 
     const tokenHash = hashToken(stewardToken);
@@ -405,7 +406,10 @@ export async function requireAuthOrApiKey(request: Request): Promise<AuthResult>
 
   // Fall back to session authentication (cookie-based)
   const user = await requireAuth(request);
-  const sessionToken = getCookieValueFromHeader(request.headers.get("cookie"), "steward-token");
+  const sessionToken = readStewardAccessCookieFromHeader(
+    request.headers.get("cookie"),
+    getCloudAwareEnv().ENVIRONMENT,
+  );
 
   return {
     user,

--- a/packages/cloud/shared/src/lib/auth.ts
+++ b/packages/cloud/shared/src/lib/auth.ts
@@ -119,7 +119,10 @@ export async function getCurrentUserFromRequest(
     const playwrightTestUser = await getPlaywrightTestUserFromHeader(cookieHeader);
     if (playwrightTestUser) return playwrightTestUser;
 
-    const stewardToken = readStewardAccessCookieFromHeader(cookieHeader, getCloudAwareEnv().ENVIRONMENT);
+    const stewardToken = readStewardAccessCookieFromHeader(
+      cookieHeader,
+      getCloudAwareEnv().ENVIRONMENT,
+    );
     if (!stewardToken) return null;
 
     const tokenHash = hashToken(stewardToken);

--- a/packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
@@ -41,7 +41,6 @@ describe("canMutateLegacyStewardCookies", () => {
   });
 });
 
-
 describe("readStewardAccessCookieFromHeader", () => {
   const beforeCutoff = LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS - 1;
   const atCutoff = LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS;

--- a/packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
@@ -7,8 +7,8 @@
 import { describe, expect, it } from "vitest";
 import {
   canMutateLegacyStewardCookies,
-  LEGACY_STEWARD_COOKIES,
   LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS,
+  LEGACY_STEWARD_COOKIES,
   readStewardAccessCookieFromHeader,
   stewardCookieNames,
 } from "./steward-cookies";
@@ -84,7 +84,11 @@ describe("readStewardAccessCookieFromHeader", () => {
       ),
     ).toBe("prod");
     expect(
-      readStewardAccessCookieFromHeader("steward-token=local", undefined, atCutoff),
+      readStewardAccessCookieFromHeader(
+        "steward-token=local",
+        undefined,
+        atCutoff,
+      ),
     ).toBe("local");
   });
 });

--- a/packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-cookies.test.ts
@@ -8,6 +8,8 @@ import { describe, expect, it } from "vitest";
 import {
   canMutateLegacyStewardCookies,
   LEGACY_STEWARD_COOKIES,
+  LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS,
+  readStewardAccessCookieFromHeader,
   stewardCookieNames,
 } from "./steward-cookies";
 
@@ -36,5 +38,54 @@ describe("canMutateLegacyStewardCookies", () => {
     expect(canMutateLegacyStewardCookies(undefined)).toBe(true);
     expect(canMutateLegacyStewardCookies("staging")).toBe(false);
     expect(canMutateLegacyStewardCookies("preview")).toBe(false);
+  });
+});
+
+
+describe("readStewardAccessCookieFromHeader", () => {
+  const beforeCutoff = LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS - 1;
+  const atCutoff = LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS;
+
+  it("reads the environment-scoped access cookie first", () => {
+    expect(
+      readStewardAccessCookieFromHeader(
+        "steward-token=prod; steward-token-staging=stage",
+        "staging",
+        beforeCutoff,
+      ),
+    ).toBe("stage");
+  });
+
+  it("allows a bounded read-only legacy fallback before the cutoff", () => {
+    expect(
+      readStewardAccessCookieFromHeader(
+        "steward-token=legacy",
+        "staging",
+        beforeCutoff,
+      ),
+    ).toBe("legacy");
+  });
+
+  it("shuts off the non-production legacy fallback at the cutoff", () => {
+    expect(
+      readStewardAccessCookieFromHeader(
+        "steward-token=legacy",
+        "staging",
+        atCutoff,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("keeps production and unset local environments on the historical cookie", () => {
+    expect(
+      readStewardAccessCookieFromHeader(
+        "steward-token=prod",
+        "production",
+        atCutoff,
+      ),
+    ).toBe("prod");
+    expect(
+      readStewardAccessCookieFromHeader("steward-token=local", undefined, atCutoff),
+    ).toBe("local");
   });
 });

--- a/packages/cloud/shared/src/lib/auth/steward-cookies.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-cookies.ts
@@ -44,14 +44,18 @@ export const LEGACY_STEWARD_COOKIES: StewardCookieNames = {
  * never clear or rotate the unsuffixed names because doing so logs out a live
  * production tab.
  */
-export function canMutateLegacyStewardCookies(environment: string | undefined): boolean {
+export function canMutateLegacyStewardCookies(
+  environment: string | undefined,
+): boolean {
   return !environment || environment === "production";
 }
 
 /** Resolve the cookie names for a Worker environment (`c.env.ENVIRONMENT`).
  * Unset (local dev / tests) behaves as production: localhost cookies are
  * host-scoped (no shared parent zone), so there is nothing to collide with. */
-export function stewardCookieNames(environment: string | undefined): StewardCookieNames {
+export function stewardCookieNames(
+  environment: string | undefined,
+): StewardCookieNames {
   if (!environment || environment === "production") {
     return LEGACY_STEWARD_COOKIES;
   }
@@ -67,7 +71,11 @@ export function stewardCookieNames(environment: string | undefined): StewardCook
  * the historical unsuffixed access cookie. This closes on 2026-08-04, one
  * 30-day refresh-cookie Max-Age after the 2026-07-05 scoped-cookie rollout.
  */
-export const LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS = Date.UTC(2026, 7, 4);
+export const LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS = Date.UTC(
+  2026,
+  7,
+  4,
+);
 
 /**
  * Read this environment's Steward access cookie, then the historical unsuffixed

--- a/packages/cloud/shared/src/lib/auth/steward-cookies.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-cookies.ts
@@ -13,6 +13,8 @@
  * untouched by the rename.
  */
 
+import { getCookieValueFromHeader } from "../http/cookie-header";
+
 export interface StewardCookieNames {
   token: string;
   refreshToken: string;
@@ -58,4 +60,36 @@ export function stewardCookieNames(environment: string | undefined): StewardCook
     refreshToken: `${BASE_REFRESH}-${environment}`,
     authed: `${BASE_AUTHED}-${environment}`,
   };
+}
+
+/**
+ * Bounded read-only migration window for non-production environments to accept
+ * the historical unsuffixed access cookie. This closes on 2026-08-04, one
+ * 30-day refresh-cookie Max-Age after the 2026-07-05 scoped-cookie rollout.
+ */
+export const LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS = Date.UTC(2026, 7, 4);
+
+/**
+ * Read this environment's Steward access cookie, then the historical unsuffixed
+ * cookie only during the bounded migration window. The fallback is read-only:
+ * callers verify the access JWT but must not rotate or clear legacy cookies in
+ * non-production.
+ */
+export function readStewardAccessCookieFromHeader(
+  cookieHeader: string | null,
+  environment: string | undefined,
+  nowMs = Date.now(),
+): string | undefined {
+  const names = stewardCookieNames(environment);
+  const ownCookie = getCookieValueFromHeader(cookieHeader, names.token);
+  if (ownCookie) return ownCookie;
+
+  if (
+    names.token === LEGACY_STEWARD_COOKIES.token ||
+    nowMs >= LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS
+  ) {
+    return undefined;
+  }
+
+  return getCookieValueFromHeader(cookieHeader, LEGACY_STEWARD_COOKIES.token);
 }

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
@@ -24,39 +24,15 @@ import {
   verifyPlaywrightTestSessionToken,
 } from "./playwright-test-session";
 import { verifyStewardTokenCached } from "./steward-client";
-import { LEGACY_STEWARD_COOKIES, stewardCookieNames } from "./steward-cookies";
-
-const LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS = Date.UTC(2026, 7, 4);
+import { readStewardAccessCookieFromHeader } from "./steward-cookies";
 
 function readStewardCookie(c: AppContext): string | null {
-  const names = stewardCookieNames(c.env?.ENVIRONMENT);
-  // Read this environment's own access-token cookie, then fall back to the
-  // legacy unsuffixed name. This fallback is READ-ONLY: it only verifies a JWT
-  // locally (jose), never rotating or invalidating the shared legacy refresh
-  // token, so a non-prod read of prod's legacy cookie cannot sign prod out
-  // (#13728). On production the two names are identical. Legacy cookies expire
-  // naturally; the fallback shuts off after 2026-08-04, one 30-day refresh
-  // cookie Max-Age after the 2026-07-05 scoped-cookie follow-up.
-  const ownCookie = readCookie(c, names.token);
-  if (ownCookie) return ownCookie;
-  if (
-    names.token === LEGACY_STEWARD_COOKIES.token ||
-    Date.now() >= LEGACY_STEWARD_COOKIE_FALLBACK_EXPIRES_AT_MS
-  ) {
-    return null;
-  }
-  return readCookie(c, LEGACY_STEWARD_COOKIES.token) ?? null;
-}
-
-function readCookie(c: AppContext, name: string): string | null {
-  const cookieHeader = c.req.header("cookie") ?? "";
-  for (const part of cookieHeader.split(";")) {
-    const [k, ...rest] = part.trim().split("=");
-    if (k === name) {
-      return decodeURIComponent(rest.join("=")) || null;
-    }
-  }
-  return null;
+  return (
+    readStewardAccessCookieFromHeader(
+      c.req.header("cookie") ?? null,
+      c.env?.ENVIRONMENT,
+    ) ?? null
+  );
 }
 
 function readBearer(c: AppContext): string | null {


### PR DESCRIPTION
## Summary
- centralize scoped Steward access-cookie reads in `steward-cookies.ts`
- keep production/unset environments on the historical `steward-token` name
- make non-production shared auth read `steward-token-<env>` first and use the unsuffixed legacy cookie only until the 2026-08-04 cutoff
- reuse the same helper from `workers-hono-auth.ts` so Worker routes and shared auth cannot drift

Project 12 draft card: `(auth) unbounded literal steward-token reads in cloud-shared auth.ts — inference proxy/models/MCP cross-env path`.

## Verification
- `bun test ./packages/cloud/shared/src/lib/auth/steward-cookies.test.ts` -> 7 pass / 0 fail
- `/Users/shawwalters/milaidy/eliza/node_modules/.bin/biome check packages/cloud/shared/src/lib/auth/steward-cookies.ts packages/cloud/shared/src/lib/auth/steward-cookies.test.ts --no-errors-on-unmatched`
- `git diff --check e5d4ff9901f73144e59552f4f2c487b967cc7ff4...HEAD`

## Not run locally
- Full `packages/cloud/shared` lint/typecheck/cloud mock request evidence. This host is a sparse, dirty checkout and repeatedly hit ENOSPC during broader build attempts; the PR is draft until a clean full workspace runs the broader gates.

## Evidence
- N/A - no UI/model/device behavior. Backend auth behavior is covered by the focused cookie-name/cutoff unit tests; broader request-level cloud evidence still needed before merge.
