### PR TITLE
fix(ui): lock ChatSurface transcript to vertical-only scroll (#14328)

### DIFF
--- a/packages/ui/src/components/shell/ChatSurface.test.tsx
+++ b/packages/ui/src/components/shell/ChatSurface.test.tsx
@@ -43,6 +43,20 @@ describe("ChatSurface composer (shared core)", () => {
     expect(input.value).toBe("");
   });
 
+  it("pins the transcript scroller to vertical-only scroll (#14328)", () => {
+    // `overflow-y-auto` coerces the cross axis to `auto`, so without an explicit
+    // `overflow-x-hidden` a single over-wide message child turns the transcript
+    // into a two-axis scroller a diagonal wheel can pan sideways. Lock it here.
+    const { container } = render(
+      surface({
+        messages: [{ id: "a", role: "assistant", content: "hi", createdAt: 1 }],
+      }),
+    );
+    const scroller = container.querySelector(".overflow-y-auto");
+    expect(scroller).not.toBeNull();
+    expect(scroller?.className).toContain("overflow-x-hidden");
+  });
+
   it("never sends on the Enter that commits an IME composition (#9148)", () => {
     const onSend = vi.fn();
     render(surface({ onSend }));

--- a/packages/ui/src/components/shell/ChatSurface.tsx
+++ b/packages/ui/src/components/shell/ChatSurface.tsx
@@ -106,7 +106,15 @@ export function ChatSurface({
   return (
     <div className="flex h-full flex-col" data-testid="shell-chat-surface">
       <div className="relative flex-1 overflow-hidden">
-        <div ref={scrollRef} className="h-full overflow-y-auto py-2">
+        {/* `overflow-x-hidden`: `overflow-y-auto` coerces the cross axis to
+            `auto` too, so a single over-wide message child (a long code line,
+            an unaudited inline widget) would turn this transcript into a
+            two-axis scroller. This message list only ever scrolls vertically —
+            pin the horizontal axis closed (#14328). */}
+        <div
+          ref={scrollRef}
+          className="h-full overflow-y-auto overflow-x-hidden py-2"
+        >
           {messages.length === 0 ? (
             <p className="text-sm text-muted">
               {greeting ??

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -1263,6 +1263,9 @@ describe("ContinuousChatOverlay", () => {
     const log = document.getElementById("continuous-thread");
     expect(log?.querySelectorAll('[data-testid="thread-line"]').length).toBe(3);
     expect(log?.className).toContain("overflow-y-auto");
+    // Vertical-only invariant (#14328): the horizontal axis is pinned closed so
+    // an over-wide child can never turn the transcript into a two-axis scroller.
+    expect(log?.className).toContain("overflow-x-hidden");
     expect(log?.textContent).toContain("one");
   });
 


### PR DESCRIPTION
Closes #14328 (final gap).

## Context — most of this landed concurrently on develop
The core of #14328 already merged to `develop` via a concurrent session:
- `#continuous-thread` (ContinuousChatOverlay) pins `overflow-x-hidden`.
- `MessageAttachments` code preview carries `overscroll-x-contain`.
- `HomeScreen` continuous-chat scroller pins `overflow-x-hidden`.
- `run-chat-scroll-axis-lock-e2e.mjs` — a real Chromium+WebKit wheel/deltaX guard.

I rebased onto that and reverted every file it already owns (zero overlap/churn).

## What this PR adds — the one transcript that fix missed
`ChatSurface` (the shell message list mounted in `App.tsx`) still set
`overflow-y-auto` with **no** `overflow-x-hidden`. Per CSS Overflow the
unspecified axis coerces to `auto`, so a single over-wide message child made it a
two-axis scroller a diagonal trackpad/wheel `deltaX` could pan sideways
(`touch-pan-y` blocks touch, not wheel). This pins its horizontal axis closed and
locks the invariant with a unit test, and adds the matching `overflow-x-hidden`
assertion to the `ContinuousChatOverlay` scroll-log test so the merged
`#continuous-thread` fix carries its own regression lock.

3 files, +26/-1: `ChatSurface.tsx`, `ChatSurface.test.tsx`, `ContinuousChatOverlay.test.tsx`.

## Cross-engine note (for reviewers of the merged e2e)
While building this I confirmed on WebKit (macOS/Electrobun WKWebView + iOS
Safari) that `overflow-x:hidden` is **not** a hard clamp once a child genuinely
overflows the box: a *pure/near-horizontal* wheel is blocked on every engine, but
a *strong-diagonal* wheel (`wheel(500,400)`) still reveals a raw overflowing
child on WebKit. The durable cross-engine guarantee is that the thread's own
`scrollWidth <= clientWidth` (every wide child self-contained — code blocks,
chips, attachment previews). In the real product no raw over-wide child ever
reaches a transcript, so this is a theoretical edge, not a live bug — the merged
`run-chat-scroll-axis-lock-e2e.mjs` (near-horizontal wheels) stays green and the
product is vertical-only.

## Evidence
| Evidence | Status |
| --- | --- |
| wheel/deltaX regression (Chromium+WebKit) for the identical mechanism | ✅ merged `run-chat-scroll-axis-lock-e2e.mjs` on develop |
| ChatSurface invariant lock | ✅ `ChatSurface.test.tsx` "pins the transcript scroller to vertical-only scroll (#14328)" — `bun run --cwd packages/ui test src/components/shell/ChatSurface.test.tsx` → 7 passed |
| `#continuous-thread` invariant lock | ✅ `ContinuousChatOverlay.test.tsx` overflow-x-hidden assertion |
| real-LLM trajectories | N/A — pure CSS/layout invariant, no agent/model path |
| screenshots / audio | N/A — one-line CSS invariant on an established pattern; behavioral wheel proof for the identical mechanism is the merged e2e above |

🤖 Generated with [Claude Code](https://claude.com/claude-code)