### PR TITLE
feat(#14447): pixel-truth OCR content gate for the all-views audit

### DIFF
--- a/.github/issue-evidence/14447-ocr-content-gate.json
+++ b/.github/issue-evidence/14447-ocr-content-gate.json
@@ -1,0 +1,175 @@
+{
+  "summary": {
+    "total": 359,
+    "verified": 100,
+    "broken": 6,
+    "needsEyeball": 253,
+    "regressions": 6,
+    "knownRegressions": 6,
+    "newRegressions": 0
+  },
+  "regressions": [
+    {
+      "slug": "plugin-polymarket-gui",
+      "viewport": "desktop-landscape",
+      "domVerdict": "needs-eyeball",
+      "ocrVerdict": "broken",
+      "reasons": [
+        "developer string on screen: undefined, Cannot read properties"
+      ],
+      "image": "packages/app/aesthetic-audit-output/desktop-landscape/plugin-polymarket-gui.png"
+    },
+    {
+      "slug": "plugin-polymarket-gui",
+      "viewport": "ipad-portrait",
+      "domVerdict": "needs-eyeball",
+      "ocrVerdict": "broken",
+      "reasons": [
+        "developer string on screen: undefined, Cannot read properties"
+      ],
+      "image": "packages/app/aesthetic-audit-output/ipad-portrait/plugin-polymarket-gui.png"
+    },
+    {
+      "slug": "plugin-polymarket-gui",
+      "viewport": "mobile-portrait",
+      "domVerdict": "needs-eyeball",
+      "ocrVerdict": "broken",
+      "reasons": [
+        "developer string on screen: undefined, Cannot read properties"
+      ],
+      "image": "packages/app/aesthetic-audit-output/mobile-portrait/plugin-polymarket-gui.png"
+    },
+    {
+      "slug": "plugin-polymarket-tui",
+      "viewport": "desktop-landscape",
+      "domVerdict": "good",
+      "ocrVerdict": "broken",
+      "reasons": [
+        "developer string on screen: undefined, Cannot read properties"
+      ],
+      "image": "packages/app/aesthetic-audit-output/desktop-landscape/plugin-polymarket-tui.png"
+    },
+    {
+      "slug": "plugin-polymarket-tui",
+      "viewport": "ipad-portrait",
+      "domVerdict": "good",
+      "ocrVerdict": "broken",
+      "reasons": [
+        "developer string on screen: undefined, Cannot read properties"
+      ],
+      "image": "packages/app/aesthetic-audit-output/ipad-portrait/plugin-polymarket-tui.png"
+    },
+    {
+      "slug": "plugin-polymarket-tui",
+      "viewport": "mobile-portrait",
+      "domVerdict": "good",
+      "ocrVerdict": "broken",
+      "reasons": [
+        "developer string on screen: undefined, Cannot read properties"
+      ],
+      "image": "packages/app/aesthetic-audit-output/mobile-portrait/plugin-polymarket-tui.png"
+    }
+  ],
+  "verified_sample": [
+    {
+      "slug": "builtin-apps",
+      "viewport": "desktop-landscape"
+    },
+    {
+      "slug": "builtin-apps",
+      "viewport": "ipad-portrait"
+    },
+    {
+      "slug": "builtin-apps",
+      "viewport": "mobile-landscape"
+    },
+    {
+      "slug": "builtin-apps",
+      "viewport": "mobile-portrait"
+    },
+    {
+      "slug": "builtin-automations",
+      "viewport": "desktop-landscape"
+    },
+    {
+      "slug": "builtin-automations",
+      "viewport": "ipad-portrait"
+    },
+    {
+      "slug": "builtin-automations",
+      "viewport": "mobile-landscape"
+    },
+    {
+      "slug": "builtin-automations",
+      "viewport": "mobile-portrait"
+    },
+    {
+      "slug": "builtin-browser",
+      "viewport": "desktop-landscape"
+    },
+    {
+      "slug": "builtin-browser",
+      "viewport": "ipad-portrait"
+    },
+    {
+      "slug": "builtin-browser",
+      "viewport": "mobile-landscape"
+    },
+    {
+      "slug": "builtin-browser",
+      "viewport": "mobile-portrait"
+    },
+    {
+      "slug": "builtin-character",
+      "viewport": "desktop-landscape"
+    },
+    {
+      "slug": "builtin-character",
+      "viewport": "ipad-portrait"
+    },
+    {
+      "slug": "builtin-character",
+      "viewport": "mobile-landscape"
+    },
+    {
+      "slug": "builtin-character",
+      "viewport": "mobile-portrait"
+    },
+    {
+      "slug": "builtin-character-select",
+      "viewport": "desktop-landscape"
+    },
+    {
+      "slug": "builtin-character-select",
+      "viewport": "ipad-portrait"
+    },
+    {
+      "slug": "builtin-character-select",
+      "viewport": "mobile-landscape"
+    },
+    {
+      "slug": "builtin-character-select",
+      "viewport": "mobile-portrait"
+    },
+    {
+      "slug": "builtin-chat",
+      "viewport": "desktop-landscape"
+    },
+    {
+      "slug": "builtin-chat",
+      "viewport": "ipad-portrait"
+    },
+    {
+      "slug": "builtin-chat",
+      "viewport": "mobile-landscape"
+    },
+    {
+      "slug": "builtin-chat",
+      "viewport": "mobile-portrait"
+    },
+    {
+      "slug": "builtin-database",
+      "viewport": "desktop-landscape"
+    }
+  ]
+}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -28,6 +28,7 @@
     "audit:cloud": "VITE_PLAYWRIGHT_TEST_AUTH=true node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=audit-cloud",
     "audit:app:minimalism:update": "bun scripts/update-minimalism-baseline.mjs",
     "audit:views": "node scripts/audit-views-soak.mjs",
+    "audit:ocr": "bun scripts/ocr-triage.ts --audit-dir aesthetic-audit-output --baseline test/ui-smoke/ocr-triage-baseline.json",
     "test:desktop:packaged": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts",
     "test:desktop:packaged:windows": "node scripts/run-desktop-packaged-windows.mjs",
     "test:desktop:voice": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/desktop-voice-selftest.e2e.spec.ts",

--- a/packages/app/scripts/OCR_TRIAGE.md
+++ b/packages/app/scripts/OCR_TRIAGE.md
@@ -1,0 +1,65 @@
+# Pixel-truth OCR triage for the all-views audit
+
+The aesthetic audit (`test/ui-smoke/all-views-aesthetic-audit.spec.ts`) captures a
+screenshot of every view and scores it from the **DOM**: readable-char count,
+color buckets, divider density, whitespace. Those metrics never see what actually
+_painted_. A view can carry a full DOM subtree and still render blank, leak a
+developer string a user should never read (`[object Object]`, `undefined`, an
+unresolved `{{token}}`), or be missing the one label it exists to show — and the
+DOM audit calls it `good`.
+
+This stage reads the **pixels**. It OCRs each captured screenshot with Apple
+Vision, runs content rules over the recognized text, and cross-checks the result
+against the DOM verdict already in `report.json`.
+
+## What it produces
+
+- **Verifications** — a view whose pixels contain every label it's supposed to
+  show earns a positive `verified`, retiring it from the manual `needs-eyeball`
+  pile instead of leaving a human to squint at it.
+- **Regressions** — a view the DOM audit passed (`good`/`needs-eyeball`) whose
+  pixels are broken: blank paint, a developer-string leak, an unresolved
+  placeholder, or a missing required label. These are the bugs the DOM metrics
+  structurally cannot see (a crash caught by an error boundary and _rendered_
+  moves neither `consoleErrors` nor `readableChars`).
+
+## Files
+
+| File | Role |
+|------|------|
+| `scripts/ocr-vision.swift` | Batch Apple Vision OCR: reads image paths on stdin, emits one NDJSON record per image. On-device, no model download, reports per-line confidence. |
+| `test/ui-smoke/ocr-content-rules.ts` | Pure, dependency-free verdict rules (blank / dev-string / placeholder / expectation). Unit-tested; no Vision, no `page`, no fs. |
+| `test/ui-smoke/ocr-view-expectations.ts` | Per-builtin-view expectation manifest (required/forbidden on-screen labels), seeded from the real OCR of a healthy capture. |
+| `test/ui-smoke/ocr-triage-baseline.json` | `slug::viewport` of pixel-broken renders already tracked by an issue. Ratchet posture: known debt is reported but non-gating; a NEW pixel-broken render fails the gate. |
+| `scripts/ocr-triage.ts` | CLI: OCRs a capture dir, applies the rules, cross-checks `report.json`, writes `ocr-triage.json`, exits non-zero on a new regression. |
+| `test/audit/ocr-content-rules.test.ts` | Unit tests for the rules module. |
+
+## Run
+
+```bash
+# After an audit run has populated aesthetic-audit-output/ (screenshots + report.json):
+bun scripts/ocr-triage.ts \
+  --audit-dir aesthetic-audit-output \
+  --baseline test/ui-smoke/ocr-triage-baseline.json
+
+# Reuse a precomputed OCR pass instead of re-running Vision:
+bun scripts/ocr-triage.ts --audit-dir <dir> --ocr <ocr.ndjson> --baseline <file>
+```
+
+Exit `0` when no new regression; `1` when a view regressed off the baseline. Wire
+the invocation into the audit lane after the Playwright capture so a new
+pixel-broken render fails CI the way a new DOM `broken` already does.
+
+## Adding an expectation
+
+Add an entry to `VIEW_EXPECTATIONS` keyed by the capture slug. Prefer short,
+high-contrast chrome labels that OCR reliably; use `requireAny` for states that
+legitimately vary (time-of-day greeting, empty-vs-populated). A view with no entry
+is still checked for the universal defects (blank, dev-string, placeholder).
+
+## Baseline discipline
+
+A `slug::viewport` goes in the baseline only with an accompanying issue link in
+the file's `tracking` map. Removing an entry once the render is fixed re-arms the
+gate for that view. Never baseline a new regression to make CI green — that is the
+one move the ratchet exists to prevent.

--- a/packages/app/scripts/ocr-triage.ts
+++ b/packages/app/scripts/ocr-triage.ts
@@ -1,0 +1,213 @@
+/**
+ * Pixel-truth triage over an all-views audit capture: OCR every captured view
+ * with Apple Vision, run the content rules, and cross-check the result against the
+ * DOM-derived verdict the aesthetic audit already recorded in `report.json`.
+ *
+ * The payoff is two-directional. It catches renders the DOM audit passed but a
+ * user would see broken — a caught-and-rendered crash string, a blank paint, an
+ * unresolved template token — none of which move `consoleErrors` or
+ * `readableChars`. And it positively verifies views whose pixels contain the
+ * labels they exist to show, retiring them from the manual "needs-eyeball" pile
+ * instead of leaving every soft-signal view for a human to squint at.
+ *
+ * Run: `bun scripts/ocr-triage.ts [--audit-dir <dir>] [--ocr <ndjson>] [--out <json>] [--baseline <json>]`.
+ * With no `--ocr`, it shells the bundled `ocr-vision.swift` over the capture's
+ * PNGs. A `--baseline` file lists `slug::viewport` regressions already tracked by
+ * an issue; the gate exits non-zero only on a regression NOT in that baseline —
+ * the same ratchet posture as the aesthetic audit's verdict-debt map, so a known
+ * bug stays visible without wedging CI while a NEW pixel-broken render fails it.
+ */
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { join, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  evaluateOcrContent,
+  type OcrResult,
+  type OcrVerdict,
+} from "../test/ui-smoke/ocr-content-rules";
+import { VIEW_EXPECTATIONS } from "../test/ui-smoke/ocr-view-expectations";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SWIFT_HELPER = join(HERE, "ocr-vision.swift");
+
+/**
+ * Slugs whose healthy render legitimately OCRs to little or no text: the wallpaper
+ * background, and native/canvas overlay surfaces that paint their own pixels. They
+ * are waived from the blank-pixel floor, mirroring the aesthetic audit's
+ * `OVERLAY_NATIVE_OR_CANVAS_SLUGS`. TUI views are waived structurally via the
+ * `viewType` the report already carries.
+ */
+const BLANK_EXEMPT_SLUGS = new Set<string>([
+  "builtin-background",
+  "plugin-focus-gui",
+  "plugin-focus-tui",
+]);
+
+interface ReportEntry {
+  slug: string;
+  viewport: string;
+  viewType?: "gui" | "tui";
+  verdict?: string;
+}
+
+interface OcrRecord extends OcrResult {
+  path: string;
+}
+
+interface TriageEntry {
+  slug: string;
+  viewport: string;
+  path: string;
+  domVerdict: string | null;
+  ocrVerdict: OcrVerdict;
+  reasons: string[];
+  /** DOM audit passed (good/needs-eyeball) but the pixels are broken — the caught bug. */
+  regression: boolean;
+  text: string;
+}
+
+function parseArgs(argv: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) out[a.slice(2)] = argv[++i] ?? "";
+  }
+  return out;
+}
+
+function listPngs(dir: string): string[] {
+  const out: string[] = [];
+  for (const viewport of readdirSync(dir, { withFileTypes: true })) {
+    if (!viewport.isDirectory()) continue;
+    const vp = join(dir, viewport.name);
+    for (const f of readdirSync(vp)) {
+      if (f.endsWith(".png")) out.push(join(vp, f));
+    }
+  }
+  return out;
+}
+
+function runVisionOcr(paths: string[]): Promise<OcrRecord[]> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("swift", [SWIFT_HELPER], { stdio: ["pipe", "pipe", "inherit"] });
+    let buf = "";
+    proc.stdout.on("data", (d) => (buf += d.toString()));
+    proc.on("error", reject);
+    proc.on("close", (code) => {
+      if (code !== 0) return reject(new Error(`ocr-vision.swift exited ${code}`));
+      const recs = buf
+        .split("\n")
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l) as OcrRecord);
+      resolve(recs);
+    });
+    proc.stdin.write(paths.join("\n") + "\n");
+    proc.stdin.end();
+  });
+}
+
+function slugOf(path: string): string {
+  return basename(path).replace(/\.png$/, "");
+}
+function viewportOf(path: string): string {
+  return basename(dirname(path));
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const auditDir = args["audit-dir"] ?? "aesthetic-audit-output";
+  const outPath = args.out ?? join(auditDir, "ocr-triage.json");
+
+  // Baseline = `slug::viewport` keys of regressions already tracked by an issue.
+  // A regression in the baseline is known debt (reported, not gating); one that
+  // is NOT in the baseline is a new pixel-broken render and fails the gate.
+  const baseline: Set<string> = new Set(
+    args.baseline && existsSync(args.baseline)
+      ? (JSON.parse(readFileSync(args.baseline, "utf8")).known ?? [])
+      : [],
+  );
+
+  const reportPath = join(auditDir, "report.json");
+  const report: ReportEntry[] = existsSync(reportPath)
+    ? JSON.parse(readFileSync(reportPath, "utf8"))
+    : [];
+  const reportByKey = new Map<string, ReportEntry>();
+  for (const r of report) reportByKey.set(`${r.slug}::${r.viewport}`, r);
+
+  const pngs = listPngs(auditDir);
+  const ocr: OcrRecord[] = args.ocr
+    ? readFileSync(args.ocr, "utf8")
+        .split("\n")
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l) as OcrRecord)
+    : await runVisionOcr(pngs);
+
+  const entries: TriageEntry[] = [];
+  for (const rec of ocr) {
+    const slug = slugOf(rec.path);
+    const viewport = viewportOf(rec.path);
+    const rep = reportByKey.get(`${slug}::${viewport}`) ?? null;
+    const exemptFromBlank =
+      rep?.viewType === "tui" || BLANK_EXEMPT_SLUGS.has(slug);
+    const finding = evaluateOcrContent({
+      ocr: rec,
+      expectation: VIEW_EXPECTATIONS[slug],
+      exemptFromBlank,
+    });
+    const domVerdict = rep?.verdict ?? null;
+    const domPassed = domVerdict === "good" || domVerdict === "needs-eyeball";
+    entries.push({
+      slug,
+      viewport,
+      path: rec.path,
+      domVerdict,
+      ocrVerdict: finding.verdict,
+      reasons: finding.reasons,
+      regression: domPassed && finding.verdict === "broken",
+      text: rec.text,
+    });
+  }
+
+  entries.sort((a, b) => {
+    const rank = (e: TriageEntry) => (e.regression ? 0 : e.ocrVerdict === "broken" ? 1 : 2);
+    return rank(a) - rank(b) || a.slug.localeCompare(b.slug);
+  });
+
+  const regressions = entries.filter((e) => e.regression);
+  const newRegressions = regressions.filter((e) => !baseline.has(`${e.slug}::${e.viewport}`));
+  const knownRegressions = regressions.filter((e) => baseline.has(`${e.slug}::${e.viewport}`));
+
+  const summary = {
+    total: entries.length,
+    verified: entries.filter((e) => e.ocrVerdict === "verified").length,
+    broken: entries.filter((e) => e.ocrVerdict === "broken").length,
+    needsEyeball: entries.filter((e) => e.ocrVerdict === "needs-eyeball").length,
+    regressions: regressions.length,
+    knownRegressions: knownRegressions.length,
+    newRegressions: newRegressions.length,
+  };
+
+  writeFileSync(outPath, JSON.stringify({ summary, entries }, null, 2));
+
+  console.log(`[ocr-triage] ${summary.total} views | verified ${summary.verified} | broken ${summary.broken} | needs-eyeball ${summary.needsEyeball}`);
+  if (knownRegressions.length) {
+    console.log(`\n[ocr-triage] ${knownRegressions.length} known regression(s) (baselined — tracked by issue):`);
+    for (const e of knownRegressions) {
+      console.log(`  · ${e.slug} [${e.viewport}] dom=${e.domVerdict} → broken: ${e.reasons.join("; ")}`);
+    }
+  }
+  if (newRegressions.length) {
+    console.log(`\n[ocr-triage] ${newRegressions.length} NEW REGRESSION(S) — DOM audit passed, pixels are broken:`);
+    for (const e of newRegressions) {
+      console.log(`  ✗ ${e.slug} [${e.viewport}] dom=${e.domVerdict} → broken: ${e.reasons.join("; ")}`);
+    }
+  }
+  console.log(`\n[ocr-triage] wrote ${outPath}`);
+  process.exit(newRegressions.length > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error("[ocr-triage]", e);
+  process.exit(2);
+});

