### PR TITLE
fix trajectories gate defaults and scenario opt-in

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -111,6 +111,7 @@ Read by the runtime (see README for the full WHY of each):
 - `ELIZA_STAGE1_GROUP_TRIAGE` (`services/message/stage1-prompt-tier.ts`) — set `0` to disable the compact Stage 1 instruction tier for unaddressed group messages and always render the full rule block (default on).
 - Prompt-batcher knobs (all `PROMPT_BATCHER_*`, read in `runtime.ts`): `PROMPT_BATCHER_BATCH_SIZE`, `PROMPT_BATCHER_MAX_DRAIN_INTERVAL_MS`, `PROMPT_BATCHER_MAX_SECTIONS_PER_CALL`, `PROMPT_BATCHER_PACKING_DENSITY`, `PROMPT_BATCHER_MAX_TOKENS_PER_CALL`, `PROMPT_BATCHER_MAX_PARALLEL_CALLS`, `PROMPT_BATCHER_MODEL_SEPARATION`.
 - `ELIZA_STATE_DIR` — state-dir resolution (`utils/state-dir.ts`); `ELIZA_WORKSPACE_DIR` — workspace folder (`utils/workspace-folder-config.ts`).
+- `ELIZA_TRAJECTORY_LOGGING` — canonical trajectory persistence gate for both file and DB recorders (`runtime/trajectory-gate.ts`): truthy enables; non-empty falsey disables; blank is unset. Defaults are on for dev/unset `NODE_ENV`, off for `NODE_ENV=test|production`. `ELIZA_TRAJECTORY_RECORDING` is the legacy alias, and `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` is the hard opt-out.
 
 Prefer the canonical env reader in `utils/read-env.ts` over raw `process.env` (it handles legacy aliases).
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -111,6 +111,7 @@ Read by the runtime (see README for the full WHY of each):
 - `ELIZA_STAGE1_GROUP_TRIAGE` (`services/message/stage1-prompt-tier.ts`) — set `0` to disable the compact Stage 1 instruction tier for unaddressed group messages and always render the full rule block (default on).
 - Prompt-batcher knobs (all `PROMPT_BATCHER_*`, read in `runtime.ts`): `PROMPT_BATCHER_BATCH_SIZE`, `PROMPT_BATCHER_MAX_DRAIN_INTERVAL_MS`, `PROMPT_BATCHER_MAX_SECTIONS_PER_CALL`, `PROMPT_BATCHER_PACKING_DENSITY`, `PROMPT_BATCHER_MAX_TOKENS_PER_CALL`, `PROMPT_BATCHER_MAX_PARALLEL_CALLS`, `PROMPT_BATCHER_MODEL_SEPARATION`.
 - `ELIZA_STATE_DIR` — state-dir resolution (`utils/state-dir.ts`); `ELIZA_WORKSPACE_DIR` — workspace folder (`utils/workspace-folder-config.ts`).
+- `ELIZA_TRAJECTORY_LOGGING` — canonical trajectory persistence gate for both file and DB recorders (`runtime/trajectory-gate.ts`): truthy enables; non-empty falsey disables; blank is unset. Defaults are on for dev/unset `NODE_ENV`, off for `NODE_ENV=test|production`. `ELIZA_TRAJECTORY_RECORDING` is the legacy alias, and `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` is the hard opt-out.
 
 Prefer the canonical env reader in `utils/read-env.ts` over raw `process.env` (it handles legacy aliases).
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -56,6 +56,9 @@ The following environment variables are used by `@elizaos/core`. Configure them 
 - `LOG_FILE`: When set to `true`/`1` or a path, enables file logging: `output.log`, `prompts.log`, and `chat.log` (in cwd or at the given path). **Why:** Lets you inspect full prompts and chat flow without scraping console; ANSI is stripped so files stay grep-friendly.
 - `BASIC_CAPABILITIES_KEEP_RESP`: When `true`, the message service does not discard a response when a newer message is being processed (avoids "stale reply" race). **Why:** Some deployments want to keep or display every response; this is the config equivalent of passing `keepExistingResponses: true` in options.
 - `SHOULD_RESPOND_MODEL`: Which model size to use for the "should I respond?" decision (`small` or `large`, read in `src/services/message.ts`). Defaults from runtime settings if not set in options.
