### PR TITLE
fix(cloud-api): mirror 3 missing @elizaos/core exports into workerd stub — unblocks prod Worker build (#14422)

### DIFF
--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -1155,6 +1155,40 @@ export function settingsDebugCloudSummary(
   };
 }
 
+// Settings-debug is disabled in the Worker (isElizaSettingsDebugEnabled → false),
+// so this only satisfies @elizaos/shared's import; keep it non-leaking rather than
+// a faithful deep-sanitize (never reached on the workerd path).
+export function sanitizeForSettingsDebug(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "object") return "[object]";
+  if (typeof value === "string") return value.length > 8 ? "[redacted]" : value;
+  return value;
+}
+
+// Faithful mirrors of @elizaos/core name-token substitution: these ARE reached on
+// the Worker prompt path, so behavior must match core exactly. A replacer function
+// (not the raw name string) keeps `$`-sequences in a name literal.
+export function replaceNameTokens(text: string, name: string): string {
+  if (!text) return text;
+  return text
+    .replace(/\{\{\s*name\s*\}\}/g, () => name)
+    .replace(/\{\{\s*agentName\s*\}\}/g, () => name);
+}
+
+export function replaceIndexedNameTokens(
+  text: string,
+  names: readonly string[],
+): string {
+  if (!text) return text;
+  return text.replace(
+    /\{\{\s*(?:name|user)(\d+)\s*\}\}/g,
+    (match, slot: string) => {
+      const name = names[Number(slot) - 1];
+      return name === undefined ? match : name;
+    },
+  );
+}
+
 export function sanitizeSpeechText(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }


### PR DESCRIPTION
## Problem

`main` tip (`c055c38c`, promote #14295) **did not build the Cloud Worker**, blocking the prod deploy on **both** the CI `cloud-cf-deploy` lane **and** out-of-band `wrangler deploy`. Fixes #14422.

## Root cause — stub drift

workerd aliases `@elizaos/core` to `packages/cloud/api/src/stubs/elizaos-core.ts` (a hand-maintained subset; node-only deps are unavailable in workerd). The promote added `@elizaos/shared` usage of three `@elizaos/core` exports the stub lacked:

- `sanitizeForSettingsDebug` (`packages/core/src/settings-debug.ts:103`)
- `replaceNameTokens` (`packages/core/src/name-tokens.ts:17`)
- `replaceIndexedNameTokens` (`packages/core/src/name-tokens.ts:37`)

esbuild: `✘ No matching export in "src/stubs/elizaos-core.ts" for import "…"`. Same class as #14141 (`ElizaError`).

## Fix

- **`replaceNameTokens` / `replaceIndexedNameTokens`** — faithful copies of the pure core impls (these ARE reached on the Worker prompt path; a replacer fn keeps `$`-sequences in a name literal).
- **`sanitizeForSettingsDebug`** — non-leaking minimal stub matching the file's convention (`isElizaSettingsDebugEnabled` already returns `false` in-Worker, so it is never reached; kept non-leaking rather than a faithful deep-sanitize).

## Evidence

- **Before:** `wrangler deploy --env production --dry-run` → 3× `No matching export` errors, bundle not built.
- **After:** dry-run builds clean — `Total Upload: 15988.52 KiB / gzip 3547.20 KiB`, Worker Startup 38 ms, bindings intact.
- **Live:** deployed out-of-band to unblock prod (owner-GO'd) — `eliza-cloud-api-prod` Version `eed41cd1-ddc2-4346-b22f-bd3dd3f7f0ae`. Post-deploy health: `/api/health` 200, `/api/v1/models` 200 (385 models, `gemma-4-31b` present), `/api/auth/siwe/nonce` 200. No 500s. This PR makes the same fix durable so CI + future promotes build clean.

## Follow-up (filed on #14422)

The stub silently drifts. Recommend a CI gate that runs the Worker `--dry-run` on cloud-touching PRs so drift fails the PR, not the deploy.

https://claude.ai/code/session_01Y9PKm5MocuCmetfstCenBH
