### PR TITLE
feat(import): add resumable upload state

### DIFF
--- a/.github/issue-evidence/13432-resumable-upload-state.md
+++ b/.github/issue-evidence/13432-resumable-upload-state.md
@@ -9,8 +9,11 @@
   - expected byte ranges per chunk,
   - SHA-256 validation,
   - idempotent duplicate chunk retries,
+  - hydration validation for persisted session metadata,
+  - merge semantics for independently accepted non-overlapping chunks from concurrent stale reads,
   - missing-range reporting,
   - progress and completion state.
+- The state stores chunk metadata and digests only. It does not store bytes or introduce a second file/media store.
 
 ## Local verification
 
@@ -21,9 +24,17 @@
 - `bunx @biomejs/biome check packages/import-conversations/src/core/resumable.ts packages/import-conversations/src/core/resumable.test.ts packages/import-conversations/src/core/index.ts .github/issue-evidence/13432-resumable-upload-state.md --no-errors-on-unmatched`
 - `git diff --check`
 
+Follow-up validation for the concurrency/hydration review fixes:
+
+- `node /Users/shawwalters/milaidy/eliza/node_modules/vitest/vitest.mjs run --config /tmp/codex-vitest-empty.mjs packages/import-conversations/src/core/resumable.test.ts --run` - pass, 1 file / 11 tests.
+- `bunx tsc --ignoreConfig --noEmit --skipLibCheck --typeRoots /Users/shawwalters/milaidy/eliza/node_modules/@types --types node --lib ES2022 --module ESNext --target ES2022 --moduleResolution bundler packages/import-conversations/src/core/resumable.ts` - pass.
+- `bunx @biomejs/biome check packages/import-conversations/src/core/resumable.ts packages/import-conversations/src/core/resumable.test.ts packages/import-conversations/src/core/index.ts .github/issue-evidence/13432-resumable-upload-state.md --no-errors-on-unmatched && git diff --check` - pass.
+
+The package script `bun run --cwd packages/import-conversations test -- src/core/resumable.test.ts` could not start in the sparse verification worktree until workspace dependencies are installed (`node_modules/vitest/vitest.mjs` missing). The focused Vitest invocation above uses the installed repo Vitest binary and a minimal node-environment config to exercise the same test file.
+
 ## Evidence matrix
 
 - Backend logs: N/A - pure importer-core state primitive; no route or object-store write path changed.
 - Frontend screenshots/video: N/A - no UI changed.
 - Real-LLM trajectories: N/A - no agent/action/provider/prompt/model behavior changed.
-- Domain artifacts: unit tests prove chunk range/hash rejection, duplicate retry idempotency, missing-range reporting, and complete progress state.
+- Domain artifacts: unit tests prove chunk range/hash rejection, duplicate retry idempotency, persisted-state validation, concurrent non-overlapping chunk merge, conflict rejection, missing-range reporting, and complete progress state.

--- a/.github/issue-evidence/13432-resumable-upload-state.md
+++ b/.github/issue-evidence/13432-resumable-upload-state.md
@@ -1,0 +1,29 @@
+# Issue #13432 Resumable Upload State Evidence
+
+## Change
+
+- Added `packages/import-conversations/src/core/resumable.ts`.
+- The module models resumable import upload sessions as deterministic state:
+  - positive upload/chunk sizing,
+  - safe session ids,
+  - expected byte ranges per chunk,
+  - SHA-256 validation,
+  - idempotent duplicate chunk retries,
+  - missing-range reporting,
+  - progress and completion state.
+
+## Local verification
+
+- `bun run --cwd packages/import-conversations test -- src/core/resumable.test.ts`
+- `bun run --cwd packages/import-conversations test` (14 files, 161 tests)
+- `bun run --cwd packages/import-conversations typecheck`
+- `bun run --cwd packages/import-conversations build`
+- `bunx @biomejs/biome check packages/import-conversations/src/core/resumable.ts packages/import-conversations/src/core/resumable.test.ts packages/import-conversations/src/core/index.ts .github/issue-evidence/13432-resumable-upload-state.md --no-errors-on-unmatched`
+- `git diff --check`
+
+## Evidence matrix
+
+- Backend logs: N/A - pure importer-core state primitive; no route or object-store write path changed.
+- Frontend screenshots/video: N/A - no UI changed.
+- Real-LLM trajectories: N/A - no agent/action/provider/prompt/model behavior changed.
+- Domain artifacts: unit tests prove chunk range/hash rejection, duplicate retry idempotency, missing-range reporting, and complete progress state.

--- a/packages/import-conversations/src/core/index.ts
+++ b/packages/import-conversations/src/core/index.ts
@@ -7,5 +7,6 @@ export * from "./redact.ts";
 export * from "./registry.ts";
 export * from "./render.ts";
 export * from "./report.ts";
+export * from "./resumable.ts";
 export * from "./sink.ts";
 export * from "./types.ts";

