### PR TITLE
fix(app-core): repair runtime-mode.disk test import

### DIFF
--- a/packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts
+++ b/packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts
@@ -8,8 +8,8 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { getRuntimeModeSnapshot } from "@elizaos/agent/api/runtime-mode/runtime-mode";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getRuntimeModeSnapshot } from "@elizaos/agent";
 
 const ENV_KEYS = [
   "ELIZA_STATE_DIR",


### PR DESCRIPTION
Fixes a develop-tip collection failure in `packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts` after runtime-mode moved into `@elizaos/agent`.

This uses the narrow `@elizaos/agent/api/runtime-mode/runtime-mode` subpath instead of the agent root barrel, so the app-core focused Vitest run does not pull the full optional-plugin import graph.

Validation run locally:

- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/app-core test -- src/runtime/mode/runtime-mode.disk.test.ts` — 1 file, 4 tests passed
- `bunx @biomejs/biome check packages/app-core/src/runtime/mode/runtime-mode.disk.test.ts`
- `git diff --check origin/develop...HEAD`