### PR TITLE
fix(#14344): wallet widget shows BTC/SOL/ETH by default, top-3 held, 60s refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ packages/ui/src/components/shell/__e2e__/output-voice-recording/
 packages/ui/src/components/pages/tutorial/__e2e__/output-tutorial/
 # FTU welcome e2e output (screenshots + webm — regenerate via test:ftu-home-e2e)
 packages/ui/src/components/chat/widgets/__e2e__/output-ftu/
+# Wallet widget e2e output (screenshots + stubs — regenerate via test:wallet-widget-e2e)
+packages/ui/src/components/chat/widgets/__e2e__/output-wallet/
 # Permission-priming e2e output (screenshots + webm + stubs — regenerate via test:permission-priming-e2e)
 packages/ui/src/components/permissions/__e2e__/output-permission-priming/
 # View-lifecycle e2e output (screenshots + webm + telemetry — regenerate via test:view-lifecycle-e2e)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -79,6 +79,7 @@
     "build:dist:unlocked": "bun run clean && node ../scripts/ensure-tsc-nested-output-dir.mjs packages/ui && tsc --noCheck -p tsconfig.build.json && node ../scripts/flatten-tsc-package-output.mjs packages/ui && node ../scripts/copy-package-assets.mjs packages/ui src/styles src/cloud-ui/index.css && node ../scripts/prepare-package-dist.mjs packages/ui && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/ui && node ../scripts/verify-package-runtime-exports.mjs packages/ui",
     "test:orchestrator-accounts-e2e": "bun run --cwd ../.. packages/ui/src/components/chat/widgets/__e2e__/run-orchestrator-accounts-e2e.mjs",
     "test:ftu-home-e2e": "bun run --cwd ../.. packages/ui/src/components/chat/widgets/__e2e__/run-ftu-home-e2e.mjs",
+    "test:wallet-widget-e2e": "bun run --cwd ../.. packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs",
     "test:task-pipeline-e2e": "bun run --cwd ../.. packages/ui/src/components/chat/widgets/__e2e__/run-task-pipeline-e2e.mjs",
     "test:home-locale-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-home-locale-e2e.mjs"
   },

