### PR TITLE
fix(ui): widen launcher tile label cap so single-word labels don't clip (#14427)

### DIFF
--- a/packages/ui/src/components/pages/Launcher.tsx
+++ b/packages/ui/src/components/pages/Launcher.tsx
@@ -153,7 +153,12 @@ const IconTile = memo(function IconTile({
           </Button>
         ) : null}
       </div>
-      <span className="line-clamp-2 max-w-[4.5rem] text-center text-[11px] font-medium leading-tight text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]">
+      {/* 5.25rem, not the icon's 4rem: the narrowest grid cell (4 cols on a
+          ~380px phone) is ~85px, and the longest single-word label
+          ("Relationships", ~79px at 11px) cannot wrap at a word boundary — a
+          tighter cap clipped it mid-glyph (#14427). line-clamp-2 still wraps
+          multi-word labels. */}
+      <span className="line-clamp-2 max-w-[5.25rem] text-center text-[11px] font-medium leading-tight text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]">
         {entry.label}
       </span>
     </div>


### PR DESCRIPTION
Closes #14427.

On the phone launcher, the **"Relationships"** tile label clipped mid-glyph at the right edge (seen on the Seeker during demo QA). The tile label (`Launcher.tsx`) was capped at `max-w-[4.5rem]` (72px); "Relationships" is ~79px at 11px and — being a **single word** — `line-clamp-2` cannot wrap it, so it clipped horizontally.

**Fix:** `max-w-[4.5rem]` → `max-w-[5.25rem]` (84px). Still fits the narrowest grid cell (4 cols on a ~380px viewport ≈ 85px); multi-word labels keep wrapping via `line-clamp-2`.

## Evidence
- `bun run --cwd packages/ui test:launcher-e2e` (real headless Chromium, desktop + mobile): **PASSED** — 16 tiles render, tap/drag/swipe interactions green, 0 page errors. The fixture's longest single-word labels ("Orchestrator", "Companion") render **fully unclipped** on the 4-column mobile grid in the run's screenshots (regenerated e2e outputs restored — not committed, per the retired-evidence rule).
- `biome check` clean.
- Before (on-device, Seeker): "Relationships" trailing glyph cut at the tile edge.

Authored by `[maintainer]` — needs a reviewer lane (no self-merge). Found during nubs-directed Seeker demo QA.