### PR TITLE
feat(ui): make native-webview isolation drive the Browser view's embedding (#14181)

### DIFF
--- a/packages/ui/src/builtin-tab-registry.test.ts
+++ b/packages/ui/src/builtin-tab-registry.test.ts
@@ -16,8 +16,29 @@ import { describe, expect, it } from "vitest";
 import {
   BUILTIN_TAB_METADATA,
   resolveBuiltinBackgroundPolicy,
+  resolveBuiltinSurfaceManifest,
   resolveBuiltinTabId,
 } from "./builtin-tab-registry";
+
+describe("builtin-tab-registry: resolveBuiltinSurfaceManifest", () => {
+  it("resolves the Browser view to the native-webview isolation level", () => {
+    // The Browser view's tab renderer reads this to drive its native child
+    // web-content embedding (#14181); the level must stay native-webview.
+    expect(resolveBuiltinSurfaceManifest("browser").isolation).toBe(
+      "native-webview",
+    );
+    expect(resolveBuiltinSurfaceManifest("browser").background).toBe("opaque");
+  });
+
+  it("throws for a tab that declares no full surface manifest", () => {
+    // `views`/`apps` declare a path-predicate `shared` form, not a full
+    // manifest — asking for their resolved isolation is a misuse to surface,
+    // not a silent default.
+    expect(() => resolveBuiltinSurfaceManifest("views")).toThrow();
+    expect(() => resolveBuiltinSurfaceManifest("settings")).toThrow();
+    expect(() => resolveBuiltinSurfaceManifest("does-not-exist")).toThrow();
+  });
+});
 
 describe("builtin-tab-registry: table integrity", () => {
   it("has unique canonical ids and no id/alias collisions", () => {

--- a/packages/ui/src/builtin-tab-registry.ts
+++ b/packages/ui/src/builtin-tab-registry.ts
@@ -1,7 +1,9 @@
 import {
   type AppShellBackgroundPolicy,
   IMMERSIVE_WALLPAPER_SURFACE,
+  type ResolvedSurfaceManifest,
   resolveSurfaceBackgroundPolicy,
+  resolveSurfaceManifest,
   type SurfaceManifest,
 } from "@elizaos/core";
 
@@ -165,4 +167,29 @@ export function resolveBuiltinBackgroundPolicy(
     return decl.shared(trimmedNavigationPath) ? "shared" : null;
   }
   return resolveSurfaceBackgroundPolicy({ surface: decl });
+}
+
+/**
+ * The fully-resolved surface manifest a builtin tab declares — the source the
+ * shell reads to enforce a tab's isolation level (not just its background). The
+ * Browser view reads this to drive its native-webview embedding selection so
+ * the declared isolation is authoritative rather than merely documented
+ * (#14181): `resolveBuiltinSurfaceManifest("browser").isolation` is what its tab
+ * renderer branches on.
+ *
+ * Throws for a tab that declares no full manifest (a path-predicate `shared`
+ * tab, or an id with no `surface`): a caller asking for a builtin tab's
+ * resolved isolation must be asking about a tab that actually declares one, so a
+ * miss is a registry misconfiguration to surface loudly, not a silent default.
+ */
+export function resolveBuiltinSurfaceManifest(
+  tab: string,
+): ResolvedSurfaceManifest {
+  const decl = BUILTIN_TAB_BY_ID.get(tab)?.surface;
+  if (decl === undefined || "shared" in decl) {
+    throw new Error(
+      `Builtin tab "${tab}" declares no full surface manifest — cannot resolve its isolation level`,
+    );
+  }
+  return resolveSurfaceManifest({ surface: decl });
 }

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -25,12 +25,14 @@ import {
   type BrowserWorkspaceTab,
   client,
 } from "../../api";
+import { resolveBuiltinSurfaceManifest } from "../../builtin-tab-registry";
 import { MOBILE_RUNTIME_MODE_CHANGED_EVENT } from "../../events";
 import { readPersistedMobileRuntimeMode } from "../../first-run/mobile-runtime-mode";
 import { useIntervalWhenDocumentVisible } from "../../hooks/useDocumentVisibility";
 import { useRenderGuard } from "../../hooks/useRenderGuard";
 import { WorkspaceLayout } from "../../layouts/workspace-layout/workspace-layout";
 import { useAppSelectorShallow } from "../../state";
+import { resolveBrowserTabRenderPath } from "../../surface-embedding";
 import { openExternalUrl } from "../../utils";
 import {
   BROWSER_TAB_PRELOAD_SCRIPT,
@@ -74,6 +76,16 @@ const BROWSER_WORKSPACE_APP_PARTITION = "persist:eliza-browser-app";
 // Default URL when the user opens a fresh tab via "+". The docs site
 // respects prefers-color-scheme so the OS theme drives light/dark.
 const BROWSER_WORKSPACE_DEFAULT_HOME_URL = "https://docs.elizaos.ai/";
+// The Browser view's isolation level, read from its builtin surface manifest
+// rather than hardcoded, so the declared `native-webview` level is what
+// actually drives which embedding each tab renders into (#14181/#13452). This
+// is the enforcement seam: the native child web-content surface (its own
+// renderer process) is selected via `resolveBrowserTabRenderPath` only because
+// this resolves to `native-webview`. If the registry ever dropped the browser
+// manifest, `resolveBuiltinSurfaceManifest` throws at import — a loud failure,
+// not a silent fall-back to the host-realm DOM.
+const BROWSER_SURFACE_ISOLATION =
+  resolveBuiltinSurfaceManifest("browser").isolation;
 // Selectors handed to `<electrobun-webview masks=…>` so the native OOPIF
 // surface doesn't paint over (or capture clicks within) React overlays
 // stacked on the same rect. Covers Radix Dialog/AlertDialog content
@@ -546,6 +558,18 @@ export function BrowserWorkspaceView(): React.JSX.Element {
       initialBrowseUrlRef.current = null;
     }
   }
+
+  // Which embedding each browser tab renders into, DRIVEN by the view's
+  // declared isolation level (not the raw mode string): `native-webview` on the
+  // desktop shell resolves to the native child web-content surface (a separate
+  // renderer process — the `<electrobun-webview renderer="cef">` OOPIF below);
+  // web resolves to a sandboxed iframe; cloud to a server snapshot. Reading the
+  // manifest here is what makes `isolation: "native-webview"` authoritative
+  // (#14181) — a view without that level could never reach the native surface.
+  const browserTabRenderPath = resolveBrowserTabRenderPath({
+    isolation: BROWSER_SURFACE_ISOLATION,
+    mode: workspace.mode,
+  });
 
   const selectedTab = useMemo(
     () => workspace.tabs.find((tab) => tab.id === selectedTabId) ?? null,
@@ -2369,7 +2393,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
             ) : null}
           </div>
         )
-      ) : workspace.mode === "desktop" ? (
+      ) : browserTabRenderPath === "native-child-webview" ? (
         workspace.tabs.map((tab) => {
           const active = tab.id === selectedTabId;
           const visibilityClass = active
@@ -2399,7 +2423,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
             />
           );
         })
