### PR TITLE
feat(#14323): date/time/datetime field types for the interaction FORM

### DIFF
--- a/packages/agent/src/providers/ui-catalog.ts
+++ b/packages/agent/src/providers/ui-catalog.ts
@@ -130,12 +130,15 @@ When you need several specific values from the user at once, render a form
 instead of asking in prose. Emit INLINE (no code fences); body is a JSON object
 on its own line between the markers:
 [FORM]
-{"title":"Schedule reminder","submitLabel":"Create","fields":[{"name":"title","type":"text","label":"Reminder","required":true},{"name":"channel","type":"select","label":"Notify via","options":[{"label":"Push","value":"push"},{"label":"Email","value":"email"}]}]}
+{"title":"Schedule reminder","submitLabel":"Create","fields":[{"name":"title","type":"text","label":"Reminder","required":true},{"name":"when","type":"datetime","label":"When","required":true},{"name":"channel","type":"select","label":"Notify via","options":[{"label":"Push","value":"push"},{"label":"Email","value":"email"}]}]}
 [/FORM]
-Field types: text | number | select (needs options) | checkbox. Each field "name"
-must start with a letter. The user's submitted values come back to you as a normal
-message. Do NOT use [FORM] for secrets or API keys (those use the secure secret
-flow), and do NOT use it for a single free-text answer — just ask.
+Field types: text | number | select (needs options) | checkbox | date | time |
+datetime. Prefer date/time/datetime for any scheduling input — they render native
+pickers and return YYYY-MM-DD / HH:mm / YYYY-MM-DDTHH:mm (local, no timezone), so
+never collect a date or time as free text. Each field "name" must start with a
+letter. The user's submitted values come back to you as a normal message. Do NOT
+use [FORM] for secrets or API keys (those use the secure secret flow), and do NOT
+use it for a single free-text answer — just ask.
 
 ### Method 5 — [CHECKLIST] inline todo list (track multi-step work in place)
 When you are working through several steps for the user, render a live checklist

--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -104,6 +104,40 @@ describe("parse", () => {
 		);
 	});
 
