### PR TITLE
fix(ci): add lane coverage check to develop PRs

### DIFF
--- a/.github/issue-evidence/13620-lane-coverage-workflow.md
+++ b/.github/issue-evidence/13620-lane-coverage-workflow.md
@@ -3,7 +3,7 @@
 ## Change
 
 - Added a `Test Integrity (lane coverage)` job to `.github/workflows/develop-pr.yml`.
-- The job runs `node packages/scripts/lint-lane-coverage.mjs` without `--dry-run`, so the seeded allowlist now gates develop PRs instead of only printing advisory output in `ci.yaml`.
+- The job runs `node packages/scripts/lint-lane-coverage.mjs` without `--dry-run`, so the seeded allowlist now produces a failing develop-PR workflow job instead of only printing advisory output in `ci.yaml`.
 - The job is read-only and install-free: checkout, Node 24 setup, then the existing script.
 
 ## Local verification
@@ -19,4 +19,4 @@
 - Real-LLM trajectories: N/A - workflow-only CI coverage wiring; no agent/action/provider/prompt/model behavior changed.
 - Backend logs: N/A - no runtime backend path changed.
 - Frontend screenshots/video: N/A - no user-facing UI changed.
-- Domain artifacts: `.github/workflows/develop-pr.yml` now contains an enforced lane coverage job.
+- Domain artifacts: `.github/workflows/develop-pr.yml` now contains a non-`continue-on-error` lane coverage job for develop PRs.

--- a/.github/issue-evidence/13620-lane-coverage-workflow.md
+++ b/.github/issue-evidence/13620-lane-coverage-workflow.md
@@ -1,0 +1,22 @@
+# Issue #13620 Lane Coverage Workflow Evidence
+
+## Change
+
+- Added a `Test Integrity (lane coverage)` job to `.github/workflows/develop-pr.yml`.
+- The job runs `node packages/scripts/lint-lane-coverage.mjs` without `--dry-run`, so the seeded allowlist now gates develop PRs instead of only printing advisory output in `ci.yaml`.
+- The job is read-only and install-free: checkout, Node 24 setup, then the existing script.
+
+## Local verification
+
+- `node --check packages/scripts/lint-lane-coverage.mjs`
+- `node packages/scripts/lint-lane-coverage.mjs` (PASS; 140 plugins scanned, 0 blocking issues, 153 suppressed issues)
+- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/develop-pr.yml"); puts "develop-pr.yml parsed"'`
+- `git diff --check`
+- `bunx @biomejs/biome check .github/issue-evidence/13620-lane-coverage-workflow.md --no-errors-on-unmatched`
+
+## Evidence matrix
+
+- Real-LLM trajectories: N/A - workflow-only CI coverage wiring; no agent/action/provider/prompt/model behavior changed.
+- Backend logs: N/A - no runtime backend path changed.
+- Frontend screenshots/video: N/A - no user-facing UI changed.
+- Domain artifacts: `.github/workflows/develop-pr.yml` now contains an enforced lane coverage job.

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -22,6 +22,23 @@ permissions:
   contents: read
 
 jobs:
+  lane-coverage:
+    name: Test Integrity (lane coverage)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Per-plugin e2e coverage
+        run: node packages/scripts/lint-lane-coverage.mjs
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Summary
- Add a `Test Integrity (lane coverage)` job to the active develop PR workflow.
- Run `node packages/scripts/lint-lane-coverage.mjs` without `--dry-run`, using the seeded allowlist from #14071.
- Keep the job read-only and install-free: checkout, Node 24, existing script.

## Issue
- Fixes the workflow CI-signal slice of #13620.
- Scope excludes broader changed-source/vitest coverage-gate work and does not claim repository branch-protection enforcement.

## Evidence
- `node --check packages/scripts/lint-lane-coverage.mjs`
- `actionlint .github/workflows/develop-pr.yml`
- `git diff --check origin/develop...HEAD`
- `node packages/scripts/lint-lane-coverage.mjs` (PASS; 140 plugins scanned, 0 blocking issues, 153 suppressed issues)
- Evidence note: `.github/issue-evidence/13620-lane-coverage-workflow.md`

## PR evidence matrix
- Real-LLM trajectories: N/A - workflow-only CI coverage wiring; no agent/action/provider/prompt/model behavior changed.
- Backend logs: N/A - no runtime backend path changed.
- Frontend screenshots/video: N/A - no user-facing UI changed.
- Domain artifacts: `.github/workflows/develop-pr.yml` now contains a non-`continue-on-error` lane coverage job for develop PRs.