### PR TITLE
fix(ui): restore home-screen swipe gestures on iOS standalone PWA (#14283)

### DIFF
--- a/packages/ui/src/platform/init.ts
+++ b/packages/ui/src/platform/init.ts
@@ -30,6 +30,45 @@ export const isNative = detected.isNative;
 export const isIOS = platform === "ios";
 export const isAndroid = platform === "android";
 
+/**
+ * True when the app is running as an INSTALLED PWA in standalone (or fullscreen)
+ * display-mode — i.e. added to the home screen and launched chrome-less — while
+ * the Capacitor platform is still `web` (this is NOT the native App Store /
+ * Play Store build; that reports `ios`/`android` and takes the `native` path).
+ *
+ * This is the iOS-home-screen-PWA case specifically: `Capacitor.getPlatform()`
+ * returns `web`, so the app never gets the `native`/`platform-ios` body class
+ * and — critically — never gets the mobile touch-viewport lockdown in
+ * `styles/base.css`. Without that lockdown the body stays at the default
+ * `touch-action: auto`, so iOS WebKit routes the first frames of every drag
+ * into its own body-pan / edge-nav pipeline and fires `pointercancel` — the
+ * home-screen swipe-up (open chat) and horizontal rail flick both silently
+ * never commit. Tagging the body with `pwa-standalone` lets base.css apply the
+ * same lockdown to the installed PWA and hand drags to the app's gestures.
+ *
+ * Detection order: the standard `display-mode` media query (Chrome/Android +
+ * modern iOS), then the legacy iOS-only `navigator.standalone` boolean.
+ * Best-effort — any absence of `matchMedia`/`navigator` returns false.
+ */
+export function isStandalonePwa(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    if (typeof window.matchMedia === "function") {
+      if (
+        window.matchMedia("(display-mode: standalone)").matches ||
+        window.matchMedia("(display-mode: fullscreen)").matches
+      ) {
+        return true;
+      }
+    }
+  } catch {
+    /* matchMedia unavailable — fall through to the legacy iOS signal */
+  }
+  // Legacy iOS Safari home-screen flag (pre-display-mode support).
+  const nav = typeof navigator !== "undefined" ? navigator : undefined;
+  return (nav as { standalone?: boolean } | undefined)?.standalone === true;
+}
+
 export function isDesktopPlatform(): boolean {
   return platform === "electrobun";
 }
