### PR TITLE
feat(app): add shared dev server scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,24 @@ Scope any command to one package with `--cwd`:
 `bun run --cwd packages/core test`. The repo has 188 root scripts; the list
 above is the day-to-day set. Use `bun run` with no args to print them all.
 
+### Shared dev server for parallel lanes
+
+When several worktrees are active on the same VPS, do **not** have every lane bind
+the default app UI port (`2138`). `packages/app` keeps `bun run dev` unchanged
+for single-lane local work, but concurrent agents should use the shared scripts:
+
+```bash
+cd packages/app
+bun run dev:shared   # long-lived Vite server on a deterministic worktree port
+bun run dev:status   # list running shared dev servers (port, worktree, pid)
+bun run dev:rebuild  # explicit Vite full-reload trigger for this worktree
+```
+
+Ports are reserved in `~/.eliza/dev-server-registry.json` (override with
+`ELIZA_DEV_SERVER_REGISTRY`) from the normalized worktree path, with registry
+locking and linear probing so active lanes do not collide. See
+[`packages/docs/development/shared-dev-server.md`](packages/docs/development/shared-dev-server.md).
+
 ### Removed Root Command Migrations
 
 | Removed command | Use instead |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,24 @@ Scope any command to one package with `--cwd`:
 `bun run --cwd packages/core test`. The repo has 188 root scripts; the list
 above is the day-to-day set. Use `bun run` with no args to print them all.
 
+### Shared dev server for parallel lanes
+
+When several worktrees are active on the same VPS, do **not** have every lane bind
+the default app UI port (`2138`). `packages/app` keeps `bun run dev` unchanged
+for single-lane local work, but concurrent agents should use the shared scripts:
+
+```bash
+cd packages/app
+bun run dev:shared   # long-lived Vite server on a deterministic worktree port
+bun run dev:status   # list running shared dev servers (port, worktree, pid)
+bun run dev:rebuild  # explicit Vite full-reload trigger for this worktree
+```
+
+Ports are reserved in `~/.eliza/dev-server-registry.json` (override with
+`ELIZA_DEV_SERVER_REGISTRY`) from the normalized worktree path, with registry
+locking and linear probing so active lanes do not collide. See
+[`packages/docs/development/shared-dev-server.md`](packages/docs/development/shared-dev-server.md).
+
 ### Removed Root Command Migrations
 
 | Removed command | Use instead |

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -75,6 +75,9 @@ All scripts from this package's `package.json`:
 
 ```bash
 bun run --cwd packages/app dev                        # Vite dev server (renderer only; UI port from ELIZA_UI_PORT, default 2138)
+bun run --cwd packages/app dev:shared                 # Shared long-lived Vite server on deterministic worktree port
+bun run --cwd packages/app dev:status                 # List running shared dev servers (port, worktree, pid)
+bun run --cwd packages/app dev:rebuild                # Trigger explicit Vite full reload for this worktree
 bun run --cwd packages/app build                      # Full app build (scripts/build.mjs)
 bun run --cwd packages/app build:web                  # Vite build only (no capacitor sync)
 bun run --cwd packages/app plugin:build               # Plugin-only build

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -75,6 +75,9 @@ All scripts from this package's `package.json`:
 
 ```bash
 bun run --cwd packages/app dev                        # Vite dev server (renderer only; UI port from ELIZA_UI_PORT, default 2138)
+bun run --cwd packages/app dev:shared                 # Shared long-lived Vite server on deterministic worktree port
+bun run --cwd packages/app dev:status                 # List running shared dev servers (port, worktree, pid)
+bun run --cwd packages/app dev:rebuild                # Trigger explicit Vite full reload for this worktree
 bun run --cwd packages/app build                      # Full app build (scripts/build.mjs)
 bun run --cwd packages/app build:web                  # Vite build only (no capacitor sync)
 bun run --cwd packages/app plugin:build               # Plugin-only build

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -113,7 +113,11 @@
     "predev": "node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --concepts --banners --background --background-videos",
     "prebuild": "node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --concepts --banners --background --background-videos",
     "capture:linux-desktop": "node scripts/capture-linux-desktop.mjs",
