### PR TITLE
fix(#14448): stop Polymarket view painting a raw property-access crash string

### DIFF
--- a/plugins/plugin-polymarket/src/components/PolymarketSpatialView.tsx
+++ b/plugins/plugin-polymarket/src/components/PolymarketSpatialView.tsx
@@ -91,8 +91,11 @@ function readyTone(ready: boolean): SpatialTone {
 }
 
 function ReadinessRow({ status }: { status: PolymarketStatusResponse | null }) {
-  const reads = status?.publicReads.ready ?? false;
-  const trading = status?.trading.ready ?? false;
+  // `publicReads`/`trading` are typed as required but a partial status response
+  // can omit them (#14448); fully optional-chain so a missing block reads as
+  // "off" rather than throwing a raw property-read into the view.
+  const reads = status?.publicReads?.ready ?? false;
+  const trading = status?.trading?.ready ?? false;
   return (
     <HStack gap={2} align="center" wrap>
       <Text style="caption" tone={readyTone(reads)}>

--- a/plugins/plugin-polymarket/src/usePolymarketState.account-missing.test.tsx
+++ b/plugins/plugin-polymarket/src/usePolymarketState.account-missing.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+
+// Regression guard for #14448: the status response can arrive without an
+// `account` block (the contract types it as required, but the UI-smoke status and
+// partial upstream responses omit it). The view must degrade — no positions, no
+// crash — never surface the raw `Cannot read properties of undefined (reading
+// 'ready')` string a user was seeing in the captured all-views audit.
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const polymarketClient = vi.hoisted(() => ({
+  polymarketStatus: vi.fn(),
+  polymarketMarkets: vi.fn(),
+  polymarketMarketById: vi.fn(),
+  polymarketMarketBySlug: vi.fn(),
+  polymarketOrderbook: vi.fn(),
+  polymarketOrders: vi.fn(),
+  polymarketPositions: vi.fn(),
+}));
+
+vi.mock("@elizaos/app-core", () => ({ client: polymarketClient }));
+vi.mock("./client", () => ({}));
+
+import { PolymarketView } from "./PolymarketView";
+
+// A real-shaped status with the `account` block absent — the exact response that
+// threw at `usePolymarketState`'s `statusResponse.account.ready`.
+const statusWithoutAccount = {
+  publicReads: {
+    ready: true,
+    reason: null,
+    gammaApiBase: "https://gamma-api.polymarket.com",
+    dataApiBase: "https://data-api.polymarket.com",
+  },
+  trading: {
+    ready: false,
+    reason: "Trading and order management are disabled.",
+    credentialsReady: false,
+    missing: ["POLYMARKET_PRIVATE_KEY"],
+    clobApiBase: "https://clob.polymarket.com",
+  },
+} as unknown;
+
+const sampleMarket = {
+  id: "market-1",
+  slug: "btc-above-100k",
+  question: "Will BTC be above 100k?",
+  description: "Market resolves based on BTC price.",
+  category: "Crypto",
+  active: true,
+  closed: false,
+  archived: false,
+  restricted: false,
+  enableOrderBook: true,
+  conditionId: "condition-1",
+  clobTokenIds: ["token-yes", "token-no"],
+  outcomes: [
+    { name: "Yes", price: "0.61" },
+    { name: "No", price: "0.39" },
+  ],
+  liquidity: "10000",
+  volume: "25000",
+  volume24hr: "1200",
+  lastTradePrice: "0.61",
+  bestBid: "0.60",
+  bestAsk: "0.62",
+  image: null,
+  icon: null,
+  endDate: null,
+  startDate: null,
+  updatedAt: null,
+};
+
+beforeEach(() => {
+  polymarketClient.polymarketStatus.mockResolvedValue(statusWithoutAccount);
+  polymarketClient.polymarketMarkets.mockResolvedValue({
+    markets: [sampleMarket],
+    source: { api: "gamma", endpoint: "/markets" },
+  });
+  polymarketClient.polymarketPositions.mockResolvedValue({
+    positions: [],
+    user: null,
+    summary: {
+      totalValue: "0",
+      totalCashPnl: "0",
+      totalPercentPnl: "0",
+      openPositions: 0,
+    },
+    source: { api: "data", endpoint: "/positions" },
+  });
+  polymarketClient.polymarketMarketById.mockResolvedValue({
+    market: sampleMarket,
+    source: { api: "gamma", endpoint: "/markets" },
+  });
+  polymarketClient.polymarketOrderbook.mockResolvedValue({
+    tokenId: "token-yes",
+    market: "market-1",
+    assetId: "asset-1",
+    bids: [],
+    asks: [],
+    bestBid: null,
+    bestBidSize: null,
+    bestAsk: null,
+    bestAskSize: null,
+    midpoint: null,
+    spread: null,
+    bidLevels: 0,
+    askLevels: 0,
+    lastTradePrice: null,
+    tickSize: "0.01",
+    source: { api: "clob", endpoint: "/book" },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("PolymarketView — status missing `account` (#14448)", () => {
+  it("renders markets and never paints the raw property-access crash string", async () => {
+    render(React.createElement(PolymarketView));
+    await screen.findByText("Will BTC be above 100k?");
+
+    const text = document.body.textContent ?? "";
+    expect(text).not.toContain("Cannot read properties");
+    expect(text).not.toContain("undefined");
+  });
+
+  it("skips the positions read when no account is resolvable", async () => {
+    render(React.createElement(PolymarketView));
+    await screen.findByText("Will BTC be above 100k?");
+    // account-less status => not ready => the positions endpoint is never hit.
+    await waitFor(() =>
+      expect(polymarketClient.polymarketStatus).toHaveBeenCalledTimes(1),
+    );
+    expect(polymarketClient.polymarketPositions).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-polymarket/src/usePolymarketState.ts
+++ b/plugins/plugin-polymarket/src/usePolymarketState.ts
@@ -40,8 +40,11 @@ export function usePolymarketState() {
       // Read the agent's own positions only when an account address is
       // resolvable; the route falls back to the configured wallet so we call
       // it without an explicit `user`. A position-read failure must not blank
-      // the whole view, so it's isolated from the markets fetch.
-      if (statusResponse.account.ready) {
+      // the whole view, so it's isolated from the markets fetch. The `account`
+      // block is typed as required but partial/upstream status responses omit it
+      // (#14448) — a missing account is simply "not resolvable", so guard the
+      // access rather than let it throw a raw property-read into the view.
+      if (statusResponse.account?.ready) {
         try {
           setPositions(await polymarketClient.polymarketPositions());
         } catch {


### PR DESCRIPTION
Closes #14448.

## Bug

The Polymarket view paints a raw runtime error string into its own UI, visible to
the user across every viewport and both GUI and TUI modalities:

> **Cannot read properties of undefined (reading 'ready')**

Surfaced by the new pixel-OCR audit gate (#14447): the DOM-metric audit passed
these views (`plugin-polymarket-tui` = `good`, `-gui` = `needs-eyeball`,
`consoleErrors: 0`) because the crash is caught by an error boundary and
*rendered* — no console error, `readableChars` stays high.

## Root cause

`usePolymarketState.ts:44` accessed `statusResponse.account.ready` unguarded. The
status contract types `account` as required, but partial/upstream status responses
(and the UI-smoke status) omit it → `Cannot read properties of undefined (reading
'ready')`, which the surrounding `try` catches and renders via `setError`.

`PolymarketSpatialView.tsx:353` *already* guarded `status?.account?.ready`; this
aligns the two remaining accesses to that established defensive pattern (the
sibling `status?.publicReads.ready` / `status?.trading.ready` are hardened too).

## Fix

- `statusResponse.account?.ready` — a missing account is "not resolvable" → skip
  the positions read (the existing else branch), not a crash. No fabricated data.
- `status?.publicReads?.ready` / `status?.trading?.ready` — a missing block reads
  as "off" instead of throwing.

## Proof (deterministic reproduction, jsdom render)

New `usePolymarketState.account-missing.test.tsx` drives `PolymarketView` with a
status that omits `account`:

- **Against the unfixed code** the test FAILS — the rendered DOM contains
  `Cannot read properties of undefined (reading 'ready')` (the exact audit string):
  ```
  × renders markets and never paints the raw property-access crash string
    Received: "…trading off1 marketsRefreshCannot read properties of undefined (reading 'ready')…"
  ```
- **Against the fix** it PASSES (2/2): markets render, no crash string, positions read is skipped.
- Existing `PolymarketView.test.tsx` still passes 9/9 (it renders `PolymarketSpatialView`, exercising the hardened `ReadinessRow`).

## Evidence matrix
- Screenshot of the rendered crash (in-repo): `packages/app/aesthetic-audit-output/mobile-portrait/plugin-polymarket-gui.png`.
- Reproduction test transcript (fail→pass) above.
- Real-LLM trajectory / on-chain — N/A: pure client-side render guard, no model/prompt/chain path touched.

## Follow-up
- Once this and #14451 both land, drop the `plugin-polymarket-*` entries from `packages/app/test/ui-smoke/ocr-triage-baseline.json` to re-arm the OCR gate for these views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
