### PR TITLE
feat(import): add content-addressed artifact policy

### DIFF
--- a/.github/issue-evidence/13432-import-artifact-policy.md
+++ b/.github/issue-evidence/13432-import-artifact-policy.md
@@ -1,0 +1,24 @@
+# Issue #13432 Import Artifact Policy Evidence
+
+## Change
+
+- Added `packages/import-conversations/src/core/artifacts.ts`.
+- The module builds deterministic content-addressed descriptors for import artifacts.
+- Storage keys are scoped by tenant, app, and import batch before the SHA-256 object name.
+- Raw uploads get short retention by default; longer raw retention requires an explicit reason.
+- Derived artifacts are marked for batch-lifecycle deletion.
+
+## Local verification
+
+- `bun run --cwd packages/import-conversations test -- src/core/artifacts.test.ts`
+- `bun run --cwd packages/import-conversations test` (14 files, 160 tests)
+- `bun run --cwd packages/import-conversations typecheck`
+- `bunx @biomejs/biome check packages/import-conversations/src/core/artifacts.ts packages/import-conversations/src/core/artifacts.test.ts packages/import-conversations/src/core/index.ts .github/issue-evidence/13432-import-artifact-policy.md --no-errors-on-unmatched`
+- `git diff --check`
+
+## Evidence matrix
+
+- Backend logs: N/A - pure importer-core policy primitive; no route or object-store write path changed.
+- Frontend screenshots/video: N/A - no UI changed.
+- Real-LLM trajectories: N/A - no agent/action/provider/prompt/model behavior changed.
+- Domain artifacts: content-addressed descriptor unit tests prove SHA-256 object naming, tenant/app/batch scoping, default raw-upload expiry, explicit raw-retain metadata, and derived batch-lifecycle metadata.

