### PR TITLE
ci: add real failure triage helper (#14051)

### DIFF
--- a/.github/issue-evidence/14051-ci-real-failures-helper.md
+++ b/.github/issue-evidence/14051-ci-real-failures-helper.md
@@ -1,0 +1,42 @@
+# #14051 CI real-failures helper
+
+## Scope
+
+Tier D helper for #14051: filter noisy cancelled/superseded check-run piles so
+CI shepherds can see real completed failures.
+
+## Change
+
+- Added `packages/scripts/ci-real-failures.mjs`.
+- Added `packages/scripts/ci-real-failures.self-test.mjs`.
+- The helper supports:
+  - `--repo owner/repo --pr <number>`: resolve the PR head SHA and inspect check
+    runs through `gh api`.
+  - `--repo owner/repo --sha <sha>`: inspect check runs for an exact commit.
+  - `--input <json>`: deterministic offline input for tests and saved API
+    payloads.
+  - `--json`: machine-readable output.
+- Filtering keeps only `status=completed` and `conclusion=failure`, excluding
+  cancelled/canceled and explicit `superseded` runs.
+
+## Verification
+
+- `node packages/scripts/ci-real-failures.self-test.mjs`
+  - Result: pass, `ci-real-failures self-test passed`
+- `node --check packages/scripts/ci-real-failures.mjs && node --check packages/scripts/ci-real-failures.self-test.mjs`
+  - Result: pass
+- `git diff --check`
+  - Result: pass
+- `bunx @biomejs/biome check packages/scripts/ci-real-failures.mjs packages/scripts/ci-real-failures.self-test.mjs .github/issue-evidence/14051-ci-real-failures-helper.md --no-errors-on-unmatched`
+  - Result: pass, `Checked 2 files`
+- Offline canary input with one cancelled check and one real failure:
+  - Command exited 1 and returned only the real failure in JSON.
+- Live PR smoke:
+  - `node packages/scripts/ci-real-failures.mjs --repo elizaOS/eliza --pr 14212 --json`
+  - Result: `{"failures":[]}` and exit 0 because the live PR currently has no
+    completed real failures.
+
+## N/A
+
+- This is a read-only CI triage helper. It does not change product UI, backend
+  runtime behavior, models, prompts, or device lanes.

--- a/packages/scripts/ci-real-failures.mjs
+++ b/packages/scripts/ci-real-failures.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+/**
+ * List completed, real GitHub Actions check failures while ignoring noisy
+ * cancelled/superseded runs from re-pushes and ready-for-review transitions.
+ *
+ * Examples:
+ *   node packages/scripts/ci-real-failures.mjs --repo elizaOS/eliza --pr 14051
+ *   node packages/scripts/ci-real-failures.mjs --repo elizaOS/eliza --sha <sha> --json
+ *   node packages/scripts/ci-real-failures.mjs --input check-runs.json
+ */
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+function usage() {
+  return [
+    "Usage: ci-real-failures.mjs (--repo owner/repo (--pr N|--sha SHA) | --input file) [--json]",
+    "",
+    "Filters to completed check-runs with conclusion=failure and excludes",
+    "cancelled/skipped/superseded noise.",
+  ].join("\n");
+}
+
+export function parseArgs(argv) {
+  const args = { json: false, input: null, repo: null, pr: null, sha: null };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") args.json = true;
+    else if (arg === "--input") args.input = argv[++i];
+    else if (arg === "--repo") args.repo = argv[++i];
+    else if (arg === "--pr") args.pr = argv[++i];
+    else if (arg === "--sha") args.sha = argv[++i];
+    else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  if (args.help) return args;
+  if (args.input) return args;
+  if (!args.repo) throw new Error("--repo is required unless --input is used");
+  if (!args.pr && !args.sha) {
+    throw new Error("one of --pr or --sha is required unless --input is used");
+  }
+  if (args.pr && args.sha)
+    throw new Error("--pr and --sha are mutually exclusive");
+  return args;
+}
+
+export function normalizeConclusion(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+export function isSupersededCheckRun(run) {
+  if (run?.superseded === true) return true;
+  if (run?.isSuperseded === true) return true;
+  const conclusion = normalizeConclusion(run?.conclusion);
+  return conclusion === "cancelled" || conclusion === "canceled";
+}
+
+export function isRealCompletedFailure(run) {
+  return (
+    String(run?.status ?? "").toLowerCase() === "completed" &&
+    normalizeConclusion(run?.conclusion) === "failure" &&
+    !isSupersededCheckRun(run)
+  );
+}
+
+export function selectRealFailures(runs) {
+  return runs.filter(isRealCompletedFailure).map((run) => ({
+    name: run.name ?? "(unnamed)",
+    workflowName: run.workflow_name ?? run.workflowName ?? run.workflow ?? null,
+    status: run.status ?? null,
+    conclusion: run.conclusion ?? null,
+    htmlUrl: run.html_url ?? run.htmlUrl ?? run.details_url ?? null,
+    startedAt: run.started_at ?? run.startedAt ?? null,
+    completedAt: run.completed_at ?? run.completedAt ?? null,
+  }));
+}
+
+function runGhJson(args) {
+  const result = spawnSync("gh", ["api", ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `gh api exited ${result.status}`);
+  }
+  return JSON.parse(result.stdout);
+}
+
+function resolvePrHeadSha(repo, pr) {
+  const data = runGhJson([`repos/${repo}/pulls/${pr}`]);
+  const sha = data?.head?.sha;
+  if (!sha) throw new Error(`could not resolve head sha for PR ${pr}`);
+  return sha;
+}
+
+function fetchCheckRuns(repo, sha) {
+  const out = [];
+  for (let page = 1; ; page++) {
+    const data = runGhJson([
+      "--method",
+      "GET",
+      `repos/${repo}/commits/${sha}/check-runs`,
+      "-f",
+      "per_page=100",
+      "-f",
+      `page=${page}`,
+    ]);
+    const pageRuns = data?.check_runs ?? [];
+    out.push(...pageRuns);
+    if (pageRuns.length < 100) return out;
+  }
+}
+
+export function readRunsFromFile(path) {
+  const parsed = JSON.parse(readFileSync(path, "utf8"));
+  if (Array.isArray(parsed)) return parsed;
+  if (Array.isArray(parsed.check_runs)) return parsed.check_runs;
+  throw new Error(`input ${path} must be an array or {check_runs: [...]}`);
+}
+
+export function formatFailureTable(failures) {
+  if (!failures.length) return "No real completed check failures found.";
+  return failures
+    .map((failure) => {
+      const workflow = failure.workflowName ? ` [${failure.workflowName}]` : "";
+      const url = failure.htmlUrl ? `\n  ${failure.htmlUrl}` : "";
+      return `- ${failure.name}${workflow}${url}`;
+    })
+    .join("\n");
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+  const runs = args.input
+    ? readRunsFromFile(args.input)
+    : fetchCheckRuns(
+        args.repo,
+        args.sha ?? resolvePrHeadSha(args.repo, args.pr),
+      );
+  const failures = selectRealFailures(runs);
+  if (args.json) {
+    console.log(JSON.stringify({ failures }, null, 2));
+  } else {
+    console.log(formatFailureTable(failures));
+  }
+  process.exit(failures.length ? 1 : 0);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`[ci-real-failures] ${error.message}`);
+    console.error(usage());
+    process.exit(2);
+  }
+}

