### PR TITLE
chore(app): remove duplicate build stamp test

### DIFF
--- a/packages/app/scripts/build.test.mjs
+++ b/packages/app/scripts/build.test.mjs
@@ -105,15 +105,4 @@ describe("shouldSkipBuildStamp", () => {
     expect(bundle).toEqual({ "assets/app.js": { type: "chunk" } });
   });
 
-  it("removes emitted build-info assets from Vite production bundles", () => {
-    const bundle = {
-      "assets/app.js": { type: "chunk" },
-      "build-info.json": { type: "asset" },
-      "/build-info.json": { type: "asset" },
-    };
-
-    removeEmittedBuildStamp(bundle);
-
-    expect(bundle).toEqual({ "assets/app.js": { type: "chunk" } });
-  });
 });


### PR DESCRIPTION
## Summary

Removes the duplicate `removes emitted build-info assets from Vite production bundles` test block that landed in #14201 after the PR was merged externally.

No production code changes.

## Verification

- `bun run --cwd packages/app test -- scripts/build.test.mjs` — 1 file / 8 tests passed
- `git diff --check` — passed

## Evidence

- UI screenshots/video: N/A - test-only cleanup with no rendered UI behavior change.
- Frontend/backend logs: N/A - no runtime path changed.
- Real-LLM trajectories: N/A - no agent/model/prompt behavior changed.
- Native/device artifacts: N/A - no native/device behavior changed.
