### PR TITLE
fix(sql): guard production message search DDL

### DIFF
--- a/.github/issue-evidence/14230-message-search-runtime-fallback.md
+++ b/.github/issue-evidence/14230-message-search-runtime-fallback.md
@@ -1,0 +1,32 @@
+# PR #14230 - message search runtime fallback
+
+## Scope
+
+Added a real regression in `plugins/plugin-sql/src/__tests__/migration/message-search-production-guard.real.test.ts` for production Postgres startup with message-search DDL skipped. The test migrates with `NODE_ENV=production`, `ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS` unset, and `databaseBackend: "postgres"`, verifies `memories.message_search_document` is absent, seeds real message rows through the SQL adapter, then calls the real `adapter.searchMessages()` path.
+
+## Runtime evidence
+
+- Text recall query: `alpha-sentinel` returned the seeded message text `runtime fallback recalls alpha-sentinel text`.
+- Attachment recall query: `incident-runbook-14230` returned the seeded message carrying `incident-runbook-14230.pdf`.
+- Both result sets reported `ftsRank === 0` and `trigramSimilarity === 0`, matching the sequential fallback path.
+- Logs showed `[MessageSearch] search objects are missing; falling back to sequential message search` for both runtime searches.
+
+## Commands
+
+```bash
+bun run --cwd plugins/plugin-sql/src test:real:files __tests__/migration/message-search-production-guard.real.test.ts
+```
+
+Result: passed. Vitest reported `1 passed` file and `4 passed` tests.
+
+```bash
+bun run --cwd plugins/plugin-sql lint:check
+```
+
+Result: passed with exit code 0. Biome reported the existing `plugins/plugin-sql/src/biome.json` ignore-folder warnings only; no touched-file errors remained.
+
+## Incomplete evidence
+
+- Full repo `bun run verify` was not run; this was scoped to the requested plugin-sql regression and Biome check.
+- No UI screenshots/video or live-LLM trajectories were produced; this change is a storage adapter regression test with no UI or model behavior.
+- No live external Postgres run was performed; the regression uses the existing real PGlite migration harness while forcing the migration service's Postgres production guard branch.

--- a/plugins/plugin-sql/AGENTS.md
+++ b/plugins/plugin-sql/AGENTS.md
@@ -92,6 +92,7 @@ bun run --cwd plugins/plugin-sql test:e2e       # live smoke test (needs running
 | `ENABLE_DATA_ISOLATION` | No | `false` | When `true`, enables PostgreSQL Row Level Security per-server isolation. |
 | `ELIZA_SERVER_ID` | Conditional | — | Required when `ENABLE_DATA_ISOLATION=true`; becomes the RLS server UUID. |
 | `ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS` | No | `false` | Allow column drops and other destructive schema changes at startup. |
+| `ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS` | No | auto | Controls automatic install of the `message_search_document` generated column and message-search GIN indexes. Production Postgres adapters skip this DDL by default; set `true` after scheduling the generated-column/index migration. |
 | `ELIZA_ELECTRIC_SYNC_URL` | No | — | URL for the Electric sync service; enables PGlite cloud sync read path. |
 | `ELIZA_CLOUD_WRITE_BASE_URL` | No | — | Base URL of the cloud API for WriteBackService (e.g. `https://api.elizacloud.ai`). If unset, write-back is a no-op. |
 | `ELIZA_CLOUD_SERVICE_KEY` | No | — | `X-Service-Key` header value sent by WriteBackService to the cloud API. |

--- a/plugins/plugin-sql/CLAUDE.md
+++ b/plugins/plugin-sql/CLAUDE.md
@@ -92,6 +92,7 @@ bun run --cwd plugins/plugin-sql test:e2e       # live smoke test (needs running
 | `ENABLE_DATA_ISOLATION` | No | `false` | When `true`, enables PostgreSQL Row Level Security per-server isolation. |
 | `ELIZA_SERVER_ID` | Conditional | — | Required when `ENABLE_DATA_ISOLATION=true`; becomes the RLS server UUID. |
 | `ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS` | No | `false` | Allow column drops and other destructive schema changes at startup. |
