### PR TITLE
fix(ui): remove agents table TODO comments

### DIFF
--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -887,9 +887,6 @@ export function ElizaAgentsTable({
   const deleteTargetBusy = (deleteIds ?? []).some((id) => poller.isActive(id));
 
   if (localSandboxes.length === 0) {
-    // Agent creation lives in the Eliza app now, not the console — so no
-    // create-agent action here (this table only lists/manages existing agents).
-    // TODO: once app.elizacloud.ai ships, make this a link that deep-links there.
     return (
       <DataListEmptyState
         title={t("cloud.elizaAgentsTable.noAgentsYet", {
@@ -945,7 +942,6 @@ export function ElizaAgentsTable({
             }),
           }}
         />
-        {/* Search + filter + create */}
         <div className="flex flex-col sm:flex-row gap-3">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted" />
@@ -1002,8 +998,6 @@ export function ElizaAgentsTable({
               </SelectItem>
             </SelectContent>
           </Select>
-          {/* Agent creation moved to the Eliza app — no create button in the
-              console toolbar. TODO: deep-link to app.elizacloud.ai when it ships. */}
         </div>
 
         {(searchQuery || statusFilter !== "all") && (


### PR DESCRIPTION
Follow-up to #14234. Removes the shipped TODO/comment-only blocker from the agents table without changing rendered behavior.

Validation:
- `bunx @biomejs/biome check packages/ui/src/cloud/instances/components/eliza-agents-table.tsx`
- `git diff --check -- packages/ui/src/cloud/instances/components/eliza-agents-table.tsx`
- `bun run audit:error-policy-ratchet`

Note: `bun run check:comment-only` is not usable for this exact JSX-comment removal in the current dirty workspace: it reports JSX comment tokens as code divergence and also notices the unrelated dirty `plugins/plugin-agent-orchestrator/vendor/opencode` submodule. The committed diff is limited to six deleted comments in one TSX file.