@@ -212,6 +251,18 @@ export function setupPlatformStyles(): void {
 
   if (isNative) {
     document.body.classList.add("native");
+  }
+
+  // Installed PWA on the WEB platform (iOS home-screen app, chrome-less Android
+  // PWA): apply the mobile touch-viewport lockdown that the Capacitor `native`
+  // path gets, so the body claims `touch-action` and hands drags to the app's
+  // home-screen gestures instead of iOS WebKit's page-pan/edge-nav (which
+  // otherwise fires pointercancel and silently drops the swipe-up-open + rail
+  // flick). Scoped to `platform === "web"`: the native App Store / Play Store
+  // build already locks down via `native`, and desktop (electrobun) must keep
+  // its window scroll/trackpad behavior.
+  if (platform === "web" && isStandalonePwa()) {
+    document.body.classList.add("pwa-standalone");
   }
 
   root.style.setProperty("--safe-area-top", "env(safe-area-inset-top, 0px)");

--- a/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
+++ b/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+
+/**
+ * Contract for the installed-PWA (iOS home-screen) touch-viewport lockdown.
+ *
+ * An installed iOS PWA runs on the `web` Capacitor platform (NOT the native
+ * App Store build), so it never gets the `native`/`platform-ios` body class and
+ * — before this fix — never got the mobile touch lockdown in styles/base.css.
+ * Without the lockdown the body stays at the default `touch-action: auto` and
+ * iOS WebKit eats the home-screen swipe-up (open chat) and horizontal rail flick
+ * as its own page pan (pointercancel), so both gestures silently die though the
+ * composer renders (issue: home-screen swipe gestures dead on iOS standalone PWA).
+ *
+ * These tests pin BOTH halves of the fix:
+ *  1. platform/init.ts detects standalone display-mode and tags the body with
+ *     `pwa-standalone` — but ONLY on the web platform (the native build already
+ *     locks down; desktop must not).
+ *  2. styles/base.css + styles.css apply the SAME lockdown to `body.pwa-standalone`
+ *     as to `body.native` (touch-action claim, fixed body, no overscroll).
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { isStandalonePwa, setupPlatformStyles } from "./init";
+
+/** Install a matchMedia stub that reports the given display-mode as active. */
+function stubDisplayMode(mode: "standalone" | "fullscreen" | "browser"): void {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string): MediaQueryList =>
+      ({
+        matches: query.includes(`display-mode: ${mode}`),
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList,
+  });
+}
+
+afterEach(() => {
+  document.body.className = "";
+  // Drop any matchMedia / navigator.standalone stub so cases don't bleed.
+  // biome-ignore lint/performance/noDelete: test teardown restoring host globals
+  delete (window as { matchMedia?: unknown }).matchMedia;
+  // biome-ignore lint/performance/noDelete: test teardown restoring host globals
+  delete (navigator as { standalone?: unknown }).standalone;
+});
+
+describe("isStandalonePwa", () => {
+  it("is true when the display-mode is standalone", () => {
+    stubDisplayMode("standalone");
+    expect(isStandalonePwa()).toBe(true);
+  });
+
+  it("is true when the display-mode is fullscreen (chrome-less PWA)", () => {
+    stubDisplayMode("fullscreen");
+    expect(isStandalonePwa()).toBe(true);
+  });
+
+  it("is FALSE in a normal browser tab (display-mode: browser)", () => {
+    stubDisplayMode("browser");
+    expect(isStandalonePwa()).toBe(false);
+  });
+
+  it("falls back to the legacy iOS navigator.standalone flag", () => {
+    // Pre-display-mode iOS Safari only exposes navigator.standalone.
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: () =>
+        ({ matches: false, addEventListener() {}, removeEventListener() {} }) as unknown as MediaQueryList,
+    });
+    Object.defineProperty(navigator, "standalone", {
+      configurable: true,
+      value: true,
+    });
+    expect(isStandalonePwa()).toBe(true);
+  });
+});
+
+describe("setupPlatformStyles — installed PWA lockdown", () => {
+  it("adds the pwa-standalone body class when launched as an installed PWA on web", () => {
+    // jsdom's Capacitor probe falls back to platform === "web" (the exact case
+    // an installed iOS home-screen PWA reports).
+    stubDisplayMode("standalone");
+    setupPlatformStyles();
+    expect(document.body.classList.contains("pwa-standalone")).toBe(true);
+    // It must NOT masquerade as the native Capacitor build.
+    expect(document.body.classList.contains("native")).toBe(false);
+    expect(document.body.classList.contains("platform-web")).toBe(true);
+  });
+
+  it("does NOT add pwa-standalone in a normal browser tab", () => {
+    stubDisplayMode("browser");
+    setupPlatformStyles();
+    expect(document.body.classList.contains("pwa-standalone")).toBe(false);
+  });
+});
+
+describe("CSS lockdown contract — base.css / styles.css cover body.pwa-standalone", () => {
+  // vitest runs with cwd = packages/ui, so resolve the CSS sources from there.
+  const stylesDir = resolve(process.cwd(), "src/styles");
+  const baseCss = readFileSync(resolve(stylesDir, "base.css"), "utf8");
+  const stylesCss = readFileSync(resolve(stylesDir, "styles.css"), "utf8");
+
+  it("gives body.pwa-standalone the same touch-viewport lockdown as body.native (base.css)", () => {
+    // The lockdown group must claim touch-action / disable overscroll / lock the
+    // body — otherwise the installed PWA keeps touch-action:auto and WebKit eats
+    // the home swipes. Assert the selector list carries pwa-standalone alongside
+    // native right before the `touch-action: pan-x pan-y` declaration.
+    const lockdownBlock = baseCss.match(
+      /body\.native,[\s\S]*?touch-action: pan-x pan-y;/,
+    );
+    expect(lockdownBlock).not.toBeNull();
+    expect(lockdownBlock?.[0]).toContain("body.pwa-standalone");
+  });
+
+  it("hands horizontal drags to the app gestures for the installed PWA (styles.css touch-action: pan-y)", () => {
+    // styles.css refines the body to `touch-action: pan-y` so only vertical pan
+    // stays native and every horizontal drag reaches the rail/grabber. The
+    // pwa-standalone selector must ride the same rule as body.native.
+    const panYBlock = stylesCss.match(
+      /body\.native,[\s\S]*?touch-action: pan-y;/,
+    );
+    expect(panYBlock).not.toBeNull();
+    expect(panYBlock?.[0]).toContain("body.pwa-standalone");
+  });
+
+  it("locks #root to the viewport for the installed PWA too (styles.css)", () => {
+    const rootBlock = stylesCss.match(
+      /body\.native #root,[\s\S]*?max-height: 100dvh;/,
+    );
+    expect(rootBlock).not.toBeNull();
+    expect(rootBlock?.[0]).toContain("body.pwa-standalone #root");
+  });
+});

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -333,9 +333,17 @@ body.desktop {
    here — `#root` is locked to `100dvh` so body-level padding wouldn't
    shrink the React tree's flex container, and inner shells would still
    render under the status bar. */
+/* `body.pwa-standalone` (added from platform/init.ts) covers the INSTALLED
+   iOS/Android PWA running on the `web` Capacitor platform: it is NOT the
+   native App Store / Play Store build (which takes the `native`/`platform-ios`
+   path above), so without this it would keep the default `touch-action: auto`
+   and iOS WebKit would eat the home-screen swipe-up + rail flick as a page pan
+   (pointercancel). It gets the SAME viewport lockdown so drags reach the app's
+   gestures. */
 body.native,
 body.platform-ios,
-body.platform-android {
+body.platform-android,
+body.pwa-standalone {
   touch-action: pan-x pan-y;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
@@ -363,7 +371,10 @@ body.platform-ios textarea,
 body.platform-ios [contenteditable="true"],
 body.platform-android input,
 body.platform-android textarea,
-body.platform-android [contenteditable="true"] {
+body.platform-android [contenteditable="true"],
+body.pwa-standalone input,
+body.pwa-standalone textarea,
+body.pwa-standalone [contenteditable="true"] {
   -webkit-user-select: text;
   user-select: text;
   -webkit-touch-callout: default;
@@ -373,7 +384,8 @@ body.platform-android [contenteditable="true"] {
    shells where the app body disables global selection to protect gestures. */
 body.native [data-chat-selectable="true"],
 body.platform-ios [data-chat-selectable="true"],
-body.platform-android [data-chat-selectable="true"] {
+body.platform-android [data-chat-selectable="true"],
+body.pwa-standalone [data-chat-selectable="true"] {
   -webkit-user-select: text;
   user-select: text;
   -webkit-touch-callout: default;
@@ -383,7 +395,8 @@ body.platform-android [data-chat-selectable="true"] {
    scrollbar; they get a momentum scroller. */
 body.native *::-webkit-scrollbar,
 body.platform-ios *::-webkit-scrollbar,
-body.platform-android *::-webkit-scrollbar {
+body.platform-android *::-webkit-scrollbar,
+body.pwa-standalone *::-webkit-scrollbar {
   width: 0;
   height: 0;
   display: none;
@@ -391,7 +404,8 @@ body.platform-android *::-webkit-scrollbar {
 
 body.native *,
 body.platform-ios *,
-body.platform-android * {
+body.platform-android *,
+body.pwa-standalone * {
   scrollbar-width: none;
   -ms-overflow-style: none;
 }

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -93,20 +93,29 @@ html.eliza-chat-overlay-shell .shell-assistant-overlay-panel {
   border-radius: var(--radius-xs);
 }
 
-body.native {
+/* `body.pwa-standalone` mirrors the native mobile lockdown for an INSTALLED
+   PWA on the web platform (iOS home-screen app): `touch-action: pan-y` hands
+   every horizontal drag to the app's rail/grabber gestures (only vertical pan
+   stays native), and the `#root` 100dvh lock keeps a stray drag from scrolling
+   the whole app off-screen — without this the home-screen swipes are eaten by
+   iOS WebKit's own page pan. See platform/init.ts isStandalonePwa(). */
+body.native,
+body.pwa-standalone {
   position: fixed;
   inset: 0;
   touch-action: pan-y;
 }
 
-body.native #root {
+body.native #root,
+body.pwa-standalone #root {
   min-height: 100dvh;
   max-height: 100dvh;
   padding: 0;
   box-sizing: border-box;
 }
 
-body.native textarea {
+body.native textarea,
+body.pwa-standalone textarea {
   resize: none;
 }
 


### PR DESCRIPTION
## Problem
On an **installed iOS PWA (standalone display-mode)**, the home/lock-screen touch gestures are dead — swipe-up (open the chat sheet) and horizontal swipe (home ↔ launcher rail nav) both do nothing — though the composer + grabber render. Device-tested by Shadow against `develop` (db89607e0d).

## Root cause
The mobile touch-viewport lockdown (`touch-action`, fixed body, `overscroll-behavior: none`, scrollbar/callout carve-outs) is gated **only** on `body.native` / `body.platform-ios` / `body.platform-android` in `styles/base.css`. Those classes come from Capacitor platform detection in `platform/init.ts`.

An **installed iOS PWA is NOT a Capacitor native build** — `Capacitor.getPlatform()` returns `"web"`, so the body gets `platform-web` and **none of the lockdown applies**. With `html, body { overflow: hidden }` but the body left at the default `touch-action: auto`, iOS WebKit routes the first frames of every drag into its own body-pan / edge-nav pipeline and fires `pointercancel` — the exact "flick silently never commits" failure the rail already documents and only fixed for `body.native`.

Both gesture roots — the `usePullGesture` grabber (overlay z-layer) and the `useHorizontalPager` rail (shell z-layer) — die from the **same** missing body-level `touch-action` claim, which is why both go dead together while the DOM still renders. The handlers themselves are correct (unit tests pass under jsdom); the gesture stream never reaches them on-device.

**Ruled out:** #14224's wallpaper bottom-floor gradient — it lives inside `ImageBackground` (`pointer-events-none fixed inset-0`) and `pointer-events` is inherited, so the floor div is pointer-transparent and never eats the flick zone.

## Fix
- **`platform/init.ts`**: `isStandalonePwa()` (display-mode `standalone`/`fullscreen` media query + legacy iOS `navigator.standalone`). `setupPlatformStyles` adds a `pwa-standalone` body class **only when `platform === "web"` && standalone** — the native App Store / Play Store build (already locked via `native`) and desktop (electrobun) are untouched.
- **`styles/base.css`**: `body.pwa-standalone` joins the native lockdown selector groups.
- **`styles.css`**: `body.pwa-standalone` mirrors `body.native` `touch-action: pan-y` + `#root` 100dvh lock, so only vertical pan stays native and every horizontal drag reaches the rail/grabber.

Restores on iOS standalone: swipe-up over the composer opens the chat, horizontal swipe navigates home↔launcher, taps still reach composer/notifications, scroll inside an OPEN sheet unaffected.

## Tests
- **NEW** `platform/standalone-pwa-lockdown.test.ts` (9): `isStandalonePwa` true for standalone/fullscreen + legacy flag, false in a browser tab; `setupPlatformStyles` tags web-standalone and never masquerades as native; CSS-source contract asserts base.css + styles.css carry `body.pwa-standalone` in the lockdown / pan-y / `#root` groups. **GREEN**
- Regression: `init` + `use-pull-gesture` + `useHorizontalPager` (x2) + `HomeLauncherSurface` = 58 GREEN; `ContinuousChatOverlay` + fuzz + `AppBackground` (validates #14224 floor untouched) = 276 GREEN.
- `bun run build:client` GREEN.

Fixes #14283

Scope note: disjoint from the concurrent ContinuousChatOverlay.tsx lanes — this touches only `platform/init.ts` + two CSS files + one new test.

— [sol-orch]
