### PR TITLE
fix(ui): remove agents table residual comments

### DIFF
--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -887,9 +887,8 @@ export function ElizaAgentsTable({
   const deleteTargetBusy = (deleteIds ?? []).some((id) => poller.isActive(id));
 
   if (localSandboxes.length === 0) {
-    // Agent creation lives in the Eliza app now, not the console — so no
-    // create-agent action here (this table only lists/manages existing agents).
-    // TODO: once app.elizacloud.ai ships, make this a link that deep-links there.
+    // Agent creation lives in the Eliza app, not the console; this surface only
+    // lists and manages existing agents.
     return (
       <DataListEmptyState
         title={t("cloud.elizaAgentsTable.noAgentsYet", {
@@ -945,7 +944,7 @@ export function ElizaAgentsTable({
             }),
           }}
         />
-        {/* Search + filter + create */}
+        {/* Search and filter controls for the visible agent set. */}
         <div className="flex flex-col sm:flex-row gap-3">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted" />
@@ -1002,8 +1001,6 @@ export function ElizaAgentsTable({
               </SelectItem>
             </SelectContent>
           </Select>
-          {/* Agent creation moved to the Eliza app — no create button in the
-              console toolbar. TODO: deep-link to app.elizacloud.ai when it ships. */}
         </div>
 
         {(searchQuery || statusFilter !== "all") && (


### PR DESCRIPTION
## Summary
- Remove residual TODO/change-narration comments left in the agents table after #14234.
- Keep the durable rationale that agent creation belongs in the Eliza app while avoiding follow-up language in production code.

## Validation
- `bunx @biomejs/biome check packages/ui/src/cloud/instances/components/eliza-agents-table.tsx --no-errors-on-unmatched`
- `git diff --check origin/develop...HEAD`

Follow-up to #14234.