### PR TITLE
docs(status): record board 15 population + coordination discussions

### DIFF
--- a/packages/docs/ongoing-development/README.md
+++ b/packages/docs/ongoing-development/README.md
@@ -25,9 +25,10 @@ pipeline:
 
 1. **Discussion** — conversation starts in
    [GitHub Discussions](https://github.com/elizaOS/eliza/discussions): one
-   kickoff thread per workstream (General, titled `[MVP] <workstream>`) plus a
-   pinned master coordination thread (Announcements). Discussions are for
-   conversation, not storage — if something was decided, it belongs in a doc.
+   kickoff thread per workstream (General) plus the master coordination thread
+   ([#14407](https://github.com/orgs/elizaOS/discussions/14407), Announcements).
+   Discussions are for conversation, not storage — if something was decided, it
+   belongs in a doc. (Live thread links: [`status/STATUS.md`](status/STATUS.md).)
 2. **Design doc** — decisions land here as a PR: a `research/` doc for the
    initial audit + plan, a `design/` doc for an accepted design being built.
    A stale design doc is a bug; the PR that diverges from it updates it.

--- a/packages/docs/ongoing-development/status/STATUS.md
+++ b/packages/docs/ongoing-development/status/STATUS.md
@@ -6,22 +6,23 @@ a dated, human-written summary. See [`../mvp/MVP.md`](../mvp/MVP.md) for scope
 and the acceptance bar.
 
 All nine workstreams have completed their research/design docs. **55 issues are
-filed** on GitHub (#14321–#14376) and are being **added to board 15**; the
-per-workstream **discussions are being opened** (master coordination thread in
-Announcements, one `[MVP] <workstream>` kickoff per workstream in General).
-"# issues" below is the count filed for each workstream.
+filed** on GitHub (#14321–#14376) and **added to [board 15](https://github.com/orgs/elizaOS/projects/15)**
+(status `Backlog`). Coordination **discussions are open**: a master thread
+([#14407](https://github.com/orgs/elizaOS/discussions/14407), Announcements) and
+one kickoff per workstream (General, linked below). "# issues" is the count
+filed for each workstream.
 
-| Workstream | Doc | Phase | # issues | Next action |
+| Workstream | Doc | Kickoff | # issues | Next action |
 | --- | --- | --- | --- | --- |
-| 1. Personas & UX journeys | [01](../research/01-mvp-product-personas.md) | research done, issues filed | 7 | Verify ADHD packs A1/A2 (P0) — live runs, hand-read trajectories |
-| 2. In-chat widgets | [02](../research/02-chat-widget-system.md) | research done, issues filed | 7 | Fix dead connector `/forms/:id` link (P0); live-LLM round-trip coverage (P0) |
-| 3. Launcher widgets | [03](../research/03-launcher-widgets.md) | research done, issues filed | 6 | Remove seven non-MVP home widgets + wallet respec (P0) |
-| 4. Onboarding, tutorial & help | [04](../research/04-onboarding-tutorial-help.md) | research done, issues filed | 7 | Resurrect `app-live-e2e.yml` (P0); device e2e for default cloud path (P0) |
-| 5. Chat window UX | [05](../research/05-chat-window-ux.md) | research done, issues filed | 6 | Lock transcript to vertical scroll (P0); history pagination (P0) |
-| 6. View↔chat integration | [06](../research/06-views-chat-integration.md) | research done, issues filed | 6 | Consolidated `SETTINGS` action + wire settings writes (P0) |
-| 7. Voice pipeline | [07](../research/07-voice-pipeline.md) | research done, issues filed | 7 | Benchmark cloud vs on-device + publish decision (P0); voice e2e (P0) |
-| 8. Device testing pipeline | [08](../research/08-device-testing-pipeline.md) | research done, issues filed | 6 | Fix Android stale-install bug (P0); ship `devices:status` (P0) |
-| 9. Doc-driven development | [09](../research/09-doc-driven-development.md) | research done, issues filed | 3 | PR-evidence gate stops accepting retired issue-evidence paths (P1) |
+| 1. Personas & UX journeys | [01](../research/01-mvp-product-personas.md) | [#14392](https://github.com/orgs/elizaOS/discussions/14392) | 7 | Verify ADHD packs A1/A2 (P0) — live runs, hand-read trajectories |
+| 2. In-chat widgets | [02](../research/02-chat-widget-system.md) | [#14396](https://github.com/orgs/elizaOS/discussions/14396) | 7 | Fix dead connector `/forms/:id` link (P0); live-LLM round-trip coverage (P0) |
+| 3. Launcher widgets | [03](../research/03-launcher-widgets.md) | [#14400](https://github.com/orgs/elizaOS/discussions/14400) | 6 | Remove seven non-MVP home widgets + wallet respec (P0) |
+| 4. Onboarding, tutorial & help | [04](../research/04-onboarding-tutorial-help.md) | [#14401](https://github.com/orgs/elizaOS/discussions/14401) | 7 | Resurrect `app-live-e2e.yml` (P0); device e2e for default cloud path (P0) |
+| 5. Chat window UX | [05](../research/05-chat-window-ux.md) | [#14402](https://github.com/orgs/elizaOS/discussions/14402) | 6 | Lock transcript to vertical scroll (P0); history pagination (P0) |
+| 6. View↔chat integration | [06](../research/06-views-chat-integration.md) | [#14403](https://github.com/orgs/elizaOS/discussions/14403) | 6 | Consolidated `SETTINGS` action + wire settings writes (P0) |
+| 7. Voice pipeline | [07](../research/07-voice-pipeline.md) | [#14404](https://github.com/orgs/elizaOS/discussions/14404) | 7 | Benchmark cloud vs on-device + publish decision (P0); voice e2e (P0) |
+| 8. Device testing pipeline | [08](../research/08-device-testing-pipeline.md) | [#14405](https://github.com/orgs/elizaOS/discussions/14405) | 6 | Fix Android stale-install bug (P0); ship `devices:status` (P0) |
+| 9. Doc-driven development | [09](../research/09-doc-driven-development.md) | [#14406](https://github.com/orgs/elizaOS/discussions/14406) | 3 | PR-evidence gate stops accepting retired issue-evidence paths (P1) |
 
 ## How to update this file
 


### PR DESCRIPTION
# Relates to

Follow-up to #14388 (merged). That PR stood up `packages/docs/ongoing-development/` and filed 55 MVP issues onto [board 15](https://github.com/orgs/elizaOS/projects/15). This PR records the now-completed coordination state in the status/index docs.

# What does this PR do?

All 55 issues (#14321–#14376) are on board 15 (status `Backlog`), and the coordination discussions are open — a master thread ([#14407](https://github.com/orgs/elizaOS/discussions/14407), Announcements) plus one per-workstream kickoff (General). This wires those live links into:

- `packages/docs/ongoing-development/status/STATUS.md` — per-workstream table now links each kickoff discussion; header reflects board populated + discussions open.
- `packages/docs/ongoing-development/README.md` — points at the master thread and STATUS.md for live links.

# Risks

**Low** — two docs files, link additions only.

# Evidence Gate

Docs-only.

<details>
<summary>Gates (green)</summary>

```
node scripts/check-markdown-links.mjs      -> exit 0
bun run --cwd packages/docs test           -> 15 pass / 0 fail
```
</details>

- [ ] Screenshots / video / logs / trajectory — `N/A - docs-only link update, no UI or runtime path`.
- [x] Domain artifacts — the [board](https://github.com/orgs/elizaOS/projects/15) (55 items) and the 10 discussions (#14392, #14396, #14400–#14407) are the artifacts.
