### PR TITLE
ci(#13402): enforce zero-key command ownership

### DIFF
--- a/.github/issue-evidence/13402-zero-key-command-ownership.md
+++ b/.github/issue-evidence/13402-zero-key-command-ownership.md
@@ -1,0 +1,44 @@
+# 13402 zero-key command ownership evidence
+
+## Scope
+
+This artifact covers the #13402 slice implemented in this PR: a static
+zero-key/keyless command ownership contract across:
+
+- `.github/workflows/test.yml`
+- `.github/workflows/scenario-pr.yml`
+- `.github/workflows/keyless-harness-e2e.yml`
+- `.github/workflows/ui-fixture-e2e.yml`
+
+It does not change user-facing UI, model behavior, native/device behavior, or
+runtime product behavior.
+
+## Before
+
+The repo had CI contracts for branch split, Turbo cache regime, Bun pinning,
+merge-gate robustness, and full-matrix proof, but no dedicated static guard
+that failed when the same zero-key/keyless test command was owned by multiple
+workflows.
+
+## After
+
+`packages/scripts/ci-zero-key-command-ownership-contract.mjs` scans
+zero-key/keyless workflow job blocks, extracts real suite commands, ignores
+known shared setup commands, and fails if any non-setup command appears more
+than once. `.github/workflows/test.yml` runs it in the existing `changes` job
+beside the other static CI contracts.
+
+## Verification
+
+- `bun test packages/scripts/__tests__/ci-zero-key-command-ownership-contract.test.ts`
+- `node packages/scripts/ci-zero-key-command-ownership-contract.mjs`
+- `node_modules/.bin/biome check packages/scripts/ci-zero-key-command-ownership-contract.mjs packages/scripts/__tests__/ci-zero-key-command-ownership-contract.test.ts .github/workflows/test.yml .github/issue-evidence/13402-zero-key-command-ownership.md`
+- `git diff --check`
+
+## Evidence rows
+
+- UI screenshots/video: N/A - CI static contract only; no rendered UI changed.
+- Frontend/backend logs: N/A - no runtime code path changed.
+- Real-LLM trajectories: N/A - no agent/model/prompt behavior changed.
+- Audio/native/device artifacts: N/A - no audio/native/device behavior changed.
+- Domain artifacts: N/A - no DB/memory/wallet/file-generation behavior changed.

--- a/.github/workflows/keyless-harness-e2e.yml
+++ b/.github/workflows/keyless-harness-e2e.yml
@@ -12,9 +12,9 @@ name: Keyless Harness E2E
 # secret — every provider key below is explicitly blanked to prove the loops
 # stay green without one.
 #
-# This standalone lane remains an always-on PR smoke. The same harness commands
-# are also folded into `.github/workflows/test.yml` through `zero-key-e2e` so at
-# least one per-plugin proof participates in the required `test-status` gate.
+# The required PR gate in `.github/workflows/test.yml` owns the central mock-LLM
+# harness plus the first adoption proofs. This standalone lane owns the remaining
+# connector harness proofs so the same command is not run twice on PRs.
 
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
@@ -79,25 +79,8 @@ jobs:
       - name: Ensure generated shared i18n data
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
-      # Deterministic mock-LLM proxy + recorded payment/connector fixtures.
-      # test/mocks/__tests__/** drives both with zero credentials.
-      - name: Keyless harness e2e (mock-LLM + recorded fixtures)
-        working-directory: packages
-        run: bunx vitest run --config test/mocks/vitest.config.ts test/mocks/__tests__/
-
-      # Issue #8801 / #10757 follow-up: the central harness proves the substrate,
-      # but the per-plugin adoption proofs are excluded from default vitest runs
-      # (each plugin's vitest.config.ts excludes *.harness.test.ts). Gate every
-      # checked-in per-plugin harness suite here so those proofs cannot drift,
-      # while still avoiding live provider credentials — each suite loads the real
-      # plugin under the deterministic mock-LLM runtime with keys blanked.
-      # NOTE (#10757): plugin-goals also ships a harness suite but is not gated
-      # here yet — it depends on the built @elizaos/registry first-party subpath
-      # and could not be confirmed keyless-green outside a full workspace build.
-      - name: Per-plugin keyless harness adoption proofs
+      - name: Remaining per-plugin keyless harness adoption proofs
         run: |
-          bun run --cwd plugins/plugin-anthropic test:harness
-          bun run --cwd plugins/plugin-discord test:harness
           bun run --cwd plugins/plugin-openai test:harness
           bun run --cwd plugins/plugin-groq test:harness
           bun run --cwd plugins/plugin-openrouter test:harness

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -745,6 +745,29 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  app-diagnostics:
+    name: Zero-Key app diagnostics
+    needs: changes
+    if: needs.changes.outputs.run_scenario_pr == 'true'
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      # The required test.yml gate owns the app-diagnostics suite commands. Keep
+      # this status name alive as a real delegation check so rulesets and the
+      # scenario aggregate do not point at a deleted job, without running the
+      # same diagnostics suites twice on PRs (#13402).
+      - name: Validate zero-key command ownership delegation
+        run: node packages/scripts/ci-zero-key-command-ownership-contract.mjs
+
   scenario-runner-e2e:
     name: Zero-Key scenario runner E2E
     needs: changes

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -1,9 +1,8 @@
 name: Scenario PR E2E
 
-# Secret-free scenario runner smoke for every pull request. The full live
-# matrix stays in scenario-matrix.yml; this job proves the scenario CLI,
-# runtime factory, deterministic LLM proxy, UI assistant flows, view/window
-# coverage, and a real scenario turn work without paid model credentials.
+# Secret-free opt-in scenario runner smoke. The required zero-key PR gate
+# lives in test.yml; this workflow owns the additional scenario-heavy and
+# browser matrix coverage that is not already run by the required gate.
 
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
@@ -118,23 +117,6 @@ jobs:
       - name: Scenario runner unit coverage
         run: bun run --cwd packages/scenario-runner test -- src/executor.test.ts src/runtime-factory.test.ts src/scenario-pr-workflow.test.ts src/__tests__/deterministic-action-coverage.test.ts
 
-      - name: Deterministic LLM proxy unit coverage
-        working-directory: packages
-        run: bunx vitest run --config test/mocks/vitest.config.ts test/mocks/__tests__/llm-proxy-plugin.test.ts
-
-      - name: UI voice interaction coverage
-        run: bun run --cwd packages/ui test -- src/hooks/useVoiceChat.bidirectional.test.tsx src/hooks/useContinuousChat.test.tsx
-
-      - name: UI dynamic view interaction coverage
-        run: bun run --cwd packages/ui test -- src/App.navigate-view-wiring.test.tsx src/app-navigate-view.test.ts src/components/shell/__tests__/shell-assistant-flow.test.tsx src/components/views/DynamicViewLoader.test.tsx src/hooks/useAvailableViews.test.tsx src/hooks/useDesktopTabs.test.tsx src/state/startup-phase-hydrate.view-interact.test.ts
-
-      - name: App route + ui-smoke spec coverage gates
-        run: bun run --cwd packages/app test -- test/route-coverage.test.ts test/ui-smoke-coverage.test.ts test/view-interaction-coverage.test.ts
-
-      # Real local agent provisioning — boots an actual AgentRuntime on PGLite +
-      # the real app-core API and asserts it provisions and serves. No model, no
-      # secret, no stub, so it gates every PR with genuinely-real (not fixtured)
-      # local provisioning coverage.
       - name: Real local agent provisioning (no model, no secret)
         run: bun run --cwd packages/app-core test:local-provisioning
 
@@ -177,20 +159,11 @@ jobs:
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium
 
-      - name: Actual app assistant pill browser coverage
-        run: bun run --cwd packages/app test:e2e test/ui-smoke/assistant-home-flow.spec.ts --project=chromium -g "captures first-run, assistant home, chat suppression, and view pill states"
-
       - name: Actual app onboarding-to-home browser coverage
         run: bun run --cwd packages/app test:e2e test/ui-smoke/onboarding-to-home.spec.ts --project=chromium
 
       - name: Mobile-viewport onboarding-to-home browser coverage
         run: bun run --cwd packages/app test:e2e test/ui-smoke/onboarding-to-home-mobile.spec.ts --project=chromium
-
-      - name: Actual app assistant voice browser coverage
-        run: bun run --cwd packages/app test:e2e test/ui-smoke/assistant-home-flow.spec.ts --project=chromium -g "drives the assistant home voice path with a scripted browser STT turn"
-
-      - name: Actual app TTS and STT browser coverage
-        run: bun run --cwd packages/app test:e2e test/ui-smoke/tts-stt-e2e.spec.ts --project=chromium
 
       - name: Actual app voice self-test browser coverage
         run: bun run --cwd packages/app test:e2e test/ui-smoke/voice-selftest-e2e.spec.ts test/ui-smoke/voice-desktop-selftest.spec.ts --project=chromium
@@ -772,52 +745,6 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  app-diagnostics:
-    name: Zero-Key app diagnostics
-    needs: changes
-    if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
-    timeout-minutes: 35
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        with:
-          submodules: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Setup workspace dependencies
-        uses: ./.github/actions/setup-bun-workspace
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-          install-command: bun install --ignore-scripts --no-frozen-lockfile
-          install-native-deps: "false"
-          skip-avatar-clone: "true"
-          no-vision-deps: "true"
-
-      - name: Ensure generated shared i18n data
-        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
-
-      - name: Electrobun window and dynamic-view coverage
-        run: bun run --cwd packages/app-core/platforms/electrobun test src/native/desktop-window.test.ts src/rpc-handlers.test.ts src/dynamic-view-rpc-schema.test.ts src/surface-windows.test.ts src/dynamic-views/host.test.ts src/application-menu.test.ts
-
-      - name: View management action coverage
-        run: bun run --cwd plugins/plugin-app-control test -- src/actions/views-management.test.ts
-
-      - name: App verification diagnostics coverage
-        run: bun run --cwd plugins/plugin-app-control test -- src/services/__tests__/app-verification.integration.test.ts src/services/__tests__/verification-room-bridge.test.ts
-
-      - name: Computer-use screenshot quality diagnostics coverage
-        run: bun run --cwd plugins/plugin-computeruse test -- test/helpers/screenshot-quality.test.ts src/__tests__/browser-auto-open.test.ts
-
-      - name: App screenshot quality diagnostics coverage
-        run: bun run --cwd packages/app test -- test/screenshot-quality.test.ts
-
-      - name: App-core screenshot quality diagnostics coverage
-        run: bun run --cwd packages/app-core test -- test/app/screenshot-quality.test.ts
-
   scenario-runner-e2e:
     name: Zero-Key scenario runner E2E
     needs: changes
@@ -846,13 +773,6 @@ jobs:
       - name: Ensure generated shared i18n data
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
-      - name: Scenario catalog coverage gate
-        run: node packages/scripts/check-scenario-workflow-coverage.mjs --report-dir reports/scenarios/catalog-inventory
-
-      # Unit-tests the cross-package test runner's pool + shard logic
-      # (packages/scripts/lib/test-task-pool.mjs). Lives here because
-      # packages/scripts/__tests__ bun:test files only run when a workflow
-      # invokes them explicitly (the dir is not a workspace member).
       - name: Test-runner pool + shard unit tests
         run: bun test packages/scripts/__tests__/test-task-pool.test.ts
 
@@ -925,9 +845,6 @@ jobs:
 
       - name: Build workspace packages for scenario resolution
         run: bun run build:core && bunx turbo run build --filter=@elizaos/plugin-github
-
-      - name: Zero-cost scenario e2e
-        run: bun run --cwd packages/scenario-runner test:pr:e2e
 
       - name: Upload scenario report
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,6 +138,9 @@ jobs:
       - name: Validate CI Bun version pin contract
         run: node packages/scripts/ci-bun-version-contract.mjs
 
+      - name: Validate zero-key command ownership contract
+        run: node packages/scripts/ci-zero-key-command-ownership-contract.mjs
+
       - name: Install alias-read guard parser dependency
         run: npm install --prefix "$RUNNER_TEMP/alias-read-guard-deps" --no-save --no-package-lock --ignore-scripts typescript@6.0.3
 

--- a/packages/scripts/__tests__/ci-zero-key-command-ownership-contract.test.ts
+++ b/packages/scripts/__tests__/ci-zero-key-command-ownership-contract.test.ts
@@ -1,0 +1,143 @@
+// Pins the zero-key command ownership contract (#13402) against synthetic
+// workflow trees: unique commands pass, duplicate real suite commands fail,
+// repeated setup stays allowed, and the shipped repo stays clean. Static only:
+// no workflow is executed.
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { collectZeroKeyCommands, findDuplicateOwnedCommands, runContract } =
+  await import(
+    new URL("../ci-zero-key-command-ownership-contract.mjs", import.meta.url)
+      .href
+  );
+
+const REAL_REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+function workflow({
+  name,
+  jobName,
+  commands,
+}: {
+  name: string;
+  jobName: string;
+  commands: string[];
+}): string {
+  return `name: ${name}
+on: [pull_request]
+jobs:
+  checks:
+    name: ${jobName}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Run
+        run: |
+${commands.map((command) => `          ${command}`).join("\n")}
+`;
+}
+
+function buildRepo(overrides: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), "zero-key-command-ownership-"));
+  mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+  const defaults: Record<string, string> = {
+    "test.yml": workflow({
+      name: "Tests",
+      jobName: "Zero-Key deterministic",
+      commands: ["bun run test:server"],
+    }),
+    "scenario-pr.yml": workflow({
+      name: "Scenario PR E2E",
+      jobName: "Zero-Key scenario",
+      commands: ["bun run --cwd packages/scenario-runner test"],
+    }),
+    "keyless-harness-e2e.yml": workflow({
+      name: "Keyless harness",
+      jobName: "Keyless harness",
+      commands: [
+        "bunx vitest run --config test/mocks/vitest.config.ts test/mocks/__tests__/",
+      ],
+    }),
+    "ui-fixture-e2e.yml": workflow({
+      name: "UI fixture",
+      jobName: "Zero-Key UI fixture",
+      commands: ["bun run --cwd packages/ui test:launcher-e2e"],
+    }),
+  };
+  for (const [name, content] of Object.entries({ ...defaults, ...overrides })) {
+    writeFileSync(join(root, ".github", "workflows", name), content);
+  }
+  return root;
+}
+
+function withRepo(
+  overrides: Record<string, string>,
+  fn: (root: string) => void,
+) {
+  const root = buildRepo(overrides);
+  try {
+    fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("ci-zero-key-command-ownership-contract", () => {
+  test("passes when every real zero-key command has one owner", () => {
+    withRepo({}, (root) => {
+      const result = runContract(root);
+      expect(result.commandCount).toBe(4);
+    });
+  });
+
+  test("fails when two workflows own the same real suite command", () => {
+    withRepo(
+      {
+        "scenario-pr.yml": workflow({
+          name: "Scenario PR E2E",
+          jobName: "Zero-Key scenario",
+          commands: ["bun run test:server"],
+        }),
+      },
+      (root) => {
+        expect(() => runContract(root)).toThrow(
+          /Duplicate zero-key command ownership/,
+        );
+      },
+    );
+  });
+
+  test("allows repeated setup commands while still collecting suite commands", () => {
+    withRepo(
+      {
+        "test.yml": workflow({
+          name: "Tests",
+          jobName: "Zero-Key deterministic",
+          commands: [
+            "node packages/app-core/scripts/ensure-shared-i18n-data.mjs",
+            "bun run test:server",
+          ],
+        }),
+        "scenario-pr.yml": workflow({
+          name: "Scenario PR E2E",
+          jobName: "Zero-Key scenario",
+          commands: [
+            "node packages/app-core/scripts/ensure-shared-i18n-data.mjs",
+            "bun run --cwd packages/scenario-runner test",
+          ],
+        }),
+      },
+      (root) => {
+        const rows = collectZeroKeyCommands(root);
+        expect(findDuplicateOwnedCommands(rows)).toEqual([]);
+        expect(runContract(root).commandCount).toBe(6);
+      },
+    );
+  });
+
+  test("the real repo satisfies the zero-key ownership contract", () => {
+    const result = runContract(REAL_REPO_ROOT);
+    expect(result.commandCount).toBeGreaterThan(0);
+  });
+});

--- a/packages/scripts/ci-zero-key-command-ownership-contract.mjs
+++ b/packages/scripts/ci-zero-key-command-ownership-contract.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * Contract for #13402's zero-key command ownership slice. The keyless and
+ * zero-key workflows may share setup, but each real test/suite command must
+ * have exactly one owner so PRs do not execute the same suite in multiple
+ * workflows by accident.
+ *
+ * This is a static YAML census: it does not run workflows. It scans only the
+ * zero-key/keyless workflow surface listed below, extracts shell commands from
+ * zero-key job blocks, normalizes them, and fails when the same non-setup
+ * command appears more than once.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_REPO_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+
+const OWNED_WORKFLOWS = [
+  { file: ".github/workflows/test.yml", owner: "test-orchestrator" },
+  { file: ".github/workflows/scenario-pr.yml", owner: "scenario-pr-zero-key" },
+  { file: ".github/workflows/keyless-harness-e2e.yml", owner: "keyless-harness" },
+  { file: ".github/workflows/ui-fixture-e2e.yml", owner: "ui-fixture-e2e" },
+];
+
+const ZERO_KEY_MARKER =
+  /Zero-Key|zero-key|keyless|secret-free|no secret|SCENARIO_USE_LLM_PROXY|ELIZA_LIVE_TEST:\s*["']?0/i;
+
+const COMMAND_PREFIX = /^(bun|bunx|node|npm|pnpm|bash|cargo|python3?)\b/;
+const IGNORED_LINE =
+  /^(set |if |then$|else$|elif |fi$|for |do$|done$|while |case |esac$|echo |cat |sleep |exit |trap |cd |mkdir |rm |cp |mv |sudo |export |[A-Za-z_][A-Za-z0-9_]*=|[{}]$)/;
+
+const ALLOWED_DUPLICATE_COMMANDS = new Set([
+  "node packages/app-core/scripts/ensure-shared-i18n-data.mjs",
+  "bunx playwright install --with-deps chromium",
+]);
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function countIndent(line) {
+  return line.match(/^ */)?.[0].length ?? 0;
+}
+
+function stripInlineComment(line) {
+  return line.replace(/\s+#.*$/, "").trim();
+}
+
+function normalizeCommand(line) {
+  return stripInlineComment(line).replace(/\s+/g, " ").trim();
+}
+
+function extractJobBlocks(workflowText) {
+  const jobsIndex = workflowText.search(/^jobs:\s*$/m);
+  if (jobsIndex < 0) return [];
+  const lines = workflowText.slice(jobsIndex).split(/\r?\n/);
+  const starts = [];
+  for (let i = 1; i < lines.length; i += 1) {
+    if (/^  [A-Za-z0-9_-]+:\s*$/.test(lines[i])) starts.push(i);
+  }
+  const blocks = [];
+  for (let i = 0; i < starts.length; i += 1) {
+    const start = starts[i];
+    const end = starts[i + 1] ?? lines.length;
+    const key = lines[start].trim().slice(0, -1);
+    blocks.push({ key, text: lines.slice(start, end).join("\n") });
+  }
+  return blocks;
+}
+
+function extractRunBodies(jobText) {
+  const lines = jobText.split(/\r?\n/);
+  const bodies = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = lines[i].match(/^(\s*)run:\s*(.*)$/);
+    if (!match) continue;
+    const indent = match[1].length;
+    const rest = match[2].trim();
+    if (rest && !/^[>|]/.test(rest)) {
+      bodies.push(rest);
+      continue;
+    }
+    const bodyLines = [];
+    for (i += 1; i < lines.length; i += 1) {
+      const line = lines[i];
+      if (line.trim() !== "" && countIndent(line) <= indent) {
+        i -= 1;
+        break;
+      }
+      bodyLines.push(line.slice(Math.min(line.length, indent + 2)));
+    }
+    bodies.push(bodyLines.join("\n"));
+  }
+  return bodies;
+}
+
+function extractCommands(jobText) {
+  const commands = [];
+  for (const body of extractRunBodies(jobText)) {
+    for (const rawLine of body.split(/\r?\n/)) {
+      const command = normalizeCommand(rawLine);
+      if (!command || command.startsWith("#")) continue;
+      if (IGNORED_LINE.test(command)) continue;
+      if (!COMMAND_PREFIX.test(command)) continue;
+      commands.push(command);
+    }
+  }
+  return commands;
+}
+
+export function collectZeroKeyCommands(repoRoot = DEFAULT_REPO_ROOT) {
+  const rows = [];
+  for (const workflow of OWNED_WORKFLOWS) {
+    const text = readFileSync(resolve(repoRoot, workflow.file), "utf8");
+    for (const job of extractJobBlocks(text)) {
+      const includeJob =
+        workflow.file.includes("keyless") || ZERO_KEY_MARKER.test(job.text);
+      if (!includeJob) continue;
+      for (const command of extractCommands(job.text)) {
+        rows.push({
+          workflow: workflow.file,
+          owner: workflow.owner,
+          job: job.key,
+          command,
+        });
+      }
+    }
+  }
+  return rows;
+}
+
+export function findDuplicateOwnedCommands(rows) {
+  const byCommand = new Map();
+  for (const row of rows) {
+    if (ALLOWED_DUPLICATE_COMMANDS.has(row.command)) continue;
+    const existing = byCommand.get(row.command) ?? [];
+    existing.push(row);
+    byCommand.set(row.command, existing);
+  }
+  return [...byCommand.entries()]
+    .filter(([, locations]) => locations.length > 1)
+    .map(([command, locations]) => ({ command, locations }));
+}
+
+export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
+  const rows = collectZeroKeyCommands(repoRoot);
+  assert(rows.length > 0, "zero-key command ownership census found no commands");
+  const duplicates = findDuplicateOwnedCommands(rows);
+  assert(
+    duplicates.length === 0,
+    "Duplicate zero-key command ownership found:\n" +
+      duplicates
+        .map(
+          ({ command, locations }) =>
+            `- ${command}\n` +
+            locations
+              .map(
+                ({ workflow, job, owner }) =>
+                  `  - ${workflow}#${job} (${owner})`,
+              )
+              .join("\n"),
+        )
+        .join("\n"),
+  );
+  return {
+    commandCount: rows.length,
+    workflows: OWNED_WORKFLOWS.map((workflow) => workflow.file),
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    const { commandCount, workflows } = runContract();
+    console.log(
+      `ci zero-key command ownership contract passed (${commandCount} command(s), ${workflows.length} workflow(s) scanned)`,
+    );
+  } catch (error) {
+    console.error(
+      `[ci-zero-key-command-ownership-contract] FAIL ${error.message}`,
+    );
+    process.exit(1);
+  }
+}

--- a/packages/scripts/ci-zero-key-command-ownership-contract.mjs
+++ b/packages/scripts/ci-zero-key-command-ownership-contract.mjs
@@ -40,6 +40,7 @@ const IGNORED_LINE =
 const ALLOWED_DUPLICATE_COMMANDS = new Set([
   "node packages/app-core/scripts/ensure-shared-i18n-data.mjs",
   "bunx playwright install --with-deps chromium",
+  "node packages/scripts/ci-zero-key-command-ownership-contract.mjs",
 ]);
 
 function assert(condition, message) {

--- a/packages/scripts/ci-zero-key-command-ownership-contract.mjs
+++ b/packages/scripts/ci-zero-key-command-ownership-contract.mjs
@@ -23,7 +23,10 @@ const DEFAULT_REPO_ROOT = resolve(
 const OWNED_WORKFLOWS = [
   { file: ".github/workflows/test.yml", owner: "test-orchestrator" },
   { file: ".github/workflows/scenario-pr.yml", owner: "scenario-pr-zero-key" },
-  { file: ".github/workflows/keyless-harness-e2e.yml", owner: "keyless-harness" },
+  {
+    file: ".github/workflows/keyless-harness-e2e.yml",
+    owner: "keyless-harness",
+  },
   { file: ".github/workflows/ui-fixture-e2e.yml", owner: "ui-fixture-e2e" },
 ];
 
@@ -61,7 +64,7 @@ function extractJobBlocks(workflowText) {
   const lines = workflowText.slice(jobsIndex).split(/\r?\n/);
   const starts = [];
   for (let i = 1; i < lines.length; i += 1) {
-    if (/^  [A-Za-z0-9_-]+:\s*$/.test(lines[i])) starts.push(i);
+    if (/^ {2}[A-Za-z0-9_-]+:\s*$/.test(lines[i])) starts.push(i);
   }
   const blocks = [];
   for (let i = 0; i < starts.length; i += 1) {
@@ -149,7 +152,10 @@ export function findDuplicateOwnedCommands(rows) {
 
 export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
   const rows = collectZeroKeyCommands(repoRoot);
-  assert(rows.length > 0, "zero-key command ownership census found no commands");
+  assert(
+    rows.length > 0,
+    "zero-key command ownership census found no commands",
+  );
   const duplicates = findDuplicateOwnedCommands(rows);
   assert(
     duplicates.length === 0,


### PR DESCRIPTION
## Summary
- add a static zero-key/keyless command ownership contract for #13402
- wire the contract into `test.yml` alongside the existing CI static contracts
- remove duplicate PR ownership by trimming `scenario-pr.yml` overlap already owned by `test.yml`
- keep `keyless-harness-e2e.yml` focused on remaining connector harness proofs not already owned by the required gate

Relates to #13402.

## Verification
- `node packages/scripts/ci-zero-key-command-ownership-contract.mjs` -> passed, 107 command(s), 4 workflow(s) scanned
- `bun test packages/scripts/__tests__/ci-zero-key-command-ownership-contract.test.ts` -> 4 pass / 0 fail
- `node_modules/.bin/biome check ...` on the new script/test and touched workflow/evidence files -> passed
- scratch base-vs-branch `git diff --check HEAD` -> clean

## Not run
- `actionlint` - not installed on this host
- full `bun run verify` - host remains disk-constrained and dirty; this PR is limited to static CI contract/workflow edits

## Evidence
- `.github/issue-evidence/13402-zero-key-command-ownership.md`
- UI screenshots/video: N/A - CI static contract only; no rendered UI changed
- Frontend/backend logs: N/A - no runtime code path changed
- Real-LLM trajectories: N/A - no agent/model/prompt behavior changed
- Audio/native/device artifacts: N/A - no audio/native/device behavior changed
- Domain artifacts: N/A - no DB/memory/wallet/file-generation behavior changed
