### PR TITLE
fix(agent): harden database readonly SQL guard

### DIFF
--- a/packages/agent/src/actions/database.readonly-redos.test.ts
+++ b/packages/agent/src/actions/database.readonly-redos.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Covers the DATABASE action's read-only SQL guard on adversarial input. The
+ * guard receives model-produced SQL, so comment and dollar-quote stripping must
+ * be linear and must leave malformed SQL visible to the mutation scanner.
+ */
+import { describe, expect, it } from "vitest";
+
+import { checkReadOnly } from "./database.ts";
+
+describe("DATABASE read-only SQL guard", () => {
+  it("rejects mutation keywords split by block comments", () => {
+    const result = checkReadOnly("DE/* invisible */LETE FROM memories");
+
+    expect(result).toEqual({
+      ok: false,
+      reason:
+        '"DELETE" is a mutation keyword. Set allowWrites:true to execute mutations.',
+    });
+  });
+
+  it("rejects mutation keywords in unterminated dollar-quoted input quickly", () => {
+    const sql = `${Array.from({ length: 50_000 }, (_, i) => `$tag${i}$x`).join(
+      "",
+    )} DELETE FROM memories`;
+
+    const start = performance.now();
+    const result = checkReadOnly(sql);
+    const elapsed = performance.now() - start;
+
+    expect(result).toMatchObject({ ok: false });
+    if (!result.ok) {
+      expect(result.reason).toContain('"DELETE"');
+    }
+    expect(elapsed).toBeLessThan(1000);
+  });
+});

--- a/packages/agent/src/actions/database.ts
+++ b/packages/agent/src/actions/database.ts
@@ -25,6 +25,10 @@ import type {
 } from "@elizaos/core";
 import { logger, ModelType } from "@elizaos/core";
 import type { ColumnInfo, TableInfo } from "@elizaos/shared";
+import {
+  stripSqlBlockComments,
+  stripSqlDollarQuotedLiterals,
+} from "../shared/sql-sanitizers.ts";
 
 // ---------------------------------------------------------------------------
 // Op dispatch
@@ -207,16 +211,14 @@ const DANGEROUS_FUNCTIONS = [
   "pg_advisory_unlock_all",
 ];
 
