### PR TITLE
refactor(ui): remove dead NATIVE_WEBVIEW_EMBEDDINGS larp table (follow-up to #14181)

### DIFF
--- a/packages/ui/src/surface-embedding.test.ts
+++ b/packages/ui/src/surface-embedding.test.ts
@@ -5,21 +5,16 @@
  * selected IFF the resolved manifest declares `isolation: "native-webview"` on
  * the desktop shell, and can never be reached by any other isolation level on
  * any mode. Also pins the actual Browser builtin manifest to that level so its
- * tab renderer keeps selecting the native surface, and pins each platform's
- * native embedding target. Pure functions over static data — no runtime harness
- * needed; the isolation property under test is the selection itself.
+ * tab renderer keeps selecting the native surface. Pure functions over the
+ * isolation catalogue — no runtime harness needed; the isolation property under
+ * test is the selection itself.
  */
 
 import { SURFACE_ISOLATION_LEVELS } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import type { BrowserWorkspaceMode } from "./api/browser-contracts";
 import { resolveBuiltinSurfaceManifest } from "./builtin-tab-registry";
-import {
-  NATIVE_WEBVIEW_EMBEDDINGS,
-  NATIVE_WEBVIEW_PLATFORMS,
-  nativeWebviewEmbedding,
-  resolveBrowserTabRenderPath,
-} from "./surface-embedding";
+import { resolveBrowserTabRenderPath } from "./surface-embedding";
 
 const ALL_MODES: readonly BrowserWorkspaceMode[] = ["desktop", "web", "cloud"];
 
@@ -84,26 +79,5 @@ describe("Browser builtin manifest drives the native path", () => {
     expect(resolveBrowserTabRenderPath({ isolation, mode: "desktop" })).toBe(
       "native-child-webview",
     );
-  });
-});
-
-describe("native-webview per-platform embedding targets", () => {
-  it("every platform names its native primitive and runs a separate renderer process", () => {
-    for (const platform of NATIVE_WEBVIEW_PLATFORMS) {
-      const embedding = nativeWebviewEmbedding(platform);
-      expect(embedding.platform).toBe(platform);
-      expect(embedding.separateRendererProcess).toBe(true);
-      expect(embedding.primitive.length).toBeGreaterThan(0);
-      expect(embedding.storagePolicy.length).toBeGreaterThan(0);
-    }
-  });
-
-  it("desktop targets the WebContentsView/CEF OOPIF; iOS WKWebView; Android WebView", () => {
-    expect(NATIVE_WEBVIEW_EMBEDDINGS.desktop.primitive).toMatch(
-      /WebContentsView|OOPIF|out-of-process/i,
-    );
-    expect(NATIVE_WEBVIEW_EMBEDDINGS.ios.primitive).toMatch(/WKWebView/);
-    expect(NATIVE_WEBVIEW_EMBEDDINGS.ios.primitive).toMatch(/WKProcessPool/);
-    expect(NATIVE_WEBVIEW_EMBEDDINGS.android.primitive).toMatch(/WebView/);
   });
 });

