### PR TITLE
test(ui): regression-guard overlay message-search query→jump path (#14330)

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -96,6 +96,9 @@ afterEach(() => {
   cleanup();
   resetShellSurfaceForTests();
   setViewChatBinding(null);
+  vi.mocked(client.searchConversationMessages).mockReset();
+  vi.mocked(Element.prototype.scrollIntoView).mockClear();
+  document.getElementById("chat-message-m-hit")?.remove();
   // Search-jump tests seed the AppContext store with spies; clear it so the
   // inert test-fallback proxy backs every other test again.
   __setAppValueForTests(null);
@@ -2477,7 +2480,12 @@ describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
     // inert test-fallback proxy (noop for everything else the overlay reads via
     // other selectors) so only the jump collaborators are observable.
     const selectSpy = vi.fn<(id: string) => Promise<void>>(async () => {});
-    const aroundSpy = vi.fn(async () => false);
+    const aroundSpy = vi.fn(async () => {
+      const anchor = document.createElement("div");
+      anchor.id = "chat-message-m-hit";
+      document.body.appendChild(anchor);
+      return true;
+    });
     const noop = () => {};
     __setAppValueForTests(
       new Proxy({} as never, {
@@ -2531,9 +2539,19 @@ describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
     expect(result.textContent).toContain("budget");
 
     // Selecting the hit jumps to its conversation (the real jump plumbing) and
-    // closes the panel.
+    // then loads the centered around-window because this fixture starts with no
+    // DOM anchor for the hit.
     fireEvent.click(result);
     expect(selectSpy).toHaveBeenCalledWith("conv-42");
+    await waitFor(() =>
+      expect(aroundSpy).toHaveBeenCalledWith("conv-42", "m-hit"),
+    );
+    await waitFor(() =>
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
+        block: "center",
+        behavior: "smooth",
+      }),
+    );
     await waitFor(() =>
       expect(screen.queryByTestId("chat-message-search")).toBeNull(),
     );

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -41,6 +41,10 @@ vi.mock("../../api/client", () => ({
     createTranscript: vi
       .fn()
       .mockResolvedValue({ transcript: { id: "t1", title: "Transcript" } }),
+    // The header search control drives the real client method; per-test the
+    // resolved value is the real `GET /api/conversations/messages/search`
+    // response shape so the query→results→jump path is exercised end to end.
+    searchConversationMessages: vi.fn(),
   },
 }));
 
@@ -51,9 +55,11 @@ vi.mock("../../utils/clipboard", () => ({
 }));
 
 import * as React from "react";
+import { client } from "../../api/client";
 import type {
   Conversation,
   ConversationMessage,
+  ConversationMessageSearchResult,
   ImageAttachment,
 } from "../../api/client-types-chat";
 import { CHAT_PREFILL_EVENT, ELIZA_BACK_INTENT_EVENT } from "../../events";
@@ -62,6 +68,7 @@ import {
   LAYOUT_SHIFT_INTENT_TRANSIENT,
 } from "../../hooks/useLayoutShiftMonitor";
 import { __resetAssistantLaunchPayloadClaimsForTests } from "../../platform/assistant-launch-payload";
+import { __setAppValueForTests } from "../../state/app-store";
 import {
   getShellSurface,
   resetShellSurfaceForTests,
@@ -89,6 +96,9 @@ afterEach(() => {
   cleanup();
   resetShellSurfaceForTests();
   setViewChatBinding(null);
+  // Search-jump tests seed the AppContext store with spies; clear it so the
+  // inert test-fallback proxy backs every other test again.
+  __setAppValueForTests(null);
 });
 
 function makeController(
@@ -2459,6 +2469,98 @@ describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
     // Tapping again toggles it closed.
     fireEvent.click(screen.getByTestId("chat-full-search"));
     expect(screen.queryByTestId("chat-message-search")).toBeNull();
+  });
+
+  it("drives the header search → query → jump path against the real search API shape (#14330)", async () => {
+    // Real jump plumbing: the overlay pulls handleSelectConversation from the
+    // AppContext store, so seed it with a spy the jump must call. Mirror the
+    // inert test-fallback proxy (noop for everything else the overlay reads via
+    // other selectors) so only the jump collaborators are observable.
+    const selectSpy = vi.fn<(id: string) => Promise<void>>(async () => {});
+    const aroundSpy = vi.fn(async () => false);
+    const noop = () => {};
+    __setAppValueForTests(
+      new Proxy({} as never, {
+        get(_t, prop) {
+          if (prop === "handleSelectConversation") return selectSpy;
+          if (prop === "loadConversationMessagesAround") return aroundSpy;
+          if (prop === "t") return (k: string) => k;
+          if (prop === "uiLanguage") return "en";
+          if (prop === "navigation") {
+            return { scheduleAfterTabCommit: (fn: () => void) => fn() };
+          }
+          return noop;
+        },
+      }),
+    );
+
+    // The panel renders exactly what the server route returns; use its real
+    // response shape (ranked hits with snippet/role/createdAt).
+    const hit: ConversationMessageSearchResult = {
+      messageId: "m-hit",
+      conversationId: "conv-42",
+      roomId: "room-1",
+      role: "assistant",
+      text: "the quarterly budget review is on friday",
+      snippet: "the quarterly …budget… review is on friday",
+      createdAt: 1_700_000_000_000,
+      score: 12.5,
+    };
+    vi.mocked(client.searchConversationMessages).mockResolvedValue({
+      results: [hit],
+      count: 1,
+    });
+
+    const { controller } = makeSwipeController();
+    render(<ContinuousChatOverlay controller={controller} />);
+    openSheet();
+
+    fireEvent.click(screen.getByTestId("chat-full-search"));
+    const input = screen.getByTestId("message-search-input");
+    fireEvent.change(input, { target: { value: "budget" } });
+
+    // The debounced (250ms) search calls the real client method and lists the
+    // ranked snippet result.
+    const result = await waitFor(() =>
+      screen.getByTestId("message-search-result"),
+    );
+    expect(client.searchConversationMessages).toHaveBeenCalledWith(
+      "budget",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result.textContent).toContain("budget");
+
+    // Selecting the hit jumps to its conversation (the real jump plumbing) and
+    // closes the panel.
+    fireEvent.click(result);
+    expect(selectSpy).toHaveBeenCalledWith("conv-42");
+    await waitFor(() =>
+      expect(screen.queryByTestId("chat-message-search")).toBeNull(),
+    );
+  });
+
+  it("renders a distinguishable error state when the search API rejects (#14330)", async () => {
+    // Three-state rule: a rejected search must surface an error render, never a
+    // fabricated empty result.
+    vi.mocked(client.searchConversationMessages).mockRejectedValue(
+      new Error("search route 500"),
+    );
+
+    const { controller } = makeSwipeController();
+    render(<ContinuousChatOverlay controller={controller} />);
+    openSheet();
+
+    fireEvent.click(screen.getByTestId("chat-full-search"));
+    fireEvent.change(screen.getByTestId("message-search-input"), {
+      target: { value: "budget" },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("message-search-error")).toBeTruthy(),
+    );
+    // The error state is NOT the empty state — a caught failure must not read as
+    // "no matches".
+    expect(screen.queryByTestId("message-search-empty")).toBeNull();
   });
 
   it("starts a fresh thread from the header new-chat control (#14279)", () => {


### PR DESCRIPTION
Closes #14330.

## Summary

Message search is already wired into the primary chat overlay on `develop`: the header control (`chat-full-search`), in-sheet `MessageSearchPanel`, real `client.searchConversationMessages` call, and `?around=` jump plumbing shipped in #14300/#14279. This PR covers the one remaining acceptance gap for #14330: a regression test that drives the header affordance -> query -> result -> jump path.

## Change

Two integration tests are added to `ContinuousChatOverlay.test.tsx`:

1. Header search -> query -> jump: opens the sheet and search panel, types `budget`, asserts the debounced call uses `client.searchConversationMessages(query, { signal })`, renders a ranked `ConversationMessageSearchResult`, clicks it, and verifies the real overlay jump collaborators fire: `handleSelectConversation("conv-42")`, `loadConversationMessagesAround("conv-42", "m-hit")`, and `scrollIntoView({ block: "center", behavior: "smooth" })`.
2. Three-state rule: a rejected search renders `message-search-error` and not `message-search-empty`, so a caught failure never masquerades as no matches.

The test seeds AppContext through `__setAppValueForTests` and resets the store/client/scroll spy after each test so the assertions do not leak across the large overlay suite.

## Proof

```text
bun run --cwd packages/ui test -- ContinuousChatOverlay.test.tsx -t "search"
  4 passed | 147 skipped

bun run --cwd packages/ui test -- ContinuousChatOverlay.test.tsx
  151 passed

bunx @biomejs/biome check packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
  clean
```

## Scope

No production source or pixel output changes in this PR. The existing overlay search UI and cross-thread jump behavior were already present on `develop`; this PR makes that path mechanically guarded.

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: `N/A - test-only PR; no production UI or pixel output changes in this branch. The search UI being guarded already shipped in #14300/#14279`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: `N/A - test-only PR; no production UI or pixel output changes in this branch. Verification is the overlay integration test asserting the existing rendered search panel and jump path`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: `N/A - test-only PR with no new user-facing interaction; the guarded interaction is exercised by ContinuousChatOverlay.test.tsx`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: `N/A - jsdom integration guard uses the typed client seam and real search response shape; it does not start the agent HTTP server`.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [local test output summarized above](https://github.com/elizaOS/eliza/pull/14463) shows the focused search slice and full overlay suite passing; no browser runtime is started for this test-only PR.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: `N/A - no agent, prompt, planner, model, or tool-call path is touched`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: `N/A - no persisted memory, scheduled task, wallet, chain, DB, or connector artifact is produced`.
