### PR TITLE
fix(cloud): restart agent after scoped credit top-up

### DIFF
--- a/packages/cloud/api/__tests__/stripe-event-waifu.test.ts
+++ b/packages/cloud/api/__tests__/stripe-event-waifu.test.ts
@@ -9,6 +9,8 @@ const addCredits = mock(async () => ({ newBalance: 8.25 }));
 const getByStripeInvoiceId = mock(async () => null);
 const createInvoice = mock(async () => undefined);
 const calculateRevenueSplits = mock(async () => ({ splits: [] }));
+const enqueueAgentRestartOnce = mock(async () => ({ jobId: "job-restart" }));
+const triggerImmediate = mock(async () => undefined);
 
 function dbChain(rows: unknown[]) {
   return {
@@ -97,6 +99,12 @@ mock.module("@/lib/services/invoices", () => ({
 mock.module("@/lib/services/org-rate-limits", () => ({
   invalidateOrgTierCache: mock(async () => undefined),
 }));
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentRestartOnce,
+    triggerImmediate,
+  },
+}));
 mock.module("@/lib/services/redeemable-earnings", () => ({
   redeemableEarningsService: {
     addEarnings: mock(async () => undefined),
@@ -125,6 +133,9 @@ describe("stripe checkout queue waifu top-up callback", () => {
     createInvoice.mockClear();
     calculateRevenueSplits.mockClear();
     webhookFetch.mockClear();
+    enqueueAgentRestartOnce.mockClear();
+    triggerImmediate.mockClear();
+    getTransactionByStripePaymentIntent.mockImplementation(async () => null);
   });
 
   test("emits token and wallet context for agent credit top-ups", async () => {
@@ -202,5 +213,112 @@ describe("stripe checkout queue waifu top-up callback", () => {
         "X-Waifu-Webhook-Signature"
       ],
     ).toStartWith("sha256=");
+    expect(enqueueAgentRestartOnce).toHaveBeenCalledWith({
+      agentId,
+      organizationId: "agent-org",
+      userId: "agent-user",
+    });
+    expect(triggerImmediate).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not enqueue an agent restart for org-only credit top-ups", async () => {
+    const result = await processStripeEvent({
+      attempts: 1,
+      body: {
+        kind: "stripe.event",
+        eventId: "evt_org_topup",
+        eventType: "checkout.session.completed",
+        paymentIntentId: "pi_org_topup",
+        receivedAt: Date.now(),
+        event: {
+          id: "evt_org_topup",
+          type: "checkout.session.completed",
+          data: {
+            object: {
+              id: "cs_org_paid",
+              payment_status: "paid",
+              amount_total: 500,
+              currency: "usd",
+              customer: "cus_org",
+              payment_intent: "pi_org_topup",
+              metadata: {
+                organization_id: "agent-org",
+                user_id: "agent-user",
+                credits: "5.00",
+                type: "custom_amount",
+              },
+            },
+          },
+        },
+      },
+    } as unknown as Parameters<typeof processStripeEvent>[0]);
+
+    expect(result).toBe("ack");
+    expect(addCredits).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "agent-org",
+        amount: 5,
+        stripePaymentIntentId: "pi_org_topup",
+      }),
+    );
+    expect(webhookFetch).not.toHaveBeenCalled();
+    expect(enqueueAgentRestartOnce).not.toHaveBeenCalled();
+    expect(triggerImmediate).not.toHaveBeenCalled();
+  });
+
+  test("retries the restart enqueue for duplicate agent top-up deliveries", async () => {
+    getTransactionByStripePaymentIntent.mockImplementationOnce(async () => ({
+      id: "existing-credit",
+    }));
+
+    const result = await processStripeEvent({
+      attempts: 2,
+      body: {
+        kind: "stripe.event",
+        eventId: "evt_agent_topup_retry",
+        eventType: "checkout.session.completed",
+        paymentIntentId,
+        receivedAt: Date.now(),
+        event: {
+          id: "evt_agent_topup_retry",
+          type: "checkout.session.completed",
+          data: {
+            object: {
+              id: "cs_agent_paid",
+              payment_status: "paid",
+              amount_total: 500,
+              currency: "usd",
+              customer: "cus_agent",
+              payment_intent: paymentIntentId,
+              metadata: {
+                organization_id: "agent-org",
+                user_id: "agent-user",
+                credits: "5.00",
+                type: "custom_amount",
+                agent_id: agentId,
+              },
+            },
+          },
+        },
+      },
+    } as unknown as Parameters<typeof processStripeEvent>[0]);
+
+    expect(result).toBe("ack");
+    expect(addCredits).not.toHaveBeenCalled();
+    expect(webhookFetch).toHaveBeenCalledTimes(1);
+    const [, init] = (webhookFetch.mock.calls[0] ?? []) as unknown as [
+      string,
+      RequestInit,
+    ];
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body.eventId).toBe(
+      `stripe:evt_agent_topup_retry:credits.topped_up:${agentId}:already_applied`,
+    );
+    expect(enqueueAgentRestartOnce).toHaveBeenCalledWith({
+      agentId,
+      organizationId: "agent-org",
+      userId: "agent-user",
+    });
+    expect(triggerImmediate).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/api/src/queue/stripe-event.ts
+++ b/packages/cloud/api/src/queue/stripe-event.ts
@@ -45,6 +45,7 @@ import { creditsService } from "@/lib/services/credits";
 import { discordService } from "@/lib/services/discord";
 import { invoicesService } from "@/lib/services/invoices";
 import { invalidateOrgTierCache } from "@/lib/services/org-rate-limits";
+import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import { redeemableEarningsService } from "@/lib/services/redeemable-earnings";
 import { referralsService } from "@/lib/services/referrals";
 import { requireStripe } from "@/lib/stripe";
@@ -281,6 +282,16 @@ async function handleCheckoutSessionCompleted(
     });
   }
 
+  if (!isAppPurchase && agentId) {
+    await enqueueAgentRestartAfterTopUp({
+      agentId,
+      organizationId,
+      userId,
+      paymentIntentId,
+      sessionId: session.id,
+    });
+  }
+
   if (isAppPurchase && appId && userId && chargeRequestId) {
     await appChargeSettlementService.markPaid({
       appId,
@@ -438,6 +449,49 @@ async function handleCheckoutSessionCompleted(
       );
     }
   }
+}
+
+async function enqueueAgentRestartAfterTopUp(params: {
+  agentId: string;
+  organizationId: string;
+  userId?: string;
+  paymentIntentId: string;
+  sessionId: string;
+}): Promise<void> {
+  if (!params.userId) {
+    logger.warn(
+      "[Stripe Queue] Agent top-up has no user_id; skipping restart enqueue",
+      {
+        agentId: params.agentId,
+        organizationId: params.organizationId,
+        paymentIntentId: params.paymentIntentId,
+        sessionId: params.sessionId,
+      },
+    );
+    return;
+  }
+
+  await provisioningJobService.enqueueAgentRestartOnce({
+    agentId: params.agentId,
+    organizationId: params.organizationId,
+    userId: params.userId,
+  });
+  void provisioningJobService.triggerImmediate().catch((err) =>
+    logger.warn(
+      "[Stripe Queue] provisioning triggerImmediate nudge failed after agent top-up",
+      {
+        agentId: params.agentId,
+        organizationId: params.organizationId,
+        paymentIntentId: params.paymentIntentId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    ),
+  );
+  logger.info("[Stripe Queue] Agent restart enqueued after credit top-up", {
+    agentId: params.agentId,
+    organizationId: params.organizationId,
+    paymentIntentId: params.paymentIntentId,
+  });
 }
 
 async function notifyWaifuCreditsToppedUp(params: {


### PR DESCRIPTION
Relates to #14424.

## Summary
- enqueue an existing `agent_restart` provisioning job after an agent-scoped credit top-up is applied
- retry-safe duplicate payment handling now also ensures the restart job is present
- keep org-only top-ups from restarting agents

## Verification
- [x] `bun test packages/cloud/api/__tests__/stripe-event-waifu.test.ts`
- [x] `bun test 'packages/cloud/api/v1/agents/[agentId]/restart/route.test.ts'`
- [x] `bunx biome check packages/cloud/api/src/queue/stripe-event.ts packages/cloud/api/__tests__/stripe-event-waifu.test.ts`
- [x] `git diff --check origin/develop...HEAD`

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend payment/provisioning queue change; no UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend payment/provisioning queue change; no UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no UI or interactive frontend flow changed`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no live cloud queue/prod credentials available in this worktree; focused queue tests exercise the production handler path and restart job enqueue contract`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend code path changed or executed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent, prompt, provider, model, or action behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: [stripe-event queue test](packages/cloud/api/__tests__/stripe-event-waifu.test.ts) asserts the restart provisioning job enqueue. Live re-key of the specific Seeker agent still requires production credentials and is left visible in #14424.

## Notes
This does not claim the production Seeker instance has been re-keyed. The live operational fix remains: restart/re-key the affected agent in production after verifying the funded wallet state.
