### PR TITLE
fix(orchestrator): reclaim child-trajectory state dir on task delete (#14109)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/child-trajectory-ingest.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/child-trajectory-ingest.test.ts
@@ -6,7 +6,7 @@
  * trajectory-context; no mock stands in for the code under test.
  */
 
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -212,5 +212,53 @@ describe("ingestChildTrajectories", () => {
     expect(ingested).toEqual([]);
     const doc = await store.getTask(taskId);
     expect(doc?.artifacts ?? []).toEqual([]);
+  });
+});
+
+describe("deleteTask reclaims child trajectories (#14109)", () => {
+  it("removes the per-task child-trajectory dir when the task is deleted", async () => {
+    const store = new InMemoryTaskStore();
+    const { taskId, sessionId } = await seedTaskWithSession(store, {
+      traceId: "trace-parent",
+    });
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+
+    const taskDir = join(
+      stateDir,
+      "orchestrator",
+      "child-trajectories",
+      taskId,
+    );
+    const agentDir = join(taskDir, "child-agent");
+    await mkdir(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, "tj-aaa.json"), JSON.stringify({ x: 1 }));
+
+    await (
+      svc as unknown as {
+        ingestChildTrajectories: (t: string, s: string) => Promise<string[]>;
+      }
+    ).ingestChildTrajectories(taskId, sessionId);
+    expect(existsSync(taskDir)).toBe(true);
+
+    const deleted = await svc.deleteTask(taskId);
+    expect(deleted).toBe(true);
+    // The dir and its JSON are gone — no state-dir leak survives task deletion.
+    expect(existsSync(taskDir)).toBe(false);
+  });
+
+  it("does not throw when a deleted task never recorded any trajectories", async () => {
+    const store = new InMemoryTaskStore();
+    const { taskId } = await seedTaskWithSession(store, {});
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+    const taskDir = join(
+      stateDir,
+      "orchestrator",
+      "child-trajectories",
+      taskId,
+    );
+    // No dir was ever written (gate off / non-eliza backend). Force-recursive
+    // rm treats the missing dir as a no-op — deletion still succeeds.
+    expect(existsSync(taskDir)).toBe(false);
+    await expect(svc.deleteTask(taskId)).resolves.toBe(true);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -23,6 +23,7 @@ import {
   mkdir,
   readdir,
   readFile,
+  rm,
   stat,
   writeFile,
 } from "node:fs/promises";
@@ -1173,7 +1174,12 @@ export class OrchestratorTaskService extends Service {
   /**
    * Per-task directory a spawned sub-agent's file recorder writes its own
    * trajectories into (#13775), scanned on task_complete. Under the shared state
-   * dir so #13773's workspace-GC registry can reclaim it with the task.
+   * dir, NOT a workspace root — so #13773's workspace-GC registry (which only
+   * scans git-workspace roots) never sees it. Its lifetime is bound to the task
+   * instead: {@link reclaimChildTrajectories} removes it on {@link deleteTask},
+   * the only point at which the task doc and the artifacts referencing these
+   * files are permanently gone (archive keeps them reopenable). Ingest is
+   * attach-by-reference, so the files must survive until the task itself does.
    */
   private childTrajectoryDir(taskId: string): string {
     return join(
@@ -1182,6 +1188,22 @@ export class OrchestratorTaskService extends Service {
       "child-trajectories",
       taskId,
     );
+  }
+
+  /**
+   * Delete a task's child-trajectory dir. Called from {@link deleteTask} — the
+   * only lifecycle point where the task doc and the `trajectory` artifacts that
+   * reference these files (by path, attach-by-reference) are permanently gone.
+   * Without this the dir leaks under the state dir forever (#14109): the
+   * workspace-GC registry (#13773) only scans git-workspace roots, never the
+   * state dir. A missing dir is the normal case (gate off, non-eliza backend,
+   * or already reclaimed), so `rm` is recursive + force.
+   */
+  private async reclaimChildTrajectories(taskId: string): Promise<void> {
+    await rm(this.childTrajectoryDir(taskId), {
+      recursive: true,
+      force: true,
+    });
   }
 
   /**
@@ -2202,6 +2224,10 @@ export class OrchestratorTaskService extends Service {
       this.sessionTaskIndex.delete(session.sessionId);
       this.recordFailureWarned.delete(session.sessionId);
     }
+    // Reclaim the per-task child-trajectory JSON now the task and its
+    // artifacts are permanently gone; nothing references these files anymore
+    // and no other GC ever scans the state dir (#14109).
+    await this.reclaimChildTrajectories(taskId);
     return this.store.deleteTask(taskId);
   }
 


### PR DESCRIPTION
## Problem

`<stateDir>/orchestrator/child-trajectories/<taskId>` was never garbage-collected. The comment on `childTrajectoryDir` claimed #13773's workspace-GC registry would "reclaim it with the task" — but that registry (`workspace-registry.ts` / `acp-service.ts` `gcOrphanedScratchDirs`) only scans **git-workspace roots** (`$TMPDIR/eliza-acp` + configured workspace dirs), never the state dir. Ingest is attach-by-reference, so the JSON is never deleted after being attached as `trajectory` artifacts.

Result: every trajectory-gated eliza-backend task run leaks per-task trajectory JSON under `<stateDir>` forever — the same disk-leak class as the 3.6TB worktree-farm incident that motivated #13773, relocated into the state dir.

## Fix

Bind the dir's lifetime to the task instead of a registry that never sees it:

- **`reclaimChildTrajectories(taskId)`** — recursive+force `rm` of the per-task dir; a missing dir is the normal case (gate off / non-eliza backend / already reclaimed), so it never throws.
- Called in **`deleteTask`** — the only lifecycle point where the task doc AND the `trajectory` artifacts that reference these files (by path) are permanently gone. `archiveTask` keeps them reopenable (the task-detail route serves the artifacts), so it deliberately does **not** delete.
- Fixed the stale `childTrajectoryDir` comment to state the real lifecycle.

Scoped to two files. No new abstraction; reclamation is one `rm` bound to the existing terminal `deleteTask` path.

## Evidence

Real test driving the actual path (`__tests__/unit/child-trajectory-ingest.test.ts`, real `InMemoryTaskStore` + real temp state dir, no mock stands in for the code under test):

- seeds real trajectory JSON under the per-task dir, runs the real `ingestChildTrajectories`, asserts the dir exists, then calls `svc.deleteTask(taskId)` and asserts the dir + JSON are **gone**.
- deletes a task that never recorded trajectories -> force-recursive `rm` is a no-op, deletion still resolves `true`.

```
$ bun run vitest run __tests__/unit/child-trajectory-ingest.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)   # 4 pre-existing + 2 new reclamation tests
```

Typecheck: no errors in either edited file (the only `bun run typecheck` errors are pre-existing `packages/core` i18n generated-file staleness, unrelated to this change).

Fixes #14109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