--- a/packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs
+++ b/packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs
@@ -1,0 +1,179 @@
+/**
+ * Real-browser screenshot + assertion harness for the WALLET home widget
+ * (#14344) — no app server. Bundles wallet-widget-fixture.tsx (the REAL
+ * `WalletBalanceWidget`) with esbuild, stubs only the `../../../api` client,
+ * auth, and nav modules, loads it in headless chromium, and proves both states:
+ *
+ *   - DEFAULT (no holdings): the tracked BTC/SOL/ETH price rows are shown
+ *     (previously the widget rendered nothing here — the bug this fixes).
+ *   - HELD (≥1 priced holding): the top-3 held by holding value, price-only.
+ *
+ * Captures a screenshot of each state for inline PR evidence.
+ *
+ * Run: bun run --cwd packages/ui test:wallet-widget-e2e
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { chromium } from "playwright";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const stylesDir = join(here, "../../../../styles");
+const outDir = join(here, "output-wallet");
+await mkdir(outDir, { recursive: true });
+
+let failures = 0;
+function assert(cond, msg) {
+  console.log(`${cond ? "✓" : "✗"} ${msg}`);
+  if (!cond) failures += 1;
+  return cond;
+}
+
+const baseCss = await readFile(join(stylesDir, "base.css"), "utf8");
+// The widget uses semantic text tokens that tailwind's CDN default config does
+// not know; map them to readable colours on the orange field for the capture.
+const TOKEN_SHIM = `
+.text-muted{color:rgba(255,255,255,0.72)}
+.text-txt-strong{color:#ffffff}
+.text-success{color:#bbf7d0}
+.text-danger{color:#fecaca}
+`;
+
+// Client + hook stubs: the widget fetches balances/overview from the api module
+// singleton, so we replace it with a state-driven stub (chosen by ?state=held).
+const apiStub = join(outDir, "api-stub.ts");
+await writeFile(
+  apiStub,
+  `const held = new URLSearchParams(location.search).get("state") === "held";
+const overview = {
+  generatedAt: "", cacheTtlSeconds: 120, stale: false,
+  sources: {}, predictions: [], movers: [],
+  prices: [
+    { id: "bitcoin", symbol: "BTC", name: "Bitcoin", priceUsd: 64000, change24hPct: 1.2, imageUrl: null },
+    { id: "ethereum", symbol: "ETH", name: "Ethereum", priceUsd: 3000, change24hPct: -0.5, imageUrl: null },
+    { id: "solana", symbol: "SOL", name: "Solana", priceUsd: 150, change24hPct: 2.1, imageUrl: null },
+    { id: "usd-coin", symbol: "USDC", name: "USD Coin", priceUsd: 1.0, change24hPct: 0.0, imageUrl: null },
+  ],
+};
+const heldBalances = {
+  evm: { address: "0xabc", chains: [{ chain: "ethereum", chainId: 1, nativeBalance: "0",
+    nativeSymbol: "ETH", nativeValueUsd: "5000", error: null, tokens: [
+      { symbol: "USDC", name: "USD Coin", balance: "0", decimals: 6, valueUsd: "800", address: "0xusdc" },
+    ] }] },
+  solana: { address: "sol1", solBalance: "0", solValueUsd: "2000", tokens: [] },
+};
+export const client = {
+  getWalletBalances: async () => (held ? heldBalances : { evm: null, solana: null }),
+  getWalletMarketOverview: async () => overview,
+};
+`,
+);
+const authStub = join(outDir, "auth-stub.ts");
+await writeFile(authStub, `export function useIsAuthenticated() { return true; }\n`);
+const navStub = join(outDir, "nav-stub.ts");
+await writeFile(
+  navStub,
+  `export function useWidgetNavigation() { return { openView() {}, openTab() {} }; }\n`,
+);
+
+const stubModules = {
+  name: "stub-wallet-deps",
+  setup(b) {
+    b.onResolve({ filter: /\/api$/ }, () => ({ path: apiStub }));
+    b.onResolve({ filter: /useAuthStatus$/ }, () => ({ path: authStub }));
+    b.onResolve({ filter: /home-widget-card$/ }, () => ({ path: navStub }));
+  },
+};
+
+const result = await build({
+  entryPoints: [join(here, "wallet-widget-fixture.tsx")],
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  jsx: "automatic",
+  loader: { ".tsx": "tsx", ".ts": "ts" },
+  define: { "process.env.NODE_ENV": '"production"' },
+  plugins: [stubModules],
+  write: false,
+});
+const js = result.outputFiles[0].text;
+const html = `<!doctype html><html class="dark"><head><meta charset="utf-8"><title>wallet widget e2e</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<style>${baseCss}</style>
+<style>${TOKEN_SHIM}</style>
+<style>html,body{margin:0;height:100%}</style>
+</head><body><div id="root"></div><script>${js}</script></body></html>`;
+const htmlPath = join(outDir, "wallet-widget.html");
+await writeFile(htmlPath, html);
+
+const browser = await chromium.launch();
+try {
+  const ctx = await browser.newContext({
+    viewport: { width: 420, height: 560 },
+    deviceScaleFactor: 2,
+  });
+  const page = await ctx.newPage();
+  const errors = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+
+  // DEFAULT state — no holdings, BTC/SOL/ETH rows must appear (the bug fix).
+  await page.goto(`file://${htmlPath}?state=default`);
+  await page.waitForSelector('[data-testid="chat-widget-wallet-prices"]', {
+    timeout: 8000,
+  });
+  const defaultRows = await page
+    .locator('[data-testid^="wallet-price-row-"]')
+    .evaluateAll((els) => els.map((e) => e.dataset.testid));
+  assert(
+    JSON.stringify(defaultRows) ===
+      JSON.stringify([
+        "wallet-price-row-BTC",
+        "wallet-price-row-SOL",
+        "wallet-price-row-ETH",
+      ]),
+    `DEFAULT state shows BTC/SOL/ETH rows (got ${JSON.stringify(defaultRows)})`,
+  );
+  await page.screenshot({ path: join(outDir, "wallet-default.png") });
+  console.log("  📸 wallet-default.png");
+
+  // HELD state — top-3 priced holdings by holding value: ETH $5000, SOL $2000, USDC $800.
+  await page.goto(`file://${htmlPath}?state=held`);
+  await page.waitForSelector('[data-testid="chat-widget-wallet-prices"]', {
+    timeout: 8000,
+  });
+  const heldRows = await page
+    .locator('[data-testid^="wallet-price-row-"]')
+    .evaluateAll((els) => els.map((e) => e.dataset.testid));
+  assert(
+    JSON.stringify(heldRows) ===
+      JSON.stringify([
+        "wallet-price-row-ETH",
+        "wallet-price-row-SOL",
+        "wallet-price-row-USDC",
+      ]),
+    `HELD state shows top-3 held by value ETH/SOL/USDC (got ${JSON.stringify(heldRows)})`,
+  );
+  // Price-only invariant (#10706): the $5000/$2000/$800 holding values must NOT leak.
+  const heldText = await page
+    .locator('[data-testid="chat-widget-wallet-prices"]')
+    .innerText();
+  assert(
+    !heldText.includes("5,000") && !heldText.includes("2,000") && !heldText.includes("800"),
+    "HELD state leaks no holding values (price-only #10706)",
+  );
+  await page.screenshot({ path: join(outDir, "wallet-held.png") });
+  console.log("  📸 wallet-held.png");
+
+  assert(errors.length === 0, `no page errors (${errors.length})`);
+  for (const e of errors) console.log("  ERR:", e);
+  await ctx.close();
+} finally {
+  await browser.close();
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} assertion(s) FAILED`);
+  process.exit(1);
+}
+console.log("\nAll wallet-widget assertions passed.");

--- a/packages/ui/src/components/chat/widgets/__e2e__/wallet-widget-fixture.tsx
+++ b/packages/ui/src/components/chat/widgets/__e2e__/wallet-widget-fixture.tsx
@@ -1,0 +1,45 @@
+/**
+ * Render fixture for the WALLET home widget (#14344). Mounts the REAL
+ * `WalletBalanceWidget` on an orange home-like field so the screenshot harness
+ * can capture both states in a real browser without an app server: the
+ * no-holdings DEFAULT state (BTC/SOL/ETH price rows) and the HELD state (top-3
+ * held by holding value, price-only). The state is chosen by `?state=held` in
+ * the URL; the `../../../api` client is stubbed by the runner to return the
+ * matching balances/overview.
+ */
+import { createRoot } from "react-dom/client";
+import { WalletBalanceWidget } from "../wallet-balance";
+
+const held = new URLSearchParams(location.search).get("state") === "held";
+
+const root = createRoot(document.getElementById("root") as HTMLElement);
+root.render(
+  <div
+    // The real home field is the orange accent surface; the widget is a
+    // chromeless tile on it. A fixed narrow column mimics the 2-col home grid.
+    style={{
+      background: "#e8590c",
+      minHeight: "100vh",
+      display: "grid",
+      placeItems: "start center",
+      padding: "48px 0",
+    }}
+  >
+    <div style={{ width: 360 }}>
+      <div
+        data-testid="wallet-state-label"
+        style={{
+          color: "rgba(255,255,255,0.85)",
+          font: "600 13px system-ui",
+          marginBottom: 8,
+          textAlign: "center",
+        }}
+      >
+        {held ? "HELD — top-3 by holding value" : "DEFAULT — no holdings"}
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <WalletBalanceWidget spanClassName="col-span-2 row-span-1" />
+      </div>
+    </div>
+  </div>,
+);

