### PR TITLE
feat(ui): sandboxed-iframe view-isolation level (#14180)

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -207,6 +207,7 @@ import {
 } from "./components/pages/WalletSectionNav";
 import { FineTuningView } from "./components/training/injected";
 import { DynamicViewLoader } from "./components/views/DynamicViewLoader";
+import { registerSandboxProbeView } from "./components/views/sandbox-probe-view";
 import {
   useAvailableViews,
   useRoutableViews,
@@ -1941,6 +1942,11 @@ export function App() {
   }));
   const isPopout = useIsPopout();
   const shellMode = useShellMode();
+  // Register the developer-only sandboxed-iframe consumer once at boot (#14180),
+  // so the level has a shipped, navigable first-party view. Idempotent.
+  useEffect(() => {
+    registerSandboxProbeView();
+  }, []);
   // Auth gate — only active after the coordinator reaches "ready".
   // During first-run setup / pairing / startup phases the StartupScreen handles
   // its own gate (bootstrap step), so we skip the check.

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -106,6 +106,7 @@ import {
   ViewLoadingSkeleton,
   ViewRestrictedState,
 } from "./ViewStatusStates";
+import { SandboxedViewFrame } from "./SandboxedViewFrame";
 import { brokerViewInteract } from "./view-capability-broker";
 import { registerViewInteractHandler } from "./view-interact-registry";
 
@@ -1208,6 +1209,11 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
     () => resolveSurfaceManifest({ surface }),
     [surface],
   );
+  // A `sandboxed-iframe` view is never imported into the host realm — that is
+  // the whole point of the level. It renders in an `<iframe sandbox>` (#14180)
+  // and talks to the shell only through the postMessage broker, so the in-realm
+  // bundle-load / interact-registry path below is skipped for it.
+  const isSandboxed = resolvedManifest.isolation === "sandboxed-iframe";
   const [bundle, setBundle] = useState<ViewBundleModule | null>(null);
   const [loadError, setLoadError] = useState<Error | null>(null);
   // Incrementing this key invalidates the module cache entry and forces a
@@ -1229,7 +1235,7 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
   // re-run this effect to invalidate the module cache.
   // biome-ignore lint/correctness/useExhaustiveDependencies: reloadKey is a manual cache-bust trigger
   useEffect(() => {
-    if (!dynamicLoadingAllowed) return;
+    if (!dynamicLoadingAllowed || isSandboxed) return;
 
     let cancelled = false;
     const lease = acquireBundleModule(bundleUrl, componentExport);
@@ -1256,7 +1262,7 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
       cancelled = true;
       lease.release();
     };
-  }, [bundleUrl, componentExport, dynamicLoadingAllowed, reloadKey]);
+  }, [bundleUrl, componentExport, dynamicLoadingAllowed, isSandboxed, reloadKey]);
 
   // Register this view's interact handler whenever the bundle is loaded.
   // The handler is unregistered on unmount or when the bundle changes.
@@ -1353,6 +1359,22 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
     setLoadError(null);
     setReloadKey((k) => k + 1);
   }, [bundleUrl, componentExport]);
