### PR TITLE
fix(console): desktop data-list tables invisible at all widths (empty agents/API-keys tables)

### DIFF
--- a/packages/ui/src/cloud-ui/components/data-list/dashboard-data-list.test.tsx
+++ b/packages/ui/src/cloud-ui/components/data-list/dashboard-data-list.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression guard for the "banner shows N but the table is empty" console bug.
+ *
+ * The console bundle concatenates two independent Tailwind builds (the app's
+ * `@elizaos/ui/styles` and cloud-ui's own `@import "tailwindcss"`). That emits a
+ * SECOND base `.hidden{display:none}` AFTER the responsive `.md:block` rule —
+ * same specificity, later wins — so any `hidden md:block` element is pinned to
+ * `display:none` at every width. Every `DashboardDataListDesktop` table (agents,
+ * API keys, …) rendered invisible while its stats banner still showed a count.
+ *
+ * The fix: the desktop wrapper must hide-below-md via `max-md:hidden` + the div's
+ * default block display, and must NOT carry the bare `hidden` base class. This
+ * test fails if someone reintroduces `hidden`/`md:block` on the desktop wrapper.
+ */
+
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup } from "@testing-library/react";
+import {
+  DashboardDataListDesktop,
+  DashboardDataListMobile,
+} from "./dashboard-data-list";
+
+afterEach(cleanup);
+
+describe("DashboardDataListDesktop — duplicate-Tailwind clobber guard", () => {
+  it("hides below md via max-md:hidden and NEVER via the bare `hidden` base class", () => {
+    const { getByTestId } = render(
+      <DashboardDataListDesktop>
+        <div data-testid="row">row</div>
+      </DashboardDataListDesktop>,
+    );
+    const wrapper = getByTestId("row").parentElement as HTMLElement;
+    const classes = wrapper.className.split(/\s+/);
+
+    // The bare `hidden` class is the one the duplicated base stylesheet clobbers
+    // back on at md+, so it must never appear on this wrapper.
+    expect(classes).not.toContain("hidden");
+    expect(classes).not.toContain("md:block");
+    expect(classes).toContain("max-md:hidden");
+  });
+
+  it("renders its children (rows reach the DOM)", () => {
+    const { getByTestId } = render(
+      <DashboardDataListDesktop>
+        <div data-testid="row">row</div>
+      </DashboardDataListDesktop>,
+    );
+    expect(getByTestId("row").textContent).toBe("row");
+  });
+
+  it("mobile wrapper still hides at md+ via md:hidden (it has no bare `hidden`)", () => {
+    const { getByTestId } = render(
+      <DashboardDataListMobile>
+        <div data-testid="card">card</div>
+      </DashboardDataListMobile>,
+    );
+    const wrapper = getByTestId("card").parentElement as HTMLElement;
+    const classes = wrapper.className.split(/\s+/);
+    expect(classes).toContain("md:hidden");
+    expect(classes).not.toContain("hidden");
+  });
+});

--- a/packages/ui/src/cloud-ui/components/data-list/dashboard-data-list.tsx
+++ b/packages/ui/src/cloud-ui/components/data-list/dashboard-data-list.tsx
@@ -51,8 +51,18 @@ export function DashboardDataListDesktop({
   return (
     <div
       data-slot="dashboard-data-list-desktop"
+      // Show at md+, hide below — via `max-md:hidden` (a max-width query) plus
+      // the div's default block display, NOT `hidden md:block`. The console
+      // bundle concatenates two independent Tailwind builds (the app's
+      // `@elizaos/ui/styles` and cloud-ui's own `@import "tailwindcss"`), so a
+      // second base `.hidden{display:none}` is emitted AFTER the responsive
+      // `.md:block` — same specificity, later wins — which pinned every
+      // `hidden md:block` desktop table to display:none at all widths (the real
+      // cause of the "banner shows N but the table is empty" bug). Avoiding the
+      // `hidden` base class sidesteps that clobber; root dedupe tracked
+      // separately.
       className={cn(
-        "hidden overflow-hidden border border-white/10 md:block",
+        "overflow-hidden border border-white/10 max-md:hidden",
         className,
       )}
     >


### PR DESCRIPTION
## The bug
Every desktop data-list table in the console renders **invisible** while its stats banner still shows a count — the recurring *"N running / 18 keys but the table below is empty"* reports (agents page, API-keys page, etc.). Users see the money/usage numbers but zero rows.

![symptom: banner says 18 keys, table empty]

## Root cause (a CSS build bug, not row data)
The console bundle concatenates **two independent Tailwind builds**:
- the app's `@elizaos/ui/styles`
- cloud-ui's own `@import "tailwindcss"` in `cloud-ui/index.css`

Each emits a full base-utility set. The **second** base `.hidden{display:none}` lands **after** the responsive `.md:block` rule in the concatenated stylesheet. Same specificity → later declaration wins → **every `hidden md:block` element is `display:none` at all widths.** `DashboardDataListDesktop` used exactly that pattern, so its `<table>` was pinned hidden while the banner (rendered outside the wrapper) stayed visible.

Verified against the **live deployed staging CSS** in a real browser:
```
desktop viewport 1280px (>= md 768):
  OLD (hidden md:block)  display: none    <- bug reproduced (invisible)
  NEW (max-md:hidden)    display: block   <- fix works (visible)
```

## The fix
Hide-below-`md` via `max-md:hidden` + the div's default block display — **no bare `hidden` base class** for the duplicate stylesheet to clobber. One-line class change on the shared `DashboardDataListDesktop` wrapper, so it fixes **every** console table at once (agents, API keys, any future data-list). Adds a regression guard test that fails if `hidden`/`md:block` is reintroduced on that wrapper.

## Follow-up (separate)
The real dedupe — the console shouldn't ship two full Tailwind utility sets — is a build-architecture change tracked separately; this PR unbreaks the visible surface safely without touching the CSS pipeline.

https://claude.ai/code/session_01CpnRyFUuGvzz61SsrnC3Sd
