### PR TITLE
fix(agent): gate mutating view interactions by surface grant

### DIFF
--- a/.github/issue-evidence/13822-view-surface-gate/README.md
+++ b/.github/issue-evidence/13822-view-surface-gate/README.md
@@ -1,0 +1,40 @@
+# View surface-grant gate (#13822 hardening)
+
+Gates **mutating** view interactions (`click-element`, `fill-input`, `agent-click`,
+`agent-fill`, `agent-focus`, `agent-scroll-to`, `set-highlight`, `refresh`,
+`focus-element`) behind the explicit `surface.capabilities: ["agent-surface"]`
+grant on the view declaration. **Read-only** capabilities (`get-state`,
+`get-text`, `list-elements`, `describe-element`, `get-focus`, `get-agent-state`)
+stay open without any grant. The gate runs at both the HTTP interact route
+(`POST /api/views/:id/interact`) and the shared `dispatchViewInteract()` path
+used by activate + view-scoped actions.
+
+This matches the canonical `SurfaceManifest` `agent-surface` capability contract
+(`packages/core/src/types/surface-manifest.ts`): "Standard read-only
+introspection is always available; this grant is for a view opting INTO richer
+agent control."
+
+## Real-path test evidence
+
+`surface-grant-tests.txt` — full run output. Decisive assertions:
+
+- **Denied without grant** (`views-routes.interact-coverage.test.ts`): a
+  `click-element` interact against `surface-denied-server` (no `agent-surface`
+  grant) is rejected with HTTP **403** *before* `serverInteract` is called, with
+  message `View "…" is not granted capability "click-element" (its surface
+  manifest does not grant \`agent-surface\`)`. `json` is never called.
+- **Allowed with grant**: the same `click-element` against
+  `surface-granted-server` (grants `agent-surface`) reaches `serverInteract` and
+  returns `success: true`.
+- **Read-only bypass**: `get-state` dispatches on a view with no grant.
+- **Built-in character view** (`view-scoped-actions.test.ts`): its scoped
+  actions drive real `agent-fill`/`agent-click` steps through the gate — the
+  view now declares the `agent-surface` grant (its scoped actions are its whole
+  purpose), so `VIEW_CHARACTER_FILL_BIO` / `ADD_STYLE_RULE` / `ADD_MESSAGE_EXAMPLE`
+  execute, and an unmounted target still fails loudly with
+  `VIEW_SCOPED_ACTION_ELEMENT_MISSING` (never a silent no-op).
+
+29/29 targeted tests pass (`interact-coverage` 10, `view-scoped-actions` 15,
+`activate` 4). Typecheck of the touched files is clean; the worktree-only
+`TS2688` (missing `@types` resolution) is a pre-existing environment blocker
+affecting every file equally.

--- a/.github/issue-evidence/13822-view-surface-gate/surface-grant-tests.txt
+++ b/.github/issue-evidence/13822-view-surface-gate/surface-grant-tests.txt
@@ -1,0 +1,25 @@
+# Surface-grant gate — real-path test evidence
+# Branch: fix/view-surface-server-gate  Base: origin/develop (c7ba64e035)
+# Date: 2026-07-05T18:22:19Z
+
+## interact-coverage: denied (403) without agent-surface, allowed with grant
+ Info       [VIEWSROUTES] [ViewsRoutes] Interact with view "surface-denied-server" capability="click-element" (viewId=surface-denied-server, capability=click-element, requestId=5878e1c4-1762-48f2-bc73-ae195263f261)
+ Info       [VIEWSROUTES] [ViewsRoutes] Interact with view "surface-granted-server" capability="click-element" (viewId=surface-granted-server, capability=click-element, requestId=7795442d-b35e-4a46-a43c-948d36f69567)
+ 10 pass
+ 0 fail
+Ran 10 tests across 1 file. [836.00ms]
+
+## view-scoped-actions: builtin character view drives real agent-fill/click through the gate
+ Info       [VIEWSCOPEDACTIONS] [ViewScopedActions] "VIEW_CHARACTER_FILL_BIO" drove 1 step(s) on view "character" (actionName=VIEW_CHARACTER_FILL_BIO, viewId=character, driven=["agent-fill:identity-bio"])
+ Info       [VIEWSCOPEDACTIONS] [ViewScopedActions] "VIEW_CHARACTER_ADD_STYLE_RULE" drove 2 step(s) on view "character" (actionName=VIEW_CHARACTER_ADD_STYLE_RULE, viewId=character, driven=["agent-fill:style-add-input-all","agent-click:style-add-all"])
+ Info       [VIEWSCOPEDACTIONS] [ViewScopedActions] "VIEW_CHARACTER_ADD_MESSAGE_EXAMPLE" drove 1 step(s) on view "character" (actionName=VIEW_CHARACTER_ADD_MESSAGE_EXAMPLE, viewId=character, driven=["agent-click:example-add-conversation"])
+ 15 pass
+ 0 fail
+Ran 15 tests across 1 file. [442.00ms]
+
+## activate route: activate on granted view dispatches click-element
+ Info       [VIEWSROUTES] [ViewsRoutes] Activate element "send-it" on view "approve" (viewId=approve, elementId=send-it, capability=click-element)
+ Info       [VIEWSROUTES] [ViewsRoutes] Activate element "send-it" on view "approve" (viewId=approve, elementId=send-it, capability=click-element)
+ 4 pass
+ 0 fail
+Ran 4 tests across 1 file. [315.00ms]