--- a/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
@@ -2,13 +2,16 @@
 //
 // WalletBalanceWidget (price-only): loading placeholder until data resolves,
 // price-only rows for held assets (no amounts/holding value), skipping holdings
-// under $1, self-hide on empty balances, and opening the wallet view on tap.
-// jsdom render with the wallet balances/market API mocked (no backend).
+// under $1, the BTC/SOL/ETH default rows when nothing is held (#14344), the 60s
+// document-visibility-gated price refresh, self-hide only when prices are
+// unavailable, and opening the wallet view on tap. jsdom render with the wallet
+// balances/market API mocked (no backend).
 import type {
   WalletBalancesResponse,
   WalletMarketOverviewResponse,
 } from "@elizaos/shared";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -85,12 +88,18 @@ function balances(
 
 function overview(
   prices: { symbol: string; priceUsd: number; change24hPct?: number }[],
+  movers: { symbol: string; priceUsd: number; change24hPct?: number }[] = [],
 ): WalletMarketOverviewResponse {
   return {
     prices: prices.map((p) => ({
       symbol: p.symbol,
       priceUsd: p.priceUsd,
       change24hPct: p.change24hPct ?? 0,
+    })),
+    movers: movers.map((m) => ({
+      symbol: m.symbol,
+      priceUsd: m.priceUsd,
+      change24hPct: m.change24hPct ?? 0,
     })),
   } as unknown as WalletMarketOverviewResponse;
 }
@@ -183,5 +192,70 @@ describe("WalletBalanceWidget (price-only, #10706)", () => {
     );
     fireEvent.click(screen.getByTestId("chat-widget-wallet-prices"));
     expect(navOpenView).toHaveBeenCalledWith("/wallet", "wallet");
+  });
+
+  it("shows BTC/SOL/ETH default rows when the user holds nothing (#14344)", async () => {
+    // Fresh account: no holdings, but the overview supplies the tracked prices.
+    getWalletBalances.mockResolvedValue({ evm: null, solana: null });
+    getWalletMarketOverview.mockResolvedValue(
+      overview([
+        { symbol: "BTC", priceUsd: 64000, change24hPct: 1.2 },
+        { symbol: "ETH", priceUsd: 3000, change24hPct: -0.5 },
+        { symbol: "SOL", priceUsd: 150, change24hPct: 2.1 },
+      ]),
+    );
+    render(<WalletBalanceWidget />);
+    await waitFor(() =>
+      expect(screen.getByTestId("chat-widget-wallet-prices")).toBeTruthy(),
+    );
+    const rows = screen.getAllByTestId(/^wallet-price-row-/);
+    // Display order is BTC / SOL / ETH regardless of snapshot arrival order.
+    expect(rows.map((r) => r.dataset.testid)).toEqual([
+      "wallet-price-row-BTC",
+      "wallet-price-row-SOL",
+      "wallet-price-row-ETH",
+    ]);
+    const text = screen.getByTestId("chat-widget-wallet-prices").textContent;
+    expect(text).toContain("$64,000.00");
+    expect(text).toContain("$150.00");
+    expect(text).toContain("$3,000.00");
+  });
+
+  it("refreshes prices on the 60s visibility-gated interval (#14344)", async () => {
+    vi.useFakeTimers();
+    try {
+      getWalletBalances.mockResolvedValue({ evm: null, solana: null });
+      getWalletMarketOverview
+        .mockResolvedValueOnce(overview([{ symbol: "BTC", priceUsd: 64000 }]))
+        .mockResolvedValue(overview([{ symbol: "BTC", priceUsd: 70000 }]));
+      render(<WalletBalanceWidget />);
+      // Flush the initial fetch.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(
+        screen.getByTestId("chat-widget-wallet-prices").textContent,
+      ).toContain("$64,000.00");
+      expect(getWalletMarketOverview).toHaveBeenCalledTimes(1);
+      // One interval tick → a fresh fetch updates the displayed price.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(getWalletMarketOverview).toHaveBeenCalledTimes(2);
+      expect(
+        screen.getByTestId("chat-widget-wallet-prices").textContent,
+      ).toContain("$70,000.00");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("hides (no error chrome) when the overview is unavailable", async () => {
+    // Overview down → no prices at all → the widget self-hides on the home.
+    getWalletBalances.mockResolvedValue({ evm: null, solana: null });
+    getWalletMarketOverview.mockRejectedValue(new Error("overview 503"));
+    const { container } = render(<WalletBalanceWidget />);
+    await waitFor(() => expect(getWalletMarketOverview).toHaveBeenCalled());
+    await waitFor(() => expect(container.firstChild).toBeNull());
   });
 });

