### PR TITLE
fix(#14321): fall back for connector forms

### DIFF
--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -75,11 +75,11 @@ FollowupsInteraction | TaskInteraction | SecretInteraction`) in
 |---|---|---|---|
 | choice | `ChoiceWidget` ✅ | inline-keyboard callback buttons ✅ | button action row ✅ |
 | followups | `FollowupsWidget` ✅ | callback buttons ✅ | button action row ✅ |
-| form | `FormRequest` ✅ | link-out (multi-field is awkward as a keyboard) ⏳ | link-out ⏳ |
+| form | `FormRequest` ✅ | free-text fallback ✅ | free-text fallback ✅ |
 | task | `TaskWidget` (live poll) ✅ | link button + title ✅ (live status ⏳) | link button + title ✅ |
 | secret/oauth | `SensitiveRequestBlock` ✅ | DM link via `sensitive-request-adapter` ✅ | DM link via `sensitive-request-adapter` ✅ |
 
-✅ implemented · ⏳ remaining (seams below). Choice/followups round-trip works on
+✅ implemented. Choice/followups round-trip works on
 **both** connectors:
 - **Telegram**: `handleCallbackQuery` decodes the tap and replays it through
   `handleMessage` as a user turn (`plugin-telegram/src/messageManager.ts`).
@@ -133,6 +133,9 @@ mounts `SensitiveRequestBlock` itself for the secret/OAuth card.
   users never see raw `[CHOICE …]`.
 - **Pick-one-or-your-own.** `ChoiceInteraction.allowCustom` renders the options as
   buttons *and* invites a free-text reply (`needsFallback` on the layout).
+- **Connector forms fall back to text.** Form specs are not persisted to a
+  hosted page, so Telegram and Discord show the form prompt and ask the user to
+  answer in chat instead of linking to a dead `/forms/:id` route.
 - **Secrets never in the transport.** Inline secure form in the app; a single
   link-out button on connectors → authenticated cloud/local entry page.
 - **Task = thread.** Each task owns a Discord thread / Telegram forum topic; its

--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -349,13 +349,16 @@ describe("buildInteractionUrlResolver (#8908)", () => {
 		);
 	});
 
-	it("resolves a form block to the hosted form route", () => {
+	it("does not resolve forms to a fabricated hosted route", () => {
 		const block: FormInteraction = {
 			kind: "form",
 			id: "form_7",
 			fields: [{ name: "k", type: "text" }],
 		};
-		expect(resolver.resolveUrl?.(block)).toBe("https://app.test/forms/form_7");
+		expect(resolver.resolveUrl?.(block)).toBeUndefined();
+		const layout = toNeutralLayout(block, resolver);
+		expect(layout.rows).toHaveLength(0);
+		expect(layout.needsFallback).toBe(true);
 	});
 
 	it("resolves navigate payloads (path + viewId) against the base url", () => {

--- a/packages/core/src/messaging/interactions/layout.ts
+++ b/packages/core/src/messaging/interactions/layout.ts
@@ -6,7 +6,8 @@
  * per-connector glue thin.
  *
  * Buttons round-trip via `callbackData` (the user's answer, re-injected as a
- * message) or open a `url` (link-out for forms, secret entry, and task views).
+ * message) or open a `url` (link-out for task views and secure secret entry).
+ * Forms without persisted hosted pages deliberately fall back to free text.
  * A button always carries exactly one of the two.
  */
 
@@ -50,9 +51,9 @@ export interface NeutralLayout {
 
 export interface LayoutOptions {
 	/**
-	 * Resolve an external entry URL for blocks that link out: complex forms,
-	 * secret/OAuth entry, and the task view. Returning undefined marks the block
-	 * as needing a free-text fallback.
+	 * Resolve an external entry URL for blocks that link out: secret/OAuth entry
+	 * and the task view. Returning undefined marks the block as needing a
+	 * free-text fallback.
 	 */
 	resolveUrl?: (block: InteractionBlock) => string | undefined;
 	/**
@@ -177,8 +178,8 @@ export function toNeutralLayout(
 
 /**
  * Build the canonical link-out resolvers connectors pass to {@link toNeutralLayout}
- * so Telegram, Discord, and any other surface produce identical URLs for task,
- * form, and navigate blocks. `appBaseUrl` is the deployment's app/dashboard
+ * so Telegram, Discord, and any other surface produce identical URLs for task
+ * and navigate blocks. `appBaseUrl` is the deployment's app/dashboard
  * origin (`ELIZA_APP_URL`, falling back to the cloud URL). Returns `undefined`
  * resolvers when no base URL is configured, which keeps the free-text fallback.
  */
@@ -192,10 +193,9 @@ export function buildInteractionUrlResolver(
 			switch (block.kind) {
 				case "task":
 					return `${base}/orchestrator?taskId=${encodeURIComponent(block.threadId)}`;
-				case "form":
-					return `${base}/forms/${encodeURIComponent(block.id)}`;
 				// Secret/OAuth blocks carry their own out-of-band entry URL
-				// (the hosted secure page); defer to it via the layout fallback.
+				// (the hosted secure page). Forms have no persisted hosted page, so
+				// they also fall through to the connector free-text fallback.
 				default:
 					return undefined;
 			}

--- a/plugins/plugin-discord/__tests__/interactions.test.ts
+++ b/plugins/plugin-discord/__tests__/interactions.test.ts
@@ -4,7 +4,7 @@
  * Pure-function assertions.
  */
 import type { Content } from "@elizaos/core";
-import { decodeCallback } from "@elizaos/core";
+import { buildInteractionUrlResolver, decodeCallback } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { renderDiscordInteractions } from "../interactions";
 
@@ -51,6 +51,18 @@ describe("renderDiscordInteractions", () => {
 		expect(button?.style).toBe(5); // Link
 		expect(button?.url).toContain(id);
 		expect(button?.custom_id).toBe("");
+	});
+
+	it("falls back to free-text for forms instead of linking to a dead hosted route", () => {
+		const out = renderDiscordInteractions(
+			{
+				text: 'Set this up.\n[FORM]\n{"id":"form_7","title":"Reminder time","fields":[{"name":"when","type":"text"}]}\n[/FORM]',
+			} as Content,
+			buildInteractionUrlResolver("https://app.test/"),
+		);
+		expect(out.text).toBe("Set this up.\n\nReminder time");
+		expect(out.components).toHaveLength(0);
+		expect(out.needsFreeTextReply).toBe(true);
 	});
 
 	it("caps action rows at the Discord limit of 5", () => {

--- a/plugins/plugin-telegram/src/interactions.test.ts
+++ b/plugins/plugin-telegram/src/interactions.test.ts
@@ -5,7 +5,7 @@
  * Deterministic; no live API.
  */
 import type { Content } from "@elizaos/core";
-import { decodeCallback } from "@elizaos/core";
+import { buildInteractionUrlResolver, decodeCallback } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { renderTelegramInteractions } from "./interactions";
 
@@ -49,6 +49,18 @@ describe("renderTelegramInteractions", () => {
     const button = out.keyboardRows[0]?.[0] as { text: string; url: string };
     expect(button.text).toBe("Open task");
     expect(button.url).toContain(id);
+  });
+
+  it("falls back to free-text for forms instead of linking to a dead hosted route", () => {
+    const out = renderTelegramInteractions(
+      {
+        text: 'Set this up.\n[FORM]\n{"id":"form_7","title":"Reminder time","fields":[{"name":"when","type":"text"}]}\n[/FORM]',
+      } as Content,
+      buildInteractionUrlResolver("https://app.test/"),
+    );
+    expect(out.text).toBe("Set this up.\n\nReminder time");
+    expect(out.keyboardRows).toHaveLength(0);
+    expect(out.needsFreeTextReply).toBe(true);
   });
 
   it("keeps a task title as text when no url is available", () => {


### PR DESCRIPTION
# Relates to

Closes #14321.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and is based on current `origin/develop` (`0b6865a18f`).
- [ ] Full `bun install` + `bun run verify` completed after sync.
- [ ] Real connector evidence captured and attached inline.

# Summary

- Stops `buildInteractionUrlResolver()` from fabricating `${appBaseUrl}/forms/<id>` URLs for connector-rendered `[FORM]` blocks.
- Leaves task link-out and followup navigation URL behavior unchanged.
- Updates the interaction protocol README and unit coverage so connector forms now deliberately render as free-text fallback instead of a dead button.

# Why

Telegram and Discord were rendering a healthy-looking "Open form" button for a route that does not exist and has no persisted form spec behind it. That violates the fail-fast interaction contract and sends users to a broken page. For MVP, the correct minimal behavior is to show the prompt and ask the user to answer in chat; secret-bearing input stays on the existing sensitive-request hosted flow.

# Verification

- `node v24.15.0 node_modules/vitest/vitest.mjs run packages/core/src/messaging/interactions/interactions.test.ts plugins/plugin-discord/__tests__/interactions.test.ts plugins/plugin-telegram/src/interactions.test.ts`
  - `packages/core/src/messaging/interactions/interactions.test.ts`: passed.
  - `plugins/plugin-discord/__tests__/interactions.test.ts`: passed after symlinking the generated i18n keyword artifact from the main checkout.
  - `plugins/plugin-telegram/src/interactions.test.ts`: blocked before tests by missing installed package `telegraf` in the shared `node_modules`; lockfile/package declare `telegraf@4.16.3`.
- `biome check packages/core/src/messaging/interactions/README.md packages/core/src/messaging/interactions/interactions.test.ts packages/core/src/messaging/interactions/layout.ts plugins/plugin-discord/__tests__/interactions.test.ts plugins/plugin-telegram/src/interactions.test.ts`: passed.
- `rg -n "forms/|/forms/|Open form" packages/core/src plugins/plugin-discord plugins/plugin-telegram packages/ui/src/cloud/public-pages packages/cloud/api/v1`: no code path remains that mints `/forms/<id>`; remaining hits are the in-app `Open form` label and README explanation.
- `git diff --check origin/develop...HEAD`: passed.

# Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - the wrong behavior is covered by the issue text; still need real Telegram/Discord before screenshots if available from an older build.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: TODO - capture real Telegram + Discord connector screenshots showing prompt text with no `/forms/:id` button.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: TODO - capture Telegram MP4 showing form emission -> free-text fallback -> user reply -> agent handles answer.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: TODO - attach structured connector logs showing the form block projected through `toNeutralLayout` with `needsFallback: true`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs: N/A - connector/core rendering change; no browser frontend path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: TODO - attach live model trajectory for the connector form round-trip, or mark N/A only if the follow-up evidence uses a deterministic connector-only fixture without model behavior.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: deterministic layout test output confirms the domain artifact is `needsFallback: true` with zero connector button rows; no DB rows or files are produced by this change.

# Known gaps

This is a draft until real Telegram/Discord screenshots, MP4, logs, and any relevant live-LLM trajectory are attached inline. The dependency layout in this machine's shared install is incomplete for Telegram (`telegraf` missing), so the Telegram unit file could not execute locally even though the code path is covered in the patch.