### PR TITLE
fix(#14183): serialize ACP per-worktree git commits to prevent same-worktree clobber

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Proves two concurrent same-worktree ACP sessions (isolate:false) can commit
+ * disjoint staged changes without either clobbering the other (#14183). Drives
+ * the real per-session git wrapper (SESSION_GIT_WRAPPER via prepareSessionGitIndex)
+ * against a real git repo, using a role-gated pre-commit hook to deterministically
+ * park session A between its read-tree and its commit while session B commits.
+ */
+
+import { execFile, execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AcpService } from "../services/acp-service.js";
+import { InMemorySessionStore } from "../services/session-store.js";
+
+function makeRuntime(): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-4000-8000-000000014183",
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    getSetting: () => undefined,
+  } as never;
+}
+
+function git(repo: string, args: string[], env?: NodeJS.ProcessEnv): string {
+  return execFileSync("git", ["-C", repo, ...args], {
+    env: { ...process.env, ...(env ?? {}) },
+    encoding: "utf8",
+  }).trim();
+}
+
+function gitAsync(
+  repo: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<{ code: number; stderr: string }> {
+  return new Promise((resolveRun) => {
+    execFile("git", ["-C", repo, ...args], { env }, (err, _stdout, stderr) => {
+      const code =
+        err && typeof (err as { code?: unknown }).code === "number"
+          ? ((err as { code: number }).code ?? 1)
+          : err
+            ? 1
+            : 0;
+      resolveRun({ code, stderr: stderr ?? "" });
+    });
+  });
+}
+
+async function waitForFile(target: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(target)) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error(`timed out waiting for ${target}`);
+}
+
+type GitIndexPreparer = {
+  prepareSessionGitIndex(
+    workdir: string,
+    sessionId: string,
+    baselineSha?: string,
+  ): Promise<
+    | {
+        env: Record<string, string>;
+        metadata: Record<string, string>;
+      }
+    | undefined
+  >;
+};
+
+describe("ACP per-session commit race on a shared worktree (#14183)", () => {
+  let tmpRoot: string;
+  let repo: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(path.join(os.tmpdir(), "acp-commit-race-"));
+    repo = path.join(tmpRoot, "repo");
+    oldHome = process.env.HOME;
+    process.env.HOME = path.join(tmpRoot, "home");
+
+    git(tmpRoot, ["init", repo]);
+    git(repo, ["config", "user.email", "test@example.com"]);
+    git(repo, ["config", "user.name", "ACP Test"]);
+    writeFileSync(path.join(repo, "README.md"), "base\n");
+    git(repo, ["add", "README.md"]);
+    git(repo, ["commit", "-m", "base"]);
+  });
+
+  afterEach(() => {
+    if (oldHome === undefined) delete process.env.HOME;
+    else process.env.HOME = oldHome;
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("lands both commits when two sessions commit concurrently in one workdir", async () => {
+    const service = new AcpService(makeRuntime(), {
+      store: new InMemorySessionStore(),
+    });
+    const prepare = (
+      service as unknown as GitIndexPreparer
+    ).prepareSessionGitIndex.bind(service);
+
+    const baselineSha = git(repo, ["rev-parse", "HEAD"]);
+    const sessionA = await prepare(repo, "sess-a", baselineSha);
+    const sessionB = await prepare(repo, "sess-b", baselineSha);
+    expect(sessionA?.env.GIT_INDEX_FILE).toBeTruthy();
+    expect(sessionB?.env.GIT_INDEX_FILE).toBeTruthy();
+    expect(sessionA?.env.GIT_INDEX_FILE).not.toBe(sessionB?.env.GIT_INDEX_FILE);
+
+    writeFileSync(path.join(repo, "a.txt"), "from a\n");
+    writeFileSync(path.join(repo, "b.txt"), "from b\n");
+    git(repo, ["add", "a.txt"], sessionA?.env);
+    git(repo, ["add", "b.txt"], sessionB?.env);
+
+    // Role A parks in its pre-commit hook AFTER the wrapper's read-tree HEAD but
+    // BEFORE git records the commit's parent — exactly the window #14183 races.
+    // Role B commits freely during that park, advancing HEAD. Without the
+    // worktree lock, A then commits a tree rebuilt from the stale HEAD and
+    // silently reverts b.txt; with the lock, B blocks until A releases and both
+    // land on a linear history.
+    const signalFile = path.join(tmpRoot, "a-entered-precommit");
+    const hookPath = path.join(repo, ".git", "hooks", "pre-commit");
+    writeFileSync(
+      hookPath,
+      `#!/bin/sh
+if [ "$ACP_TEST_ROLE" = "A" ]; then
+  : > "${signalFile}"
+  sleep 1.5
+fi
+exit 0
+`,
+    );
+    chmodSync(hookPath, 0o755);
+
+    const envA = { ...process.env, ...sessionA?.env, ACP_TEST_ROLE: "A" };
+    const envB = { ...process.env, ...sessionB?.env, ACP_TEST_ROLE: "B" };
+
+    const commitA = gitAsync(repo, ["commit", "-m", "session a"], envA);
+    await waitForFile(signalFile, 10_000);
+    const commitB = gitAsync(repo, ["commit", "-m", "session b"], envB);
+
+    const [resultA, resultB] = await Promise.all([commitA, commitB]);
+    expect(resultA.code, `session a failed: ${resultA.stderr}`).toBe(0);
+    expect(resultB.code, `session b failed: ${resultB.stderr}`).toBe(0);
+
+    const tree = git(repo, ["ls-tree", "--name-only", "-r", "HEAD"]);
+    expect(tree.split("\n").filter(Boolean).sort()).toEqual([
+      "README.md",
+      "a.txt",
+      "b.txt",
+    ]);
+
+    expect(Number(git(repo, ["rev-list", "--count", "HEAD"]))).toBe(3);
+    const parents = git(repo, ["log", "--pretty=%P", "HEAD"]).split("\n");
+    for (const line of parents) {
+      const parentCount = line.trim().split(/\s+/).filter(Boolean).length;
+      expect(parentCount).toBeLessThanOrEqual(1);
+    }
+  }, 30_000);
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -270,6 +270,8 @@ const MAX_CAPTURED_TOOL_OUTPUT_CHARS = 12_000;
 const TOOL_OUTPUT_END_MARKER = "[/tool output]";
 const SESSION_GIT_WRAPPER = `#!/usr/bin/env node
 const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
 const git = process.env.ACP_REAL_GIT || "git";
 const indexFile = process.env.ACP_GIT_INDEX_FILE;
 const baseline = process.env.ACP_GIT_BASELINE_SHA;
@@ -303,14 +305,95 @@ function commandInfo(argv) {
 function run(argv, opts = {}) {
   return spawnSync(git, argv, { stdio: "inherit", env: process.env, ...opts });
 }
+// A per-worktree commit is not one atomic git operation: we read-tree HEAD to
+// rebuild this session's index onto the current tip, replay the staged diff, then
+// git commit re-reads HEAD for the parent. Two sessions sharing one worktree
+// (isolate:false) run this wrapper as two separate processes; if the other's
+// commit lands between our read-tree and our commit, our tree (built from the
+// older HEAD) silently reverts it (#14183). Serialize that window across
+// processes with an exclusive lockfile in the worktree's own git dir (where HEAD
+// lives), so isolated worktrees — which have distinct git dirs and HEADs — never
+// contend, while shared ones can't interleave.
+const LOCK_POLL_MS = 25;
+const LOCK_WAIT_MS = 120000;
+const LOCK_STALE_MS = 300000;
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+function processAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === "EPERM";
+  }
+}
+function lockIsStale(lockPath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(lockPath, "utf8");
+  } catch (err) {
+    if (err.code === "ENOENT") return false;
+    throw err;
+  }
+  const pid = Number.parseInt(raw, 10);
+  if (Number.isInteger(pid) && pid > 0) return !processAlive(pid);
+  let st;
+  try {
+    st = fs.statSync(lockPath);
+  } catch (err) {
+    if (err.code === "ENOENT") return false;
+    throw err;
+  }
+  return Date.now() - st.mtimeMs > LOCK_STALE_MS;
+}
+function resolveGitDir(prefix) {
+  const res = spawnSync(git, [...prefix, "rev-parse", "--absolute-git-dir"], { encoding: "utf8" });
+  if (res.status !== 0) return undefined;
+  const dir = (res.stdout || "").trim();
+  return dir || undefined;
+}
+function acquireCommitLock(gitDir) {
+  const lockPath = path.join(gitDir, "eliza-acp-commit.lock");
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  for (;;) {
+    let fd;
+    try {
+      fd = fs.openSync(lockPath, "wx");
+    } catch (err) {
+      if (err.code !== "EEXIST") throw err;
+      if (lockIsStale(lockPath)) {
+        fs.rmSync(lockPath, { force: true });
+        continue;
+      }
+      if (Date.now() >= deadline) throw new Error("eliza-acp: timed out acquiring commit lock at " + lockPath);
+      sleepSync(LOCK_POLL_MS);
+      continue;
+    }
+    fs.writeSync(fd, String(process.pid));
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      fs.closeSync(fd);
+      fs.rmSync(lockPath, { force: true });
+    };
+    process.on("exit", release);
+    return release;
+  }
+}
 const info = commandInfo(args);
 if (indexFile && baseline && info.cmd === "commit") {
+  // The diff reads only this session's staged index vs its baseline, so it does
+  // not depend on HEAD and stays outside the lock.
   const diff = spawnSync(git, [...info.prefix, "diff", "--cached", "--binary", baseline], {
     env: process.env,
     encoding: "buffer",
     maxBuffer: 64 * 1024 * 1024,
   });
   if (diff.status !== 0) process.exit(diff.status || 1);
+  const gitDir = resolveGitDir(info.prefix);
+  const release = gitDir ? acquireCommitLock(gitDir) : () => {};
   if (diff.stdout.length > 0) {
     const reset = run([...info.prefix, "read-tree", "HEAD"]);
     if (reset.status !== 0) process.exit(reset.status || 1);
@@ -321,6 +404,10 @@ if (indexFile && baseline && info.cmd === "commit") {
     });
     if (apply.status !== 0) process.exit(apply.status || 1);
   }
+  const result = run(args);
+  release();
+  if (result.signal) process.kill(process.pid, result.signal);
+  process.exit(result.status ?? 1);
 }
 const result = run(args);
 if (result.signal) process.kill(process.pid, result.signal);


### PR DESCRIPTION
Fixes #14183.

## Verified defect (real + unfixed on develop)

The per-session ACP git wrapper (`SESSION_GIT_WRAPPER` in `plugins/plugin-agent-orchestrator/src/services/acp-service.ts`) isolates the **index** correctly (`GIT_INDEX_FILE`, landed in #14042), but the **commit** path for a shared (`isolate:false`) worktree was **not atomic wrt `HEAD`**. On `git commit` the wrapper runs four separate `git` processes:

1. `git diff --cached --binary <baseline>` — capture the session's staged changes
2. `git read-tree HEAD` — reset the per-session index to current HEAD
3. `git apply --cached -` — replay the diff onto the HEAD-based index
4. `git commit`

Each `git commit` runs as its **own OS process** (the wrapper node script), so two sessions sharing one worktree have **no lock serializing steps 2→4**. If session B commits (HEAD X→B′) in the window between A's `read-tree HEAD` and A's `git commit`, A rebuilds its tree from the stale HEAD X → it **silently reverts B's changes**, or A's ref-update CAS fails outright and A's work is dropped. (Because the commit is a separate process, an in-process async mutex cannot serialize it — the lock must be cross-process.)

## Fix

Serialize the HEAD-dependent `read-tree → apply → commit` critical section **per worktree** with an exclusive lockfile (`eliza-acp-commit.lock`) placed in the worktree's own git dir (resolved via `git rev-parse --absolute-git-dir` — where `HEAD` actually lives). Because the key is the per-worktree git dir:

- **Shared worktrees** (`isolate:false`) resolve to the same git dir → same lock → commits can't interleave.
- **Isolated worktrees** (`isolate:true`) have distinct git dirs/HEADs → distinct locks → no false contention.

The `git diff` (step 1) reads only the per-session index and stays outside the lock. Stale locks (crashed holder) are reclaimed via PID-liveness (`process.kill(pid, 0)`) plus an mtime backstop, so a dead holder can never wedge the worktree. Every exit path releases the lock (a `process.on("exit")` handler covers the error-exits; the signal-reraise path releases explicitly).

## Regression test — fail-before / pass-after

New `plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts` drives the **real** wrapper (via the real `prepareSessionGitIndex`) against a **real** git repo. It prepares two sessions on one shared workdir, stages `a.txt` into A's index and `b.txt` into B's, then uses a role-gated `pre-commit` hook to deterministically park session A between its `read-tree` and its `commit` while session B commits — exactly the #14183 window. It asserts **both** commits succeed, **both** files are present in the final tree, and history is linear.

**Before (fix reverted):**
```
× lands both commits when two sessions commit concurrently in one workdir
AssertionError: session a failed: fatal: cannot lock ref 'HEAD':
  is at 1b36c517… but expected ce58696e…
  expected 128 to be +0
 Test Files  1 failed (1)
```

**After (fix applied):**
```
 ✓ src/__tests__/acp-git-commit-race.test.ts (1 test) 
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

The existing #14042 isolation test (`acp-git-index-isolation.test.ts`) continues to pass.

## Verification
- `bunx vitest run acp-git-commit-race.test.ts acp-git-index-isolation.test.ts` → **2 passed**
- `biome check` on both changed files → clean
- `tsc -p tsconfig.json` → no errors referencing the changed files (only pre-existing environmental TS7016 for third-party `@types`)
- `bun run audit:error-policy-ratchet` → `no new fallback-slop in touched files` (emptyCatch 3→3, serverConsole 0→0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