--- a/packages/agent/src/api/builtin-views.ts
+++ b/packages/agent/src/api/builtin-views.ts
@@ -85,6 +85,12 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     tags: ["identity", "personality", "character"],
     anticipatoryIntent:
       "Offer to refine the agent's identity, personality, or style from the current character state, and point out the highest-leverage next edit.",
+    // The scoped actions below expand into mutating `agent-fill`/`agent-click`
+    // interactions, which the route/dispatch gate denies unless the view opts
+    // into agent control via the `agent-surface` grant (read-only introspection
+    // stays open without it). This is the only built-in view driving the agent
+    // surface, so it is the only one that declares the grant.
+    surface: { capabilities: ["agent-surface"] },
     // Named actions the agent can invoke ONLY while the Character view is the
     // foreground view (#14155, deferred step 8 of #13591/#14123). Each targets
     // a `useAgentElement` id in the Character editor (`CharacterEditor` /
@@ -146,9 +152,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
           "add conversation example",
           "create a new example conversation",
         ],
-        steps: [
-          { kind: "agent-click", target: "example-add-conversation" },
-        ],
+        steps: [{ kind: "agent-click", target: "example-add-conversation" }],
       },
     ],
     visibleInManager: true,

--- a/packages/agent/src/api/views-routes.activate.test.ts
+++ b/packages/agent/src/api/views-routes.activate.test.ts
@@ -79,6 +79,7 @@ describe("POST /api/views/:id/activate", () => {
             // A serverInteract handler takes the in-process dispatch path so the
             // test does not need a frontend round-trip.
             serverInteract,
+            surface: { capabilities: ["agent-surface"] },
             capabilities: [{ id: "get-state", description: "Read state." }],
           },
         ],

