### PR TITLE
fix(ui): enforce sandbox frame view contract

### DIFF
--- a/packages/agent/src/__tests__/views-system-smoke.test.ts
+++ b/packages/agent/src/__tests__/views-system-smoke.test.ts
@@ -61,6 +61,7 @@ function makeCtx(
     body?: unknown;
     broadcastWs?: (payload: object) => void;
     developerMode?: boolean;
+    headers?: http.IncomingHttpHeaders;
     res?: http.ServerResponse;
   } = {},
 ): {
@@ -74,7 +75,7 @@ function makeCtx(
   const req =
     opts.body !== undefined || method === "POST"
       ? makeReqWithBody(opts.body)
-      : ({ headers: {} } as http.IncomingMessage);
+      : ({ headers: opts.headers ?? {} } as http.IncomingMessage);
   const ctx: ViewsRouteContext = {
     req,
     res: opts.res ?? ({} as http.ServerResponse),
@@ -354,6 +355,99 @@ describe("stage 2: HTTP GET /api/views returns views list", () => {
       await rm(pluginDir, { recursive: true, force: true });
     }
   });
+
+  it("marks sandboxed iframe views unavailable when their frame document is missing", async () => {
+    const pluginDir = await mkdtemp(path.join(os.tmpdir(), "eliza-frame-"));
+    try {
+      await mkdir(path.join(pluginDir, "dist", "views"), { recursive: true });
+      await writeFile(
+        path.join(pluginDir, "dist", "views", "bundle.js"),
+        "export default function Smoke() { return null; }",
+      );
+
+      await registerPluginViews(
+        {
+          name: SMOKE_PLUGIN,
+          description: "smoke plugin",
+          actions: [],
+          views: [
+            {
+              ...SMOKE_VIEW,
+              framePath: "dist/views/frame.html",
+              surface: { isolation: "sandboxed-iframe" },
+            },
+          ],
+        },
+        pluginDir,
+      );
+
+      const { ctx, json } = makeCtx("GET", "/api/views");
+      await handleViewsRoutes(ctx);
+
+      const [, body] = json.mock.calls[0] as [
+        unknown,
+        {
+          views: {
+            id: string;
+            available: boolean;
+            bundleUrl?: string;
+            frameUrl?: string;
+          }[];
+        },
+      ];
+      const view = body.views.find((v) => v.id === "smoke.main");
+      expect(view?.bundleUrl).toMatch(
+        /^\/api\/views\/smoke\.main\/bundle\.js\?v=\d+$/,
+      );
+      expect(view?.frameUrl).toMatch(
+        /^\/api\/views\/smoke\.main\/frame\.html\?v=\d+$/,
+      );
+      expect(view?.available).toBe(false);
+    } finally {
+      await rm(pluginDir, { recursive: true, force: true });
+    }
+  });
+
+  it("filters sandbox frame documents from restricted native platforms", async () => {
+    const pluginDir = await mkdtemp(path.join(os.tmpdir(), "eliza-frame-"));
+    try {
+      await mkdir(path.join(pluginDir, "dist", "views"), { recursive: true });
+      await writeFile(
+        path.join(pluginDir, "dist", "views", "frame.html"),
+        "<!doctype html><title>Sandbox smoke</title>",
+      );
+
+      await registerPluginViews(
+        {
+          name: SMOKE_PLUGIN,
+          description: "smoke plugin",
+          actions: [],
+          views: [
+            {
+              ...SMOKE_VIEW,
+              bundlePath: undefined,
+              framePath: "dist/views/frame.html",
+              surface: { isolation: "sandboxed-iframe" },
+            },
+          ],
+        },
+        pluginDir,
+      );
+
+      const { ctx, json } = makeCtx("GET", "/api/views", {
+        headers: { "x-eliza-platform": "ios" },
+      });
+      await handleViewsRoutes(ctx);
+
+      const [, body] = json.mock.calls[0] as [
+        unknown,
+        { views: { id: string }[] },
+      ];
+      expect(body.views.some((v) => v.id === "smoke.main")).toBe(false);
+    } finally {
+      await rm(pluginDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -544,6 +638,52 @@ describe("stage 4b: GET /api/views/:id/frame.html serves sandbox frame documents
       const served = res.end.mock.calls[0]?.[0];
       expect(Buffer.isBuffer(served)).toBe(true);
       expect(String(served)).toContain("<title>Sandbox smoke</title>");
+    } finally {
+      await rm(pluginDir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks sandbox frame documents on restricted native platforms", async () => {
+    const pluginDir = await mkdtemp(path.join(os.tmpdir(), "eliza-frame-"));
+    try {
+      await mkdir(path.join(pluginDir, "dist", "views"), { recursive: true });
+      await writeFile(
+        path.join(pluginDir, "dist", "views", "frame.html"),
+        "<!doctype html><title>Sandbox smoke</title>",
+      );
+
+      await registerPluginViews(
+        {
+          name: SMOKE_PLUGIN,
+          description: "smoke plugin",
+          actions: [],
+          views: [
+            {
+              ...SMOKE_VIEW,
+              bundlePath: undefined,
+              framePath: "dist/views/frame.html",
+              surface: { isolation: "sandboxed-iframe" },
+            },
+          ],
+        },
+        pluginDir,
+      );
+
+      const { ctx, error } = makeCtx(
+        "GET",
+        "/api/views/smoke.main/frame.html",
+        {
+          headers: { "x-eliza-platform": "ios" },
+        },
+      );
+      const handled = await handleViewsRoutes(ctx);
+
+      expect(handled).toBe(true);
+      expect(error).toHaveBeenCalledWith(
+        expect.anything(),
+        "Dynamic view frame loading is not permitted on this platform.",
+        403,
+      );
     } finally {
       await rm(pluginDir, { recursive: true, force: true });
     }

--- a/packages/agent/src/api/views-registry.ts
+++ b/packages/agent/src/api/views-registry.ts
@@ -538,17 +538,23 @@ async function buildEntry(
   const loadedAt = Date.now();
   const normalizedViewType = normalizeViewType(view.viewType);
   const registryKey = viewRegistryKey(view.id, normalizedViewType);
+  const requiresFrameDocument = view.surface?.isolation === "sandboxed-iframe";
 
   // Check bundle availability and collect hash + size when resolvable.
-  let available = Boolean(view.bundleUrl || view.frameUrl);
+  let available = requiresFrameDocument
+    ? Boolean(view.frameUrl)
+    : Boolean(view.bundleUrl || view.frameUrl);
   let bundleHash: string | undefined;
   let bundleSize: number | undefined;
   if (!view.bundleUrl && pluginDir && view.bundlePath) {
     const bundleAbs = path.resolve(pluginDir, view.bundlePath);
     const packageRoot = `${path.resolve(pluginDir)}${path.sep}`;
     if (bundleAbs.startsWith(packageRoot)) {
-      available = await fileExists(bundleAbs);
-      if (available) {
+      const bundleExists = await fileExists(bundleAbs);
+      if (!requiresFrameDocument) {
+        available = bundleExists;
+      }
+      if (bundleExists) {
         const [hash, stat] = await Promise.all([
           computeBundleHash(bundleAbs),
           fs.stat(bundleAbs).catch(() => null),
@@ -582,11 +588,16 @@ async function buildEntry(
       }
     }
   }
-  if (!available && !view.frameUrl && pluginDir && view.framePath) {
+  if (!view.frameUrl && pluginDir && view.framePath) {
     const frameAbs = path.resolve(pluginDir, view.framePath);
     const packageRoot = `${path.resolve(pluginDir)}${path.sep}`;
     if (frameAbs.startsWith(packageRoot)) {
-      available = await fileExists(frameAbs);
+      const frameExists = await fileExists(frameAbs);
+      if (requiresFrameDocument) {
+        available = frameExists;
+      } else if (!available) {
+        available = frameExists;
+      }
     }
   }
 

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -402,10 +402,10 @@ export async function handleViewsRoutes(
     // user enabled, so kind-gating is a client responsibility.
     const allViews = listViews({ includeAllKinds: true, viewType });
     // On restricted platforms (iOS/Android store builds), only surface views
-    // without a dynamic bundle URL (already in-process).
+    // without dynamic code URLs (already in-process).
     const filtered = dynamicAllowed
       ? allViews
-      : allViews.filter((v) => !v.bundleUrl);
+      : allViews.filter((v) => !v.bundleUrl && !v.frameUrl);
     // Annotate each entry with `builtin: true` when it comes from the shell.
     const views = filtered.map((v) => ({
       ...v,
@@ -634,6 +634,16 @@ export async function handleViewsRoutes(
 
   // ── GET/HEAD /api/views/:id/frame.html ───────────────────────────────────
   if ((method === "GET" || method === "HEAD") && subResource === "frame.html") {
+    const clientPlatform = detectClientPlatform(req);
+    if (!isDynamicLoadingAllowed(clientPlatform)) {
+      error(
+        res,
+        "Dynamic view frame loading is not permitted on this platform.",
+        403,
+      );
+      return true;
+    }
+
     const viewType = parseViewTypeParam(url.searchParams.get("viewType"));
     const entry = getView(id, { viewType });
     if (!entry) {

--- a/packages/agent/src/services/remote-plugin-adapter.test.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.test.ts
@@ -228,7 +228,12 @@ const remoteModule: RemotePluginModuleManifest = {
       id: "remote-view",
       label: "Remote View",
       viewType: "gui",
+      surface: {
+        isolation: "sandboxed-iframe",
+        capabilities: ["navigate", "storage"],
+      },
       bundleUrl: "https://remote.example/assets/remote-view.js",
+      frameUrl: "https://remote.example/assets/remote-view.html",
     },
   ],
 };
@@ -534,6 +539,11 @@ describe("remote plugin adapter", () => {
     expect(plugin.views?.[0]).toMatchObject({
       id: "remote-view",
       bundleUrl: "https://remote.example/assets/remote-view.js",
+      frameUrl: "https://remote.example/assets/remote-view.html",
+      surface: {
+        isolation: "sandboxed-iframe",
+        capabilities: ["navigate", "storage"],
+      },
     });
     expect(plugin.widgets?.[0]).toMatchObject({
       id: "remote.widget",

--- a/packages/agent/src/services/remote-plugin-adapter.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.ts
@@ -286,10 +286,15 @@ export function createRemoteCapabilityPlugin(
       ...(view.backgroundPolicy === undefined
         ? {}
         : { backgroundPolicy: view.backgroundPolicy }),
+      ...(view.surface === undefined ? {} : { surface: view.surface }),
       ...(view.bundleUrl === undefined ? {} : { bundleUrl: view.bundleUrl }),
       ...(view.bundleUrl !== undefined || view.bundlePath === undefined
         ? {}
         : { bundlePath: view.bundlePath }),
+      ...(view.frameUrl === undefined ? {} : { frameUrl: view.frameUrl }),
+      ...(view.frameUrl !== undefined || view.framePath === undefined
+        ? {}
+        : { framePath: view.framePath }),
     }),
   );
   const evaluators = (module.evaluators ?? []).map(

--- a/packages/core/src/capabilities/index.test.ts
+++ b/packages/core/src/capabilities/index.test.ts
@@ -1896,6 +1896,78 @@ describe("capability router", () => {
 		});
 	});
 
+	it("accepts remote plugin sandbox frame view manifests", async () => {
+		const router = new RuntimeBrokerCapabilityRouter({
+			invokeRuntime: async () => ({
+				modules: [
+					{
+						id: "remote-weather",
+						name: "@remote/weather",
+						views: [
+							{
+								id: "weather-sandbox",
+								label: "Weather Sandbox",
+								surface: {
+									isolation: "sandboxed-iframe",
+									capabilities: ["navigate", "storage"],
+								},
+								frameUrl: "https://weather.example/frame.html",
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		await expect(router.plugin.listModules()).resolves.toEqual({
+			modules: [
+				expect.objectContaining({
+					id: "remote-weather",
+					views: [
+						expect.objectContaining({
+							id: "weather-sandbox",
+							frameUrl: "https://weather.example/frame.html",
+							surface: {
+								isolation: "sandboxed-iframe",
+								capabilities: ["navigate", "storage"],
+							},
+						}),
+					],
+				}),
+			],
+		});
+	});
+
+	it("rejects remote plugin views with invalid surface manifests", async () => {
+		const router = new RuntimeBrokerCapabilityRouter({
+			invokeRuntime: async () => ({
+				modules: [
+					{
+						id: "remote-weather",
+						name: "@remote/weather",
+						views: [
+							{
+								id: "weather-sandbox",
+								label: "Weather Sandbox",
+								surface: {
+									isolation: "sandboxed-iframe",
+									capabilities: ["navigate", "admin"],
+								},
+								frameUrl: "https://weather.example/frame.html",
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		await expect(router.plugin.listModules()).rejects.toMatchObject({
+			code: "CAPABILITY_DECODE_FAILED",
+			method: "plugin.modules.list.modules.views.surface",
+			message: "capabilities contains unsupported capability.",
+		});
+	});
+
 	it("rejects remote plugin views with unsafe bundle paths", async () => {
 		const router = new RuntimeBrokerCapabilityRouter({
 			invokeRuntime: async () => ({

--- a/packages/core/src/capabilities/index.ts
+++ b/packages/core/src/capabilities/index.ts
@@ -15,6 +15,7 @@
  * that pins the wire protocol.
  */
 import type { JsonObject, JsonValue } from "../types/primitives";
+import type { SurfaceCapability } from "../types/surface-manifest";
 
 export * from "./sandbox-factory";
 
@@ -239,11 +240,24 @@ export type RemotePluginRouteManifest = {
 
 export type RemotePluginBackgroundPolicy = "opaque" | "shared";
 
+export type RemotePluginSurfaceManifest = JsonObject & {
+	background?: RemotePluginBackgroundPolicy;
+	header?: "normal" | "fullscreen" | "modal" | "immersive";
+	isolation?:
+		| "in-process"
+		| "sandboxed-iframe"
+		| "native-webview"
+		| "immersive";
+	lifecycle?: "ephemeral" | "retained";
+	capabilities?: SurfaceCapability[];
+};
+
 export type RemotePluginViewManifest = {
 	id: string;
 	label: string;
 	viewType?: "gui" | "tui" | "xr";
 	backgroundPolicy?: RemotePluginBackgroundPolicy;
+	surface?: RemotePluginSurfaceManifest;
 	bundlePath?: string;
 	bundleUrl?: string;
 	framePath?: string;
@@ -2526,6 +2540,102 @@ function optionalBackgroundPolicy(
 	throw decodeError(method, `${key} must be "opaque" or "shared".`);
 }
 
+function optionalSurfaceManifest(
+	object: JsonObject,
+	key: string,
+	method: string,
+): RemotePluginSurfaceManifest | undefined {
+	const value = optionalJsonObject(object, key, method);
+	if (value === undefined) return undefined;
+
+	const background = optionalString(value, "background", `${method}.${key}`);
+	if (
+		background !== undefined &&
+		background !== "opaque" &&
+		background !== "shared"
+	) {
+		throw decodeError(
+			method,
+			`${key}.background must be "opaque" or "shared".`,
+		);
+	}
+
+	const header = optionalString(value, "header", `${method}.${key}`);
+	if (
+		header !== undefined &&
+		header !== "normal" &&
+		header !== "fullscreen" &&
+		header !== "modal" &&
+		header !== "immersive"
+	) {
+		throw decodeError(
+			method,
+			`${key}.header must be "normal", "fullscreen", "modal", or "immersive".`,
+		);
+	}
+
+	const isolation = optionalString(value, "isolation", `${method}.${key}`);
+	if (
+		isolation !== undefined &&
+		isolation !== "in-process" &&
+		isolation !== "sandboxed-iframe" &&
+		isolation !== "native-webview" &&
+		isolation !== "immersive"
+	) {
+		throw decodeError(method, `${key}.isolation is not supported.`);
+	}
+
+	const lifecycle = optionalString(value, "lifecycle", `${method}.${key}`);
+	if (
+		lifecycle !== undefined &&
+		lifecycle !== "ephemeral" &&
+		lifecycle !== "retained"
+	) {
+		throw decodeError(
+			method,
+			`${key}.lifecycle must be "ephemeral" or "retained".`,
+		);
+	}
+
+	const capabilities = optionalSurfaceCapabilities(
+		value,
+		"capabilities",
+		`${method}.${key}`,
+	);
+
+	return {
+		...(background === undefined ? {} : { background }),
+		...(header === undefined ? {} : { header }),
+		...(isolation === undefined ? {} : { isolation }),
+		...(lifecycle === undefined ? {} : { lifecycle }),
+		...(capabilities === undefined ? {} : { capabilities }),
+	};
+}
+
+function optionalSurfaceCapabilities(
+	object: JsonObject,
+	key: string,
+	method: string,
+): SurfaceCapability[] | undefined {
+	const values = optionalStringArray(object, key, method);
+	if (values === undefined) return undefined;
+	const allowed = new Set<SurfaceCapability>([
+		"wallpaper",
+		"background:apply",
+		"navigate",
+		"storage",
+		"agent-surface",
+	]);
+	const capabilities: SurfaceCapability[] = [];
+	for (const value of values) {
+		if (!allowed.has(value as SurfaceCapability)) {
+			throw decodeError(method, `${key} contains unsupported capability.`);
+		}
+		capabilities.push(value as SurfaceCapability);
+	}
+	return capabilities;
+}
+
 function requireResponseHandlerFieldEffect(
 	value: JsonValue,
 	method: string,
@@ -3434,6 +3544,7 @@ function requireRemotePluginView(
 		"backgroundPolicy",
 		method,
 	);
+	const surface = optionalSurfaceManifest(object, "surface", method);
 	const contentType = optionalString(object, "contentType", method);
 	const integrity = optionalString(object, "integrity", method);
 	return {
@@ -3441,6 +3552,7 @@ function requireRemotePluginView(
 		label: requireNonEmptyString(object, "label", method),
 		...(viewType === undefined ? {} : { viewType }),
 		...(backgroundPolicy === undefined ? {} : { backgroundPolicy }),
+		...(surface === undefined ? {} : { surface }),
 		...(bundlePath === undefined ? {} : { bundlePath }),
 		...(bundleUrl === undefined ? {} : { bundleUrl }),
 		...(framePath === undefined ? {} : { framePath }),

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -1369,6 +1369,12 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
     setReloadKey((k) => k + 1);
   }, [bundleUrl, componentExport]);
 
+  // iOS App Store and Google Play builds cannot load remote JS or HTML frame
+  // documents at runtime; both execute plugin-provided code.
+  if (!dynamicLoadingAllowed) {
+    return <ViewRestrictedState viewId={viewId} />;
+  }
+
   // A sandboxed-iframe view embeds cross-realm through a real HTML document URL.
   // Never feed the JS module `bundleUrl` to an iframe: `/api/views/:id/bundle.js`
   // is served as JavaScript and is only valid for host-realm dynamic import.
@@ -1397,11 +1403,6 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
         />
       </div>
     );
-  }
-
-  // iOS App Store and Google Play builds cannot load remote JS at runtime.
-  if (!dynamicLoadingAllowed) {
-    return <ViewRestrictedState viewId={viewId} />;
   }
 
   if (loadError) {


### PR DESCRIPTION
## Summary

Fix-forward for #14270 after review found the merged sandbox frame contract was not enforced end-to-end.

- preserves remote `surface` / `framePath` / `frameUrl` fields through manifest decode and agent materialization;
- makes sandboxed-iframe registry availability depend on a real frame document, not just a JS bundle;
- filters and blocks sandbox frame documents on restricted native platforms just like dynamic bundle code;
- keeps the UI loader from rendering sandbox frames when runtime dynamic loading is disallowed.

## Validation

- `bun test packages/core/src/capabilities/index.test.ts packages/agent/src/services/remote-plugin-adapter.test.ts packages/agent/src/__tests__/views-system-smoke.test.ts` - passed, 133 pass / 3 skip / 0 fail.
- `bunx @biomejs/biome check packages/core/src/capabilities/index.ts packages/core/src/capabilities/index.test.ts packages/agent/src/services/remote-plugin-adapter.ts packages/agent/src/services/remote-plugin-adapter.test.ts packages/agent/src/api/views-registry.ts packages/agent/src/api/views-routes.ts packages/agent/src/__tests__/views-system-smoke.test.ts packages/ui/src/components/views/DynamicViewLoader.tsx` - passed.
- `git diff --check origin/develop...HEAD` - passed in clean worktree.

## Known validation limits

- `bun run --cwd packages/ui test -- src/components/views/DynamicViewLoader.sandboxed-frame.test.tsx src/components/views/SandboxedViewFrame.test.tsx src/components/views/sandboxed-view-broker.test.ts src/components/views/sandbox-policy.test.ts` currently fails in this checkout before exercising the change because React resolves from both `dist/node_modules` and root `node_modules`, causing invalid-hook-call errors.
- `bun run --cwd packages/core typecheck` still fails on unrelated logger `adze` declaration resolution from `dist/node_modules`; my earlier `SurfaceManifest` header/value mismatch was fixed before this PR.
- `bun run --cwd packages/agent typecheck` still fails on unrelated existing missing optional package/declaration errors and unrelated test typing errors; the remote surface JSON compatibility error from this change was fixed before this PR.

## Evidence

N/A - no user-facing visual design change. This is a server/core contract hardening and UI fail-closed guard for sandboxed plugin view loading. The focused route/registry/manifest tests cover the regression paths.

Refs #14270.