### PR TITLE
fix(orchestrator): reclaim ACP commit locks safely

### DIFF
--- a/.github/issue-evidence/14245-acp-commit-lock-heartbeat.md
+++ b/.github/issue-evidence/14245-acp-commit-lock-heartbeat.md
@@ -1,0 +1,38 @@
+# 14245 ACP commit-lock heartbeat
+
+Date: 2026-07-05
+
+## What changed
+
+- Kept the detached commit-lock heartbeat child alive by leaving its own interval referenced. The parent still `unref()`s the detached child, so the wrapper process is not kept alive after release.
+- Added a regression in `acp-git-commit-race.test.ts` where session A owns the real commit lock and sleeps in a pre-commit hook for longer than `ACP_COMMIT_LOCK_STALE_MS`, while session B attempts to commit in the same worktree. Both commits must land linearly and preserve both staged file sets.
+
+## Verification
+
+```bash
+bun run --cwd plugins/plugin-agent-orchestrator test -- src/__tests__/acp-git-commit-race.test.ts
+```
+
+Result: passed. Vitest reported `1 passed` test file and `5 passed` tests.
+
+```bash
+bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts
+```
+
+Result: passed. Biome reported `Checked 2 files in 61ms. No fixes applied.`
+
+## Non-applicable evidence
+
+- UI screenshots/video: N/A - ACP git wrapper behavior has no UI surface.
+- Live-LLM trajectory: N/A - this fix is deterministic git wrapper concurrency behavior, not agent model/action selection.
+- Backend/frontend logs: N/A - the regression drives the real generated git wrapper against a real git repository and asserts the resulting git history/tree.
+
+## Blocker observed
+
+Direct root-level Bun test invocation did not reach the test body:
+
+```bash
+bun test plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts
+```
+
+Result: failed before tests with `SyntaxError: export 'syncBrandEnvToEliza' not found in '@elizaos/core'`. The package-local Vitest command above is the passing focused verification for this plugin.

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts
@@ -62,6 +62,10 @@ function gitAsync(
   });
 }
 
+function lockFile(repo: string): string {
+  return path.join(repo, ".git", "eliza-acp-commit.lock");
+}
+
 async function waitForFile(target: string, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -182,6 +186,81 @@ exit 0
       const parentCount = line.trim().split(/\s+/).filter(Boolean).length;
       expect(parentCount).toBeLessThanOrEqual(1);
     }
