### PR TITLE
fix(ios): make the sim boot-gate lane runnable on Xcode 26 (#13571)

### DIFF
--- a/packages/app/scripts/ios-device-capture.mjs
+++ b/packages/app/scripts/ios-device-capture.mjs
@@ -763,27 +763,27 @@ async function main() {
       ["simctl", "get_app_container", simUdid, bundleId, "data"],
       { label: `reset ${label}: get data container`, required: false },
     );
+    // `simctl listapps` takes the device as its first positional and prints a
+    // NeXTSTEP plist. Xcode 26 dropped the `-j` JSON flag from this subcommand,
+    // so passing `-j` makes simctl read it as the device ("Invalid device: -j")
+    // and JSON.parse on the plist would fail regardless. We only need a presence
+    // proof that the bundle survived the reinstall, so match the bundle key in
+    // the plist text instead of parsing it.
     const listappsRaw = runCaptureCommand(
       "xcrun",
-      ["simctl", "listapps", "-j", simUdid],
+      ["simctl", "listapps", simUdid],
       { label: `reset ${label}: listapps proof` },
     );
-    let listappsEntry = null;
-    try {
-      const parsed = JSON.parse(listappsRaw);
-      listappsEntry = parsed?.[bundleId] ?? null;
-    } catch (error) {
-      fail(
-        `reset ${label}: could not parse simctl listapps proof (${error?.message ?? error})`,
-      );
-    }
-    if (!listappsEntry) {
+    const bundleKey = new RegExp(
+      `"${bundleId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"\\s*=`,
+    );
+    if (!bundleKey.test(listappsRaw)) {
       fail(`reset ${label}: ${bundleId} missing from simctl listapps proof`);
     }
     return {
       appContainer,
       dataContainer,
-      listappsEntry,
+      listappsPresent: true,
     };
   };
 
@@ -868,7 +868,12 @@ async function main() {
       args["only-testing"] ||
       (strictGate ? "AppUITests/BootCaptureUITests" : "AppUITests"),
   });
-  if (!args["only-testing"]) {
+  // The full-matrix coverage guard only applies to the DEFAULT lane that is
+  // meant to run every committed XCUITest class. `--strict-gate` deliberately
+  // narrows the plan to the boot/chat health class (BootCaptureUITests) — a
+  // boot gate is not a coverage gate — so it must not be rejected for "missing"
+  // the gesture/widget/device-extension matrix it was never asked to run.
+  if (!args["only-testing"] && !strictGate) {
     const uncovered = findUncoveredIosXcuitestEntries({
       entries: extractSwiftXcuitestEntries(collectAppUITestsSources()),
       shards: shardPlan.map((shard) => shard.identifier),

--- a/packages/app/scripts/ios-device-lib.mjs
+++ b/packages/app/scripts/ios-device-lib.mjs
@@ -921,7 +921,12 @@ export function findUncoveredIosXcuitestEntries({ entries, shards }) {
 }
 
 export function isBenignIosAppAbsence(output) {
-  return /not installed|not found|no such app|unknown application|does not exist|could not find/i.test(
+  // simctl reports an absent app differently per verb: uninstall/get-container
+  // say "not installed"/"could not find", while `terminate` against an app that
+  // is not currently running exits non-zero with "found nothing to terminate".
+  // For a fresh-container reset all of these mean the same benign thing — there
+  // was nothing to clean up — so the reset must not treat them as failures.
+  return /not installed|not found|no such app|unknown application|does not exist|could not find|found nothing to terminate|no matching processes|not currently running/i.test(
     String(output ?? ""),
   );
 }

--- a/packages/app/scripts/ios-device-lib.test.mjs
+++ b/packages/app/scripts/ios-device-lib.test.mjs
@@ -1317,6 +1317,20 @@ describe("buildIosXcuitestShardPlan (#13686)", () => {
       false,
     );
   });
+
+  it("treats a terminate of a not-running app as benign (fresh-container reset)", () => {
+    // `simctl terminate <udid> <bundle>` exits non-zero with this message when
+    // the app is installed but not currently running — the exact state a
+    // per-shard reset hits when it terminates before uninstalling (#13571).
+    expect(
+      isBenignIosAppAbsence(
+        'The request to terminate "ai.elizaos.app" failed. found nothing to terminate',
+      ),
+    ).toBe(true);
+    expect(isBenignIosAppAbsence("No matching processes belonging to you")).toBe(
+      true,
+    );
+  });
 });
 
 describe("evaluateRunnerStaleness (#13566)", () => {


### PR DESCRIPTION
## What

The strict iOS simulator boot-gate (`test:e2e:ios:boot-gate`) **aborted before running any test on Xcode 26**, so it could not gate boot health at all — the core complaint in #13571. Three concrete defects in the capture harness:

1. **`simctl listapps -j <udid>` → `Invalid device: -j` (exit 148).** Xcode 26 dropped the `-j` flag from `listapps`, so simctl read `-j` as the device positional; and the output is a NeXTSTEP plist that `JSON.parse` would reject regardless. Fixed to `simctl listapps <udid>` + a plist bundle-key presence match.
2. **`isBenignIosAppAbsence` missed `terminate`’s wording.** `simctl terminate` of a not-running app exits non-zero with *"found nothing to terminate"*, which the per-shard fresh-container reset hard-failed on. Added that (and `no matching processes` / `not currently running`) to the benign set.
3. **Coverage guard fired under `--strict-gate`.** Strict-gate deliberately narrows to `BootCaptureUITests` (boot/chat health); the full-matrix XCTest coverage guard then rejected it for "missing" the gesture/widget matrix. A boot gate is not a coverage gate — the guard now skips when strict-gate narrowed the plan.

## Evidence (real iPhone 16 Plus simulator, Xcode 26.4.1)

- Built the sim app end-to-end (web → cap sync → xcodebuild, all 5 appexes) and confirmed a **healthy boot** to the cloud onboarding chat surface (screenshot + os_log; no `Startup failed:` error card).
- **Before the fix:** the lane aborted with `simctl listapps -j` → `Invalid device: -j`, `simctl terminate … found nothing to terminate`, and `default AppUITests shard plan is missing committed XCTest coverage`.
- **After the fix:** `AppUITests.BootCaptureUITests testBootReachesHomeOrErrorCard` runs **green end-to-end** — `Test Case … passed (5.198 seconds)`, `** TEST EXECUTE SUCCEEDED **`, `iOS capture PASSED: 1 shard(s) completed with fresh containers`, exit 0. `--strict-gate` (no `--only-testing`) now reaches `xcuitest shards: 1 (AppUITests/BootCaptureUITests)` instead of aborting (coverage-guard aborts: 0).
- Unit tests: `packages/app/scripts/ios-device-lib.test.mjs` **91 passed** (incl. a new case pinning the terminate-absence classification).

Video walkthrough / desktop screenshots: N/A — this is a CI test-harness script fix (no product UI change). The relevant rendered proof (the healthy boot the gate now checks) is the sim screenshot on #13571.

Closes part of #13571; unblocks the sim leg of #13573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)