### PR TITLE
fix(core): free-text invite + connector tests + README matrix for connector form fallback (#14321)

### DIFF
--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -75,12 +75,17 @@ FollowupsInteraction | TaskInteraction | SecretInteraction`) in
 |---|---|---|---|
 | choice | `ChoiceWidget` ✅ | inline-keyboard callback buttons ✅ | button action row ✅ |
 | followups | `FollowupsWidget` ✅ | callback buttons ✅ | button action row ✅ |
-| form | `FormRequest` ✅ | link-out (multi-field is awkward as a keyboard) ⏳ | link-out ⏳ |
+| form | `FormRequest` ✅ | free-text fallback (by design) ✅ | free-text fallback (by design) ✅ |
 | task | `TaskWidget` (live poll) ✅ | link button + title ✅ (live status ⏳) | link button + title ✅ |
 | secret/oauth | `SensitiveRequestBlock` ✅ | DM link via `sensitive-request-adapter` ✅ | DM link via `sensitive-request-adapter` ✅ |
 
-✅ implemented · ⏳ remaining (seams below). Choice/followups round-trip works on
-**both** connectors:
+✅ implemented · ⏳ remaining (seams below). Forms never link out on
+connectors **by design** (#14321): no hosted `/forms/:id` page exists (form
+specs are not persisted server-side), so `buildInteractionUrlResolver` resolves
+no URL for them and the layout degrades to the form's title/description plus a
+"Reply with your answer." invite. Secret-bearing input must never use a form —
+it goes through the sensitive-request flow, which has a real hosted page.
+Choice/followups round-trip works on **both** connectors:
 - **Telegram**: `handleCallbackQuery` decodes the tap and replays it through
   `handleMessage` as a user turn (`plugin-telegram/src/messageManager.ts`).
 - **Discord**: the `isButton` handler in `discord-interactions.ts` decodes the

--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -19,7 +19,11 @@ import {
 	isInteractionCallback,
 	MAX_CALLBACK_BYTES,
 } from "./callback";
-import { buildInteractionUrlResolver, toNeutralLayout } from "./layout";
+import {
+	buildInteractionUrlResolver,
+	FORM_FREE_TEXT_INVITE,
+	toNeutralLayout,
+} from "./layout";
 import {
 	normalizeContentInteractions,
 	stripInteractionMarkers,
@@ -283,13 +287,39 @@ describe("layout", () => {
 		});
 	});
 
-	it("falls back when a form has no link-out url", () => {
+	it("falls back when a form has no link-out url (#14321)", () => {
+		const block: FormInteraction = {
+			kind: "form",
+			id: "f",
+			title: "Set your reminder",
+			fields: [{ name: "k", type: "text" }],
+		};
+		const layout = toNeutralLayout(block);
+		expect(layout.needsFallback).toBe(true);
+		expect(layout.rows).toHaveLength(0);
+		expect(layout.text).toBe(`Set your reminder\n\n${FORM_FREE_TEXT_INVITE}`);
+	});
+
+	it("invites a free-text reply even when a form has no title or description", () => {
 		const block: FormInteraction = {
 			kind: "form",
 			id: "f",
 			fields: [{ name: "k", type: "text" }],
 		};
-		expect(toNeutralLayout(block).needsFallback).toBe(true);
+		expect(toNeutralLayout(block).text).toBe(FORM_FREE_TEXT_INVITE);
+	});
+
+	it("uses a non-blank form description when the title is blank", () => {
+		const block: FormInteraction = {
+			kind: "form",
+			id: "f",
+			title: "  ",
+			description: "Tell us when to remind you.",
+			fields: [{ name: "k", type: "text" }],
+		};
+		expect(toNeutralLayout(block).text).toBe(
+			`Tell us when to remind you.\n\n${FORM_FREE_TEXT_INVITE}`,
+		);
 	});
 
 	// #8908 — navigate followups render as link-out buttons when a URL resolver

--- a/packages/core/src/messaging/interactions/layout.ts
+++ b/packages/core/src/messaging/interactions/layout.ts
@@ -67,6 +67,23 @@ export interface LayoutOptions {
 	maxButtonsPerRow?: number;
 }
 
+/**
+ * Copy appended to a form block's prose when it cannot render natively and no
+ * link-out URL exists — the free-text fallback affordance connectors show
+ * instead of a dead button (#14321).
+ */
+export const FORM_FREE_TEXT_INVITE = "Reply with your answer.";
+
+function firstNonBlankText(
+	...values: Array<string | undefined>
+): string | undefined {
+	for (const value of values) {
+		const trimmed = value?.trim();
+		if (trimmed) return trimmed;
+	}
+	return undefined;
+}
+
 function chunk<T>(items: T[], size: number): T[][] {
 	const rows: T[][] = [];
 	for (let i = 0; i < items.length; i += size)
@@ -139,22 +156,31 @@ export function toNeutralLayout(
 		}
 		case "form": {
 			const url = resolveUrl?.(block);
+			if (url) {
+				return {
+					text: firstNonBlankText(block.title, block.description),
+					rows: [
+						{
+							buttons: [
+								{
+									label: block.submitLabel ?? "Open form",
+									url,
+									style: "primary",
+								},
+							],
+						},
+					],
+				};
+			}
+			// No hosted form page: show the form's prose and invite a free-text
+			// reply instead of leaving a bare title with no affordance (#14321).
+			const prose = firstNonBlankText(block.title, block.description);
 			return {
-				text: block.title ?? block.description,
-				rows: url
-					? [
-							{
-								buttons: [
-									{
-										label: block.submitLabel ?? "Open form",
-										url,
-										style: "primary",
-									},
-								],
-							},
-						]
-					: [],
-				needsFallback: !url,
+				text: prose
+					? `${prose}\n\n${FORM_FREE_TEXT_INVITE}`
+					: FORM_FREE_TEXT_INVITE,
+				rows: [],
+				needsFallback: true,
 			};
 		}
 		case "secret": {

--- a/plugins/plugin-discord/__tests__/interactions.test.ts
+++ b/plugins/plugin-discord/__tests__/interactions.test.ts
@@ -4,7 +4,11 @@
  * Pure-function assertions.
  */
 import type { Content } from "@elizaos/core";
-import { decodeCallback } from "@elizaos/core";
+import {
+	buildInteractionUrlResolver,
+	decodeCallback,
+	FORM_FREE_TEXT_INVITE,
+} from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { renderDiscordInteractions } from "../interactions";
 
@@ -78,5 +82,20 @@ describe("renderDiscordInteractions", () => {
 		expect(nav?.url).toBe("https://app.test/orchestrator");
 		expect(reply?.url).toBeUndefined();
 		expect(reply?.custom_id).toBeTruthy();
+	});
+	// #14321 — no hosted /forms/:id page exists; the canonical resolver must not
+	// mint a dead link-out. The form renders as prose + a free-text invite.
+	it("renders a form as prose + free-text fallback, never a dead link (#14321)", () => {
+		const out = renderDiscordInteractions(
+			{
+				text: 'Happy to set that up.\n[FORM]\n{"id":"f1","title":"Set your reminder","fields":[{"name":"when","type":"text"}]}\n[/FORM]',
+			} as Content,
+			buildInteractionUrlResolver("https://app.test"),
+		);
+		expect(out.components).toHaveLength(0);
+		expect(out.needsFreeTextReply).toBe(true);
+		expect(out.text).toContain("Set your reminder");
+		expect(out.text).toContain(FORM_FREE_TEXT_INVITE);
+		expect(out.text).not.toContain("/forms/");
 	});
 });

--- a/plugins/plugin-telegram/src/interactions.test.ts
+++ b/plugins/plugin-telegram/src/interactions.test.ts
@@ -5,7 +5,11 @@
  * Deterministic; no live API.
  */
 import type { Content } from "@elizaos/core";
-import { decodeCallback } from "@elizaos/core";
+import {
+  buildInteractionUrlResolver,
+  decodeCallback,
+  FORM_FREE_TEXT_INVITE,
+} from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { renderTelegramInteractions } from "./interactions";
 
@@ -77,5 +81,20 @@ describe("renderTelegramInteractions", () => {
     expect(nav?.url).toBe("https://app.test/orchestrator");
     expect(reply?.url).toBeUndefined();
     expect(reply?.callback_data).toBeTruthy();
+  });
+  // #14321 — no hosted /forms/:id page exists; the canonical resolver must not
+  // mint a dead link-out. The form renders as prose + a free-text invite.
+  it("renders a form as prose + free-text fallback, never a dead link (#14321)", () => {
+    const out = renderTelegramInteractions(
+      {
+        text: 'Happy to set that up.\n[FORM]\n{"id":"f1","title":"Set your reminder","fields":[{"name":"when","type":"text"}]}\n[/FORM]',
+      } as Content,
+      buildInteractionUrlResolver("https://app.test"),
+    );
+    expect(out.keyboardRows).toHaveLength(0);
+    expect(out.needsFreeTextReply).toBe(true);
+    expect(out.text).toContain("Set your reminder");
+    expect(out.text).toContain(FORM_FREE_TEXT_INVITE);
+    expect(out.text).not.toContain("/forms/");
   });
 });


### PR DESCRIPTION
Closes #14321 (remaining acceptance criteria on top of #14438).

## What

#14438 stopped `buildInteractionUrlResolver` from minting the dead `/forms/:id` URL, so `[FORM]` blocks on Telegram/Discord no longer render a dead button. But three of #14321's acceptance criteria were still open:

1. **The fallback had no affordance** — a form block degraded to its bare title with nothing inviting the user to answer. `toNeutralLayout`'s form fallback now appends `FORM_FREE_TEXT_INVITE` ("Reply with your answer.") to the form's title/description (or renders it alone when the form has neither), so connectors show a designed degrade per the issue text.
2. **No connector-level tests** — added Telegram + Discord unit tests that drive a `[FORM]` reply through the *canonical* resolver (`buildInteractionUrlResolver`) and assert: zero keyboard rows / components, `needsFreeTextReply === true`, prose contains the title + invite, and **no `/forms/` URL anywhere**.
3. **README rendering matrix still said `link-out ⏳`** — updated to `free-text fallback (by design) ✅` for both connectors, with the rationale (no hosted page; specs never persisted) and the standing rule that secret-bearing input uses the sensitive-request flow (which has a real hosted page).

## Evidence

**Transport payloads (the exact object each connector sends), rendered through `renderTelegramInteractions` / `renderDiscordInteractions` with `buildInteractionUrlResolver("https://app.example.com")`:**

BEFORE (pre-#14438 develop) — fabricated dead control:
```json
{ "text": "Happy to set that up.",
  "keyboardRows": [[ { "text": "Submit", "url": "https://app.example.com/forms/reminder_1" } ]],
  "needsFreeTextReply": false }
```

develop today (post-#14438) — dead button gone, but bare title, no affordance:
```json
{ "text": "Happy to set that up.\n\nSet your reminder", "keyboardRows": [], "needsFreeTextReply": true }
```

AFTER (this PR) — designed degrade with invite (identical on Discord):
```json
{ "text": "Happy to set that up.\n\nSet your reminder\n\nReply with your answer.",
  "keyboardRows": [], "needsFreeTextReply": true }
```

**Unit tests** (all green):
- `packages/core` interactions suite: 31 passed — includes fallback-with-title, fallback-without-title, and the #14438 resolver test.
- `plugins/plugin-telegram/src/interactions.test.ts` + `plugins/plugin-discord/__tests__/interactions.test.ts`: 12 passed, including the new `renders a form as prose + free-text fallback, never a dead link (#14321)` on each connector.

**Grep proof** — the only `/forms/` minting site in packages/plugins was `layout.ts:196` (removed in #14438); repo grep shows no other code path produces one (remaining hits are `platforms/` substring false-positives and the research doc describing the old bug).

- Real Telegram/Discord client screenshots + MP4: **N/A — no Telegram/Discord bot credentials or logged-in clients exist on this host.** The transport payloads above are byte-level what the platforms render; the connector unit tests pin them. #14322 (live-LLM widget round-trip scenarios) is the tracked home for live-connector coverage.
- Backend structured logs: **N/A — change is a pure projection-layer function (no service boots in unit scope)**; the render path is exercised deterministically above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)