### PR TITLE
ci(android): signal scheduled e2e failures (#13580)

### DIFF
--- a/.github/issue-evidence/13580-android-scheduled-failure-signal.md
+++ b/.github/issue-evidence/13580-android-scheduled-failure-signal.md
@@ -1,0 +1,37 @@
+# #13580 Android scheduled failure signal
+
+## Scope
+
+This follow-up covers only the visible failure-signal gap from #13580 after the
+weekly host-backed Android emulator cadence landed.
+
+## Change
+
+- `.github/workflows/android-device-e2e.yml` now grants `issues: write` only to
+  the full `android-e2e` job.
+- Scheduled failures run an `actions/github-script` step after artifact upload.
+- The step creates or updates one open issue titled
+  `Scheduled Android device e2e is failing (#13580)` with the failed run URL,
+  workflow name, backend, timestamp, and the remaining #13580 residuals.
+- Repeated scheduled failures update that issue body and add a fresh comment, so
+  regressions are visible outside Actions history and artifact discovery.
+
+## Verification
+
+- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/android-device-e2e.yml"); puts "yaml ok"'`
+  - Result: `yaml ok`
+- `git diff --check`
+  - Result: pass
+- `GOBIN=/tmp/codex-go-bin go install github.com/rhysd/actionlint/cmd/actionlint@latest && /tmp/codex-go-bin/actionlint .github/workflows/android-device-e2e.yml`
+  - Result: pass
+- `bun install`
+  - Result: blocked by host storage while expanding this isolated sparse
+    worktree: `No space left on device` creating files under
+    `packages/research/robot/examples/robot-mujoco-demo/evidence/...`
+
+## N/A
+
+- Real scheduled failure creation is N/A locally; it requires the GitHub Actions
+  `schedule` event and `GITHUB_TOKEN` issue-write context.
+- LOCAL arm64 runner and signal-only PR leg promotion are explicitly outside
+  this slice.

--- a/.github/issue-evidence/13580-android-scheduled-failure-signal.md
+++ b/.github/issue-evidence/13580-android-scheduled-failure-signal.md
@@ -8,18 +8,21 @@ weekly host-backed Android emulator cadence landed.
 ## Change
 
 - `.github/workflows/android-device-e2e.yml` now grants `issues: write` only to
-  the full `android-e2e` job.
-- Scheduled failures run an `actions/github-script` step after artifact upload.
+  a hosted Ubuntu notifier job.
+- Scheduled failures run an `actions/github-script` step in
+  `notify-scheduled-failure`, which depends on `android-e2e` and uses
+  `always()` so timeout/cancelled/runner-loss results still trigger the signal.
 - The step creates or updates one open issue titled
   `Scheduled Android device e2e is failing (#13580)` with the failed run URL,
-  workflow name, backend, timestamp, and the remaining #13580 residuals.
+  artifact link, workflow name, Android job result, backend, timestamp, and the
+  remaining #13580 residuals.
 - Repeated scheduled failures update that issue body and add a fresh comment, so
   regressions are visible outside Actions history and artifact discovery.
 
 ## Verification
 
-- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/android-device-e2e.yml"); puts "yaml ok"'`
-  - Result: `yaml ok`
+- `actionlint .github/workflows/android-device-e2e.yml`
+  - Result: pass
 - `git diff --check`
   - Result: pass
 - `GOBIN=/tmp/codex-go-bin go install github.com/rhysd/actionlint/cmd/actionlint@latest && /tmp/codex-go-bin/actionlint .github/workflows/android-device-e2e.yml`

--- a/.github/issue-evidence/14212-android-scheduled-failure-signal.md
+++ b/.github/issue-evidence/14212-android-scheduled-failure-signal.md
@@ -1,9 +1,9 @@
-# #13580 Android scheduled failure signal
+# #14212 Android scheduled failure signal
 
 ## Scope
 
-This follow-up covers only the visible failure-signal gap from #13580 after the
-weekly host-backed Android emulator cadence landed.
+This draft-PR follow-up covers only the visible failure-signal gap from #13580
+after the weekly host-backed Android emulator cadence landed.
 
 ## Change
 
@@ -11,7 +11,8 @@ weekly host-backed Android emulator cadence landed.
   a hosted Ubuntu notifier job.
 - Scheduled failures run an `actions/github-script` step in
   `notify-scheduled-failure`, which depends on `android-e2e` and uses
-  `always()` so timeout/cancelled/runner-loss results still trigger the signal.
+  `always()` plus the `schedule` event guard so timeout/cancelled/runner-loss
+  results still trigger the signal outside the timed Android job.
 - The step creates or updates one open issue titled
   `Scheduled Android device e2e is failing (#13580)` with the failed run URL,
   artifact link, workflow name, Android job result, backend, timestamp, and the
@@ -23,14 +24,13 @@ weekly host-backed Android emulator cadence landed.
 
 - `actionlint .github/workflows/android-device-e2e.yml`
   - Result: pass
+- `ruby -e 'require "psych"; Psych.parse_file(ARGV.fetch(0)); puts "YAML parse: ok"' .github/workflows/android-device-e2e.yml`
+  - Result: pass (`YAML parse: ok`)
+- `rg -n "notify-scheduled-failure|needs: android-e2e|always\\(\\).*github.event_name == 'schedule'.*needs.android-e2e.result != 'success'|runs-on: ubuntu-24.04|issues: write|actions/github-script" .github/workflows/android-device-e2e.yml`
+  - Result: pass; matched the notifier job, `needs: android-e2e`, scheduled
+    `always()` guard, hosted runner, `issues: write`, and `github-script` step.
 - `git diff --check`
   - Result: pass
-- `GOBIN=/tmp/codex-go-bin go install github.com/rhysd/actionlint/cmd/actionlint@latest && /tmp/codex-go-bin/actionlint .github/workflows/android-device-e2e.yml`
-  - Result: pass
-- `bun install`
-  - Result: blocked by host storage while expanding this isolated sparse
-    worktree: `No space left on device` creating files under
-    `packages/research/robot/examples/robot-mujoco-demo/evidence/...`
 
 ## N/A
 

--- a/.github/workflows/android-device-e2e.yml
+++ b/.github/workflows/android-device-e2e.yml
@@ -51,6 +51,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 90
+    permissions:
+      contents: read
+      issues: write
     env:
       ELIZA_MOBILE_REPO_ROOT: ${{ github.workspace }}
       ELIZA_WEBVIEW_DEBUG: "1"
@@ -177,6 +180,60 @@ jobs:
             packages/app/test-results/**
             packages/app/playwright-report/**
           if-no-files-found: ignore
+
+      - name: Open / update scheduled failure issue
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const title = "Scheduled Android device e2e is failing (#13580)";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const runDate = new Date().toISOString();
+            const body = [
+              "The weekly host-backed Android device e2e cadence failed.",
+              "",
+              `Run: ${runUrl}`,
+              `Workflow: \`${context.workflow}\``,
+              `Backend: \`${process.env.ELIZA_ANDROID_BACKEND || "host"}\``,
+              `Observed: ${runDate}`,
+              "",
+              "This issue is auto-maintained by `.github/workflows/android-device-e2e.yml` so scheduled failures are visible outside Actions history.",
+              "",
+              "Known #13580 residuals still tracked separately:",
+              "- LOCAL arm64 on-device route needs a self-hosted arm64 runner.",
+              "- Signal-only PR legs should be promoted only after emulator-green evidence exists.",
+            ].join("\n");
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100,
+            });
+            const existing = openIssues.find((issue) => !issue.pull_request && issue.title === title);
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Scheduled Android device e2e failed again: ${runUrl}`,
+              });
+              core.info(`Updated scheduled failure issue #${existing.number}`);
+            } else {
+              const { data: created } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+              core.info(`Opened scheduled failure issue #${created.number}`);
+            }
 
   # Minimal, label-gated PR device smoke (issue #9943). Reachable on a PR only
   # when the `ci:device` label is applied, so it never burns an emulator runner

--- a/.github/workflows/android-device-e2e.yml
+++ b/.github/workflows/android-device-e2e.yml
@@ -53,7 +53,6 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: read
-      issues: write
     env:
       ELIZA_MOBILE_REPO_ROOT: ${{ github.workspace }}
       ELIZA_WEBVIEW_DEBUG: "1"
@@ -181,19 +180,33 @@ jobs:
             packages/app/playwright-report/**
           if-no-files-found: ignore
 
+  notify-scheduled-failure:
+    needs: android-e2e
+    if: ${{ always() && github.event_name == 'schedule' && needs.android-e2e.result != 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    env:
+      ANDROID_E2E_RESULT: ${{ needs.android-e2e.result }}
+      ELIZA_ANDROID_BACKEND: host
+    steps:
       - name: Open / update scheduled failure issue
-        if: ${{ failure() && github.event_name == 'schedule' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const title = "Scheduled Android device e2e is failing (#13580)";
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const artifactsUrl = `${runUrl}#artifacts`;
             const runDate = new Date().toISOString();
+            const result = process.env.ANDROID_E2E_RESULT || "unknown";
             const body = [
               "The weekly host-backed Android device e2e cadence failed.",
               "",
               `Run: ${runUrl}`,
+              `Artifacts: ${artifactsUrl}`,
               `Workflow: \`${context.workflow}\``,
+              `Android job result: \`${result}\``,
               `Backend: \`${process.env.ELIZA_ANDROID_BACKEND || "host"}\``,
               `Observed: ${runDate}`,
               "",
@@ -222,7 +235,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: existing.number,
-                body: `Scheduled Android device e2e failed again: ${runUrl}`,
+                body: `Scheduled Android device e2e failed again (${result}): ${runUrl}`,
               });
               core.info(`Updated scheduled failure issue #${existing.number}`);
             } else {


### PR DESCRIPTION
# Relates to

Closes a follow-up slice of #13580.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and is based on latest `origin/develop` at branch creation.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Based on latest `origin/develop`; zero conflicts at branch creation.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. This only adds a scheduled-failure issue signal to the existing Android device e2e workflow. It does not change PR device-smoke behavior or promote the known signal-only LOCAL arm64 legs.

# Background

## What does this PR do?

When the weekly scheduled `android-device-e2e` host-backed run fails, the workflow now creates or updates a single open GitHub issue titled `Scheduled Android device e2e is failing (#13580)`. The issue includes the run URL, workflow name, backend, timestamp, and the remaining #13580 residuals. Repeated scheduled failures update the issue body and add a fresh comment.

## What kind of change is this?

Improvements / CI hardening.

# Documentation changes needed?

The evidence note documents the behavior in `.github/issue-evidence/13580-android-scheduled-failure-signal.md`. No product documentation change is needed.

# Testing

## Where should a reviewer start?

Start with `.github/workflows/android-device-e2e.yml`, specifically the `Open / update scheduled failure issue` step after artifact upload.

## Detailed testing steps

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/android-device-e2e.yml"); puts "yaml ok"'` -> `yaml ok`
- `git diff --check HEAD -- .github/workflows/android-device-e2e.yml .github/issue-evidence/13580-android-scheduled-failure-signal.md` -> pass
- `git diff --check HEAD~1..HEAD` -> pass before amend; scoped post-amend check above remains clean
- `GOBIN=/tmp/codex-go-bin go install github.com/rhysd/actionlint/cmd/actionlint@latest && /tmp/codex-go-bin/actionlint .github/workflows/android-device-e2e.yml` -> pass

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - workflow-only CI change; no frontend surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - workflow-only CI change; no frontend surface`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - workflow-only CI change; no user UI flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - GitHub Actions scheduled failure path cannot be executed locally; local syntax checks attached`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or marked `N/A - no frontend runtime change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/action/provider/prompt/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - no domain artifact; evidence note added at .github/issue-evidence/13580-android-scheduled-failure-signal.md`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changes.

## Backend + frontend logs

N/A - this is a GitHub Actions workflow failure-notification path. The live scheduled failure path requires a `schedule` event and `GITHUB_TOKEN` issue-write context.

## Screenshots (before / after) + video walkthrough

N/A - workflow-only CI change; no product UI surface.

## Audio / voice walkthrough

N/A - no audio/voice behavior changed.

## Known gaps / failures

- `bun install` was attempted in the isolated worktree. Initial sparse checkout failed because required workspaces were missing; after disabling sparse checkout, checkout expansion failed with `No space left on device` while creating large files under `packages/research/robot/examples/robot-mujoco-demo/evidence/...`. `df -h .` showed only 117 MiB free on the host volume.
- `bun run verify` was not run because `bun install` could not complete on the full host volume.
- Real issue creation/update is not locally runnable; it requires GitHub Actions `schedule` plus issue-write token permissions.
- #13580 still has separate residuals not claimed here: LOCAL arm64 runner and signal-only PR leg promotion after emulator-green evidence.