### PR TITLE
fix(ui): resolve surface scope at bridge call time

### DIFF
--- a/.github/issue-evidence/14226-surface-realm-calltime-scope.txt
+++ b/.github/issue-evidence/14226-surface-realm-calltime-scope.txt
@@ -1,0 +1,27 @@
+Issue/PR: #14226 follow-up
+PR: pending at capture time
+
+Scope reviewed:
+- packages/ui/src/components/views/DynamicViewLoader.tsx
+- packages/ui/src/components/views/DynamicViewLoader.test.tsx
+
+Manual review:
+- Confirmed the merged host-external wrappers captured `getActiveSurfaceRealmScope()` once when `@elizaos/ui/app-navigate-view` or `@elizaos/ui/bridge` was imported.
+- Changed those wrappers to resolve the active scope inside each exported method call.
+- Added a regression that imports `@elizaos/ui/bridge` once, then publishes two different active scopes and verifies storage writes land in each view namespace instead of raw shell storage.
+
+Verification:
+- node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+- bunx @biomejs/biome check packages/ui/src/components/views/DynamicViewLoader.tsx packages/ui/src/components/views/DynamicViewLoader.test.tsx --write --no-errors-on-unmatched
+- bun run --cwd packages/ui test src/components/views/DynamicViewLoader.test.tsx -t "host-external importer resolution"
+
+Focused test result:
+- Test Files: 1 passed
+- Tests: 4 passed, 23 skipped
+
+Known unrelated failing verification:
+- bun run --cwd packages/ui test src/components/views/DynamicViewLoader.test.tsx
+- Result: 9 existing DynamicViewLoader interaction tests fail on agent-surface capability expectations in this develop snapshot. The new host-external importer group passes in isolation.
+
+Evidence gaps:
+- Full rendered app audit/screenshot/video evidence is still required before merge because this is a shared UI runtime isolation change.

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -7,6 +7,7 @@
 // asserting against a mock.
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { resolveSurfaceManifest } from "@elizaos/core";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { transform } from "esbuild";
 import { type ReactElement, useState } from "react";
@@ -17,11 +18,20 @@ import {
 } from "../../cache-telemetry";
 import { APP_PAUSE_EVENT } from "../../events";
 import {
+  SurfaceRealmScope,
+  setActiveSurfaceRealmScope,
+  surfaceViewStoragePrefix,
+} from "../../surface-realm-broker";
+import {
   __resetDynamicViewLoaderCacheForTests,
   DynamicViewLoader,
   hostImport,
   isSameOriginBundleUrl,
 } from "./DynamicViewLoader";
