### PR TITLE
fix(ui): cover sandbox iframe frame documents

### DIFF
--- a/packages/agent/src/api/views-routes.sandbox-document.test.ts
+++ b/packages/agent/src/api/views-routes.sandbox-document.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Covers the sandboxed dynamic-view document contract (#14263). A plugin view
+ * can still declare a JS bundle for host-realm dynamic loading metadata, but a
+ * `surface.isolation: "sandboxed-iframe"` view must also declare a separate
+ * HTML document. The registry resolves `framePath` to
+ * `/api/views/:id/frame.html`, and the route serves that document directly.
+ */
+import { promises as fs } from "node:fs";
+import type http from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getView,
+  registerPluginViews,
+  unregisterPluginViews,
+} from "./views-registry.ts";
+import {
+  clearCurrentViewState,
+  handleViewsRoutes,
+  type ViewsRouteContext,
+} from "./views-routes.ts";
+
+const TEST_PLUGIN = "@test/sandbox-document-view";
+const VIEW_ID = "sandbox-document-view";
+
+interface CapturedRes {
+  writeHead: ReturnType<typeof vi.fn>;
+  setHeader: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+}
+
+function makeCtx(pathname: string, method = "GET") {
+  const req = Readable.from([]) as unknown as http.IncomingMessage;
+  req.headers = {};
+  const res: CapturedRes = {
+    writeHead: vi.fn(),
+    setHeader: vi.fn(),
+    end: vi.fn(),
+  };
+  const json = vi.fn();
+  const error = vi.fn();
+  const ctx: ViewsRouteContext = {
+    req,
+    res: res as unknown as http.ServerResponse,
+    method,
+    pathname,
+    url: new URL(`http://local${pathname}`),
+    json,
+    error,
+    broadcastWs: vi.fn(),
+  };
+  return { ctx, res, json, error };
+}
+
+function statusFrom(res: CapturedRes): number | undefined {
+  return res.writeHead.mock.calls[0]?.[0] as number | undefined;
+}
+
+function headersFrom(res: CapturedRes): Record<string, string | number> {
+  return (res.writeHead.mock.calls[0]?.[1] ?? {}) as Record<
+    string,
+    string | number
+  >;
+}
+
+function bodyFrom(res: CapturedRes): string {
+  const chunk = res.end.mock.calls[0]?.[0];
+  if (chunk instanceof Buffer) return chunk.toString("utf8");
+  return typeof chunk === "string" ? chunk : "";
+}
+
+describe("GET /api/views/:id/frame.html", () => {
+  let pluginDir: string | null = null;
+
+  beforeEach(async () => {
+    clearCurrentViewState();
+    pluginDir = await fs.mkdtemp(path.join(tmpdir(), "eliza-sandbox-doc-"));
+    await fs.mkdir(path.join(pluginDir, "dist", "views"), {
+      recursive: true,
+    });
+    await fs.mkdir(path.join(pluginDir, "sandbox"), { recursive: true });
+    await fs.writeFile(
+      path.join(pluginDir, "dist", "views", "bundle.js"),
+      "export default function View() { return null; }\n",
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "sandbox", "index.html"),
+      "<!doctype html><title>Sandbox frame</title><script>parent.postMessage({ready:true}, '*')</script>",
+    );
+
+    await registerPluginViews(
+      {
+        name: TEST_PLUGIN,
+        description: "Synthetic sandbox frame view plugin.",
+        views: [
+          {
+            id: VIEW_ID,
+            label: "Sandbox Document View",
+            path: "/apps/sandbox-document-view",
+            bundlePath: "dist/views/bundle.js",
+            framePath: "sandbox/index.html",
+            surface: {
+              isolation: "sandboxed-iframe",
+              capabilities: ["navigate", "storage"],
+            },
+          },
+        ],
+      },
+      pluginDir,
+    );
+  });
+
+  afterEach(async () => {
+    unregisterPluginViews(TEST_PLUGIN);
+    clearCurrentViewState();
+    if (pluginDir) {
+      await fs.rm(pluginDir, { recursive: true, force: true });
+      pluginDir = null;
+    }
+  });
+
+  it("exposes a distinct iframe document URL in view metadata", async () => {
+    const entry = getView(VIEW_ID);
+    expect(entry?.bundleUrl).toMatch(
+      new RegExp(`^/api/views/${VIEW_ID}/bundle\\.js\\?v=\\d+$`),
+    );
+    expect(entry?.frameUrl).toMatch(
+      new RegExp(`^/api/views/${VIEW_ID}/frame\\.html\\?v=\\d+$`),
+    );
+
+    const { ctx, json, error } = makeCtx(
+      `/api/views/${encodeURIComponent(VIEW_ID)}`,
+    );
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(error).not.toHaveBeenCalled();
+    expect(json.mock.calls[0][1]).toMatchObject({
+      id: VIEW_ID,
+      surface: { isolation: "sandboxed-iframe" },
+    });
+    expect(json.mock.calls[0][1].frameUrl).toMatch(
+      new RegExp(`^/api/views/${VIEW_ID}/frame\\.html\\?v=\\d+$`),
+    );
+    expect(json.mock.calls[0][1].bundleUrl).toMatch(
+      new RegExp(`^/api/views/${VIEW_ID}/bundle\\.js\\?v=\\d+$`),
+    );
+  });
+
+  it("serves the declared sandbox frame, not the JS bundle endpoint", async () => {
+    const { ctx, res, error } = makeCtx(`/api/views/${VIEW_ID}/frame.html`);
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(error).not.toHaveBeenCalled();
+    expect(statusFrom(res)).toBe(200);
+    expect(headersFrom(res)).toMatchObject({
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-cache",
+      "X-Content-Type-Options": "nosniff",
+    });
+    expect(bodyFrom(res)).toContain("<title>Sandbox frame</title>");
+    expect(bodyFrom(res)).not.toContain("export default function View");
+  });
+});

