### PR TITLE
fix(ui): close surface realm residual authority leaks

### DIFF
--- a/.github/issue-evidence/14237-surface-realm-forward.md
+++ b/.github/issue-evidence/14237-surface-realm-forward.md
@@ -1,0 +1,37 @@
+# #14237 Surface Realm Forward Fix Evidence
+
+Branch: `fix/14237-surface-realm-forward`
+
+Base verified after rebase: `origin/develop` at `6c1b2debbb` (`feat(ui): chat history — infinite scroll, search, reachable clear in overlay (#14300)`)
+
+## Focused Verification
+
+- `bunx @biomejs/biome check packages/ui/src/components/views/DynamicViewLoader.tsx packages/ui/src/components/views/DynamicViewLoader.root-ui-broker.test.tsx packages/ui/src/surface-realm-broker.ts packages/ui/src/surface-realm-broker.test.tsx`
+  - Result: pass.
+- `BUN_OPTIONS=--conditions=eliza-source bun run --cwd packages/ui test -- src/surface-realm-broker.test.tsx -t 'resetHostRealm'`
+  - Result: pass, 8 tests passed / 8 skipped.
+- `BUN_OPTIONS=--conditions=eliza-source bun run --cwd packages/ui test -- src/components/views/DynamicViewLoader.root-ui-broker.test.tsx -t 'cached broker helpers'`
+  - Result: pass, 1 test passed / 3 skipped.
+- `git diff --check origin/develop...HEAD`
+  - Result: pass.
+
+## Local Harness Notes
+
+The sparse local review worktree needed local-only `node_modules` stubs for optional UI barrel dependencies that are not installed in this checkout (`@pixiv/three-vrm`, `three`, `webxr-polyfill`, `motion/react`, `@stwd/react`, `react-router-dom`, `react-day-picker`) plus workspace symlinks and generated keyword data. These stubs were not committed.
+
+## Evidence Still Required Before Merge
+
+- `bun run --cwd packages/app audit:app`
+- Manual review verdicts for touched/reachable app views.
+- Desktop/mobile screenshots and video walkthrough, or explicit N/A rows where appropriate.
+- Frontend console/network logs if a rendered app audit is captured.
+
+## App Audit Attempt
+
+Attempted `bun run --cwd packages/app audit:app` in the sparse forward-fix worktree after adding `packages/app` and its immediate workspace build dependencies.
+
+- First attempt failed before rendering because Turbo could not find `@elizaos/contracts` in the sparse checkout.
+- After adding `packages/contracts`, the build failed because the local test-stub `node_modules` shadowed real dependencies and `@types/node` could not resolve for `@elizaos/logger`.
+- After switching the worktree to the parent checkout's full `node_modules`, the build progressed through `@elizaos/logger`, `@elizaos/contracts`, and `@elizaos/cloud-routing`, then failed while generating `@elizaos/core` declarations due workspace/package resolution gaps in the sparse setup (`@elizaos/cloud-routing`, `@elizaos/prompts`, and `file-type` not resolving correctly from this worktree).
+
+No rendered screenshots/manual-review artifacts were produced from this environment.

--- a/packages/ui/src/components/views/DynamicViewLoader.root-ui-broker.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.root-ui-broker.test.tsx
@@ -108,6 +108,37 @@ describe("root @elizaos/ui import is broker-scoped, not an escape hatch (#14237)
     expect(await getStorageValue("probe-key")).toBe("probe-value");
   }, 120_000);
 