-    "capture:windows-desktop": "node scripts/capture-windows-desktop.mjs"
+    "capture:windows-desktop": "node scripts/capture-windows-desktop.mjs",
+    "dev:shared": "node scripts/dev-shared.mjs",
+    "dev:rebuild": "node scripts/dev-rebuild.mjs",
+    "dev:status": "node scripts/dev-status.mjs",
+    "test:dev-server-registry": "node --test scripts/dev-server-registry.test.mjs"
   },
   "dependencies": {
     "@capacitor/android": "8.3.4",

--- a/packages/app/scripts/dev-rebuild.mjs
+++ b/packages/app/scripts/dev-rebuild.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  defaultRegistryPath,
+  getEntryRuntime,
+  normalizeWorktreePath,
+  readRegistry,
+  updateRegistryEntry,
+} from "./dev-server-registry.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(here, "..");
+const worktree = normalizeWorktreePath(path.resolve(appDir, "../.."));
+const registryPath = defaultRegistryPath();
+const registry = readRegistry(registryPath);
+const entry = registry.entries.find(
+  (candidate) => candidate.worktree === worktree,
+);
+
+if (!entry) {
+  console.error(
+    "No shared dev server reservation for this worktree. Start one with `bun run dev:shared`.",
+  );
+  process.exit(1);
+}
+
+const runtime = await getEntryRuntime(entry);
+if (!runtime.running) {
+  console.error(
+    `No running shared dev server for this worktree on port ${entry.uiPort}. Start one with \`bun run dev:shared\`.`,
+  );
+  process.exit(1);
+}
+
+const htmlPath = path.join(appDir, "index.html");
+const now = new Date();
+fs.utimesSync(htmlPath, now, now);
+await updateRegistryEntry(
+  worktree,
+  { lastRebuildAt: now.toISOString() },
+  { registryPath },
+);
+
+console.log(
+  `[dev:rebuild] triggered Vite full-reload via ${path.relative(appDir, htmlPath)} on http://127.0.0.1:${entry.uiPort}`,
+);

