### PR TITLE
fix(app): gate packaged runtime chooser override

### DIFF
--- a/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.test.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.test.ts
@@ -19,6 +19,7 @@ const ENV_KEYS = [
   "ELIZA_DESKTOP_RUNTIME_MODE",
   "ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT",
   "ELIZA_DESKTOP_TEST_API_BASE",
+  "ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER",
   "ELIZA_STARTUP_SESSION_ID",
   "ELIZA_STARTUP_STATE_FILE",
   "ELIZA_STARTUP_EVENTS_FILE",
@@ -93,6 +94,17 @@ describe("api-base-owner", () => {
     expect(injected).not.toContain("__ELIZA_API_TOKEN__");
     expect(injected).toContain("apiToken");
     expect(injected).toContain("elizaos.app.boot-config");
+  });
+
+  it("injects the packaged runtime chooser test marker without an API base", () => {
+    process.env.ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER = "1";
+
+    const injected = injectIntoHtml("<html><head></head><body></body></html>");
+
+    expect(injected).toContain(
+      "window.__ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER__=true;",
+    );
+    expect(injected).not.toContain("apiBase:");
   });
 
   it("marks a non-loopback current API base as an external desktop API base", () => {

--- a/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts
@@ -66,6 +66,10 @@ function safeJsonForHtml(value: unknown): string {
   );
 }
 
+function shouldInjectRuntimeChooserTestMode(): boolean {
+  return process.env.ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER === "1";
+}
+
 function resolveStartupTraceId(): string | null {
   return getStartupTraceConfig().sessionId;
 }
@@ -132,7 +136,11 @@ export function injectIntoHtml(html: string): string {
   const startupTraceInject = startupTraceId
     ? `window.__ELIZA_STARTUP_TRACE_ID__=${safeJsonForHtml(startupTraceId)};`
     : "";
-  if (!current.base && !startupTraceInject) return html;
+  const runtimeChooserTestInject = shouldInjectRuntimeChooserTestMode()
+    ? "window.__ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER__=true;"
+    : "";
+  if (!current.base && !startupTraceInject && !runtimeChooserTestInject)
+    return html;
 
   let apiBaseInject = "";
   if (current.base) {
@@ -155,7 +163,7 @@ export function injectIntoHtml(html: string): string {
     apiBaseInject = `${runtimeModeInject}${externalApiBaseInject}${bootConfigInject}`;
   }
 
-  const script = `<script>${startupTraceInject}${apiBaseInject}</script>`;
+  const script = `<script>${startupTraceInject}${runtimeChooserTestInject}${apiBaseInject}</script>`;
   if (html.includes("</head>")) {
     return html.replace("</head>", `${script}</head>`);
   }

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -189,6 +189,10 @@ import {
   SIDE_EFFECT_APP_MODULE_LOADERS,
   type SideEffectAppModuleLoader,
 } from "./plugin-registrations";
+import {
+  applyRuntimeChooserOverrideFromUrl,
+  removeUrlParameter,
+} from "./runtime-chooser-override";
 import { registerViewServiceWorker } from "./sw-registration";
 
 declare const __ELIZA_BUILD_VARIANT__: string | undefined;
@@ -418,21 +422,6 @@ function getWindowUrlSearchParams(): URLSearchParams {
   const search = window.location?.search ?? "";
   const hashSearch = window.location?.hash?.split("?")[1] ?? "";
   return new URLSearchParams(search || hashSearch);
-}
-
-function applyRuntimeChooserOverrideFromUrl(): void {
-  const params = getWindowUrlSearchParams();
-  if (params.get("enableRuntimeChooser") !== "1") {
-    return;
-  }
-
-  try {
-    window.localStorage.setItem("eliza:enable-runtime-chooser", "1");
-    removeUrlParameter("enableRuntimeChooser");
-  } catch (error) {
-    // error-policy:J3 storage/history can be unavailable in constrained webviews; keep booting.
-    logger.warn("[App] Failed to persist runtime chooser override", { error });
-  }
 }
 
 function applyCloudPairSessionToken(): void {
@@ -2893,24 +2882,6 @@ function injectWaifuChatAccessToken(): void {
       removeUrlParameter(window.location.href, "waifu_access_token"),
     );
   }
-}
-
-function removeUrlParameter(href: string, parameter: string): URL {
-  const nextUrl = new URL(href);
-  nextUrl.searchParams.delete(parameter);
-  const hashQueryIndex = nextUrl.hash.indexOf("?");
-  if (hashQueryIndex >= 0) {
-    const hashPath = nextUrl.hash.slice(0, hashQueryIndex);
-    const hashParams = new URLSearchParams(
-      nextUrl.hash.slice(hashQueryIndex + 1),
-    );
-    hashParams.delete(parameter);
-    const serializedHashParams = hashParams.toString();
-    nextUrl.hash = serializedHashParams
-      ? `${hashPath}?${serializedHashParams}`
-      : hashPath;
-  }
-  return nextUrl;
 }
 
 function injectDetachedShellApiBase(): void {

--- a/packages/app/src/runtime-chooser-override.test.ts
+++ b/packages/app/src/runtime-chooser-override.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  applyRuntimeChooserOverrideFromUrl,
+  removeUrlParameter,
+} from "./runtime-chooser-override";
+
+describe("runtime chooser override", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.history.replaceState(null, "", "/");
+    window.__ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER__ = undefined;
+  });
+
+  it("ignores a user-controlled URL param without the packaged test injection", () => {
+    window.history.replaceState(null, "", "/?enableRuntimeChooser=1");
+
+    expect(applyRuntimeChooserOverrideFromUrl()).toBe(false);
+
+    expect(
+      window.localStorage.getItem("eliza:enable-runtime-chooser"),
+    ).toBeNull();
+    expect(window.location.search).toBe("?enableRuntimeChooser=1");
+  });
+
+  it("persists and removes the URL param when the packaged test injection is present", () => {
+    window.__ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER__ = true;
+    window.history.replaceState(
+      { from: "test" },
+      "",
+      "/?enableRuntimeChooser=1&runtime=first-run",
+    );
+
+    expect(applyRuntimeChooserOverrideFromUrl()).toBe(true);
+
+    expect(window.localStorage.getItem("eliza:enable-runtime-chooser")).toBe(
+      "1",
+    );
+    expect(window.location.href).toBe(
+      `${window.location.origin}/?runtime=first-run`,
+    );
+  });
+
+  it("removes query params from hash-router URLs too", () => {
+    const next = removeUrlParameter(
+      `${window.location.origin}/#/chat?enableRuntimeChooser=1&runtime=first-run`,
+      "enableRuntimeChooser",
+    );
+
+    expect(next.href).toBe(
+      `${window.location.origin}/#/chat?runtime=first-run`,
+    );
+  });
+});

