### PR TITLE
fix(#14110): dedupe child-trajectory ingest against already-recorded artifacts

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/child-trajectory-ingest.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/child-trajectory-ingest.test.ts
@@ -213,4 +213,147 @@ describe("ingestChildTrajectories", () => {
     const doc = await store.getTask(taskId);
     expect(doc?.artifacts ?? []).toEqual([]);
   });
+
+  // #14110: the trajectory dir is per-TASK but `task_complete` fires per
+  // SESSION-completion. Re-completions and respawned sessions re-scan the same
+  // files; without dedupe each pass duplicates artifacts and mis-stamps
+  // correlation.
+  function ingest(svc: OrchestratorTaskService, t: string, s: string) {
+    return (
+      svc as unknown as {
+        ingestChildTrajectories: (t: string, s: string) => Promise<string[]>;
+      }
+    ).ingestChildTrajectories(t, s);
+  }
+
+  async function writeTrajectoryFile(
+    taskId: string,
+    name: string,
+    traceId: string,
+  ): Promise<void> {
+    const dir = join(
+      stateDir,
+      "orchestrator",
+      "child-trajectories",
+      taskId,
+      "child-agent",
+    );
+    await mkdir(dir, { recursive: true });
+    writeFileSync(join(dir, name), JSON.stringify({ traceId }));
+  }
+
+  it("does not duplicate artifacts or ids when the same session re-completes", async () => {
+    const store = new InMemoryTaskStore();
+    const { taskId, sessionId } = await seedTaskWithSession(store, {
+      traceId: "trace-parent",
+    });
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+    await writeTrajectoryFile(taskId, "tj-aaa.json", "trace-parent");
+    await writeTrajectoryFile(taskId, "tj-bbb.json", "trace-parent");
+
+    const first = await ingest(svc, taskId, sessionId);
+    expect(first.sort()).toEqual(["tj-aaa", "tj-bbb"]);
+
+    // Second `task_complete` for the SAME session (follow-up prompt re-completes)
+    // must re-scan and skip — REVERSION: the pre-fix code re-attached both files
+    // as brand-new artifacts with fresh ids.
+    const second = await ingest(svc, taskId, sessionId);
+    expect(second).toEqual([]);
+
+    const doc = await store.getTask(taskId);
+    const artifacts = doc?.artifacts ?? [];
+    expect(artifacts.length).toBe(2);
+    // Exactly one artifact per file path — no duplicate rows.
+    expect(new Set(artifacts.map((a) => a.path)).size).toBe(2);
+
+    const updated = (await store.findSession(sessionId))?.session;
+    // No duplicate ids accumulated on the session.
+    expect((updated?.childTrajectoryIds ?? []).sort()).toEqual([
+      "tj-aaa",
+      "tj-bbb",
+    ]);
+  });
+
+  it("a respawned session does not re-ingest session A's files or overwrite A's correlation", async () => {
+    const store = new InMemoryTaskStore();
+    const { taskId, sessionId: sessA } = await seedTaskWithSession(store, {
+      traceId: "trace-A",
+      parentTrajectoryStepId: "step-A",
+    });
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+    await writeTrajectoryFile(taskId, "tj-from-A.json", "trace-A");
+
+    const fromA = await ingest(svc, taskId, sessA);
+    expect(fromA).toEqual(["tj-from-A"]);
+
+    // A respawned session B on the same task ingests. Session A's file is still
+    // on disk (per-task dir) — B must NOT re-attach it under B's correlation.
+    const now = new Date().toISOString();
+    const sessB = "sess-B";
+    await store.addSession({
+      id: "row-B",
+      taskId,
+      sessionId: sessB,
+      framework: "elizaos",
+      label: "worker-B",
+      originalTask: "do the thing",
+      workdir: "/tmp/wd",
+      status: "completed",
+      decisionCount: 0,
+      autoResolvedCount: 0,
+      registeredAt: Date.now(),
+      lastActivityAt: Date.now(),
+      idleCheckCount: 0,
+      taskDelivered: true,
+      lastSeenDecisionIndex: 0,
+      spawnedAt: Date.now(),
+      retryCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      cacheTokens: 0,
+      costUsd: 0,
+      usageState: "unavailable",
+      traceId: "trace-B",
+      parentTrajectoryStepId: "step-B",
+      metadata: {},
+      createdAt: now,
+      updatedAt: now,
+    });
+    // Session B also records a genuinely-new file.
+    await writeTrajectoryFile(taskId, "tj-from-B.json", "trace-B");
+
+    const fromB = await ingest(svc, taskId, sessB);
+    // Only B's own new file is ingested; A's file is skipped.
+    expect(fromB).toEqual(["tj-from-B"]);
+
+    const doc = await store.getTask(taskId);
+    const artifacts = doc?.artifacts ?? [];
+    expect(artifacts.length).toBe(2);
+
+    const byId = (id: string) =>
+      artifacts.find(
+        (a) =>
+          (a.metadata.correlation as { childTrajectoryId?: string })
+            ?.childTrajectoryId === id,
+      );
+    // A's file keeps A's correlation (session + traceId), NOT re-stamped to B.
+    const aCorr = byId("tj-from-A")?.metadata.correlation as {
+      traceId?: string;
+      sessionId?: string;
+      parentStepId?: string;
+    };
+    expect(aCorr.traceId).toBe("trace-A");
+    expect(aCorr.sessionId).toBe(sessA);
+    expect(aCorr.parentStepId).toBe("step-A");
+    // B's file carries B's correlation.
+    const bCorr = byId("tj-from-B")?.metadata.correlation as {
+      traceId?: string;
+      sessionId?: string;
+      parentStepId?: string;
+    };
+    expect(bCorr.traceId).toBe("trace-B");
+    expect(bCorr.sessionId).toBe(sessB);
+    expect(bCorr.parentStepId).toBe("step-B");
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -1241,10 +1241,30 @@ export class OrchestratorTaskService extends Service {
     }
     if (files.length === 0) return [];
 
+    // Dedupe against files this task already recorded (#14110). The trajectory
+    // dir is per-TASK but `task_complete` fires per-SESSION-completion, so a
+    // re-completion of the same session or a respawned second session re-scans
+    // the same files. Without this guard each pass re-attaches them as brand-new
+    // artifacts (fresh `randomUUID()` ids) and re-stamps the *current* session's
+    // correlation onto files an *earlier* session actually recorded — corrupting
+    // the file↔DB trace join #13871 exists to provide. The already-recorded
+    // artifact paths are the persistent dedupe key: they survive restart with
+    // the task document, and skipping them preserves the original ingesting
+    // session's correlation (we never touch an already-attached artifact).
+    const existingArtifactPaths = new Set(
+      ((await this.store.getTask(taskId))?.artifacts ?? [])
+        .filter((a) => a.artifactType === "trajectory" && a.path)
+        .map((a) => a.path as string),
+    );
+    const freshFiles = files.filter((path) => !existingArtifactPaths.has(path));
+    if (freshFiles.length === 0) return [];
+
     // Newest first, capped so a runaway child can't flood the task doc; the
-    // store's MAX_ARTIFACTS also clamps.
+    // store's MAX_ARTIFACTS also clamps. Cap applies to genuinely-new files only
+    // so a large already-ingested backlog can't starve fresh trajectories out of
+    // the window.
     const withMtime = await Promise.all(
-      files.map(async (path) => ({
+      freshFiles.map(async (path) => ({
         path,
         mtimeMs: (await stat(path)).mtimeMs,
       })),
@@ -1280,10 +1300,16 @@ export class OrchestratorTaskService extends Service {
     }
 
     if (ingested.length > 0) {
+      // Union-dedupe the id list too: even though path-dedupe above prevents
+      // re-ingesting a file, two distinct files sharing a `<trajectoryId>.json`
+      // basename (or a legacy pre-fix duplicate row) must not append a repeat id.
       const existing = session?.childTrajectoryIds ?? [];
-      await this.store.updateSession(sessionId, {
-        childTrajectoryIds: [...existing, ...ingested],
-      });
+      const merged = [...new Set([...existing, ...ingested])];
+      if (merged.length !== existing.length) {
+        await this.store.updateSession(sessionId, {
+          childTrajectoryIds: merged,
+        });
+      }
     }
     return ingested;
   }


### PR DESCRIPTION
## Problem (#14110, #13871 WS5 audit)

`ingestChildTrajectories` (`orchestrator-task-service.ts:1223`, invoked from the `task_complete` bridge) rescanned the **per-task** child-trajectory dir on every **per-session** `task_complete` with **no dedupe**:

1. A follow-up prompt re-completing the same session re-attached every file as a brand-new artifact (fresh `randomUUID()` id) and appended duplicate `childTrajectoryIds`.
2. A respawned second session re-ingested session A's files and stamped **session B's** correlation (`sessionId`/`parentStepId`/`traceId`) onto trajectories session A actually recorded — corrupting the file↔DB trace join #13871 exists to provide.

## Fix

Dedupe against the task's **already-recorded trajectory artifact paths** (read via `store.getTask(taskId)`) before ingest, skipping files already attached:

- The recorded-artifact set is the **persistent** dedupe key — it survives restart with the task document (no new schema field).
- Skipping already-attached files **preserves the original ingesting session's correlation** (we never touch an already-attached artifact), so session B can't overwrite session A's trace stamp.
- `MAX_CHILD_TRAJECTORY_ARTIFACTS` now caps **genuinely-new** files only, so a large already-ingested backlog can't starve fresh trajectories out of the window.
- `childTrajectoryIds` append is union-deduped defensively.

## Tests

`child-trajectory-ingest.test.ts` — 2 new regression cases, **reversion-proven** (both FAIL on pristine source, verified via patch-out/re-apply):

- same-session re-completion attaches **no duplicate** artifacts/ids
- a respawned session B ingests **only its own new file** and leaves session A's file + correlation (traceId/sessionId/parentStepId) **untouched**

Existing ingest + env-stamp cases green (env-stamp pair skips in the isolated worktree per the file's own stale-dist guard). **4 passed / 2 skipped.**

## Verification

- targeted vitest green (4 passed, 2 skipped)
- reversion-proof: both new tests fail on pristine develop
- `tsgo --noEmit`: **0 errors in touched files** (post-regen `generate-keywords.mjs`, EXIT:0)
- biome clean on both files
- error-policy-ratchet: no new fallback-slop

Distinct from #14092 (traceId join key, core/message.ts, merged) and the never-GC'd trajectory dir (#14109, filed separately).

-- [sol-orch]