### PR TITLE
fix(scripts): enforce docker node host key on re-onboard

### DIFF
--- a/.github/issue-evidence/14272-onboard-host-key.md
+++ b/.github/issue-evidence/14272-onboard-host-key.md
@@ -1,0 +1,53 @@
+# Evidence: #14272 docker node re-onboard host-key pinning
+
+## What changed
+
+- `onboard-docker-node.ts` now loads the existing `docker_nodes` row before
+  constructing `DockerSSHClient`.
+- A stored `host_key_fingerprint` is passed into the SSH verifier before any
+  root command runs, so a re-onboarded node with a different presented key hits
+  the existing mismatch refusal path instead of TOFU.
+- The upsert path preserves an established pin even if a callback somehow
+  captured a new fingerprint; first-onboard and still-unpinned rows still persist
+  the TOFU capture.
+
+## Verification
+
+Run from `/tmp/eliza-14272-host-key` on 2026-07-05:
+
+```bash
+bun test packages/scripts/cloud/admin/onboard-docker-node.test.ts
+```
+
+Result: 15 pass, 0 fail.
+
+```bash
+bunx @biomejs/biome check --write \
+  packages/scripts/cloud/admin/onboard-docker-node.ts \
+  packages/scripts/cloud/admin/onboard-docker-node.test.ts
+```
+
+Result: checked 2 files; formatter updated the touched script once, then the
+focused test above passed.
+
+```bash
+git diff --check
+```
+
+Result: pass.
+
+## Manual review notes
+
+- Verified `buildOnboardSshConfig()` passes `existing.host_key_fingerprint` into
+  the SSH config for re-onboard.
+- Verified `hostKeyFingerprintForOnboardUpsert()` prefers the existing pin over
+  any captured fingerprint and only persists a captured key for first-onboard or
+  still-unpinned rows.
+- The regression is covered with pure unit tests; no real SSH host was contacted.
+
+## Evidence not applicable
+
+- UI screenshots/video: N/A - admin script security fix only.
+- Live LLM trajectories: N/A - no agent/model behavior changed.
+- Backend logs/domain artifacts: N/A - no live production node was contacted;
+  the test validates the pinning contract without making SSH or DB side effects.

--- a/packages/scripts/cloud/admin/onboard-docker-node.test.ts
+++ b/packages/scripts/cloud/admin/onboard-docker-node.test.ts
@@ -1,6 +1,8 @@
 // Exercises cloud admin onboard docker node.test automation behavior with deterministic script fixtures.
 import { describe, expect, it } from "bun:test";
 import {
+  buildOnboardSshConfig,
+  hostKeyFingerprintForOnboardUpsert,
   parseArgs,
   parseDockerPs,
   selectZombieAgentContainers,
@@ -139,5 +141,72 @@ describe("parseArgs", () => {
     expect(() => parseArgs(["--host", "--node-id", "n"], emptyEnv)).toThrow(
       "requires a value",
     );
+  });
+});
+
+describe("host-key pinning helpers", () => {
+  const args = {
+    host: "203.0.113.10",
+    nodeId: "robot-1",
+    keyPath: "/ssh/key",
+    sshPort: 2222,
+    sshUser: "root",
+    capacity: 8,
+    dryRun: false,
+  };
+
+  it("passes an existing docker node pin into the SSH verifier before re-onboard", () => {
+    const onHostKeyDiscovered = async () => {};
+    const config = buildOnboardSshConfig(
+      args,
+      { host_key_fingerprint: "pinned-fingerprint" },
+      onHostKeyDiscovered,
+    );
+
+    expect(config).toEqual({
+      hostname: "203.0.113.10",
+      port: 2222,
+      username: "root",
+      privateKeyPath: "/ssh/key",
+      hostKeyFingerprint: "pinned-fingerprint",
+      onHostKeyDiscovered,
+    });
+  });
+
+  it("uses TOFU only when the existing docker node is unpinned or absent", () => {
+    const onHostKeyDiscovered = async () => {};
+
+    expect(
+      buildOnboardSshConfig(
+        args,
+        { host_key_fingerprint: null },
+        onHostKeyDiscovered,
+      ).hostKeyFingerprint,
+    ).toBeUndefined();
+    expect(
+      buildOnboardSshConfig(args, null, onHostKeyDiscovered).hostKeyFingerprint,
+    ).toBeUndefined();
+  });
+
+  it("never overwrites an established pin with a re-onboard capture", () => {
+    expect(
+      hostKeyFingerprintForOnboardUpsert(
+        { host_key_fingerprint: "pinned-fingerprint" },
+        "attacker-fingerprint",
+      ),
+    ).toBe("pinned-fingerprint");
+  });
+
+  it("persists the captured fingerprint for first onboard or still-unpinned nodes", () => {
+    expect(hostKeyFingerprintForOnboardUpsert(null, "first-pin")).toBe(
+      "first-pin",
+    );
+    expect(
+      hostKeyFingerprintForOnboardUpsert(
+        { host_key_fingerprint: null },
+        "first-pin",
+      ),
+    ).toBe("first-pin");
+    expect(hostKeyFingerprintForOnboardUpsert(null, undefined)).toBeNull();
   });
 });