--- a/packages/ui/src/surface-embedding.ts
+++ b/packages/ui/src/surface-embedding.ts
@@ -18,9 +18,12 @@
  * is the single decision point that selects it.
  *
  * Consumer: `packages/ui/src/components/pages/BrowserWorkspaceView.tsx` (the tab
- * render branch). The per-platform target table {@link NATIVE_WEBVIEW_EMBEDDINGS}
- * is the typed, greppable statement of which native primitive each platform uses
- * and its process/storage-sharing policy — read alongside the catalogue.
+ * render branch). Per-platform native targets (named by the catalogue): desktop
+ * Electron/Electrobun `WebContentsView` (CEF out-of-process frame, per-tab
+ * `persist:` partition) — wired today; iOS `WKWebView` on a dedicated
+ * `WKProcessPool` with its own `WKWebsiteDataStore`, and Android `WebView` with
+ * an out-of-process renderer — the mobile shell has no Browser view yet, so
+ * those degrade to `sandboxed-iframe` until the native mode lands (#14181).
  */
 
 import type { SurfaceIsolationLevel } from "@elizaos/core";
@@ -78,66 +81,4 @@ export function resolveBrowserTabRenderPath(input: {
   // both land here: a sandboxed, in-realm iframe. Third-party content is served
   // cross-origin so the sandbox is meaningful.
   return "sandboxed-iframe";
-}
-
-/** The platforms that provide a native child web-content surface. */
-export const NATIVE_WEBVIEW_PLATFORMS = ["desktop", "ios", "android"] as const;
-
-/** A platform that can host the `native-webview` embedding. */
-export type NativeWebviewPlatform = (typeof NATIVE_WEBVIEW_PLATFORMS)[number];
-
-/**
- * The native primitive + process/storage policy each platform uses to embed
- * `native-webview` content. The durable, typed answer to "what actually hosts
- * the Browser view's page content, and how isolated is it" per platform.
- */
-export interface NativeWebviewEmbedding {
-  readonly platform: NativeWebviewPlatform;
-  /** The native primitive that hosts the child web content. */
-  readonly primitive: string;
-  /**
-   * The defining property of this level: the embedded content runs in a
-   * renderer process distinct from the host shell's renderer, so its crash or
-   * heavy load cannot take down the shell and its realm is not shared.
-   */
-  readonly separateRendererProcess: true;
-  /** The web-storage sharing policy between the child surface and the host. */
-  readonly storagePolicy: string;
-}
-
-/**
- * The per-platform `native-webview` embedding target. Desktop is wired today
- * (the Browser view mounts the CEF OOPIF `<electrobun-webview renderer="cef">`
- * with a per-tab storage partition); iOS/Android name the native primitive and
- * process/storage policy the mobile shell embeds the Browser view with.
- */
-export const NATIVE_WEBVIEW_EMBEDDINGS: Readonly<
-  Record<NativeWebviewPlatform, NativeWebviewEmbedding>
-> = {
-  desktop: {
-    platform: "desktop",
-    primitive: "Electron/Electrobun WebContentsView (CEF out-of-process frame)",
-    separateRendererProcess: true,
-    storagePolicy: "per-tab persistent partition (persist:<tab-partition>)",
-  },
-  ios: {
-    platform: "ios",
-    primitive: "WKWebView backed by a dedicated WKProcessPool",
-    separateRendererProcess: true,
-    storagePolicy:
-      "own WKWebsiteDataStore, not shared with the app's host web view",
-  },
-  android: {
-    platform: "android",
-    primitive: "WebView with out-of-process renderer (renderer isolation)",
-    separateRendererProcess: true,
-    storagePolicy: "app-scoped WebView storage behind an isolated renderer",
-  },
-};
-
-/** The native embedding descriptor for a platform. */
-export function nativeWebviewEmbedding(
-  platform: NativeWebviewPlatform,
-): NativeWebviewEmbedding {
-  return NATIVE_WEBVIEW_EMBEDDINGS[platform];
 }


### PR DESCRIPTION
Follow-up cleanup to the merged #14181 (PR #14244). Review of that merge found a dead abstraction that shipped: the `NATIVE_WEBVIEW_EMBEDDINGS` per-platform descriptor table in `surface-embedding.ts`.

## What was wrong

- **Zero non-test consumers.** `resolveBrowserTabRenderPath` never reads the table, and `BrowserWorkspaceView.tsx` hardcodes `renderer="cef"` directly. `git grep` confirmed the only references outside the export site were its own test.
- **Self-referential / vacuously-green test.** Its test asserted the string constants matched regexes it defined and asserted `separateRendererProcess: true` for iOS/Android — surfaces **no code implements** (there is no mobile Browser view yet). Per the repo anti-vacuous-test doctrine that is larp: it proves a property of an embedding that does not exist.

## What this does

- Deletes `NATIVE_WEBVIEW_PLATFORMS`, `NativeWebviewPlatform`, `NativeWebviewEmbedding`, `NATIVE_WEBVIEW_EMBEDDINGS`, `nativeWebviewEmbedding` and the two tests that only exercised them.
- Folds the accurate per-platform target documentation (desktop `WebContentsView`/CEF OOPIF wired today; iOS `WKWebView`+`WKProcessPool`; Android OOP `WebView` — degrade to `sandboxed-iframe` until a mobile Browser mode lands) into the module header prose.
- **Keeps the one real, consumed export:** `resolveBrowserTabRenderPath` + `BrowserTabRenderPath`, and its genuine enforcement test — the exhaustive `SURFACE_ISOLATION_LEVELS x {desktop,web,cloud}` matrix proving no non-`native-webview` level can ever resolve to the separate-renderer native surface. Also keeps the real `resolveBuiltinSurfaceManifest` (throws loudly, no silent default).

## Verification

- `bun run --cwd packages/ui test src/surface-embedding.test.ts src/builtin-tab-registry.test.ts src/surface-isolation.test.ts` -> 3 files / **33 tests pass** (was 35; removed 2 larp tests).
- `bunx @biomejs/biome@2.5.1 check` on the 5 relevant files -> clean.
- `bun run --cwd packages/ui typecheck` -> only the 4 pre-existing unrelated failures; none are touched files.
- Rebased clean onto `origin/develop`.

## Evidence

- **N/A — no runtime/UI behavior change.** Pure dead-code deletion of an unconsumed export + its self-referential tests; the resolver, the render branch, and all runtime behavior are byte-identical.
- Desktop separate-renderer-process live proof and iOS/Android on-device evidence remain the follow-up work #14181's acceptance criteria call for (require booting electrobun / simulators; no mobile Browser mode exists yet). This PR removes a table that falsely *claimed* those platforms were done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)