+  it("cached broker helpers cannot borrow the next active view's scope", async () => {
+    const firstNavigateMod = await hostImport("@elizaos/ui/app-navigate-view");
+    const firstBridgeMod = await hostImport("@elizaos/ui/bridge");
+    const firstNavigate = firstNavigateMod.navigateBrowserPath as (
+      path: string,
+    ) => void;
+    const firstSetStorageValue = firstBridgeMod.setStorageValue as (
+      key: string,
+      value: string,
+    ) => Promise<void>;
+    const secondBacking = new MemoryStorage();
+    const secondScope = new SurfaceRealmScope(
+      resolveSurfaceManifest({
+        surface: { capabilities: ["navigate", "storage"] },
+      }),
+      "second.view",
+      secondBacking,
+      () => {
+        throw new Error("stale helper borrowed the second view navigate scope");
+      },
+    );
+
+    setActiveSurfaceRealmScope(secondScope);
+
+    expect(() => firstNavigate("/stale")).toThrow(SurfaceRealmDeniedError);
+    await expect(firstSetStorageValue("probe-key", "stale")).rejects.toThrow(
+      SurfaceRealmDeniedError,
+    );
+    expect(secondBacking.getItem("probe-key")).toBeNull();
+  }, 120_000);
+
   it("the raw app-navigate-view helper (the pre-fix barrel export) bypasses the scope — proving the fix closes a real hole", async () => {
     const raw = await import("../../app-navigate-view");
     const rawNavigate = raw.navigateBrowserPath;

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -78,7 +78,11 @@ import {
 } from "../../state/bounded-view-lru";
 import { installHeapPressureMonitor } from "../../state/heap-pressure-monitor";
 import { useApp } from "../../state/useApp.ts";
-import { getActiveSurfaceRealmScope } from "../../surface-realm-broker";
+import {
+  getActiveSurfaceRealmScope,
+  SurfaceRealmDeniedError,
+  type SurfaceRealmScope,
+} from "../../surface-realm-broker";
 import { registerDetailExtension } from "../apps/extensions/registry.ts";
 import {
   formatDetailTimestamp,
@@ -390,6 +394,21 @@ async function importUiComponentsCompat(): Promise<Record<string, unknown>> {
   return import("../index.ts");
 }
 
+function resolveSurfaceRealmScopeForHostExternal(
+  boundScope: SurfaceRealmScope | null,
+  vector: "storage" | "navigate",
+  detail: string,
+): SurfaceRealmScope | null {
+  const activeScope = getActiveSurfaceRealmScope();
+  if (!boundScope) return activeScope;
+  if (activeScope === boundScope) return boundScope;
+  throw new SurfaceRealmDeniedError(
+    boundScope.viewId,
+    vector,
+    `stale host external call after surface deactivation: ${detail}`,
+  );
+}
+
 async function importUiRootCompat(): Promise<Record<string, unknown>> {
   // The root barrel re-exports the RAW navigation/storage helpers (via
   // `export * from "./app-navigate-view"` and `export * from "./bridge/index"`),
@@ -411,10 +430,15 @@ async function importUiAppNavigateViewCompat(): Promise<
   Record<string, unknown>
 > {
   const appNavigateView = await import("../../app-navigate-view.ts");
-  const scope = getActiveSurfaceRealmScope();
+  const boundScope = getActiveSurfaceRealmScope();
   return {
     ...appNavigateView,
     navigateBrowserPath(path: string): void {
+      const scope = resolveSurfaceRealmScopeForHostExternal(
+        boundScope,
+        "navigate",
+        `blocked navigation to "${path}"`,
+      );
       if (scope) {
         scope.navigate(path);
         return;
@@ -426,14 +450,24 @@ async function importUiAppNavigateViewCompat(): Promise<
 
 async function importUiBridgeCompat(): Promise<Record<string, unknown>> {
   const bridge = await import("../../bridge/index.ts");
-  const scope = getActiveSurfaceRealmScope();
+  const boundScope = getActiveSurfaceRealmScope();
   return {
     ...bridge,
     async getStorageValue(key: string): Promise<string | null> {
+      const scope = resolveSurfaceRealmScopeForHostExternal(
+        boundScope,
+        "storage",
+        `blocked read for key "${key}"`,
+      );
       if (scope) return scope.storage.getItem(key);
       return bridge.getStorageValue(key);
     },
     async setStorageValue(key: string, value: string): Promise<void> {
+      const scope = resolveSurfaceRealmScopeForHostExternal(
+        boundScope,
+        "storage",
+        `blocked write for key "${key}"`,
+      );
       if (scope) {
         scope.storage.setItem(key, value);
         return;
@@ -441,6 +475,11 @@ async function importUiBridgeCompat(): Promise<Record<string, unknown>> {
       await bridge.setStorageValue(key, value);
     },
     async removeStorageValue(key: string): Promise<void> {
+      const scope = resolveSurfaceRealmScopeForHostExternal(
+        boundScope,
+        "storage",
+        `blocked removal for key "${key}"`,
+      );
       if (scope) {
         scope.storage.removeItem(key);
         return;

--- a/packages/ui/src/surface-realm-broker.test.tsx
+++ b/packages/ui/src/surface-realm-broker.test.tsx
@@ -233,21 +233,23 @@ describe("SurfaceRealmScope.resetHostRealm — root/body class + :root var vecto
     );
   });
 
-  it("preserves a theme class toggled ON while the view was active (shell writers stay allowed)", () => {
+  it("removes a same-realm theme class added after activation", () => {
     document.documentElement.className = "light";
     const scope = makeScope();
-    // Shell toggles theme mid-view (light -> dark).
-    document.documentElement.classList.remove("light");
+    // Same-realm code toggles the shell-owned theme family after activation.
     document.documentElement.classList.add("dark");
-    // View injects its own class.
     document.documentElement.classList.add("rogue-root-class");
 
-    scope.resetHostRealm();
+    const result = scope.resetHostRealm();
 
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
     expect(
       document.documentElement.classList.contains("rogue-root-class"),
     ).toBe(false);
+    expect(result.rootClasses).toEqual(
+      expect.arrayContaining(["dark", "rogue-root-class"]),
+    );
   });
 
   // A view leaks into the next surface by DELETING a shell baseline token just
@@ -293,19 +295,31 @@ describe("SurfaceRealmScope.resetHostRealm — root/body class + :root var vecto
     expect(result.restoredRootVars).toContain("--accent");
   });
 
-  it("does not re-add the previous theme class after a legitimate shell theme swap", () => {
+  it("restores a shell-owned :root var when the view rewrites it to another value", () => {
+    const scope = makeScope();
+    document.documentElement.style.setProperty("--accent", "red");
+
+    const result = scope.resetHostRealm();
+
+    expect(document.documentElement.style.getPropertyValue("--accent")).toBe(
+      "#f60",
+    );
+    expect(result.restoredRootVars).toContain("--accent");
+  });
+
+  it("restores the baseline theme class and removes a same-realm theme swap", () => {
     document.documentElement.className = "light";
     const scope = makeScope();
-    // Shell legitimately swaps theme mid-view: `light` out, `dark` in.
+    // Same-realm code removes the baseline theme and adds another shell-owned
+    // theme class. Teardown must restore the activation baseline exactly.
     document.documentElement.classList.remove("light");
     document.documentElement.classList.add("dark");
 
     const result = scope.resetHostRealm();
 
-    // The theme family is still represented — the swap is not a view deletion,
-    // so `light` must NOT be restored (that would leave both classes set).
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
-    expect(document.documentElement.classList.contains("light")).toBe(false);
-    expect(result.restoredRootClasses).not.toContain("light");
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(result.rootClasses).toContain("dark");
+    expect(result.restoredRootClasses).toContain("light");
   });
 });

--- a/packages/ui/src/surface-realm-broker.ts
+++ b/packages/ui/src/surface-realm-broker.ts
@@ -263,9 +263,9 @@ function readRootVarNames(el: HTMLElement): string[] {
 /**
  * What a host-realm reset changed — returned so callers can log/inspect. The
  * `removed*` fields are rogue tokens the view ADDED and the reset stripped; the
- * `restored*` fields are shell-owned baseline tokens the view DELETED and the
- * reset re-asserted (a view leaks just as much by deleting `dark`/`native`/
- * `--accent` as by injecting a rogue token).
+ * `restored*` fields are shell-owned baseline tokens the view DELETED or
+ * MUTATED and the reset re-asserted (a view leaks just as much by deleting or
+ * rewriting `dark`/`native`/`--accent` as by injecting a rogue token).
  */
 export interface HostRealmResetResult {
   rootClasses: string[];
@@ -294,10 +294,10 @@ export class SurfaceRealmScope {
   private readonly rootClassBaseline: ReadonlySet<string>;
   private readonly bodyClassBaseline: ReadonlySet<string>;
   private readonly rootVarBaseline: ReadonlySet<string>;
-  // Baseline presence/values of the SHELL-OWNED tokens only, snapshotted at
-  // activation. Restored on teardown if the view deleted them — the shell owns
-  // these, so re-asserting its own theme/platform/accent state is safe, whereas
-  // a plugin/content-pack token the view deleted is not the shell's to restore.
+  // Baseline presence/values of the SHELL-OWNED tokens, snapshotted at
+  // activation. Restored on teardown if same-realm view code deletes or rewrites
+  // them; without a privileged shell-write channel, exact reset is the only
+  // deterministic boundary between the view and the host realm.
   private readonly shellRootClassBaseline: readonly string[];
   private readonly shellBodyClassBaseline: readonly string[];
   private readonly shellRootVarBaseline: ReadonlyMap<string, string>;
@@ -339,10 +339,10 @@ export class SurfaceRealmScope {
    * Undo a view's global root/body-class + `:root`-var mutations on teardown so
    * nothing it did to the host realm leaks into the next view. Two directions:
    * (1) remove tokens the view ADDED beyond the shell's own set, and (2) restore
-   * shell-owned baseline tokens the view DELETED. A legitimate theme SWAP by the
-   * shell (removing `light` while adding `dark`) is not a deletion to restore —
-   * the family is still represented — so restoration skips a missing theme class
-   * whenever any theme class is present.
+   * shell-owned baseline tokens the view DELETED or MUTATED. The reset restores
+   * the activation baseline for shell-owned tokens exactly: otherwise a view can
+   * remove `dark` and add allowlisted `light`, or rewrite `--accent`, and have the
+   * mutation survive into the next surface.
    */
   resetHostRealm(): HostRealmResetResult {
     const result: HostRealmResetResult = {
@@ -357,32 +357,23 @@ export class SurfaceRealmScope {
     const root = document.documentElement;
     const { body } = document;
     for (const cls of [...root.classList]) {
-      if (isShellOwnedRootClass(cls) || this.rootClassBaseline.has(cls))
-        continue;
+      if (this.rootClassBaseline.has(cls)) continue;
       root.classList.remove(cls);
       result.rootClasses.push(cls);
     }
     for (const cls of [...body.classList]) {
-      if (isShellOwnedBodyClass(cls) || this.bodyClassBaseline.has(cls))
-        continue;
+      if (this.bodyClassBaseline.has(cls)) continue;
       body.classList.remove(cls);
       result.bodyClasses.push(cls);
     }
     for (const name of readRootVarNames(root)) {
-      if (isShellOwnedRootVar(name) || this.rootVarBaseline.has(name)) continue;
+      if (this.rootVarBaseline.has(name)) continue;
       root.style.removeProperty(name);
       result.rootVars.push(name);
     }
 
-    // All shell-owned root classes are the mutually-exclusive theme family; if
-    // any is present, the theme is validly set and a missing baseline sibling is
-    // a legitimate swap, not a view deletion.
-    const themeRootClassPresent = [...SHELL_OWNED_ROOT_CLASSES].some((cls) =>
-      root.classList.contains(cls),
-    );
     for (const cls of this.shellRootClassBaseline) {
       if (root.classList.contains(cls)) continue;
-      if (themeRootClassPresent) continue;
       root.classList.add(cls);
       result.restoredRootClasses.push(cls);
     }
@@ -392,10 +383,7 @@ export class SurfaceRealmScope {
       result.restoredBodyClasses.push(cls);
     }
     for (const [name, value] of this.shellRootVarBaseline) {
-      // Only a deletion (property absent → empty string) is unambiguously the
-      // view's doing; a changed non-empty value can be a legitimate shell accent
-      // update, so it is left alone.
-      if (root.style.getPropertyValue(name) !== "") continue;
+      if (root.style.getPropertyValue(name) === value) continue;
       root.style.setProperty(name, value);
       result.restoredRootVars.push(name);
     }


### PR DESCRIPTION
## Summary

Closes residual code gaps from #14237 after #14288 merged but #14237 was reopened.

- Bind brokered host-external navigate/storage helpers to the scope visible when the helper resolves; cached callbacks now throw instead of borrowing the next active view's authority.
- Keep the null-scope fallback path for helpers resolved before the app publishes a scope, so they still use the current active scope at call time instead of falling back raw.
- Reset shell-owned host-realm classes and CSS vars back to the activation baseline exactly, closing the `dark` -> `light` / `--accent` rewrite residual.
- Add focused regression coverage and evidence notes in `.github/issue-evidence/14237-surface-realm-forward.md`.

## Verification

- `bunx @biomejs/biome check packages/ui/src/components/views/DynamicViewLoader.tsx packages/ui/src/components/views/DynamicViewLoader.root-ui-broker.test.tsx packages/ui/src/surface-realm-broker.ts packages/ui/src/surface-realm-broker.test.tsx`
- `BUN_OPTIONS=--conditions=eliza-source bun run --cwd packages/ui test -- src/surface-realm-broker.test.tsx -t 'resetHostRealm'` — 8 pass / 8 skipped
- `BUN_OPTIONS=--conditions=eliza-source bun run --cwd packages/ui test -- src/components/views/DynamicViewLoader.root-ui-broker.test.tsx -t 'cached broker helpers'` — 1 pass / 3 skipped
- `git diff --check origin/develop...HEAD`

## App Audit Attempt

`bun run --cwd packages/app audit:app` was attempted from the sparse forward-fix worktree but did not reach rendering:

- first attempt: Turbo could not find `@elizaos/contracts` in sparse checkout;
- after adding `packages/contracts`: local test-stub `node_modules` shadowed real deps and `@types/node` could not resolve for `@elizaos/logger`;
- after switching to the parent checkout's full `node_modules`: build reached `@elizaos/core` declaration generation, then failed on sparse/workspace package resolution for `@elizaos/cloud-routing`, `@elizaos/prompts`, and `file-type`.

No screenshots/manual-review artifacts were produced locally.

## Draft / Evidence Status

Draft because this touches `packages/ui` behavior that bleeds into `packages/app`; the required rendered `audit:app`, manual-review verdicts, screenshots/video, and frontend logs are still pending.