### PR TITLE
fix(#14237): close root @elizaos/ui import escape hatch + restore deleted baseline realm tokens

### DIFF
--- a/packages/ui/src/components/views/DynamicViewLoader.root-ui-broker.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.root-ui-broker.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+//
+// The root `@elizaos/ui` host-external must not be a broker escape hatch
+// (#14237). The barrel re-exports the RAW navigation/storage helpers, so a view
+// importing them from `@elizaos/ui` — instead of the wrapped `@elizaos/ui/*`
+// subpaths — could reach host `window.history` / `window.localStorage` outside
+// the surface-realm scope. These tests drive the real `hostImport` seam a served
+// view-bundle factory receives and prove the root barrel now hands back the SAME
+// scope-brokered wrappers as the subpaths. Unit/element level only (no <App/>).
+
+import { resolveSurfaceManifest } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  SurfaceRealmDeniedError,
+  SurfaceRealmScope,
+  setActiveSurfaceRealmScope,
+} from "../../surface-realm-broker";
+import { hostImport } from "./DynamicViewLoader";
+
+// In-memory Storage so the scope's façade runs against a real Storage-shaped
+// backing that is NOT the jsdom global localStorage — a wrapped write lands
+// here, a raw (escape-hatch) write would land in window.localStorage instead.
+class MemoryStorage implements Storage {
+  private map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  getItem(key: string): string | null {
+    return this.map.has(key) ? (this.map.get(key) as string) : null;
+  }
+  key(index: number): string | null {
+    return [...this.map.keys()][index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+  [name: string]: unknown;
+}
+
+const VIEW_ID = "root.import.view";
+
+describe("root @elizaos/ui import is broker-scoped, not an escape hatch (#14237)", () => {
+  let backing: MemoryStorage;
+
+  beforeEach(() => {
+    backing = new MemoryStorage();
+    // A no-grants scope: storage is confined to the view namespace, navigation
+    // is denied. The raw navigate must never be reached — if the wrapper falls
+    // through to it, this throws a distinct error and fails the assertion.
+    const scope = new SurfaceRealmScope(
+      resolveSurfaceManifest({ surface: { capabilities: [] } }),
+      VIEW_ID,
+      backing,
+      () => {
+        throw new Error("raw shell navigate reached — broker was bypassed");
+      },
+    );
+    setActiveSurfaceRealmScope(scope);
+  });
+
+  afterEach(() => {
+    setActiveSurfaceRealmScope(null);
+    window.localStorage.clear();
+  });
+
+  it("root navigateBrowserPath is the scope-brokered wrapper (denied without the grant), like the subpath", async () => {
+    const rootMod = await hostImport("@elizaos/ui");
+    const navigate = rootMod.navigateBrowserPath as (path: string) => void;
+    expect(typeof navigate).toBe("function");
+
+    // Brokered: a no-navigate-grant scope raises an observable denial instead of
+    // driving host history. The RAW barrel export would pushState and not throw.
+    expect(() => navigate("/hijack")).toThrow(SurfaceRealmDeniedError);
+
+    // Parity with the wrapped subpath specifier: same brokered behavior.
+    const subMod = await hostImport("@elizaos/ui/app-navigate-view");
+    const subNavigate = subMod.navigateBrowserPath as (path: string) => void;
+    expect(() => subNavigate("/hijack")).toThrow(SurfaceRealmDeniedError);
+    // Resolving the whole `@elizaos/ui` barrel graph in jsdom is slow (~25s).
+  }, 120_000);
+
+  it("root storage helpers write through the scoped namespace, never the host keyspace", async () => {
+    const rootMod = await hostImport("@elizaos/ui");
+    const setStorageValue = rootMod.setStorageValue as (
+      key: string,
+      value: string,
+    ) => Promise<void>;
+    const getStorageValue = rootMod.getStorageValue as (
+      key: string,
+    ) => Promise<string | null>;
+
+    await setStorageValue("probe-key", "probe-value");
+
+    // Scoped away from the host keyspace...
+    expect(backing.getItem("probe-key")).toBeNull();
+    expect(window.localStorage.getItem("probe-key")).toBeNull();
+    // ...and confined to the view-prefixed namespace instead.
+    expect(backing.getItem(`surface:view:${VIEW_ID}:probe-key`)).toBe(
+      "probe-value",
+    );
+    // The view reads back its own scoped value transparently.
+    expect(await getStorageValue("probe-key")).toBe("probe-value");
+  }, 120_000);
+
+  it("the raw app-navigate-view helper (the pre-fix barrel export) bypasses the scope — proving the fix closes a real hole", async () => {
+    const raw = await import("../../app-navigate-view");
+    const rawNavigate = raw.navigateBrowserPath;
+    // The raw helper reaches window.history directly and never consults the
+    // scope, so it does NOT throw under the no-grant scope. This is exactly the
+    // escape hatch the root barrel used to re-export; the root import above no
+    // longer resolves to it.
+    expect(() => rawNavigate("/raw-path")).not.toThrow();
+  });
+});

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -391,7 +391,20 @@ async function importUiComponentsCompat(): Promise<Record<string, unknown>> {
 }
 
 async function importUiRootCompat(): Promise<Record<string, unknown>> {
-  return import("../../index.ts");
+  // The root barrel re-exports the RAW navigation/storage helpers (via
+  // `export * from "./app-navigate-view"` and `export * from "./bridge/index"`),
+  // which reach host `window.history` / `window.localStorage` directly. Exposing
+  // that unbrokered would let an in-process view bypass the manifest broker by
+  // importing from `@elizaos/ui` instead of the wrapped `@elizaos/ui/*` subpaths.
+  // Overlay the SAME wrapped versions the subpath compat modules expose so the
+  // sensitive nav/storage symbols route through the active surface-realm scope no
+  // matter which specifier the view imports; every other root export is untouched.
+  const [root, appNavigateView, bridge] = await Promise.all([
+    import("../../index.ts"),
+    importUiAppNavigateViewCompat(),
+    importUiBridgeCompat(),
+  ]);
+  return { ...root, ...appNavigateView, ...bridge };
 }
 
 async function importUiAppNavigateViewCompat(): Promise<

--- a/packages/ui/src/surface-realm-broker.test.tsx
+++ b/packages/ui/src/surface-realm-broker.test.tsx
@@ -249,4 +249,63 @@ describe("SurfaceRealmScope.resetHostRealm — root/body class + :root var vecto
       document.documentElement.classList.contains("rogue-root-class"),
     ).toBe(false);
   });
