### PR TITLE
fix(ui): require frame documents for sandboxed views

### DIFF
--- a/packages/agent/src/__tests__/views-system-smoke.test.ts
+++ b/packages/agent/src/__tests__/views-system-smoke.test.ts
@@ -24,6 +24,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   generateViewHeroSvg,
   getBundleDiskPath,
+  getFrameDiskPath,
   getView,
   listViews,
   registerPluginViews,
@@ -297,6 +298,62 @@ describe("stage 2: HTTP GET /api/views returns views list", () => {
     );
     expect(view?.heroImageUrl).toBe("/api/views/smoke.main/hero");
   });
+
+  it("GET /api/views response includes frameUrl for sandboxed iframe views with framePath", async () => {
+    const pluginDir = await mkdtemp(path.join(os.tmpdir(), "eliza-frame-"));
+    try {
+      await mkdir(path.join(pluginDir, "dist", "views"), { recursive: true });
+      await writeFile(
+        path.join(pluginDir, "dist", "views", "frame.html"),
+        "<!doctype html><title>Sandbox smoke</title>",
+      );
+
+      await registerPluginViews(
+        {
+          name: SMOKE_PLUGIN,
+          description: "smoke plugin",
+          actions: [],
+          views: [
+            {
+              ...SMOKE_VIEW,
+              bundlePath: undefined,
+              framePath: "dist/views/frame.html",
+              surface: { isolation: "sandboxed-iframe" },
+            },
+          ],
+        },
+        pluginDir,
+      );
+
+      const { ctx, json } = makeCtx("GET", "/api/views");
+      await handleViewsRoutes(ctx);
+
+      const [, body] = json.mock.calls[0] as [
+        unknown,
+        {
+          views: {
+            id: string;
+            bundleUrl?: string;
+            frameUrl?: string;
+            available: boolean;
+          }[];
+        },
+      ];
+      const view = body.views.find((v) => v.id === "smoke.main");
+      expect(view?.bundleUrl).toBeUndefined();
+      expect(view?.frameUrl).toMatch(
+        /^\/api\/views\/smoke\.main\/frame\.html\?v=\d+$/,
+      );
+      expect(view?.available).toBe(true);
+      const registryEntry = getView("smoke.main");
+      expect(registryEntry).toBeTruthy();
+      expect(registryEntry ? getFrameDiskPath(registryEntry) : null).toBe(
+        path.join(pluginDir, "dist", "views", "frame.html"),
+      );
+    } finally {
+      await rm(pluginDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -437,6 +494,84 @@ describe("stage 4: GET /api/views/:id/bundle.js serves the view bundle", () => {
     } finally {
       await rm(pluginDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("stage 4b: GET /api/views/:id/frame.html serves sandbox frame documents", () => {
+  it("serves a configured sandbox frame document as HTML", async () => {
+    const pluginDir = await mkdtemp(path.join(os.tmpdir(), "eliza-frame-"));
+    try {
+      await mkdir(path.join(pluginDir, "dist", "views"), { recursive: true });
+      await writeFile(
+        path.join(pluginDir, "dist", "views", "frame.html"),
+        "<!doctype html><title>Sandbox smoke</title>",
+      );
+
+      await registerPluginViews(
+        {
+          name: SMOKE_PLUGIN,
+          description: "smoke plugin",
+          actions: [],
+          views: [
+            {
+              ...SMOKE_VIEW,
+              bundlePath: undefined,
+              framePath: "dist/views/frame.html",
+              surface: { isolation: "sandboxed-iframe" },
+            },
+          ],
+        },
+        pluginDir,
+      );
+
+      const res = {
+        writeHead: vi.fn(),
+        end: vi.fn(),
+      };
+      const { ctx } = makeCtx("GET", "/api/views/smoke.main/frame.html", {
+        res: res as unknown as http.ServerResponse,
+      });
+      const handled = await handleViewsRoutes(ctx);
+
+      expect(handled).toBe(true);
+      expect(res.writeHead).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          "Content-Type": "text/html; charset=utf-8",
+          "X-Content-Type-Options": "nosniff",
+        }),
+      );
+      const served = res.end.mock.calls[0]?.[0];
+      expect(Buffer.isBuffer(served)).toBe(true);
+      expect(String(served)).toContain("<title>Sandbox smoke</title>");
+    } finally {
+      await rm(pluginDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not serve bundle.js as the sandbox frame document fallback", async () => {
+    await registerPluginViews(
+      {
+        name: SMOKE_PLUGIN,
+        description: "smoke plugin",
+        actions: [],
+        views: [SMOKE_VIEW],
+      },
+      undefined,
+    );
+
+    const { ctx, error } = makeCtx("GET", "/api/views/smoke.main/frame.html");
+    const handled = await handleViewsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledOnce();
+    const [, message, status] = error.mock.calls[0] as [
+      unknown,
+      string,
+      number,
+    ];
+    expect(status).toBe(404);
+    expect(message).toContain("no sandbox frame document configured");
   });
 });
 

--- a/packages/agent/src/api/view-registry-types.ts
+++ b/packages/agent/src/api/view-registry-types.ts
@@ -19,6 +19,8 @@ export interface ViewRegistryEntry extends ViewDeclaration {
   pluginDir?: string;
   /** Resolved URL served by the agent: `/api/views/<id>/bundle.js`. */
   bundleUrl?: string;
+  /** Resolved sandbox document URL served by the agent: `/api/views/<id>/frame.html`. */
+  frameUrl?: string;
   /** Resolved URL served by the agent: `/api/views/<id>/hero`. */
   heroImageUrl?: string;
   /**

--- a/packages/agent/src/api/views-registry.ts
+++ b/packages/agent/src/api/views-registry.ts
@@ -188,6 +188,18 @@ export function getBundleDiskPath(entry: ViewRegistryEntry): string | null {
 }
 
 /**
+ * Resolve the absolute on-disk path for a sandbox frame HTML document.
+ * Returns `null` when the entry has no `framePath` or no `pluginDir`.
+ */
+export function getFrameDiskPath(entry: ViewRegistryEntry): string | null {
+  if (!entry.framePath || !entry.pluginDir) return null;
+  const resolved = path.resolve(entry.pluginDir, entry.framePath);
+  const packageRoot = `${path.resolve(entry.pluginDir)}${path.sep}`;
+  if (!resolved.startsWith(packageRoot)) return null;
+  return resolved;
+}
+
+/**
  * Resolve the absolute on-disk path for a hero image.
  * Returns `null` when the entry has no `heroImagePath` or no `pluginDir`.
  * This only handles declared paths; for extension-probing see `findHeroOnDisk`.
@@ -528,7 +540,7 @@ async function buildEntry(
   const registryKey = viewRegistryKey(view.id, normalizedViewType);
 
   // Check bundle availability and collect hash + size when resolvable.
-  let available = Boolean(view.bundleUrl);
+  let available = Boolean(view.bundleUrl || view.frameUrl);
   let bundleHash: string | undefined;
   let bundleSize: number | undefined;
   if (!view.bundleUrl && pluginDir && view.bundlePath) {
@@ -570,12 +582,19 @@ async function buildEntry(
       }
     }
   }
+  if (!available && !view.frameUrl && pluginDir && view.framePath) {
+    const frameAbs = path.resolve(pluginDir, view.framePath);
+    const packageRoot = `${path.resolve(pluginDir)}${path.sep}`;
+    if (frameAbs.startsWith(packageRoot)) {
+      available = await fileExists(frameAbs);
+    }
+  }
 
   const encodedId = encodeURIComponent(view.id);
   // bundleUrl uses a timestamp ?v= param for backwards-compat; bundleUrlVersioned
   // uses the content hash when available (allows immutable long-lived caching).
   const buildAssetUrl = (
-    asset: "bundle.js" | "hero",
+    asset: "bundle.js" | "frame.html" | "hero",
     version?: number | string,
   ): string => {
     const params = new URLSearchParams();
@@ -599,6 +618,11 @@ async function buildEntry(
     : view.bundlePath && bundleHash
       ? buildAssetUrl("bundle.js", bundleHash)
       : bundleUrl;
+  const frameUrl = view.frameUrl
+    ? view.frameUrl
+    : view.framePath
+      ? buildAssetUrl("frame.html", loadedAt)
+      : undefined;
 
   const heroImageUrl = buildAssetUrl("hero");
   // Probe for a real hero asset so the client can choose a photo vs. its icon.
@@ -622,6 +646,7 @@ async function buildEntry(
     pluginDir,
     bundleUrl,
     bundleUrlVersioned,
+    frameUrl,
     heroImageUrl,
     hasHeroImage,
     available,

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -10,6 +10,7 @@
  *   GET  /api/views/search?q=&limit=   — hybrid keyword+semantic ranked search (JSON)
  *   GET  /api/views/:id                — single view metadata (JSON)
  *   GET  /api/views/:id/bundle.js      — compiled view bundle (JS)
+ *   GET  /api/views/:id/frame.html     — sandboxed iframe document (HTML)
  *   GET  /api/views/:id/<asset>        — compiled bundle chunk/asset
  *   GET  /api/views/:id/hero           — hero image (image/*)
  *   POST /api/views/:id/navigate       — broadcast shell navigation event (JSON)
@@ -65,6 +66,7 @@ import {
   findHeroOnDisk,
   generateViewHeroSvg,
   getBundleDiskPath,
+  getFrameDiskPath,
   getView,
   listViews,
 } from "./views-registry.ts";
@@ -626,6 +628,79 @@ export async function handleViewsRoutes(
         raw.setHeader("X-Content-Hash", `sha256-${contentHash}`);
       }
     }
+    raw.end?.(method === "HEAD" ? undefined : data);
+    return true;
+  }
+
+  // ── GET/HEAD /api/views/:id/frame.html ───────────────────────────────────
+  if ((method === "GET" || method === "HEAD") && subResource === "frame.html") {
+    const viewType = parseViewTypeParam(url.searchParams.get("viewType"));
+    const entry = getView(id, { viewType });
+    if (!entry) {
+      error(res, `View "${id}" not found`, 404);
+      return true;
+    }
+
+    const framePath = getFrameDiskPath(entry);
+    if (!framePath) {
+      error(res, `View "${id}" has no sandbox frame document configured.`, 404);
+      return true;
+    }
+
+    let stat: import("node:fs").Stats;
+    try {
+      stat = await fs.stat(framePath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        error(res, `Sandbox frame document not built for view "${id}".`, 404);
+      } else {
+        logger.error(
+          { src: "ViewsRoutes", viewId: id, framePath, err },
+          `[ViewsRoutes] Failed to stat sandbox frame for view "${id}"`,
+        );
+        error(res, `Failed to read sandbox frame for view "${id}"`, 500);
+      }
+      return true;
+    }
+
+    let data: Buffer;
+    try {
+      data = method === "HEAD" ? Buffer.alloc(0) : await fs.readFile(framePath);
+    } catch (err) {
+      logger.error(
+        { src: "ViewsRoutes", viewId: id, framePath, err },
+        `[ViewsRoutes] Failed to read sandbox frame for view "${id}"`,
+      );
+      error(res, `Failed to read sandbox frame for view "${id}"`, 500);
+      return true;
+    }
+
+    const etagRaw = `${stat.mtimeMs}-${stat.size}`;
+    const etag = `"${createHash("sha256").update(etagRaw).digest("hex").slice(0, 16)}"`;
+    if (req.headers["if-none-match"] === etag) {
+      const raw304 = res as {
+        writeHead?: (status: number, headers: Record<string, string>) => void;
+        end?: () => void;
+      };
+      raw304.writeHead?.(304, {});
+      raw304.end?.();
+      return true;
+    }
+
+    const raw = res as {
+      writeHead?: (
+        status: number,
+        headers: Record<string, string | number>,
+      ) => void;
+      end?: (chunk?: unknown) => void;
+    };
+    raw.writeHead?.(200, {
+      "Content-Type": "text/html; charset=utf-8",
+      "Content-Length": stat.size,
+      "Cache-Control": "no-cache",
+      "X-Content-Type-Options": "nosniff",
+      ETag: etag,
+    });
     raw.end?.(method === "HEAD" ? undefined : data);
     return true;
   }

--- a/packages/core/src/capabilities/index.ts
+++ b/packages/core/src/capabilities/index.ts
@@ -246,6 +246,8 @@ export type RemotePluginViewManifest = {
 	backgroundPolicy?: RemotePluginBackgroundPolicy;
 	bundlePath?: string;
 	bundleUrl?: string;
+	framePath?: string;
+	frameUrl?: string;
 	contentType?: string;
 	integrity?: string;
 };
@@ -3413,11 +3415,19 @@ function requireRemotePluginView(
 	}
 	const bundlePath = optionalNonEmptyString(object, "bundlePath", method);
 	const bundleUrl = optionalNonEmptyString(object, "bundleUrl", method);
+	const framePath = optionalNonEmptyString(object, "framePath", method);
+	const frameUrl = optionalNonEmptyString(object, "frameUrl", method);
 	if (bundlePath !== undefined) {
 		validateRemotePluginAssetPath(bundlePath, "bundlePath", method);
 	}
 	if (bundleUrl !== undefined) {
 		validateRemotePluginBundleUrl(bundleUrl, "bundleUrl", method);
+	}
+	if (framePath !== undefined) {
+		validateRemotePluginAssetPath(framePath, "framePath", method);
+	}
+	if (frameUrl !== undefined) {
+		validateRemotePluginBrowserUrl(frameUrl, "frameUrl", method);
 	}
 	const backgroundPolicy = optionalBackgroundPolicy(
 		object,
@@ -3433,6 +3443,8 @@ function requireRemotePluginView(
 		...(backgroundPolicy === undefined ? {} : { backgroundPolicy }),
 		...(bundlePath === undefined ? {} : { bundlePath }),
 		...(bundleUrl === undefined ? {} : { bundleUrl }),
+		...(framePath === undefined ? {} : { framePath }),
+		...(frameUrl === undefined ? {} : { frameUrl }),
 		...(contentType === undefined ? {} : { contentType }),
 		...(integrity === undefined ? {} : { integrity }),
 	};

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -1000,6 +1000,17 @@ export interface ViewDeclaration {
 	 * the code is served by a sandbox/container rather than the agent process.
 	 */
 	bundleUrl?: string;
+	/**
+	 * Path from the plugin's package root to a sandbox frame HTML document.
+	 * Required for `surface.isolation: "sandboxed-iframe"` local plugin views;
+	 * the registry resolves this to `/api/views/<id>/frame.html`.
+	 */
+	framePath?: string;
+	/**
+	 * Fully resolved sandbox frame document URL for remote/containerized views.
+	 * This is an HTML document URL, not a JavaScript bundle URL.
+	 */
+	frameUrl?: string;
 	/** Capabilities the agent can exercise on this view when it is mounted. */
 	capabilities?: ViewCapability[];
 	/**

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1036,7 +1036,11 @@ function trimmedNavigationPath(navigationPath: string): string {
 }
 
 function remoteViewAvailable(view: ViewRegistryEntry): boolean {
-  return Boolean(view.bundleUrl && view.available !== false);
+  return Boolean((view.bundleUrl || view.frameUrl) && view.available !== false);
+}
+
+function remoteViewLoaderUrl(view: ViewRegistryEntry): string | null {
+  return view.bundleUrl ?? view.frameUrl ?? null;
 }
 
 function remoteViewMatchesTab(
@@ -1099,11 +1103,13 @@ function findRemoteViewForRoute(
 }
 
 function renderRemoteView(view: ViewRegistryEntry, nav?: ReactNode): ReactNode {
-  if (!view.bundleUrl) return null;
+  const loaderUrl = remoteViewLoaderUrl(view);
+  if (!loaderUrl) return null;
   return (
     <TabContentView nav={nav}>
       <DynamicViewLoader
-        bundleUrl={view.bundleUrl}
+        bundleUrl={loaderUrl}
+        frameUrl={view.frameUrl}
         componentExport={view.componentExport}
         viewId={view.id}
         viewType={view.viewType}
@@ -1204,32 +1210,36 @@ function ViewLayoutSurface({
           )} eliza-continuous-chat-scroll pb-[calc(0.5rem+var(--eliza-continuous-chat-clearance,5.25rem))]`}
         >
           {entries.length > 0 ? (
-            entries.map((view) => (
-              <section
-                key={view.id}
-                data-testid={`view-layout-pane-${view.id}`}
-                className={paneClassName}
-              >
-                <div className="flex h-9 shrink-0 items-center border-b border-border/35 px-2.5">
-                  <span className="truncate text-xs font-medium text-muted">
-                    {view.label}
-                  </span>
-                </div>
-                <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-                  {view.bundleUrl ? (
-                    <DynamicViewLoader
-                      bundleUrl={view.bundleUrl}
-                      componentExport={view.componentExport}
-                      viewId={view.id}
-                      viewType={view.viewType}
-                      surface={view.surface}
-                    />
-                  ) : (
-                    <ViewRouter routeOverride={routeOverrideForView(view)} />
-                  )}
-                </div>
-              </section>
-            ))
+            entries.map((view) => {
+              const loaderUrl = remoteViewLoaderUrl(view);
+              return (
+                <section
+                  key={view.id}
+                  data-testid={`view-layout-pane-${view.id}`}
+                  className={paneClassName}
+                >
+                  <div className="flex h-9 shrink-0 items-center border-b border-border/35 px-2.5">
+                    <span className="truncate text-xs font-medium text-muted">
+                      {view.label}
+                    </span>
+                  </div>
+                  <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+                    {loaderUrl ? (
+                      <DynamicViewLoader
+                        bundleUrl={loaderUrl}
+                        frameUrl={view.frameUrl}
+                        componentExport={view.componentExport}
+                        viewId={view.id}
+                        viewType={view.viewType}
+                        surface={view.surface}
+                      />
+                    ) : (
+                      <ViewRouter routeOverride={routeOverrideForView(view)} />
+                    )}
+                  </div>
+                </section>
+              );
+            })
           ) : (
             <div className="flex min-h-[18rem] items-center justify-center border border-border/45 px-4 text-center text-sm text-muted">
               Requested views are not available.
@@ -1487,7 +1497,9 @@ function renderViewRouterContent({
     tab,
     appSlug,
   );
-  if (remoteView?.bundleUrl) return renderRemoteView(remoteView, walletNav);
+  if (remoteView && remoteViewLoaderUrl(remoteView)) {
+    return renderRemoteView(remoteView, walletNav);
+  }
   return renderStaticViewRouterTab({
     tab,
     nativeOsSurfaceEnabled,

--- a/packages/ui/src/components/views/DynamicViewLoader.sandboxed-frame.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.sandboxed-frame.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetDynamicViewLoaderCacheForTests,
+  DynamicViewLoader,
+} from "./DynamicViewLoader";
+
+describe("DynamicViewLoader sandboxed iframe document contract", () => {
+  afterEach(() => {
+    delete window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__;
+    cleanup();
+    __resetDynamicViewLoaderCacheForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("renders sandboxed-iframe views from frameUrl, never from the JavaScript bundleUrl", () => {
+    const importBundle = vi.fn();
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = importBundle;
+
+    render(
+      <DynamicViewLoader
+        bundleUrl="/api/views/sandboxed.view/bundle.js"
+        frameUrl="/api/views/sandboxed.view/frame.html"
+        viewId="sandboxed.view"
+        surface={{
+          isolation: "sandboxed-iframe",
+          capabilities: ["navigate", "storage"],
+        }}
+      />,
+    );
+
+    const frame = screen.getByTestId(
+      "sandboxed-view-frame-sandboxed.view",
+    ) as HTMLIFrameElement;
+    expect(frame.getAttribute("src")).toBe(
+      "/api/views/sandboxed.view/frame.html",
+    );
+    expect(frame.getAttribute("src")).not.toBe(
+      "/api/views/sandboxed.view/bundle.js",
+    );
+    expect(frame.getAttribute("sandbox")?.split(" ")).toContain(
+      "allow-scripts",
+    );
+    expect(importBundle).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a sandboxed-iframe view only has a JavaScript bundleUrl", () => {
+    const importBundle = vi.fn();
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = importBundle;
+
+    render(
+      <DynamicViewLoader
+        bundleUrl="/api/views/broken.sandbox/bundle.js"
+        viewId="broken.sandbox"
+        surface={{ isolation: "sandboxed-iframe" }}
+      />,
+    );
+
+    expect(screen.getByText("Failed to load view")).toBeTruthy();
+    expect(screen.getByText(/require a frameUrl HTML document/)).toBeTruthy();
+    expect(
+      screen.queryByTestId("sandboxed-view-frame-broken.sandbox"),
+    ).toBeNull();
+    expect(importBundle).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -100,13 +100,13 @@ import { Button } from "../ui/button.tsx";
 import { ErrorBoundary } from "../ui/error-boundary";
 import { Input } from "../ui/input.tsx";
 import { Spinner } from "../ui/spinner.tsx";
+import { SandboxedViewFrame } from "./SandboxedViewFrame";
 import {
   navigateToViews,
   ViewErrorState,
   ViewLoadingSkeleton,
   ViewRestrictedState,
 } from "./ViewStatusStates";
-import { SandboxedViewFrame } from "./SandboxedViewFrame";
 import { brokerViewInteract } from "./view-capability-broker";
 import { registerViewInteractHandler } from "./view-interact-registry";
 
@@ -1165,6 +1165,8 @@ async function handleStandardCapability(
 interface DynamicViewLoaderProps {
   /** The URL of the JS bundle to dynamically import. */
   bundleUrl: string;
+  /** HTML document URL for sandboxed-iframe views. */
+  frameUrl?: string;
   /** Named export inside the bundle to use as the root component. Defaults to "default". */
   componentExport?: string;
   /** The view's stable ID, used in error state messages. */
@@ -1196,6 +1198,7 @@ interface DynamicViewLoaderProps {
  */
 export const DynamicViewLoader = memo(function DynamicViewLoader({
   bundleUrl,
+  frameUrl,
   componentExport = "default",
   viewId,
   viewProps: forwardedViewProps,
@@ -1262,7 +1265,13 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
       cancelled = true;
       lease.release();
     };
-  }, [bundleUrl, componentExport, dynamicLoadingAllowed, isSandboxed, reloadKey]);
+  }, [
+    bundleUrl,
+    componentExport,
+    dynamicLoadingAllowed,
+    isSandboxed,
+    reloadKey,
+  ]);
 
   // Register this view's interact handler whenever the bundle is loaded.
   // The handler is unregistered on unmount or when the bundle changes.
@@ -1360,16 +1369,30 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
     setReloadKey((k) => k + 1);
   }, [bundleUrl, componentExport]);
 
-  // A sandboxed-iframe view embeds cross-realm; its `bundleUrl` is the framed
-  // document entry, not a host-external JS bundle. Delegating here means untrusted
-  // web content never executes in the shell's realm (#14180).
+  // A sandboxed-iframe view embeds cross-realm through a real HTML document URL.
+  // Never feed the JS module `bundleUrl` to an iframe: `/api/views/:id/bundle.js`
+  // is served as JavaScript and is only valid for host-realm dynamic import.
   if (isSandboxed) {
+    if (!frameUrl) {
+      return (
+        <ViewErrorState
+          viewId={viewId}
+          error={
+            new Error(
+              "Sandboxed iframe views require a frameUrl HTML document; bundleUrl is a JavaScript module.",
+            )
+          }
+          onRetry={recoverView}
+          onBack={navigateToViews}
+        />
+      );
+    }
     return (
       <div ref={containerRef} className="contents">
         <SandboxedViewFrame
           viewId={viewId}
           surface={surface}
-          src={bundleUrl}
+          src={frameUrl}
           title={viewId}
         />
       </div>

--- a/packages/ui/src/hooks/useAvailableViews.ts
+++ b/packages/ui/src/hooks/useAvailableViews.ts
@@ -54,6 +54,12 @@ export interface ViewRegistryEntry {
    * Absent for views that are already registered in-process.
    */
   bundleUrl?: string;
+  /**
+   * HTML document URL used for `surface.isolation: "sandboxed-iframe"` views.
+   * This is intentionally separate from `bundleUrl`; JavaScript bundles are not
+   * valid iframe documents.
+   */
+  frameUrl?: string;
   /** Named export inside the bundle to mount. Defaults to "default". */
   componentExport?: string;
   /** Public URL of a preview image to show in the view card. */


### PR DESCRIPTION
Fix-forward for #14255 / #14180. The merged sandboxed-iframe path pointed iframe `src` at `/api/views/:id/bundle.js`, which is a JavaScript module endpoint, not an HTML frame document.

## What changed

- Adds `framePath` / `frameUrl` to the view contract for sandboxed iframe documents.
- Derives and serves local plugin frame documents at `/api/views/:id/frame.html` with `text/html` + `nosniff`.
- For `surface.isolation: "sandboxed-iframe"`, `DynamicViewLoader` now requires `frameUrl` and fails closed instead of using `bundleUrl` as iframe `src`.
- Updates App routing so frame-only sandboxed views are considered routable.
- Adds regression coverage for the API registry/route and the UI loader.

## Verification

From `/tmp/codex-14255-fix` after sparse test prereqs (`packages/cloud/routing build`, `packages/shared build:i18n`, package-local third-party symlinks for missing optional deps):

- `bun run --cwd packages/ui test -- src/components/views/DynamicViewLoader.sandboxed-frame.test.tsx src/components/views/SandboxedViewFrame.test.tsx src/components/views/sandboxed-view-broker.test.ts src/components/views/sandbox-policy.test.ts`: pass, 4 files / 21 tests.
- `bun run --cwd packages/agent test -- src/__tests__/views-system-smoke.test.ts`: pass, 1 file / 28 tests.
- `bunx @biomejs/biome check` on touched files: pass.
- `git diff --check`: pass.

## Evidence still needed before merge

This is a UI/runtime fix-forward. Before final merge, CI should run the broader package lanes, and a rendered walkthrough should exercise an actual registered sandboxed view loading `/api/views/:id/frame.html` in the app shell. [shaw-codex]