### PR TITLE
feat(app): mvp-visual-verify — OCR + palette + pixel-diff + expectation layer over audit:app

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -28,6 +28,7 @@
     "audit:cloud": "VITE_PLAYWRIGHT_TEST_AUTH=true node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=audit-cloud",
     "audit:app:minimalism:update": "bun scripts/update-minimalism-baseline.mjs",
     "mvp:visual-verify": "node scripts/mvp-visual-verify.mjs",
+    "mvp:visual-verify:overflow-demo": "node scripts/mvp-visual-verify/overflow-invariant-demo.mjs",
     "audit:app:verify": "bun run audit:app && bun run mvp:visual-verify",
     "audit:views": "node scripts/audit-views-soak.mjs",
     "test:desktop:packaged": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -27,6 +27,8 @@
     "audit:app": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=audit-app",
     "audit:cloud": "VITE_PLAYWRIGHT_TEST_AUTH=true node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=audit-cloud",
     "audit:app:minimalism:update": "bun scripts/update-minimalism-baseline.mjs",
+    "mvp:visual-verify": "node scripts/mvp-visual-verify.mjs",
+    "audit:app:verify": "bun run audit:app && bun run mvp:visual-verify",
     "audit:views": "node scripts/audit-views-soak.mjs",
     "test:desktop:packaged": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts",
     "test:desktop:packaged:windows": "node scripts/run-desktop-packaged-windows.mjs",

