### PR TITLE
fix(orchestrator): derive fork world on project change

### DIFF
--- a/.github/issue-evidence/14222-project-world-fork-isolation.txt
+++ b/.github/issue-evidence/14222-project-world-fork-isolation.txt
@@ -1,0 +1,42 @@
+Evidence for #14222 follow-up: project fork memory-world isolation.
+
+Reviewed on 2026-07-05 from branch fix/14222-project-world-isolation.
+
+Bug reproduced by inspection:
+
+- #14222 allowed `forkTask(parent, { projectId: target, worldId: sourceWorld })`.
+- Because `overrides.worldId` was forwarded while changing `projectId`, createTask
+  treated the caller world as authoritative and could persist target project B
+  with source project A's memory world.
+
+Fix verified:
+
+- Changed-project forks now pass `worldId: undefined` into createTask so the
+  existing project binding path derives projectWorldId(agentId, targetProject).
+- Same-project and inherited-project forks still preserve the existing world.
+
+Commands run:
+
+node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
+bunx @biomejs/biome check \
+  plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts \
+  plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts \
+  --write --no-errors-on-unmatched
+
+bun test plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
+
+Verifier result:
+
+13 pass
+0 fail
+57 expect() calls
+Ran 13 tests across 1 file. [759.00ms]
+
+Manual review:
+
+- The new real OrchestratorTaskService test creates project A and project B,
+  forks an A-bound task while maliciously supplying B's projectId plus A's
+  worldId, and verifies the persisted fork uses projectWorldId(agentId, B).
+- The same test spawns the fork and verifies the worker lands in project B's
+  registered localPath.

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts
@@ -553,6 +553,54 @@ describe("project memory-world stamping at bind time (#13776 D3)", () => {
     }
   });
 
+  it("derives the target project world when a fork changes projects", async () => {
+    const sourceProject = upsertProject({
+      name: "repo-a",
+      localPath: firstDir,
+    });
+    const targetProject = upsertProject({
+      name: "repo-b",
+      localPath: overrideDir,
+    });
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const acp = makeWorkdirCapturingAcp();
+    const service = new OrchestratorTaskService(makeRuntime(acp.service), {
+      store,
+    });
+    await service.start();
+    try {
+      const parent = await service.createTask({
+        title: "bound parent",
+        goal: "work in project A",
+        acceptanceCriteria: [],
+        projectId: sourceProject.id,
+      });
+      const sourceWorld = projectWorldId(BINDER_AGENT_ID, sourceProject.id);
+      const targetWorld = projectWorldId(BINDER_AGENT_ID, targetProject.id);
+
+      const fork = await service.forkTask(parent.id, {
+        projectId: targetProject.id,
+        worldId: sourceWorld,
+      });
+
+      expect(fork).not.toBeNull();
+      expect(fork?.parentTaskId).toBe(parent.id);
+      expect(fork?.projectId).toBe(targetProject.id);
+      expect(fork?.worldId).toBe(targetWorld);
+      expect(fork?.worldId).not.toBe(sourceWorld);
+      const record = fork ? await store.getTask(fork.id) : null;
+      expect(record?.task.projectId).toBe(targetProject.id);
+      expect(record?.task.worldId).toBe(targetWorld);
+
+      await service.spawnAgentForTask(fork?.id as string, {
+        task: "continue",
+      });
+      expect(acp.spawns.at(0)?.workdir).toBe(overrideDir);
+    } finally {
+      await service.stop().catch(() => undefined);
+    }
+  });
+
   it("leaves an unbound task's worldId untouched and lets an explicit worldId win", async () => {
     const project = upsertProject({ name: "repo-a", localPath: firstDir });
     const store = new OrchestratorTaskStore({ backend: "memory" });

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -2518,11 +2518,12 @@ export class OrchestratorTaskService extends Service {
     const doc = await this.store.getTask(taskId);
     if (!doc) return null;
     const projectId = overrides.projectId ?? doc.task.projectId ?? undefined;
-    const worldId =
-      overrides.worldId ??
-      (overrides.projectId && overrides.projectId !== doc.task.projectId
-        ? undefined
-        : doc.task.worldId);
+    const projectChanged =
+      overrides.projectId !== undefined &&
+      overrides.projectId !== doc.task.projectId;
+    const worldId = projectChanged
+      ? undefined
+      : (overrides.worldId ?? doc.task.worldId);
     return this.createTask({
       title: overrides.title ?? `${doc.task.title} (fork)`,
       goal: overrides.goal ?? doc.task.goal,


### PR DESCRIPTION
## Summary
- prevent project-changing forks from carrying a stale caller/parent `worldId` into the target project
- let the existing project binding path derive `projectWorldId(agentId, targetProject)` for changed-project forks
- add real `OrchestratorTaskService` coverage for project A -> project B fork isolation and spawn workdir routing

## Verification
- `node packages/app-core/scripts/ensure-shared-i18n-data.mjs`
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts --write --no-errors-on-unmatched`
- `bun test plugins/plugin-agent-orchestrator/src/__tests__/task-workdir-binding.test.ts` (13 pass, 0 fail, 57 assertions; reviewed summary in `.github/issue-evidence/14222-project-world-fork-isolation.txt`)

Follow-up to #14222: a fork could accept target project B while retaining project A's memory world.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - orchestrator service logic fix with no UI surface.`

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - orchestrator service logic fix with no UI surface.`

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - orchestrator service logic fix with no UI flow.`

<!-- evidence-row:backend-logs -->
- [ ] Backend/test logs: `.github/issue-evidence/14222-project-world-fork-isolation.txt`

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change or browser-exercised flow.`

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - deterministic task binding/isolation fix; no model prompt, action planning, or live model behavior changed.`

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: `.github/issue-evidence/14222-project-world-fork-isolation.txt`