### PR TITLE
test(ui): scroll + tap-target certification harness (#14380)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1527,3 +1527,6 @@ railway.json
 .railwayignore
 .dockerignore
 packages/ui/src/components/shell/__e2e__/output-fused-wake-integration/
+
+# widget scroll + tap-target certification evidence (#14380)
+packages/ui/src/testing/__e2e__/output-widget-cert/

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -190,6 +190,49 @@ component should ship at least a `*.stories.tsx` (states) **and** a `*.test.tsx`
 (behaviour). The live full-app visual audit lives in `packages/app`
 (`audit:app`) and `packages/cloud-frontend` (`audit:cloud`).
 
+### Scroll + tap-target certification (`src/testing/scroll-cert.ts`, #14380)
+
+A UI-library-wide certification harness holds every scrollable / interactive
+widget to four device-review guarantees: **scroll stability**, **keyboard
+interaction geometry**, **safe-area clearance**, and **tap-target minimums**
+(44x44 CSS px). It is two layers, same split as the rest of `src/testing`:
+
+- **Pure verdict math** — `scroll-cert.ts` is `(measurements) -> Violation[]`,
+  proven both ways (RED on a violation, GREEN when it holds) in
+  `scroll-cert.test.ts`. This is the always-trustworthy detector.
+- **DOM sweep** — `widget-cert.ts` walks a rendered widget for interactive
+  controls + scroll containers, reads their boxes through a pluggable
+  `GeometryProvider`, and runs the verdicts into a per-widget `WidgetCertReport`
+  (JSON + rendered summary). Under jsdom (`widget-cert.test.tsx`) geometry is
+  injected via `mapGeometryProvider`; a real browser supplies
+  `liveGeometryProvider` (getBoundingClientRect + getComputedStyle).
+- **Deep layer** — `src/testing/__e2e__/run-widget-cert-e2e.mjs`
+  (`bun run test:widget-cert-e2e`) mounts the widgets in real Chromium/WebKit
+  and runs the SAME sweep against real layout, emitting evidence
+  (`output-widget-cert/{widget-cert.json,widget-cert.txt,<engine>.png}`).
+  Playwright is flaky in CI — the runner SKIPs (exit 0) if the browser can't
+  launch; the vitest static layer is the always-green gate.
+
+**To certify a NEW widget:**
+
+1. Give the widget's scroll container a `data-scroll-cert-scroller` attribute
+   (or reuse `#continuous-thread` / `[data-testid="chat-thread"]`), and make sure
+   every interactive control is a native control / has a `role` / is
+   `tabindex>=0` (the sweep only enforces the tap floor on real controls). A
+   control with an expanded hit area (padding / hitSlop) should report an
+   effective hit box via the provider; a genuinely non-pointer affordance opts
+   out with `data-tap-target="ignore"`.
+2. Add a `certifyWidget("my-widget", root, provider, { dimensions: [...] })` case
+   to `widget-cert.test.tsx` (static, always runs) — pick the dimensions that
+   apply (`scroll`, `tap-target`, `safe-area`, `keyboard`). Inject known-good and
+   known-broken geometry so the cert is proven, not just green-because-empty.
+3. Optionally add the widget to the deep fixture
+   (`__e2e__/widget-cert-fixture.tsx`) so it is also certified against real
+   layout when playwright can run.
+4. A cert FAILURE is an actionable per-control report (code + selector +
+   measurement). This harness only DETECTS — component sizing/layout fixes are
+   owned by the component's lane; route findings there.
+
 ## Config / env vars
 
 This package mostly reads config injected by the host, not raw env vars:

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,6 +34,7 @@
     "test:agent-surface-e2e": "bun run --cwd ../.. packages/ui/src/agent-surface/__e2e__/run-e2e.mjs",
     "test:chat-sheet-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs",
     "test:chat-scroll-web-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-scroll-web-e2e.mjs",
+    "test:widget-cert-e2e": "bun run --cwd ../.. packages/ui/src/testing/__e2e__/run-widget-cert-e2e.mjs",
     "test:bottombar-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-bottombar-e2e.mjs",
     "test:fused-wake-integration-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-fused-wake-integration-e2e.mjs",
     "test:chat-sheet-frame-glitch-e2e": "node src/components/shell/__e2e__/run-chat-sheet-frame-glitch-e2e.mjs",

--- a/packages/ui/src/testing/__e2e__/run-widget-cert-e2e.mjs
+++ b/packages/ui/src/testing/__e2e__/run-widget-cert-e2e.mjs
@@ -1,0 +1,175 @@
+/**
+ * DEEP (real-browser) layer of the UI widget certification harness (#14380).
+ *
+ * Bundles `widget-cert-fixture.tsx`, mounts it in real Chromium (and WebKit if
+ * `ENGINE=webkit`) at a mobile viewport, then drives `window.__widgetCert.run()`
+ * so the SAME `certifyWidget` sweep runs against real layout + computed style.
+ * Emits, per PR_EVIDENCE.md, an evidence directory with:
+ *   - `widget-cert.json`     — the machine-readable run summary (per-widget)
+ *   - `widget-cert.txt`      — the rendered, human-readable summary
+ *   - `<engine>.png`         — a screenshot of the certified surface
+ *
+ * Exit code semantics: this runner is a HARNESS PROOF, not the gate itself — it
+ * exits 0 when it ran and produced a report even if widgets have violations
+ * (violations are FINDINGS routed to follow-up lanes, not this lane's failures).
+ * Set `FAIL_ON_VIOLATIONS=1` to make it red on any violation (useful once the
+ * component-owning lanes have fixed the known undersized controls).
+ *
+ * Playwright is known-flaky in the fleet CI box; if the browser can't launch
+ * this exits 0 with a SKIPPED note so it never falsely reddens a test-infra PR.
+ * The always-green gate is the vitest static layer (`widget-cert.test.tsx`).
+ *
+ * Run: node src/testing/__e2e__/run-widget-cert-e2e.mjs
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = join(here, "output-widget-cert");
+await mkdir(outDir, { recursive: true });
+
+const ENGINE_NAME = process.env.ENGINE === "webkit" ? "webkit" : "chromium";
+const FAIL_ON_VIOLATIONS = process.env.FAIL_ON_VIOLATIONS === "1";
+
+function skip(reason) {
+  console.log(`SKIPPED (${reason}) — static layer widget-cert.test.tsx is the gate`);
+  process.exit(0);
+}
+
+let playwright;
+try {
+  playwright = await import("playwright");
+} catch {
+  skip("playwright not installed");
+}
+let esbuild;
+try {
+  esbuild = await import("esbuild");
+} catch {
+  skip("esbuild not installed");
+}
+
+const ENGINE =
+  ENGINE_NAME === "webkit" ? playwright.webkit : playwright.chromium;
+
+let js;
+try {
+  const result = await esbuild.build({
+    entryPoints: [join(here, "widget-cert-fixture.tsx")],
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    jsx: "automatic",
+    loader: { ".tsx": "tsx", ".ts": "ts" },
+    define: { "process.env.NODE_ENV": '"production"' },
+    write: false,
+  });
+  js = result.outputFiles[0].text;
+} catch (e) {
+  skip(`fixture bundle failed: ${e?.message ?? e}`);
+}
+
+// Load Tailwind so the kit's size utilities (h-11/h-10/h-9/w-10/…) actually
+// resolve to real box heights — otherwise every Button collapses to content
+// height and the tap-target measurement is a fixture artifact, not a finding.
+const html = `<!doctype html><html><head><meta charset="utf-8"><title>widget cert</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<style>html,body{margin:0;height:100%;background:#0a0d16;font-family:system-ui}</style>
+</head><body><div id="root"></div><script>${js}</script></body></html>`;
+const htmlPath = join(outDir, "widget-cert.html");
+await writeFile(htmlPath, html);
+
+let browser;
+try {
+  browser = await ENGINE.launch(
+    ENGINE_NAME === "chromium" ? { args: ["--no-sandbox"] } : {},
+  );
+} catch (e) {
+  skip(`browser launch failed: ${e?.message ?? e}`);
+}
+
+const consoleErrors = [];
+try {
+  const page = await browser.newPage({
+    viewport: { width: 402, height: 874 },
+    hasTouch: true,
+    isMobile: true,
+    deviceScaleFactor: 2,
+  });
+  page.on("console", (m) => {
+    if (m.type() === "error") consoleErrors.push(m.text());
+  });
+  page.on("pageerror", (e) => consoleErrors.push(String(e)));
+
+  await page.goto(`file://${htmlPath}`);
+  await page.waitForFunction(() => window.__widgetCert?.ready === true, {
+    timeout: 20_000,
+  });
+  // Let the Tailwind CDN JIT apply the size utilities before we measure.
+  await page.waitForTimeout(800);
+
+  const reports = await page.evaluate(() => window.__widgetCert.run());
+
+  const failed = reports.filter((r) => !r.passed).length;
+  const run = {
+    runAt: new Date().toISOString(),
+    engine: ENGINE_NAME,
+    passed: failed === 0,
+    total: reports.length,
+    failed,
+    reports,
+    consoleErrors,
+  };
+
+  await writeFile(
+    join(outDir, "widget-cert.json"),
+    `${JSON.stringify(run, null, 2)}\n`,
+  );
+
+  const lines = [];
+  lines.push(
+    `UI widget certification (deep/${ENGINE_NAME}) — ${run.passed ? "PASS" : "FINDINGS"}`,
+  );
+  lines.push(
+    `${run.total - run.failed}/${run.total} widgets certified (${run.failed} with findings) @ ${run.runAt}`,
+  );
+  lines.push("");
+  for (const r of reports) {
+    lines.push(
+      `${r.passed ? "\u2713" : "\u2717"} ${r.widget}  [${r.dimensions.join(", ")}]`,
+    );
+    for (const v of r.violations) {
+      lines.push(
+        `    \u2717 (${v.dimension}) ${v.code}${v.target ? ` @ ${v.target}` : ""}: ${v.message}`,
+      );
+    }
+  }
+  const summary = lines.join("\n");
+  await writeFile(join(outDir, "widget-cert.txt"), `${summary}\n`);
+  console.log(summary);
+
+  await page.screenshot({ path: join(outDir, `${ENGINE_NAME}.png`) });
+
+  if (consoleErrors.length) {
+    for (const e of consoleErrors) console.log("  ERR:", e);
+  }
+
+  await browser.close();
+
+  if (FAIL_ON_VIOLATIONS && failed > 0) {
+    console.error(`\n${failed} widget(s) have unresolved findings.`);
+    process.exit(1);
+  }
+  console.log(
+    `\nwidget-cert deep layer ran [${ENGINE_NAME}]. Evidence: ${outDir}`,
+  );
+  process.exit(0);
+} catch (e) {
+  try {
+    await browser.close();
+  } catch {}
+  // A flaky browser run must not redden a test-infra PR — the static gate holds.
+  skip(`run error: ${e?.message ?? e}`);
+}

--- a/packages/ui/src/testing/__e2e__/widget-cert-fixture.tsx
+++ b/packages/ui/src/testing/__e2e__/widget-cert-fixture.tsx
@@ -1,0 +1,113 @@
+/**
+ * Fixture for the DEEP (real-browser) widget-cert layer (#14380). Renders the
+ * representative widgets on a mobile-sized page so the playwright runner can
+ * run the SAME `certifyWidget` sweep against real layout + computed style via
+ * the live geometry provider. Kept minimal + dependency-light so it bundles the
+ * same way the other `__e2e__` fixtures do (esbuild IIFE, no app runtime).
+ *
+ * The runner reads `window.__widgetCert` to drive certification in-page.
+ */
+
+import { createRoot } from "react-dom/client";
+
+import { Button } from "../../components/ui/button";
+import {
+  certifyWidget,
+  liveGeometryProvider,
+  type WidgetCertReport,
+} from "../widget-cert";
+
+declare global {
+  interface Window {
+    __widgetCert: {
+      ready: boolean;
+      /** Certify every mounted widget and return the reports. */
+      run: () => WidgetCertReport[];
+    };
+  }
+}
+
+/** A tall, button-dense, scrollable demo surface. */
+function DemoScreen() {
+  const rows = Array.from({ length: 40 }, (_, i) => i);
+  return (
+    <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
+      {/* button-dense demo view */}
+      <div
+        data-testid="demo-buttons"
+        style={{ display: "flex", gap: 8, padding: 12, flexWrap: "wrap" }}
+      >
+        <Button data-testid="btn-lg" size="lg">
+          Large
+        </Button>
+        <Button data-testid="btn-default">Default</Button>
+        <Button data-testid="btn-sm" size="sm">
+          Small
+        </Button>
+        <Button data-testid="btn-icon" size="icon" aria-label="icon">
+          i
+        </Button>
+        <Button data-testid="btn-icon-sm" size="icon-sm" aria-label="small">
+          s
+        </Button>
+      </div>
+      {/* scrollable transcript / list */}
+      <div
+        id="continuous-thread"
+        data-scroll-cert-scroller
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: "auto",
+          overflowX: "hidden",
+          overscrollBehavior: "contain",
+        }}
+      >
+        {rows.map((i) => (
+          <button
+            key={i}
+            data-testid={`row-${i}`}
+            style={{
+              display: "block",
+              width: "100%",
+              height: 56,
+              textAlign: "left",
+            }}
+          >
+            row {i}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const root = document.getElementById("root");
+if (root) {
+  createRoot(root).render(<DemoScreen />);
+  window.__widgetCert = {
+    ready: true,
+    run() {
+      const provider = liveGeometryProvider(window);
+      const reports: WidgetCertReport[] = [];
+      const demo = document.querySelector('[data-testid="demo-buttons"]');
+      if (demo) {
+        reports.push(
+          certifyWidget("demo-buttons", demo, provider, {
+            dimensions: ["tap-target"],
+          }),
+        );
+      }
+      const thread = document.querySelector("#continuous-thread");
+      if (thread) {
+        reports.push(
+          certifyWidget("transcript", thread, provider, {
+            dimensions: ["scroll", "tap-target"],
+            nestedScrollers: { "#continuous-thread": true },
+          }),
+        );
+      }
+      return reports;
+    },
+  };
+}

--- a/packages/ui/src/testing/scroll-cert.test.ts
+++ b/packages/ui/src/testing/scroll-cert.test.ts
@@ -1,0 +1,328 @@
+// @vitest-environment node
+//
+// Unit coverage for the PURE scroll + tap-target certification verdict math
+// (#14380). Each dimension is proven both ways: the detector fires (RED) on a
+// violating measurement and stays silent (GREEN) on a compliant one — so the
+// certification itself is trustworthy before it is pointed at any live widget.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWidgetReport,
+  certifyAnchorPreserved,
+  certifyKeyboardClearance,
+  certifyOverscrollContained,
+  certifySafeAreaClearance,
+  certifyScrollGeometry,
+  certifyTapTarget,
+  certifyTapTargets,
+  MAX_ANCHOR_JUMP_PX,
+  MIN_TAP_TARGET_PX,
+  renderRunSummary,
+  type ScrollerGeometry,
+  summarizeRun,
+} from "./scroll-cert";
+
+/* ── 1. scroll geometry ─────────────────────────────────────────────────── */
+
+const goodScroller: ScrollerGeometry = {
+  scrollHeight: 2000,
+  clientHeight: 800,
+  scrollWidth: 400,
+  clientWidth: 400,
+  overflowY: "auto",
+  overflowX: "hidden",
+  midScrollTopSettled: 600,
+  overscrollBehaviorY: "contain",
+};
+
+describe("certifyScrollGeometry", () => {
+  it("passes a bounded overflow scroller that accepts a mid scrollTop", () => {
+    expect(certifyScrollGeometry(goodScroller)).toEqual([]);
+  });
+
+  it("ignores a scroller whose content fits (nothing to scroll)", () => {
+    expect(
+      certifyScrollGeometry({
+        ...goodScroller,
+        scrollHeight: 800,
+        clientHeight: 800,
+        overflowY: "visible",
+        midScrollTopSettled: 0,
+      }),
+    ).toEqual([]);
+  });
+
+  it("FAILS when content overflows but overflow-y is not scrollable", () => {
+    const v = certifyScrollGeometry({ ...goodScroller, overflowY: "visible" });
+    expect(v.map((x) => x.code)).toContain("scroll/overflow-not-scrollable");
+  });
+
+  it("FAILS the height-chain when a mid scrollTop clamps to 0 (can't-scroll bug)", () => {
+    const v = certifyScrollGeometry({
+      ...goodScroller,
+      midScrollTopSettled: 0,
+    });
+    expect(v.map((x) => x.code)).toContain("scroll/height-chain-collapsed");
+  });
+
+  it("FAILS on unintended horizontal overflow", () => {
+    const v = certifyScrollGeometry(
+      {
+        ...goodScroller,
+        scrollWidth: 520,
+        clientWidth: 400,
+        overflowX: "hidden",
+      },
+      "#continuous-thread",
+    );
+    const h = v.find((x) => x.code === "scroll/horizontal-overflow");
+    expect(h).toBeTruthy();
+    expect(h?.target).toBe("#continuous-thread");
+  });
+
+  it("allows horizontal overflow when overflow-x is an explicit opt-in", () => {
+    const v = certifyScrollGeometry({
+      ...goodScroller,
+      scrollWidth: 520,
+      clientWidth: 400,
+      overflowX: "auto",
+    });
+    expect(v.map((x) => x.code)).not.toContain("scroll/horizontal-overflow");
+  });
+});
+
+/* ── anchor preservation ────────────────────────────────────────────────── */
+
+describe("certifyAnchorPreserved", () => {
+  it("passes when the anchor stays put across a prepend", () => {
+    expect(
+      certifyAnchorPreserved({
+        anchorOffsetBefore: 120,
+        anchorOffsetAfter: 121,
+        kind: "prepend",
+      }),
+    ).toEqual([]);
+  });
+
+  it("FAILS when a prepend yanks the reader down by the grown height", () => {
+    const v = certifyAnchorPreserved({
+      anchorOffsetBefore: 120,
+      anchorOffsetAfter: 620,
+      kind: "prepend",
+    });
+    expect(v).toHaveLength(1);
+    expect(v[0].code).toBe("scroll/anchor-jump-on-prepend");
+    expect(v[0].message).toContain("500.0px");
+  });
+
+  it("tolerates sub-pixel rounding at the cap boundary", () => {
+    expect(
+      certifyAnchorPreserved({
+        anchorOffsetBefore: 0,
+        anchorOffsetAfter: MAX_ANCHOR_JUMP_PX,
+        kind: "append",
+      }),
+    ).toEqual([]);
+  });
+});
+
+/* ── overscroll containment ─────────────────────────────────────────────── */
+
+describe("certifyOverscrollContained", () => {
+  it("exempts a root (non-nested) scroller", () => {
+    expect(
+      certifyOverscrollContained(
+        { overscrollBehaviorY: "auto" },
+        { nestedInScroller: false },
+      ),
+    ).toEqual([]);
+  });
+
+  it("passes a nested scroller that contains its overscroll", () => {
+    expect(
+      certifyOverscrollContained(
+        { overscrollBehaviorY: "contain" },
+        { nestedInScroller: true },
+      ),
+    ).toEqual([]);
+  });
+
+  it("FAILS a nested scroller that chains overscroll to an ancestor", () => {
+    const v = certifyOverscrollContained(
+      { overscrollBehaviorY: "auto" },
+      { nestedInScroller: true },
+      "conversations-sidebar",
+    );
+    expect(v).toHaveLength(1);
+    expect(v[0].code).toBe("scroll/overscroll-chains");
+    expect(v[0].target).toBe("conversations-sidebar");
+  });
+
+  it("treats a missing overscroll-behavior as the chaining default", () => {
+    const v = certifyOverscrollContained({}, { nestedInScroller: true });
+    expect(v.map((x) => x.code)).toContain("scroll/overscroll-chains");
+  });
+});
+
+/* ── 2. keyboard clearance ──────────────────────────────────────────────── */
+
+describe("certifyKeyboardClearance", () => {
+  it("passes when the composer stays above the keyboard fold", () => {
+    expect(
+      certifyKeyboardClearance({
+        layoutViewportHeight: 874,
+        visualViewportHeight: 500,
+        interactiveTop: 440,
+        interactiveBottom: 496,
+      }),
+    ).toEqual([]);
+  });
+
+  it("no-ops when the keyboard is down (visual == layout)", () => {
+    expect(
+      certifyKeyboardClearance({
+        layoutViewportHeight: 874,
+        visualViewportHeight: 874,
+        interactiveTop: 900,
+        interactiveBottom: 980,
+      }),
+    ).toEqual([]);
+  });
+
+  it("FAILS when the interactive region is fully behind the keyboard", () => {
+    const v = certifyKeyboardClearance({
+      layoutViewportHeight: 874,
+      visualViewportHeight: 500,
+      interactiveTop: 520,
+      interactiveBottom: 576,
+    });
+    expect(v[0].code).toBe("keyboard/region-fully-hidden");
+  });
+
+  it("FAILS when the interactive region is partially clipped by the keyboard", () => {
+    const v = certifyKeyboardClearance({
+      layoutViewportHeight: 874,
+      visualViewportHeight: 500,
+      interactiveTop: 470,
+      interactiveBottom: 540,
+    });
+    expect(v[0].code).toBe("keyboard/region-clipped");
+  });
+});
+
+/* ── 3. safe-area clearance ─────────────────────────────────────────────── */
+
+describe("certifySafeAreaClearance", () => {
+  const base = {
+    insetTop: 59,
+    insetBottom: 34,
+    viewportHeight: 874,
+  };
+
+  it("passes a control clear of both insets", () => {
+    expect(
+      certifySafeAreaClearance({
+        ...base,
+        controlTop: 70,
+        controlBottom: 114,
+      }),
+    ).toEqual([]);
+  });
+
+  it("FAILS a control whose top sits under the notch", () => {
+    const v = certifySafeAreaClearance({
+      ...base,
+      controlTop: 20,
+      controlBottom: 64,
+    });
+    expect(v[0].code).toBe("safe-area/under-top-inset");
+  });
+
+  it("FAILS a control whose bottom sits under the home indicator", () => {
+    const v = certifySafeAreaClearance({
+      ...base,
+      controlTop: 800,
+      controlBottom: 860,
+    });
+    expect(v[0].code).toBe("safe-area/under-bottom-inset");
+  });
+});
+
+/* ── 4. tap targets ─────────────────────────────────────────────────────── */
+
+describe("certifyTapTarget", () => {
+  it("passes a 44x44 control", () => {
+    expect(certifyTapTarget({ width: 44, height: 44, target: "send" })).toEqual(
+      [],
+    );
+  });
+
+  it(`FAILS a control below ${MIN_TAP_TARGET_PX}px on either axis`, () => {
+    expect(
+      certifyTapTarget({ width: 44, height: 28, target: "close-x" }),
+    ).toHaveLength(1);
+    expect(
+      certifyTapTarget({ width: 30, height: 44, target: "chevron" }),
+    ).toHaveLength(1);
+  });
+
+  it("uses the effective (expanded) hit box when provided", () => {
+    // A 24px glyph with a 44px padded hit area passes.
+    expect(
+      certifyTapTarget({
+        width: 24,
+        height: 24,
+        effectiveWidth: 44,
+        effectiveHeight: 48,
+        target: "icon-btn",
+      }),
+    ).toEqual([]);
+  });
+
+  it("sweeps a set and collects every undersized control", () => {
+    const v = certifyTapTargets([
+      { width: 44, height: 44, target: "ok" },
+      { width: 20, height: 20, target: "tiny-a" },
+      { width: 44, height: 30, target: "short-b" },
+    ]);
+    expect(v).toHaveLength(2);
+    expect(v.map((x) => x.target)).toEqual(["tiny-a", "short-b"]);
+  });
+});
+
+/* ── report assembly ────────────────────────────────────────────────────── */
+
+describe("report assembly", () => {
+  it("marks a widget passed when it has no violations", () => {
+    const r = buildWidgetReport("demo-buttons", ["tap-target"], []);
+    expect(r.passed).toBe(true);
+  });
+
+  it("marks a widget failed and carries its violations", () => {
+    const viol = certifyTapTarget({ width: 20, height: 20, target: "x" });
+    const r = buildWidgetReport("demo-buttons", ["tap-target"], viol);
+    expect(r.passed).toBe(false);
+    expect(r.violations).toEqual(viol);
+  });
+
+  it("summarizes a run and renders an actionable text block", () => {
+    const pass = buildWidgetReport("transcript", ["scroll"], []);
+    const fail = buildWidgetReport(
+      "demo-buttons",
+      ["tap-target"],
+      certifyTapTarget({ width: 30, height: 30, target: "swatch-3" }),
+    );
+    const run = summarizeRun([pass, fail]);
+    expect(run.passed).toBe(false);
+    expect(run.total).toBe(2);
+    expect(run.failed).toBe(1);
+
+    const text = renderRunSummary(run);
+    expect(text).toContain("FAIL");
+    expect(text).toContain("\u2713 transcript");
+    expect(text).toContain("\u2717 demo-buttons");
+    expect(text).toContain("swatch-3");
+    expect(text).toContain("tap-target/below-minimum");
+  });
+});

--- a/packages/ui/src/testing/scroll-cert.ts
+++ b/packages/ui/src/testing/scroll-cert.ts
@@ -1,0 +1,418 @@
+/**
+ * UI-library scroll + tap-target CERTIFICATION — the PURE verdict math (#14380).
+ *
+ * This is the certification counterpart to {@link ./layout-stability.ts}: the
+ * PURE, deterministically unit-testable core that decides PASS/FAIL for the
+ * four device-review dimensions, given measurements a caller has already taken.
+ * A Playwright/jsdom harness (see {@link ./widget-cert.tsx}) feeds it real
+ * geometry; keeping the verdict logic pure means the DETECTOR itself is proven
+ * (RED when the property is violated, GREEN when it holds) before it is pointed
+ * at any live widget — no larp, no "it passed because it measured nothing".
+ *
+ * The four dimensions (from #14380 "done when" / the device review in #14317):
+ *   1. SCROLL STABILITY — a scroller has real bounded overflow, accepts a mid
+ *      scrollTop, does NOT jump the reader on prepend/append (anchor preserved),
+ *      does NOT trap/overscroll-chain to an ancestor, and has NO horizontal
+ *      overflow it never intended.
+ *   2. KEYBOARD INTERACTION — when the soft keyboard reduces the visual
+ *      viewport, the interactive region (composer / focused control) stays
+ *      inside the shrunken viewport (not hidden behind the keyboard), and the
+ *      scroller's usable height shrinks rather than the content being clipped.
+ *   3. SAFE-AREA CLEARANCE — interactive controls clear the top notch inset and
+ *      the bottom home-indicator inset (no tap target under the notch/indicator).
+ *   4. TAP-TARGET MINIMUMS — every interactive control's hit box is at least the
+ *      platform minimum (44×44 CSS px, the iOS HIG / WCAG 2.5.5 AAA floor).
+ *
+ * Every function is pure `(measurements) -> Violation[]`. A widget "certifies"
+ * when the union of violations across the dimensions it opts into is empty.
+ */
+
+/** The platform tap-target floor in CSS px (iOS HIG / WCAG 2.5.5 Level AAA). */
+export const MIN_TAP_TARGET_PX = 44;
+
+/**
+ * How much bounded overflow (scrollHeight − clientHeight) a scroller must have
+ * before we consider it "actually scrollable". Below this it either fits its
+ * content (nothing to scroll — fine, but then scroll-stability checks are moot)
+ * or is a rounding wobble.
+ */
+export const MIN_OVERFLOW_PX = 8;
+
+/**
+ * Max net viewport motion (px) a prepend/append is allowed to induce at the
+ * reader's anchor. Anchor preservation means the message that was at the top
+ * (or the follow position at the bottom) stays visually put; a few px of
+ * sub-pixel rounding is tolerated, a visible jump is not.
+ */
+export const MAX_ANCHOR_JUMP_PX = 4;
+
+/** One certification failure, addressed to a specific widget + dimension. */
+export interface Violation {
+  /** Which of the four cert dimensions this failure belongs to. */
+  dimension: "scroll" | "keyboard" | "safe-area" | "tap-target";
+  /** A stable machine code so follow-up lanes can grep for a class of failure. */
+  code: string;
+  /** Human-actionable message: what is wrong + the offending measurement. */
+  message: string;
+  /**
+   * An optional selector / testid / label locating the offending element, so a
+   * per-widget report points a fixer at the exact control.
+   */
+  target?: string;
+}
+
+/* ───────────────────────── 1. SCROLL STABILITY ─────────────────────────── */
+
+/** A snapshot of a scroll container's box + computed scroll styles. */
+export interface ScrollerGeometry {
+  scrollHeight: number;
+  clientHeight: number;
+  scrollWidth: number;
+  clientWidth: number;
+  /** Computed `overflow-y` (auto | scroll | hidden | visible | clip). */
+  overflowY: string;
+  /** Computed `overflow-x`. */
+  overflowX: string;
+  /**
+   * Where scrollTop settled after the harness set it to ~scrollHeight/2. When
+   * the viewport is bounded below its content this sticks near the midpoint;
+   * when the scroller sized to content (the "can't scroll" bug) it clamps to 0.
+   */
+  midScrollTopSettled: number;
+  /** Computed `overscroll-behavior-y` — `contain`/`none` stop chain to ancestor. */
+  overscrollBehaviorY?: string;
+}
+
+/**
+ * Certify a scroller's basic vertical scrollability + that it does not leak a
+ * horizontal scrollbar or chain its overscroll to an ancestor.
+ *
+ * NOTE: a scroller whose content fits (no bounded overflow) is NOT a failure —
+ * there is simply nothing to scroll. We only assert scrollability when the
+ * content genuinely overflows (`scrollHeight > clientHeight + MIN_OVERFLOW_PX`).
+ */
+export function certifyScrollGeometry(
+  g: ScrollerGeometry,
+  target?: string,
+): Violation[] {
+  const v: Violation[] = [];
+  const overflows = g.scrollHeight > g.clientHeight + MIN_OVERFLOW_PX;
+
+  if (overflows) {
+    // The scroller must actually be an overflow scroller.
+    if (g.overflowY !== "auto" && g.overflowY !== "scroll") {
+      v.push({
+        dimension: "scroll",
+        code: "scroll/overflow-not-scrollable",
+        message: `content overflows (scrollHeight ${g.scrollHeight} > clientHeight ${g.clientHeight}) but overflow-y is "${g.overflowY}" — nothing scrolls`,
+        target,
+      });
+    }
+    // And a programmatic mid scrollTop must have stuck (bounded viewport).
+    if (g.midScrollTopSettled <= MIN_OVERFLOW_PX) {
+      v.push({
+        dimension: "scroll",
+        code: "scroll/height-chain-collapsed",
+        message: `scroller did not accept a mid scrollTop (settled at ${g.midScrollTopSettled}) — the height chain sized to content, so it cannot scroll`,
+        target,
+      });
+    }
+  }
+
+  // Horizontal overflow the widget never intended: a visible x-scrollbar on a
+  // vertical surface is a layout bug (a too-wide child). Only flag when x can
+  // actually scroll AND overflow-x is not an explicit auto/scroll opt-in.
+  const xOverflows = g.scrollWidth > g.clientWidth + MIN_OVERFLOW_PX;
+  if (xOverflows && g.overflowX !== "auto" && g.overflowX !== "scroll") {
+    v.push({
+      dimension: "scroll",
+      code: "scroll/horizontal-overflow",
+      message: `unintended horizontal overflow: scrollWidth ${g.scrollWidth} > clientWidth ${g.clientWidth} with overflow-x "${g.overflowX}" — a child is too wide`,
+      target,
+    });
+  }
+
+  return v;
+}
+
+/** Prepend/append anchor-preservation measurement. */
+export interface AnchorSample {
+  /**
+   * The viewport offset (px) of the anchored reference element BEFORE the
+   * mutation — e.g. `top - containerTop` of the message the reader was viewing.
+   */
+  anchorOffsetBefore: number;
+  /** The same reference element's viewport offset AFTER the mutation + reflow. */
+  anchorOffsetAfter: number;
+  /** "prepend" (older content grows upward) or "append" (newer at bottom). */
+  kind: "prepend" | "append";
+}
+
+/**
+ * Certify that a prepend/append did NOT shove the reader's viewport: the
+ * anchored element's on-screen offset must be within {@link MAX_ANCHOR_JUMP_PX}
+ * of where it was. A prepend that grows the scroller upward without restoring
+ * `scrollTop` moves the anchor down by the whole grown height — the classic
+ * "scroll-up loads history and yanks you" bug.
+ */
+export function certifyAnchorPreserved(
+  s: AnchorSample,
+  target?: string,
+): Violation[] {
+  const jump = Math.abs(s.anchorOffsetAfter - s.anchorOffsetBefore);
+  if (jump > MAX_ANCHOR_JUMP_PX) {
+    return [
+      {
+        dimension: "scroll",
+        code: `scroll/anchor-jump-on-${s.kind}`,
+        message: `${s.kind} moved the reader's anchor by ${jump.toFixed(1)}px (offset ${s.anchorOffsetBefore.toFixed(1)} → ${s.anchorOffsetAfter.toFixed(1)}); anchor preservation caps the jump at ${MAX_ANCHOR_JUMP_PX}px`,
+        target,
+      },
+    ];
+  }
+  return [];
+}
+
+/**
+ * Certify overscroll containment: an INNER scroller that reaches its top/bottom
+ * edge must not chain the scroll to an ANCESTOR (the page / the sheet), which on
+ * touch reads as "the whole app moved when I tried to scroll the list". A
+ * scroller that can chain (overscroll-behavior-y is the default `auto`) AND is
+ * nested inside another scroller fails; a root scroller is exempt.
+ */
+export function certifyOverscrollContained(
+  g: Pick<ScrollerGeometry, "overscrollBehaviorY">,
+  opts: { nestedInScroller: boolean },
+  target?: string,
+): Violation[] {
+  if (!opts.nestedInScroller) return [];
+  const b = g.overscrollBehaviorY ?? "auto";
+  if (b !== "contain" && b !== "none") {
+    return [
+      {
+        dimension: "scroll",
+        code: "scroll/overscroll-chains",
+        message: `nested scroller has overscroll-behavior-y "${b}" — reaching its edge chains the scroll to an ancestor (use "contain")`,
+        target,
+      },
+    ];
+  }
+  return [];
+}
+
+/* ───────────────────────── 2. KEYBOARD INTERACTION ─────────────────────── */
+
+/**
+ * Geometry captured with a soft keyboard "up" — the harness mocks
+ * `visualViewport` so the visual viewport height is reduced by the keyboard.
+ */
+export interface KeyboardGeometry {
+  /** Layout viewport height (window.innerHeight) — unchanged by the keyboard. */
+  layoutViewportHeight: number;
+  /** Visual viewport height with the keyboard up (< layout height). */
+  visualViewportHeight: number;
+  /**
+   * The bottom edge (px from top of layout viewport) of the interactive region
+   * that must stay visible with the keyboard up — e.g. the composer input, or
+   * the focused control. If this exceeds `visualViewportHeight` it is hidden
+   * behind the keyboard.
+   */
+  interactiveBottom: number;
+  /** The interactive region's TOP edge (px). */
+  interactiveTop: number;
+}
+
+/**
+ * Certify that the focused/interactive region stays inside the keyboard-shrunk
+ * visual viewport. Two failures: the region is fully behind the keyboard
+ * (top past the fold), or partially clipped (bottom past the fold).
+ */
+export function certifyKeyboardClearance(
+  k: KeyboardGeometry,
+  target?: string,
+): Violation[] {
+  const v: Violation[] = [];
+  const fold = k.visualViewportHeight;
+  // Only meaningful when a keyboard is actually up (visual < layout).
+  const keyboardUp = k.visualViewportHeight < k.layoutViewportHeight - 1;
+  if (!keyboardUp) return v;
+
+  if (k.interactiveTop >= fold) {
+    v.push({
+      dimension: "keyboard",
+      code: "keyboard/region-fully-hidden",
+      message: `interactive region top (${k.interactiveTop.toFixed(0)}px) is at/below the keyboard fold (${fold.toFixed(0)}px) — fully hidden behind the keyboard`,
+      target,
+    });
+  } else if (k.interactiveBottom > fold + 1) {
+    v.push({
+      dimension: "keyboard",
+      code: "keyboard/region-clipped",
+      message: `interactive region bottom (${k.interactiveBottom.toFixed(0)}px) extends past the keyboard fold (${fold.toFixed(0)}px) — partially hidden behind the keyboard`,
+      target,
+    });
+  }
+  return v;
+}
+
+/* ───────────────────────── 3. SAFE-AREA CLEARANCE ──────────────────────── */
+
+/** The device safe-area insets (px) + a control's box to check against them. */
+export interface SafeAreaGeometry {
+  insetTop: number;
+  insetBottom: number;
+  viewportHeight: number;
+  /** The interactive control's box top/bottom (px from top of viewport). */
+  controlTop: number;
+  controlBottom: number;
+}
+
+/**
+ * Certify an interactive control clears both safe-area insets: its top edge is
+ * at or below the top inset (not under the notch), and its bottom edge is at or
+ * above the bottom-inset line (not under the home indicator). Non-interactive
+ * chrome (backgrounds) is allowed under the insets — this is for TAP targets.
+ */
+export function certifySafeAreaClearance(
+  s: SafeAreaGeometry,
+  target?: string,
+): Violation[] {
+  const v: Violation[] = [];
+  if (s.controlTop < s.insetTop) {
+    v.push({
+      dimension: "safe-area",
+      code: "safe-area/under-top-inset",
+      message: `control top (${s.controlTop.toFixed(0)}px) is above the top safe-area inset (${s.insetTop.toFixed(0)}px) — a tap target sits under the notch`,
+      target,
+    });
+  }
+  const bottomLine = s.viewportHeight - s.insetBottom;
+  if (s.controlBottom > bottomLine) {
+    v.push({
+      dimension: "safe-area",
+      code: "safe-area/under-bottom-inset",
+      message: `control bottom (${s.controlBottom.toFixed(0)}px) is below the bottom safe-area line (${bottomLine.toFixed(0)}px) — a tap target sits under the home indicator`,
+      target,
+    });
+  }
+  return v;
+}
+
+/* ───────────────────────── 4. TAP-TARGET MINIMUMS ──────────────────────── */
+
+/** A single interactive control's hit box + how we located it. */
+export interface TapTarget {
+  width: number;
+  height: number;
+  /** testid / selector / accessible name for the per-widget report. */
+  target: string;
+  /**
+   * Some controls legitimately render small but expand their hit area via
+   * padding/`hitSlop`/an ::before overlay. If the harness measured an EFFECTIVE
+   * hit box (e.g. the nearest ancestor with a click handler, or an explicit
+   * expanded region), pass it here and it is checked instead of width/height.
+   */
+  effectiveWidth?: number;
+  effectiveHeight?: number;
+}
+
+/**
+ * Certify a single tap target meets the {@link MIN_TAP_TARGET_PX} floor on both
+ * axes, using the effective hit box when the caller measured one.
+ */
+export function certifyTapTarget(t: TapTarget): Violation[] {
+  const w = t.effectiveWidth ?? t.width;
+  const h = t.effectiveHeight ?? t.height;
+  if (w + 0.5 < MIN_TAP_TARGET_PX || h + 0.5 < MIN_TAP_TARGET_PX) {
+    return [
+      {
+        dimension: "tap-target",
+        code: "tap-target/below-minimum",
+        message: `hit box ${w.toFixed(0)}×${h.toFixed(0)}px is below the ${MIN_TAP_TARGET_PX}×${MIN_TAP_TARGET_PX}px minimum`,
+        target: t.target,
+      },
+    ];
+  }
+  return [];
+}
+
+/** Sweep a set of interactive controls and collect every undersized one. */
+export function certifyTapTargets(targets: readonly TapTarget[]): Violation[] {
+  return targets.flatMap(certifyTapTarget);
+}
+
+/* ───────────────────────── report assembly ─────────────────────────────── */
+
+/** The per-widget certification result, ready to serialize to JSON. */
+export interface WidgetCertReport {
+  widget: string;
+  /** Which dimensions were exercised for this widget. */
+  dimensions: Violation["dimension"][];
+  passed: boolean;
+  violations: Violation[];
+  /** Optional evidence artifact paths (screenshot/video) if the deep layer ran. */
+  artifacts?: string[];
+}
+
+/** Assemble a per-widget report from the violations gathered for it. */
+export function buildWidgetReport(
+  widget: string,
+  dimensions: Violation["dimension"][],
+  violations: Violation[],
+  artifacts?: string[],
+): WidgetCertReport {
+  return {
+    widget,
+    dimensions,
+    passed: violations.length === 0,
+    violations,
+    ...(artifacts?.length ? { artifacts } : {}),
+  };
+}
+
+/** A full certification run across many widgets. */
+export interface CertRun {
+  runAt: string;
+  passed: boolean;
+  total: number;
+  failed: number;
+  reports: WidgetCertReport[];
+}
+
+/** Fold per-widget reports into a run summary (JSON evidence artifact). */
+export function summarizeRun(reports: readonly WidgetCertReport[]): CertRun {
+  const failed = reports.filter((r) => !r.passed).length;
+  return {
+    runAt: new Date().toISOString(),
+    passed: failed === 0,
+    total: reports.length,
+    failed,
+    reports: [...reports],
+  };
+}
+
+/** Render a run summary as a human-readable text block for the evidence dir. */
+export function renderRunSummary(run: CertRun): string {
+  const lines: string[] = [];
+  lines.push(
+    `UI scroll + tap-target certification — ${run.passed ? "PASS" : "FAIL"}`,
+  );
+  lines.push(
+    `${run.total - run.failed}/${run.total} widgets certified (${run.failed} failing) @ ${run.runAt}`,
+  );
+  lines.push("");
+  for (const r of run.reports) {
+    lines.push(
+      `${r.passed ? "\u2713" : "\u2717"} ${r.widget}  [${r.dimensions.join(", ")}]`,
+    );
+    for (const viol of r.violations) {
+      lines.push(
+        `    \u2717 (${viol.dimension}) ${viol.code}${viol.target ? ` @ ${viol.target}` : ""}: ${viol.message}`,
+      );
+    }
+    if (r.artifacts?.length) {
+      for (const a of r.artifacts) lines.push(`    \u2192 ${a}`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/packages/ui/src/testing/widget-cert.test.tsx
+++ b/packages/ui/src/testing/widget-cert.test.tsx
@@ -1,0 +1,327 @@
+// @vitest-environment jsdom
+//
+// biome-ignore-all lint/a11y/useButtonType: test fixtures deliberately construct edge-case DOM to exercise the interactive-control sweep
+// biome-ignore-all lint/a11y/useSemanticElements: test fixtures deliberately use role=button spans to exercise the sweep selector
+// biome-ignore-all lint/a11y/useFocusableInteractive: intentional non-focusable role=button edge case for the sweep
+// biome-ignore-all lint/a11y/noNoninteractiveTabindex: intentional tabindex div edge case for the sweep
+//
+// Certifies the WIDGET-CERT harness (#14380) end-to-end against real rendered
+// DOM: the sweep finds the interactive controls + scrollers, reads geometry
+// through a provider, and the pure verdicts produce an actionable per-widget
+// report. jsdom does not lay out, so geometry is injected through
+// `mapGeometryProvider` (the same technique `useLoadOlderOnScroll.test.tsx`
+// uses to give jsdom real scrollHeight) — the harness logic (which elements
+// count, how the report is shaped) is what is under test here; the pure
+// verdict math is proven separately in `scroll-cert.test.ts`.
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Button } from "../components/ui/button";
+import {
+  type Box,
+  certifyWidget,
+  collectInteractive,
+  collectScrollers,
+  locate,
+  mapGeometryProvider,
+} from "./widget-cert";
+
+afterEach(cleanup);
+
+const box = (
+  top: number,
+  left: number,
+  width: number,
+  height: number,
+): Box => ({ top, left, width, height });
+
+/* ── the harness collects the right elements ────────────────────────────── */
+
+describe("collectInteractive", () => {
+  it("finds native + role + tabindex controls, skips ignored/disabled/hidden", () => {
+    const { container } = render(
+      // Deliberately constructs edge-case DOM (role=button spans, tabindex divs,
+      // disabled/hidden buttons) to prove the sweep's element-collection
+      // selector + filters — a11y semantics are not under test here.
+      <div>
+        <button type="button" data-testid="a">
+          a
+        </button>
+        <a href="#x" data-testid="b">
+          b
+        </a>
+        <span role="button" data-testid="c">
+          c
+        </span>
+        <div tabIndex={0} data-testid="d">
+          d
+        </div>
+        <button type="button" data-testid="ignored" data-tap-target="ignore">
+          ignore me
+        </button>
+        <button type="button" data-testid="disabled" disabled>
+          off
+        </button>
+        <span aria-hidden="true" role="button" data-testid="hidden">
+          hidden
+        </span>
+        <div tabIndex={-1} data-testid="neg">
+          not focusable
+        </div>
+        <span data-testid="decorative">just text</span>
+      </div>,
+    );
+    const found = collectInteractive(container).map((el) =>
+      el.getAttribute("data-testid"),
+    );
+    expect(found).toEqual(["a", "b", "c", "d"]);
+  });
+});
+
+describe("collectScrollers", () => {
+  it("finds opted-in scroll containers", () => {
+    const { container } = render(
+      <div>
+        <div data-scroll-cert-scroller data-testid="s1">
+          scroller
+        </div>
+        <div id="continuous-thread">thread</div>
+        <div>not a scroller</div>
+      </div>,
+    );
+    const ids = collectScrollers(container).map(
+      (el) => el.getAttribute("data-testid") || el.id,
+    );
+    expect(ids).toContain("s1");
+    expect(ids).toContain("continuous-thread");
+    expect(ids).toHaveLength(2);
+  });
+});
+
+describe("locate", () => {
+  it("prefers testid > tap-target > aria-label > id > text", () => {
+    const mk = (html: string) => {
+      const d = document.createElement("div");
+      d.innerHTML = html;
+      return d.firstElementChild as Element;
+    };
+    expect(locate(mk('<button data-testid="send">x</button>'))).toBe(
+      '[data-testid="send"]',
+    );
+    expect(locate(mk('<button aria-label="Close">x</button>'))).toBe(
+      'button[aria-label="Close"]',
+    );
+    expect(locate(mk('<button id="ok">x</button>'))).toBe("#ok");
+    expect(locate(mk("<button>Save changes</button>"))).toBe(
+      'button:"Save changes"',
+    );
+  });
+});
+
+/* ── first certified widget: the demo-buttons view ──────────────────────── */
+
+/**
+ * A button-dense interactive surface — the "demo buttons view" the device
+ * review called out for too-small controls (#14317 / #14380). We render the
+ * real `Button` primitive across its sizes so the cert catches the ACTUAL
+ * undersized variants (default h-10=40, sm h-9=36, icon-sm h-8=32 are all
+ * below the 44px floor) — this is a genuine finding, reported not fixed
+ * (component sizing is owned by wt-14399 / wt-13453).
+ */
+function DemoButtonsView() {
+  return (
+    <div data-testid="demo-buttons">
+      <Button data-testid="btn-lg" size="lg">
+        Large
+      </Button>
+      <Button data-testid="btn-default" size="default">
+        Default
+      </Button>
+      <Button data-testid="btn-sm" size="sm">
+        Small
+      </Button>
+      <Button data-testid="btn-icon" size="icon" aria-label="icon">
+        i
+      </Button>
+      <Button data-testid="btn-icon-sm" size="icon-sm" aria-label="icon small">
+        s
+      </Button>
+    </div>
+  );
+}
+
+/** Map a Button test size class to the px box it lays out to (Tailwind h-*). */
+const BUTTON_BOXES: Record<string, Box> = {
+  "btn-lg": box(0, 0, 88, 44), // h-11 = 44 (passes)
+  "btn-default": box(0, 0, 96, 40), // h-10 = 40 (FAILS)
+  "btn-sm": box(0, 0, 72, 36), // h-9 = 36 (FAILS)
+  "btn-icon": box(0, 0, 40, 40), // h-10 w-10 = 40 (FAILS)
+  "btn-icon-sm": box(0, 0, 32, 32), // h-8 w-8 = 32 (FAILS)
+};
+
+describe("certifyWidget — demo-buttons view (tap-target)", () => {
+  it("catches every sub-44px button and passes the compliant one", () => {
+    const { container } = render(<DemoButtonsView />);
+    const controls = collectInteractive(container);
+    const provider = mapGeometryProvider(
+      controls.map((el) => {
+        const id = el.getAttribute("data-testid") ?? "";
+        return [el, { box: BUTTON_BOXES[id] ?? box(0, 0, 44, 44) }] as const;
+      }),
+    );
+
+    const report = certifyWidget("demo-buttons", container, provider, {
+      dimensions: ["tap-target"],
+    });
+
+    expect(report.passed).toBe(false);
+    const failedTargets = report.violations.map((v) => v.target);
+    // The four undersized variants are all flagged.
+    expect(failedTargets).toEqual(
+      expect.arrayContaining([
+        '[data-testid="btn-default"]',
+        '[data-testid="btn-sm"]',
+        '[data-testid="btn-icon"]',
+        '[data-testid="btn-icon-sm"]',
+      ]),
+    );
+    // The 44px `lg` button is NOT flagged.
+    expect(failedTargets).not.toContain('[data-testid="btn-lg"]');
+    // Every violation is tap-target class with an actionable message.
+    for (const v of report.violations) {
+      expect(v.dimension).toBe("tap-target");
+      expect(v.message).toMatch(/below the 44×44px minimum/);
+    }
+  });
+
+  it("passes when an undersized glyph carries an expanded hit box", () => {
+    const { container } = render(
+      <div data-testid="w">
+        <button type="button" data-testid="icon-only" aria-label="menu">
+          ≡
+        </button>
+      </div>,
+    );
+    const el = collectInteractive(container)[0];
+    const provider = mapGeometryProvider([
+      [el, { box: box(0, 0, 24, 24), effectiveHitBox: box(-10, -10, 44, 44) }],
+    ]);
+    const report = certifyWidget("icon-btn", container, provider, {
+      dimensions: ["tap-target"],
+    });
+    expect(report.passed).toBe(true);
+  });
+});
+
+/* ── certified widget: the chat transcript scroller ─────────────────────── */
+
+describe("certifyWidget — transcript scroller (scroll)", () => {
+  it("passes a bounded overflow scroller that scrolls + contains overscroll", () => {
+    const { container } = render(
+      <div>
+        <div id="continuous-thread">messages</div>
+      </div>,
+    );
+    const scroller = container.querySelector(
+      "#continuous-thread",
+    ) as Element & {
+      scrollHeight: number;
+      scrollWidth: number;
+    };
+    Object.defineProperty(scroller, "scrollHeight", {
+      value: 2400,
+      configurable: true,
+    });
+    Object.defineProperty(scroller, "scrollWidth", {
+      value: 402,
+      configurable: true,
+    });
+
+    const provider = mapGeometryProvider([
+      [
+        scroller,
+        {
+          box: box(120, 0, 402, 700),
+          overflowY: "auto",
+          overflowX: "hidden",
+          overscrollBehaviorY: "contain",
+          midScrollTopSettled: 850,
+        },
+      ],
+    ]);
+    const report = certifyWidget("transcript", scroller, provider, {
+      dimensions: ["scroll"],
+      nestedScrollers: { "#continuous-thread": true },
+    });
+    expect(report.passed).toBe(true);
+  });
+
+  it("catches a collapsed height chain (the can't-scroll bug)", () => {
+    const { container } = render(<div id="continuous-thread">messages</div>);
+    const scroller = container.querySelector(
+      "#continuous-thread",
+    ) as Element & {
+      scrollHeight: number;
+      scrollWidth: number;
+    };
+    Object.defineProperty(scroller, "scrollHeight", {
+      value: 2400,
+      configurable: true,
+    });
+    Object.defineProperty(scroller, "scrollWidth", {
+      value: 402,
+      configurable: true,
+    });
+    const provider = mapGeometryProvider([
+      [
+        scroller,
+        {
+          box: box(120, 0, 402, 700),
+          overflowY: "auto",
+          overflowX: "hidden",
+          overscrollBehaviorY: "contain",
+          midScrollTopSettled: 0, // clamped to 0 → sized to content
+        },
+      ],
+    ]);
+    const report = certifyWidget("transcript", scroller, provider, {
+      dimensions: ["scroll"],
+    });
+    expect(report.passed).toBe(false);
+    expect(report.violations.map((v) => v.code)).toContain(
+      "scroll/height-chain-collapsed",
+    );
+  });
+});
+
+/* ── certified widget: a list view (safe-area) ──────────────────────────── */
+
+describe("certifyWidget — list view (safe-area)", () => {
+  it("flags a control that sits under the bottom home indicator", () => {
+    const { container } = render(
+      <div data-testid="list">
+        <button type="button" data-testid="row-1">
+          row 1
+        </button>
+        <button type="button" data-testid="row-last">
+          row last
+        </button>
+      </div>,
+    );
+    const controls = collectInteractive(container);
+    const provider = mapGeometryProvider([
+      [controls[0], { box: box(120, 0, 402, 56) }],
+      [controls[1], { box: box(850, 0, 402, 56) }], // bottom = 906, past 840 line
+    ]);
+    const report = certifyWidget("list", container, provider, {
+      dimensions: ["safe-area"],
+      safeArea: { insetTop: 59, insetBottom: 34, viewportHeight: 874 },
+    });
+    expect(report.passed).toBe(false);
+    const v = report.violations.find(
+      (x) => x.code === "safe-area/under-bottom-inset",
+    );
+    expect(v?.target).toBe('[data-testid="row-last"]');
+  });
+});

--- a/packages/ui/src/testing/widget-cert.ts
+++ b/packages/ui/src/testing/widget-cert.ts
@@ -1,0 +1,327 @@
+/**
+ * WIDGET CERTIFICATION HARNESS (#14380) — the DOM-walking layer that turns a
+ * rendered widget into the measurements {@link ./scroll-cert.ts} judges.
+ *
+ * Two-layer design, same philosophy as the rest of `src/testing`:
+ *
+ *  • STATIC layer (jsdom / vitest, always runs): walk the rendered widget's DOM
+ *    for interactive controls and scroll containers, read their boxes through a
+ *    pluggable {@link GeometryProvider}, and run the pure verdicts. jsdom does
+ *    not lay out, so the provider is where a test injects known geometry (the
+ *    same technique `useLoadOlderOnScroll.test.tsx` uses to stub scrollHeight).
+ *    A real browser can supply a provider backed by `getBoundingClientRect` +
+ *    `getComputedStyle` so the SAME sweep runs live.
+ *
+ *  • DEEP layer (playwright, env-permitting): the browser harness in
+ *    `__e2e__/run-widget-cert-e2e.mjs` mounts the widget in real Chromium/WebKit
+ *    and provides a live provider, so anchor-jump / overscroll / keyboard checks
+ *    exercise real layout + touch. Playwright is known-flaky in the fleet CI
+ *    box; the static layer is the always-green gate, the deep layer is the
+ *    proof when it can run.
+ *
+ * The sweep is deliberately conservative about what counts as an INTERACTIVE
+ * control (so the tap-target floor isn't applied to decorative spans): native
+ * button/a/input/select/textarea + `[role=button|link|tab|switch|menuitem|
+ * checkbox|radio]` + `[tabindex]` >= 0 + anything with an explicit
+ * `data-tap-target`. A control opts OUT with `data-tap-target="ignore"`
+ * (documented escape hatch for genuinely non-pointer affordances).
+ */
+
+import {
+  buildWidgetReport,
+  certifyKeyboardClearance,
+  certifyOverscrollContained,
+  certifySafeAreaClearance,
+  certifyScrollGeometry,
+  certifyTapTargets,
+  type KeyboardGeometry,
+  type SafeAreaGeometry,
+  type ScrollerGeometry,
+  type TapTarget,
+  type Violation,
+  type WidgetCertReport,
+} from "./scroll-cert";
+
+/** A measured box in the layout viewport (px). */
+export interface Box {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Supplies geometry + computed style for an element. In a real browser this is
+ * `getBoundingClientRect` + `getComputedStyle`; under jsdom a test provides a
+ * map so the DETECTOR is exercised on known-broken and known-good inputs.
+ */
+export interface GeometryProvider {
+  box(el: Element): Box;
+  computed(el: Element): {
+    overflowY: string;
+    overflowX: string;
+    overscrollBehaviorY?: string;
+  };
+  /**
+   * Optional effective (expanded) hit box for a control whose visual box is
+   * smaller than its tappable area (padding / ::before / hitSlop). Returning
+   * undefined falls back to the visual box.
+   */
+  effectiveHitBox?(el: Element): Box | undefined;
+  /**
+   * Optional: set scrollTop to ~scrollHeight/2 and return where it settled, so
+   * the height-chain check works. Under jsdom the provider fakes this; a real
+   * browser mutates the node. Defaults to reporting the element's scrollTop.
+   */
+  probeMidScrollTop?(el: Element): number;
+}
+
+const INTERACTIVE_SELECTOR = [
+  "button",
+  "a[href]",
+  "input:not([type=hidden])",
+  "select",
+  "textarea",
+  '[role="button"]',
+  '[role="link"]',
+  '[role="tab"]',
+  '[role="switch"]',
+  '[role="menuitem"]',
+  '[role="checkbox"]',
+  '[role="radio"]',
+  "[tabindex]",
+  "[data-tap-target]",
+].join(",");
+
+const SCROLLER_SELECTOR = [
+  "[data-scroll-cert-scroller]",
+  '[data-testid="chat-thread"]',
+  "#continuous-thread",
+].join(",");
+
+/** Best-effort human locator for a control, for the per-widget report. */
+export function locate(el: Element): string {
+  const testid = el.getAttribute("data-testid");
+  if (testid) return `[data-testid="${testid}"]`;
+  const tap = el.getAttribute("data-tap-target");
+  if (tap && tap !== "ignore") return `[data-tap-target="${tap}"]`;
+  const aria = el.getAttribute("aria-label");
+  if (aria) return `${el.tagName.toLowerCase()}[aria-label="${aria}"]`;
+  const id = el.id;
+  if (id) return `#${id}`;
+  const text = (el.textContent ?? "").trim().slice(0, 24);
+  return `${el.tagName.toLowerCase()}${text ? `:"${text}"` : ""}`;
+}
+
+/** Collect the interactive controls inside a root that opt into the tap floor. */
+export function collectInteractive(root: Element): Element[] {
+  const out: Element[] = [];
+  for (const el of Array.from(root.querySelectorAll(INTERACTIVE_SELECTOR))) {
+    if (el.getAttribute("data-tap-target") === "ignore") continue;
+    // A disabled/aria-hidden control is not a live tap target.
+    if (el.hasAttribute("disabled")) continue;
+    if (el.getAttribute("aria-hidden") === "true") continue;
+    const tabindex = el.getAttribute("tabindex");
+    if (tabindex !== null && Number(tabindex) < 0) continue;
+    out.push(el);
+  }
+  return out;
+}
+
+/** Collect scroll containers inside a root. */
+export function collectScrollers(root: Element): Element[] {
+  const found = Array.from(root.querySelectorAll(SCROLLER_SELECTOR));
+  // Include the root itself if it opted in.
+  if (root.matches?.(SCROLLER_SELECTOR)) found.unshift(root);
+  return found;
+}
+
+/** Which dimensions to exercise for a given widget certification. */
+export interface CertifyOptions {
+  dimensions?: Violation["dimension"][];
+  /** Safe-area insets in effect (px); required for the safe-area dimension. */
+  safeArea?: { insetTop: number; insetBottom: number; viewportHeight: number };
+  /** Keyboard geometry per interactive region; required for the keyboard dim. */
+  keyboard?: KeyboardGeometry;
+  /**
+   * For each scroller, whether it is nested inside another scroller (so
+   * overscroll containment is required). Keyed by the scroller's `locate()`.
+   */
+  nestedScrollers?: Record<string, boolean>;
+  /** Optional evidence artifact paths to attach to the report. */
+  artifacts?: string[];
+}
+
+const DEFAULT_DIMENSIONS: Violation["dimension"][] = [
+  "scroll",
+  "tap-target",
+  "safe-area",
+];
+
+/**
+ * Certify a rendered widget: sweep its DOM, read geometry through the provider,
+ * run the pure verdicts, and assemble a per-widget report. This is the single
+ * entry point both the jsdom tests and the playwright deep layer call.
+ */
+export function certifyWidget(
+  widgetName: string,
+  root: Element,
+  provider: GeometryProvider,
+  opts: CertifyOptions = {},
+): WidgetCertReport {
+  const dimensions = opts.dimensions ?? DEFAULT_DIMENSIONS;
+  const violations: Violation[] = [];
+
+  // ── tap-target sweep ──────────────────────────────────────────────────
+  if (dimensions.includes("tap-target")) {
+    const controls = collectInteractive(root);
+    const targets: TapTarget[] = controls.map((el) => {
+      const box = provider.box(el);
+      const eff = provider.effectiveHitBox?.(el);
+      return {
+        width: box.width,
+        height: box.height,
+        target: locate(el),
+        ...(eff
+          ? { effectiveWidth: eff.width, effectiveHeight: eff.height }
+          : {}),
+      };
+    });
+    violations.push(...certifyTapTargets(targets));
+  }
+
+  // ── safe-area sweep (interactive controls only) ───────────────────────
+  if (dimensions.includes("safe-area") && opts.safeArea) {
+    const controls = collectInteractive(root);
+    for (const el of controls) {
+      const box = provider.box(el);
+      const s: SafeAreaGeometry = {
+        insetTop: opts.safeArea.insetTop,
+        insetBottom: opts.safeArea.insetBottom,
+        viewportHeight: opts.safeArea.viewportHeight,
+        controlTop: box.top,
+        controlBottom: box.top + box.height,
+      };
+      violations.push(...certifySafeAreaClearance(s, locate(el)));
+    }
+  }
+
+  // ── scroll sweep ──────────────────────────────────────────────────────
+  if (dimensions.includes("scroll")) {
+    for (const el of collectScrollers(root)) {
+      const box = provider.box(el);
+      const cs = provider.computed(el);
+      const anyEl = el as unknown as {
+        scrollHeight: number;
+        scrollWidth: number;
+        scrollTop: number;
+      };
+      const geo: ScrollerGeometry = {
+        scrollHeight: anyEl.scrollHeight,
+        clientHeight: box.height,
+        scrollWidth: anyEl.scrollWidth,
+        clientWidth: box.width,
+        overflowY: cs.overflowY,
+        overflowX: cs.overflowX,
+        overscrollBehaviorY: cs.overscrollBehaviorY,
+        midScrollTopSettled: provider.probeMidScrollTop
+          ? provider.probeMidScrollTop(el)
+          : anyEl.scrollTop,
+      };
+      const loc = locate(el);
+      violations.push(...certifyScrollGeometry(geo, loc));
+      const nested = opts.nestedScrollers?.[loc] ?? false;
+      violations.push(
+        ...certifyOverscrollContained(
+          { overscrollBehaviorY: cs.overscrollBehaviorY },
+          { nestedInScroller: nested },
+          loc,
+        ),
+      );
+    }
+  }
+
+  // ── keyboard clearance ────────────────────────────────────────────────
+  if (dimensions.includes("keyboard") && opts.keyboard) {
+    violations.push(...certifyKeyboardClearance(opts.keyboard, widgetName));
+  }
+
+  return buildWidgetReport(widgetName, dimensions, violations, opts.artifacts);
+}
+
+/**
+ * A jsdom-friendly {@link GeometryProvider} backed by an explicit element→box
+ * map — the technique the hooks tests use to give jsdom (which never lays out)
+ * real geometry. Elements not in the map report a zero box (so an unmeasured
+ * control is a loud, catchable failure rather than a silent pass).
+ */
+export function mapGeometryProvider(
+  entries: Iterable<
+    [
+      Element,
+      {
+        box: Box;
+        overflowY?: string;
+        overflowX?: string;
+        overscrollBehaviorY?: string;
+        scrollHeight?: number;
+        scrollWidth?: number;
+        midScrollTopSettled?: number;
+        effectiveHitBox?: Box;
+      },
+    ]
+  >,
+): GeometryProvider {
+  const map = new Map(entries);
+  return {
+    box(el) {
+      return map.get(el)?.box ?? { top: 0, left: 0, width: 0, height: 0 };
+    },
+    computed(el) {
+      const e = map.get(el);
+      return {
+        overflowY: e?.overflowY ?? "visible",
+        overflowX: e?.overflowX ?? "visible",
+        overscrollBehaviorY: e?.overscrollBehaviorY,
+      };
+    },
+    effectiveHitBox(el) {
+      return map.get(el)?.effectiveHitBox;
+    },
+    probeMidScrollTop(el) {
+      return map.get(el)?.midScrollTopSettled ?? 0;
+    },
+  };
+}
+
+/**
+ * A live-browser {@link GeometryProvider} backed by `getBoundingClientRect` +
+ * `getComputedStyle`. Used by the playwright deep layer (and any real-DOM
+ * test). `probeMidScrollTop` actually mutates the node — only safe in a
+ * laying-out environment.
+ */
+export function liveGeometryProvider(win: Window): GeometryProvider {
+  return {
+    box(el) {
+      const r = el.getBoundingClientRect();
+      return { top: r.top, left: r.left, width: r.width, height: r.height };
+    },
+    computed(el) {
+      const cs = win.getComputedStyle(el);
+      return {
+        overflowY: cs.overflowY,
+        overflowX: cs.overflowX,
+        overscrollBehaviorY:
+          cs.getPropertyValue("overscroll-behavior-y") || undefined,
+      };
+    },
+    probeMidScrollTop(el) {
+      const node = el as unknown as {
+        scrollHeight: number;
+        scrollTop: number;
+      };
+      node.scrollTop = Math.round(node.scrollHeight / 2);
+      return node.scrollTop;
+    },
+  };
+}


### PR DESCRIPTION
## What

A UI-library-wide **scroll + tap-target certification harness** (#14380, superset of the closed #14394). It holds scrollable / interactive widgets to the four device-review guarantees called out in #14317:

1. **Scroll stability** — bounded overflow, mid-scrollTop sticks (catches the "can't scroll" height-chain collapse), no unintended horizontal overflow, anchor preserved on prepend/append (no scroll-up-yanks-you), nested overscroll contained.
2. **Keyboard interaction** — harness-level geometry: the focused/interactive region stays inside the keyboard-shrunk visual viewport (not hidden/clipped behind the soft keyboard).
3. **Safe-area clearance** — interactive controls clear the top notch inset and the bottom home-indicator inset.
4. **Tap-target minimums** — every interactive control's hit box ≥ 44×44 CSS px (iOS HIG / WCAG 2.5.5 AAA).

## How (two layers, mirroring `src/testing/layout-stability.ts`)

- **`scroll-cert.ts`** — PURE `(measurements) -> Violation[]` verdict math for all four dimensions. Proven **both ways** (RED on a violation, GREEN when it holds) in `scroll-cert.test.ts` — the detector is trustworthy before it is pointed at any live widget. No larp.
- **`widget-cert.ts`** — a DOM sweep: walks a rendered widget for interactive controls + scroll containers, reads geometry through a pluggable `GeometryProvider` (`mapGeometryProvider` for jsdom, `liveGeometryProvider` = getBoundingClientRect + getComputedStyle for a real browser), and assembles a per-widget `WidgetCertReport` (JSON + rendered summary). `widget-cert.test.tsx` certifies the harness against real rendered DOM incl. the `Button` primitive.
- **Deep layer** — `__e2e__/run-widget-cert-e2e.mjs` + `widget-cert-fixture.tsx` (`bun run test:widget-cert-e2e`) mounts the widgets in real Chromium/WebKit and runs the **same** sweep against real layout, emitting evidence. Gracefully **SKIPs (exit 0)** when playwright can't launch — the vitest static layer is the always-green gate.

First certified widgets: **demo-buttons view** (device-review target, explicit req), the **chat transcript scroller**, and a **list view**.

## Scope discipline (per [sol-orch] confirm on #14380)

This harness only **DETECTS**. Component sizing / layout fixes are owned by the component lanes (`wt-14399` / `wt-13453` for demo-view tap-target sizes, `wt-chat-keyboard` / #14379 for chat keyboard overlay fixes). My keyboard slice is harness geometry **checks**, not overlay fixes.

## Evidence

**Static gate (always runs) — `packages/ui/src/testing/`:**
```
✓ scroll-cert.test.ts  (27 tests)   — every dimension proven RED + GREEN
✓ widget-cert.test.tsx (8 tests)    — sweep + report vs real DOM (Button primitive)
  35/35 GREEN
```

**Deep layer against real Chromium (`test:widget-cert-e2e`) — REAL findings:**
```
UI widget certification (deep/chromium) — FINDINGS
1/2 widgets certified

✗ demo-buttons  [tap-target]
    ✗ btn-default: hit box 83×40px  below 44×44 (h-10)
    ✗ btn-sm:      hit box 63×36px  below 44×44 (h-9)
    ✗ btn-icon:    hit box 40×40px  below 44×44 (h-10 w-10)
    ✗ btn-icon-sm: hit box 32×32px  below 44×44 (h-8 w-8)
✓ transcript  [scroll, tap-target]   — bounded overflow, contains overscroll
```
Evidence artifacts: `output-widget-cert/{widget-cert.json, widget-cert.txt, chromium.png}` (gitignored, regenerable via `test:widget-cert-e2e`).

**`cd packages/app && bun run build` → EXIT 0 (`✓ built in 1m 2s`).**

## Findings (reported, NOT fixed — routed to follow-up)

The `Button` primitive's `default` (40px), `sm` (36px), `icon` (40px), `icon-sm` (32px) sizes render **below the 44px tap floor**; only `lg` (44px) clears it. These are genuine device-review findings for the component-owning lanes — commented on #14380.

## Docs

`packages/ui/AGENTS.md` — "Scroll + tap-target certification" section: how to certify a new widget.

Fixes #14380

— [sol-orch] / signed sol-scroll-cert
