### PR TITLE
fix(app): run MVP visual verifier in strict mode

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -30,7 +30,7 @@
     "audit:app:minimalism:update": "bun scripts/update-minimalism-baseline.mjs",
     "mvp:visual-verify": "node scripts/mvp-visual-verify.mjs",
     "mvp:visual-verify:overflow-demo": "node scripts/mvp-visual-verify/overflow-invariant-demo.mjs",
-    "audit:app:verify": "bun run audit:app && bun run mvp:visual-verify",
+    "audit:app:verify": "bun run audit:app && bun run mvp:visual-verify -- --strict",
     "audit:views": "node scripts/audit-views-soak.mjs",
     "audit:ocr": "bun scripts/ocr-triage.ts --audit-dir aesthetic-audit-output --baseline test/ui-smoke/ocr-triage-baseline.json",
     "test:desktop:packaged": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts",


### PR DESCRIPTION
# Relates to

Follow-up to #14437.

# What Changed

`audit:app:verify` now runs `mvp:visual-verify -- --strict` instead of the non-strict reporter mode.

# Why

#14437 added the strict visual verifier and its OCR/palette/diff/expectation layer, but the package-level verification script still invoked the non-strict command. That meant skipped expectation checks or first-run baselines could stay advisory when the command name says “verify”. For MVP QA, unknown evidence must be visibly red rather than quietly review-only.

# Validation

```text
bun run --cwd packages/app test -- test/audit/mvp-visual-verify.test.ts
Test Files  1 passed (1)
Tests       21 passed (21)
```

```text
bun run --cwd packages/app mvp:visual-verify:overflow-demo
[overflow-demo] BUGGY (un-contained token):     2886px  -> INVARIANT FIRES ✓
[overflow-demo] FIXED (overflow-x:hidden+wrap): 0px  -> passes ✓
[overflow-demo] PASS — the invariant catches the regression and clears the fix
```

```text
bunx @biomejs/biome check packages/app/package.json
Checked 1 file. No fixes applied.
```

```text
git diff --check origin/develop...HEAD
passed with no output
```

# Evidence Matrix

- Real-LLM trajectory: N/A - package script wiring only; no model/action/provider behavior changed.
- Backend logs: N/A - no backend path changed.
- Frontend screenshots/video: N/A - no shipped UI changed; this makes the visual evidence command strict.
- Domain artifacts: N/A - no domain state changed.