### PR TITLE
fix(#14171): single-source project world-id derivation on the per-agent core helper

### DIFF
--- a/packages/core/src/utils/project-registry.ts
+++ b/packages/core/src/utils/project-registry.ts
@@ -44,12 +44,12 @@ export interface ProjectRecord {
 	 * elizaOS world this project's memory/knowledge is partitioned into, so a
 	 * subagent working project B never sees project A's injected context (#13776
 	 * design D3): a free partition in the existing memory schema, no column
-	 * change. Deterministically derived from the project id via the
-	 * `project:<id>` {@link stringToUuid} convention (see {@link PROJECT_WORLD_ID_PREFIX}),
-	 * so every process derives the same world without coordinating through the
-	 * file. Persisted so future project CRUD/UI can read it without re-deriving;
-	 * the derivation at the orchestrator task bind seam (`project-binding.ts`)
-	 * remains the source of truth stamped onto a task.
+	 * change. Derived per-agent via core's `projectWorldId(agentId, id)` — the
+	 * single source of truth (#14171) — as `stringToUuid("project:<id>:<agentId>")`;
+	 * Worlds are agent-scoped (`World.agentId`), so two agents on the same project
+	 * get distinct worlds. Persisted so future project CRUD/UI can read it without
+	 * re-deriving; the orchestrator task bind seam stamps the same core derivation
+	 * onto each task.
 	 */
 	worldId?: string;
 	/** macOS security-scoped bookmark for the picked folder, when present. */
@@ -63,12 +63,13 @@ export interface ProjectRecord {
 }
 
 /**
- * `stringToUuid` seed prefix for a project's memory world. Kept here (not the
- * plugin) so the string convention lives with the record it stamps; the
- * orchestrator bind seam derives `stringToUuid(PROJECT_WORLD_ID_PREFIX + id)`
- * without duplicating the literal. Importing `stringToUuid` into this pre-DB,
- * import-time module would pull the heavy `utils.ts` barrel, so the derivation
- * stays at the plugin seam that already depends on it.
+ * `stringToUuid` seed prefix for a project's memory world, mirroring
+ * `PROJECT_WORLD_PREFIX` in `project-memory-scope.ts` where the canonical
+ * derivation lives. Kept next to the record it stamps for documentation, but
+ * the world itself is derived ONLY through core's per-agent
+ * `projectWorldId(agentId, id)` (#14171) — `stringToUuid("project:<id>:<agentId>")`
+ * — never `stringToUuid(prefix + id)` alone, which would drop the agent scope
+ * and reintroduce the cross-agent collision #14171 fixed.
  */
 export const PROJECT_WORLD_ID_PREFIX = "project:";
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
@@ -10,15 +10,16 @@ import { join } from "node:path";
 import {
   getProjectById,
   logger,
+  projectWorldId,
   setActiveProject,
   stringToUuid,
+  type UUID,
   upsertProject,
   writeWorkspaceFolderConfig,
 } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   bindProjectCloudApp,
-  deriveProjectWorldId,
   findProjectByWorkdir,
   resolveBoundProjectCloudAppId,
   resolveBoundProjectWorkdir,
@@ -190,14 +191,25 @@ describe("project-binding", () => {
     });
   });
 
