### PR TITLE
fix(#14331): pulse the overlay mic while capture is hot + balance composer icons

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -529,6 +529,74 @@ describe("ContinuousChatOverlay", () => {
     expect(grabber.className).toContain("before:bottom-0");
   });
 
+  // #14331: the overlay mic must pulse whenever a live capture is hot, so its
+  // motion agrees with the accent color (previously it only recolored, never
+  // pulsed, while every sibling surface pulsed). Reduced-motion falls back to the
+  // static accent. The pill/grabber pulse already shipped; pin it here.
+  describe("mic + pill pulse while capture is hot (#14331)", () => {
+    it("does not pulse the mic while idle (neutral resting, no motion)", () => {
+      render(<ContinuousChatOverlay controller={makeController()} />);
+      const mic = screen.getByTestId("chat-composer-mic");
+      expect(mic.className).not.toContain("animate-pulse");
+      expect(mic.className).not.toContain("text-accent");
+    });
+
+    it.each([
+      ["recording", { recording: true }],
+      ["hands-free", { handsFree: true }],
+      ["transcribing", { transcriptionMode: true }],
+    ] as const)("pulses the accent mic while %s", (_label, override) => {
+      render(<ContinuousChatOverlay controller={makeController(override)} />);
+      const mic = screen.getByTestId("chat-composer-mic");
+      expect(mic.className).toContain("animate-pulse");
+      expect(mic.className).toContain("motion-reduce:animate-none");
+      expect(mic.className).toContain("text-accent");
+    });
+
+    it("drops the pulse the moment the capture predicate clears", () => {
+      const { rerender } = render(
+        <ContinuousChatOverlay
+          controller={makeController({ recording: true })}
+        />,
+      );
+      expect(screen.getByTestId("chat-composer-mic").className).toContain(
+        "animate-pulse",
+      );
+      rerender(
+        <ContinuousChatOverlay
+          controller={makeController({ recording: false })}
+        />,
+      );
+      expect(screen.getByTestId("chat-composer-mic").className).not.toContain(
+        "animate-pulse",
+      );
+    });
+
+    it("pulses the collapsed pill bar only while listening (regression guard)", () => {
+      const { rerender } = render(
+        <ContinuousChatOverlay controller={makeController()} />,
+      );
+      const sheet = screen.getByTestId("chat-sheet");
+      const barOf = () =>
+        screen.getByTestId("chat-pill").querySelector("span")?.className ?? "";
+      expect(barOf()).not.toContain("animate-pulse");
+      expect(barOf()).toContain("bg-muted-strong");
+      rerender(
+        <ContinuousChatOverlay
+          controller={makeController({ phase: "listening", recording: true })}
+        />,
+      );
+      const grabber = screen.getByTestId("chat-sheet-grabber");
+      fireEvent.pointerDown(grabber, { clientY: 200, pointerId: 1 });
+      fireEvent.pointerMove(grabber, { clientY: 380, pointerId: 1 });
+      fireEvent.pointerUp(grabber, { clientY: 380, pointerId: 1 });
+      expect(sheet.getAttribute("data-detent")).toBe("pill");
+      expect(barOf()).toContain("animate-pulse");
+      expect(barOf()).toContain("bg-accent");
+      expect(barOf()).toContain("motion-reduce:animate-none");
+    });
+  });
+
   it("toggles the sheet open and closed on repeated grabber taps", () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
     const sheet = screen.getByTestId("chat-sheet");
@@ -832,6 +900,8 @@ describe("ContinuousChatOverlay", () => {
     const mic = screen.getByTestId("chat-composer-mic");
     expect(mic.getAttribute("aria-pressed")).toBe("true");
     expect(mic.className).toContain("text-accent");
+    expect(mic.className).toContain("animate-pulse");
+    expect(mic.className).toContain("motion-reduce:animate-none");
     expect(mic.className).not.toMatch(/bg-white/);
     expect(mic.className).not.toMatch(/\bborder\b/);
   });

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -116,7 +116,6 @@ import {
   deriveChannelTopics,
   groupMessagesByTopic,
   hasMultipleTopicGroups,
-  humanizeTopicLabel,
 } from "./topic-grouping";
 import { type PullGestureBinding, usePullGesture } from "./use-pull-gesture";
 import { usePromptSuggestions } from "./usePromptSuggestions";
@@ -331,6 +330,7 @@ function SoftButton({
   onPointerLeave,
   disabled,
   active,
+  pulse,
   testId,
 }: {
   /** A hand-drawn SVG path glyph (legacy), OR pass `icon` for a lucide icon. */
@@ -344,6 +344,8 @@ function SoftButton({
   onPointerLeave?: React.PointerEventHandler<HTMLButtonElement>;
   disabled?: boolean;
   active?: boolean;
+  /** Breathe the accent glyph while a live capture is hot. */
+  pulse?: boolean;
   testId?: string;
 }): React.JSX.Element {
   return (
@@ -370,13 +372,18 @@ function SoftButton({
         // blue.
         "grid h-11 w-11 shrink-0 place-items-center bg-transparent p-0 transition-colors hover:bg-transparent",
         active ? "text-accent" : "text-muted-strong hover:text-txt",
+        // Pulse the accent glyph while capture is hot; reduced-motion falls back
+        // to the static accent without adding background or border chrome.
+        pulse && "animate-pulse motion-reduce:animate-none",
         disabled && "opacity-40",
       )}
     >
       {Icon ? (
         <Icon className="h-[26px] w-[26px]" aria-hidden={true} />
       ) : glyph ? (
-        <Glyph d={glyph} className="h-[30px] w-[30px]" />
+        // Hand-drawn glyphs fill their 36-unit box, so 24px balances their
+        // optical weight against the padded lucide mic/send marks.
+        <Glyph d={glyph} className="h-[24px] w-[24px]" />
       ) : null}
     </Button>
   );
@@ -4735,6 +4742,7 @@ export function ContinuousChatOverlay({
                       // the composer while onboarding is choice-driven.
                       disabled={firstRunOpen}
                       active={recording || handsFree || transcriptionMode}
+                      pulse={recording || handsFree || transcriptionMode}
                       onClick={handleMicClick}
                       onPointerDown={micHoldHandlers.onPointerDown}
                       onPointerUp={micHoldHandlers.onPointerUp}


### PR DESCRIPTION
Closes #14331.

## What & why
The overlay mic users press on the primary chat surface only turned accent-colored while recording; sibling surfaces (grabber, pill, kiosk composer, HomePill) also pulse. This makes color and motion agree and fixes the minor optical mismatch where the hand-drawn `+` glyph rendered heavier than the mic/send icons.

## Changes
- `SoftButton` gains a scoped `pulse` prop: `animate-pulse motion-reduce:animate-none`, accent only, no background/border, no blue.
- The mic uses the same `recording || handsFree || transcriptionMode` predicate for `pulse` that already drives `active`.
- Hand-drawn glyphs render at 24px instead of 30px so `+`, stop, mic, and send read closer in optical weight. The 44x44 hit target is unchanged.
- Removed an unused import in the touched overlay file.

## Verification
- `bun run --cwd packages/ui test -- src/components/shell/ContinuousChatOverlay.test.tsx` -> 155 tests passed.
- `bunx @biomejs/biome check packages/ui/src/components/shell/ContinuousChatOverlay.tsx packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx` -> clean.
- `git diff --check -- packages/ui/src/components/shell/ContinuousChatOverlay.tsx packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx` -> clean.
- Browser fixture capture: `node packages/ui/src/components/shell/__e2e__/capture-mic-optics.mjs` -> idle/recording/draft assertions passed.
- Reduced-motion browser check -> `motion-reduce:animate-none` present and computed `animationName=none` under `prefers-reduced-motion: reduce`.

## Screenshot / OCR / color evidence
Generated from the real `ContinuousChatOverlay` chat-sheet fixture in `packages/ui/src/components/shell/__e2e__/output/` and reviewed manually:

- `optics-idle-plus-mic.png`: idle composer shows `+`, `Ask Eliza`, mic; no pulse class. OCR `+ AskEliza C0)`. `orange_fraction=0.9666`, `blue_fraction=0`.
- `optics-recording-mic-pulse.png`: recording composer shows `+`, transcribe control, mic; mic has `animate-pulse motion-reduce:animate-none text-accent`. OCR `+ AskEliza i) C0)`. `orange_fraction=0.9639`, `blue_fraction=0`.
- `optics-draft-plus-send.png`: draft state shows `+`, text, send arrow; glyph optical weight is balanced. OCR `+ remind me to call the pharmacy at 5 >`. `orange_fraction=0.9533`, `blue_fraction=0`.
- `optics-recording-reduced-motion.png`: full mobile screenshot under reduced motion shows the same sparse composer controls; computed style proves no animation. OCR reads the workspace copy correctly. `orange_fraction=0.9753`, `blue_fraction=0`.
- `optics-recording-mic-pulse.mp4`: MP4 walkthrough generated from the fixture recording state.

Note: GitHub REST does not support uploading local binary attachments into PR comments, so the generated artifacts are referenced by exact local paths and summarized with OCR/color metrics here. The verification values above are copied from the captured artifacts, not inferred from code.

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots `N/A - visual before state is described by the issue; PR captures after states and class-level regression tests. No pre-change browser run retained after branch was already pushed.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `packages/ui/src/components/shell/__e2e__/output/optics-idle-plus-mic.png`, `optics-recording-mic-pulse.png`, `optics-draft-plus-send.png`, `optics-recording-reduced-motion.png`; manually reviewed and OCR/color summarized above.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `packages/ui/src/components/shell/__e2e__/output/optics-recording-mic-pulse.mp4`; generated and reviewed locally.
<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - presentation-only UI class/glyph change; no backend path changed`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - isolated fixture has no network path; browser assertions and screenshots exercise the rendered frontend state`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - no DB/memory/scheduled-task/wallet/file artifacts produced`.