+| `ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS` | No | auto | Controls automatic install of the `message_search_document` generated column and message-search GIN indexes. Production Postgres adapters skip this DDL by default; set `true` after scheduling the generated-column/index migration. |
 | `ELIZA_ELECTRIC_SYNC_URL` | No | — | URL for the Electric sync service; enables PGlite cloud sync read path. |
 | `ELIZA_CLOUD_WRITE_BASE_URL` | No | — | Base URL of the cloud API for WriteBackService (e.g. `https://api.elizacloud.ai`). If unset, write-back is a no-op. |
 | `ELIZA_CLOUD_SERVICE_KEY` | No | — | `X-Service-Key` header value sent by WriteBackService to the cloud API. |

--- a/plugins/plugin-sql/README.md
+++ b/plugins/plugin-sql/README.md
@@ -70,6 +70,7 @@ The Caddyfile at `plugins/plugin-sql/caddy/electric-proxy.Caddyfile` forwards ev
 | `ENABLE_DATA_ISOLATION` | No | `false` | When `true`, enables PostgreSQL Row Level Security per-server isolation. |
 | `ELIZA_SERVER_ID` | Conditional | — | Required when `ENABLE_DATA_ISOLATION=true`; becomes the RLS server UUID. |
 | `ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS` | No | `false` | Allow column drops and other destructive schema changes at startup. |
+| `ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS` | No | auto | Controls automatic install of the `message_search_document` generated column and message-search GIN indexes. Production Postgres adapters skip this DDL by default; set `true` after scheduling the generated-column/index migration. |
 | `NODE_ENV` | No | `development` | `production` disables verbose migration logging and tightens safety checks. |
 
 Settings are read via `runtime.getSetting(key)` inside `plugin.init`.
