### PR TITLE
fix(ci/#14188): use ISA-compatible python on self-hosted runners

### DIFF
--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -88,8 +88,30 @@ runs:
     - name: Restore Turbo cache (GitHub-native)
       uses: ./.github/actions/turbo-cache-github
 
+    # actions/setup-python@v6 downloads a CPython build requiring the
+    # x86-64-v3 CPU baseline; some [self-hosted, hetzner-robot] runners expose
+    # a lower ISA and the download aborts with "CPU ISA level is lower than
+    # required" (exit 127), killing the whole step even though Python here is
+    # only a best-effort node-gyp fallback (#14188). GitHub-hosted runners are
+    # never affected, so this probe (and the fallback it enables) only runs on
+    # self-hosted runners via runner.environment — hosted CI takes the
+    # untouched actions/setup-python@v6 path below.
+    - name: Detect usable system Python (self-hosted ISA guard)
+      id: system-python
+      if: ${{ inputs.setup-python == 'true' && runner.environment == 'self-hosted' }}
+      shell: bash
+      run: |
+        if command -v python3 >/dev/null 2>&1 && python3 -c "import sys" >/dev/null 2>&1; then
+          echo "python-bin=$(command -v python3)" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Setup Python
-      if: ${{ inputs.setup-python == 'true' }}
+      if: ${{ inputs.setup-python == 'true' && steps.system-python.outputs.python-bin == '' }}
+      # Skipped outright when the probe above found a usable system Python.
+      # If it didn't (a self-hosted runner with no system python3 either),
+      # don't let an ISA-incompatible download turn into a hard job failure —
+      # hosted runners are never in this branch and keep fail-fast behavior.
+      continue-on-error: ${{ runner.environment == 'self-hosted' }}
       uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
@@ -97,7 +119,16 @@ runs:
     - name: Install setuptools for distutils (Python 3.12+)
       if: ${{ inputs.setup-python == 'true' }}
       shell: bash
-      run: pip install setuptools
+      run: |
+        python_bin="${{ steps.system-python.outputs.python-bin }}"
+        if [ -z "$python_bin" ]; then
+          python_bin="python3"
+        fi
+        if ! command -v "$python_bin" >/dev/null 2>&1; then
+          echo "::warning::No usable python3 found; skipping setuptools install (node-gyp fallback unavailable)"
+          exit 0
+        fi
+        "$python_bin" -m pip install setuptools
 
     - name: Install protoc
       # protoc is required even when install-native-deps=false because Rust
@@ -278,7 +309,11 @@ runs:
           sleep 5
         done
       env:
-        npm_config_python: ${{ env.pythonLocation }}/bin/python3
+        # When the system-Python guard above found a usable interpreter,
+        # `pythonLocation` is never set (actions/setup-python@v6 was skipped),
+        # so prefer the probed binary and only fall back to the downloaded
+        # toolcache path.
+        npm_config_python: ${{ steps.system-python.outputs.python-bin || format('{0}/bin/python3', env.pythonLocation) }}
 
     - name: Materialize bun npm package binary
       if: ${{ runner.os != 'Windows' }}


### PR DESCRIPTION
## Verified defect

`actions/setup-python@v6` (invoked by `.github/actions/setup-bun-workspace/action.yml`) downloads a prebuilt CPython built for the `x86-64-v3` CPU baseline. Some `[self-hosted, hetzner-robot]` runners expose a lower ISA and the download aborts:

```
##[error]./python: CPU ISA level is lower than required
```

which kills the whole step and fails every job that lands on the affected hardware — author-blameless, runner-dependent red X's. Confirmed still present on current `develop` (`24ea3d65a8c` at investigation time): every job wired through `setup-bun-workspace` on the shared self-hosted pool (`test.yml` shards, `chat-shell-gestures.yml`, `keyless-harness-e2e.yml`, `cloud-aesthetic-audit.yml`, and more) runs `setup-python: "true"` (the default) with no ISA guard.

Live evidence cited in #14188: PR #13394 (`Chat shell gesture + parity e2e`, `Deterministic mock-LLM connector loops (no secret)`, `cloud-aesthetic-audit` — three jobs, same signature, `runner-4`) and PR #13974 (`Plugin Tests` shard).

This is distinct from the Node-PATH gap fixed by #14161/PR referencing `sol-orch/ci-node-path-setup-bun-stale-base-guard` — that fix *adds* `setup-node` because `node` was **missing** from self-hosted PATH. Here the runner-side gap is the opposite: a working system `python3` already exists, but the **download** is what's ISA-incompatible.

## Fix

`.github/actions/setup-bun-workspace/action.yml` — the "Setup Python" step exists purely as a node-gyp fallback, so:

1. **New probe step** (`Detect usable system Python`), gated to `runner.environment == 'self-hosted'` — checks for a working system `python3` (`command -v` + a real interpreter invocation, not just presence). Hosted runners never execute this step, so hosted CI takes the byte-identical `actions/setup-python@v6` path it always has.
2. **`Setup Python`** now skips the download entirely when the probe found a usable system Python (`steps.system-python.outputs.python-bin == ''` gate). On self-hosted runners with no usable system python3 either, the download still runs but with `continue-on-error: true` so an ISA failure doesn't kill the job — hosted runners keep `continue-on-error: false` (unchanged fail-fast behavior).
3. **`Install setuptools`** and the downstream **`npm_config_python`** env (consumed by the `Install dependencies` step for the node-gyp fallback) both resolve to whichever python3 actually got set up — the probed system binary, or the downloaded toolcache's `pythonLocation`, never a stale/missing path. If truly no python3 is available anywhere, the setuptools step warns and no-ops rather than hard-failing (this whole path is documented in the composite as a best-effort node-gyp fallback, never a hard requirement).

## Why hosted runners are unaffected

Every new/changed conditional is gated on `runner.environment == 'self-hosted'`. On GitHub-hosted runners (`runner.environment == 'github-hosted'`):
- the probe step's `if` is false → it never runs → `steps.system-python.outputs.python-bin` is always empty.
- `Setup Python`'s guard (`steps.system-python.outputs.python-bin == ''`) is therefore always true → the step runs exactly as before.
- `continue-on-error` evaluates to `false` → fail-fast is unchanged.
- `npm_config_python` falls back to the original `${{ env.pythonLocation }}/bin/python3` expression, unchanged.

So the diff is a strict no-op on hosted CI and only changes behavior on self-hosted runners, where it removes the ISA-incompatible download from the critical path.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open(...))"` — action YAML parses.
- `bun test packages/scripts/__tests__/ci-bun-version-contract.test.ts packages/scripts/__tests__/turbo-cache-key.test.ts packages/scripts/__tests__/ci-turbo-cache-contract.test.ts` → 16 pass, 0 fail (only contract tests that reference `setup-bun-workspace`/`setup-python`).
- `.github/workflows/setup-bun-workspace-self-test.yml` always passes `setup-python: "false"`, so it doesn't exercise this path either way (untouched).
- `actionlint` on `.github/workflows/*.yml`: no new findings (pre-existing single unrelated finding in `mobile-resource-workbench.yml` re: a custom self-hosted label, not touched by this PR).
- `ci-workflow-dedup-contract.test.ts` has one pre-existing failure (`test.yml: missing on.pull_request`) confirmed present on `origin/develop` HEAD before this change (unrelated file, not touched here) — not introduced by this PR.

## Files touched

- `.github/actions/setup-bun-workspace/action.yml` (only file changed)

Fixes #14188
