### PR TITLE
fix(ui,app): real 44px back-control hit target + scoped ViewHeader sweep (#14178 review holds)

### DIFF
--- a/.github/issue-evidence/14152-back-control-hit-target.md
+++ b/.github/issue-evidence/14152-back-control-hit-target.md
@@ -1,0 +1,45 @@
+# Evidence — real ≥44px back-control hit target + scoped ViewHeader sweep (#14152 / #14178 follow-up)
+
+Follow-up landing the two holds from the #14178 review (lalalune, 18:0x–18:1xZ):
+the back control's own box must satisfy the 44px tap minimum (no borrowing from
+the header row), and the all-pages sweep must bind to the ROUTED view's header
+(no ambient-header fallback).
+
+## What changed
+- `packages/ui/src/components/shared/ViewHeader.tsx` — `ViewBackButton` is now a
+  44×44 hit target (`h-11 w-11 -m-1`) with the 36px visual chip moved to an
+  inner span (`group-hover:bg-bg-hover`). Zero visual delta: the negative
+  margin preserves the 36px layout footprint, the resting state stays
+  chromeless, hover chip unchanged at 36px.
+- `packages/app/test/ui-smoke/helpers/view-header.ts` — the tap-target check
+  measures the BUTTON's own `boundingBox()` and requires ≥44px in BOTH
+  dimensions; the row-borrowing `Math.max` is gone entirely. New `title`
+  scoping option alongside `within`.
+- `packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts` — every
+  `requireViewHeader` route now scopes the assertion: `viewHeaderWithin` for
+  the four shell-container routes (automations/wallet/settings/help),
+  `viewHeaderTitle` for the two character deep-links (Skills/Experience).
+
+## Evidence rows
+- **Unit (structure + contract):** `bunx vitest run src/components/shared/ViewHeader.test.tsx`
+  → **9/9 pass**, including the new pins: button `h-11 w-11 -m-1` (44px own-box
+  hit target), chip on the inner span (`h-9 w-9`, `group-hover:bg-bg-hover`),
+  rest state chromeless, icon-only. The old test pinned the chip ON the button;
+  updated to pin the new two-layer structure explicitly.
+- **Lint:** biome clean on all four files.
+- **Sweep (mobile tap-target leg):** exercised by
+  `all-pages-clicksafe.spec.ts` on the ≤500px viewport across the six
+  `requireViewHeader` routes — runs in the `test:e2e` lane on this PR's CI; the
+  new assertion fails against the pre-change 36px button by construction
+  (button box < 44 in both dimensions, no fallback path).
+- **Desktop/mobile screenshots:** N/A — zero-visual-delta change by design
+  (layout footprint preserved via `-m-1`; hover chip identical). The unit pins
+  + the measured-box e2e assertion are the behavioral proof; any visual drift
+  would fail the existing aesthetic-audit baselines untouched by this PR.
+- **Video walkthrough:** N/A — no flow change; the back control's behavior
+  (click → navigate) is untouched and covered by `clickViewHeaderBack` specs.
+- **Native/device capture:** N/A — web/desktop shared component; no native
+  bridge or platform-conditional code touched. The 44px minimum this enforces
+  IS the mobile-web guideline the sweep's mobile viewport leg asserts.
+- **Real-LLM trajectories:** N/A — no agent/action/provider/prompt change
+  (`useAgentElement` registration unchanged).

