### PR TITLE
fix(ui): gate AppRunsWidget poll on document visibility (#14346)

### DIFF
--- a/packages/ui/src/components/chat/widgets/agent-orchestrator-app-runs.test.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator-app-runs.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 //
 // AppRunsWidget polling gates: skips the app-run poll on limited cloud agent
-// bases and while unauthenticated, and starts once the session authenticates.
-// jsdom render with the API client + auth hook + app store mocked (no backend).
-import { cleanup, render, waitFor } from "@testing-library/react";
+// bases and while unauthenticated, starts once the session authenticates, and
+// (the #14346 gate) pauses the recurring poll while the tab is backgrounded and
+// resumes it on foreground. jsdom render with the API client + auth hook + app
+// store mocked (no backend); document.visibilityState is driven directly.
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -57,6 +59,14 @@ if (!AppRunsWidget) {
   throw new Error("agent-orchestrator.apps widget not registered");
 }
 
+function setVisibility(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
 beforeEach(() => {
   getBaseUrlMock.mockReset();
   getBaseUrlMock.mockReturnValue("http://localhost");
@@ -65,10 +75,13 @@ beforeEach(() => {
   mockState.setTab.mockClear();
   mockState.setState.mockClear();
   authMock.authenticated = true;
+  setVisibility("visible");
 });
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
+  setVisibility("visible");
 });
 
 describe("AppRunsWidget", () => {
@@ -110,5 +123,34 @@ describe("AppRunsWidget", () => {
     await waitFor(() => {
       expect(listAppRunsMock).toHaveBeenCalled();
     });
+  });
+
+  // #14346 — a backgrounded webview must stop waking the API. The recurring
+  // poll is gated on document visibility; the immediate first fetch still fires
+  // once on mount (that gate governs the interval, not the initial load).
+  it("does not poll while the document is hidden and resumes on foreground", async () => {
+    vi.useFakeTimers();
+
+    render(
+      <AppRunsWidget slot="chat-sidebar" events={[]} clearEvents={vi.fn()} />,
+    );
+    // Flush the mount effect's immediate fetch.
+    await act(async () => {});
+    expect(listAppRunsMock).toHaveBeenCalledTimes(1);
+
+    // Background the tab: advancing well past several 15s ticks yields no
+    // further requests — the interval is unsubscribed while hidden.
+    act(() => setVisibility("hidden"));
+    await act(async () => {
+      vi.advanceTimersByTime(15_000 * 3);
+    });
+    expect(listAppRunsMock).toHaveBeenCalledTimes(1);
+
+    // Foreground again: the poll resumes on the next tick.
+    act(() => setVisibility("visible"));
+    await act(async () => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(listAppRunsMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
@@ -43,6 +43,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { client, type RegistryAppInfo } from "../../../api";
@@ -451,69 +452,72 @@ function AppRunsWidget({
     };
   }, []);
 
+  const runsPollEnabled =
+    supportsFullAppShellRoutes(currentBaseUrl) && authenticated;
+  // The poll pushes appRuns into the global AppContext, which re-renders every
+  // useApp() consumer. Persist the last-seen run set across ticks so we only
+  // push when it actually changed and a steady poll doesn't bust the whole app.
+  // A ref (not effect-local state) because refreshRuns now outlives a single
+  // effect run — the visibility-gated interval re-subscribes on every
+  // foreground/background transition.
+  const lastAppRunsKeyRef = useRef("");
+
+  const refreshRuns = useCallback(async () => {
+    if (!runsPollEnabled) return;
+    try {
+      const nextRuns = await client.listAppRuns();
+      const nextRunsSafe = Array.isArray(nextRuns) ? nextRuns : [];
+      setError(null);
+      const nextKey = JSON.stringify(nextRunsSafe);
+      const changed = nextKey !== lastAppRunsKeyRef.current;
+      lastAppRunsKeyRef.current = nextKey;
+      startTransition(() => {
+        setRuns(nextRunsSafe);
+        if (changed) setState("appRuns", nextRunsSafe);
+      });
+    } catch (refreshError) {
+      // error-policy:J4 load failure renders the widget's error state
+      setError(
+        getClientErrorMessage(
+          refreshError,
+          t("agentorchestrator.loadRunsError", {
+            defaultValue: "Failed to load app runs.",
+          }),
+        ),
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [runsPollEnabled, setState, t]);
+
   useEffect(() => {
-    if (!supportsFullAppShellRoutes(currentBaseUrl) || !authenticated) {
+    if (!runsPollEnabled) {
       // Idempotent reset: keep the previous reference when already empty. A
       // fresh `[]` here re-renders unconditionally, and because the update
       // rides a transition lane it dodges React's synchronous nested-update
       // guard — with any unstable dep this loops render→effect→render until
-      // the worker OOMs (the #11107 WidgetHost test crash).
+      // the worker OOMs (the #11107 WidgetHost test crash). Clear the change
+      // key too so the first fetch after re-auth always repopulates AppContext.
+      lastAppRunsKeyRef.current = "";
       startTransition(() => {
         setRuns((prev) => (prev.length === 0 ? prev : []));
         setState("appRuns", []);
       });
       setError(null);
       setLoading(false);
-      return undefined;
+      return;
     }
-
-    let cancelled = false;
-    // The 5s poll pushes appRuns into the global AppContext, which re-renders
-    // every useApp() consumer. Only push when the run set actually changed so a
-    // steady poll doesn't bust the whole app every 5 seconds.
-    let lastAppRunsKey = "";
-
-    const refreshRuns = async () => {
-      try {
-        const nextRuns = await client.listAppRuns();
-        const nextRunsSafe = Array.isArray(nextRuns) ? nextRuns : [];
-        if (cancelled) return;
-        setError(null);
-        const nextKey = JSON.stringify(nextRunsSafe);
-        const changed = nextKey !== lastAppRunsKey;
-        lastAppRunsKey = nextKey;
-        startTransition(() => {
-          setRuns(nextRunsSafe);
-          if (changed) setState("appRuns", nextRunsSafe);
-        });
-      } catch (refreshError) {
-        // error-policy:J4 load failure renders the widget's error state
-        if (cancelled) return;
-        setError(
-          getClientErrorMessage(
-            refreshError,
-            t("agentorchestrator.loadRunsError", {
-              defaultValue: "Failed to load app runs.",
-            }),
-          ),
-        );
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    };
-
     void refreshRuns();
-    const timer = setInterval(() => {
-      void refreshRuns();
-    }, 5_000);
+  }, [runsPollEnabled, refreshRuns, setState]);
 
-    return () => {
-      cancelled = true;
-      clearInterval(timer);
-    };
-  }, [authenticated, currentBaseUrl, setState, t]);
+  // Gate the recurring poll on document visibility so a backgrounded window
+  // stops waking the API (and the radio). 15s matches the sibling orchestrator
+  // widgets — no live-run progress requirement justifies a tighter cadence.
+  useIntervalWhenDocumentVisible(
+    () => void refreshRuns(),
+    15_000,
+    runsPollEnabled,
+  );
 
   if (shouldHideWidget) {
     return null;


### PR DESCRIPTION
Fixes #14346

## What was wrong
`AppRunsWidget` (chat-sidebar "Apps" widget) was the **only** orchestrator widget polling with a raw `setInterval` — `client.listAppRuns()` every **5 seconds, forever**, even when the window/webview was backgrounded. Every sibling widget (accounts, rooms) already gates its poll on `useIntervalWhenDocumentVisible`. A backgrounded desktop/mobile webview kept waking the API and the mobile radio indefinitely.

## What changed (one file of product code)
`packages/ui/src/components/chat/widgets/agent-orchestrator.tsx`
- Replaced the raw `setInterval(() => void refreshRuns(), 5_000)` with `useIntervalWhenDocumentVisible(() => void refreshRuns(), 15_000, runsPollEnabled)` — the exact hook + signature the sibling accounts/rooms widgets use.
- **Cadence 5s → 15s**, matching the sibling orchestrator widgets (the issue notes no live-run progress requirement justifies a tighter cadence).
- Preserved behavior:
  - **Immediate first fetch** on mount / re-auth (the visibility gate governs the *recurring* poll, not the initial load).
  - **Change-key guard** — global `AppContext` is written only when the run set actually changed — moved from an effect-local `let` to a `useRef` so it survives the interval re-subscribing on every foreground/background transition. It is cleared on reset so the first fetch after re-auth always repopulates `AppContext`.
  - **Error state** on load failure (unchanged `// error-policy:J4`).
  - Auth / app-shell-route gating (`runsPollEnabled`) drives both the reset branch and the poll's `enabled` flag.

## How to confirm it works (without reading the code)
The updated unit test drives the real widget through a background/foreground cycle with fake timers and a driven `document.visibilityState`, asserting the poll is silent while hidden and resumes on foreground.

### Before vs after (behavioral)
- **Before:** hide the tab → `listAppRuns` keeps firing every 5s forever.
- **After:** hide the tab → after the one immediate mount fetch, advancing **3 × 15s** produces **zero** further `listAppRuns` calls; foregrounding + advancing 15s resumes polling (call count goes 1 → 1 → 2).

### Test output (`bun run --cwd packages/ui test src/components/chat/widgets/agent-orchestrator-app-runs.test.tsx`)
```
 RUN  v4.1.5 packages/ui

 Test Files  1 passed (1)
      Tests  4 passed (4)
```
The four cases: skips poll on limited cloud bases · does not poll while unauthenticated · polls once authenticated · **does not poll while the document is hidden and resumes on foreground** (the new #14346 gate).

## Evidence
- **Updated test output** — pasted above (4/4 passing).
- **Browser network log / MP4 toggling tab visibility** — N/A for this PR: the poll gate is proven deterministically by the fake-timer + driven-visibility unit test above (exercises the real widget component and the real `useIntervalWhenDocumentVisible` hook, no mock of the thing under test). The behavior is identical to the already-shipped accounts/rooms widgets that use the same hook.
- **Typecheck** — my two files are clean; the only `bun run --cwd packages/ui typecheck` errors are pre-existing failures in unrelated test files on `develop` (`todo.test.tsx`, `spatial/__e2e__/immersive-fixture.ts`, `startup-phase-poll.test.ts`, `voice-selftest-harness.test.ts`), untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjaSfQrf3xRDfPXuc9fgeA