### PR TITLE
fix(browser-extension): annotate blocked URL sanitization

### DIFF
--- a/packages/browser-extension/src/url.ts
+++ b/packages/browser-extension/src/url.ts
@@ -80,6 +80,7 @@ export function normalizeNavigableUrl(
     }
     return parsed.toString();
   } catch {
+    // error-policy:J3 untrusted query-string input resolves to an explicit invalid navigation target.
     return null;
   }
 }


### PR DESCRIPTION
Follow-up to #14227. The merged security fix correctly treats malformed blocked-page `?url=` input as invalid, but its parser `catch` needs the repo-required `error-policy:J3` annotation for untrusted-input sanitizing.

Validation:
- `bun run --cwd packages/browser-extension test:unit -- src/url.test.ts` (9 pass)
- `git diff --check origin/develop...HEAD`