### PR TITLE
fix(app): SW must not cache /login or the OAuth callback (stale-shell login breakage)

### DIFF
--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -85,6 +85,20 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
+  // Auth navigations are NEVER intercepted: the sign-in page and the OAuth
+  // callback must always load the freshest shell from the network. A stale
+  // cached shell can carry an outdated build — e.g. one baked with the wrong
+  // Steward tenant — which makes the code exchange fail with 401, and caching a
+  // one-time `?code=` callback URL risks replaying a consumed code. Bypassing
+  // (no respondWith) lets the browser fetch directly, uncached.
+  if (
+    pathname === "/login" ||
+    url.searchParams.has("code") ||
+    url.searchParams.has("token")
+  ) {
+    return;
+  }
+
   // App shell: only intercept navigation requests for index.html (not API calls
   // or static assets that the browser handles fine without SW involvement).
   if (request.mode === "navigate") {

--- a/packages/app/test/service-worker-auth-bypass.test.ts
+++ b/packages/app/test/service-worker-auth-bypass.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Service-worker auth navigation guard. The test evaluates the real `sw.js`
+ * file inside a minimal worker-like VM so the fetch handler can be exercised
+ * without a browser install.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+type FetchEventLike = {
+  request: {
+    method: string;
+    mode: string;
+    url: string;
+    clone: () => FetchEventLike["request"];
+  };
+  respondWith: ReturnType<typeof vi.fn>;
+};
+
+function loadServiceWorker() {
+  const listeners = new Map<string, ((event: unknown) => void)[]>();
+  const self = {
+    location: { origin: "https://app.example.test" },
+    addEventListener(type: string, listener: (event: unknown) => void) {
+      listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+    },
+    skipWaiting: () => Promise.resolve(),
+    clients: {
+      claim: () => Promise.resolve(),
+      matchAll: () => Promise.resolve([]),
+    },
+  };
+  const cache = {
+    match: () => Promise.resolve(null),
+    put: () => Promise.resolve(),
+    keys: () => Promise.resolve([]),
+    delete: () => Promise.resolve(true),
+  };
+  const context = vm.createContext({
+    self,
+    URL,
+    Response,
+    caches: {
+      keys: () => Promise.resolve([]),
+      open: () => Promise.resolve(cache),
+      delete: () => Promise.resolve(true),
+    },
+    fetch: () =>
+      Promise.resolve(new Response("<html></html>", { status: 200 })),
+    Promise,
+  });
+  const script = readFileSync(path.resolve(here, "../public/sw.js"), "utf8");
+  vm.runInContext(script, context, { filename: "sw.js" });
+  return {
+    dispatchFetch(event: FetchEventLike) {
+      for (const listener of listeners.get("fetch") ?? []) listener(event);
+    },
+  };
+}
+
+function navigation(pathname: string): FetchEventLike {
+  const request = {
+    method: "GET",
+    mode: "navigate",
+    url: `https://app.example.test${pathname}`,
+    clone: () => request,
+  };
+  return { request, respondWith: vi.fn() };
+}
+
+describe("service worker auth navigation bypass", () => {
+  it.each([
+    "/login",
+    "/login?code=one-time",
+    "/chat?token=handoff",
+  ])("does not intercept %s", (pathname) => {
+    const worker = loadServiceWorker();
+    const event = navigation(pathname);
+
+    worker.dispatchFetch(event);
+
+    expect(event.respondWith).not.toHaveBeenCalled();
+  });
+
+  it("still intercepts ordinary app-shell navigations", () => {
+    const worker = loadServiceWorker();
+    const event = navigation("/chat");
+
+    worker.dispatchFetch(event);
+
+    expect(event.respondWith).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Bypass the service worker for `/login` + `?code=`/`?token=` navigations so auth always loads the freshest shell from network. Prevents the stale-SW-serves-old-build class that broke staging login with 401 'Invalid token' (root-caused in HQ #14308). Closes #14391.

Evidence: minimal early-return in `sw.js` (biome-ignored static file); live SW-cache verification (`/login` never in Cache Storage; deploy picked up without manual unregister) to run post-deploy on staging. [qa-agent]