### PR TITLE
fix(ui): autosave Character personality identity edits

### DIFF
--- a/packages/ui/src/components/character/CharacterEditor.tsx
+++ b/packages/ui/src/components/character/CharacterEditor.tsx
@@ -1455,7 +1455,6 @@ export function CharacterEditor({
               normalizedMessageExamples={normalizedMessageExamples}
               pendingStyleEntries={pendingStyleEntries}
               styleEntryDrafts={styleEntryDrafts}
-              handleFieldEdit={handleFieldEdit}
               applyFieldEdit={(field, value) => {
                 handleCharacterFieldInput(
                   field as keyof CharacterData,

--- a/packages/ui/src/components/character/CharacterHubView.test.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.test.tsx
@@ -8,32 +8,61 @@
 // header (the shared CharacterSectionNav supplies it). The panels are stubbed so
 // the test isolates the hub's own structure, not their internals.
 
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  setActionNotice: vi.fn(),
+  updateCharacter: vi.fn(),
+}));
 
 vi.mock("../../state", () => ({
   useAppSelectorShallow: (selector: (s: unknown) => unknown) =>
     selector({
-      setActionNotice: vi.fn(),
+      setActionNotice: mocks.setActionNotice,
       t: (_key: string, opts?: { defaultValue?: string }) =>
         opts?.defaultValue ?? _key,
     }),
 }));
-vi.mock("../../api/client", () => ({ client: { updateCharacter: vi.fn() } }));
+vi.mock("../../api/client", () => ({
+  client: { updateCharacter: mocks.updateCharacter },
+}));
 vi.mock("../../widgets/WidgetHost", () => ({ WidgetHost: () => null }));
 vi.mock("./CharacterEditorPanels", () => ({
-  CharacterIdentityPanel: () => <div data-testid="identity-panel" />,
+  CharacterIdentityPanel: ({
+    handleFieldEdit,
+  }: {
+    handleFieldEdit: (field: string, value: unknown) => void;
+  }) => (
+    <div data-testid="identity-panel">
+      <button type="button" onClick={() => handleFieldEdit("bio", "new bio")}>
+        Edit bio
+      </button>
+    </div>
+  ),
   CharacterStylePanel: () => <div data-testid="style-panel" />,
   CharacterExamplesPanel: () => <div data-testid="examples-panel" />,
 }));
 
 import { CharacterHubView } from "./CharacterHubView";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
 
 const noop = vi.fn();
 
-function renderHub() {
+function renderHub(
+  overrides: Partial<Parameters<typeof CharacterHubView>[0]> = {},
+) {
   return render(
     <CharacterHubView
       d={{}}
@@ -41,12 +70,12 @@ function renderHub() {
       normalizedMessageExamples={[]}
       pendingStyleEntries={{}}
       styleEntryDrafts={{}}
-      handleFieldEdit={noop}
       applyFieldEdit={noop}
       handlePendingStyleEntryChange={noop}
       applyStyleEdit={noop}
       handleStyleEntryDraftChange={noop}
       characterSaveError={null}
+      {...overrides}
     />,
   );
 }
@@ -93,5 +122,22 @@ describe("CharacterHubView (Personality-only collapse)", () => {
   it("has no manual Save button (edits autosave)", () => {
     renderHub();
     expect(screen.queryByRole("button", { name: /save/i })).toBeNull();
+  });
+
+  it("autosaves identity edits after the debounce", async () => {
+    vi.useFakeTimers();
+    const applyFieldEdit = vi.fn();
+
+    renderHub({ applyFieldEdit });
+    fireEvent.click(screen.getByRole("button", { name: "Edit bio" }));
+
+    expect(applyFieldEdit).toHaveBeenCalledWith("bio", "new bio");
+    expect(mocks.updateCharacter).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(700);
+    });
+
+    expect(mocks.updateCharacter).toHaveBeenCalledWith({ bio: "new bio" });
   });
 });

--- a/packages/ui/src/components/character/CharacterHubView.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.tsx
@@ -48,7 +48,6 @@ export function CharacterHubView({
   normalizedMessageExamples,
   pendingStyleEntries,
   styleEntryDrafts,
-  handleFieldEdit,
   applyFieldEdit,
   handlePendingStyleEntryChange,
   applyStyleEdit,
@@ -60,7 +59,6 @@ export function CharacterHubView({
   normalizedMessageExamples: MessageExampleGroup[];
   pendingStyleEntries: Record<string, string>;
   styleEntryDrafts: Record<string, string[]>;
-  handleFieldEdit: (field: string, value: unknown) => void;
   applyFieldEdit: (field: string, value: unknown) => void;
   handlePendingStyleEntryChange: (key: string, value: string) => void;
   applyStyleEdit: (key: CharacterStyleSection, value: string) => void;
@@ -131,6 +129,16 @@ export function CharacterHubView({
     (field: string, value: unknown) => {
       applyFieldEdit(field, value);
       if (field === "messageExamples" || field === "postExamples") {
+        scheduleAutoSave({ [field]: value } as CharacterData);
+      }
+    },
+    [applyFieldEdit, scheduleAutoSave],
+  );
+
+  const handleAutoSavedIdentityEdit = useCallback(
+    (field: string, value: unknown) => {
+      applyFieldEdit(field, value);
+      if (field === "bio") {
         scheduleAutoSave({ [field]: value } as CharacterData);
       }
     },
@@ -230,7 +238,7 @@ export function CharacterHubView({
           <section>
             <CharacterIdentityPanel
               bioText={bioText}
-              handleFieldEdit={handleFieldEdit}
+              handleFieldEdit={handleAutoSavedIdentityEdit}
               t={t}
             />
           </section>

--- a/packages/ui/src/components/character/CharacterHubView.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.tsx
@@ -194,7 +194,13 @@ export function CharacterHubView({
       applyStyleEdit(styleKey, nextItems.join("\n"));
       scheduleAutoSave(buildStylePatch(styleKey, nextItems));
     },
-    [applyStyleEdit, buildStylePatch, d.style, scheduleAutoSave, styleEntryDrafts],
+    [
+      applyStyleEdit,
+      buildStylePatch,
+      d.style,
+      scheduleAutoSave,
+      styleEntryDrafts,
+    ],
   );
 
   const handleAutoReorderStyleEntries = useCallback(

--- a/packages/ui/src/components/character/CharacterHubView.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.tsx
@@ -194,13 +194,7 @@ export function CharacterHubView({
       applyStyleEdit(styleKey, nextItems.join("\n"));
       scheduleAutoSave(buildStylePatch(styleKey, nextItems));
     },
-    [
-      applyStyleEdit,
-      buildStylePatch,
-      d.style,
-      scheduleAutoSave,
-      styleEntryDrafts,
-    ],
+    [applyStyleEdit, buildStylePatch, d.style, scheduleAutoSave, styleEntryDrafts],
   );
 
   const handleAutoReorderStyleEntries = useCallback(


### PR DESCRIPTION
## Summary
- restores autosave for the Personality identity bio field after the Character hub removed the manual Save button
- removes the stale dirty-tracking prop from the standalone Character hub path
- adds a regression test proving bio edits call local field update immediately and persist after the autosave debounce

## Verification
- bun run --cwd packages/ui test -- src/components/character/CharacterHubView.test.tsx src/components/character/CharacterSectionNav.test.tsx src/components/pages/WalletSectionNav.test.tsx
- bunx biome check packages/ui/src/components/character/CharacterEditor.tsx packages/ui/src/components/character/CharacterHubView.tsx packages/ui/src/components/character/CharacterHubView.test.tsx
- git diff --check origin/develop...HEAD
- bun run audit:error-policy-ratchet

Follow-up to merged #14123; the original PR merged at stale SHA ddc6458, while this branch now carries the reviewed autosave repair on top of current develop.