### PR TITLE
fix(orchestrator): route operator status writes through the transition table (#14105)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -1217,6 +1217,90 @@ describe("OrchestratorTaskService — task status guards", () => {
     expect(detail.status).toBe("interrupted");
     expect(must(detail.sessions[0], "session").status).toBe("stop_failed");
   });
+
+  // #14105: the operator stop paths used to write `status: "interrupted"`
+  // directly, so a terminal task (done/failed/archived) still holding a live
+  // keepAlive session whose ACP stop fails was stomped to `interrupted` —
+  // `done → interrupted` is not a legal transition-table edge and this broke the
+  // terminal-immutability invariant #13830 enforces. Routing through
+  // advanceTaskStatus makes the illegal edge a no-op.
+  it("does NOT move a terminal `done` task to interrupted when stopTaskAgent hits an unavailable ACP", async () => {
+    const { service, store } = makeServiceWithStore();
+    const task = await service.createTask(createInput());
+    const sessionId = await addStoredSession(store, task.id);
+    // Terminal `done` while a `ready` (live) session is still on the record.
+    await store.updateTask(task.id, {
+      status: "done",
+      closedAt: new Date().toISOString(),
+    });
+
+    await expect(service.stopTaskAgent(task.id, sessionId)).rejects.toThrow(
+      /ACP service unavailable/,
+    );
+
+    const detail = must(await service.getTask(task.id), "detail");
+    expect(detail.status).toBe("done");
+    // The session-level stop failure is still recorded for observability.
+    expect(must(detail.sessions[0], "session").status).toBe("stop_failed");
+  });
+
+  it("does NOT regress a terminal `done` task to interrupted when archive's session stop fails", async () => {
+    const acp = new FakeAcp();
+    const { service, store } = makeServiceWithStore(acp);
+    await service.start();
+    const task = await service.createTask(createInput());
+    const sessionId = await addStoredSession(store, task.id);
+    await store.updateTask(task.id, {
+      status: "done",
+      closedAt: new Date().toISOString(),
+    });
+    acp.failStop = true;
+
+    // stopActiveSessions throws on the failed stop before archive fields land;
+    // the terminal task must stay `done` (pre-#14105 it was stomped to
+    // `interrupted` first — `done → interrupted` is an illegal edge).
+    await expect(service.archiveTask(task.id)).rejects.toThrow(
+      /Failed to stop/,
+    );
+    const detail = must(await service.getTask(task.id), "detail");
+    expect(detail.status).toBe("done");
+    expect(must(detail.sessions[0], "session").status).toBe("stop_failed");
+    void sessionId;
+  });
+
+  it("archives a terminal `done` task through the transition table when no live session blocks the stop", async () => {
+    const { service, store } = makeServiceWithStore();
+    const task = await service.createTask(createInput());
+    await store.updateTask(task.id, {
+      status: "done",
+      closedAt: new Date().toISOString(),
+    });
+
+    // No active sessions → stopActiveSessions is a no-op → archive resolves the
+    // target via nextTaskStatus(done, "archived") (a live table edge, not a
+    // literal write).
+    const archived = must(await service.archiveTask(task.id), "archived");
+    expect(archived.status).toBe("archived");
+    expect(archived.archivedAt).toBeTruthy();
+  });
+
+  it("still interrupts a NON-terminal task when archive's session stop fails", async () => {
+    const acp = new FakeAcp();
+    const { service, store } = makeServiceWithStore(acp);
+    await service.start();
+    const task = await service.createTask(createInput());
+    await addStoredSession(store, task.id); // leaves task `active`
+    acp.failStop = true;
+
+    // stopActiveSessions throws a RecoveryConflictError on the failed stop; the
+    // active task legally advances to `interrupted` (active → interrupted is a
+    // table edge) before the throw, so archive is not reached.
+    await expect(service.archiveTask(task.id)).rejects.toThrow(
+      /Failed to stop/,
+    );
+    const detail = must(await service.getTask(task.id), "detail");
+    expect(detail.status).toBe("interrupted");
+  });
 });
 
 describe("OrchestratorTaskService — usage telemetry", () => {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -117,6 +117,7 @@ import {
   type CreateTaskInput,
   MAX_ATTEMPT_REFLECTIONS,
   MAX_SESSION_RETRY_ATTEMPTS,
+  nextTaskStatus,
   type OrchestratorAccountAssignment,
   type OrchestratorAccountOverview,
   type OrchestratorRoomParticipant,
@@ -2169,9 +2170,16 @@ export class OrchestratorTaskService extends Service {
     if (!doc) return null;
     await this.dequeueAdmission(taskId);
     await this.stopActiveSessions(doc);
+    // Re-read after stopActiveSessions, which may have advanced the status, and
+    // resolve the archive target through the transition table rather than
+    // writing `"archived"` literally: the `archived` trigger is legal from every
+    // state, so this is total, but going through the table keeps that table row
+    // live (a legality regression there now fails this write) instead of dead
+    // documentation the operator path silently bypasses.
+    const current = (await this.store.getTask(taskId)) ?? doc;
     await this.store.updateTask(taskId, {
       archived: true,
-      status: "archived",
+      status: nextTaskStatus(current.task.status, "archived"),
       archivedAt: nowIso(),
       closedAt: doc.task.closedAt ?? nowIso(),
     });
@@ -3736,7 +3744,12 @@ export class OrchestratorTaskService extends Service {
     const acp = this.acp();
     if (!acp) {
       await this.store.updateSession(sessionId, { status: "stop_failed" });
-      await this.store.updateTask(taskId, { status: "interrupted" });
+      // Route through the transition table: a task that already reached a
+      // terminal state (done/failed/archived) but still holds a live keepAlive
+      // session whose stop we can't attempt must NOT be stomped to `interrupted`
+      // — `done → interrupted` has no table edge, so this is a legal no-op there
+      // and only interrupts a genuinely non-terminal task.
+      await this.advanceTaskStatus(taskId, "interrupted");
       throw new Error("ACP service unavailable; cannot stop active session");
     }
     try {
@@ -3974,7 +3987,7 @@ export class OrchestratorTaskService extends Service {
           }),
         ),
       );
-      await this.store.updateTask(doc.task.id, { status: "interrupted" });
+      await this.advanceTaskStatus(doc.task.id, "interrupted");
       throw new RecoveryConflictError(
         "ACP service unavailable; cannot stop active sessions",
       );
@@ -4001,7 +4014,10 @@ export class OrchestratorTaskService extends Service {
       }),
     );
     if (failures.length > 0) {
-      await this.store.updateTask(doc.task.id, { status: "interrupted" });
+      // A terminal task holding a live keepAlive session whose ACP stop fails
+      // must not regress to `interrupted`; the table makes that a legal no-op
+      // while still interrupting a non-terminal one.
+      await this.advanceTaskStatus(doc.task.id, "interrupted");
       throw new RecoveryConflictError(
         `Failed to stop ${failures.length} active session${
           failures.length === 1 ? "" : "s"


### PR DESCRIPTION
## What & why

Post-merge audit finding on PR #13830 (epic #13766, WS1 lifecycle). The operator lifecycle paths wrote task status **directly** instead of going through the legal-transition table #13830 introduced, producing two related gaps.

### Defect 1 — direct `interrupted` writes could move a terminal task

`stopTaskAgent` and `stopActiveSessions` (two sites) wrote `store.updateTask(taskId, { status: "interrupted" })` on the ACP-unavailable / stop-failure paths, bypassing `nextTaskStatus`/`TASK_STATUS_TRANSITIONS`.

Failure scenario: `archiveTask`/`restartTask` on a `done` task that still holds a live keepAlive session whose ACP stop fails → the terminal task was stomped to `interrupted`. `done → interrupted` is **not** a table edge; this violated the terminal-immutability invariant #13830 exists to enforce (same class of bug #14099 fixed on the auto-verify path).

### Defect 2 — `nextTaskStatus` was dead on the production path

`nextTaskStatus` was exported but consumed **only by tests**. The operator lifecycle write sites wrote `status` directly, so the `interrupted`/`archived` triggers were dead table rows — the table asserted legality that nothing enforced at the write sites.

## Fix

- The three `interrupted` writes now route through `advanceTaskStatus(taskId, "interrupted")` — a table lookup that is a **no-op on an illegal edge** (`resolveTaskTransition` returns `null`), so a terminal task is left untouched while a non-terminal one still advances to `interrupted`.
- `archiveTask` resolves its target through `nextTaskStatus(currentStatus, "archived")` (the `archived` trigger is legal from every state, so this is total) instead of writing the literal `"archived"`. This revives the `archived` table row: a legality regression there now fails this write instead of being silently bypassed.

Illegal terminal edges become legal no-ops instead of silent stomps; `nextTaskStatus` gains a real production consumer.

## Evidence

New tests in `__tests__/unit/orchestrator-task-service.test.ts` pin the fix (all pass):

| Test | Asserts |
|---|---|
| terminal `done` + unavailable ACP via `stopTaskAgent` | stays `done`; session recorded `stop_failed` |
| terminal `done` + failed stop via `archive` | stays `done` (throws before archive fields land) |
| terminal `done`, no live session, via `archive` | lands `archived` through the table edge |
| **non-terminal** task + failed stop via `archive` | still advances to `interrupted` |

Existing regression tests unchanged and green:
- `orchestrator-task-service.test.ts` (all pass)
- `task-status-transitions.test.ts`, `stop-agent.test.ts`, `archive-reopen-lifecycle.test.ts`, `control-resume-clears-paused.test.ts` — all pass.

```
Test Files  4 passed (4)     Tests  96 passed (96)   # service + transitions + archive/reopen + control
Test Files  3 passed (3)     Tests  19 passed (19)   # stop-agent + archive-reopen + control-resume
```

Scoped typecheck: no type errors in the changed files. Biome: clean.

### Scope note — `reopened` / `restarted` table rows

The `reopened`/`restarted` triggers remain unrouted (still documentation-only). Unlike `archived` (a single legal target from every state), `reopenTask`/`restartTask` compute a **conditional** status (`reopen → active` when sessions remain, else `open`; restart clears archive fields) that a single-target trigger can't express — forcing them through the table would regress their tested `reopen → active/open` semantics. Reviving those two rows requires the deeper design reconciliation (conditional-target triggers or a `reopened_fresh`/`reopened_resumed` split) and is left to the epic; a checklist comment is filed on #14105.

Fixes #14105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
