### PR TITLE
fix(pwa): dark host-chrome (theme-color + launch bg) + shell cache bump — kills the orange band

### DIFF
--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -64,11 +64,14 @@ for the full env var table; `.env.example` documents the build-time `VITE_*` fla
 
 ## Launch Surface
 
-Boot, splash, and first-paint fallback surfaces use the home background orange
-`#ef5a1f`, not the brand accent `#FF5800`. Keep `index.html`,
-`capacitor.config.ts`, Android launch resources, iOS `LaunchScreen.storyboard`,
-and the renderer root CSS aligned so native splash -> StartupShell -> home does
-not flash a different color.
+Native boot splash surfaces (`capacitor.config.ts`, Android launch resources,
+iOS `LaunchScreen.storyboard`) use the splash orange `#ef5a1f`, not the brand
+accent `#FF5800`. Persistent host-chrome surfaces (`index.html` FOUC
+background, `<meta name="theme-color">` / manifest colors via `app.config.ts`,
+the renderer root CSS) use the dark home background `#160d07`
+(`DEFAULT_BACKGROUND_COLOR`): they stay visible under the app (iOS
+home-indicator safe-area, overscroll), so an orange there reads as a glowing
+band instead of a boot flash.
 
 ## License
 

--- a/packages/app/app.config.ts
+++ b/packages/app/app.config.ts
@@ -37,14 +37,18 @@ const config = {
 
   web: {
     shortName: "Eliza",
-    // Launch/loading orange used by manifest theme_color + background_color,
+    // Launch/loading surface used by manifest theme_color + background_color,
     // <meta name="theme-color">, and PWA launch surfaces. Matches the default
-    // home-background orange (#ef5a1f = DEFAULT_BACKGROUND_COLOR) so chrome and
-    // splash never flash a different orange before the home background appears
-    // (issue #9565). The brand accent (logos, buttons) stays #FF5800 / the CSS
-    // --brand-orange and is intentionally separate from these launch surfaces.
-    themeColor: "#ef5a1f",
-    backgroundColor: "#ef5a1f",
+    // home background (#160d07 = DEFAULT_BACKGROUND_COLOR, the ember-night
+    // dark) so chrome and splash never flash a different color before the home
+    // background appears (issue #9565). On iOS standalone PWAs theme-color
+    // paints the home-indicator safe-area inset, so this must be the DARK app
+    // surface: the old launch orange (#ef5a1f) read as a persistent glowing
+    // band under the composer. The brand accent (logos, buttons) stays
+    // #FF5800 / the CSS --brand-orange and is intentionally separate from
+    // these launch surfaces.
+    themeColor: "#160d07",
+    backgroundColor: "#160d07",
     shareImagePath: "/brand/ogembeds/eliza_ogembed.svg",
   },
 

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -275,19 +275,23 @@
   </script>
   <style>
     /* FOUC guard — runs before external CSS so we use concrete values.
-       The launch surface is the home background orange (#ef5a1f —
-       DEFAULT_BACKGROUND_COLOR, the color the home ShaderBackground and the
-       StartupShell loader paint). Keep it separate from --bg: --bg resolves to
-       the light/dark theme background and can flash white/black before the
-       loader appears. */
+       The launch surface is the home background dark (#160d07 —
+       DEFAULT_BACKGROUND_COLOR, the ember-night base the home wallpaper and
+       the StartupShell loader paint). Keep it separate from --bg: --bg
+       resolves to the light/dark theme background and can flash white/black
+       before the loader appears. This surface PERSISTS as the page background
+       under the app: any strip the fixed background layers don't reach (the
+       iOS home-indicator safe-area under the composer, overscroll zones)
+       shows this color, so it must be the dark app surface. The old launch
+       orange (#ef5a1f) read as a glowing band at the bottom. */
     :root {
-      --launch-bg: #ef5a1f;
+      --launch-bg: #160d07;
     }
 
     html,
     body,
     #root {
-      background-color: var(--launch-bg, #ef5a1f);
+      background-color: var(--launch-bg, #160d07);
     }
 
     html, body {
@@ -313,7 +317,7 @@
 
     #root {
       min-height: 100dvh;
-      background-color: var(--launch-bg, #ef5a1f);
+      background-color: var(--launch-bg, #160d07);
     }
 
     .eliza-preboot-shell {
@@ -321,7 +325,7 @@
       display: grid;
       place-items: center;
       overflow: hidden;
-      background: var(--launch-bg, #ef5a1f);
+      background: var(--launch-bg, #160d07);
       color: #ffffff;
     }
 

--- a/packages/app/public/site.webmanifest
+++ b/packages/app/public/site.webmanifest
@@ -4,8 +4,8 @@
   "description": "Your agent, everywhere. Desktop, mobile, and cloud, all running the same Eliza.",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#ef5a1f",
-  "theme_color": "#ef5a1f",
+  "background_color": "#160d07",
+  "theme_color": "#160d07",
   "icons": [
     {
       "src": "/brand/favicons/favicon.svg",

--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -18,7 +18,12 @@ const VIEWS_CACHE_NAME = "elizaos-views-v1";
 // iOS standalone PWA (Add-to-Home-Screen runs this SW). The network-first shell
 // still updates on reload, but the version bump forces old caches to be dropped
 // in `activate` so a re-open can't serve a pre-safe-area-fix shell from cache.
-const SHELL_CACHE_NAME = "elizaos-shell-v2";
+// v3: evict any stale precached shell in an installed (iOS standalone) PWA
+// after the dark host-chrome fix (theme-color + launch-bg #ef5a1f -> #160d07,
+// the orange band under the composer). The network-first shell still updates
+// on reload; the version bump forces old caches to be dropped in `activate`
+// so a re-open can't serve a pre-fix orange shell.
+const SHELL_CACHE_NAME = "elizaos-shell-v3";
 const HERO_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 h
 const KNOWN_CACHES = [VIEWS_CACHE_NAME, SHELL_CACHE_NAME];
 

--- a/packages/app/test/brand-surface.test.ts
+++ b/packages/app/test/brand-surface.test.ts
@@ -1,14 +1,22 @@
 /**
  * Brand-surface smoke. Verifies the first-paint / launch surfaces (FOUC HTML,
- * native launch configs, capacitor + Android/iOS resources) all use the SAME
- * orange the React home background uses, so the user never sees a foreign
- * color — or a *different* orange — before the home background paints.
+ * native launch configs, capacitor + Android/iOS resources) use the right
+ * color for their lifetime, so the user never sees a foreign color — or a
+ * glowing orange band — behind or after the home background paints.
  *
- * Two distinct oranges, kept deliberately separate (issue #9565):
- *  - LAUNCH_ORANGE (#ef5a1f) — every boot/loading/launch surface. This equals
- *    DEFAULT_BACKGROUND_COLOR (packages/ui/src/state/ui-preferences.ts), the
- *    default home ShaderBackground, so the native splash → React StartupShell →
- *    home transition is a single seamless orange.
+ * Three colors, kept deliberately separate (issues #9565, orange-band fix):
+ *  - LAUNCH_DARK (#160d07) — every PERSISTENT host-chrome surface: the
+ *    index.html FOUC background (html/body/#root stays the page background
+ *    under the app forever — it bleeds through the iOS home-indicator
+ *    safe-area and overscroll zones), the PWA <meta theme-color> and manifest
+ *    colors (iOS standalone paints the home-indicator inset with it). This
+ *    equals DEFAULT_BACKGROUND_COLOR (packages/ui/src/state/ui-preferences.ts),
+ *    the ember-night base of the default home wallpaper, so any bleed-through
+ *    is invisible against the app.
+ *  - SPLASH_ORANGE (#ef5a1f) — native boot splash surfaces ONLY (capacitor
+ *    splash, Android splash resources, iOS LaunchScreen). These are true
+ *    boot-flash surfaces that are fully covered once the app paints, so they
+ *    keep the legacy launch orange; they must never be a persistent surface.
  *  - BRAND_ORANGE (#FF5800) — the brand accent (logos, brand surfaces). It may
  *    persist on brand resources but must NOT be a launch surface.
  *
@@ -26,8 +34,9 @@ const root = join(here, "..");
 const appCorePlatformsRoot = join(root, "..", "app-core", "platforms");
 
 const BRAND_ORANGE = "#FF5800";
-const LAUNCH_ORANGE = "#ef5a1f";
-const LAUNCH_ORANGE_RGB = [239, 90, 31];
+const LAUNCH_DARK = "#160d07";
+const SPLASH_ORANGE = "#ef5a1f";
+const SPLASH_ORANGE_RGB = [239, 90, 31];
 const ANDROID_SPLASH_TEMPLATE_FILES = [
   "android/app/src/main/res/drawable/splash.png",
   "android/app/src/main/res/drawable-land-hdpi/splash.png",
@@ -72,41 +81,47 @@ async function readPngRgb(path: string, x = 0, y = 0): Promise<number[]> {
 }
 
 describe("brand surfaces", () => {
-  it("launch orange equals the default home background color", () => {
-    // The single source of truth for the home ShaderBackground orange. Every
-    // launch surface below must equal this so boot → home is one seamless
-    // color. If the default home background changes, this test forces the
-    // launch surfaces to move with it.
+  it("launch dark equals the default home background color", () => {
+    // The single source of truth for the home background base. Every
+    // persistent host-chrome surface below must equal this so any strip the
+    // app's fixed background layers don't cover (iOS home-indicator inset,
+    // overscroll) is invisible. If the default home background changes, this
+    // test forces the host-chrome surfaces to move with it.
     const uiPrefs = readFileSync(
       join(root, "..", "ui", "src", "state", "ui-preferences.ts"),
       "utf8",
     );
     expect(uiPrefs).toMatch(
-      new RegExp(`DEFAULT_BACKGROUND_COLOR\\s*=\\s*"${LAUNCH_ORANGE}"`),
+      new RegExp(`DEFAULT_BACKGROUND_COLOR\\s*=\\s*"${LAUNCH_DARK}"`),
     );
   });
 
-  it("app.config web/theme colors are the launch orange (not the brand accent)", () => {
+  it("app.config web/theme colors are the persistent dark surface (not orange)", () => {
+    // theme-color paints the iOS-standalone home-indicator safe-area inset —
+    // a PERSISTENT surface, so it must be the dark app background, never the
+    // splash orange (which read as a glowing band under the composer) and
+    // never the brand accent.
     const src = read("app.config.ts");
-    expect(src).toMatch(new RegExp(`themeColor:\\s*"${LAUNCH_ORANGE}"`));
-    expect(src).toMatch(new RegExp(`backgroundColor:\\s*"${LAUNCH_ORANGE}"`));
+    expect(src).toMatch(new RegExp(`themeColor:\\s*"${LAUNCH_DARK}"`));
+    expect(src).toMatch(new RegExp(`backgroundColor:\\s*"${LAUNCH_DARK}"`));
+    expect(src).not.toMatch(new RegExp(`themeColor:\\s*"${SPLASH_ORANGE}"`));
     expect(src).not.toMatch(/themeColor:\s*"#FF5800"/);
   });
 
-  it("capacitor config and native backgrounds are the launch orange", () => {
+  it("capacitor config and native backgrounds are the splash orange", () => {
     const src = read("capacitor.config.ts");
     expect(src).toMatch(
       new RegExp(
-        `SplashScreen:\\s*\\{[^}]*backgroundColor:\\s*"${LAUNCH_ORANGE}"`,
+        `SplashScreen:\\s*\\{[^}]*backgroundColor:\\s*"${SPLASH_ORANGE}"`,
         "s",
       ),
     );
     expect(src).toMatch(
-      new RegExp(`ios:\\s*\\{[^}]*backgroundColor:\\s*"${LAUNCH_ORANGE}"`, "s"),
+      new RegExp(`ios:\\s*\\{[^}]*backgroundColor:\\s*"${SPLASH_ORANGE}"`, "s"),
     );
     expect(src).toMatch(
       new RegExp(
-        `android:\\s*\\{[^}]*backgroundColor:\\s*"${LAUNCH_ORANGE}"`,
+        `android:\\s*\\{[^}]*backgroundColor:\\s*"${SPLASH_ORANGE}"`,
         "s",
       ),
     );
@@ -119,7 +134,7 @@ describe("brand surfaces", () => {
     // Launch splash + launch status bar track the home background; brand
     // accent tokens stay separate and unchanged.
     expect(colors).toContain(
-      `<color name="splash_background">${LAUNCH_ORANGE}</color>`,
+      `<color name="splash_background">${SPLASH_ORANGE}</color>`,
     );
     expect(colors).toContain(
       `<color name="eliza_orange">${BRAND_ORANGE}</color>`,
@@ -137,7 +152,7 @@ describe("brand surfaces", () => {
 
     for (const rel of ANDROID_SPLASH_TEMPLATE_FILES) {
       expect(await readPngRgb(platformTemplatePath(rel)), rel).toEqual(
-        LAUNCH_ORANGE_RGB,
+        SPLASH_ORANGE_RGB,
       );
     }
   });
@@ -153,37 +168,50 @@ describe("brand surfaces", () => {
     expect(xml).not.toContain('image name="Splash"');
   });
 
-  it("index.html FOUC fallback uses the launch orange, not a foreign color", () => {
+  it("index.html FOUC fallback uses the persistent launch dark, not orange", () => {
     const html = read("index.html");
-    // The FOUC fallback tracks the home background orange (#ef5a1f, #9565) so
-    // boot never flashes a different orange before the home background paints.
-    // The previous `#08080a` near-black is a slop value and should not regress.
+    // html/body/#root is a PERSISTENT page background, not a boot-flash-only
+    // surface: it bleeds through wherever the app's fixed background layers
+    // don't reach (iOS home-indicator safe-area, overscroll). It must track
+    // the dark home background (#160d07 = DEFAULT_BACKGROUND_COLOR) so any
+    // bleed is invisible; the old launch orange read as a glowing band.
+    // The `#08080a` near-black slop value must also not regress.
     expect(html).not.toContain("#08080a");
-    expect(html).toMatch(new RegExp(`--launch-bg:\\s*${LAUNCH_ORANGE}`));
+    expect(html).toMatch(new RegExp(`--launch-bg:\\s*${LAUNCH_DARK}`));
     expect(html).toMatch(
       new RegExp(
-        `html,\\s*body,\\s*#root\\s*\\{[^}]*background-color:\\s*var\\(--launch-bg,\\s*${LAUNCH_ORANGE}\\)`,
+        `html,\\s*body,\\s*#root\\s*\\{[^}]*background-color:\\s*var\\(--launch-bg,\\s*${LAUNCH_DARK}\\)`,
         "s",
       ),
+    );
+    // The splash orange must never be a persistent html/body/#root surface.
+    expect(html).not.toMatch(
+      new RegExp(`var\\(--launch-bg,\\s*${SPLASH_ORANGE}\\)`),
     );
     expect(html).not.toMatch(/background-color:\s*var\(--bg/);
     // The pre-#9565 brand-accent fallback must not regress.
     expect(html).not.toMatch(/var\(--bg,\s*#FF5800\)/);
   });
 
-  it("renderer root CSS keeps the pre-app surface on the home-background orange", () => {
+  it("renderer root CSS keeps the pre-app surface on the launch dark", () => {
+    // Same persistence argument as index.html: html/body/#root in the
+    // renderer CSS is the page background under the app, so its --launch-bg
+    // fallback must be the dark app surface, never the splash orange.
     const styles = read("../ui/src/styles/styles.css");
     expect(styles).toMatch(
       new RegExp(
-        `body\\s*\\{[^}]*background:\\s*var\\(--launch-bg,\\s*${LAUNCH_ORANGE}\\)`,
+        `body\\s*\\{[^}]*background:\\s*var\\(--launch-bg,\\s*${LAUNCH_DARK}\\)`,
         "s",
       ),
     );
     expect(styles).toMatch(
       new RegExp(
-        `#root\\s*\\{[^}]*background:\\s*var\\(--launch-bg,\\s*${LAUNCH_ORANGE}\\)`,
+        `#root\\s*\\{[^}]*background:\\s*var\\(--launch-bg,\\s*${LAUNCH_DARK}\\)`,
         "s",
       ),
+    );
+    expect(styles).not.toMatch(
+      new RegExp(`var\\(--launch-bg,\\s*${SPLASH_ORANGE}\\)`),
     );
     expect(styles).not.toMatch(/#root\s*\{[^}]*background:\s*var\(--bg\)/s);
   });

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -44,7 +44,7 @@ body {
   max-width: 100%;
   height: 100%;
   margin: 0;
-  background: var(--launch-bg, #ef5a1f);
+  background: var(--launch-bg, #160d07);
   overflow: hidden;
   /* Split the axes instead of a blanket `overscroll-behavior: none`.
      `-y: none` keeps the vertical rubber-band / pull-to-refresh suppression
@@ -69,7 +69,7 @@ body {
   overflow: hidden;
   font-family: var(--font-body);
   color: var(--text);
-  background: var(--launch-bg, #ef5a1f);
+  background: var(--launch-bg, #160d07);
 }
 
 html.eliza-chat-overlay-shell,


### PR DESCRIPTION
## The orange band, killed at the root

Shadow's screenshot: iOS standalone PWA shows a glowing **orange band** in the home-indicator safe-area under the composer. The App.tsx safe-area-floor transparency fix (#14067/#14072) landed the floor layer but not the host-chrome colors, so the band survived.

### Root cause (3 parts)

A pure-develop PWA build paints the launch orange `#ef5a1f` as a **persistent surface**, not a boot flash:

1. **`packages/app/app.config.ts`** — `themeColor`/`backgroundColor` were `#ef5a1f`. The build substitutes `__APP_THEME_COLOR__` in index.html from this, and on iOS standalone PWAs `<meta name="theme-color">` paints the **home-indicator safe-area inset**. Orange inset = orange band.
2. **`packages/app/index.html`** — `html, body, #root { background-color: var(--launch-bg, #ef5a1f) }` is the page background **under the app forever**, not FOUC-only. Any strip the fixed background layers don't reach (home-indicator zone, overscroll) bleeds orange. Same for the renderer root CSS fallbacks in `packages/ui/src/styles/styles.css`.
3. **`packages/app/public/sw.js`** — `SHELL_CACHE_NAME` was `v2`; an installed PWA re-serves the stale orange shell from cache even after this fix deploys. Bumped to `v3` so `activate` drops old caches.

### Fix

All persistent host-chrome surfaces now use `#160d07` = `DEFAULT_BACKGROUND_COLOR` (the ember-night home base develop already ships in `ui-preferences.ts` since #13438), so any bleed-through is invisible against the dark app. The static `site.webmanifest` colors are aligned too.

**Theme decision (documented per plan):** the dark value is unconditional. develop is dark-first now — `DEFAULT_BACKGROUND_COLOR` itself is `#160d07` and there is no light/dark launch-color mechanism to wire into. The `__APP_THEME_COLOR__` build substitution contract is preserved (only the app.config value changes, no hardcoding in index.html, unlike the overhaul branch which duplicated the meta tag).

**Intentionally NOT changed:** native boot-splash surfaces (capacitor config, Android splash resources, iOS LaunchScreen) keep the splash orange — they are true boot-flash surfaces fully covered once the app paints.

### Tests

`packages/app/test/brand-surface.test.ts` was **already red on pristine develop**: its first assertion pins `DEFAULT_BACKGROUND_COLOR` to orange, but develop moved that to `#160d07` in #13438. Realigned it to encode the persistent-vs-splash split (`LAUNCH_DARK` vs `SPLASH_ORANGE`), with new negative assertions that the splash orange never becomes a persistent surface again.

- `brand-surface.test.ts`: 1 failed / 9 passed on pristine develop → **10/10 green** with this PR
- `bun run build:client`: 104/104 tasks pass; built `dist/index.html` carries `<meta name="theme-color" content="#160d07" />` + `--launch-bg: #160d07`, built `sw.js` = `elizaos-shell-v3`, built manifest dark
- remaining app-suite failures (route-coverage/plugin-registrations etc, 14) are pre-existing on develop (missing `plugins/plugin-shopify` manifest), untouched by this PR
- note: codex review hung >100s and was killed; self-reviewed the full staged diff instead

### Verify on device

Install the PWA to an iOS home screen, open standalone: the strip under the composer should be dark `#160d07`, not orange. Re-open an already-installed PWA once online: the v3 cache bump evicts the stale orange shell.

Ported from `feat/ui-overhaul` (canon series PR1).

— [sol-orch]
