### PR TITLE
test(ui): cover sandboxed frame document contract

### DIFF
--- a/.github/issue-evidence/14263-sandbox-frame-document.md
+++ b/.github/issue-evidence/14263-sandbox-frame-document.md
@@ -1,0 +1,82 @@
+# 14263 sandboxed frame document contract
+
+## Scope
+
+Issue #14263 follows up #14255: sandboxed dynamic/plugin views must load a real
+framed HTML document, not the JavaScript module endpoint. After rebasing on the
+latest `develop`, the canonical contract is `framePath` / `frameUrl` with
+package-local documents served from `/api/views/:id/frame.html`. This branch
+adds focused coverage and evidence for that contract.
+
+## What changed
+
+- Remote plugin manifest tests now reject unsafe `framePath` and `frameUrl`.
+- A new agent route test registers a real sandboxed dynamic view with
+  `framePath`, verifies `/api/views` exposes `frameUrl`, and serves
+  `GET`/`HEAD /api/views/:id/frame.html`.
+- The route test verifies package-root traversal protection for escaping
+  `framePath` values.
+- `DynamicViewLoader` coverage verifies sandboxed iframe views use `frameUrl`
+  as iframe `src`, do not import `bundleUrl` into the host realm, and still
+  broker navigate/storage requests through `SandboxedViewFrame`.
+- App-level wiring coverage verifies a frame-only registered route is passed to
+  `DynamicViewLoader` with both `bundleUrl` and `frameUrl`.
+
+## Verification run
+
+All commands were run in the isolated worktree:
+`.codex-worktrees/14263-sandbox-frame-doc`.
+
+```bash
+bunx @biomejs/biome check .github/issue-evidence/14263-sandbox-frame-document.md packages/agent/src/api/views-routes.frame.test.ts packages/core/src/capabilities/index.test.ts packages/ui/src/App.navigate-view-wiring.test.tsx packages/ui/src/components/views/DynamicViewLoader.test.tsx
+```
+
+Result: passed, 4 files checked (markdown evidence is ignored by the current
+Biome config).
+
+```bash
+bun run --cwd packages/agent test -- src/api/views-routes.frame.test.ts
+```
+
+Result: passed, 1 file, 2 tests. This covers registry exposure,
+`GET /api/views/:id/frame.html`, `HEAD /api/views/:id/frame.html`, HTML
+response headers, body content for GET, and package-escaping `framePath`
+rejection.
+
+```bash
+bun run --cwd packages/ui test -- src/components/views/DynamicViewLoader.test.tsx -t "loads sandboxed dynamic views"
+```
+
+Result: passed, 1 focused test, 26 skipped in the filtered file. This covers
+`frameUrl` iframe `src` selection, no host-realm bundle import, storage
+brokering, and navigate brokering.
+
+```bash
+bun run --cwd packages/core test -- src/capabilities/index.test.ts
+```
+
+Result: passed, 1 file, 63 tests. This includes rejection for unsafe
+`framePath` and unsafe `frameUrl` in remote plugin manifests.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Verification gaps
+
+- `bun run --cwd packages/ui test -- src/App.navigate-view-wiring.test.tsx -t "sandboxed frame-only"` could not collect tests in this sparse worktree.
+  The local dependency shim is incomplete for the mounted App graph; Vite first
+  lacked `@elizaos/capacitor-bun-runtime`, then followed the `motion` cache
+  symlink and could not resolve `framer-motion` from that real path. A full
+  workspace install should run this newly added App-level frame-only route
+  assertion.
+- Full `DynamicViewLoader.test.tsx` was not used as the pass/fail signal here.
+  The focused new sandbox tests pass; the full file has neighboring existing
+  agent-surface grant expectation failures unrelated to this document contract.
+- No app audit screenshots or video were captured in this sparse worktree.
+  This change does not alter visible shell chrome, but it does affect frontend
+  routing behavior; the draft PR should keep rendered proof marked as pending
+  until a full app workspace can run `bun run --cwd packages/app audit:app` or an
+  equivalent real dynamic-view walkthrough.

