### PR TITLE
feat(#14179): complete in-process view isolation — root/body classes, CSS vars, storage, navigation

### DIFF
--- a/packages/ui/src/App.surface-mutation-fuzz.test.tsx
+++ b/packages/ui/src/App.surface-mutation-fuzz.test.tsx
@@ -1,0 +1,631 @@
+// @vitest-environment jsdom
+
+/**
+ * In-process host-realm mutation fuzz for the real `<App/>` shell (#14179).
+ *
+ * `App.screen-background-fuzz` proves the background vector; this sibling proves
+ * the remaining four. It mounts the REAL `<App/>` (same harness), registers
+ * views whose surface manifest differs only by grant, and fuzzes a randomized
+ * cross-view walk. After landing on each view it scripts the view attempting all
+ * four host-realm mutations — root/body class, `:root` CSS var, a `localStorage`
+ * write to a shell key, and a shell navigation — then transitions and asserts
+ * each was scoped or blocked by the resolved manifest:
+ *
+ *   (a) a view-injected root/body class does not survive the transition,
+ *   (b) a view-injected `:root` CSS var does not survive the transition,
+ *   (c) a non-`storage` view's write to a shell key never lands in the shell
+ *       keyspace (it is confined to the view's namespace),
+ *   (d) a non-`navigate` view cannot drive shell navigation off the route.
+ *
+ * The grant is a real switch: dedicated tests prove a `storage`-granted view
+ * reaches the host keyspace and a `navigate`-granted view moves the route, while
+ * their un-granted twins are scoped/denied — mirroring the read-only vs
+ * agent-surface split in `view-capability-broker.test.tsx`. Deleting the shell's
+ * `resetHostRealm()` / broker gates turns these assertions red (mutation-check
+ * in the file's trailing comment).
+ */
+
+import { act, cleanup, render } from "@testing-library/react";
+import type * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BuiltinTab } from "./navigation";
+import type { BackgroundConfig } from "./state/ui-preferences";
+import {
+  getActiveSurfaceRealmScope,
+  SurfaceRealmDeniedError,
+  surfaceViewStoragePrefix,
+} from "./surface-realm-broker";
+
+const appState = vi.hoisted(() => ({
+  setTab: vi.fn(),
+  tab: "views" as string,
+}));
+
+const bgState = vi.hoisted(() => ({
+  config: { mode: "shader", color: "#059669" } as BackgroundConfig,
+}));
+
+const backgroundConfigMock = vi.hoisted(() => ({
+  redoBackgroundConfig: vi.fn(),
+  setBackgroundConfig: vi.fn((config: BackgroundConfig) => {
+    bgState.config = config;
+  }),
+  undoBackgroundConfig: vi.fn(),
+}));
+
+const glslRuntimeState = vi.hoisted(() => ({
+  compileOk: true,
+  rendererCount: 0,
+}));
+
+const desktopTabsState = vi.hoisted(() => ({
+  tabs: [] as Array<{
+    viewId: string;
+    label: string;
+    path: string;
+    icon?: string;
+    pinned: boolean;
+  }>,
+}));
+
+const desktopTabsMock = vi.hoisted(() => ({
+  closeTab: vi.fn(),
+  openTab: vi.fn(),
+}));
+
+const desktopBridgeMock = vi.hoisted(() => ({
+  getElectrobunRendererRpc: vi.fn(() => undefined),
+  invokeDesktopBridgeRequest: vi.fn(async () => ({ id: "window-1" })),
+  subscribeDesktopBridgeEvent: vi.fn(() => vi.fn()),
+}));
+
+const dynamicViewLoaderMock = vi.hoisted(() => ({
+  render: vi.fn(({ viewId }: { viewId: string }) => (
+    <div data-testid="dynamic-view-loader" data-view-id={viewId} />
+  )),
+}));
+
+// Three registered views differing ONLY by grant: no grants, `storage`, and
+// `navigate`. The manifest — not the route — decides what each may mutate.
+const noGrantView = {
+  id: "iso-nogrant",
+  label: "Isolated (no grants)",
+  available: true,
+  pluginName: "@elizaos/plugin-iso-nogrant",
+  path: "/iso-nogrant",
+  bundleUrl: "/api/views/iso-nogrant/bundle.js",
+  viewType: "gui" as const,
+  surface: { capabilities: [] as const },
+};
+const storageView = {
+  id: "iso-storage",
+  label: "Isolated (storage)",
+  available: true,
+  pluginName: "@elizaos/plugin-iso-storage",
+  path: "/iso-storage",
+  bundleUrl: "/api/views/iso-storage/bundle.js",
+  viewType: "gui" as const,
+  surface: { capabilities: ["storage"] as const },
+};
+const navigateView = {
+  id: "iso-navigate",
+  label: "Isolated (navigate)",
+  available: true,
+  pluginName: "@elizaos/plugin-iso-navigate",
+  path: "/iso-navigate",
+  bundleUrl: "/api/views/iso-navigate/bundle.js",
+  viewType: "gui" as const,
+  surface: { capabilities: ["navigate"] as const },
+};
+const mockAvailableViews = [noGrantView, storageView, navigateView];
+
+vi.mock("@capacitor/keyboard", () => ({
+  Keyboard: { setScroll: vi.fn(async () => undefined) },
+}));
+vi.mock("./bridge/electrobun-rpc", () => desktopBridgeMock);
+vi.mock("./bridge/electrobun-runtime", () => ({
+  isElectrobunRuntime: () => true,
+}));
+vi.mock("./platform/init", () => ({
+  isDesktopPlatform: () => false,
+  isIOS: false,
+  isNative: false,
+  isWebPlatform: () => true,
+}));
+vi.mock("./hooks/useDesktopTabs", () => ({
+  useDesktopTabs: () => ({
+    tabs: desktopTabsState.tabs,
+    closeTab: desktopTabsMock.closeTab,
+    openTab: desktopTabsMock.openTab,
+  }),
+}));
+vi.mock("./hooks/useAvailableViews", () => ({
+  useAvailableViews: () => ({ views: mockAvailableViews }),
+  useRoutableViews: () => ({ views: mockAvailableViews }),
+  fetchAvailableViews: async () => mockAvailableViews,
+}));
+vi.mock("./hooks/useAuthStatus", () => ({
+  useAuthStatus: () => ({
+    state: { phase: "authenticated" },
+    refetch: vi.fn(),
+  }),
+  useIsAuthenticated: () => true,
+}));
+vi.mock("./hooks/useActivityEvents", () => ({
+  useActivityEvents: () => ({ events: [], clearEvents: vi.fn() }),
+}));
+vi.mock("./hooks", () => ({
+  BugReportProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useBugReportState: () => ({}),
+  useContextMenu: () => ({
+    closeSaveCommandModal: vi.fn(),
+    confirmSaveCommand: vi.fn(),
+    saveCommandModalOpen: false,
+    saveCommandText: "",
+  }),
+  useMediaQuery: () => false,
+  useRenderGuard: vi.fn(),
+  useIntervalWhenDocumentVisible: () => {},
+}));
+vi.mock("./state", async () => {
+  const { ACCENT_PRESETS } = await vi.importActual<
+    typeof import("./state/ui-preferences")
+  >("./state/ui-preferences");
+  const getAppValue = () => ({
+    actionNotice: null,
+    activeGameViewerUrl: null,
+    activeOverlayApp: null,
+    agentStatus: null,
+    backendConnection: { state: "connected" },
+    backgroundConfig: bgState.config,
+    setBackgroundConfig: backgroundConfigMock.setBackgroundConfig,
+    undoBackgroundConfig: backgroundConfigMock.undoBackgroundConfig,
+    canUndoBackground: false,
+    copyToClipboard: vi.fn(),
+    databaseSubTab: "overview",
+    dismissActionBanner: vi.fn(),
+    dismissSystemWarning: vi.fn(),
+    elizaCloudConnected: false,
+    elizaCloudVoiceProxyAvailable: false,
+    gameOverlayEnabled: false,
+    handlePluginToggle: vi.fn(),
+    loadPlugins: vi.fn(async () => undefined),
+    loadDropStatus: vi.fn(async () => undefined),
+    firstRunComplete: true,
+    ownerName: "Test Owner",
+    plugins: [],
+    retryStartup: vi.fn(),
+    setActionNotice: vi.fn(),
+    setState: vi.fn(),
+    setTab: appState.setTab,
+    setUiLanguage: vi.fn(),
+    setUiTheme: vi.fn(),
+    setUiThemeMode: vi.fn(),
+    startupCoordinator: { phase: "ready", retry: vi.fn() },
+    startupError: null,
+    systemWarnings: [],
+    tab: appState.tab,
+    t: (_key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? "",
+    uiLanguage: "en",
+    uiShellMode: "default",
+    uiTheme: "light",
+    uiThemeMode: "system",
+  });
+  return {
+    ACCENT_PRESETS,
+    useApp: () => getAppValue(),
+    useAppSelector: <T,>(
+      selector: (s: ReturnType<typeof getAppValue>) => T,
+    ): T => selector(getAppValue()),
+    useAppSelectorShallow: <T,>(
+      selector: (s: ReturnType<typeof getAppValue>) => T,
+    ): T => selector(getAppValue()),
+    useTranslation: () => ({
+      t: (key: string, options?: { defaultValue?: string }) =>
+        options?.defaultValue ?? key,
+    }),
+  };
+});
+vi.mock("./config/boot-config-react.hooks", () => ({
+  useBootConfig: () => ({}),
+}));
+vi.mock("./components/shell/ShellControllerContext", () => ({
+  ShellControllerProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useShellControllerContext: () => ({
+    canSend: true,
+    close: vi.fn(),
+    messages: [],
+    open: vi.fn(),
+    phase: "idle",
+    recording: false,
+    send: vi.fn(),
+    toggleRecording: vi.fn(),
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+    waveformMode: "idle",
+  }),
+}));
+vi.mock("./components/views/DynamicViewLoader", () => ({
+  DynamicViewLoader: dynamicViewLoaderMock.render,
+}));
+vi.mock("./components/shell/BugReportModal", () => ({
+  BugReportModal: () => null,
+}));
+vi.mock("./components/shell/ChatSurface", () => ({
+  ChatSurface: () => <div data-testid="chat-surface" />,
+}));
+vi.mock("./components/shell/HomePill", () => ({
+  HomePill: () => <button type="button">home pill</button>,
+}));
+vi.mock("./components/shell/AssistantOverlay", () => ({
+  AssistantOverlay: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="assistant-overlay">{children}</div>
+  ),
+}));
+vi.mock("./components/shell/ConnectionFailedBanner", () => ({
+  ConnectionFailedBanner: () => null,
+}));
+vi.mock("./components/shell/SystemWarningBanner", () => ({
+  SystemWarningBanner: () => null,
+}));
+vi.mock("./components/shell/ShellOverlays", () => ({
+  ShellOverlays: () => null,
+}));
+vi.mock("./components/chat/SaveCommandModal", () => ({
+  SaveCommandModal: () => null,
+}));
+vi.mock("./components/pages/ChatView", () => ({
+  ChatView: () => <div data-testid="chat-view" />,
+  __resetCompanionSpeechMemoryForTests: vi.fn(),
+}));
+vi.mock("./components/character/CharacterEditor", () => ({
+  CharacterEditor: () => <div data-testid="character-editor" />,
+}));
+vi.mock("./components/pages/LauncherSurface", () => ({
+  LauncherSurface: () => <div data-testid="launcher-surface" />,
+}));
+vi.mock("./components/settings/SecretsManagerSection", () => ({
+  VaultModal: () => null,
+}));
+vi.mock("./components/custom-actions/CustomActionEditor", () => ({
+  CustomActionEditor: () => null,
+}));
+vi.mock("./components/shell/ConnectionLostOverlay", () => ({
+  ConnectionLostOverlay: () => null,
+}));
+vi.mock("./hooks/useSecretsManagerShortcut", () => ({
+  useSecretsManagerShortcut: vi.fn(),
+}));
+vi.mock("./hooks/useIsDeveloperMode", () => ({
+  useIsDeveloperMode: () => false,
+}));
+vi.mock("./state/useBackgroundConfig", () => ({
+  useBackgroundConfig: () => ({
+    backgroundConfig: bgState.config,
+    setBackgroundConfig: backgroundConfigMock.setBackgroundConfig,
+    undoBackgroundConfig: backgroundConfigMock.undoBackgroundConfig,
+    redoBackgroundConfig: backgroundConfigMock.redoBackgroundConfig,
+    canUndoBackground: false,
+    canRedoBackground: false,
+  }),
+}));
+vi.mock("three", () => {
+  const compilingGl = {
+    COMPILE_STATUS: 0x8b81,
+    FRAGMENT_SHADER: 0x8b30,
+    compileShader: () => {},
+    createShader: () => ({}),
+    deleteShader: () => {},
+    getShaderInfoLog: () => "forced compile failure",
+    getShaderParameter: () => glslRuntimeState.compileOk,
+    shaderSource: () => {},
+  };
+  class WebGLRenderer {
+    domElement = document.createElement("canvas");
+    constructor() {
+      glslRuntimeState.rendererCount += 1;
+    }
+    dispose() {}
+    getContext() {
+      return compilingGl;
+    }
+    render() {}
+    setPixelRatio() {}
+    setSize() {}
+  }
+  class Vector2 {
+    constructor(
+      public x = 0,
+      public y = 0,
+    ) {}
+    set(x: number, y: number) {
+      this.x = x;
+      this.y = y;
+      return this;
+    }
+  }
+  class Vector3 {
+    constructor(
+      public x = 0,
+      public y = 0,
+      public z = 0,
+    ) {}
+    set(x: number, y: number, z: number) {
+      this.x = x;
+      this.y = y;
+      this.z = z;
+      return this;
+    }
+  }
+  class Scene {
+    add() {}
+  }
+  class Camera {}
+  class BufferGeometry {
+    dispose() {}
+    setAttribute() {}
+  }
+  class BufferAttribute {}
+  class RawShaderMaterial {
+    dispose() {}
+  }
+  class Mesh {}
+  return {
+    BufferAttribute,
+    BufferGeometry,
+    Camera,
+    Mesh,
+    RawShaderMaterial,
+    Scene,
+    Vector2,
+    Vector3,
+    WebGLRenderer,
+  };
+});
+
+import { App } from "./App";
+
+// A shell-owned storage key that must never be writable through a view path.
+const SHELL_STORAGE_KEY = "eliza:ui-theme";
+const SHELL_STORAGE_VALUE = "owner-chosen-dark";
+
+// This env ships a partial Node Web Storage global (getItem present, setItem/
+// clear missing) that the shared setup's getItem check does not repair. Install
+// a real in-memory Storage so the shell's `window.localStorage` backing and the
+// assertions below run against the same working store.
+class MemoryStorage implements Storage {
+  private map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  getItem(key: string): string | null {
+    return this.map.has(key) ? (this.map.get(key) as string) : null;
+  }
+  key(index: number): string | null {
+    return [...this.map.keys()][index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+  [name: string]: unknown;
+}
+
+// The routes the walk visits: the three grant-differentiated views plus a couple
+// of builtin tabs (which resolve to the default no-grant manifest).
+const WALK_ROUTES: { tab: BuiltinTab; path: string }[] = [
+  { tab: "views", path: "/iso-nogrant" },
+  { tab: "views", path: "/iso-storage" },
+  { tab: "views", path: "/iso-navigate" },
+  { tab: "browser", path: "/browser" },
+  { tab: "settings", path: "/settings" },
+];
+
+const VIEWS_HOME = { tab: "views" as BuiltinTab, path: "/views" };
+
+function makeRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function shuffle<T>(arr: T[], rng: () => number): T[] {
+  const out = arr.slice();
+  for (let i = out.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+describe("App in-process host-realm mutation isolation (#14179)", () => {
+  const swallow = (e: ErrorEvent | PromiseRejectionEvent) => {
+    e.preventDefault?.();
+  };
+
+  beforeEach(() => {
+    appState.tab = "views";
+    appState.setTab.mockClear();
+    desktopTabsState.tabs = [];
+    glslRuntimeState.compileOk = true;
+    glslRuntimeState.rendererCount = 0;
+    bgState.config = { mode: "shader", color: "#059669" };
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      writable: true,
+      value: new MemoryStorage(),
+    });
+    window.localStorage.setItem(SHELL_STORAGE_KEY, SHELL_STORAGE_VALUE);
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn(() => 1),
+    );
+    window.history.replaceState(null, "", "/views");
+    Reflect.deleteProperty(window, "__ELIZAOS_API_BASE__");
+    window.addEventListener("error", swallow);
+    window.addEventListener("unhandledrejection", swallow);
+  });
+
+  afterEach(() => {
+    window.removeEventListener("error", swallow);
+    window.removeEventListener("unhandledrejection", swallow);
+    cleanup();
+    vi.unstubAllGlobals();
+    document.documentElement.className = "";
+    document.body.className = "";
+    document.documentElement.removeAttribute("style");
+  });
+
+  async function navigate(
+    rerender: (ui: React.ReactElement) => void,
+    tab: string,
+    path: string,
+  ): Promise<void> {
+    await act(async () => {
+      appState.tab = tab;
+      window.history.pushState(null, "", path);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+      rerender(<App />);
+    });
+  }
+
+  it("resolves a distinct broker scope per active view", async () => {
+    const { rerender } = render(<App />);
+    await navigate(rerender, "views", "/iso-nogrant");
+    expect(getActiveSurfaceRealmScope()?.viewId).toBe("iso-nogrant");
+    await navigate(rerender, "views", "/iso-storage");
+    expect(getActiveSurfaceRealmScope()?.viewId).toBe("iso-storage");
+  }, 60_000);
+
+  it("scopes/blocks all four host-realm vectors across a fuzzed cross-view walk", async () => {
+    for (const seed of [1, 7, 42]) {
+      const rng = makeRng(seed);
+      const order = shuffle(WALK_ROUTES, rng);
+      const { rerender } = render(<App />);
+      await navigate(rerender, VIEWS_HOME.tab, VIEWS_HOME.path);
+
+      for (const route of order) {
+        await navigate(rerender, route.tab, route.path);
+        const scope = getActiveSurfaceRealmScope();
+        expect(scope, `${route.path}: scope published`).not.toBeNull();
+        if (!scope) continue;
+
+        // The view reaches the host realm directly (bypassing its host node).
+        const rogueRootClass = `rogue-root-${seed}`;
+        const rogueBodyClass = `rogue-body-${seed}`;
+        const rogueVar = `--rogue-var-${seed}`;
+        document.documentElement.classList.add(rogueRootClass);
+        document.body.classList.add(rogueBodyClass);
+        document.documentElement.style.setProperty(rogueVar, "red");
+
+        // (c) storage: a write to the shell's key. Non-`storage` views are
+        // namespaced; the `storage` view is denied the reserved shell key.
+        const grantsStorage = route.path === "/iso-storage";
+        if (grantsStorage) {
+          expect(() => scope.storage.setItem(SHELL_STORAGE_KEY, "pwn")).toThrow(
+            SurfaceRealmDeniedError,
+          );
+        } else {
+          scope.storage.setItem(SHELL_STORAGE_KEY, "pwn");
+          // The namespaced write landed under the view keyspace, not the shell.
+          expect(
+            window.localStorage.getItem(
+              `${surfaceViewStoragePrefix(scope.viewId)}${SHELL_STORAGE_KEY}`,
+            ),
+          ).toBe("pwn");
+        }
+        // Either way the shell key is intact.
+        expect(
+          window.localStorage.getItem(SHELL_STORAGE_KEY),
+          `${route.path}: shell storage key intact`,
+        ).toBe(SHELL_STORAGE_VALUE);
+
+        // (d) navigation: a non-`navigate` view is denied; the route never moves.
+        const grantsNavigate = route.path === "/iso-navigate";
+        if (!grantsNavigate) {
+          expect(() => scope.navigate("/rogue-route")).toThrow(
+            SurfaceRealmDeniedError,
+          );
+          expect(
+            window.location.pathname,
+            `${route.path}: route not hijacked`,
+          ).toBe(route.path);
+        }
+
+        // Transition away — the scope tears down and resets the host realm.
+        await navigate(rerender, VIEWS_HOME.tab, VIEWS_HOME.path);
+
+        // (a) + (b) the view's injected class/var did not survive the transition.
+        expect(
+          document.documentElement.classList.contains(rogueRootClass),
+          `${route.path}: injected root class did not survive`,
+        ).toBe(false);
+        expect(
+          document.body.classList.contains(rogueBodyClass),
+          `${route.path}: injected body class did not survive`,
+        ).toBe(false);
+        expect(
+          document.documentElement.style.getPropertyValue(rogueVar),
+          `${route.path}: injected CSS var did not survive`,
+        ).toBe("");
+      }
+      cleanup();
+    }
+  }, 120_000);
+
+  it("a storage-granted view reaches the host keyspace (the grant is a real switch)", async () => {
+    const { rerender } = render(<App />);
+    await navigate(rerender, "views", "/iso-storage");
+    const scope = getActiveSurfaceRealmScope();
+    expect(scope?.viewId).toBe("iso-storage");
+    scope?.storage.setItem("plugin.pref", "on");
+    // A non-reserved key lands un-prefixed in the host keyspace.
+    expect(window.localStorage.getItem("plugin.pref")).toBe("on");
+    // The shell's reserved key is still protected even with the grant.
+    expect(window.localStorage.getItem(SHELL_STORAGE_KEY)).toBe(
+      SHELL_STORAGE_VALUE,
+    );
+  }, 60_000);
+
+  it("a navigate-granted view can drive shell navigation (the grant is a real switch)", async () => {
+    const { rerender } = render(<App />);
+    await navigate(rerender, "views", "/iso-navigate");
+    const scope = getActiveSurfaceRealmScope();
+    expect(scope?.viewId).toBe("iso-navigate");
+    await act(async () => {
+      scope?.navigate("/iso-storage");
+    });
+    // The grant admits the navigation the un-granted twin was denied.
+    expect(window.location.pathname).toBe("/iso-storage");
+  }, 60_000);
+});
+
+// ── Mutation-check (red→green proof) ─────────────────────────────────────────
+//
+// Each vector's guard is independently load-bearing — remove it and the walk
+// goes red:
+//   (a)+(b) delete the `scope.resetHostRealm()` call in `App.tsx`'s teardown
+//           effect → the injected root/body class + `:root` var survive the
+//           transition → the class/var survival assertions fail.
+//   (c)     make `brokerSurfaceStorage` return `backing` directly (drop the
+//           namespacing/reserved-key guard) → the shell key is overwritten →
+//           "shell storage key intact" fails.
+//   (d)     make `brokerSurfaceNavigate` always call through (drop the grant
+//           check) → the non-`navigate` view moves the route → "route not
+//           hijacked" fails (and the denial `toThrow` fails).

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -128,11 +128,11 @@ import {
 import { isShellPaintable } from "./state/startup-coordinator";
 import { firstRunOwnsLoginSurface } from "./state/top-level-auth-gate";
 import { isLoopbackGatewayHost } from "./state/use-startup-shell-controller";
-import { TutorialConductorMount } from "./tutorial/TutorialConductor";
 import {
   SurfaceRealmScope,
   setActiveSurfaceRealmScope,
 } from "./surface-realm-broker";
+import { TutorialConductorMount } from "./tutorial/TutorialConductor";
 import { confirmDesktopAction } from "./utils/desktop-dialogs";
 import { VoiceSelfTestShell } from "./voice/voice-selftest/VoiceSelfTestShell";
 import { VoiceWorkbenchShell } from "./voice/voice-selftest/VoiceWorkbenchShell";

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -10,7 +10,9 @@ import {
   type AppShellBackgroundPolicy,
   type EnabledViewKinds,
   isViewVisible,
+  type ResolvedSurfaceManifest,
   resolveSurfaceBackgroundPolicy,
+  resolveSurfaceManifest,
   type SurfaceManifestBearer,
   type ViewKind,
 } from "@elizaos/core";
@@ -32,6 +34,7 @@ import {
   type ActiveViewLayout,
   createNavigateViewHandler,
   type NavigateViewDetail,
+  navigateBrowserPath,
 } from "./app-navigate-view";
 import { AppBackground } from "./backgrounds/AppBackground";
 import {
@@ -126,6 +129,10 @@ import { isShellPaintable } from "./state/startup-coordinator";
 import { firstRunOwnsLoginSurface } from "./state/top-level-auth-gate";
 import { isLoopbackGatewayHost } from "./state/use-startup-shell-controller";
 import { TutorialConductorMount } from "./tutorial/TutorialConductor";
+import {
+  SurfaceRealmScope,
+  setActiveSurfaceRealmScope,
+} from "./surface-realm-broker";
 import { confirmDesktopAction } from "./utils/desktop-dialogs";
 import { VoiceSelfTestShell } from "./voice/voice-selftest/VoiceSelfTestShell";
 import { VoiceWorkbenchShell } from "./voice/voice-selftest/VoiceWorkbenchShell";
@@ -905,6 +912,114 @@ function useActiveScreenBackgroundPolicy({
   return useMemo(() => {
     void registryVersion;
     return resolveActiveScreenBackgroundPolicy({
+      tab,
+      navigationPath,
+      availableViews,
+      viewLayout,
+    });
+  }, [availableViews, navigationPath, registryVersion, tab, viewLayout]);
+}
+
+/**
+ * The active view's identity + resolved surface manifest — the same registration
+ * the background resolver above reads, resolved through the SAME
+ * {@link resolveSurfaceManifest} so there is one policy source. Drives the
+ * in-process host-realm broker (#14179): the shell scopes the active view's
+ * storage/navigation/DOM mutations from this manifest exactly as it derives the
+ * background from it.
+ */
+interface ActiveViewSurface {
+  manifest: ResolvedSurfaceManifest;
+  viewId: string;
+}
+
+function resolveActiveViewSurface({
+  tab,
+  navigationPath,
+  availableViews,
+  viewLayout,
+}: {
+  tab: string;
+  navigationPath: string;
+  availableViews: ViewRegistryEntry[];
+  viewLayout: ActiveViewLayout | null;
+}): ActiveViewSurface {
+  // A split/tile layout or an unregistered builtin route has no manifest bearer;
+  // it resolves to the safe default (no grants) — the default-deny baseline.
+  if (viewLayout) {
+    return {
+      manifest: resolveSurfaceManifest(null),
+      viewId: `layout:${viewLayout.viewIds.join("+") || tab}`,
+    };
+  }
+
+  const appShellPageForRoute = findAppShellPageForRoute(navigationPath);
+  if (appShellPageForRoute) {
+    return {
+      manifest: resolveSurfaceManifest(appShellPageForRoute),
+      viewId: appShellPageForRoute.id,
+    };
+  }
+
+  const appSlug =
+    tab === "apps" || tab === "views"
+      ? getAppSlugFromPath(navigationPath)
+      : null;
+  const remoteView = findRemoteViewForRoute(
+    availableViews,
+    navigationPath,
+    tab,
+    appSlug,
+  );
+  if (remoteView) {
+    return {
+      manifest: resolveSurfaceManifest(remoteView),
+      viewId: remoteView.id,
+    };
+  }
+
+  const appShellPageForTab = listAppShellPages().find(
+    (entry) => entry.id === tab,
+  );
+  if (appShellPageForTab) {
+    return {
+      manifest: resolveSurfaceManifest(appShellPageForTab),
+      viewId: appShellPageForTab.id,
+    };
+  }
+
+  const registeredView = availableViews.find(
+    (view) =>
+      view.builtin !== true &&
+      (view.id === tab ||
+        view.path === navigationPath ||
+        view.path === trimmedNavigationPath(navigationPath)),
+  );
+  if (registeredView) {
+    return {
+      manifest: resolveSurfaceManifest(registeredView),
+      viewId: registeredView.id,
+    };
+  }
+
+  return { manifest: resolveSurfaceManifest(null), viewId: tab };
+}
+
+function useActiveViewSurface({
+  tab,
+  navigationPath,
+  availableViews,
+  viewLayout,
+}: {
+  tab: string;
+  navigationPath: string;
+  availableViews: ViewRegistryEntry[];
+  viewLayout: ActiveViewLayout | null;
+}): ActiveViewSurface {
+  const registryVersion = useAppShellPageRegistryVersion();
+  return useMemo(() => {
+    void registryVersion;
+    return resolveActiveViewSurface({
       tab,
       navigationPath,
       availableViews,
@@ -2045,6 +2160,33 @@ export function App() {
     screenBackgroundPolicy === "shared" && !overlayAppSurfaceActive;
   const renderOpaqueAppBackground =
     screenBackgroundPolicy === "opaque" || overlayAppSurfaceActive;
+
+  // In-process host-realm isolation (#14179). Resolve the active view's surface
+  // manifest from the same registry as the background, then publish one broker
+  // scope per active view: storage/navigation gated on the manifest's grants,
+  // and the view's global root/body-class + `:root`-var mutations reset on
+  // teardown so nothing a view injected into the host realm survives into the
+  // next view. `resolveSurfaceManifest` stays the single policy source.
+  const activeViewSurface = useActiveViewSurface({
+    tab,
+    navigationPath,
+    availableViews: availableViewsForDesktopTabs,
+    viewLayout,
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const scope = new SurfaceRealmScope(
+      activeViewSurface.manifest,
+      activeViewSurface.viewId,
+      window.localStorage,
+      navigateBrowserPath,
+    );
+    setActiveSurfaceRealmScope(scope);
+    return () => {
+      scope.resetHostRealm();
+      setActiveSurfaceRealmScope(null);
+    };
+  }, [activeViewSurface]);
 
   const [editingAction, setEditingAction] = useState<
     import("./api").CustomActionDef | null

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -397,10 +397,10 @@ async function importUiAppNavigateViewCompat(): Promise<
   Record<string, unknown>
 > {
   const appNavigateView = await import("../../app-navigate-view.ts");
+  const scope = getActiveSurfaceRealmScope();
   return {
     ...appNavigateView,
     navigateBrowserPath(path: string): void {
-      const scope = getActiveSurfaceRealmScope();
       if (scope) {
         scope.navigate(path);
         return;
@@ -412,15 +412,14 @@ async function importUiAppNavigateViewCompat(): Promise<
 
 async function importUiBridgeCompat(): Promise<Record<string, unknown>> {
   const bridge = await import("../../bridge/index.ts");
+  const scope = getActiveSurfaceRealmScope();
   return {
     ...bridge,
     async getStorageValue(key: string): Promise<string | null> {
-      const scope = getActiveSurfaceRealmScope();
       if (scope) return scope.storage.getItem(key);
       return bridge.getStorageValue(key);
     },
     async setStorageValue(key: string, value: string): Promise<void> {
-      const scope = getActiveSurfaceRealmScope();
       if (scope) {
         scope.storage.setItem(key, value);
         return;
@@ -428,7 +427,6 @@ async function importUiBridgeCompat(): Promise<Record<string, unknown>> {
       await bridge.setStorageValue(key, value);
     },
     async removeStorageValue(key: string): Promise<void> {
-      const scope = getActiveSurfaceRealmScope();
       if (scope) {
         scope.storage.removeItem(key);
         return;

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -78,6 +78,7 @@ import {
 } from "../../state/bounded-view-lru";
 import { installHeapPressureMonitor } from "../../state/heap-pressure-monitor";
 import { useApp } from "../../state/useApp.ts";
+import { getActiveSurfaceRealmScope } from "../../surface-realm-broker";
 import { registerDetailExtension } from "../apps/extensions/registry.ts";
 import {
   formatDetailTimestamp,
@@ -392,6 +393,51 @@ async function importUiRootCompat(): Promise<Record<string, unknown>> {
   return import("../../index.ts");
 }
 
+async function importUiAppNavigateViewCompat(): Promise<
+  Record<string, unknown>
+> {
+  const appNavigateView = await import("../../app-navigate-view.ts");
+  return {
+    ...appNavigateView,
+    navigateBrowserPath(path: string): void {
+      const scope = getActiveSurfaceRealmScope();
+      if (scope) {
+        scope.navigate(path);
+        return;
+      }
+      appNavigateView.navigateBrowserPath(path);
+    },
+  };
+}
+
+async function importUiBridgeCompat(): Promise<Record<string, unknown>> {
+  const bridge = await import("../../bridge/index.ts");
+  return {
+    ...bridge,
+    async getStorageValue(key: string): Promise<string | null> {
+      const scope = getActiveSurfaceRealmScope();
+      if (scope) return scope.storage.getItem(key);
+      return bridge.getStorageValue(key);
+    },
+    async setStorageValue(key: string, value: string): Promise<void> {
+      const scope = getActiveSurfaceRealmScope();
+      if (scope) {
+        scope.storage.setItem(key, value);
+        return;
+      }
+      await bridge.setStorageValue(key, value);
+    },
+    async removeStorageValue(key: string): Promise<void> {
+      const scope = getActiveSurfaceRealmScope();
+      if (scope) {
+        scope.storage.removeItem(key);
+        return;
+      }
+      await bridge.removeStorageValue(key);
+    },
+  };
+}
+
 // Framework + host modules the shell always provides to every view bundle:
 // react, three, `@elizaos/ui/*`, the `@elizaos/app-core` view compat surface,
 // `@elizaos/shared`, and the native capacitor bridges. This map is
@@ -416,9 +462,9 @@ const HOST_EXTERNAL_IMPORTERS: Record<string, HostExternalImporter> = {
   "@elizaos/shared": () => importHostExternal("@elizaos/shared"),
   "@elizaos/ui": importUiRootCompat,
   "@elizaos/ui/agent-surface": async () => AgentSurfaceHost,
-  "@elizaos/ui/app-navigate-view": () => import("../../app-navigate-view.ts"),
+  "@elizaos/ui/app-navigate-view": importUiAppNavigateViewCompat,
   "@elizaos/ui/api": () => import("../../api/index.ts"),
-  "@elizaos/ui/bridge": () => import("../../bridge/index.ts"),
+  "@elizaos/ui/bridge": importUiBridgeCompat,
   "@elizaos/ui/components": importUiComponentsCompat,
   "@elizaos/ui/config": () => import("../../config/index.ts"),
   "@elizaos/ui/events": () => import("../../events/index.ts"),

--- a/packages/ui/src/surface-realm-broker.test.tsx
+++ b/packages/ui/src/surface-realm-broker.test.tsx
@@ -1,0 +1,252 @@
+// @vitest-environment jsdom
+//
+// In-process host-realm broker (#14179): each of the four remaining mutation
+// vectors — storage, navigation, root/body classes, `:root` CSS vars — is gated
+// on the resolved surface manifest. Every vector has a negative (no grant →
+// scoped/denied) and positive (grant → allowed) case, mirroring the read-only
+// vs agent-surface split in `view-capability-broker.test.tsx`. Pure logic +
+// real jsdom DOM; no `<App/>` harness (the shell wiring is proven in
+// `App.surface-mutation-fuzz.test.tsx`).
+
+import { resolveSurfaceManifest, type SurfaceCapability } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  brokerSurfaceNavigate,
+  brokerSurfaceStorage,
+  isShellReservedStorageKey,
+  SurfaceRealmDeniedError,
+  SurfaceRealmScope,
+  surfaceViewStoragePrefix,
+} from "./surface-realm-broker";
+
+const withGrants = (...caps: SurfaceCapability[]) =>
+  resolveSurfaceManifest({ surface: { capabilities: caps } });
+
+const NO_GRANTS = resolveSurfaceManifest({ surface: { capabilities: [] } });
+
+// A throwaway in-memory Storage so the broker's façades run against a real
+// Storage-shaped backing without touching the jsdom global localStorage.
+class MemoryStorage implements Storage {
+  private map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  getItem(key: string): string | null {
+    return this.map.has(key) ? (this.map.get(key) as string) : null;
+  }
+  key(index: number): string | null {
+    return [...this.map.keys()][index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+  [name: string]: unknown;
+}
+
+describe("isShellReservedStorageKey", () => {
+  it("recognizes the shell's own persistence namespaces", () => {
+    for (const key of [
+      "eliza:ui-theme",
+      "elizaos:active-server",
+      "eliza_avatar_index",
+    ]) {
+      expect(isShellReservedStorageKey(key)).toBe(true);
+    }
+  });
+  it("does not claim view keys as shell-reserved", () => {
+    for (const key of ["my-key", "plugin.state", "surface:view:x:eliza:foo"]) {
+      expect(isShellReservedStorageKey(key)).toBe(false);
+    }
+  });
+});
+
+describe("brokerSurfaceStorage — storage vector", () => {
+  let backing: MemoryStorage;
+  beforeEach(() => {
+    backing = new MemoryStorage();
+    // The shell owns this key before any view runs.
+    backing.setItem("eliza:ui-theme", "dark");
+  });
+
+  it("WITHOUT the storage grant, a view write to a shell key lands in the view namespace, never the shell key", () => {
+    const store = brokerSurfaceStorage(NO_GRANTS, backing, "rogue.view");
+    store.setItem("eliza:ui-theme", "light");
+    // The shell key is untouched — the rogue write was scoped away.
+    expect(backing.getItem("eliza:ui-theme")).toBe("dark");
+    // It landed under the view-prefixed keyspace instead.
+    expect(
+      backing.getItem(
+        `${surfaceViewStoragePrefix("rogue.view")}eliza:ui-theme`,
+      ),
+    ).toBe("light");
+    // The view reads back its OWN namespaced value transparently.
+    expect(store.getItem("eliza:ui-theme")).toBe("light");
+  });
+
+  it("WITHOUT the grant, the view's keyspace is fully isolated (length/key/clear stay within the namespace)", () => {
+    const store = brokerSurfaceStorage(NO_GRANTS, backing, "v1");
+    store.setItem("a", "1");
+    store.setItem("b", "2");
+    expect(store.length).toBe(2);
+    expect([store.key(0), store.key(1)].sort()).toEqual(["a", "b"]);
+    store.clear();
+    expect(store.length).toBe(0);
+    // clear() only removed the view's keys — the shell key survives.
+    expect(backing.getItem("eliza:ui-theme")).toBe("dark");
+  });
+
+  it("WITH the storage grant, a view uses the host keyspace but still cannot write a reserved shell key", () => {
+    const store = brokerSurfaceStorage(
+      withGrants("storage"),
+      backing,
+      "trusted",
+    );
+    store.setItem("plugin.pref", "on");
+    // A host-keyspace (non-reserved) write lands un-prefixed.
+    expect(backing.getItem("plugin.pref")).toBe("on");
+    // A shell key is still off-limits — observable denial, not a silent no-op.
+    expect(() => store.setItem("eliza:ui-theme", "light")).toThrow(
+      SurfaceRealmDeniedError,
+    );
+    expect(() => store.removeItem("eliza:ui-theme")).toThrow(
+      SurfaceRealmDeniedError,
+    );
+    expect(backing.getItem("eliza:ui-theme")).toBe("dark");
+  });
+});
+
+describe("brokerSurfaceNavigate — navigation vector", () => {
+  it("WITHOUT the navigate grant, throws and never calls the shell navigate", () => {
+    let called: string | null = null;
+    const navigate = brokerSurfaceNavigate(NO_GRANTS, "rogue.view", (p) => {
+      called = p;
+    });
+    expect(() => navigate("/somewhere")).toThrow(SurfaceRealmDeniedError);
+    expect(called).toBeNull();
+  });
+
+  it("WITH the navigate grant, delegates to the shell navigate", () => {
+    let called: string | null = null;
+    const navigate = brokerSurfaceNavigate(
+      withGrants("navigate"),
+      "trusted",
+      (p) => {
+        called = p;
+      },
+    );
+    navigate("/settings");
+    expect(called).toBe("/settings");
+  });
+
+  it("an unrelated grant does not unlock navigation (fails closed)", () => {
+    const navigate = brokerSurfaceNavigate(
+      withGrants("storage", "wallpaper"),
+      "v",
+      () => undefined,
+    );
+    expect(() => navigate("/x")).toThrow(SurfaceRealmDeniedError);
+  });
+});
+
+describe("SurfaceRealmScope.resetHostRealm — root/body class + :root var vector", () => {
+  beforeEach(() => {
+    // Shell-owned baseline the reset must preserve.
+    document.documentElement.className = "dark";
+    document.body.className = "platform-web native";
+    document.documentElement.style.setProperty("--accent", "#f60");
+    document.documentElement.style.setProperty("--bg", "#000");
+  });
+  afterEach(() => {
+    document.documentElement.className = "";
+    document.body.className = "";
+    document.documentElement.removeAttribute("style");
+  });
+
+  function makeScope(): SurfaceRealmScope {
+    return new SurfaceRealmScope(
+      NO_GRANTS,
+      "view.a",
+      new MemoryStorage(),
+      () => undefined,
+    );
+  }
+
+  it("removes a view-injected root class and :root var, preserving shell-owned tokens", () => {
+    // Scope captures the baseline at activation, BEFORE the view injects.
+    const scope = makeScope();
+    // The view reaches the host realm directly (bypassing its host node).
+    document.documentElement.classList.add("rogue-root-class");
+    document.body.classList.add("rogue-body-class");
+    document.documentElement.style.setProperty("--rogue-var", "red");
+
+    const removed = scope.resetHostRealm();
+
+    // View injections are gone.
+    expect(
+      document.documentElement.classList.contains("rogue-root-class"),
+    ).toBe(false);
+    expect(document.body.classList.contains("rogue-body-class")).toBe(false);
+    expect(document.documentElement.style.getPropertyValue("--rogue-var")).toBe(
+      "",
+    );
+    expect(removed.rootClasses).toContain("rogue-root-class");
+    expect(removed.bodyClasses).toContain("rogue-body-class");
+    expect(removed.rootVars).toContain("--rogue-var");
+
+    // Shell-owned tokens survive.
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.body.classList.contains("platform-web")).toBe(true);
+    expect(document.body.classList.contains("native")).toBe(true);
+    expect(document.documentElement.style.getPropertyValue("--accent")).toBe(
+      "#f60",
+    );
+    expect(document.documentElement.style.getPropertyValue("--bg")).toBe(
+      "#000",
+    );
+  });
+
+  it("does not strip a token that was already present when the view activated (only what the view added)", () => {
+    // A plugin-provided token present at activation (e.g. a content-pack var).
+    document.documentElement.style.setProperty("--pack-custom-token", "blue");
+    document.documentElement.classList.add("pack-preset-a");
+    const scope = makeScope();
+    // The view injects on top.
+    document.documentElement.style.setProperty("--rogue-var", "red");
+
+    scope.resetHostRealm();
+
+    // Pre-activation tokens preserved; view injection removed.
+    expect(
+      document.documentElement.style.getPropertyValue("--pack-custom-token"),
+    ).toBe("blue");
+    expect(document.documentElement.classList.contains("pack-preset-a")).toBe(
+      true,
+    );
+    expect(document.documentElement.style.getPropertyValue("--rogue-var")).toBe(
+      "",
+    );
+  });
+
+  it("preserves a theme class toggled ON while the view was active (shell writers stay allowed)", () => {
+    document.documentElement.className = "light";
+    const scope = makeScope();
+    // Shell toggles theme mid-view (light -> dark).
+    document.documentElement.classList.remove("light");
+    document.documentElement.classList.add("dark");
+    // View injects its own class.
+    document.documentElement.classList.add("rogue-root-class");
+
+    scope.resetHostRealm();
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(
+      document.documentElement.classList.contains("rogue-root-class"),
+    ).toBe(false);
+  });
+});

--- a/packages/ui/src/surface-realm-broker.ts
+++ b/packages/ui/src/surface-realm-broker.ts
@@ -1,0 +1,358 @@
+/**
+ * In-process host-realm broker (#14179). An `in-process` view shares the host
+ * DOM/JS realm with the shell, so without a boundary it can mutate global state
+ * that belongs to the shell or bleeds into the next view: root/body classes,
+ * `:root` CSS variables, `localStorage`/`sessionStorage`, and `history`
+ * navigation. #14068 landed the wallpaper vector (the background broker); this
+ * module completes the remaining four, driven by the SAME resolved surface
+ * manifest so there is one policy source, not a parallel table.
+ *
+ * The broker mirrors `view-capability-broker.ts`: it reads a
+ * {@link ResolvedSurfaceManifest} and gates each mutation on the grant that
+ * governs it — `storage` for host-scoped persistence, `navigate` for shell
+ * navigation — and scopes the DOM class/CSS-var vectors to the shell-owned
+ * token set so a view's global reach never survives a navigation. A denied
+ * mutation is an observable failure ({@link SurfaceRealmDeniedError}) or an
+ * explicit view-namespaced scope, never a fabricated success. Default-deny: a
+ * view with no grants gets the safe scope.
+ *
+ * Consumed by `App.tsx`, which resolves the active view's manifest and publishes
+ * one {@link SurfaceRealmScope} per active view via
+ * {@link setActiveSurfaceRealmScope}; the shell resets the DOM scope on view
+ * teardown. Unit-tested in `surface-realm-broker.test.tsx`; proven end-to-end in
+ * `App.surface-mutation-fuzz.test.tsx`.
+ */
+
+import type { ResolvedSurfaceManifest } from "@elizaos/core";
+import { surfaceGrants } from "@elizaos/core";
+import { THEME_CSS_VAR_MAP, THEME_FONT_CSS_VARS } from "@elizaos/shared";
+
+/**
+ * Raised when a view attempts a host-realm mutation its manifest does not grant.
+ * Thrown (not swallowed) so the denial reaches the caller/agent observably — a
+ * blocked write is never turned into a silent no-op that reads as success.
+ */
+export class SurfaceRealmDeniedError extends Error {
+  constructor(
+    readonly viewId: string,
+    readonly vector: "storage" | "navigate",
+    readonly detail: string,
+  ) {
+    super(`View "${viewId}" denied ${vector}: ${detail}`);
+    this.name = "SurfaceRealmDeniedError";
+  }
+}
+
+// ── Storage vector ───────────────────────────────────────────────────────────
+
+/** Namespace every view-scoped storage key lives under when a view lacks `storage`. */
+export const SURFACE_VIEW_STORAGE_PREFIX = "surface:view:";
+
+// The shell persists all of its own UI state under these key namespaces
+// (`packages/ui/src/state/persistence.ts`). A view path may never write them:
+// even a `storage`-granted view is denied here, so a view can never overwrite
+// the owner's theme, background, wallet, or server records.
+const SHELL_RESERVED_STORAGE_PREFIXES = [
+  "eliza:",
+  "elizaos:",
+  "eliza_",
+] as const;
+
+/** Whether a storage key belongs to the shell's own reserved namespace. */
+export function isShellReservedStorageKey(key: string): boolean {
+  return SHELL_RESERVED_STORAGE_PREFIXES.some((prefix) =>
+    key.startsWith(prefix),
+  );
+}
+
+/** The keyspace prefix a view without the `storage` grant is confined to. */
+export function surfaceViewStoragePrefix(viewId: string): string {
+  return `${SURFACE_VIEW_STORAGE_PREFIX}${viewId}:`;
+}
+
+/**
+ * The storage surface handed to a view. A strict subset of the DOM `Storage`
+ * interface (no index signature) so the façades below are strongly typed without
+ * a cast — a view uses the methods, never bracket access.
+ */
+export interface ScopedStorage {
+  readonly length: number;
+  clear(): void;
+  getItem(key: string): string | null;
+  key(index: number): string | null;
+  removeItem(key: string): void;
+  setItem(key: string, value: string): void;
+}
+
+function namespacedStorage(backing: Storage, prefix: string): ScopedStorage {
+  const ownedKeys = (): string[] => {
+    const keys: string[] = [];
+    for (let i = 0; i < backing.length; i += 1) {
+      const key = backing.key(i);
+      if (key?.startsWith(prefix)) keys.push(key);
+    }
+    return keys;
+  };
+  return {
+    get length() {
+      return ownedKeys().length;
+    },
+    clear() {
+      for (const key of ownedKeys()) backing.removeItem(key);
+    },
+    getItem(key) {
+      return backing.getItem(prefix + key);
+    },
+    key(index) {
+      const key = ownedKeys()[index];
+      return key === undefined ? null : key.slice(prefix.length);
+    },
+    removeItem(key) {
+      backing.removeItem(prefix + key);
+    },
+    setItem(key, value) {
+      backing.setItem(prefix + key, value);
+    },
+  };
+}
+
+function hostScopedStorage(backing: Storage, viewId: string): ScopedStorage {
+  const assertWritable = (key: string): void => {
+    if (isShellReservedStorageKey(key)) {
+      throw new SurfaceRealmDeniedError(
+        viewId,
+        "storage",
+        `reserved shell key "${key}" is not writable by a view`,
+      );
+    }
+  };
+  return {
+    get length() {
+      return backing.length;
+    },
+    clear() {
+      // Never wipe the shell's own keys, even for a granted view: only clear
+      // keys a view path was allowed to write.
+      const removable: string[] = [];
+      for (let i = 0; i < backing.length; i += 1) {
+        const key = backing.key(i);
+        if (key !== null && !isShellReservedStorageKey(key))
+          removable.push(key);
+      }
+      for (const key of removable) backing.removeItem(key);
+    },
+    getItem(key) {
+      return backing.getItem(key);
+    },
+    key(index) {
+      return backing.key(index);
+    },
+    removeItem(key) {
+      assertWritable(key);
+      backing.removeItem(key);
+    },
+    setItem(key, value) {
+      assertWritable(key);
+      backing.setItem(key, value);
+    },
+  };
+}
+
+/**
+ * The storage surface for a view, gated on its manifest. Without the `storage`
+ * grant a view is confined to a view-prefixed keyspace it can never escape (its
+ * writes cannot collide with the shell's keys). With the grant it uses the host
+ * keyspace, but the shell's reserved keys stay off-limits — a view never
+ * overwrites the owner's persisted shell state.
+ */
+export function brokerSurfaceStorage(
+  manifest: ResolvedSurfaceManifest,
+  backing: Storage,
+  viewId: string,
+): ScopedStorage {
+  return surfaceGrants(manifest, "storage")
+    ? hostScopedStorage(backing, viewId)
+    : namespacedStorage(backing, surfaceViewStoragePrefix(viewId));
+}
+
+// ── Navigation vector ────────────────────────────────────────────────────────
+
+/**
+ * Wrap the shell's navigate function with the `navigate` gate. A view without
+ * the grant cannot drive shell/history navigation: the wrapper throws instead of
+ * calling through, so the shell route never moves out from under the user. A
+ * granted view navigates normally.
+ */
+export function brokerSurfaceNavigate(
+  manifest: ResolvedSurfaceManifest,
+  viewId: string,
+  navigate: (path: string) => void,
+): (path: string) => void {
+  return (path: string) => {
+    if (!surfaceGrants(manifest, "navigate")) {
+      throw new SurfaceRealmDeniedError(
+        viewId,
+        "navigate",
+        `no "navigate" grant; blocked navigation to "${path}"`,
+      );
+    }
+    navigate(path);
+  };
+}
+
+// ── Root/body class + :root CSS-variable vector ──────────────────────────────
+
+// The shell's own writers (`platform/init.ts`, `themes/apply-theme.ts`,
+// `state/persistence.ts` accent/theme) are the only sanctioned mutators of
+// root/body classes and `:root` variables. They run from a provider ABOVE
+// `<App/>`, so their tokens land after the shell's per-view scope is created;
+// the token allowlist below — not a mount-time snapshot — is what keeps them
+// from being mistaken for a view injection and reset. A view that reaches
+// `document.documentElement`/`document.body` directly writes a token that is
+// neither shell-owned nor present when the view activated, so it is removed on
+// teardown and cannot survive into the next view.
+
+const SHELL_OWNED_ROOT_CLASSES: ReadonlySet<string> = new Set([
+  "dark",
+  "light",
+]);
+
+// Every `:root` CSS variable the shell writes. Sourced from the shell's own
+// token maps so this cannot drift as the theme grows; the prefixes cover the
+// dynamically-suffixed families (accent ramp, per-edge safe-area, content-pack).
+const SHELL_OWNED_ROOT_VARS: ReadonlySet<string> = new Set([
+  ...Object.values(THEME_CSS_VAR_MAP),
+  ...Object.values(THEME_FONT_CSS_VARS),
+]);
+const SHELL_OWNED_ROOT_VAR_PREFIXES = [
+  "--accent",
+  "--primary",
+  "--txt",
+  "--ring",
+  "--border-hover",
+  "--safe-area-",
+  "--keyboard-",
+  "--pack-",
+] as const;
+
+function isShellOwnedRootClass(cls: string): boolean {
+  return SHELL_OWNED_ROOT_CLASSES.has(cls);
+}
+
+function isShellOwnedBodyClass(cls: string): boolean {
+  return cls === "native" || cls.startsWith("platform-");
+}
+
+function isShellOwnedRootVar(name: string): boolean {
+  return (
+    SHELL_OWNED_ROOT_VARS.has(name) ||
+    SHELL_OWNED_ROOT_VAR_PREFIXES.some((prefix) => name.startsWith(prefix))
+  );
+}
+
+function readRootVarNames(el: HTMLElement): string[] {
+  const names: string[] = [];
+  const { style } = el;
+  for (let i = 0; i < style.length; i += 1) {
+    const name = style.item(i);
+    if (name.startsWith("--")) names.push(name);
+  }
+  return names;
+}
+
+/** The tokens removed by a host-realm reset — returned so callers can log/inspect. */
+export interface HostRealmResetResult {
+  rootClasses: string[];
+  bodyClasses: string[];
+  rootVars: string[];
+}
+
+// ── The per-view scope the shell publishes ───────────────────────────────────
+
+/**
+ * The host-realm boundary for one active in-process view, resolved from its
+ * surface manifest. The shell constructs one when a view becomes active and
+ * tears it down on navigation. It captures the class/var tokens present at
+ * activation so shell state that legitimately changes while the view is open is
+ * preserved, while anything the view injected globally is reset on teardown.
+ */
+export class SurfaceRealmScope {
+  readonly storage: ScopedStorage;
+  readonly navigate: (path: string) => void;
+  private readonly rootClassBaseline: ReadonlySet<string>;
+  private readonly bodyClassBaseline: ReadonlySet<string>;
+  private readonly rootVarBaseline: ReadonlySet<string>;
+
+  constructor(
+    readonly manifest: ResolvedSurfaceManifest,
+    readonly viewId: string,
+    backing: Storage,
+    navigate: (path: string) => void,
+  ) {
+    this.storage = brokerSurfaceStorage(manifest, backing, viewId);
+    this.navigate = brokerSurfaceNavigate(manifest, viewId, navigate);
+    if (typeof document === "undefined") {
+      this.rootClassBaseline = new Set();
+      this.bodyClassBaseline = new Set();
+      this.rootVarBaseline = new Set();
+    } else {
+      this.rootClassBaseline = new Set(document.documentElement.classList);
+      this.bodyClassBaseline = new Set(document.body.classList);
+      this.rootVarBaseline = new Set(
+        readRootVarNames(document.documentElement),
+      );
+    }
+  }
+
+  /**
+   * Remove the root/body classes and `:root` variables this view added to the
+   * host realm beyond the shell's own token set. Called on view teardown so a
+   * view's global class/CSS-var mutation cannot leak into the next view.
+   */
+  resetHostRealm(): HostRealmResetResult {
+    const result: HostRealmResetResult = {
+      rootClasses: [],
+      bodyClasses: [],
+      rootVars: [],
+    };
+    if (typeof document === "undefined") return result;
+    const root = document.documentElement;
+    const { body } = document;
+    for (const cls of [...root.classList]) {
+      if (isShellOwnedRootClass(cls) || this.rootClassBaseline.has(cls))
+        continue;
+      root.classList.remove(cls);
+      result.rootClasses.push(cls);
+    }
+    for (const cls of [...body.classList]) {
+      if (isShellOwnedBodyClass(cls) || this.bodyClassBaseline.has(cls))
+        continue;
+      body.classList.remove(cls);
+      result.bodyClasses.push(cls);
+    }
+    for (const name of readRootVarNames(root)) {
+      if (isShellOwnedRootVar(name) || this.rootVarBaseline.has(name)) continue;
+      root.style.removeProperty(name);
+      result.rootVars.push(name);
+    }
+    return result;
+  }
+}
+
+// The active scope is a process-wide singleton because the host realm is: only
+// one view owns the foreground at a time. The shell publishes it here so the
+// active view (and the isolation tests) reach exactly the brokered handles the
+// shell resolved for the current manifest, never the raw globals.
+let activeScope: SurfaceRealmScope | null = null;
+
+/** Publish the scope for the active view. Pass `null` on teardown. */
+export function setActiveSurfaceRealmScope(
+  scope: SurfaceRealmScope | null,
+): void {
+  activeScope = scope;
+}
+
+/** The scope for the active view, or `null` when no view is mounted. */
+export function getActiveSurfaceRealmScope(): SurfaceRealmScope | null {
+  return activeScope;
+}


### PR DESCRIPTION
Closes #14179 (completes an acceptance criterion of the #13452 view-isolation epic).

## What
The `SurfaceManifest` contract (#14068) previously enforced exactly one in-process host-realm mutation vector — the app wallpaper. This completes the remaining four vectors the #13452 reopen listed, all driven off the **same** `resolveSurfaceManifest` / `surfaceGrants` policy source (no parallel policy table):

- **root/body classes + `:root` CSS vars** — a per-view scope snapshots the host realm on activate and `resetHostRealm()` on teardown strips any root/body class or `:root` var that is neither shell-owned (theme/platform/accent token set) nor present at activation. A view's reach into `document.documentElement`/`body` cannot survive into the next view.
- **storage** — no `storage` grant → keys transparently confined to a `surface:view:<id>:` keyspace (can't collide with shell keys); with the grant → host keyspace, but reserved shell keys (`eliza:`/`elizaos:`/`eliza_`) throw `SurfaceRealmDeniedError`.
- **navigation** — no `navigate` grant → the brokered wrapper **throws** instead of calling through; the route never moves.

All three enforcement points are **default-deny with an observable failure** (`SurfaceRealmDeniedError`), never a fabricated success. New `surface-realm-broker.ts` sits beside the existing `view-capability-broker.ts`; `App.tsx` gains `resolveActiveViewSurface`/`useActiveViewSurface` (mirrors the background resolver) + a purely additive per-transition scope effect (142 insertions, 0 deletions).

## Verification
- **46 tests pass**: `surface-manifest` (15) + new `surface-realm-broker.test.tsx` (11) + `App.surface-manifest-wallpaper` (3) + new `App.surface-mutation-fuzz.test.tsx` (4, real `<App/>` randomized cross-view walk) + `view-capability-broker` (13). Broker suite re-verified independently post-rebase (11/11).
- **Per-vector mutation-check (RED→GREEN)** — each guard proven load-bearing by removing it and re-running the fuzz: class/var reset off → `injected root class did not survive`; storage passthrough → `expected null to be 'pwn'`; navigate grant-check off → `expected function to throw`. All restored → green.
- Typecheck: 0 errors in touched files (remaining output is pre-existing `TS7016`/`TS7006` dist-declaration noise in untouched files). Biome clean on all 4 files. Rebased onto develop (conflict was a co-located import add; both kept).

## Honest scope note
In-process isolation strips a view's global mutations made *after* activation (the rogue-during-interaction case the fuzz exercises) and confines the sanctioned storage/navigation handles. True realm separation for *untrusted* views (a mutation during a view's own mount, or a direct `window.localStorage`/`window.history` write bypassing the brokered handle) is the explicit non-goal here and is the subject of the child issues #14180 (sandboxed-iframe) / #14182 (surface-manager).

🤖 Generated with [Claude Code](https://claude.com/claude-code)