### PR TITLE
fix(#14328): deltaX-lock the chat transcript + regression e2e (chromium + webkit)

### DIFF
--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -27,7 +27,7 @@ name: Chat shell gestures
 # imports the real @elizaos/core, so the shared i18n data is generated first.
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - ".github/workflows/chat-shell-gestures.yml"
       - "package.json"

--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -101,8 +101,8 @@ jobs:
       - name: Ensure generated shared i18n data
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
-      - name: Install Playwright chromium
-        run: bunx playwright install --with-deps chromium
+      - name: Install Playwright chromium + webkit
+        run: bunx playwright install --with-deps chromium webkit
 
       # Boot-free coverage gate: fails when a gesture-handler site in
       # packages/ui/src lacks a CHAT_GESTURE_COVERAGE matrix row (#12188).
@@ -136,6 +136,14 @@ jobs:
       # into the sheet pull. RED before the fix, GREEN after.
       - name: Chat-scroll web e2e
         run: bun run --cwd packages/ui test:chat-scroll-web-e2e
+
+      # Transcript is vertical-only: an over-wide child + diagonal wheel must not
+      # pan #continuous-thread sideways; designed inner scrollers still scroll and
+      # don't chain (#14328). Both engines — the deltaX lock must hold on WebKit.
+      - name: Chat transcript axis-lock e2e (chromium)
+        run: bun run --cwd packages/ui test:chat-scroll-axis-lock-e2e
+      - name: Chat transcript axis-lock e2e (webkit)
+        run: ENGINE=webkit bun run --cwd packages/ui test:chat-scroll-axis-lock-e2e
 
       # TopicGroup flick-collapse/expand gestures.
       - name: TopicGroup gesture e2e

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,6 +34,7 @@
     "test:agent-surface-e2e": "bun run --cwd ../.. packages/ui/src/agent-surface/__e2e__/run-e2e.mjs",
     "test:chat-sheet-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs",
     "test:chat-scroll-web-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-scroll-web-e2e.mjs",
+    "test:chat-scroll-axis-lock-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-scroll-axis-lock-e2e.mjs",
     "test:bottombar-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-bottombar-e2e.mjs",
     "test:fused-wake-integration-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-fused-wake-integration-e2e.mjs",
     "test:chat-sheet-frame-glitch-e2e": "node src/components/shell/__e2e__/run-chat-sheet-frame-glitch-e2e.mjs",

--- a/packages/ui/src/components/chat/MessageAttachments.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.tsx
@@ -828,7 +828,7 @@ function CodeTile({
         value={text}
         copyable
         data-language={language}
-        className="max-h-[24rem] overflow-auto rounded-none border-0 bg-transparent"
+        className="max-h-[24rem] overflow-auto overscroll-x-contain rounded-none border-0 bg-transparent"
       />
     </figure>
   );

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -4310,7 +4310,8 @@ export function ContinuousChatOverlay({
                   // long code line, the full-bleed chips rail) surfaces a
                   // horizontal scrollbar strip across the sheet on iOS — the
                   // "weird side scroll thingy." This transcript only ever scrolls
-                  // vertically; pin the horizontal axis closed.
+                  // vertically; pin the horizontal axis closed. deltaX-locked by
+                  // run-chat-scroll-axis-lock-e2e (chromium + webkit, #14328).
                   className="relative flex min-h-0 w-full flex-1 touch-pan-y flex-col overflow-y-auto overflow-x-hidden overscroll-contain px-5 [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden"
                   style={{ opacity: threadContentOpacity }}
                 >

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -186,7 +186,7 @@ export function HomeScreen({
         // `overscroll-y-contain`: keep the browser's own pull-to-refresh /
         // scroll-chaining off the top overscroll so a drag past the top never
         // yanks the whole page.
-        "eliza-continuous-chat-scroll absolute inset-0 z-[1] touch-pan-y overflow-y-auto overscroll-y-contain",
+        "eliza-continuous-chat-scroll absolute inset-0 z-[1] touch-pan-y overflow-x-hidden overflow-y-auto overscroll-y-contain",
         // The shell root already reserves the status-bar safe area (its
         // paddingTop: var(--safe-area-top)); adding it again here double-padded
         // the content and left a large empty band above the dashboard. Just a

--- a/packages/ui/src/components/shell/__e2e__/run-chat-scroll-axis-lock-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-scroll-axis-lock-e2e.mjs
@@ -1,0 +1,334 @@
+/**
+ * Regression harness for "the chat transcript can pan sideways" (#14328).
+ *
+ * The continuous-chat transcript (`#continuous-thread`) is a single-axis scroll
+ * surface: it scrolls vertically and must NEVER scroll horizontally. CSS Overflow
+ * coerces the unspecified axis from `visible` to `auto`, so `overflow-y-auto`
+ * alone silently makes the thread horizontally scrollable the instant any child
+ * overflows — an attachment preview, an unaudited inline widget, a wide table.
+ * `touch-pan-y` blocks touch panning but does NOT block trackpad/wheel deltaX, so
+ * on desktop a diagonal two-finger scroll pans the whole transcript sideways.
+ *
+ * This drives the REAL `ContinuousChatOverlay` (via chat-sheet-fixture.tsx), opens
+ * the sheet to FULL, injects an over-wide child into the genuine `#continuous-thread`
+ * scroller, then dispatches a diagonal wheel and asserts `scrollLeft` never leaves 0.
+ * A second case proves a DESIGNED inner scroller (the repo's `overflow-x-auto
+ * overscroll-x-contain` contract used by code blocks / chip rows) still scrolls
+ * inside its own row and does NOT chain its horizontal scroll to the thread.
+ *
+ * RED before the fix (computed `overflow-x: auto`, thread pans), GREEN after
+ * (`overflow-x: hidden`, thread pinned). Runs on Chromium AND WebKit — the
+ * acceptance bar requires both engines (#14328).
+ *
+ * Run:  node src/components/shell/__e2e__/run-chat-scroll-axis-lock-e2e.mjs
+ *       ENGINE=webkit node …/run-chat-scroll-axis-lock-e2e.mjs
+ * Exits non-zero on any failed assertion / console error.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { builtinModules } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { chromium, webkit } from "playwright";
+import { touchDragHold } from "../../../testing/real-touch-gestures.ts";
+
+const ENGINE = process.env.ENGINE === "webkit" ? webkit : chromium;
+const ENGINE_NAME = process.env.ENGINE === "webkit" ? "webkit" : "chromium";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = join(here, "output");
+await mkdir(outDir, { recursive: true });
+
+let failures = 0;
+function assert(cond, msg) {
+  console.log(`${cond ? "✓" : "✗"} ${msg}`);
+  if (!cond) failures += 1;
+  return cond;
+}
+
+// --- same bundle stubs as run-chat-scroll-web-e2e.mjs --------------------
+const stubPromptSuggestions = {
+  name: "stub-prompt-suggestions",
+  setup(b) {
+    b.onResolve({ filter: /usePromptSuggestions\.stub$/ }, (args) => ({
+      path: args.path,
+      namespace: "prompt-suggestions-stub",
+    }));
+    b.onResolve({ filter: /usePromptSuggestions$/ }, () => ({
+      path: join(here, "usePromptSuggestions.stub.ts"),
+    }));
+  },
+};
+const stubElizaCore = {
+  name: "stub-eliza-core",
+  setup(b) {
+    b.onResolve({ filter: /^@elizaos\/core$/ }, (args) => ({
+      path: args.path,
+      namespace: "eliza-core-stub",
+    }));
+    b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
+      contents: `
+        const noop = new Proxy(() => noop, { get: () => noop });
+        module.exports = new Proxy(
+          {
+            isViewVisible: () => true,
+            dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
+            findInteractionRegions: () => [],
+          },
+          { get: (t, p) => (p in t ? t[p] : noop) },
+        );
+      `,
+      loader: "js",
+    }));
+  },
+};
+const nodeBuiltins = new Set([
+  ...builtinModules,
+  ...builtinModules.map((m) => `node:${m}`),
+]);
+const stubNodeBuiltins = {
+  name: "stub-node-builtins",
+  setup(b) {
+    b.onResolve({ filter: /.*/ }, (args) => {
+      const bare = args.path.replace(/^node:/, "").split("/")[0];
+      if (
+        args.path.startsWith("node:") ||
+        nodeBuiltins.has(args.path) ||
+        builtinModules.includes(bare)
+      ) {
+        return { path: args.path, namespace: "node-stub" };
+      }
+      return null;
+    });
+    b.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
+      contents:
+        "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
+      loader: "js",
+    }));
+  },
+};
+
+const result = await build({
+  entryPoints: [join(here, "chat-sheet-fixture.tsx")],
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  jsx: "automatic",
+  loader: { ".tsx": "tsx", ".ts": "ts" },
+  define: { "process.env.NODE_ENV": '"production"' },
+  plugins: [stubPromptSuggestions, stubElizaCore, stubNodeBuiltins],
+  write: false,
+});
+const js = result.outputFiles[0].text;
+const html = `<!doctype html><html><head><meta charset="utf-8"><title>chat scroll axis lock e2e</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
+<style>html,body{margin:0;height:100%;background:#0a0d16}</style>
+</head><body><div id="root"></div><script>${js}</script></body></html>`;
+const htmlPath = join(outDir, "chat-scroll-axis-lock.html");
+await writeFile(htmlPath, html);
+const url = `file://${htmlPath}?many`;
+
+const SCROLLER = "#continuous-thread";
+const THREAD = '[data-testid="chat-thread"]';
+const GRABBER = '[data-testid="chat-sheet-grabber"]';
+
+// Open the sheet to FULL — touch-drag on Chromium (CDP), keyboard disclosure on
+// WebKit (no CDP touch). Both reach the same open state, matching the sibling
+// scroll-web harness so the scroller is measured identically on each engine.
+async function openToFull(page) {
+  if (ENGINE_NAME === "chromium") {
+    await (
+      await touchDragHold(page, GRABBER, 0, -260, { steps: 16, stepDelayMs: 8 })
+    ).release();
+    await page.waitForTimeout(500);
+    await (
+      await touchDragHold(page, GRABBER, 0, -400, { steps: 16, stepDelayMs: 8 })
+    ).release();
+    await page.waitForTimeout(600);
+    return;
+  }
+  const grabber = page.locator(GRABBER);
+  await grabber.focus();
+  await page.keyboard.press("ArrowUp");
+  await page.waitForTimeout(500);
+  await page.keyboard.press("ArrowUp");
+  await page.waitForTimeout(600);
+}
+
+// Wheel at the CENTER of an element's box: move the pointer there, then emit a
+// wheel with the given deltas. Playwright's mouse.wheel works on both Chromium
+// and WebKit, so this is the cross-engine analogue of a trackpad two-finger drag.
+async function wheelOver(page, selector, deltaX, deltaY) {
+  const box = await page.locator(selector).first().boundingBox();
+  if (!box) throw new Error(`no bounding box for ${selector}`);
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.wheel(deltaX, deltaY);
+  await page.waitForTimeout(200);
+}
+
+console.log(`engine: ${ENGINE_NAME}`);
+const browser = await ENGINE.launch(
+  ENGINE_NAME === "chromium" ? { args: ["--no-sandbox"] } : {},
+);
+const consoleErrors = [];
+try {
+  // Chromium runs a mobile touch context (CDP touch-drag opens the sheet, and
+  // Chromium still honours mouse.wheel there). WebKit CANNOT emit mouse.wheel in
+  // a mobile context ("Mouse wheel is not supported in mobile WebKit"), and the
+  // deltaX bug is a *desktop* trackpad bug regardless — so WebKit runs a
+  // fine-pointer desktop context and opens the sheet via the keyboard path.
+  const page = await browser.newPage(
+    ENGINE_NAME === "chromium"
+      ? {
+          viewport: { width: 402, height: 874 },
+          hasTouch: true,
+          isMobile: true,
+          deviceScaleFactor: 2,
+        }
+      : { viewport: { width: 900, height: 900 } },
+  );
+  page.on("console", (m) => {
+    if (m.type() === "error") consoleErrors.push(m.text());
+  });
+  page.on("pageerror", (e) => consoleErrors.push(String(e)));
+  await page.goto(url);
+  await page.waitForSelector('[data-testid="chat-sheet"]');
+  await page.waitForTimeout(700);
+
+  await openToFull(page);
+  await page.waitForSelector(THREAD);
+  await page.waitForTimeout(300);
+  assert(
+    !!(await page.locator(SCROLLER).count()),
+    `scroller ${SCROLLER} is present`,
+  );
+
+  const geom = await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    const r = el.getBoundingClientRect();
+    return { clientWidth: el.clientWidth, boxW: Math.round(r.width), boxX: Math.round(r.x) };
+  }, SCROLLER);
+  console.log(`  thread geometry: ${JSON.stringify(geom)}`);
+
+  // 1) THE CONTRACT: the transcript scroller computes `overflow-x: hidden`. This
+  //    is the single fact the fix establishes; before the fix it is `auto`
+  //    (CSS coerces the unspecified axis) and the wheel below pans the thread.
+  const overflowX = await page.evaluate(
+    (sel) => getComputedStyle(document.querySelector(sel)).overflowX,
+    SCROLLER,
+  );
+  console.log(`  computed overflow-x: ${overflowX}`);
+  assert(
+    overflowX === "hidden",
+    `#continuous-thread computes overflow-x: hidden (got ${overflowX})`,
+  );
+
+  // INJECT AN OVER-WIDE DIRECT CHILD: a 4000px block inside the ~360px thread.
+  // With overflow-x:hidden the thread clips it and no user gesture can pan to it;
+  // under the bug (overflow-x:auto) the same wheel would slide the whole
+  // transcript sideways. NOTE: `overflow:hidden` still allows *programmatic*
+  // scrollLeft and still reports scrollWidth>clientWidth — only USER scrolling is
+  // blocked — so the wheel gesture, not a scrollWidth check, is the discriminator.
+  await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    const wide = document.createElement("div");
+    wide.id = "e2e-overwide-child";
+    wide.textContent = "over-wide adversarial child ".repeat(20);
+    Object.assign(wide.style, {
+      width: "4000px",
+      minWidth: "4000px",
+      flex: "0 0 auto",
+      height: "24px",
+      whiteSpace: "nowrap",
+      background: "rgba(255,0,0,0.15)",
+    });
+    el.appendChild(wide);
+    el.scrollLeft = 0; // baseline
+    wide.scrollIntoView({ block: "nearest", inline: "nearest" });
+    el.scrollLeft = 0; // scrollIntoView may nudge; re-baseline
+  }, SCROLLER);
+  await page.waitForTimeout(150);
+
+  // 2) DIAGONAL WHEEL (the real trackpad two-finger gesture) then a pure-X wheel:
+  //    neither may move scrollLeft off 0 on a locked (overflow-x:hidden) thread.
+  await wheelOver(page, SCROLLER, 400, 40);
+  await wheelOver(page, SCROLLER, 600, 0);
+  const scrollLeftAfterWheel = await page.evaluate(
+    (sel) => document.querySelector(sel).scrollLeft,
+    SCROLLER,
+  );
+  console.log(`  thread scrollLeft after diagonal+horizontal wheel: ${scrollLeftAfterWheel}`);
+  assert(
+    scrollLeftAfterWheel === 0,
+    `diagonal/horizontal wheel leaves #continuous-thread pinned (scrollLeft=${scrollLeftAfterWheel})`,
+  );
+
+  // 3) DESIGNED INNER SCROLLER survives + does not chain — AND doubles as the
+  //    POSITIVE CONTROL that the wheel mechanism scrolls overflow-x:auto here.
+  //    Inject the repo's inner-scroller contract (`overflow-x-auto
+  //    overscroll-x-contain`, as on code blocks / chip rows) with over-wide
+  //    content, scroll it into view, wheel over IT: its OWN scrollLeft must
+  //    advance (designed scroll preserved + wheel works) while the thread stays
+  //    pinned at 0 (overflow-x:hidden clips; overscroll-x-contain stops the chain).
+  await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    el.scrollLeft = 0;
+    const row = document.createElement("div");
+    row.id = "e2e-inner-scroller";
+    row.className = "overflow-x-auto overscroll-x-contain";
+    Object.assign(row.style, {
+      width: "100%",
+      maxWidth: "320px",
+      height: "40px",
+      margin: "8px 0",
+      flex: "0 0 auto",
+    });
+    const inner = document.createElement("div");
+    Object.assign(inner.style, {
+      width: "3000px",
+      minWidth: "3000px",
+      height: "24px",
+      background:
+        "repeating-linear-gradient(90deg,#2b6,#2b6 20px,#083 20px,#083 40px)",
+    });
+    row.appendChild(inner);
+    el.appendChild(row);
+    row.scrollIntoView({ block: "center", inline: "nearest" });
+    el.scrollLeft = 0;
+  }, SCROLLER);
+  await page.waitForTimeout(200);
+  await wheelOver(page, "#e2e-inner-scroller", 500, 0);
+  const chain = await page.evaluate(
+    (sel) => ({
+      inner: document.querySelector("#e2e-inner-scroller").scrollLeft,
+      thread: document.querySelector(sel).scrollLeft,
+    }),
+    SCROLLER,
+  );
+  console.log(`  inner-scroller chain: ${JSON.stringify(chain)}`);
+  assert(
+    chain.inner > 20,
+    `designed inner scroller still scrolls horizontally in its own row (positive control; scrollLeft=${chain.inner})`,
+  );
+  assert(
+    chain.thread === 0,
+    `inner horizontal scroll does NOT chain to the thread (thread scrollLeft=${chain.thread})`,
+  );
+
+  await page.screenshot({
+    path: join(outDir, `chat-scroll-axis-lock-${ENGINE_NAME}.png`),
+  });
+} finally {
+  await browser.close();
+}
+
+assert(consoleErrors.length === 0, `no console errors (${consoleErrors.length})`);
+if (consoleErrors.length) for (const e of consoleErrors) console.log("  ERR:", e);
+
+if (failures > 0) {
+  console.error(`\n${failures} assertion(s) FAILED [${ENGINE_NAME}]`);
+  process.exit(1);
+}
+console.log(`\nAll axis-lock assertions passed [${ENGINE_NAME}].`);


