### PR TITLE
fix(app): keep the build-freshness badge out of production builds (promote-blocking, #14174 audit)

### DIFF
--- a/packages/app/scripts/build.mjs
+++ b/packages/app/scripts/build.mjs
@@ -5,7 +5,7 @@ import { execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveElizaAssetBaseUrls } from "../../../packages/app-core/scripts/lib/asset-cdn.mjs";
 import { normalizeEnvPrefix } from "../src/env-prefix.js";
 
@@ -106,12 +106,16 @@ function run(command, args, cwd) {
 // the build's declared environment instead — production/store builds delete
 // any prior stamp so a stale local file can never ship. ELIZA_BUILD_STAMP=1
 // force-enables for debugging the badge itself.
-function stampBuildInfo() {
+export function shouldSkipBuildStamp(env = process.env) {
   const isProductionBuild =
-    process.env.VITE_ENVIRONMENT === "production" ||
-    Boolean(process.env.ELIZA_RELEASE_AUTHORITY) ||
-    process.env.ELIZA_BUILD_VARIANT === "store";
-  if (isProductionBuild && process.env.ELIZA_BUILD_STAMP !== "1") {
+    env.VITE_ENVIRONMENT === "production" ||
+    env.ELIZA_RELEASE_AUTHORITY === "apple-app-store" ||
+    env.ELIZA_BUILD_VARIANT?.toLowerCase() === "store";
+  return isProductionBuild && env.ELIZA_BUILD_STAMP !== "1";
+}
+
+function stampBuildInfo() {
+  if (shouldSkipBuildStamp()) {
     fs.rmSync(path.join(appDir, "public", "build-info.json"), { force: true });
     return;
   }
@@ -144,24 +148,37 @@ function stampBuildInfo() {
   }
 }
 
-if (fullSetup) {
-  await run(bunExecutable, ["install", "--ignore-scripts"], repoRoot);
-  await run(process.execPath, [repoSetupScript], repoRoot);
+async function main() {
+  if (fullSetup) {
+    await run(bunExecutable, ["install", "--ignore-scripts"], repoRoot);
+    await run(process.execPath, [repoSetupScript], repoRoot);
+  }
+
+  stampBuildInfo();
+
+  await run(
+    process.execPath,
+    [path.join(__dirname, "plugin-build.mjs")],
+    appDir,
+  );
+
+  if (fullSetup) {
+    await run(bunExecutable, ["install", "--ignore-scripts"], appDir);
+  }
+
+  await run(
+    bunExecutable,
+    ["--bun", "vite", "build", "--configLoader", "runner"],
+    appDir,
+  );
+  if (resolveElizaAssetBaseUrls().appAssetBaseUrl) {
+    await run(process.execPath, [pruneCdnAssetsScript], repoRoot);
+  }
 }
 
-stampBuildInfo();
-
-await run(process.execPath, [path.join(__dirname, "plugin-build.mjs")], appDir);
-
-if (fullSetup) {
-  await run(bunExecutable, ["install", "--ignore-scripts"], appDir);
-}
-
-await run(
-  bunExecutable,
-  ["--bun", "vite", "build", "--configLoader", "runner"],
-  appDir,
-);
-if (resolveElizaAssetBaseUrls().appAssetBaseUrl) {
-  await run(process.execPath, [pruneCdnAssetsScript], repoRoot);
+const invokedPath = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : "";
+if (import.meta.url === invokedPath) {
+  await main();
 }

--- a/packages/app/scripts/build.mjs
+++ b/packages/app/scripts/build.mjs
@@ -98,9 +98,23 @@ function run(command, args, cwd) {
 // Best-effort build stamp for the in-app BuildBadge (PWA cache-freshness
 // check). Writes public/build-info.json with the current git sha + build
 // time. The file is gitignored, so it never commits a stale local stamp; when
-// git is unavailable (some CI/tarball builds) it is skipped and the badge
-// simply renders nothing.
+// git is unavailable (some tarball builds) it is skipped and the badge simply
+// renders nothing.
+//
+// The badge is a tester/staging affordance, and "no .git → no stamp" does NOT
+// keep it out of production: CI checkouts and Pages clones carry .git. Gate on
+// the build's declared environment instead — production/store builds delete
+// any prior stamp so a stale local file can never ship. ELIZA_BUILD_STAMP=1
+// force-enables for debugging the badge itself.
 function stampBuildInfo() {
+  const isProductionBuild =
+    process.env.VITE_ENVIRONMENT === "production" ||
+    Boolean(process.env.ELIZA_RELEASE_AUTHORITY) ||
+    process.env.ELIZA_BUILD_VARIANT === "store";
+  if (isProductionBuild && process.env.ELIZA_BUILD_STAMP !== "1") {
+    fs.rmSync(path.join(appDir, "public", "build-info.json"), { force: true });
+    return;
+  }
   try {
     const commit = execFileSync("git", ["rev-parse", "--short=10", "HEAD"], {
       cwd: repoRoot,

--- a/packages/app/scripts/build.test.mjs
+++ b/packages/app/scripts/build.test.mjs
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for the app build script's build-info stamp gate. The stamp is a
+ * staging/debug affordance, so production and store builds must delete it even
+ * when the checkout has a `.git` directory.
+ */
+import { describe, expect, it } from "vitest";
+import { shouldSkipBuildStamp } from "./build.mjs";
+
+const env = (overrides = {}) => ({
+  ELIZA_BUILD_STAMP: undefined,
+  ELIZA_BUILD_VARIANT: undefined,
+  ELIZA_RELEASE_AUTHORITY: undefined,
+  VITE_ENVIRONMENT: undefined,
+  ...overrides,
+});
+
+describe("shouldSkipBuildStamp", () => {
+  it("skips the stamp for Cloudflare production builds", () => {
+    expect(shouldSkipBuildStamp(env({ VITE_ENVIRONMENT: "production" }))).toBe(
+      true,
+    );
+  });
+
+  it("skips the stamp for app-store builds", () => {
+    expect(shouldSkipBuildStamp(env({ ELIZA_BUILD_VARIANT: "store" }))).toBe(
+      true,
+    );
+    expect(shouldSkipBuildStamp(env({ ELIZA_BUILD_VARIANT: "STORE" }))).toBe(
+      true,
+    );
+    expect(
+      shouldSkipBuildStamp(env({ ELIZA_RELEASE_AUTHORITY: "apple-app-store" })),
+    ).toBe(true);
+  });
+
+  it("keeps the stamp for staging, direct, and developer-toolchain builds", () => {
+    expect(shouldSkipBuildStamp(env({ VITE_ENVIRONMENT: "staging" }))).toBe(
+      false,
+    );
+    expect(shouldSkipBuildStamp(env({ ELIZA_BUILD_VARIANT: "direct" }))).toBe(
+      false,
+    );
+    expect(
+      shouldSkipBuildStamp(
+        env({ ELIZA_RELEASE_AUTHORITY: "developer-toolchain" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("allows forced stamp debugging even in production", () => {
+    expect(
+      shouldSkipBuildStamp(
+        env({ ELIZA_BUILD_STAMP: "1", VITE_ENVIRONMENT: "production" }),
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
**Urgent for the next promote** — post-merge audit of #14174 (full analysis on that PR): the badge's prod-safety claim ('no git → renders nothing') only covers tarball builds. **CI checkouts and CF Pages clones have `.git`, so the next promote would stamp `build-info.json` into dist and render the git-sha pill for every production user, reappearing each session** (dismiss is sessionStorage-only).

Fix: `stampBuildInfo()` now gates on the build's declared environment — `VITE_ENVIRONMENT=production` (what the deploy workflow sets), `ELIZA_RELEASE_AUTHORITY`, or `ELIZA_BUILD_VARIANT=store` — and **deletes any pre-existing stamp** on production builds so a stale local file can never ride into dist. `ELIZA_BUILD_STAMP=1` force-enables for debugging the badge itself. Staging/dev keep the badge exactly as #14174 intended.

Known residual (separate, filed on #14174): the stale-stamp-in-dev issue (stamp written before the vite build; `vite dev` serves it) — that one degrades the badge's signal but doesn't leak to prod; this PR is scoped to the promote-blocking half.

Verification: `node --check` + biome clean; gate predicate exercised (prod env → stamp deleted + skipped; non-prod unchanged). My commit → no self-merge; needs a lane arm **before the next promote is cut**. (#13406) `[maintainer]`