### PR TITLE
fix(orchestrator): dedupe ingestChildTrajectories across re-completion + respawn (#14110)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/child-trajectory-ingest.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/child-trajectory-ingest.test.ts
@@ -213,4 +213,175 @@ describe("ingestChildTrajectories", () => {
     const doc = await store.getTask(taskId);
     expect(doc?.artifacts ?? []).toEqual([]);
   });
+
+  // #14110: the trajectory dir is per-task but ingest runs per session-
+  // completion, so a re-completion or a respawned session used to re-attach
+  // the same files. These regressions lock in idempotency.
+  it("is idempotent across a re-completion of the same session (no duplicate artifacts or ids)", async () => {
+    const store = new InMemoryTaskStore();
+    const { taskId, sessionId } = await seedTaskWithSession(store, {
+      traceId: "trace-parent",
+      parentTrajectoryStepId: "step-7",
+    });
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+    const dir = join(
+      stateDir,
+      "orchestrator",
+      "child-trajectories",
+      taskId,
+      "child-agent",
+    );
+    await mkdir(dir, { recursive: true });
+    writeFileSync(join(dir, "tj-aaa.json"), JSON.stringify({ t: 1 }));
+    writeFileSync(join(dir, "tj-bbb.json"), JSON.stringify({ t: 1 }));
+
+    const ingest = (
+      svc as unknown as {
+        ingestChildTrajectories: (t: string, s: string) => Promise<string[]>;
+      }
+    ).ingestChildTrajectories.bind(svc);
+
+    const first = await ingest(taskId, sessionId);
+    expect(first.sort()).toEqual(["tj-aaa", "tj-bbb"]);
+
+    // Same session re-completes (follow-up prompt) → same files re-scanned.
+    const second = await ingest(taskId, sessionId);
+    expect(second).toEqual([]);
+
+    const doc = await store.getTask(taskId);
+    const artifacts = doc?.artifacts ?? [];
+    // Still exactly two — no fresh-UUID duplicates.
+    expect(artifacts.length).toBe(2);
+    const ids = artifacts
+      .map(
+        (a) =>
+          (a.metadata.correlation as { childTrajectoryId?: string })
+            .childTrajectoryId,
+      )
+      .sort();
+    expect(ids).toEqual(["tj-aaa", "tj-bbb"]);
+
+    const session = (await store.findSession(sessionId))?.session;
+    // No duplicate ids on the session record either.
+    expect((session?.childTrajectoryIds ?? []).sort()).toEqual([
+      "tj-aaa",
+      "tj-bbb",
+    ]);
+  });
+
+  it("does not re-ingest session A's files under a respawned session B, preserving A's correlation", async () => {
+    const store = new InMemoryTaskStore();
+    const { taskId, sessionId: sessionA } = await seedTaskWithSession(store, {
+      traceId: "trace-A",
+      parentTrajectoryStepId: "step-A",
+    });
+    // Respawned session B on the SAME task (different correlation).
+    const sessionB = "sess-B";
+    const now = new Date().toISOString();
+    await store.addSession({
+      id: "row-B",
+      taskId,
+      sessionId: sessionB,
+      framework: "elizaos",
+      label: "worker",
+      originalTask: "do the thing",
+      workdir: "/tmp/wd",
+      status: "completed",
+      decisionCount: 0,
+      autoResolvedCount: 0,
+      registeredAt: Date.now(),
+      lastActivityAt: Date.now(),
+      idleCheckCount: 0,
+      taskDelivered: true,
+      lastSeenDecisionIndex: 0,
+      spawnedAt: Date.now(),
+      retryCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      cacheTokens: 0,
+      costUsd: 0,
+      usageState: "unavailable",
+      traceId: "trace-B",
+      parentTrajectoryStepId: "step-B",
+      metadata: {},
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+    const dir = join(
+      stateDir,
+      "orchestrator",
+      "child-trajectories",
+      taskId,
+      "child-agent",
+    );
+    await mkdir(dir, { recursive: true });
+    // These files were recorded by session A.
+    writeFileSync(join(dir, "tj-aaa.json"), JSON.stringify({ t: 1 }));
+    writeFileSync(join(dir, "tj-bbb.json"), JSON.stringify({ t: 1 }));
+
+    const ingest = (
+      svc as unknown as {
+        ingestChildTrajectories: (t: string, s: string) => Promise<string[]>;
+      }
+    ).ingestChildTrajectories.bind(svc);
+
+    // Session A completes first and attaches its files.
+    await ingest(taskId, sessionA);
+    // Session B (respawn) completes; must NOT re-attach A's files nor stamp B.
+    const bIngested = await ingest(taskId, sessionB);
+    expect(bIngested).toEqual([]);
+
+    const doc = await store.getTask(taskId);
+    const artifacts = doc?.artifacts ?? [];
+    expect(artifacts.length).toBe(2);
+    // Every trajectory still carries session A's correlation, not B's.
+    for (const a of artifacts) {
+      const corr = a.metadata.correlation as {
+        sessionId?: string;
+        traceId?: string;
+        parentStepId?: string;
+      };
+      expect(corr.sessionId).toBe(sessionA);
+      expect(corr.traceId).toBe("trace-A");
+      expect(corr.parentStepId).toBe("step-A");
+    }
+    // B's session record never gained A's ids.
+    const sessionBRec = (await store.findSession(sessionB))?.session;
+    expect(sessionBRec?.childTrajectoryIds ?? []).toEqual([]);
+  });
+
+  it("only the new file is ingested when a second, distinct trajectory appears later", async () => {
+    const store = new InMemoryTaskStore();
+    const { taskId, sessionId } = await seedTaskWithSession(store, {
+      traceId: "trace-parent",
+    });
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+    const dir = join(
+      stateDir,
+      "orchestrator",
+      "child-trajectories",
+      taskId,
+      "child-agent",
+    );
+    await mkdir(dir, { recursive: true });
+    writeFileSync(join(dir, "tj-aaa.json"), JSON.stringify({ t: 1 }));
+
+    const ingest = (
+      svc as unknown as {
+        ingestChildTrajectories: (t: string, s: string) => Promise<string[]>;
+      }
+    ).ingestChildTrajectories.bind(svc);
+
+    expect(await ingest(taskId, sessionId)).toEqual(["tj-aaa"]);
+
+    // A genuinely new trajectory shows up on a later completion.
+    writeFileSync(join(dir, "tj-ccc.json"), JSON.stringify({ t: 1 }));
+    expect(await ingest(taskId, sessionId)).toEqual(["tj-ccc"]);
+
+    const doc = await store.getTask(taskId);
+    expect((doc?.artifacts ?? []).length).toBe(2);
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -1346,7 +1346,9 @@ export class OrchestratorTaskService extends Service {
       const correlation = isRecord(artifact.metadata?.correlation)
         ? artifact.metadata.correlation
         : undefined;
-      const stamped = correlation ? str(correlation.childTrajectoryId) : undefined;
+      const stamped = correlation
+        ? str(correlation.childTrajectoryId)
+        : undefined;
       if (stamped) {
         ids.add(stamped);
         continue;

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -241,6 +241,10 @@ const INDEPENDENT_ACP_VERIFIER_NAME = "independent-acp-verifier";
 /** Cap on child trajectories ingested per task_complete (#13775) so a runaway
  *  sub-agent can't flood the task doc; the store's MAX_ARTIFACTS also clamps. */
 const MAX_CHILD_TRAJECTORY_ARTIFACTS = 20;
+/** Title prefix for an ingested sub-agent trajectory artifact. Kept as a
+ * constant so the #14110 dedupe fallback (parse the id back out of the title
+ * for pre-stamp records) stays in lockstep with how the title is written. */
+const TRAJECTORY_TITLE_PREFIX = "Sub-agent trajectory ";
 
 /** Default upper bound on how long the independent verifier session may run
  *  before its await is abandoned (treated as inconclusive). Overridable via
@@ -1241,10 +1245,33 @@ export class OrchestratorTaskService extends Service {
     }
     if (files.length === 0) return [];
 
+    // Idempotency: the trajectory dir is per-TASK but this runs per-session-
+    // completion (#14110). Two paths would otherwise duplicate: (a) a follow-up
+    // prompt RE-COMPLETING the same session re-scans the same files, and (b) a
+    // RESPAWNED session B on the same task re-scans session A's files — worse,
+    // it would stamp B's correlation (sessionId/parentStepId) onto trajectories
+    // A actually recorded, corrupting the file↔DB trace join #13871 exists to
+    // provide. Both are the same defect: re-ingesting an already-attached file.
+    //
+    // The stable dedupe key is the recorder's `<trajectoryId>` (the file
+    // basename), scoped to the task. A trajectory id is already attached iff a
+    // `trajectory` artifact on THIS task carries it (correlation.childTrajectoryId,
+    // with a title-suffix fallback for older records). Skipping such files keeps
+    // ingest idempotent and preserves the ORIGINAL session's correlation.
+    const alreadyIngested = await this.ingestedTrajectoryIds(taskId);
+
+    // Drop files already attached to this task (re-completion or respawn-replay)
+    // BEFORE the cap so the cap governs only NEW trajectories — otherwise a
+    // task with >MAX already-ingested files could crowd out genuinely new ones.
+    const fresh = files.filter(
+      (path) => !alreadyIngested.has(basename(path, ".json")),
+    );
+    if (fresh.length === 0) return [];
+
     // Newest first, capped so a runaway child can't flood the task doc; the
     // store's MAX_ARTIFACTS also clamps.
     const withMtime = await Promise.all(
-      files.map(async (path) => ({
+      fresh.map(async (path) => ({
         path,
         mtimeMs: (await stat(path)).mtimeMs,
       })),
@@ -1262,7 +1289,7 @@ export class OrchestratorTaskService extends Service {
         taskId,
         sessionId,
         artifactType: "trajectory",
-        title: `Sub-agent trajectory ${trajectoryId}`,
+        title: `${TRAJECTORY_TITLE_PREFIX}${trajectoryId}`,
         path,
         verificationStatus: "pending",
         metadata: {
@@ -1280,12 +1307,57 @@ export class OrchestratorTaskService extends Service {
     }
 
     if (ingested.length > 0) {
+      // De-dupe the session's id list too: a re-completion of the SAME session
+      // could otherwise re-append ids that survived on the session record even
+      // when the artifact skip above prevented a duplicate artifact.
       const existing = session?.childTrajectoryIds ?? [];
-      await this.store.updateSession(sessionId, {
-        childTrajectoryIds: [...existing, ...ingested],
-      });
+      const merged = [...existing];
+      const seen = new Set(existing);
+      for (const id of ingested) {
+        if (!seen.has(id)) {
+          seen.add(id);
+          merged.push(id);
+        }
+      }
+      if (merged.length !== existing.length) {
+        await this.store.updateSession(sessionId, {
+          childTrajectoryIds: merged,
+        });
+      }
     }
     return ingested;
+  }
+
+  /**
+   * The set of child `<trajectoryId>`s already attached to a task as
+   * `trajectory` artifacts (#14110 dedupe key). Reads the correlation stamp the
+   * ingest writes (`correlation.childTrajectoryId`); falls back to the id parsed
+   * from the artifact title for records written before the stamp existed. Used
+   * to make {@link ingestChildTrajectories} idempotent across re-completions and
+   * respawned-session replays without double-attaching a file or overwriting the
+   * original session's correlation.
+   */
+  private async ingestedTrajectoryIds(taskId: string): Promise<Set<string>> {
+    const doc = await this.store.getTask(taskId);
+    const ids = new Set<string>();
+    if (!doc) return ids;
+    for (const artifact of doc.artifacts) {
+      if (artifact.artifactType !== "trajectory") continue;
+      const correlation = isRecord(artifact.metadata?.correlation)
+        ? artifact.metadata.correlation
+        : undefined;
+      const stamped = correlation ? str(correlation.childTrajectoryId) : undefined;
+      if (stamped) {
+        ids.add(stamped);
+        continue;
+      }
+      // Fallback for pre-#14110 records: title is `Sub-agent trajectory <id>`.
+      const fromTitle = artifact.title.startsWith(TRAJECTORY_TITLE_PREFIX)
+        ? artifact.title.slice(TRAJECTORY_TITLE_PREFIX.length).trim()
+        : undefined;
+      if (fromTitle) ids.add(fromTitle);
+    }
+    return ids;
   }
 
   /**


### PR DESCRIPTION
Fixes #14110

## Problem

`ingestChildTrajectories` (`orchestrator-task-service.ts`) scans the **per-task** child-trajectory dir (`child-trajectories/<taskId>/`) on every `task_complete`, but `task_complete` fires **per session-completion**. With no dedupe, two paths corrupted the trace record #13871 exists to provide:

1. **Re-completion** — a follow-up prompt re-completing the same session re-attached the same trajectory files as brand-new artifacts (fresh `randomUUID()` ids) and re-appended duplicate ids to `session.childTrajectoryIds`.
2. **Respawned session** — a second session B on the same task re-ingested session A's files, and stamped **B's** correlation (`sessionId`/`parentStepId`/`traceId`) onto trajectories A actually recorded, corrupting the file↔DB trace join.

## Fix

Make ingest **idempotent** using the recorder's `<trajectoryId>` (the file basename) as a stable per-task dedupe key:

1. **`ingestedTrajectoryIds(taskId)`** — reads the task doc's existing `trajectory` artifacts and collects their `correlation.childTrajectoryId` (with a title-suffix fallback, `Sub-agent trajectory <id>`, for any pre-fix records).
2. Filter already-ingested files **before** the `MAX_CHILD_TRAJECTORY_ARTIFACTS` cap, so a task with ≥MAX already-attached files can't crowd out genuinely new trajectories.
3. Skip already-attached files — the original artifact **and its correlation** stay authoritative, so a respawn never overwrites the originating session's trace stamp.
4. De-dupe `session.childTrajectoryIds` on append and only write when it actually changes.

Attach-by-reference semantics, the per-task cap, and the ENOENT-is-empty contract are all unchanged.

## Tests

`__tests__/unit/child-trajectory-ingest.test.ts` (real `InMemoryTaskStore`, real service, temp state dir — no mock stands in for the code under test):

- **re-completion** of the same session → second ingest returns `[]`, still exactly 2 artifacts, no duplicate ids on the session.
- **respawned session B** → does not re-ingest A's files; every artifact still carries A's `sessionId`/`traceId`/`parentStepId`; B's session record stays empty.
- **new trajectory later** → only the genuinely-new file is ingested on a later completion.
- existing attach + missing-dir cases still pass.

```
bunx vitest run --config vitest.config.ts \
  __tests__/unit/child-trajectory-ingest.test.ts \
  __tests__/unit/spawn-trajectory-link.test.ts \
  __tests__/unit/trajectory-feedback-insight-cap.test.ts \
  __tests__/unit/orchestrator-task-service.test.ts
Test Files  4 passed (4)
Tests  85 passed (85)
```

Biome clean on both touched files.

## Review note

Codex review timed out (>100s) on the VPS and was killed per lane protocol; self-reviewed the diff instead — dedupe key aligns with how `childTrajectoryId` is written (`basename(path, ".json")`), filter-before-cap fixes the crowd-out edge, and the respawn correlation-preservation is asserted by test.

N/A: no UI surface (service-internal ingest plumbing) → no screenshots/video; behavior is deterministic file/DB bookkeeping covered by the unit suite, no live-LLM path changed.

— [sol-orch]

🤖 Generated with Sol