--- a/packages/app/src/runtime-chooser-override.test.ts
+++ b/packages/app/src/runtime-chooser-override.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Runtime chooser override tests cover the packaged-desktop-only guard and URL
+ * cleanup for both browser and hash-router entrypoints.
+ */
+
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   applyRuntimeChooserOverrideFromUrl,

--- a/packages/app/src/runtime-chooser-override.ts
+++ b/packages/app/src/runtime-chooser-override.ts
@@ -1,3 +1,10 @@
+/**
+ * Packaged-runtime test escape hatch for enabling the first-run runtime chooser.
+ * The override is intentionally inert unless desktop packaging injects the test
+ * global, so a user-controlled URL cannot flip local runtime selection in the
+ * normal web app.
+ */
+
 const RUNTIME_CHOOSER_OVERRIDE_PARAM = "enableRuntimeChooser";
 const RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY = "eliza:enable-runtime-chooser";
 const DESKTOP_RUNTIME_CHOOSER_TEST_GLOBAL =

--- a/packages/app/src/runtime-chooser-override.ts
+++ b/packages/app/src/runtime-chooser-override.ts
@@ -1,0 +1,62 @@
+const RUNTIME_CHOOSER_OVERRIDE_PARAM = "enableRuntimeChooser";
+const RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY = "eliza:enable-runtime-chooser";
+const DESKTOP_RUNTIME_CHOOSER_TEST_GLOBAL =
+  "__ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER__";
+
+declare global {
+  interface Window {
+    __ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER__?: boolean;
+  }
+}
+
+function getWindowUrlSearchParams(win: Window): URLSearchParams {
+  const search = win.location?.search ?? "";
+  const hashSearch = win.location?.hash?.split("?")[1] ?? "";
+  return new URLSearchParams(search || hashSearch);
+}
+
+function hasDesktopRuntimeChooserTestInjection(win: Window): boolean {
+  return Reflect.get(win, DESKTOP_RUNTIME_CHOOSER_TEST_GLOBAL) === true;
+}
+
+export function applyRuntimeChooserOverrideFromUrl(win = window): boolean {
+  if (!hasDesktopRuntimeChooserTestInjection(win)) {
+    return false;
+  }
+
+  const params = getWindowUrlSearchParams(win);
+  if (params.get(RUNTIME_CHOOSER_OVERRIDE_PARAM) !== "1") {
+    return false;
+  }
+
+  try {
+    win.localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "1");
+    win.history.replaceState(
+      win.history.state,
+      "",
+      removeUrlParameter(win.location.href, RUNTIME_CHOOSER_OVERRIDE_PARAM),
+    );
+    return true;
+  } catch {
+    // error-policy:J3 storage/history can be unavailable in constrained webviews; keep booting.
+    return false;
+  }
+}
+
+export function removeUrlParameter(href: string, parameter: string): URL {
+  const nextUrl = new URL(href);
+  nextUrl.searchParams.delete(parameter);
+  const hashQueryIndex = nextUrl.hash.indexOf("?");
+  if (hashQueryIndex >= 0) {
+    const hashPath = nextUrl.hash.slice(0, hashQueryIndex);
+    const hashParams = new URLSearchParams(
+      nextUrl.hash.slice(hashQueryIndex + 1),
+    );
+    hashParams.delete(parameter);
+    const serializedHashParams = hashParams.toString();
+    nextUrl.hash = serializedHashParams
+      ? `${hashPath}?${serializedHashParams}`
+      : hashPath;
+  }
+  return nextUrl;
+}


