### PR TITLE
fix(security): validate blocked-page navigation target (CodeQL #645, js/xss)

### DIFF
--- a/packages/browser-extension/entrypoints/blocked.ts
+++ b/packages/browser-extension/entrypoints/blocked.ts
@@ -4,6 +4,8 @@
  * and agent base from the query string, then polls the agent for the group's
  * required tasks and links back to LifeOps so the user can clear the block.
  */
+import { normalizeNavigableUrl } from "../src/url";
+
 const POLL_INTERVAL_MS = 30_000;
 
 interface RequiredTask {
@@ -118,10 +120,10 @@ async function loadBlockingReason(): Promise<void> {
 async function pollForUnblock(): Promise<void> {
   const data = await fetchBlockingReason();
   if (data && !data.blocked) {
-    const target = blockedUrl.startsWith("http")
-      ? blockedUrl
-      : `https://${blockedUrl}`;
-    window.location.href = target;
+    const target = normalizeNavigableUrl(blockedUrl);
+    if (target) {
+      window.location.href = target;
+    }
   }
 }
 

--- a/packages/browser-extension/src/url.test.ts
+++ b/packages/browser-extension/src/url.test.ts
@@ -3,7 +3,11 @@
  * URL forms (credentials, non-http schemes).
  */
 import { describe, expect, it } from "vitest";
-import { normalizeHttpBaseUrl, normalizeHttpOrigin } from "./url";
+import {
+  normalizeHttpBaseUrl,
+  normalizeHttpOrigin,
+  normalizeNavigableUrl,
+} from "./url";
 
 describe("normalizeHttpBaseUrl", () => {
   it("normalizes http URLs by trimming, stripping query/fragment, and removing trailing slashes", () => {
@@ -46,6 +50,63 @@ describe("normalizeHttpOrigin", () => {
       "not a url",
     ]) {
       expect(normalizeHttpOrigin(value)).toBeNull();
+    }
+  });
+});
+
+describe("normalizeNavigableUrl", () => {
+  it("keeps a full http(s) blocked-site URL, preserving path and query", () => {
+    expect(normalizeNavigableUrl("https://example.com/read?id=7")).toBe(
+      "https://example.com/read?id=7",
+    );
+    expect(normalizeNavigableUrl("http://intra.example/page")).toBe(
+      "http://intra.example/page",
+    );
+  });
+
+  it("upgrades a scheme-less host to https", () => {
+    expect(normalizeNavigableUrl("example.com")).toBe("https://example.com/");
+    expect(normalizeNavigableUrl("  news.example.com/top  ")).toBe(
+      "https://news.example.com/top",
+    );
+  });
+
+  it("returns null for a javascript: payload so it never reaches location.href", () => {
+    // The block interstitial's `?url=` query param is attacker-controllable;
+    // a `javascript:` scheme must not be force-prefixed into a navigable value.
+    expect(
+      normalizeNavigableUrl("javascript:alert(document.cookie)"),
+    ).toBeNull();
+    expect(normalizeNavigableUrl("JavaScript:alert(1)")).toBeNull();
+    expect(
+      normalizeNavigableUrl("data:text/html,<script>alert(1)</script>"),
+    ).toBeNull();
+    expect(normalizeNavigableUrl("vbscript:msgbox(1)")).toBeNull();
+  });
+
+  it("returns null for empty or blank input", () => {
+    for (const value of [null, undefined, "", "   "]) {
+      expect(normalizeNavigableUrl(value)).toBeNull();
+    }
+  });
+
+  it("never yields a non-http(s) scheme for any hostile input (the security invariant)", () => {
+    // The one property the navigation sink relies on: the result is always
+    // either null or an http/https URL. A `file:`/`javascript:`/`data:` scheme
+    // can never survive to be assigned to `window.location.href`.
+    for (const value of [
+      "javascript:alert(1)",
+      "data:text/html,x",
+      "file:///etc/passwd",
+      "vbscript:msgbox(1)",
+      "httpx://not-really-http.example",
+      "//evil.example.com",
+      "\tjavascript:alert(1)",
+    ]) {
+      const result = normalizeNavigableUrl(value);
+      if (result !== null) {
+        expect(result).toMatch(/^https?:\/\//);
+      }
     }
   });
 });

--- a/packages/browser-extension/src/url.ts
+++ b/packages/browser-extension/src/url.ts
@@ -1,8 +1,9 @@
 /**
  * URL normalization helpers shared across the extension: coerce a user-entered
- * agent API URL or a page origin to a canonical, safe http(s) form. Rejects
- * non-http(s) schemes and credentials-in-URL so downstream code can trust the
- * result. Pure functions with no browser dependencies.
+ * agent API URL, a page origin, or a blocked-site navigation target to a
+ * canonical, safe http(s) form. Rejects non-http(s) schemes and
+ * credentials-in-URL so downstream code can trust the result. Pure functions
+ * with no browser dependencies.
  */
 export function normalizeHttpBaseUrl(
   value: unknown,
@@ -44,6 +45,40 @@ export function normalizeHttpOrigin(
       return null;
     }
     return parsed.origin.replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Coerce a blocked-site URL — which arrives from the block interstitial's own
+ * `?url=` query param and may be scheme-less (e.g. `example.com`) — to a
+ * canonical http(s) URL safe to assign to `window.location.href`. Returns null
+ * for anything that does not resolve to an http/https URL, so a crafted
+ * `javascript:`/`data:` value can never reach the navigation sink (a
+ * `startsWith("http")` string check does not stop a `javascript:` scheme from
+ * being force-prefixed, nor does it validate the URL is well-formed). Pure; no
+ * browser dependencies.
+ */
+export function normalizeNavigableUrl(
+  value: string | null | undefined,
+): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const candidate = /^https?:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.toString();
   } catch {
     return null;
   }


### PR DESCRIPTION
## Security fix — CodeQL alert #645 (`js/xss`, high)

Closes CodeQL alert **#645** (`js/xss`, "Client-side cross-site scripting").

**Note on the alert location:** the alert points at `apps/browser-bridge/entrypoints/blocked.ts:126`; that file has since been moved (byte-identical) to `packages/browser-extension/entrypoints/blocked.ts` by `chore(repo): rename packages/browser-bridge-extension -> browser-extension`. The vulnerable code is unchanged, so the alert is a live true-positive on current `develop`.

### The vulnerability (verified true-positive)

The block interstitial (`blocked.html`) reads `?url=` from its own query string (`window.location.search`, the tainted source) and, once the agent reports the site is no longer blocked, navigates the browser back to it:

```ts
const target = blockedUrl.startsWith("http") ? blockedUrl : `https://${blockedUrl}`;
window.location.href = target;   // sink flagged by CodeQL
```

`blockedUrl.startsWith("http")` is **not** a scheme validator. It does not reject a `javascript:`/`data:` payload (they fail the check and are force-prefixed to `https://…`, but the value is still unvalidated and malformed), and it accepts anything beginning with `http` (e.g. `httpx://`) as-is. The block-page URL is fully attacker-controllable, so a crafted `?url=` reaches a navigation sink without contextual sanitization — DOM-based XSS / open-redirect surface. CodeQL does not recognize `startsWith("http")` as a sanitizer, which is why the flow is flagged.

### The fix

Add `normalizeNavigableUrl` to `src/url.ts` — a pure helper that parses the value with the `URL` API and allowlists **only** `http:`/`https:`, returning `null` otherwise. This mirrors the discipline the same file already uses for the API base (`normalizeApiBase`) and the existing `normalizeHttpBaseUrl`/`normalizeHttpOrigin` helpers. `blocked.ts` now navigates only when the helper returns a validated URL:

```ts
const target = normalizeNavigableUrl(blockedUrl);
if (target) window.location.href = target;
```

Legitimate behavior is preserved: a real http(s) blocked site still resolves back to its exact URL (path + query retained) when unblocked; scheme-less hosts are upgraded to `https://`. `javascript:`, `data:`, `vbscript:`, `file:`, and malformed input can no longer reach `location.href`.

### Deviation from the brief

The brief anticipated an **innerHTML** sink and suggested `textContent`/an HTML escaper plus an `<img src=x onerror=…>` test. The actual flagged sink (alert columns 28–34 on the old line 126) is **`window.location.href = target`** — a navigation sink, not an HTML sink. The `innerHTML` paths in this file are already safe (`escapeHtml` + `textContent`) and are not flagged. The correct remediation for a navigation sink is URL-scheme validation (done here), and the regression test uses `javascript:`/`data:` payloads accordingly.

### Verification

- `bun run --cwd packages/browser-extension test` → **30 unit tests passed** (6 files) + Chrome dist smoke checks passed (proves `blocked.ts` bundles with the new `../src/url` import).
- `bun run --cwd packages/browser-extension build:chrome` → build OK.
- Biome `check` clean on all touched files.
- New tests in `src/url.test.ts` assert `javascript:`/`data:`/`vbscript:` return `null` and the security invariant "result is always `null` or an `http(s)` URL" holds for hostile inputs.

Advances the CodeQL security-hardening sweep. This is an extension package (`"private": true`, no runtime UI surface in `packages/app`); no screenshot/trajectory evidence applies — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
