### PR TITLE
fix(theme): re-tokenize cloud Applications + MCPs surfaces for light theme (#14203)

### DIFF
--- a/packages/ui/src/cloud/applications/ApplicationsPage.tsx
+++ b/packages/ui/src/cloud/applications/ApplicationsPage.tsx
@@ -55,7 +55,7 @@ export default function ApplicationsPage() {
               defaultValue: "Total Users",
             })}
             value={totalUsers.toLocaleString()}
-            icon={<Users className="h-5 w-5 text-white/70" />}
+            icon={<Users className="h-5 w-5 text-muted" />}
           />
           <DashboardStatCard
             label={t("cloud.apps.stat.totalRequests", {

--- a/packages/ui/src/cloud/applications/NativeAppsStudio.tsx
+++ b/packages/ui/src/cloud/applications/NativeAppsStudio.tsx
@@ -219,8 +219,8 @@ function StudioBootFallback(): React.JSX.Element {
  * Opaque dark cloud surface for the native mount. The Applications pages are
  * authored against the cloud console's dark theme (`theme-cloud` tokens, white
  * text, `white/10` borders); on web `CloudRouterShell` mounts that surface
- * around every authenticated route (`theme-cloud min-h-dvh bg-black
- * text-white`). The native app shell instead renders registered pages over the
+ * around every authenticated route (`theme-cloud min-h-dvh bg-surface
+ * text-txt`). The native app shell instead renders registered pages over the
  * HOST app theme (light/orange), so without this wrapper the studio floods
  * with the host background and its white-on-dark text is unreadable. Sized to
  * fill the shell's flex slot and own its scrolling.
@@ -231,7 +231,7 @@ function StudioSurface({
   children: ReactNode;
 }): React.JSX.Element {
   return (
-    <div className="theme-cloud flex h-full min-h-0 w-full flex-col overflow-y-auto bg-black text-white">
+    <div className="theme-cloud flex h-full min-h-0 w-full flex-col overflow-y-auto bg-surface text-txt">
       {children}
     </div>
   );

--- a/packages/ui/src/cloud/applications/components/BuyDomainCard.tsx
+++ b/packages/ui/src/cloud/applications/components/BuyDomainCard.tsx
@@ -171,7 +171,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
   return (
     <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
       <div>
-        <h3 className="text-sm font-medium text-white flex items-center gap-2">
+        <h3 className="text-sm font-medium text-txt flex items-center gap-2">
           <ShoppingCart className="h-4 w-4 text-[var(--accent)]" />
           {t("cloud.appDomains.buyTitle", { defaultValue: "Buy a Domain" })}
         </h3>
@@ -199,7 +199,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
           aria-label={t("cloud.appDomains.buyInputLabel", {
             defaultValue: "Domain to buy",
           })}
-          className="bg-black/40 border-neutral-800 text-white"
+          className="bg-surface border-neutral-800 text-txt"
           autoCapitalize="none"
           autoCorrect="off"
           spellCheck={false}
@@ -222,7 +222,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
       </form>
 
       {result && !result.available && (
-        <div className="flex items-center gap-2 p-3 rounded-sm bg-black/40 text-sm text-neutral-300">
+        <div className="flex items-center gap-2 p-3 rounded-sm bg-surface text-sm text-neutral-300">
           <XCircle className="h-4 w-4 text-neutral-500 shrink-0" />
           <span>
             {t("cloud.appDomains.buyTaken", {
@@ -234,11 +234,11 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
       )}
 
       {result?.available && result.price && (
-        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-3 rounded-sm bg-black/40">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-3 rounded-sm bg-surface">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
               <CheckCircle2 className="h-4 w-4 text-[var(--accent)] shrink-0" />
-              <span className="text-sm font-medium text-white truncate">
+              <span className="text-sm font-medium text-txt truncate">
                 {result.domain}
               </span>
             </div>
@@ -327,7 +327,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
               size="sm"
               variant="outline"
               onClick={openBilling}
-              className="self-start border-neutral-700 hover:bg-white/5"
+              className="self-start border-neutral-700 hover:bg-surface"
             >
               <CreditCard className="h-4 w-4 mr-1.5" />
               {t("cloud.appDomains.buyAddCredits", {

--- a/packages/ui/src/cloud/applications/components/app-analytics.tsx
+++ b/packages/ui/src/cloud/applications/components/app-analytics.tsx
@@ -382,8 +382,8 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                 className={cn(
                   "flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-sm transition-colors whitespace-nowrap",
                   activeTab === tab.value
-                    ? "bg-white/10 text-white"
-                    : "text-neutral-400 hover:text-white",
+                    ? "bg-surface text-txt"
+                    : "text-neutral-400 hover:text-txt",
                 )}
               >
                 <Icon className="h-4 w-4" />
@@ -401,10 +401,10 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                 setPeriod(v)
               }
             >
-              <SelectTrigger className="w-[130px] h-9 bg-neutral-900 border-white/10 rounded-sm">
+              <SelectTrigger className="w-[130px] h-9 bg-neutral-900 border-border rounded-sm">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent className="bg-neutral-800 border-white/10 rounded-sm">
+              <SelectContent className="bg-neutral-800 border-border rounded-sm">
                 <SelectItem value="hourly">Hourly</SelectItem>
                 <SelectItem value="daily">Daily</SelectItem>
                 <SelectItem value="monthly">Monthly</SelectItem>
@@ -443,7 +443,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
               <DashboardStatCard
                 label="Total Users"
                 value={totalStats.totalUsers?.toLocaleString("en-US") || "0"}
-                icon={<Users className="h-5 w-5 text-white/70" />}
+                icon={<Users className="h-5 w-5 text-muted" />}
               />
               <DashboardStatCard
                 label="Credits Used"
@@ -454,7 +454,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
           )}
 
           <div className="bg-neutral-900 rounded-sm p-4">
-            <h3 className="text-sm font-medium text-white mb-4 flex items-center gap-2">
+            <h3 className="text-sm font-medium text-txt mb-4 flex items-center gap-2">
               <BarChart3 className="h-4 w-4 text-[var(--brand-orange)]" />
               Requests Over Time
             </h3>
@@ -500,7 +500,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
           </div>
 
           <div className="bg-neutral-900 rounded-sm p-4">
-            <h3 className="text-sm font-medium text-white mb-4">User Growth</h3>
+            <h3 className="text-sm font-medium text-txt mb-4">User Growth</h3>
             {chartData.length > 0 ? (
               <ResponsiveContainer width="100%" height={250}>
                 <BarChart data={chartData}>
@@ -571,7 +571,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                 <MiniStatCard
                   label="Unique Visitors"
                   value={requestStats.uniqueIps.toLocaleString("en-US")}
-                  color="text-white"
+                  color="text-txt"
                 />
                 <MiniStatCard
                   label="Avg Response"
@@ -580,18 +580,18 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                       ? `${requestStats.avgResponseTime}ms`
                       : "N/A"
                   }
-                  color="text-white"
+                  color="text-txt"
                 />
                 <MiniStatCard
                   label="Total Credits"
                   value={`$${parseFloat(requestStats.totalCredits || "0").toFixed(4)}`}
-                  color="text-white"
+                  color="text-txt"
                 />
               </div>
 
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="bg-neutral-900 rounded-sm p-4">
-                  <h3 className="text-sm font-medium text-white mb-4">
+                  <h3 className="text-sm font-medium text-txt mb-4">
                     By Source
                   </h3>
                   {sourceData.length > 0 ? (
@@ -638,7 +638,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                 </div>
 
                 <div className="bg-neutral-900 rounded-sm p-4">
-                  <h3 className="text-sm font-medium text-white mb-4">
+                  <h3 className="text-sm font-medium text-txt mb-4">
                     By Type
                   </h3>
                   {Object.keys(requestStats.byType).length > 0 ? (
@@ -659,7 +659,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                               {TYPE_LABELS[type] || type}
                             </span>
                             <div className="flex items-center gap-2">
-                              <div className="w-24 h-1.5 bg-white/10 rounded-full overflow-hidden">
+                              <div className="w-24 h-1.5 bg-surface rounded-full overflow-hidden">
                                 <div
                                   className="h-full rounded-full"
                                   style={{
@@ -714,7 +714,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                   <DashboardStatCard
                     label="Unique Users"
                     value={requestStats.uniqueUsers.toLocaleString("en-US")}
-                    icon={<Users className="h-5 w-5 text-white/70" />}
+                    icon={<Users className="h-5 w-5 text-muted" />}
                   />
                   <DashboardStatCard
                     label="Avg Requests/IP"
@@ -732,7 +732,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
 
               <div className="bg-neutral-900 rounded-sm p-4">
                 <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-sm font-medium text-white">
+                  <h3 className="text-sm font-medium text-txt">
                     Top Visitors
                   </h3>
                   <Button
@@ -751,7 +751,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                   <div className="overflow-x-auto">
                     <table className="w-full text-sm">
                       <thead>
-                        <tr className="border-b border-white/10">
+                        <tr className="border-b border-border">
                           <th className="text-left py-2 px-3 text-neutral-500 font-medium text-xs">
                             IP Address
                           </th>
@@ -767,19 +767,19 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                         {visitors.map((visitor, index) => (
                           <tr
                             key={visitor.ip}
-                            className="border-b border-white/5 hover:bg-white/5"
+                            className="border-b border-border hover:bg-surface"
                           >
                             <td className="py-2 px-3">
                               <div className="flex items-center gap-2">
                                 <span className="text-neutral-500 text-xs w-4">
                                   {index + 1}
                                 </span>
-                                <code className="text-white font-mono text-xs">
+                                <code className="text-txt font-mono text-xs">
                                   {visitor.ip}
                                 </code>
                               </div>
                             </td>
-                            <td className="py-2 px-3 text-right text-white text-xs">
+                            <td className="py-2 px-3 text-right text-txt text-xs">
                               {visitor.requestCount.toLocaleString("en-US")}
                             </td>
                             <td className="py-2 px-3 text-right text-neutral-500 text-xs">
@@ -825,7 +825,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                   value={sessionAnalytics.summary.uniqueVisitors.toLocaleString(
                     "en-US",
                   )}
-                  color="text-white"
+                  color="text-txt"
                 />
                 <MiniStatCard
                   label="Page Views"
@@ -837,18 +837,18 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                 <MiniStatCard
                   label="Pages/Session"
                   value={sessionAnalytics.summary.avgPagesPerSession.toFixed(1)}
-                  color="text-white"
+                  color="text-txt"
                 />
                 <MiniStatCard
                   label="Bounce Rate"
                   value={`${sessionAnalytics.summary.bounceRatePercent.toFixed(1)}%`}
-                  color="text-white"
+                  color="text-txt"
                 />
               </div>
 
               <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
                 <div className="bg-neutral-900 rounded-sm p-4">
-                  <h3 className="text-sm font-medium text-white mb-4 flex items-center gap-2">
+                  <h3 className="text-sm font-medium text-txt mb-4 flex items-center gap-2">
                     <GitBranch className="h-4 w-4 text-[var(--brand-orange)]" />
                     Funnel
                   </h3>
@@ -857,14 +857,14 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                       {sessionAnalytics.funnel.steps.map((step) => (
                         <div key={step.path} className="space-y-1.5">
                           <div className="flex items-center justify-between gap-3">
-                            <span className="text-sm text-white truncate">
+                            <span className="text-sm text-txt truncate">
                               {step.label}
                             </span>
                             <span className="text-xs text-neutral-400 whitespace-nowrap">
                               {step.sessions.toLocaleString("en-US")} sessions
                             </span>
                           </div>
-                          <div className="h-2 bg-white/10 rounded-full overflow-hidden">
+                          <div className="h-2 bg-surface rounded-full overflow-hidden">
                             <div
                               className="h-full bg-[var(--brand-orange)]"
                               style={{
@@ -892,14 +892,14 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                 </div>
 
                 <div className="bg-neutral-900 rounded-sm p-4">
-                  <h3 className="text-sm font-medium text-white mb-4">
+                  <h3 className="text-sm font-medium text-txt mb-4">
                     Recent Sessions
                   </h3>
                   {sessionAnalytics.sessions.length > 0 ? (
                     <div className="overflow-x-auto">
                       <table className="w-full text-sm">
                         <thead>
-                          <tr className="border-b border-white/10">
+                          <tr className="border-b border-border">
                             <th className="text-left py-2 px-3 text-neutral-500 font-medium text-xs">
                               Entry
                             </th>
@@ -918,15 +918,15 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                           {sessionAnalytics.sessions.slice(0, 10).map((s) => (
                             <tr
                               key={s.sessionId}
-                              className="border-b border-white/5 hover:bg-white/5"
+                              className="border-b border-border hover:bg-surface"
                             >
-                              <td className="py-2 px-3 text-white text-xs max-w-[180px] truncate">
+                              <td className="py-2 px-3 text-txt text-xs max-w-[180px] truncate">
                                 {s.entryPath}
                               </td>
                               <td className="py-2 px-3 text-neutral-300 text-xs max-w-[180px] truncate">
                                 {s.exitPath}
                               </td>
-                              <td className="py-2 px-3 text-right text-white text-xs">
+                              <td className="py-2 px-3 text-right text-txt text-xs">
                                 {s.pageViews.toLocaleString("en-US")}
                               </td>
                               <td className="py-2 px-3 text-right text-neutral-500 text-xs whitespace-nowrap">
@@ -959,7 +959,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
       {activeTab === "logs" && (
         <div className="bg-neutral-900 rounded-sm p-4">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-sm font-medium text-white">Request Logs</h3>
+            <h3 className="text-sm font-medium text-txt">Request Logs</h3>
             <div className="flex items-center gap-2">
               <span className="text-xs text-neutral-500">
                 {logsTotal.toLocaleString("en-US")} total
@@ -987,7 +987,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
               <div className="overflow-x-auto">
                 <table className="w-full text-xs">
                   <thead>
-                    <tr className="border-b border-white/10">
+                    <tr className="border-b border-border">
                       <th className="text-left py-2 px-2 text-neutral-500 font-medium">
                         Time
                       </th>
@@ -1012,7 +1012,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                     {requestLogs.map((log) => (
                       <tr
                         key={log.id}
-                        className="border-b border-white/5 hover:bg-white/5"
+                        className="border-b border-border hover:bg-surface"
                       >
                         <td className="py-2 px-2 text-neutral-500 whitespace-nowrap">
                           {formatDistanceToNow(new Date(log.created_at), {

--- a/packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx
+++ b/packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx
@@ -180,14 +180,14 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
     return (
       <div className="bg-neutral-900 rounded-sm p-8 text-center">
         <AlertCircle className="h-12 w-12 mx-auto mb-4 text-red-400" />
-        <h3 className="text-lg font-medium text-white mb-2">
+        <h3 className="text-lg font-medium text-txt-strong mb-2">
           Error loading earnings
         </h3>
         <p className="text-neutral-400 mb-4 text-sm">{error}</p>
         <Button
           onClick={fetchEarnings}
           variant="outline"
-          className="border-white/10 hover:bg-white/10"
+          className="border-border hover:bg-surface"
         >
           Try Again
         </Button>
@@ -217,10 +217,10 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
           value={period}
           onValueChange={(v) => setPeriod(v as typeof period)}
         >
-          <SelectTrigger className="w-[140px] h-9 bg-neutral-900 border-white/10 rounded-sm">
+          <SelectTrigger className="w-[140px] h-9 bg-neutral-900 border-border rounded-sm">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent className="bg-neutral-800 border-white/10 rounded-sm">
+          <SelectContent className="bg-neutral-800 border-border rounded-sm">
             <SelectItem value="7">Last 7 days</SelectItem>
             <SelectItem value="30">Last 30 days</SelectItem>
             <SelectItem value="90">Last 90 days</SelectItem>
@@ -267,7 +267,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
                 <p className="text-xs text-neutral-500">
                   Total Lifetime Earnings
                 </p>
-                <p className="text-2xl font-semibold text-white mt-1">
+                <p className="text-2xl font-semibold text-txt-strong mt-1">
                   ${summary.totalLifetimeEarnings.toFixed(2)}
                 </p>
                 {breakdown && (
@@ -302,7 +302,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
                 <Button
                   onClick={() => setShowWithdrawDialog(true)}
                   size="sm"
-                  className="w-full bg-green-600 hover:bg-green-500 text-white"
+                  className="w-full bg-green-600 hover:bg-green-500 text-txt"
                 >
                   <Wallet className="h-4 w-4 mr-2" />
                   Withdraw Now
@@ -360,7 +360,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
           ].map(({ label, data }) => (
             <div key={label} className="bg-neutral-900 rounded-sm p-3">
               <p className="text-xs text-neutral-500">{label}</p>
-              <p className="text-lg font-semibold text-white mt-1">
+              <p className="text-lg font-semibold text-txt-strong mt-1">
                 ${data.total.toFixed(2)}
               </p>
               <div className="flex gap-3 text-xs mt-2">
@@ -380,7 +380,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
 
       {/* Chart */}
       <div className="bg-neutral-900 rounded-sm p-4">
-        <h3 className="text-sm font-medium text-white mb-4 flex items-center gap-2">
+        <h3 className="text-sm font-medium text-txt mb-4 flex items-center gap-2">
           <BarChart3 className="h-4 w-4 text-neutral-400" />
           Earnings Over Time
         </h3>
@@ -443,7 +443,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
 
       {/* Recent Transactions */}
       <div className="bg-neutral-900 rounded-sm p-4">
-        <h3 className="text-sm font-medium text-white mb-4 flex items-center gap-2">
+        <h3 className="text-sm font-medium text-txt mb-4 flex items-center gap-2">
           <Clock className="h-4 w-4 text-neutral-400" />
           Recent Earnings
         </h3>
@@ -453,12 +453,12 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
             {transactions.map((tx) => (
               <div
                 key={tx.id}
-                className="flex items-center justify-between p-3 bg-black/30 rounded-sm border border-white/5 hover:border-white/10 transition-colors"
+                className="flex items-center justify-between p-3 bg-surface rounded-sm border border-border hover:border-border transition-colors"
               >
                 <div className="flex items-center gap-3">
                   <TransactionIcon type={tx.type} />
                   <div>
-                    <p className="text-sm text-white">{tx.description}</p>
+                    <p className="text-sm text-txt">{tx.description}</p>
                     <p className="text-xs text-neutral-500">
                       {formatDistanceToNow(new Date(tx.created_at), {
                         addSuffix: true,
@@ -544,7 +544,7 @@ function TransactionBadge({ type }: { type: string }) {
       );
     default:
       return (
-        <Badge className="bg-white/10 text-neutral-400 border-white/20 text-[10px]">
+        <Badge className="bg-surface text-neutral-400 border-border text-[10px]">
           {type}
         </Badge>
       );

--- a/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
+++ b/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
@@ -292,24 +292,24 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
   return (
     <TooltipProvider>
       <div className="space-y-4">
-        <div className="border border-white/10 bg-neutral-900 p-4">
+        <div className="border border-border bg-neutral-900 p-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-start gap-3">
               <div
                 className={cn(
                   "mt-0.5 rounded-sm p-2",
-                  reviewApproved ? "bg-green-500/10" : "bg-white/5",
+                  reviewApproved ? "bg-green-500/10" : "bg-surface",
                 )}
               >
                 <ShieldCheck
                   className={cn(
                     "h-5 w-5",
-                    reviewApproved ? "text-green-400" : "text-white/50",
+                    reviewApproved ? "text-green-400" : "text-muted",
                   )}
                 />
               </div>
               <div className="min-w-0">
-                <p className="text-sm font-medium text-white">
+                <p className="text-sm font-medium text-txt">
                   {getReviewStatusLabel(reviewStatus, t)}
                 </p>
                 <p className="mt-1 text-xs text-neutral-500">
@@ -335,7 +335,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                 type="button"
                 onClick={submitForReview}
                 disabled={isSubmittingReview}
-                className="shrink-0 bg-[var(--brand-orange)] text-white hover:bg-[#e54f00]"
+                className="shrink-0 bg-[var(--brand-orange)] text-txt hover:bg-[#e54f00]"
               >
                 {isSubmittingReview ? (
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -356,14 +356,14 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
             "rounded-sm p-4 border transition-colors",
             settings.monetizationEnabled
               ? "bg-green-500/5 border-green-500/20"
-              : "bg-neutral-900 border-white/10",
+              : "bg-neutral-900 border-border",
           )}
         >
           <div className="flex items-start gap-3">
             <div
               className={cn(
                 "p-2 rounded-sm mt-0.5",
-                settings.monetizationEnabled ? "bg-green-500/10" : "bg-white/5",
+                settings.monetizationEnabled ? "bg-green-500/10" : "bg-surface",
               )}
             >
               <DollarSign
@@ -371,13 +371,13 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                   "h-5 w-5",
                   settings.monetizationEnabled
                     ? "text-green-400"
-                    : "text-white/40",
+                    : "text-muted",
                 )}
               />
             </div>
             <div className="flex-1">
               <div className="flex items-center justify-between">
-                <p className="text-sm font-medium text-white">
+                <p className="text-sm font-medium text-txt">
                   {settings.monetizationEnabled
                     ? t("cloud.monetization.active", {
                         defaultValue: "Monetization Active",
@@ -421,7 +421,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                   onClick={() =>
                     navigate(`/dashboard/apps/${appId}?tab=earnings`)
                   }
-                  className="mt-2 text-xs text-white/60 hover:text-white transition-colors flex items-center gap-1"
+                  className="mt-2 text-xs text-muted hover:text-txt transition-colors flex items-center gap-1"
                 >
                   {t("cloud.monetization.earned", {
                     amount: settings.totalCreatorEarnings.toFixed(2),
@@ -438,7 +438,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
         <div className="grid gap-4 lg:grid-cols-2">
           {/* Markup Controls */}
           <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
-            <h3 className="text-sm font-medium text-white">
+            <h3 className="text-sm font-medium text-txt">
               {t("cloud.monetization.revenueSettings", {
                 defaultValue: "Revenue Settings",
               })}
@@ -448,7 +448,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                  <span className="text-sm text-white">
+                  <span className="text-sm text-txt">
                     {t("cloud.monetization.inferenceMarkup", {
                       defaultValue: "Inference Markup",
                     })}
@@ -459,7 +459,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                     </TooltipTrigger>
                     <TooltipContent
                       side="right"
-                      className="max-w-[200px] bg-neutral-800 border-white/10 text-white"
+                      className="max-w-[200px] bg-neutral-800 border-border text-txt"
                     >
                       {t("cloud.monetization.inferenceMarkupTooltip", {
                         defaultValue:
@@ -492,7 +492,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                       "px-2.5 py-1 text-xs rounded-sm transition-colors",
                       settings.inferenceMarkupPercentage === preset
                         ? "bg-purple-500/20 text-purple-400 border border-purple-500/30"
-                        : "bg-white/5 text-neutral-400 hover:bg-white/10 border border-transparent",
+                        : "bg-surface text-neutral-400 hover:bg-surface border border-transparent",
                     )}
                     onClick={() =>
                       updateSetting("inferenceMarkupPercentage", preset)
@@ -504,13 +504,13 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
               </div>
             </div>
 
-            <div className="h-px bg-white/10" />
+            <div className="h-px bg-surface" />
 
             {/* Purchase Share */}
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                  <span className="text-sm text-white">
+                  <span className="text-sm text-txt">
                     {t("cloud.monetization.purchaseShare", {
                       defaultValue: "Purchase Share",
                     })}
@@ -521,7 +521,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                     </TooltipTrigger>
                     <TooltipContent
                       side="right"
-                      className="max-w-[200px] bg-neutral-800 border-white/10 text-white"
+                      className="max-w-[200px] bg-neutral-800 border-border text-txt"
                     >
                       {t("cloud.monetization.purchaseShareTooltip", {
                         defaultValue:
@@ -553,8 +553,8 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                     className={cn(
                       "px-2.5 py-1 text-xs rounded-sm transition-colors",
                       settings.purchaseSharePercentage === preset
-                        ? "bg-orange-500/20 text-white border border-orange-500/30"
-                        : "bg-white/5 text-neutral-400 hover:bg-white/10 border border-transparent",
+                        ? "bg-orange-500/20 text-txt border border-orange-500/30"
+                        : "bg-surface text-neutral-400 hover:bg-surface border border-transparent",
                     )}
                     onClick={() =>
                       updateSetting("purchaseSharePercentage", preset)
@@ -571,7 +571,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
               <Button
                 onClick={handleSave}
                 disabled={!hasChanges || isSaving}
-                className="w-full bg-[var(--brand-orange)] hover:bg-[#e54f00] text-white disabled:bg-white/5 disabled:text-white/30"
+                className="w-full bg-[var(--brand-orange)] hover:bg-[#e54f00] text-txt disabled:bg-surface disabled:text-muted"
               >
                 {isSaving ? (
                   <Loader2 className="h-4 w-4 animate-spin mr-2" />
@@ -603,9 +603,9 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
 
         {/* Enable Monetization Confirmation Dialog */}
         <AlertDialog open={showEnableDialog} onOpenChange={setShowEnableDialog}>
-          <AlertDialogContent className="bg-neutral-900 border-white/10">
+          <AlertDialogContent className="bg-neutral-900 border-border">
             <AlertDialogHeader>
-              <AlertDialogTitle className="text-white text-center sm:text-left">
+              <AlertDialogTitle className="text-txt text-center sm:text-left">
                 {t("cloud.monetization.enableDialogTitle", {
                   defaultValue: "Enable Monetization?",
                 })}
@@ -645,7 +645,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
               </p>
             </div>
             <AlertDialogFooter className="gap-2 sm:gap-2">
-              <AlertDialogCancel className="border-0 bg-transparent text-neutral-400 hover:text-white hover:bg-transparent">
+              <AlertDialogCancel className="border-0 bg-transparent text-neutral-400 hover:text-txt hover:bg-transparent">
                 {t("cloud.monetization.cancel", { defaultValue: "Cancel" })}
               </AlertDialogCancel>
               <AlertDialogAction
@@ -653,7 +653,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                   toggleMonetization(true);
                   setShowEnableDialog(false);
                 }}
-                className="bg-[var(--brand-orange)] hover:bg-[#e54f00] text-white px-6"
+                className="bg-[var(--brand-orange)] hover:bg-[#e54f00] text-txt px-6"
               >
                 {t("cloud.monetization.startEarning", {
                   defaultValue: "Start Earning",
@@ -720,12 +720,12 @@ function SelfHostCTA() {
           <Server className="h-5 w-5 text-[var(--brand-orange)]" />
         </div>
         <div className="flex-1 min-w-0">
-          <h3 className="text-base font-mono text-white mb-1">
+          <h3 className="text-base font-mono text-txt mb-1">
             {t("cloud.monetization.selfHostTitle", {
               defaultValue: "Let this app host itself.",
             })}
           </h3>
-          <p className="text-sm text-white/60 mb-3">
+          <p className="text-sm text-muted mb-3">
             {t("cloud.monetization.selfHostDesc", {
               defaultValue:
                 "Deploy as a container — daily hosting bills are paid from your app earnings first, then your credits. No setup, no settings. Cashout still works whenever you want.",
@@ -741,7 +741,7 @@ function SelfHostCTA() {
                   e.preventDefault();
                 }
               }}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-[var(--brand-orange)] hover:bg-[#e54f00] text-white text-sm font-mono transition-colors"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-[var(--brand-orange)] hover:bg-[#e54f00] text-txt text-sm font-mono transition-colors"
             >
               <Server className="h-4 w-4" />
               {t("cloud.monetization.deployAgent", {
@@ -757,7 +757,7 @@ function SelfHostCTA() {
                   e.preventDefault();
                 }
               }}
-              className="inline-flex items-center gap-2 px-4 py-2 text-white/80 hover:bg-foreground hover:text-background text-sm font-mono transition-colors"
+              className="inline-flex items-center gap-2 px-4 py-2 text-muted hover:bg-foreground hover:text-background text-sm font-mono transition-colors"
             >
               <Coins className="h-4 w-4" />
               {t("cloud.monetization.viewEarnings", {

--- a/packages/ui/src/cloud/applications/components/app-overview.tsx
+++ b/packages/ui/src/cloud/applications/components/app-overview.tsx
@@ -329,29 +329,29 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
           <div className="flex items-start gap-3">
             <Key className="h-5 w-5 text-[var(--accent)] mt-0.5 shrink-0" />
             <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-white mb-2">
+              <p className="text-sm font-medium text-txt mb-2">
                 {t("cloud.apps.overview.apiKeyOnce", {
                   defaultValue: "Your API Key (shown once)",
                 })}
               </p>
               <div className="flex items-center gap-2 mb-2">
-                <code className="flex-1 bg-black/30 px-3 py-2 rounded-sm text-xs text-white/80 font-mono overflow-x-auto">
+                <code className="flex-1 bg-surface px-3 py-2 rounded-sm text-xs text-muted font-mono overflow-x-auto">
                   {displayApiKey}
                 </code>
                 <Button
                   variant="ghost"
                   type="button"
                   onClick={() => copyToClipboard(displayApiKey, "API Key")}
-                  className="p-2 bg-white/10 hover:bg-white/20 rounded-sm transition-colors shrink-0"
+                  className="p-2 bg-surface hover:bg-surface rounded-sm transition-colors shrink-0"
                 >
                   {copiedItem === "API Key" ? (
                     <Check className="h-4 w-4 text-green-400" />
                   ) : (
-                    <Copy className="h-4 w-4 text-white/60" />
+                    <Copy className="h-4 w-4 text-muted" />
                   )}
                 </Button>
               </div>
-              <p className="text-xs text-white/74">
+              <p className="text-xs text-muted">
                 {t("cloud.apps.overview.saveKeyHint", {
                   defaultValue:
                     "Save this key securely. You won't see it again. This message disappears in 60 seconds.",
@@ -412,7 +412,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
       {/* Deployment (#9145) — the client trigger for POST /apps/:id/deploy. */}
       <div className="bg-neutral-900 rounded-sm p-4 space-y-3">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-medium text-white flex items-center gap-2">
+          <h3 className="text-sm font-medium text-txt flex items-center gap-2">
             <Rocket className="h-4 w-4 text-[var(--accent)]" />
             {t("cloud.apps.overview.deployment", {
               defaultValue: "Deployment",
@@ -451,7 +451,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
               placeholder="https://github.com/org/app.git"
               density="compact"
               hasError={Boolean(deployInputError)}
-              className="border-white/10 bg-black/30 text-white placeholder:text-neutral-600"
+              className="border-border bg-surface text-txt placeholder:text-neutral-600"
             />
           </label>
           <label className="space-y-1.5" htmlFor={deployRefInputId}>
@@ -467,7 +467,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
               placeholder="40-character SHA"
               density="compact"
               hasError={Boolean(deployInputError)}
-              className="font-mono border-white/10 bg-black/30 text-white placeholder:text-neutral-600"
+              className="font-mono border-border bg-surface text-txt placeholder:text-neutral-600"
             />
           </label>
           <div className="flex items-end">
@@ -475,7 +475,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
               variant="ghost"
               type="submit"
               disabled={deploymentButtonDisabled}
-              className="h-9 w-full min-w-28 text-xs text-neutral-200 bg-white/10 hover:bg-white/15 flex items-center justify-center gap-1 transition-colors disabled:opacity-50"
+              className="h-9 w-full min-w-28 text-xs text-neutral-200 bg-surface hover:bg-surface flex items-center justify-center gap-1 transition-colors disabled:opacity-50"
             >
               {isDeploying || isPollingDeployment || deploymentInProgress ? (
                 <Loader2 className="h-3 w-3 animate-spin" />
@@ -511,7 +511,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
               placeholder="Dockerfile"
               density="compact"
               hasError={Boolean(deployInputError)}
-              className="border-white/10 bg-black/30 text-white placeholder:text-neutral-600"
+              className="border-border bg-surface text-txt placeholder:text-neutral-600"
             />
           </label>
         </form>
@@ -526,7 +526,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
         {/* API Key Card */}
         <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-medium text-white flex items-center gap-2">
+            <h3 className="text-sm font-medium text-txt flex items-center gap-2">
               <Key className="h-4 w-4 text-[var(--accent)]" />
               {t("cloud.apps.overview.apiKey", { defaultValue: "API Key" })}
             </h3>
@@ -536,7 +536,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
                   variant="ghost"
                   type="button"
                   disabled={isRegenerating}
-                  className="text-xs text-neutral-400 hover:text-white flex items-center gap-1 transition-colors"
+                  className="text-xs text-neutral-400 hover:text-txt flex items-center gap-1 transition-colors"
                 >
                   {isRegenerating ? (
                     <Loader2 className="h-3 w-3 animate-spin" />
@@ -581,9 +581,9 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
             </AlertDialog>
           </div>
 
-          <div className="bg-black/40 rounded-sm p-3 border border-white/10">
+          <div className="bg-surface rounded-sm p-3 border border-border">
             <div className="flex items-center gap-2">
-              <code className="flex-1 text-xs text-white/70 font-mono overflow-x-auto">
+              <code className="flex-1 text-xs text-muted font-mono overflow-x-auto">
                 {showKey && displayApiKey ? displayApiKey : maskedApiKey}
               </code>
               {displayApiKey && (
@@ -592,24 +592,24 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
                     variant="ghost"
                     type="button"
                     onClick={() => setShowKey(!showKey)}
-                    className="p-1.5 hover:bg-white/10 rounded-sm transition-colors"
+                    className="p-1.5 hover:bg-surface rounded-sm transition-colors"
                   >
                     {showKey ? (
-                      <EyeOff className="h-3.5 w-3.5 text-white/50" />
+                      <EyeOff className="h-3.5 w-3.5 text-muted" />
                     ) : (
-                      <Eye className="h-3.5 w-3.5 text-white/50" />
+                      <Eye className="h-3.5 w-3.5 text-muted" />
                     )}
                   </Button>
                   <Button
                     variant="ghost"
                     type="button"
                     onClick={() => copyToClipboard(displayApiKey, "API Key")}
-                    className="p-1.5 hover:bg-white/10 rounded-sm transition-colors"
+                    className="p-1.5 hover:bg-surface rounded-sm transition-colors"
                   >
                     {copiedItem === "API Key" ? (
                       <Check className="h-3.5 w-3.5 text-green-400" />
                     ) : (
-                      <Copy className="h-3.5 w-3.5 text-white/50" />
+                      <Copy className="h-3.5 w-3.5 text-muted" />
                     )}
                   </Button>
                 </>
@@ -626,7 +626,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
 
         {/* Basic Info Card */}
         <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
-          <h3 className="text-sm font-medium text-white flex items-center gap-2">
+          <h3 className="text-sm font-medium text-txt flex items-center gap-2">
             <Globe className="h-4 w-4 text-[var(--accent)]" />
             {t("cloud.apps.overview.appInformation", {
               defaultValue: "App Information",
@@ -692,7 +692,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
                 <Coins className="h-5 w-5 text-orange-400" />
               </div>
               <div>
-                <h3 className="text-sm font-medium text-white">Monetization</h3>
+                <h3 className="text-sm font-medium text-txt">Monetization</h3>
                 <p className="text-xs text-neutral-500">
                   {monetizationEnabled
                     ? totalEarnings && totalEarnings > 0
@@ -707,7 +707,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
                 className={cn(
                   monetizationEnabled
                     ? "bg-green-500/20 text-green-400 border-green-500/30"
-                    : "bg-white/10 text-white/50 border-white/20",
+                    : "bg-surface text-muted border-border",
                 )}
               >
                 {monetizationEnabled ? "Enabled" : "Disabled"}
@@ -718,7 +718,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
                 onClick={() =>
                   navigate(`/dashboard/apps/${app.id}?tab=monetization`)
                 }
-                className="p-2 hover:bg-white/10 rounded-sm transition-colors"
+                className="p-2 hover:bg-surface rounded-sm transition-colors"
               >
                 <ChevronRight className="h-4 w-4 text-neutral-400" />
               </Button>
@@ -730,15 +730,15 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
       {/* Allowed Origins */}
       <div className="bg-neutral-900 rounded-sm p-4 space-y-3">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-medium text-white flex items-center gap-2">
-            <Shield className="h-4 w-4 text-white/70" />
+          <h3 className="text-sm font-medium text-txt flex items-center gap-2">
+            <Shield className="h-4 w-4 text-muted" />
             Allowed Origins
           </h3>
           <Button
             variant="ghost"
             type="button"
             onClick={() => navigate(`/dashboard/apps/${app.id}?tab=settings`)}
-            className="text-xs text-neutral-400 hover:text-white transition-colors"
+            className="text-xs text-neutral-400 hover:text-txt transition-colors"
           >
             Edit
           </Button>
@@ -751,7 +751,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
             allowedOrigins.map((origin) => (
               <Badge
                 key={origin}
-                className="bg-white/5 text-white/70 border-white/10"
+                className="bg-surface text-muted border-border"
               >
                 {origin}
               </Badge>
@@ -791,7 +791,7 @@ function InfoRow({
               e.preventDefault();
             }
           }}
-          className="text-sm text-white hover:opacity-75 transition-opacity flex items-center gap-1 mt-0.5"
+          className="text-sm text-txt hover:opacity-75 transition-opacity flex items-center gap-1 mt-0.5"
         >
           {icon}
           <span className="truncate">{value}</span>
@@ -800,7 +800,7 @@ function InfoRow({
           )}
         </a>
       ) : (
-        <p className="text-sm text-white mt-0.5 line-clamp-2">{value}</p>
+        <p className="text-sm text-txt mt-0.5 line-clamp-2">{value}</p>
       )}
     </div>
   );

--- a/packages/ui/src/cloud/applications/components/app-promote.tsx
+++ b/packages/ui/src/cloud/applications/components/app-promote.tsx
@@ -105,7 +105,7 @@ export function AppPromote({ app }: AppPromoteProps) {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
         <div>
-          <h3 className="text-sm font-medium text-white flex items-center gap-2">
+          <h3 className="text-sm font-medium text-txt flex items-center gap-2">
             <Megaphone className="h-4 w-4 text-[var(--accent)]" />
             {t("cloud.appPromote.title", {
               name: app.name,
@@ -125,7 +125,7 @@ export function AppPromote({ app }: AppPromoteProps) {
             size="sm"
             onClick={handleGenerateAssets}
             disabled={isGeneratingAssets}
-            className="border-white/10 hover:bg-white/10 rounded-sm"
+            className="border-border hover:bg-surface rounded-sm"
           >
             {isGeneratingAssets ? (
               <>
@@ -162,7 +162,7 @@ export function AppPromote({ app }: AppPromoteProps) {
       {/* Suggestions */}
       {suggestions && (
         <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
-          <h3 className="text-sm font-medium text-white">
+          <h3 className="text-sm font-medium text-txt">
             {t("cloud.appPromote.tipsTitle", {
               defaultValue: "Promotion Tips",
             })}
@@ -180,14 +180,14 @@ export function AppPromote({ app }: AppPromoteProps) {
             ))}
           </div>
 
-          <div className="pt-3 border-t border-white/10">
+          <div className="pt-3 border-t border-border">
             <div className="flex items-center justify-between text-xs">
               <span className="text-neutral-500">
                 {t("cloud.appPromote.estimatedBudget", {
                   defaultValue: "Estimated budget range:",
                 })}
               </span>
-              <span className="text-white font-medium">
+              <span className="text-txt font-medium">
                 ${suggestions.estimatedBudget.min} - $
                 {suggestions.estimatedBudget.max}
               </span>
@@ -199,7 +199,7 @@ export function AppPromote({ app }: AppPromoteProps) {
       {/* Connected Ad Accounts */}
       <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-medium text-white">
+          <h3 className="text-sm font-medium text-txt">
             {t("cloud.appPromote.connectedAccounts", {
               defaultValue: "Connected Ad Accounts",
             })}
@@ -208,7 +208,7 @@ export function AppPromote({ app }: AppPromoteProps) {
             variant="outline"
             size="sm"
             asChild
-            className="border-white/10 hover:bg-white/10 rounded-sm"
+            className="border-border hover:bg-surface rounded-sm"
           >
             <Link
               to="/dashboard/settings?tab=connections"
@@ -250,16 +250,16 @@ export function AppPromote({ app }: AppPromoteProps) {
             {adAccounts.map((account) => (
               <div
                 key={account.id}
-                className="flex items-center justify-between p-3 rounded-sm bg-black/30 border border-white/5"
+                className="flex items-center justify-between p-3 rounded-sm bg-surface border border-border"
               >
                 <div className="flex items-center gap-2">
                   <Badge
                     variant="outline"
-                    className="capitalize text-xs border-white/20"
+                    className="capitalize text-xs border-border"
                   >
                     {account.platform}
                   </Badge>
-                  <span className="text-sm text-white">
+                  <span className="text-sm text-txt">
                     {account.accountName}
                   </span>
                 </div>

--- a/packages/ui/src/cloud/applications/components/app-settings.tsx
+++ b/packages/ui/src/cloud/applications/components/app-settings.tsx
@@ -193,7 +193,7 @@ export function AppSettings({ app }: AppSettingsProps) {
     <div className="space-y-4">
       {/* Basic Settings */}
       <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
-        <h3 className="text-sm font-medium text-white flex items-center gap-2">
+        <h3 className="text-sm font-medium text-txt flex items-center gap-2">
           <Settings className="h-4 w-4 text-[var(--brand-orange)]" />
           {t("cloud.appSettings.basicSettings", {
             defaultValue: "Basic Settings",
@@ -214,7 +214,7 @@ export function AppSettings({ app }: AppSettingsProps) {
               placeholder={t("cloud.appSettings.appNamePlaceholder", {
                 defaultValue: "My Awesome App",
               })}
-              className="bg-black/40 border-white/10  rounded-sm"
+              className="bg-surface border-border  rounded-sm"
             />
           </div>
 
@@ -234,7 +234,7 @@ export function AppSettings({ app }: AppSettingsProps) {
                 defaultValue: "A brief description of your app...",
               })}
               rows={3}
-              className="bg-black/40 border-white/10  resize-none rounded-sm"
+              className="bg-surface border-border  resize-none rounded-sm"
             />
           </div>
 
@@ -251,7 +251,7 @@ export function AppSettings({ app }: AppSettingsProps) {
                   setFormData({ ...formData, app_url: e.target.value })
                 }
                 placeholder="https://myapp.com"
-                className="bg-black/40 border-white/10  rounded-sm"
+                className="bg-surface border-border  rounded-sm"
               />
             </div>
 
@@ -269,7 +269,7 @@ export function AppSettings({ app }: AppSettingsProps) {
                   setFormData({ ...formData, website_url: e.target.value })
                 }
                 placeholder="https://website.com"
-                className="bg-black/40 border-white/10  rounded-sm"
+                className="bg-surface border-border  rounded-sm"
               />
             </div>
           </div>
@@ -288,13 +288,13 @@ export function AppSettings({ app }: AppSettingsProps) {
                 setFormData({ ...formData, contact_email: e.target.value })
               }
               placeholder="contact@myapp.com"
-              className="bg-black/40 border-white/10  rounded-sm"
+              className="bg-surface border-border  rounded-sm"
             />
           </div>
 
-          <div className="flex items-center justify-between p-3 bg-black/30 rounded-sm border border-white/10">
+          <div className="flex items-center justify-between p-3 bg-surface rounded-sm border border-border">
             <div>
-              <p className="text-sm font-medium text-white">
+              <p className="text-sm font-medium text-txt">
                 {t("cloud.appSettings.activeStatus", {
                   defaultValue: "Active Status",
                 })}
@@ -320,8 +320,8 @@ export function AppSettings({ app }: AppSettingsProps) {
       {/* Allowed Origins */}
       <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
         <div>
-          <h3 className="text-sm font-medium text-white flex items-center gap-2">
-            <Shield className="h-4 w-4 text-white/70" />
+          <h3 className="text-sm font-medium text-txt flex items-center gap-2">
+            <Shield className="h-4 w-4 text-muted" />
             {t("cloud.appSettings.allowedOrigins", {
               defaultValue: "Allowed Origins",
             })}
@@ -338,7 +338,7 @@ export function AppSettings({ app }: AppSettingsProps) {
             value={newOrigin}
             onChange={(e) => setNewOrigin(e.target.value)}
             placeholder="https://example.com"
-            className="bg-black/40 border-white/10  rounded-sm"
+            className="bg-surface border-border  rounded-sm"
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 e.preventDefault();
@@ -351,7 +351,7 @@ export function AppSettings({ app }: AppSettingsProps) {
             onClick={addOrigin}
             variant="outline"
             size="icon"
-            className="shrink-0 border-white/10 hover:bg-white/10"
+            className="shrink-0 border-border hover:bg-surface"
           >
             <Plus className="h-4 w-4" />
           </Button>
@@ -362,14 +362,14 @@ export function AppSettings({ app }: AppSettingsProps) {
             {allowedOrigins.map((origin) => (
               <Badge
                 key={origin}
-                className="bg-white/5 text-white/70 border-white/10 flex items-center gap-1 pr-1"
+                className="bg-surface text-muted border-border flex items-center gap-1 pr-1"
               >
                 {origin}
                 <Button
                   variant="ghost"
                   type="button"
                   onClick={() => removeOrigin(origin)}
-                  className="ml-1 p-0.5 hover:bg-white/10 rounded-sm transition-colors"
+                  className="ml-1 p-0.5 hover:bg-surface rounded-sm transition-colors"
                 >
                   <X className="h-3 w-3" />
                 </Button>
@@ -384,7 +384,7 @@ export function AppSettings({ app }: AppSettingsProps) {
         <Button
           onClick={handleSave}
           disabled={isLoading}
-          className="bg-[var(--brand-orange)] hover:bg-[#e54f00] text-white"
+          className="bg-[var(--brand-orange)] hover:bg-[#e54f00] text-txt"
         >
           {isLoading ? (
             <>
@@ -410,9 +410,9 @@ export function AppSettings({ app }: AppSettingsProps) {
         </h3>
 
         <div className="space-y-3">
-          <div className="flex items-center justify-between p-4 bg-black rounded-sm border border-red-500/10">
+          <div className="flex items-center justify-between p-4 bg-surface rounded-sm border border-red-500/10">
             <div className="min-w-0 flex-1 mr-3">
-              <p className="text-sm font-medium text-white">
+              <p className="text-sm font-medium text-txt">
                 {t("cloud.appSettings.regenerateApiKey", {
                   defaultValue: "Regenerate API Key",
                 })}
@@ -427,7 +427,7 @@ export function AppSettings({ app }: AppSettingsProps) {
               <AlertDialogTrigger asChild>
                 <Button
                   size="sm"
-                  className="bg-red-600 hover:bg-red-700 text-white shrink-0"
+                  className="bg-red-600 hover:bg-red-700 text-txt shrink-0"
                   disabled={isRegenerating}
                 >
                   {isRegenerating ? (
@@ -442,9 +442,9 @@ export function AppSettings({ app }: AppSettingsProps) {
                   )}
                 </Button>
               </AlertDialogTrigger>
-              <AlertDialogContent className="bg-neutral-900 border-white/10">
+              <AlertDialogContent className="bg-neutral-900 border-border">
                 <AlertDialogHeader>
-                  <AlertDialogTitle className="text-white">
+                  <AlertDialogTitle className="text-txt">
                     {t("cloud.appSettings.regenerateDialogTitle", {
                       defaultValue: "Regenerate API Key?",
                     })}
@@ -457,12 +457,12 @@ export function AppSettings({ app }: AppSettingsProps) {
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
-                  <AlertDialogCancel className="border-white/10 text-white hover:bg-white/10">
+                  <AlertDialogCancel className="border-border text-txt hover:bg-surface">
                     {t("cloud.appSettings.cancel", { defaultValue: "Cancel" })}
                   </AlertDialogCancel>
                   <AlertDialogAction
                     onClick={handleRegenerateApiKey}
-                    className="bg-red-600 hover:bg-red-700 text-white"
+                    className="bg-red-600 hover:bg-red-700 text-txt"
                   >
                     {t("cloud.appSettings.regenerateApiKey", {
                       defaultValue: "Regenerate API Key",
@@ -473,9 +473,9 @@ export function AppSettings({ app }: AppSettingsProps) {
             </AlertDialog>
           </div>
 
-          <div className="flex items-center justify-between p-4 bg-black rounded-sm border border-red-500/10">
+          <div className="flex items-center justify-between p-4 bg-surface rounded-sm border border-red-500/10">
             <div className="min-w-0 flex-1 mr-3">
-              <p className="text-sm font-medium text-white">
+              <p className="text-sm font-medium text-txt">
                 {t("cloud.appSettings.deleteApp", {
                   defaultValue: "Delete App",
                 })}
@@ -490,7 +490,7 @@ export function AppSettings({ app }: AppSettingsProps) {
               <AlertDialogTrigger asChild>
                 <Button
                   size="sm"
-                  className="bg-red-600 hover:bg-red-700 text-white shrink-0"
+                  className="bg-red-600 hover:bg-red-700 text-txt shrink-0"
                   disabled={isDeleting}
                 >
                   {isDeleting ? (
@@ -505,9 +505,9 @@ export function AppSettings({ app }: AppSettingsProps) {
                   )}
                 </Button>
               </AlertDialogTrigger>
-              <AlertDialogContent className="bg-neutral-900 border-white/10">
+              <AlertDialogContent className="bg-neutral-900 border-border">
                 <AlertDialogHeader>
-                  <AlertDialogTitle className="text-white">
+                  <AlertDialogTitle className="text-txt">
                     {t("cloud.appSettings.deleteDialogTitle", {
                       defaultValue: "Delete App?",
                     })}
@@ -517,7 +517,7 @@ export function AppSettings({ app }: AppSettingsProps) {
                       defaultValue:
                         "This action cannot be undone. This will permanently delete the app",
                     })}
-                    <strong className="text-white"> {app.name}</strong>{" "}
+                    <strong className="text-txt"> {app.name}</strong>{" "}
                     {t("cloud.appSettings.deleteDialogOutro", {
                       defaultValue:
                         "and remove all associated data including analytics and user tracking.",
@@ -525,12 +525,12 @@ export function AppSettings({ app }: AppSettingsProps) {
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
-                  <AlertDialogCancel className="border-white/10 text-white hover:bg-white/10">
+                  <AlertDialogCancel className="border-border text-txt hover:bg-surface">
                     {t("cloud.appSettings.cancel", { defaultValue: "Cancel" })}
                   </AlertDialogCancel>
                   <AlertDialogAction
                     onClick={handleDelete}
-                    className="bg-red-600 hover:bg-red-700 text-white"
+                    className="bg-red-600 hover:bg-red-700 text-txt"
                   >
                     {t("cloud.appSettings.deleteApp", {
                       defaultValue: "Delete App",

--- a/packages/ui/src/cloud/applications/components/withdraw-dialog.tsx
+++ b/packages/ui/src/cloud/applications/components/withdraw-dialog.tsx
@@ -104,11 +104,11 @@ export function WithdrawDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-md bg-neutral-900 border-white/10">
+      <DialogContent className="sm:max-w-md bg-neutral-900 border-border">
         {state === "confirm" && (
           <>
             <DialogHeader>
-              <DialogTitle className="flex items-center gap-2 text-white">
+              <DialogTitle className="flex items-center gap-2 text-txt">
                 <Wallet className="h-5 w-5 text-[var(--brand-orange)]" />
                 Withdraw Earnings
               </DialogTitle>
@@ -120,7 +120,7 @@ export function WithdrawDialog({
 
             <div className="space-y-4 py-4">
               {/* Balance display */}
-              <div className="flex items-center justify-between p-3 bg-black/30 rounded-sm border border-white/10">
+              <div className="flex items-center justify-between p-3 bg-surface rounded-sm border border-border">
                 <span className="text-sm text-neutral-400">
                   Available Balance
                 </span>
@@ -146,7 +146,7 @@ export function WithdrawDialog({
                     type="number"
                     value={amount}
                     onChange={(e) => setAmount(e.target.value)}
-                    className="pl-7 bg-black/40 border-white/10 text-white font-mono "
+                    className="pl-7 bg-surface border-border text-txt font-mono "
                     min={payoutThreshold}
                     max={withdrawableBalance}
                     step="0.01"
@@ -160,7 +160,7 @@ export function WithdrawDialog({
                     variant="ghost"
                     type="button"
                     onClick={() => setAmount(withdrawableBalance.toFixed(2))}
-                    className="text-white/60 hover:text-white transition-colors"
+                    className="text-muted hover:text-txt transition-colors"
                   >
                     Withdraw All
                   </Button>
@@ -182,14 +182,14 @@ export function WithdrawDialog({
               <Button
                 variant="ghost"
                 onClick={handleClose}
-                className="text-neutral-400 hover:text-white"
+                className="text-neutral-400 hover:text-txt"
               >
                 Cancel
               </Button>
               <Button
                 onClick={handleWithdraw}
                 disabled={!isValidAmount}
-                className="bg-[var(--brand-orange)] hover:bg-[#e54f00] text-white disabled:opacity-50"
+                className="bg-[var(--brand-orange)] hover:bg-[#e54f00] text-txt disabled:opacity-50"
               >
                 <ArrowRight className="h-4 w-4 mr-2" />
                 Withdraw ${parsedAmount.toFixed(2)}
@@ -203,7 +203,7 @@ export function WithdrawDialog({
             <div className="mx-auto w-16 h-16 mb-4 flex items-center justify-center">
               <Loader2 className="h-8 w-8 text-[var(--brand-orange)] animate-spin" />
             </div>
-            <h3 className="text-lg font-medium text-white mb-2">
+            <h3 className="text-lg font-medium text-txt-strong mb-2">
               Processing Withdrawal
             </h3>
             <p className="text-sm text-neutral-400">
@@ -217,7 +217,7 @@ export function WithdrawDialog({
             <div className="mx-auto w-16 h-16 mb-4 flex items-center justify-center bg-green-500/10 rounded-full border border-green-500/30">
               <CheckCircle2 className="h-8 w-8 text-green-400" />
             </div>
-            <h3 className="text-xl font-semibold text-white mb-2">
+            <h3 className="text-xl font-semibold text-txt-strong mb-2">
               Withdrawal Complete!
             </h3>
             <p className="text-neutral-400 mb-2">
@@ -226,12 +226,12 @@ export function WithdrawDialog({
             <p className="text-xs text-neutral-500 mb-4">
               Visit your Earnings page to redeem as elizaOS tokens
             </p>
-            <div className="inline-block p-3 bg-black/30 rounded-sm border border-white/10">
+            <div className="inline-block p-3 bg-surface rounded-sm border border-border">
               <span className="text-xs text-neutral-500">
                 Remaining App Balance
               </span>
               {newBalance !== null ? (
-                <p className="text-lg font-mono font-semibold text-white">
+                <p className="text-lg font-mono font-semibold text-txt-strong">
                   ${newBalance.toFixed(2)}
                 </p>
               ) : (
@@ -243,7 +243,7 @@ export function WithdrawDialog({
             <DialogFooter className="mt-6">
               <Button
                 onClick={handleClose}
-                className="w-full bg-[var(--brand-orange)] hover:bg-[#e54f00] text-white"
+                className="w-full bg-[var(--brand-orange)] hover:bg-[#e54f00] text-txt"
               >
                 Done
               </Button>
@@ -256,7 +256,7 @@ export function WithdrawDialog({
             <div className="mx-auto w-16 h-16 mb-4 flex items-center justify-center bg-red-500/10 rounded-full border border-red-500/30">
               <AlertCircle className="h-8 w-8 text-red-400" />
             </div>
-            <h3 className="text-lg font-medium text-white mb-2">
+            <h3 className="text-lg font-medium text-txt-strong mb-2">
               Withdrawal Failed
             </h3>
             <p className="text-sm text-red-400 mb-4">{error}</p>
@@ -264,13 +264,13 @@ export function WithdrawDialog({
               <Button
                 variant="ghost"
                 onClick={handleClose}
-                className="text-neutral-400 hover:text-white"
+                className="text-neutral-400 hover:text-txt"
               >
                 Cancel
               </Button>
               <Button
                 onClick={() => setState("confirm")}
-                className="bg-white/10 hover:bg-white/20 text-white"
+                className="bg-surface hover:bg-surface text-txt"
               >
                 Try Again
               </Button>

--- a/packages/ui/src/cloud/mcps/McpEditorDialog.tsx
+++ b/packages/ui/src/cloud/mcps/McpEditorDialog.tsx
@@ -296,7 +296,7 @@ export function McpEditorDialog({
                   update_("slug", slugify(e.target.value));
                 }}
               />
-              <p className="text-xs text-white/40">
+              <p className="text-xs text-muted">
                 {t("cloud.mcps.slugHint", {
                   defaultValue: "Lowercase letters, numbers and dashes only.",
                 })}
@@ -402,7 +402,7 @@ export function McpEditorDialog({
             </div>
           )}
 
-          <div className="flex items-center justify-between rounded-sm border border-white/10 bg-white/5 px-3 py-2">
+          <div className="flex items-center justify-between rounded-sm border border-border bg-surface px-3 py-2">
             <Label htmlFor="mcp-x402-enabled" className="cursor-pointer">
               {t("cloud.mcps.x402EnabledLabel", {
                 defaultValue: "Enable x402 micropayments",
@@ -461,7 +461,7 @@ export function McpEditorDialog({
               }
               className="font-mono text-xs"
             />
-            <p className="text-xs text-white/40">
+            <p className="text-xs text-muted">
               {t("cloud.mcps.toolsHint", {
                 defaultValue:
                   "At least one tool is required before you can publish.",


### PR DESCRIPTION
## What

Re-tokenizes the cloud **Applications** + **MCPs** surfaces to theme-aware design tokens so they read on **both** the dark console and the light settings surface. Follow-up to #13823 (issue #13767); closes #14203.

170 utility swaps across 11 files (balanced **170 +/170 −** — every change is a 1-for-1 className token swap, no logic touched).

## Why

#13823 re-tokenized the Settings section bodies (account-security, billing, api-keys, organization) that lost their `.theme-cloud` island, but the **Applications** and **MCPs** surfaces were missed. They render both inside the standalone dashboard island **and** embedded on light Settings surfaces (`McpsSection` re-exports `McpsSurface`; `ApplicationsPage` has a section variant), so their hardcoded `text-white` / `bg-black` render white-on-light — unreadable — exactly the #13823 regression class.

## Mapping (identical doctrine to #13823)

| hardcoded | token |
|---|---|
| `text-white` (body) | `text-txt` |
| `text-white` (bold/heading) | `text-txt-strong` |
| `text-white/NN` | `text-muted` |
| `bg-white/NN`, `bg-white/[0.0N]`, `bg-black`, `bg-black/NN` | `bg-surface` |
| `border-white/NN` | `border-border` |

These tokens resolve **dark under `.theme-cloud`** (unchanged console appearance) and **light on the light settings surface** (fixes readability).

**Deliberately untouched** (per #13823 scope + its review corrections about over-converting): orange brand accents `bg-[#e54f00]` / `bg-[#FF5800]` (accent-only, correct in both themes), semantic `red-*` controls, and all `neutral-*` utilities.

## Evidence

- **Light + dark render** → delegated to the **`cloud-aesthetic-audit` CI job** on this PR. Local app render was environmentally unavailable in the authoring run (no app build), so per PR_EVIDENCE this row is provided by CI rather than attached screenshots — please confirm the rendered light/dark audit before merge, as #13823's own review caught inert hovers / over-converted buttons that way.
- **Typecheck**: unaffected — changes are className string literals only.
- **Backend/native/trajectory/audio**: N/A — pure presentational token swap in `packages/ui` cloud console, no runtime/agent/model/API behavior changes.

## Test plan

- [ ] `cloud-aesthetic-audit` renders Applications + MCPs surfaces readable in **light** theme (was white-on-light) and unchanged in **dark**.
- [ ] Orange CTAs, red destructive controls unchanged.
- [ ] Hover states behave as before (`hover:bg-white/*` → `hover:bg-surface`, matching #13823).