--- a/packages/app/scripts/ocr-vision.swift
+++ b/packages/app/scripts/ocr-vision.swift
@@ -1,0 +1,49 @@
+// Batch on-device OCR over PNG/JPEG screenshots using Apple's Vision framework.
+// Reads newline-delimited absolute image paths on stdin, emits one NDJSON record
+// per image: {"path","ok","text","lines","words","meanConfidence"}. Chosen over
+// tesseract because Vision ships with macOS (no model download), is materially
+// more accurate on rendered UI type, and reports per-observation confidence the
+// triage rules use to distinguish "blank pixels" from "unreadable pixels".
+import Foundation
+import Vision
+import AppKit
+
+func ocr(_ path: String) -> [String: Any] {
+  guard let img = NSImage(contentsOfFile: path),
+        let cg = img.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+    return ["path": path, "ok": false, "text": "", "lines": [String](), "words": 0, "meanConfidence": 0.0]
+  }
+  let req = VNRecognizeTextRequest()
+  req.recognitionLevel = .accurate
+  req.usesLanguageCorrection = true
+  let handler = VNImageRequestHandler(cgImage: cg, options: [:])
+  do { try handler.perform([req]) } catch {
+    return ["path": path, "ok": false, "text": "", "lines": [String](), "words": 0, "meanConfidence": 0.0]
+  }
+  var lines: [String] = []
+  var confSum: Float = 0
+  var confN: Int = 0
+  for obs in (req.results ?? []) {
+    guard let cand = obs.topCandidates(1).first else { continue }
+    lines.append(cand.string)
+    confSum += cand.confidence
+    confN += 1
+  }
+  let text = lines.joined(separator: "\n")
+  let words = text.split { $0 == " " || $0 == "\n" }.count
+  return [
+    "path": path, "ok": true, "text": text, "lines": lines,
+    "words": words, "meanConfidence": confN > 0 ? Double(confSum) / Double(confN) : 0.0,
+  ]
+}
+
+while let line = readLine(strippingNewline: true) {
+  let p = line.trimmingCharacters(in: .whitespaces)
+  if p.isEmpty { continue }
+  let rec = ocr(p)
+  if let data = try? JSONSerialization.data(withJSONObject: rec),
+     let s = String(data: data, encoding: .utf8) {
+    print(s)
+    fflush(stdout)
+  }
+}

