### PR TITLE
fix(ci): guarantee Node on PATH in setup-bun-workspace + stale-base-guard

### DIFF
--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -46,10 +46,37 @@ inputs:
     description: "Run `git submodule update --init --recursive` before install"
     required: false
     default: "false"
+  setup-node:
+    description: >-
+      Whether to set up Node.js. Self-hosted runners are not guaranteed to have
+      `node` on PATH, and this action's very first step (turbo-cache-key) shells
+      out to `node`, so leave this on unless the caller already ran
+      actions/setup-node in the same job.
+    required: false
+    default: "true"
+  node-version:
+    description: "Node.js version to set up when setup-node is true"
+    required: false
+    default: "24"
 
 runs:
   using: "composite"
   steps:
+    # Self-hosted (hetzner-robot) runners are not guaranteed to expose `node`
+    # on the step PATH, and the very next step (turbo-cache-github ->
+    # turbo-cache-key.mjs) invokes `node` directly. Without this, jobs that
+    # rely solely on this composite for their toolchain (coverage-gate,
+    # feed-env-audit, scenario-matrix, voice-workbench) fail with
+    # "node: command not found" on runners missing a system Node. setup-node is
+    # idempotent, so callers that already ran it (keyless-harness, the audits)
+    # just re-select the same version. Toggle off via setup-node: "false".
+    - name: Setup Node.js
+      if: ${{ inputs.setup-node == 'true' }}
+      # actions/setup-node@v4 (48b55a0)
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      with:
+        node-version: ${{ inputs.node-version }}
+
     # Persist Turbo's local filesystem cache (.turbo) through the pinned
     # GitHub-native shim (#12341) — the single Turbo cache regime, replacing the
     # Vercel SaaS remote cache. The shim keys on the deterministic

--- a/.github/workflows/stale-base-guard.yml
+++ b/.github/workflows/stale-base-guard.yml
@@ -57,6 +57,16 @@ jobs:
           fetch-depth: 1
           submodules: false
 
+      # The guard steps below invoke `node` directly, but self-hosted
+      # (hetzner-robot) runners are not guaranteed to have Node on PATH, so
+      # the self-test step fails with "node: command not found". Set up Node
+      # explicitly; this workflow does not use setup-bun-workspace.
+      - name: Setup Node.js
+        # actions/setup-node@v4 (48b55a0)
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
       - name: Fetch PR head + bounded history (blobless)
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Problem

Self-hosted (`hetzner-robot`) runners are not guaranteed to expose `node` on the step PATH. Two CI surfaces relied on a pre-installed system Node and failed **deterministically** with `node: command not found` on the `eliza-prod-robot-*` fleet:

1. **`setup-bun-workspace` composite** — its very first step (`turbo-cache-github` → `turbo-cache-key.mjs`) invokes `node` directly. Jobs that use this composite as their only toolchain setup fail: **coverage-gate**, **Env Audit** (`feed-env-audit`), **scenario-matrix**, **voice-workbench** (the four workflows that use the composite but carry *zero* `setup-node` steps).
2. **`stale-base-guard.yml`** — its self-test + detector steps call `node` with no `setup-node` and don't use the composite.

Runs land on `eliza-robot-1..22` (system Node present → pass) or `eliza-prod-robot-*` (no system Node → fail), so it looked flaky but is deterministic per-runner.

## Evidence (develop, last 24h, non-cancelled)

| Workflow | Failures | Signature |
|---|---|---|
| Env Audit | 66 | `node: command not found` in Setup Bun workspace |
| Stale Base Guard | 58 | `node: command not found` in self-test |
| coverage-gate | 34 | `node: command not found` in Setup Bun workspace |

## Fix

- Add a `setup-node` step (default **on**, toggleable via a new `setup-node` input; `node-version` default `24`) to the composite, **before** the turbo-cache step. Idempotent for callers that already run `actions/setup-node` (keyless-harness, app/cloud aesthetic audits) — they just re-select 24.
- Add `setup-node` after checkout in `stale-base-guard.yml`.

Root cause is runner-side (node absent on prod-robot fleet), but the robust fix is to make the workflows self-sufficient rather than depend on undocumented runner state — the app/cloud audits already carry their own `setup-node` for exactly this reason. If the prod-robot fleet later gets Node baked into the image, `setup-node: "false"` is available to skip.

## Validation

- Contract tests pass: `ci-bun-version-contract`, `ci-workflow-dedup-contract`, `turbo-cache-key` (16), `scenario-pr-workflow` (11).
- `actionlint` clean on both touched workflows; composite YAML validated.

Refs #14051.

[sol-orch] ci-medic