### PR TITLE
feat(ui): de-surface Organization from the console (per-user-account presentation)

### DIFF
--- a/packages/ui/src/cloud/home/DashboardHomePage.test.tsx
+++ b/packages/ui/src/cloud/home/DashboardHomePage.test.tsx
@@ -74,6 +74,7 @@ describe("DashboardHomePage", () => {
     for (const to of EXPECTED_LINKS) {
       expect(hrefs, `missing console link ${to}`).toContain(to);
     }
+    expect(hrefs).not.toContain("/dashboard/organization");
   });
 
   it("links Add funds to the billing console page", () => {

--- a/packages/ui/src/cloud/home/DashboardHomePage.test.tsx
+++ b/packages/ui/src/cloud/home/DashboardHomePage.test.tsx
@@ -54,7 +54,6 @@ const EXPECTED_LINKS = [
   "/dashboard/billing",
   "/dashboard/api-keys",
   "/dashboard/account",
-  "/dashboard/organization",
 ];
 
 describe("DashboardHomePage", () => {

--- a/packages/ui/src/cloud/home/DashboardHomePage.tsx
+++ b/packages/ui/src/cloud/home/DashboardHomePage.tsx
@@ -98,7 +98,7 @@ export function DashboardHomePage() {
   useSetPageHeader({
     title: t("cloud.home.title", { defaultValue: "Overview" }),
     description: t("cloud.home.subtitle", {
-      defaultValue: "Manage your agents, credits, keys, and organization.",
+      defaultValue: "Manage your agents, credits, keys, and account.",
     }),
   });
 

--- a/packages/ui/src/cloud/shell/ConsoleShell.test.tsx
+++ b/packages/ui/src/cloud/shell/ConsoleShell.test.tsx
@@ -58,13 +58,15 @@ const NAV_HREFS = [
   "/dashboard/billing",
   "/dashboard/api-keys",
   "/dashboard/account",
-  "/dashboard/organization",
 ];
 
 /** De-navved surfaces — routable, but must NOT appear in the sidebar. */
 const CULLED_HREFS = [
   // Apps moved into the Eliza app; the console route now redirects.
   "/dashboard/apps",
+  // Organization is de-surfaced (console presents as plain user accounts); the
+  // route stays registered for invite deep-links but is not in the sidebar.
+  "/dashboard/organization",
   "/dashboard/my-agents",
   "/dashboard/mcps",
   "/dashboard/analytics",

--- a/packages/ui/src/cloud/shell/ConsoleShell.tsx
+++ b/packages/ui/src/cloud/shell/ConsoleShell.tsx
@@ -49,8 +49,8 @@ import { clearStaleStewardSession } from "./StewardProviderShared";
 
 /**
  * The console nav is one flat list so sidebar section labels never compete
- * with Account and Organization route labels. Specialist routes stay registered
- * for deep links but are not promoted into the default console chrome.
+ * with route labels. Specialist routes stay registered for deep links but are
+ * not promoted into the default console chrome.
  */
 const CONSOLE_NAV_SECTIONS: DashboardSidebarSection[] = [
   {

--- a/packages/ui/src/cloud/shell/console-surfaces.ts
+++ b/packages/ui/src/cloud/shell/console-surfaces.ts
@@ -2,7 +2,7 @@
  * Console surface catalog shared by the sidebar and overview cards. The
  * advertised control-plane routes are intentionally narrower than the complete
  * router: deep-linkable specialist surfaces stay registered, but only the core
- * agent, app, billing, key, account, and organization paths are promoted here.
+ * agent, billing, key, and account paths are promoted here.
  */
 
 import {
@@ -78,8 +78,7 @@ export const CONSOLE_SURFACES: ReadonlyArray<ConsoleSurface> = [
   },
 ];
 
-// The console presents as plain per-user accounts — the "Organization" surface
-// is intentionally NOT promoted here (a solo user's org already IS their
-// account). The org route stays registered (register-all's `import
-// "./organization/routes"`) so invite deep-links keep working; it's just not
-// surfaced in the sidebar or the overview cards. Backend/DB orgs are untouched.
+// The console presents as plain per-user accounts. The org route stays
+// registered (register-all's `import "./organization/routes"`) so invite
+// deep-links keep working; it is just not surfaced in the sidebar or overview
+// cards. Backend/DB orgs are untouched.

--- a/packages/ui/src/cloud/shell/console-surfaces.ts
+++ b/packages/ui/src/cloud/shell/console-surfaces.ts
@@ -7,7 +7,6 @@
 
 import {
   Bot,
-  Building2,
   CreditCard,
   Home,
   KeyRound,
@@ -77,14 +76,10 @@ export const CONSOLE_SURFACES: ReadonlyArray<ConsoleSurface> = [
     descKey: "cloud.home.accountDesc",
     descDefault: "Profile, email, identity, and security.",
   },
-  {
-    id: "organization",
-    href: "/dashboard/organization",
-    icon: Building2,
-    label: "Organization",
-    titleKey: "cloud.home.organization",
-    titleDefault: "Organization",
-    descKey: "cloud.home.organizationDesc",
-    descDefault: "Members, credentials, and invites.",
-  },
 ];
+
+// The console presents as plain per-user accounts — the "Organization" surface
+// is intentionally NOT promoted here (a solo user's org already IS their
+// account). The org route stays registered (register-all's `import
+// "./organization/routes"`) so invite deep-links keep working; it's just not
+// surfaced in the sidebar or the overview cards. Backend/DB orgs are untouched.


### PR DESCRIPTION
Follow-up to #14208 (this piece missed the merge window). nubs's direction: the console should feel like **plain user accounts, no orgs**.

- Removes the **Organization** sidebar item + overview card (`console-surfaces.ts`).
- The org **route stays registered** (import-time self-registration) so invite deep-links (`?tab=credentials&contribute=1`) keep working — it's just not surfaced.
- **No backend/DB change**: orgs remain the money/tenancy container under the hood (credits/Stripe/keys all hang off `organization_id`; a solo user's org ≡ their account). Nuking the schema was evaluated and rejected as live-money surgery across 68 schema files.

Evidence: ConsoleShell + DashboardHome suites **13/13** on develop tip; biome clean. Live-render verified on the signed-in console via the CDP harness (Organization absent from nav + cards, invite route still mounts).

[qa-agent]