### PR TITLE
ci(android): document iOS onboarding-smoke parity divergence (#13580)

### DIFF
--- a/.github/workflows/android-device-e2e.yml
+++ b/.github/workflows/android-device-e2e.yml
@@ -14,6 +14,18 @@ name: android-device-e2e
 # expected-to-surface) signal. For green route coverage on the emulator, supply
 # an Eliza Cloud token (ELIZA_CLOUD_AUTH_TOKEN secret) so the app onboards to a
 # real cloud agent.
+#
+# iOS onboarding-smoke parity (#13580): mobile-build-smoke.yml runs
+# ios-onboarding-smoke.mjs on every path-gated PR, but the Android
+# onboarding->home smoke (test:e2e:android:onboarding) is intentionally NOT
+# per-PR. The iOS smoke boots a simulator on a macOS runner cheaply; the
+# Android smoke needs a KVM-accelerated x86_64 emulator on a Linux runner,
+# which is too heavy to boot on every PR (issue #9943). Android
+# onboarding->home instead runs on three cadences: the label-gated
+# (ci:device) pr-device-smoke job below, the weekly host-backed schedule,
+# and workflow_dispatch -- so an onboarding regression is caught on a PR
+# opt-in or within one weekly cycle rather than never. This is the
+# documented divergence the parity checkbox in #13580 asks for.
 
 on:
   schedule:


### PR DESCRIPTION
## What & why

`#13580` tracks giving the Android device-e2e lane an unattended cadence and closing several coverage gaps. Two slices already landed on `develop`:

- **#13860** — weekly host-backed `schedule:` (`cron: 17 9 * * 1`, `ELIZA_ANDROID_BACKEND=host`) + hardened the host/cloud route leg (removed its vacuous `|| true`).
- **#14212** — a visible failure signal: the `notify-scheduled-failure` job auto-files/updates a tracking issue when a scheduled run fails.

The remaining `#13580` "Done when" list has one item that is resolvable **without a device or emulator-green evidence**:

> Android onboarding→home reaches per-PR parity with the iOS onboarding smoke, **or the divergence is documented in the workflow header with rationale.**

`mobile-build-smoke.yml` runs `ios-onboarding-smoke.mjs` on every path-gated PR, but the Android `onboarding→home` smoke (`test:e2e:android:onboarding`) only runs on the `ci:device`-labeled PR smoke, the weekly schedule, and `workflow_dispatch`. The header explained the label-gated cadence generally but never named this specific iOS divergence, so that checkbox stayed open. This PR takes the sanctioned escape hatch and **documents the divergence with rationale** in the workflow header.

## Change

- `.github/workflows/android-device-e2e.yml` — add a header paragraph explaining the Android↔iOS onboarding-smoke divergence and why (iOS sim boots cheaply on a macOS runner; the Android smoke needs a KVM-accelerated x86_64 emulator on a Linux runner, too heavy per-PR — `#9943`) and where the Android onboarding→home coverage actually runs (label-gated PR smoke + weekly schedule + dispatch).

**Comment-only change to the workflow header** — no job, step, trigger, or gating behavior changes.

## Verification

- CI is the gate: this touches only YAML comments, so `actionlint` / workflow parsing on this PR verifies the file is still valid. No runtime behavior to exercise.
- **N/A (local) — rendered/device evidence:** I authored this from an environment with no Android emulator, device, or build host, so I cannot run the lane or capture screenrecords/logcat. This change requires none — it is documentation of an already-deliberate cadence decision. Flagging honestly rather than attaching stale/fabricated proof.

## Honest scope — what this does NOT close

`Refs #13580` (not `Fixes`). The remaining residuals are **not** author-able without infrastructure I do not have:

- **LOCAL arm64 CI home** — the embedded bun+llama agent SIGSEGVs on the hosted x86_64 emulator; it needs a self-hosted **arm64** runner. The repo's self-hosted fleet is entirely `X64` (verified via `actions/runners`), so this is genuinely infra-blocked. (Note: the earlier blocker `#13550` is now closed, but the arm64 runner still does not exist.)
- **Promoting the remaining `|| true` legs** (`local-chat`, `launcher-loop`, and the PR-lane `native-plugin-view` / `touch-gesture` / `view-runtime-soak`) — the in-file comments gate promotion on an **emulator-green dispatch run linked as evidence**, which requires actually booting the emulator. I cannot produce that evidence here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)