### PR TITLE
fix(security): SHA-256 for lifeops schedule-observation ids (CodeQL #649); dismiss #641 FP

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/schedule-state.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/schedule-state.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Locks the schedule-observation identity scheme. `observationId` derives the
+ * persisted primary key that `repository.upsertScheduleObservation`'s
+ * ON CONFLICT(id) collapses duplicates on, so the derivation must be
+ * deterministic (same tuple -> same id, for dedup) and use a strong,
+ * non-weak-crypto digest (SHA-256) — CodeQL js/weak-cryptographic-algorithm
+ * flags SHA-1 here even though the use is content-addressing, not signing.
+ * The golden recompute below fails if the code ever reverts to SHA-1.
+ */
+import crypto from "node:crypto";
+import type { SyncLifeOpsScheduleObservationsRequest } from "@elizaos/plugin-elizacloud/cloud/lifeops-schedule-sync-contracts";
+import { describe, expect, it } from "vitest";
+import { recordsFromSyncRequest } from "./schedule-state";
+
+const AGENT_ID = "agent-schedule-id-test";
+
+// UTC, 30-min-aligned so window bucketing is a no-op and the input flows
+// straight into the id tuple; keeps the golden recompute inputs unambiguous.
+const baseRequest = (
+  overrides: Partial<SyncLifeOpsScheduleObservationsRequest> = {},
+): SyncLifeOpsScheduleObservationsRequest => ({
+  deviceId: "device-alpha",
+  deviceKind: "mac",
+  timezone: "UTC",
+  observedAt: "2026-01-01T10:05:00.000Z",
+  observations: [
+    {
+      circadianState: "awake",
+      stateConfidence: 0.9,
+      windowStartAt: "2026-01-01T10:00:00.000Z",
+    },
+  ],
+  ...overrides,
+});
+
+// Independent reimplementation of the id derivation, keyed off the returned
+// record's own fields, so it verifies the algorithm without coupling to the
+// internal bucketing that produces windowStartAt.
+function expectedId(
+  observation: {
+    agentId: string;
+    origin: string;
+    deviceId: string;
+    circadianState: string;
+    windowStartAt: string;
+    mealLabel: string | null;
+  },
+  hash: "sha256" | "sha1",
+): string {
+  const digest = crypto
+    .createHash(hash)
+    .update(
+      [
+        observation.agentId,
+        observation.origin,
+        observation.deviceId,
+        observation.circadianState,
+        observation.windowStartAt,
+        observation.mealLabel ?? "",
+      ].join("|"),
+    )
+    .digest("hex")
+    .slice(0, 16);
+  return `lifeops-schedule-observation:${digest}`;
+}
+
+describe("schedule observation id derivation", () => {
+  it("produces a prefixed 16-hex-char content-addressed id", () => {
+    const [observation] = recordsFromSyncRequest({
+      agentId: AGENT_ID,
+      origin: "device_sync",
+      request: baseRequest(),
+    });
+    expect(observation).toBeDefined();
+    expect(observation.id).toMatch(
+      /^lifeops-schedule-observation:[0-9a-f]{16}$/,
+    );
+  });
+
+  it("is deterministic so identical observations dedup to one row", () => {
+    const first = recordsFromSyncRequest({
+      agentId: AGENT_ID,
+      origin: "device_sync",
+      request: baseRequest(),
+    })[0];
+    const second = recordsFromSyncRequest({
+      agentId: AGENT_ID,
+      origin: "device_sync",
+      request: baseRequest(),
+    })[0];
+    expect(second.id).toBe(first.id);
+  });
+
+  it("distinguishes observations that differ in a tuple field", () => {
+    const alpha = recordsFromSyncRequest({
+      agentId: AGENT_ID,
+      origin: "device_sync",
+      request: baseRequest(),
+    })[0];
+    const beta = recordsFromSyncRequest({
+      agentId: AGENT_ID,
+      origin: "device_sync",
+      request: baseRequest({ deviceId: "device-beta" }),
+    })[0];
+    expect(beta.id).not.toBe(alpha.id);
+  });
+
+  it("derives the id with SHA-256, not the weak SHA-1 (CodeQL #649)", () => {
+    const [observation] = recordsFromSyncRequest({
+      agentId: AGENT_ID,
+      origin: "device_sync",
+      request: baseRequest(),
+    });
+    expect(observation.id).toBe(expectedId(observation, "sha256"));
+    expect(observation.id).not.toBe(expectedId(observation, "sha1"));
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/schedule-state.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/schedule-state.ts
@@ -225,8 +225,13 @@ function observationId(args: {
   windowStartAt: string;
   mealLabel: LifeOpsScheduleMealLabel | null;
 }): string {
+  // Content-addressed dedup key: identical (agent, origin, device, state,
+  // window, meal) tuples must collapse to one row via the upsert's
+  // ON CONFLICT(id) (repository.upsertScheduleObservation). SHA-256 (not a
+  // weak hash) gives a stable digest whose collision space is comfortable at
+  // the truncation below; this is deduplication, not a security signature.
   const digest = crypto
-    .createHash("sha1")
+    .createHash("sha256")
     .update(
       [
         args.agentId,
@@ -299,7 +304,7 @@ export function resolveScheduleDeviceIdentity(): ResolvedScheduleDeviceIdentity 
   const deviceId =
     envDeviceId && envDeviceId.length > 0
       ? envDeviceId
-      : `${process.platform}-${crypto.createHash("sha1").update(process.cwd()).digest("hex").slice(0, 8)}`;
+      : `${process.platform}-${crypto.createHash("sha256").update(process.cwd()).digest("hex").slice(0, 8)}`;
   const envDeviceKind =
     process.env.ELIZA_DEVICE_KIND?.trim().toLowerCase() ?? "";
   if (


### PR DESCRIPTION
## Security hardening — CodeQL alerts #641 and #649

Two CodeQL alerts triaged. One is a real (if non-security) weak-crypto use fixed in code; the other is a genuine false positive dismissed via the API with justification.

### Alert #649 — `js/weak-cryptographic-algorithm` (fixed here)
`plugins/plugin-personal-assistant/src/lifeops/schedule-state.ts` used **SHA-1** in two places, both of which derive **deterministic identifiers, not security signatures**:

- `observationId()` builds the persisted **primary key** that `LifeOpsRepository.upsertScheduleObservation` collapses duplicates on via `INSERT ... ON CONFLICT(id) DO UPDATE` — a content-addressed **dedup key** over `(agentId, origin, deviceId, circadianState, windowStartAt, mealLabel)`.
- `resolveScheduleDeviceIdentity()` derives a short fallback device id from `process.cwd()` when `ELIZA_DEVICE_ID`/`HOSTNAME` are unset.

Neither is authentication, signing, integrity-against-adversary, secret derivation, or password hashing, so collision-resistance-for-security is not the requirement. But SHA-1 is a deprecated primitive, and the cheapest, most durable resolution is to **switch both to SHA-256** — it keeps the exact digest format (hex), the same truncation (16 / 8 chars), and full determinism, while making intent explicit ("a strong, stable content hash") and clearing the alert permanently rather than leaving dismissed-but-present weak crypto that re-alerts when the code moves.

A durable `// why` comment now records that this id is a dedup key, not a signature.

**Migration note:** these ids are internal DB dedup keys with a ~48h relevance window (`SCHEDULE_OBSERVATION_LOOKBACK_MS`) and `ON CONFLICT DO UPDATE` idempotency; they are not exposed in any API/URL/external contract. Changing the digest changes derived ids, so during a mixed-version rollout a logical observation may briefly not dedup against an old SHA-1 row — self-healing within the lookback window. No fixtures/snapshots pin these ids (verified repo-wide).

### Alert #641 — `js/clear-text-storage-of-sensitive-data` (dismissed, false positive)
`packages/homepage/src/pages/get-started.tsx` — CodeQL flags storing the value from `generateOAuthState()` in `sessionStorage`. That value is the **OAuth 2.0 CSRF `state` nonce**, not a secret/credential/PII:
- It is transmitted **in cleartext in the Discord authorize-URL query string by design** (address bar, history, provider logs) — a value intentionally sent in cleartext cannot be "sensitive data stored in clear text."
- Its security property is **unpredictability + binding across the redirect round-trip**, not confidentiality. It is compared on return (`storedState !== discordState`) then removed.
- `sessionStorage` is the RFC 6749 §10.12 / OAuth-2.0-for-Browser-Based-Apps-BCP recommended store; the value **must** persist across the full-page redirect for the CSRF check to work. Encrypting it would be security theater (the key would live in the same JS bundle readable by any XSS that could already read the store).

Dismissed via the code-scanning API as `false positive` with the above rationale. No code change is correct here.

## Verification

- **New test** `plugins/plugin-personal-assistant/src/lifeops/schedule-state.test.ts` — 4/4 passing:
  - id matches `^lifeops-schedule-observation:[0-9a-f]{16}$`
  - deterministic (identical observations dedup to one id)
  - distinct when a tuple field differs
  - **algorithm lock**: id equals the SHA-256 golden recompute and does **not** equal the SHA-1 recompute (fails on the vulnerable version)
- `bun run --cwd plugins/plugin-personal-assistant typecheck` → exit 0
- `biome check` on both touched files → clean

```
Test Files  1 passed (1)
     Tests  4 passed (4)
```

Evidence rows (PR_EVIDENCE.md): rendered-UI / trajectory / screenshots rows are **N/A** — this is a crypto-primitive swap in a pure ID-derivation function plus a CodeQL dismissal; there is no user-facing UI or model behavior change. Domain artifact affected (observation-id derivation) is exercised by the new unit test.

Advances the CodeQL security-alert cleanup. Fixes CodeQL alert #649; #641 dismissed as false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
