### PR TITLE
fix(scenario-runner): treat blank trajectory opt-in as unset

### DIFF
--- a/packages/scenario-runner/src/trajectory-opt-in.test.ts
+++ b/packages/scenario-runner/src/trajectory-opt-in.test.ts
@@ -37,4 +37,15 @@ describe("shouldOptInScenarioTrajectoryLogging", () => {
       } as NodeJS.ProcessEnv),
     ).toBe(false);
   });
+
+  it("treats blank canonical values as unset so the runner still opts in", () => {
+    for (const blank of ["", " ", "\t"]) {
+      expect(
+        shouldOptInScenarioTrajectoryLogging({
+          ELIZA_TRAJECTORY_LOGGING: blank,
+          NODE_ENV: "production",
+        } as NodeJS.ProcessEnv),
+      ).toBe(true);
+    }
+  });
 });

--- a/packages/scenario-runner/src/trajectory-opt-in.ts
+++ b/packages/scenario-runner/src/trajectory-opt-in.ts
@@ -18,5 +18,5 @@
 export function shouldOptInScenarioTrajectoryLogging(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  return !env.ELIZA_TRAJECTORY_LOGGING;
+  return !env.ELIZA_TRAJECTORY_LOGGING?.trim();
 }


### PR DESCRIPTION
## Summary
- fix the #14143 residual blocker: whitespace-only `ELIZA_TRAJECTORY_LOGGING` now counts as unset in the scenario-runner opt-in helper
- add a unit truth-table case for `""`, `" "`, and `"\t"` under `NODE_ENV=production`

## Verification
- `bun test packages/scenario-runner/src/trajectory-opt-in.test.ts` (3 pass, 8 expects)
- `bunx @biomejs/biome check packages/scenario-runner/src/trajectory-opt-in.ts packages/scenario-runner/src/trajectory-opt-in.test.ts --no-errors-on-unmatched`
- `git diff --check origin/develop...HEAD`

## Evidence rows
- Live LLM trajectory: N/A - pure env gate helper, no runtime/model behavior changed directly.
- UI screenshots/video: N/A - no UI.
- Runtime/domain artifacts: focused truth-table test covers the blank-is-unset scenario that blocked #14143.

Follow-up to the unresolved #14143 blocker: https://github.com/elizaOS/eliza/pull/14143#issuecomment-4886992371