### PR TITLE
fix(ui): make Account page account-first

### DIFF
--- a/.github/issue-evidence/14298-account-page-org-language.md
+++ b/.github/issue-evidence/14298-account-page-org-language.md
@@ -1,0 +1,69 @@
+# Evidence: #14298 Account page organization language
+
+## Scope
+
+- Removed the Account page welcome-card organization membership copy.
+- Stopped rendering the Organization card on the reachable Account page.
+- Kept the backend `user.organization` data shape intact; the Account surface
+  simply no longer promotes that tenancy data in plain user settings.
+
+## Verification
+
+```bash
+bun run --cwd packages/ui test src/cloud/account-security/components/account-page-client.test.tsx
+```
+
+Result: passed, 2 tests.
+
+```bash
+bunx @biomejs/biome@2.5.1 check \
+  packages/ui/src/cloud/account-security/components/account-page-client.tsx \
+  packages/ui/src/cloud/account-security/components/account-page-client.test.tsx
+```
+
+Result: passed, no fixes applied.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Required App Audit
+
+```bash
+bun run --cwd packages/app audit:app
+```
+
+Result: blocked before Playwright capture by unrelated plugin view build
+dependency resolution in this symlinked worktree:
+
+- `plugins/plugin-phone`: could not resolve `@elizaos/capacitor-phone`.
+- `plugins/plugin-messages`: could not resolve `@elizaos/capacitor-messages`.
+- `plugins/plugin-task-coordinator`: could not resolve `@xterm/addon-fit`.
+
+```bash
+ELIZA_UI_SMOKE_SKIP_VIEW_BUILD=1 bun run --cwd packages/app audit:app
+```
+
+Result: advanced past plugin view builds, then failed in `@elizaos/core#build`
+declaration generation because dependencies resolved through the main checkout
+`dist/node_modules` without declarations (`drizzle-orm`, `yaml`, `fs-extra`,
+`markdown-it`, `dotenv`, and others).
+
+```bash
+ELIZA_UI_SMOKE_SKIP_VIEW_BUILD=1 ELIZA_UI_SMOKE_SKIP_CORE_BUILD=1 \
+  bun run --cwd packages/app audit:app
+```
+
+Result: blocked before Playwright capture by renderer build resolution for
+`@tailwindcss/vite` through the symlinked dependency tree.
+
+## Missing Evidence
+
+- Rendered before/after Account page screenshots: not captured because the app
+  audit could not start in this worktree.
+- Video walkthrough: not captured for the same reason.
+- Frontend console/network logs: not captured for the same reason.
+- Backend logs and domain artifacts: N/A; this change only removes Account page
+  presentation of already-loaded user tenancy data.

--- a/packages/ui/src/cloud/account-security/components/account-page-client.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-page-client.test.tsx
@@ -1,7 +1,7 @@
 /**
- * Account page banner tests for generated and manually named organizations.
- * Lower panels are mocked so the assertions stay focused on welcome-card copy
- * and shell-header publication.
+ * Account page tests for the account-first presentation. The fixture still
+ * carries tenancy data so the page proves it does not promote organization
+ * language from the user record.
  */
 
 // @vitest-environment jsdom
