### PR TITLE
feat(app): add connected device freshness status

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -57,6 +57,7 @@
     "test:e2e:android:lifecycle:reboot": "ELIZA_ANDROID_BACKEND=${ELIZA_ANDROID_BACKEND:-local} ELIZA_ANDROID_REQUIRE_AGENT=${ELIZA_ANDROID_REQUIRE_AGENT:-1} ELIZA_ANDROID_LIFECYCLE_REBOOT=1 bunx playwright test --config playwright.android.config.ts test/android/lifecycle-reboot.android.spec.ts",
     "test:e2e:android:cloud": "node scripts/android-e2e.mjs --skip-local-chat --skip-route-coverage --cloud",
     "test:e2e:android:webview": "ANDROID_SERIAL=${ANDROID_SERIAL:-} bunx playwright test --config playwright.android.config.ts",
+    "devices:status": "node scripts/devices-status.mjs",
     "test:e2e:ios:onboarding": "node scripts/ios-onboarding-smoke.mjs",
     "test:e2e:ios:voice": "node scripts/ios-voice-selftest-smoke.mjs",
     "test:sim:local-chat": "node scripts/mobile-local-chat-smoke.mjs --platform ios --require-installed",

--- a/packages/app/scripts/devices-status.mjs
+++ b/packages/app/scripts/devices-status.mjs
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+/**
+ * Read-only fleet freshness report for attached Android devices, booted iOS
+ * simulators, and paired physical iOS devices. It compares each installed
+ * renderer stamp against `origin/develop` so stale device coverage is visible
+ * before a runner starts.
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
+import { DEFAULT_APP_BUNDLE_ID } from "./ios-device-lib.mjs";
+import {
+  APP_ID,
+  listDevices,
+  readInstalledRendererStamp,
+  resolveAdb,
+} from "./lib/android-device.mjs";
+import {
+  buildDeviceStatusRow,
+  formatDeviceStatusTable,
+  hasNonFreshDevice,
+} from "./lib/devices-status.mjs";
+import {
+  readRendererManifest,
+  rendererManifestPathFromAppPath,
+} from "./lib/ios-renderer-stamp.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const appRoot = path.resolve(scriptDir, "..");
+const repoRoot = path.resolve(appRoot, "..", "..");
+export const IOS_DEVICE_DEPLOY_LEDGER = "ios-device-deploy-ledger.jsonl";
+
+function hasArg(name) {
+  return process.argv.includes(name);
+}
+
+function runText(command, args, options = {}) {
+  try {
+    return execFileSync(command, args, {
+      cwd: options.cwd ?? repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+export function devicesStatusStateDir(env = process.env) {
+  return path.resolve(
+    env.ELIZA_DEVICES_STATUS_DIR?.trim() ||
+      env.ELIZA_STATE_DIR?.trim() ||
+      path.join(os.homedir(), ".local", "state", "eliza"),
+  );
+}
+
+export function devicesStatusLedgerPath(env = process.env) {
+  return path.join(devicesStatusStateDir(env), IOS_DEVICE_DEPLOY_LEDGER);
+}
+
+export function appendIosDeviceDeployLedger(entry, env = process.env) {
+  const ledgerPath = devicesStatusLedgerPath(env);
+  fs.mkdirSync(path.dirname(ledgerPath), { recursive: true });
+  fs.appendFileSync(ledgerPath, `${JSON.stringify(entry)}\n`);
+  return ledgerPath;
+}
+
+function readIosDeviceDeployLedger(env = process.env) {
+  const ledgerPath = devicesStatusLedgerPath(env);
+  if (!fs.existsSync(ledgerPath)) return [];
+  return fs
+    .readFileSync(ledgerPath, "utf8")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function latestLedgerEntryForDevice(device, entries) {
+  const identifiers = new Set(
+    [device.udid, device.identifier, device.name].filter(Boolean).map(String),
+  );
+  return entries
+    .filter((entry) =>
+      [entry.udid, entry.identifier, entry.name].some((value) =>
+        identifiers.has(String(value ?? "")),
+      ),
+    )
+    .sort((a, b) =>
+      String(b.deployedAt).localeCompare(String(a.deployedAt)),
+    )[0];
+}
+
+function fetchDevelopHead() {
+  spawnSync("git", ["fetch", "origin", "develop", "--quiet"], {
+    cwd: repoRoot,
+    stdio: "ignore",
+  });
+  return runText("git", ["rev-parse", "origin/develop"]);
+}
+
+function androidRows(developHead) {
+  let adb;
+  try {
+    adb = resolveAdb();
+  } catch {
+    return [
+      buildDeviceStatusRow({
+        platform: "android",
+        id: "adb",
+        name: "adb not available",
+        kind: "n/a",
+        stamp: null,
+        developHead,
+        source: "adb",
+      }),
+    ];
+  }
+  const devices = listDevices(adb);
+  if (devices.length === 0) return [];
+  return devices.map((serial) => {
+    let stamp = null;
+    try {
+      stamp = readInstalledRendererStamp(adb, serial);
+    } catch {
+      stamp = null;
+    }
+    return buildDeviceStatusRow({
+      platform: "android",
+      id: serial,
+      name: serial,
+      kind: serial.startsWith("emulator-") ? "emulator" : "device",
+      stamp,
+      developHead,
+      source: `adb:${APP_ID}`,
+    });
+  });
+}
+
+function bootedIosSimulators() {
+  const raw = runText("xcrun", ["simctl", "list", "devices", "--json"]);
+  if (!raw) return [];
+  const parsed = JSON.parse(raw);
+  return Object.values(parsed.devices ?? {})
+    .flat()
+    .filter((device) => device?.state === "Booted");
+}
+
+function iosSimulatorRows(developHead) {
+  if (process.platform !== "darwin") {
+    return [
+      buildDeviceStatusRow({
+        platform: "ios-sim",
+        id: "simctl",
+        name: "iOS simulator n/a",
+        kind: "n/a",
+        stamp: null,
+        developHead,
+        source: "not macOS",
+      }),
+    ];
+  }
+  return bootedIosSimulators().map((device) => {
+    const appPath = runText("xcrun", [
+      "simctl",
+      "get_app_container",
+      device.udid,
+      DEFAULT_APP_BUNDLE_ID,
+      "app",
+    ]);
+    let stamp = null;
+    if (appPath) {
+      try {
+        stamp = readRendererManifest(
+          rendererManifestPathFromAppPath(appPath),
+          `iOS simulator ${device.name}`,
+        );
+      } catch {
+        stamp = null;
+      }
+    }
+    return buildDeviceStatusRow({
+      platform: "ios-sim",
+      id: device.udid,
+      name: device.name,
+      kind: "simulator",
+      stamp,
+      developHead,
+      source: "simctl",
+    });
+  });
+}
+
+function physicalIosDevices() {
+  if (process.platform !== "darwin") return [];
+  try {
+    return (readDevicectlDeviceList()?.result?.devices ?? []).map((device) => ({
+      identifier: device.identifier,
+      udid: device.hardwareProperties?.udid,
+      name: device.deviceProperties?.name ?? device.identifier,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function iosPhysicalRows(developHead) {
+  if (process.platform !== "darwin") {
+    return [
+      buildDeviceStatusRow({
+        platform: "ios-device",
+        id: "devicectl",
+        name: "physical iOS n/a",
+        kind: "n/a",
+        stamp: null,
+        developHead,
+        source: "not macOS",
+      }),
+    ];
+  }
+  const ledger = readIosDeviceDeployLedger();
+  return physicalIosDevices().map((device) => {
+    const entry = latestLedgerEntryForDevice(device, ledger);
+    const stamp = entry
+      ? {
+          buildId: entry.buildId,
+          commit: entry.commit,
+          builtAt: entry.builtAt,
+        }
+      : null;
+    return buildDeviceStatusRow({
+      platform: "ios-device",
+      id: device.udid ?? device.identifier,
+      name: device.name,
+      kind: "physical",
+      stamp,
+      developHead,
+      source: entry ? "deploy-ledger" : "no ledger entry",
+    });
+  });
+}
+
+export function collectDeviceStatus() {
+  const developHead = fetchDevelopHead();
+  return [
+    ...androidRows(developHead),
+    ...iosSimulatorRows(developHead),
+    ...iosPhysicalRows(developHead),
+  ];
+}
+
+function main() {
+  const rows = collectDeviceStatus();
+  if (hasArg("--json")) {
+    console.log(JSON.stringify(rows, null, 2));
+  } else {
+    console.log(formatDeviceStatusTable(rows));
+  }
+  if (hasArg("--require-fresh") && hasNonFreshDevice(rows)) {
+    process.exitCode = 1;
+  }
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirectRun) {
+  main();
+}

--- a/packages/app/scripts/devices-status.test.mjs
+++ b/packages/app/scripts/devices-status.test.mjs
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the device freshness status policy. Hardware probing is
+ * exercised by the device lanes; these tests pin the verdicts and table output
+ * that make stale installs machine-readable.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildDeviceStatusRow,
+  formatDeviceStatusTable,
+  hasNonFreshDevice,
+  rendererStampVerdict,
+  sameCommit,
+} from "./lib/devices-status.mjs";
+
+describe("devices-status policy", () => {
+  it("matches full and short shas in either direction", () => {
+    expect(sameCommit("abcdef1234567890", "abcdef123456")).toBe(true);
+    expect(sameCommit("abcdef123456", "abcdef1234567890")).toBe(true);
+    expect(sameCommit("111111", "222222")).toBe(false);
+  });
+
+  it("marks matching installed commits fresh", () => {
+    expect(
+      rendererStampVerdict({
+        stamp: { buildId: "b", commit: "abcdef1234567890" },
+        developHead: "abcdef1234567890",
+      }),
+    ).toEqual({
+      verdict: "FRESH",
+      reason: "installed commit matches develop",
+    });
+  });
+
+  it("marks mismatched installed commits stale", () => {
+    expect(
+      rendererStampVerdict({
+        stamp: { buildId: "b", commit: "111111111111" },
+        developHead: "222222222222",
+      }),
+    ).toMatchObject({
+      verdict: "STALE",
+      reason: expect.stringContaining("111111111111 != develop 222222222222"),
+    });
+  });
+
+  it("marks missing stamps unknown", () => {
+    expect(rendererStampVerdict({ stamp: null, developHead: "abc" })).toEqual({
+      verdict: "UNKNOWN",
+      reason: "no installed renderer stamp",
+    });
+  });
+
+  it("ignores host-unavailable n/a rows for require-fresh", () => {
+    const rows = [
+      buildDeviceStatusRow({
+        platform: "ios-sim",
+        id: "simctl",
+        name: "iOS simulator n/a",
+        kind: "n/a",
+        stamp: null,
+        developHead: "abc",
+        source: "not macOS",
+      }),
+    ];
+    expect(hasNonFreshDevice(rows)).toBe(false);
+  });
+
+  it("formats a reviewer-readable table", () => {
+    const row = buildDeviceStatusRow({
+      platform: "android",
+      id: "emulator-5554",
+      name: "emulator-5554",
+      kind: "emulator",
+      stamp: { buildId: "buildabcdef", commit: "abcdef1234567890" },
+      developHead: "abcdef1234567890",
+      source: "adb",
+    });
+    expect(formatDeviceStatusTable([row])).toContain("emulator-5554");
+    expect(formatDeviceStatusTable([row])).toContain("FRESH");
+  });
+});

--- a/packages/app/scripts/ios-device-deploy.mjs
+++ b/packages/app/scripts/ios-device-deploy.mjs
@@ -38,6 +38,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { appendIosDeviceDeployLedger } from "./devices-status.mjs";
 import {
   readDevicectlDeviceList,
   readDevicectlDeviceLockState,
@@ -57,6 +58,10 @@ import {
   selectProvisioningProfile,
   selectSigningIdentity,
 } from "./ios-device-lib.mjs";
+import {
+  readRendererManifest,
+  rendererManifestPathFromAppPath,
+} from "./lib/ios-renderer-stamp.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(scriptDir, "..");
@@ -481,6 +486,21 @@ async function main() {
     device.identifier,
     stagedApp,
   ]);
+  const rendererStamp = readRendererManifest(
+    rendererManifestPathFromAppPath(stagedApp),
+    "staged iOS device app",
+  );
+  const ledgerPath = appendIosDeviceDeployLedger({
+    identifier: device.identifier,
+    udid: device.udid,
+    name: device.name,
+    bundleId,
+    buildId: rendererStamp.buildId,
+    commit: rendererStamp.commit ?? null,
+    builtAt: rendererStamp.builtAt ?? null,
+    deployedAt: new Date().toISOString(),
+  });
+  log(`deploy ledger: ${ledgerPath}`);
 
   // 6. Launch (default on; --no-launch to skip). Console capture is
   //    ios-device-logs.mjs's job — this launch does not hold the terminal.

--- a/packages/app/scripts/lib/devices-status.mjs
+++ b/packages/app/scripts/lib/devices-status.mjs
@@ -1,0 +1,99 @@
+/**
+ * Pure device-status policy shared by the CLI and tests. Device probing is
+ * host-specific, but freshness verdicts must stay deterministic so stale
+ * installs fail the same way on every machine.
+ */
+
+export function sameCommit(a, b) {
+  if (!a || !b) return false;
+  const left = String(a);
+  const right = String(b);
+  return left.startsWith(right) || right.startsWith(left);
+}
+
+export function shortSha(value) {
+  return value ? String(value).slice(0, 12) : "-";
+}
+
+export function rendererStampVerdict({ stamp, developHead }) {
+  if (!stamp) {
+    return { verdict: "UNKNOWN", reason: "no installed renderer stamp" };
+  }
+  if (!stamp.commit) {
+    return { verdict: "UNKNOWN", reason: "installed stamp has no commit" };
+  }
+  if (!developHead) {
+    return { verdict: "UNKNOWN", reason: "origin/develop head unavailable" };
+  }
+  if (sameCommit(stamp.commit, developHead)) {
+    return { verdict: "FRESH", reason: "installed commit matches develop" };
+  }
+  return {
+    verdict: "STALE",
+    reason: `installed ${shortSha(stamp.commit)} != develop ${shortSha(developHead)}`,
+  };
+}
+
+export function buildDeviceStatusRow({
+  platform,
+  id,
+  name,
+  kind,
+  stamp,
+  developHead,
+  source,
+}) {
+  const status = rendererStampVerdict({ stamp, developHead });
+  return {
+    platform,
+    id,
+    name: name || id,
+    kind,
+    buildId: stamp?.buildId ?? null,
+    commit: stamp?.commit ?? null,
+    developHead: developHead ?? null,
+    verdict: status.verdict,
+    reason: status.reason,
+    source,
+  };
+}
+
+export function hasNonFreshDevice(rows) {
+  return rows.some((row) => row.kind !== "n/a" && row.verdict !== "FRESH");
+}
+
+export function formatDeviceStatusTable(rows) {
+  const headers = [
+    "PLATFORM",
+    "DEVICE",
+    "KIND",
+    "BUILD",
+    "COMMIT",
+    "DEVELOP",
+    "VERDICT",
+    "REASON",
+  ];
+  const body = rows.map((row) => [
+    row.platform,
+    row.name || row.id,
+    row.kind,
+    shortSha(row.buildId),
+    shortSha(row.commit),
+    shortSha(row.developHead),
+    row.verdict,
+    row.reason,
+  ]);
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...body.map((row) => String(row[index]).length)),
+  );
+  const render = (row) =>
+    row
+      .map((cell, index) => String(cell).padEnd(widths[index]))
+      .join("  ")
+      .trimEnd();
+  return [
+    render(headers),
+    render(headers.map((h) => "-".repeat(h.length))),
+    ...body.map(render),
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary
- add `bun run --cwd packages/app devices:status` with table and `--json` output
- report Android installed renderer stamps, booted iOS simulator stamps, and physical iOS deploy-ledger stamps against `origin/develop`
- add `--require-fresh` policy that fails for connected STALE/UNKNOWN devices while ignoring host-unavailable `n/a` lanes
- write a physical-iOS deploy ledger entry after successful `ios-device-deploy.mjs` installs

Relates to #14335.

Stacked on #14475 because Android stamp readback lands there. Retarget to `develop` after #14475 merges.

## Validation
- `bunx @biomejs/biome check packages/app/scripts/devices-status.mjs packages/app/scripts/lib/devices-status.mjs packages/app/scripts/devices-status.test.mjs packages/app/scripts/ios-device-deploy.mjs packages/app/package.json packages/app/scripts/android-adb-install.mjs packages/app/scripts/android-e2e.mjs packages/app/scripts/lib/android-device.mjs packages/app/scripts/lib/android-renderer-stamp.mjs packages/app/scripts/android-renderer-stamp.test.mjs packages/app/test/android-renderer-stamp.test.ts`
- `bunx vitest run --config packages/app/vitest.config.ts packages/app/scripts/devices-status.test.mjs packages/app/scripts/android-renderer-stamp.test.mjs packages/app/test/android-renderer-stamp.test.ts packages/app/test/ios-renderer-stamp.test.ts`
- `node --check packages/app/scripts/devices-status.mjs && node --check packages/app/scripts/lib/devices-status.mjs && node --check packages/app/scripts/ios-device-deploy.mjs && git diff --check`
- `bun run --cwd packages/app devices:status -- --json`
- `bun run --cwd packages/app devices:status`

## Local evidence
Table output from this host (Android attached, no macOS iOS lanes):
```text
PLATFORM    DEVICE             KIND    BUILD         COMMIT        DEVELOP       VERDICT  REASON
--------    ------             ----    -----         ------        -------       -------  ------
android     27051JEGR10034     device  5c05ab1770dd  3403f9bc241f  2c1f4301e4a3  STALE    installed 3403f9bc241f != develop 2c1f4301e4a3
ios-sim     iOS simulator n/a  n/a     -             -             2c1f4301e4a3  UNKNOWN  no installed renderer stamp
ios-device  physical iOS n/a   n/a     -             -             2c1f4301e4a3  UNKNOWN  no installed renderer stamp
```

`--json` reported the same Android device as `STALE` with buildId `5c05ab1770dd...`, installed commit `3403f9bc241f...`, and develop head `2c1f4301e4a3...`.

## Evidence still needed before merge
- Run on a machine with at least one Android device and one iOS device attached.
- Capture the required before/after terminal output showing STALE, redeploy, then FRESH.
- Attach a JPG screenshot of the table output and the full `--json` output for the same run.