### PR TITLE
fix(ci): harden system-python setuptools fallback

### DIFF
--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -128,7 +128,13 @@ runs:
           echo "::warning::No usable python3 found; skipping setuptools install (node-gyp fallback unavailable)"
           exit 0
         fi
-        "$python_bin" -m pip install setuptools
+        if "$python_bin" -c 'import setuptools' >/dev/null 2>&1; then
+          echo "setuptools already present: $("$python_bin" -c 'import setuptools; print(setuptools.__version__)')"
+          exit 0
+        fi
+        "$python_bin" -m pip install setuptools \
+          || "$python_bin" -m pip install --user setuptools \
+          || "$python_bin" -m pip install --break-system-packages setuptools
 
     - name: Install protoc
       # protoc is required even when install-native-deps=false because Rust


### PR DESCRIPTION
## What

Follow-up to #14207 / #14188. When `setup-bun-workspace` skips `actions/setup-python` on a self-hosted runner with usable system `python3`, harden the setuptools install path for system interpreters.

- skip install when `setuptools` is already importable
- try normal pip install first
- fall back to `--user` and then `--break-system-packages` for PEP 668 externally managed Python

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/actions/setup-bun-workspace/action.yml'))"`
- `git diff --check origin/develop...HEAD`
- `git diff --check`
- `bun test packages/scripts/__tests__/ci-bun-version-contract.test.ts packages/scripts/__tests__/turbo-cache-key.test.ts packages/scripts/__tests__/ci-turbo-cache-contract.test.ts` -> 16 pass

## Evidence

N/A screenshots/video/backend logs: CI composite shell hardening only; no user-facing UI, runtime agent, or API behavior change.

Fixes the remaining setuptools hardening gap from #14188.