### PR TITLE
fix(#13890): throttle steward session during Redis outages

### DIFF
--- a/.github/issue-evidence/13890-steward-session-fallback-limiter.md
+++ b/.github/issue-evidence/13890-steward-session-fallback-limiter.md
@@ -1,0 +1,54 @@
+# #13890 Steward Session Redis-Outage Fallback Limiter
+
+## Change
+
+- `POST /api/auth/steward-session` keeps its normal Redis-backed strict per-IP
+  limiter.
+- If Redis throws at request time, the route uses an explicit in-isolate
+  fallback bucket (`X-RateLimit-Policy: redis-unavailable-local`) instead of
+  returning `rate_limit_unavailable` before auth validation.
+- Top-up/payment routes keep the existing hard fail-closed behavior.
+
+## Verification Run Locally
+
+- `bun test packages/cloud/api/auth/steward-session/steward-session-rate-limit.test.ts packages/cloud/api/v1/topup/topup-rate-limit.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts`
+  - 7 pass / 0 fail.
+  - Real route proof: missing token reaches normal `400 missing_token` under a
+    throwing Redis dependency.
+  - Real route proof: valid Steward token mints staging-scoped cookies under a
+    throwing Redis dependency.
+  - Abuse proof: 10 invalid-token attempts reach auth validation; the 11th is
+    blocked by the local fallback bucket with `429 rate_limit_exceeded`.
+  - Money-surface proof: `/api/v1/topup/10` still returns
+    `503 rate_limit_unavailable` and never reaches the top-up handler.
+- `bunx @biomejs/biome check packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts packages/cloud/api/auth/steward-session/route.ts packages/cloud/api/auth/steward-session/steward-session-rate-limit.test.ts packages/cloud/api/v1/topup/topup-rate-limit.test.ts`
+- `node packages/shared/scripts/generate-keywords.mjs --target ts`
+- `git diff --check`
+
+## Broader Checks
+
+- `bun run --cwd packages/cloud/api build` was attempted and failed on
+  pre-existing unrelated type errors:
+  - `packages/cloud/api/__tests__/my-agents-claim-affiliate-characters.test.ts`
+    expects `default.fetch(...)` to return `Promise<Response>` but the route
+    type allows `Response | Promise<Response>`.
+  - `packages/cloud/shared/src/lib/auth/workers-hono-auth.ts:129` references
+    missing `readCookie`.
+- `bun run --cwd packages/cloud/shared typecheck` was attempted and failed on
+  the same existing `workers-hono-auth.ts:129` missing `readCookie` error.
+
+## Evidence Matrix
+
+- Real cloud-stack request/response trace: covered by route-level Hono tests
+  with the real route and middleware; full `bun run cloud:mock` was not run in
+  this worktree because the current host has been disk constrained and the
+  change has no DB migration or external-provider dependency.
+- Structured backend logs: fallback path logs through the shared logger at
+  `[RateLimit] Redis unavailable; using local fallback limiter`; unit tests mock
+  the logger to keep output deterministic.
+- DB state / migrations: N/A - no database schema, repository, billing, usage,
+  or migration changes.
+- Auth / role-gating denied path: covered by invalid-token spray test and
+  top-up fail-closed regression; origin/JWT validation logic is unchanged.
+- Model trajectories: N/A - no model-backed endpoint or agent action changed.
+- Screenshots/video: N/A - backend rate-limit middleware only; no rendered UI.

--- a/packages/cloud/api/auth/steward-session/route.ts
+++ b/packages/cloud/api/auth/steward-session/route.ts
@@ -147,15 +147,17 @@ function errorBody(
 
 const app = new Hono<AppEnv>();
 
-// Pre-auth session-mint endpoint: previously guarded only by the Origin
-// allowlist + JWT verify, with no per-IP throttle. Add a strict, per-IP,
-// fail-closed rate limit so a credential-stuffing / token-spray flood on a
-// money/auth surface is bounded even if Redis blips at request time (M11).
+// Pre-auth session-mint endpoint: the global Redis bucket is the primary
+// throttle. If Redis is unreachable, keep login available but still bounded by
+// a strict per-isolate bucket; top-up/payment routes stay hard fail-closed.
 app.use(
   rateLimit({
     ...RateLimitPresets.STRICT,
     keyGenerator: getIpKey,
     failClosed: true,
+    redisUnavailableFallback: {
+      namespace: "steward-session",
+    },
   }),
 );
 

--- a/packages/cloud/api/auth/steward-session/steward-session-rate-limit.test.ts
+++ b/packages/cloud/api/auth/steward-session/steward-session-rate-limit.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Steward-session Redis-outage rate-limit behavior.
+ *
+ * The route must not repeat the staging outage from #13890: a Redis limiter
+ * failure cannot block legitimate session minting before auth validation. It
+ * also cannot become naked fail-open, so this drives the real route with a
+ * throwing Redis client and proves the route-owned fallback bucket still bounds
+ * invalid-token spray.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const emitAudit = mock(async () => undefined);
+const verifyStewardTokenCached = mock(async (_env: unknown, token: string) =>
+  token === "valid-steward-token"
+    ? {
+        userId: "steward-user-1",
+        email: "person@example.test",
+        expiration: Math.floor(Date.now() / 1000) + 900,
+      }
+    : null,
+);
+const syncUserFromSteward = mock(async () => ({
+  id: "cloud-user-1",
+  organization_id: "org-1",
+  initialCreditsGranted: false,
+  initialFreeCreditsUsd: "0.00",
+  welcomeBonusWithheld: false,
+  welcomeBonusWithheldReason: undefined,
+  welcomeBonusWithheldMessage: undefined,
+}));
+
+const throwingRedis = {
+  incr: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  pttl: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  pexpire: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+};
+
+mock.module("@/lib/cache/redis-factory", () => ({
+  buildRedisClient: () => throwingRedis,
+  hasRedisConfig: () => true,
+  isCloudflareWorkerRuntime: () => false,
+}));
+
+mock.module("@/api-app/services/audit-dispatcher-singleton", () => ({
+  getAuditDispatcher: () => ({ emit: emitAudit }),
+}));
+
+mock.module("@/lib/auth/steward-client", () => ({
+  verifyStewardTokenCached,
+}));
+
+mock.module("@/lib/steward-sync", () => ({
+  describeSyncError: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
+  syncUserFromSteward,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { default: stewardSessionRoute } = await import("./route");
+const { _resetRedisUnavailableFallbackBuckets } = await import(
+  "@/lib/middleware/rate-limit-hono-cloudflare"
+);
+
+const ENV = {
+  ENVIRONMENT: "staging",
+  NODE_ENV: "production",
+  REDIS_URL: "redis://mock:6379",
+  STEWARD_SESSION_SECRET: "test-secret",
+};
+
+function postStewardSession(body: unknown, ip = "203.0.113.10") {
+  const app = new Hono();
+  app.route("/api/auth/steward-session", stewardSessionRoute);
+  return app.fetch(
+    new Request("https://api-staging.elizacloud.ai/api/auth/steward-session", {
+      method: "POST",
+      headers: {
+        "cf-connecting-ip": ip,
+        "content-type": "application/json",
+        origin: "https://staging.elizacloud.ai",
+      },
+      body: JSON.stringify(body),
+    }),
+    ENV,
+  );
+}
+
+beforeEach(() => {
+  emitAudit.mockClear();
+  verifyStewardTokenCached.mockClear();
+  syncUserFromSteward.mockClear();
+  _resetRedisUnavailableFallbackBuckets();
+});
+
+describe("POST /api/auth/steward-session — Redis outage fallback limiter", () => {
+  test("a missing token reaches normal auth validation instead of rate_limit_unavailable", async () => {
+    const res = await postStewardSession({});
+    expect(res.status).toBe(400);
+    expect(res.headers.get("X-RateLimit-Policy")).toBe(
+      "redis-unavailable-local",
+    );
+    await expect(res.json()).resolves.toMatchObject({
+      code: "missing_token",
+    });
+    expect(verifyStewardTokenCached).not.toHaveBeenCalled();
+  });
+
+  test("a valid Steward token can mint staging-scoped cookies while Redis is down", async () => {
+    const res = await postStewardSession({
+      token: "valid-steward-token",
+      refreshToken: "valid-refresh-token",
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Policy")).toBe(
+      "redis-unavailable-local",
+    );
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      userId: "cloud-user-1",
+      stewardUserId: "steward-user-1",
+    });
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("steward-token-staging=valid-steward-token");
+    expect(setCookie).toContain(
+      "steward-refresh-token-staging=valid-refresh-token",
+    );
+    expect(verifyStewardTokenCached).toHaveBeenCalledTimes(1);
+    expect(syncUserFromSteward).toHaveBeenCalledTimes(1);
+  });
+
+  test("invalid-token spray is still bounded by the local fallback bucket", async () => {
+    for (let i = 0; i < 10; i += 1) {
+      const res = await postStewardSession({ token: `invalid-${i}` });
+      expect(res.status).toBe(401);
+    }
+
+    const blocked = await postStewardSession({ token: "invalid-10" });
+    expect(blocked.status).toBe(429);
+    await expect(blocked.json()).resolves.toMatchObject({
+      success: false,
+      code: "rate_limit_exceeded",
+    });
+    expect(blocked.headers.get("X-RateLimit-Policy")).toBe(
+      "redis-unavailable-local",
+    );
+    expect(verifyStewardTokenCached).toHaveBeenCalledTimes(10);
+  });
+});

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
@@ -2,17 +2,26 @@
  * Rate limiter fail-closed behavior on a runtime Redis error (#12227 M11).
  *
  * The limiter falls OPEN on a Redis error at request time — correct for
- * ordinary routes (a store outage shouldn't 500 the app). But money/auth
- * routes (steward-session mint, crypto top-up) must fail CLOSED: losing the
- * limiter there is worse than a brief 503. `RateLimitConfig.failClosed` opts a
- * route into rejecting (503) instead of serving unlimited when Redis throws.
+ * ordinary routes (a store outage shouldn't 500 the app). Sensitive routes must
+ * either fail CLOSED (top-up) or install an explicit local fallback limiter
+ * (steward-session mint) so a Redis outage never becomes unlimited traffic.
  *
  * The Redis DEPENDENCY is mocked to simulate the outage (that outage is the
  * condition under test); the real `rateLimit` middleware logic runs.
  */
 
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+
+mock.module("@elizaos/cloud-routing", () => ({}));
+mock.module("../utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
 
 // Simulate a Redis backend that is present (getRedis returns a client) but
 // throws on every op — i.e. a runtime outage, not a "not configured" state.
@@ -34,7 +43,8 @@ mock.module("../cache/redis-factory", () => ({
   isCloudflareWorkerRuntime: () => false,
 }));
 
-const { rateLimit, RateLimitPresets, getIpKey } = await import("./rate-limit-hono-cloudflare");
+const { rateLimit, RateLimitPresets, getIpKey, _resetRedisUnavailableFallbackBuckets } =
+  await import("./rate-limit-hono-cloudflare");
 
 // A configured, non-disabled env so getRedis returns the (throwing) client.
 const ENV = { REDIS_URL: "redis://mock:6379", NODE_ENV: "production" };
@@ -55,6 +65,10 @@ function req() {
 
 afterAll(() => {
   mock.restore();
+});
+
+beforeEach(() => {
+  _resetRedisUnavailableFallbackBuckets();
 });
 
 describe("rateLimit — fail-closed vs fall-open on runtime Redis error (M11)", () => {
@@ -79,5 +93,32 @@ describe("rateLimit — fail-closed vs fall-open on runtime Redis error (M11)", 
     await expect(res.json()).resolves.toMatchObject({ ok: true });
     // and it advertises the degraded policy rather than pretending it enforced.
     expect(res.headers.get("X-RateLimit-Policy")).toBe("redis-unavailable");
+  });
+
+  test("a route with a Redis-outage fallback stays available but locally throttled", async () => {
+    const app = appWith({
+      ...RateLimitPresets.STRICT,
+      keyGenerator: getIpKey,
+      redisUnavailableFallback: {
+        namespace: "test-fallback",
+        maxRequests: 2,
+      },
+      failClosed: true,
+    });
+
+    const first = await app.fetch(req(), ENV);
+    expect(first.status).toBe(200);
+    expect(first.headers.get("X-RateLimit-Policy")).toBe("redis-unavailable-local");
+
+    const second = await app.fetch(req(), ENV);
+    expect(second.status).toBe(200);
+
+    const third = await app.fetch(req(), ENV);
+    expect(third.status).toBe(429);
+    await expect(third.json()).resolves.toMatchObject({
+      success: false,
+      code: "rate_limit_exceeded",
+    });
+    expect(third.headers.get("X-RateLimit-Policy")).toBe("redis-unavailable-local");
   });
 });

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -2,6 +2,9 @@
  * Rate-limit middleware for Hono on Cloudflare Workers.
  *
  * Falls open if Redis is not configured. Adds `X-RateLimit-*` headers on success.
+ * Routes that must stay available during a Redis outage can install an
+ * explicit per-isolate fallback bucket; every other sensitive route either
+ * fails closed or falls open according to its config.
  */
 
 import type { Context, MiddlewareHandler } from "hono";
@@ -14,11 +17,24 @@ export interface RateLimitConfig {
   maxRequests: number;
   keyGenerator?: (c: AppContext) => string;
   /**
+   * Use an in-isolate fallback bucket when Redis throws at request time.
+   * This is weaker than the shared Redis limiter because every Worker isolate
+   * has its own map, but it keeps low-risk login/session paths throttled during
+   * a Redis outage instead of choosing between total outage and unlimited
+   * fail-open traffic. Keep money/payment routes on `failClosed` without this.
+   */
+  redisUnavailableFallback?: {
+    namespace: string;
+    windowMs?: number;
+    maxRequests?: number;
+  };
+  /**
    * Fail CLOSED on a runtime Redis error. Default (undefined/false) falls open
    * — a Redis outage should not turn ordinary routes into 503s. Set on
-   * money/auth routes (session mint, top-up) where losing the limiter is worse
-   * than a brief availability hit: if the backing store throws at request time
-   * the request is rejected (503) instead of sailing through unlimited.
+   * sensitive routes where losing every limiter is worse than a brief
+   * availability hit: if the backing store throws at request time the request
+   * is rejected (503) instead of sailing through unlimited. Auth/session routes
+   * that install `redisUnavailableFallback` stay available but locally bounded.
    */
   failClosed?: boolean;
 }
@@ -132,6 +148,57 @@ function fallOpenResult(config: RateLimitConfig): CheckResult {
   };
 }
 
+interface LocalFallbackBucket {
+  count: number;
+  resetAt: number;
+}
+
+const redisUnavailableFallbackBuckets = new Map<string, LocalFallbackBucket>();
+
+function resolvedFallbackConfig(
+  config: RateLimitConfig,
+): { namespace: string; windowMs: number; maxRequests: number } | null {
+  const fallback = config.redisUnavailableFallback;
+  if (!fallback) return null;
+  return {
+    namespace: fallback.namespace,
+    windowMs: fallback.windowMs ?? config.windowMs,
+    maxRequests: fallback.maxRequests ?? config.maxRequests,
+  };
+}
+
+function fallbackHeadersConfig(config: RateLimitConfig): RateLimitConfig {
+  const fallback = resolvedFallbackConfig(config);
+  if (!fallback) return config;
+  return {
+    ...config,
+    windowMs: fallback.windowMs,
+    maxRequests: fallback.maxRequests,
+  };
+}
+
+function checkRedisUnavailableFallback(
+  key: string,
+  config: RateLimitConfig,
+  now = Date.now(),
+): CheckResult {
+  const fallback = resolvedFallbackConfig(config);
+  if (!fallback) return fallOpenResult(config);
+  const bucketKey = `${fallback.namespace}:${key}`;
+  const current = redisUnavailableFallbackBuckets.get(bucketKey);
+  const bucket =
+    current && current.resetAt > now ? current : { count: 0, resetAt: now + fallback.windowMs };
+  bucket.count += 1;
+  redisUnavailableFallbackBuckets.set(bucketKey, bucket);
+  const allowed = bucket.count <= fallback.maxRequests;
+  return {
+    allowed,
+    remaining: Math.max(0, fallback.maxRequests - bucket.count),
+    resetAt: bucket.resetAt,
+    retryAfter: allowed ? undefined : Math.ceil((bucket.resetAt - now) / 1000),
+  };
+}
+
 function applyRateLimitHeaders(c: Context, headers: Record<string, string>): void {
   for (const [k, v] of Object.entries(headers)) {
     c.res.headers.set(k, v);
@@ -215,6 +282,7 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
     const key = (config.keyGenerator ?? getDefaultKey)(c);
     let result: CheckResult;
     let policy = "redis";
+    let headersConfig = effectiveConfig;
 
     try {
       result = await checkUpstash(
@@ -225,7 +293,14 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      if (config.failClosed) {
+      if (effectiveConfig.redisUnavailableFallback) {
+        logger.warn("[RateLimit] Redis unavailable; using local fallback limiter", {
+          error: message,
+        });
+        result = checkRedisUnavailableFallback(key, effectiveConfig);
+        headersConfig = fallbackHeadersConfig(effectiveConfig);
+        policy = "redis-unavailable-local";
+      } else if (config.failClosed) {
         // Money/auth route: losing the limiter is worse than a brief 503, so
         // reject rather than serve unlimited requests while Redis is down.
         logger.error("[RateLimit] Redis unavailable on fail-closed route; rejecting", {
@@ -241,18 +316,19 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
           503,
           { "Retry-After": "30" },
         );
+      } else {
+        // Rate limiting is protective middleware. If its backing store is down
+        // or unreachable in local Worker dev, requests should fall open instead
+        // of turning application routes into 500s.
+        logger.warn("[RateLimit] Redis unavailable; falling open", {
+          error: message,
+        });
+        result = fallOpenResult(effectiveConfig);
+        policy = "redis-unavailable";
       }
-      // Rate limiting is protective middleware. If its backing store is down
-      // or unreachable in local Worker dev, requests should fall open instead
-      // of turning application routes into 500s.
-      logger.warn("[RateLimit] Redis unavailable; falling open", {
-        error: message,
-      });
-      result = fallOpenResult(effectiveConfig);
-      policy = "redis-unavailable";
     }
 
-    const headers = rateLimitHeaders(effectiveConfig, result, policy);
+    const headers = rateLimitHeaders(headersConfig, result, policy);
 
     if (!result.allowed) {
       return c.json(
@@ -260,8 +336,8 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
           success: false,
           error: "Too many requests",
           code: "rate_limit_exceeded" as const,
-          message: `Rate limit exceeded. Maximum ${effectiveConfig.maxRequests} requests per ${Math.ceil(
-            effectiveConfig.windowMs / 1000,
+          message: `Rate limit exceeded. Maximum ${headersConfig.maxRequests} requests per ${Math.ceil(
+            headersConfig.windowMs / 1000,
           )} seconds.`,
           retryAfter: result.retryAfter,
         },
@@ -295,3 +371,4 @@ export const RateLimitPresets = {
 
 export { getDefaultKey, getIpKey, getRequestIp };
 export const _multiplier = multiplier;
+export const _resetRedisUnavailableFallbackBuckets = () => redisUnavailableFallbackBuckets.clear();


### PR DESCRIPTION
## Summary
- add an explicit Redis-outage fallback bucket to the shared Hono rate limiter
- mount that fallback only on `POST /api/auth/steward-session`, preserving login/session mint availability during Redis failures without naked fail-open traffic
- keep top-up/payment routes hard fail-closed on Redis outage
- add route-level coverage for missing-token, valid-token cookie minting, invalid-token spray, and top-up fail-closed behavior

Fixes the code-coupling half of #13890; the staging Redis restoration remains an ops concern.

## Verification
- `bun test packages/cloud/api/auth/steward-session/steward-session-rate-limit.test.ts packages/cloud/api/v1/topup/topup-rate-limit.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts` -> 7 pass / 0 fail
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts packages/cloud/api/auth/steward-session/route.ts packages/cloud/api/auth/steward-session/steward-session-rate-limit.test.ts packages/cloud/api/v1/topup/topup-rate-limit.test.ts` -> clean
- `node packages/shared/scripts/generate-keywords.mjs --target ts` -> completed, no diff
- `git diff --check origin/develop..HEAD` -> clean

## Broader Checks
- `bun run --cwd packages/cloud/api build` attempted; failed on pre-existing unrelated type drift: `my-agents-claim-affiliate-characters.test.ts` route `fetch` return type and `packages/cloud/shared/src/lib/auth/workers-hono-auth.ts:129` missing `readCookie`.
- `bun run --cwd packages/cloud/shared typecheck` attempted; failed on the same existing `workers-hono-auth.ts:129` missing `readCookie`.

## Evidence
- Added `.github/issue-evidence/13890-steward-session-fallback-limiter.md`.
- Full `bun run cloud:mock` request/log capture is not included yet; PR is draft until that package-level evidence is captured or explicitly accepted as not feasible for this narrow middleware fix.