### PR TITLE
ci: Windows command-coverage contract (#13402)

### DIFF
--- a/.github/ci-windows-command-inventory.json
+++ b/.github/ci-windows-command-inventory.json
@@ -1,0 +1,27 @@
+{
+  "$comment": "Coverage floor for the Windows CI lane (#13402). Every command here must stay wired in some jobs.windows.strategy.matrix.include[].commands list in .github/workflows/windows-ci.yml. The Windows lane is a deliberately narrow subset of the Linux gates (see WINDOWS.md), so these suites are the only Windows proof for the runtime/dashboard/shared TypeScript packages — dropping one silently regresses coverage with a still-green pipeline. Enforced by packages/scripts/ci-windows-command-coverage-contract.mjs: adding a command is always allowed (this is a floor, not an exact match); to intentionally retire one, delete it from the matrix AND from this list in the SAME PR so the reduction is reviewable in the diff.",
+  "commands": [
+    "node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/cloud-shared --concurrency=4",
+    "bun run --cwd packages/core test",
+    "bun run --cwd packages/shared test",
+    "bun run --cwd packages/app-core test",
+    "bun run --cwd packages/elizaos test",
+    "bun run --cwd packages/cloud/shared test",
+    "bun run --cwd packages/scenario-runner test",
+    "bun run --cwd packages/vault test",
+    "bun run --cwd packages/security test",
+    "bun run --cwd plugins/plugin-coding-tools test",
+    "bun run --cwd plugins/plugin-elizacloud test",
+    "bun run --cwd plugins/plugin-discord test",
+    "bun run --cwd plugins/plugin-anthropic test",
+    "bun run --cwd plugins/plugin-openai test",
+    "bun run --cwd plugins/plugin-app-control test",
+    "bun run --cwd plugins/plugin-task-coordinator test",
+    "bun run --cwd plugins/plugin-browser test",
+    "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/agent --concurrency=4",
+    "node packages/scripts/run-bash-linux-only.mjs scripts/verify-riscv64-buildpaths.sh",
+    "node packages/scripts/run-python.mjs --version",
+    "node packages/scripts/test-cloud-run.mjs",
+    "node packages/scripts/clean-stray-dts.mjs"
+  ]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,6 +138,9 @@ jobs:
       - name: Validate zero-key command ownership contract
         run: node packages/scripts/ci-zero-key-command-ownership-contract.mjs
 
+      - name: Validate Windows command coverage contract
+        run: node packages/scripts/ci-windows-command-coverage-contract.mjs
+
       - name: Install alias-read guard parser dependency
         run: npm install --prefix "$RUNNER_TEMP/alias-read-guard-deps" --no-save --no-package-lock --ignore-scripts typescript@6.0.3
 

--- a/packages/scripts/__tests__/ci-windows-command-coverage-contract.test.ts
+++ b/packages/scripts/__tests__/ci-windows-command-coverage-contract.test.ts
@@ -1,0 +1,160 @@
+// Pins the Windows command-coverage contract (#13402) against synthetic
+// workflow + inventory trees: dropping an inventoried command from the matrix
+// throws (RED), keeping all present passes (GREEN), adding a new command is
+// allowed, and the shipped repo satisfies its own inventory. Static only: no
+// workflow is executed.
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const {
+  parseWindowsCommands,
+  loadInventory,
+  findDroppedCommands,
+  runContract,
+} = await import(
+  new URL("../ci-windows-command-coverage-contract.mjs", import.meta.url).href
+);
+
+const REAL_REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+// Two lanes with two commands each is enough to exercise both the multi-lane
+// flatten and the per-lane list boundary. Indentation matches windows-ci.yml
+// (include items at 10 spaces, command items at 14).
+function windowsWorkflow(lanes: { lane: string; commands: string[] }[]): string {
+  const include = lanes
+    .map(
+      ({ lane, commands }) =>
+        `          - lane: ${lane}\n` +
+        `            commands:\n` +
+        commands.map((command) => `              - ${command}`).join("\n"),
+    )
+    .join("\n");
+  return `name: Windows CI
+on: [push]
+jobs:
+  windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+${include}
+    steps:
+      - uses: actions/checkout@v4
+`;
+}
+
+function buildRepo({
+  lanes,
+  inventory,
+}: {
+  lanes: { lane: string; commands: string[] }[];
+  inventory: string[];
+}): string {
+  const root = mkdtempSync(join(tmpdir(), "windows-command-coverage-"));
+  mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+  writeFileSync(
+    join(root, ".github", "workflows", "windows-ci.yml"),
+    windowsWorkflow(lanes),
+  );
+  writeFileSync(
+    join(root, ".github", "ci-windows-command-inventory.json"),
+    JSON.stringify({ commands: inventory }, null, 2),
+  );
+  return root;
+}
+
+function withRepo(
+  config: {
+    lanes: { lane: string; commands: string[] }[];
+    inventory: string[];
+  },
+  fn: (root: string) => void,
+) {
+  const root = buildRepo(config);
+  try {
+    fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+const CORE_LANE = {
+  lane: "core-runtime",
+  commands: ["bun run --cwd packages/core test", "bun run --cwd packages/shared test"],
+};
+const PLUGIN_LANE = {
+  lane: "plugins",
+  commands: ["bun run --cwd plugins/plugin-openai test"],
+};
+const FULL_INVENTORY = [...CORE_LANE.commands, ...PLUGIN_LANE.commands];
+
+describe("ci-windows-command-coverage-contract", () => {
+  test("GREEN: passes when every inventoried command is still wired in a lane", () => {
+    withRepo(
+      { lanes: [CORE_LANE, PLUGIN_LANE], inventory: FULL_INVENTORY },
+      (root) => {
+        const result = runContract(root);
+        expect(result.commandCount).toBe(3);
+        expect(result.inventoryCount).toBe(3);
+      },
+    );
+  });
+
+  test("RED: throws when an inventoried command is dropped from the matrix", () => {
+    withRepo(
+      { lanes: [CORE_LANE], inventory: FULL_INVENTORY },
+      (root) => {
+        expect(() => runContract(root)).toThrow(
+          /Windows CI command coverage shrank/,
+        );
+        expect(findDroppedCommands(FULL_INVENTORY, parseWindowsCommands(root))).toEqual(
+          ["bun run --cwd plugins/plugin-openai test"],
+        );
+      },
+    );
+  });
+
+  test("flattens commands across every include[] lane", () => {
+    withRepo(
+      { lanes: [CORE_LANE, PLUGIN_LANE], inventory: FULL_INVENTORY },
+      (root) => {
+        expect(parseWindowsCommands(root)).toEqual([
+          "bun run --cwd packages/core test",
+          "bun run --cwd packages/shared test",
+          "bun run --cwd plugins/plugin-openai test",
+        ]);
+      },
+    );
+  });
+
+  test("adding a command beyond the inventory is allowed (floor, not exact match)", () => {
+    withRepo(
+      {
+        lanes: [
+          CORE_LANE,
+          { lane: "extra", commands: ["bun run --cwd packages/new test"] },
+        ],
+        inventory: CORE_LANE.commands,
+      },
+      (root) => {
+        expect(runContract(root).commandCount).toBe(3);
+      },
+    );
+  });
+
+  test("rejects an empty inventory", () => {
+    withRepo({ lanes: [CORE_LANE], inventory: [] }, (root) => {
+      expect(() => loadInventory(root)).toThrow(/must not be empty/);
+    });
+  });
+
+  test("the real repo satisfies its committed Windows command inventory", () => {
+    const result = runContract(REAL_REPO_ROOT);
+    expect(result.inventoryCount).toBeGreaterThan(0);
+    expect(result.commandCount).toBeGreaterThanOrEqual(result.inventoryCount);
+  });
+});

--- a/packages/scripts/__tests__/ci-windows-command-coverage-contract.test.ts
+++ b/packages/scripts/__tests__/ci-windows-command-coverage-contract.test.ts
@@ -1,8 +1,10 @@
-// Pins the Windows command-coverage contract (#13402) against synthetic
-// workflow + inventory trees: dropping an inventoried command from the matrix
-// throws (RED), keeping all present passes (GREEN), adding a new command is
-// allowed, and the shipped repo satisfies its own inventory. Static only: no
-// workflow is executed.
+/**
+ * Pins the Windows command-coverage contract (#13402) against synthetic
+ * workflow and inventory trees. Dropping an inventoried command from the matrix
+ * throws (RED), keeping all present passes (GREEN), adding a new command is
+ * allowed, and the shipped repo satisfies its own inventory. Static only: no
+ * workflow is executed.
+ */
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/packages/scripts/__tests__/ci-windows-command-coverage-contract.test.ts
+++ b/packages/scripts/__tests__/ci-windows-command-coverage-contract.test.ts
@@ -23,7 +23,9 @@ const REAL_REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
 // Two lanes with two commands each is enough to exercise both the multi-lane
 // flatten and the per-lane list boundary. Indentation matches windows-ci.yml
 // (include items at 10 spaces, command items at 14).
-function windowsWorkflow(lanes: { lane: string; commands: string[] }[]): string {
+function windowsWorkflow(
+  lanes: { lane: string; commands: string[] }[],
+): string {
   const include = lanes
     .map(
       ({ lane, commands }) =>
@@ -84,7 +86,10 @@ function withRepo(
 
 const CORE_LANE = {
   lane: "core-runtime",
-  commands: ["bun run --cwd packages/core test", "bun run --cwd packages/shared test"],
+  commands: [
+    "bun run --cwd packages/core test",
+    "bun run --cwd packages/shared test",
+  ],
 };
 const PLUGIN_LANE = {
   lane: "plugins",
@@ -105,17 +110,14 @@ describe("ci-windows-command-coverage-contract", () => {
   });
 
   test("RED: throws when an inventoried command is dropped from the matrix", () => {
-    withRepo(
-      { lanes: [CORE_LANE], inventory: FULL_INVENTORY },
-      (root) => {
-        expect(() => runContract(root)).toThrow(
-          /Windows CI command coverage shrank/,
-        );
-        expect(findDroppedCommands(FULL_INVENTORY, parseWindowsCommands(root))).toEqual(
-          ["bun run --cwd plugins/plugin-openai test"],
-        );
-      },
-    );
+    withRepo({ lanes: [CORE_LANE], inventory: FULL_INVENTORY }, (root) => {
+      expect(() => runContract(root)).toThrow(
+        /Windows CI command coverage shrank/,
+      );
+      expect(
+        findDroppedCommands(FULL_INVENTORY, parseWindowsCommands(root)),
+      ).toEqual(["bun run --cwd plugins/plugin-openai test"]);
+    });
   });
 
   test("flattens commands across every include[] lane", () => {

--- a/packages/scripts/ci-windows-command-coverage-contract.mjs
+++ b/packages/scripts/ci-windows-command-coverage-contract.mjs
@@ -158,7 +158,9 @@ if (import.meta.url === `file://${process.argv[1]}`) {
         `(${commandCount} lane command(s); ${inventoryCount} inventoried command(s) all present)`,
     );
   } catch (error) {
-    console.error(`[ci-windows-command-coverage-contract] FAIL ${error.message}`);
+    console.error(
+      `[ci-windows-command-coverage-contract] FAIL ${error.message}`,
+    );
     process.exit(1);
   }
 }

--- a/packages/scripts/ci-windows-command-coverage-contract.mjs
+++ b/packages/scripts/ci-windows-command-coverage-contract.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * Contract for #13402's Windows command-coverage slice. The Windows CI lane is
+ * a deliberately narrow subset of the Linux gates (see WINDOWS.md), so the
+ * suites it guards are the only proof that the runtime/dashboard/shared
+ * TypeScript packages still build and pass on Windows. Nothing else re-runs
+ * them there. That makes silent shrinkage the failure mode: a lane trimmed
+ * "to speed CI up", a plugin quietly dropped from the `plugins` lane, or a
+ * whole matrix entry removed in a refactor, and Windows coverage regresses
+ * with a still-green pipeline and no reviewer signal.
+ *
+ * This is a static YAML census — it never executes a workflow. It parses the
+ * `commands` lists under `jobs.windows.strategy.matrix.include[]` in
+ * `.github/workflows/windows-ci.yml`, flattens them into a set, and asserts
+ * every command in the committed inventory `.github/ci-windows-command-inventory.json`
+ * is still wired in some lane. If any inventoried command is missing, Windows
+ * coverage shrank: the contract throws (exit 1) naming the dropped commands.
+ *
+ * Adding a command is always allowed — the inventory is a floor, not an exact
+ * match. To intentionally retire a Windows command, delete it from the matrix
+ * AND from the inventory in the same PR; the contract then passes because the
+ * floor moved with it, and the diff makes the coverage reduction reviewable.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_REPO_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+
+const WORKFLOW_FILE = ".github/workflows/windows-ci.yml";
+const INVENTORY_FILE = ".github/ci-windows-command-inventory.json";
+const JOB_KEY = "windows";
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function indentOf(line) {
+  return line.match(/^ */)?.[0].length ?? 0;
+}
+
+// Slice the lines of a single top-level job block (`  <key>:`) out of the
+// `jobs:` section. Job keys are the only 2-space-indented map keys under
+// `jobs:`, so the block runs from that header until the next 2-space key.
+function jobBlockLines(workflowText, jobKey) {
+  const lines = workflowText.split(/\r?\n/);
+  const jobsIndex = lines.findIndex((line) => /^jobs:\s*$/.test(line));
+  assert(jobsIndex >= 0, `${WORKFLOW_FILE}: no top-level "jobs:" mapping`);
+
+  let start = -1;
+  for (let i = jobsIndex + 1; i < lines.length; i += 1) {
+    if (new RegExp(`^ {2}${jobKey}:\\s*$`).test(lines[i])) {
+      start = i;
+      break;
+    }
+  }
+  assert(start >= 0, `${WORKFLOW_FILE}: no "${jobKey}" job under "jobs:"`);
+
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() !== "" && /^ {2}\S/.test(line)) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end);
+}
+
+// Collect every command string from the `commands:` block-sequences inside the
+// job's `strategy.matrix.include[]`. Each `commands:` header opens a YAML list
+// whose items (`- <command>`) sit at a deeper indent; the list ends at the
+// first line indented at or below the header (the next `- lane:` entry or the
+// sibling matrix key). Multiple `include[]` entries each contribute their list.
+export function parseWindowsCommands(repoRoot = DEFAULT_REPO_ROOT) {
+  const text = readFileSync(resolve(repoRoot, WORKFLOW_FILE), "utf8");
+  const lines = jobBlockLines(text, JOB_KEY);
+
+  const commands = [];
+  let listIndent = null;
+  for (const line of lines) {
+    if (line.trim() === "") continue;
+    if (/^\s*commands:\s*$/.test(line)) {
+      listIndent = indentOf(line);
+      continue;
+    }
+    if (listIndent === null) continue;
+
+    const itemIndent = indentOf(line);
+    if (itemIndent <= listIndent) {
+      listIndent = null;
+      continue;
+    }
+    const item = line.slice(itemIndent).match(/^-\s+(.+?)\s*$/);
+    assert(
+      item !== null,
+      `${WORKFLOW_FILE}: malformed command list under "${JOB_KEY}" matrix (got: ${JSON.stringify(line)})`,
+    );
+    commands.push(item[1]);
+  }
+
+  assert(
+    commands.length > 0,
+    `${WORKFLOW_FILE}: parsed no commands from "${JOB_KEY}" strategy.matrix.include[].commands`,
+  );
+  return commands;
+}
+
+export function loadInventory(repoRoot = DEFAULT_REPO_ROOT) {
+  const manifest = JSON.parse(
+    readFileSync(resolve(repoRoot, INVENTORY_FILE), "utf8"),
+  );
+  const inventory = manifest.commands;
+  assert(
+    Array.isArray(inventory) && inventory.every((c) => typeof c === "string"),
+    `${INVENTORY_FILE}: "commands" must be a string array`,
+  );
+  assert(
+    inventory.length > 0,
+    `${INVENTORY_FILE}: "commands" must not be empty`,
+  );
+  return inventory;
+}
+
+// Inventoried commands no longer wired in any Windows lane. A non-empty result
+// means coverage shrank without the inventory being updated to match.
+export function findDroppedCommands(inventory, present) {
+  const wired = new Set(present);
+  return inventory.filter((command) => !wired.has(command));
+}
+
+export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
+  const present = parseWindowsCommands(repoRoot);
+  const inventory = loadInventory(repoRoot);
+  const dropped = findDroppedCommands(inventory, present);
+
+  assert(
+    dropped.length === 0,
+    `Windows CI command coverage shrank. These inventoried commands are no longer wired in any ` +
+      `${WORKFLOW_FILE} lane:\n` +
+      dropped.map((command) => `  - ${command}`).join("\n") +
+      `\n\nRestore them, or — if the reduction is intentional — remove them from ${INVENTORY_FILE} ` +
+      `in the same PR so the coverage floor moves with the matrix.`,
+  );
+
+  return { commandCount: present.length, inventoryCount: inventory.length };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    const { commandCount, inventoryCount } = runContract();
+    console.log(
+      `ci windows command coverage contract passed ` +
+        `(${commandCount} lane command(s); ${inventoryCount} inventoried command(s) all present)`,
+    );
+  } catch (error) {
+    console.error(`[ci-windows-command-coverage-contract] FAIL ${error.message}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
Part of #13402 (CI reliability umbrella).

## What

Adds a static **Windows command-coverage contract** — a YAML census that guards the Windows CI lane against silent coverage shrinkage.

The Windows lane (`.github/workflows/windows-ci.yml`) is a *deliberately narrow subset* of the Linux gates (see `WINDOWS.md`): nothing else re-runs those suites on Windows. That makes silent shrinkage the failure mode — a lane trimmed "to speed CI up", a plugin quietly dropped from the `plugins` lane, or a whole matrix entry removed in a refactor — and Windows coverage regresses with a **still-green pipeline and no reviewer signal**.

## How

- **`packages/scripts/ci-windows-command-coverage-contract.mjs`** — parses the `commands:` lists under `jobs.windows.strategy.matrix.include[]`, flattens them into a set, and asserts every command in the committed inventory is still wired in some lane. If any inventoried command is missing, it **throws + `exit(1)`** naming the dropped command(s). Never executes a workflow. Mirrors the structure/style of the sibling `ci-bun-version-contract.mjs` and `ci-zero-key-command-ownership-contract.mjs`.
- **`.github/ci-windows-command-inventory.json`** — seeded (derived, not guessed) from the **current** `windows-ci.yml` command set (22 commands). It is a **coverage floor, not an exact match**: adding commands is always allowed; intentionally retiring one requires deleting it from the matrix **and** the inventory in the same PR, so the reduction is reviewable in the diff.
- **`packages/scripts/__tests__/ci-windows-command-coverage-contract.test.ts`** — synthetic **RED** fixture (dropped command → throws `/Windows CI command coverage shrank/`) and **GREEN** fixture (all present → passes), plus flatten-across-lanes, add-allowed, empty-inventory-rejected, and a **real-repo positive assertion**.
- **`.github/workflows/test.yml`** — wired as a step in the `changes` job beside the existing `ci-*-contract.mjs` steps.

## Verification

```
$ node packages/scripts/ci-windows-command-coverage-contract.mjs
ci windows command coverage contract passed (22 lane command(s); 22 inventoried command(s) all present)

$ bun test packages/scripts/__tests__/ci-windows-command-coverage-contract.test.ts
 6 pass  0 fail  (RED throws, GREEN passes, real repo satisfies its inventory)

$ actionlint .github/workflows/test.yml .github/workflows/windows-ci.yml   # OK
$ git diff --check                                                          # clean
```

RED path proven end-to-end (synthetic repo, one command dropped from the matrix): the CLI exits `1` and names the missing `bun run --cwd packages/shared test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjaSfQrf3xRDfPXuc9fgeA