### PR TITLE
fix(orchestrator): single-source the state-lost retry budget — no 4th orphan respawn against a failed task (#14104)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/account-failover-respawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/account-failover-respawn.test.ts
@@ -79,7 +79,7 @@ function makeAcp(sessions: SessionInfo[]) {
   };
 }
 
-function makeRuntime(acp: unknown) {
+function makeRuntime(acp: unknown, setting?: Record<string, string>) {
   const handleMessage = vi.fn<
     (rt: unknown, m: Memory, cb?: HandlerCallback) => Promise<unknown>
   >(async () => ({}));
@@ -87,7 +87,7 @@ function makeRuntime(acp: unknown) {
     agentId: "00000000-0000-0000-0000-000000000001",
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     getService: vi.fn(() => acp),
-    getSetting: vi.fn(() => undefined),
+    getSetting: vi.fn((k: string) => setting?.[k]),
     createMemory: vi.fn(async () => undefined),
     createEntity: vi.fn(async () => true),
     addParticipant: vi.fn(async () => true),
@@ -221,10 +221,14 @@ describe("mid-session account failover", () => {
   it("exhausts the shared lineage budget and posts ONE honest account-failure terminal", async () => {
     // Four sessions in the same origin lineage (respawn cascade): the first
     // three rate-limit errors respawn; the fourth crosses the cap (3) and
-    // posts a single terminal narration naming the account failure.
+    // posts a single terminal narration naming the account failure. Pin the cap
+    // to 3 so this stays a mechanism test — the default is now derived from the
+    // shared crash-retry budget (#14104).
     const sessions = ["s-1", "s-2", "s-3", "s-4"].map(makeSession);
     const acp = makeAcp(sessions);
-    const { runtime, handleMessage } = makeRuntime(acp.service);
+    const { runtime, handleMessage } = makeRuntime(acp.service, {
+      ACPX_STATE_LOST_RESPAWN_CAP: "3",
+    });
     const router = await SubAgentRouter.start(runtime);
 
     for (const [i, s] of sessions.entries()) {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -1953,9 +1953,7 @@ describe("OrchestratorTaskService — retry-budget/router-cap reconciliation (#1
       lineageKey: "override-lineage",
     });
     expect(terminalTransition.decision.kind).toBe("terminal_failure");
-    expect(must(await service.getTask(task.id), "final").status).toBe(
-      "failed",
-    );
+    expect(must(await service.getTask(task.id), "final").status).toBe("failed");
   });
 
   it("restartTask resets the crash-retry budget so a restarted task survives its first recoverable blip", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -19,9 +19,16 @@ import { OrchestratorTaskService } from "../../src/services/orchestrator-task-se
 import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
 import {
   type CreateTaskInput,
+  MAX_SESSION_RETRY_ATTEMPTS,
   type OrchestratorTaskSession,
+  RETRY_BUDGET_EPOCH_METADATA_KEY,
+  stateLostRespawnCapFor,
   TERMINAL_TASK_STATUSES,
 } from "../../src/services/orchestrator-task-types.js";
+import {
+  createRouterLoopState,
+  routerLoopTransition,
+} from "../../src/services/router-loop-guard.js";
 
 // This suite pins the status state machine and the ACP→task event bridge — NOT
 // the #8896 default-criteria feature. createTask now auto-populates acceptance
@@ -1783,5 +1790,156 @@ describe("OrchestratorTaskService — post-completion teardown race (#13830 audi
     await settleStatus(service, taskId, "failed");
     const detail = must(await service.getTask(taskId), "detail");
     expect(must(detail.sessions[0], "session").status).toBe("errored");
+  });
+});
+
+// The #14104 divergence: the task service's terminal budget and the router's
+// per-lineage state-lost respawn cap used to be independent numbers with
+// mismatched arithmetic, so the task went `failed` at the 3rd errored session
+// while the router still respawned a 4th orphan worker on the same event. These
+// tests pin the reconciliation — one budget, one owner — by driving BOTH
+// subsystems over the SAME state-lost stream and asserting they agree, and by
+// checking the restart-budget reset.
+describe("OrchestratorTaskService — retry-budget/router-cap reconciliation (#14104)", () => {
+  it("task terminal decision and router respawn cap agree on the same state-lost stream — no 4th orphan", async () => {
+    const acp = new FakeAcp();
+    const service = makeService(acp);
+    await service.start();
+    const task = await service.createTask(createInput());
+
+    // Drive the state-lost lineage session by session, recording at each error
+    // (a) whether the task is now terminal `failed`, and (b) what the router's
+    // loop-guard reducer decides for the SAME event under its default cap.
+    let loopState = createRouterLoopState();
+    const lineageKey = "lineage-a";
+    const routerDecisions: string[] = [];
+    const taskTerminalAtError: boolean[] = [];
+
+    // Enough iterations to pass the budget: budget N ⇒ terminal at the Nth error.
+    for (let i = 0; i < MAX_SESSION_RETRY_ATTEMPTS + 1; i += 1) {
+      const status = must(await service.getTask(task.id), "status").status;
+      // Once terminal, the task refuses further spawns/errors — stop driving it.
+      if (TERMINAL_TASK_STATUSES.has(status)) break;
+
+      const detail = must(
+        await service.spawnAgentForTask(task.id),
+        "spawn detail",
+      );
+      const sessionId = must(detail.sessions.at(-1), "session").sessionId;
+      await drive(acp, sessionId, "error", {
+        failureKind: "session_state_lost",
+        message: `state lost ${i + 1}`,
+      });
+
+      const transition = routerLoopTransition(loopState, {
+        type: "state_lost",
+        lineageKey,
+      });
+      loopState = transition.state;
+      routerDecisions.push(transition.decision.kind);
+      taskTerminalAtError.push(
+        TERMINAL_TASK_STATUSES.has(
+          must(await service.getTask(task.id), "after").status,
+        ),
+      );
+    }
+
+    // The router's default cap is derived from the shared budget, so it stops
+    // respawning on exactly the error at which the task goes terminal. The last
+    // decision is a terminal_failure (not a respawn), and the task is `failed`
+    // at that same error — the divergence (router respawn while task failed) is
+    // gone.
+    expect(routerDecisions.at(-1)).toBe("terminal_failure");
+    const respawnCount = routerDecisions.filter((d) => d === "respawn").length;
+    // With budget N the router respawns N-1 times (sessions #2…#N), never an
+    // (N+1)th orphan.
+    expect(respawnCount).toBe(
+      stateLostRespawnCapFor(MAX_SESSION_RETRY_ATTEMPTS),
+    );
+    expect(taskTerminalAtError.at(-1)).toBe(true);
+
+    const final = must(await service.getTask(task.id), "final");
+    expect(final.status).toBe("failed");
+    // The number of errored sessions equals the budget — no extra orphan
+    // session was spawned past the terminal decision.
+    const erroredSessions = (final.sessions ?? []).filter(
+      (s) => s.status === "errored",
+    ).length;
+    expect(erroredSessions).toBe(MAX_SESSION_RETRY_ATTEMPTS);
+  });
+
+  it("keeps the lineage non-terminal while the router still respawns (each error under the cap)", async () => {
+    const acp = new FakeAcp();
+    const { service, store } = makeServiceWithStore(acp);
+    await service.start();
+    const task = await service.createTask(createInput());
+
+    // The first N-1 state-lost errors are under the router's respawn cap, so the
+    // task must stay non-terminal (the router will re-drive it).
+    const respawnBudget = stateLostRespawnCapFor(MAX_SESSION_RETRY_ATTEMPTS);
+    for (let i = 0; i < respawnBudget; i += 1) {
+      const detail = must(
+        await service.spawnAgentForTask(task.id),
+        "spawn detail",
+      );
+      const sessionId = must(detail.sessions.at(-1), "session").sessionId;
+      await drive(acp, sessionId, "error", {
+        failureKind: "session_state_lost",
+        message: `state lost ${i + 1}`,
+      });
+      const detailAfter = must(await service.getTask(task.id), "after");
+      expect(detailAfter.status).not.toBe("failed");
+      const found = must(await store.findSession(sessionId), "found");
+      expect(found.session.retryCount).toBe(i + 1);
+    }
+  });
+
+  it("restartTask resets the crash-retry budget so a restarted task survives its first recoverable blip", async () => {
+    const acp = new FakeAcp();
+    const { service, store } = makeServiceWithStore(acp);
+    await service.start();
+    const task = await service.createTask(createInput());
+
+    // Exhaust the budget → terminal failed.
+    for (let i = 0; i < MAX_SESSION_RETRY_ATTEMPTS; i += 1) {
+      const status = must(await service.getTask(task.id), "s").status;
+      if (TERMINAL_TASK_STATUSES.has(status)) break;
+      const detail = must(await service.spawnAgentForTask(task.id), "spawn");
+      const sessionId = must(detail.sessions.at(-1), "session").sessionId;
+      await drive(acp, sessionId, "error", {
+        failureKind: "session_state_lost",
+        message: `state lost ${i + 1}`,
+      });
+    }
+    expect(must(await service.getTask(task.id), "failed").status).toBe(
+      "failed",
+    );
+
+    // Operator restarts. The restart stamps a fresh budget epoch, so the prior
+    // run's dead errored sessions no longer count.
+    const restarted = must(
+      await service.restartTask(task.id, { instruction: "try again" }),
+      "restarted",
+    );
+    expect(restarted.status).toBe("active");
+    const epoch = restarted.metadata?.[RETRY_BUDGET_EPOCH_METADATA_KEY];
+    expect(typeof epoch).toBe("number");
+    expect(epoch as number).toBeGreaterThan(0);
+
+    // A single recoverable state-lost error in the new run must NOT re-fail the
+    // task — the budget reset means this is attempt 1 of the new run, not the
+    // (already-spent) old one. Query the raw store (the DTO omits `spawnedAt`)
+    // for the session the restart spawned at/after the epoch.
+    const doc = must(await store.getTask(task.id), "doc");
+    const freshSession = must(
+      doc.sessions.filter((s) => s.spawnedAt >= (epoch as number)).at(-1),
+      "fresh session spawned by restart",
+    );
+    await drive(acp, freshSession.sessionId, "error", {
+      failureKind: "session_state_lost",
+      message: "recoverable blip after restart",
+    });
+    const afterBlip = must(await service.getTask(task.id), "after blip");
+    expect(afterBlip.status).not.toBe("failed");
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -109,9 +109,13 @@ class FakeAcp {
   }
 }
 
-function runtime(acp?: FakeAcp): IAgentRuntime {
+function runtime(
+  acp?: FakeAcp,
+  settings: Record<string, string> = {},
+): IAgentRuntime {
   return {
     getService: () => acp ?? null,
+    getSetting: (key: string) => settings[key],
     logger: {
       debug: vi.fn(),
       info: vi.fn(),
@@ -121,19 +125,25 @@ function runtime(acp?: FakeAcp): IAgentRuntime {
   } as never;
 }
 
-function makeServiceWithStore(acp?: FakeAcp): {
+function makeServiceWithStore(
+  acp?: FakeAcp,
+  settings: Record<string, string> = {},
+): {
   service: OrchestratorTaskService;
   store: OrchestratorTaskStore;
 } {
   const store = new OrchestratorTaskStore({ backend: "memory" });
   return {
-    service: new OrchestratorTaskService(runtime(acp), { store }),
+    service: new OrchestratorTaskService(runtime(acp, settings), { store }),
     store,
   };
 }
 
-function makeService(acp?: FakeAcp): OrchestratorTaskService {
-  return makeServiceWithStore(acp).service;
+function makeService(
+  acp?: FakeAcp,
+  settings: Record<string, string> = {},
+): OrchestratorTaskService {
+  return makeServiceWithStore(acp, settings).service;
 }
 
 function createInput(
@@ -1895,62 +1905,57 @@ describe("OrchestratorTaskService — retry-budget/router-cap reconciliation (#1
   });
 
   it("honors an operator-raised state-lost cap before failing the task", async () => {
-    const previous = process.env.ACPX_STATE_LOST_RESPAWN_CAP;
-    process.env.ACPX_STATE_LOST_RESPAWN_CAP = "3";
-    try {
-      const acp = new FakeAcp();
-      const { service, store } = makeServiceWithStore(acp);
-      await service.start();
-      const task = await service.createTask(createInput());
-      let loopState = createRouterLoopState({ stateLostRespawnCap: 3 });
+    const acp = new FakeAcp();
+    const { service, store } = makeServiceWithStore(acp, {
+      ACPX_STATE_LOST_RESPAWN_CAP: "3",
+    });
+    await service.start();
+    const task = await service.createTask(createInput());
+    let loopState = createRouterLoopState({ stateLostRespawnCap: 3 });
 
-      for (let i = 0; i < 3; i += 1) {
-        const detail = must(
-          await service.spawnAgentForTask(task.id),
-          "spawn detail",
-        );
-        const sessionId = must(detail.sessions.at(-1), "session").sessionId;
-        await drive(acp, sessionId, "error", {
-          failureKind: "session_state_lost",
-          message: `state lost override ${i + 1}`,
-        });
-        const transition = routerLoopTransition(loopState, {
-          type: "state_lost",
-          lineageKey: "override-lineage",
-        });
-        loopState = transition.state;
-        expect(transition.decision.kind).toBe("respawn");
-        expect(must(await service.getTask(task.id), "after").status).not.toBe(
-          "failed",
-        );
-        const found = must(await store.findSession(sessionId), "found");
-        expect(found.session.retryCount).toBe(i + 1);
-      }
-
-      const terminalSpawn = must(
+    for (let i = 0; i < 3; i += 1) {
+      const detail = must(
         await service.spawnAgentForTask(task.id),
-        "terminal spawn detail",
+        "spawn detail",
       );
-      const terminalSessionId = must(
-        terminalSpawn.sessions.at(-1),
-        "terminal session",
-      ).sessionId;
-      await drive(acp, terminalSessionId, "error", {
+      const sessionId = must(detail.sessions.at(-1), "session").sessionId;
+      await drive(acp, sessionId, "error", {
         failureKind: "session_state_lost",
-        message: "state lost override terminal",
+        message: `state lost override ${i + 1}`,
       });
-      const terminalTransition = routerLoopTransition(loopState, {
+      const transition = routerLoopTransition(loopState, {
         type: "state_lost",
         lineageKey: "override-lineage",
       });
-      expect(terminalTransition.decision.kind).toBe("terminal_failure");
-      expect(must(await service.getTask(task.id), "final").status).toBe(
+      loopState = transition.state;
+      expect(transition.decision.kind).toBe("respawn");
+      expect(must(await service.getTask(task.id), "after").status).not.toBe(
         "failed",
       );
-    } finally {
-      if (previous === undefined) delete process.env.ACPX_STATE_LOST_RESPAWN_CAP;
-      else process.env.ACPX_STATE_LOST_RESPAWN_CAP = previous;
+      const found = must(await store.findSession(sessionId), "found");
+      expect(found.session.retryCount).toBe(i + 1);
     }
+
+    const terminalSpawn = must(
+      await service.spawnAgentForTask(task.id),
+      "terminal spawn detail",
+    );
+    const terminalSessionId = must(
+      terminalSpawn.sessions.at(-1),
+      "terminal session",
+    ).sessionId;
+    await drive(acp, terminalSessionId, "error", {
+      failureKind: "session_state_lost",
+      message: "state lost override terminal",
+    });
+    const terminalTransition = routerLoopTransition(loopState, {
+      type: "state_lost",
+      lineageKey: "override-lineage",
+    });
+    expect(terminalTransition.decision.kind).toBe("terminal_failure");
+    expect(must(await service.getTask(task.id), "final").status).toBe(
+      "failed",
+    );
   });
 
   it("restartTask resets the crash-retry budget so a restarted task survives its first recoverable blip", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -1894,6 +1894,65 @@ describe("OrchestratorTaskService — retry-budget/router-cap reconciliation (#1
     }
   });
 
+  it("honors an operator-raised state-lost cap before failing the task", async () => {
+    const previous = process.env.ACPX_STATE_LOST_RESPAWN_CAP;
+    process.env.ACPX_STATE_LOST_RESPAWN_CAP = "3";
+    try {
+      const acp = new FakeAcp();
+      const { service, store } = makeServiceWithStore(acp);
+      await service.start();
+      const task = await service.createTask(createInput());
+      let loopState = createRouterLoopState({ stateLostRespawnCap: 3 });
+
+      for (let i = 0; i < 3; i += 1) {
+        const detail = must(
+          await service.spawnAgentForTask(task.id),
+          "spawn detail",
+        );
+        const sessionId = must(detail.sessions.at(-1), "session").sessionId;
+        await drive(acp, sessionId, "error", {
+          failureKind: "session_state_lost",
+          message: `state lost override ${i + 1}`,
+        });
+        const transition = routerLoopTransition(loopState, {
+          type: "state_lost",
+          lineageKey: "override-lineage",
+        });
+        loopState = transition.state;
+        expect(transition.decision.kind).toBe("respawn");
+        expect(must(await service.getTask(task.id), "after").status).not.toBe(
+          "failed",
+        );
+        const found = must(await store.findSession(sessionId), "found");
+        expect(found.session.retryCount).toBe(i + 1);
+      }
+
+      const terminalSpawn = must(
+        await service.spawnAgentForTask(task.id),
+        "terminal spawn detail",
+      );
+      const terminalSessionId = must(
+        terminalSpawn.sessions.at(-1),
+        "terminal session",
+      ).sessionId;
+      await drive(acp, terminalSessionId, "error", {
+        failureKind: "session_state_lost",
+        message: "state lost override terminal",
+      });
+      const terminalTransition = routerLoopTransition(loopState, {
+        type: "state_lost",
+        lineageKey: "override-lineage",
+      });
+      expect(terminalTransition.decision.kind).toBe("terminal_failure");
+      expect(must(await service.getTask(task.id), "final").status).toBe(
+        "failed",
+      );
+    } finally {
+      if (previous === undefined) delete process.env.ACPX_STATE_LOST_RESPAWN_CAP;
+      else process.env.ACPX_STATE_LOST_RESPAWN_CAP = previous;
+    }
+  });
+
   it("restartTask resets the crash-retry budget so a restarted task survives its first recoverable blip", async () => {
     const acp = new FakeAcp();
     const { service, store } = makeServiceWithStore(acp);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -2262,7 +2262,13 @@ describe("SubAgentRouter state_lost respawn cap", () => {
       listSessions: vi.fn(async () => []),
       stopSession,
     };
-    const { runtime, handleMessage } = makeRuntime({ acp: acpService });
+    // Pin the cap to 3 so this stays a mechanism test: the default cap is now
+    // derived from the shared crash-retry budget (#14104), so an explicit cap
+    // keeps this asserting the cap machinery itself, not the default value.
+    const { runtime, handleMessage } = makeRuntime({
+      acp: acpService,
+      setting: { ACPX_STATE_LOST_RESPAWN_CAP: "3" },
+    });
     const router = await SubAgentRouter.start(runtime);
 
     // 5 events: distinct sessionIds, same origin room (taskRoomId fallback)
@@ -2544,8 +2550,11 @@ describe("SubAgentRouter — deterministic session_state_lost recovery", () => {
       listSessions: vi.fn(async () => [...sessions.values()]),
       stopSession: vi.fn(async () => {}),
     };
+    // Pin the cap to 3 so this stays a mechanism test independent of the
+    // budget-derived default (#14104).
     const { runtime, handleMessage, spawnSession } = makeRuntime({
       acp: service,
+      setting: { ACPX_STATE_LOST_RESPAWN_CAP: "3" },
     });
     await SubAgentRouter.start(runtime);
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -130,7 +130,11 @@ import {
   type OrchestratorTaskSession,
   type OrchestratorTaskStatus,
   type OrchestratorTaskUsage,
+  RETRY_BUDGET_EPOCH_METADATA_KEY,
+  readRetryBudgetEpoch,
+  resolveStateLostRespawnCap,
   resolveTaskTransition,
+  stateLostRespawnUnderCap,
   type TaskLifecycleTrigger,
   type TaskListFilter,
   type TaskMessageDirection,
@@ -1917,9 +1921,17 @@ export class OrchestratorTaskService extends Service {
     if (doc.task.paused) return;
     if (TERMINAL_TASK_STATUSES.has(doc.task.status)) return;
 
+    // Scope the budget to the current run: an operator `restartTask` stamps a
+    // budget epoch, and sessions spawned before it (a prior failed run's dead
+    // lineage) must not count, or a restarted task re-fails on its first blip
+    // (#14104). Absent epoch → every session counts (pre-restart lifetime).
+    const budgetEpoch = readRetryBudgetEpoch(doc.task.metadata);
     const erroredSessionIds = new Set(
       doc.sessions
-        .filter((s) => SESSION_ERROR_STATUSES.has(s.status))
+        .filter(
+          (s) =>
+            SESSION_ERROR_STATUSES.has(s.status) && s.spawnedAt >= budgetEpoch,
+        )
         .map((s) => s.sessionId),
     );
     erroredSessionIds.add(sessionId);
@@ -1932,11 +1944,16 @@ export class OrchestratorTaskService extends Service {
     const respawnable = this.routerWillRespawn(
       doc.sessions.find((s) => s.sessionId === sessionId),
       failure,
+      erroredSessions,
     );
-    const budgetSpent = erroredSessions >= MAX_SESSION_RETRY_ATTEMPTS;
-    // Terminal unless the router will respawn this crash class AND the lineage
-    // budget still has room. An un-respawnable crash fails on its first
+    // `routerWillRespawn` already folds the state-lost respawn cap into its
+    // verdict via the SAME gate + effective cap the router's loop-guard uses
+    // (#14104), so a state-lost lineage goes terminal on exactly the error the
+    // router refuses to respawn — no 4th orphan worker. The account-failover
+    // class carries no per-lineage router cap, so the shared errored-session
+    // budget still bounds it here. An un-respawnable crash fails on its first
     // occurrence — nothing will re-drive it, so a non-terminal verdict wedges.
+    const budgetSpent = erroredSessions >= MAX_SESSION_RETRY_ATTEMPTS;
     const terminal = !respawnable || budgetSpent;
     await this.store.addEvent({
       id: randomUUID(),
@@ -1967,7 +1984,13 @@ export class OrchestratorTaskService extends Service {
    * Whether `sub-agent-router.ts` will deterministically respawn this crash —
    * the same gate the router itself uses, mirrored here so status termination
    * and respawn agree. Only these two classes get a successor session:
-   *   - `session_state_lost` (unconditional respawn under the lineage cap), and
+   *   - `session_state_lost`, respawned by the router only while the lineage's
+   *     errored count stays under the effective respawn cap. `erroredSessions`
+   *     is the 1-based lineage position of the just-errored session, which the
+   *     router tracks as its own per-lineage state-lost count; consulting the
+   *     SAME cap + gate here means the task goes terminal on exactly the error
+   *     the router refuses to respawn, so no 4th orphan worker spawns against a
+   *     `failed` task (#14104).
    *   - a pooled-account failure whose message classifies as rate-limit /
    *     needs-reauth, while the session carried a pooled account and a healthy
    *     sibling remains for failover.
@@ -1976,8 +1999,14 @@ export class OrchestratorTaskService extends Service {
   private routerWillRespawn(
     session: OrchestratorTaskSession | undefined,
     failure: { failureKind?: string; message: string },
+    erroredSessions: number,
   ): boolean {
-    if (failure.failureKind === "session_state_lost") return true;
+    if (failure.failureKind === "session_state_lost") {
+      return stateLostRespawnUnderCap(
+        erroredSessions,
+        resolveStateLostRespawnCap(this.runtime),
+      );
+    }
     if (classifyAccountFailure(failure.message) === null) return false;
     if (!session?.accountProviderId || !session.accountId) return false;
     return hasHealthyPooledAccount(session.framework);
@@ -3286,6 +3315,17 @@ export class OrchestratorTaskService extends Service {
         "Restart this task from the current durable context. Reinspect the task timeline, then continue until the goal is met or you are blocked.",
       planRevision,
     );
+    // Open a fresh budget epoch BEFORE the first spawn of the new run so the
+    // prior (failed) run's dead errored sessions no longer count toward the
+    // crash-retry budget — otherwise a restarted task re-fails on its first
+    // recoverable blip while the router respawns anyway (#14104). Merge into the
+    // existing bag: `updateTask` replaces `metadata` wholesale.
+    await this.store.updateTask(taskId, {
+      metadata: {
+        ...doc.task.metadata,
+        [RETRY_BUDGET_EPOCH_METADATA_KEY]: Date.now(),
+      },
+    });
     await this.spawnAgentForTask(taskId, {
       ...input.agent,
       task: instruction,

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -1949,11 +1949,14 @@ export class OrchestratorTaskService extends Service {
     // `routerWillRespawn` already folds the state-lost respawn cap into its
     // verdict via the SAME gate + effective cap the router's loop-guard uses
     // (#14104), so a state-lost lineage goes terminal on exactly the error the
-    // router refuses to respawn — no 4th orphan worker. The account-failover
-    // class carries no per-lineage router cap, so the shared errored-session
-    // budget still bounds it here. An un-respawnable crash fails on its first
-    // occurrence — nothing will re-drive it, so a non-terminal verdict wedges.
-    const budgetSpent = erroredSessions >= MAX_SESSION_RETRY_ATTEMPTS;
+    // router refuses to respawn — including when an operator raises or lowers
+    // ACPX_STATE_LOST_RESPAWN_CAP. The account-failover class carries no
+    // per-lineage router cap, so the shared errored-session budget still bounds
+    // it here. An un-respawnable crash fails on its first occurrence — nothing
+    // will re-drive it, so a non-terminal verdict wedges.
+    const stateLost = failure.failureKind === "session_state_lost";
+    const budgetSpent =
+      !stateLost && erroredSessions >= MAX_SESSION_RETRY_ATTEMPTS;
     const terminal = !respawnable || budgetSpent;
     await this.store.addEvent({
       id: randomUUID(),

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
@@ -118,11 +118,60 @@ export interface AttemptReflection {
 /** Cap on retained reflections — keep the most recent few to bound prompt size. */
 export const MAX_ATTEMPT_REFLECTIONS = 5;
 
-/** Crash-retry budget: how many times an unrecoverable session error may
- * re-dispatch a task's sub-agent lineage before the task goes terminal
- * `failed`. Bounds the general-crash respawn the same way
- * `MAX_AUTO_VERIFY_ATTEMPTS` bounds verification re-prompts. */
+/** Crash-retry budget: the total number of errored sessions a task's sub-agent
+ * lineage may accrue before the task goes terminal `failed`. Bounds the
+ * general-crash respawn the same way `MAX_AUTO_VERIFY_ATTEMPTS` bounds
+ * verification re-prompts.
+ *
+ * This is the ONE budget for the whole crash-retry event stream (#14104). The
+ * router's per-lineage `session_state_lost` respawn cap is derived from it via
+ * {@link stateLostRespawnCapFor}, and the task service's terminal decision uses
+ * the same {@link stateLostRespawnUnderCap} gate the router uses — so the two
+ * subsystems can never disagree about when the lineage is exhausted (the "4th
+ * orphan respawn against an already-`failed` task" divergence). */
 export const MAX_SESSION_RETRY_ATTEMPTS = 3;
+
+/** The router respawns AFTER an errored session, so the number of respawns it
+ * may perform is one fewer than the total errored-session budget: with a budget
+ * of N errored sessions, the Nth error is terminal and gets no successor, i.e.
+ * at most `N - 1` respawns produce sessions #2…#N. Deriving the respawn cap from
+ * the shared budget (rather than an independent constant) is what keeps the
+ * router from spawning an (N+1)th orphan worker against a `failed` task. */
+export function stateLostRespawnCapFor(budget: number): number {
+  return Math.max(0, budget - 1);
+}
+
+/** The single gate both the router's loop-guard reducer and the task service's
+ * terminal decision consult: given the 1-based respawn/errored count for a
+ * lineage and the respawn cap, may another successor session spawn? A respawn is
+ * permitted only while the count has not yet reached the cap; once it does, the
+ * lineage is exhausted and the next error is terminal with no orphan spawn. */
+export function stateLostRespawnUnderCap(count: number, cap: number): boolean {
+  return count <= cap;
+}
+
+/** Operator override for the state-lost respawn cap. Kept here (not inline in
+ * the router) so the router's loop-guard AND the task service's terminal
+ * decision resolve the SAME effective cap from the SAME env key — otherwise a
+ * deployment raising this would widen the router's respawn budget while the
+ * task service's terminal threshold stayed fixed, re-opening the #14104 drift. */
+export const STATE_LOST_RESPAWN_CAP_SETTING = "ACPX_STATE_LOST_RESPAWN_CAP";
+
+/** Resolve the effective state-lost respawn cap: a positive operator override
+ * from {@link STATE_LOST_RESPAWN_CAP_SETTING} wins, else the budget-derived
+ * default. `getSetting` reads character settings/secrets, so fall back to
+ * `process.env` for deployments that configure the cap purely via env. */
+export function resolveStateLostRespawnCap(runtime: {
+  getSetting?: (key: string) => unknown;
+}): number {
+  const raw =
+    runtime.getSetting?.(STATE_LOST_RESPAWN_CAP_SETTING) ??
+    process.env[STATE_LOST_RESPAWN_CAP_SETTING];
+  const parsed = typeof raw === "string" ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : stateLostRespawnCapFor(MAX_SESSION_RETRY_ATTEMPTS);
+}
 
 /** The metadata key both the durable session `retryCount` and the router's
  * respawn-lineage counter fold into, so the two subsystems name ONE counter.
@@ -140,6 +189,24 @@ export function readSessionRetryCount(
   metadata: Record<string, unknown> | undefined,
 ): number {
   const raw = metadata?.[SESSION_RETRY_METADATA_KEY];
+  return typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? raw : 0;
+}
+
+/** Task-metadata key holding the epoch-ms boundary of the current run. The
+ * crash-retry budget counts errored sessions, but that count is per-RUN, not
+ * per-lifetime: an operator `restartTask` stamps `Date.now()` here so only
+ * sessions spawned at/after the restart count toward the budget. Without it a
+ * previously-`failed` task re-fails on its first recoverable blip because its
+ * dead sessions still fill the budget (#14104). */
+export const RETRY_BUDGET_EPOCH_METADATA_KEY = "retryBudgetEpochMs";
+
+/** Read the current run's budget epoch (epoch ms) off a task-metadata bag.
+ * Absent/non-positive reads to 0 — every session then counts, which is the
+ * correct pre-restart lifetime behavior. */
+export function readRetryBudgetEpoch(
+  metadata: Record<string, unknown> | undefined,
+): number {
+  const raw = metadata?.[RETRY_BUDGET_EPOCH_METADATA_KEY];
   return typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? raw : 0;
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/router-loop-guard.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/router-loop-guard.ts
@@ -25,11 +25,23 @@
  * early force-stop, no leaked (unbounded / un-force-stopped) session.
  */
 
+import {
+  MAX_SESSION_RETRY_ATTEMPTS,
+  stateLostRespawnCapFor,
+  stateLostRespawnUnderCap,
+} from "./orchestrator-task-types.js";
+
 /** FIFO bound on every per-session / per-lineage map so state can't grow without limit. */
 export const ROUTER_LOOP_STATE_BOUND = 1024;
 
 export const DEFAULT_ROUND_TRIP_CAP = 32;
-export const DEFAULT_STATE_LOST_RESPAWN_CAP = 3;
+/** Derived from the shared crash-retry budget so the router's respawn cap and
+ * the task service's terminal budget are ONE number (#14104): with a budget of
+ * N errored sessions, the router may respawn at most `N - 1` times, so the Nth
+ * error terminates the task instead of spawning an (N+1)th orphan worker. */
+export const DEFAULT_STATE_LOST_RESPAWN_CAP = stateLostRespawnCapFor(
+  MAX_SESSION_RETRY_ATTEMPTS,
+);
 
 /**
  * The complete loop-guard state. Every field is treated as immutable: the
@@ -223,7 +235,7 @@ export function routerLoopTransition(
         event.lineageKey,
         count,
       );
-      if (count <= state.stateLostRespawnCap) {
+      if (stateLostRespawnUnderCap(count, state.stateLostRespawnCap)) {
         return {
           state: { ...state, stateLostRespawnCounts },
           decision: { kind: "respawn", count },

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -34,6 +34,7 @@ import {
 } from "./coding-account-selection.js";
 import {
   readSessionRetryCount,
+  resolveStateLostRespawnCap,
   SESSION_RETRY_METADATA_KEY,
 } from "./orchestrator-task-types.js";
 import {
@@ -675,12 +676,12 @@ export class SubAgentRouter extends Service {
     }
     const capRaw = readSetting(this.runtime, "ACPX_SUB_AGENT_ROUND_TRIP_CAP");
     const parsed = capRaw ? Number.parseInt(capRaw, 10) : NaN;
-    const slCapRaw = readSetting(this.runtime, "ACPX_STATE_LOST_RESPAWN_CAP");
-    const slParsed = slCapRaw ? Number.parseInt(slCapRaw, 10) : NaN;
+    // Resolve the state-lost respawn cap through the shared resolver so the
+    // router and the task service's terminal decision agree on the SAME
+    // effective cap even under an operator override (#14104).
     this.loopState = createRouterLoopState({
       roundTripCap: Number.isFinite(parsed) && parsed > 0 ? parsed : undefined,
-      stateLostRespawnCap:
-        Number.isFinite(slParsed) && slParsed > 0 ? slParsed : undefined,
+      stateLostRespawnCap: resolveStateLostRespawnCap(this.runtime),
     });
     // Service registration runs in parallel — when router.start() executes,
     // AcpService may not yet be registered with the runtime, so getService


### PR DESCRIPTION
## Summary

Post-merge audit residual on epic #13766 / PR #13830 (WS1 lifecycle). The task service and the sub-agent router kept **independent retry budgets for the same crash-retry event stream** and disagreed:

- `orchestrator-task-types.ts` — task budget `MAX_SESSION_RETRY_ATTEMPTS = 3`: task goes terminal `failed` at the 3rd errored session (`erroredSessions >= 3`).
- `router-loop-guard.ts` — router cap `DEFAULT_STATE_LOST_RESPAWN_CAP = 3` with `count <= cap`: the router still respawns a **4th** session on the same `session_state_lost` event.

Result: after 3 errored state-lost sessions the task record is `failed`, yet a 4th orphan worker spawns and burns tokens; if it succeeds, its `completion_reported` is dropped by terminal immutability, so the user sees router success narration against a `failed` task.

## Fix — one budget, one owner

1. **Derive the router's respawn cap from the shared budget.** `DEFAULT_STATE_LOST_RESPAWN_CAP = stateLostRespawnCapFor(MAX_SESSION_RETRY_ATTEMPTS)` (= budget − 1: the router respawns *after* an error, so N errored sessions ⇒ N−1 respawns ⇒ no (N+1)th orphan).
2. **Both sides consult one gate + one effective cap.** The router's loop-guard reducer and the task service's terminal decision both call `stateLostRespawnUnderCap(count, cap)` with the cap resolved by `resolveStateLostRespawnCap(runtime)` — which honors the `ACPX_STATE_LOST_RESPAWN_CAP` operator override on **both** sides (closing the operator-tuning drift). The task now goes terminal on exactly the error the router refuses to respawn. (Same precedent as #13909's `hasHealthyPooledAccount` shared gate.)
3. **Reset the budget on operator `restartTask`.** A per-run budget epoch is stamped in task metadata before the first spawn of the new run; the errored-session count only sums sessions spawned at/after it, so a restarted previously-failed task no longer re-fails on its first recoverable blip.

## Evidence

New reconciliation suite (`orchestrator-task-service.test.ts`, `#14104`) drives **both** subsystems over the same `session_state_lost` stream and asserts they agree:

- `task terminal decision and router respawn cap agree … — no 4th orphan`: the router's last decision is `terminal_failure` (not `respawn`), respawn count == `budget − 1`, task is `failed`, and exactly `MAX_SESSION_RETRY_ATTEMPTS` errored sessions exist (no orphan spawned past terminal).
- `keeps the lineage non-terminal while the router still respawns`.
- `restartTask resets the crash-retry budget so a restarted task survives its first recoverable blip`.

Router/account-failover mechanism tests pin `ACPX_STATE_LOST_RESPAWN_CAP` explicitly so they exercise the cap machinery, not the derived default.

```
orchestrator-task-service:   74 pass 0 fail
sub-agent-router:            89 pass 0 fail
router-loop-guard:           11 pass 0 fail
session-crash-terminates:     6 pass 0 fail
account-failover-respawn:     5 pass 0 fail
```

Scoped typecheck: no errors in the four touched source files. (Pre-existing repo-wide errors from a missing generated `src/i18n/generated/validation-keyword-data.ts` are unrelated — resolved by the normal build step.)

Out of scope / N/A: no UI, no LLM/prompt behavior, no native surface — pure orchestrator control-flow reconciliation covered by deterministic unit tests. The 3 failing `swarm-coordinator-service` fake-timer grace-window tests are pre-existing on the develop tip (those files are byte-identical to HEAD in this branch) and unrelated to this change.

Fixes #14104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
