### PR TITLE
test(orchestrator): de-flake admission-queue cap test 9-vs-10 session count (#14311)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-admission-queue.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-admission-queue.test.ts
@@ -249,6 +249,11 @@ describe("orchestrator admission queue — N tasks vs maxSessions (#13778)", () 
     expect(await service.getAdmissionSnapshot()).toMatchObject({
       queueDepth: 0,
     });
+    // queueDepth hits 0 the instant the final queued spawn is DEQUEUED, but its
+    // session row lands a `reserveSessionSlot` tick later (the slot lock
+    // serializes create). Poll on the observable count instead of asserting on
+    // the same turn the queue drained, or listSessions races in at N-1.
+    await poll(async () => (await acp.listSessions()).length === N);
     expect(await acp.listSessions()).toHaveLength(N);
 
     await service.stop();


### PR DESCRIPTION
## What

De-flakes the sole intermittently-red test in `plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-admission-queue.test.ts`: **"queues tasks beyond the session cap through the real orchestrator and admits them as slots free"**.

Fixes #14311.

## Root cause

The cap test's drain loop frees slots one at a time and polls until `getAdmissionSnapshot().queueDepth` decrements. `queueDepth` drops to 0 the instant the final queued spawn is **dequeued** (the admission decision fires), but its session row lands one `reserveSessionSlot` tick later — the slot lock (`spawnReservationLock`) serializes `store.create(session)` after the dequeue. The test asserted `expect(await acp.listSessions()).toHaveLength(N)` on the same turn the queue drained, so `listSessions()` intermittently sampled the store a beat early and observed `N-1`:

```
AssertionError: expected [ …(9) ] to have a length of 10 but got 9
  ❯ orchestrator-admission-queue.test.ts:252
```

This is a **harness** race, not a production defect: the admission-control invariants (cap never overshot, nothing dropped/rejected, `queueDepth` reaches 0) all hold; only the terminal count assertion read the store too early.

### On the earlier #14042 diagnosis
An earlier closeout note attributed a second red test to a `git`-spawn `TypeError` from per-session git-index preparation (#14042). That no longer reproduces on `develop` tip — `runGitForAcp` and `workspace-diff` both use `spawnSync` (already stubbed to `{ status: 1 }`), so `prepareSessionGitIndex` degrades cleanly and no async `spawn` result is dereferenced during `spawnSession` in this test. Only the 9-vs-10 flake remained, so the fix is scoped to it and **no** speculative spawn stub was added.

## Fix

Wait on the observable condition before the terminal assertion:

```ts
await poll(async () => (await acp.listSessions()).length === N);
expect(await acp.listSessions()).toHaveLength(N);
```

5-line, **test-only** change. No production source file is touched.

## Evidence

**Whole file, 20x in a row — 20/20 pass** (`for i in {1..20}; do bunx vitest run __tests__/unit/orchestrator-admission-queue.test.ts || break; done`):
```
run 1: PASS (1/1)
...
run 20: PASS (20/20)
=== TOTAL PASS: 20/20 ===
```

**Formerly-red test in isolation (`-t`):**
```
$ bunx vitest run … -t "queues tasks beyond the session cap"
 Test Files  1 passed (1)
      Tests  1 passed | 1 skipped (2)
```

**Baseline (pre-fix) reproduction of the flake:**
```
AssertionError: expected [ …(9) ] to have a length of 10 but got 9
  ❯ orchestrator-admission-queue.test.ts:252:38
```

**Sibling acp suites still green (no collateral):**
```
$ bunx vitest run __tests__/unit/acp-service.test.ts __tests__/unit/acp-scratch-gc.test.ts
 Test Files  2 passed (2)
      Tests  67 passed (67)
```

## Scope

- Files: `plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-admission-queue.test.ts` (test only, +5 lines).
- N/A - real-LLM trajectories / UI screenshots / audio: test-harness timing fix, no agent/model/UI surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)