### PR TITLE
fix(ui): harden FORM state records for constructor fields (#14489)

### DIFF
--- a/packages/ui/src/components/chat/widgets/form-request.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.tsx
@@ -40,7 +40,9 @@ export type FormResultValue = string | boolean;
  * so no custom picker or dependency is added. Any other type is a plain text
  * box. Exported for the field-type unit test.
  */
-export function htmlInputTypeForField(fieldType: FormFieldSpec["type"]): string {
+export function htmlInputTypeForField(
+  fieldType: FormFieldSpec["type"],
+): string {
   switch (fieldType) {
     case "number":
       return "number";
@@ -61,19 +63,24 @@ export type FormRequestProps = {
   onSubmit: (formId: string, values: Record<string, FormResultValue>) => void;
 };
 
+function createFormRecord<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
 function initialValueFor(field: FormFieldSpec): FormResultValue {
   return field.type === "checkbox" ? false : "";
 }
 
 export function FormRequest({ form, onSubmit }: FormRequestProps) {
   const [values, setValues] = useState<Record<string, FormResultValue>>(() => {
-    const initial: Record<string, FormResultValue> = {};
+    const initial = createFormRecord<FormResultValue>();
     for (const field of form.fields) {
       initial[field.name] = initialValueFor(field);
     }
     return initial;
   });
-  const [errors, setErrors] = useState<Record<string, string[]>>({});
+  const [errors, setErrors] = useState<Record<string, string[]>>(() =>
+    createFormRecord<string[]>(),
+  );
   const [submitted, setSubmitted] = useState(false);
 
   const requiredFields = useMemo(
@@ -82,7 +89,11 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
   );
 
   const setValue = useCallback((name: string, value: FormResultValue) => {
-    setValues((prev) => ({ ...prev, [name]: value }));
+    setValues((prev) =>
+      Object.assign(createFormRecord<FormResultValue>(), prev, {
+        [name]: value,
+      }),
+    );
   }, []);
 
   const validateField = useCallback(
@@ -97,7 +108,11 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
         ],
         value,
       );
-      setErrors((prev) => ({ ...prev, [field.name]: fieldErrors }));
+      setErrors((prev) =>
+        Object.assign(createFormRecord<string[]>(), prev, {
+          [field.name]: fieldErrors,
+        }),
+      );
     },
     [],
   );
@@ -107,7 +122,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
       event.preventDefault();
       if (submitted) return;
 
-      const nextErrors: Record<string, string[]> = {};
+      const nextErrors = createFormRecord<string[]>();
       for (const field of requiredFields) {
         const fieldErrors = runValidation(
           [
@@ -124,7 +139,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
       if (Object.keys(nextErrors).length > 0) return;
 
       setSubmitted(true);
-      onSubmit(form.id, values);
+      onSubmit(form.id, { ...values });
     },
     [form.id, onSubmit, requiredFields, submitted, values],
   );

--- a/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
+++ b/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
@@ -109,6 +109,33 @@ describe("FormRequest — every input + submit", () => {
     expect(screen.getByRole("button", { name: "Submitted" })).toBeTruthy();
   });
 
+  it("handles a protocol-valid field named constructor without inherited object state", () => {
+    const onSubmit = vi.fn();
+    const formWithConstructorField: FormRequestSpec = {
+      id: "prototype-safe",
+      submitLabel: "Send",
+      fields: [
+        {
+          name: "constructor",
+          type: "text",
+          label: "Constructor",
+          required: true,
+        },
+      ],
+    };
+    render(<FormRequest form={formWithConstructorField} onSubmit={onSubmit} />);
+
+    expect(screen.queryByText(/Constructor is required/i)).toBeNull();
+    fireEvent.change(screen.getByLabelText("Constructor"), {
+      target: { value: "safe-value" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("prototype-safe", {
+      constructor: "safe-value",
+    });
+  });
   it("renders a select field's options", () => {
     const onSubmit = vi.fn();
     const withSelect: FormRequestSpec = {


### PR DESCRIPTION
Closes #14489.

## Summary
- Replace plain object form value/error records in `FormRequest` with null-prototype records so protocol-valid field names like `constructor` cannot collide with inherited object properties.
- Copy the null-prototype values into a plain object at submit time so host callbacks still receive normal JSON-shaped data.
- Add a regression test that renders and submits a FORM field named `constructor`.

## Validation
- `bun run --cwd packages/ui test -- src/components/chat/widgets/interaction-widgets.behavior.test.tsx src/components/chat/widgets/form-request.test.tsx` -> 2 files / 14 tests passed.
- `bunx biome check packages/ui/src/components/chat/widgets/form-request.tsx packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx` -> passed.
- `git diff --check origin/develop...HEAD` -> passed.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - crash-only state-record fix in the existing FORM widget; no visual layout or before-state screenshot is meaningful.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no visual layout change; regression is proven by the focused jsdom widget test.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-flow or visual behavior change beyond preventing a render crash for a malicious/edge field name.
<!-- evidence-row:backend-logs -->
- [ ] N/A - frontend-only component state fix; no backend code path changed.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no network request or browser-console path changed; focused widget test drives the frontend state path directly.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain artifact is produced; the submitted callback payload is asserted in the regression test.
