### PR TITLE
fix(orchestrator): protect native terminal git env

### DIFF
--- a/.github/issue-evidence/13773-native-terminal-git-env.md
+++ b/.github/issue-evidence/13773-native-terminal-git-env.md
@@ -1,0 +1,45 @@
+# #13773 Native Terminal Git Env Isolation
+
+Date: 2026-07-05
+Branch: `fix/13773-workspace-isolation`
+
+## What Changed
+
+- Native ACP `terminal/create` now preserves the session-owned `GIT_INDEX_FILE`
+  from the trusted session env and removes ACP-requested `GIT_INDEX_FILE`,
+  `GIT_DIR`, and `GIT_WORK_TREE` overrides.
+- `runGitForAcp()` now uses a bounded synchronous git probe that returns
+  `undefined` on git failure/unavailability instead of assuming a subprocess
+  object exists. This keeps same-repo git-index setup fail-closed and fixed the
+  current unit harness residual from the existing #13773 implementation.
+
+## Verification
+
+Passed:
+
+```bash
+bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/workspace-isolation.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-gc.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+# Test Files  4 passed (4)
+# Tests       92 passed (92)
+```
+
+```bash
+bunx biome check plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/workspace-isolation.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-gc.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+# Checked 6 files. No fixes applied.
+```
+
+```bash
+git diff --check
+# passed
+```
+
+Known unrelated blocker:
+
+```bash
+bun run --cwd plugins/plugin-agent-orchestrator typecheck
+# fails because @elizaos/contracts declarations are missing from core/shared imports
+```
+
+No UI, browser, mobile, live-model, or screenshot evidence applies; this is a
+subprocess environment isolation fix covered by unit-level process-env
+assertions.

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -661,6 +661,51 @@ describe("NativeAcpClient terminal actions", () => {
       },
     });
   });
+
+  it("protects the session git index from terminal env overrides", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "native-acp-"));
+    const agentProc = queueProc();
+    queueProc();
+    const client = new NativeAcpClient({
+      command: "agent-acp",
+      cwd,
+      approvalPreset: "autonomous",
+      env: {
+        PATH: process.env.PATH,
+        GIT_INDEX_FILE: "/tmp/eliza-acp/git-indexes/session-safe/index",
+      },
+    });
+    const started = client.start();
+    await waitForWrites(agentProc, 1);
+    emitJson(agentProc, { jsonrpc: "2.0", id: 1, result: {} });
+    await started;
+
+    emitJson(agentProc, {
+      jsonrpc: "2.0",
+      id: "terminal-protected-env",
+      method: "terminal/create",
+      params: {
+        command: "node",
+        args: ["-v"],
+        cwd,
+        env: [
+          { name: "GIT_INDEX_FILE", value: "/tmp/attacker-index" },
+          { name: "GIT_DIR", value: "/tmp/attacker-git-dir" },
+          { name: "GIT_WORK_TREE", value: "/tmp/attacker-work-tree" },
+        ],
+      },
+    });
+    await waitForSpawnCalls(2);
+
+    const env = spawnMock.mock.calls[1]?.[2]?.env as
+      | Record<string, string>
+      | undefined;
+    expect(env?.GIT_INDEX_FILE).toBe(
+      "/tmp/eliza-acp/git-indexes/session-safe/index",
+    );
+    expect(env).not.toHaveProperty("GIT_DIR");
+    expect(env).not.toHaveProperty("GIT_WORK_TREE");
+  });
 });
 
 describe("splitCommandLine", () => {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -484,12 +484,14 @@ export class NativeAcpClient {
       stringValue(params?.cwd) ?? this.opts.cwd,
     );
     const spawnCommand = terminalSpawnCommand(command, args);
+    const env = {
+      ...this.opts.env,
+      ...envArrayToRecord(params?.env),
+    };
+    protectTerminalGitEnv(env, this.opts.env);
     const proc = spawn(spawnCommand.command, spawnCommand.args, {
       cwd,
-      env: {
-        ...this.opts.env,
-        ...envArrayToRecord(params?.env),
-      },
+      env,
       stdio: ["pipe", "pipe", "pipe"],
       detached: process.platform !== "win32",
     });
@@ -758,6 +760,18 @@ function envArrayToRecord(value: unknown): Record<string, string> {
     env[name] = stringValue(record?.value) ?? "";
   }
   return env;
+}
+
+function protectTerminalGitEnv(
+  env: Record<string, string | undefined>,
+  trusted: NodeJS.ProcessEnv | undefined,
+): void {
+  for (const key of ["GIT_INDEX_FILE", "GIT_DIR", "GIT_WORK_TREE"]) {
+    delete env[key];
+  }
+  if (typeof trusted?.GIT_INDEX_FILE === "string") {
+    env.GIT_INDEX_FILE = trusted.GIT_INDEX_FILE;
+  }
 }
 
 function ensureInsideCwd(cwd: string, requested: string | undefined): string {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -14,7 +14,11 @@
  * SIGTERM/SIGINT handler fans out to every live instance so multi-tenant hosts,
  * test runners, and hot-reload cycles don't leak per-instance listeners.
  */
-import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import {
+  type ChildProcessWithoutNullStreams,
+  spawn,
+  spawnSync,
+} from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import {
@@ -209,28 +213,19 @@ async function runGitForAcp(
   workdir: string,
   args: string[],
 ): Promise<string | undefined> {
-  return new Promise((resolveRun) => {
-    const proc = spawn("git", ["-C", workdir, ...args], {
-      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    let stdout = "";
-    const timer = setTimeout(() => {
-      proc.kill("SIGTERM");
-      resolveRun(undefined);
-    }, 5_000);
-    proc.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString("utf8");
-    });
-    proc.on("error", () => {
-      clearTimeout(timer);
-      resolveRun(undefined);
-    });
-    proc.on("close", (code) => {
-      clearTimeout(timer);
-      resolveRun(code === 0 ? stdout.trim() : undefined);
-    });
+  const result = spawnSync("git", ["-C", workdir, ...args], {
+    env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+    timeout: 5_000,
+    maxBuffer: 1024 * 1024,
+    windowsHide: true,
   });
+  if (result.status !== 0) return undefined;
+  const stdout = result.stdout;
+  const text =
+    stdout instanceof Uint8Array
+      ? Buffer.from(stdout).toString("utf8")
+      : String(stdout ?? "");
+  return text.trim();
 }
 
 /**


### PR DESCRIPTION
## Summary
- protect native ACP terminal subprocesses from ACP-requested `GIT_INDEX_FILE`, `GIT_DIR`, and `GIT_WORK_TREE` overrides
- preserve the trusted session `GIT_INDEX_FILE` when terminal commands run inside a per-session git-index-isolated workspace
- make `runGitForAcp()` use a bounded synchronous git probe that degrades to `undefined` when git is unavailable, fixing the current test harness residual from the existing #13773 implementation

## Evidence
- `.github/issue-evidence/13773-native-terminal-git-env.md`

## Verification
- `bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/workspace-isolation.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-gc.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts` (4 files, 92 tests passed)
- `bunx biome check plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/workspace-isolation.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-scratch-gc.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts`
- `git diff --check`
- post-rebase quick check: `bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts`

## Known unrelated blocker
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` fails on current develop because `@elizaos/contracts` declarations are missing from core/shared imports.

Closes #13773