### PR TITLE
fix: define sandboxed frame view URL contract

### DIFF
--- a/.github/issue-evidence/14263-sandbox-frame-contract.md
+++ b/.github/issue-evidence/14263-sandbox-frame-contract.md
@@ -1,0 +1,49 @@
+# Issue #14263 - sandboxed frame document contract
+
+## Scope
+
+- Added explicit `framePath` / `frameUrl` view manifest fields for
+  `surface.isolation: "sandboxed-iframe"` views.
+- Kept `bundleUrl` as the host-realm JavaScript module contract.
+- Added local `GET/HEAD /api/views/:id/frame.html` serving for packaged frame
+  documents.
+- Normalized remote `framePath` through the capability asset route.
+- Updated UI routing and `DynamicViewLoader` so sandboxed iframe views use
+  `frameUrl` and fail closed when it is missing.
+
+## Verification
+
+- `bunx @biomejs/biome check <16 touched files>` - pass.
+- `git diff --check` - pass.
+- `bunx tsc --noEmit --pretty false -p packages/core/tsconfig.json` - pass.
+- `bun --conditions=eliza-source test packages/core/src/capabilities/index.test.ts` - pass.
+- `bun --conditions=eliza-source test packages/agent/src/__tests__/views-registry-integration.test.ts --test-name-pattern "frameUrl|frame.html"` - pass.
+- `bun --conditions=eliza-source test packages/agent/src/services/remote-capability-router.test.ts --test-name-pattern "frame URLs|multiple remote capability endpoints"` - pass.
+- `bun --conditions=eliza-source test packages/agent/src/services/remote-plugin-adapter.test.ts --test-name-pattern "real local capability HTTP server"` - pass.
+- `bun run --cwd packages/ui test src/components/views/DynamicViewLoader.test.tsx -t "sandboxed"` - pass.
+- `bun run --cwd packages/ui test src/App.navigate-view-wiring.test.tsx -t "frame-only"` - pass.
+
+## Incomplete Required Evidence
+
+- `bun run --cwd packages/app audit:app` - attempted, but did not reach
+  Playwright capture in the sparse worktree. The build failed in
+  `@elizaos/shared#build` because `prepare-package-dist.mjs` could not resolve
+  the workspace dependency `@elizaos/registry`.
+- Desktop/mobile screenshots - not captured; blocked by the app audit build
+  failure above.
+- Video walkthrough - not captured; blocked by the app audit build failure
+  above.
+- Frontend console/network logs - not captured; blocked by the app audit build
+  failure above.
+- Backend logs - N/A for current local verification; no server was successfully
+  launched by the audit command.
+- Real-LLM trajectories - N/A; this change does not alter prompts, actions,
+  providers, model selection, or agent generation behavior.
+- Domain artifacts - N/A; this change does not create memories, knowledge rows,
+  DB rows, scheduled tasks, wallet artifacts, chain transactions, generated
+  user files, or device output.
+
+## Notes
+
+This PR should remain draft or unmerged until the app audit and visual evidence
+are captured from a full workspace checkout.

--- a/packages/agent/src/__tests__/views-registry-integration.test.ts
+++ b/packages/agent/src/__tests__/views-registry-integration.test.ts
@@ -130,7 +130,9 @@ const PLUGIN_NAMES = [
   "views-integration-dev",
   "views-integration-modalities",
   "views-integration-remote",
+  "views-integration-remote-frame",
   "views-integration-local-bundle",
+  "views-integration-local-frame",
   "todos",
 ];
 
@@ -159,6 +161,18 @@ async function createLocalBundlePlugin(bundleSource: string): Promise<{
   const bundlePath = path.join(bundleDir, "bundle.js");
   await writeFile(bundlePath, bundleSource);
   return { pluginDir, bundlePath };
+}
+
+async function createLocalFramePlugin(frameSource: string): Promise<{
+  pluginDir: string;
+  framePath: string;
+}> {
+  const pluginDir = await mkdtemp(path.join(tmpdir(), "eliza-view-frame-"));
+  const frameDir = path.join(pluginDir, "dist", "views");
+  await mkdir(frameDir, { recursive: true });
+  const absoluteFramePath = path.join(frameDir, "frame.html");
+  await writeFile(absoluteFramePath, frameSource);
+  return { pluginDir, framePath: path.relative(pluginDir, absoluteFramePath) };
 }
 
 function rawResponse(ctx: ViewsRouteContext): {
@@ -447,6 +461,57 @@ describe("GET /api/views", () => {
         "https://capability.example.test/assets/remote-panel.js",
     });
   });
