### PR TITLE
fix(training): preserve trace filters in trajectory exports

### DIFF
--- a/.github/issue-evidence/13871-traceid-export.md
+++ b/.github/issue-evidence/13871-traceid-export.md
@@ -1,0 +1,32 @@
+# TraceId Export Filter Follow-Up
+
+## Scope
+
+- `TrajectoriesService.exportTrajectoriesZip()` now forwards `traceId` into the
+  list query it uses when no explicit trajectory IDs are provided.
+- `/api/trajectories` list, JSON/JSONL export, and ZIP export all accept and
+  forward `traceId`.
+- `/api/training/trajectories/export` accepts `traceId`, forwards it to the
+  training service list call, and records the requested trace in bundle source
+  metadata.
+
+## Verification
+
+- `node packages/shared/scripts/generate-keywords.mjs --target ts` passed.
+- `bun test plugins/plugin-training/src/routes/trajectory-routes.test.ts plugins/plugin-training/src/core/trajectory-export-bundle.test.ts plugins/plugin-training/src/services/training-service.test.ts`:
+  - Passed the new `/api/trajectories` `traceId` propagation regression.
+  - Passed `TrainingService.buildDataset` coverage.
+  - Passed the updated training export bundle regression.
+  - The broader `trajectory-export-bundle.test.ts` file then timed out in the
+    existing `lets the training collection route pull natural runtime
+    trajectories` case after failing to find a generated README in its temp
+    output. That case is outside this traceId plumbing change.
+- `bunx @biomejs/biome check packages/core/src/features/trajectories/TrajectoriesService.ts plugins/plugin-training/src/routes/trajectory-routes.ts plugins/plugin-training/src/routes/training-routes.ts plugins/plugin-training/src/services/training-service.ts plugins/plugin-training/src/services/training-service-like.ts plugins/plugin-training/src/routes/trajectory-routes.test.ts plugins/plugin-training/src/core/trajectory-export-bundle.test.ts --no-errors-on-unmatched` passed with pre-existing warnings in touched test/route files.
+- `git diff --check` passed.
+
+## Manual Review
+
+Reviewed the changed route and service boundaries by hand. The filter now
+survives every path that can expand a trace-scoped request into trajectory IDs:
+core ZIP export, plugin-training `/api/trajectories` list/export, and
+plugin-training rich bundle export.

--- a/packages/core/src/features/trajectories/TrajectoriesService.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.ts
@@ -2659,6 +2659,7 @@ export class TrajectoriesService extends Service {
 				startDate: options.startDate,
 				endDate: options.endDate,
 				scenarioId: options.scenarioId,
+				traceId: options.traceId,
 				batchId: options.batchId,
 			});
 			targetIds = list.trajectories.map((trajectory) => trajectory.id);

--- a/plugins/plugin-training/src/core/trajectory-export-bundle.test.ts
+++ b/plugins/plugin-training/src/core/trajectory-export-bundle.test.ts
@@ -394,6 +394,7 @@ describe("trajectory export bundle", () => {
       exportBundle: true,
       includeRaw: true,
       runId: "run-1",
+      traceId: "trace-1",
       outputDir,
       tasks: ["response"],
     });
@@ -403,6 +404,7 @@ describe("trajectory export bundle", () => {
       limit: 100,
       offset: 0,
       runId: "run-1",
+      traceId: "trace-1",
     });
     expect(trainingService.getTrajectoryById).toHaveBeenCalledTimes(2);
 
