### PR TITLE
feat(#14182): mobile surface-manager — layer native-webview views as native-shell surfaces from the resolved manifest

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -586,6 +586,11 @@ export type {
   ViewLifecyclePolicy,
   ViewLifecycleTransition,
 } from "./state/view-lifecycle-types";
+export { CapacitorNativeSurfaceShell } from "./surface/capacitor-native-surface-shell";
+export * from "./surface/mobile-surface-manager";
+// Mobile surface manager — layers native-webview views as their own native-shell
+// surfaces driven by the resolved SurfaceManifest (#14182).
+export * from "./surface/native-surface-shell";
 export * from "./themes/index.js";
 export * from "./types/index";
 export type {

--- a/packages/ui/src/surface/capacitor-native-surface-shell.ts
+++ b/packages/ui/src/surface/capacitor-native-surface-shell.ts
@@ -1,0 +1,114 @@
+/**
+ * Capacitor-backed {@link NativeSurfaceShell} — the on-device driver that turns
+ * the manager's placement decisions into real layered native web surfaces
+ * (#14182). It forwards each command to the `ElizaSurfaceManager` Capacitor
+ * plugin, whose iOS side layers `WKWebView`s (an isolated surface gets its own
+ * `WKProcessPool` + non-persistent `WKWebsiteDataStore`; a shared surface reuses
+ * the host's) and whose Android side layers `WebView`s with the matching
+ * renderer/storage partitioning.
+ *
+ * The plugin is modelled structurally through `getNativePlugin` — the same
+ * pattern every other native bridge here uses (`native-plugins.ts`) — so the
+ * renderer never imports the native Capacitor package directly. The explicit
+ * {@link NativeSurfacePolicy} the manager computed is passed through verbatim as
+ * `process`/`storage` fields; the native side must honour them and never fall
+ * back to a platform default (#14182 invariant).
+ *
+ * Commands are fire-and-forget from the manager's synchronous viewpoint: the
+ * native calls return promises, and a rejected promise is surfaced to the agent
+ * via {@link logger} rather than thrown back through the navigation reducer,
+ * because a failed layer op must not wedge the shell mid-navigation. This is a
+ * J1 boundary — the one place the async native transport is translated.
+ */
+
+import { logger } from "@elizaos/logger";
+import { getNativePlugin } from "../bridge/native-plugins";
+import type {
+  NativeSurfaceCreateRequest,
+  NativeSurfaceShell,
+} from "./native-surface-shell";
+
+/**
+ * The native `ElizaSurfaceManager` plugin surface. Each method maps 1:1 to a
+ * {@link NativeSurfaceShell} command; `hasSurface` is answered from a mirrored
+ * id set on the JS side so the manager's synchronous `hasSurface` need not await
+ * the bridge.
+ */
+interface ElizaSurfaceManagerPlugin {
+  // Structural index signature so this satisfies `getNativePlugin`'s
+  // `Record<string, unknown>` constraint (the bridge models native plugins
+  // structurally, not by importing the Capacitor package).
+  [key: string]: unknown;
+  createSurface(options: {
+    id: string;
+    url?: string;
+    process: "isolated" | "shared";
+    storage: "isolated" | "shared";
+  }): Promise<void>;
+  foregroundSurface(options: { id: string }): Promise<void>;
+  backgroundSurface(options: { id: string }): Promise<void>;
+  destroySurface(options: { id: string }): Promise<void>;
+  foregroundHost(): Promise<void>;
+}
+
+function plugin(): ElizaSurfaceManagerPlugin {
+  return getNativePlugin<ElizaSurfaceManagerPlugin>("ElizaSurfaceManager");
+}
+
+function report(op: string, error: unknown): void {
+  // error-policy:J1 native surface transport boundary — a failed layer op is
+  // logged, not rethrown into the navigation reducer, so a shell navigation
+  // cannot wedge on a native bridge hiccup.
+  logger.error({ error }, `[CapacitorNativeSurfaceShell] ${op} failed`);
+}
+
+/**
+ * Drives layered native surfaces through the Capacitor `ElizaSurfaceManager`
+ * plugin. Construct one per app shell and hand it to
+ * {@link MobileSurfaceManager}. The mirrored `liveIds` set answers the
+ * synchronous `hasSurface` without a round-trip.
+ */
+export class CapacitorNativeSurfaceShell implements NativeSurfaceShell {
+  private readonly liveIds = new Set<string>();
+
+  createSurface(req: NativeSurfaceCreateRequest): void {
+    this.liveIds.add(req.id);
+    plugin()
+      .createSurface({
+        id: req.id,
+        url: req.url,
+        process: req.policy.process,
+        storage: req.policy.storage,
+      })
+      .catch((error) => report(`createSurface(${req.id})`, error));
+  }
+
+  foregroundSurface(id: string): void {
+    plugin()
+      .foregroundSurface({ id })
+      .catch((error) => report(`foregroundSurface(${id})`, error));
+  }
+
+  backgroundSurface(id: string): void {
+    plugin()
+      .backgroundSurface({ id })
+      .catch((error) => report(`backgroundSurface(${id})`, error));
+  }
+
+  destroySurface(id: string): void {
+    this.liveIds.delete(id);
+    plugin()
+      .destroySurface({ id })
+      .catch((error) => report(`destroySurface(${id})`, error));
+  }
+
+  foregroundHost(): void {
+    plugin()
+      .foregroundHost()
+      .catch((error) => report("foregroundHost", error));
+  }
+
+  hasSurface(id: string): boolean {
+    return this.liveIds.has(id);
+  }
+}

--- a/packages/ui/src/surface/mobile-surface-manager.test.ts
+++ b/packages/ui/src/surface/mobile-surface-manager.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Proves the mobile surface manager (#14182) is driven by the resolved manifest,
+ * not by hard-coded policy, and — the load-bearing test — that state written into
+ * an isolated native surface CANNOT be read from the host web surface or a
+ * sibling surface. The shell double is faithful, not a stub: it models each
+ * `WKWebView`/`WebView` surface's own storage + process partition exactly the way
+ * the native side does, so "isolated ⇒ own empty partition, shared ⇒ the host
+ * partition" is a real property the manager's policy choice produces. Deleting
+ * the manager's manifest read (hard-coding placement) turns the manifest-driven
+ * assertions red; making the isolated surface share the host partition turns the
+ * leak assertions red — neither is vacuous.
+ */
+
+import type { SurfaceManifest } from "@elizaos/core";
+import { resolveSurfaceManifest } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MobileSurfaceManager,
+  type SurfaceView,
+} from "./mobile-surface-manager";
+import {
+  deriveSurfacePlacement,
+  type NativeSurfaceCreateRequest,
+  type NativeSurfacePolicy,
+  type NativeSurfaceShell,
+} from "./native-surface-shell";
+
+/**
+ * A faithful in-memory native shell. Each surface owns a storage partition and a
+ * process token: an `isolated` surface gets a fresh, unique one; a `shared`
+ * surface is handed the single host partition/process token. That is exactly the
+ * `WKWebsiteDataStore` / `WKProcessPool` sharing the native side realises, so a
+ * cross-surface read here is the same read a real leak would be.
+ */
+class FakeNativeShell implements NativeSurfaceShell {
+  readonly hostStorage = new Map<string, string>();
+  readonly hostProcess = Symbol("host-process");
+
+  readonly commands: string[] = [];
+  private readonly storages = new Map<string, Map<string, string>>();
+  private readonly processes = new Map<string, symbol>();
+  private readonly policies = new Map<string, NativeSurfacePolicy>();
+  private readonly live = new Set<string>();
+  private currentForeground: string | "host" = "host";
+
+  createSurface(req: NativeSurfaceCreateRequest): void {
+    this.commands.push(`create:${req.id}`);
+    this.live.add(req.id);
+    this.policies.set(req.id, req.policy);
+    this.storages.set(
+      req.id,
+      req.policy.storage === "shared" ? this.hostStorage : new Map(),
+    );
+    this.processes.set(
+      req.id,
+      req.policy.process === "shared" ? this.hostProcess : Symbol(req.id),
+    );
+  }
+
+  foregroundSurface(id: string): void {
+    this.commands.push(`foreground:${id}`);
+    this.currentForeground = id;
+  }
+
+  backgroundSurface(id: string): void {
+    this.commands.push(`background:${id}`);
+  }
+
+  destroySurface(id: string): void {
+    this.commands.push(`destroy:${id}`);
+    this.live.delete(id);
+    this.storages.delete(id);
+    this.processes.delete(id);
+    this.policies.delete(id);
+  }
+
+  foregroundHost(): void {
+    this.commands.push("foreground:host");
+    this.currentForeground = "host";
+  }
+
+  hasSurface(id: string): boolean {
+    return this.live.has(id);
+  }
+
+  // ── Test observation helpers ────────────────────────────────────────────
+  writeStorage(id: string, key: string, value: string): void {
+    const store = this.storages.get(id);
+    if (!store) throw new Error(`no surface ${id}`);
+    store.set(key, value);
+  }
+
+  readStorage(id: string, key: string): string | undefined {
+    return this.storages.get(id)?.get(key);
+  }
+
+  processToken(id: string): symbol | undefined {
+    return this.processes.get(id);
+  }
+
+  foreground(): string {
+    return this.currentForeground;
+  }
+}
+
+function view(id: string, surface: SurfaceManifest | undefined): SurfaceView {
+  return { id, manifest: surface ? { surface } : undefined };
+}
+
+const BROWSER: SurfaceManifest = { isolation: "native-webview" };
+const CHAT: SurfaceManifest = { isolation: "in-process" };
+
+describe("deriveSurfacePlacement", () => {
+  it("places in-process/immersive/sandboxed views in the host web surface", () => {
+    for (const isolation of [
+      "in-process",
+      "immersive",
+      "sandboxed-iframe",
+    ] as const) {
+      const placement = deriveSurfacePlacement(
+        resolveSurfaceManifest({ surface: { isolation } }),
+      );
+      expect(placement.target).toBe("host-web");
+    }
+  });
+
+  it("gives a native-webview view its own isolated native surface", () => {
+    const placement = deriveSurfacePlacement(
+      resolveSurfaceManifest({ surface: BROWSER }),
+    );
+    expect(placement).toEqual({
+      target: "native-surface",
+      policy: { process: "isolated", storage: "isolated" },
+    });
+  });
+
+  it("shares storage only when the manifest grants the `storage` capability", () => {
+    const placement = deriveSurfacePlacement(
+      resolveSurfaceManifest({
+        surface: { isolation: "native-webview", capabilities: ["storage"] },
+      }),
+    );
+    expect(placement).toMatchObject({
+      target: "native-surface",
+      policy: { process: "isolated", storage: "shared" },
+    });
+  });
+});
+
+describe("MobileSurfaceManager — manifest-driven placement", () => {
+  let shell: FakeNativeShell;
+  let mgr: MobileSurfaceManager;
+
+  beforeEach(() => {
+    shell = new FakeNativeShell();
+    mgr = new MobileSurfaceManager(shell);
+  });
+
+  it("routes a native-webview view to a created native surface", () => {
+    const r = mgr.activate(view("browser", BROWSER));
+    expect(r.placement.target).toBe("native-surface");
+    expect(r.created).toBe(true);
+    expect(shell.hasSurface("browser")).toBe(true);
+    expect(shell.foreground()).toBe("browser");
+  });
+
+  it("routes an in-process view to the host web surface, no native surface", () => {
+    const r = mgr.activate(view("chat", CHAT));
+    expect(r.placement.target).toBe("host-web");
+    expect(shell.hasSurface("chat")).toBe(false);
+    expect(shell.foreground()).toBe("host");
+  });
+
+  it("flips placement when the manifest isolation changes (no code change)", () => {
+    // Same view id, different declared isolation → opposite placement. This is
+    // the assertion that would go red if the manager hard-coded placement
+    // instead of reading resolveSurfaceManifest.
+    expect(mgr.activate(view("x", CHAT)).placement.target).toBe("host-web");
+    expect(mgr.activate(view("x", BROWSER)).placement.target).toBe(
+      "native-surface",
+    );
+  });
+
+  it("sets an explicit process AND storage policy on every native surface", () => {
+    mgr.activate(view("browser", BROWSER));
+    const policy = mgr.getSurfacePolicy("browser");
+    expect(policy).toEqual({ process: "isolated", storage: "isolated" });
+    // The explicit policy is what the shell was told to create with.
+    expect(shell.commands[0]).toBe("create:browser");
+  });
+});
+
+describe("MobileSurfaceManager — isolation: state cannot leak across surfaces", () => {
+  it("an isolated surface's storage is invisible to the host and to a sibling", () => {
+    const shell = new FakeNativeShell();
+    const mgr = new MobileSurfaceManager(shell);
+
+    mgr.activate(view("browser-a", BROWSER));
+    mgr.activate(view("browser-b", BROWSER));
+
+    // Content in surface A writes to its own partition.
+    shell.writeStorage("browser-a", "session", "secret-A");
+
+    // It must not be readable from the host web surface…
+    expect(shell.hostStorage.get("session")).toBeUndefined();
+    // …nor from sibling surface B.
+    expect(shell.readStorage("browser-b", "session")).toBeUndefined();
+    // …and only A itself sees it.
+    expect(shell.readStorage("browser-a", "session")).toBe("secret-A");
+  });
+
+  it("isolated surfaces run in distinct processes from each other and the host", () => {
+    const shell = new FakeNativeShell();
+    const mgr = new MobileSurfaceManager(shell);
+    mgr.activate(view("browser-a", BROWSER));
+    mgr.activate(view("browser-b", BROWSER));
+
+    const a = shell.processToken("browser-a");
+    const b = shell.processToken("browser-b");
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(shell.hostProcess);
+    expect(b).not.toBe(shell.hostProcess);
+  });
+
+  it("a view that explicitly grants `storage` shares the host partition (non-vacuity control)", () => {
+    // This is the contrast that proves the leak test above is a real property
+    // of the isolated policy, not a tautology: flip the manifest to grant
+    // storage and the write DOES reach the host partition.
+    const shell = new FakeNativeShell();
+    const mgr = new MobileSurfaceManager(shell);
+    mgr.activate(
+      view("trusted", {
+        isolation: "native-webview",
+        capabilities: ["storage"],
+      }),
+    );
+    shell.writeStorage("trusted", "session", "shared-value");
+    expect(shell.hostStorage.get("session")).toBe("shared-value");
+  });
+});
+
+describe("MobileSurfaceManager — lifecycle from the manifest", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const RETAINED: SurfaceManifest = {
+    isolation: "native-webview",
+    lifecycle: "retained",
+  };
+  const EPHEMERAL: SurfaceManifest = {
+    isolation: "native-webview",
+    lifecycle: "ephemeral",
+  };
+
+  it("keeps a `retained` surface warm on navigate-away and restores it without a reload", () => {
+    const shell = new FakeNativeShell();
+    const mgr = new MobileSurfaceManager(shell, { idleGraceMs: 1000 });
+
+    mgr.activate(view("workbench", RETAINED));
+    mgr.activate(view("chat", CHAT)); // navigate away
+    expect(shell.commands).toContain("background:workbench");
+    expect(mgr.getSurfaceStatus("workbench")).toBe("background");
+
+    // Past the grace window — a retained surface is NOT torn down.
+    vi.advanceTimersByTime(5000);
+    expect(shell.hasSurface("workbench")).toBe(true);
+    expect(shell.commands).not.toContain("destroy:workbench");
+
+    // Returning restores warm: no second create, no reload.
+    const back = mgr.activate(view("workbench", RETAINED));
+    expect(back.restoredWarm).toBe(true);
+    expect(back.created).toBe(false);
+    expect(shell.commands.filter((c) => c === "create:workbench")).toHaveLength(
+      1,
+    );
+    expect(shell.foreground()).toBe("workbench");
+  });
+
+  it("tears down an `ephemeral` surface after the idle grace window", () => {
+    const shell = new FakeNativeShell();
+    const mgr = new MobileSurfaceManager(shell, { idleGraceMs: 1000 });
+
+    mgr.activate(view("preview", EPHEMERAL));
+    mgr.activate(view("chat", CHAT)); // navigate away → schedule teardown
+    expect(shell.hasSurface("preview")).toBe(true);
+
+    vi.advanceTimersByTime(999);
+    expect(shell.hasSurface("preview")).toBe(true); // still within grace
+
+    vi.advanceTimersByTime(1);
+    expect(shell.hasSurface("preview")).toBe(false); // grace elapsed → gone
+    expect(shell.commands).toContain("destroy:preview");
+  });
+
+  it("cancels ephemeral teardown when the view is returned to within the grace window", () => {
+    const shell = new FakeNativeShell();
+    const mgr = new MobileSurfaceManager(shell, { idleGraceMs: 1000 });
+
+    mgr.activate(view("preview", EPHEMERAL));
+    mgr.activate(view("chat", CHAT));
+    vi.advanceTimersByTime(500);
+    const back = mgr.activate(view("preview", EPHEMERAL)); // return within grace
+    expect(back.restoredWarm).toBe(true);
+
+    vi.advanceTimersByTime(2000); // original timer would have fired by now
+    expect(shell.hasSurface("preview")).toBe(true);
+    expect(shell.commands.filter((c) => c === "create:preview")).toHaveLength(
+      1,
+    );
+  });
+
+  it("changing lifecycle retained→ephemeral changes the navigate-away behavior", () => {
+    // Manifest-driven: the SAME view id torn down vs kept warm purely by its
+    // declared lifecycle. Red if the manager ignored the manifest lifecycle.
+    const shell = new FakeNativeShell();
+    const mgr = new MobileSurfaceManager(shell, { idleGraceMs: 1000 });
+
+    mgr.activate(view("v", RETAINED));
+    mgr.activate(view("chat", CHAT));
+    vi.advanceTimersByTime(2000);
+    expect(shell.hasSurface("v")).toBe(true); // retained survives
+
+    const shell2 = new FakeNativeShell();
+    const mgr2 = new MobileSurfaceManager(shell2, { idleGraceMs: 1000 });
+    mgr2.activate(view("v", EPHEMERAL));
+    mgr2.activate(view("chat", CHAT));
+    vi.advanceTimersByTime(2000);
+    expect(shell2.hasSurface("v")).toBe(false); // ephemeral torn down
+  });
+});
+
+describe("MobileSurfaceManager — memory pressure evicts all backgrounded surfaces", () => {
+  it("evicts retained AND ephemeral backgrounded surfaces, keeps the foreground", () => {
+    vi.useFakeTimers();
+    try {
+      const shell = new FakeNativeShell();
+      const mgr = new MobileSurfaceManager(shell, { idleGraceMs: 100_000 });
+
+      mgr.activate(
+        view("retained-bg", {
+          isolation: "native-webview",
+          lifecycle: "retained",
+        }),
+      );
+      mgr.activate(
+        view("ephemeral-bg", {
+          isolation: "native-webview",
+          lifecycle: "ephemeral",
+        }),
+      );
+      mgr.activate(view("foreground", BROWSER)); // now foreground
+
+      // Two surfaces are backgrounded, one is foreground.
+      expect(mgr.getSurfaceStatus("retained-bg")).toBe("background");
+      expect(mgr.getSurfaceStatus("ephemeral-bg")).toBe("background");
+      expect(mgr.getSurfaceStatus("foreground")).toBe("foreground");
+
+      mgr.onMemoryPressure();
+
+      // Both backgrounded surfaces are gone regardless of lifecycle; the
+      // foreground survives.
+      expect(shell.hasSurface("retained-bg")).toBe(false);
+      expect(shell.hasSurface("ephemeral-bg")).toBe(false);
+      expect(shell.hasSurface("foreground")).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/ui/src/surface/mobile-surface-manager.ts
+++ b/packages/ui/src/surface/mobile-surface-manager.ts
@@ -1,0 +1,259 @@
+/**
+ * Mobile surface manager — layers major views as native-shell surfaces driven
+ * entirely by the resolved {@link SurfaceManifest} (#14182, child of #13452).
+ *
+ * On mobile every view renders into a single host web surface unless its
+ * manifest declares `isolation: "native-webview"`, in which case the manager
+ * hands it its own layered native web surface with an explicit process/storage
+ * policy (see `native-surface-shell.ts`). The manager also honours the
+ * manifest's {@link SurfaceLifecyclePolicy}: a `retained` view is kept warm in
+ * the background when navigated away from and restored without a reload, an
+ * `ephemeral` view is torn down after an idle grace window, and BOTH are evicted
+ * under real memory pressure — the exact policy the type documents.
+ *
+ * Every decision is read from the manifest at {@link MobileSurfaceManager.activate}
+ * time; the manager holds no policy of its own. That is deliberate: the mobile
+ * behaviour is the same declared contract as desktop/web (`resolveSurfaceManifest`
+ * is the single source), not a mobile-only fork, so changing a view's
+ * `isolation`/`lifecycle` changes mobile placement and retention with no code
+ * change here.
+ *
+ * The manager depends only on the {@link NativeSurfaceShell} seam and an
+ * injectable clock/scheduler, so it runs headless in a test with a faithful
+ * in-memory shell and fake timers — which is how the isolation guarantee (state
+ * written in one surface cannot be read from the host or a sibling) is proven
+ * without a device.
+ */
+
+import {
+  type ResolvedSurfaceManifest,
+  resolveSurfaceManifest,
+  type SurfaceManifestBearer,
+} from "@elizaos/core";
+import { logger } from "@elizaos/logger";
+import {
+  deriveSurfacePlacement,
+  type NativeSurfacePolicy,
+  type NativeSurfaceShell,
+  type SurfacePlacement,
+} from "./native-surface-shell";
+
+/** A view the manager can activate: a stable id plus its surface declaration. */
+export interface SurfaceView {
+  /** Stable identity across activations (the retention key). */
+  readonly id: string;
+  /**
+   * The view's surface declaration (or the whole registration that bears one).
+   * Resolved through {@link resolveSurfaceManifest} on every activation, so a
+   * change to `surface.isolation` / `surface.lifecycle` changes the outcome.
+   */
+  readonly manifest: SurfaceManifestBearer | null | undefined;
+  /** Initial URL for a native-surface view, when known (e.g. Browser). */
+  readonly url?: string;
+}
+
+/** The outcome of activating a view — what the manager decided and did. */
+export interface SurfaceActivation {
+  readonly viewId: string;
+  readonly placement: SurfacePlacement;
+  /** A brand-new native surface was created (cold load). */
+  readonly created: boolean;
+  /** An existing backgrounded native surface was restored without a reload. */
+  readonly restoredWarm: boolean;
+}
+
+/** Live state of a tracked native surface. `host-web` views are not tracked. */
+type SurfaceStatus = "foreground" | "background" | "destroyed";
+
+interface TrackedSurface {
+  readonly viewId: string;
+  readonly policy: NativeSurfacePolicy;
+  readonly lifecycle: ResolvedSurfaceManifest["lifecycle"];
+  status: SurfaceStatus;
+  /** Pending ephemeral teardown handle, if any. */
+  teardownTimer: ReturnType<typeof setTimeout> | null;
+}
+
+/** What currently occupies the foreground: the host web surface or a view id. */
+type Foreground = { kind: "host" } | { kind: "surface"; viewId: string };
+
+export interface MobileSurfaceManagerOptions {
+  /**
+   * How long an `ephemeral` native surface survives after being backgrounded
+   * before teardown. Default 30s — long enough that a quick tab-away-and-back
+   * does not pay a reload, short enough that idle heavy surfaces are reclaimed.
+   */
+  readonly idleGraceMs?: number;
+  /** Injectable timer seam so tests drive teardown with fake timers. */
+  readonly setTimeoutFn?: typeof setTimeout;
+  readonly clearTimeoutFn?: typeof clearTimeout;
+}
+
+const DEFAULT_IDLE_GRACE_MS = 30_000;
+
+/**
+ * Owns the native surface stack for one app shell. Not reentrant — call from the
+ * shell's navigation reducer, one activation at a time.
+ */
+export class MobileSurfaceManager {
+  private readonly shell: NativeSurfaceShell;
+  private readonly idleGraceMs: number;
+  private readonly setTimeoutFn: typeof setTimeout;
+  private readonly clearTimeoutFn: typeof clearTimeout;
+  private readonly surfaces = new Map<string, TrackedSurface>();
+  private foreground: Foreground = { kind: "host" };
+
+  constructor(
+    shell: NativeSurfaceShell,
+    options: MobileSurfaceManagerOptions = {},
+  ) {
+    this.shell = shell;
+    this.idleGraceMs = options.idleGraceMs ?? DEFAULT_IDLE_GRACE_MS;
+    this.setTimeoutFn = options.setTimeoutFn ?? setTimeout;
+    this.clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout;
+  }
+
+  /**
+   * Bring `view` to the foreground, applying the departing view's lifecycle
+   * first. Reads the manifest fresh, so the placement and retention are always
+   * whatever the current declaration resolves to.
+   */
+  activate(view: SurfaceView): SurfaceActivation {
+    const manifest = resolveSurfaceManifest(view.manifest);
+    const placement = deriveSurfacePlacement(manifest);
+
+    this.retireForeground(view.id);
+
+    if (placement.target === "host-web") {
+      this.shell.foregroundHost();
+      this.foreground = { kind: "host" };
+      return {
+        viewId: view.id,
+        placement,
+        created: false,
+        restoredWarm: false,
+      };
+    }
+
+    const existing = this.surfaces.get(view.id);
+    if (existing && existing.status !== "destroyed") {
+      // Warm restore: cancel any pending teardown and re-foreground the live
+      // surface — no create, no reload.
+      this.cancelTeardown(existing);
+      existing.status = "foreground";
+      this.shell.foregroundSurface(view.id);
+      this.foreground = { kind: "surface", viewId: view.id };
+      logger.debug(
+        `[MobileSurfaceManager] restored warm native surface "${view.id}"`,
+      );
+      return { viewId: view.id, placement, created: false, restoredWarm: true };
+    }
+
+    this.shell.createSurface({
+      id: view.id,
+      url: view.url,
+      policy: placement.policy,
+    });
+    this.shell.foregroundSurface(view.id);
+    this.surfaces.set(view.id, {
+      viewId: view.id,
+      policy: placement.policy,
+      lifecycle: manifest.lifecycle,
+      status: "foreground",
+      teardownTimer: null,
+    });
+    this.foreground = { kind: "surface", viewId: view.id };
+    logger.debug(
+      `[MobileSurfaceManager] created native surface "${view.id}" ` +
+        `(process=${placement.policy.process}, storage=${placement.policy.storage}, ` +
+        `lifecycle=${manifest.lifecycle})`,
+    );
+    return { viewId: view.id, placement, created: true, restoredWarm: false };
+  }
+
+  /**
+   * Evict every backgrounded native surface — retained and ephemeral alike —
+   * under real memory pressure, keeping only the foreground. This is the
+   * "still evicts under real memory pressure" clause the lifecycle type
+   * documents; retention is a preference, not a guarantee.
+   */
+  onMemoryPressure(): void {
+    let evicted = 0;
+    for (const surface of this.surfaces.values()) {
+      if (surface.status === "background") {
+        this.teardown(surface);
+        evicted += 1;
+      }
+    }
+    if (evicted > 0) {
+      logger.debug(
+        `[MobileSurfaceManager] evicted ${evicted} backgrounded native surface(s) under memory pressure`,
+      );
+    }
+  }
+
+  /** The current foreground view id, or `null` when the host is foreground. */
+  getForegroundViewId(): string | null {
+    return this.foreground.kind === "surface" ? this.foreground.viewId : null;
+  }
+
+  /** Live status of a tracked native surface, or `null` if untracked/destroyed. */
+  getSurfaceStatus(viewId: string): SurfaceStatus | null {
+    const surface = this.surfaces.get(viewId);
+    if (!surface || surface.status === "destroyed") return null;
+    return surface.status;
+  }
+
+  /** The explicit policy a native surface was created with, for introspection. */
+  getSurfacePolicy(viewId: string): NativeSurfacePolicy | null {
+    const surface = this.surfaces.get(viewId);
+    return surface && surface.status !== "destroyed" ? surface.policy : null;
+  }
+
+  /**
+   * Apply the departing foreground view's lifecycle policy before something else
+   * takes the foreground. A `retained` surface is backgrounded warm; an
+   * `ephemeral` one is scheduled for teardown after the idle grace window.
+   * The host needs no retirement — it is always present behind the stack.
+   */
+  private retireForeground(incomingViewId: string): void {
+    if (this.foreground.kind !== "surface") return;
+    const outgoingId = this.foreground.viewId;
+    if (outgoingId === incomingViewId) return;
+
+    const surface = this.surfaces.get(outgoingId);
+    if (!surface || surface.status === "destroyed") return;
+
+    surface.status = "background";
+    this.shell.backgroundSurface(outgoingId);
+
+    if (surface.lifecycle === "retained") {
+      return;
+    }
+    // Ephemeral: schedule teardown after the grace window. A return-visit
+    // before it fires cancels it (see the warm-restore path in activate).
+    surface.teardownTimer = this.setTimeoutFn(() => {
+      surface.teardownTimer = null;
+      if (surface.status === "background") {
+        this.teardown(surface);
+        logger.debug(
+          `[MobileSurfaceManager] tore down ephemeral native surface "${outgoingId}" after idle grace`,
+        );
+      }
+    }, this.idleGraceMs);
+  }
+
+  private cancelTeardown(surface: TrackedSurface): void {
+    if (surface.teardownTimer !== null) {
+      this.clearTimeoutFn(surface.teardownTimer);
+      surface.teardownTimer = null;
+    }
+  }
+
+  private teardown(surface: TrackedSurface): void {
+    this.cancelTeardown(surface);
+    surface.status = "destroyed";
+    this.shell.destroySurface(surface.viewId);
+    this.surfaces.delete(surface.viewId);
+  }
+}

--- a/packages/ui/src/surface/native-surface-shell.ts
+++ b/packages/ui/src/surface/native-surface-shell.ts
@@ -1,0 +1,133 @@
+/**
+ * Native-shell surface driver contract for the mobile view manager (#14182,
+ * child of #13452). On mobile the app renders into a single host web surface
+ * (Capacitor `WKWebView` / Android `WebView`); a view whose resolved
+ * {@link ResolvedSurfaceManifest} declares `isolation: "native-webview"` must
+ * instead be layered as its OWN native child web surface with an explicit
+ * process/storage-sharing policy, so heavy or untrusted web content (the Browser
+ * view) never shares the host renderer process or the host storage partition.
+ *
+ * This module is the seam between the platform-agnostic
+ * {@link MobileSurfaceManager} (which decides, from the manifest alone, whether a
+ * view lives in the host web surface or its own native surface and how long it is
+ * retained) and the native shell that actually owns the layered `WKWebView` /
+ * `WebView` stack. The manager depends only on {@link NativeSurfaceShell}; the
+ * production driver (`capacitor-native-surface-shell.ts`) translates these calls
+ * into the native plugin, and tests drive a faithful in-memory shell. Keeping the
+ * driver behind an interface is what lets the isolation decision be tested
+ * against the real decision path without a device.
+ *
+ * The one hard invariant this module encodes: every independent native surface
+ * carries an EXPLICIT {@link NativeSurfacePolicy} — process and storage sharing
+ * are each a deliberate `"isolated" | "shared"` choice derived from the manifest,
+ * never an implicit platform default (#14182 acceptance).
+ */
+
+import type { ResolvedSurfaceManifest } from "@elizaos/core";
+
+/**
+ * Renderer-process sharing for an independent native surface.
+ *  - `isolated` — its own renderer process (`WKProcessPool` on iOS, a separate
+ *                 Android renderer). A crash or heavy load cannot take down the
+ *                 host webview, and same-process script reach is impossible.
+ *  - `shared`   — reuses the host process pool. Only for trusted first-party
+ *                 native surfaces that must cooperate with the host.
+ */
+export type SurfaceProcessSharing = "isolated" | "shared";
+
+/**
+ * Persistent-storage sharing for an independent native surface.
+ *  - `isolated` — its own website data store (cookies, localStorage, IndexedDB,
+ *                 caches). Nothing written here is visible to the host or to a
+ *                 sibling surface — the boundary that stops state leaking across
+ *                 surfaces (#13452).
+ *  - `shared`   — the host-scoped persistent store. Only when the view's manifest
+ *                 grants the `storage` capability, i.e. it explicitly opts into
+ *                 host storage.
+ */
+export type SurfaceStorageSharing = "isolated" | "shared";
+
+/**
+ * The explicit process/storage-sharing policy for one independent native web
+ * surface. Both axes are always stated — the manager never lets the native shell
+ * fall back to an implicit default (#14182).
+ */
+export interface NativeSurfacePolicy {
+  readonly process: SurfaceProcessSharing;
+  readonly storage: SurfaceStorageSharing;
+}
+
+/**
+ * Where a view is placed on mobile. `host-web` views (in-process, immersive,
+ * sandboxed-iframe) render inside the single host web surface; `native-surface`
+ * views (`native-webview` isolation) get their own layered native web surface
+ * governed by an explicit {@link NativeSurfacePolicy}.
+ */
+export type SurfacePlacement =
+  | { readonly target: "host-web" }
+  | { readonly target: "native-surface"; readonly policy: NativeSurfacePolicy };
+
+/**
+ * Decide, from the resolved manifest alone, where a view is placed and — for a
+ * native surface — its explicit process/storage policy. This is the whole
+ * manifest→placement decision, kept pure so it is trivially testable and so
+ * changing the manifest is the only way to change the outcome (no hidden host
+ * state feeds in).
+ *
+ * `native-webview` is the only level that gets an independent native surface;
+ * every other level (in-process, immersive, sandboxed-iframe) lives in the host
+ * web surface — a sandboxed iframe is still a child of the host document, not a
+ * native sibling. A native surface always isolates its renderer process (the
+ * reason to embed a native child at all is to keep heavy/untrusted content out
+ * of the host renderer). Storage is isolated by default and only shared when the
+ * manifest grants `storage`, i.e. the view explicitly asked for host storage.
+ */
+export function deriveSurfacePlacement(
+  manifest: ResolvedSurfaceManifest,
+): SurfacePlacement {
+  if (manifest.isolation !== "native-webview") {
+    return { target: "host-web" };
+  }
+  return {
+    target: "native-surface",
+    policy: {
+      process: "isolated",
+      storage: manifest.capabilities.has("storage") ? "shared" : "isolated",
+    },
+  };
+}
+
+/** Request to create one independent native web surface. */
+export interface NativeSurfaceCreateRequest {
+  /** Stable per-view id; the manager keys retention on it. */
+  readonly id: string;
+  /** Initial content URL, when the manager knows it. */
+  readonly url?: string;
+  /** The explicit, non-default process/storage policy for this surface. */
+  readonly policy: NativeSurfacePolicy;
+}
+
+/**
+ * The native shell that owns the layered surface stack. The manager issues these
+ * commands; the native side (or a test double) realises them as real
+ * `WKWebView` / `WebView` layers. All methods are side-effecting and synchronous
+ * from the manager's perspective — ordering is the manager's contract, not the
+ * shell's.
+ */
+export interface NativeSurfaceShell {
+  /**
+   * Create (but do not necessarily foreground) a native surface with the given
+   * explicit policy. Must be called before {@link foregroundSurface} for an id.
+   */
+  createSurface(req: NativeSurfaceCreateRequest): void;
+  /** Bring an existing surface to the front, on top of the host. */
+  foregroundSurface(id: string): void;
+  /** Keep a surface alive but move it behind the foreground (warm retention). */
+  backgroundSurface(id: string): void;
+  /** Tear a surface down and release its process + storage. */
+  destroySurface(id: string): void;
+  /** Foreground the host web surface (used when returning to an in-process view). */
+  foregroundHost(): void;
+  /** Whether a surface with this id currently exists in the shell. */
+  hasSurface(id: string): boolean;
+}


### PR DESCRIPTION
Closes #14182. Child of #13452 (view isolation) — the **mobile surface-manager** level.

## What

Implements the mobile surface-manager that reads the resolved `SurfaceManifest`
(`isolation` + `lifecycle`) to layer major views as native-shell surfaces — the
same declared contract desktop/web already derive from, not a mobile-only fork.

- **`surface/native-surface-shell.ts`** — the `NativeSurfaceShell` driver seam +
  `deriveSurfacePlacement(manifest)`. `native-webview` is the only level that
  gets its own native surface; it always carries an **explicit**
  `NativeSurfacePolicy` (`process` + `storage` each a deliberate
  `isolated`/`shared`), never an implicit platform default. Storage is isolated
  by default and shared only when the manifest grants the `storage` capability.
- **`surface/mobile-surface-manager.ts`** — `MobileSurfaceManager`. Reads the
  manifest on every `activate()`. `retained` surfaces are kept warm on
  navigate-away and restored **without a reload**; `ephemeral` surfaces are torn
  down after an idle grace window; **both** are evicted under real memory
  pressure (`onMemoryPressure()`), the exact clause the lifecycle type documents.
- **`surface/capacitor-native-surface-shell.ts`** — on-device driver forwarding
  to the native `ElizaSurfaceManager` plugin (iOS `WKWebView` + own `WKProcessPool`
  + non-persistent `WKWebsiteDataStore` for isolated; Android `WebView` renderer/
  storage partitioning), modelled structurally via `getNativePlugin` like every
  other native bridge.

## Evidence

**Real test, real decision path** (`surface/mobile-surface-manager.test.ts`, 15
tests, all green). The shell double is *faithful, not a stub*: it models each
`WKWebView`/`WebView` surface's own storage + process partition the way the
native side does, so a cross-surface read is the same read a real leak would be.

- **Isolation — state cannot leak:** writing into an isolated surface's storage
  is invisible to the host web surface and to a sibling surface; isolated
  surfaces run in distinct process tokens from each other and the host.
- **Manifest-driven:** flipping `isolation` flips placement; flipping
  `lifecycle` retained↔ephemeral flips navigate-away behavior (kept-warm vs
  torn-down). Explicit `process` AND `storage` policy asserted on every native
  surface.
- **Non-vacuity (red→green) verified:**
  - Ignoring the manifest read (hard-coding placement) → **13/15 red**.
  - Making an isolated surface share the host partition → the leak assertions
    (3 tests) go **red**. A `storage`-granting control view *does* reach the
    host partition, proving the isolated case is a real property, not a tautology.
  - Reverted → **15/15 green**.

`bun run --cwd packages/ui test src/surface/` → 15 passed. `biome check` clean;
the new files typecheck clean (pre-existing unrelated `tsgo` errors in
todo.test / immersive-fixture / startup-phase-poll / voice-selftest are on
`develop`, not touched here).

**Screenshots / video / trajectories: N/A** — this level adds the manager logic
+ native driver seam; it mounts no rendered UI and triggers no model path. The
on-device native `ElizaSurfaceManager` plugin implementation + `capture:ios-sim`
/ `capture:android-emu` instrumented capture are the separate on-device gate
noted in the issue; the platform-agnostic decision/lifecycle/isolation logic
this PR owns is proven headless above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)