+
+  // A view leaks into the next surface by DELETING a shell baseline token just
+  // as much as by injecting a rogue one — teardown must restore what the shell
+  // owned at activation. (Existing tests above cover only ADDED rogue tokens.)
+  it("restores a shell-owned root class the view deleted while active", () => {
+    // Baseline root class is `dark` (beforeEach).
+    const scope = makeScope();
+    document.documentElement.classList.remove("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+    const result = scope.resetHostRealm();
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(result.restoredRootClasses).toContain("dark");
+  });
+
+  it("restores a shell-owned body class the view deleted while active", () => {
+    // Baseline body classes are `platform-web native` (beforeEach).
+    const scope = makeScope();
+    document.body.classList.remove("native");
+    expect(document.body.classList.contains("native")).toBe(false);
+
+    const result = scope.resetHostRealm();
+
+    expect(document.body.classList.contains("native")).toBe(true);
+    expect(result.restoredBodyClasses).toContain("native");
+  });
+
+  it("restores a shell-owned :root var (with its baseline value) the view deleted while active", () => {
+    // Baseline `--accent` is `#f60` (beforeEach).
+    const scope = makeScope();
+    document.documentElement.style.removeProperty("--accent");
+    expect(document.documentElement.style.getPropertyValue("--accent")).toBe(
+      "",
+    );
+
+    const result = scope.resetHostRealm();
+
+    expect(document.documentElement.style.getPropertyValue("--accent")).toBe(
+      "#f60",
+    );
+    expect(result.restoredRootVars).toContain("--accent");
+  });
+
+  it("does not re-add the previous theme class after a legitimate shell theme swap", () => {
+    document.documentElement.className = "light";
+    const scope = makeScope();
+    // Shell legitimately swaps theme mid-view: `light` out, `dark` in.
+    document.documentElement.classList.remove("light");
+    document.documentElement.classList.add("dark");
+
+    const result = scope.resetHostRealm();
+
+    // The theme family is still represented — the swap is not a view deletion,
+    // so `light` must NOT be restored (that would leave both classes set).
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.classList.contains("light")).toBe(false);
+    expect(result.restoredRootClasses).not.toContain("light");
+  });
 });

--- a/packages/ui/src/surface-realm-broker.ts
+++ b/packages/ui/src/surface-realm-broker.ts
@@ -260,11 +260,20 @@ function readRootVarNames(el: HTMLElement): string[] {
   return names;
 }
 
