### PR TITLE
fix(ui): friendly copy for a rejected sign-in code + honest wallet-signin note

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.callback-state.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.callback-state.test.tsx
@@ -12,6 +12,7 @@
  * options again, so a real failure is never hidden behind the spinner.
  */
 
+import { StewardSessionError } from "@elizaos/shared/steward-session-client";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -134,6 +135,29 @@ describe("StewardLoginSection — OAuth callback completion state (#13519)", () 
     );
 
     // Completing spinner is gone; the sign-in options are reachable again.
+    expect(screen.queryByText("Completing sign-in…")).toBeNull();
+    expect(screen.getByPlaceholderText("you@example.com")).toBeTruthy();
+  });
+
+  it("shows a friendly 'expired / try again' message (not the raw 401) when a stale or cross-tenant one-time code is rejected", async () => {
+    // A prod-issued code replayed against staging comes back 401 — benign and
+    // recoverable, so the copy must invite a fresh sign-in, not read as broken.
+    callbackState.exchange = () =>
+      Promise.reject(
+        new StewardSessionError("Unauthorized", 401, "code_tenant_mismatch"),
+      );
+
+    renderSection();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "That sign-in link expired or was already used. Please sign in again below.",
+        ),
+      ).toBeTruthy(),
+    );
+    // The raw upstream error is not surfaced, and the form is usable again.
+    expect(screen.queryByText(/Unauthorized/)).toBeNull();
     expect(screen.queryByText("Completing sign-in…")).toBeNull();
     expect(screen.getByPlaceholderText("you@example.com")).toBeTruthy();
   });

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -5,15 +5,20 @@
  * (Google / Discord / GitHub), plus the post-redirect OAuth `code` / `#token`
  * consumption + cookie sync.
  *
- * Wallet (SIWE / SIWS) sign-in is intentionally absent: it pulls
- * `@rainbow-me/rainbowkit` + `@solana/*` + `wagmi`, which are not dependencies
- * of `@elizaos/ui`. The wallet branch is gated off (`showWallets` is forced
- * false); email/passkey/OAuth cover the primary sign-in paths.
+ * Wallet (SIWE / SIWS) sign-in is currently absent — it was dropped when the
+ * old cloud-frontend was folded into `@elizaos/ui` (`4056e0e868`), where the
+ * wallet libs weren't yet available. There is no `showWallets` flag; the
+ * branch simply wasn't ported. The original blocker is gone (rainbowkit /
+ * wagmi / @solana are now deps here, added for billing crypto top-up, and the
+ * Steward backend serves `siwe`/`siws` on staging + prod), so re-enabling is a
+ * bounded port of the wallet UI from `cloud-frontend@4056e0e868` gated on the
+ * live `auth.getProviders()` flags — not a flag flip. Tracked for nubs's call.
  */
 
 import {
   hasStewardAuthedCookie,
   readStoredStewardToken,
+  StewardSessionError,
   writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
 import type {
@@ -122,6 +127,28 @@ function requireCompletedAuth(
     throw new Error("MFA required — not yet supported in this client.");
   }
   return result;
+}
+
+/**
+ * Message for a failed one-time-code exchange. A 401/403/410 from
+ * `steward-nonce-exchange` means the code was rejected — expired, already
+ * consumed, or issued for a different tenant (e.g. a prod code replayed against
+ * staging). That is benign and recoverable: the working sign-in form renders
+ * underneath, so we say "sign in again" instead of surfacing the raw upstream
+ * error, which read as a broken login. Genuine faults (5xx/network) still show
+ * their real message.
+ */
+function describeCodeExchangeError(error: unknown, t: LoginTranslator): string {
+  if (
+    error instanceof StewardSessionError &&
+    (error.status === 401 || error.status === 403 || error.status === 410)
+  ) {
+    return t("cloud.login.callback.codeRejected", {
+      defaultValue:
+        "That sign-in link expired or was already used. Please sign in again below.",
+    });
+  }
+  return getErrorMessage(error, "Could not complete Eliza Cloud sign-in.");
 }
 
 function getCallbackReasonMessage(
@@ -291,12 +318,7 @@ export default function StewardLoginSection() {
         })
         .catch((sessionError) => {
           setCompletingCallback(false);
-          setCallbackError(
-            getErrorMessage(
-              sessionError,
-              "Could not complete Eliza Cloud sign-in.",
-            ),
-          );
+          setCallbackError(describeCodeExchangeError(sessionError, t));
         });
       return;
     }

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -355,7 +355,7 @@ export default function StewardLoginSection() {
           getErrorMessage(sessionError, "Could not establish a local session"),
         );
       });
-  }, [searchParams]);
+  }, [searchParams, t]);
 
   useEffect(() => {
     if (PLAYWRIGHT_TEST_AUTH_ENABLED) return;


### PR DESCRIPTION
## What nubs saw
`POST .../auth/steward-nonce-exchange 401` on **staging** login → read as broken sign-in.

## What was really happening (root-caused, evidence below)
**Sign-in is not broken.** Staging is tenant-pinned (`STEWARD_TENANT_ID=elizacloud-staging`); a one-time OAuth **code carried over from a prod session** is correctly refused with 401. The code is stripped from the URL before the POST, the working form renders underneath, and a fresh sign-in works (verified live: Google → real `accounts.google.com` 'continue to ELIZA'). Staging STEWARD secrets are byte-identical to prod.

## Fixes (frontend-only, no auth-logic change)
1. **Friendly error copy** — a 401/403/410 from the code exchange now reads *'That sign-in link expired or was already used. Please sign in again below.'* instead of the raw upstream error. Genuine 5xx/network still surface real detail. (`describeCodeExchangeError`)
2. **Honest header comment** — it falsely claimed a `showWallets` flag gates wallet sign-in. **No such flag exists.** Wallet (SIWE/SIWS) was dropped in the cloud-frontend→`@elizaos/ui` fold (`4056e0e868`); the dep-weight blocker is now gone (rainbowkit/wagmi/@solana are deps here for billing; Steward serves siwe/siws on staging+prod). Re-enable = a bounded UI port gated on live `auth.getProviders()` — **a product decision (see below).**

## Evidence
- **3/3** tests in `steward-login-section.callback-state.test.tsx` incl. the new rejected-code → friendly-copy render assertion; typecheck + biome clean.
- Live triage: fresh staging login renders all providers + Google OAuth initiates; stale-token seed still renders the form (no hang). No staging outage (health 200; nonce-exchange parity with prod).

## Follow-up for @nubs — crypto/wallet sign-in
Re-enabling is safe + bounded (~300-line port), but a wallet login mints a **separate account** from a passkey/Google identity (no linking yet). Keep cut, or port it back accepting separate-account for launch? Deciding on the tracker.

[qa-agent]