### PR TITLE
fix(#13773): workspace backpressure refuses first spawn on a cold machine (measure nearest existing ancestor)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_WORKSPACE_DISK_CAP_BYTES,
   DEFAULT_WORKSPACE_MIN_FREE_BYTES,
+  freeBytesFor,
   getSharedWorkspaceRegistry,
   measureDirBytes,
   parseByteSetting,
@@ -181,6 +182,24 @@ describe("WorkspaceRegistry free-disk precheck", () => {
     const root = tmpRoot("wsreg-df-ok-");
     const registry = new WorkspaceRegistry();
     const decision = await registry.checkDiskBudget(root, { minFreeBytes: 1 });
+    expect(decision.allowed).toBe(true);
+    expect(decision.freeBytes).toBeGreaterThan(0);
+  });
+
+  it("measures a not-yet-created root against its nearest existing ancestor", async () => {
+    const root = tmpRoot("wsreg-df-cold-");
+    // The cold-first-spawn case: the backpressure gate runs BEFORE the scratch
+    // root (or its task-* child) is created, so `statfs` on the target ENOENTs.
+    // It must measure the existing parent filesystem, not fail closed as if the
+    // disk were full — otherwise the very first spawn on a fresh machine is
+    // refused with used=0/free=0.
+    const notCreated = join(root, "eliza-acp", "task-cold");
+    const free = await freeBytesFor(notCreated);
+    expect(free).toBeGreaterThan(0);
+    const registry = new WorkspaceRegistry();
+    const decision = await registry.checkDiskBudget(notCreated, {
+      minFreeBytes: 1,
+    });
     expect(decision.allowed).toBe(true);
     expect(decision.freeBytes).toBeGreaterThan(0);
   });

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-registry.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-registry.ts
@@ -19,7 +19,7 @@
  */
 import type { Dirent } from "node:fs";
 import { readdir, rm, stat, statfs } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 export type WorkspaceKind = "acp-scratch" | "git-workspace";
 
@@ -118,14 +118,31 @@ export async function measureDirBytes(dir: string): Promise<number> {
  * cannot report it. `undefined` is an explicit "unknown" (never fabricated as
  * plenty-of-space): the caller treats an unknown reading as a hard refusal when
  * a floor is configured, so a broken `statfs` fails closed, not open.
+ *
+ * The backpressure gate measures a workspace root BEFORE that root (or its
+ * `task-*` child) is created, and `statfs` throws `ENOENT` on a path that does
+ * not exist yet — so a not-yet-created target is measured against the nearest
+ * existing ancestor, which is on the same filesystem that will host it. Without
+ * this walk, the very first spawn on a cold machine (where `$TMPDIR/eliza-acp`
+ * has never been created) would be refused as if the disk were full. A
+ * genuinely unreadable filesystem still yields `undefined` (every ancestor up
+ * to the root throws), preserving the fail-closed contract.
  */
 export async function freeBytesFor(path: string): Promise<number | undefined> {
-  try {
-    const st = await statfs(path);
-    // bavail is blocks available to unprivileged users; bsize the block size.
-    return st.bavail * st.bsize;
-  } catch {
-    return undefined;
+  let current = resolve(path);
+  for (;;) {
+    try {
+      const st = await statfs(current);
+      // bavail is blocks available to unprivileged users; bsize the block size.
+      return st.bavail * st.bsize;
+    } catch {
+      const parent = dirname(current);
+      // `dirname` is a fixed point at the filesystem root ("/" → "/", "C:\" →
+      // "C:\"): once we can climb no further and still cannot stat, the reading
+      // is genuinely unknown.
+      if (parent === current) return undefined;
+      current = parent;
+    }
   }
 }
 


### PR DESCRIPTION
## What

Post-merge fix for a **HIGH** regression introduced by #14097 (shared workspace registry + disk backpressure, part of #13773), now on `develop`.

## Failure

The disk-backpressure gate runs `enforceWorkspaceDiskBudget(resolve(baseWorkdir))` on the scratch/clone root **before** that root (or its `task-<id>` child) is created — that is the whole point of a *pre*-flight budget check. But `statfs` throws `ENOENT` on a path that does not exist yet, so `freeBytesFor` returned `undefined`, and with the default 2 GiB free-disk floor (`ELIZA_WORKSPACE_MIN_FREE_BYTES`) the gate fails **closed**.

On a cold machine — where `$TMPDIR/eliza-acp` (`DEFAULT_WORKDIR_ROOT`) has never been created — this refuses the **very first isolated spawn**:

```
Error: workspace disk budget exceeded (free-disk-floor): used=0 free=0 cap=21474836480 minFree=2147483648 root=…/eliza-acp
```

`AcpService.start()` does not `mkdir` the root, and the startup orphan sweep `continue`s past a missing root (`cleanOrphanedScratchWorkdirs`), so nothing creates it before the first spawn. The same defect gates `CodingWorkspaceService.provisionWorkspace` on a not-yet-created `baseDir`. The `#14097` disk-budget tests all used pre-existing `mkdtemp` roots, so they never exercised this path.

I reproduced it against the real `spawnSession` path (probe: a spawn with `ELIZA_ACP_WORKSPACE_ROOT` pointing at a not-yet-created dir is refused with the message above).

## Fix

`freeBytesFor` now walks up to the nearest **existing** ancestor and `statfs`s that — it is on the same filesystem that will host the new dir, so the free-space reading is correct. A genuinely unreadable filesystem still yields `undefined` (every ancestor up to the root throws), so the floor's **fail-closed** contract is preserved. No behavior change when the target already exists.

## Test

Adds `measures a not-yet-created root against its nearest existing ancestor` to `workspace-registry.test.ts`. Verified it **fails without the fix** (the not-yet-created root refuses / `freeBytesFor` returns `undefined`) and **passes with it**. Full `workspace-registry.test.ts` + `acp-spawn-disk-budget.test.ts` = **17 passed**. `biome check` clean, package `typecheck` clean.

### Evidence

- **N/A – no user-facing UI.** Server-side disk-lifecycle fix in `@elizaos/plugin-agent-orchestrator`; the observable behavior (first spawn on a cold machine no longer refused, floor still enforced when disk is genuinely low) is proven by the real-fs regression test driving the production gate.

Part of #13773

🤖 Generated with [Claude Code](https://claude.com/claude-code)