-function checkReadOnly(
+export function checkReadOnly(
   sqlText: string,
 ): { ok: true } | { ok: false; reason: string } {
-  const stripped = sqlText
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/--.*$/gm, "")
-    .trim();
-  const noLiterals = stripped
-    .replace(/\$([A-Za-z0-9_]*)\$[\s\S]*?\$\1\$/g, " ")
-    .replace(/'(?:[^']|'')*'/g, " ");
+  const stripped = stripSqlBlockComments(sqlText).replace(/--.*$/gm, "").trim();
+  const noLiterals = stripSqlDollarQuotedLiterals(stripped).replace(
+    /'(?:[^']|'')*'/g,
+    " ",
+  );
   const noStrings = noLiterals.replace(/"(?:[^"]|"")*"/g, " ");
 
   const mutation = new RegExp(

--- a/packages/agent/src/api/database.strip-comments.test.ts
+++ b/packages/agent/src/api/database.strip-comments.test.ts
@@ -8,7 +8,10 @@
  * Deterministic, no server or DB.
  */
 import { describe, expect, it } from "vitest";
-import { stripSqlBlockComments } from "./database.ts";
+import {
+  stripSqlBlockComments,
+  stripSqlDollarQuotedLiterals,
+} from "./database.ts";
 
 describe("stripSqlBlockComments", () => {
   it("leaves comment-free SQL untouched", () => {
@@ -44,11 +47,36 @@ describe("stripSqlBlockComments", () => {
 
   it("is linear on the ReDoS input (many openers, no closer)", () => {
     // The old regex was O(n²) here and took seconds; this must finish in ms.
-    const evil = "/*" + "a/*".repeat(200_000);
+    const evil = `/*${"a/*".repeat(200_000)}`;
     const start = performance.now();
     const out = stripSqlBlockComments(evil);
     const elapsed = performance.now() - start;
     // No closing "*/" anywhere, so nothing is stripped.
+    expect(out).toBe(evil);
+    expect(elapsed).toBeLessThan(1000);
+  });
+});
+
+describe("stripSqlDollarQuotedLiterals", () => {
+  it("strips untagged and tagged dollar-quoted SQL literals", () => {
+    expect(
+      stripSqlDollarQuotedLiterals("SELECT $$DROP$$, $tag$ALTER$tag$"),
+    ).toBe("SELECT  ,  ");
+  });
+
+  it("leaves unterminated literals intact so the guard still sees following SQL", () => {
+    expect(
+      stripSqlDollarQuotedLiterals("SELECT $tag$ unterminated DELETE"),
+    ).toBe("SELECT $tag$ unterminated DELETE");
+  });
+
+  it("is linear on many unterminated dollar-quote openers", () => {
+    const evil = Array.from({ length: 50_000 }, (_, i) => `$tag${i}$x`).join(
+      "",
+    );
+    const start = performance.now();
+    const out = stripSqlDollarQuotedLiterals(evil);
+    const elapsed = performance.now() - start;
     expect(out).toBe(evil);
     expect(elapsed).toBeLessThan(1000);
   });

--- a/packages/agent/src/api/database.ts
+++ b/packages/agent/src/api/database.ts
@@ -45,6 +45,16 @@ import {
   normalizeIpForPolicy,
 } from "../security/network-policy.ts";
 
+export {
+  stripSqlBlockComments,
+  stripSqlDollarQuotedLiterals,
+} from "../shared/sql-sanitizers.ts";
+
+import {
+  stripSqlBlockComments,
+  stripSqlDollarQuotedLiterals,
+} from "../shared/sql-sanitizers.ts";
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -1038,35 +1048,6 @@ async function handleDeleteRow(
 }
 
 /**
- * Strip non-nested C-style block comments (opened with slash-star, closed with
- * star-slash) from SQL in a single linear pass. Used instead of the obvious
- * `/\/\*[\s\S]*?\*\//g` regex because that regex's global re-scan is O(n²) on
- * adversarial input — a string with many block-comment openers and no closer
- * forces a fresh scan-to-end from every opener. Since the SQL text comes
- * straight off the request body, that quadratic blowup is a ReDoS vector.
- * An unterminated opener is left intact, matching the lazy regex's non-match.
- */
-export function stripSqlBlockComments(sql: string): string {
-  let result = "";
-  let i = 0;
-  while (i < sql.length) {
-    const open = sql.indexOf("/*", i);
-    if (open === -1) {
-      result += sql.slice(i);
-      break;
-    }
-    const close = sql.indexOf("*/", open + 2);
-    if (close === -1) {
-      result += sql.slice(i);
-      break;
-    }
-    result += sql.slice(i, open);
-    i = close + 2;
-  }
-  return result;
-}
-
-/**
  * POST /api/database/query
  * Execute a raw SQL query. Body: { sql: string, readOnly?: boolean }
  */
@@ -1108,9 +1089,10 @@ async function handleQuery(
     // Strip string literals so that mutation keywords/functions inside quoted
     // strings are ignored. Handles single-quoted ('...'), dollar-quoted
     // ($$...$$), and tagged dollar-quoted ($tag$...$tag$) strings.
-    const noLiterals = stripped
-      .replace(/\$([A-Za-z0-9_]*)\$[\s\S]*?\$\1\$/g, " ")
-      .replace(/'(?:[^']|'')*'/g, " ");
+    const noLiterals = stripSqlDollarQuotedLiterals(stripped).replace(
+      /'(?:[^']|'')*'/g,
+      " ",
+    );
 
     // For keyword checks, also strip double-quoted identifiers to avoid
     // matching words inside quoted table/column names.

--- a/packages/agent/src/shared/sql-sanitizers.ts
+++ b/packages/agent/src/shared/sql-sanitizers.ts
@@ -1,0 +1,85 @@
+/**
+ * Linear SQL text sanitizers used before read-only guard scans. These helpers
+ * intentionally preserve malformed/unterminated constructs so invalid SQL does
+ * not hide mutation keywords from the caller's policy check.
+ */
+
+/**
+ * Strip non-nested C-style block comments (opened with slash-star, closed with
+ * star-slash) from SQL in a single linear pass. Used instead of the obvious
+ * `/\/\*[\s\S]*?\*\//g` regex because that regex's global re-scan is O(n²) on
+ * adversarial input.
+ */
+export function stripSqlBlockComments(sql: string): string {
+  let result = "";
+  let i = 0;
+  while (i < sql.length) {
+    const open = sql.indexOf("/*", i);
+    if (open === -1) {
+      result += sql.slice(i);
+      break;
+    }
+    const close = sql.indexOf("*/", open + 2);
+    if (close === -1) {
+      result += sql.slice(i);
+      break;
+    }
+    result += sql.slice(i, open);
+    i = close + 2;
+  }
+  return result;
+}
+
+/**
+ * Strip PostgreSQL dollar-quoted literals (`$$...$$`, `$tag$...$tag$`) in a
+ * single pass. Unterminated literals are left intact so the read-only guard
+ * still sees any mutation text that follows invalid SQL.
+ */
+export function stripSqlDollarQuotedLiterals(sql: string): string {
+  let result = "";
+  let i = 0;
+
+  while (i < sql.length) {
+    if (sql[i] !== "$") {
+      result += sql[i];
+      i += 1;
+      continue;
+    }
+
+    let tagEnd = i + 1;
+    while (
+      tagEnd < sql.length &&
+      /[A-Za-z0-9_]/.test(sql.charAt(tagEnd)) &&
+      tagEnd - i <= 128
+    ) {
+      tagEnd += 1;
+    }
+
+    if (tagEnd >= sql.length || sql[tagEnd] !== "$") {
+      result += sql[i];
+      i += 1;
+      continue;
+    }
+
+    const delimiter = sql.slice(i, tagEnd + 1);
+    let j = tagEnd + 1;
+    let closedAt = -1;
+    while (j < sql.length) {
+      if (sql.startsWith(delimiter, j)) {
+        closedAt = j;
+        break;
+      }
+      j += 1;
+    }
+
+    if (closedAt === -1) {
+      result += sql.slice(i);
+      break;
+    }
+
+    result += " ";
+    i = closedAt + delimiter.length;
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Fixes #14262.

- moves SQL comment/literal stripping into a shared linear sanitizer module;
- reuses the linear block-comment stripper in the agent DATABASE action read-only guard;
- replaces the lazy dollar-quote regex with a linear pass that leaves unterminated literals visible to the mutation scanner;
- adds action-level regression coverage for block-comment keyword splitting and adversarial unterminated dollar-quote input.

## Validation

- `bun run --cwd packages/agent test -- src/api/database.strip-comments.test.ts src/actions/database.readonly-redos.test.ts` — 2 files / 13 tests passed.
- `bunx @biomejs/biome@2.5.1 check packages/agent/src/shared/sql-sanitizers.ts packages/agent/src/api/database.ts packages/agent/src/api/database.strip-comments.test.ts packages/agent/src/actions/database.ts packages/agent/src/actions/database.readonly-redos.test.ts` — passed.
- `git diff --check -- packages/agent/src/actions/database.ts packages/agent/src/api/database.strip-comments.test.ts packages/agent/src/api/database.ts packages/agent/src/actions/database.readonly-redos.test.ts packages/agent/src/shared/sql-sanitizers.ts` — passed.

## Evidence

N/A — no UI, model, route, or live agent behavior changed beyond the local SQL guard implementation. The regression is covered by deterministic focused tests on the affected parser/guard path.