--- a/packages/scripts/ci-real-failures.self-test.mjs
+++ b/packages/scripts/ci-real-failures.self-test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  formatFailureTable,
+  isRealCompletedFailure,
+  isSupersededCheckRun,
+  parseArgs,
+  readRunsFromFile,
+  selectRealFailures,
+} from "./ci-real-failures.mjs";
+
+const run = (overrides) => ({
+  name: "check",
+  status: "completed",
+  conclusion: "success",
+  html_url: "https://example.test/run",
+  workflow_name: "workflow",
+  ...overrides,
+});
+
+assert.equal(isRealCompletedFailure(run({ conclusion: "failure" })), true);
+assert.equal(isRealCompletedFailure(run({ conclusion: "success" })), false);
+assert.equal(isRealCompletedFailure(run({ conclusion: "skipped" })), false);
+assert.equal(isRealCompletedFailure(run({ conclusion: "cancelled" })), false);
+assert.equal(
+  isRealCompletedFailure(run({ status: "queued", conclusion: null })),
+  false,
+);
+assert.equal(
+  isRealCompletedFailure(run({ conclusion: "failure", superseded: true })),
+  false,
+);
+assert.equal(isSupersededCheckRun(run({ conclusion: "cancelled" })), true);
+assert.equal(isSupersededCheckRun(run({ conclusion: "failure" })), false);
+
+const selected = selectRealFailures([
+  run({ name: "lint", conclusion: "failure" }),
+  run({ name: "old lint", conclusion: "cancelled" }),
+  run({ name: "build", conclusion: "success" }),
+  run({ name: "superseded failure", conclusion: "failure", superseded: true }),
+]);
+assert.deepEqual(
+  selected.map((entry) => entry.name),
+  ["lint"],
+);
+assert.match(formatFailureTable(selected), /lint \[workflow\]/);
+assert.match(formatFailureTable([]), /No real completed check failures/);
+
+assert.deepEqual(parseArgs(["--repo", "elizaOS/eliza", "--pr", "14051"]), {
+  json: false,
+  input: null,
+  repo: "elizaOS/eliza",
+  pr: "14051",
+  sha: null,
+});
+assert.throws(
+  () => parseArgs(["--repo", "elizaOS/eliza"]),
+  /one of --pr or --sha/,
+);
+assert.throws(
+  () => parseArgs(["--repo", "elizaOS/eliza", "--pr", "1", "--sha", "abc"]),
+  /mutually exclusive/,
+);
+
+const dir = mkdtempSync(join(tmpdir(), "ci-real-failures-"));
+try {
+  const input = join(dir, "runs.json");
+  writeFileSync(
+    input,
+    JSON.stringify({ check_runs: [run({ conclusion: "failure" })] }),
+  );
+  assert.equal(readRunsFromFile(input).length, 1);
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log("ci-real-failures self-test passed");


### PR DESCRIPTION
# Relates to

Refs #14051 Tier D.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and is based on latest `origin/develop` at branch creation.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Based on latest `origin/develop`; zero conflicts at branch creation.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. This is a read-only CI triage helper and self-test. It does not alter workflow behavior, required checks, or product runtime code.

# Background

## What does this PR do?

Adds `packages/scripts/ci-real-failures.mjs`, a shepherd helper for #14051 Tier D. It filters GitHub check-runs down to completed real failures while ignoring cancelled/canceled, skipped, queued, and explicit superseded noise. It supports live `gh api` lookup by PR or SHA plus offline `--input` JSON for saved payloads/tests.

## What kind of change is this?

CI tooling / observability.

# Documentation changes needed?

No product docs. Evidence is recorded at `.github/issue-evidence/14051-ci-real-failures-helper.md`.

# Testing

## Where should a reviewer start?

Start with `packages/scripts/ci-real-failures.mjs` and `packages/scripts/ci-real-failures.self-test.mjs`.

## Detailed testing steps

- `node packages/scripts/ci-real-failures.self-test.mjs` -> pass
- `node --check packages/scripts/ci-real-failures.mjs && node --check packages/scripts/ci-real-failures.self-test.mjs` -> pass
- `git diff --check` -> pass
- `bunx @biomejs/biome check packages/scripts/ci-real-failures.mjs packages/scripts/ci-real-failures.self-test.mjs .github/issue-evidence/14051-ci-real-failures-helper.md --no-errors-on-unmatched` -> pass
- Offline canary input with one cancelled check and one real failure exits 1 and reports only the real failure.
- Live smoke: `node packages/scripts/ci-real-failures.mjs --repo elizaOS/eliza --pr 14212 --json` -> `{"failures":[]}`, exit 0.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - read-only CI helper; no UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - read-only CI helper; no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no user UI flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - helper reads GitHub check-run metadata; command output recorded in evidence`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or marked `N/A - no frontend runtime change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/action/provider/prompt/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - evidence note added at .github/issue-evidence/14051-ci-real-failures-helper.md`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

N/A - this is a local/GitHub Actions metadata helper, not app backend/frontend runtime. See evidence note for command outputs.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no audio/voice behavior changed.

## Known gaps / failures

- Full `bun install` / `bun run verify` were not run in this sparse low-disk worktree. The previous full-worktree install attempt in this session filled the host volume while expanding large research evidence files. This PR is limited to a no-dependency Node script and self-test.
- CI should run the helper in the full checkout and confirm repository-level gates.