### PR TITLE
test(#13689): assert chat history survives app relaunch

### DIFF
--- a/.github/issue-evidence/13689-relaunch-persistence/device-leg-and-verdict-logic.md
+++ b/.github/issue-evidence/13689-relaunch-persistence/device-leg-and-verdict-logic.md
@@ -1,0 +1,51 @@
+# #13689 — device relaunch-persistence leg + off-device verdict logic
+
+This complements the merged web/agent server-truth leg (see `README.md`, PR
+#14006, which extracted `restoreConversationsFromDb` and tested it against a real
+migrated PGlite DB). That covered item 4 (the agent-DB round trip). This adds the
+**Android on-device app-relaunch leg** (item 2 surface) and the **pure verdict
+logic** shared by every surface.
+
+## What this adds
+
+1. **`packages/app/scripts/lib/chat-history-persistence.mjs`** — the pure
+   accept/reject verdict for the relaunch-persistence property, verifiable
+   off-device so it can never false-green:
+   - `buildRelaunchMarker(...)` — a unique-per-run marker (`RELAUNCH-PERSIST-<platform>-<runId>-<ts>-<rand>`), so residue from a prior run (the exact `GestureSemanticsUITests` pollution the issue cites) cannot satisfy the check.
+   - `extractMessageTexts(body)` — fail-fast parse of the real `GET /api/conversations/:id/messages` body (`{ messages: [{ role, text }] }`). A malformed body **throws** (#9324 doctrine: THROW, never fabricate); only a well-formed `{ messages: [] }` is a legitimately empty thread.
+   - `assertMarkerSurvivedRelaunch({ marker, beforeBody, afterBody })` — asserts the marker reached server truth **before** relaunch (guards a broken send) and survived **after** relaunch. An empty/lost thread after relaunch (fresh state dir) throws `MARKER_LOST_ON_RELAUNCH` — the negative check the issue's "Done when" requires.
+
+2. **`--relaunch-persistence`** in `packages/app/scripts/mobile-local-chat-smoke.mjs`
+   (lane `test:sim:local-chat:android:relaunch-persistence`). After the verified
+   turn it: creates a fresh conversation → seeds the unique marker through the
+   real inference-free `/import` route (the main turn already proves the live
+   send+inference path; this leg isolates DB survival) → `GET /messages` (before)
+   → `am force-stop` + cold `am start` so `ElizaAgentService` re-boots against the
+   **same on-device SQLite DB** → re-acquires the forwarded API + waits for
+   process stability → `GET /messages` (after) → `assertMarkerSurvivedRelaunch`.
+   Pre/post screenshots + the after-relaunch server thread are written to
+   `packages/app/test-results/relaunch-persistence/android-<id>.json`.
+
+   iOS (in-process IPC-only agent, no HTTP the harness can reach) and `--api-base`
+   (the harness does not own the process) surface an explicit **N/A with reason**
+   rather than a silent skip.
+
+## Verification (this environment: headless, no emulator)
+
+- **Verdict logic — enforced vitest lane (`packages/app`):** `verdict-logic-vitest.txt` — **11/11 passing**.
+  ```bash
+  bun run --cwd packages/app test -- scripts/lib/chat-history-persistence.test.mjs
+  ```
+- **Verdict logic — independent `node --test`** (no vitest, proves the module standalone on a disk-contended host): `verdict-logic-node-test.txt` — **7/7 passing**.
+- **Script wiring:** `node --check scripts/mobile-local-chat-smoke.mjs` (syntax) + `--help` reflects the new flag. Biome clean on all three files.
+
+## N/A (device/live-infra — wired to real scripts, not run here)
+
+- **Android on-device leg execution:** needs a booted emulator with the app
+  installed (`test:sim:local-chat:android:relaunch-persistence`). Wired to real
+  `adb` / `am force-stop` / forwarded HTTP `GET /messages`; not runnable on this
+  headless host.
+- **iOS leg:** the on-device agent is IPC-only; its relaunch check needs the
+  Preferences-handshake / XCUITest path (issue item 1) — surfaced as N/A.
+- **Web nightly live-walkthrough (item 4 second half):** belongs to the
+  `app-live-e2e` lane against a real backend agent.

--- a/.github/issue-evidence/13689-relaunch-persistence/verdict-logic-node-test.txt
+++ b/.github/issue-evidence/13689-relaunch-persistence/verdict-logic-node-test.txt
@@ -1,0 +1,15 @@
+✔ unique markers (0.373584ms)
+✔ extract + empty (0.326375ms)
+✔ malformed throws (0.156208ms)
+✔ survives (0.106125ms)
+✔ lost on relaunch throws loudly (0.070583ms)
+✔ broken send refused (0.056125ms)
+✔ contains (0.074584ms)
+ℹ tests 7
+ℹ suites 0
+ℹ pass 7
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 48.378083

--- a/.github/issue-evidence/13689-relaunch-persistence/verdict-logic-vitest.txt
+++ b/.github/issue-evidence/13689-relaunch-persistence/verdict-logic-vitest.txt
@@ -1,0 +1,21 @@
+$ vitest run --config vitest.config.ts scripts/lib/chat-history-persistence.test.mjs --run "--reporter=verbose"
+
+ RUN  v4.1.5 /Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/wf_11cd7a4f-a39-5/packages/app
+
+ ✓ scripts/lib/chat-history-persistence.test.mjs > buildRelaunchMarker is unique per call and carries the prefix + platform 1ms
+ ✓ scripts/lib/chat-history-persistence.test.mjs > isRelaunchMarker rejects arbitrary user text 0ms
+ ✓ scripts/lib/chat-history-persistence.test.mjs > extractMessageTexts returns ordered texts and treats {messages:[]} as a real empty thread 1ms
+ ✓ scripts/lib/chat-history-persistence.test.mjs > extractMessageTexts throws on a malformed body instead of fabricating an empty thread 0ms
+ ✓ scripts/lib/chat-history-persistence.test.mjs > messageThreadContainsMarker matches only the exact marker 0ms
+ ✓ scripts/lib/chat-history-persistence.test.mjs > assertMarkerSurvivedRelaunch passes when the marker is in both before and after threads 0ms
+ ✓ scripts/lib/chat-history-persistence.test.mjs > assertMarkerSurvivedRelaunch fails loudly when the thread is empty after relaunch (fresh/lost state dir) 0ms
+ ✓ scripts/lib/chat-history-persistence.test.mjs > assertMarkerSurvivedRelaunch fails when a stale prior-run message is present but the current marker is not 0ms
+ ✓ scripts/lib/chat-history-persistence.test.mjs > assertMarkerSurvivedRelaunch refuses to pass when the marker never reached server truth (broken send) 0ms
+ ✓ scripts/lib/chat-history-persistence.test.mjs > assertMarkerSurvivedRelaunch refuses a non-unique marker so a hardcoded string can't false-green 0ms
+ ✓ scripts/lib/chat-history-persistence.test.mjs > assertMarkerSurvivedRelaunch surfaces a malformed after-relaunch read as an error, not a pass 0ms
+
+ Test Files  1 passed (1)
+      Tests  11 passed (11)
+   Start at  15:33:52
+   Duration  685ms (transform 53ms, setup 58ms, import 9ms, tests 3ms, environment 528ms)
+

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -58,6 +58,7 @@
     "test:sim:local-chat:android": "node scripts/mobile-local-chat-smoke.mjs --platform android --require-installed",
     "test:sim:local-chat:android:live": "node scripts/mobile-local-chat-smoke.mjs --platform android --require-installed --live --android-select-local --android-stage-smoke-model",
     "test:sim:local-chat:android:background": "node scripts/mobile-local-chat-smoke.mjs --platform android --require-installed --live --android-select-local --android-stage-smoke-model --android-background",
+    "test:sim:local-chat:android:relaunch-persistence": "node scripts/mobile-local-chat-smoke.mjs --platform android --require-installed --live --android-select-local --android-stage-smoke-model --relaunch-persistence",
     "test:sim:local-chat:both": "node scripts/mobile-local-chat-smoke.mjs --platform both --require-installed",
     "test:sim:local-chat:ios": "node scripts/mobile-local-chat-smoke.mjs --platform ios --require-installed",
     "test:sim:local-chat:ios:live": "node scripts/mobile-local-chat-smoke.mjs --platform ios --require-installed",

--- a/packages/app/scripts/lib/chat-history-persistence.mjs
+++ b/packages/app/scripts/lib/chat-history-persistence.mjs
@@ -32,7 +32,12 @@ export const RELAUNCH_MARKER_PREFIX = "RELAUNCH-PERSIST";
  * a message left over from a previous run can never satisfy the survival check,
  * and `platform`/`runId` make failures self-describing in logs.
  */
-export function buildRelaunchMarker({ platform = "app", runId, now = Date.now(), random } = {}) {
+export function buildRelaunchMarker({
+  platform = "app",
+  runId,
+  now = Date.now(),
+  random,
+} = {}) {
   const rand =
     typeof random === "string" && random
       ? random
@@ -43,7 +48,9 @@ export function buildRelaunchMarker({ platform = "app", runId, now = Date.now(),
 
 /** True only for a string that came from `buildRelaunchMarker`. */
 export function isRelaunchMarker(value) {
-  return typeof value === "string" && value.startsWith(`${RELAUNCH_MARKER_PREFIX}-`);
+  return (
+    typeof value === "string" && value.startsWith(`${RELAUNCH_MARKER_PREFIX}-`)
+  );
 }
 
 /**
@@ -101,7 +108,11 @@ export function messageThreadContainsMarker(body, marker) {
  * lost-DB regression this issue guards — throws loudly. Returns a summary for
  * the caller to log as evidence.
  */
-export function assertMarkerSurvivedRelaunch({ marker, beforeBody, afterBody }) {
+export function assertMarkerSurvivedRelaunch({
+  marker,
+  beforeBody,
+  afterBody,
+}) {
   if (!isRelaunchMarker(marker)) {
     throw new ChatHistoryPersistenceError(
       `Refusing to assert a non-unique marker: ${JSON.stringify(marker)}`,
@@ -123,7 +134,11 @@ export function assertMarkerSurvivedRelaunch({ marker, beforeBody, afterBody }) 
     throw new ChatHistoryPersistenceError(
       `Chat history did NOT survive relaunch: marker "${marker}" is absent from the server-truth thread after relaunch (${afterTexts.length} message(s) returned). A regression that empties the thread on relaunch — or a fresh/lost agent state dir — trips this.`,
       "MARKER_LOST_ON_RELAUNCH",
-      { marker, beforeCount: beforeTexts.length, afterCount: afterTexts.length },
+      {
+        marker,
+        beforeCount: beforeTexts.length,
+        afterCount: afterTexts.length,
+      },
     );
   }
 

--- a/packages/app/scripts/lib/chat-history-persistence.mjs
+++ b/packages/app/scripts/lib/chat-history-persistence.mjs
@@ -1,0 +1,136 @@
+/**
+ * Pure decision logic for the chat-history relaunch-persistence lane (#13689):
+ * "my conversation is still there after I reopen the app". The device/HTTP legs
+ * in mobile-local-chat-smoke.mjs drive the real path — send a unique marker
+ * through the running agent, kill+relaunch the app process, re-fetch the thread
+ * from server truth (`GET /api/conversations/:id/messages`) — but the accept/
+ * reject verdict lives here so it is verifiable off-device and can never
+ * false-green: a run that never sent the marker, or one whose after-relaunch
+ * fetch is empty (fresh state dir / lost DB), throws loudly instead of passing.
+ *
+ * The marker is unique per run so residue from a prior run (the exact pollution
+ * this issue calls out in GestureSemanticsUITests) cannot satisfy the check.
+ * Parsing the server response is fail-fast (issue #9324 doctrine, THROW never
+ * fabricate): a malformed body is a broken pipeline, not an empty thread — only
+ * a well-formed `{ messages: [] }` is a legitimately empty thread.
+ */
+
+/** Error raised by this module; `code` lets callers branch without string-matching. */
+export class ChatHistoryPersistenceError extends Error {
+  constructor(message, code, context) {
+    super(message);
+    this.name = "ChatHistoryPersistenceError";
+    this.code = code;
+    if (context) this.context = context;
+  }
+}
+
+export const RELAUNCH_MARKER_PREFIX = "RELAUNCH-PERSIST";
+
+/**
+ * A per-run unique marker string. The timestamp + random suffix guarantee that
+ * a message left over from a previous run can never satisfy the survival check,
+ * and `platform`/`runId` make failures self-describing in logs.
+ */
+export function buildRelaunchMarker({ platform = "app", runId, now = Date.now(), random } = {}) {
+  const rand =
+    typeof random === "string" && random
+      ? random
+      : Math.random().toString(36).slice(2, 10);
+  const run = runId ? String(runId).replace(/[^A-Za-z0-9_-]/g, "") : rand;
+  return `${RELAUNCH_MARKER_PREFIX}-${platform}-${run}-${now}-${rand}`;
+}
+
+/** True only for a string that came from `buildRelaunchMarker`. */
+export function isRelaunchMarker(value) {
+  return typeof value === "string" && value.startsWith(`${RELAUNCH_MARKER_PREFIX}-`);
+}
+
+/**
+ * Extract the ordered message texts from a `GET /api/conversations/:id/messages`
+ * body (`{ messages: [{ role, text }] }`). Throws on a malformed body so a
+ * broken read is never mistaken for an empty thread; `{ messages: [] }` returns
+ * `[]` because that is a real (empty) thread, not a pipeline failure.
+ */
+export function extractMessageTexts(body) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new ChatHistoryPersistenceError(
+      `Malformed GET /messages body (expected an object): ${JSON.stringify(body)}`,
+      "MALFORMED_BODY",
+    );
+  }
+  const { messages } = body;
+  if (!Array.isArray(messages)) {
+    throw new ChatHistoryPersistenceError(
+      `GET /messages body is missing a \`messages\` array: ${JSON.stringify(body)}`,
+      "MISSING_MESSAGES",
+    );
+  }
+  return messages.map((m, index) => {
+    if (!m || typeof m !== "object") {
+      throw new ChatHistoryPersistenceError(
+        `GET /messages entry ${index} is not an object`,
+        "MALFORMED_MESSAGE",
+        { index },
+      );
+    }
+    const text = m.text;
+    if (typeof text !== "string") {
+      throw new ChatHistoryPersistenceError(
+        `GET /messages entry ${index} has a non-string text field`,
+        "MALFORMED_MESSAGE",
+        { index, role: m.role },
+      );
+    }
+    return text;
+  });
+}
+
+/** Whether the server-truth thread body contains the marker text. */
+export function messageThreadContainsMarker(body, marker) {
+  return extractMessageTexts(body).some((text) => text.includes(marker));
+}
+
+/**
+ * Assert a sent marker survived an app relaunch.
+ *
+ * `beforeBody` proves the marker actually reached server truth before the
+ * relaunch (guards a broken send that would otherwise let the leg pass without
+ * ever testing persistence); `afterBody` is the thread re-fetched from a freshly
+ * relaunched process. A marker absent from `afterBody` — the fresh-state-dir /
+ * lost-DB regression this issue guards — throws loudly. Returns a summary for
+ * the caller to log as evidence.
+ */
+export function assertMarkerSurvivedRelaunch({ marker, beforeBody, afterBody }) {
+  if (!isRelaunchMarker(marker)) {
+    throw new ChatHistoryPersistenceError(
+      `Refusing to assert a non-unique marker: ${JSON.stringify(marker)}`,
+      "INVALID_MARKER",
+    );
+  }
+
+  const beforeTexts = extractMessageTexts(beforeBody);
+  if (!beforeTexts.some((text) => text.includes(marker))) {
+    throw new ChatHistoryPersistenceError(
+      `Marker "${marker}" was not present in the thread BEFORE relaunch — the send never reached server truth, so persistence cannot be asserted. Pre-relaunch thread had ${beforeTexts.length} message(s).`,
+      "MARKER_NOT_SENT",
+      { marker, beforeCount: beforeTexts.length },
+    );
+  }
+
+  const afterTexts = extractMessageTexts(afterBody);
+  if (!afterTexts.some((text) => text.includes(marker))) {
+    throw new ChatHistoryPersistenceError(
+      `Chat history did NOT survive relaunch: marker "${marker}" is absent from the server-truth thread after relaunch (${afterTexts.length} message(s) returned). A regression that empties the thread on relaunch — or a fresh/lost agent state dir — trips this.`,
+      "MARKER_LOST_ON_RELAUNCH",
+      { marker, beforeCount: beforeTexts.length, afterCount: afterTexts.length },
+    );
+  }
+
+  return {
+    marker,
+    beforeCount: beforeTexts.length,
+    afterCount: afterTexts.length,
+    survived: true,
+  };
+}

--- a/packages/app/scripts/lib/chat-history-persistence.test.mjs
+++ b/packages/app/scripts/lib/chat-history-persistence.test.mjs
@@ -168,7 +168,10 @@ test("assertMarkerSurvivedRelaunch refuses a non-unique marker so a hardcoded st
 });
 
 test("assertMarkerSurvivedRelaunch surfaces a malformed after-relaunch read as an error, not a pass", () => {
-  const marker = buildRelaunchMarker({ platform: "android", runId: "malformed" });
+  const marker = buildRelaunchMarker({
+    platform: "android",
+    runId: "malformed",
+  });
   assert.throws(
     () =>
       assertMarkerSurvivedRelaunch({

--- a/packages/app/scripts/lib/chat-history-persistence.test.mjs
+++ b/packages/app/scripts/lib/chat-history-persistence.test.mjs
@@ -1,0 +1,181 @@
+/**
+ * Deterministic coverage for the chat-history relaunch-persistence verdict logic
+ * (#13689). Fixtures are real-shaped `GET /api/conversations/:id/messages`
+ * bodies (`{ messages: [{ role, text }] }`), not mocks of the parser — the
+ * accept/reject logic is a pure function, so this proves the exact false-green
+ * paths the issue warns about: a marker that never persisted, an empty thread
+ * after relaunch (fresh/lost state dir), and stale residue from a prior run.
+ *
+ * Runs in the `packages/app` vitest lane (which collects `scripts/**\/*.test.mjs`)
+ * so a regression fails CI. `node:assert` still throws on failure — a `node:test`
+ * form would be loaded by vitest but collected as ZERO tests, an unenforced
+ * green-by-skip (see android-assistant-verify-lib.test.mjs).
+ *
+ * Run: `bun run --cwd packages/app test -- scripts/lib/chat-history-persistence.test.mjs`
+ */
+import assert from "node:assert/strict";
+import { test } from "vitest";
+
+import {
+  assertMarkerSurvivedRelaunch,
+  buildRelaunchMarker,
+  ChatHistoryPersistenceError,
+  extractMessageTexts,
+  isRelaunchMarker,
+  messageThreadContainsMarker,
+  RELAUNCH_MARKER_PREFIX,
+} from "./chat-history-persistence.mjs";
+
+/** A real-shaped GET /messages body. */
+function threadBody(texts) {
+  return {
+    messages: texts.map((text, i) => ({
+      role: i % 2 === 0 ? "user" : "assistant",
+      text,
+    })),
+  };
+}
+
+test("buildRelaunchMarker is unique per call and carries the prefix + platform", () => {
+  const a = buildRelaunchMarker({ platform: "android", runId: "run1" });
+  const b = buildRelaunchMarker({ platform: "android", runId: "run1" });
+  assert.notEqual(a, b, "two markers from the same runId must still differ");
+  assert.ok(a.startsWith(`${RELAUNCH_MARKER_PREFIX}-android-run1-`));
+  assert.ok(isRelaunchMarker(a));
+  assert.ok(isRelaunchMarker(b));
+  // Deterministic when now+random are pinned (used for reproducible logs).
+  const pinned = buildRelaunchMarker({
+    platform: "ios",
+    runId: "r",
+    now: 1000,
+    random: "abcd1234",
+  });
+  assert.equal(pinned, `${RELAUNCH_MARKER_PREFIX}-ios-r-1000-abcd1234`);
+});
+
+test("isRelaunchMarker rejects arbitrary user text", () => {
+  assert.ok(!isRelaunchMarker("hello world"));
+  assert.ok(!isRelaunchMarker(""));
+  assert.ok(!isRelaunchMarker(undefined));
+  assert.ok(!isRelaunchMarker(`prefixed-${RELAUNCH_MARKER_PREFIX}-x`));
+});
+
+test("extractMessageTexts returns ordered texts and treats {messages:[]} as a real empty thread", () => {
+  assert.deepEqual(extractMessageTexts(threadBody(["hi", "yo"])), ["hi", "yo"]);
+  assert.deepEqual(extractMessageTexts({ messages: [] }), []);
+});
+
+test("extractMessageTexts throws on a malformed body instead of fabricating an empty thread", () => {
+  // A broken read (no messages key, wrong type, non-string text) is a broken
+  // pipeline — never silently an empty thread.
+  assert.throws(() => extractMessageTexts(null), ChatHistoryPersistenceError);
+  assert.throws(() => extractMessageTexts({}), ChatHistoryPersistenceError);
+  assert.throws(
+    () => extractMessageTexts({ messages: "nope" }),
+    ChatHistoryPersistenceError,
+  );
+  assert.throws(
+    () => extractMessageTexts({ messages: [{ role: "user" }] }),
+    /non-string text/,
+  );
+  assert.throws(
+    () => extractMessageTexts([{ text: "x" }]),
+    ChatHistoryPersistenceError,
+  );
+});
+
+test("messageThreadContainsMarker matches only the exact marker", () => {
+  const marker = buildRelaunchMarker({ platform: "android", runId: "hit" });
+  assert.ok(messageThreadContainsMarker(threadBody(["noise", marker]), marker));
+  assert.ok(
+    !messageThreadContainsMarker(threadBody(["noise", "other"]), marker),
+  );
+});
+
+test("assertMarkerSurvivedRelaunch passes when the marker is in both before and after threads", () => {
+  const marker = buildRelaunchMarker({ platform: "android", runId: "ok" });
+  const result = assertMarkerSurvivedRelaunch({
+    marker,
+    beforeBody: threadBody(["android smoke model works", marker]),
+    afterBody: threadBody(["android smoke model works", marker, "reply"]),
+  });
+  assert.equal(result.survived, true);
+  assert.equal(result.marker, marker);
+  assert.equal(result.beforeCount, 2);
+  assert.equal(result.afterCount, 3);
+});
+
+test("assertMarkerSurvivedRelaunch fails loudly when the thread is empty after relaunch (fresh/lost state dir)", () => {
+  const marker = buildRelaunchMarker({ platform: "android", runId: "lost" });
+  assert.throws(
+    () =>
+      assertMarkerSurvivedRelaunch({
+        marker,
+        beforeBody: threadBody([marker]),
+        afterBody: { messages: [] },
+      }),
+    (err) => {
+      assert.ok(err instanceof ChatHistoryPersistenceError);
+      assert.equal(err.code, "MARKER_LOST_ON_RELAUNCH");
+      assert.match(err.message, /did NOT survive relaunch/);
+      return true;
+    },
+  );
+});
+
+test("assertMarkerSurvivedRelaunch fails when a stale prior-run message is present but the current marker is not", () => {
+  const stale = buildRelaunchMarker({ platform: "android", runId: "prev" });
+  const current = buildRelaunchMarker({ platform: "android", runId: "curr" });
+  assert.throws(
+    () =>
+      assertMarkerSurvivedRelaunch({
+        marker: current,
+        // The send genuinely reached server truth this run...
+        beforeBody: threadBody([current]),
+        // ...but after relaunch only last run's residue remains — must fail.
+        afterBody: threadBody([stale]),
+      }),
+    (err) => err.code === "MARKER_LOST_ON_RELAUNCH",
+  );
+});
+
+test("assertMarkerSurvivedRelaunch refuses to pass when the marker never reached server truth (broken send)", () => {
+  const marker = buildRelaunchMarker({ platform: "ios", runId: "nosend" });
+  assert.throws(
+    () =>
+      assertMarkerSurvivedRelaunch({
+        marker,
+        beforeBody: threadBody(["some other message"]),
+        afterBody: threadBody([marker]),
+      }),
+    (err) => {
+      assert.equal(err.code, "MARKER_NOT_SENT");
+      return true;
+    },
+  );
+});
+
+test("assertMarkerSurvivedRelaunch refuses a non-unique marker so a hardcoded string can't false-green", () => {
+  assert.throws(
+    () =>
+      assertMarkerSurvivedRelaunch({
+        marker: "hello",
+        beforeBody: threadBody(["hello"]),
+        afterBody: threadBody(["hello"]),
+      }),
+    (err) => err.code === "INVALID_MARKER",
+  );
+});
+
+test("assertMarkerSurvivedRelaunch surfaces a malformed after-relaunch read as an error, not a pass", () => {
+  const marker = buildRelaunchMarker({ platform: "android", runId: "malformed" });
+  assert.throws(
+    () =>
+      assertMarkerSurvivedRelaunch({
+        marker,
+        beforeBody: threadBody([marker]),
+        afterBody: { error: "Failed to fetch messages" },
+      }),
+    (err) => err.code === "MISSING_MESSAGES",
+  );
+});

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -15,6 +15,10 @@ import {
   ANDROID_FULL_TURN_FAILURE_RE,
   IOS_FULL_BUN_SMOKE_FAILURE_RE,
 } from "./lib/chat-failure-strings.mjs";
+import {
+  assertMarkerSurvivedRelaunch,
+  buildRelaunchMarker,
+} from "./lib/chat-history-persistence.mjs";
 import { startDeviceE2eHostAgent } from "./lib/host-agent.mjs";
 import { assertInstalledIosAppRendererFresh } from "./lib/ios-renderer-stamp.mjs";
 import { clearIosSmokeDefaults } from "./lib/ios-sim-defaults-hygiene.mjs";
@@ -28,6 +32,10 @@ const appConfigPath = path.join(repoRoot, "packages/app/app.config.ts");
 const iosLocalChatResultDir = path.join(
   repoRoot,
   "packages/app/test-results/ios-local-chat",
+);
+const relaunchPersistenceResultDir = path.join(
+  repoRoot,
+  "packages/app/test-results/relaunch-persistence",
 );
 
 function argValue(name) {
@@ -51,6 +59,7 @@ const androidStageSmokeModel = process.argv.includes(
   "--android-stage-smoke-model",
 );
 const iosBackground = process.argv.includes("--ios-background");
+const relaunchPersistence = process.argv.includes("--relaunch-persistence");
 const iosBackgroundTaskId =
   argValue("--ios-background-task-id") ?? "ai.eliza.tasks.refresh";
 const IOS_FULL_BUN_SMOKE_REQUEST_KEY = "eliza:ios-full-bun-smoke:request";
@@ -198,6 +207,10 @@ Options:
   --android-background             Background Android, force-fire the WorkManager job, and poll /api/health
   --ios-background                 Background iOS, fire a BGTaskScheduler task via LLDB, and poll /api/health
   --ios-background-task-id ID      iOS BGTask identifier to simulate (default: ai.eliza.tasks.refresh)
+  --relaunch-persistence           After the turn, persist a unique marker message, force-stop + relaunch the app,
+                                   and assert the marker survives from server truth (GET /messages). Android only:
+                                   the iOS on-device agent is IPC-only, so its relaunch check needs the Preferences
+                                   handshake / XCUITest path (#13689).
   --help                           Print this help
 
 Notes:
@@ -2434,6 +2447,174 @@ async function runLocalInferenceApiSmoke(
   );
 }
 
+/**
+ * Force-stop and relaunch the installed Android app so its ElizaAgentService is
+ * torn down and re-booted against the same on-device SQLite database — the real
+ * "reopen the app" event whose persistence #13689 asserts. `am force-stop` kills
+ * the whole process (not just the activity), so the next `am start` is a cold
+ * relaunch, not a resume.
+ */
+function relaunchAndroidApp(context) {
+  const id = appId();
+  requireExec(
+    context.adb,
+    ["-s", context.serial, "shell", "am", "force-stop", id],
+    `Failed to force-stop ${id} on ${context.serial}.`,
+  );
+  requireExec(
+    context.adb,
+    ["-s", context.serial, "shell", "am", "start", "-n", `${id}/.MainActivity`],
+    `Failed to relaunch ${id} on ${context.serial}.`,
+  );
+  tryExec(context.adb, [
+    "-s",
+    context.serial,
+    "shell",
+    "am",
+    "start",
+    "-a",
+    "android.intent.action.VIEW",
+    "-d",
+    "elizaos://chat",
+    id,
+  ]);
+}
+
+/**
+ * Re-establish the forwarded HTTP surface after a relaunch. The old adb forward
+ * points at a dead process, and the app rebinds device port 31337 on restart, so
+ * the stale forward is dropped and `waitForAndroidApi` allocates a fresh one and
+ * re-reads the (persisted) local-agent token, then the process-stability gate
+ * ensures the restart settled before we read the thread back.
+ */
+async function reacquireAndroidApiAfterRelaunch(context) {
+  cleanupAndroidAgentForwards(context, "relaunch");
+  const api = await waitForAndroidApi(context);
+  if (!api) {
+    throw new Error(
+      "Android local-agent API did not come back after relaunch; cannot assert chat-history persistence.",
+    );
+  }
+  await waitForAndroidProcessStability(api.apiBase, api.token);
+  return api;
+}
+
+/**
+ * Android relaunch-persistence leg (#13689). Seeds a unique marker message into
+ * a fresh conversation through the real inference-free bulk-insert route (the
+ * main smoke turn already proves the live send+inference path; this leg isolates
+ * the DB-survival property), captures the thread from server truth, force-stops
+ * and cold-relaunches the app, then re-fetches the thread from the restarted
+ * agent and asserts the marker survived. The verdict — including the loud
+ * failure when the thread comes back empty (a lost/fresh state dir) — is the
+ * pure `assertMarkerSurvivedRelaunch`.
+ */
+async function verifyAndroidChatHistoryPersistence(context, initialApi) {
+  if (!context?.installed) {
+    const message =
+      "[local-chat-smoke] --relaunch-persistence requested but the Android app is not installed.";
+    if (requireInstalled) throw new Error(message);
+    console.warn(message);
+    return null;
+  }
+
+  let { apiBase, token } = initialApi;
+
+  const created = await requestJson(
+    "POST",
+    "/api/conversations",
+    { title: "Relaunch persistence smoke" },
+    apiBase,
+    token,
+  );
+  const conversationId = created.conversation?.id;
+  if (!conversationId) {
+    throw new Error(
+      "Relaunch-persistence conversation creation did not return an id.",
+    );
+  }
+  const marker = buildRelaunchMarker({
+    platform: "android",
+    runId: conversationId,
+  });
+  const messagesPath = `/api/conversations/${encodeURIComponent(conversationId)}/messages`;
+
+  const imported = await requestJson(
+    "POST",
+    `/api/conversations/${encodeURIComponent(conversationId)}/import`,
+    {
+      title: `Relaunch persistence ${marker}`,
+      messages: [{ role: "user", text: marker }],
+    },
+    apiBase,
+    token,
+  );
+  if (imported.inserted !== 1) {
+    throw new Error(
+      `Marker message was not persisted before relaunch: ${JSON.stringify(imported)}`,
+    );
+  }
+
+  const beforeBody = await requestJson(
+    "GET",
+    messagesPath,
+    undefined,
+    apiBase,
+    token,
+  );
+  const preShot = takeAndroidScreenshot(context, "relaunch-persistence-pre");
+
+  console.log(
+    `[local-chat-smoke] Relaunch persistence: seeded marker ${marker} into ${conversationId}; force-stopping + relaunching ${appId()}.`,
+  );
+  relaunchAndroidApp(context);
+  const reacquired = await reacquireAndroidApiAfterRelaunch(context);
+  apiBase = reacquired.apiBase;
+  token = reacquired.token;
+
+  const afterBody = await requestJson(
+    "GET",
+    messagesPath,
+    undefined,
+    apiBase,
+    token,
+  );
+  const postShot = takeAndroidScreenshot(context, "relaunch-persistence-post");
+
+  const result = assertMarkerSurvivedRelaunch({
+    marker,
+    beforeBody,
+    afterBody,
+  });
+
+  fs.mkdirSync(relaunchPersistenceResultDir, { recursive: true });
+  const evidencePath = path.join(
+    relaunchPersistenceResultDir,
+    `android-${conversationId}.json`,
+  );
+  fs.writeFileSync(
+    evidencePath,
+    `${JSON.stringify(
+      {
+        platform: "android",
+        conversationId,
+        marker,
+        result,
+        preRelaunchScreenshot: preShot,
+        postRelaunchScreenshot: postShot,
+        afterRelaunchServerThread: afterBody,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  console.log(
+    `[local-chat-smoke] Relaunch persistence PASSED: marker survived (${result.beforeCount} → ${result.afterCount} message(s) from server truth). Evidence: ${evidencePath}`,
+  );
+  return result;
+}
+
 async function main() {
   let androidContext = null;
   let iosContext = null;
@@ -2469,6 +2650,14 @@ async function main() {
 
     if (apiBase) {
       await runLocalInferenceApiSmoke(apiBase, authTokenArg);
+      if (relaunchPersistence) {
+        // The harness does not own the --api-base process, so it cannot force a
+        // real app relaunch; the relaunch-persistence leg is a device-driven
+        // lane (Android below).
+        console.warn(
+          "[local-chat-smoke] --relaunch-persistence is N/A with --api-base: the harness does not own the agent process and cannot relaunch it. Use --platform android against an installed app.",
+        );
+      }
       return;
     }
 
@@ -2483,7 +2672,26 @@ async function main() {
           );
         }
         await runLocalInferenceApiSmoke(androidApi.apiBase, androidApi.token);
+        if (relaunchPersistence) {
+          await verifyAndroidChatHistoryPersistence(androidContext, androidApi);
+        }
       }
+    }
+
+    if (
+      relaunchPersistence &&
+      (platform === "ios" || platform === "both") &&
+      !apiBase
+    ) {
+      // The iOS on-device agent runs in-process over the Capacitor IPC bridge
+      // (no HTTP port the harness can reach), so it cannot re-fetch the thread
+      // via GET /messages here. Its relaunch-persistence leg belongs to the
+      // Preferences-handshake / XCUITest path (#13689 item 1) — surface it as an
+      // explicit N/A rather than a silent skip.
+      const message =
+        "[local-chat-smoke] --relaunch-persistence is N/A on iOS from this harness: the on-device agent is IPC-only. Implement the iOS leg via the Preferences handshake or an XCUITest that relaunches and asserts the marker bubble (#13689).";
+      if (requireInstalled && platform === "ios") throw new Error(message);
+      console.warn(message);
     }
 
     if (iosBackground && (platform === "ios" || platform === "both")) {


### PR DESCRIPTION
## What & why

"My conversation is still there after I reopen the app" — the most basic chat-correctness property — had no automated assertion that isn't mock-substituted (#13689). PR #14006 (merged) closed **item 4** (the real agent-DB round trip) by extracting `restoreConversationsFromDb` and testing it against a real migrated PGlite DB. This PR adds the **Android on-device app-relaunch leg** (item 2 surface) and the **pure verdict logic** shared by every surface, wired so it can never false-green.

## Changes

- **`packages/app/scripts/lib/chat-history-persistence.mjs`** — pure accept/reject verdict, verifiable off-device:
  - `buildRelaunchMarker(...)` — unique-per-run marker so residue from a prior run (the exact `GestureSemanticsUITests` pollution the issue cites) can't satisfy the check.
  - `extractMessageTexts(body)` — fail-fast parse of the real `GET /api/conversations/:id/messages` shape (`{ messages: [{ role, text }] }`); a malformed body **throws** (#9324 THROW-never-fabricate), only `{ messages: [] }` is a legitimately empty thread.
  - `assertMarkerSurvivedRelaunch(...)` — asserts the marker reached server truth **before** relaunch (guards a broken send) and survived **after**; an empty/lost thread throws `MARKER_LOST_ON_RELAUNCH` (the negative check the "Done when" requires).
- **`--relaunch-persistence`** in `mobile-local-chat-smoke.mjs` (lane `test:sim:local-chat:android:relaunch-persistence`): after the verified turn, seeds a unique marker via the real inference-free `/import` route → `GET /messages` (before) → `am force-stop` + cold `am start` so `ElizaAgentService` re-boots against the same on-device SQLite DB → re-acquires the forwarded API + waits for stability → `GET /messages` (after) → asserts survival. Pre/post screenshots + the after-relaunch server thread are captured as evidence.
- iOS (IPC-only on-device agent) and `--api-base` (harness doesn't own the process) surface an explicit **N/A with reason**, not a silent skip.

## Verification

| Check | Result |
|---|---|
| `bun run --cwd packages/app test -- scripts/lib/chat-history-persistence.test.mjs` (enforced vitest lane) | **11/11 pass** |
| Independent `node --test` on the module (no vitest, disk-contended host) | **7/7 pass** |
| `node --check scripts/mobile-local-chat-smoke.mjs` + `--help` reflects the flag | pass |
| Biome check on all touched files | clean |

Transcripts: `.github/issue-evidence/13689-relaunch-persistence/verdict-logic-{vitest,node-test}.txt` and `device-leg-and-verdict-logic.md`.

## N/A (device/live-infra — wired to real scripts, not run on this headless host)

- **Android leg execution** — needs a booted emulator + installed app; wired to real `adb`/`am force-stop`/forwarded `GET /messages`.
- **iOS leg** — on-device agent is IPC-only; its relaunch check needs the Preferences-handshake / XCUITest path (issue item 1).
- **Web nightly live-walkthrough** (item 4 second half) — belongs to the `app-live-e2e` lane.

Part of the flawless-testing-loop initiative (#13562).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