+
+  // A sandboxed-iframe view embeds cross-realm; its `bundleUrl` is the framed
+  // document entry, not a host-external JS bundle. Delegating here means untrusted
+  // web content never executes in the shell's realm (#14180).
+  if (isSandboxed) {
+    return (
+      <div ref={containerRef} className="contents">
+        <SandboxedViewFrame
+          viewId={viewId}
+          surface={surface}
+          src={bundleUrl}
+          title={viewId}
+        />
+      </div>
+    );
+  }
 
   // iOS App Store and Google Play builds cannot load remote JS at runtime.
   if (!dynamicLoadingAllowed) {

--- a/packages/ui/src/components/views/SandboxedViewFrame.test.tsx
+++ b/packages/ui/src/components/views/SandboxedViewFrame.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+//
+// The REAL sandboxed-iframe isolation path (#14180). Mounts the actual
+// SandboxedViewFrame, drives its parent-side postMessage broker exactly as a
+// framed document would (a `message` event whose `source` is the real iframe
+// `contentWindow`), and asserts the boundary holds: an ungranted `navigate`
+// changes no shell route, an ungranted `storage` write touches no key, and the
+// same requests WITH the grant are serviced. No stub stands in for the iframe or
+// the broker — the frame's own listener services the message and posts the reply
+// back through the frame window. Deleting the grant check in the broker turns the
+// two negative-path assertions red (the ungranted requests would then fire the
+// navigate event / write the storage key), so this is a genuine red→green guard.
+
+import type { SurfaceManifest } from "@elizaos/core";
+import { NAVIGATE_VIEW_EVENT } from "@elizaos/shared/events";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  SANDBOX_STORAGE_PREFIX,
+  SandboxedViewFrame,
+} from "./SandboxedViewFrame";
+import { SANDBOXED_VIEW_CHANNEL } from "./sandboxed-view-broker";
+
+const VIEW_ID = "probe.view";
+const GRANTED: SurfaceManifest = {
+  isolation: "sandboxed-iframe",
+  capabilities: ["navigate", "storage"],
+};
+const UNGRANTED: SurfaceManifest = {
+  isolation: "sandboxed-iframe",
+  capabilities: [],
+};
+
+/** Mount the frame and return its live iframe + a spy on the frame's postMessage. */
+function mountFrame(surface: SurfaceManifest) {
+  render(
+    <SandboxedViewFrame
+      viewId={VIEW_ID}
+      surface={surface}
+      srcDoc="<!doctype html><title>probe</title>"
+      title="probe"
+    />,
+  );
+  const iframe = screen.getByTestId(
+    `sandboxed-view-frame-${VIEW_ID}`,
+  ) as HTMLIFrameElement;
+  const frameWindow = iframe.contentWindow;
+  if (!frameWindow) throw new Error("iframe contentWindow missing in jsdom");
+  const postSpy = vi
+    .spyOn(frameWindow, "postMessage")
+    .mockImplementation(() => {});
+  return { iframe, frameWindow, postSpy };
+}
+
+/** Post a request into the parent AS the framed view (event.source === the frame). */
+function postFromFrame(
+  frameWindow: Window,
+  capability: string,
+  payload: unknown,
+  requestId: string,
+) {
+  const event = new MessageEvent("message", {
+    data: {
+      channel: SANDBOXED_VIEW_CHANNEL,
+      kind: "request",
+      requestId,
+      capability,
+      payload,
+    },
+  });
+  // jsdom does not populate `source` from the MessageEvent init, so bind it to
+  // the real frame window — the identity the frame's listener gates on.
+  Object.defineProperty(event, "source", { value: frameWindow });
+  window.dispatchEvent(event);
+}
+
+function lastResponse(postSpy: ReturnType<typeof vi.spyOn>) {
+  const calls = postSpy.mock.calls;
+  return calls[calls.length - 1]?.[0] as {
+    channel: string;
+    kind: string;
+    requestId: string;
+    ok: boolean;
+    result?: unknown;
+    error?: string;
+  };
+}
+
+describe("SandboxedViewFrame — real isolation path (#14180)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("renders a REAL sandbox: allow-scripts without allow-same-origin", () => {
+    render(
+      <SandboxedViewFrame
+        viewId={VIEW_ID}
+        surface={GRANTED}
+        srcDoc="<!doctype html><title>x</title>"
+        title="x"
+      />,
+    );
+    const iframe = screen.getByTestId(
+      `sandboxed-view-frame-${VIEW_ID}`,
+    ) as HTMLIFrameElement;
+    const sandbox = iframe.getAttribute("sandbox") ?? "";
+    expect(sandbox.split(" ")).toContain("allow-scripts");
+    expect(sandbox.split(" ")).not.toContain("allow-same-origin");
+  });
+
+  it("DENIES navigate without the grant — no shell route change, typed denial to the frame", async () => {
+    const navSpy = vi.fn();
+    window.addEventListener(NAVIGATE_VIEW_EVENT, navSpy);
+    const { frameWindow, postSpy } = mountFrame(UNGRANTED);
+
+    postFromFrame(frameWindow, "navigate", { viewId: "chat" }, "req-nav-deny");
+
+    await waitFor(() => expect(postSpy).toHaveBeenCalled());
+    const res = lastResponse(postSpy);
+    expect(res.requestId).toBe("req-nav-deny");
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("not granted capability");
+    // The route facility never fired — the shell did not navigate.
+    expect(navSpy).not.toHaveBeenCalled();
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, navSpy);
+  });
+
+  it("DENIES storage without the grant — no key is written, typed denial to the frame", async () => {
+    const { frameWindow, postSpy } = mountFrame(UNGRANTED);
+
+    postFromFrame(
+      frameWindow,
+      "storage",
+      { op: "set", key: "secret", value: "pwn" },
+      "req-store-deny",
+    );
+
+    await waitFor(() => expect(postSpy).toHaveBeenCalled());
+    expect(lastResponse(postSpy).ok).toBe(false);
+    // No key — neither namespaced nor a raw shell key — was written.
+    expect(window.localStorage.length).toBe(0);
+  });
+
+  it("SERVICES navigate with the grant — fires the shell navigate event", async () => {
+    const navSpy = vi.fn();
+    window.addEventListener(NAVIGATE_VIEW_EVENT, navSpy);
+    const { frameWindow, postSpy } = mountFrame(GRANTED);
+
+    postFromFrame(frameWindow, "navigate", { viewId: "chat" }, "req-nav-ok");
+
+    await waitFor(() => expect(postSpy).toHaveBeenCalled());
+    expect(lastResponse(postSpy).ok).toBe(true);
+    await waitFor(() => expect(navSpy).toHaveBeenCalledTimes(1));
+    const detail = (navSpy.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail).toMatchObject({ viewId: "chat" });
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, navSpy);
+  });
+
+  it("SERVICES storage with the grant — writes ONLY the view-namespaced key", async () => {
+    const { frameWindow, postSpy } = mountFrame(GRANTED);
+
+    postFromFrame(
+      frameWindow,
+      "storage",
+      { op: "set", key: "draft", value: "hello" },
+      "req-store-ok",
+    );
+
+    await waitFor(() => expect(postSpy).toHaveBeenCalled());
+    expect(lastResponse(postSpy).ok).toBe(true);
+    const namespaced = `${SANDBOX_STORAGE_PREFIX}${VIEW_ID}:draft`;
+    expect(window.localStorage.getItem(namespaced)).toBe("hello");
+    // The only key written is the namespaced one — no bare "draft" shell key.
+    expect(window.localStorage.getItem("draft")).toBeNull();
+    expect(window.localStorage.length).toBe(1);
+  });
+
+  it("IGNORES a message that is not from this frame's window (identity gate)", async () => {
+    const { postSpy } = mountFrame(GRANTED);
+    // A message with no/other source must not drive the broker.
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: {
+          channel: SANDBOXED_VIEW_CHANNEL,
+          kind: "request",
+          requestId: "spoof",
+          capability: "navigate",
+          payload: { viewId: "chat" },
+        },
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports a bad payload as a typed failure with the grant (never a fake success)", async () => {
+    const navSpy = vi.fn();
+    window.addEventListener(NAVIGATE_VIEW_EVENT, navSpy);
+    const { frameWindow, postSpy } = mountFrame(GRANTED);
+
+    // Granted, but the payload is missing viewId — the facility throws, and the
+    // broker translates it to an observable failure (not a navigate).
+    postFromFrame(frameWindow, "navigate", {}, "req-bad");
+
+    await waitFor(() => expect(postSpy).toHaveBeenCalled());
+    const res = lastResponse(postSpy);
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("viewId");
+    expect(navSpy).not.toHaveBeenCalled();
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, navSpy);
+  });
+});

