### PR TITLE
fix(ci): keep setuptools shim best effort on self-hosted

### DIFF
--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -119,6 +119,8 @@ runs:
     - name: Install setuptools for distutils (Python 3.12+)
       if: ${{ inputs.setup-python == 'true' }}
       shell: bash
+      env:
+        RUNNER_ENVIRONMENT: ${{ runner.environment }}
       run: |
         python_bin="${{ steps.system-python.outputs.python-bin }}"
         if [ -z "$python_bin" ]; then
@@ -131,6 +133,22 @@ runs:
         if "$python_bin" -c 'import setuptools' >/dev/null 2>&1; then
           echo "setuptools already present: $("$python_bin" -c 'import setuptools; print(setuptools.__version__)')"
           exit 0
+        fi
+        if "$python_bin" - <<'PY'
+        import sys
+        raise SystemExit(0 if sys.version_info < (3, 12) else 1)
+        PY
+        then
+          echo "Python <3.12; setuptools distutils shim is not required"
+          exit 0
+        fi
+        if ! "$python_bin" -m pip --version >/dev/null 2>&1; then
+          if [ "$RUNNER_ENVIRONMENT" = "self-hosted" ]; then
+            echo "::warning::No usable pip found; skipping setuptools install (node-gyp fallback unavailable)"
+            exit 0
+          fi
+          echo "::error::No usable pip found for setuptools install"
+          exit 1
         fi
         "$python_bin" -m pip install setuptools \
           || "$python_bin" -m pip install --user setuptools \


### PR DESCRIPTION
## Summary
- skip the setuptools/distutils shim when the selected Python is older than 3.12
- warn and continue on self-hosted runners when Python 3.12+ has no usable pip, keeping the node-gyp fallback best-effort
- keep hosted runners fail-fast when pip is missing

## Validation
- Parsed `.github/actions/setup-bun-workspace/action.yml` with PyYAML; action has 15 steps
- Extracted every composite `run:` block and ran `bash -n`
- `bun test packages/scripts/__tests__/ci-bun-version-contract.test.ts packages/scripts/__tests__/turbo-cache-key.test.ts packages/scripts/__tests__/ci-turbo-cache-contract.test.ts` (16 pass, 0 fail)
- Simulated setuptools step behavior:
  - Python 3.11 without setuptools exits 0 without pip
  - self-hosted Python 3.12 without pip warns and exits 0
  - hosted Python 3.12 without pip exits 1
- `git diff --check`

Follow-up to #14207 / #14211 / #14188; keeps #14215/#14216 closed as duplicate branches.