### PR TITLE
fix(training): preserve trace filters in trajectory exports

### DIFF
--- a/.github/issue-evidence/13871-traceid-export.md
+++ b/.github/issue-evidence/13871-traceid-export.md
@@ -9,6 +9,12 @@
 - `/api/training/trajectories/export` accepts `traceId`, forwards it to the
   training service list call, and records the requested trace in bundle source
   metadata.
+- The agent runtime compatibility trajectory logger now applies `traceId` in
+  its SQL-backed list reader, so runtimes using `installDatabaseTrajectoryLogger`
+  do not broaden trace-scoped exports.
+- The same compatibility logger export loader now includes `traceId`, so
+  JSON/JSONL/CSV/ART exports from agent-hosted routes do not broaden a
+  trace-scoped request.
 
 ## Verification
 
@@ -22,6 +28,11 @@
     trajectories` case after failing to find a generated README in its temp
     output. That case is outside this traceId plumbing change.
 - `bunx @biomejs/biome check packages/core/src/features/trajectories/TrajectoriesService.ts plugins/plugin-training/src/routes/trajectory-routes.ts plugins/plugin-training/src/routes/training-routes.ts plugins/plugin-training/src/services/training-service.ts plugins/plugin-training/src/services/training-service-like.ts plugins/plugin-training/src/routes/trajectory-routes.test.ts plugins/plugin-training/src/core/trajectory-export-bundle.test.ts --no-errors-on-unmatched` passed with pre-existing warnings in touched test/route files.
+- `bun test packages/agent/src/runtime/trajectory-bridge.test.ts -t traceId`
+  ran the compatibility-logger list and export assertions; both passed. The Bun
+  process then exited nonzero while printing the repository coverage table with
+  `WriteFailed`; no test assertion failed.
+- `bunx @biomejs/biome check packages/agent/src/runtime/trajectory-storage.ts packages/agent/src/runtime/trajectory-bridge.test.ts --no-errors-on-unmatched` passed.
 - `git diff --check` passed.
 
 ## Manual Review
@@ -29,4 +40,5 @@
 Reviewed the changed route and service boundaries by hand. The filter now
 survives every path that can expand a trace-scoped request into trajectory IDs:
 core ZIP export, plugin-training `/api/trajectories` list/export, and
-plugin-training rich bundle export.
+plugin-training rich bundle export. After the PR review catch, also reviewed
+the agent compatibility logger path that powers agent-hosted trajectory routes.

--- a/packages/agent/src/runtime/trajectory-bridge.test.ts
+++ b/packages/agent/src/runtime/trajectory-bridge.test.ts
@@ -17,6 +17,15 @@ import { flushTrajectoryWrites } from "./trajectory-storage.ts";
 interface MockLogger {
   logLlmCall: (...args: unknown[]) => void;
   logProviderAccess: (...args: unknown[]) => void;
+  listTrajectories?: (options?: {
+    limit?: number;
+    offset?: number;
+    traceId?: string;
+  }) => Promise<unknown>;
+  exportTrajectories?: (options: {
+    format: "json";
+    traceId?: string;
+  }) => Promise<unknown>;
   isEnabled: () => boolean;
   setEnabled: (v: boolean) => void;
   llmCalls: unknown[];
@@ -47,6 +56,23 @@ function makeRuntime() {
     },
   } as unknown as AgentRuntime;
   return { runtime, logger, originalLogLlmCall, execute };
+}
+
+function sqlText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object") return "";
+  const chunks = (value as { queryChunks?: Array<{ value?: unknown }> })
+    .queryChunks;
+  if (!Array.isArray(chunks)) return String(value);
+  return chunks
+    .flatMap((chunk) => (Array.isArray(chunk.value) ? chunk.value : []))
+    .join("");
+}
+
+function hasTraceFilter(execute: ReturnType<typeof vi.fn>, traceId: string) {
+  return execute.mock.calls.some(([query]) =>
+    sqlText(query).includes(`trace_id = '${traceId}'`),
+  );
 }
 
 describe("installDatabaseTrajectoryLogger (capture bridge)", () => {
@@ -87,5 +113,26 @@ describe("installDatabaseTrajectoryLogger (capture bridge)", () => {
     const patched = logger.logLlmCall;
     await installDatabaseTrajectoryLogger(runtime);
     expect(logger.logLlmCall).toBe(patched);
+  });
+
+  it("applies traceId filters to the SQL-backed list reader", async () => {
+    const { runtime, logger, execute } = makeRuntime();
+    execute.mockResolvedValueOnce([{ total: 0 }]).mockResolvedValueOnce([]);
+
+    await installDatabaseTrajectoryLogger(runtime);
+    await logger.listTrajectories?.({ traceId: "trace-1", limit: 10 });
+
+    expect(hasTraceFilter(execute, "trace-1")).toBe(true);
+  });
+
+  it("applies traceId filters to the compatibility export reader", async () => {
+    const { runtime, logger, execute } = makeRuntime();
+
+    await installDatabaseTrajectoryLogger(runtime);
+    execute.mockClear();
+
+    await logger.exportTrajectories?.({ format: "json", traceId: "trace-1" });
+
+    expect(hasTraceFilter(execute, "trace-1")).toBe(true);
   });
 });

--- a/packages/agent/src/runtime/trajectory-storage.ts
+++ b/packages/agent/src/runtime/trajectory-storage.ts
@@ -425,6 +425,9 @@ function buildTrajectoryWhereClauses(options: TrajectoryListOptions): string[] {
   if (options.scenarioId) {
     whereClauses.push(`scenario_id = ${sqlQuote(options.scenarioId)}`);
   }
+  if (options.traceId) {
+    whereClauses.push(`trace_id = ${sqlQuote(options.traceId)}`);
+  }
   if (options.batchId) {
     whereClauses.push(`batch_id = ${sqlQuote(options.batchId)}`);
   }
@@ -485,6 +488,7 @@ async function loadPersistedTrajectoriesForExport(
     endDate: options.endDate,
     search: options.search,
     scenarioId: options.scenarioId,
+    traceId: options.traceId,
     batchId: options.batchId,
   });
   if (options.trajectoryIds && options.trajectoryIds.length > 0) {


### PR DESCRIPTION
## Summary
- forwards `traceId` through core ZIP trajectory exports when the request expands filters into trajectory IDs
- adds `traceId` support to `/api/trajectories` list, JSON/JSONL export, and ZIP export
- threads `traceId` through `/api/training/trajectories/export` bundle generation and records the requested trace in bundle metadata
- applies `traceId` in the agent runtime compatibility trajectory logger used by `installDatabaseTrajectoryLogger` / `DatabaseTrajectoryLogger`

Replacement for closed #14176, with the compatibility-logger review blocker fixed.

## Verification
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun test plugins/plugin-training/src/routes/trajectory-routes.test.ts plugins/plugin-training/src/core/trajectory-export-bundle.test.ts plugins/plugin-training/src/services/training-service.test.ts`
  - new `/api/trajectories` traceId regression passed
  - updated training bundle export regression passed
  - TrainingService paging tests passed
  - broader run then hit an existing unrelated `trajectory-export-bundle.test.ts` timeout in `lets the training collection route pull natural runtime trajectories` after missing its temp README
- `bun test packages/agent/src/runtime/trajectory-bridge.test.ts -t traceId` ran the new assertion and it passed; Bun then exited nonzero while dumping the repo coverage table with `WriteFailed`, no test assertion failed
- `bunx @biomejs/biome check packages/agent/src/runtime/trajectory-storage.ts packages/agent/src/runtime/trajectory-bridge.test.ts --no-errors-on-unmatched`
- `bunx @biomejs/biome check .github/issue-evidence/13871-traceid-export.md packages/core/src/features/trajectories/TrajectoriesService.ts plugins/plugin-training/src/routes/trajectory-routes.ts plugins/plugin-training/src/routes/training-routes.ts plugins/plugin-training/src/services/training-service.ts plugins/plugin-training/src/services/training-service-like.ts plugins/plugin-training/src/routes/trajectory-routes.test.ts plugins/plugin-training/src/core/trajectory-export-bundle.test.ts --no-errors-on-unmatched` (passed with pre-existing no-non-null warnings in touched files)
- `git diff --check`

## Evidence
- `.github/issue-evidence/13871-traceid-export.md`

Screenshots/video/frontend logs are N/A: this is API route/service filter plumbing with no rendered UI.