### PR TITLE
fix(ui): stop onboarding chat-spam loop on a stale cloud token (#14387)

### DIFF
--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -1303,6 +1303,53 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
     expect(reply.text).toContain("sign in to Eliza Cloud");
     unmount();
   });
+
+  it("a stale cloud session (connected in memory, no usable token) does not complete onboarding or loop provisioning (#14387)", async () => {
+    // elizaCloudConnected reads true, but the durable steward token is gone, so
+    // getCloudAuthToken() is empty and the bind reports needs-cloud-login. Pre-fix
+    // this re-armed the auto-resume marker WHILE already "connected", and the
+    // effect re-fired on every seeded-turn render → an unbounded
+    // provision→fail→re-arm loop that spammed the transcript. The fix skips the
+    // re-arm while connected and fires the auto-resume effect at most once per
+    // connection epoch, so the stale session lands on a bounded recovery surface
+    // and never silently completes onboarding.
+    localStorage.removeItem("steward_session_token");
+    mocks.client.getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          agent_id: "agent-stale",
+          agent_name: "Stale",
+          status: "running",
+          created_at: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+    const spies = seedAppStore({ elizaCloudConnected: true });
+    const { transcript, unmount } = renderConductor();
+
+    // A recovery surface (sign-in retry OR error card) appears — onboarding is
+    // NOT silently completed on a stale/invalid token.
+    await waitFor(() => {
+      expect(
+        transcript.current.some(
+          (m) =>
+            m.id === "first-run:cloud-oauth" ||
+            m.id.startsWith("first-run:error:"),
+        ),
+      ).toBe(true);
+    });
+    expect(spies.completeFirstRun).not.toHaveBeenCalled();
+
+    // No runaway: give any residual auto-resume loop a window, then prove the
+    // provision listing was attempted a bounded number of times and does not keep
+    // growing (pre-fix it grew every re-fired render).
+    const listed = mocks.client.getCloudCompatAgents.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(mocks.client.getCloudCompatAgents.mock.calls.length).toBe(listed);
+    expect(listed).toBeLessThanOrEqual(3);
+    unmount();
+  });
 });
 
 // ── persistFirstRun exactly-once under concurrency (via the real finish) ────

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -605,6 +605,12 @@ export function useFirstRunConductor(): void {
     null,
   );
   const bindInFlightRef = React.useRef(false);
