### PR TITLE
fix(ui): close surface realm residual leaks

### DIFF
--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -134,6 +134,45 @@ describe("host-external importer resolution (factory hostImport)", () => {
     expect(calls).toEqual(["first:/first", "second:/second"]);
     setActiveSurfaceRealmScope(null);
   });
+
+  it("wraps root @elizaos/ui navigation and storage exports through the active scope", async () => {
+    const calls: string[] = [];
+    const manifest = resolveSurfaceManifest({
+      surface: { capabilities: ["navigate"] },
+    });
+    const scope = new SurfaceRealmScope(
+      manifest,
+      "root.import.view",
+      window.localStorage,
+      (path) => calls.push(path),
+    );
+    const uiRoot = await resolveHostExternal("@elizaos/ui");
+    const navigateBrowserPath = uiRoot.navigateBrowserPath as (
+      path: string,
+    ) => void;
+    const getStorageValue = uiRoot.getStorageValue as (
+      key: string,
+    ) => Promise<string | null>;
+    const setStorageValue = uiRoot.setStorageValue as (
+      key: string,
+      value: string,
+    ) => Promise<void>;
+    const removeStorageValue = uiRoot.removeStorageValue as (
+      key: string,
+    ) => Promise<void>;
+
+    setActiveSurfaceRealmScope(scope);
+    navigateBrowserPath("/root-import");
+    await setStorageValue("root-key", "root-value");
+
+    expect(calls).toEqual(["/root-import"]);
+    expect(window.localStorage.getItem("root-key")).toBeNull();
+    expect(await getStorageValue("root-key")).toBe("root-value");
+
+    await removeStorageValue("root-key");
+    expect(await getStorageValue("root-key")).toBeNull();
+    setActiveSurfaceRealmScope(null);
+  }, 15_000);
 });
 
 const { sendWsMessage } = vi.hoisted(() => ({

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -172,7 +172,7 @@ describe("host-external importer resolution (factory hostImport)", () => {
     await removeStorageValue("root-key");
     expect(await getStorageValue("root-key")).toBeNull();
     setActiveSurfaceRealmScope(null);
-  }, 15_000);
+  }, 45_000);
 });
 
 const { sendWsMessage } = vi.hoisted(() => ({

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -7,6 +7,7 @@
 // asserting against a mock.
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { resolveSurfaceManifest } from "@elizaos/core";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { transform } from "esbuild";
 import { type ReactElement, useState } from "react";
@@ -16,6 +17,10 @@ import {
   type ModuleCacheTelemetryEvent,
 } from "../../cache-telemetry";
 import { APP_PAUSE_EVENT } from "../../events";
+import {
+  SurfaceRealmScope,
+  setActiveSurfaceRealmScope,
+} from "../../surface-realm-broker";
 import {
   __resetDynamicViewLoaderCacheForTests,
   DynamicViewLoader,
@@ -95,6 +100,40 @@ describe("host-external importer resolution (factory hostImport)", () => {
       resolveHostExternal("@test/never-registered-external"),
     ).rejects.toThrow(/unsupported host external/);
   });
+
+  it("looks up the active surface realm scope when a cached host external is called", async () => {
+    const calls: string[] = [];
+    const manifest = resolveSurfaceManifest({
+      surface: { capabilities: ["navigate"] },
+    });
+    const firstScope = new SurfaceRealmScope(
+      manifest,
+      "first.view",
+      window.localStorage,
+      (path) => calls.push(`first:${path}`),
+    );
+    const secondScope = new SurfaceRealmScope(
+      manifest,
+      "second.view",
+      window.localStorage,
+      (path) => calls.push(`second:${path}`),
+    );
+
+    const appNavigateView = await resolveHostExternal(
+      "@elizaos/ui/app-navigate-view",
+    );
+    const navigateBrowserPath = appNavigateView.navigateBrowserPath as (
+      path: string,
+    ) => void;
+
+    setActiveSurfaceRealmScope(firstScope);
+    navigateBrowserPath("/first");
+    setActiveSurfaceRealmScope(secondScope);
+    navigateBrowserPath("/second");
+
+    expect(calls).toEqual(["first:/first", "second:/second"]);
+    setActiveSurfaceRealmScope(null);
+  });
 });
 
 const { sendWsMessage } = vi.hoisted(() => ({
@@ -123,6 +162,7 @@ describe("DynamicViewLoader", () => {
 
   afterEach(() => {
     delete window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__;
+    setActiveSurfaceRealmScope(null);
     sendWsMessage.mockClear();
     cleanup();
     __resetDynamicViewLoaderCacheForTests();

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -398,10 +398,10 @@ async function importUiAppNavigateViewCompat(): Promise<
   Record<string, unknown>
 > {
   const appNavigateView = await import("../../app-navigate-view.ts");
-  const scope = getActiveSurfaceRealmScope();
   return {
     ...appNavigateView,
     navigateBrowserPath(path: string): void {
+      const scope = getActiveSurfaceRealmScope();
       if (scope) {
         scope.navigate(path);
         return;
@@ -413,14 +413,15 @@ async function importUiAppNavigateViewCompat(): Promise<
 
 async function importUiBridgeCompat(): Promise<Record<string, unknown>> {
   const bridge = await import("../../bridge/index.ts");
-  const scope = getActiveSurfaceRealmScope();
   return {
     ...bridge,
     async getStorageValue(key: string): Promise<string | null> {
+      const scope = getActiveSurfaceRealmScope();
       if (scope) return scope.storage.getItem(key);
       return bridge.getStorageValue(key);
     },
     async setStorageValue(key: string, value: string): Promise<void> {
+      const scope = getActiveSurfaceRealmScope();
       if (scope) {
         scope.storage.setItem(key, value);
         return;
@@ -428,6 +429,7 @@ async function importUiBridgeCompat(): Promise<Record<string, unknown>> {
       await bridge.setStorageValue(key, value);
     },
     async removeStorageValue(key: string): Promise<void> {
+      const scope = getActiveSurfaceRealmScope();
       if (scope) {
         scope.storage.removeItem(key);
         return;
@@ -1421,9 +1423,17 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
   }
 
   const View = bundle.component;
+  const exitToApps = () => {
+    const scope = getActiveSurfaceRealmScope();
+    if (scope) {
+      scope.navigate("/views");
+      return;
+    }
+    navigateToViews();
+  };
   const viewProps = {
     ...forwardedViewProps,
-    exitToApps: navigateToViews,
+    exitToApps,
     t: (
       key: string,
       options?: { defaultValue?: string } | Record<string, unknown>,

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -391,7 +391,39 @@ async function importUiComponentsCompat(): Promise<Record<string, unknown>> {
 }
 
 async function importUiRootCompat(): Promise<Record<string, unknown>> {
-  return import("../../index.ts");
+  const uiRoot = await import("../../index.ts");
+  return {
+    ...uiRoot,
+    navigateBrowserPath(path: string): void {
+      const scope = getActiveSurfaceRealmScope();
+      if (scope) {
+        scope.navigate(path);
+        return;
+      }
+      uiRoot.navigateBrowserPath(path);
+    },
+    async getStorageValue(key: string): Promise<string | null> {
+      const scope = getActiveSurfaceRealmScope();
+      if (scope) return scope.storage.getItem(key);
+      return uiRoot.getStorageValue(key);
+    },
+    async setStorageValue(key: string, value: string): Promise<void> {
+      const scope = getActiveSurfaceRealmScope();
+      if (scope) {
+        scope.storage.setItem(key, value);
+        return;
+      }
+      await uiRoot.setStorageValue(key, value);
+    },
+    async removeStorageValue(key: string): Promise<void> {
+      const scope = getActiveSurfaceRealmScope();
+      if (scope) {
+        scope.storage.removeItem(key);
+        return;
+      }
+      await uiRoot.removeStorageValue(key);
+    },
+  };
 }
 
 async function importUiAppNavigateViewCompat(): Promise<

--- a/packages/ui/src/surface-realm-broker.test.tsx
+++ b/packages/ui/src/surface-realm-broker.test.tsx
@@ -233,6 +233,30 @@ describe("SurfaceRealmScope.resetHostRealm — root/body class + :root var vecto
     );
   });
 
+  it("restores non-shell baseline tokens a view deletes or mutates", () => {
+    document.documentElement.style.setProperty("--view-host-baseline", "blue");
+    document.documentElement.classList.add("pack-preset-a");
+    document.body.classList.add("host-layout-a");
+    const scope = makeScope();
+
+    document.documentElement.style.setProperty("--view-host-baseline", "red");
+    document.documentElement.classList.remove("pack-preset-a");
+    document.body.classList.remove("host-layout-a");
+
+    const reset = scope.resetHostRealm();
+
+    expect(
+      document.documentElement.style.getPropertyValue("--view-host-baseline"),
+    ).toBe("blue");
+    expect(document.documentElement.classList.contains("pack-preset-a")).toBe(
+      true,
+    );
+    expect(document.body.classList.contains("host-layout-a")).toBe(true);
+    expect(reset.rootVars).toContain("--view-host-baseline");
+    expect(reset.rootClasses).toContain("pack-preset-a");
+    expect(reset.bodyClasses).toContain("host-layout-a");
+  });
+
   it("preserves a theme class toggled ON while the view was active (shell writers stay allowed)", () => {
     document.documentElement.className = "light";
     const scope = makeScope();

--- a/packages/ui/src/surface-realm-broker.ts
+++ b/packages/ui/src/surface-realm-broker.ts
@@ -281,7 +281,7 @@ export class SurfaceRealmScope {
   readonly navigate: (path: string) => void;
   private readonly rootClassBaseline: ReadonlySet<string>;
   private readonly bodyClassBaseline: ReadonlySet<string>;
-  private readonly rootVarBaseline: ReadonlySet<string>;
+  private readonly rootVarBaseline: ReadonlyMap<string, string>;
 
   constructor(
     readonly manifest: ResolvedSurfaceManifest,
@@ -294,12 +294,15 @@ export class SurfaceRealmScope {
     if (typeof document === "undefined") {
       this.rootClassBaseline = new Set();
       this.bodyClassBaseline = new Set();
-      this.rootVarBaseline = new Set();
+      this.rootVarBaseline = new Map();
     } else {
       this.rootClassBaseline = new Set(document.documentElement.classList);
       this.bodyClassBaseline = new Set(document.body.classList);
-      this.rootVarBaseline = new Set(
-        readRootVarNames(document.documentElement),
+      this.rootVarBaseline = new Map(
+        readRootVarNames(document.documentElement).map((name) => [
+          name,
+          document.documentElement.style.getPropertyValue(name),
+        ]),
       );
     }
   }
@@ -330,9 +333,25 @@ export class SurfaceRealmScope {
       body.classList.remove(cls);
       result.bodyClasses.push(cls);
     }
+    for (const cls of this.rootClassBaseline) {
+      if (isShellOwnedRootClass(cls) || root.classList.contains(cls)) continue;
+      root.classList.add(cls);
+      result.rootClasses.push(cls);
+    }
+    for (const cls of this.bodyClassBaseline) {
+      if (isShellOwnedBodyClass(cls) || body.classList.contains(cls)) continue;
+      body.classList.add(cls);
+      result.bodyClasses.push(cls);
+    }
     for (const name of readRootVarNames(root)) {
       if (isShellOwnedRootVar(name) || this.rootVarBaseline.has(name)) continue;
       root.style.removeProperty(name);
+      result.rootVars.push(name);
+    }
+    for (const [name, value] of this.rootVarBaseline) {
+      if (isShellOwnedRootVar(name)) continue;
+      if (root.style.getPropertyValue(name) === value) continue;
+      root.style.setProperty(name, value);
       result.rootVars.push(name);
     }
     return result;


### PR DESCRIPTION
## Summary
- Restore non-shell baseline root/body classes and root CSS variable values when an in-process view deletes or mutates them during its lifetime.
- Keep #14288's shell-owned token restoration while adding the missing non-shell baseline restoration.
- Make host-external navigate/storage wrappers resolve `getActiveSurfaceRealmScope()` at call time, so cached bundle modules cannot retain a stale/null scope.
- Route `exitToApps` through the active surface realm navigate grant before falling back to the raw shell navigation helper.
- Add focused regression tests for baseline restoration and cached host-external scope lookup.

Fix-forward for #14179 / #14237 after #14288 merged without the call-time scope and `exitToApps` fixes.

## Verification
```bash
bun run install:light
bun run --cwd packages/cloud/routing build
node packages/shared/scripts/generate-keywords.mjs --target ts
```
Result: prepared the temp worktree test dependencies and generated inputs.

```bash
bun run --cwd packages/ui test src/surface-realm-broker.test.tsx --run
```
Result: 16 pass, 0 fail.

```bash
bun run --cwd packages/ui test src/components/views/DynamicViewLoader.test.tsx --run -t "host-external importer resolution"
```
Result: 5 pass, 23 skipped, 0 fail.

```bash
bunx @biomejs/biome check packages/ui/src/surface-realm-broker.ts packages/ui/src/surface-realm-broker.test.tsx packages/ui/src/components/views/DynamicViewLoader.tsx packages/ui/src/components/views/DynamicViewLoader.test.tsx
```
Result: checked 4 files, no fixes applied.

```bash
git diff --check origin/develop...HEAD
```
Result: pass.

## Known unrelated test drift
```bash
bun run --cwd packages/ui test src/surface-realm-broker.test.tsx src/components/views/DynamicViewLoader.test.tsx --run
```
Result: `surface-realm-broker.test.tsx` passed, but the full `DynamicViewLoader.test.tsx` suite had 9 existing interaction-capability failures after current `develop`'s agent-surface gating changes. The host-external group added/covered by this PR passes.

## Evidence still needed
- `bun run --cwd packages/app audit:app` / app visual evidence for shared UI behavior remains required before final merge.