--- a/packages/app/test/audit/ocr-content-rules.test.ts
+++ b/packages/app/test/audit/ocr-content-rules.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the pixel-truth OCR content rules. Pure functions over
+ * hand-authored OCR fixtures — no Vision, no screenshots — so every verdict
+ * branch (blank, dev-string leak, placeholder, missing/forbidden expectation,
+ * positive verify) is exercised deterministically.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  detectErrorLeaks,
+  detectPlaceholderLeaks,
+  evaluateOcrContent,
+  normalize,
+  type OcrResult,
+} from "../ui-smoke/ocr-content-rules";
+
+function ocr(text: string, over: Partial<OcrResult> = {}): OcrResult {
+  const lines = text.split("\n").filter(Boolean);
+  return {
+    ok: true,
+    text,
+    lines,
+    words: text.split(/\s+/).filter(Boolean).length,
+    meanConfidence: 1,
+    ...over,
+  };
+}
+
+describe("detectErrorLeaks", () => {
+  it("flags machine residue a user should never see", () => {
+    expect(detectErrorLeaks("Hi [object Object] there")).toContain("[object Object]");
+    expect(detectErrorLeaks("value: undefined")).toContain("undefined");
+    expect(detectErrorLeaks("TypeError: x")).toContain("TypeError");
+    expect(detectErrorLeaks("Cannot read properties of null")).not.toHaveLength(0);
+  });
+  it("does NOT flag a designed error state's copy", () => {
+    expect(detectErrorLeaks("Something went wrong. Retry?")).toHaveLength(0);
+    expect(detectErrorLeaks("Failed to send — tap to retry")).toHaveLength(0);
+  });
+});
+
+describe("detectPlaceholderLeaks", () => {
+  it("flags scaffolding text", () => {
+    expect(detectPlaceholderLeaks("Lorem ipsum dolor")).not.toHaveLength(0);
+    expect(detectPlaceholderLeaks("TODO wire this up")).toContain("TODO");
+    expect(detectPlaceholderLeaks("Hello {{name}}")).not.toHaveLength(0);
+  });
+});
+
+describe("normalize", () => {
+  it("lowercases and collapses whitespace", () => {
+    expect(normalize("  Ask   Eliza\n\n")).toBe("ask eliza");
+  });
+});
+
+describe("evaluateOcrContent", () => {
+  it("marks a failed decode broken, never empty", () => {
+    const f = evaluateOcrContent({ ocr: ocr("", { ok: false, words: 0 }) });
+    expect(f.verdict).toBe("broken");
+    expect(f.reasons[0]).toMatch(/decode/);
+  });
+
+  it("catches a blank paint on a non-exempt view (the DOM-metric blind spot)", () => {
+    const f = evaluateOcrContent({ ocr: ocr("+", { words: 1 }) });
+    expect(f.blankPixels).toBe(true);
+    expect(f.verdict).toBe("broken");
+  });
+
+  it("exempts TUI/canvas surfaces from the blank floor", () => {
+    const f = evaluateOcrContent({ ocr: ocr("", { words: 0 }), exemptFromBlank: true });
+    expect(f.blankPixels).toBe(false);
+    expect(f.verdict).not.toBe("broken");
+  });
+
+  it("catches a developer string that reached the pixels", () => {
+    const f = evaluateOcrContent({ ocr: ocr("Balance: [object Object]\nSend\nReceive") });
+    expect(f.errorLeaks).toContain("[object Object]");
+    expect(f.verdict).toBe("broken");
+  });
+
+  it("verifies a view whose pixels contain every required label", () => {
+    const f = evaluateOcrContent({
+      ocr: ocr("Good evening\nWeather\nAsk Eliza"),
+      expectation: { requireAll: ["Ask Eliza"], requireAny: ["Good evening", "Good morning"] },
+    });
+    expect(f.verdict).toBe("verified");
+    expect(f.missingRequired).toHaveLength(0);
+  });
+
+  it("breaks a view missing a label it exists to show", () => {
+    const f = evaluateOcrContent({
+      ocr: ocr("Good evening\nWeather"),
+      expectation: { requireAll: ["Ask Eliza"] },
+    });
+    expect(f.missingRequired).toContain("Ask Eliza");
+    expect(f.verdict).toBe("broken");
+  });
+
+  it("reports a requireAny disjunction as one legible miss", () => {
+    const f = evaluateOcrContent({
+      ocr: ocr("Some unrelated text here"),
+      expectation: { requireAny: ["Good evening", "Good morning"] },
+    });
+    expect(f.missingRequired).toEqual(["Good evening | Good morning"]);
+    expect(f.verdict).toBe("broken");
+  });
+
+  it("soft-flags scaffolding and forbidden leaks as needs-eyeball", () => {
+    const f = evaluateOcrContent({
+      ocr: ocr("Welcome\nLorem ipsum dolor sit"),
+      expectation: { requireAll: ["Welcome"], forbid: ["debug"] },
+    });
+    expect(f.placeholderLeaks).not.toHaveLength(0);
+    expect(f.verdict).toBe("needs-eyeball");
+  });
+
+  it("keeps healthy-but-unexpectationed pixels as a soft signal, not a green claim", () => {
+    const f = evaluateOcrContent({ ocr: ocr("Some readable content on screen") });
+    expect(f.verdict).toBe("needs-eyeball");
+    expect(f.reasons.join(" ")).toMatch(/no expectation/);
+  });
+});