--- a/packages/ui/src/components/views/SandboxedViewFrame.tsx
+++ b/packages/ui/src/components/views/SandboxedViewFrame.tsx
@@ -1,0 +1,212 @@
+/**
+ * Renders a `sandboxed-iframe` isolation-level view (#14180): an untrusted or
+ * third-party web view embedded in a real `<iframe sandbox>` instead of the host
+ * React realm. `DynamicViewLoader` delegates here when a view's resolved manifest
+ * declares `isolation: "sandboxed-iframe"`, so the framed document runs on an
+ * opaque origin (the sandbox grants `allow-scripts` but never `allow-same-origin`
+ * — see `sandbox-policy.ts`) with no ambient reach into the shell's DOM, storage,
+ * cookies, or navigation.
+ *
+ * The one channel between the frame and the shell is `postMessage`, gated by the
+ * capability broker (`sandboxed-view-broker.ts`): this component installs the
+ * parent-side listener, binds it to the view's live `navigate`/`storage`
+ * facilities, and only accepts messages from THIS frame's `contentWindow`
+ * (identity-bound, since an opaque-origin frame reports origin `"null"`). A
+ * request for a capability the manifest does not grant is answered with a typed
+ * denial and never touches the shell — an ungranted `navigate` changes no route,
+ * an ungranted `storage` writes no key. `storage` is confined to a per-view
+ * namespace so even a granted view can only ever read/write its own keys, never a
+ * shell key.
+ */
+
+import {
+  type ResolvedSurfaceManifest,
+  resolveSurfaceManifest,
+  type SurfaceManifest,
+} from "@elizaos/core";
+import { logger } from "@elizaos/logger";
+import { dispatchNavigateViewEvent } from "@elizaos/shared/events";
+import { useEffect, useMemo, useRef } from "react";
+import { resolveSandboxTokens } from "./sandbox-policy";
+import {
+  brokerSandboxedViewRequest,
+  parseSandboxedViewRequest,
+  type SandboxHostFacilities,
+} from "./sandboxed-view-broker";
+
+/** localStorage prefix that confines a framed view to its own key namespace. */
+export const SANDBOX_STORAGE_PREFIX = "eliza:sbxview:" as const;
+
+/**
+ * The concrete host facilities the broker calls for a view. Split out (and
+ * exported) so tests exercise the real navigate/storage behaviour directly, and
+ * so the frame's listener binds one stable object per view.
+ */
+export function createSandboxHostFacilities(
+  viewId: string,
+): SandboxHostFacilities {
+  return {
+    async navigate(payload: unknown): Promise<unknown> {
+      const target = readNavigatePayload(payload);
+      dispatchNavigateViewEvent({
+        viewId: target.viewId,
+        subview: target.subview,
+        action: target.action,
+      });
+      return { navigated: true, viewId: target.viewId };
+    },
+    async storage(payload: unknown): Promise<unknown> {
+      const request = readStoragePayload(payload);
+      const namespaced = `${SANDBOX_STORAGE_PREFIX}${viewId}:${request.key}`;
+      if (request.op === "get") {
+        return { value: window.localStorage.getItem(namespaced) };
+      }
+      if (request.op === "set") {
+        window.localStorage.setItem(namespaced, request.value);
+        return { ok: true };
+      }
+      window.localStorage.removeItem(namespaced);
+      return { ok: true };
+    },
+  };
+}
+
+interface NavigateTarget {
+  viewId: string;
+  subview?: string;
+  action?: string;
+}
+
+function readNavigatePayload(payload: unknown): NavigateTarget {
+  if (typeof payload !== "object" || payload === null) {
+    throw new Error("navigate requires a { viewId } payload");
+  }
+  const record = payload as Record<string, unknown>;
+  const viewId = record.viewId;
+  if (typeof viewId !== "string" || viewId.length === 0) {
+    throw new Error("navigate requires a non-empty string `viewId`");
+  }
+  return {
+    viewId,
+    subview: typeof record.subview === "string" ? record.subview : undefined,
+    action: typeof record.action === "string" ? record.action : undefined,
+  };
+}
+
+type StorageRequest =
+  | { op: "get"; key: string }
+  | { op: "set"; key: string; value: string }
+  | { op: "remove"; key: string };
+
+function readStoragePayload(payload: unknown): StorageRequest {
+  if (typeof payload !== "object" || payload === null) {
+    throw new Error("storage requires a { op, key } payload");
+  }
+  const record = payload as Record<string, unknown>;
+  const key = record.key;
+  if (typeof key !== "string" || key.length === 0) {
+    throw new Error("storage requires a non-empty string `key`");
+  }
+  const op = record.op;
+  if (op === "get") return { op, key };
+  if (op === "remove") return { op, key };
+  if (op === "set") {
+    if (typeof record.value !== "string") {
+      throw new Error("storage set requires a string `value`");
+    }
+    return { op, key, value: record.value };
+  }
+  throw new Error(`storage: unknown op "${String(op)}"`);
+}
+
+interface SandboxedViewFrameProps {
+  viewId: string;
+  /** The view's declared manifest; resolved to gate the postMessage broker. */
+  surface?: SurfaceManifest;
+  /**
+   * Cross-origin (or opaque-served) document URL for the framed view. Exactly
+   * one of `src` / `srcDoc` is used; `src` is the path for served plugin views.
+   */
+  src?: string;
+  /**
+   * Inline HTML document for a first-party framed view (the sandbox-probe
+   * diagnostics view uses this). Rendered on an opaque origin like any other
+   * sandboxed frame — the inline source does not grant it host access.
+   */
+  srcDoc?: string;
+  /** Extra sandbox tokens to union with the safe default; validated (never defeats the sandbox). */
+  sandboxExtra?: readonly string[];
+  title: string;
+}
+
+/**
+ * Mount a framed view and broker its postMessage requests. The listener binds to
+ * the specific frame `contentWindow` so a message from any other window (or the
+ * host itself) is ignored, and it resolves the manifest once so the grant check
+ * reads a stable {@link ResolvedSurfaceManifest}.
+ */
+export function SandboxedViewFrame({
+  viewId,
+  surface,
+  src,
+  srcDoc,
+  sandboxExtra,
+  title,
+}: SandboxedViewFrameProps) {
+  const frameRef = useRef<HTMLIFrameElement>(null);
+  const resolvedManifest: ResolvedSurfaceManifest = useMemo(
+    () => resolveSurfaceManifest({ surface }),
+    [surface],
+  );
+  // Enforced here too (not only in the attribute) so a bad `sandboxExtra` fails
+  // the render loudly rather than emitting a decorative sandbox.
+  const sandbox = useMemo(
+    () => resolveSandboxTokens(sandboxExtra),
+    [sandboxExtra],
+  );
+  const facilities = useMemo(
+    () => createSandboxHostFacilities(viewId),
+    [viewId],
+  );
+
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      const frameWindow = frameRef.current?.contentWindow;
+      // Identity gate: only this frame may drive its own broker. An opaque-origin
+      // sandbox reports origin "null", so binding to the window object — not an
+      // origin string — is the correct, spoof-proof check.
+      if (!frameWindow || event.source !== frameWindow) return;
+      const request = parseSandboxedViewRequest(event.data);
+      if (!request) return;
+      void brokerSandboxedViewRequest(
+        viewId,
+        resolvedManifest,
+        request,
+        facilities,
+      ).then((response) => {
+        if (!response.ok) {
+          logger.warn(
+            `[SandboxedViewFrame] denied "${request.capability}" for view "${viewId}": ${response.error}`,
+          );
+        }
+        // Opaque-origin frames cannot be targeted by origin, so "*" is required;
+        // the payload is a capability result, not a secret.
+        frameWindow.postMessage(response, "*");
+      });
+    };
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [viewId, resolvedManifest, facilities]);
+
+  return (
+    <iframe
+      ref={frameRef}
+      data-testid={`sandboxed-view-frame-${viewId}`}
+      title={title}
+      sandbox={sandbox}
+      src={src}
+      srcDoc={srcDoc}
+      className="h-full w-full border-0 bg-bg"
+    />
+  );
+}

