### PR TITLE
fix(ci): annotate check-run triage CLI boundary

### DIFF
--- a/packages/scripts/gh-check-run-triage.mjs
+++ b/packages/scripts/gh-check-run-triage.mjs
@@ -235,6 +235,7 @@ async function main() {
 const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
 if (invokedPath === fileURLToPath(import.meta.url)) {
   main().catch((error) => {
+    // error-policy:J1 CLI boundary translates failures to stderr + exit status.
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;
   });


### PR DESCRIPTION
Follow-up to #14233. The merged helper has a CLI boundary `main().catch(...)`; this adds the required `error-policy:J1` annotation without changing behavior.

Validation:
- `bun test packages/scripts/__tests__/gh-check-run-triage.test.ts` (2 pass)
- `git diff --check origin/develop...HEAD -- packages/scripts/gh-check-run-triage.mjs packages/scripts/__tests__/gh-check-run-triage.test.ts`