### PR TITLE
test(#13571): pin iOS boot-gate harness fixes

### DIFF
--- a/.github/issue-evidence/13571-ios-boot-gate-regression-tests.md
+++ b/.github/issue-evidence/13571-ios-boot-gate-regression-tests.md
@@ -1,0 +1,43 @@
+# #13571 iOS Boot Gate Regression Tests
+
+Follow-up after #14200. That PR fixed the Xcode 26 simulator boot-gate
+breakage, but its post-merge review noted two harness fixes were not pinned by
+focused regression tests:
+
+- `simctl listapps <udid>` plist/bundle-presence proof
+- `--strict-gate` bypass of the full XCUITest coverage guard
+
+This change extracts those decisions into pure helpers and covers them in
+`packages/app/scripts/ios-device-lib.test.mjs`.
+
+## Checks
+
+```bash
+bun run --cwd packages/app test -- scripts/ios-device-lib.test.mjs
+```
+
+Result: pass, 1 file / 97 tests.
+
+```bash
+bunx biome check \
+  packages/app/scripts/ios-device-lib.mjs \
+  packages/app/scripts/ios-device-lib.test.mjs \
+  packages/app/scripts/ios-device-capture.mjs
+```
+
+Result: pass.
+
+```bash
+node --check packages/app/scripts/ios-device-lib.mjs
+node --check packages/app/scripts/ios-device-capture.mjs
+git diff --check
+```
+
+Result: pass.
+
+## Remaining Evidence
+
+This does not provide the missing real simulator screenshot/video/xcresult
+artifacts from #14200. Those still require a macOS/Xcode simulator host with the
+app built and installed. This patch only closes the code-level regression-test
+residual called out after #14200 merged.

--- a/packages/app/scripts/ios-device-capture.mjs
+++ b/packages/app/scripts/ios-device-capture.mjs
@@ -45,6 +45,7 @@ import {
   assertDeviceUnlocked,
   buildIosXcuitestShardPlan,
   buildPlistXml,
+  buildSimctlListappsArgs,
   classifyCodesignPreflight,
   classifyIsolatedReruns,
   classifyXcresultSummaryForGate,
@@ -54,6 +55,7 @@ import {
   extractXctestrunAppPaths,
   findDeviceRecord,
   findUncoveredIosXcuitestEntries,
+  hasBundleKeyInSimctlListappsOutput,
   isBenignIosAppAbsence,
   normalizeDeviceLockState,
   parseCliArgs,
@@ -63,6 +65,7 @@ import {
   resolveDeviceId,
   resolveXctestrunTestRoot,
   rewriteXctestrunUITargetApp,
+  shouldRunIosXcuitestCoverageGuard,
   sweepXctestrunDependentProductPaths,
 } from "./ios-device-lib.mjs";
 
@@ -771,13 +774,10 @@ async function main() {
     // the plist text instead of parsing it.
     const listappsRaw = runCaptureCommand(
       "xcrun",
-      ["simctl", "listapps", simUdid],
+      buildSimctlListappsArgs(simUdid),
       { label: `reset ${label}: listapps proof` },
     );
-    const bundleKey = new RegExp(
-      `"${bundleId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"\\s*=`,
-    );
-    if (!bundleKey.test(listappsRaw)) {
+    if (!hasBundleKeyInSimctlListappsOutput(listappsRaw, bundleId)) {
       fail(`reset ${label}: ${bundleId} missing from simctl listapps proof`);
     }
     return {
@@ -873,7 +873,12 @@ async function main() {
   // narrows the plan to the boot/chat health class (BootCaptureUITests) — a
   // boot gate is not a coverage gate — so it must not be rejected for "missing"
   // the gesture/widget/device-extension matrix it was never asked to run.
-  if (!args["only-testing"] && !strictGate) {
+  if (
+    shouldRunIosXcuitestCoverageGuard({
+      onlyTesting: args["only-testing"],
+      strictGate,
+    })
+  ) {
     const uncovered = findUncoveredIosXcuitestEntries({
       entries: extractSwiftXcuitestEntries(collectAppUITestsSources()),
       shards: shardPlan.map((shard) => shard.identifier),

--- a/packages/app/scripts/ios-device-lib.mjs
+++ b/packages/app/scripts/ios-device-lib.mjs
@@ -920,6 +920,25 @@ export function findUncoveredIosXcuitestEntries({ entries, shards }) {
   return uncovered;
 }
 
+export function shouldRunIosXcuitestCoverageGuard({
+  onlyTesting = null,
+  strictGate = false,
+} = {}) {
+  return !onlyTesting && !strictGate;
+}
+
+export function buildSimctlListappsArgs(simUdid) {
+  return ["simctl", "listapps", simUdid];
+}
+
+export function hasBundleKeyInSimctlListappsOutput(output, bundleId) {
+  if (typeof output !== "string" || typeof bundleId !== "string") {
+    return false;
+  }
+  const escapedBundleId = bundleId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`"${escapedBundleId}"\\s*=`).test(output);
+}
+
 export function isBenignIosAppAbsence(output) {
   // simctl reports an absent app differently per verb: uninstall/get-container
   // say "not installed"/"could not find", while `terminate` against an app that

--- a/packages/app/scripts/ios-device-lib.test.mjs
+++ b/packages/app/scripts/ios-device-lib.test.mjs
@@ -20,6 +20,7 @@ import {
   buildIosXcuitestShardPlan,
   buildOnlyTestingIdentifier,
   buildPlistXml,
+  buildSimctlListappsArgs,
   CONSOLE_SIGTRAP_SIGNATURE,
   classifyCodesignPreflight,
   classifyConsoleExit,
@@ -33,6 +34,7 @@ import {
   findDeviceRecord,
   findUncoveredIosXcuitestEntries,
   formatDeviceUnlockWaitMessage,
+  hasBundleKeyInSimctlListappsOutput,
   isBenignIosAppAbsence,
   normalizeDeviceLockState,
   normalizeProvisioningProfile,
@@ -49,6 +51,7 @@ import {
   safeShardName,
   selectProvisioningProfile,
   selectSigningIdentity,
+  shouldRunIosXcuitestCoverageGuard,
   sweepXctestrunDependentProductPaths,
 } from "./ios-device-lib.mjs";
 
@@ -60,6 +63,12 @@ const CERT_SHA1 = crypto
   .update(CERT_DER)
   .digest("hex")
   .toUpperCase();
+
+function appScriptPath(scriptName) {
+  const packageRelative = path.join(process.cwd(), "scripts", scriptName);
+  if (fs.existsSync(packageRelative)) return packageRelative;
+  return path.join(process.cwd(), "packages/app/scripts", scriptName);
+}
 
 function profilePlist({
   name = "iOS Team Provisioning Profile: ai.elizaos.app",
@@ -759,7 +768,7 @@ describe("classifyXcresultSummaryForGate", () => {
 describe("ios-device-capture strict summary gate", () => {
   it("keeps test-summary classification behind --strict-gate", () => {
     const source = fs.readFileSync(
-      path.join(process.cwd(), "packages/app/scripts/ios-device-capture.mjs"),
+      appScriptPath("ios-device-capture.mjs"),
       "utf8",
     );
     const summaryWriteIndex = source.indexOf("test-summary.json");
@@ -773,6 +782,85 @@ describe("ios-device-capture strict summary gate", () => {
     );
     expect(strictGateIndex).toBeGreaterThan(summaryWriteIndex);
     expect(classifierIndex).toBeGreaterThan(strictGateIndex);
+  });
+});
+
+describe("iOS simulator listapps proof (#13571)", () => {
+  it("uses the Xcode 26 positional listapps form without the removed -j flag", () => {
+    expect(buildSimctlListappsArgs("SIM-UDID")).toEqual([
+      "simctl",
+      "listapps",
+      "SIM-UDID",
+    ]);
+    expect(buildSimctlListappsArgs("SIM-UDID")).not.toContain("-j");
+  });
+
+  it("matches bundle keys in simctl listapps plist output", () => {
+    const plist = `
+      {
+        "com.apple.Preferences" = {
+          ApplicationType = System;
+        };
+        "ai.elizaos.app" = {
+          ApplicationType = User;
+          CFBundleDisplayName = Eliza;
+        };
+      }
+    `;
+
+    expect(hasBundleKeyInSimctlListappsOutput(plist, "ai.elizaos.app")).toBe(
+      true,
+    );
+    expect(
+      hasBundleKeyInSimctlListappsOutput(plist, "ai.elizaos.missing"),
+    ).toBe(false);
+  });
+
+  it("escapes regex characters in bundle identifiers", () => {
+    const plist = `
+      {
+        "ai.elizaos.app.beta+qa" = {
+          ApplicationType = User;
+        };
+      }
+    `;
+
+    expect(
+      hasBundleKeyInSimctlListappsOutput(plist, "ai.elizaos.app.beta+qa"),
+    ).toBe(true);
+    expect(hasBundleKeyInSimctlListappsOutput(plist, "aiXelizaosXapp")).toBe(
+      false,
+    );
+  });
+});
+
+describe("iOS strict-gate coverage guard (#13571)", () => {
+  it("runs the coverage guard only for the default full AppUITests lane", () => {
+    expect(
+      shouldRunIosXcuitestCoverageGuard({
+        onlyTesting: null,
+        strictGate: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("skips the full-matrix coverage guard when strict-gate narrows to boot health", () => {
+    expect(
+      shouldRunIosXcuitestCoverageGuard({
+        onlyTesting: null,
+        strictGate: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("skips the default coverage guard for explicit only-testing shards", () => {
+    expect(
+      shouldRunIosXcuitestCoverageGuard({
+        onlyTesting:
+          "AppUITests/BootCaptureUITests/testBootReachesHomeOrErrorCard",
+        strictGate: false,
+      }),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up for #13571 after #14200. The Xcode 26 harness fixes were merged, but the post-merge review noted two code-level residuals were not pinned by focused tests. This extracts those decisions into pure helpers and adds regression coverage for them.

## What changed

- Added `buildSimctlListappsArgs()` and `hasBundleKeyInSimctlListappsOutput()` so the simulator listapps proof is covered without invoking `simctl`.
- Added `shouldRunIosXcuitestCoverageGuard()` so strict-gate coverage-guard behavior is explicitly tested.
- Wired `ios-device-capture.mjs` through those helpers.
- Added a small evidence note at `.github/issue-evidence/13571-ios-boot-gate-regression-tests.md`.

## Verification

- `bun run --cwd packages/app test -- scripts/ios-device-lib.test.mjs` - passed, 1 file / 97 tests.
- `bunx biome check packages/app/scripts/ios-device-lib.mjs packages/app/scripts/ios-device-lib.test.mjs packages/app/scripts/ios-device-capture.mjs` - passed.
- `node --check packages/app/scripts/ios-device-lib.mjs && node --check packages/app/scripts/ios-device-capture.mjs && git diff --check origin/develop...HEAD` - passed.
- `bun install --frozen-lockfile --ignore-scripts` - failed in this reused worktree because Bun wanted a lockfile update, but it made no worktree changes. No dependency/package files are part of this PR.

## Remaining evidence

This does not supply the missing real macOS/Xcode simulator screenshot/video/xcresult artifacts called out after #14200. It only closes the focused code-level regression-test residual that can be handled on this host.

Refs #13571.