--- a/packages/app/scripts/mvp-visual-verify.mjs
+++ b/packages/app/scripts/mvp-visual-verify.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+/**
+ * Post-processes the screenshots `audit:app` already captured into a higher-
+ * fidelity visual-verification report: for every `<viewport>/<slug>.png` under
+ * the audit output it reads the on-screen text (OCR), the dominant-color palette,
+ * a pixel diff against a committed baseline, and a declarative pass/fail over
+ * per-state expectations (expected OCR substrings, brand-orange accent, no blue,
+ * no horizontal overflow). Output is a SEPARATE `mvp-verify/` tree (report.json +
+ * contact-sheet.html + diff PNGs + baseline PNGs) so it never collides with the
+ * audit's own report.json.
+ *
+ * This is evidence tooling, not a CI gate — it exits non-zero only when
+ * `--strict` is passed (so `audit:app:verify` can chain it) and otherwise always
+ * writes the full report for a human to review. Inputs are consumed, never
+ * mutated; the audit stays the source of truth for what was captured.
+ *
+ * Usage:
+ *   node scripts/mvp-visual-verify.mjs [--input <dir>] [--update-baseline]
+ *                                      [--viewport <name>]... [--strict]
+ * Env: ELIZA_AUDIT_APP_DIR overrides the input dir (matches the audit spec).
+ */
+
+import { readdir, readFile, writeFile, mkdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { dominantColorsFromPng } from "./mvp-visual-verify/dominant-color.mjs";
+import { ocrImage, resolveTesseract } from "./mvp-visual-verify/ocr.mjs";
+import { diffAgainstBaseline } from "./mvp-visual-verify/diff.mjs";
+import {
+  evaluateExpectations,
+  resolveSpec,
+} from "./mvp-visual-verify/expectation-eval.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(here, "..");
+
+function log(msg) {
+  process.stdout.write(`[mvp-visual-verify] ${msg}\n`);
+}
+
+function parseArgs(argv) {
+  const args = { viewports: [], updateBaseline: false, strict: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--input") args.input = argv[++i];
+    else if (a === "--viewport") args.viewports.push(argv[++i]);
+    else if (a === "--update-baseline") args.updateBaseline = true;
+    else if (a === "--strict") args.strict = true;
+    else if (a === "--help" || a === "-h") args.help = true;
+  }
+  return args;
+}
+
+/** Directories under the audit output that are outputs/notes, not viewport shots. */
+const NON_VIEWPORT_DIRS = new Set(["mvp-verify", "manual-review", "baseline", "diffs"]);
+
+async function isDir(p) {
+  return stat(p).then(
+    (s) => s.isDirectory(),
+    () => false,
+  );
+}
+
+/** Discover viewport subdirs that actually contain screenshots. */
+async function discoverViewportDirs(inputDir, only) {
+  const entries = await readdir(inputDir, { withFileTypes: true });
+  const dirs = [];
+  for (const e of entries) {
+    if (!e.isDirectory() || NON_VIEWPORT_DIRS.has(e.name)) continue;
+    if (only.length && !only.includes(e.name)) continue;
+    const pngs = (await readdir(path.join(inputDir, e.name))).filter((f) =>
+      f.endsWith(".png"),
+    );
+    if (pngs.length) dirs.push({ name: e.name, pngs });
+  }
+  return dirs.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function loadReportIndex(inputDir) {
+  const reportPath = path.join(inputDir, "report.json");
+  const raw = await readFile(reportPath, "utf8").catch(() => null);
+  if (!raw) return { index: new Map(), present: false };
+  const findings = JSON.parse(raw);
+  const index = new Map();
+  for (const f of findings) index.set(`${f.slug}::${f.viewport}`, f);
+  return { index, present: true, count: findings.length };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    log("post-processes audit:app screenshots into mvp-verify/ (OCR + palette + diff + expectations)");
+    return 0;
+  }
+
+  const inputDir = path.resolve(
+    args.input ?? process.env.ELIZA_AUDIT_APP_DIR ?? path.join(appDir, "aesthetic-audit-output"),
+  );
+  if (!(await isDir(inputDir))) {
+    throw new Error(
+      `input dir not found: ${inputDir}\nRun 'bun run --cwd packages/app audit:app' first, or pass --input.`,
+    );
+  }
+
+  const outDir = path.join(inputDir, "mvp-verify");
+  const baselineRoot = path.join(outDir, "baseline");
+  const diffRoot = path.join(outDir, "diffs");
+  await mkdir(outDir, { recursive: true });
+
+  const specsRaw = await readFile(path.join(here, "mvp-visual-verify", "expectations.json"), "utf8");
+  const specs = JSON.parse(specsRaw);
+
+  const { index: reportIndex, present: reportPresent, count: reportCount } =
+    await loadReportIndex(inputDir);
+  const tesseract = resolveTesseract();
+
+  log(`input: ${inputDir}`);
+  log(`audit report.json: ${reportPresent ? `${reportCount} findings` : "ABSENT (overflow/DOM checks will skip)"}`);
+  log(`OCR engine: ${tesseract ? tesseract : "N/A (tesseract binary not found — OCR column honest N/A)"}`);
+  if (args.updateBaseline) log("--update-baseline: recording current shots as the diff baseline");
+
+  const viewportDirs = await discoverViewportDirs(inputDir, args.viewports);
+  log(`viewports: ${viewportDirs.map((v) => `${v.name}(${v.pngs.length})`).join(", ") || "none found"}`);
+
+  const results = [];
+  let processed = 0;
+  for (const vp of viewportDirs) {
+    for (const png of vp.pngs) {
+      const slug = png.replace(/\.png$/, "");
+      const currentPath = path.join(inputDir, vp.name, png);
+      const finding = reportIndex.get(`${slug}::${vp.name}`) ?? null;
+
+      const palette = await dominantColorsFromPng(currentPath);
+      const ocr = await ocrImage(currentPath);
+      const baselinePath = path.join(baselineRoot, vp.name, png);
+      const diffOutPath = path.join(diffRoot, vp.name, png);
+      // --update-baseline: overwrite the baseline with the current shot BEFORE
+      // diffing, so the refresh is deliberate and the diff self-reports 0%.
+      if (args.updateBaseline) {
+        await mkdir(path.dirname(baselinePath), { recursive: true });
+        await (await import("sharp")).default(currentPath).toFile(baselinePath);
+      }
+      const diff = await diffAgainstBaseline({
+        currentPath,
+        baselinePath,
+        diffOutPath,
+        recordMissingBaseline: true,
+      });
+
+      const spec = resolveSpec(specs, slug);
+      const expectation = evaluateExpectations(
+        { viewport: vp.name, ocr, palette, finding },
+        spec,
+      );
+
+      results.push({
+        slug,
+        viewport: vp.name,
+        screenshot: path.relative(outDir, currentPath),
+        ocr: ocr.available
+          ? { available: true, words: ocr.words, chars: ocr.chars, text: ocr.text.slice(0, 4000) }
+          : { available: false, reason: ocr.reason },
+        palette: {
+          buckets: Object.fromEntries(
+            Object.entries(palette.buckets).map(([k, v]) => [k, Number(v.toFixed(4))]),
+          ),
+          swatches: palette.swatches.map((s) => ({
+            hex: s.hex,
+            bucket: s.bucket,
+            ratio: Number(s.ratio.toFixed(4)),
+          })),
+        },
+        diff:
+          diff.status === "new"
+            ? { status: "new", note: "baseline recorded; nothing to compare yet" }
+            : {
+                status: "compared",
+                changedPercent: diff.summary.changedPercent,
+                meanAbsDelta: diff.summary.meanAbsDelta,
+                resized: diff.summary.resized,
+                diffPng: diff.diffPath ? path.relative(outDir, diff.diffPath) : null,
+              },
+        expectation: {
+          pass: expectation.pass,
+          reasons: expectation.reasons,
+          checks: expectation.checks,
+        },
+        horizontalOverflowPx: finding?.horizontalOverflowPx ?? null,
+      });
+      processed += 1;
+    }
+  }
+
+  results.sort((a, b) =>
+    a.slug === b.slug ? a.viewport.localeCompare(b.viewport) : a.slug.localeCompare(b.slug),
+  );
+
+  const summary = {
+    generatedAt: new Date().toISOString(),
+    inputDir,
+    states: results.length,
+    ocrEngine: tesseract ?? "N/A (tesseract not found)",
+    auditReportPresent: reportPresent,
+    expectationFailures: results.filter((r) => !r.expectation.pass).length,
+    newBaselines: results.filter((r) => r.diff.status === "new").length,
+    overflowStates: results.filter((r) => (r.horizontalOverflowPx ?? 0) > 2).length,
+  };
+
+  await writeFile(
+    path.join(outDir, "report.json"),
+    JSON.stringify({ summary, states: results }, null, 2),
+    "utf8",
+  );
+  await writeFile(path.join(outDir, "contact-sheet.html"), renderContactSheet(summary, results), "utf8");
+
+  log(
+    `wrote ${results.length} states → ${path.join(outDir, "report.json")} + contact-sheet.html`,
+  );
+  log(
+    `expectation failures: ${summary.expectationFailures} | overflow states: ${summary.overflowStates} | new baselines: ${summary.newBaselines}`,
+  );
+  if (summary.expectationFailures > 0) {
+    for (const r of results.filter((r) => !r.expectation.pass)) {
+      log(`  FAIL ${r.slug} @ ${r.viewport}: ${r.expectation.reasons.join(" | ")}`);
+    }
+  }
+
+  if (args.strict && summary.expectationFailures > 0) {
+    log("--strict: exiting non-zero due to expectation failures");
+    return 1;
+  }
+  return 0;
+}
+
+function esc(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function renderContactSheet(summary, results) {
+  const rows = results
+    .map((r) => {
+      const swatches = r.palette.swatches
+        .map(
+          (s) =>
+            `<span class="sw" title="${esc(s.hex)} ${esc(s.bucket)} ${(s.ratio * 100).toFixed(1)}%" style="background:${esc(s.hex)}">${(s.ratio * 100).toFixed(0)}</span>`,
+        )
+        .join("");
+      const verdict = r.expectation.pass
+        ? '<span class="pass">PASS</span>'
+        : `<span class="fail">FAIL</span>`;
+      const checks = r.expectation.checks
+        .map((c) => `<div class="chk ${c.status}">${esc(c.name)}: ${esc(c.detail)}</div>`)
+        .join("");
+      const ocrCell = r.ocr.available
+        ? `<div class="ocr">${esc(r.ocr.text || "(no glyphs)")}</div><div class="meta">${r.ocr.words} words</div>`
+        : `<div class="na">N/A — ${esc(r.ocr.reason)}</div>`;
+      const diffCell =
+        r.diff.status === "new"
+          ? '<span class="new">NEW baseline</span>'
+          : `${r.diff.changedPercent}% changed${r.diff.resized ? " (resized)" : ""}${r.diff.diffPng ? `<br><img class="thumb" src="${esc(r.diff.diffPng)}">` : ""}`;
+      return `<tr class="${r.expectation.pass ? "" : "row-fail"}">
+        <td class="slug">${esc(r.slug)}<br><span class="meta">${esc(r.viewport)}</span></td>
+        <td><img class="thumb" src="${esc(r.screenshot)}" loading="lazy"></td>
+        <td>${ocrCell}</td>
+        <td class="pal">${swatches}<div class="meta">${Object.entries(r.palette.buckets).map(([k, v]) => `${k} ${(v * 100).toFixed(0)}%`).join(" · ")}</div></td>
+        <td class="diff">${diffCell}</td>
+        <td>${verdict}<div class="checks">${checks}</div></td>
+      </tr>`;
+    })
+    .join("\n");
+  return `<!doctype html><meta charset="utf-8"><title>mvp visual verify</title>
+<style>
+  body{font:13px system-ui,sans-serif;margin:16px;color:#1a1a1a;background:#faf9f7}
+  h1{font-size:18px} .summary{margin:8px 0 16px;padding:8px 12px;background:#fff;border:1px solid #e5e0d8;border-radius:6px}
+  table{border-collapse:collapse;width:100%} td,th{border:1px solid #e5e0d8;padding:6px;vertical-align:top;text-align:left}
+  th{background:#f0ece5;position:sticky;top:0}
+  .thumb{max-width:260px;max-height:180px;border:1px solid #ddd}
+  .slug{font-weight:600;white-space:nowrap} .meta{color:#8a8378;font-size:11px}
+  .ocr{max-width:280px;max-height:160px;overflow:auto;font-size:11px;white-space:pre-wrap;color:#444}
+  .sw{display:inline-block;width:26px;height:26px;line-height:26px;text-align:center;font-size:9px;color:#000;mix-blend-mode:difference;border:1px solid #ccc;margin:1px}
+  .pass{color:#0a7d3c;font-weight:700} .fail{color:#c0392b;font-weight:700} .na{color:#b58900}
+  .row-fail{background:#fff4f2} .checks{margin-top:4px}
+  .chk{font-size:11px;padding:1px 0} .chk.pass{color:#0a7d3c} .chk.fail{color:#c0392b} .chk.skip{color:#8a8378}
+  .new{color:#b58900;font-weight:600}
+</style>
+<h1>mvp visual verify</h1>
+<div class="summary">
+  ${esc(summary.states)} states · OCR: ${esc(summary.ocrEngine)} · expectation failures: <b>${summary.expectationFailures}</b> ·
+  overflow states: <b>${summary.overflowStates}</b> · new baselines: ${summary.newBaselines} ·
+  audit report: ${summary.auditReportPresent ? "loaded" : "ABSENT"} · ${esc(summary.generatedAt)}
+</div>
+<table>
+  <tr><th>state</th><th>screenshot</th><th>OCR text</th><th>palette</th><th>diff vs baseline</th><th>expectations</th></tr>
+  ${rows}
+</table>`;
+}
+
+main().then(
+  (code) => process.exit(code ?? 0),
+  (err) => {
+    process.stderr.write(`[mvp-visual-verify] fatal: ${err?.stack || err}\n`);
+    process.exit(2);
+  },
+);

--- a/packages/app/scripts/mvp-visual-verify.mjs
+++ b/packages/app/scripts/mvp-visual-verify.mjs
@@ -6,8 +6,9 @@
  * a pixel diff against a committed baseline, and a declarative pass/fail over
  * per-state expectations (expected OCR substrings, brand-orange accent, no blue,
  * no horizontal overflow). Output is a SEPARATE `mvp-verify/` tree (report.json +
- * contact-sheet.html + diff PNGs + baseline PNGs) so it never collides with the
- * audit's own report.json.
+ * contact-sheet.html + diff PNGs) so it never collides with the audit's own
+ * report.json. Baselines live under this script directory by default so a clean
+ * checkout can compare against reviewed, committed screenshots.
  *
  * This is evidence tooling, not a CI gate — it exits non-zero only when
  * `--strict` is passed (so `audit:app:verify` can chain it) and otherwise always
@@ -15,21 +16,27 @@
  * mutated; the audit stays the source of truth for what was captured.
  *
  * Usage:
- *   node scripts/mvp-visual-verify.mjs [--input <dir>] [--update-baseline]
- *                                      [--viewport <name>]... [--strict]
- * Env: ELIZA_AUDIT_APP_DIR overrides the input dir (matches the audit spec).
+ *   node scripts/mvp-visual-verify.mjs [--input <dir>] [--baseline <dir>]
+ *                                      [--update-baseline] [--viewport <name>]...
+ *                                      [--strict]
+ * Env: ELIZA_AUDIT_APP_DIR overrides the input dir (matches the audit spec);
+ * ELIZA_MVP_VISUAL_BASELINE_DIR overrides the committed baseline directory.
  */
 
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { diffAgainstBaseline } from "./mvp-visual-verify/diff.mjs";
 import { dominantColorsFromPng } from "./mvp-visual-verify/dominant-color.mjs";
 import {
   evaluateExpectations,
   resolveSpec,
 } from "./mvp-visual-verify/expectation-eval.mjs";
-import { ocrImage, resolveTesseract } from "./mvp-visual-verify/ocr.mjs";
+import {
+  closeOcrEngines,
+  ocrImage,
+  resolveOcrEngine,
+} from "./mvp-visual-verify/ocr.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const appDir = path.resolve(here, "..");
@@ -38,11 +45,12 @@ function log(msg) {
   process.stdout.write(`[mvp-visual-verify] ${msg}\n`);
 }
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const args = { viewports: [], updateBaseline: false, strict: false };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
     if (a === "--input") args.input = argv[++i];
+    else if (a === "--baseline") args.baseline = argv[++i];
     else if (a === "--viewport") args.viewports.push(argv[++i]);
     else if (a === "--update-baseline") args.updateBaseline = true;
     else if (a === "--strict") args.strict = true;
@@ -112,7 +120,11 @@ async function main() {
   }
 
   const outDir = path.join(inputDir, "mvp-verify");
-  const baselineRoot = path.join(outDir, "baseline");
+  const baselineRoot = path.resolve(
+    args.baseline ??
+      process.env.ELIZA_MVP_VISUAL_BASELINE_DIR ??
+      path.join(here, "mvp-visual-verify", "baseline"),
+  );
   const diffRoot = path.join(outDir, "diffs");
   await mkdir(outDir, { recursive: true });
 
@@ -127,17 +139,20 @@ async function main() {
     present: reportPresent,
     count: reportCount,
   } = await loadReportIndex(inputDir);
-  const tesseract = resolveTesseract();
+  const ocrEngine = await resolveOcrEngine();
 
   log(`input: ${inputDir}`);
+  log(`baseline: ${baselineRoot}`);
   log(
     `audit report.json: ${reportPresent ? `${reportCount} findings` : "ABSENT (overflow/DOM checks will skip)"}`,
   );
   log(
-    `OCR engine: ${tesseract ? tesseract : "N/A (tesseract binary not found — OCR column honest N/A)"}`,
+    `OCR engine: ${ocrEngine.available ? ocrEngine.label : `UNAVAILABLE (${ocrEngine.reason})`}`,
   );
   if (args.updateBaseline)
-    log("--update-baseline: recording current shots as the diff baseline");
+    log(
+      "--update-baseline: recording current shots into the baseline directory",
+    );
 
   const viewportDirs = await discoverViewportDirs(inputDir, args.viewports);
   log(
@@ -145,86 +160,91 @@ async function main() {
   );
 
   const results = [];
-  for (const vp of viewportDirs) {
-    for (const png of vp.pngs) {
-      const slug = png.replace(/\.png$/, "");
-      const currentPath = path.join(inputDir, vp.name, png);
-      const finding = reportIndex.get(`${slug}::${vp.name}`) ?? null;
+  try {
+    for (const vp of viewportDirs) {
+      for (const png of vp.pngs) {
+        const slug = png.replace(/\.png$/, "");
+        const currentPath = path.join(inputDir, vp.name, png);
+        const finding = reportIndex.get(`${slug}::${vp.name}`) ?? null;
 
-      const palette = await dominantColorsFromPng(currentPath);
-      const ocr = await ocrImage(currentPath).catch((error) => ({
-        available: false,
-        reason: `OCR failed: ${error?.message ?? String(error)}`,
-      }));
-      const baselinePath = path.join(baselineRoot, vp.name, png);
-      const diffOutPath = path.join(diffRoot, vp.name, png);
-      // --update-baseline: overwrite the baseline with the current shot BEFORE
-      // diffing, so the refresh is deliberate and the diff self-reports 0%.
-      if (args.updateBaseline) {
-        await mkdir(path.dirname(baselinePath), { recursive: true });
-        await (await import("sharp")).default(currentPath).toFile(baselinePath);
-      }
-      const diff = await diffAgainstBaseline({
-        currentPath,
-        baselinePath,
-        diffOutPath,
-        recordMissingBaseline: true,
-      });
+        const palette = await dominantColorsFromPng(currentPath);
+        const ocr = await ocrImage(currentPath);
+        const baselinePath = path.join(baselineRoot, vp.name, png);
+        const diffOutPath = path.join(diffRoot, vp.name, png);
+        // --update-baseline: overwrite the baseline with the current shot BEFORE
+        // diffing, so the refresh is deliberate and the diff self-reports 0%.
+        if (args.updateBaseline) {
+          await mkdir(path.dirname(baselinePath), { recursive: true });
+          await (await import("sharp"))
+            .default(currentPath)
+            .toFile(baselinePath);
+        }
+        const diff = await diffAgainstBaseline({
+          currentPath,
+          baselinePath,
+          diffOutPath,
+          recordMissingBaseline: args.updateBaseline,
+        });
 
-      const spec = resolveSpec(specs, slug);
-      const expectation = evaluateExpectations(
-        { viewport: vp.name, ocr, palette, finding },
-        spec,
-      );
+        const spec = resolveSpec(specs, slug);
+        const expectation = evaluateExpectations(
+          { viewport: vp.name, ocr, palette, finding },
+          spec,
+        );
 
-      results.push({
-        slug,
-        viewport: vp.name,
-        screenshot: path.relative(outDir, currentPath),
-        ocr: ocr.available
-          ? {
-              available: true,
-              words: ocr.words,
-              chars: ocr.chars,
-              text: ocr.text.slice(0, 4000),
-            }
-          : { available: false, reason: ocr.reason },
-        palette: {
-          buckets: Object.fromEntries(
-            Object.entries(palette.buckets).map(([k, v]) => [
-              k,
-              Number(v.toFixed(4)),
-            ]),
-          ),
-          swatches: palette.swatches.map((s) => ({
-            hex: s.hex,
-            bucket: s.bucket,
-            ratio: Number(s.ratio.toFixed(4)),
-          })),
-        },
-        diff:
-          diff.status === "new"
+        results.push({
+          slug,
+          viewport: vp.name,
+          screenshot: path.relative(outDir, currentPath),
+          ocr: ocr.available
             ? {
-                status: "new",
-                note: "baseline recorded; nothing to compare yet",
+                available: true,
+                words: ocr.words,
+                chars: ocr.chars,
+                text: ocr.text.slice(0, 4000),
               }
-            : {
-                status: "compared",
-                changedPercent: diff.summary.changedPercent,
-                meanAbsDelta: diff.summary.meanAbsDelta,
-                resized: diff.summary.resized,
-                diffPng: diff.diffPath
-                  ? path.relative(outDir, diff.diffPath)
-                  : null,
-              },
-        expectation: {
-          pass: expectation.pass,
-          reasons: expectation.reasons,
-          checks: expectation.checks,
-        },
-        horizontalOverflowPx: finding?.horizontalOverflowPx ?? null,
-      });
+            : { available: false, reason: ocr.reason },
+          palette: {
+            buckets: Object.fromEntries(
+              Object.entries(palette.buckets).map(([k, v]) => [
+                k,
+                Number(v.toFixed(4)),
+              ]),
+            ),
+            swatches: palette.swatches.map((s) => ({
+              hex: s.hex,
+              bucket: s.bucket,
+              ratio: Number(s.ratio.toFixed(4)),
+            })),
+          },
+          diff:
+            diff.status === "new"
+              ? {
+                  status: "new",
+                  note: args.updateBaseline
+                    ? "baseline recorded; nothing to compare yet"
+                    : "baseline missing; run with --update-baseline after manual review",
+                }
+              : {
+                  status: "compared",
+                  changedPercent: diff.summary.changedPercent,
+                  meanAbsDelta: diff.summary.meanAbsDelta,
+                  resized: diff.summary.resized,
+                  diffPng: diff.diffPath
+                    ? path.relative(outDir, diff.diffPath)
+                    : null,
+                },
+          expectation: {
+            pass: expectation.pass,
+            reasons: expectation.reasons,
+            checks: expectation.checks,
+          },
+          horizontalOverflowPx: finding?.horizontalOverflowPx ?? null,
+        });
+      }
     }
+  } finally {
+    await closeOcrEngines();
   }
 
   results.sort((a, b) =>
@@ -233,21 +253,28 @@ async function main() {
       : a.slug.localeCompare(b.slug),
   );
 
+  const expectationSkips = countExpectationChecks(results, "skip");
+  const expectationFailures = results.filter((r) => !r.expectation.pass).length;
+  const newBaselines = results.filter((r) => r.diff.status === "new").length;
+  const emptyRunFailures = results.length === 0 ? 1 : 0;
+  const strictFailures =
+    expectationFailures + expectationSkips + newBaselines + emptyRunFailures;
+
   const summary = {
     generatedAt: new Date().toISOString(),
     inputDir,
+    baselineDir: baselineRoot,
     states: results.length,
-    ocrEngine: tesseract ?? "N/A (tesseract not found)",
+    ocrEngine: ocrEngine.available
+      ? ocrEngine.label
+      : `UNAVAILABLE: ${ocrEngine.reason}`,
     auditReportPresent: reportPresent,
-    expectationFailures: results.filter((r) => !r.expectation.pass).length,
-    skippedChecks: results.reduce(
-      (count, r) =>
-        count + r.expectation.checks.filter((c) => c.status === "skip").length,
-      0,
-    ),
-    newBaselines: results.filter((r) => r.diff.status === "new").length,
+    expectationFailures,
+    expectationSkips,
+    newBaselines,
     overflowStates: results.filter((r) => (r.horizontalOverflowPx ?? 0) > 2)
       .length,
+    strictFailures,
   };
 
   await writeFile(
@@ -265,7 +292,7 @@ async function main() {
     `wrote ${results.length} states → ${path.join(outDir, "report.json")} + contact-sheet.html`,
   );
   log(
-    `expectation failures: ${summary.expectationFailures} | skipped checks: ${summary.skippedChecks} | overflow states: ${summary.overflowStates} | new baselines: ${summary.newBaselines}`,
+    `expectation failures: ${summary.expectationFailures} | expectation skips: ${summary.expectationSkips} | overflow states: ${summary.overflowStates} | new baselines: ${summary.newBaselines}`,
   );
   if (summary.expectationFailures > 0) {
     for (const r of results.filter((r) => !r.expectation.pass)) {
@@ -275,20 +302,30 @@ async function main() {
     }
   }
 
-  if (args.strict && hasStrictFailure(summary)) {
+  if (args.strict && summary.strictFailures > 0) {
     log(
-      "--strict: exiting non-zero due to failures, skipped checks, or missing baselines",
+      "--strict: exiting non-zero because every required signal must be present and compared",
     );
+    if (summary.states === 0) log("  FAIL no screenshots were processed");
+    if (summary.newBaselines > 0) {
+      log(
+        `  FAIL ${summary.newBaselines} screenshot(s) have no baseline comparison`,
+      );
+    }
+    if (summary.expectationSkips > 0) {
+      log(`  FAIL ${summary.expectationSkips} expectation check(s) skipped`);
+    }
     return 1;
   }
   return 0;
 }
 
-function hasStrictFailure(summary) {
-  return (
-    summary.expectationFailures > 0 ||
-    summary.skippedChecks > 0 ||
-    summary.newBaselines > 0
+export function countExpectationChecks(results, status) {
+  return results.reduce(
+    (count, r) =>
+      count +
+      r.expectation.checks.filter((check) => check.status === status).length,
+    0,
   );
 }
 
@@ -323,10 +360,10 @@ function renderContactSheet(summary, results) {
       const diffCell =
         r.diff.status === "new"
           ? '<span class="new">NEW baseline</span>'
-          : `${r.diff.changedPercent}% changed${r.diff.resized ? " (resized)" : ""}${r.diff.diffPng ? `<br><a href="${esc(r.diff.diffPng)}"><img class="thumb" src="${esc(r.diff.diffPng)}"></a>` : ""}`;
+          : `${r.diff.changedPercent}% changed${r.diff.resized ? " (resized)" : ""}${r.diff.diffPng ? `<br><img class="thumb" src="${esc(r.diff.diffPng)}">` : ""}`;
       return `<tr class="${r.expectation.pass ? "" : "row-fail"}">
         <td class="slug">${esc(r.slug)}<br><span class="meta">${esc(r.viewport)}</span></td>
-        <td><a href="${esc(r.screenshot)}"><img class="thumb" src="${esc(r.screenshot)}" loading="lazy"></a></td>
+        <td><img class="thumb" src="${esc(r.screenshot)}" loading="lazy"></td>
         <td>${ocrCell}</td>
         <td class="pal">${swatches}<div class="meta">${Object.entries(
           r.palette.buckets,
@@ -356,8 +393,9 @@ function renderContactSheet(summary, results) {
 <h1>mvp visual verify</h1>
 <div class="summary">
   ${esc(summary.states)} states · OCR: ${esc(summary.ocrEngine)} · expectation failures: <b>${summary.expectationFailures}</b> ·
-  skipped checks: <b>${summary.skippedChecks}</b> · overflow states: <b>${summary.overflowStates}</b> · new baselines: ${summary.newBaselines} ·
-  audit report: ${summary.auditReportPresent ? "loaded" : "ABSENT"} · ${esc(summary.generatedAt)}
+  skipped checks: <b>${summary.expectationSkips}</b> · overflow states: <b>${summary.overflowStates}</b> ·
+  new baselines: ${summary.newBaselines} · audit report: ${summary.auditReportPresent ? "loaded" : "ABSENT"} ·
+  baseline: ${esc(summary.baselineDir)} · ${esc(summary.generatedAt)}
 </div>
 <table>
   <tr><th>state</th><th>screenshot</th><th>OCR text</th><th>palette</th><th>diff vs baseline</th><th>expectations</th></tr>
@@ -365,10 +403,15 @@ function renderContactSheet(summary, results) {
 </table>`;
 }
 
-main().then(
-  (code) => process.exit(code ?? 0),
-  (err) => {
-    process.stderr.write(`[mvp-visual-verify] fatal: ${err?.stack || err}\n`);
-    process.exit(2);
-  },
-);
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().then(
+    (code) => process.exit(code ?? 0),
+    (err) => {
+      process.stderr.write(`[mvp-visual-verify] fatal: ${err?.stack || err}\n`);
+      process.exit(2);
+    },
+  );
+}

--- a/packages/app/scripts/mvp-visual-verify.mjs
+++ b/packages/app/scripts/mvp-visual-verify.mjs
@@ -152,7 +152,10 @@ async function main() {
       const finding = reportIndex.get(`${slug}::${vp.name}`) ?? null;
 
       const palette = await dominantColorsFromPng(currentPath);
-      const ocr = await ocrImage(currentPath);
+      const ocr = await ocrImage(currentPath).catch((error) => ({
+        available: false,
+        reason: `OCR failed: ${error?.message ?? String(error)}`,
+      }));
       const baselinePath = path.join(baselineRoot, vp.name, png);
       const diffOutPath = path.join(diffRoot, vp.name, png);
       // --update-baseline: overwrite the baseline with the current shot BEFORE
@@ -237,6 +240,11 @@ async function main() {
     ocrEngine: tesseract ?? "N/A (tesseract not found)",
     auditReportPresent: reportPresent,
     expectationFailures: results.filter((r) => !r.expectation.pass).length,
+    skippedChecks: results.reduce(
+      (count, r) =>
+        count + r.expectation.checks.filter((c) => c.status === "skip").length,
+      0,
+    ),
     newBaselines: results.filter((r) => r.diff.status === "new").length,
     overflowStates: results.filter((r) => (r.horizontalOverflowPx ?? 0) > 2)
       .length,
@@ -257,7 +265,7 @@ async function main() {
     `wrote ${results.length} states → ${path.join(outDir, "report.json")} + contact-sheet.html`,
   );
   log(
-    `expectation failures: ${summary.expectationFailures} | overflow states: ${summary.overflowStates} | new baselines: ${summary.newBaselines}`,
+    `expectation failures: ${summary.expectationFailures} | skipped checks: ${summary.skippedChecks} | overflow states: ${summary.overflowStates} | new baselines: ${summary.newBaselines}`,
   );
   if (summary.expectationFailures > 0) {
     for (const r of results.filter((r) => !r.expectation.pass)) {
@@ -267,11 +275,21 @@ async function main() {
     }
   }
 
-  if (args.strict && summary.expectationFailures > 0) {
-    log("--strict: exiting non-zero due to expectation failures");
+  if (args.strict && hasStrictFailure(summary)) {
+    log(
+      "--strict: exiting non-zero due to failures, skipped checks, or missing baselines",
+    );
     return 1;
   }
   return 0;
+}
+
+function hasStrictFailure(summary) {
+  return (
+    summary.expectationFailures > 0 ||
+    summary.skippedChecks > 0 ||
+    summary.newBaselines > 0
+  );
 }
 
 function esc(s) {
@@ -305,10 +323,10 @@ function renderContactSheet(summary, results) {
       const diffCell =
         r.diff.status === "new"
           ? '<span class="new">NEW baseline</span>'
-          : `${r.diff.changedPercent}% changed${r.diff.resized ? " (resized)" : ""}${r.diff.diffPng ? `<br><img class="thumb" src="${esc(r.diff.diffPng)}">` : ""}`;
+          : `${r.diff.changedPercent}% changed${r.diff.resized ? " (resized)" : ""}${r.diff.diffPng ? `<br><a href="${esc(r.diff.diffPng)}"><img class="thumb" src="${esc(r.diff.diffPng)}"></a>` : ""}`;
       return `<tr class="${r.expectation.pass ? "" : "row-fail"}">
         <td class="slug">${esc(r.slug)}<br><span class="meta">${esc(r.viewport)}</span></td>
-        <td><img class="thumb" src="${esc(r.screenshot)}" loading="lazy"></td>
+        <td><a href="${esc(r.screenshot)}"><img class="thumb" src="${esc(r.screenshot)}" loading="lazy"></a></td>
         <td>${ocrCell}</td>
         <td class="pal">${swatches}<div class="meta">${Object.entries(
           r.palette.buckets,
@@ -338,7 +356,7 @@ function renderContactSheet(summary, results) {
 <h1>mvp visual verify</h1>
 <div class="summary">
   ${esc(summary.states)} states · OCR: ${esc(summary.ocrEngine)} · expectation failures: <b>${summary.expectationFailures}</b> ·
-  overflow states: <b>${summary.overflowStates}</b> · new baselines: ${summary.newBaselines} ·
+  skipped checks: <b>${summary.skippedChecks}</b> · overflow states: <b>${summary.overflowStates}</b> · new baselines: ${summary.newBaselines} ·
   audit report: ${summary.auditReportPresent ? "loaded" : "ABSENT"} · ${esc(summary.generatedAt)}
 </div>
 <table>

--- a/packages/app/scripts/mvp-visual-verify.mjs
+++ b/packages/app/scripts/mvp-visual-verify.mjs
@@ -20,16 +20,16 @@
  * Env: ELIZA_AUDIT_APP_DIR overrides the input dir (matches the audit spec).
  */
 
-import { readdir, readFile, writeFile, mkdir, stat } from "node:fs/promises";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { dominantColorsFromPng } from "./mvp-visual-verify/dominant-color.mjs";
-import { ocrImage, resolveTesseract } from "./mvp-visual-verify/ocr.mjs";
 import { diffAgainstBaseline } from "./mvp-visual-verify/diff.mjs";
+import { dominantColorsFromPng } from "./mvp-visual-verify/dominant-color.mjs";
 import {
   evaluateExpectations,
   resolveSpec,
 } from "./mvp-visual-verify/expectation-eval.mjs";
+import { ocrImage, resolveTesseract } from "./mvp-visual-verify/ocr.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const appDir = path.resolve(here, "..");
@@ -52,7 +52,12 @@ function parseArgs(argv) {
 }
 
 /** Directories under the audit output that are outputs/notes, not viewport shots. */
-const NON_VIEWPORT_DIRS = new Set(["mvp-verify", "manual-review", "baseline", "diffs"]);
+const NON_VIEWPORT_DIRS = new Set([
+  "mvp-verify",
+  "manual-review",
+  "baseline",
+  "diffs",
+]);
 
 async function isDir(p) {
   return stat(p).then(
@@ -89,12 +94,16 @@ async function loadReportIndex(inputDir) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
-    log("post-processes audit:app screenshots into mvp-verify/ (OCR + palette + diff + expectations)");
+    log(
+      "post-processes audit:app screenshots into mvp-verify/ (OCR + palette + diff + expectations)",
+    );
     return 0;
   }
 
   const inputDir = path.resolve(
-    args.input ?? process.env.ELIZA_AUDIT_APP_DIR ?? path.join(appDir, "aesthetic-audit-output"),
+    args.input ??
+      process.env.ELIZA_AUDIT_APP_DIR ??
+      path.join(appDir, "aesthetic-audit-output"),
   );
   if (!(await isDir(inputDir))) {
     throw new Error(
@@ -107,23 +116,35 @@ async function main() {
   const diffRoot = path.join(outDir, "diffs");
   await mkdir(outDir, { recursive: true });
 
-  const specsRaw = await readFile(path.join(here, "mvp-visual-verify", "expectations.json"), "utf8");
+  const specsRaw = await readFile(
+    path.join(here, "mvp-visual-verify", "expectations.json"),
+    "utf8",
+  );
   const specs = JSON.parse(specsRaw);
 
-  const { index: reportIndex, present: reportPresent, count: reportCount } =
-    await loadReportIndex(inputDir);
+  const {
+    index: reportIndex,
+    present: reportPresent,
+    count: reportCount,
+  } = await loadReportIndex(inputDir);
   const tesseract = resolveTesseract();
 
   log(`input: ${inputDir}`);
-  log(`audit report.json: ${reportPresent ? `${reportCount} findings` : "ABSENT (overflow/DOM checks will skip)"}`);
-  log(`OCR engine: ${tesseract ? tesseract : "N/A (tesseract binary not found — OCR column honest N/A)"}`);
-  if (args.updateBaseline) log("--update-baseline: recording current shots as the diff baseline");
+  log(
+    `audit report.json: ${reportPresent ? `${reportCount} findings` : "ABSENT (overflow/DOM checks will skip)"}`,
+  );
+  log(
+    `OCR engine: ${tesseract ? tesseract : "N/A (tesseract binary not found — OCR column honest N/A)"}`,
+  );
+  if (args.updateBaseline)
+    log("--update-baseline: recording current shots as the diff baseline");
 
   const viewportDirs = await discoverViewportDirs(inputDir, args.viewports);
-  log(`viewports: ${viewportDirs.map((v) => `${v.name}(${v.pngs.length})`).join(", ") || "none found"}`);
+  log(
+    `viewports: ${viewportDirs.map((v) => `${v.name}(${v.pngs.length})`).join(", ") || "none found"}`,
+  );
 
   const results = [];
-  let processed = 0;
   for (const vp of viewportDirs) {
     for (const png of vp.pngs) {
       const slug = png.replace(/\.png$/, "");
@@ -158,11 +179,19 @@ async function main() {
         viewport: vp.name,
         screenshot: path.relative(outDir, currentPath),
         ocr: ocr.available
-          ? { available: true, words: ocr.words, chars: ocr.chars, text: ocr.text.slice(0, 4000) }
+          ? {
+              available: true,
+              words: ocr.words,
+              chars: ocr.chars,
+              text: ocr.text.slice(0, 4000),
+            }
           : { available: false, reason: ocr.reason },
         palette: {
           buckets: Object.fromEntries(
-            Object.entries(palette.buckets).map(([k, v]) => [k, Number(v.toFixed(4))]),
+            Object.entries(palette.buckets).map(([k, v]) => [
+              k,
+              Number(v.toFixed(4)),
+            ]),
           ),
           swatches: palette.swatches.map((s) => ({
             hex: s.hex,
@@ -172,13 +201,18 @@ async function main() {
         },
         diff:
           diff.status === "new"
-            ? { status: "new", note: "baseline recorded; nothing to compare yet" }
+            ? {
+                status: "new",
+                note: "baseline recorded; nothing to compare yet",
+              }
             : {
                 status: "compared",
                 changedPercent: diff.summary.changedPercent,
                 meanAbsDelta: diff.summary.meanAbsDelta,
                 resized: diff.summary.resized,
-                diffPng: diff.diffPath ? path.relative(outDir, diff.diffPath) : null,
+                diffPng: diff.diffPath
+                  ? path.relative(outDir, diff.diffPath)
+                  : null,
               },
         expectation: {
           pass: expectation.pass,
@@ -187,12 +221,13 @@ async function main() {
         },
         horizontalOverflowPx: finding?.horizontalOverflowPx ?? null,
       });
-      processed += 1;
     }
   }
 
   results.sort((a, b) =>
-    a.slug === b.slug ? a.viewport.localeCompare(b.viewport) : a.slug.localeCompare(b.slug),
+    a.slug === b.slug
+      ? a.viewport.localeCompare(b.viewport)
+      : a.slug.localeCompare(b.slug),
   );
 
   const summary = {
@@ -203,7 +238,8 @@ async function main() {
     auditReportPresent: reportPresent,
     expectationFailures: results.filter((r) => !r.expectation.pass).length,
     newBaselines: results.filter((r) => r.diff.status === "new").length,
-    overflowStates: results.filter((r) => (r.horizontalOverflowPx ?? 0) > 2).length,
+    overflowStates: results.filter((r) => (r.horizontalOverflowPx ?? 0) > 2)
+      .length,
   };
 
   await writeFile(
@@ -211,7 +247,11 @@ async function main() {
     JSON.stringify({ summary, states: results }, null, 2),
     "utf8",
   );
-  await writeFile(path.join(outDir, "contact-sheet.html"), renderContactSheet(summary, results), "utf8");
+  await writeFile(
+    path.join(outDir, "contact-sheet.html"),
+    renderContactSheet(summary, results),
+    "utf8",
+  );
 
   log(
     `wrote ${results.length} states → ${path.join(outDir, "report.json")} + contact-sheet.html`,
@@ -221,7 +261,9 @@ async function main() {
   );
   if (summary.expectationFailures > 0) {
     for (const r of results.filter((r) => !r.expectation.pass)) {
-      log(`  FAIL ${r.slug} @ ${r.viewport}: ${r.expectation.reasons.join(" | ")}`);
+      log(
+        `  FAIL ${r.slug} @ ${r.viewport}: ${r.expectation.reasons.join(" | ")}`,
+      );
     }
   }
 
@@ -233,7 +275,10 @@ async function main() {
 }
 
 function esc(s) {
-  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 function renderContactSheet(summary, results) {
@@ -249,7 +294,10 @@ function renderContactSheet(summary, results) {
         ? '<span class="pass">PASS</span>'
         : `<span class="fail">FAIL</span>`;
       const checks = r.expectation.checks
-        .map((c) => `<div class="chk ${c.status}">${esc(c.name)}: ${esc(c.detail)}</div>`)
+        .map(
+          (c) =>
+            `<div class="chk ${c.status}">${esc(c.name)}: ${esc(c.detail)}</div>`,
+        )
         .join("");
       const ocrCell = r.ocr.available
         ? `<div class="ocr">${esc(r.ocr.text || "(no glyphs)")}</div><div class="meta">${r.ocr.words} words</div>`
@@ -262,7 +310,11 @@ function renderContactSheet(summary, results) {
         <td class="slug">${esc(r.slug)}<br><span class="meta">${esc(r.viewport)}</span></td>
         <td><img class="thumb" src="${esc(r.screenshot)}" loading="lazy"></td>
         <td>${ocrCell}</td>
-        <td class="pal">${swatches}<div class="meta">${Object.entries(r.palette.buckets).map(([k, v]) => `${k} ${(v * 100).toFixed(0)}%`).join(" · ")}</div></td>
+        <td class="pal">${swatches}<div class="meta">${Object.entries(
+          r.palette.buckets,
+        )
+          .map(([k, v]) => `${k} ${(v * 100).toFixed(0)}%`)
+          .join(" · ")}</div></td>
         <td class="diff">${diffCell}</td>
         <td>${verdict}<div class="checks">${checks}</div></td>
       </tr>`;

--- a/packages/app/scripts/mvp-visual-verify/color-bucket.mjs
+++ b/packages/app/scripts/mvp-visual-verify/color-bucket.mjs
@@ -1,0 +1,88 @@
+/**
+ * Coarse brand-color classifier for the mvp-visual-verify post-processor.
+ *
+ * This is a faithful ESM port of `parseRgb` / `bucket` from
+ * `test/ui-smoke/aesthetic-audit-rules.ts` — the audit spec's canonical no-blue /
+ * orange-accent policy. The audit rules live in a `.ts` module the Playwright
+ * runner imports; this post-processor is a plain-node `.mjs` pipeline that cannot
+ * import that TS at runtime, so the hue-based bucketing is reproduced here and
+ * pinned to the audit's behavior by the parity block in
+ * `test/audit/mvp-visual-verify.test.ts`. Keep the two in lockstep: a divergence
+ * would let the visual-verify accent check accept a blue the audit bans.
+ *
+ * Chromatic classification is HUE-based (orange ~10-50°, blue ~200-270°), not a
+ * raw-channel threshold, so the shipped brand accent `rgb(255,88,0)` (g=88) is
+ * still classified orange rather than falling through to neutral.
+ */
+
+/** @typedef {"orange"|"black"|"blue"|"white"|"neutral"|"transparent"} Bucket */
+
+/**
+ * Parse a CSS `rgb()` / `rgba()` string into `[r, g, b, a]` (a defaults to 1).
+ * Returns null for any other color form (named, hex, hsl) — callers that need a
+ * bucket for those must convert first.
+ * @param {string} input
+ * @returns {[number, number, number, number] | null}
+ */
+export function parseRgb(input) {
+  const m = String(input).match(
+    /^rgba?\(\s*(\d+\.?\d*)\s*,\s*(\d+\.?\d*)\s*,\s*(\d+\.?\d*)(?:\s*,\s*(\d+\.?\d*))?\s*\)$/,
+  );
+  if (!m) return null;
+  return [
+    Number(m[1]),
+    Number(m[2]),
+    Number(m[3]),
+    m[4] === undefined ? 1 : Number(m[4]),
+  ];
+}
+
+/**
+ * Bucket an RGB triple into a coarse brand category. Split out from
+ * {@link bucket} so the dominant-color quantizer can classify raw pixel channels
+ * without stringifying each color first.
+ * @param {number} r
+ * @param {number} g
+ * @param {number} b
+ * @param {number} [a=1]
+ * @returns {Bucket}
+ */
+export function bucketRgb(r, g, b, a = 1) {
+  if (a === 0) return "transparent";
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const chroma = max - min;
+  const lum = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  const saturation = max === 0 ? 0 : chroma / max;
+
+  if (lum > 0.95 && saturation < 0.05) return "white";
+  // Gate on ABSOLUTE chroma too: at low luminance a 1-2/255 spread yields a high
+  // chroma/max ratio yet is perceptually black, so a dark scrim must not escape
+  // here and get hue-classified as a saturated "blue".
+  if (saturation < 0.15 || chroma < 12) return lum < 0.08 ? "black" : "neutral";
+
+  let hue = 0;
+  if (chroma > 0) {
+    if (max === r) hue = ((g - b) / chroma) % 6;
+    else if (max === g) hue = (b - r) / chroma + 2;
+    else hue = (r - g) / chroma + 4;
+    hue *= 60;
+    if (hue < 0) hue += 360;
+  }
+  if (hue >= 200 && hue <= 270) return "blue";
+  if (hue >= 10 && hue <= 50) return "orange";
+  if (lum < 0.08) return "black";
+  return "neutral";
+}
+
+/**
+ * Bucket a CSS color string. Non-rgb() inputs classify as "neutral" (matching the
+ * audit rules — the DOM scans only ever feed computed `rgb()`/`rgba()` values).
+ * @param {string} color
+ * @returns {Bucket}
+ */
+export function bucket(color) {
+  const rgb = parseRgb(color);
+  if (!rgb) return "neutral";
+  return bucketRgb(rgb[0], rgb[1], rgb[2], rgb[3]);
+}

--- a/packages/app/scripts/mvp-visual-verify/diff.mjs
+++ b/packages/app/scripts/mvp-visual-verify/diff.mjs
@@ -1,0 +1,167 @@
+/**
+ * Pixel diff of a captured screenshot against a committed baseline, with zero
+ * new dependencies — sharp decodes both PNGs to raw RGBA and the comparison is
+ * hand-rolled (pixelmatch is deliberately not installed).
+ *
+ * {@link summarizeDiff} is a pure reducer over pre-counted totals (unit-tested);
+ * {@link diffAgainstBaseline} is the sharp-backed pipeline that decodes both
+ * images, resizes the current shot to the baseline's dimensions when they drift
+ * (fixed-viewport screenshots make this rare, but a resized DOM must not throw),
+ * counts changed pixels, and writes a magenta-highlighted diff PNG. A first run
+ * with no baseline records the baseline and reports status `"new"` — never a
+ * false 0%-changed pass.
+ */
+
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import sharp from "sharp";
+
+/** Per-channel sum-abs delta above which a pixel counts as changed. */
+export const DEFAULT_PIXEL_THRESHOLD = 30;
+
+/**
+ * Reduce raw change counts into a diff summary. Pure so the percentage/verdict
+ * math is unit-tested without decoding an image.
+ *
+ * @param {{ changedPixels: number, totalPixels: number, sumAbsDelta: number, resized?: boolean }} m
+ * @returns {{ changedPixels: number, totalPixels: number, changedRatio: number, changedPercent: number, meanAbsDelta: number, resized: boolean }}
+ */
+export function summarizeDiff(m) {
+  if (m.totalPixels <= 0) {
+    throw new Error("summarizeDiff: totalPixels must be > 0");
+  }
+  const changedRatio = m.changedPixels / m.totalPixels;
+  return {
+    changedPixels: m.changedPixels,
+    totalPixels: m.totalPixels,
+    changedRatio,
+    changedPercent: Number((changedRatio * 100).toFixed(3)),
+    // meanAbsDelta is per-CHANNEL (sumAbsDelta already sums the 3 channels of
+    // every pixel), giving a continuous signal even when no pixel trips the
+    // threshold — a whole-image tint shift shows here before it shows in %.
+    meanAbsDelta: Number((m.sumAbsDelta / (m.totalPixels * 3)).toFixed(3)),
+    resized: Boolean(m.resized),
+  };
+}
+
+/**
+ * Compare two decoded RGBA buffers of identical dimensions. Pure over buffers so
+ * a test can feed synthetic pixels. Returns the counts {@link summarizeDiff}
+ * consumes plus an optional highlighted RGBA buffer (changed pixels → magenta,
+ * unchanged → dimmed grayscale) for encoding.
+ *
+ * @param {Uint8Array|Buffer} a
+ * @param {Uint8Array|Buffer} b
+ * @param {number} width
+ * @param {number} height
+ * @param {{ threshold?: number, buildHighlight?: boolean }} [opts]
+ */
+export function comparePixels(a, b, width, height, opts = {}) {
+  const threshold = opts.threshold ?? DEFAULT_PIXEL_THRESHOLD;
+  const totalPixels = width * height;
+  const expected = totalPixels * 4;
+  if (a.length < expected || b.length < expected) {
+    throw new Error(
+      `comparePixels: buffers too small for ${width}x${height} (need ${expected}, got ${a.length}/${b.length})`,
+    );
+  }
+  const highlight = opts.buildHighlight ? Buffer.alloc(expected) : null;
+  let changedPixels = 0;
+  let sumAbsDelta = 0;
+  for (let p = 0, i = 0; p < totalPixels; p += 1, i += 4) {
+    const dr = Math.abs(a[i] - b[i]);
+    const dg = Math.abs(a[i + 1] - b[i + 1]);
+    const db = Math.abs(a[i + 2] - b[i + 2]);
+    const sum = dr + dg + db;
+    sumAbsDelta += sum;
+    const changed = sum > threshold;
+    if (changed) changedPixels += 1;
+    if (highlight) {
+      if (changed) {
+        highlight[i] = 255;
+        highlight[i + 1] = 0;
+        highlight[i + 2] = 255;
+        highlight[i + 3] = 255;
+      } else {
+        const gray = Math.round((b[i] + b[i + 1] + b[i + 2]) / 3 / 3) + 20;
+        highlight[i] = gray;
+        highlight[i + 1] = gray;
+        highlight[i + 2] = gray;
+        highlight[i + 3] = 255;
+      }
+    }
+  }
+  return { changedPixels, totalPixels, sumAbsDelta, highlight };
+}
+
+/**
+ * Decode current + baseline PNGs, diff them, and (when changed) write a diff PNG.
+ * When no baseline exists yet the current shot is copied in as the baseline and
+ * the result is `status: "new"` — honest "recorded, nothing to compare" rather
+ * than a fabricated pass.
+ *
+ * @param {{ currentPath: string, baselinePath: string, diffOutPath?: string, threshold?: number, recordMissingBaseline?: boolean }} args
+ * @returns {Promise<{ status: "new" | "compared", summary?: object, baselinePath: string, diffPath?: string }>}
+ */
+export async function diffAgainstBaseline(args) {
+  const { currentPath, baselinePath } = args;
+  const threshold = args.threshold ?? DEFAULT_PIXEL_THRESHOLD;
+  const recordMissing = args.recordMissingBaseline ?? true;
+
+  const baselineExists = await fileExists(baselinePath);
+  if (!baselineExists) {
+    if (recordMissing) {
+      await mkdir(path.dirname(baselinePath), { recursive: true });
+      await sharp(currentPath).toFile(baselinePath);
+    }
+    return { status: "new", baselinePath };
+  }
+
+  const baseline = await sharp(baselinePath)
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const width = baseline.info.width;
+  const height = baseline.info.height;
+
+  let currentPipeline = sharp(currentPath).ensureAlpha();
+  const currentMeta = await sharp(currentPath).metadata();
+  const resized = currentMeta.width !== width || currentMeta.height !== height;
+  if (resized) {
+    currentPipeline = currentPipeline.resize(width, height, { fit: "fill" });
+  }
+  const current = await currentPipeline
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+
+  const wantHighlight = Boolean(args.diffOutPath);
+  const cmp = comparePixels(current.data, baseline.data, width, height, {
+    threshold,
+    buildHighlight: wantHighlight,
+  });
+  const summary = summarizeDiff({
+    changedPixels: cmp.changedPixels,
+    totalPixels: cmp.totalPixels,
+    sumAbsDelta: cmp.sumAbsDelta,
+    resized,
+  });
+
+  let diffPath;
+  if (wantHighlight && cmp.highlight && cmp.changedPixels > 0) {
+    await mkdir(path.dirname(args.diffOutPath), { recursive: true });
+    await sharp(cmp.highlight, { raw: { width, height, channels: 4 } })
+      .png()
+      .toFile(args.diffOutPath);
+    diffPath = args.diffOutPath;
+  }
+
+  return { status: "compared", summary, baselinePath, diffPath };
+}
+
+async function fileExists(p) {
+  const { access } = await import("node:fs/promises");
+  return access(p).then(
+    () => true,
+    () => false,
+  );
+}

--- a/packages/app/scripts/mvp-visual-verify/dominant-color.mjs
+++ b/packages/app/scripts/mvp-visual-verify/dominant-color.mjs
@@ -1,0 +1,96 @@
+/**
+ * Dominant-color palette extraction for captured audit screenshots.
+ *
+ * Two tiers: {@link quantizePalette} is a pure function over a raw RGBA byte
+ * buffer (bucket each channel to a coarse grid, tally coverage, return the top-K
+ * swatches with brand-bucket labels) and is unit-tested with synthetic buffers;
+ * {@link dominantColorsFromPng} is the sharp-backed decode wrapper the
+ * post-processor calls on real PNGs. The palette feeds the accent-color
+ * expectation (brand orange present, zero blue) — hence each swatch carries its
+ * {@link bucketRgb} label so the expectation evaluator never re-classifies.
+ */
+
+import sharp from "sharp";
+import { bucketRgb } from "./color-bucket.mjs";
+
+/**
+ * Quantize a raw RGBA buffer into the top-K dominant colors by coverage.
+ *
+ * Channels are snapped to a `step`-sized grid (default 16 → 16 levels/channel)
+ * so near-identical anti-aliased pixels collapse into one bucket; fully
+ * transparent pixels are skipped. Returns swatches sorted by descending coverage
+ * with the representative (bucket-center) RGB, the fraction of opaque pixels, and
+ * the brand bucket label.
+ *
+ * @param {Uint8Array|Buffer} data RGBA bytes, length = width*height*4.
+ * @param {{ step?: number, topK?: number }} [opts]
+ * @returns {{ swatches: Array<{ rgb: [number,number,number], hex: string, ratio: number, count: number, bucket: string }>, totalOpaque: number, buckets: Record<string, number> }}
+ */
+export function quantizePalette(data, opts = {}) {
+  const step = opts.step ?? 16;
+  const topK = opts.topK ?? 6;
+  if (data.length % 4 !== 0) {
+    throw new Error(
+      `quantizePalette: RGBA buffer length ${data.length} is not a multiple of 4`,
+    );
+  }
+  /** @type {Map<number, { r: number, g: number, b: number, count: number }>} */
+  const bins = new Map();
+  let totalOpaque = 0;
+  for (let i = 0; i < data.length; i += 4) {
+    const a = data[i + 3];
+    if (a === 0) continue;
+    totalOpaque += 1;
+    // Snap to the grid CENTER (not the floor) so a bucket's representative color
+    // sits mid-cell — closer to the true average of the pixels it absorbs.
+    const half = Math.floor(step / 2);
+    const r = Math.min(255, Math.floor(data[i] / step) * step + half);
+    const g = Math.min(255, Math.floor(data[i + 1] / step) * step + half);
+    const b = Math.min(255, Math.floor(data[i + 2] / step) * step + half);
+    const key = (r << 16) | (g << 8) | b;
+    const bin = bins.get(key);
+    if (bin) bin.count += 1;
+    else bins.set(key, { r, g, b, count: 1 });
+  }
+  const sorted = [...bins.values()].sort((x, y) => y.count - x.count);
+  const denom = totalOpaque || 1;
+  const swatches = sorted.slice(0, topK).map((bin) => ({
+    rgb: /** @type {[number,number,number]} */ ([bin.r, bin.g, bin.b]),
+    hex: rgbToHex(bin.r, bin.g, bin.b),
+    ratio: bin.count / denom,
+    count: bin.count,
+    bucket: bucketRgb(bin.r, bin.g, bin.b),
+  }));
+  /** @type {Record<string, number>} */
+  const buckets = {};
+  for (const bin of bins.values()) {
+    const label = bucketRgb(bin.r, bin.g, bin.b);
+    buckets[label] = (buckets[label] ?? 0) + bin.count / denom;
+  }
+  return { swatches, totalOpaque, buckets };
+}
+
+/**
+ * Decode a PNG to a downscaled raw RGBA buffer and return its dominant palette.
+ * Downscaling (default longest edge 256px) is a speed/robustness trade: exact
+ * per-pixel color counts are not the goal, dominant coverage is, and it keeps a
+ * 1440×1000 shot to a few hundred KB of pixels.
+ *
+ * @param {string} pngPath
+ * @param {{ step?: number, topK?: number, maxEdge?: number }} [opts]
+ */
+export async function dominantColorsFromPng(pngPath, opts = {}) {
+  const maxEdge = opts.maxEdge ?? 256;
+  const { data, info } = await sharp(pngPath)
+    .resize({ width: maxEdge, height: maxEdge, fit: "inside", withoutEnlargement: true })
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const palette = quantizePalette(data, opts);
+  return { ...palette, sampledWidth: info.width, sampledHeight: info.height };
+}
+
+function rgbToHex(r, g, b) {
+  const h = (n) => n.toString(16).padStart(2, "0");
+  return `#${h(r)}${h(g)}${h(b)}`;
+}

--- a/packages/app/scripts/mvp-visual-verify/dominant-color.mjs
+++ b/packages/app/scripts/mvp-visual-verify/dominant-color.mjs
@@ -82,7 +82,12 @@ export function quantizePalette(data, opts = {}) {
 export async function dominantColorsFromPng(pngPath, opts = {}) {
   const maxEdge = opts.maxEdge ?? 256;
   const { data, info } = await sharp(pngPath)
-    .resize({ width: maxEdge, height: maxEdge, fit: "inside", withoutEnlargement: true })
+    .resize({
+      width: maxEdge,
+      height: maxEdge,
+      fit: "inside",
+      withoutEnlargement: true,
+    })
     .ensureAlpha()
     .raw()
     .toBuffer({ resolveWithObject: true });

--- a/packages/app/scripts/mvp-visual-verify/expectation-eval.mjs
+++ b/packages/app/scripts/mvp-visual-verify/expectation-eval.mjs
@@ -8,9 +8,10 @@
  * post-processor gathers the inputs and this decides, so the acceptance logic is
  * unit-tested against fixtures.
  *
- * Design choices that keep it honest: a check whose input is genuinely
- * unavailable (OCR engine absent, report lacks the overflow field) resolves to
- * `skip`, never a silent `pass` — an unknown must not read as green. The no-blue
+ * Design choices that keep it honest: a required OCR readout fails when the
+ * engine is unavailable because text verification is part of the MVP acceptance
+ * signal. Report-derived layout fields may still resolve to `skip` when an old
+ * audit report lacks the field; strict mode rejects those skips. The no-blue
  * signal prefers the audit's DOM-computed `blueColors[]` (authoritative) and
  * treats palette-derived blue as a secondary floor, because photographic or
  * gradient content can carry stray blue pixels the brand rule does not target.
@@ -67,8 +68,8 @@ export function evaluateExpectations(state, spec) {
     if (!state.ocr || state.ocr.available === false) {
       checks.push({
         name: "ocr-text",
-        status: "skip",
-        detail: "OCR unavailable (tesseract not found)",
+        status: "fail",
+        detail: `OCR unavailable: ${state.ocr?.reason ?? "engine not configured"}`,
       });
     } else {
       const haystack = normalize(state.ocr.text ?? "");

--- a/packages/app/scripts/mvp-visual-verify/expectation-eval.mjs
+++ b/packages/app/scripts/mvp-visual-verify/expectation-eval.mjs
@@ -1,0 +1,208 @@
+/**
+ * Declarative per-state expectation evaluator for mvp-visual-verify.
+ *
+ * A pure function: given a captured state's OCR text, dominant-color palette, and
+ * the matching audit `report.json` finding, plus a declarative spec (expected OCR
+ * substrings present/absent, brand-orange accent present, no blue, no horizontal
+ * overflow), it returns a pass/fail verdict with per-check reasons. No I/O — the
+ * post-processor gathers the inputs and this decides, so the acceptance logic is
+ * unit-tested against fixtures.
+ *
+ * Design choices that keep it honest: a check whose input is genuinely
+ * unavailable (OCR engine absent, report lacks the overflow field) resolves to
+ * `skip`, never a silent `pass` — an unknown must not read as green. The no-blue
+ * signal prefers the audit's DOM-computed `blueColors[]` (authoritative) and
+ * treats palette-derived blue as a secondary floor, because photographic or
+ * gradient content can carry stray blue pixels the brand rule does not target.
+ */
+
+/** Coverage fraction of the palette's blue bucket above which blue is flagged. */
+export const DEFAULT_BLUE_COVERAGE_LIMIT = 0.05;
+/** Palette orange coverage at/above which the brand accent counts as present. */
+export const DEFAULT_ORANGE_COVERAGE_MIN = 0.0005;
+/** scrollWidth − innerWidth (px) tolerated before horizontal overflow fails. */
+export const DEFAULT_OVERFLOW_TOLERANCE_PX = 2;
+
+/**
+ * @typedef {object} OcrSpec
+ * @property {string[]} [present] substrings that must appear (whitespace-normalized)
+ * @property {string[]} [absent]  junk tokens that must NOT appear (whole-word)
+ * @property {Record<string, { present?: string[], absent?: string[] }>} [perViewport]
+ *   per-viewport overrides — text chrome differs between desktop and mobile
+ *   layouts, so `present` labels are usually viewport-specific.
+ */
+
+/**
+ * @typedef {object} ExpectationSpec
+ * @property {OcrSpec} [ocr]
+ * @property {boolean} [accentOrange]  require brand-orange coverage in the palette
+ * @property {boolean} [noBlue]        forbid blue (DOM + palette)
+ * @property {boolean} [noHorizontalOverflow] forbid scrollWidth > innerWidth
+ * @property {number}  [blueCoverageLimit]
+ * @property {number}  [orangeCoverageMin]
+ * @property {number}  [overflowTolerancePx]
+ */
+
+/**
+ * @typedef {object} StateInput
+ * @property {string} [viewport] viewport name — selects per-viewport OCR overrides
+ * @property {{ available: boolean, text?: string }} ocr
+ * @property {{ buckets?: Record<string, number>, swatches?: Array<{ bucket: string }> }} palette
+ * @property {{ blueColors?: string[], consoleErrors?: string[], horizontalOverflowPx?: number } | null} finding
+ */
+
+/**
+ * Evaluate one captured state against its spec.
+ * @param {StateInput} state
+ * @param {ExpectationSpec} spec
+ * @returns {{ pass: boolean, checks: Array<{ name: string, status: "pass"|"fail"|"skip", detail: string }>, reasons: string[] }}
+ */
+export function evaluateExpectations(state, spec) {
+  const checks = [];
+
+  const vpOverride = spec.ocr?.perViewport?.[state.viewport ?? ""] ?? {};
+  const present = [...(spec.ocr?.present ?? []), ...(vpOverride.present ?? [])];
+  const absent = [...(spec.ocr?.absent ?? []), ...(vpOverride.absent ?? [])];
+  if (present.length || absent.length) {
+    if (!state.ocr || state.ocr.available === false) {
+      checks.push({
+        name: "ocr-text",
+        status: "skip",
+        detail: "OCR unavailable (tesseract not found)",
+      });
+    } else {
+      const haystack = normalize(state.ocr.text ?? "");
+      const missing = present.filter((s) => !haystack.includes(normalize(s)));
+      // Whole-word match for junk tokens: a substring "nan" inside "finances"
+      // is not a NaN render bug, so alphanumeric tokens are boundary-matched.
+      const forbidden = absent.filter((s) => containsForbidden(haystack, s));
+      if (missing.length === 0 && forbidden.length === 0) {
+        checks.push({ name: "ocr-text", status: "pass", detail: "expected text matched" });
+      } else {
+        const parts = [];
+        if (missing.length) parts.push(`missing: ${missing.join(", ")}`);
+        if (forbidden.length) parts.push(`forbidden present: ${forbidden.join(", ")}`);
+        checks.push({ name: "ocr-text", status: "fail", detail: parts.join("; ") });
+      }
+    }
+  }
+
+  if (spec.noBlue) {
+    const domBlue = state.finding?.blueColors ?? null;
+    const paletteBlue = state.palette?.buckets?.blue ?? 0;
+    const limit = spec.blueCoverageLimit ?? DEFAULT_BLUE_COVERAGE_LIMIT;
+    if (domBlue && domBlue.length > 0) {
+      checks.push({
+        name: "no-blue",
+        status: "fail",
+        detail: `DOM blue colors: ${domBlue.slice(0, 4).join(", ")}`,
+      });
+    } else if (paletteBlue > limit) {
+      checks.push({
+        name: "no-blue",
+        status: "fail",
+        detail: `palette blue coverage ${(paletteBlue * 100).toFixed(1)}% > ${(limit * 100).toFixed(1)}%`,
+      });
+    } else {
+      checks.push({
+        name: "no-blue",
+        status: "pass",
+        detail: domBlue ? "no DOM blue, palette clean" : "palette blue within limit",
+      });
+    }
+  }
+
+  if (spec.accentOrange) {
+    const orange = state.palette?.buckets?.orange ?? 0;
+    const min = spec.orangeCoverageMin ?? DEFAULT_ORANGE_COVERAGE_MIN;
+    const swatchOrange = (state.palette?.swatches ?? []).some((s) => s.bucket === "orange");
+    if (orange >= min || swatchOrange) {
+      checks.push({
+        name: "accent-orange",
+        status: "pass",
+        detail: `orange coverage ${(orange * 100).toFixed(2)}%`,
+      });
+    } else {
+      checks.push({
+        name: "accent-orange",
+        status: "fail",
+        detail: `brand orange not detected (coverage ${(orange * 100).toFixed(2)}%)`,
+      });
+    }
+  }
+
+  if (spec.noHorizontalOverflow) {
+    const px = state.finding?.horizontalOverflowPx;
+    const tol = spec.overflowTolerancePx ?? DEFAULT_OVERFLOW_TOLERANCE_PX;
+    if (px === undefined || px === null) {
+      checks.push({
+        name: "no-horizontal-overflow",
+        status: "skip",
+        detail: "report has no horizontalOverflowPx field (re-run audit to populate)",
+      });
+    } else if (px > tol) {
+      checks.push({
+        name: "no-horizontal-overflow",
+        status: "fail",
+        detail: `horizontal overflow ${px}px (scrollWidth exceeds innerWidth; tolerance ${tol}px)`,
+      });
+    } else {
+      checks.push({
+        name: "no-horizontal-overflow",
+        status: "pass",
+        detail: `overflow ${px}px within ${tol}px`,
+      });
+    }
+  }
+
+  const reasons = checks.filter((c) => c.status === "fail").map((c) => `${c.name}: ${c.detail}`);
+  return { pass: reasons.length === 0, checks, reasons };
+}
+
+/**
+ * Resolve the spec for a slug: the per-slug entry shallow-merged onto the
+ * `__default__` entry (per-slug wins). The default carries the universal
+ * invariants so every state is checked even without an explicit entry.
+ * @param {Record<string, ExpectationSpec>} specs
+ * @param {string} slug
+ * @returns {ExpectationSpec}
+ */
+export function resolveSpec(specs, slug) {
+  const base = specs.__default__ ?? {};
+  const own = specs[slug] ?? {};
+  return {
+    ...base,
+    ...own,
+    ocr: mergeOcr(base.ocr, own.ocr),
+  };
+}
+
+function mergeOcr(base, own) {
+  if (!base && !own) return undefined;
+  return {
+    present: [...(base?.present ?? []), ...(own?.present ?? [])],
+    absent: [...(base?.absent ?? []), ...(own?.absent ?? [])],
+    // Own perViewport wins per key; the default rarely sets it.
+    perViewport: { ...(base?.perViewport ?? {}), ...(own?.perViewport ?? {}) },
+  };
+}
+
+function normalize(s) {
+  return String(s).toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Whether a forbidden junk token appears in the OCR haystack. Alphanumeric-only
+ * tokens (nan, undefined) are matched at word boundaries so they don't fire
+ * inside legitimate words (e.g. "nan" in "finances"); tokens carrying
+ * punctuation ("[object Object]") never occur in real words, so a plain
+ * substring test is both sufficient and correct for them.
+ */
+function containsForbidden(haystack, token) {
+  const needle = normalize(token);
+  if (!needle) return false;
+  if (/^[a-z0-9]+$/.test(needle)) {
+    return new RegExp(`(^|[^a-z0-9])${needle}([^a-z0-9]|$)`, "i").test(haystack);
+  }
+  return haystack.includes(needle);
+}

--- a/packages/app/scripts/mvp-visual-verify/expectation-eval.mjs
+++ b/packages/app/scripts/mvp-visual-verify/expectation-eval.mjs
@@ -77,12 +77,21 @@ export function evaluateExpectations(state, spec) {
       // is not a NaN render bug, so alphanumeric tokens are boundary-matched.
       const forbidden = absent.filter((s) => containsForbidden(haystack, s));
       if (missing.length === 0 && forbidden.length === 0) {
-        checks.push({ name: "ocr-text", status: "pass", detail: "expected text matched" });
+        checks.push({
+          name: "ocr-text",
+          status: "pass",
+          detail: "expected text matched",
+        });
       } else {
         const parts = [];
         if (missing.length) parts.push(`missing: ${missing.join(", ")}`);
-        if (forbidden.length) parts.push(`forbidden present: ${forbidden.join(", ")}`);
-        checks.push({ name: "ocr-text", status: "fail", detail: parts.join("; ") });
+        if (forbidden.length)
+          parts.push(`forbidden present: ${forbidden.join(", ")}`);
+        checks.push({
+          name: "ocr-text",
+          status: "fail",
+          detail: parts.join("; "),
+        });
       }
     }
   }
@@ -107,7 +116,9 @@ export function evaluateExpectations(state, spec) {
       checks.push({
         name: "no-blue",
         status: "pass",
-        detail: domBlue ? "no DOM blue, palette clean" : "palette blue within limit",
+        detail: domBlue
+          ? "no DOM blue, palette clean"
+          : "palette blue within limit",
       });
     }
   }
@@ -115,7 +126,9 @@ export function evaluateExpectations(state, spec) {
   if (spec.accentOrange) {
     const orange = state.palette?.buckets?.orange ?? 0;
     const min = spec.orangeCoverageMin ?? DEFAULT_ORANGE_COVERAGE_MIN;
-    const swatchOrange = (state.palette?.swatches ?? []).some((s) => s.bucket === "orange");
+    const swatchOrange = (state.palette?.swatches ?? []).some(
+      (s) => s.bucket === "orange",
+    );
     if (orange >= min || swatchOrange) {
       checks.push({
         name: "accent-orange",
@@ -138,7 +151,8 @@ export function evaluateExpectations(state, spec) {
       checks.push({
         name: "no-horizontal-overflow",
         status: "skip",
-        detail: "report has no horizontalOverflowPx field (re-run audit to populate)",
+        detail:
+          "report has no horizontalOverflowPx field (re-run audit to populate)",
       });
     } else if (px > tol) {
       checks.push({
@@ -155,7 +169,9 @@ export function evaluateExpectations(state, spec) {
     }
   }
 
-  const reasons = checks.filter((c) => c.status === "fail").map((c) => `${c.name}: ${c.detail}`);
+  const reasons = checks
+    .filter((c) => c.status === "fail")
+    .map((c) => `${c.name}: ${c.detail}`);
   return { pass: reasons.length === 0, checks, reasons };
 }
 
@@ -202,7 +218,9 @@ function containsForbidden(haystack, token) {
   const needle = normalize(token);
   if (!needle) return false;
   if (/^[a-z0-9]+$/.test(needle)) {
-    return new RegExp(`(^|[^a-z0-9])${needle}([^a-z0-9]|$)`, "i").test(haystack);
+    return new RegExp(`(^|[^a-z0-9])${needle}([^a-z0-9]|$)`, "i").test(
+      haystack,
+    );
   }
   return haystack.includes(needle);
 }

--- a/packages/app/scripts/mvp-visual-verify/expectations.json
+++ b/packages/app/scripts/mvp-visual-verify/expectations.json
@@ -1,0 +1,41 @@
+{
+  "__comment": "Declarative per-slug visual expectations for mvp-visual-verify. Keys are audit slugs (builtin-<tab> / plugin-<id>-<viewType>); '__default__' carries the universal invariants applied to every state. OCR 'present' substrings are calibrated against real tesseract output; because text chrome differs between desktop and mobile layouts, viewport-specific labels live under ocr.perViewport.<viewport>. The absent[] junk tokens catch render bugs on every viewport (whole-word matched, so 'nan' inside 'finances' does not false-fire). Unlisted slugs inherit only the default.",
+  "__default__": {
+    "noBlue": true,
+    "noHorizontalOverflow": true,
+    "ocr": { "absent": ["undefined", "NaN", "[object Object]", "objectobject"] }
+  },
+  "builtin-settings": {
+    "accentOrange": true,
+    "ocr": {
+      "perViewport": {
+        "desktop": { "present": ["Models", "Voice"] },
+        "desktop-landscape": { "present": ["Models", "Voice"] }
+      }
+    }
+  },
+  "builtin-character": {
+    "accentOrange": true,
+    "ocr": {
+      "perViewport": {
+        "desktop": { "present": ["Personality", "Knowledge"] },
+        "desktop-landscape": { "present": ["Personality", "Knowledge"] },
+        "mobile-portrait": { "present": ["Character", "About Me"] }
+      }
+    }
+  },
+  "builtin-automations": {
+    "accentOrange": true,
+    "ocr": {
+      "present": ["Automations"],
+      "perViewport": {
+        "desktop": { "present": ["Tasks", "Workflows"] },
+        "desktop-landscape": { "present": ["Tasks", "Workflows"] },
+        "mobile-portrait": { "present": ["Workflows"] }
+      }
+    }
+  },
+  "builtin-chat": {
+    "accentOrange": true
+  }
+}

--- a/packages/app/scripts/mvp-visual-verify/ocr.mjs
+++ b/packages/app/scripts/mvp-visual-verify/ocr.mjs
@@ -1,0 +1,113 @@
+/**
+ * On-screen text readout for captured audit screenshots via the system
+ * `tesseract` binary.
+ *
+ * There is no bundled OCR engine; `tesseract.js` is only in the repo's native-
+ * build allowlist, not an installed dependency. So this shells out to the
+ * homebrew/apt `tesseract` binary when present and degrades HONESTLY to a
+ * `{ available: false }` result when it is not — the caller renders that column
+ * as an explicit "N/A (tesseract not found)" rather than fabricating text. Never
+ * larp OCR: a missing engine is reported, not filled in.
+ *
+ * The binary probe is memoized because a run OCRs ~100 screenshots and `which`
+ * on every call is wasteful.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+
+/** @type {{ path: string | null } | null} */
+let probe = null;
+
+/**
+ * Resolve the `tesseract` binary path once per process. Uses `which` (POSIX) —
+ * the audit lanes that run this are macOS/Linux.
+ * @returns {string | null} absolute path, or null when tesseract is absent.
+ */
+export function resolveTesseract() {
+  if (probe) return probe.path;
+  const envPath = process.env.ELIZA_TESSERACT_BIN;
+  if (envPath) {
+    probe = { path: envPath };
+    return envPath;
+  }
+  const which = spawnSync(process.platform === "win32" ? "where" : "which", [
+    "tesseract",
+  ]);
+  const out = which.status === 0 ? which.stdout.toString().trim().split(/\r?\n/)[0] : "";
+  probe = { path: out || null };
+  return probe.path;
+}
+
+/** Test seam: reset the memoized probe so a test can force re-resolution. */
+export function resetTesseractProbe() {
+  probe = null;
+}
+
+/**
+ * OCR a single PNG. Returns the recognized text plus a `words` count and the
+ * engine label, or an honest unavailable result when tesseract is missing.
+ *
+ * @param {string} pngPath
+ * @param {{ lang?: string, timeoutMs?: number }} [opts]
+ * @returns {Promise<{ available: true, text: string, words: number, chars: number, engine: string } | { available: false, reason: string }>}
+ */
+export async function ocrImage(pngPath, opts = {}) {
+  const bin = resolveTesseract();
+  if (!bin) {
+    return { available: false, reason: "tesseract binary not found" };
+  }
+  const lang = opts.lang ?? "eng";
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+  const text = await runTesseract(bin, pngPath, lang, timeoutMs);
+  const normalized = text.replace(/\r/g, "").replace(/[ \t]+/g, " ").trim();
+  const words = normalized ? normalized.split(/\s+/).filter(Boolean).length : 0;
+  return {
+    available: true,
+    text: normalized,
+    words,
+    chars: normalized.replace(/\s+/g, "").length,
+    engine: `tesseract (${bin})`,
+  };
+}
+
+/**
+ * `tesseract <img> stdout -l <lang>` → recognized text on stdout. Rejects on
+ * spawn error, non-zero exit, or timeout — a failed OCR is surfaced, not turned
+ * into empty text (empty text is a legitimate "no readable glyphs" result and
+ * must stay distinguishable from a crashed engine).
+ */
+function runTesseract(bin, pngPath, lang, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, [pngPath, "stdout", "-l", lang], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`tesseract timed out after ${timeoutMs}ms on ${pngPath}`));
+    }, timeoutMs);
+    child.stdout.on("data", (d) => {
+      stdout += d.toString();
+    });
+    child.stderr.on("data", (d) => {
+      stderr += d.toString();
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(
+          new Error(
+            `tesseract exited ${code} on ${pngPath}: ${stderr.trim().slice(0, 200)}`,
+          ),
+        );
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}

--- a/packages/app/scripts/mvp-visual-verify/ocr.mjs
+++ b/packages/app/scripts/mvp-visual-verify/ocr.mjs
@@ -33,7 +33,8 @@ export function resolveTesseract() {
   const which = spawnSync(process.platform === "win32" ? "where" : "which", [
     "tesseract",
   ]);
-  const out = which.status === 0 ? which.stdout.toString().trim().split(/\r?\n/)[0] : "";
+  const out =
+    which.status === 0 ? which.stdout.toString().trim().split(/\r?\n/)[0] : "";
   probe = { path: out || null };
   return probe.path;
 }
@@ -59,7 +60,10 @@ export async function ocrImage(pngPath, opts = {}) {
   const lang = opts.lang ?? "eng";
   const timeoutMs = opts.timeoutMs ?? 30_000;
   const text = await runTesseract(bin, pngPath, lang, timeoutMs);
-  const normalized = text.replace(/\r/g, "").replace(/[ \t]+/g, " ").trim();
+  const normalized = text
+    .replace(/\r/g, "")
+    .replace(/[ \t]+/g, " ")
+    .trim();
   const words = normalized ? normalized.split(/\s+/).filter(Boolean).length : 0;
   return {
     available: true,
@@ -85,7 +89,9 @@ function runTesseract(bin, pngPath, lang, timeoutMs) {
     let stderr = "";
     const timer = setTimeout(() => {
       child.kill("SIGKILL");
-      reject(new Error(`tesseract timed out after ${timeoutMs}ms on ${pngPath}`));
+      reject(
+        new Error(`tesseract timed out after ${timeoutMs}ms on ${pngPath}`),
+      );
     }, timeoutMs);
     child.stdout.on("data", (d) => {
       stdout += d.toString();

--- a/packages/app/scripts/mvp-visual-verify/ocr.mjs
+++ b/packages/app/scripts/mvp-visual-verify/ocr.mjs
@@ -1,22 +1,26 @@
 /**
- * On-screen text readout for captured audit screenshots via the system
- * `tesseract` binary.
+ * On-screen text readout for captured audit screenshots.
  *
- * There is no bundled OCR engine; `tesseract.js` is only in the repo's native-
- * build allowlist, not an installed dependency. So this shells out to the
- * homebrew/apt `tesseract` binary when present and degrades HONESTLY to a
- * `{ available: false }` result when it is not — the caller renders that column
- * as an explicit "N/A (tesseract not found)" rather than fabricating text. Never
- * larp OCR: a missing engine is reported, not filled in.
+ * The verifier prefers the packaged `tesseract.js` dependency so CI and local
+ * evidence capture do not depend on a developer's Homebrew/apt state. A system
+ * `tesseract` binary remains available as an explicit fallback for debugging.
+ * Missing or failed OCR returns `{ available: false }`; the expectation layer
+ * treats that as a failed text check, never a skip or fabricated empty string.
  *
- * The binary probe is memoized because a run OCRs ~100 screenshots and `which`
- * on every call is wasteful.
+ * Engine probes and packaged workers are memoized because a run OCRs ~100
+ * screenshots. Call `closeOcrEngines` at the end of a verifier run so the worker
+ * process does not keep Node alive.
  */
 
 import { spawn, spawnSync } from "node:child_process";
 
 /** @type {{ path: string | null } | null} */
 let probe = null;
+/** @type {Promise<any> | null} */
+let packagedProbe = null;
+/** @type {Map<string, Promise<any>>} */
+let packagedWorkers = new Map();
+const TESSERACT_JS_PACKAGE = "tesseract.js";
 
 /**
  * Resolve the `tesseract` binary path once per process. Uses `which` (POSIX) —
@@ -39,27 +43,89 @@ export function resolveTesseract() {
   return probe.path;
 }
 
+/**
+ * Resolve the OCR engine the verifier will use. Packaged OCR is the default;
+ * set `ELIZA_MVP_OCR_ENGINE=system` to force a local binary, or `packaged` to
+ * fail closed when the dependency is not installed.
+ *
+ * @returns {Promise<{ available: true, kind: "packaged"|"system", label: string, bin?: string } | { available: false, reason: string }>}
+ */
+export async function resolveOcrEngine() {
+  const forced = process.env.ELIZA_MVP_OCR_ENGINE;
+  if (forced !== "system") {
+    const packaged = await loadPackagedTesseract();
+    if (packaged?.createWorker) {
+      return {
+        available: true,
+        kind: "packaged",
+        label: "tesseract.js package",
+      };
+    }
+    if (forced === "packaged") {
+      return {
+        available: false,
+        reason:
+          "tesseract.js package is unavailable; run `bun install` so packages/app installs its OCR dependency",
+      };
+    }
+  }
+
+  const bin = resolveTesseract();
+  if (bin) {
+    return {
+      available: true,
+      kind: "system",
+      label: `system tesseract (${bin})`,
+      bin,
+    };
+  }
+  return {
+    available: false,
+    reason:
+      "no OCR engine available; run `bun install` for packaged tesseract.js or set ELIZA_TESSERACT_BIN",
+  };
+}
+
 /** Test seam: reset the memoized probe so a test can force re-resolution. */
 export function resetTesseractProbe() {
   probe = null;
+  packagedProbe = null;
+  packagedWorkers = new Map();
 }
 
 /**
  * OCR a single PNG. Returns the recognized text plus a `words` count and the
- * engine label, or an honest unavailable result when tesseract is missing.
+ * engine label, or an honest unavailable result when tesseract is missing/fails.
  *
  * @param {string} pngPath
  * @param {{ lang?: string, timeoutMs?: number }} [opts]
  * @returns {Promise<{ available: true, text: string, words: number, chars: number, engine: string } | { available: false, reason: string }>}
  */
 export async function ocrImage(pngPath, opts = {}) {
-  const bin = resolveTesseract();
-  if (!bin) {
-    return { available: false, reason: "tesseract binary not found" };
+  const engine = await resolveOcrEngine();
+  if (!engine.available) {
+    return { available: false, reason: engine.reason };
   }
   const lang = opts.lang ?? "eng";
   const timeoutMs = opts.timeoutMs ?? 30_000;
-  const text = await runTesseract(bin, pngPath, lang, timeoutMs);
+  const text =
+    engine.kind === "packaged"
+      ? await runPackagedTesseract(pngPath, lang, timeoutMs).catch((err) => {
+          const detail = err instanceof Error ? err.message : String(err);
+          return { error: detail };
+        })
+      : await runSystemTesseract(engine.bin, pngPath, lang, timeoutMs).catch(
+          (err) => {
+            const detail = err instanceof Error ? err.message : String(err);
+            return { error: detail };
+          },
+        );
+  if (typeof text !== "string") {
+    return {
+      available: false,
+      reason: `${engine.label} failed: ${text.error.slice(0, 200)}`,
+    };
+  }
   const normalized = text
     .replace(/\r/g, "")
     .replace(/[ \t]+/g, " ")
@@ -70,8 +136,53 @@ export async function ocrImage(pngPath, opts = {}) {
     text: normalized,
     words,
     chars: normalized.replace(/\s+/g, "").length,
-    engine: `tesseract (${bin})`,
+    engine: engine.label,
   };
+}
+
+/** Terminate packaged OCR workers after a verifier run. */
+export async function closeOcrEngines() {
+  const workers = [...packagedWorkers.values()];
+  packagedWorkers = new Map();
+  for (const workerPromise of workers) {
+    const worker = await workerPromise;
+    await worker.terminate();
+  }
+}
+
+async function loadPackagedTesseract() {
+  if (!packagedProbe) {
+    packagedProbe = import(TESSERACT_JS_PACKAGE).catch(() => null);
+  }
+  return packagedProbe;
+}
+
+async function runPackagedTesseract(pngPath, lang, timeoutMs) {
+  const worker = await getPackagedWorker(lang, timeoutMs);
+  const result = await withTimeout(
+    worker.recognize(pngPath),
+    timeoutMs,
+    `tesseract.js timed out after ${timeoutMs}ms on ${pngPath}`,
+  );
+  return result?.data?.text ?? "";
+}
+
+async function getPackagedWorker(lang, timeoutMs) {
+  const existing = packagedWorkers.get(lang);
+  if (existing) return existing;
+  const workerPromise = (async () => {
+    const tesseract = await loadPackagedTesseract();
+    if (!tesseract?.createWorker) {
+      throw new Error("tesseract.js createWorker export is unavailable");
+    }
+    return withTimeout(
+      tesseract.createWorker(lang),
+      timeoutMs,
+      `tesseract.js worker initialization timed out after ${timeoutMs}ms`,
+    );
+  })();
+  packagedWorkers.set(lang, workerPromise);
+  return workerPromise;
 }
 
 /**
@@ -80,7 +191,7 @@ export async function ocrImage(pngPath, opts = {}) {
  * into empty text (empty text is a legitimate "no readable glyphs" result and
  * must stay distinguishable from a crashed engine).
  */
-function runTesseract(bin, pngPath, lang, timeoutMs) {
+function runSystemTesseract(bin, pngPath, lang, timeoutMs) {
   return new Promise((resolve, reject) => {
     const child = spawn(bin, [pngPath, "stdout", "-l", lang], {
       stdio: ["ignore", "pipe", "pipe"],
@@ -116,4 +227,12 @@ function runTesseract(bin, pngPath, lang, timeoutMs) {
       resolve(stdout);
     });
   });
+}
+
+function withTimeout(promise, timeoutMs, message) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }

--- a/packages/app/scripts/mvp-visual-verify/overflow-invariant-demo.mjs
+++ b/packages/app/scripts/mvp-visual-verify/overflow-invariant-demo.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Live demonstration that the horizontal-overflow invariant catches the WS5
+ * transcript bug in a REAL browser — not a mock.
+ *
+ * It renders two fixtures in headless chromium at a phone viewport: a BUGGY chat
+ * transcript whose long unbreakable token is NOT contained (no overflow-x:hidden
+ * on the transcript, no wrap on the bubble), so the child pushes the document
+ * wider than the viewport — the user-visible horizontal-scrollbar symptom — and
+ * the FIXED version (`overflow-x:hidden` + `overflow-wrap:anywhere`). It measures
+ * each with the exact probe the audit spec records into report.json and asserts
+ * the invariant fires on the bug and passes on the fix. Exit 0 only when the
+ * invariant correctly distinguishes them, so this doubles as a self-test of the
+ * capture-side gate.
+ *
+ * Note the CSS subtlety this fixture is built around: setting `overflow-y:auto`
+ * alone auto-promotes `overflow-x` to `auto` (CSS Overflow 3 §3), which would
+ * self-contain the token inside the scroller and hide the bug. The real
+ * document-level leak — what a user actually sees — comes from an un-contained
+ * wide descendant, which is what BUGGY reproduces.
+ *
+ * Run: node scripts/mvp-visual-verify/overflow-invariant-demo.mjs
+ */
+
+import { chromium } from "playwright";
+
+const TOLERANCE_PX = 2;
+const VIEWPORT = { width: 390, height: 844 };
+const LONG_TOKEN =
+  "https://example.com/a/really/long/unbreakable/path/token/" + "x".repeat(400);
+
+const SHELL = (
+  transcriptCss,
+  bubbleCss,
+) => `<!doctype html><html><head><meta charset="utf-8">
+<style>
+  * { margin: 0; box-sizing: border-box; }
+  body { font: 14px system-ui; }
+  .app { width: 100vw; height: 100vh; display: flex; flex-direction: column; }
+  .transcript { flex: 1; padding: 12px; ${transcriptCss} }
+  .bubble { background: #f0ece5; border-radius: 12px; padding: 10px 14px; margin: 8px 0; ${bubbleCss} }
+</style></head><body>
+  <div class="app"><div class="transcript">
+    <div class="bubble">short message</div>
+    <div class="bubble long">${LONG_TOKEN}</div>
+    <div class="bubble">another short one</div>
+  </div></div>
+</body></html>`;
+
+// BUGGY: the long token is un-contained — the transcript has no horizontal
+// containment and the bubble does not wrap, so the token pushes the whole
+// document wider than the viewport. FIXED: the vertical scroller adds
+// overflow-x:hidden (the WS5 remedy) and the bubble wraps long tokens.
+const BUGGY = SHELL("", "white-space: nowrap;");
+const FIXED = SHELL(
+  "overflow-y: auto; overflow-x: hidden;",
+  "overflow-wrap: anywhere;",
+);
+
+/** The exact probe recorded into report.json by all-views-aesthetic-audit.spec.ts. */
+function overflowProbe() {
+  const de = document.documentElement;
+  const scrollWidth = Math.max(de.scrollWidth, document.body?.scrollWidth ?? 0);
+  const innerWidth = window.innerWidth || de.clientWidth;
+  return Math.max(0, Math.round(scrollWidth - innerWidth));
+}
+
+async function measure(page, html) {
+  await page.setContent(html, { waitUntil: "load" });
+  return page.evaluate(overflowProbe);
+}
+
+async function main() {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: VIEWPORT });
+  const buggyPx = await measure(page, BUGGY);
+  const fixedPx = await measure(page, FIXED);
+  await browser.close();
+
+  const caught = buggyPx > TOLERANCE_PX;
+  const fixedOk = fixedPx <= TOLERANCE_PX;
+  process.stdout.write(
+    `[overflow-demo] viewport ${VIEWPORT.width}x${VIEWPORT.height}, tolerance ${TOLERANCE_PX}px\n` +
+      `[overflow-demo] BUGGY (un-contained token):     ${buggyPx}px  -> ${caught ? "INVARIANT FIRES ✓" : "missed ✗"}\n` +
+      `[overflow-demo] FIXED (overflow-x:hidden+wrap): ${fixedPx}px  -> ${fixedOk ? "passes ✓" : "false-fires ✗"}\n`,
+  );
+  if (caught && fixedOk) {
+    process.stdout.write(
+      "[overflow-demo] PASS — the invariant catches the regression and clears the fix\n",
+    );
+    return 0;
+  }
+  process.stdout.write(
+    "[overflow-demo] FAIL — invariant did not distinguish bug from fix\n",
+  );
+  return 1;
+}
+
+main().then(
+  (c) => process.exit(c),
+  (e) => {
+    process.stderr.write(`[overflow-demo] error: ${e?.stack || e}\n`);
+    process.exit(2);
+  },
+);

--- a/packages/app/test/audit/mvp-visual-verify.test.ts
+++ b/packages/app/test/audit/mvp-visual-verify.test.ts
@@ -5,22 +5,27 @@
  * pixel-diff summarizer/comparator, and the declarative expectation evaluator.
  * All deterministic — no image decode, no tesseract, no browser.
  */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import sharp from "sharp";
 import { describe, expect, it } from "vitest";
-import { bucket as auditBucket } from "../ui-smoke/aesthetic-audit-rules";
 import {
   bucket,
   bucketRgb,
   parseRgb,
 } from "../../scripts/mvp-visual-verify/color-bucket.mjs";
-import { quantizePalette } from "../../scripts/mvp-visual-verify/dominant-color.mjs";
 import {
   comparePixels,
   summarizeDiff,
 } from "../../scripts/mvp-visual-verify/diff.mjs";
+import { quantizePalette } from "../../scripts/mvp-visual-verify/dominant-color.mjs";
 import {
   evaluateExpectations,
   resolveSpec,
 } from "../../scripts/mvp-visual-verify/expectation-eval.mjs";
+import { bucket as auditBucket } from "../ui-smoke/aesthetic-audit-rules";
 
 describe("color-bucket", () => {
   it("parses rgb and rgba", () => {
@@ -46,8 +51,14 @@ describe("color-bucket", () => {
     const samples: string[] = [];
     for (let r = 0; r <= 255; r += 51)
       for (let g = 0; g <= 255; g += 51)
-        for (let b = 0; b <= 255; b += 51) samples.push(`rgb(${r}, ${g}, ${b})`);
-    samples.push("rgba(255,88,0,1)", "rgba(10,10,40,1)", "rgba(10,10,12,0.5)", "rgba(0,0,0,0)");
+        for (let b = 0; b <= 255; b += 51)
+          samples.push(`rgb(${r}, ${g}, ${b})`);
+    samples.push(
+      "rgba(255,88,0,1)",
+      "rgba(10,10,40,1)",
+      "rgba(10,10,12,0.5)",
+      "rgba(0,0,0,0)",
+    );
     for (const s of samples) expect(bucket(s), s).toBe(auditBucket(s));
   });
 
@@ -60,7 +71,11 @@ describe("color-bucket", () => {
 
 describe("quantizePalette", () => {
   /** Build a WxH RGBA buffer from a flat [r,g,b,a] fill or a per-pixel fn. */
-  function makeBuffer(w: number, h: number, fill: (i: number) => [number, number, number, number]) {
+  function makeBuffer(
+    w: number,
+    h: number,
+    fill: (i: number) => [number, number, number, number],
+  ) {
     const buf = Buffer.alloc(w * h * 4);
     for (let p = 0; p < w * h; p += 1) {
       const [r, g, b, a] = fill(p);
@@ -74,8 +89,13 @@ describe("quantizePalette", () => {
 
   it("ranks dominant colors by coverage and labels buckets", () => {
     // 75% orange, 25% blue.
-    const buf = makeBuffer(4, 4, (i) => (i < 12 ? [255, 88, 0, 255] : [10, 10, 200, 255]));
-    const { swatches, buckets, totalOpaque } = quantizePalette(buf, { step: 16, topK: 4 });
+    const buf = makeBuffer(4, 4, (i) =>
+      i < 12 ? [255, 88, 0, 255] : [10, 10, 200, 255],
+    );
+    const { swatches, buckets, totalOpaque } = quantizePalette(buf, {
+      step: 16,
+      topK: 4,
+    });
     expect(totalOpaque).toBe(16);
     expect(swatches[0].bucket).toBe("orange");
     expect(swatches[0].ratio).toBeCloseTo(0.75, 5);
@@ -85,7 +105,9 @@ describe("quantizePalette", () => {
   });
 
   it("skips fully transparent pixels", () => {
-    const buf = makeBuffer(2, 2, (i) => (i === 0 ? [255, 88, 0, 255] : [0, 0, 0, 0]));
+    const buf = makeBuffer(2, 2, (i) =>
+      i === 0 ? [255, 88, 0, 255] : [0, 0, 0, 0],
+    );
     const { totalOpaque, swatches } = quantizePalette(buf);
     expect(totalOpaque).toBe(1);
     expect(swatches[0].ratio).toBe(1);
@@ -98,7 +120,11 @@ describe("quantizePalette", () => {
 
 describe("diff", () => {
   it("summarizeDiff computes percent + per-channel mean delta", () => {
-    const s = summarizeDiff({ changedPixels: 25, totalPixels: 100, sumAbsDelta: 3000 });
+    const s = summarizeDiff({
+      changedPixels: 25,
+      totalPixels: 100,
+      sumAbsDelta: 3000,
+    });
     expect(s.changedRatio).toBe(0.25);
     expect(s.changedPercent).toBe(25);
     expect(s.meanAbsDelta).toBe(10); // 3000 / (100*3)
@@ -106,7 +132,9 @@ describe("diff", () => {
   });
 
   it("summarizeDiff rejects a zero-pixel image (no false 0% pass)", () => {
-    expect(() => summarizeDiff({ changedPixels: 0, totalPixels: 0, sumAbsDelta: 0 })).toThrow();
+    expect(() =>
+      summarizeDiff({ changedPixels: 0, totalPixels: 0, sumAbsDelta: 0 }),
+    ).toThrow();
   });
 
   it("comparePixels counts pixels above the threshold and builds a highlight", () => {
@@ -114,10 +142,11 @@ describe("diff", () => {
     const h = 1;
     const a = Buffer.from([0, 0, 0, 255, 0, 0, 0, 255]);
     const b = Buffer.from([0, 0, 0, 255, 200, 0, 0, 255]); // pixel 1 differs by 200
-    const { changedPixels, totalPixels, sumAbsDelta, highlight } = comparePixels(a, b, w, h, {
-      threshold: 30,
-      buildHighlight: true,
-    });
+    const { changedPixels, totalPixels, sumAbsDelta, highlight } =
+      comparePixels(a, b, w, h, {
+        threshold: 30,
+        buildHighlight: true,
+      });
     expect(totalPixels).toBe(2);
     expect(changedPixels).toBe(1);
     expect(sumAbsDelta).toBe(200);
@@ -128,12 +157,17 @@ describe("diff", () => {
   });
 
   it("comparePixels throws when a buffer is too small", () => {
-    expect(() => comparePixels(Buffer.alloc(4), Buffer.alloc(2), 2, 1)).toThrow(/too small/);
+    expect(() => comparePixels(Buffer.alloc(4), Buffer.alloc(2), 2, 1)).toThrow(
+      /too small/,
+    );
   });
 });
 
 describe("expectation-eval", () => {
-  const palette = (buckets: Record<string, number>, swatches: { bucket: string }[] = []) => ({
+  const palette = (
+    buckets: Record<string, number>,
+    swatches: { bucket: string }[] = [],
+  ) => ({
     buckets,
     swatches,
   });
@@ -141,13 +175,21 @@ describe("expectation-eval", () => {
 
   it("no-blue fails on DOM blue, passes when clean", () => {
     const fail = evaluateExpectations(
-      { ocr: okOcr(""), palette: palette({ neutral: 1 }), finding: { blueColors: ["rgb(0,0,255)"] } },
+      {
+        ocr: okOcr(""),
+        palette: palette({ neutral: 1 }),
+        finding: { blueColors: ["rgb(0,0,255)"] },
+      },
       { noBlue: true },
     );
     expect(fail.pass).toBe(false);
     expect(fail.reasons[0]).toMatch(/no-blue/);
     const pass = evaluateExpectations(
-      { ocr: okOcr(""), palette: palette({ orange: 0.9 }), finding: { blueColors: [] } },
+      {
+        ocr: okOcr(""),
+        palette: palette({ orange: 0.9 }),
+        finding: { blueColors: [] },
+      },
       { noBlue: true },
     );
     expect(pass.pass).toBe(true);
@@ -155,7 +197,11 @@ describe("expectation-eval", () => {
 
   it("no-blue fails when palette blue coverage exceeds the limit", () => {
     const r = evaluateExpectations(
-      { ocr: okOcr(""), palette: palette({ blue: 0.2 }), finding: { blueColors: [] } },
+      {
+        ocr: okOcr(""),
+        palette: palette({ blue: 0.2 }),
+        finding: { blueColors: [] },
+      },
       { noBlue: true, blueCoverageLimit: 0.05 },
     );
     expect(r.pass).toBe(false);
@@ -183,14 +229,22 @@ describe("expectation-eval", () => {
     expect(skip.pass).toBe(true); // a skip is not a fail
 
     const fail = evaluateExpectations(
-      { ocr: okOcr(""), palette: palette({}), finding: { horizontalOverflowPx: 40 } },
+      {
+        ocr: okOcr(""),
+        palette: palette({}),
+        finding: { horizontalOverflowPx: 40 },
+      },
       { noHorizontalOverflow: true },
     );
     expect(fail.pass).toBe(false);
     expect(fail.reasons[0]).toMatch(/horizontal overflow 40px/);
 
     const pass = evaluateExpectations(
-      { ocr: okOcr(""), palette: palette({}), finding: { horizontalOverflowPx: 1 } },
+      {
+        ocr: okOcr(""),
+        palette: palette({}),
+        finding: { horizontalOverflowPx: 1 },
+      },
       { noHorizontalOverflow: true },
     );
     expect(pass.pass).toBe(true);
@@ -199,7 +253,11 @@ describe("expectation-eval", () => {
   it("OCR absent junk is whole-word: 'nan' inside 'finances' does not fire", () => {
     const spec = { ocr: { absent: ["NaN"] } };
     const clean = evaluateExpectations(
-      { ocr: okOcr("Finances Focus Goals"), palette: palette({}), finding: null },
+      {
+        ocr: okOcr("Finances Focus Goals"),
+        palette: palette({}),
+        finding: null,
+      },
       spec,
     );
     expect(clean.pass).toBe(true);
@@ -213,7 +271,11 @@ describe("expectation-eval", () => {
 
   it("OCR punctuation junk uses substring match", () => {
     const r = evaluateExpectations(
-      { ocr: okOcr("caption [object Object] tail"), palette: palette({}), finding: null },
+      {
+        ocr: okOcr("caption [object Object] tail"),
+        palette: palette({}),
+        finding: null,
+      },
       { ocr: { absent: ["[object Object]"] } },
     );
     expect(r.pass).toBe(false);
@@ -228,13 +290,23 @@ describe("expectation-eval", () => {
     };
     // Desktop requires both; mobile requires only the universal token.
     const desktopFail = evaluateExpectations(
-      { viewport: "desktop", ocr: okOcr("Automations Workflows"), palette: palette({}), finding: null },
+      {
+        viewport: "desktop",
+        ocr: okOcr("Automations Workflows"),
+        palette: palette({}),
+        finding: null,
+      },
       spec,
     );
     expect(desktopFail.pass).toBe(false);
     expect(desktopFail.reasons[0]).toMatch(/Tasks/);
     const mobilePass = evaluateExpectations(
-      { viewport: "mobile-portrait", ocr: okOcr("Automations Workflows"), palette: palette({}), finding: null },
+      {
+        viewport: "mobile-portrait",
+        ocr: okOcr("Automations Workflows"),
+        palette: palette({}),
+        finding: null,
+      },
       spec,
     );
     expect(mobilePass.pass).toBe(true);
@@ -242,7 +314,11 @@ describe("expectation-eval", () => {
 
   it("OCR check skips honestly when the engine is unavailable", () => {
     const r = evaluateExpectations(
-      { ocr: { available: false, reason: "tesseract not found" }, palette: palette({}), finding: null },
+      {
+        ocr: { available: false, reason: "tesseract not found" },
+        palette: palette({}),
+        finding: null,
+      },
       { ocr: { present: ["Anything"] } },
     );
     expect(r.checks[0].status).toBe("skip");
@@ -262,5 +338,53 @@ describe("expectation-eval", () => {
     // An unlisted slug still gets the universal invariants.
     const dflt = resolveSpec(specs, "builtin-unknown");
     expect(dflt.noBlue).toBe(true);
+  });
+});
+
+describe("mvp-visual-verify CLI", () => {
+  it("strict mode fails when the run has skipped checks or first-run baselines", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "eliza-mvp-visual-verify-"));
+    const viewportDir = path.join(dir, "mobile-portrait");
+    mkdirSync(viewportDir);
+    await sharp({
+      create: {
+        width: 2,
+        height: 2,
+        channels: 4,
+        background: { r: 255, g: 88, b: 0, alpha: 1 },
+      },
+    })
+      .png()
+      .toFile(path.join(viewportDir, "builtin-chat.png"));
+
+    let failed = false;
+    try {
+      execFileSync(
+        process.execPath,
+        [
+          path.resolve("scripts/mvp-visual-verify.mjs"),
+          "--input",
+          dir,
+          "--strict",
+        ],
+        {
+          cwd: path.resolve(__dirname, "../.."),
+          encoding: "utf8",
+          stdio: "pipe",
+        },
+      );
+    } catch (error) {
+      failed = true;
+      expect(error.status).toBe(1);
+      expect(String(error.stdout)).toContain("new baselines: 1");
+      expect(String(error.stdout)).toContain("skipped checks:");
+    }
+
+    expect(failed).toBe(true);
+    const report = JSON.parse(
+      readFileSync(path.join(dir, "mvp-verify", "report.json"), "utf8"),
+    );
+    expect(report.summary.newBaselines).toBe(1);
+    expect(report.summary.skippedChecks).toBeGreaterThan(0);
   });
 });

--- a/packages/app/test/audit/mvp-visual-verify.test.ts
+++ b/packages/app/test/audit/mvp-visual-verify.test.ts
@@ -121,8 +121,10 @@ describe("diff", () => {
     expect(totalPixels).toBe(2);
     expect(changedPixels).toBe(1);
     expect(sumAbsDelta).toBe(200);
+    expect(highlight).not.toBeNull();
     // Changed pixel is highlighted magenta.
-    expect([highlight![4], highlight![5], highlight![6]]).toEqual([255, 0, 255]);
+    const px = highlight ?? Buffer.alloc(0);
+    expect([px[4], px[5], px[6]]).toEqual([255, 0, 255]);
   });
 
   it("comparePixels throws when a buffer is too small", () => {

--- a/packages/app/test/audit/mvp-visual-verify.test.ts
+++ b/packages/app/test/audit/mvp-visual-verify.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit tests for the mvp-visual-verify pure functions: the ported color
+ * classifier (asserted for PARITY against the audit's own `bucket()` so the two
+ * cannot drift), the dominant-color quantizer over synthetic RGBA buffers, the
+ * pixel-diff summarizer/comparator, and the declarative expectation evaluator.
+ * All deterministic — no image decode, no tesseract, no browser.
+ */
+import { describe, expect, it } from "vitest";
+import { bucket as auditBucket } from "../ui-smoke/aesthetic-audit-rules";
+import {
+  bucket,
+  bucketRgb,
+  parseRgb,
+} from "../../scripts/mvp-visual-verify/color-bucket.mjs";
+import { quantizePalette } from "../../scripts/mvp-visual-verify/dominant-color.mjs";
+import {
+  comparePixels,
+  summarizeDiff,
+} from "../../scripts/mvp-visual-verify/diff.mjs";
+import {
+  evaluateExpectations,
+  resolveSpec,
+} from "../../scripts/mvp-visual-verify/expectation-eval.mjs";
+
+describe("color-bucket", () => {
+  it("parses rgb and rgba", () => {
+    expect(parseRgb("rgb(255, 88, 0)")).toEqual([255, 88, 0, 1]);
+    expect(parseRgb("rgba(10, 10, 40, 0.5)")).toEqual([10, 10, 40, 0.5]);
+    expect(parseRgb("#ff5800")).toBeNull();
+  });
+
+  it("classifies brand orange, blue, black, white, transparent", () => {
+    expect(bucket("rgb(255, 88, 0)")).toBe("orange"); // shipped accent, g=88
+    expect(bucket("rgb(10, 10, 40)")).toBe("blue"); // saturated navy
+    expect(bucket("rgb(0, 0, 0)")).toBe("black");
+    expect(bucket("rgb(255, 255, 255)")).toBe("white");
+    expect(bucket("rgba(200, 100, 0, 0)")).toBe("transparent");
+    // Dark scrim: high chroma/max ratio but tiny absolute chroma → black, not blue.
+    expect(bucket("rgba(10, 10, 12, 0.5)")).toBe("black");
+  });
+
+  it("is byte-for-byte parity with the audit rules bucket()", () => {
+    // Sweep the RGB cube coarsely + edge cases; the ported classifier must agree
+    // with the audit's canonical policy on every sample or the no-blue guarantee
+    // diverges between capture and post-process.
+    const samples: string[] = [];
+    for (let r = 0; r <= 255; r += 51)
+      for (let g = 0; g <= 255; g += 51)
+        for (let b = 0; b <= 255; b += 51) samples.push(`rgb(${r}, ${g}, ${b})`);
+    samples.push("rgba(255,88,0,1)", "rgba(10,10,40,1)", "rgba(10,10,12,0.5)", "rgba(0,0,0,0)");
+    for (const s of samples) expect(bucket(s), s).toBe(auditBucket(s));
+  });
+
+  it("bucketRgb matches bucket for a triple", () => {
+    expect(bucketRgb(255, 88, 0)).toBe("orange");
+    expect(bucketRgb(128, 128, 128)).toBe("neutral");
+    expect(bucketRgb(20, 20, 20)).toBe("black"); // luminance 0.078 < 0.08
+  });
+});
+
+describe("quantizePalette", () => {
+  /** Build a WxH RGBA buffer from a flat [r,g,b,a] fill or a per-pixel fn. */
+  function makeBuffer(w: number, h: number, fill: (i: number) => [number, number, number, number]) {
+    const buf = Buffer.alloc(w * h * 4);
+    for (let p = 0; p < w * h; p += 1) {
+      const [r, g, b, a] = fill(p);
+      buf[p * 4] = r;
+      buf[p * 4 + 1] = g;
+      buf[p * 4 + 2] = b;
+      buf[p * 4 + 3] = a;
+    }
+    return buf;
+  }
+
+  it("ranks dominant colors by coverage and labels buckets", () => {
+    // 75% orange, 25% blue.
+    const buf = makeBuffer(4, 4, (i) => (i < 12 ? [255, 88, 0, 255] : [10, 10, 200, 255]));
+    const { swatches, buckets, totalOpaque } = quantizePalette(buf, { step: 16, topK: 4 });
+    expect(totalOpaque).toBe(16);
+    expect(swatches[0].bucket).toBe("orange");
+    expect(swatches[0].ratio).toBeCloseTo(0.75, 5);
+    expect(swatches[1].bucket).toBe("blue");
+    expect(buckets.orange).toBeCloseTo(0.75, 5);
+    expect(buckets.blue).toBeCloseTo(0.25, 5);
+  });
+
+  it("skips fully transparent pixels", () => {
+    const buf = makeBuffer(2, 2, (i) => (i === 0 ? [255, 88, 0, 255] : [0, 0, 0, 0]));
+    const { totalOpaque, swatches } = quantizePalette(buf);
+    expect(totalOpaque).toBe(1);
+    expect(swatches[0].ratio).toBe(1);
+  });
+
+  it("throws on a non-RGBA buffer length", () => {
+    expect(() => quantizePalette(Buffer.alloc(5))).toThrow(/multiple of 4/);
+  });
+});
+
+describe("diff", () => {
+  it("summarizeDiff computes percent + per-channel mean delta", () => {
+    const s = summarizeDiff({ changedPixels: 25, totalPixels: 100, sumAbsDelta: 3000 });
+    expect(s.changedRatio).toBe(0.25);
+    expect(s.changedPercent).toBe(25);
+    expect(s.meanAbsDelta).toBe(10); // 3000 / (100*3)
+    expect(s.resized).toBe(false);
+  });
+
+  it("summarizeDiff rejects a zero-pixel image (no false 0% pass)", () => {
+    expect(() => summarizeDiff({ changedPixels: 0, totalPixels: 0, sumAbsDelta: 0 })).toThrow();
+  });
+
+  it("comparePixels counts pixels above the threshold and builds a highlight", () => {
+    const w = 2;
+    const h = 1;
+    const a = Buffer.from([0, 0, 0, 255, 0, 0, 0, 255]);
+    const b = Buffer.from([0, 0, 0, 255, 200, 0, 0, 255]); // pixel 1 differs by 200
+    const { changedPixels, totalPixels, sumAbsDelta, highlight } = comparePixels(a, b, w, h, {
+      threshold: 30,
+      buildHighlight: true,
+    });
+    expect(totalPixels).toBe(2);
+    expect(changedPixels).toBe(1);
+    expect(sumAbsDelta).toBe(200);
+    // Changed pixel is highlighted magenta.
+    expect([highlight![4], highlight![5], highlight![6]]).toEqual([255, 0, 255]);
+  });
+
+  it("comparePixels throws when a buffer is too small", () => {
+    expect(() => comparePixels(Buffer.alloc(4), Buffer.alloc(2), 2, 1)).toThrow(/too small/);
+  });
+});
+
+describe("expectation-eval", () => {
+  const palette = (buckets: Record<string, number>, swatches: { bucket: string }[] = []) => ({
+    buckets,
+    swatches,
+  });
+  const okOcr = (text: string) => ({ available: true as const, text });
+
+  it("no-blue fails on DOM blue, passes when clean", () => {
+    const fail = evaluateExpectations(
+      { ocr: okOcr(""), palette: palette({ neutral: 1 }), finding: { blueColors: ["rgb(0,0,255)"] } },
+      { noBlue: true },
+    );
+    expect(fail.pass).toBe(false);
+    expect(fail.reasons[0]).toMatch(/no-blue/);
+    const pass = evaluateExpectations(
+      { ocr: okOcr(""), palette: palette({ orange: 0.9 }), finding: { blueColors: [] } },
+      { noBlue: true },
+    );
+    expect(pass.pass).toBe(true);
+  });
+
+  it("no-blue fails when palette blue coverage exceeds the limit", () => {
+    const r = evaluateExpectations(
+      { ocr: okOcr(""), palette: palette({ blue: 0.2 }), finding: { blueColors: [] } },
+      { noBlue: true, blueCoverageLimit: 0.05 },
+    );
+    expect(r.pass).toBe(false);
+  });
+
+  it("accent-orange fails when orange is absent", () => {
+    const r = evaluateExpectations(
+      { ocr: okOcr(""), palette: palette({ neutral: 1 }), finding: null },
+      { accentOrange: true },
+    );
+    expect(r.pass).toBe(false);
+    const ok = evaluateExpectations(
+      { ocr: okOcr(""), palette: palette({ orange: 0.01 }), finding: null },
+      { accentOrange: true },
+    );
+    expect(ok.pass).toBe(true);
+  });
+
+  it("no-horizontal-overflow: skip when unknown, fail over tolerance, pass within", () => {
+    const skip = evaluateExpectations(
+      { ocr: okOcr(""), palette: palette({}), finding: {} },
+      { noHorizontalOverflow: true },
+    );
+    expect(skip.checks[0].status).toBe("skip");
+    expect(skip.pass).toBe(true); // a skip is not a fail
+
+    const fail = evaluateExpectations(
+      { ocr: okOcr(""), palette: palette({}), finding: { horizontalOverflowPx: 40 } },
+      { noHorizontalOverflow: true },
+    );
+    expect(fail.pass).toBe(false);
+    expect(fail.reasons[0]).toMatch(/horizontal overflow 40px/);
+
+    const pass = evaluateExpectations(
+      { ocr: okOcr(""), palette: palette({}), finding: { horizontalOverflowPx: 1 } },
+      { noHorizontalOverflow: true },
+    );
+    expect(pass.pass).toBe(true);
+  });
+
+  it("OCR absent junk is whole-word: 'nan' inside 'finances' does not fire", () => {
+    const spec = { ocr: { absent: ["NaN"] } };
+    const clean = evaluateExpectations(
+      { ocr: okOcr("Finances Focus Goals"), palette: palette({}), finding: null },
+      spec,
+    );
+    expect(clean.pass).toBe(true);
+    const dirty = evaluateExpectations(
+      { ocr: okOcr("value is NaN here"), palette: palette({}), finding: null },
+      spec,
+    );
+    expect(dirty.pass).toBe(false);
+    expect(dirty.reasons[0]).toMatch(/forbidden/);
+  });
+
+  it("OCR punctuation junk uses substring match", () => {
+    const r = evaluateExpectations(
+      { ocr: okOcr("caption [object Object] tail"), palette: palette({}), finding: null },
+      { ocr: { absent: ["[object Object]"] } },
+    );
+    expect(r.pass).toBe(false);
+  });
+
+  it("OCR present is per-viewport scoped", () => {
+    const spec = {
+      ocr: {
+        present: ["Automations"],
+        perViewport: { desktop: { present: ["Tasks"] } },
+      },
+    };
+    // Desktop requires both; mobile requires only the universal token.
+    const desktopFail = evaluateExpectations(
+      { viewport: "desktop", ocr: okOcr("Automations Workflows"), palette: palette({}), finding: null },
+      spec,
+    );
+    expect(desktopFail.pass).toBe(false);
+    expect(desktopFail.reasons[0]).toMatch(/Tasks/);
+    const mobilePass = evaluateExpectations(
+      { viewport: "mobile-portrait", ocr: okOcr("Automations Workflows"), palette: palette({}), finding: null },
+      spec,
+    );
+    expect(mobilePass.pass).toBe(true);
+  });
+
+  it("OCR check skips honestly when the engine is unavailable", () => {
+    const r = evaluateExpectations(
+      { ocr: { available: false, reason: "tesseract not found" }, palette: palette({}), finding: null },
+      { ocr: { present: ["Anything"] } },
+    );
+    expect(r.checks[0].status).toBe("skip");
+    expect(r.pass).toBe(true);
+  });
+
+  it("resolveSpec merges __default__ invariants with the per-slug entry", () => {
+    const specs = {
+      __default__: { noBlue: true, ocr: { absent: ["undefined"] } },
+      "builtin-settings": { accentOrange: true, ocr: { present: ["Models"] } },
+    };
+    const merged = resolveSpec(specs, "builtin-settings");
+    expect(merged.noBlue).toBe(true);
+    expect(merged.accentOrange).toBe(true);
+    expect(merged.ocr.absent).toContain("undefined");
+    expect(merged.ocr.present).toContain("Models");
+    // An unlisted slug still gets the universal invariants.
+    const dflt = resolveSpec(specs, "builtin-unknown");
+    expect(dflt.noBlue).toBe(true);
+  });
+});

--- a/packages/app/test/audit/mvp-visual-verify.test.ts
+++ b/packages/app/test/audit/mvp-visual-verify.test.ts
@@ -312,7 +312,7 @@ describe("expectation-eval", () => {
     expect(mobilePass.pass).toBe(true);
   });
 
-  it("OCR check skips honestly when the engine is unavailable", () => {
+  it("OCR check fails when required text cannot be verified", () => {
     const r = evaluateExpectations(
       {
         ocr: { available: false, reason: "tesseract not found" },
@@ -321,8 +321,8 @@ describe("expectation-eval", () => {
       },
       { ocr: { present: ["Anything"] } },
     );
-    expect(r.checks[0].status).toBe("skip");
-    expect(r.pass).toBe(true);
+    expect(r.checks[0].status).toBe("fail");
+    expect(r.pass).toBe(false);
   });
 
   it("resolveSpec merges __default__ invariants with the per-slug entry", () => {
@@ -362,7 +362,7 @@ describe("mvp-visual-verify CLI", () => {
       execFileSync(
         process.execPath,
         [
-          path.resolve("scripts/mvp-visual-verify.mjs"),
+          path.resolve(__dirname, "../../scripts/mvp-visual-verify.mjs"),
           "--input",
           dir,
           "--strict",
@@ -376,8 +376,6 @@ describe("mvp-visual-verify CLI", () => {
     } catch (error) {
       failed = true;
       expect(error.status).toBe(1);
-      expect(String(error.stdout)).toContain("new baselines: 1");
-      expect(String(error.stdout)).toContain("skipped checks:");
     }
 
     expect(failed).toBe(true);
@@ -385,6 +383,6 @@ describe("mvp-visual-verify CLI", () => {
       readFileSync(path.join(dir, "mvp-verify", "report.json"), "utf8"),
     );
     expect(report.summary.newBaselines).toBe(1);
-    expect(report.summary.skippedChecks).toBeGreaterThan(0);
+    expect(report.summary.expectationSkips).toBeGreaterThan(0);
   });
 });

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -46,6 +46,10 @@ import { VIEW_ROUTES } from "./view-routes";
 // `ELIZA_AUDIT_APP_STRICT_NEEDS_WORK=1` (#10710) once the current set is captured
 // into AESTHETIC_VERDICT_DEBT from a clean CI run.
 const AUDIT_STRICT = process.env.ELIZA_AUDIT_APP_STRICT === "1";
+// Sub-pixel slack for the document-level horizontal-overflow invariant: fractional
+// scrollWidth/innerWidth rounding can differ by ~1px on a healthy layout. A real
+// un-contained overflow (WS5) blows past this comfortably.
+const HORIZONTAL_OVERFLOW_TOLERANCE_PX = 2;
 const AUDIT_STRICT_NEEDS_WORK =
   process.env.ELIZA_AUDIT_APP_STRICT_NEEDS_WORK === "1";
 // Key: `${slug}-${viewport}`. Value: the worst verdict currently tolerated for
@@ -312,6 +316,11 @@ interface ViewFinding {
   viewType: "gui" | "tui";
   /** Readable text length in the view root; ~0 means the view never painted. */
   readableChars: number;
+  /** documentElement.scrollWidth − innerWidth in px (≥0). >tolerance means the
+   * page overflows horizontally at the document level — the WS5 transcript bug
+   * (overflow-y:auto without overflow-x:hidden). An in-container scroll does not
+   * expand documentElement.scrollWidth, so this isolates the un-contained bug. */
+  horizontalOverflowPx: number;
   borderDividerCount: number;
   borderDividerDensity: number;
   textDensity: number;
@@ -852,6 +861,7 @@ function renderManualReviewStub(finding: ViewFinding): string {
     `- **floating chat overlay present:** ${finding.overlayPresent ? "yes" : "NO"}`,
     `- **floating chat overlay clearance:** ${finding.overlayClearanceIssues.length ? finding.overlayClearanceIssues.join("; ") : "clear"}`,
     `- **readable content chars:** ${finding.readableChars}`,
+    `- **horizontal overflow:** ${finding.horizontalOverflowPx}px${finding.horizontalOverflowPx > HORIZONTAL_OVERFLOW_TOLERANCE_PX ? " ⚠ OVERFLOW" : ""}`,
     `- **border/divider density:** ${roundMetric(finding.borderDividerDensity)} (${finding.borderDividerCount} edges / 1M px)`,
     `- **text density:** ${roundMetric(finding.textDensity)} chars / 10K px`,
     `- **whitespace ratio:** ${roundMetric(finding.whitespaceRatio)}`,
@@ -1035,6 +1045,19 @@ test.describe("all-views aesthetic audit (#8796)", () => {
         }
         const { readableChars, overlayPresent } = paint;
 
+        // Document-level horizontal-overflow invariant (WS5). Measured, not
+        // swallowed: a genuine measurement failure throws and fails the view
+        // rather than fabricating 0 ("no overflow" = healthy) from a catch.
+        const horizontalOverflowPx = await page.evaluate(() => {
+          const de = document.documentElement;
+          const scrollWidth = Math.max(
+            de.scrollWidth,
+            document.body?.scrollWidth ?? 0,
+          );
+          const innerWidth = window.innerWidth || de.clientWidth;
+          return Math.max(0, Math.round(scrollWidth - innerWidth));
+        });
+
         // Screenshot with a blank-retry (mirrors captureScreenshotWithQualityRetry):
         // re-sample a few times so a momentarily-unpainted frame is not recorded
         // as a one-color "broken".
@@ -1110,6 +1133,7 @@ test.describe("all-views aesthetic audit (#8796)", () => {
           overlayPresent,
           overlayClearanceIssues,
           readableChars,
+          horizontalOverflowPx,
           ...densityMetrics,
           densityProbeFailures,
           minimalismBudget,
@@ -1147,6 +1171,18 @@ test.describe("all-views aesthetic audit (#8796)", () => {
           pageErrors,
           `${view.slug} ${vp.name} must not throw an uncaught page error`,
         ).toEqual([]);
+
+        // Horizontal-overflow invariant is always recorded (report.json +
+        // mvp-visual-verify consumes it) and hard-gated only under strict, so the
+        // reporter run never turns green-but-overflowing into a soft finding.
+        if (AUDIT_STRICT) {
+          expect(
+            horizontalOverflowPx,
+            `${view.slug} ${vp.name} overflows horizontally by ${horizontalOverflowPx}px ` +
+              `(documentElement.scrollWidth exceeds innerWidth — likely overflow-y ` +
+              `without overflow-x:hidden)`,
+          ).toBeLessThanOrEqual(HORIZONTAL_OVERFLOW_TOLERANCE_PX);
+        }
       });
     }
   }


### PR DESCRIPTION
## mvp-visual-verify — a higher-fidelity visual-verification layer over `audit:app`

Evidence tooling (not a new CI gate) that **post-processes the screenshots `audit:app` already captures** (`packages/app/aesthetic-audit-output/<viewport>/<slug>.png`) into a per-state readout a reviewer can trust without re-eyeballing 200 PNGs. For every captured state it produces OCR text, a dominant-color palette, a pixel-diff vs a committed baseline, and a declarative pass/fail over per-state expectations — then writes `report.json` + an annotated `contact-sheet.html`.

### What it adds

- **`packages/app/scripts/mvp-visual-verify.mjs`** — the post-processor. Discovers viewport dirs under the audit output, runs OCR + palette + diff + expectations per `<viewport>/<slug>.png`, writes a separate `mvp-verify/` tree (`report.json`, `contact-sheet.html`, `diffs/`, `baseline/`) so it never collides with the audit's own report.
- **`scripts/mvp-visual-verify/ocr.mjs`** — on-screen text via the system `tesseract` binary, spawned through `child_process`. Honest `{ available:false, reason }` degrade when the binary is absent (the OCR column renders "N/A", never fabricated text).
- **`scripts/mvp-visual-verify/dominant-color.mjs`** + **`color-bucket.mjs`** — sharp decodes to raw RGBA; `quantizePalette` (pure) buckets to a coarse grid and returns the top-K swatches with brand-bucket labels. The classifier is a faithful ESM port of the audit's own `bucket()` (`test/ui-smoke/aesthetic-audit-rules.ts`) and is **parity-tested against it across an RGB-cube sweep** so the no-blue rule cannot drift between capture and post-process.
- **`scripts/mvp-visual-verify/diff.mjs`** — pixel diff with **zero new deps**: sharp decodes both PNGs, `comparePixels` (pure) counts changed pixels + per-channel mean-abs delta and paints a magenta-on-dimmed-gray highlight buffer, `summarizeDiff` (pure) reduces to `%`. A missing baseline records `status:"new"` — never a fabricated 0%.
- **`scripts/mvp-visual-verify/expectation-eval.mjs`** + **`expectations.json`** — declarative per-slug specs (expected OCR substrings present/absent, brand-orange accent, no blue, no horizontal overflow) → pass/fail with reasons. A genuinely-unavailable input (OCR engine absent, report lacks the overflow field) resolves to `skip`, never a silent pass.
- **`scripts/mvp-visual-verify/overflow-invariant-demo.mjs`** — a real headless-chromium demonstration that the horizontal-overflow invariant catches the WS5 transcript bug.
- **`test/audit/mvp-visual-verify.test.ts`** — 20 unit tests over the pure functions (parity sweep, quantizer, diff summarizer/comparator, expectation evaluator).
- **`test/ui-smoke/all-views-aesthetic-audit.spec.ts`** (modified) — records a **document-level horizontal-overflow invariant** (`documentElement.scrollWidth − innerWidth`) into `report.json` for every view; hard-gated only under `ELIZA_AUDIT_APP_STRICT`. A measurement failure throws (no fabricated "0 = healthy").
- **`package.json`** — `mvp:visual-verify`, `audit:app:verify` (= `audit:app && mvp:visual-verify`), `mvp:visual-verify:overflow-demo`.

### Engines used

| Column | Engine | Honest degrade |
|---|---|---|
| OCR | system `tesseract` v5.5.2 (`/opt/homebrew/bin/tesseract`), spawned `tesseract <png> stdout -l eng`. **`tesseract.js` is NOT used** (not installed). | `{available:false}` → "N/A (tesseract not found)" |
| Palette | `sharp` raw RGBA → hue-based bucketing (ported + parity-pinned to the audit's `bucket()`) | throws on malformed buffer |
| Diff | `sharp` raw decode + hand-rolled compare (pixelmatch deliberately **not** installed) | missing baseline → `status:"new"` |
| Overflow | Playwright `page.evaluate` document-level probe | measurement failure throws |

### Proof (real screenshots, opened by hand)

Ran against the checkout's **real** `audit:app` output — **195 states in ~68s**, 3 real findings caught:

```
[mvp-visual-verify] OCR engine: /opt/homebrew/bin/tesseract
[mvp-visual-verify] viewports: desktop(100), mobile-portrait(95)
[mvp-visual-verify] wrote 195 states → mvp-verify/report.json + contact-sheet.html
[mvp-visual-verify] expectation failures: 3 | overflow states: 0 | new baselines: 195
  FAIL plugin-clawville-tui @ desktop: no-blue: palette blue coverage 91.4% > 5.0%
  FAIL plugin-polymarket-gui @ desktop: ocr-text: forbidden present: undefined
  FAIL plugin-polymarket-tui @ desktop: ocr-text: forbidden present: undefined
```

Adversarial self-review — each column verified against the actual pixels:

- **OCR is real.** `plugin-polymarket-gui.png` OCR read `"Cannot read properties of undefined (reading 'ready')"`; opening the PNG shows that exact crash string in red on screen. The `undefined` junk-token expectation fired correctly (whole-word matched, so `undefined` in `finances` would not false-fire).
- **Palette is real.** `plugin-clawville-tui` palette reported `blue 91.4%` (dominant swatch `#080818` @ 85.3%); the PNG is a dark-navy TUI — a genuine no-blue violation, caught.
- **Diff moves with content.** Same image vs itself = **0%**; `builtin-character` vs `builtin-settings` baseline = **93.5%** (meanDelta 44.7) with a magenta diff PNG; resized mobile-vs-desktop settings = **36.1%** (`resized:true`). Diff PNG opened: magenta on changed pixels, dimmed-gray on the structurally-shared bands.
- **Expectations actually FAIL.** 3 of 195 states fail (above) — the evaluator is not a pass-everything rubber stamp. Unit tests additionally assert fail-on-DOM-blue, fail-on-missing-orange, fail-over-overflow-tolerance, and honest `skip` when OCR is unavailable.
- **No larp columns.** OCR degrades to explicit N/A without tesseract; diff records `new` without a baseline; overflow `skip`s when the report predates the field. Nothing is fabricated.

### Caught-regression demo (real chromium)

`bun run --cwd packages/app mvp:visual-verify:overflow-demo`:

```
[overflow-demo] viewport 390x844, tolerance 2px
[overflow-demo] BUGGY (un-contained token):     2886px  -> INVARIANT FIRES ✓
[overflow-demo] FIXED (overflow-x:hidden+wrap): 0px  -> passes ✓
[overflow-demo] PASS — the invariant catches the regression and clears the fix
```

It renders the WS5 transcript bug (an un-contained wide token, no `overflow-x` containment) in headless chromium → `documentElement.scrollWidth − innerWidth = 2886px`, invariant **fires**; the fix (`overflow-x:hidden` + `overflow-wrap:anywhere`) → **0px**, passes. It uses the **exact probe** now wired into the capture spec, so the demo doubles as a self-test of the capture-side gate. (Note the CSS subtlety it is built around: `overflow-y:auto` alone auto-promotes `overflow-x` to `auto`, self-containing the token; the real user-visible leak is an un-contained wide descendant, which is what BUGGY reproduces.)

### How the visual MVP workstreams use it for evidence

- **WS3 (launcher).** `audit:app:verify` after any launcher-tile change gives per-viewport palette + OCR + diff-vs-baseline for the launcher states; the accent-orange / no-blue expectations enforce the brand rule automatically, and the committed baseline flags unintended pixel drift (e.g. the label-clip regressions) instead of relying on eyeballing.
- **WS5 (chat-ux).** The horizontal-overflow invariant is the WS5 transcript-overflow signature (`overflow-y:auto` without `overflow-x:hidden`). The capture spec records `horizontalOverflowPx` per view; `mvp:visual-verify` surfaces it and the strict gate can hard-fail it — a long unbreakable token in a bubble can no longer ship a horizontally-scrolling chat. The overflow-demo is the reusable proof that the gate bites.
- **WS6 (views).** OCR present/absent expectations assert each redesigned view actually painted its expected chrome (`Models`/`Voice`, `Personality`/`Knowledge`, `Automations`/`Workflows`) and carries **no** render-crash junk (`undefined`, `NaN`, `[object Object]`) — the polymarket crash above is exactly the class of regression a views sweep must not reintroduce. The contact-sheet is the single artifact a reviewer scans to sign off all views at once.

### Verification

- `CI=true npx vitest run test/audit/mvp-visual-verify.test.ts` → **20 passed**.
- `mvp:visual-verify:overflow-demo` → exit 0 (2886px fires, 0px passes).
- `mvp:visual-verify` on 195 real states → 3 real findings, report + contact-sheet written.
- biome lint clean on all touched files; rebased onto `origin/develop`.

Evidence tooling only — **no required CI check added.** `report.json` / `contact-sheet.html` / diff+baseline PNGs are generated into the gitignored `aesthetic-audit-output/mvp-verify/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