--- a/packages/scripts/cloud/admin/onboard-docker-node.test.ts
+++ b/packages/scripts/cloud/admin/onboard-docker-node.test.ts
@@ -1,4 +1,8 @@
-// Exercises cloud admin onboard docker node.test automation behavior with deterministic script fixtures.
+/**
+ * Deterministic coverage for docker-node onboarding helpers. The tests exercise
+ * argument parsing, container selection, and host-key pin preservation without
+ * opening SSH connections or touching a real control-plane database.
+ */
 import { describe, expect, it } from "bun:test";
 import {
   buildOnboardSshConfig,

--- a/packages/scripts/cloud/admin/onboard-docker-node.ts
+++ b/packages/scripts/cloud/admin/onboard-docker-node.ts
@@ -127,6 +127,41 @@ export interface OnboardArgs {
   dryRun: boolean;
 }
 
+interface ExistingDockerNodePin {
+  host_key_fingerprint: string | null;
+}
+
+interface OnboardSshConfig {
+  hostname: string;
+  port: number;
+  username: string;
+  privateKeyPath: string;
+  hostKeyFingerprint?: string;
+  onHostKeyDiscovered: (hostname: string, fingerprint: string) => Promise<void>;
+}
+
+export function buildOnboardSshConfig(
+  args: OnboardArgs,
+  existing: ExistingDockerNodePin | null,
+  onHostKeyDiscovered: OnboardSshConfig["onHostKeyDiscovered"],
+): OnboardSshConfig {
+  return {
+    hostname: args.host,
+    port: args.sshPort,
+    username: args.sshUser,
+    privateKeyPath: args.keyPath,
+    hostKeyFingerprint: existing?.host_key_fingerprint ?? undefined,
+    onHostKeyDiscovered,
+  };
+}
+
+export function hostKeyFingerprintForOnboardUpsert(
+  existing: ExistingDockerNodePin | null,
+  capturedFingerprint: string | undefined,
+): string | null {
+  return existing?.host_key_fingerprint ?? capturedFingerprint ?? null;
+}
+
 /** Parse argv + env into a validated config. Throws on missing required fields. */
 export function parseArgs(argv: string[], env: NodeJS.ProcessEnv): OnboardArgs {
   const flags = new Map<string, string>();
@@ -213,22 +248,20 @@ async function main(): Promise<void> {
     DockerSSHClient,
   } = await loadDeps();
   const summary: string[] = [];
+  const existing = await dockerNodesRepository.findByNodeId(args.nodeId);
 
-  // TOFU capture: the target host has never been pinned (this is its first
-  // onboard), so DockerSSHClient accepts the presented key on first connect and
-  // hands it back here. We stash it and persist it into docker_nodes during the
-  // upsert below so every later control-plane SSH verifies against a real pin.
+  // Re-onboard must verify against the stored pin before any root SSH command
+  // runs. Only a never-pinned node takes the TOFU branch and persists the
+  // captured key during the upsert below.
   let capturedFingerprint: string | undefined;
-  const ssh = new DockerSSHClient({
-    hostname: args.host,
-    port: args.sshPort,
-    username: args.sshUser,
-    privateKeyPath: args.keyPath,
-    onHostKeyDiscovered: async (hostname, fingerprint) => {
+  const ssh = new DockerSSHClient(
+    buildOnboardSshConfig(args, existing, async (hostname, fingerprint) => {
       capturedFingerprint = fingerprint;
-      console.log(`[onboard] TOFU captured host key for ${hostname}: SHA256:${fingerprint}`);
-    },
-  });
+      console.log(
+        `[onboard] TOFU captured host key for ${hostname}: SHA256:${fingerprint}`,
+      );
+    }),
+  );
 
   try {
     // 1. Docker present + running (install via get.docker.com only if missing).
@@ -294,7 +327,6 @@ async function main(): Promise<void> {
       });
 
     // 6. Register / upsert into docker_nodes — same shape as bootstrap-callback.
-    const existing = await dockerNodesRepository.findByNodeId(args.nodeId);
     if (existing) {
       await dockerNodesRepository.update(existing.id, {
         hostname: args.host,
@@ -302,8 +334,12 @@ async function main(): Promise<void> {
         ssh_user: args.sshUser,
         capacity: args.capacity,
         status: "unknown",
-        // Persist the TOFU-captured pin; keep any existing one if capture was skipped.
-        host_key_fingerprint: capturedFingerprint ?? existing.host_key_fingerprint,
+        // Never overwrite an established pin during re-onboard; a differing
+        // presented key must fail in DockerSSHClient before this update.
+        host_key_fingerprint: hostKeyFingerprintForOnboardUpsert(
+          existing,
+          capturedFingerprint,
+        ),
         metadata: {
           ...((existing.metadata as Record<string, unknown>) ?? {}),
           provider: "operator-onboarded",
@@ -322,7 +358,10 @@ async function main(): Promise<void> {
         status: "unknown",
         allocated_count: 0,
         // Persist the TOFU-captured pin so later control-plane SSH is verified.
-        host_key_fingerprint: capturedFingerprint ?? null,
+        host_key_fingerprint: hostKeyFingerprintForOnboardUpsert(
+          null,
+          capturedFingerprint,
+        ),
         metadata: {
           provider: "operator-onboarded",
           onboardedAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- look up the existing `docker_nodes` row before creating the onboarding SSH client
- pass an existing `host_key_fingerprint` into `DockerSSHClient` so re-onboard verifies the stored pin before any root SSH command runs
- preserve established pins on update; TOFU-captured keys only persist for first-onboard or still-unpinned rows
- add focused helper coverage for the re-onboard pinning contract

Fixes #14272.

## Evidence
- `.github/issue-evidence/14272-onboard-host-key.md`

## Verification
```bash
bun test packages/scripts/cloud/admin/onboard-docker-node.test.ts
```
Result: 15 pass, 0 fail.

```bash
bunx @biomejs/biome check packages/scripts/cloud/admin/onboard-docker-node.ts packages/scripts/cloud/admin/onboard-docker-node.test.ts .github/issue-evidence/14272-onboard-host-key.md --no-errors-on-unmatched
```
Result: checked 2 files, no fixes applied.

```bash
git diff --check
```
Result: pass.

## Notes
- UI screenshots/video: N/A, admin script security fix only.
- Live LLM trajectories: N/A, no agent/model behavior changed.
- Live SSH/backend artifacts: N/A, no production host contacted; focused tests validate the host-key pinning contract without SSH or DB side effects.
