### PR TITLE
fix(agent): report frame document size on HEAD

### DIFF
--- a/packages/agent/src/__tests__/views-registry-integration.test.ts
+++ b/packages/agent/src/__tests__/views-registry-integration.test.ts
@@ -910,9 +910,25 @@ describe("GET /api/views/:id/frame.html", () => {
       ];
       const getBody = getRes.end.mock.calls[0]?.[0] as Buffer;
       expect(getHeaders["Content-Type"]).toBe("text/html; charset=utf-8");
+      expect(getHeaders["Content-Length"]).toBe(getBody.byteLength);
       expect(getHeaders["X-Content-Type-Options"]).toBe("nosniff");
       expect(getHeaders["Cache-Control"]).toBe("no-cache");
       expect(getBody.toString("utf8")).toContain("Frame v1");
+
+      const { ctx: headCtx } = makeCtx(
+        "HEAD",
+        "/api/views/local.frame/frame.html",
+      );
+      await handleViewsRoutes(headCtx);
+      const headRes = rawResponse(headCtx);
+      const [, headHeaders] = headRes.writeHead.mock.calls[0] as [
+        number,
+        Record<string, string | number>,
+      ];
+      expect(headHeaders["Content-Type"]).toBe("text/html; charset=utf-8");
+      expect(headHeaders["Content-Length"]).toBe(getBody.byteLength);
+      expect(headHeaders["Cache-Control"]).toBe("no-cache");
+      expect(headRes.end).toHaveBeenCalledWith(undefined);
 
       const { ctx: immutableCtx } = makeCtx(
         "GET",

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -730,14 +730,14 @@ export async function handleViewsRoutes(
     if (typeof raw.writeHead === "function") {
       raw.writeHead(200, {
         "Content-Type": "text/html; charset=utf-8",
-        "Content-Length": data.byteLength,
+        "Content-Length": stat.size,
         "Cache-Control": cacheControl,
         "X-Content-Type-Options": "nosniff",
         ETag: etag,
       });
     } else if (typeof raw.setHeader === "function") {
       raw.setHeader("Content-Type", "text/html; charset=utf-8");
-      raw.setHeader("Content-Length", data.byteLength);
+      raw.setHeader("Content-Length", stat.size);
       raw.setHeader("Cache-Control", cacheControl);
       raw.setHeader("X-Content-Type-Options", "nosniff");
       raw.setHeader("ETag", etag);


### PR DESCRIPTION
## Summary

Follow-up to #14281 / #14263.

- report the real frame document size in Content-Length for HEAD /api/views/:id/frame.html
- keep HEAD bodyless while matching the GET document length
- add regression coverage beside the local frame document route test

## Verification

- bun --conditions=eliza-source test packages/agent/src/__tests__/views-registry-integration.test.ts --test-name-pattern "frame.html"
- bunx @biomejs/biome@2.5.1 check packages/agent/src/api/views-routes.ts packages/agent/src/__tests__/views-registry-integration.test.ts
- git diff --check origin/develop...HEAD && git diff --check

## Evidence

N/A - HTTP header contract only; no UI/pixel, model, audio, or domain artifact changes.
