### PR TITLE
ci(cloud): gate PRs on the Worker production bundle dry-run (#14422)

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -72,6 +72,26 @@ jobs:
       - name: Tenant-scope gate (no unscoped pk-only reads of apps data-plane) (#9853)
         run: bun run --cwd packages/cloud/shared check:tenant-scope
 
+  # The prod Worker bundles against a hand-maintained @elizaos/core stub
+  # (packages/cloud/api/src/stubs/elizaos-core.ts) because real core cannot
+  # load in workerd. Nothing else fails a PR when a newly-imported core export
+  # is missing from the stub — the break surfaces at DEPLOY time as esbuild
+  # "No matching export" errors (#14422). This job performs the exact
+  # deploy-time bundle in a canonical clean checkout, so stub drift fails the
+  # PR instead of the deploy. Local caveat from the #14432 postmortem: stale
+  # compiled .js next to packages/shared/src TS sources flips esbuild
+  # resolution and yields phantom results locally — CI's fresh checkout is the
+  # truth this job pins.
+  worker-bundle-dry-run:
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: ./.github/actions/cloud-setup-test-env
+      - name: Worker production bundle dry-run (stub-drift gate, #14422)
+        working-directory: packages/cloud/api
+        run: bunx wrangler deploy --env production --dry-run
+
   unit-tests:
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 15

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -6,7 +6,7 @@ name: Cloud Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches: [develop, main]
     paths:
       - "packages/cloud/api/**"
       - "packages/cloud/shared/**"

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches: [develop, main]
     paths:
+      - ".github/actions/cloud-setup-test-env/**"
+      - ".github/workflows/cloud-tests.yml"
       - "packages/cloud/api/**"
       - "packages/cloud/shared/**"
       - "packages/cloud/sdk/**"


### PR DESCRIPTION
Adds the CI gate recommended on #14422: run the **exact deploy-time Worker bundle** (`wrangler deploy --env production --dry-run`) on cloud-touching PRs, so a @elizaos/core export missing from the workerd stub fails the PR instead of the deploy.

## Why now — empirical correction to the post-#14432 audit
A post-merge audit claimed develop tip still fails the dry-run with 15 "No matching export in src/stubs/elizaos-core.ts" errors (10 core exports pulled via @elizaos/shared barrels from #14229). **Re-verified in a properly-installed, artifact-clean tree at tip `921d5f7698`: the dry-run is GREEN.**

<details><summary>Verification detail</summary>

- `bunx wrangler deploy --env production --dry-run` from `packages/cloud/api`: exit 0, zero esbuild errors (run twice, incl. `--outdir` inspection).
- Bundle sourcemap: the flagged shared modules (`env-utils.ts`, `config/boot-config-store.ts`, `connectors.ts`, `recent-messages-state.ts`) ARE bundled; the flagged names are NOT referenced; the only real-core module in the bundle is `security/redact.ts`; the stub IS the @elizaos/core resolution.
- The audit's failing run happened in a worktree polluted with ~800 stale compiled `.js` files next to `packages/shared/src` TS sources (build side-effects) — stale compiled barrels flip esbuild resolution and produce phantom "missing export" errors (and, inversely, could mask real ones). The audit generalized this to "fresh worktree"; a genuinely clean tree builds green.
</details>

So: **no stub mirror is needed today** — mirroring 10 unused registry/env exports into the prod Worker stub would be speculative bloat. What IS needed is this gate, which pins the canonical-clean-checkout truth on every cloud PR and catches *real* drift the moment a new core import lands (the #14422/#14432 failure class).

- New job `worker-bundle-dry-run` in `cloud-tests.yml`, same runner/setup pattern as the sibling jobs; YAML validated.
- Evidence per above (`N/A` for UI/device rows — CI-config change; the gate's own first run on this PR is the live proof).

Authored by `[maintainer]` — needs a reviewer lane (no self-merge). Refs #14422, #14432.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - CI workflow-only change; no UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - CI workflow-only change; no UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - CI workflow-only change; no interactive user flow changed`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend runtime code path changed; workflow dry-run gate validates bundle creation`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend code path changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent, prompt, provider, model, or action behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - CI workflow gate only; domain artifact is the queued worker-bundle-dry-run check on this PR`.