### PR DESCRIPTION
Closes #14328.

## What & why

`#continuous-thread` (the continuous-chat transcript) must scroll **vertically only**. CSS Overflow coerces an unspecified axis from `visible` to `auto`, so `overflow-y-auto` alone silently makes the thread horizontally scrollable the instant any child overflows — and `touch-pan-y` blocks touch panning but **not** trackpad/wheel `deltaX`. On desktop a diagonal two-finger scroll then pans the whole transcript sideways. An axis surprise is the single thing that most degrades trust in a chat surface, and chat is the MVP's primary surface.

The `#continuous-thread` className already carries `overflow-x-hidden` on `develop` (the obvious CSS part landed earlier), **but #14328's acceptance criteria were never met**: there was no wheel/`deltaX` regression proving the lock on either engine, and two sibling transcript surfaces were still y-only:

| File | Change | Why |
| --- | --- | --- |
| `ContinuousChatOverlay.tsx` | comment only (className already correct on develop) | anchor the lock to the new e2e |
| `MessageAttachments.tsx:831` | `+ overscroll-x-contain` on the code-preview `CodeBlock` | its designed inner scroll must not chain to the thread |
| `HomeScreen.tsx:189` | `+ overflow-x-hidden` on the ambient-chat transcript | same surface, same coercion bug, was unlocked |
| `run-chat-scroll-axis-lock-e2e.mjs` | **new** wheel/`deltaX` regression (chromium + webkit) | the missing acceptance criterion |
| `chat-shell-gestures.yml` | run the new guard on both engines; install webkit | CI enforcement |