-      ) : workspace.mode === "web" ? (
+      ) : browserTabRenderPath === "sandboxed-iframe" ? (
         workspace.tabs.map((tab) => {
           const active = tab.id === selectedTabId;
           const highlighted = tab.visible;

--- a/packages/ui/src/surface-embedding.test.ts
+++ b/packages/ui/src/surface-embedding.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Proves the native-webview enforcement invariant of the surface-embedding
+ * resolver (#14181/#13452): the native child web-content surface — the only
+ * render path that puts a browser tab in a separate renderer process — is
+ * selected IFF the resolved manifest declares `isolation: "native-webview"` on
+ * the desktop shell, and can never be reached by any other isolation level on
+ * any mode. Also pins the actual Browser builtin manifest to that level so its
+ * tab renderer keeps selecting the native surface, and pins each platform's
+ * native embedding target. Pure functions over static data — no runtime harness
+ * needed; the isolation property under test is the selection itself.
+ */
+
+import { SURFACE_ISOLATION_LEVELS } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import type { BrowserWorkspaceMode } from "./api/browser-contracts";
+import { resolveBuiltinSurfaceManifest } from "./builtin-tab-registry";
+import {
+  NATIVE_WEBVIEW_EMBEDDINGS,
+  NATIVE_WEBVIEW_PLATFORMS,
+  nativeWebviewEmbedding,
+  resolveBrowserTabRenderPath,
+} from "./surface-embedding";
+
+const ALL_MODES: readonly BrowserWorkspaceMode[] = ["desktop", "web", "cloud"];
+
+describe("resolveBrowserTabRenderPath", () => {
+  it("hands out the native child surface only for native-webview on desktop", () => {
+    expect(
+      resolveBrowserTabRenderPath({
+        isolation: "native-webview",
+        mode: "desktop",
+      }),
+    ).toBe("native-child-webview");
+  });
+
+  it("native-webview degrades to a sandboxed iframe on the web platform", () => {
+    expect(
+      resolveBrowserTabRenderPath({ isolation: "native-webview", mode: "web" }),
+    ).toBe("sandboxed-iframe");
+  });
+
+  it("cloud renders a server snapshot regardless of isolation level", () => {
+    for (const isolation of SURFACE_ISOLATION_LEVELS) {
+      expect(resolveBrowserTabRenderPath({ isolation, mode: "cloud" })).toBe(
+        "server-snapshot",
+      );
+    }
+  });
+
+  it("ENFORCEMENT: no non-native-webview level ever reaches the native surface", () => {
+    // The isolation guarantee: a view that did not declare `native-webview`
+    // must never be handed a separate-renderer native child surface — that is
+    // what keeps a leak-capable embedding out of any surface that didn't opt in.
+    for (const isolation of SURFACE_ISOLATION_LEVELS) {
+      if (isolation === "native-webview") continue;
+      for (const mode of ALL_MODES) {
+        expect(resolveBrowserTabRenderPath({ isolation, mode })).not.toBe(
+          "native-child-webview",
+        );
+      }
+    }
+  });
+
+  it("is total over every isolation level × mode", () => {
+    const valid = new Set([
+      "native-child-webview",
+      "sandboxed-iframe",
+      "server-snapshot",
+    ]);
+    for (const isolation of SURFACE_ISOLATION_LEVELS) {
+      for (const mode of ALL_MODES) {
+        expect(
+          valid.has(resolveBrowserTabRenderPath({ isolation, mode })),
+        ).toBe(true);
+      }
+    }
+  });
+});
+
+describe("Browser builtin manifest drives the native path", () => {
+  it("declares native-webview, so its desktop tab renderer selects the native surface", () => {
+    const isolation = resolveBuiltinSurfaceManifest("browser").isolation;
+    expect(isolation).toBe("native-webview");
+    expect(resolveBrowserTabRenderPath({ isolation, mode: "desktop" })).toBe(
+      "native-child-webview",
+    );
+  });
+});
+
+describe("native-webview per-platform embedding targets", () => {
+  it("every platform names its native primitive and runs a separate renderer process", () => {
+    for (const platform of NATIVE_WEBVIEW_PLATFORMS) {
+      const embedding = nativeWebviewEmbedding(platform);
+      expect(embedding.platform).toBe(platform);
+      expect(embedding.separateRendererProcess).toBe(true);
+      expect(embedding.primitive.length).toBeGreaterThan(0);
+      expect(embedding.storagePolicy.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("desktop targets the WebContentsView/CEF OOPIF; iOS WKWebView; Android WebView", () => {
+    expect(NATIVE_WEBVIEW_EMBEDDINGS.desktop.primitive).toMatch(
+      /WebContentsView|OOPIF|out-of-process/i,
+    );
+    expect(NATIVE_WEBVIEW_EMBEDDINGS.ios.primitive).toMatch(/WKWebView/);
+    expect(NATIVE_WEBVIEW_EMBEDDINGS.ios.primitive).toMatch(/WKProcessPool/);
+    expect(NATIVE_WEBVIEW_EMBEDDINGS.android.primitive).toMatch(/WebView/);
+  });
+});

--- a/packages/ui/src/surface-embedding.ts
+++ b/packages/ui/src/surface-embedding.ts
@@ -1,0 +1,143 @@
+/**
+ * Turns a view's declared `native-webview` isolation level into the concrete
+ * web-content embedding its page actually renders into, per host platform — the
+ * enforcement half of the isolation catalogue (#14181, parent #13452). The
+ * catalogue in `surface-isolation.ts` *documents* that `native-webview` views
+ * embed a native child web-content surface with its own renderer process; this
+ * module is what makes that documentation authoritative: the Browser view's tab
+ * renderer reads the resolved manifest through {@link resolveBrowserTabRenderPath}
+ * and hands out the native child surface ONLY when the manifest declares
+ * `native-webview`, so no view that did not opt into that level can ever be
+ * given (or wrongly denied) a separate-renderer native surface.
+ *
+ * The isolation guarantee this protects: arbitrary third-party web content in
+ * the Browser view must never share the host renderer realm — its DOM, globals,
+ * storage, and a crash/heavy-load in it must not reach the shell. On desktop
+ * that separation is a real, distinct renderer process (the Electron/Electrobun
+ * `WebContentsView` / CEF OOPIF the Browser view already mounts); this resolver
+ * is the single decision point that selects it.
+ *
+ * Consumer: `packages/ui/src/components/pages/BrowserWorkspaceView.tsx` (the tab
+ * render branch). The per-platform target table {@link NATIVE_WEBVIEW_EMBEDDINGS}
+ * is the typed, greppable statement of which native primitive each platform uses
+ * and its process/storage-sharing policy — read alongside the catalogue.
+ */
+
+import type { SurfaceIsolationLevel } from "@elizaos/core";
+import type { BrowserWorkspaceMode } from "./api/browser-contracts";
+
+/**
+ * The concrete render path the Browser view uses for a tab's page content.
+ *
+ *  - `native-child-webview` — a native child web-content surface with its own
+ *    renderer process (desktop `WebContentsView` / CEF OOPIF). Third-party web
+ *    content runs fully outside the host renderer realm. Selected only when the
+ *    resolved manifest declares `native-webview`.
+ *  - `sandboxed-iframe` — a sandboxed in-realm `<iframe>` (the web platform has
+ *    no native child surface, so `native-webview` degrades to a cross-origin
+ *    sandboxed iframe there).
+ *  - `server-snapshot` — a server-rendered screenshot preview (cloud mode never
+ *    runs page content locally).
+ */
+export type BrowserTabRenderPath =
+  | "native-child-webview"
+  | "sandboxed-iframe"
+  | "server-snapshot";
+
+/**
+ * Resolve which embedding the Browser view uses for its tabs, from the view's
+ * declared isolation level and the running host mode.
+ *
+ * The one enforced invariant (#14181): `native-child-webview` — the only path
+ * that hands page content a separate renderer process — is returned **iff** the
+ * manifest declares `isolation: "native-webview"` AND the host is the desktop
+ * shell that can host a native child surface. Any other isolation level, on any
+ * mode, can never resolve to the native surface: it degrades to the in-realm
+ * sandboxed iframe (or the cloud snapshot). This is what stops a view that did
+ * not opt into `native-webview` from being handed a native renderer surface,
+ * and stops the Browser view from silently losing it if its manifest drifts.
+ */
+export function resolveBrowserTabRenderPath(input: {
+  isolation: SurfaceIsolationLevel;
+  mode: BrowserWorkspaceMode;
+}): BrowserTabRenderPath {
+  const { isolation, mode } = input;
+
+  // Cloud shows a server-rendered snapshot; no local web content runs, so the
+  // isolation level does not select a local embedding here.
+  if (mode === "cloud") return "server-snapshot";
+
+  // The native child web-content surface exists only on the desktop shell and
+  // is granted only to the declared `native-webview` level. This conjunction is
+  // the enforcement point: drop either condition and no native surface is used.
+  if (mode === "desktop" && isolation === "native-webview") {
+    return "native-child-webview";
+  }
+
+  // Web platform (no native child surface) and any non-`native-webview` view
+  // both land here: a sandboxed, in-realm iframe. Third-party content is served
+  // cross-origin so the sandbox is meaningful.
+  return "sandboxed-iframe";
+}
+
+/** The platforms that provide a native child web-content surface. */
+export const NATIVE_WEBVIEW_PLATFORMS = ["desktop", "ios", "android"] as const;
+
+/** A platform that can host the `native-webview` embedding. */
+export type NativeWebviewPlatform = (typeof NATIVE_WEBVIEW_PLATFORMS)[number];
+
+/**
+ * The native primitive + process/storage policy each platform uses to embed
+ * `native-webview` content. The durable, typed answer to "what actually hosts
+ * the Browser view's page content, and how isolated is it" per platform.
+ */
+export interface NativeWebviewEmbedding {
+  readonly platform: NativeWebviewPlatform;
+  /** The native primitive that hosts the child web content. */
+  readonly primitive: string;
+  /**
+   * The defining property of this level: the embedded content runs in a
+   * renderer process distinct from the host shell's renderer, so its crash or
+   * heavy load cannot take down the shell and its realm is not shared.
+   */
+  readonly separateRendererProcess: true;
+  /** The web-storage sharing policy between the child surface and the host. */
+  readonly storagePolicy: string;
+}
+
+/**
+ * The per-platform `native-webview` embedding target. Desktop is wired today
+ * (the Browser view mounts the CEF OOPIF `<electrobun-webview renderer="cef">`
+ * with a per-tab storage partition); iOS/Android name the native primitive and
+ * process/storage policy the mobile shell embeds the Browser view with.
+ */
+export const NATIVE_WEBVIEW_EMBEDDINGS: Readonly<
+  Record<NativeWebviewPlatform, NativeWebviewEmbedding>
+> = {
+  desktop: {
+    platform: "desktop",
+    primitive: "Electron/Electrobun WebContentsView (CEF out-of-process frame)",
+    separateRendererProcess: true,
+    storagePolicy: "per-tab persistent partition (persist:<tab-partition>)",
+  },
+  ios: {
+    platform: "ios",
+    primitive: "WKWebView backed by a dedicated WKProcessPool",
+    separateRendererProcess: true,
+    storagePolicy:
+      "own WKWebsiteDataStore, not shared with the app's host web view",
+  },
+  android: {
+    platform: "android",
+    primitive: "WebView with out-of-process renderer (renderer isolation)",
+    separateRendererProcess: true,
+    storagePolicy: "app-scoped WebView storage behind an isolated renderer",
+  },
+};
+
+/** The native embedding descriptor for a platform. */
+export function nativeWebviewEmbedding(
+  platform: NativeWebviewPlatform,
+): NativeWebviewEmbedding {
+  return NATIVE_WEBVIEW_EMBEDDINGS[platform];
+}


### PR DESCRIPTION
Closes #14181. Parent #13452; sibling of the other isolation-level slices.

## What this does

The Browser view **declared** `isolation: "native-webview"` but nothing read it — its tab renderer selected the native child web-content surface (`<electrobun-webview renderer="cef">`, a CEF OOPIF with its **own renderer process**) purely from the raw `workspace.mode` string. The catalogue entry was documented, not enforced. This makes the declared isolation level **authoritative** over which embedding the Browser view's page content renders into, per platform.

## Changes

- **`packages/ui/src/surface-embedding.ts`** (new) — `resolveBrowserTabRenderPath({ isolation, mode })`: the single decision point. Returns `native-child-webview` **iff** the resolved manifest declares `native-webview` on the desktop shell; any other isolation level, on any mode, degrades to `sandboxed-iframe` (web) or `server-snapshot` (cloud) and can **never** reach the native surface. `NATIVE_WEBVIEW_EMBEDDINGS` pins each platform's native primitive + process/storage policy (desktop `WebContentsView`/CEF OOPIF; iOS `WKWebView` + dedicated `WKProcessPool`; Android `WebView` out-of-process renderer).
- **`packages/ui/src/builtin-tab-registry.ts`** — `resolveBuiltinSurfaceManifest(tab)`: reads a builtin tab's fully-resolved manifest so the shell can enforce its isolation level (not just its background). Throws — never silently defaults — for a tab with no full manifest.
- **`packages/ui/src/components/pages/BrowserWorkspaceView.tsx`** — reads `resolveBuiltinSurfaceManifest("browser").isolation` and branches its tab render on `resolveBrowserTabRenderPath(...)`. The native OOPIF path is now selected *because* the manifest says `native-webview`, not because of a mode string. If the registry ever dropped the browser manifest, import fails loudly instead of falling back to the host-realm DOM.

## The isolation guarantee (why this closes the issue)

Arbitrary third-party web content in the Browser view must never share the host renderer realm. On desktop that separation is a real, distinct renderer process — the CEF OOPIF the view already mounts, with a per-tab storage partition. This change makes that surface reachable **only** through the declared `native-webview` level, so no view that did not opt into that level can be handed a separate-renderer native surface, and the Browser view can't silently lose it to manifest drift.

## Tests (real, no mocks)

`packages/ui/src/surface-embedding.test.ts` + extended `builtin-tab-registry.test.ts` — 35 passing:
- **Enforcement invariant**: exhaustive `SURFACE_ISOLATION_LEVELS × {desktop,web,cloud}` matrix asserting **no** non-`native-webview` level ever resolves to the native child surface.
- Native path selected only for `native-webview` + desktop; totality over the whole matrix.
- The actual Browser builtin manifest resolves to `native-webview` and therefore drives the native path on desktop.
- Per-platform embedding targets (desktop WebContentsView/OOPIF, iOS WKWebView + WKProcessPool, Android WebView) and the `separateRendererProcess` property.
- `resolveBuiltinSurfaceManifest` throws for path-predicate / manifest-less tabs.

```
bun run --cwd packages/ui test src/surface-embedding.test.ts src/builtin-tab-registry.test.ts src/surface-isolation.test.ts
Test Files  3 passed (3) · Tests  35 passed (35)
```

Typecheck of `packages/ui` reports only pre-existing failures in unrelated files (`todo.test.tsx`, `immersive-fixture.ts`, `startup-phase-poll.test.ts`, `voice-selftest-harness.test.ts`) — none touched here. Biome clean on all changed files.

## Evidence

| Type | Status |
| --- | --- |
| Unit/behavior tests (real path, no mock) | ✅ 35 passing — the isolation selection *is* the behavior under test |
| Desktop OOPIF separate-renderer capture | N/A this session — electrobun cannot be booted in the sub-agent sandbox. The `<electrobun-webview renderer="cef">` OOPIF the view mounts is a separate renderer process by CEF's architecture; this PR only changes which manifest condition routes to it (behavior for the Browser view is byte-identical: it still declares `native-webview`). |
| iOS `capture:ios-sim` / Android `capture:android-emu` | N/A this session — no simulator/emulator reachable in the sandbox. The mobile native `WKWebView`/`WebView` **runtime wiring** is a follow-up slice (the Browser workspace has no `ios`/`android` mode today); `NATIVE_WEBVIEW_EMBEDDINGS` encodes the per-platform target the mobile shell embeds against, and the resolver + selection test are in place for it. |
| Before/after screenshots | N/A — no pixel change; the Browser view renders the identical native OOPIF, now manifest-gated. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
