### PR TITLE
fix(#14103): let first-run bootstrap chat reach cloud bridge

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1607,12 +1607,14 @@ export function ContinuousChatOverlay({
       const trimmed = text.trim();
       // An image-only turn is valid; only bail when there's nothing to send.
       if (!trimmed && images.length === 0) return;
-      // During onboarding the composer is unlocked (#12178) but free text is
-      // answered locally by the in-chat conductor and NEVER reaches the server.
-      // Route it through the shared action funnel (classify → "conductor" →
-      // conductor text handler) — `controller.send` is never called here, so
-      // "no server send pre-completion" holds. Attach is disabled during
-      // onboarding, so any images are dropped (text-only echo).
+      // During onboarding the composer is unlocked (#12178). Route free text
+      // through the shared action funnel: before a runtime is chosen it is
+      // answered locally by the in-chat conductor (classify → "conductor") and
+      // does not reach the server; once a Cloud agent is provisioning behind a
+      // ready bootstrap bridge the funnel classifies it as "send" so the first
+      // real message reaches the bootstrap-bridge agent (#14103). Either way
+      // `controller.send` is never called here — the funnel owns the decision.
+      // Attach is disabled during onboarding, so any images are dropped.
       if (firstRunOpen) {
         if (trimmed) void sendActionMessage(trimmed);
         setDraft("");

--- a/packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md
+++ b/packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md
@@ -46,13 +46,16 @@ pre-completion" property is preserved. The contract, enforced in
   the reveal.
 - **Composer is UNLOCKED (#12178).** The textarea and send are live with the
   placeholder "Ask me anything — or pick an option"; attach and mic/push-to-talk
-  stay disabled (no agent to serve media yet). Typed text is answered by the
-  conductor's local echo persona, never forwarded to the server: `submitText`
-  routes it through the shared `sendActionMessage` funnel, where
-  `classifyActionMessage` returns `"conductor"` and the value is delivered via
-  `tryHandleFirstRunText` (the `"conductor"` branch never calls the real send).
-  `submit` skips slash/shortcut resolution while `firstRunOpen`, so no command
-  runs and nothing reaches the server before a runtime exists. The `__first_run__:`
+  stay disabled (no agent to serve media yet). Before a runtime exists, typed
+  text is answered by the conductor's local echo persona, never forwarded to the
+  server: `submitText` routes it through the shared `sendActionMessage` funnel,
+  where `classifyActionMessage` returns `"conductor"` and the value is delivered
+  via `tryHandleFirstRunText` (the `"conductor"` branch never calls the real
+  send). Once a Cloud agent is provisioning behind a ready bootstrap bridge
+  (`cloudProvisionedContainer`), the funnel passes `allowFirstRunTextSend` and
+  `classifyActionMessage` returns `"send"` instead, so the first real message
+  reaches the bootstrap-bridge agent (#14103). `submit` skips slash/shortcut
+  resolution while `firstRunOpen`, so no command runs. The `__first_run__:`
   prefix is still reserved unconditionally.
 - **Undismissable.** Every collapse path is a no-op while `firstRunOpen`:
   `collapse()` (the single funnel for Escape on document/thread/composer,

--- a/packages/ui/src/first-run/README.md
+++ b/packages/ui/src/first-run/README.md
@@ -20,12 +20,16 @@ auto-collapse — with the backdrop fading to the normal scrim — on completion
 
 The composer is **unlocked** (#12178, a deliberate reversal of the #9952
 onboarding lock): the user can type freely with the placeholder "Ask me anything
-— or pick an option". Typed text is answered by the conductor's local echo
-persona (a friendly not-ready line that varies by flow position) and **never
-reaches the server pre-completion** — the AppContext send funnel enforces that
-via `classifyActionMessage` → `"conductor"` → `tryHandleFirstRunText`. Attach and
-mic stay disabled (no agent to serve media yet); the seeded CHOICE/OAuth widgets
-remain the primary input. The full contract (and which seam enforces each
+— or pick an option". Before a runtime is chosen, typed text is answered by the
+conductor's local echo persona (a friendly not-ready line that varies by flow
+position) and never reaches the server — the AppContext send funnel enforces
+that via `classifyActionMessage` → `"conductor"` → `tryHandleFirstRunText`. The
+one exception (#14103): once the user has picked Cloud and the dedicated agent
+is provisioning behind a ready bootstrap bridge (`cloudProvisionedContainer`),
+the funnel classifies free text as `"send"` so the first real message reaches
+the bootstrap-bridge agent instead of the canned setup copy. Attach and mic stay
+disabled (no agent to serve media yet); the seeded CHOICE/OAuth widgets remain
+the primary input. The full contract (and which seam enforces each
 guarantee) is documented in
 [`IN_CHAT_ONBOARDING_DESIGN.md`](./IN_CHAT_ONBOARDING_DESIGN.md) and covered by
 `../components/shell/ContinuousChatOverlay.firstrun.test.tsx`.

--- a/packages/ui/src/first-run/first-run-action-channel.test.ts
+++ b/packages/ui/src/first-run/first-run-action-channel.test.ts
@@ -21,10 +21,10 @@ import {
  * the headless onboarding conductor. Its load-bearing invariants: a first-run
  * choice value is ONLY dispatched to a conductor while one is active, a
  * non-prefixed value is never intercepted by the ACTION handler, free text is
- * offered to the TEXT handler while onboarding is open (and never forwarded to
- * the server), and — via `classifyActionMessage` — a reserved-prefix value is
- * NEVER forwarded to the server as a chat message, even after onboarding
- * finished and the handler is gone (leftover transcript widgets stay inert).
+ * offered to the TEXT handler while onboarding is still making a choice, and —
+ * via `classifyActionMessage` — a reserved-prefix value is NEVER forwarded to
+ * the server as a chat message, even after onboarding finished and the handler
+ * is gone (leftover transcript widgets stay inert).
  */
 
 afterEach(() => {
@@ -93,6 +93,19 @@ describe("classifyActionMessage (the send funnel's routing contract)", () => {
   it("routes free text to the conductor while onboarding is active and sends it afterwards", () => {
     expect(classifyActionMessage("hello", false)).toBe("conductor");
     expect(classifyActionMessage("hello", true)).toBe("send");
+  });
+
+  it("allows first-run free text through once a bootstrap chat bridge is available", () => {
+    expect(
+      classifyActionMessage("hello", false, {
+        allowFirstRunTextSend: true,
+      }),
+    ).toBe("send");
+    expect(
+      classifyActionMessage(`${FIRST_RUN_ACTION_PREFIX}runtime:cloud`, false, {
+        allowFirstRunTextSend: true,
+      }),
+    ).toBe("first-run");
   });
 });
 

--- a/packages/ui/src/first-run/first-run-action-channel.ts
+++ b/packages/ui/src/first-run/first-run-action-channel.ts
@@ -72,9 +72,10 @@ export function getFirstRunCloudLoginFallbackPath(
 /**
  * Offer free text to the active onboarding conductor. Returns true when the
  * conductor consumed it (rendered a local turn + reply); false when no
- * conductor is active. The caller must NEVER forward the text to the server
- * while onboarding is open — the hard "no server send pre-completion" property
- * lives at the AppContext funnel, this is just the delivery seam.
+ * conductor is active. The caller decides whether onboarding still owns free
+ * text: before a runtime is chosen it must stay local, but the first-run
+ * bootstrap window for a provisioned Cloud agent must be allowed through to the
+ * real chat bridge.
  */
 export function tryHandleFirstRunText(text: string): boolean {
   if (!textHandler) return false;
@@ -87,17 +88,18 @@ export function tryHandleFirstRunText(text: string): boolean {
  *   it unconditionally. Even after onboarding completes (conductor
  *   unregistered), a tap on a leftover onboarding widget must never reach the
  *   server as a literal `__first_run__:` chat message.
- * - `"conductor"` — onboarding is still active: free text is answered locally
- *   by the in-chat conductor (`tryHandleFirstRunText`) and never reaches the
- *   server mid-setup. The composer is unlocked (#12178, a deliberate reversal
- *   of the #9952 onboarding lock), so this is the real delivery path, not a
- *   backstop.
+ * - `"conductor"` — onboarding is still active and no provisioned chat bridge
+ *   is available: free text is answered locally by the in-chat conductor
+ *   (`tryHandleFirstRunText`) and never reaches the server mid-choice. The
+ *   composer is unlocked (#12178, a deliberate reversal of the #9952 onboarding
+ *   lock), so this is the real delivery path, not a backstop.
  * - `"send"` — a normal post-onboarding value: forward to the real send.
  */
 export function classifyActionMessage(
   value: string,
   firstRunComplete: boolean,
+  opts: { allowFirstRunTextSend?: boolean } = {},
 ): "first-run" | "conductor" | "send" {
   if (value.startsWith(FIRST_RUN_ACTION_PREFIX)) return "first-run";
-  return firstRunComplete ? "send" : "conductor";
+  return firstRunComplete || opts.allowFirstRunTextSend ? "send" : "conductor";
 }

--- a/packages/ui/src/state/AppContext.tsx
+++ b/packages/ui/src/state/AppContext.tsx
@@ -1176,10 +1176,10 @@ function AppProviderInner({
   // onboarding widget in the transcript is dropped here instead of sending the
   // literal sentinel to the agent as a chat message. While onboarding is
   // ACTIVE (firstRunComplete false) free text is routed to the conductor's
-  // in-chat reply persona (`tryHandleFirstRunText`) and never reaches the
-  // server — the #12178 composer unlock keeps chat interactive without
-  // breaking the "no server send pre-completion" property, which is enforced
-  // HERE (the `"conductor"` case never calls `rawSendActionMessage`). Once
+  // in-chat reply persona (`tryHandleFirstRunText`) until a Cloud-provisioned
+  // bootstrap bridge exists. That preserves the pre-choice "no server send"
+  // invariant while letting the user's first real post-provisioning message
+  // reach the dedicated agent instead of being swallowed by setup copy. Once
   // onboarding completes, every non-first-run value falls through to the real
   // send funnel unchanged. Widgets stay 100% display-only — both
   // InlineWidgetText and MessageContent route picks through this single
@@ -1190,7 +1190,13 @@ function AppProviderInner({
       // to cloud / retry / download) are consumed by the model-status conductor
       // and NEVER reach the server — regardless of onboarding state.
       if (tryHandleModelAction(text)) return Promise.resolve();
-      switch (classifyActionMessage(text, firstRunComplete === true)) {
+      const firstRunIsComplete = firstRunComplete === true;
+      switch (
+        classifyActionMessage(text, firstRunIsComplete, {
+          allowFirstRunTextSend:
+            !firstRunIsComplete && firstRunCloudProvisionedContainer,
+        })
+      ) {
         case "first-run": {
           const handled = tryHandleFirstRunAction(text);
           const fallbackPath = handled
@@ -1211,7 +1217,7 @@ function AppProviderInner({
           return rawSendActionMessage(text);
       }
     },
-    [firstRunComplete, rawSendActionMessage],
+    [firstRunCloudProvisionedContainer, firstRunComplete, rawSendActionMessage],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
During a dedicated agent's cold-boot / bootstrap window the app's chat returned a canned "not fully set up yet" line and the user's first message never reached the server — even though the in-Worker bootstrap shared runtime was already `ready:true` and answering (proven live on Stan's staging session, issue #14103).

This routes the very first real message through to the ready bootstrap bridge:

- `classifyActionMessage` takes an `allowFirstRunTextSend` option; when set it classifies ordinary free text as `"send"` instead of `"conductor"`, so the message reaches the agent instead of the local canned reply.
- `AppContext.sendActionMessage` passes `allowFirstRunTextSend` only when `!firstRunComplete && firstRunCloudProvisionedContainer` — i.e. Cloud was picked and a `ready:true` bootstrap bridge exists. The pre-choice "no server send" invariant is otherwise unchanged.
- The reserved `__first_run__:` prefix stays quarantined unconditionally, so stale onboarding widgets can never reach chat.
- First-run docs (`README.md`, `IN_CHAT_ONBOARDING_DESIGN.md`) updated to record the exception so they no longer contradict the funnel.

`firstRunCloudProvisionedContainer` is the existing latch set in `startup-phase-poll.ts` on `auth.bootstrapRequired` / `firstRunStatus.cloudProvisioned` — the same signal the bootstrap window uses — so no new state was introduced.

Fixes #14103.

## Verification
- `bun run --cwd packages/ui vitest run src/first-run/first-run-action-channel.test.ts` → 14/14 pass (adds the bootstrap-bridge routing case: free text with `allowFirstRunTextSend` → `"send"`; reserved-prefix value still → `"first-run"`).
- `bunx @biomejs/biome check packages/ui/src/first-run/first-run-action-channel.ts packages/ui/src/first-run/first-run-action-channel.test.ts packages/ui/src/state/AppContext.tsx` → clean.
- `packages/ui typecheck`: the three touched files are error-free (the only tsc errors in this worktree are pre-existing and unrelated — a missing `i18n/generated/*` codegen artifact and unrelated `*.test.tsx` type drift, none in files this PR touches).
- Rebased cleanly onto `origin/develop` (was 314 commits behind).

## Evidence
- **Real path / trajectory:** the send-reaches-bridge behavior is already proven live in #14103 — the identical text hit the bootstrap bridge (`UITEST-OK` / `PONG` via `gemma-4-31b`, billed) while the app UI showed the canned placeholder. This change flips the UI onto that same proven path. The behavioral seam is the `classifyActionMessage` routing decision, which is unit-tested directly (the real function, not a mock).
- **Visual:** N/A — no visual delta. This changes only how one free-text message during the narrow Cloud bootstrap window is routed (canned local echo → real server send); no layout, color, or component changes.