--- a/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
@@ -104,6 +104,15 @@ function overview(
   } as unknown as WalletMarketOverviewResponse;
 }
 
+/** Override jsdom's document visibility so the refresh gate can be exercised. */
+function setVisibility(state: "visible" | "hidden"): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
 beforeEach(() => {
   authMock.authenticated = true;
   navOpenView.mockReset();
@@ -115,6 +124,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  setVisibility("visible");
 });
 
 describe("WalletBalanceWidget (price-only, #10706)", () => {
@@ -245,6 +255,54 @@ describe("WalletBalanceWidget (price-only, #10706)", () => {
       expect(
         screen.getByTestId("chat-widget-wallet-prices").textContent,
       ).toContain("$70,000.00");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not poll while the document is hidden", async () => {
+    vi.useFakeTimers();
+    try {
+      setVisibility("hidden");
+      getWalletBalances.mockResolvedValue({ evm: null, solana: null });
+      getWalletMarketOverview.mockResolvedValue(
+        overview([{ symbol: "BTC", priceUsd: 64000 }]),
+      );
+
+      render(<WalletBalanceWidget />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(getWalletMarketOverview).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(180_000);
+      });
+      expect(getWalletMarketOverview).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not fetch or install the refresh poll before authentication", async () => {
+    vi.useFakeTimers();
+    try {
+      authMock.authenticated = false;
+      getWalletBalances.mockResolvedValue({ evm: null, solana: null });
+      getWalletMarketOverview.mockResolvedValue(
+        overview([{ symbol: "BTC", priceUsd: 64000 }]),
+      );
+
+      render(<WalletBalanceWidget />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(180_000);
+      });
+
+      expect(getWalletBalances).not.toHaveBeenCalled();
+      expect(getWalletMarketOverview).not.toHaveBeenCalled();
+      expect(
+        screen.getByTestId("chat-widget-wallet-balance-loading"),
+      ).toBeTruthy();
     } finally {
       vi.useRealTimers();
     }

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -1,25 +1,34 @@
 /**
  * WALLET home widget. A glanceable, chromeless tile on the orange home field
- * listing the top cryptocurrencies the user HOLDS by **unit price only** — never
- * the amount held or the holding value (#10706). Tapping opens the wallet view.
+ * showing crypto **unit prices only** — never the amount held or the holding
+ * value (#10706). Tapping opens the wallet view.
  *
- * Holdings-gated: when there is no qualifying priced holding (nothing held worth
- * ≥ $1 that also has a market price), the widget renders nothing rather than a
- * connect affordance — an empty wallet is not actionable here.
+ * Two states, always visible once prices load (#14344): when the user holds ≥1
+ * priced token worth ≥ $1, the top-3 held by holding value; otherwise the
+ * tracked BTC/SOL/ETH default rows (back-filled from trending movers if the
+ * overview is partial). Prices refresh on a 60s document-visibility-gated
+ * interval — no polling while the app is backgrounded. It self-hides only when
+ * prices are unavailable (both endpoints down / never loaded): the home surface
+ * shows no error chrome; the wallet view owns error state (J4).
  */
 
 import type { WalletBalancesResponse } from "@elizaos/shared";
 import { Wallet } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { client } from "../../../api";
 import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
+import { useIntervalWhenDocumentVisible } from "../../../hooks/useDocumentVisibility";
 import type { WidgetProps } from "../../../widgets/types";
 import { Button } from "../../ui/button";
 import { useWidgetNavigation } from "./home-widget-card";
 import {
   type PricedHolding,
+  selectDefaultPriceRows,
   selectPricedHoldings,
 } from "./wallet-price-holdings";
+
+/** Price refresh cadence; the server caches market overview 120s so this is cheap. */
+const REFRESH_INTERVAL_MS = 60_000;
 
 const DEFAULT_SPAN = "col-span-2 row-span-1";
 
@@ -55,38 +64,44 @@ export function WalletBalanceWidget(
   const [loading, setLoading] = useState(true);
   const nav = useWidgetNavigation();
   // Auth gate (#11084): the widget mounts before the auth probe resolves, so
-  // the one-shot balances/prices fetch must stay dormant until the session is
-  // authenticated (it fires once the phase flips).
+  // fetching stays dormant until the session is authenticated.
   const authenticated = useIsAuthenticated();
+
+  // Prices (BTC/SOL/ETH + trending) come from the market-overview endpoint;
+  // balances decide the held-vs-default branch. Both are fetched together and
+  // best-effort (J4): a null overview means prices are unavailable → hide; a
+  // null balances alone still shows the default rows.
+  const refresh = useCallback(async () => {
+    const [balances, overview] = await Promise.all([
+      // error-policy:J4 balances failure ⇒ no held rows; default rows still show
+      (client.getWalletBalances() as Promise<WalletBalancesResponse>).catch(
+        () => null,
+      ),
+      // error-policy:J4 overview failure ⇒ no prices at all ⇒ widget hides
+      client.getWalletMarketOverview().catch(() => null),
+    ]);
+    const held = selectPricedHoldings(balances, overview?.prices);
+    const next = held.length > 0 ? held : selectDefaultPriceRows(overview);
+    // A failed refresh (next empty) keeps the last-good rows so a transient
+    // outage does not flicker the tile out; only a first load with no prices
+    // resolves to empty (→ hidden).
+    setHoldings((prev) => (next.length > 0 ? next : (prev ?? [])));
+    setLoading(false);
+  }, []);
 
   useEffect(() => {
     if (!authenticated) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        // Prices come from a separate endpoint; fetch both together. The widget
-        // shows prices only, so a balances failure means "nothing to show".
-        const [balances, overview] = await Promise.all([
-          client.getWalletBalances() as Promise<WalletBalancesResponse>,
-          // error-policy:J4 prices are the widget's optional decoration; the
-          // hide-on-failure degrade below covers a missing overview too
-          client.getWalletMarketOverview().catch(() => null),
-        ]);
-        if (cancelled) return;
-        setHoldings(selectPricedHoldings(balances, overview?.prices));
-      } catch {
-        // error-policy:J4 home-grid tiles self-hide rather than surface error
-        // chrome (designed home-surface degrade); the wallet page itself owns
-        // the visible error state for a broken balances endpoint.
-        if (!cancelled) setHoldings(null);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [authenticated]);
+    void refresh();
+  }, [authenticated, refresh]);
+
+  // Visibility-gated refresh: no requests fire while the app is backgrounded.
+  useIntervalWhenDocumentVisible(
+    () => {
+      void refresh();
+    },
+    REFRESH_INTERVAL_MS,
+    authenticated,
+  );
 
   // First load pending: a quiet placeholder keeps the grid cell stable.
   if (loading && holdings == null) {
@@ -99,7 +114,8 @@ export function WalletBalanceWidget(
     );
   }
 
-  // Holdings-gated empty: no qualifying priced holding → render nothing.
+  // Prices unavailable (overview never loaded / both endpoints down) → render
+  // nothing rather than error chrome on the home surface (J4).
   if (!holdings || holdings.length === 0) return null;
 
   return (

--- a/packages/ui/src/components/chat/widgets/wallet-price-holdings.test.ts
+++ b/packages/ui/src/components/chat/widgets/wallet-price-holdings.test.ts
@@ -1,22 +1,26 @@
 // `selectPricedHoldings` selection logic: empty on missing balances, price-only
 // rows with no amount/holding value leaked, dust (<$1) skipped, capped at the top
-// 5 by holding value, only priced symbols included, same symbol aggregated across
-// chains (case-insensitive), native SOL/ETH counted. Pure function — no jsdom.
+// 3 by holding value, only priced symbols included, same symbol aggregated across
+// chains (case-insensitive), native SOL/ETH counted. Plus `selectDefaultPriceRows`
+// for the no-holdings state (BTC/SOL/ETH + trending fill). Pure function — no jsdom.
 import type {
   WalletBalancesResponse,
+  WalletMarketMover,
   WalletMarketPriceSnapshot,
 } from "@elizaos/contracts";
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_WIDGET_SYMBOLS,
   MAX_PRICED_HOLDINGS,
   MIN_HOLDING_USD,
   type PricedHolding,
+  selectDefaultPriceRows,
   selectPricedHoldings,
 } from "./wallet-price-holdings.ts";
 
 /**
  * Price-only wallet widget derivation (#10706). The acceptance criteria are the
- * contract: top-5 HELD assets, prices only, skip holdings < $1, and never leak
+ * contract: top-3 HELD assets, prices only, skip holdings < $1, and never leak
  * the amount/holding value. Each is pinned here.
  */
 
@@ -112,7 +116,7 @@ describe("selectPricedHoldings", () => {
     expect(MIN_HOLDING_USD).toBe(1);
   });
 
-  it("caps the list at the top 5 by holding value (ranked desc)", () => {
+  it("caps the list at the top 3 by holding value (ranked desc)", () => {
     const held = [
       { symbol: "A", valueUsd: "10" },
       { symbol: "B", valueUsd: "60" },
@@ -127,8 +131,9 @@ describe("selectPricedHoldings", () => {
       held.map((h) => price(h.symbol, 1)),
     );
     expect(rows).toHaveLength(MAX_PRICED_HOLDINGS);
-    // top 5 by value: G(70) B(60) D(50) F(40) C(30)
-    expect(rows.map((r) => r.symbol)).toEqual(["G", "B", "D", "F", "C"]);
+    expect(MAX_PRICED_HOLDINGS).toBe(3);
+    // top 3 by value: G(70) B(60) D(50)
+    expect(rows.map((r) => r.symbol)).toEqual(["G", "B", "D"]);
   });
 
   it("only includes symbols that have a unit price in the market overview", () => {
@@ -169,5 +174,68 @@ describe("selectPricedHoldings", () => {
         price("SHIB", 0.00001),
       ]),
     ).toEqual([]);
+  });
+});
+
+const mover = (
+  symbol: string,
+  priceUsd: number,
+  change24hPct = 0,
+): WalletMarketMover => ({
+  id: symbol.toLowerCase(),
+  symbol,
+  name: symbol,
+  priceUsd,
+  change24hPct,
+  marketCapRank: null,
+  imageUrl: null,
+});
+
+describe("selectDefaultPriceRows (#14344)", () => {
+  it("returns [] for a null/absent overview (prices unavailable → widget hides)", () => {
+    expect(selectDefaultPriceRows(null)).toEqual([]);
+    expect(selectDefaultPriceRows(undefined)).toEqual([]);
+    expect(selectDefaultPriceRows({ prices: [], movers: [] })).toEqual([]);
+  });
+
+  it("returns BTC/SOL/ETH in display order from the fixed snapshots", () => {
+    // Snapshots arrive in MARKET_PRICE_IDS order (BTC, ETH, SOL); display is BTC/SOL/ETH.
+    const rows = selectDefaultPriceRows({
+      prices: [
+        price("BTC", 64000, 1.2),
+        price("ETH", 3000, -0.5),
+        price("SOL", 150, 2.1),
+      ],
+      movers: [],
+    });
+    expect(rows.map((r) => r.symbol)).toEqual([...DEFAULT_WIDGET_SYMBOLS]);
+    expect(rows).toEqual<PricedHolding[]>([
+      { symbol: "BTC", priceUsd: 64000, change24hPct: 1.2 },
+      { symbol: "SOL", priceUsd: 150, change24hPct: 2.1 },
+      { symbol: "ETH", priceUsd: 3000, change24hPct: -0.5 },
+    ]);
+  });
+
+  it("back-fills a missing fixed snapshot from trending movers, up to 3 rows", () => {
+    // Partial source: only BTC + ETH snapshots; SOL is missing → fill from movers.
+    const rows = selectDefaultPriceRows({
+      prices: [price("BTC", 64000), price("ETH", 3000)],
+      movers: [mover("DOGE", 0.12, 5.5), mover("PEPE", 0.000008, -3)],
+    });
+    expect(rows).toHaveLength(3);
+    // BTC, ETH from snapshots; DOGE fills the third slot (first eligible mover).
+    expect(rows.map((r) => r.symbol)).toEqual(["BTC", "ETH", "DOGE"]);
+  });
+
+  it("does not duplicate a symbol that is both a fixed snapshot and a mover", () => {
+    const rows = selectDefaultPriceRows({
+      prices: [price("BTC", 64000)],
+      movers: [
+        mover("BTC", 64000),
+        mover("DOGE", 0.12),
+        mover("PEPE", 0.00001),
+      ],
+    });
+    expect(rows.map((r) => r.symbol)).toEqual(["BTC", "DOGE", "PEPE"]);
   });
 });

--- a/packages/ui/src/components/chat/widgets/wallet-price-holdings.ts
+++ b/packages/ui/src/components/chat/widgets/wallet-price-holdings.ts
@@ -4,6 +4,8 @@
  */
 import type {
   WalletBalancesResponse,
+  WalletMarketMover,
+  WalletMarketOverviewResponse,
   WalletMarketPriceSnapshot,
 } from "@elizaos/contracts";
 
@@ -21,7 +23,7 @@ import type {
  *      for ranking, never surfaced),
  *   4. keep only symbols that have a unit price in the market overview,
  *   5. rank by aggregated holding value (desc; ties broken by symbol), take
- *      top 5,
+ *      top {@link MAX_PRICED_HOLDINGS},
  *   6. return price-only rows — `{ symbol, priceUsd, change24hPct }`, with NO
  *      balance, holding value, or portfolio total.
  */
@@ -29,7 +31,16 @@ import type {
 /** The minimum holding value (USD) a position must be worth to appear. */
 export const MIN_HOLDING_USD = 1;
 /** Max assets shown in the price-only widget. */
-export const MAX_PRICED_HOLDINGS = 5;
+export const MAX_PRICED_HOLDINGS = 3;
+
+/**
+ * Default rows shown when the user holds nothing priceable, in display order.
+ * BTC/SOL/ETH are the tracked fixed snapshots (`MARKET_PRICE_IDS`); when a
+ * partial-source overview drops one, the gap is filled from trending movers.
+ */
+export const DEFAULT_WIDGET_SYMBOLS = ["BTC", "SOL", "ETH"] as const;
+/** Rows shown in the default (no-holdings) state. */
+export const MAX_DEFAULT_ROWS = 3;
 
 /** A price-only row — deliberately carries no amount/holding value. */
 export interface PricedHolding {
@@ -113,4 +124,60 @@ export function selectPricedHoldings(
       change24hPct: price.change24hPct,
     };
   });
+}
+
+type MarketOverviewLike = Pick<
+  WalletMarketOverviewResponse,
+  "prices" | "movers"
+>;
+
+function toPricedRow(
+  s: WalletMarketPriceSnapshot | WalletMarketMover,
+): PricedHolding | null {
+  if (!Number.isFinite(s.priceUsd)) return null;
+  return {
+    symbol: s.symbol,
+    priceUsd: s.priceUsd,
+    change24hPct: s.change24hPct,
+  };
+}
+
+/**
+ * Rows for the no-holdings default state: the tracked BTC/SOL/ETH price
+ * snapshots in {@link DEFAULT_WIDGET_SYMBOLS} order, back-filled from trending
+ * movers when a partial-source overview omits one, capped at
+ * {@link MAX_DEFAULT_ROWS}. Pure + deterministic. Returns `[]` for a null/absent
+ * overview — the widget treats an empty result as "prices unavailable, hide".
+ */
+export function selectDefaultPriceRows(
+  overview: MarketOverviewLike | null | undefined,
+): PricedHolding[] {
+  if (!overview) return [];
+
+  const priceBySymbol = new Map<string, WalletMarketPriceSnapshot>();
+  for (const p of overview.prices ?? []) {
+    const key = p.symbol.trim().toUpperCase();
+    if (key && !priceBySymbol.has(key)) priceBySymbol.set(key, p);
+  }
+
+  const rows: PricedHolding[] = [];
+  const present = new Set<string>();
+  const push = (row: PricedHolding | null) => {
+    if (!row || rows.length >= MAX_DEFAULT_ROWS) return;
+    const key = row.symbol.trim().toUpperCase();
+    if (!key || present.has(key)) return;
+    present.add(key);
+    rows.push(row);
+  };
+
+  for (const symbol of DEFAULT_WIDGET_SYMBOLS) {
+    const snap = priceBySymbol.get(symbol);
+    if (snap) push(toPricedRow(snap));
+  }
+  // Fill any gap (a partial-source overview) with trending movers.
+  for (const mover of overview.movers ?? []) {
+    if (rows.length >= MAX_DEFAULT_ROWS) break;
+    push(toPricedRow(mover));
+  }
+  return rows;
 }


### PR DESCRIPTION
# Relates to

Closes #14344.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [ ] `bun run verify` was run after sync, or any failure is recorded below.
- [x] A reviewer can confirm the wallet-widget behavior from the tests and rendered screenshots below.

# Sync with develop

- [x] Rebased onto latest `origin/develop` (`7a0f0f33e35`) with zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact blocker is documented below.

# Risks

Low-medium. This is visible launcher/home UI behavior, but it is isolated to the wallet home widget and uses existing wallet endpoints only. The primary risk is polling more than intended; the tests now cover visible polling, hidden-tab silence, and pre-auth silence.

# Background

## What does this PR do?

The wallet home widget hid entirely when the user held nothing, and its one-shot mount fetch let prices go stale. This PR makes the widget match launcher doctrine: BTC/SOL/ETH by default, top-3 held when qualifying holdings exist, price-only display, 60s visibility-gated refresh, and no home error chrome when prices are unavailable.

## What kind of change is this?

Bug fix / UI behavior cleanup.

# Documentation changes needed?

No product docs required. This implements the existing launcher-widget doctrine from `packages/docs/ongoing-development/research/03-launcher-widgets.md`.

# Testing

## Where should a reviewer start?

Start with `packages/ui/src/components/chat/widgets/wallet-price-holdings.ts` for the pure row selection, then `packages/ui/src/components/chat/widgets/wallet-balance.tsx` for the widget behavior. The rendered proof comes from `packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs`.

## Detailed testing steps

```bash
bun run --cwd packages/ui test -- src/components/chat/widgets/wallet-balance.test.tsx src/components/chat/widgets/wallet-price-holdings.test.ts
bun run --cwd packages/ui test:wallet-widget-e2e
bunx @biomejs/biome check packages/ui/src/components/chat/widgets/wallet-balance.tsx packages/ui/src/components/chat/widgets/wallet-balance.test.tsx packages/ui/src/components/chat/widgets/wallet-price-holdings.ts packages/ui/src/components/chat/widgets/wallet-price-holdings.test.ts packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs packages/ui/src/components/chat/widgets/__e2e__/wallet-widget-fixture.tsx
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots / before state: [before empty state evidence](https://github.com/elizaOS/eliza/issues/14344#issuecomment-4888123080) documents the prior empty-wallet state where the tile self-hid.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [wallet default state](https://raw.githubusercontent.com/elizaOS/eliza/evidence/14344-wallet/default.png) and [wallet held state](https://raw.githubusercontent.com/elizaOS/eliza/evidence/14344-wallet/held.png); locally regenerated as `packages/ui/src/components/chat/widgets/__e2e__/output-wallet/wallet-default.png` and `wallet-held.png` and manually reviewed.
<!-- evidence-row:walkthrough-video -->
- [ ] Video walkthrough: N/A - this widget has no multi-step user flow beyond tap-to-open wallet; the real-browser screenshot harness covers both rendered states and the click path is covered by component test.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - no server path changed; this reuses existing cached `GET /api/wallet/market-overview` and `getWalletBalances` plumbing.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no browser network integration changed; the real-browser render transcript below shows default rows, held rows, no holding-value leak, and no page errors.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [wallet default screenshot](https://raw.githubusercontent.com/elizaOS/eliza/evidence/14344-wallet/default.png) and [wallet held screenshot](https://raw.githubusercontent.com/elizaOS/eliza/evidence/14344-wallet/held.png) prove the widget's default and held render states.

# Evidence Details

## Unit/component tests

```text
bun run --cwd packages/ui test -- src/components/chat/widgets/wallet-balance.test.tsx src/components/chat/widgets/wallet-price-holdings.test.ts
Test Files  2 passed (2)
Tests  22 passed (22)
```

Coverage includes default BTC/SOL/ETH rows, held rows, trending back-fill, both endpoint failure behavior, visible 60s refresh, no polling while hidden, and no fetch/poll before authentication.

## Real-browser wallet widget e2e

```text
bun run --cwd packages/ui test:wallet-widget-e2e
✓ DEFAULT state shows BTC/SOL/ETH rows (got ["wallet-price-row-BTC","wallet-price-row-SOL","wallet-price-row-ETH"])
  📸 wallet-default.png
✓ HELD state shows top-3 held by value ETH/SOL/USDC (got ["wallet-price-row-ETH","wallet-price-row-SOL","wallet-price-row-USDC"])
✓ HELD state leaks no holding values (price-only #10706)
  📸 wallet-held.png
✓ no page errors (0)
All wallet-widget assertions passed.
```

I manually opened the regenerated screenshots. The default state shows Wallet + BTC/SOL/ETH with unit prices and 24h changes on the orange field. The held state shows Wallet + ETH/SOL/USDC, with unit prices only; the seeded holding values are not visible.

## Biome

```text
Checked 4 files in 51ms. No fixes applied.
```

## Known gaps / failures

- `bun run verify`: not run in this turn; focused tests, real-browser wallet e2e, and scoped Biome were run after rebase.
- Live funded-wallet MP4: N/A for this local run. The held state is exercised with the real component over stubbed balances/overview in Chromium; no live funded wallet was available.