@@ -27,10 +27,6 @@ vi.mock("../../../cloud-ui", () => ({
 
 vi.mock("./account-details", () => ({
   AccountDetails: () => <div>account details</div>,
-}));
-
-vi.mock("./organization-info", () => ({
-  OrganizationInfo: () => <div>organization info</div>,
 }));
 
 vi.mock("./profile-form", () => ({
@@ -93,25 +89,28 @@ describe("AccountPageClient", () => {
     setPageHeaderMock.mockReset();
   });
 
-  it("does not append a second organization noun to generated org names", () => {
+  it("keeps organization data out of the welcome card", () => {
     const { container } = render(
       <AccountPageClient user={makeUser("0x1234's Organization")} />,
     );
     const text = container.textContent ?? "";
 
-    expect(text).toContain("You're part of 0x1234's Organization");
-    expect(text).not.toMatch(/Organization organization/i);
+    expect(text).toContain("Welcome back, user@example.com!");
+    expect(text).not.toContain("You're part of");
+    expect(text).not.toContain("0x1234's Organization");
     expect(setPageHeaderMock).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Account" }),
     );
   });
 
-  it("does not append an organization noun to custom org names", () => {
+  it("does not render the Organization card on the Account page", () => {
     const { container } = render(
       <AccountPageClient user={makeUser("Team Sol")} />,
     );
 
-    expect(container.textContent).toContain("You're part of Team Sol");
-    expect(container.textContent).not.toMatch(/Team Sol organization/i);
+    expect(container.textContent).toContain("profile form");
+    expect(container.textContent).toContain("account details");
+    expect(container.textContent).not.toContain("organization info");
+    expect(container.textContent).not.toContain("Team Sol");
   });
 });

--- a/packages/ui/src/cloud/account-security/components/account-page-client.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-page-client.tsx
@@ -1,6 +1,7 @@
 /**
- * Account page body: profile form, organization info, account details. The
- * live MFA / privacy / delete controls live in the Security section instead.
+ * Account page body for user-owned profile and account details. Tenancy data
+ * can still exist on the user record, but this surface keeps organization
+ * administration out of the plain account settings path.
  */
 
 import {
@@ -11,7 +12,6 @@ import {
 } from "../../../cloud-ui";
 import type { UserProfile } from "../data/user";
 import { AccountDetails } from "./account-details";
-import { OrganizationInfo } from "./organization-info";
 import { ProfileForm } from "./profile-form";
 
 interface AccountPageClientProps {
@@ -41,12 +41,6 @@ export function AccountPageClient({ user }: AccountPageClientProps) {
               Welcome back, <span className="font-semibold">{displayName}</span>
               !
             </p>
-            {user.organization?.name && (
-              <p className="text-xs text-muted mt-1">
-                You&apos;re part of{" "}
-                <span className="font-medium">{user.organization.name}</span>
-              </p>
-            )}
           </div>
         </div>
       </BrandCard>
@@ -57,9 +51,6 @@ export function AccountPageClient({ user }: AccountPageClientProps) {
         </div>
 
         <div className="space-y-6">
-          {user.organization && (
-            <OrganizationInfo organization={user.organization} />
-          )}
           <AccountDetails user={user} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- removes Account page welcome-card organization membership copy
- stops rendering the Organization card from the reachable Account page
- keeps the backend `user.organization` data shape intact; this is presentation-only

Closes #14298 once rendered app evidence is captured.

## Verification
```bash
bun run --cwd packages/ui test src/cloud/account-security/components/account-page-client.test.tsx
```
Result: passed, 2 tests.

```bash
bunx @biomejs/biome@2.5.1 check packages/ui/src/cloud/account-security/components/account-page-client.tsx packages/ui/src/cloud/account-security/components/account-page-client.test.tsx .github/issue-evidence/14298-account-page-org-language.md
```
Result: passed.

```bash
git diff --check
```
Result: passed.

## Evidence
- `.github/issue-evidence/14298-account-page-org-language.md`

## Draft blocker
`bun run --cwd packages/app audit:app` could not reach Playwright capture in this symlinked worktree. Attempts failed before render on unrelated workspace dependency/build resolution: first plugin view builds (`@elizaos/capacitor-phone`, `@elizaos/capacitor-messages`, `@xterm/addon-fit`), then core declaration dependency resolution when view builds were skipped, then `@tailwindcss/vite` renderer resolution when both view/core builds were skipped. The evidence file records the exact commands and blockers.

This PR should stay draft until Account page screenshots/app audit/manual review are captured from a full workspace or a maintainer explicitly accepts scoped N/A.