--- a/packages/ui/src/components/views/sandbox-policy.test.ts
+++ b/packages/ui/src/components/views/sandbox-policy.test.ts
@@ -1,0 +1,48 @@
+// Sandbox-attribute policy (#14180): the MDN foot-gun guard that a framed view
+// never gets `allow-scripts` + `allow-same-origin` together (which would make
+// the sandbox decorative). Pure logic, no DOM.
+
+import { describe, expect, it } from "vitest";
+import {
+  assertRealSandbox,
+  isRealSandbox,
+  resolveSandboxTokens,
+  SANDBOXED_VIEW_TOKENS,
+  SandboxPolicyError,
+} from "./sandbox-policy";
+
+describe("sandbox-policy", () => {
+  it("the default token set runs scripts but is NOT same-origin", () => {
+    expect(SANDBOXED_VIEW_TOKENS).toContain("allow-scripts");
+    expect(SANDBOXED_VIEW_TOKENS).not.toContain("allow-same-origin");
+    expect(isRealSandbox(SANDBOXED_VIEW_TOKENS)).toBe(true);
+  });
+
+  it("flags the allow-scripts + allow-same-origin pairing as not a real sandbox", () => {
+    expect(isRealSandbox(["allow-scripts", "allow-same-origin"])).toBe(false);
+    expect(() =>
+      assertRealSandbox(["allow-scripts", "allow-same-origin"]),
+    ).toThrow(SandboxPolicyError);
+  });
+
+  it("allows same-origin alone or scripts alone (only the pairing is unsafe)", () => {
+    expect(isRealSandbox(["allow-same-origin"])).toBe(true);
+    expect(isRealSandbox(["allow-scripts"])).toBe(true);
+    expect(isRealSandbox(["allow-scripts", "allow-forms"])).toBe(true);
+  });
+
+  it("resolveSandboxTokens returns a deterministic, real-sandbox attribute string", () => {
+    const tokens = resolveSandboxTokens();
+    expect(tokens).toBe("allow-scripts");
+    // Sorted + deduped regardless of extra order.
+    expect(resolveSandboxTokens(["allow-forms", "allow-scripts"])).toBe(
+      "allow-forms allow-scripts",
+    );
+  });
+
+  it("resolveSandboxTokens REFUSES a request that would defeat the sandbox", () => {
+    expect(() => resolveSandboxTokens(["allow-same-origin"])).toThrow(
+      SandboxPolicyError,
+    );
+  });
+});

