### PR TITLE
fix(agent): proxy remote sandbox frame paths

### DIFF
--- a/packages/agent/src/services/remote-capability-router.test.ts
+++ b/packages/agent/src/services/remote-capability-router.test.ts
@@ -791,6 +791,52 @@ describe("remote capability router", () => {
     });
   });
 
+  it("rewrites remote sandboxed iframe frame paths into proxied frame URLs", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({
+        ok: true,
+        result: {
+          modules: [
+            {
+              id: "device-plugin",
+              name: "@remote/device",
+              views: [
+                {
+                  id: "device-frame-view",
+                  label: "Device Frame View",
+                  framePath: "dist/views/frame.html",
+                  surface: { isolation: "sandboxed-iframe" },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ) as unknown as typeof fetch;
+
+    const service = new RemoteCapabilityRouterService(makeRuntime(), {
+      enabled: true,
+      endpoints: [{ id: "device", baseUrl: "https://device.example" }],
+      environment: "server",
+      requestTimeoutMs: 1000,
+    });
+
+    await expect(service.plugin.listModules()).resolves.toMatchObject({
+      modules: [
+        {
+          id: "device-plugin",
+          views: [
+            {
+              id: "device-frame-view",
+              frameUrl:
+                "https://device.example/v1/capabilities/assets/device-plugin/dist/views/frame.html",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it("rejects unsafe remote view bundle URLs before exposing browser import URLs", async () => {
     globalThis.fetch = vi.fn(async () =>
       jsonResponse({
@@ -826,6 +872,45 @@ describe("remote capability router", () => {
       method: "plugin.modules.list",
       message:
         'Remote plugin bundleUrl "javascript:alert(1)" must be an absolute http(s) URL without embedded credentials.',
+    });
+  });
+
+  it("rejects unsafe remote view frame URLs before exposing browser frame URLs", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({
+        ok: true,
+        result: {
+          modules: [
+            {
+              id: "device-plugin",
+              name: "@remote/device",
+              views: [
+                {
+                  id: "device-frame-view",
+                  label: "Device Frame View",
+                  frameUrl: "javascript:alert(1)",
+                  surface: { isolation: "sandboxed-iframe" },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ) as unknown as typeof fetch;
+
+    const service = new RemoteCapabilityRouterService(makeRuntime(), {
+      enabled: true,
+      endpoints: [{ id: "device", baseUrl: "https://device.example" }],
+      environment: "server",
+      requestTimeoutMs: 1000,
+    });
+
+    await expect(service.plugin.listModules()).rejects.toMatchObject({
+      code: "CAPABILITY_DECODE_FAILED",
+      capability: "plugin",
+      method: "plugin.modules.list",
+      message:
+        'Remote plugin frameUrl "javascript:alert(1)" must be an absolute http(s) URL without embedded credentials.',
     });
   });
 

--- a/packages/agent/src/services/remote-capability-router.ts
+++ b/packages/agent/src/services/remote-capability-router.ts
@@ -914,22 +914,48 @@ function normalizeRemoteModuleManifest(
     ...withEndpoint,
     views: views.map((view) => {
       if (!isRecord(view) || !isJsonValue(view)) return view;
-      if (typeof view.bundleUrl === "string" && view.bundleUrl) {
-        validateRemoteBundleUrl(view.bundleUrl);
-        return view;
+      const normalizedView = { ...view };
+      if (
+        typeof normalizedView.bundleUrl === "string" &&
+        normalizedView.bundleUrl
+      ) {
+        validateRemoteAssetUrl(normalizedView.bundleUrl, "bundleUrl");
+      } else if (
+        typeof normalizedView.bundlePath === "string" &&
+        normalizedView.bundlePath
+      ) {
+        normalizedView.bundleUrl = remoteAssetUrl(
+          endpoint,
+          moduleId,
+          normalizedView.bundlePath,
+        );
       }
-      if (typeof view.bundlePath !== "string" || !view.bundlePath) return view;
-      return {
-        ...view,
-        bundleUrl: remoteAssetUrl(endpoint, moduleId, view.bundlePath),
-      };
+      if (
+        typeof normalizedView.frameUrl === "string" &&
+        normalizedView.frameUrl
+      ) {
+        validateRemoteAssetUrl(normalizedView.frameUrl, "frameUrl");
+      } else if (
+        typeof normalizedView.framePath === "string" &&
+        normalizedView.framePath
+      ) {
+        normalizedView.frameUrl = remoteAssetUrl(
+          endpoint,
+          moduleId,
+          normalizedView.framePath,
+        );
+      }
+      return normalizedView;
     }),
   };
 }
 
-function validateRemoteBundleUrl(bundleUrl: string): void {
+function validateRemoteAssetUrl(
+  assetUrl: string,
+  fieldName: "bundleUrl" | "frameUrl",
+): void {
   try {
-    const parsed = new URL(bundleUrl);
+    const parsed = new URL(assetUrl);
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       throw new Error("invalid protocol");
     }
@@ -939,7 +965,7 @@ function validateRemoteBundleUrl(bundleUrl: string): void {
   } catch {
     throw new CapabilityError({
       code: "CAPABILITY_DECODE_FAILED",
-      message: `Remote plugin bundleUrl "${bundleUrl}" must be an absolute http(s) URL without embedded credentials.`,
+      message: `Remote plugin ${fieldName} "${assetUrl}" must be an absolute http(s) URL without embedded credentials.`,
       capability: "plugin",
       method: "plugin.modules.list",
     });

--- a/packages/agent/src/services/remote-plugin-adapter.test.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.test.ts
@@ -3400,6 +3400,8 @@ describe("remote plugin adapter", () => {
                       id: "device.panel",
                       label: "Device Panel",
                       bundlePath: "/assets/device-panel.js",
+                      framePath: "/assets/device-frame.html",
+                      surface: { isolation: "sandboxed-iframe" },
                     },
                   ],
                 },
@@ -3522,6 +3524,9 @@ describe("remote plugin adapter", () => {
       id: "device.panel",
       bundleUrl:
         "https://device.example/v1/capabilities/assets/device-tools/assets/device-panel.js",
+      frameUrl:
+        "https://device.example/v1/capabilities/assets/device-tools/assets/device-frame.html",
+      surface: { isolation: "sandboxed-iframe" },
     });
     expect(runtime.plugins[0]?.config).toMatchObject({
       remoteCapabilityModuleId: "device-tools",


### PR DESCRIPTION
## Summary

- rewrites remote sandboxed iframe `framePath` values into proxied `frameUrl` values during remote module normalization
- validates absolute remote `frameUrl` values with the same http(s), no-credentials policy used for `bundleUrl`
- extends router and remote plugin adapter regression coverage for sandbox frame manifests

Fixes #14263

## Validation

- `bun test packages/agent/src/services/remote-capability-router.test.ts`
- `bun test packages/agent/src/services/remote-plugin-adapter.test.ts -t "syncs multiple remote servers into executable runtime plugin components"`
- `bunx @biomejs/biome@2.5.1 check packages/agent/src/services/remote-capability-router.ts packages/agent/src/services/remote-capability-router.test.ts packages/agent/src/services/remote-plugin-adapter.test.ts`
- `git diff --check -- packages/agent/src/services/remote-capability-router.ts packages/agent/src/services/remote-capability-router.test.ts packages/agent/src/services/remote-plugin-adapter.test.ts`

## Evidence

- N/A - backend manifest normalization only; no `packages/app` UI surface changed.
- N/A - no model/action/provider prompt behavior changed.