### PR TITLE
fix(#14109): age-gated GC for the never-reclaimed child-trajectory state dir

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/child-trajectory-gc.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/child-trajectory-gc.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Bounded retention for the child-trajectory state dir (#14109). Drives the
+ * service's real startup GC (`gcChildTrajectoryDirs`) against a temp state dir
+ * of per-task trajectory dirs and asserts that:
+ *   - a terminal task's aged dir is reclaimed,
+ *   - a recent (possibly not-yet-ingested) dir is preserved even when terminal,
+ *   - a live (non-terminal) task's dir is never reclaimed even when aged,
+ *   - an orphan dir (no task doc) is reclaimed once aged,
+ *   - the retention window is honored (env override respected).
+ *
+ * Uses the injectable InMemoryTaskStore (real store, no DB); no mock stands in
+ * for the code under test. The recorder's on-disk layout (per-task dir with an
+ * <agentId>/ subdir of `<trajectoryId>.json` files) is reproduced faithfully.
+ */
+
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdir, utimes } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { InMemoryTaskStore } from "../../src/services/orchestrator-task-store.js";
+
+let stateDir: string;
+const prevStateDir = process.env.ELIZA_STATE_DIR;
+const prevMaxAge =
+  process.env.ELIZA_ORCHESTRATOR_CHILD_TRAJECTORY_GC_MAX_AGE_MS;
+
+function makeRuntime() {
+  return {
+    agentId: "00000000-0000-4000-8000-000000000001",
+    adapter: undefined,
+    databaseAdapter: undefined,
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    getSetting: () => undefined,
+    reportError: () => {},
+  } as unknown as Parameters<typeof OrchestratorTaskService>[0];
+}
+
+/** The service's private per-task dir helper — the single source of truth for
+ *  where the recorder writes, so the test can't drift from production layout. */
+function childTrajectoryDir(
+  svc: OrchestratorTaskService,
+  taskId: string,
+): string {
+  return (
+    svc as unknown as { childTrajectoryDir: (t: string) => string }
+  ).childTrajectoryDir(taskId);
+}
+
+function gc(svc: OrchestratorTaskService): Promise<void> {
+  return (
+    svc as unknown as { gcChildTrajectoryDirs: () => Promise<void> }
+  ).gcChildTrajectoryDirs();
+}
+
+/** Write a `<trajectoryId>.json` under the task's dir (nested <agentId>/ subdir,
+ *  matching the recorder) and set the whole tree's mtime to `ageMs` in the past. */
+async function writeTrajectory(
+  svc: OrchestratorTaskService,
+  taskId: string,
+  name: string,
+  ageMs: number,
+): Promise<void> {
+  const dir = join(childTrajectoryDir(svc, taskId), "child-agent");
+  await mkdir(dir, { recursive: true });
+  const file = join(dir, name);
+  writeFileSync(file, JSON.stringify({ trajectoryId: name }));
+  const when = new Date(Date.now() - ageMs);
+  // Backdate the file, the <agentId>/ subdir, and the per-task dir so the
+  // newest-mtime age gate sees the intended age.
+  await utimes(file, when, when);
+  await utimes(dir, when, when);
+  await utimes(childTrajectoryDir(svc, taskId), when, when);
+}
+
+async function makeTask(
+  store: InMemoryTaskStore,
+  status?: string,
+): Promise<string> {
+  const doc = await store.createTask({ title: "t", goal: "do the thing" });
+  if (status) {
+    await store.updateTask(doc.task.id, {
+      status: status as never,
+    });
+  }
+  return doc.task.id;
+}
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "orch-traj-gc-"));
+  process.env.ELIZA_STATE_DIR = stateDir;
+});
+
+afterEach(() => {
+  if (prevStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+  else process.env.ELIZA_STATE_DIR = prevStateDir;
+  if (prevMaxAge === undefined)
+    delete process.env.ELIZA_ORCHESTRATOR_CHILD_TRAJECTORY_GC_MAX_AGE_MS;
+  else
+    process.env.ELIZA_ORCHESTRATOR_CHILD_TRAJECTORY_GC_MAX_AGE_MS = prevMaxAge;
+});
+
+describe("gcChildTrajectoryDirs (#14109)", () => {
+  it("reclaims an aged terminal task's dir but preserves a recent un-ingested one", async () => {
+    const store = new InMemoryTaskStore();
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+
+    // Aged + terminal → reclaimed. 25h > the 24h default window.
+    const agedDone = await makeTask(store, "done");
+    await writeTrajectory(svc, agedDone, "aged.json", 25 * 60 * 60_000);
+
+    // Terminal but RECENT (10 min old) → preserved. This is the "never delete a
+    // not-yet-ingested trajectory" guarantee: a just-completed task whose files
+    // may still be mid-ingest must survive the sweep.
+    const recentDone = await makeTask(store, "done");
+    await writeTrajectory(svc, recentDone, "recent.json", 10 * 60_000);
+
+    await gc(svc);
+
+    expect(existsSync(childTrajectoryDir(svc, agedDone))).toBe(false);
+    expect(existsSync(childTrajectoryDir(svc, recentDone))).toBe(true);
+  });
+
+  it("never reclaims a live (non-terminal) task's dir even when aged", async () => {
+    const store = new InMemoryTaskStore();
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+
+    // Live task (status "open"), dir aged well past the window: a long-running
+    // task is still producing trajectories under this dir — must be kept.
+    const live = await makeTask(store); // default "open" (non-terminal)
+    await writeTrajectory(svc, live, "still-writing.json", 48 * 60 * 60_000);
+
+    await gc(svc);
+
+    expect(existsSync(childTrajectoryDir(svc, live))).toBe(true);
+  });
+
+  it("reclaims an aged orphan dir with no owning task doc", async () => {
+    const store = new InMemoryTaskStore();
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+
+    // No task doc for this id (task was purged/never persisted) → orphan.
+    const orphanId = "orphan-task-id";
+    await writeTrajectory(svc, orphanId, "orphan.json", 30 * 60 * 60_000);
+
+    await gc(svc);
+
+    expect(existsSync(childTrajectoryDir(svc, orphanId))).toBe(false);
+  });
+
+  it("preserves a recent orphan dir (a brand-new task's doc may not have landed)", async () => {
+    const store = new InMemoryTaskStore();
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+
+    const orphanId = "fresh-orphan-id";
+    await writeTrajectory(svc, orphanId, "fresh.json", 5 * 60_000);
+
+    await gc(svc);
+
+    expect(existsSync(childTrajectoryDir(svc, orphanId))).toBe(true);
+  });
+
+  it("honors the retention window override (bound respected)", async () => {
+    const store = new InMemoryTaskStore();
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+
+    // Shrink the window to 1h via env; a 2h-old terminal dir now ages out.
+    process.env.ELIZA_ORCHESTRATOR_CHILD_TRAJECTORY_GC_MAX_AGE_MS = String(
+      60 * 60_000,
+    );
+
+    const shortDone = await makeTask(store, "done");
+    await writeTrajectory(svc, shortDone, "twohr.json", 2 * 60 * 60_000);
+
+    // A 30-min-old dir stays inside the shrunk window → preserved.
+    const insideWindow = await makeTask(store, "done");
+    await writeTrajectory(svc, insideWindow, "halfhr.json", 30 * 60_000);
+
+    await gc(svc);
+
+    expect(existsSync(childTrajectoryDir(svc, shortDone))).toBe(false);
+    expect(existsSync(childTrajectoryDir(svc, insideWindow))).toBe(true);
+  });
+
+  it("is a no-op (no throw) when the trajectories root does not exist", async () => {
+    const store = new InMemoryTaskStore();
+    const svc = new OrchestratorTaskService(makeRuntime(), { store });
+    // Nothing written; the root dir was never created.
+    await expect(gc(svc)).resolves.toBeUndefined();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -23,6 +23,7 @@ import {
   mkdir,
   readdir,
   readFile,
+  rm,
   stat,
   writeFile,
 } from "node:fs/promises";
@@ -241,6 +242,17 @@ const INDEPENDENT_ACP_VERIFIER_NAME = "independent-acp-verifier";
 /** Cap on child trajectories ingested per task_complete (#13775) so a runaway
  *  sub-agent can't flood the task doc; the store's MAX_ARTIFACTS also clamps. */
 const MAX_CHILD_TRAJECTORY_ARTIFACTS = 20;
+
+/** Default retention window for per-task child-trajectory dirs under the state
+ *  dir (#14109). A per-task `<stateDir>/orchestrator/child-trajectories/<taskId>`
+ *  dir is attach-by-reference (ingest never deletes its files), so without an
+ *  aged reclaim it grows unbounded — the same disk-leak class as the 3.6TB
+ *  worktree-farm incident (#13773), just relocated into the state dir. Reclaimed
+ *  only once the owning task is terminal (or absent) AND the dir has been idle
+ *  past this window, so an in-flight or not-yet-ingested trajectory is never
+ *  deleted. 24h mirrors ACP_SCRATCH_GC_MAX_AGE_MS. Overridable via
+ *  `ELIZA_ORCHESTRATOR_CHILD_TRAJECTORY_GC_MAX_AGE_MS`. */
+const CHILD_TRAJECTORY_GC_MAX_AGE_MS = 24 * 60 * 60_000;
 
 /** Default upper bound on how long the independent verifier session may run
  *  before its await is abandoned (treated as inconclusive). Overridable via
@@ -770,6 +782,20 @@ export class OrchestratorTaskService extends Service {
     // Persist self-spend durably so a configured ELIZA_AGENT_SPEND_CAP_USD
     // survives a restart instead of resetting to zero (#8924).
     configureSpendLedger(createTaskStoreSpendLedger(this.store));
+    // Reclaim aged per-task child-trajectory dirs under the state dir (#14109).
+    // Ingest attaches by reference and never deletes, and no workspace-GC path
+    // reaches the state dir, so without this the dir grows without bound. Runs
+    // once at start, after the store is wired; best-effort so a sweep hiccup
+    // never blocks service start (below).
+    void this.gcChildTrajectoryDirs().catch((err) => {
+      // error-policy:J7 startup GC is a disk-hygiene convenience; a failure is
+      // reported (the leak stays observable) but must not abort service start.
+      this.runtime.reportError?.(
+        "OrchestratorTask.gcChildTrajectoryDirs",
+        err,
+        {},
+      );
+    });
     // Resume any tasks parked before a restart, then arm the reconcile tick that
     // drains the queue even when no terminal session event fires (a sweptStale
     // session frees a slot silently). Best-effort: a store hiccup here must not
@@ -1171,17 +1197,167 @@ export class OrchestratorTaskService extends Service {
   }
 
   /**
+   * Root under the state dir holding every task's child-trajectory dir (#13775),
+   * i.e. `<stateDir>/orchestrator/child-trajectories`. Swept by
+   * {@link gcChildTrajectoryDirs} on start (#14109).
+   */
+  private childTrajectoriesRoot(): string {
+    return join(resolveStateDir(), "orchestrator", "child-trajectories");
+  }
+
+  /**
    * Per-task directory a spawned sub-agent's file recorder writes its own
-   * trajectories into (#13775), scanned on task_complete. Under the shared state
-   * dir so #13773's workspace-GC registry can reclaim it with the task.
+   * trajectories into (#13775), scanned on task_complete.
+   *
+   * NOTE (#14109): this lives under the state dir, NOT a workspace scratch root,
+   * so `AcpService.gcOrphanedScratchDirs` (which only scans configured workspace
+   * roots) never reclaims it, and ingest is attach-by-reference (the JSON files
+   * are never deleted after being attached). Reclamation is therefore explicit,
+   * via {@link gcChildTrajectoryDirs}, an age-gated startup sweep of
+   * {@link childTrajectoriesRoot}.
    */
   private childTrajectoryDir(taskId: string): string {
-    return join(
-      resolveStateDir(),
-      "orchestrator",
-      "child-trajectories",
-      taskId,
+    return join(this.childTrajectoriesRoot(), taskId);
+  }
+
+  /**
+   * Bounded retention for the child-trajectory state dir (#14109). A per-task
+   * `<stateDir>/orchestrator/child-trajectories/<taskId>` dir is written by a
+   * sub-agent's recorder and attached by reference on task_complete — the files
+   * are never deleted after ingest, and no workspace-GC path reaches the state
+   * dir. Left unchecked it grows without bound (the disk-leak class #13773
+   * exists to prevent, relocated into the state dir).
+   *
+   * Runs once at startup (mirroring `AcpService.cleanOrphanedScratchWorkdirs`).
+   * For each per-task dir it reclaims ONLY when BOTH hold:
+   *  - the owning task is terminal in this store, OR has no task doc at all
+   *    (an orphan left by a crashed/purged task) — a live task keeps its dir; and
+   *  - the dir has been idle (newest entry's mtime) past the retention window.
+   *
+   * The age gate is the load-bearing safety: a not-yet-ingested or in-flight
+   * trajectory is recent by construction, so it is never deleted even if its
+   * task doc looks terminal (e.g. a respawned session still writing). Deletes
+   * are best-effort; a locked/vanished dir is skipped and retried next boot.
+   */
+  private async gcChildTrajectoryDirs(): Promise<void> {
+    const root = this.childTrajectoriesRoot();
+    let entries: string[];
+    try {
+      entries = await readdir(root);
+    } catch (err) {
+      // error-policy:J3 an absent root is the expected empty shape (no task has
+      // ever recorded a child trajectory) — explicit zero-work result, never a
+      // masked read failure.
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      this.runtime.reportError?.(
+        "OrchestratorTaskService.gcChildTrajectoryDirs",
+        err,
+        { phase: "readdir", root },
+      );
+      return;
+    }
+
+    const maxAgeMs = parsePositiveIntSetting(
+      this.readSetting("ELIZA_ORCHESTRATOR_CHILD_TRAJECTORY_GC_MAX_AGE_MS"),
+      CHILD_TRAJECTORY_GC_MAX_AGE_MS,
     );
+    const now = Date.now();
+    let reclaimed = 0;
+    let kept = 0;
+
+    await Promise.allSettled(
+      entries.map(async (taskId) => {
+        const path = join(root, taskId);
+        try {
+          const st = await stat(path);
+          if (!st.isDirectory()) {
+            kept++;
+            return;
+          }
+        } catch {
+          // error-policy:J6 vanished mid-scan — nothing left to reclaim.
+          return;
+        }
+
+        // A live (non-terminal) task is still producing trajectories under this
+        // dir — never reclaim it. An absent task doc is an orphan (its task was
+        // purged/never persisted): reclaimable, but still age-gated below so a
+        // dir a brand-new task is actively writing isn't yanked out from under
+        // it before its doc lands.
+        let taskIsReclaimable: boolean;
+        try {
+          const doc = await this.store.getTask(taskId);
+          taskIsReclaimable =
+            !doc || TERMINAL_TASK_STATUSES.has(doc.task.status);
+        } catch (err) {
+          // error-policy:J7 DATA-LOSS GUARD. A store read failure must not be
+          // read as "no task" — that would treat a live task's dir as an orphan
+          // and delete work. Keep the dir; the next boot retries with real data.
+          this.runtime.reportError?.(
+            "OrchestratorTaskService.gcChildTrajectoryDirs",
+            err,
+            { phase: "store.getTask", taskId },
+          );
+          kept++;
+          return;
+        }
+        if (!taskIsReclaimable) {
+          kept++;
+          return;
+        }
+
+        // Age gate: newest mtime across the dir tree (the recorder nests files
+        // under an <agentId>/ subdir). A trajectory written since the retention
+        // window — i.e. possibly not yet ingested, or from a respawned session
+        // still running — keeps the whole dir. Fall back to the dir's own mtime
+        // for an empty dir.
+        let newestMtimeMs = 0;
+        try {
+          const rel = await readdir(path, { recursive: true });
+          const stats = await Promise.all(
+            rel.map((p) =>
+              stat(join(path, p)).then(
+                (s) => s.mtimeMs,
+                () => 0,
+              ),
+            ),
+          );
+          newestMtimeMs = stats.reduce((max, m) => Math.max(max, m), 0);
+          if (newestMtimeMs === 0) {
+            newestMtimeMs = (await stat(path)).mtimeMs;
+          }
+        } catch {
+          // error-policy:J6 vanished mid-scan — nothing left to reclaim.
+          return;
+        }
+        if (now - newestMtimeMs <= maxAgeMs) {
+          kept++;
+          return;
+        }
+
+        try {
+          await rm(path, { recursive: true, force: true });
+          reclaimed++;
+        } catch (err) {
+          // error-policy:J6 best-effort GC; a locked/vanished dir is skipped so
+          // the sweep continues and retries next boot.
+          this.log("warn", "child-trajectory GC: failed to remove dir", {
+            taskId,
+            path,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }),
+    );
+
+    if (reclaimed > 0 || kept > 0) {
+      this.log("info", "reclaimed aged child-trajectory dirs", {
+        reclaimed,
+        kept,
+        root,
+        olderThanMs: maxAgeMs,
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem (#14109, #13871 WS5 audit)

`<stateDir>/orchestrator/child-trajectories/<taskId>` is **never garbage-collected**.

- Ingest (`ingestChildTrajectories`) is attach-by-reference — the trajectory JSON files are never deleted after being attached as artifacts.
- No workspace-GC path reaches the state dir: `AcpService.gcOrphanedScratchDirs` / `configuredScratchRoots` only scan **workspace roots**, never `<stateDir>`. The stale comment at `orchestrator-task-service.ts` claimed #13773's workspace-GC registry could reclaim it — it cannot.

Result: every trajectory-gated eliza-backend task run accumulates per-task JSON under the state dir **forever** — the same disk-leak class as the 3.6TB worktree-farm incident that motivated #13773, relocated into `<stateDir>`.

## Fix

Add `gcChildTrajectoryDirs`, an age-gated **startup sweep** (mirroring `AcpService.cleanOrphanedScratchWorkdirs`) of the child-trajectories root. A per-task dir is reclaimed only when **BOTH** hold:

1. the owning task is **terminal** in the store, OR has **no task doc** at all (an orphan left by a purged/never-persisted task); **and**
2. the dir has been **idle** (newest entry's mtime across the tree) **past a retention window**.

The **age gate is the load-bearing safety**: a not-yet-ingested or in-flight trajectory is recent by construction, so it is never deleted — even if its task looks terminal (e.g. a respawned session still writing). A store-read failure **keeps** the dir (data-loss guard) instead of misreading it as an orphan. Deletes are best-effort; a locked/vanished dir is skipped and retried next boot.

- Default window **24h**, overridable via `ELIZA_ORCHESTRATOR_CHILD_TRAJECTORY_GC_MAX_AGE_MS` (mirrors `ELIZA_ACP_SCRATCH_GC_MAX_AGE_MS`).
- Also fixes the stale `#13773 workspace-GC` comment at `childTrajectoryDir`.

### Non-overlap with #14110 (PR #14137)

Purely **additive** to the ingest-dedupe fix. #14110 intentionally *leaves* files on disk for cross-session ingest dedupe; this GC only touches dirs that are **terminal/absent AND aged**, so recent files (its dedupe substrate) are never touched.

## Tests

`child-trajectory-gc.test.ts` — real vitest against the injectable `InMemoryTaskStore` and a temp state dir (no mocks for code under test):

- aged terminal-task dir **reclaimed**
- terminal but **recent** (un-ingested) dir **preserved**
- **live** (non-terminal) task dir **never** reclaimed even when aged
- aged **orphan** (no task doc) reclaimed
- **recent** orphan preserved (a brand-new task's doc may not have landed)
- retention-window **override honored**
- absent-root **no-op** (no throw)

The three safety cases are **reversion-proven** (they FAIL when the age gate is removed — verified by patch-out/re-apply).

```
✓ __tests__/unit/child-trajectory-gc.test.ts (6 tests)
✓ __tests__/unit/child-trajectory-ingest.test.ts (4 tests)   # sibling, unaffected
Test Files  2 passed (2)
     Tests  10 passed (10)
```

## Verification

- targeted vitest green (6 gc + 4 sibling-ingest)
- reversion-proof: 3 safety tests fail on the age-gate-removed variant
- `tsgo --noEmit -p tsconfig.json`: **0 errors**
- biome clean on both touched files
- codex review hung >100s on this host (large noisy worktree) → killed per protocol; self-reviewed (concurrency-safe sync counters, path stays under root, non-dir/symlink root entries skipped, clock-skew is conservative-keep)
- pre-existing `acp-scratch-gc.test.ts` reds are unrelated (that suite references neither touched file; fails identically on pristine `develop`)

Introduced by #13871; found by the post-merge audit for epic #13766. Related: #13773, #14110 (PR #14137).

Fixes #14109

-- [sol-orch]
