### PR TITLE
fix(orchestrator): unify spawn-workdir precedence across action + service entry points (#14108)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
@@ -16,7 +16,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   findProjectByWorkdir,
   resolveBoundProjectWorkdir,
+  resolveSpawnWorkdirPrecedence,
   resolveTaskProjectId,
+  WorkdirBindingConflictError,
 } from "../services/project-binding.ts";
 
 describe("project-binding", () => {
@@ -98,5 +100,73 @@ describe("project-binding", () => {
     } finally {
       rmSync(legacyDir, { recursive: true, force: true });
     }
+  });
+
+  // The single precedence resolver both entry points (SPAWN_AGENT action and
+  // OrchestratorTaskService.spawnAgentForTask) share, so identical operator
+  // input lands identically regardless of path (#14108).
+  describe("resolveSpawnWorkdirPrecedence", () => {
+    it("prefers project localPath over explicit and bound workdir", () => {
+      const projectDir = realpathSync(os.tmpdir());
+      expect(
+        resolveSpawnWorkdirPrecedence({
+          projectWorkdir: projectDir,
+          explicitWorkdir: undefined,
+          boundWorkdir: "/tmp/bound",
+        }),
+      ).toBe(projectDir);
+    });
+
+    it("rejects loudly when an explicit workdir conflicts with the project binding", () => {
+      expect(() =>
+        resolveSpawnWorkdirPrecedence({
+          projectWorkdir: "/tmp/project-a",
+          explicitWorkdir: "/tmp/somewhere-else",
+          boundWorkdir: undefined,
+        }),
+      ).toThrow(WorkdirBindingConflictError);
+    });
+
+    it("accepts an explicit workdir equal to the project path (realpath-normalized)", () => {
+      // A symlink pointing at the project dir must not read as a conflict.
+      const realDir = mkdtempSync(join(os.tmpdir(), "precedence-real-"));
+      const link = join(stateDir, "precedence-link");
+      symlinkSync(realDir, link);
+      try {
+        expect(
+          resolveSpawnWorkdirPrecedence({
+            projectWorkdir: realDir,
+            explicitWorkdir: link,
+            boundWorkdir: undefined,
+          }),
+        ).toBe(realDir);
+      } finally {
+        rmSync(realDir, { recursive: true, force: true });
+      }
+    });
+
+    it("falls through to explicit, then boundWorkdir, for an unbound task", () => {
+      expect(
+        resolveSpawnWorkdirPrecedence({
+          projectWorkdir: null,
+          explicitWorkdir: "/tmp/explicit",
+          boundWorkdir: "/tmp/bound",
+        }),
+      ).toBe("/tmp/explicit");
+      expect(
+        resolveSpawnWorkdirPrecedence({
+          projectWorkdir: null,
+          explicitWorkdir: undefined,
+          boundWorkdir: "/tmp/bound",
+        }),
+      ).toBe("/tmp/bound");
+      expect(
+        resolveSpawnWorkdirPrecedence({
+          projectWorkdir: undefined,
+          explicitWorkdir: undefined,
+          boundWorkdir: undefined,
+        }),
+      ).toBeUndefined();
+    });
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
@@ -10,11 +10,12 @@
 import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { IAgentRuntime } from "@elizaos/core";
+import { type IAgentRuntime, upsertProject } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AcpService } from "../services/acp-service.js";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../services/orchestrator-task-store.js";
+import { WorkdirBindingConflictError } from "../services/project-binding.js";
 import type { SpawnOptions, SpawnResult } from "../services/types.js";
 
 /** ACP stand-in that records the workdir each spawn was handed and echoes it
@@ -399,6 +400,103 @@ describe("durable task→workdir binding (#13776)", () => {
       // A follow-up spawn with no workdir reuses the attach-pinned binding.
       await service.spawnAgentForTask(taskId, { task: "continue" });
       expect(acp.spawns.at(0)?.workdir).toBe(firstDir);
+    } finally {
+      await service.stop().catch(() => undefined);
+    }
+  });
+});
+
+// The service entry point (spawnAgentForTask) resolves workdir precedence
+// through the SAME shared resolver the SPAWN_AGENT action uses, so a
+// project-bound task lands in its project's localPath and a conflicting
+// explicit workdir rejects loudly instead of silently diverging by entry
+// point (#14108). Drives the REAL service over an in-memory store + a real
+// on-disk project registry under a temp ELIZA_STATE_DIR (no mocks).
+describe("spawnAgentForTask project-binding precedence (#14108)", () => {
+  let stateDir: string;
+  let projectDir: string;
+  let savedStateDir: string | undefined;
+  let projectId: string;
+
+  beforeEach(() => {
+    stateDir = realpathSync(
+      mkdtempSync(path.join(os.tmpdir(), "task-project-binding-")),
+    );
+    projectDir = path.join(tmpRoot, "bound-project");
+    mkdirSync(projectDir, { recursive: true });
+    // resolveBoundProjectWorkdir reads the project registry from process.env;
+    // register the project under a temp state dir so the service resolves it.
+    savedStateDir = process.env.ELIZA_STATE_DIR;
+    process.env.ELIZA_STATE_DIR = stateDir;
+    projectId = upsertProject({ name: "bound", localPath: projectDir }).id;
+  });
+
+  afterEach(() => {
+    if (savedStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+    else process.env.ELIZA_STATE_DIR = savedStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  async function seedProjectTask(
+    store: OrchestratorTaskStore,
+  ): Promise<string> {
+    const detail = await store.createTask({
+      title: "Project-bound task",
+      goal: "spawn in the bound project",
+      acceptanceCriteria: [],
+      roomId: "binding-room",
+      worldId: "binding-world",
+      projectId,
+    });
+    return detail.task.id;
+  }
+
+  it("spawns a project-bound task in its project localPath even with no explicit workdir", async () => {
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const acp = makeWorkdirCapturingAcp();
+    const service = new OrchestratorTaskService(makeRuntime(acp.service), {
+      store,
+    });
+    await service.start();
+    try {
+      const taskId = await seedProjectTask(store);
+      await service.spawnAgentForTask(taskId, { task: "go" });
+      expect(acp.spawns.at(0)?.workdir).toBe(projectDir);
+    } finally {
+      await service.stop().catch(() => undefined);
+    }
+  });
+
+  it("rejects loudly when an explicit workdir conflicts with the project binding", async () => {
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const acp = makeWorkdirCapturingAcp();
+    const service = new OrchestratorTaskService(makeRuntime(acp.service), {
+      store,
+    });
+    await service.start();
+    try {
+      const taskId = await seedProjectTask(store);
+      await expect(
+        service.spawnAgentForTask(taskId, { workdir: firstDir }),
+      ).rejects.toBeInstanceOf(WorkdirBindingConflictError);
+      // The conflict is surfaced before any ACP spawn — no session leaked.
+      expect(acp.spawns.length).toBe(0);
+    } finally {
+      await service.stop().catch(() => undefined);
+    }
+  });
+
+  it("accepts an explicit workdir equal to the project localPath", async () => {
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const acp = makeWorkdirCapturingAcp();
+    const service = new OrchestratorTaskService(makeRuntime(acp.service), {
+      store,
+    });
+    await service.start();
+    try {
+      const taskId = await seedProjectTask(store);
+      await service.spawnAgentForTask(taskId, { workdir: projectDir });
+      expect(acp.spawns.at(0)?.workdir).toBe(projectDir);
     } finally {
       await service.stop().catch(() => undefined);
     }

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
@@ -519,7 +519,9 @@ describe("spawnAgentForTask explicit workdir validation", () => {
 
       await expect(
         service.spawnAgentForTask(taskId, { workdir: ` ${outsideDir} ` }),
-      ).rejects.toThrow(/workdir must be within workspace base directory or cwd/);
+      ).rejects.toThrow(
+        /workdir must be within workspace base directory or cwd/,
+      );
       expect(acp.spawns.length).toBe(0);
     } finally {
       await service.stop().catch(() => undefined);

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
@@ -502,3 +502,28 @@ describe("spawnAgentForTask project-binding precedence (#14108)", () => {
     }
   });
 });
+
+describe("spawnAgentForTask explicit workdir validation", () => {
+  it("validates a trimmed explicit workdir before spawning an unbound task", async () => {
+    const outsideDir = realpathSync(
+      mkdtempSync(path.join(os.tmpdir(), "task-workdir-outside-")),
+    );
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const acp = makeWorkdirCapturingAcp();
+    const service = new OrchestratorTaskService(makeRuntime(acp.service), {
+      store,
+    });
+    await service.start();
+    try {
+      const taskId = await seedTask(store);
+
+      await expect(
+        service.spawnAgentForTask(taskId, { workdir: ` ${outsideDir} ` }),
+      ).rejects.toThrow(/workdir must be within workspace base directory or cwd/);
+      expect(acp.spawns.length).toBe(0);
+    } finally {
+      await service.stop().catch(() => undefined);
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -53,7 +53,10 @@ import { resolveCodingBackendLogged } from "../services/coding-backend-routing.j
 import type { TaskThreadDto } from "../services/orchestrator-task-mapper.js";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
 import type { OrchestratorTaskStatus } from "../services/orchestrator-task-types.js";
-import { resolveBoundProjectWorkdir } from "../services/project-binding.js";
+import {
+  resolveBoundProjectWorkdir,
+  resolveSpawnWorkdirPrecedence,
+} from "../services/project-binding.js";
 import { normalizeRepositoryInput } from "../services/repo-input.js";
 import {
   runDurableTask,
@@ -1128,12 +1131,22 @@ async function runSpawnAgent(
     // localPath: resolve it up-front and pass it as an explicit, LOCKED workdir
     // so route/convention resolution is skipped and every session of the task
     // targets the same repo (the #13776 per-session drift fix). Unbound tasks
-    // fall through to the normal explicit/route/convention resolution.
+    // fall through to the normal explicit/route/convention resolution. Both
+    // entry points (this action and OrchestratorTaskService.spawnAgentForTask)
+    // resolve precedence through the shared resolver so the same operator input
+    // lands identically — project localPath > explicit workdir > boundWorkdir —
+    // and a conflicting explicit workdir is rejected loudly, never silently
+    // substituted by the project path (#14108).
     const boundProjectWorkdir = await resolveBoundTaskWorkdir(
       runtime,
       pickString(params, content, "taskId") ??
         pickString(params, content, "threadId"),
     );
+    const effectiveExplicitWorkdir = resolveSpawnWorkdirPrecedence({
+      projectWorkdir: boundProjectWorkdir,
+      explicitWorkdir: pickString(params, content, "workdir"),
+      boundWorkdir: undefined,
+    });
     const {
       workdir,
       route,
@@ -1142,7 +1155,7 @@ async function runSpawnAgent(
       runtime,
       task,
       routingRequest,
-      boundProjectWorkdir ?? pickString(params, content, "workdir"),
+      effectiveExplicitWorkdir,
       {
         lockWorkdir:
           boundProjectWorkdir != null ||

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -142,7 +142,11 @@ import {
   isParentAgentBrokerWired,
   PARENT_AGENT_BROKER_MANIFEST_ENTRY,
 } from "./parent-agent-broker.js";
-import { resolveTaskProjectId } from "./project-binding.js";
+import {
+  resolveBoundProjectWorkdir,
+  resolveSpawnWorkdirPrecedence,
+  resolveTaskProjectId,
+} from "./project-binding.js";
 import { buildSkillsManifest } from "./skill-manifest.js";
 import {
   configureSpendLedger,
@@ -3275,15 +3279,26 @@ export class OrchestratorTaskService extends Service {
     }
     const acp = this.acp();
     if (!acp) throw new Error("ACP service unavailable");
-    // An explicit caller workdir wins and re-pins the binding; otherwise a
-    // follow-up spawn reuses the workdir pinned at the task's first spawn so it
-    // can't silently migrate repos when routing env changes between sessions
-    // (#13776). `boundWorkdir` was validated when first pinned, so reuse skips
-    // the allow-list probe — it may point at a configured project root the
-    // probe would otherwise reject once env drifts.
-    const workdir = opts.workdir
-      ? await resolveAllowedWorkdir(opts.workdir)
-      : doc.task.boundWorkdir;
+    // Spawn workdir precedence — resolved through the SAME shared resolver the
+    // SPAWN_AGENT action uses, so the same operator input lands identically
+    // regardless of entry point (#14108): project localPath > explicit caller
+    // workdir > boundWorkdir. A project-bound task always spawns in its
+    // project's localPath (#13776); a conflicting explicit `opts.workdir`
+    // rejects loudly (WorkdirBindingConflictError) instead of being silently
+    // overridden. Project localPath and `boundWorkdir` are already-validated
+    // registered project roots, so they skip the allow-list probe (which could
+    // reject a configured root once routing env drifts); only a fresh explicit
+    // caller workdir goes through `resolveAllowedWorkdir`.
+    const projectWorkdir = resolveBoundProjectWorkdir(doc.task.projectId);
+    const resolvedWorkdir = resolveSpawnWorkdirPrecedence({
+      projectWorkdir,
+      explicitWorkdir: opts.workdir,
+      boundWorkdir: doc.task.boundWorkdir,
+    });
+    const workdir =
+      resolvedWorkdir && resolvedWorkdir === opts.workdir && !projectWorkdir
+        ? await resolveAllowedWorkdir(resolvedWorkdir)
+        : resolvedWorkdir;
 
     const policy = doc.task.providerPolicy ?? {};
     // Give every sub-agent a distinct person-name. An explicit caller label

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -3290,13 +3290,17 @@ export class OrchestratorTaskService extends Service {
     // reject a configured root once routing env drifts); only a fresh explicit
     // caller workdir goes through `resolveAllowedWorkdir`.
     const projectWorkdir = resolveBoundProjectWorkdir(doc.task.projectId);
+    const explicitWorkdir = opts.workdir?.trim() || undefined;
     const resolvedWorkdir = resolveSpawnWorkdirPrecedence({
       projectWorkdir,
-      explicitWorkdir: opts.workdir,
+      explicitWorkdir,
       boundWorkdir: doc.task.boundWorkdir,
     });
     const workdir =
-      resolvedWorkdir && resolvedWorkdir === opts.workdir && !projectWorkdir
+      resolvedWorkdir &&
+      explicitWorkdir &&
+      resolvedWorkdir === explicitWorkdir &&
+      !projectWorkdir
         ? await resolveAllowedWorkdir(resolvedWorkdir)
         : resolvedWorkdir;
 

--- a/plugins/plugin-agent-orchestrator/src/services/project-binding.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/project-binding.ts
@@ -75,3 +75,57 @@ export function resolveBoundProjectWorkdir(
   if (!id) return null;
   return getProjectById(id, env)?.localPath ?? null;
 }
+
+/**
+ * Raised when a caller passes an explicit spawn workdir that conflicts with the
+ * task's project binding. A project-bound task always spawns in its project's
+ * localPath; rather than silently substituting the project path for the
+ * operator's explicit request (which produced divergent, unobservable behavior
+ * at the action vs service entry points — #14108), the conflict is surfaced so
+ * the caller can retract the workdir or rebind the task.
+ */
+export class WorkdirBindingConflictError extends Error {
+  constructor(
+    readonly explicitWorkdir: string,
+    readonly projectWorkdir: string,
+  ) {
+    super(
+      `explicit workdir "${explicitWorkdir}" conflicts with the task's project binding "${projectWorkdir}"; ` +
+        "a project-bound task always spawns in its project's localPath — omit the explicit workdir, or rebind the task's project",
+    );
+    this.name = "WorkdirBindingConflictError";
+  }
+}
+
+/**
+ * The single source of truth for spawn-workdir precedence, shared by the action
+ * layer (`SPAWN_AGENT`) and the service layer (`spawnAgentForTask`) so the same
+ * operator input resolves identically regardless of entry point (#14108).
+ *
+ * Precedence: **project localPath > explicit caller workdir > boundWorkdir**.
+ * A project binding is authoritative — every session of a project-bound task
+ * targets the same repo (#13776). But rather than *silently* discarding an
+ * explicit caller workdir, a project-bound task rejects a conflicting explicit
+ * workdir loudly (`WorkdirBindingConflictError`); an explicit workdir equal to
+ * the project path, or absent, is accepted. Unbound tasks fall through to the
+ * explicit workdir, then the older per-first-spawn `boundWorkdir` pin.
+ *
+ * Paths are compared by realpath so symlinked / non-canonical forms of the same
+ * directory do not read as a conflict.
+ */
+export function resolveSpawnWorkdirPrecedence(input: {
+  projectWorkdir: string | null | undefined;
+  explicitWorkdir: string | null | undefined;
+  boundWorkdir: string | null | undefined;
+}): string | undefined {
+  const project = input.projectWorkdir?.trim() || undefined;
+  const explicit = input.explicitWorkdir?.trim() || undefined;
+  const bound = input.boundWorkdir?.trim() || undefined;
+  if (project) {
+    if (explicit && canonical(explicit) !== canonical(project)) {
+      throw new WorkdirBindingConflictError(explicit, project);
+    }
+    return project;
+  }
+  return explicit ?? bound;
+}


### PR DESCRIPTION
Fixes #14108.

## Problem

The two workdir-binding mechanisms — #13801 `boundWorkdir` and #13851 `projectId` — resolved spawn-workdir precedence **differently at the action layer vs the service layer**, so the same operator input produced a different workdir depending on the entry point:

- **Action layer** (`SPAWN_AGENT`, `tasks.ts`): for a project-bound task, `boundProjectWorkdir ?? explicit` silently **discarded** an explicit caller `workdir` and forced the project path.
- **Service layer** (`spawnAgentForTask`, `orchestrator-task-service.ts`): `opts.workdir` took priority **over** `boundWorkdir`, and `projectId` was never consulted here at all.

Same input, divergent behavior, no error or warning either way.

## Fix

One canonical precedence, enforced at both entry points through a single shared resolver:

**project localPath > explicit caller workdir > boundWorkdir**

- New `resolveSpawnWorkdirPrecedence()` in `services/project-binding.ts` is the single source of truth; both the action and the service call it.
- A project-bound task still always spawns in its project's `localPath` (#13776) — but a **conflicting** explicit workdir now **rejects loudly** via the new `WorkdirBindingConflictError` instead of being silently substituted. On the action path this surfaces at the existing J1 boundary as a user-facing `Failed to spawn agent: …` result; on the direct service path it throws before any ACP spawn (no session leaked).
- An explicit workdir **equal to** the project path (realpath-normalized, so symlinks don't false-conflict) is accepted.
- Registered project roots / `boundWorkdir` skip the allow-list probe (already-validated, as before); only a fresh explicit caller workdir goes through `resolveAllowedWorkdir`.

## Evidence

**Scoped typecheck** — clean:
```
$ bun run --cwd plugins/plugin-agent-orchestrator typecheck
$ tsgo --noEmit -p tsconfig.json    # (no errors)
```

**Tests driving the REAL path** (real `OrchestratorTaskService.spawnAgentForTask` over an in-memory store + a real on-disk project registry under a temp `ELIZA_STATE_DIR`; no mocks of the code under test):

- `project-binding.test.ts` — resolver unit coverage: project-over-explicit-over-bound precedence; **loud** `WorkdirBindingConflictError` on conflict; realpath-equivalent explicit accepted; unbound fall-through (explicit → bound → undefined). **4 new, all pass.**
- `task-workdir-binding.test.ts` — service e2e: a project-bound task spawns in its `localPath` with no explicit workdir; a conflicting explicit workdir **rejects with no leaked ACP session** (`spawns.length === 0`); an explicit workdir equal to the project path is accepted. **3 new, all pass.**

```
$ bun run --cwd plugins/plugin-agent-orchestrator vitest run \
    src/__tests__/task-workdir-binding.test.ts src/__tests__/project-binding.test.ts
 Tests  1 failed | 19 passed (20)
```

The single failure — `project-binding.test.ts > "…legacy workspace-folder.json synthesis…"` — is a **pre-existing** flake in `resolveTaskProjectId`'s legacy path (unstable synthesized project IDs), unrelated to this change. Verified by running that test against pristine `origin/develop` source with all my edits removed: it fails there identically. My diff does not touch `resolveTaskProjectId` / `findProjectByWorkdir`.

| Evidence | Status |
| --- | --- |
| Backend structured logs | N/A - pure workdir-resolution precedence; no new log path. Loud rejection asserted via typed error in tests. |
| Frontend / screenshots / video | N/A - no UI surface; orchestrator service + action only. |
| Real-LLM trajectories | N/A - deterministic resolver; no model/prompt/planner behavior changed. |
| Domain artifacts | Spawn workdir captured by the real service e2e (asserted `acp.spawns[…].workdir`). |

🤖 Generated with [Claude Code](https://claude.com/claude-code)