### PR TITLE
feat(#14119): bind Cloud apps to Projects via cloudAppId (bridge + guidance + broker write-back)

### DIFF
--- a/packages/core/src/utils/project-registry.ts
+++ b/packages/core/src/utils/project-registry.ts
@@ -13,10 +13,12 @@
  * This mirrors `workspace-folder-config.ts` in shape and atomic-write style.
  *
  * `localPath` is the identity key for a project (realpath-compared against a
- * task's resolved workdir to bind it). `cloudAppId` is reserved but never
- * auto-populated here — that relation is an owner decision (epic #13766 WS4).
- * The VFS `projectId` (`virtual-filesystem.ts`) is a separate workbench-sandbox
- * namespace and is intentionally unrelated to a ProjectRecord id.
+ * task's resolved workdir to bind it). `cloudAppId` binds the project to an
+ * Eliza Cloud app: the orchestrator broker writes it here on an `apps.create`
+ * success for a task on this project (#14119), and a later task reads it back to
+ * update that app instead of minting a duplicate. The VFS `projectId`
+ * (`virtual-filesystem.ts`) is a separate workbench-sandbox namespace and is
+ * intentionally unrelated to a ProjectRecord id.
  */
 
 import { createHash, randomUUID } from "node:crypto";
@@ -52,7 +54,9 @@ export interface ProjectRecord {
 	worldId?: string;
 	/** macOS security-scoped bookmark for the picked folder, when present. */
 	bookmark?: string | null;
-	/** Reserved for the task↔Cloud-app relation; never auto-populated (#13766 WS4). */
+	/** The Eliza Cloud app this project owns, if any. Written back by the
+	 * orchestrator broker on an `apps.create` success for a task bound to this
+	 * project (#14119); read to update the existing app rather than duplicate it. */
 	cloudAppId?: string;
 	createdAt: string;
 	lastOpenedAt: string;

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
@@ -328,4 +328,68 @@ describe("app-deploy-guidance", () => {
       expect(out).not.toContain("POST /api/v1/apps");
     });
   });
+
+  // #14119: when the task's Project already owns a Cloud app, the guidance must
+  // flip apps.create -> apps.get/apps.update on that id so a follow-up task does
+  // not mint a duplicate app.
+  describe("bound Cloud app id mode-switch (#14119)", () => {
+    it("adds no bound-app line when cloudAppId is absent", () => {
+      const out = buildAppDeployGuidance(
+        { target: "eliza-cloud" },
+        "build a website about cats",
+      );
+      expect(out).not.toContain("apps.update");
+      expect(out).not.toContain("bound to Cloud app");
+    });
+
+    it("instructs apps.get/apps.update on the bound id instead of apps.create", () => {
+      const out = buildAppDeployGuidance(
+        { target: "eliza-cloud" },
+        "build a website about cats",
+        false,
+        "app_bound_42",
+      );
+      expect(out).toContain("bound to Cloud app `app_bound_42`");
+      expect(out).toContain("Do NOT `apps.create`");
+      expect(out).toContain("`apps.get`");
+      expect(out).toContain("`apps.update`");
+    });
+
+    it("augmentTaskWithDeployGuidance threads cloudAppId into a cloud app build", () => {
+      const out = augmentTaskWithDeployGuidance(
+        "build a website about cats",
+        { target: "eliza-cloud" },
+        { cloudAppId: "app_thread" },
+      );
+      expect(out).toContain("--- App Deployment (Eliza Cloud) ---");
+      expect(out).toContain("bound to Cloud app `app_thread`");
+    });
+
+    it("a monetized custom-host app still gets the bound-app line (it touches Cloud)", () => {
+      const out = augmentTaskWithDeployGuidance(
+        "an app where people pay $1 to chat with a bot",
+        {
+          target: "custom",
+          customAppsDir: "/data/apps",
+          customBaseUrl: "https://example.test",
+        },
+        { monetized: true, cloudAppId: "app_custom" },
+      );
+      expect(out).toContain("bound to Cloud app `app_custom`");
+      expect(out).toContain("`apps.update`");
+    });
+
+    it("a non-monetized custom-host app gets no Cloud bound-app line", () => {
+      const out = augmentTaskWithDeployGuidance(
+        "build a plain static landing page",
+        {
+          target: "custom",
+          customAppsDir: "/data/apps",
+          customBaseUrl: "https://example.test",
+        },
+        { cloudAppId: "app_ignored" },
+      );
+      expect(out).not.toContain("bound to Cloud app");
+    });
+  });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/parent-context-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/parent-context-routes.test.ts
@@ -3,9 +3,13 @@
  * endpoints and the originatingTask read-back added for #13774.
  * Deterministic unit test with stubbed runtime + services; no live model.
  */
+import { mkdtempSync, rmSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import os from "node:os";
+import { join } from "node:path";
 import { Readable } from "node:stream";
-import { describe, expect, it } from "vitest";
+import { upsertProject } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { handleParentContextRoutes } from "../../src/api/parent-context-routes.ts";
 import type { RouteContext } from "../../src/api/route-utils.ts";
 
@@ -72,6 +76,7 @@ function makeCtx(opts: {
   task?: {
     goal: string;
     acceptanceCriteria?: string[];
+    projectId?: string | null;
     decisions?: Array<Record<string, unknown>>;
   } | null;
   noSkillsService?: boolean;
@@ -267,6 +272,89 @@ describe("parent-context originatingTask", () => {
       ctx,
     );
     expect((body as { originatingTask: unknown }).originatingTask).toBeNull();
+  });
+});
+
+describe("parent-context project↔Cloud-app binding (#14119)", () => {
+  // The bridge resolves cloudAppId from the REAL on-disk project registry keyed
+  // by the task's projectId, so point the state dir at a temp registry.
+  let stateDir: string;
+  let priorStateDir: string | undefined;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(os.tmpdir(), "parent-context-project-"));
+    priorStateDir = process.env.ELIZA_STATE_DIR;
+    process.env.ELIZA_STATE_DIR = stateDir;
+  });
+
+  afterEach(() => {
+    if (priorStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+    else process.env.ELIZA_STATE_DIR = priorStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("surfaces cloudAppId for a task bound to a project that owns a Cloud app", async () => {
+    const project = upsertProject({
+      name: "shop",
+      localPath: "/tmp/shop",
+      cloudAppId: "app_live_1",
+    });
+    const ctx = makeCtx({
+      sessionMetadata: { taskId: "task-1" },
+      task: {
+        goal: "update the shop",
+        projectId: project.id,
+        decisions: [],
+      },
+    });
+    const { body } = await call(
+      `/api/coding-agents/${SESSION}/parent-context`,
+      ctx,
+    );
+    const originating = (body as { originatingTask: Record<string, unknown> })
+      .originatingTask;
+    expect(originating.projectId).toBe(project.id);
+    expect(originating.cloudAppId).toBe("app_live_1");
+    // Hoisted top-level descriptor mirrors it.
+    expect((body as { project: Record<string, unknown> }).project).toEqual({
+      projectId: project.id,
+      cloudAppId: "app_live_1",
+    });
+  });
+
+  it("cloudAppId is null when the bound project owns no Cloud app", async () => {
+    const project = upsertProject({ name: "bare", localPath: "/tmp/bare" });
+    const ctx = makeCtx({
+      sessionMetadata: { taskId: "task-2" },
+      task: { goal: "build", projectId: project.id, decisions: [] },
+    });
+    const { body } = await call(
+      `/api/coding-agents/${SESSION}/parent-context`,
+      ctx,
+    );
+    const originating = (body as { originatingTask: Record<string, unknown> })
+      .originatingTask;
+    expect(originating.projectId).toBe(project.id);
+    expect(originating.cloudAppId).toBeNull();
+    expect(
+      (body as { project: { cloudAppId: unknown } }).project.cloudAppId,
+    ).toBeNull();
+  });
+
+  it("project descriptor is null for an unbound task (no projectId)", async () => {
+    const ctx = makeCtx({
+      sessionMetadata: { taskId: "task-3" },
+      task: { goal: "build", projectId: null, decisions: [] },
+    });
+    const { body } = await call(
+      `/api/coding-agents/${SESSION}/parent-context`,
+      ctx,
+    );
+    const originating = (body as { originatingTask: Record<string, unknown> })
+      .originatingTask;
+    expect(originating.projectId).toBeNull();
+    expect(originating.cloudAppId).toBeNull();
+    expect((body as { project: unknown }).project).toBeNull();
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
@@ -117,6 +117,35 @@ describe("buildGoalPrompt capability fence", () => {
   });
 });
 
+describe("buildGoalPrompt Cloud app descriptor (#14119)", () => {
+  const baseInput = { agentName: "Ada", goal: "ship the thing" };
+
+  it("omits the Cloud app line when no cloudAppId is bound", () => {
+    expect(buildGoalPrompt(baseInput)).not.toContain("Cloud app:");
+    expect(buildGoalPrompt({ ...baseInput, cloudAppId: "   " })).not.toContain(
+      "Cloud app:",
+    );
+  });
+
+  it("renders the bound Cloud app id in the Workspace descriptor", () => {
+    const prompt = buildGoalPrompt({
+      ...baseInput,
+      workdir: "/repo",
+      cloudAppId: "app_abc",
+    });
+    expect(prompt).toContain("--- Workspace ---");
+    expect(prompt).toContain("Cloud app: app_abc");
+    expect(prompt).toContain("apps.get/apps.update");
+    expect(prompt).toContain("instead of creating a new one");
+  });
+
+  it("renders the Workspace section even with no workdir/repo when only a Cloud app is bound", () => {
+    const prompt = buildGoalPrompt({ ...baseInput, cloudAppId: "app_only" });
+    expect(prompt).toContain("--- Workspace ---");
+    expect(prompt).toContain("Cloud app: app_only");
+  });
+});
+
 describe("buildGoalPrompt attempt reflections (#8899)", () => {
   const baseInput = { agentName: "Ada", goal: "ship the thing" };
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
@@ -2,7 +2,11 @@
  * Verifies runParentAgentBroker.
  * Deterministic unit test with a stubbed runtime; no live model.
  */
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
 import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { getProjectById, upsertProject } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runParentAgentBroker } from "../services/parent-agent-broker.js";
 import {
@@ -279,6 +283,182 @@ describe("runParentAgentBroker", () => {
     expect(init.body).toBe(
       JSON.stringify({ name: "Test App", description: "integration test" }),
     );
+  });
+
+  describe("apps.create project write-back (#14119)", () => {
+    let stateDir: string;
+    let priorStateDir: string | undefined;
+
+    afterEach(() => {
+      if (priorStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+      else process.env.ELIZA_STATE_DIR = priorStateDir;
+      if (stateDir) rmSync(stateDir, { recursive: true, force: true });
+    });
+
+    function withProjectState(cloudAppId?: string): {
+      projectId: string;
+    } {
+      stateDir = mkdtempSync(join(os.tmpdir(), "broker-project-"));
+      priorStateDir = process.env.ELIZA_STATE_DIR;
+      process.env.ELIZA_STATE_DIR = stateDir;
+      const project = upsertProject({
+        name: "shop",
+        localPath: "/tmp/broker-shop",
+        ...(cloudAppId ? { cloudAppId } : {}),
+      });
+      return { projectId: project.id };
+    }
+
+    /** Runtime whose task service maps the session's task to `projectId`,
+     * matching the real ORCHESTRATOR_TASK_SERVICE.getTask contract the broker
+     * resolves. */
+    function taskBoundRuntime(projectId: string): IAgentRuntime {
+      return createRuntime({
+        getService: ((name: string) =>
+          name === "ORCHESTRATOR_TASK_SERVICE"
+            ? { getTask: async (_id: string) => ({ projectId }) }
+            : null) as IAgentRuntime["getService"],
+      });
+    }
+
+    function appsCreateArgs() {
+      return {
+        mode: "cloud-command" as const,
+        command: "apps.create",
+        params: { body: { name: "Test App" } },
+      };
+    }
+
+    it("writes the created app id back to the task's bound project", async () => {
+      const { projectId } = withProjectState();
+      vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "test-key");
+      vi.stubEnv("ELIZA_CLOUD_BASE_URL", "https://cloud.test");
+      const fetchMock = vi.fn(async () => {
+        // Cloud returns the created app nested under `app` (service shape).
+        return new Response(
+          JSON.stringify({ app: { id: "app_created_99" }, apiKey: "secret" }),
+          { status: 201, headers: { "content-type": "application/json" } },
+        );
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const runtime = taskBoundRuntime(projectId);
+      const session = {
+        id: "session-9",
+        status: "running",
+        metadata: { taskId: "task-9" },
+      } as unknown as Parameters<typeof runParentAgentBroker>[0]["session"];
+
+      // Two-phase: pending confirmation, then the confirmed run.
+      await runParentAgentBroker({
+        runtime,
+        sessionId: "session-9",
+        session,
+        message: brokerMessage(),
+        args: appsCreateArgs(),
+      });
+      const result = await runParentAgentBroker({
+        runtime,
+        sessionId: "session-9",
+        session,
+        message: brokerMessage("yes"),
+        args: appsCreateArgs(),
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.boundCloudAppId).toBe("app_created_99");
+      // Persisted to the real registry, atomically.
+      expect(getProjectById(projectId)?.cloudAppId).toBe("app_created_99");
+    });
+
+    it("does not write back when the session has no bound project", async () => {
+      const { projectId } = withProjectState();
+      vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "test-key");
+      vi.stubEnv("ELIZA_CLOUD_BASE_URL", "https://cloud.test");
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(
+          async () =>
+            new Response(JSON.stringify({ app: { id: "app_x" } }), {
+              status: 201,
+              headers: { "content-type": "application/json" },
+            }),
+        ),
+      );
+      // Runtime with a task service that returns an UNBOUND task (no projectId).
+      const runtime = createRuntime({
+        getService: ((name: string) =>
+          name === "ORCHESTRATOR_TASK_SERVICE"
+            ? { getTask: async () => ({ projectId: null }) }
+            : null) as IAgentRuntime["getService"],
+      });
+      const session = {
+        id: "s",
+        status: "running",
+        metadata: { taskId: "task-unbound" },
+      } as unknown as Parameters<typeof runParentAgentBroker>[0]["session"];
+
+      await runParentAgentBroker({
+        runtime,
+        sessionId: "s",
+        session,
+        message: brokerMessage(),
+        args: appsCreateArgs(),
+      });
+      const result = await runParentAgentBroker({
+        runtime,
+        sessionId: "s",
+        session,
+        message: brokerMessage("yes"),
+        args: appsCreateArgs(),
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.boundCloudAppId).toBeUndefined();
+      // The project keeps no cloudAppId — nothing was written.
+      expect(getProjectById(projectId)?.cloudAppId).toBeUndefined();
+    });
+
+    it("does not write back when apps.create fails (non-ok response)", async () => {
+      const { projectId } = withProjectState();
+      vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "test-key");
+      vi.stubEnv("ELIZA_CLOUD_BASE_URL", "https://cloud.test");
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(
+          async () =>
+            new Response(JSON.stringify({ error: "quota" }), {
+              status: 402,
+              headers: { "content-type": "application/json" },
+            }),
+        ),
+      );
+      const runtime = taskBoundRuntime(projectId);
+      const session = {
+        id: "sf",
+        status: "running",
+        metadata: { taskId: "task-fail" },
+      } as unknown as Parameters<typeof runParentAgentBroker>[0]["session"];
+
+      await runParentAgentBroker({
+        runtime,
+        sessionId: "sf",
+        session,
+        message: brokerMessage(),
+        args: appsCreateArgs(),
+      });
+      const result = await runParentAgentBroker({
+        runtime,
+        sessionId: "sf",
+        session,
+        message: brokerMessage("yes"),
+        args: appsCreateArgs(),
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.data?.boundCloudAppId).toBeUndefined();
+      expect(getProjectById(projectId)?.cloudAppId).toBeUndefined();
+    });
   });
 
   it("does not leak Cloud path params into inferred request bodies", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
@@ -8,6 +8,7 @@ import { mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
 import {
+  getProjectById,
   logger,
   setActiveProject,
   stringToUuid,
@@ -16,8 +17,10 @@ import {
 } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  bindProjectCloudApp,
   deriveProjectWorldId,
   findProjectByWorkdir,
+  resolveBoundProjectCloudAppId,
   resolveBoundProjectWorkdir,
   resolveTaskProjectId,
   resolveTaskSpawnWorkdir,
@@ -196,6 +199,58 @@ describe("project-binding", () => {
     expect(deriveProjectWorldId("proj-2")).not.toBe(a);
     expect(a).toBe(stringToUuid("project:proj-1"));
     expect(a).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("resolveBoundProjectCloudAppId returns the project's cloudAppId or null", () => {
+    const withApp = upsertProject(
+      { name: "with-app", localPath: "/tmp/with-app", cloudAppId: "app_123" },
+      env,
+    );
+    const noApp = upsertProject(
+      { name: "no-app", localPath: "/tmp/no-app" },
+      env,
+    );
+    expect(resolveBoundProjectCloudAppId(withApp.id, env)).toBe("app_123");
+    expect(resolveBoundProjectCloudAppId(noApp.id, env)).toBeNull();
+    expect(resolveBoundProjectCloudAppId("stale-id", env)).toBeNull();
+    expect(resolveBoundProjectCloudAppId(undefined, env)).toBeNull();
+  });
+
+  it("bindProjectCloudApp writes cloudAppId back and persists it atomically", () => {
+    const p = upsertProject({ name: "p", localPath: "/tmp/bind-app" }, env);
+    expect(getProjectById(p.id, env)?.cloudAppId).toBeUndefined();
+
+    const bound = bindProjectCloudApp(p.id, "app_new", env);
+    expect(bound?.cloudAppId).toBe("app_new");
+    // Persisted to disk: a fresh read (new registry parse) sees the id, other
+    // fields (id/localPath/createdAt) are preserved by the localPath-keyed upsert.
+    const reread = getProjectById(p.id, env);
+    expect(reread?.cloudAppId).toBe("app_new");
+    expect(reread?.id).toBe(p.id);
+    expect(reread?.localPath).toBe("/tmp/bind-app");
+    expect(reread?.createdAt).toBe(p.createdAt);
+  });
+
+  it("bindProjectCloudApp overwrites a different existing cloudAppId (latest create wins)", () => {
+    const p = upsertProject(
+      { name: "p", localPath: "/tmp/rebind", cloudAppId: "app_old" },
+      env,
+    );
+    const bound = bindProjectCloudApp(p.id, "app_replacement", env);
+    expect(bound?.cloudAppId).toBe("app_replacement");
+    expect(getProjectById(p.id, env)?.cloudAppId).toBe("app_replacement");
+  });
+
+  it("bindProjectCloudApp is a no-op for an unknown project or blank app id", () => {
+    const p = upsertProject(
+      { name: "p", localPath: "/tmp/noop", cloudAppId: "app_keep" },
+      env,
+    );
+    expect(bindProjectCloudApp("stale-id", "app_x", env)).toBeNull();
+    expect(bindProjectCloudApp(p.id, "  ", env)).toBeNull();
+    expect(bindProjectCloudApp(undefined, "app_x", env)).toBeNull();
+    // The existing binding is untouched by the no-op calls.
+    expect(getProjectById(p.id, env)?.cloudAppId).toBe("app_keep");
   });
 
   it("a projectId bound via the legacy workspace-folder.json synthesis resolves back to its workdir", () => {

--- a/plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts
@@ -10,7 +10,7 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { IAgentRuntime, Memory } from "@elizaos/core";
-import { ModelType } from "@elizaos/core";
+import { getProjectById, ModelType } from "@elizaos/core";
 import { activeWorkspaceContextProvider } from "../providers/active-workspace-context.js";
 import {
   type SessionInfo,
@@ -65,6 +65,10 @@ interface OrchestratorTaskServiceShape {
   getTask: (taskId: string) => Promise<{
     goal: string;
     acceptanceCriteria?: string[];
+    /** Registered Project this task is bound to; drives the Cloud-app binding
+     * (`cloudAppId`) the bridge surfaces so a child updates the existing app
+     * instead of creating a duplicate. */
+    projectId?: string | null;
     decisions?: Array<{
       id: string;
       sessionId: string;
@@ -329,8 +333,23 @@ async function loadOriginatingTask(
     acceptanceCriteria: Array.isArray(task.acceptanceCriteria)
       ? task.acceptanceCriteria
       : [],
+    projectId: readString(task.projectId),
+    // The Cloud app this task's Project is bound to, when any. A child that sees
+    // this updates the existing app (apps.update) instead of apps.create-ing a
+    // duplicate (#14119). Absent for unbound tasks or projects with no Cloud app.
+    cloudAppId: resolveCloudAppId(task.projectId),
     decisions,
   };
+}
+
+/** The `cloudAppId` bound to a task's Project, or null when the task is unbound
+ * or its project carries no Cloud app. Reads the shared core project registry
+ * (`projects.json`) — the single source of truth for the Project↔Cloud-app
+ * relation the broker writes back on apps.create. */
+function resolveCloudAppId(projectId: string | null | undefined): string | null {
+  const id = readString(projectId);
+  if (!id) return null;
+  return readString(getProjectById(id)?.cloudAppId);
 }
 
 async function buildParentContext(
@@ -341,6 +360,7 @@ async function buildParentContext(
   const metadata = readSessionMetadata(session);
   const roomId = readOriginRoomId(metadata);
   const character = ctx.runtime.character;
+  const originatingTask = await loadOriginatingTask(ctx, metadata);
   return {
     sessionId,
     character: {
@@ -358,8 +378,27 @@ async function buildParentContext(
     currentRoom: await loadRoom(ctx.runtime, roomId),
     workdir: session?.workdir ?? null,
     model: normalizeModel(session, metadata),
-    originatingTask: await loadOriginatingTask(ctx, metadata),
+    originatingTask,
+    // Hoisted from originatingTask so a child can read the Project↔Cloud-app
+    // binding without unpacking the task block; null for unbound tasks (#14119).
+    project: buildProjectDescriptor(originatingTask),
   };
+}
+
+/** The bound Project's id + Cloud app, lifted to a top-level `project` field, or
+ * null when the session has no originating task. Mirrors what the goal-prompt
+ * project descriptor line carries so both spawn-time prompt and bridge agree. */
+function buildProjectDescriptor(originatingTask: JsonValue): JsonValue {
+  if (
+    !originatingTask ||
+    typeof originatingTask !== "object" ||
+    Array.isArray(originatingTask)
+  ) {
+    return null;
+  }
+  const projectId = readString(originatingTask.projectId);
+  if (!projectId) return null;
+  return { projectId, cloudAppId: readString(originatingTask.cloudAppId) };
 }
 
 async function searchParentMemory(

--- a/plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts
@@ -346,7 +346,9 @@ async function loadOriginatingTask(
  * or its project carries no Cloud app. Reads the shared core project registry
  * (`projects.json`) — the single source of truth for the Project↔Cloud-app
  * relation the broker writes back on apps.create. */
-function resolveCloudAppId(projectId: string | null | undefined): string | null {
+function resolveCloudAppId(
+  projectId: string | null | undefined,
+): string | null {
   const id = readString(projectId);
   if (!id) return null;
   return readString(getProjectById(id)?.cloudAppId);

--- a/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
@@ -230,16 +230,32 @@ export function viewPluginGuidance(
     : buildLocalViewPluginPrompt();
 }
 
+/**
+ * When the task's Project is already bound to a Cloud app (`cloudAppId`, #14119),
+ * the child must UPDATE that app, not mint a duplicate. One extra line pins the
+ * id and flips the create verb to get/update — the rest of the deploy contract
+ * is unchanged. Empty string when there is no bound app.
+ */
+function existingCloudAppLine(cloudAppId?: string): string {
+  const id = cloudAppId?.trim();
+  if (!id) return "";
+  return `- This task's Project is already bound to Cloud app \`${id}\`. Do NOT \`apps.create\` a new app — that duplicates it. Read the existing app with \`apps.get\` (id \`${id}\`) and modify it with \`apps.update\`; deploy a new container revision to the SAME app id.`;
+}
+
 /** Build the deploy-guidance block for the configured target. */
 export function buildAppDeployGuidance(
   config?: AppDeployConfig,
   task?: string,
   monetized?: boolean,
+  cloudAppId?: string,
 ): string {
   const resolved = config ?? resolveAppDeployConfig();
-  return resolved.target === "custom"
-    ? customHostGuidance(resolved, task, monetized)
-    : elizaCloudGuidance(task, monetized);
+  const base =
+    resolved.target === "custom"
+      ? customHostGuidance(resolved, task, monetized)
+      : elizaCloudGuidance(task, monetized);
+  const boundLine = existingCloudAppLine(cloudAppId);
+  return boundLine ? `${base}\n${boundLine}` : base;
 }
 
 function isCloudDeployTarget(config: AppDeployConfig): boolean {
@@ -261,7 +277,7 @@ function extractViewPluginSourceDir(task: string): string | undefined {
 export function augmentTaskWithDeployGuidance(
   task: string,
   config?: AppDeployConfig,
-  opts?: { monetized?: boolean },
+  opts?: { monetized?: boolean; cloudAppId?: string },
 ): string {
   // Idempotent: if a deploy block is already present, no-op.
   if (
@@ -293,7 +309,12 @@ export function augmentTaskWithDeployGuidance(
   // the agent got no apps-dir context and could not find or edit the deployed
   // app. Letting the model decide from an always-present note is cleaner.
   if (resolved.target === "custom") {
-    return `${task.trimEnd()}\n\n${customHostGuidance(resolved, task, monetized)}`;
+    // A custom-host app only touches Cloud when it is monetized (it registers
+    // for billing); only then does an existing-app binding apply.
+    const boundLine = monetized ? existingCloudAppLine(opts?.cloudAppId) : "";
+    const custom = customHostGuidance(resolved, task, monetized);
+    const block = boundLine ? `${custom}\n${boundLine}` : custom;
+    return `${task.trimEnd()}\n\n${block}`;
   }
   // Force the deploy contract for a monetized task even when isAppBuildTask
   // misses it — a monetized request ("an app where people pay $1 to chat …") is
@@ -302,5 +323,5 @@ export function augmentTaskWithDeployGuidance(
   if (!monetized && !isAppBuildTask(task)) {
     return task;
   }
-  return `${task.trimEnd()}\n\n${buildAppDeployGuidance(resolved, task, monetized)}`;
+  return `${task.trimEnd()}\n\n${buildAppDeployGuidance(resolved, task, monetized, opts?.cloudAppId)}`;
 }

--- a/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
@@ -106,6 +106,10 @@ export interface GoalPromptInput {
   worktreeRoomId?: string;
   workdir?: string;
   repo?: string;
+  /** The Cloud app this task's bound Project already owns (#14119). Rendered in
+   * the Workspace descriptor so the worker updates it rather than creating a
+   * duplicate app. Undefined = unbound project / no Cloud app. */
+  cloudAppId?: string;
   /** Named capability fence to apply when `allowedCapabilities` is not given.
    * Defaults to `"default"` (the coding-only fence). */
   capabilityProfile?: GoalCapabilityProfile;
@@ -203,6 +207,11 @@ export function buildGoalPrompt(input: GoalPromptInput): string {
   const workspaceLines: string[] = [];
   if (input.workdir) workspaceLines.push(`Workdir: ${input.workdir}`);
   if (input.repo) workspaceLines.push(`Repo: ${input.repo}`);
+  if (input.cloudAppId?.trim()) {
+    workspaceLines.push(
+      `Cloud app: ${input.cloudAppId.trim()} — this Project already owns this app; update it (apps.get/apps.update) instead of creating a new one.`,
+    );
+  }
   if (workspaceLines.length > 0) {
     sections.push("--- Workspace ---", workspaceLines.join("\n"));
   }

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -150,6 +150,7 @@ import {
 } from "./parent-agent-broker.js";
 import {
   deriveProjectWorldId,
+  resolveBoundProjectCloudAppId,
   resolveTaskProjectId,
   resolveTaskSpawnWorkdir,
 } from "./project-binding.js";
@@ -3585,6 +3586,11 @@ export class OrchestratorTaskService extends Service {
       doc.task.metadata?.capabilityProfile,
     );
     const brokerWired = isParentAgentBrokerWired(this.runtime);
+    // A task bound to a Project that already owns a Cloud app carries that app's
+    // id into the prompt so the worker updates it rather than minting a duplicate
+    // (#14119). Null for unbound tasks or projects with no Cloud app.
+    const cloudAppId =
+      resolveBoundProjectCloudAppId(doc.task.projectId) ?? undefined;
     const goalPrompt = buildGoalPrompt({
       agentName,
       goal: doc.task.goal,
@@ -3593,6 +3599,7 @@ export class OrchestratorTaskService extends Service {
       taskRoomId: doc.task.taskRoomId ?? doc.task.roomId,
       workdir,
       repo: opts.repo,
+      ...(cloudAppId ? { cloudAppId } : {}),
       // Replay prior failed-verification post-mortems so a re-spawn of this task
       // doesn't repeat them (#8899).
       attemptReflections: readAttemptReflections(doc.task.metadata),

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -17,6 +17,7 @@ import type {
 } from "@elizaos/core";
 import { requireConfirmation } from "@elizaos/core";
 import { readConfigCloudKey, readConfigEnvKey } from "./config-env.js";
+import { bindProjectCloudApp } from "./project-binding.js";
 import {
   addSessionSpendUsd,
   decideSpendAuthorization,
@@ -1065,6 +1066,51 @@ function brokerConfirmationMemory(
   } as Memory;
 }
 
+/**
+ * The id of the app a successful `apps.create` minted, dug out of the Cloud
+ * REST response. The envelope varies (`{id}`, `{app:{id}}`, or either nested
+ * under `{data}`), so probe the known shapes and take the first string id.
+ * error-policy:J3 — this parses an untrusted external API body; a shape we do
+ * not recognize yields null (no write-back), never a fabricated id.
+ */
+function extractCreatedAppId(payload: unknown): string | undefined {
+  const candidates: unknown[] = [];
+  const push = (v: unknown) => {
+    if (isRecord(v)) {
+      candidates.push(v.id);
+      if (isRecord(v.app)) candidates.push(v.app.id);
+    }
+  };
+  push(payload);
+  if (isRecord(payload)) push(payload.data);
+  for (const candidate of candidates) {
+    const id = normalizeString(candidate);
+    if (id) return id;
+  }
+  return undefined;
+}
+
+/**
+ * The registered-Project id the child's task is bound to, resolved from the
+ * session's `taskId` via the orchestrator task service. Null when the session
+ * has no task, the service is absent, the task is unbound, or the task no longer
+ * exists — the write-back is skipped in every such case. Structural service
+ * lookup avoids a value import on the task service (loose coupling; no cycle).
+ */
+async function resolveSessionProjectId(
+  runtime: IAgentRuntime,
+  session: SessionInfo | undefined,
+): Promise<string | undefined> {
+  const taskId = normalizeString(session?.metadata?.taskId);
+  if (!taskId) return undefined;
+  const service = runtime.getService("ORCHESTRATOR_TASK_SERVICE") as {
+    getTask?: (id: string) => Promise<{ projectId?: string | null } | null>;
+  } | null;
+  if (typeof service?.getTask !== "function") return undefined;
+  const task = await service.getTask(taskId);
+  return normalizeString(task?.projectId);
+}
+
 async function runCloudCommand(args: {
   runtime: IAgentRuntime;
   command: string | undefined;
@@ -1072,6 +1118,9 @@ async function runCloudCommand(args: {
   confirmationMessage: Memory;
   /** Child session id — keys the per-session self-spend ledger. */
   sessionId: string;
+  /** Session the request came from — carries `metadata.taskId`, used to bind a
+   * created Cloud app back to the task's Project (#14119). */
+  session?: SessionInfo;
 }): Promise<{
   success: boolean;
   text: string;
@@ -1268,6 +1317,29 @@ async function runCloudCommand(args: {
     truncate(payloadText, CLOUD_RESPONSE_MAX_CHARS),
   ].join("\n");
 
+  // Bind the created Cloud app to the task's Project so the next task on this
+  // Project updates it instead of creating a duplicate (#14119). Only on a
+  // successful apps.create for a project-bound session; otherwise a no-op.
+  let boundCloudAppId: string | undefined;
+  if (definition.command === "apps.create" && response.ok) {
+    const createdAppId = extractCreatedAppId(payload);
+    const projectId = await resolveSessionProjectId(args.runtime, args.session);
+    const bound = bindProjectCloudApp(projectId, createdAppId);
+    if (bound) {
+      boundCloudAppId = bound.cloudAppId;
+      log?.info?.(
+        {
+          src: LOG_PREFIX,
+          event: "project_cloud_app_bound",
+          sessionId: args.sessionId,
+          projectId: bound.id,
+          cloudAppId: bound.cloudAppId,
+        },
+        `${LOG_PREFIX} bound Cloud app ${bound.cloudAppId} to project ${bound.id}`,
+      );
+    }
+  }
+
   return {
     success: response.ok,
     text,
@@ -1278,6 +1350,7 @@ async function runCloudCommand(args: {
       risk: definition.risk,
       status: response.status,
       path: `${built.url.pathname}${built.url.search}`,
+      ...(boundCloudAppId ? { boundCloudAppId } : {}),
     },
   };
 }
@@ -1560,6 +1633,7 @@ export async function runParentAgentBroker(
         params: args.params,
         confirmationMessage: brokerConfirmationMemory(request),
         sessionId: request.sessionId,
+        session: request.session,
       });
     } catch (error) {
       // error-policy:J1 boundary — translates a Cloud command fault into the structured {success:false} broker result.

--- a/plugins/plugin-agent-orchestrator/src/services/project-binding.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/project-binding.ts
@@ -26,6 +26,7 @@ import {
   type ProjectRecord,
   readProjectRegistry,
   stringToUuid,
+  upsertProject,
   type UUID,
 } from "@elizaos/core";
 
@@ -174,4 +175,41 @@ export function resolveTaskSpawnWorkdir(
 
   // 4. Nothing bound/explicit — caller resolves route/convention/default.
   return { workdir: undefined, lockWorkdir: false, source: "unresolved" };
+}
+
+/** The Cloud app id a bound task's Project already owns, or `null` when the task
+ * is unbound, its project id is stale, or the project carries no Cloud app. Lets
+ * a spawn tell the worker to update the existing app instead of duplicating it
+ * (#14119). */
+export function resolveBoundProjectCloudAppId(
+  projectId: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const id = projectId?.trim();
+  if (!id) return null;
+  return getProjectById(id, env)?.cloudAppId ?? null;
+}
+
+/**
+ * Persist a Project↔Cloud-app binding: write `cloudAppId` onto the registered
+ * project so the next task on it updates the existing app instead of creating a
+ * duplicate (#14119). The registry is the single source of truth for this
+ * relation — the broker calls this on an `apps.create` success for a
+ * project-bound task. No-op returning `null` when the project id is unknown or
+ * the app id is blank; when the project already carries a DIFFERENT cloudAppId
+ * this overwrites it (the latest successful create wins). The underlying
+ * `upsertProject` write is atomic (tmp-file + rename).
+ */
+export function bindProjectCloudApp(
+  projectId: string | undefined,
+  cloudAppId: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): ProjectRecord | null {
+  const id = projectId?.trim();
+  const appId = cloudAppId?.trim();
+  if (!id || !appId) return null;
+  const project = getProjectById(id, env);
+  if (!project) return null;
+  if (project.cloudAppId === appId) return project;
+  return upsertProject({ ...project, cloudAppId: appId }, env);
 }


### PR DESCRIPTION
## What

Resolves owner-decision (c) from #13774 / epic #13766: bind Cloud apps to Projects via an optional `cloudAppId` on `ProjectRecord`, surfaced to spawned sub-agents through the parent-context bridge and the goal prompt, enforced in the app-deploy guidance, and written back on `apps.create`. A task on a Project that already owns a Cloud app now updates that app instead of minting a duplicate; the degenerate case (no `cloudAppId`) behaves exactly as before.

## Work items (all 5 from the issue)

1. **Optional `cloudAppId` on `ProjectRecord`** — the field, type guard, and `upsertProject` pass-through already existed (additive, `version: 1` unchanged); this PR updates the stale "never auto-populated" comment to describe the now-live write-back. `packages/core/src/utils/project-registry.ts`.
2. **Surfaced in `buildParentContext`** — the bridge resolves the session's task → `projectId` → registry `cloudAppId` and exposes it on `originatingTask.cloudAppId`, plus a hoisted top-level `project` descriptor (`{ projectId, cloudAppId }`). Only bound tasks get a non-null value. `plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts`.
   - **Goal-prompt project descriptor line** — `buildGoalPrompt` renders a `Cloud app: <id> — …update it instead of creating a new one` line in the `--- Workspace ---` section when a `cloudAppId` is bound. `services/goal-prompt.ts` + `services/orchestrator-task-service.ts` (threads the bound id).
3. **`app-deploy-guidance` mode-switch** — when `cloudAppId` is present, the guidance appends a directive to `apps.get`/`apps.update` that id and NOT `apps.create`. Applies to the Eliza-Cloud path and to a monetized custom-host app (which still registers with Cloud). `services/app-deploy-guidance.ts`.
4. **Broker write-back** — on an `apps.create` success for a project-bound session, the broker digs the created app id out of the Cloud REST response (envelope-tolerant; J3 parse of untrusted body) and writes `cloudAppId` back to the task's Project atomically. Skipped for unbound sessions and non-ok responses. `services/parent-agent-broker.ts` + `bindProjectCloudApp` in `services/project-binding.ts`.
5. **Tests** — real on-disk registry (temp `ELIZA_STATE_DIR`, no mocks) for binding + bridge; deterministic prompt/guidance assertions; broker write-back drives the real two-phase confirm path with a stubbed `fetch` and asserts the registry mutation.

## Coordination note (#14118)

The sibling #14118 agent is editing `app-deploy-guidance.ts` concurrently. My change there is intentionally minimal — one `existingCloudAppLine(cloudAppId)` helper plus threading `cloudAppId` through `buildAppDeployGuidance` / `augmentTaskWithDeployGuidance`. **Whichever of #14118 / #14119 merges second should rebase** and re-thread the `cloudAppId` arg; the surface area is the two guidance builders and the `augmentTaskWithDeployGuidance` opts bag.

## Verification

- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` — clean.
- New/changed tests (all green):
  - `src/__tests__/project-binding.test.ts` — `resolveBoundProjectCloudAppId`, `bindProjectCloudApp` (write/persist/overwrite/no-op).
  - `__tests__/unit/parent-context-routes.test.ts` — cloudAppId surfaced only for bound tasks; null for unowned/unbound; top-level `project` descriptor.
  - `src/__tests__/goal-prompt.test.ts` — Workspace Cloud-app line on presence only.
  - `__tests__/unit/app-deploy-guidance.test.ts` — apps.create→apps.get/update switch (cloud + monetized custom; not non-monetized custom).
  - `src/__tests__/parent-agent-broker.test.ts` — write-back persists the created id; no write when unbound or non-ok.
- Biome clean on all touched files.

N/A: no UI surface (bridge/prompt/registry only) — no screenshots/video. No live-model behavior change — the guidance is deterministic string assembly.

Fixes #14119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
