### PR TITLE
fix(ci): drop stale aosp snap filter

### DIFF
--- a/packages/app-core/packaging/snap/snapcraft.yaml
+++ b/packages/app-core/packaging/snap/snapcraft.yaml
@@ -128,7 +128,6 @@ parts:
         const keep = new Set([
           "plugin-agent-skills",
           "plugin-anthropic",
-          "plugin-aosp-local-inference",
           "plugin-browser",
           "plugin-capacitor-bridge",
           "plugin-commands",
@@ -492,7 +491,6 @@ parts:
         --filter=@elizaos/app-core \
         --filter=@elizaos/agent \
         --filter=@elizaos/plugin-agent-skills \
-        --filter=@elizaos/plugin-aosp-local-inference \
         --filter=@elizaos/plugin-browser \
         --filter=@elizaos/plugin-commands \
         --filter=@elizaos/plugin-imessage \


### PR DESCRIPTION
## Summary
- remove the deleted `plugin-aosp-local-inference` workspace from the Snap runtime keep-list
- remove the matching `--filter=@elizaos/plugin-aosp-local-inference` Turbo filter from the Snap build closure

## Why
`Build Snap (arm64)` currently fails before the Snap build can run because Turbo is asked to build `@elizaos/plugin-aosp-local-inference`, but current `develop` no longer contains that workspace.

## Validation
- `python3`/PyYAML parse of `packages/app-core/packaging/snap/snapcraft.yaml`: pass
- `git diff --check`: pass
- streaming workspace-name check over current Git tree: every remaining Snap `--filter=@elizaos/...` maps to an existing package name
- confirmed the Snap file no longer references `plugin-aosp-local-inference`

## Not Run
- Full `snapcraft` build: not run locally; this environment is macOS and does not have the Linux Snapcraft runner.
- Local `turbo --dry` over the Snap filter closure: sparse checkout could not model the Snap script's own `turbo.json` dependency-pruning step, so it failed later on a sparse-only missing transitive package. The removed `@elizaos/plugin-aosp-local-inference` filter itself is gone and covered by the workspace-name check above.