### PR TITLE
test(agent): isolate character scoped action harness

### DIFF
--- a/packages/agent/src/runtime/view-scoped-actions.test.ts
+++ b/packages/agent/src/runtime/view-scoped-actions.test.ts
@@ -426,6 +426,7 @@ const CHARACTER_MOUNTED_IDS = new Set([
   "example-add-conversation",
   "post-example-add",
 ]);
+const CHARACTER_TEST_VIEW_ID = "character_fixture";
 
 function characterView() {
   const source = BUILTIN_VIEWS.find((v) => v.id === "character");
@@ -437,9 +438,9 @@ function characterView() {
     clicked,
     scopedActions: (source.scopedActions ?? []) as ViewScopedAction[],
     view: {
-      id: "character",
+      id: CHARACTER_TEST_VIEW_ID,
       label: "Character view",
-      path: "/character",
+      path: `/${CHARACTER_TEST_VIEW_ID}`,
       relatedActions: [] as string[],
       scopedActions: source.scopedActions,
       // Preserve the real view's agent-surface grant so the mutating
@@ -529,12 +530,12 @@ describe("character view scoped actions (#14155)", () => {
     const fillBio = actions.get("VIEW_CHARACTER_FILL_BIO");
     expect(fillBio).toBeDefined();
 
-    // Gated closed everywhere but the character view.
+    // Gated closed everywhere but the declaring view.
     await navigateTo("chat");
     expect(await fillBio?.validate?.({} as IAgentRuntime, fakeMessage)).toBe(
       false,
     );
-    await navigateTo("character");
+    await navigateTo(CHARACTER_TEST_VIEW_ID);
     expect(await fillBio?.validate?.({} as IAgentRuntime, fakeMessage)).toBe(
       true,
     );
@@ -550,10 +551,10 @@ describe("character view scoped actions (#14155)", () => {
       },
       process.cwd(),
     );
-    await navigateTo("character");
+    await navigateTo(CHARACTER_TEST_VIEW_ID);
 
     const action = buildViewScopedAction(
-      "character",
+      CHARACTER_TEST_VIEW_ID,
       findAction(char.scopedActions, "VIEW_CHARACTER_FILL_BIO"),
     );
     const result = await action.handler(
@@ -579,10 +580,10 @@ describe("character view scoped actions (#14155)", () => {
       },
       process.cwd(),
     );
-    await navigateTo("character");
+    await navigateTo(CHARACTER_TEST_VIEW_ID);
 
     const action = buildViewScopedAction(
-      "character",
+      CHARACTER_TEST_VIEW_ID,
       findAction(char.scopedActions, "VIEW_CHARACTER_ADD_STYLE_RULE"),
     );
     const result = await action.handler(
@@ -612,10 +613,10 @@ describe("character view scoped actions (#14155)", () => {
       },
       process.cwd(),
     );
-    await navigateTo("character");
+    await navigateTo(CHARACTER_TEST_VIEW_ID);
 
     const action = buildViewScopedAction(
-      "character",
+      CHARACTER_TEST_VIEW_ID,
       findAction(char.scopedActions, "VIEW_CHARACTER_ADD_MESSAGE_EXAMPLE"),
     );
     const result = await action.handler(
@@ -637,9 +638,9 @@ describe("character view scoped actions (#14155)", () => {
     // missing-element error — never a silent no-op.
     const source = BUILTIN_VIEWS.find((v) => v.id === "character");
     const bareView = {
-      id: "character",
+      id: CHARACTER_TEST_VIEW_ID,
       label: "Character view",
-      path: "/character",
+      path: `/${CHARACTER_TEST_VIEW_ID}`,
       relatedActions: [] as string[],
       scopedActions: source?.scopedActions,
       // Grant agent-surface (as the real view does) so the step clears the
@@ -662,10 +663,10 @@ describe("character view scoped actions (#14155)", () => {
       },
       process.cwd(),
     );
-    await navigateTo("character");
+    await navigateTo(CHARACTER_TEST_VIEW_ID);
 
     const action = buildViewScopedAction(
-      "character",
+      CHARACTER_TEST_VIEW_ID,
       findAction(
         (source?.scopedActions ?? []) as ViewScopedAction[],
         "VIEW_CHARACTER_ADD_STYLE_RULE",


### PR DESCRIPTION
## Summary
- isolates the Character scoped-action test harness under a fixture view id so it does not collide with the built-in `character` view registered by #14162
- keeps the assertions wired to the real Character scoped-action declarations from `BUILTIN_VIEWS`

## Verification
- `bun test packages/agent/src/api/views-routes.interact-coverage.test.ts packages/agent/src/api/views-routes.activate.test.ts packages/agent/src/runtime/view-scoped-actions.test.ts`
- `bunx biome check packages/agent/src/runtime/view-scoped-actions.test.ts --no-errors-on-unmatched`
- `git diff --check origin/develop...HEAD`
- `bun run audit:error-policy-ratchet`

Follow-up for merged #14162: the merged branch had the correct built-in surface grant, but the Character tests still attempted to register a test plugin view with id `character`; the built-in registry entry wins that conflict, so the test harness timed out through the WebSocket path instead of using `serverInteract`.