### PR TITLE
fix(process): reject retired issue-evidence paths

### DIFF
--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -64,7 +64,7 @@ export function hasArtifactReference(text) {
   ) {
     return true;
   }
-  return /\.github\/issue-evidence\/\S+/i.test(text);
+  return false;
 }
 
 export function isChecked(rowText) {
@@ -198,9 +198,9 @@ function buildFixtureBody(overrides = {}) {
     "after-screenshots":
       "- [ ] After screenshots `N/A - backend-only change, no UI surface`.",
     "walkthrough-video":
-      "- [x] A video walkthrough: .github/issue-evidence/13676-video.mp4",
+      "- [x] A video walkthrough: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000000",
     "backend-logs":
-      "- [ ] Backend logs: see .github/issue-evidence/13676-backend.txt",
+      "- [ ] Backend logs: [backend.txt](https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001)",
     "frontend-logs": "- [ ] Frontend logs `N/A - no frontend change`.",
     "llm-trajectory":
       "- [ ] Real-LLM trajectory: [report](https://example.com/report.json)",
@@ -284,6 +284,20 @@ function runSelfTest() {
   }
 
   {
+    const { ok, findings } = evaluatePrEvidence(
+      buildFixtureBody({
+        "backend-logs":
+          "- [ ] Backend logs: .github/issue-evidence/13676-backend.txt",
+      }),
+    );
+    const backend = findings.find((finding) => finding.id === "backend-logs");
+    if (ok) failures.push("issue-evidence-only row should fail");
+    if (backend?.status !== "blank") {
+      failures.push("issue-evidence-only row should be reported blank");
+    }
+  }
+
+  {
     const body = REQUIRED_EVIDENCE_ROWS.slice(1)
       .map(
         ({ id }) =>
@@ -305,7 +319,7 @@ function runSelfTest() {
     for (const failure of failures) console.error(`  - ${failure}`);
     process.exit(1);
   }
-  console.log("check-pr-evidence self-test passed (7 cases).");
+  console.log("check-pr-evidence self-test passed (8 cases).");
 }
 
 function main() {
@@ -342,7 +356,8 @@ function main() {
     console.error(
       `\nEvidence gate FAILED: ${bad.length} row(s) blank or missing. ` +
         "Attach an artifact link/path or write `N/A - <reason>` on each row. " +
-        "For ui/frontend/native PRs, before/after screenshots and walkthrough video require concrete artifact links/paths.",
+        "For ui/frontend/native PRs, before/after screenshots and walkthrough video require concrete artifact links/paths. " +
+        "Retired `.github/issue-evidence/...` repo paths do not count as evidence.",
     );
     process.exit(1);
   }

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -34,9 +34,9 @@ function buildBody(overrides = {}) {
     "after-screenshots":
       "- [ ] After screenshots `N/A - backend-only change, no UI surface`.",
     "walkthrough-video":
-      "- [x] A video walkthrough: .github/issue-evidence/13676-video.mp4",
+      "- [x] A video walkthrough: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000000",
     "backend-logs":
-      "- [ ] Backend logs: see .github/issue-evidence/13676-backend.txt",
+      "- [ ] Backend logs: [backend.txt](https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001)",
     "frontend-logs": "- [ ] Frontend logs `N/A - no frontend change`.",
     "llm-trajectory":
       "- [ ] Real-LLM trajectory: [report](https://example.com/report.json)",
@@ -128,11 +128,11 @@ describe("check-pr-evidence parser", () => {
     const { ok, findings } = evaluatePrEvidence(
       buildBody({
         "before-screenshots":
-          "- [ ] Before screenshots: .github/issue-evidence/13622-before.png",
+          "- [ ] Before screenshots: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000002",
         "after-screenshots":
-          "- [ ] After screenshots: .github/issue-evidence/13622-after.png",
+          "- [ ] After screenshots: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000003",
         "walkthrough-video":
-          "- [ ] Walkthrough video: .github/issue-evidence/13622-demo.webm",
+          "- [ ] Walkthrough video: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000004",
       }),
       REQUIRED_EVIDENCE_ROWS,
       { labels: "frontend" },
@@ -189,7 +189,7 @@ describe("check-pr-evidence row primitives", () => {
     assert.equal(hasNaWithReason("N/A - <reason>."), false);
   });
 
-  it("detects links, URLs, and issue-evidence paths", () => {
+  it("detects links and URLs", () => {
     assert.equal(hasArtifactReference("[report](https://x/y.json)"), true);
     assert.equal(
       hasArtifactReference("see https://github.com/o/r/assets/1"),
@@ -197,11 +197,31 @@ describe("check-pr-evidence row primitives", () => {
     );
     assert.equal(
       hasArtifactReference(
-        "committed under .github/issue-evidence/13676-a.png",
+        "see https://user-images.githubusercontent.com/1/a.jpg",
       ),
       true,
     );
     assert.equal(hasArtifactReference("just words, no artifact"), false);
+  });
+
+  it("rejects retired repo-local issue-evidence paths", () => {
+    assert.equal(
+      hasArtifactReference(
+        "committed under .github/issue-evidence/13676-a.png",
+      ),
+      false,
+    );
+    const { ok, findings } = evaluatePrEvidence(
+      buildBody({
+        "backend-logs":
+          "- [ ] Backend logs: .github/issue-evidence/13676-backend.txt",
+      }),
+    );
+    assert.equal(ok, false);
+    assert.equal(
+      findings.find((finding) => finding.id === "backend-logs").status,
+      "blank",
+    );
   });
 
   it("detects checked checkboxes without treating them as evidence", () => {
@@ -236,9 +256,12 @@ describe("check-pr-evidence row primitives", () => {
       false,
     );
     assert.equal(
-      isRowSatisfiedForContext("- [ ] .github/issue-evidence/13622-ui.png", {
-        artifactRequired: true,
-      }),
+      isRowSatisfiedForContext(
+        "- [ ] https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000005",
+        {
+          artifactRequired: true,
+        },
+      ),
       true,
     );
   });
@@ -252,11 +275,11 @@ describe("check-pr-evidence marker extraction", () => {
       "      or are marked `N/A - no backend path in this change`.",
       "",
       "<!-- evidence-row:frontend-logs -->",
-      "- [ ] Frontend logs: .github/issue-evidence/13676-frontend.txt",
+      "- [ ] Frontend logs: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000006",
     ].join("\n");
     const rows = extractEvidenceRows(body);
     assert.ok(rows.get("backend-logs").includes("N/A - no backend path"));
-    assert.ok(rows.get("frontend-logs").includes("13676-frontend.txt"));
+    assert.ok(rows.get("frontend-logs").includes("user-attachments/assets"));
   });
 
   it("bounds the last row so trailing links do not bleed in", () => {


### PR DESCRIPTION
# Relates to

Closes #14340.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. This only tightens the PR-body evidence parser so retired repo-local evidence paths no longer satisfy a row.

# Background

## What does this PR do?

- Stops treating `.github/issue-evidence/...` as a valid artifact reference.
- Updates self-test and unit fixtures to use GitHub inline attachment URLs.
- Adds coverage proving an issue-evidence-only row is reported `blank`.

## What kind of change is this?

Bug fix / process gate hardening.

# Documentation changes needed?

My changes do not require a change to the project documentation; the docs already state `.github/issue-evidence/` is retired.

# Testing

## Where should a reviewer start?

Start with `scripts/check-pr-evidence.mjs:57` and `scripts/check-pr-evidence.test.mjs`.

## Detailed testing steps

<details><summary><code>bun test scripts/check-pr-evidence.test.mjs</code></summary>

```text
23 pass
0 fail
Ran 23 tests across 1 file.
```

</details>

<details><summary><code>node scripts/check-pr-evidence.mjs --self-test</code></summary>

```text
check-pr-evidence self-test passed (8 cases).
```

</details>

<details><summary>Planted retired path body fails</summary>

```json
{
  "ok": false,
  "findings": [
    { "id": "backend-logs", "label": "Backend logs", "status": "blank" }
  ]
}
```

The CLI exits non-zero and prints: `Retired .github/issue-evidence/... repo paths do not count as evidence.`

</details>

<details><summary>Planted user-attachments body passes</summary>

```json
{
  "ok": true,
  "findings": [
    { "id": "backend-logs", "label": "Backend logs", "status": "ok" }
  ]
}
```

The CLI exits 0 and prints: `Evidence gate passed: all required rows satisfied.`

</details>

<details><summary><code>git diff --check</code></summary>

```text
passed with no output
```

</details>

# Evidence Gate

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the description or a comment), or write `N/A - <reason>` on the row. Do not leave evidence rows blank. Videos must be **MP4** (GitHub renders them inline); prefer **JPG over PNG** for screenshots. Do not commit evidence files to the repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots `N/A - CLI evidence-gate parser change with no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots `N/A - CLI evidence-gate parser change with no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - CLI evidence-gate parser change; behavior is proven by terminal pass/fail fixtures above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend service path changed`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend surface changed`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no DB/memory/scheduled-task/wallet/file artifacts produced`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

N/A - no backend service or frontend surface changed. CLI command output is pasted under Testing.

## Screenshots (before / after) + video walkthrough

N/A - CLI evidence-gate parser change with no UI surface.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT surface changed.

## Known gaps / failures

`bun run verify` was not run for this narrow two-file CLI parser change; focused parser tests, self-test, planted pass/fail fixtures, and `git diff --check` passed.