## How it's proven (real browser, no mock)

The runner drives the **real** `ContinuousChatOverlay` via the shared chat-sheet fixture, opens the sheet to FULL, injects an over-wide child into the **genuine** `#continuous-thread`, then dispatches a diagonal + pure-horizontal wheel and asserts `scrollLeft` never leaves `0`. A designed inner scroller (`overflow-x-auto overscroll-x-contain`, the repo's code-block/chip contract) is the **positive control**: the identical wheel scrolls *it* while the thread stays pinned — same gesture, opposite outcome, so the lock is real and not a dead element.

### 🔴 RED — with the `overflow-x-hidden` reverted (bug present)
```
computed overflow-x: auto
✗ #continuous-thread computes overflow-x: hidden (got auto)
  thread scrollLeft after diagonal+horizontal wheel: 2438
✗ diagonal/horizontal wheel leaves #continuous-thread pinned (scrollLeft=2438)
✓ designed inner scroller still scrolls horizontally in its own row (positive control; scrollLeft=1219)
2 assertion(s) FAILED [chromium]
```
The transcript pans sideways to `scrollLeft=2438` — the exact reported bug.

### 🟢 GREEN — this branch, both engines
<details><summary>chromium</summary>

```
computed overflow-x: hidden
✓ #continuous-thread computes overflow-x: hidden (got hidden)
  thread scrollLeft after diagonal+horizontal wheel: 0
✓ diagonal/horizontal wheel leaves #continuous-thread pinned (scrollLeft=0)
  inner-scroller chain: {"inner":1219,"thread":0}
✓ designed inner scroller still scrolls horizontally in its own row (positive control; scrollLeft=1219)
✓ inner horizontal scroll does NOT chain to the thread (thread scrollLeft=0)
✓ no console errors (0)
All axis-lock assertions passed [chromium].
```
</details>
<details><summary>webkit (desktop context — mobile WebKit blocks mouse.wheel; the deltaX bug is a desktop bug)</summary>

```
computed overflow-x: hidden
✓ #continuous-thread computes overflow-x: hidden (got hidden)
  thread scrollLeft after diagonal+horizontal wheel: 0
✓ diagonal/horizontal wheel leaves #continuous-thread pinned (scrollLeft=0)
  inner-scroller chain: {"inner":500,"thread":0}
✓ designed inner scroller still scrolls horizontally in its own row (positive control; scrollLeft=500)
✓ inner horizontal scroll does NOT chain to the thread (thread scrollLeft=0)
✓ no console errors (0)
All axis-lock assertions passed [webkit].
```
</details>

### No-regression: the existing vertical-scroll guard still passes
<details><summary>run-chat-scroll-web-e2e (chromium)</summary>

```
✓ scroller computes overflow-y: auto/scroll (got auto)
✓ scroller has real overflow: scrollHeight(2816) > clientHeight(1941)
✓ vertical finger-drag scrolls the transcript natively (scrollTop moved 875 → 650)
✓ sheet detent unchanged by the scroll drag (OPEN_HALF_OR_OVER -> OPEN_HALF_OR_OVER)
✓ a drift scroll did NOT trigger a conversation swipe
All scroll-web assertions passed.
```
</details>

## Acceptance criteria
- [x] `#continuous-thread` cannot scroll horizontally on Chromium **and** WebKit — over-wide child + diagonal wheel, `scrollLeft` stays 0.
- [x] A designed inner scroller still scrolls horizontally in its own row and does **not** chain to the thread (`overscroll-x-contain` verified; positive control).
- [x] `run-chat-scroll-web-e2e.mjs` (vertical scroll-chain guard) still passes.
- [x] No regression in the `chat-shell-gestures.yml` gesture lane — guard added there, chromium + webkit.

## Screenshots (evidence)
The axis-lock e2e writes `chat-scroll-axis-lock-{chromium,webkit}.png` to `packages/ui/src/components/shell/__e2e__/output/`; the gesture lane's **"Upload gesture videos + screenshots"** step publishes them as CI artifacts. In the GREEN capture the injected over-wide "adversarial child" row is **clipped at the panel's right edge** (the thread did not pan to reveal it) and the green `overflow-x-auto` inner scroller sits contained within the thread width — the visual twin of the `scrollLeft=0` assertion.

## Evidence not applicable
- **Real-LLM trajectory** — N/A: pure CSS/layout scroll-axis fix, no agent/model/prompt path touched.
- **Backend logs** — N/A: front-end only.


## Additional local verification (Codex, 2026-07-05)

I checked out `fix/14328-chat-transcript-axis-lock` and ran the same generated-data setup used by `.github/workflows/chat-shell-gestures.yml` before the harness:

<details><summary><code>node packages/app-core/scripts/ensure-shared-i18n-data.mjs</code></summary>

```text
Generated shared/core validation keyword data successfully.
```

</details>

<details><summary><code>bun run --cwd packages/ui test:chat-scroll-axis-lock-e2e</code></summary>

```text
engine: chromium
✓ #continuous-thread computes overflow-x: hidden (got hidden)
✓ diagonal/horizontal wheel leaves #continuous-thread pinned (scrollLeft=0)
✓ designed inner scroller still scrolls horizontally in its own row (positive control; scrollLeft=1219)
✓ inner horizontal scroll does NOT chain to the thread (thread scrollLeft=0)
✓ no console errors (0)
All axis-lock assertions passed [chromium].
```

</details>

<details><summary><code>ENGINE=webkit bun run --cwd packages/ui test:chat-scroll-axis-lock-e2e</code></summary>

```text
engine: webkit
✓ #continuous-thread computes overflow-x: hidden (got hidden)
✓ diagonal/horizontal wheel leaves #continuous-thread pinned (scrollLeft=0)
✓ designed inner scroller still scrolls horizontally in its own row (positive control; scrollLeft=500)
✓ inner horizontal scroll does NOT chain to the thread (thread scrollLeft=0)
✓ no console errors (0)
All axis-lock assertions passed [webkit].
```

</details>

<details><summary><code>bun run --cwd packages/ui test:chat-scroll-web-e2e</code></summary>

```text
✓ vertical finger-drag scrolls the transcript natively (scrollTop moved from 875 to 647)
✓ sheet detent unchanged by the scroll drag (OPEN_HALF_OR_OVER -> OPEN_HALF_OR_OVER)
✓ vertical-dominant drag WITH horizontal drift still scrolls natively (875 -> 669)
✓ a drift scroll did NOT trigger a conversation swipe (null -> null)
✓ no console errors (0)
All scroll-web assertions passed.
```

</details>

Manual screenshot review: `chat-scroll-axis-lock-chromium.png` and `chat-scroll-axis-lock-webkit.png` both show the over-wide adversarial row clipped at the sheet edge and the green inner scroller contained inside the chat sheet. No sideways transcript offset was visible.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: [red failure output is embedded above](https://github.com/elizaOS/eliza/pull/14446) showing the reverted bug path with `scrollLeft=2438`; no binary before screenshot was available from this review environment.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: [chat-shell-gestures CI run](https://github.com/elizaOS/eliza/actions/runs/28757605687) uploads `chat-scroll-axis-lock-{chromium,webkit}.png`; local screenshots were also manually reviewed as described above.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: [chat-shell-gestures CI run](https://github.com/elizaOS/eliza/actions/runs/28757605687) publishes gesture artifacts; this fix is additionally covered by deterministic wheel/deltaX e2e logs above.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - frontend CSS/layout + UI e2e only; no backend service path changed`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: e2e console assertion above shows `no console errors (0)` for Chromium, WebKit, and the vertical scroll guard.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no DB/memory/scheduled-task/wallet/file artifacts produced`.
