### PR TITLE
fix(#14202): atomic ACP commit-lock stale reclaim — close the TOCTOU

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts
@@ -6,13 +6,20 @@
  * park session A between its read-tree and its commit while session B commits.
  */
 
-import { execFile, execFileSync } from "node:child_process";
+import {
+  type ChildProcess,
+  execFile,
+  execFileSync,
+  spawn,
+} from "node:child_process";
 import {
   chmodSync,
   existsSync,
   mkdtempSync,
   readdirSync,
+  readFileSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import * as os from "node:os";
@@ -62,6 +69,14 @@ async function waitForFile(target: string, timeoutMs: number): Promise<void> {
     await new Promise((r) => setTimeout(r, 20));
   }
   throw new Error(`timed out waiting for ${target}`);
+}
+
+// A real, long-lived process whose PID stands in for the number a crashed
+// holder's PID was recycled to — process.kill(pid, 0) reports it alive.
+function spawnLiveChild(): ChildProcess {
+  return spawn(process.execPath, ["-e", "setInterval(() => {}, 1e9)"], {
+    stdio: "ignore",
+  });
 }
 
 type GitIndexPreparer = {
@@ -205,4 +220,115 @@ exit 0
       ),
     ).toEqual([]);
   });
+
+  // A crashed holder's PID can be recycled by the OS to an unrelated live
+  // process. processAlive() then reports it alive, so before #14202 lockIsStale
+  // returned "not stale" for it and never consulted the mtime backstop — the dead
+  // lock wedged the worktree until the 120s acquire deadline, then threw. With the
+  // backstop reachable for a live PID, the aged lock is reclaimed at once. The
+  // tight 20s timeout is itself the guard: a regression to never-reclaim wedges
+  // for LOCK_WAIT_MS (120s) and fails here.
+  it("reclaims a stale lock whose crashed holder's PID was recycled to a live process (#14202)", async () => {
+    const service = new AcpService(makeRuntime(), {
+      store: new InMemorySessionStore(),
+    });
+    const prepare = (
+      service as unknown as GitIndexPreparer
+    ).prepareSessionGitIndex.bind(service);
+
+    const baselineSha = git(repo, ["rev-parse", "HEAD"]);
+    const session = await prepare(repo, "sess-recycled", baselineSha);
+    expect(session?.env.GIT_INDEX_FILE).toBeTruthy();
+
+    writeFileSync(path.join(repo, "recycled.txt"), "after recycled-pid lock\n");
+    git(repo, ["add", "recycled.txt"], session?.env);
+
+    const live = spawnLiveChild();
+    try {
+      expect(() => process.kill(live.pid as number, 0)).not.toThrow();
+      const lockPath = path.join(repo, ".git", "eliza-acp-commit.lock");
+      writeFileSync(
+        lockPath,
+        JSON.stringify({
+          pid: live.pid,
+          token: "recycled-owner",
+          createdAt: Date.now() - 600_000,
+        }),
+      );
+      // Age the mtime well past LOCK_STALE_MS (30s) so the backstop fires.
+      const old = new Date(Date.now() - 600_000);
+      utimesSync(lockPath, old, old);
+
+      const result = await gitAsync(
+        repo,
+        ["commit", "-m", "reclaim recycled-pid lock"],
+        { ...process.env, ...session?.env },
+      );
+      expect(result.code, `commit failed: ${result.stderr}`).toBe(0);
+      expect(
+        git(repo, ["ls-tree", "--name-only", "-r", "HEAD"]).split("\n"),
+      ).toContain("recycled.txt");
+      expect(existsSync(lockPath)).toBe(false);
+    } finally {
+      try {
+        live.kill("SIGKILL");
+      } catch {
+        // error-policy:J6 test teardown; child may already be gone.
+      }
+    }
+  }, 20_000);
+
+  // The mtime backstop must not over-reach: a fresh lock held by a genuinely live
+  // process is NOT stale, so the wrapper must wait for it rather than steal it.
+  it("does not falsely reclaim a fresh, live-held commit lock (#14202)", async () => {
+    const service = new AcpService(makeRuntime(), {
+      store: new InMemorySessionStore(),
+    });
+    const prepare = (
+      service as unknown as GitIndexPreparer
+    ).prepareSessionGitIndex.bind(service);
+
+    const baselineSha = git(repo, ["rev-parse", "HEAD"]);
+    const session = await prepare(repo, "sess-wait", baselineSha);
+    expect(session?.env.GIT_INDEX_FILE).toBeTruthy();
+
+    writeFileSync(
+      path.join(repo, "waited.txt"),
+      "after waiting for a live holder\n",
+    );
+    git(repo, ["add", "waited.txt"], session?.env);
+
+    // Held by this (alive) process with a fresh mtime → not stale.
+    const lockPath = path.join(repo, ".git", "eliza-acp-commit.lock");
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: process.pid,
+        token: "live-holder",
+        createdAt: Date.now(),
+      }),
+    );
+
+    let done = false;
+    const commit = gitAsync(repo, ["commit", "-m", "waits for live holder"], {
+      ...process.env,
+      ...session?.env,
+    }).then((r) => {
+      done = true;
+      return r;
+    });
+
+    await new Promise((r) => setTimeout(r, 800));
+    // Still blocked: a fresh, live-held lock was not stolen.
+    expect(done, "wrapper reclaimed a fresh, live-held lock").toBe(false);
+    expect(readFileSync(lockPath, "utf8")).toContain("live-holder");
+
+    // Release the held lock; the waiting wrapper now acquires and commits.
+    rmSync(lockPath, { force: true });
+    const result = await commit;
+    expect(result.code, `commit failed: ${result.stderr}`).toBe(0);
+    expect(
+      git(repo, ["ls-tree", "--name-only", "-r", "HEAD"]).split("\n"),
+    ).toContain("waited.txt");
+  }, 20_000);
 });

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -317,7 +317,14 @@ function run(argv, opts = {}) {
 // contend, while shared ones can't interleave.
 const LOCK_POLL_MS = 25;
 const LOCK_WAIT_MS = 120000;
-const LOCK_STALE_MS = 300000;
+// A lock becomes reclaimable once its mtime is older than this. It sits below
+// LOCK_WAIT_MS so a crashed holder whose PID was recycled to an unrelated live
+// process is reclaimed by a waiter before that waiter's acquire deadline (#14202)
+// — otherwise the dead lock would wedge the worktree until the 120s timeout — and
+// well above the interval at which a live holder refreshes mtime via lock.verify()
+// (each read-tree/apply/commit boundary), so a legitimately long commit is never
+// falsely reclaimed.
+const LOCK_STALE_MS = 30000;
 function sleepSync(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
@@ -348,8 +355,6 @@ function readLock(lockPath) {
 function lockIsStale(lockPath) {
   const lock = readLock(lockPath);
   if (!lock) return undefined;
-  const pid = Number(lock.owner.pid);
-  if (Number.isInteger(pid) && pid > 0) return processAlive(pid) ? undefined : lock;
   let st;
   try {
     st = fs.statSync(lockPath);
@@ -357,7 +362,18 @@ function lockIsStale(lockPath) {
     if (err.code === "ENOENT") return undefined;
     throw err;
   }
-  return Date.now() - st.mtimeMs > LOCK_STALE_MS ? lock : undefined;
+  const mtimeStale = Date.now() - st.mtimeMs > LOCK_STALE_MS;
+  const pid = Number(lock.owner.pid);
+  if (Number.isInteger(pid) && pid > 0) {
+    // A live PID proves only that *some* process owns that number — not that it
+    // is our holder, which may have crashed with its PID since recycled to an
+    // unrelated live process. So the mtime backstop is consulted for a live PID
+    // too: a real holder refreshes mtime via lock.verify() well within
+    // LOCK_STALE_MS and never trips it, while a recycled PID cannot keep a dead
+    // holder's lock wedged until the acquire deadline (#14202 companion defect).
+    return !processAlive(pid) || mtimeStale ? lock : undefined;
+  }
+  return mtimeStale ? lock : undefined;
 }
 function stealStaleLock(lockPath, staleRaw) {
   const claimPath = lockPath + ".stale-" + process.pid + "-" + randomUUID();


### PR DESCRIPTION
Closes #14202.

## Context

#14202 tracks two stale-reclaim defects in the per-worktree ACP commit lock (`SESSION_GIT_WRAPPER` in `plugins/plugin-agent-orchestrator/src/services/acp-service.ts`):

1. **The TOCTOU** — two waiters both detect one stale lock, both `rmSync` + recreate, briefly reintroducing the #14183 same-worktree HEAD clobber. **Already fixed on `develop` by #14214** (inode-verified `stealStaleLock` + `verify()` ownership re-check). This PR keeps that intact.
2. **The companion defect** (flagged by @lalalune on the issue, and required for #14202 to close) — a crashed holder's PID gets **recycled by the OS to an unrelated live process**, so `processAlive(pid)` is `true`, `lockIsStale` returns "not stale" and **never consults the mtime backstop**. The dead lock then wedges the worktree until `LOCK_WAIT_MS` (120s), then throws `timed out acquiring commit lock` — directly contradicting the reclaim path's promise that "a dead holder can never wedge the worktree."

This PR closes defect 2.

## Fix (`acp-service.ts`, wrapper lock logic)

- **`lockIsStale` now consults the mtime backstop for a live PID too:** `stale = PID-dead OR mtime-older-than-STALE`. A live PID only proves *some* process owns that number, not that it is our (possibly crashed, PID-recycled) holder — so the mtime check is always evaluated.
- **`LOCK_STALE_MS` 300s → 30s**, so it sits *below* `LOCK_WAIT_MS` (120s): a recycled-PID dead lock is reclaimed well before a waiter's acquire deadline. It stays well *above* the interval at which a live holder refreshes its mtime via `lock.verify()` (already added by #14214, called at each `read-tree`/`apply`/`commit` boundary), so a legitimately long commit is never falsely reclaimed.

No change to #14214's `stealStaleLock` (atomic inode-verified steal) or `acquireCommitLock`/`verify`/`release`. 24-line surgical diff to production code.

## Tests (extend `acp-git-commit-race.test.ts`; drive the REAL wrapper via `prepareSessionGitIndex` against a real git repo)

- `reclaims a stale lock whose crashed holder's PID was recycled to a live process (#14202)` — seeds a lock owned by a genuinely-live PID with an aged mtime; asserts the commit reclaims and lands. **Fails on pre-fix source (wedges to the 120s deadline).**
- `does not falsely reclaim a fresh, live-held commit lock (#14202)` — seeds a fresh, live-held lock; asserts the wrapper *waits* (does not steal it), then proceeds after release. Guards the backstop from over-reaching (matrix item c).

The existing two-waiter TOCTOU (#14183) and dead-PID reclaim (#14214) tests continue to pass, guarding against regression of #14214's fix.

## Evidence

**Real vitest, all 4 in the suite pass (fix in place):**
```
✓ lands both commits when two sessions commit concurrently in one workdir 2288ms
✓ reclaims a stale commit lock without leaving reclaim artifacts 633ms
✓ reclaims a stale lock whose crashed holder's PID was recycled to a live process (#14202) 406ms
✓ does not falsely reclaim a fresh, live-held commit lock (#14202) 1190ms
Tests  4 passed (4)
```

**Regression-guard proof — the new recycled-PID test FAILS on pre-fix `develop` source** (swapped `develop`'s `acp-service.ts` in, ran the same test):
```
× reclaims a stale lock whose crashed holder's PID was recycled to a live process (#14202) 20369ms
  → wedged; hit the 20s test-timeout instead of reclaiming
Tests  1 failed | 1 passed
```

**Before/after driving the extracted wrapper as an on-PATH `git` (reconstruct-and-run harness, real repo):**

| scenario | pre-fix `develop` wrapper | fixed wrapper |
|---|---|---|
| dead-PID (SIGKILL) reclaim | PASS (97ms) | PASS (102ms) |
| **recycled-live-PID reclaim** | **FAIL — timed out @15000ms (wedged)** | **PASS (86ms)** |
| fresh live-held NOT reclaimed | PASS (blocked@800ms, then commits) | PASS |
| two-waiter TOCTOU single-holder (#14214) | PASS (both land, linear, no aside artifacts) | PASS |

`bun run audit:error-policy-ratchet`: `emptyCatch 3->3, serverConsole 0->0` — no new fallback-slop.

Backend/model trajectories, screenshots, video: **N/A** — this is a crash-recovery concurrency fix in a git-wrapper subprocess with no UI, no model, and no rendered surface. Verified end-to-end by driving the real wrapper against a real git repo (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
