### PR TITLE
fix(chat): pulse overlay mic while recording + normalize composer icon optics (#14331)

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -869,7 +869,9 @@ describe("ContinuousChatOverlay", () => {
 
   it("keeps the hot-mic pulse OFF under reduced motion — static accent, no breathing (#14331)", () => {
     render(
-      <ContinuousChatOverlay controller={makeController({ recording: true })} />,
+      <ContinuousChatOverlay
+        controller={makeController({ recording: true })}
+      />,
     );
     const mic = screen.getByTestId("chat-composer-mic");
     // The animate-pulse ships paired with motion-reduce:animate-none so an OS

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -836,6 +836,113 @@ describe("ContinuousChatOverlay", () => {
     expect(mic.className).not.toMatch(/\bborder\b/);
   });
 
+  // #14331: color and motion must agree. At rest the mic is neutral and still;
+  // once the mic is hot it breathes the accent — the SAME predicate that flips
+  // `active`/`text-accent` — so it matches the grabber bar and collapsed pill
+  // (which already pulse) instead of only changing color.
+  it("pulses the mic button exactly when the recording predicate is true, static at rest (#14331)", () => {
+    const { unmount } = render(
+      <ContinuousChatOverlay controller={makeController()} />,
+    );
+    // Rest: neutral, no pulse.
+    const resting = screen.getByTestId("chat-composer-mic");
+    expect(resting.getAttribute("aria-pressed")).toBe("false");
+    expect(resting.className).not.toContain("animate-pulse");
+    unmount();
+
+    // Each arm of `recording || handsFree || transcriptionMode` must pulse.
+    for (const arm of [
+      { recording: true },
+      { handsFree: true },
+      { transcriptionMode: true },
+    ] as const) {
+      const view = render(
+        <ContinuousChatOverlay controller={makeController(arm)} />,
+      );
+      const mic = screen.getByTestId("chat-composer-mic");
+      expect(mic.getAttribute("aria-pressed")).toBe("true");
+      expect(mic.className).toContain("text-accent");
+      expect(mic.className).toContain("animate-pulse");
+      view.unmount();
+    }
+  });
+
+  it("keeps the hot-mic pulse OFF under reduced motion — static accent, no breathing (#14331)", () => {
+    render(
+      <ContinuousChatOverlay controller={makeController({ recording: true })} />,
+    );
+    const mic = screen.getByTestId("chat-composer-mic");
+    // The animate-pulse ships paired with motion-reduce:animate-none so an OS
+    // reduce-motion preference cancels the animation while the accent stays.
+    expect(mic.className).toContain("animate-pulse");
+    expect(mic.className).toContain("motion-reduce:animate-none");
+    expect(mic.className).toContain("text-accent");
+  });
+
+  // The collapsed-pill pulse (glow={listening || responding}) shipped without a
+  // regression test; #14331 adds one so the sibling behavior the mic now matches
+  // can't silently regress.
+  it("pulses the collapsed pill while audio is hot and stays static otherwise (#14331)", () => {
+    const { unmount } = render(
+      <ContinuousChatOverlay controller={makeController()} />,
+    );
+    const restingPill = screen
+      .getByTestId("chat-pill")
+      .querySelector("span[aria-hidden='true']");
+    expect(restingPill?.className).not.toContain("animate-pulse");
+    expect(restingPill?.className).toContain("bg-muted-strong");
+    unmount();
+
+    render(
+      <ContinuousChatOverlay
+        controller={makeController({ phase: "listening", recording: true })}
+      />,
+    );
+    const hotPill = screen
+      .getByTestId("chat-pill")
+      .querySelector("span[aria-hidden='true']");
+    expect(hotPill?.className).toContain("animate-pulse");
+    expect(hotPill?.className).toContain("bg-accent");
+    expect(hotPill?.className).toContain("motion-reduce:animate-none");
+  });
+
+  // #14331 optics: the '+' (filled glyph) and mic/send (lucide strokes) must
+  // read at one visual weight — a single glyph size, not the old 30px vs 26px
+  // split — while the 44×44 hit target (WCAG 2.5.5) is untouched.
+  it("renders the +, mic, and send glyphs at one shared size with the hit target intact (#14331)", () => {
+    const { unmount } = render(
+      <ContinuousChatOverlay controller={makeController()} />,
+    );
+    const attachGlyph = screen
+      .getByTestId("chat-composer-attach")
+      .querySelector("svg");
+    const micGlyph = screen
+      .getByTestId("chat-composer-mic")
+      .querySelector("svg");
+    expect(attachGlyph?.getAttribute("class")).toContain("h-[28px]");
+    expect(attachGlyph?.getAttribute("class")).toContain("w-[28px]");
+    expect(micGlyph?.getAttribute("class")).toContain("h-[28px]");
+    expect(micGlyph?.getAttribute("class")).toContain("w-[28px]");
+    // The old asymmetric sizes are gone.
+    expect(attachGlyph?.getAttribute("class")).not.toContain("h-[30px]");
+    expect(micGlyph?.getAttribute("class")).not.toContain("h-[26px]");
+    // Hit target unchanged.
+    expect(screen.getByTestId("chat-composer-mic").className).toContain("h-11");
+    expect(screen.getByTestId("chat-composer-attach").className).toContain(
+      "w-11",
+    );
+    unmount();
+
+    // Send swaps in on a draft — it too rides the shared glyph size.
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    fireEvent.change(screen.getByLabelText("message"), {
+      target: { value: "hi" },
+    });
+    const sendGlyph = screen.getByLabelText("send").querySelector("svg");
+    expect(sendGlyph?.getAttribute("class")).toContain("h-[28px]");
+    expect(sendGlyph?.getAttribute("class")).toContain("w-[28px]");
+  });
+
   it("does not render the resting suggestion strip (feature-flagged off)", () => {
     render(
       <ContinuousChatOverlay controller={makeController({ messages: [] })} />,

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -301,6 +301,12 @@ function textToBase64(text: string): string {
 // Muted-speaker glyph for the autoplay-blocked "tap to enable sound" prompt.
 const SPEAKER_MUTED_GLYPH =
   "M7 15H12L18 10V26L12 21H7Z M21 12.4L22.4 11L31 19.6L29.6 21Z";
+// One optically-balanced glyph size for every composer control. Lucide icons
+// (stroked, 24-unit viewBox) and the hand-drawn glyphs (filled, 36-unit viewBox)
+// previously rendered at 26px vs 30px, so the filled '+' read heavier than the
+// mic/send strokes; a single 28px converges their visual weight while the 44×44
+// SoftButton hit target (WCAG 2.5.5) is unchanged.
+const COMPOSER_GLYPH_SIZE = "h-[28px] w-[28px]";
 function Glyph({
   d,
   className,
@@ -331,6 +337,7 @@ function SoftButton({
   onPointerLeave,
   disabled,
   active,
+  pulse,
   testId,
 }: {
   /** A hand-drawn SVG path glyph (legacy), OR pass `icon` for a lucide icon. */
@@ -344,6 +351,9 @@ function SoftButton({
   onPointerLeave?: React.PointerEventHandler<HTMLButtonElement>;
   disabled?: boolean;
   active?: boolean;
+  /** When true, breathe the accent glyph (same pulse the hot-mic grabber/pill
+   *  use) so the primary-surface control's motion agrees with its accent color. */
+  pulse?: boolean;
   testId?: string;
 }): React.JSX.Element {
   return (
@@ -370,13 +380,18 @@ function SoftButton({
         // blue.
         "grid h-11 w-11 shrink-0 place-items-center bg-transparent p-0 transition-colors hover:bg-transparent",
         active ? "text-accent" : "text-muted-strong hover:text-txt",
+        // Breathe the accent glyph while the mic is hot — the same
+        // `animate-pulse` + `motion-reduce:animate-none` the grabber bar and
+        // collapsed pill use, so every surface's motion agrees. Reduced motion
+        // keeps the static accent, no pulse.
+        pulse && "animate-pulse motion-reduce:animate-none",
         disabled && "opacity-40",
       )}
     >
       {Icon ? (
-        <Icon className="h-[26px] w-[26px]" aria-hidden={true} />
+        <Icon className={COMPOSER_GLYPH_SIZE} aria-hidden={true} />
       ) : glyph ? (
-        <Glyph d={glyph} className="h-[30px] w-[30px]" />
+        <Glyph d={glyph} className={COMPOSER_GLYPH_SIZE} />
       ) : null}
     </Button>
   );
@@ -4735,6 +4750,7 @@ export function ContinuousChatOverlay({
                       // the composer while onboarding is choice-driven.
                       disabled={firstRunOpen}
                       active={recording || handsFree || transcriptionMode}
+                      pulse={recording || handsFree || transcriptionMode}
                       onClick={handleMicClick}
                       onPointerDown={micHoldHandlers.onPointerDown}
                       onPointerUp={micHoldHandlers.onPointerUp}

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -864,6 +864,15 @@ try {
         .evaluate((el) => el.className.includes("animate-pulse")),
       "LISTENING: the grabber bar pulses while the mic is hot",
     );
+    // #14331: the overlay's own mic button must pulse too — color AND motion
+    // agree on the primary surface, matching the grabber/pill instead of only
+    // turning accent.
+    assert(
+      await p
+        .getByTestId("chat-composer-mic")
+        .evaluate((el) => el.className.includes("animate-pulse")),
+      "LISTENING: the mic button itself pulses (accent) while hot (#14331)",
+    );
     await snap(p, "state-recording-listening");
     await p.close();
   }


### PR DESCRIPTION
Closes #14331

## What

On the **primary** chat surface, the overlay's own mic button only turned accent-colored while recording — it never pulsed, even though every sibling hot-mic surface (grabber bar, collapsed pill, kiosk composer, HomePill) already breathes. Color and motion disagreed.

1. **Mic pulse.** Added a `pulse` prop to `SoftButton` that applies the same `animate-pulse motion-reduce:animate-none` the grabber bar (`:529`) and collapsed pill (`:620`) use, driven off the SAME `recording || handsFree || transcriptionMode` predicate that already sets `active`/`text-accent`. Orange accent only — no background/border change, no blue.
2. **Icon optics.** Lucide icons (26px) and hand-drawn glyphs (30px) now share one `COMPOSER_GLYPH_SIZE` (28px) so `+`, mic, and send read at one visual weight. The 44×44 hit target (WCAG 2.5.5) is unchanged (only the inner glyph metrics moved).

No new buttons — iconography/animation only (native-over-buttons).

## Tests (real path, no mocks standing in for the thing under test)

New cases in `ContinuousChatOverlay.test.tsx` render the **real** overlay in jsdom and assert on the actual DOM classes:

- mic carries `animate-pulse` exactly when the recording predicate is true — each arm (`recording`, `handsFree`, `transcriptionMode`) — and drops it at rest (`aria-pressed=false`, no pulse).
- reduced-motion pairing: `motion-reduce:animate-none` ships with the pulse; accent stays.
- **collapsed-pill pulse regression** (previously untested per the issue): pill span pulses `bg-accent` when audio is hot, `bg-muted-strong` static otherwise.
- `+`/mic/send all render at the single `h-[28px] w-[28px]` size; hit target `h-11 w-11` intact.

`bun run --cwd packages/ui test -- ContinuousChatOverlay.test.tsx` → **153 passed**.

## Evidence

- [ ] MP4 walkthrough (desktop + mobile): listening → mic pulses; stop → static; reduced-motion → no pulse
- [ ] Before/after JPG: mic static-while-recording (wrong) vs pulsing (right); +/mic/send optical-size side-by-side
- [x] Regression-test output (pass) — see above
- [ ] Frontend console logs of the recording state transitions

Evidence posted inline below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)