### PR TITLE
fix(#14329): fix flaky WebKit scroll-anchor on prepend + webkit e2e lane

### DIFF
--- a/.github/workflows/ui-fixture-e2e.yml
+++ b/.github/workflows/ui-fixture-e2e.yml
@@ -72,7 +72,7 @@ jobs:
           no-vision-deps: "true"
 
       - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
+        run: bunx playwright install --with-deps chromium webkit
 
       # The permission-priming fixture pulls @elizaos/shared, whose i18n module
       # loads generated keyword data that is gitignored. Generate it so the
@@ -98,12 +98,15 @@ jobs:
         run: bun run --cwd packages/ui test:background-e2e
 
       # Infinite upward scroll (#13532): the REAL useLoadOlderOnScroll +
-      # loadOlderConversationMessages driven in Chromium — scroll-to-top fires a
-      # ?before= fetch, older rows prepend, the viewport anchor stays put, plus
-      # the empty-history (no fetch) and fetch-failure (no fabricated prepend, no
-      # retry storm) legs.
-      - name: Chat infinite-scroll e2e
+      # loadOlderConversationMessages — scroll-to-top fires a ?before= fetch,
+      # older rows prepend, the viewport anchor stays put, plus the empty-history
+      # (no fetch) and fetch-failure (no fabricated prepend, no retry storm) legs.
+      # Both engines: scroll-anchor-on-prepend is engine-specific and was FLAKY
+      # on WebKit until #14329 (double-rAF anchor expiry) — this lane guards it.
+      - name: Chat infinite-scroll e2e (chromium)
         run: bun run --cwd packages/ui test:chat-infinite-scroll-e2e
+      - name: Chat infinite-scroll e2e (webkit)
+        run: ENGINE=webkit bun run --cwd packages/ui test:chat-infinite-scroll-e2e
 
       # Launcher view: tiles, tap-launch, long-press edit, page-nav, telemetry.
       - name: Launcher e2e

--- a/.github/workflows/ui-fixture-e2e.yml
+++ b/.github/workflows/ui-fixture-e2e.yml
@@ -20,7 +20,7 @@ on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
   pull_request:
-    branches: [main]
+    branches: [develop, main]
     paths:
       - "packages/ui/src/**"
       - ".github/workflows/ui-fixture-e2e.yml"

--- a/.github/workflows/ui-fixture-e2e.yml
+++ b/.github/workflows/ui-fixture-e2e.yml
@@ -161,6 +161,7 @@ jobs:
             packages/ui/src/components/shell/__e2e__/output
             packages/ui/src/components/shell/__e2e__/output-bottombar
             packages/ui/src/components/pages/__e2e__/output-background
+            packages/ui/src/components/pages/__e2e__/output-infinite-scroll
             packages/ui/src/components/pages/__e2e__/output-launcher
             packages/ui/src/components/pages/__e2e__/output-connectors
             packages/ui/src/components/views/__e2e__/output-view-lifecycle

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ packages/ui/src/components/views/__e2e__/output-view-lifecycle/
 packages/ui/src/components/shell/__e2e__/output-bottombar/
 # Connector card e2e output (screenshots + bundles — regenerate via test:connectors-e2e; committed evidence lives in .github/issue-evidence/10705-connector-config-co-render/)
 packages/ui/src/components/pages/__e2e__/output-connectors/
+# Chat infinite-scroll e2e output (screenshots + request/assertion logs)
+packages/ui/src/components/pages/__e2e__/output-infinite-scroll/
 # Resize-handles e2e output (screenshots + html bundle — regenerate via the composites __e2e__ runner; committed evidence lives in .github/issue-evidence/11144-spatial-chrome-gestures/)
 packages/ui/src/components/composites/__e2e__/output-resize-handles/
 # Launcher gesture-loop e2e output (webm videos + html bundle + traces — regenerate via test:launcher-loop-e2e; committed evidence lives in .github/issue-evidence/12179-web-loop/)

--- a/packages/ui/src/components/pages/__e2e__/run-chat-infinite-scroll-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-chat-infinite-scroll-e2e.mjs
@@ -20,6 +20,7 @@
  */
 
 import { createServer } from "node:http";
+import { mkdir, rename, writeFile } from "node:fs/promises";
 import { builtinModules } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -35,12 +36,25 @@ const ENGINE = process.env.ENGINE === "webkit" ? webkit : chromium;
 const ENGINE_NAME = process.env.ENGINE === "webkit" ? "webkit" : "chromium";
 
 const here = dirname(fileURLToPath(import.meta.url));
+const outDir = join(here, "output-infinite-scroll");
+const videoDir = join(outDir, "video");
+await mkdir(outDir, { recursive: true });
+await mkdir(videoDir, { recursive: true });
 
 let failures = 0;
+const assertions = [];
 function assert(cond, msg) {
   console.log(`${cond ? "✓" : "✗"} ${msg}`);
+  assertions.push({ status: cond ? "pass" : "fail", message: msg });
   if (!cond) failures += 1;
   return cond;
+}
+
+async function screenshot(page, name) {
+  await page.screenshot({
+    path: join(outDir, `${ENGINE_NAME}-${name}.png`),
+    fullPage: false,
+  });
 }
 
 // --- bundle the fixture (same stub set as the sibling chat-scroll runner) ---
@@ -173,26 +187,42 @@ const browser = await ENGINE.launch(
   ENGINE_NAME === "chromium" ? { args: ["--no-sandbox"] } : {},
 );
 const consoleErrors = [];
+const networkRequests = [];
 
 async function newPage(query) {
-  const page = await browser.newPage({
+  const context = await browser.newContext({
     viewport: { width: 480, height: 700 },
+    recordVideo: { dir: videoDir, size: { width: 480, height: 700 } },
   });
+  const page = await context.newPage();
   const requests = [];
-  page.on("request", (r) => requests.push(r.url()));
+  page.on("request", (r) => {
+    requests.push(r.url());
+    networkRequests.push(r.url());
+  });
   page.on("console", (m) => {
     if (m.type() === "error") consoleErrors.push(m.text());
   });
   page.on("pageerror", (e) => consoleErrors.push(String(e)));
   await page.goto(`${base}/${query}`);
   await page.waitForSelector(SCROLLER);
-  return { page, requests };
+  return { page, requests, context };
+}
+
+async function closePageWithVideo(run, name) {
+  const video = run.page.video();
+  await run.page.close();
+  await run.context.close();
+  if (!video) return;
+  const videoPath = await video.path();
+  await rename(videoPath, join(outDir, `${ENGINE_NAME}-${name}.webm`));
 }
 
 try {
   // ── 1) Load-older: scroll to top → ?before= fires → prepend → no jump ──────
   {
-    const { page, requests } = await newPage("");
+    const run = await newPage("");
+    const { page, requests } = run;
     await page.waitForSelector(ROW);
     // The thread mounts pinned to the bottom (sentinel off-screen), so NO fetch
     // has fired yet — the load-older is entirely reader-driven below.
@@ -204,11 +234,16 @@ try {
       requests.filter((u) => /\/messages\?before=/.test(u)).length === 0,
       "no ?before= fetch fired at mount (thread starts pinned to bottom)",
     );
+    await screenshot(page, "01-mounted-bottom");
 
     // Scroll to the very top and, in the SAME evaluate, capture the anchor: the
     // top-most row's identity + viewport-y at scrollTop=0, BEFORE the prepend
     // lands. The prefetch fires from this scroll; the only thing that then moves
     // this row is the older-page grow — exactly the anchor behaviour under test.
+    const beforeRequest = page.waitForRequest(
+      (r) => /\/messages\?before=/.test(r.url()),
+      { timeout: 8_000 },
+    );
     const anchorInfo = await page.evaluate(
       ({ scrollerSel, rowSel }) => {
         const scroller = document.querySelector(scrollerSel);
@@ -223,15 +258,14 @@ try {
       },
       { scrollerSel: SCROLLER, rowSel: ROW },
     );
+    await screenshot(page, "02-before-prepend-top");
     assert(
       anchorInfo && anchorInfo.id,
       "captured the top anchor row at scrollTop=0 before the load-older",
     );
 
     // The `?before=` request must fire on scroll-to-top.
-    await page.waitForRequest((r) => /\/messages\?before=/.test(r.url()), {
-      timeout: 8_000,
-    });
+    await beforeRequest;
     assert(
       requests.some((u) => /\/messages\?before=/.test(u)),
       "a GET .../messages?before= request fired on scroll-to-top",
@@ -272,15 +306,18 @@ try {
         `anchor row viewport-y preserved across the prepend (drift ${drift.toFixed(1)}px ≤ 4px, ${anchorInfo.y.toFixed(0)} → ${yAfter.toFixed(0)})`,
       );
     }
-    await page.close();
+    await screenshot(page, "03-after-prepend-anchored");
+    await closePageWithVideo(run, "01-prepend-anchor");
   }
 
   // ── 2) Empty history: NO fetch loop ────────────────────────────────────────
   {
-    const { page, requests } = await newPage("?empty");
+    const run = await newPage("?empty");
+    const { page, requests } = run;
     await page.waitForTimeout(600);
     const rows = await page.locator(ROW).count();
     assert(rows === 0, "empty thread renders zero rows");
+    await screenshot(page, "04-empty-history");
     // Scroll (no-op on an empty scroller) — still must not fetch.
     await page.evaluate((sel) => {
       const el = document.querySelector(sel);
@@ -291,12 +328,13 @@ try {
       !requests.some((u) => /\/messages\?before=/.test(u)),
       "empty thread issues NO ?before= fetch (no cursor to page below)",
     );
-    await page.close();
+    await closePageWithVideo(run, "02-empty-history");
   }
 
   // ── 3) Fetch failure: error surfaces, guard re-arms, no retry storm ─────────
   {
-    const { page } = await newPage("?fail");
+    const run = await newPage("?fail");
+    const { page } = run;
     await page.waitForSelector(ROW);
     const rowsBefore = await page.locator(ROW).count();
     // Trigger the (failing) older-page load.
@@ -320,11 +358,37 @@ try {
       resolves <= 2,
       `no retry storm on failure (older-page loads resolved ${resolves} times ≤ 2)`,
     );
-    await page.close();
+    await screenshot(page, "05-fetch-failure");
+    await closePageWithVideo(run, "03-fetch-failure");
   }
 } finally {
   await browser.close();
   server.close();
+  const evidence = {
+    engine: ENGINE_NAME,
+    assertions,
+    serverRequests,
+    networkRequests,
+    consoleErrors,
+  };
+  await writeFile(
+    join(outDir, `${ENGINE_NAME}-evidence.json`),
+    `${JSON.stringify(evidence, null, 2)}\n`,
+  );
+  await writeFile(
+    join(outDir, `${ENGINE_NAME}-frontend-log.txt`),
+    [
+      `engine=${ENGINE_NAME}`,
+      `consoleErrors=${consoleErrors.length}`,
+      ...consoleErrors.map((entry) => `ERROR ${entry}`),
+      "",
+      "networkRequests:",
+      ...networkRequests,
+      "",
+      "serverRequests:",
+      JSON.stringify(serverRequests, null, 2),
+    ].join("\n"),
+  );
 }
 
 assert(consoleErrors.length === 0, `no console errors (${consoleErrors.length})`);

--- a/packages/ui/src/components/pages/__e2e__/run-chat-infinite-scroll-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-chat-infinite-scroll-e2e.mjs
@@ -24,7 +24,15 @@ import { builtinModules } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
-import { chromium } from "playwright";
+import { chromium, webkit } from "playwright";
+
+// `ENGINE=webkit` runs the SAME harness under WebKit — scroll-anchor
+// preservation on prepend is engine-specific (WebKit's scroll-anchoring
+// heuristics differ from Blink), so AC #2 (#14329) requires both engines. The
+// harness drives scrollTop programmatically (not a wheel), so it is
+// engine-agnostic and needs no per-engine gesture path.
+const ENGINE = process.env.ENGINE === "webkit" ? webkit : chromium;
+const ENGINE_NAME = process.env.ENGINE === "webkit" ? "webkit" : "chromium";
 
 const here = dirname(fileURLToPath(import.meta.url));
 
@@ -160,7 +168,10 @@ const base = `http://127.0.0.1:${port}`;
 const SCROLLER = '[data-testid="infinite-scroll-scroller"]';
 const ROW = '[data-testid="infinite-scroll-row"]';
 
-const browser = await chromium.launch({ args: ["--no-sandbox"] });
+console.log(`engine: ${ENGINE_NAME}`);
+const browser = await ENGINE.launch(
+  ENGINE_NAME === "chromium" ? { args: ["--no-sandbox"] } : {},
+);
 const consoleErrors = [];
 
 async function newPage(query) {
@@ -320,7 +331,7 @@ assert(consoleErrors.length === 0, `no console errors (${consoleErrors.length})`
 if (consoleErrors.length) for (const e of consoleErrors) console.log("  ERR:", e);
 
 if (failures > 0) {
-  console.error(`\n${failures} assertion(s) FAILED`);
+  console.error(`\n${failures} assertion(s) FAILED [${ENGINE_NAME}]`);
   process.exit(1);
 }
-console.log("\nAll infinite-scroll assertions passed.");
+console.log(`\nAll infinite-scroll assertions passed [${ENGINE_NAME}].`);

--- a/packages/ui/src/hooks/useLoadOlderOnScroll.test.tsx
+++ b/packages/ui/src/hooks/useLoadOlderOnScroll.test.tsx
@@ -405,14 +405,15 @@ describe("useLoadOlderOnScroll — scroll-anchor preservation", () => {
       />,
     );
 
-    // Fire the load; it resolves with no growth. Flush the finally rAF that
-    // clears the un-consumed anchor.
+    // Fire the load; it resolves with no growth. Flush the finally's DOUBLE rAF
+    // that clears the un-consumed anchor (two frames of runway so a real
+    // prepend's commit outlasts the expiry on WebKit — see the hook comment).
     await act(async () => {
       FakeIntersectionObserver.last?.fire(true);
     });
     await act(async () => {
       await new Promise((resolve) =>
-        requestAnimationFrame(() => resolve(null)),
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve(null))),
       );
     });
 

--- a/packages/ui/src/hooks/useLoadOlderOnScroll.ts
+++ b/packages/ui/src/hooks/useLoadOlderOnScroll.ts
@@ -122,11 +122,21 @@ export function useLoadOlderOnScroll<T extends HTMLElement = HTMLDivElement>({
         // leaves topItemKey unchanged, so the preservation layout effect never
         // runs and the pre-grow height would otherwise stay parked — then a
         // later UNRELATED top-key change (e.g. a conversation switch) would
-        // apply a bogus scrollTop delta. A real prepend commits + runs the
-        // preservation effect (nulling the ref) before this rAF fires, so this
-        // is a harmless no-op in that case and a correct cleanup otherwise.
+        // apply a bogus scrollTop delta.
+        //
+        // DOUBLE rAF (not single): a real prepend's React commit + preservation
+        // layout effect are scheduled off the SAME promise resolution as this
+        // finally, and their relative order is engine-dependent — on WebKit the
+        // commit routinely lands a frame LATER than a single rAF, so a
+        // single-frame expiry nulled the anchor before the effect consumed it
+        // and every ~3rd prepend jumped the viewport ~1 screen (verified via the
+        // webkit lane of run-chat-infinite-scroll-e2e). Two frames of runway
+        // reliably outlast the commit while still expiring long before any
+        // real user-driven unrelated top-key change.
         requestAnimationFrame(() => {
-          pendingAnchorHeightRef.current = null;
+          requestAnimationFrame(() => {
+            pendingAnchorHeightRef.current = null;
+          });
         });
       });
   }, [scrollRef]);


### PR DESCRIPTION
Part of #14329. This PR covers the remaining WebKit scroll-anchor regression and adds durable browser evidence for the infinite-scroll fixture; #14329 should stay open until the separate `chat-perf-gate` CLS acceptance item tracked by #14333 is green.

## The Bug The WebKit Lane Caught
`run-chat-infinite-scroll-e2e` ran Chromium-only, so a genuine WebKit defect was invisible. Running the same fixture on WebKit reproduced a flaky roughly one-screen viewport jump on older-page prepend: the anchor row that should stay put drifted 1440px on roughly 1 in 3 loads.

Clean WebKit runs before the fix:
```text
run 1: PASS anchor row viewport-y preserved (drift 0.0px)
run 2: FAIL anchor row viewport-y preserved (drift 1440.0px, 20 -> 1460)
run 3: PASS anchor row viewport-y preserved (drift 0.0px)
```

## Root Cause
`useLoadOlderOnScroll` captures `scrollHeight` before the grow and, in a `useLayoutEffect` after the prepend commits, adds the height delta back to `scrollTop`. The prior single-`requestAnimationFrame` expiry could clear the pending anchor before WebKit committed the prepend and ran the preservation layout effect.

## Fix
Expire the pending anchor after a double rAF. Two frames reliably outlast the WebKit commit while still clearing stale anchors from empty/deduped pages before unrelated top-key changes.

The CI fixture now runs the same infinite-scroll browser runner in Chromium and WebKit. The runner also writes screenshots, WebM clips, assertion JSON, request logs, and frontend logs to `packages/ui/src/components/pages/__e2e__/output-infinite-scroll`, and `ui-fixture-e2e` uploads that directory as part of `ui-fixture-e2e-output`.

## Proof
```text
bun run --cwd packages/ui test src/hooks/useLoadOlderOnScroll.test.tsx
  9 passed

bun run --cwd packages/ui test:chat-infinite-scroll-e2e
  Chromium: 12/12 assertions, 0 console errors, anchor drift 0.0px

ENGINE=webkit bun run --cwd packages/ui test:chat-infinite-scroll-e2e
  WebKit: 12/12 assertions, 0 console errors, anchor drift 0.0px
```

Manual visual review of the WebKit screenshots confirmed `Tail message 0` remains pinned at the same viewport position before and after prepend. Quick color stats on the WebKit before/after frames are stable: average rgb(35, 41, 55/56), dominant rgb(24, 40, 56).

## Acceptance Criteria (#14329)
- [x] Load older until exhausted; sentinel stops on `hasMore=false` — existing `useLoadOlderOnScroll` coverage plus the browser fixture.
- [x] Prepend does not jump the viewport on WebKit + Chromium — this double-rAF fix plus both-engine e2e.
- [x] Bounded sliding window around the reducer cap — existing cap-yank guard.
- [x] `?before=` failure path does not fabricate an empty page — fixture failure leg asserts no prepend and no retry storm.
- [x] Regression e2e asserts a `before` request fires + anchor-compensated `scrollTop` — now both engines.
- [ ] `chat-perf-gate` CLS <= 0.1 — still tracked by #14333, not resolved by this PR.

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: [ui-fixture-e2e artifact bundle](https://github.com/elizaOS/eliza/actions/workflows/ui-fixture-e2e.yml?query=branch%3Afix%2F14329-webkit-scroll-anchor) includes `chromium-01-mounted-bottom.png`, `chromium-02-before-prepend-top.png`, `webkit-01-mounted-bottom.png`, and `webkit-02-before-prepend-top.png` under `output-infinite-scroll`.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [ui-fixture-e2e artifact bundle](https://github.com/elizaOS/eliza/actions/workflows/ui-fixture-e2e.yml?query=branch%3Afix%2F14329-webkit-scroll-anchor) includes `chromium-03-after-prepend-anchored.png` and `webkit-03-after-prepend-anchored.png`; WebKit was manually reviewed for anchor stability.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [ui-fixture-e2e artifact bundle](https://github.com/elizaOS/eliza/actions/workflows/ui-fixture-e2e.yml?query=branch%3Afix%2F14329-webkit-scroll-anchor) includes deterministic WebM clips for Chromium/WebKit prepend-anchor, empty-history, and fetch-failure scenarios.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [ui-fixture-e2e artifact bundle](https://github.com/elizaOS/eliza/actions/workflows/ui-fixture-e2e.yml?query=branch%3Afix%2F14329-webkit-scroll-anchor) includes `chromium-evidence.json` and `webkit-evidence.json` with the in-process `?before=` server request log; each engine recorded one real network request for the prepend scenario.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [ui-fixture-e2e artifact bundle](https://github.com/elizaOS/eliza/actions/workflows/ui-fixture-e2e.yml?query=branch%3Afix%2F14329-webkit-scroll-anchor) includes `chromium-frontend-log.txt` and `webkit-frontend-log.txt`; local runs showed 0 console errors.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: `N/A - browser scroll math and CI harness change only; no agent, prompt, model, planner, or tool-call path is touched`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: `N/A - isolated UI fixture change; no persisted memory, scheduled task, wallet, chain, DB, or connector artifact is produced`.
