### PR TITLE
fix(test): real ViewHeader height assertion + views-soak failure notification (#14152 follow-ups)

### DIFF
--- a/.github/workflows/views-soak.yml
+++ b/.github/workflows/views-soak.yml
@@ -126,3 +126,35 @@ jobs:
             /tmp/views-soak-dev.log
           if-no-files-found: ignore
           retention-days: 7
+
+  # A hard-fail nightly that only reds in the Actions tab is indistinguishable
+  # from no lane: without an alert nobody notices the view-isolation soak went
+  # red and regressions accumulate silently. This turns a red scheduled run into
+  # an actionable signal by commenting on the testing-loop umbrella (#13562, the
+  # issue this soak lane closes) with the result and a link to the run. Scheduled
+  # runs only — manual workflow_dispatch runs stay quiet to avoid noise. Mirrors
+  # app-live-e2e.yml's notify-on-failure idiom.
+  notify-on-failure:
+    name: notify on red nightly
+    needs: [views-soak]
+    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - name: Comment red-nightly diagnostic on umbrella issue #13562
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          R_SOAK: ${{ needs.views-soak.result }}
+        run: |
+          set -euo pipefail
+          {
+            printf '## 🌙 Nightly Views Soak failed (scheduled run)\n\n'
+            printf 'The hard-fail view-lifecycle soak (`packages/app audit:views`) went red — a render-storm, unbounded module cache, or unbounded heap growth in the real ViewRouter. Result:\n\n'
+            printf -- '- real-app view-lifecycle soak: `%s`\n' "$R_SOAK"
+            printf '\nRun log + failure artifacts: %s\n\n' "$RUN_URL"
+            printf '_Auto-posted by views-soak.yml so a red nightly notifies someone (#13562)._\n'
+          } > "$RUNNER_TEMP/nightly-red.md"
+          gh issue comment 13562 --repo "$REPO" --body-file "$RUNNER_TEMP/nightly-red.md"


### PR DESCRIPTION
Small follow-up closing residuals found in the post-merge review of #14152.

## Findings

**1. DEAD ASSERTION (already fixed on `develop` — no code here).**
`packages/app/test/ui-smoke/helpers/view-header.ts` computed
`const effectiveHeight = Math.max(box.height, 44); expect(effectiveHeight).toBeGreaterThanOrEqual(44)`
— a tautology that can never fail. While this follow-up was in flight, PR #14178
(`0000d4d06b9`, "land the two gate-prescribed residues merged over in
#13965/#14152") landed the real fix independently: it measures the actual header
row and asserts `Math.max(box.height, headerBox.height) >= 44`, with a comment
noting "clamping the measurement to the threshold would make this vacuous." That
resolution is correct and already on `develop`, so this PR does **not** re-touch
the helper — item 1 is closed by #14178.

The true geometry (verified by rendering the exact `ViewHeader` markup in
Chromium at a 390px mobile viewport): the `h-9 w-9` back button measures
**36×36px** — `boundingBox()` measures the button, which `items-center` centers
in the taller `min-h-14` header row (**57px**), not the row itself. `develop`'s
fix asserts against that measured 57px row (≥44 holds); the original raw
`box.height >= 44` would have failed on the real 36px button, which is exactly
why the vacuous `Math.max(..., 44)` clamp was there.

**2. SOAK FAILURE NOTIFICATION (this PR).**
`.github/workflows/views-soak.yml` (new nightly, hard-fail) surfaced failures
only in the Actions tab — a red run is invisible unless someone looks, so a
view-isolation regression can sit red night after night unseen. This mirrors
`app-live-e2e.yml`'s `notify-on-failure` idiom exactly: a `notify-on-failure`
job (`needs: [views-soak]`; `if: always() && github.event_name == 'schedule' &&
contains(needs.*.result, 'failure')`; `permissions: issues: write`) that posts a
diagnostic comment with the job result + run link to the testing-loop umbrella
**#13562** (the issue this soak lane closes, per #14152's commit). Scheduled runs
only, so manual `workflow_dispatch` stays quiet.

## Evidence

- **actionlint**: `actionlint .github/workflows/views-soak.yml` → PASS
  (shellcheck-clean on the `run:` block); baseline `app-live-e2e.yml` still
  passes.
- **YAML structural parse**: jobs `views-soak, notify-on-failure`; notify
  `needs: ["views-soak"]`, `if: always() && schedule && contains(needs.*.result,
  'failure')`, `permissions: { issues: write }` — parses OK.
- **Item-1 geometry**: direct Chromium measurement of the real `ViewHeader`
  markup → `buttonBox 36×36`, `headerBox 57` tall, confirming `develop`'s
  measured-row assertion is real and holds.

Item-1 code is intentionally absent (superseded by #14178). If a reviewer
prefers this PR also carry a redundant assertion change, say so; otherwise the
helper is left as `develop` has it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)