### PR TITLE
fix(orchestrator): keep live ACP commit locks fresh

### DIFF
--- a/.github/issue-evidence/14261-acp-commit-lock-heartbeat.md
+++ b/.github/issue-evidence/14261-acp-commit-lock-heartbeat.md
@@ -1,0 +1,56 @@
+# #14261 ACP commit-lock live-holder heartbeat
+
+Date: 2026-07-05
+
+## What changed
+
+- Added a detached heartbeat for the ACP shared-worktree commit lock. The wrapper
+  blocks inside `spawnSync` while `git commit` and hooks run, so the parent
+  process cannot refresh the lock mtime itself during a long critical section.
+- Added a regression where session A holds the real commit lock in a pre-commit
+  hook beyond a lowered stale threshold while session B waits. Both commits must
+  land linearly without stealing the live holder's lock.
+
+## Verification
+
+```bash
+bun run --cwd plugins/plugin-agent-orchestrator test -- src/__tests__/acp-git-commit-race.test.ts
+```
+
+Result: 1 file / 5 tests passed.
+
+```bash
+bun run --cwd plugins/plugin-agent-orchestrator test -- src/__tests__/acp-git-index-isolation.test.ts
+```
+
+Result: 1 file / 1 test passed.
+
+```bash
+bunx @biomejs/biome@2.5.1 check \
+  plugins/plugin-agent-orchestrator/src/services/acp-service.ts \
+  plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts
+```
+
+Result: clean.
+
+```bash
+bun run --cwd plugins/plugin-agent-orchestrator build
+```
+
+Result: passed.
+
+## Typecheck note
+
+`bun run --cwd plugins/plugin-agent-orchestrator typecheck` was attempted after
+generating shared i18n data. It failed before touching the changed ACP files
+because this temp worktree resolves many workspace dependencies through
+`/home/shaw/milady/eliza/dist/node_modules` without declaration files
+(`drizzle-orm`, `yaml`, `fs-extra`, `git-workspace-service`,
+`coding-agent-adapters`, and others). No type error cited the changed files.
+
+## Non-applicable evidence
+
+- UI screenshots/video: N/A - deterministic git wrapper behavior; no UI surface.
+- Live-LLM trajectories: N/A - no prompt/model/action behavior changed.
+- Backend/frontend logs: N/A - the regression drives the real generated git
+  wrapper against a real git repository and asserts the resulting git history.

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts
@@ -62,6 +62,10 @@ function gitAsync(
   });
 }
 
+function lockFile(repo: string): string {
+  return path.join(repo, ".git", "eliza-acp-commit.lock");
+}
+
 async function waitForFile(target: string, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -182,6 +186,81 @@ exit 0
       const parentCount = line.trim().split(/\s+/).filter(Boolean).length;
       expect(parentCount).toBeLessThanOrEqual(1);
     }
