### PR TITLE
feat(testing): HITL inventory + runner skeleton + non-destructive onboarding replay (part of #14381, #14382)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -720,6 +720,8 @@ docs/*
 !docs/tee-architecture-implementation-plan.md
 !docs/security/
 !docs/security/**
+!docs/testing/
+!docs/testing/**
 !docs/transcripts/
 !docs/transcripts/**
 yolov8n.pt

--- a/docs/testing/hitl-inventory.md
+++ b/docs/testing/hitl-inventory.md
@@ -1,0 +1,124 @@
+# Human-in-the-Loop (HITL) test inventory
+
+> Part of #14381 (HITL inventory / developer-facing runner), split from the
+> device-review rollup #14317 / #14395. Companion: #14382 (resettable
+> onboarding). Plugs into the existing evidence loop
+> (`scripts/e2e-recordings/*` → contact sheets → viewer) and nubs'
+> `launch-qa` board — this does **not** replace the device passes, it tells a
+> developer *which* things a human/device still has to eyeball and pre-stages
+> the frames so the review is a contact-sheet skim, not a manual drive.
+
+## What "HITL" means here
+
+A flow is HITL when an automated assertion **cannot** decide pass/fail — the
+signal lives in a human's eye, thumb, ear, or a real device capability the
+headless runner can't fake:
+
+- **Visual polish** — clipping, overflow, contrast, spacing, safe-area,
+  leaked error strings. A DOM node can *exist* and still look broken.
+- **Gesture / motion feel** — scroll momentum, sheet detents, drag, long-press,
+  frame glitches. "It renders" ≠ "it feels right."
+- **Keyboard behavior** — soft-keyboard push/resize, focus retention, IME,
+  input obscuring on real mobile.
+- **Onboarding** — first impression, copy, pacing; historically untestable
+  because you can't reset a real, memory-laden agent (→ #14382).
+- **Login / auth** — real OAuth round-trip, tenant, token, redirect. Injected
+  state proves nothing (FLEET.md ban; qa-agent's staging-401 lesson).
+- **Wallet** — real signing, balances, "not found" / error copy (#14426).
+- **Notifications** — permission prompt, delivery, tap-through.
+- **Camera / mic** — real permission grant + capture feel.
+
+## Coverage legend
+
+| Mark | Meaning |
+|---|---|
+| ✅ auto | Fully machine-decidable; e2e asserts it, no human needed |
+| 🟡 frame | Headless can **stage + screenshot** the state; a human judges the frame |
+| 🔴 device | Needs a **real device** capability (soft keyboard, wallet, camera, push) |
+| ⛔ none | No current coverage; manual-only today |
+
+## Inventory
+
+### Onboarding
+
+| Flow / decision point | Why HITL | Current coverage | What a harness can pre-stage |
+|---|---|---|---|
+| First-run welcome + name/style pick | first impression, copy, pacing | 🟡 frame — `packages/ui` first-run e2e + `test:ftu-home-e2e`; `capture-android-emu` / `capture-ios-sim` drive the real Capacitor onboarding | contact-sheet of each step (welcome → name → style → provider → complete) via the replay entry (#14382) so a fully-onboarded dev can re-walk it without a wipe |
+| Provider / model selection | catalog correctness + visual density | 🟡 frame — first-run options e2e | screenshot of the provider grid at each viewport |
+| Boot-trouble-speaks-in-chat (no banners) | tone / does the copy read right | 🟡 frame — `App.chat-overlay-first-run.test.tsx`, #14168 detent work | staged error card frame |
+| Onboarding **persists** across restart | correctness (not visual) | ✅ auto — `first-run-persistence.restart.test.ts` (real `saveElizaConfig`/`loadElizaConfig`) | n/a (already machine-decided) |
+| Onboarding **re-runnable** on a real agent | can't reset without nuking memories | ⛔ none → **#14382 slice in this PR** | dev-gated `?onboarding-replay=1` client overlay (no server wipe) |
+
+### First chat
+
+| Flow / decision point | Why HITL | Current coverage | What a harness can pre-stage |
+|---|---|---|---|
+| First message send → streamed reply | live inference + feel | 🟡 frame — app `test:e2e` chat suite (stubbed); real inference needs credits (see #14424 credit path) | staged send + streamed-token frames; a human confirms cadence |
+| Suggestions / FTU home widgets | visual + relevance | 🟡 frame — `test:suggestions-e2e`, `test:ftu-home-e2e` | rest + populated frames |
+| Chat scroll / infinite scroll / momentum | gesture feel | 🟡 frame — `test:chat-scroll-web-e2e`, `test:chat-infinite-scroll-e2e`, `test:chat-perf-gate`; scroll **cert** superset #14380 | scroll-position + perf-gate frames |
+| Chat sheet detents / frame glitch | motion feel | 🟡 frame — `test:chat-sheet-e2e`, `test:chat-sheet-frame-glitch-e2e`, `test:chatux-gesture-e2e` | detent-state frames |
+
+### Login / auth
+
+| Flow / decision point | Why HITL | Current coverage | What a harness can pre-stage |
+|---|---|---|---|
+| Cloud sign-in (OAuth round-trip) | real token/tenant/redirect | 🟡 frame — `cloud-e2e` mock login; **real** sign-in is device-only (#13609, #13611, #13610) | mock-login contact sheet; real login stays 🔴 device |
+| Stale-token / no-credits resume (spam guard) | correctness + no visual spam | ✅ auto — `use-first-run-conductor.test.ts` (#14387 / PR #14423) | n/a |
+| Staging tenant correctness | env-bake correctness | ✅ auto (process) — FLEET.md rule + qa-agent SW fix #14409 | n/a |
+
+### Wallet
+
+| Flow / decision point | Why HITL | Current coverage | What a harness can pre-stage |
+|---|---|---|---|
+| Wallet view render | leaked "Not found" red string (#14426, P1) | 🟡 frame | staged wallet-empty + wallet-populated frames so the leak is obvious on the sheet |
+| Real signing / balances | real key material | 🔴 device — `platform/e2e-wallet.ts` stub only | n/a headless |
+
+### Notifications / camera / mic
+
+| Flow / decision point | Why HITL | Current coverage | What a harness can pre-stage |
+|---|---|---|---|
+| Permission priming prompt | copy + timing | 🟡 frame — `test:permission-priming-e2e` | priming-prompt frame |
+| Mic permission (first-run) | real grant + capture | 🔴 device — `use-microphone-permission.ts` | n/a headless |
+| Push delivery + tap-through | real device push | 🔴 device — Seeker pass (qa-agent) | n/a headless |
+
+### Visual polish (cross-cutting launch-qa)
+
+| Issue | Why HITL | Coverage | Pre-stage |
+|---|---|---|---|
+| #14427 launcher 'Relationships' label clips | pixel clipping | 🟡 frame | launcher tile frame at each width |
+| #14426 wallet red 'Not found' leak (P1) | error-string leak | 🟡 frame | wallet frame |
+| #14425 'when this Mac is asleep' on non-Mac | platform copy | 🟡 frame | CloudOverview frame on non-mac env |
+| #14380 scroll + tap-target cert | gesture + hit-area | 🟡 frame — superset harness (sibling sol lane) | per-widget scroll/tap frames |
+| #14379 mobile chat/search keyboard states | soft-keyboard | 🔴 device | n/a headless — real-device cert |
+
+## How the runner surfaces this (design)
+
+The runner does **not** invent a new capture stack. It:
+
+1. Selects the **HITL subset** of `UI_E2E_SUITES` relevant to a decision point
+   (onboarding / first-chat / login) via a tag manifest
+   (`scripts/hitl/hitl-manifest.mjs`).
+2. Runs them through the existing `e2e-recordings` pipeline (record → extract
+   frames → `generate-contact-sheets` → `generate-viewer`).
+3. Emits a **HITL contact sheet** where each staged frame is labelled with its
+   decision point + a `pass / fail / blocked` slot, so a developer reviews a
+   sheet *during* development instead of driving the app by hand or waiting for
+   a post-merge device pass.
+
+Pass/fail/blocked is recorded by the human in the viewer; 🔴 device rows are
+marked `blocked (device)` automatically and routed to the Seeker pass
+(qa-agent) rather than pretending headless covered them. **Auth/wallet/real
+inference use real flows only** (FLEET.md) — the harness stages the *mockable*
+frames and explicitly defers the rest to device, never fabricates state as
+evidence.
+
+## Non-goals / honesty
+
+- The `packages/ui` e2e env is known-flaky; this inventory marks what *can*
+  run headless (🟡) vs what genuinely needs a device (🔴). It does not claim
+  headless coverage where only a device suffices.
+- This is the inventory + the onboarding-replay slice + a harness skeleton.
+  Wiring every 🟡 row into the tagged sheet and the full launch-qa board
+  labelling is follow-up (tracked on #14381).
+
+— [sol-orch]

--- a/packages/ui/src/platform/index.ts
+++ b/packages/ui/src/platform/index.ts
@@ -23,6 +23,7 @@ export {
 export * from "./cloud-preference-patch";
 export * from "./desktop-permissions-client";
 export * from "./first-run-reset";
+export * from "./onboarding-replay";
 export {
   canHostLocalAgent,
   canRunLocal,

--- a/packages/ui/src/platform/onboarding-replay.test.ts
+++ b/packages/ui/src/platform/onboarding-replay.test.ts
@@ -1,0 +1,199 @@
+/**
+ * #14382 — proves the dev-gated onboarding replay is NON-DESTRUCTIVE.
+ *
+ * The whole point of this mechanism is that a developer can re-run onboarding
+ * on a real, memory-laden agent WITHOUT the destructive `POST /api/agent/reset`
+ * (which wipes the PGlite data dir — conversations/knowledge/trajectories).
+ * These tests lock that guarantee: the replay must NEVER call a delete/reset,
+ * NEVER clear the persisted active-server, and must restore the client verbatim
+ * on uninstall. It also must be compiled out (inert) in prod builds.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  armOnboardingReplay,
+  isOnboardingReplayRequested,
+  isOnboardingReplaySupported,
+  ONBOARDING_REPLAY_QUERY_PARAM,
+} from "./onboarding-replay";
+import type { FirstRunClientLike } from "./types";
+
+/**
+ * A spy client that records EVERY method touched. If the replay ever reaches
+ * for a destructive method, these spies fire and the test fails.
+ */
+function makeSpyClient() {
+  const originalGetConfig = vi.fn(async () => ({
+    meta: { firstRunComplete: true },
+    agentName: "Real Agent",
+  }));
+  const originalGetFirstRunStatus = vi.fn(async () => ({ complete: true }));
+  const originalSubmitFirstRun = vi.fn(async () => ({ ok: true }));
+
+  // Destructive methods that MUST NOT be invoked by a replay.
+  const deleteAgent = vi.fn(async () => ({ ok: true }));
+  const resetAgent = vi.fn(async () => ({ ok: true }));
+  const clearMemories = vi.fn(async () => ({ ok: true }));
+
+  const client = {
+    getConfig: originalGetConfig,
+    getFirstRunStatus: originalGetFirstRunStatus,
+    submitFirstRun: originalSubmitFirstRun,
+    // Present so we can assert they are never called.
+    deleteAgent,
+    resetAgent,
+    clearMemories,
+  } as unknown as FirstRunClientLike & {
+    deleteAgent: typeof deleteAgent;
+    resetAgent: typeof resetAgent;
+    clearMemories: typeof clearMemories;
+  };
+
+  return {
+    client,
+    originalGetConfig,
+    originalGetFirstRunStatus,
+    originalSubmitFirstRun,
+    deleteAgent,
+    resetAgent,
+    clearMemories,
+  };
+}
+
+function urlWithReplay(): URL {
+  return new URL(`https://dev.local/?${ONBOARDING_REPLAY_QUERY_PARAM}=1`);
+}
+
+describe("onboarding-replay (dev-gated, non-destructive)", () => {
+  beforeEach(() => {
+    vi.stubEnv("DEV", true);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("is inert in a prod build (no replay even with the query param)", () => {
+    vi.stubEnv("DEV", false);
+    expect(isOnboardingReplaySupported()).toBe(false);
+    expect(isOnboardingReplayRequested(urlWithReplay())).toBe(false);
+
+    const { client } = makeSpyClient();
+    const handle = armOnboardingReplay(client, { url: urlWithReplay() });
+    expect(handle.active).toBe(false);
+  });
+
+  it("does not arm without the query param", () => {
+    const { client } = makeSpyClient();
+    const handle = armOnboardingReplay(client, {
+      url: new URL("https://dev.local/"),
+    });
+    expect(handle.active).toBe(false);
+  });
+
+  it("arms in dev with ?onboarding-replay=1 and reports fresh WITHOUT any destructive call", async () => {
+    const spies = makeSpyClient();
+    const handle = armOnboardingReplay(spies.client, { url: urlWithReplay() });
+
+    expect(handle.active).toBe(true);
+
+    // Overlay makes the client REPORT fresh...
+    const status = await spies.client.getFirstRunStatus();
+    expect(status.complete).toBe(false);
+    const config = await spies.client.getConfig();
+    expect(config).toEqual({});
+
+    // ...but NEVER calls anything destructive.
+    expect(spies.deleteAgent).not.toHaveBeenCalled();
+    expect(spies.resetAgent).not.toHaveBeenCalled();
+    expect(spies.clearMemories).not.toHaveBeenCalled();
+
+    handle.uninstall();
+  });
+
+  it("never clears the persisted active-server (unlike ?reset)", () => {
+    const removed: string[] = [];
+    const storage = {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: (k: string) => {
+        removed.push(k);
+      },
+    };
+
+    const { client } = makeSpyClient();
+    const handle = armOnboardingReplay(client, {
+      url: urlWithReplay(),
+      storage,
+    });
+    expect(handle.active).toBe(true);
+
+    // The active-server key must NEVER be removed by the replay path.
+    expect(removed).not.toContain("elizaos:active-server");
+    handle.uninstall();
+  });
+
+  it("never touches the durable force-fresh restore key (uses ephemeral storage)", async () => {
+    const touchedKeys: string[] = [];
+    const storage = {
+      getItem: () => null,
+      setItem: (k: string) => {
+        touchedKeys.push(k);
+      },
+      removeItem: (k: string) => {
+        touchedKeys.push(k);
+      },
+    };
+
+    const { client } = makeSpyClient();
+    // Drive the overlay methods so any storage write would surface.
+    const handle = armOnboardingReplay(client, {
+      url: urlWithReplay(),
+      storage,
+    });
+    await client.getFirstRunStatus();
+    await client.getConfig();
+    handle.uninstall();
+
+    // The durable restore key must never be written via the passed-in storage.
+    expect(touchedKeys).not.toContain("elizaos:first-run:force-fresh");
+  });
+
+  it("restores the client verbatim on uninstall (real agent unchanged after replay)", async () => {
+    const spies = makeSpyClient();
+
+    const handle = armOnboardingReplay(spies.client, { url: urlWithReplay() });
+    expect(handle.active).toBe(true);
+
+    // During replay: reports fresh.
+    expect((await spies.client.getFirstRunStatus()).complete).toBe(false);
+
+    handle.uninstall();
+
+    // After uninstall: the REAL methods answer again — agent is exactly as it
+    // was, still complete, real config intact, no data destroyed.
+    const status = await spies.client.getFirstRunStatus();
+    expect(status.complete).toBe(true);
+    const config = await spies.client.getConfig();
+    expect(config).toMatchObject({ agentName: "Real Agent" });
+
+    // Still no destructive call across the whole lifecycle.
+    expect(spies.deleteAgent).not.toHaveBeenCalled();
+    expect(spies.resetAgent).not.toHaveBeenCalled();
+    expect(spies.clearMemories).not.toHaveBeenCalled();
+  });
+
+  it("submitting the replay onboarding lifts the overlay without deleting anything", async () => {
+    const spies = makeSpyClient();
+    const handle = armOnboardingReplay(spies.client, { url: urlWithReplay() });
+
+    // Simulate the user finishing the replayed onboarding.
+    await spies.client.submitFirstRun({} as never);
+    // The real submit ran exactly once (the overlay wraps, not replaces).
+    expect(spies.originalSubmitFirstRun).toHaveBeenCalledTimes(1);
+    // And still nothing destructive.
+    expect(spies.deleteAgent).not.toHaveBeenCalled();
+    expect(spies.resetAgent).not.toHaveBeenCalled();
+
+    handle.uninstall();
+  });
+});

--- a/packages/ui/src/platform/onboarding-replay.ts
+++ b/packages/ui/src/platform/onboarding-replay.ts
@@ -1,0 +1,178 @@
+/**
+ * Dev-gated onboarding replay (#14382).
+ *
+ * **Problem:** a fully-onboarded agent can't re-run onboarding for QA without
+ * `POST /api/agent/reset`, which is *destructive* — it calls
+ * `clearCompatPgliteDataDir` and wipes conversations, knowledge, and
+ * trajectories (see `packages/app-core/src/api/server.ts` agent-reset hop). So
+ * developers simply never re-test onboarding on their real agent.
+ *
+ * **This mechanism** re-runs onboarding **without touching any server state**:
+ * it installs the existing, already-tested non-destructive client overlay
+ * (`installForceFreshFirstRunClientPatch`) which makes the client *report*
+ * `firstRunStatus.complete = false` and `getConfig() = {}` for the duration of
+ * the replay. The real `eliza.json`, the PGlite data dir, and all memories are
+ * untouched — nothing is deleted, no reset endpoint is called. When the replay
+ * onboarding is submitted (or the flag is dropped), the overlay lifts and the
+ * real agent is exactly as it was.
+ *
+ * **Safety invariants (enforced + tested in `onboarding-replay.test.ts`):**
+ *  1. Gated to dev builds only (`import.meta.env.DEV`) — never active in prod.
+ *  2. Never calls `client.deleteAgent` / `POST /api/agent/reset` / any wipe.
+ *  3. Never clears the persisted active-server (unlike the `?reset` escape
+ *     hatch) — the replay points at the *same* real agent, it just re-shows
+ *     onboarding on top of it.
+ *  4. Purely additive overlay: uninstalling it restores the original client
+ *     methods verbatim.
+ *
+ * **Entry:** append `?onboarding-replay=1` to the dev URL. This is intentionally
+ * distinct from the destructive `?reset` param (which clears active-server and
+ * force-fresh flags) — replay is the *safe* path for QA on a real agent.
+ *
+ * **On submit:** walking the replayed onboarding is fully non-destructive. If a
+ * developer *submits* the replayed onboarding, the real `submitFirstRun` runs
+ * (that's the point — it exercises the full flow), which re-applies the chosen
+ * onboarding *config* to the agent. That updates onboarding config only; it does
+ * NOT delete the PGlite data dir / conversations / knowledge — those are wiped
+ * exclusively by `POST /api/agent/reset`, which this mechanism never calls. To
+ * inspect without applying, walk the steps and drop the flag before submitting.
+ */
+
+import {
+  enableForceFreshFirstRun,
+  installForceFreshFirstRunClientPatch,
+} from "./first-run-reset";
+import type { FirstRunClientLike, StorageLike } from "./types";
+
+export const ONBOARDING_REPLAY_QUERY_PARAM = "onboarding-replay";
+
+/** In-memory replay flag key (session-scoped; NOT the durable force-fresh key). */
+const REPLAY_SESSION_KEY = "elizaos:onboarding-replay:active";
+
+/**
+ * True only in a dev build. Prod bundles set `import.meta.env.DEV` to `false`,
+ * so this whole mechanism is compiled out of the user-facing surface.
+ */
+export function isOnboardingReplaySupported(): boolean {
+  try {
+    return Boolean(import.meta.env?.DEV);
+  } catch {
+    return false;
+  }
+}
+
+function getSearchParams(url?: URL | null): URLSearchParams | null {
+  if (url) {
+    return url.searchParams;
+  }
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return new URLSearchParams(
+    window.location.search || window.location.hash.split("?")[1] || "",
+  );
+}
+
+/**
+ * True when the current URL requests an onboarding replay AND the build allows
+ * it. Prod builds always return false regardless of the query param.
+ */
+export function isOnboardingReplayRequested(url?: URL | null): boolean {
+  if (!isOnboardingReplaySupported()) {
+    return false;
+  }
+  const params = getSearchParams(url);
+  if (!params) {
+    return false;
+  }
+  const raw = params.get(ONBOARDING_REPLAY_QUERY_PARAM);
+  return raw === "1" || raw === "true";
+}
+
+/**
+ * Result of arming a replay. `active: false` means the replay was not requested
+ * or not supported (prod) — the caller should do nothing. When `active: true`,
+ * `uninstall()` lifts the overlay and restores the real client verbatim.
+ */
+export interface OnboardingReplayHandle {
+  active: boolean;
+  uninstall: () => void;
+}
+
+const NOOP_HANDLE: OnboardingReplayHandle = {
+  active: false,
+  uninstall: () => {},
+};
+
+/**
+ * Arms a non-destructive onboarding replay if requested by the URL and allowed
+ * by the build. Composes the existing force-fresh client overlay; performs NO
+ * destructive action (no reset endpoint, no active-server clear, no storage
+ * wipe). Returns a handle whose `uninstall()` fully restores the client.
+ *
+ * @param client the first-run-capable API client to overlay
+ * @param opts.url  optional URL (defaults to `window.location`)
+ * @param opts.storage optional storage shim (defaults to `window.localStorage`)
+ */
+export function armOnboardingReplay(
+  client: FirstRunClientLike,
+  opts?: { url?: URL | null; storage?: StorageLike | null },
+): OnboardingReplayHandle {
+  if (!isOnboardingReplayRequested(opts?.url)) {
+    return NOOP_HANDLE;
+  }
+
+  // Mark the session as in-replay for any UI that wants a "replay" badge.
+  // Session-scoped and best-effort: never durable, never a prod footgun.
+  try {
+    const storage =
+      opts?.storage ??
+      (typeof window !== "undefined" ? window.sessionStorage : null);
+    storage?.setItem(REPLAY_SESSION_KEY, "1");
+  } catch {
+    // Ignore storage failures — the overlay is the source of truth.
+  }
+
+  // Deliberately use a throwaway storage so the overlay's force-fresh read/write
+  // is scoped to replay and never mutates the durable
+  // `elizaos:first-run:force-fresh` restore key used by the ?reset path. Enable
+  // the flag in that ephemeral storage so the overlay actually reports fresh.
+  const ephemeralStorage = createEphemeralStorage();
+  enableForceFreshFirstRun(ephemeralStorage);
+  const uninstallPatch = installForceFreshFirstRunClientPatch(
+    client,
+    ephemeralStorage,
+  );
+
+  return {
+    active: true,
+    uninstall: () => {
+      uninstallPatch();
+      try {
+        const storage =
+          opts?.storage ??
+          (typeof window !== "undefined" ? window.sessionStorage : null);
+        storage?.removeItem(REPLAY_SESSION_KEY);
+      } catch {
+        // Ignore.
+      }
+    },
+  };
+}
+
+/**
+ * A tiny in-memory `StorageLike` so the replay overlay's internal force-fresh
+ * flag never touches real localStorage / the durable restore path.
+ */
+function createEphemeralStorage(): StorageLike {
+  const map = new Map<string, string>();
+  return {
+    getItem: (k) => (map.has(k) ? (map.get(k) as string) : null),
+    setItem: (k, v) => {
+      map.set(k, String(v));
+    },
+    removeItem: (k) => {
+      map.delete(k);
+    },
+  };
+}

--- a/scripts/hitl/hitl-manifest.mjs
+++ b/scripts/hitl/hitl-manifest.mjs
@@ -1,0 +1,176 @@
+/**
+ * HITL manifest (#14381).
+ *
+ * Maps human-decision points to the EXISTING e2e recording suites
+ * (`scripts/e2e-recordings/suites.mjs`) that stage the frames a human must
+ * eyeball. This is the tag layer the runner uses to select the onboarding /
+ * first-chat / login subset and to know which decision points are only
+ * satisfiable on a real device (routed to the Seeker pass, not faked headless).
+ *
+ * Marks:
+ *   frame  — headless can stage + screenshot the state; human judges the frame
+ *   device — needs a real device capability; NOT covered headless
+ *   auto   — machine-decidable; listed for completeness, no human needed
+ *
+ * See docs/testing/hitl-inventory.md for the full rationale per row.
+ */
+
+/** @typedef {"frame"|"device"|"auto"} HitlMark */
+
+/**
+ * @typedef {Object} HitlDecisionPoint
+ * @property {string} id           stable id for the decision point
+ * @property {string} group        onboarding | first-chat | login | wallet | notifications | visual
+ * @property {string} label        human-readable
+ * @property {HitlMark} mark
+ * @property {string} why          why a human/device is required
+ * @property {string[]} suites     UI_E2E_SUITES names that stage this (empty if device-only)
+ * @property {string[]} [scripts]  specific package test scripts that stage frames
+ * @property {number[]} [issues]   related GitHub issues
+ */
+
+/** @type {HitlDecisionPoint[]} */
+export const HITL_DECISION_POINTS = [
+  // ── Onboarding ──────────────────────────────────────────────────────────
+  {
+    id: "onboarding-welcome",
+    group: "onboarding",
+    label: "First-run welcome + name/style pick",
+    mark: "frame",
+    why: "first impression, copy, pacing — not machine-decidable",
+    suites: ["app", "android-emu", "ios-sim"],
+    scripts: ["test:ftu-home-e2e"],
+    issues: [14382, 14168],
+  },
+  {
+    id: "onboarding-provider",
+    group: "onboarding",
+    label: "Provider / model selection grid",
+    mark: "frame",
+    why: "catalog correctness + visual density",
+    suites: ["app"],
+    issues: [14382],
+  },
+  {
+    id: "onboarding-replay",
+    group: "onboarding",
+    label: "Re-run onboarding on a real agent (no wipe)",
+    mark: "frame",
+    why: "historically impossible without nuking memories — see the dev-gated replay entry",
+    suites: ["app"],
+    issues: [14382],
+  },
+  {
+    id: "onboarding-persist",
+    group: "onboarding",
+    label: "Onboarding persists across restart",
+    mark: "auto",
+    why: "machine-decided by first-run-persistence.restart.test.ts",
+    suites: [],
+    issues: [14382],
+  },
+
+  // ── First chat ──────────────────────────────────────────────────────────
+  {
+    id: "first-chat-send",
+    group: "first-chat",
+    label: "First message send → streamed reply",
+    mark: "frame",
+    why: "cadence/feel; real inference needs credits (stubbed frames here)",
+    suites: ["app"],
+    issues: [14424],
+  },
+  {
+    id: "first-chat-suggestions",
+    group: "first-chat",
+    label: "Suggestions / FTU home widgets",
+    mark: "frame",
+    why: "visual + relevance",
+    suites: ["app"],
+    scripts: ["test:suggestions-e2e", "test:ftu-home-e2e"],
+  },
+  {
+    id: "first-chat-scroll",
+    group: "first-chat",
+    label: "Chat scroll / momentum / sheet detents",
+    mark: "frame",
+    why: "gesture feel",
+    suites: ["app"],
+    scripts: [
+      "test:chat-scroll-web-e2e",
+      "test:chat-sheet-e2e",
+      "test:chatux-gesture-e2e",
+    ],
+    issues: [14380],
+  },
+
+  // ── Login / auth ────────────────────────────────────────────────────────
+  {
+    id: "login-cloud-mock",
+    group: "login",
+    label: "Cloud sign-in (mock OAuth round-trip)",
+    mark: "frame",
+    why: "mockable frames only; REAL sign-in is device-only per FLEET.md",
+    suites: ["cloud-e2e"],
+    issues: [13609],
+  },
+  {
+    id: "login-real-device",
+    group: "login",
+    label: "Real cloud sign-in golden path",
+    mark: "device",
+    why: "real OAuth/token/tenant — injected state is banned as evidence",
+    suites: [],
+    issues: [13611, 13610, 13609],
+  },
+  {
+    id: "login-stale-token-spam",
+    group: "login",
+    label: "Stale-token / no-credits resume spam guard",
+    mark: "auto",
+    why: "machine-decided by use-first-run-conductor.test.ts (#14387)",
+    suites: [],
+    issues: [14387],
+  },
+
+  // ── Wallet / notifications (mostly device) ──────────────────────────────
+  {
+    id: "wallet-empty-render",
+    group: "wallet",
+    label: "Wallet view render (no leaked 'Not found')",
+    mark: "frame",
+    why: "error-string leak visible only to the eye (#14426)",
+    suites: ["app"],
+    issues: [14426],
+  },
+  {
+    id: "notifications-priming",
+    group: "notifications",
+    label: "Permission priming prompt",
+    mark: "frame",
+    why: "copy + timing",
+    suites: ["app"],
+    scripts: ["test:permission-priming-e2e"],
+  },
+];
+
+/** The core golden-path groups this session's harness targets. */
+export const HITL_GOLDEN_GROUPS = ["onboarding", "first-chat", "login"];
+
+/** All e2e suite names referenced by frame-mark decision points (dedup). */
+export function hitlFrameSuites(groups = HITL_GOLDEN_GROUPS) {
+  const names = new Set();
+  for (const dp of HITL_DECISION_POINTS) {
+    if (dp.mark !== "frame") continue;
+    if (groups && !groups.includes(dp.group)) continue;
+    for (const s of dp.suites) names.add(s);
+  }
+  return [...names];
+}
+
+/** Decision points that are device-only (routed to the Seeker pass, not faked). */
+export function hitlDeviceOnly(groups = HITL_GOLDEN_GROUPS) {
+  return HITL_DECISION_POINTS.filter(
+    (dp) => dp.mark === "device" && (!groups || groups.includes(dp.group)),
+  );
+}

--- a/scripts/hitl/run-hitl.mjs
+++ b/scripts/hitl/run-hitl.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * run-hitl.mjs — HITL golden-path harness skeleton (#14381).
+ *
+ * Walks the onboarding → first-chat → login decision points and produces a
+ * HITL review packet: it drives the relevant EXISTING e2e recording suites
+ * (through `scripts/e2e-recordings/run-all.mjs`, which already extracts frames,
+ * builds contact sheets, and a viewer), then emits a `hitl-report.json` +
+ * `hitl-report.md` that labels each staged frame with its decision point and a
+ * pass / fail / blocked slot — so a developer skims a contact sheet during
+ * development instead of manually driving the app or waiting for a device pass.
+ *
+ * It does NOT reinvent capture. Device-only decision points (real login,
+ * wallet signing, push) are emitted as `blocked (device)` and routed to the
+ * Seeker pass rather than faked headless.
+ *
+ * Usage:
+ *   node scripts/hitl/run-hitl.mjs                # plan + report from existing recordings
+ *   node scripts/hitl/run-hitl.mjs --record       # also (re)run the frame suites first
+ *   node scripts/hitl/run-hitl.mjs --groups=onboarding,login
+ *   node scripts/hitl/run-hitl.mjs --out=<dir>
+ *
+ * Honesty: the packages/ui e2e env is known-flaky. `--record` best-efforts the
+ * suites and reports which ran / skipped / failed; the report is still emitted
+ * from whatever frames exist so a partial run is still reviewable.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  HITL_DECISION_POINTS,
+  HITL_GOLDEN_GROUPS,
+  hitlDeviceOnly,
+  hitlFrameSuites,
+} from "./hitl-manifest.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const RECORDINGS_DIR = path.join(REPO_ROOT, "e2e-recordings");
+
+// ── args ────────────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const flags = new Map();
+for (const a of args) {
+  const [k, v] = a.replace(/^--/, "").split("=");
+  flags.set(k, v ?? true);
+}
+const doRecord = flags.get("record") === true || flags.get("record") === "true";
+const groups = flags.has("groups")
+  ? String(flags.get("groups"))
+      .split(",")
+      .map((s) => s.trim())
+  : HITL_GOLDEN_GROUPS;
+const outDir = flags.has("out")
+  ? path.resolve(String(flags.get("out")))
+  : path.join(RECORDINGS_DIR, "hitl");
+
+function log(...m) {
+  console.log("[hitl]", ...m);
+}
+
+// ── plan ──────────────────────────────────────────────────────────────────
+const frameSuites = hitlFrameSuites(groups);
+const deviceOnly = hitlDeviceOnly(groups);
+const framePoints = HITL_DECISION_POINTS.filter(
+  (dp) => dp.mark === "frame" && groups.includes(dp.group),
+);
+const autoPoints = HITL_DECISION_POINTS.filter(
+  (dp) => dp.mark === "auto" && groups.includes(dp.group),
+);
+
+log(`groups: ${groups.join(", ")}`);
+log(
+  `frame decision points: ${framePoints.length} (suites: ${frameSuites.join(", ") || "none"})`,
+);
+log(`device-only (blocked, routed to Seeker): ${deviceOnly.length}`);
+log(`auto (machine-decided, no human): ${autoPoints.length}`);
+
+// ── optionally (re)run the frame suites through the existing pipeline ────────
+const recordResult = { attempted: false, ran: [], failed: [], skipped: [] };
+if (doRecord && frameSuites.length) {
+  recordResult.attempted = true;
+  const runAll = path.join(
+    REPO_ROOT,
+    "scripts",
+    "e2e-recordings",
+    "run-all.mjs",
+  );
+  log(
+    `recording frame suites via ${path.relative(REPO_ROOT, runAll)} --packages=${frameSuites.join(",")}`,
+  );
+  const res = spawnSync(
+    "node",
+    [runAll, `--packages=${frameSuites.join(",")}`],
+    { cwd: REPO_ROOT, stdio: "inherit", env: process.env },
+  );
+  // run-all uses exit code 77 for "skipped" per its contract.
+  if (res.status === 0) recordResult.ran = frameSuites;
+  else if (res.status === 77) recordResult.skipped = frameSuites;
+  else recordResult.failed = frameSuites;
+  log(`record exit=${res.status ?? "signal:" + res.signal}`);
+} else if (doRecord) {
+  log("no frame suites for the selected groups — nothing to record");
+}
+
+// ── collect whatever frames exist (partial runs still reviewable) ────────────
+function readManifest() {
+  const p = path.join(RECORDINGS_DIR, "manifest.json");
+  if (!fs.existsSync(p)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+}
+const manifest = readManifest();
+const haveContactSheets = fs.existsSync(
+  path.join(RECORDINGS_DIR, "contact-sheets"),
+);
+
+// ── build the HITL review packet ─────────────────────────────────────────────
+const report = {
+  generatedAt: new Date().toISOString(),
+  groups,
+  record: recordResult,
+  contactSheetsPresent: haveContactSheets,
+  manifestPackages: manifest ? Object.keys(manifest).length : 0,
+  decisionPoints: [],
+};
+
+for (const dp of HITL_DECISION_POINTS) {
+  if (!groups.includes(dp.group)) continue;
+  let state;
+  if (dp.mark === "auto") state = "auto (no human needed)";
+  else if (dp.mark === "device") state = "blocked (device) → Seeker pass";
+  else
+    state = haveContactSheets
+      ? "review (frame staged)"
+      : "review (no frames yet — run --record)";
+  report.decisionPoints.push({
+    id: dp.id,
+    group: dp.group,
+    label: dp.label,
+    mark: dp.mark,
+    why: dp.why,
+    suites: dp.suites,
+    scripts: dp.scripts ?? [],
+    issues: dp.issues ?? [],
+    result: null, // human fills: pass | fail | blocked
+    state,
+  });
+}
+
+fs.mkdirSync(outDir, { recursive: true });
+const jsonPath = path.join(outDir, "hitl-report.json");
+fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2));
+
+// markdown review sheet (what a developer skims)
+const lines = [];
+lines.push("# HITL review sheet");
+lines.push("");
+lines.push(`Generated: ${report.generatedAt}`);
+lines.push(`Groups: ${groups.join(", ")}`);
+lines.push(
+  `Contact sheets: ${haveContactSheets ? "present (open e2e-recordings/viewer)" : "NOT present — run `node scripts/hitl/run-hitl.mjs --record`"}`,
+);
+lines.push("");
+lines.push("| # | Group | Decision point | Mark | Result (fill in) | State |");
+lines.push("|---|---|---|---|---|---|");
+report.decisionPoints.forEach((dp, i) => {
+  lines.push(
+    `| ${i + 1} | ${dp.group} | ${dp.label} | ${dp.mark} | ☐ pass ☐ fail ☐ blocked | ${dp.state} |`,
+  );
+});
+lines.push("");
+if (deviceOnly.length) {
+  lines.push("## Device-only (route to Seeker pass — not faked headless)");
+  for (const dp of deviceOnly) {
+    lines.push(
+      `- **${dp.label}** — ${dp.why} (issues: ${(dp.issues ?? []).map((n) => `#${n}`).join(", ") || "—"})`,
+    );
+  }
+  lines.push("");
+}
+lines.push("_See docs/testing/hitl-inventory.md for full rationale._");
+const mdPath = path.join(outDir, "hitl-report.md");
+fs.writeFileSync(mdPath, lines.join("\n") + "\n");
+
+log(`wrote ${path.relative(REPO_ROOT, jsonPath)}`);
+log(`wrote ${path.relative(REPO_ROOT, mdPath)}`);
+log(
+  `summary: ${report.decisionPoints.length} decision points ` +
+    `(${framePoints.length} frame / ${deviceOnly.length} device / ${autoPoints.length} auto)`,
+);
+
+// non-zero only if --record was asked and the suites hard-failed, so CI can gate
+// on capture health while a plan-only run always succeeds.
+if (recordResult.attempted && recordResult.failed.length) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## What

Part of **#14381** (HITL inventory + developer-facing runner) and **#14382** (resettable onboarding). Re-homed from **#14395** (closed as dup by @lalalune → split into these two).

Delivers the **inventory + runner skeleton + the onboarding-replay slice**. Plugs into the existing evidence loop (`scripts/e2e-recordings/*` → contact sheets → viewer) and nubs' `launch-qa` Seeker passes — this does **not** duplicate the device passes, it tells a developer *which* things a human/device still has to eyeball and pre-stages the frames.

## Inventory (#14381)
- **`docs/testing/hitl-inventory.md`** — every user-facing flow requiring human/device verification: flow → why HITL → current coverage → what a harness can pre-stage. Marks: `auto` (machine-decided) / `frame` (headless stages + screenshots, human judges) / `device` (real device only — routed to Seeker, never faked). Covers onboarding, first-chat, login, wallet (#14426), notifications, visual polish (#14427/#14425/#14380/#14379).
- **`scripts/hitl/hitl-manifest.mjs`** — maps decision points → existing e2e suites; tags device-only rows.
- **`scripts/hitl/run-hitl.mjs`** — walks onboarding→first-chat→login, drives the frame suites through the existing recording pipeline, emits `hitl-report.{json,md}` with a per-decision-point pass/fail/blocked review sheet. Device rows auto-marked `blocked (device) → Seeker`. Plan mode is deterministic; `--record` best-efforts the known-flaky ui e2e env and reports what ran/skipped/failed.

## Resettable onboarding (#14382)
- **`packages/ui/src/platform/onboarding-replay.ts`** — dev-gated **`?onboarding-replay=1`** entry composing the *existing* non-destructive force-fresh client overlay. Safety invariants (all tested):
  1. `import.meta.env.DEV`-gated → compiled inert in prod.
  2. **Never** calls `POST /api/agent/reset` (the only path that wipes the PGlite data dir — conversations/knowledge/trajectories).
  3. **Never** clears the persisted `elizaos:active-server` (unlike `?reset`) — replay points at the *same* real agent.
  4. Overlay's force-fresh flag lives in **ephemeral in-memory storage** → the durable restore key is never touched.
  5. Fully reversible — `uninstall()` restores the real client verbatim.
- **`onboarding-replay.test.ts`** — **7/7 green**, explicitly proving real agent data is untouched across the full replay lifecycle.

## Verify
- `onboarding-replay.test.ts` — **7 passed / 7**.
- `run-hitl.mjs` — emits `hitl-report.{json,md}` locally (10 decision points: 7 frame / 1 device / 2 auto).
- `bun run build:client` — **green, 104/104 tasks** (`@elizaos/app:build ✓`).
- `biome check` — clean on all touched files.

## Notes
- ⚠️ Touches first-run state-handling → **no auto-merge**, posted for review.
- Did **not** touch `use-first-run-conductor.ts` — nubs owns it in #14423 / #14387.
- Honest scope: wiring every `frame` row into the tagged sheet + full board labelling is follow-up on #14381.

— [sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - testing/HITL inventory and runner scaffolding; no shipped UI surface changed in this PR`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - testing/HITL inventory and runner scaffolding; no shipped UI surface changed in this PR`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - test harness/inventory change; no user-facing walkthrough flow changed`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend/runtime server code path changed`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend runtime code path changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent, prompt, provider, model, or action behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - test harness/inventory scaffolding; verification commands are listed in the PR body`.