### PR DESCRIPTION
## Summary

- Fixes the merged #14116 runtime chooser override bug from #13610.
- Moves the `enableRuntimeChooser=1` consumer into a tested helper that requires an Electrobun-injected test marker before writing `eliza:enable-runtime-chooser`. A normal production/web/desktop URL param no longer flips the chooser.
- Uses `history.replaceState(..., removeUrlParameter(window.location.href, "enableRuntimeChooser"))` so the original TS2554 / no-op cleanup path is gone.
- Electrobun HTML injection now emits `window.__ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER__=true` only when `ELIZA_DESKTOP_TEST_ENABLE_RUNTIME_CHOOSER=1` is set by the packaged test harness.

## Validation

- `bun run --cwd packages/app test -- src/runtime-chooser-override.test.ts --run`
- `bunx tsc --ignoreConfig --noEmit --skipLibCheck --lib DOM,DOM.Iterable,ES2022 --module ESNext --target ES2022 --moduleResolution bundler packages/app/src/runtime-chooser-override.ts`
- `bunx @biomejs/biome check packages/app/src/main.tsx packages/app/src/runtime-chooser-override.ts packages/app/src/runtime-chooser-override.test.ts packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.test.ts`
- `git diff --check origin/develop..HEAD`

## Not Run

- Full `bun run --cwd packages/app typecheck`: not useful in this sparse worktree; it fails on many missing workspace/native optional modules before reaching this change. The narrow helper type-check above proves the extracted code has no TS error, and the bad one-arg `removeUrlParameter` call was removed from `main.tsx`.
- `bun run --cwd packages/app-core/platforms/electrobun test -- src/lifecycle/api-base-owner.test.ts --run`: the sparse worktree lacks generated core keyword data (`packages/core/src/i18n/generated/validation-keyword-data.ts`) and the suite aborts before running tests. The test was updated for full-workspace CI.
- Packaged Electrobun E2E/video: N/A for this fix-forward on this host; this patch removes a production-reachable test override and covers the URL/storage behavior with unit tests.

Refs #13610.