### PR TITLE
fix(ui): restore agents create handoff

### DIFF
--- a/.github/issue-evidence/14234-agents-create-link.txt
+++ b/.github/issue-evidence/14234-agents-create-link.txt
@@ -1,0 +1,24 @@
+Issue: #14234 follow-up
+PR: pending at capture time
+
+Scope reviewed:
+- packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+- packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx
+
+Manual review:
+- Confirmed the merged Agents page empty state removed the create/open action and left TODO comments.
+- Restored a visible "Open Eliza app" action in the zero-agent empty state.
+- Added the same action to the non-empty toolbar so the create path remains available after agents exist.
+- Confirmed no TODO comments remain in the touched table component for this create-path handoff.
+
+Verification:
+- node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+- bunx @biomejs/biome check packages/ui/src/cloud/instances/components/eliza-agents-table.tsx packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx --write --no-errors-on-unmatched
+- bun run --cwd packages/ui test src/cloud/instances/components/eliza-agents-table.render.test.tsx
+
+Focused test result:
+- Test Files: 1 passed
+- Tests: 6 passed
+
+Evidence gaps:
+- Full rendered app audit/screenshot/video evidence is still required before merge because this is a UI change in a shared UI package.

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx
@@ -1,11 +1,24 @@
+// @vitest-environment jsdom
+
 /**
  * ElizaAgentsTable per-row view model (#13916): the desktop table and mobile
  * card render one derived row, so the shared derivation owns runtime labels,
  * action availability, and Web UI reachability.
  */
 
-import { describe, expect, it, vi } from "vitest";
-import { deriveAgentRow, type ElizaAgentRow } from "./eliza-agents-table";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  deriveAgentRow,
+  type ElizaAgentRow,
+  ElizaAgentsTable,
+} from "./eliza-agents-table";
+
+vi.mock("../lib/i18n", () => ({
+  useT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+}));
 
 function row(overrides: Partial<ElizaAgentRow>): ElizaAgentRow {
   return {
@@ -58,6 +71,10 @@ function derive(
 }
 
 describe("ElizaAgentsTable per-row view model", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it("marks a running cloud sandbox as stoppable with standalone Web UI access", () => {
     const vm = derive({ status: "running" });
 
@@ -116,5 +133,28 @@ describe("ElizaAgentsTable per-row view model", () => {
     expect(vm.busy).toBe(true);
     expect(vm.canStart).toBe(false);
     expect(vm.canStop).toBe(false);
+  });
+
+  it("keeps the empty Agents page connected to the Eliza app create flow", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ElizaAgentsTable sandboxes={[]} />
+      </QueryClientProvider>,
+    );
+
+    const links = screen.getAllByRole("link", { name: "Open Eliza app" });
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    for (const link of links) {
+      expect(link.getAttribute("href")).toBe("https://app.elizacloud.ai");
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noreferrer");
+    }
   });
 });

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -160,6 +160,7 @@ function mergeSandboxRow(
  * that a delete that never took only hides the billed agent for ~a minute.
  */
 const TOMBSTONE_GRACE_MS = 60_000;
+const ELIZA_APP_AGENT_CREATE_URL = "https://app.elizacloud.ai";
 
 /**
  * Retire delete-tombstones by TIME only — the single retirement clock for both
@@ -898,6 +899,20 @@ export function ElizaAgentsTable({
           defaultValue: "Create and manage agents from the Eliza app.",
         })}
         icon={Boxes}
+        action={
+          <Button asChild size="sm">
+            <a
+              href={ELIZA_APP_AGENT_CREATE_URL}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <ExternalLink className="h-4 w-4" />
+              {t("cloud.elizaAgentsTable.openElizaApp", {
+                defaultValue: "Open Eliza app",
+              })}
+            </a>
+          </Button>
+        }
       />
     );
   }
@@ -1001,6 +1016,18 @@ export function ElizaAgentsTable({
               </SelectItem>
             </SelectContent>
           </Select>
+          <Button asChild size="sm" className="h-9">
+            <a
+              href={ELIZA_APP_AGENT_CREATE_URL}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <ExternalLink className="h-4 w-4" />
+              {t("cloud.elizaAgentsTable.openElizaApp", {
+                defaultValue: "Open Eliza app",
+              })}
+            </a>
+          </Button>
         </div>
 
         {(searchQuery || statusFilter !== "all") && (


### PR DESCRIPTION
## Summary
- Restores the Agents empty-state action that hands users to the Eliza app create flow.
- Adds the same handoff to the table toolbar for non-empty lists.
- Covers the empty-state link with a rendered component regression test.

## Evidence
| Requirement | Status | Evidence |
| --- | --- | --- |
| Focused tests | Passed | `bun run --cwd packages/ui test src/cloud/instances/components/eliza-agents-table.render.test.tsx` — 1 file, 6 tests passed |
| Formatting | Passed | `bunx @biomejs/biome check packages/ui/src/cloud/instances/components/eliza-agents-table.tsx packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx --write --no-errors-on-unmatched` |
| Manual review | Done | `.github/issue-evidence/14234-agents-create-link.txt` |
| Screenshots / app audit | Missing | Draft blocker: this shared UI change still needs full rendered evidence before merge. |
| Logs / trajectories | N/A | UI-only link restoration; no backend, prompt, model, or trajectory path changes. |
