### PR TITLE
fix(ui): paint wallpaper to true screen bottom on standalone home view (kill residual black band)

### DIFF
--- a/packages/ui/src/backgrounds/AppBackground.test.tsx
+++ b/packages/ui/src/backgrounds/AppBackground.test.tsx
@@ -71,6 +71,57 @@ describe("AppBackground", () => {
     expect(scrim?.className).toContain("bg-bg/50");
   });
 
+  it("lifts the wallpaper's bottom edge with a warm floor so it never reads as a black band", () => {
+    // The residual "black band" on the standalone home view: the fixed inset-0
+    // wallpaper DOES paint into the iOS home-indicator safe-area, but cover-
+    // cropping a wallpaper whose bottom is dark (the stock sunset, many user
+    // uploads) left that strip near-black. A short bottom-anchored warm floor
+    // gradient lifts only the lowest strip toward the ember floor tone, so the
+    // zone under the composer reads as intentional ambience, not a dead bar.
+    seed({ mode: "image", color: "#000000", imageUrl: "/api/media/x.png" });
+    const { container } = render(<AppBackground />);
+    const floor = container.querySelector<HTMLElement>(
+      '[data-testid="app-background-image-floor"]',
+    );
+    expect(floor).not.toBeNull();
+    // Lives INSIDE the single image layer (one-background invariant holds).
+    expect(
+      floor?.closest('[data-testid="app-background-image"]'),
+    ).not.toBeNull();
+    // Anchored at the true bottom edge, a short strip only — never a full wash.
+    expect(floor?.className).toContain("bottom-0");
+    expect(floor?.className).toContain("inset-x-0");
+    expect(floor?.className).not.toContain("inset-0");
+    // A bottom-anchored gradient (fades UP to transparent) built on the theme
+    // --bg token so it stays warm-but-legible in both themes, not a flat fill.
+    expect(floor?.style.backgroundImage).toContain("linear-gradient");
+    expect(floor?.style.backgroundImage).toContain("to top");
+    expect(floor?.style.backgroundImage).toContain("var(--bg)");
+    expect(floor?.style.backgroundImage).toContain("transparent");
+  });
+
+  it("paints the bottom floor ABOVE the legibility scrim (so the scrim can't dim it back to black)", () => {
+    // Ordering invariant: the floor must be the LAST child of the image layer.
+    // Under the scrim it would just get re-dimmed toward --bg and the band
+    // would return; above it, it lifts the already-scrimmed bottom out of
+    // near-black. Assert DOM order rather than z-index (both are absolute).
+    seed({ mode: "image", color: "#000000", imageUrl: "/api/media/x.png" });
+    const { container } = render(<AppBackground />);
+    const image = container.querySelector<HTMLElement>(
+      '[data-testid="app-background-image"]',
+    );
+    const children = Array.from(image?.children ?? []);
+    const scrimIdx = children.findIndex(
+      (c) => c.getAttribute("data-testid") === "app-background-image-scrim",
+    );
+    const floorIdx = children.findIndex(
+      (c) => c.getAttribute("data-testid") === "app-background-image-floor",
+    );
+    expect(scrimIdx).toBeGreaterThanOrEqual(0);
+    expect(floorIdx).toBeGreaterThanOrEqual(0);
+    expect(floorIdx).toBeGreaterThan(scrimIdx);
+  });
+
   it("renders the programmable shader (or its color-field fallback) for glsl mode", () => {
     seed({
       mode: "glsl",

--- a/packages/ui/src/backgrounds/ImageBackground.tsx
+++ b/packages/ui/src/backgrounds/ImageBackground.tsx
@@ -24,7 +24,25 @@ export interface ImageBackgroundProps {
  * warm white that dark text needs. A token scrim (no blur, no per-pixel
  * filter work) is also the cheapest possible treatment: one plain composited
  * layer, gate-safe, GPU-trivial.
- */
+ *
+ * BOTTOM-EDGE FLOOR (kills the residual "black band"): the wallpaper is a
+ * `fixed inset-0` cover-fit layer, so on an iOS standalone PWA it already
+ * paints into the home-indicator safe-area at the true screen bottom (that is
+ * the whole reason the transparent app-safe-area-floor lets it own the edge).
+ * But cover-cropping the stock "Ember Night" sunset — and many user uploads —
+ * shows a DARK image region at the very bottom (the sunset floor samples to
+ * ~lum 31 after the 0.5 --bg scrim), so the strip under the floating composer
+ * read as a near-black band even though the wallpaper was painting there. Prior
+ * fixes only removed the OTHER painters of that zone (the orange host-chrome,
+ * the opaque bg-bg floor, the launch-bg repaint strip); the residual band was
+ * the wallpaper's own dark bottom. A short, bottom-anchored warm floor gradient
+ * lifts just the lowest strip toward the ember floor tone the ShaderBackground
+ * fallback already pools there, so the home-indicator zone reads as intentional
+ * lock-screen ambience in one continuous field with the rest of the wallpaper —
+ * never a dead black bar. It fades out fast (well before the composer) so it
+ * never washes the wallpaper's content region, and it is wallpaper-agnostic:
+ * dark user uploads get the same warm floor. Anchored below the legibility
+ * scrim so the scrim still governs the readable middle of the image. */
 export function ImageBackground({
   imageUrl,
 }: ImageBackgroundProps): React.JSX.Element {
@@ -50,6 +68,25 @@ export function ImageBackground({
         aria-hidden="true"
         data-testid="app-background-image-scrim"
         className="absolute inset-0 bg-bg/50"
+      />
+      {/* Bottom warm-floor lift: a short gradient anchored at the true bottom
+          edge that pulls the lowest strip (the home-indicator safe-area zone
+          under the composer) toward the ember floor glow, so a dark wallpaper
+          bottom never reads as a black band. Uses the brand ember glow at low
+          alpha over the base --bg, matching the ShaderBackground fallback's
+          low ember pool; fades to transparent by ~22% up so it only touches
+          the bottom edge and never the content region. Sits ABOVE the scrim
+          (last child) because it must lift the ALREADY-scrimmed bottom out of
+          near-black — putting it under the scrim would just get dimmed back
+          down. pointer-events inherit none from the parent. */}
+      <div
+        aria-hidden="true"
+        data-testid="app-background-image-floor"
+        className="absolute inset-x-0 bottom-0 h-[22%]"
+        style={{
+          backgroundImage:
+            "linear-gradient(to top, color-mix(in srgb, var(--bg) 62%, #ef5a1f) 0%, transparent 100%)",
+        }}
       />
     </div>
   );


### PR DESCRIPTION
## Problem

Shadow device-tested r3.5 (installed iOS PWA, standalone, wallpaper home view at sol-dev.shad0w.xyz) and reported: **"improvement, but we still have some black on the bottom, look into the capacitor safety margin and remove it."**

A black band still painted at the very bottom below the composer, even after:
- **#14166** — dark host chrome (`theme-color` + launch-bg `#160d07`)
- **#14067** — transparent `app-safe-area-floor` on wallpaper routes
- **#14184** — lowered composer to safe-area×0.4 + removed the launch-bg repaint strip

## Actual root cause found

The boot default background is `mode: image` — the curated "Ember Night" `bg-sunset.jpg` (`DEFAULT_BACKGROUND_CONFIG` in `ui-preferences.ts`), **not** the ember ShaderBackground.

`ImageBackground` is a `fixed inset-0` cover-fit layer, so it **already paints into the iOS home-indicator safe-area at the true screen bottom** (that's exactly what the transparent `app-safe-area-floor` lets it own, lock-screen style). The band was **not** an unpainted void, and **not** a capacitor margin (this is the PWA/web path — `Capacitor.getPlatform()` returns `web`, so no `platform-ios` / native fixed-body rules and no gesture-inset apply).

The real painter: **cover-cropping the sunset shows a DARK image region at the very bottom** (samples to ~lum 31 after the existing 0.5 `--bg` legibility scrim). So the strip under the floating composer read as near-black even though the wallpaper WAS painting there. Every prior fix removed a *different* painter of that zone (orange chrome → opaque bg-bg floor → launch-bg repaint); the residual band was the wallpaper's own dark bottom, dimmed further by the scrim.

## Fix

`ImageBackground.tsx`: add a short **bottom-anchored warm floor gradient** (`h-22%`, `linear-gradient(to top, color-mix(in srgb, var(--bg) 62%, #ef5a1f) 0%, transparent 100%)`) as the **last child** of the single image layer, **above** the legibility scrim (so the scrim can't dim it back down).

- Lifts only the lowest strip toward the ember floor tone the `ShaderBackground` fallback already pools there → the home-indicator zone reads as intentional lock-screen ambience in one continuous field with the rest of the wallpaper, never a dead black bar.
- Fades to transparent well before the composer → content region untouched.
- Wallpaper-agnostic → a dark user upload gets the same warm floor.
- One-background invariant holds (floor lives inside the image layer, not a sibling). `color-mix` + `--bg` are used widely in the codebase and defined in both themes.

## Tests

New contract tests in `AppBackground.test.tsx`:
- floor exists inside the image layer, is bottom-anchored (`bottom-0 inset-x-0`, **not** a full `inset-0` wash)
- uses a `to top` `--bg`-token gradient fading to `transparent`
- paints **above** the scrim in DOM order (ordering invariant — under the scrim it would be re-dimmed and the band would return)

```
✓ src/backgrounds/AppBackground.test.tsx (9 tests) 168ms
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

`bun run build:client`:
```
@elizaos/app:build: ✓ built in 1m 2s
 Tasks:    104 successful, 104 total
```
Verified the floor gradient is in the built bundle and `viewport-fit=cover` is present in the built `index.html`.

> codex review hung >120s with no output; killed per protocol. Self-review: change is additive-only (one `aria-hidden` gradient div + tests), no logic/safe-area-math change, no behavior change; worst case is a slightly-too-warm bottom strip, which strictly improves over the near-black band.

Author: Sol <sol@shad0w.xyz>
Co-authored-by: wakesync <shadow@shad0w.xyz>

— [sol-orch]