--- a/packages/ui/src/components/views/sandbox-policy.ts
+++ b/packages/ui/src/components/views/sandbox-policy.ts
@@ -1,0 +1,82 @@
+/**
+ * Sandbox-attribute policy for `sandboxed-iframe` views (#14180). A view at that
+ * isolation level renders in an `<iframe sandbox>`; this module owns the one
+ * security-critical invariant MDN warns about — an iframe that grants both
+ * `allow-scripts` and `allow-same-origin` on same-origin content can reach back
+ * out of the sandbox (it can rewrite its own `sandbox` attribute and re-run with
+ * full privilege), so it is not a real sandbox at all. The shipped token set
+ * therefore grants `allow-scripts` (the framed view needs to run) but never
+ * `allow-same-origin`, which forces the document to an opaque origin: it cannot
+ * touch the host's DOM, cookies, `localStorage`, or same-origin network — every
+ * host facility must instead be requested through the postMessage broker.
+ *
+ * `resolveSandboxTokens` is the single constructor of the attribute string and
+ * `assertRealSandbox` is the grep-able guard both this module and the frame
+ * component run before rendering, so a future edit that widens the token set can
+ * never silently re-introduce the foot-gun. Consumed by `SandboxedViewFrame.tsx`;
+ * unit-tested in `sandbox-policy.test.ts`.
+ */
+
+/** The token that lets the framed view execute — the only privilege it needs. */
+const ALLOW_SCRIPTS = "allow-scripts";
+
+/**
+ * The token that keeps the frame on the host origin. Combined with
+ * {@link ALLOW_SCRIPTS} it defeats the sandbox (MDN), so it is never emitted for
+ * an untrusted view — its presence alongside `allow-scripts` is the exact
+ * condition {@link assertRealSandbox} rejects.
+ */
+const ALLOW_SAME_ORIGIN = "allow-same-origin";
+
+/**
+ * The default sandbox token set for an untrusted framed view: scripts may run,
+ * but the document is forced to an opaque origin (no `allow-same-origin`), so it
+ * has no ambient access to host storage, cookies, or the parent DOM. Everything
+ * it needs from the shell goes through the capability broker.
+ */
+export const SANDBOXED_VIEW_TOKENS: readonly string[] = [ALLOW_SCRIPTS];
+
+/** Raised when a requested sandbox token set would not be a real sandbox. */
+export class SandboxPolicyError extends Error {
+  constructor(reason: string) {
+    super(`Refusing to render a non-isolating iframe sandbox: ${reason}`);
+    this.name = "SandboxPolicyError";
+  }
+}
+
+/**
+ * Whether a token set is a real sandbox for untrusted content. It is not when it
+ * grants scripts AND same-origin at once — that pairing lets the framed document
+ * escape (MDN). Every other combination (scripts alone, same-origin alone, no
+ * scripts) is genuinely isolating for our purposes.
+ */
+export function isRealSandbox(tokens: readonly string[]): boolean {
+  const set = new Set(tokens);
+  return !(set.has(ALLOW_SCRIPTS) && set.has(ALLOW_SAME_ORIGIN));
+}
+
+/**
+ * Throw {@link SandboxPolicyError} unless `tokens` is a real sandbox. Called
+ * before the frame is created so a decorative sandbox can never render.
+ */
+export function assertRealSandbox(tokens: readonly string[]): void {
+  if (!isRealSandbox(tokens)) {
+    throw new SandboxPolicyError(
+      "`allow-scripts` and `allow-same-origin` together let the framed view " +
+        "rewrite its own sandbox and run with full host privilege",
+    );
+  }
+}
+
+/**
+ * Build the `sandbox` attribute string for a framed view. Extra tokens a view
+ * asks for are unioned with the safe default, then validated — a request that
+ * would defeat the sandbox throws rather than downgrading isolation silently.
+ * The returned tokens are sorted so the attribute is deterministic (stable
+ * across renders and snapshot-friendly).
+ */
+export function resolveSandboxTokens(extra: readonly string[] = []): string {
+  const tokens = [...new Set([...SANDBOXED_VIEW_TOKENS, ...extra])].sort();
+  assertRealSandbox(tokens);
+  return tokens.join(" ");
+}

--- a/packages/ui/src/components/views/sandbox-probe-view.tsx
+++ b/packages/ui/src/components/views/sandbox-probe-view.tsx
@@ -1,0 +1,126 @@
+/**
+ * The shipped first-party consumer of the `sandboxed-iframe` isolation level
+ * (#14180): a developer-only diagnostics view that renders a real framed
+ * document and exercises the postMessage capability broker end to end. Before
+ * this view the level was catalogued with `examples: []` — no view declared it —
+ * so the isolation mechanism had no in-app proof. The probe closes that: it is a
+ * genuine opaque-origin `<iframe sandbox>` that requests `navigate` and `storage`
+ * over postMessage and renders the shell's granted/denied replies, letting a
+ * developer see the boundary hold with their own eyes.
+ *
+ * Registered gated behind Developer Mode (`registerSandboxProbeView`) so it never
+ * appears in the normal launcher; named as the level's consumer in
+ * `surface-isolation.ts`. Consumes `SandboxedViewFrame` (the mechanism) directly.
+ */
+
+import type { SurfaceManifest } from "@elizaos/core";
+import { registerAppShellPage } from "../../app-shell-registry";
+import { SandboxedViewFrame } from "./SandboxedViewFrame";
+import { SANDBOXED_VIEW_CHANNEL } from "./sandboxed-view-broker";
+
+/** Stable id; the value `surface-isolation.ts` names as the level's consumer. */
+export const SANDBOX_PROBE_VIEW_ID = "sandbox-probe" as const;
+
+/**
+ * The probe's declared surface: the level under test plus the two brokered grants
+ * so the framed document can demonstrate both facilities succeeding. A view
+ * without these grants is denied — that path is covered by the broker tests.
+ */
+export const SANDBOX_PROBE_MANIFEST: SurfaceManifest = {
+  isolation: "sandboxed-iframe",
+  capabilities: ["navigate", "storage"],
+};
+
+/**
+ * The framed document. Runs on an opaque origin (the frame never gets
+ * `allow-same-origin`), so it cannot touch the shell directly — every action
+ * below goes through `postMessage` and is answered by the broker. Kept dependency
+ * free (inline vanilla JS) because a sandboxed frame shares nothing with the host
+ * bundle.
+ */
+export const SANDBOX_PROBE_DOC = `<!doctype html>
+<html>
+<head><meta charset="utf-8"><style>
+  :root { color-scheme: dark; }
+  body { margin: 0; padding: 16px; font: 13px system-ui, sans-serif;
+         background: #0b0b0d; color: #e7e7ea; }
+  h1 { font-size: 14px; margin: 0 0 12px; }
+  button { font: inherit; padding: 6px 12px; margin-right: 8px; cursor: pointer;
+           color: #0b0b0d; background: #ff7a1a; border: 0; border-radius: 6px; }
+  button:hover { background: #e56400; }
+  pre { margin-top: 12px; padding: 10px; background: #141417; border-radius: 6px;
+        white-space: pre-wrap; word-break: break-word; }
+</style></head>
+<body>
+  <h1>Sandboxed view isolation probe</h1>
+  <button id="nav">Request navigate → chat</button>
+  <button id="store">Request storage write</button>
+  <pre id="log" data-testid="probe-log">idle</pre>
+  <script>
+    var CHANNEL = ${JSON.stringify(SANDBOXED_VIEW_CHANNEL)};
+    var pending = {};
+    var seq = 0;
+    function log(line) { document.getElementById("log").textContent = line; }
+    function request(capability, payload) {
+      var requestId = capability + ":" + (++seq);
+      return new Promise(function (resolve) {
+        pending[requestId] = resolve;
+        parent.postMessage(
+          { channel: CHANNEL, kind: "request", requestId: requestId,
+            capability: capability, payload: payload },
+          "*"
+        );
+      });
+    }
+    window.addEventListener("message", function (event) {
+      var data = event.data;
+      if (!data || data.channel !== CHANNEL || data.kind !== "response") return;
+      var resolve = pending[data.requestId];
+      if (!resolve) return;
+      delete pending[data.requestId];
+      resolve(data);
+    });
+    document.getElementById("nav").addEventListener("click", function () {
+      request("navigate", { viewId: "chat" }).then(function (r) {
+        log(r.ok ? "navigate serviced: " + JSON.stringify(r.result)
+                 : "navigate DENIED: " + r.error);
+      });
+    });
+    document.getElementById("store").addEventListener("click", function () {
+      request("storage", { op: "set", key: "probe", value: "hello" }).then(function (r) {
+        log(r.ok ? "storage serviced: " + JSON.stringify(r.result)
+                 : "storage DENIED: " + r.error);
+      });
+    });
+  </script>
+</body>
+</html>`;
+
+/** The developer-mode page component. */
+export function SandboxProbeView() {
+  return (
+    <SandboxedViewFrame
+      viewId={SANDBOX_PROBE_VIEW_ID}
+      surface={SANDBOX_PROBE_MANIFEST}
+      srcDoc={SANDBOX_PROBE_DOC}
+      title="Sandboxed view isolation probe"
+    />
+  );
+}
+
+/**
+ * Register the probe as a developer-only nav page. Idempotent (the registry keys
+ * by id), so a host may call it at boot without guarding against double-register.
+ */
+export function registerSandboxProbeView(): void {
+  registerAppShellPage({
+    id: SANDBOX_PROBE_VIEW_ID,
+    pluginId: "app-core",
+    label: "Sandbox Probe",
+    icon: "shield",
+    path: `/apps/${SANDBOX_PROBE_VIEW_ID}`,
+    developerOnly: true,
+    surface: SANDBOX_PROBE_MANIFEST,
+    Component: SandboxProbeView,
+  });
+}

