### PR TITLE
fix(orchestrator): preserve project bindings on forks

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.test.ts
@@ -269,6 +269,36 @@ describe("orchestrator routes — task CRUD", () => {
     expect(result.json.acceptanceCriteria).toEqual(["ci green"]);
   });
 
+  it("forwards project binding fields when creating a task", async () => {
+    const createTask = vi.fn(async (input: Record<string, unknown>) => ({
+      id: "created-task",
+      ...input,
+    }));
+    const result = await call(
+      { createTask } as unknown as OrchestratorTaskService,
+      "POST",
+      "/api/orchestrator/tasks",
+      {
+        title: "Project work",
+        goal: "Stay in the registered project",
+        projectId: "project-123",
+        workdir: "/repo/project",
+        worldId: "caller-world",
+      },
+    );
+
+    expect(result.status).toBe(201);
+    expect(createTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Project work",
+        goal: "Stay in the registered project",
+        projectId: "project-123",
+        workdir: "/repo/project",
+        worldId: "caller-world",
+      }),
+    );
+  });
+
   it("rejects a task with no title", async () => {
     const result = await call(
       makeService(),
@@ -412,6 +442,35 @@ describe("orchestrator routes — lifecycle", () => {
         )
       ).status,
     ).toBe(400);
+  });
+
+  it("forwards project binding overrides when forking a task", async () => {
+    const forkTask = vi.fn(async () => ({
+      id: "forked-task",
+      parentTaskId: "origin-task",
+    }));
+    const result = await call(
+      { forkTask } as unknown as OrchestratorTaskService,
+      "POST",
+      "/api/orchestrator/tasks/origin-task/fork",
+      {
+        title: "Project fork",
+        projectId: "project-456",
+        workdir: "/repo/project-b",
+        worldId: "project-world",
+      },
+    );
+
+    expect(result.status).toBe(201);
+    expect(forkTask).toHaveBeenCalledWith(
+      "origin-task",
+      expect.objectContaining({
+        title: "Project fork",
+        projectId: "project-456",
+        workdir: "/repo/project-b",
+        worldId: "project-world",
+      }),
+    );
   });
 
   it("requires a boolean `passed` to validate", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
@@ -524,6 +524,35 @@ describe("project memory-world stamping at bind time (#13776 D3)", () => {
     }
   });
 
+  it("preserves a task's project memory world when forking", async () => {
+    const project = upsertProject({ name: "repo-a", localPath: firstDir });
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const acp = makeWorkdirCapturingAcp();
+    const service = new OrchestratorTaskService(makeRuntime(acp.service), {
+      store,
+    });
+    await service.start();
+    try {
+      const parent = await service.createTask({
+        title: "bound parent",
+        goal: "work in project A",
+        acceptanceCriteria: [],
+        workdir: firstDir,
+      });
+      const fork = await service.forkTask(parent.id);
+      const expectedWorld = projectWorldId(BINDER_AGENT_ID, project.id);
+
+      expect(fork?.parentTaskId).toBe(parent.id);
+      expect(fork?.projectId).toBe(project.id);
+      expect(fork?.worldId).toBe(expectedWorld);
+      const record = fork ? await store.getTask(fork.id) : null;
+      expect(record?.task.projectId).toBe(project.id);
+      expect(record?.task.worldId).toBe(expectedWorld);
+    } finally {
+      await service.stop().catch(() => undefined);
+    }
+  });
+
   it("leaves an unbound task's worldId untouched and lets an explicit worldId win", async () => {
     const project = upsertProject({ name: "repo-a", localPath: firstDir });
     const store = new OrchestratorTaskStore({ backend: "memory" });

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -321,6 +321,8 @@ async function dispatchOrchestratorRoutes(
       acceptanceCriteria: asStringArray(body.acceptanceCriteria),
       ownerUserId: asString(body.ownerUserId),
       worldId: asString(body.worldId),
+      projectId: asString(body.projectId),
+      workdir: asString(body.workdir),
       roomId: asString(body.roomId),
       taskRoomId: asString(body.taskRoomId),
       providerPolicy: asProviderPolicy(body.providerPolicy),
@@ -518,6 +520,9 @@ async function dispatchOrchestratorRoutes(
         goal: asString(body.goal),
         priority: asPriority(body.priority),
         acceptanceCriteria: asStringArray(body.acceptanceCriteria),
+        worldId: asString(body.worldId),
+        projectId: asString(body.projectId),
+        workdir: asString(body.workdir),
       });
       if (!forked) {
         sendError(res, "Task not found", 404);

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -2517,6 +2517,12 @@ export class OrchestratorTaskService extends Service {
   ): Promise<TaskThreadDetailDto | null> {
     const doc = await this.store.getTask(taskId);
     if (!doc) return null;
+    const projectId = overrides.projectId ?? doc.task.projectId ?? undefined;
+    const worldId =
+      overrides.worldId ??
+      (overrides.projectId && overrides.projectId !== doc.task.projectId
+        ? undefined
+        : doc.task.worldId);
     return this.createTask({
       title: overrides.title ?? `${doc.task.title} (fork)`,
       goal: overrides.goal ?? doc.task.goal,
@@ -2527,7 +2533,9 @@ export class OrchestratorTaskService extends Service {
         ...doc.task.acceptanceCriteria,
       ],
       ownerUserId: overrides.ownerUserId ?? doc.task.ownerUserId,
-      worldId: overrides.worldId ?? doc.task.worldId,
+      worldId,
+      projectId,
+      workdir: overrides.workdir,
       providerPolicy: overrides.providerPolicy ?? doc.task.providerPolicy,
       currentPlan: overrides.currentPlan ?? doc.task.currentPlan,
       parentTaskId: taskId,


### PR DESCRIPTION
## Summary
- Forward project binding fields through orchestrator task create/fork routes.
- Preserve a task's projectId/worldId when forking, while allowing an explicit project override to derive its own project world.
- Add route-boundary coverage and real OrchestratorTaskService coverage for project-bound forks.

## Verification
- PASS: `bunx @biomejs/biome check --write plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.test.ts plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts --no-errors-on-unmatched`
- PASS: `bun test plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.test.ts plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts` (37 tests, run in main workspace with installed/generated artifacts)
- TEMP WORKTREE NOTE: the same test command in `/tmp/eliza-fork-binding` failed before execution because that clean worktree lacked generated/dependency artifacts: `fs-extra` and `./generated/validation-keyword-data.js`.