--- a/packages/app/scripts/dev-server-registry.mjs
+++ b/packages/app/scripts/dev-server-registry.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+export const DEFAULT_UI_PORT_BASE = 2100;
+export const DEFAULT_UI_PORT_SPAN = 900;
+export const DEFAULT_API_PORT_OFFSET = 10_000;
+export const REGISTRY_VERSION = 1;
+
+export function defaultRegistryPath(env = process.env) {
+  return (
+    env.ELIZA_DEV_SERVER_REGISTRY ??
+    path.join(os.homedir(), ".eliza", "dev-server-registry.json")
+  );
+}
+
+export function normalizeWorktreePath(worktreePath) {
+  return path.resolve(worktreePath).replace(/\\/g, "/");
+}
+
+export function hashString(input) {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+export function preferredUiPortForWorktree(
+  worktreePath,
+  { base = DEFAULT_UI_PORT_BASE, span = DEFAULT_UI_PORT_SPAN } = {},
+) {
+  return base + (hashString(normalizeWorktreePath(worktreePath)) % span);
+}
+
+export function portsForUiPort(uiPort) {
+  return {
+    uiPort,
+    apiPort: uiPort + DEFAULT_API_PORT_OFFSET,
+  };
+}
+
+export function createEmptyRegistry() {
+  return { version: REGISTRY_VERSION, entries: [] };
+}
+
+export function readRegistry(registryPath = defaultRegistryPath()) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      !Array.isArray(parsed.entries)
+    ) {
+      return createEmptyRegistry();
+    }
+    return {
+      version: REGISTRY_VERSION,
+      entries: parsed.entries.filter(
+        (entry) => entry && typeof entry === "object",
+      ),
+    };
+  } catch (error) {
+    if (error && error.code === "ENOENT") return createEmptyRegistry();
+    throw error;
+  }
+}
+
+export function writeRegistry(registry, registryPath = defaultRegistryPath()) {
+  fs.mkdirSync(path.dirname(registryPath), { recursive: true });
+  const tmp = `${registryPath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(registry, null, 2)}\n`);
+  fs.renameSync(tmp, registryPath);
+}
+
+export function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error && error.code === "EPERM";
+  }
+}
+
+export async function isPortOpen(port, host = "127.0.0.1", timeoutMs = 250) {
+  return await new Promise((resolve) => {
+    const socket = net.createConnection({ host, port });
+    const done = (value) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(value);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once("connect", () => done(true));
+    socket.once("timeout", () => done(false));
+    socket.once("error", () => done(false));
+  });
+}
+
+export async function getEntryRuntime(entry) {
+  const pidAlive = isPidAlive(entry.pid);
+  const portOpen = Number.isInteger(entry.uiPort)
+    ? await isPortOpen(entry.uiPort)
+    : false;
+  return {
+    pidAlive,
+    portOpen,
+    running: pidAlive || portOpen,
+  };
+}
+
+export async function listRegistryEntries({
+  registryPath = defaultRegistryPath(),
+  includeStopped = false,
+} = {}) {
+  const registry = readRegistry(registryPath);
+  const rows = [];
+  for (const entry of registry.entries) {
+    const runtime = await getEntryRuntime(entry);
+    if (!includeStopped && !runtime.running) continue;
+    rows.push({ ...entry, ...runtime });
+  }
+  rows.sort((a, b) => (a.uiPort ?? 0) - (b.uiPort ?? 0));
+  return rows;
+}
+
+function pruneDeadEntries(entries, currentWorktree) {
+  return entries.filter((entry) => {
+    if (entry.worktree === currentWorktree) return false;
+    if (entry.stoppedAt) return false;
+    if (entry.pid === null || entry.pid === undefined) return true;
+    return isPidAlive(entry.pid);
+  });
+}
+
+export function allocatePortsForWorktree(
+  worktreePath,
+  {
+    registry = createEmptyRegistry(),
+    base = DEFAULT_UI_PORT_BASE,
+    span = DEFAULT_UI_PORT_SPAN,
+    now = new Date().toISOString(),
+    blockedUiPorts = [],
+  } = {},
+) {
+  const worktree = normalizeWorktreePath(worktreePath);
+  const preferredUiPort = preferredUiPortForWorktree(worktree, { base, span });
+  const entries = pruneDeadEntries(registry.entries ?? [], worktree);
+  const usedUiPorts = new Set([
+    ...entries.map((entry) => entry.uiPort),
+    ...blockedUiPorts,
+  ]);
+
+  let uiPort = preferredUiPort;
+  let probeCount = 0;
+  while (usedUiPorts.has(uiPort) && probeCount < span) {
+    probeCount += 1;
+    uiPort = base + ((preferredUiPort - base + probeCount) % span);
+  }
+  if (probeCount >= span) {
+    throw new Error(
+      `No free deterministic UI ports in ${base}-${base + span - 1}`,
+    );
+  }
+
+  const ports = portsForUiPort(uiPort);
+  const entry = {
+    worktree,
+    packageDir: path.join(worktree, "packages", "app"),
+    uiPort: ports.uiPort,
+    apiPort: ports.apiPort,
+    preferredUiPort,
+    pid: null,
+    startedAt: null,
+    updatedAt: now,
+    lastRebuildAt: null,
+  };
+
+  return {
+    entry,
+    registry: { version: REGISTRY_VERSION, entries: [...entries, entry] },
+  };
+}
+
+export async function withRegistryLock(
+  callback,
+  { registryPath = defaultRegistryPath(), staleMs = 30_000 } = {},
+) {
+  const lockPath = `${registryPath}.lock`;
+  fs.mkdirSync(path.dirname(registryPath), { recursive: true });
+  const start = Date.now();
+  while (true) {
+    try {
+      fs.mkdirSync(lockPath);
+      fs.writeFileSync(path.join(lockPath, "pid"), String(process.pid));
+      break;
+    } catch (error) {
+      if (error && error.code !== "EEXIST") throw error;
+      let stale = false;
+      try {
+        const stat = fs.statSync(lockPath);
+        stale = Date.now() - stat.mtimeMs > staleMs;
+      } catch {
+        stale = true;
+      }
+      if (stale) {
+        fs.rmSync(lockPath, { recursive: true, force: true });
+        continue;
+      }
+      if (Date.now() - start > staleMs) {
+        throw new Error(`Timed out waiting for registry lock ${lockPath}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+
+  try {
+    return await callback();
+  } finally {
+    fs.rmSync(lockPath, { recursive: true, force: true });
+  }
+}
+
+export async function reservePortsForWorktree(
+  worktreePath,
+  { registryPath = defaultRegistryPath(), base, span } = {},
+) {
+  return await withRegistryLock(
+    async () => {
+      const current = readRegistry(registryPath);
+      const blockedUiPorts = new Set();
+      while (true) {
+        const allocated = allocatePortsForWorktree(worktreePath, {
+          registry: current,
+          base,
+          span,
+          blockedUiPorts,
+        });
+        if (!(await isPortOpen(allocated.entry.uiPort))) {
+          writeRegistry(allocated.registry, registryPath);
+          return allocated.entry;
+        }
+        blockedUiPorts.add(allocated.entry.uiPort);
+      }
+    },
+    { registryPath },
+  );
+}
+
+export async function updateRegistryEntry(
+  worktreePath,
+  patch,
+  { registryPath = defaultRegistryPath() } = {},
+) {
+  const worktree = normalizeWorktreePath(worktreePath);
+  return await withRegistryLock(
+    async () => {
+      const registry = readRegistry(registryPath);
+      const entries = registry.entries ?? [];
+      const index = entries.findIndex((entry) => entry.worktree === worktree);
+      if (index === -1) return null;
+      const updated = {
+        ...entries[index],
+        ...patch,
+        updatedAt: new Date().toISOString(),
+      };
+      entries[index] = updated;
+      writeRegistry({ version: REGISTRY_VERSION, entries }, registryPath);
+      return updated;
+    },
+    { registryPath },
+  );
+}

--- a/packages/app/scripts/dev-server-registry.test.mjs
+++ b/packages/app/scripts/dev-server-registry.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import {
+  allocatePortsForWorktree,
+  createEmptyRegistry,
+  preferredUiPortForWorktree,
+  readRegistry,
+  reservePortsForWorktree,
+} from "./dev-server-registry.mjs";
+
+describe("shared dev server registry", () => {
+  it("allocates stable deterministic ports for a worktree", () => {
+    const worktree = "/tmp/eliza-workers/wt-alpha";
+    const first = allocatePortsForWorktree(worktree, {
+      registry: createEmptyRegistry(),
+    }).entry;
+    const second = allocatePortsForWorktree(worktree, {
+      registry: createEmptyRegistry(),
+    }).entry;
+
+    assert.equal(first.uiPort, second.uiPort);
+    assert.equal(first.apiPort, first.uiPort + 10_000);
+    assert.equal(first.preferredUiPort, preferredUiPortForWorktree(worktree));
+  });
+
+  it("keeps two occupied worktrees on distinct ports", () => {
+    const alpha = allocatePortsForWorktree("/tmp/eliza-workers/wt-alpha", {
+      registry: createEmptyRegistry(),
+    });
+    alpha.entry.pid = process.pid;
+    const beta = allocatePortsForWorktree("/tmp/eliza-workers/wt-beta", {
+      registry: alpha.registry,
+    });
+
+    assert.notEqual(alpha.entry.uiPort, beta.entry.uiPort);
+    assert.notEqual(alpha.entry.apiPort, beta.entry.apiPort);
+  });
+
+  it("linear-probes when two worktree hashes prefer the same small range", () => {
+    const first = allocatePortsForWorktree("/tmp/a", {
+      registry: createEmptyRegistry(),
+      base: 2400,
+      span: 1,
+    });
+    first.entry.pid = process.pid;
+
+    assert.throws(
+      () =>
+        allocatePortsForWorktree("/tmp/b", {
+          registry: first.registry,
+          base: 2400,
+          span: 1,
+        }),
+      /No free deterministic UI ports/,
+    );
+  });
+
+  it("writes reservations through the lock-protected registry", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-dev-registry-"));
+    const registryPath = path.join(dir, "registry.json");
+
+    const alpha = await reservePortsForWorktree("/tmp/eliza-workers/wt-alpha", {
+      registryPath,
+    });
+    const beta = await reservePortsForWorktree("/tmp/eliza-workers/wt-beta", {
+      registryPath,
+    });
+    const registry = readRegistry(registryPath);
+
+    assert.equal(registry.entries.length, 2);
+    assert.notEqual(alpha.uiPort, beta.uiPort);
+  });
+});

--- a/packages/app/scripts/dev-shared.mjs
+++ b/packages/app/scripts/dev-shared.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  defaultRegistryPath,
+  normalizeWorktreePath,
+  reservePortsForWorktree,
+  updateRegistryEntry,
+} from "./dev-server-registry.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(here, "..");
+const worktree = normalizeWorktreePath(path.resolve(appDir, "../.."));
+const registryPath = defaultRegistryPath();
+
+const entry = await reservePortsForWorktree(worktree, { registryPath });
+const env = {
+  ...process.env,
+  ELIZA_UI_PORT: String(entry.uiPort),
+  ELIZA_API_PORT: String(entry.apiPort),
+  VITE_ELIZA_DEV_SHARED: "1",
+};
+
+console.log(
+  `[dev:shared] worktree=${worktree}\n` +
+    `[dev:shared] ui=http://127.0.0.1:${entry.uiPort} api=http://127.0.0.1:${entry.apiPort}\n` +
+    `[dev:shared] registry=${registryPath}`,
+);
+
+const child = spawn("bun", ["--bun", "vite"], {
+  cwd: appDir,
+  env,
+  stdio: "inherit",
+});
+
+await updateRegistryEntry(
+  worktree,
+  {
+    pid: child.pid,
+    startedAt: new Date().toISOString(),
+    uiPort: entry.uiPort,
+    apiPort: entry.apiPort,
+    packageDir: appDir,
+  },
+  { registryPath },
+);
+
+function forward(signal) {
+  if (!child.killed) child.kill(signal);
+}
+process.once("SIGINT", () => forward("SIGINT"));
+process.once("SIGTERM", () => forward("SIGTERM"));
+
+child.on("exit", async (code, signal) => {
+  await updateRegistryEntry(
+    worktree,
+    { pid: null, stoppedAt: new Date().toISOString() },
+    { registryPath },
+  );
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});

--- a/packages/app/scripts/dev-status.mjs
+++ b/packages/app/scripts/dev-status.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import {
+  defaultRegistryPath,
+  listRegistryEntries,
+} from "./dev-server-registry.mjs";
+
+const includeStopped = process.argv.includes("--all");
+const json = process.argv.includes("--json");
+const registryPath = defaultRegistryPath();
+const rows = await listRegistryEntries({ registryPath, includeStopped });
+
+if (json) {
+  console.log(JSON.stringify({ registryPath, servers: rows }, null, 2));
+  process.exit(0);
+}
+
+if (rows.length === 0) {
+  console.log(
+    `No ${includeStopped ? "registered" : "running"} shared dev servers.`,
+  );
+  console.log(`registry: ${registryPath}`);
+  process.exit(0);
+}
+
+console.log(`registry: ${registryPath}`);
+console.log("PORT\tAPI\tPID\tSTATE\tWORKTREE");
+for (const row of rows) {
+  const state = row.running ? "running" : "stopped";
+  console.log(
+    `${row.uiPort}\t${row.apiPort}\t${row.pid ?? "-"}\t${state}\t${row.worktree}`,
+  );
+}

--- a/packages/docs/development/shared-dev-server.md
+++ b/packages/docs/development/shared-dev-server.md
@@ -1,0 +1,50 @@
+# Shared dev server for concurrent lanes
+
+Parallel worktrees should not all bind the default app UI port (`2138`). The app Vite config uses `strictPort: true`, so a second server on the same port fails instead of auto-incrementing. Use the shared dev-server scripts when multiple agents or lanes are active on the same VPS.
+
+## Commands
+
+Run from `packages/app`:
+
+```bash
+bun run dev:shared   # long-lived Vite server on this worktree's deterministic port
+bun run dev:status   # list running shared dev servers from the registry
+bun run dev:rebuild  # explicit Vite full-reload trigger for this worktree
+```
+
+`bun run dev` is unchanged for single-lane local development.
+
+## Port contract
+
+`dev:shared` reserves a deterministic port from the worktree path and stores the reservation in `~/.eliza/dev-server-registry.json` (override with `ELIZA_DEV_SERVER_REGISTRY`). The UI port is allocated from `2100-2999`; the paired API port is `uiPort + 10000`. If two worktrees hash to the same port, the registry lock linear-probes to the next free port, so active lanes stay distinct.
+
+The script exports `ELIZA_UI_PORT` and `ELIZA_API_PORT` before starting Vite, then records the Vite pid. `dev:status` checks both pid liveness and whether the UI port is open.
+
+## Rebuild trigger
+
+`dev:rebuild` is intentionally explicit. It requires a running shared server for the current worktree, then updates `packages/app/index.html` mtime. Vite watches the HTML shell and broadcasts a full reload to connected clients. This gives agents a cheap, composable "refresh now" hook without each lane starting another server.
+
+## VPS workflow
+
+1. Pick or create the worktree for your lane.
+2. Start one long-lived server:
+
+   ```bash
+   cd packages/app
+   bun run dev:shared
+   ```
+
+3. In another shell, discover the URL:
+
+   ```bash
+   bun run dev:status
+   ```
+
+4. Point the Cloudflare tunnel, browser, or installed PWA live-reload URL at that lane's UI port.
+5. After source/build state changes that need a visible refresh, run:
+
+   ```bash
+   bun run dev:rebuild
+   ```
+
+If a stale process dies, `dev:status` hides it by default; use `bun run dev:status -- --all` to inspect stopped registry entries.


### PR DESCRIPTION
## Summary
- add `packages/app` shared dev-server scripts: `dev:shared`, `dev:rebuild`, `dev:status`
- reserve deterministic per-worktree UI/API ports with a lockfile registry and open-port guard
- document the parallel-lane workflow in root/package agent docs and `packages/docs/development/shared-dev-server.md`

## Collision mechanism found
`packages/app` runs `bun --bun vite`; Vite resolves `ELIZA_UI_PORT` through shared runtime env defaults and binds UI port `2138` with `strictPort: true`. Parallel worktrees without env overrides therefore try the same port and fail instead of auto-incrementing. Existing HMR restarts also came from workspace manifest watcher restarts, not a lane-level registry.

## Verification
```bash
cd packages/app && bun run test:dev-server-registry
# pass: 4 tests, 0 fail
```

```bash
ELIZA_DEV_SERVER_REGISTRY=/tmp/eliza-dev-registry.X.json node --input-type=module ...
/mnt/HC_Volume_106234565/eliza-workers/wt-devserver -> ui=2310 api=12310 preferred=2310
/mnt/HC_Volume_106234565/eliza-workers/wt-chat-keyboard -> ui=2682 api=12682 preferred=2682
# repeat produced the same two ports
```

```bash
node -e "const p=require('./packages/app/package.json'); console.log(p.scripts.dev)"
# bun --bun vite
```

```bash
cd packages/app && bun run build
# ✓ built in 1m 2s
```

Notes: Codex review was started with the required 100s cap and killed by timeout, then I self-reviewed the scripts/docs manually. Initial app build attempts exposed missing local worktree deps; after local `bun install`, `ensure-workspace-symlinks`, and building `packages/cloud/routing` + `packages/shared`, the post-rebase `packages/app` build completed green.

Fixes #14383
Fixes #14398

[sol-orch]

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - dev-server script and documentation workflow change; no user-facing UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - dev-server script and documentation workflow change; no user-facing UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - command-line dev workflow change; no interactive user flow changed`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend/runtime server code path changed`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend runtime code path changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent, prompt, provider, model, or action behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - dev workflow scripts only; verification is the registry unit test plus docs link test listed above`.

