### PR TITLE
fix(#14173): clear ContinuousChatOverlay from view controls in mobile-landscape

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -97,6 +97,7 @@ import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Textarea } from "../ui/textarea";
 import {
+  isShortLandscapeViewport,
   measureSafeAreaInsetTop,
   resolveChatPanelLayout,
 } from "./chat-panel-layout";
@@ -1199,6 +1200,12 @@ export function ContinuousChatOverlay({
   // Invariant: only true while at FULL (sheetOpen && expanded && !pilled); every
   // leave-full transition resets it.
   const [maximized, setMaximized] = React.useState(false);
+  // Reactive composer-focus flag. Only the short-landscape compact resting
+  // affordance reads it (#14173): focusing the field lifts the compact treatment
+  // so the composer widens to full BEFORE the first keystroke, and blurring an
+  // empty composer settles it back to compact. Elsewhere focus is tracked via
+  // refs (composerFocusedAtPressRef) that must not trigger a re-render.
+  const [composerFocused, setComposerFocused] = React.useState(false);
   // Whether the sheet was collapsed when the composer last gained focus — so
   // dismissing the keyboard (tap the handle, tap the scrim, tap outside) returns
   // to the prior resting state (collapsed → input) instead of leaving the sheet
@@ -1804,7 +1811,12 @@ export function ContinuousChatOverlay({
   // reserved when bounding the panel height.
   const readViewport = React.useCallback(() => {
     if (typeof window === "undefined")
-      return { height: 800, keyboardInset: 0, innerHeight: 800 };
+      return {
+        height: 800,
+        keyboardInset: 0,
+        innerHeight: 800,
+        innerWidth: 1280,
+      };
     const vv = window.visualViewport;
     const innerHeight = window.innerHeight;
     const height = vv?.height ?? innerHeight;
@@ -1813,8 +1825,15 @@ export function ContinuousChatOverlay({
       : 0;
     // innerHeight is the LAYOUT viewport: on Android it shrinks (adjustResize)
     // when the keyboard opens, on iOS (`resize: "body"`) it does not. The lift
-    // math below uses that to avoid double-counting the keyboard.
-    return { height, keyboardInset, innerHeight };
+    // math below uses that to avoid double-counting the keyboard. innerWidth +
+    // innerHeight also drive the short-landscape compact treatment (#14173) —
+    // the LAYOUT viewport so a raised keyboard never flips the orientation read.
+    return {
+      height,
+      keyboardInset,
+      innerHeight,
+      innerWidth: window.innerWidth,
+    };
   }, []);
   const [viewport, setViewport] = React.useState(readViewport);
   const [bottomPad, setBottomPad] = React.useState(0);
@@ -1845,7 +1864,8 @@ export function ContinuousChatOverlay({
       const next = readViewport();
       return prev.height === next.height &&
         prev.keyboardInset === next.keyboardInset &&
-        prev.innerHeight === next.innerHeight
+        prev.innerHeight === next.innerHeight &&
+        prev.innerWidth === next.innerWidth
         ? prev
         : next;
     });
@@ -1963,6 +1983,29 @@ export function ContinuousChatOverlay({
   // a stale flag can never leak into half/collapsed/pill. Drives the edge-to-edge
   // panel styles + a zero top margin.
   const fullBleed = maximized && expanded && sheetOpen && !pilled;
+
+  // #14173: on a wide-but-short landscape viewport the bottom-anchored composer
+  // spans nearly the full width (max-w-3xl, centered) as a ~full-width band, and
+  // in the short height that band sits on top of the view's own controls (the
+  // audit's `overlayClearanceIssues`, e.g. builtin-browser). Shrink the RESTING
+  // overlay to a compact bottom-corner affordance so it clears them; the moment
+  // it is opened, focused, composing, or working, the normal centered composer
+  // returns (so the reading/typing surface is never cramped). Portrait phones
+  // and desktop/tablet never satisfy `shortLandscape`, so they are untouched.
+  const shortLandscape = isShortLandscapeViewport(
+    viewport.innerWidth,
+    viewport.innerHeight,
+  );
+  const compactLanding =
+    shortLandscape &&
+    !sheetOpen &&
+    !fullBleed &&
+    !composerFocused &&
+    !hasDraft &&
+    !hasImages &&
+    !recording &&
+    !responding &&
+    !firstRunOpen;
 
   // Top clearance + max height come from the pure, unit-tested layout solver.
   // It reserves the real measured notch inset (`safeAreaTop`) above the panel,
@@ -3523,7 +3566,13 @@ export function ContinuousChatOverlay({
     <div
       ref={overlayRef}
       className={cn(
-        "pointer-events-none fixed inset-x-0 bottom-0 flex w-full min-w-0 flex-col items-center",
+        "pointer-events-none fixed inset-x-0 bottom-0 flex w-full min-w-0 flex-col",
+        // Resting on a landscape phone, the compact composer hugs the trailing
+        // (inline-end) bottom corner — the conventional compose slot views leave
+        // free — instead of centering a wide band over their controls (#14173).
+        // Direction-aware: `items-end` is inline-end, so it lands bottom-left in
+        // RTL. Full-width children (banners) are unaffected (they stay `w-full`).
+        compactLanding ? "items-end" : "items-center",
         // Full-bleed (maximized) removes the side inset so the chat is edge-to-edge.
         fullBleed ? "px-0" : "px-3 sm:px-4",
       )}
@@ -3728,7 +3777,15 @@ export function ContinuousChatOverlay({
       <div
         className={cn(
           "pointer-events-none relative flex w-full flex-col items-center",
-          fullBleed ? "max-w-none" : "max-w-3xl",
+          // Compact resting affordance on a landscape phone (#14173): a narrow
+          // 13rem composer whose overlap with view controls stays under the
+          // audit's clearance threshold. The grabber + pill are positioned
+          // relative to THIS wrapper, so they shrink and re-corner with it.
+          fullBleed
+            ? "max-w-none"
+            : compactLanding
+              ? "max-w-[13rem]"
+              : "max-w-3xl",
         )}
       >
         {!fullBleed ? (
@@ -4321,6 +4378,9 @@ export function ContinuousChatOverlay({
                   if (e.target.value.trim().length > 0) expand();
                 }}
                 onFocus={() => {
+                  // Widen out of the short-landscape compact affordance (#14173)
+                  // on focus, before the first keystroke.
+                  setComposerFocused(true);
                   // A pill-open focus only raises the keyboard; it must not
                   // expand a history thread (see suppressExpandOnFocusRef).
                   if (suppressExpandOnFocusRef.current) {
@@ -4329,6 +4389,7 @@ export function ContinuousChatOverlay({
                     expand();
                   }
                 }}
+                onBlur={() => setComposerFocused(false)}
                 onPaste={handleComposerPaste}
                 onKeyDown={handleComposerKeyDown}
                 // The composer is unlocked during onboarding (#12178): typing is

--- a/packages/ui/src/components/shell/chat-panel-layout.test.ts
+++ b/packages/ui/src/components/shell/chat-panel-layout.test.ts
@@ -5,8 +5,10 @@
 import { describe, expect, it } from "vitest";
 import {
   type ChatPanelLayoutInput,
+  isShortLandscapeViewport,
   resolveChatPanelLayout,
   SHEET_TOP_MARGIN,
+  SHORT_LANDSCAPE_MAX_HEIGHT,
 } from "./chat-panel-layout";
 
 // The overlay is a bottom-anchored fixed element lifted by
@@ -225,5 +227,37 @@ describe("resolveChatPanelLayout", () => {
       fullBleed: false,
     });
     expect(topMargin).toBe(SHEET_TOP_MARGIN);
+  });
+});
+
+describe("isShortLandscapeViewport (#14173)", () => {
+  it("flags the audited landscape-phone viewport (844x390)", () => {
+    // The exact `mobile-landscape` case where the overlay's ~full-width composer
+    // band overlaps view controls in the audit; the compact treatment applies.
+    expect(isShortLandscapeViewport(844, 390)).toBe(true);
+  });
+
+  it("does NOT flag the portrait phone (390x844) — taller than wide", () => {
+    expect(isShortLandscapeViewport(390, 844)).toBe(false);
+  });
+
+  it("does NOT flag desktop (1440x900) or tablet portrait (820x1180)", () => {
+    // Wide but far taller than the ceiling → the normal centered composer stays.
+    expect(isShortLandscapeViewport(1440, 900)).toBe(false);
+    expect(isShortLandscapeViewport(820, 1180)).toBe(false);
+  });
+
+  it("is bounded by the ceiling: at it true, one past it false", () => {
+    expect(isShortLandscapeViewport(900, SHORT_LANDSCAPE_MAX_HEIGHT)).toBe(
+      true,
+    );
+    expect(isShortLandscapeViewport(900, SHORT_LANDSCAPE_MAX_HEIGHT + 1)).toBe(
+      false,
+    );
+  });
+
+  it("rejects degenerate/zero-height viewports", () => {
+    expect(isShortLandscapeViewport(0, 0)).toBe(false);
+    expect(isShortLandscapeViewport(800, 0)).toBe(false);
   });
 });

--- a/packages/ui/src/components/shell/chat-panel-layout.ts
+++ b/packages/ui/src/components/shell/chat-panel-layout.ts
@@ -121,6 +121,35 @@ export function resolveChatPanelLayout(
   return { topMargin, panelMaxH };
 }
 
+// Ceiling (px) for the "short landscape" (landscape-phone) treatment: a viewport
+// wider than tall and no taller than this reads as a landscape phone. 480 clears
+// a landscape iPhone (~390–430 tall) while staying well below every portrait
+// phone (≥667 tall), tablet, and desktop height — so only the cramped
+// landscape-phone case trips it (#14173).
+export const SHORT_LANDSCAPE_MAX_HEIGHT = 480;
+
+/**
+ * True for a wide-but-short viewport (a landscape phone): wider than tall AND no
+ * taller than {@link SHORT_LANDSCAPE_MAX_HEIGHT}. The continuous-chat overlay
+ * shrinks its RESTING footprint to a compact bottom-corner affordance here, so
+ * its otherwise ~full-width composer band stops overlapping the view controls
+ * that pack into the short height (#14173). Portrait phones (taller than wide)
+ * and desktop / tablet (taller than the ceiling) return false and keep the
+ * normal centered composer. Takes the LAYOUT viewport (`window.innerWidth/
+ * innerHeight`), not the keyboard-shrunk visual viewport, so a raised keyboard
+ * never toggles the treatment.
+ */
+export function isShortLandscapeViewport(
+  innerWidth: number,
+  innerHeight: number,
+): boolean {
+  return (
+    innerHeight > 0 &&
+    innerWidth > innerHeight &&
+    innerHeight <= SHORT_LANDSCAPE_MAX_HEIGHT
+  );
+}
+
 /**
  * Measure the resolved `env(safe-area-inset-top)` in CSS px via a throwaway
  * probe. `env()` can't be read off a custom property as a number, so this reads


### PR DESCRIPTION
Closes #14173.

## Problem
The shared `ContinuousChatOverlay` ("Ask Eliza" floating composer, mounted on every GUI view) overlaps view controls in the **mobile-landscape viewport (844×390)** — consistently across ~5 views (the `audit:app` loop-1 `overlayClearanceIssues`). Pre-existing geometry bug in the overlay (not a regression); only the short-landscape viewport is affected.

## Fix
Shrink the at-rest overlay to a small bottom-corner affordance in a **short-landscape** viewport, reverting to the full centered composer the instant it's engaged:
- New pure, unit-tested helper `isShortLandscapeViewport(w, h)` (`chat-panel-layout.ts`, `SHORT_LANDSCAPE_MAX_HEIGHT = 480`) — reads the *layout* viewport so a raised keyboard never toggles it.
- `ContinuousChatOverlay.tsx`: when `shortLandscape && !sheetOpen && !fullBleed && !composerFocused && !hasDraft && !hasImages && !recording && !responding && !firstRunOpen`, the container goes `items-center → items-end` (inline-end corner, RTL-aware) and the panel `max-w-3xl (768px) → max-w-[13rem] (208px)`. Focus/compose/record/respond reverts it to the full composer, so the typing surface is never cramped.

## Why it clears the overlaps without regressing portrait/desktop
At rest the overlay's dominant rect drops from a ~768×60 centered band to a ~208×60 bottom-corner affordance, moving it off the centered view controls and clearing ~60% of the width — dropping the flagged overlaps under the audit's ≥160px²/≥25% threshold. Portrait (taller than wide) and desktop/tablet (height > 480) never satisfy `shortLandscape`, so their layout is unchanged.

## Verification
- `bunx vitest run chat-panel-layout.test.ts` → **17/17 pass** (12 existing + 5 new), incl. the exact 844×390 case + portrait/desktop/boundary/degenerate. Rebased onto develop (incl. #14184's composer changes to the same files) — tests green post-rebase, both changes coexist. Typecheck: no new errors on touched lines; Biome clean.
- **Deferred to CI:** the browser `audit:app` visual re-audit + the React-DOM overlay suites could not run in the local worktree (a pre-existing duplicate-React resolution issue in the symlinked-node_modules worktree — confirmed by an *untouched* UI test failing identically). The geometry decision is driven entirely by the unit-tested helper, so the CI `audit:app` run is the visual confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)