### PR TITLE
fix(ci): harden self-hosted setuptools fallback

### DIFF
--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -119,7 +119,10 @@ runs:
     - name: Install setuptools for distutils (Python 3.12+)
       if: ${{ inputs.setup-python == 'true' }}
       shell: bash
+      env:
+        RUNNER_ENVIRONMENT: ${{ runner.environment }}
       run: |
+        set +e
         python_bin="${{ steps.system-python.outputs.python-bin }}"
         if [ -z "$python_bin" ]; then
           python_bin="python3"
@@ -128,7 +131,23 @@ runs:
           echo "::warning::No usable python3 found; skipping setuptools install (node-gyp fallback unavailable)"
           exit 0
         fi
-        "$python_bin" -m pip install setuptools
+        if "$python_bin" -c 'import setuptools' >/dev/null 2>&1; then
+          echo "setuptools already present: $("$python_bin" -c 'import setuptools; print(setuptools.__version__)')"
+          exit 0
+        fi
+
+        "$python_bin" -m pip install setuptools \
+          || "$python_bin" -m pip install --user setuptools \
+          || "$python_bin" -m pip install --break-system-packages setuptools
+        install_status=$?
+        if [ "$install_status" -eq 0 ]; then
+          exit 0
+        fi
+        if [ "$RUNNER_ENVIRONMENT" = "self-hosted" ]; then
+          echo "::warning::Could not install setuptools with system python; node-gyp fallback may be unavailable"
+          exit 0
+        fi
+        exit "$install_status"
 
     - name: Install protoc
       # protoc is required even when install-native-deps=false because Rust


### PR DESCRIPTION
## Summary

Follow-up to #14207 / #14188. #14207 correctly avoids the ISA-incompatible `actions/setup-python@v6` download on self-hosted runners with a usable system Python, but the subsequent setuptools step still hard-failed on that same system interpreter if pip was missing or PEP 668 blocked a normal install.

This keeps the #14207 base shape and hardens only the setuptools step:
- skip when `setuptools` is already importable
- try normal pip, then `--user`, then `--break-system-packages`
- on self-hosted runners, warn and continue if setuptools still cannot be installed, because Python is only the documented node-gyp fallback path
- hosted runners retain fail-fast behavior

## Verification

- Parsed `.github/actions/setup-bun-workspace/action.yml` with Python/PyYAML; action has 15 steps.
- Confirmed step conditions/env:
  - system Python probe is self-hosted only
  - `actions/setup-python@v6` still runs on hosted runners and only skips when a self-hosted system Python is present
  - `npm_config_python` prefers the probed system binary, then the setup-python toolcache path
- Extracted the changed bash snippets and ran `bash -n` on each.
- `git diff --check` — passed.

## Evidence

- CI logs: pending; this patch exists because #14207 merged before the real self-hosted path completed.
- UI screenshots/video: N/A - CI composite action only.
- Backend/native/model artifacts: N/A - no runtime product behavior changed.