### PR TITLE
fix(cloud): stub provisionDefaultApiKey in steward-sync-grant test (unblock cloud CI)

### DIFF
--- a/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
@@ -86,6 +86,12 @@ mock.module("./services/api-keys", () => ({
     listByOrganization: async () => [],
     create: async () => ({ id: "key-1" }),
     ensureUserHasApiKey: async () => undefined,
+    // steward-sync's new-user path awaits apiKeysService.provisionDefaultApiKey
+    // (steward-sync.ts:717); without this stub the grant happy-path test throws
+    // `apiKeysService.provisionDefaultApiKey is not a function` and the cloud
+    // suite (packages/cloud/shared/src) stays deterministically red. Complements
+    // PR #14259 which fixed the same stale stub in steward-sync-default-provisioning.test.ts.
+    provisionDefaultApiKey: async () => undefined,
   },
 }));
 


### PR DESCRIPTION
## What & why

The cloud test suite (`packages/cloud/shared/src`) is **deterministically red**: `steward-sync.ts:717` awaits `apiKeysService.provisionDefaultApiKey(...)` on the new-user path, but `steward-sync-grant.test.ts` stubbed only `ensureUserHasApiKey`, so its happy-path test threw `apiKeysService.provisionDefaultApiKey is not a function`.

PR #14259 fixed the *same* stale stub in the sibling `steward-sync-default-provisioning.test.ts` but not this file — an adversarial review of #14259 found this file still red. This adds the missing `provisionDefaultApiKey: async () => undefined` stub. The two PRs are complementary (different files, no overlap); together they make the cloud lane green.

Verified by inspection (mirrors #14259's proven stub + fixes the exact confirmed TypeError); the full cloud-lane run is CI's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)