--- a/packages/import-conversations/src/core/artifacts.test.ts
+++ b/packages/import-conversations/src/core/artifacts.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildImportArtifactDescriptor,
+  DEFAULT_RAW_UPLOAD_RETENTION_MS,
+  importArtifactByteLength,
+  importArtifactExpired,
+  sha256Hex,
+} from "./artifacts.ts";
+
+const scope = {
+  tenantId: "tenant-a",
+  appId: "app-main",
+  batchId: "batch-2026-07-05",
+  source: "chatgpt" as const,
+};
+
+describe("import artifact descriptors", () => {
+  it("builds content-addressed tenant/app/batch storage keys", () => {
+    const descriptor = buildImportArtifactDescriptor({
+      kind: "derived-document",
+      scope,
+      contentType: "text/markdown",
+      bytes: "# hello",
+      extension: "md",
+    });
+
+    expect(descriptor.sha256).toBe(sha256Hex("# hello"));
+    expect(descriptor.byteLength).toBe(Buffer.byteLength("# hello", "utf8"));
+    expect(descriptor.storageKey).toBe(
+      `conversation-imports/tenant-a/apps/app-main/batches/batch-2026-07-05/derived-document/${descriptor.sha256}.md`,
+    );
+    expect(descriptor.retention).toEqual({
+      mode: "batch-lifecycle",
+      deleteWithBatch: true,
+    });
+  });
+
+  it("keeps the content address stable while scope changes the object key", () => {
+    const first = buildImportArtifactDescriptor({
+      kind: "derived-manifest",
+      scope,
+      contentType: "application/json",
+      bytes: "{}",
+      extension: "json",
+    });
+    const second = buildImportArtifactDescriptor({
+      kind: "derived-manifest",
+      scope: { ...scope, tenantId: "tenant-b" },
+      contentType: "application/json",
+      bytes: "{}",
+      extension: "json",
+    });
+
+    expect(first.sha256).toBe(second.sha256);
+    expect(first.storageKey).not.toBe(second.storageKey);
+    expect(second.storageKey).toContain("/tenant-b/apps/app-main/");
+  });
+
+  it("applies short retention to raw uploads by default", () => {
+    const now = Date.parse("2026-07-05T12:00:00Z");
+    const descriptor = buildImportArtifactDescriptor({
+      kind: "raw-upload",
+      scope,
+      contentType: "application/zip",
+      bytes: new Uint8Array([1, 2, 3]),
+      extension: "zip",
+      now: () => now,
+    });
+
+    expect(descriptor.retention).toEqual({
+      mode: "short-lived",
+      retentionMs: DEFAULT_RAW_UPLOAD_RETENTION_MS,
+      expiresAt: now + DEFAULT_RAW_UPLOAD_RETENTION_MS,
+    });
+    expect(importArtifactExpired(descriptor, now)).toBe(false);
+    expect(
+      importArtifactExpired(descriptor, now + DEFAULT_RAW_UPLOAD_RETENTION_MS),
+    ).toBe(true);
+  });
+
+  it("requires an explicit reason before raw uploads can be retained longer", () => {
+    expect(() =>
+      buildImportArtifactDescriptor({
+        kind: "raw-upload",
+        scope,
+        contentType: "application/json",
+        bytes: "{}",
+        rawRetention: { retainRawUpload: true },
+      }),
+    ).toThrow(/retainReason/);
+
+    const descriptor = buildImportArtifactDescriptor({
+      kind: "raw-upload",
+      scope,
+      contentType: "application/json",
+      bytes: "{}",
+      rawRetention: {
+        retainRawUpload: true,
+        retainReason: "user requested audit hold",
+      },
+    });
+
+    expect(descriptor.retention).toEqual({
+      mode: "explicit-raw-retain",
+      reason: "user requested audit hold",
+    });
+  });
+
+  it("honors caller-supplied short retention windows", () => {
+    const descriptor = buildImportArtifactDescriptor({
+      kind: "raw-upload",
+      scope,
+      contentType: "application/json",
+      bytes: "{}",
+      rawRetention: { retentionMs: 60_000 },
+      now: () => 1000,
+    });
+
+    expect(descriptor.retention).toEqual({
+      mode: "short-lived",
+      retentionMs: 60_000,
+      expiresAt: 61_000,
+    });
+  });
+
+  it("rejects unsafe scope and extension components instead of escaping keys", () => {
+    expect(() =>
+      buildImportArtifactDescriptor({
+        kind: "derived-document",
+        scope: { ...scope, tenantId: "../tenant" },
+        contentType: "text/markdown",
+        bytes: "hi",
+      }),
+    ).toThrow(/tenantId/);
+    expect(() =>
+      buildImportArtifactDescriptor({
+        kind: "derived-document",
+        scope,
+        contentType: "text/markdown",
+        bytes: "hi",
+        extension: "../md",
+      }),
+    ).toThrow(/extension/);
+  });
+
+  it("normalizes content type and UTF-8 byte length", () => {
+    const descriptor = buildImportArtifactDescriptor({
+      kind: "import-report",
+      scope,
+      contentType: " Application/JSON ",
+      bytes: "é",
+      extension: ".JSON",
+    });
+
+    expect(descriptor.contentType).toBe("application/json");
+    expect(descriptor.byteLength).toBe(2);
+    expect(importArtifactByteLength("é")).toBe(2);
+    expect(descriptor.storageKey.endsWith(".json")).toBe(true);
+  });
+});