+
+const NO_SURFACE_GRANTS = resolveSurfaceManifest({
+  surface: { capabilities: [] },
+});
 
 describe("isSameOriginBundleUrl (view-bundle origin gate)", () => {
   it("accepts same-origin and root-relative /api/views bundle URLs", () => {
@@ -70,6 +80,11 @@ describe("host-external importer resolution (factory hostImport)", () => {
     specifier: string,
   ): Promise<Record<string, unknown>> => hostImport(specifier);
 
+  afterEach(() => {
+    setActiveSurfaceRealmScope(null);
+    window.localStorage.clear();
+  });
+
   it("consults an importer contributed through registerHostExternalImporter", async () => {
     const { registerHostExternalImporter } = await import(
       "../../app-shell-registry"
@@ -94,6 +109,46 @@ describe("host-external importer resolution (factory hostImport)", () => {
     await expect(
       resolveHostExternal("@test/never-registered-external"),
     ).rejects.toThrow(/unsupported host external/);
+  });
+
+  it("resolves the active view scope at host-bridge call time, not import time", async () => {
+    const bridge = await resolveHostExternal("@elizaos/ui/bridge");
+    const scopeA = new SurfaceRealmScope(
+      NO_SURFACE_GRANTS,
+      "view-a",
+      window.localStorage,
+      () => undefined,
+    );
+    const scopeB = new SurfaceRealmScope(
+      NO_SURFACE_GRANTS,
+      "view-b",
+      window.localStorage,
+      () => undefined,
+    );
+
+    setActiveSurfaceRealmScope(scopeA);
+    await (bridge.setStorageValue as (key: string, value: string) => void)(
+      "shared-key",
+      "a",
+    );
+
+    setActiveSurfaceRealmScope(scopeB);
+    await (bridge.setStorageValue as (key: string, value: string) => void)(
+      "shared-key",
+      "b",
+    );
+
+    expect(
+      window.localStorage.getItem(
+        `${surfaceViewStoragePrefix("view-a")}shared-key`,
+      ),
+    ).toBe("a");
+    expect(
+      window.localStorage.getItem(
+        `${surfaceViewStoragePrefix("view-b")}shared-key`,
+      ),
+    ).toBe("b");
+    expect(window.localStorage.getItem("shared-key")).toBeNull();
   });
 });
 
@@ -122,6 +177,8 @@ describe("DynamicViewLoader", () => {
   });
 
   afterEach(() => {
+    setActiveSurfaceRealmScope(null);
+    window.localStorage.clear();
     delete window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__;
     sendWsMessage.mockClear();
     cleanup();

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -397,10 +397,10 @@ async function importUiAppNavigateViewCompat(): Promise<
   Record<string, unknown>
 > {
   const appNavigateView = await import("../../app-navigate-view.ts");
-  const scope = getActiveSurfaceRealmScope();
   return {
     ...appNavigateView,
     navigateBrowserPath(path: string): void {
+      const scope = getActiveSurfaceRealmScope();
       if (scope) {
         scope.navigate(path);
         return;
@@ -412,14 +412,15 @@ async function importUiAppNavigateViewCompat(): Promise<
 
 async function importUiBridgeCompat(): Promise<Record<string, unknown>> {
   const bridge = await import("../../bridge/index.ts");
-  const scope = getActiveSurfaceRealmScope();
   return {
     ...bridge,
     async getStorageValue(key: string): Promise<string | null> {
+      const scope = getActiveSurfaceRealmScope();
       if (scope) return scope.storage.getItem(key);
       return bridge.getStorageValue(key);
     },
     async setStorageValue(key: string, value: string): Promise<void> {
+      const scope = getActiveSurfaceRealmScope();
       if (scope) {
         scope.storage.setItem(key, value);
         return;
@@ -427,6 +428,7 @@ async function importUiBridgeCompat(): Promise<Record<string, unknown>> {
       await bridge.setStorageValue(key, value);
     },
     async removeStorageValue(key: string): Promise<void> {
+      const scope = getActiveSurfaceRealmScope();
       if (scope) {
         scope.storage.removeItem(key);
         return;


### PR DESCRIPTION
## Summary
- Fixes one #14226 residual: host-external bridge/navigation wrappers now resolve the active surface realm scope when each method is called, not when the host external is first imported.
- Adds a focused regression that imports the bridge once and verifies subsequent calls route to two different active view scopes.

## Evidence
| Requirement | Status | Evidence |
| --- | --- | --- |
| Focused regression | Passed | `bun run --cwd packages/ui test src/components/views/DynamicViewLoader.test.tsx -t "host-external importer resolution"` — 1 file passed, 4 tests passed, 23 skipped |
| Formatting | Passed | `bunx @biomejs/biome check packages/ui/src/components/views/DynamicViewLoader.tsx packages/ui/src/components/views/DynamicViewLoader.test.tsx --write --no-errors-on-unmatched` |
| Manual review | Done | `.github/issue-evidence/14226-surface-realm-calltime-scope.txt` |
| Full DynamicViewLoader suite | Failing | Draft blocker: full `bun run --cwd packages/ui test src/components/views/DynamicViewLoader.test.tsx` still has 9 existing interaction/capability failures on this develop snapshot. |
| Screenshots / app audit | Missing | Draft blocker: shared UI runtime isolation change still needs rendered app evidence before merge. |
| Logs / trajectories | N/A | UI runtime isolation only; no backend, prompt, model, or trajectory path changes. |
