### PR TITLE
fix(ui): gate AppRunsWidget polling safely

### DIFF
--- a/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
@@ -461,12 +461,14 @@ function AppRunsWidget({
   // effect run — the visibility-gated interval re-subscribes on every
   // foreground/background transition.
   const lastAppRunsKeyRef = useRef("");
+  const runsPollActiveRef = useRef(false);
 
   const refreshRuns = useCallback(async () => {
     if (!runsPollEnabled) return;
     try {
       const nextRuns = await client.listAppRuns();
       const nextRunsSafe = Array.isArray(nextRuns) ? nextRuns : [];
+      if (!runsPollActiveRef.current) return;
       setError(null);
       const nextKey = JSON.stringify(nextRunsSafe);
       const changed = nextKey !== lastAppRunsKeyRef.current;
@@ -477,6 +479,7 @@ function AppRunsWidget({
       });
     } catch (refreshError) {
       // error-policy:J4 load failure renders the widget's error state
+      if (!runsPollActiveRef.current) return;
       setError(
         getClientErrorMessage(
           refreshError,
@@ -486,7 +489,7 @@ function AppRunsWidget({
         ),
       );
     } finally {
-      setLoading(false);
+      if (runsPollActiveRef.current) setLoading(false);
     }
   }, [runsPollEnabled, setState, t]);
 
@@ -498,6 +501,7 @@ function AppRunsWidget({
       // guard — with any unstable dep this loops render→effect→render until
       // the worker OOMs (the #11107 WidgetHost test crash). Clear the change
       // key too so the first fetch after re-auth always repopulates AppContext.
+      runsPollActiveRef.current = false;
       lastAppRunsKeyRef.current = "";
       startTransition(() => {
         setRuns((prev) => (prev.length === 0 ? prev : []));
@@ -507,7 +511,11 @@ function AppRunsWidget({
       setLoading(false);
       return;
     }
+    runsPollActiveRef.current = true;
     void refreshRuns();
+    return () => {
+      runsPollActiveRef.current = false;
+    };
   }, [runsPollEnabled, refreshRuns, setState]);
 
   // Gate the recurring poll on document visibility so a backgrounded window


### PR DESCRIPTION
# Relates to

Closes #14346. Supersedes #14440, whose PR head stayed pinned to the original commit even after the source branch ref moved.

# What does this PR do?

- Replaces `AppRunsWidget`'s raw `setInterval` with `useIntervalWhenDocumentVisible`, matching sibling orchestrator widgets.
- Slows the recurring poll from 5s to 15s and pauses it while the document is hidden.
- Preserves the immediate first fetch on mount / re-auth.
- Preserves the previous stale in-flight response guard so a late `listAppRuns()` response cannot repopulate state after logout, disable, or unmount.
- Keeps the `AppContext` change-key guard in a ref so visibility resubscription does not cause steady-state global updates.

# Evidence Gate

```
bun run --cwd packages/ui test -- src/components/chat/widgets/agent-orchestrator-app-runs.test.tsx
# 1 file passed, 4 tests passed

bunx @biomejs/biome@2.5.1 check packages/ui/src/components/chat/widgets/agent-orchestrator.tsx packages/ui/src/components/chat/widgets/agent-orchestrator-app-runs.test.tsx
# clean

git diff --check
# clean
```

Notes from review: in a fresh worktree the focused UI test required building `packages/cloud/routing` and generating the ignored validation keyword artifacts first.

Screenshots/video: N/A - non-visual polling behavior, covered by deterministic component test driving real widget + hook with fake timers and document visibility.
Real-LLM trajectories: N/A - no model/agent behavior changed.
Domain artifacts: N/A - client polling cadence/visibility gate only.