--- a/packages/agent/src/api/views-routes.interact-coverage.test.ts
+++ b/packages/agent/src/api/views-routes.interact-coverage.test.ts
@@ -40,6 +40,7 @@ import {
 
 const REFERENCE_PLUGIN = "@test/views-manager-reference";
 const DECLARED_PLUGIN = "@test/views-declared-caps";
+const SURFACE_PLUGIN = "@test/views-surface-grants";
 
 /**
  * A deterministic, self-contained stand-in for the plugin-app-control
@@ -170,12 +171,42 @@ describe("per-view interact e2e — serverInteract reaches view capabilities hea
       },
       process.cwd(),
     );
+
+    await registerPluginViews(
+      {
+        name: SURFACE_PLUGIN,
+        description: "Synthetic views for server-side surface grant coverage.",
+        views: [
+          {
+            id: "surface-denied-server",
+            label: "Surface Denied Server",
+            path: "/surface-denied-server",
+            serverInteract: async (capability) => ({
+              success: true,
+              capability,
+            }),
+          },
+          {
+            id: "surface-granted-server",
+            label: "Surface Granted Server",
+            path: "/surface-granted-server",
+            surface: { capabilities: ["agent-surface"] },
+            serverInteract: async (capability) => ({
+              success: true,
+              capability,
+            }),
+          },
+        ],
+      },
+      process.cwd(),
+    );
   });
 
   afterEach(() => {
     clearCurrentViewState();
     unregisterPluginViews(REFERENCE_PLUGIN);
     unregisterPluginViews(DECLARED_PLUGIN);
+    unregisterPluginViews(SURFACE_PLUGIN);
     vi.restoreAllMocks();
   });
 
@@ -290,7 +321,8 @@ describe("per-view interact e2e — serverInteract reaches view capabilities hea
 
   it("accepts a standard capability even when the view declares its own allowlist", async () => {
     // get-state is a STANDARD capability accepted on any view, so it bypasses
-    // the declared-allowlist gate and dispatches through serverInteract.
+    // the declared-allowlist gate and dispatches through serverInteract. It is
+    // read-only, so the surface broker allows it without the agent-surface grant.
     const { ctx, json, error } = makeCtx(
       "POST",
       "/api/views/declared-caps/interact",
@@ -306,6 +338,40 @@ describe("per-view interact e2e — serverInteract reaches view capabilities hea
     };
     expect(payload.success).toBe(true);
     expect(payload.result.capability).toBe("get-state");
+  });
+
+  it("denies mutating standard capabilities before serverInteract when the view lacks the agent-surface grant", async () => {
+    const { ctx, json, error } = makeCtx(
+      "POST",
+      "/api/views/surface-denied-server/interact",
+      { capability: "click-element", params: { id: "submit" } },
+    );
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+    expect(json).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      'View "surface-denied-server" is not granted capability "click-element" (its surface manifest does not grant `agent-surface`)',
+      403,
+    );
+  });
+
+  it("allows mutating standard capabilities through serverInteract when the view grants agent-surface", async () => {
+    const { ctx, json, error } = makeCtx(
+      "POST",
+      "/api/views/surface-granted-server/interact",
+      { capability: "click-element", params: { id: "submit" } },
+    );
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+    expect(error).not.toHaveBeenCalled();
+
+    const payload = json.mock.calls[0][1] as {
+      success: boolean;
+      result: { capability: string };
+    };
+    expect(payload.success).toBe(true);
+    expect(payload.result.capability).toBe("click-element");
   });
 
   it("404s an interact against an unregistered view id", async () => {

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -153,6 +153,42 @@ const STANDARD_CAPABILITY_IDS: ReadonlySet<string> = new Set<string>([
   ...AGENT_SURFACE_CAPABILITY_IDS,
 ]);
 
+const READ_ONLY_VIEW_CAPABILITIES: ReadonlySet<string> = new Set<string>([
+  STANDARD_CAPABILITIES.GET_STATE,
+  STANDARD_CAPABILITIES.GET_TEXT,
+  "list-elements",
+  "describe-element",
+  "get-focus",
+  "get-agent-state",
+]);
+
+function isSurfaceBrokeredCapability(capability: string): boolean {
+  return (
+    STANDARD_CAPABILITY_IDS.has(capability) ||
+    AGENT_SURFACE_CAPABILITY_IDS.has(capability)
+  );
+}
+
+function isReadOnlyViewCapability(capability: string): boolean {
+  return READ_ONLY_VIEW_CAPABILITIES.has(capability);
+}
+
+function viewManifestAllowsCapability(
+  entry: ViewRegistryEntry,
+  capability: string,
+): boolean {
+  if (!isSurfaceBrokeredCapability(capability)) return true;
+  if (isReadOnlyViewCapability(capability)) return true;
+  return entry.surface?.capabilities?.includes("agent-surface") === true;
+}
+
+function capabilityDeniedMessage(viewId: string, capability: string): string {
+  return (
+    `View "${viewId}" is not granted capability "${capability}" ` +
+    "(its surface manifest does not grant `agent-surface`)"
+  );
+}
+
 /** Module-level map of pending interact requests awaiting a frontend result. */
 const pendingInteractRequests = new PendingRequestMap();
 
@@ -1087,6 +1123,11 @@ export async function handleViewsRoutes(
       `[ViewsRoutes] Interact with view "${id}" capability="${capability}"`,
     );
 
+    if (!viewManifestAllowsCapability(entry, capability)) {
+      error(res, capabilityDeniedMessage(id, capability), 403);
+      return true;
+    }
+
     if (typeof entry.serverInteract === "function") {
       try {
         const result = await entry.serverInteract(capability, params);
@@ -1184,6 +1225,14 @@ export async function dispatchViewInteract(
   timeoutMs = 5_000,
 ): Promise<ViewInteractDispatchResult> {
   const requestId = randomUUID();
+
+  if (!viewManifestAllowsCapability(entry, capability)) {
+    return {
+      requestId,
+      success: false,
+      error: capabilityDeniedMessage(viewId, capability),
+    };
+  }
 
   if (typeof entry.serverInteract === "function") {
     try {

--- a/packages/agent/src/runtime/view-scoped-actions.test.ts
+++ b/packages/agent/src/runtime/view-scoped-actions.test.ts
@@ -39,6 +39,7 @@ import {
 } from "./view-scoped-actions.ts";
 
 const TEST_PLUGIN = "@test/view-scoped-actions";
+const INTERACTIVE_VIEW_ID = "settings_fixture";
 
 /**
  * Mounted view whose serverInteract stands in for the shell's agent-surface
@@ -56,6 +57,7 @@ function makeInteractiveView(id: string, mountedIds: Set<string>) {
       id,
       label: `${id} view`,
       path: `/${id}`,
+      surface: { capabilities: ["agent-surface"] },
       relatedActions: [] as string[],
       scopedActions: [
         {
@@ -174,7 +176,7 @@ afterEach(() => {
 
 describe("view-scoped action validate() gating on the active view", () => {
   it("returns false when the declaring view is not active and true when it is", async () => {
-    const settings = makeInteractiveView("settings", new Set());
+    const settings = makeInteractiveView(INTERACTIVE_VIEW_ID, new Set());
     await registerPluginViews(
       {
         name: TEST_PLUGIN,
@@ -184,7 +186,7 @@ describe("view-scoped action validate() gating on the active view", () => {
       process.cwd(),
     );
     const action = buildViewScopedAction(
-      "settings",
+      INTERACTIVE_VIEW_ID,
       settings.view.scopedActions[0],
     );
 
@@ -196,7 +198,7 @@ describe("view-scoped action validate() gating on the active view", () => {
     expect(await action.validate({} as IAgentRuntime, fakeMessage)).toBe(false);
 
     // Switch INTO the declaring view via the real navigate route → open.
-    await navigateTo("settings");
+    await navigateTo(INTERACTIVE_VIEW_ID);
     expect(await action.validate({} as IAgentRuntime, fakeMessage)).toBe(true);
 
     // Switch away again → closes without any restart.
@@ -208,7 +210,7 @@ describe("view-scoped action validate() gating on the active view", () => {
 describe("view-scoped action handler drives the interact protocol", () => {
   it("resolves a named action to the real agent-fill/click sequence", async () => {
     const settings = makeInteractiveView(
-      "settings",
+      INTERACTIVE_VIEW_ID,
       new Set(["provider-select", "save-button"]),
     );
     await registerPluginViews(
@@ -219,10 +221,10 @@ describe("view-scoped action handler drives the interact protocol", () => {
       },
       process.cwd(),
     );
-    await navigateTo("settings");
+    await navigateTo(INTERACTIVE_VIEW_ID);
 
     const action = buildViewScopedAction(
-      "settings",
+      INTERACTIVE_VIEW_ID,
       settings.view.scopedActions[0],
     );
     const result = await action.handler(
@@ -247,7 +249,7 @@ describe("view-scoped action handler drives the interact protocol", () => {
 
   it("throws a typed missing-element error when a target useAgentElement id is not mounted", async () => {
     const settings = makeInteractiveView(
-      "settings",
+      INTERACTIVE_VIEW_ID,
       new Set(["provider-select"]),
     );
     await registerPluginViews(
@@ -258,11 +260,11 @@ describe("view-scoped action handler drives the interact protocol", () => {
       },
       process.cwd(),
     );
-    await navigateTo("settings");
+    await navigateTo(INTERACTIVE_VIEW_ID);
 
     // The MISSING_TARGET action clicks "ghost-button", which is never mounted.
     const action = buildViewScopedAction(
-      "settings",
+      INTERACTIVE_VIEW_ID,
       settings.view.scopedActions[1],
     );
 
@@ -281,7 +283,7 @@ describe("view-scoped action handler drives the interact protocol", () => {
 
   it("throws a typed param-missing error when a {{param}} value is not supplied", async () => {
     const settings = makeInteractiveView(
-      "settings",
+      INTERACTIVE_VIEW_ID,
       new Set(["provider-select", "save-button"]),
     );
     await registerPluginViews(
@@ -292,10 +294,10 @@ describe("view-scoped action handler drives the interact protocol", () => {
       },
       process.cwd(),
     );
-    await navigateTo("settings");
+    await navigateTo(INTERACTIVE_VIEW_ID);
 
     const action = buildViewScopedAction(
-      "settings",
+      INTERACTIVE_VIEW_ID,
       settings.view.scopedActions[0],
     );
     // No `provider` param → the {{provider}} fill step must fail loudly, not
@@ -311,7 +313,7 @@ describe("view-scoped action handler drives the interact protocol", () => {
 
   it("throws VIEW_SCOPED_ACTION_VIEW_INACTIVE when invoked while its view is not active", async () => {
     const settings = makeInteractiveView(
-      "settings",
+      INTERACTIVE_VIEW_ID,
       new Set(["provider-select", "save-button"]),
     );
     await registerPluginViews(
@@ -327,7 +329,7 @@ describe("view-scoped action handler drives the interact protocol", () => {
     await navigateTo("chat");
 
     const action = buildViewScopedAction(
-      "settings",
+      INTERACTIVE_VIEW_ID,
       settings.view.scopedActions[0],
     );
     await expect(

--- a/packages/agent/src/runtime/view-scoped-actions.test.ts
+++ b/packages/agent/src/runtime/view-scoped-actions.test.ts
@@ -11,11 +11,7 @@
  */
 import type http from "node:http";
 import { Readable } from "node:stream";
-import type {
-  Action,
-  IAgentRuntime,
-  ViewScopedAction,
-} from "@elizaos/core";
+import type { Action, IAgentRuntime, ViewScopedAction } from "@elizaos/core";
 import { type ElizaError, isElizaError } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BUILTIN_VIEWS } from "../api/builtin-views.ts";
@@ -446,6 +442,9 @@ function characterView() {
       path: "/character",
       relatedActions: [] as string[],
       scopedActions: source.scopedActions,
+      // Preserve the real view's agent-surface grant so the mutating
+      // agent-fill/agent-click steps clear the route/dispatch surface gate.
+      surface: source.surface,
       serverInteract: async (
         capability: string,
         params?: Record<string, unknown>,
@@ -495,14 +494,15 @@ describe("character view scoped actions (#14155)", () => {
 
     // FILL_BIO / ADD_STYLE_RULE take their text from a param; ADD_MESSAGE_EXAMPLE
     // is a pure click with no params.
-    expect(findAction(scopedActions, "VIEW_CHARACTER_FILL_BIO").parameters).toEqual([
-      "bio",
-    ]);
+    expect(
+      findAction(scopedActions, "VIEW_CHARACTER_FILL_BIO").parameters,
+    ).toEqual(["bio"]);
     expect(
       findAction(scopedActions, "VIEW_CHARACTER_ADD_STYLE_RULE").parameters,
     ).toEqual(["rule"]);
     expect(
-      findAction(scopedActions, "VIEW_CHARACTER_ADD_MESSAGE_EXAMPLE").parameters,
+      findAction(scopedActions, "VIEW_CHARACTER_ADD_MESSAGE_EXAMPLE")
+        .parameters,
     ).toBeUndefined();
   });
 
@@ -642,7 +642,13 @@ describe("character view scoped actions (#14155)", () => {
       path: "/character",
       relatedActions: [] as string[],
       scopedActions: source?.scopedActions,
-      serverInteract: async (_cap: string, params?: Record<string, unknown>) => ({
+      // Grant agent-surface (as the real view does) so the step clears the
+      // surface gate and reaches the mounted-element check under test.
+      surface: source?.surface,
+      serverInteract: async (
+        _cap: string,
+        params?: Record<string, unknown>,
+      ) => ({
         ok: false,
         id: typeof params?.id === "string" ? params.id : "",
         reason: "element not found",

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -783,11 +783,6 @@ export interface ViewCapability {
 	>;
 }
 
-/** Permissions granted to the host surface while a view is mounted. */
-export interface ViewSurfaceManifest {
-	/** Host-level capabilities the view can exercise through the mounted surface. */
-	capabilities?: string[];
-}
 
 /**
  * One agent-surface interaction step a {@link ViewScopedAction} expands into.
@@ -1017,11 +1012,6 @@ export interface ViewDeclaration {
 		capability: string,
 		params?: Record<string, unknown>,
 	) => Promise<unknown>;
-	/**
-	 * Host-level permissions granted while this view is mounted. Mutating
-	 * agent-surface protocol calls require the explicit `agent-surface` grant.
-	 */
-	surface?: ViewSurfaceManifest;
 	/** Allow this view to be pinned as a desktop tab. Default true. */
 	desktopTabEnabled?: boolean;
 	/** Show this view in the view manager grid. Default true. */

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -783,6 +783,12 @@ export interface ViewCapability {
 	>;
 }
 
+/** Permissions granted to the host surface while a view is mounted. */
+export interface ViewSurfaceManifest {
+	/** Host-level capabilities the view can exercise through the mounted surface. */
+	capabilities?: string[];
+}
+
 /**
  * One agent-surface interaction step a {@link ViewScopedAction} expands into.
  * The `kind` maps to the exact interact capability the view already dispatches
@@ -1011,6 +1017,11 @@ export interface ViewDeclaration {
 		capability: string,
 		params?: Record<string, unknown>,
 	) => Promise<unknown>;
+	/**
+	 * Host-level permissions granted while this view is mounted. Mutating
+	 * agent-surface protocol calls require the explicit `agent-surface` grant.
+	 */
+	surface?: ViewSurfaceManifest;
 	/** Allow this view to be pinned as a desktop tab. Default true. */
 	desktopTabEnabled?: boolean;
 	/** Show this view in the view manager grid. Default true. */

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -783,7 +783,6 @@ export interface ViewCapability {
 	>;
 }
 
-
 /**
  * One agent-surface interaction step a {@link ViewScopedAction} expands into.
  * The `kind` maps to the exact interact capability the view already dispatches


### PR DESCRIPTION
## Summary
Gate **mutating** view interactions behind the explicit
`surface.capabilities: ["agent-surface"]` grant on the view declaration, while
leaving **read-only** capabilities open — the least-privilege split the
canonical `SurfaceManifest` `agent-surface` capability already documents.

- Gate applied at both the HTTP interact route (`POST /api/views/:id/interact`)
  and the shared `dispatchViewInteract()` path used by activate + view-scoped
  actions (`packages/agent/src/api/views-routes.ts`).
- `READ_ONLY_VIEW_CAPABILITIES` (`get-state`/`get-text`/`list-elements`/
  `describe-element`/`get-focus`/`get-agent-state`) bypass the gate; every
  mutating cap (`refresh`, `focus-element`, `click-element`, `fill-input`,
  `agent-click`/`fill`/`focus`/`scroll-to`, `set-highlight`) requires the grant.
- Grant `agent-surface` to the built-in **character** view — the only built-in
  shipping `scopedActions`, whose whole purpose is agent-driven fill/click.
- Reuses the canonical `SurfaceManifest` / `SurfaceCapability` types (no parallel
  manifest shape); `plugin.ts` carries zero net change vs `develop`.

## Verification
- Rebased onto current `origin/develop` (`c7ba64e035`); conflict in
  `view-scoped-actions.test.ts` resolved (keeps develop's `ViewScopedAction`
  import + `BUILTIN_VIEWS`, applies the fixture surface grant).
- `bun test` targeted suites — **29/29 pass**: `views-routes.interact-coverage`
  (10), `view-scoped-actions` (15), `views-routes.activate` (4). Broader view
  suites (registry/hero/search/affinity/capability-audit/id-drift/…) green.
- Touched files typecheck clean; the worktree-only `TS2688` (`@types` resolution)
  is a pre-existing environment blocker affecting every file equally.
- `audit:error-policy-ratchet`: no new fallback-slop / server console.
- Biome clean on all touched files.

## Evidence
`.github/issue-evidence/13822-view-surface-gate/` — real-path run output +
README. Decisive assertions: `click-element` on a view **without** the grant is
rejected **403 before `serverInteract`** (`json` never called); the same cap on a
**granted** view reaches `serverInteract` and succeeds; `get-state` bypasses;
the built-in character view drives real `agent-fill`/`agent-click` through the
gate and still fails loudly (`VIEW_SCOPED_ACTION_ELEMENT_MISSING`) on an unmounted
target.

- Real-LLM trajectory — **N/A**: server-side capability gate + type contract; no
  prompt/model behavior change (scoped-action *awareness* was unit-covered in
  #13822; no new agent-visible action is added here).
- Screenshots/video — **N/A**: no user-visible UI change (route/dispatch gate +
  view manifest field only).

## Follow-up (out of scope, separate issue)
The interact frame is still broadcast to all connected WS clients via
`state.broadcastWs` — per-session/per-client targeting of the dispatch (so only
the owning mounted shell executes) is a distinct WS-layer hardening on top of
this declaration gate and is tracked separately from this least-privilege grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
