### PR TITLE
fix(#14171): unify project-world-id derivation — plugin delegates to core

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
@@ -12,6 +12,7 @@ import {
   logger,
   setActiveProject,
   stringToUuid,
+  type UUID,
   upsertProject,
   writeWorkspaceFolderConfig,
 } from "@elizaos/core";
@@ -190,14 +191,16 @@ describe("project-binding", () => {
     });
   });
 
-  it("deriveProjectWorldId is deterministic in the project id and matches the stringToUuid convention", () => {
-    // #13776 D3: the world must be reproducible from the id alone so the agent
-    // runtime, desktop picker, and bind seam all land on the same partition
-    // without coordinating through disk.
-    const a = deriveProjectWorldId("proj-1");
-    expect(deriveProjectWorldId("proj-1")).toBe(a);
-    expect(deriveProjectWorldId("proj-2")).not.toBe(a);
-    expect(a).toBe(stringToUuid("project:proj-1"));
+  it("deriveProjectWorldId is deterministic and matches core's per-agent createUniqueUuid convention", () => {
+    // #14171: the bind seam delegates to core's projectWorldId, so the world is
+    // keyed on (agent, project) — `createUniqueUuid(runtime, 'project:' + id)` —
+    // not the project id alone. Same agent+project ⇒ same world; a different
+    // project (or a different agent) ⇒ a different world.
+    const agentId = "00000000-0000-4000-8000-000000000abc" as UUID;
+    const a = deriveProjectWorldId(agentId, "proj-1");
+    expect(deriveProjectWorldId(agentId, "proj-1")).toBe(a);
+    expect(deriveProjectWorldId(agentId, "proj-2")).not.toBe(a);
+    expect(a).toBe(stringToUuid(`project:proj-1:${agentId}`));
     expect(a).toMatch(/^[0-9a-f-]{36}$/);
   });
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/project-world-id-parity.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/project-world-id-parity.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Cross-package guard pinning the orchestrator's project→world derivation to
+ * core's single source of truth. `deriveProjectWorldId` (this plugin) must be a
+ * pure delegate to `projectWorldId` (`@elizaos/core`) so the two can never drift
+ * into the divergence #14171 caught (a second, per-project-only derivation that
+ * ignored the per-agent Worlds contract from #13776 D3). Drives both REAL
+ * functions — no mock stands in for either derivation.
+ */
+
+import { projectWorldId, stringToUuid, type UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { deriveProjectWorldId } from "../services/project-binding.ts";
+
+const AGENTS: readonly UUID[] = [
+  "00000000-0000-4000-8000-000000000abc" as UUID,
+  "11111111-1111-4111-8111-111111111111" as UUID,
+  "deadbeef-0000-4000-8000-00000000cafe" as UUID,
+];
+const PROJECTS: readonly string[] = ["proj-1", "proj-2", "repo-a", "a/b/c"];
+
+describe("project world id: plugin derivation delegates to core", () => {
+  it("deriveProjectWorldId === core projectWorldId for every (agent, project)", () => {
+    for (const agentId of AGENTS) {
+      for (const projectId of PROJECTS) {
+        expect(deriveProjectWorldId(agentId, projectId)).toBe(
+          projectWorldId(agentId, projectId),
+        );
+      }
+    }
+  });
+
+  it("matches the per-agent createUniqueUuid convention project:<id>:<agentId>", () => {
+    const agentId = AGENTS[0];
+    expect(deriveProjectWorldId(agentId, "proj-1")).toBe(
+      stringToUuid(`project:proj-1:${agentId}`),
+    );
+  });
+
+  it("is per-agent: the same project yields distinct worlds per agent", () => {
+    const a = deriveProjectWorldId(AGENTS[0], "proj-1");
+    const b = deriveProjectWorldId(AGENTS[1], "proj-1");
+    expect(a).not.toBe(b);
+  });
+
+  it("is deterministic and distinct in the project id for a fixed agent", () => {
+    const agentId = AGENTS[0];
+    const a = deriveProjectWorldId(agentId, "proj-1");
+    expect(deriveProjectWorldId(agentId, "proj-1")).toBe(a);
+    expect(deriveProjectWorldId(agentId, "proj-2")).not.toBe(a);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
@@ -10,7 +10,7 @@
 import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { type IAgentRuntime, upsertProject } from "@elizaos/core";
+import { type IAgentRuntime, type UUID, upsertProject } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AcpService } from "../services/acp-service.js";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
@@ -53,9 +53,13 @@ function makeWorkdirCapturingAcp() {
   return { service, spawns };
 }
 
+/** The agentId the fake runtime reports; project worlds are agent-scoped, so the
+ * worldId assertions below must derive against this exact id. */
+const AGENT_ID = "00000000-0000-4000-8000-000000000abc" as UUID;
+
 function makeRuntime(acpService: unknown): IAgentRuntime {
   return {
-    agentId: "00000000-0000-4000-8000-000000000abc",
+    agentId: AGENT_ID,
     character: { name: "Binder" },
     logger: {
       debug: () => undefined,
@@ -498,11 +502,13 @@ describe("project memory-world stamping at bind time (#13776 D3)", () => {
         workdir: firstDir,
       });
       expect(detail.projectId).toBe(project.id);
-      expect(detail.worldId).toBe(deriveProjectWorldId(project.id));
+      expect(detail.worldId).toBe(deriveProjectWorldId(AGENT_ID, project.id));
       // Persisted, not just returned.
       const record = await store.getTask(detail.id);
       expect(record?.task.projectId).toBe(project.id);
-      expect(record?.task.worldId).toBe(deriveProjectWorldId(project.id));
+      expect(record?.task.worldId).toBe(
+        deriveProjectWorldId(AGENT_ID, project.id),
+      );
     } finally {
       await service.stop().catch(() => undefined);
     }

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -2195,7 +2195,10 @@ export class OrchestratorTaskService extends Service {
     const projectId = resolveTaskProjectId(input);
     const { workdir: _workdir, ...rest } = input;
     const worldId =
-      rest.worldId ?? (projectId ? deriveProjectWorldId(projectId) : undefined);
+      rest.worldId ??
+      (projectId
+        ? deriveProjectWorldId(this.runtime.agentId, projectId)
+        : undefined);
     return { ...rest, projectId, worldId };
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/project-binding.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/project-binding.ts
@@ -13,8 +13,9 @@
  * Binding also stamps the task's memory world ({@link deriveProjectWorldId}):
  * this is the live implementation of #13776 design D3's per-project memory
  * partition — subagents on project B never see project A's injected context.
- * The derivation is deterministic in the project id, so it is the source of
- * truth even though the core `ProjectRecord.worldId` also persists it for CRUD.
+ * The world is derived by delegating to core's `projectWorldId` (the single
+ * source of truth, #14171) so this bind seam and the runtime's memory-scope
+ * guards can never land on different partitions for the same (agent, project).
  */
 
 import { realpathSync } from "node:fs";
@@ -22,12 +23,11 @@ import { resolve } from "node:path";
 import {
   getProjectById,
   logger,
-  PROJECT_WORLD_ID_PREFIX,
   type ProjectRecord,
+  projectWorldId,
   readProjectRegistry,
-  stringToUuid,
-  upsertProject,
   type UUID,
+  upsertProject,
 } from "@elizaos/core";
 
 /** Canonicalize a path for identity comparison; falls back to a resolved
@@ -76,14 +76,18 @@ export function resolveTaskProjectId(
 }
 
 /**
- * The memory world a project partitions into — `stringToUuid('project:' + id)`.
- * Deterministic so the agent runtime, desktop picker, and this bind seam all
- * derive the same world for a project id without coordinating through disk. This
- * is #13776 design D3's cheaper option: a dedicated free partition in the
- * existing memory schema, no column change.
+ * The memory world a project partitions into, for a given agent. A thin
+ * delegate to core's {@link projectWorldId} — the single source of truth for
+ * this derivation (#14171). Worlds are agent-scoped (`World.agentId`), so the
+ * world is keyed on both the agent and the project, matching what
+ * `createUniqueUuid(runtime, 'project:' + projectId)` produces at runtime. This
+ * bind seam and core's memory-scope guards therefore always agree on a
+ * project's partition. Kept as a plugin-local export (rather than importing core
+ * at every call site) so a cross-package test can pin the two to equality and
+ * catch any future re-divergence.
  */
-export function deriveProjectWorldId(projectId: string): UUID {
-  return stringToUuid(`${PROJECT_WORLD_ID_PREFIX}${projectId}`);
+export function deriveProjectWorldId(agentId: UUID, projectId: string): UUID {
+  return projectWorldId(agentId, projectId);
 }
 
 /** The localPath of the registered project a bound task targets, or `null` when


### PR DESCRIPTION
## Verified defect (#14171)

`#14159` shipped a **second** project→world-id derivation inside
`plugin-agent-orchestrator`, recreating (one level down) the exact divergence
class `#14107` fixed. The two derivations produced **different UUIDs** for the
same project:

| Source | Derivation |
| --- | --- |
| `plugins/plugin-agent-orchestrator` `deriveProjectWorldId(projectId)` | `stringToUuid("project:" + projectId)` |
| `packages/core` `projectWorldId(agentId, projectId)` | `stringToUuid("project:" + projectId + ":" + agentId)` |

Core's value is exactly `createUniqueUuid(runtime, "project:" + projectId)` — Worlds are agent-scoped (`World.agentId`), the contract fixed by the `#13776` D3 decision. The plugin's per-project-only world therefore never matched core's per-agent memory-scope guards (`scopeMemoryFilterToProject` / `assertMemoriesInProject`) for the same project, so a bound task's stamped `worldId` could never align with the runtime's project-scoped reads.

Confirmed real and unfixed on `origin/develop` (81e035c0f44): both functions exist and both are live — plugin's is called from `OrchestratorTaskService.bindProject`.

## Fix (per the #13776 D3 decision — plugin delegates to core)

- `deriveProjectWorldId` is now a **thin delegate** to core's `projectWorldId` — the single source of truth. Signature is `(agentId: UUID, projectId: string)`; it simply `return projectWorldId(agentId, projectId)`.
- The sole caller, `OrchestratorTaskService.bindProject`, now passes `this.runtime.agentId`.
- Kept `deriveProjectWorldId` as a plugin-local export (not inlined at the call site) so a cross-package test can pin the two to equality and catch any future re-divergence.
- Removed the now-dead `PROJECT_WORLD_ID_PREFIX` / `stringToUuid` imports from the plugin.

## Regression test (fail-before / pass-after)

New `src/__tests__/project-world-id-parity.test.ts` drives **both real functions** — the plugin's `deriveProjectWorldId` and core's `projectWorldId` — and asserts equality across a matrix of `(agentId, projectId)` pairs, plus per-agent distinctness and the `project:<id>:<agentId>` convention. Two existing tests that pinned the old per-project-only semantics were migrated to the per-agent contract (`project-binding.test.ts`, `task-workdir-binding.test.ts` — the latter drives the real `OrchestratorTaskService.createTask → bindProject` path and asserts the stamped `worldId`).

**Before (parity test vs. the unfixed `deriveProjectWorldId`):**

```
FAIL  src/__tests__/project-world-id-parity.test.ts
 > deriveProjectWorldId === core projectWorldId for every (agent, project)
 > matches the per-agent createUniqueUuid convention project:<id>:<agentId>
AssertionError: expected '644fcad8-10c5-08b1-bebd-9960ed41582b'
             to be 'e7cac2da-1277-07dc-a681-4928fbffac3c'
 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

**After (parity + both migrated suites):**

```
 Test Files  3 passed (3)
      Tests  32 passed (32)
```

`bunx biome check` clean on all touched files. The only local `bun run typecheck` errors are pre-existing ambient module-resolution noise (missing `.d.ts` for `drizzle-orm`, `git-workspace-service`, `fast-redact`, `coding-agent-adapters`, and a missing generated file) — none reference the touched files.

Closes #14171. Cross-ref: #14107, #14159, #13776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)