### PR TITLE
fix(theme): repair Applications token contrast

### DIFF
--- a/.github/issue-evidence/14203-applications-token-contrast-followup.txt
+++ b/.github/issue-evidence/14203-applications-token-contrast-followup.txt
@@ -1,0 +1,63 @@
+Evidence for #14203 / #14205 follow-up: Applications token contrast.
+
+Reviewed on 2026-07-05 from branch
+fix/14203-apps-token-contrast-followup.
+
+Commands run:
+
+node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
+bun test packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
+
+Result:
+2 pass
+0 fail
+2 expect() calls
+
+git diff --check
+
+bunx @biomejs/biome check \
+  packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts \
+  packages/ui/src/cloud/applications/components/BuyDomainCard.tsx \
+  packages/ui/src/cloud/applications/components/app-analytics.tsx \
+  packages/ui/src/cloud/applications/components/app-details-tabs.tsx \
+  packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx \
+  packages/ui/src/cloud/applications/components/app-monetization-settings.tsx \
+  packages/ui/src/cloud/applications/components/app-overview.tsx \
+  packages/ui/src/cloud/applications/components/app-promote.tsx \
+  packages/ui/src/cloud/applications/components/app-settings.tsx \
+  packages/ui/src/cloud/applications/components/app-users.tsx \
+  packages/ui/src/cloud/applications/components/withdraw-dialog.tsx \
+  --no-errors-on-unmatched
+
+Result:
+Checked 11 files. No fixes applied.
+
+Manual review:
+
+- Confirmed remaining Applications `bg-neutral-900` panels now use `bg-card`,
+  so `text-txt` and `text-txt-strong` resolve with the active theme instead of
+  becoming dark text on hard dark cards in the light settings surface.
+- Confirmed destructive red controls use `text-white`, matching the existing
+  settings token rule that white text is valid on solid saturated destructive
+  fills and avoids the low-contrast light-theme `text-txt` foreground.
+- Confirmed no `bg-surface hover:bg-surface` no-op hover classes remain in the
+  Applications components; changed rest/hover pairs use `hover:bg-bg-hover`.
+- Extended the settings token regression guard to scan Applications components
+  and `McpEditorDialog.tsx` for hard dark/light theme-locked utilities.
+
+Visual audit:
+
+bun run --cwd packages/app audit:app
+
+Result:
+Failed before screenshot capture during the shared plugin view prebuild, before
+this branch's Applications surfaces rendered. The unrelated build blockers were:
+
+- plugins/plugin-phone: unresolved `@elizaos/capacitor-phone`
+- plugins/plugin-messages: unresolved `@elizaos/capacitor-messages`
+- plugins/plugin-task-coordinator: unresolved `@xterm/addon-fit`
+
+No `aesthetic-audit-output` was produced in this worktree. Rendered light/dark
+proof still needs the GitHub app/cloud aesthetic audit environment or a checkout
+with those view-build dependencies materialized.