@@ -425,6 +427,7 @@ describe("trajectory export bundle", () => {
       metadata: {
         requestedLimit: 100,
         requestedRunId: "run-1",
+        requestedTraceId: "trace-1",
         selectedTrajectoryIds: 2,
         loadedTrajectories: 2,
         bundledTrajectories: 1,

--- a/plugins/plugin-training/src/routes/training-routes.ts
+++ b/plugins/plugin-training/src/routes/training-routes.ts
@@ -1698,6 +1698,7 @@ export async function handleTrainingRoutes(
       includeRawJsonl?: boolean;
       tasks?: string[];
       runId?: string;
+      traceId?: string;
     }>(req, res);
     if (!body) return true;
 
@@ -1705,6 +1706,7 @@ export async function handleTrainingRoutes(
       error(res, "runId must be a non-empty string", 400);
       return true;
     }
+    const requestedTraceId = resolveStringSetting(body.traceId);
 
     const outputPath =
       body.outputPath ?? `.tmp/training-trajectory-export-${Date.now()}.jsonl`;
@@ -1720,6 +1722,7 @@ export async function handleTrainingRoutes(
               limit: body.limit ?? 100,
               offset: 0,
               runId: normalizeRunId(body.runId),
+              traceId: requestedTraceId,
             });
       const trajectoryIds =
         explicitIds.length > 0
@@ -1759,6 +1762,7 @@ export async function handleTrainingRoutes(
             metadata: {
               requestedLimit: body.limit ?? 100,
               requestedRunId: requestedRunId ?? null,
+              requestedTraceId: requestedTraceId ?? null,
               explicitTrajectoryIds: explicitIds.length,
               selectedTrajectoryIds: trajectoryIds.length,
               loadedTrajectories: details.length,

--- a/plugins/plugin-training/src/routes/trajectory-routes.test.ts
+++ b/plugins/plugin-training/src/routes/trajectory-routes.test.ts
@@ -279,6 +279,69 @@ describe("trajectory routes", () => {
     });
   });
 
+  it("passes traceId through list and export filters", async () => {
+    const listTrajectories = vi.fn(async () => ({
+      trajectories: [],
+      total: 0,
+      offset: 0,
+      limit: 20,
+    }));
+    const exportTrajectories = vi.fn(async () => ({
+      data: "[]",
+      filename: "trajectories.json",
+      mimeType: "application/json",
+    }));
+    const exportTrajectoriesZip = vi.fn(async () => ({
+      filename: "trajectories.zip",
+      entries: [],
+    }));
+    const logger = createLogger({
+      listTrajectories,
+      exportTrajectories,
+      exportTrajectoriesZip,
+    });
+
+    const listRequest = createRequest() as http.IncomingMessage & {
+      url?: string;
+      headers: Record<string, string>;
+    };
+    listRequest.url = "/api/trajectories?traceId=trace-1&limit=20";
+    listRequest.headers = { host: "localhost" };
+
+    await handleTrajectoryRoute(
+      listRequest,
+      createResponse(),
+      createRuntime(logger),
+      "/api/trajectories",
+      "GET",
+    );
+    expect(listTrajectories).toHaveBeenCalledWith(
+      expect.objectContaining({ traceId: "trace-1" }),
+    );
+
+    await handleTrajectoryRoute(
+      createRequest({ format: "json", traceId: "trace-1" }),
+      createResponse(),
+      createRuntime(logger),
+      "/api/trajectories/export",
+      "POST",
+    );
+    expect(exportTrajectories).toHaveBeenCalledWith(
+      expect.objectContaining({ traceId: "trace-1" }),
+    );
+
+    await handleTrajectoryRoute(
+      createRequest({ format: "zip", traceId: "trace-1" }),
+      createResponse(),
+      createRuntime(logger),
+      "/api/trajectories/export",
+      "POST",
+    );
+    expect(exportTrajectoriesZip).toHaveBeenCalledWith(
+      expect.objectContaining({ traceId: "trace-1" }),
+    );
+  });
+
   it("delegates search to the SQL reader so matches past the first 500 rows are returned with a DB-wide total", async () => {
     // Seed 600 list items; only one (at index 550) carries the needle.
     // The old route re-fetched limit:500/offset:0 then filtered in memory,

--- a/plugins/plugin-training/src/routes/trajectory-routes.ts
+++ b/plugins/plugin-training/src/routes/trajectory-routes.ts
@@ -69,6 +69,7 @@ type TrajectoryZipExportOptions = {
   startDate?: string;
   endDate?: string;
   scenarioId?: string;
+  traceId?: string;
   batchId?: string;
 };
 
@@ -1653,6 +1654,7 @@ async function handleGetTrajectories(
     endDate: url.searchParams.get("endDate") || undefined,
     search: url.searchParams.get("search") || undefined,
     scenarioId: url.searchParams.get("scenarioId") || undefined,
+    traceId: url.searchParams.get("traceId") || undefined,
     batchId: url.searchParams.get("batchId") || undefined,
     isTrainingData: url.searchParams.has("isTrainingData")
       ? url.searchParams.get("isTrainingData") === "true"
@@ -1778,6 +1780,7 @@ async function handleExportTrajectories(
     startDate?: string;
     endDate?: string;
     scenarioId?: string;
+    traceId?: string;
     batchId?: string;
     jsonShape?: string;
   }>(req, res);
@@ -1799,6 +1802,7 @@ async function handleExportTrajectories(
       startDate: body.startDate,
       endDate: body.endDate,
       scenarioId: body.scenarioId,
+      traceId: body.traceId,
       batchId: body.batchId,
     };
     const zipResult = await logger.exportTrajectoriesZip(zipOptions);
@@ -1844,6 +1848,7 @@ async function handleExportTrajectories(
     startDate: body.startDate,
     endDate: body.endDate,
     scenarioId: body.scenarioId,
+    traceId: body.traceId,
     batchId: body.batchId,
     ...((body.format === "json" || body.format === "jsonl") && jsonShape
       ? { jsonShape }

--- a/plugins/plugin-training/src/services/training-service-like.ts
+++ b/plugins/plugin-training/src/services/training-service-like.ts
@@ -7,6 +7,7 @@ export interface TrainingServiceLike {
     limit?: number;
     offset?: number;
     runId?: string;
+    traceId?: string;
   }): Promise<TrajectoryListResult>;
   getTrajectoryById(trajectoryId: string): Promise<Trajectory | null>;
   listDatasets(): Record<string, unknown>[];

--- a/plugins/plugin-training/src/services/training-service.ts
+++ b/plugins/plugin-training/src/services/training-service.ts
@@ -35,6 +35,7 @@ interface TrajectoryServiceLike {
     limit?: number;
     offset?: number;
     runId?: string;
+    traceId?: string;
   }) => Promise<TrajectoryListResult>;
   getTrajectoryDetail: (id: string) => Promise<Trajectory | null>;
 }
@@ -96,6 +97,7 @@ export class TrainingService implements TrainingServiceWithRuntime {
     limit?: number;
     offset?: number;
     runId?: string;
+    traceId?: string;
   }): Promise<TrajectoryListResult> {
     return await this.trajectoryService().listTrajectories(options);
   }


### PR DESCRIPTION
## Summary
- forwards `traceId` through core ZIP trajectory exports when the request expands filters into trajectory IDs
- adds `traceId` support to `/api/trajectories` list, JSON/JSONL export, and ZIP export
- threads `traceId` through `/api/training/trajectories/export` bundle generation and records the requested trace in bundle metadata

Follow-up for the post-merge review blocker on #13871.

## Verification
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun test plugins/plugin-training/src/routes/trajectory-routes.test.ts plugins/plugin-training/src/core/trajectory-export-bundle.test.ts plugins/plugin-training/src/services/training-service.test.ts`
  - new `/api/trajectories` traceId regression passed
  - updated training bundle export regression passed
  - TrainingService paging tests passed
  - broader run then hit an existing unrelated `trajectory-export-bundle.test.ts` timeout in `lets the training collection route pull natural runtime trajectories` after missing its temp README
- `bunx @biomejs/biome check .github/issue-evidence/13871-traceid-export.md packages/core/src/features/trajectories/TrajectoriesService.ts plugins/plugin-training/src/routes/trajectory-routes.ts plugins/plugin-training/src/routes/training-routes.ts plugins/plugin-training/src/services/training-service.ts plugins/plugin-training/src/services/training-service-like.ts plugins/plugin-training/src/routes/trajectory-routes.test.ts plugins/plugin-training/src/core/trajectory-export-bundle.test.ts --no-errors-on-unmatched` (passed with pre-existing no-non-null warnings in touched files)
- `git diff --check`

## Evidence
- `.github/issue-evidence/13871-traceid-export.md`

Screenshots/video/frontend logs are N/A: this is API route/service filter plumbing with no rendered UI.