--- a/packages/ui/src/components/views/sandboxed-view-broker.test.ts
+++ b/packages/ui/src/components/views/sandboxed-view-broker.test.ts
@@ -1,0 +1,151 @@
+// postMessage capability broker (#14180): deny-by-default over the iframe
+// boundary. Pure logic — parses untrusted messages, checks grants, and returns
+// typed denials without touching a facility when a capability is not granted.
+
+import { resolveSurfaceManifest, type SurfaceManifest } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  brokerSandboxedViewRequest,
+  parseSandboxedViewRequest,
+  SANDBOXED_VIEW_CHANNEL,
+  type SandboxedViewRequest,
+} from "./sandboxed-view-broker";
+
+const NAV_GRANT: SurfaceManifest = { capabilities: ["navigate"] };
+const NO_GRANT: SurfaceManifest = { capabilities: [] };
+
+function req(
+  capability: string,
+  payload?: unknown,
+  requestId = "r1",
+): SandboxedViewRequest {
+  return {
+    channel: SANDBOXED_VIEW_CHANNEL,
+    kind: "request",
+    requestId,
+    capability: capability as SandboxedViewRequest["capability"],
+    payload,
+  };
+}
+
+function facilitySpies() {
+  return {
+    navigate: vi.fn(async () => ({ navigated: true })),
+    storage: vi.fn(async () => ({ ok: true })),
+  };
+}
+
+describe("parseSandboxedViewRequest", () => {
+  it("accepts a well-formed navigate/storage request", () => {
+    expect(
+      parseSandboxedViewRequest({
+        channel: SANDBOXED_VIEW_CHANNEL,
+        kind: "request",
+        requestId: "abc",
+        capability: "navigate",
+        payload: { viewId: "chat" },
+      }),
+    ).toEqual({
+      channel: SANDBOXED_VIEW_CHANNEL,
+      kind: "request",
+      requestId: "abc",
+      capability: "navigate",
+      payload: { viewId: "chat" },
+    });
+  });
+
+  it("rejects wrong channel, wrong kind, missing id, and non-brokered capability", () => {
+    expect(parseSandboxedViewRequest(null)).toBeNull();
+    expect(parseSandboxedViewRequest("nope")).toBeNull();
+    expect(
+      parseSandboxedViewRequest({
+        channel: "other",
+        kind: "request",
+        requestId: "x",
+        capability: "navigate",
+      }),
+    ).toBeNull();
+    expect(
+      parseSandboxedViewRequest({
+        channel: SANDBOXED_VIEW_CHANNEL,
+        kind: "response",
+        requestId: "x",
+        capability: "navigate",
+      }),
+    ).toBeNull();
+    expect(
+      parseSandboxedViewRequest({
+        channel: SANDBOXED_VIEW_CHANNEL,
+        kind: "request",
+        requestId: "",
+        capability: "navigate",
+      }),
+    ).toBeNull();
+    // `wallpaper`/`agent-surface` are SurfaceCapabilities but NOT brokered here.
+    expect(
+      parseSandboxedViewRequest({
+        channel: SANDBOXED_VIEW_CHANNEL,
+        kind: "request",
+        requestId: "x",
+        capability: "wallpaper",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("brokerSandboxedViewRequest", () => {
+  it("DENIES navigate without the grant — the facility never runs", async () => {
+    const facilities = facilitySpies();
+    const res = await brokerSandboxedViewRequest(
+      "v1",
+      resolveSurfaceManifest({ surface: NO_GRANT }),
+      req("navigate", { viewId: "chat" }),
+      facilities,
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("not granted capability");
+    expect(facilities.navigate).not.toHaveBeenCalled();
+  });
+
+  it("DENIES storage without the grant — the facility never runs", async () => {
+    const facilities = facilitySpies();
+    const res = await brokerSandboxedViewRequest(
+      "v1",
+      resolveSurfaceManifest({ surface: NAV_GRANT }),
+      req("storage", { op: "set", key: "k", value: "v" }),
+      facilities,
+    );
+    expect(res.ok).toBe(false);
+    expect(facilities.storage).not.toHaveBeenCalled();
+  });
+
+  it("SERVICES a granted capability and returns its result", async () => {
+    const facilities = facilitySpies();
+    const res = await brokerSandboxedViewRequest(
+      "v1",
+      resolveSurfaceManifest({ surface: NAV_GRANT }),
+      req("navigate", { viewId: "chat" }),
+      facilities,
+    );
+    expect(res.ok).toBe(true);
+    expect(res.result).toEqual({ navigated: true });
+    expect(facilities.navigate).toHaveBeenCalledWith({ viewId: "chat" });
+  });
+
+  it("translates a facility throw into a typed failure frame (never a fake success)", async () => {
+    const facilities = {
+      navigate: vi.fn(async () => {
+        throw new Error("bad payload");
+      }),
+      storage: vi.fn(async () => ({ ok: true })),
+    };
+    const res = await brokerSandboxedViewRequest(
+      "v1",
+      resolveSurfaceManifest({ surface: NAV_GRANT }),
+      req("navigate", {}),
+      facilities,
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe("bad payload");
+  });
+});

--- a/packages/ui/src/components/views/sandboxed-view-broker.ts
+++ b/packages/ui/src/components/views/sandboxed-view-broker.ts
@@ -1,0 +1,158 @@
+/**
+ * postMessage capability broker for `sandboxed-iframe` views (#14180). A framed
+ * view runs in an opaque-origin `<iframe sandbox>` (see `sandbox-policy.ts`), so
+ * it has zero ambient access to the shell — no shared DOM, storage, cookies, or
+ * navigation. The only channel out is `postMessage`, and this module is the gate
+ * on the parent side of it: it parses the untrusted message (J3), checks the
+ * requested {@link SurfaceCapability} against the view's resolved manifest, and
+ * either services the request through a host facility or returns a typed denial.
+ *
+ * It mirrors the deny-by-default doctrine of the same-realm agent-interact broker
+ * (`view-capability-broker.ts`, #14068): anything not explicitly granted is
+ * denied, an unparseable/unknown message is dropped, and a denied request yields
+ * an observable typed error to the framed view — never a silent no-op that a
+ * plugin could mistake for success. `navigate` and `storage` are the only
+ * facilities exposed; they already exist as `SurfaceCapability` values.
+ *
+ * Consumed by `SandboxedViewFrame.tsx` (which binds the {@link SandboxHostFacilities}
+ * to the real shell navigate/storage) and unit-tested in
+ * `sandboxed-view-broker.test.ts`.
+ */
+
+import {
+  type ResolvedSurfaceManifest,
+  type SurfaceCapability,
+  surfaceGrants,
+} from "@elizaos/core";
+
+/** Marks every frame of the sandboxed-view protocol so unrelated postMessages are ignored. */
+export const SANDBOXED_VIEW_CHANNEL = "eliza:sandboxed-view" as const;
+
+/** The capabilities a framed view may request over postMessage. */
+const BROKERED_CAPABILITIES: ReadonlySet<SurfaceCapability> =
+  new Set<SurfaceCapability>(["navigate", "storage"]);
+
+/** A request a framed view sends to the shell. */
+export interface SandboxedViewRequest {
+  channel: typeof SANDBOXED_VIEW_CHANNEL;
+  kind: "request";
+  /** Correlates the response the shell posts back. */
+  requestId: string;
+  capability: SurfaceCapability;
+  /** Capability-specific arguments, validated by the servicing facility. */
+  payload?: unknown;
+}
+
+/** The reply the shell posts back to the framed view for a request. */
+export interface SandboxedViewResponse {
+  channel: typeof SANDBOXED_VIEW_CHANNEL;
+  kind: "response";
+  requestId: string;
+  ok: boolean;
+  result?: unknown;
+  /** Present iff `ok` is false — a human-readable denial/failure reason. */
+  error?: string;
+}
+
+/**
+ * The real shell facilities the broker calls when a capability is granted. The
+ * frame component binds these to `dispatchNavigateViewEvent` and a per-view
+ * namespaced storage; tests bind them to spies to assert the broker only reaches
+ * a facility when the grant check passes.
+ */
+export interface SandboxHostFacilities {
+  navigate(payload: unknown): Promise<unknown>;
+  storage(payload: unknown): Promise<unknown>;
+}
+
+/**
+ * Parse an untrusted `MessageEvent.data` into a {@link SandboxedViewRequest}, or
+ * `null` if it is not a well-formed request for a brokered capability. This is
+ * the J3 boundary: a malformed or unknown-capability message is rejected here
+ * and never reaches a facility.
+ */
+export function parseSandboxedViewRequest(
+  data: unknown,
+): SandboxedViewRequest | null {
+  if (typeof data !== "object" || data === null) return null;
+  const msg = data as Record<string, unknown>;
+  if (msg.channel !== SANDBOXED_VIEW_CHANNEL) return null;
+  if (msg.kind !== "request") return null;
+  if (typeof msg.requestId !== "string" || msg.requestId.length === 0) {
+    return null;
+  }
+  const capability = msg.capability;
+  if (
+    typeof capability !== "string" ||
+    !BROKERED_CAPABILITIES.has(capability as SurfaceCapability)
+  ) {
+    return null;
+  }
+  return {
+    channel: SANDBOXED_VIEW_CHANNEL,
+    kind: "request",
+    requestId: msg.requestId,
+    capability: capability as SurfaceCapability,
+    payload: msg.payload,
+  };
+}
+
+/** Raised when a framed view requests a capability its manifest does not grant. */
+export class SandboxCapabilityDeniedError extends Error {
+  constructor(
+    readonly viewId: string,
+    readonly capability: SurfaceCapability,
+  ) {
+    super(
+      `Sandboxed view "${viewId}" is not granted capability "${capability}"`,
+    );
+    this.name = "SandboxCapabilityDeniedError";
+  }
+}
+
+/**
+ * Broker one parsed request against the manifest. Returns the response frame to
+ * post back to the view. A capability the manifest does not grant is denied
+ * before the facility runs, so an ungranted `navigate`/`storage` can never reach
+ * the shell — the denial is reported as `ok: false` with a reason, never a
+ * fabricated success.
+ */
+export async function brokerSandboxedViewRequest(
+  viewId: string,
+  manifest: ResolvedSurfaceManifest,
+  request: SandboxedViewRequest,
+  facilities: SandboxHostFacilities,
+): Promise<SandboxedViewResponse> {
+  const base = {
+    channel: SANDBOXED_VIEW_CHANNEL,
+    kind: "response",
+    requestId: request.requestId,
+  } as const;
+
+  if (!surfaceGrants(manifest, request.capability)) {
+    return {
+      ...base,
+      ok: false,
+      error: new SandboxCapabilityDeniedError(viewId, request.capability)
+        .message,
+    };
+  }
+
+  try {
+    const facility =
+      request.capability === "navigate"
+        ? facilities.navigate
+        : facilities.storage;
+    const result = await facility(request.payload);
+    return { ...base, ok: true, result };
+  } catch (error) {
+    // error-policy:J1 boundary translation — the framed view is a transport
+    // boundary; a facility throw (bad payload, storage failure) becomes a typed
+    // failure frame the view observes, never a fabricated success.
+    return {
+      ...base,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/packages/ui/src/surface-isolation.test.ts
+++ b/packages/ui/src/surface-isolation.test.ts
@@ -36,4 +36,12 @@ describe("surface-isolation catalogue", () => {
     expect(examples).toContain("chat");
     expect(examples).toContain("settings");
   });
+
+  it("the sandboxed-iframe level names its shipped consumer (#14180)", () => {
+    // The level was `examples: []` until a real framed consumer shipped; the
+    // sandbox-probe developer view now exercises the postMessage broker path.
+    const examples = isolationEntry("sandboxed-iframe").examples;
+    expect(examples.length).toBeGreaterThan(0);
+    expect(examples).toContain("sandbox-probe");
+  });
 });

--- a/packages/ui/src/surface-isolation.ts
+++ b/packages/ui/src/surface-isolation.ts
@@ -20,10 +20,10 @@
  *  sandboxed-iframe — untrusted or third-party WEB views that must not share the
  *    host realm. They render in an `<iframe sandbox>` with a postMessage
  *    capability broker; MDN warns that `allow-scripts` + `allow-same-origin` on
- *    same-origin content is not a real sandbox, so an untrusted view is served
- *    from a distinct origin or without `allow-same-origin`. No shipped built-in
- *    view uses this today (every first-party view is in-process); it is the
- *    designated level for future untrusted web plugin views.
+ *    same-origin content is not a real sandbox, so the frame is served without
+ *    `allow-same-origin` (opaque origin) and reaches the shell only through the
+ *    broker (`navigate`/`storage`). `DynamicViewLoader` frames any view declaring
+ *    this level; the `sandbox-probe` developer view is the shipped consumer.
  *
  *  native-webview — heavy or untrusted views that embed a NATIVE child
  *    web-content surface with its own renderer process and an explicit
@@ -92,12 +92,14 @@ export const SURFACE_ISOLATION_CATALOGUE: Readonly<
   "sandboxed-iframe": {
     level: "sandboxed-iframe",
     rationale:
-      "Untrusted / third-party WEB views. Rendered in an `<iframe sandbox>` with " +
-      "a postMessage capability broker, served cross-origin (never " +
-      "`allow-scripts` + `allow-same-origin` on same-origin content). No shipped " +
-      "built-in view uses this yet — it is the designated level for future " +
-      "untrusted web plugin views.",
-    examples: [],
+      "Untrusted / third-party WEB views. Rendered in an `<iframe sandbox>` " +
+      "(`allow-scripts`, never `allow-same-origin` — so the document is opaque " +
+      "origin and cannot reach host DOM/storage/cookies) with a postMessage " +
+      "capability broker gating `navigate`/`storage`. `DynamicViewLoader` frames " +
+      "any view whose manifest declares this level instead of importing it into " +
+      "the host realm; the `sandbox-probe` developer view is the shipped " +
+      "first-party consumer (see `SandboxedViewFrame.tsx`).",
+    examples: ["sandbox-probe"],
   },
   "native-webview": {
     level: "native-webview",


### PR DESCRIPTION
Implements #14180 — sandboxed-iframe view-isolation level (child of #13452): real `<iframe sandbox>` opaque-origin embedding, deny-by-default postMessage capability broker gating navigate/storage with typed denials, DynamicViewLoader delegation so untrusted content never runs in the host realm, + a first-party developer-only sandbox-probe consumer. Real red→green tests prove state/navigation/storage cannot leak across the boundary without a grant.

⚠️ Overlap note for maintainer: @lalalune is running an active fleet on the #13452 surface-manifest subsystem (#14251/#14258). Not force-merging — reconcile if it composes cleanly, close if superseded.

Closes #14180

🤖 Generated with [Claude Code](https://claude.com/claude-code)