### PR TITLE
fix(orchestrator): protect git terminal env case-insensitively

### DIFF
--- a/.github/issue-evidence/13773-native-terminal-git-env.md
+++ b/.github/issue-evidence/13773-native-terminal-git-env.md
@@ -43,3 +43,28 @@ bun run --cwd plugins/plugin-agent-orchestrator typecheck
 No UI, browser, mobile, live-model, or screenshot evidence applies; this is a
 subprocess environment isolation fix covered by unit-level process-env
 assertions.
+
+## Follow-up: case-insensitive git env protection
+
+After #14238 merged, native terminal env protection was hardened to delete
+`GIT_INDEX_FILE`, `GIT_DIR`, and `GIT_WORK_TREE` case-insensitively before
+restoring the trusted session-owned `GIT_INDEX_FILE`. This covers Windows child
+process environments, where variable lookup is case-insensitive.
+
+Passed:
+
+```bash
+bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+# Test Files  1 passed (1)
+# Tests       21 passed (21)
+```
+
+```bash
+bunx biome check plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts .github/issue-evidence/13773-native-terminal-git-env.md
+# Checked 2 files. No fixes applied.
+```
+
+```bash
+git diff --check -- plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts .github/issue-evidence/13773-native-terminal-git-env.md
+# passed
+```

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -692,6 +692,9 @@ describe("NativeAcpClient terminal actions", () => {
           { name: "GIT_INDEX_FILE", value: "/tmp/attacker-index" },
           { name: "GIT_DIR", value: "/tmp/attacker-git-dir" },
           { name: "GIT_WORK_TREE", value: "/tmp/attacker-work-tree" },
+          { name: "git_index_file", value: "/tmp/lower-index" },
+          { name: "git_dir", value: "/tmp/lower-git-dir" },
+          { name: "Git_Work_Tree", value: "/tmp/mixed-work-tree" },
         ],
       },
     });
@@ -705,6 +708,9 @@ describe("NativeAcpClient terminal actions", () => {
     );
     expect(env).not.toHaveProperty("GIT_DIR");
     expect(env).not.toHaveProperty("GIT_WORK_TREE");
+    expect(env).not.toHaveProperty("git_index_file");
+    expect(env).not.toHaveProperty("git_dir");
+    expect(env).not.toHaveProperty("Git_Work_Tree");
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -766,8 +766,9 @@ function protectTerminalGitEnv(
   env: Record<string, string | undefined>,
   trusted: NodeJS.ProcessEnv | undefined,
 ): void {
-  for (const key of ["GIT_INDEX_FILE", "GIT_DIR", "GIT_WORK_TREE"]) {
-    delete env[key];
+  const protectedKeys = new Set(["GIT_INDEX_FILE", "GIT_DIR", "GIT_WORK_TREE"]);
+  for (const key of Object.keys(env)) {
+    if (protectedKeys.has(key.toUpperCase())) delete env[key];
   }
   if (typeof trusted?.GIT_INDEX_FILE === "string") {
     env.GIT_INDEX_FILE = trusted.GIT_INDEX_FILE;


### PR DESCRIPTION
## Summary
- harden native ACP terminal git env protection to delete protected keys case-insensitively before restoring the trusted session-owned `GIT_INDEX_FILE`
- cover lower/mixed-case `git_index_file`, `git_dir`, and `Git_Work_Tree` terminal env requests in the existing process-env unit test
- update #13773 evidence with the follow-up validation

## Validation
- `bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts` — 1 file / 21 tests passed
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts .github/issue-evidence/13773-native-terminal-git-env.md` — checked 2 files, no fixes applied
- `git diff --check origin/develop...HEAD -- plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts .github/issue-evidence/13773-native-terminal-git-env.md && git diff --check -- plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts .github/issue-evidence/13773-native-terminal-git-env.md`

## Evidence
- `.github/issue-evidence/13773-native-terminal-git-env.md`

## Notes
- Follow-up to #14238 for #13773.
- `bun install` is blocked in this sparse worktree because root `package.json` references workspace paths that are not materialized here, including `packages/security/soc2-verify`, `packages/benchmarks/lib`, `packages/cloud/api`, and `packages/test/cloud-e2e`.