### PR TITLE
fix(agent): type database route test recorder

### DIFF
--- a/packages/agent/src/api/database.query-readonly.test.ts
+++ b/packages/agent/src/api/database.query-readonly.test.ts
@@ -6,8 +6,8 @@
 
 import type http from "node:http";
 import { PassThrough } from "node:stream";
+import type { AgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentRuntime } from "../runtime/eliza.ts";
 import { handleDatabaseRoute } from "./database.ts";
 
 function jsonPost(body: unknown): http.IncomingMessage {
@@ -19,26 +19,29 @@ function jsonPost(body: unknown): http.IncomingMessage {
   return req;
 }
 
-function responseRecorder(): http.ServerResponse & {
+type RecordedResponse = http.ServerResponse & {
   body: string;
   headers: Record<string, string | number | readonly string[]>;
-} {
+};
+
+function responseRecorder(): RecordedResponse {
   return {
     statusCode: 200,
     body: "",
     headers: {},
-    setHeader(name: string, value: string | number | readonly string[]) {
+    setHeader(
+      this: RecordedResponse,
+      name: string,
+      value: string | number | readonly string[],
+    ) {
       this.headers[name.toLowerCase()] = value;
       return this;
     },
-    end(chunk?: unknown) {
+    end(this: RecordedResponse, chunk?: unknown) {
       if (chunk !== undefined) this.body += String(chunk);
       return this;
     },
-  } as unknown as http.ServerResponse & {
-    body: string;
-    headers: Record<string, string | number | readonly string[]>;
-  };
+  } as unknown as RecordedResponse;
 }
 
 describe("POST /api/database/query read-only guard", () => {


### PR DESCRIPTION
## Summary
- Import `AgentRuntime` for the database route readonly test from `@elizaos/core` instead of the runtime implementation path.
- Give the test response recorder a local `RecordedResponse` type and typed `this` methods so the helper stays explicit without repeating the intersection cast.

## Verification
- PASS: `bun run --cwd packages/agent test database.query-readonly.test.ts`
- FAIL (unrelated develop baseline): `bun run --cwd packages/agent typecheck` currently fails on missing `@elizaos/plugin-aosp-local-inference`, trajectory/view-scoped-action types, plugin-sql nullable memory IDs, and task-coordinator UI exports.

## Notes
- Synced `origin/develop` and `origin/main`; `origin/main` is an ancestor of `origin/develop`.
- Removed generated untracked JS/d.ts/map build output from the worktree. Local nested `.codex-pr-worktrees/` entries are dirty Git worktrees, so they were hidden via `.git/info/exclude` rather than deleted.