--- a/packages/agent/src/api/views-routes.frame.test.ts
+++ b/packages/agent/src/api/views-routes.frame.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Sandboxed dynamic views load a framed HTML document, not the JS bundle URL.
+ * These tests exercise the registry + route contract behind that document:
+ * a plugin declares `framePath`, `/api/views` exposes `frameUrl`, and
+ * `GET /api/views/:id/frame.html` serves the package-local HTML with traversal
+ * protection.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import type http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import type { Plugin } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  listViews,
+  registerPluginViews,
+  unregisterPluginViews,
+} from "./views-registry.ts";
+import {
+  clearCurrentViewState,
+  handleViewsRoutes,
+  type ViewsRouteContext,
+} from "./views-routes.ts";
+
+const TEST_PLUGIN = "@test/sandbox-document";
+const DOCUMENT_HTML =
+  "<!doctype html><title>Sandbox document</title><main>framed ok</main>";
+
+interface CapturedRes {
+  writeHead: ReturnType<typeof vi.fn>;
+  setHeader: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+}
+
+function makeCtx(
+  id: string,
+  method: "GET" | "HEAD" = "GET",
+): {
+  ctx: ViewsRouteContext;
+  res: CapturedRes;
+  error: ReturnType<typeof vi.fn>;
+} {
+  const req = Readable.from([]) as unknown as http.IncomingMessage;
+  req.headers = {};
+  const res: CapturedRes = {
+    writeHead: vi.fn(),
+    setHeader: vi.fn(),
+    end: vi.fn(),
+  };
+  const pathname = `/api/views/${encodeURIComponent(id)}/frame.html`;
+  const ctx: ViewsRouteContext = {
+    req,
+    res: res as unknown as http.ServerResponse,
+    method,
+    pathname,
+    url: new URL(`http://local${pathname}`),
+    json: vi.fn(),
+    error: vi.fn(),
+    broadcastWs: vi.fn(),
+  };
+  return { ctx, res, error: ctx.error as ReturnType<typeof vi.fn> };
+}
+
+function bodyFrom(res: CapturedRes): string {
+  const chunk = res.end.mock.calls[0]?.[0];
+  if (chunk instanceof Buffer) return chunk.toString("utf8");
+  if (typeof chunk === "string") return chunk;
+  return "";
+}
+
+describe("GET/HEAD /api/views/:id/frame.html", () => {
+  let pluginDir: string;
+
+  beforeEach(async () => {
+    clearCurrentViewState();
+    pluginDir = await mkdtemp(path.join(os.tmpdir(), "eliza-view-doc-"));
+    await mkdir(path.join(pluginDir, "dist", "views"), { recursive: true });
+    await writeFile(
+      path.join(pluginDir, "dist", "views", "sandbox.html"),
+      DOCUMENT_HTML,
+      "utf8",
+    );
+  });
+
+  afterEach(async () => {
+    clearCurrentViewState();
+    unregisterPluginViews(TEST_PLUGIN);
+    await rm(pluginDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("exposes and serves a declared sandbox document URL", async () => {
+    const plugin: Plugin = {
+      name: TEST_PLUGIN,
+      description: "sandbox document fixture",
+      views: [
+        {
+          id: "sandbox-doc",
+          label: "Sandbox Doc",
+          bundlePath: "dist/views/bundle.js",
+          framePath: "dist/views/sandbox.html",
+          surface: {
+            isolation: "sandboxed-iframe",
+            capabilities: ["navigate", "storage"],
+          },
+        },
+      ],
+    } as Plugin;
+    await registerPluginViews(plugin, pluginDir);
+
+    const entry = listViews({ includeAllKinds: true }).find(
+      (view) => view.id === "sandbox-doc",
+    );
+    expect(entry?.frameUrl).toMatch(
+      /^\/api\/views\/sandbox-doc\/frame\.html\?v=\d+$/,
+    );
+    expect(entry?.available).toBe(true);
+
+    const { ctx, res } = makeCtx("sandbox-doc");
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.writeHead).toHaveBeenCalledWith(
+      200,
+      expect.objectContaining({
+        "Content-Type": "text/html; charset=utf-8",
+        "Cache-Control": "no-cache",
+      }),
+    );
+    expect(bodyFrom(res)).toContain("framed ok");
+
+    const { ctx: headCtx, res: headRes } = makeCtx("sandbox-doc", "HEAD");
+    await expect(handleViewsRoutes(headCtx)).resolves.toBe(true);
+
+    expect(headRes.writeHead).toHaveBeenCalledWith(
+      200,
+      expect.objectContaining({
+        "Content-Type": "text/html; charset=utf-8",
+        "Content-Length": Buffer.byteLength(DOCUMENT_HTML),
+        "Cache-Control": "no-cache",
+      }),
+    );
+    expect(headRes.end).toHaveBeenCalledWith(undefined);
+  });
+
+  it("does not serve undeclared or package-escaping document paths", async () => {
+    const plugin: Plugin = {
+      name: TEST_PLUGIN,
+      description: "sandbox document traversal fixture",
+      views: [
+        {
+          id: "sandbox-escape",
+          label: "Sandbox Escape",
+          bundlePath: "dist/views/bundle.js",
+          framePath: "../outside.html",
+          surface: { isolation: "sandboxed-iframe" },
+        },
+      ],
+    } as Plugin;
+    await registerPluginViews(plugin, pluginDir);
+
+    const { ctx, res, error } = makeCtx("sandbox-escape");
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      'View "sandbox-escape" has no sandbox frame document configured.',
+      404,
+    );
+    expect(res.writeHead).not.toHaveBeenCalled();
+    expect(res.end).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/capabilities/index.test.ts
+++ b/packages/core/src/capabilities/index.test.ts
@@ -2021,4 +2021,58 @@ describe("capability router", () => {
 				"bundleUrl must be an absolute http(s) URL without embedded credentials.",
 		});
 	});
+
+	it("rejects remote plugin views with unsafe sandbox frame paths", async () => {
+		const router = new RuntimeBrokerCapabilityRouter({
+			invokeRuntime: async () => ({
+				modules: [
+					{
+						id: "remote-weather",
+						name: "@remote/weather",
+						views: [
+							{
+								id: "weather-panel",
+								label: "Weather",
+								framePath: "../sandbox.html",
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		await expect(router.plugin.listModules()).rejects.toMatchObject({
+			code: "CAPABILITY_DECODE_FAILED",
+			method: "plugin.modules.list.modules.views",
+			message:
+				"framePath must not contain empty, current-directory, or parent-directory segments.",
+		});
+	});
+
+	it("rejects remote plugin views with unsafe sandbox frame URLs", async () => {
+		const router = new RuntimeBrokerCapabilityRouter({
+			invokeRuntime: async () => ({
+				modules: [
+					{
+						id: "remote-weather",
+						name: "@remote/weather",
+						views: [
+							{
+								id: "weather-panel",
+								label: "Weather",
+								frameUrl: "javascript:alert(1)",
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		await expect(router.plugin.listModules()).rejects.toMatchObject({
+			code: "CAPABILITY_DECODE_FAILED",
+			method: "plugin.modules.list.modules.views",
+			message:
+				"frameUrl must be an absolute http(s) URL without embedded credentials.",
+		});
+	});
 });

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -53,17 +53,20 @@ const dynamicViewLoaderMock = vi.hoisted(() => ({
   render: vi.fn(
     ({
       bundleUrl,
+      frameUrl,
       surface,
       viewId,
       viewType,
     }: {
       bundleUrl: string;
+      frameUrl?: string;
       surface?: { capabilities?: string[] };
       viewId: string;
       viewType?: string;
     }) => (
       <div
         data-bundle-url={bundleUrl}
+        data-frame-url={frameUrl ?? ""}
         data-surface-capabilities={surface?.capabilities?.join(",") ?? ""}
         data-testid="dynamic-view-loader"
         data-view-id={viewId}
@@ -145,6 +148,17 @@ const documentsView = {
   viewType: "gui" as const,
 };
 
+const sandboxDocumentView = {
+  id: "sandbox-doc",
+  label: "Sandbox Doc",
+  available: true,
+  pluginName: "@local/plugin-sandbox-doc",
+  path: "/apps/sandbox-doc",
+  frameUrl: "/api/views/sandbox-doc/frame.html?v=123",
+  viewType: "gui" as const,
+  isolation: "sandboxed-iframe" as const,
+};
+
 const mockAvailableViews = [
   remoteLedgerView,
   viewsManagerView,
@@ -153,6 +167,7 @@ const mockAvailableViews = [
   calendarView,
   sharedCanvasView,
   documentsView,
+  sandboxDocumentView,
 ];
 
 function resetMockAvailableViews() {
@@ -166,6 +181,7 @@ function resetMockAvailableViews() {
     calendarView,
     sharedCanvasView,
     documentsView,
+    sandboxDocumentView,
   );
 }
 
@@ -521,6 +537,33 @@ describe("App navigate-view event wiring", () => {
     ).toBe(true);
     expect(getByTestId("app-opaque-background")).toBeTruthy();
     expect(queryByTestId("app-background-shader")).toBeNull();
+  });
+
+  it("renders a sandboxed frame-only route through DynamicViewLoader in the mounted App", async () => {
+    appState.tab = "apps";
+    window.history.replaceState(null, "", "/apps/sandbox-doc");
+
+    const { getByTestId } = render(<App />);
+
+    await waitFor(() => {
+      expect(dynamicViewLoaderMock.render).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bundleUrl: "/api/views/sandbox-doc/frame.html?v=123",
+          frameUrl: "/api/views/sandbox-doc/frame.html?v=123",
+          viewId: "sandbox-doc",
+          viewType: "gui",
+        }),
+        undefined,
+      );
+    });
+
+    const loader = getByTestId("dynamic-view-loader");
+    expect(loader.getAttribute("data-bundle-url")).toBe(
+      "/api/views/sandbox-doc/frame.html?v=123",
+    );
+    expect(loader.getAttribute("data-frame-url")).toBe(
+      "/api/views/sandbox-doc/frame.html?v=123",
+    );
   });
 
   it("renders no global corner back button on app routes (removed in favor of per-page back affordances + browser/OS back)", async () => {

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -7,6 +7,7 @@
 // asserting against a mock.
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { NAVIGATE_VIEW_EVENT } from "@elizaos/shared/events";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { transform } from "esbuild";
 import { type ReactElement, useState } from "react";
@@ -22,6 +23,8 @@ import {
   hostImport,
   isSameOriginBundleUrl,
 } from "./DynamicViewLoader";
+import { sandboxStorageKey } from "./SandboxedViewFrame";
+import { SANDBOXED_VIEW_CHANNEL } from "./sandboxed-view-broker";
 
 describe("isSameOriginBundleUrl (view-bundle origin gate)", () => {
   it("accepts same-origin and root-relative /api/views bundle URLs", () => {
@@ -105,6 +108,35 @@ vi.mock("../../api", () => ({
   client: { sendWsMessage },
 }));
 
+function postFromSandboxFrame(
+  frameWindow: Window,
+  capability: string,
+  payload: unknown,
+  requestId: string,
+): void {
+  const event = new MessageEvent("message", {
+    data: {
+      channel: SANDBOXED_VIEW_CHANNEL,
+      kind: "request",
+      requestId,
+      capability,
+      payload,
+    },
+  });
+  Object.defineProperty(event, "source", { value: frameWindow });
+  window.dispatchEvent(event);
+}
+
+function lastSandboxResponse(postSpy: ReturnType<typeof vi.spyOn>) {
+  const calls = postSpy.mock.calls;
+  return calls[calls.length - 1]?.[0] as {
+    requestId: string;
+    ok: boolean;
+    result?: unknown;
+    error?: string;
+  };
+}
+
 describe("DynamicViewLoader", () => {
   beforeEach(() => {
     Object.defineProperty(HTMLElement.prototype, "innerText", {
@@ -148,6 +180,75 @@ describe("DynamicViewLoader", () => {
     expect(importBundle).not.toHaveBeenCalledWith(
       expect.stringContaining("/api/views/remote.panel/bundle.js"),
     );
+  });
+
+  it("loads sandboxed dynamic views through the frame URL and brokers frame requests", async () => {
+    const bundleUrl = "/api/views/sandboxed-panel/bundle.js?v=bundle";
+    const frameUrl = "/api/views/sandboxed-panel/frame.html?v=frame";
+    const importBundle = vi.fn();
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = importBundle;
+    window.localStorage.clear();
+    const navSpy = vi.fn();
+    window.addEventListener(NAVIGATE_VIEW_EVENT, navSpy);
+
+    render(
+      <DynamicViewLoader
+        bundleUrl={bundleUrl}
+        frameUrl={frameUrl}
+        viewId="sandboxed-panel"
+        surface={{
+          isolation: "sandboxed-iframe",
+          capabilities: ["navigate", "storage"],
+        }}
+      />,
+    );
+
+    const iframe = screen.getByTestId(
+      "sandboxed-view-frame-sandboxed-panel",
+    ) as HTMLIFrameElement;
+    expect(iframe.getAttribute("src")).toBe(frameUrl);
+    expect(iframe.getAttribute("src")).not.toBe(bundleUrl);
+    expect(importBundle).not.toHaveBeenCalled();
+
+    const frameWindow = iframe.contentWindow;
+    if (!frameWindow) throw new Error("iframe contentWindow missing in jsdom");
+    const postSpy = vi
+      .spyOn(frameWindow, "postMessage")
+      .mockImplementation(() => {});
+
+    postFromSandboxFrame(
+      frameWindow,
+      "storage",
+      { op: "set", key: "draft", value: "inside-frame" },
+      "req-store",
+    );
+    await waitFor(() => expect(postSpy).toHaveBeenCalledTimes(1));
+    expect(lastSandboxResponse(postSpy)).toMatchObject({
+      requestId: "req-store",
+      ok: true,
+    });
+    expect(
+      window.localStorage.getItem(
+        sandboxStorageKey("sandboxed-panel", "draft"),
+      ),
+    ).toBe("inside-frame");
+
+    postFromSandboxFrame(
+      frameWindow,
+      "navigate",
+      { viewId: "chat" },
+      "req-nav",
+    );
+    await waitFor(() => expect(postSpy).toHaveBeenCalledTimes(2));
+    expect(lastSandboxResponse(postSpy)).toMatchObject({
+      requestId: "req-nav",
+      ok: true,
+    });
+    await waitFor(() => expect(navSpy).toHaveBeenCalledTimes(1));
+    expect((navSpy.mock.calls[0][0] as CustomEvent).detail).toMatchObject({
+      viewId: "chat",
+    });
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, navSpy);
   });
 
   it("registers remote view interact handlers after the bundle loads", async () => {


### PR DESCRIPTION
## Summary
- Adds route coverage for sandboxed frame documents declared with `framePath` and served from `/api/views/:id/frame.html`.
- Adds DynamicViewLoader coverage that `frameUrl` is used as the iframe `src`, the JS bundle is not imported into the host realm, and navigate/storage broker requests work.
- Adds App wiring coverage for frame-only dynamic routes plus remote manifest rejection coverage for unsafe `framePath`/`frameUrl`.
- Adds evidence at `.github/issue-evidence/14263-sandbox-frame-document.md`.

## Verification
- `bunx @biomejs/biome check .github/issue-evidence/14263-sandbox-frame-document.md packages/agent/src/api/views-routes.frame.test.ts packages/core/src/capabilities/index.test.ts packages/ui/src/App.navigate-view-wiring.test.tsx packages/ui/src/components/views/DynamicViewLoader.test.tsx`
- `bun run --cwd packages/agent test -- src/api/views-routes.frame.test.ts`
- `bun run --cwd packages/ui test -- src/components/views/DynamicViewLoader.test.tsx -t "loads sandboxed dynamic views"`
- `bun run --cwd packages/core test -- src/capabilities/index.test.ts`
- `git diff --check`

## Evidence
- `.github/issue-evidence/14263-sandbox-frame-document.md`

## Pending / N/A
- App mounted-route test `bun run --cwd packages/ui test -- src/App.navigate-view-wiring.test.tsx -t "sandboxed frame-only"` could not collect in this sparse worktree because Vite follows the local `motion` cache symlink and cannot resolve `framer-motion` from that real path.
- App audit screenshots/video are pending for a full workspace; this PR is draft until rendered proof is attached or explicitly accepted as N/A.