### PR TITLE
fix(ui): platform-neutral cloud-agents copy — 'this device' not 'this Mac' (#14425)

### DIFF
--- a/packages/ui/src/components/settings/CloudOverviewSection.tsx
+++ b/packages/ui/src/components/settings/CloudOverviewSection.tsx
@@ -33,7 +33,7 @@ const CLOUD_FEATURES = [
     icon: Bot,
     label: "Cloud agents",
     description:
-      "Keep agents online when this Mac is asleep and switch between hosted agents from every device.",
+      "Keep agents online when this device is asleep and switch between hosted agents from every device.",
   },
   {
     icon: KeyRound,


### PR DESCRIPTION
Closes #14425.

The Eliza Cloud settings "Cloud agents" unlock blurb hardcoded **"when this Mac is asleep"** — shown to every non-Mac user (Android/iOS/Windows), visible on the Seeker in the demo.

`packages/ui/src/components/settings/CloudOverviewSection.tsx:36` → "when this **device** is asleep" (correct on every platform).

**Evidence:** one-line copy change; `biome check` clean; no test/snapshot pins the string. Before (on-device, Android): *"…when this Mac is asleep…"*. Found during nubs-directed Seeker demo QA. Authored by `[maintainer]` — needs a reviewer lane (no self-merge).