+	it("parses temporal field types and round-trips them (#14323)", () => {
+		const text = `[FORM]\n${JSON.stringify({
+			title: "Schedule reminder",
+			fields: [
+				{ name: "day", type: "date", label: "Day", required: true },
+				{ name: "at", type: "time", label: "At" },
+				{ name: "when", type: "datetime", label: "When" },
+			],
+		})}\n[/FORM]`;
+		const { blocks } = parseInteractionBlocks(text);
+		const form = blocks[0] as FormInteraction;
+		expect(form.fields.map((f) => f.type)).toEqual(["date", "time", "datetime"]);
+		// parse ↔ serialize parity: the temporal types survive a round trip.
+		const rt = parseInteractionBlocks(serializeInteractionBlock(form));
+		expect((rt.blocks[0] as FormInteraction).fields.map((f) => f.type)).toEqual([
+			"date",
+			"time",
+			"datetime",
+		]);
+	});
+
+	it("drops a field with an unknown type (core parser is strict)", () => {
+		const text = `[FORM]\n${JSON.stringify({
+			fields: [
+				{ name: "ok", type: "date" },
+				{ name: "bad", type: "color" },
+			],
+		})}\n[/FORM]`;
+		const { blocks } = parseInteractionBlocks(text);
+		const form = blocks[0] as FormInteraction;
+		// unknown "color" is rejected; the valid "date" field survives.
+		expect(form.fields.map((f) => f.name)).toEqual(["ok"]);
+	});
+
 	it("rejects malformed form JSON (left as text)", () => {
 		const text = "[FORM]\n{not json}\n[/FORM]";
 		const { blocks, cleanedText } = parseInteractionBlocks(text);

--- a/packages/core/src/messaging/interactions/parse.ts
+++ b/packages/core/src/messaging/interactions/parse.ts
@@ -47,6 +47,9 @@ const FIELD_TYPES: ReadonlySet<InteractionFieldType> = new Set([
 	"secret",
 	"image",
 	"file",
+	"date",
+	"time",
+	"datetime",
 ]);
 const FOLLOWUP_KINDS: ReadonlySet<FollowupKind> = new Set([
 	"reply",

--- a/packages/core/src/types/interactions.ts
+++ b/packages/core/src/types/interactions.ts
@@ -36,7 +36,14 @@ export type InteractionFieldType =
 	| "checkbox"
 	| "secret"
 	| "image"
-	| "file";
+	| "file"
+	// Native temporal pickers. Submitted values are the HTML input's own string
+	// value — `date` → `YYYY-MM-DD`, `time` → `HH:mm`, `datetime` →
+	// `YYYY-MM-DDTHH:mm` (local, no timezone). Consuming actions parse these
+	// deterministically; there is no custom picker or extra dependency.
+	| "date"
+	| "time"
+	| "datetime";
 
 /** A single field in a form or secret request. */
 export interface InteractionField {

--- a/packages/ui/src/components/chat/message-form-parser.test.ts
+++ b/packages/ui/src/components/chat/message-form-parser.test.ts
@@ -61,6 +61,29 @@ describe("parseFormBody", () => {
     expect(form?.fields[0].type).toBe("text");
   });
 
+  it("preserves the temporal field types (date, time, datetime)", () => {
+    const form = parseFormBody(
+      JSON.stringify({
+        fields: [
+          { name: "day", type: "date", label: "Day", required: true },
+          { name: "at", type: "time", label: "At" },
+          { name: "when", type: "datetime", label: "When" },
+        ],
+      }),
+    );
+    expect(form?.fields.map((f) => f.type)).toEqual([
+      "date",
+      "time",
+      "datetime",
+    ]);
+    expect(form?.fields[0]).toEqual({
+      name: "day",
+      type: "date",
+      label: "Day",
+      required: true,
+    });
+  });
+
   it("drops fields with unsafe or missing names and dedupes by name", () => {
     const form = parseFormBody(
       JSON.stringify({

--- a/packages/ui/src/components/chat/message-form-parser.ts
+++ b/packages/ui/src/components/chat/message-form-parser.ts
@@ -31,7 +31,18 @@
  * the structured result back as a message via the existing action callback.
  */
 
-export type FormFieldType = "text" | "number" | "select" | "checkbox";
+// Temporal types render native `<input type="date|time|datetime-local">`, which
+// submit an ISO-ish string (`YYYY-MM-DD` / `HH:mm` / `YYYY-MM-DDTHH:mm`). Kept
+// in sync with the core `InteractionFieldType` union; both parsers coerce any
+// unknown type to `text` so a client on an older type set degrades safely.
+export type FormFieldType =
+  | "text"
+  | "number"
+  | "select"
+  | "checkbox"
+  | "date"
+  | "time"
+  | "datetime";
 
 export interface FormFieldSpec {
   name: string;
@@ -58,6 +69,9 @@ const FORM_FIELD_TYPES = new Set<FormFieldType>([
   "number",
   "select",
   "checkbox",
+  "date",
+  "time",
+  "datetime",
 ]);
 
 /** Field names become state-path segments + result keys; keep them safe. */

--- a/packages/ui/src/components/chat/widgets/form-request.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.stories.tsx
@@ -152,6 +152,40 @@ export const SelectAndCheckboxOnly: Story = {
   },
 };
 
+export const SchedulingWithTemporalFields: Story = {
+  args: {
+    form: {
+      id: "schedule-reminder",
+      title: "Schedule reminder",
+      description: "Native date/time/datetime pickers (#14323).",
+      submitLabel: "Create",
+      fields: [
+        {
+          name: "title",
+          type: "text",
+          label: "Reminder",
+          placeholder: "Call the pharmacy",
+          required: true,
+        },
+        { name: "day", type: "date", label: "Day", required: true },
+        { name: "at", type: "time", label: "Time" },
+        { name: "when", type: "datetime", label: "Exact date + time" },
+        {
+          name: "channel",
+          type: "select",
+          label: "Notify via",
+          placeholder: "Pick one",
+          options: [
+            { label: "Push", value: "push" },
+            { label: "Email", value: "email" },
+          ],
+        },
+      ],
+    },
+    onSubmit: () => {},
+  },
+};
+
 export const Minimal: Story = {
   args: {
     form: {

--- a/packages/ui/src/components/chat/widgets/form-request.test.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+//
+// Renderer coverage for the [FORM] widget: the field-type → HTML input-type
+// mapping (pure) and that temporal fields render native pickers and submit the
+// browser's ISO-ish string value. jsdom + testing-library; no model, no network.
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FormRequestSpec } from "../message-form-parser";
+import { FormRequest, htmlInputTypeForField } from "./form-request";
+
+// This suite renders the same form in multiple cases; unmount between them so
+// duplicate labels don't collide in `getByLabelText`.
+afterEach(cleanup);
+
+describe("htmlInputTypeForField", () => {
+  it("maps each field type to the right native input type", () => {
+    expect(htmlInputTypeForField("text")).toBe("text");
+    expect(htmlInputTypeForField("number")).toBe("number");
+    expect(htmlInputTypeForField("date")).toBe("date");
+    expect(htmlInputTypeForField("time")).toBe("time");
+    // `datetime` is the field type; the HTML control is `datetime-local`.
+    expect(htmlInputTypeForField("datetime")).toBe("datetime-local");
+  });
+});
+
+describe("FormRequest temporal fields", () => {
+  const form: FormRequestSpec = {
+    id: "sched",
+    title: "Schedule reminder",
+    submitLabel: "Create",
+    fields: [
+      { name: "day", type: "date", label: "Day", required: true },
+      { name: "at", type: "time", label: "At" },
+      { name: "when", type: "datetime", label: "When" },
+    ],
+  };
+
+  it("renders native date/time/datetime-local inputs", () => {
+    render(<FormRequest form={form} onSubmit={() => {}} />);
+    expect((screen.getByLabelText("Day") as HTMLInputElement).type).toBe("date");
+    expect((screen.getByLabelText("At") as HTMLInputElement).type).toBe("time");
+    expect((screen.getByLabelText("When") as HTMLInputElement).type).toBe(
+      "datetime-local",
+    );
+  });
+
+  it("submits the picked values verbatim keyed by field name", () => {
+    const onSubmit = vi.fn();
+    render(<FormRequest form={form} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText("Day"), {
+      target: { value: "2026-07-10" },
+    });
+    fireEvent.change(screen.getByLabelText("At"), {
+      target: { value: "09:30" },
+    });
+    fireEvent.change(screen.getByLabelText("When"), {
+      target: { value: "2026-07-10T09:30" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(onSubmit).toHaveBeenCalledWith("sched", {
+      day: "2026-07-10",
+      at: "09:30",
+      when: "2026-07-10T09:30",
+    });
+  });
+});

--- a/packages/ui/src/components/chat/widgets/form-request.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.tsx
@@ -32,6 +32,29 @@ export type { FormFieldSpec, FormRequestSpec };
 /** Value emitted per field: string for text/number/select, boolean for checkbox. */
 export type FormResultValue = string | boolean;
 
+/**
+ * Map a form field type to the `<input type>` used for the text-like branch
+ * (checkbox and select render their own controls). The temporal types delegate
+ * to the browser's native pickers — `date` → `YYYY-MM-DD`, `time` → `HH:mm`,
+ * `datetime` → `<input type="datetime-local">` yielding `YYYY-MM-DDTHH:mm` —
+ * so no custom picker or dependency is added. Any other type is a plain text
+ * box. Exported for the field-type unit test.
+ */
+export function htmlInputTypeForField(fieldType: FormFieldSpec["type"]): string {
+  switch (fieldType) {
+    case "number":
+      return "number";
+    case "date":
+      return "date";
+    case "time":
+      return "time";
+    case "datetime":
+      return "datetime-local";
+    default:
+      return "text";
+  }
+}
+
 export type FormRequestProps = {
   form: FormRequestSpec;
   /** Receives the structured result keyed by field name. */
@@ -182,7 +205,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
             </div>
           );
         }
-        // text / number
+        // text / number / date / time / datetime (native inputs)
         return (
           <div key={field.name} className="flex flex-col gap-1 text-xs">
             <span className="font-semibold">{label}</span>
@@ -192,7 +215,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
                 density: "compact",
                 hasError: !!fieldErrors?.length,
               })}
-              type={field.type === "number" ? "number" : "text"}
+              type={htmlInputTypeForField(field.type)}
               name={field.name}
               placeholder={field.placeholder ?? ""}
               value={String(values[field.name] ?? "")}


### PR DESCRIPTION
Closes #14323.

## What & why

The `[FORM]` widget could not collect a date or time except as free text — the exact error-prone input the widget system exists to remove, and it disproportionately hurts the LifeOps MVP's scheduling core (reminders, check-ins, "get the report done on time"). This adds native temporal field types.

**Additive, no migration:** unknown field types already coerce to `text` on the dashboard parser and are rejected by the strict core parser, so older clients degrade safely.

1. **Core** — `date | time | datetime` added to `InteractionFieldType` (`types/interactions.ts`) and the core `FIELD_TYPES` validator (`messaging/interactions/parse.ts`).
2. **Dashboard parser** — mirrored in `FormFieldType` + `FORM_FIELD_TYPES` (`message-form-parser.ts`).
3. **Renderer** — a new exported `htmlInputTypeForField()` maps them to native `<input type="date|time|datetime-local">` (`form-request.tsx`). No custom picker, no dependency. Submitted values are the browser's own strings: `date`→`YYYY-MM-DD`, `time`→`HH:mm`, `datetime`→`YYYY-MM-DDTHH:mm` (local, no timezone), documented in JSDoc so consuming actions parse deterministically.
4. **Model guidance** — `ui-catalog.ts` Method 4 field-type list + `[FORM]` example updated to prefer date/time/datetime for scheduling.
5. **Tests + story** — added below; plus a `SchedulingWithTemporalFields` story so the story-gate renders the new state.

## Acceptance criteria

- [x] `[FORM]` with `date`/`time`/`datetime` renders native pickers on **both** chat surfaces — both `ContinuousChatOverlay` (via `InlineWidgetText`) and `ChatView` (via `MessageContent`) render the **same** `FormRequest` component; the component test asserts the rendered input `type` for each.
- [x] Submitted values arrive in the documented format — the renderer test drives real DOM `change` events and asserts `onSubmit` receives `{day:"2026-07-10", at:"09:30", when:"2026-07-10T09:30"}`.
- [x] Old/unknown field types still coerce to text (dashboard) / are dropped (strict core) — regression tests for both.
- [x] Core and UI parsers agree — both accept the three temporal types; core round-trip (parse↔serialize) test added.
- [ ] **Live-LLM scheduling trajectory** — see evidence note below (the code is complete + test-proven; the model-adoption run is the one remaining item).

## Evidence — real test runs (ran locally, green)

```
# core — packages/core
bun run --cwd packages/core test --run src/messaging/interactions/interactions
  → Tests  34 passed (34)     # incl. "parses temporal field types and round-trips them (#14323)"
                              #      + "drops a field with an unknown type (core parser is strict)"

# ui — packages/ui
bun run --cwd packages/ui test --run src/components/chat/message-form-parser src/components/chat/widgets/form-request
  → Tests  12 passed (12)     # message-form-parser 10/10 (incl. "preserves the temporal field types")
                              # form-request 3/3: htmlInputTypeForField mapping,
                              #   renders native date/time/datetime-local inputs,
                              #   submits picked values verbatim keyed by field name

# agent — packages/agent (guidance provider still valid)
bun run --cwd packages/agent test --run src/providers/ui-catalog
  → Tests  4 passed (4)
```

**Rendered proof — component test, not a screenshot (deliberate):** the three new types render *native* HTML controls (`<input type="date">` etc.). A JPG would show the browser's/OS's own picker chrome — nothing this PR controls or styles. The functional proof that matters — the correct input `type` renders on the shared surface and the ISO-ish value flows through submit — is asserted deterministically in `form-request.test.tsx`. Marking the JPG row **N/A (native control; component test is the rendered proof)**.

**Remaining item — live-LLM scheduling trajectory + MP4 (not faked):** AC also asks for a live run showing the agent emit a date field → user picks → submit → a correctly-timed scheduled-task row. That exercises the model *adopting* the new `ui-catalog` guidance, which needs a live scheduling scenario against a real model. The field-type **support** here is complete and fully test-proven; I did not fabricate a trajectory. Recommend gating final close on a live scheduling-form scenario run (or I can follow up with one) — flagging it honestly rather than marking it done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
