### PR TITLE
fix(ui): retokenize applications popovers

### DIFF
--- a/packages/ui/src/cloud/applications/components/app-analytics.tsx
+++ b/packages/ui/src/cloud/applications/components/app-analytics.tsx
@@ -404,7 +404,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
               <SelectTrigger className="w-[130px] h-9 bg-card border-border rounded-sm">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent className="bg-neutral-800 border-border rounded-sm">
+              <SelectContent className="bg-popover border-border rounded-sm">
                 <SelectItem value="hourly">Hourly</SelectItem>
                 <SelectItem value="daily">Daily</SelectItem>
                 <SelectItem value="monthly">Monthly</SelectItem>

--- a/packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx
+++ b/packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx
@@ -220,7 +220,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
           <SelectTrigger className="w-[140px] h-9 bg-card border-border rounded-sm">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent className="bg-neutral-800 border-border rounded-sm">
+          <SelectContent className="bg-popover border-border rounded-sm">
             <SelectItem value="7">Last 7 days</SelectItem>
             <SelectItem value="30">Last 30 days</SelectItem>
             <SelectItem value="90">Last 90 days</SelectItem>

--- a/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
+++ b/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
@@ -459,7 +459,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                     </TooltipTrigger>
                     <TooltipContent
                       side="right"
-                      className="max-w-[200px] bg-neutral-800 border-border text-txt"
+                      className="max-w-[200px] bg-popover border-border text-txt"
                     >
                       {t("cloud.monetization.inferenceMarkupTooltip", {
                         defaultValue:
@@ -521,7 +521,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                     </TooltipTrigger>
                     <TooltipContent
                       side="right"
-                      className="max-w-[200px] bg-neutral-800 border-border text-txt"
+                      className="max-w-[200px] bg-popover border-border text-txt"
                     >
                       {t("cloud.monetization.purchaseShareTooltip", {
                         defaultValue:

--- a/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
+++ b/packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts
@@ -53,6 +53,7 @@ const FORBIDDEN_TOKEN_PATTERNS: RegExp[] = [
   /\bborder-white\/[\w.[\]%]+/,
   /\bdivide-white\/[\w.[\]%]+/,
   /\bbg-black(?:\/[\w.[\]%]+)?/, // opaque / translucent black surfaces
+  /\bbg-neutral-800\b/,
   /\bbg-neutral-900\b/,
   /\bbg-\[rgba\(10,10,10/, // bespoke near-black panels
   /\bbg-\[rgba\(29,29,29/,


### PR DESCRIPTION
## Summary
- Replace the remaining Applications `bg-neutral-800` select/tooltip popovers with semantic `bg-popover` tokens.
- Extend the Cloud settings token regression guard to reject `bg-neutral-800` in the scanned Applications/MCP surfaces.

## Validation
- `bun test packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts` — 2 pass / 0 fail
- `rg -n "bg-neutral-800" packages/ui/src/cloud/applications/components packages/ui/src/cloud/mcps -g"*.tsx"` — no matches
- `bunx @biomejs/biome check packages/ui/src/cloud/applications/components/app-analytics.tsx packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx packages/ui/src/cloud/applications/components/app-monetization-settings.tsx packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts`
- `git diff --check -- packages/ui/src/cloud/applications/components/app-analytics.tsx packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx packages/ui/src/cloud/applications/components/app-monetization-settings.tsx packages/ui/src/cloud/settings/cloud-settings-theme-tokens.test.ts`
- `bun run audit:error-policy-ratchet`

## Required visual audit
Attempted `bun run --cwd packages/app audit:app`, but it failed before screenshot capture during view prebuild on unrelated unresolved dependencies:

- `plugins/plugin-messages`: failed to resolve `@elizaos/capacitor-messages`
- `plugins/plugin-phone`: failed to resolve `@elizaos/capacitor-phone`
- `plugins/plugin-task-coordinator`: failed to resolve `@xterm/addon-fit`

No `aesthetic-audit-output` was produced because the audit did not reach Playwright. This is the same pre-capture blocker noted on the parent contrast follow-up.

Refs #14232.