### PR TITLE
docs(#14341): repoint DoD evidence-location clause off retired .github/issue-evidence

### DIFF
--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -180,7 +180,7 @@ supervisor relaunches) — never a silent `process.exit`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/agent/CLAUDE.md
+++ b/packages/agent/CLAUDE.md
@@ -180,7 +180,7 @@ supervisor relaunches) — never a silent `process.exit`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/app-core/AGENTS.md
+++ b/packages/app-core/AGENTS.md
@@ -127,7 +127,7 @@ Run from repo root with `--cwd packages/app-core`:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/app-core/CLAUDE.md
+++ b/packages/app-core/CLAUDE.md
@@ -127,7 +127,7 @@ Run from repo root with `--cwd packages/app-core`:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -120,7 +120,7 @@ bun run --cwd packages/app install:android:adb
 ### iOS device automation (one command each — no Xcode UI, no manual signing)
 
 Agent-drivable pipeline for physical-device work (codifies the proven #11030
-device-boot recipe in `.github/issue-evidence/11030-ios-boot-fix/device-boot-README.md`).
+device-boot recipe).
 Device id comes from `--device <devicectl-id|udid|name>` or `ELIZA_IOS_DEVICE_ID`.
 Lane phones must stay on power with Settings > Display & Brightness > Auto-Lock
 set to Never. The device scripts probe `devicectl device info lockState` before
@@ -308,7 +308,7 @@ bun run --cwd packages/app test:e2e
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -120,7 +120,7 @@ bun run --cwd packages/app install:android:adb
 ### iOS device automation (one command each — no Xcode UI, no manual signing)
 
 Agent-drivable pipeline for physical-device work (codifies the proven #11030
-device-boot recipe in `.github/issue-evidence/11030-ios-boot-fix/device-boot-README.md`).
+device-boot recipe).
 Device id comes from `--device <devicectl-id|udid|name>` or `ELIZA_IOS_DEVICE_ID`.
 Lane phones must stay on power with Settings > Display & Brightness > Auto-Lock
 set to Never. The device scripts probe `devicectl device info lockState` before
