### PR TITLE
fix(knowledge): preserve help tags on seeded fragments

### DIFF
--- a/.github/issue-evidence/13974-help-fragment-tags-tests.txt
+++ b/.github/issue-evidence/13974-help-fragment-tags-tests.txt
@@ -1,0 +1,45 @@
+Evidence for #13974 follow-up / #14210: help-tagged bundled document fragments.
+
+Reviewed on 2026-07-05 from branch fix/13974-help-fragment-tags at commit
+98bdd174c0dc365d924f38588bafae36a22661fa, rebased on origin/develop.
+
+Commands run:
+
+node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
+bunx @biomejs/biome check \
+  packages/agent/src/runtime/default-documents.ts \
+  packages/agent/src/runtime/__tests__/default-documents.test.ts \
+  packages/agent/src/actions/knowledge.test.ts \
+  plugins/plugin-documents/src/routes.filters.test.ts \
+  --write --no-errors-on-unmatched
+
+bun test \
+  packages/agent/src/runtime/__tests__/default-documents.test.ts \
+  packages/agent/src/actions/knowledge.test.ts \
+  plugins/plugin-documents/src/routes.filters.test.ts
+
+Manual review:
+
+- Confirmed default seeded help fragments inherit the parent document facets:
+  tags=["help"] and helpCategory.
+- Confirmed SEARCH_KNOWLEDGE with query="chat pill" and tags=["help"] returns
+  the help fragment instead of being removed by the post-search facet filter.
+- Confirmed /api/documents/search?q=chat%20pill&tag=help keeps the matching
+  help-tagged fragment result after threshold, tag, and access filters.
+
+Verifier result:
+
+Checked 4 files in 73ms. No fixes applied.
+
+38 pass
+0 fail
+202 expect() calls
+Ran 38 tests across 3 files. [4.41s]
+
+The full local Bun output was captured in:
+/tmp/eliza-13974-focused-tests-rebased.log
+
+Bun coverage output is intentionally not pasted here because repo bunfig enables
+large coverage tables for `bun test`; the pass/fail summary above is the
+reviewed signal from the captured run.

--- a/packages/agent/src/actions/knowledge.test.ts
+++ b/packages/agent/src/actions/knowledge.test.ts
@@ -168,6 +168,32 @@ describe("SEARCH_KNOWLEDGE", () => {
     expect((res.data as { count: number }).count).toBeGreaterThan(0);
   });
 
