### PR TITLE
fix(process): block retired evidence markdown links

### DIFF
--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -27,6 +27,7 @@ export const SURFACE_ARTIFACT_ROW_IDS = [
 ];
 
 const MARKER_RE = /<!--\s*evidence-row:([a-z0-9-]+)\s*-->/gi;
+const RETIRED_ISSUE_EVIDENCE_RE = /\.github\/issue-evidence\/\S+/i;
 
 export function parseLabels(value) {
   if (Array.isArray(value)) {
@@ -55,7 +56,14 @@ export function hasNaWithReason(text) {
 }
 
 export function hasArtifactReference(text) {
-  if (/\[[^\]]+\]\(\s*\S+\s*\)/.test(text)) return true;
+  const markdownLinks = [
+    ...String(text ?? "").matchAll(/\[[^\]]+\]\(\s*(\S+)\s*\)/g),
+  ];
+  if (
+    markdownLinks.some((match) => !RETIRED_ISSUE_EVIDENCE_RE.test(match[1]))
+  ) {
+    return true;
+  }
   if (/https?:\/\/\S+/i.test(text)) return true;
   if (
     /user-images\.githubusercontent\.com|github\.com\/[^)\s]+\/assets\//i.test(
@@ -355,8 +363,8 @@ function main() {
     const bad = findings.filter((finding) => finding.status !== "ok");
     console.error(
       `\nEvidence gate FAILED: ${bad.length} row(s) blank or missing. ` +
-        "Attach an artifact link/path or write `N/A - <reason>` on each row. " +
-        "For ui/frontend/native PRs, before/after screenshots and walkthrough video require concrete artifact links/paths. " +
+        "Attach the artifact inline (GitHub attachment URL) or write `N/A - <reason>` on each row. " +
+        "For ui/frontend/native PRs, before/after screenshots and walkthrough video require concrete inline artifact links. " +
         "Retired `.github/issue-evidence/...` repo paths do not count as evidence.",
     );
     process.exit(1);

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -211,6 +211,10 @@ describe("check-pr-evidence row primitives", () => {
       ),
       false,
     );
+    assert.equal(
+      hasArtifactReference("[proof](.github/issue-evidence/13676-a.png)"),
+      false,
+    );
     const { ok, findings } = evaluatePrEvidence(
       buildBody({
         "backend-logs":


### PR DESCRIPTION
# Relates to

Follow-up to #14340 / #14431. The base PR stopped accepting bare `.github/issue-evidence/...` paths, but markdown links like `[proof](.github/issue-evidence/foo.png)` still passed because markdown was accepted before the retired-path check.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# What Changed

- Rejects retired `.github/issue-evidence/...` targets when they are wrapped in markdown links.
- Updates the evidence gate failure copy to say inline GitHub attachment URL instead of artifact path.
- Adds a unit assertion for `[proof](.github/issue-evidence/13676-a.png)` returning false.

# Testing

<details><summary><code>node scripts/check-pr-evidence.mjs --self-test</code></summary>

```text
check-pr-evidence self-test passed (8 cases).
```

</details>

<details><summary><code>bun test scripts/check-pr-evidence.test.mjs</code></summary>

```text
23 pass
0 fail
Ran 23 tests across 1 file.
```

</details>

<details><summary><code>bunx @biomejs/biome check scripts/check-pr-evidence.mjs scripts/check-pr-evidence.test.mjs</code></summary>

```text
Checked 2 files in 120ms. No fixes applied.
```

</details>

<details><summary>Planted retired path body fails; user-attachment body passes</summary>

```text
Evidence gate FAILED: 1 row(s) blank or missing. Attach the artifact inline (GitHub attachment URL) or write `N/A - <reason>` on each row. For ui/frontend/native PRs, before/after screenshots and walkthrough video require concrete inline artifact links. Retired `.github/issue-evidence/...` repo paths do not count as evidence.
...
"backend-logs", "status": "blank"
...
Evidence gate passed: all required rows satisfied.
planted retired-path exit=1; planted user-attachment exit=0
```

</details>

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots `N/A - CLI evidence-gate parser change with no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots `N/A - CLI evidence-gate parser change with no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - CLI evidence-gate parser change; behavior is proven by terminal pass/fail fixtures above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend service path changed`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend surface changed`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no DB/memory/scheduled-task/wallet/file artifacts produced`.

# Known Gaps / Failures

`bun run verify` was not run for this narrow two-file CLI parser hardening; focused parser tests, self-test, planted pass/fail fixtures, and Biome passed.
