### PR TITLE
test(app): require live relaunch transcript proof (#13689)

### DIFF
--- a/.github/issue-evidence/13689-relaunch-persistence/device-leg-and-verdict-logic.md
+++ b/.github/issue-evidence/13689-relaunch-persistence/device-leg-and-verdict-logic.md
@@ -17,13 +17,16 @@ logic** shared by every surface.
 
 2. **`--relaunch-persistence`** in `packages/app/scripts/mobile-local-chat-smoke.mjs`
    (lane `test:sim:local-chat:android:relaunch-persistence`). After the verified
-   turn it: creates a fresh conversation → seeds the unique marker through the
-   real inference-free `/import` route (the main turn already proves the live
-   send+inference path; this leg isolates DB survival) → `GET /messages` (before)
-   → `am force-stop` + cold `am start` so `ElizaAgentService` re-boots against the
-   **same on-device SQLite DB** → re-acquires the forwarded API + waits for
-   process stability → `GET /messages` (after) → `assertMarkerSurvivedRelaunch`.
-   Pre/post screenshots + the after-relaunch server thread are written to
+   turn it: creates a fresh conversation → sends the unique marker through the
+   real streamed chat endpoint (`POST /api/conversations/:id/messages/stream`)
+   with the same deterministic local-model reply gate used by the Android smoke
+   turn → `GET /messages` (before) → `am force-stop` + cold `am start` so
+   `ElizaAgentService` re-boots against the **same on-device SQLite DB** →
+   re-acquires the forwarded API + waits for process stability → `GET /messages`
+   (after) → `assertMarkerSurvivedRelaunch` → Android accessibility hierarchy
+   dump must expose the marker or deterministic reply after relaunch. Pre/post
+   screenshots, UI hierarchy dump, live-stream usage, and the after-relaunch
+   server thread are written to
    `packages/app/test-results/relaunch-persistence/android-<id>.json`.
 
    iOS (in-process IPC-only agent, no HTTP the harness can reach) and `--api-base`
@@ -43,8 +46,8 @@ logic** shared by every surface.
 
 - **Android on-device leg execution:** needs a booted emulator with the app
   installed (`test:sim:local-chat:android:relaunch-persistence`). Wired to real
-  `adb` / `am force-stop` / forwarded HTTP `GET /messages`; not runnable on this
-  headless host.
+  `adb` / `am force-stop` / forwarded HTTP stream+`GET /messages` and rendered
+  Android UI-hierarchy proof; not runnable on this headless host.
 - **iOS leg:** the on-device agent is IPC-only; its relaunch check needs the
   Preferences-handshake / XCUITest path (issue item 1) — surfaced as N/A.
 - **Web nightly live-walkthrough (item 4 second half):** belongs to the

--- a/packages/app/scripts/lib/chat-history-persistence.mjs
+++ b/packages/app/scripts/lib/chat-history-persistence.mjs
@@ -26,6 +26,16 @@ export class ChatHistoryPersistenceError extends Error {
 }
 
 export const RELAUNCH_MARKER_PREFIX = "RELAUNCH-PERSIST";
+const RELAUNCH_MARKER_RE = new RegExp(
+  `^${RELAUNCH_MARKER_PREFIX}-[A-Za-z0-9_-]+-[A-Za-z0-9_-]+-\\d{10,}-[A-Za-z0-9]{8,}$`,
+);
+
+function markerSegment(value, fallback) {
+  const sanitized = String(value ?? "")
+    .replace(/[^A-Za-z0-9_-]/g, "")
+    .trim();
+  return sanitized || fallback;
+}
 
 /**
  * A per-run unique marker string. The timestamp + random suffix guarantee that
@@ -42,15 +52,14 @@ export function buildRelaunchMarker({
     typeof random === "string" && random
       ? random
       : Math.random().toString(36).slice(2, 10);
-  const run = runId ? String(runId).replace(/[^A-Za-z0-9_-]/g, "") : rand;
-  return `${RELAUNCH_MARKER_PREFIX}-${platform}-${run}-${now}-${rand}`;
+  const platformSegment = markerSegment(platform, "app");
+  const run = markerSegment(runId, rand);
+  return `${RELAUNCH_MARKER_PREFIX}-${platformSegment}-${run}-${now}-${rand}`;
 }
 
-/** True only for a string that came from `buildRelaunchMarker`. */
+/** True only for a marker with the full shape emitted by `buildRelaunchMarker`. */
 export function isRelaunchMarker(value) {
-  return (
-    typeof value === "string" && value.startsWith(`${RELAUNCH_MARKER_PREFIX}-`)
-  );
+  return typeof value === "string" && RELAUNCH_MARKER_RE.test(value);
 }
 
 /**

--- a/packages/app/scripts/lib/chat-history-persistence.mjs
+++ b/packages/app/scripts/lib/chat-history-persistence.mjs
@@ -37,6 +37,13 @@ function markerSegment(value, fallback) {
   return sanitized || fallback;
 }
 
+function markerRandomSegment(value, fallback) {
+  const sanitized = String(value ?? "")
+    .replace(/[^A-Za-z0-9]/g, "")
+    .trim();
+  return sanitized.length >= 8 ? sanitized : fallback;
+}
+
 /**
  * A per-run unique marker string. The timestamp + random suffix guarantee that
  * a message left over from a previous run can never satisfy the survival check,
@@ -48,10 +55,8 @@ export function buildRelaunchMarker({
   now = Date.now(),
   random,
 } = {}) {
-  const rand =
-    typeof random === "string" && random
-      ? random
-      : Math.random().toString(36).slice(2, 10);
+  const generatedRand = Math.random().toString(36).slice(2, 10);
+  const rand = markerRandomSegment(random, generatedRand);
   const platformSegment = markerSegment(platform, "app");
   const run = markerSegment(runId, rand);
   return `${RELAUNCH_MARKER_PREFIX}-${platformSegment}-${run}-${now}-${rand}`;

--- a/packages/app/scripts/lib/chat-history-persistence.node.test.mjs
+++ b/packages/app/scripts/lib/chat-history-persistence.node.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assertMarkerSurvivedRelaunch,
+  buildRelaunchMarker,
+  ChatHistoryPersistenceError,
+  extractMessageTexts,
+  isRelaunchMarker,
+  RELAUNCH_MARKER_PREFIX,
+} from "./chat-history-persistence.mjs";
+
+function threadBody(texts) {
+  return {
+    messages: texts.map((text, i) => ({
+      role: i % 2 === 0 ? "user" : "assistant",
+      text,
+    })),
+  };
+}
+
+test("unique markers require full generated shape", () => {
+  const marker = buildRelaunchMarker({
+    platform: "android",
+    runId: "conv_123",
+    now: 1783280000000,
+    random: "abcd1234",
+  });
+  assert.equal(
+    marker,
+    `${RELAUNCH_MARKER_PREFIX}-android-conv_123-1783280000000-abcd1234`,
+  );
+  assert.equal(isRelaunchMarker(marker), true);
+  assert.equal(isRelaunchMarker(`${RELAUNCH_MARKER_PREFIX}-hardcoded`), false);
+  assert.equal(
+    isRelaunchMarker(
+      buildRelaunchMarker({
+        platform: "android local",
+        runId: "conversation:123",
+        now: 1783280000000,
+        random: "abcd1234",
+      }),
+    ),
+    true,
+  );
+});
+
+test("extractMessageTexts parses real-shaped message bodies and rejects malformed reads", () => {
+  assert.deepEqual(extractMessageTexts(threadBody(["one", "two"])), [
+    "one",
+    "two",
+  ]);
+  assert.deepEqual(extractMessageTexts({ messages: [] }), []);
+  assert.throws(() => extractMessageTexts({}), ChatHistoryPersistenceError);
+  assert.throws(
+    () => extractMessageTexts({ messages: [{ role: "user" }] }),
+    /non-string text/,
+  );
+});
+
+test("assertMarkerSurvivedRelaunch accepts only current marker before and after relaunch", () => {
+  const marker = buildRelaunchMarker({
+    platform: "android",
+    runId: "survived",
+  });
+  assert.equal(
+    assertMarkerSurvivedRelaunch({
+      marker,
+      beforeBody: threadBody([marker]),
+      afterBody: threadBody(["reply", marker]),
+    }).survived,
+    true,
+  );
+
+  assert.throws(
+    () =>
+      assertMarkerSurvivedRelaunch({
+        marker,
+        beforeBody: threadBody([marker]),
+        afterBody: { messages: [] },
+      }),
+    (error) => error.code === "MARKER_LOST_ON_RELAUNCH",
+  );
+});

--- a/packages/app/scripts/lib/chat-history-persistence.test.mjs
+++ b/packages/app/scripts/lib/chat-history-persistence.test.mjs
@@ -65,6 +65,18 @@ test("buildRelaunchMarker sanitizes marker segments so generated markers validat
     `${RELAUNCH_MARKER_PREFIX}-androidlocal-conversation123-1783280000000-abcd1234`,
   );
   assert.ok(isRelaunchMarker(marker));
+
+  const markerWithNoisyRandom = buildRelaunchMarker({
+    platform: "android",
+    runId: "conversation",
+    now: 1783280000000,
+    random: "abcd-1234",
+  });
+  assert.equal(
+    markerWithNoisyRandom,
+    `${RELAUNCH_MARKER_PREFIX}-android-conversation-1783280000000-abcd1234`,
+  );
+  assert.ok(isRelaunchMarker(markerWithNoisyRandom));
 });
 
 test("isRelaunchMarker rejects arbitrary user text", () => {

--- a/packages/app/scripts/lib/chat-history-persistence.test.mjs
+++ b/packages/app/scripts/lib/chat-history-persistence.test.mjs
@@ -53,11 +53,29 @@ test("buildRelaunchMarker is unique per call and carries the prefix + platform",
   assert.equal(pinned, `${RELAUNCH_MARKER_PREFIX}-ios-r-1000-abcd1234`);
 });
 
+test("buildRelaunchMarker sanitizes marker segments so generated markers validate", () => {
+  const marker = buildRelaunchMarker({
+    platform: "android local",
+    runId: "conversation:123",
+    now: 1783280000000,
+    random: "abcd1234",
+  });
+  assert.equal(
+    marker,
+    `${RELAUNCH_MARKER_PREFIX}-androidlocal-conversation123-1783280000000-abcd1234`,
+  );
+  assert.ok(isRelaunchMarker(marker));
+});
+
 test("isRelaunchMarker rejects arbitrary user text", () => {
   assert.ok(!isRelaunchMarker("hello world"));
   assert.ok(!isRelaunchMarker(""));
   assert.ok(!isRelaunchMarker(undefined));
   assert.ok(!isRelaunchMarker(`prefixed-${RELAUNCH_MARKER_PREFIX}-x`));
+  assert.ok(!isRelaunchMarker(`${RELAUNCH_MARKER_PREFIX}-hardcoded`));
+  assert.ok(
+    !isRelaunchMarker(`${RELAUNCH_MARKER_PREFIX}-android-run-123-short`),
+  );
 });
 
 test("extractMessageTexts returns ordered texts and treats {messages:[]} as a real empty thread", () => {
@@ -156,15 +174,17 @@ test("assertMarkerSurvivedRelaunch refuses to pass when the marker never reached
 });
 
 test("assertMarkerSurvivedRelaunch refuses a non-unique marker so a hardcoded string can't false-green", () => {
-  assert.throws(
-    () =>
-      assertMarkerSurvivedRelaunch({
-        marker: "hello",
-        beforeBody: threadBody(["hello"]),
-        afterBody: threadBody(["hello"]),
-      }),
-    (err) => err.code === "INVALID_MARKER",
-  );
+  for (const marker of ["hello", `${RELAUNCH_MARKER_PREFIX}-hardcoded`]) {
+    assert.throws(
+      () =>
+        assertMarkerSurvivedRelaunch({
+          marker,
+          beforeBody: threadBody([marker]),
+          afterBody: threadBody([marker]),
+        }),
+      (err) => err.code === "INVALID_MARKER",
+    );
+  }
 });
 
 test("assertMarkerSurvivedRelaunch surfaces a malformed after-relaunch read as an error, not a pass", () => {

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -207,8 +207,9 @@ Options:
   --android-background             Background Android, force-fire the WorkManager job, and poll /api/health
   --ios-background                 Background iOS, fire a BGTaskScheduler task via LLDB, and poll /api/health
   --ios-background-task-id ID      iOS BGTask identifier to simulate (default: ai.eliza.tasks.refresh)
-  --relaunch-persistence           After the turn, persist a unique marker message, force-stop + relaunch the app,
-                                   and assert the marker survives from server truth (GET /messages). Android only:
+  --relaunch-persistence           After the turn, send a unique marker through the live stream path, force-stop +
+                                   relaunch the app, and assert server truth plus rendered transcript proof.
+                                   Android only:
                                    the iOS on-device agent is IPC-only, so its relaunch check needs the Preferences
                                    handshake / XCUITest path (#13689).
   --help                           Print this help
@@ -1570,6 +1571,71 @@ function takeAndroidScreenshot(context, label) {
   return outPath;
 }
 
+function dumpAndroidUiHierarchy(context, label) {
+  if (!context?.installed) return null;
+  const outDir = path.join(os.tmpdir(), "eliza-android-ui-dumps");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(
+    outDir,
+    `${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.xml`,
+  );
+  const remote = `/sdcard/${path.basename(outPath)}`;
+  if (
+    tryExec(context.adb, [
+      "-s",
+      context.serial,
+      "shell",
+      "uiautomator",
+      "dump",
+      remote,
+    ]) === null
+  ) {
+    return null;
+  }
+  if (
+    tryExec(context.adb, ["-s", context.serial, "pull", remote, outPath]) ===
+    null
+  ) {
+    return null;
+  }
+  tryExec(context.adb, ["-s", context.serial, "shell", "rm", remote]);
+  return outPath;
+}
+
+function readTextFileIfPresent(filePath) {
+  if (!filePath) return "";
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function assertAndroidRenderedTranscript({ context, marker, expectedReply }) {
+  const dumpPath = dumpAndroidUiHierarchy(context, "relaunch-persistence-post");
+  const uiXml = readTextFileIfPresent(dumpPath);
+  const visibleMarker = uiXml.includes(marker);
+  const visibleReply =
+    typeof expectedReply === "string" &&
+    expectedReply.length > 0 &&
+    uiXml.toLowerCase().includes(expectedReply.toLowerCase());
+  if (!visibleMarker && !visibleReply) {
+    const screenshot = takeAndroidScreenshot(
+      context,
+      "relaunch-persistence-render-missing",
+    );
+    throw new Error(
+      `Relaunch-persistence server thread survived, but the Android UI hierarchy did not expose the marker or expected reply after relaunch. ` +
+        `marker=${marker} expectedReply=${expectedReply} uiDump=${dumpPath ?? "<unavailable>"} screenshot=${screenshot ?? "<unavailable>"}`,
+    );
+  }
+  return {
+    uiHierarchyDump: dumpPath,
+    visibleMarker,
+    visibleReply,
+  };
+}
+
 function androidBackgroundServicesReady(services, id) {
   const foregroundCount = services.match(/isForeground=true/g)?.length ?? 0;
   return (
@@ -2500,14 +2566,12 @@ async function reacquireAndroidApiAfterRelaunch(context) {
 }
 
 /**
- * Android relaunch-persistence leg (#13689). Seeds a unique marker message into
- * a fresh conversation through the real inference-free bulk-insert route (the
- * main smoke turn already proves the live send+inference path; this leg isolates
- * the DB-survival property), captures the thread from server truth, force-stops
- * and cold-relaunches the app, then re-fetches the thread from the restarted
- * agent and asserts the marker survived. The verdict — including the loud
- * failure when the thread comes back empty (a lost/fresh state dir) — is the
- * pure `assertMarkerSurvivedRelaunch`.
+ * Android relaunch-persistence leg (#13689). Sends a unique marker message
+ * through the real streamed chat path, captures the thread from server truth,
+ * force-stops and cold-relaunches the app, then re-fetches the thread from the
+ * restarted agent and asserts the marker survived. It also requires post-relaunch
+ * rendered proof from the Android accessibility hierarchy, so the lane cannot
+ * pass from a database row that never reappears in the transcript UI.
  */
 async function verifyAndroidChatHistoryPersistence(context, initialApi) {
   if (!context?.installed) {
@@ -2538,22 +2602,39 @@ async function verifyAndroidChatHistoryPersistence(context, initialApi) {
     runId: conversationId,
   });
   const messagesPath = `/api/conversations/${encodeURIComponent(conversationId)}/messages`;
+  const markerPrompt = `${marker}\nReply with exactly these four words: ${ANDROID_FULL_TURN_EXPECTED_REPLY}.`;
 
-  const imported = await requestJson(
-    "POST",
-    `/api/conversations/${encodeURIComponent(conversationId)}/import`,
-    {
-      title: `Relaunch persistence ${marker}`,
-      messages: [{ role: "user", text: marker }],
+  const { done, reply } = await withTransientRetry(
+    "relaunch-persistence streamed marker turn",
+    async () => {
+      const streamText = await requestTextResponse(
+        "POST",
+        `/api/conversations/${encodeURIComponent(conversationId)}/messages/stream`,
+        {
+          text: markerPrompt,
+          channelType: "DM",
+          source: "android-local-relaunch-persistence",
+          metadata: {
+            smoke: "android-relaunch-persistence",
+            marker,
+          },
+        },
+        apiBase,
+        token,
+        ANDROID_FULL_TURN_TIMEOUT_MS,
+      );
+      if (!streamText) {
+        throw new Error(
+          "Relaunch-persistence marker turn returned an empty body.",
+        );
+      }
+      const doneEvent = extractDoneEventFromSse(streamText);
+      return {
+        done: doneEvent,
+        reply: requireUsableFullTurnReply(doneEvent, streamText),
+      };
     },
-    apiBase,
-    token,
   );
-  if (imported.inserted !== 1) {
-    throw new Error(
-      `Marker message was not persisted before relaunch: ${JSON.stringify(imported)}`,
-    );
-  }
 
   const beforeBody = await requestJson(
     "GET",
@@ -2586,6 +2667,11 @@ async function verifyAndroidChatHistoryPersistence(context, initialApi) {
     beforeBody,
     afterBody,
   });
+  const renderedTranscript = assertAndroidRenderedTranscript({
+    context,
+    marker,
+    expectedReply: reply,
+  });
 
   fs.mkdirSync(relaunchPersistenceResultDir, { recursive: true });
   const evidencePath = path.join(
@@ -2600,8 +2686,13 @@ async function verifyAndroidChatHistoryPersistence(context, initialApi) {
         conversationId,
         marker,
         result,
+        liveStream: {
+          reply,
+          usage: done?.usage ?? null,
+        },
         preRelaunchScreenshot: preShot,
         postRelaunchScreenshot: postShot,
+        renderedTranscript,
         afterRelaunchServerThread: afterBody,
       },
       null,
@@ -2610,7 +2701,7 @@ async function verifyAndroidChatHistoryPersistence(context, initialApi) {
   );
 
   console.log(
-    `[local-chat-smoke] Relaunch persistence PASSED: marker survived (${result.beforeCount} → ${result.afterCount} message(s) from server truth). Evidence: ${evidencePath}`,
+    `[local-chat-smoke] Relaunch persistence PASSED: marker survived (${result.beforeCount} → ${result.afterCount} message(s) from server truth) and rendered proof was visible. Evidence: ${evidencePath}`,
   );
   return result;
 }


### PR DESCRIPTION
## Summary

Follow-up to closed PR #14264 for #13689. This keeps the useful pure verdict work that is now on `develop`, and adds the missing no-false-green constraints called out in review:

- the Android relaunch-persistence marker is now sent through the live streamed chat endpoint instead of `/api/conversations/:id/import`;
- the marker must use the full generated shape, so hardcoded `RELAUNCH-PERSIST-*` strings are rejected;
- after relaunch the lane still checks server truth, and now also requires Android UI hierarchy proof that the transcript exposes the marker or deterministic reply;
- added a standalone `node --test` regression file for the pure marker/parser/verdict logic.

## Sync

Rebased onto current `origin/develop` after #14264 merged as `982e5aa5d6`; this PR is now only the follow-up commit on top of develop.

## Validation

- `node --test packages/app/scripts/lib/chat-history-persistence.node.test.mjs` - pass, 3/3.
- `bunx @biomejs/biome@2.5.1 check packages/app/scripts/mobile-local-chat-smoke.mjs packages/app/scripts/lib/chat-history-persistence.mjs packages/app/scripts/lib/chat-history-persistence.test.mjs packages/app/scripts/lib/chat-history-persistence.node.test.mjs .github/issue-evidence/13689-relaunch-persistence/device-leg-and-verdict-logic.md` - pass.
- `node --check packages/app/scripts/mobile-local-chat-smoke.mjs && node --check packages/app/scripts/lib/chat-history-persistence.mjs && git diff --check origin/develop..HEAD` - pass.

## Known gaps

- `bunx vitest@4.1.5 run --config vitest.config.ts scripts/lib/chat-history-persistence.test.mjs --run` could not start in the sparse worktree because workspace dependencies/config imports were not installed/present (`vitest/config`, shared app-core test config paths).
- The real Android emulator/device leg was not run on this host; it still needs a booted emulator or device with the app installed and the local smoke model staged.
- This does not close the iOS, desktop, or web relaunch-persistence surfaces from #13689.

Refs #13689. Supersedes closed #14264.