--- a/packages/agent/src/services/remote-plugin-adapter.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.ts
@@ -290,6 +290,10 @@ export function createRemoteCapabilityPlugin(
       ...(view.bundleUrl !== undefined || view.bundlePath === undefined
         ? {}
         : { bundlePath: view.bundlePath }),
+      ...(view.frameUrl === undefined ? {} : { frameUrl: view.frameUrl }),
+      ...(view.frameUrl !== undefined || view.framePath === undefined
+        ? {}
+        : { framePath: view.framePath }),
     }),
   );
   const evaluators = (module.evaluators ?? []).map(

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -7,6 +7,8 @@
 // asserting against a mock.
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import type { SurfaceManifest } from "@elizaos/core";
+import { NAVIGATE_VIEW_EVENT } from "@elizaos/shared/events";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { transform } from "esbuild";
 import { type ReactElement, useState } from "react";
@@ -22,6 +24,8 @@ import {
   hostImport,
   isSameOriginBundleUrl,
 } from "./DynamicViewLoader";
+import { sandboxStorageKey } from "./SandboxedViewFrame";
+import { SANDBOXED_VIEW_CHANNEL } from "./sandboxed-view-broker";
 
 describe("isSameOriginBundleUrl (view-bundle origin gate)", () => {
   it("accepts same-origin and root-relative /api/views bundle URLs", () => {
@@ -105,6 +109,40 @@ vi.mock("../../api", () => ({
   client: { sendWsMessage },
 }));
 
+const SANDBOXED_SURFACE: SurfaceManifest = {
+  isolation: "sandboxed-iframe",
+  capabilities: ["navigate", "storage"],
+};
+
+function postSandboxRequestFromFrame(
+  frameWindow: Window,
+  capability: string,
+  payload: unknown,
+  requestId: string,
+) {
+  const event = new MessageEvent("message", {
+    data: {
+      channel: SANDBOXED_VIEW_CHANNEL,
+      kind: "request",
+      requestId,
+      capability,
+      payload,
+    },
+  });
+  Object.defineProperty(event, "source", { value: frameWindow });
+  window.dispatchEvent(event);
+}
+
+function lastSandboxResponse(postSpy: ReturnType<typeof vi.spyOn>) {
+  const calls = postSpy.mock.calls;
+  return calls[calls.length - 1]?.[0] as {
+    requestId: string;
+    ok: boolean;
+    result?: unknown;
+    error?: string;
+  };
+}
+
 describe("DynamicViewLoader", () => {
   beforeEach(() => {
     Object.defineProperty(HTMLElement.prototype, "innerText", {
@@ -119,6 +157,7 @@ describe("DynamicViewLoader", () => {
         escape: (value: string) => value.replaceAll('"', '\\"'),
       },
     });
+    window.localStorage.clear();
   });
 
   afterEach(() => {
@@ -130,6 +169,7 @@ describe("DynamicViewLoader", () => {
     vi.unstubAllGlobals();
     vi.clearAllTimers();
     vi.useRealTimers();
+    window.localStorage.clear();
   });
 
   it("imports absolute remote bundleUrl directly", async () => {
@@ -148,6 +188,98 @@ describe("DynamicViewLoader", () => {
     expect(importBundle).not.toHaveBeenCalledWith(
       expect.stringContaining("/api/views/remote.panel/bundle.js"),
     );
+  });
+
+  it("renders sandboxed dynamic views from frameUrl and brokers opaque-frame requests", async () => {
+    const bundleUrl = "/api/views/sandboxed-plugin/bundle.js";
+    const frameUrl = "/api/views/sandboxed-plugin/frame.html";
+    const importBundle = vi.fn(async () => ({
+      default: function ShouldNotLoadInHostRealm() {
+        return <div>incorrect host realm load</div>;
+      },
+    }));
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = importBundle;
+    const navSpy = vi.fn();
+    window.addEventListener(NAVIGATE_VIEW_EVENT, navSpy);
+
+    render(
+      <DynamicViewLoader
+        bundleUrl={bundleUrl}
+        frameUrl={frameUrl}
+        viewId="sandboxed-plugin"
+        surface={SANDBOXED_SURFACE}
+      />,
+    );
+
+    const iframe = screen.getByTestId(
+      "sandboxed-view-frame-sandboxed-plugin",
+    ) as HTMLIFrameElement;
+    expect(iframe.getAttribute("src")).toBe(frameUrl);
+    expect(iframe.getAttribute("src")).not.toBe(bundleUrl);
+    expect(importBundle).not.toHaveBeenCalled();
+
+    const frameWindow = iframe.contentWindow;
+    if (!frameWindow) throw new Error("iframe contentWindow missing in jsdom");
+    const postSpy = vi
+      .spyOn(frameWindow, "postMessage")
+      .mockImplementation(() => {});
+
+    postSandboxRequestFromFrame(
+      frameWindow,
+      "storage",
+      { op: "set", key: "draft", value: "opaque-doc" },
+      "req-store",
+    );
+    await waitFor(() => expect(postSpy).toHaveBeenCalledTimes(1));
+    expect(lastSandboxResponse(postSpy)).toMatchObject({
+      requestId: "req-store",
+      ok: true,
+    });
+    expect(
+      window.localStorage.getItem(
+        sandboxStorageKey("sandboxed-plugin", "draft"),
+      ),
+    ).toBe("opaque-doc");
+    expect(window.localStorage.getItem("draft")).toBeNull();
+
+    postSandboxRequestFromFrame(
+      frameWindow,
+      "navigate",
+      { viewId: "chat" },
+      "req-nav",
+    );
+    await waitFor(() => expect(postSpy).toHaveBeenCalledTimes(2));
+    expect(lastSandboxResponse(postSpy)).toMatchObject({
+      requestId: "req-nav",
+      ok: true,
+    });
+    await waitFor(() => expect(navSpy).toHaveBeenCalledTimes(1));
+    expect((navSpy.mock.calls[0][0] as CustomEvent).detail).toMatchObject({
+      viewId: "chat",
+    });
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, navSpy);
+  });
+
+  it("fails closed when a sandboxed dynamic view has no framed document URL", () => {
+    const importBundle = vi.fn(async () => ({
+      default: function ShouldNotLoadInHostRealm() {
+        return <div>incorrect host realm load</div>;
+      },
+    }));
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = importBundle;
+
+    render(
+      <DynamicViewLoader
+        bundleUrl="/api/views/missing-doc/bundle.js"
+        viewId="missing-doc"
+        surface={{ isolation: "sandboxed-iframe" }}
+      />,
+    );
+
+    expect(screen.getByText("Failed to load view")).toBeTruthy();
+    expect(screen.getByText(/require a frameUrl/)).toBeTruthy();
+    expect(screen.queryByTestId("sandboxed-view-frame-missing-doc")).toBeNull();
+    expect(importBundle).not.toHaveBeenCalled();
   });
 
   it("registers remote view interact handlers after the bundle loads", async () => {


### PR DESCRIPTION
## Summary
- Forward remote capability-router view `frameUrl` / `framePath` metadata into `ViewDeclaration` so sandboxed remote views keep their HTML frame contract.
- Add API coverage proving `framePath` resolves to a versioned `/api/views/:id/frame.html` URL and serves the declared HTML document instead of the JS bundle endpoint.
- Add DynamicViewLoader coverage proving sandboxed views load `frameUrl`, never iframe `bundleUrl`, broker navigate/storage from the opaque frame, and fail closed without `frameUrl`.

Fixes #14263.

## Verification
- `bunx @biomejs/biome check packages/agent/src/services/remote-plugin-adapter.ts packages/agent/src/api/views-routes.sandbox-document.test.ts packages/ui/src/components/views/DynamicViewLoader.test.tsx`
- `bun run --cwd packages/agent test -- src/api/views-routes.sandbox-document.test.ts`
- `bun run --cwd packages/ui test -- src/components/views/DynamicViewLoader.test.tsx -t "frameUrl|fails closed"`
- `bun run --cwd packages/ui test -- src/components/views/SandboxedViewFrame.test.tsx`

## Evidence notes
- N/A real LLM trajectories: no model/action/prompt behavior changed.
- N/A screenshots/video: final patch changes route metadata forwarding and tests only; no production UI pixels changed beyond upstream frame handling.
- Full `bun run verify` not run in this sparse worktree; root install/verify requires workspace directories outside the sparse checkout.