+
+  it("returns absolute remote frameUrl for sandboxed remote capability views", async () => {
+    await registerPluginViews(
+      {
+        name: "views-integration-remote-frame",
+        description: "remote frame",
+        actions: [],
+        views: [
+          {
+            id: "remote.frame",
+            label: "Remote Frame",
+            surface: { isolation: "sandboxed-iframe" },
+            frameUrl: "https://capability.example.test/assets/frame.html",
+          },
+        ],
+      },
+      undefined,
+    );
+
+    const registryEntry = getView("remote.frame");
+    expect(registryEntry).toMatchObject({
+      id: "remote.frame",
+      pluginName: "views-integration-remote-frame",
+      available: true,
+      bundleUrl: undefined,
+      frameUrl: "https://capability.example.test/assets/frame.html",
+      frameUrlVersioned: "https://capability.example.test/assets/frame.html",
+    });
+
+    const { ctx, json } = makeCtx("GET", "/api/views");
+    await handleViewsRoutes(ctx);
+
+    const [, payload] = json.mock.calls[0] as [
+      unknown,
+      {
+        views: Array<{
+          id: string;
+          available: boolean;
+          bundleUrl?: string;
+          frameUrl?: string;
+          frameUrlVersioned?: string;
+        }>;
+      },
+    ];
+    expect(payload.views.find((v) => v.id === "remote.frame")).toMatchObject({
+      available: true,
+      bundleUrl: undefined,
+      frameUrl: "https://capability.example.test/assets/frame.html",
+      frameUrlVersioned: "https://capability.example.test/assets/frame.html",
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -536,6 +601,41 @@ describe("GET /api/views/:id", () => {
       id: "remote.panel",
       available: true,
       bundleUrl: "https://capability.example.test/assets/remote-panel.js",
+    });
+  });
+
+  it("returns single sandboxed view metadata with frameUrl and no bundleUrl", async () => {
+    await registerPluginViews(
+      {
+        name: "views-integration-remote-frame",
+        description: "remote frame",
+        actions: [],
+        views: [
+          {
+            id: "remote.frame",
+            label: "Remote Frame",
+            surface: { isolation: "sandboxed-iframe" },
+            frameUrl: "https://capability.example.test/assets/frame.html",
+          },
+        ],
+      },
+      undefined,
+    );
+
+    const { ctx, json } = makeCtx("GET", "/api/views/remote.frame");
+    const handled = await handleViewsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(json).toHaveBeenCalledOnce();
+    const [, payload] = json.mock.calls[0] as [
+      unknown,
+      { id: string; available: boolean; bundleUrl?: string; frameUrl?: string },
+    ];
+    expect(payload).toMatchObject({
+      id: "remote.frame",
+      available: true,
+      bundleUrl: undefined,
+      frameUrl: "https://capability.example.test/assets/frame.html",
     });
   });
 });
