### PR TITLE
fix(app): prebuild live e2e renderer deps

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -96,8 +96,14 @@ jobs:
       - name: Generate shared i18n assets
         run: bun run --cwd packages/shared build:i18n
 
-      # Prebuild the renderer dist so the live stack reuses a fresh bundle instead
-      # of a cold ~12 min in-harness vite build (viteRendererBuildNeeded check).
+      # Vite loads package exports before renderer aliases apply; fresh CI
+      # checkouts need these dist bundles before packages/app can resolve
+      # @elizaos/core and @elizaos/shared subpaths.
+      - name: Build @elizaos/core + @elizaos/shared browser bundles
+        run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
+
+      # Prebuild the renderer dist so the live stack reuses a fresh bundle
+      # instead of a cold in-harness vite build (viteRendererBuildNeeded check).
       - name: Build app renderer bundle
         run: bun run --cwd packages/app build:web
 
@@ -169,8 +175,13 @@ jobs:
       - name: Generate shared i18n assets
         run: bun run --cwd packages/shared build:i18n
 
-      # Prebuild the renderer dist so the live stack reuses a fresh bundle instead
-      # of a cold ~12 min in-harness vite build.
+      # Vite resolves linked workspace package exports while loading the app
+      # config, before renderer aliases can redirect to source files.
+      - name: Build @elizaos/core + @elizaos/shared browser bundles
+        run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
+
+      # Prebuild the renderer dist so the live stack reuses a fresh bundle
+      # instead of a cold in-harness vite build.
       - name: Build app renderer bundle
         run: bun run --cwd packages/app build:web
 
@@ -230,6 +241,11 @@ jobs:
 
       - name: Generate shared i18n assets
         run: bun run --cwd packages/shared build:i18n
+
+      # Cloud-live still builds the same renderer bundle, so it needs the same
+      # workspace dists before Vite can load packages/app/vite.config.ts.
+      - name: Build @elizaos/core + @elizaos/shared browser bundles
+        run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
 
       - name: Build app renderer bundle
         run: bun run --cwd packages/app build:web

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -203,6 +203,10 @@ const pluginBrowserBridgeSrcRoot = path.join(
 );
 const uiPkgRoot = path.join(elizaRoot, "packages/ui");
 const cloudUiPkgRoot = path.join(elizaRoot, "packages/cloud-ui");
+const importConversationsSrcRoot = path.join(
+  elizaRoot,
+  "packages/import-conversations/src",
+);
 const capacitorCoreEntry = path.join(
   path.dirname(_require.resolve("@capacitor/core/package.json")),
   "dist/index.js",
@@ -2594,6 +2598,17 @@ export const INVALID_TRACER_PROVIDER = {};
       {
         find: /^@elizaos\/ui\/(.+)$/,
         replacement: path.join(uiPkgRoot, "src/$1"),
+      },
+      // The memory viewer imports the browser-safe conversation importer
+      // through @elizaos/ui source. Keep the app renderer on package source so
+      // fresh CI checkouts do not need import-conversations dist artifacts.
+      {
+        find: /^@elizaos\/import-conversations$/,
+        replacement: path.join(importConversationsSrcRoot, "index.ts"),
+      },
+      {
+        find: /^@elizaos\/import-conversations\/(.+)$/,
+        replacement: path.join(importConversationsSrcRoot, "$1.ts"),
       },
       {
         find: /^@elizaos\/shared\/brand$/,


### PR DESCRIPTION
## Summary

Fixes the pre-test build failures in `app-live-e2e.yml` so the live lane can reach its real assertions again.

- Prebuilds `@elizaos/core` and `@elizaos/shared` before each live web renderer build (`app-live-chat`, `walkthrough-live`, `cloud-live`).
- Adds a source alias for `@elizaos/import-conversations` in the app Vite config so the `@elizaos/ui` memory viewer does not require an incidental `packages/import-conversations/dist` on fresh CI checkouts.

## Root Cause

July 3 live jobs failed before tests while loading `packages/app/vite.config.ts`:

```text
Failed to resolve entry for package "@elizaos/core"
failed to load config from packages/app/vite.config.ts
```

A fresh `bun install` does not build `packages/core/dist`, and postinstall explicitly logs that `@elizaos/core` dist is not present yet. Once core/shared are built, the next local build blocker was `@elizaos/import-conversations/browser`, imported through `@elizaos/ui` source without an app Vite source alias.

## Validation

- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile`
- `bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared`
- `test ! -d packages/import-conversations/dist && echo 'import-conversations dist absent' || find packages/import-conversations/dist -maxdepth 1 -type f | head && bun run --cwd packages/app build:web`
  - Confirmed `import-conversations dist absent` before the build.
  - `build:web` passed and `verify-chunk-safety` passed.
- Rebased onto latest `origin/develop` and reran:
  - `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/app-live-e2e.yml`
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/app-live-e2e.yml"); puts "yaml ok"' && git diff --check origin/develop...HEAD`
  - `bun run --cwd packages/app build:web`

## Evidence Matrix

- App Live E2E workflow dispatch: pending on this branch after PR creation.
- Screenshots/video: N/A - workflow/build dependency fix; no renderer UI behavior changed.
- Live LLM/cloud trajectory: pending App Live E2E workflow dispatch; this PR unblocks the lane that captures it.

Refs #14357.