### PR TITLE
fix(app): land the two gate-prescribed residues merged over in #13965/#14152

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -180,7 +180,6 @@ import {
   type IosRuntimeConfig,
   resolveIosRuntimeConfig,
 } from "./ios-runtime";
-import { runIosVoiceSelfTestSmokeIfRequested } from "./ios-voice-selftest-smoke";
 import { startKeyboardDictationSession } from "./keyboard-dictation";
 import {
   createMobileLifecycle,
@@ -1857,15 +1856,24 @@ async function initializePlatform(): Promise<void> {
     waitForElement: waitForIosOnboardingElement,
     readStorageSnapshot: readIosOnboardingSmokeStorageSnapshot,
   });
-  void runIosVoiceSelfTestSmokeIfRequested({
-    isIOS,
-    client,
-    getPreference: boundedPreferenceGet,
-    removePreference: (key) =>
-      boundedPreferenceWrite(() => Preferences.remove({ key })),
-    writeResult: writeIosPreferenceSmokeResult,
-    readStorageSnapshot: readIosOnboardingSmokeStorageSnapshot,
-  });
+  // Lazy + iOS-gated: the voice self-test pulls the whole @elizaos/ui/voice
+  // graph, which a static import anchors into every web/desktop entry chunk.
+  // Non-iOS platforms never ran the smoke anyway (the module self-gates), so
+  // they now skip fetching the chunk entirely.
+  if (isIOS) {
+    void import("./ios-voice-selftest-smoke").then(
+      ({ runIosVoiceSelfTestSmokeIfRequested }) =>
+        runIosVoiceSelfTestSmokeIfRequested({
+          isIOS,
+          client,
+          getPreference: boundedPreferenceGet,
+          removePreference: (key) =>
+            boundedPreferenceWrite(() => Preferences.remove({ key })),
+          writeResult: writeIosPreferenceSmokeResult,
+          readStorageSnapshot: readIosOnboardingSmokeStorageSnapshot,
+        }),
+    );
+  }
 
   if (isIOS || isAndroid) {
     await initializeStatusBar();

--- a/packages/app/test/ui-smoke/helpers/view-header.ts
+++ b/packages/app/test/ui-smoke/helpers/view-header.ts
@@ -63,12 +63,14 @@ export async function assertSharedViewHeaderContract(
     const box = await back.boundingBox();
     expect(box, "the back control has a measurable box").not.toBeNull();
     if (box) {
-      // The icon glyph is 20px but the hit target (h-9 w-9 = 36px) plus the
-      // header's min-h-14 row give a ≥44px effective tap height on mobile.
-      const effectiveHeight = Math.max(box.height, 44);
+      // The icon button's own box is 36px (h-9 w-9); the effective tap target
+      // extends to the header row (min-h-14). Assert the MEASURED row height —
+      // clamping the measurement to the threshold would make this vacuous.
+      const headerBox = await header.boundingBox();
+      const effectiveHeight = Math.max(box.height, headerBox?.height ?? 0);
       expect(
         effectiveHeight,
-        `the back control tap target is at least 44px (got ${box.height})`,
+        `the back control tap target is at least 44px (button ${box.height}px, header row ${headerBox?.height ?? 0}px)`,
       ).toBeGreaterThanOrEqual(44);
       expect(
         box.width,


### PR DESCRIPTION
Both PRs merged over their gate reviews (verdicts on the PRs); the third prescribed fix (#14143's `?.trim()`) already landed on tip, so this carries the remaining two:

1. **#13965 residue — voice self-test rides every production bundle**: `main.tsx` statically imported `ios-voice-selftest-smoke`, anchoring the `@elizaos/ui/voice` graph into the web/desktop entry chunk for an iOS-only smoke. Now an **iOS-gated lazy import** — non-iOS never fetches the chunk; iOS behavior identical (the module still self-gates on its smoke-request preference).
2. **#14152 residue — vacuous tap-target assertion**: `view-header.ts` clamped the measured height to the 44px threshold (`Math.max(box.height, 44)`), so the ≥44 assertion could never fail. Now measures the **header row's real `boundingBox()`** (the actual effective tap target per the h-9 button + min-h-14 row design) and asserts the measurement.

**Verification:** `ios-voice-selftest-smoke.test.ts` 1/1 (drives the module directly — unaffected wiring); biome clean; `packages/app` typecheck fails identically with and without this diff (pre-existing `@elizaos/tui` resolution error in ui/spatial — fresh-worktree/dep issue, reported).

My commit → no self-merge; lalalune/0xSolace lanes please review + arm. (#13406) `[maintainer]`