-/** The tokens removed by a host-realm reset — returned so callers can log/inspect. */
+/**
+ * What a host-realm reset changed — returned so callers can log/inspect. The
+ * `removed*` fields are rogue tokens the view ADDED and the reset stripped; the
+ * `restored*` fields are shell-owned baseline tokens the view DELETED and the
+ * reset re-asserted (a view leaks just as much by deleting `dark`/`native`/
+ * `--accent` as by injecting a rogue token).
+ */
 export interface HostRealmResetResult {
   rootClasses: string[];
   bodyClasses: string[];
   rootVars: string[];
+  restoredRootClasses: string[];
+  restoredBodyClasses: string[];
+  restoredRootVars: string[];
 }
 
 // ── The per-view scope the shell publishes ───────────────────────────────────
@@ -275,6 +284,9 @@ export interface HostRealmResetResult {
  * tears it down on navigation. It captures the class/var tokens present at
  * activation so shell state that legitimately changes while the view is open is
  * preserved, while anything the view injected globally is reset on teardown.
+ * The reset is symmetric: it strips the rogue tokens a view ADDED and restores
+ * the shell-owned baseline tokens a view DELETED, so neither direction of
+ * mutation survives into the next view.
  */
 export class SurfaceRealmScope {
   readonly storage: ScopedStorage;
@@ -282,6 +294,13 @@ export class SurfaceRealmScope {
   private readonly rootClassBaseline: ReadonlySet<string>;
   private readonly bodyClassBaseline: ReadonlySet<string>;
   private readonly rootVarBaseline: ReadonlySet<string>;
+  // Baseline presence/values of the SHELL-OWNED tokens only, snapshotted at
+  // activation. Restored on teardown if the view deleted them — the shell owns
+  // these, so re-asserting its own theme/platform/accent state is safe, whereas
+  // a plugin/content-pack token the view deleted is not the shell's to restore.
+  private readonly shellRootClassBaseline: readonly string[];
+  private readonly shellBodyClassBaseline: readonly string[];
+  private readonly shellRootVarBaseline: ReadonlyMap<string, string>;
 
   constructor(
     readonly manifest: ResolvedSurfaceManifest,
@@ -295,25 +314,44 @@ export class SurfaceRealmScope {
       this.rootClassBaseline = new Set();
       this.bodyClassBaseline = new Set();
       this.rootVarBaseline = new Set();
+      this.shellRootClassBaseline = [];
+      this.shellBodyClassBaseline = [];
+      this.shellRootVarBaseline = new Map();
     } else {
-      this.rootClassBaseline = new Set(document.documentElement.classList);
-      this.bodyClassBaseline = new Set(document.body.classList);
-      this.rootVarBaseline = new Set(
-        readRootVarNames(document.documentElement),
+      const root = document.documentElement;
+      const rootClasses = [...root.classList];
+      const bodyClasses = [...document.body.classList];
+      const rootVars = readRootVarNames(root);
+      this.rootClassBaseline = new Set(rootClasses);
+      this.bodyClassBaseline = new Set(bodyClasses);
+      this.rootVarBaseline = new Set(rootVars);
+      this.shellRootClassBaseline = rootClasses.filter(isShellOwnedRootClass);
+      this.shellBodyClassBaseline = bodyClasses.filter(isShellOwnedBodyClass);
+      this.shellRootVarBaseline = new Map(
+        rootVars
+          .filter(isShellOwnedRootVar)
+          .map((name) => [name, root.style.getPropertyValue(name)]),
       );
     }
   }
 
   /**
-   * Remove the root/body classes and `:root` variables this view added to the
-   * host realm beyond the shell's own token set. Called on view teardown so a
-   * view's global class/CSS-var mutation cannot leak into the next view.
+   * Undo a view's global root/body-class + `:root`-var mutations on teardown so
+   * nothing it did to the host realm leaks into the next view. Two directions:
+   * (1) remove tokens the view ADDED beyond the shell's own set, and (2) restore
+   * shell-owned baseline tokens the view DELETED. A legitimate theme SWAP by the
+   * shell (removing `light` while adding `dark`) is not a deletion to restore —
+   * the family is still represented — so restoration skips a missing theme class
+   * whenever any theme class is present.
    */
   resetHostRealm(): HostRealmResetResult {
     const result: HostRealmResetResult = {
       rootClasses: [],
       bodyClasses: [],
       rootVars: [],
+      restoredRootClasses: [],
+      restoredBodyClasses: [],
+      restoredRootVars: [],
     };
     if (typeof document === "undefined") return result;
     const root = document.documentElement;
@@ -334,6 +372,32 @@ export class SurfaceRealmScope {
       if (isShellOwnedRootVar(name) || this.rootVarBaseline.has(name)) continue;
       root.style.removeProperty(name);
       result.rootVars.push(name);
+    }
+
+    // All shell-owned root classes are the mutually-exclusive theme family; if
+    // any is present, the theme is validly set and a missing baseline sibling is
+    // a legitimate swap, not a view deletion.
+    const themeRootClassPresent = [...SHELL_OWNED_ROOT_CLASSES].some((cls) =>
+      root.classList.contains(cls),
+    );
+    for (const cls of this.shellRootClassBaseline) {
+      if (root.classList.contains(cls)) continue;
+      if (themeRootClassPresent) continue;
+      root.classList.add(cls);
+      result.restoredRootClasses.push(cls);
+    }
+    for (const cls of this.shellBodyClassBaseline) {
+      if (body.classList.contains(cls)) continue;
+      body.classList.add(cls);
+      result.restoredBodyClasses.push(cls);
+    }
+    for (const [name, value] of this.shellRootVarBaseline) {
+      // Only a deletion (property absent → empty string) is unambiguously the
+      // view's doing; a changed non-empty value can be a legitimate shell accent
+      // update, so it is left alone.
+      if (root.style.getPropertyValue(name) !== "") continue;
+      root.style.setProperty(name, value);
+      result.restoredRootVars.push(name);
     }
     return result;
   }


### PR DESCRIPTION
Closes #14237 (the two **code** blockers from the #14226/#14179 in-process view-isolation follow-up).

## Blocker 1 — root `@elizaos/ui` import escape hatch (closed)
`DynamicViewLoader` wrapped the `@elizaos/ui/*` subpath imports (nav → `scope.navigate`, storage → `scope.storage`) but the ROOT barrel `"@elizaos/ui": importUiRootCompat` still `import("../../index.ts")`'d the RAW helpers — the barrel re-exports `navigateBrowserPath` (→ `window.history.pushState`) and `getStorageValue/setStorageValue/removeStorageValue` (→ `window.localStorage`), so an in-process view importing them via root `@elizaos/ui` bypassed the manifest broker and reached the host realm directly.

`importUiRootCompat` now overlays the wrapped compat modules onto the barrel — `{ ...root, ...importUiAppNavigateViewCompat(), ...importUiBridgeCompat() }` — so the sensitive nav/storage/bridge symbols are the SAME scope-brokered wrappers as the subpaths; all other exports pass through. **Proof:** `hostImport("@elizaos/ui").navigateBrowserPath("/hijack")` throws `SurfaceRealmDeniedError` under a no-grant scope (raw would `pushState`); a root `setStorageValue` lands in `surface:view:<id>:` and leaves `window.localStorage` untouched. A companion test shows the raw `app-navigate-view` helper does NOT throw — proving the hole was real.

## Blocker 2 — `resetHostRealm()` now restores DELETIONS
`resetHostRealm()` removed *added* rogue tokens but did not restore baseline shell classes/vars a view *deleted* while active (a view could strip `dark`/`native`/`platform-*` or a baseline `--accent` and the deletion survived teardown). The scope now snapshots shell-owned baseline class presence + var values at activation and re-asserts any deleted-while-scoped on teardown. Theme classes are the mutually-exclusive `{dark,light}` family (a missing baseline theme class is skipped when any theme class is present — a legit shell swap); var restore fires only on true deletion (empty value), leaving legit shell value-changes alone.

## Verification
- **18/18 tests pass** via the `packages/ui` vitest config (`surface-realm-broker.test.tsx` 15 + `DynamicViewLoader.root-ui-broker.test.tsx` 3) — re-confirmed independently (the tests need the package's `vitest.setup.ts` localStorage provider; a bare worktree-root run lacks it).
- **Mutation-checks:** blocker 2 restore neutralized → exactly the 3 deletion tests RED (theme-swap guard + add-side tests stay GREEN); blocker 1 `importUiRootCompat` reverted to raw `import("../../index.ts")` → the 2 brokered-nav/storage tests RED. Both restored → GREEN.
- Typecheck 0 errors in touched files; Biome clean. Rebased onto develop (clean).
- **app:audit visual evidence** is app-run-gated (boots a dev server + full `<App/>` render, not runnable in the symlinked worktree) → deferred to CI; both fixes are logic isolated to the broker/loader and proven at the unit/element level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)