### PR TITLE
fix(ui): iOS standalone PWA — pin fixed body to large viewport (kill bottom black band + restore swipe-up)

### DIFF
--- a/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
+++ b/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
@@ -140,3 +140,94 @@ describe("CSS lockdown contract — base.css / styles.css cover body.pwa-standal
     expect(rootBlock?.[0]).toContain("body.pwa-standalone #root");
   });
 });
+
+describe("CSS geometry contract — fixed-body ICB collapse fix (bottom black band)", () => {
+  // The residual bottom band regression: #14293's `position: fixed` body on the
+  // iOS Safari standalone PWA collapsed the fixed-descendant initial containing
+  // block to the layout (small) viewport, so `fixed inset-0` layers (wallpaper,
+  // safe-area floor) stopped ~59px above the true bottom and html/body/#root
+  // --launch-bg (#160d07) showed through as a near-black band. The fix pins the
+  // fixed body to the LARGE viewport height so its ICB fills the real screen.
+  const stylesDir = resolve(process.cwd(), "src/styles");
+  const stylesCss = readFileSync(resolve(stylesDir, "styles.css"), "utf8");
+
+  /** Extract the declaration block for the bare `body.pwa-standalone { ... }`
+   *  GEOMETRY rule (the one carrying the lvh height fix), NOT the grouped
+   *  `body.native, body.pwa-standalone { ... }` lockdown rule nor the
+   *  `body.pwa-standalone #root` rule. Walks every `body.pwa-standalone {`
+   *  block and returns the one whose body contains `100lvh`. */
+  function standalonePwaOwnBlock(): string {
+    // A selector that is EXACTLY `body.pwa-standalone` (preceded by start/`\n`,
+    // and — critically — not the tail of a comma group: the char before the
+    // preceding newline must not be a comma). Capture each block body and pick
+    // the one with the lvh height fix.
+    const re = /(?:^|[^,]\n)body\.pwa-standalone\s*\{([\s\S]*?)\}/g;
+    let match: RegExpExecArray | null;
+    // biome-ignore lint/suspicious/noAssignInExpressions: standard regex walk
+    while ((match = re.exec(stylesCss)) !== null) {
+      if (match[1].includes("100lvh")) return match[1];
+    }
+    // Fall back to the first bare block if none carried lvh (test will then
+    // fail loudly on the missing-100lvh assertion, which is the intent).
+    const first = stylesCss.match(
+      /(?:^|[^,]\n)body\.pwa-standalone\s*\{([\s\S]*?)\}/,
+    );
+    expect(first).not.toBeNull();
+    return first?.[1] ?? "";
+  }
+
+  it("pins the standalone-PWA fixed body to the LARGE viewport height (100lvh)", () => {
+    const block = standalonePwaOwnBlock();
+    // `100lvh` is the load-bearing declaration: it forces the fixed body's ICB
+    // to the large viewport so `fixed inset-0` children reach the true bottom.
+    expect(block).toContain("100lvh");
+    // Progressive-enhancement fallbacks for engines without lvh.
+    expect(block).toContain("100dvh");
+    expect(block).toContain("100vh");
+  });
+
+  it("releases `bottom` on the standalone-PWA body so top+height drive the box", () => {
+    // base.css's lockdown group sets `inset: 0` (=> bottom: 0) on
+    // body.pwa-standalone; leaving it would re-anchor the fixed body to the
+    // collapsed layout-viewport bottom (the bug). The geometry rule must reset
+    // it to `auto` so height governs the extent.
+    const block = standalonePwaOwnBlock();
+    expect(block).toMatch(/bottom:\s*auto/);
+  });
+
+  it("anchors the standalone-PWA body to the top-left of the viewport", () => {
+    const block = standalonePwaOwnBlock();
+    expect(block).toMatch(/top:\s*0/);
+    expect(block).toMatch(/left:\s*0/);
+    expect(block).toMatch(/right:\s*0/);
+  });
+
+  it("paints a warm ember floor color on the standalone body (no --launch-bg black seam)", () => {
+    // Defensive: any sub-pixel seam at the true bottom must read as the warm
+    // ember-floor ambience, never the near-black --launch-bg band.
+    const block = standalonePwaOwnBlock();
+    expect(block).toMatch(/background-color:\s*color-mix/);
+    expect(block).toContain("--launch-bg");
+  });
+
+  it("keeps the native (Capacitor) body on `inset: 0` — the fix is PWA-scoped", () => {
+    // Native WKWebView's fixed-ICB is already the full screen, so inset:0 is
+    // correct there; the lvh override must NOT bleed onto body.native. Find the
+    // BARE `body.native { ... }` rule (not the grouped lockdown selector) by
+    // picking the block that carries `inset: 0`.
+    const re = /(?:^|[^,]\n)body\.native\s*\{([\s\S]*?)\}/g;
+    let nativeOwn: string | null = null;
+    let match: RegExpExecArray | null;
+    // biome-ignore lint/suspicious/noAssignInExpressions: standard regex walk
+    while ((match = re.exec(stylesCss)) !== null) {
+      if (/inset:\s*0/.test(match[1])) {
+        nativeOwn = match[1];
+        break;
+      }
+    }
+    expect(nativeOwn).not.toBeNull();
+    expect(nativeOwn ?? "").toMatch(/inset:\s*0/);
+    // And the native own-block must not carry the lvh height override.
+    expect(nativeOwn ?? "").not.toContain("100lvh");
+  });
+});

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -102,8 +102,53 @@ html.eliza-chat-overlay-shell .shell-assistant-overlay-panel {
 body.native,
 body.pwa-standalone {
   position: fixed;
-  inset: 0;
   touch-action: pan-y;
+}
+
+/* Native Capacitor build: the WKWebView is the app window, so a fixed body's
+   initial containing block IS the full screen — `inset: 0` fills it. */
+body.native {
+  inset: 0;
+}
+
+/* iOS SAFARI standalone PWA — fixed-body ICB collapse fix (kills the residual
+   bottom black band + restores the bottom flick zone).
+
+   #14293 made this body `position: fixed` for the first time on the iOS *Safari*
+   standalone PWA (not the Capacitor native build). On Safari's WKWebView a
+   `position: fixed` BODY collapses the initial containing block for descendant
+   `position: fixed` elements to the LAYOUT (small) viewport — ~59px shorter than
+   `100dvh` (the large viewport) on a home-indicator phone. So `inset: 0` on the
+   body — and every `fixed inset-0` layer inside it (the ImageBackground
+   wallpaper, the app-safe-area-floor) — anchored `bottom: 0` to that collapsed
+   box and stopped ~59px above the true screen bottom. Below them, html/body/#root
+   painted `--launch-bg` (#160d07) → the measured near-black band. The same
+   collapse seated the chat composer + its bottom flick zone ~59px high and left
+   the strip below OUTSIDE the fixed body box, where touches hit html
+   (touch-action: auto) and Safari's edge-pan ate the swipe-up.
+
+   Fix: pin the fixed body to the LARGE viewport height so its ICB fills the real
+   screen. `100lvh` is the large-viewport unit (stable regardless of the
+   fixed-body ICB collapse); `100dvh`/`100vh` are progressive-enhancement
+   fallbacks for engines without `lvh`. `top: 0; left: 0; right: 0` anchor it;
+   height (not `bottom: 0`) drives the extent so it reaches the true bottom. */
+body.pwa-standalone {
+  top: 0;
+  left: 0;
+  right: 0;
+  /* Explicitly release `bottom` (base.css's lockdown `inset: 0` sets it): with
+     top + height driving the box, a leftover `bottom: 0` would re-anchor the
+     fixed body to the collapsed layout-viewport bottom — the exact bug. */
+  bottom: auto;
+  height: 100vh;
+  height: 100dvh;
+  height: 100lvh;
+  /* Defensive floor color: if a 1px sub-pixel seam survives at the very bottom
+     edge (rounding between 100lvh and the device screen), paint it the warm
+     ember-floor tone the ImageBackground bottom-gradient + ShaderBackground
+     fallback already pool there, so a seam reads as lock-screen ambience —
+     never the near-black --launch-bg band. Sits UNDER the fixed wallpaper. */
+  background-color: color-mix(in srgb, var(--launch-bg, #160d07) 82%, #ef5a1f);
 }
 
 body.native #root,


### PR DESCRIPTION
## What
Kills the residual **near-black bottom band** on the installed iOS Safari standalone PWA and restores the dead **home-screen swipe-up / rail flick** — both of which survived #14224 and #14293.

Fixes #14318

## Root cause — fixed-body ICB collapse (post-#14293)
#14293 added `body.pwa-standalone { position: fixed; inset: 0 }` — the **first** time the iOS *Safari* standalone PWA got a `position: fixed` **body** (the Capacitor native build already had it and is immune). On Safari's WKWebView a `position: fixed` **body collapses the initial containing block for descendant `position: fixed` elements to the LAYOUT (small) viewport** — ~59px shorter than `100dvh` (large viewport) on a home-indicator phone.

Therefore:
1. `ImageBackground` (`fixed inset-0` wallpaper) + `app-safe-area-floor` (`fixed inset-0`) anchor `bottom: 0` to the collapsed box → stop ~59px above the true bottom.
2. Below them, html/body/#root paint `--launch-bg` (`#160d07`) → the band.
3. The same collapse seats the `ContinuousChatOverlay` composer + bottom flick zone ~59px high; the strip below is **outside the fixed body box**, where touches hit `html` (`touch-action: auto`) and Safari's edge-pan eats the swipe → dead gestures.

Native is immune (its WKWebView fixed-ICB == full screen — why #14224 worked on native but the PWA band survived).

## Device receipts
- Build `889903ee43` (develop tip incl. #14293 + #14224), iPhone 15/16 Pro Max standalone PWA.
- Screenshot pixel analysis (1290×2796, DPR 3 → 430×932 CSS): bottom band = solid `rgb(22,13,7)` = **`#160d07` = exactly `--launch-bg`**, **59.3 CSS px** tall, uniform full-width. Home-indicator inset = 34px, so the band is ~25px **taller** than the safe area — the layout-viewport shortfall, not just the inset.

## Fix (`styles.css`, scoped to `body.pwa-standalone`)
- Pin the fixed body to the **large viewport height**: `height: 100vh → 100dvh → 100lvh` (progressive enhancement; `100lvh` is stable under the fixed-body ICB collapse) so its ICB fills the real screen and every `fixed inset-0` child + the flick zone/composer reach the true bottom.
- `bottom: auto` so top + height drive the box (base.css's lockdown `inset: 0` would otherwise re-anchor to the collapsed bottom).
- `top/left/right: 0`.
- Defensive warm ember-floor `background-color` so any sub-pixel seam reads as lock-screen ambience, never the `--launch-bg` black band.
- `body.native` keeps `inset: 0`; desktop/electrobun untouched.

## Tests
- `packages/ui/src/platform/standalone-pwa-lockdown.test.ts`: new geometry-contract block (14 tests total, green) — asserts the standalone body carries `100lvh` (+dvh/vh fallbacks), `bottom: auto`, top/left/right anchors, the ember floor color, and that `body.native` stays on `inset: 0` without the lvh override. Existing lockdown/gesture/`#root` contracts intact.
- Full `src/platform/` lane: **60/60 green**.
- `bun run build:client`: **green, 104/104 turbo tasks** (@elizaos/app vite bundle built; CSS compiles clean).

## Notes for the next device test
The `BuildBadge` already stamps the sha; a follow-up could extend its long-press to surface `body` classes + `innerHeight` vs `100dvh` px for remote confirmation. Not included here to keep the fix minimal.

— [sol-orch]