+  it("free-text search composes with the help tag on fragment metadata", async () => {
+    const helpFragment = doc(DOC_GLOBAL, "global", {
+      documentId: DOC_GLOBAL,
+      title: "Getting started",
+      tags: ["help"],
+    });
+    helpFragment.content.text = "The chat pill opens Eliza from every view.";
+    const runtime = makeRuntime({ service: makeService([helpFragment]) });
+
+    const res = await call(
+      searchKnowledgeAction,
+      runtime,
+      msg(OWNER_ENTITY, DM_ROOM),
+      {
+        query: "chat pill",
+        tags: ["help"],
+      },
+    );
+
+    expect(res.success).toBe(true);
+    expect((res.data as { count: number }).count).toBe(1);
+    expect(
+      (res.data as { items: Array<{ title: string }> }).items[0]?.title,
+    ).toBe("Getting started");
+  });
+
   it("rejects a request with neither query nor any filter", async () => {
     const runtime = makeRuntime({ service: makeService() });
     const res = await call(

--- a/packages/agent/src/runtime/__tests__/default-documents.test.ts
+++ b/packages/agent/src/runtime/__tests__/default-documents.test.ts
@@ -14,7 +14,10 @@ import {
   listFragmentIdsForDocument,
   seedBundledDocuments,
 } from "../default-documents.ts";
-import { HELP_DOCUMENTS } from "../default-help-documents.ts";
+import {
+  HELP_DOCUMENTS,
+  HELP_KNOWLEDGE_TAG,
+} from "../default-help-documents.ts";
 
 const AGENT_ID = "00000000-0000-0000-0000-00000000a9e1" as UUID;
 const DOCUMENT_ID = "00000000-0000-0000-0000-0000000d0c01" as UUID;
@@ -209,6 +212,25 @@ describe("seedBundledDocuments", () => {
       );
       expect(documentRow?.content.text).toBe(doc.text);
     }
+  });
+
+  it("copies searchable document metadata onto seeded fragments", async () => {
+    const harness = makeSeedHarness();
+    const [helpDocument] = HELP_DOCUMENTS;
+
+    await seedBundledDocuments(harness.runtime, [helpDocument]);
+
+    const fragmentRow = [...harness.memories.values()].find(
+      (m) =>
+        (m.metadata as Record<string, unknown>).bundledDocumentKey ===
+          helpDocument.key &&
+        (m.metadata as Record<string, unknown>).type === "fragment",
+    );
+    expect(fragmentRow?.metadata).toMatchObject({
+      type: "fragment",
+      tags: [HELP_KNOWLEDGE_TAG],
+      helpCategory: helpDocument.metadata?.helpCategory,
+    });
   });
 
   it("re-runs idempotently: no creates, updates, or deletes the second time", async () => {

--- a/packages/agent/src/runtime/default-documents.ts
+++ b/packages/agent/src/runtime/default-documents.ts
@@ -211,6 +211,7 @@ function buildFragmentMetadata(
   timestamp: number,
 ): Record<string, unknown> {
   return {
+    ...(document.metadata ?? {}),
     type: MemoryType.FRAGMENT,
     documentId,
     position: index,
@@ -264,6 +265,7 @@ function fragmentMatchesDefinition(
   index: number,
   text: string,
   embedding: readonly number[] | undefined,
+  expectedMetadata: Record<string, unknown>,
 ): boolean {
   if (!existing) return false;
 
@@ -279,6 +281,9 @@ function fragmentMatchesDefinition(
     metadata.position === index &&
     metadata.bundledDocumentKey === document.key &&
     metadata.bundledDocumentVersion === document.version &&
+    Object.entries(expectedMetadata).every(
+      ([key, value]) => JSON.stringify(metadata[key]) === JSON.stringify(value),
+    ) &&
     embeddingsEqual(existingEmbedding, embedding)
   );
 }
@@ -399,6 +404,14 @@ async function seedBundledDocument(
         ? existingFragment.createdAt
         : Date.now();
 
+    const fragmentMetadata = buildFragmentMetadata(
+      document,
+      documentId,
+      runtime.agentId as UUID,
+      index,
+      runtime.agentId,
+      fragmentTimestamp,
+    );
     const fragmentMemory: SeededMemory = {
       id: fragmentId,
       agentId: runtime.agentId,
@@ -406,14 +419,7 @@ async function seedBundledDocument(
       worldId: runtime.agentId,
       entityId: runtime.agentId,
       content: { text: fragment.text },
-      metadata: buildFragmentMetadata(
-        document,
-        documentId,
-        runtime.agentId as UUID,
-        index,
-        runtime.agentId,
-        fragmentTimestamp,
-      ),
+      metadata: fragmentMetadata,
       ...(fragmentEmbedding ? { embedding: fragmentEmbedding } : {}),
       createdAt: fragmentCreatedAt,
     };
@@ -430,6 +436,7 @@ async function seedBundledDocument(
         index,
         fragment.text,
         fragmentMemory.embedding,
+        fragmentMetadata,
       )
     ) {
       if (existingFragment) {

--- a/plugins/plugin-documents/src/routes.filters.test.ts
+++ b/plugins/plugin-documents/src/routes.filters.test.ts
@@ -377,4 +377,66 @@ describe("GET /api/documents/search — roomId pushed into service scope (#13593
       | undefined;
     expect(scopeArg?.roomId).toBe(ROOM_A);
   });
+
+  it("keeps help-tagged fragment results when free-text search also has tag=help", async () => {
+    const helpFragment = docMemory("help-fragment", {
+      documentId: "help-doc",
+      title: "Getting started",
+      tags: ["help"],
+      scope: "global",
+      addedBy: AGENT_ID,
+    });
+    helpFragment.content.text = "The chat pill opens Eliza from every view.";
+    helpFragment.similarity = 0.92;
+    const searchDocuments = vi.fn(async () => [helpFragment]);
+    const documentsService = {
+      getMemories: vi.fn(async () => []),
+      countMemories: vi.fn(async () => 0),
+      addDocument: vi.fn(),
+      searchDocuments,
+      updateDocument: vi.fn(),
+      deleteMemory: vi.fn(),
+    };
+    const runtime = {
+      agentId: AGENT_ID,
+      getService: vi.fn((name: string) =>
+        name === "documents" ? documentsService : null,
+      ),
+      getServiceLoadPromise: vi.fn(),
+      getSetting: vi.fn((key: string) =>
+        key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER_ENTITY : undefined,
+      ),
+      getMemoryById: vi.fn(async () => null),
+    };
+    const url = new URL(
+      "http://local/api/documents/search?q=chat%20pill&tag=help",
+    );
+    let captured: unknown = null;
+    const ctx = {
+      req: { headers: { "x-eliza-entity-id": OWNER_ENTITY } },
+      res: { setHeader: vi.fn() },
+      method: "GET",
+      pathname: "/api/documents/search",
+      url,
+      runtime: runtime as never,
+      json: (_res: unknown, data: unknown) => {
+        captured = data;
+      },
+      error: vi.fn(),
+      readJsonBody: async () => null,
+    } as unknown as DocumentRouteContext;
+
+    const handled = await handleDocumentsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(captured).toMatchObject({
+      count: 1,
+      results: [
+        {
+          documentId: "help-doc",
+          documentTitle: "Getting started",
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- copy bundled document metadata onto seeded fragment metadata so `tags=["help"]` is searchable on semantic fragment hits
- make the bundled-document seeder update existing fragments whose metadata is missing the expected inherited facets
- add regressions for default help seeding, `SEARCH_KNOWLEDGE({ query, tags: ["help"] })`, and `/api/documents/search?q=...&tag=help`

## Verification
- `node packages/app-core/scripts/ensure-shared-i18n-data.mjs`
- `bunx @biomejs/biome check packages/agent/src/runtime/default-documents.ts packages/agent/src/runtime/__tests__/default-documents.test.ts packages/agent/src/actions/knowledge.test.ts plugins/plugin-documents/src/routes.filters.test.ts --write --no-errors-on-unmatched`
- `bun test packages/agent/src/runtime/__tests__/default-documents.test.ts packages/agent/src/actions/knowledge.test.ts plugins/plugin-documents/src/routes.filters.test.ts` (38 pass, 0 fail, 202 assertions; reviewed summary in `.github/issue-evidence/13974-help-fragment-tags-tests.txt`)

Follow-up to #13974: the merged help documents put `tags=["help"]` on parent document metadata, but semantic search returns `document_fragments`; without inheriting facets onto fragments, `query + tag=help` can filter out matching help results.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend/search metadata fix with no UI surface.`

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend/search metadata fix with no UI surface.`

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - backend/search metadata fix with no UI flow.`

<!-- evidence-row:backend-logs -->
- [ ] Backend/test logs: `.github/issue-evidence/13974-help-fragment-tags-tests.txt`

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change or browser-exercised flow.`

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - deterministic metadata/filtering regression; no model prompt, action planning, or live model behavior changed.`

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: `.github/issue-evidence/13974-help-fragment-tags-tests.txt`