### PR TITLE
fix(ui): autosave Character bio edits — stop losing About Me on section-switch (#14154)

### DIFF
--- a/packages/ui/src/components/character/CharacterEditor.tsx
+++ b/packages/ui/src/components/character/CharacterEditor.tsx
@@ -1455,7 +1455,6 @@ export function CharacterEditor({
               normalizedMessageExamples={normalizedMessageExamples}
               pendingStyleEntries={pendingStyleEntries}
               styleEntryDrafts={styleEntryDrafts}
-              handleFieldEdit={handleFieldEdit}
               applyFieldEdit={(field, value) => {
                 handleCharacterFieldInput(
                   field as keyof CharacterData,

--- a/packages/ui/src/components/character/CharacterHubView.test.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.test.tsx
@@ -54,7 +54,9 @@ afterEach(() => {
 
 const noop = vi.fn();
 
-function renderHub(applyFieldEdit: (field: string, value: unknown) => void = noop) {
+function renderHub(
+  applyFieldEdit: (field: string, value: unknown) => void = noop,
+) {
   return render(
     <CharacterHubView
       d={{}}

--- a/packages/ui/src/components/character/CharacterHubView.test.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.test.tsx
@@ -8,8 +8,10 @@
 // header (the shared CharacterSectionNav supplies it). The panels are stubbed so
 // the test isolates the hub's own structure, not their internals.
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { updateCharacter } = vi.hoisted(() => ({ updateCharacter: vi.fn() }));
 
 vi.mock("../../state", () => ({
   useAppSelectorShallow: (selector: (s: unknown) => unknown) =>
@@ -19,21 +21,40 @@ vi.mock("../../state", () => ({
         opts?.defaultValue ?? _key,
     }),
 }));
-vi.mock("../../api/client", () => ({ client: { updateCharacter: vi.fn() } }));
+vi.mock("../../api/client", () => ({ client: { updateCharacter } }));
 vi.mock("../../widgets/WidgetHost", () => ({ WidgetHost: () => null }));
+// The identity-panel stub exposes a button that drives the `handleFieldEdit`
+// prop the hub passes in, so the bio-autosave wiring can be exercised without
+// rendering the real Textarea/agent-surface machinery.
 vi.mock("./CharacterEditorPanels", () => ({
-  CharacterIdentityPanel: () => <div data-testid="identity-panel" />,
+  CharacterIdentityPanel: ({
+    handleFieldEdit,
+  }: {
+    handleFieldEdit: (field: string, value: unknown) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="identity-panel"
+      onClick={() => handleFieldEdit("bio", "new bio text")}
+    >
+      identity
+    </button>
+  ),
   CharacterStylePanel: () => <div data-testid="style-panel" />,
   CharacterExamplesPanel: () => <div data-testid="examples-panel" />,
 }));
 
 import { CharacterHubView } from "./CharacterHubView";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  updateCharacter.mockReset();
+  vi.useRealTimers();
+});
 
 const noop = vi.fn();
 
-function renderHub() {
+function renderHub(applyFieldEdit: (field: string, value: unknown) => void = noop) {
   return render(
     <CharacterHubView
       d={{}}
@@ -41,8 +62,7 @@ function renderHub() {
       normalizedMessageExamples={[]}
       pendingStyleEntries={{}}
       styleEntryDrafts={{}}
-      handleFieldEdit={noop}
-      applyFieldEdit={noop}
+      applyFieldEdit={applyFieldEdit}
       handlePendingStyleEntryChange={noop}
       applyStyleEdit={noop}
       handleStyleEntryDraftChange={noop}
@@ -93,5 +113,22 @@ describe("CharacterHubView (Personality-only collapse)", () => {
   it("has no manual Save button (edits autosave)", () => {
     renderHub();
     expect(screen.queryByRole("button", { name: /save/i })).toBeNull();
+  });
+
+  // With the manual Save button gone, an identity (bio) edit must debounce-persist
+  // on its own — otherwise it would be lost on section-switch (the regression this
+  // guards). The style/examples panels already autosaved; bio did not.
+  it("autosaves a bio edit (debounced PATCH), applying the draft immediately", () => {
+    vi.useFakeTimers();
+    const applyFieldEdit = vi.fn();
+    renderHub(applyFieldEdit);
+
+    fireEvent.click(screen.getByTestId("identity-panel"));
+    // Draft update is synchronous; the network patch is debounced.
+    expect(applyFieldEdit).toHaveBeenCalledWith("bio", "new bio text");
+    expect(updateCharacter).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(700);
+    expect(updateCharacter).toHaveBeenCalledWith({ bio: "new bio text" });
   });
 });

--- a/packages/ui/src/components/character/CharacterHubView.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.tsx
@@ -48,7 +48,6 @@ export function CharacterHubView({
   normalizedMessageExamples,
   pendingStyleEntries,
   styleEntryDrafts,
-  handleFieldEdit,
   applyFieldEdit,
   handlePendingStyleEntryChange,
   applyStyleEdit,
@@ -60,7 +59,6 @@ export function CharacterHubView({
   normalizedMessageExamples: MessageExampleGroup[];
   pendingStyleEntries: Record<string, string>;
   styleEntryDrafts: Record<string, string[]>;
-  handleFieldEdit: (field: string, value: unknown) => void;
   applyFieldEdit: (field: string, value: unknown) => void;
   handlePendingStyleEntryChange: (key: string, value: string) => void;
   applyStyleEdit: (key: CharacterStyleSection, value: string) => void;
@@ -133,6 +131,18 @@ export function CharacterHubView({
       if (field === "messageExamples" || field === "postExamples") {
         scheduleAutoSave({ [field]: value } as CharacterData);
       }
+    },
+    [applyFieldEdit, scheduleAutoSave],
+  );
+
+  // Identity fields (bio) autosave on the same debounce as style/examples. This
+  // view has no manual Save button, so an identity edit that only updated the
+  // draft would be lost on section-switch; scheduling the patch here is the only
+  // persistence path for the field.
+  const handleAutoSavedFieldEdit = useCallback(
+    (field: string, value: unknown) => {
+      applyFieldEdit(field, value);
+      scheduleAutoSave({ [field]: value } as CharacterData);
     },
     [applyFieldEdit, scheduleAutoSave],
   );
@@ -230,7 +240,7 @@ export function CharacterHubView({
           <section>
             <CharacterIdentityPanel
               bioText={bioText}
-              handleFieldEdit={handleFieldEdit}
+              handleFieldEdit={handleAutoSavedFieldEdit}
               t={t}
             />
           </section>


### PR DESCRIPTION
Closes #14154. Follow-up to #13591 (merged as #14123 / `525e5aa`).

## The bug (data loss)

#13591 removed the Character **Personality** view's manual Save button in favor of debounced autosave (spec step 7) — but only **style** and **message-example** edits were wired to `scheduleAutoSave`. The identity panel's `handleFieldEdit` (which edits **bio / About Me**) merely updated the draft; nothing persisted it. With the Save button gone and `beforeunload` only guarding tab-close (not in-app section-switch), **editing the bio and switching Character sections silently lost the edit** — no autosave, no Save button, no persistence path at all.

Before #13591 the bio was covered by the Personality view's (now-deleted) manual Save button. This is the "not loaded reads as healthy" failure the error policy bans: an edit reads as accepted, then vanishes.

## Fix

Route identity edits through an autosaving wrapper (`applyFieldEdit` + `scheduleAutoSave({ [field]: value })`) on the same 700 ms debounce, flushed on unmount — mirroring `handleAutoSavedExamplesEdit`. The now-unused `handleFieldEdit` prop is dropped from `CharacterHubView` (the sceneOverlay editor keeps its own manual-save path, untouched).

The server `PUT /api/character` already partial-merges a `{ bio }` patch (`packages/agent/src/api/character-routes.ts:440-443` converts a string bio to `[bio]`), so a bio-only debounced patch persists exactly like the style/example patches that already worked.

## Test

`CharacterHubView.test.tsx` gains a regression test: a bio edit applies the draft synchronously and PATCHes `{ bio: "new bio text" }` after the 700 ms debounce (fake timers). The prior "no manual Save button" assertion is kept — this test proves the autosave that assertion presumed.

- `bun run --cwd packages/ui test -- CharacterHubView CharacterSectionNav` → 14 pass.
- `bun run audit:error-policy-ratchet` → no new fallback-slop (2 touched production files).
- Scoped typecheck: no new errors in `components/character` / `App.tsx`.

## Evidence

Rendered-proof (video/screenshots desktop+mobile) defers to the epic's visual-audit sweep #13598, per #13560 plan — this is a wiring fix to an already-merged structural PR. The regression test drives the real autosave debounce/PATCH path (deterministic timers + mocked client asserting the exact `{ bio }` body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