@@ -103,6 +104,8 @@ export const plugin = {
 ```
 
 Destructive changes (column drops, type changes) are blocked by default. Set `ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS=true` to allow them.
+
+Message-search DDL is also guarded on production Postgres. The generated column and GIN indexes are still installed automatically for development/test and embedded PGlite. For production Postgres, schedule the table rewrite/index creation and run with `ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS=true` once the deployment window is approved.
 
 ## Connection Management
 

--- a/plugins/plugin-sql/src/__tests__/migration/message-search-production-guard.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/message-search-production-guard.real.test.ts
@@ -5,12 +5,24 @@
  */
 import { PGlite } from "@electric-sql/pglite";
 import { vector } from "@electric-sql/pglite/vector";
+import {
+  type Agent,
+  ChannelType,
+  type Entity,
+  type Memory,
+  type Room,
+  type UUID,
+  type World,
+} from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
+import { v4 } from "uuid";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { plugin as sqlPlugin } from "../../index";
 import { DatabaseMigrationService } from "../../migration-service";
 import type { DrizzleDatabase } from "../../types";
+import { mockCharacter } from "../schema-data";
+import { createIsolatedTestDatabaseForMigration } from "../test-helpers";
 
 describe("message-search production DDL guard", () => {
   let pgClient: PGlite;
@@ -41,15 +53,15 @@ describe("message-search production DDL guard", () => {
     await pgClient.close();
   });
 
-  const runSqlPluginMigration = async (databaseBackend: "postgres" | "pglite") => {
+  const runSqlPluginMigration = async (databaseBackend: "postgres" | "pglite", targetDb = db) => {
     const migrationService = new DatabaseMigrationService({ databaseBackend });
-    await migrationService.initializeWithDatabase(db);
+    await migrationService.initializeWithDatabase(targetDb);
     migrationService.discoverAndRegisterPluginSchemas([sqlPlugin]);
     await migrationService.runAllPluginMigrations();
   };
 
-  const messageSearchColumnExists = async (): Promise<boolean> => {
-    const result = await db.execute(sql`
+  const messageSearchColumnExists = async (targetDb = db): Promise<boolean> => {
+    const result = await targetDb.execute(sql`
       SELECT column_name
       FROM information_schema.columns
       WHERE table_name = 'memories'
@@ -83,5 +95,105 @@ describe("message-search production DDL guard", () => {
     await runSqlPluginMigration("pglite");
 
     expect(await messageSearchColumnExists()).toBe(true);
+  });
+
+  it("falls back at runtime when production Postgres startup skipped message-search DDL", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS;
+
+    const setup = await createIsolatedTestDatabaseForMigration("message_search_runtime_fallback");
+    try {
+      await runSqlPluginMigration("postgres", setup.db);
+      expect(await messageSearchColumnExists(setup.db)).toBe(false);
+
+      const { adapter, testAgentId } = setup;
+      const now = Date.now();
+      expect(
+        await adapter.createAgent({
+          ...mockCharacter,
+          id: testAgentId,
+          createdAt: now,
+          updatedAt: now,
+        } as Agent)
+      ).toBe(true);
+
+      const worldId = v4() as UUID;
+      const entityId = v4() as UUID;
+      const roomId = v4() as UUID;
+      await adapter.createWorld({
+        id: worldId,
+        agentId: testAgentId,
+        name: "Runtime fallback world",
+        serverId: v4(),
+      } as World);
+      await adapter.createEntities([
+        { id: entityId, agentId: testAgentId, names: ["Runtime User"] } as Entity,
+      ]);
+      await adapter.createRooms([
+        {
+          id: roomId,
+          agentId: testAgentId,
+          worldId,
+          name: "Runtime fallback room",
+          source: "test",
+          type: ChannelType.DM,
+        } as Room,
+      ]);
+      await adapter.addParticipant(entityId, roomId);
+
+      const seedMessage = async (
+        text: string,
+        createdAt: number,
+        attachments?: Array<{ title: string; url: string }>
+      ) => {
+        await adapter.createMemory(
+          {
+            id: v4() as UUID,
+            entityId,
+            agentId: testAgentId,
+            roomId,
+            worldId,
+            content: attachments ? { text, attachments } : { text },
+            metadata: { type: "messages" },
+            createdAt,
+          } as Memory,
+          "messages"
+        );
+      };
+
+      await seedMessage("runtime fallback recalls alpha-sentinel text", now);
+      await seedMessage("attachment carrier for production fallback", now + 1_000, [
+        {
+          title: "incident-runbook-14230.pdf",
+          url: "https://cdn.example.test/incident-runbook-14230.pdf",
+        },
+      ]);
+
+      const textHits = await adapter.searchMessages({
+        roomIds: [roomId],
+        query: "alpha-sentinel",
+        tableName: "messages",
+        limit: 10,
+      });
+      expect(textHits.map((hit) => (hit.memory.content as { text?: string }).text)).toContain(
+        "runtime fallback recalls alpha-sentinel text"
+      );
+      expect(textHits.every((hit) => hit.ftsRank === 0 && hit.trigramSimilarity === 0)).toBe(true);
+
+      const attachmentHits = await adapter.searchMessages({
+        roomIds: [roomId],
+        query: "incident-runbook-14230",
+        tableName: "messages",
+        limit: 10,
+      });
+      expect(attachmentHits.map((hit) => (hit.memory.content as { text?: string }).text)).toContain(
+        "attachment carrier for production fallback"
+      );
+      expect(attachmentHits.every((hit) => hit.ftsRank === 0 && hit.trigramSimilarity === 0)).toBe(
+        true
+      );
+    } finally {
+      await setup.cleanup();
+    }
   });
 });

--- a/plugins/plugin-sql/src/__tests__/migration/message-search-production-guard.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/message-search-production-guard.real.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Real-PGlite migration tests for the production guard around message-search
+ * DDL. The guard is environment-driven because the migration service only sees
+ * a Drizzle handle, not the adapter/manager that selected Postgres vs PGlite.
+ */
+import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite/vector";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { plugin as sqlPlugin } from "../../index";
+import { DatabaseMigrationService } from "../../migration-service";
+import type { DrizzleDatabase } from "../../types";
+
+describe("message-search production DDL guard", () => {
+  let pgClient: PGlite;
+  let db: DrizzleDatabase;
+  let originalNodeEnv: string | undefined;
+  let originalApplyMessageSearchObjects: string | undefined;
+
+  beforeEach(async () => {
+    originalNodeEnv = process.env.NODE_ENV;
+    originalApplyMessageSearchObjects = process.env.ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS;
+
+    pgClient = new PGlite({ extensions: { vector } });
+    db = drizzle(pgClient);
+  });
+
+  afterEach(async () => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+    if (originalApplyMessageSearchObjects === undefined) {
+      delete process.env.ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS;
+    } else {
+      process.env.ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS = originalApplyMessageSearchObjects;
+    }
+
+    await pgClient.close();
+  });
+
+  const runSqlPluginMigration = async (databaseBackend: "postgres" | "pglite") => {
+    const migrationService = new DatabaseMigrationService({ databaseBackend });
+    await migrationService.initializeWithDatabase(db);
+    migrationService.discoverAndRegisterPluginSchemas([sqlPlugin]);
+    await migrationService.runAllPluginMigrations();
+  };
+
+  const messageSearchColumnExists = async (): Promise<boolean> => {
+    const result = await db.execute(sql`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_name = 'memories'
+        AND column_name = 'message_search_document'
+    `);
+    return result.rows.length > 0;
+  };
+
+  it("skips generated-column/index DDL by default for production Postgres startup", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS;
+
+    await runSqlPluginMigration("postgres");
+
+    expect(await messageSearchColumnExists()).toBe(false);
+  });
+
+  it("applies generated-column/index DDL in production Postgres only when explicitly enabled", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS = "true";
+
+    await runSqlPluginMigration("postgres");
+
+    expect(await messageSearchColumnExists()).toBe(true);
+  });
+
+  it("keeps automatic install enabled for embedded PGlite production builds", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS;
+
+    await runSqlPluginMigration("pglite");
+
+    expect(await messageSearchColumnExists()).toBe(true);
+  });
+});

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -172,6 +172,28 @@ function escapeIlikeLiteral(value: string): string {
   return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
 }
 
+function isMessageSearchObjectsMissing(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const layer = current as {
+      code?: unknown;
+      message?: unknown;
+      cause?: unknown;
+    };
+    const message = typeof layer.message === "string" ? layer.message : "";
+    if (
+      (layer.code === "42703" || layer.code === "42883" || /does not exist/i.test(message)) &&
+      /message_search_document|eliza_search_fold|eliza_search_like_pattern/i.test(message)
+    ) {
+      return true;
+    }
+    current = layer.cause;
+  }
+  return false;
+}
+
 type CountMemoriesParams = {
   roomIds?: UUID[];
   unique?: boolean;
@@ -225,7 +247,7 @@ function isDuplicateKeyError(error: unknown): boolean {
   return false;
 }
 
-import type { DatabaseMigrationService } from "./migration-service";
+import type { DatabaseBackend, DatabaseMigrationService } from "./migration-service";
 import { DIMENSION_MAP, type EmbeddingDimensionColumn } from "./schema/embedding";
 import {
   agentTable,
@@ -313,6 +335,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   protected readonly maxDelay: number = 10000;
   protected readonly jitterMax: number = 1000;
   protected embeddingDimension: EmbeddingDimensionColumn = DIMENSION_MAP[384];
+  protected readonly databaseBackend: DatabaseBackend = "unknown";
   protected migrationService?: DatabaseMigrationService;
   private migrationRunPromise: Promise<void> | null = null;
   private _connectorAccountStore?: ConnectorAccountStore;
@@ -359,7 +382,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   ): Promise<void> {
     if (!this.migrationService) {
       const { DatabaseMigrationService } = await import("./migration-service");
-      this.migrationService = new DatabaseMigrationService();
+      this.migrationService = new DatabaseMigrationService({
+        databaseBackend: this.databaseBackend,
+      });
       await this.migrationService.initializeWithDatabase(this.db as DrizzleDatabase);
     }
 
@@ -1739,30 +1764,88 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         sql`(${tsvector} @@ ${tsquery} OR ${document} LIKE eliza_search_like_pattern(${params.query}) OR ${trigramMatch})`,
       ];
 
-      const rows = await this.db
-        .select({
-          id: memoryTable.id,
-          createdAt: memoryTable.createdAt,
-          content: memoryTable.content,
-          entityId: memoryTable.entityId,
-          agentId: memoryTable.agentId,
-          roomId: memoryTable.roomId,
-          worldId: memoryTable.worldId,
-          unique: memoryTable.unique,
-          metadata: memoryTable.metadata,
-          ftsRank: ftsRankExpr.as("fts_rank"),
-          trigramSimilarity: trigramExpr.as("trgm_sim"),
-        })
-        .from(memoryTable)
-        .where(and(...conditions))
-        .orderBy(
-          sql`fts_rank DESC`,
-          sql`trgm_sim DESC`,
-          desc(memoryTable.createdAt),
-          asc(memoryTable.id)
-        )
-        .limit(limit)
-        .offset(offset);
+      let rows: Array<{
+        id: string;
+        createdAt: Date;
+        content: unknown;
+        entityId: string;
+        agentId: string;
+        roomId: string;
+        worldId: string | null;
+        unique: boolean;
+        metadata: unknown;
+        ftsRank: unknown;
+        trigramSimilarity: unknown;
+      }>;
+      try {
+        rows = await this.db
+          .select({
+            id: memoryTable.id,
+            createdAt: memoryTable.createdAt,
+            content: memoryTable.content,
+            entityId: memoryTable.entityId,
+            agentId: memoryTable.agentId,
+            roomId: memoryTable.roomId,
+            worldId: memoryTable.worldId,
+            unique: memoryTable.unique,
+            metadata: memoryTable.metadata,
+            ftsRank: ftsRankExpr.as("fts_rank"),
+            trigramSimilarity: trigramExpr.as("trgm_sim"),
+          })
+          .from(memoryTable)
+          .where(and(...conditions))
+          .orderBy(
+            sql`fts_rank DESC`,
+            sql`trgm_sim DESC`,
+            desc(memoryTable.createdAt),
+            asc(memoryTable.id)
+          )
+          .limit(limit)
+          .offset(offset);
+      } catch (error) {
+        if (!isMessageSearchObjectsMissing(error)) {
+          throw error;
+        }
+        // error-policy:J4 production Postgres can deliberately skip the heavy
+        // generated-column/index DDL at startup; until an operator applies it,
+        // keep search functional with the older sequential text/attachment scan.
+        logger.warn(
+          {
+            src: "plugin:sql",
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "[MessageSearch] search objects are missing; falling back to sequential message search"
+        );
+        rows = await this.db
+          .select({
+            id: memoryTable.id,
+            createdAt: memoryTable.createdAt,
+            content: memoryTable.content,
+            entityId: memoryTable.entityId,
+            agentId: memoryTable.agentId,
+            roomId: memoryTable.roomId,
+            worldId: memoryTable.worldId,
+            unique: memoryTable.unique,
+            metadata: memoryTable.metadata,
+            ftsRank: sql<number>`0`.as("fts_rank"),
+            trigramSimilarity: sql<number>`0`.as("trgm_sim"),
+          })
+          .from(memoryTable)
+          .where(
+            and(
+              eq(memoryTable.type, tableName),
+              eq(memoryTable.agentId, this.agentId),
+              inArray(memoryTable.roomId, params.roomIds),
+              or(
+                sql`(${memoryTable.content}->>'text') ILIKE ${`%${escapeIlikeLiteral(params.query)}%`} ESCAPE '\\'`,
+                sql`${memoryTable.content}::text ILIKE ${`%${escapeIlikeLiteral(params.query)}%`} ESCAPE '\\'`
+              )
+            )
+          )
+          .orderBy(desc(memoryTable.createdAt), asc(memoryTable.id))
+          .limit(limit)
+          .offset(offset);
+      }
 
       return rows.map((row) => ({
         memory: {

--- a/plugins/plugin-sql/src/migration-service.ts
+++ b/plugins/plugin-sql/src/migration-service.ts
@@ -13,10 +13,35 @@ import { applyEntityRLSToAllTables, applyRLSToNewTables, installRLSFunctions } f
 import { RuntimeMigrator } from "./runtime-migrator";
 import type { DrizzleDatabase } from "./types";
 
+const MESSAGE_SEARCH_OBJECTS_ENV = "ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS";
+
+export type DatabaseBackend = "postgres" | "pglite" | "unknown";
+
+interface DatabaseMigrationServiceOptions {
+  databaseBackend?: DatabaseBackend;
+}
+
+function shouldApplyMessageSearchObjects(databaseBackend: DatabaseBackend): boolean {
+  const setting = process.env[MESSAGE_SEARCH_OBJECTS_ENV]?.toLowerCase();
+  if (setting === "false" || setting === "0") {
+    return false;
+  }
+  if (setting === "true" || setting === "1") {
+    return true;
+  }
+
+  return !(process.env.NODE_ENV === "production" && databaseBackend === "postgres");
+}
+
 export class DatabaseMigrationService {
   private db: DrizzleDatabase | null = null;
   private registeredSchemas = new Map<string, Record<string, unknown>>();
   private migrator: RuntimeMigrator | null = null;
+  private readonly databaseBackend: DatabaseBackend;
+
+  constructor(options: DatabaseMigrationServiceOptions = {}) {
+    this.databaseBackend = options.databaseBackend ?? "unknown";
+  }
 
   async initializeWithDatabase(db: DrizzleDatabase): Promise<void> {
     this.db = db;
@@ -116,7 +141,18 @@ export class DatabaseMigrationService {
       // Install the message full-text/trigram search objects on the migrated
       // `memories` table (#13534). Idempotent; runs after the table exists so the
       // GIN expression indexes can be created.
-      await applyMessageSearchObjects(this.db);
+      if (shouldApplyMessageSearchObjects(this.databaseBackend)) {
+        await applyMessageSearchObjects(this.db);
+      } else {
+        logger.warn(
+          {
+            src: "plugin:sql",
+            env: MESSAGE_SEARCH_OBJECTS_ENV,
+            databaseBackend: this.databaseBackend,
+          },
+          "[MessageSearch] skipping automatic search-object install in production Postgres; set ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS=true after scheduling the generated-column/index DDL"
+        );
+      }
 
       const dataIsolationEnabled = process.env.ENABLE_DATA_ISOLATION === "true";
 

--- a/plugins/plugin-sql/src/neon/adapter.ts
+++ b/plugins/plugin-sql/src/neon/adapter.ts
@@ -30,6 +30,7 @@ import type { NeonConnectionManager } from "./manager";
  */
 export class NeonDatabaseAdapter extends BaseDrizzleAdapter {
   protected embeddingDimension: EmbeddingDimensionColumn = DIMENSION_MAP[384];
+  protected readonly databaseBackend = "postgres";
   private manager: NeonConnectionManager;
 
   constructor(agentId: UUID, manager: NeonConnectionManager, _schema?: Record<string, unknown>) {

--- a/plugins/plugin-sql/src/pg/adapter.ts
+++ b/plugins/plugin-sql/src/pg/adapter.ts
@@ -25,6 +25,7 @@ import type { PostgresConnectionManager } from "./manager";
 
 export class PgDatabaseAdapter extends BaseDrizzleAdapter {
   protected embeddingDimension: EmbeddingDimensionColumn = DIMENSION_MAP[384];
+  protected readonly databaseBackend = "postgres";
   private manager: PostgresConnectionManager;
 
   constructor(

--- a/plugins/plugin-sql/src/pglite/adapter.ts
+++ b/plugins/plugin-sql/src/pglite/adapter.ts
@@ -27,6 +27,7 @@ import type { PGliteClientManager } from "./manager";
 export class PgliteDatabaseAdapter extends BaseDrizzleAdapter {
   private manager: PGliteClientManager;
   protected embeddingDimension: EmbeddingDimensionColumn = DIMENSION_MAP[384];
+  protected readonly databaseBackend = "pglite";
 
   constructor(agentId: UUID, manager: PGliteClientManager) {
     super(agentId);


### PR DESCRIPTION
## Summary
- Guard automatic message-search generated-column/GIN-index DDL in production Postgres unless `ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS=true` is set.
- Keep search functional before that DDL is applied by falling back to the previous sequential text/attachment scan when search objects are missing.
- Document the operator opt-in and add real-PGlite migration coverage for skip, opt-in, and embedded PGlite behavior.

## Evidence
- `bun run --cwd plugins/plugin-sql/src format:check -- base.ts migration-service.ts __tests__/migration/message-search-production-guard.real.test.ts`
- `bun run --cwd plugins/plugin-sql/src lint:check -- base.ts migration-service.ts __tests__/migration/message-search-production-guard.real.test.ts` (passes; existing `biome.json` schema/ignore-pattern warnings only)

## Not run
- `bun run --cwd plugins/plugin-sql/src test:real:files -- __tests__/migration/message-search-production-guard.real.test.ts` — local temp worktree could not resolve `vitest/config` without a full workspace install; `bun run install:light` hit local `ENOSPC`. PR is draft pending remote CI / a clean installed workspace run.

Fix-forward for #13534 / #13880 residual production-startup DDL risk.