+- `ELIZA_TRAJECTORY_LOGGING`: Canonical trajectory persistence knob. Truthy values (`1`, `true`, `yes`, `on`) enable file and DB trajectory recording; non-empty falsey values disable it; blank is treated as unset. When unset, recording is on for local/dev and unset `NODE_ENV`, but off for `NODE_ENV=test` and `NODE_ENV=production` unless explicitly enabled.
+- `ELIZA_TRAJECTORY_RECORDING`: Legacy alias honored only when `ELIZA_TRAJECTORY_LOGGING` is unset.
+- `ELIZA_DISABLE_TRAJECTORY_LOGGING=1`: Hard opt-out that wins over both trajectory enable knobs.
 
 **Example `.env`:**
 
@@ -74,6 +77,8 @@ LOG_FILE=true
 Per-change notes with the WHY for each addition or fix live in [CHANGELOG.md](CHANGELOG.md). The sections below document the reasoning behind the major subsystems so future changes stay consistent with intent.
 
 ### Benchmark & Trajectory Tracing
+
+Trajectory persistence is controlled by `ELIZA_TRAJECTORY_LOGGING`: dev/local defaults on, while `NODE_ENV=test` and `NODE_ENV=production` default off unless explicitly opted in. Blank values are treated as unset so empty `.env` entries do not silently disable local recording.
 
 Benchmarks and harnesses can attach metadata to inbound messages:
 

