### PR TITLE
fix(#14332): delete dead verticalScrollPriority option + filler-class slop

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -511,7 +511,6 @@ function SheetGrabber({
         // caught) and STOPS at the handle's own bottom, so it never overlaps the
         // interactive composer row beneath — taps fall through to the input.
         "before:absolute before:-inset-x-2 before:-top-6 before:bottom-0 before:content-['']",
-        "   ",
       )}
     >
       <span
@@ -587,7 +586,6 @@ function PillHandle({
         // let taps fall through to the composer textarea below it — otherwise its
         // tall hit zone steals the tap and the keyboard never opens.
         pilled ? "pointer-events-auto" : "pointer-events-none",
-        "   ",
       )}
     >
       <span
@@ -3840,7 +3838,6 @@ export function ContinuousChatOverlay({
             className={cn(
               "pointer-events-auto h-auto gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
               "border-warn/40 bg-warn/15 text-warn hover:bg-warn/25",
-              "  ",
               FLOAT_SHADOW,
             )}
           >
@@ -3898,7 +3895,6 @@ export function ContinuousChatOverlay({
                 "h-auto max-w-full truncate rounded-full border border-white/15 bg-black/40 px-3 py-1.5",
                 "text-[12px] text-white/80 transition-colors",
                 "hover:border-white/30 hover:bg-white/15 hover:text-white",
-                "  ",
               )}
             >
               {s}

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -51,7 +51,6 @@ export function HomePill({
         "pointer-events-auto relative mb-3",
         // Generous tap target
         "flex h-8 w-32 items-center justify-center",
-        "    ",
         phase === "booting" && "cursor-not-allowed opacity-60",
       )}
     >

--- a/packages/ui/src/components/shell/use-pull-gesture.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.ts
@@ -72,19 +72,6 @@ export interface PullGestureOptions {
   distanceThresholdX?: number;
   /** Minimum horizontal speed (px/ms) to count as a swipe flick. Default 0.4. */
   velocityThresholdX?: number;
-  /**
-   * Bias axis commitment toward VERTICAL for a binding that shares a surface
-   * with a native vertical scroller (the conversation transcript, #8929). When
-   * true, the MID-gesture X commit requires horizontal to STRICTLY dominate
-   * (`ax > ay`, not the widened 0.8 cone) and defers the X capture until a
-   * larger horizontal slop is crossed — so a real thumb SCROLL (whose first few
-   * px are usually a little diagonal) is never mistaken for a horizontal swipe,
-   * captured, and blocked from scrolling natively (the "can't scroll chat on
-   * mobile web" bug, #chat-scroll-web). Release-time swipe recognition is
-   * unchanged, so a deliberate horizontal flick still navigates. Default false
-   * keeps the grabber/home rail on the widened cone (#10715).
-   */
-  verticalScrollPriority?: boolean;
 }
 
 /** Movement (px) under which a release is treated as a tap, not a drag. Exported
@@ -92,14 +79,6 @@ export interface PullGestureOptions {
  *  from the same press) use the SAME tap definition as the gesture engine — see
  *  the HomeScreen notification pull zone. Aliases the shared {@link TAP_SLOP}. */
 export const PULL_GESTURE_TAP_SLOP = TAP_SLOP;
-
-/**
- * Larger axis-commit slop used when {@link PullGestureOptions.verticalScrollPriority}
- * is set: the binding waits for a clearer horizontal intent before it commits
- * (and captures) the X axis, so the browser's native vertical pan owns the first
- * frames of a thumb scroll on the shared transcript surface (#chat-scroll-web).
- */
-const AXIS_COMMIT_SLOP_SCROLL_SAFE = 16;
 
 export { resolvePull, resolveSwipe };
 
@@ -135,15 +114,7 @@ export function usePullGesture(
     velocityThreshold = DEFAULT_PULL_VELOCITY,
     distanceThresholdX = DEFAULT_SWIPE_DISTANCE,
     velocityThresholdX = DEFAULT_SWIPE_VELOCITY,
-    verticalScrollPriority = false,
   } = options;
-
-  // On a scroll-priority surface the mid-gesture X commit needs a clearer
-  // horizontal intent (larger slop + strict dominance) so a thumb SCROLL is
-  // never captured as a swipe; release-time recognition is unchanged.
-  const midCommitSlop = verticalScrollPriority
-    ? AXIS_COMMIT_SLOP_SCROLL_SAFE
-    : AXIS_COMMIT_SLOP;
 
   const hasSwipe =
     swipeEnabled && Boolean(onSwipeLeft || onSwipeRight || onDragX);
@@ -228,19 +199,7 @@ export function usePullGesture(
         // swipe, a deliberate diagonal (horizontal ≥ 0.8× vertical) commits the
         // X axis. A strict ax > ay would re-narrow the cone to 45° at the first
         // 8px of travel.
-        //
-        // EXCEPTION — `verticalScrollPriority` (the transcript, #chat-scroll-web):
-        // the surface is ALSO a native vertical scroller, so a mid-gesture X
-        // commit here would capture the pointer and BLOCK the scroll. Pass
-        // canSwipe=false so horizontal must STRICTLY dominate (`ax > ay`) and a
-        // mostly-vertical thumb scroll stays on the Y axis (uncaptured → native
-        // scroll wins); release-time recognition still lands a deliberate flick.
-        const committed = commitAxis(
-          dx,
-          dy,
-          midCommitSlop,
-          hasSwipe && !verticalScrollPriority,
-        );
+        const committed = commitAxis(dx, dy, AXIS_COMMIT_SLOP, hasSwipe);
         if (committed !== null) {
           axis.current = committed;
           // Take over the pointer now that intent is clear (deferred-capture path).
@@ -278,16 +237,7 @@ export function usePullGesture(
         scheduleDrag("y", dy); // pre-commit: drive the vertical sheet
       }
     },
-    [
-      hasSwipe,
-      hasVerticalPull,
-      onDragReset,
-      onDragX,
-      scheduleDrag,
-      drag,
-      midCommitSlop,
-      verticalScrollPriority,
-    ],
+    [hasSwipe, hasVerticalPull, onDragReset, onDragX, scheduleDrag, drag],
   );
 
   const finish = React.useCallback(


### PR DESCRIPTION
Partially addresses #14332 (the verifiable slop-removal half). See the scope note below.

## What this PR does (fully verified)
1. **Deletes the dead `verticalScrollPriority` gesture option** from `use-pull-gesture.ts`. Grep confirms **zero consumers** — the transcript-swipe binding that once passed it was removed in #13531, so every caller has been running the `false` branch. Removed: the option + JSDoc, the `AXIS_COMMIT_SLOP_SCROLL_SAFE` constant, the `midCommitSlop` branch, the exception comment, and the two logic sites. `commitAxis(dx, dy, AXIS_COMMIT_SLOP, hasSwipe)` is exactly what every consumer already got.
2. **Deletes five whitespace-only filler class strings** in `cn()` calls (`ContinuousChatOverlay.tsx` ×4, `HomePill.tsx` ×1) — pure no-op slop.

## Proof (behavior-neutral)
```
use-pull-gesture.test.ts        25/25 pass
ContinuousChatOverlay.test.tsx  149/149 pass
run-chat-scroll-web-e2e         ALL pass — incl:
  ✓ vertical-dominant drag WITH horizontal drift still scrolls natively (875 -> 646)
  ✓ a drift scroll did NOT trigger a conversation swipe (null -> null)
```
The last two are the exact axis-commit behavior `verticalScrollPriority` was theoretically meant to protect; they pass unchanged, proving the option was inert. Biome clean. Net −67 lines.

## ⚠️ Scope note — the issue's spec-cleanup half rests on a STALE premise
The issue says #13531 removed the clear/new-chat control. **On current `develop` that is no longer true — #14279 re-added `chat-full-clear` as the live "new chat" control** (`ContinuousChatOverlay.tsx:4199`, `RotateCcw`, delegates to `clearConversation`), with current passing tests (`ContinuousChatOverlay.test.tsx:2437-2473`). So the issue's instruction to "delete the `chat-full-clear` assertions" is wrong now — those assertions guard a real control.

What IS still stale/broken (needs the app Playwright lane, so split out — I can't boot the app here to verify a rewrite):
- `walkthrough-capture-smoke.spec.ts:242` — **unguarded** `chat-full-maximize` click; the button was removed, so this fails. Rewrite to reach `data-detent=full` via the pull gesture (mirror `run-chat-sheet-e2e.mjs:256-354`).
- `journey.ts:1015` step 09 — guarded by `isVisible()`, so it **silently no-ops** now instead of asserting. Rewrite to the pull gesture.
- `chat-thread-gestures.spec.ts:371` — asserts `chat-full-clear` **absent** (`toHaveCount(0)`), but #14279 made it present → this assertion is now wrong and should become `1` (only `chat-full-maximize` is genuinely removed).

These are flagged with precise line refs in the issue comment for whoever owns the scenario-pr / app-e2e lane.

## Evidence not applicable
- **Real-LLM trajectory / device capture** — N/A: dead-code + slop removal, no runtime agent path.
