### PR TITLE
fix(orchestrator): reclaimIdleSession resolves session→task via store fallback (#14106)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-admission-queue.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-admission-queue.test.ts
@@ -255,3 +255,90 @@ describe("orchestrator admission queue — N tasks vs maxSessions (#13778)", () 
     await acp.stop();
   });
 });
+
+describe("orchestrator keepAlive reclaim — post-restart session→task fallback (#14106)", () => {
+  it("reclaims a pre-restart idle keepAlive session whose owning task is terminal even when the in-memory index is empty", async () => {
+    // Reproduces the #14106 starvation: after a parent restart the in-memory
+    // `sessionTaskIndex` is empty, but pre-restart keepAlive sessions are still
+    // live in the ACP and their session→task mapping survives only in the
+    // durable store. The starvation guard must resolve that mapping via the
+    // store (like `resolveTaskId`) — reading the index alone reclaims nothing
+    // and queued tasks starve behind zombie sessions of already-terminal tasks.
+    const CAP = 1;
+
+    const acp = new AcpService(
+      acpRuntime({
+        ELIZA_ACP_MAX_SESSIONS: String(CAP),
+        ELIZA_ACP_ADMISSION_POLL_MS: "5",
+      }),
+    );
+    await acp.start();
+
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(orchestratorRuntime(acp), {
+      store,
+    });
+    await service.start();
+
+    // A task that occupied the only worker slot with a keepAlive session, then
+    // finished — the durable store retains its session→task mapping.
+    const finished = await service.createTask({
+      title: "pre-restart",
+      goal: "Implement and verify",
+    });
+    await service.spawnAgentForTask(finished.id);
+    await poll(async () => (await acp.listSessions()).length === 1);
+    const zombie = (await acp.listSessions())[0];
+    expect(zombie).toBeDefined();
+    if (!zombie) throw new Error("expected a live session");
+    // The session's task is now terminal; the live session is dead-weight
+    // holding the only slot.
+    await store.updateTask(finished.id, { status: "done" });
+    expect((await store.findSession(zombie.id))?.taskId).toBe(finished.id);
+
+    // Simulate the parent restart: drop the in-memory index so the ONLY
+    // session→task mapping is the durable store, exactly as after a cold boot
+    // that reattached the live keepAlive session.
+    (
+      service as unknown as { sessionTaskIndex: Map<string, string> }
+    ).sessionTaskIndex.clear();
+
+    // A newly queued task hits the full worker cap and parks. Its drain must
+    // reclaim the zombie session — which is only possible via the store
+    // fallback, since the in-memory index no longer knows the session.
+    const queued = await service.createTask({
+      title: "post-restart-queued",
+      goal: "Implement and verify",
+    });
+    const detail = await service.spawnAgentForTask(queued.id);
+    expect(detail?.admission).toBeTruthy();
+
+    // The guard stops the pre-restart zombie session, freeing the slot, the
+    // queued task drains out of the queue, and its fresh session becomes the
+    // sole active worker — all only reachable because the store fallback mapped
+    // the zombie session to its terminal task.
+    await poll(async () => {
+      const sessions = await acp.listSessions();
+      const zombieStopped = !sessions.some(
+        (s) => s.id === zombie.id && isActive(s),
+      );
+      const queuedAdmitted =
+        (await service.getAdmissionSnapshot()).queueDepth === 0;
+      const oneActiveWorker = sessions.filter(isActive).length === CAP;
+      return zombieStopped && queuedAdmitted && oneActiveWorker;
+    });
+
+    const sessionsAfter = await acp.listSessions();
+    expect(sessionsAfter.some((s) => s.id === zombie.id && isActive(s))).toBe(
+      false,
+    );
+    expect((await service.getAdmissionSnapshot()).queueDepth).toBe(0);
+    expect(sessionsAfter.filter(isActive).length).toBe(CAP);
+    // The one live worker is the queued task's fresh session, not the zombie.
+    const liveWorker = sessionsAfter.find(isActive);
+    expect(liveWorker?.id).not.toBe(zombie.id);
+
+    await service.stop();
+    await acp.stop();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -4361,7 +4361,13 @@ export class OrchestratorTaskService extends Service {
     const candidates: Array<{ id: string; createdAt: number }> = [];
     for (const session of sessions) {
       if (TERMINAL_SESSION_STATUSES.has(session.status)) continue;
-      const taskId = this.sessionTaskIndex.get(session.id);
+      // Resolve via `resolveTaskId`, not the in-memory `sessionTaskIndex`
+      // directly: after a parent restart the index is empty but pre-restart
+      // keepAlive sessions are still live, so the session→task mapping only
+      // exists in the durable store. Reading the index alone leaves this guard
+      // unable to reclaim any pre-restart session, starving queued tasks behind
+      // zombie sessions whose owning tasks are already terminal (#14106).
+      const taskId = await this.resolveTaskId(session.id);
       if (!taskId) continue;
       const doc = await this.store.getTask(taskId);
       if (!doc || !TERMINAL_TASK_STATUSES.has(doc.task.status)) continue;


### PR DESCRIPTION
## Problem

`reclaimIdleSession` — the keepAlive **starvation guard** in the orchestrator admission drain — resolved a live session to its owning task by reading the **in-memory** `sessionTaskIndex` directly (`orchestrator-task-service.ts:4364`). Its sibling resolver `resolveTaskId` (~L1915) already falls back to `store.findSession` on an index miss and re-primes the index; the guard had no such fallback.

**Failure scenario (from the #13766 post-merge audit of #13830):**

1. Parent process restarts. `sessionTaskIndex` (a plain in-memory `Map`) is empty, but pre-restart keepAlive sessions are still live and reattached — their session→task mapping survives only in the durable store.
2. The admission drain hits the worker cap and calls the starvation guard to free a slot.
3. The guard can't map any pre-restart session to its (terminal) owning task, so it reclaims nothing — **queued tasks starve behind zombie pre-restart keepAlive sessions** even though their owning tasks are `done`/`failed`/`archived`.

## Fix

Route the lookup through `resolveTaskId(session.id)` instead of `sessionTaskIndex.get(session.id)` — one-line seam that gives the guard the exact `store.findSession` fallback its siblings already have, and re-primes the index on the way.

```diff
-      const taskId = this.sessionTaskIndex.get(session.id);
+      const taskId = await this.resolveTaskId(session.id);
```

## Evidence — red/green proven

New regression test drives the **REAL** `OrchestratorTaskService` + **REAL** `AcpService` worker cap (only the subprocess leaf `NativeAcpClient` is stubbed, exactly like the existing `#13778` admission-queue test): spawn a keepAlive session, mark its owning task `done`, **clear the in-memory index to simulate a parent restart** (leaving the session→task mapping only in the durable store), then park a queued task at full worker capacity so the drain invokes the guard.

- **Against the old index-only code:** the drain never reclaims the zombie — poll times out (`poll timed out waiting for admission-queue condition`). ✔ test catches the bug.
- **With the store fallback:** the zombie session is stopped, the slot frees, and the queued task is admitted (queueDepth → 0, sole live worker is the fresh session, not the zombie). ✔ test passes.

```
$ bunx vitest run __tests__/unit/orchestrator-admission-queue.test.ts -t "#14106"
 Test Files  1 passed (1)
      Tests  1 passed | 1 skipped (2)
```

Sibling suite unaffected: `orchestrator-task-service.test.ts` → **71 passed**. Biome clean on both touched files. Remaining repo typecheck errors are the pre-existing missing `generated/validation-keyword-data` artifacts in `packages/core`/`packages/shared`, unrelated to this change (the swap is `string | undefined` → `string | undefined`).

Supersedes the blocked draft #14126 (same one-line code slice; that PR's author could not run the focused test locally — this PR ships it, red/green-verified).

Fixes #14106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
