### PR TITLE
ci: lightweight develop-PR gate; remove merge queue + heavy suites from develop PRs

### DIFF
--- a/.github/workflows/android-device-e2e.yml
+++ b/.github/workflows/android-device-e2e.yml
@@ -37,7 +37,7 @@ on:
   # runs a MINIMAL slice (build + install + WebView attach + onboarding→home +
   # one host-backed chat turn); the full dispatch matrix above is unchanged.
   pull_request:
-    branches: [develop, main]
+    branches: [main]
     types: [opened, synchronize, reopened, labeled]
 
 concurrency:

--- a/.github/workflows/app-aesthetic-audit.yml
+++ b/.github/workflows/app-aesthetic-audit.yml
@@ -13,7 +13,7 @@ name: App Aesthetic Audit
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/app/**"
       - "packages/ui/**"

--- a/.github/workflows/apps-deploy-e2e.yml
+++ b/.github/workflows/apps-deploy-e2e.yml
@@ -15,6 +15,7 @@ name: Apps Deploy E2E (Product 2)
 on:
   workflow_dispatch:
   pull_request:
+    branches: [main]
     paths:
       - "packages/cloud/shared/src/lib/services/app-deploy-runner.ts"
       - "packages/cloud/shared/src/lib/services/app-container-provider.ts"

--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -19,7 +19,7 @@ on:
       - "packages/lifeops-bench/**"
       - ".github/workflows/benchmark-tests.yml"
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/lifeops-bench/**"
       - ".github/workflows/benchmark-tests.yml"

--- a/.github/workflows/browser-real-bench.yml
+++ b/.github/workflows/browser-real-bench.yml
@@ -18,6 +18,7 @@ on:
     - cron: "0 10 * * *"
   workflow_dispatch: {}
   pull_request:
+    branches: [main]
     paths:
       - "plugins/plugin-browser/src/benchmark/**"
       - "plugins/plugin-browser/vitest.real.config.ts"

--- a/.github/workflows/cache-key-stability.yml
+++ b/.github/workflows/cache-key-stability.yml
@@ -20,7 +20,7 @@ name: Cache-key Stability
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/core/**"
       - "plugins/plugin-personal-assistant/**"

--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -27,7 +27,7 @@ name: Chat shell gestures
 # imports the real @elizaos/core, so the shared i18n data is generated first.
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - ".github/workflows/chat-shell-gestures.yml"
       - "package.json"

--- a/.github/workflows/ci-full-matrix-proof.yml
+++ b/.github/workflows/ci-full-matrix-proof.yml
@@ -20,16 +20,6 @@ on:
     - cron: "13 3 * * *"
     - cron: "13 15 * * *"
   workflow_dispatch:
-  pull_request:
-    branches: [develop]
-    # Only re-validate the proof when its own inputs move, so this stays off the
-    # PR hot path for the other ~200 daily PRs.
-    paths:
-      - "packages/scripts/ci-full-matrix-proof.mjs"
-      - "packages/scripts/ci-lane-manifest.json"
-      - "packages/scripts/run-all-tests.mjs"
-      - ".github/workflows/test.yml"
-      - ".github/workflows/ci-full-matrix-proof.yml"
 
 # Never cancel an in-flight proof run. Push/PR traffic must not be able to
 # abort the scheduled exhaustive-lane signal (#12337/#12342).

--- a/.github/workflows/cloud-aesthetic-audit.yml
+++ b/.github/workflows/cloud-aesthetic-audit.yml
@@ -19,7 +19,7 @@ name: Cloud Aesthetic Audit
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/app/**"
       - "packages/ui/**"

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -46,7 +46,7 @@ on:
       - "packages/ui/**"
       - ".github/workflows/cloud-cf-deploy.yml"
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/cloud/api/**"
       - "packages/cloud/shared/**"

--- a/.github/workflows/cloud-e2e.yml
+++ b/.github/workflows/cloud-e2e.yml
@@ -6,7 +6,7 @@ name: cloud-e2e
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [main]
     paths:
       - "packages/cloud/api/**"
       - "packages/cloud/shared/**"

--- a/.github/workflows/cloud-gateway-discord.yml
+++ b/.github/workflows/cloud-gateway-discord.yml
@@ -25,7 +25,7 @@ on:
       - "packages/cloud/shared/src/db/**/discord-connections.ts"
       - ".github/workflows/cloud-gateway-discord.yml"
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/cloud/services/gateway-discord/**"
       - "packages/cloud/shared/src/lib/services/gateway-discord/**"

--- a/.github/workflows/cloud-gateway-webhook.yml
+++ b/.github/workflows/cloud-gateway-webhook.yml
@@ -14,7 +14,7 @@ on:
       - "packages/cloud/shared/scripts/messaging-gateway-preflight.mjs"
       - ".github/workflows/cloud-gateway-webhook.yml"
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/cloud/services/gateway-webhook/**"
       - "packages/cloud/shared/src/lib/services/**"

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -6,7 +6,7 @@ name: Cloud Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches: [develop, main]
+    branches: [main]
     paths:
       - "packages/cloud/api/**"
       - "packages/cloud/shared/**"

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -16,7 +16,7 @@ name: coverage-gate
 
 on:
   pull_request:
-    branches: ["main", "develop"]
+    branches: [main]
     paths:
       - "packages/**"
       - "plugins/**"

--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -4,7 +4,7 @@ on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   push:
     branches: [main, develop]

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -1,0 +1,109 @@
+name: Develop PR
+
+# Lightweight gate for pull requests targeting `develop`: lint, typecheck, and
+# build only. The full test/e2e/scenario/benchmark surface runs post-merge on
+# push to `develop` (and nightly/on-demand), not on every PR — so PR feedback
+# stays fast and hosted-runner capacity is spent on the ~200 daily PRs' fast
+# signal rather than the whole integration matrix. `main` PRs keep the heavy
+# gates via `ci.yaml`, `test.yml`'s peers, and `quality.yml`. Steps mirror
+# `ci.yaml` so PR and post-merge lanes stay in agreement.
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: develop-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# Default to least privilege. Override per-job where needed.
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14" # pinned: floating canary writes lockfileVersion 2 and breaks --frozen-lockfile (#11184/#9454)
+          install-command: bun install
+          install-native-deps: "false"
+          install-protoc: "false"
+          setup-python: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Run lint
+        run: bun run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          # Full history so `turbo run typecheck --affected` can resolve the PR
+          # merge base (#12341); a shallow clone degrades to typechecking all.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14" # pinned: floating canary writes lockfileVersion 2 and breaks --frozen-lockfile (#11184/#9454)
+          install-command: bun install
+          install-native-deps: "false"
+          install-protoc: "false"
+          setup-python: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      # Typecheck resolves `@elizaos/core` types from its built dist, so build
+      # core before running tsc across the affected cone.
+      - name: Build core
+        run: bun run build:core
+
+      - name: Run typecheck (affected)
+        run: NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --concurrency=8 --affected
+        env:
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14" # pinned: floating canary writes lockfileVersion 2 and breaks --frozen-lockfile (#11184/#9454)
+          install-command: bun install
+          install-native-deps: "false"
+          install-protoc: "false"
+          setup-python: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Build packages
+        run: bun run build:core

--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -3,12 +3,6 @@ name: Docker CI Smoke
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
-  # Heavy family moved off per-PR push (#14051 Tier A): PR runs are opt-in via
-  # the `ci:full` label (job-level gate on `changes` below). Unlabeled PRs
-  # skip every job instantly and consume zero runners.
-  pull_request:
-    branches: [develop]
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
   push:
     branches: [develop]
   schedule:
@@ -34,9 +28,6 @@ permissions:
 jobs:
   changes:
     name: Classify changed paths
-    # #14051: PRs only run this heavy family when explicitly opted in with the
-    # `ci:full` label. Every downstream job needs this one, so an unlabeled PR
-    # skips the whole workflow without touching a runner.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full')
     # Path classifier is a git-diff + node script: no self-hosted resources.
     # Keep it on GitHub-hosted so a drained hetzner fleet cannot leave it

--- a/.github/workflows/e1-chip.yml
+++ b/.github/workflows/e1-chip.yml
@@ -7,6 +7,7 @@ on:
       - "packages/research/chip/**"
       - ".github/workflows/e1-chip.yml"
   pull_request:
+    branches: [main]
     paths:
       - "packages/research/chip/**"
       - ".github/workflows/e1-chip.yml"

--- a/.github/workflows/elizaos-os-release.yml
+++ b/.github/workflows/elizaos-os-release.yml
@@ -3,6 +3,7 @@ name: ElizaOS OS release validation
 on:
   workflow_dispatch:
   pull_request:
+    branches: [main]
     paths:
       - ".github/workflows/elizaos-os-release.yml"
       - "packages/os/**"

--- a/.github/workflows/feed-test.yml
+++ b/.github/workflows/feed-test.yml
@@ -27,7 +27,7 @@ name: feed-test
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [main]
     paths:
       - "packages/feed/**"
       - ".github/workflows/feed-test.yml"

--- a/.github/workflows/keyless-harness-e2e.yml
+++ b/.github/workflows/keyless-harness-e2e.yml
@@ -20,7 +20,7 @@ on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch: {}
 

--- a/.github/workflows/launch-qa.yml
+++ b/.github/workflows/launch-qa.yml
@@ -2,7 +2,7 @@ name: Launch QA
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "launchdocs/**"
       - "packages/docs/docs/launchdocs/**"

--- a/.github/workflows/lifeops-bench-manifest.yml
+++ b/.github/workflows/lifeops-bench-manifest.yml
@@ -21,7 +21,7 @@ name: LifeOps Action Manifest Gate
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "plugins/plugin-personal-assistant/**"
       - "plugins/plugin-contacts/**"

--- a/.github/workflows/lifeops-bench-multi-tier.yml
+++ b/.github/workflows/lifeops-bench-multi-tier.yml
@@ -20,7 +20,7 @@ name: LifeOps Benchmark — Multi-Tier
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/benchmarks/**"
       - "plugins/plugin-training/**"

--- a/.github/workflows/lifeops-bench-python.yml
+++ b/.github/workflows/lifeops-bench-python.yml
@@ -27,7 +27,7 @@ name: LifeOpsBench (Python)
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/benchmarks/lifeops-bench/**"
       - "packages/benchmarks/eliza-adapter/eliza_adapter/lifeops_bench.py"

--- a/.github/workflows/lifeops-bench.yml
+++ b/.github/workflows/lifeops-bench.yml
@@ -21,7 +21,7 @@ name: LifeOps Benchmark
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "plugins/plugin-personal-assistant/**"
       - "plugins/plugin-training/**"

--- a/.github/workflows/lifeops-prompt-benchmark.yml
+++ b/.github/workflows/lifeops-prompt-benchmark.yml
@@ -8,7 +8,7 @@ name: LifeOps Prompt Benchmark
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "plugins/plugin-personal-assistant/test/helpers/lifeops-prompt-benchmark-*.ts"
       - "plugins/plugin-personal-assistant/test/lifeops-prompt-benchmark.test.ts"

--- a/.github/workflows/lifeops-quality-bench.yml
+++ b/.github/workflows/lifeops-quality-bench.yml
@@ -22,6 +22,7 @@ name: lifeops-quality-bench
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - "packages/benchmarks/lifeops-quality/**"
       - "plugins/plugin-inbox/src/inbox/**"

--- a/.github/workflows/loadperf.yml
+++ b/.github/workflows/loadperf.yml
@@ -5,6 +5,7 @@ on:
     # Daily at 09:17 UTC, after the normal nightly lanes have had time to settle.
     - cron: "17 9 * * *"
   pull_request:
+    branches: [main]
     paths:
       - ".github/workflows/loadperf.yml"
       - "packages/benchmarks/loadperf/**"

--- a/.github/workflows/local-inference-bench.yml
+++ b/.github/workflows/local-inference-bench.yml
@@ -26,6 +26,7 @@ on:
     # 04:30 UTC Sunday — weekly eliza-1 model publish window.
     - cron: "30 4 * * 0"
   pull_request:
+    branches: [main]
     paths:
       - "packages/scripts/benchmark/**"
       - ".github/workflows/local-inference-bench.yml"

--- a/.github/workflows/local-inference-matrix.yml
+++ b/.github/workflows/local-inference-matrix.yml
@@ -35,6 +35,7 @@ on:
         type: boolean
         default: false
   pull_request:
+    branches: [main]
     paths:
       - "packages/app-core/src/services/local-inference/**"
       - "packages/scripts/local-inference-ablation.mjs"

--- a/.github/workflows/memperf.yml
+++ b/.github/workflows/memperf.yml
@@ -13,6 +13,7 @@ name: memperf
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - "packages/benchmarks/memperf/**"
       - "plugins/plugin-local-inference/src/services/memory-arbiter.ts"

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -4,7 +4,7 @@ on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/mobile-resource-workbench.yml
+++ b/.github/workflows/mobile-resource-workbench.yml
@@ -25,6 +25,7 @@ on:
     # 05:30 UTC — after the nightly publish window, like local-inference-bench.
     - cron: "30 5 * * *"
   pull_request:
+    branches: [main]
     paths:
       - "packages/benchmarks/mobile-resource/**"
       - ".github/workflows/mobile-resource-workbench.yml"

--- a/.github/workflows/orchestrator-multi-account.yml
+++ b/.github/workflows/orchestrator-multi-account.yml
@@ -15,6 +15,7 @@ name: Orchestrator multi-account
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - "plugins/plugin-agent-orchestrator/**"
       - "packages/app-core/src/services/coding-account-bridge.ts"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,8 +7,11 @@ name: Quality (Extended)
 # typecheck/biome format gate.
 
 on:
+  # PRs to `develop` use the lightweight lint/typecheck/build gate
+  # (develop-pr.yml); these extended quality gates run on `main` PRs and
+  # post-merge on push to both branches.
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths-ignore:
       - "docs/**"
       - "packages/docs/**"

--- a/.github/workflows/recall-bench.yml
+++ b/.github/workflows/recall-bench.yml
@@ -18,6 +18,7 @@ name: recall-bench
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - "packages/benchmarks/recall-bench/**"
       - "packages/benchmarks/registry/**"

--- a/.github/workflows/riscv64-smoke.yml
+++ b/.github/workflows/riscv64-smoke.yml
@@ -11,6 +11,7 @@ name: riscv64 cross-build smoke
 on:
   workflow_dispatch:
   pull_request:
+    branches: [main]
     types: [labeled, synchronize, reopened]
 
 # cancel superseded in-flight runs for the same PR to free hosted-runner

--- a/.github/workflows/sandbox-live-smoke.yml
+++ b/.github/workflows/sandbox-live-smoke.yml
@@ -18,7 +18,7 @@ on:
         type: boolean
         default: false
   pull_request:
-    branches: [develop, main]
+    branches: [main]
     paths:
       - ".github/workflows/sandbox-live-smoke.yml"
       - ".env.example"

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -11,7 +11,7 @@ on:
   # the `ci:full` label (job-level gate on `changes` below). Unlabeled PRs
   # skip every job instantly and consume zero runners.
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   push:
     branches: [develop]

--- a/.github/workflows/snap-build-test.yml
+++ b/.github/workflows/snap-build-test.yml
@@ -6,6 +6,7 @@ on:
       - 'packages/app-core/packaging/snap/**'
       - '.github/workflows/snap-build-test.yml'
   pull_request:
+    branches: [main]
     paths:
       - 'packages/app-core/packaging/snap/**'
       - '.github/workflows/snap-build-test.yml'

--- a/.github/workflows/terraform-apps-data-plane.yml
+++ b/.github/workflows/terraform-apps-data-plane.yml
@@ -47,6 +47,7 @@ name: Terraform — Apps Data Plane (Hetzner)
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - "packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/**"
       - ".github/workflows/terraform-apps-data-plane.yml"

--- a/.github/workflows/terraform-apps-shared.yml
+++ b/.github/workflows/terraform-apps-shared.yml
@@ -27,6 +27,7 @@ name: Terraform — Apps Shared (Hetzner)
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - "packages/cloud/infra/cloud/terraform/hetzner/apps-shared/**"
       - ".github/workflows/terraform-apps-shared.yml"

--- a/.github/workflows/terraform-control-plane.yml
+++ b/.github/workflows/terraform-control-plane.yml
@@ -29,6 +29,7 @@ name: Terraform — Control Plane (Hetzner)
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - "packages/cloud/infra/cloud/terraform/hetzner/control-plane/**"
       - ".github/workflows/terraform-control-plane.yml"

--- a/.github/workflows/test-electrobun-release.yml
+++ b/.github/workflows/test-electrobun-release.yml
@@ -4,7 +4,7 @@ on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-elizaos-setup.yml
+++ b/.github/workflows/test-elizaos-setup.yml
@@ -2,6 +2,7 @@ name: Test AOSP flasher
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - "packages/os/setup/**"
       - ".github/workflows/test-elizaos-setup.yml"

--- a/.github/workflows/test-flatpak.yml
+++ b/.github/workflows/test-flatpak.yml
@@ -2,6 +2,7 @@ name: Test Flatpak Build
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - 'packages/app-core/packaging/flatpak/**'
       - '.github/workflows/test-flatpak.yml'

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -2,6 +2,7 @@ name: Test Packaging
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - 'packages/app-core/packaging/**'
       - 'packages/core/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,9 @@ name: Tests
 # build+core-test gate; this workflow adds the broader integration surface.
 
 on:
-  pull_request:
-    branches: [develop]
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
-  merge_group:
-    branches: [develop]
-    types: [checks_requested]
+  # Post-merge integration surface. PRs to `develop` run the lightweight
+  # lint/typecheck/build gate (develop-pr.yml); the full suite runs here once
+  # changes land on `develop`, plus nightly and on demand.
   push:
     branches: [develop]
   workflow_dispatch:

--- a/.github/workflows/training-stack.yml
+++ b/.github/workflows/training-stack.yml
@@ -24,11 +24,6 @@ on:
     paths:
       - "packages/training/**"
       - ".github/workflows/training-stack.yml"
-  pull_request:
-    branches: [develop]
-    paths:
-      - "packages/training/**"
-      - ".github/workflows/training-stack.yml"
   workflow_dispatch:
 
 # CI fan-out fix: the PR-scoped concurrency from #14069 fell back to

--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -16,7 +16,7 @@ on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       # The fixture runners esbuild-bundle from the full packages/ui/src tree,
       # so any source change there can reach a bundled runner.

--- a/.github/workflows/ui-fixture-e2e.yml
+++ b/.github/workflows/ui-fixture-e2e.yml
@@ -20,7 +20,7 @@ on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/ui/src/**"
       - ".github/workflows/ui-fixture-e2e.yml"

--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -12,7 +12,7 @@ on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/ui/**"
       - "packages/shared/**"

--- a/.github/workflows/vault-ci.yaml
+++ b/.github/workflows/vault-ci.yaml
@@ -32,7 +32,7 @@ on:
       - "packages/app-core/src/hooks/useSecretsManagerShortcut.ts"
       - ".github/workflows/vault-ci.yaml"
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/vault/**"
       - "packages/app-core/src/api/plugins-compat-routes.ts"

--- a/.github/workflows/view-bundle-size.yml
+++ b/.github/workflows/view-bundle-size.yml
@@ -16,6 +16,7 @@ name: view-bundle-size
 
 on:
   pull_request:
+    branches: [main]
     paths:
       # Plugin source (where view components live) + the view-bundle build/config
       # + the gate itself. Scheduled runs below are the catch-all for drift.

--- a/.github/workflows/voice-bench-smoke.yml
+++ b/.github/workflows/voice-bench-smoke.yml
@@ -22,6 +22,7 @@ on:
       - "scripts/bench-voice.mjs"
       - ".github/workflows/voice-bench-smoke.yml"
   pull_request:
+    branches: [main]
     paths:
       - "packages/benchmarks/voicebench/**"
       - "packages/benchmarks/voicebench-quality/**"

--- a/.github/workflows/voice-workbench.yml
+++ b/.github/workflows/voice-workbench.yml
@@ -39,6 +39,7 @@ on:
       - "packages/shared/src/voice/owner-inference.ts"
       - ".github/workflows/voice-workbench.yml"
   pull_request:
+    branches: [main]
     paths:
       - "plugins/plugin-local-inference/src/services/voice/voice-scenario.ts"
       - "plugins/plugin-local-inference/src/services/voice/e2e-harness.ts"

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -52,7 +52,7 @@ on:
       - "WINDOWS.md"
       - ".github/workflows/windows-ci.yml"
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "package.json"
       - "bun.lock"

--- a/.github/workflows/windows-desktop-preload-smoke.yml
+++ b/.github/workflows/windows-desktop-preload-smoke.yml
@@ -2,7 +2,7 @@ name: Windows Desktop Preload Smoke
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
 

--- a/.github/workflows/windows-dev-smoke.yml
+++ b/.github/workflows/windows-dev-smoke.yml
@@ -1,9 +1,6 @@
 name: Windows Dev Smoke
 
 on:
-  pull_request:
-    branches: [develop]
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
   schedule:
     # Weekly Windows smoke check (Mondays 06:00 UTC).
     - cron: "0 6 * * 1"


### PR DESCRIPTION
# Relates to

CI weight reduction on `develop` PRs (no linked issue — infra/workflow change).

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop`.
- [x] Change is workflow-config only; validated with `actionlint`.
- [x] A reviewer can confirm the change works without reading the code, from the trigger enumeration below.

# Sync with develop

- [ ] Rebase onto latest `origin/develop` before merge (branch is behind by whatever landed since branch point; no code conflicts expected — this touches only `.github/workflows/`).

# Risks

**Low.** Workflow-trigger changes only; no runtime/product code touched. Reversible by reverting this commit. The heavy suites are not deleted — they keep running on `push:[develop]` (post-merge), nightly `schedule`, `workflow_dispatch`, `workflow_call` (the scheduled exhaustive lane), and on `main` PRs. Worst case if something was miscategorized: a check that used to run on a develop PR now runs post-merge instead of pre-merge.

# Background

## What does this PR do?

Makes CI on **PRs to `develop`** lightweight — only **lint + typecheck + build** — and removes the leftover merge-queue plumbing.

- **New `develop-pr.yml`** — the develop-PR gate: `lint`, `typecheck --affected`, `build:core`, mirroring `ci.yaml`'s proven setup. No tests.
- **`test.yml`** — removed the `merge_group` (merge queue) trigger **and** the `pull_request:[develop]` trigger; kept `push:[develop]` + nightly `schedule` + `workflow_dispatch`.
- **`quality.yml`** — PR trigger restricted to `[main]`; still runs post-merge on the develop `push` trigger.
- **~50 heavy workflows** (test/e2e/scenario/benchmark/perf/smoke/coverage/cloud/mobile/windows/android/packaging/infra/deploy-preview) — dropped `develop` from their `pull_request` trigger. They keep their `main` PR trigger and **every** `push`/`schedule`/`workflow_dispatch`/`workflow_call` trigger, so post-merge and scheduled-exhaustive coverage is unchanged.

**Kept on develop PRs:** `gitleaks` + `claude-security-review` (security), `pr.yaml` title/evidence, `markdown-links`, and the lightweight guard/meta workflows.

**Repo-settings note:** `develop` already had **no merge queue and no required status checks** (only `main` carries a protection ruleset), so no branch-protection / ruleset change is needed for this to take effect.

## What kind of change is this?

Improvements (CI/infra).

# Documentation changes needed?

My changes do not require a documentation change.

# Testing

## Where should a reviewer start?

Open `.github/workflows/develop-pr.yml` (the new gate) and the `on:` block of `.github/workflows/test.yml` (merge_group + develop-PR trigger removed).

## Detailed testing steps

Verified mechanically (no product surface to click):

- **YAML parse:** all 60 changed/added workflows parse.
- **`actionlint`** on all changed + new files: clean, aside from pre-existing custom self-hosted-runner-label warnings (`hetzner-robot`, `eliza-e2e-macos`) on `runs-on:` lines this PR does not touch.
- **`merge_group` triggers repo-wide: 0** (merge queue plumbing fully removed).
- **Enumerated every workflow that can fire on a `pull_request` to `develop`** → only: `develop-pr.yml`, `quality-fork.yml` (fork lint/typecheck/build), `gitleaks`, `claude-security-review`, `pr.yaml`, `markdown-links`, and lightweight guards (auto-label, stale-base-guard, electrobun-submodule-guard, verify-patches, docs-ci, skill-review, setup-bun-workspace-self-test, feed-env-audit). No tests/e2e/benches/perf/scenario/smoke/packaging/deploy/infra.
- **35 workflows retain `push:[develop]`** → post-merge coverage intact.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- N/A - CI workflow-trigger change only; no UI surface.
<!-- evidence-row:after-screenshots -->
- N/A - CI workflow-trigger change only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- N/A - No user-facing flow; change is GitHub Actions triggers.
<!-- evidence-row:backend-logs -->
- N/A - No server code path; validated with `actionlint` + trigger enumeration instead (see Testing).
<!-- evidence-row:frontend-logs -->
- N/A - No frontend code path.
<!-- evidence-row:llm-trajectory -->
- N/A - No agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- N/A - No runtime artifacts produced; the artifact is the workflow config itself.

# Evidence Details

## Real LLM-call trajectory

N/A - No agent/model behavior changes.

## Backend + frontend logs

N/A - No runtime code path. Verification is `actionlint` + a parse/trigger enumeration script (results in Testing above).

## Screenshots (before / after) + video walkthrough

N/A - No UI change.

## Audio / voice walkthrough

N/A - No voice change.

## Known gaps / failures

- Pre-existing `actionlint` `runner-label` warnings (`hetzner-robot`, `eliza-e2e-macos`) are unchanged by this PR — they flag custom self-hosted labels not declared in `actionlint.yaml`, on `runs-on:` lines not touched here.
- `claude-code-review.yml` still runs on develop PRs (it's the AI review bot, not test/build weight). Easy to also restrict to `main` if desired.
