### PR TITLE
chore(chat): rewrite stale chat-full-maximize specs to the pull gesture (#14332)

### DIFF
--- a/packages/app/test/ui-smoke/chat-send-voice-newchat-fuzz.spec.ts
+++ b/packages/app/test/ui-smoke/chat-send-voice-newchat-fuzz.spec.ts
@@ -303,14 +303,15 @@ test.beforeEach(async ({ page }) => {
 test("a turn queued while the view switches away and back lands in the conversation it was sent in (#10700)", async ({
   page,
 }, testInfo) => {
-  // Post-#13531 the single infinite thread removed the overlay's new-chat
-  // trigger (chat-full-clear), so the original "start a new chat mid-flight"
-  // perturbation is no longer reachable on this surface. The #10700 routing
-  // invariant it protected — a queued turn is delivered ONLY to the conversation
-  // it was enqueued in, never rerouted when the active conversation context
-  // changes under it — is exercised here by switching the view away and back
-  // while a turn is still queued (a real, overlay-supported perturbation). The
-  // exact per-turn ordering is pinned deterministically by the component fuzz
+  // The single infinite thread (#13531) never resets, so the "start a new chat
+  // mid-flight" perturbation the original #10700 repro used is gone (the header
+  // new-chat control clears the active thread, it does not spawn a competing
+  // conversation). The #10700 routing invariant it protected — a queued turn is
+  // delivered ONLY to the conversation it was enqueued in, never rerouted when
+  // the active conversation context changes under it — is exercised here by
+  // switching the view away and back while a turn is still queued (a real,
+  // overlay-supported perturbation). The exact per-turn ordering is pinned
+  // deterministically by the component fuzz
   // (useChatSend.send-voice-newchat.race.test.tsx).
   await installConversationStore(page, store, 1600);
   await openAppPath(page, "/chat");

--- a/packages/app/test/ui-smoke/walkthrough/journey.ts
+++ b/packages/app/test/ui-smoke/walkthrough/journey.ts
@@ -629,6 +629,44 @@ async function sendChatMessage(page: Page, text: string): Promise<void> {
   await page.locator(CHAT_SEND_SELECTOR).first().click();
 }
 
+/**
+ * Drive the open chat sheet to its FULL detent with a real upward flick on the
+ * grabber — the pull gesture that REPLACED the removed `chat-full-maximize`
+ * button (#13531/#14332). A few-step, large-travel drag clears the flick
+ * velocity threshold so the sheet snaps up a detent; retried because a single
+ * flick from a partially-open sheet can land at HALF first. Uses `page.mouse`
+ * so it drives the pointer-generic gesture binding identically at the desktop
+ * and mobile viewports the journey runs at. Full-bleed maximize
+ * (`data-maximized`) is the finickier over-pull gated by the dedicated
+ * chat-thread-gestures + run-chat-sheet-e2e lanes; the walkthrough only needs
+ * the full detent.
+ */
+async function pullChatSheetToFull(page: Page): Promise<void> {
+  const overlay = page.getByTestId("continuous-chat-overlay");
+  const sheet = page.getByTestId("chat-sheet");
+  await expect(overlay).toHaveAttribute("data-open", "true", {
+    timeout: 15_000,
+  });
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    if ((await sheet.getAttribute("data-detent")) === "full") return;
+    const box = await page.getByTestId("chat-sheet-grabber").boundingBox();
+    if (!box) throw new Error("no bounding box for chat-sheet-grabber");
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    const travel = Math.min(cy - 4, 560);
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    for (let i = 1; i <= 3; i += 1) {
+      await page.mouse.move(cx, cy - (travel * i) / 3);
+    }
+    await page.mouse.up();
+    await page.waitForTimeout(400);
+  }
+  await expect(sheet).toHaveAttribute("data-detent", "full", {
+    timeout: 5_000,
+  });
+}
+
 async function navigateViaAgentEvent(
   page: Page,
   detail: Record<string, unknown>,
@@ -1008,40 +1046,20 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
   {
     n: "09",
     id: "chat-full-detent",
-    title: "Maximize chat",
+    title: "Expand chat to full",
     expectation:
-      "The chat overlay expands to its full-height detent; the maximize control sets data-detent=full and data-maximized=true.",
+      "An upward flick on the sheet grabber — the pull gesture that replaced the removed maximize button (#13531) — expands the chat overlay to its full-height detent (data-detent=full).",
     async run({ page }) {
-      const maximize = page.getByTestId("chat-full-maximize");
       const sheet = page.getByTestId("chat-sheet");
-      if (await maximize.isVisible().catch(() => false)) {
-        await maximize.click();
-        await expect(sheet).toHaveAttribute("data-detent", "full", {
-          timeout: 10_000,
-        });
-        await expect(sheet).toHaveAttribute("data-maximized", "true", {
-          timeout: 10_000,
-        });
-        return {
-          assertions: [
-            "chat-full-maximize → data-detent=full",
-            "chat-full-maximize → data-maximized=true",
-          ],
-          dom: {
-            detent: await sheet.getAttribute("data-detent"),
-            maximized: await sheet.getAttribute("data-maximized"),
-          },
-        };
-      }
-      // Mobile: no maximize affordance — the overlay is already full-bleed.
-      await expect(page.getByTestId("continuous-chat-overlay")).toHaveAttribute(
-        "data-open",
-        "true",
-      );
+      await pullChatSheetToFull(page);
       return {
         assertions: [
-          "overlay open at full-bleed (mobile has no separate maximize control)",
+          "grabber flick-up → data-detent=full (pull gesture; no maximize button)",
         ],
+        dom: {
+          detent: await sheet.getAttribute("data-detent"),
+          maximized: await sheet.getAttribute("data-maximized"),
+        },
       };
     },
   },

--- a/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
+++ b/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
@@ -178,6 +178,40 @@ async function captureState(
   await testInfo.attach(filename, { path, contentType: "image/png" });
 }
 
+/**
+ * Flick the open chat sheet's grabber up to the FULL detent — the pull gesture
+ * that replaced the removed `chat-full-maximize` button (#13531/#14332). A
+ * few-step, large-travel `page.mouse` drag clears the flick velocity threshold
+ * so the sheet snaps up a detent; retried since a single flick can land at HALF
+ * first.
+ */
+async function flickSheetToFull(page: Page): Promise<void> {
+  const sheet = page.getByTestId("chat-sheet");
+  await expect(page.getByTestId("continuous-chat-overlay")).toHaveAttribute(
+    "data-open",
+    "true",
+    { timeout: 15_000 },
+  );
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    if ((await sheet.getAttribute("data-detent")) === "full") return;
+    const box = await page.getByTestId("chat-sheet-grabber").boundingBox();
+    if (!box) throw new Error("no bounding box for chat-sheet-grabber");
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    const travel = Math.min(cy - 4, 560);
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    for (let i = 1; i <= 3; i += 1) {
+      await page.mouse.move(cx, cy - (travel * i) / 3);
+    }
+    await page.mouse.up();
+    await page.waitForTimeout(400);
+  }
+  await expect(sheet).toHaveAttribute("data-detent", "full", {
+    timeout: 5_000,
+  });
+}
+
 test.describe("walkthrough capture smoke", () => {
   test("captures the first stable walkthrough states", async ({
     page,
@@ -239,15 +273,10 @@ test.describe("walkthrough capture smoke", () => {
     ).toBeVisible({ timeout: 30_000 });
     await captureState(page, testInfo, "walkthrough-03-chat-round-trip.png");
 
-    await page.getByTestId("chat-full-maximize").click();
+    await flickSheetToFull(page);
     await expect(page.getByTestId("chat-sheet")).toHaveAttribute(
       "data-detent",
       "full",
-      { timeout: 10_000 },
-    );
-    await expect(page.getByTestId("chat-sheet")).toHaveAttribute(
-      "data-maximized",
-      "true",
       { timeout: 10_000 },
     );
     await captureState(page, testInfo, "walkthrough-04-chat-full-detent.png");


### PR DESCRIPTION
Completes #14332. The dead-code half (delete `verticalScrollPriority` + filler-class slop) landed via #14473 (merged); this PR is rebased on top of it and handles the part #14473 left: the **stale `chat-full-maximize` spec references**.

## What #13531 removed vs. what develop still carried
`#13531` removed the `chat-full-maximize` header button (pull-above-80% maximizes instead). Two specs still drove the deleted button:
- `walkthrough-capture-smoke.spec.ts` **clicked** `chat-full-maximize` — a locator that resolves to 0 elements, so the click hangs until timeout (broken spec).
- `journey.ts` step 09 carried a dead `if (await maximize.isVisible())` branch that always fell through to a no-op "overlay is open" assertion — it never actually exercised maximize/full.

## Change
Both now drive the **real pull gesture**: a `page.mouse` flick-up on `chat-sheet-grabber` steps the sheet to its FULL detent (`data-detent=full`), retried up to 4×. This is the same flick-to-full mechanism the CI-green `chat-thread-gestures.spec.ts` (`openSheetToFull`) and `run-chat-sheet-e2e.mjs` already use, and it is pointer-generic so it runs at the desktop and mobile viewports the journey covers. Full-bleed maximize (`data-maximized`) stays gated by those dedicated lanes — the walkthrough only needs the full detent.

Also corrects a now-false comment in `chat-send-voice-newchat-fuzz.spec.ts` that claimed the new-chat control was removed by #13531 (it was re-added in #14279).

## Scope note (issue premise drifted)
The issue also asked to delete `chat-full-clear` references. **Not done, intentionally:** `chat-full-clear` is a live header "new chat" control on develop (re-added per #14279); `ContinuousChatOverlay` renders it and the unit + `chat-thread-gestures` + `chat-clear-swipe` specs assert it PRESENT. Deleting it would regress shipped UI.

## Acceptance
- [x] No spec drives the removed `chat-full-maximize` button; the remaining refs are absence-assertions (`toHaveCount(0)`) + docs/explanatory comments.
- [x] The walkthrough reaches the full detent via the pull gesture.
- [x] `verticalScrollPriority` grep-clean (done on develop via #14473).

## Evidence
See the evidence comment below. Real-LLM trajectory + device capture: **N/A** — this is a test-only cleanup (no agent/model/prompt/native path touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)