### PR TITLE
test(theme): scan the retokenized Applications + MCPs surfaces (#14205 follow-up)

### DIFF
--- a/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
+++ b/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
@@ -26,6 +26,11 @@ const ROOT = join(fileURLToPath(new URL("..", import.meta.url)));
 
 const SCANNED_PATHS = [
   "account-security",
+  // #14205 retokenized these two Settings surfaces after the #13755 audit
+  // found ~170 hardcoded light-on-dark utilities; scanning them keeps the
+  // fix regression-proof (the gap that let the drift accumulate unnoticed).
+  "applications",
+  "mcps",
   "organization",
   "billing/components",
   "connectors/discord-gateway-connection.tsx",


### PR DESCRIPTION
#14205 landed the retokenization from my #13755 audit inventory (all 11 files — verified complete), but **`SCANNED_PATHS` never gained `applications`/`mcps`** — so the freshly-fixed surfaces had no regression guard, which is precisely the gap that let ~170 violations accumulate unnoticed the first time.

Two-line (plus why-comment) addition. **Red/green proven**: scan is green on both dirs at tip (2/2 — confirming #14205 is complete); a planted `text-white` in `ApplicationsPage.tsx` fails the scan naming the exact file+pattern; green again after revert.

My commit → no self-merge; lane please arm. (#13406, #14205 follow-up) `[maintainer]`