--- a/packages/core/src/runtime/trajectory-gate.test.ts
+++ b/packages/core/src/runtime/trajectory-gate.test.ts
@@ -9,116 +9,116 @@ import { resolveTrajectoryGate } from "./trajectory-gate";
 import { isTrajectoryRecordingEnabled } from "./trajectory-recorder";
 
 function gate(env: Record<string, string | undefined>): boolean {
-	return resolveTrajectoryGate(env as NodeJS.ProcessEnv).enabled;
+  return resolveTrajectoryGate(env as NodeJS.ProcessEnv).enabled;
 }
 
 describe("resolveTrajectoryGate precedence", () => {
-	it("hard opt-out wins over everything", () => {
-		const decision = resolveTrajectoryGate({
-			ELIZA_DISABLE_TRAJECTORY_LOGGING: "1",
-			ELIZA_TRAJECTORY_LOGGING: "1",
-			ELIZA_TRAJECTORY_RECORDING: "1",
-			NODE_ENV: "development",
-		} as NodeJS.ProcessEnv);
-		expect(decision.enabled).toBe(false);
-		expect(decision.reason).toBe("disable-flag");
-	});
+  it("hard opt-out wins over everything", () => {
+    const decision = resolveTrajectoryGate({
+      ELIZA_DISABLE_TRAJECTORY_LOGGING: "1",
+      ELIZA_TRAJECTORY_LOGGING: "1",
+      ELIZA_TRAJECTORY_RECORDING: "1",
+      NODE_ENV: "development",
+    } as NodeJS.ProcessEnv);
+    expect(decision.enabled).toBe(false);
+    expect(decision.reason).toBe("disable-flag");
+  });
 
-	it("explicit ELIZA_TRAJECTORY_LOGGING overrides NODE_ENV and the legacy alias", () => {
-		expect(
-			gate({ ELIZA_TRAJECTORY_LOGGING: "1", NODE_ENV: "production" }),
-		).toBe(true);
-		expect(
-			gate({ ELIZA_TRAJECTORY_LOGGING: "0", NODE_ENV: "development" }),
-		).toBe(false);
-		expect(
-			gate({
-				ELIZA_TRAJECTORY_LOGGING: "1",
-				ELIZA_TRAJECTORY_RECORDING: "0",
-			}),
-		).toBe(true);
-	});
+  it("explicit ELIZA_TRAJECTORY_LOGGING overrides NODE_ENV and the legacy alias", () => {
+    expect(
+      gate({ ELIZA_TRAJECTORY_LOGGING: "1", NODE_ENV: "production" }),
+    ).toBe(true);
+    expect(
+      gate({ ELIZA_TRAJECTORY_LOGGING: "0", NODE_ENV: "development" }),
+    ).toBe(false);
+    expect(
+      gate({
+        ELIZA_TRAJECTORY_LOGGING: "1",
+        ELIZA_TRAJECTORY_RECORDING: "0",
+      }),
+    ).toBe(true);
+  });
 
-	it("coerces truthy/falsey strings for the explicit knob", () => {
-		for (const v of ["1", "true", "yes", "on", "TRUE", " On "]) {
-			expect(gate({ ELIZA_TRAJECTORY_LOGGING: v })).toBe(true);
-		}
-		for (const v of ["0", "false", "no", "off", "nonsense"]) {
-			expect(gate({ ELIZA_TRAJECTORY_LOGGING: v })).toBe(false);
-		}
-	});
+  it("coerces truthy/falsey strings for the explicit knob", () => {
+    for (const v of ["1", "true", "yes", "on", "TRUE", " On "]) {
+      expect(gate({ ELIZA_TRAJECTORY_LOGGING: v })).toBe(true);
+    }
+    for (const v of ["0", "false", "no", "off", "nonsense"]) {
+      expect(gate({ ELIZA_TRAJECTORY_LOGGING: v })).toBe(false);
+    }
+  });
 
-	it("treats blank explicit knobs as unset", () => {
-		expect(
-			resolveTrajectoryGate({
-				ELIZA_TRAJECTORY_LOGGING: "",
-				NODE_ENV: "development",
-			} as NodeJS.ProcessEnv),
-		).toEqual({ enabled: true, reason: "dev-default-on" });
+  it("treats blank explicit knobs as unset", () => {
+    expect(
+      resolveTrajectoryGate({
+        ELIZA_TRAJECTORY_LOGGING: "",
+        NODE_ENV: "development",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ enabled: true, reason: "dev-default-on" });
 
-		expect(
-			resolveTrajectoryGate({
-				ELIZA_TRAJECTORY_LOGGING: "   ",
-				NODE_ENV: "test",
-			} as NodeJS.ProcessEnv),
-		).toEqual({ enabled: false, reason: "test-default-off" });
+    expect(
+      resolveTrajectoryGate({
+        ELIZA_TRAJECTORY_LOGGING: "   ",
+        NODE_ENV: "test",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ enabled: false, reason: "test-default-off" });
 
-		expect(
-			resolveTrajectoryGate({
-				ELIZA_TRAJECTORY_LOGGING: "",
-				ELIZA_TRAJECTORY_RECORDING: "1",
-				NODE_ENV: "production",
-			} as NodeJS.ProcessEnv),
-		).toEqual({ enabled: true, reason: "explicit-recording-legacy" });
+    expect(
+      resolveTrajectoryGate({
+        ELIZA_TRAJECTORY_LOGGING: "",
+        ELIZA_TRAJECTORY_RECORDING: "1",
+        NODE_ENV: "production",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ enabled: true, reason: "explicit-recording-legacy" });
 
-		expect(
-			resolveTrajectoryGate({
-				ELIZA_TRAJECTORY_RECORDING: "",
-				NODE_ENV: "development",
-			} as NodeJS.ProcessEnv),
-		).toEqual({ enabled: true, reason: "dev-default-on" });
-	});
+    expect(
+      resolveTrajectoryGate({
+        ELIZA_TRAJECTORY_RECORDING: "",
+        NODE_ENV: "development",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ enabled: true, reason: "dev-default-on" });
+  });
 
-	it("honors the legacy ELIZA_TRAJECTORY_RECORDING alias when the canonical knob is unset", () => {
-		expect(
-			gate({ ELIZA_TRAJECTORY_RECORDING: "0", NODE_ENV: "development" }),
-		).toBe(false);
-		expect(
-			gate({ ELIZA_TRAJECTORY_RECORDING: "1", NODE_ENV: "production" }),
-		).toBe(true);
-	});
+  it("honors the legacy ELIZA_TRAJECTORY_RECORDING alias when the canonical knob is unset", () => {
+    expect(
+      gate({ ELIZA_TRAJECTORY_RECORDING: "0", NODE_ENV: "development" }),
+    ).toBe(false);
+    expect(
+      gate({ ELIZA_TRAJECTORY_RECORDING: "1", NODE_ENV: "production" }),
+    ).toBe(true);
+  });
 
-	it("test NODE_ENV is off by default", () => {
-		const decision = resolveTrajectoryGate({
-			NODE_ENV: "test",
-		} as NodeJS.ProcessEnv);
-		expect(decision.enabled).toBe(false);
-		expect(decision.reason).toBe("test-default-off");
-	});
+  it("test NODE_ENV is off by default", () => {
+    const decision = resolveTrajectoryGate({
+      NODE_ENV: "test",
+    } as NodeJS.ProcessEnv);
+    expect(decision.enabled).toBe(false);
+    expect(decision.reason).toBe("test-default-off");
+  });
 
-	it("production NODE_ENV is opt-in (off by default, SOC2 O-5)", () => {
-		const decision = resolveTrajectoryGate({
-			NODE_ENV: "production",
-		} as NodeJS.ProcessEnv);
-		expect(decision.enabled).toBe(false);
-		expect(decision.reason).toBe("production-opt-in");
-	});
+  it("production NODE_ENV is opt-in (off by default, SOC2 O-5)", () => {
+    const decision = resolveTrajectoryGate({
+      NODE_ENV: "production",
+    } as NodeJS.ProcessEnv);
+    expect(decision.enabled).toBe(false);
+    expect(decision.reason).toBe("production-opt-in");
+  });
 
-	it("dev / unset NODE_ENV is on by default", () => {
-		expect(
-			resolveTrajectoryGate({ NODE_ENV: "development" } as NodeJS.ProcessEnv)
-				.reason,
-		).toBe("dev-default-on");
-		expect(gate({})).toBe(true);
-	});
+  it("dev / unset NODE_ENV is on by default", () => {
+    expect(
+      resolveTrajectoryGate({ NODE_ENV: "development" } as NodeJS.ProcessEnv)
+        .reason,
+    ).toBe("dev-default-on");
+    expect(gate({})).toBe(true);
+  });
 });
 
 describe("recorder wrapper agrees with the gate", () => {
-	it("isTrajectoryRecordingEnabled reflects resolveTrajectoryGate(process.env)", () => {
-		// The file-recorder wrapper reads process.env directly; assert it matches
-		// the resolver for whatever the ambient env currently is.
-		expect(isTrajectoryRecordingEnabled()).toBe(
-			resolveTrajectoryGate(process.env).enabled,
-		);
-	});
+  it("isTrajectoryRecordingEnabled reflects resolveTrajectoryGate(process.env)", () => {
+    // The file-recorder wrapper reads process.env directly; assert it matches
+    // the resolver for whatever the ambient env currently is.
+    expect(isTrajectoryRecordingEnabled()).toBe(
+      resolveTrajectoryGate(process.env).enabled,
+    );
+  });
 });

--- a/packages/core/src/runtime/trajectory-gate.test.ts
+++ b/packages/core/src/runtime/trajectory-gate.test.ts
@@ -43,9 +43,40 @@ describe("resolveTrajectoryGate precedence", () => {
 		for (const v of ["1", "true", "yes", "on", "TRUE", " On "]) {
 			expect(gate({ ELIZA_TRAJECTORY_LOGGING: v })).toBe(true);
 		}
-		for (const v of ["0", "false", "no", "off", "nonsense", ""]) {
+		for (const v of ["0", "false", "no", "off", "nonsense"]) {
 			expect(gate({ ELIZA_TRAJECTORY_LOGGING: v })).toBe(false);
 		}
+	});
+
+	it("treats blank explicit knobs as unset", () => {
+		expect(
+			resolveTrajectoryGate({
+				ELIZA_TRAJECTORY_LOGGING: "",
+				NODE_ENV: "development",
+			} as NodeJS.ProcessEnv),
+		).toEqual({ enabled: true, reason: "dev-default-on" });
+
+		expect(
+			resolveTrajectoryGate({
+				ELIZA_TRAJECTORY_LOGGING: "   ",
+				NODE_ENV: "test",
+			} as NodeJS.ProcessEnv),
+		).toEqual({ enabled: false, reason: "test-default-off" });
+
+		expect(
+			resolveTrajectoryGate({
+				ELIZA_TRAJECTORY_LOGGING: "",
+				ELIZA_TRAJECTORY_RECORDING: "1",
+				NODE_ENV: "production",
+			} as NodeJS.ProcessEnv),
+		).toEqual({ enabled: true, reason: "explicit-recording-legacy" });
+
+		expect(
+			resolveTrajectoryGate({
+				ELIZA_TRAJECTORY_RECORDING: "",
+				NODE_ENV: "development",
+			} as NodeJS.ProcessEnv),
+		).toEqual({ enabled: true, reason: "dev-default-on" });
 	});
 
 	it("honors the legacy ELIZA_TRAJECTORY_RECORDING alias when the canonical knob is unset", () => {

--- a/packages/core/src/runtime/trajectory-gate.ts
+++ b/packages/core/src/runtime/trajectory-gate.ts
@@ -17,13 +17,15 @@
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
 
 /**
- * Coerce a raw env value to a boolean. Returns undefined when the var is unset
- * (so the caller can fall through to the next precedence tier); a set-but-not-
- * truthy value coerces to false (an explicit opt-out).
+ * Coerce a raw env value to a boolean. Returns undefined when the var is
+ * unset or blank (so the caller can fall through to the next precedence tier);
+ * a non-empty set-but-not-truthy value coerces to false (an explicit opt-out).
  */
 function coerceFlag(raw: string | undefined): boolean | undefined {
 	if (raw === undefined) return undefined;
-	return TRUTHY.has(raw.trim().toLowerCase());
+	const normalized = raw.trim().toLowerCase();
+	if (normalized.length === 0) return undefined;
+	return TRUTHY.has(normalized);
 }
 
 export interface TrajectoryGateDecision {

--- a/packages/core/src/runtime/trajectory-gate.ts
+++ b/packages/core/src/runtime/trajectory-gate.ts
@@ -22,16 +22,16 @@ const TRUTHY = new Set(["1", "true", "yes", "on"]);
  * a non-empty set-but-not-truthy value coerces to false (an explicit opt-out).
  */
 function coerceFlag(raw: string | undefined): boolean | undefined {
-	if (raw === undefined) return undefined;
-	const normalized = raw.trim().toLowerCase();
-	if (normalized.length === 0) return undefined;
-	return TRUTHY.has(normalized);
+  if (raw === undefined) return undefined;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized.length === 0) return undefined;
+  return TRUTHY.has(normalized);
 }
 
 export interface TrajectoryGateDecision {
-	enabled: boolean;
-	/** Which precedence tier decided, for diagnostics/logging. */
-	reason: string;
+  enabled: boolean;
+  /** Which precedence tier decided, for diagnostics/logging. */
+  reason: string;
 }
 
 /**
@@ -46,29 +46,29 @@ export interface TrajectoryGateDecision {
  *   6. otherwise (dev / unset NODE_ENV) — on, for local debugging.
  */
 export function resolveTrajectoryGate(
-	env: NodeJS.ProcessEnv = process.env,
+  env: NodeJS.ProcessEnv = process.env,
 ): TrajectoryGateDecision {
-	if (env.ELIZA_DISABLE_TRAJECTORY_LOGGING === "1") {
-		return { enabled: false, reason: "disable-flag" };
-	}
+  if (env.ELIZA_DISABLE_TRAJECTORY_LOGGING === "1") {
+    return { enabled: false, reason: "disable-flag" };
+  }
 
-	const explicit = coerceFlag(env.ELIZA_TRAJECTORY_LOGGING);
-	if (explicit !== undefined) {
-		return { enabled: explicit, reason: "explicit-logging" };
-	}
+  const explicit = coerceFlag(env.ELIZA_TRAJECTORY_LOGGING);
+  if (explicit !== undefined) {
+    return { enabled: explicit, reason: "explicit-logging" };
+  }
 
-	const legacy = coerceFlag(env.ELIZA_TRAJECTORY_RECORDING);
-	if (legacy !== undefined) {
-		return { enabled: legacy, reason: "explicit-recording-legacy" };
-	}
+  const legacy = coerceFlag(env.ELIZA_TRAJECTORY_RECORDING);
+  if (legacy !== undefined) {
+    return { enabled: legacy, reason: "explicit-recording-legacy" };
+  }
 
-	if (env.NODE_ENV === "test") {
-		return { enabled: false, reason: "test-default-off" };
-	}
+  if (env.NODE_ENV === "test") {
+    return { enabled: false, reason: "test-default-off" };
+  }
 
-	if (env.NODE_ENV === "production") {
-		return { enabled: false, reason: "production-opt-in" };
-	}
+  if (env.NODE_ENV === "production") {
+    return { enabled: false, reason: "production-opt-in" };
+  }
 
-	return { enabled: true, reason: "dev-default-on" };
+  return { enabled: true, reason: "dev-default-on" };
 }

--- a/packages/scenario-runner/AGENTS.md
+++ b/packages/scenario-runner/AGENTS.md
@@ -130,6 +130,7 @@ bun run --cwd packages/scenario-runner clean
 | `ELIZA_SCENARIO_PGLITE_DIR` / `SCENARIO_PGLITE_DIR` | Override the temp PGLite directory |
 | `ELIZA_SAVE_TRAJECTORIES` / `SCENARIO_SAVE_TRAJECTORIES` | `1` = preserve PGLite DB after run |
 | `ELIZA_TRAJECTORY_DIR` | Set by CLI when `--run-dir` is active; picked up by the trajectory recorder |
+| `ELIZA_TRAJECTORY_LOGGING` | Set to `1` by `eliza-scenarios run` before runtime startup so scenario runs record trajectories even when `NODE_ENV=test|production`; `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` remains the hard opt-out |
 | `ELIZA_LIFEOPS_RUN_ID` | Injected by CLI; tags trajectories with the run ID |
 | `ELIZA_LIFEOPS_SCENARIO_ID` | Injected per scenario so trajectory files are tagged correctly |
 | `ELIZA_DISABLE_ACTIVITY_TRACKER` | Set to `1` by the runtime factory; suppresses activity-tracker background work |

--- a/packages/scenario-runner/CLAUDE.md
+++ b/packages/scenario-runner/CLAUDE.md
@@ -130,6 +130,7 @@ bun run --cwd packages/scenario-runner clean
 | `ELIZA_SCENARIO_PGLITE_DIR` / `SCENARIO_PGLITE_DIR` | Override the temp PGLite directory |
 | `ELIZA_SAVE_TRAJECTORIES` / `SCENARIO_SAVE_TRAJECTORIES` | `1` = preserve PGLite DB after run |
 | `ELIZA_TRAJECTORY_DIR` | Set by CLI when `--run-dir` is active; picked up by the trajectory recorder |
+| `ELIZA_TRAJECTORY_LOGGING` | Set to `1` by `eliza-scenarios run` before runtime startup so scenario runs record trajectories even when `NODE_ENV=test|production`; `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` remains the hard opt-out |
 | `ELIZA_LIFEOPS_RUN_ID` | Injected by CLI; tags trajectories with the run ID |
 | `ELIZA_LIFEOPS_SCENARIO_ID` | Injected per scenario so trajectory files are tagged correctly |
 | `ELIZA_DISABLE_ACTIVITY_TRACKER` | Set to `1` by the runtime factory; suppresses activity-tracker background work |

--- a/packages/scenario-runner/README.md
+++ b/packages/scenario-runner/README.md
@@ -93,6 +93,8 @@ eliza-scenarios run  <dir>
 | `SKIP_REASON` | Set to allow intentional scenario skips without exit code 2 |
 | `SCENARIO_INCLUDE_PENDING` | `1` = include `status: "pending"` scenarios |
 | `ELIZA_BENCH_SKIP_EMBEDDING` | Default `1`; set to `0` for real local-inference embeddings |
+| `ELIZA_TRAJECTORY_LOGGING` | The `run` command sets this to `1` so scenario trajectories are recorded even under `NODE_ENV=test` or `NODE_ENV=production`; `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` still hard-disables recording |
+| `ELIZA_TRAJECTORY_DIR` | Set automatically when `--run-dir` or `--export-native` creates an effective run directory |
 
 Any one of `GROQ_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, or `OPENROUTER_API_KEY` satisfies the live-provider requirement when not in proxy mode.
 

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -24,6 +24,7 @@ import {
   loadAllScenarios,
   validateScenarioCorpus,
 } from "./loader.ts";
+import { enableScenarioTrajectoryLogging } from "./trajectory-env.ts";
 import type { ScenarioReport } from "./types.ts";
 
 const SCENARIO_LANES: readonly ScenarioLane[] = [
@@ -228,6 +229,8 @@ async function main(): Promise<number> {
     return 0;
   }
 
+  enableScenarioTrajectoryLogging(process.env);
+
   const liveProviderSpecifier = "@elizaos/core/testing" as string;
   const [
     { availableProviderNames },
@@ -319,10 +322,6 @@ async function main(): Promise<number> {
     process.env.ELIZA_TRAJECTORY_DIR = trajectoryDir;
     process.env.ELIZA_LIFEOPS_RUN_ID = effectiveRunId;
     process.env.ELIZA_LIFEOPS_RUN_DIR = effectiveRunDir;
-    // The recorder default flipped to opt-in for prod/test (#13775); a scenario
-    // run capturing trajectories must opt in explicitly so the per-turn traces
-    // this run then aggregates/exports are actually written.
-    process.env.ELIZA_TRAJECTORY_LOGGING = "1";
     logger.info(
       `[eliza-scenarios] run-dir: ${effectiveRunDir} (trajectories → ${trajectoryDir}, runId=${effectiveRunId})`,
     );

--- a/packages/scenario-runner/src/trajectory-env.test.ts
+++ b/packages/scenario-runner/src/trajectory-env.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { enableScenarioTrajectoryLogging } from "./trajectory-env.ts";
+
+describe("enableScenarioTrajectoryLogging", () => {
+  it("opts every scenario run into trajectory recording", () => {
+    const env: NodeJS.ProcessEnv = {};
+
+    enableScenarioTrajectoryLogging(env);
+
+    expect(env.ELIZA_TRAJECTORY_LOGGING).toBe("1");
+  });
+
+  it("overrides a falsey or blank scenario logging value", () => {
+    const falseyEnv: NodeJS.ProcessEnv = { ELIZA_TRAJECTORY_LOGGING: "0" };
+    const blankEnv: NodeJS.ProcessEnv = { ELIZA_TRAJECTORY_LOGGING: "" };
+
+    enableScenarioTrajectoryLogging(falseyEnv);
+    enableScenarioTrajectoryLogging(blankEnv);
+
+    expect(falseyEnv.ELIZA_TRAJECTORY_LOGGING).toBe("1");
+    expect(blankEnv.ELIZA_TRAJECTORY_LOGGING).toBe("1");
+  });
+
+  it("does not clear the hard operator disable flag", () => {
+    const env: NodeJS.ProcessEnv = { ELIZA_DISABLE_TRAJECTORY_LOGGING: "1" };
+
+    enableScenarioTrajectoryLogging(env);
+
+    expect(env.ELIZA_DISABLE_TRAJECTORY_LOGGING).toBe("1");
+    expect(env.ELIZA_TRAJECTORY_LOGGING).toBe("1");
+  });
+});

--- a/packages/scenario-runner/src/trajectory-env.ts
+++ b/packages/scenario-runner/src/trajectory-env.ts
@@ -1,0 +1,5 @@
+export function enableScenarioTrajectoryLogging(
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  env.ELIZA_TRAJECTORY_LOGGING = "1";
+}

--- a/packages/training/SECURITY.md
+++ b/packages/training/SECURITY.md
@@ -29,9 +29,13 @@ customer-data. The current ``consent_proof_uri`` points back to this
 document because the production opt-in flow is still in design (see
 "open items" below). The provisional control is:
 
-  - Local-only ``~/.eliza/training/datasets/`` writes happen ONLY when
-    ``ELIZA_DISABLE_TRAJECTORY_LOGGING`` is unset (default opt-in for
-    dogfooders, will flip to opt-out once the consent UI ships).
+  - Runtime trajectory writes are gated by
+    ``ELIZA_TRAJECTORY_LOGGING``: local/dev and unset ``NODE_ENV`` default
+    on, while ``NODE_ENV=test`` and ``NODE_ENV=production`` default off unless
+    explicitly opted in with a truthy value. Blank values are treated as unset,
+    ``ELIZA_TRAJECTORY_RECORDING`` is the legacy alias, and
+    ``ELIZA_DISABLE_TRAJECTORY_LOGGING=1`` is the hard opt-out. Scenario
+    evidence runs opt in explicitly through ``eliza-scenarios run``.
   - The privacy filter runs ``--strict`` by default
     ([``scripts/privacy_filter_trajectories.py``](scripts/privacy_filter_trajectories.py)).
   - Nubilio data is internal-dogfood collected from a self-hosted bot the


### PR DESCRIPTION
## Summary

Fixes #14111.

- Treat blank `ELIZA_TRAJECTORY_LOGGING` / `ELIZA_TRAJECTORY_RECORDING` values as unset so empty `.env` entries fall through to the normal `NODE_ENV` defaults or legacy alias.
- Move scenario-runner trajectory opt-in out of the `--run-dir` branch so every `eliza-scenarios run` sets `ELIZA_TRAJECTORY_LOGGING=1` before runtime startup.
- Document the trajectory gate in core and scenario-runner docs, keep `CLAUDE.md` / `AGENTS.md` mirrors in sync, and correct the stale training SECURITY.md “default opt-in” wording.

## Verification

- PASS: `node_modules/.bin/biome check` on downloaded branch copies of the changed TypeScript files (`trajectory-gate.ts`, `trajectory-gate.test.ts`, `cli.ts`, `trajectory-env.ts`, `trajectory-env.test.ts`).
- PASS: `bun test /tmp/eliza-14111-behavior/trajectory-behavior.test.ts` against downloaded branch copies (3 pass, 0 fail): blank env falls through, legacy alias still works, scenario helper opts in while preserving hard disable flag.
- PASS: temporary base-vs-branch repo `git diff --check HEAD` for all changed files.
- PASS: remote doc mirror check: `packages/core/CLAUDE.md` == `packages/core/AGENTS.md`; `packages/scenario-runner/CLAUDE.md` == `packages/scenario-runner/AGENTS.md`.

## Evidence not captured yet

- Full package Vitest lanes and root `bun run verify` were not run locally because the active checkout is sparse/dirty and the machine had ~172 MiB free when this pass started.
- Live-model scenario trajectory evidence was not captured in this draft pass; this PR intentionally stays draft until the repo-standard scenario report/viewer/native-jsonl evidence can be run and reviewed on a machine with sufficient disk and credentials.