--- a/packages/ui/src/cloud/applications/components/BuyDomainCard.tsx
+++ b/packages/ui/src/cloud/applications/components/BuyDomainCard.tsx
@@ -169,7 +169,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
   }
 
   return (
-    <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
+    <div className="bg-card rounded-sm p-4 space-y-4">
       <div>
         <h3 className="text-sm font-medium text-txt flex items-center gap-2">
           <ShoppingCart className="h-4 w-4 text-[var(--accent)]" />
@@ -327,7 +327,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
               size="sm"
               variant="outline"
               onClick={openBilling}
-              className="self-start border-neutral-700 hover:bg-surface"
+              className="self-start border-neutral-700 hover:bg-bg-hover"
             >
               <CreditCard className="h-4 w-4 mr-1.5" />
               {t("cloud.appDomains.buyAddCredits", {

--- a/packages/ui/src/cloud/applications/components/app-analytics.tsx
+++ b/packages/ui/src/cloud/applications/components/app-analytics.tsx
@@ -370,7 +370,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
     <div className="space-y-4">
       {/* Tab Navigation */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-        <div className="flex items-center gap-1 p-1 bg-neutral-900 rounded-sm w-fit overflow-x-auto">
+        <div className="flex items-center gap-1 p-1 bg-card rounded-sm w-fit overflow-x-auto">
           {tabs.map((tab) => {
             const Icon = tab.icon;
             return (
@@ -401,7 +401,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                 setPeriod(v)
               }
             >
-              <SelectTrigger className="w-[130px] h-9 bg-neutral-900 border-border rounded-sm">
+              <SelectTrigger className="w-[130px] h-9 bg-card border-border rounded-sm">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent className="bg-neutral-800 border-border rounded-sm">
@@ -453,7 +453,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
             </div>
           )}
 
-          <div className="bg-neutral-900 rounded-sm p-4">
+          <div className="bg-card rounded-sm p-4">
             <h3 className="text-sm font-medium text-txt mb-4 flex items-center gap-2">
               <BarChart3 className="h-4 w-4 text-[var(--brand-orange)]" />
               Requests Over Time
@@ -499,7 +499,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
             )}
           </div>
 
-          <div className="bg-neutral-900 rounded-sm p-4">
+          <div className="bg-card rounded-sm p-4">
             <h3 className="text-sm font-medium text-txt mb-4">User Growth</h3>
             {chartData.length > 0 ? (
               <ResponsiveContainer width="100%" height={250}>
@@ -590,7 +590,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
               </div>
 
               <div className="grid gap-4 md:grid-cols-2">
-                <div className="bg-neutral-900 rounded-sm p-4">
+                <div className="bg-card rounded-sm p-4">
                   <h3 className="text-sm font-medium text-txt mb-4">
                     By Source
                   </h3>
@@ -637,10 +637,8 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                   )}
                 </div>
 
-                <div className="bg-neutral-900 rounded-sm p-4">
-                  <h3 className="text-sm font-medium text-txt mb-4">
-                    By Type
-                  </h3>
+                <div className="bg-card rounded-sm p-4">
+                  <h3 className="text-sm font-medium text-txt mb-4">By Type</h3>
                   {Object.keys(requestStats.byType).length > 0 ? (
                     <div className="space-y-2">
                       {Object.entries(requestStats.byType).map(
@@ -730,11 +728,9 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                 </div>
               )}
 
-              <div className="bg-neutral-900 rounded-sm p-4">
+              <div className="bg-card rounded-sm p-4">
                 <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-sm font-medium text-txt">
-                    Top Visitors
-                  </h3>
+                  <h3 className="text-sm font-medium text-txt">Top Visitors</h3>
                   <Button
                     variant="ghost"
                     size="sm"
@@ -767,7 +763,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                         {visitors.map((visitor, index) => (
                           <tr
                             key={visitor.ip}
-                            className="border-b border-border hover:bg-surface"
+                            className="border-b border-border hover:bg-bg-hover"
                           >
                             <td className="py-2 px-3">
                               <div className="flex items-center gap-2">
@@ -847,7 +843,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
               </div>
 
               <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
-                <div className="bg-neutral-900 rounded-sm p-4">
+                <div className="bg-card rounded-sm p-4">
                   <h3 className="text-sm font-medium text-txt mb-4 flex items-center gap-2">
                     <GitBranch className="h-4 w-4 text-[var(--brand-orange)]" />
                     Funnel
@@ -891,7 +887,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                   )}
                 </div>
 
-                <div className="bg-neutral-900 rounded-sm p-4">
+                <div className="bg-card rounded-sm p-4">
                   <h3 className="text-sm font-medium text-txt mb-4">
                     Recent Sessions
                   </h3>
@@ -918,7 +914,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                           {sessionAnalytics.sessions.slice(0, 10).map((s) => (
                             <tr
                               key={s.sessionId}
-                              className="border-b border-border hover:bg-surface"
+                              className="border-b border-border hover:bg-bg-hover"
                             >
                               <td className="py-2 px-3 text-txt text-xs max-w-[180px] truncate">
                                 {s.entryPath}
@@ -957,7 +953,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
 
       {/* Logs Tab */}
       {activeTab === "logs" && (
-        <div className="bg-neutral-900 rounded-sm p-4">
+        <div className="bg-card rounded-sm p-4">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-sm font-medium text-txt">Request Logs</h3>
             <div className="flex items-center gap-2">
@@ -1012,7 +1008,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                     {requestLogs.map((log) => (
                       <tr
                         key={log.id}
-                        className="border-b border-border hover:bg-surface"
+                        className="border-b border-border hover:bg-bg-hover"
                       >
                         <td className="py-2 px-2 text-neutral-500 whitespace-nowrap">
                           {formatDistanceToNow(new Date(log.created_at), {

--- a/packages/ui/src/cloud/applications/components/app-details-tabs.tsx
+++ b/packages/ui/src/cloud/applications/components/app-details-tabs.tsx
@@ -128,7 +128,7 @@ export function AppDetailsTabs({ app, showApiKey }: AppDetailsTabsProps) {
                 "flex min-w-0 items-center justify-center gap-1.5 rounded-sm px-2 py-1.5 text-xs font-medium transition-colors sm:text-sm",
                 activeTab === tab.value
                   ? "bg-card text-txt"
-                  : "text-muted hover:bg-surface hover:text-txt",
+                  : "text-muted hover:bg-bg-hover hover:text-txt",
               )}
             >
               <Icon className="h-4 w-4 hidden sm:block" />

--- a/packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx
+++ b/packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx
@@ -178,7 +178,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
 
   if (error) {
     return (
-      <div className="bg-neutral-900 rounded-sm p-8 text-center">
+      <div className="bg-card rounded-sm p-8 text-center">
         <AlertCircle className="h-12 w-12 mx-auto mb-4 text-red-400" />
         <h3 className="text-lg font-medium text-txt-strong mb-2">
           Error loading earnings
@@ -187,7 +187,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
         <Button
           onClick={fetchEarnings}
           variant="outline"
-          className="border-border hover:bg-surface"
+          className="border-border hover:bg-bg-hover"
         >
           Try Again
         </Button>
@@ -217,7 +217,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
           value={period}
           onValueChange={(v) => setPeriod(v as typeof period)}
         >
-          <SelectTrigger className="w-[140px] h-9 bg-neutral-900 border-border rounded-sm">
+          <SelectTrigger className="w-[140px] h-9 bg-card border-border rounded-sm">
             <SelectValue />
           </SelectTrigger>
           <SelectContent className="bg-neutral-800 border-border rounded-sm">
@@ -230,7 +230,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
 
       {/* Empty State */}
       {!summary && !isLoading && (
-        <div className="bg-neutral-900 rounded-sm p-8 text-center">
+        <div className="bg-card rounded-sm p-8 text-center">
           <TrendingUp className="h-12 w-12 mx-auto mb-4 text-neutral-600" />
           <h3 className="text-lg font-medium text-neutral-500 mb-2">
             No earnings yet
@@ -261,7 +261,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
       {summary && (
         <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
           {/* Total Earnings */}
-          <div className="bg-neutral-900 rounded-sm p-4">
+          <div className="bg-card rounded-sm p-4">
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-xs text-neutral-500">
@@ -284,7 +284,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
           {/* Withdrawable Balance */}
           <div
             className={cn(
-              "bg-neutral-900 rounded-sm p-4",
+              "bg-card rounded-sm p-4",
               canWithdraw && "border border-green-500/30",
             )}
           >
@@ -358,7 +358,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
             { label: "This Month", data: breakdown.thisMonth },
             { label: "All Time", data: breakdown.allTime },
           ].map(({ label, data }) => (
-            <div key={label} className="bg-neutral-900 rounded-sm p-3">
+            <div key={label} className="bg-card rounded-sm p-3">
               <p className="text-xs text-neutral-500">{label}</p>
               <p className="text-lg font-semibold text-txt-strong mt-1">
                 ${data.total.toFixed(2)}
@@ -379,7 +379,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
       )}
 
       {/* Chart */}
-      <div className="bg-neutral-900 rounded-sm p-4">
+      <div className="bg-card rounded-sm p-4">
         <h3 className="text-sm font-medium text-txt mb-4 flex items-center gap-2">
           <BarChart3 className="h-4 w-4 text-neutral-400" />
           Earnings Over Time
@@ -442,7 +442,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
       </div>
 
       {/* Recent Transactions */}
-      <div className="bg-neutral-900 rounded-sm p-4">
+      <div className="bg-card rounded-sm p-4">
         <h3 className="text-sm font-medium text-txt mb-4 flex items-center gap-2">
           <Clock className="h-4 w-4 text-neutral-400" />
           Recent Earnings

--- a/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
+++ b/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
@@ -292,7 +292,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
   return (
     <TooltipProvider>
       <div className="space-y-4">
-        <div className="border border-border bg-neutral-900 p-4">
+        <div className="border border-border bg-card p-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-start gap-3">
               <div
@@ -356,7 +356,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
             "rounded-sm p-4 border transition-colors",
             settings.monetizationEnabled
               ? "bg-green-500/5 border-green-500/20"
-              : "bg-neutral-900 border-border",
+              : "bg-card border-border",
           )}
         >
           <div className="flex items-start gap-3">
@@ -437,7 +437,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
         {/* Settings Grid */}
         <div className="grid gap-4 lg:grid-cols-2">
           {/* Markup Controls */}
-          <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
+          <div className="bg-card rounded-sm p-4 space-y-4">
             <h3 className="text-sm font-medium text-txt">
               {t("cloud.monetization.revenueSettings", {
                 defaultValue: "Revenue Settings",
@@ -492,7 +492,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                       "px-2.5 py-1 text-xs rounded-sm transition-colors",
                       settings.inferenceMarkupPercentage === preset
                         ? "bg-purple-500/20 text-purple-400 border border-purple-500/30"
-                        : "bg-surface text-neutral-400 hover:bg-surface border border-transparent",
+                        : "bg-surface text-neutral-400 hover:bg-bg-hover border border-transparent",
                     )}
                     onClick={() =>
                       updateSetting("inferenceMarkupPercentage", preset)
@@ -554,7 +554,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                       "px-2.5 py-1 text-xs rounded-sm transition-colors",
                       settings.purchaseSharePercentage === preset
                         ? "bg-orange-500/20 text-txt border border-orange-500/30"
-                        : "bg-surface text-neutral-400 hover:bg-surface border border-transparent",
+                        : "bg-surface text-neutral-400 hover:bg-bg-hover border border-transparent",
                     )}
                     onClick={() =>
                       updateSetting("purchaseSharePercentage", preset)
@@ -603,7 +603,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
 
         {/* Enable Monetization Confirmation Dialog */}
         <AlertDialog open={showEnableDialog} onOpenChange={setShowEnableDialog}>
-          <AlertDialogContent className="bg-neutral-900 border-border">
+          <AlertDialogContent className="bg-card border-border">
             <AlertDialogHeader>
               <AlertDialogTitle className="text-txt text-center sm:text-left">
                 {t("cloud.monetization.enableDialogTitle", {

--- a/packages/ui/src/cloud/applications/components/app-overview.tsx
+++ b/packages/ui/src/cloud/applications/components/app-overview.tsx
@@ -342,7 +342,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
                   variant="ghost"
                   type="button"
                   onClick={() => copyToClipboard(displayApiKey, "API Key")}
-                  className="p-2 bg-surface hover:bg-surface rounded-sm transition-colors shrink-0"
+                  className="p-2 bg-surface hover:bg-bg-hover rounded-sm transition-colors shrink-0"
                 >
                   {copiedItem === "API Key" ? (
                     <Check className="h-4 w-4 text-green-400" />
@@ -410,7 +410,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
       </div>
 
       {/* Deployment (#9145) — the client trigger for POST /apps/:id/deploy. */}
-      <div className="bg-neutral-900 rounded-sm p-4 space-y-3">
+      <div className="bg-card rounded-sm p-4 space-y-3">
         <div className="flex items-center justify-between">
           <h3 className="text-sm font-medium text-txt flex items-center gap-2">
             <Rocket className="h-4 w-4 text-[var(--accent)]" />
@@ -475,7 +475,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
               variant="ghost"
               type="submit"
               disabled={deploymentButtonDisabled}
-              className="h-9 w-full min-w-28 text-xs text-neutral-200 bg-surface hover:bg-surface flex items-center justify-center gap-1 transition-colors disabled:opacity-50"
+              className="h-9 w-full min-w-28 text-xs text-neutral-200 bg-surface hover:bg-bg-hover flex items-center justify-center gap-1 transition-colors disabled:opacity-50"
             >
               {isDeploying || isPollingDeployment || deploymentInProgress ? (
                 <Loader2 className="h-3 w-3 animate-spin" />
@@ -524,7 +524,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
 
       <div className="grid gap-4 md:grid-cols-2">
         {/* API Key Card */}
-        <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
+        <div className="bg-card rounded-sm p-4 space-y-4">
           <div className="flex items-center justify-between">
             <h3 className="text-sm font-medium text-txt flex items-center gap-2">
               <Key className="h-4 w-4 text-[var(--accent)]" />
@@ -592,7 +592,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
                     variant="ghost"
                     type="button"
                     onClick={() => setShowKey(!showKey)}
-                    className="p-1.5 hover:bg-surface rounded-sm transition-colors"
+                    className="p-1.5 hover:bg-bg-hover rounded-sm transition-colors"
                   >
                     {showKey ? (
                       <EyeOff className="h-3.5 w-3.5 text-muted" />
@@ -604,7 +604,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
                     variant="ghost"
                     type="button"
                     onClick={() => copyToClipboard(displayApiKey, "API Key")}
-                    className="p-1.5 hover:bg-surface rounded-sm transition-colors"
+                    className="p-1.5 hover:bg-bg-hover rounded-sm transition-colors"
                   >
                     {copiedItem === "API Key" ? (
                       <Check className="h-3.5 w-3.5 text-green-400" />
@@ -625,7 +625,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
         </div>
 
         {/* Basic Info Card */}
-        <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
+        <div className="bg-card rounded-sm p-4 space-y-4">
           <h3 className="text-sm font-medium text-txt flex items-center gap-2">
             <Globe className="h-4 w-4 text-[var(--accent)]" />
             {t("cloud.apps.overview.appInformation", {
@@ -685,7 +685,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
 
       {/* Monetization Card */}
       {monetizationEnabled !== null && (
-        <div className="bg-neutral-900 rounded-sm p-4">
+        <div className="bg-card rounded-sm p-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <div className="p-2 rounded-sm bg-orange-500/10">
@@ -718,7 +718,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
                 onClick={() =>
                   navigate(`/dashboard/apps/${app.id}?tab=monetization`)
                 }
-                className="p-2 hover:bg-surface rounded-sm transition-colors"
+                className="p-2 hover:bg-bg-hover rounded-sm transition-colors"
               >
                 <ChevronRight className="h-4 w-4 text-neutral-400" />
               </Button>
@@ -728,7 +728,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
       )}
 
       {/* Allowed Origins */}
-      <div className="bg-neutral-900 rounded-sm p-4 space-y-3">
+      <div className="bg-card rounded-sm p-4 space-y-3">
         <div className="flex items-center justify-between">
           <h3 className="text-sm font-medium text-txt flex items-center gap-2">
             <Shield className="h-4 w-4 text-muted" />

--- a/packages/ui/src/cloud/applications/components/app-promote.tsx
+++ b/packages/ui/src/cloud/applications/components/app-promote.tsx
@@ -125,7 +125,7 @@ export function AppPromote({ app }: AppPromoteProps) {
             size="sm"
             onClick={handleGenerateAssets}
             disabled={isGeneratingAssets}
-            className="border-border hover:bg-surface rounded-sm"
+            className="border-border hover:bg-bg-hover rounded-sm"
           >
             {isGeneratingAssets ? (
               <>
@@ -161,7 +161,7 @@ export function AppPromote({ app }: AppPromoteProps) {
 
       {/* Suggestions */}
       {suggestions && (
-        <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
+        <div className="bg-card rounded-sm p-4 space-y-4">
           <h3 className="text-sm font-medium text-txt">
             {t("cloud.appPromote.tipsTitle", {
               defaultValue: "Promotion Tips",
@@ -197,7 +197,7 @@ export function AppPromote({ app }: AppPromoteProps) {
       )}
 
       {/* Connected Ad Accounts */}
-      <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
+      <div className="bg-card rounded-sm p-4 space-y-4">
         <div className="flex items-center justify-between">
           <h3 className="text-sm font-medium text-txt">
             {t("cloud.appPromote.connectedAccounts", {
@@ -208,7 +208,7 @@ export function AppPromote({ app }: AppPromoteProps) {
             variant="outline"
             size="sm"
             asChild
-            className="border-border hover:bg-surface rounded-sm"
+            className="border-border hover:bg-bg-hover rounded-sm"
           >
             <Link
               to="/dashboard/settings?tab=connections"

--- a/packages/ui/src/cloud/applications/components/app-settings.tsx
+++ b/packages/ui/src/cloud/applications/components/app-settings.tsx
@@ -192,7 +192,7 @@ export function AppSettings({ app }: AppSettingsProps) {
   return (
     <div className="space-y-4">
       {/* Basic Settings */}
-      <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
+      <div className="bg-card rounded-sm p-4 space-y-4">
         <h3 className="text-sm font-medium text-txt flex items-center gap-2">
           <Settings className="h-4 w-4 text-[var(--brand-orange)]" />
           {t("cloud.appSettings.basicSettings", {
@@ -318,7 +318,7 @@ export function AppSettings({ app }: AppSettingsProps) {
       </div>
 
       {/* Allowed Origins */}
-      <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
+      <div className="bg-card rounded-sm p-4 space-y-4">
         <div>
           <h3 className="text-sm font-medium text-txt flex items-center gap-2">
             <Shield className="h-4 w-4 text-muted" />
@@ -351,7 +351,7 @@ export function AppSettings({ app }: AppSettingsProps) {
             onClick={addOrigin}
             variant="outline"
             size="icon"
-            className="shrink-0 border-border hover:bg-surface"
+            className="shrink-0 border-border hover:bg-bg-hover"
           >
             <Plus className="h-4 w-4" />
           </Button>
@@ -369,7 +369,7 @@ export function AppSettings({ app }: AppSettingsProps) {
                   variant="ghost"
                   type="button"
                   onClick={() => removeOrigin(origin)}
-                  className="ml-1 p-0.5 hover:bg-surface rounded-sm transition-colors"
+                  className="ml-1 p-0.5 hover:bg-bg-hover rounded-sm transition-colors"
                 >
                   <X className="h-3 w-3" />
                 </Button>
@@ -427,7 +427,7 @@ export function AppSettings({ app }: AppSettingsProps) {
               <AlertDialogTrigger asChild>
                 <Button
                   size="sm"
-                  className="bg-red-600 hover:bg-red-700 text-txt shrink-0"
+                  className="bg-red-600 hover:bg-red-700 text-white shrink-0"
                   disabled={isRegenerating}
                 >
                   {isRegenerating ? (
@@ -442,7 +442,7 @@ export function AppSettings({ app }: AppSettingsProps) {
                   )}
                 </Button>
               </AlertDialogTrigger>
-              <AlertDialogContent className="bg-neutral-900 border-border">
+              <AlertDialogContent className="bg-card border-border">
                 <AlertDialogHeader>
                   <AlertDialogTitle className="text-txt">
                     {t("cloud.appSettings.regenerateDialogTitle", {
@@ -457,12 +457,12 @@ export function AppSettings({ app }: AppSettingsProps) {
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
-                  <AlertDialogCancel className="border-border text-txt hover:bg-surface">
+                  <AlertDialogCancel className="border-border text-txt hover:bg-bg-hover">
                     {t("cloud.appSettings.cancel", { defaultValue: "Cancel" })}
                   </AlertDialogCancel>
                   <AlertDialogAction
                     onClick={handleRegenerateApiKey}
-                    className="bg-red-600 hover:bg-red-700 text-txt"
+                    className="bg-red-600 hover:bg-red-700 text-white"
                   >
                     {t("cloud.appSettings.regenerateApiKey", {
                       defaultValue: "Regenerate API Key",
@@ -490,7 +490,7 @@ export function AppSettings({ app }: AppSettingsProps) {
               <AlertDialogTrigger asChild>
                 <Button
                   size="sm"
-                  className="bg-red-600 hover:bg-red-700 text-txt shrink-0"
+                  className="bg-red-600 hover:bg-red-700 text-white shrink-0"
                   disabled={isDeleting}
                 >
                   {isDeleting ? (
@@ -505,7 +505,7 @@ export function AppSettings({ app }: AppSettingsProps) {
                   )}
                 </Button>
               </AlertDialogTrigger>
-              <AlertDialogContent className="bg-neutral-900 border-border">
+              <AlertDialogContent className="bg-card border-border">
                 <AlertDialogHeader>
                   <AlertDialogTitle className="text-txt">
                     {t("cloud.appSettings.deleteDialogTitle", {
@@ -525,12 +525,12 @@ export function AppSettings({ app }: AppSettingsProps) {
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
-                  <AlertDialogCancel className="border-border text-txt hover:bg-surface">
+                  <AlertDialogCancel className="border-border text-txt hover:bg-bg-hover">
                     {t("cloud.appSettings.cancel", { defaultValue: "Cancel" })}
                   </AlertDialogCancel>
                   <AlertDialogAction
                     onClick={handleDelete}
-                    className="bg-red-600 hover:bg-red-700 text-txt"
+                    className="bg-red-600 hover:bg-red-700 text-white"
                   >
                     {t("cloud.appSettings.deleteApp", {
                       defaultValue: "Delete App",

--- a/packages/ui/src/cloud/applications/components/app-users.tsx
+++ b/packages/ui/src/cloud/applications/components/app-users.tsx
@@ -128,7 +128,7 @@ export function AppUsers({ appId }: AppUsersProps) {
             {users.map((appUser) => (
               <div
                 key={appUser.id}
-                className="flex items-center justify-between rounded-sm bg-bg-accent p-3 transition-all hover:bg-surface"
+                className="flex items-center justify-between rounded-sm bg-bg-accent p-3 transition-all hover:bg-bg-hover"
               >
                 <div className="flex items-center gap-3 flex-1 min-w-0">
                   <Avatar className="h-8 w-8">
@@ -231,7 +231,7 @@ export function AppUsers({ appId }: AppUsersProps) {
                 {visitors.map((visitor, index) => (
                   <tr
                     key={visitor.ip}
-                    className="border-b border-border/60 hover:bg-surface"
+                    className="border-b border-border/60 hover:bg-bg-hover"
                   >
                     <td className="py-2 px-3">
                       <div className="flex items-center gap-2">

--- a/packages/ui/src/cloud/applications/components/withdraw-dialog.tsx
+++ b/packages/ui/src/cloud/applications/components/withdraw-dialog.tsx
@@ -104,7 +104,7 @@ export function WithdrawDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-md bg-neutral-900 border-border">
+      <DialogContent className="sm:max-w-md bg-card border-border">
         {state === "confirm" && (
           <>
             <DialogHeader>
@@ -270,7 +270,7 @@ export function WithdrawDialog({
               </Button>
               <Button
                 onClick={() => setState("confirm")}
-                className="bg-surface hover:bg-surface text-txt"
+                className="bg-surface hover:bg-bg-hover text-txt"
               >
                 Try Again
               </Button>

--- a/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
+++ b/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
@@ -26,11 +26,13 @@ const ROOT = join(fileURLToPath(new URL("..", import.meta.url)));
 
 const SCANNED_PATHS = [
   "account-security",
+  "applications/components",
   "organization",
   "billing/components",
   "connectors/discord-gateway-connection.tsx",
   "connectors/telegram-connection.tsx",
   "api-keys/ApiKeysView.tsx",
+  "mcps/McpEditorDialog.tsx",
 ];
 
 const STATUS_TOKEN_FILES = [
@@ -48,6 +50,7 @@ const FORBIDDEN_TOKEN_PATTERNS: RegExp[] = [
   /\bborder-white\/[\w.[\]%]+/,
   /\bdivide-white\/[\w.[\]%]+/,
   /\bbg-black(?:\/[\w.[\]%]+)?/, // opaque / translucent black surfaces
+  /\bbg-neutral-900\b/,
   /\bbg-\[rgba\(10,10,10/, // bespoke near-black panels
   /\bbg-\[rgba\(29,29,29/,
   /\bbg-\[#(?:1a1a1a|0b0d11)\]/,
@@ -60,7 +63,7 @@ const FORBIDDEN_TOKEN_PATTERNS: RegExp[] = [
 // A `text-white`-family token is permitted when the same className also paints a
 // solid saturated background (white-on-color reads in both themes).
 const SOLID_COLOR_BG =
-  /\bbg-(?:accent|primary|destructive)\b|\bbg-\[#(?:eb4335|ff5800|e54f00)\]|\bbg-\[(?:rgba\()?var\(--accent/i;
+  /\bbg-(?:accent|primary|destructive|red-(?:5|6|7|8|9)00)\b|\bbg-\[#(?:eb4335|ff5800|e54f00)\]|\bbg-\[(?:rgba\()?var\(--accent/i;
 const isWhiteTextToken = (pattern: RegExp) =>
   pattern.source.includes("text-white");
 


### PR DESCRIPTION
## Summary

Follow-up to #14205 / #14203 after review found the one-for-one retokenization still had light-theme contrast holes.

- convert remaining hard `bg-neutral-900` Applications panels/dialogs to semantic `bg-card`
- restore `text-white` on solid red destructive buttons so light-theme `text-txt` does not drop below contrast
- replace `bg-surface hover:bg-surface` no-op hovers with `hover:bg-bg-hover`
- extend the Cloud settings token regression guard to scan Applications components and `McpEditorDialog.tsx`
- add reviewed evidence notes under `.github/issue-evidence/14203-applications-token-contrast-followup.txt`

## Verification

- `node packages/app-core/scripts/ensure-shared-i18n-data.mjs`
- `bun test packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts` -> 2 pass
- `git diff --check`
- `bunx @biomejs/biome check packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts packages/ui/src/cloud/applications/components/BuyDomainCard.tsx packages/ui/src/cloud/applications/components/app-analytics.tsx packages/ui/src/cloud/applications/components/app-details-tabs.tsx packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx packages/ui/src/cloud/applications/components/app-monetization-settings.tsx packages/ui/src/cloud/applications/components/app-overview.tsx packages/ui/src/cloud/applications/components/app-promote.tsx packages/ui/src/cloud/applications/components/app-settings.tsx packages/ui/src/cloud/applications/components/app-users.tsx packages/ui/src/cloud/applications/components/withdraw-dialog.tsx --no-errors-on-unmatched`

## Visual audit

Attempted `bun run --cwd packages/app audit:app`, but it failed before screenshot capture during unrelated plugin view prebuilds:

- `plugins/plugin-phone`: unresolved `@elizaos/capacitor-phone`
- `plugins/plugin-messages`: unresolved `@elizaos/capacitor-messages`
- `plugins/plugin-task-coordinator`: unresolved `@xterm/addon-fit`

No `aesthetic-audit-output` was produced locally. This still needs rendered light/dark audit proof from CI or a checkout with those view-build dependencies materialized before merge.

Fixes the contrast regressions found after #14205.