### PR TITLE
fix(ui): UiRenderer control tap targets to 44px floor + wallet partial-funding fixture (#14399)

### DIFF
--- a/packages/ui/src/components/config-ui/__tests__/ui-renderer-tap-targets.test.tsx
+++ b/packages/ui/src/components/config-ui/__tests__/ui-renderer-tap-targets.test.tsx
@@ -1,0 +1,318 @@
+// @vitest-environment jsdom
+//
+// Tap-target floor guard for the agent-emitted UiRenderer control family
+// (#14399 device review: "buttons too small on the demo buttons view").
+//
+// These controls render inside chat / widget / dynamic-view surfaces, not at a
+// standalone `/route`, so the route-walking `tap-target-geometry-all-views`
+// Playwright gate never measured them. Pre-fix the whole button family shipped
+// at ~28-30px tall (`px-3 py-1.5 text-xs`), under the 44px HIG floor on a touch
+// device. The fix composes the shared coarse-pointer floor
+// (`pointer-coarse:min-h-touch` / `pointer-coarse:min-w-touch`, resolving to
+// `var(--min-touch-target)` = 2.75rem) onto every tappable control so touch
+// hits the floor while fine-pointer keeps the compact resting look.
+//
+// jsdom does not run layout, so this asserts the class CONTRACT that produces
+// the floor (the same convention chat-composer.tsx uses) rather than measured
+// geometry — geometry stays the Playwright gate's job. Every button-family
+// control here must carry at least the coarse-pointer height floor; standalone
+// (non-full-width) controls must also carry the width floor.
+
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { UiSpec } from "../../../config/ui-spec";
+import { __setAppValueForTests } from "../../../state/app-store";
+import { AppContext } from "../../../state/useApp";
+import { UiRenderer } from "../ui-renderer";
+
+function withApp(node: React.ReactElement) {
+  const appValue = {
+    t: (key: string, vars?: Record<string, unknown>) =>
+      String(vars?.defaultValue ?? key),
+    sendActionMessage: () => {},
+  } as never;
+  __setAppValueForTests(appValue);
+  return render(
+    React.createElement(AppContext.Provider, { value: appValue }, node),
+  );
+}
+
+const asSpec = (o: unknown) => o as unknown as UiSpec;
+
+afterEach(() => {
+  cleanup();
+  __setAppValueForTests(null);
+});
+
+const HEIGHT_FLOOR = "pointer-coarse:min-h-touch";
+const WIDTH_FLOOR = "pointer-coarse:min-w-touch";
+
+function renderSpec(spec: unknown) {
+  return withApp(
+    React.createElement(UiRenderer, { spec: asSpec(spec) }),
+  ).container;
+}
+
+describe("UiRenderer tap-target floor — standalone button-family controls", () => {
+  // Each case: a spec whose root renders exactly one control family; every
+  // <button> it produces must carry both the height AND width coarse-pointer
+  // floor (these are freestanding controls, not full-width rows).
+  const standaloneCases: Array<{ name: string; spec: unknown }> = [
+    {
+      name: "Button",
+      spec: {
+        root: "a",
+        elements: { a: { type: "Button", props: { label: "Go" } } },
+      },
+    },
+    {
+      name: "ButtonGroup",
+      spec: {
+        root: "a",
+        elements: {
+          a: {
+            type: "ButtonGroup",
+            props: {
+              statePath: "v",
+              buttons: [
+                { label: "One", value: "1" },
+                { label: "Two", value: "2" },
+              ],
+            },
+          },
+        },
+      },
+    },
+    {
+      name: "ToggleGroup",
+      spec: {
+        root: "a",
+        elements: {
+          a: {
+            type: "ToggleGroup",
+            props: {
+              statePath: "v",
+              items: [
+                { label: "A", value: "a" },
+                { label: "B", value: "b" },
+              ],
+            },
+          },
+        },
+      },
+    },
+    {
+      name: "Toggle",
+      spec: {
+        root: "a",
+        elements: {
+          a: { type: "Toggle", props: { statePath: "v", label: "Flag" } },
+        },
+      },
+    },
+    {
+      name: "Switch",
+      spec: {
+        root: "a",
+        elements: {
+          a: { type: "Switch", props: { statePath: "v", label: "On" } },
+        },
+      },
+    },
+    {
+      name: "Tabs",
+      spec: {
+        root: "a",
+        elements: {
+          a: {
+            type: "Tabs",
+            props: {
+              statePath: "v",
+              tabs: [
+                { label: "First", value: "1", content: "one" },
+                { label: "Second", value: "2", content: "two" },
+              ],
+            },
+          },
+        },
+      },
+    },
+    {
+      name: "Pagination",
+      spec: {
+        root: "a",
+        elements: {
+          a: {
+            type: "Pagination",
+            props: { statePath: "p", totalPages: 3 },
+          },
+        },
+      },
+    },
+    {
+      name: "DropdownMenu trigger",
+      spec: {
+        root: "a",
+        elements: {
+          a: {
+            type: "DropdownMenu",
+            props: {
+              label: "Menu",
+              items: [{ label: "Item", value: "i" }],
+            },
+          },
+        },
+      },
+    },
+    {
+      name: "Carousel nav",
+      spec: {
+        root: "a",
+        elements: {
+          a: {
+            type: "Carousel",
+            props: {
+              items: [
+                { title: "One", description: "first" },
+                { title: "Two", description: "second" },
+              ],
+            },
+          },
+        },
+      },
+    },
+  ];
+
+  for (const { name, spec } of standaloneCases) {
+    it(`${name}: every button carries the coarse-pointer height + width floor`, () => {
+      const container = renderSpec(spec);
+      const buttons = Array.from(container.querySelectorAll("button"));
+      expect(buttons.length).toBeGreaterThan(0);
+      for (const btn of buttons) {
+        expect(btn.className).toContain(HEIGHT_FLOOR);
+        expect(btn.className).toContain(WIDTH_FLOOR);
+      }
+    });
+  }
+});
+
+describe("UiRenderer tap-target floor — full-width row controls (height floor only)", () => {
+  // Collapsible / Accordion headers and DropdownMenu items are full-width rows,
+  // so the width floor is already satisfied by the row; they only need the
+  // coarse-pointer height floor to clear 44px.
+  const rowCases: Array<{ name: string; spec: unknown }> = [
+    {
+      name: "Collapsible header",
+      spec: {
+        root: "a",
+        elements: {
+          a: {
+            type: "Collapsible",
+            props: { title: "More", defaultOpen: false },
+          },
+        },
+      },
+    },
+    {
+      name: "Accordion header",
+      spec: {
+        root: "a",
+        elements: {
+          a: {
+            type: "Accordion",
+            props: {
+              items: [{ title: "Section", content: "body" }],
+            },
+          },
+        },
+      },
+    },
+  ];
+
+  for (const { name, spec } of rowCases) {
+    it(`${name}: header button carries the coarse-pointer height floor`, () => {
+      const container = renderSpec(spec);
+      const buttons = Array.from(container.querySelectorAll("button"));
+      expect(buttons.length).toBeGreaterThan(0);
+      for (const btn of buttons) {
+        expect(btn.className).toContain(HEIGHT_FLOOR);
+      }
+    });
+  }
+
+  it("DropdownMenu items carry the coarse-pointer height floor when open", () => {
+    const container = renderSpec({
+      root: "a",
+      elements: {
+        a: {
+          type: "DropdownMenu",
+          props: {
+            label: "Menu",
+            items: [
+              { label: "First", value: "1" },
+              { label: "Second", value: "2" },
+            ],
+          },
+        },
+      },
+    });
+    const trigger = container.querySelector("button");
+    expect(trigger).toBeTruthy();
+    act(() => {
+      fireEvent.click(trigger as HTMLButtonElement);
+    });
+    const buttons = Array.from(container.querySelectorAll("button"));
+    // trigger + 2 items
+    expect(buttons.length).toBe(3);
+    for (const btn of buttons) {
+      expect(btn.className).toContain(HEIGHT_FLOOR);
+    }
+  });
+});
+
+describe("UiRenderer tap-target floor — accessible names on icon-only controls", () => {
+  it("Dialog close, Pagination arrows, and Carousel arrows expose an accessible name", () => {
+    const dialog = renderSpec({
+      root: "a",
+      elements: {
+        a: {
+          type: "Dialog",
+          props: { openPath: "open", title: "Hi" },
+          children: [],
+        },
+      },
+      state: { open: true },
+    });
+    const close = dialog.querySelector('button[aria-label="Close dialog"]');
+    expect(close).toBeTruthy();
+
+    const pager = renderSpec({
+      root: "a",
+      elements: {
+        a: { type: "Pagination", props: { statePath: "p", totalPages: 3 } },
+      },
+    });
+    expect(pager.querySelector('button[aria-label="Previous page"]')).toBeTruthy();
+    expect(pager.querySelector('button[aria-label="Next page"]')).toBeTruthy();
+
+    const carousel = renderSpec({
+      root: "a",
+      elements: {
+        a: {
+          type: "Carousel",
+          props: {
+            items: [
+              { title: "One", description: "first" },
+              { title: "Two", description: "second" },
+            ],
+          },
+        },
+      },
+    });
+    expect(
+      carousel.querySelector('button[aria-label="Previous item"]'),
+    ).toBeTruthy();
+    expect(carousel.querySelector('button[aria-label="Next item"]')).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/config-ui/ui-renderer.tsx
+++ b/packages/ui/src/components/config-ui/ui-renderer.tsx
@@ -224,6 +224,22 @@ const JUSTIFY: Record<string, string> = {
 // COMPONENT REGISTRY
 // ══════════════════════════════════════════════════════════════════════
 
+/**
+ * Coarse-pointer tap-target floor for the agent-emitted UiRenderer controls
+ * (#14399 device review: "buttons too small on the demo buttons view").
+ *
+ * These controls render inside chat/widget/dynamic-view surfaces, NOT at a
+ * standalone `/route`, so the route-walking `tap-target-geometry-all-views`
+ * Playwright gate never measured them — the whole button family here ships at
+ * ~28-30px tall (`px-3 py-1.5 text-xs`), well under the 44px HIG floor on a
+ * touch device. Compose the shared `min-h-touch`/`min-w-touch`
+ * (`var(--min-touch-target)` = 2.75rem) floor ONLY on coarse pointers so touch
+ * hits the floor while fine-pointer (desktop mouse) keeps the compact resting
+ * look — same convention as `chat-composer.tsx` and the spatial button rule in
+ * `base.css`. Applied to every tappable control below.
+ */
+const TAP_FLOOR = "pointer-coarse:min-h-touch pointer-coarse:min-w-touch";
+
 type ComponentFn = (
   props: Record<string, unknown>,
   children: React.ReactNode,
@@ -518,7 +534,9 @@ const SwitchComponent: ComponentFn = (props, _children, ctx) => {
       <Button
         type="button"
         variant="ghost"
-        className={`relative w-9 h-[18px] p-0 transition-colors rounded-none ${checked ? "bg-accent" : "bg-muted"}`}
+        role="switch"
+        aria-checked={checked}
+        className={`relative w-9 h-[18px] p-0 transition-colors rounded-none ${TAP_FLOOR} ${checked ? "bg-accent" : "bg-muted"}`}
         onClick={() => setValue(!checked)}
       >
         <div
@@ -567,7 +585,7 @@ const ToggleComponent: ComponentFn = (props, _children, ctx, el) => {
     <Button
       type="button"
       variant={pressed ? "default" : "outline"}
-      className={`px-3 py-1.5 text-xs transition-colors ${
+      className={`px-3 py-1.5 text-xs transition-colors ${TAP_FLOOR} ${
         pressed
           ? "bg-accent text-accent-fg border-accent"
           : "bg-card text-txt hover:bg-[var(--bg-hover)]"
@@ -613,7 +631,7 @@ const ToggleGroupComponent: ComponentFn = (props, _children, ctx) => {
             key={item.value}
             type="button"
             variant={active ? "default" : "outline"}
-            className={`px-2.5 py-1 text-xs transition-colors ${
+            className={`px-2.5 py-1 text-xs transition-colors ${TAP_FLOOR} ${
               active
                 ? "bg-accent text-accent-fg border-accent"
                 : "bg-card text-txt hover:bg-[var(--bg-hover)]"
@@ -644,7 +662,7 @@ const ButtonGroupComponent: ComponentFn = (props, _children, ctx) => {
             key={btn.value}
             type="button"
             variant={active ? "default" : "outline"}
-            className={`px-3 py-1.5 text-xs transition-colors ${
+            className={`px-3 py-1.5 text-xs transition-colors ${TAP_FLOOR} ${
               active
                 ? "bg-accent text-accent-fg border-accent"
                 : "bg-card text-txt hover:bg-[var(--bg-hover)]"
@@ -722,7 +740,8 @@ const CarouselComponent: ComponentFn = (props) => {
           type="button"
           variant="outline"
           size="sm"
-          className="text-xs px-2 py-0.5"
+          aria-label="Previous item"
+          className={`text-xs px-2 py-0.5 ${TAP_FLOOR}`}
           onClick={() => setCurrent((p) => Math.max(0, p - 1))}
           disabled={current === 0}
         >
@@ -735,7 +754,8 @@ const CarouselComponent: ComponentFn = (props) => {
           type="button"
           variant="outline"
           size="sm"
-          className="text-xs px-2 py-0.5"
+          aria-label="Next item"
+          className={`text-xs px-2 py-0.5 ${TAP_FLOOR}`}
           onClick={() => setCurrent((p) => Math.min(items.length - 1, p + 1))}
           disabled={current === items.length - 1}
         >
@@ -941,7 +961,7 @@ const ButtonComponent: ComponentFn = (props, _children, ctx, el) => {
               ? "outline"
               : "default"
       }
-      className={`px-3 py-1.5 text-xs font-medium transition-colors ${cls[variant] ?? cls.primary}`}
+      className={`px-3 py-1.5 text-xs font-medium transition-colors ${TAP_FLOOR} ${cls[variant] ?? cls.primary}`}
       disabled={!!props.disabled}
       onClick={() => fireEvent(el.on?.press, ctx)}
     >
@@ -980,7 +1000,7 @@ const DropdownMenuComponent: ComponentFn = (props, _children, ctx) => {
         type="button"
         variant="outline"
         size="sm"
-        className="px-3 py-1.5 text-xs"
+        className={`px-3 py-1.5 text-xs ${TAP_FLOOR}`}
         onClick={() => setOpen(!open)}
       >
         {String(props.label ?? "Menu")} ▾
@@ -992,7 +1012,7 @@ const DropdownMenuComponent: ComponentFn = (props, _children, ctx) => {
               key={item.value}
               type="button"
               variant="ghost"
-              className="block w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--bg-hover)] rounded-none justify-start h-auto"
+              className="block w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--bg-hover)] rounded-none justify-start h-auto pointer-coarse:min-h-touch"
               onClick={() => {
                 setOpen(false);
                 if (ctx.onAction)
@@ -1029,7 +1049,9 @@ const TabsComponent: ComponentFn = (props, _children, ctx) => {
             key={tab.value}
             type="button"
             variant="ghost"
-            className={`px-3 py-1.5 text-xs rounded-none transition-colors h-auto ${
+            role="tab"
+            aria-selected={tab.value === active}
+            className={`px-3 py-1.5 text-xs rounded-none transition-colors h-auto ${TAP_FLOOR} ${
               tab.value === active
                 ? "border-b-2 border-accent text-accent font-semibold"
                 : "text-muted hover:text-txt"
@@ -1058,7 +1080,8 @@ const PaginationComponent: ComponentFn = (props, _children, ctx) => {
         type="button"
         variant="outline"
         size="sm"
-        className="px-2 py-1 text-xs disabled:opacity-40"
+        aria-label="Previous page"
+        className={`px-2 py-1 text-xs disabled:opacity-40 ${TAP_FLOOR}`}
         disabled={current <= 1}
         onClick={() => setValue(current - 1)}
       >
@@ -1070,7 +1093,9 @@ const PaginationComponent: ComponentFn = (props, _children, ctx) => {
           type="button"
           variant={page === current ? "default" : "outline"}
           size="sm"
-          className={`px-2 py-1 text-xs ${
+          aria-label={`Page ${page}`}
+          aria-current={page === current ? "page" : undefined}
+          className={`px-2 py-1 text-xs ${TAP_FLOOR} ${
             page === current
               ? "bg-accent text-accent-fg border-accent"
               : "hover:bg-[var(--bg-hover)]"
@@ -1084,7 +1109,8 @@ const PaginationComponent: ComponentFn = (props, _children, ctx) => {
         type="button"
         variant="outline"
         size="sm"
-        className="px-2 py-1 text-xs disabled:opacity-40"
+        aria-label="Next page"
+        className={`px-2 py-1 text-xs disabled:opacity-40 ${TAP_FLOOR}`}
         disabled={current >= total}
         onClick={() => setValue(current + 1)}
       >
@@ -1278,7 +1304,8 @@ const CollapsibleComponent: ComponentFn = (props, children) => {
       <Button
         type="button"
         variant="ghost"
-        className="w-full flex items-center gap-2 px-3 py-2 text-xs font-semibold hover:bg-[var(--bg-hover)] transition-colors rounded-none justify-start h-auto"
+        aria-expanded={open}
+        className="w-full flex items-center gap-2 px-3 py-2 text-xs font-semibold hover:bg-[var(--bg-hover)] transition-colors rounded-none justify-start h-auto pointer-coarse:min-h-touch"
         onClick={() => setOpen(!open)}
       >
         <span
@@ -1316,7 +1343,8 @@ const AccordionComponent: ComponentFn = (props) => {
           <Button
             type="button"
             variant="ghost"
-            className="w-full flex items-center gap-2 px-3 py-2 text-xs font-semibold hover:bg-[var(--bg-hover)] rounded-none justify-start h-auto"
+            aria-expanded={openSet.has(i)}
+            className="w-full flex items-center gap-2 px-3 py-2 text-xs font-semibold hover:bg-[var(--bg-hover)] rounded-none justify-start h-auto pointer-coarse:min-h-touch"
             onClick={() => toggle(i)}
           >
             <span
@@ -1374,7 +1402,8 @@ const DialogComponent: ComponentFn = (props, children, ctx) => {
             type="button"
             variant="ghost"
             size="icon"
-            className="text-muted hover:text-txt text-lg leading-none px-1 h-auto w-auto"
+            aria-label="Close dialog"
+            className={`text-muted hover:text-txt text-lg leading-none px-1 h-auto w-auto ${TAP_FLOOR}`}
             onClick={close}
           >
             ×

--- a/plugins/plugin-wallet-ui/src/components/InventoryAppView.gui.test.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventoryAppView.gui.test.tsx
@@ -381,6 +381,46 @@ describe("InventoryView GUI — populated holdings", () => {
     expect(within(sidebar).getByText("So1an...1111")).toBeTruthy();
   });
 
+  it("renders a partially-funded portfolio: EVM holdings present, Solana connected but zero balance (#14384)", async () => {
+    // The exact state the wallet lands in when funds arrive on ONE chain first:
+    // EVM has real token balances, Solana is connected + balance-ready but holds
+    // nothing. This must render the funded EVM rows AND a portfolio total that
+    // reflects only the funded side (750 BNB + 100 USDC + 80 CAKE = 930), not
+    // the empty-wallet hero. Locks the mixed render in before real funds land so
+    // the UI is already proven for the first-funded-chain case.
+    const partialBalances: WalletBalancesResponse = {
+      evm: balances.evm,
+      solana: {
+        address: SOL_ADDRESS,
+        solBalance: "0",
+        solValueUsd: "0",
+        tokens: [],
+      },
+    };
+    appHooks.useApp.mockReturnValue(
+      makeAppState({
+        walletBalances: partialBalances,
+        walletNfts: { evm: nfts.evm, solana: null },
+      }),
+    );
+    render(React.createElement(InventoryAppView));
+    const sidebar = await screen.findByTestId("wallets-sidebar");
+
+    // Funded EVM side still renders its rows + values.
+    expect(within(sidebar).getByText(hasFlatText("100.0000 USDC"))).toBeTruthy();
+    expect(within(sidebar).getByText("$750.00")).toBeTruthy();
+    expect(within(sidebar).getByText("$80.00")).toBeTruthy();
+
+    // Portfolio total reflects only the funded EVM side (no Solana value).
+    expect(within(sidebar).getByText("$930.00")).toBeTruthy();
+
+    // Both chains connected/ready — this is a funded portfolio, not the empty
+    // hero, so the "Your wallet is empty." line must not appear.
+    expect(within(sidebar).getByTitle("EVM ready")).toBeTruthy();
+    expect(within(sidebar).getByTitle("SOL ready")).toBeTruthy();
+    expect(screen.queryByText("Your wallet is empty.")).toBeNull();
+  });
+
   it("shows needs-RPC chip when a chain balance is not ready", async () => {
     appHooks.useApp.mockReturnValue(
       makeAppState({


### PR DESCRIPTION
## What

Review-sweep for #14399 (device review rollup #14317, shad0w + shaw session). Lands the **code side** of the three findings; cross-links the open split issues.

### 1. Demo/buttons tap targets → **fixed** (#14380)
Root cause: the "demo buttons view" is the agent-emitted **`UiRenderer`** (`packages/ui/src/components/config-ui/ui-renderer.tsx`). Its whole button family shipped at `px-3 py-1.5 text-xs` (~28-30px), under the 44px HIG floor on touch.

**Why the audit missed it:** the `tap-target-geometry-all-views` Playwright gate walks standalone `/routes` (`VIEW_ROUTES`) and **never measures this renderer** — it renders *inside* chat / widget / dynamic-view surfaces, not at a route. So the sub-44 controls stayed green.

**Fix:** compose the shared coarse-pointer floor (`pointer-coarse:min-h-touch` / `pointer-coarse:min-w-touch` = `var(--min-touch-target)` 2.75rem — the same convention `chat-composer.tsx` and the spatial-button rule in `base.css` already use) onto every tappable control: Button, ButtonGroup, ToggleGroup, Toggle, Switch, Tabs, Pagination, DropdownMenu, Carousel, Collapsible/Accordion headers, Dialog close. Full-width rows get the height floor only (width is already full). Fine-pointer (desktop mouse) keeps the compact resting look.

Also added the missing `aria-label` / `role="switch"|"tab"` / `aria-selected` / `aria-checked` / `aria-expanded` on icon-only + stateful controls, so they satisfy the same role/DOM-coherence contract the geometry gate enforces.

New vitest **`ui-renderer-tap-targets.test.tsx`** (13 tests): every button-family control carries the floor class contract; icon-only controls expose an accessible name. jsdom has no layout, so the class contract is the guard here — measured geometry stays the Playwright gate's job.

### 2. Wallet render states → **verified + fixture added** (#14384)
`InventoryAppView.gui.test.tsx` already covers funded / partial (needs-RPC per chain) / error (J4 unavailable + thrown fetch) / empty (calm hero). Added a **partially-funded** fixture — EVM holdings present, Solana connected but zero balance (the first-funded-chain state) — so the mixed-portfolio render (funded rows + a portfolio total that excludes the empty chain, no empty-hero) is proven **before** real funds land.

**Funding the test wallet stays `needs-human`** (@wakesync) — that half of #14384 is out of scope here; only the code/test side lands. #14384 stays open for the funding step.

### 3. Settings resets → **skipped** (#14386)
Already claimed by @lalalune (draft PR #14421 removes the `AdvancedSection` reset controls). No overlap; deferring to that lane.

## Verification
- `bunx vitest run` — `ui-renderer-tap-targets.test.tsx` **13/13**, `configui-stories-smoke` **21/21**, `MessageContent.uispec-crash` **2/2**, `InventoryAppView.gui.test.tsx` **17/17** — all green (post-rebase onto develop).
- `bun run build:client` — **104/104 turbo tasks, vite client built (9448 modules, 788 assets), exit 0.**
- Tokens only, no hex, no new icon imports, no new audit-gate violations. Rebased clean onto current develop.
- codex review exceeded 100s exploring repo context without converging (known VPS pattern) → killed + self-reviewed: pure additive CSS-utility + a11y-attribute patch, no logic/state/dep changes.

Fixes #14399 (wallet-funding item stays open as needs-human on #14384).

— [sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>