--- a/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
+++ b/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
@@ -40,6 +40,14 @@ type RouteProbe = {
    * no-op-for-exempt-views semantics.
    */
   requireViewHeader?: boolean;
+  /**
+   * Scope for the ViewHeader assertion: the routed view's shell selector
+   * (`viewHeaderWithin`) or the header's own title text (`viewHeaderTitle`).
+   * Without one, the helper could bind to an AMBIENT header floating under
+   * the routed view and mask a view that lost its own header (#14152).
+   */
+  viewHeaderWithin?: string;
+  viewHeaderTitle?: string;
 };
 
 type ViewportProbe = {
@@ -169,6 +177,7 @@ const CORE_ROUTE_PROBES: readonly RouteProbe[] = [
     name: "automations",
     path: "/automations",
     readyChecks: [{ selector: '[data-testid="automations-shell"]' }],
+    viewHeaderWithin: '[data-testid="automations-shell"]',
     timeoutMs: 60_000,
     requireViewHeader: true,
   },
@@ -197,6 +206,7 @@ const CORE_ROUTE_PROBES: readonly RouteProbe[] = [
     name: "wallet",
     path: "/wallet",
     readyChecks: [{ selector: '[data-testid="wallet-shell"]' }],
+    viewHeaderWithin: '[data-testid="wallet-shell"]',
     timeoutMs: 60_000,
     requireViewHeader: true,
   },
@@ -218,6 +228,7 @@ const CORE_ROUTE_PROBES: readonly RouteProbe[] = [
     name: "settings",
     path: "/settings",
     readyChecks: [{ selector: '[data-testid="settings-shell"]' }],
+    viewHeaderWithin: '[data-testid="settings-shell"]',
     timeoutMs: 60_000,
     requireViewHeader: true,
   },
@@ -286,6 +297,7 @@ const CORE_ROUTE_PROBES: readonly RouteProbe[] = [
     mode: "all",
     timeoutMs: 60_000,
     requireViewHeader: true,
+    viewHeaderTitle: "Skills",
   },
   {
     name: "character experience deep link",
@@ -297,6 +309,7 @@ const CORE_ROUTE_PROBES: readonly RouteProbe[] = [
     mode: "all",
     timeoutMs: 60_000,
     requireViewHeader: true,
+    viewHeaderTitle: "Experience",
   },
   {
     name: "automation node catalog deep link",
@@ -344,6 +357,7 @@ const CORE_ROUTE_PROBES: readonly RouteProbe[] = [
     name: "help",
     path: "/help",
     readyChecks: [{ selector: '[data-testid="help-view"]' }],
+    viewHeaderWithin: '[data-testid="help-view"]',
     timeoutMs: 60_000,
     requireViewHeader: true,
   },
@@ -1497,6 +1511,8 @@ async function probeRoute(page: Page, route: RouteProbe): Promise<void> {
     const isMobileViewport = Boolean(viewport && viewport.width <= 500);
     await assertSharedViewHeaderContract(page, {
       requireTapTarget: isMobileViewport,
+      within: route.viewHeaderWithin,
+      title: route.viewHeaderTitle,
     });
   }
 }

--- a/packages/app/test/ui-smoke/helpers/view-header.ts
+++ b/packages/app/test/ui-smoke/helpers/view-header.ts
@@ -27,15 +27,20 @@ export async function assertSharedViewHeaderContract(
   {
     requireTapTarget = false,
     within,
-  }: { requireTapTarget?: boolean; within?: string } = {},
+    title,
+  }: { requireTapTarget?: boolean; within?: string; title?: string } = {},
 ): Promise<void> {
-  // A route can float its view over the ambient home, so the page may carry more
-  // than one `view-header`. When the caller knows the routed view's shell
-  // (`within`), scope to the header INSIDE it so we assert the routed view's
-  // header, not whichever one paints first in the DOM.
-  const header = within
-    ? page.locator(within).getByTestId(VIEW_HEADER_TESTID).first()
-    : page.getByTestId(VIEW_HEADER_TESTID).first();
+  // A route can float its view over the ambient home, so the page may carry
+  // more than one `view-header` — an unscoped .first() could assert the
+  // AMBIENT header and mask a routed view that lost its own. Callers scope by
+  // the routed view's shell (`within`) or by the header's own title text
+  // (`title`) so the assertion binds to the routed view's header.
+  const scoped = within
+    ? page.locator(within).getByTestId(VIEW_HEADER_TESTID)
+    : page.getByTestId(VIEW_HEADER_TESTID);
+  const header = (
+    title ? scoped.filter({ hasText: title }) : scoped
+  ).first();
   await expect(
     header,
     "a normal view must render the shared ViewHeader ([data-testid=view-header])",
@@ -60,22 +65,20 @@ export async function assertSharedViewHeaderContract(
   ).toBe("");
 
   if (requireTapTarget) {
+    // The BUTTON's own box is the hit target (h-11 w-11 with a 36px visual
+    // chip inside — ViewBackButton). Measure the button, no borrowing from
+    // surrounding rows and no clamping: a shrunken control must fail here.
     const box = await back.boundingBox();
     expect(box, "the back control has a measurable box").not.toBeNull();
     if (box) {
-      // The icon button's own box is 36px (h-9 w-9); the effective tap target
-      // extends to the header row (min-h-14). Assert the MEASURED row height —
-      // clamping the measurement to the threshold would make this vacuous.
-      const headerBox = await header.boundingBox();
-      const effectiveHeight = Math.max(box.height, headerBox?.height ?? 0);
       expect(
-        effectiveHeight,
-        `the back control tap target is at least 44px (button ${box.height}px, header row ${headerBox?.height ?? 0}px)`,
+        box.height,
+        `the back control's own tap target is at least 44px tall (got ${box.height})`,
       ).toBeGreaterThanOrEqual(44);
       expect(
         box.width,
-        `the back control tap target is at least 32px wide (got ${box.width})`,
-      ).toBeGreaterThanOrEqual(32);
+        `the back control's own tap target is at least 44px wide (got ${box.width})`,
+      ).toBeGreaterThanOrEqual(44);
     }
   }
 }

--- a/packages/ui/src/components/shared/ViewHeader.test.tsx
+++ b/packages/ui/src/components/shared/ViewHeader.test.tsx
@@ -62,8 +62,19 @@ describe("ViewHeader — standardized normal-view header (#13451)", () => {
     // old `bg-bg` fill that read as a chip).
     expect(back.className).not.toContain("bg-bg ");
     expect(back.className).not.toMatch(/\bbg-bg\b(?!-)/);
-    // Hover/focus is the ONLY place a chip appears.
-    expect(back.className).toContain("hover:bg-bg-hover");
+    // The BUTTON is the hit target and meets the 44px mobile minimum on its
+    // own box (#14152 follow-up: a target borrowed from the surrounding row
+    // is not clickable-by-contract); -m-1 keeps the 36px layout footprint.
+    expect(back.className).toContain("h-11");
+    expect(back.className).toContain("w-11");
+    expect(back.className).toContain("-m-1");
+    // Hover is the ONLY place a chip appears — on the inner 36px visual span,
+    // so the resting/hover appearance is unchanged by the larger hit box.
+    const chip = back.querySelector("span");
+    expect(chip).not.toBeNull();
+    expect(chip?.className).toContain("group-hover:bg-bg-hover");
+    expect(chip?.className).toContain("h-9");
+    expect(chip?.className).toContain("w-9");
     // Icon-only: no visible text label in the button.
     expect(back.textContent?.trim()).toBe("");
   });

--- a/packages/ui/src/components/shared/ViewHeader.tsx
+++ b/packages/ui/src/components/shared/ViewHeader.tsx
@@ -63,6 +63,11 @@ export function ViewBackButton({
     description: "Return to the launcher",
     onActivate: handleBack,
   });
+  // The BUTTON is the hit target and must meet the 44px mobile minimum on its
+  // own box (#13586 / #14152 — a tap target borrowed from the surrounding row
+  // is not clickable-by-contract). h-11 w-11 with -m-1 keeps the 36px layout
+  // footprint; the visual affordance (36px hover chip) lives on the inner span
+  // so the resting/hover appearance is unchanged.
   return (
     <button
       ref={ref}
@@ -70,12 +75,14 @@ export function ViewBackButton({
       onClick={handleBack}
       aria-label={label}
       className={cn(
-        "inline-flex h-9 w-9 items-center justify-center rounded-md bg-transparent text-txt transition-colors hover:bg-bg-hover",
+        "group -m-1 inline-flex h-11 w-11 items-center justify-center bg-transparent text-txt",
         className,
       )}
       {...agentProps}
     >
-      <ArrowLeft className="h-5 w-5" aria-hidden />
+      <span className="inline-flex h-9 w-9 items-center justify-center rounded-md transition-colors group-hover:bg-bg-hover">
+        <ArrowLeft className="h-5 w-5" aria-hidden />
+      </span>
     </button>
   );
 }


### PR DESCRIPTION
Lands both holds from @lalalune's #14178 review (which merged before the rework could ride it):

1. **The back control's own box is now the ≥44px tap target** — `ViewBackButton` becomes `h-11 w-11 -m-1` (44×44 hit box, 36px layout footprint preserved) with the visual 36px hover chip moved to an inner span (`group-hover:bg-bg-hover`). **Zero visual delta** at rest and hover. The sweep helper now measures the button's own `boundingBox()` and requires ≥44px in BOTH dimensions — the row-borrowing `Math.max` is gone; a shrunken control fails, full stop.
2. **The sweep binds to the routed view's header** — `all-pages-clicksafe.spec.ts` gets `viewHeaderWithin`/`viewHeaderTitle` per route: shell-selector scoping for automations/wallet/settings/help, title scoping for the character Skills/Experience deep-links. A routed view that loses its own header can no longer pass against an ambient one.

**Evidence:** [.github/issue-evidence/14152-back-control-hit-target.md](/.github/issue-evidence/14152-back-control-hit-target.md) — ViewHeader.test.tsx **9/9** (updated to pin the new two-layer structure: 44px button box + 36px inner chip), biome clean, explicit N/A rows with reasons (zero-visual-delta by construction; no flow/native/LLM surface touched).

My commit → no self-merge; @lalalune please confirm this closes your #14178 holds + arm. (#13406, #14152) `[maintainer]`