### PR TITLE
feat(#14112): project switcher UI + per-project task filter + single-project no-chrome guard

### DIFF
--- a/packages/agent/src/api/index.ts
+++ b/packages/agent/src/api/index.ts
@@ -60,6 +60,7 @@ export * from "./parse-action-block.ts";
 export * from "./permission-request-prompt.ts";
 export * from "./permissions-routes.ts";
 export * from "./plugin-validation.ts";
+export * from "./project-routes.ts";
 export * from "./provider-switch-config.ts";
 export * from "./rate-limiter.ts";
 export * from "./registry-routes.ts";

--- a/packages/agent/src/api/project-routes.test.ts
+++ b/packages/agent/src/api/project-routes.test.ts
@@ -133,6 +133,18 @@ describe("handleProjectRoutes", () => {
     expect(helpers.error).toHaveBeenCalledWith(res, "Invalid project id", 400);
   });
 
+  it("POST activate with malformed percent-encoding returns 400", async () => {
+    const helpers = makeHelpers();
+    const activate = vi.fn();
+    const handled = await handleProjectRoutes(
+      ctx("POST", "/api/projects/%E0%A4%A/activate", helpers),
+      { activate },
+    );
+    expect(handled).toBe(true);
+    expect(activate).not.toHaveBeenCalled();
+    expect(helpers.error).toHaveBeenCalledWith(res, "Invalid project id", 400);
+  });
+
   it("surfaces a 500 when the registry read throws", async () => {
     const helpers = makeHelpers();
     const handled = await handleProjectRoutes(

--- a/packages/agent/src/api/project-routes.test.ts
+++ b/packages/agent/src/api/project-routes.test.ts
@@ -5,7 +5,11 @@
  * activate success (200 + record), unknown id (404), invalid id (400), and
  * pass-through (returns false) for unrelated paths.
  */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type http from "node:http";
+import os from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   handleProjectRoutes,
@@ -161,5 +165,56 @@ describe("handleProjectRoutes", () => {
       "Failed to read project registry",
       500,
     );
+  });
+
+  it("uses a stable legacy workspace-folder project id across list and activation", async () => {
+    const stateDir = mkdtempSync(join(os.tmpdir(), "project-routes-legacy-"));
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    process.env.ELIZA_STATE_DIR = stateDir;
+    try {
+      writeFileSync(
+        join(stateDir, "workspace-folder.json"),
+        `${JSON.stringify(
+          {
+            path: "/tmp/legacy-folder",
+            bookmark: null,
+            updatedAt: "2026-07-05T00:00:00.000Z",
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const first = makeHelpers();
+      await handleProjectRoutes(ctx("GET", "/api/projects", first));
+      const firstBody = first.json.mock.calls[0]?.[1] as ProjectListDTO;
+      const projectId = firstBody.projects[0]?.id;
+      expect(projectId).toMatch(/^legacy-[a-f0-9]{16}$/);
+      expect(firstBody.activeProjectId).toBe(projectId);
+
+      const second = makeHelpers();
+      await handleProjectRoutes(ctx("GET", "/api/projects", second));
+      const secondBody = second.json.mock.calls[0]?.[1] as ProjectListDTO;
+      expect(secondBody.projects[0]?.id).toBe(projectId);
+      expect(secondBody.activeProjectId).toBe(projectId);
+
+      const activate = makeHelpers();
+      await handleProjectRoutes(
+        ctx("POST", `/api/projects/${projectId}/activate`, activate),
+      );
+      expect(activate.error).not.toHaveBeenCalled();
+      expect(activate.json.mock.calls[0]?.[1]).toMatchObject({
+        id: projectId,
+        localPath: "/tmp/legacy-folder",
+      });
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.ELIZA_STATE_DIR;
+      } else {
+        process.env.ELIZA_STATE_DIR = previousStateDir;
+      }
+      rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/agent/src/api/project-routes.test.ts
+++ b/packages/agent/src/api/project-routes.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for the project registry HTTP routes (#13776 item 5). The handler
+ * takes injectable `readRegistry`/`activate` deps so these tests drive the
+ * request/response contract without touching a real state dir: list shape,
+ * activate success (200 + record), unknown id (404), invalid id (400), and
+ * pass-through (returns false) for unrelated paths.
+ */
+import type http from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleProjectRoutes,
+  type ProjectListDTO,
+  type ProjectSummaryDTO,
+} from "./project-routes.ts";
+
+const res = {} as http.ServerResponse;
+
+function makeHelpers() {
+  const json = vi.fn();
+  const error = vi.fn();
+  const readJsonBody = vi.fn();
+  return { json, error, readJsonBody };
+}
+
+function ctx(
+  method: string,
+  pathname: string,
+  helpers: ReturnType<typeof makeHelpers>,
+) {
+  return {
+    req: {} as http.IncomingMessage,
+    res,
+    method,
+    pathname,
+    json: helpers.json,
+    error: helpers.error,
+    readJsonBody: helpers.readJsonBody,
+  };
+}
+
+const PROJECT_A: ProjectSummaryDTO = {
+  id: "proj-a",
+  name: "Alpha",
+  localPath: "/home/dev/alpha",
+  repoUrl: "https://github.com/x/alpha",
+  defaultBranch: "main",
+  lastOpenedAt: "2026-07-05T00:00:00.000Z",
+};
+const PROJECT_B: ProjectSummaryDTO = {
+  id: "proj-b",
+  name: "Beta",
+  localPath: "/home/dev/beta",
+  lastOpenedAt: "2026-07-04T00:00:00.000Z",
+};
+
+describe("handleProjectRoutes", () => {
+  it("returns false for unrelated paths (no capture)", async () => {
+    const helpers = makeHelpers();
+    const handled = await handleProjectRoutes(
+      ctx("GET", "/api/other", helpers),
+      { readRegistry: () => ({ projects: [], activeProjectId: null }) },
+    );
+    expect(handled).toBe(false);
+    expect(helpers.json).not.toHaveBeenCalled();
+    expect(helpers.error).not.toHaveBeenCalled();
+  });
+
+  it("GET /api/projects returns the registry list + active pointer", async () => {
+    const helpers = makeHelpers();
+    const registry: ProjectListDTO = {
+      projects: [PROJECT_A, PROJECT_B],
+      activeProjectId: "proj-a",
+    };
+    const handled = await handleProjectRoutes(
+      ctx("GET", "/api/projects", helpers),
+      { readRegistry: () => registry },
+    );
+    expect(handled).toBe(true);
+    expect(helpers.json).toHaveBeenCalledWith(res, registry);
+    expect(helpers.error).not.toHaveBeenCalled();
+  });
+
+  it("GET /api/projects renders empty when the registry is absent", async () => {
+    const helpers = makeHelpers();
+    const handled = await handleProjectRoutes(
+      ctx("GET", "/api/projects", helpers),
+      { readRegistry: () => ({ projects: [], activeProjectId: null }) },
+    );
+    expect(handled).toBe(true);
+    expect(helpers.json).toHaveBeenCalledWith(res, {
+      projects: [],
+      activeProjectId: null,
+    });
+  });
+
+  it("POST /api/projects/:id/activate switches the active project", async () => {
+    const helpers = makeHelpers();
+    const activate = vi.fn((id: string) =>
+      id === "proj-b" ? PROJECT_B : null,
+    );
+    const handled = await handleProjectRoutes(
+      ctx("POST", "/api/projects/proj-b/activate", helpers),
+      { activate },
+    );
+    expect(handled).toBe(true);
+    expect(activate).toHaveBeenCalledWith("proj-b");
+    expect(helpers.json).toHaveBeenCalledWith(res, PROJECT_B);
+    expect(helpers.error).not.toHaveBeenCalled();
+  });
+
+  it("POST activate with an unknown id returns 404", async () => {
+    const helpers = makeHelpers();
+    const handled = await handleProjectRoutes(
+      ctx("POST", "/api/projects/nope/activate", helpers),
+      { activate: () => null },
+    );
+    expect(handled).toBe(true);
+    expect(helpers.error).toHaveBeenCalledWith(res, "Project not found", 404);
+    expect(helpers.json).not.toHaveBeenCalled();
+  });
+
+  it("POST activate with a slashy/invalid id returns 400", async () => {
+    const helpers = makeHelpers();
+    const activate = vi.fn();
+    // A path segment with an encoded slash decodes to an id containing "/",
+    // which must be rejected before hitting the registry.
+    const handled = await handleProjectRoutes(
+      ctx("POST", "/api/projects/a%2Fb/activate", helpers),
+      { activate },
+    );
+    expect(handled).toBe(true);
+    expect(activate).not.toHaveBeenCalled();
+    expect(helpers.error).toHaveBeenCalledWith(res, "Invalid project id", 400);
+  });
+
+  it("surfaces a 500 when the registry read throws", async () => {
+    const helpers = makeHelpers();
+    const handled = await handleProjectRoutes(
+      ctx("GET", "/api/projects", helpers),
+      {
+        readRegistry: () => {
+          throw new Error("disk gone");
+        },
+      },
+    );
+    expect(handled).toBe(true);
+    expect(helpers.error).toHaveBeenCalledWith(
+      res,
+      "Failed to read project registry",
+      500,
+    );
+  });
+});

--- a/packages/agent/src/api/project-routes.ts
+++ b/packages/agent/src/api/project-routes.ts
@@ -120,7 +120,15 @@ export async function handleProjectRoutes(
       "/api/projects/".length,
       pathname.length - ACTIVATE_SUFFIX.length,
     );
-    const id = decodeURIComponent(rawId);
+    let id: string;
+    try {
+      id = decodeURIComponent(rawId);
+    } catch {
+      // error-policy:J3 untrusted path segment — malformed percent-encoding is
+      // an invalid project id, not a route/server failure.
+      error(res, "Invalid project id", 400);
+      return true;
+    }
     if (!id || !PROJECT_ID_PATTERN.test(id)) {
       error(res, "Invalid project id", 400);
       return true;

--- a/packages/agent/src/api/project-routes.ts
+++ b/packages/agent/src/api/project-routes.ts
@@ -1,0 +1,143 @@
+/**
+ * HTTP routes for the first-class Project registry (#13776 item 5) — the
+ * read/switch surface the UI project switcher is wired to.
+ *
+ * The registry itself is the merged core store in
+ * `@elizaos/core/utils/project-registry` (a `projects.json` snapshot under the
+ * per-user state dir). This module is a thin HTTP projection over it:
+ *
+ *   GET  /api/projects            → { projects, activeProjectId }
+ *   POST /api/projects/:id/activate → mark a project active, return the record
+ *
+ * Registration/edit/delete of projects flows through the desktop folder picker
+ * write-through (owned elsewhere); this route deliberately exposes only the
+ * list + switch verbs the switcher needs so it can never mint/destroy projects
+ * behind the user's back. Absent registry ⇒ empty list + `null` active, which
+ * the switcher renders as its no-projects empty state.
+ */
+import {
+  getActiveProject,
+  logger,
+  readProjectRegistry,
+  type RouteRequestContext,
+  setActiveProject,
+} from "@elizaos/core";
+
+/** DTO for the switcher: only the fields the UI renders + switches on. Internal
+ * bookkeeping (bookmark, createdAt) is intentionally not surfaced. */
+export interface ProjectSummaryDTO {
+  id: string;
+  name: string;
+  localPath: string;
+  repoUrl?: string;
+  defaultBranch?: string;
+  lastOpenedAt: string;
+}
+
+export interface ProjectListDTO {
+  projects: ProjectSummaryDTO[];
+  activeProjectId: string | null;
+}
+
+/** Project id path segment: a uuid-ish token; reject anything with a slash or
+ * whitespace so the route can't be tricked into matching a nested path. */
+const PROJECT_ID_PATTERN = /^[\w.-]+$/;
+
+const ACTIVATE_SUFFIX = "/activate";
+
+function toSummary(project: {
+  id: string;
+  name: string;
+  localPath: string;
+  repoUrl?: string;
+  defaultBranch?: string;
+  lastOpenedAt: string;
+}): ProjectSummaryDTO {
+  return {
+    id: project.id,
+    name: project.name,
+    localPath: project.localPath,
+    repoUrl: project.repoUrl,
+    defaultBranch: project.defaultBranch,
+    lastOpenedAt: project.lastOpenedAt,
+  };
+}
+
+/**
+ * Serve the project registry read + switch endpoints. Returns `true` when the
+ * request was handled (so the caller stops the route chain), `false` otherwise.
+ *
+ * `readRegistry` / `activate` are injectable so tests drive the handler without
+ * touching a real state dir; production wiring binds the core registry.
+ */
+export async function handleProjectRoutes(
+  ctx: RouteRequestContext,
+  deps: {
+    readRegistry?: () => ProjectListDTO;
+    activate?: (id: string) => ProjectSummaryDTO | null;
+  } = {},
+): Promise<boolean> {
+  const { method, pathname, res, json, error } = ctx;
+
+  if (!pathname.startsWith("/api/projects")) return false;
+
+  const readRegistry =
+    deps.readRegistry ??
+    (() => {
+      const registry = readProjectRegistry();
+      const active = getActiveProject();
+      return {
+        projects: (registry?.projects ?? []).map(toSummary),
+        activeProjectId: active?.id ?? registry?.activeProjectId ?? null,
+      } satisfies ProjectListDTO;
+    });
+
+  const activate =
+    deps.activate ??
+    ((id: string) => {
+      const record = setActiveProject(id);
+      return record ? toSummary(record) : null;
+    });
+
+  // GET /api/projects — list + active pointer for the switcher.
+  if (method === "GET" && pathname === "/api/projects") {
+    try {
+      json(res, readRegistry());
+    } catch (err) {
+      logger.error({ error: err }, "[projects] Failed to read registry");
+      error(res, "Failed to read project registry", 500);
+    }
+    return true;
+  }
+
+  // POST /api/projects/:id/activate — switch the active project.
+  if (
+    method === "POST" &&
+    pathname.startsWith("/api/projects/") &&
+    pathname.endsWith(ACTIVATE_SUFFIX)
+  ) {
+    const rawId = pathname.slice(
+      "/api/projects/".length,
+      pathname.length - ACTIVATE_SUFFIX.length,
+    );
+    const id = decodeURIComponent(rawId);
+    if (!id || !PROJECT_ID_PATTERN.test(id)) {
+      error(res, "Invalid project id", 400);
+      return true;
+    }
+    try {
+      const activated = activate(id);
+      if (!activated) {
+        error(res, "Project not found", 404);
+        return true;
+      }
+      json(res, activated);
+    } catch (err) {
+      logger.error({ error: err }, "[projects] Failed to activate project");
+      error(res, "Failed to activate project", 500);
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/packages/agent/src/api/project-routes.ts
+++ b/packages/agent/src/api/project-routes.ts
@@ -18,8 +18,8 @@
 import {
   getActiveProject,
   logger,
-  readProjectRegistry,
   type RouteRequestContext,
+  readProjectRegistry,
   setActiveProject,
 } from "@elizaos/core";
 

--- a/packages/agent/src/api/server-lazy-routes.ts
+++ b/packages/agent/src/api/server-lazy-routes.ts
@@ -507,6 +507,15 @@ export async function handlePermissionRoutes(
   );
 }
 
+type ProjectRoutesModule = typeof import("./project-routes.ts");
+export async function handleProjectRoutes(
+  ...args: Parameters<ProjectRoutesModule["handleProjectRoutes"]>
+): ReturnType<ProjectRoutesModule["handleProjectRoutes"]> {
+  const ctx = routeContext(args);
+  if (!ctx?.pathname.startsWith("/api/projects")) return false;
+  return (await import("./project-routes.ts")).handleProjectRoutes(...args);
+}
+
 type PermissionsExtraRoutesModule =
   typeof import("./permissions-routes-extra.ts");
 export async function handlePermissionsExtraRoutes(

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -446,6 +446,7 @@ import {
   handleModelsRoutes,
   handlePermissionRoutes,
   handlePermissionsExtraRoutes,
+  handleProjectRoutes,
   handleProviderSwitchRoutes,
   handleRegistryRoutes,
   handleRelationshipsRoutes,
@@ -2718,6 +2719,24 @@ async function handleRequest(
   // ═══════════════════════════════════════════════════════════════════════
   if (
     await handleBugReportRoutes({
+      req,
+      res,
+      method,
+      pathname,
+      readJsonBody,
+      json,
+      error,
+    })
+  ) {
+    return;
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Project registry routes (#13776 item 5): list + switch the active project
+  // that backs the UI project switcher.
+  // ═══════════════════════════════════════════════════════════════════════
+  if (
+    await handleProjectRoutes({
       req,
       res,
       method,

--- a/packages/core/src/utils/project-registry.test.ts
+++ b/packages/core/src/utils/project-registry.test.ts
@@ -109,10 +109,18 @@ describe("project-registry", () => {
 		expect(reg?.projects[0]?.localPath).toBe("/tmp/legacy-folder");
 		expect(reg?.projects[0]?.bookmark).toBe("bm");
 		expect(reg?.activeProjectId).toBe(reg?.projects[0]?.id);
+		const projectId = reg?.projects[0]?.id;
+		expect(readProjectRegistry(env)?.projects[0]?.id).toBe(projectId);
+		expect(readProjectRegistry(env)?.activeProjectId).toBe(projectId);
 		expect(getActiveProject(env)?.localPath).toBe("/tmp/legacy-folder");
+		expect(getActiveProject(env)?.id).toBe(projectId);
 
 		// No projects.json was written by the read.
 		expect(() => readFileSync(projectRegistryPath(env), "utf8")).toThrow();
+
+		const activated = setActiveProject(projectId ?? "", env);
+		expect(activated?.id).toBe(projectId);
+		expect(readProjectRegistry(env)?.activeProjectId).toBe(projectId);
 	});
 
 	it("synthesized legacy project keeps a stable id across reads and across the first real upsert", () => {

--- a/packages/core/src/utils/project-registry.ts
+++ b/packages/core/src/utils/project-registry.ts
@@ -152,6 +152,10 @@ function synthesizeFromLegacyWorkspaceFolder(
 	return { version: 1, activeProjectId: project.id, projects: [project] };
 }
 
+function legacyProjectId(localPath: string): string {
+	return `legacy-${createHash("sha256").update(localPath).digest("hex").slice(0, 16)}`;
+}
+
 function basename(p: string): string {
 	const parts = p.replace(/[\\/]+$/, "").split(/[\\/]/);
 	return parts[parts.length - 1] || p;

--- a/packages/core/src/utils/project-registry.ts
+++ b/packages/core/src/utils/project-registry.ts
@@ -152,10 +152,6 @@ function synthesizeFromLegacyWorkspaceFolder(
 	return { version: 1, activeProjectId: project.id, projects: [project] };
 }
 
-function legacyProjectId(localPath: string): string {
-	return `legacy-${createHash("sha256").update(localPath).digest("hex").slice(0, 16)}`;
-}
-
 function basename(p: string): string {
 	const parts = p.replace(/[\\/]+$/, "").split(/[\\/]/);
 	return parts[parts.length - 1] || p;

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -90,6 +90,8 @@ import type {
   OrchestratorRoomRosterOverview,
   PluginInfo,
   PluginMutationResult,
+  ProjectListResponse,
+  ProjectSummary,
   ProviderModelRecord,
   RawAcpSession,
   RelationshipsActivityResponse,
@@ -1021,12 +1023,16 @@ declare module "./client-base" {
       status?: string;
       search?: string;
       limit?: number;
+      /** Restrict to tasks bound to this project (#13776 item 5). */
+      projectId?: string;
     }): Promise<CodingAgentTaskThread[]>;
     getCodingAgentTaskThread(
       threadId: string,
     ): Promise<CodingAgentTaskThreadDetail | null>;
     archiveCodingAgentTaskThread(threadId: string): Promise<boolean>;
     reopenCodingAgentTaskThread(threadId: string): Promise<boolean>;
+    listProjects(): Promise<ProjectListResponse>;
+    activateProject(projectId: string): Promise<ProjectSummary>;
     getOrchestratorStatus(): Promise<CodingAgentOrchestratorStatus | null>;
     getOrchestratorAccounts(): Promise<OrchestratorAccountOverview>;
     getOrchestratorAccountReadiness(opts?: {
@@ -3837,6 +3843,7 @@ ElizaClient.prototype.listCodingAgentTaskThreads = async function (
   if (options?.includeArchived) params.set("includeArchived", "true");
   if (options?.status) params.set("status", options.status);
   if (options?.search) params.set("search", options.search);
+  if (options?.projectId) params.set("projectId", options.projectId);
   if (typeof options?.limit === "number") {
     params.set("limit", String(options.limit));
   }
@@ -3886,6 +3893,32 @@ ElizaClient.prototype.reopenCodingAgentTaskThread = async function (
     { method: "POST" },
   );
   return true;
+};
+
+// --- Project registry (#13776 item 5): list + switch the active project ----
+// The switcher reads the merged core registry through these; an absent registry
+// (mobile/web where the surface isn't hosted) resolves to an empty list so the
+// switcher renders its no-projects empty state instead of erroring.
+
+ElizaClient.prototype.listProjects = async function (this: ElizaClient) {
+  try {
+    return await this.fetch<ProjectListResponse>("/api/projects");
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return { projects: [], activeProjectId: null };
+    }
+    throw error;
+  }
+};
+
+ElizaClient.prototype.activateProject = async function (
+  this: ElizaClient,
+  projectId,
+) {
+  return this.fetch<ProjectSummary>(
+    `/api/projects/${encodeURIComponent(projectId)}/activate`,
+    { method: "POST" },
+  );
 };
 
 // --- Orchestrator-native task operations (/api/orchestrator/*) -------------

--- a/packages/ui/src/api/client-types-cloud.ts
+++ b/packages/ui/src/api/client-types-cloud.ts
@@ -887,6 +887,23 @@ export interface CodingAgentTaskProviderPolicy {
   model?: string;
 }
 
+/** A registered project the switcher lists + activates (#13776 item 5). Mirrors
+ * the agent-side `ProjectSummaryDTO`. */
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  localPath: string;
+  repoUrl?: string;
+  defaultBranch?: string;
+  lastOpenedAt: string;
+}
+
+/** `GET /api/projects` payload: the registry list plus the active pointer. */
+export interface ProjectListResponse {
+  projects: ProjectSummary[];
+  activeProjectId: string | null;
+}
+
 export interface CodingAgentTaskThread {
   id: string;
   title: string;

--- a/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.project-switcher.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.project-switcher.test.tsx
@@ -89,15 +89,17 @@ const PROJECT_A = {
   localPath: "/home/dev/alpha",
   lastOpenedAt: "2026-07-05T00:00:00.000Z",
 };
+const PROJECT_B = {
+  id: "proj-b",
+  name: "Beta",
+  localPath: "/home/dev/beta",
+  lastOpenedAt: "2026-07-04T00:00:00.000Z",
+};
 
 describe("CodingAgentTasksPanel project switcher integration", () => {
   beforeEach(() => {
     calls.listProjects.mockReset();
     calls.listCodingAgentTaskThreads.mockReset();
-    calls.listProjects.mockResolvedValue({
-      projects: [PROJECT_A],
-      activeProjectId: "proj-a",
-    });
     calls.listCodingAgentTaskThreads.mockResolvedValue([]);
   });
 
@@ -105,7 +107,11 @@ describe("CodingAgentTasksPanel project switcher integration", () => {
     cleanup();
   });
 
-  it("uses the initially active project for the first task-thread fetch", async () => {
+  it("filters the first task-thread fetch by the active project when ≥2 projects exist", async () => {
+    calls.listProjects.mockResolvedValue({
+      projects: [PROJECT_A, PROJECT_B],
+      activeProjectId: "proj-a",
+    });
     render(<CodingAgentTasksPanel />);
 
     await waitFor(() =>
@@ -115,6 +121,26 @@ describe("CodingAgentTasksPanel project switcher integration", () => {
       includeArchived: false,
       search: undefined,
       projectId: "proj-a",
+      limit: 30,
+    });
+  });
+
+  it("does NOT filter with a single project — the list stays unfiltered like today (#14112)", async () => {
+    calls.listProjects.mockResolvedValue({
+      projects: [PROJECT_A],
+      activeProjectId: "proj-a",
+    });
+    render(<CodingAgentTasksPanel />);
+
+    await waitFor(() =>
+      expect(calls.listCodingAgentTaskThreads).toHaveBeenCalledTimes(1),
+    );
+    // projectId omitted (undefined) → server returns all threads, including
+    // project-unbound ones, identical to the pre-switcher single-project view.
+    expect(calls.listCodingAgentTaskThreads).toHaveBeenCalledWith({
+      includeArchived: false,
+      search: undefined,
+      projectId: undefined,
       limit: 30,
     });
   });

--- a/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.project-switcher.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.project-switcher.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+//
+// Project-switcher integration coverage for the legacy Tasks-page slot panel.
+// The parent must wait for the switcher to load the active project before its
+// first task-thread query, otherwise the header can show one project while the
+// list briefly contains every project's tasks.
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const calls = vi.hoisted(() => ({
+  listProjects: vi.fn(),
+  listCodingAgentTaskThreads: vi.fn(),
+}));
+
+vi.mock("@elizaos/ui/agent-surface", () => ({
+  useAgentElement: () => ({ ref: () => {}, agentProps: {} }),
+}));
+
+vi.mock("@elizaos/ui/components", () => ({
+  ViewBackButton: () => <button type="button">Back</button>,
+}));
+
+vi.mock("@elizaos/ui/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({
+    children,
+    align: _align,
+    ...rest
+  }: { children: ReactNode; align?: string } & Record<string, unknown>) => (
+    <div {...rest}>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    ...rest
+  }: {
+    children: ReactNode;
+    onSelect?: () => void;
+  } & Record<string, unknown>) => (
+    <button type="button" onClick={() => onSelect?.()} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@elizaos/ui", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+  Button: ({
+    children,
+    ...rest
+  }: { children: ReactNode } & Record<string, unknown>) => (
+    <button type="button" {...rest}>
+      {children}
+    </button>
+  ),
+  ChatEmptyStateWithRecommendations: ({
+    title,
+    testId,
+  }: {
+    title: ReactNode;
+    testId?: string;
+  }) => <div data-testid={testId}>{title}</div>,
+  client: {
+    listProjects: () => calls.listProjects(),
+    listCodingAgentTaskThreads: (options: unknown) =>
+      calls.listCodingAgentTaskThreads(options),
+  },
+  useAppSelectorShallow: () => ({ t: undefined, uiLanguage: "en" }),
+}));
+
+import { CodingAgentTasksPanel } from "./CodingAgentTasksPanel";
+
+const PROJECT_A = {
+  id: "proj-a",
+  name: "Alpha",
+  localPath: "/home/dev/alpha",
+  lastOpenedAt: "2026-07-05T00:00:00.000Z",
+};
+
+describe("CodingAgentTasksPanel project switcher integration", () => {
+  beforeEach(() => {
+    calls.listProjects.mockReset();
+    calls.listCodingAgentTaskThreads.mockReset();
+    calls.listProjects.mockResolvedValue({
+      projects: [PROJECT_A],
+      activeProjectId: "proj-a",
+    });
+    calls.listCodingAgentTaskThreads.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses the initially active project for the first task-thread fetch", async () => {
+    render(<CodingAgentTasksPanel />);
+
+    await waitFor(() =>
+      expect(calls.listCodingAgentTaskThreads).toHaveBeenCalledTimes(1),
+    );
+    expect(calls.listCodingAgentTaskThreads).toHaveBeenCalledWith({
+      includeArchived: false,
+      search: undefined,
+      projectId: "proj-a",
+      limit: 30,
+    });
+  });
+});

--- a/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx
@@ -17,6 +17,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { ProjectSwitcher } from "./ProjectSwitcher";
 import {
   BackChip,
   SparseWatermark,
@@ -609,6 +610,9 @@ export function CodingAgentTasksPanel({
     useState<CodingAgentTaskThreadDetail | null>(null);
   const [showArchived, setShowArchived] = useState(false);
   const [search, setSearch] = useState("");
+  // Active project drives the task list's projectId filter (#13776 item 5).
+  // null = show tasks across all projects (today's behavior).
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [mutating, setMutating] = useState(false);
   // The coding-agent endpoint is owned by the Node-only orchestrator plugin and
@@ -658,6 +662,7 @@ export function CodingAgentTasksPanel({
         const nextThreads = await client.listCodingAgentTaskThreads({
           includeArchived: showArchived,
           search: deferredSearch || undefined,
+          projectId: activeProjectId ?? undefined,
           limit: 30,
         });
         if (cancelled) return;
@@ -718,7 +723,7 @@ export function CodingAgentTasksPanel({
       cancelled = true;
       clearInterval(timer);
     };
-  }, [deferredSearch, showArchived, t]);
+  }, [deferredSearch, showArchived, activeProjectId, t]);
 
   useEffect(() => {
     let cancelled = false;
@@ -775,6 +780,7 @@ export function CodingAgentTasksPanel({
       const nextThreads = await client.listCodingAgentTaskThreads({
         includeArchived: showArchived,
         search: deferredSearch || undefined,
+        projectId: activeProjectId ?? undefined,
         limit: 30,
       });
       setLoadError(null);
@@ -806,6 +812,7 @@ export function CodingAgentTasksPanel({
       const nextThreads = await client.listCodingAgentTaskThreads({
         includeArchived: false,
         search: deferredSearch || undefined,
+        projectId: activeProjectId ?? undefined,
         limit: 30,
       });
       setLoadError(null);
@@ -876,20 +883,31 @@ export function CodingAgentTasksPanel({
         // second heading (#13565). The counts survive as a lightweight,
         // left-aligned meta strip that mirrors the SectionNav secondary-row
         // geometry beneath the uniform header.
-        threads.length > 0 ? (
-          <div
-            className="flex flex-wrap items-center gap-x-3 gap-y-1 px-1"
-            data-testid="task-count-strip"
-          >
-            <TaskCountChip value={threads.length} label="total" />
-            {activeCount > 0 ? (
-              <TaskCountChip value={activeCount} label="active" tone="active" />
-            ) : null}
-            {doneCount > 0 ? (
-              <TaskCountChip value={doneCount} label="done" tone="accent" />
-            ) : null}
-          </div>
-        ) : null
+        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 px-1">
+          {threads.length > 0 ? (
+            <div
+              className="flex flex-wrap items-center gap-x-3 gap-y-1"
+              data-testid="task-count-strip"
+            >
+              <TaskCountChip value={threads.length} label="total" />
+              {activeCount > 0 ? (
+                <TaskCountChip
+                  value={activeCount}
+                  label="active"
+                  tone="active"
+                />
+              ) : null}
+              {doneCount > 0 ? (
+                <TaskCountChip value={doneCount} label="done" tone="accent" />
+              ) : null}
+            </div>
+          ) : (
+            <span aria-hidden="true" />
+          )}
+          <ProjectSwitcher
+            onActiveProjectChange={(projectId) => setActiveProjectId(projectId)}
+          />
+        </div>
       ) : (
         <TaskListHeader
           icon={<ListChecks className="h-5 w-5" />}
@@ -909,7 +927,14 @@ export function CodingAgentTasksPanel({
                   <TaskCountChip value={doneCount} label="done" tone="accent" />
                 ) : null}
               </>
-            ) : null
+            ) : null}
+          }
+          action={
+            <ProjectSwitcher
+              onActiveProjectChange={(projectId) =>
+                setActiveProjectId(projectId)
+              }
+            />
           }
         />
       )}

--- a/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx
@@ -933,7 +933,7 @@ export function CodingAgentTasksPanel({
                   <TaskCountChip value={doneCount} label="done" tone="accent" />
                 ) : null}
               </>
-            ) : null}
+            ) : null
           }
           action={
             <ProjectSwitcher

--- a/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx
@@ -12,6 +12,7 @@ import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { Archive, Bot, ListChecks, Terminal } from "lucide-react";
 import {
   type ReactNode,
+  useCallback,
   useDeferredValue,
   useEffect,
   useMemo,
@@ -611,8 +612,11 @@ export function CodingAgentTasksPanel({
   const [showArchived, setShowArchived] = useState(false);
   const [search, setSearch] = useState("");
   // Active project drives the task list's projectId filter (#13776 item 5).
-  // null = show tasks across all projects (today's behavior).
-  const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
+  // undefined = switcher has not loaded the registry yet; null = show tasks
+  // across all projects (today's behavior).
+  const [activeProjectId, setActiveProjectId] = useState<
+    string | null | undefined
+  >(undefined);
   const [loading, setLoading] = useState(true);
   const [mutating, setMutating] = useState(false);
   // The coding-agent endpoint is owned by the Node-only orchestrator plugin and
@@ -650,8 +654,12 @@ export function CodingAgentTasksPanel({
       description: "Toggle showing archived tasks",
       onActivate: () => setShowArchived((value) => !value),
     });
+  const handleActiveProjectChange = useCallback((projectId: string | null) => {
+    setActiveProjectId(projectId);
+  }, []);
 
   useEffect(() => {
+    if (activeProjectId === undefined) return;
     let cancelled = false;
 
     const refreshThreads = async (silent = false) => {
@@ -904,9 +912,7 @@ export function CodingAgentTasksPanel({
           ) : (
             <span aria-hidden="true" />
           )}
-          <ProjectSwitcher
-            onActiveProjectChange={(projectId) => setActiveProjectId(projectId)}
-          />
+          <ProjectSwitcher onActiveProjectChange={handleActiveProjectChange} />
         </div>
       ) : (
         <TaskListHeader
@@ -931,9 +937,7 @@ export function CodingAgentTasksPanel({
           }
           action={
             <ProjectSwitcher
-              onActiveProjectChange={(projectId) =>
-                setActiveProjectId(projectId)
-              }
+              onActiveProjectChange={handleActiveProjectChange}
             />
           }
         />

--- a/plugins/plugin-task-coordinator/src/ProjectSwitcher.test.tsx
+++ b/plugins/plugin-task-coordinator/src/ProjectSwitcher.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+//
+// ProjectSwitcher (#13776 item 5) — drives the switcher through the REAL
+// client boundary (mocked) and the dropdown primitives (rendered inline so
+// items are always in the DOM for assertions). Proves: it renders one row per
+// registered project with the active one marked, selecting a row calls
+// client.activateProject and fires onActiveProjectChange with the new id, and
+// an empty registry self-hides (renders nothing).
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Local mirror of the client `ProjectSummary` shape — the module is fully
+ *  mocked below (no real @elizaos/ui import) so we don't drag core into the
+ *  browser test graph. */
+interface ProjectSummary {
+  id: string;
+  name: string;
+  localPath: string;
+  repoUrl?: string;
+  defaultBranch?: string;
+  lastOpenedAt: string;
+}
+
+const calls = vi.hoisted(() => ({
+  listProjects: vi.fn(),
+  activateProject: vi.fn(),
+}));
+
+vi.mock("@elizaos/ui/agent-surface", () => ({
+  useAgentElement: () => ({ ref: () => {}, agentProps: {} }),
+}));
+
+// Render the dropdown inline: trigger + content are always mounted so items are
+// queryable without simulating the Radix portal open sequence.
+vi.mock("@elizaos/ui/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({
+    children,
+    align: _align,
+    ...rest
+  }: { children: ReactNode; align?: string } & Record<string, unknown>) => (
+    <div {...rest}>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    ...rest
+  }: {
+    children: ReactNode;
+    onSelect?: () => void;
+  } & Record<string, unknown>) => (
+    <button type="button" onClick={() => onSelect?.()} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+// Full mock (no importOriginal): the switcher only touches `client`,
+// `useAppSelectorShallow`, and `Button`, so stub them and keep @elizaos/core
+// out of the browser test graph (mirrors use-orchestrator-data.test.ts).
+vi.mock("@elizaos/ui", () => ({
+  client: {
+    listProjects: () => calls.listProjects(),
+    activateProject: (id: string) => calls.activateProject(id),
+  },
+  // Selector returns a stable no-i18n object so the fallback translate runs.
+  useAppSelectorShallow: () => ({ t: undefined }),
+  Button: ({
+    children,
+    ...rest
+  }: { children: ReactNode } & Record<string, unknown>) => (
+    <button type="button" {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+import { ProjectSwitcher } from "./ProjectSwitcher";
+
+const PROJECT_A: ProjectSummary = {
+  id: "proj-a",
+  name: "Alpha",
+  localPath: "/home/dev/alpha",
+  lastOpenedAt: "2026-07-05T00:00:00.000Z",
+};
+const PROJECT_B: ProjectSummary = {
+  id: "proj-b",
+  name: "Beta",
+  localPath: "/home/dev/beta",
+  lastOpenedAt: "2026-07-04T00:00:00.000Z",
+};
+
+describe("ProjectSwitcher", () => {
+  beforeEach(() => {
+    calls.listProjects.mockReset();
+    calls.activateProject.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders a row per project with the active one marked", async () => {
+    calls.listProjects.mockResolvedValue({
+      projects: [PROJECT_A, PROJECT_B],
+      activeProjectId: "proj-a",
+    });
+    render(<ProjectSwitcher />);
+    await waitFor(() =>
+      expect(screen.getByTestId("project-switcher-menu")).toBeTruthy(),
+    );
+    expect(screen.getByTestId("project-switcher-item-proj-a")).toBeTruthy();
+    expect(screen.getByTestId("project-switcher-item-proj-b")).toBeTruthy();
+    // Active row carries the data-active marker; inactive does not.
+    expect(
+      screen
+        .getByTestId("project-switcher-item-proj-a")
+        .getAttribute("data-active"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByTestId("project-switcher-item-proj-b")
+        .getAttribute("data-active"),
+    ).toBeNull();
+  });
+
+  it("switching a project calls activateProject + fires the change callback", async () => {
+    calls.listProjects.mockResolvedValue({
+      projects: [PROJECT_A, PROJECT_B],
+      activeProjectId: "proj-a",
+    });
+    calls.activateProject.mockResolvedValue({
+      ...PROJECT_B,
+      lastOpenedAt: "2026-07-05T12:00:00.000Z",
+    });
+    const onChange = vi.fn();
+    render(<ProjectSwitcher onActiveProjectChange={onChange} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("project-switcher-item-proj-b")).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByTestId("project-switcher-item-proj-b"));
+
+    await waitFor(() =>
+      expect(calls.activateProject).toHaveBeenCalledWith("proj-b"),
+    );
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith("proj-b"));
+  });
+
+  it("self-hides when the registry has no projects", async () => {
+    calls.listProjects.mockResolvedValue({
+      projects: [],
+      activeProjectId: null,
+    });
+    const { container } = render(<ProjectSwitcher />);
+    // Give the async load a tick to settle, then assert nothing rendered.
+    await waitFor(() => expect(calls.listProjects).toHaveBeenCalled());
+    await Promise.resolve();
+    expect(screen.queryByTestId("project-switcher-menu")).toBeNull();
+    expect(screen.queryByTestId("project-switcher-trigger")).toBeNull();
+    expect(container.textContent).toBe("");
+  });
+});

--- a/plugins/plugin-task-coordinator/src/ProjectSwitcher.test.tsx
+++ b/plugins/plugin-task-coordinator/src/ProjectSwitcher.test.tsx
@@ -5,8 +5,9 @@
 // items are always in the DOM for assertions). Proves: it renders one row per
 // registered project with the active one marked, initial load reports the
 // active project to the host, selecting a row calls client.activateProject and
-// fires onActiveProjectChange with the new id, empty registry self-hides, and
-// registry/switch failures render visible error states.
+// fires onActiveProjectChange with the new id, the degenerate zero/one-project
+// case self-hides and reports null (unfiltered, exactly like pre-switcher
+// builds — #14112), and registry/switch failures render visible error states.
 
 import {
   cleanup,
@@ -183,6 +184,26 @@ describe("ProjectSwitcher", () => {
     expect(screen.queryByTestId("project-switcher-menu")).toBeNull();
     expect(screen.queryByTestId("project-switcher-trigger")).toBeNull();
     expect(container.textContent).toBe("");
+  });
+
+  it("self-hides with a single project and reports null so the list stays unfiltered (#14112)", async () => {
+    calls.listProjects.mockResolvedValue({
+      projects: [PROJECT_A],
+      activeProjectId: "proj-a",
+    });
+    const onChange = vi.fn();
+    const { container } = render(
+      <ProjectSwitcher onActiveProjectChange={onChange} />,
+    );
+    // The degenerate single-project case must look exactly like pre-switcher
+    // builds: no chrome rendered, and the host told to NOT filter (null), so
+    // project-unbound tasks stay visible.
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(null));
+    expect(screen.queryByTestId("project-switcher-menu")).toBeNull();
+    expect(screen.queryByTestId("project-switcher-trigger")).toBeNull();
+    expect(container.textContent).toBe("");
+    // Never leaks the single project's id as a filter.
+    expect(onChange).not.toHaveBeenCalledWith("proj-a");
   });
 
   it("renders a visible unavailable state when the registry load fails", async () => {

--- a/plugins/plugin-task-coordinator/src/ProjectSwitcher.test.tsx
+++ b/plugins/plugin-task-coordinator/src/ProjectSwitcher.test.tsx
@@ -3,9 +3,10 @@
 // ProjectSwitcher (#13776 item 5) — drives the switcher through the REAL
 // client boundary (mocked) and the dropdown primitives (rendered inline so
 // items are always in the DOM for assertions). Proves: it renders one row per
-// registered project with the active one marked, selecting a row calls
-// client.activateProject and fires onActiveProjectChange with the new id, and
-// an empty registry self-hides (renders nothing).
+// registered project with the active one marked, initial load reports the
+// active project to the host, selecting a row calls client.activateProject and
+// fires onActiveProjectChange with the new id, empty registry self-hides, and
+// registry/switch failures render visible error states.
 
 import {
   cleanup,
@@ -41,7 +42,9 @@ vi.mock("@elizaos/ui/agent-surface", () => ({
 // Render the dropdown inline: trigger + content are always mounted so items are
 // queryable without simulating the Radix portal open sequence.
 vi.mock("@elizaos/ui/components/ui/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenu: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
@@ -135,6 +138,16 @@ describe("ProjectSwitcher", () => {
     ).toBeNull();
   });
 
+  it("fires the initial active project after registry load", async () => {
+    calls.listProjects.mockResolvedValue({
+      projects: [PROJECT_A, PROJECT_B],
+      activeProjectId: "proj-a",
+    });
+    const onChange = vi.fn();
+    render(<ProjectSwitcher onActiveProjectChange={onChange} />);
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith("proj-a"));
+  });
+
   it("switching a project calls activateProject + fires the change callback", async () => {
     calls.listProjects.mockResolvedValue({
       projects: [PROJECT_A, PROJECT_B],
@@ -170,5 +183,41 @@ describe("ProjectSwitcher", () => {
     expect(screen.queryByTestId("project-switcher-menu")).toBeNull();
     expect(screen.queryByTestId("project-switcher-trigger")).toBeNull();
     expect(container.textContent).toBe("");
+  });
+
+  it("renders a visible unavailable state when the registry load fails", async () => {
+    calls.listProjects.mockRejectedValue(new Error("registry down"));
+    const onChange = vi.fn();
+    render(<ProjectSwitcher onActiveProjectChange={onChange} />);
+
+    await screen.findByTestId("project-switcher-error");
+
+    expect(screen.getByText("Projects unavailable")).toBeTruthy();
+    expect(
+      screen.getByTestId("project-switcher-error").getAttribute("title"),
+    ).toBe("registry down");
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("renders a visible error when activation fails", async () => {
+    calls.listProjects.mockResolvedValue({
+      projects: [PROJECT_A, PROJECT_B],
+      activeProjectId: "proj-a",
+    });
+    calls.activateProject.mockRejectedValue(new Error("switch failed"));
+    const onChange = vi.fn();
+    render(<ProjectSwitcher onActiveProjectChange={onChange} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("project-switcher-item-proj-b")).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByTestId("project-switcher-item-proj-b"));
+
+    await screen.findByTestId("project-switcher-error");
+    expect(
+      screen.getByText("Project switch failed: switch failed"),
+    ).toBeTruthy();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("proj-a");
   });
 });

--- a/plugins/plugin-task-coordinator/src/ProjectSwitcher.tsx
+++ b/plugins/plugin-task-coordinator/src/ProjectSwitcher.tsx
@@ -37,8 +37,8 @@ const fallbackTranslate = (
 ): string => String(vars?.defaultValue ?? key);
 
 export interface ProjectSwitcherProps {
-  /** Fired with the newly-active project id (or null when cleared) after a
-   *  successful switch, so the host can re-filter its task list. */
+  /** Fired with the active project id after initial registry load and after a
+   *  successful switch, so the host can re-filter its task list before it fetches. */
   onActiveProjectChange?: (projectId: string | null) => void;
 }
 
@@ -65,28 +65,33 @@ export function ProjectSwitcher({
   const t = appT ?? fallbackTranslate;
   const [state, setState] = useState<ProjectSwitcherState>(INITIAL_STATE);
 
-  const loadProjects = useCallback(async (signal: { cancelled: boolean }) => {
-    try {
-      const { projects, activeProjectId } = await client.listProjects();
-      if (signal.cancelled) return;
-      setState((prev) => ({
-        ...prev,
-        projects,
-        activeProjectId,
-        loading: false,
-        error: null,
-      }));
-    } catch (error) {
-      if (signal.cancelled) return;
-      // A registry read failure is non-fatal: the switcher simply hides. Keep
-      // the message for debugging but don't surface a red banner in a header.
-      setState((prev) => ({
-        ...prev,
-        loading: false,
-        error: error instanceof Error ? error.message : "Unknown",
-      }));
-    }
-  }, []);
+  const loadProjects = useCallback(
+    async (signal: { cancelled: boolean }) => {
+      try {
+        const { projects, activeProjectId } = await client.listProjects();
+        if (signal.cancelled) return;
+        setState((prev) => ({
+          ...prev,
+          projects,
+          activeProjectId,
+          loading: false,
+          error: null,
+        }));
+        onActiveProjectChange?.(activeProjectId);
+      } catch (error) {
+        if (signal.cancelled) return;
+        setState((prev) => ({
+          ...prev,
+          projects: [],
+          activeProjectId: null,
+          loading: false,
+          error: error instanceof Error ? error.message : "Unknown",
+        }));
+        onActiveProjectChange?.(null);
+      }
+    },
+    [onActiveProjectChange],
+  );
 
   useEffect(() => {
     const signal = { cancelled: false };
@@ -135,17 +140,44 @@ export function ProjectSwitcher({
       description: "Open the project switcher to change the active project",
     });
 
+  if (state.loading) {
+    return null;
+  }
+
+  if (state.error && state.projects.length === 0) {
+    return (
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        disabled
+        data-testid="project-switcher-error"
+        title={state.error}
+        className="inline-flex h-8 max-w-[12rem] items-center gap-1.5 rounded-xl border border-danger/40 bg-danger/10 px-2.5 text-xs font-medium text-danger"
+      >
+        <FolderGit2 className="h-3.5 w-3.5 shrink-0" />
+        <span className="truncate">
+          {t("projectswitcher.unavailable", {
+            defaultValue: "Projects unavailable",
+          })}
+        </span>
+      </Button>
+    );
+  }
+
   // Hide entirely when there are no registered projects — a switcher with
   // nothing to switch to is dead chrome (mobile/web, or a fresh install).
-  if (state.loading || state.projects.length === 0) {
+  if (state.projects.length === 0) {
     return null;
   }
 
   const active =
     state.projects.find((p) => p.id === state.activeProjectId) ?? null;
   const activeName =
-    active?.name ??
-    t("projectswitcher.none", { defaultValue: "All projects" });
+    active?.name ?? t("projectswitcher.none", { defaultValue: "All projects" });
+  const switchFailedLabel = t("projectswitcher.switchFailed", {
+    defaultValue: "Project switch failed",
+  });
 
   return (
     <DropdownMenu>
@@ -199,6 +231,15 @@ export function ProjectSwitcher({
             </DropdownMenuItem>
           );
         })}
+        {state.error ? (
+          <div
+            className="px-2 py-1.5 text-2xs text-danger"
+            data-testid="project-switcher-error"
+            role="alert"
+          >
+            {switchFailedLabel}: {state.error}
+          </div>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/plugins/plugin-task-coordinator/src/ProjectSwitcher.tsx
+++ b/plugins/plugin-task-coordinator/src/ProjectSwitcher.tsx
@@ -10,8 +10,14 @@
  * neutral "All projects" label when none is active), matching the task panel's
  * header chrome — design tokens only (no raw hex, no purple/blue, no
  * backdrop-blur), a single lucide folder glyph, and a check mark on the active
- * row. When the registry is empty (mobile/web or a fresh install) the switcher
- * self-hides so it never renders a dead control.
+ * row.
+ *
+ * The switcher self-hides in the degenerate case of zero or one project
+ * (#14112): most users only ever open a single workspace folder, and a control
+ * with nothing to switch *between* is dead chrome — the single-project panel
+ * header must stay identical to pre-switcher builds. It appears only once a
+ * second project is registered. In the hidden case it reports a `null`
+ * projectId to the host so the task list stays unfiltered exactly like today.
  */
 import {
   Button,
@@ -77,7 +83,11 @@ export function ProjectSwitcher({
           loading: false,
           error: null,
         }));
-        onActiveProjectChange?.(activeProjectId);
+        // With 0 or 1 project the switcher is hidden (see the render guard), so
+        // the task list must behave exactly like today: unfiltered, including
+        // project-unbound tasks. Only report a filtering projectId once there
+        // are ≥2 projects to switch between (#14112).
+        onActiveProjectChange?.(projects.length > 1 ? activeProjectId : null);
       } catch (error) {
         if (signal.cancelled) return;
         setState((prev) => ({
@@ -165,9 +175,13 @@ export function ProjectSwitcher({
     );
   }
 
-  // Hide entirely when there are no registered projects — a switcher with
-  // nothing to switch to is dead chrome (mobile/web, or a fresh install).
-  if (state.projects.length === 0) {
+  // Hide entirely in the degenerate case of zero or one registered project: a
+  // switcher with nothing to switch *between* is dead chrome. This keeps the
+  // single-project experience byte-identical to pre-switcher builds (#14112) —
+  // most users only ever open one workspace folder, so the panel header must
+  // stay unchanged for them; the switcher only earns its place once a second
+  // project exists to switch to (mobile/web with no registry also lands here).
+  if (state.projects.length <= 1) {
     return null;
   }
 

--- a/plugins/plugin-task-coordinator/src/ProjectSwitcher.tsx
+++ b/plugins/plugin-task-coordinator/src/ProjectSwitcher.tsx
@@ -1,0 +1,205 @@
+/**
+ * ProjectSwitcher — the per-project switcher affordance (#13776 item 5).
+ *
+ * Reads the merged core project registry through `client.listProjects()` and
+ * lets the user switch the active project via `client.activateProject(id)`.
+ * The active project drives the task list's `projectId` filter (the caller
+ * passes `onActiveProjectChange` and threads the id into its task fetch).
+ *
+ * Design: a compact dropdown trigger showing the active project's name (or a
+ * neutral "All projects" label when none is active), matching the task panel's
+ * header chrome — design tokens only (no raw hex, no purple/blue, no
+ * backdrop-blur), a single lucide folder glyph, and a check mark on the active
+ * row. When the registry is empty (mobile/web or a fresh install) the switcher
+ * self-hides so it never renders a dead control.
+ */
+import {
+  Button,
+  client,
+  type ProjectSummary,
+  useAppSelectorShallow,
+} from "@elizaos/ui";
+import { useAgentElement } from "@elizaos/ui/agent-surface";
+// Direct subpath (mirrors the sibling panels): the browser barrel doesn't
+// reliably re-export the newer dropdown-menu primitives.
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@elizaos/ui/components/ui/dropdown-menu";
+import { Check, FolderGit2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+const fallbackTranslate = (
+  key: string,
+  vars?: Record<string, unknown>,
+): string => String(vars?.defaultValue ?? key);
+
+export interface ProjectSwitcherProps {
+  /** Fired with the newly-active project id (or null when cleared) after a
+   *  successful switch, so the host can re-filter its task list. */
+  onActiveProjectChange?: (projectId: string | null) => void;
+}
+
+interface ProjectSwitcherState {
+  projects: ProjectSummary[];
+  activeProjectId: string | null;
+  loading: boolean;
+  switching: boolean;
+  error: string | null;
+}
+
+const INITIAL_STATE: ProjectSwitcherState = {
+  projects: [],
+  activeProjectId: null,
+  loading: true,
+  switching: false,
+  error: null,
+};
+
+export function ProjectSwitcher({
+  onActiveProjectChange,
+}: ProjectSwitcherProps) {
+  const { t: appT } = useAppSelectorShallow((s) => ({ t: s.t }));
+  const t = appT ?? fallbackTranslate;
+  const [state, setState] = useState<ProjectSwitcherState>(INITIAL_STATE);
+
+  const loadProjects = useCallback(async (signal: { cancelled: boolean }) => {
+    try {
+      const { projects, activeProjectId } = await client.listProjects();
+      if (signal.cancelled) return;
+      setState((prev) => ({
+        ...prev,
+        projects,
+        activeProjectId,
+        loading: false,
+        error: null,
+      }));
+    } catch (error) {
+      if (signal.cancelled) return;
+      // A registry read failure is non-fatal: the switcher simply hides. Keep
+      // the message for debugging but don't surface a red banner in a header.
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: error instanceof Error ? error.message : "Unknown",
+      }));
+    }
+  }, []);
+
+  useEffect(() => {
+    const signal = { cancelled: false };
+    void loadProjects(signal);
+    return () => {
+      signal.cancelled = true;
+    };
+  }, [loadProjects]);
+
+  const handleSelect = useCallback(
+    async (projectId: string) => {
+      if (projectId === state.activeProjectId || state.switching) return;
+      setState((prev) => ({ ...prev, switching: true, error: null }));
+      try {
+        const activated = await client.activateProject(projectId);
+        setState((prev) => ({
+          ...prev,
+          activeProjectId: activated.id,
+          // Reflect the freshly-stamped lastOpenedAt in the list too.
+          projects: prev.projects.map((p) =>
+            p.id === activated.id ? { ...p, ...activated } : p,
+          ),
+          switching: false,
+        }));
+        onActiveProjectChange?.(activated.id);
+      } catch (error) {
+        setState((prev) => ({
+          ...prev,
+          switching: false,
+          error: error instanceof Error ? error.message : "Unknown",
+        }));
+      }
+    },
+    [state.activeProjectId, state.switching, onActiveProjectChange],
+  );
+
+  const triggerLabel = t("projectswitcher.trigger", {
+    defaultValue: "Switch project",
+  });
+  const { ref: triggerRef, agentProps: triggerAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "project-switcher-trigger",
+      role: "button",
+      label: triggerLabel,
+      group: "project-switcher",
+      description: "Open the project switcher to change the active project",
+    });
+
+  // Hide entirely when there are no registered projects — a switcher with
+  // nothing to switch to is dead chrome (mobile/web, or a fresh install).
+  if (state.loading || state.projects.length === 0) {
+    return null;
+  }
+
+  const active =
+    state.projects.find((p) => p.id === state.activeProjectId) ?? null;
+  const activeName =
+    active?.name ??
+    t("projectswitcher.none", { defaultValue: "All projects" });
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          ref={triggerRef}
+          type="button"
+          variant="secondary"
+          size="sm"
+          disabled={state.switching}
+          data-testid="project-switcher-trigger"
+          aria-label={triggerLabel}
+          className="inline-flex h-8 max-w-[12rem] items-center gap-1.5 rounded-xl border border-border/50 bg-bg-accent/30 px-2.5 text-xs font-medium text-txt hover:text-txt-strong"
+          {...triggerAgentProps}
+        >
+          <FolderGit2 className="h-3.5 w-3.5 shrink-0 text-accent" />
+          <span className="truncate">{activeName}</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        className="min-w-[13rem]"
+        data-testid="project-switcher-menu"
+      >
+        {state.projects.map((project) => {
+          const isActive = project.id === state.activeProjectId;
+          return (
+            <DropdownMenuItem
+              key={project.id}
+              onSelect={() => {
+                void handleSelect(project.id);
+              }}
+              data-testid={`project-switcher-item-${project.id}`}
+              data-active={isActive ? "true" : undefined}
+              className="flex items-start gap-2"
+            >
+              <Check
+                className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${
+                  isActive ? "text-accent" : "text-transparent"
+                }`}
+                aria-hidden="true"
+              />
+              <span className="flex min-w-0 flex-col">
+                <span className="truncate text-xs font-medium text-txt">
+                  {project.name}
+                </span>
+                <span className="truncate text-2xs text-muted">
+                  {project.localPath}
+                </span>
+              </span>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/index.ts
+++ b/plugins/plugin-task-coordinator/src/index.ts
@@ -326,6 +326,7 @@ const taskCoordinatorPlugin: Plugin = {
 };
 
 export default taskCoordinatorPlugin;
+export { ProjectSwitcher } from "./ProjectSwitcher";
 export {
   ORCHESTRATOR_STATUS_COMMAND_ACTION,
   ORCHESTRATOR_STATUS_COMMAND_KEY,

--- a/plugins/plugin-task-coordinator/src/index.ts
+++ b/plugins/plugin-task-coordinator/src/index.ts
@@ -326,7 +326,6 @@ const taskCoordinatorPlugin: Plugin = {
 };
 
 export default taskCoordinatorPlugin;
-export { ProjectSwitcher } from "./ProjectSwitcher";
 export {
   ORCHESTRATOR_STATUS_COMMAND_ACTION,
   ORCHESTRATOR_STATUS_COMMAND_KEY,
@@ -334,3 +333,4 @@ export {
   orchestratorStatusCommandAction,
   registerOrchestratorCommands,
 } from "./orchestrator-command";
+export { ProjectSwitcher } from "./ProjectSwitcher";


### PR DESCRIPTION
Fixes #14112. The UI slice for the first-class Project entity (epic #13766 / #13776): a per-project switcher in the Tasks panel, per-project task grouping via the `?projectId=` filter, and — critically — a **degenerate single-project case that looks exactly like today**.

## Relationship to #14080

This PR builds directly on @sol-orch's #14080 (all of its commits are included here), then closes the one gap #14112 explicitly calls out that #14080 left open: the single-project case must render **no new chrome**. #14080's switcher self-hid only on an *empty* registry, so a user with one workspace folder saw a new dropdown. This PR makes it hide on `projects.length <= 1` and report `null` (unfiltered) to the host in that case, so the single-project Tasks panel is byte-identical to pre-switcher builds. It supersedes #14080; #14080 can be closed in favor of this.

## What this delivers (the full #14112 scope)

**(1) Project list + active-project switcher** — `ProjectSwitcher` in the `CodingAgentTasksPanel` header. Compact dropdown, design tokens only (no raw hex, no blue/purple, no backdrop-blur), a single lucide `FolderGit2` glyph + `Check` on the active row, neutral-with-opacity hover. It evolves the existing workspace-folder pick flow (every desktop folder pick already `upsertProject` + `setActiveProject` in `desktop.ts`) rather than adding a parallel surface.

**(2) Per-project task filter (commandment-10 gap closed)** — `listCodingAgentTaskThreads` gains a `projectId` param wired to the previously-orphaned `GET /api/orchestrator/tasks?projectId=` (from #13851). Selecting a project re-filters the task list; the panel waits for the switcher's registry load before its first fetch so the header and list never disagree.

**(3) Degenerate single-project case = no new chrome (#14112 core requirement)** — with 0 or 1 registered project the switcher renders nothing and reports `null`, so the list stays unfiltered (project-unbound tasks stay visible) — identical to today. The switcher earns its place only once a second project exists to switch between. Mobile/web (no registry hosted) also lands here and self-hides.

**Minimal HTTP surface** — `packages/agent/src/api/project-routes.ts` is a thin read/switch projection over `@elizaos/core` `project-registry`:
- `GET /api/projects` → `{ projects, activeProjectId }`
- `POST /api/projects/:id/activate` → switch active, return the record
- Read + switch verbs only (no register/delete — the switcher can never mint/destroy projects behind the user's back). Absent registry ⇒ empty list + `null` active. Path-id validated (`/^[\w.-]+$/`), malformed percent-encoding → 400 (`error-policy:J3`), read/activate throw → 500.

Capacity/admission (`GET /api/orchestrator/capacity`, `admission.position`) — the *other* orphan #14112 lists — is **out of scope here**; it is a separate orchestrator-workbench surface, not part of the project switcher, and is tracked independently.

## Tests (real, drive the actual path)

- `plugin-task-coordinator/src/ProjectSwitcher.test.tsx` — **7 pass**: row-per-project with active marker, initial active reported to host, switch calls `activateProject` + fires change, **single-project self-hides and reports `null` (#14112)**, empty self-hides, registry-load failure + switch failure render visible error states. Drives the real client boundary (mocked) + dropdown primitives rendered inline.
- `plugin-task-coordinator/src/CodingAgentTasksPanel.project-switcher.test.tsx` — **2 pass**: ≥2 projects → first fetch filtered by active id; **1 project → first fetch unfiltered (`projectId: undefined`), like today (#14112)**.
- `packages/agent/src/api/project-routes.test.ts` — list shape, activate 200, unknown id 404, slashy/encoded-slash id 400, absent-registry empty, read-throw 500, stable legacy id.

```
bun run --cwd plugins/plugin-task-coordinator test src/ProjectSwitcher.test.tsx src/CodingAgentTasksPanel.project-switcher.test.tsx --run   → 9/9 pass
```

## Verification notes (worktree/CI caveats — read before re-running locally)

This ran in a shared-`node_modules` worktree where `@elizaos/core` and `@elizaos/ui` resolve to the **parent repo's stale compiled `dist/`**, which predates the develop changes that added `legacyProjectId` (deterministic legacy id), `ProjectSummary`, `listProjects`/`activateProject`, and the `projectId` param. Consequences, all environmental — none are defects in this diff, and all resolve on a fresh build (CI):
- `packages/agent` `project-routes.test.ts` "stable legacy id" fails locally: the stale dist's `synthesizeFromLegacyWorkspaceFolder` still uses `randomUUID()` (two reads → two different ids), so the deterministic-id assertion can't hold against it. The current source (this branch and develop) uses `legacy-<sha256-16>`; verified by importing the worktree source directly.
- `plugin-task-coordinator` typecheck reports `ProjectSummary` / `listProjects` / `activateProject` / `projectId` "missing" — they exist in this branch's `packages/ui` source (confirmed) but not in the parent's stale `packages/ui/dist`. The `surface`/`ViewDeclaration` typecheck errors in `index.ts` are pre-existing and unrelated.

**Visual audit (`bun run --cwd packages/app audit:app`): N/A** — the switcher only renders with ≥2 registered projects, which needs a live desktop runtime that has picked two folders; the audit harness can't reach that state in this headless worktree, and `@elizaos/ui` would resolve to the stale parent dist regardless. Substituted component-level rendered evidence via the vitest/jsdom render lane (9 passing tests covering render + switch + single-project-hide + empty-hide + error states). Rendered before/after with two real projects is a follow-up human/UI verify on a built desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
