### PR TITLE
fix(trajectories): document gate tiers, treat blank env as unset, hoist scenario opt-in (#14111)

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -111,6 +111,7 @@ Read by the runtime (see README for the full WHY of each):
 - `ELIZA_STAGE1_GROUP_TRIAGE` (`services/message/stage1-prompt-tier.ts`) — set `0` to disable the compact Stage 1 instruction tier for unaddressed group messages and always render the full rule block (default on).
 - Prompt-batcher knobs (all `PROMPT_BATCHER_*`, read in `runtime.ts`): `PROMPT_BATCHER_BATCH_SIZE`, `PROMPT_BATCHER_MAX_DRAIN_INTERVAL_MS`, `PROMPT_BATCHER_MAX_SECTIONS_PER_CALL`, `PROMPT_BATCHER_PACKING_DENSITY`, `PROMPT_BATCHER_MAX_TOKENS_PER_CALL`, `PROMPT_BATCHER_MAX_PARALLEL_CALLS`, `PROMPT_BATCHER_MODEL_SEPARATION`.
 - `ELIZA_STATE_DIR` — state-dir resolution (`utils/state-dir.ts`); `ELIZA_WORKSPACE_DIR` — workspace folder (`utils/workspace-folder-config.ts`).
+- `ELIZA_TRAJECTORY_LOGGING` — canonical trajectory persistence gate for both file and DB recorders (`runtime/trajectory-gate.ts`): truthy enables; non-empty falsey disables; blank is unset. Defaults are on for dev/unset `NODE_ENV`, off for `NODE_ENV=test|production`. `ELIZA_TRAJECTORY_RECORDING` is the legacy alias, and `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` is the hard opt-out.
 
 Prefer the canonical env reader in `utils/read-env.ts` over raw `process.env` (it handles legacy aliases).
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -111,6 +111,7 @@ Read by the runtime (see README for the full WHY of each):
 - `ELIZA_STAGE1_GROUP_TRIAGE` (`services/message/stage1-prompt-tier.ts`) — set `0` to disable the compact Stage 1 instruction tier for unaddressed group messages and always render the full rule block (default on).
 - Prompt-batcher knobs (all `PROMPT_BATCHER_*`, read in `runtime.ts`): `PROMPT_BATCHER_BATCH_SIZE`, `PROMPT_BATCHER_MAX_DRAIN_INTERVAL_MS`, `PROMPT_BATCHER_MAX_SECTIONS_PER_CALL`, `PROMPT_BATCHER_PACKING_DENSITY`, `PROMPT_BATCHER_MAX_TOKENS_PER_CALL`, `PROMPT_BATCHER_MAX_PARALLEL_CALLS`, `PROMPT_BATCHER_MODEL_SEPARATION`.
 - `ELIZA_STATE_DIR` — state-dir resolution (`utils/state-dir.ts`); `ELIZA_WORKSPACE_DIR` — workspace folder (`utils/workspace-folder-config.ts`).
+- `ELIZA_TRAJECTORY_LOGGING` — canonical trajectory persistence gate for both file and DB recorders (`runtime/trajectory-gate.ts`): truthy enables; non-empty falsey disables; blank is unset. Defaults are on for dev/unset `NODE_ENV`, off for `NODE_ENV=test|production`. `ELIZA_TRAJECTORY_RECORDING` is the legacy alias, and `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` is the hard opt-out.
 
 Prefer the canonical env reader in `utils/read-env.ts` over raw `process.env` (it handles legacy aliases).
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -56,6 +56,9 @@ The following environment variables are used by `@elizaos/core`. Configure them 
 - `LOG_FILE`: When set to `true`/`1` or a path, enables file logging: `output.log`, `prompts.log`, and `chat.log` (in cwd or at the given path). **Why:** Lets you inspect full prompts and chat flow without scraping console; ANSI is stripped so files stay grep-friendly.
 - `BASIC_CAPABILITIES_KEEP_RESP`: When `true`, the message service does not discard a response when a newer message is being processed (avoids "stale reply" race). **Why:** Some deployments want to keep or display every response; this is the config equivalent of passing `keepExistingResponses: true` in options.
 - `SHOULD_RESPOND_MODEL`: Which model size to use for the "should I respond?" decision (`small` or `large`, read in `src/services/message.ts`). Defaults from runtime settings if not set in options.
+- `ELIZA_TRAJECTORY_LOGGING`: Canonical trajectory persistence knob. Truthy values (`1`, `true`, `yes`, `on`) enable file and DB trajectory recording; non-empty falsey values disable it; blank is treated as unset. When unset, recording is on for local/dev and unset `NODE_ENV`, but off for `NODE_ENV=test` and `NODE_ENV=production` unless explicitly enabled.
+- `ELIZA_TRAJECTORY_RECORDING`: Legacy alias honored only when `ELIZA_TRAJECTORY_LOGGING` is unset.
+- `ELIZA_DISABLE_TRAJECTORY_LOGGING=1`: Hard opt-out that wins over both trajectory enable knobs.
 
 **Example `.env`:**
 
@@ -74,6 +77,8 @@ LOG_FILE=true
 Per-change notes with the WHY for each addition or fix live in [CHANGELOG.md](CHANGELOG.md). The sections below document the reasoning behind the major subsystems so future changes stay consistent with intent.
 
 ### Benchmark & Trajectory Tracing
+
+Trajectory persistence is controlled by `ELIZA_TRAJECTORY_LOGGING`: dev/local defaults on, while `NODE_ENV=test` and `NODE_ENV=production` default off unless explicitly opted in. Blank values are treated as unset so empty `.env` entries do not silently disable local recording.
 
 Benchmarks and harnesses can attach metadata to inbound messages:
 

--- a/packages/core/src/runtime/trajectory-gate.test.ts
+++ b/packages/core/src/runtime/trajectory-gate.test.ts
@@ -9,113 +9,113 @@ import { resolveTrajectoryGate } from "./trajectory-gate";
 import { isTrajectoryRecordingEnabled } from "./trajectory-recorder";
 
 function gate(env: Record<string, string | undefined>): boolean {
-	return resolveTrajectoryGate(env as NodeJS.ProcessEnv).enabled;
+  return resolveTrajectoryGate(env as NodeJS.ProcessEnv).enabled;
 }
 
 describe("resolveTrajectoryGate precedence", () => {
-	it("hard opt-out wins over everything", () => {
-		const decision = resolveTrajectoryGate({
-			ELIZA_DISABLE_TRAJECTORY_LOGGING: "1",
-			ELIZA_TRAJECTORY_LOGGING: "1",
-			ELIZA_TRAJECTORY_RECORDING: "1",
-			NODE_ENV: "development",
-		} as NodeJS.ProcessEnv);
-		expect(decision.enabled).toBe(false);
-		expect(decision.reason).toBe("disable-flag");
-	});
+  it("hard opt-out wins over everything", () => {
+    const decision = resolveTrajectoryGate({
+      ELIZA_DISABLE_TRAJECTORY_LOGGING: "1",
+      ELIZA_TRAJECTORY_LOGGING: "1",
+      ELIZA_TRAJECTORY_RECORDING: "1",
+      NODE_ENV: "development",
+    } as NodeJS.ProcessEnv);
+    expect(decision.enabled).toBe(false);
+    expect(decision.reason).toBe("disable-flag");
+  });
 
-	it("explicit ELIZA_TRAJECTORY_LOGGING overrides NODE_ENV and the legacy alias", () => {
-		expect(
-			gate({ ELIZA_TRAJECTORY_LOGGING: "1", NODE_ENV: "production" }),
-		).toBe(true);
-		expect(
-			gate({ ELIZA_TRAJECTORY_LOGGING: "0", NODE_ENV: "development" }),
-		).toBe(false);
-		expect(
-			gate({
-				ELIZA_TRAJECTORY_LOGGING: "1",
-				ELIZA_TRAJECTORY_RECORDING: "0",
-			}),
-		).toBe(true);
-	});
+  it("explicit ELIZA_TRAJECTORY_LOGGING overrides NODE_ENV and the legacy alias", () => {
+    expect(
+      gate({ ELIZA_TRAJECTORY_LOGGING: "1", NODE_ENV: "production" }),
+    ).toBe(true);
+    expect(
+      gate({ ELIZA_TRAJECTORY_LOGGING: "0", NODE_ENV: "development" }),
+    ).toBe(false);
+    expect(
+      gate({
+        ELIZA_TRAJECTORY_LOGGING: "1",
+        ELIZA_TRAJECTORY_RECORDING: "0",
+      }),
+    ).toBe(true);
+  });
 
-	it("coerces truthy/falsey strings for the explicit knob", () => {
-		for (const v of ["1", "true", "yes", "on", "TRUE", " On "]) {
-			expect(gate({ ELIZA_TRAJECTORY_LOGGING: v })).toBe(true);
-		}
-		for (const v of ["0", "false", "no", "off", "nonsense"]) {
-			expect(gate({ ELIZA_TRAJECTORY_LOGGING: v })).toBe(false);
-		}
-	});
+  it("coerces truthy/falsey strings for the explicit knob", () => {
+    for (const v of ["1", "true", "yes", "on", "TRUE", " On "]) {
+      expect(gate({ ELIZA_TRAJECTORY_LOGGING: v })).toBe(true);
+    }
+    for (const v of ["0", "false", "no", "off", "nonsense"]) {
+      expect(gate({ ELIZA_TRAJECTORY_LOGGING: v })).toBe(false);
+    }
+  });
 
-	it("treats a blank/whitespace-only explicit knob as unset, not opt-out (#13802)", () => {
-		// An empty `.env` line (`ELIZA_TRAJECTORY_LOGGING=`) must not silently
-		// disable dev recording — it falls through to the NODE_ENV default.
-		for (const blank of ["", " ", "\t"]) {
-			const dev = resolveTrajectoryGate({
-				ELIZA_TRAJECTORY_LOGGING: blank,
-				NODE_ENV: "development",
-			} as NodeJS.ProcessEnv);
-			expect(dev.enabled).toBe(true);
-			expect(dev.reason).toBe("dev-default-on");
+  it("treats a blank/whitespace-only explicit knob as unset, not opt-out (#13802)", () => {
+    // An empty `.env` line (`ELIZA_TRAJECTORY_LOGGING=`) must not silently
+    // disable dev recording — it falls through to the NODE_ENV default.
+    for (const blank of ["", " ", "\t"]) {
+      const dev = resolveTrajectoryGate({
+        ELIZA_TRAJECTORY_LOGGING: blank,
+        NODE_ENV: "development",
+      } as NodeJS.ProcessEnv);
+      expect(dev.enabled).toBe(true);
+      expect(dev.reason).toBe("dev-default-on");
 
-			const prod = resolveTrajectoryGate({
-				ELIZA_TRAJECTORY_LOGGING: blank,
-				NODE_ENV: "production",
-			} as NodeJS.ProcessEnv);
-			expect(prod.enabled).toBe(false);
-			expect(prod.reason).toBe("production-opt-in");
-		}
-		// A blank canonical knob also falls through to the legacy alias.
-		expect(
-			gate({
-				ELIZA_TRAJECTORY_LOGGING: "",
-				ELIZA_TRAJECTORY_RECORDING: "1",
-				NODE_ENV: "production",
-			}),
-		).toBe(true);
-	});
+      const prod = resolveTrajectoryGate({
+        ELIZA_TRAJECTORY_LOGGING: blank,
+        NODE_ENV: "production",
+      } as NodeJS.ProcessEnv);
+      expect(prod.enabled).toBe(false);
+      expect(prod.reason).toBe("production-opt-in");
+    }
+    // A blank canonical knob also falls through to the legacy alias.
+    expect(
+      gate({
+        ELIZA_TRAJECTORY_LOGGING: "",
+        ELIZA_TRAJECTORY_RECORDING: "1",
+        NODE_ENV: "production",
+      }),
+    ).toBe(true);
+  });
 
-	it("honors the legacy ELIZA_TRAJECTORY_RECORDING alias when the canonical knob is unset", () => {
-		expect(
-			gate({ ELIZA_TRAJECTORY_RECORDING: "0", NODE_ENV: "development" }),
-		).toBe(false);
-		expect(
-			gate({ ELIZA_TRAJECTORY_RECORDING: "1", NODE_ENV: "production" }),
-		).toBe(true);
-	});
+  it("honors the legacy ELIZA_TRAJECTORY_RECORDING alias when the canonical knob is unset", () => {
+    expect(
+      gate({ ELIZA_TRAJECTORY_RECORDING: "0", NODE_ENV: "development" }),
+    ).toBe(false);
+    expect(
+      gate({ ELIZA_TRAJECTORY_RECORDING: "1", NODE_ENV: "production" }),
+    ).toBe(true);
+  });
 
-	it("test NODE_ENV is off by default", () => {
-		const decision = resolveTrajectoryGate({
-			NODE_ENV: "test",
-		} as NodeJS.ProcessEnv);
-		expect(decision.enabled).toBe(false);
-		expect(decision.reason).toBe("test-default-off");
-	});
+  it("test NODE_ENV is off by default", () => {
+    const decision = resolveTrajectoryGate({
+      NODE_ENV: "test",
+    } as NodeJS.ProcessEnv);
+    expect(decision.enabled).toBe(false);
+    expect(decision.reason).toBe("test-default-off");
+  });
 
-	it("production NODE_ENV is opt-in (off by default, SOC2 O-5)", () => {
-		const decision = resolveTrajectoryGate({
-			NODE_ENV: "production",
-		} as NodeJS.ProcessEnv);
-		expect(decision.enabled).toBe(false);
-		expect(decision.reason).toBe("production-opt-in");
-	});
+  it("production NODE_ENV is opt-in (off by default, SOC2 O-5)", () => {
+    const decision = resolveTrajectoryGate({
+      NODE_ENV: "production",
+    } as NodeJS.ProcessEnv);
+    expect(decision.enabled).toBe(false);
+    expect(decision.reason).toBe("production-opt-in");
+  });
 
-	it("dev / unset NODE_ENV is on by default", () => {
-		expect(
-			resolveTrajectoryGate({ NODE_ENV: "development" } as NodeJS.ProcessEnv)
-				.reason,
-		).toBe("dev-default-on");
-		expect(gate({})).toBe(true);
-	});
+  it("dev / unset NODE_ENV is on by default", () => {
+    expect(
+      resolveTrajectoryGate({ NODE_ENV: "development" } as NodeJS.ProcessEnv)
+        .reason,
+    ).toBe("dev-default-on");
+    expect(gate({})).toBe(true);
+  });
 });
 
 describe("recorder wrapper agrees with the gate", () => {
-	it("isTrajectoryRecordingEnabled reflects resolveTrajectoryGate(process.env)", () => {
-		// The file-recorder wrapper reads process.env directly; assert it matches
-		// the resolver for whatever the ambient env currently is.
-		expect(isTrajectoryRecordingEnabled()).toBe(
-			resolveTrajectoryGate(process.env).enabled,
-		);
-	});
+  it("isTrajectoryRecordingEnabled reflects resolveTrajectoryGate(process.env)", () => {
+    // The file-recorder wrapper reads process.env directly; assert it matches
+    // the resolver for whatever the ambient env currently is.
+    expect(isTrajectoryRecordingEnabled()).toBe(
+      resolveTrajectoryGate(process.env).enabled,
+    );
+  });
 });

--- a/packages/core/src/runtime/trajectory-gate.test.ts
+++ b/packages/core/src/runtime/trajectory-gate.test.ts
@@ -43,9 +43,37 @@ describe("resolveTrajectoryGate precedence", () => {
 		for (const v of ["1", "true", "yes", "on", "TRUE", " On "]) {
 			expect(gate({ ELIZA_TRAJECTORY_LOGGING: v })).toBe(true);
 		}
-		for (const v of ["0", "false", "no", "off", "nonsense", ""]) {
+		for (const v of ["0", "false", "no", "off", "nonsense"]) {
 			expect(gate({ ELIZA_TRAJECTORY_LOGGING: v })).toBe(false);
 		}
+	});
+
+	it("treats a blank/whitespace-only explicit knob as unset, not opt-out (#13802)", () => {
+		// An empty `.env` line (`ELIZA_TRAJECTORY_LOGGING=`) must not silently
+		// disable dev recording — it falls through to the NODE_ENV default.
+		for (const blank of ["", " ", "\t"]) {
+			const dev = resolveTrajectoryGate({
+				ELIZA_TRAJECTORY_LOGGING: blank,
+				NODE_ENV: "development",
+			} as NodeJS.ProcessEnv);
+			expect(dev.enabled).toBe(true);
+			expect(dev.reason).toBe("dev-default-on");
+
+			const prod = resolveTrajectoryGate({
+				ELIZA_TRAJECTORY_LOGGING: blank,
+				NODE_ENV: "production",
+			} as NodeJS.ProcessEnv);
+			expect(prod.enabled).toBe(false);
+			expect(prod.reason).toBe("production-opt-in");
+		}
+		// A blank canonical knob also falls through to the legacy alias.
+		expect(
+			gate({
+				ELIZA_TRAJECTORY_LOGGING: "",
+				ELIZA_TRAJECTORY_RECORDING: "1",
+				NODE_ENV: "production",
+			}),
+		).toBe(true);
 	});
 
 	it("honors the legacy ELIZA_TRAJECTORY_RECORDING alias when the canonical knob is unset", () => {

--- a/packages/core/src/runtime/trajectory-gate.ts
+++ b/packages/core/src/runtime/trajectory-gate.ts
@@ -26,16 +26,16 @@ const TRUTHY = new Set(["1", "true", "yes", "on"]);
  * opt-out and coerces to false.
  */
 function coerceFlag(raw: string | undefined): boolean | undefined {
-	if (raw === undefined) return undefined;
-	const trimmed = raw.trim();
-	if (trimmed === "") return undefined;
-	return TRUTHY.has(trimmed.toLowerCase());
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  return TRUTHY.has(trimmed.toLowerCase());
 }
 
 export interface TrajectoryGateDecision {
-	enabled: boolean;
-	/** Which precedence tier decided, for diagnostics/logging. */
-	reason: string;
+  enabled: boolean;
+  /** Which precedence tier decided, for diagnostics/logging. */
+  reason: string;
 }
 
 /**
@@ -50,29 +50,29 @@ export interface TrajectoryGateDecision {
  *   6. otherwise (dev / unset NODE_ENV) — on, for local debugging.
  */
 export function resolveTrajectoryGate(
-	env: NodeJS.ProcessEnv = process.env,
+  env: NodeJS.ProcessEnv = process.env,
 ): TrajectoryGateDecision {
-	if (env.ELIZA_DISABLE_TRAJECTORY_LOGGING === "1") {
-		return { enabled: false, reason: "disable-flag" };
-	}
+  if (env.ELIZA_DISABLE_TRAJECTORY_LOGGING === "1") {
+    return { enabled: false, reason: "disable-flag" };
+  }
 
-	const explicit = coerceFlag(env.ELIZA_TRAJECTORY_LOGGING);
-	if (explicit !== undefined) {
-		return { enabled: explicit, reason: "explicit-logging" };
-	}
+  const explicit = coerceFlag(env.ELIZA_TRAJECTORY_LOGGING);
+  if (explicit !== undefined) {
+    return { enabled: explicit, reason: "explicit-logging" };
+  }
 
-	const legacy = coerceFlag(env.ELIZA_TRAJECTORY_RECORDING);
-	if (legacy !== undefined) {
-		return { enabled: legacy, reason: "explicit-recording-legacy" };
-	}
+  const legacy = coerceFlag(env.ELIZA_TRAJECTORY_RECORDING);
+  if (legacy !== undefined) {
+    return { enabled: legacy, reason: "explicit-recording-legacy" };
+  }
 
-	if (env.NODE_ENV === "test") {
-		return { enabled: false, reason: "test-default-off" };
-	}
+  if (env.NODE_ENV === "test") {
+    return { enabled: false, reason: "test-default-off" };
+  }
 
-	if (env.NODE_ENV === "production") {
-		return { enabled: false, reason: "production-opt-in" };
-	}
+  if (env.NODE_ENV === "production") {
+    return { enabled: false, reason: "production-opt-in" };
+  }
 
-	return { enabled: true, reason: "dev-default-on" };
+  return { enabled: true, reason: "dev-default-on" };
 }

--- a/packages/core/src/runtime/trajectory-gate.ts
+++ b/packages/core/src/runtime/trajectory-gate.ts
@@ -18,12 +18,18 @@ const TRUTHY = new Set(["1", "true", "yes", "on"]);
 
 /**
  * Coerce a raw env value to a boolean. Returns undefined when the var is unset
- * (so the caller can fall through to the next precedence tier); a set-but-not-
- * truthy value coerces to false (an explicit opt-out).
+ * or blank/whitespace-only — a set-but-empty entry (an empty `.env` line,
+ * `ELIZA_TRAJECTORY_LOGGING=`) is treated as unset so the caller falls through
+ * to the next precedence tier rather than reading as an explicit opt-out, per
+ * the repo's blank-is-unset env contract (`presentEnvValue`, boot-env.ts;
+ * #13802). A set, non-blank, non-truthy value ("0"/"false"/…) is an explicit
+ * opt-out and coerces to false.
  */
 function coerceFlag(raw: string | undefined): boolean | undefined {
 	if (raw === undefined) return undefined;
-	return TRUTHY.has(raw.trim().toLowerCase());
+	const trimmed = raw.trim();
+	if (trimmed === "") return undefined;
+	return TRUTHY.has(trimmed.toLowerCase());
 }
 
 export interface TrajectoryGateDecision {

--- a/packages/scenario-runner/AGENTS.md
+++ b/packages/scenario-runner/AGENTS.md
@@ -130,6 +130,7 @@ bun run --cwd packages/scenario-runner clean
 | `ELIZA_SCENARIO_PGLITE_DIR` / `SCENARIO_PGLITE_DIR` | Override the temp PGLite directory |
 | `ELIZA_SAVE_TRAJECTORIES` / `SCENARIO_SAVE_TRAJECTORIES` | `1` = preserve PGLite DB after run |
 | `ELIZA_TRAJECTORY_DIR` | Set by CLI when `--run-dir` is active; picked up by the trajectory recorder |
+| `ELIZA_TRAJECTORY_LOGGING` | Set to `1` by `eliza-scenarios run` when the operator has not already set it, so bare scenario runs record trajectories even when `NODE_ENV=test|production`; explicit `0` and `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` are respected |
 | `ELIZA_LIFEOPS_RUN_ID` | Injected by CLI; tags trajectories with the run ID |
 | `ELIZA_LIFEOPS_SCENARIO_ID` | Injected per scenario so trajectory files are tagged correctly |
 | `ELIZA_DISABLE_ACTIVITY_TRACKER` | Set to `1` by the runtime factory; suppresses activity-tracker background work |

--- a/packages/scenario-runner/CLAUDE.md
+++ b/packages/scenario-runner/CLAUDE.md
@@ -130,6 +130,7 @@ bun run --cwd packages/scenario-runner clean
 | `ELIZA_SCENARIO_PGLITE_DIR` / `SCENARIO_PGLITE_DIR` | Override the temp PGLite directory |
 | `ELIZA_SAVE_TRAJECTORIES` / `SCENARIO_SAVE_TRAJECTORIES` | `1` = preserve PGLite DB after run |
 | `ELIZA_TRAJECTORY_DIR` | Set by CLI when `--run-dir` is active; picked up by the trajectory recorder |
+| `ELIZA_TRAJECTORY_LOGGING` | Set to `1` by `eliza-scenarios run` when the operator has not already set it, so bare scenario runs record trajectories even when `NODE_ENV=test|production`; explicit `0` and `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` are respected |
 | `ELIZA_LIFEOPS_RUN_ID` | Injected by CLI; tags trajectories with the run ID |
 | `ELIZA_LIFEOPS_SCENARIO_ID` | Injected per scenario so trajectory files are tagged correctly |
 | `ELIZA_DISABLE_ACTIVITY_TRACKER` | Set to `1` by the runtime factory; suppresses activity-tracker background work |

--- a/packages/scenario-runner/README.md
+++ b/packages/scenario-runner/README.md
@@ -93,6 +93,8 @@ eliza-scenarios run  <dir>
 | `SKIP_REASON` | Set to allow intentional scenario skips without exit code 2 |
 | `SCENARIO_INCLUDE_PENDING` | `1` = include `status: "pending"` scenarios |
 | `ELIZA_BENCH_SKIP_EMBEDDING` | Default `1`; set to `0` for real local-inference embeddings |
+| `ELIZA_TRAJECTORY_LOGGING` | The `run` command sets this to `1` when the operator has not already set it, so scenario trajectories are recorded even under `NODE_ENV=test` or `NODE_ENV=production`; explicit `0` and `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` are respected |
+| `ELIZA_TRAJECTORY_DIR` | Set automatically when `--run-dir` or `--export-native` creates an effective run directory; otherwise the recorder falls back to the state-dir trajectories path |
 
 Any one of `GROQ_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, or `OPENROUTER_API_KEY` satisfies the live-provider requirement when not in proxy mode.
 

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -24,6 +24,7 @@ import {
   loadAllScenarios,
   validateScenarioCorpus,
 } from "./loader.ts";
+import { shouldOptInScenarioTrajectoryLogging } from "./trajectory-opt-in.ts";
 import type { ScenarioReport } from "./types.ts";
 
 const SCENARIO_LANES: readonly ScenarioLane[] = [
@@ -314,15 +315,19 @@ async function main(): Promise<number> {
           `scenario-run-${effectiveRunId}`,
         )
       : undefined);
+  // Opt the recorder in for the whole run (see the helper's rationale) — this
+  // is hoisted out of the `effectiveRunDir` branch so a bare run under
+  // NODE_ENV=test|production still captures the per-turn traces it aggregates.
+  // The recorder falls back to `${stateDir}/trajectories` when
+  // ELIZA_TRAJECTORY_DIR is unset (resolveTrajectoryDir, trajectory-recorder.ts).
+  if (shouldOptInScenarioTrajectoryLogging()) {
+    process.env.ELIZA_TRAJECTORY_LOGGING = "1";
+  }
   if (effectiveRunDir) {
     const trajectoryDir = path.join(effectiveRunDir, "trajectories");
     process.env.ELIZA_TRAJECTORY_DIR = trajectoryDir;
     process.env.ELIZA_LIFEOPS_RUN_ID = effectiveRunId;
     process.env.ELIZA_LIFEOPS_RUN_DIR = effectiveRunDir;
-    // The recorder default flipped to opt-in for prod/test (#13775); a scenario
-    // run capturing trajectories must opt in explicitly so the per-turn traces
-    // this run then aggregates/exports are actually written.
-    process.env.ELIZA_TRAJECTORY_LOGGING = "1";
     logger.info(
       `[eliza-scenarios] run-dir: ${effectiveRunDir} (trajectories → ${trajectoryDir}, runId=${effectiveRunId})`,
     );

--- a/packages/scenario-runner/src/trajectory-opt-in.test.ts
+++ b/packages/scenario-runner/src/trajectory-opt-in.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit truth-table for the scenario-runner's trajectory opt-in decision
+ * (`shouldOptInScenarioTrajectoryLogging`). Pure env in, boolean out — asserts a
+ * bare `run` opts in regardless of --run-dir (#14111) while an operator-set knob
+ * is respected. No runtime, no filesystem.
+ */
+
+import { describe, expect, it } from "vitest";
+import { shouldOptInScenarioTrajectoryLogging } from "./trajectory-opt-in.ts";
+
+describe("shouldOptInScenarioTrajectoryLogging", () => {
+  it("opts in when the knob is unset — a bare run must still capture", () => {
+    expect(shouldOptInScenarioTrajectoryLogging({} as NodeJS.ProcessEnv)).toBe(
+      true,
+    );
+    expect(
+      shouldOptInScenarioTrajectoryLogging({
+        NODE_ENV: "test",
+      } as NodeJS.ProcessEnv),
+    ).toBe(true);
+    expect(
+      shouldOptInScenarioTrajectoryLogging({
+        NODE_ENV: "production",
+      } as NodeJS.ProcessEnv),
+    ).toBe(true);
+  });
+
+  it("respects an operator-set knob, including an explicit opt-out", () => {
+    expect(
+      shouldOptInScenarioTrajectoryLogging({
+        ELIZA_TRAJECTORY_LOGGING: "1",
+      } as NodeJS.ProcessEnv),
+    ).toBe(false);
+    expect(
+      shouldOptInScenarioTrajectoryLogging({
+        ELIZA_TRAJECTORY_LOGGING: "0",
+      } as NodeJS.ProcessEnv),
+    ).toBe(false);
+  });
+});

--- a/packages/scenario-runner/src/trajectory-opt-in.ts
+++ b/packages/scenario-runner/src/trajectory-opt-in.ts
@@ -1,0 +1,22 @@
+/**
+ * The scenario runner's trajectory recording opt-in decision, isolated from the
+ * CLI entry so it is unit-testable without executing `main()` (cli.ts runs on
+ * import). The recorder default flipped to opt-in for `NODE_ENV=production|test`
+ * (#13775/#13871), so a bare `eliza-scenarios run <scenario>` under those envs
+ * would otherwise capture nothing — even though scenario trajectories are
+ * required PR evidence. A run is trajectory evidence by definition, so it opts
+ * in unconditionally, regardless of `--run-dir`/`--export-native` (#14111). An
+ * operator-set `ELIZA_TRAJECTORY_LOGGING` is respected (including an explicit
+ * `0`); the hard `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` opt-out is enforced
+ * downstream by the gate resolver, which honors it above this knob.
+ */
+
+/**
+ * Whether the scenario runner should set `ELIZA_TRAJECTORY_LOGGING="1"`.
+ * Returns `false` when the operator already set the knob (respect their value).
+ */
+export function shouldOptInScenarioTrajectoryLogging(
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	return !env.ELIZA_TRAJECTORY_LOGGING;
+}

--- a/packages/scenario-runner/src/trajectory-opt-in.ts
+++ b/packages/scenario-runner/src/trajectory-opt-in.ts
@@ -16,7 +16,7 @@
  * Returns `false` when the operator already set the knob (respect their value).
  */
 export function shouldOptInScenarioTrajectoryLogging(
-	env: NodeJS.ProcessEnv = process.env,
+  env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-	return !env.ELIZA_TRAJECTORY_LOGGING;
+  return !env.ELIZA_TRAJECTORY_LOGGING;
 }

--- a/packages/training/AGENTS.md
+++ b/packages/training/AGENTS.md
@@ -18,6 +18,14 @@ applies to everything under `packages/training/`.
   recorder. The state dir resolves (see `packages/core/src/utils/state-dir.ts`)
   as `ELIZA_STATE_DIR` → `$XDG_STATE_HOME/eliza` → `~/.local/state/eliza` — NOT
   `~/.eliza/state`. No database dependency.
+  - **Recording gate (`resolveTrajectoryGate`,
+    `packages/core/src/runtime/trajectory-gate.ts`):** capture is **opt-in in
+    `NODE_ENV=production` and `test`, default-on in dev/unset**. Precedence,
+    first match wins: `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` (hard off) →
+    `ELIZA_TRAJECTORY_LOGGING` (canonical truthy/falsey knob; blank =
+    unset) → legacy `ELIZA_TRAJECTORY_RECORDING` alias → the `NODE_ENV`
+    default. To collect RL data in prod/test you must set
+    `ELIZA_TRAJECTORY_LOGGING=1`; the scenario runner sets it automatically.
 
 Do not edit configs to point at non-Gemma base names or OpenAI judges —
 the lock above is the product contract.

--- a/packages/training/CLAUDE.md
+++ b/packages/training/CLAUDE.md
@@ -18,6 +18,14 @@ applies to everything under `packages/training/`.
   recorder. The state dir resolves (see `packages/core/src/utils/state-dir.ts`)
   as `ELIZA_STATE_DIR` → `$XDG_STATE_HOME/eliza` → `~/.local/state/eliza` — NOT
   `~/.eliza/state`. No database dependency.
+  - **Recording gate (`resolveTrajectoryGate`,
+    `packages/core/src/runtime/trajectory-gate.ts`):** capture is **opt-in in
+    `NODE_ENV=production` and `test`, default-on in dev/unset**. Precedence,
+    first match wins: `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` (hard off) →
+    `ELIZA_TRAJECTORY_LOGGING` (canonical truthy/falsey knob; blank =
+    unset) → legacy `ELIZA_TRAJECTORY_RECORDING` alias → the `NODE_ENV`
+    default. To collect RL data in prod/test you must set
+    `ELIZA_TRAJECTORY_LOGGING=1`; the scenario runner sets it automatically.
 
 Do not edit configs to point at non-Gemma base names or OpenAI judges —
 the lock above is the product contract.

--- a/packages/training/SECURITY.md
+++ b/packages/training/SECURITY.md
@@ -29,9 +29,17 @@ customer-data. The current ``consent_proof_uri`` points back to this
 document because the production opt-in flow is still in design (see
 "open items" below). The provisional control is:
 
-  - Local-only ``~/.eliza/training/datasets/`` writes happen ONLY when
-    ``ELIZA_DISABLE_TRAJECTORY_LOGGING`` is unset (default opt-in for
-    dogfooders, will flip to opt-out once the consent UI ships).
+  - Local-only ``~/.eliza/training/datasets/`` writes are gated by the
+    single trajectory resolver (``resolveTrajectoryGate``,
+    ``packages/core/src/runtime/trajectory-gate.ts``). Precedence, first
+    match wins: (1) ``ELIZA_DISABLE_TRAJECTORY_LOGGING=1`` — hard opt-out;
+    (2) ``ELIZA_TRAJECTORY_LOGGING`` explicit truthy/falsey — canonical
+    operator knob (blank/whitespace = unset, falls through); (3) the legacy
+    ``ELIZA_TRAJECTORY_RECORDING`` alias; then the ``NODE_ENV`` defaults —
+    **off in ``production`` (SOC2 O-5: opt-in only) and in ``test``, on in
+    dev/unset**. So in production, capture happens ONLY when an operator sets
+    ``ELIZA_TRAJECTORY_LOGGING=1`` (not merely when the disable flag is
+    absent). This will flip to a consent-UI opt-out once that ships.
   - The privacy filter runs ``--strict`` by default
     ([``scripts/privacy_filter_trajectories.py``](scripts/privacy_filter_trajectories.py)).
   - Nubilio data is internal-dogfood collected from a self-hosted bot the


### PR DESCRIPTION
Fixes #14111.

Three residual gaps from the #13871 trajectory-recording gate (post-merge audit for epic #13766).

## What changed

**1. Documented the gate tiers (was undocumented).** `#13871` flipped the file recorder to opt-in for `NODE_ENV=production|test`, but no doc mentioned it and `packages/training/SECURITY.md:33` still described capture as default-on gated only by `ELIZA_DISABLE_TRAJECTORY_LOGGING`. Rewrote that bullet and added a "recording gate" paragraph to `packages/training/CLAUDE.md` + `AGENTS.md` spelling out the full `resolveTrajectoryGate` precedence.

**2. Blank env no longer silently disables dev recording.** `coerceFlag` treated a set-but-blank `ELIZA_TRAJECTORY_LOGGING=""` (an empty `.env` line) as an explicit opt-out. Now blank/whitespace-only coerces to `undefined` (unset), falling through to the `NODE_ENV` default — matching the repo's blank-is-unset env contract (`presentEnvValue`, `packages/core/src/boot-env.ts:124`; #13802).

**3. Scenario CLI opts in unconditionally.** The `ELIZA_TRAJECTORY_LOGGING = "1"` assignment lived inside the `if (effectiveRunDir)` branch, so a bare `eliza-scenarios run <scenario>` (no `--run-dir`/`--export-native`) under `NODE_ENV=test|production` captured **no trajectories** — despite scenario trajectories being required PR evidence. Hoisted the opt-in out of the branch into a pure, unit-tested helper `shouldOptInScenarioTrajectoryLogging` (`packages/scenario-runner/src/trajectory-opt-in.ts`) that respects an operator-set knob (including an explicit `0`); the hard `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` opt-out is still enforced downstream by the gate. The recorder falls back to `${stateDir}/trajectories` when `ELIZA_TRAJECTORY_DIR` is unset (`resolveTrajectoryDir`), so a dir-less run still writes.

## Evidence

Real deterministic truth-table tests drive the actual decision functions (pure env → boolean; no mocks):

```
$ bun test packages/core/src/runtime/trajectory-gate.test.ts
 9 pass  0 fail  38 expect() calls

$ bun test packages/scenario-runner/src/trajectory-opt-in.test.ts
 2 pass  0 fail  5 expect() calls
```

New `trajectory-gate.test.ts` case asserts blank (`""`, `" "`, `"\t"`) falls through to the `NODE_ENV` default (dev→on, prod→opt-in-off) and to the legacy alias, replacing the old assertion that `""` opted out. New `trajectory-opt-in.test.ts` asserts a bare run opts in under `test`/`production`/unset while an operator-set knob (`1` or `0`) is respected.

Scoped typecheck: no errors in any touched file (`trajectory-gate.ts`, `cli.ts`, `trajectory-opt-in.ts`). Remaining package typecheck noise is pre-existing unbuilt-workspace-dep / unrelated-UI errors, not from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)