### PR TITLE
feat(agent): Character view-scoped actions (FILL_BIO / style / examples)

### DIFF
--- a/packages/agent/src/api/builtin-views.ts
+++ b/packages/agent/src/api/builtin-views.ts
@@ -85,6 +85,72 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     tags: ["identity", "personality", "character"],
     anticipatoryIntent:
       "Offer to refine the agent's identity, personality, or style from the current character state, and point out the highest-leverage next edit.",
+    // Named actions the agent can invoke ONLY while the Character view is the
+    // foreground view (#14155, deferred step 8 of #13591/#14123). Each targets
+    // a `useAgentElement` id in the Character editor (`CharacterEditor` /
+    // `CharacterEditorPanels`) and expands into the same `agent-fill`/
+    // `agent-click` interact sequence the element-level protocol drives — no
+    // parallel DOM path. Only ids that are ALWAYS mounted are targeted: the
+    // editor renders all three panels (personality/style/examples) up front and
+    // toggles visibility with CSS (`hidden`/`display:none`), so `identity-bio`,
+    // `style-add-input-all`/`style-add-all`, `example-add-conversation`, and
+    // `post-example-add` are registered regardless of the active tab. Row-level
+    // ids (`style-rule-remove-<section>-<index>`, `example-message-<c>-<m>`) are
+    // index-dependent and only mounted when that row exists, so they are NOT
+    // declared here — a blind declaration against them would target an unmounted
+    // element and fail loudly (`VIEW_SCOPED_ACTION_ELEMENT_MISSING`).
+    scopedActions: [
+      {
+        name: "VIEW_CHARACTER_FILL_BIO",
+        description:
+          "Set the agent's bio / about-me text on the Character view's Personality section. Autosaves.",
+        similes: [
+          "set bio",
+          "edit bio",
+          "update about me",
+          "write the agent's bio",
+          "rewrite the character bio",
+        ],
+        parameters: ["bio"],
+        steps: [
+          { kind: "agent-fill", target: "identity-bio", value: "{{bio}}" },
+        ],
+      },
+      {
+        name: "VIEW_CHARACTER_ADD_STYLE_RULE",
+        description:
+          "Add a style rule to the agent's writing style on the Character view's Style section. Autosaves.",
+        similes: [
+          "add style rule",
+          "add a writing style rule",
+          "add style guideline",
+          "append a style rule",
+        ],
+        parameters: ["rule"],
+        steps: [
+          {
+            kind: "agent-fill",
+            target: "style-add-input-all",
+            value: "{{rule}}",
+          },
+          { kind: "agent-click", target: "style-add-all" },
+        ],
+      },
+      {
+        name: "VIEW_CHARACTER_ADD_MESSAGE_EXAMPLE",
+        description:
+          "Add a new chat-example conversation on the Character view's Examples section, ready for turns to be filled in. Autosaves.",
+        similes: [
+          "add message example",
+          "add a chat example",
+          "add conversation example",
+          "create a new example conversation",
+        ],
+        steps: [
+          { kind: "agent-click", target: "example-add-conversation" },
+        ],
+      },
+    ],
     visibleInManager: true,
     desktopTabEnabled: true,
   },

