### PR TITLE
fix(ui): stop leaking topic machine labels in chat sheet, kill PWA scrollbar chrome, deslop home notification card

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -407,9 +407,7 @@ describe("ContinuousChatOverlay", () => {
     // (wallpaper on shared-background routes), the repaint band WAS the
     // residual visible gap on the standalone home view. It must stay gone.
     render(<ContinuousChatOverlay controller={makeController()} />);
-    expect(
-      screen.queryByTestId("continuous-chat-bottom-floor"),
-    ).toBeNull();
+    expect(screen.queryByTestId("continuous-chat-bottom-floor")).toBeNull();
   });
 
   it("blurs the focused composer when the active view leaves chat (drops the iOS accessory bar)", () => {
@@ -856,6 +854,77 @@ describe("ContinuousChatOverlay", () => {
     expect(log?.querySelectorAll('[data-testid="thread-line"]').length).toBe(1);
   });
 
+  it("hides the topic chips bar + dividers on a single-topic thread", () => {
+    // The lock-screen leak: a fresh thread whose only Stage-1 topic is
+    // `greeting` was rendering a grey `greeting` chip top-left and a
+    // "— GREETING —" divider above the only message. One topic group must
+    // open clean — no chips rail, no divider.
+    render(
+      <ContinuousChatOverlay
+        controller={makeController({
+          messages: [
+            {
+              id: "a",
+              role: "assistant",
+              content: "hey, how can I help?",
+              createdAt: 1,
+              topics: ["greeting"],
+            },
+            {
+              id: "b",
+              role: "user",
+              content: "just saying hi",
+              createdAt: 2,
+              topics: ["greeting"],
+            },
+          ],
+        } as unknown as Partial<ShellController>)}
+      />,
+    );
+    fireEvent.focus(screen.getByLabelText("message"));
+    expect(screen.queryByTestId("topic-chips-bar")).toBeNull();
+    expect(screen.queryByTestId("topic-group-header")).toBeNull();
+    expect(screen.queryByTestId("topic-group-pill")).toBeNull();
+    // The message still renders — gating only removes the topic chrome.
+    const log = document.getElementById("continuous-thread");
+    expect(log?.textContent).toContain("how can I help");
+  });
+
+  it("shows the chips bar + dividers once the thread spans two topics", () => {
+    render(
+      <ContinuousChatOverlay
+        controller={makeController({
+          messages: [
+            {
+              id: "a",
+              role: "user",
+              content: "deploy failing",
+              createdAt: 1,
+              topics: ["deployment"],
+            },
+            {
+              id: "b",
+              role: "user",
+              content: "and my card was charged twice",
+              createdAt: 2,
+              topics: ["billing"],
+            },
+          ],
+        } as unknown as Partial<ShellController>)}
+      />,
+    );
+    fireEvent.focus(screen.getByLabelText("message"));
+    expect(screen.getByTestId("topic-chips-bar")).toBeTruthy();
+    // Two distinct topics → two group dividers, labels humanized.
+    expect(screen.getAllByTestId("topic-group-header").length).toBe(2);
+    expect(screen.getByTestId("topic-chips-bar").textContent).toContain(
+      "Deployment",
+    );
+    expect(screen.getByTestId("topic-chips-bar").textContent).toContain(
+      "Billing",
+    );
+  });
+
   it("aligns the assistant bubble left and the user bubble right", () => {
     render(
       <ContinuousChatOverlay
@@ -885,9 +954,7 @@ describe("ContinuousChatOverlay", () => {
     );
     fireEvent.focus(screen.getByLabelText("message"));
     // The status indicator sits inside a left-aligned, full-width assistant row.
-    const row = screen
-      .getByTestId("turn-status-indicator")
-      .closest(".w-full");
+    const row = screen.getByTestId("turn-status-indicator").closest(".w-full");
     expect(row?.className).toContain("w-full");
     expect(row?.className).toContain("justify-start");
   });

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -104,7 +104,12 @@ import { SlashCommandMenu, useSlashMenu } from "./SlashCommandMenu";
 import { type ShellMessage, selectVisibleShellMessages } from "./shell-state";
 import { TopicChipsBar } from "./TopicChipsBar";
 import { TopicGroup } from "./TopicGroup";
-import { deriveChannelTopics, groupMessagesByTopic } from "./topic-grouping";
+import {
+  deriveChannelTopics,
+  groupMessagesByTopic,
+  hasMultipleTopicGroups,
+  humanizeTopicLabel,
+} from "./topic-grouping";
 import { type PullGestureBinding, usePullGesture } from "./use-pull-gesture";
 import { usePromptSuggestions } from "./usePromptSuggestions";
 import type { ConversationNav, ShellController } from "./useShellController";
@@ -1454,17 +1459,24 @@ export function ContinuousChatOverlay({
   ]);
 
   // Topic grouping + chips bar (#8928). Derived from the per-message Stage-1
-  // topic tags; when no message is tagged the transcript renders flat (the
-  // chips bar and groups simply don't appear), preserving the prior behavior.
-  const channelTopics = React.useMemo(
-    () => deriveChannelTopics(visibleMessages),
-    [visibleMessages],
-  );
+  // topic tags. The chips rail and dividers ONLY earn their pixels once a
+  // transcript genuinely spans MULTIPLE topics — a fresh/single-subject thread
+  // renders flat so the lock-screen chat opens clean (no machine-topic pill
+  // top-left, no "— GREETING —" divider above the only group). See
+  // `hasMultipleTopicGroups`. Chip labels are humanized from the tagger's
+  // machine slugs (`user_greeting` → "User Greeting").
   const topicSegments = React.useMemo(
     () => groupMessagesByTopic(visibleMessages),
     [visibleMessages],
   );
-  const hasTopics = channelTopics.length > 0;
+  const hasTopics = React.useMemo(
+    () => hasMultipleTopicGroups(topicSegments),
+    [topicSegments],
+  );
+  const channelTopics = React.useMemo(
+    () => deriveChannelTopics(visibleMessages),
+    [visibleMessages],
+  );
   const [collapsedTopics, setCollapsedTopics] = React.useState<
     ReadonlySet<string>
   >(() => new Set<string>());
@@ -4087,7 +4099,13 @@ export function ContinuousChatOverlay({
                   // overflow region on iOS can fail to take the touch-scroll at
                   // all (the transcript reads as "stuck" — #chat-scroll-web).
                   // Harmless/ignored on every non-WebKit engine.
-                  className="relative flex min-h-0 w-full flex-1 touch-pan-y flex-col overflow-y-auto overscroll-contain px-5 [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden"
+                  // `overflow-x-hidden`: `overflow-y-auto` alone computes the
+                  // cross axis to `auto` too, so a child a hair too wide (a
+                  // long code line, the full-bleed chips rail) surfaces a
+                  // horizontal scrollbar strip across the sheet on iOS — the
+                  // "weird side scroll thingy." This transcript only ever scrolls
+                  // vertically; pin the horizontal axis closed.
+                  className="relative flex min-h-0 w-full flex-1 touch-pan-y flex-col overflow-y-auto overflow-x-hidden overscroll-contain px-5 [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden"
                   style={{ opacity: threadContentOpacity }}
                 >
                   {/* Empty-thread loading: a fresh/cleared chat awaiting its

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -200,4 +200,40 @@ describe("NotificationsHomeCenter", () => {
     render(<NotificationsHomeCenter />);
     expect(screen.getAllByTestId("notification-row")).toHaveLength(100);
   });
+
+  it("renders a normal row with no priority rail (lock-screen restraint)", () => {
+    __ingestNotificationForTests(
+      makeNotification({ priority: "normal", title: "Quiet one" }),
+    );
+    render(<NotificationsHomeCenter />);
+    // A normal notification is just its line + time — no leading accent rail,
+    // no per-row icon chip (the box-in-a-box slop is gone).
+    expect(screen.queryByTestId("notification-row-accent")).toBeNull();
+    expect(screen.queryByTestId("notification-row-icon")).toBeNull();
+  });
+
+  it("shows a priority rail only for urgent/high rows", () => {
+    __ingestNotificationForTests(
+      makeNotification({ priority: "urgent", title: "Urgent" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ priority: "high", title: "High" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ priority: "low", title: "Low" }),
+    );
+    render(<NotificationsHomeCenter />);
+    // Two elevated rows carry the rail; the low row does not.
+    expect(screen.getAllByTestId("notification-row-accent")).toHaveLength(2);
+  });
+
+  it("is a quiet glass surface, not a heavy filled card", () => {
+    __ingestNotificationForTests(makeNotification());
+    render(<NotificationsHomeCenter />);
+    const card = screen.getByTestId("home-notification-center");
+    // Hairline border + translucent surface (lock-screen glass), not the old
+    // opaque `bg-card` box with a solid `border-border`.
+    expect(card.className).toContain("backdrop-blur");
+    expect(card.className).not.toContain("border-border");
+  });
 });

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -17,11 +17,10 @@
  * marks it read) never reshuffles the list under the user's finger.
  */
 import type { AgentNotification } from "@elizaos/core";
-import { Bell, CheckCheck, Trash2, X } from "lucide-react";
+import { CheckCheck, Trash2, X } from "lucide-react";
 import { useCallback, useEffect, useRef } from "react";
 import { useNow } from "../../hooks/useNow";
 import { cn } from "../../lib/utils";
-import { categoryIcon } from "../../state/notifications/category-icon";
 import {
   isSafeDeepLink,
   navigateDeepLink,
@@ -153,14 +152,31 @@ function NotificationRow({
   const unread = !notification.readAt;
   const urgent = notification.priority === "urgent";
   const high = notification.priority === "high";
+  // Lock-screen restraint: NO per-row icon chip (a box inside a box inside the
+  // card). Priority is carried by a hairline accent rail on the leading edge —
+  // present only for urgent/high — and an unread state by a single dot, so a
+  // quiet normal notification is just its line + time, like an iOS lock note.
+  const accent = urgent ? "bg-danger" : high ? "bg-accent" : null;
   return (
     <li className="eliza-notif-row" data-notif-row>
       <div
         className={cn(
-          "eliza-notif-row-inner group relative flex items-start rounded-xl transition-colors duration-150 hover:bg-bg-hover",
-          unread && "bg-bg-hover/60",
+          "eliza-notif-row-inner group relative flex items-stretch overflow-hidden rounded-xl transition-colors duration-150 hover:bg-bg-hover",
+          unread && "bg-bg-hover/50",
         )}
       >
+        {/* Priority rail: a 2px edge tint, urgent/high only. The row without
+            it reads as ordinary — restraint over decoration. */}
+        {accent ? (
+          <span
+            aria-hidden
+            data-testid="notification-row-accent"
+            className={cn(
+              "absolute inset-y-1.5 left-0 w-0.5 rounded-full",
+              accent,
+            )}
+          />
+        ) : null}
         <button
           type="button"
           data-testid="notification-row"
@@ -169,57 +185,41 @@ function NotificationRow({
             notification.body ? `. ${notification.body}` : ""
           }${unread ? ". Unread." : ""}`}
           onClick={() => onOpen(notification)}
-          className="flex min-h-touch min-w-0 flex-1 items-start gap-2.5 rounded-xl px-2 py-2 pr-9 text-left active:scale-[0.99] motion-reduce:active:scale-100 pointer-coarse:pr-11"
+          className="flex min-h-touch min-w-0 flex-1 flex-col gap-0.5 rounded-xl px-3 py-2 pr-9 text-left active:scale-[0.99] motion-reduce:active:scale-100 pointer-coarse:pr-11"
         >
-          <span
-            className={cn(
-              "mt-px inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg [&>svg]:h-3.5 [&>svg]:w-3.5",
-              urgent
-                ? "bg-danger/15 text-danger"
-                : high
-                  ? "bg-accent-subtle text-accent"
-                  : "bg-bg-muted text-muted",
-            )}
-            data-testid="notification-row-icon"
-            aria-hidden
-          >
-            {categoryIcon(notification.category)}
-          </span>
-          <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-            <span className="flex items-center gap-1.5">
-              {unread ? (
-                <span
-                  aria-hidden
-                  data-testid="notification-unread-dot"
-                  className={cn(
-                    "h-1.5 w-1.5 shrink-0 rounded-full",
-                    urgent ? "bg-danger" : "bg-accent",
-                  )}
-                />
-              ) : null}
+          <span className="flex items-baseline gap-1.5">
+            {unread ? (
               <span
+                aria-hidden
+                data-testid="notification-unread-dot"
                 className={cn(
-                  "truncate text-sm",
-                  unread
-                    ? "font-semibold text-txt"
-                    : "font-medium text-muted-strong",
+                  "mb-px h-1.5 w-1.5 shrink-0 self-center rounded-full",
+                  urgent ? "bg-danger" : "bg-accent",
                 )}
-              >
-                {notification.title}
-              </span>
-              <time
-                className="ml-auto shrink-0 pl-2 text-2xs tabular-nums text-muted"
-                data-testid="notification-row-time"
-              >
-                {formatRelativeTime(notification.createdAt)}
-              </time>
-            </span>
-            {notification.body ? (
-              <span className="line-clamp-2 text-xs text-muted-strong">
-                {notification.body}
-              </span>
+              />
             ) : null}
+            <span
+              className={cn(
+                "truncate text-sm",
+                unread
+                  ? "font-semibold text-txt"
+                  : "font-medium text-muted-strong",
+              )}
+            >
+              {notification.title}
+            </span>
+            <time
+              className="ml-auto shrink-0 pl-2 text-2xs tabular-nums text-muted"
+              data-testid="notification-row-time"
+            >
+              {formatRelativeTime(notification.createdAt)}
+            </time>
           </span>
+          {notification.body ? (
+            <span className="line-clamp-2 text-xs leading-snug text-muted">
+              {notification.body}
+            </span>
+          ) : null}
         </button>
         {/* Visible at rest (dimmed) — on touch there is no hover, and an
             invisible dismiss silently ate near-edge taps in the old center. */}
@@ -229,7 +229,7 @@ function NotificationRow({
           aria-label="Dismiss notification"
           data-testid="notification-row-dismiss"
           onClick={() => onDismiss(notification.id)}
-          className="absolute right-1 top-1.5 h-auto w-auto shrink-0 rounded-full p-1.5 text-muted opacity-50 transition-opacity pointer-coarse:min-h-touch pointer-coarse:min-w-touch hover:bg-bg-hover hover:text-txt group-hover:opacity-100"
+          className="absolute right-1 top-1.5 h-auto w-auto shrink-0 rounded-full p-1.5 text-muted opacity-40 transition-opacity pointer-coarse:min-h-touch pointer-coarse:min-w-touch hover:bg-bg-hover hover:text-txt group-hover:opacity-100"
         >
           <X className="h-3.5 w-3.5" />
         </Button>
@@ -293,21 +293,24 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
       data-testid="home-notification-center"
       // The card owns its gap from the editorial header above (mt-4) so a
       // hidden widget (null render) leaves no dead spacer in the column.
-      className="mt-4 flex flex-col overflow-hidden rounded-2xl border border-border bg-card"
+      //
+      // Lock-screen glass, not a chrome box: a single hairline border + a
+      // faintly translucent surface over the wallpaper (backdrop-blur where
+      // supported), no heavy filled card. This reads as an iOS lock-screen
+      // notification stack sitting on the home field rather than an app card.
+      className="mt-4 flex flex-col overflow-hidden rounded-2xl border border-txt/10 bg-card/70 backdrop-blur-xl supports-[backdrop-filter]:bg-card/55"
     >
       <style>{NOTIF_SCROLL_CSS}</style>
-      {/* Pinned header: eyebrow label + unread badge, mark-all-read + clear. */}
-      <div className="flex shrink-0 items-center gap-2 px-3.5 pb-1 pt-2.5">
-        <span className="inline-flex h-6 w-6 items-center justify-center rounded-lg bg-accent-subtle text-accent">
-          <Bell className="h-3.5 w-3.5" aria-hidden />
-        </span>
-        <span className="text-xs-tight font-medium uppercase tracking-[0.08em] text-muted">
+      {/* Pinned header: a quiet eyebrow + unread count, actions to the right.
+          No boxed bell chip — the label alone names the surface. */}
+      <div className="flex shrink-0 items-center gap-1.5 px-3.5 pb-1 pt-2.5">
+        <span className="text-2xs font-medium uppercase tracking-[0.1em] text-muted">
           Notifications
         </span>
         {unreadCount > 0 ? (
           <span
             data-testid="notifications-unread-badge"
-            className="rounded-full bg-accent-subtle px-1.5 py-0.5 text-2xs font-semibold tabular-nums leading-none text-accent"
+            className="text-2xs font-semibold tabular-nums leading-none text-accent"
           >
             {unreadCount > 99 ? "99+" : unreadCount}
           </span>

--- a/packages/ui/src/components/shell/TopicChipsBar.tsx
+++ b/packages/ui/src/components/shell/TopicChipsBar.tsx
@@ -4,6 +4,7 @@
 import type * as React from "react";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
+import { humanizeTopicLabel } from "./topic-grouping";
 
 /**
  * Horizontal topic chips above the transcript (#8928). Shows the channel's
@@ -34,6 +35,9 @@ export function TopicChipsBar({
     >
       {topics.map((topic) => {
         const active = activeTopic != null && activeTopic === topic;
+        // Show a human label; keep the raw slug as the key/identity so the
+        // scroll-to-topic lookup (data-topic on the group) still matches.
+        const label = humanizeTopicLabel(topic) ?? topic;
         return (
           <Button
             key={topic}
@@ -49,7 +53,7 @@ export function TopicChipsBar({
                 : "border-white/15 bg-white/10 text-white/70 hover:bg-white/20 hover:text-white",
             )}
           >
-            {topic}
+            {label}
           </Button>
         );
       })}

--- a/packages/ui/src/components/shell/TopicGroup.tsx
+++ b/packages/ui/src/components/shell/TopicGroup.tsx
@@ -6,6 +6,7 @@ import type * as React from "react";
 import { useClickSuppression } from "../../gestures";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
+import { humanizeTopicLabel } from "./topic-grouping";
 import { usePullGesture } from "./use-pull-gesture";
 
 /**
@@ -78,6 +79,9 @@ function TitledTopicGroup({
     onPullUp: () => toggleFromGesture(true),
     onPullDown: () => toggleFromGesture(false),
   });
+  // Human label for display; `data-topic` + aria keep the raw slug so the
+  // chip scroll-into-view lookup and collapse keying stay stable.
+  const label = humanizeTopicLabel(topic) ?? topic;
 
   return (
     <div
@@ -104,7 +108,7 @@ function TitledTopicGroup({
             className="h-1.5 w-1.5 shrink-0 rounded-full bg-white/60"
             aria-hidden
           />
-          <span className="truncate text-[13px] font-medium">{topic}</span>
+          <span className="truncate text-[13px] font-medium">{label}</span>
           <span className="ml-auto shrink-0 text-[11px] text-white/45">
             {count} {count === 1 ? "message" : "messages"}
           </span>
@@ -125,7 +129,7 @@ function TitledTopicGroup({
         >
           <span className="h-px flex-1 bg-white/10" aria-hidden />
           <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide">
-            {topic}
+            {label}
           </span>
           <span className="h-px flex-1 bg-white/10" aria-hidden />
         </Button>

--- a/packages/ui/src/components/shell/topic-grouping.test.ts
+++ b/packages/ui/src/components/shell/topic-grouping.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, it } from "vitest";
 import {
   deriveChannelTopics,
   groupMessagesByTopic,
+  hasMultipleTopicGroups,
+  humanizeTopicLabel,
   MAX_TOPIC_CHIPS,
   type TopicTaggedMessage,
 } from "./topic-grouping";
@@ -83,5 +85,70 @@ describe("deriveChannelTopics", () => {
       m(`${i}`, [`topic-${i}`]),
     );
     expect(deriveChannelTopics(many)).toHaveLength(MAX_TOPIC_CHIPS);
+  });
+});
+
+describe("hasMultipleTopicGroups", () => {
+  it("is false for an all-untitled transcript (no topics)", () => {
+    const segments = groupMessagesByTopic([m("1"), m("2")]);
+    expect(hasMultipleTopicGroups(segments)).toBe(false);
+  });
+
+  it("is false for a single-topic thread (the divider would be noise)", () => {
+    // A fresh thread whose only topic is `greeting` — the exact leak Shadow
+    // saw: one titled group must NOT trigger the chips bar or a divider.
+    const segments = groupMessagesByTopic([
+      m("1", ["greeting"]),
+      m("2", ["greeting"]),
+    ]);
+    expect(hasMultipleTopicGroups(segments)).toBe(false);
+  });
+
+  it("is false when a leading untitled run adopts one topic", () => {
+    const segments = groupMessagesByTopic([m("1"), m("2", ["billing"])]);
+    expect(segments).toHaveLength(1);
+    expect(hasMultipleTopicGroups(segments)).toBe(false);
+  });
+
+  it("is true once two DISTINCT topics are present", () => {
+    const segments = groupMessagesByTopic([
+      m("1", ["billing"]),
+      m("2", ["deployment"]),
+    ]);
+    expect(hasMultipleTopicGroups(segments)).toBe(true);
+  });
+
+  it("counts distinct topics, not segment runs (A → B → A is multi)", () => {
+    const segments = groupMessagesByTopic([
+      m("1", ["billing"]),
+      m("2", ["deployment"]),
+      m("3", ["billing"]),
+    ]);
+    expect(segments).toHaveLength(3);
+    expect(hasMultipleTopicGroups(segments)).toBe(true);
+  });
+});
+
+describe("humanizeTopicLabel", () => {
+  it("title-cases snake_case slugs", () => {
+    expect(humanizeTopicLabel("user_greeting")).toBe("User Greeting");
+  });
+
+  it("title-cases kebab and dotted slugs", () => {
+    expect(humanizeTopicLabel("deploy-status")).toBe("Deploy Status");
+    expect(humanizeTopicLabel("billing.refund")).toBe("Billing Refund");
+  });
+
+  it("title-cases a bare single-word slug", () => {
+    expect(humanizeTopicLabel("greeting")).toBe("Greeting");
+  });
+
+  it("leaves an already-human multi-word label untouched", () => {
+    expect(humanizeTopicLabel("Q3 planning notes")).toBe("Q3 planning notes");
+  });
+
+  it("returns null for an empty/whitespace label", () => {
+    expect(humanizeTopicLabel("")).toBeNull();
+    expect(humanizeTopicLabel("   ")).toBeNull();
   });
 });

--- a/packages/ui/src/components/shell/topic-grouping.ts
+++ b/packages/ui/src/components/shell/topic-grouping.ts
@@ -29,6 +29,28 @@ export interface TopicSegment<T extends TopicTaggedMessage> {
 /** Maximum chips rendered in the topic bar before the rest are summarized. */
 export const MAX_TOPIC_CHIPS = 12;
 
+/**
+ * Humanize a Stage-1 topic id for display. The tagger emits machine-y labels —
+ * snake_case / kebab-case / dotted slugs (`user_greeting`, `deploy-status`,
+ * `billing.refund`) — that read as noise in the transcript. Turn a slug into
+ * Title Case words; leave already-human labels (those with a space or other
+ * non-slug characters) untouched. Returns null only for an empty/whitespace
+ * label so callers can fall back to the raw value.
+ */
+export function humanizeTopicLabel(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  // Slug detection: only letters/digits and the separators . _ -, no spaces.
+  const isSlug = /^[a-z0-9]+([._-][a-z0-9]+)*$/i.test(trimmed);
+  if (!isSlug) return trimmed;
+  const words = trimmed
+    .split(/[._-]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
+  if (words.length === 0) return null;
+  return words.join(" ");
+}
+
 function dominantTopic(message: TopicTaggedMessage): string | null {
   const topics = message.topics;
   if (!Array.isArray(topics)) return null;
@@ -72,6 +94,25 @@ export function groupMessagesByTopic<T extends TopicTaggedMessage>(
     }
   }
   return segments;
+}
+
+/**
+ * Whether the transcript spans genuinely MULTIPLE topics — the only case where
+ * the chips bar and topic dividers earn their pixels. A fresh thread with one
+ * (or zero) tagged topic must open clean: no chips rail, no divider above the
+ * only group. "Multiple" = at least two DISTINCT titled topics present, so a
+ * long single-subject thread (or an untitled leading run that later adopts one
+ * topic) stays flat. Pass the already-computed segments to avoid re-walking.
+ */
+export function hasMultipleTopicGroups(
+  segments: readonly TopicSegment<TopicTaggedMessage>[],
+): boolean {
+  const distinct = new Set<string>();
+  for (const segment of segments) {
+    if (segment.topic) distinct.add(segment.topic);
+    if (distinct.size >= 2) return true;
+  }
+  return false;
 }
 
 /**

--- a/packages/ui/src/components/shell/topic-views.test.tsx
+++ b/packages/ui/src/components/shell/topic-views.test.tsx
@@ -32,6 +32,32 @@ describe("TopicChipsBar", () => {
       container.querySelector('[data-testid="topic-chips-bar"]'),
     ).toBeNull();
   });
+
+  it("humanizes machine slug labels but keeps the raw slug as identity", () => {
+    const onSelectTopic = vi.fn();
+    render(
+      <TopicChipsBar
+        topics={["user_greeting", "deploy-status"]}
+        onSelectTopic={onSelectTopic}
+      />,
+    );
+    // Display is humanized …
+    expect(screen.getByText("User Greeting")).toBeTruthy();
+    expect(screen.getByText("Deploy Status")).toBeTruthy();
+    // … while the testid (and the scroll-to lookup) stays on the raw slug.
+    fireEvent.click(screen.getByTestId("topic-chip-user_greeting"));
+    expect(onSelectTopic).toHaveBeenCalledWith("user_greeting");
+  });
+
+  it("keeps the chip rail scrollbar-free (touch never shows chrome)", () => {
+    render(<TopicChipsBar topics={["billing", "deployment"]} />);
+    const rail = screen.getByTestId("topic-chips-bar");
+    // The horizontal overflow rail must hide its scrollbar on every engine:
+    // Firefox (`scrollbar-width:none`) and WebKit (`::-webkit-scrollbar`).
+    expect(rail.className).toContain("[scrollbar-width:none]");
+    expect(rail.className).toContain("[&::-webkit-scrollbar]:hidden");
+    expect(rail.className).toContain("overflow-x-auto");
+  });
 });
 
 describe("TopicGroup", () => {
@@ -48,7 +74,8 @@ describe("TopicGroup", () => {
       </TopicGroup>,
     );
     const pill = screen.getByTestId("topic-group-pill");
-    expect(pill.textContent).toContain("deployment");
+    // Label is humanized for display; the group keeps the raw slug in data-topic.
+    expect(pill.textContent).toContain("Deployment");
     expect(pill.textContent).toContain("12 messages");
     // Children are hidden while collapsed.
     expect(screen.queryByTestId("group-child")).toBeNull();
@@ -69,6 +96,26 @@ describe("TopicGroup", () => {
     );
     expect(screen.getByTestId("group-child")).toBeTruthy();
     expect(screen.getByTestId("topic-group-header")).toBeTruthy();
+  });
+
+  it("humanizes the divider label while keeping data-topic raw", () => {
+    render(
+      <TopicGroup
+        topic="deploy_status"
+        count={2}
+        collapsed={false}
+        onCollapsedChange={() => {}}
+      >
+        <div data-testid="group-child">visible</div>
+      </TopicGroup>,
+    );
+    const group = screen.getByTestId("topic-group");
+    // Raw slug persists as the scroll-into-view + collapse identity.
+    expect(group.getAttribute("data-topic")).toBe("deploy_status");
+    // Divider shows the human label, not the slug.
+    expect(screen.getByTestId("topic-group-header").textContent).toContain(
+      "Deploy Status",
+    );
   });
 
   it("renders an untitled run with no header/pill", () => {

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -396,6 +396,49 @@ body.platform-android * {
   -ms-overflow-style: none;
 }
 
+/* Installed PWA (iOS/Android "Add to Home Screen", desktop install) runs as a
+   web build — Capacitor reports NOT native — so it misses the `body.native`
+   scrollbar reset above and inherits the global 10px chrome scrollbar from
+   styles.css. On a standalone install that chrome bar reads as a stray grey
+   track down the sheet edge (and a horizontal strip above the composer) — the
+   "weird side scroll thingy." A standalone display-mode is a full-screen app,
+   not a browser tab: kill the scrollbar chrome and let momentum scrolling
+   carry. Scoped to display-mode so an in-browser tab keeps its scrollbar. */
+@media (display-mode: standalone), (display-mode: fullscreen),
+  (display-mode: minimal-ui) {
+  /* biome-ignore lint/style/noDescendingSpecificity: universal scrollbar reset is intentional (matches styles.css). */
+  *::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+    display: none;
+  }
+  /* biome-ignore lint/style/noDescendingSpecificity: universal scrollbar reset is intentional (matches styles.css). */
+  * {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+}
+
+/* Coarse pointers (touch) never benefit from a draggable scrollbar — there is
+   no cursor to grab it, and the thumb only steals a strip of the reading
+   surface. A touch phone in the browser (not yet installed) still showed the
+   universal 10px scrollbar over the chat sheet; hide the chrome on any coarse
+   pointer so touch scrolling stays edge-to-edge and invisible, matching the
+   native shell. Fine-pointer (mouse) desktop keeps the styled scrollbar. */
+@media (pointer: coarse) {
+  /* biome-ignore lint/style/noDescendingSpecificity: universal scrollbar reset is intentional (matches styles.css). */
+  *::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+    display: none;
+  }
+  /* biome-ignore lint/style/noDescendingSpecificity: universal scrollbar reset is intentional (matches styles.css). */
+  * {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+}
+
 /* ─── Brand theme variants ───────────────────────────────────────────
    Each marketing surface picks one of these by setting the class on
    <html> or <body>. Shared palette, different center of gravity:


### PR DESCRIPTION
## Summary

Taste pass on the core chat surface after Shadow's iOS-standalone device test ("gotta deslop hard as chat is the core"). Three surgical fixes, no behavior rewrites.

### 1. Topic machine labels leaked on single-topic threads (#8928)

A fresh thread opened with a grey lowercase `greeting` chip top-left and a `— GREETING —` divider above the only message — raw Stage-1 topic ids in the UI.

- New `hasMultipleTopicGroups(segments)`: the chips bar + topic dividers now only render once the transcript spans **2+ distinct titled topics**. One (or zero) topic → flat transcript, the lock-screen chat opens clean.
- New `humanizeTopicLabel(raw)`: machine slugs (`user_greeting`, `deploy-status`, `billing.refund`) display as Title Case (`User Greeting`); already-human labels pass through. The **raw slug stays the identity** for chip→group scroll-into-view (`data-topic`) and collapse keying.

### 2. "Weird side scroll thingy" — scrollbar chrome on the sheet

Root cause: the universal styled 10px scrollbar in `styles.css` applies to installed PWAs because Capacitor reports a standalone install as **not native**, so it misses the `body.native` scrollbar reset in `base.css`. That's the grey track down the sheet edge + the horizontal strip above the composer.

- `base.css`: hide scrollbar chrome under `display-mode: standalone/fullscreen/minimal-ui` and `pointer: coarse` (touch has no cursor to grab a thumb; fine-pointer desktop keeps the styled scrollbar).
- Chat transcript scroller: `overflow-x-hidden` (with `overflow-y-auto` alone, the cross axis computes to `auto`, so a slightly-too-wide child surfaced a horizontal bar). The chips rail already carried `[scrollbar-width:none]` + webkit hidden; now contract-tested.

### 3. Home autonomy notification card deslop

`NotificationsHomeCenter` was a heavy filled card with borders-on-borders: boxed Bell chip in the header, a rounded icon box on every row. Redesigned to lock-screen restraint:

- Quiet glass: hairline `border-txt/10` + translucent `bg-card/55` with `backdrop-blur-xl` (graceful fallback to `bg-card/70` without backdrop-filter support).
- Rows: one clear title line + tabular timestamp; body as secondary. Per-row icon boxes gone; priority is a 2px leading rail on urgent/high rows ONLY. Normal notifications carry no decoration.
- Header: small tracking eyebrow + bare unread count, ghost actions. No boxed bell.

### Not touched (explicit non-goals)

- Sheet gestures, detents, onboarding seeded-greeting flow (the `greeting` prop in `ChatSurface.tsx` is unrelated and untouched).
- Topic grouping/collapse behavior for genuinely multi-topic threads — chips bar still appears at 2+ distinct topics, gesture collapse unchanged.
- The separate `components/chat/widgets/topic-chips-bar` module (different component, untouched).

## Tests

- `topic-grouping.test.ts`: +11 (hasMultipleTopicGroups incl. the exact `greeting` leak case + A→B→A recurrence; humanizeTopicLabel snake/kebab/dot/bare/human/empty).
- `topic-views.test.tsx`: +3 contract tests (humanized chip labels w/ raw identity, scrollbar-none chip rail, humanized divider w/ raw `data-topic`); updated 2 label assertions.
- `ContinuousChatOverlay.test.tsx`: +2 integration contracts (single-topic thread → no chips bar, no divider, no pill, messages still render; two topics → chips bar + 2 dividers, humanized).
- `NotificationsHomeCenter.test.tsx`: +3 (no rail/icon on normal rows, rail only on urgent/high, glass surface not bordered card).

### Test output (vitest, packages/ui)

```
✓ src/components/shell/topic-grouping.test.ts (18 tests) 12ms
✓ src/components/shell/topic-views.test.tsx (8 tests) 94ms
✓ src/components/shell/NotificationsHomeCenter.test.tsx (14 tests) 469ms
✓ src/components/shell/ContinuousChatOverlay.test.tsx (145 tests) 7140ms

Test Files  4 passed (4)
     Tests  185 passed (185)
```

Full `src/components/shell/` sweep: 708 passed | 7 skipped; the single failing suite (`HomeLauncherSurface.composed.test.tsx`, push-registration mock hoist error) **fails identically with my diff reverted** — pre-existing on develop, unrelated.

### Build

```
bun run build:client
@elizaos/app:build: ✓ built in 1m 7s
@elizaos/app:build: [renderer-build-manifest] wrote eliza-renderer-build.json buildId=52b35b275bbf (789 assets)
 Tasks:    104 successful, 104 total
  Time:    5m29.773s
```

Fixes #14284

— [sol-orch]
