### PR TITLE
fix(app): make Android e2e installs renderer-stamp fresh

### DIFF
--- a/packages/app/scripts/android-adb-install.mjs
+++ b/packages/app/scripts/android-adb-install.mjs
@@ -9,9 +9,11 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { assertAndroidApkRendererFresh } from "./lib/android-renderer-stamp.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(scriptDir, "..");
+const repoRoot = path.resolve(appRoot, "..", "..");
 
 function readFlag(name) {
   const prefix = `${name}=`;
@@ -117,6 +119,11 @@ function sha256File(filePath) {
   return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
 }
 
+function currentHeadCommit() {
+  const result = run("git", ["rev-parse", "HEAD"], { cwd: repoRoot });
+  return result.status === 0 ? result.stdout.trim() || null : null;
+}
+
 function latestApk() {
   const roots = [
     path.join(appRoot, "android", "app", "build", "outputs", "apk"),
@@ -206,6 +213,14 @@ if (apkPackage && apkPackage !== appId) {
       `You likely built the wrong brand (check repoRoot / ELIZA_ANDROID_USE_APP_DIR). Pass the matching --apk.`,
   );
 }
+
+assertAndroidApkRendererFresh({
+  apkPath,
+  repoRoot,
+  expectedCommit: currentHeadCommit(),
+  label: path.relative(process.cwd(), apkPath),
+  log: (message) => console.log(`android-adb-install: ${message}`),
+});
 
 console.log(
   `Installing ${path.relative(process.cwd(), apkPath)} (${apkPackage ?? appId}) to ${serial ?? onlineDevices[0]}`,

--- a/packages/app/scripts/android-e2e.mjs
+++ b/packages/app/scripts/android-e2e.mjs
@@ -21,6 +21,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  androidApkNeedsBuild,
   androidDistNeedsBuild,
   androidInstallDecision,
   ensureEmulatorBooted,
@@ -28,6 +29,7 @@ import {
   installApk,
   readFreshAndroidRendererStamp,
   readInstalledRendererStamp,
+  readRendererStampFromApk,
   resolveAdb,
   resolveApk,
   resolveSerial,
@@ -205,6 +207,17 @@ function stampLabel(stamp) {
   return `${buildId}${commit}`;
 }
 
+function readApkRendererStamp(apk) {
+  try {
+    return readRendererStampFromApk(apk);
+  } catch (error) {
+    log(
+      `APK renderer stamp unavailable from ${apk}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+}
+
 function ensureFreshApkInstalled(adb, serial) {
   const forceBuild = has("--force-build") || has("--build");
   const skipBuild = has("--skip-build");
@@ -233,7 +246,36 @@ function ensureFreshApkInstalled(adb, serial) {
     );
   }
 
-  const apk = resolveApk(process.env.ELIZA_ANDROID_APK);
+  let apk = resolveApk(process.env.ELIZA_ANDROID_APK);
+  let apkStamp = readApkRendererStamp(apk);
+  let apkDecision = androidApkNeedsBuild({ freshStamp, apkStamp });
+  if (apkDecision.build) {
+    if (skipBuild) {
+      throw new Error(
+        `--skip-build requested, but Android APK is not usable: ${apkDecision.reason}`,
+      );
+    }
+    if (!forceBuild) {
+      log(`${apkDecision.reason} — rebuilding APK before install.`);
+      buildAndroidApk();
+      freshStamp = readFreshAndroidRendererStamp();
+      if (!freshStamp) {
+        throw new Error(
+          "Android build did not produce dist/eliza-renderer-build.json; refusing to install an unverifiable APK.",
+        );
+      }
+      apk = resolveApk(process.env.ELIZA_ANDROID_APK);
+      apkStamp = readApkRendererStamp(apk);
+      apkDecision = androidApkNeedsBuild({ freshStamp, apkStamp });
+    }
+  }
+  if (apkDecision.build) {
+    throw new Error(
+      `Android build did not produce an APK with the fresh renderer stamp: ${apkDecision.reason}`,
+    );
+  }
+  log(`${apkDecision.reason} in ${apk}`);
+
   const installedStamp = readInstalledRendererStamp(adb, serial, { log });
   const installDecision = forceBuild
     ? { install: true, reason: "--force-build/--build requested" }

--- a/packages/app/scripts/android-e2e.mjs
+++ b/packages/app/scripts/android-e2e.mjs
@@ -14,16 +14,20 @@
 //
 // Flags: --serial <s>  --skip-local-chat  --skip-route-coverage  --cloud
 //        --launcher-loop (≥200-action seeded launcher gesture loop; opt-in)
-//        --build (build the APK first)  --no-emulator-boot
+//        --force-build/--build (build the APK first)  --skip-build
+//        --no-emulator-boot
 import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  androidDistNeedsBuild,
+  androidInstallDecision,
   ensureEmulatorBooted,
   ensureEmulatorPermissive,
   installApk,
-  isInstalled,
+  readFreshAndroidRendererStamp,
+  readInstalledRendererStamp,
   resolveAdb,
   resolveApk,
   resolveSerial,
@@ -171,6 +175,89 @@ function run(cmd, args, env = {}) {
   }
 }
 
+function currentHeadCommit() {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: elizaRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function buildAndroidApk() {
+  log("building WebView-debuggable APK…");
+  run("bun", ["run", "build:android"], {
+    ELIZA_MOBILE_REPO_ROOT: elizaRoot,
+    ELIZA_WEBVIEW_DEBUG: "1",
+    ELIZA_BUN_RISCV64_OPTIONAL: "1",
+  });
+}
+
+function stampLabel(stamp) {
+  if (!stamp) return "missing";
+  const buildId = String(stamp.buildId ?? "unknown").slice(0, 12);
+  const commit = stamp.commit
+    ? ` commit=${String(stamp.commit).slice(0, 12)}`
+    : "";
+  return `${buildId}${commit}`;
+}
+
+function ensureFreshApkInstalled(adb, serial) {
+  const forceBuild = has("--force-build") || has("--build");
+  const skipBuild = has("--skip-build");
+  const headCommit = currentHeadCommit();
+  let freshStamp = readFreshAndroidRendererStamp();
+  const buildDecision = androidDistNeedsBuild({ freshStamp, headCommit });
+
+  if (forceBuild) {
+    buildAndroidApk();
+  } else if (buildDecision.build) {
+    if (skipBuild) {
+      throw new Error(
+        `--skip-build requested, but Android dist is not usable: ${buildDecision.reason}`,
+      );
+    }
+    log(`${buildDecision.reason} — rebuilding before install check.`);
+    buildAndroidApk();
+  } else {
+    log(`fresh dist renderer stamp: ${stampLabel(freshStamp)}`);
+  }
+
+  freshStamp = readFreshAndroidRendererStamp();
+  if (!freshStamp) {
+    throw new Error(
+      "Android build did not produce dist/eliza-renderer-build.json; refusing to install an unverifiable APK.",
+    );
+  }
+
+  const apk = resolveApk(process.env.ELIZA_ANDROID_APK);
+  const installedStamp = readInstalledRendererStamp(adb, serial, { log });
+  const installDecision = forceBuild
+    ? { install: true, reason: "--force-build/--build requested" }
+    : androidInstallDecision({ freshStamp, installedStamp });
+  if (installDecision.install) {
+    log(`${installDecision.reason} — installing ${apk}`);
+    installApk(adb, serial, apk);
+    const readback = readInstalledRendererStamp(adb, serial, { log });
+    const readbackDecision = androidInstallDecision({
+      freshStamp,
+      installedStamp: readback,
+    });
+    if (readbackDecision.install) {
+      throw new Error(
+        `Android install did not produce the fresh renderer stamp: ${readbackDecision.reason}`,
+      );
+    }
+    log(`installed renderer stamp verified: ${stampLabel(readback)}`);
+    return;
+  }
+
+  log(`${installDecision.reason} — skipping APK install.`);
+}
+
 // Node's fetch chokes on the HF Xet LFS redirect; curl handles it. Pre-cache the
 // model so the smoke reuses it offline instead of failing on the redirect.
 function ensureSmokeModelCached() {
@@ -206,19 +293,7 @@ async function main() {
 
   await ensureEmulatorPermissive(adb, serial, { log });
 
-  if (has("--build")) {
-    log("building WebView-debuggable APK…");
-    run("bun", ["run", "build:android"], {
-      ELIZA_MOBILE_REPO_ROOT: elizaRoot,
-      ELIZA_WEBVIEW_DEBUG: "1",
-      ELIZA_BUN_RISCV64_OPTIONAL: "1",
-    });
-  }
-  if (!isInstalled(adb, serial)) {
-    const apk = resolveApk(process.env.ELIZA_ANDROID_APK);
-    log(`installing ${apk}`);
-    installApk(adb, serial, apk);
-  }
+  ensureFreshApkInstalled(adb, serial);
 
   if (!has("--skip-local-chat")) {
     const modelPath = ensureSmokeModelCached();

--- a/packages/app/scripts/android-renderer-stamp.test.mjs
+++ b/packages/app/scripts/android-renderer-stamp.test.mjs
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for the Android APK renderer freshness guard. The fixtures are
+ * minimal zip files with the same `assets/public` manifest path Gradle packages
+ * into real APKs, so the verifier can fail stale installs without adb.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ANDROID_APK_RENDERER_MANIFEST_PATH,
+  assertAndroidApkRendererFresh,
+  compareAndroidRendererBuildIds,
+  readAndroidApkRendererManifest,
+} from "./lib/android-renderer-stamp.mjs";
+
+const tempDirs = [];
+
+function tempDir() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "android-renderer-stamp-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function u16(value) {
+  const buffer = Buffer.alloc(2);
+  buffer.writeUInt16LE(value);
+  return buffer;
+}
+
+function u32(value) {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32LE(value);
+  return buffer;
+}
+
+function writeStoredZipEntry(zipPath, entryName, content) {
+  const name = Buffer.from(entryName);
+  const data = Buffer.from(content);
+  const local = Buffer.concat([
+    u32(0x04034b50),
+    u16(20),
+    u16(0),
+    u16(0),
+    u16(0),
+    u16(0),
+    u32(0),
+    u32(data.length),
+    u32(data.length),
+    u16(name.length),
+    u16(0),
+    name,
+    data,
+  ]);
+  const centralOffset = local.length;
+  const central = Buffer.concat([
+    u32(0x02014b50),
+    u16(20),
+    u16(20),
+    u16(0),
+    u16(0),
+    u16(0),
+    u16(0),
+    u32(0),
+    u32(data.length),
+    u32(data.length),
+    u16(name.length),
+    u16(0),
+    u16(0),
+    u16(0),
+    u16(0),
+    u32(0),
+    u32(0),
+    name,
+  ]);
+  const eocd = Buffer.concat([
+    u32(0x06054b50),
+    u16(0),
+    u16(0),
+    u16(1),
+    u16(1),
+    u32(central.length),
+    u32(centralOffset),
+    u16(0),
+  ]);
+  writeFileSync(zipPath, Buffer.concat([local, central, eocd]));
+}
+
+function writeApk(repoRoot, buildId) {
+  const apkPath = path.join(repoRoot, "app-debug.apk");
+  writeStoredZipEntry(
+    apkPath,
+    ANDROID_APK_RENDERER_MANIFEST_PATH,
+    JSON.stringify({ buildId, builtAt: "2026-07-05T00:00:00.000Z" }),
+  );
+  return apkPath;
+}
+
+function writeFreshDist(repoRoot, buildId) {
+  const dist = path.join(repoRoot, "packages", "app", "dist");
+  mkdirSync(dist, { recursive: true });
+  writeFileSync(
+    path.join(dist, "eliza-renderer-build.json"),
+    JSON.stringify({ buildId, builtAt: "2026-07-05T00:01:00.000Z" }),
+  );
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("Android renderer stamp", () => {
+  it("reads the renderer manifest packaged in an APK", () => {
+    const repoRoot = tempDir();
+    const apkPath = writeApk(repoRoot, "packaged");
+
+    expect(readAndroidApkRendererManifest(apkPath)).toMatchObject({
+      buildId: "packaged",
+    });
+  });
+
+  it("accepts matching fresh and packaged build ids", () => {
+    expect(
+      compareAndroidRendererBuildIds({
+        fresh: { buildId: "same", builtAt: "now" },
+        packaged: { buildId: "same" },
+      }),
+    ).toEqual({ buildId: "same", builtAt: "now" });
+  });
+
+  it("rejects stale packaged renderer manifests", () => {
+    expect(() =>
+      compareAndroidRendererBuildIds({
+        fresh: { buildId: "fresh" },
+        packaged: { buildId: "old" },
+      }),
+    ).toThrow(/stale Android APK/);
+  });
+
+  it("rejects a fresh dist manifest from another commit", () => {
+    expect(() =>
+      compareAndroidRendererBuildIds({
+        fresh: { buildId: "same", commit: "111111111111" },
+        packaged: { buildId: "same" },
+        expectedCommit: "222222222222",
+      }),
+    ).toThrow(/stale Android dist/);
+  });
+
+  it("compares a packaged APK against the freshly built dist manifest", () => {
+    const repoRoot = tempDir();
+    writeFreshDist(repoRoot, "same");
+    const apkPath = writeApk(repoRoot, "same");
+
+    expect(
+      assertAndroidApkRendererFresh({
+        apkPath,
+        repoRoot,
+        expectedCommit: null,
+      }),
+    ).toEqual({
+      buildId: "same",
+      builtAt: "2026-07-05T00:01:00.000Z",
+    });
+  });
+
+  it("fails when the APK is missing the renderer manifest", () => {
+    const repoRoot = tempDir();
+    const apkPath = path.join(repoRoot, "missing.apk");
+    writeStoredZipEntry(apkPath, "assets/public/index.html", "<html></html>");
+
+    expect(() => readAndroidApkRendererManifest(apkPath)).toThrow(
+      /missing assets\/public\/eliza-renderer-build\.json/,
+    );
+  });
+});

--- a/packages/app/scripts/android-renderer-stamp.test.mjs
+++ b/packages/app/scripts/android-renderer-stamp.test.mjs
@@ -11,6 +11,7 @@ import {
   ANDROID_APK_RENDERER_MANIFEST_PATH,
   assertAndroidApkRendererFresh,
   compareAndroidRendererBuildIds,
+  freshAndroidRendererManifestPath,
   readAndroidApkRendererManifest,
 } from "./lib/android-renderer-stamp.mjs";
 
@@ -106,6 +107,8 @@ function writeFreshDist(repoRoot, buildId) {
 }
 
 afterEach(() => {
+  delete process.env.ELIZA_ANDROID_RENDERER_DIST;
+  delete process.env.ELIZA_SMOKE_RENDERER_DIST;
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -164,6 +167,18 @@ describe("Android renderer stamp", () => {
       buildId: "same",
       builtAt: "2026-07-05T00:01:00.000Z",
     });
+  });
+
+  it("prefers the Android renderer dist override over the generic smoke override", () => {
+    const repoRoot = tempDir();
+    const smokeDist = path.join(repoRoot, "smoke-dist");
+    const androidDist = path.join(repoRoot, "android-dist");
+    process.env.ELIZA_SMOKE_RENDERER_DIST = smokeDist;
+    process.env.ELIZA_ANDROID_RENDERER_DIST = androidDist;
+
+    expect(freshAndroidRendererManifestPath({ repoRoot })).toBe(
+      path.join(androidDist, "eliza-renderer-build.json"),
+    );
   });
 
   it("fails when the APK is missing the renderer manifest", () => {

--- a/packages/app/scripts/lib/android-device.mjs
+++ b/packages/app/scripts/lib/android-device.mjs
@@ -522,6 +522,30 @@ export function androidInstallDecision({ freshStamp, installedStamp } = {}) {
   };
 }
 
+export function androidApkNeedsBuild({ freshStamp, apkStamp } = {}) {
+  if (!freshStamp) {
+    throw new Error(
+      "fresh Android renderer stamp is required before APK check.",
+    );
+  }
+  if (!apkStamp) {
+    return {
+      build: true,
+      reason: `APK has no readable ${RENDERER_BUILD_MANIFEST_FILENAME}`,
+    };
+  }
+  if (apkStamp.buildId !== freshStamp.buildId) {
+    return {
+      build: true,
+      reason: `APK ${apkStamp.buildId} != fresh ${freshStamp.buildId}`,
+    };
+  }
+  return {
+    build: false,
+    reason: `APK buildId matches fresh ${freshStamp.buildId}`,
+  };
+}
+
 export function clearAppData(adbBin, serial) {
   adbDevice(adbBin, serial, ["shell", "pm", "clear", APP_ID], {
     stdio: "inherit",

--- a/packages/app/scripts/lib/android-device.mjs
+++ b/packages/app/scripts/lib/android-device.mjs
@@ -12,6 +12,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  RENDERER_BUILD_MANIFEST_FILENAME,
+  readRendererBuildManifest,
+} from "../../../app-core/scripts/lib/renderer-build-manifest.mjs";
+import { readAndroidApkRendererManifest } from "./android-renderer-stamp.mjs";
 
 const IS_WINDOWS = process.platform === "win32";
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -47,6 +52,7 @@ const APK_CANDIDATES = [
   ),
   path.join(appDir, "android/app/build/outputs/apk/debug/app-debug.apk"),
 ];
+const DEFAULT_RENDERER_DIST = path.join(appDir, "dist");
 
 // ---------------------------------------------------------------------------
 // SDK binary resolution
@@ -393,6 +399,127 @@ export function isInstalled(adbBin, serial) {
 
 export function installApk(adbBin, serial, apk) {
   adbDevice(adbBin, serial, ["install", "-r", "-d", apk], { stdio: "inherit" });
+}
+
+function validateRendererStamp(stamp, label) {
+  if (!stamp || typeof stamp !== "object") {
+    throw new Error(`${label} renderer stamp is missing or invalid.`);
+  }
+  if (typeof stamp.buildId !== "string" || stamp.buildId.length === 0) {
+    throw new Error(`${label} renderer stamp has no buildId.`);
+  }
+  return stamp;
+}
+
+export function readFreshAndroidRendererStamp(
+  rendererDist = process.env.ELIZA_ANDROID_RENDERER_DIST ??
+    DEFAULT_RENDERER_DIST,
+) {
+  const stamp = readRendererBuildManifest(path.resolve(rendererDist));
+  return stamp ? validateRendererStamp(stamp, "fresh Android dist") : null;
+}
+
+function parseApkPath(pmPathOutput) {
+  return (
+    pmPathOutput
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => line.replace(/^package:/, ""))
+      .find((line) => /(?:^|\/)base\.apk$/.test(line)) ??
+    pmPathOutput
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => line.replace(/^package:/, ""))
+      .find((line) => line.endsWith(".apk")) ??
+    null
+  );
+}
+
+export function readRendererStampFromApk(apkPath) {
+  return readAndroidApkRendererManifest(apkPath);
+}
+
+export function readInstalledRendererStamp(
+  adbBin,
+  serial,
+  { tmpRoot = os.tmpdir(), log = () => {} } = {},
+) {
+  const pmPath = adbTry(adbBin, ["-s", serial, "shell", "pm", "path", APP_ID]);
+  const remoteApk = parseApkPath(pmPath);
+  if (!remoteApk) return null;
+
+  const tempDir = fs.mkdtempSync(path.join(tmpRoot, "eliza-android-apk-"));
+  const localApk = path.join(tempDir, "base.apk");
+  try {
+    adbDevice(adbBin, serial, ["pull", remoteApk, localApk], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    return readRendererStampFromApk(localApk);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(`installed renderer stamp unavailable from ${remoteApk}: ${message}`);
+    return null;
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+export function androidDistNeedsBuild({
+  freshStamp,
+  headCommit,
+  requireCapacitorTarget = "android",
+} = {}) {
+  if (!freshStamp) {
+    return {
+      build: true,
+      reason: `dist has no ${RENDERER_BUILD_MANIFEST_FILENAME}`,
+    };
+  }
+  if (
+    freshStamp.capacitorTarget != null &&
+    freshStamp.capacitorTarget !== requireCapacitorTarget
+  ) {
+    return {
+      build: true,
+      reason: `dist capacitorTarget=${freshStamp.capacitorTarget} but this lane bakes ${requireCapacitorTarget}`,
+    };
+  }
+  if (
+    headCommit &&
+    freshStamp.commit &&
+    !String(headCommit).startsWith(String(freshStamp.commit)) &&
+    !String(freshStamp.commit).startsWith(String(headCommit))
+  ) {
+    return {
+      build: true,
+      reason: `dist commit=${freshStamp.commit} but HEAD=${headCommit}`,
+    };
+  }
+  return { build: false, reason: "dist renderer stamp is usable" };
+}
+
+export function androidInstallDecision({ freshStamp, installedStamp } = {}) {
+  if (!freshStamp) {
+    throw new Error("fresh Android renderer stamp is required before install.");
+  }
+  if (!installedStamp) {
+    return {
+      install: true,
+      reason: `installed app has no readable ${RENDERER_BUILD_MANIFEST_FILENAME}`,
+    };
+  }
+  if (installedStamp.buildId !== freshStamp.buildId) {
+    return {
+      install: true,
+      reason: `installed ${installedStamp.buildId} != fresh ${freshStamp.buildId}`,
+    };
+  }
+  return {
+    install: false,
+    reason: `installed buildId matches fresh ${freshStamp.buildId}`,
+  };
 }
 
 export function clearAppData(adbBin, serial) {

--- a/packages/app/scripts/lib/android-renderer-stamp.mjs
+++ b/packages/app/scripts/lib/android-renderer-stamp.mjs
@@ -73,7 +73,8 @@ function readRendererManifest(manifestPath, label) {
 
 export function freshAndroidRendererManifestPath({
   repoRoot,
-  rendererDist = process.env.ELIZA_SMOKE_RENDERER_DIST,
+  rendererDist = process.env.ELIZA_ANDROID_RENDERER_DIST ??
+    process.env.ELIZA_SMOKE_RENDERER_DIST,
 }) {
   return path.join(
     rendererDist
@@ -127,7 +128,8 @@ export function compareAndroidRendererBuildIds({
 export function assertAndroidApkRendererFresh({
   apkPath,
   repoRoot,
-  rendererDist = process.env.ELIZA_SMOKE_RENDERER_DIST,
+  rendererDist = process.env.ELIZA_ANDROID_RENDERER_DIST ??
+    process.env.ELIZA_SMOKE_RENDERER_DIST,
   expectedCommit = null,
   label = "Android APK",
   log = () => {},

--- a/packages/app/scripts/lib/android-renderer-stamp.mjs
+++ b/packages/app/scripts/lib/android-renderer-stamp.mjs
@@ -1,0 +1,151 @@
+/**
+ * Android renderer-stamp verifier for sideload APKs. The mobile build already
+ * proves the staged Gradle assets match the fresh Vite build; this module
+ * checks the packaged APK before adb install so a stale artifact cannot reach a
+ * device just because it was the newest file in the outputs directory.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import zlib from "node:zlib";
+
+const RENDERER_MANIFEST = "eliza-renderer-build.json";
+export const ANDROID_APK_RENDERER_MANIFEST_PATH = `assets/public/${RENDERER_MANIFEST}`;
+
+function findEndOfCentralDirectory(buffer) {
+  const signature = 0x06054b50;
+  const minOffset = Math.max(0, buffer.length - 65_557);
+  for (let offset = buffer.length - 22; offset >= minOffset; offset -= 1) {
+    if (buffer.readUInt32LE(offset) === signature) return offset;
+  }
+  return -1;
+}
+
+function readZipEntry(zipPath, entryName) {
+  const buffer = fs.readFileSync(zipPath);
+  const eocd = findEndOfCentralDirectory(buffer);
+  if (eocd < 0) throw new Error(`APK is not a readable zip: ${zipPath}`);
+  const entryCount = buffer.readUInt16LE(eocd + 10);
+  let cursor = buffer.readUInt32LE(eocd + 16);
+  for (let index = 0; index < entryCount; index += 1) {
+    if (buffer.readUInt32LE(cursor) !== 0x02014b50) {
+      throw new Error(`APK central directory is corrupt: ${zipPath}`);
+    }
+    const method = buffer.readUInt16LE(cursor + 10);
+    const compressedSize = buffer.readUInt32LE(cursor + 20);
+    const nameLength = buffer.readUInt16LE(cursor + 28);
+    const extraLength = buffer.readUInt16LE(cursor + 30);
+    const commentLength = buffer.readUInt16LE(cursor + 32);
+    const localHeaderOffset = buffer.readUInt32LE(cursor + 42);
+    const nameStart = cursor + 46;
+    const name = buffer.toString("utf8", nameStart, nameStart + nameLength);
+    if (name === entryName) {
+      if (buffer.readUInt32LE(localHeaderOffset) !== 0x04034b50) {
+        throw new Error(`APK local file header is corrupt: ${zipPath}`);
+      }
+      const localNameLength = buffer.readUInt16LE(localHeaderOffset + 26);
+      const localExtraLength = buffer.readUInt16LE(localHeaderOffset + 28);
+      const dataStart =
+        localHeaderOffset + 30 + localNameLength + localExtraLength;
+      const data = buffer.subarray(dataStart, dataStart + compressedSize);
+      if (method === 0) return data;
+      if (method === 8) return zlib.inflateRawSync(data);
+      throw new Error(
+        `APK entry ${entryName} uses unsupported zip compression method ${method}.`,
+      );
+    }
+    cursor = nameStart + nameLength + extraLength + commentLength;
+  }
+  return null;
+}
+
+function readRendererManifest(manifestPath, label) {
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`${label} renderer manifest is missing: ${manifestPath}`);
+  }
+  const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (typeof parsed.buildId !== "string" || parsed.buildId.length === 0) {
+    throw new Error(
+      `${label} renderer manifest has no buildId: ${manifestPath}`,
+    );
+  }
+  return parsed;
+}
+
+export function freshAndroidRendererManifestPath({
+  repoRoot,
+  rendererDist = process.env.ELIZA_SMOKE_RENDERER_DIST,
+}) {
+  return path.join(
+    rendererDist
+      ? path.resolve(rendererDist)
+      : path.join(repoRoot, "packages", "app", "dist"),
+    RENDERER_MANIFEST,
+  );
+}
+
+export function readAndroidApkRendererManifest(apkPath, label = "Android APK") {
+  const entry = readZipEntry(apkPath, ANDROID_APK_RENDERER_MANIFEST_PATH);
+  if (!entry) {
+    throw new Error(
+      `${label} is missing ${ANDROID_APK_RENDERER_MANIFEST_PATH}; refusing to install an unverifiable renderer.`,
+    );
+  }
+  const parsed = JSON.parse(entry.toString("utf8"));
+  if (typeof parsed.buildId !== "string" || parsed.buildId.length === 0) {
+    throw new Error(`${label} renderer manifest has no buildId.`);
+  }
+  return parsed;
+}
+
+export function compareAndroidRendererBuildIds({
+  fresh,
+  packaged,
+  label = "Android APK",
+  expectedCommit = null,
+}) {
+  if (
+    expectedCommit &&
+    fresh.commit &&
+    !String(expectedCommit).startsWith(String(fresh.commit)) &&
+    !String(fresh.commit).startsWith(String(expectedCommit))
+  ) {
+    throw new Error(
+      `freshly built renderer commit ${fresh.commit} != HEAD ${expectedCommit} - stale Android dist.`,
+    );
+  }
+  if (packaged.buildId !== fresh.buildId) {
+    throw new Error(
+      `${label} renderer buildId ${packaged.buildId} != freshly built ${fresh.buildId} - stale Android APK.`,
+    );
+  }
+  return {
+    buildId: fresh.buildId,
+    builtAt: fresh.builtAt ?? null,
+  };
+}
+
+export function assertAndroidApkRendererFresh({
+  apkPath,
+  repoRoot,
+  rendererDist = process.env.ELIZA_SMOKE_RENDERER_DIST,
+  expectedCommit = null,
+  label = "Android APK",
+  log = () => {},
+}) {
+  const freshManifest = freshAndroidRendererManifestPath({
+    repoRoot,
+    rendererDist,
+  });
+  const fresh = readRendererManifest(freshManifest, "freshly built");
+  const packaged = readAndroidApkRendererManifest(apkPath, label);
+  const result = compareAndroidRendererBuildIds({
+    fresh,
+    packaged,
+    label,
+    expectedCommit,
+  });
+  log(
+    `renderer build stamp OK for ${label}: ${String(result.buildId).slice(0, 12)}${result.builtAt ? ` built ${result.builtAt}` : ""}`,
+  );
+  return result;
+}

--- a/packages/app/test/android-renderer-stamp.test.ts
+++ b/packages/app/test/android-renderer-stamp.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  androidApkNeedsBuild,
   androidDistNeedsBuild,
   androidInstallDecision,
 } from "../scripts/lib/android-device.mjs";
@@ -98,6 +99,42 @@ describe("Android renderer stamp decisions", () => {
     ).toEqual({
       install: false,
       reason: "installed buildId matches fresh fresh",
+    });
+  });
+
+  it("requires an APK rebuild when the packaged stamp is missing", () => {
+    expect(
+      androidApkNeedsBuild({
+        freshStamp: { buildId: "fresh" },
+        apkStamp: null,
+      }),
+    ).toMatchObject({
+      build: true,
+      reason: expect.stringContaining("APK has no readable"),
+    });
+  });
+
+  it("requires an APK rebuild when the packaged buildId differs from fresh dist", () => {
+    expect(
+      androidApkNeedsBuild({
+        freshStamp: { buildId: "fresh" },
+        apkStamp: { buildId: "old" },
+      }),
+    ).toEqual({
+      build: true,
+      reason: "APK old != fresh fresh",
+    });
+  });
+
+  it("accepts an APK whose packaged buildId matches fresh dist", () => {
+    expect(
+      androidApkNeedsBuild({
+        freshStamp: { buildId: "fresh" },
+        apkStamp: { buildId: "fresh" },
+      }),
+    ).toEqual({
+      build: false,
+      reason: "APK buildId matches fresh fresh",
     });
   });
 

--- a/packages/app/test/android-renderer-stamp.test.ts
+++ b/packages/app/test/android-renderer-stamp.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Android renderer freshness tests cover the pure decisions behind the device
+ * runner's APK install guard. The adb-facing readback is exercised by device
+ * evidence; these tests keep the stale-install policy deterministic without an
+ * attached emulator.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  androidDistNeedsBuild,
+  androidInstallDecision,
+} from "../scripts/lib/android-device.mjs";
+import { compareAndroidRendererBuildIds } from "../scripts/lib/android-renderer-stamp.mjs";
+
+describe("Android renderer stamp decisions", () => {
+  it("requires a build when dist has no renderer stamp", () => {
+    expect(androidDistNeedsBuild({ freshStamp: null })).toMatchObject({
+      build: true,
+      reason: expect.stringContaining("dist has no"),
+    });
+  });
+
+  it("requires a build when dist was baked for another Capacitor target", () => {
+    expect(
+      androidDistNeedsBuild({
+        freshStamp: {
+          buildId: "same",
+          commit: "abc123",
+          capacitorTarget: "ios",
+        },
+        headCommit: "abc123",
+      }),
+    ).toMatchObject({
+      build: true,
+      reason: expect.stringContaining("capacitorTarget=ios"),
+    });
+  });
+
+  it("requires a build when dist belongs to another commit", () => {
+    expect(
+      androidDistNeedsBuild({
+        freshStamp: {
+          buildId: "same",
+          commit: "111111111111",
+          capacitorTarget: "android",
+        },
+        headCommit: "222222222222",
+      }),
+    ).toMatchObject({
+      build: true,
+      reason: expect.stringContaining("dist commit=111111111111"),
+    });
+  });
+
+  it("accepts a matching Android dist stamp", () => {
+    expect(
+      androidDistNeedsBuild({
+        freshStamp: {
+          buildId: "same",
+          commit: "abcdef123456",
+          capacitorTarget: "android",
+        },
+        headCommit: "abcdef1234567890",
+      }),
+    ).toEqual({ build: false, reason: "dist renderer stamp is usable" });
+  });
+
+  it("installs when the device has no readable installed stamp", () => {
+    expect(
+      androidInstallDecision({
+        freshStamp: { buildId: "fresh" },
+        installedStamp: null,
+      }),
+    ).toMatchObject({
+      install: true,
+      reason: expect.stringContaining("no readable"),
+    });
+  });
+
+  it("installs when the installed buildId differs from fresh dist", () => {
+    expect(
+      androidInstallDecision({
+        freshStamp: { buildId: "fresh" },
+        installedStamp: { buildId: "old" },
+      }),
+    ).toEqual({
+      install: true,
+      reason: "installed old != fresh fresh",
+    });
+  });
+
+  it("skips install when installed and fresh buildIds match", () => {
+    expect(
+      androidInstallDecision({
+        freshStamp: { buildId: "fresh" },
+        installedStamp: { buildId: "fresh" },
+      }),
+    ).toEqual({
+      install: false,
+      reason: "installed buildId matches fresh fresh",
+    });
+  });
+
+  it("rejects a packaged APK whose renderer buildId differs from fresh dist", () => {
+    expect(() =>
+      compareAndroidRendererBuildIds({
+        fresh: { buildId: "fresh" },
+        packaged: { buildId: "old" },
+      }),
+    ).toThrow(/stale Android APK/);
+  });
+});


### PR DESCRIPTION
## Summary
- add an Android APK renderer-stamp reader for `assets/public/eliza-renderer-build.json`
- make `android-e2e.mjs` build/reinstall based on fresh dist vs installed renderer buildId instead of package presence
- make `install:android:adb` reject APKs whose packaged renderer stamp is stale relative to fresh dist/current HEAD
- add focused Vitest coverage for APK stamp parsing, stale APK rejection, stale dist rejection, and Android install/build decisions

Relates to #14334.

## Validation
- `bunx @biomejs/biome check packages/app/scripts/android-adb-install.mjs packages/app/scripts/android-e2e.mjs packages/app/scripts/lib/android-device.mjs packages/app/scripts/lib/android-renderer-stamp.mjs packages/app/scripts/android-renderer-stamp.test.mjs packages/app/test/android-renderer-stamp.test.ts`
- `bunx vitest run --config packages/app/vitest.config.ts packages/app/scripts/android-renderer-stamp.test.mjs packages/app/test/android-renderer-stamp.test.ts packages/app/test/ios-renderer-stamp.test.ts`
- `node --check packages/app/scripts/android-adb-install.mjs && node --check packages/app/scripts/android-e2e.mjs && node --check packages/app/scripts/lib/android-device.mjs && node --check packages/app/scripts/lib/android-renderer-stamp.mjs`
- `git diff --check`

## Evidence
- N/A for screenshots/video in this local pass: no Android emulator/device is available in this runner session, so the required stale-install/fresh-install terminal logs, device screenrecord, and home screenshot still need to be captured from an attached Android target before merge.
- `bun run --cwd packages/app typecheck` was attempted but is currently blocked by existing workspace dependency/type-resolution failures unrelated to this diff, including missing `@elizaos/auth`, Capacitor, drizzle, and plugin declaration modules.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - Android install/e2e script freshness guard; no app UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - Android install/e2e script freshness guard; no app UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - command-line Android install/e2e workflow change; no user-facing walkthrough flow changed`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend/runtime server code path changed`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend runtime code path changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent, prompt, provider, model, or action behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - mobile install workflow guard only; focused stamp tests cover the renderer-stamp policy`.
