### PR TITLE
fix(cloud): fail closed on redemption IP count aggregates

### DIFF
--- a/packages/cloud/shared/src/lib/services/token-redemption-secure.ip-cap-refund.test.ts
+++ b/packages/cloud/shared/src/lib/services/token-redemption-secure.ip-cap-refund.test.ts
@@ -111,6 +111,27 @@ describe("checkIPRateLimits — per-IP daily USD cap (fail-closed)", () => {
     expect(result.error).toContain("Unable to verify");
   });
 
+  test("missing daily aggregate row is corrupt, not an implicit $0", async () => {
+    executeResults = [{ rows: [{ count: "0" }] }, { rows: [] }];
+    const result = await callCheckIPRateLimits(1000);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Unable to verify");
+  });
+
+  test("corrupt hourly count denies instead of becoming zero", async () => {
+    executeResults = [{ rows: [{ count: "NaN" }] }];
+    const result = await callCheckIPRateLimits(1000);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Unable to verify");
+  });
+
+  test("corrupt daily count denies instead of becoming zero", async () => {
+    executeResults = [{ rows: [{ count: "0" }] }, { rows: [{ count: "NaN", total_usd: "0" }] }];
+    const result = await callCheckIPRateLimits(1000);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Unable to verify");
+  });
+
   test("healthy aggregate under the cap still passes", async () => {
     executeResults = [{ rows: [{ count: "1" }] }, { rows: [{ count: "2", total_usd: "50.25" }] }];
     const result = await callCheckIPRateLimits(1000); // +$10

--- a/packages/cloud/shared/src/lib/services/token-redemption-secure.ts
+++ b/packages/cloud/shared/src/lib/services/token-redemption-secure.ts
@@ -901,7 +901,22 @@ export class SecureTokenRedemptionService {
       AND status NOT IN ('rejected', 'expired')
     `);
 
-    const hourlyRedemptions = Number((hourlyCount.rows[0] as { count: string })?.count || 0);
+    let hourlyRedemptions: number;
+    try {
+      hourlyRedemptions = parseRedemptionLimitNumber(
+        (hourlyCount.rows[0] as { count: unknown } | undefined)?.count,
+        "ip_hourly_redemption_count",
+      );
+    } catch (error) {
+      logger.error("[SecureRedemption] Corrupt per-IP hourly count aggregate; denying redemption", {
+        ipAddress: ipAddress.split(".").slice(0, 2).join(".") + ".x.x",
+        reason: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        valid: false,
+        error: "Unable to verify redemption limits right now. Please try again later.",
+      };
+    }
 
     if (hourlyRedemptions >= IP_RATE_LIMITS.MAX_REDEMPTIONS_PER_IP_HOURLY) {
       return {
@@ -921,22 +936,25 @@ export class SecureTokenRedemptionService {
       AND status NOT IN ('rejected', 'expired')
     `);
 
-    const dailyRedemptions = Number((dailyStats.rows[0] as { count: string })?.count || 0);
-
     // Fail-closed: this is the per-IP daily USD anti-sybil money-out cap. The
     // SUM aggregates usd_value (NUMERIC) rows and the driver returns it as a
     // string; a single corrupt 'NaN'::numeric row poisons the whole SUM to
     // "NaN", and `NaN + usdValue > MAX_USD_PER_IP_DAILY` is false -> the cap
     // would fail OPEN and authorize unbounded per-IP redemptions. Deny instead.
     // error-policy:J4
+    let dailyRedemptions: number;
     let dailyUsd: number;
     try {
+      dailyRedemptions = parseRedemptionLimitNumber(
+        (dailyStats.rows[0] as { count: unknown } | undefined)?.count,
+        "ip_daily_redemption_count",
+      );
       dailyUsd = parseRedemptionLimitNumber(
-        (dailyStats.rows[0] as { total_usd: string })?.total_usd ?? 0,
+        (dailyStats.rows[0] as { total_usd: unknown } | undefined)?.total_usd,
         "ip_daily_usd_total",
       );
     } catch (error) {
-      logger.error("[SecureRedemption] Corrupt per-IP daily USD aggregate; denying redemption", {
+      logger.error("[SecureRedemption] Corrupt per-IP daily aggregate; denying redemption", {
         ipAddress: ipAddress.split(".").slice(0, 2).join(".") + ".x.x",
         reason: error instanceof Error ? error.message : String(error),
       });


### PR DESCRIPTION
## Summary
- parse per-IP hourly and daily redemption COUNT aggregates through the fail-closed numeric boundary
- remove TypeScript-side healthy-zero defaults for missing daily aggregate rows
- add regressions for missing aggregate rows and corrupt hourly/daily counts

## Validation
- bun test packages/cloud/shared/src/lib/services/token-redemption-secure.ip-cap-refund.test.ts packages/cloud/shared/src/lib/services/token-redemption-secure.daily-limit.test.ts (31 pass, 0 fail)
- bunx @biomejs/biome check packages/cloud/shared/src/lib/services/token-redemption-secure.ts packages/cloud/shared/src/lib/services/token-redemption-secure.ip-cap-refund.test.ts packages/cloud/shared/src/lib/services/token-redemption-secure.daily-limit.test.ts
- git diff --check

Follow-up to #14060 / #13415.