--- a/packages/agent/src/api/server-lazy-routes.ts
+++ b/packages/agent/src/api/server-lazy-routes.ts
@@ -706,8 +706,9 @@ export async function registerBuiltinViews(
 ): Promise<void> {
   (await import("./views-registry.ts")).registerBuiltinViews();
   // Register the built-in shell views' scoped actions once the runtime exists.
-  // Mechanism only: BUILTIN_VIEWS carries no scoped actions until per-view
-  // children add them, so this is a no-op today but wires the boot path.
+  // The Character view declares FILL_BIO / ADD_STYLE_RULE / ADD_MESSAGE_EXAMPLE
+  // (#14155); other builtin views carry none yet. registerViewScopedActions is
+  // idempotent, so re-running on reload reconciles the builtin set cleanly.
   if (runtime) {
     const { BUILTIN_VIEWS } = await import("./builtin-views.ts");
     const { registerViewScopedActions } = await import(

--- a/packages/agent/src/runtime/view-scoped-actions.test.ts
+++ b/packages/agent/src/runtime/view-scoped-actions.test.ts
@@ -11,9 +11,14 @@
  */
 import type http from "node:http";
 import { Readable } from "node:stream";
-import type { Action, IAgentRuntime } from "@elizaos/core";
+import type {
+  Action,
+  IAgentRuntime,
+  ViewScopedAction,
+} from "@elizaos/core";
 import { type ElizaError, isElizaError } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_VIEWS } from "../api/builtin-views.ts";
 import {
   registerPluginViews,
   unregisterPluginViews,
@@ -405,5 +410,271 @@ describe("view-scoped action registration reconciliation", () => {
     unregisterViewScopedActions(runtime, TEST_PLUGIN);
     expect(actions.get("VIEW_SETTINGS_SET_PROVIDER")).toBe(incumbent);
     expect(actions.has("VIEW_SETTINGS_MISSING_TARGET")).toBe(false);
+  });
+});
+
+/**
+ * The Character view's concrete scoped actions (#14155). These exercise the
+ * REAL declarations shipped in `BUILTIN_VIEWS` — not a fixture — so the test
+ * fails if the declared action names, params, or step targets drift. The
+ * mounted stand-in registers exactly the always-mounted `useAgentElement` ids
+ * the Character editor renders (bio / add-style-rule / add-conversation), and
+ * reports "element not found" for anything else, mirroring the live registry.
+ */
+const CHARACTER_MOUNTED_IDS = new Set([
+  "identity-bio",
+  "style-add-input-all",
+  "style-add-all",
+  "example-add-conversation",
+  "post-example-add",
+]);
+
+function characterView() {
+  const source = BUILTIN_VIEWS.find((v) => v.id === "character");
+  if (!source) throw new Error("character view missing from BUILTIN_VIEWS");
+  const filled: Record<string, string> = {};
+  const clicked: string[] = [];
+  return {
+    filled,
+    clicked,
+    scopedActions: (source.scopedActions ?? []) as ViewScopedAction[],
+    view: {
+      id: "character",
+      label: "Character view",
+      path: "/character",
+      relatedActions: [] as string[],
+      scopedActions: source.scopedActions,
+      serverInteract: async (
+        capability: string,
+        params?: Record<string, unknown>,
+      ) => {
+        const targetId = typeof params?.id === "string" ? params.id : "";
+        if (!CHARACTER_MOUNTED_IDS.has(targetId)) {
+          return { ok: false, id: targetId, reason: "element not found" };
+        }
+        if (capability === "agent-fill") {
+          filled[targetId] =
+            typeof params?.value === "string" ? params.value : "";
+          return { ok: true, id: targetId, value: filled[targetId] };
+        }
+        if (capability === "agent-click") clicked.push(targetId);
+        return { ok: true, id: targetId };
+      },
+    },
+  };
+}
+
+function findAction(
+  scopedActions: ViewScopedAction[],
+  name: string,
+): ViewScopedAction {
+  const decl = scopedActions.find((a) => a.name === name);
+  if (!decl) throw new Error(`character view missing scoped action ${name}`);
+  return decl;
+}
+
+describe("character view scoped actions (#14155)", () => {
+  it("declares FILL_BIO / ADD_STYLE_RULE / ADD_MESSAGE_EXAMPLE with stable targets", () => {
+    const { scopedActions } = characterView();
+    const names = scopedActions.map((a) => a.name);
+    expect(names).toEqual([
+      "VIEW_CHARACTER_FILL_BIO",
+      "VIEW_CHARACTER_ADD_STYLE_RULE",
+      "VIEW_CHARACTER_ADD_MESSAGE_EXAMPLE",
+    ]);
+
+    // Every declared step target must be an always-mounted editor id — guards
+    // against declaring against an index-dependent (row-level) id by mistake.
+    for (const action of scopedActions) {
+      for (const step of action.steps) {
+        expect(CHARACTER_MOUNTED_IDS.has(step.target)).toBe(true);
+      }
+    }
+
+    // FILL_BIO / ADD_STYLE_RULE take their text from a param; ADD_MESSAGE_EXAMPLE
+    // is a pure click with no params.
+    expect(findAction(scopedActions, "VIEW_CHARACTER_FILL_BIO").parameters).toEqual([
+      "bio",
+    ]);
+    expect(
+      findAction(scopedActions, "VIEW_CHARACTER_ADD_STYLE_RULE").parameters,
+    ).toEqual(["rule"]);
+    expect(
+      findAction(scopedActions, "VIEW_CHARACTER_ADD_MESSAGE_EXAMPLE").parameters,
+    ).toBeUndefined();
+  });
+
+  it("registers exactly the three Character actions and gates them on the view being active", async () => {
+    const { runtime, actions } = makeRuntime();
+    const char = characterView();
+    await registerPluginViews(
+      {
+        name: TEST_PLUGIN,
+        description: "character scoped action fixtures",
+        views: [char.view],
+      },
+      process.cwd(),
+    );
+    const registered = registerViewScopedActions(runtime, TEST_PLUGIN, [
+      char.view,
+    ]);
+    expect(registered).toEqual([
+      "VIEW_CHARACTER_FILL_BIO",
+      "VIEW_CHARACTER_ADD_STYLE_RULE",
+      "VIEW_CHARACTER_ADD_MESSAGE_EXAMPLE",
+    ]);
+
+    const fillBio = actions.get("VIEW_CHARACTER_FILL_BIO");
+    expect(fillBio).toBeDefined();
+
+    // Gated closed everywhere but the character view.
+    await navigateTo("chat");
+    expect(await fillBio?.validate?.({} as IAgentRuntime, fakeMessage)).toBe(
+      false,
+    );
+    await navigateTo("character");
+    expect(await fillBio?.validate?.({} as IAgentRuntime, fakeMessage)).toBe(
+      true,
+    );
+  });
+
+  it("FILL_BIO fills the identity-bio control from the {{bio}} param", async () => {
+    const char = characterView();
+    await registerPluginViews(
+      {
+        name: TEST_PLUGIN,
+        description: "character scoped action fixtures",
+        views: [char.view],
+      },
+      process.cwd(),
+    );
+    await navigateTo("character");
+
+    const action = buildViewScopedAction(
+      "character",
+      findAction(char.scopedActions, "VIEW_CHARACTER_FILL_BIO"),
+    );
+    const result = await action.handler(
+      {} as IAgentRuntime,
+      fakeMessage,
+      undefined,
+      { parameters: { bio: "A calm, precise onchain research agent." } },
+    );
+    expect(result?.success).toBe(true);
+    expect(char.filled["identity-bio"]).toBe(
+      "A calm, precise onchain research agent.",
+    );
+    expect(result?.data?.steps).toEqual(["agent-fill:identity-bio"]);
+  });
+
+  it("ADD_STYLE_RULE fills the pending input then clicks add", async () => {
+    const char = characterView();
+    await registerPluginViews(
+      {
+        name: TEST_PLUGIN,
+        description: "character scoped action fixtures",
+        views: [char.view],
+      },
+      process.cwd(),
+    );
+    await navigateTo("character");
+
+    const action = buildViewScopedAction(
+      "character",
+      findAction(char.scopedActions, "VIEW_CHARACTER_ADD_STYLE_RULE"),
+    );
+    const result = await action.handler(
+      {} as IAgentRuntime,
+      fakeMessage,
+      undefined,
+      { parameters: { rule: "Keep replies under three sentences." } },
+    );
+    expect(result?.success).toBe(true);
+    expect(char.filled["style-add-input-all"]).toBe(
+      "Keep replies under three sentences.",
+    );
+    expect(char.clicked).toContain("style-add-all");
+    expect(result?.data?.steps).toEqual([
+      "agent-fill:style-add-input-all",
+      "agent-click:style-add-all",
+    ]);
+  });
+
+  it("ADD_MESSAGE_EXAMPLE clicks add-conversation with no params", async () => {
+    const char = characterView();
+    await registerPluginViews(
+      {
+        name: TEST_PLUGIN,
+        description: "character scoped action fixtures",
+        views: [char.view],
+      },
+      process.cwd(),
+    );
+    await navigateTo("character");
+
+    const action = buildViewScopedAction(
+      "character",
+      findAction(char.scopedActions, "VIEW_CHARACTER_ADD_MESSAGE_EXAMPLE"),
+    );
+    const result = await action.handler(
+      {} as IAgentRuntime,
+      fakeMessage,
+      undefined,
+      {},
+    );
+    expect(result?.success).toBe(true);
+    expect(char.clicked).toContain("example-add-conversation");
+    expect(result?.data?.steps).toEqual([
+      "agent-click:example-add-conversation",
+    ]);
+  });
+
+  it("ADD_STYLE_RULE fails loudly if the target id is not mounted", async () => {
+    // Register the character view with an EMPTY mounted set: the declared
+    // style-add ids are absent, so the first step must throw the typed
+    // missing-element error — never a silent no-op.
+    const source = BUILTIN_VIEWS.find((v) => v.id === "character");
+    const bareView = {
+      id: "character",
+      label: "Character view",
+      path: "/character",
+      relatedActions: [] as string[],
+      scopedActions: source?.scopedActions,
+      serverInteract: async (_cap: string, params?: Record<string, unknown>) => ({
+        ok: false,
+        id: typeof params?.id === "string" ? params.id : "",
+        reason: "element not found",
+      }),
+    };
+    await registerPluginViews(
+      {
+        name: TEST_PLUGIN,
+        description: "character scoped action fixtures (unmounted)",
+        views: [bareView],
+      },
+      process.cwd(),
+    );
+    await navigateTo("character");
+
+    const action = buildViewScopedAction(
+      "character",
+      findAction(
+        (source?.scopedActions ?? []) as ViewScopedAction[],
+        "VIEW_CHARACTER_ADD_STYLE_RULE",
+      ),
+    );
+
+    let thrown: unknown;
+    try {
+      await action.handler({} as IAgentRuntime, fakeMessage, undefined, {
+        parameters: { rule: "never fills" },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(isElizaError(thrown)).toBe(true);
+    const elizaErr = thrown as ElizaError;
+    expect(elizaErr.code).toBe("VIEW_SCOPED_ACTION_ELEMENT_MISSING");
+    expect(elizaErr.context?.target).toBe("style-add-input-all");
   });
 });


### PR DESCRIPTION
Fixes #14155

Deferred step 8 of #13591/#14123: declare concrete `scopedActions` on the builtin `character` view, on top of the #13589 view-scoped-action mechanism.

## What

Three named, view-scoped actions on the `character` view, registered at boot via the existing `registerViewScopedActions(runtime, "@elizaos/builtin", BUILTIN_VIEWS)` path:

- **`VIEW_CHARACTER_FILL_BIO`** — `agent-fill` `identity-bio` from `{{bio}}`.
- **`VIEW_CHARACTER_ADD_STYLE_RULE`** — `agent-fill` `style-add-input-all` from `{{rule}}` + `agent-click` `style-add-all`.
- **`VIEW_CHARACTER_ADD_MESSAGE_EXAMPLE`** — `agent-click` `example-add-conversation`.

Each reuses `buildViewScopedAction` 1:1 — no parallel DOM-automation path. The handler expands the declared `steps` into the same `agent-fill`/`agent-click` interact sequence the element-level protocol drives, `validate()` gates on the Character view being foreground, and a step whose target id is not mounted fails loudly with `VIEW_SCOPED_ACTION_ELEMENT_MISSING` (never a silent no-op).

## Id-stability (why these targets)

The DoD requires verifying id stability before declaring. `CharacterEditor` renders all three editor panels (personality/style/examples) up front and toggles visibility with CSS (`hidden`/`display:none`) — it never unmounts them — so `identity-bio`, `style-add-input-all`/`style-add-all`, and `example-add-conversation` are registered in the agent-surface registry regardless of the active tab. Fills/clicks route through the elements' `onFill`/`onActivate` handlers, so visibility is irrelevant; only registry membership (mounted) matters.

Deliberately **out of scope** for this declaration (would target unmounted/absent ids and fail-loud):
- Row-level `REMOVE_STYLE_RULE` / `EDIT_MESSAGE_EXAMPLE` — their ids are index-dependent (`style-rule-remove-all-<i>`, `example-message-<c>-<m>`) and only mounted when that row exists; not stable for a blind declaration.
- `EDIT_EXPERIENCE` / `TOGGLE_SKILL` — the `experience` / `character-skills` views are not in `BUILTIN_VIEWS` on develop.
- `chat`/`post` style sections — develop's `STYLE_SECTION_KEYS = ["all"]`; only the `all` section is mounted.

## Tests

Five new cases in `view-scoped-actions.test.ts` drive the **real** `BUILTIN_VIEWS` character declarations (not fixtures) through the mechanism: name/param/target-stability assertions, active-view gating (chat → false, character → true), per-action dispatch (bio fill, style fill+click, add-conversation click), and a loud `VIEW_SCOPED_ACTION_ELEMENT_MISSING` on an unmounted target.

```
✓ src/runtime/view-scoped-actions.test.ts (15 tests) 40ms
Test Files  1 passed (1)
     Tests  15 passed (15)
```

Rebased on latest develop (compatible with #14160 owner-preservation).

— [sol-orch]