--- a/packages/import-conversations/src/core/resumable.test.ts
+++ b/packages/import-conversations/src/core/resumable.test.ts
@@ -1,10 +1,21 @@
+/**
+ * Resumable upload state tests for import-conversations.
+ *
+ * These cover the pure metadata contract that future HTTP/object-store routes
+ * will persist between chunk requests: range/hash validation, idempotent
+ * retries, hydration validation, and merge semantics for independently accepted
+ * chunks. Bytes remain outside this state object.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   createResumableUploadSession,
   findMissingResumableUploadRanges,
   getResumableUploadProgress,
+  mergeResumableUploadSessions,
   recordResumableChunk,
   sha256Hex,
+  validateResumableUploadSession,
 } from "./resumable.ts";
 
 describe("resumable import upload state", () => {
@@ -96,7 +107,7 @@ describe("resumable import upload state", () => {
     });
 
     expect(retry.status).toBe("duplicate");
-    expect(retry.session).toBe(first.session);
+    expect(retry.session).toEqual(first.session);
     expect(retry.chunk.receivedAt).toBe(10);
   });
 
@@ -214,5 +225,128 @@ describe("resumable import upload state", () => {
       receivedChunks: 1,
       complete: false,
     });
+  });
+
+  it("validates hydrated persisted state before computing progress", () => {
+    const session = createResumableUploadSession({
+      sessionId: "s1",
+      uploadBytes: 8,
+      chunkSize: 4,
+      now: () => 0,
+    });
+    const next = recordResumableChunk(session, {
+      index: 0,
+      offset: 0,
+      bytes: "aaaa",
+    }).session;
+
+    expect(validateResumableUploadSession(next)).toEqual(next);
+    expect(() =>
+      validateResumableUploadSession({
+        ...next,
+        chunkCount: 99,
+      }),
+    ).toThrow(/chunkCount/);
+    expect(() =>
+      getResumableUploadProgress({
+        ...next,
+        status: "complete",
+      }),
+    ).toThrow(/status/);
+    expect(() =>
+      findMissingResumableUploadRanges({
+        ...next,
+        chunks: {
+          ...next.chunks,
+          0: {
+            ...next.chunks[0],
+            byteLength: 3,
+          },
+        },
+      }),
+    ).toThrow(/byteLength/);
+    expect(() =>
+      validateResumableUploadSession({
+        ...next,
+        chunks: {
+          "00": next.chunks[0],
+        },
+      }),
+    ).toThrow(/canonical/);
+    expect(() =>
+      validateResumableUploadSession({
+        ...next,
+        updatedAt: 0,
+      }),
+    ).toThrow(/updatedAt/);
+  });
+
+  it("merges non-overlapping accepted chunks from concurrent stale reads", () => {
+    const base = createResumableUploadSession({
+      sessionId: "s1",
+      uploadBytes: 8,
+      chunkSize: 4,
+      now: () => 0,
+    });
+    const firstWriter = recordResumableChunk(base, {
+      index: 0,
+      offset: 0,
+      bytes: "aaaa",
+      now: () => 10,
+    }).session;
+    const secondWriter = recordResumableChunk(base, {
+      index: 1,
+      offset: 4,
+      bytes: "bbbb",
+      now: () => 20,
+    }).session;
+
+    const merged = mergeResumableUploadSessions(
+      base,
+      firstWriter,
+      secondWriter,
+    );
+
+    expect(merged.status).toBe("complete");
+    expect(merged.updatedAt).toBe(20);
+    expect(Object.keys(merged.chunks).sort()).toEqual(["0", "1"]);
+    expect(getResumableUploadProgress(merged)).toEqual({
+      receivedBytes: 8,
+      uploadBytes: 8,
+      receivedChunks: 2,
+      chunkCount: 2,
+      complete: true,
+    });
+  });
+
+  it("rejects conflicting merged chunks and mismatched session identities", () => {
+    const base = createResumableUploadSession({
+      sessionId: "s1",
+      uploadBytes: 4,
+      chunkSize: 4,
+      now: () => 0,
+    });
+    const first = recordResumableChunk(base, {
+      index: 0,
+      offset: 0,
+      bytes: "aaaa",
+      now: () => 10,
+    }).session;
+    const conflict = recordResumableChunk(base, {
+      index: 0,
+      offset: 0,
+      bytes: "bbbb",
+      now: () => 20,
+    }).session;
+
+    expect(() => mergeResumableUploadSessions(base, first, conflict)).toThrow(
+      /conflicts/,
+    );
+    expect(() =>
+      mergeResumableUploadSessions(base, {
+        ...first,
+        sessionId: "other",
+      }),
+    ).toThrow(/sessionId/);
   });
 });

--- a/packages/import-conversations/src/core/resumable.test.ts
+++ b/packages/import-conversations/src/core/resumable.test.ts
@@ -14,7 +14,7 @@ import {
   getResumableUploadProgress,
   mergeResumableUploadSessions,
   recordResumableChunk,
-  sha256Hex,
+  resumableSha256Hex,
   validateResumableUploadSession,
 } from "./resumable.ts";
 
@@ -152,7 +152,7 @@ describe("resumable import upload state", () => {
         index: 0,
         offset: 0,
         bytes: "aaaa",
-        sha256: sha256Hex("bbbb"),
+        sha256: resumableSha256Hex("bbbb"),
       }),
     ).toThrow(/sha256/);
     expect(() =>

--- a/packages/import-conversations/src/core/resumable.test.ts
+++ b/packages/import-conversations/src/core/resumable.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import {
+  createResumableUploadSession,
+  findMissingResumableUploadRanges,
+  getResumableUploadProgress,
+  recordResumableChunk,
+  sha256Hex,
+} from "./resumable.ts";
+
+describe("resumable import upload state", () => {
+  it("creates deterministic open sessions", () => {
+    const session = createResumableUploadSession({
+      sessionId: "import-batch-a",
+      uploadBytes: 10,
+      chunkSize: 4,
+      now: () => 123,
+    });
+
+    expect(session).toEqual({
+      sessionId: "import-batch-a",
+      uploadBytes: 10,
+      chunkSize: 4,
+      chunkCount: 3,
+      createdAt: 123,
+      updatedAt: 123,
+      status: "open",
+      chunks: {},
+    });
+  });
+
+  it("records chunks, progress, missing ranges, and completion", () => {
+    let session = createResumableUploadSession({
+      sessionId: "s1",
+      uploadBytes: 10,
+      chunkSize: 4,
+      now: () => 0,
+    });
+
+    const first = recordResumableChunk(session, {
+      index: 1,
+      offset: 4,
+      bytes: "bbbb",
+      now: () => 10,
+    });
+    expect(first.status).toBe("accepted");
+    session = first.session;
+    expect(first.progress).toEqual({
+      receivedBytes: 4,
+      uploadBytes: 10,
+      receivedChunks: 1,
+      chunkCount: 3,
+      complete: false,
+    });
+    expect(findMissingResumableUploadRanges(session)).toEqual([
+      { start: 0, endExclusive: 4, chunkIndex: 0 },
+      { start: 8, endExclusive: 10, chunkIndex: 2 },
+    ]);
+
+    session = recordResumableChunk(session, {
+      index: 0,
+      offset: 0,
+      bytes: "aaaa",
+      now: () => 20,
+    }).session;
+    const final = recordResumableChunk(session, {
+      index: 2,
+      offset: 8,
+      bytes: "cc",
+      now: () => 30,
+    });
+
+    expect(final.session.status).toBe("complete");
+    expect(final.progress.complete).toBe(true);
+    expect(final.progress.receivedBytes).toBe(10);
+    expect(findMissingResumableUploadRanges(final.session)).toEqual([]);
+  });
+
+  it("treats identical duplicate chunks as idempotent retries", () => {
+    const session = createResumableUploadSession({
+      sessionId: "s1",
+      uploadBytes: 4,
+      chunkSize: 4,
+      now: () => 0,
+    });
+    const first = recordResumableChunk(session, {
+      index: 0,
+      offset: 0,
+      bytes: "abcd",
+      now: () => 10,
+    });
+    const retry = recordResumableChunk(first.session, {
+      index: 0,
+      offset: 0,
+      bytes: "abcd",
+      now: () => 20,
+    });
+
+    expect(retry.status).toBe("duplicate");
+    expect(retry.session).toBe(first.session);
+    expect(retry.chunk.receivedAt).toBe(10);
+  });
+
+  it("rejects conflicting duplicate chunks", () => {
+    const session = createResumableUploadSession({
+      sessionId: "s1",
+      uploadBytes: 4,
+      chunkSize: 4,
+      now: () => 0,
+    });
+    const first = recordResumableChunk(session, {
+      index: 0,
+      offset: 0,
+      bytes: "abcd",
+    });
+
+    expect(() =>
+      recordResumableChunk(first.session, {
+        index: 0,
+        offset: 0,
+        bytes: "wxyz",
+      }),
+    ).toThrow(/conflicts/);
+  });
+
+  it("rejects wrong byte ranges and wrong chunk hashes", () => {
+    const session = createResumableUploadSession({
+      sessionId: "s1",
+      uploadBytes: 10,
+      chunkSize: 4,
+      now: () => 0,
+    });
+
+    expect(() =>
+      recordResumableChunk(session, { index: 1, offset: 5, bytes: "bbbb" }),
+    ).toThrow(/offset/);
+    expect(() =>
+      recordResumableChunk(session, { index: 0, offset: 0, bytes: "too-long" }),
+    ).toThrow(/length/);
+    expect(() =>
+      recordResumableChunk(session, {
+        index: 0,
+        offset: 0,
+        bytes: "aaaa",
+        sha256: sha256Hex("bbbb"),
+      }),
+    ).toThrow(/sha256/);
+    expect(() =>
+      recordResumableChunk(session, { index: 3, offset: 12, bytes: "" }),
+    ).toThrow(/outside/);
+  });
+
+  it("keeps completed duplicate retries idempotent", () => {
+    const session = createResumableUploadSession({
+      sessionId: "s1",
+      uploadBytes: 4,
+      chunkSize: 4,
+    });
+    const complete = recordResumableChunk(session, {
+      index: 0,
+      offset: 0,
+      bytes: "aaaa",
+    }).session;
+
+    const retry = recordResumableChunk(complete, {
+      index: 0,
+      offset: 0,
+      bytes: "aaaa",
+    });
+
+    expect(retry.status).toBe("duplicate");
+    expect(retry.progress.complete).toBe(true);
+  });
+
+  it("rejects unsafe or nonsensical session metadata", () => {
+    expect(() =>
+      createResumableUploadSession({
+        sessionId: "../escape",
+        uploadBytes: 1,
+        chunkSize: 1,
+      }),
+    ).toThrow(/sessionId/);
+    expect(() =>
+      createResumableUploadSession({
+        sessionId: "s1",
+        uploadBytes: 0,
+        chunkSize: 1,
+      }),
+    ).toThrow(/uploadBytes/);
+    expect(() =>
+      createResumableUploadSession({
+        sessionId: "s1",
+        uploadBytes: 1,
+        chunkSize: Number.NaN,
+      }),
+    ).toThrow(/chunkSize/);
+  });
+
+  it("computes progress from persisted state without mutation", () => {
+    const session = createResumableUploadSession({
+      sessionId: "s1",
+      uploadBytes: 6,
+      chunkSize: 3,
+      now: () => 0,
+    });
+    const next = recordResumableChunk(session, {
+      index: 0,
+      offset: 0,
+      bytes: new Uint8Array([1, 2, 3]),
+    }).session;
+
+    expect(getResumableUploadProgress(session).receivedBytes).toBe(0);
+    expect(getResumableUploadProgress(next)).toMatchObject({
+      receivedBytes: 3,
+      receivedChunks: 1,
+      complete: false,
+    });
+  });
+});

--- a/packages/import-conversations/src/core/resumable.ts
+++ b/packages/import-conversations/src/core/resumable.ts
@@ -116,7 +116,7 @@ export function recordResumableChunk(
     );
   }
 
-  const sha256 = sha256Hex(options.bytes);
+  const sha256 = resumableSha256Hex(options.bytes);
   if (options.sha256 !== undefined && options.sha256 !== sha256) {
     throw new Error(
       `recordResumableChunk: chunk ${options.index} sha256 mismatch`,
@@ -327,7 +327,7 @@ export function mergeResumableUploadSessions(
   };
 }
 
-export function sha256Hex(bytes: Uint8Array | string): string {
+export function resumableSha256Hex(bytes: Uint8Array | string): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
 

--- a/packages/import-conversations/src/core/resumable.ts
+++ b/packages/import-conversations/src/core/resumable.ts
@@ -1,0 +1,247 @@
+/**
+ * Resumable upload session state for large conversation imports.
+ *
+ * The cloud transport can persist this shape between requests, but the rules
+ * stay pure here: validate chunk index/range/hash, make duplicate chunk retries
+ * idempotent, report missing ranges, and expose deterministic progress.
+ */
+
+import { createHash } from "node:crypto";
+
+export interface ResumableUploadSession {
+  sessionId: string;
+  uploadBytes: number;
+  chunkSize: number;
+  chunkCount: number;
+  createdAt: number;
+  updatedAt: number;
+  status: "open" | "complete";
+  chunks: Record<number, ResumableUploadChunk>;
+}
+
+export interface ResumableUploadChunk {
+  index: number;
+  offset: number;
+  byteLength: number;
+  sha256: string;
+  receivedAt: number;
+}
+
+export interface CreateResumableUploadSessionOptions {
+  sessionId: string;
+  uploadBytes: number;
+  chunkSize: number;
+  now?: () => number;
+}
+
+export interface RecordResumableChunkOptions {
+  index: number;
+  offset: number;
+  bytes: Uint8Array | string;
+  /** Optional caller-supplied digest; when present it must match the bytes. */
+  sha256?: string;
+  now?: () => number;
+}
+
+export interface ResumableUploadProgress {
+  receivedBytes: number;
+  uploadBytes: number;
+  receivedChunks: number;
+  chunkCount: number;
+  complete: boolean;
+}
+
+export interface MissingUploadRange {
+  start: number;
+  endExclusive: number;
+  chunkIndex: number;
+}
+
+export type RecordResumableChunkResult =
+  | {
+      status: "accepted";
+      session: ResumableUploadSession;
+      chunk: ResumableUploadChunk;
+      progress: ResumableUploadProgress;
+    }
+  | {
+      status: "duplicate";
+      session: ResumableUploadSession;
+      chunk: ResumableUploadChunk;
+      progress: ResumableUploadProgress;
+    };
+
+const DEFAULT_NOW = () => Date.now();
+const SAFE_SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+export function createResumableUploadSession(
+  options: CreateResumableUploadSessionOptions,
+): ResumableUploadSession {
+  const sessionId = safeSessionId(options.sessionId);
+  assertPositiveInteger(options.uploadBytes, "uploadBytes");
+  assertPositiveInteger(options.chunkSize, "chunkSize");
+
+  const now = options.now ?? DEFAULT_NOW;
+  const timestamp = now();
+  return {
+    sessionId,
+    uploadBytes: options.uploadBytes,
+    chunkSize: options.chunkSize,
+    chunkCount: Math.ceil(options.uploadBytes / options.chunkSize),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    status: "open",
+    chunks: {},
+  };
+}
+
+export function recordResumableChunk(
+  session: ResumableUploadSession,
+  options: RecordResumableChunkOptions,
+): RecordResumableChunkResult {
+  const expected = expectedChunkRange(session, options.index);
+  if (options.offset !== expected.start) {
+    throw new Error(
+      `recordResumableChunk: chunk ${options.index} offset ${options.offset} does not match expected ${expected.start}`,
+    );
+  }
+
+  const byteLength = resumableByteLength(options.bytes);
+  const expectedLength = expected.endExclusive - expected.start;
+  if (byteLength !== expectedLength) {
+    throw new Error(
+      `recordResumableChunk: chunk ${options.index} length ${byteLength} does not match expected ${expectedLength}`,
+    );
+  }
+
+  const sha256 = sha256Hex(options.bytes);
+  if (options.sha256 !== undefined && options.sha256 !== sha256) {
+    throw new Error(
+      `recordResumableChunk: chunk ${options.index} sha256 mismatch`,
+    );
+  }
+
+  const existing = session.chunks[options.index];
+  if (existing) {
+    if (
+      existing.offset !== options.offset ||
+      existing.byteLength !== byteLength ||
+      existing.sha256 !== sha256
+    ) {
+      throw new Error(
+        `recordResumableChunk: chunk ${options.index} conflicts with previously received bytes`,
+      );
+    }
+    return {
+      status: "duplicate",
+      session,
+      chunk: existing,
+      progress: getResumableUploadProgress(session),
+    };
+  }
+
+  if (session.status !== "open") {
+    throw new Error("recordResumableChunk: session is already complete");
+  }
+
+  const receivedAt = (options.now ?? DEFAULT_NOW)();
+  const chunk: ResumableUploadChunk = {
+    index: options.index,
+    offset: options.offset,
+    byteLength,
+    sha256,
+    receivedAt,
+  };
+  const chunks = { ...session.chunks, [options.index]: chunk };
+  const complete = Object.keys(chunks).length === session.chunkCount;
+  const next: ResumableUploadSession = {
+    ...session,
+    chunks,
+    updatedAt: receivedAt,
+    status: complete ? "complete" : "open",
+  };
+
+  return {
+    status: "accepted",
+    session: next,
+    chunk,
+    progress: getResumableUploadProgress(next),
+  };
+}
+
+export function getResumableUploadProgress(
+  session: ResumableUploadSession,
+): ResumableUploadProgress {
+  const chunks = Object.values(session.chunks);
+  return {
+    receivedBytes: chunks.reduce((total, chunk) => total + chunk.byteLength, 0),
+    uploadBytes: session.uploadBytes,
+    receivedChunks: chunks.length,
+    chunkCount: session.chunkCount,
+    complete: chunks.length === session.chunkCount,
+  };
+}
+
+export function findMissingResumableUploadRanges(
+  session: ResumableUploadSession,
+): MissingUploadRange[] {
+  const ranges: MissingUploadRange[] = [];
+  for (let index = 0; index < session.chunkCount; index += 1) {
+    if (session.chunks[index]) continue;
+    const range = expectedChunkRange(session, index);
+    ranges.push({
+      start: range.start,
+      endExclusive: range.endExclusive,
+      chunkIndex: index,
+    });
+  }
+  return ranges;
+}
+
+export function sha256Hex(bytes: Uint8Array | string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function resumableByteLength(bytes: Uint8Array | string): number {
+  return typeof bytes === "string"
+    ? Buffer.byteLength(bytes, "utf8")
+    : bytes.byteLength;
+}
+
+function expectedChunkRange(
+  session: ResumableUploadSession,
+  index: number,
+): { start: number; endExclusive: number } {
+  if (
+    !Number.isSafeInteger(index) ||
+    index < 0 ||
+    index >= session.chunkCount
+  ) {
+    throw new Error(
+      `recordResumableChunk: chunk index ${index} is outside 0..${session.chunkCount - 1}`,
+    );
+  }
+  const start = index * session.chunkSize;
+  return {
+    start,
+    endExclusive: Math.min(start + session.chunkSize, session.uploadBytes),
+  };
+}
+
+function assertPositiveInteger(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(
+      `createResumableUploadSession: ${field} must be a positive safe integer`,
+    );
+  }
+}
+
+function safeSessionId(value: string): string {
+  const trimmed = value.trim();
+  if (!SAFE_SESSION_ID.test(trimmed)) {
+    throw new Error(
+      "createResumableUploadSession: sessionId must be a safe path component",
+    );
+  }
+  return trimmed;
+}

