### PR TITLE
fix(wallet-ui): stop leaking the raw trading-profile error body into the view (#14426)

### DIFF
--- a/plugins/plugin-wallet-ui/src/components/InventoryAppView.gui.test.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventoryAppView.gui.test.tsx
@@ -44,6 +44,12 @@ const appHooks = vi.hoisted(() => ({
 vi.mock("@elizaos/ui", () => ({
   useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
   client: walletClient,
+  // Mirrors the real guard's contract (an ApiError carries a numeric
+  // `status`); tests reject fetches with Object.assign(new Error(body),
+  // { status }) to model the client's error shape at the network boundary.
+  isApiError: (value: unknown): boolean =>
+    value instanceof Error &&
+    typeof (value as { status?: unknown }).status === "number",
   Button: (props: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
     React.createElement("button", { type: "button", ...props }),
   cn: (...classes: unknown[]) => classes.filter(Boolean).join(" "),
@@ -756,5 +762,39 @@ describe("InventoryView GUI — calm empty-wallet hero", () => {
     // The synthesized unavailable overview surfaces the thrown message.
     expect(await screen.findByText("network down")).toBeTruthy();
     expect(screen.getByTitle("Top movers unavailable")).toBeTruthy();
+  });
+
+  it("degrades a trading-profile 404 to the designed empty P&L state — no raw 'Not found' leak (#14426)", async () => {
+    // A backend without the trading-stats route rejects with the client's
+    // ApiError (status 404, message = the raw body "Not found"). That is the
+    // designed no-trading-data state, not an error: the P&L panel keeps its
+    // own empty copy and NO red error text renders — before the fix the raw
+    // body leaked into the view as a bare red "Not found".
+    walletClient.getWalletTradingProfile.mockRejectedValue(
+      Object.assign(new Error("Not found"), { status: 404 }),
+    );
+    appHooks.useApp.mockReturnValue(makeAppState());
+    render(React.createElement(InventoryAppView));
+    await screen.findByTestId("wallets-sidebar");
+
+    expect(await screen.findByText("Trade to see your P&L here")).toBeTruthy();
+    expect(screen.queryByText("Not found")).toBeNull();
+    expect(screen.queryByText(/Couldn't load trading stats/)).toBeNull();
+  });
+
+  it("surfaces a non-404 trading-profile failure as human copy, never the raw response body (#14426)", async () => {
+    walletClient.getWalletTradingProfile.mockRejectedValue(
+      Object.assign(new Error("upstream exploded (traceid=abc123)"), {
+        status: 500,
+      }),
+    );
+    appHooks.useApp.mockReturnValue(makeAppState());
+    render(React.createElement(InventoryAppView));
+    await screen.findByTestId("wallets-sidebar");
+
+    expect(
+      await screen.findByText("Couldn't load trading stats — try again shortly."),
+    ).toBeTruthy();
+    expect(screen.queryByText(/upstream exploded/)).toBeNull();
   });
 });

--- a/plugins/plugin-wallet-ui/src/components/InventoryAppView.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventoryAppView.tsx
@@ -21,7 +21,7 @@ import type {
   WalletTradingProfileWindow,
 } from "@elizaos/shared";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
-import { client } from "@elizaos/ui/api";
+import { client, isApiError } from "@elizaos/ui/api";
 import { Button } from "@elizaos/ui/components";
 import { type ActivityEvent, useActivityEvents } from "@elizaos/ui/hooks";
 import type { InventoryChainFilters } from "@elizaos/ui/state";
@@ -1990,13 +1990,19 @@ export function InventoryAppView() {
         setTradingProfile(profile);
       }
     } catch (cause) {
-      const message =
-        cause instanceof Error && cause.message.trim().length > 0
-          ? cause.message.trim()
-          : "Failed to load trading profile.";
       if (tradingProfileRequestRef.current === requestId) {
         setTradingProfile(null);
-        setTradingProfileError(message);
+        // error-policy:J4 — a 404 means this wallet backend doesn't serve
+        // trading stats (feature-gated/older agent): that is the designed
+        // "no trading data" render (PnlChart's own empty copy), not an error
+        // to paint red. Any other failure surfaces human copy — never the raw
+        // response body, which leaked a bare red "Not found" into the view
+        // (#14426).
+        setTradingProfileError(
+          isApiError(cause) && cause.status === 404
+            ? null
+            : "Couldn't load trading stats — try again shortly.",
+        );
       }
     } finally {
       if (tradingProfileRequestRef.current === requestId) {


### PR DESCRIPTION
Closes #14426.

## The bug (on-device, Seeker demo QA)
The wallet dashboard rendered a bare red **"Not found"** under the P&L chart. Root cause: `InventoryAppView.tsx` `loadTradingProfile`'s catch stored the caught error's message **verbatim** (`cause.message`) — for a backend that doesn't serve the trading-stats route, that's the raw 404 body `"Not found"` — and rendered it in `text-danger` (L2207).

## Fix (three-state rule, matching the established wallet pattern at `useWalletState.ts:359`)
- **404 (feature unavailable on this backend) → designed empty state (J4):** no error text; the P&L panel keeps its own "Trade to see your P&L here" copy.
- **Any other failure → human copy** ("Couldn't load trading stats — try again shortly.") — never the raw response body.

(`loadMarketOverview` next to it already degrades correctly via `marketOverviewUnavailable` — unchanged.)

## Evidence
<details><summary><code>plugins/plugin-wallet-ui</code> — <b>44/44 pass</b> (10 files), incl. 2 new regression tests</summary>

```
 Test Files  10 passed (10)
      Tests  44 passed (44)
```
New: *degrades a trading-profile 404 to the designed empty P&L state — no raw 'Not found' leak (#14426)* and *surfaces a non-404 trading-profile failure as human copy, never the raw response body (#14426)* — both reject the mocked client fetch with the ApiError shape (`Object.assign(new Error(body), {status})`) and assert on the rendered DOM.
</details>

- `biome check` clean on both files.
- Before (on-device): red "Not found" at the bottom of the wallet view (screenshot in the issue thread context).

Authored by `[maintainer]` — needs a reviewer lane (no self-merge). Fourth and last of tonight's Seeker demo-QA findings (#14423, #14429, #14441 all merged).