### PR TITLE
fix(cloud): repair steward-sync default-provisioning test stub (deterministic CI red)

### DIFF
--- a/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
@@ -93,10 +93,12 @@ mock.module("./services/api-keys", () => {
     apiKeysService: {
       listByOrganization: async () => [],
       create,
-      // Mirrors the real service method: resolves only once the (deferred)
-      // key create has completed, so the await-not-fire-and-forget proof
-      // below still measures the provisioning write itself.
-      ensureUserHasApiKey: async () => {
+      // Mirrors the real service method steward-sync now calls
+      // (provisionDefaultApiKey, renamed from ensureUserHasApiKey in
+      // df09d846faa): resolves only once the (deferred) key create has
+      // completed, so the await-not-fire-and-forget proof below still
+      // measures the provisioning write itself.
+      provisionDefaultApiKey: async () => {
         await create();
       },
     },

--- a/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
@@ -93,11 +93,9 @@ mock.module("./services/api-keys", () => {
     apiKeysService: {
       listByOrganization: async () => [],
       create,
-      // Mirrors the real service method steward-sync now calls
-      // (provisionDefaultApiKey, renamed from ensureUserHasApiKey in
-      // df09d846faa): resolves only once the (deferred) key create has
-      // completed, so the await-not-fire-and-forget proof below still
-      // measures the provisioning write itself.
+      // Mirrors steward-sync's default-key provisioner: resolves only once the
+      // deferred key create has completed, so the await-not-fire-and-forget
+      // proof below still measures the provisioning write itself.
       provisionDefaultApiKey: async () => {
         await create();
       },


### PR DESCRIPTION
## What

`df09d846faa` ("harden invite default api key provisioning", follow-up to #13989) renamed both steward-sync call sites `ensureUserHasApiKey` → `provisionDefaultApiKey`, but did not update the `api-keys` service stub in `steward-sync-default-provisioning.test.ts`. The stub still exposes `ensureUserHasApiKey`, so the code path under test (`steward-sync` default provisioning) hits `TypeError: apiKeysService.provisionDefaultApiKey is not a function`.

## Why it matters

`cloud-tests.yml` runs this file (`packages/scripts/test-cloud-run.mjs`, `bun test … --isolate`) with **no skip guard**, so it's a **deterministic red for the next cloud PR**. The tip's own CI run was cancelled/skipped, so it hasn't surfaced yet — this repairs it before it blocks anyone.

## Fix

One-line rename of the stub method to match what the product now calls. Product is intact and correct — the service still defines `ensureUserHasApiKey` (an error-swallowing wrapper used by `auth.ts`'s opportunistic self-heal) *and* `provisionDefaultApiKey` (the honest-failing method `steward-sync` calls). Only the test stub was stale.

## Verification (real, no mocks)

```
bun test packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
→ 1 pass / 0 fail / 7 expect() calls
```

The await-not-fire-and-forget proof still measures the provisioning write itself (stub resolves only after the deferred create completes).

Found by the [core-brain] launch-readiness regression sweep after Shaw's merge wave (#13406). Test-only; product behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
