### PR TITLE
fix(security): complete <script> escaping in desktop boot-config inject (CodeQL #642/#643, js/bad-code-sanitization)

### DIFF
--- a/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.test.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.test.ts
@@ -143,4 +143,50 @@ describe("api-base-owner", () => {
       externalApiBase: null,
     });
   });
+
+  it("neutralizes a </script> breakout in the injected base and token (js/bad-code-sanitization)", () => {
+    // Both the base and the token flow verbatim into an inline <script>.
+    // JSON.stringify alone leaves `</script>`/`<script>` intact, so a crafted
+    // value could terminate the element and inject markup; the escaper must map
+    // the angle brackets so only the snippet's own closing tag survives.
+    setCurrent(
+      "http://127.0.0.1:31337/</script><script>alert(1)</script>",
+      "tok</script><img src=x onerror=alert(2)>",
+    );
+
+    const injected = injectIntoHtml("<html><head></head><body></body></html>");
+
+    // Exactly one real opening + closing tag — the injected snippet's own.
+    expect((injected.match(/<script>/g) ?? []).length).toBe(1);
+    expect((injected.match(/<\/script>/g) ?? []).length).toBe(1);
+    // The payload's angle brackets are emitted as \uXXXX escapes, not raw.
+    expect(injected).not.toContain('apiBase:"http://127.0.0.1:31337/</script>');
+    expect(injected).toContain("\\u003C/script\\u003E");
+    // The value still round-trips to the identical string at renderer parse
+    // time (the \uXXXX escapes decode back inside the JS string literal).
+    const baseLiteral = injected.match(/apiBase:("(?:[^"\\]|\\.)*")/)?.[1];
+    expect(baseLiteral).toBeDefined();
+    expect(JSON.parse(baseLiteral as string)).toBe(
+      "http://127.0.0.1:31337/</script><script>alert(1)</script>",
+    );
+  });
+
+  it("escapes U+2028 / U+2029 line separators in injected values", () => {
+    const ls = String.fromCharCode(0x2028);
+    const ps = String.fromCharCode(0x2029);
+    setCurrent(`http://127.0.0.1:31337/${ls}p`, `token${ps}x`);
+
+    const injected = injectIntoHtml("<html><head></head><body></body></html>");
+
+    // Raw separators are illegal in older JS string literals; they must be
+    // escaped, and the runtime value must still round-trip.
+    expect(injected).not.toContain(ls);
+    expect(injected).not.toContain(ps);
+    expect(injected).toContain("\\u2028");
+    expect(injected).toContain("\\u2029");
+    const baseLiteral = injected.match(/apiBase:("(?:[^"\\]|\\.)*")/)?.[1];
+    expect(JSON.parse(baseLiteral as string)).toBe(
+      `http://127.0.0.1:31337/${ls}p`,
+    );
+  });
 });

--- a/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts
@@ -44,8 +44,26 @@ interface ApiBaseSnapshot {
 
 let current: ApiBaseSnapshot = { base: null, token: "" };
 
+// `JSON.stringify` is not a code sanitizer (CWE-94): it leaves `<`, `>`, and
+// the U+2028 / U+2029 line separators raw, so a base/token value containing
+// `</script>`, `<!--`, `<script`, or a line separator can terminate the
+// injected `<script>` element or break the surrounding JS string literal.
+// Mapping those characters to their `\uXXXX` escapes neutralizes the breakout
+// while keeping the runtime value identical — inside a JS string literal the
+// escapes decode back to the same character — so every legitimate URL/token is
+// unchanged.
+const SCRIPT_UNSAFE_CHARS: Record<string, string> = {
+  "<": "\\u003C",
+  ">": "\\u003E",
+  "\u2028": "\\u2028",
+  "\u2029": "\\u2029",
+};
+
 function safeJsonForHtml(value: unknown): string {
-  return JSON.stringify(value).replace(/<\//g, "<\\/");
+  return JSON.stringify(value).replace(
+    /[<>\u2028\u2029]/g,
+    (ch) => SCRIPT_UNSAFE_CHARS[ch] ?? ch,
+  );
 }
 
 function resolveStartupTraceId(): string | null {


### PR DESCRIPTION
## Security fix — CodeQL alerts #642 + #643 (`js/bad-code-sanitization`, medium)

Closes CodeQL alerts **#642** and **#643** (`js/bad-code-sanitization`, "Improper code sanitization", CWE-94/79/116).

**Note on the alert location:** the alerts point at `packages/app-core/platforms/electrobun/src/index.ts:853`; the injection logic has since been extracted into `packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts` (`injectIntoHtml` / `safeJsonForHtml`). Both flagged sources — the API base (#642) and the API token (#643) — flow through this one function, so the single fix resolves both.

### The vulnerability (verified true-positive)

The electrobun desktop static server injects the current API base + token into an inline `<script>` boot-config snippet that runs before any renderer JS:

```ts
// current develop
function safeJsonForHtml(value: unknown): string {
  return JSON.stringify(value).replace(/<\//g, "<\\/");
}
```

At the flagged commit the values were raw `JSON.stringify(...)` with no escaping; a partial `.replace(/<\//g, ...)` was added later. It is still an **incomplete code sanitizer**: `JSON.stringify` leaves `<`, `>`, and the U+2028 / U+2029 line separators raw, and the `<\/` replace only handles the `</` sequence. A base or token value containing `<!--`, `<script`, or a raw line separator can therefore still terminate the `<script>` element or break the surrounding JS string literal. CodeQL correctly flags "escaping code as HTML does not protect against code injection."

The token especially (`configureDesktopLocalApiAuth()` / `resolveApiToken(env)`) and the external-mode base are values that should not be assumed free of these characters.

### The fix

Replace the partial `.replace` with a complete escaper that maps every dangerous character `JSON.stringify` passes through raw to its `\uXXXX` escape:

```ts
const SCRIPT_UNSAFE_CHARS = { "<": "\\u003C", ">": "\\u003E", " ": "\\u2028", " ": "\\u2029" };
function safeJsonForHtml(value: unknown): string {
  return JSON.stringify(value).replace(/[<>  ]/g, (ch) => SCRIPT_UNSAFE_CHARS[ch] ?? ch);
}
```

This is exactly the pattern CodeQL's own guidance recommends (escape `<`/`>` and the line separators after `JSON.stringify`). Inside a JS string literal `<` decodes back to `<`, so the **runtime value is byte-for-byte identical** for every legitimate URL/token, while the injected markup stays well-formed regardless of the value. No literal U+2028/U+2029 characters are introduced into the source (escape sequences only).

### Verification

- `bun run --cwd packages/app-core/platforms/electrobun test src/lifecycle/api-base-owner` → **8 tests passed** (6 existing + 2 new). New cases prove a `</script><script>alert(1)</script>` payload in both the base and token is neutralized (only the snippet's own tag survives), U+2028/U+2029 are escaped, and the value still round-trips exactly via `JSON.parse`.
- `@elizaos/electrobun` typecheck: my file (`api-base-owner.ts`) is clean; verify green except **pre-existing develop failures** `app#typecheck`/`electrobun#typecheck` (untouched by this PR — cross-package resolution errors in agent/ui/plugins, reproduced on clean `origin/develop`).
- Biome `check` clean on both touched files. All existing `injectIntoHtml` assertions (benign base/token unchanged) still pass, confirming no behavior change for legitimate values.

No renderer UI change (byte-identical output for real values); no screenshot/trajectory evidence applies — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
