### PR TITLE
fix(browser-extension): validate blocked-page redirect host

### DIFF
--- a/packages/browser-extension/entrypoints/blocked.ts
+++ b/packages/browser-extension/entrypoints/blocked.ts
@@ -4,7 +4,10 @@
  * and agent base from the query string, then polls the agent for the group's
  * required tasks and links back to LifeOps so the user can clear the block.
  */
-import { normalizeNavigableUrl } from "../src/url";
+import {
+  normalizeHostForComparison,
+  normalizeNavigableUrlForHost,
+} from "../src/url";
 
 const POLL_INTERVAL_MS = 30_000;
 
@@ -23,8 +26,11 @@ interface BlockedHostResponse {
 }
 
 const params = new URLSearchParams(window.location.search);
-const blockedUrl = params.get("url") || "Unknown site";
-const blockedHost = params.get("host") || blockedUrl;
+const blockedUrl = params.get("url");
+const blockedHost =
+  normalizeHostForComparison(params.get("host")) ??
+  normalizeHostForComparison(blockedUrl) ??
+  "Unknown site";
 const apiBase = normalizeApiBase(params.get("api"));
 
 const blockedSiteEl = document.getElementById("blockedSite");
@@ -120,7 +126,7 @@ async function loadBlockingReason(): Promise<void> {
 async function pollForUnblock(): Promise<void> {
   const data = await fetchBlockingReason();
   if (data && !data.blocked) {
-    const target = normalizeNavigableUrl(blockedUrl);
+    const target = normalizeNavigableUrlForHost(blockedUrl, blockedHost);
     if (target) {
       window.location.href = target;
     }

--- a/packages/browser-extension/src/url.test.ts
+++ b/packages/browser-extension/src/url.test.ts
@@ -4,9 +4,11 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+  normalizeHostForComparison,
   normalizeHttpBaseUrl,
   normalizeHttpOrigin,
   normalizeNavigableUrl,
+  normalizeNavigableUrlForHost,
 } from "./url";
 
 describe("normalizeHttpBaseUrl", () => {
@@ -69,19 +71,40 @@ describe("normalizeNavigableUrl", () => {
     expect(normalizeNavigableUrl("  news.example.com/top  ")).toBe(
       "https://news.example.com/top",
     );
+    expect(normalizeNavigableUrl("example.com:443/path")).toBe(
+      "https://example.com/path",
+    );
+    expect(normalizeNavigableUrl("localhost:3000/path")).toBe(
+      "https://localhost:3000/path",
+    );
   });
 
-  it("returns null for a javascript: payload so it never reaches location.href", () => {
+  it("returns null for explicit non-http schemes so they never reach location.href", () => {
     // The block interstitial's `?url=` query param is attacker-controllable;
-    // a `javascript:` scheme must not be force-prefixed into a navigable value.
-    expect(
-      normalizeNavigableUrl("javascript:alert(document.cookie)"),
-    ).toBeNull();
-    expect(normalizeNavigableUrl("JavaScript:alert(1)")).toBeNull();
-    expect(
-      normalizeNavigableUrl("data:text/html,<script>alert(1)</script>"),
-    ).toBeNull();
-    expect(normalizeNavigableUrl("vbscript:msgbox(1)")).toBeNull();
+    // explicit schemes must not be force-prefixed into navigable https URLs.
+    for (const value of [
+      "javascript:alert(document.cookie)",
+      "JavaScript:alert(1)",
+      "javascript:foo@evil.example",
+      "data:text/html,<script>alert(1)</script>",
+      "mailto:foo@example.com",
+      "file://evil.example/path",
+      "vbscript:msgbox(1)",
+      "httpx://not-really-http.example",
+      "//evil.example.com",
+    ]) {
+      expect(normalizeNavigableUrl(value)).toBeNull();
+    }
+  });
+
+  it("returns null for credentialed URLs", () => {
+    for (const value of [
+      "https://user:pass@example.com/path",
+      "http://user@example.com/path",
+      "user:pass@example.com/path",
+    ]) {
+      expect(normalizeNavigableUrl(value)).toBeNull();
+    }
   });
 
   it("returns null for empty or blank input", () => {
@@ -103,10 +126,42 @@ describe("normalizeNavigableUrl", () => {
       "//evil.example.com",
       "\tjavascript:alert(1)",
     ]) {
-      const result = normalizeNavigableUrl(value);
-      if (result !== null) {
-        expect(result).toMatch(/^https?:\/\//);
-      }
+      expect(normalizeNavigableUrl(value)).toBeNull();
     }
+  });
+});
+
+describe("normalizeNavigableUrlForHost", () => {
+  it("allows redirects only when the normalized URL host matches the polled host", () => {
+    expect(
+      normalizeNavigableUrlForHost(
+        "https://blocked.example/read",
+        "blocked.example",
+      ),
+    ).toBe("https://blocked.example/read");
+    expect(
+      normalizeNavigableUrlForHost(
+        "blocked.example:443/read",
+        "https://blocked.example",
+      ),
+    ).toBe("https://blocked.example/read");
+  });
+
+  it("rejects host/url mismatches from attacker-controlled blocked-page query params", () => {
+    expect(
+      normalizeNavigableUrlForHost("https://evil.example", "blocked.example"),
+    ).toBeNull();
+    expect(
+      normalizeNavigableUrlForHost(
+        "https://blocked.example.evil.example",
+        "blocked.example",
+      ),
+    ).toBeNull();
+  });
+
+  it("normalizes hosts to lowercase hostnames for comparison", () => {
+    expect(normalizeHostForComparison("HTTPS://Example.COM:443/path")).toBe(
+      "example.com",
+    );
   });
 });

--- a/packages/browser-extension/src/url.ts
+++ b/packages/browser-extension/src/url.ts
@@ -70,12 +70,29 @@ export function normalizeNavigableUrl(
   if (!trimmed) {
     return null;
   }
-  const candidate = /^https?:\/\//i.test(trimmed)
-    ? trimmed
-    : `https://${trimmed}`;
+  if (trimmed.startsWith("//")) {
+    return null;
+  }
+  const schemeMatch = /^([a-z][a-z0-9+.-]*):/i.exec(trimmed);
+  const scheme = schemeMatch?.[1]?.toLowerCase();
+  const afterSchemeColon = schemeMatch
+    ? trimmed.slice(schemeMatch[0].length)
+    : "";
+  const hostPortLike =
+    scheme !== undefined &&
+    (scheme.includes(".") || scheme === "localhost") &&
+    /^\d+(?:[/?#]|$)/.test(afterSchemeColon);
+  if (scheme && scheme !== "http" && scheme !== "https" && !hostPortLike) {
+    return null;
+  }
+  const candidate =
+    scheme === "http" || scheme === "https" ? trimmed : `https://${trimmed}`;
   try {
     const parsed = new URL(candidate);
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    if (parsed.username || parsed.password) {
       return null;
     }
     return parsed.toString();
@@ -83,4 +100,27 @@ export function normalizeNavigableUrl(
     // error-policy:J3 untrusted query-string input resolves to an explicit invalid navigation target.
     return null;
   }
+}
+
+export function normalizeHostForComparison(
+  value: string | null | undefined,
+): string | null {
+  const normalized = normalizeNavigableUrl(value);
+  if (!normalized) {
+    return null;
+  }
+  return new URL(normalized).hostname.toLowerCase();
+}
+
+export function normalizeNavigableUrlForHost(
+  value: string | null | undefined,
+  expectedHost: string | null | undefined,
+): string | null {
+  const target = normalizeNavigableUrl(value);
+  const host = normalizeHostForComparison(expectedHost);
+  if (!target || !host) {
+    return null;
+  }
+  const targetHost = new URL(target).hostname.toLowerCase();
+  return targetHost === host ? target : null;
 }


### PR DESCRIPTION
Follow-up to #14227 / #14235. The annotation-only fix merged, but the blocked-page redirect still needed the full sanitization repair called out in review.

## Summary
- reject explicit non-http(s) schemes before applying the scheme-less-host fallback
- reject credentialed navigable URLs
- reject protocol-relative blocked-page targets
- normalize the blocked host and require the redirect target host to match the host being polled for unblock
- add focused tests for explicit schemes, credentials, host:port fallback, and host/url mismatch

## Validation
- `bun run --cwd packages/browser-extension test:unit -- src/url.test.ts` — 13 pass
- `bunx @biomejs/biome check packages/browser-extension/src/url.ts packages/browser-extension/src/url.test.ts packages/browser-extension/entrypoints/blocked.ts`
- `git diff --check`