### PR TITLE
fix(agent): preserve incumbent view-scoped action owners

### DIFF
--- a/packages/agent/src/runtime/view-scoped-actions.test.ts
+++ b/packages/agent/src/runtime/view-scoped-actions.test.ts
@@ -12,7 +12,7 @@
 import type http from "node:http";
 import { Readable } from "node:stream";
 import type { Action, IAgentRuntime } from "@elizaos/core";
-import { ElizaError, isElizaError } from "@elizaos/core";
+import { type ElizaError, isElizaError } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   registerPluginViews,
@@ -70,9 +70,7 @@ function makeInteractiveView(id: string, mountedIds: Set<string>) {
         {
           name: `VIEW_${id.toUpperCase()}_MISSING_TARGET`,
           description: "Drives an element that is not mounted",
-          steps: [
-            { kind: "agent-click" as const, target: "ghost-button" },
-          ],
+          steps: [{ kind: "agent-click" as const, target: "ghost-button" }],
         },
       ],
       serverInteract: async (
@@ -122,18 +120,30 @@ async function navigateTo(id: string): Promise<void> {
  * validate()/handler() the mechanism built.
  */
 function makeRuntime(): {
-  runtime: Pick<IAgentRuntime, "registerAction" | "unregisterAction">;
+  runtime: Pick<
+    IAgentRuntime,
+    "actions" | "registerAction" | "unregisterAction"
+  >;
   actions: Map<string, Action>;
 } {
   const actions = new Map<string, Action>();
+  const actionList: Action[] = [];
   return {
     actions,
     runtime: {
+      actions: actionList,
       registerAction: (action: Action) => {
+        if (actions.has(action.name)) return;
         actions.set(action.name, action);
+        actionList.push(action);
       },
-      unregisterAction: (name: string) => actions.delete(name),
-    } as Pick<IAgentRuntime, "registerAction" | "unregisterAction">,
+      unregisterAction: (name: string) => {
+        const removed = actions.delete(name);
+        const index = actionList.findIndex((action) => action.name === name);
+        if (index >= 0) actionList.splice(index, 1);
+        return removed;
+      },
+    } as Pick<IAgentRuntime, "actions" | "registerAction" | "unregisterAction">,
   };
 }
 
@@ -231,7 +241,10 @@ describe("view-scoped action handler drives the interact protocol", () => {
   });
 
   it("throws a typed missing-element error when a target useAgentElement id is not mounted", async () => {
-    const settings = makeInteractiveView("settings", new Set(["provider-select"]));
+    const settings = makeInteractiveView(
+      "settings",
+      new Set(["provider-select"]),
+    );
     await registerPluginViews(
       {
         name: TEST_PLUGIN,
@@ -328,9 +341,7 @@ describe("view-scoped action registration reconciliation", () => {
       settings.view,
     ]);
 
-    expect(registered).toEqual(
-      scopedActionNames(settings.view.scopedActions),
-    );
+    expect(registered).toEqual(scopedActionNames(settings.view.scopedActions));
     expect(actions.has("VIEW_SETTINGS_SET_PROVIDER")).toBe(true);
     expect(actions.has("VIEW_SETTINGS_MISSING_TARGET")).toBe(true);
 
@@ -372,5 +383,27 @@ describe("view-scoped action registration reconciliation", () => {
       a.view.scopedActions[0].description,
     );
     void warn;
+  });
+
+  it("does not unregister an incumbent action when a scoped action collides by name", () => {
+    const { runtime, actions } = makeRuntime();
+    const incumbent: Action = {
+      name: "VIEW_SETTINGS_SET_PROVIDER",
+      description: "global incumbent",
+      handler: async () => undefined,
+    };
+    runtime.registerAction(incumbent);
+    const settings = makeInteractiveView("settings", new Set());
+
+    const registered = registerViewScopedActions(runtime, TEST_PLUGIN, [
+      settings.view,
+    ]);
+
+    expect(registered).toEqual(["VIEW_SETTINGS_MISSING_TARGET"]);
+    expect(actions.get("VIEW_SETTINGS_SET_PROVIDER")).toBe(incumbent);
+
+    unregisterViewScopedActions(runtime, TEST_PLUGIN);
+    expect(actions.get("VIEW_SETTINGS_SET_PROVIDER")).toBe(incumbent);
+    expect(actions.has("VIEW_SETTINGS_MISSING_TARGET")).toBe(false);
   });
 });

--- a/packages/agent/src/runtime/view-scoped-actions.ts
+++ b/packages/agent/src/runtime/view-scoped-actions.ts
@@ -29,13 +29,12 @@ import {
   type State,
   type ViewScopedAction,
   type ViewScopedActionStep,
-  type ViewType,
 } from "@elizaos/core";
+import { getView } from "../api/views-registry.ts";
 import {
   dispatchViewInteract,
   getViewsBroadcastWs,
 } from "../api/views-routes.ts";
-import { getView } from "../api/views-registry.ts";
 import { getActiveViewContext } from "./view-action-affinity.ts";
 
 /** How long a single agent-surface step waits for the frontend to resolve. */
@@ -49,9 +48,7 @@ const PARAM_TOKEN = /^\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}$/;
  * params under `options.parameters` (the #10677 contract); fall back to the flat
  * `options` object for direct/test callers. Returns an empty object when absent.
  */
-function readActionParams(
-  options: unknown,
-): Record<string, unknown> {
+function readActionParams(options: unknown): Record<string, unknown> {
   if (!options || typeof options !== "object") return {};
   const record = options as Record<string, unknown>;
   const nested = record.parameters;
@@ -148,17 +145,6 @@ function unwrapInteractResult(result: unknown): unknown {
 }
 
 /**
- * Resolve the concrete view type the scoped action's view is registered under,
- * preferring the active view's type. Scoped actions only validate while their
- * view is active, so at handler time the active view IS the declaring view.
- */
-function resolveViewType(viewId: string): ViewType {
-  const active = getActiveViewContext();
-  if (active?.viewId === viewId) return active.viewType;
-  return getView(viewId)?.viewType ?? "gui";
-}
-
-/**
  * Build a runtime {@link Action} from a view's scoped-action declaration.
  *
  * @param viewId - the declaring view's id (the active-view gate).
@@ -236,7 +222,6 @@ export function buildViewScopedAction(
       }
 
       const params = readActionParams(options);
-      const viewType = resolveViewType(viewId);
       const driven: string[] = [];
 
       for (const step of decl.steps) {
@@ -314,9 +299,7 @@ export function scopedActionNames(
   scopedActions: readonly ViewScopedAction[] | undefined,
 ): string[] {
   return [
-    ...new Set(
-      (scopedActions ?? []).map((a) => a.name.trim()).filter(Boolean),
-    ),
+    ...new Set((scopedActions ?? []).map((a) => a.name.trim()).filter(Boolean)),
   ];
 }
 
@@ -327,12 +310,55 @@ interface ScopedActionSourceView {
 }
 
 /**
- * Per-owner set of scoped-action names currently registered in the runtime, so
- * a reload/unload can remove exactly the previously-registered set without
+ * Per-owner action objects currently registered in the runtime, so a
+ * reload/unload can remove exactly the previously-registered set without
  * touching another owner's actions. Keyed by the owner passed to
  * {@link registerViewScopedActions} (plugin name, or "@elizaos/builtin").
  */
-const registeredByOwner = new Map<string, Set<string>>();
+const registeredByOwner = new Map<string, Map<string, Action>>();
+
+type ScopedActionRuntime = Pick<
+  IAgentRuntime,
+  "registerAction" | "unregisterAction"
+> &
+  Partial<Pick<IAgentRuntime, "actions">>;
+
+function findRuntimeAction(
+  runtime: Pick<IAgentRuntime, "actions">,
+  name: string,
+): Action | undefined {
+  return runtime.actions.find((action) => action.name === name);
+}
+
+function unregisterOwnedScopedActions(
+  runtime: ScopedActionRuntime,
+  owner: string,
+): void {
+  const previous = registeredByOwner.get(owner);
+  if (!previous) return;
+  if (!Array.isArray(runtime.actions)) {
+    logger.warn(
+      { src: "ViewScopedActions", owner },
+      `[ViewScopedActions] cannot prove scoped-action ownership for owner "${owner}" during unregister; leaving actions registered`,
+    );
+    registeredByOwner.delete(owner);
+    return;
+  }
+  for (const [name, action] of previous) {
+    if (
+      findRuntimeAction(runtime as Pick<IAgentRuntime, "actions">, name) !==
+      action
+    ) {
+      logger.warn(
+        { src: "ViewScopedActions", owner, actionName: name },
+        `[ViewScopedActions] scoped action "${name}" for owner "${owner}" is no longer installed by that owner; skipping unregister`,
+      );
+      continue;
+    }
+    runtime.unregisterAction(name);
+  }
+  registeredByOwner.delete(owner);
+}
 
 /**
  * Reconcile the runtime action registry with the scoped actions declared by
@@ -344,29 +370,48 @@ const registeredByOwner = new Map<string, Set<string>>();
  * @returns the scoped-action names now registered for this owner.
  */
 export function registerViewScopedActions(
-  runtime: Pick<IAgentRuntime, "registerAction" | "unregisterAction">,
+  runtime: ScopedActionRuntime,
   owner: string,
   views: readonly ScopedActionSourceView[],
 ): string[] {
-  const previous = registeredByOwner.get(owner);
-  if (previous) {
-    for (const name of previous) runtime.unregisterAction(name);
-  }
+  unregisterOwnedScopedActions(runtime, owner);
 
-  const registered = new Set<string>();
+  const registered = new Map<string, Action>();
   for (const view of views) {
     for (const decl of view.scopedActions ?? []) {
       const name = decl.name.trim();
       if (!name) continue;
       if (registered.has(name)) {
         logger.warn(
-          { src: "ViewScopedActions", owner, viewId: view.id, actionName: name },
+          {
+            src: "ViewScopedActions",
+            owner,
+            viewId: view.id,
+            actionName: name,
+          },
           `[ViewScopedActions] duplicate scoped-action name "${name}" for owner "${owner}" — keeping first`,
         );
         continue;
       }
-      runtime.registerAction(buildViewScopedAction(view.id, decl));
-      registered.add(name);
+      const action = buildViewScopedAction(view.id, decl);
+      runtime.registerAction(action);
+      if (
+        Array.isArray(runtime.actions) &&
+        findRuntimeAction(runtime as Pick<IAgentRuntime, "actions">, name) !==
+          action
+      ) {
+        logger.warn(
+          {
+            src: "ViewScopedActions",
+            owner,
+            viewId: view.id,
+            actionName: name,
+          },
+          `[ViewScopedActions] scoped-action name "${name}" for owner "${owner}" conflicts with an existing action — keeping incumbent`,
+        );
+        continue;
+      }
+      registered.set(name, action);
     }
   }
 
@@ -379,18 +424,15 @@ export function registerViewScopedActions(
   } else {
     registeredByOwner.delete(owner);
   }
-  return [...registered];
+  return [...registered.keys()];
 }
 
 /** Unregister all scoped actions registered for `owner` (plugin unload). */
 export function unregisterViewScopedActions(
-  runtime: Pick<IAgentRuntime, "unregisterAction">,
+  runtime: ScopedActionRuntime,
   owner: string,
 ): void {
-  const previous = registeredByOwner.get(owner);
-  if (!previous) return;
-  for (const name of previous) runtime.unregisterAction(name);
-  registeredByOwner.delete(owner);
+  unregisterOwnedScopedActions(runtime, owner);
 }
 
 /** Test-only: forget all owner→action bookkeeping (does not touch a runtime). */


### PR DESCRIPTION
## Summary
- fix post-merge #13822 scoped-action ownership: only record scoped actions that the runtime actually installed
- skip unregister when the installed action no longer matches the owner
- remove the unused viewType helper that caused Biome to fail on the merged file
- add a regression proving a colliding global/incumbent action survives scoped plugin unload

## Verification
- `node packages/shared/scripts/generate-keywords.mjs --target ts` (fresh worktree prerequisite)
- `bun run --cwd packages/agent test src/runtime/view-scoped-actions.test.ts` (9 passed)
- `bunx @biomejs/biome check packages/agent/src/runtime/view-scoped-actions.ts packages/agent/src/runtime/view-scoped-actions.test.ts --no-errors-on-unmatched`
- `git diff --check`

## Evidence rows
- Live LLM trajectory: N/A - registry ownership bugfix, no model/action planner behavior beyond runtime action registration semantics.
- UI screenshots/video: N/A - no rendered UI change.
- Backend logs/domain artifacts: focused runtime test exercises the real register/unregister reconciliation path with `AgentRuntime`-compatible action storage.

Follow-up to post-merge blocker found on #13822: https://github.com/elizaOS/eliza/pull/13822#issuecomment-4884644488