-  it("deriveProjectWorldId is deterministic in the project id and matches the stringToUuid convention", () => {
-    // #13776 D3: the world must be reproducible from the id alone so the agent
-    // runtime, desktop picker, and bind seam all land on the same partition
-    // without coordinating through disk.
-    const a = deriveProjectWorldId("proj-1");
-    expect(deriveProjectWorldId("proj-1")).toBe(a);
-    expect(deriveProjectWorldId("proj-2")).not.toBe(a);
-    expect(a).toBe(stringToUuid("project:proj-1"));
+  it("project world-id derivation is single-sourced on core's per-agent projectWorldId (#14171)", () => {
+    // #13776 D3 / #14171: a project's memory world is derived ONCE, in core, as
+    // `projectWorldId(agentId, id)` — per-agent because Worlds are agent-scoped
+    // (`World.agentId`). The plugin bind seam delegates to it (no second
+    // derivation), so this pins the contract the whole system now shares.
+    const agentA = "00000000-0000-4000-8000-0000000000a1" as UUID;
+    const agentB = "00000000-0000-4000-8000-0000000000b2" as UUID;
+
+    // Deterministic in (agent, project).
+    const a = projectWorldId(agentA, "proj-1");
+    expect(projectWorldId(agentA, "proj-1")).toBe(a);
+    // Distinct per project AND per agent (agent-scoped Worlds — the #14171 fix).
+    expect(projectWorldId(agentA, "proj-2")).not.toBe(a);
+    expect(projectWorldId(agentB, "proj-1")).not.toBe(a);
+
+    // Mirrors the createUniqueUuid convention: `project:<id>:<agentId>`.
+    expect(a).toBe(stringToUuid(`project:proj-1:${agentA}`));
+    // Mutation guard: NOT the old agentId-less global form the bug reintroduced.
+    expect(a).not.toBe(stringToUuid("project:proj-1"));
     expect(a).toMatch(/^[0-9a-f-]{36}$/);
   });
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
@@ -10,13 +10,22 @@
 import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { type IAgentRuntime, upsertProject } from "@elizaos/core";
+import {
+  type IAgentRuntime,
+  projectWorldId,
+  stringToUuid,
+  type UUID,
+  upsertProject,
+} from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AcpService } from "../services/acp-service.js";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../services/orchestrator-task-store.js";
-import { deriveProjectWorldId } from "../services/project-binding.js";
 import type { SpawnOptions, SpawnResult } from "../services/types.js";
+
+/** The agentId the test runtime carries; the stamped project world is derived
+ * per-agent from it (#14171), so the assertions below reuse this exact value. */
+const BINDER_AGENT_ID: UUID = "00000000-0000-4000-8000-000000000abc";
 
 /** ACP stand-in that records the workdir each spawn was handed and echoes it
  * back as the session's landed workdir (what AcpService does when the caller
@@ -55,7 +64,7 @@ function makeWorkdirCapturingAcp() {
 
 function makeRuntime(acpService: unknown): IAgentRuntime {
   return {
-    agentId: "00000000-0000-4000-8000-000000000abc",
+    agentId: BINDER_AGENT_ID,
     character: { name: "Binder" },
     logger: {
       debug: () => undefined,
@@ -497,12 +506,19 @@ describe("project memory-world stamping at bind time (#13776 D3)", () => {
         acceptanceCriteria: [],
         workdir: firstDir,
       });
+      // Cross-package equality guard (#14171): the world the real service path
+      // stamps must be EXACTLY core's per-agent `projectWorldId(agentId, id)` —
+      // a single source of truth, never the plugin re-deriving its own.
+      const expectedWorld = projectWorldId(BINDER_AGENT_ID, project.id);
       expect(detail.projectId).toBe(project.id);
-      expect(detail.worldId).toBe(deriveProjectWorldId(project.id));
+      expect(detail.worldId).toBe(expectedWorld);
+      // Mutation guard: it must NOT be the old agentId-less global form; if the
+      // plugin ever reverts to `stringToUuid("project:" + id)` this fails.
+      expect(detail.worldId).not.toBe(stringToUuid(`project:${project.id}`));
       // Persisted, not just returned.
       const record = await store.getTask(detail.id);
       expect(record?.task.projectId).toBe(project.id);
-      expect(record?.task.worldId).toBe(deriveProjectWorldId(project.id));
+      expect(record?.task.worldId).toBe(expectedWorld);
     } finally {
       await service.stop().catch(() => undefined);
     }

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -32,6 +32,7 @@ import { basename, dirname, join } from "node:path";
 import {
   getTrajectoryContext,
   type IAgentRuntime,
+  projectWorldId,
   type RecordedTrajectory,
   resolveStateDir,
   resolveTrajectoryGate,
@@ -149,7 +150,6 @@ import {
   PARENT_AGENT_BROKER_MANIFEST_ENTRY,
 } from "./parent-agent-broker.js";
 import {
-  deriveProjectWorldId,
   resolveBoundProjectCloudAppId,
   resolveTaskProjectId,
   resolveTaskSpawnWorkdir,
@@ -2186,16 +2186,20 @@ export class OrchestratorTaskService extends Service {
    * persisted on the record — only the resolved `projectId` is. No match leaves
    * the task unbound, preserving per-session workdir re-resolution.
    *
-   * A bound task is also stamped with the project's memory world (#13776 D3), so
-   * its subagents are partitioned to the project and never see another project's
-   * injected context. A caller-supplied `worldId` is authoritative and wins —
-   * only an unset one is filled from the binding.
+   * A bound task is also stamped with the project's memory world (#13776 D3),
+   * derived per-agent via core's `projectWorldId(agentId, projectId)` — the
+   * single source of truth (#14171); Worlds are agent-scoped, so the runtime's
+   * agentId is part of the derivation. Its subagents are thus partitioned to the
+   * project and never see another project's injected context. A caller-supplied
+   * `worldId` is authoritative and wins — only an unset one is filled from the
+   * binding.
    */
   private bindProject(input: CreateTaskInput): CreateTaskInput {
     const projectId = resolveTaskProjectId(input);
     const { workdir: _workdir, ...rest } = input;
     const worldId =
-      rest.worldId ?? (projectId ? deriveProjectWorldId(projectId) : undefined);
+      rest.worldId ??
+      (projectId ? projectWorldId(this.runtime.agentId, projectId) : undefined);
     return { ...rest, projectId, worldId };
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/project-binding.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/project-binding.ts
@@ -10,11 +10,14 @@
  * Realpath is used on both sides so symlinked / non-canonical paths that point
  * at the same directory still match.
  *
- * Binding also stamps the task's memory world ({@link deriveProjectWorldId}):
- * this is the live implementation of #13776 design D3's per-project memory
- * partition — subagents on project B never see project A's injected context.
- * The derivation is deterministic in the project id, so it is the source of
- * truth even though the core `ProjectRecord.worldId` also persists it for CRUD.
+ * Binding also stamps the task's memory world via core's
+ * `projectWorldId(agentId, projectId)` — the single, per-agent derivation
+ * (#14171): this is the live implementation of #13776 design D3's per-project
+ * memory partition, so subagents on project B never see project A's injected
+ * context. Worlds are agent-scoped (`World.agentId`), so the world is derived
+ * from the runtime's agentId at the service call site (`orchestrator-task-
+ * service.ts`); core's helper is the sole source of truth even though
+ * `ProjectRecord.worldId` also persists it for CRUD.
  */
 
 import { realpathSync } from "node:fs";
@@ -22,12 +25,9 @@ import { resolve } from "node:path";
 import {
   getProjectById,
   logger,
-  PROJECT_WORLD_ID_PREFIX,
   type ProjectRecord,
   readProjectRegistry,
-  stringToUuid,
   upsertProject,
-  type UUID,
 } from "@elizaos/core";
 
 /** Canonicalize a path for identity comparison; falls back to a resolved
@@ -73,17 +73,6 @@ export function resolveTaskProjectId(
     return getProjectById(explicit, env) ? explicit : undefined;
   }
   return findProjectByWorkdir(input.workdir, env)?.id;
-}
-
-/**
- * The memory world a project partitions into — `stringToUuid('project:' + id)`.
- * Deterministic so the agent runtime, desktop picker, and this bind seam all
- * derive the same world for a project id without coordinating through disk. This
- * is #13776 design D3's cheaper option: a dedicated free partition in the
- * existing memory schema, no column change.
- */
-export function deriveProjectWorldId(projectId: string): UUID {
-  return stringToUuid(`${PROJECT_WORLD_ID_PREFIX}${projectId}`);
 }
 
 /** The localPath of the registered project a bound task targets, or `null` when


### PR DESCRIPTION
Closes #14171.

## Problem
Two competing derivations of a project's memory world-id shipped (recreating the divergence #14107 was fixing):
- **core** `projectWorldId(agentId, projectId)` = `stringToUuid("project:<projectId>:<agentId>")` — **per-agent** (Worlds are agent-scoped; matches `createUniqueUuid(runtime, "project:"+projectId)`), the correct #13776 D3 contract.
- **plugin** `deriveProjectWorldId(projectId)` = `stringToUuid("project:<projectId>")` — **omitted agentId** → a different UUID for the same project → memory scoped inconsistently depending on which derivation ran.

## Fix
Single-source the derivation on the core per-agent helper:
- **Deleted** the plugin's local `deriveProjectWorldId` (`project-binding.ts`) and its now-unused imports.
- The one production seam — `OrchestratorTaskService.bindProject` — now stamps `projectWorldId(this.runtime.agentId, projectId)` from `@elizaos/core` (the service already holds `runtime`, so no plumbing).
- Corrected the stale `worldId` JSDoc in `project-registry.ts` that still documented the buggy global form.

## Verification
- `bunx vitest run project-binding.test.ts task-workdir-binding.test.ts` → **28/28 pass**.
- **Cross-package equality guard** (the drift-pin the issue asks for): `task-workdir-binding.test.ts` drives the real `createTask → bindProject` and asserts `detail.worldId === projectWorldId(agentId, project.id)` **and** `!== stringToUuid("project:"+id)` (the old global form). `project-binding.test.ts` adds the unit-level per-agent contract.
- **Mutation-checked:** reverting the service call site to the global `stringToUuid("project:"+id)` **fails** the equality guard (`expected <global> to be <per-agent>`); restored → 28/28 green.
- Typecheck: 0 errors in touched files (remaining output is pre-existing `TS7016` third-party-declaration noise, unrelated). Biome clean.

Note: this intentionally changes the derived worldId to the per-agent form — the documented-correct #13776 D3 direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)