### PR TITLE
fix(interactions): suppress dead /forms/:id link-out for FORM blocks

### DIFF
--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -349,13 +349,37 @@ describe("buildInteractionUrlResolver (#8908)", () => {
 		);
 	});
 
-	it("resolves a form block to the hosted form route", () => {
-		const block: FormInteraction = {
+	// #14321 — there is no hosted /forms/:id page and form specs are never
+	// persisted, so a form block must NOT mint a link-out (that would be a dead
+	// route). It resolves to undefined and the layout degrades to a free-text
+	// reply, while a hosted-page block type (task) still resolves its real URL.
+	it("does not mint a link-out for a form block (no hosted page → free-text fallback)", () => {
+		const form: FormInteraction = {
 			kind: "form",
 			id: "form_7",
 			fields: [{ name: "k", type: "text" }],
 		};
-		expect(resolver.resolveUrl?.(block)).toBe("https://app.test/forms/form_7");
+		expect(resolver.resolveUrl?.(form)).toBeUndefined();
+
+		const layout = toNeutralLayout(form, resolver);
+		expect(layout.needsFallback).toBe(true);
+		expect(layout.rows).toEqual([]);
+		// No button anywhere points at the nonexistent /forms/ route.
+		const urls = layout.rows.flatMap((r) => r.buttons ?? []).map((b) => b.url);
+		expect(urls).not.toContain("https://app.test/forms/form_7");
+
+		// A block type that DOES have a hosted page still resolves normally.
+		const task: TaskInteraction = {
+			kind: "task",
+			threadId: "abc-123",
+			title: "Build it",
+		};
+		expect(resolver.resolveUrl?.(task)).toBe(
+			"https://app.test/orchestrator?taskId=abc-123",
+		);
+		expect(toNeutralLayout(task, resolver).rows[0]?.buttons?.[0]?.url).toBe(
+			"https://app.test/orchestrator?taskId=abc-123",
+		);
 	});
 
 	it("resolves navigate payloads (path + viewId) against the base url", () => {

--- a/packages/core/src/messaging/interactions/layout.ts
+++ b/packages/core/src/messaging/interactions/layout.ts
@@ -6,8 +6,8 @@
  * per-connector glue thin.
  *
  * Buttons round-trip via `callbackData` (the user's answer, re-injected as a
- * message) or open a `url` (link-out for forms, secret entry, and task views).
- * A button always carries exactly one of the two.
+ * message) or open a `url` (link-out for secret entry and task views). A button
+ * always carries exactly one of the two.
  */
 
 import type {
@@ -50,9 +50,10 @@ export interface NeutralLayout {
 
 export interface LayoutOptions {
 	/**
-	 * Resolve an external entry URL for blocks that link out: complex forms,
-	 * secret/OAuth entry, and the task view. Returning undefined marks the block
-	 * as needing a free-text fallback.
+	 * Resolve an external entry URL for blocks that link out: secret/OAuth entry
+	 * and the task view. Returning undefined marks the block as needing a
+	 * free-text fallback (this is the designed path for `form` blocks, which have
+	 * no hosted page — see {@link buildInteractionUrlResolver}).
 	 */
 	resolveUrl?: (block: InteractionBlock) => string | undefined;
 	/**
@@ -177,10 +178,15 @@ export function toNeutralLayout(
 
 /**
  * Build the canonical link-out resolvers connectors pass to {@link toNeutralLayout}
- * so Telegram, Discord, and any other surface produce identical URLs for task,
- * form, and navigate blocks. `appBaseUrl` is the deployment's app/dashboard
- * origin (`ELIZA_APP_URL`, falling back to the cloud URL). Returns `undefined`
+ * so Telegram, Discord, and any other surface produce identical URLs for task
+ * and navigate blocks. `appBaseUrl` is the deployment's app/dashboard origin
+ * (`ELIZA_APP_URL`, falling back to the cloud URL). Returns `undefined`
  * resolvers when no base URL is configured, which keeps the free-text fallback.
+ *
+ * `form` blocks are intentionally NOT resolved: there is no hosted `/forms/:id`
+ * page and form specs are never persisted, so any link-out would be a dead
+ * route. Leaving them unresolved routes them to the layout's free-text reply
+ * fallback instead of fabricating a healthy-looking dead control (#14321).
  */
 export function buildInteractionUrlResolver(
 	appBaseUrl: string | undefined | null,
@@ -192,10 +198,10 @@ export function buildInteractionUrlResolver(
 			switch (block.kind) {
 				case "task":
 					return `${base}/orchestrator?taskId=${encodeURIComponent(block.threadId)}`;
-				case "form":
-					return `${base}/forms/${encodeURIComponent(block.id)}`;
-				// Secret/OAuth blocks carry their own out-of-band entry URL
-				// (the hosted secure page); defer to it via the layout fallback.
+				// `form` and secret/OAuth blocks fall through to undefined: a form
+				// has no hosted `/forms/:id` page (degrade to free-text reply), and
+				// secret/OAuth blocks carry their own out-of-band entry URL that the
+				// layout defers to.
 				default:
 					return undefined;
 			}


### PR DESCRIPTION
Fixes #14321

## Problem
A `[FORM]` block delivered on Telegram/Discord rendered an **"Open form"** button linking to `${base}/forms/<id>`. That page **does not exist** and form specs are **never persisted**, so tapping the button dropped users on a dead route. This is a healthy-looking control minted for a broken pipeline — a fail-fast doctrine violation.

## Fix
`buildInteractionUrlResolver` (`packages/core/src/messaging/interactions/layout.ts`) no longer mints a URL for `form` blocks. The `form` case now falls through to `undefined`, which makes `toNeutralLayout` take the **already-designed free-text reply fallback** (`needsFallback: true`, no button rows). No new code path — the fallback wiring already existed for forms with no link-out URL.

Unaffected block types that DO have hosted destinations:
- `task` → still resolves to the real `/orchestrator?taskId=...` deep link.
- `secret`/OAuth → still defers to its own out-of-band entry URL.

## How to confirm without reading code
The change is proven by a unit test in the layout's suite. It was written to fail against the old behavior and pass against the fix.

**RED** — new test run against the ORIGINAL (buggy) `layout.ts`:
```
 × does not mint a link-out for a form block (no hosted page → free-text fallback)
 FAIL  src/messaging/interactions/interactions.test.ts
 AssertionError: expected 'https://app.test/forms/form_7' to be undefined
      Tests  1 failed | 29 passed (30)
```

**GREEN** — full suite with the fix applied:
```
 Test Files  1 passed (1)
      Tests  30 passed (30)
```

Run it yourself:
```
bun run --cwd packages/core test src/messaging/interactions/interactions.test.ts
```
(or `bunx vitest run src/messaging/interactions/interactions.test.ts` from `packages/core` in a shared-node_modules worktree.)

The test asserts a form block yields `resolveUrl === undefined` + `needsFallback === true` + zero button rows (no `/forms/` URL anywhere), while a `task` block still resolves its real `/orchestrator` URL in the same resolver.

## Evidence checklist
- Real-LLM trajectory: N/A — pure projection/URL-minting logic, no model/action/prompt behavior changed.
- UI screenshots/video: N/A — no `packages/app` or cloud-frontend surface touched; the user-visible effect is the *absence* of a dead button on Telegram/Discord, covered deterministically by the unit test above.
- Backend logs: N/A — no runtime service path; change is in a synchronous layout helper.
- Domain artifacts: N/A — no DB rows / memories / files produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjaSfQrf3xRDfPXuc9fgeA