### PR TITLE
fix(build): turbo strips ELIZA_BUILD_STAMP so the app BuildBadge stamp is never written via build:client

### DIFF
--- a/packages/scripts/__tests__/turbo-build-stamp-env-contract.test.ts
+++ b/packages/scripts/__tests__/turbo-build-stamp-env-contract.test.ts
@@ -1,0 +1,109 @@
+// Guards against the ELIZA_BUILD_STAMP passthrough regression: the tester
+// BuildBadge stamp (`packages/app/dist/build-info.json`) is written by
+// `packages/app/scripts/build.mjs` via `shouldSkipBuildStamp()`, which reads
+// ELIZA_BUILD_STAMP / ELIZA_BUILD_VARIANT / VITE_ENVIRONMENT /
+// ELIZA_RELEASE_AUTHORITY. The app is built through turbo (`build:client` ->
+// `run-turbo run build --filter=@elizaos/app`), and turbo STRIPS any env var
+// that is not in the task's env allowlist (or globalEnv) before the task runs.
+// If those policy vars are not allowlisted for the app build task, setting the
+// flag has no effect and the stamp policy is undefined under turbo. This
+// contract asserts the resolved env allowlist for `@elizaos/app#build` covers
+// every var the stamp policy actually reads. Deterministic — parses turbo.json
+// and build-stamp.mjs source, runs nothing.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const TURBO_JSON = fileURLToPath(new URL("../../../turbo.json", import.meta.url));
+const BUILD_STAMP_MJS = fileURLToPath(
+  new URL("../../app/scripts/build-stamp.mjs", import.meta.url),
+);
+
+// The exact vars `shouldSkipBuildStamp()` reads from `env`. If the stamp policy
+// grows a new env input, add it here AND to the app build task's env allowlist
+// in turbo.json — otherwise the new input is silently stripped by turbo and the
+// policy becomes undefined on the normal `build:client` path.
+const STAMP_POLICY_ENV = [
+  "ELIZA_BUILD_STAMP",
+  "ELIZA_BUILD_VARIANT",
+  "ELIZA_RELEASE_AUTHORITY",
+  "VITE_ENVIRONMENT",
+];
+
+function readTurbo(): {
+  globalEnv?: string[];
+  tasks: Record<string, { env?: string[] }>;
+} {
+  return JSON.parse(readFileSync(TURBO_JSON, "utf8"));
+}
+
+/**
+ * The env allowlist turbo applies to a package's `build` task: the
+ * package-specific `pkg#build` entry (which fully replaces the base `build`
+ * task when present) if it exists, otherwise the generic `build` task.
+ */
+function resolvedBuildEnv(
+  turbo: ReturnType<typeof readTurbo>,
+  pkg: string,
+): string[] {
+  const specific = turbo.tasks[`${pkg}#build`];
+  const generic = turbo.tasks.build;
+  const taskEnv = (specific ?? generic)?.env ?? [];
+  return [...(turbo.globalEnv ?? []), ...taskEnv];
+}
+
+describe("turbo build-stamp env passthrough contract", () => {
+  test("build-stamp policy reads exactly the declared STAMP_POLICY_ENV vars", () => {
+    // Keep STAMP_POLICY_ENV honest against the real source: every var the
+    // policy references via `env.<VAR>` must be in the list, so the allowlist
+    // assertion below can never go stale silently.
+    const source = readFileSync(BUILD_STAMP_MJS, "utf8");
+    const referenced = new Set(
+      [...source.matchAll(/env\.([A-Z0-9_]+)/g)].map((m) => m[1]),
+    );
+    for (const varName of referenced) {
+      expect(STAMP_POLICY_ENV).toContain(varName);
+    }
+    // And every declared policy var is actually read by the policy (no dead
+    // entries that would give false confidence).
+    for (const varName of STAMP_POLICY_ENV) {
+      expect(referenced.has(varName)).toBe(true);
+    }
+  });
+
+  test("@elizaos/app#build allowlists every stamp-policy env var", () => {
+    const turbo = readTurbo();
+    const env = resolvedBuildEnv(turbo, "@elizaos/app");
+    for (const varName of STAMP_POLICY_ENV) {
+      expect(env).toContain(varName);
+    }
+  });
+
+  test("@elizaos/app#build preserves the generic build inputs and outputs", () => {
+    // The pkg#build entry fully replaces the base `build` task, so dropping its
+    // inputs/outputs would break cache invalidation. Guard that the override
+    // still carries them (source changes must bust the cache; dist is emitted).
+    const turbo = readTurbo();
+    const appBuild = turbo.tasks["@elizaos/app#build"] as
+      | { inputs?: string[]; outputs?: string[] }
+      | undefined;
+    expect(appBuild).toBeDefined();
+    expect(appBuild?.inputs).toContain("src/**");
+    expect(appBuild?.inputs).toContain("scripts/**");
+    expect(appBuild?.inputs).toContain("build.mjs");
+    expect(appBuild?.outputs).toContain("dist/**");
+  });
+
+  test("the app build script is wired through turbo (regression premise holds)", () => {
+    // If `build:client` stops going through turbo, this contract is moot —
+    // assert the premise so the guard fails loudly if the build path changes
+    // out from under it.
+    const rootPkg = JSON.parse(
+      readFileSync(`${REPO_ROOT}/package.json`, "utf8"),
+    ) as { scripts?: Record<string, string> };
+    const buildClient = rootPkg.scripts?.["build:client"] ?? "";
+    expect(buildClient).toContain("run-turbo.mjs");
+    expect(buildClient).toContain("--filter=@elizaos/app");
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -46,6 +46,40 @@
         "$TURBO_ROOT$/packages/scripts/rewrite-dist-relative-imports-node-esm.mjs"
       ]
     },
+    "@elizaos/app#build": {
+      "dependsOn": ["@elizaos/core#build", "^build"],
+      "env": [
+        "LOG_LEVEL",
+        "ELIZA_BUILD_STAMP",
+        "ELIZA_BUILD_VARIANT",
+        "ELIZA_RELEASE_AUTHORITY",
+        "VITE_ENVIRONMENT"
+      ],
+      "outputs": ["dist/**"],
+      "inputs": [
+        "src/**",
+        "index.ts",
+        "index.node.ts",
+        "index.browser.ts",
+        "build.ts",
+        "build.mjs",
+        "build.config.ts",
+        "scripts/**",
+        "tsup.config.ts",
+        "tsup.config.*.ts",
+        "tsdown.config.ts",
+        "vite.config.ts",
+        "vite.config.*.ts",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "package.json",
+        "assets/**",
+        "public/**",
+        "$TURBO_ROOT$/plugins/tsup.plugin-packages.shared.ts",
+        "$TURBO_ROOT$/packages/scripts/view-bundle-vite.config.ts",
+        "$TURBO_ROOT$/packages/scripts/rewrite-dist-relative-imports-node-esm.mjs"
+      ]
+    },
     "@elizaos-benchmarks/lib#build": {
       "dependsOn": ["@elizaos/core#build", "^build"],
       "outputs": []


### PR DESCRIPTION
## What
The tester-only BuildBadge stamp (`packages/app/dist/build-info.json`) is silently **never written** on the normal build path (`bun run build:client` → `run-turbo run build --filter=@elizaos/app`).

## Root cause
`packages/app/scripts/build.mjs` → `stampBuildInfo()` → `shouldSkipBuildStamp()` (`build-stamp.mjs`) reads four env vars to decide whether to emit the stamp:

- `ELIZA_BUILD_STAMP`
- `ELIZA_BUILD_VARIANT`
- `VITE_ENVIRONMENT`
- `ELIZA_RELEASE_AUTHORITY`

turbo strips any env var not in the task's `env` allowlist (or `globalEnv`). In `turbo.json`, `globalEnv` did not list any of them and the app used the generic `build` task (`env: ["LOG_LEVEL"]`) with no `@elizaos/app#build` override. So `ELIZA_BUILD_STAMP=1` was inert through turbo and the rest of the policy was undefined on the `build:client` path. (Building the app package directly with the flag DOES emit the file; through turbo it does not.)

## Fix
Add a `@elizaos/app#build` task override in `turbo.json` that allowlists the four stamp-policy vars (plus `LOG_LEVEL`).

⚠️ **turbo.json change (flagged for orch review):** a root `pkg#task` entry **fully replaces** the base `build` task — it does not merge. So the override replicates the generic `build` task's `dependsOn` / `outputs` / `inputs` verbatim; only the `env` array is extended. This keeps cache invalidation (237 inputs) and the dependency graph identical.

**No change to `build-stamp.mjs` policy semantics:** prod/store still skip by default; dev/staging/`ELIZA_BUILD_STAMP=1` still stamp.

## Proof
`turbo run build --filter=@elizaos/app --dry=json` now resolves the app build task env allowlist to:
```
["ELIZA_BUILD_STAMP","ELIZA_BUILD_VARIANT","ELIZA_RELEASE_AUTHORITY","LOG_LEVEL","VITE_ENVIRONMENT"]
```
with 237 inputs preserved. Pre-fix it was `["BUN_PATH","SEARCHBENCH_CORPUS","SEARCHBENCH_LATENCY_REPEATS","LOG_LEVEL"]`.

## Test
New `packages/scripts/__tests__/turbo-build-stamp-env-contract.test.ts` (bun:test, deterministic):
- keeps the checked policy-var list in sync with the actual `env.<VAR>` references in `build-stamp.mjs` (bidirectional)
- asserts `@elizaos/app#build` allowlists every stamp-policy var
- asserts the override preserves `inputs`/`outputs`
- asserts `build:client` still routes through turbo (regression premise)

```
$ bun test packages/scripts/__tests__/turbo-build-stamp-env-contract.test.ts
 4 pass  0 fail  19 expect() calls
```
Reverting the turbo.json fix makes 2 of these tests fail (guard confirmed). Adjacent `build.test.mjs` (8 pass) and `turbo-cache-key.test.ts` (5 pass) stay green.

Fixes #14302

— [sol-orch]