@@ -756,6 +856,114 @@ describe("GET /api/views/:id/bundle.js", () => {
       unregisterPluginViews("views-integration-local-bundle");
       await rm(pluginDir, { recursive: true, force: true });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/views/:id/frame.html — sandboxed iframe document
+// ---------------------------------------------------------------------------
+
+describe("GET /api/views/:id/frame.html", () => {
+  it("serves local frame documents with HTML content type and immutable versioned URLs", async () => {
+    const { pluginDir } = await createLocalFramePlugin(
+      '<!doctype html><html><body><main id="app">Frame v1</main></body></html>\n',
+    );
+
+    try {
+      await registerPluginViews(
+        {
+          name: "views-integration-local-frame",
+          description: "local frame",
+          actions: [],
+          views: [
+            {
+              id: "local.frame",
+              label: "Local Frame",
+              path: "/local-frame",
+              surface: { isolation: "sandboxed-iframe" },
+              framePath: "dist/views/frame.html",
+            },
+          ],
+        },
+        pluginDir,
+      );
+
+      const entry = getView("local.frame");
+      expect(entry).toMatchObject({
+        available: true,
+        bundleUrl: undefined,
+        framePath: "dist/views/frame.html",
+      });
+      expect(entry?.frameHash).toMatch(/^[a-f0-9]{12}$/);
+      expect(entry?.frameUrl).toContain("/api/views/local.frame/frame.html?v=");
+      expect(entry?.frameUrlVersioned).toContain(`v=${entry?.frameHash}`);
+
+      const { ctx: getCtx } = makeCtx(
+        "GET",
+        "/api/views/local.frame/frame.html",
+      );
+      await handleViewsRoutes(getCtx);
+      const getRes = rawResponse(getCtx);
+      const [, getHeaders] = getRes.writeHead.mock.calls[0] as [
+        number,
+        Record<string, string | number>,
+      ];
+      const getBody = getRes.end.mock.calls[0]?.[0] as Buffer;
+      expect(getHeaders["Content-Type"]).toBe("text/html; charset=utf-8");
+      expect(getHeaders["X-Content-Type-Options"]).toBe("nosniff");
+      expect(getHeaders["Cache-Control"]).toBe("no-cache");
+      expect(getBody.toString("utf8")).toContain("Frame v1");
+
+      const { ctx: immutableCtx } = makeCtx(
+        "GET",
+        "/api/views/local.frame/frame.html",
+        { v: entry?.frameHash ?? "" },
+      );
+      await handleViewsRoutes(immutableCtx);
+      const immutableRes = rawResponse(immutableCtx);
+      const [, immutableHeaders] = immutableRes.writeHead.mock.calls[0] as [
+        number,
+        Record<string, string | number>,
+      ];
+      expect(immutableHeaders["Cache-Control"]).toBe(
+        "public, max-age=31536000, immutable",
+      );
+    } finally {
+      unregisterPluginViews("views-integration-local-frame");
+      await rm(pluginDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not fabricate a local frame route for remote absolute frameUrl views", async () => {
+    await registerPluginViews(
+      {
+        name: "views-integration-remote-frame",
+        description: "remote frame",
+        actions: [],
+        views: [
+          {
+            id: "remote.frame",
+            label: "Remote Frame",
+            surface: { isolation: "sandboxed-iframe" },
+            frameUrl: "https://capability.example.test/assets/frame.html",
+          },
+        ],
+      },
+      undefined,
+    );
+
+    const { ctx, error } = makeCtx("GET", "/api/views/remote.frame/frame.html");
+    const handled = await handleViewsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledOnce();
+    const [, message, status] = error.mock.calls[0] as [
+      unknown,
+      string,
+      number,
+    ];
+    expect(status).toBe(404);
+    expect(message).toContain("no frame path configured");
   });
 });
 

--- a/packages/agent/src/api/view-registry-types.ts
+++ b/packages/agent/src/api/view-registry-types.ts
@@ -46,6 +46,12 @@ export interface ViewRegistryEntry extends ViewDeclaration {
   bundleUrlVersioned?: string;
   /** Bundle file size in bytes. */
   bundleSize?: number;
+  /** First 12 hex chars of the SHA-256 content hash of the frame document. */
+  frameHash?: string;
+  /** Frame URL with `?v=<hash>` for immutable long-lived caching. */
+  frameUrlVersioned?: string;
+  /** Frame document file size in bytes. */
+  frameSize?: number;
   /**
    * True for entries registered by the built-in shell itself
    * (pluginName === "@elizaos/builtin"). These views live in the main

--- a/packages/agent/src/api/views-registry.ts
+++ b/packages/agent/src/api/views-registry.ts
@@ -188,7 +188,7 @@ export function getBundleDiskPath(entry: ViewRegistryEntry): string | null {
 }
 
 /**
- * Resolve the absolute on-disk path for a sandbox frame HTML document.
+ * Resolve the absolute on-disk path for a sandboxed frame document.
  * Returns `null` when the entry has no `framePath` or no `pluginDir`.
  */
 export function getFrameDiskPath(entry: ViewRegistryEntry): string | null {
@@ -409,6 +409,8 @@ export function registerBuiltinViews(runtime?: IAgentRuntime): void {
         pluginDir,
         bundleUrl: undefined,
         bundleUrlVersioned: undefined,
+        frameUrl: undefined,
+        frameUrlVersioned: undefined,
         heroImageUrl: `/api/views/${encodeURIComponent(view.id)}/hero${
           query ? `?${query}` : ""
         }`,
@@ -520,8 +522,8 @@ export function getView(
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/** Compute a short content hash for a bundle file. Returns `null` on any I/O error. */
-async function computeBundleHash(filePath: string): Promise<string | null> {
+/** Compute a short content hash for a served view file. Returns `null` on any I/O error. */
+async function computeFileHash(filePath: string): Promise<string | null> {
   try {
     const content = await fs.readFile(filePath);
     return createHash("sha256").update(content).digest("hex").slice(0, 12);
@@ -540,7 +542,7 @@ async function buildEntry(
   const registryKey = viewRegistryKey(view.id, normalizedViewType);
   const requiresFrameDocument = view.surface?.isolation === "sandboxed-iframe";
 
-  // Check bundle availability and collect hash + size when resolvable.
+  // Check bundle/frame availability and collect hashes + sizes when resolvable.
   let available = requiresFrameDocument
     ? Boolean(view.frameUrl)
     : Boolean(view.bundleUrl || view.frameUrl);
@@ -550,13 +552,13 @@ async function buildEntry(
     const bundleAbs = path.resolve(pluginDir, view.bundlePath);
     const packageRoot = `${path.resolve(pluginDir)}${path.sep}`;
     if (bundleAbs.startsWith(packageRoot)) {
-      const bundleExists = await fileExists(bundleAbs);
-      if (!requiresFrameDocument) {
-        available = bundleExists;
+      const bundleAvailable = await fileExists(bundleAbs);
+      if (bundleAvailable && !requiresFrameDocument) {
+        available = true;
       }
-      if (bundleExists) {
+      if (bundleAvailable) {
         const [hash, stat] = await Promise.all([
-          computeBundleHash(bundleAbs),
+          computeFileHash(bundleAbs),
           fs.stat(bundleAbs).catch(() => null),
         ]);
         if (hash) bundleHash = hash;
@@ -588,15 +590,23 @@ async function buildEntry(
       }
     }
   }
+  let frameHash: string | undefined;
+  let frameSize: number | undefined;
   if (!view.frameUrl && pluginDir && view.framePath) {
     const frameAbs = path.resolve(pluginDir, view.framePath);
     const packageRoot = `${path.resolve(pluginDir)}${path.sep}`;
     if (frameAbs.startsWith(packageRoot)) {
-      const frameExists = await fileExists(frameAbs);
-      if (requiresFrameDocument) {
-        available = frameExists;
-      } else if (!available) {
-        available = frameExists;
+      const frameAvailable = await fileExists(frameAbs);
+      if (frameAvailable) {
+        available = true;
+      }
+      if (frameAvailable) {
+        const [hash, stat] = await Promise.all([
+          computeFileHash(frameAbs),
+          fs.stat(frameAbs).catch(() => null),
+        ]);
+        if (hash) frameHash = hash;
+        if (stat) frameSize = stat.size;
       }
     }
   }
@@ -634,6 +644,11 @@ async function buildEntry(
     : view.framePath
       ? buildAssetUrl("frame.html", loadedAt)
       : undefined;
+  const frameUrlVersioned = view.frameUrl
+    ? view.frameUrl
+    : view.framePath && frameHash
+      ? buildAssetUrl("frame.html", frameHash)
+      : frameUrl;
 
   const heroImageUrl = buildAssetUrl("hero");
   // Probe for a real hero asset so the client can choose a photo vs. its icon.
@@ -658,6 +673,7 @@ async function buildEntry(
     bundleUrl,
     bundleUrlVersioned,
     frameUrl,
+    frameUrlVersioned,
     heroImageUrl,
     hasHeroImage,
     available,
@@ -665,5 +681,7 @@ async function buildEntry(
     platform,
     bundleHash,
     bundleSize,
+    frameHash,
+    frameSize,
   };
 }

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -124,6 +124,9 @@ function contentTypeForViewAsset(assetPath: string): string {
     case ".json":
     case ".map":
       return "application/json; charset=utf-8";
+    case ".html":
+    case ".htm":
+      return "text/html; charset=utf-8";
     case ".svg":
       return "image/svg+xml";
     case ".png":
@@ -402,7 +405,7 @@ export async function handleViewsRoutes(
     // user enabled, so kind-gating is a client responsibility.
     const allViews = listViews({ includeAllKinds: true, viewType });
     // On restricted platforms (iOS/Android store builds), only surface views
-    // without dynamic code URLs (already in-process).
+    // without dynamic bundle/frame URLs (already in-process).
     const filtered = dynamicAllowed
       ? allViews
       : allViews.filter((v) => !v.bundleUrl && !v.frameUrl);
@@ -653,7 +656,11 @@ export async function handleViewsRoutes(
 
     const framePath = getFrameDiskPath(entry);
     if (!framePath) {
-      error(res, `View "${id}" has no sandbox frame document configured.`, 404);
+      error(
+        res,
+        `View "${id}" has no frame path configured. Build or declare the sandboxed frame document first.`,
+        404,
+      );
       return true;
     }
 
@@ -662,26 +669,23 @@ export async function handleViewsRoutes(
       stat = await fs.stat(framePath);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-        error(res, `Sandbox frame document not built for view "${id}".`, 404);
+        error(
+          res,
+          `Frame document not built for view "${id}". Build the plugin frame document first.`,
+          404,
+        );
       } else {
         logger.error(
           { src: "ViewsRoutes", viewId: id, framePath, err },
-          `[ViewsRoutes] Failed to stat sandbox frame for view "${id}"`,
+          `[ViewsRoutes] Failed to stat frame document for view "${id}"`,
         );
-        error(res, `Failed to read sandbox frame for view "${id}"`, 500);
+        error(res, `Failed to read frame document for view "${id}"`, 500);
       }
       return true;
     }
 
-    let data: Buffer;
-    try {
-      data = method === "HEAD" ? Buffer.alloc(0) : await fs.readFile(framePath);
-    } catch (err) {
-      logger.error(
-        { src: "ViewsRoutes", viewId: id, framePath, err },
-        `[ViewsRoutes] Failed to read sandbox frame for view "${id}"`,
-      );
-      error(res, `Failed to read sandbox frame for view "${id}"`, 500);
+    if (!stat.isFile()) {
+      error(res, `Frame document not built for view "${id}".`, 404);
       return true;
     }
 
@@ -697,20 +701,47 @@ export async function handleViewsRoutes(
       return true;
     }
 
+    let data: Buffer;
+    try {
+      data = method === "HEAD" ? Buffer.alloc(0) : await fs.readFile(framePath);
+    } catch (err) {
+      logger.error(
+        { src: "ViewsRoutes", viewId: id, framePath, err },
+        `[ViewsRoutes] Failed to read frame document for view "${id}"`,
+      );
+      error(res, `Failed to read frame document for view "${id}"`, 500);
+      return true;
+    }
+
+    const vParam = url.searchParams.get("v");
+    const contentHashMatch = entry.frameHash && vParam === entry.frameHash;
+    const cacheControl = contentHashMatch
+      ? "public, max-age=31536000, immutable"
+      : "no-cache";
     const raw = res as {
       writeHead?: (
         status: number,
         headers: Record<string, string | number>,
       ) => void;
+      setHeader?: (name: string, value: string | number) => void;
       end?: (chunk?: unknown) => void;
     };
-    raw.writeHead?.(200, {
-      "Content-Type": "text/html; charset=utf-8",
-      "Content-Length": stat.size,
-      "Cache-Control": "no-cache",
-      "X-Content-Type-Options": "nosniff",
-      ETag: etag,
-    });
+
+    if (typeof raw.writeHead === "function") {
+      raw.writeHead(200, {
+        "Content-Type": "text/html; charset=utf-8",
+        "Content-Length": data.byteLength,
+        "Cache-Control": cacheControl,
+        "X-Content-Type-Options": "nosniff",
+        ETag: etag,
+      });
+    } else if (typeof raw.setHeader === "function") {
+      raw.setHeader("Content-Type", "text/html; charset=utf-8");
+      raw.setHeader("Content-Length", data.byteLength);
+      raw.setHeader("Cache-Control", cacheControl);
+      raw.setHeader("X-Content-Type-Options", "nosniff");
+      raw.setHeader("ETag", etag);
+    }
     raw.end?.(method === "HEAD" ? undefined : data);
     return true;
   }

--- a/packages/agent/src/services/remote-capability-router.test.ts
+++ b/packages/agent/src/services/remote-capability-router.test.ts
@@ -665,6 +665,7 @@ describe("remote capability router", () => {
                       id: "device-view",
                       label: "Device View",
                       bundlePath: "/assets/device-view.js",
+                      framePath: "/assets/device-frame.html",
                     },
                   ],
                   actions: [
@@ -733,6 +734,8 @@ describe("remote capability router", () => {
               id: "device-view",
               bundleUrl:
                 "https://device.example/v1/capabilities/assets/device-plugin/assets/device-view.js",
+              frameUrl:
+                "https://device.example/v1/capabilities/assets/device-plugin/assets/device-frame.html",
             },
           ],
         },
@@ -837,6 +840,44 @@ describe("remote capability router", () => {
     });
   });
 
+  it("rejects unsafe remote view frame URLs before exposing browser frame URLs", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({
+        ok: true,
+        result: {
+          modules: [
+            {
+              id: "device-plugin",
+              name: "@remote/device",
+              views: [
+                {
+                  id: "device-view",
+                  label: "Device View",
+                  frameUrl: "javascript:alert(1)",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ) as unknown as typeof fetch;
+
+    const service = new RemoteCapabilityRouterService(makeRuntime(), {
+      enabled: true,
+      endpoints: [{ id: "device", baseUrl: "https://device.example" }],
+      environment: "server",
+      requestTimeoutMs: 1000,
+    });
+
+    await expect(service.plugin.listModules()).rejects.toMatchObject({
+      code: "CAPABILITY_DECODE_FAILED",
+      capability: "plugin",
+      method: "plugin.modules.list",
+      message:
+        'Remote plugin frameUrl "javascript:alert(1)" must be an absolute http(s) URL without embedded credentials.',
+    });
+  });
+
   it("rejects unsafe remote view bundle URLs before exposing browser import URLs", async () => {
     globalThis.fetch = vi.fn(async () =>
       jsonResponse({
@@ -875,7 +916,7 @@ describe("remote capability router", () => {
     });
   });
 
-  it("rejects unsafe remote view frame URLs before exposing browser frame URLs", async () => {
+  it("rejects unsafe sandboxed remote view frame URLs before exposing browser frame URLs", async () => {
     globalThis.fetch = vi.fn(async () =>
       jsonResponse({
         ok: true,

--- a/packages/agent/src/services/remote-plugin-adapter.test.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.test.ts
@@ -3653,7 +3653,8 @@ describe("remote plugin adapter", () => {
                 {
                   id: "localhost.panel",
                   label: "Localhost Panel",
-                  bundlePath: "/assets/localhost-panel.js",
+                  bundlePath: "assets/localhost-panel.js",
+                  framePath: "assets/localhost-frame.html",
                 },
               ],
             },
@@ -3671,9 +3672,11 @@ describe("remote plugin adapter", () => {
         }),
         getAsset: async ({ path }) => ({
           path,
-          contentType: "text/javascript",
+          contentType: path.endsWith(".html") ? "text/html" : "text/javascript",
           bodyBase64: Buffer.from(
-            "export const marker = 'remote-panel';",
+            path.endsWith(".html")
+              ? "<!doctype html><html><body>remote frame</body></html>"
+              : "export const marker = 'remote-panel';",
           ).toString("base64"),
         }),
       }),
@@ -3690,9 +3693,8 @@ describe("remote plugin adapter", () => {
         }),
       );
 
-      await expect(
-        bootstrapRemoteCapabilityPlugins(runtime),
-      ).resolves.toMatchObject({
+      const bootstrapResult = await bootstrapRemoteCapabilityPlugins(runtime);
+      expect(bootstrapResult).toMatchObject({
         registered: [
           expect.objectContaining({ name: "@remote/localhost-tools" }),
         ],
@@ -3708,15 +3710,20 @@ describe("remote plugin adapter", () => {
       });
       const expectedBundleUrl =
         "/api/capability-router/assets/primary/localhost-tools/assets/localhost-panel.js";
+      const expectedFrameUrl =
+        "/api/capability-router/assets/primary/localhost-tools/assets/localhost-frame.html";
       expect(runtime.plugins[0]?.views?.[0]).toMatchObject({
         id: "localhost.panel",
         bundleUrl: expectedBundleUrl,
+        frameUrl: expectedFrameUrl,
       });
       expect(getView("localhost.panel")).toMatchObject({
         id: "localhost.panel",
         pluginName: "@remote/localhost-tools",
         bundleUrl: expectedBundleUrl,
         bundleUrlVersioned: expectedBundleUrl,
+        frameUrl: expectedFrameUrl,
+        frameUrlVersioned: expectedFrameUrl,
         available: true,
       });
       const remoteBundleUrl = `${server.baseUrl}/v1/capabilities/assets/localhost-tools/assets/localhost-panel.js`;
@@ -3729,6 +3736,13 @@ describe("remote plugin adapter", () => {
       );
       const bundleSource = await bundleResponse.text();
       expect(bundleSource).toBe("export const marker = 'remote-panel';");
+      const remoteFrameUrl = `${server.baseUrl}/v1/capabilities/assets/localhost-tools/assets/localhost-frame.html`;
+      const frameResponse = await fetch(remoteFrameUrl, {
+        headers: { authorization: "Bearer local-server-token" },
+      });
+      expect(frameResponse.status).toBe(200);
+      expect(frameResponse.headers.get("content-type")).toBe("text/html");
+      await expect(frameResponse.text()).resolves.toContain("remote frame");
       const moduleUrl = `data:text/javascript;base64,${Buffer.from(
         bundleSource,
       ).toString("base64")}`;

--- a/packages/core/src/capabilities/index.test.ts
+++ b/packages/core/src/capabilities/index.test.ts
@@ -2021,4 +2021,58 @@ describe("capability router", () => {
 				"bundleUrl must be an absolute http(s) URL without embedded credentials.",
 		});
 	});
+
+	it("rejects remote plugin views with unsafe frame paths", async () => {
+		const router = new RuntimeBrokerCapabilityRouter({
+			invokeRuntime: async () => ({
+				modules: [
+					{
+						id: "remote-weather",
+						name: "@remote/weather",
+						views: [
+							{
+								id: "weather-panel",
+								label: "Weather",
+								framePath: "../frame.html",
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		await expect(router.plugin.listModules()).rejects.toMatchObject({
+			code: "CAPABILITY_DECODE_FAILED",
+			method: "plugin.modules.list.modules.views",
+			message:
+				"framePath must not contain empty, current-directory, or parent-directory segments.",
+		});
+	});
+
+	it("rejects remote plugin views with unsafe frame URLs", async () => {
+		const router = new RuntimeBrokerCapabilityRouter({
+			invokeRuntime: async () => ({
+				modules: [
+					{
+						id: "remote-weather",
+						name: "@remote/weather",
+						views: [
+							{
+								id: "weather-panel",
+								label: "Weather",
+								frameUrl: "javascript:alert(1)",
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		await expect(router.plugin.listModules()).rejects.toMatchObject({
+			code: "CAPABILITY_DECODE_FAILED",
+			method: "plugin.modules.list.modules.views",
+			message:
+				"frameUrl must be an absolute http(s) URL without embedded credentials.",
+		});
+	});
 });

--- a/packages/core/src/capabilities/index.ts
+++ b/packages/core/src/capabilities/index.ts
@@ -3537,7 +3537,7 @@ function requireRemotePluginView(
 		validateRemotePluginAssetPath(framePath, "framePath", method);
 	}
 	if (frameUrl !== undefined) {
-		validateRemotePluginBrowserUrl(frameUrl, "frameUrl", method);
+		validateRemotePluginBundleUrl(frameUrl, "frameUrl", method);
 	}
 	const backgroundPolicy = optionalBackgroundPolicy(
 		object,

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -852,13 +852,16 @@ export interface ViewScopedAction {
  *
  * Views are compiled to JavaScript bundles, served by the agent router at
  * `/api/views/<id>/bundle.js`, and loaded dynamically by the frontend shell
- * via `import()`. On platforms where dynamic code loading is restricted (iOS
- * App Store, Google Play store builds), bundles are pre-compiled into the app
- * binary and the agent serves them from bundled assets — no remote download.
+ * via `import()`. Views that declare `surface.isolation: "sandboxed-iframe"`
+ * instead supply a complete HTML document via `framePath`/`frameUrl`; the shell
+ * mounts that document in `<iframe sandbox>` and never substitutes a JS bundle
+ * URL for it. On platforms where dynamic code loading is restricted (iOS App
+ * Store, Google Play store builds), dynamic bundle/frame URLs are filtered out.
  *
  * The frontend shell:
  *   1. Fetches `GET /api/views` to discover all registered views.
- *   2. Calls `import(bundleUrl)` when a view is first requested.
+ *   2. Calls `import(bundleUrl)` for host-realm views, or mounts `frameUrl` for
+ *      sandboxed iframe views.
  *   3. Mounts `module[componentExport ?? "default"]` in an error boundary.
  *   4. Calls the view's `cleanup()` export on unmount.
  */
@@ -1001,14 +1004,15 @@ export interface ViewDeclaration {
 	 */
 	bundleUrl?: string;
 	/**
-	 * Path from the plugin's package root to a sandbox frame HTML document.
-	 * Required for `surface.isolation: "sandboxed-iframe"` local plugin views;
-	 * the registry resolves this to `/api/views/<id>/frame.html`.
+	 * Path from the plugin's package root to a complete HTML document for
+	 * `surface.isolation: "sandboxed-iframe"` views. The registry resolves this
+	 * to `/api/views/<id>/frame.html`; it is a document URL, never a JS bundle.
 	 */
 	framePath?: string;
 	/**
-	 * Fully resolved sandbox frame document URL for remote/containerized views.
-	 * This is an HTML document URL, not a JavaScript bundle URL.
+	 * Fully resolved HTML document URL for `surface.isolation: "sandboxed-iframe"`
+	 * views served by a remote capability module or container. The shell mounts
+	 * this in `<iframe sandbox>` and must never substitute `bundleUrl` here.
 	 */
 	frameUrl?: string;
 	/** Capabilities the agent can exercise on this view when it is mounted. */

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -17,6 +17,7 @@ import {
 import type * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_BOOT_CONFIG, setBootConfig } from "./config/boot-config";
+import type { ViewRegistryEntry } from "./hooks/useAvailableViews";
 
 const appState = vi.hoisted(() => ({
   setTab: vi.fn(),
@@ -53,17 +54,20 @@ const dynamicViewLoaderMock = vi.hoisted(() => ({
   render: vi.fn(
     ({
       bundleUrl,
+      frameUrl,
       surface,
       viewId,
       viewType,
     }: {
-      bundleUrl: string;
-      surface?: { capabilities?: string[] };
+      bundleUrl?: string;
+      frameUrl?: string;
+      surface?: { capabilities?: string[]; isolation?: string };
       viewId: string;
       viewType?: string;
     }) => (
       <div
-        data-bundle-url={bundleUrl}
+        data-bundle-url={bundleUrl ?? ""}
+        data-frame-url={frameUrl ?? ""}
         data-surface-capabilities={surface?.capabilities?.join(",") ?? ""}
         data-testid="dynamic-view-loader"
         data-view-id={viewId}
@@ -111,7 +115,7 @@ const shopifyView = {
 
 const shopifyAgentSurfaceView = {
   ...shopifyView,
-  surface: { capabilities: ["agent-surface"] },
+  surface: { capabilities: ["agent-surface" as const] },
 };
 
 const calendarView = {
@@ -145,7 +149,18 @@ const documentsView = {
   viewType: "gui" as const,
 };
 
-const mockAvailableViews = [
+const sandboxedFrameView = {
+  id: "sandboxed-frame",
+  label: "Sandboxed Frame",
+  available: true,
+  pluginName: "@elizaos/plugin-sandboxed-frame",
+  path: "/apps/sandboxed-frame",
+  frameUrl: "/api/views/sandboxed-frame/frame.html",
+  surface: { isolation: "sandboxed-iframe" as const },
+  viewType: "gui" as const,
+};
+
+const mockAvailableViews: ViewRegistryEntry[] = [
   remoteLedgerView,
   viewsManagerView,
   viewsManagerTuiView,
@@ -521,6 +536,32 @@ describe("App navigate-view event wiring", () => {
     ).toBe(true);
     expect(getByTestId("app-opaque-background")).toBeTruthy();
     expect(queryByTestId("app-background-shader")).toBeNull();
+  });
+
+  it("routes frame-only sandboxed views through DynamicViewLoader with frameUrl", async () => {
+    mockAvailableViews.push(sandboxedFrameView);
+    appState.tab = "apps";
+    window.history.replaceState(null, "", "/apps/sandboxed-frame");
+
+    const { getByTestId } = render(<App />);
+
+    await waitFor(() => {
+      expect(dynamicViewLoaderMock.render).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bundleUrl: undefined,
+          frameUrl: "/api/views/sandboxed-frame/frame.html",
+          viewId: "sandboxed-frame",
+          viewType: "gui",
+        }),
+        undefined,
+      );
+    });
+
+    const loader = getByTestId("dynamic-view-loader");
+    expect(loader.getAttribute("data-bundle-url")).toBe("");
+    expect(loader.getAttribute("data-frame-url")).toBe(
+      "/api/views/sandboxed-frame/frame.html",
+    );
   });
 
   it("renders no global corner back button on app routes (removed in favor of per-page back affordances + browser/OS back)", async () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1039,10 +1039,6 @@ function remoteViewAvailable(view: ViewRegistryEntry): boolean {
   return Boolean((view.bundleUrl || view.frameUrl) && view.available !== false);
 }
 
-function remoteViewLoaderUrl(view: ViewRegistryEntry): string | null {
-  return view.bundleUrl ?? view.frameUrl ?? null;
-}
-
 function remoteViewMatchesTab(
   view: ViewRegistryEntry,
   tab: string,
@@ -1103,12 +1099,11 @@ function findRemoteViewForRoute(
 }
 
 function renderRemoteView(view: ViewRegistryEntry, nav?: ReactNode): ReactNode {
-  const loaderUrl = remoteViewLoaderUrl(view);
-  if (!loaderUrl) return null;
+  if (!view.bundleUrl && !view.frameUrl) return null;
   return (
     <TabContentView nav={nav}>
       <DynamicViewLoader
-        bundleUrl={loaderUrl}
+        bundleUrl={view.bundleUrl}
         frameUrl={view.frameUrl}
         componentExport={view.componentExport}
         viewId={view.id}
@@ -1210,36 +1205,33 @@ function ViewLayoutSurface({
           )} eliza-continuous-chat-scroll pb-[calc(0.5rem+var(--eliza-continuous-chat-clearance,5.25rem))]`}
         >
           {entries.length > 0 ? (
-            entries.map((view) => {
-              const loaderUrl = remoteViewLoaderUrl(view);
-              return (
-                <section
-                  key={view.id}
-                  data-testid={`view-layout-pane-${view.id}`}
-                  className={paneClassName}
-                >
-                  <div className="flex h-9 shrink-0 items-center border-b border-border/35 px-2.5">
-                    <span className="truncate text-xs font-medium text-muted">
-                      {view.label}
-                    </span>
-                  </div>
-                  <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-                    {loaderUrl ? (
-                      <DynamicViewLoader
-                        bundleUrl={loaderUrl}
-                        frameUrl={view.frameUrl}
-                        componentExport={view.componentExport}
-                        viewId={view.id}
-                        viewType={view.viewType}
-                        surface={view.surface}
-                      />
-                    ) : (
-                      <ViewRouter routeOverride={routeOverrideForView(view)} />
-                    )}
-                  </div>
-                </section>
-              );
-            })
+            entries.map((view) => (
+              <section
+                key={view.id}
+                data-testid={`view-layout-pane-${view.id}`}
+                className={paneClassName}
+              >
+                <div className="flex h-9 shrink-0 items-center border-b border-border/35 px-2.5">
+                  <span className="truncate text-xs font-medium text-muted">
+                    {view.label}
+                  </span>
+                </div>
+                <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+                  {view.bundleUrl || view.frameUrl ? (
+                    <DynamicViewLoader
+                      bundleUrl={view.bundleUrl}
+                      frameUrl={view.frameUrl}
+                      componentExport={view.componentExport}
+                      viewId={view.id}
+                      viewType={view.viewType}
+                      surface={view.surface}
+                    />
+                  ) : (
+                    <ViewRouter routeOverride={routeOverrideForView(view)} />
+                  )}
+                </div>
+              </section>
+            ))
           ) : (
             <div className="flex min-h-[18rem] items-center justify-center border border-border/45 px-4 text-center text-sm text-muted">
               Requested views are not available.
@@ -1497,7 +1489,7 @@ function renderViewRouterContent({
     tab,
     appSlug,
   );
-  if (remoteView && remoteViewLoaderUrl(remoteView)) {
+  if (remoteView?.bundleUrl || remoteView?.frameUrl) {
     return renderRemoteView(remoteView, walletNav);
   }
   return renderStaticViewRouterTab({

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -150,6 +150,58 @@ describe("DynamicViewLoader", () => {
     );
   });
 
+  it("renders sandboxed iframe views from frameUrl and does not import bundleUrl", () => {
+    const importBundle = vi.fn(async () => ({
+      default: function ShouldNotLoad() {
+        return <div>Host realm bundle loaded</div>;
+      },
+    }));
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = importBundle;
+
+    render(
+      <DynamicViewLoader
+        bundleUrl="/api/views/sandboxed.panel/bundle.js"
+        frameUrl="/api/views/sandboxed.panel/frame.html"
+        viewId="sandboxed.panel"
+        surface={{ isolation: "sandboxed-iframe" }}
+      />,
+    );
+
+    const frame = screen.getByTestId("sandboxed-view-frame-sandboxed.panel");
+    expect(frame.getAttribute("src")).toBe(
+      "/api/views/sandboxed.panel/frame.html",
+    );
+    expect(importBundle).not.toHaveBeenCalled();
+    expect(screen.queryByText("Host realm bundle loaded")).toBeNull();
+  });
+
+  it("fails closed when sandboxed iframe views omit frameUrl", () => {
+    const importBundle = vi.fn(async () => ({
+      default: function ShouldNotLoad() {
+        return <div>Host realm bundle loaded</div>;
+      },
+    }));
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = importBundle;
+
+    render(
+      <DynamicViewLoader
+        bundleUrl="/api/views/sandboxed.panel/bundle.js"
+        viewId="sandboxed.panel"
+        surface={{ isolation: "sandboxed-iframe" }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        /require a frameUrl HTML document; bundleUrl is a JavaScript module/,
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.queryByTestId("sandboxed-view-frame-sandboxed.panel"),
+    ).toBeNull();
+    expect(importBundle).not.toHaveBeenCalled();
+  });
+
   it("registers remote view interact handlers after the bundle loads", async () => {
     const bundleUrl = "https://capability.example.test/assets/interactive.js";
     const interact = vi.fn(async (capability: string) => ({ capability }));

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -1177,7 +1177,7 @@ async function handleStandardCapability(
 
 interface DynamicViewLoaderProps {
   /** The URL of the JS bundle to dynamically import. */
-  bundleUrl: string;
+  bundleUrl?: string;
   /** HTML document URL for sandboxed-iframe views. */
   frameUrl?: string;
   /** Named export inside the bundle to use as the root component. Defaults to "default". */
@@ -1251,7 +1251,7 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
   // re-run this effect to invalidate the module cache.
   // biome-ignore lint/correctness/useExhaustiveDependencies: reloadKey is a manual cache-bust trigger
   useEffect(() => {
-    if (!dynamicLoadingAllowed || isSandboxed) return;
+    if (!dynamicLoadingAllowed || isSandboxed || !bundleUrl) return;
 
     let cancelled = false;
     const lease = acquireBundleModule(bundleUrl, componentExport);
@@ -1320,6 +1320,11 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
           // Standard capabilities are handled here regardless of whether the
           // module exports interact — they operate on the registry or the DOM.
           if (STANDARD_CAPABILITIES.has(capability)) {
+            if (!bundleUrl) {
+              throw new Error(
+                `View "${viewId}" has no bundleUrl for capability "${capability}"`,
+              );
+            }
             return handleStandardCapability(
               capability,
               params,
@@ -1377,6 +1382,7 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
   // ErrorBoundary key below, remounting it with cleared state — so a view that
   // crashed at render is genuinely retried, not stuck behind a latched boundary.
   const recoverView = useCallback(() => {
+    if (!bundleUrl) return;
     invalidateBundleModule(`${bundleUrl}::${componentExport}`);
     setLoadError(null);
     setReloadKey((k) => k + 1);
@@ -1401,7 +1407,6 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
               "Sandboxed iframe views require a frameUrl HTML document; bundleUrl is a JavaScript module.",
             )
           }
-          onRetry={recoverView}
           onBack={navigateToViews}
         />
       );
@@ -1418,6 +1423,19 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
     );
   }
 
+  if (!bundleUrl) {
+    return (
+      <ViewErrorState
+        viewId={viewId}
+        error={
+          new Error(
+            `Dynamic view "${viewId}" requires bundleUrl unless it declares sandboxed-iframe isolation with frameUrl.`,
+          )
+        }
+        onBack={navigateToViews}
+      />
+    );
+  }
   if (loadError) {
     return (
       <ViewErrorState

--- a/packages/ui/src/hooks/useAvailableViews.ts
+++ b/packages/ui/src/hooks/useAvailableViews.ts
@@ -55,9 +55,8 @@ export interface ViewRegistryEntry {
    */
   bundleUrl?: string;
   /**
-   * HTML document URL used for `surface.isolation: "sandboxed-iframe"` views.
-   * This is intentionally separate from `bundleUrl`; JavaScript bundles are not
-   * valid iframe documents.
+   * URL of a complete HTML document for `surface.isolation: "sandboxed-iframe"`
+   * views. This is mounted as an iframe `src`; it is not imported as JS.
    */
   frameUrl?: string;
   /** Named export inside the bundle to mount. Defaults to "default". */


### PR DESCRIPTION
## Summary

Closes #14263.

Defines the real framed-document contract for dynamic/plugin views:

- adds explicit `framePath` / `frameUrl` view manifest fields for sandboxed iframe views
- keeps `bundleUrl` as the host-realm JavaScript module contract
- serves local frame documents at `GET/HEAD /api/views/:id/frame.html`
- normalizes remote `framePath` through the capability asset route
- updates UI routing and `DynamicViewLoader` so sandboxed iframe views use `frameUrl` and fail closed without it

## Validation

- `bunx @biomejs/biome check <touched files>`
- `git diff --check`
- `bunx tsc --noEmit --pretty false -p packages/core/tsconfig.json`
- `bun --conditions=eliza-source test packages/core/src/capabilities/index.test.ts`
- `bun --conditions=eliza-source test packages/agent/src/__tests__/views-registry-integration.test.ts --test-name-pattern "frameUrl|frame.html"`
- `bun --conditions=eliza-source test packages/agent/src/services/remote-capability-router.test.ts --test-name-pattern "frame URLs|multiple remote capability endpoints"`
- `bun --conditions=eliza-source test packages/agent/src/services/remote-plugin-adapter.test.ts --test-name-pattern "real local capability HTTP server"`
- `bun run --cwd packages/ui test src/components/views/DynamicViewLoader.test.tsx -t "sandboxed"`
- `bun run --cwd packages/ui test src/App.navigate-view-wiring.test.tsx -t "frame-only"`

## Evidence

See `.github/issue-evidence/14263-sandbox-frame-contract.md`.

`bun run --cwd packages/app audit:app` was attempted on the rebased commit, but did not reach Playwright capture in this sparse worktree because `@elizaos/shared#build` could not resolve the local workspace dependency `@elizaos/registry`. This PR must remain draft until app audit screenshots/video/logs are captured from a full workspace checkout.