@@ -308,7 +308,7 @@ bun run --cwd packages/app test:e2e
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/AGENTS.md
+++ b/packages/benchmarks/AGENTS.md
@@ -111,7 +111,7 @@ Operator runbook (remote GPU, calibration/readiness gates, code-agent matrix):
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/CLAUDE.md
+++ b/packages/benchmarks/CLAUDE.md
@@ -111,7 +111,7 @@ Operator runbook (remote GPU, calibration/readiness gates, code-agent matrix):
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/HyperliquidBench/AGENTS.md
+++ b/packages/benchmarks/HyperliquidBench/AGENTS.md
@@ -133,7 +133,7 @@ the Rust `cargo test` target and the Makefile shortcuts (`make format`, `make ch
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/HyperliquidBench/CLAUDE.md
+++ b/packages/benchmarks/HyperliquidBench/CLAUDE.md
@@ -133,7 +133,7 @@ the Rust `cargo test` target and the Makefile shortcuts (`make format`, `make ch
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/OSWorld/AGENTS.md
+++ b/packages/benchmarks/OSWorld/AGENTS.md
@@ -125,7 +125,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/OSWorld/CLAUDE.md
+++ b/packages/benchmarks/OSWorld/CLAUDE.md
@@ -125,7 +125,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/abliteration-robustness/AGENTS.md
+++ b/packages/benchmarks/abliteration-robustness/AGENTS.md
@@ -91,7 +91,7 @@ pytest abliteration-robustness/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/abliteration-robustness/CLAUDE.md
+++ b/packages/benchmarks/abliteration-robustness/CLAUDE.md
@@ -91,7 +91,7 @@ pytest abliteration-robustness/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/action-calling/AGENTS.md
+++ b/packages/benchmarks/action-calling/AGENTS.md
@@ -87,7 +87,7 @@ pytest packages/benchmarks/action-calling/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/action-calling/CLAUDE.md
+++ b/packages/benchmarks/action-calling/CLAUDE.md
@@ -87,7 +87,7 @@ pytest packages/benchmarks/action-calling/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/adhdbench/AGENTS.md
+++ b/packages/benchmarks/adhdbench/AGENTS.md
@@ -101,7 +101,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/adhdbench/CLAUDE.md
+++ b/packages/benchmarks/adhdbench/CLAUDE.md
@@ -101,7 +101,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/agentbench/AGENTS.md
+++ b/packages/benchmarks/agentbench/AGENTS.md
@@ -97,7 +97,7 @@ pytest elizaos_agentbench/tests/test_upstream_scoring.py -v  # scoring contracts
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/agentbench/CLAUDE.md
+++ b/packages/benchmarks/agentbench/CLAUDE.md
@@ -97,7 +97,7 @@ pytest elizaos_agentbench/tests/test_upstream_scoring.py -v  # scoring contracts
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/app-eval/AGENTS.md
+++ b/packages/benchmarks/app-eval/AGENTS.md
@@ -123,7 +123,7 @@ bun test packages/benchmarks/app-eval/evaluate.real.test.ts
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/app-eval/CLAUDE.md
+++ b/packages/benchmarks/app-eval/CLAUDE.md
@@ -123,7 +123,7 @@ bun test packages/benchmarks/app-eval/evaluate.real.test.ts
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/bfcl/AGENTS.md
+++ b/packages/benchmarks/bfcl/AGENTS.md
@@ -94,7 +94,7 @@ pytest bfcl/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/bfcl/CLAUDE.md
+++ b/packages/benchmarks/bfcl/CLAUDE.md
@@ -94,7 +94,7 @@ pytest bfcl/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/clawbench/AGENTS.md
+++ b/packages/benchmarks/clawbench/AGENTS.md
@@ -108,7 +108,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/clawbench/CLAUDE.md
+++ b/packages/benchmarks/clawbench/CLAUDE.md
@@ -108,7 +108,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/configbench/AGENTS.md
+++ b/packages/benchmarks/configbench/AGENTS.md
@@ -90,7 +90,7 @@ bun run test        # vitest run (all four test files)
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/configbench/CLAUDE.md
+++ b/packages/benchmarks/configbench/CLAUDE.md
@@ -90,7 +90,7 @@ bun run test        # vitest run (all four test files)
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/context-bench/AGENTS.md
+++ b/packages/benchmarks/context-bench/AGENTS.md
@@ -92,7 +92,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/context-bench/CLAUDE.md
+++ b/packages/benchmarks/context-bench/CLAUDE.md
@@ -92,7 +92,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/eliza-1/AGENTS.md
+++ b/packages/benchmarks/eliza-1/AGENTS.md
@@ -126,7 +126,7 @@ bun run --cwd packages/benchmarks/eliza-1/vision-cua-e2e test
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/eliza-1/CLAUDE.md
+++ b/packages/benchmarks/eliza-1/CLAUDE.md
@@ -126,7 +126,7 @@ bun run --cwd packages/benchmarks/eliza-1/vision-cua-e2e test
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/eliza-adapter/AGENTS.md
+++ b/packages/benchmarks/eliza-adapter/AGENTS.md
@@ -131,7 +131,7 @@ subprocess calls.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/eliza-adapter/CLAUDE.md
+++ b/packages/benchmarks/eliza-adapter/CLAUDE.md
@@ -131,7 +131,7 @@ subprocess calls.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/experience/AGENTS.md
+++ b/packages/benchmarks/experience/AGENTS.md
@@ -84,7 +84,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/experience/CLAUDE.md
+++ b/packages/benchmarks/experience/CLAUDE.md
@@ -84,7 +84,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/gauntlet/AGENTS.md
+++ b/packages/benchmarks/gauntlet/AGENTS.md
@@ -112,7 +112,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/gauntlet/CLAUDE.md
+++ b/packages/benchmarks/gauntlet/CLAUDE.md
@@ -112,7 +112,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/hermes-adapter/AGENTS.md
+++ b/packages/benchmarks/hermes-adapter/AGENTS.md
@@ -96,7 +96,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/hermes-adapter/CLAUDE.md
+++ b/packages/benchmarks/hermes-adapter/CLAUDE.md
@@ -96,7 +96,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/interrupt-bench/AGENTS.md
+++ b/packages/benchmarks/interrupt-bench/AGENTS.md
@@ -100,7 +100,7 @@ bun run typecheck     # tsgo --noEmit
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/interrupt-bench/CLAUDE.md
+++ b/packages/benchmarks/interrupt-bench/CLAUDE.md
@@ -100,7 +100,7 @@ bun run typecheck     # tsgo --noEmit
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/lifeops-bench/AGENTS.md
+++ b/packages/benchmarks/lifeops-bench/AGENTS.md
@@ -103,7 +103,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/lifeops-bench/CLAUDE.md
+++ b/packages/benchmarks/lifeops-bench/CLAUDE.md
@@ -103,7 +103,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/loadperf/AGENTS.md
+++ b/packages/benchmarks/loadperf/AGENTS.md
@@ -103,7 +103,7 @@ against a built dist as shown above.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/loadperf/CLAUDE.md
+++ b/packages/benchmarks/loadperf/CLAUDE.md
@@ -103,7 +103,7 @@ against a built dist as shown above.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/meeting-transcription-proof/AGENTS.md
+++ b/packages/benchmarks/meeting-transcription-proof/AGENTS.md
@@ -159,5 +159,4 @@ cloud captures.
 
 Mocked reports prove plumbing only. Real reports must reference reviewed audio,
 video, logs, screenshots, trajectories, transcript artifacts, speaker profile
-artifacts, consent records, and retention/deletion artifacts under
-`.github/issue-evidence/<issue#>-<slug>/`.
+artifacts, consent records, and retention/deletion artifacts, attached inline in the PR.

--- a/packages/benchmarks/meeting-transcription-proof/CLAUDE.md
+++ b/packages/benchmarks/meeting-transcription-proof/CLAUDE.md
@@ -159,5 +159,4 @@ cloud captures.
 
 Mocked reports prove plumbing only. Real reports must reference reviewed audio,
 video, logs, screenshots, trajectories, transcript artifacts, speaker profile
-artifacts, consent records, and retention/deletion artifacts under
-`.github/issue-evidence/<issue#>-<slug>/`.
+artifacts, consent records, and retention/deletion artifacts, attached inline in the PR.

--- a/packages/benchmarks/memperf/AGENTS.md
+++ b/packages/benchmarks/memperf/AGENTS.md
@@ -122,7 +122,7 @@ node_modules/.bin/tsgo --noEmit -p packages/benchmarks/memperf/tsconfig.check.js
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/memperf/CLAUDE.md
+++ b/packages/benchmarks/memperf/CLAUDE.md
@@ -122,7 +122,7 @@ node_modules/.bin/tsgo --noEmit -p packages/benchmarks/memperf/tsconfig.check.js
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/mind2web/AGENTS.md
+++ b/packages/benchmarks/mind2web/AGENTS.md
@@ -88,7 +88,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/mind2web/CLAUDE.md
+++ b/packages/benchmarks/mind2web/CLAUDE.md
@@ -88,7 +88,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/mint/AGENTS.md
+++ b/packages/benchmarks/mint/AGENTS.md
@@ -105,7 +105,7 @@ repo tree).
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/mint/CLAUDE.md
+++ b/packages/benchmarks/mint/CLAUDE.md
@@ -105,7 +105,7 @@ repo tree).
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/mmau-audio/AGENTS.md
+++ b/packages/benchmarks/mmau-audio/AGENTS.md
@@ -92,7 +92,7 @@ pytest tests/ -x
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/mmau-audio/CLAUDE.md
+++ b/packages/benchmarks/mmau-audio/CLAUDE.md
@@ -92,7 +92,7 @@ pytest tests/ -x
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/mobile-resource/AGENTS.md
+++ b/packages/benchmarks/mobile-resource/AGENTS.md
@@ -84,7 +84,7 @@ See the root [AGENTS.md](../../../AGENTS.md) for repo-wide rules and the issue
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/mobile-resource/CLAUDE.md
+++ b/packages/benchmarks/mobile-resource/CLAUDE.md
@@ -84,7 +84,7 @@ See the root [AGENTS.md](../../../AGENTS.md) for repo-wide rules and the issue
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/nl2repo/AGENTS.md
+++ b/packages/benchmarks/nl2repo/AGENTS.md
@@ -94,7 +94,7 @@ pytest packages/benchmarks/nl2repo/tests/test_adapter_matrix.py -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/nl2repo/CLAUDE.md
+++ b/packages/benchmarks/nl2repo/CLAUDE.md
@@ -94,7 +94,7 @@ pytest packages/benchmarks/nl2repo/tests/test_adapter_matrix.py -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/openclaw-adapter/AGENTS.md
+++ b/packages/benchmarks/openclaw-adapter/AGENTS.md
@@ -95,7 +95,7 @@ pytest openclaw-adapter/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/openclaw-adapter/CLAUDE.md
+++ b/packages/benchmarks/openclaw-adapter/CLAUDE.md
@@ -95,7 +95,7 @@ pytest openclaw-adapter/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/openclaw-benchmark/AGENTS.md
+++ b/packages/benchmarks/openclaw-benchmark/AGENTS.md
@@ -98,7 +98,7 @@ pytest openclaw-benchmark/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/openclaw-benchmark/CLAUDE.md
+++ b/packages/benchmarks/openclaw-benchmark/CLAUDE.md
@@ -98,7 +98,7 @@ pytest openclaw-benchmark/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/orchestrator_lifecycle/AGENTS.md
+++ b/packages/benchmarks/orchestrator_lifecycle/AGENTS.md
@@ -96,7 +96,7 @@ pytest packages/benchmarks/orchestrator_lifecycle/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/orchestrator_lifecycle/CLAUDE.md
+++ b/packages/benchmarks/orchestrator_lifecycle/CLAUDE.md
@@ -96,7 +96,7 @@ pytest packages/benchmarks/orchestrator_lifecycle/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/personality-bench/AGENTS.md
+++ b/packages/benchmarks/personality-bench/AGENTS.md
@@ -99,7 +99,7 @@ bun x vitest run tests/judge.test.ts --reporter=verbose
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/personality-bench/CLAUDE.md
+++ b/packages/benchmarks/personality-bench/CLAUDE.md
@@ -99,7 +99,7 @@ bun x vitest run tests/judge.test.ts --reporter=verbose
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/realm/AGENTS.md
+++ b/packages/benchmarks/realm/AGENTS.md
@@ -97,7 +97,7 @@ pytest packages/benchmarks/realm/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/realm/CLAUDE.md
+++ b/packages/benchmarks/realm/CLAUDE.md
@@ -97,7 +97,7 @@ pytest packages/benchmarks/realm/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/rlm-bench/AGENTS.md
+++ b/packages/benchmarks/rlm-bench/AGENTS.md
@@ -81,7 +81,7 @@ pytest elizaos_rlm_bench/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/rlm-bench/CLAUDE.md
+++ b/packages/benchmarks/rlm-bench/CLAUDE.md
@@ -81,7 +81,7 @@ pytest elizaos_rlm_bench/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/scambench/AGENTS.md
+++ b/packages/benchmarks/scambench/AGENTS.md
@@ -87,7 +87,7 @@ No install step — the package is part of the monorepo `benchmarks` namespace.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/scambench/CLAUDE.md
+++ b/packages/benchmarks/scambench/CLAUDE.md
@@ -87,7 +87,7 @@ No install step — the package is part of the monorepo `benchmarks` namespace.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/smithers-adapter/AGENTS.md
+++ b/packages/benchmarks/smithers-adapter/AGENTS.md
@@ -107,7 +107,7 @@ Tests are offline (no API keys or real Smithers install required).
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/smithers-adapter/CLAUDE.md
+++ b/packages/benchmarks/smithers-adapter/CLAUDE.md
@@ -107,7 +107,7 @@ Tests are offline (no API keys or real Smithers install required).
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/social-alpha/AGENTS.md
+++ b/packages/benchmarks/social-alpha/AGENTS.md
@@ -95,7 +95,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/social-alpha/CLAUDE.md
+++ b/packages/benchmarks/social-alpha/CLAUDE.md
@@ -95,7 +95,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/solana/AGENTS.md
+++ b/packages/benchmarks/solana/AGENTS.md
@@ -111,7 +111,7 @@ are absent. Tests requiring live Surfpool or API keys are not in this suite.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/solana/CLAUDE.md
+++ b/packages/benchmarks/solana/CLAUDE.md
@@ -111,7 +111,7 @@ are absent. Tests requiring live Surfpool or API keys are not in this suite.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/solana/solana-gym-env/AGENTS.md
+++ b/packages/benchmarks/solana/solana-gym-env/AGENTS.md
@@ -252,7 +252,7 @@ The Code Loop Explorer tracks detailed metrics in JSON files saved to `/metrics/
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/solana/solana-gym-env/CLAUDE.md
+++ b/packages/benchmarks/solana/solana-gym-env/CLAUDE.md
@@ -252,7 +252,7 @@ The Code Loop Explorer tracks detailed metrics in JSON files saved to `/metrics/
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/standard/AGENTS.md
+++ b/packages/benchmarks/standard/AGENTS.md
@@ -119,7 +119,7 @@ No extra install step — the `standard/` package is part of the `benchmarks` na
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/standard/CLAUDE.md
+++ b/packages/benchmarks/standard/CLAUDE.md
@@ -119,7 +119,7 @@ No extra install step — the `standard/` package is part of the `benchmarks` na
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/swe_bench/AGENTS.md
+++ b/packages/benchmarks/swe_bench/AGENTS.md
@@ -99,7 +99,7 @@ pytest swe_bench/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/swe_bench/CLAUDE.md
+++ b/packages/benchmarks/swe_bench/CLAUDE.md
@@ -99,7 +99,7 @@ pytest swe_bench/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/tau-bench/AGENTS.md
+++ b/packages/benchmarks/tau-bench/AGENTS.md
@@ -95,7 +95,7 @@ pytest packages/benchmarks/tau-bench/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/tau-bench/CLAUDE.md
+++ b/packages/benchmarks/tau-bench/CLAUDE.md
@@ -95,7 +95,7 @@ pytest packages/benchmarks/tau-bench/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/terminal-bench/AGENTS.md
+++ b/packages/benchmarks/terminal-bench/AGENTS.md
@@ -103,7 +103,7 @@ pytest tests/ --cov=elizaos_terminal_bench
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/terminal-bench/CLAUDE.md
+++ b/packages/benchmarks/terminal-bench/CLAUDE.md
@@ -103,7 +103,7 @@ pytest tests/ --cov=elizaos_terminal_bench
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/three-agent-dialogue/AGENTS.md
+++ b/packages/benchmarks/three-agent-dialogue/AGENTS.md
@@ -102,7 +102,7 @@ unless `GROQ_API_KEY` is set.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/three-agent-dialogue/CLAUDE.md
+++ b/packages/benchmarks/three-agent-dialogue/CLAUDE.md
@@ -102,7 +102,7 @@ unless `GROQ_API_KEY` is set.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/trust/AGENTS.md
+++ b/packages/benchmarks/trust/AGENTS.md
@@ -97,7 +97,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/trust/CLAUDE.md
+++ b/packages/benchmarks/trust/CLAUDE.md
@@ -97,7 +97,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/vending-bench/AGENTS.md
+++ b/packages/benchmarks/vending-bench/AGENTS.md
@@ -89,7 +89,7 @@ pytest elizaos_vending_bench/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/vending-bench/CLAUDE.md
+++ b/packages/benchmarks/vending-bench/CLAUDE.md
@@ -89,7 +89,7 @@ pytest elizaos_vending_bench/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/vision-language/AGENTS.md
+++ b/packages/benchmarks/vision-language/AGENTS.md
@@ -93,7 +93,7 @@ bun run test      # vitest run
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/vision-language/CLAUDE.md
+++ b/packages/benchmarks/vision-language/CLAUDE.md
@@ -93,7 +93,7 @@ bun run test      # vitest run
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/visualwebbench/AGENTS.md
+++ b/packages/benchmarks/visualwebbench/AGENTS.md
@@ -94,7 +94,7 @@ pytest visualwebbench/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/visualwebbench/CLAUDE.md
+++ b/packages/benchmarks/visualwebbench/CLAUDE.md
@@ -94,7 +94,7 @@ pytest visualwebbench/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/voice-emotion/AGENTS.md
+++ b/packages/benchmarks/voice-emotion/AGENTS.md
@@ -104,7 +104,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/voice-emotion/CLAUDE.md
+++ b/packages/benchmarks/voice-emotion/CLAUDE.md
@@ -104,7 +104,7 @@ pytest tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/voice-speaker-validation/AGENTS.md
+++ b/packages/benchmarks/voice-speaker-validation/AGENTS.md
@@ -102,7 +102,7 @@ python voice_profile_lifecycle.py          # write artifacts/voice-profile-lifec
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/voice-speaker-validation/CLAUDE.md
+++ b/packages/benchmarks/voice-speaker-validation/CLAUDE.md
@@ -102,7 +102,7 @@ python voice_profile_lifecycle.py          # write artifacts/voice-profile-lifec
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/voice/AGENTS.md
+++ b/packages/benchmarks/voice/AGENTS.md
@@ -115,7 +115,7 @@ count and exits 1 on any failure.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/voice/CLAUDE.md
+++ b/packages/benchmarks/voice/CLAUDE.md
@@ -115,7 +115,7 @@ count and exits 1 on any failure.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/voiceagentbench/AGENTS.md
+++ b/packages/benchmarks/voiceagentbench/AGENTS.md
@@ -90,7 +90,7 @@ PYTHONPATH=/path/to/eliza/packages/benchmarks/voiceagentbench:/path/to/eliza/pac
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/voiceagentbench/CLAUDE.md
+++ b/packages/benchmarks/voiceagentbench/CLAUDE.md
@@ -90,7 +90,7 @@ PYTHONPATH=/path/to/eliza/packages/benchmarks/voiceagentbench:/path/to/eliza/pac
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/voicebench-quality/AGENTS.md
+++ b/packages/benchmarks/voicebench-quality/AGENTS.md
@@ -96,7 +96,7 @@ pytest tests/ -x
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/voicebench-quality/CLAUDE.md
+++ b/packages/benchmarks/voicebench-quality/CLAUDE.md
@@ -96,7 +96,7 @@ pytest tests/ -x
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/voicebench/AGENTS.md
+++ b/packages/benchmarks/voicebench/AGENTS.md
@@ -96,7 +96,7 @@ inspecting the output JSON, then run the real profile against a fixture dataset.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/voicebench/CLAUDE.md
+++ b/packages/benchmarks/voicebench/CLAUDE.md
@@ -96,7 +96,7 @@ inspecting the output JSON, then run the real profile against a fixture dataset.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/webshop/AGENTS.md
+++ b/packages/benchmarks/webshop/AGENTS.md
@@ -100,7 +100,7 @@ absent, so `pytest` still passes cleanly in a fresh checkout.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/webshop/CLAUDE.md
+++ b/packages/benchmarks/webshop/CLAUDE.md
@@ -100,7 +100,7 @@ absent, so `pytest` still passes cleanly in a fresh checkout.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/woobench/AGENTS.md
+++ b/packages/benchmarks/woobench/AGENTS.md
@@ -99,7 +99,7 @@ pytest packages/benchmarks/woobench/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/benchmarks/woobench/CLAUDE.md
+++ b/packages/benchmarks/woobench/CLAUDE.md
@@ -99,7 +99,7 @@ pytest packages/benchmarks/woobench/tests/ -v
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/browser-extension/AGENTS.md
+++ b/packages/browser-extension/AGENTS.md
@@ -188,7 +188,7 @@ Edit `BROWSER_BRIDGE_HOST_ALLOWLIST` in `scripts/build.mjs`. The array is mirror
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/browser-extension/CLAUDE.md
+++ b/packages/browser-extension/CLAUDE.md
@@ -188,7 +188,7 @@ Edit `BROWSER_BRIDGE_HOST_ALLOWLIST` in `scripts/build.mjs`. The array is mirror
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/api/AGENTS.md
+++ b/packages/cloud/api/AGENTS.md
@@ -135,7 +135,7 @@ Add an endpoint:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/api/CLAUDE.md
+++ b/packages/cloud/api/CLAUDE.md
@@ -135,7 +135,7 @@ Add an endpoint:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/docs-redirect/AGENTS.md
+++ b/packages/cloud/docs-redirect/AGENTS.md
@@ -95,7 +95,7 @@ The worker is intentionally trivial. If redirect rules change:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/docs-redirect/CLAUDE.md
+++ b/packages/cloud/docs-redirect/CLAUDE.md
@@ -95,7 +95,7 @@ The worker is intentionally trivial. If redirect rules change:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/infra/AGENTS.md
+++ b/packages/cloud/infra/AGENTS.md
@@ -213,7 +213,7 @@ Local cluster service env vars (copy from `.env.*.example`):
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/infra/CLAUDE.md
+++ b/packages/cloud/infra/CLAUDE.md
@@ -213,7 +213,7 @@ Local cluster service env vars (copy from `.env.*.example`):
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/routing/AGENTS.md
+++ b/packages/cloud/routing/AGENTS.md
@@ -154,7 +154,7 @@ Use `resolveFeatureCloudRoute` instead of `resolveCloudRoute` when the caller wa
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/routing/CLAUDE.md
+++ b/packages/cloud/routing/CLAUDE.md
@@ -154,7 +154,7 @@ Use `resolveFeatureCloudRoute` instead of `resolveCloudRoute` when the caller wa
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/sdk/AGENTS.md
+++ b/packages/cloud/sdk/AGENTS.md
@@ -198,7 +198,7 @@ Implement the five methods on the interface in `src/cloud-setup-session/service-
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/sdk/CLAUDE.md
+++ b/packages/cloud/sdk/CLAUDE.md
@@ -198,7 +198,7 @@ Implement the five methods on the interface in `src/cloud-setup-session/service-
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/_common/AGENTS.md
+++ b/packages/cloud/services/_common/AGENTS.md
@@ -81,7 +81,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/_common/CLAUDE.md
+++ b/packages/cloud/services/_common/CLAUDE.md
@@ -81,7 +81,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/agent-server/AGENTS.md
+++ b/packages/cloud/services/agent-server/AGENTS.md
@@ -126,7 +126,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/agent-server/CLAUDE.md
+++ b/packages/cloud/services/agent-server/CLAUDE.md
@@ -126,7 +126,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/coding-remote-runner/AGENTS.md
+++ b/packages/cloud/services/coding-remote-runner/AGENTS.md
@@ -119,7 +119,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/coding-remote-runner/CLAUDE.md
+++ b/packages/cloud/services/coding-remote-runner/CLAUDE.md
@@ -119,7 +119,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/container-control-plane/AGENTS.md
+++ b/packages/cloud/services/container-control-plane/AGENTS.md
@@ -122,7 +122,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/container-control-plane/CLAUDE.md
+++ b/packages/cloud/services/container-control-plane/CLAUDE.md
@@ -122,7 +122,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/gateway-discord/AGENTS.md
+++ b/packages/cloud/services/gateway-discord/AGENTS.md
@@ -128,7 +128,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/gateway-discord/CLAUDE.md
+++ b/packages/cloud/services/gateway-discord/CLAUDE.md
@@ -128,7 +128,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/gateway-webhook/AGENTS.md
+++ b/packages/cloud/services/gateway-webhook/AGENTS.md
@@ -155,7 +155,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/gateway-webhook/CLAUDE.md
+++ b/packages/cloud/services/gateway-webhook/CLAUDE.md
@@ -155,7 +155,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/operator/AGENTS.md
+++ b/packages/cloud/services/operator/AGENTS.md
@@ -105,7 +105,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/services/operator/CLAUDE.md
+++ b/packages/cloud/services/operator/CLAUDE.md
@@ -105,7 +105,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/shared/AGENTS.md
+++ b/packages/cloud/shared/AGENTS.md
@@ -120,7 +120,7 @@ bun run --cwd packages/cloud/shared generate:email-templates
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/cloud/shared/CLAUDE.md
+++ b/packages/cloud/shared/CLAUDE.md
@@ -120,7 +120,7 @@ bun run --cwd packages/cloud/shared generate:email-templates
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/contracts/AGENTS.md
+++ b/packages/contracts/AGENTS.md
@@ -102,7 +102,7 @@ None. This package reads no env vars and has no config.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/contracts/CLAUDE.md
+++ b/packages/contracts/CLAUDE.md
@@ -102,7 +102,7 @@ None. This package reads no env vars and has no config.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -198,7 +198,7 @@ visible.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -198,7 +198,7 @@ visible.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/docs/AGENTS.md
+++ b/packages/docs/AGENTS.md
@@ -160,7 +160,7 @@ Top-level tabs as of current content:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/docs/CLAUDE.md
+++ b/packages/docs/CLAUDE.md
@@ -160,7 +160,7 @@ Top-level tabs as of current content:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/elizaos/AGENTS.md
+++ b/packages/elizaos/AGENTS.md
@@ -115,7 +115,7 @@ Generated projects record state in `.elizaos/template.json` (`ProjectTemplateMet
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/elizaos/CLAUDE.md
+++ b/packages/elizaos/CLAUDE.md
@@ -115,7 +115,7 @@ Generated projects record state in `.elizaos/template.json` (`ProjectTemplateMet
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/_plugin/AGENTS.md
+++ b/packages/examples/_plugin/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/_plugin/CLAUDE.md
+++ b/packages/examples/_plugin/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/a2a/AGENTS.md
+++ b/packages/examples/a2a/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/a2a/CLAUDE.md
+++ b/packages/examples/a2a/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/agent-console/AGENTS.md
+++ b/packages/examples/agent-console/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/agent-console/CLAUDE.md
+++ b/packages/examples/agent-console/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/app/AGENTS.md
+++ b/packages/examples/app/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/app/CLAUDE.md
+++ b/packages/examples/app/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/autonomous/AGENTS.md
+++ b/packages/examples/autonomous/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/autonomous/CLAUDE.md
+++ b/packages/examples/autonomous/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/aws/AGENTS.md
+++ b/packages/examples/aws/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/aws/CLAUDE.md
+++ b/packages/examples/aws/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/bluesky/AGENTS.md
+++ b/packages/examples/bluesky/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/bluesky/CLAUDE.md
+++ b/packages/examples/bluesky/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/browser-extension/AGENTS.md
+++ b/packages/examples/browser-extension/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/browser-extension/CLAUDE.md
+++ b/packages/examples/browser-extension/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/chat/AGENTS.md
+++ b/packages/examples/chat/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/chat/CLAUDE.md
+++ b/packages/examples/chat/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/cloudflare/AGENTS.md
+++ b/packages/examples/cloudflare/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/cloudflare/CLAUDE.md
+++ b/packages/examples/cloudflare/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/code/AGENTS.md
+++ b/packages/examples/code/AGENTS.md
@@ -57,7 +57,7 @@ The interactive TUI is built on `@elizaos/tui` (differential renderer, `Editor`,
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/code/CLAUDE.md
+++ b/packages/examples/code/CLAUDE.md
@@ -57,7 +57,7 @@ The interactive TUI is built on `@elizaos/tui` (differential renderer, `Editor`,
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/convex/AGENTS.md
+++ b/packages/examples/convex/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/convex/CLAUDE.md
+++ b/packages/examples/convex/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/discord/AGENTS.md
+++ b/packages/examples/discord/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/discord/CLAUDE.md
+++ b/packages/examples/discord/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/elizagotchi/AGENTS.md
+++ b/packages/examples/elizagotchi/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/elizagotchi/CLAUDE.md
+++ b/packages/examples/elizagotchi/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/farcaster-miniapp/AGENTS.md
+++ b/packages/examples/farcaster-miniapp/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/farcaster-miniapp/CLAUDE.md
+++ b/packages/examples/farcaster-miniapp/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/farcaster/AGENTS.md
+++ b/packages/examples/farcaster/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/farcaster/CLAUDE.md
+++ b/packages/examples/farcaster/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/form/AGENTS.md
+++ b/packages/examples/form/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/form/CLAUDE.md
+++ b/packages/examples/form/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/game-of-life/AGENTS.md
+++ b/packages/examples/game-of-life/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/game-of-life/CLAUDE.md
+++ b/packages/examples/game-of-life/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/gcp/AGENTS.md
+++ b/packages/examples/gcp/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/gcp/CLAUDE.md
+++ b/packages/examples/gcp/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/html/AGENTS.md
+++ b/packages/examples/html/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/html/CLAUDE.md
+++ b/packages/examples/html/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/lp-manager/AGENTS.md
+++ b/packages/examples/lp-manager/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/lp-manager/CLAUDE.md
+++ b/packages/examples/lp-manager/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/mcp/AGENTS.md
+++ b/packages/examples/mcp/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/mcp/CLAUDE.md
+++ b/packages/examples/mcp/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/moltbook/AGENTS.md
+++ b/packages/examples/moltbook/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/moltbook/CLAUDE.md
+++ b/packages/examples/moltbook/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/next/AGENTS.md
+++ b/packages/examples/next/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/next/CLAUDE.md
+++ b/packages/examples/next/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/plugin-echo/AGENTS.md
+++ b/packages/examples/plugin-echo/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/plugin-echo/CLAUDE.md
+++ b/packages/examples/plugin-echo/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/react/AGENTS.md
+++ b/packages/examples/react/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/react/CLAUDE.md
+++ b/packages/examples/react/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/rest-api/AGENTS.md
+++ b/packages/examples/rest-api/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/rest-api/CLAUDE.md
+++ b/packages/examples/rest-api/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/smartglasses/AGENTS.md
+++ b/packages/examples/smartglasses/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/smartglasses/CLAUDE.md
+++ b/packages/examples/smartglasses/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/supabase/AGENTS.md
+++ b/packages/examples/supabase/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/supabase/CLAUDE.md
+++ b/packages/examples/supabase/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/telegram/AGENTS.md
+++ b/packages/examples/telegram/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/telegram/CLAUDE.md
+++ b/packages/examples/telegram/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/text-adventure/AGENTS.md
+++ b/packages/examples/text-adventure/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/text-adventure/CLAUDE.md
+++ b/packages/examples/text-adventure/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/tic-tac-toe/AGENTS.md
+++ b/packages/examples/tic-tac-toe/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/tic-tac-toe/CLAUDE.md
+++ b/packages/examples/tic-tac-toe/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/trader/AGENTS.md
+++ b/packages/examples/trader/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/trader/CLAUDE.md
+++ b/packages/examples/trader/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/twitter-xai/AGENTS.md
+++ b/packages/examples/twitter-xai/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/twitter-xai/CLAUDE.md
+++ b/packages/examples/twitter-xai/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/vercel/AGENTS.md
+++ b/packages/examples/vercel/AGENTS.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/examples/vercel/CLAUDE.md
+++ b/packages/examples/vercel/CLAUDE.md
@@ -33,7 +33,7 @@ A first-party elizaOS runnable example. See [README.md](README.md) for what it d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/feed/AGENTS.md
+++ b/packages/feed/AGENTS.md
@@ -170,7 +170,7 @@ bun scripts/prompt-diff.ts \
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/feed/CLAUDE.md
+++ b/packages/feed/CLAUDE.md
@@ -170,7 +170,7 @@ bun scripts/prompt-diff.ts \
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/homepage/AGENTS.md
+++ b/packages/homepage/AGENTS.md
@@ -164,7 +164,7 @@ Use `elizacloudFetch` (public) or `elizacloudAuthFetch` (sends Bearer token) fro
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/homepage/CLAUDE.md
+++ b/packages/homepage/CLAUDE.md
@@ -164,7 +164,7 @@ Use `elizacloudFetch` (public) or `elizacloudAuthFetch` (sends Bearer token) fro
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/logger/AGENTS.md
+++ b/packages/logger/AGENTS.md
@@ -66,7 +66,7 @@ bun run --cwd packages/logger test
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/logger/CLAUDE.md
+++ b/packages/logger/CLAUDE.md
@@ -66,7 +66,7 @@ bun run --cwd packages/logger test
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/doctr-cpp/AGENTS.md
+++ b/packages/native/plugins/doctr-cpp/AGENTS.md
@@ -152,7 +152,7 @@ linking and error contracts.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/doctr-cpp/CLAUDE.md
+++ b/packages/native/plugins/doctr-cpp/CLAUDE.md
@@ -152,7 +152,7 @@ linking and error contracts.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/face-cpp/AGENTS.md
+++ b/packages/native/plugins/face-cpp/AGENTS.md
@@ -256,7 +256,7 @@ fixtures are available.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/face-cpp/CLAUDE.md
+++ b/packages/native/plugins/face-cpp/CLAUDE.md
@@ -256,7 +256,7 @@ fixtures are available.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/polarquant-cpu/AGENTS.md
+++ b/packages/native/plugins/polarquant-cpu/AGENTS.md
@@ -90,7 +90,7 @@ PolarQuant-V + TurboQuant-W variants) lives at
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/polarquant-cpu/CLAUDE.md
+++ b/packages/native/plugins/polarquant-cpu/CLAUDE.md
@@ -90,7 +90,7 @@ PolarQuant-V + TurboQuant-W variants) lives at
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/qjl-cpu/AGENTS.md
+++ b/packages/native/plugins/qjl-cpu/AGENTS.md
@@ -85,7 +85,7 @@ PolarQuant-V + TurboQuant-W variants) lives at
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/qjl-cpu/CLAUDE.md
+++ b/packages/native/plugins/qjl-cpu/CLAUDE.md
@@ -85,7 +85,7 @@ PolarQuant-V + TurboQuant-W variants) lives at
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/silero-vad-cpp/AGENTS.md
+++ b/packages/native/plugins/silero-vad-cpp/AGENTS.md
@@ -280,7 +280,7 @@ threshold.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/silero-vad-cpp/CLAUDE.md
+++ b/packages/native/plugins/silero-vad-cpp/CLAUDE.md
@@ -280,7 +280,7 @@ threshold.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/turboquant-cpu/AGENTS.md
+++ b/packages/native/plugins/turboquant-cpu/AGENTS.md
@@ -118,7 +118,7 @@ artifact paths, build commands, kernel-contract test references).
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/turboquant-cpu/CLAUDE.md
+++ b/packages/native/plugins/turboquant-cpu/CLAUDE.md
@@ -118,7 +118,7 @@ artifact paths, build commands, kernel-contract test references).
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/voice-classifier-cpp/AGENTS.md
+++ b/packages/native/plugins/voice-classifier-cpp/AGENTS.md
@@ -293,7 +293,7 @@ large GGUF/reference fixture bundles are absent.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/voice-classifier-cpp/CLAUDE.md
+++ b/packages/native/plugins/voice-classifier-cpp/CLAUDE.md
@@ -293,7 +293,7 @@ large GGUF/reference fixture bundles are absent.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/wakeword-cpp/AGENTS.md
+++ b/packages/native/plugins/wakeword-cpp/AGENTS.md
@@ -48,7 +48,7 @@ are not present.
   "hey eliza" scores ~1.0 while "hey jarvis" scores ~0.13 (i.e. it is the
   trained eliza-1 head, NOT the old `hey_jarvis_v0.1` placeholder).
   Reproduce with `test/wakeword_score_raw.c` — see
