### PR TITLE
ci(#13402): realign workflow-dedup contract to post-#14194 develop split

### DIFF
--- a/packages/scripts/__tests__/ci-workflow-dedup-contract.test.ts
+++ b/packages/scripts/__tests__/ci-workflow-dedup-contract.test.ts
@@ -32,29 +32,43 @@ jobs:
       - uses: ./.github/actions/setup-bun-workspace
 `;
 
+// Post-#14194: test.yml is the develop POST-MERGE orchestrator. Develop `push`
+// only — no pull_request, no merge_group (merge queue removed repo-wide).
 const TEST_YML = `name: Tests
 on:
   push:
     branches: [develop]
-  pull_request:
-    branches: [develop]
-  merge_group:
-    branches: [develop]
+  workflow_dispatch:
+  schedule:
+    - cron: "17 9 * * *"
 jobs:
   ci-ok:
     name: ci-ok
     runs-on: ubuntu-24.04
     steps:
-      - run: |
-          if [ "\${GITHUB_EVENT_NAME}" = "merge_group" ]; then
-            echo bypass
-          fi
+      - run: echo aggregate
 `;
 
-const SCENARIO_PR_YML = `name: Scenario PR
+// The lightweight develop-PR gate that owns the pre-merge half of the split.
+const DEVELOP_PR_YML = `name: Develop PR
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [develop]
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: ./.github/actions/setup-bun-workspace
+`;
+
+// Heavy scenario family: PRs gate on main, develop coverage is post-merge push.
+const SCENARIO_PR_YML = `name: Scenario PR
+on:
+  workflow_call:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [develop]
 jobs:
   x:
     runs-on: ubuntu-24.04
@@ -87,6 +101,7 @@ function baseWorkflows() {
   return {
     "ci.yaml": CI_YAML,
     "test.yml": TEST_YML,
+    "develop-pr.yml": DEVELOP_PR_YML,
     "scenario-pr.yml": SCENARIO_PR_YML,
     "nightly.yml": NIGHTLY_YML,
     "release.yaml": RELEASE_YAML,
@@ -115,6 +130,58 @@ describe("ci-workflow-dedup-contract", () => {
   test("a clean branch-split repo with no SaaS env passes", () => {
     withRepo(baseWorkflows(), (root) => {
       expect(runContract(root)).toEqual({ ok: true });
+    });
+  });
+
+  test("re-adding a pull_request trigger to test.yml fails the double-run guard", () => {
+    const workflows = baseWorkflows();
+    workflows["test.yml"] = TEST_YML.replace(
+      "  workflow_dispatch:",
+      "  pull_request:\n    branches: [develop]\n  workflow_dispatch:",
+    );
+    withRepo(workflows, (root) => {
+      expect(() => runContract(root)).toThrow(
+        /test\.yml must NOT declare on\.pull_request/,
+      );
+    });
+  });
+
+  test("re-adding a merge_group trigger to test.yml fails the double-run guard", () => {
+    const workflows = baseWorkflows();
+    workflows["test.yml"] = TEST_YML.replace(
+      "  workflow_dispatch:",
+      "  merge_group:\n    branches: [develop]\n  workflow_dispatch:",
+    );
+    withRepo(workflows, (root) => {
+      expect(() => runContract(root)).toThrow(
+        /test\.yml must NOT declare on\.merge_group/,
+      );
+    });
+  });
+
+  test("an `if:`-guard mention of merge_group in test.yml is not a trigger", () => {
+    const workflows = baseWorkflows();
+    // A leftover merge_group reference inside a step condition must NOT trip
+    // the trigger guard — only a top-level on.merge_group counts.
+    workflows["test.yml"] = TEST_YML.replace(
+      "      - run: echo aggregate",
+      "      - if: github.event_name == 'merge_group'\n        run: echo aggregate",
+    );
+    withRepo(workflows, (root) => {
+      expect(runContract(root)).toEqual({ ok: true });
+    });
+  });
+
+  test("dropping the develop-pr.yml gate fails the contract", () => {
+    const workflows = baseWorkflows();
+    workflows["develop-pr.yml"] = DEVELOP_PR_YML.replace(
+      "  pull_request:\n    branches: [develop]",
+      "  workflow_dispatch:",
+    );
+    withRepo(workflows, (root) => {
+      expect(() => runContract(root)).toThrow(
+        /develop-pr\.yml: missing on\.pull_request/,
+      );
     });
   });
 

--- a/packages/scripts/ci-workflow-dedup-contract.mjs
+++ b/packages/scripts/ci-workflow-dedup-contract.mjs
@@ -5,11 +5,25 @@
  * regime. Run in test.yml's `changes` job; a violation fails the branch's CI.
  *
  * Branch coverage stays split by responsibility, so a check never runs twice
- * across the split:
- *   - ci.yaml owns the main-branch gate (main only).
- *   - test.yml owns the develop test orchestrator and the merge-queue `ci-ok`
- *     aggregate (develop push/PR/merge_group).
- *   - scenario-pr.yml keeps zero-key deterministic PR E2E on both main+develop.
+ * across the split (post-#14194 develop-PR-weight-reduction):
+ *   - ci.yaml owns the main-branch gate (push+PR, main only).
+ *   - test.yml owns the develop POST-MERGE test orchestrator and the `ci-ok`
+ *     aggregate: develop `push` only (plus nightly `schedule` and
+ *     `workflow_dispatch`). #14194 removed the `pull_request:[develop]` and
+ *     `merge_group` triggers from test.yml. The merge queue is gone repo-wide
+ *     and develop PRs run the lightweight gate instead, so the full suite
+ *     never double-runs pre- and post-merge.
+ *   - develop-pr.yml owns the lightweight develop-PR gate (lint/typecheck/
+ *     build only, NO tests): the pre-merge half of the split.
+ *   - scenario-pr.yml keeps zero-key deterministic E2E: `pull_request:[main]`
+ *     pre-merge and `push:[develop]` post-merge (#14051/#14194 moved the heavy
+ *     scenario family off per-PR develop runs, matching the test.yml split).
+ *
+ * The de-dup invariant therefore requires BOTH sides: test.yml must carry
+ * develop `push` + `ci-ok` and must NOT carry a `pull_request`/`merge_group`
+ * trigger (else the heavy suite would run twice), and develop-pr.yml must own
+ * the `pull_request:[develop]` gate. Re-adding a PR/merge_group trigger to
+ * test.yml, or dropping the develop-pr.yml gate, fails this contract.
  *
  * Cache regime (#12341): the whole repo is on the GitHub-native Turbo cache
  * (setup-bun-workspace → the pinned `turbo-cache-github` shim). NO workflow may
@@ -74,6 +88,32 @@ function parseInlineBranches(text, eventName, workflowRel) {
   );
 }
 
+// True iff the workflow declares a top-level `on.<eventName>:` trigger. Only
+// scans the `on:` mapping block (2-space-indented keys) so an `if:` guard or a
+// comment that merely names the event does not count as a trigger.
+function hasInlineEvent(text, eventName) {
+  const lines = text.split(/\r?\n/);
+  const onIndex = lines.findIndex((line) => /^on:\s*$/.test(line));
+  if (onIndex < 0) return false;
+  for (let index = onIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line.trim() === "" || /^\s*#/.test(line)) continue;
+    // Left the `on:` mapping once we hit a non-indented (top-level) key.
+    if (/^\S/.test(line)) break;
+    const match = line.match(/^ {2}([a-z_]+):/);
+    if (match && match[1] === eventName) return true;
+  }
+  return false;
+}
+
+function assertNoInlineEvent(text, eventName, workflowRel, message) {
+  if (hasInlineEvent(text, eventName)) {
+    throw new Error(
+      `${message}: ${workflowRel} must NOT declare on.${eventName} (would double-run the heavy suite across the develop pre/post-merge split)`,
+    );
+  }
+}
+
 function assertDeepEqual(actual, expected, message) {
   const actualJson = JSON.stringify(actual);
   const expectedJson = JSON.stringify(expected);
@@ -120,29 +160,47 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
     "ci.yaml PR branches",
   );
 
+  // test.yml is the develop POST-MERGE orchestrator (#14194): develop `push`
+  // only, and it must NOT carry a `pull_request` or `merge_group` trigger, or
+  // the heavy suite would run both pre- and post-merge (the double-run this
+  // contract exists to forbid).
   const tests = read(".github/workflows/test.yml");
   assertDeepEqual(
     parseInlineBranches(tests, "push", ".github/workflows/test.yml"),
     ["develop"],
     "test.yml push branches",
   );
-  assertDeepEqual(
-    parseInlineBranches(tests, "pull_request", ".github/workflows/test.yml"),
-    ["develop"],
-    "test.yml PR branches",
+  assertNoInlineEvent(
+    tests,
+    "pull_request",
+    ".github/workflows/test.yml",
+    "test.yml develop-PR gate moved to develop-pr.yml (#14194)",
   );
-  assertDeepEqual(
-    parseInlineBranches(tests, "merge_group", ".github/workflows/test.yml"),
-    ["develop"],
-    "test.yml merge queue branches",
+  assertNoInlineEvent(
+    tests,
+    "merge_group",
+    ".github/workflows/test.yml",
+    "merge queue removed repo-wide (#14194)",
   );
   assertIncludes(tests, "name: ci-ok", "test.yml required aggregate status");
-  assertIncludes(
-    tests,
-    'if [ "${GITHUB_EVENT_NAME}" = "merge_group" ]; then',
-    "test.yml merge queue path-gate bypass",
+
+  // develop-pr.yml owns the lightweight pre-merge develop-PR gate. It must
+  // carry the `pull_request:[develop]` trigger that test.yml gave up, so the
+  // split has an owner on the pre-merge side.
+  const developPr = read(".github/workflows/develop-pr.yml");
+  assertDeepEqual(
+    parseInlineBranches(
+      developPr,
+      "pull_request",
+      ".github/workflows/develop-pr.yml",
+    ),
+    ["develop"],
+    "develop-pr.yml PR branches",
   );
 
+  // scenario-pr.yml follows the same pre/post-merge split as test.yml: the
+  // heavy scenario family is off per-PR develop runs (#14051/#14194), so it
+  // gates PRs on `main` and runs post-merge on develop `push`.
   const scenarioPr = read(".github/workflows/scenario-pr.yml");
   assertDeepEqual(
     parseInlineBranches(
@@ -150,8 +208,17 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
       "pull_request",
       ".github/workflows/scenario-pr.yml",
     ),
-    ["main", "develop"],
+    ["main"],
     "scenario-pr.yml PR branches",
+  );
+  assertDeepEqual(
+    parseInlineBranches(
+      scenarioPr,
+      "push",
+      ".github/workflows/scenario-pr.yml",
+    ),
+    ["develop"],
+    "scenario-pr.yml develop push branches",
   );
 
   // --- Cache-regime invariant (#12341): one GitHub-native cache, no SaaS. ---


### PR DESCRIPTION
## part of #13402

### Problem (live latent breakage on develop)

`ci-workflow-dedup-contract.mjs` **fails on the current `develop` tip**:

```
[ci-workflow-dedup-contract] FAIL .github/workflows/test.yml: missing on.pull_request
```

PR #14194 ("lightweight develop-PR gate; remove merge queue + heavy suites from develop PRs") intentionally:
- removed the `pull_request:[develop]` **and** `merge_group` triggers from `test.yml` (the merge queue is now gone repo-wide, 0 `merge_group` triggers),
- moved the pre-merge develop gate to the new `develop-pr.yml` (lint/typecheck/build only),
- dropped `develop` from the heavy scenario family's PR trigger (`scenario-pr.yml` now gates PRs on `[main]`, covers develop via `push`).

The dedup contract still asserted the *old* topology (`test.yml` must have `on.pull_request[develop]` + `on.merge_group[develop]`; `scenario-pr.yml` PRs on `[main,develop]`). That step runs in `test.yml`'s `changes` job on `push:[develop]`, so **the next push to develop would fail the `changes` job and cascade the whole run.**

### Fix

Realign the branch-split invariant to the real post-#14194 architecture, kept **non-vacuous** by encoding *both* sides of the pre/post-merge split:

- **test.yml** owns develop `push` + the `ci-ok` aggregate, and must **NOT** declare a `pull_request`/`merge_group` trigger. New `assertNoInlineEvent` double-run guard: re-adding either trigger fails (it would run the heavy suite both pre- and post-merge). `hasInlineEvent` scans only the `on:` mapping, so a leftover `merge_group` mention inside an `if:` step or a comment is not treated as a trigger.
- **develop-pr.yml** must own `pull_request:[develop]` (the pre-merge gate). Dropping it fails.
- **scenario-pr.yml** gates PRs on `[main]` and covers develop via `push:[develop]`.

The cache-regime invariant (#12341 SaaS-cache ban) is unchanged.

### Verification

```
$ node packages/scripts/ci-workflow-dedup-contract.mjs
ci workflow dedup contract passed        # exit 0 (was exit 1 on develop)

$ bun test packages/scripts/__tests__/ci-workflow-dedup-contract.test.ts
9 pass / 0 fail
```

New negative tests added:
- re-adding a `pull_request` trigger to test.yml → fails
- re-adding a `merge_group` trigger to test.yml → fails
- an `if:`-guard `merge_group` mention in test.yml → stays green (not a trigger)
- dropping the `develop-pr.yml` gate → fails

All 5 other #13402 CI contracts re-verified green vs develop (dedup, turbo-cache, full-matrix-proof, bun-version, windows-command-coverage, zero-key-ownership).

`git diff --check`: clean. No workflow YAML touched (contract + its spec only), so no `actionlint` surface.

### Evidence
- N/A UI screenshots — CI contract script change, no user-facing surface.
- N/A model trajectory / audio / product-domain artifacts.
- Backend/frontend logs: N/A — no runtime code path; verification is the contract run + bun spec above.

— [sol-orch]
Co-authored-by: wakesync <shadow@shad0w.xyz>