### PR TITLE
fix(ui): finish #13914 sweep — stale Instances skeleton + last dead PageHeaderProvider

### DIFF
--- a/packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx
+++ b/packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx
@@ -226,12 +226,15 @@ export function AppsSkeleton() {
 export function ContainersSkeleton() {
   return (
     <DashboardTableSkeleton
+      // Columns must mirror the real Agents table header (eliza-agents-table)
+      // so the loading skeleton doesn't flash stale labels ("Instances",
+      // "Port") before the live headers ("Agent", "Runtime", "Web UI") paint.
       columns={[
-        { key: "name", label: "Name", skeletonClassName: "w-32" },
+        { key: "agent", label: "Agent", skeletonClassName: "w-32" },
         { key: "status", label: "Status", skeletonClassName: "h-6 w-20" },
-        { key: "port", label: "Port", skeletonClassName: "w-12" },
-        { key: "instances", label: "Instances", skeletonClassName: "w-8" },
-        { key: "deployed", label: "Deployed", skeletonClassName: "w-24" },
+        { key: "runtime", label: "Runtime", skeletonClassName: "w-20" },
+        { key: "webui", label: "Web UI", skeletonClassName: "w-16" },
+        { key: "created", label: "Created", skeletonClassName: "w-24" },
         {
           key: "actions",
           label: "Actions",

--- a/packages/ui/src/cloud/mcps/McpsRoute.tsx
+++ b/packages/ui/src/cloud/mcps/McpsRoute.tsx
@@ -4,13 +4,14 @@
  * Gates on the Steward session (the registry CRUD routes require auth), then
  * renders {@link McpsView}. The same {@link McpsSurface} backs both the
  * standalone route and the Settings-section wrapper, so they stay identical.
- * `McpsView` sets the page header, so each entry point supplies a
- * `PageHeaderProvider`: the standalone route wraps one here; the settings
- * section gets it from `CloudSettingsSectionShell`.
+ * `McpsView` sets the page header via `useSetPageHeader`. The standalone route
+ * is in the `dashboard` group, so ConsoleShell already supplies the header
+ * provider — a local one here would SHADOW it, leaving the top-bar title empty
+ * (#13914). The settings section gets its provider from
+ * `CloudSettingsSectionShell`.
  */
 
 import { DashboardLoadingState } from "../../cloud-ui/components/dashboard/route-placeholders";
-import { PageHeaderProvider } from "../../cloud-ui/components/layout";
 import { useSessionAuth } from "../lib/use-session-auth";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { McpsView } from "./McpsView";
@@ -37,9 +38,5 @@ export function McpsSurface() {
 
 /** Default export consumed by the cloud-route registry. */
 export default function McpsRoute() {
-  return (
-    <PageHeaderProvider>
-      <McpsSurface />
-    </PageHeaderProvider>
-  );
+  return <McpsSurface />;
 }


### PR DESCRIPTION
Two residuals the **ultracode adversarial verification** surfaced on #13914 (the core rename/provider fix was correct; the sweep missed these two):

1. **Stale loading skeleton** — `ContainersSkeleton` (the agents-table skeleton) declared `Name / Status / Port / Instances / Deployed / Actions`, but the real Agents table is `Agent / Status / Runtime / Web UI / Created / Actions`. It flashed 'Instances' + wrong headers on every `/dashboard/agents` load until the live headers painted. Columns realigned to the real table.
2. **Last dead PageHeaderProvider** — `McpsRoute` mounted a local provider that shadows ConsoleShell's (the standalone route is `group: dashboard` → ConsoleShell already supplies one), so `/dashboard/mcps` had no top-bar title. Same bug class #13914 fixed elsewhere. Removed; the settings-section entry (different component) keeps its `CloudSettingsSectionShell` provider.

Typecheck clean, biome clean. Found by the 9-agent verify sweep, not a green check. [qa-agent]