+  }, 30_000);
+
+  it("does not steal a live commit lock during a long critical section", async () => {
+    const service = new AcpService(makeRuntime(), {
+      store: new InMemorySessionStore(),
+    });
+    const prepare = (
+      service as unknown as GitIndexPreparer
+    ).prepareSessionGitIndex.bind(service);
+
+    const baselineSha = git(repo, ["rev-parse", "HEAD"]);
+    const sessionA = await prepare(repo, "sess-live-owner-a", baselineSha);
+    const sessionB = await prepare(repo, "sess-live-owner-b", baselineSha);
+    expect(sessionA?.env.GIT_INDEX_FILE).toBeTruthy();
+    expect(sessionB?.env.GIT_INDEX_FILE).toBeTruthy();
+
+    writeFileSync(path.join(repo, "live-a.txt"), "from live owner a\n");
+    writeFileSync(path.join(repo, "live-b.txt"), "from live owner b\n");
+    git(repo, ["add", "live-a.txt"], sessionA?.env);
+    git(repo, ["add", "live-b.txt"], sessionB?.env);
+
+    const signalFile = path.join(tmpRoot, "a-live-lock-precommit");
+    const hookPath = path.join(repo, ".git", "hooks", "pre-commit");
+    writeFileSync(
+      hookPath,
+      `#!/bin/sh
+if [ "$ACP_TEST_ROLE" = "A" ]; then
+  : > "${signalFile}"
+  sleep 0.8
+fi
+exit 0
+`,
+    );
+    chmodSync(hookPath, 0o755);
+
+    const lockRaceEnv = {
+      ACP_COMMIT_LOCK_POLL_MS: "5",
+      ACP_COMMIT_LOCK_STALE_MS: "120",
+      ACP_COMMIT_LOCK_WAIT_MS: "5000",
+    };
+    const envA = {
+      ...process.env,
+      ...sessionA?.env,
+      ...lockRaceEnv,
+      ACP_TEST_ROLE: "A",
+    };
+    const envB = {
+      ...process.env,
+      ...sessionB?.env,
+      ...lockRaceEnv,
+      ACP_TEST_ROLE: "B",
+    };
+
+    const commitA = gitAsync(repo, ["commit", "-m", "live owner a"], envA);
+    await waitForFile(signalFile, 10_000);
+    const commitB = gitAsync(repo, ["commit", "-m", "live waiter b"], envB);
+
+    const [resultA, resultB] = await Promise.all([commitA, commitB]);
+    expect(resultA.code, `session a failed: ${resultA.stderr}`).toBe(0);
+    expect(resultB.code, `session b failed: ${resultB.stderr}`).toBe(0);
+
+    const tree = git(repo, ["ls-tree", "--name-only", "-r", "HEAD"]);
+    expect(tree.split("\n").filter(Boolean).sort()).toEqual([
+      "README.md",
+      "live-a.txt",
+      "live-b.txt",
+    ]);
+
+    expect(Number(git(repo, ["rev-list", "--count", "HEAD"]))).toBe(3);
+    const parents = git(repo, ["log", "--pretty=%P", "HEAD"]).split("\n");
+    for (const line of parents) {
+      const parentCount = line.trim().split(/\s+/).filter(Boolean).length;
+      expect(parentCount).toBeLessThanOrEqual(1);
+    }
+    expect(existsSync(lockFile(repo))).toBe(false);
   }, 30_000);
 
   it("reclaims a stale commit lock without leaving reclaim artifacts", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -264,7 +264,7 @@ const ACP_METADATA_GIT_WRAPPER_DIR = "gitWrapperDir";
 const MAX_CAPTURED_TOOL_OUTPUT_CHARS = 12_000;
 const TOOL_OUTPUT_END_MARKER = "[/tool output]";
 const SESSION_GIT_WRAPPER = `#!/usr/bin/env node
-const { spawnSync } = require("node:child_process");
+const { spawn, spawnSync } = require("node:child_process");
 const { randomUUID } = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
@@ -310,16 +310,15 @@ function run(argv, opts = {}) {
 // processes with an exclusive lockfile in the worktree's own git dir (where HEAD
 // lives), so isolated worktrees — which have distinct git dirs and HEADs — never
 // contend, while shared ones can't interleave.
-const LOCK_POLL_MS = 25;
-const LOCK_WAIT_MS = 120000;
+const LOCK_POLL_MS = Number.parseInt(process.env.ACP_COMMIT_LOCK_POLL_MS || "25", 10);
+const LOCK_WAIT_MS = Number.parseInt(process.env.ACP_COMMIT_LOCK_WAIT_MS || "120000", 10);
 // A lock becomes reclaimable once its mtime is older than this. It sits below
 // LOCK_WAIT_MS so a crashed holder whose PID was recycled to an unrelated live
 // process is reclaimed by a waiter before that waiter's acquire deadline (#14202)
-// — otherwise the dead lock would wedge the worktree until the 120s timeout — and
-// well above the interval at which a live holder refreshes mtime via lock.verify()
-// (each read-tree/apply/commit boundary), so a legitimately long commit is never
-// falsely reclaimed.
-const LOCK_STALE_MS = 30000;
+// — otherwise the dead lock would wedge the worktree until the 120s timeout.
+// Live holders keep the mtime fresh through a detached heartbeat because the
+// wrapper blocks in spawnSync while git commit/pre-commit hooks run.
+const LOCK_STALE_MS = Number.parseInt(process.env.ACP_COMMIT_LOCK_STALE_MS || "30000", 10);
 function sleepSync(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
@@ -370,6 +369,33 @@ function lockIsStale(lockPath) {
   }
   return mtimeStale ? lock : undefined;
 }
+function startLockHeartbeat(lockPath, expected) {
+  const interval = Math.max(10, Math.min(1000, Math.floor(LOCK_STALE_MS / 4)));
+  const script = [
+    "const fs=require('node:fs');",
+    "const lockPath=process.argv[1];",
+    "const parentPid=Number(process.argv[2]);",
+    "const token=process.argv[3];",
+    "const interval=Number(process.argv[4]);",
+    "function alive(pid){try{process.kill(pid,0);return true;}catch(err){return err.code==='EPERM';}}",
+    "function tick(){",
+    " if(!alive(parentPid)) process.exit(0);",
+    " let owner;",
+    " try{owner=JSON.parse(fs.readFileSync(lockPath,'utf8'));}catch{process.exit(0);}",
+    " if(!owner||owner.pid!==parentPid||owner.token!==token) process.exit(0);",
+    " const now=new Date();",
+    " try{fs.utimesSync(lockPath,now,now);}catch{process.exit(0);}",
+    "}",
+    "tick();",
+    "setInterval(tick,interval);",
+  ].join("");
+  const child = spawn(process.execPath, ["-e", script, lockPath, String(expected.pid), expected.token, String(interval)], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+  return child;
+}
 function stealStaleLock(lockPath, staleRaw) {
   const claimPath = lockPath + ".stale-" + process.pid + "-" + randomUUID();
   try {
@@ -406,7 +432,8 @@ function resolveGitDir(prefix) {
 function acquireCommitLock(gitDir) {
   const lockPath = path.join(gitDir, "eliza-acp-commit.lock");
   const token = process.pid + ":" + randomUUID();
-  const owner = JSON.stringify({ pid: process.pid, token, createdAt: Date.now() });
+  const ownerRecord = { pid: process.pid, token, createdAt: Date.now() };
+  const owner = JSON.stringify(ownerRecord);
   const deadline = Date.now() + LOCK_WAIT_MS;
   for (;;) {
     let fd;
@@ -423,6 +450,8 @@ function acquireCommitLock(gitDir) {
       continue;
     }
     fs.writeSync(fd, owner);
+    fs.fsyncSync(fd);
+    const heartbeat = startLockHeartbeat(lockPath, ownerRecord);
     let released = false;
     const owns = () => {
       const lock = readLock(lockPath);
@@ -435,6 +464,11 @@ function acquireCommitLock(gitDir) {
     const release = () => {
       if (released) return;
       released = true;
+      try {
+        heartbeat.kill();
+      } catch {
+        // error-policy:J6 best-effort teardown; heartbeat exits once the lock is gone.
+      }
       fs.closeSync(fd);
       if (owns()) fs.rmSync(lockPath, { force: true });
     };


### PR DESCRIPTION
## Summary

Fixes #14261.

The ACP shared-worktree git wrapper currently treats an old lock mtime as stale even when the recorded PID is alive. That is necessary for recycled-PID reclaim, but the wrapper blocks in `spawnSync` during `git commit` and pre-commit hooks, so a legitimate live holder cannot refresh its mtime while the critical section is running. A waiter can then steal a live lock and recreate the silent HEAD-revert window from #14183.

This PR keeps live holders fresh with a detached heartbeat process tied to the lock owner token. The heartbeat exits when the parent dies, when ownership changes, or when the lock disappears; the wrapper still unrefs it so it cannot keep the git wrapper alive after release.

## Verification

- `bun run --cwd plugins/plugin-agent-orchestrator test -- src/__tests__/acp-git-commit-race.test.ts` -> 1 file / 5 tests passed
- `bun run --cwd plugins/plugin-agent-orchestrator test -- src/__tests__/acp-git-index-isolation.test.ts` -> 1 file / 1 test passed
- `bunx @biomejs/biome@2.5.1 check plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/src/__tests__/acp-git-commit-race.test.ts` -> clean
- `bun run --cwd plugins/plugin-agent-orchestrator build` -> passed

## Typecheck note

`node packages/app-core/scripts/ensure-shared-i18n-data.mjs && bun run --cwd plugins/plugin-agent-orchestrator typecheck` was attempted. It failed before touching the changed ACP files because this temp worktree resolves many workspace dependencies through `/home/shaw/milady/eliza/dist/node_modules` without declaration files (`drizzle-orm`, `yaml`, `fs-extra`, `git-workspace-service`, `coding-agent-adapters`, and others). No error cited the changed files.

## Evidence

See `.github/issue-evidence/14261-acp-commit-lock-heartbeat.md`.

UI screenshots/video: N/A - deterministic git wrapper behavior; no UI surface.
Live-LLM trajectories: N/A - no prompt/model/action behavior changed.