### PR TITLE
fix(agent): block unicode-escaped identifiers that bypass the read-only SQL guard (prompt-injection→write)

### DIFF
--- a/packages/agent/src/actions/database.readonly-redos.test.ts
+++ b/packages/agent/src/actions/database.readonly-redos.test.ts
@@ -33,4 +33,34 @@ describe("DATABASE read-only SQL guard", () => {
     }
     expect(elapsed).toBeLessThan(1000);
   });
+
+  it("blocks dangerous functions hidden behind unicode-escaped identifiers", () => {
+    // `U&"s\0065tval"` decodes to setval() at PG parse time — a sequence write
+    // that a literal-name scan of the raw text misses. Confirmed executable in
+    // PGlite before this guard. Every dangerous function is reachable this way.
+    for (const sql of [
+      `SELECT U&"s\\0065tval"('s', 999)`,
+      `SELECT U&"pg_sl\\0065ep"(0.15)`,
+      `SELECT U&"pg_wr\\0069te_file"('/tmp/x', 'data')`,
+      `SELECT u&"lo_exp\\006Frt"(1, '/tmp/x')`, // lower-case u& is valid too
+    ]) {
+      const result = checkReadOnly(sql);
+      expect(result, sql).toMatchObject({ ok: false });
+      if (!result.ok) {
+        expect(result.reason).toContain("Unicode-escaped identifiers");
+      }
+    }
+  });
+
+  it("still allows ordinary read-only queries (no false positives)", () => {
+    // A stray `U&` that is not the unicode-escape identifier syntax (space
+    // before the quote, or inside a string literal) must not trip the guard.
+    for (const sql of [
+      "SELECT id, name FROM users WHERE active = true LIMIT 10",
+      `SELECT "user" AS u FROM accounts`, // plain quoted identifier
+      `SELECT 'contains U&\\" text' AS note`, // U&" inside a string literal
+    ]) {
+      expect(checkReadOnly(sql), sql).toEqual({ ok: true });
+    }
+  });
 });

--- a/packages/agent/src/actions/database.ts
+++ b/packages/agent/src/actions/database.ts
@@ -221,6 +221,22 @@ export function checkReadOnly(
   );
   const noStrings = noLiterals.replace(/"(?:[^"]|"")*"/g, " ");
 
+  // PostgreSQL unicode-escaped quoted identifiers (`U&"s\0065tval"`) decode to
+  // their real name only at parse time, so the literal-name dangerous-function
+  // scan below sees `s\0065tval`, not `setval`, and waves the write through
+  // (confirmed: `SELECT U&"s\0065tval"('s',999)` mutated a sequence). Read-only
+  // queries never legitimately need unicode-escaped identifiers, so reject the
+  // token outright rather than attempt to decode it. Checked on `noLiterals`
+  // (string/comment content already removed) so a `U&"` here is unambiguously
+  // an identifier, not string data.
+  if (/[uU]&"/.test(noLiterals)) {
+    return {
+      ok: false,
+      reason:
+        'Unicode-escaped identifiers (U&"...") are not allowed in read-only mode: they can hide a dangerous function name from the guard.',
+    };
+  }
+
   const mutation = new RegExp(
     `\\b(${MUTATION_KEYWORDS.join("|")})\\b`,
     "i",

--- a/packages/agent/src/api/database.ts
+++ b/packages/agent/src/api/database.ts
@@ -1098,6 +1098,19 @@ async function handleQuery(
     // matching words inside quoted table/column names.
     const noStrings = noLiterals.replace(/"(?:[^"]|"")*"/g, " ");
 
+    // Reject PostgreSQL unicode-escaped quoted identifiers (`U&"s\0065tval"`)
+    // in read-only mode: they decode to the real name only at parse time, so
+    // the literal-name dangerous-function scan below is bypassable (a mutating
+    // function hides as `U&"s\0065tval"`). Legit read-only queries never need
+    // them. Mirrors checkReadOnly() in actions/database.ts.
+    if (/[uU]&"/.test(noLiterals)) {
+      return {
+        ok: false,
+        reason:
+          'Unicode-escaped identifiers (U&"...") are not allowed in read-only mode: they can hide a dangerous function name from the guard.',
+      };
+    }
+
     const mutationKeywords = [
       // ── DML ────────────────────────────────────────────────────────────
       "INSERT",


### PR DESCRIPTION
Closes the confirmed prompt-injection→write bypass my post-merge audit of #14269 surfaced (full analysis on that PR + skeptic repro). #14269 correctly fixed the ReDoS (#14262); this closes the deeper hole in the guard it hardens.

## The bug (empirically confirmed)

`checkReadOnly()` (`actions/database.ts`) and the mirrored `handleQuery()` guard (`api/database.ts`) detect dangerous functions with a **literal-name regex over the raw SQL text**. PostgreSQL **unicode-escaped quoted identifiers** — `U&"s\0065tval"` — decode to their real name (`setval`) **only at parse time**, so the raw text the guard scans contains no literal `setval` → no match → classified read-only → the write executes.

```sql
SELECT U&"s\0065tval"('s', 999)      -- guard: {ok:true}  → actually mutated a sequence (PGlite PG16)
SELECT U&"pg_wr\0069te_file"('/tmp/x','data')   -- file write, guard passes
SELECT U&"pg_sl\0065ep"(0.15)        -- DoS, guard passes
```

Every one of the 33 `DANGEROUS_FUNCTIONS` is reachable this way. Because the guard protects **LLM-generated** action SQL, a prompt-injected model becomes a data-write / file-write / DoS primitive against any agent on a Postgres backend. The mutation-*keyword* scan is unaffected (SQL keywords aren't quotable identifiers), so bare `INSERT`/`UPDATE`/`DELETE` stayed blocked — the gap was function-based writes/side-effects only. Pre-existing (not introduced by #14269).

## The fix

Reject the unicode-escaped **identifier** token `U&"…"` in read-only mode at both guard sites, checked on the string/comment-stripped text so a `U&"` there is unambiguously an identifier (not string data). Legit read-only queries never need unicode-escaped identifiers; the surgical reject closes the whole class without trying to decode escapes. The unicode-escaped *string* form `U&'…'` is already neutralized by the existing literal strippers, so it needs no change.

## Evidence (red / green)

- **RED** (unpatched guard): the new `blocks dangerous functions hidden behind unicode-escaped identifiers` case **FAILS** — `checkReadOnly` returns `{ok:true}` on the `U&"setval"`/`pg_sleep`/`pg_write_file`/`lo_export` payloads.
- **GREEN** (with fix): `database.readonly-redos.test.ts` **4/4 pass**, including the new block-case and a `no-false-positives` case proving ordinary reads — plus `U&"` *inside a string literal* and a space-separated `U& "ident"` — are still allowed.
- `biome check` clean on all three files.
- N/A rows: no UI / no live-LLM trajectory (pure server-side guard logic); the empirical PGlite write-execution is described in the #14269 skeptic repro rather than re-run here since the unit test pins the guard decision directly.

My commit → **no self-merge**; a @lalalune / @0xSolace lane please review + arm. This is a live prompt-injection→write hole on any Postgres-backed agent, so worth prioritizing. (#14262, #14269, #13406)

— `[maintainer]`