+  // Live mirror of elizaCloudConnected for call-time reads inside callbacks that
+  // must NOT list it as a dep (adding it re-registers the action handler and
+  // re-seeds on every connection change). It also gates the needs-cloud-login
+  // re-arm below so a stale-but-"connected" token can't spin the resume loop.
+  const elizaCloudConnectedRef = React.useRef(elizaCloudConnected);
+  elizaCloudConnectedRef.current = elizaCloudConnected;
 
   const handleOutcome = React.useCallback(
     (outcome: FirstRunFinishOutcome) => {
@@ -634,8 +640,18 @@ export function useFirstRunConductor(): void {
           return;
         }
         case "needs-cloud-login": {
-          pendingCloudResumeRef.current =
-            draftRef.current.runtime === "cloud" ? "cloud" : "hybrid";
+          // Arm auto-resume ONLY when not already connected. If elizaCloudConnected
+          // already reads true yet the bind still reported needs-cloud-login, the
+          // stored token is stale/invalid (getCloudAuthToken shadowed empty) — arming
+          // would let the auto-resume effect (gated on elizaCloudConnected) re-fire at
+          // once and spin the provision→fail→re-arm loop that spammed the transcript
+          // (#14387). Show the retry turn and wait for a genuine re-auth (a false→true
+          // flip re-enables resume); its sign-in tap re-enters the flow meanwhile.
+          pendingCloudResumeRef.current = elizaCloudConnectedRef.current
+            ? null
+            : draftRef.current.runtime === "cloud"
+              ? "cloud"
+              : "hybrid";
           surfaceCloudLoginRetryTurn({ seedTurn, replaceTurn });
           return;
         }
@@ -756,25 +772,34 @@ export function useFirstRunConductor(): void {
   );
   bindCloudAgentByIdRef.current = bindCloudAgentById;
 
-  // Auto-resume: when the user connects Eliza Cloud from the retry turn's
-  // OAuth block (instead of re-picking a runtime), continue the interrupted
-  // flow the moment the store learns the connection landed. A fresh pick
-  // clears the pending marker, so the user's latest intent always wins.
-  React.useEffect(() => {
-    if (!active || !elizaCloudConnected) return;
-    const resume = pendingCloudResumeRef.current;
-    if (!resume) return;
-    runCloudResume(resume);
-  }, [active, elizaCloudConnected, runCloudResume]);
-
-  // Read-only mirrors so the mount effect can resume immediately when the
-  // durable token already made the connection live at launch — without adding
-  // elizaCloudConnected/runCloudResume to the mount effect's deps (which would
-  // re-register the action handler and re-seed on every connection change).
-  const elizaCloudConnectedRef = React.useRef(elizaCloudConnected);
-  elizaCloudConnectedRef.current = elizaCloudConnected;
+  // Read-only mirror so the auto-resume effect + the mount rehydrate can drive
+  // runCloudResume without listing it as a dep. Its identity churns as its own
+  // deps (replaceTurn, the flow launchers) change; the effect below depending on
+  // it re-fired on every seeded-turn render and, on a stale token, spun the
+  // provision→fail→re-arm loop (#14387).
   const runCloudResumeRef = React.useRef(runCloudResume);
   runCloudResumeRef.current = runCloudResume;
+
+  // Auto-resume: when the user connects Eliza Cloud from the retry turn's OAuth
+  // block (instead of re-picking a runtime), continue the interrupted flow the
+  // moment the store learns the connection landed. Fires AT MOST ONCE per
+  // connection epoch: a resume that lands back on needs-cloud-login (stale token)
+  // must not immediately re-fire — that is the loop that spammed the onboarding
+  // transcript (#14387). A fresh false→true connection flip clears the latch and
+  // re-enables resume; the retry turn's sign-in tap re-enters the flow meanwhile.
+  // A fresh pick clears the pending marker, so the user's latest intent wins.
+  const resumedForConnectionRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!active || !elizaCloudConnected) {
+      resumedForConnectionRef.current = false;
+      return;
+    }
+    if (resumedForConnectionRef.current) return;
+    const resume = pendingCloudResumeRef.current;
+    if (!resume) return;
+    resumedForConnectionRef.current = true;
+    runCloudResumeRef.current(resume);
+  }, [active, elizaCloudConnected]);
 
   const handleFirstRunAction = React.useCallback(
     (value: string): boolean => {


### PR DESCRIPTION
Closes #14387.

## The bug (shaw's report)
The in-chat onboarding **spams the transcript** — repeated sign-in/error cards — when the app is "connected" (`elizaCloudConnected === true`) but the stored token is stale/invalid, or when provisioning 402s on no credits. First experience a new user hits → launch/demo-critical.

## Root cause (`use-first-run-conductor.ts`)
An infinite `provision → bind → needs-cloud-login → re-arm → auto-resume` loop whose failure surface appends a card every cycle:

1. **Effect re-fires on churn.** The auto-resume effect depended on `runCloudResume`'s *identity*, which churns as its own deps (`replaceTurn`, the flow launchers → `seedError`) change on every seeded-turn render.
2. **Re-arm while connected.** `handleOutcome` re-armed `pendingCloudResumeRef` on `needs-cloud-login` even while already connected — so `bindCloudAgentById` (empty `getCloudAuthToken`) → `needs-cloud-login` → re-arm → the effect re-fires → provision again → …
3. **Non-idempotent seeding.** Each cycle mints a unique id (`first-run:error:${Date.now()}`, `…:retry:${Date.now()}`) → a *new* card every time = the visible spam.

Regressing merges: the cloud-only onboarding rewrite (#13393 / #13521, umbrella #13377). Independently corroborated by @cloud-agent (same 402/no-credits trigger path).

## Fix (3 changes, all in `use-first-run-conductor.ts`)
- **Skip the resume re-arm while `elizaCloudConnected` is already true** — a stale "connected" token surfaces the sign-in retry and waits for a real `false→true` reconnect instead of silently retrying.
- **Drive the auto-resume effect through `runCloudResumeRef`** (already present) instead of the churning callback identity; effect deps drop to `[active, elizaCloudConnected]`.
- **One-shot latch the auto-resume per connection epoch**; a fresh `false→true` flip clears it.

The user-initiated retry path (each tapped retry mints a distinct error card — intentional, asserted by the existing `error:retry` tests) is unchanged.

## Evidence
<details><summary><code>packages/ui</code> — use-first-run-conductor.test.ts · <b>41/41 pass</b></summary>

```
❯ src/first-run/use-first-run-conductor.test.ts (41 tests)
  Test Files  1 passed (1)
       Tests  41 passed (41)
```
40 existing onboarding-flow tests unchanged (incl. the auto-resume-once happy path) + 1 new regression guard: *"a stale cloud session (connected in memory, no usable token) does not complete onboarding or loop provisioning (#14387)"*.
</details>

- `biome check` on both changed files: clean.
- **Harness note (honesty):** the unbounded *storm* itself needs production render-identity churn that the stable jsdom harness cannot reproduce (stable callback identities + no auto-rerender). The new test therefore pins the observable invariants — **no silent completion on a stale token, bounded provisioning** — while the loop removal is code-level (effect deps + epoch latch + no re-arm-while-connected). On-device repro of the storm is deferred (would require resetting first-run on the demo Seeker, wiping the signed-in state).

## Notes
Authored by `[maintainer]` — per FLEET.md I will **not** self-merge; needs a reviewer lane. cc @shaw @qa-agent (#13377 onboarding lane).