--- a/packages/import-conversations/src/core/artifacts.test.ts
+++ b/packages/import-conversations/src/core/artifacts.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Pure artifact-policy tests for conversation imports. The harness stays
+ * in-memory so storage-key, retention, and content-addressing decisions remain
+ * deterministic before any cloud object store integration exists.
+ */
 import { describe, expect, it } from "vitest";
 import {
   buildImportArtifactDescriptor,

--- a/packages/import-conversations/src/core/artifacts.ts
+++ b/packages/import-conversations/src/core/artifacts.ts
@@ -1,0 +1,210 @@
+/**
+ * Content-addressed artifact descriptors for conversation imports.
+ *
+ * This is the pure policy layer for #13432's storage contract: raw uploads are
+ * short-lived by default, derived artifacts are content-addressed and tied to
+ * an import batch lifecycle, and every storage key is scoped by tenant/app/batch
+ * before any cloud object store is asked to write bytes.
+ */
+
+import { createHash } from "node:crypto";
+import type { ConversationSource } from "./types.ts";
+
+export const DEFAULT_RAW_UPLOAD_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type ImportArtifactKind =
+  | "raw-upload"
+  | "derived-document"
+  | "derived-manifest"
+  | "import-report";
+
+export interface ImportArtifactScope {
+  tenantId: string;
+  appId: string;
+  batchId: string;
+  source?: ConversationSource;
+}
+
+export type ImportArtifactRetention =
+  | {
+      mode: "short-lived";
+      retentionMs: number;
+      expiresAt: number;
+    }
+  | {
+      mode: "explicit-raw-retain";
+      reason: string;
+    }
+  | {
+      mode: "batch-lifecycle";
+      deleteWithBatch: true;
+    };
+
+export interface ImportArtifactDescriptor {
+  kind: ImportArtifactKind;
+  scope: ImportArtifactScope;
+  sha256: string;
+  byteLength: number;
+  contentType: string;
+  storageKey: string;
+  retention: ImportArtifactRetention;
+}
+
+export interface RawUploadRetentionOptions {
+  /**
+   * Override the default short retention window. The upload still expires unless
+   * `retainRawUpload` is set with an explicit reason.
+   */
+  retentionMs?: number;
+  /**
+   * Longer raw retention is intentionally explicit. A caller must provide a
+   * reason so the route/service log can show why raw user exports outlive the
+   * short default.
+   */
+  retainRawUpload?: boolean;
+  retainReason?: string;
+}
+
+export interface BuildImportArtifactDescriptorOptions {
+  kind: ImportArtifactKind;
+  scope: ImportArtifactScope;
+  contentType: string;
+  bytes: string | Uint8Array;
+  /** Optional storage-key suffix without a leading dot, for human inspection. */
+  extension?: string;
+  rawRetention?: RawUploadRetentionOptions;
+  /** Clock injection for deterministic tests. */
+  now?: () => number;
+}
+
+const SAFE_COMPONENT = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const SAFE_EXTENSION = /^[A-Za-z0-9][A-Za-z0-9_-]{0,15}$/;
+const DEFAULT_NOW = () => Date.now();
+
+export function sha256Hex(bytes: string | Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function importArtifactByteLength(bytes: string | Uint8Array): number {
+  return typeof bytes === "string"
+    ? Buffer.byteLength(bytes, "utf8")
+    : bytes.byteLength;
+}
+
+export function buildImportArtifactDescriptor(
+  options: BuildImportArtifactDescriptorOptions,
+): ImportArtifactDescriptor {
+  const scope = normalizeScope(options.scope);
+  const contentType = normalizeContentType(options.contentType);
+  const extension = normalizeExtension(options.extension);
+  const sha256 = sha256Hex(options.bytes);
+  const byteLength = importArtifactByteLength(options.bytes);
+  const suffix = extension ? `.${extension}` : "";
+  const storageKey = [
+    "conversation-imports",
+    scope.tenantId,
+    "apps",
+    scope.appId,
+    "batches",
+    scope.batchId,
+    options.kind,
+    `${sha256}${suffix}`,
+  ].join("/");
+
+  return {
+    kind: options.kind,
+    scope,
+    sha256,
+    byteLength,
+    contentType,
+    storageKey,
+    retention: retentionForKind(
+      options.kind,
+      options.rawRetention,
+      options.now ?? DEFAULT_NOW,
+    ),
+  };
+}
+
+export function importArtifactExpired(
+  descriptor: Pick<ImportArtifactDescriptor, "retention">,
+  atMs = Date.now(),
+): boolean {
+  return (
+    descriptor.retention.mode === "short-lived" &&
+    atMs >= descriptor.retention.expiresAt
+  );
+}
+
+function retentionForKind(
+  kind: ImportArtifactKind,
+  rawRetention: RawUploadRetentionOptions | undefined,
+  now: () => number,
+): ImportArtifactRetention {
+  if (kind !== "raw-upload") {
+    return { mode: "batch-lifecycle", deleteWithBatch: true };
+  }
+
+  if (rawRetention?.retainRawUpload) {
+    const reason = rawRetention.retainReason?.trim();
+    if (!reason) {
+      throw new Error(
+        "buildImportArtifactDescriptor: retainRawUpload requires a retainReason",
+      );
+    }
+    return { mode: "explicit-raw-retain", reason };
+  }
+
+  const retentionMs =
+    rawRetention?.retentionMs ?? DEFAULT_RAW_UPLOAD_RETENTION_MS;
+  if (!Number.isFinite(retentionMs) || retentionMs <= 0) {
+    throw new Error(
+      `buildImportArtifactDescriptor: raw retentionMs must be a positive finite number, got ${retentionMs}`,
+    );
+  }
+  return {
+    mode: "short-lived",
+    retentionMs,
+    expiresAt: now() + retentionMs,
+  };
+}
+
+function normalizeScope(scope: ImportArtifactScope): ImportArtifactScope {
+  return {
+    tenantId: safeComponent(scope.tenantId, "tenantId"),
+    appId: safeComponent(scope.appId, "appId"),
+    batchId: safeComponent(scope.batchId, "batchId"),
+    source: scope.source,
+  };
+}
+
+function normalizeContentType(contentType: string): string {
+  const trimmed = contentType.trim().toLowerCase();
+  if (!trimmed || /[\r\n]/.test(trimmed)) {
+    throw new Error(
+      "buildImportArtifactDescriptor: contentType must be a non-empty MIME type",
+    );
+  }
+  return trimmed;
+}
+
+function normalizeExtension(extension: string | undefined): string | undefined {
+  if (extension === undefined) return undefined;
+  const trimmed = extension.trim().replace(/^\./, "").toLowerCase();
+  if (!SAFE_EXTENSION.test(trimmed)) {
+    throw new Error(
+      `buildImportArtifactDescriptor: extension must be a safe suffix, got "${extension}"`,
+    );
+  }
+  return trimmed;
+}
+
+function safeComponent(value: string, field: string): string {
+  const trimmed = value.trim();
+  if (!SAFE_COMPONENT.test(trimmed)) {
+    throw new Error(
+      `buildImportArtifactDescriptor: ${field} must be a safe path component`,
+    );
+  }
+  return trimmed;
+}

--- a/packages/import-conversations/src/core/index.ts
+++ b/packages/import-conversations/src/core/index.ts
@@ -1,5 +1,6 @@
 /** Public barrel for the conversation-importer core (Track A). */
 
+export * from "./artifacts.ts";
 export * from "./manifest.ts";
 export * from "./pipeline.ts";
 export * from "./preflight.ts";


### PR DESCRIPTION
## Summary
- Add a pure importer-core artifact policy module for #13432.
- Build deterministic SHA-256 descriptors with tenant/app/batch-scoped object keys.
- Mark raw uploads short-lived by default, require an explicit reason for raw retention, and mark derived artifacts for batch-lifecycle deletion.

## Scope
This is only the content-addressed artifact/retention primitive. It does not add cloud routes, object-store writes, resumable chunk transport, #13431 UI integration, or batch-delete service wiring.

## Evidence
- `bun run --cwd packages/import-conversations test -- src/core/artifacts.test.ts` (7 passed)
- `bun run --cwd packages/import-conversations test` (14 files, 160 tests)
- `bun run --cwd packages/import-conversations typecheck`
- `bunx @biomejs/biome check packages/import-conversations/src/core/artifacts.ts packages/import-conversations/src/core/artifacts.test.ts packages/import-conversations/src/core/index.ts .github/issue-evidence/13432-import-artifact-policy.md --no-errors-on-unmatched`
- `git diff --check origin/develop...HEAD`

## PR evidence matrix
- Backend logs: N/A - pure importer-core policy primitive; no route or object-store write path changed.
- Frontend screenshots/video: N/A - no UI changed.
- Real-LLM trajectories: N/A - no agent/action/provider/prompt/model behavior changed.
- Domain artifacts: unit tests prove SHA-256 object naming, tenant/app/batch scoping, default raw-upload expiry, explicit raw-retain metadata, and derived batch-lifecycle metadata.