-  `.github/issue-evidence/9880-wake-word/`. The `hey-eliza-int8.onnx`
+  #9880. The `hey-eliza-int8.onnx`
   placeholder note is historical (pre-v0.3.0).
 
 ## Three-stage pipeline + GGUF conversion
@@ -252,7 +252,7 @@ packages/native/plugins/wakeword-cpp/
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/wakeword-cpp/CLAUDE.md
+++ b/packages/native/plugins/wakeword-cpp/CLAUDE.md
@@ -48,7 +48,7 @@ are not present.
   "hey eliza" scores ~1.0 while "hey jarvis" scores ~0.13 (i.e. it is the
   trained eliza-1 head, NOT the old `hey_jarvis_v0.1` placeholder).
   Reproduce with `test/wakeword_score_raw.c` — see
-  `.github/issue-evidence/9880-wake-word/`. The `hey-eliza-int8.onnx`
+  #9880. The `hey-eliza-int8.onnx`
   placeholder note is historical (pre-v0.3.0).
 
 ## Three-stage pipeline + GGUF conversion
@@ -252,7 +252,7 @@ packages/native/plugins/wakeword-cpp/
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/yolo-cpp/AGENTS.md
+++ b/packages/native/plugins/yolo-cpp/AGENTS.md
@@ -301,7 +301,7 @@ Still missing (Phase 3 work):
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/native/plugins/yolo-cpp/CLAUDE.md
+++ b/packages/native/plugins/yolo-cpp/CLAUDE.md
@@ -301,7 +301,7 @@ Still missing (Phase 3 work):
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/os/AGENTS.md
+++ b/packages/os/AGENTS.md
@@ -271,7 +271,7 @@ Place it under `android/vendor/eliza/` following AOSP vendor tree conventions. B
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/os/CLAUDE.md
+++ b/packages/os/CLAUDE.md
@@ -271,7 +271,7 @@ Place it under `android/vendor/eliza/` following AOSP vendor tree conventions. B
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/os/homepage/AGENTS.md
+++ b/packages/os/homepage/AGENTS.md
@@ -148,7 +148,7 @@ Language preference is stored in `localStorage` under the key `os.lang`. The `?l
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/os/homepage/CLAUDE.md
+++ b/packages/os/homepage/CLAUDE.md
@@ -148,7 +148,7 @@ Language preference is stored in `localStorage` under the key `os.lang`. The `?l
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/plugin-remote-manifest/AGENTS.md
+++ b/packages/plugin-remote-manifest/AGENTS.md
@@ -197,7 +197,7 @@ and worker bootstrap in `packages/app-core/platforms/electrobun` will need corre
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/plugin-remote-manifest/CLAUDE.md
+++ b/packages/plugin-remote-manifest/CLAUDE.md
@@ -197,7 +197,7 @@ and worker bootstrap in `packages/app-core/platforms/electrobun` will need corre
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/plugin-sub-agent-claude-code/AGENTS.md
+++ b/packages/plugin-sub-agent-claude-code/AGENTS.md
@@ -146,7 +146,7 @@ Add the absolute path to `BINARY_DIR_ALLOWLIST` in `src/sandbox.ts`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/plugin-sub-agent-claude-code/CLAUDE.md
+++ b/packages/plugin-sub-agent-claude-code/CLAUDE.md
@@ -146,7 +146,7 @@ Add the absolute path to `BINARY_DIR_ALLOWLIST` in `src/sandbox.ts`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/plugin-worker-runtime/AGENTS.md
+++ b/packages/plugin-worker-runtime/AGENTS.md
@@ -199,7 +199,7 @@ Implement `WorkerChannel` in `src/envelope.ts` (or a separate file), export it, 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/plugin-worker-runtime/CLAUDE.md
+++ b/packages/plugin-worker-runtime/CLAUDE.md
@@ -199,7 +199,7 @@ Implement `WorkerChannel` in `src/envelope.ts` (or a separate file), export it, 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/prompts/AGENTS.md
+++ b/packages/prompts/AGENTS.md
@@ -113,7 +113,7 @@ Regenerate the plugin action spec after adding or renaming a plugin `Action`:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/prompts/CLAUDE.md
+++ b/packages/prompts/CLAUDE.md
@@ -113,7 +113,7 @@ Regenerate the plugin action spec after adding or renaming a plugin `Action`:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/registry/AGENTS.md
+++ b/packages/registry/AGENTS.md
@@ -134,7 +134,7 @@ bun run --cwd packages/registry typecheck
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/registry/CLAUDE.md
+++ b/packages/registry/CLAUDE.md
@@ -134,7 +134,7 @@ bun run --cwd packages/registry typecheck
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/research/chip/AGENTS.md
+++ b/packages/research/chip/AGENTS.md
@@ -124,7 +124,7 @@ treat that as a bug to fix.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/research/chip/CLAUDE.md
+++ b/packages/research/chip/CLAUDE.md
@@ -124,7 +124,7 @@ treat that as a bug to fix.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/research/robot/AGENTS.md
+++ b/packages/research/robot/AGENTS.md
@@ -208,7 +208,7 @@ See the root `AGENTS.md` for repo-wide architecture commandments, logger-only ru
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/research/robot/CLAUDE.md
+++ b/packages/research/robot/CLAUDE.md
@@ -208,7 +208,7 @@ See the root `AGENTS.md` for repo-wide architecture commandments, logger-only ru
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/scenario-runner/AGENTS.md
+++ b/packages/scenario-runner/AGENTS.md
@@ -236,7 +236,7 @@ and update the owning pack catalog.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/scenario-runner/CLAUDE.md
+++ b/packages/scenario-runner/CLAUDE.md
@@ -236,7 +236,7 @@ and update the owning pack catalog.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/security/AGENTS.md
+++ b/packages/security/AGENTS.md
@@ -208,7 +208,7 @@ bun run --cwd packages/security clean        # rm -rf dist
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/security/CLAUDE.md
+++ b/packages/security/CLAUDE.md
@@ -208,7 +208,7 @@ bun run --cwd packages/security clean        # rm -rf dist
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/security/soc2-verify/AGENTS.md
+++ b/packages/security/soc2-verify/AGENTS.md
@@ -152,7 +152,7 @@ Readiness score = `pass / (pass + fail)`, excludes `warn` and `skip`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/security/soc2-verify/CLAUDE.md
+++ b/packages/security/soc2-verify/CLAUDE.md
@@ -152,7 +152,7 @@ Readiness score = `pass / (pass + fail)`, excludes `warn` and `skip`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -240,7 +240,7 @@ bun run --cwd packages/shared sync           # copy assets to consumer public/ d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -240,7 +240,7 @@ bun run --cwd packages/shared sync           # copy assets to consumer public/ d
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/skills/AGENTS.md
+++ b/packages/skills/AGENTS.md
@@ -158,7 +158,7 @@ bun run --cwd packages/skills clean       # rm -rf dist
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/skills/CLAUDE.md
+++ b/packages/skills/CLAUDE.md
@@ -158,7 +158,7 @@ bun run --cwd packages/skills clean       # rm -rf dist
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/test/AGENTS.md
+++ b/packages/test/AGENTS.md
@@ -135,7 +135,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/test/CLAUDE.md
+++ b/packages/test/CLAUDE.md
@@ -135,7 +135,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/test/cloud-e2e/AGENTS.md
+++ b/packages/test/cloud-e2e/AGENTS.md
@@ -126,7 +126,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/test/cloud-e2e/CLAUDE.md
+++ b/packages/test/cloud-e2e/CLAUDE.md
@@ -126,7 +126,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/test/cloud-mocks/AGENTS.md
+++ b/packages/test/cloud-mocks/AGENTS.md
@@ -108,7 +108,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/test/cloud-mocks/CLAUDE.md
+++ b/packages/test/cloud-mocks/CLAUDE.md
@@ -108,7 +108,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/training/AGENTS.md
+++ b/packages/training/AGENTS.md
@@ -365,7 +365,7 @@ shipped bundle.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/training/CLAUDE.md
+++ b/packages/training/CLAUDE.md
@@ -365,7 +365,7 @@ shipped bundle.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/tui/AGENTS.md
+++ b/packages/tui/AGENTS.md
@@ -175,7 +175,7 @@ Use `setEditorKeybindings(manager)` at startup to remap `EditorAction` values to
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/tui/CLAUDE.md
+++ b/packages/tui/CLAUDE.md
@@ -175,7 +175,7 @@ Use `setEditorKeybindings(manager)` at startup to remap `EditorAction` values to
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -291,7 +291,7 @@ This package mostly reads config injected by the host, not raw env vars:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -291,7 +291,7 @@ This package mostly reads config injected by the host, not raw env vars:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/vault/AGENTS.md
+++ b/packages/vault/AGENTS.md
@@ -193,7 +193,7 @@ await test.dispose(); // removes temp dir
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/packages/vault/CLAUDE.md
+++ b/packages/vault/CLAUDE.md
@@ -193,7 +193,7 @@ await test.dispose(); // removes temp dir
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/app-model-tester/AGENTS.md
+++ b/plugins/app-model-tester/AGENTS.md
@@ -134,7 +134,7 @@ No plugin-specific env vars are read at load time. Model provider credentials (A
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/app-model-tester/CLAUDE.md
+++ b/plugins/app-model-tester/CLAUDE.md
@@ -134,7 +134,7 @@ No plugin-specific env vars are read at load time. Model provider credentials (A
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -387,7 +387,7 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -387,7 +387,7 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-agent-skills/AGENTS.md
+++ b/plugins/plugin-agent-skills/AGENTS.md
@@ -200,7 +200,7 @@ See root `AGENTS.md` for repo-wide architecture rules, logger conventions, and g
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-agent-skills/CLAUDE.md
+++ b/plugins/plugin-agent-skills/CLAUDE.md
@@ -200,7 +200,7 @@ See root `AGENTS.md` for repo-wide architecture rules, logger conventions, and g
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-anthropic-proxy/AGENTS.md
+++ b/plugins/plugin-anthropic-proxy/AGENTS.md
@@ -149,7 +149,7 @@ Drop a `config.json` (shape: `config.json.example`) next to the agent root, or p
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-anthropic-proxy/CLAUDE.md
+++ b/plugins/plugin-anthropic-proxy/CLAUDE.md
@@ -149,7 +149,7 @@ Drop a `config.json` (shape: `config.json.example`) next to the agent root, or p
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-anthropic/AGENTS.md
+++ b/plugins/plugin-anthropic/AGENTS.md
@@ -162,7 +162,7 @@ Follow the pattern in `utils/config.ts`: `getRawSetting(runtime, "ANTHROPIC_X_MO
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-anthropic/CLAUDE.md
+++ b/plugins/plugin-anthropic/CLAUDE.md
@@ -162,7 +162,7 @@ Follow the pattern in `utils/config.ts`: `getRawSetting(runtime, "ANTHROPIC_X_MO
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-aosp-local-inference/AGENTS.md
+++ b/plugins/plugin-aosp-local-inference/AGENTS.md
@@ -151,7 +151,7 @@ All env vars are read at call time (no module-load side effects).
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-aosp-local-inference/CLAUDE.md
+++ b/plugins/plugin-aosp-local-inference/CLAUDE.md
@@ -151,7 +151,7 @@ All env vars are read at call time (no module-load side effects).
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-app-control/AGENTS.md
+++ b/plugins/plugin-app-control/AGENTS.md
@@ -214,7 +214,7 @@ Follow the same pattern in `src/actions/views.ts` and create a `src/actions/view
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-app-control/CLAUDE.md
+++ b/plugins/plugin-app-control/CLAUDE.md
@@ -214,7 +214,7 @@ Follow the same pattern in `src/actions/views.ts` and create a `src/actions/view
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-app-manager/AGENTS.md
+++ b/plugins/plugin-app-manager/AGENTS.md
@@ -152,7 +152,7 @@ The state-dir path used by `readAppRunStore` / `writeAppRunStore` comes from `@e
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-app-manager/CLAUDE.md
+++ b/plugins/plugin-app-manager/CLAUDE.md
@@ -152,7 +152,7 @@ The state-dir path used by `readAppRunStore` / `writeAppRunStore` comes from `@e
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-background-runner/AGENTS.md
+++ b/plugins/plugin-background-runner/AGENTS.md
@@ -118,7 +118,7 @@ This plugin reads no environment variables and has no `agentConfig.pluginParamet
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-background-runner/CLAUDE.md
+++ b/plugins/plugin-background-runner/CLAUDE.md
@@ -118,7 +118,7 @@ This plugin reads no environment variables and has no `agentConfig.pluginParamet
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-benchmarks/AGENTS.md
+++ b/plugins/plugin-benchmarks/AGENTS.md
@@ -116,7 +116,7 @@ None. This plugin reads no environment variables and has no runtime configuratio
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-benchmarks/CLAUDE.md
+++ b/plugins/plugin-benchmarks/CLAUDE.md
@@ -116,7 +116,7 @@ None. This plugin reads no environment variables and has no runtime configuratio
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-blocker/AGENTS.md
+++ b/plugins/plugin-blocker/AGENTS.md
@@ -135,7 +135,7 @@ the lifeops implementations they replace.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-blocker/CLAUDE.md
+++ b/plugins/plugin-blocker/CLAUDE.md
@@ -135,7 +135,7 @@ the lifeops implementations they replace.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-bluebubbles/AGENTS.md
+++ b/plugins/plugin-bluebubbles/AGENTS.md
@@ -174,7 +174,7 @@ blocks under `character.settings.bluebubbles.accounts.<id>`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-bluebubbles/CLAUDE.md
+++ b/plugins/plugin-bluebubbles/CLAUDE.md
@@ -174,7 +174,7 @@ blocks under `character.settings.bluebubbles.accounts.<id>`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-bluesky/AGENTS.md
+++ b/plugins/plugin-bluesky/AGENTS.md
@@ -161,7 +161,7 @@ runtime.on("bluesky.mention_received", (payload: BlueSkyNotificationEventPayload
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-bluesky/CLAUDE.md
+++ b/plugins/plugin-bluesky/CLAUDE.md
@@ -161,7 +161,7 @@ runtime.on("bluesky.mention_received", (payload: BlueSkyNotificationEventPayload
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-browser/AGENTS.md
+++ b/plugins/plugin-browser/AGENTS.md
@@ -209,7 +209,7 @@ Plugin activation: `config.features.browser` must be truthy (object with `enable
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-browser/CLAUDE.md
+++ b/plugins/plugin-browser/CLAUDE.md
@@ -209,7 +209,7 @@ Plugin activation: `config.features.browser` must be truthy (object with `enable
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-calendar/AGENTS.md
+++ b/plugins/plugin-calendar/AGENTS.md
@@ -87,7 +87,7 @@ bun run --cwd plugins/plugin-calendar typecheck
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-calendar/CLAUDE.md
+++ b/plugins/plugin-calendar/CLAUDE.md
@@ -87,7 +87,7 @@ bun run --cwd plugins/plugin-calendar typecheck
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-calendly/AGENTS.md
+++ b/plugins/plugin-calendly/AGENTS.md
@@ -142,7 +142,7 @@ The `autoEnable.envKeys` check uses `CALENDLY_ACCESS_TOKEN`, `CALENDLY_ACCOUNTS`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-calendly/CLAUDE.md
+++ b/plugins/plugin-calendly/CLAUDE.md
@@ -142,7 +142,7 @@ The `autoEnable.envKeys` check uses `CALENDLY_ACCESS_TOKEN`, `CALENDLY_ACCOUNTS`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-capacitor-bridge/AGENTS.md
+++ b/plugins/plugin-capacitor-bridge/AGENTS.md
@@ -203,7 +203,7 @@ If a new `node:fs` function needs sandboxing, add it to the appropriate array (`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-capacitor-bridge/CLAUDE.md
+++ b/plugins/plugin-capacitor-bridge/CLAUDE.md
@@ -203,7 +203,7 @@ If a new `node:fs` function needs sandboxing, add it to the appropriate array (`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-cli-inference/AGENTS.md
+++ b/plugins/plugin-cli-inference/AGENTS.md
@@ -213,7 +213,7 @@ bun run --cwd plugins/plugin-cli-inference build
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-cli-inference/CLAUDE.md
+++ b/plugins/plugin-cli-inference/CLAUDE.md
@@ -213,7 +213,7 @@ bun run --cwd plugins/plugin-cli-inference build
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-cli/AGENTS.md
+++ b/plugins/plugin-cli/AGENTS.md
@@ -192,7 +192,7 @@ await withProgress(deps, "Doing work", async () => {
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-cli/CLAUDE.md
+++ b/plugins/plugin-cli/CLAUDE.md
@@ -192,7 +192,7 @@ await withProgress(deps, "Doing work", async () => {
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-cloud-apps/AGENTS.md
+++ b/plugins/plugin-cloud-apps/AGENTS.md
@@ -156,4 +156,4 @@ domain artifacts the change produced (app rows, deploy status, credit/earnings
 ledger rows, domain records), and — for anything user-exercisable — before/after
 UI proof. "Tests pass" and "CI green" are not proof. No TODOs, stubs, or
 "follow-ups"; clear blockers by the hard path. Artifacts →
-`.github/issue-evidence/<issue#>-<slug>.<ext>`, or mark a row `N/A - <reason>`.
+attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`), or mark a row `N/A - <reason>`.

--- a/plugins/plugin-cloud-apps/CLAUDE.md
+++ b/plugins/plugin-cloud-apps/CLAUDE.md
@@ -156,4 +156,4 @@ domain artifacts the change produced (app rows, deploy status, credit/earnings
 ledger rows, domain records), and — for anything user-exercisable — before/after
 UI proof. "Tests pass" and "CI green" are not proof. No TODOs, stubs, or
 "follow-ups"; clear blockers by the hard path. Artifacts →
-`.github/issue-evidence/<issue#>-<slug>.<ext>`, or mark a row `N/A - <reason>`.
+attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`), or mark a row `N/A - <reason>`.

--- a/plugins/plugin-codex-cli/AGENTS.md
+++ b/plugins/plugin-codex-cli/AGENTS.md
@@ -130,7 +130,7 @@ No auto-enable env var trigger exists. Auto-enable logic lives in `auto-enable.t
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-codex-cli/CLAUDE.md
+++ b/plugins/plugin-codex-cli/CLAUDE.md
@@ -130,7 +130,7 @@ No auto-enable env var trigger exists. Auto-enable logic lives in `auto-enable.t
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-coding-tools/AGENTS.md
+++ b/plugins/plugin-coding-tools/AGENTS.md
@@ -178,7 +178,7 @@ Runtime gating env vars (read by `auto-enable.ts` and `index.ts`):
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-coding-tools/CLAUDE.md
+++ b/plugins/plugin-coding-tools/CLAUDE.md
@@ -178,7 +178,7 @@ Runtime gating env vars (read by `auto-enable.ts` and `index.ts`):
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-commands/AGENTS.md
+++ b/plugins/plugin-commands/AGENTS.md
@@ -166,7 +166,7 @@ registerCommand({
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-commands/CLAUDE.md
+++ b/plugins/plugin-commands/CLAUDE.md
@@ -166,7 +166,7 @@ registerCommand({
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-computeruse/AGENTS.md
+++ b/plugins/plugin-computeruse/AGENTS.md
@@ -289,7 +289,7 @@ Call `registerSetOfMarksProvider(provider)` (same module, `src/mobile/ocr-provid
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-computeruse/CLAUDE.md
+++ b/plugins/plugin-computeruse/CLAUDE.md
@@ -289,7 +289,7 @@ Call `registerSetOfMarksProvider(provider)` (same module, `src/mobile/ocr-provid
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-contacts/AGENTS.md
+++ b/plugins/plugin-contacts/AGENTS.md
@@ -124,7 +124,7 @@ The provider limit is a hardcoded constant `CONTACTS_PROVIDER_LIMIT = 50` in `sr
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-contacts/CLAUDE.md
+++ b/plugins/plugin-contacts/CLAUDE.md
@@ -124,7 +124,7 @@ The provider limit is a hardcoded constant `CONTACTS_PROVIDER_LIMIT = 50` in `sr
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-discord-local/AGENTS.md
+++ b/plugins/plugin-discord-local/AGENTS.md
@@ -168,7 +168,7 @@ Same pattern: define a `Provider`, add to `discordLocalPlugin.providers = [...]`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-discord-local/CLAUDE.md
+++ b/plugins/plugin-discord-local/CLAUDE.md
@@ -168,7 +168,7 @@ Same pattern: define a `Provider`, add to `discordLocalPlugin.providers = [...]`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-discord/AGENTS.md
+++ b/plugins/plugin-discord/AGENTS.md
@@ -191,7 +191,7 @@ All settings can also be provided in the character file under `settings.discord`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-discord/CLAUDE.md
+++ b/plugins/plugin-discord/CLAUDE.md
@@ -191,7 +191,7 @@ All settings can also be provided in the character file under `settings.discord`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-documents/AGENTS.md
+++ b/plugins/plugin-documents/AGENTS.md
@@ -139,7 +139,7 @@ All scope/permission decisions live in `src/routes.ts` (`canReadDocumentMemory`,
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-documents/CLAUDE.md
+++ b/plugins/plugin-documents/CLAUDE.md
@@ -139,7 +139,7 @@ All scope/permission decisions live in `src/routes.ts` (`canReadDocumentMemory`,
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-edge-tts/AGENTS.md
+++ b/plugins/plugin-edge-tts/AGENTS.md
@@ -130,7 +130,7 @@ This plugin has a single responsibility (TTS model handler). The typical extensi
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-edge-tts/CLAUDE.md
+++ b/plugins/plugin-edge-tts/CLAUDE.md
@@ -130,7 +130,7 @@ This plugin has a single responsibility (TTS model handler). The typical extensi
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-elevenlabs/AGENTS.md
+++ b/plugins/plugin-elevenlabs/AGENTS.md
@@ -123,7 +123,7 @@ To add an action, provider, or service (not currently present), add an `actions`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-elevenlabs/CLAUDE.md
+++ b/plugins/plugin-elevenlabs/CLAUDE.md
@@ -123,7 +123,7 @@ To add an action, provider, or service (not currently present), add an `actions`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-elizacloud/AGENTS.md
+++ b/plugins/plugin-elizacloud/AGENTS.md
@@ -328,7 +328,7 @@ All settings are optional except `ELIZAOS_CLOUD_API_KEY` (required for any authe
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-elizacloud/CLAUDE.md
+++ b/plugins/plugin-elizacloud/CLAUDE.md
@@ -328,7 +328,7 @@ All settings are optional except `ELIZAOS_CLOUD_API_KEY` (required for any authe
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-embeddings/AGENTS.md
+++ b/plugins/plugin-embeddings/AGENTS.md
@@ -144,7 +144,7 @@ No central list edit is needed. The plugin lives under the repo `plugins/*` work
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-embeddings/CLAUDE.md
+++ b/plugins/plugin-embeddings/CLAUDE.md
@@ -144,7 +144,7 @@ No central list edit is needed. The plugin lives under the repo `plugins/*` work
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-facewear/AGENTS.md
+++ b/plugins/plugin-facewear/AGENTS.md
@@ -221,7 +221,7 @@ Legacy aliases `SMARTGLASSES_TRANSPORT`, `SMARTGLASSES_SCAN_TIMEOUT_MS`, `SMARTG
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-facewear/CLAUDE.md
+++ b/plugins/plugin-facewear/CLAUDE.md
@@ -221,7 +221,7 @@ Legacy aliases `SMARTGLASSES_TRANSPORT`, `SMARTGLASSES_SCAN_TIMEOUT_MS`, `SMARTG
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-farcaster/AGENTS.md
+++ b/plugins/plugin-farcaster/AGENTS.md
@@ -163,7 +163,7 @@ Read via `validateFarcasterConfig()` in `utils/config.ts` against `FarcasterConf
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-farcaster/CLAUDE.md
+++ b/plugins/plugin-farcaster/CLAUDE.md
@@ -163,7 +163,7 @@ Read via `validateFarcasterConfig()` in `utils/config.ts` against `FarcasterConf
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-feed/AGENTS.md
+++ b/plugins/plugin-feed/AGENTS.md
@@ -149,7 +149,7 @@ Session tokens (`FEED_AGENT_SESSION_TOKEN`, `FEED_AGENT_SESSION_EXPIRES_AT`) are
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-feed/CLAUDE.md
+++ b/plugins/plugin-feed/CLAUDE.md
@@ -149,7 +149,7 @@ Session tokens (`FEED_AGENT_SESSION_TOKEN`, `FEED_AGENT_SESSION_EXPIRES_AT`) are
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-feishu/AGENTS.md
+++ b/plugins/plugin-feishu/AGENTS.md
@@ -149,7 +149,7 @@ Multi-account configuration is read from `character.settings.feishu` (see `src/a
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-feishu/CLAUDE.md
+++ b/plugins/plugin-feishu/CLAUDE.md
@@ -149,7 +149,7 @@ Multi-account configuration is read from `character.settings.feishu` (see `src/a
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-finances/AGENTS.md
+++ b/plugins/plugin-finances/AGENTS.md
@@ -205,7 +205,7 @@ bun run --cwd plugins/plugin-finances clean        # rm -rf dist
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-finances/CLAUDE.md
+++ b/plugins/plugin-finances/CLAUDE.md
@@ -205,7 +205,7 @@ bun run --cwd plugins/plugin-finances clean        # rm -rf dist
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-form/AGENTS.md
+++ b/plugins/plugin-form/AGENTS.md
@@ -145,7 +145,7 @@ await formService.startSession('onboard', entityId, roomId, { context: { tier: '
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-form/CLAUDE.md
+++ b/plugins/plugin-form/CLAUDE.md
@@ -145,7 +145,7 @@ await formService.startSession('onboard', entityId, roomId, { context: { tier: '
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-github/AGENTS.md
+++ b/plugins/plugin-github/AGENTS.md
@@ -155,7 +155,7 @@ Add an entry to `githubRoutes` in `src/index.ts` and a handler in `src/routes/gi
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-github/CLAUDE.md
+++ b/plugins/plugin-github/CLAUDE.md
@@ -155,7 +155,7 @@ Add an entry to `githubRoutes` in `src/index.ts` and a handler in `src/routes/gi
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-gitpathologist/AGENTS.md
+++ b/plugins/plugin-gitpathologist/AGENTS.md
@@ -138,7 +138,7 @@ The action reads `ELIZA_WORKSPACE_DIR` to resolve the repo root when running ins
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-gitpathologist/CLAUDE.md
+++ b/plugins/plugin-gitpathologist/CLAUDE.md
@@ -138,7 +138,7 @@ The action reads `ELIZA_WORKSPACE_DIR` to resolve the repo root when running ins
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-goals/AGENTS.md
+++ b/plugins/plugin-goals/AGENTS.md
@@ -205,7 +205,7 @@ ownership changes.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-goals/CLAUDE.md
+++ b/plugins/plugin-goals/CLAUDE.md
@@ -205,7 +205,7 @@ ownership changes.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-google-chat/AGENTS.md
+++ b/plugins/plugin-google-chat/AGENTS.md
@@ -144,7 +144,7 @@ Character-level config (`character.settings.googleChat`) accepts all fields in `
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-google-chat/CLAUDE.md
+++ b/plugins/plugin-google-chat/CLAUDE.md
@@ -144,7 +144,7 @@ Character-level config (`character.settings.googleChat`) accepts all fields in `
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-google-genai/AGENTS.md
+++ b/plugins/plugin-google-genai/AGENTS.md
@@ -133,7 +133,7 @@ Append a `TestCase` object to the `pluginTests[0].tests` array in `index.ts`. Te
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-google-genai/CLAUDE.md
+++ b/plugins/plugin-google-genai/CLAUDE.md
@@ -133,7 +133,7 @@ Append a `TestCase` object to the `pluginTests[0].tests` array in `index.ts`. Te
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-google/AGENTS.md
+++ b/plugins/plugin-google/AGENTS.md
@@ -80,7 +80,7 @@ transcript spans, generated summary/key-point/action-item notes, warnings, and
 missing-artifact classifications for no transcript, delayed transcript, missing
 recording, revoked access, permission denied, meeting not found,
 organizer-only artifacts, and expired media URLs. Live sandbox evidence still
-requires real Google account access and belongs in `.github/issue-evidence/`.
+requires real Google account access and attaches inline in the PR.
 
 ## Commands
 
@@ -173,7 +173,7 @@ See the root `AGENTS.md` for repo-wide architecture rules, logger conventions, a
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-google/CLAUDE.md
+++ b/plugins/plugin-google/CLAUDE.md
@@ -80,7 +80,7 @@ transcript spans, generated summary/key-point/action-item notes, warnings, and
 missing-artifact classifications for no transcript, delayed transcript, missing
 recording, revoked access, permission denied, meeting not found,
 organizer-only artifacts, and expired media URLs. Live sandbox evidence still
-requires real Google account access and belongs in `.github/issue-evidence/`.
+requires real Google account access and attaches inline in the PR.
 
 ## Commands
 
@@ -173,7 +173,7 @@ See the root `AGENTS.md` for repo-wide architecture rules, logger conventions, a
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-groq/AGENTS.md
+++ b/plugins/plugin-groq/AGENTS.md
@@ -129,7 +129,7 @@ All vars are read via `runtime.getSetting(...)` at call time (not cached at init
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-groq/CLAUDE.md
+++ b/plugins/plugin-groq/CLAUDE.md
@@ -129,7 +129,7 @@ All vars are read via `runtime.getSetting(...)` at call time (not cached at init
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-health/AGENTS.md
+++ b/plugins/plugin-health/AGENTS.md
@@ -211,7 +211,7 @@ Create `src/default-packs/<name>.ts` implementing `DefaultPack`, add it to `HEAL
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-health/CLAUDE.md
+++ b/plugins/plugin-health/CLAUDE.md
@@ -211,7 +211,7 @@ Create `src/default-packs/<name>.ts` implementing `DefaultPack`, add it to `HEAL
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-hyperliquid/AGENTS.md
+++ b/plugins/plugin-hyperliquid/AGENTS.md
@@ -160,7 +160,7 @@ The action (`PERPETUAL_MARKET`) calls the agent's local API via `resolveDesktopA
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-hyperliquid/CLAUDE.md
+++ b/plugins/plugin-hyperliquid/CLAUDE.md
@@ -160,7 +160,7 @@ The action (`PERPETUAL_MARKET`) calls the agent's local API via `resolveDesktopA
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-imessage/AGENTS.md
+++ b/plugins/plugin-imessage/AGENTS.md
@@ -176,7 +176,7 @@ Config block in character settings:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-imessage/CLAUDE.md
+++ b/plugins/plugin-imessage/CLAUDE.md
@@ -176,7 +176,7 @@ Config block in character settings:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-inbox/AGENTS.md
+++ b/plugins/plugin-inbox/AGENTS.md
@@ -151,7 +151,7 @@ None. Channel credentials are read from each provider plugin (`plugin-discord`, 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-inbox/CLAUDE.md
+++ b/plugins/plugin-inbox/CLAUDE.md
@@ -151,7 +151,7 @@ None. Channel credentials are read from each provider plugin (`plugin-discord`, 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-inmemorydb/AGENTS.md
+++ b/plugins/plugin-inmemorydb/AGENTS.md
@@ -107,7 +107,7 @@ To replace the vector index: implement `IVectorStorage` (in `types.ts`) and pass
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-inmemorydb/CLAUDE.md
+++ b/plugins/plugin-inmemorydb/CLAUDE.md
@@ -107,7 +107,7 @@ To replace the vector index: implement `IVectorStorage` (in `types.ts`) and pass
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-instagram/AGENTS.md
+++ b/plugins/plugin-instagram/AGENTS.md
@@ -170,7 +170,7 @@ pattern).
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-instagram/CLAUDE.md
+++ b/plugins/plugin-instagram/CLAUDE.md
@@ -170,7 +170,7 @@ pattern).
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-line/AGENTS.md
+++ b/plugins/plugin-line/AGENTS.md
@@ -142,7 +142,7 @@ Multi-account config can also be provided via `character.settings.line` (see `Li
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-line/CLAUDE.md
+++ b/plugins/plugin-line/CLAUDE.md
@@ -142,7 +142,7 @@ Multi-account config can also be provided via `character.settings.line` (see `Li
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-linear/AGENTS.md
+++ b/plugins/plugin-linear/AGENTS.md
@@ -187,7 +187,7 @@ Character-file override: `character.settings.linear.accounts` (array or object) 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-linear/CLAUDE.md
+++ b/plugins/plugin-linear/CLAUDE.md
@@ -187,7 +187,7 @@ Character-file override: `character.settings.linear.accounts` (array or object) 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-lmstudio/AGENTS.md
+++ b/plugins/plugin-lmstudio/AGENTS.md
@@ -137,7 +137,7 @@ All vars are optional. Resolution order: `runtime.getSetting(key)` → `process.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-lmstudio/CLAUDE.md
+++ b/plugins/plugin-lmstudio/CLAUDE.md
@@ -137,7 +137,7 @@ All vars are optional. Resolution order: `runtime.getSetting(key)` → `process.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-local-inference/AGENTS.md
+++ b/plugins/plugin-local-inference/AGENTS.md
@@ -238,7 +238,7 @@ Call `arbiter.registerCapability({ capability, residentRole, load, unload, run }
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-local-inference/CLAUDE.md
+++ b/plugins/plugin-local-inference/CLAUDE.md
@@ -238,7 +238,7 @@ Call `arbiter.registerCapability({ capability, residentRole, load, unload, run }
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-local-storage/AGENTS.md
+++ b/plugins/plugin-local-storage/AGENTS.md
@@ -117,7 +117,7 @@ bun run --cwd plugins/plugin-local-storage clean        # rm dist/ + turbo cache
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-local-storage/CLAUDE.md
+++ b/plugins/plugin-local-storage/CLAUDE.md
@@ -117,7 +117,7 @@ bun run --cwd plugins/plugin-local-storage clean        # rm dist/ + turbo cache
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-localdb/AGENTS.md
+++ b/plugins/plugin-localdb/AGENTS.md
@@ -109,7 +109,7 @@ To add a new collection: add a key to `COLLECTIONS` in `@elizaos/plugin-inmemory
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-localdb/CLAUDE.md
+++ b/plugins/plugin-localdb/CLAUDE.md
@@ -109,7 +109,7 @@ To add a new collection: add a key to `COLLECTIONS` in `@elizaos/plugin-inmemory
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-matrix/AGENTS.md
+++ b/plugins/plugin-matrix/AGENTS.md
@@ -152,7 +152,7 @@ Supply `MATRIX_ACCOUNTS='[{"accountId":"work","homeserver":"...","userId":"...",
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-matrix/CLAUDE.md
+++ b/plugins/plugin-matrix/CLAUDE.md
@@ -152,7 +152,7 @@ Supply `MATRIX_ACCOUNTS='[{"accountId":"work","homeserver":"...","userId":"...",
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-mcp/AGENTS.md
+++ b/plugins/plugin-mcp/AGENTS.md
@@ -161,7 +161,7 @@ Add a branch in `src/routes-mcp.ts` `handleMcpRoutes`. The host server passes a 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-mcp/CLAUDE.md
+++ b/plugins/plugin-mcp/CLAUDE.md
@@ -161,7 +161,7 @@ Add a branch in `src/routes-mcp.ts` `handleMcpRoutes`. The host server passes a 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-meetings/AGENTS.md
+++ b/plugins/plugin-meetings/AGENTS.md
@@ -191,7 +191,7 @@ bun run --cwd plugins/plugin-meetings typecheck   # tsgo --noEmit
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-meetings/CLAUDE.md
+++ b/plugins/plugin-meetings/CLAUDE.md
@@ -191,7 +191,7 @@ bun run --cwd plugins/plugin-meetings typecheck   # tsgo --noEmit
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-messages/AGENTS.md
+++ b/plugins/plugin-messages/AGENTS.md
@@ -145,7 +145,7 @@ import messagesPlugin from "@elizaos/plugin-messages";
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-messages/CLAUDE.md
+++ b/plugins/plugin-messages/CLAUDE.md
@@ -145,7 +145,7 @@ import messagesPlugin from "@elizaos/plugin-messages";
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-music/AGENTS.md
+++ b/plugins/plugin-music/AGENTS.md
@@ -239,7 +239,7 @@ See the repo-wide rules in the root `AGENTS.md`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-music/CLAUDE.md
+++ b/plugins/plugin-music/CLAUDE.md
@@ -239,7 +239,7 @@ See the repo-wide rules in the root `AGENTS.md`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-activity-tracker/AGENTS.md
+++ b/plugins/plugin-native-activity-tracker/AGENTS.md
@@ -116,7 +116,7 @@ Add the field to `ActivityCollectorOptions`, use it inside `startActivityCollect
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-activity-tracker/CLAUDE.md
+++ b/plugins/plugin-native-activity-tracker/CLAUDE.md
@@ -116,7 +116,7 @@ Add the field to `ActivityCollectorOptions`, use it inside `startActivityCollect
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-agent/AGENTS.md
+++ b/plugins/plugin-native-agent/AGENTS.md
@@ -142,7 +142,7 @@ Android uses reflection to call `ElizaAgentService` (resolved by scanning regist
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-agent/CLAUDE.md
+++ b/plugins/plugin-native-agent/CLAUDE.md
@@ -142,7 +142,7 @@ Android uses reflection to call `ElizaAgentService` (resolved by scanning regist
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-appblocker/AGENTS.md
+++ b/plugins/plugin-native-appblocker/AGENTS.md
@@ -127,7 +127,7 @@ This plugin reads no environment variables. It requires OS-level permissions gra
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-appblocker/CLAUDE.md
+++ b/plugins/plugin-native-appblocker/CLAUDE.md
@@ -127,7 +127,7 @@ This plugin reads no environment variables. It requires OS-level permissions gra
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-bun-runtime/AGENTS.md
+++ b/plugins/plugin-native-bun-runtime/AGENTS.md
@@ -175,7 +175,7 @@ Runtime options passed to `start()`:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-bun-runtime/CLAUDE.md
+++ b/plugins/plugin-native-bun-runtime/CLAUDE.md
@@ -175,7 +175,7 @@ Runtime options passed to `start()`:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-calendar/AGENTS.md
+++ b/plugins/plugin-native-calendar/AGENTS.md
@@ -124,7 +124,7 @@ None. This package reads no environment variables and has no runtime configurati
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-calendar/CLAUDE.md
+++ b/plugins/plugin-native-calendar/CLAUDE.md
@@ -124,7 +124,7 @@ None. This package reads no environment variables and has no runtime configurati
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-camera/AGENTS.md
+++ b/plugins/plugin-native-camera/AGENTS.md
@@ -148,7 +148,7 @@ Capacitor plugin registration name: `"ElizaCamera"` (used internally by `@capaci
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-camera/CLAUDE.md
+++ b/plugins/plugin-native-camera/CLAUDE.md
@@ -148,7 +148,7 @@ Capacitor plugin registration name: `"ElizaCamera"` (used internally by `@capaci
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-canvas/AGENTS.md
+++ b/plugins/plugin-native-canvas/AGENTS.md
@@ -162,7 +162,7 @@ This plugin reads no environment variables. Configuration is entirely call-time 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-canvas/CLAUDE.md
+++ b/plugins/plugin-native-canvas/CLAUDE.md
@@ -162,7 +162,7 @@ This plugin reads no environment variables. Configuration is entirely call-time 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-contacts/AGENTS.md
+++ b/plugins/plugin-native-contacts/AGENTS.md
@@ -128,7 +128,7 @@ Add the interface/type to `src/definitions.ts` and re-export via `src/index.ts` 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-contacts/CLAUDE.md
+++ b/plugins/plugin-native-contacts/CLAUDE.md
@@ -128,7 +128,7 @@ Add the interface/type to `src/definitions.ts` and re-export via `src/index.ts` 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-desktop/AGENTS.md
+++ b/plugins/plugin-native-desktop/AGENTS.md
@@ -123,7 +123,7 @@ None. This package reads no env vars and has no runtime configuration. All behav
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-desktop/CLAUDE.md
+++ b/plugins/plugin-native-desktop/CLAUDE.md
@@ -123,7 +123,7 @@ None. This package reads no env vars and has no runtime configuration. All behav
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-eliza-tasks/AGENTS.md
+++ b/plugins/plugin-native-eliza-tasks/AGENTS.md
@@ -126,7 +126,7 @@ The `scheduleNext` method accepts `earliestBeginSec` (default 900s / 15 min, flo
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-eliza-tasks/CLAUDE.md
+++ b/plugins/plugin-native-eliza-tasks/CLAUDE.md
@@ -126,7 +126,7 @@ The `scheduleNext` method accepts `earliestBeginSec` (default 900s / 15 min, flo
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-filesystem/AGENTS.md
+++ b/plugins/plugin-native-filesystem/AGENTS.md
@@ -137,7 +137,7 @@ const content = await bridge.read("notes/checklist.md");
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-filesystem/CLAUDE.md
+++ b/plugins/plugin-native-filesystem/CLAUDE.md
@@ -137,7 +137,7 @@ const content = await bridge.read("notes/checklist.md");
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-gateway/AGENTS.md
+++ b/plugins/plugin-native-gateway/AGENTS.md
@@ -168,7 +168,7 @@ mDNS service type: `_eliza-gw._tcp` (local.) on iOS/Android; `_eliza-gw._tcp.` o
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-gateway/CLAUDE.md
+++ b/plugins/plugin-native-gateway/CLAUDE.md
@@ -168,7 +168,7 @@ mDNS service type: `_eliza-gw._tcp` (local.) on iOS/Android; `_eliza-gw._tcp.` o
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-llama/AGENTS.md
+++ b/plugins/plugin-native-llama/AGENTS.md
@@ -127,7 +127,7 @@ Add a new variant to the `SamplerStage` union in `src/definitions.ts`. The nativ
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-llama/CLAUDE.md
+++ b/plugins/plugin-native-llama/CLAUDE.md
@@ -127,7 +127,7 @@ Add a new variant to the `SamplerStage` union in `src/definitions.ts`. The nativ
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-location/AGENTS.md
+++ b/plugins/plugin-native-location/AGENTS.md
@@ -144,7 +144,7 @@ Native platform permissions are requested at runtime via `requestPermissions()` 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-location/CLAUDE.md
+++ b/plugins/plugin-native-location/CLAUDE.md
@@ -144,7 +144,7 @@ Native platform permissions are requested at runtime via `requestPermissions()` 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-macosalarm/AGENTS.md
+++ b/plugins/plugin-native-macosalarm/AGENTS.md
@@ -129,7 +129,7 @@ No runtime config keys are read from the agent runtime settings object. The only
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-macosalarm/CLAUDE.md
+++ b/plugins/plugin-native-macosalarm/CLAUDE.md
@@ -129,7 +129,7 @@ No runtime config keys are read from the agent runtime settings object. The only
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-messages/AGENTS.md
+++ b/plugins/plugin-native-messages/AGENTS.md
@@ -115,7 +115,7 @@ Both permissions are declared in `android/src/main/AndroidManifest.xml`. The hos
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-messages/CLAUDE.md
+++ b/plugins/plugin-native-messages/CLAUDE.md
@@ -115,7 +115,7 @@ Both permissions are declared in `android/src/main/AndroidManifest.xml`. The hos
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-mobile-agent-bridge/AGENTS.md
+++ b/plugins/plugin-native-mobile-agent-bridge/AGENTS.md
@@ -126,7 +126,7 @@ Add the event name as a string literal parameter to `addListener` in `definition
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-mobile-agent-bridge/CLAUDE.md
+++ b/plugins/plugin-native-mobile-agent-bridge/CLAUDE.md
@@ -126,7 +126,7 @@ Add the event name as a string literal parameter to `addListener` in `definition
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-mobile-signals/AGENTS.md
+++ b/plugins/plugin-native-mobile-signals/AGENTS.md
@@ -152,7 +152,7 @@ Extend `MobileSignalsSnapshot` or `MobileSignalsHealthSnapshot` in `src/definiti
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-mobile-signals/CLAUDE.md
+++ b/plugins/plugin-native-mobile-signals/CLAUDE.md
@@ -152,7 +152,7 @@ Extend `MobileSignalsSnapshot` or `MobileSignalsHealthSnapshot` in `src/definiti
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-network-policy/AGENTS.md
+++ b/plugins/plugin-native-network-policy/AGENTS.md
@@ -127,7 +127,7 @@ None. This plugin reads no environment variables and has no elizaOS `settings` f
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-network-policy/CLAUDE.md
+++ b/plugins/plugin-native-network-policy/CLAUDE.md
@@ -127,7 +127,7 @@ None. This plugin reads no environment variables and has no elizaOS `settings` f
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-phone/AGENTS.md
+++ b/plugins/plugin-native-phone/AGENTS.md
@@ -121,7 +121,7 @@ No environment variables. No runtime config keys. Android permissions are declar
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-phone/CLAUDE.md
+++ b/plugins/plugin-native-phone/CLAUDE.md
@@ -121,7 +121,7 @@ No environment variables. No runtime config keys. Android permissions are declar
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-reminders/AGENTS.md
+++ b/plugins/plugin-native-reminders/AGENTS.md
@@ -94,7 +94,7 @@ pure and testable.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-reminders/CLAUDE.md
+++ b/plugins/plugin-native-reminders/CLAUDE.md
@@ -94,7 +94,7 @@ pure and testable.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-screencapture/AGENTS.md
+++ b/plugins/plugin-native-screencapture/AGENTS.md
@@ -156,7 +156,7 @@ Emit from native via `self.notifyListeners("eventName", data: [...])` (Swift) or
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-screencapture/CLAUDE.md
+++ b/plugins/plugin-native-screencapture/CLAUDE.md
@@ -156,7 +156,7 @@ Emit from native via `self.notifyListeners("eventName", data: [...])` (Swift) or
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-settings/AGENTS.md
+++ b/plugins/plugin-native-settings/AGENTS.md
@@ -113,7 +113,7 @@ Create a new plugin following the same shape: define an `OverlayApp` object, cal
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-settings/CLAUDE.md
+++ b/plugins/plugin-native-settings/CLAUDE.md
@@ -113,7 +113,7 @@ Create a new plugin following the same shape: define an `OverlayApp` object, cal
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-shared-types/AGENTS.md
+++ b/plugins/plugin-native-shared-types/AGENTS.md
@@ -99,7 +99,7 @@ Do not add runtime logic, class implementations, or any code with side effects t
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-shared-types/CLAUDE.md
+++ b/plugins/plugin-native-shared-types/CLAUDE.md
@@ -99,7 +99,7 @@ Do not add runtime logic, class implementations, or any code with side effects t
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-swabble/AGENTS.md
+++ b/plugins/plugin-native-swabble/AGENTS.md
@@ -144,7 +144,7 @@ No environment variables. Configuration is passed at runtime via `SwabbleConfig`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-swabble/CLAUDE.md
+++ b/plugins/plugin-native-swabble/CLAUDE.md
@@ -144,7 +144,7 @@ No environment variables. Configuration is passed at runtime via `SwabbleConfig`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-system/AGENTS.md
+++ b/plugins/plugin-native-system/AGENTS.md
@@ -144,7 +144,7 @@ Use `notifyListeners("eventName", data)` in the Kotlin plugin and `System.addLis
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-system/CLAUDE.md
+++ b/plugins/plugin-native-system/CLAUDE.md
@@ -144,7 +144,7 @@ Use `notifyListeners("eventName", data)` in the Kotlin plugin and `System.addLis
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-talkmode/AGENTS.md
+++ b/plugins/plugin-native-talkmode/AGENTS.md
@@ -149,7 +149,7 @@ The `speak()` call also accepts a `TTSDirective` for per-utterance overrides (vo
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-talkmode/CLAUDE.md
+++ b/plugins/plugin-native-talkmode/CLAUDE.md
@@ -149,7 +149,7 @@ The `speak()` call also accepts a `TTSDirective` for per-utterance overrides (vo
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-websiteblocker/AGENTS.md
+++ b/plugins/plugin-native-websiteblocker/AGENTS.md
@@ -148,7 +148,7 @@ All public TS types live in `src/definitions.ts`. Keep them co-located; do not s
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-websiteblocker/CLAUDE.md
+++ b/plugins/plugin-native-websiteblocker/CLAUDE.md
@@ -148,7 +148,7 @@ All public TS types live in `src/definitions.ts`. Keep them co-located; do not s
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-wifi/AGENTS.md
+++ b/plugins/plugin-native-wifi/AGENTS.md
@@ -124,7 +124,7 @@ To add a new method to this Capacitor plugin:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-native-wifi/CLAUDE.md
+++ b/plugins/plugin-native-wifi/CLAUDE.md
@@ -124,7 +124,7 @@ To add a new method to this Capacitor plugin:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-nostr/AGENTS.md
+++ b/plugins/plugin-nostr/AGENTS.md
@@ -133,7 +133,7 @@ Character-file override path: `character.settings.nostr` — same fields as `Nos
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-nostr/CLAUDE.md
+++ b/plugins/plugin-nostr/CLAUDE.md
@@ -133,7 +133,7 @@ Character-file override path: `character.settings.nostr` — same fields as `Nos
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-ollama/AGENTS.md
+++ b/plugins/plugin-ollama/AGENTS.md
@@ -136,7 +136,7 @@ All vars are read by `utils/config.ts` via `runtime.getSetting(key)` first, then
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-ollama/CLAUDE.md
+++ b/plugins/plugin-ollama/CLAUDE.md
@@ -136,7 +136,7 @@ All vars are read by `utils/config.ts` via `runtime.getSetting(key)` first, then
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-openai/AGENTS.md
+++ b/plugins/plugin-openai/AGENTS.md
@@ -182,7 +182,7 @@ Model tiers (nano/medium/mega/response-handler/action-planner) all call the shar
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-openai/CLAUDE.md
+++ b/plugins/plugin-openai/CLAUDE.md
@@ -182,7 +182,7 @@ Model tiers (nano/medium/mega/response-handler/action-planner) all call the shar
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-openrouter/AGENTS.md
+++ b/plugins/plugin-openrouter/AGENTS.md
@@ -150,7 +150,7 @@ Settings are read via `runtime.getSetting(key)` first, then `process.env[key]`. 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-openrouter/CLAUDE.md
+++ b/plugins/plugin-openrouter/CLAUDE.md
@@ -150,7 +150,7 @@ Settings are read via `runtime.getSetting(key)` first, then `process.env[key]`. 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-pdf/AGENTS.md
+++ b/plugins/plugin-pdf/AGENTS.md
@@ -113,7 +113,7 @@ Edit `services/pdf.ts`. The class extends `Service` from `@elizaos/core`. Add th
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-pdf/CLAUDE.md
+++ b/plugins/plugin-pdf/CLAUDE.md
@@ -113,7 +113,7 @@ Edit `services/pdf.ts`. The class extends `Service` from `@elizaos/core`. Add th
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-personal-assistant/AGENTS.md
+++ b/plugins/plugin-personal-assistant/AGENTS.md
@@ -304,7 +304,7 @@ bun run --cwd plugins/plugin-personal-assistant verify:live-schedule          # 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-personal-assistant/CLAUDE.md
+++ b/plugins/plugin-personal-assistant/CLAUDE.md
@@ -304,7 +304,7 @@ bun run --cwd plugins/plugin-personal-assistant verify:live-schedule          # 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-phone/AGENTS.md
+++ b/plugins/plugin-phone/AGENTS.md
@@ -148,7 +148,7 @@ The `phoneCallLog` provider reads no env vars; it calls `Phone.listRecentCalls` 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-phone/CLAUDE.md
+++ b/plugins/plugin-phone/CLAUDE.md
@@ -148,7 +148,7 @@ The `phoneCallLog` provider reads no env vars; it calls `Phone.listRecentCalls` 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-polymarket/AGENTS.md
+++ b/plugins/plugin-polymarket/AGENTS.md
@@ -161,7 +161,7 @@ See the root [AGENTS.md](../../AGENTS.md) for repo-wide architecture rules, logg
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-polymarket/CLAUDE.md
+++ b/plugins/plugin-polymarket/CLAUDE.md
@@ -161,7 +161,7 @@ See the root [AGENTS.md](../../AGENTS.md) for repo-wide architecture rules, logg
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-registry/AGENTS.md
+++ b/plugins/plugin-registry/AGENTS.md
@@ -140,7 +140,7 @@ Env vars consumed indirectly at route-handler call time:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-registry/CLAUDE.md
+++ b/plugins/plugin-registry/CLAUDE.md
@@ -140,7 +140,7 @@ Env vars consumed indirectly at route-handler call time:
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-relationships/AGENTS.md
+++ b/plugins/plugin-relationships/AGENTS.md
@@ -156,7 +156,7 @@ needed.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-relationships/CLAUDE.md
+++ b/plugins/plugin-relationships/CLAUDE.md
@@ -156,7 +156,7 @@ needed.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-reminders/AGENTS.md
+++ b/plugins/plugin-reminders/AGENTS.md
@@ -64,7 +64,7 @@ See the root `AGENTS.md` for repo-wide architecture rules.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-reminders/CLAUDE.md
+++ b/plugins/plugin-reminders/CLAUDE.md
@@ -64,7 +64,7 @@ See the root `AGENTS.md` for repo-wide architecture rules.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-remote-desktop/AGENTS.md
+++ b/plugins/plugin-remote-desktop/AGENTS.md
@@ -118,7 +118,7 @@ The remote-desktop domain moved here from `@elizaos/plugin-personal-assistant`. 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-remote-desktop/CLAUDE.md
+++ b/plugins/plugin-remote-desktop/CLAUDE.md
@@ -118,7 +118,7 @@ The remote-desktop domain moved here from `@elizaos/plugin-personal-assistant`. 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-scheduling/AGENTS.md
+++ b/plugins/plugin-scheduling/AGENTS.md
@@ -103,7 +103,7 @@ See the root `AGENTS.md` for repo-wide architecture rules.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-scheduling/CLAUDE.md
+++ b/plugins/plugin-scheduling/CLAUDE.md
@@ -103,7 +103,7 @@ See the root `AGENTS.md` for repo-wide architecture rules.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-screenshare/AGENTS.md
+++ b/plugins/plugin-screenshare/AGENTS.md
@@ -150,7 +150,7 @@ The `GET /capabilities` route reports all three capability flags along with whic
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-screenshare/CLAUDE.md
+++ b/plugins/plugin-screenshare/CLAUDE.md
@@ -150,7 +150,7 @@ The `GET /capabilities` route reports all three capability flags along with whic
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-shell/AGENTS.md
+++ b/plugins/plugin-shell/AGENTS.md
@@ -137,7 +137,7 @@ Config is validated by zod in `utils/config.ts → loadShellConfig()`. Missing o
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-shell/CLAUDE.md
+++ b/plugins/plugin-shell/CLAUDE.md
@@ -137,7 +137,7 @@ Config is validated by zod in `utils/config.ts → loadShellConfig()`. Missing o
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-signal/AGENTS.md
+++ b/plugins/plugin-signal/AGENTS.md
@@ -145,7 +145,7 @@ See the root `AGENTS.md` for repo-wide architecture rules, logger conventions, a
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-signal/CLAUDE.md
+++ b/plugins/plugin-signal/CLAUDE.md
@@ -145,7 +145,7 @@ See the root `AGENTS.md` for repo-wide architecture rules, logger conventions, a
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-slack/AGENTS.md
+++ b/plugins/plugin-slack/AGENTS.md
@@ -151,7 +151,7 @@ Multi-account config: set `character.settings.slack.accounts` as a record keyed 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-slack/CLAUDE.md
+++ b/plugins/plugin-slack/CLAUDE.md
@@ -151,7 +151,7 @@ Multi-account config: set `character.settings.slack.accounts` as a record keyed 
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-sql/AGENTS.md
+++ b/plugins/plugin-sql/AGENTS.md
@@ -164,7 +164,7 @@ Settings are read via `runtime.getSetting(key)` inside `plugin.init`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-sql/CLAUDE.md
+++ b/plugins/plugin-sql/CLAUDE.md
@@ -164,7 +164,7 @@ Settings are read via `runtime.getSetting(key)` inside `plugin.init`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-streaming/AGENTS.md
+++ b/plugins/plugin-streaming/AGENTS.md
@@ -173,7 +173,7 @@ Add a conditional branch in `handleStreamRoute()` in `src/api/stream-routes.ts`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-streaming/CLAUDE.md
+++ b/plugins/plugin-streaming/CLAUDE.md
@@ -173,7 +173,7 @@ Add a conditional branch in `handleStreamRoute()` in `src/api/stream-routes.ts`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-suno/AGENTS.md
+++ b/plugins/plugin-suno/AGENTS.md
@@ -127,7 +127,7 @@ Default Suno base URL: `https://api.suno.ai/v1` (hardcoded; no env override).
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-suno/CLAUDE.md
+++ b/plugins/plugin-suno/CLAUDE.md
@@ -127,7 +127,7 @@ Default Suno base URL: `https://api.suno.ai/v1` (hardcoded; no env override).
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-tailscale/AGENTS.md
+++ b/plugins/plugin-tailscale/AGENTS.md
@@ -130,7 +130,7 @@ Config resolution order for each key: account record in `character.settings.tail
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-tailscale/CLAUDE.md
+++ b/plugins/plugin-tailscale/CLAUDE.md
@@ -130,7 +130,7 @@ Config resolution order for each key: account record in `character.settings.tail
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-task-coordinator/AGENTS.md
+++ b/plugins/plugin-task-coordinator/AGENTS.md
@@ -198,7 +198,7 @@ These prefixes are used to build preference keys sent to the agent prefs API; th
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-task-coordinator/CLAUDE.md
+++ b/plugins/plugin-task-coordinator/CLAUDE.md
@@ -198,7 +198,7 @@ These prefixes are used to build preference keys sent to the agent prefs API; th
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-tee/AGENTS.md
+++ b/plugins/plugin-tee/AGENTS.md
@@ -129,7 +129,7 @@ bun run --cwd plugins/plugin-tee clean           # rm -rf dist .turbo .turbo-tsc
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-tee/CLAUDE.md
+++ b/plugins/plugin-tee/CLAUDE.md
@@ -129,7 +129,7 @@ bun run --cwd plugins/plugin-tee clean           # rm -rf dist .turbo .turbo-tsc
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-telegram/AGENTS.md
+++ b/plugins/plugin-telegram/AGENTS.md
@@ -161,7 +161,7 @@ Account resolution order (for the `default` account): `character.settings.telegr
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-telegram/CLAUDE.md
+++ b/plugins/plugin-telegram/CLAUDE.md
@@ -161,7 +161,7 @@ Account resolution order (for the `default` account): `character.settings.telegr
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-todos/AGENTS.md
+++ b/plugins/plugin-todos/AGENTS.md
@@ -121,7 +121,7 @@ No plugin-specific settings keys. No API keys or external service credentials ne
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-todos/CLAUDE.md
+++ b/plugins/plugin-todos/CLAUDE.md
@@ -121,7 +121,7 @@ No plugin-specific settings keys. No API keys or external service credentials ne
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-training/AGENTS.md
+++ b/plugins/plugin-training/AGENTS.md
@@ -252,7 +252,7 @@ Training config is persisted at `<stateDir>/training/config.json`. Key fields: `
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-training/CLAUDE.md
+++ b/plugins/plugin-training/CLAUDE.md
@@ -252,7 +252,7 @@ Training config is persisted at `<stateDir>/training/config.json`. Key fields: `
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-tunnel/AGENTS.md
+++ b/plugins/plugin-tunnel/AGENTS.md
@@ -125,7 +125,7 @@ None are required; all have defaults. The device must already be authenticated (
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-tunnel/CLAUDE.md
+++ b/plugins/plugin-tunnel/CLAUDE.md
@@ -125,7 +125,7 @@ None are required; all have defaults. The device must already be authenticated (
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-twitch/AGENTS.md
+++ b/plugins/plugin-twitch/AGENTS.md
@@ -131,7 +131,7 @@ Settings are resolved in priority order: per-account object in `TWITCH_ACCOUNTS`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-twitch/CLAUDE.md
+++ b/plugins/plugin-twitch/CLAUDE.md
@@ -131,7 +131,7 @@ Settings are resolved in priority order: per-account object in `TWITCH_ACCOUNTS`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-vector-browser/AGENTS.md
+++ b/plugins/plugin-vector-browser/AGENTS.md
@@ -104,7 +104,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-vector-browser/CLAUDE.md
+++ b/plugins/plugin-vector-browser/CLAUDE.md
@@ -104,7 +104,7 @@ Repo-wide rules (logger-only, ESM, naming, architecture) are in the root [AGENTS
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-video/AGENTS.md
+++ b/plugins/plugin-video/AGENTS.md
@@ -112,7 +112,7 @@ Same pattern: create `src/providers/my-provider.ts`, export a `Provider`, and ad
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-video/CLAUDE.md
+++ b/plugins/plugin-video/CLAUDE.md
@@ -112,7 +112,7 @@ Same pattern: create `src/providers/my-provider.ts`, export a `Provider`, and ad
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-wallet-ui/AGENTS.md
+++ b/plugins/plugin-wallet-ui/AGENTS.md
@@ -157,7 +157,7 @@ Two localStorage keys are used for user preferences (no config required):
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-wallet-ui/CLAUDE.md
+++ b/plugins/plugin-wallet-ui/CLAUDE.md
@@ -157,7 +157,7 @@ Two localStorage keys are used for user preferences (no config required):
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-wallet/AGENTS.md
+++ b/plugins/plugin-wallet/AGENTS.md
@@ -241,7 +241,7 @@ Extend `src/analytics/birdeye/service.ts`. The service proxies all calls through
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-wallet/CLAUDE.md
+++ b/plugins/plugin-wallet/CLAUDE.md
@@ -241,7 +241,7 @@ Extend `src/analytics/birdeye/service.ts`. The service proxies all calls through
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-web-search/AGENTS.md
+++ b/plugins/plugin-web-search/AGENTS.md
@@ -111,7 +111,7 @@ Edit `WEB_SEARCH_CATEGORY.filters` in `src/index.ts`. Filter names must match ke
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-web-search/CLAUDE.md
+++ b/plugins/plugin-web-search/CLAUDE.md
@@ -111,7 +111,7 @@ Edit `WEB_SEARCH_CATEGORY.filters` in `src/index.ts`. Filter names must match ke
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-wechat/AGENTS.md
+++ b/plugins/plugin-wechat/AGENTS.md
@@ -169,7 +169,7 @@ mapping to `WECHAT_TYPE_MAP` in `src/callback-server.ts`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-wechat/CLAUDE.md
+++ b/plugins/plugin-wechat/CLAUDE.md
@@ -169,7 +169,7 @@ mapping to `WECHAT_TYPE_MAP` in `src/callback-server.ts`.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-whatsapp/AGENTS.md
+++ b/plugins/plugin-whatsapp/AGENTS.md
@@ -169,7 +169,7 @@ Configure multiple accounts under `character.settings.whatsapp.accounts.<id>` us
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-whatsapp/CLAUDE.md
+++ b/plugins/plugin-whatsapp/CLAUDE.md
@@ -169,7 +169,7 @@ Configure multiple accounts under `character.settings.whatsapp.accounts.<id>` us
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-wifi/AGENTS.md
+++ b/plugins/plugin-wifi/AGENTS.md
@@ -104,7 +104,7 @@ No env vars or settings keys. The plugin reads no process environment at runtime
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-wifi/CLAUDE.md
+++ b/plugins/plugin-wifi/CLAUDE.md
@@ -104,7 +104,7 @@ No env vars or settings keys. The plugin reads no process environment at runtime
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-workflow/AGENTS.md
+++ b/plugins/plugin-workflow/AGENTS.md
@@ -221,7 +221,7 @@ Node definitions live in `src/data/defaultNodes.json`. Add new entries and updat
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-workflow/CLAUDE.md
+++ b/plugins/plugin-workflow/CLAUDE.md
@@ -221,7 +221,7 @@ Node definitions live in `src/data/defaultNodes.json`. Add new entries and updat
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-x/AGENTS.md
+++ b/plugins/plugin-x/AGENTS.md
@@ -203,7 +203,7 @@ All vars are read via `getSetting(runtime, key)` which checks `runtime.getSettin
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-x/CLAUDE.md
+++ b/plugins/plugin-x/CLAUDE.md
@@ -203,7 +203,7 @@ All vars are read via `getSetting(runtime, key)` which checks `runtime.getSettin
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-x402/AGENTS.md
+++ b/plugins/plugin-x402/AGENTS.md
@@ -195,7 +195,7 @@ Edit `verifyPayment` in `src/payment-wrapper.ts`. Each strategy must call `repla
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-x402/CLAUDE.md
+++ b/plugins/plugin-x402/CLAUDE.md
@@ -195,7 +195,7 @@ Edit `verifyPayment` in `src/payment-wrapper.ts`. Each strategy must call `repla
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-xai/AGENTS.md
+++ b/plugins/plugin-xai/AGENTS.md
@@ -155,7 +155,7 @@ separate plugin rather than bloating this model-only plugin.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-xai/CLAUDE.md
+++ b/plugins/plugin-xai/CLAUDE.md
@@ -155,7 +155,7 @@ separate plugin rather than bloating this model-only plugin.
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-zai/AGENTS.md
+++ b/plugins/plugin-zai/AGENTS.md
@@ -134,7 +134,7 @@ All values are read via `runtime.getSetting(key)` first, then `process.env[key]`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 

--- a/plugins/plugin-zai/CLAUDE.md
+++ b/plugins/plugin-zai/CLAUDE.md
@@ -134,7 +134,7 @@ All values are read via `runtime.getSetting(key)` first, then `process.env[key]`
   "follow-up." When unsure, research thoroughly, weigh the options, and ship the best,
   highest-effort, production-ready version. Keep going until every possibility is exhausted.
 
-Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or**
+Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or**
 explicitly mark it N/A with a reason — never leave it blank. If `develop` moved and changed
 behavior, **re-capture** evidence; stale proof is worse than none.
 


### PR DESCRIPTION
Closes #14341.

## What & why (docs-only)

Every package/plugin agent guide restated the Definition-of-Done evidence rule with a byte-identical line pointing at the **retired** `.github/issue-evidence/` directory. Agents reading a package guide cold keep committing evidence files to the repo instead of attaching them inline. This sweeps that location clause to the canonical inline-PR-attachment wording.

Verified against `origin/develop` (base `f5f8167`), not the working tree — the shared tree is dirty and ahead; content was read from develop and pushed via the Git Data API.

## Changes (552 files, all CLAUDE.md/AGENTS.md, +558/−560)

1. **Uniform line — 548 files.** Byte-identical replacement:
   - before: `` Artifacts → `.github/issue-evidence/<issue#>-<slug>.<ext>`; attach each evidence type **or** ``
   - after: `` Artifacts → attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`); attach each evidence type **or** ``
2. **5 bespoke package mentions — hand-reworded** to drop the retired path:
   - `plugins/plugin-google` — "…requires real Google account access **and attaches inline in the PR.**"
   - `packages/app` — "codifies the proven #11030 **device-boot recipe).**" (the cited `device-boot-README.md` was deleted)
   - `packages/benchmarks/meeting-transcription-proof` — "…retention/deletion **artifacts, attached inline in the PR.**"
   - `packages/native/plugins/wakeword-cpp` — "Reproduce with `test/wakeword_score_raw.c` — see **#9880.**"
   - `plugins/plugin-cloud-apps` — "Artifacts → **attached inline in the PR (MP4 video, JPG screenshots, logs in `<details>`)**, or mark a row `N/A - <reason>`."
3. **Intentionally kept:** the root `CLAUDE.md`/`AGENTS.md` retirement statements (`:211`, `:492`) — those *state the retirement* and are the only allowed remaining mention.

## Acceptance criteria

- [x] **AC1** — `git grep "issue-evidence" -- '*CLAUDE.md' '*AGENTS.md'` on the branch returns **only** the root pair (4 lines: `CLAUDE.md`/`AGENTS.md` `:211` + `:492`, the retirement statement). Evidence below.
- [x] **AC2** — `check:agents-claude` (byte-identical pairs) holds: the push script gated on every edited `CLAUDE.md` being byte-identical to its `AGENTS.md` sibling — **276 pairs, all identical** (GATE B). The same replacement is applied to both halves of each pair, so identity is preserved by construction.
- [x] **AC3** — `check-markdown-links.mjs` on `STT_SELECTION.md`: the dead links were already removed on current `develop` (a prior merge), so there is nothing left to fail — grep-confirmed clean.
- [x] **AC4** — diff is docs-only: **all 552 changed files are `CLAUDE.md`/`AGENTS.md`** (0 non-`.md`), no code tokens.

## Evidence

**AC1 — only the root retirement mention remains (branch grep):**
```
$ git grep -n "issue-evidence" origin/fix/14341-evidence-location-sweep -- '*CLAUDE.md' '*AGENTS.md'
…/CLAUDE.md:211:behavior. `.github/issue-evidence/` is retired; the full standard is
…/CLAUDE.md:492:    (`.github/issue-evidence/` is retired). Each evidence type is attached
…/AGENTS.md:211:behavior. `.github/issue-evidence/` is retired; the full standard is
…/AGENTS.md:492:    (`.github/issue-evidence/` is retired). Each evidence type is attached
```
(No package/plugin guide retains the retired path — all 5 bespoke mentions successfully reworded, else they would appear here.)

**AC2/AC4 — push-time structural gates:**
```
uniform files: 548, union to touch: 552
GATE A ok (no non-root issue-evidence). GATE B ok (276 pairs identical).
created 552 blobs
```
Commit stats: 552 files, +558 / −560, all `CLAUDE.md`/`AGENTS.md`.

**Screenshots / MP4 / trajectories: N/A** — mechanical docs sweep, no code or runtime surface.

## Spotted-adjacent residual (out of scope, noted not fixed)

`packages/benchmarks/multitask-bench/README.md:104` still has a markdown link to a retired `.github/issue-evidence/13777-multitask-live/…` path — outside this issue's CLAUDE/AGENTS + STT_SELECTION scope. Worth a follow-up if `check-markdown-links` covers that README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