--- a/packages/import-conversations/src/core/resumable.ts
+++ b/packages/import-conversations/src/core/resumable.ts
@@ -73,6 +73,7 @@ export type RecordResumableChunkResult =
 
 const DEFAULT_NOW = () => Date.now();
 const SAFE_SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const SHA256_HEX = /^[a-f0-9]{64}$/;
 
 export function createResumableUploadSession(
   options: CreateResumableUploadSessionOptions,
@@ -99,7 +100,8 @@ export function recordResumableChunk(
   session: ResumableUploadSession,
   options: RecordResumableChunkOptions,
 ): RecordResumableChunkResult {
-  const expected = expectedChunkRange(session, options.index);
+  const validSession = validateResumableUploadSession(session);
+  const expected = expectedChunkRange(validSession, options.index);
   if (options.offset !== expected.start) {
     throw new Error(
       `recordResumableChunk: chunk ${options.index} offset ${options.offset} does not match expected ${expected.start}`,
@@ -121,7 +123,7 @@ export function recordResumableChunk(
     );
   }
 
-  const existing = session.chunks[options.index];
+  const existing = validSession.chunks[options.index];
   if (existing) {
     if (
       existing.offset !== options.offset ||
@@ -134,13 +136,13 @@ export function recordResumableChunk(
     }
     return {
       status: "duplicate",
-      session,
+      session: validSession,
       chunk: existing,
-      progress: getResumableUploadProgress(session),
+      progress: getResumableUploadProgress(validSession),
     };
   }
 
-  if (session.status !== "open") {
+  if (validSession.status !== "open") {
     throw new Error("recordResumableChunk: session is already complete");
   }
 
@@ -152,10 +154,10 @@ export function recordResumableChunk(
     sha256,
     receivedAt,
   };
-  const chunks = { ...session.chunks, [options.index]: chunk };
-  const complete = Object.keys(chunks).length === session.chunkCount;
+  const chunks = { ...validSession.chunks, [options.index]: chunk };
+  const complete = Object.keys(chunks).length === validSession.chunkCount;
   const next: ResumableUploadSession = {
-    ...session,
+    ...validSession,
     chunks,
     updatedAt: receivedAt,
     status: complete ? "complete" : "open",
@@ -172,23 +174,25 @@ export function recordResumableChunk(
 export function getResumableUploadProgress(
   session: ResumableUploadSession,
 ): ResumableUploadProgress {
-  const chunks = Object.values(session.chunks);
+  const validSession = validateResumableUploadSession(session);
+  const chunks = Object.values(validSession.chunks);
   return {
     receivedBytes: chunks.reduce((total, chunk) => total + chunk.byteLength, 0),
-    uploadBytes: session.uploadBytes,
+    uploadBytes: validSession.uploadBytes,
     receivedChunks: chunks.length,
-    chunkCount: session.chunkCount,
-    complete: chunks.length === session.chunkCount,
+    chunkCount: validSession.chunkCount,
+    complete: chunks.length === validSession.chunkCount,
   };
 }
 
 export function findMissingResumableUploadRanges(
   session: ResumableUploadSession,
 ): MissingUploadRange[] {
+  const validSession = validateResumableUploadSession(session);
   const ranges: MissingUploadRange[] = [];
-  for (let index = 0; index < session.chunkCount; index += 1) {
-    if (session.chunks[index]) continue;
-    const range = expectedChunkRange(session, index);
+  for (let index = 0; index < validSession.chunkCount; index += 1) {
+    if (validSession.chunks[index]) continue;
+    const range = expectedChunkRange(validSession, index);
     ranges.push({
       start: range.start,
       endExclusive: range.endExclusive,
@@ -196,6 +200,131 @@ export function findMissingResumableUploadRanges(
     });
   }
   return ranges;
+}
+
+export function validateResumableUploadSession(
+  value: unknown,
+): ResumableUploadSession {
+  if (!isRecord(value)) {
+    throw new Error(
+      "validateResumableUploadSession: session must be an object",
+    );
+  }
+  const sessionId = safeSessionId(readString(value, "sessionId"));
+  const uploadBytes = readPositiveInteger(value, "uploadBytes");
+  const chunkSize = readPositiveInteger(value, "chunkSize");
+  const chunkCount = readPositiveInteger(value, "chunkCount");
+  const expectedChunkCount = Math.ceil(uploadBytes / chunkSize);
+  if (chunkCount !== expectedChunkCount) {
+    throw new Error(
+      `validateResumableUploadSession: chunkCount ${chunkCount} does not match expected ${expectedChunkCount}`,
+    );
+  }
+  const createdAt = readNonNegativeInteger(value, "createdAt");
+  const updatedAt = readNonNegativeInteger(value, "updatedAt");
+  if (updatedAt < createdAt) {
+    throw new Error(
+      "validateResumableUploadSession: updatedAt must be greater than or equal to createdAt",
+    );
+  }
+  const status = value.status;
+  if (status !== "open" && status !== "complete") {
+    throw new Error(
+      "validateResumableUploadSession: status must be open or complete",
+    );
+  }
+  if (!isRecord(value.chunks)) {
+    throw new Error("validateResumableUploadSession: chunks must be an object");
+  }
+
+  const chunks: Record<number, ResumableUploadChunk> = {};
+  for (const [key, rawChunk] of Object.entries(value.chunks)) {
+    const keyIndex = Number(key);
+    if (!Number.isSafeInteger(keyIndex) || keyIndex < 0) {
+      throw new Error(
+        `validateResumableUploadSession: chunk key ${key} is not a safe index`,
+      );
+    }
+    if (String(keyIndex) !== key) {
+      throw new Error(
+        `validateResumableUploadSession: chunk key ${key} must be canonical`,
+      );
+    }
+    const chunk = validateResumableUploadChunk(
+      rawChunk,
+      {
+        sessionId,
+        uploadBytes,
+        chunkSize,
+        chunkCount,
+        createdAt,
+        updatedAt,
+        status,
+        chunks: {},
+      },
+      keyIndex,
+    );
+    chunks[chunk.index] = chunk;
+  }
+  const maxReceivedAt = Object.values(chunks).reduce(
+    (max, chunk) => Math.max(max, chunk.receivedAt),
+    createdAt,
+  );
+  if (updatedAt < maxReceivedAt) {
+    throw new Error(
+      "validateResumableUploadSession: updatedAt must cover received chunk timestamps",
+    );
+  }
+
+  const complete = Object.keys(chunks).length === chunkCount;
+  if (complete !== (status === "complete")) {
+    throw new Error(
+      "validateResumableUploadSession: status does not match received chunk completeness",
+    );
+  }
+
+  return {
+    sessionId,
+    uploadBytes,
+    chunkSize,
+    chunkCount,
+    createdAt,
+    updatedAt,
+    status,
+    chunks,
+  };
+}
+
+export function mergeResumableUploadSessions(
+  baseSession: ResumableUploadSession,
+  ...updates: ResumableUploadSession[]
+): ResumableUploadSession {
+  const base = validateResumableUploadSession(baseSession);
+  const chunks: Record<number, ResumableUploadChunk> = { ...base.chunks };
+  let updatedAt = base.updatedAt;
+
+  for (const rawUpdate of updates) {
+    const update = validateResumableUploadSession(rawUpdate);
+    assertSameSessionIdentity(base, update);
+    updatedAt = Math.max(updatedAt, update.updatedAt);
+    for (const chunk of Object.values(update.chunks)) {
+      const existing = chunks[chunk.index];
+      if (existing && !sameChunk(existing, chunk)) {
+        throw new Error(
+          `mergeResumableUploadSessions: chunk ${chunk.index} conflicts with an already merged chunk`,
+        );
+      }
+      chunks[chunk.index] = chunk;
+    }
+  }
+
+  const complete = Object.keys(chunks).length === base.chunkCount;
+  return {
+    ...base,
+    chunks,
+    updatedAt,
+    status: complete ? "complete" : "open",
+  };
 }
 
 export function sha256Hex(bytes: Uint8Array | string): string {
@@ -228,6 +357,45 @@ function expectedChunkRange(
   };
 }
 
+function validateResumableUploadChunk(
+  value: unknown,
+  session: ResumableUploadSession,
+  keyIndex: number,
+): ResumableUploadChunk {
+  if (!isRecord(value)) {
+    throw new Error(
+      `validateResumableUploadSession: chunk ${keyIndex} must be an object`,
+    );
+  }
+  const index = readNonNegativeInteger(value, "index");
+  if (index !== keyIndex) {
+    throw new Error(
+      `validateResumableUploadSession: chunk key ${keyIndex} does not match index ${index}`,
+    );
+  }
+  const expected = expectedChunkRange(session, index);
+  const offset = readNonNegativeInteger(value, "offset");
+  const byteLength = readPositiveInteger(value, "byteLength");
+  const sha256 = readString(value, "sha256");
+  const receivedAt = readNonNegativeInteger(value, "receivedAt");
+  if (offset !== expected.start) {
+    throw new Error(
+      `validateResumableUploadSession: chunk ${index} offset ${offset} does not match expected ${expected.start}`,
+    );
+  }
+  if (byteLength !== expected.endExclusive - expected.start) {
+    throw new Error(
+      `validateResumableUploadSession: chunk ${index} byteLength ${byteLength} does not match expected ${expected.endExclusive - expected.start}`,
+    );
+  }
+  if (!SHA256_HEX.test(sha256)) {
+    throw new Error(
+      `validateResumableUploadSession: chunk ${index} sha256 must be lowercase hex`,
+    );
+  }
+  return { index, offset, byteLength, sha256, receivedAt };
+}
+
 function assertPositiveInteger(value: number, field: string): void {
   if (!Number.isSafeInteger(value) || value <= 0) {
     throw new Error(
@@ -244,4 +412,83 @@ function safeSessionId(value: string): string {
     );
   }
   return trimmed;
+}
+
+function assertSameSessionIdentity(
+  base: ResumableUploadSession,
+  update: ResumableUploadSession,
+): void {
+  for (const field of [
+    "sessionId",
+    "uploadBytes",
+    "chunkSize",
+    "chunkCount",
+    "createdAt",
+  ] as const) {
+    if (base[field] !== update[field]) {
+      throw new Error(
+        `mergeResumableUploadSessions: update ${field} does not match base session`,
+      );
+    }
+  }
+}
+
+function sameChunk(
+  left: ResumableUploadChunk,
+  right: ResumableUploadChunk,
+): boolean {
+  return (
+    left.index === right.index &&
+    left.offset === right.offset &&
+    left.byteLength === right.byteLength &&
+    left.sha256 === right.sha256
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function readString(value: Record<string, unknown>, field: string): string {
+  const fieldValue = value[field];
+  if (typeof fieldValue !== "string") {
+    throw new Error(
+      `validateResumableUploadSession: ${field} must be a string`,
+    );
+  }
+  return fieldValue;
+}
+
+function readPositiveInteger(
+  value: Record<string, unknown>,
+  field: string,
+): number {
+  const fieldValue = value[field];
+  if (
+    typeof fieldValue !== "number" ||
+    !Number.isSafeInteger(fieldValue) ||
+    fieldValue <= 0
+  ) {
+    throw new Error(
+      `validateResumableUploadSession: ${field} must be a positive safe integer`,
+    );
+  }
+  return fieldValue;
+}
+
+function readNonNegativeInteger(
+  value: Record<string, unknown>,
+  field: string,
+): number {
+  const fieldValue = value[field];
+  if (
+    typeof fieldValue !== "number" ||
+    !Number.isSafeInteger(fieldValue) ||
+    fieldValue < 0
+  ) {
+    throw new Error(
+      `validateResumableUploadSession: ${field} must be a non-negative safe integer`,
+    );
+  }
+  return fieldValue;
 }


### PR DESCRIPTION
## Summary
- Add a pure `@elizaos/import-conversations` resumable upload state primitive for #13432.
- Validate session ids, upload/chunk sizing, expected byte ranges, optional chunk SHA-256 digests, and hydrated/persisted session metadata.
- Track progress, missing ranges, completion, and idempotent duplicate chunk retries.
- Add `mergeResumableUploadSessions(base, ...updates)` so future routes can merge independently accepted chunk updates after CAS/transaction retry instead of last-write-wins replacing the whole session.

## Scope
This is only the importer-core resumable state/validation layer. It stores chunk metadata and digests only; bytes still belong in the canonical content-addressed artifact/media path. It does not add cloud routes, object-store writes, artifact descriptor policy from #14256, #13431 UI integration, or batch-delete service wiring.

## Evidence
Original verification:
- `bun run --cwd packages/import-conversations test -- src/core/resumable.test.ts` (8 passed)
- `bun run --cwd packages/import-conversations test` (14 files, 161 tests)
- `bun run --cwd packages/import-conversations typecheck`
- `bunx @biomejs/biome check packages/import-conversations/src/core/resumable.ts packages/import-conversations/src/core/resumable.test.ts packages/import-conversations/src/core/index.ts .github/issue-evidence/13432-resumable-upload-state.md --no-errors-on-unmatched`
- `git diff --check origin/develop...HEAD`

Follow-up verification after concurrency/hydration fixes, rebased onto current `origin/develop`:
- `node /Users/shawwalters/milaidy/eliza/node_modules/vitest/vitest.mjs run --config /tmp/codex-vitest-empty.mjs packages/import-conversations/src/core/resumable.test.ts --run` - pass, 1 file / 11 tests.
- `bunx tsc --ignoreConfig --noEmit --skipLibCheck --typeRoots /Users/shawwalters/milaidy/eliza/node_modules/@types --types node --lib ES2022 --module ESNext --target ES2022 --moduleResolution bundler packages/import-conversations/src/core/resumable.ts` - pass.
- `bunx @biomejs/biome check packages/import-conversations/src/core/resumable.ts packages/import-conversations/src/core/resumable.test.ts packages/import-conversations/src/core/index.ts .github/issue-evidence/13432-resumable-upload-state.md --no-errors-on-unmatched && git diff --check origin/develop..HEAD` - pass.

## PR evidence matrix
- Backend logs: N/A - pure importer-core state primitive; no route or object-store write path changed.
- Frontend screenshots/video: N/A - no UI changed.
- Real-LLM trajectories: N/A - no agent/action/provider/prompt/model behavior changed.
- Domain artifacts: unit tests prove chunk range/hash rejection, duplicate retry idempotency, persisted-state validation, concurrent non-overlapping chunk merge, conflict rejection, missing-range reporting, and complete progress state.

## Known gaps
- The sparse verification worktree did not have local `node_modules/vitest`, so the follow-up focused test used the installed repo Vitest binary plus a minimal node-environment config.
- GitHub checks are queued on the latest head; keeping draft until they settle.

Refs #13432.