+  }, 30_000);
+
+  it("does not steal a live commit lock during a long critical section", async () => {
+    const service = new AcpService(makeRuntime(), {
+      store: new InMemorySessionStore(),
+    });
+    const prepare = (
+      service as unknown as GitIndexPreparer
+    ).prepareSessionGitIndex.bind(service);
+
+    const baselineSha = git(repo, ["rev-parse", "HEAD"]);
+    const sessionA = await prepare(repo, "sess-live-owner-a", baselineSha);
+    const sessionB = await prepare(repo, "sess-live-owner-b", baselineSha);
+    expect(sessionA?.env.GIT_INDEX_FILE).toBeTruthy();
+    expect(sessionB?.env.GIT_INDEX_FILE).toBeTruthy();
+
+    writeFileSync(path.join(repo, "live-a.txt"), "from live owner a\n");
+    writeFileSync(path.join(repo, "live-b.txt"), "from live owner b\n");
+    git(repo, ["add", "live-a.txt"], sessionA?.env);
+    git(repo, ["add", "live-b.txt"], sessionB?.env);
+
+    const signalFile = path.join(tmpRoot, "a-live-lock-precommit");
+    const hookPath = path.join(repo, ".git", "hooks", "pre-commit");
+    writeFileSync(
+      hookPath,
+      `#!/bin/sh
+if [ "$ACP_TEST_ROLE" = "A" ]; then
+  : > "${signalFile}"
+  sleep 0.8
+fi
+exit 0
+`,
+    );
+    chmodSync(hookPath, 0o755);
+
+    const lockRaceEnv = {
+      ACP_COMMIT_LOCK_POLL_MS: "5",
+      ACP_COMMIT_LOCK_STALE_MS: "120",
+      ACP_COMMIT_LOCK_WAIT_MS: "5000",
+    };
+    const envA = {
+      ...process.env,
+      ...sessionA?.env,
+      ...lockRaceEnv,
+      ACP_TEST_ROLE: "A",
+    };
+    const envB = {
+      ...process.env,
+      ...sessionB?.env,
+      ...lockRaceEnv,
+      ACP_TEST_ROLE: "B",
+    };
+
+    const commitA = gitAsync(repo, ["commit", "-m", "live owner a"], envA);
+    await waitForFile(signalFile, 10_000);
+    const commitB = gitAsync(repo, ["commit", "-m", "live waiter b"], envB);
+
+    const [resultA, resultB] = await Promise.all([commitA, commitB]);
+    expect(resultA.code, `session a failed: ${resultA.stderr}`).toBe(0);
+    expect(resultB.code, `session b failed: ${resultB.stderr}`).toBe(0);
+
+    const tree = git(repo, ["ls-tree", "--name-only", "-r", "HEAD"]);
+    expect(tree.split("\n").filter(Boolean).sort()).toEqual([
+      "README.md",
+      "live-a.txt",
+      "live-b.txt",
+    ]);
+
+    expect(Number(git(repo, ["rev-list", "--count", "HEAD"]))).toBe(3);
+    const parents = git(repo, ["log", "--pretty=%P", "HEAD"]).split("\n");
+    for (const line of parents) {
+      const parentCount = line.trim().split(/\s+/).filter(Boolean).length;
+      expect(parentCount).toBeLessThanOrEqual(1);
+    }
+    expect(existsSync(lockFile(repo))).toBe(false);
   }, 30_000);
 
   it("reclaims a stale commit lock without leaving reclaim artifacts", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -264,7 +264,7 @@ const ACP_METADATA_GIT_WRAPPER_DIR = "gitWrapperDir";
 const MAX_CAPTURED_TOOL_OUTPUT_CHARS = 12_000;
 const TOOL_OUTPUT_END_MARKER = "[/tool output]";
 const SESSION_GIT_WRAPPER = `#!/usr/bin/env node
-const { spawnSync } = require("node:child_process");
+const { spawn, spawnSync } = require("node:child_process");
 const { randomUUID } = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
@@ -310,8 +310,8 @@ function run(argv, opts = {}) {
 // processes with an exclusive lockfile in the worktree's own git dir (where HEAD
 // lives), so isolated worktrees — which have distinct git dirs and HEADs — never
 // contend, while shared ones can't interleave.
-const LOCK_POLL_MS = 25;
-const LOCK_WAIT_MS = 120000;
+const LOCK_POLL_MS = Number.parseInt(process.env.ACP_COMMIT_LOCK_POLL_MS || "25", 10);
+const LOCK_WAIT_MS = Number.parseInt(process.env.ACP_COMMIT_LOCK_WAIT_MS || "120000", 10);
 // A lock becomes reclaimable once its mtime is older than this. It sits below
 // LOCK_WAIT_MS so a crashed holder whose PID was recycled to an unrelated live
 // process is reclaimed by a waiter before that waiter's acquire deadline (#14202)
@@ -319,7 +319,7 @@ const LOCK_WAIT_MS = 120000;
 // well above the interval at which a live holder refreshes mtime via lock.verify()
 // (each read-tree/apply/commit boundary), so a legitimately long commit is never
 // falsely reclaimed.
-const LOCK_STALE_MS = 30000;
+const LOCK_STALE_MS = Number.parseInt(process.env.ACP_COMMIT_LOCK_STALE_MS || "30000", 10);
 function sleepSync(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
@@ -370,6 +370,33 @@ function lockIsStale(lockPath) {
   }
   return mtimeStale ? lock : undefined;
 }
+function startLockHeartbeat(lockPath, expected) {
+  const interval = Math.max(10, Math.min(1000, Math.floor(LOCK_STALE_MS / 4)));
+  const script = [
+    "const fs=require('node:fs');",
+    "const lockPath=process.argv[1];",
+    "const parentPid=Number(process.argv[2]);",
+    "const token=process.argv[3];",
+    "const interval=Number(process.argv[4]);",
+    "function alive(pid){try{process.kill(pid,0);return true;}catch(err){return err.code==='EPERM';}}",
+    "function tick(){",
+    " if(!alive(parentPid)) process.exit(0);",
+    " let owner;",
+    " try{owner=JSON.parse(fs.readFileSync(lockPath,'utf8'));}catch{process.exit(0);}",
+    " if(!owner||owner.pid!==parentPid||owner.token!==token) process.exit(0);",
+    " const now=new Date();",
+    " try{fs.utimesSync(lockPath,now,now);}catch{process.exit(0);}",
+    "}",
+    "tick();",
+    "setInterval(tick,interval);",
+  ].join("");
+  const child = spawn(process.execPath, ["-e", script, lockPath, String(expected.pid), expected.token, String(interval)], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+  return child;
+}
 function stealStaleLock(lockPath, staleRaw) {
   const claimPath = lockPath + ".stale-" + process.pid + "-" + randomUUID();
   try {
@@ -406,7 +433,8 @@ function resolveGitDir(prefix) {
 function acquireCommitLock(gitDir) {
   const lockPath = path.join(gitDir, "eliza-acp-commit.lock");
   const token = process.pid + ":" + randomUUID();
-  const owner = JSON.stringify({ pid: process.pid, token, createdAt: Date.now() });
+  const ownerRecord = { pid: process.pid, token, createdAt: Date.now() };
+  const owner = JSON.stringify(ownerRecord);
   const deadline = Date.now() + LOCK_WAIT_MS;
   for (;;) {
     let fd;
@@ -423,6 +451,8 @@ function acquireCommitLock(gitDir) {
       continue;
     }
     fs.writeSync(fd, owner);
+    fs.fsyncSync(fd);
+    const heartbeat = startLockHeartbeat(lockPath, ownerRecord);
     let released = false;
     const owns = () => {
       const lock = readLock(lockPath);
@@ -435,6 +465,9 @@ function acquireCommitLock(gitDir) {
     const release = () => {
       if (released) return;
       released = true;
+      try {
+        heartbeat.kill();
+      } catch {}
       fs.closeSync(fd);
       if (owns()) fs.rmSync(lockPath, { force: true });
     };


### PR DESCRIPTION
## Summary
- Fixes #14202.
- Keeps ACP commit-lock stale reclaim compare-and-claim based instead of blind deletion.
- Treats an old mtime as stale even when the recorded PID is currently alive, while adding a heartbeat for legitimate live lock holders.
- Verifies lock ownership before each commit-window mutation and always releases the lock through `finally`.

## Evidence
- `git fetch origin && git rebase origin/develop` completed; conflicts in the ACP wrapper/tests were resolved onto current `origin/develop`.
- `bun run --cwd plugins/plugin-agent-orchestrator test src/__tests__/acp-git-commit-race.test.ts --run` - 1 file, 4 tests passed.
- `bun run --cwd plugins/plugin-agent-orchestrator test src/__tests__/acp-git-index-isolation.test.ts --run` - 1 file, 1 test passed.
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts` - passed.
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` - passed.
- `bun run --cwd plugins/plugin-agent-orchestrator build` - passed.

## Root verify note
- Attempted a workspace `bun install --no-save --ignore-scripts` in the isolated worktree before verification; it failed with `ENOSPC` after installing 1467 packages, so full root `bun run verify` was not run in this worktree. I freed the temporary install space and used the existing main checkout dependency install plus package-local builds for the focused verification above.

## PR Evidence Checklist
- Real-LLM trajectories: N/A - git wrapper lock behavior; no agent/model/prompt behavior changed.
- Backend logs: N/A - no server route/runtime logging path changed.
- Frontend screenshots/video/logs: N/A - no UI change.
- Domain artifacts: N/A - regression evidence is real git repository state asserted by focused tests.