### PR TITLE
test(ios): fix device capture proof path

### DIFF
--- a/packages/app/scripts/ios-device-lib.test.mjs
+++ b/packages/app/scripts/ios-device-lib.test.mjs
@@ -23,8 +23,8 @@ import {
   CONSOLE_SIGTRAP_SIGNATURE,
   classifyCodesignPreflight,
   classifyConsoleExit,
-  classifyXcresultSummaryForGate,
   classifyIsolatedReruns,
+  classifyXcresultSummaryForGate,
   DEFAULT_IOS_XCUITEST_SHARDS,
   deriveSigningEntitlements,
   evaluateRunnerStaleness,
@@ -32,8 +32,8 @@ import {
   extractXctestrunAppPaths,
   findDeviceRecord,
   findUncoveredIosXcuitestEntries,
-  isBenignIosAppAbsence,
   formatDeviceUnlockWaitMessage,
+  isBenignIosAppAbsence,
   normalizeDeviceLockState,
   normalizeProvisioningProfile,
   PlistData,
@@ -759,7 +759,7 @@ describe("classifyXcresultSummaryForGate", () => {
 describe("ios-device-capture strict summary gate", () => {
   it("keeps test-summary classification behind --strict-gate", () => {
     const source = fs.readFileSync(
-      path.join(process.cwd(), "scripts", "ios-device-capture.mjs"),
+      path.join(process.cwd(), "packages/app/scripts/ios-device-capture.mjs"),
       "utf8",
     );
     const summaryWriteIndex = source.indexOf("test-summary.json");
@@ -1327,9 +1327,9 @@ describe("buildIosXcuitestShardPlan (#13686)", () => {
         'The request to terminate "ai.elizaos.app" failed. found nothing to terminate',
       ),
     ).toBe(true);
-    expect(isBenignIosAppAbsence("No matching processes belonging to you")).toBe(
-      true,
-    );
+    expect(
+      isBenignIosAppAbsence("No matching processes belonging to you"),
+    ).toBe(true);
   });
 });
 
@@ -1386,7 +1386,6 @@ describe("evaluateRunnerStaleness (#13566)", () => {
     expect(decision.newestSource).toBe(null);
   });
 });
-
 
 describe("ios-device-capture agent availability preflight (#13569)", () => {
   it("prefers the configured iOS API base over the cloud health fallback", () => {
@@ -1469,7 +1468,8 @@ describe("ios-device-capture agent availability preflight (#13569)", () => {
         "MessageGestureUITests/testSendsMessage()",
         "OnboardingChatUITests/testFirstReply()",
       ],
-      message: "2 chat legs skipped: agent never ready (not-ready(ready=false))",
+      message:
+        "2 chat legs skipped: agent never ready (not-ready(ready=false))",
     });
   });
 


### PR DESCRIPTION
## Summary
- fix `ios-device-lib.test.mjs` so the strict-gate proof reads the committed `packages/app/scripts/ios-device-capture.mjs` path
- run Biome on the touched test file so the deterministic proof suite is clean

## Context
#13686 has already been implemented on develop via the iOS XCUITest shard plan and fresh-container reset work. While verifying that, the local proof suite failed before reaching the #13686 assertions because this test still pointed at a removed root-level script path.

## Validation
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun test packages/app/scripts/ios-device-lib.test.mjs` (91 pass, 0 fail)
- `bunx @biomejs/biome check packages/app/scripts/ios-device-lib.test.mjs`
- `git diff --check`

Refs #13686.