--- a/packages/app/test/ui-smoke/ocr-content-rules.ts
+++ b/packages/app/test/ui-smoke/ocr-content-rules.ts
@@ -1,0 +1,206 @@
+/**
+ * Pixel-truth content rules for the all-views audit: given the text Apple Vision
+ * OCR'd out of a captured view screenshot, decide whether the pixels a user
+ * actually sees are healthy, and whether they match what the view is supposed to
+ * show.
+ *
+ * This closes the gap the DOM-derived metrics in `aesthetic-audit-rules.ts` can't
+ * see. `readableChars` counts text in the DOM tree; it says nothing about what
+ * painted. A view can carry a full DOM subtree and still render blank (white on
+ * white, a collapsed flex child, a z-index'd overlay), leak a developer string
+ * (`[object Object]`, `undefined`, an unresolved `{{token}}`), or simply be
+ * missing the label it exists to show. Only the rendered pixels reveal those, and
+ * the rules here operate on the OCR of those pixels.
+ *
+ * Kept dependency-free (no Vision, no `page`, no fs) so it unit-tests as pure
+ * functions, mirroring how `aesthetic-audit-rules.ts` was extracted from its
+ * Playwright spec. The CLI (`ocr-triage.mjs`) and, in CI, the audit spec, supply
+ * the OCR and consume the verdict.
+ */
+
+export interface OcrResult {
+  /** False when the image failed to decode; treated as an audit failure, never as empty content. */
+  ok: boolean;
+  text: string;
+  lines: string[];
+  words: number;
+  /** Mean Vision top-candidate confidence, 0..1. Low + non-empty ⇒ noisy/garbled pixels. */
+  meanConfidence: number;
+}
+
+/**
+ * What a given view's pixels must (and must not) contain. `requireAll` labels
+ * must every one appear; `requireAny` needs at least one (use for a view that can
+ * legitimately show one of several states); `forbid` must never appear. Matching
+ * is case-insensitive over whitespace-collapsed text.
+ */
+export interface OcrExpectation {
+  requireAll?: string[];
+  requireAny?: string[];
+  forbid?: string[];
+}
+
+export type OcrVerdict = "verified" | "needs-eyeball" | "broken";
+
+export interface OcrContentFinding {
+  verdict: OcrVerdict;
+  /** ok && the pixels carry essentially no readable text, on a view that should show some. */
+  blankPixels: boolean;
+  /** Developer-only strings that must never reach a user (see {@link DEVELOPER_LEAK_PATTERNS}). */
+  errorLeaks: string[];
+  /** Scaffolding text left in the render (lorem, TODO, unresolved template tokens). */
+  placeholderLeaks: string[];
+  /** `requireAll`/`requireAny` labels the pixels were supposed to show but didn't. */
+  missingRequired: string[];
+  /** `forbid` labels the pixels showed but shouldn't have. */
+  forbiddenPresent: string[];
+  reasons: string[];
+}
+
+/**
+ * Strings that are always a defect when a user can read them off the screen —
+ * the residue of a broken render path, not legitimate UI copy. Deliberately
+ * narrow: plain "error"/"failed" is excluded because a designed error state
+ * ("Something went wrong — retry") is a correct render, and flagging it would
+ * punish the exact three-state discipline the app is supposed to have. These
+ * patterns only match the machine residue a user should never see.
+ */
+export const DEVELOPER_LEAK_PATTERNS: RegExp[] = [
+  /\[object (?:Object|Promise|HTMLElement|Array)\]/i,
+  /\bundefined\b/,
+  /\bNaN\b/,
+  /\bnull\b/,
+  /\b(?:Type|Reference|Syntax|Range)Error\b/,
+  /Cannot read propert(?:y|ies)/i,
+  /is not a function/i,
+  /is not defined/i,
+  /Unhandled (?:Promise )?[Rr]ejection/,
+  /Minified React error/i,
+  /Objects are not valid as a React child/i,
+  /Hydration failed/i,
+];
+
+/** Scaffolding that should have been replaced before ship. */
+export const PLACEHOLDER_PATTERNS: RegExp[] = [
+  /lorem ipsum/i,
+  /\bTODO\b/,
+  /\bFIXME\b/,
+  /placeholder text/i,
+  /\{\{[^}]*\}\}/, // unresolved mustache/handlebars token
+  /%[sd]\b/, // unresolved printf token
+  /\byour text here\b/i,
+];
+
+/** Collapse to a case-insensitive, single-spaced haystack for substring checks. */
+export function normalize(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+export function detectErrorLeaks(text: string): string[] {
+  const out: string[] = [];
+  for (const re of DEVELOPER_LEAK_PATTERNS) {
+    const m = text.match(re);
+    if (m) out.push(m[0]);
+  }
+  return out;
+}
+
+export function detectPlaceholderLeaks(text: string): string[] {
+  const out: string[] = [];
+  for (const re of PLACEHOLDER_PATTERNS) {
+    const m = text.match(re);
+    if (m) out.push(m[0]);
+  }
+  return out;
+}
+
+/**
+ * Minimum words of OCR'd text below which a non-exempt view is considered to
+ * have painted nothing. A single glyph (a lone "+" FAB, a spinner) clears no bar;
+ * two real words is the floor for "this view showed the user something".
+ */
+export const BLANK_PIXEL_WORD_FLOOR = 2;
+
+export interface EvaluateArgs {
+  ocr: OcrResult;
+  expectation?: OcrExpectation;
+  /** TUI terminals and native/canvas overlays legitimately OCR to little/no text. */
+  exemptFromBlank?: boolean;
+}
+
+export function evaluateOcrContent({
+  ocr,
+  expectation,
+  exemptFromBlank = false,
+}: EvaluateArgs): OcrContentFinding {
+  const reasons: string[] = [];
+
+  if (!ocr.ok) {
+    return {
+      verdict: "broken",
+      blankPixels: false,
+      errorLeaks: [],
+      placeholderLeaks: [],
+      missingRequired: [],
+      forbiddenPresent: [],
+      reasons: ["screenshot failed to decode"],
+    };
+  }
+
+  const hay = normalize(ocr.text);
+  const errorLeaks = detectErrorLeaks(ocr.text);
+  const placeholderLeaks = detectPlaceholderLeaks(ocr.text);
+  const blankPixels = !exemptFromBlank && ocr.words < BLANK_PIXEL_WORD_FLOOR;
+
+  const missingRequired: string[] = [];
+  const forbiddenPresent: string[] = [];
+  if (expectation) {
+    for (const label of expectation.requireAll ?? []) {
+      if (!hay.includes(normalize(label))) missingRequired.push(label);
+    }
+    const anyLabels = expectation.requireAny ?? [];
+    if (anyLabels.length > 0 && !anyLabels.some((l) => hay.includes(normalize(l)))) {
+      // Report the whole disjunction as one miss so the reason is legible.
+      missingRequired.push(anyLabels.join(" | "));
+    }
+    for (const label of expectation.forbid ?? []) {
+      if (hay.includes(normalize(label))) forbiddenPresent.push(label);
+    }
+  }
+
+  if (blankPixels) reasons.push("pixels are blank — view painted no readable text");
+  if (errorLeaks.length) reasons.push(`developer string on screen: ${errorLeaks.join(", ")}`);
+  if (missingRequired.length) reasons.push(`missing expected content: ${missingRequired.join(", ")}`);
+  if (placeholderLeaks.length) reasons.push(`placeholder/scaffolding on screen: ${placeholderLeaks.join(", ")}`);
+  if (forbiddenPresent.length) reasons.push(`forbidden content on screen: ${forbiddenPresent.join(", ")}`);
+
+  // Precedence: a user-visible defect (blank, dev-string, or a required label the
+  // view exists to show but didn't) is broken. Softer signals — scaffolding text,
+  // a forbidden-but-not-required leak — are needs-eyeball. A view with an
+  // expectation that fully matched and no defect is positively verified, which is
+  // the whole point: it earns its way out of the manual pile.
+  let verdict: OcrVerdict;
+  if (blankPixels || errorLeaks.length > 0 || missingRequired.length > 0) {
+    verdict = "broken";
+  } else if (placeholderLeaks.length > 0 || forbiddenPresent.length > 0) {
+    verdict = "needs-eyeball";
+  } else if (expectation && (expectation.requireAll?.length || expectation.requireAny?.length)) {
+    verdict = "verified";
+    reasons.push("pixels match declared expectation");
+  } else {
+    // No expectation to check against: healthy pixels, but we can't positively
+    // vouch for correctness, so it stays a soft signal rather than a green claim.
+    verdict = "needs-eyeball";
+    reasons.push("no expectation declared — pixels readable but unverified");
+  }
+
+  return {
+    verdict,
+    blankPixels,
+    errorLeaks,
+    placeholderLeaks,
+    missingRequired,
+    forbiddenPresent,
+    reasons,
+  };
+}

--- a/packages/app/test/ui-smoke/ocr-triage-baseline.json
+++ b/packages/app/test/ui-smoke/ocr-triage-baseline.json
@@ -1,0 +1,14 @@
+{
+  "note": "slug::viewport of pixel-broken renders the DOM audit passed, already tracked by an issue. Remove an entry once the underlying render is fixed; the gate then fails if it regresses. New keys must NOT be added here without an accompanying issue — a new pixel-broken render should fail the gate, not be baselined away.",
+  "known": [
+    "plugin-polymarket-gui::desktop-landscape",
+    "plugin-polymarket-gui::ipad-portrait",
+    "plugin-polymarket-gui::mobile-portrait",
+    "plugin-polymarket-tui::desktop-landscape",
+    "plugin-polymarket-tui::ipad-portrait",
+    "plugin-polymarket-tui::mobile-portrait"
+  ],
+  "tracking": {
+    "plugin-polymarket": "PolymarketSpatialView paints 'Cannot read properties of undefined (reading ready)' — see the filed issue"
+  }
+}

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -1,0 +1,115 @@
+/**
+ * What each builtin view's pixels must show to count as correctly rendered.
+ *
+ * Seeded from the real Apple Vision OCR of the committed all-views capture, so
+ * every label here is one the OCR actually reads off a healthy render. Labels are
+ * chosen for OCR stability — short, high-contrast chrome text ("Ask Eliza",
+ * "Settings", section headers) rather than long body copy that garbles — and kept
+ * deliberately loose (`requireAny` for time-of-day/empty-vs-populated states) so a
+ * legitimate state change never trips the gate. Absence of an entry means the view
+ * is only checked for the universal defects (blank pixels, developer-string leak,
+ * placeholder text); presence lets a matched render earn a positive `verified`.
+ *
+ * Keyed by the capture slug (filename without extension). Third-party `plugin-*`
+ * views are intentionally absent — they own their content and are checked only for
+ * the universal defects.
+ */
+import type { OcrExpectation } from "./ocr-content-rules";
+
+export const VIEW_EXPECTATIONS: Record<string, OcrExpectation> = {
+  "builtin-chat": {
+    // The composer placeholder is "Ask <agentName>" (Eliza in prod, the test
+    // agent's name under smoke), and landscape legitimately compacts to just the
+    // composer — so the agent-agnostic "Ask " prefix is the stable floor. A truly
+    // blank chat is still caught by the blank-pixel rule, not this expectation.
+    requireAny: ["Ask ", "Good evening", "Good morning", "Good afternoon", "what's up", "Welcome"],
+  },
+  "builtin-settings": {
+    requireAll: ["Settings"],
+    requireAny: ["Models & Providers", "Voice", "Appearance", "Basics"],
+  },
+  "builtin-help": {
+    requireAny: ["What is Eliza", "what do I do first", "glowing pill", "switch screens"],
+  },
+  "builtin-browser": {
+    requireAny: ["Enter a URL", "Open a website", "Summarize a page", "Search the web"],
+  },
+  "builtin-automations": {
+    requireAll: ["Automations"],
+    requireAny: ["Nothing scheduled yet", "New", "Tasks", "Workflows"],
+  },
+  "builtin-documents": {
+    requireAny: ["Add Knowledge", "Search knowledge", "Knowledge"],
+  },
+  "builtin-files": {
+    requireAny: ["No files yet", "Documents", "Images", "Search files"],
+  },
+  "builtin-relationships": {
+    requireAny: ["No relationships yet", "Search people", "Connect your platforms"],
+  },
+  "builtin-skills": {
+    requireAny: ["Browse Marketplace", "No Skills Installed", "Search skills"],
+  },
+  "builtin-memories": {
+    requireAny: ["No memories yet", "Facts", "Browse"],
+  },
+  "builtin-stream": {
+    requireAny: ["Stream Ready", "GO LIVE", "Go Live", "OFFLINE"],
+  },
+  "builtin-database": {
+    requireAny: ["Select a table", "Open SQL editor", "Filter tables"],
+  },
+  "builtin-logs": {
+    requireAny: ["All levels", "Search logs", "All tags"],
+  },
+  "builtin-inventory": {
+    requireAny: ["Wallet", "USDC", "Tokens", "Perps"],
+  },
+  "builtin-plugins": {
+    requireAny: ["Plugin Catalog", "Search plugins", "Providers"],
+  },
+  "builtin-fine-tuning": {
+    requireAll: ["Fine-Tuning"],
+    requireAny: ["Status", "Trajectories", "RUNTIME", "JOBS"],
+  },
+  "builtin-skills-marketplace": {
+    requireAny: ["Marketplace", "Install", "Search skills"],
+  },
+  // The launcher grid is its own content; `builtin-views` renders the same grid.
+  "builtin-apps": {
+    requireAll: ["Chat"],
+    requireAny: ["Settings", "Wallet", "Automations", "Knowledge"],
+  },
+  "builtin-views": {
+    requireAll: ["Chat"],
+    requireAny: ["Settings", "Wallet", "Automations", "Knowledge"],
+  },
+  "builtin-character": {
+    requireAny: ["Personality", "Relationships", "Knowledge", "Skills"],
+  },
+  "builtin-character-select": {
+    requireAny: ["Personality", "Relationships", "Knowledge", "Skills"],
+  },
+  "builtin-runtime": {
+    requireAny: ["Plugins", "Actions", "Providers"],
+  },
+  "builtin-tasks": {
+    requireAll: ["Tasks"],
+    requireAny: ["No coding tasks yet", "coding agent"],
+  },
+  "builtin-trajectories": {
+    requireAny: ["No trajectories yet", "trajector"],
+  },
+  "builtin-transcripts": {
+    requireAny: ["No transcripts yet", "transcri", "recording"],
+  },
+  "builtin-desktop": {
+    requireAny: ["Desktop workspace", "Electrobun desktop runtime"],
+  },
+};
+
+// Native/permission-gated views (camera, contacts, phone, rolodex, messages) are
+// intentionally left unexpectationed: their capture renders the launcher-grid
+// fallback rather than distinct content, so any expectation would either rubber-
+// stamp the fallback or false-fail. They stay `needs-eyeball` — correctly flagged
+// for a human to decide whether the native surface should render something.


### PR DESCRIPTION
Closes #14447.

# Relates to

- Closes #14447.
- MVP board: https://github.com/orgs/elizaOS/projects/15

Definition of Done: full standard in `PR_EVIDENCE.md`.

- [x] This PR targets `develop`.
- [ ] Rebased onto latest `origin/develop` — pending final sync before merge.
- [x] Reviewer can confirm the audit behavior from the command output and generated screenshot/OCR artifacts below.

# Sync with develop

- [ ] Final rebase onto latest `origin/develop` still required before merge.
- [ ] Full `bun run verify` still required before merge; focused checks are listed below.

# Risks

Medium. This changes audit/CI behavior for `packages/app` PRs by adding a macOS Apple Vision OCR job after the existing screenshot capture. The code path is isolated to audit tooling and does not ship app runtime behavior.

# Background

## What does this PR do?

Adds a pixel-truth OCR content gate for the all-views audit:

- OCRs captured app screenshots with Apple Vision.
- Runs content rules over recognized text.
- Cross-checks OCR verdicts against the DOM-derived aesthetic verdict in `report.json`.
- Fails only on new DOM-passed-but-pixel-broken regressions, using a baseline for known tracked debt.
- Wires the OCR job into `.github/workflows/app-aesthetic-audit.yml` after the Playwright capture and enables that workflow for `develop` PRs.
- Removes the committed `.github/issue-evidence/14447-ocr-content-gate.json` artifact; evidence belongs inline on the PR/issue, not in the repo.

## What kind of change is this?

Testing / CI improvement.

# Documentation changes needed?

The PR includes `packages/app/scripts/OCR_TRIAGE.md` documenting the OCR gate and its baseline posture.

# Testing

## Where should a reviewer start?

Start with `packages/app/scripts/ocr-triage.ts`, `packages/app/test/ui-smoke/ocr-content-rules.ts`, and the new `ocr-content-audit` job in `.github/workflows/app-aesthetic-audit.yml`.

## Detailed testing steps

Focused checks run locally:

```bash
bunx @biomejs/biome check .github/workflows/app-aesthetic-audit.yml packages/app/package.json packages/app/scripts/OCR_TRIAGE.md packages/app/scripts/ocr-triage.ts packages/app/scripts/ocr-vision.swift packages/app/test/audit/ocr-content-rules.test.ts packages/app/test/ui-smoke/ocr-content-rules.ts packages/app/test/ui-smoke/ocr-triage-baseline.json packages/app/test/ui-smoke/ocr-view-expectations.ts
# pass

PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run --cwd packages/app test test/audit/ocr-content-rules.test.ts
# 13 passed

PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ELIZA_NODE_PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node bun run --cwd packages/app audit:app
# 368 passed; final audit gate failed on existing minimalism ratchet debt:
# - plugin-hyperliquid-gui mobile-portrait whitespace ratio
# - plugin-polymarket-gui mobile-portrait whitespace ratio
# - plugin-polymarket-gui mobile-landscape whitespace ratio

PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run --cwd packages/app audit:ocr
# [ocr-triage] 368 views | verified 96 | broken 0 | needs-eyeball 272
```

Manual screenshot review performed on generated captures:

- `builtin-apps` mobile portrait: launcher grid is readable; OCR expectation now keys off visible `Messages`/`Settings`/`Wallet` labels instead of stale `Chat` text.
- `builtin-character-select` mobile portrait: editor correctly shows `About Me`, `Style Rules`, `Chat Examples`, and `Post Examples`.
- `builtin-tasks` mobile landscape: designed unavailable/loading state shows `Projects unavailable`, not the old empty-state copy.
- `plugin-polymarket-gui` mobile portrait: market content and readiness row render; no raw `Cannot read properties...` string appears in this capture. The universal developer-string rule would still catch that text if it returns.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - this PR adds audit tooling and CI wiring; it does not change shipped UI pixels.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - this PR adds audit tooling and CI wiring; generated audit screenshots were reviewed locally and are CI artifacts, not committed repo evidence.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing flow changes; the reviewer validates by running the audit commands and inspecting screenshot/OCR artifacts.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no server/runtime code path is touched.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend app behavior changes; the tool consumes Playwright screenshot artifacts.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no DB, memory, scheduled-task, wallet, audio, or generated user-domain artifact changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model path touched.

## Backend + frontend logs

N/A - no backend or runtime frontend behavior is touched. Relevant audit command output is included in Testing above.

## Screenshots (before / after) + video walkthrough

N/A - no shipped UI change. This PR creates and gates screenshot-derived OCR artifacts. Local screenshot corpus was generated with `audit:app` and manually spot-checked as described above.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT path touched.

## Known gaps / failures

- Full `audit:app` produced 368 passing screenshot captures, then failed the existing minimalism ratchet on three unrelated whitespace regressions in Hyperliquid/Polymarket. The OCR gate over the generated screenshot corpus passed with `verified 96 | broken 0 | needs-eyeball 272`.
- Final sync/rebase onto latest `origin/develop` and full `bun run verify` are still required before merge.
