### PR TITLE
fix(agent): send API error for unicode SQL guard

### DIFF
--- a/packages/agent/src/api/database.query-readonly.test.ts
+++ b/packages/agent/src/api/database.query-readonly.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Route-level coverage for the raw database query read-only guard. The DATABASE
+ * action has its own helper tests; this file pins the HTTP route copy so a
+ * rejection sends a JSON response instead of silently returning from the handler.
+ */
+
+import type http from "node:http";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRuntime } from "../runtime/eliza.ts";
+import { handleDatabaseRoute } from "./database.ts";
+
+function jsonPost(body: unknown): http.IncomingMessage {
+  const req = new PassThrough() as unknown as http.IncomingMessage;
+  req.method = "POST";
+  req.headers = { "content-type": "application/json" };
+  req.push(JSON.stringify(body));
+  req.push(null);
+  return req;
+}
+
+function responseRecorder(): http.ServerResponse & {
+  body: string;
+  headers: Record<string, string | number | readonly string[]>;
+} {
+  return {
+    statusCode: 200,
+    body: "",
+    headers: {},
+    setHeader(name: string, value: string | number | readonly string[]) {
+      this.headers[name.toLowerCase()] = value;
+      return this;
+    },
+    end(chunk?: unknown) {
+      if (chunk !== undefined) this.body += String(chunk);
+      return this;
+    },
+  } as unknown as http.ServerResponse & {
+    body: string;
+    headers: Record<string, string | number | readonly string[]>;
+  };
+}
+
+describe("POST /api/database/query read-only guard", () => {
+  it("rejects unicode-escaped identifiers with a JSON error before query execution", async () => {
+    const query = vi.fn();
+    const runtime = {
+      adapter: {
+        db: { query },
+      },
+    } as unknown as AgentRuntime;
+    const res = responseRecorder();
+
+    await expect(
+      handleDatabaseRoute(
+        jsonPost({
+          sql: `SELECT U&"s\\0065tval"('s', 999)`,
+          readOnly: true,
+        }),
+        res,
+        runtime,
+        "/api/database/query",
+      ),
+    ).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.headers["content-type"]).toBe("application/json");
+    expect(JSON.parse(res.body)).toEqual({
+      error:
+        'Query rejected: Unicode-escaped identifiers (U&"...") are not allowed in read-only mode: they can hide a dangerous function name from the guard.',
+    });
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/api/database.ts
+++ b/packages/agent/src/api/database.ts
@@ -1104,11 +1104,11 @@ async function handleQuery(
     // function hides as `U&"s\0065tval"`). Legit read-only queries never need
     // them. Mirrors checkReadOnly() in actions/database.ts.
     if (/[uU]&"/.test(noLiterals)) {
-      return {
-        ok: false,
-        reason:
-          'Unicode-escaped identifiers (U&"...") are not allowed in read-only mode: they can hide a dangerous function name from the guard.',
-      };
+      sendJsonError(
+        res,
+        'Query rejected: Unicode-escaped identifiers (U&"...") are not allowed in read-only mode: they can hide a dangerous function name from the guard.',
+      );
+      return;
     }
 
     const mutationKeywords = [


### PR DESCRIPTION
## Summary
- fixes the post-merge #14285 API route regression where the unicode-escaped identifier guard returned an object from `handleQuery()` instead of sending an HTTP response
- mirrors the other read-only rejection paths with `sendJsonError(...)` + `return`
- adds route-level coverage for `POST /api/database/query` proving the request receives a JSON 400 and the DB query adapter is not called

Fix-forward for #14285.

## Verification

```bash
bunx @biomejs/biome check packages/agent/src/api/database.ts packages/agent/src/api/database.query-readonly.test.ts packages/agent/src/actions/database.ts packages/agent/src/actions/database.readonly-redos.test.ts
```
Result: passed.

```bash
git diff --check origin/develop...HEAD
```
Result: passed.

## Not run / blocked locally

```bash
bun test packages/agent/src/api/database.query-readonly.test.ts packages/agent/src/actions/database.readonly-redos.test.ts
```
Could not start in the clean temp worktree because workspace dependencies were missing (`json5` from agent config and `handlebars` from core utils). CI/full workspace should run the new test.

A standalone `tsc --ignoreConfig` pass was also not useful because it does not load the package tsconfig/workspace aliases and expands into unrelated missing workspace modules.

## Evidence matrix
- UI screenshots/video: N/A - API guard response only.
- Live LLM trajectories: N/A - no prompt/model behavior changed; this fixes the HTTP route guard around SQL execution.
- Backend/domain artifact: route-level test asserts rejected SQL does not call the DB query adapter.